### PR TITLE
Types renderer improvements.

### DIFF
--- a/compiler/frontend/src/org/jetbrains/jet/lang/types/JetStandardClasses.java
+++ b/compiler/frontend/src/org/jetbrains/jet/lang/types/JetStandardClasses.java
@@ -392,7 +392,11 @@ public class JetStandardClasses {
     }
 
     public static boolean isFunctionType(@NotNull JetType type) {
-        return FUNCTION_TYPE_CONSTRUCTORS.contains(type.getConstructor()) || RECEIVER_FUNCTION_TYPE_CONSTRUCTORS.contains(type.getConstructor());
+        return FUNCTION_TYPE_CONSTRUCTORS.contains(type.getConstructor()) || isReceiverFunctionType(type);
+    }
+
+    public static boolean isReceiverFunctionType(@NotNull JetType type) {
+        return RECEIVER_FUNCTION_TYPE_CONSTRUCTORS.contains(type.getConstructor());
     }
 
     @Nullable


### PR DESCRIPTION
Here is a simple types (descriptors) renderer improvement, that displays correctly main types:
- Tuple0 -> Unit
- FunctionNN<..., R> -> (...) -> R
- ExtensionFunctionNN<E,...,R> -> E.(...) -> R

It is normally works on nested constructions, so I hope it can be temporary solution for displaying types.

P.S. It will fix KT-916 Rename Tuple0 to Unit (http://youtrack.jetbrains.com/issue/KT-916)
