### PR TITLE
Fix Stream.filterNotNull

### DIFF
--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Filtering.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Filtering.kt
@@ -244,7 +244,7 @@ fun filtering(): List<GenericFunction> {
         returns(Streams) { "Stream<T>" }
         body(Streams) {
             """
-            return FilteringStream(this, false, { it != null }) as Stream<T>
+            return FilteringStream(this, false, { it == null }) as Stream<T>
             """
         }
     }


### PR DESCRIPTION
Stream<T>.filterNotNull() was filtering out non-null values instead of null values.
**NOTE: I haven't regenerated the standard library due build failures.**
