### PR TITLE
Prevent infinite loop when HashMap is empty and values() method is called

### DIFF
--- a/js/js.translator/testFiles/maps.js
+++ b/js/js.translator/testFiles/maps.js
@@ -300,7 +300,7 @@
             var values = this._values();
             var i = values.length
             var result = Kotlin.$new(Kotlin.ArrayList)();
-            while (--i) {
+            while (i--) {
                 result.add(values[i]);
             }
             return result;


### PR DESCRIPTION
Fixes issue: http://youtrack.jetbrains.com/issue/KT-3035
