### PR TITLE
js-backend: reuse assert functions in testData

### DIFF
--- a/js/js.tests/test/org/jetbrains/k2js/test/BasicTest.java
+++ b/js/js.tests/test/org/jetbrains/k2js/test/BasicTest.java
@@ -19,6 +19,8 @@ package org.jetbrains.k2js.test;
 import com.google.common.collect.Lists;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.util.Function;
+import com.intellij.util.containers.ContainerUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.jet.JetTestUtils;
 import org.jetbrains.jet.cli.jvm.compiler.JetCoreEnvironment;
@@ -32,6 +34,7 @@ import org.jetbrains.k2js.test.rhino.RhinoResultChecker;
 import org.jetbrains.k2js.test.utils.TranslationUtils;
 
 import java.io.File;
+import java.io.FilenameFilter;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -48,6 +51,7 @@ public abstract class BasicTest extends KotlinTestWithEnvironment {
     private static final String CASES = "cases/";
     private static final String OUT = "out/";
     private static final String EXPECTED = "expected/";
+    private static final String COMMON_FILES_DIR = "_commonFiles/";
 
     public static final String TEST_PACKAGE = "foo";
     public static final String TEST_FUNCTION = "box";
@@ -169,9 +173,38 @@ public abstract class BasicTest extends KotlinTestWithEnvironment {
 
     @NotNull
     protected List<String> additionalKotlinFiles() {
-        return Lists.newArrayList();
+        List<String> additionalFiles = Lists.newArrayList();
+        additionalFiles.addAll(kotlinFilesInDirectory(pathToTestFilesRoot() + COMMON_FILES_DIR));
+        additionalFiles.addAll(kotlinFilesInDirectory(pathToTestFiles() + COMMON_FILES_DIR));
+        return additionalFiles;
     }
 
+    @NotNull
+    private List<String> kotlinFilesInDirectory(@NotNull String directory) {
+        File dir = new File(directory);
+
+        if (!dir.isDirectory()) {
+            return ContainerUtil.emptyList();
+        }
+
+        File[] kotlinFiles = dir.listFiles(new FilenameFilter() {
+            @Override
+            public boolean accept(@NotNull File dir, @NotNull String name) {
+                return name.endsWith(".kt");
+            }
+        });
+
+        if (kotlinFiles == null) {
+            return ContainerUtil.emptyList();
+        }
+
+        return ContainerUtil.map2List(kotlinFiles, new Function<File, String>() {
+            @Override
+            public String fun(File kotlinFile) {
+                return kotlinFile.getAbsolutePath();
+            }
+        });
+    }
 
     protected static String casesDirectoryName() {
         return CASES;
@@ -225,11 +258,6 @@ public abstract class BasicTest extends KotlinTestWithEnvironment {
     @NotNull
     protected String getInputFilePath(@NotNull String filename) {
         return getInputPath() + filename;
-    }
-
-    @NotNull
-    protected String cases(@NotNull String filename) {
-        return getInputFilePath(filename);
     }
 
     @NotNull

--- a/js/js.translator/testData/_commonFiles/asserts.kt
+++ b/js/js.translator/testData/_commonFiles/asserts.kt
@@ -1,0 +1,15 @@
+package kotlin
+
+fun assertEquals<T>(expected: T, actual: T, message: String? = null) {
+    if (expected != actual) {
+        val msg = if (message == null) "" else (" message = '" + message + "',")
+        throw Exception("Unexpected value:$msg expected = '$expected', actual = '$actual'")
+    }
+}
+
+fun assertNotEquals<T>(illegal: T, actual: T, message: String? = null) {
+    if (illegal == actual) {
+        val msg = if (message == null) "" else (" message = '" + message + "',")
+        throw Exception("Illegal value:$msg illegal = '$illegal', actual = '$actual'")
+    }
+}

--- a/js/js.translator/testData/classObject/cases/accessing.kt
+++ b/js/js.translator/testData/classObject/cases/accessing.kt
@@ -33,10 +33,6 @@ class Foo() {
     }
 }
 
-fun assertEquals<T>(expected: T, actual: T, id: String) {
-    if (expected != actual) throw Exception("Failed on $id, expected = '$expected', actual = '$actual'")
-}
-
 fun box(): String {
     assertEquals("Foo.baz() Foo.bar Implicit", Foo.testImplicitThis(), "testImplicitThis")
     assertEquals("Foo.baz() Foo.bar Explicit", Foo.testExplicitThis(), "testExplicitThis")

--- a/js/js.translator/testData/closure/cases/closureGenericTypeValue.kt
+++ b/js/js.translator/testData/closure/cases/closureGenericTypeValue.kt
@@ -6,10 +6,6 @@ class A<T>(val a: T) {
 
 fun <T> T.bar() = { this }
 
-fun assertEquals(expected: String, actual: String) {
-    if (expected != actual) throw Exception("Expected: $expected, actual: $actual")
-}
-
 fun box(): String {
     assertEquals("ok", A("ok").foo())
     assertEquals("a42", "a42".bar()())

--- a/js/js.translator/testData/closure/cases/closureInNestedFunctionsInMethod.kt
+++ b/js/js.translator/testData/closure/cases/closureInNestedFunctionsInMethod.kt
@@ -2,47 +2,38 @@ package foo
 
 fun run<T>(f: () -> T) = f()
 
-class Fail(val message: String) : RuntimeException(message) {
-    val isFail = true // workaround for exception handling
-}
-
-
 class A {
-    var testName = ""
-    fun assertEquals(actual: Int, expected: Int, message: String) =
-            if (actual != expected) throw Fail("$message in $testName test.")
-
     val a = 12
     var b = 1
 
     fun boo(c: Int) = c
 
     fun litlit() {
-        testName = "litlit"
+        val testName = "litlit"
         run {
             run {
-                assertEquals(a, 12, "a != 12")
+                assertEquals(12, a, testName)
 
-                assertEquals(b, 1, "b != 1")
+                assertEquals(1, b, testName)
                 b = 23
-                assertEquals(b, 23, "b != 23")
+                assertEquals(23, b, testName)
 
-                assertEquals(boo(34), 34, "boo(34) != 34")
+                assertEquals(34, boo(34), testName)
             }
         }
     }
 
     fun funfun() {
-        testName = "funfun"
+        val testName = "funfun"
         fun foo() {
             fun bar() {
-                assertEquals(a, 12, "a != 12")
+                assertEquals(12, a, testName)
 
-                assertEquals(b, 1, "b != 1")
+                assertEquals(1, b, testName)
                 b = 23
-                assertEquals(b, 23, "b != 23")
+                assertEquals(23, b, testName)
 
-                assertEquals(boo(34), 34, "boo(34) != 34")
+                assertEquals(34, boo(34), testName)
             }
             bar()
         }
@@ -50,32 +41,32 @@ class A {
     }
 
     fun litfun() {
-        testName = "litfun"
+        val testName = "litfun"
         run {
             fun bar() {
-                assertEquals(a, 12, "a != 12")
+                assertEquals(12, a, testName)
 
-                assertEquals(b, 1, "b != 1")
+                assertEquals(1, b, testName)
                 b = 23
-                assertEquals(b, 23, "b != 23")
+                assertEquals(23, b, testName)
 
-                assertEquals(boo(34), 34, "boo(34) != 34")
+                assertEquals(34, boo(34), testName)
             }
             bar()
         }
     }
 
     fun funlit() {
-        testName = "funlit"
+        val testName = "funlit"
         fun foo() {
             run {
-                assertEquals(a, 12, "a != 12")
+                assertEquals(12, a, testName)
 
-                assertEquals(b, 1, "b != 1")
+                assertEquals(1, b, testName)
                 b = 23
-                assertEquals(b, 23, "b != 23")
+                assertEquals(23, b, testName)
 
-                assertEquals(boo(34), 34, "boo(34) != 34")
+                assertEquals(34, boo(34), testName)
             }
         }
         foo()
@@ -83,16 +74,10 @@ class A {
 }
 
 fun box(): String {
-    try {
-        A().litlit()
-        A().funfun()
-        A().litfun()
-        A().funlit()
-    }
-    catch(f: Fail) {
-        if (!f.isFail) throw f
-        return f.message
-    }
+    A().litlit()
+    A().funfun()
+    A().litfun()
+    A().funlit()
 
     return "OK"
 }

--- a/js/js.translator/testData/closure/cases/closureLambdaVarInLambda.kt
+++ b/js/js.translator/testData/closure/cases/closureLambdaVarInLambda.kt
@@ -2,10 +2,6 @@
 
 package foo
 
-fun assertEquals<T>(expected: T, actual: T) {
-    if (expected != actual) throw Exception("expected = $expected, actual = $actual")
-}
-
 fun box(): String {
     var foo = { 1 }
     var bar = 1

--- a/js/js.translator/testData/closure/cases/closureReceiverInLocalExtFunByLocalExtFun.kt
+++ b/js/js.translator/testData/closure/cases/closureReceiverInLocalExtFunByLocalExtFun.kt
@@ -1,9 +1,5 @@
 package foo
 
-fun assertEquals<T>(expected: T, actual: T, message: String) {
-    if (expected != actual) throw Exception("Failed when $message, expected = $expected, actual = $actual")
-}
-
 // workaround for Rhino
 var n = 0
 class A {

--- a/js/js.translator/testData/closure/cases/closureThisAndReceiver.kt
+++ b/js/js.translator/testData/closure/cases/closureThisAndReceiver.kt
@@ -17,10 +17,6 @@ class A(val a: String) {
     }
 }
 
-fun assertEquals(expected: String, actual: String) {
-    if (expected != actual) throw Exception("Expected: $expected, actual: $actual")
-}
-
 fun box(): String {
     val a = A("a")
     val b = A("b")

--- a/js/js.translator/testData/closure/cases/closureThisByUsingMethodFromParentClass.kt
+++ b/js/js.translator/testData/closure/cases/closureThisByUsingMethodFromParentClass.kt
@@ -48,10 +48,6 @@ fun box(): String {
 
 // Helpers
 
-fun assertEquals<T>(expected: T, actual: T) {
-    if (expected != actual) throw Exception("expected: $expected, actual: $actual");
-}
-
 native
 fun String.replace(regexp: RegExp, replacement: String): String = noImpl
 

--- a/js/js.translator/testData/closure/cases/recursiveExtFunction.kt
+++ b/js/js.translator/testData/closure/cases/recursiveExtFunction.kt
@@ -8,10 +8,6 @@ fun Int.foo(a: Int): Int {
     return a
 }
 
-fun assertEquals<T>(expected: T, actual: T) {
-    if (expected != actual) throw Exception("expected: $expected, actual, $actual")
-}
-
 fun box(): String {
     assertEquals(34, 23.foo(0))
 

--- a/js/js.translator/testData/dataClass/cases/components.kt
+++ b/js/js.translator/testData/dataClass/cases/components.kt
@@ -6,14 +6,6 @@ data class Dat(val start: String, middle: String, val end: String) {
     }
 }
 
-fun assertEquals<T>(expected: T, actual: T) {
-    if (expected != actual) throw Exception("expected: $expected, actual, $actual")
-}
-
-fun assertNotEqual<T>(expected: T, actual: T) {
-    if (expected == actual) throw Exception("unexpectedly equal: $expected and $actual")
-}
-
 fun box(): String {
     val d = Dat("max", "-", "min")
     assertEquals("maxmin", d.getLabel())

--- a/js/js.translator/testData/dataClass/cases/equals.kt
+++ b/js/js.translator/testData/dataClass/cases/equals.kt
@@ -8,14 +8,6 @@ data class Dat2(val start: String, val end: String)
 
 class Obj(val start: String, val end: String)
 
-fun assertEquals<T>(expected: T, actual: T) {
-    if (expected != actual) throw Exception("expected: $expected, actual, $actual")
-}
-
-fun assertNotEqual<T>(expected: T, actual: T) {
-    if (expected == actual) throw Exception("unexpectedly equal: $expected and $actual")
-}
-
 fun box(): String {
     val d1 = Dat("a", "b")
     val d2 = Dat("a", "b")
@@ -25,9 +17,9 @@ fun box(): String {
 
     assertEquals(d1, d1)
     assertEquals(d1, d2)
-    assertNotEqual(d1, d3)
+    assertNotEquals(d1, d3)
 
-    assertNotEqual(d1, otherD1)
+    assertNotEquals(d1, otherD1)
 
     var hd1 = Holder(Dat("y", "n"))
     var hd2 = Holder(Dat("y", "n"))
@@ -35,15 +27,15 @@ fun box(): String {
 
     assertEquals(hd1, hd1)
     assertEquals(hd1, hd2)
-    assertNotEqual(hd1, hd3)
+    assertNotEquals(hd1, hd3)
 
     var ho1 = Holder(Obj("+", "-"))
     var ho2 = Holder(Obj("+", "-"))
     var ho3 = Holder(Obj("*", "*"))
 
     assertEquals(ho1, ho1)
-    assertNotEqual(ho1, ho2)
-    assertNotEqual(ho1, ho3)
+    assertNotEquals(ho1, ho2)
+    assertNotEquals(ho1, ho3)
 
     return "OK"
 }

--- a/js/js.translator/testData/dataClass/cases/hashcode.kt
+++ b/js/js.translator/testData/dataClass/cases/hashcode.kt
@@ -9,11 +9,6 @@ data class Dat(val start: String, val end: String)
 
 class Obj(val start: String, val end: String)
 
-
-fun assertEquals<T>(expected: T, actual: T) {
-    if (expected != actual) throw Exception("expected: $expected, actual, $actual")
-}
-
 fun assertSomeNotEqual<T>(c: Iterable<T>) {
     val it = c.iterator()
     val first = it.next()

--- a/js/js.translator/testData/dataClass/cases/keyrole.kt
+++ b/js/js.translator/testData/dataClass/cases/keyrole.kt
@@ -6,10 +6,6 @@ data class Dat(val start: String, val end: String)
 
 class Obj(val start: String, val end: String)
 
-fun assertEquals<T>(expected: T, actual: T) {
-    if (expected != actual) throw Exception("expected: $expected, actual, $actual")
-}
-
 fun box(): String {
     val setD = java.util.HashSet<Holder<Dat>>()
     setD.add(Holder(Dat("a", "b")))

--- a/js/js.translator/testData/dataClass/cases/override.kt
+++ b/js/js.translator/testData/dataClass/cases/override.kt
@@ -11,10 +11,6 @@ data class Dat(val start: String, middle: String, val end: String) {
     }
 }
 
-fun assertEquals<T>(expected: T, actual: T) {
-    if (expected != actual) throw Exception("expected: $expected, actual, $actual")
-}
-
 fun box(): String {
     val d = Dat("max", "-", "min")
     val other = Dat("other", "-", "instance")

--- a/js/js.translator/testData/dataClass/cases/tostring.kt
+++ b/js/js.translator/testData/dataClass/cases/tostring.kt
@@ -6,10 +6,6 @@ data class Dat(val start: String, val end: String)
 
 class Obj(val start: String, val end: String)
 
-fun assertEquals<T>(expected: T, actual: T) {
-    if (expected != actual) throw Exception("expected: $expected, actual, $actual")
-}
-
 fun box(): String {
     val d = Dat("a", "b")
 

--- a/js/js.translator/testData/enum/cases/accessing.kt
+++ b/js/js.translator/testData/enum/cases/accessing.kt
@@ -18,10 +18,6 @@ fun A.extExplicit() = A.FOO
 fun A.extByThis() = this.FOO
 //fun A.extImplicit() = FOO
 
-fun assertEquals<T>(expected: T, actual: T, id: String) {
-    if (expected != actual) throw Exception("Failed on $id, expected = '$expected', actual = '$actual'")
-}
-
 fun box(): String {
     assertEquals(A.FOO, A.FOO.explicit(), "explicit access")
     assertEquals(A.FOO, A.FOO.byThis(), "access by this")

--- a/js/js.translator/testData/expression/cast/cases/smartCastInExtensionFunction.kt
+++ b/js/js.translator/testData/expression/cast/cases/smartCastInExtensionFunction.kt
@@ -10,40 +10,36 @@ fun A.bar() = "A.bar()"
 fun boo(a: Any) = "boo(Any)"
 fun boo(a: A) = "boo(A)"
 
-fun assert<T>(expected: T, actual: T, caseName: String) {
-    if (expected != actual) throw Exception("Filed on $caseName, expected: $expected, actual: $actual")
-}
-
 fun Any.testInTopLevel() {
-    assert(bar(), "Any.bar()", "bar()")
-    assert(this.bar(), "Any.bar()", "this.bar()")
-    assert(boo(this), "boo(Any)", "boo(this)")
+    assertEquals(bar(), "Any.bar()", "bar()")
+    assertEquals(this.bar(), "Any.bar()", "this.bar()")
+    assertEquals(boo(this), "boo(Any)", "boo(this)")
 
     if (this is A) {
-        assert(foo(47), "A.foo(47)", "foo(47)")
-        assert(bar(), "A.bar()", "bar()")
+        assertEquals(foo(47), "A.foo(47)", "foo(47)")
+        assertEquals(bar(), "A.bar()", "bar()")
 
-        assert(this.foo(47), "A.foo(47)", "this.foo(47)")
-        assert(this.bar(), "A.bar()", "this.bar()")
+        assertEquals(this.foo(47), "A.foo(47)", "this.foo(47)")
+        assertEquals(this.bar(), "A.bar()", "this.bar()")
 
-        assert(boo(this), "boo(A)", "boo(this: A)")
+        assertEquals(boo(this), "boo(A)", "boo(this: A)")
     }
 }
 
 class B {
     fun Any.test() {
-        assert(bar(), "Any.bar()", "bar()")
-        assert(this.bar(), "Any.bar()", "this.bar()")
-        assert(boo(this), "boo(Any)", "boo(this)")
+        assertEquals(bar(), "Any.bar()", "bar()")
+        assertEquals(this.bar(), "Any.bar()", "this.bar()")
+        assertEquals(boo(this), "boo(Any)", "boo(this)")
 
         if (this is A) {
-            assert(foo(47), "A.foo(47)", "foo(47)")
-            assert(bar(), "A.bar()", "bar()")
+            assertEquals(foo(47), "A.foo(47)", "foo(47)")
+            assertEquals(bar(), "A.bar()", "bar()")
 
-            assert(this.foo(47), "A.foo(47)", "this.foo(47)")
-            assert(this.bar(), "A.bar()", "this.bar()")
+            assertEquals(this.foo(47), "A.foo(47)", "this.foo(47)")
+            assertEquals(this.bar(), "A.bar()", "this.bar()")
 
-            assert(boo(this), "boo(A)", "boo(this: A)")
+            assertEquals(boo(this), "boo(A)", "boo(this: A)")
         }
     }
 

--- a/js/js.translator/testData/expression/cast/cases/smartCastInFunction.kt
+++ b/js/js.translator/testData/expression/cast/cases/smartCastInFunction.kt
@@ -10,32 +10,28 @@ fun A.bar() = "A.bar()"
 fun boo(a: Any) = "boo(Any)"
 fun boo(a: A) = "boo(A)"
 
-fun assert<T>(expected: T, actual: T, caseName: String) {
-    if (expected != actual) throw Exception("Filed on $caseName, expected: $expected, actual: $actual")
-}
-
 fun testInTopLevel(a: Any) {
-    assert(a.bar(), "Any.bar()", "bar()")
-    assert(a.bar(), "Any.bar()", "this.bar()")
-    assert(boo(a), "boo(Any)", "boo(this)")
+    assertEquals(a.bar(), "Any.bar()", "bar()")
+    assertEquals(a.bar(), "Any.bar()", "this.bar()")
+    assertEquals(boo(a), "boo(Any)", "boo(this)")
 
     if (a is A) {
-        assert(a.foo(47), "A.foo(47)", "a.foo(47)")
-        assert(a.bar(), "A.bar()", "a.bar()")
-        assert(boo(a), "boo(A)", "boo(a: A)")
+        assertEquals(a.foo(47), "A.foo(47)", "a.foo(47)")
+        assertEquals(a.bar(), "A.bar()", "a.bar()")
+        assertEquals(boo(a), "boo(A)", "boo(a: A)")
     }
 }
 
 class B {
     fun testInClass(a: Any) {
-        assert(a.bar(), "Any.bar()", "bar()")
-        assert(a.bar(), "Any.bar()", "this.bar()")
-        assert(boo(a), "boo(Any)", "boo(this)")
+        assertEquals(a.bar(), "Any.bar()", "bar()")
+        assertEquals(a.bar(), "Any.bar()", "this.bar()")
+        assertEquals(boo(a), "boo(Any)", "boo(this)")
 
         if (a is A) {
-            assert(a.foo(47), "A.foo(47)", "a.foo(47)")
-            assert(a.bar(), "A.bar()", "a.bar()")
-            assert(boo(a), "boo(A)", "boo(a: A)")
+            assertEquals(a.foo(47), "A.foo(47)", "a.foo(47)")
+            assertEquals(a.bar(), "A.bar()", "a.bar()")
+            assertEquals(boo(a), "boo(A)", "boo(a: A)")
         }
     }
 

--- a/js/js.translator/testData/expression/function/_commonFiles/helpers.kt
+++ b/js/js.translator/testData/expression/function/_commonFiles/helpers.kt
@@ -1,0 +1,14 @@
+package foo
+
+native
+fun String.replace(regexp: RegExp, replacement: String): String = noImpl
+
+fun String.replaceAll(regexp: String, replacement: String): String = replace(RegExp(regexp, "g"), replacement)
+
+native
+fun String.search(regexp: RegExp): Int = noImpl
+
+native
+class RegExp(regexp: String, flags: String = "") {
+    fun exec(s: String): Array<String>? = noImpl
+}

--- a/js/js.translator/testData/expression/function/cases/infixCall.kt
+++ b/js/js.translator/testData/expression/function/cases/infixCall.kt
@@ -7,10 +7,6 @@ val bar = { Int.(a: Int) -> this * a }
 
 fun test(op: Int.(Int) -> Int) = 3 op 20
 
-fun assertEquals<T>(expected: T, actual: T) {
-    if (expected != actual) throw Exception("expected: $expected, actual: $actual")
-}
-
 fun box(): String {
     val op = { Int.(a: Int) -> this / a }
 

--- a/js/js.translator/testData/expression/function/cases/mangling.kt
+++ b/js/js.translator/testData/expression/function/cases/mangling.kt
@@ -137,14 +137,6 @@ open private class OpenPrivateClass {
 
 // Helpers
 
-native
-fun String.search(regexp: RegExp): Int = noImpl
-
-native
-class RegExp(regexp: String, flags: String = "") {
-    fun exec(s: String): Array<String>? = noImpl
-}
-
 val CALEE_NAME = RegExp("""\b\w*(baz[^(]*)""")
 
 fun Function0<Unit>.extractNames(): Array<String> {

--- a/js/js.translator/testData/expression/function/cases/manglingAnyMethods.kt
+++ b/js/js.translator/testData/expression/function/cases/manglingAnyMethods.kt
@@ -34,14 +34,6 @@ private class PrivateClass {
 
 // Helpers
 
-native
-fun String.search(regexp: RegExp): Int = noImpl
-
-native
-class RegExp(regexp: String, flags: String = "") {
-    fun exec(s: String): Array<String>? = noImpl
-}
-
 val CALEE_NAME = RegExp("""((?:equals|hashCode|toString)[^(]*)""")
 
 fun <T> Function0<T>.extractNames(): Array<String> {

--- a/js/js.translator/testData/expression/function/cases/manglingClashWithFunctionsWithoutParameters.kt
+++ b/js/js.translator/testData/expression/function/cases/manglingClashWithFunctionsWithoutParameters.kt
@@ -17,15 +17,6 @@ public class A : T {
     fun boo(i: Int): String = "A.boo" + i
 }
 
-// Helpers
-native
-fun String.replace(regexp: RegExp, replacement: String): String = noImpl
-
-fun String.replaceAll(regexp: String, replacement: String): String = replace(RegExp(regexp, "g"), replacement)
-
-native
-class RegExp(regexp: String, flags: String)
-
 //Testing
 
 fun test(testName: String, ff: Any, fb: Any) {
@@ -33,10 +24,6 @@ fun test(testName: String, ff: Any, fb: Any) {
     val b = fb.toString().replaceAll("boo", "foo")
 
     if (f != b) throw Exception("FAILED on ${testName}:\n f = \"$f\"\n b = \"$b\"")
-}
-
-fun assertEquals<T>(expected: T, actual: T) {
-    if (expected != actual) throw Exception("expected: $expected, actual: $actual")
 }
 
 fun box(): String {

--- a/js/js.translator/testData/expression/function/cases/manglingStability.kt
+++ b/js/js.translator/testData/expression/function/cases/manglingStability.kt
@@ -115,15 +115,6 @@ class TestMixed {
 val mixed_in_class_f = TestMixed().f
 val mixed_in_class_b = TestMixed().b
 
-// Helpers
-native
-fun String.replace(regexp: RegExp, replacement: String): String = noImpl
-
-fun String.replaceAll(regexp: String, replacement: String): String = replace(RegExp(regexp, "g"), replacement)
-
-native
-class RegExp(regexp: String, flags: String)
-
 //Testing
 
 fun test(testName: String, ff: Any, fb: Any) {

--- a/js/js.translator/testData/expression/function/cases/overloadClassConstructorByFactoryMethod.kt
+++ b/js/js.translator/testData/expression/function/cases/overloadClassConstructorByFactoryMethod.kt
@@ -6,10 +6,6 @@ class Foo(val name: String)
 
 fun Foo() = Foo("<default-name>")
 
-fun assertEquals(expected: Any, actual: Any) {
-    if (expected != actual) throw Exception("expected = $expected, actual = $actual")
-}
-
 fun box(): String {
     assertEquals("<default-name>", Foo().name)
     assertEquals("BarBaz", Foo("BarBaz").name)

--- a/js/js.translator/testData/expression/function/cases/overloadOverridenFun.kt
+++ b/js/js.translator/testData/expression/function/cases/overloadOverridenFun.kt
@@ -2,10 +2,6 @@
 
 package foo
 
-fun assertEquals(expected: Any, actual: Any) {
-    if (expected != actual) throw Exception("expected = $expected, actual = $actual")
-}
-
 trait I {
     fun test(): String
 }

--- a/js/js.translator/testData/expression/function/cases/overloadingWithInheritance.kt
+++ b/js/js.translator/testData/expression/function/cases/overloadingWithInheritance.kt
@@ -12,9 +12,6 @@ class C : A, B {
     fun foo() = "C"
 }
 
-fun assertEquals(expected: Any, actual: Any) {
-    if (expected != actual) throw Exception("expected = $expected, actual = $actual")
-}
 fun box(): String {
     assertEquals("A", C().foo(1))
     assertEquals("B", C().foo(""))

--- a/js/js.translator/testData/expression/invoke/cases/infixCall.kt
+++ b/js/js.translator/testData/expression/invoke/cases/infixCall.kt
@@ -28,10 +28,6 @@ fun test2(): String {
     return "$f | $s"
 }
 
-fun assertEquals<T>(expected: T, actual: T) {
-    if (expected != actual) throw Exception("expected: $expected, actual: $actual")
-}
-
 fun box(): String {
     assertEquals("a b c | a b c", test1())
     assertEquals("a b c | a b c", test2())

--- a/js/js.translator/testData/expression/misc/cases/elvisReturnNested.kt
+++ b/js/js.translator/testData/expression/misc/cases/elvisReturnNested.kt
@@ -6,10 +6,6 @@
 
 package foo
 
-fun assertEquals<T>(expected: T, actual: T) {
-    if (expected != actual) throw Exception("expected: $expected, actual: $actual")
-}
-
 fun firstNotNullLen(s1 : String?, s2 : String?, s3 : String?) : Int {
     val len = (s1?.length() ?: s2?.length()) ?:
                 (s2?.length() ?: s3?.length()) ?:

--- a/js/js.translator/testData/expression/misc/cases/elvisReturnSimple.kt
+++ b/js/js.translator/testData/expression/misc/cases/elvisReturnSimple.kt
@@ -6,10 +6,6 @@
 
 package foo
 
-fun assertEquals<T>(expected: T, actual: T) {
-    if (expected != actual) throw Exception("expected: $expected, actual: $actual")
-}
-
 fun stringLen(s : String?) : Int {
     val s1 : String = s ?: return 0
     return s1.length

--- a/js/js.translator/testData/expression/misc/cases/elvisWithThrow.kt
+++ b/js/js.translator/testData/expression/misc/cases/elvisWithThrow.kt
@@ -1,9 +1,5 @@
 package foo
 
-fun assertEquals<T>(expected: T, actual: T) {
-    if (expected != actual) throw Exception("expected: $expected, actual: $actual")
-}
-
 var i = 0
 fun bar(): Any? {
     i++

--- a/js/js.translator/testData/inheritance/cases/overrideAnyMethods.kt
+++ b/js/js.translator/testData/inheritance/cases/overrideAnyMethods.kt
@@ -23,10 +23,6 @@ class Foo(val name: String) {
     override fun toString(): String = "Foo($name)"
 }
 
-fun assertEquals(expected: Any, actual: Any) {
-    if (expected != actual) throw Exception("expected = $expected, actual = $actual")
-}
-
 fun box(): String {
     val james = Foo("James")
     val anotherJames = Foo("James")

--- a/js/js.translator/testData/java/arrayList/cases/misc.kt
+++ b/js/js.translator/testData/java/arrayList/cases/misc.kt
@@ -2,12 +2,6 @@ package foo
 
 import java.util.ArrayList
 
-fun assertThat(a: Any, b: Any) {
-    if (a != b) {
-        throw Exception("$a is not equal to $b")
-    }
-}
-
 fun box(): Boolean {
     var i = 0
     val list = ArrayList<Int>()
@@ -38,22 +32,18 @@ fun box(): Boolean {
         return false
     }
 
-    assertThat(a.equals(b), false)
+    assertNotEquals(a, b, "a != b")
 
     b[0] = a[0]
     b.add(a[1])
-    assertThat(a.equals(b), true)
+    assertEquals(a, b, "a == b")
 
     a.clear()
-    assertThat(a.isEmpty(), true)
+    assertEquals(true, a.isEmpty(), "a.isEmpty()")
 
-    val array = list.copyToArray()
 
-    assertThat(array[0], 1)
-    assertThat(array[1], 500)
-    assertThat(array[2], 2)
-    assertThat(array[3], 3)
-    assertThat(JSON.stringify(list), "[1,500,2,3]")
-    assertThat(list.toString(), "[1, 500, 2, 3]")
+    assertEquals(array(1, 500, 2, 3), list.copyToArray(), "list.copyToArray()")
+    assertEquals("[1,500,2,3]", JSON.stringify(list), "JSON.stringify(list)")
+    assertEquals("[1, 500, 2, 3]", list.toString(), "list.toString()")
     return true;
 }

--- a/js/js.translator/testData/operatorOverloading/cases/overloadByLambda.kt
+++ b/js/js.translator/testData/operatorOverloading/cases/overloadByLambda.kt
@@ -7,10 +7,6 @@ val times = { A.(a: Int) -> this.v * a }
 
 fun test(div: A.(Int) -> Int) = A(20) / 4
 
-fun assertEquals<T>(expected: T, actual: T) {
-    if (expected != actual) throw Exception("expected: $expected, actual: $actual")
-}
-
 fun box(): String {
     val compareTo = { A.(a: A) -> this.v - a.v }
 


### PR DESCRIPTION
It seems that assertEquals-like function has been defined at least 28 times in testData (at js-backend).

It might be a good idea to create directory with common kotlin files, that are included with every test case.

Did so.
