### PR TITLE
Do not annotate bare type parameters as @Nullable

### DIFF
--- a/compiler/testData/asJava/nullabilityAnnotations/Generic.java
+++ b/compiler/testData/asJava/nullabilityAnnotations/Generic.java
@@ -1,0 +1,6 @@
+public interface Generic <N, NN>  extends jet.JetObject {
+    N a(@jet.runtime.typeinfo.JetValueParameter(name = "n") N n);
+
+    @org.jetbrains.annotations.NotNull
+    NN b(@org.jetbrains.annotations.NotNull @jet.runtime.typeinfo.JetValueParameter(name = "nn") NN nn);
+}

--- a/compiler/testData/asJava/nullabilityAnnotations/Generic.kt
+++ b/compiler/testData/asJava/nullabilityAnnotations/Generic.kt
@@ -1,0 +1,4 @@
+trait Generic<N, NN: Any> {
+    fun a(n: N): N
+    fun b(nn: NN): NN
+}

--- a/compiler/tests/org/jetbrains/jet/asJava/NullabilityAnnotationsTest.java
+++ b/compiler/tests/org/jetbrains/jet/asJava/NullabilityAnnotationsTest.java
@@ -86,6 +86,10 @@ public class NullabilityAnnotationsTest extends KotlinAsJavaTestBase {
         doTest(getTestName(false));
     }
 
+    public void testGeneric() throws Exception {
+        doTest(getTestName(false));
+    }
+
     private void doTest(@NotNull String fqName) {
         PsiClass psiClass = finder.findClass(fqName, GlobalSearchScope.allScope(getProject()));
         if (!(psiClass instanceof KotlinLightClass)) {


### PR DESCRIPTION
This is to account for the case of, say

```
 class Function<R> { fun invoke(): R }
```

it would be a shame to put @Nullable on the return type of the function, and force all callers to check for null,
so we put no annotations
