### PR TITLE
KT-4889: (Bug fix) Intention to move lambda outside parentheses now handles commas

### DIFF
--- a/idea/testData/intentions/moveLambdaOutsideParentheses/lambdaWithCommas.kt
+++ b/idea/testData/intentions/moveLambdaOutsideParentheses/lambdaWithCommas.kt
@@ -1,0 +1,9 @@
+// IS_APPLICABLE: true
+fun bar(f: () -> Unit) {}
+fun foo(a: Int, b: Int) = 2
+
+fun test() {
+    bar({
+        <caret>val a = foo(1, 2)
+    })
+}

--- a/idea/testData/intentions/moveLambdaOutsideParentheses/lambdaWithCommas.kt.after
+++ b/idea/testData/intentions/moveLambdaOutsideParentheses/lambdaWithCommas.kt.after
@@ -1,0 +1,9 @@
+// IS_APPLICABLE: true
+fun bar(f: () -> Unit) {}
+fun foo(a: Int, b: Int) = 2
+
+fun test() {
+    bar {
+        val a = foo(1, 2)
+    }
+}

--- a/idea/testData/intentions/moveLambdaOutsideParentheses/lambdaWithCommas2.kt
+++ b/idea/testData/intentions/moveLambdaOutsideParentheses/lambdaWithCommas2.kt
@@ -1,0 +1,9 @@
+// IS_APPLICABLE: true
+fun bar(x: Int, f: () -> Unit) {}
+fun foo(a: Int, b: Int) = 2
+
+fun test() {
+    bar(1, {
+        <caret>val a = foo(1, 2)
+    })
+}

--- a/idea/testData/intentions/moveLambdaOutsideParentheses/lambdaWithCommas2.kt.after
+++ b/idea/testData/intentions/moveLambdaOutsideParentheses/lambdaWithCommas2.kt.after
@@ -1,0 +1,9 @@
+// IS_APPLICABLE: true
+fun bar(x: Int, f: () -> Unit) {}
+fun foo(a: Int, b: Int) = 2
+
+fun test() {
+    bar(1) {
+        val a = foo(1, 2)
+    }
+}

--- a/idea/testData/intentions/moveLambdaOutsideParentheses/lambdaWithCommas3.kt
+++ b/idea/testData/intentions/moveLambdaOutsideParentheses/lambdaWithCommas3.kt
@@ -1,0 +1,9 @@
+// IS_APPLICABLE: true
+fun bar(a: Int, b: Int, f: () -> Unit) {}
+fun foo(a: Int, b: Int) = 2
+
+fun test() {
+    bar(1, 2, /* , , */ {
+        <caret>val a = foo(1, 2)
+    })
+}

--- a/idea/testData/intentions/moveLambdaOutsideParentheses/lambdaWithCommas3.kt.after
+++ b/idea/testData/intentions/moveLambdaOutsideParentheses/lambdaWithCommas3.kt.after
@@ -1,0 +1,9 @@
+// IS_APPLICABLE: true
+fun bar(a: Int, b: Int, f: () -> Unit) {}
+fun foo(a: Int, b: Int) = 2
+
+fun test() {
+    bar(1, 2) {
+        val a = foo(1, 2)
+    }
+}

--- a/idea/tests/org/jetbrains/jet/plugin/intentions/CodeTransformationTestGenerated.java
+++ b/idea/tests/org/jetbrains/jet/plugin/intentions/CodeTransformationTestGenerated.java
@@ -2256,6 +2256,21 @@ public class CodeTransformationTestGenerated extends AbstractCodeTransformationT
             doTestMoveLambdaOutsideParentheses("idea/testData/intentions/moveLambdaOutsideParentheses/inapplicable3.kt");
         }
         
+        @TestMetadata("lambdaWithCommas.kt")
+        public void testLambdaWithCommas() throws Exception {
+            doTestMoveLambdaOutsideParentheses("idea/testData/intentions/moveLambdaOutsideParentheses/lambdaWithCommas.kt");
+        }
+        
+        @TestMetadata("lambdaWithCommas2.kt")
+        public void testLambdaWithCommas2() throws Exception {
+            doTestMoveLambdaOutsideParentheses("idea/testData/intentions/moveLambdaOutsideParentheses/lambdaWithCommas2.kt");
+        }
+        
+        @TestMetadata("lambdaWithCommas3.kt")
+        public void testLambdaWithCommas3() throws Exception {
+            doTestMoveLambdaOutsideParentheses("idea/testData/intentions/moveLambdaOutsideParentheses/lambdaWithCommas3.kt");
+        }
+        
         @TestMetadata("moveLambda1.kt")
         public void testMoveLambda1() throws Exception {
             doTestMoveLambdaOutsideParentheses("idea/testData/intentions/moveLambdaOutsideParentheses/moveLambda1.kt");


### PR DESCRIPTION
issue: http://youtrack.jetbrains.com/issue/KT-4889
previous PR: https://github.com/JetBrains/kotlin/pull/455

no longer processing strings, working with the JetElement
