### PR TITLE
add Readme to kotlin-stdlib-gen explaining how to run code generation

### DIFF
--- a/libraries/tools/kotlin-stdlib-gen/ReadMe.md
+++ b/libraries/tools/kotlin-stdlib-gen/ReadMe.md
@@ -1,0 +1,11 @@
+## Code Generation for Standard Library
+
+Some of the code in the standard library is created by code generation based on templates.
+For example, many Array methods need to be implemented separately for Array<T>, ByteArray, ShortArray, IntArray, etc.
+
+To run the code generator from a kotlin checkout
+
+    cd libraries/tools/kotlin-stdlib-gen
+    mvn compile exec:java
+
+This then runs the [GenerateStandardLib.kt](https://github.com/JetBrains/kotlin/blob/master/libraries/tools/kotlin-stdlib-gen/src/generators/GenerateStandardLib.kt) script to create the source from the files for java.lang.Iterable<T> and java.util.Collection etc.


### PR DESCRIPTION
As an outside contributor I originally had trouble figuring out how to run the code generator [see forum post](http://devnet.jetbrains.com/thread/451790?tstart=0).

I think this is because the ReadMe file that explains how to do so is located in libraries/stdlib, not in libraries/tools/kotlin-stdlib-gen

So I added a modified version of the ReadMe to kotlin-stdlib-gen
