### PR TITLE
KT-3370 Formatter doesn't remove redundant spaces between modifiers, name, and opening brace

### DIFF
--- a/idea/src/org/jetbrains/jet/plugin/formatter/JetFormattingModelBuilder.java
+++ b/idea/src/org/jetbrains/jet/plugin/formatter/JetFormattingModelBuilder.java
@@ -76,6 +76,7 @@ public class JetFormattingModelBuilder implements FormattingModelBuilder {
                 .around(RANGE).spaceIf(jetSettings.SPACE_AROUND_RANGE)
 
                 .beforeInside(BLOCK, FUN).spaceIf(jetCommonSettings.SPACE_BEFORE_METHOD_LBRACE)
+                .beforeInside(CLASS_BODY, CLASS).spaceIf(jetCommonSettings.SPACE_BEFORE_CLASS_LBRACE)
 
                 .afterInside(LPAR, VALUE_PARAMETER_LIST).spaces(0)
                 .beforeInside(RPAR, VALUE_PARAMETER_LIST).spaces(0)
@@ -103,6 +104,10 @@ public class JetFormattingModelBuilder implements FormattingModelBuilder {
                 .beforeInside(COLON, TYPE_PARAMETER).spaceIf(jetSettings.SPACE_BEFORE_EXTEND_COLON)
                 .afterInside(COLON, TYPE_PARAMETER).spaceIf(jetSettings.SPACE_AFTER_EXTEND_COLON)
 
+                .after(ANNOTATION_ENTRY).spaces(1)
+                .after(MODIFIER_LIST).spaces(1)
+                .afterInside(MODIFIER_KEYWORDS, MODIFIER_LIST).spaces(1)
+                .between(CLASS_KEYWORD, IDENTIFIER).spaces(1)
                 .between(VALUE_ARGUMENT_LIST, FUNCTION_LITERAL_EXPRESSION).spaces(1)
                 .aroundInside(ARROW, WHEN_ENTRY).spaces(1)
                 ;

--- a/idea/testData/formatter/Class.kt
+++ b/idea/testData/formatter/Class.kt
@@ -1,3 +1,3 @@
-class Some() {
+class   Some()   {
 val a : Int
 }

--- a/idea/testData/formatter/Modifiers.kt
+++ b/idea/testData/formatter/Modifiers.kt
@@ -1,0 +1,4 @@
+private   data   class   Foo {
+public   open   func () {
+}
+}

--- a/idea/testData/formatter/Modifiers_after.kt
+++ b/idea/testData/formatter/Modifiers_after.kt
@@ -1,0 +1,4 @@
+private data class Foo {
+    public open func () {
+    }
+}

--- a/idea/tests/org/jetbrains/jet/formatter/JetFormatterTest.java
+++ b/idea/tests/org/jetbrains/jet/formatter/JetFormatterTest.java
@@ -72,6 +72,10 @@ public class JetFormatterTest extends AbstractJetFormatterTest {
         doTest();
     }
 
+    public void testModifiers() throws Exception {
+        doTest();
+    }
+
     public void testMultilineFunctionLiteral() throws Exception {
         doTest();
     }


### PR DESCRIPTION
# KT-3370 fixed
