### PR TITLE
make UTF-8 the default for all extension methods, and consistently put t...

### DIFF
--- a/libraries/stdlib/src/kotlin/io/Files.kt
+++ b/libraries/stdlib/src/kotlin/io/Files.kt
@@ -114,37 +114,37 @@ public fun File.appendBytes(data: ByteArray): Unit {
  *
  * This method is not recommended on huge files.
  */
-public fun File.readText(encoding:String = Charset.defaultCharset().name()) : String = readBytes().toString(encoding)
+public fun File.readText(encoding: String) : String = readBytes().toString(encoding)
 
 /**
- * Reads the entire content of the file as a String using a character encoding.
+ * Reads the entire content of the file as a String using a character encoding defaulting to UTF-8
  *
  * This method is not recommended on huge files.
  */
-public fun File.readText(encoding: Charset) : String = readBytes().toString(encoding)
+public fun File.readText(encoding: Charset = defaultCharset) : String = readBytes().toString(encoding)
 
 /**
  * Writes the text as the contents of the file using the a
  * character encoding.
  */
-public fun File.writeText(text: String, encoding: String = Charset.defaultCharset().name()): Unit { writeBytes(text.toByteArray(encoding)) }
+public fun File.writeText(text: String, encoding: String): Unit { writeBytes(text.toByteArray(encoding)) }
 
 /**
- * Writes the text as the contents of the file using a character encoding.
+ * Writes the text as the contents of the file using a character encoding defaulting to UTF-8.
  */
-public fun File.writeText(text: String, encoding: Charset): Unit { writeBytes(text.toByteArray(encoding)) }
+public fun File.writeText(text: String, encoding: Charset = defaultCharset): Unit { writeBytes(text.toByteArray(encoding)) }
 
 /**
- * Appends text to the contents of the file using a given character encoding.
+ * Appends text to the contents of the file using a given character encoding defaulting to UTF-8.
  */
-public fun File.appendText(text: String, encoding: Charset): Unit {
+public fun File.appendText(text: String, encoding: Charset = defaultCharset): Unit {
     appendBytes(text.toByteArray(encoding))
 }
 
 /**
  * Appends text to the contents of the file using a character encoding.
  */
-public fun File.appendText(text: String, encoding: String = Charset.defaultCharset().name()): Unit {
+public fun File.appendText(text: String, encoding: String): Unit {
     appendBytes(text.toByteArray(encoding))
 }
 
@@ -187,12 +187,21 @@ fun File.forEachBlock(closure : (ByteArray, Int) -> Unit) : Unit {
 }
 
 /**
- * Reads file line by line. Default charset is UTF-8.
+ * Reads file line by line using the specified encoding.
  *
  * You may use this function on huge files
  */
-fun File.forEachLine (charset : String = "UTF-8", closure : (line : String) -> Unit) : Unit {
-    val reader = BufferedReader(InputStreamReader(FileInputStream(this), charset))
+fun File.forEachLine (encoding : String, closure : (line : String) -> Unit) : Unit {
+    forEachLine(Charset.forName(encoding), closure)
+}
+
+/**
+ * Reads file line by line using the specified encoding defaulting to UTF-8.
+ *
+ * You may use this function on huge files
+ */
+fun File.forEachLine (encoding : Charset = defaultCharset, closure : (line : String) -> Unit) : Unit {
+    val reader = BufferedReader(InputStreamReader(FileInputStream(this), encoding))
     try {
         reader.forEachLine(closure)
     } finally {
@@ -201,14 +210,23 @@ fun File.forEachLine (charset : String = "UTF-8", closure : (line : String) -> U
 }
 
 /**
- * Reads file content as strings list. By default uses UTF-8 charset.
+ * Reads file content as strings list using the specified encoding.
  *
  * Do not use this function for huge files.
  */
-fun File.readLines(charset : String = "UTF-8") : List<String> {
+fun File.readLines(encoding : String) : List<String> {
+    return readLines(Charset.forName(encoding))
+}
+
+/**
+ * Reads file content as strings list using the specified encoding defaulting to UTF-8.
+ *
+ * Do not use this function for huge files.
+ */
+fun File.readLines(encoding : Charset = defaultCharset) : List<String> {
     val rs = ArrayList<String>()
 
-    this.forEachLine(charset) { (line : String) : Unit ->
+    this.forEachLine(encoding) { (line : String) : Unit ->
         rs.add(line);
     }
 

--- a/libraries/stdlib/src/kotlin/io/JIO.kt
+++ b/libraries/stdlib/src/kotlin/io/JIO.kt
@@ -161,7 +161,7 @@ public fun InputStream.buffered(bufferSize: Int = defaultBufferSize): InputStrea
 else
     BufferedInputStream(this, bufferSize)
 
-/** Creates a reader on an input stream with specified *encoding* */
+/** Creates a reader on an input stream with specified *encoding* defaulting to UTF8 */
 public fun InputStream.reader(encoding: Charset = defaultCharset): InputStreamReader = InputStreamReader(this, encoding)
 
 /** Creates a reader on an input stream with specified *encoding* */
@@ -175,7 +175,7 @@ public fun InputStream.reader(encoding: CharsetDecoder): InputStreamReader = Inp
 public fun OutputStream.buffered(bufferSize: Int = defaultBufferSize): BufferedOutputStream
         = if (this is BufferedOutputStream) this else BufferedOutputStream(this, bufferSize)
 
-/** Creates a writer on an output stream with specified *encoding* */
+/** Creates a writer on an output stream with specified *encoding* defaulting to UTF8 */
 public fun OutputStream.writer(encoding: Charset = defaultCharset): OutputStreamWriter = OutputStreamWriter(this, encoding)
 
 /** Creates a writer on an output stream with specified *encoding* */
@@ -302,14 +302,14 @@ public fun Reader.copyTo(out: Writer, bufferSize: Int = defaultBufferSize): Long
  *
  * This method is not recommended on huge files.
  */
-public fun URL.readText(encoding: String = Charset.defaultCharset().name()): String = readBytes().toString(encoding)
+public fun URL.readText(encoding: String): String = readBytes().toString(encoding)
 
 /**
- * Reads the entire content of the URL as a String with the specified character encoding.
+ * Reads the entire content of the URL as a String with the specified character encoding defaulting to UTF-8.
  *
  * This method is not recommended on huge files.
  */
-public fun URL.readText(encoding: Charset): String = readBytes().toString(encoding)
+public fun URL.readText(encoding: Charset = defaultCharset): String = readBytes().toString(encoding)
 
 /**
  * Reads the entire content of the URL as bytes


### PR DESCRIPTION
make UTF-8 the default for all extension methods, and consistently put this default on the Charset version of the methods, not the name-of-charset as string methods.  this was written two different ways before, and the behaviour would default in some cases to UTF-8 and in others to whatever the system default encoding.
