### PR TITLE
QuickFix for PARAMETER_NAME_CHANGED_ON_OVERRIDE.

### DIFF
--- a/idea/src/org/jetbrains/jet/plugin/JetBundle.properties
+++ b/idea/src/org/jetbrains/jet/plugin/JetBundle.properties
@@ -40,6 +40,8 @@ specify.type.explicitly.action.family.name=Specify Type Explicitly
 specify.type.explicitly.add.return.type.action.name=Specify return type explicitly
 specify.type.explicitly.add.action.name=Specify type explicitly
 specify.type.explicitly.remove.action.name=Remove explicitly specified type
+rename.parameter.to.match.overridden.method=Rename parameter to match overridden method
+rename.family=Rename
 
 add.kotlin.signature.action.family.name=Specify Custom Kotlin Signature
 add.kotlin.signature.action.text=Specify custom Kotlin signature

--- a/idea/src/org/jetbrains/jet/plugin/quickfix/QuickFixes.java
+++ b/idea/src/org/jetbrains/jet/plugin/quickfix/QuickFixes.java
@@ -157,5 +157,7 @@ public class QuickFixes {
         factories.put(INACCESSIBLE_OUTER_CLASS_EXPRESSION, AddModifierFix.createFactory(INNER_KEYWORD, JetClass.class));
         
         factories.put(FINAL_SUPERTYPE, FinalSupertypeFix.createFactory());
+
+        factories.put(PARAMETER_NAME_CHANGED_ON_OVERRIDE, RenameParameterToMatchOverriddenMethodFix.createFactory());
     }
 }

--- a/idea/src/org/jetbrains/jet/plugin/quickfix/RenameParameterToMatchOverriddenMethodFix.java
+++ b/idea/src/org/jetbrains/jet/plugin/quickfix/RenameParameterToMatchOverriddenMethodFix.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2010-2013 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.jet.plugin.quickfix;
+
+import com.intellij.codeInsight.intention.IntentionAction;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiFile;
+import com.intellij.refactoring.rename.RenameProcessor;
+import com.intellij.util.IncorrectOperationException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.jet.lang.descriptors.*;
+import org.jetbrains.jet.lang.diagnostics.Diagnostic;
+import org.jetbrains.jet.lang.psi.JetParameter;
+import org.jetbrains.jet.lang.resolve.BindingContext;
+import org.jetbrains.jet.plugin.JetBundle;
+import org.jetbrains.jet.plugin.caches.resolve.KotlinCacheManager;
+
+public class RenameParameterToMatchOverriddenMethodFix extends JetIntentionAction<JetParameter>{
+    private final JetParameter parameter;
+    private String parameterFromSuperclassName;
+
+    public RenameParameterToMatchOverriddenMethodFix(@NotNull JetParameter parameter) {
+        super(parameter);
+        this.parameter = parameter;
+    }
+
+    @Override
+    public boolean isAvailable(@NotNull Project project, Editor editor, PsiFile file) {
+        if (!super.isAvailable(project, editor, file)) {
+            return false;
+        }
+
+        BindingContext context = KotlinCacheManager.getInstance(project).getDeclarationsFromProject(project).getBindingContext();
+        VariableDescriptor parameterDescriptor = context.get(BindingContext.VALUE_PARAMETER, parameter);
+        if (parameterDescriptor == null) {
+            return false;
+        }
+        for (CallableDescriptor parameterFromSuperclass : parameterDescriptor.getOverriddenDescriptors()) {
+            if (parameterFromSuperclassName == null) {
+                parameterFromSuperclassName = parameterFromSuperclass.getName().getName();
+            }
+            else if (!parameterFromSuperclassName.equals(parameterFromSuperclass.getName().getName())) {
+                return false;
+            }
+        }
+
+        return parameterFromSuperclassName != null;
+    }
+
+    @NotNull
+    @Override
+    public String getText() {
+        return JetBundle.message("rename.parameter.to.match.overridden.method");
+    }
+
+    @NotNull
+    @Override
+    public String getFamilyName() {
+        return JetBundle.message("rename.family");
+    }
+
+    @Override
+    public void invoke(@NotNull Project project, Editor editor, PsiFile file) throws IncorrectOperationException {
+        new RenameProcessor(project, parameter, parameterFromSuperclassName, false, false).run();
+    }
+
+    @NotNull
+    public static JetIntentionActionFactory createFactory() {
+        return new JetIntentionActionFactory() {
+            @Nullable
+            @Override
+            public IntentionAction createAction(Diagnostic diagnostic) {
+                JetParameter parameter = QuickFixUtil.getParentElementOfType(diagnostic, JetParameter.class);
+                return parameter == null ? null : new RenameParameterToMatchOverriddenMethodFix(parameter);
+            }
+        };
+    }
+}

--- a/idea/testData/quickfix/override/afterParameterNameChangedMultipleOverrideRenamePossible.kt
+++ b/idea/testData/quickfix/override/afterParameterNameChangedMultipleOverrideRenamePossible.kt
@@ -1,0 +1,15 @@
+// "Rename parameter to match overridden method" "true"
+abstract class A {
+    abstract fun foo(arg : Int) : Int;
+}
+
+trait X {
+    fun foo(arg : Int) : Int;
+}
+
+class B : A(), X {
+    override fun foo(var arg: Int) : Int {
+        arg += 5
+        return arg
+    }
+}

--- a/idea/testData/quickfix/override/afterParameterNameChangedRenamePossible.kt
+++ b/idea/testData/quickfix/override/afterParameterNameChangedRenamePossible.kt
@@ -1,0 +1,11 @@
+// "Rename parameter to match overridden method" "true"
+abstract class A {
+    abstract fun foo(arg : Int) : Int;
+}
+
+class B : A() {
+    override fun foo(var arg: Int) : Int {
+        arg += 5
+        return arg
+    }
+}

--- a/idea/testData/quickfix/override/beforeParameterNameChangedAmbiguousRename.kt
+++ b/idea/testData/quickfix/override/beforeParameterNameChangedAmbiguousRename.kt
@@ -1,0 +1,15 @@
+// "Rename parameter to match overridden method" "false"
+abstract class A {
+    abstract fun foo(arg : Int) : Int;
+}
+
+trait X {
+    fun foo(agr: Int) : Int;
+}
+
+class B : A(), X {
+    override fun foo(var arg<caret>: Int) : Int {
+        arg += 5
+        return arg
+    }
+}

--- a/idea/testData/quickfix/override/beforeParameterNameChangedMultipleOverrideRenamePossible.kt
+++ b/idea/testData/quickfix/override/beforeParameterNameChangedMultipleOverrideRenamePossible.kt
@@ -1,0 +1,15 @@
+// "Rename parameter to match overridden method" "true"
+abstract class A {
+    abstract fun foo(arg : Int) : Int;
+}
+
+trait X {
+    fun foo(arg : Int) : Int;
+}
+
+class B : A(), X {
+    override fun foo(var agr<caret> : Int) : Int {
+        agr += 5
+        return agr
+    }
+}

--- a/idea/testData/quickfix/override/beforeParameterNameChangedRenamePossible.kt
+++ b/idea/testData/quickfix/override/beforeParameterNameChangedRenamePossible.kt
@@ -1,0 +1,11 @@
+// "Rename parameter to match overridden method" "true"
+abstract class A {
+    abstract fun foo(arg : Int) : Int;
+}
+
+class B : A() {
+    override fun foo(var agr<caret> : Int) : Int {
+        agr += 5
+        return agr
+    }
+}


### PR DESCRIPTION
QuickFix renames method parameter to match the name from the overridden method.

I wanted to make this QuickFix unavailable when renaming causes conflict, e. g.:

```
abstract class A {
  abstract fun foo(x : Int) : Int;
}

class B {
  override fun foo(y : Int) : Int {
    x = 5
    return x + y
  }
}
```

But I didn't figure out reasonable way of achieving such behaviour.
