### PR TITLE
Fix for: KT-1403 Code completion for keywords when replacing another keyword should not double spaces

### DIFF
--- a/idea/src/org/jetbrains/jet/plugin/completion/handlers/JetKeywordInsertHandler.java
+++ b/idea/src/org/jetbrains/jet/plugin/completion/handlers/JetKeywordInsertHandler.java
@@ -17,6 +17,7 @@
 package org.jetbrains.jet.plugin.completion.handlers;
 
 import com.google.common.collect.Sets;
+import com.intellij.codeInsight.TailType;
 import com.intellij.codeInsight.completion.InsertHandler;
 import com.intellij.codeInsight.completion.InsertionContext;
 import com.intellij.codeInsight.lookup.LookupElement;
@@ -39,12 +40,11 @@ public class JetKeywordInsertHandler implements InsertHandler<LookupElement> {
         // Add space after keyword
         if (!NO_SPACE_AFTER.contains(keyword)) {
             Editor editor = context.getEditor();
-            Document document = editor.getDocument();
 
-            int offset = context.getStartOffset() + keyword.length();
             context.setAddCompletionChar(false);
-            document.insertString(offset, " ");
-            editor.getCaretModel().moveToOffset(editor.getCaretModel().getOffset() + 1);
+            final TailType tailType = TailType.SPACE;
+            tailType.processTail(context.getEditor(), context.getTailOffset());
+            editor.getCaretModel().moveToOffset(editor.getCaretModel().getOffset());
         }
     }
 }


### PR DESCRIPTION
Not really sure if this is the right approach, or if there might be side effects I am unaware of, but it seems to work.
