### PR TITLE
Parser: fix recovery for object literal with no body

### DIFF
--- a/compiler/frontend/src/org/jetbrains/jet/lang/parsing/JetParsing.java
+++ b/compiler/frontend/src/org/jetbrains/jet/lang/parsing/JetParsing.java
@@ -626,15 +626,17 @@ public class JetParsing extends AbstractJetParsing {
         PsiBuilder.Marker body = mark();
 
         myBuilder.enableNewlines();
-        expect(LBRACE, "Expecting a class body", TokenSet.create(LBRACE));
 
-        while (!eof()) {
-            if (at(RBRACE)) {
-                break;
+        if (expect(LBRACE, "Expecting a class body")) {
+            while (!eof()) {
+                if (at(RBRACE)) {
+                    break;
+                }
+                parseMemberDeclaration();
             }
-            parseMemberDeclaration();
+            expect(RBRACE, "Missing '}");
         }
-        expect(RBRACE, "Missing '}");
+
         myBuilder.restoreNewlinesState();
 
         body.done(CLASS_BODY);

--- a/compiler/testData/psi/recovery/kt5102.kt
+++ b/compiler/testData/psi/recovery/kt5102.kt
@@ -1,0 +1,8 @@
+fun foo() {
+    bar() // unresolved
+
+    return object : Foo
+}
+
+fun bar() {}
+

--- a/compiler/testData/psi/recovery/kt5102.txt
+++ b/compiler/testData/psi/recovery/kt5102.txt
@@ -1,0 +1,55 @@
+JetFile: kt5102.kt
+  PACKAGE_DIRECTIVE
+    <empty list>
+  FUN
+    PsiElement(fun)('fun')
+    PsiWhiteSpace(' ')
+    PsiElement(IDENTIFIER)('foo')
+    VALUE_PARAMETER_LIST
+      PsiElement(LPAR)('(')
+      PsiElement(RPAR)(')')
+    PsiWhiteSpace(' ')
+    BLOCK
+      PsiElement(LBRACE)('{')
+      PsiWhiteSpace('\n    ')
+      CALL_EXPRESSION
+        REFERENCE_EXPRESSION
+          PsiElement(IDENTIFIER)('bar')
+        VALUE_ARGUMENT_LIST
+          PsiElement(LPAR)('(')
+          PsiElement(RPAR)(')')
+      PsiWhiteSpace(' ')
+      PsiComment(EOL_COMMENT)('// unresolved')
+      PsiWhiteSpace('\n\n    ')
+      RETURN
+        PsiElement(return)('return')
+        PsiWhiteSpace(' ')
+        OBJECT_LITERAL
+          OBJECT_DECLARATION
+            PsiElement(object)('object')
+            PsiWhiteSpace(' ')
+            PsiElement(COLON)(':')
+            PsiWhiteSpace(' ')
+            DELEGATION_SPECIFIER_LIST
+              DELEGATOR_SUPER_CLASS
+                TYPE_REFERENCE
+                  USER_TYPE
+                    REFERENCE_EXPRESSION
+                      PsiElement(IDENTIFIER)('Foo')
+            PsiWhiteSpace('\n')
+            CLASS_BODY
+              PsiErrorElement:Expecting a class body
+                <empty list>
+      PsiElement(RBRACE)('}')
+  PsiWhiteSpace('\n\n')
+  FUN
+    PsiElement(fun)('fun')
+    PsiWhiteSpace(' ')
+    PsiElement(IDENTIFIER)('bar')
+    VALUE_PARAMETER_LIST
+      PsiElement(LPAR)('(')
+      PsiElement(RPAR)(')')
+    PsiWhiteSpace(' ')
+    BLOCK
+      PsiElement(LBRACE)('{')
+      PsiElement(RBRACE)('}')

--- a/compiler/tests/org/jetbrains/jet/parsing/JetParsingTestGenerated.java
+++ b/compiler/tests/org/jetbrains/jet/parsing/JetParsingTestGenerated.java
@@ -900,6 +900,11 @@ public class JetParsingTestGenerated extends AbstractJetParsingTest {
                 doParsingTest("compiler/testData/psi/recovery/kt2172.kt");
             }
             
+            @TestMetadata("kt5102.kt")
+            public void testKt5102() throws Exception {
+                doParsingTest("compiler/testData/psi/recovery/kt5102.kt");
+            }
+            
             @TestMetadata("MissingCommaInConstructorValueParameterList.kt")
             public void testMissingCommaInConstructorValueParameterList() throws Exception {
                 doParsingTest("compiler/testData/psi/recovery/MissingCommaInConstructorValueParameterList.kt");


### PR DESCRIPTION
http://youtrack.jetbrains.com/issue/KT-5102 No recovery for object literal with no body
