### PR TITLE
KT-3368 J2K: converted enums contain name() method

### DIFF
--- a/j2k/src/org/jetbrains/jet/j2k/ast/Enum.java
+++ b/j2k/src/org/jetbrains/jet/j2k/ast/Enum.java
@@ -42,12 +42,11 @@ public class Enum extends Class {
     @NotNull
     @Override
     public String toKotlin() {
+        String primaryConstructorBody = primaryConstructorBodyToKotlin();
         return modifiersToKotlin() + "enum class" + SPACE + myName.toKotlin() + primaryConstructorSignatureToKotlin() +
                typeParametersToKotlin() + implementTypesToKotlin() + SPACE + "{" + N +
                AstUtil.joinNodes(membersExceptConstructors(), N) + N +
-               primaryConstructorBodyToKotlin() + N +
-               "public fun name()  : String { return \"\" }" + N + // TODO : remove hack
-               "public fun order() : Int { return 0 }" + N +
+               (primaryConstructorBody.isEmpty() ? EMPTY : primaryConstructorBody + N) +
                "}";
     }
 }

--- a/j2k/tests/testData/ast/enum/class/colorEnum.kt
+++ b/j2k/tests/testData/ast/enum/class/colorEnum.kt
@@ -9,6 +9,4 @@ return color
 {
 color = _color
 }
-public fun name() : String { return "" }
-public fun order() : Int { return 0 }
 }

--- a/j2k/tests/testData/ast/enum/class/emptyEnum.kt
+++ b/j2k/tests/testData/ast/enum/class/emptyEnum.kt
@@ -1,4 +1,2 @@
 enum class A {
-public fun name() : String { return "" }
-public fun order() : Int { return 0 }
 }

--- a/j2k/tests/testData/ast/enum/class/enumConstantIsNotNull.kt
+++ b/j2k/tests/testData/ast/enum/class/enumConstantIsNotNull.kt
@@ -3,6 +3,4 @@ FOO
 fun foo() : Unit {
 FOO.toString()
 }
-public fun name() : String { return "" }
-public fun order() : Int { return 0 }
 }

--- a/j2k/tests/testData/ast/enum/class/enumImplementsOneInterface.kt
+++ b/j2k/tests/testData/ast/enum/class/enumImplementsOneInterface.kt
@@ -1,4 +1,2 @@
 enum class A : I {
-public fun name() : String { return "" }
-public fun order() : Int { return 0 }
 }

--- a/j2k/tests/testData/ast/enum/class/enumImplementsSeveralInterfaces.kt
+++ b/j2k/tests/testData/ast/enum/class/enumImplementsSeveralInterfaces.kt
@@ -1,4 +1,2 @@
 enum class A : I0, I1, I2 {
-public fun name() : String { return "" }
-public fun order() : Int { return 0 }
 }

--- a/j2k/tests/testData/ast/enum/class/enumWithNameField.kt
+++ b/j2k/tests/testData/ast/enum/class/enumWithNameField.kt
@@ -1,6 +1,4 @@
 enum class E {
 I
 private var name : String? = null
-public fun name() : String { return "" }
-public fun order() : Int { return 0 }
 }

--- a/j2k/tests/testData/ast/enum/class/fieldsWithPrimaryPrivateConstructor.kt
+++ b/j2k/tests/testData/ast/enum/class/fieldsWithPrimaryPrivateConstructor.kt
@@ -11,6 +11,4 @@ return code
 {
 code = c
 }
-public fun name() : String { return "" }
-public fun order() : Int { return 0 }
 }

--- a/j2k/tests/testData/ast/enum/class/internalEnum.kt
+++ b/j2k/tests/testData/ast/enum/class/internalEnum.kt
@@ -1,4 +1,2 @@
 enum class Test {
-public fun name() : String { return "" }
-public fun order() : Int { return 0 }
 }

--- a/j2k/tests/testData/ast/enum/class/overrideToString.kt
+++ b/j2k/tests/testData/ast/enum/class/overrideToString.kt
@@ -7,6 +7,4 @@ BLUE
 override fun toString() : String? {
 return "COLOR"
 }
-public fun name() : String { return "" }
-public fun order() : Int { return 0 }
 }

--- a/j2k/tests/testData/ast/enum/class/primaryPrivateConstructor.kt
+++ b/j2k/tests/testData/ast/enum/class/primaryPrivateConstructor.kt
@@ -7,6 +7,4 @@ return code
 {
 code = c
 }
-public fun name() : String { return "" }
-public fun order() : Int { return 0 }
 }

--- a/j2k/tests/testData/ast/enum/class/privateEnum.kt
+++ b/j2k/tests/testData/ast/enum/class/privateEnum.kt
@@ -1,4 +1,2 @@
 private enum class Test {
-public fun name() : String { return "" }
-public fun order() : Int { return 0 }
 }

--- a/j2k/tests/testData/ast/enum/class/protectedEnum.kt
+++ b/j2k/tests/testData/ast/enum/class/protectedEnum.kt
@@ -1,4 +1,2 @@
 protected enum class Test {
-public fun name() : String { return "" }
-public fun order() : Int { return 0 }
 }

--- a/j2k/tests/testData/ast/enum/class/publicEnum.kt
+++ b/j2k/tests/testData/ast/enum/class/publicEnum.kt
@@ -1,4 +1,2 @@
 public enum class Test {
-public fun name() : String { return "" }
-public fun order() : Int { return 0 }
 }

--- a/j2k/tests/testData/ast/enum/class/runnableImplementation.kt
+++ b/j2k/tests/testData/ast/enum/class/runnableImplementation.kt
@@ -7,6 +7,4 @@ BLUE
 public override fun run() : Unit {
 System.out?.println("name()=" + name() + ", toString()=" + toString())
 }
-public fun name() : String { return "" }
-public fun order() : Int { return 0 }
 }

--- a/j2k/tests/testData/ast/enum/class/typeSafeEnum.kt
+++ b/j2k/tests/testData/ast/enum/class/typeSafeEnum.kt
@@ -3,6 +3,4 @@ PENNY
 NICKEL
 DIME
 QUARTER
-public fun name() : String { return "" }
-public fun order() : Int { return 0 }
 }


### PR DESCRIPTION
Removed name() and order() functions from converted enums
