### PR TITLE
KT-4950: Insert type intention now only applicable in function names

### DIFF
--- a/idea/src/org/jetbrains/jet/plugin/intentions/InsertExplicitTypeArguments.kt
+++ b/idea/src/org/jetbrains/jet/plugin/intentions/InsertExplicitTypeArguments.kt
@@ -28,26 +28,38 @@ import org.jetbrains.jet.lang.types.TypeUtils
 import org.jetbrains.jet.lang.types.ErrorUtils
 import org.jetbrains.jet.renderer.DescriptorRenderer
 import org.jetbrains.jet.plugin.codeInsight.ShortenReferences
+import com.intellij.openapi.application.ApplicationManager
+import org.jetbrains.jet.lang.psi.JetExpressionImpl
 
 public class InsertExplicitTypeArguments : JetSelfTargetingIntention<JetCallExpression>(
         "insert.explicit.type.arguments", javaClass()) {
 
-    private var resolvedCall: ResolvedCall<out CallableDescriptor?> by Delegates.notNull()
-
     override fun isApplicableTo(element: JetCallExpression): Boolean {
+        throw IllegalStateException("isApplicableTo(JetExpressionImpl, Editor) should be called instead")
+    }
+
+    override fun isApplicableTo(element: JetCallExpression, editor: Editor): Boolean {
         if (!element.getTypeArguments().isEmpty()) return false
+
+        val textRange = element.getCalleeExpression()?.getTextRange()
+        if (textRange == null || !textRange.contains(editor.getCaretModel().getOffset())) return false
+
         val context = AnalyzerFacadeWithCache.getContextForElement(element)
-        val nullableResolvedCall = context[BindingContext.RESOLVED_CALL, element.getCalleeExpression()]
-        if (nullableResolvedCall == null) return false
-        resolvedCall = nullableResolvedCall
+        val resolvedCall = context[BindingContext.RESOLVED_CALL, element.getCalleeExpression()]
+        if (resolvedCall == null) return false
+
         val types = resolvedCall.getTypeArguments()
         return !types.isEmpty() && types.values().none { ErrorUtils.containsErrorType(it) }
     }
 
     override fun applyTo(element: JetCallExpression, editor: Editor) {
+
+        val context = AnalyzerFacadeWithCache.getContextForElement(element)
+        val resolvedCall = context[BindingContext.RESOLVED_CALL, element.getCalleeExpression()]
+        if (resolvedCall == null) return
+
         val args = resolvedCall.getTypeArguments()
-        val types = resolvedCall.getCandidateDescriptor()?.getTypeParameters()
-        if (types == null) return
+        val types = resolvedCall.getCandidateDescriptor().getTypeParameters()
 
         val typeArgs = types.map {
             assert(args[it] != null, "there is a null in the type arguments to transform")
@@ -59,7 +71,7 @@ public class InsertExplicitTypeArguments : JetSelfTargetingIntention<JetCallExpr
 
         val name = element.getCalleeExpression()?.getText()
         val text = element.getText()
-        if (name == null || text == null) return
+        if (name == null) return
         val valueAndFunctionArguments = text.substring(name.size)
         val expr = JetPsiFactory.createExpression(element.getProject(), "$name$typeArgs${valueAndFunctionArguments}")
         element.replace(expr)

--- a/idea/testData/intentions/insertExplicitTypeArguments/inapplicableNotInCallable.kt
+++ b/idea/testData/intentions/insertExplicitTypeArguments/inapplicableNotInCallable.kt
@@ -1,0 +1,6 @@
+// IS_APPLICABLE: false
+fun foo() {
+    val x = bar("<caret>x")
+}
+
+fun bar<T>(t: T): Int = 1

--- a/idea/testData/intentions/insertExplicitTypeArguments/inapplicableNotInCallable2.kt
+++ b/idea/testData/intentions/insertExplicitTypeArguments/inapplicableNotInCallable2.kt
@@ -1,0 +1,6 @@
+// IS_APPLICABLE: false
+fun foo() {
+    val x = bar("x") { <caret>2 }
+}
+
+fun bar<T>(t: T, v : () -> Int): Int = 1

--- a/idea/tests/org/jetbrains/jet/plugin/intentions/CodeTransformationTestGenerated.java
+++ b/idea/tests/org/jetbrains/jet/plugin/intentions/CodeTransformationTestGenerated.java
@@ -3646,6 +3646,16 @@ public class CodeTransformationTestGenerated extends AbstractCodeTransformationT
             doTestInsertExplicitTypeArguments("idea/testData/intentions/insertExplicitTypeArguments/inapplicableNotGeneric.kt");
         }
         
+        @TestMetadata("inapplicableNotInCallable.kt")
+        public void testInapplicableNotInCallable() throws Exception {
+            doTestInsertExplicitTypeArguments("idea/testData/intentions/insertExplicitTypeArguments/inapplicableNotInCallable.kt");
+        }
+        
+        @TestMetadata("inapplicableNotInCallable2.kt")
+        public void testInapplicableNotInCallable2() throws Exception {
+            doTestInsertExplicitTypeArguments("idea/testData/intentions/insertExplicitTypeArguments/inapplicableNotInCallable2.kt");
+        }
+        
         @TestMetadata("inapplicableTypeNotInferred.kt")
         public void testInapplicableTypeNotInferred() throws Exception {
             doTestInsertExplicitTypeArguments("idea/testData/intentions/insertExplicitTypeArguments/inapplicableTypeNotInferred.kt");


### PR DESCRIPTION
Fix for this issue http://youtrack.jetbrains.com/issue/KT-4950

Fixes for this previous pr: https://github.com/JetBrains/kotlin/pull/464

changed the way i check offset, added a couple of tests and made stateless
