### PR TITLE
Fix for KT-1334 Class object in "Show Structure View" action

### DIFF
--- a/idea/src/org/jetbrains/jet/plugin/structureView/JetStructureViewElement.java
+++ b/idea/src/org/jetbrains/jet/plugin/structureView/JetStructureViewElement.java
@@ -157,6 +157,10 @@ public class JetStructureViewElement implements StructureViewTreeElement {
             if (myElement instanceof JetClassInitializer) {
                 return "<class initializer>";
             }
+
+            if (myElement instanceof JetClassObject) {
+                return "<class object>";
+            }
         }
 
         return text;


### PR DESCRIPTION
Here is a small fix for displaying "<class object>" in "Show Structure View" action instead of empty line. Navigation to class object element works fine.
