### PR TITLE
KT-4854: Inspection to detect redundant type arguments

### DIFF
--- a/idea/resources/inspectionDescriptions/RemoveExplicitTypeArgs.html
+++ b/idea/resources/inspectionDescriptions/RemoveExplicitTypeArgs.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This inspection reports any function call wiith type arguments that can be safely removed and inferred
+</body>
+</html>

--- a/idea/src/META-INF/plugin.xml
+++ b/idea/src/META-INF/plugin.xml
@@ -655,7 +655,6 @@
       <className>org.jetbrains.jet.plugin.intentions.SimplifyBooleanWithConstantsIntention</className>
       <category>Kotlin</category>
     </intentionAction>
-    
 
     <intentionAction>
       <className>org.jetbrains.jet.plugin.intentions.SwapBinaryExpression</className>
@@ -713,6 +712,13 @@
 
     <localInspection implementationClass="org.jetbrains.jet.plugin.inspections.IfThenToSafeAccessInspection"
         displayName="If-Then foldable to '?.'"
+        groupName="Kotlin"
+        enabledByDefault="true"
+        level="WARNING"
+        />
+
+    <localInspection implementationClass="org.jetbrains.jet.plugin.inspections.RemoveExplicitTypeArgsInspection"
+        displayName="Type arguments are unnecessary"
         groupName="Kotlin"
         enabledByDefault="true"
         level="WARNING"

--- a/idea/src/org/jetbrains/jet/plugin/inspections/RemoveExplicitTypeArgsInspection.kt
+++ b/idea/src/org/jetbrains/jet/plugin/inspections/RemoveExplicitTypeArgsInspection.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2010-2014 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.jet.plugin.inspections
+
+import org.jetbrains.jet.plugin.intentions.RemoveExplicitTypeArguments
+import org.jetbrains.jet.lang.psi.JetCallExpression
+
+public class RemoveExplicitTypeArgsInspection : IntentionBasedInspection<JetCallExpression>(RemoveExplicitTypeArguments())

--- a/idea/testData/intentions/removeExplicitTypeArguments/inspectionData/expected.xml
+++ b/idea/testData/intentions/removeExplicitTypeArguments/inspectionData/expected.xml
@@ -1,0 +1,101 @@
+<problems>
+  <problem>
+    <file>variableStringFartherScope.kt</file>
+    <line>5</line>
+    <module>light_idea_test_case</module>
+    <entry_point TYPE="file" FQNAME="temp:///src/variableStringFartherScope.kt" />
+    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">Type arguments are unnecessary</problem_class>
+    <description>Remove explicit type arguments</description>
+  </problem>
+
+  <problem>
+    <file>fourLiterals.kt</file>
+    <line>3</line>
+    <module>light_idea_test_case</module>
+    <entry_point TYPE="file" FQNAME="temp:///src/fourLiterals.kt" />
+    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">Type arguments are unnecessary</problem_class>
+    <description>Remove explicit type arguments</description>
+  </problem>
+  
+  <problem>
+    <file>literalStringWithClass.kt</file>
+    <line>3</line>
+    <module>light_idea_test_case</module>
+    <entry_point TYPE="file" FQNAME="temp:///src/literalStringWithClass.kt" />
+    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">Type arguments are unnecessary</problem_class>
+    <description>Remove explicit type arguments</description>
+  </problem>
+  
+  <problem>
+    <file>lambdaType.kt</file>
+    <line>3</line>
+    <module>light_idea_test_case</module>
+    <entry_point TYPE="file" FQNAME="temp:///src/lambdaType.kt" />
+    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">Type arguments are unnecessary</problem_class>
+    <description>Remove explicit type arguments</description>
+  </problem>
+  
+  <problem>
+    <file>literalAny.kt</file>
+    <line>3</line>
+    <module>light_idea_test_case</module>
+    <entry_point TYPE="file" FQNAME="temp:///src/literalAny.kt" />
+    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">Type arguments are unnecessary</problem_class>
+    <description>Remove explicit type arguments</description>
+  </problem>
+  
+  <problem>
+    <file>literalString.kt</file>
+    <line>3</line>
+    <module>light_idea_test_case</module>
+    <entry_point TYPE="file" FQNAME="temp:///src/literalString.kt" />
+    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">Type arguments are unnecessary</problem_class>
+    <description>Remove explicit type arguments</description>
+  </problem>
+
+  <problem>
+    <file>variablesAndLiterals.kt</file>
+    <line>5</line>
+    <module>light_idea_test_case</module>
+    <entry_point TYPE="file" FQNAME="temp:///src/variablesAndLiterals.kt" />
+    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">Type arguments are unnecessary</problem_class>
+    <description>Remove explicit type arguments</description>
+  </problem>
+  
+  <problem>
+    <file>literalsWhenTypeArgHasTypeArg.kt</file>
+    <line>3</line>
+    <module>light_idea_test_case</module>
+    <entry_point TYPE="file" FQNAME="temp:///src/literalsWhenTypeArgHasTypeArg.kt" />
+    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">Type arguments are unnecessary</problem_class>
+    <description>Remove explicit type arguments</description>
+  </problem>
+  
+  <problem>
+    <file>variableString.kt</file>
+    <line>4</line>
+    <module>light_idea_test_case</module>
+    <entry_point TYPE="file" FQNAME="temp:///src/variableString.kt" />
+    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">Type arguments are unnecessary</problem_class>
+    <description>Remove explicit type arguments</description>
+  </problem>
+  
+  <problem>
+    <file>variableString2.kt</file>
+    <line>3</line>
+    <module>light_idea_test_case</module>
+    <entry_point TYPE="file" FQNAME="temp:///src/variableString2.kt" />
+    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">Type arguments are unnecessary</problem_class>
+    <description>Remove explicit type arguments</description>
+  </problem>
+  
+  <problem>
+    <file>twoLiteralValues.kt</file>
+    <line>3</line>
+    <module>light_idea_test_case</module>
+    <entry_point TYPE="file" FQNAME="temp:///src/twoLiteralValues.kt" />
+    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">Type arguments are unnecessary</problem_class>
+    <description>Remove explicit type arguments</description>
+  </problem>
+
+</problems>

--- a/idea/testData/intentions/removeExplicitTypeArguments/inspectionData/inspections.test
+++ b/idea/testData/intentions/removeExplicitTypeArguments/inspectionData/inspections.test
@@ -1,0 +1,1 @@
+// INSPECTION_CLASS: org.jetbrains.jet.plugin.inspections.RemoveExplicitTypeArgsInspection

--- a/idea/tests/org/jetbrains/jet/plugin/codeInsight/JetInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/jet/plugin/codeInsight/JetInspectionTestGenerated.java
@@ -51,4 +51,9 @@ public class JetInspectionTestGenerated extends AbstractJetInspectionTest {
         doTest("idea/testData/intentions/branched/ifThenToSafeAccess/inspectionData/inspections.test");
     }
     
+    @TestMetadata("removeExplicitTypeArguments/inspectionData/inspections.test")
+    public void testRemoveExplicitTypeArguments_inspectionData_Inspections_test() throws Exception {
+        doTest("idea/testData/intentions/removeExplicitTypeArguments/inspectionData/inspections.test");
+    }
+    
 }

--- a/idea/tests/org/jetbrains/jet/plugin/intentions/CodeTransformationTestGenerated.java
+++ b/idea/tests/org/jetbrains/jet/plugin/intentions/CodeTransformationTestGenerated.java
@@ -7,6 +7,7 @@
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -3719,6 +3720,7 @@ public class CodeTransformationTestGenerated extends AbstractCodeTransformationT
     }
     
     @TestMetadata("idea/testData/intentions/removeExplicitTypeArguments")
+    @InnerTestClasses({})
     public static class RemoveExplicitTypeArguments extends AbstractCodeTransformationTest {
         public void testAllFilesPresentInRemoveExplicitTypeArguments() throws Exception {
             JetTestUtils.assertAllTestsPresentByMetadata(this.getClass(), "org.jetbrains.jet.generators.tests.TestsPackage", new File("idea/testData/intentions/removeExplicitTypeArguments"), Pattern.compile("^(.+)\\.kt$"), true);
@@ -3799,6 +3801,11 @@ public class CodeTransformationTestGenerated extends AbstractCodeTransformationT
             doTestRemoveExplicitTypeArguments("idea/testData/intentions/removeExplicitTypeArguments/variablesAndLiterals.kt");
         }
         
+        public static Test innerSuite() {
+            TestSuite suite = new TestSuite("RemoveExplicitTypeArguments");
+            suite.addTestSuite(RemoveExplicitTypeArguments.class);
+            return suite;
+        }
     }
     
     @TestMetadata("idea/testData/intentions/convertAssertToIf")
@@ -4171,7 +4178,7 @@ public class CodeTransformationTestGenerated extends AbstractCodeTransformationT
         suite.addTestSuite(ReplaceWithTraditionalAssignment.class);
         suite.addTestSuite(SimplifyBooleanWithConstants.class);
         suite.addTestSuite(InsertExplicitTypeArguments.class);
-        suite.addTestSuite(RemoveExplicitTypeArguments.class);
+        suite.addTest(RemoveExplicitTypeArguments.innerSuite());
         suite.addTestSuite(ConvertAssertToIf.class);
         suite.addTestSuite(ConvertIfToAssert.class);
         suite.addTestSuite(MakeTypeExplicitInLambda.class);


### PR DESCRIPTION
inspection to report on function calls where the type arguments can be automatically inferred
http://youtrack.jetbrains.com/issue/KT-4854
