### PR TITLE
Added scanning for annotations.xml entries within maven dependencies

### DIFF
--- a/libraries/tools/kotlin-maven-plugin/pom.xml
+++ b/libraries/tools/kotlin-maven-plugin/pom.xml
@@ -20,7 +20,12 @@
     <packaging>maven-plugin</packaging>
 
     <dependencies>
-        <dependency>
+      <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>${maven.version}</version>
+      </dependency>
+      <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
             <version>${maven.version}</version>


### PR DESCRIPTION
This patch provides scanning for annotations.xml files within the resolved dependencies for projects using the kotlin-maven-plugin, to avoid the need to explicitly list the paths for external annotations, and to allow third party libraries to package their own annotations.

This is tracked in http://youtrack.jetbrains.com/issue/KT-2765 (be able to discover annotations.xml files on the classpath from the maven plugin).
