### PR TITLE
Fix line endings in dependency injector generator

### DIFF
--- a/injector-generator/src/org/jetbrains/jet/di/DependencyInjectorGenerator.java
+++ b/injector-generator/src/org/jetbrains/jet/di/DependencyInjectorGenerator.java
@@ -92,7 +92,7 @@ public class DependencyInjectorGenerator {
             }
 
             String copyright = "injector-generator/copyright.txt";
-            out.println(FileUtil.loadFile(new File(copyright), true));
+            out.println(FileUtil.loadFile(new File(copyright)));
             out.println();
 
             out.println("package " + injectorPackageName + ";");
@@ -305,7 +305,8 @@ public class DependencyInjectorGenerator {
                     out.println(",");
                 }
             }
-            out.println("\n    ) {");
+            out.println();
+            out.println("    ) {");
         }
 
         if (lazy) {


### PR DESCRIPTION
Copyright text should be printed as is, without translating line endings to LF. This prevents injectors from having mixed endings on Windows with core.autocrlf=true
