### PR TITLE
KT4385 Bug Fix for Unnecessary Parentheses in WhenToIfIntention

### DIFF
--- a/compiler/frontend/src/org/jetbrains/jet/lang/psi/JetPsiUnparsingUtils.java
+++ b/compiler/frontend/src/org/jetbrains/jet/lang/psi/JetPsiUnparsingUtils.java
@@ -53,7 +53,8 @@ public class JetPsiUnparsingUtils {
 
         return (expression instanceof JetParenthesizedExpression ||
                 expression instanceof JetConstantExpression ||
-                expression instanceof JetSimpleNameExpression)
+                expression instanceof JetSimpleNameExpression ||
+                expression instanceof JetDotQualifiedExpression)
                ? text : "(" + text + ")";
     }
 

--- a/idea/testData/intentions/branched/ifWhen/whenToIf/whenWithDotQualifiedExpression.kt
+++ b/idea/testData/intentions/branched/ifWhen/whenToIf/whenWithDotQualifiedExpression.kt
@@ -1,0 +1,13 @@
+class G {
+    fun cat(x: Int, y: Int): Int {
+        return x + y
+    }
+}
+
+fun test(x: Int, y: Int): String {
+    when<caret> (G.cat(x, y)) {
+        1 -> return "one"
+        2 -> return "two"
+        else -> return "big"
+    }
+}

--- a/idea/testData/intentions/branched/ifWhen/whenToIf/whenWithDotQualifiedExpression.kt.after
+++ b/idea/testData/intentions/branched/ifWhen/whenToIf/whenWithDotQualifiedExpression.kt.after
@@ -1,0 +1,11 @@
+class G {
+    fun cat(x: Int, y: Int): Int {
+        return x + y
+    }
+}
+
+fun test(x: Int, y: Int): String {
+    if (G.cat(x, y) == 1) return "one"
+    else if (G.cat(x, y) == 2) return "two"
+    else return "big"
+}

--- a/idea/tests/org/jetbrains/jet/plugin/intentions/CodeTransformationTestGenerated.java
+++ b/idea/tests/org/jetbrains/jet/plugin/intentions/CodeTransformationTestGenerated.java
@@ -469,6 +469,11 @@ public class CodeTransformationTestGenerated extends AbstractCodeTransformationT
             JetTestUtils.assertAllTestsPresentByMetadata(this.getClass(), "org.jetbrains.jet.generators.tests.TestsPackage", new File("idea/testData/intentions/branched/ifWhen/whenToIf"), Pattern.compile("^(.+)\\.kt$"), true);
         }
         
+        @TestMetadata("whenWithDotQualifiedExpression.kt")
+        public void testWhenWithDotQualifiedExpression() throws Exception {
+            doTestWhenToIf("idea/testData/intentions/branched/ifWhen/whenToIf/whenWithDotQualifiedExpression.kt");
+        }
+        
         @TestMetadata("whenWithEqualityTests.kt")
         public void testWhenWithEqualityTests() throws Exception {
             doTestWhenToIf("idea/testData/intentions/branched/ifWhen/whenToIf/whenWithEqualityTests.kt");


### PR DESCRIPTION
There were some cases where the when to if intention were leaving some unnecessary parentheses after the intention was applied. I narrowed the case down to when the operand is a dot qualified expression and added a line in the `parenthesizeIfNeeded()` function to include a clause for dot qualified expressions.

Link: http://youtrack.jetbrains.com/issue/KT-4385
