### PR TITLE
#KT-2341 Fixed

### DIFF
--- a/libraries/stdlib/src/kotlin/JUtil.kt
+++ b/libraries/stdlib/src/kotlin/JUtil.kt
@@ -90,7 +90,7 @@ val <T> List<T>.lastIndex : Int
  * @includeFunctionBody ../../test/ListTest.kt head
  */
 val <T> List<T>.head : T?
-    get() = this.get(0)
+    get() = if (this.isNotEmpty()) this.get(0) else null
 
 /**
  * Returns all elements in this collection apart from the first one

--- a/libraries/stdlib/test/ListTest.kt
+++ b/libraries/stdlib/test/ListTest.kt
@@ -11,6 +11,11 @@ class ListTest {
         assertEquals("[foo, bar]", data.toString())
     }
 
+    test fun emptyHead() {
+        val data = ArrayList<String>()
+        assertNull(data.head)
+    }
+
     test fun head() {
         val data = arrayList("foo", "bar")
         assertEquals("foo", data.head)
@@ -21,6 +26,11 @@ class ListTest {
         val actual = data.tail
         val expected = arrayList("bar", "whatnot")
         assertEquals(expected, actual)
+    }
+
+    test fun emptyFirst() {
+        val data  = ArrayList<String>()
+        assertNull(data.first)
     }
 
     test fun first() {


### PR DESCRIPTION
Fixed KT-2341 according to issue description i.e. `first` and `head` now return `null` if the list is empty.

If another design of the API is anticipated (as some commenters suggested) please close the issue and create a new one.
