### PR TITLE
KT-2438 Prohibit inner classes with the same name

### DIFF
--- a/compiler/frontend/src/org/jetbrains/jet/lang/descriptors/MutableClassDescriptorLite.java
+++ b/compiler/frontend/src/org/jetbrains/jet/lang/descriptors/MutableClassDescriptorLite.java
@@ -43,7 +43,6 @@ public abstract class MutableClassDescriptorLite extends ClassDescriptorBase
 
     private List<TypeParameterDescriptor> typeParameters;
     private Collection<JetType> supertypes = Lists.newArrayList();
-    private final Collection<ClassDescriptor> innerClasses = Lists.newArrayList();
 
     private TypeConstructor typeConstructor;
 
@@ -210,10 +209,6 @@ public abstract class MutableClassDescriptorLite extends ClassDescriptorBase
         return innerClassesScope;
     }
 
-    public Collection<ClassDescriptor> getInnerClasses() {
-        return innerClasses;
-    }
-
 
     public void addSupertype(@NotNull JetType supertype) {
         if (!ErrorUtils.isErrorType(supertype)) {
@@ -281,7 +276,6 @@ public abstract class MutableClassDescriptorLite extends ClassDescriptorBase
                 @Override
                 public void addClassifierDescriptor(@NotNull MutableClassDescriptorLite classDescriptor) {
                     getScopeForMemberLookupAsWritableScope().addClassifierDescriptor(classDescriptor);
-                    innerClasses.add(classDescriptor);
                 }
 
                 @Override

--- a/compiler/frontend/src/org/jetbrains/jet/lang/resolve/AbstractScopeAdapter.java
+++ b/compiler/frontend/src/org/jetbrains/jet/lang/resolve/AbstractScopeAdapter.java
@@ -107,4 +107,10 @@ public abstract class AbstractScopeAdapter implements JetScope {
     public Collection<DeclarationDescriptor> getAllDescriptors() {
         return getWorkerScope().getAllDescriptors();
     }
+
+    @NotNull
+    @Override
+    public Collection<DeclarationDescriptor> getOwnDeclaredDescriptors() {
+        return getWorkerScope().getOwnDeclaredDescriptors();
+    }
 }

--- a/compiler/frontend/src/org/jetbrains/jet/lang/resolve/lazy/AbstractLazyMemberScope.java
+++ b/compiler/frontend/src/org/jetbrains/jet/lang/resolve/lazy/AbstractLazyMemberScope.java
@@ -260,4 +260,10 @@ public abstract class AbstractLazyMemberScope<D extends DeclarationDescriptor, D
     // a generic implementation can't do this properly
     @Override
     public abstract String toString();
+
+    @NotNull
+    @Override
+    public Collection<DeclarationDescriptor> getOwnDeclaredDescriptors() {
+        return getAllDescriptors();
+    }
 }

--- a/compiler/frontend/src/org/jetbrains/jet/lang/resolve/scopes/ChainedScope.java
+++ b/compiler/frontend/src/org/jetbrains/jet/lang/resolve/scopes/ChainedScope.java
@@ -166,4 +166,10 @@ public class ChainedScope implements JetScope {
         }
         return allDescriptors;
     }
+
+    @NotNull
+    @Override
+    public Collection<DeclarationDescriptor> getOwnDeclaredDescriptors() {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/compiler/frontend/src/org/jetbrains/jet/lang/resolve/scopes/InnerClassesScopeWrapper.java
+++ b/compiler/frontend/src/org/jetbrains/jet/lang/resolve/scopes/InnerClassesScopeWrapper.java
@@ -24,6 +24,7 @@ import org.jetbrains.jet.lang.descriptors.ClassDescriptor;
 import org.jetbrains.jet.lang.descriptors.ClassKind;
 import org.jetbrains.jet.lang.descriptors.ClassifierDescriptor;
 import org.jetbrains.jet.lang.descriptors.DeclarationDescriptor;
+import org.jetbrains.jet.lang.resolve.AbstractScopeAdapter;
 import org.jetbrains.jet.lang.resolve.name.LabelName;
 import org.jetbrains.jet.lang.resolve.name.Name;
 import org.jetbrains.jet.lang.resolve.scopes.receivers.ReceiverDescriptor;
@@ -34,11 +35,17 @@ import java.util.List;
 /**
  * @author svtk
  */
-public class InnerClassesScopeWrapper extends JetScopeImpl {
+public class InnerClassesScopeWrapper extends AbstractScopeAdapter {
     private final JetScope actualScope;
 
     public InnerClassesScopeWrapper(JetScope actualScope) {
         this.actualScope = actualScope;
+    }
+
+    @NotNull
+    @Override
+    protected JetScope getWorkerScope() {
+        return actualScope;
     }
 
     private boolean isClass(DeclarationDescriptor descriptor) {
@@ -50,12 +57,6 @@ public class InnerClassesScopeWrapper extends JetScopeImpl {
         ClassifierDescriptor classifier = actualScope.getClassifier(name);
         if (isClass(classifier)) return classifier;
         return null;
-    }
-
-    @NotNull
-    @Override
-    public DeclarationDescriptor getContainingDeclaration() {
-        return actualScope.getContainingDeclaration();
     }
 
     @NotNull

--- a/compiler/frontend/src/org/jetbrains/jet/lang/resolve/scopes/JetScope.java
+++ b/compiler/frontend/src/org/jetbrains/jet/lang/resolve/scopes/JetScope.java
@@ -97,4 +97,7 @@ public interface JetScope {
      * @param result
      */
     void getImplicitReceiversHierarchy(@NotNull List<ReceiverDescriptor> result);
+
+    @NotNull
+    Collection<DeclarationDescriptor> getOwnDeclaredDescriptors();
 }

--- a/compiler/frontend/src/org/jetbrains/jet/lang/resolve/scopes/JetScopeImpl.java
+++ b/compiler/frontend/src/org/jetbrains/jet/lang/resolve/scopes/JetScopeImpl.java
@@ -95,4 +95,10 @@ public abstract class JetScopeImpl implements JetScope {
     @Override
     public void getImplicitReceiversHierarchy(@NotNull List<ReceiverDescriptor> result) {
     }
+
+    @NotNull
+    @Override
+    public Collection<DeclarationDescriptor> getOwnDeclaredDescriptors() {
+        return Collections.emptyList();
+    }
 }

--- a/compiler/frontend/src/org/jetbrains/jet/lang/resolve/scopes/SubstitutingScope.java
+++ b/compiler/frontend/src/org/jetbrains/jet/lang/resolve/scopes/SubstitutingScope.java
@@ -162,4 +162,10 @@ public class SubstitutingScope implements JetScope {
         }
         return allDescriptors;
     }
+
+    @NotNull
+    @Override
+    public Collection<DeclarationDescriptor> getOwnDeclaredDescriptors() {
+        return substitute(workerScope.getOwnDeclaredDescriptors());
+    }
 }

--- a/compiler/frontend/src/org/jetbrains/jet/lang/resolve/scopes/WritableScopeImpl.java
+++ b/compiler/frontend/src/org/jetbrains/jet/lang/resolve/scopes/WritableScopeImpl.java
@@ -533,4 +533,10 @@ public class WritableScopeImpl extends WritableScopeWithImports {
     public Multimap<Name, DeclarationDescriptor> getDeclaredDescriptorsAccessibleBySimpleName() {
         return declaredDescriptorsAccessibleBySimpleName;
     }
+
+    @NotNull
+    @Override
+    public Collection<DeclarationDescriptor> getOwnDeclaredDescriptors() {
+        return declaredDescriptorsAccessibleBySimpleName.values();
+    }
 }

--- a/compiler/frontend/src/org/jetbrains/jet/lang/types/ErrorUtils.java
+++ b/compiler/frontend/src/org/jetbrains/jet/lang/types/ErrorUtils.java
@@ -116,6 +116,11 @@ public class ErrorUtils {
             return Collections.emptyList();
         }
 
+        @NotNull
+        @Override
+        public Collection<DeclarationDescriptor> getOwnDeclaredDescriptors() {
+            return Collections.emptyList();
+        }
     }
 
     private static final ClassDescriptorImpl ERROR_CLASS = new ClassDescriptorImpl(ERROR_MODULE, Collections.<AnnotationDescriptor>emptyList(), Modality.OPEN, Name.special("<ERROR CLASS>")) {

--- a/compiler/testData/diagnostics/tests/redeclarations/kt2438.kt
+++ b/compiler/testData/diagnostics/tests/redeclarations/kt2438.kt
@@ -1,0 +1,21 @@
+//KT-2438 Prohibit inner classes with the same name
+
+package kt2438
+
+class B {
+    class <!REDECLARATION!>C<!>
+    class <!REDECLARATION!>C<!>
+}
+
+
+
+class A {
+    class <!REDECLARATION!>B<!>
+    
+    class object {
+        class <!REDECLARATION!>B<!>
+        class <!REDECLARATION!>B<!>
+    }
+    
+    class <!REDECLARATION!>B<!>
+}

--- a/compiler/tests/org/jetbrains/jet/checkers/JetDiagnosticsTestGenerated.java
+++ b/compiler/tests/org/jetbrains/jet/checkers/JetDiagnosticsTestGenerated.java
@@ -1898,6 +1898,11 @@ public class JetDiagnosticsTestGenerated extends AbstractDiagnosticsTestWithEage
                 doTest("compiler/testData/diagnostics/tests/redeclarations/kt2247.kt");
             }
             
+            @TestMetadata("kt2438.kt")
+            public void testKt2438() throws Exception {
+                doTest("compiler/testData/diagnostics/tests/redeclarations/kt2438.kt");
+            }
+            
             @TestMetadata("MultiFilePackageRedeclaration.kt")
             public void testMultiFilePackageRedeclaration() throws Exception {
                 doTest("compiler/testData/diagnostics/tests/redeclarations/MultiFilePackageRedeclaration.kt");


### PR DESCRIPTION
Rewrite checkClassObjectInnerClassNames() to also check for name clashes between inner classes of a single class
 #KT-2438 Fixed
