### PR TITLE
Avoid unnecessary null checks in'!!' and 'as'

### DIFF
--- a/js/js.translator/src/org/jetbrains/k2js/translate/expression/ExpressionVisitor.java
+++ b/js/js.translator/src/org/jetbrains/k2js/translate/expression/ExpressionVisitor.java
@@ -29,6 +29,7 @@ import org.jetbrains.jet.lang.resolve.BindingContext;
 import org.jetbrains.jet.lang.resolve.BindingContextUtils;
 import org.jetbrains.jet.lang.resolve.constants.CompileTimeConstant;
 import org.jetbrains.jet.lang.resolve.constants.NullValue;
+import org.jetbrains.jet.lang.types.JetType;
 import org.jetbrains.jet.lexer.JetTokens;
 import org.jetbrains.k2js.translate.context.TemporaryVariable;
 import org.jetbrains.k2js.translate.context.TranslationContext;
@@ -360,10 +361,11 @@ public final class ExpressionVisitor extends TranslatorVisitor<JsNode> {
         if (expression.getOperationReference().getReferencedNameElementType() != JetTokens.AS_KEYWORD)
             return jsExpression.source(expression);
 
-        JetTypeReference type = expression.getRight();
-        assert type != null;
-        if (BindingContextUtils.getNotNull(context.bindingContext(), BindingContext.TYPE, type).isNullable())
+        JetType rightType = BindingContextUtils.getNotNull(context.bindingContext(), BindingContext.TYPE, expression.getRight());
+        JetType leftType = BindingContextUtils.getNotNull(context.bindingContext(), BindingContext.EXPRESSION_TYPE, expression.getLeft());
+        if (rightType.isNullable() || !leftType.isNullable()) {
             return jsExpression.source(expression);
+        }
 
         // KT-2670
         // we actually do not care for types in js

--- a/js/js.translator/src/org/jetbrains/k2js/translate/operation/UnaryOperationTranslator.java
+++ b/js/js.translator/src/org/jetbrains/k2js/translate/operation/UnaryOperationTranslator.java
@@ -21,8 +21,12 @@ import com.google.dart.compiler.backend.js.ast.JsExpression;
 import com.intellij.psi.tree.IElementType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.jet.lang.descriptors.FunctionDescriptor;
+import org.jetbrains.jet.lang.psi.JetExpression;
 import org.jetbrains.jet.lang.psi.JetUnaryExpression;
+import org.jetbrains.jet.lang.resolve.BindingContext;
+import org.jetbrains.jet.lang.resolve.BindingContextUtils;
 import org.jetbrains.jet.lang.resolve.calls.model.ResolvedCall;
+import org.jetbrains.jet.lang.types.JetType;
 import org.jetbrains.jet.lexer.JetTokens;
 import org.jetbrains.k2js.translate.callTranslator.CallTranslator;
 import org.jetbrains.k2js.translate.context.TranslationContext;
@@ -45,8 +49,12 @@ public final class UnaryOperationTranslator {
     ) {
         IElementType operationToken = expression.getOperationReference().getReferencedNameElementType();
         if (operationToken == JetTokens.EXCLEXCL) {
-            return sure(translateAsExpression(getBaseExpression(expression), context), context);
+            JetExpression baseExpression = getBaseExpression(expression);
+            JetType type = BindingContextUtils.getNotNull(context.bindingContext(), BindingContext.EXPRESSION_TYPE, baseExpression);
+            JsExpression translatedExpression = translateAsExpression(baseExpression, context);
+            return type.isNullable() ? sure(translatedExpression, context) : translatedExpression;
         }
+
         if (IncrementTranslator.isIncrement(operationToken)) {
             return IncrementTranslator.translate(expression, context);
         }

--- a/js/js.translator/testData/expression/cast/cases/castToNullableType.kt
+++ b/js/js.translator/testData/expression/cast/cases/castToNullableType.kt
@@ -2,6 +2,8 @@ package foo
 
 class A
 
+fun <T> Any.cast() = this!! as T
+
 fun box(): String {
     val a = null
     val s = a as A?


### PR DESCRIPTION
When receiver of '!!' or 'as' operator is not nullable there is no need to check for null and generate call to Kotlin.throwNpe()
