### PR TITLE
Quickfix for NO_BACKING_FIELD_ABSTRACT_PROPERTY.

### DIFF
--- a/idea/src/org/jetbrains/jet/plugin/JetBundle.properties
+++ b/idea/src/org/jetbrains/jet/plugin/JetBundle.properties
@@ -111,3 +111,5 @@ add.when.else.branch.action.family.name=Add Else Branch
 add.when.else.branch.action=Add else branch
 move.when.else.branch.to.the.end.action=Move else branch to the end
 move.when.else.branch.to.the.end.family.name=Move Else Branch to the End
+change.to.property.name.family.name=Change to property name
+change.to.property.name.action=Change ''{0}'' to ''{1}''

--- a/idea/src/org/jetbrains/jet/plugin/quickfix/ChangeToPropertyNameFix.java
+++ b/idea/src/org/jetbrains/jet/plugin/quickfix/ChangeToPropertyNameFix.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2010-2013 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.jet.plugin.quickfix;
+
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.util.IncorrectOperationException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.jet.lang.diagnostics.Diagnostic;
+import org.jetbrains.jet.lang.psi.*;
+import org.jetbrains.jet.plugin.JetBundle;
+
+public class ChangeToPropertyNameFix extends JetIntentionAction<JetSimpleNameExpression> {
+    public ChangeToPropertyNameFix(@NotNull JetSimpleNameExpression element) {
+        super(element);
+    }
+
+
+    private String getBackingFieldName() {
+        return element.getText();
+    }
+
+    private String getPropertyName() {
+        return getBackingFieldName().replaceFirst("\\$", "");
+    }
+
+    @NotNull
+    @Override
+    public String getText() {
+        return JetBundle.message("change.to.property.name.action", getBackingFieldName(), getPropertyName());
+    }
+
+    @NotNull
+    @Override
+    public String getFamilyName() {
+        return JetBundle.message("change.to.property.name.family.name");
+    }
+
+    @Override
+    public void invoke(@NotNull Project project, Editor editor, PsiFile file) throws IncorrectOperationException {
+        JetSimpleNameExpression propertyName = (JetSimpleNameExpression) JetPsiFactory.createExpression(project, getPropertyName());
+        element.replace(propertyName);
+    }
+
+    public static JetIntentionActionFactory createFactory() {
+        return new JetIntentionActionFactory() {
+            @Override
+            public JetIntentionAction<JetSimpleNameExpression> createAction(Diagnostic diagnostic) {
+                JetSimpleNameExpression expression = QuickFixUtil.getParentElementOfType(diagnostic, JetSimpleNameExpression.class);
+                if (expression == null) {
+                    PsiElement element = diagnostic.getPsiElement();
+                    if (element instanceof JetQualifiedExpression && ((JetQualifiedExpression) element).getReceiverExpression() instanceof JetThisExpression) {
+                        JetExpression selector = ((JetQualifiedExpression) element).getSelectorExpression();
+                        if (selector instanceof JetSimpleNameExpression) {
+                            expression = (JetSimpleNameExpression) selector;
+                        }
+                    }
+                }
+                if (expression == null) return null;
+                return new ChangeToPropertyNameFix(expression);
+            }
+        };
+    }
+}

--- a/idea/src/org/jetbrains/jet/plugin/quickfix/QuickFixes.java
+++ b/idea/src/org/jetbrains/jet/plugin/quickfix/QuickFixes.java
@@ -119,6 +119,9 @@ public class QuickFixes {
         factories.put(INITIALIZATION_USING_BACKING_FIELD_CUSTOM_SETTER, changeToBackingFieldFactory);
         factories.put(INITIALIZATION_USING_BACKING_FIELD_OPEN_SETTER, changeToBackingFieldFactory);
 
+        JetIntentionActionFactory changeToPropertyNameFactory = ChangeToPropertyNameFix.createFactory();
+        factories.put(NO_BACKING_FIELD_ABSTRACT_PROPERTY, changeToPropertyNameFactory);
+
         JetIntentionActionFactory unresolvedReferenceFactory = ImportClassAndFunFix.createFactory();
         factories.put(UNRESOLVED_REFERENCE, unresolvedReferenceFactory);
 

--- a/idea/testData/quickfix/variables/changeToPropertyName/afterAbstractProperty.kt
+++ b/idea/testData/quickfix/variables/changeToPropertyName/afterAbstractProperty.kt
@@ -1,0 +1,5 @@
+// "Change '$foo' to 'foo'" "true"
+abstract class Foo {
+    abstract var foo : String
+    fun bar() = <caret>foo + "bar"
+}

--- a/idea/testData/quickfix/variables/changeToPropertyName/afterAbstractPropertyThis.kt
+++ b/idea/testData/quickfix/variables/changeToPropertyName/afterAbstractPropertyThis.kt
@@ -1,0 +1,5 @@
+// "Change '$bar' to 'bar'" "true"
+abstract class Bar {
+    abstract var bar : String
+    fun foo() = "foo" + <caret>this.bar
+}

--- a/idea/testData/quickfix/variables/changeToPropertyName/beforeAbstractProperty.kt
+++ b/idea/testData/quickfix/variables/changeToPropertyName/beforeAbstractProperty.kt
@@ -1,0 +1,5 @@
+// "Change '$foo' to 'foo'" "true"
+abstract class Foo {
+    abstract var foo : String
+    fun bar() = <caret>$foo + "bar"
+}

--- a/idea/testData/quickfix/variables/changeToPropertyName/beforeAbstractPropertyThis.kt
+++ b/idea/testData/quickfix/variables/changeToPropertyName/beforeAbstractPropertyThis.kt
@@ -1,0 +1,5 @@
+// "Change '$bar' to 'bar'" "true"
+abstract class Bar {
+    abstract var bar : String
+    fun foo() = "foo" + <caret>this.$bar
+}

--- a/idea/tests/org/jetbrains/jet/plugin/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/jet/plugin/quickfix/QuickFixTestGenerated.java
@@ -734,7 +734,7 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
     }
     
     @TestMetadata("idea/testData/quickfix/variables")
-    @InnerTestClasses({Variables.ChangeMutability.class, Variables.ChangeToBackingField.class, Variables.ChangeToFunctionInvocation.class})
+    @InnerTestClasses({Variables.ChangeMutability.class, Variables.ChangeToBackingField.class, Variables.ChangeToFunctionInvocation.class, Variables.ChangeToPropertyName.class})
     public static class Variables extends AbstractQuickFixTest {
         public void testAllFilesPresentInVariables() throws Exception {
             JetTestUtils.assertAllTestsPresentByMetadata(this.getClass(), "org.jetbrains.jet.generators.tests.GenerateTests", new File("idea/testData/quickfix/variables"), Pattern.compile("^before(\\w+)\\.kt$"), true);
@@ -804,12 +804,31 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
             
         }
         
+        @TestMetadata("idea/testData/quickfix/variables/changeToPropertyName")
+        public static class ChangeToPropertyName extends AbstractQuickFixTest {
+            @TestMetadata("beforeAbstractProperty.kt")
+            public void testAbstractProperty() throws Exception {
+                doTest("idea/testData/quickfix/variables/changeToPropertyName/beforeAbstractProperty.kt");
+            }
+            
+            @TestMetadata("beforeAbstractPropertyThis.kt")
+            public void testAbstractPropertyThis() throws Exception {
+                doTest("idea/testData/quickfix/variables/changeToPropertyName/beforeAbstractPropertyThis.kt");
+            }
+            
+            public void testAllFilesPresentInChangeToPropertyName() throws Exception {
+                JetTestUtils.assertAllTestsPresentByMetadata(this.getClass(), "org.jetbrains.jet.generators.tests.GenerateTests", new File("idea/testData/quickfix/variables/changeToPropertyName"), Pattern.compile("^before(\\w+)\\.kt$"), true);
+            }
+            
+        }
+        
         public static Test innerSuite() {
             TestSuite suite = new TestSuite("Variables");
             suite.addTestSuite(Variables.class);
             suite.addTestSuite(ChangeMutability.class);
             suite.addTestSuite(ChangeToBackingField.class);
             suite.addTestSuite(ChangeToFunctionInvocation.class);
+            suite.addTestSuite(ChangeToPropertyName.class);
             return suite;
         }
     }


### PR DESCRIPTION
This quickfix is based on ChangeToBackingFieldFix and shares some of it's code in createFactory method. I could extract this common code, but I don't know if I should and what would be the best place for it (maybe QuickFixUtil?).
