### PR TITLE
Quickfix for INCOMPATIBLE_MODIFIERS.

### DIFF
--- a/idea/src/org/jetbrains/jet/plugin/quickfix/QuickFixes.java
+++ b/idea/src/org/jetbrains/jet/plugin/quickfix/QuickFixes.java
@@ -112,6 +112,9 @@ public class QuickFixes {
         factories.put(GETTER_VISIBILITY_DIFFERS_FROM_PROPERTY_VISIBILITY, removeModifierFactory);
         factories.put(REDUNDANT_MODIFIER_IN_GETTER, removeRedundantModifierFactory);
         factories.put(ILLEGAL_MODIFIER, removeModifierFactory);
+        for (JetIntentionActionFactory factory : RemoveModifierFix.getIncompatibleModifiersFactories()) {
+            factories.put(INCOMPATIBLE_MODIFIERS, factory);
+        }
 
         JetIntentionActionFactory changeToBackingFieldFactory = ChangeToBackingFieldFix.createFactory();
         factories.put(INITIALIZATION_USING_BACKING_FIELD_CUSTOM_SETTER, changeToBackingFieldFactory);

--- a/idea/testData/quickfix/modifiers/afterFinalAbstractClass1.kt
+++ b/idea/testData/quickfix/modifiers/afterFinalAbstractClass1.kt
@@ -1,0 +1,2 @@
+// "Make 'C' not abstract" "true"
+<caret>final class C {}

--- a/idea/testData/quickfix/modifiers/afterFinalAbstractClass2.kt
+++ b/idea/testData/quickfix/modifiers/afterFinalAbstractClass2.kt
@@ -1,0 +1,2 @@
+// "Remove 'final' modifier" "true"
+<caret>abstract class C {}

--- a/idea/testData/quickfix/modifiers/afterFinalOpenClass1.kt
+++ b/idea/testData/quickfix/modifiers/afterFinalOpenClass1.kt
@@ -1,0 +1,2 @@
+// "Make 'C' not open" "true"
+<caret>final class C {}

--- a/idea/testData/quickfix/modifiers/afterFinalOpenClass2.kt
+++ b/idea/testData/quickfix/modifiers/afterFinalOpenClass2.kt
@@ -1,0 +1,2 @@
+// "Remove 'final' modifier" "true"
+op<caret>en class C {}

--- a/idea/testData/quickfix/modifiers/afterPrivatePublicFunction1.kt
+++ b/idea/testData/quickfix/modifiers/afterPrivatePublicFunction1.kt
@@ -1,0 +1,4 @@
+// "Remove 'private' modifier" "true"
+class A {
+    <caret>public fun f() {}
+}

--- a/idea/testData/quickfix/modifiers/afterPrivatePublicFunction2.kt
+++ b/idea/testData/quickfix/modifiers/afterPrivatePublicFunction2.kt
@@ -1,0 +1,4 @@
+// "Remove 'public' modifier" "true"
+class A {
+    private fun f() {}
+}

--- a/idea/testData/quickfix/modifiers/afterPrivatePublicFunction3.kt
+++ b/idea/testData/quickfix/modifiers/afterPrivatePublicFunction3.kt
@@ -1,0 +1,8 @@
+// "Remove 'internal' modifier" "false"
+// ACTION: Remove 'private' modifier
+// ACTION: Remove 'public' modifier
+// ERROR: Incompatible modifiers: 'private public'
+// ERROR: Incompatible modifiers: 'private public'
+class A {
+    <caret>private public fun f() {}
+}

--- a/idea/testData/quickfix/modifiers/beforeFinalAbstractClass1.kt
+++ b/idea/testData/quickfix/modifiers/beforeFinalAbstractClass1.kt
@@ -1,0 +1,2 @@
+// "Make 'C' not abstract" "true"
+<caret>final abstract class C {}

--- a/idea/testData/quickfix/modifiers/beforeFinalAbstractClass2.kt
+++ b/idea/testData/quickfix/modifiers/beforeFinalAbstractClass2.kt
@@ -1,0 +1,2 @@
+// "Remove 'final' modifier" "true"
+<caret>final abstract class C {}

--- a/idea/testData/quickfix/modifiers/beforeFinalOpenClass1.kt
+++ b/idea/testData/quickfix/modifiers/beforeFinalOpenClass1.kt
@@ -1,0 +1,2 @@
+// "Make 'C' not open" "true"
+op<caret>en final class C {}

--- a/idea/testData/quickfix/modifiers/beforeFinalOpenClass2.kt
+++ b/idea/testData/quickfix/modifiers/beforeFinalOpenClass2.kt
@@ -1,0 +1,2 @@
+// "Remove 'final' modifier" "true"
+op<caret>en final class C {}

--- a/idea/testData/quickfix/modifiers/beforePrivatePublicFunction1.kt
+++ b/idea/testData/quickfix/modifiers/beforePrivatePublicFunction1.kt
@@ -1,0 +1,4 @@
+// "Remove 'private' modifier" "true"
+class A {
+    <caret>private public fun f() {}
+}

--- a/idea/testData/quickfix/modifiers/beforePrivatePublicFunction2.kt
+++ b/idea/testData/quickfix/modifiers/beforePrivatePublicFunction2.kt
@@ -1,0 +1,4 @@
+// "Remove 'public' modifier" "true"
+class A {
+    <caret>private public fun f() {}
+}

--- a/idea/testData/quickfix/modifiers/beforePrivatePublicFunction3.kt
+++ b/idea/testData/quickfix/modifiers/beforePrivatePublicFunction3.kt
@@ -1,0 +1,8 @@
+// "Remove 'internal' modifier" "false"
+// ACTION: Remove 'private' modifier
+// ACTION: Remove 'public' modifier
+// ERROR: Incompatible modifiers: 'private public'
+// ERROR: Incompatible modifiers: 'private public'
+class A {
+    <caret>private public fun f() {}
+}

--- a/idea/tests/org/jetbrains/jet/plugin/quickfix/QuickFixMultiFileTestGenerated.java
+++ b/idea/tests/org/jetbrains/jet/plugin/quickfix/QuickFixMultiFileTestGenerated.java
@@ -134,7 +134,7 @@ public class QuickFixMultiFileTestGenerated extends AbstractQuickFixMultiFileTes
             }
             
             @TestMetadata("idea/testData/quickfix/modifiers/finalSupertype/finalJavaSupertype")
-            @InnerTestClasses({FinalJavaSupertype.JavaCode.class, })
+            @InnerTestClasses({FinalJavaSupertype.JavaCode.class})
             public static class FinalJavaSupertype extends AbstractQuickFixMultiFileTest {
                 public void testAllFilesPresentInFinalJavaSupertype() throws Exception {
                     JetTestUtils.assertAllTestsPresentByMetadata(this.getClass(), "org.jetbrains.jet.generators.tests.GenerateTests", new File("idea/testData/quickfix/modifiers/finalSupertype/finalJavaSupertype"), Pattern.compile("^(\\w+)\\.before\\.Main\\.kt$"), true);

--- a/idea/tests/org/jetbrains/jet/plugin/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/jet/plugin/quickfix/QuickFixTestGenerated.java
@@ -403,6 +403,26 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
             JetTestUtils.assertAllTestsPresentByMetadata(this.getClass(), "org.jetbrains.jet.generators.tests.GenerateTests", new File("idea/testData/quickfix/modifiers"), Pattern.compile("^before(\\w+)\\.kt$"), true);
         }
         
+        @TestMetadata("beforeFinalAbstractClass1.kt")
+        public void testFinalAbstractClass1() throws Exception {
+            doTest("idea/testData/quickfix/modifiers/beforeFinalAbstractClass1.kt");
+        }
+        
+        @TestMetadata("beforeFinalAbstractClass2.kt")
+        public void testFinalAbstractClass2() throws Exception {
+            doTest("idea/testData/quickfix/modifiers/beforeFinalAbstractClass2.kt");
+        }
+        
+        @TestMetadata("beforeFinalOpenClass1.kt")
+        public void testFinalOpenClass1() throws Exception {
+            doTest("idea/testData/quickfix/modifiers/beforeFinalOpenClass1.kt");
+        }
+        
+        @TestMetadata("beforeFinalOpenClass2.kt")
+        public void testFinalOpenClass2() throws Exception {
+            doTest("idea/testData/quickfix/modifiers/beforeFinalOpenClass2.kt");
+        }
+        
         @TestMetadata("beforeFinalTrait.kt")
         public void testFinalTrait() throws Exception {
             doTest("idea/testData/quickfix/modifiers/beforeFinalTrait.kt");
@@ -416,6 +436,21 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
         @TestMetadata("beforeOpenMemberInFinalClass2.kt")
         public void testOpenMemberInFinalClass2() throws Exception {
             doTest("idea/testData/quickfix/modifiers/beforeOpenMemberInFinalClass2.kt");
+        }
+        
+        @TestMetadata("beforePrivatePublicFunction1.kt")
+        public void testPrivatePublicFunction1() throws Exception {
+            doTest("idea/testData/quickfix/modifiers/beforePrivatePublicFunction1.kt");
+        }
+        
+        @TestMetadata("beforePrivatePublicFunction2.kt")
+        public void testPrivatePublicFunction2() throws Exception {
+            doTest("idea/testData/quickfix/modifiers/beforePrivatePublicFunction2.kt");
+        }
+        
+        @TestMetadata("beforePrivatePublicFunction3.kt")
+        public void testPrivatePublicFunction3() throws Exception {
+            doTest("idea/testData/quickfix/modifiers/beforePrivatePublicFunction3.kt");
         }
         
         @TestMetadata("beforeRemoveRedundantModifier1.kt")
@@ -481,7 +516,7 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
             }
             
             @TestMetadata("idea/testData/quickfix/modifiers/finalSupertype/finalJavaSupertype")
-            @InnerTestClasses({FinalJavaSupertype.JavaCode.class, })
+            @InnerTestClasses({FinalJavaSupertype.JavaCode.class})
             public static class FinalJavaSupertype extends AbstractQuickFixTest {
                 public void testAllFilesPresentInFinalJavaSupertype() throws Exception {
                     JetTestUtils.assertAllTestsPresentByMetadata(this.getClass(), "org.jetbrains.jet.generators.tests.GenerateTests", new File("idea/testData/quickfix/modifiers/finalSupertype/finalJavaSupertype"), Pattern.compile("^before(\\w+)\\.kt$"), true);


### PR DESCRIPTION
I've expanded univerio's quickfix (https://github.com/JetBrains/kotlin/pull/176) to allow the user to choose which one of conflicting keywords should be removed (instead of just removing the one under the cursor). However, the code is much more complicated and I'm not sure whether the feature is worth this complication (since I don't think that this quickfix will be frequently used).
