### PR TITLE
Fix for issue: http://youtrack.jetbrains.com/issue/KT-2976

### DIFF
--- a/js/js.translator/src/org/jetbrains/k2js/translate/context/Namer.java
+++ b/js/js.translator/src/org/jetbrains/k2js/translate/context/Namer.java
@@ -43,7 +43,7 @@ public final class Namer {
     private static final String ROOT_NAMESPACE = "_";
     private static final String RECEIVER_PARAMETER_NAME = "receiver";
     private static final String CLASSES_OBJECT_NAME = "classes";
-    private static final String THROW_NPE_FUN_NAME = "throwNPE";
+    private static final String ENSURE_NOT_NULL_FUN_NAME = "ensureNotNull";
 
     @NotNull
     public static String getReceiverParameterName() {
@@ -158,8 +158,8 @@ public final class Namer {
     }
 
     @NotNull
-    public JsExpression throwNPEFunctionCall() {
-        return new JsInvocation(new JsNameRef(THROW_NPE_FUN_NAME, kotlinObject()));
+    public JsExpression ensureNotNullFunctionCall(JsExpression arg) {
+        return new JsInvocation(new JsNameRef(ENSURE_NOT_NULL_FUN_NAME, kotlinObject()), arg);
     }
 
     @NotNull

--- a/js/js.translator/src/org/jetbrains/k2js/translate/operation/UnaryOperationTranslator.java
+++ b/js/js.translator/src/org/jetbrains/k2js/translate/operation/UnaryOperationTranslator.java
@@ -16,12 +16,10 @@
 
 package org.jetbrains.k2js.translate.operation;
 
-import com.google.dart.compiler.backend.js.ast.JsConditional;
 import com.google.dart.compiler.backend.js.ast.JsExpression;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.jet.lang.psi.JetUnaryExpression;
 import org.jetbrains.jet.lexer.JetTokens;
-import org.jetbrains.k2js.translate.context.TemporaryVariable;
 import org.jetbrains.k2js.translate.context.TranslationContext;
 import org.jetbrains.k2js.translate.reference.CallBuilder;
 import org.jetbrains.k2js.translate.reference.CallType;
@@ -33,7 +31,6 @@ import static org.jetbrains.k2js.translate.general.Translation.translateAsExpres
 import static org.jetbrains.k2js.translate.utils.BindingUtils.getResolvedCall;
 import static org.jetbrains.k2js.translate.utils.PsiUtils.getBaseExpression;
 import static org.jetbrains.k2js.translate.utils.PsiUtils.getOperationToken;
-import static org.jetbrains.k2js.translate.utils.TranslationUtils.notNullConditionalTestExpression;
 
 /**
  * @author Pavel Talanov
@@ -60,9 +57,10 @@ public final class UnaryOperationTranslator {
     }
 
     @NotNull
-    private static JsExpression translateExclExclOperator(@NotNull JetUnaryExpression expression, @NotNull TranslationContext context) {
-        TemporaryVariable cachedValue = context.declareTemporary(translateAsExpression(getBaseExpression(expression), context));
-        return new JsConditional(notNullConditionalTestExpression(cachedValue), cachedValue.reference(), context.namer().throwNPEFunctionCall());
+    private static JsExpression translateExclExclOperator(@NotNull JetUnaryExpression expression,
+                                                          @NotNull TranslationContext context) {
+        JsExpression value = translateAsExpression(getBaseExpression(expression), context);
+        return context.namer().ensureNotNullFunctionCall(value);
     }
 
     @NotNull

--- a/js/js.translator/testFiles/kotlin_lib.js
+++ b/js/js.translator/testFiles/kotlin_lib.js
@@ -84,7 +84,10 @@ var kotlin = {set:function (receiver, key, value) {
     Kotlin.UnsupportedOperationException = Kotlin.$createClass(Kotlin.Exception);
     Kotlin.IOException = Kotlin.$createClass(Kotlin.Exception);
 
-    Kotlin.throwNPE = function () {
+    Kotlin.ensureNotNull = function (value) {
+        if (value !== null)
+            return value;
+
         throw Kotlin.$new(Kotlin.NullPointerException)();
     };
 


### PR DESCRIPTION
This is a patch for issue: http://youtrack.jetbrains.com/issue/KT-2976

It's regarding a cleaner way to implement the generated Javascript code for !!-expressions.
Since this patch also makes the existing code for throwNPE unused it is replaced entirely by this new code.

All js-backend tests passed both before and after this change.
