### PR TITLE
Correct the argument types of the StringBuilder.append

### DIFF
--- a/compiler/testData/codegen/bytecodeText/kt5016.kt
+++ b/compiler/testData/codegen/bytecodeText/kt5016.kt
@@ -1,0 +1,10 @@
+// KT-5016 wrong StringBuilder append method invoked
+class kt5016 {
+    fun f1(name : String) : String {
+         return "Hello $name!"
+    }
+}
+
+// 0 INVOKEVIRTUAL java/lang/StringBuilder.append \(Ljava/lang/Object;\)Ljava/lang/StringBuilder
+// 3 INVOKEVIRTUAL java/lang/StringBuilder.append \(Ljava/lang/String;\)Ljava/lang/StringBuilder
+// 1 INVOKEVIRTUAL java/lang/StringBuilder.toString

--- a/compiler/tests/org/jetbrains/jet/codegen/BytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/jet/codegen/BytecodeTextTestGenerated.java
@@ -107,6 +107,11 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
         doTest("compiler/testData/codegen/bytecodeText/kt2887.kt");
     }
     
+    @TestMetadata("kt5016.kt")
+    public void testKt5016() throws Exception {
+        doTest("compiler/testData/codegen/bytecodeText/kt5016.kt");
+    }
+    
     @TestMetadata("noVolatileAnnotation.kt")
     public void testNoVolatileAnnotation() throws Exception {
         doTest("compiler/testData/codegen/bytecodeText/noVolatileAnnotation.kt");


### PR DESCRIPTION
Modified AsmUtil to generate calls to more specific append methods
in the StringBuilder class in order to save computation time and make
less temporary objects.

Also adds unit-test to verify that the append(Object) method was
invoked 0 times while the append(String) 3 times

Signed-off-by: Laszlo Hornyak laszlo.hornyak@gmail.com
