### PR TITLE
Implement reduce and reduceRight functions

### DIFF
--- a/libraries/stdlib/src/generated/ArraysFromJLangIterables.kt
+++ b/libraries/stdlib/src/generated/ArraysFromJLangIterables.kt
@@ -147,6 +147,36 @@ public inline fun <T> Array<T>.fold(initial: T, operation: (T, T) -> T): T {
  */
 public inline fun <T> Array<T>.foldRight(initial: T, operation: (T, T) -> T): T = reverse().fold(initial, {x, y -> operation(y, x)})
 
+
+/**
+ * Applies binary operation to all elements of iterable, going from left to right.
+ * Similar to fold function, but uses the first element as initial value
+ *
+ * @includeFunctionBody ../../test/CollectionTest.kt reduce
+ */
+public inline fun <T> Array<T>.reduce(operation: (T, T) -> T): T {
+    val iterator = this.iterator().sure()
+    if (!iterator.hasNext) {
+        throw UnsupportedOperationException("Empty iterable can't be reduced")
+    }
+
+    var result: T = iterator.next() //compiler doesn't understand that result will initialized anyway
+    while (iterator.hasNext) {
+        result = operation(result, iterator.next())
+    }
+
+    return result
+}
+
+/**
+ * Applies binary operation to all elements of iterable, going from right to left.
+ * Similar to foldRight function, but uses the last element as initial value
+ *
+ * @includeFunctionBody ../../test/CollectionTest.kt reduceRight
+ */
+public inline fun <T> Array<T>.reduceRight(operation: (T, T) -> T): T = reverse().reduce { x, y -> operation(y, x) }
+
+
 /**
  * Groups the elements in the collection into a new [[Map]] using the supplied *toKey* function to calculate the key to group the elements by
  *

--- a/libraries/stdlib/src/generated/BooleanArraysFromJLangIterables.kt
+++ b/libraries/stdlib/src/generated/BooleanArraysFromJLangIterables.kt
@@ -147,6 +147,36 @@ public inline fun BooleanArray.fold(initial: Boolean, operation: (Boolean, Boole
  */
 public inline fun BooleanArray.foldRight(initial: Boolean, operation: (Boolean, Boolean) -> Boolean): Boolean = reverse().fold(initial, {x, y -> operation(y, x)})
 
+
+/**
+ * Applies binary operation to all elements of iterable, going from left to right.
+ * Similar to fold function, but uses the first element as initial value
+ *
+ * @includeFunctionBody ../../test/CollectionTest.kt reduce
+ */
+public inline fun BooleanArray.reduce(operation: (Boolean, Boolean) -> Boolean): Boolean {
+    val iterator = this.iterator().sure()
+    if (!iterator.hasNext) {
+        throw UnsupportedOperationException("Empty iterable can't be reduced")
+    }
+
+    var result: Boolean = iterator.next() //compiler doesn't understand that result will initialized anyway
+    while (iterator.hasNext) {
+        result = operation(result, iterator.next())
+    }
+
+    return result
+}
+
+/**
+ * Applies binary operation to all elements of iterable, going from right to left.
+ * Similar to foldRight function, but uses the last element as initial value
+ *
+ * @includeFunctionBody ../../test/CollectionTest.kt reduceRight
+ */
+public inline fun BooleanArray.reduceRight(operation: (Boolean, Boolean) -> Boolean): Boolean = reverse().reduce { x, y -> operation(y, x) }
+
+
 /**
  * Groups the elements in the collection into a new [[Map]] using the supplied *toKey* function to calculate the key to group the elements by
  *

--- a/libraries/stdlib/src/generated/ByteArraysFromJLangIterables.kt
+++ b/libraries/stdlib/src/generated/ByteArraysFromJLangIterables.kt
@@ -147,6 +147,36 @@ public inline fun ByteArray.fold(initial: Byte, operation: (Byte, Byte) -> Byte)
  */
 public inline fun ByteArray.foldRight(initial: Byte, operation: (Byte, Byte) -> Byte): Byte = reverse().fold(initial, {x, y -> operation(y, x)})
 
+
+/**
+ * Applies binary operation to all elements of iterable, going from left to right.
+ * Similar to fold function, but uses the first element as initial value
+ *
+ * @includeFunctionBody ../../test/CollectionTest.kt reduce
+ */
+public inline fun ByteArray.reduce(operation: (Byte, Byte) -> Byte): Byte {
+    val iterator = this.iterator().sure()
+    if (!iterator.hasNext) {
+        throw UnsupportedOperationException("Empty iterable can't be reduced")
+    }
+
+    var result: Byte = iterator.next() //compiler doesn't understand that result will initialized anyway
+    while (iterator.hasNext) {
+        result = operation(result, iterator.next())
+    }
+
+    return result
+}
+
+/**
+ * Applies binary operation to all elements of iterable, going from right to left.
+ * Similar to foldRight function, but uses the last element as initial value
+ *
+ * @includeFunctionBody ../../test/CollectionTest.kt reduceRight
+ */
+public inline fun ByteArray.reduceRight(operation: (Byte, Byte) -> Byte): Byte = reverse().reduce { x, y -> operation(y, x) }
+
+
 /**
  * Groups the elements in the collection into a new [[Map]] using the supplied *toKey* function to calculate the key to group the elements by
  *

--- a/libraries/stdlib/src/generated/CharArraysFromJLangIterables.kt
+++ b/libraries/stdlib/src/generated/CharArraysFromJLangIterables.kt
@@ -147,6 +147,36 @@ public inline fun CharArray.fold(initial: Char, operation: (Char, Char) -> Char)
  */
 public inline fun CharArray.foldRight(initial: Char, operation: (Char, Char) -> Char): Char = reverse().fold(initial, {x, y -> operation(y, x)})
 
+
+/**
+ * Applies binary operation to all elements of iterable, going from left to right.
+ * Similar to fold function, but uses the first element as initial value
+ *
+ * @includeFunctionBody ../../test/CollectionTest.kt reduce
+ */
+public inline fun CharArray.reduce(operation: (Char, Char) -> Char): Char {
+    val iterator = this.iterator().sure()
+    if (!iterator.hasNext) {
+        throw UnsupportedOperationException("Empty iterable can't be reduced")
+    }
+
+    var result: Char = iterator.next() //compiler doesn't understand that result will initialized anyway
+    while (iterator.hasNext) {
+        result = operation(result, iterator.next())
+    }
+
+    return result
+}
+
+/**
+ * Applies binary operation to all elements of iterable, going from right to left.
+ * Similar to foldRight function, but uses the last element as initial value
+ *
+ * @includeFunctionBody ../../test/CollectionTest.kt reduceRight
+ */
+public inline fun CharArray.reduceRight(operation: (Char, Char) -> Char): Char = reverse().reduce { x, y -> operation(y, x) }
+
+
 /**
  * Groups the elements in the collection into a new [[Map]] using the supplied *toKey* function to calculate the key to group the elements by
  *

--- a/libraries/stdlib/src/generated/DoubleArraysFromJLangIterables.kt
+++ b/libraries/stdlib/src/generated/DoubleArraysFromJLangIterables.kt
@@ -147,6 +147,36 @@ public inline fun DoubleArray.fold(initial: Double, operation: (Double, Double) 
  */
 public inline fun DoubleArray.foldRight(initial: Double, operation: (Double, Double) -> Double): Double = reverse().fold(initial, {x, y -> operation(y, x)})
 
+
+/**
+ * Applies binary operation to all elements of iterable, going from left to right.
+ * Similar to fold function, but uses the first element as initial value
+ *
+ * @includeFunctionBody ../../test/CollectionTest.kt reduce
+ */
+public inline fun DoubleArray.reduce(operation: (Double, Double) -> Double): Double {
+    val iterator = this.iterator().sure()
+    if (!iterator.hasNext) {
+        throw UnsupportedOperationException("Empty iterable can't be reduced")
+    }
+
+    var result: Double = iterator.next() //compiler doesn't understand that result will initialized anyway
+    while (iterator.hasNext) {
+        result = operation(result, iterator.next())
+    }
+
+    return result
+}
+
+/**
+ * Applies binary operation to all elements of iterable, going from right to left.
+ * Similar to foldRight function, but uses the last element as initial value
+ *
+ * @includeFunctionBody ../../test/CollectionTest.kt reduceRight
+ */
+public inline fun DoubleArray.reduceRight(operation: (Double, Double) -> Double): Double = reverse().reduce { x, y -> operation(y, x) }
+
+
 /**
  * Groups the elements in the collection into a new [[Map]] using the supplied *toKey* function to calculate the key to group the elements by
  *

--- a/libraries/stdlib/src/generated/FloatArraysFromJLangIterables.kt
+++ b/libraries/stdlib/src/generated/FloatArraysFromJLangIterables.kt
@@ -147,6 +147,36 @@ public inline fun FloatArray.fold(initial: Float, operation: (Float, Float) -> F
  */
 public inline fun FloatArray.foldRight(initial: Float, operation: (Float, Float) -> Float): Float = reverse().fold(initial, {x, y -> operation(y, x)})
 
+
+/**
+ * Applies binary operation to all elements of iterable, going from left to right.
+ * Similar to fold function, but uses the first element as initial value
+ *
+ * @includeFunctionBody ../../test/CollectionTest.kt reduce
+ */
+public inline fun FloatArray.reduce(operation: (Float, Float) -> Float): Float {
+    val iterator = this.iterator().sure()
+    if (!iterator.hasNext) {
+        throw UnsupportedOperationException("Empty iterable can't be reduced")
+    }
+
+    var result: Float = iterator.next() //compiler doesn't understand that result will initialized anyway
+    while (iterator.hasNext) {
+        result = operation(result, iterator.next())
+    }
+
+    return result
+}
+
+/**
+ * Applies binary operation to all elements of iterable, going from right to left.
+ * Similar to foldRight function, but uses the last element as initial value
+ *
+ * @includeFunctionBody ../../test/CollectionTest.kt reduceRight
+ */
+public inline fun FloatArray.reduceRight(operation: (Float, Float) -> Float): Float = reverse().reduce { x, y -> operation(y, x) }
+
+
 /**
  * Groups the elements in the collection into a new [[Map]] using the supplied *toKey* function to calculate the key to group the elements by
  *

--- a/libraries/stdlib/src/generated/IntArraysFromJLangIterables.kt
+++ b/libraries/stdlib/src/generated/IntArraysFromJLangIterables.kt
@@ -147,6 +147,36 @@ public inline fun IntArray.fold(initial: Int, operation: (Int, Int) -> Int): Int
  */
 public inline fun IntArray.foldRight(initial: Int, operation: (Int, Int) -> Int): Int = reverse().fold(initial, {x, y -> operation(y, x)})
 
+
+/**
+ * Applies binary operation to all elements of iterable, going from left to right.
+ * Similar to fold function, but uses the first element as initial value
+ *
+ * @includeFunctionBody ../../test/CollectionTest.kt reduce
+ */
+public inline fun IntArray.reduce(operation: (Int, Int) -> Int): Int {
+    val iterator = this.iterator().sure()
+    if (!iterator.hasNext) {
+        throw UnsupportedOperationException("Empty iterable can't be reduced")
+    }
+
+    var result: Int = iterator.next() //compiler doesn't understand that result will initialized anyway
+    while (iterator.hasNext) {
+        result = operation(result, iterator.next())
+    }
+
+    return result
+}
+
+/**
+ * Applies binary operation to all elements of iterable, going from right to left.
+ * Similar to foldRight function, but uses the last element as initial value
+ *
+ * @includeFunctionBody ../../test/CollectionTest.kt reduceRight
+ */
+public inline fun IntArray.reduceRight(operation: (Int, Int) -> Int): Int = reverse().reduce { x, y -> operation(y, x) }
+
+
 /**
  * Groups the elements in the collection into a new [[Map]] using the supplied *toKey* function to calculate the key to group the elements by
  *

--- a/libraries/stdlib/src/generated/JUtilIteratorsFromJLangIterables.kt
+++ b/libraries/stdlib/src/generated/JUtilIteratorsFromJLangIterables.kt
@@ -145,6 +145,36 @@ public inline fun <T> java.util.Iterator<T>.fold(initial: T, operation: (T, T) -
  */
 public inline fun <T> java.util.Iterator<T>.foldRight(initial: T, operation: (T, T) -> T): T = reverse().fold(initial, {x, y -> operation(y, x)})
 
+
+/**
+ * Applies binary operation to all elements of iterable, going from left to right.
+ * Similar to fold function, but uses the first element as initial value
+ *
+ * @includeFunctionBody ../../test/CollectionTest.kt reduce
+ */
+public inline fun <T> java.util.Iterator<T>.reduce(operation: (T, T) -> T): T {
+    val iterator = this.iterator().sure()
+    if (!iterator.hasNext()) {
+        throw UnsupportedOperationException("Empty iterable can't be reduced")
+    }
+
+    var result: T = iterator.next() //compiler doesn't understand that result will initialized anyway
+    while (iterator.hasNext()) {
+        result = operation(result, iterator.next())
+    }
+
+    return result
+}
+
+/**
+ * Applies binary operation to all elements of iterable, going from right to left.
+ * Similar to foldRight function, but uses the last element as initial value
+ *
+ * @includeFunctionBody ../../test/CollectionTest.kt reduceRight
+ */
+public inline fun <T> java.util.Iterator<T>.reduceRight(operation: (T, T) -> T): T = reverse().reduce { x, y -> operation(y, x) }
+
+
 /**
  * Groups the elements in the collection into a new [[Map]] using the supplied *toKey* function to calculate the key to group the elements by
  *

--- a/libraries/stdlib/src/generated/LongArraysFromJLangIterables.kt
+++ b/libraries/stdlib/src/generated/LongArraysFromJLangIterables.kt
@@ -147,6 +147,36 @@ public inline fun LongArray.fold(initial: Long, operation: (Long, Long) -> Long)
  */
 public inline fun LongArray.foldRight(initial: Long, operation: (Long, Long) -> Long): Long = reverse().fold(initial, {x, y -> operation(y, x)})
 
+
+/**
+ * Applies binary operation to all elements of iterable, going from left to right.
+ * Similar to fold function, but uses the first element as initial value
+ *
+ * @includeFunctionBody ../../test/CollectionTest.kt reduce
+ */
+public inline fun LongArray.reduce(operation: (Long, Long) -> Long): Long {
+    val iterator = this.iterator().sure()
+    if (!iterator.hasNext) {
+        throw UnsupportedOperationException("Empty iterable can't be reduced")
+    }
+
+    var result: Long = iterator.next() //compiler doesn't understand that result will initialized anyway
+    while (iterator.hasNext) {
+        result = operation(result, iterator.next())
+    }
+
+    return result
+}
+
+/**
+ * Applies binary operation to all elements of iterable, going from right to left.
+ * Similar to foldRight function, but uses the last element as initial value
+ *
+ * @includeFunctionBody ../../test/CollectionTest.kt reduceRight
+ */
+public inline fun LongArray.reduceRight(operation: (Long, Long) -> Long): Long = reverse().reduce { x, y -> operation(y, x) }
+
+
 /**
  * Groups the elements in the collection into a new [[Map]] using the supplied *toKey* function to calculate the key to group the elements by
  *

--- a/libraries/stdlib/src/generated/ShortArraysFromJLangIterables.kt
+++ b/libraries/stdlib/src/generated/ShortArraysFromJLangIterables.kt
@@ -147,6 +147,36 @@ public inline fun ShortArray.fold(initial: Short, operation: (Short, Short) -> S
  */
 public inline fun ShortArray.foldRight(initial: Short, operation: (Short, Short) -> Short): Short = reverse().fold(initial, {x, y -> operation(y, x)})
 
+
+/**
+ * Applies binary operation to all elements of iterable, going from left to right.
+ * Similar to fold function, but uses the first element as initial value
+ *
+ * @includeFunctionBody ../../test/CollectionTest.kt reduce
+ */
+public inline fun ShortArray.reduce(operation: (Short, Short) -> Short): Short {
+    val iterator = this.iterator().sure()
+    if (!iterator.hasNext) {
+        throw UnsupportedOperationException("Empty iterable can't be reduced")
+    }
+
+    var result: Short = iterator.next() //compiler doesn't understand that result will initialized anyway
+    while (iterator.hasNext) {
+        result = operation(result, iterator.next())
+    }
+
+    return result
+}
+
+/**
+ * Applies binary operation to all elements of iterable, going from right to left.
+ * Similar to foldRight function, but uses the last element as initial value
+ *
+ * @includeFunctionBody ../../test/CollectionTest.kt reduceRight
+ */
+public inline fun ShortArray.reduceRight(operation: (Short, Short) -> Short): Short = reverse().reduce { x, y -> operation(y, x) }
+
+
 /**
  * Groups the elements in the collection into a new [[Map]] using the supplied *toKey* function to calculate the key to group the elements by
  *

--- a/libraries/stdlib/src/generated/StandardFromJLangIterables.kt
+++ b/libraries/stdlib/src/generated/StandardFromJLangIterables.kt
@@ -147,6 +147,36 @@ public inline fun <T> Iterable<T>.fold(initial: T, operation: (T, T) -> T): T {
  */
 public inline fun <T> Iterable<T>.foldRight(initial: T, operation: (T, T) -> T): T = reverse().fold(initial, {x, y -> operation(y, x)})
 
+
+/**
+ * Applies binary operation to all elements of iterable, going from left to right.
+ * Similar to fold function, but uses the first element as initial value
+ *
+ * @includeFunctionBody ../../test/CollectionTest.kt reduce
+ */
+public inline fun <T> Iterable<T>.reduce(operation: (T, T) -> T): T {
+    val iterator = this.iterator().sure()
+    if (!iterator.hasNext) {
+        throw UnsupportedOperationException("Empty iterable can't be reduced")
+    }
+
+    var result: T = iterator.next() //compiler doesn't understand that result will initialized anyway
+    while (iterator.hasNext) {
+        result = operation(result, iterator.next())
+    }
+
+    return result
+}
+
+/**
+ * Applies binary operation to all elements of iterable, going from right to left.
+ * Similar to foldRight function, but uses the last element as initial value
+ *
+ * @includeFunctionBody ../../test/CollectionTest.kt reduceRight
+ */
+public inline fun <T> Iterable<T>.reduceRight(operation: (T, T) -> T): T = reverse().reduce { x, y -> operation(y, x) }
+
+
 /**
  * Groups the elements in the collection into a new [[Map]] using the supplied *toKey* function to calculate the key to group the elements by
  *

--- a/libraries/stdlib/src/kotlin/JLangIterables.kt
+++ b/libraries/stdlib/src/kotlin/JLangIterables.kt
@@ -137,6 +137,36 @@ public inline fun <T> java.lang.Iterable<T>.fold(initial: T, operation: (T, T) -
  */
 public inline fun <T> java.lang.Iterable<T>.foldRight(initial: T, operation: (T, T) -> T): T = reverse().fold(initial, {x, y -> operation(y, x)})
 
+
+/**
+ * Applies binary operation to all elements of iterable, going from left to right.
+ * Similar to fold function, but uses the first element as initial value
+ *
+ * @includeFunctionBody ../../test/CollectionTest.kt reduce
+ */
+public inline fun <T> java.lang.Iterable<T>.reduce(operation: (T, T) -> T): T {
+    val iterator = this.iterator().sure()
+    if (!iterator.hasNext()) {
+        throw UnsupportedOperationException("Empty iterable can't be reduced")
+    }
+
+    var result: T = iterator.next() //compiler doesn't understand that result will initialized anyway
+    while (iterator.hasNext()) {
+        result = operation(result, iterator.next())
+    }
+
+    return result
+}
+
+/**
+ * Applies binary operation to all elements of iterable, going from right to left.
+ * Similar to foldRight function, but uses the last element as initial value
+ *
+ * @includeFunctionBody ../../test/CollectionTest.kt reduceRight
+ */
+public inline fun <T> java.lang.Iterable<T>.reduceRight(operation: (T, T) -> T): T = reverse().reduce { x, y -> operation(y, x) }
+
+
 /**
  * Groups the elements in the collection into a new [[Map]] using the supplied *toKey* function to calculate the key to group the elements by
  *

--- a/libraries/stdlib/test/ArraysTest.kt
+++ b/libraries/stdlib/test/ArraysTest.kt
@@ -1,12 +1,11 @@
 package test.arrays
 
 import kotlin.test.*
+import org.junit.Test as test
 
-import junit.framework.TestCase
+class ArraysTest {
 
-class ArraysTest() : TestCase() {
-
-    fun testCopyOf() {
+    test fun copyOf() {
         checkContent(booleanArray(true, false, true, false, true, false).copyOf().iterator(), 6) { it % 2 == 0 }
         checkContent(byteArray(0, 1, 2, 3, 4, 5).copyOf().iterator(), 6) { it.toByte() }
         checkContent(shortArray(0, 1, 2, 3, 4, 5).copyOf().iterator(), 6) { it.toShort() }
@@ -17,7 +16,7 @@ class ArraysTest() : TestCase() {
         checkContent(charArray('0', '1', '2', '3', '4', '5').copyOf().iterator(), 6) { (it + '0').toChar() }
     }
 
-    fun testCopyOfRange() {
+    test fun copyOfRange() {
         checkContent(booleanArray(true, false, true, false, true, false).copyOfRange(0, 3).iterator(), 3) { it % 2 == 0 }
         checkContent(byteArray(0, 1, 2, 3, 4, 5).copyOfRange(0, 3).iterator(), 3) { it.toByte() }
         checkContent(shortArray(0, 1, 2, 3, 4, 5).copyOfRange(0, 3).iterator(), 3) { it.toShort() }
@@ -39,7 +38,7 @@ class ArraysTest() : TestCase() {
         assertFalse(iter.hasNext, "Invalid length (hasNext)")
     }
 
-    fun testEmptyArrayLastIndex() {
+    test fun emptyArrayLastIndex() {
         val arr1 = IntArray(0)
         assertEquals(-1, arr1.lastIndex)
 
@@ -47,7 +46,7 @@ class ArraysTest() : TestCase() {
         assertEquals(-1, arr2.lastIndex)
     }
 
-    fun testArrayLastIndex() {
+    test fun arrayLastIndex() {
         val arr1 = intArray(0, 1, 2, 3, 4)
         assertEquals(4, arr1.lastIndex)
         assertEquals(4, arr1[arr1.lastIndex])
@@ -55,6 +54,38 @@ class ArraysTest() : TestCase() {
         val arr2 = Array<String>(5, {"$it"})
         assertEquals(4, arr2.lastIndex)
         assertEquals("4", arr2[arr2.lastIndex])
+    }
+
+    test fun reduce() {
+        expect(-4) { intArray(1, 2, 3) reduce { a, b -> a - b } }
+        expect(-4.toLong()) { longArray(1, 2, 3) reduce { a, b -> a - b } }
+        expect(-4.toFloat()) { floatArray(1.toFloat(), 2.toFloat(), 3.toFloat()) reduce { a, b -> a - b } }
+        expect(-4.0) { doubleArray(1.0, 2.0, 3.0) reduce { a, b -> a - b } }
+        expect('3') { charArray('1', '3', '2') reduce { a, b -> if(a > b) a else b } }
+        expect(false) { booleanArray(true, true, false) reduce { a, b -> a && b } }
+        expect(true) { booleanArray(true, true) reduce { a, b -> a && b } }
+        expect(0.toByte()) { byteArray(3, 2, 1) reduce { a, b -> (a - b).toByte() } }
+        expect(0.toShort()) { shortArray(3, 2, 1) reduce { a, b -> (a - b).toShort() } }
+
+        failsWith<UnsupportedOperationException> {
+            intArray().reduce { a, b -> a + b}
+        }
+    }
+
+    test fun reduceRight() {
+        expect(2) { intArray(1, 2, 3) reduceRight { a, b -> a - b } }
+        expect(2.toLong()) { longArray(1, 2, 3) reduceRight { a, b -> a - b } }
+        expect(2.toFloat()) { floatArray(1.toFloat(), 2.toFloat(), 3.toFloat()) reduceRight { a, b -> a - b } }
+        expect(2.0) { doubleArray(1.0, 2.0, 3.0) reduceRight { a, b -> a - b } }
+        expect('3') { charArray('1', '3', '2') reduceRight { a, b -> if(a > b) a else b } }
+        expect(false) { booleanArray(true, true, false) reduceRight { a, b -> a && b } }
+        expect(true) { booleanArray(true, true) reduceRight { a, b -> a && b } }
+        expect(2.toByte()) { byteArray(1, 2, 3) reduceRight { a, b -> (a - b).toByte() } }
+        expect(2.toShort()) { shortArray(1, 2, 3) reduceRight { a, b -> (a - b).toShort() } }
+
+        failsWith<UnsupportedOperationException> {
+            intArray().reduceRight { a, b -> a + b}
+        }
     }
 
 }

--- a/libraries/stdlib/test/CollectionTest.kt
+++ b/libraries/stdlib/test/CollectionTest.kt
@@ -216,6 +216,37 @@ class CollectionTest {
         }
     }
 
+    test fun reduce() {
+        expect("1234") {
+            val list = arrayList("1", "2", "3", "4")
+            list.reduce { a, b -> a + b }
+        }
+
+        expect(-4) {
+            val array = array(1, 2, 3)
+            array.reduce { a, b -> a - b }
+        }
+
+        failsWith<UnsupportedOperationException> {
+            arrayList<Int>().reduce { a, b -> a + b}
+        }
+    }
+
+    test fun reduceRight() {
+        expect("1234") {
+            val list = arrayList("1", "2", "3", "4")
+            list.reduceRight { a, b -> a + b }
+        }
+        expect(2) {
+            val array = array(1, 2, 3)
+            array.reduceRight { a, b -> a - b }
+        }
+
+        failsWith<UnsupportedOperationException> {
+            arrayList<Int>().reduceRight { a, b -> a + b}
+        }
+    }
+
     test fun groupBy() {
         val words = arrayList("a", "ab", "abc", "def", "abcd")
         val byLength = words.groupBy{ it.length }

--- a/libraries/stdlib/test/CollectionTest.kt
+++ b/libraries/stdlib/test/CollectionTest.kt
@@ -222,11 +222,6 @@ class CollectionTest {
             list.reduce { a, b -> a + b }
         }
 
-        expect(-4) {
-            val array = array(1, 2, 3)
-            array.reduce { a, b -> a - b }
-        }
-
         failsWith<UnsupportedOperationException> {
             arrayList<Int>().reduce { a, b -> a + b}
         }
@@ -236,10 +231,6 @@ class CollectionTest {
         expect("1234") {
             val list = arrayList("1", "2", "3", "4")
             list.reduceRight { a, b -> a + b }
-        }
-        expect(2) {
-            val array = array(1, 2, 3)
-            array.reduceRight { a, b -> a - b }
         }
 
         failsWith<UnsupportedOperationException> {

--- a/libraries/stdlib/test/org/jetbrains/kotlin/tools/GenerateStandardLib.kt
+++ b/libraries/stdlib/test/org/jetbrains/kotlin/tools/GenerateStandardLib.kt
@@ -63,7 +63,9 @@ fun main(args: Array<String>) {
 
     // JLangIterables - Generic iterable stuff
     generateFile(File(outDir, "ArraysFromJLangIterables.kt"), "package kotlin\n\nimport kotlin.util.*", File(srcDir, "JLangIterables.kt")) {
-        it.replaceAll("java.lang.Iterable<T", "Array<T").replaceAll("java.lang.Iterable<T", "Array<T")
+        it.replaceAll("java.lang.Iterable<T", "Array<T").
+            replaceAll("java.lang.Iterable<T", "Array<T").
+            replaceAll("iterator.hasNext\\(\\)", "iterator.hasNext")
     }
     generateFile(File(outDir, "ArraysFromJLangIterablesLazy.kt"), "package kotlin\n\nimport kotlin.util.*", File(srcDir, "JLangIterablesLazy.kt")) {
         it.replaceAll("java.lang.Iterable<T", "Array<T").replaceAll("java.lang.Iterable<T", "Array<T")
@@ -73,7 +75,8 @@ fun main(args: Array<String>) {
             replaceGenerics(arrayName, it.replaceAll("<T> java.lang.Iterable<T>", "${arrayName}Array").
             replaceAll("<T> java.lang.Iterable<T\\?>", "${arrayName}Array").
             replaceAll("java.lang.Iterable<T\\?>", "${arrayName}Array").
-            replaceAll("java.lang.Iterable<T>", "${arrayName}Array"))
+            replaceAll("java.lang.Iterable<T>", "${arrayName}Array")).
+            replaceAll("iterator.hasNext\\(\\)", "iterator.hasNext")
         }
 
         generateFile(File(outDir, "${arrayName}ArraysFromJLangIterables.kt"), "package kotlin\n\nimport kotlin.util.*", File(srcDir, "JLangIterables.kt")) {
@@ -85,7 +88,8 @@ fun main(args: Array<String>) {
     }
 
     generateFile(File(outDir, "StandardFromJLangIterables.kt"), "package kotlin\n\nimport kotlin.util.*", File(srcDir, "JLangIterables.kt")) {
-        it.replaceAll("java.lang.Iterable<T", "Iterable<T")
+        it.replaceAll("java.lang.Iterable<T", "Iterable<T").
+            replaceAll("iterator.hasNext\\(\\)", "iterator.hasNext")
     }
     generateFile(File(outDir, "StandardFromJLangIterablesLazy.kt"), "package kotlin\n\nimport kotlin.util.*", File(srcDir, "JLangIterablesLazy.kt")) {
         it.replaceAll("java.lang.Iterable<T", "Iterable<T")


### PR DESCRIPTION
Implementation of reduce-functions.

Functions have been named according to fold-functions, i.e. functions `reduce` and `reduceRight` make reducing from left to right and from right to left respectively.

Implementation corresponds to Scala functions `reduceLeft` and `reduceRight` from [TraversableOnce](http://www.scala-lang.org/api/current/index.html#scala.collection.TraversableOnce) 
