### PR TITLE
Fix PluginVerifier update

### DIFF
--- a/update_dependencies.xml
+++ b/update_dependencies.xml
@@ -14,6 +14,8 @@
         <attribute name="teamcity.build" default="bt343"/>
         <sequential>
             <delete dir="PluginVerifier" failonerror="false" />
+	    <delete file="PluginVerifier" failonerror="false" />
+	    <mkdir dir="PluginVerifier" />
             <get src="http://teamcity.jetbrains.com/guestAuth/repository/download/bt351/.lastPinned/plugin-verifier-1.0-SNAPSHOT.jar" dest="PluginVerifier" />
 
             <property name="core" value="ideaSDK/core"/>


### PR DESCRIPTION
Currently we delete "PluginVerifier" directory and then download jar to file "PluginVerifier", but we should download it to "PluginVerifier/plugin-verifier-XXX.jar". 

So, I think that we should delete dir or file named "PluginVerifier", create dir "PluginVerifier" and than download jar to dir.
