### PR TITLE
KT-4567: Inspection to detect negations that can be simplified 

### DIFF
--- a/idea/resources/inspectionDescriptions/SimplifyBinaryNegationInspection.html
+++ b/idea/resources/inspectionDescriptions/SimplifyBinaryNegationInspection.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This inspection reports any negated binary expressions that can be simplified
+</body>
+</html>

--- a/idea/src/META-INF/plugin.xml
+++ b/idea/src/META-INF/plugin.xml
@@ -718,6 +718,13 @@
         level="WARNING"
         />
 
+    <localInspection implementationClass="org.jetbrains.jet.plugin.inspections.SimplifyBinaryNegationInspection"
+        displayName="Simplify Negated Binary Expression"
+        groupName="Kotlin"
+        enabledByDefault="true"
+        level="WARNING"
+        />
+
     <project.converterProvider implementation="org.jetbrains.jet.plugin.converters.JetRunConfigurationSettingsFormatConverterProvider"/>
 
   </extensions>

--- a/idea/src/org/jetbrains/jet/plugin/inspections/SimplifyBinaryNegationInspection.kt
+++ b/idea/src/org/jetbrains/jet/plugin/inspections/SimplifyBinaryNegationInspection.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2010-2014 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.jet.plugin.inspections
+
+import org.jetbrains.jet.lang.psi.*
+import org.jetbrains.jet.plugin.intentions.SimplifyNegatedBinaryExpressionIntention
+
+public class SimplifyBinaryNegationInspection : IntentionBasedInspection<JetPrefixExpression>(SimplifyNegatedBinaryExpressionIntention())

--- a/idea/testData/intentions/simplifyNegatedBinaryExpressionIntention/inspectionData/expected.xml
+++ b/idea/testData/intentions/simplifyNegatedBinaryExpressionIntention/inspectionData/expected.xml
@@ -1,0 +1,93 @@
+<problems>
+
+<problem>
+  <file>notIs.kt</file>
+  <line>3</line>
+  <module>light_idea_test_case</module>
+  <entry_point TYPE="file" FQNAME="temp:///src/notIs.kt" />
+  <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">Simplify Negated Binary Expression</problem_class>
+  <description>Simplify negated '!is' expression to 'is'</description>
+</problem>
+
+<problem>
+  <file>notIn.kt</file>
+  <line>8</line>
+  <module>light_idea_test_case</module>
+  <entry_point TYPE="file" FQNAME="temp:///src/notIn.kt" />
+  <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">Simplify Negated Binary Expression</problem_class>
+  <description>Simplify negated '!in' expression to 'in'</description>
+</problem>
+
+<problem>
+  <file>notEquals.kt</file>
+  <line>3</line>
+  <module>light_idea_test_case</module>
+  <entry_point TYPE="file" FQNAME="temp:///src/notEquals.kt" />
+  <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">Simplify Negated Binary Expression</problem_class>
+  <description>Simplify negated '!=' expression to '=='</description>
+</problem>
+
+<problem>
+  <file>lessThanOrEquals.kt</file>
+  <line>3</line>
+  <module>light_idea_test_case</module>
+  <entry_point TYPE="file" FQNAME="temp:///src/lessThanOrEquals.kt" />
+  <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">Simplify Negated Binary Expression</problem_class>
+  <description>Simplify negated '&lt;=' expression to '&gt;'</description>
+</problem>
+
+<problem>
+  <file>lessThan.kt</file>
+  <line>3</line>
+  <module>light_idea_test_case</module>
+  <entry_point TYPE="file" FQNAME="temp:///src/lessThan.kt" />
+  <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">Simplify Negated Binary Expression</problem_class>
+  <description>Simplify negated '&lt;' expression to '&gt;='</description>
+</problem>
+
+<problem>
+  <file>is.kt</file>
+  <line>3</line>
+  <module>light_idea_test_case</module>
+  <entry_point TYPE="file" FQNAME="temp:///src/is.kt" />
+  <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">Simplify Negated Binary Expression</problem_class>
+  <description>Simplify negated 'is' expression to '!is'</description>
+</problem>
+
+<problem>
+  <file>in.kt</file>
+  <line>8</line>
+  <module>light_idea_test_case</module>
+  <entry_point TYPE="file" FQNAME="temp:///src/in.kt" />
+  <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">Simplify Negated Binary Expression</problem_class>
+  <description>Simplify negated 'in' expression to '!in'</description>
+</problem>
+
+<problem>
+  <file>greaterThanOrEquals.kt</file>
+  <line>3</line>
+  <module>light_idea_test_case</module>
+  <entry_point TYPE="file" FQNAME="temp:///src/greaterThanOrEquals.kt" />
+  <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">Simplify Negated Binary Expression</problem_class>
+  <description>Simplify negated '&gt;=' expression to '&lt;'</description>
+</problem>
+
+<problem>
+  <file>greaterThan.kt</file>
+  <line>3</line>
+  <module>light_idea_test_case</module>
+  <entry_point TYPE="file" FQNAME="temp:///src/greaterThan.kt" />
+  <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">Simplify Negated Binary Expression</problem_class>
+  <description>Simplify negated '&gt;' expression to '&lt;='</description>
+</problem>
+
+<problem>
+  <file>equals.kt</file>
+  <line>3</line>
+  <module>light_idea_test_case</module>
+  <entry_point TYPE="file" FQNAME="temp:///src/equals.kt" />
+  <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">Simplify Negated Binary Expression</problem_class>
+  <description>Simplify negated '==' expression to '!='</description>
+</problem>
+
+</problems>

--- a/idea/testData/intentions/simplifyNegatedBinaryExpressionIntention/inspectionData/inspections.test
+++ b/idea/testData/intentions/simplifyNegatedBinaryExpressionIntention/inspectionData/inspections.test
@@ -1,0 +1,1 @@
+// INSPECTION_CLASS: org.jetbrains.jet.plugin.inspections.SimplifyBinaryNegationInspection

--- a/idea/tests/org/jetbrains/jet/plugin/codeInsight/JetInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/jet/plugin/codeInsight/JetInspectionTestGenerated.java
@@ -51,4 +51,9 @@ public class JetInspectionTestGenerated extends AbstractJetInspectionTest {
         doTest("idea/testData/intentions/branched/ifThenToSafeAccess/inspectionData/inspections.test");
     }
     
+    @TestMetadata("simplifyNegatedBinaryExpressionIntention/inspectionData/inspections.test")
+    public void testSimplifyNegatedBinaryExpressionIntention_inspectionData_Inspections_test() throws Exception {
+        doTest("idea/testData/intentions/simplifyNegatedBinaryExpressionIntention/inspectionData/inspections.test");
+    }
+    
 }

--- a/idea/tests/org/jetbrains/jet/plugin/intentions/CodeTransformationTestGenerated.java
+++ b/idea/tests/org/jetbrains/jet/plugin/intentions/CodeTransformationTestGenerated.java
@@ -2897,6 +2897,7 @@ public class CodeTransformationTestGenerated extends AbstractCodeTransformationT
     }
     
     @TestMetadata("idea/testData/intentions/simplifyNegatedBinaryExpressionIntention")
+    @InnerTestClasses({})
     public static class SimplifyNegatedBinaryExpressionIntention extends AbstractCodeTransformationTest {
         public void testAllFilesPresentInSimplifyNegatedBinaryExpressionIntention() throws Exception {
             JetTestUtils.assertAllTestsPresentByMetadata(this.getClass(), "org.jetbrains.jet.generators.tests.TestsPackage", new File("idea/testData/intentions/simplifyNegatedBinaryExpressionIntention"), Pattern.compile("^(.+)\\.kt$"), true);
@@ -2962,6 +2963,11 @@ public class CodeTransformationTestGenerated extends AbstractCodeTransformationT
             doTestSimplifyNegatedBinaryExpressionIntention("idea/testData/intentions/simplifyNegatedBinaryExpressionIntention/simpleInvert.kt");
         }
         
+        public static Test innerSuite() {
+            TestSuite suite = new TestSuite("SimplifyNegatedBinaryExpressionIntention");
+            suite.addTestSuite(SimplifyNegatedBinaryExpressionIntention.class);
+            return suite;
+        }
     }
     
     @TestMetadata("idea/testData/intentions/convertNegatedBooleanSequence")
@@ -4162,7 +4168,7 @@ public class CodeTransformationTestGenerated extends AbstractCodeTransformationT
         suite.addTestSuite(ReplaceBinaryInfixIntention.class);
         suite.addTestSuite(ReplaceUnaryPrefixIntention.class);
         suite.addTestSuite(ReplaceInvokeIntention.class);
-        suite.addTestSuite(SimplifyNegatedBinaryExpressionIntention.class);
+        suite.addTest(SimplifyNegatedBinaryExpressionIntention.innerSuite());
         suite.addTestSuite(ConvertNegatedBooleanSequence.class);
         suite.addTestSuite(ConvertNegatedExpressionWithDemorgansLaw.class);
         suite.addTestSuite(SwapBinaryExpression.class);


### PR DESCRIPTION
issue: http://youtrack.jetbrains.com/issue/KT-4567

Since the last pull from master I have lot's of failing tests (hundreds) so I couldn't run all tests, but this seems to work as far as the inspection tests go. 
As soon as I'll resolve my other issue I'll run all tests as well
