### PR TITLE
A small confusing typo

### DIFF
--- a/compiler/frontend/src/org/jetbrains/jet/lang/diagnostics/rendering/DefaultErrorMessages.java
+++ b/compiler/frontend/src/org/jetbrains/jet/lang/diagnostics/rendering/DefaultErrorMessages.java
@@ -97,7 +97,7 @@ public class DefaultErrorMessages {
         MAP.put(PLATFORM_CLASS_MAPPED_TO_KOTLIN, "This class shouldn''t be used in Kotlin. Use {0} instead.", CLASSES_OR_SEPARATED);
 
         MAP.put(CANNOT_INFER_PARAMETER_TYPE,
-                "Cannot infer a type for this parameter. To specify it explicitly use the {(p : Type) => ...} notation");
+                "Cannot infer a type for this parameter. To specify it explicitly use the {(p : Type) -> ...} notation");
 
         MAP.put(NO_BACKING_FIELD_ABSTRACT_PROPERTY, "This property doesn't have a backing field, because it's abstract");
         MAP.put(NO_BACKING_FIELD_CUSTOM_ACCESSORS,


### PR DESCRIPTION
Here was an out-of-date error message. It could confuse developers about the function literal syntax.

"To specify it explicitly use the {(p : Type) => ...} notation"
