### PR TITLE
load 'this' instead of $classobj if we're inside class object's constructor

### DIFF
--- a/compiler/backend/src/org/jetbrains/jet/codegen/ExpressionCodegen.java
+++ b/compiler/backend/src/org/jetbrains/jet/codegen/ExpressionCodegen.java
@@ -1487,11 +1487,15 @@ public class ExpressionCodegen extends JetVisitor<StackValue, StackValue> {
         if (descriptor instanceof ClassReceiver) {
             Type exprType = asmType(descriptor.getType());
             ClassReceiver classReceiver = (ClassReceiver) descriptor;
-            ClassDescriptor classReceiverDeclarationDescriptor = (ClassDescriptor) classReceiver.getDeclarationDescriptor();
+            ClassDescriptor classReceiverDeclarationDescriptor = classReceiver.getDeclarationDescriptor();
             if (DescriptorUtils.isClassObject(classReceiverDeclarationDescriptor)) {
                 ClassDescriptor containingDeclaration = (ClassDescriptor) classReceiverDeclarationDescriptor.getContainingDeclaration();
                 Type classObjType = typeMapper.mapType(containingDeclaration.getDefaultType(), MapTypeMode.IMPL);
-                v.getstatic(classObjType.getInternalName(), "$classobj", exprType.getDescriptor());
+                if (context.getContextDescriptor() instanceof ConstructorDescriptor && classReceiverDeclarationDescriptor.getDefaultType().equals(((ConstructorDescriptor)context.getContextDescriptor()).getReturnType())) {
+                    v.load(0, classObjType);
+                } else {
+                    v.getstatic(classObjType.getInternalName(), "$classobj", exprType.getDescriptor());
+                }
             }
             else {
                 generateThisOrOuter(classReceiverDeclarationDescriptor).put(exprType, v);

--- a/compiler/testData/codegen/regressions/kt2384.kt
+++ b/compiler/testData/codegen/regressions/kt2384.kt
@@ -1,0 +1,15 @@
+class A {
+    class object {
+        val b = 0
+        val c = b
+        
+        {
+            val d = b
+        }
+    }
+}
+
+fun box(): String {
+    A()
+    return if (A.c == A.b) "OK" else "Fail"
+}

--- a/compiler/tests/org/jetbrains/jet/codegen/ClassGenTest.java
+++ b/compiler/tests/org/jetbrains/jet/codegen/ClassGenTest.java
@@ -451,4 +451,9 @@ public class ClassGenTest extends CodegenTestCase {
         createEnvironmentWithMockJdkAndIdeaAnnotations(ConfigurationKind.JDK_ONLY);
         blackBoxFile("regressions/kt2224.kt");
     }
+
+    public void testKt2384() {
+        createEnvironmentWithMockJdkAndIdeaAnnotations(ConfigurationKind.JDK_ONLY);
+        blackBoxFile("regressions/kt2384.kt");
+    }
 }


### PR DESCRIPTION
# KT-2384 Fixed
