### PR TITLE
Fix to a bug in the intention to move lambda expressions inside parentheses

### DIFF
--- a/idea/src/org/jetbrains/jet/plugin/intentions/MoveLambdaInsideParenthesesIntention.kt
+++ b/idea/src/org/jetbrains/jet/plugin/intentions/MoveLambdaInsideParenthesesIntention.kt
@@ -29,8 +29,10 @@ public class MoveLambdaInsideParenthesesIntention : JetSelfTargetingIntention<Je
     override fun isApplicableTo(element: JetCallExpression): Boolean = !element.getFunctionLiteralArguments().isEmpty()
 
     override fun applyTo(element: JetCallExpression, editor: Editor) {
-        val funName = element.getCalleeExpression()?.getText()
-        if (funName == null) return
+        val typeArgs = element.getTypeArgumentList()?.getText()
+        val exprText = element.getCalleeExpression()?.getText()
+        if (exprText == null) return
+        val funName = if (!element.getTypeArguments().isEmpty() && typeArgs != null) "$exprText$typeArgs" else "$exprText"
         val sb = StringBuilder()
         sb.append("(")
         for (value in element.getValueArguments()) {

--- a/idea/testData/intentions/moveLambdaInsideParentheses/moveLambda10.kt
+++ b/idea/testData/intentions/moveLambdaInsideParentheses/moveLambda10.kt
@@ -1,0 +1,8 @@
+// IS_APPLICABLE: true
+fun foo() {
+    bar<String>("x") <caret>{ it }
+}
+
+fun bar<T>(t:T, a: Int->Int) : Int {
+    return a(1)
+}

--- a/idea/testData/intentions/moveLambdaInsideParentheses/moveLambda10.kt.after
+++ b/idea/testData/intentions/moveLambdaInsideParentheses/moveLambda10.kt.after
@@ -1,0 +1,8 @@
+// IS_APPLICABLE: true
+fun foo() {
+    bar<String>("x", { it })
+}
+
+fun bar<T>(t:T, a: Int->Int) : Int {
+    return a(1)
+}

--- a/idea/testData/intentions/moveLambdaInsideParentheses/moveLambda11.kt
+++ b/idea/testData/intentions/moveLambdaInsideParentheses/moveLambda11.kt
@@ -1,0 +1,8 @@
+// IS_APPLICABLE: true
+fun foo() {
+    bar<String> <caret>{ it }
+}
+
+fun bar<T>(a: (Int)->T): T {
+    return a(1)
+}

--- a/idea/testData/intentions/moveLambdaInsideParentheses/moveLambda11.kt.after
+++ b/idea/testData/intentions/moveLambdaInsideParentheses/moveLambda11.kt.after
@@ -1,0 +1,8 @@
+// IS_APPLICABLE: true
+fun foo() {
+    bar<String>({ it })
+}
+
+fun bar<T>(a: (Int)->T): T {
+    return a(1)
+}

--- a/idea/testData/intentions/moveLambdaInsideParentheses/moveLambda12.kt
+++ b/idea/testData/intentions/moveLambdaInsideParentheses/moveLambda12.kt
@@ -1,0 +1,8 @@
+// IS_APPLICABLE: true
+fun foo() {
+    bar<String, Int, Int>("x", 1, 2) <caret>{ it }
+}
+
+fun bar<T, V, K>(t: T, v: V, k: K, a: (Int)->Int): Int {
+    return a(1)
+}

--- a/idea/testData/intentions/moveLambdaInsideParentheses/moveLambda12.kt.after
+++ b/idea/testData/intentions/moveLambdaInsideParentheses/moveLambda12.kt.after
@@ -1,0 +1,8 @@
+// IS_APPLICABLE: true
+fun foo() {
+    bar<String, Int, Int>("x", 1, 2, { it })
+}
+
+fun bar<T, V, K>(t: T, v: V, k: K, a: (Int)->Int): Int {
+    return a(1)
+}

--- a/idea/tests/org/jetbrains/jet/plugin/intentions/CodeTransformationTestGenerated.java
+++ b/idea/tests/org/jetbrains/jet/plugin/intentions/CodeTransformationTestGenerated.java
@@ -1383,6 +1383,21 @@ public class CodeTransformationTestGenerated extends AbstractCodeTransformationT
             doTestMoveLambdaInsideParentheses("idea/testData/intentions/moveLambdaInsideParentheses/moveLambda1.kt");
         }
         
+        @TestMetadata("moveLambda10.kt")
+        public void testMoveLambda10() throws Exception {
+            doTestMoveLambdaInsideParentheses("idea/testData/intentions/moveLambdaInsideParentheses/moveLambda10.kt");
+        }
+        
+        @TestMetadata("moveLambda11.kt")
+        public void testMoveLambda11() throws Exception {
+            doTestMoveLambdaInsideParentheses("idea/testData/intentions/moveLambdaInsideParentheses/moveLambda11.kt");
+        }
+        
+        @TestMetadata("moveLambda12.kt")
+        public void testMoveLambda12() throws Exception {
+            doTestMoveLambdaInsideParentheses("idea/testData/intentions/moveLambdaInsideParentheses/moveLambda12.kt");
+        }
+        
         @TestMetadata("moveLambda2.kt")
         public void testMoveLambda2() throws Exception {
             doTestMoveLambdaInsideParentheses("idea/testData/intentions/moveLambdaInsideParentheses/moveLambda2.kt");


### PR DESCRIPTION
type arguments were being deleted:
foo<String> { it } -> foo({ it })
this commit fixes it
foo<String> { it } -> foo<String>({ it })

also added a few tests for this
