### PR TITLE
js enumerable for ecma5

### DIFF
--- a/js/js.libraries/src/core/annotations.kt
+++ b/js/js.libraries/src/core/annotations.kt
@@ -4,3 +4,5 @@ native
 annotation class native(name : String = "") {}
 native
 annotation class library(name : String = "") {}
+native
+annotation class enumerable() {}

--- a/js/js.tests/test/org/jetbrains/k2js/test/semantics/PropertyAccessTest.java
+++ b/js/js.tests/test/org/jetbrains/k2js/test/semantics/PropertyAccessTest.java
@@ -16,10 +16,14 @@
 
 package org.jetbrains.k2js.test.semantics;
 
+import com.google.common.collect.Lists;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.k2js.config.EcmaVersion;
 import org.jetbrains.k2js.test.SingleFileTranslationTest;
+import org.jetbrains.k2js.test.utils.JsTestUtils;
 
 import java.util.EnumSet;
+import java.util.List;
 
 /**
  * @author Pavel Talanov
@@ -78,5 +82,19 @@ public final class PropertyAccessTest extends SingleFileTranslationTest {
 
     public void testInitInstanceProperties() throws Exception {
         fooBoxTest(EnumSet.of(EcmaVersion.v5));
+    }
+    
+    public void testEnumerable() throws Exception {
+            fooBoxTest(JsTestUtils.successOnEcmaV5());
+        }
+
+    @Override
+    @NotNull
+    protected List<String> additionalJSFiles(@NotNull EcmaVersion ecmaVersion) {
+        List<String> result = Lists.newArrayList(super.additionalJSFiles(ecmaVersion));
+        if (getName().equals("testEnumerable")) {
+            result.add(pathToTestFiles() + "enumerate.js");
+        }
+        return result;
     }
 }

--- a/js/js.tests/test/org/jetbrains/k2js/test/utils/JsTestUtils.java
+++ b/js/js.tests/test/org/jetbrains/k2js/test/utils/JsTestUtils.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 
 /**
@@ -32,6 +33,11 @@ import java.util.List;
 public final class JsTestUtils {
 
     private JsTestUtils() {
+    }
+
+    @NotNull
+    public static EnumSet<EcmaVersion> successOnEcmaV5() {
+        return EnumSet.of(EcmaVersion.v5);
     }
 
     @NotNull

--- a/js/js.translator/src/org/jetbrains/k2js/translate/context/Namer.java
+++ b/js/js.translator/src/org/jetbrains/k2js/translate/context/Namer.java
@@ -122,6 +122,9 @@ public final class Namer {
     @NotNull
     private final JsPropertyInitializer writablePropertyDescriptorField;
 
+    @NotNull
+    private final JsPropertyInitializer enumerablePropertyDescriptorField;
+
     private Namer(@NotNull JsScope rootScope) {
         kotlinName = rootScope.declareName(KOTLIN_OBJECT_NAME);
         kotlinScope = new JsScope(rootScope, "Kotlin standard object");
@@ -132,7 +135,9 @@ public final class Namer {
 
         isTypeName = kotlinScope.declareName("isType");
 
-        writablePropertyDescriptorField = new JsPropertyInitializer(new JsNameRef("writable"), rootScope.getProgram().getTrueLiteral());
+        JsProgram program = rootScope.getProgram();
+        writablePropertyDescriptorField = new JsPropertyInitializer(program.getStringLiteral("writable"), program.getTrueLiteral());
+        enumerablePropertyDescriptorField = new JsPropertyInitializer(program.getStringLiteral("enumerable"), program.getTrueLiteral());
     }
 
     @NotNull
@@ -188,6 +193,11 @@ public final class Namer {
     @NotNull
     public JsPropertyInitializer writablePropertyDescriptorField() {
         return writablePropertyDescriptorField;
+    }
+
+    @NotNull
+    public JsPropertyInitializer enumerablePropertyDescriptorField() {
+        return enumerablePropertyDescriptorField;
     }
 
     @NotNull

--- a/js/js.translator/src/org/jetbrains/k2js/translate/declaration/DeclarationBodyVisitor.java
+++ b/js/js.translator/src/org/jetbrains/k2js/translate/declaration/DeclarationBodyVisitor.java
@@ -71,10 +71,9 @@ public final class DeclarationBodyVisitor extends TranslatorVisitor<List<JsPrope
                                                           @NotNull TranslationContext context) {
         JsPropertyInitializer methodAsPropertyInitializer = Translation.functionTranslator(expression, context).translateAsMethod();
         if (context.isEcma5()) {
-            final FunctionDescriptor descriptor = getFunctionDescriptor(context.bindingContext(), expression);
-            boolean overridable = descriptor.getModality().isOverridable();
+            FunctionDescriptor descriptor = getFunctionDescriptor(context.bindingContext(), expression);
             JsExpression methodBodyExpression = methodAsPropertyInitializer.getValueExpr();
-            methodAsPropertyInitializer.setValueExpr(JsAstUtils.createPropertyDataDescriptor(overridable, methodBodyExpression, context));
+            methodAsPropertyInitializer.setValueExpr(JsAstUtils.createPropertyDataDescriptor(descriptor, methodBodyExpression, context));
         }
         return Collections.singletonList(methodAsPropertyInitializer);
     }

--- a/js/js.translator/src/org/jetbrains/k2js/translate/utils/AnnotationsUtils.java
+++ b/js/js.translator/src/org/jetbrains/k2js/translate/utils/AnnotationsUtils.java
@@ -19,6 +19,7 @@ package org.jetbrains.k2js.translate.utils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.jet.lang.descriptors.ClassDescriptor;
+import org.jetbrains.jet.lang.descriptors.ClassKind;
 import org.jetbrains.jet.lang.descriptors.DeclarationDescriptor;
 import org.jetbrains.jet.lang.descriptors.annotations.AnnotationDescriptor;
 import org.jetbrains.jet.lang.resolve.DescriptorUtils;
@@ -30,6 +31,8 @@ import static org.jetbrains.k2js.translate.utils.JsDescriptorUtils.getContaining
  * @author Pavel Talanov
  */
 public final class AnnotationsUtils {
+
+    private static final String ENUMERABLE = "js.enumerable";
 
     private AnnotationsUtils() {
     }
@@ -69,10 +72,14 @@ public final class AnnotationsUtils {
 
     @Nullable
     private static AnnotationDescriptor getAnnotationByName(@NotNull DeclarationDescriptor descriptor,
-                                                            @NotNull PredefinedAnnotation annotation) {
+            @NotNull PredefinedAnnotation annotation) {
+        return getAnnotationByName(descriptor, annotation.getFQName());
+    }
+
+    @Nullable
+    private static AnnotationDescriptor getAnnotationByName(@NotNull DeclarationDescriptor descriptor, @NotNull String fqn) {
         for (AnnotationDescriptor annotationDescriptor : descriptor.getAnnotations()) {
-            String annotationClassFQName = getAnnotationClassFQName(annotationDescriptor);
-            if (annotationClassFQName.equals(annotation.getFQName())) {
+            if (getAnnotationClassFQName(annotationDescriptor).equals(fqn)) {
                 return annotationDescriptor;
             }
         }
@@ -91,6 +98,16 @@ public final class AnnotationsUtils {
         return hasAnnotationOrInsideAnnotatedClass(descriptor, PredefinedAnnotation.NATIVE);
     }
 
+    public static boolean isEnumerable(@NotNull DeclarationDescriptor descriptor) {
+        if (getAnnotationByName(descriptor, ENUMERABLE) != null) {
+            return true;
+        }
+        ClassDescriptor containingClass = getContainingClass(descriptor);
+        return containingClass != null &&
+               (getAnnotationByName(containingClass, ENUMERABLE) != null ||
+                (containingClass.getKind().equals(ClassKind.OBJECT) && containingClass.getName().isSpecial()));
+    }
+
     public static boolean isLibraryObject(@NotNull DeclarationDescriptor descriptor) {
         return hasAnnotationOrInsideAnnotatedClass(descriptor, PredefinedAnnotation.LIBRARY);
     }
@@ -105,14 +122,15 @@ public final class AnnotationsUtils {
     }
 
     public static boolean hasAnnotationOrInsideAnnotatedClass(@NotNull DeclarationDescriptor descriptor,
-                                                              @NotNull PredefinedAnnotation annotation) {
-        if (getAnnotationByName(descriptor, annotation) != null) {
+            @NotNull PredefinedAnnotation annotation) {
+        return hasAnnotationOrInsideAnnotatedClass(descriptor, annotation.getFQName());
+    }
+
+    private static boolean hasAnnotationOrInsideAnnotatedClass(@NotNull DeclarationDescriptor descriptor, @NotNull String fqn) {
+        if (getAnnotationByName(descriptor, fqn) != null) {
             return true;
         }
         ClassDescriptor containingClass = getContainingClass(descriptor);
-        if (containingClass == null) {
-            return false;
-        }
-        return (getAnnotationByName(containingClass, annotation) != null);
+        return containingClass != null && getAnnotationByName(containingClass, fqn) != null;
     }
 }

--- a/js/js.translator/src/org/jetbrains/k2js/translate/utils/PredefinedAnnotation.java
+++ b/js/js.translator/src/org/jetbrains/k2js/translate/utils/PredefinedAnnotation.java
@@ -22,8 +22,6 @@ import org.jetbrains.annotations.NotNull;
  * @author Pavel Talanov
  */
 public enum PredefinedAnnotation {
-
-
     LIBRARY("js.library"),
     NATIVE("js.native");
 

--- a/js/js.translator/testFiles/propertyAccess/cases/enumerable.kt
+++ b/js/js.translator/testFiles/propertyAccess/cases/enumerable.kt
@@ -1,0 +1,28 @@
+package foo
+
+import js.enumerable
+import js.native
+
+native
+fun <T> _enumerate(o:T):T = noImpl
+
+native
+fun _findFirst<T>(o:Any):T = noImpl
+
+enumerable
+class Test() {
+    val a:Int = 100
+    val b:String = "s"
+}
+
+class P() {
+    enumerable
+    val a:Int = 100
+    val b:String = "s"
+}
+
+fun box():Boolean {
+    val test = _enumerate(Test())
+    val p = _enumerate(P())
+    return (100 == test.a && "s" == test.b) && p.a == 100 && _findFirst<Int>(object {val test = 100}) == 100;
+}

--- a/js/js.translator/testFiles/propertyAccess/enumerate.js
+++ b/js/js.translator/testFiles/propertyAccess/enumerate.js
@@ -1,0 +1,13 @@
+function _enumerate(o) {
+    var r = {};
+    for (var p in o) {
+        r[p] = o[p];
+    }
+    return r;
+}
+
+function _findFirst(o) {
+    for (var p in o) {
+        return o[p];
+    }
+}


### PR DESCRIPTION
Enumerable is not possible for ecma 3, but is possible for ecma 5.

By default, any property or function is not enumerable. But sometimes we need to define property as enumerable. For example, if dto (data transfer object) has non-enumerable properties, google chrome extension will crash (on attach debugger).

So:
1) new annotation — enumerable (class or property/function level)
2) anonymous object is enumerable by default (i.e. object {val data = "foo"} will be enumerable).
