### PR TITLE
Test common Gradle property for kotlin version

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-core/src/test/resources/testProject/alfa/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-core/src/test/resources/testProject/alfa/build.gradle
@@ -1,4 +1,5 @@
 buildscript {
+  ext.kotlin_version = "0.1-SNAPSHOT"
   repositories {
     mavenCentral()
     maven {
@@ -6,7 +7,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin-core:0.1-SNAPSHOT'
+    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin-core:$kotlin_version"
   }
 }
 
@@ -30,7 +31,7 @@ dependencies {
     compile 'com.google.guava:guava:12.0'
     deployCompile 'com.google.guava:guava:12.0'
     testCompile  'org.testng:testng:6.8'
-    testRuntime  'org.jetbrains.kotlin:kotlin-stdlib:0.1-SNAPSHOT'
+    testRuntime  "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
 
 test {


### PR DESCRIPTION
Slightly modified test data so that it contains an example of setting common property for kotlin version across the project.
