### PR TITLE
KT-4522: Display gutter icon for recursive method calls.

### DIFF
--- a/idea/src/org/jetbrains/jet/plugin/JetBundle.properties
+++ b/idea/src/org/jetbrains/jet/plugin/JetBundle.properties
@@ -293,6 +293,8 @@ property.is.overridden.too.many=Is overridden in subclasses
 property.is.implemented.header=Is implemented in <br/>
 property.is.overridden.header=Is overridden in <br/>
 
+recursive.function.tooltip=Recursive call on {0}
+
 navigation.title.overriding.property=Choose Implementation of {0}
 navigation.findUsages.title.overriding.property=Overriding properties of {0}
 add.function.to.supertype.family=Add Function to Supertype

--- a/idea/testData/codeInsight/lineMarker/QualifiedNameRecursiveMarker.kt
+++ b/idea/testData/codeInsight/lineMarker/QualifiedNameRecursiveMarker.kt
@@ -1,0 +1,7 @@
+package foo
+
+class Bar {
+    fun foobar() {
+        <lineMarker descr="Recursive call on foo.Bar.foobar"></lineMarker>foobar()
+    }
+}

--- a/idea/testData/codeInsight/lineMarker/SimpleRecursiveMarker.kt
+++ b/idea/testData/codeInsight/lineMarker/SimpleRecursiveMarker.kt
@@ -1,0 +1,3 @@
+fun test() {
+    <lineMarker></lineMarker>test()
+}

--- a/idea/testData/codeInsight/lineMarker/SpecialNameRecursiveMarker.kt
+++ b/idea/testData/codeInsight/lineMarker/SpecialNameRecursiveMarker.kt
@@ -1,0 +1,5 @@
+class A
+
+fun A.plus(a: Int): Int {
+    return this <lineMarker descr="Recursive call on plus"></lineMarker>+ 12
+}

--- a/idea/tests/org/jetbrains/jet/plugin/codeInsight/LineMarkersTest.java
+++ b/idea/tests/org/jetbrains/jet/plugin/codeInsight/LineMarkersTest.java
@@ -27,7 +27,7 @@ import org.jetbrains.jet.plugin.PluginTestCaseBase;
 
 import java.util.List;
 
-public class OverrideImplementLineMarkerTest extends JetLightCodeInsightFixtureTestCase {
+public class LineMarkersTest extends JetLightCodeInsightFixtureTestCase {
     @Override
     protected String getBasePath() {
         return PluginTestCaseBase.TEST_DATA_PROJECT_RELATIVE + "/codeInsight/lineMarker";
@@ -70,6 +70,18 @@ public class OverrideImplementLineMarkerTest extends JetLightCodeInsightFixtureT
     }
 
     public void testFakeOverrideFunWithMostRelevantImplementation() throws Exception {
+        doTest();
+    }
+
+    public void testSimpleRecursiveMarker() throws Exception {
+        doTest();
+    }
+
+    public void testQualifiedNameRecursiveMarker() throws Exception {
+        doTest();
+    }
+
+    public void testSpecialNameRecursiveMarker() throws Exception {
         doTest();
     }
 


### PR DESCRIPTION
This is an extremely simple PR to gutter icons on recursive function calls. The first commit is a faithful reproduction of the behavior in Java (albeit with a slightly more verbose tooltip) however I feel there is room for improvement.

The only known bug at the moment is multiple recursive calls on the same line creating multiple icons in the gutter but this accurately reflects Java behavior as well.
