### PR TITLE
Contribution from Hackergarten Vienna

### DIFF
--- a/compiler/backend/src/org/jetbrains/jet/codegen/ImplementationBodyCodegen.java
+++ b/compiler/backend/src/org/jetbrains/jet/codegen/ImplementationBodyCodegen.java
@@ -750,7 +750,8 @@ public class ImplementationBodyCodegen extends ClassBodyCodegen {
                     InstructionAdapter iv = new InstructionAdapter(mv);
 
                     iv.load(0, OBJECT_TYPE);
-                    if (original.getVisibility() == Visibilities.PRIVATE) {
+                    boolean hasBackingField = Boolean.TRUE.equals(bindingContext.get(BindingContext.BACKING_FIELD_REQUIRED, original));
+                    if (original.getVisibility() == Visibilities.PRIVATE && hasBackingField) {
                         iv.getfield(typeMapper.getOwner(original, OwnerKind.IMPLEMENTATION).getInternalName(), original.getName().getName(),
                                     originalMethod.getReturnType().getDescriptor());
                     }

--- a/compiler/testData/codegen/properties/kt2892.kt
+++ b/compiler/testData/codegen/properties/kt2892.kt
@@ -1,0 +1,16 @@
+open class A
+class B : A() {
+    fun foo() = 1
+}
+
+class Test {
+    val a : A = B()
+    private val b : B get() = a as B //'private' is important here
+
+    fun outer() : Int {
+        fun inner() : Int = b.foo() //'no such field error' here
+        return inner()
+    }
+}
+
+fun box() = if (Test().outer() == 1) "OK" else "fail"

--- a/compiler/tests/org/jetbrains/jet/codegen/PropertyGenTest.java
+++ b/compiler/tests/org/jetbrains/jet/codegen/PropertyGenTest.java
@@ -360,4 +360,10 @@ public class PropertyGenTest extends CodegenTestCase {
             throw new RuntimeException(e);
         }
     }
+
+    public void testKt2892() throws Exception {
+        createEnvironmentWithMockJdkAndIdeaAnnotations(ConfigurationKind.JDK_ONLY);
+        blackBoxFile("properties/kt2892.kt");
+    }
+
 }


### PR DESCRIPTION
fixed KT-2892 'No such field error' when invoke private property without backing field from inner function with help from Dmitry.
