### PR TITLE
object literals now capture expressions from 'by' delegate specifier

### DIFF
--- a/compiler/backend/src/org/jetbrains/jet/codegen/ObjectOrClosureCodegen.java
+++ b/compiler/backend/src/org/jetbrains/jet/codegen/ObjectOrClosureCodegen.java
@@ -16,6 +16,7 @@
 
 package org.jetbrains.jet.codegen;
 
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.jet.lang.descriptors.*;
 import org.jetbrains.jet.lang.psi.JetDelegatorToSuperCall;
 import org.jetbrains.jet.lang.psi.JetElement;
@@ -48,7 +49,7 @@ public class ObjectOrClosureCodegen {
         this.state = state;
     }
 
-    public StackValue lookupInContext(DeclarationDescriptor d, StackValue result) {
+    public StackValue lookupInContext(DeclarationDescriptor d, @Nullable StackValue result) {
         EnclosedValueDescriptor answer = closure.get(d);
         if (answer != null) {
             StackValue innerValue = answer.getInnerValue();

--- a/compiler/testData/codegen/regressions/kt2224.kt
+++ b/compiler/testData/codegen/regressions/kt2224.kt
@@ -1,0 +1,44 @@
+trait A {
+    fun foo(): Int
+}
+
+class B1 : A {
+    override fun foo() = 10
+}
+
+class B2(val z: Int) : A {
+    override fun foo() = z
+}
+
+
+
+fun f1(b: B1): Int {
+    val o = object : A by b { }
+    return o.foo()
+}
+
+fun f2(b: B2): Int {
+    val o = object : A by B2(b.z) { }
+    return o.foo()
+}
+
+fun f3(b: B2, mult: Int): Int {
+    val o = object : A by B2(mult * b.z) { }
+    return o.foo()
+}
+
+fun f4(b: B1, x: Int, y: Int, z: Int): Int {
+    val o = object : A by b {
+        fun bar() = x + y + z
+    }
+    return o.foo()
+}
+
+
+fun box(): String {
+    if (f1(B1()) != 10) return "fail #1"
+    if (f2(B2(239)) != 239) return "fail #2"
+    if (f3(B2(239), 2) != 239*2) return "fail #3"
+    if (f4(B1(), 1, 2, 3) != 10) return "fail #4"
+    return "OK"
+}

--- a/compiler/tests/org/jetbrains/jet/codegen/ClassGenTest.java
+++ b/compiler/tests/org/jetbrains/jet/codegen/ClassGenTest.java
@@ -446,4 +446,9 @@ public class ClassGenTest extends CodegenTestCase {
         createEnvironmentWithMockJdkAndIdeaAnnotations(ConfigurationKind.JDK_ONLY);
         blackBoxFile("regressions/kt1891.kt");
     }
+
+    public void testKt2224() {
+        createEnvironmentWithMockJdkAndIdeaAnnotations(ConfigurationKind.JDK_ONLY);
+        blackBoxFile("regressions/kt2224.kt");
+    }
 }


### PR DESCRIPTION
# KT-2224 Fixed
