### PR TITLE
Fix foldRight implementation for iterables

### DIFF
--- a/js/js.libraries/src/core/dom.kt
+++ b/js/js.libraries/src/core/dom.kt
@@ -49,17 +49,17 @@ native public trait Document: Node {
     public var xmlVersion: String
     public fun createElement(arg1: String): Element = js.noImpl
     public fun createComment(arg1: String): Comment = js.noImpl
-    public fun getElementsByTagName(arg1: String): NodeList = js.noImpl
-    public fun getElementsByTagNameNS(arg1: String, arg2: String): NodeList = js.noImpl
     public fun createDocumentFragment(): DocumentFragment = js.noImpl
     public fun createTextNode(arg1: String): Text = js.noImpl
     public fun createCDATASection(arg1: String): CDATASection = js.noImpl
     public fun createProcessingInstruction(arg1: String, arg2: String): ProcessingInstruction = js.noImpl
     public fun createAttribute(arg1: String): Attr = js.noImpl
     public fun createEntityReference(arg1: String): EntityReference = js.noImpl
+    public fun getElementsByTagName(arg1: String): NodeList = js.noImpl
     public fun importNode(arg1: Node, arg2: Boolean): Node = js.noImpl
     public fun createElementNS(arg1: String, arg2: String): Element = js.noImpl
     public fun createAttributeNS(arg1: String, arg2: String): Attr = js.noImpl
+    public fun getElementsByTagNameNS(arg1: String, arg2: String): NodeList = js.noImpl
     public fun getElementById(arg1: String): Element = js.noImpl
     public fun adoptNode(arg1: Node): Node = js.noImpl
     public fun normalizeDocument(): Unit = js.noImpl
@@ -136,15 +136,15 @@ native public trait Element: Node {
     public val tagName: String
     public fun getAttribute(arg1: String): String = js.noImpl
     public fun setAttribute(arg1: String, arg2: String): Unit = js.noImpl
+    public fun getElementsByTagName(arg1: String): NodeList = js.noImpl
+    public fun getElementsByTagNameNS(arg1: String, arg2: String): NodeList = js.noImpl
     public fun removeAttribute(arg1: String): Unit = js.noImpl
     public fun getAttributeNode(arg1: String): Attr = js.noImpl
     public fun removeAttributeNode(arg1: Attr): Attr = js.noImpl
-    public fun getElementsByTagName(arg1: String): NodeList = js.noImpl
     public fun getAttributeNS(arg1: String, arg2: String): String = js.noImpl
     public fun setAttributeNS(arg1: String, arg2: String, arg3: String): Unit = js.noImpl
     public fun removeAttributeNS(arg1: String, arg2: String): Unit = js.noImpl
     public fun getAttributeNodeNS(arg1: String, arg2: String): Attr = js.noImpl
-    public fun getElementsByTagNameNS(arg1: String, arg2: String): NodeList = js.noImpl
     public fun hasAttribute(arg1: String): Boolean = js.noImpl
     public fun hasAttributeNS(arg1: String, arg2: String): Boolean = js.noImpl
     public fun setIdAttribute(arg1: String, arg2: Boolean): Unit = js.noImpl
@@ -204,11 +204,10 @@ native public trait Node {
     public var textContent: String
     public fun normalize(): Unit = js.noImpl
     public fun isSupported(arg1: String, arg2: String): Boolean = js.noImpl
-    public fun getUserData(arg1: String): Any = js.noImpl
-    public fun setUserData(arg1: String, arg2: Any, arg3: UserDataHandler): Any = js.noImpl
     public fun getFeature(arg1: String, arg2: String): Any = js.noImpl
     public fun hasAttributes(): Boolean = js.noImpl
     public fun removeChild(arg1: Node): Node = js.noImpl
+    public fun getUserData(arg1: String): Any = js.noImpl
     public fun replaceChild(arg1: Node, arg2: Node): Node = js.noImpl
     public fun insertBefore(arg1: Node, arg2: Node): Node = js.noImpl
     public fun appendChild(arg1: Node): Node = js.noImpl
@@ -220,6 +219,7 @@ native public trait Node {
     public fun isDefaultNamespace(arg1: String): Boolean = js.noImpl
     public fun lookupNamespaceURI(arg1: String): String = js.noImpl
     public fun isEqualNode(arg1: Node): Boolean = js.noImpl
+    public fun setUserData(arg1: String, arg2: Any, arg3: UserDataHandler): Any = js.noImpl
 
     class object {
         public val ELEMENT_NODE: Short = 1

--- a/libraries/stdlib/src/generated/ArraysFromJLangIterables.kt
+++ b/libraries/stdlib/src/generated/ArraysFromJLangIterables.kt
@@ -145,7 +145,7 @@ public inline fun <T> Array<T>.fold(initial: T, operation: (T, T) -> T): T {
  *
  * @includeFunctionBody ../../test/CollectionTest.kt foldRight
  */
-public inline fun <T> Array<T>.foldRight(initial: T, operation: (T, T) -> T): T = reverse().fold(initial, operation)
+public inline fun <T> Array<T>.foldRight(initial: T, operation: (T, T) -> T): T = reverse().fold(initial, {x, y -> operation(y, x)})
 
 /**
  * Groups the elements in the collection into a new [[Map]] using the supplied *toKey* function to calculate the key to group the elements by

--- a/libraries/stdlib/src/generated/BooleanArraysFromJLangIterables.kt
+++ b/libraries/stdlib/src/generated/BooleanArraysFromJLangIterables.kt
@@ -145,7 +145,7 @@ public inline fun BooleanArray.fold(initial: Boolean, operation: (Boolean, Boole
  *
  * @includeFunctionBody ../../test/CollectionTest.kt foldRight
  */
-public inline fun BooleanArray.foldRight(initial: Boolean, operation: (Boolean, Boolean) -> Boolean): Boolean = reverse().fold(initial, operation)
+public inline fun BooleanArray.foldRight(initial: Boolean, operation: (Boolean, Boolean) -> Boolean): Boolean = reverse().fold(initial, {x, y -> operation(y, x)})
 
 /**
  * Groups the elements in the collection into a new [[Map]] using the supplied *toKey* function to calculate the key to group the elements by

--- a/libraries/stdlib/src/generated/ByteArraysFromJLangIterables.kt
+++ b/libraries/stdlib/src/generated/ByteArraysFromJLangIterables.kt
@@ -145,7 +145,7 @@ public inline fun ByteArray.fold(initial: Byte, operation: (Byte, Byte) -> Byte)
  *
  * @includeFunctionBody ../../test/CollectionTest.kt foldRight
  */
-public inline fun ByteArray.foldRight(initial: Byte, operation: (Byte, Byte) -> Byte): Byte = reverse().fold(initial, operation)
+public inline fun ByteArray.foldRight(initial: Byte, operation: (Byte, Byte) -> Byte): Byte = reverse().fold(initial, {x, y -> operation(y, x)})
 
 /**
  * Groups the elements in the collection into a new [[Map]] using the supplied *toKey* function to calculate the key to group the elements by

--- a/libraries/stdlib/src/generated/CharArraysFromJLangIterables.kt
+++ b/libraries/stdlib/src/generated/CharArraysFromJLangIterables.kt
@@ -145,7 +145,7 @@ public inline fun CharArray.fold(initial: Char, operation: (Char, Char) -> Char)
  *
  * @includeFunctionBody ../../test/CollectionTest.kt foldRight
  */
-public inline fun CharArray.foldRight(initial: Char, operation: (Char, Char) -> Char): Char = reverse().fold(initial, operation)
+public inline fun CharArray.foldRight(initial: Char, operation: (Char, Char) -> Char): Char = reverse().fold(initial, {x, y -> operation(y, x)})
 
 /**
  * Groups the elements in the collection into a new [[Map]] using the supplied *toKey* function to calculate the key to group the elements by

--- a/libraries/stdlib/src/generated/DoubleArraysFromJLangIterables.kt
+++ b/libraries/stdlib/src/generated/DoubleArraysFromJLangIterables.kt
@@ -145,7 +145,7 @@ public inline fun DoubleArray.fold(initial: Double, operation: (Double, Double) 
  *
  * @includeFunctionBody ../../test/CollectionTest.kt foldRight
  */
-public inline fun DoubleArray.foldRight(initial: Double, operation: (Double, Double) -> Double): Double = reverse().fold(initial, operation)
+public inline fun DoubleArray.foldRight(initial: Double, operation: (Double, Double) -> Double): Double = reverse().fold(initial, {x, y -> operation(y, x)})
 
 /**
  * Groups the elements in the collection into a new [[Map]] using the supplied *toKey* function to calculate the key to group the elements by

--- a/libraries/stdlib/src/generated/FloatArraysFromJLangIterables.kt
+++ b/libraries/stdlib/src/generated/FloatArraysFromJLangIterables.kt
@@ -145,7 +145,7 @@ public inline fun FloatArray.fold(initial: Float, operation: (Float, Float) -> F
  *
  * @includeFunctionBody ../../test/CollectionTest.kt foldRight
  */
-public inline fun FloatArray.foldRight(initial: Float, operation: (Float, Float) -> Float): Float = reverse().fold(initial, operation)
+public inline fun FloatArray.foldRight(initial: Float, operation: (Float, Float) -> Float): Float = reverse().fold(initial, {x, y -> operation(y, x)})
 
 /**
  * Groups the elements in the collection into a new [[Map]] using the supplied *toKey* function to calculate the key to group the elements by

--- a/libraries/stdlib/src/generated/IntArraysFromJLangIterables.kt
+++ b/libraries/stdlib/src/generated/IntArraysFromJLangIterables.kt
@@ -145,7 +145,7 @@ public inline fun IntArray.fold(initial: Int, operation: (Int, Int) -> Int): Int
  *
  * @includeFunctionBody ../../test/CollectionTest.kt foldRight
  */
-public inline fun IntArray.foldRight(initial: Int, operation: (Int, Int) -> Int): Int = reverse().fold(initial, operation)
+public inline fun IntArray.foldRight(initial: Int, operation: (Int, Int) -> Int): Int = reverse().fold(initial, {x, y -> operation(y, x)})
 
 /**
  * Groups the elements in the collection into a new [[Map]] using the supplied *toKey* function to calculate the key to group the elements by

--- a/libraries/stdlib/src/generated/JUtilIteratorsFromJLangIterables.kt
+++ b/libraries/stdlib/src/generated/JUtilIteratorsFromJLangIterables.kt
@@ -143,7 +143,7 @@ public inline fun <T> java.util.Iterator<T>.fold(initial: T, operation: (T, T) -
  *
  * @includeFunctionBody ../../test/CollectionTest.kt foldRight
  */
-public inline fun <T> java.util.Iterator<T>.foldRight(initial: T, operation: (T, T) -> T): T = reverse().fold(initial, operation)
+public inline fun <T> java.util.Iterator<T>.foldRight(initial: T, operation: (T, T) -> T): T = reverse().fold(initial, {x, y -> operation(y, x)})
 
 /**
  * Groups the elements in the collection into a new [[Map]] using the supplied *toKey* function to calculate the key to group the elements by

--- a/libraries/stdlib/src/generated/LongArraysFromJLangIterables.kt
+++ b/libraries/stdlib/src/generated/LongArraysFromJLangIterables.kt
@@ -145,7 +145,7 @@ public inline fun LongArray.fold(initial: Long, operation: (Long, Long) -> Long)
  *
  * @includeFunctionBody ../../test/CollectionTest.kt foldRight
  */
-public inline fun LongArray.foldRight(initial: Long, operation: (Long, Long) -> Long): Long = reverse().fold(initial, operation)
+public inline fun LongArray.foldRight(initial: Long, operation: (Long, Long) -> Long): Long = reverse().fold(initial, {x, y -> operation(y, x)})
 
 /**
  * Groups the elements in the collection into a new [[Map]] using the supplied *toKey* function to calculate the key to group the elements by

--- a/libraries/stdlib/src/generated/ShortArraysFromJLangIterables.kt
+++ b/libraries/stdlib/src/generated/ShortArraysFromJLangIterables.kt
@@ -145,7 +145,7 @@ public inline fun ShortArray.fold(initial: Short, operation: (Short, Short) -> S
  *
  * @includeFunctionBody ../../test/CollectionTest.kt foldRight
  */
-public inline fun ShortArray.foldRight(initial: Short, operation: (Short, Short) -> Short): Short = reverse().fold(initial, operation)
+public inline fun ShortArray.foldRight(initial: Short, operation: (Short, Short) -> Short): Short = reverse().fold(initial, {x, y -> operation(y, x)})
 
 /**
  * Groups the elements in the collection into a new [[Map]] using the supplied *toKey* function to calculate the key to group the elements by

--- a/libraries/stdlib/src/generated/StandardFromJLangIterables.kt
+++ b/libraries/stdlib/src/generated/StandardFromJLangIterables.kt
@@ -145,7 +145,7 @@ public inline fun <T> Iterable<T>.fold(initial: T, operation: (T, T) -> T): T {
  *
  * @includeFunctionBody ../../test/CollectionTest.kt foldRight
  */
-public inline fun <T> Iterable<T>.foldRight(initial: T, operation: (T, T) -> T): T = reverse().fold(initial, operation)
+public inline fun <T> Iterable<T>.foldRight(initial: T, operation: (T, T) -> T): T = reverse().fold(initial, {x, y -> operation(y, x)})
 
 /**
  * Groups the elements in the collection into a new [[Map]] using the supplied *toKey* function to calculate the key to group the elements by

--- a/libraries/stdlib/src/kotlin/JLangIterables.kt
+++ b/libraries/stdlib/src/kotlin/JLangIterables.kt
@@ -135,7 +135,7 @@ public inline fun <T> java.lang.Iterable<T>.fold(initial: T, operation: (T, T) -
  *
  * @includeFunctionBody ../../test/CollectionTest.kt foldRight
  */
-public inline fun <T> java.lang.Iterable<T>.foldRight(initial: T, operation: (T, T) -> T): T = reverse().fold(initial, operation)
+public inline fun <T> java.lang.Iterable<T>.foldRight(initial: T, operation: (T, T) -> T): T = reverse().fold(initial, {x, y -> operation(y, x)})
 
 /**
  * Groups the elements in the collection into a new [[Map]] using the supplied *toKey* function to calculate the key to group the elements by

--- a/libraries/stdlib/src/kotlin/nullable/Nullables.kt
+++ b/libraries/stdlib/src/kotlin/nullable/Nullables.kt
@@ -103,8 +103,8 @@ public inline fun <T> T?.fold(initial: T, operation: (it: T, it2: T) -> T): T {
  * Folds all the values from right to left with the initial value to perform the operation on sequential pairs of values
  */
 public inline fun <T> T?.foldRight(initial: T, operation: (it: T, it2: T) -> T): T {
-    // maximum size is 1 so it makes no difference :)
-    return fold(initial, operation)
+    // maximum size is 1 so reverse is not needed
+    return fold(initial, {x, y -> operation(y, x)})
 }
 
 /**

--- a/libraries/stdlib/test/CollectionTest.kt
+++ b/libraries/stdlib/test/CollectionTest.kt
@@ -195,10 +195,24 @@ class CollectionTest {
         }
     }
 
+    test fun foldWithNonCommutativeOperation() {
+        expect(1) {
+            val numbers = arrayList(1, 2, 3)
+            numbers.fold(7) {a, b -> a - b}
+        }
+    }
+
     test fun foldRight() {
-        expect("4321") {
+        expect("1234") {
             val numbers = arrayList(1, 2, 3, 4)
             numbers.map<Int, String>{it.toString()}.foldRight(""){ a, b -> a + b}
+        }
+    }
+
+    test fun foldRightWithNonCommutativeOperation() {
+        expect(-5) {
+            val numbers = arrayList(1, 2, 3)
+            numbers.foldRight(7) {a, b -> a - b}
         }
     }
 


### PR DESCRIPTION
In Scala `foldLeft` and `foldRight` functions have extremely simple definition. `foldLeft` function groups elements of array from left and processes grouped pairs with given operation. E.g. array `(1, 2, 3, 4)` with operation `+` and initial value `0` processed as 

```
 ((((0 + 1) + 2) + 3) + 4)
```

`foldRight` function should do the same, but from right side of array:

```
 (1 + (2 + (3 + (4 + 0))))
```

Current implementation of `foldRight` folds of reversed array from left in fact (It's not really right-folding, but literally left-folding of reversed array:)).

It does not make sense with commutative operation:

```
 Correct implementation (1, 2, 3).foldRight(0, +) => (1 + (2 + (3 + 0))) => 6
 Current implementation (1, 2, 3).foldRight(0, +) => (3, 2, 1).fold(0, +) => (((0 + 3) + 2) + 1) => 6
```

But current implementation gives wrong answer with noncommutative operation:

```
 Correct implementation (1, 2, 3).foldRight(0, -) => (1 - (2 - (3 - 0))) => 2
 Current implementation (1, 2, 3).foldRight(0, -) => (3, 2, 1).fold(0, -) => (((0 - 3) - 2) - 1) => -6
```

According to the `foldRightTest` in `CollectionTest` current implementation is correct. But according to [Scala implementation](http://www.scala-lang.org/archives/downloads/distrib/files/nightly/docs/library/scala/collection/TraversableOnce.html) or [Wolfram implementation](http://reference.wolfram.com/mathematica/ref/Fold.html) of this methods `foldRightTest` is wrong too. 
## To discuss

Scala distinguishes methods `fold` and `foldLeft`. `fold` function uses given comparator to define folding order. May be it make sense to rename kotlin `fold` function to `foldLeft` and create extra `fold` function with comparator.
