### PR TITLE
KT-3159 Disallow overriding var with different type #KT-3159 fixed

### DIFF
--- a/compiler/frontend/src/org/jetbrains/jet/lang/resolve/OverridingUtil.java
+++ b/compiler/frontend/src/org/jetbrains/jet/lang/resolve/OverridingUtil.java
@@ -239,8 +239,15 @@ public class OverridingUtil {
         TypeSubstitutor typeSubstitutor = TypeSubstitutor.create(substitutionContext);
         JetType substitutedSuperReturnType = typeSubstitutor.substitute(superDescriptor.getReturnType(), Variance.OUT_VARIANCE);
         assert substitutedSuperReturnType != null;
-        if (!typeChecker.isSubtypeOf(subDescriptor.getReturnType(), substitutedSuperReturnType)) {
-            return false;
+        if (superDescriptor instanceof PropertyDescriptor && ((PropertyDescriptor) superDescriptor).isVar()) {
+            if (!typeChecker.equalTypes(subDescriptor.getReturnType(), substitutedSuperReturnType)) {
+                return false;
+            }
+        }
+        else {
+            if (!typeChecker.isSubtypeOf(subDescriptor.getReturnType(), substitutedSuperReturnType)) {
+                return false;
+            }
         }
 
         return true;

--- a/compiler/testData/diagnostics/tests/subtyping/kt3159.kt
+++ b/compiler/testData/diagnostics/tests/subtyping/kt3159.kt
@@ -1,0 +1,9 @@
+trait Super {
+    var v: CharSequence
+    val v2: CharSequence
+}
+
+class Sub: Super {
+    override var v: <!RETURN_TYPE_MISMATCH_ON_OVERRIDE!>String<!> = "fail"
+    override val v2: String = "ok"
+}

--- a/compiler/tests/org/jetbrains/jet/checkers/JetDiagnosticsTestGenerated.java
+++ b/compiler/tests/org/jetbrains/jet/checkers/JetDiagnosticsTestGenerated.java
@@ -3817,6 +3817,11 @@ public class JetDiagnosticsTestGenerated extends AbstractDiagnosticsTestWithEage
             public void testKt2744() throws Exception {
                 doTest("compiler/testData/diagnostics/tests/subtyping/kt2744.kt");
             }
+
+            @TestMetadata("kt3159.kt")
+            public void testKt3159() throws Exception {
+                doTest("compiler/testData/diagnostics/tests/subtyping/kt3159.kt");
+            }
             
             @TestMetadata("kt304.kt")
             public void testKt304() throws Exception {


### PR DESCRIPTION
This changes fix the issue. But:

it uses the same RETURN_TYPE_MISMATCH_ON_OVERRIDE error. It's message states that "Return type of 'v' is not a subtype of super's 'v'", what is, obviously, not true in this case. Any suggestions? 

Thank you.
