### PR TITLE
QuickFix for OVERRIDDING_FINAL_MEMBER

### DIFF
--- a/idea/src/org/jetbrains/jet/plugin/JetBundle.properties
+++ b/idea/src/org/jetbrains/jet/plugin/JetBundle.properties
@@ -12,6 +12,7 @@ remove.function.body=Remove function body
 make.element.modifier=Make {0} {1}
 add.modifier=Add ''{0}'' modifier
 add.modifier.family=Add Modifier
+make.overridden.members.open=Make member ''{0}'' in types {1} open
 make.class.annotation.class=Make ''{0}'' an annotation class
 make.class.annotation.class.family=Make Class an Annotation Class
 add.star.projections=Add ''{0}''

--- a/idea/src/org/jetbrains/jet/plugin/quickfix/MakeOverriddenMemberOpenFix.java
+++ b/idea/src/org/jetbrains/jet/plugin/quickfix/MakeOverriddenMemberOpenFix.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2010-2013 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.jet.plugin.quickfix;
+
+import com.intellij.codeInsight.intention.IntentionAction;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.util.IncorrectOperationException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.jet.lang.descriptors.CallableMemberDescriptor;
+import org.jetbrains.jet.lang.descriptors.DeclarationDescriptor;
+import org.jetbrains.jet.lang.diagnostics.Diagnostic;
+import org.jetbrains.jet.lang.psi.JetDeclaration;
+import org.jetbrains.jet.lang.psi.JetFile;
+import org.jetbrains.jet.lang.resolve.BindingContextUtils;
+import org.jetbrains.jet.lang.resolve.lazy.ResolveSession;
+import org.jetbrains.jet.plugin.JetBundle;
+import org.jetbrains.jet.plugin.project.WholeProjectAnalyzerFacade;
+
+import java.util.*;
+
+import static org.jetbrains.jet.lexer.JetTokens.OPEN_KEYWORD;
+
+public class MakeOverriddenMemberOpenFix extends JetIntentionAction<JetDeclaration> {
+    private final Set<PsiElement> overriddenMembers;
+    private final Set<String> overriddenMembersNames;
+
+    public MakeOverriddenMemberOpenFix(@NotNull JetDeclaration declaration) {
+        super(declaration);
+        overriddenMembers = new HashSet<PsiElement>();
+        overriddenMembersNames = new TreeSet<String>();
+    }
+
+    @Override
+    public boolean isAvailable(@NotNull Project project, Editor editor, PsiFile file) {
+        if (!super.isAvailable(project, editor, file) || !(file instanceof JetFile)) {
+            return false;
+        }
+
+        ResolveSession resolveSession = WholeProjectAnalyzerFacade.getLazyResolveSessionForFile((JetFile) element.getContainingFile());
+        DeclarationDescriptor descriptor = resolveSession.resolveToDescriptor(element);
+        if (!(descriptor instanceof CallableMemberDescriptor)) return false;
+        CallableMemberDescriptor callableMemberDescriptor = (CallableMemberDescriptor) descriptor;
+        for (CallableMemberDescriptor overriddenDescriptor : callableMemberDescriptor.getOverriddenDescriptors()) {
+            if (!overriddenDescriptor.getModality().isOverridable()) {
+                PsiElement overriddenMember = BindingContextUtils.descriptorToDeclaration(resolveSession.getBindingContext(), overriddenDescriptor);
+                if (overriddenMember == null || !overriddenMember.isWritable()) {
+                    return false;
+                }
+                String containingDeclarationName = overriddenDescriptor.getContainingDeclaration().getName().getName();
+                overriddenMembers.add(overriddenMember);
+                overriddenMembersNames.add(containingDeclarationName);
+            }
+        }
+        return overriddenMembers.size() > 0;
+    }
+
+    @NotNull
+    @Override
+    public String getText() {
+        if (overriddenMembers.size() == 1) {
+            String typeName = overriddenMembersNames.iterator().next();
+            return JetBundle.message("make.element.modifier", typeName + "." + element.getName(), OPEN_KEYWORD);
+        }
+
+        StringBuilder types = new StringBuilder();
+        for(Iterator<String> iterator = overriddenMembersNames.iterator(); iterator.hasNext(); ) {
+            String typeName = iterator.next();
+            if (!iterator.hasNext()) {
+                types.deleteCharAt(types.length() - 2);
+                types.append("and ");
+            }
+            types.append(typeName);
+            if (iterator.hasNext()) {
+                types.append(", ");
+            }
+        }
+
+        return JetBundle.message("make.overridden.members.open", element.getName(), types.toString());
+    }
+
+    @NotNull
+    @Override
+    public String getFamilyName() {
+        return JetBundle.message("add.modifier.family");
+    }
+
+    @Override
+    public void invoke(@NotNull Project project, Editor editor, PsiFile file) throws IncorrectOperationException {
+        for(PsiElement overriddenMember: overriddenMembers) {
+            overriddenMember.replace(AddModifierFix.addModifierWithDefaultReplacement(overriddenMember, OPEN_KEYWORD, project, false));
+        }
+    }
+
+    @NotNull
+    public static JetIntentionActionFactory createFactory() {
+        return new JetIntentionActionFactory() {
+            @Nullable
+            @Override
+            public IntentionAction createAction(Diagnostic diagnostic) {
+                JetDeclaration declaration = QuickFixUtil.getParentElementOfType(diagnostic, JetDeclaration.class);
+                assert declaration != null;
+                return new MakeOverriddenMemberOpenFix(declaration);
+            }
+        };
+    }
+}

--- a/idea/src/org/jetbrains/jet/plugin/quickfix/QuickFixes.java
+++ b/idea/src/org/jetbrains/jet/plugin/quickfix/QuickFixes.java
@@ -187,6 +187,8 @@ public class QuickFixes {
         factories.put(FINAL_SUPERTYPE, addOpenModifierToClassDeclarationFix);
         factories.put(FINAL_UPPER_BOUND, addOpenModifierToClassDeclarationFix);
 
+        factories.put(OVERRIDING_FINAL_MEMBER, MakeOverriddenMemberOpenFix.createFactory());
+
         factories.put(PARAMETER_NAME_CHANGED_ON_OVERRIDE, RenameParameterToMatchOverriddenMethodFix.createFactory());
 
         factories.put(OPEN_MODIFIER_IN_ENUM, RemoveModifierFix.createRemoveModifierFromListOwnerFactory(OPEN_KEYWORD));

--- a/idea/testData/quickfix/override/afterOverriddingMultipleFinalMethods.kt
+++ b/idea/testData/quickfix/override/afterOverriddingMultipleFinalMethods.kt
@@ -1,0 +1,20 @@
+// "Make member 'foo' in types A, X and Y open" "true"
+open class A {
+    open fun foo() {}
+}
+
+trait X {
+    open fun foo() {}
+}
+
+trait Y {
+    open fun foo() {}
+}
+
+trait Z {
+    fun foo() {}
+}
+
+class B : A(), X, Y, Z {
+    override<caret> fun foo() {}
+}

--- a/idea/testData/quickfix/override/afterOverridingFinalMethod.kt
+++ b/idea/testData/quickfix/override/afterOverridingFinalMethod.kt
@@ -1,0 +1,8 @@
+// "Make A.foo open" "true"
+open class A {
+    open fun foo() {}
+}
+
+class B : A() {
+    override<caret> fun foo() {}
+}

--- a/idea/testData/quickfix/override/afterOverridingFinalProperty.kt
+++ b/idea/testData/quickfix/override/afterOverridingFinalProperty.kt
@@ -1,0 +1,8 @@
+// "Make A.x open" "true"
+open class A {
+    open var x = 42;
+}
+
+class B : A() {
+    override<caret> var x = 24;
+}

--- a/idea/testData/quickfix/override/beforeOverriddingMultipleFinalMethods.kt
+++ b/idea/testData/quickfix/override/beforeOverriddingMultipleFinalMethods.kt
@@ -1,0 +1,20 @@
+// "Make member 'foo' in types A, X and Y open" "true"
+open class A {
+    fun foo() {}
+}
+
+trait X {
+    final fun foo() {}
+}
+
+trait Y {
+    final fun foo() {}
+}
+
+trait Z {
+    fun foo() {}
+}
+
+class B : A(), X, Y, Z {
+    override<caret> fun foo() {}
+}

--- a/idea/testData/quickfix/override/beforeOverridingFinalJavaMethod.kt
+++ b/idea/testData/quickfix/override/beforeOverridingFinalJavaMethod.kt
@@ -1,0 +1,5 @@
+// "Make Object.notify open" "false"
+// ERROR: 'notify' in 'Object' is final and cannot be overridden
+class A : Object() {
+    override<caret> fun notify() {}
+}

--- a/idea/testData/quickfix/override/beforeOverridingFinalMethod.kt
+++ b/idea/testData/quickfix/override/beforeOverridingFinalMethod.kt
@@ -1,0 +1,8 @@
+// "Make A.foo open" "true"
+open class A {
+    fun foo() {}
+}
+
+class B : A() {
+    override<caret> fun foo() {}
+}

--- a/idea/testData/quickfix/override/beforeOverridingFinalProperty.kt
+++ b/idea/testData/quickfix/override/beforeOverridingFinalProperty.kt
@@ -1,0 +1,8 @@
+// "Make A.x open" "true"
+open class A {
+    final var x = 42;
+}
+
+class B : A() {
+    override<caret> var x = 24;
+}

--- a/idea/tests/org/jetbrains/jet/plugin/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/jet/plugin/quickfix/QuickFixTestGenerated.java
@@ -662,6 +662,26 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
             doTest("idea/testData/quickfix/override/beforeNothingToOverride.kt");
         }
         
+        @TestMetadata("beforeOverriddingMultipleFinalMethods.kt")
+        public void testOverriddingMultipleFinalMethods() throws Exception {
+            doTest("idea/testData/quickfix/override/beforeOverriddingMultipleFinalMethods.kt");
+        }
+        
+        @TestMetadata("beforeOverridingFinalJavaMethod.kt")
+        public void testOverridingFinalJavaMethod() throws Exception {
+            doTest("idea/testData/quickfix/override/beforeOverridingFinalJavaMethod.kt");
+        }
+        
+        @TestMetadata("beforeOverridingFinalMethod.kt")
+        public void testOverridingFinalMethod() throws Exception {
+            doTest("idea/testData/quickfix/override/beforeOverridingFinalMethod.kt");
+        }
+        
+        @TestMetadata("beforeOverridingFinalProperty.kt")
+        public void testOverridingFinalProperty() throws Exception {
+            doTest("idea/testData/quickfix/override/beforeOverridingFinalProperty.kt");
+        }
+        
         @TestMetadata("beforeParameterNameChangedAmbiguousRename.kt")
         public void testParameterNameChangedAmbiguousRename() throws Exception {
             doTest("idea/testData/quickfix/override/beforeParameterNameChangedAmbiguousRename.kt");


### PR DESCRIPTION
Previous attempt: https://github.com/JetBrains/kotlin/pull/213

I liked suggestion about reusing diagnostic rather than invoking resolution (and probably I will make use of it when implementing other quickfixes), but here I decided to stay with resolution as diagnostic carries information only about one overridden member while I need all of them (or maybe I missed something).
