### PR TITLE
fix null pointer while looking for super klass match

### DIFF
--- a/js/js.translator/testFiles/kotlin_lib_ecma3.js
+++ b/js/js.translator/testFiles/kotlin_lib_ecma3.js
@@ -63,13 +63,13 @@ var Kotlin = {};
     }
 
     Kotlin.isType = function (object, klass) {
-        if (object === null || object === undefined) {
+        if (object == null) {
             return false;
         }
 
         var current = object.get_class();
         while (current !== klass) {
-            if (current === null || current === undefined) {
+            if (current == null) {
                 return false;
             }
             current = current.superclass;


### PR DESCRIPTION
additional protection for Kotlin isType method to avoid bad call on undefined super klass.
