### PR TITLE
Fix std lib generators: allow executing from command line.

### DIFF
--- a/libraries/stdlib/ReadMe.md
+++ b/libraries/stdlib/ReadMe.md
@@ -8,7 +8,7 @@ We use some code generation to apply the various collection-like methods to vari
 
 To run the code generator from a kotlin checkout
 
-    cd libraries/stdlib
-    mvn test-compile exec:java
+    cd libraries/tools/kotlin-stdlib-gen
+    mvn compile exec:java
 
-This then runs the [GenerateStandardLib.kt](https://github.com/JetBrains/kotlin/blob/master/libraries/stdlib/test/org/jetbrains/kotlin/tools/GenerateStandardLib.kt) script to create the source from the files for java.lang.Iterable<T> and java.util.Collection etc.
+This then runs the [GenerateStandardLib.kt](https://github.com/JetBrains/kotlin/blob/master/libraries/tools/kotlin-stdlib-gen/src/generators/GenerateStandardLib.kt) script to create the source from the files for java.lang.Iterable<T> and java.util.Collection etc.

--- a/libraries/stdlib/pom.xml
+++ b/libraries/stdlib/pom.xml
@@ -26,24 +26,7 @@
         <testSourceDirectory>test</testSourceDirectory>
 
         <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>${exec-maven-plugin.version}</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>java</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <mainClass>org.jetbrains.kotlin.tools.ToolsPackage</mainClass>
-                    <classpathScope>test</classpathScope>
-                </configuration>
-            </plugin>
-
-            <plugin>
+             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <version>${project.version}</version>

--- a/libraries/tools/kotlin-stdlib-gen/pom.xml
+++ b/libraries/tools/kotlin-stdlib-gen/pom.xml
@@ -26,11 +26,46 @@
     </dependencies>
 
     <build>
+        <sourceDirectory>src</sourceDirectory>
         <plugins>
             <plugin>
                 <artifactId>maven-deploy-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${project.version}</version>
+
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>${exec-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <mainClass>generators.GeneratorsPackage</mainClass>
+                    <classpathScope>compile</classpathScope>
+                    <arguments>
+                        <argument>${project.parent.basedir}/..</argument>
+                    </arguments>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Fix for the issue reported in forum: http://devnet.jetbrains.com/message/5499373#5499373

Compile and execute moved generators from command line using maven
