### PR TITLE
Fix test's name

### DIFF
--- a/idea/tests/org/jetbrains/jet/completion/JetBasicCompletionTest.java
+++ b/idea/tests/org/jetbrains/jet/completion/JetBasicCompletionTest.java
@@ -101,7 +101,7 @@ public class JetBasicCompletionTest extends JetCompletionTestBase {
         doTest();
     }
 
-    public void testNoCLassNameDuplication() {
+    public void testNoClassNameDuplication() {
         doTest();
     }
 


### PR DESCRIPTION
Super small fix for test's name. 

http://teamcity.jetbrains.com/viewLog.html?buildId=63136&tab=buildResultsDiv&buildTypeId=bt345 - ubuntu agent
http://teamcity.jetbrains.com/viewLog.html?buildId=63134&tab=buildResultsDiv&buildTypeId=bt345 - win agent

win build agents are case-insensitive, but we have an exception on linux:

java.lang.AssertionError: java.lang.RuntimeException: java.io.FileNotFoundException: ./idea/testData/completion/basic/NoCLassNameDuplication.kt (No such file or directory)
