### PR TITLE
Fix missing Kotlin tests

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt
@@ -64,10 +64,7 @@ open class KotlinPlugin: Plugin<Project> {
                     javaBasePlugin.configureForSourceSet(sourceSet, kotlinTask)
                     // store kotlin classes in separate directory. They will serve as class-path to java compiler
                     val kotlinOutputDir = File(project.getBuildDir(), "kotlin-classes/${sourceSetName}")
-                    // builtBy allows to correctly run kotlinTask as a transitive dependency on anything,
-                    // that wants to use sourceSet output (e.g., 'jar' task
-                    sourceSet.getOutput()?.dir(mapOf(Pair("builtBy", kotlinTask)), kotlinOutputDir)
-                    kotlinTask.setDestinationDir(kotlinOutputDir);
+                    kotlinTask.kotlinDestinationDir = kotlinOutputDir;
 
                     kotlinTask.setDescription("Compiles the $sourceSet.kotlin.")
                     kotlinTask.source(kotlinDirSet)
@@ -76,7 +73,7 @@ open class KotlinPlugin: Plugin<Project> {
 
                     if (javaTask != null) {
                         javaTask.dependsOn(kotlinTaskName)
-                        val javacClassPath = javaTask.getClasspath() + project.files(kotlinTask.getDestinationDir());
+                        val javacClassPath = javaTask.getClasspath() + project.files(kotlinTask.kotlinDestinationDir);
                         javaTask.setClasspath(javacClassPath)
                     }
                 }

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/Tasks.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/Tasks.kt
@@ -23,6 +23,7 @@ import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.apache.commons.lang.StringUtils
 import org.gradle.api.initialization.dsl.ScriptHandler
+import org.apache.commons.io.FileUtils
 
 public open class KotlinCompile(): AbstractCompile() {
 
@@ -31,6 +32,8 @@ public open class KotlinCompile(): AbstractCompile() {
     val logger = Logging.getLogger(getClass())
 
     public val kotlinOptions: K2JVMCompilerArguments = K2JVMCompilerArguments();
+
+    public var kotlinDestinationDir : File? = getDestinationDir()
 
     // override setSource to track source directory sets
     override fun setSource(source: Any?) {
@@ -98,7 +101,7 @@ public open class KotlinCompile(): AbstractCompile() {
             args.setClasspath(effectiveClassPath)
         }
 
-        args.outputDir = if (StringUtils.isEmpty(kotlinOptions.outputDir)) { getDestinationDir()?.getPath() } else { kotlinOptions.outputDir }
+        args.outputDir = if (StringUtils.isEmpty(kotlinOptions.outputDir)) { kotlinDestinationDir?.getPath() } else { kotlinOptions.outputDir }
 
         val embeddedAnnotations = getAnnotations()
         val userAnnotations = (kotlinOptions.annotations ?: "").split(File.pathSeparatorChar).toList()
@@ -116,6 +119,9 @@ public open class KotlinCompile(): AbstractCompile() {
             ExitCode.INTERNAL_ERROR -> throw GradleException("Internal compiler error. See log for more details")
             else -> {}
         }
+
+        // Copy kotlin classes to all classes directory
+        FileUtils.copyDirectory(kotlinDestinationDir, getDestinationDir())
     }
 
     fun getAnnotations(): File {

--- a/libraries/tools/kotlin-gradle-plugin/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinGradlePluginIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinGradlePluginIT.kt
@@ -58,6 +58,7 @@ class BasicKotlinGradleIT {
         assertTrue(buildOutput.contains(":compileKotlin"), "Should contain ':compileKotlin'")
         assertTrue(buildOutput.contains(":compileTestKotlin"), "Should contain ':compileTestKotlin'")
         assertTrue(buildOutput.contains(":compileDeployKotlin"), "Should contain ':compileDeployKotlin'")
+        assertTrue(File(projectDir, "build/reports/tests/demo.TestSource.html").exists(), "Test report does not exist. Were tests executed?")
 
         // Run the build second time, assert everything is up-to-date
 

--- a/libraries/tools/kotlin-gradle-plugin/src/test/resources/testProject/alfa/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin/src/test/resources/testProject/alfa/build.gradle
@@ -25,6 +25,11 @@ dependencies {
     compile 'com.google.guava:guava:12.0'
     deployCompile 'com.google.guava:guava:12.0'
     testCompile  'org.testng:testng:6.8'
+    testRuntime  'org.jetbrains.kotlin:kotlin-stdlib:0.1-SNAPSHOT'
+}
+
+test {
+    useTestNG()
 }
 
 task show << {


### PR DESCRIPTION
Fix for http://youtrack.jetbrains.com/issue/KT-3490
Compile kotlin classes to separate dir, then copy to classes directory. Separate copy is used as an input for javac. This also allows mixed java-kotlin tests execution out of the box
