### PR TITLE
Skip Plugin Exceution for POM Projects

### DIFF
--- a/libraries/tools/kotlin-maven-plugin/pom.xml
+++ b/libraries/tools/kotlin-maven-plugin/pom.xml
@@ -26,6 +26,11 @@
             <version>${maven.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>${maven.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-compiler</artifactId>
             <version>${project.version}</version>

--- a/libraries/tools/kotlin-maven-plugin/src/main/java/org/jetbrains/kotlin/maven/KotlinCompileMojoBase.java
+++ b/libraries/tools/kotlin-maven-plugin/src/main/java/org/jetbrains/kotlin/maven/KotlinCompileMojoBase.java
@@ -19,6 +19,7 @@ package org.jetbrains.kotlin.maven;
 import com.google.common.base.Joiner;
 import com.google.common.io.Files;
 import com.google.common.io.Resources;
+import org.apache.maven.project.MavenProject;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -128,8 +129,21 @@ public abstract class KotlinCompileMojoBase extends AbstractMojo {
      */
     public String testModule;
 
+    /**
+     * The maven project.
+     *
+     * @parameter default-value="${project}"
+     * @required
+     * @readonly
+     */
+    public MavenProject project;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
+        if (project.getPackaging().equals("pom")) {
+            getLog().info( "Skipping Kotlin execution for POM projects" );
+        }
+
         // Check sources
         List<String> sources = getSources();
         if (sources != null && sources.size() > 0) {


### PR DESCRIPTION
It's quite common to have a multi module project with a parent project
that has POM packaging. It would be quite convenient if the
kotlin-maven-plugin could be configured there instead of in each module.
Currently this is not possible because the plugin tries to execute on
POM projects with fails.
- skip execution on POM projects
