### PR TITLE
Implemented Sequence#equals(Any?) and Sequence#toString()

### DIFF
--- a/libraries/stdlib/src/sequences/Sequence.kt
+++ b/libraries/stdlib/src/sequences/Sequence.kt
@@ -1,8 +1,9 @@
 package kotlin.sequences
 
 /**
- * A sequence of items of type *T* that are lazily produced by the given closure
+ * A sequence of elements of type *T* that are lazily produced by the given closure
  *
+ * @param reset a closure initialising the iteration context
  * @param next a closure yielding the next element in this sequence
  *
  * @author [Franck Rasolo](http://www.linkedin.com/in/franckrasolo)

--- a/libraries/stdlib/src/sequences/Sequences.kt
+++ b/libraries/stdlib/src/sequences/Sequences.kt
@@ -1,11 +1,9 @@
 package kotlin.sequences
 
-import com.sun.tools.javac.resources.javac
-
-/** Creates a sequence without elements of type *T* */
+/** Creates an empty sequence which would have otherwise contained elements of type *T* */
 inline fun <T> empty(): Sequence<T> = Sequence<T>
 
-/** Creates a sequence from the given list of *elements* */
+/** Creates a sequence from the given list of *elements* of type *T* */
 inline fun <T> sequence(vararg elements: T): Sequence<T> {
   var iterator: Iterator<T>
 

--- a/libraries/stdlib/test/sequences/SequenceTest.kt
+++ b/libraries/stdlib/test/sequences/SequenceTest.kt
@@ -1,12 +1,8 @@
 package test.sequences
 
-import java.util.ArrayList
-
 import kotlin.sequences.asSequence
 import kotlin.sequences.empty
 import kotlin.sequences.sequence
-import kotlin.util.arrayList
-import kotlin.util.fold
 
 import kotlin.test.assertEquals
 import org.junit.Test
@@ -19,37 +15,31 @@ class SequenceTest {
   }
 
   Test fun filterReturnsAnEmptySequenceWhenNoElementMatchesThePredicate() {
-    val actual = sequence(1, 3, 4, 7).filter { it > 7 }
-    assertEquals(empty<Int>(), actual)
+    assertEquals(empty<Int>(), sequence(1, 3, 4, 7).filter { it > 7 })
   }
 
   Test fun foldReturnsTheExpectedReduction() {
-    val actual = (1..10).asSequence().filter { it % 2 == 1 }.fold(0, sum)
-    assertEquals(1 + 3 + 5 + 7 + 9, actual)
+    val actual = sequence(1, 3, 5, 7, 9).fold(-10, sum)
+    assertEquals(-10 + 1 + 3 + 5 + 7 + 9, actual)
   }
 
   Test fun foldReturnsTheInitialValueForAnEmptySequence() {
-    val initialValue = 0
-    val actual = (1..0).asSequence().fold(initialValue, sum)
-
-    assertEquals(initialValue, actual)
+    val initialValue = -10
+    assertEquals(initialValue, empty<Int>().fold(initialValue, sum))
   }
 
   private val sum = { (a : Int, b : Int) -> a + b }
 
   Test fun mapReturnsTheExpectedTransformation() {
-    val actual = sequence(1, 3, 4, 7).map { it * 2 }
-    assertEquals(sequence(2, 6, 8, 14), actual)
+    assertEquals(sequence(2, 6, 8, 14), sequence(1, 3, 4, 7).map { it * 2 })
   }
 
   Test fun takeReturnsTheFirstNElements() {
-    var actual = (1..5).asSequence().take(3)
-    assertEquals(sequence(1, 2, 3), actual)
+    assertEquals(sequence(2, 1, 3), sequence(2, 1, 3, 5, 4).take(3))
   }
 
   Test fun takeReturnsTheEntireSequenceWhenTheNumberOfElementsIsGreaterThanItsSize() {
-    val actual = sequence(1, 2).take(3)
-    assertEquals(sequence(1, 2), actual)
+    assertEquals(sequence(1, 2), sequence(1, 2).take(3))
   }
 
   Test fun takeReturnsAnEmptySequenceForAnEmptySequence() {
@@ -57,13 +47,11 @@ class SequenceTest {
   }
 
   Test fun takeReturnsAnEmptySequenceWhenTheNumberOfElementsToExtractIsZero() {
-    val actual = sequence(1, 2).take(0)
-    assertEquals(empty<Int>(), actual)
+    assertEquals(empty<Int>(), sequence(1, 2).take(0))
   }
 
   Test fun takeReturnsAnEmptySequenceWhenTheNumberOfElementsToExtractIsNegative() {
-    val actual = sequence(1, 2).take(-1)
-    assertEquals(empty<Int>(), actual)
+    assertEquals(empty<Int>(), sequence(1, 2).take(-1))
   }
 
   Test fun takeWhileReturnsTheFirstElementsMatchingAGivenPredicate() {
@@ -72,12 +60,10 @@ class SequenceTest {
   }
 
   Test fun takeWhileReturnsTheEntireSequenceWhenThePredicateMatchesAllElements() {
-    val actual = sequence(1, 2, 3).takeWhile { it < 9 }
-    assertEquals(sequence(1, 2, 3), actual)
+    assertEquals(sequence(1, 2, 3), sequence(1, 2, 3).takeWhile { it < 9 })
   }
 
   Test fun takeWhileReturnsAnEmptySequenceWhenThePredicateMatchesNothing() {
-    val actual = sequence(1, 2, 3).takeWhile { it < 0 }
-    assertEquals(empty<Int>(), actual)
+    assertEquals(empty<Int>(), sequence(1, 2, 3).takeWhile { it < 0 })
   }
 }

--- a/libraries/stdlib/test/sequences/SequencesTest.kt
+++ b/libraries/stdlib/test/sequences/SequencesTest.kt
@@ -4,7 +4,6 @@ import kotlin.sequences.grouped
 import kotlin.sequences.sequence
 import kotlin.sequences.sliding
 import kotlin.sequences.times
-import kotlin.util.arrayList
 
 import kotlin.test.assertEquals
 import org.junit.Test
@@ -12,56 +11,45 @@ import org.junit.Test
 class SequencesTest {
 
   Test fun timesComputesTheCartesianSquareOfAnIterable() {
-    val actual = (1..3) * (1..3)
     val expected = sequence(
         #(1, 1), #(1, 2), #(1, 3),
         #(2, 1), #(2, 2), #(2, 3),
         #(3, 1), #(3, 2), #(3, 3)
     )
-    assertEquals(expected, actual)
+    assertEquals(expected, (1..3) * (1..3))
   }
 
   Test fun timesComputesTheCartesianProductOfTwoRanges() {
-    val actual = (1..3) * (4..7)
     val expected = sequence(
         #(1, 4), #(1, 5), #(1, 6), #(1, 7),
         #(2, 4), #(2, 5), #(2, 6), #(2, 7),
         #(3, 4), #(3, 5), #(3, 6), #(3, 7)
     )
-    assertEquals(expected, actual)
+    assertEquals(expected, (1..3) * (4..7))
   }
 
   Test fun timesComputesTheCartesianProductOfTwoIterables() {
-    val actual = sequence(1, 3, 5, 7) * (4..6)
     val expected = sequence(
         #(1, 4), #(1, 5), #(1, 6),
         #(3, 4), #(3, 5), #(3, 6),
         #(5, 4), #(5, 5), #(5, 6),
         #(7, 4), #(7, 5), #(7, 6)
     )
-    assertEquals(expected, actual)
+    assertEquals(expected, sequence(1, 3, 5, 7) * (4..6))
   }
 
-  Test fun groupedReturnsFixedSizeGroupsOfStrings() {
-    val digits = """
+  private val digits = """
 62229893423380308135336276614282806444486645238749
 30358907296290491560440772390713810515859307960866
-70172427121883998797908792274921901699720888093776
-65727333001053367881220235421809751254540594752243
+701724271218839987979087922749219016997
 """.trim().replaceAll("\\n", "")
 
+  Test fun groupedReturnsFixedSizeGroupsOfStrings() {
     val actual = digits.grouped(50).toList().get(2)
-    assertEquals("70172427121883998797908792274921901699720888093776", actual)
+    assertEquals("701724271218839987979087922749219016997", actual)
   }
 
   Test fun slidingOverALongStringOfDigits() {
-    val digits = """
-62229893423380308135336276614282806444486645238749
-30358907296290491560440772390713810515859307960866
-70172427121883998797908792274921901699720888093776
-65727333001053367881220235421809751254540594752243
-""".trim().replaceAll("\\n", "")
-
     val actual = digits.sliding(3).filter { Integer.parseInt(it) > 990 }
     assertEquals(sequence("998", "997"), actual)
   }


### PR DESCRIPTION
Test failures for sequences are now much easier to diagnose when they occur. Also, for infinite sequences, `Sequence#toString()` will only list the first `n` elements.
