### PR TITLE
correct resolve inter-module references

### DIFF
--- a/compiler/frontend/src/org/jetbrains/jet/lang/resolve/BindingContextUtils.java
+++ b/compiler/frontend/src/org/jetbrains/jet/lang/resolve/BindingContextUtils.java
@@ -73,22 +73,6 @@ public class BindingContextUtils {
         return null;
     }
 
-    @NotNull
-    public static List<PsiElement> resolveToDeclarationPsiElements(@NotNull BindingContext bindingContext, @Nullable JetReferenceExpression referenceExpression) {
-        DeclarationDescriptor declarationDescriptor = bindingContext.get(BindingContext.REFERENCE_TARGET, referenceExpression);
-        if (declarationDescriptor == null) {
-            return Lists.newArrayList(bindingContext.get(BindingContext.LABEL_TARGET, referenceExpression));
-        }
-
-        List<PsiElement> elements = descriptorToDeclarations(bindingContext, declarationDescriptor);
-        if (elements.size() > 0) {
-            return elements;
-        }
-
-        return Lists.newArrayList();
-    }
-
-
     @Nullable
     public static VariableDescriptor extractVariableDescriptorIfAny(@NotNull BindingContext bindingContext, @Nullable JetElement element, boolean onlyReference) {
         DeclarationDescriptor descriptor = null;
@@ -147,21 +131,6 @@ public class BindingContextUtils {
         }
     }
 
-    @NotNull
-    public static List<PsiElement> descriptorToDeclarations(@NotNull BindingContext context, @NotNull DeclarationDescriptor descriptor) {
-        if (descriptor instanceof CallableMemberDescriptor) {
-            return callableDescriptorToDeclarations(context, (CallableMemberDescriptor) descriptor);
-        }
-        else {
-            PsiElement psiElement = descriptorToDeclaration(context, descriptor);
-            if (psiElement != null) {
-                return Lists.newArrayList(psiElement);
-            } else {
-                return Lists.newArrayList();
-            }
-        }
-    }
-
     @Nullable
     public static PsiElement callableDescriptorToDeclaration(@NotNull BindingContext context, @NotNull CallableMemberDescriptor callable) {
         if (callable.getKind() == CallableMemberDescriptor.Kind.SYNTHESIZED) {
@@ -182,7 +151,10 @@ public class BindingContextUtils {
     }
 
     @NotNull
-    private static List<PsiElement> callableDescriptorToDeclarations(@NotNull BindingContext context, @NotNull CallableMemberDescriptor callable) {
+    public static List<PsiElement> callableDescriptorToDeclarations(
+            @NotNull BindingContext context,
+            @NotNull CallableMemberDescriptor callable
+    ) {
         if (callable.getKind() == CallableMemberDescriptor.Kind.SYNTHESIZED) {
             return Collections.emptyList();
         }

--- a/idea/src/org/jetbrains/jet/plugin/codeInsight/DescriptorToDeclarationUtil.java
+++ b/idea/src/org/jetbrains/jet/plugin/codeInsight/DescriptorToDeclarationUtil.java
@@ -1,20 +1,67 @@
+/*
+ * Copyright 2010-2013 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.jetbrains.jet.plugin.codeInsight;
 
+import com.google.common.collect.Lists;
 import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.jet.analyzer.AnalyzeExhaust;
+import org.jetbrains.jet.lang.descriptors.CallableMemberDescriptor;
 import org.jetbrains.jet.lang.descriptors.DeclarationDescriptor;
 import org.jetbrains.jet.lang.psi.JetFile;
+import org.jetbrains.jet.lang.psi.JetReferenceExpression;
 import org.jetbrains.jet.lang.resolve.BindingContext;
 import org.jetbrains.jet.lang.resolve.BindingContextUtils;
 import org.jetbrains.jet.plugin.references.BuiltInsReferenceResolver;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 public final class DescriptorToDeclarationUtil {
     private DescriptorToDeclarationUtil() {
     }
 
+    @NotNull
+    public static List<PsiElement> resolveToDeclarationPsiElements(
+            @NotNull AnalyzeExhaust analyzeExhaust,
+            @Nullable JetReferenceExpression referenceExpression
+    ) {
+        DeclarationDescriptor declarationDescriptor = analyzeExhaust.getBindingContext().get(BindingContext.REFERENCE_TARGET,
+                                                                                             referenceExpression);
+        if (declarationDescriptor == null) {
+            return Collections.singletonList(analyzeExhaust.getBindingContext().get(BindingContext.LABEL_TARGET, referenceExpression));
+        }
+
+        BindingContext targetBindingContext = getBindingContextByDeclaration(analyzeExhaust, declarationDescriptor);
+        return targetBindingContext == null
+               ? Collections.<PsiElement>emptyList()
+               : descriptorToDeclarations(targetBindingContext, declarationDescriptor);
+    }
+
+    @Nullable
+    private static BindingContext getBindingContextByDeclaration(AnalyzeExhaust analyzeExhaust, DeclarationDescriptor declarationDescriptor) {
+        // todo https://github.com/develar/kotlin/commit/991c85ba9768cf2ad156f13ba384c9de642588c2 for JS
+        return analyzeExhaust.getBindingContext();
+    }
+
     public static PsiElement getDeclaration(JetFile file, DeclarationDescriptor descriptor, BindingContext bindingContext) {
-        Collection<PsiElement> elements = BindingContextUtils.descriptorToDeclarations(bindingContext, descriptor);
+        Collection<PsiElement> elements = descriptorToDeclarations(bindingContext, descriptor);
 
         if (elements.isEmpty()) {
             BuiltInsReferenceResolver libraryReferenceResolver =
@@ -27,5 +74,21 @@ public final class DescriptorToDeclarationUtil {
         }
 
         return null;
+    }
+
+    @NotNull
+    public static List<PsiElement> descriptorToDeclarations(@NotNull BindingContext context, @NotNull DeclarationDescriptor descriptor) {
+        if (descriptor instanceof CallableMemberDescriptor) {
+            return BindingContextUtils.callableDescriptorToDeclarations(context, (CallableMemberDescriptor) descriptor);
+        }
+        else {
+            PsiElement psiElement = BindingContextUtils.descriptorToDeclaration(context, descriptor);
+            if (psiElement != null) {
+                return Lists.newArrayList(psiElement);
+            }
+            else {
+                return Lists.newArrayList();
+            }
+        }
     }
 }

--- a/idea/src/org/jetbrains/jet/plugin/references/BuiltInsReferenceResolver.java
+++ b/idea/src/org/jetbrains/jet/plugin/references/BuiltInsReferenceResolver.java
@@ -45,6 +45,7 @@ import org.jetbrains.jet.lang.resolve.scopes.WritableScope;
 import org.jetbrains.jet.lang.resolve.scopes.WritableScopeImpl;
 import org.jetbrains.jet.lang.types.lang.KotlinBuiltIns;
 import org.jetbrains.jet.plugin.BuiltInsInitializer;
+import org.jetbrains.jet.plugin.codeInsight.DescriptorToDeclarationUtil;
 import org.jetbrains.jet.renderer.DescriptorRenderer;
 
 import java.net.URL;
@@ -214,7 +215,7 @@ public class BuiltInsReferenceResolver extends AbstractProjectComponent {
         descriptor = descriptor.getOriginal();
         descriptor = findCurrentDescriptor(descriptor);
         if (descriptor != null) {
-            return BindingContextUtils.descriptorToDeclarations(bindingContext, descriptor);
+            return DescriptorToDeclarationUtil.descriptorToDeclarations(bindingContext, descriptor);
         }
         return Collections.emptyList();
     }

--- a/idea/src/org/jetbrains/jet/plugin/references/JetPsiReference.java
+++ b/idea/src/org/jetbrains/jet/plugin/references/JetPsiReference.java
@@ -16,7 +16,6 @@
 
 package org.jetbrains.jet.plugin.references;
 
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementResolveResult;
 import com.intellij.psi.PsiPolyVariantReference;
@@ -24,11 +23,12 @@ import com.intellij.psi.ResolveResult;
 import com.intellij.util.IncorrectOperationException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.jet.analyzer.AnalyzeExhaust;
 import org.jetbrains.jet.lang.descriptors.DeclarationDescriptor;
 import org.jetbrains.jet.lang.psi.JetFile;
 import org.jetbrains.jet.lang.psi.JetReferenceExpression;
 import org.jetbrains.jet.lang.resolve.BindingContext;
-import org.jetbrains.jet.lang.resolve.BindingContextUtils;
+import org.jetbrains.jet.plugin.codeInsight.DescriptorToDeclarationUtil;
 import org.jetbrains.jet.plugin.project.WholeProjectAnalyzerFacade;
 
 import java.util.ArrayList;
@@ -39,9 +39,6 @@ import static org.jetbrains.jet.lang.resolve.BindingContext.AMBIGUOUS_LABEL_TARG
 import static org.jetbrains.jet.lang.resolve.BindingContext.AMBIGUOUS_REFERENCE_TARGET;
 
 public abstract class JetPsiReference implements PsiPolyVariantReference {
-
-    private static final Logger LOG = Logger.getInstance("#org.jetbrains.jet.plugin.references.JetPsiReference");
-
     @NotNull
     protected final JetReferenceExpression myExpression;
 
@@ -103,15 +100,15 @@ public abstract class JetPsiReference implements PsiPolyVariantReference {
     @Nullable
     protected PsiElement doResolve() {
         JetFile file = (JetFile) getElement().getContainingFile();
-        BindingContext bindingContext = WholeProjectAnalyzerFacade.analyzeProjectWithCacheOnAFile(file).getBindingContext();
-        List<PsiElement> psiElements = BindingContextUtils.resolveToDeclarationPsiElements(bindingContext, myExpression);
+        AnalyzeExhaust analyzeExhaust = WholeProjectAnalyzerFacade.analyzeProjectWithCacheOnAFile(file);
+        List<PsiElement> psiElements = DescriptorToDeclarationUtil.resolveToDeclarationPsiElements(analyzeExhaust, myExpression);
         if (psiElements.size() == 1) {
             return psiElements.iterator().next();
         }
         if (psiElements.size() > 1) {
             return null;
         }
-        Collection<PsiElement> stdlibSymbols = resolveStandardLibrarySymbol(bindingContext);
+        Collection<PsiElement> stdlibSymbols = resolveStandardLibrarySymbol(analyzeExhaust.getBindingContext());
         if (stdlibSymbols.size() == 1) {
             return stdlibSymbols.iterator().next();
         }
@@ -120,10 +117,11 @@ public abstract class JetPsiReference implements PsiPolyVariantReference {
 
     protected ResolveResult[] doMultiResolve() {
         JetFile file = (JetFile) getElement().getContainingFile();
-        BindingContext bindingContext = WholeProjectAnalyzerFacade.analyzeProjectWithCacheOnAFile(file).getBindingContext();
+        AnalyzeExhaust analyzeExhaust = WholeProjectAnalyzerFacade.analyzeProjectWithCacheOnAFile(file);
+        BindingContext bindingContext = analyzeExhaust.getBindingContext();
         Collection<? extends DeclarationDescriptor> declarationDescriptors = bindingContext.get(AMBIGUOUS_REFERENCE_TARGET, myExpression);
         if (declarationDescriptors == null) {
-            List<PsiElement> psiElements = BindingContextUtils.resolveToDeclarationPsiElements(bindingContext, myExpression);
+            List<PsiElement> psiElements = DescriptorToDeclarationUtil.resolveToDeclarationPsiElements(analyzeExhaust, myExpression);
             if (psiElements.size() > 1) {
                 return PsiElementResolveResult.createResults(psiElements);
             }
@@ -140,7 +138,7 @@ public abstract class JetPsiReference implements PsiPolyVariantReference {
 
         List<ResolveResult> results = new ArrayList<ResolveResult>(declarationDescriptors.size());
         for (DeclarationDescriptor descriptor : declarationDescriptors) {
-            List<PsiElement> elements = BindingContextUtils.descriptorToDeclarations(bindingContext, descriptor);
+            List<PsiElement> elements = DescriptorToDeclarationUtil.descriptorToDeclarations(bindingContext, descriptor);
             for (PsiElement element : elements) {
                 results.add(new PsiElementResolveResult(element, true));
             }


### PR DESCRIPTION
I don't believe that you accept my JS changes in the near time, so, I will pull some java related stuff and I hope, java team members will be faster ;)

Problem: We don't support intermodule references properly. Ok — I fixed it partially for JS, but JetPsiReference should be modified. Please review my changes:
1) move resolveToDeclarationPsiElements and descriptorToDeclarations to DescriptorToDeclarationUtil from BindingContextUtils. Reason: it is required and must be used only in idea plugin.
2) we must not use reference binding context to find declaration for descriptor — we should try to find corresponding by module descriptor.

Please note — patch contains only core stuff, because js stuff depends on my 340 commits.
