### PR TITLE
KT-1760 delegation to java interface

### DIFF
--- a/compiler/backend/src/org/jetbrains/jet/codegen/ImplementationBodyCodegen.java
+++ b/compiler/backend/src/org/jetbrains/jet/codegen/ImplementationBodyCodegen.java
@@ -839,7 +839,6 @@ public class ImplementationBodyCodegen extends ClassBodyCodegen {
         StackValue field = StackValue.field(fieldType, classname, delegateField, false);
         field.store(fieldType, iv);
 
-        JetClass superClass = (JetClass) BindingContextUtils.classDescriptorToDeclaration(bindingContext, superClassDescriptor);
         final CodegenContext delegateContext = context.intoClass(superClassDescriptor,
                                                                  new OwnerKind.DelegateKind(StackValue.field(fieldType, classname,
                                                                                                              delegateField, false),
@@ -848,7 +847,7 @@ public class ImplementationBodyCodegen extends ClassBodyCodegen {
                                                                                                                MapTypeMode.IMPL)
                                                                                                     .getInternalName()),
                                                                  state.getInjector().getJetTypeMapper());
-        generateDelegates(superClass, delegateContext, field);
+        generateDelegates(superClassDescriptor, delegateContext, field);
     }
 
     private int addClosureToConstructorParameters(
@@ -1263,18 +1262,17 @@ public class ImplementationBodyCodegen extends ClassBodyCodegen {
         return false;
     }
 
-    protected void generateDelegates(JetClass toClass, CodegenContext delegateContext, StackValue field) {
+    protected void generateDelegates(ClassDescriptor toClass, CodegenContext delegateContext, StackValue field) {
         final FunctionCodegen functionCodegen = new FunctionCodegen(delegateContext, v, state);
         final PropertyCodegen propertyCodegen = new PropertyCodegen(delegateContext, v, functionCodegen, state);
 
-        ClassDescriptor classDescriptor = bindingContext.get(BindingContext.CLASS, toClass);
         for (DeclarationDescriptor declaration : descriptor.getDefaultType().getMemberScope().getAllDescriptors()) {
             if (declaration instanceof CallableMemberDescriptor) {
                 CallableMemberDescriptor callableMemberDescriptor = (CallableMemberDescriptor) declaration;
                 if (callableMemberDescriptor.getKind() == CallableMemberDescriptor.Kind.DELEGATION) {
                     Set<? extends CallableMemberDescriptor> overriddenDescriptors = callableMemberDescriptor.getOverriddenDescriptors();
                     for (CallableMemberDescriptor overriddenDescriptor : overriddenDescriptors) {
-                        if (overriddenDescriptor.getContainingDeclaration() == classDescriptor) {
+                        if (overriddenDescriptor.getContainingDeclaration() == toClass) {
                             if (declaration instanceof PropertyDescriptor) {
                                 propertyCodegen
                                         .genDelegate((PropertyDescriptor) declaration, (PropertyDescriptor) overriddenDescriptor, field);

--- a/compiler/frontend/src/org/jetbrains/jet/lang/resolve/DelegationResolver.java
+++ b/compiler/frontend/src/org/jetbrains/jet/lang/resolve/DelegationResolver.java
@@ -64,7 +64,7 @@ public class DelegationResolver {
     public static <T extends CallableMemberDescriptor> Collection<T> generateDelegatedMembers(DeclarationDescriptor newOwner, Collection<T> delegatedDescriptors) {
         Collection<CallableMemberDescriptor> result = Lists.newArrayList();
         for (CallableMemberDescriptor memberDescriptor : delegatedDescriptors) {
-            if (memberDescriptor.getModality().isOverridable()) {
+            if (memberDescriptor.getModality() == Modality.ABSTRACT) {
                 Modality modality = DescriptorUtils.convertModality(memberDescriptor.getModality(), true);
                 CallableMemberDescriptor copy =
                         memberDescriptor.copy(newOwner, modality, false, CallableMemberDescriptor.Kind.DELEGATION, true);

--- a/compiler/testData/codegen/classes/delegationJava.kt
+++ b/compiler/testData/codegen/classes/delegationJava.kt
@@ -1,0 +1,13 @@
+class TestJava(r : Runnable) : Runnable by r {}
+class TestRunnable() : Runnable {
+  public override fun run() = System.out.println("foobar")
+}
+
+fun box() : String {
+    var del = TestJava(TestRunnable())
+    del.run()
+    if (del !is Runnable)
+        return "Fail #1"
+
+    return "OK"
+}

--- a/compiler/testData/diagnostics/tests/DelegationToJavaIface.kt
+++ b/compiler/testData/diagnostics/tests/DelegationToJavaIface.kt
@@ -1,0 +1,3 @@
+class TestIface(r : Runnable) : Runnable by r {}
+
+class TestObject(o : Object) : <!DELEGATION_NOT_TO_TRAIT!>Object<!> by o {}

--- a/compiler/tests/org/jetbrains/jet/checkers/JetDiagnosticsTestGenerated.java
+++ b/compiler/tests/org/jetbrains/jet/checkers/JetDiagnosticsTestGenerated.java
@@ -184,6 +184,11 @@ public class JetDiagnosticsTestGenerated extends AbstractDiagnosticsTestWithEage
         public void testDelegation_ScopeInitializationOrder() throws Exception {
             doTest("compiler/testData/diagnostics/tests/Delegation_ScopeInitializationOrder.kt");
         }
+
+        @TestMetadata("DelegationToJavaIface.kt")
+        public void testDelegationToJavaIface() throws Exception {
+            doTest("compiler/testData/diagnostics/tests/DelegationToJavaIface.kt");
+        }
         
         @TestMetadata("DiamondFunction.kt")
         public void testDiamondFunction() throws Exception {

--- a/compiler/tests/org/jetbrains/jet/codegen/ClassGenTest.java
+++ b/compiler/tests/org/jetbrains/jet/codegen/ClassGenTest.java
@@ -53,6 +53,11 @@ public class ClassGenTest extends CodegenTestCase {
         assertInstanceOf(aClass.newInstance(), List.class);
     }
 
+    public void testDelegationJavaIface() throws Exception {
+        createEnvironmentWithMockJdkAndIdeaAnnotations(ConfigurationKind.JDK_ONLY);
+        blackBoxFile("classes/delegationJava.kt");
+    }
+
     public void testInheritanceAndDelegation_DelegatingDefaultConstructorProperties() throws Exception {
         createEnvironmentWithMockJdkAndIdeaAnnotations(ConfigurationKind.JDK_ONLY);
         blackBoxFile("classes/inheritance.jet");


### PR DESCRIPTION
KT-1760 delegation to java interface, separated from the [former pull-request](kt-1760 delegation to java iface)
- removed codegen's unnecessary lookup for a declaration
- narrowed delegated methods' possible modalities to ABSTRACT
