### PR TITLE
Added "META-INF/build.txt" to Kotlin archives so that Kotlin build number becomes visible in Maven artifacts.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -111,6 +111,7 @@
                     <fileset dir="compiler/jet.as.java.psi/src"/>
                     <fileset dir="runtime/src"/>
                     <fileset dir="js/js.translator/src"/>
+                    <zipfileset file="${kotlin-home}/build.txt" prefix="META-INF"/>
 
                     <manifest>
                         <attribute name="Built-By" value="JetBrains"/>
@@ -129,6 +130,7 @@
                          windowtitle="Kotlin Compiler"/>
                 <jar jarfile="${output}/kotlin-compiler-javadoc.jar">
                     <fileset dir="${output}/kotlin-compiler-javadoc"/>
+                    <zipfileset file="${kotlin-home}/build.txt" prefix="META-INF"/>
 
                     <manifest>
                         <attribute name="Built-By" value="JetBrains"/>
@@ -150,6 +152,7 @@
         <include name="dom/**"/>
         <include name="html5/**"/>
       </fileset>
+      <zipfileset file="${kotlin-home}/build.txt" prefix="META-INF"/>
     </jar>
     <java classname="com.google.javascript.jscomp.CommandLineRunner" failonerror="true">
       <classpath>
@@ -279,6 +282,7 @@
                         <include name="META-INF/services/**"/>
                         <include name="messages/**"/>
                     </fileset>
+                    <zipfileset file="${kotlin-home}/build.txt" prefix="META-INF"/>
                 </jar>
                 <delete dir="${output}/kotlin-compiler.exploded"/>
 
@@ -370,6 +374,7 @@
         <jar destfile="${kotlin-home}/lib/kotlin-ant.jar">
             <fileset dir="${output}/classes/buildTools"/>
             <fileset dir="${basedir}/build-tools/ant/src" includes="**/*.xml"/>
+            <zipfileset file="${kotlin-home}/build.txt" prefix="META-INF"/>
 
             <manifest>
                 <attribute name="Built-By" value="JetBrains"/>
@@ -388,6 +393,7 @@
 
         <jar destfile="${kotlin-home}/lib/kotlin-jdk-annotations.jar">
             <fileset dir="${basedir}/jdk-annotations"/>
+            <zipfileset file="${kotlin-home}/build.txt" prefix="META-INF"/>
 
             <manifest>
                 <attribute name="Built-By" value="JetBrains"/>
@@ -425,6 +431,7 @@
             <fileset dir="${output}/classes/stdlib"/>
             <fileset dir="${basedir}/runtime" includes="src/**/*"/>
             <fileset dir="${basedir}/libraries/stdlib" includes="src/**/*"/>
+            <zipfileset file="${kotlin-home}/build.txt" prefix="META-INF"/>
 
             <manifest>
                 <attribute name="Built-By" value="JetBrains"/>


### PR DESCRIPTION
It is not clear which build number Maven artifacts (http://repository.jetbrains.com/kotlin/org/jetbrains/kotlin/kotlin-compiler/0.1-SNAPSHOT/) belong to. Now archives built by Ant and used by Maven as artifacts contain "build.txt" in "META-INF".
