### PR TITLE
KT-4576: (Bug fix) Intention to transform an if an AssertionError throw into an assert

### DIFF
--- a/idea/src/org/jetbrains/jet/plugin/intentions/ConvertAssertToIfWithThrowIntention.kt
+++ b/idea/src/org/jetbrains/jet/plugin/intentions/ConvertAssertToIfWithThrowIntention.kt
@@ -28,6 +28,7 @@ import org.jetbrains.jet.lang.resolve.DescriptorUtils
 import kotlin.properties.Delegates
 import org.jetbrains.jet.lang.types.lang.KotlinBuiltIns
 import org.jetbrains.jet.lang.psi.JetIfExpression
+import org.jetbrains.jet.lang.psi.JetDotQualifiedExpression
 
 public class ConvertAssertToIfWithThrowIntention : JetSelfTargetingIntention<JetCallExpression>(
         "convert.assert.to.if.with.throw", javaClass()) {
@@ -98,6 +99,11 @@ public class ConvertAssertToIfWithThrowIntention : JetSelfTargetingIntention<Jet
             simplifier.applyTo(ifCondition, editor)
         }
 
-        element.replace(ifExpression)
+        val parent = element.getParent()
+        if (parent is JetDotQualifiedExpression) {
+            parent.replace(ifExpression)
+        } else {
+            element.replace(ifExpression)
+        }
     }
 }

--- a/idea/testData/intentions/convertAssertToIf/dotQualifiedCall.kt
+++ b/idea/testData/intentions/convertAssertToIf/dotQualifiedCall.kt
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun foo() {
+    kotlin.<caret>assert(true, "text")
+}

--- a/idea/testData/intentions/convertAssertToIf/dotQualifiedCall.kt.after
+++ b/idea/testData/intentions/convertAssertToIf/dotQualifiedCall.kt.after
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+fun foo() {
+    if (!true) {
+        throw AssertionError("text")
+    }
+}

--- a/idea/tests/org/jetbrains/jet/plugin/intentions/CodeTransformationTestGenerated.java
+++ b/idea/tests/org/jetbrains/jet/plugin/intentions/CodeTransformationTestGenerated.java
@@ -3541,6 +3541,11 @@ public class CodeTransformationTestGenerated extends AbstractCodeTransformationT
             doTestConvertAssertToIfWithThrowIntention("idea/testData/intentions/convertAssertToIf/booleanConditionWithVariables.kt");
         }
         
+        @TestMetadata("dotQualifiedCall.kt")
+        public void testDotQualifiedCall() throws Exception {
+            doTestConvertAssertToIfWithThrowIntention("idea/testData/intentions/convertAssertToIf/dotQualifiedCall.kt");
+        }
+        
         @TestMetadata("functionCallCondition.kt")
         public void testFunctionCallCondition() throws Exception {
             doTestConvertAssertToIfWithThrowIntention("idea/testData/intentions/convertAssertToIf/functionCallCondition.kt");


### PR DESCRIPTION
I noticed my intention wasn't behaving correctly on dot qualified calls to assert (kotlin.assert(..))
i made a small change to fix that and added a test

original PR: https://github.com/JetBrains/kotlin/pull/442
