### PR TITLE
Bug Fix for KT-4652 Replace with Infix Call

### DIFF
--- a/idea/src/org/jetbrains/jet/plugin/intentions/ReplaceWithInfixFunctionCallIntention.kt
+++ b/idea/src/org/jetbrains/jet/plugin/intentions/ReplaceWithInfixFunctionCallIntention.kt
@@ -34,6 +34,20 @@ import org.jetbrains.jet.lang.psi.JetFile
 
 public class ReplaceWithInfixFunctionCallIntention : JetSelfTargetingIntention<JetCallExpression>("replace.with.infix.function.call.intention", javaClass()) {
     override fun isApplicableTo(element: JetCallExpression): Boolean {
+        throw IllegalStateException("isApplicableTo(JetExpressionImpl, Editor) should be called instead")
+    }
+
+    override fun isApplicableTo(element: JetCallExpression, editor: Editor): Boolean {
+        val caretLocation = editor.getCaretModel().getOffset()
+
+        val calleeExpr = element.getCalleeExpression()
+        if (calleeExpr == null) return false
+
+        val textRange = calleeExpr.getTextRange()
+        if (textRange == null) return false
+
+        if (caretLocation !in textRange) return false
+
         val parent = element.getParent()
 
         if (parent is JetDotQualifiedExpression) {

--- a/idea/testData/intentions/replaceWithInfixFunctionCall/caretInsideCalleeExpr.kt
+++ b/idea/testData/intentions/replaceWithInfixFunctionCall/caretInsideCalleeExpr.kt
@@ -1,0 +1,3 @@
+fun foo(x: Int) {
+    x.tim<caret>es(1)
+}

--- a/idea/testData/intentions/replaceWithInfixFunctionCall/caretInsideCalleeExpr.kt.after
+++ b/idea/testData/intentions/replaceWithInfixFunctionCall/caretInsideCalleeExpr.kt.after
@@ -1,0 +1,3 @@
+fun foo(x: Int) {
+    x times 1
+}

--- a/idea/testData/intentions/replaceWithInfixFunctionCall/caretInsideReceiverExpr.kt
+++ b/idea/testData/intentions/replaceWithInfixFunctionCall/caretInsideReceiverExpr.kt
@@ -1,0 +1,4 @@
+// IS_APPLICABLE: false
+fun foo(num: Int) {
+    n<caret>um.times(1)
+}

--- a/idea/testData/intentions/replaceWithInfixFunctionCall/inapplicableCaretPosition.kt
+++ b/idea/testData/intentions/replaceWithInfixFunctionCall/inapplicableCaretPosition.kt
@@ -1,0 +1,4 @@
+// IS_APPLICABLE: false
+fun foo(x: Int) {
+    x.times(<caret>1)
+}

--- a/idea/tests/org/jetbrains/jet/plugin/intentions/CodeTransformationTestGenerated.java
+++ b/idea/tests/org/jetbrains/jet/plugin/intentions/CodeTransformationTestGenerated.java
@@ -1751,6 +1751,16 @@ public class CodeTransformationTestGenerated extends AbstractCodeTransformationT
             doTestReplaceWithInfixFunctionCall("idea/testData/intentions/replaceWithInfixFunctionCall/binaryExpressionArgument.kt");
         }
         
+        @TestMetadata("caretInsideCalleeExpr.kt")
+        public void testCaretInsideCalleeExpr() throws Exception {
+            doTestReplaceWithInfixFunctionCall("idea/testData/intentions/replaceWithInfixFunctionCall/caretInsideCalleeExpr.kt");
+        }
+        
+        @TestMetadata("caretInsideReceiverExpr.kt")
+        public void testCaretInsideReceiverExpr() throws Exception {
+            doTestReplaceWithInfixFunctionCall("idea/testData/intentions/replaceWithInfixFunctionCall/caretInsideReceiverExpr.kt");
+        }
+        
         @TestMetadata("doubleFunctionCall.kt")
         public void testDoubleFunctionCall() throws Exception {
             doTestReplaceWithInfixFunctionCall("idea/testData/intentions/replaceWithInfixFunctionCall/doubleFunctionCall.kt");
@@ -1774,6 +1784,11 @@ public class CodeTransformationTestGenerated extends AbstractCodeTransformationT
         @TestMetadata("functionSafeCall.kt")
         public void testFunctionSafeCall() throws Exception {
             doTestReplaceWithInfixFunctionCall("idea/testData/intentions/replaceWithInfixFunctionCall/functionSafeCall.kt");
+        }
+        
+        @TestMetadata("inapplicableCaretPosition.kt")
+        public void testInapplicableCaretPosition() throws Exception {
+            doTestReplaceWithInfixFunctionCall("idea/testData/intentions/replaceWithInfixFunctionCall/inapplicableCaretPosition.kt");
         }
         
         @TestMetadata("multipleArguments.kt")


### PR DESCRIPTION
This is a fix for KT-4652 Replace With Infix Call.
Link: http://youtrack.jetbrains.com/issue/KT-4652
Issue: The applicable context was thought to be too large, as below:

```
package boo

fun main(args: Array<String>) {
    // intention will be applied here
    A().g(object: T {
        // may include hundreds of lines of code
        override fun f() {
            //intention is applicable here
            1 + 2
        }
    })
}

trait T {
    fun f()
}

class A {
    fun g(t: T) {
    }
}
```

Proposed solution:
I narrowed the scope down to be applicable only when the caret is anywhere on the callee expression or immediately after it.
