### PR TITLE
KT-3893 Fix

### DIFF
--- a/compiler/frontend/builtins/jet/Arrays.jet
+++ b/compiler/frontend/builtins/jet/Arrays.jet
@@ -1,6 +1,6 @@
 package jet
 
-public fun arrayOfNulls<T>(public size : Int) : Array<T?>
+public fun arrayOfNulls<T>(size : Int) : Array<T?>
 
 public class Array<reified T>(public val size : Int, init : (Int) -> T) {
   public fun get(index : Int) : T

--- a/compiler/frontend/src/org/jetbrains/jet/lang/resolve/DescriptorResolver.java
+++ b/compiler/frontend/src/org/jetbrains/jet/lang/resolve/DescriptorResolver.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.util.PsiTreeUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -486,6 +487,9 @@ public class DescriptorResolver {
 
             if (!(functionDescriptor instanceof ConstructorDescriptor)) {
                 checkParameterHasNoValOrVar(trace, valueParameter, VAL_OR_VAR_ON_FUN_PARAMETER);
+                checkParameterHasNoModifier(trace, valueParameter);
+            } else {
+                checkConstructorParameterHasNoModifier(trace, valueParameter);
             }
 
             ValueParameterDescriptor valueParameterDescriptor =
@@ -1562,6 +1566,35 @@ public class DescriptorResolver {
         ASTNode valOrVarNode = parameter.getValOrVarNode();
         if (valOrVarNode != null) {
             trace.report(diagnosticFactory.on(valOrVarNode.getPsi(), ((JetKeywordToken) valOrVarNode.getElementType())));
+        }
+    }
+
+    private static void checkConstructorParameterHasNoModifier(
+            @NotNull BindingTrace trace,
+            @NotNull JetParameter parameter
+    ) {
+        // If is not a property, then it must have no modifier
+        if (parameter.getValOrVarNode() == null) {
+            checkParameterHasNoModifier(trace, parameter);
+        }
+    }
+
+    public static void checkParameterHasNoModifier(
+            @NotNull BindingTrace trace,
+            @NotNull JetParameter parameter
+    ) {
+        JetModifierList modifiers = parameter.getModifierList();
+        if (modifiers != null) {
+            ASTNode node = modifiers.getNode().getFirstChildNode();
+
+            while (node != null) {
+                IElementType elementType = node.getElementType();
+
+                if (elementType != JetTokens.VARARG_KEYWORD && elementType instanceof JetKeywordToken) {
+                    trace.report(ILLEGAL_MODIFIER.on(node.getPsi(), (JetKeywordToken) elementType));
+                }
+                node = node.getTreeNext();
+            }
         }
     }
 }

--- a/compiler/frontend/src/org/jetbrains/jet/lang/types/expressions/ControlStructureTypingVisitor.java
+++ b/compiler/frontend/src/org/jetbrains/jet/lang/types/expressions/ControlStructureTypingVisitor.java
@@ -433,6 +433,7 @@ public class ControlStructureTypingVisitor extends ExpressionTypingVisitor {
             JetExpression catchBody = catchClause.getCatchBody();
             if (catchParameter != null) {
                 DescriptorResolver.checkParameterHasNoValOrVar(context.trace, catchParameter, VAL_OR_VAR_ON_CATCH_PARAMETER);
+                DescriptorResolver.checkParameterHasNoModifier(context.trace, catchParameter);
 
                 VariableDescriptor variableDescriptor = context.expressionTypingServices.getDescriptorResolver().resolveLocalVariableDescriptor(
                         context.scope, catchParameter, context.trace);

--- a/compiler/testData/diagnostics/tests/IllegalModifiers.kt
+++ b/compiler/testData/diagnostics/tests/IllegalModifiers.kt
@@ -22,3 +22,47 @@ class FinalClass() {
 
 <!INCOMPATIBLE_MODIFIERS!>private<!> <!INCOMPATIBLE_MODIFIERS!>public<!> class C
 <!INCOMPATIBLE_MODIFIERS!>private<!> <!INCOMPATIBLE_MODIFIERS!>public<!> object D
+
+//A sample annotation to check annotation usage in parameters.
+annotation class annotated(val text: String = "not given")
+
+//Check legal modifiers in constructor
+class LegalModifier(val a: Int, annotated private var b: String, annotated vararg v: Int)
+
+//Check illegal modifier in constructor parameters
+class IllegalModifiers1(<!ILLEGAL_MODIFIER!>private<!> a: Int)
+
+//Check multiple illegal modifiers in constructor
+class IllegalModifiers2(<!ILLEGAL_MODIFIER!>private<!> <!ILLEGAL_MODIFIER!>abstract<!> a: Int)
+
+
+//Check annotations with illegal modifiers in constructor
+class IllegalModifiers3(annotated <!ILLEGAL_MODIFIER!>public<!> <!ILLEGAL_MODIFIER!>abstract<!> b: String)
+
+//Check annotations and vararg with illegal modifiers in constructor
+class IllegalModifiers4(val a: Int, annotated("a text") <!ILLEGAL_MODIFIER!>protected<!> vararg v: Int)
+
+//Check illegal modifiers for functions and catch block
+abstract class IllegalModifiers5() {
+
+  //Check illegal modifier in function parameter
+  abstract fun foo(<!ILLEGAL_MODIFIER!>public<!> a: Int, vararg v: String)
+
+  //Check multiple illegal modifiers in function parameter
+  abstract fun bar(<!ILLEGAL_MODIFIER!>public<!> <!ILLEGAL_MODIFIER!>abstract<!> a: Int, vararg v: String)
+
+  //Check annotations with illegal modifiers
+  abstract fun baz(annotated("a text") <!ILLEGAL_MODIFIER!>public<!> <!ILLEGAL_MODIFIER!>abstract<!> a: Int)
+
+  private fun qux() {
+
+    //Check illegal modifier in catch block
+    try {} catch (<!ILLEGAL_MODIFIER!>public<!> e: Exception) {}
+
+    //Check multiple illegal modifiers in catch block
+    try {} catch (<!ILLEGAL_MODIFIER!>abstract<!> <!ILLEGAL_MODIFIER!>public<!> e: Exception) {}
+
+    //Check annotations with illegal modifiers
+    try {} catch (annotated("a text") <!ILLEGAL_MODIFIER!>abstract<!> <!ILLEGAL_MODIFIER!>public<!> e: Exception) {}
+  }
+}

--- a/libraries/tools/kdoc/src/main/kotlin/org/jetbrains/kotlin/doc/KDoc.kt
+++ b/libraries/tools/kdoc/src/main/kotlin/org/jetbrains/kotlin/doc/KDoc.kt
@@ -5,7 +5,7 @@ import org.jetbrains.kotlin.doc.highlighter2.Html2CompilerPlugin
 import org.jetbrains.kotlin.doc.model.*
 
 /** Generates the Kotlin Documentation for the model */
-class KDoc(protected arguments: KDocArguments) : KModelCompilerPlugin(arguments) {
+class KDoc(arguments: KDocArguments) : KModelCompilerPlugin(arguments) {
 
     protected override fun processModel(model: KModel) {
         val outputDir = File(arguments.apply().docOutputDir)


### PR DESCRIPTION
- Added checking for 'vararg'
- removed existing illegal modifiers in the sources
- moved unit tests to JetDiagnosticsTest
- Added modifier check for parameters in constructors.
- Added modifier check for parameters in functions.
- Added modifier check for parameters in try/catch
