### PR TITLE
kotlin-jdbc: Additional extenstions to work with ResultSet

### DIFF
--- a/libraries/kotlin-jdbc/src/main/kotlin/kotlin/jdbc/Connections.kt
+++ b/libraries/kotlin-jdbc/src/main/kotlin/kotlin/jdbc/Connections.kt
@@ -3,9 +3,47 @@ package kotlin.jdbc
 import java.sql.*
 import kotlin.template.StringTemplate
 import java.math.BigDecimal
+import java.util.Map
+import java.util.Properties
+
+private fun Map<String, String>.toProperties() : Properties {
+    val p = Properties()
+
+    this.keySet().forEach {
+        p.put(it, this[it])
+    }
+
+    return p
+}
 
 /**
- * Helper method to process a statement on this collection
+ * create connection for the specified jdbc url with no credentials
+ */
+fun getConnection(url : String) : Connection = DriverManager.getConnection(url).sure()
+
+/**
+ * create connection for the specified jdbc url and properties
+ */
+fun getConnection(url : String, info : Map<String, String>) : Connection = DriverManager.getConnection(url, info.toProperties())!!
+
+/**
+ * create connection for the specified jdbc url and credentials
+ */
+fun getConnection(url : String, user : String, password : String) : Connection = DriverManager.getConnection(url, user, password)!!
+
+/**
+ * Executes specified block with connection and close connection after this
+ */
+fun Connection.use(block : (Connection) -> Any?) : Unit {
+    try {
+        block(this)
+    } finally {
+        this.close()
+    }
+}
+
+/**
+ * Helper method to process a statement on this connection
  */
 fun <T> Connection.statement(block: (Statement) -> T): T {
     val statement = createStatement()

--- a/libraries/kotlin-jdbc/src/test/kotlin/test/kotlin/jdbc/JdbcTest.kt
+++ b/libraries/kotlin-jdbc/src/test/kotlin/test/kotlin/jdbc/JdbcTest.kt
@@ -7,6 +7,8 @@ import junit.framework.TestCase
 import org.h2.jdbcx.JdbcDataSource
 import javax.sql.DataSource
 import org.h2.jdbcx.JdbcConnectionPool
+import kotlin.nullable.forEach
+import java.sql.ResultSet
 
 public val dataSource : DataSource = createDataSource()
 
@@ -37,6 +39,50 @@ class JdbcTest : TestCase() {
         dataSource.query("select * from foo") {
             for (row in it) {
                 println("name: ${row["name"]} has id ${row["id"]}")
+            }
+        }
+    }
+
+    fun testGetValuesAsMap() {
+        dataSource.query("select * from foo") {
+            for (row in it) {
+                println(row.getValuesAsMap())
+            }
+        }
+    }
+
+    fun testStringFormat() {
+        dataSource.query(kotlin.template.StringTemplate(array("select * from foo where id = ", 1))) {
+            for (row in it) {
+                println(row.getValuesAsMap())
+            }
+        }
+    }
+
+    fun testMapIterator() {
+        val mapper = { (rs : ResultSet) ->
+            "id: ${rs["id"]}"
+        }
+
+        dataSource.query("select * from foo") {
+            for (row in it.getMapped(mapper)) {
+                println(row)
+            }
+        }
+    }
+
+    fun testCount() {
+        dataSource.query("select count(*) from foo") {
+            println("count: ${it.singleInt()}")
+        }
+    }
+
+    fun testFormatCursor() {
+        dataSource.query("select * from foo") {
+            println(it.getColumnNames().toList().makeString("\t"))
+
+            for (row in it) {
+                println(it.getValues().makeString("\t"))
             }
         }
     }


### PR DESCRIPTION
Additional methods to extract data from ResultSet and to create connection with no DataSource.

The methods to create connection and one method to use it. Sometimes DataSource, connection pools, etc are not required: you just need to open connection and execute sometings. I often use it to test or find something in database. Now I use Groovy for this. But with these extension I will be able to use kotlin instead.

Also added methods to works with result set.

The first added method is getMapped. It returns jet.Iterable. User of this API can provide mapper-function that will be used to produce elements for iterable. (see testMapIterator in JdbcTest for usage example).

The second group of methods are related to cursor metadata and specific row handling.

getColumnNames provides array of column names

getValues and getValuesAsMap extracts values from ResultSet and produces array and map for the specified list of columns or for all columns by default.

And the last group of methods are useful to get single result from result set. For example if we want just to extract result of "count(*)" we don't need iterate over rows, etc but we can just use singleInt(): Int instead.

Also few tests added to check methods works and to show usage examples.
