### PR TITLE
KT-3575 Extra "}" inserted when typing "${" before "]" or ")" in string constant

### DIFF
--- a/idea/src/org/jetbrains/jet/plugin/JetPairMatcher.java
+++ b/idea/src/org/jetbrains/jet/plugin/JetPairMatcher.java
@@ -39,7 +39,8 @@ public class JetPairMatcher implements PairedBraceMatcher {
 
     @Override
     public boolean isPairedBracesAllowedBeforeType(@NotNull IElementType lbraceType, @Nullable IElementType contextType) {
-        return JetTokens.WHITE_SPACE_OR_COMMENT_BIT_SET.contains(contextType)
+        return  lbraceType.equals(JetTokens.LONG_TEMPLATE_ENTRY_START)
+                || JetTokens.WHITE_SPACE_OR_COMMENT_BIT_SET.contains(contextType)
                 || contextType == JetTokens.SEMICOLON
                 || contextType == JetTokens.COMMA
                 || contextType == JetTokens.RPAR

--- a/idea/src/org/jetbrains/jet/plugin/editor/KotlinTypedHandler.java
+++ b/idea/src/org/jetbrains/jet/plugin/editor/KotlinTypedHandler.java
@@ -57,20 +57,6 @@ public class KotlinTypedHandler extends TypedHandlerDelegate {
             JetLtGtTypingUtils.handleJetAutoCloseLT(editor);
             return Result.STOP;
         }
-
-        if (!(file instanceof JetFile) || !CodeInsightSettings.getInstance().AUTOINSERT_PAIR_BRACKET) {
-            return Result.CONTINUE;
-        }
-        if (c == '{') {
-            PsiDocumentManager.getInstance(project).commitAllDocuments();
-            int offset = editor.getCaretModel().getOffset();
-            PsiElement previousElement = file.findElementAt(offset - 1);
-            if (previousElement instanceof LeafPsiElement
-                    && ((LeafPsiElement) previousElement).getElementType() == JetTokens.LONG_TEMPLATE_ENTRY_START) {
-                editor.getDocument().insertString(offset, "}");
-            }
-            return Result.STOP;
-        }
         return Result.CONTINUE;
     }
 }

--- a/idea/tests/org/jetbrains/jet/editor/TypedHandlerTest.java
+++ b/idea/tests/org/jetbrains/jet/editor/TypedHandlerTest.java
@@ -26,6 +26,12 @@ public class TypedHandlerTest extends LightCodeInsightTestCase {
         checkResultByText("val x = \"${}\"");
     }
 
+    public void testKT3575() throws Exception {
+        configureFromFileText("a.kt", "val x = \"$<caret>]\"");
+        EditorTestUtil.performTypingAction(getEditor(), '{');
+        checkResultByText("val x = \"${}]\"");
+    }
+
     public void testTypeLtInFunDeclaration() throws Exception {
         doLtGtTest("fun <caret>");
     }


### PR DESCRIPTION
The problem in fact that the bracket was inserted by JetPairMatcher _and_ KotlinTypeHandler (if cursor before "]" or ")").

Using only JetPairMatcher instead of KotlinTypeHandler fixes problem.
