### PR TITLE
KT-4555 Inspection to detect if's that are foldable to elvis operator

### DIFF
--- a/idea/resources/inspectionDescriptions/IfThenToElvis.html
+++ b/idea/resources/inspectionDescriptions/IfThenToElvis.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This inspection reports any if-then expressions that can be folded into elvis (?:) expressions
+</body>
+</html>

--- a/idea/src/META-INF/plugin.xml
+++ b/idea/src/META-INF/plugin.xml
@@ -638,12 +638,6 @@
       <category>Kotlin</category>
     </intentionAction>
     
-    <localInspection implementationClass="org.jetbrains.jet.plugin.inspections.ExplicitGetInspection"
-        displayName="Explicit 'get'"
-        groupName="Kotlin"
-        enabledByDefault="true"
-        level="WARNING"
-        />
 
     <intentionAction>
       <className>org.jetbrains.jet.plugin.intentions.SwapBinaryExpression</className>
@@ -664,6 +658,20 @@
       <className>org.jetbrains.jet.plugin.intentions.ReplaceWithTraditionalAssignmentIntention</className>
       <category>Kotlin</category>
     </intentionAction>
+
+    <localInspection implementationClass="org.jetbrains.jet.plugin.inspections.ExplicitGetInspection"
+        displayName="Explicit 'get'"
+        groupName="Kotlin"
+        enabledByDefault="true"
+        level="WARNING"
+        />
+
+    <localInspection implementationClass="org.jetbrains.jet.plugin.inspections.IfThenToElvisInspection"
+        displayName="If-Then foldable to '?:'"
+        groupName="Kotlin"
+        enabledByDefault="true"
+        level="WARNING"
+        />
 
     <project.converterProvider implementation="org.jetbrains.jet.plugin.converters.JetRunConfigurationSettingsFormatConverterProvider"/>
 

--- a/idea/src/org/jetbrains/jet/plugin/inspections/IfThenToElvisInspection.kt
+++ b/idea/src/org/jetbrains/jet/plugin/inspections/IfThenToElvisInspection.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2010-2014 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.jet.plugin.inspections
+
+import org.jetbrains.jet.plugin.intentions.branchedTransformations.intentions.IfThenToElvisIntention
+import org.jetbrains.jet.lang.psi.JetIfExpression
+
+public class IfThenToElvisInspection : IntentionBasedInspection<JetIfExpression>(IfThenToElvisIntention())

--- a/idea/testData/intentions/branched/ifThenToElvis/inspectionData/expected.xml
+++ b/idea/testData/intentions/branched/ifThenToElvis/inspectionData/expected.xml
@@ -1,0 +1,82 @@
+<problems>
+  <problem>
+    <file>willNotInlineClassProperty.kt</file>
+    <line>3</line>
+    <module>light_idea_test_case</module>
+    <entry_point TYPE="file" FQNAME="temp:///src/src/willNotInlineClassProperty.kt" />
+    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">If-Then foldable to '?:'.</problem_class>
+    <description>Replace 'if' expression with elvis expression</description>
+  </problem>
+  <problem>
+    <file>rhsNotEqualsNull.kt</file>
+    <line>9</line>
+    <module>light_idea_test_case</module>
+    <entry_point TYPE="file" FQNAME="temp:///src/src/rhsNotEqualsNull.kt" />
+    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">If-Then foldable to '?:'.</problem_class>
+    <description>Replace 'if' expression with elvis expression</description>
+  </problem>
+  <problem>
+    <file>rhsEqualsNull.kt</file>
+    <line>8</line>
+    <module>light_idea_test_case</module>
+    <entry_point TYPE="file" FQNAME="temp:///src/src/rhsEqualsNull.kt" />
+    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">If-Then foldable to '?:'.</problem_class>
+    <description>Replace 'if' expression with elvis expression</description>
+  </problem>
+  <problem>
+    <file>lhsNotEqualsNull.kt</file>
+    <line>8</line>
+    <module>light_idea_test_case</module>
+    <entry_point TYPE="file" FQNAME="temp:///src/src/lhsNotEqualsNull.kt" />
+    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">If-Then foldable to '?:'.</problem_class>
+    <description>Replace 'if' expression with elvis expression</description>
+  </problem>
+  <problem>
+    <file>lhsEqualsNull.kt</file>
+    <line>8</line>
+    <module>light_idea_test_case</module>
+    <entry_point TYPE="file" FQNAME="temp:///src/src/lhsEqualsNull.kt" />
+    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">If-Then foldable to '?:'.</problem_class>
+    <description>Replace 'if' expression with elvis expression</description>
+  </problem>
+  <problem>
+    <file>ifAsExpression.kt</file>
+    <line>8</line>
+    <module>light_idea_test_case</module>
+    <entry_point TYPE="file" FQNAME="temp:///src/src/ifAsExpression.kt" />
+    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">If-Then foldable to '?:'.</problem_class>
+    <description>Replace 'if' expression with elvis expression</description>
+  </problem>
+  <problem>
+    <file>ifAndElseNotInBlocks.kt</file>
+    <line>8</line>
+    <module>light_idea_test_case</module>
+    <entry_point TYPE="file" FQNAME="temp:///src/src/ifAndElseNotInBlocks.kt" />
+    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">If-Then foldable to '?:'.</problem_class>
+    <description>Replace 'if' expression with elvis expression</description>
+  </problem>
+  <problem>
+    <file>ifAndElseBothInBlocks.kt</file>
+    <line>8</line>
+    <module>light_idea_test_case</module>
+    <entry_point TYPE="file" FQNAME="temp:///src/src/ifAndElseBothInBlocks.kt" />
+    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">If-Then foldable to '?:'.</problem_class>
+    <description>Replace 'if' expression with elvis expression</description>
+  </problem>
+  <problem>
+    <file>doesNotinlineValueOutsideOfScope.kt</file>
+    <line>8</line>
+    <module>light_idea_test_case</module>
+    <entry_point TYPE="file" FQNAME="temp:///src/src/doesNotinlineValueOutsideOfScope.kt" />
+    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">If-Then foldable to '?:'.</problem_class>
+    <description>Replace 'if' expression with elvis expression</description>
+  </problem>
+  <problem>
+    <file>doesNotinlineValueIfUsedMoreThanOnce.kt</file>
+    <line>11</line>
+    <module>light_idea_test_case</module>
+    <entry_point TYPE="file" FQNAME="temp:///src/src/doesNotinlineValueIfUsedMoreThanOnce.kt" />
+    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">If-Then foldable to '?:'.</problem_class>
+    <description>Replace 'if' expression with elvis expression</description>
+  </problem>
+</problems>

--- a/idea/testData/intentions/branched/ifThenToElvis/inspectionData/inspections.test
+++ b/idea/testData/intentions/branched/ifThenToElvis/inspectionData/inspections.test
@@ -1,0 +1,1 @@
+// INSPECTION_CLASS: org.jetbrains.jet.plugin.inspections.IfThenToElvisInspection

--- a/idea/tests/org/jetbrains/jet/plugin/codeInsight/JetInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/jet/plugin/codeInsight/JetInspectionTestGenerated.java
@@ -41,4 +41,9 @@ public class JetInspectionTestGenerated extends AbstractJetInspectionTest {
         doTest("idea/testData/intentions/attributeCallReplacements/replaceGetIntention/inspectionData/inspections.test");
     }
     
+    @TestMetadata("branched/ifThenToElvis/inspectionData/inspections.test")
+    public void testBranched_ifThenToElvis_inspectionData_Inspections_test() throws Exception {
+        doTest("idea/testData/intentions/branched/ifThenToElvis/inspectionData/inspections.test");
+    }
+    
 }

--- a/idea/tests/org/jetbrains/jet/plugin/intentions/CodeTransformationTestGenerated.java
+++ b/idea/tests/org/jetbrains/jet/plugin/intentions/CodeTransformationTestGenerated.java
@@ -96,6 +96,7 @@ public class CodeTransformationTestGenerated extends AbstractCodeTransformationT
     }
     
     @TestMetadata("idea/testData/intentions/branched/ifThenToElvis")
+    @InnerTestClasses({})
     public static class IfThenToElvis extends AbstractCodeTransformationTest {
         public void testAllFilesPresentInIfThenToElvis() throws Exception {
             JetTestUtils.assertAllTestsPresentByMetadata(this.getClass(), "org.jetbrains.jet.generators.tests.TestsPackage", new File("idea/testData/intentions/branched/ifThenToElvis"), Pattern.compile("^(.+)\\.kt$"), true);
@@ -236,6 +237,11 @@ public class CodeTransformationTestGenerated extends AbstractCodeTransformationT
             doTestIfThenToElvis("idea/testData/intentions/branched/ifThenToElvis/willNotInlineClassProperty.kt");
         }
         
+        public static Test innerSuite() {
+            TestSuite suite = new TestSuite("IfThenToElvis");
+            suite.addTestSuite(IfThenToElvis.class);
+            return suite;
+        }
     }
     
     @TestMetadata("idea/testData/intentions/branched/safeAccessToIfThen")
@@ -3418,7 +3424,7 @@ public class CodeTransformationTestGenerated extends AbstractCodeTransformationT
     public static Test suite() {
         TestSuite suite = new TestSuite("CodeTransformationTestGenerated");
         suite.addTestSuite(ElvisToIfThen.class);
-        suite.addTestSuite(IfThenToElvis.class);
+        suite.addTest(IfThenToElvis.innerSuite());
         suite.addTestSuite(SafeAccessToIfThen.class);
         suite.addTestSuite(IfThenToSafeAccess.class);
         suite.addTestSuite(IfToAssignment.class);


### PR DESCRIPTION
This inspection highlights if-statements of the form:

``` kotlin
if (foo != null) foo else bar
```

and provides quickFix to:

``` kotlin
foo ?: bar
```

based off of [IfThenToElvisIntention](https://github.com/jetbrains/kotlin/blob/master/idea/src/org/jetbrains/jet/plugin/intentions/branchedTransformations/intentions/IfThenToElvisIntention.kt)

All of the tests here were copied from the tests for that inspection
[testData/intentions/branched/ifThenToElvis](https://github.com/JetBrains/kotlin/tree/master/idea/testData/intentions/branched/ifThenToElvis)
