### PR TITLE
Support for generic classes in quickfix for NOTHING_TO_OVERRIDE

### DIFF
--- a/compiler/frontend/src/org/jetbrains/jet/lang/descriptors/ValueParameterDescriptor.java
+++ b/compiler/frontend/src/org/jetbrains/jet/lang/descriptors/ValueParameterDescriptor.java
@@ -19,6 +19,7 @@ package org.jetbrains.jet.lang.descriptors;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.jet.lang.descriptors.annotations.Annotated;
+import org.jetbrains.jet.lang.resolve.name.Name;
 import org.jetbrains.jet.lang.types.JetType;
 
 import java.util.Set;
@@ -57,7 +58,7 @@ public interface ValueParameterDescriptor extends VariableDescriptor, Annotated 
     ValueParameterDescriptor getOriginal();
 
     @NotNull
-    ValueParameterDescriptor copy(DeclarationDescriptor newOwner);
+    ValueParameterDescriptor copy(DeclarationDescriptor newOwner, Name newName);
 
     /**
      * Parameter p1 overrides p2 iff

--- a/compiler/frontend/src/org/jetbrains/jet/lang/descriptors/impl/ValueParameterDescriptorImpl.java
+++ b/compiler/frontend/src/org/jetbrains/jet/lang/descriptors/impl/ValueParameterDescriptorImpl.java
@@ -111,6 +111,7 @@ public class ValueParameterDescriptorImpl extends VariableDescriptorImpl impleme
     }
 
     @Nullable
+    @Override
     public JetType getVarargElementType() {
         return varargElementType;
     }
@@ -139,8 +140,8 @@ public class ValueParameterDescriptorImpl extends VariableDescriptorImpl impleme
 
     @NotNull
     @Override
-    public ValueParameterDescriptor copy(@NotNull DeclarationDescriptor newOwner) {
-        return new ValueParameterDescriptorImpl(newOwner, index, Lists.newArrayList(getAnnotations()), getName(), getType(), hasDefaultValue, varargElementType);
+    public ValueParameterDescriptor copy(@NotNull DeclarationDescriptor newOwner, @NotNull Name newName) {
+        return new ValueParameterDescriptorImpl(newOwner, index, Lists.newArrayList(getAnnotations()), newName, getType(), declaresDefaultValue(), varargElementType);
     }
 
     @NotNull

--- a/idea/testData/quickfix/override/nothingToOverride/afterAddParameterGenericClass.kt
+++ b/idea/testData/quickfix/override/nothingToOverride/afterAddParameterGenericClass.kt
@@ -1,0 +1,8 @@
+// "Change function signature to 'override fun f(a: Int, x: T)'" "true"
+trait A<R> {
+    fun f(a: Int, b: R)
+}
+
+class B<T> : A<T> {
+    <caret>override fun f(a: Int, x: T) {}
+}

--- a/idea/testData/quickfix/override/nothingToOverride/afterSwapParametersGenericClass.kt
+++ b/idea/testData/quickfix/override/nothingToOverride/afterSwapParametersGenericClass.kt
@@ -1,0 +1,8 @@
+// "Change function signature to 'override fun f(y: S, x: List<Set<R>>)'" "true"
+trait A<P,Q> {
+    fun f(a: Q, b: List<Set<P>>)
+}
+
+class B<R,S> : A<R,S> {
+    <caret>override fun f(y: S, x: List<Set<R>>) {}
+}

--- a/idea/testData/quickfix/override/nothingToOverride/beforeAddParameterGenericClass.kt
+++ b/idea/testData/quickfix/override/nothingToOverride/beforeAddParameterGenericClass.kt
@@ -1,0 +1,8 @@
+// "Change function signature to 'override fun f(a: Int, x: T)'" "true"
+trait A<R> {
+    fun f(a: Int, b: R)
+}
+
+class B<T> : A<T> {
+    <caret>override fun f(x: T) {}
+}

--- a/idea/testData/quickfix/override/nothingToOverride/beforeSwapParametersGenericClass.kt
+++ b/idea/testData/quickfix/override/nothingToOverride/beforeSwapParametersGenericClass.kt
@@ -1,0 +1,8 @@
+// "Change function signature to 'override fun f(y: S, x: List<Set<R>>)'" "true"
+trait A<P,Q> {
+    fun f(a: Q, b: List<Set<P>>)
+}
+
+class B<R,S> : A<R,S> {
+    <caret>override fun f(x: List<Set<R>>, y: S) {}
+}

--- a/idea/tests/org/jetbrains/jet/plugin/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/jet/plugin/quickfix/QuickFixTestGenerated.java
@@ -871,6 +871,11 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
                 doTest("idea/testData/quickfix/override/nothingToOverride/beforeAddParameter.kt");
             }
             
+            @TestMetadata("beforeAddParameterGenericClass.kt")
+            public void testAddParameterGenericClass() throws Exception {
+                doTest("idea/testData/quickfix/override/nothingToOverride/beforeAddParameterGenericClass.kt");
+            }
+            
             @TestMetadata("beforeAddParameterMultiple.kt")
             public void testAddParameterMultiple() throws Exception {
                 doTest("idea/testData/quickfix/override/nothingToOverride/beforeAddParameterMultiple.kt");
@@ -963,6 +968,11 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
             @TestMetadata("beforeRemoveParameterTwoTraits.kt")
             public void testRemoveParameterTwoTraits() throws Exception {
                 doTest("idea/testData/quickfix/override/nothingToOverride/beforeRemoveParameterTwoTraits.kt");
+            }
+            
+            @TestMetadata("beforeSwapParametersGenericClass.kt")
+            public void testSwapParametersGenericClass() throws Exception {
+                doTest("idea/testData/quickfix/override/nothingToOverride/beforeSwapParametersGenericClass.kt");
             }
             
         }


### PR DESCRIPTION
This fixes some of the issues mentioned by @abreslav in https://github.com/JetBrains/kotlin/pull/262.
The things that are still missing:
- Changing the call sites 
- Support for generic functions
