### PR TITLE
KT-3287_Arrays.contains()

### DIFF
--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Arrays.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Arrays.kt
@@ -68,5 +68,39 @@ fun arrays(): List<GenericFunction> {
         }
     }
 
+    templates add f("contains(item: Any?)") {
+        absentFor(Arrays)
+        isInline = false
+        doc = "Returns whether the item is in the array"
+        returns("Boolean")
+        body {
+            """
+                if(obj !is T) return false
+
+                for(elm in this)
+                    if(elm == item) return true
+                return false
+            """
+        }
+    }
+
+    /*
+     * implementation for PrimitiveArrays is separate from it for Arrays,
+     * because they cannot hold elements of different types
+     * */
+    templates add f("contains(item: T)") {
+        absentFor(PrimitiveArrays)
+        isInline = false
+        doc = "Returns whether the item is in the array"
+        returns("Boolean")
+        body {
+            """
+                for(elm in this)
+                    if(elm == item) return true
+                return false
+            """
+        }
+    }
+
     return templates.sort()
 }


### PR DESCRIPTION
KT-3287 implementation.

Extension contains() methods for arrays
via stdlib generators for  was added.

Implementation for PrimitiveArrays
differs from it for Arrays
by the type of the argument.
