### PR TITLE
Fix test

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/test/resources/testProject/alfa/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin/src/test/resources/testProject/alfa/build.gradle
@@ -17,7 +17,9 @@ sourceSets {
 }
 
 repositories {
-  mavenLocal()
+  maven {
+     url 'file://' + pathToKotlinPlugin
+  }
   mavenCentral()
 }
 


### PR DESCRIPTION
Fix test. Avoid using Maven local repository in integration test, because test's parent Maven process can have some tricky settings, that are not propagated down to the test project.
