### PR TITLE
JS backend: fix generated code for ternary operator

### DIFF
--- a/js/js.dart-ast/src/com/google/dart/compiler/backend/js/JsToStringGenerationVisitor.java
+++ b/js/js.dart-ast/src/com/google/dart/compiler/backend/js/JsToStringGenerationVisitor.java
@@ -365,7 +365,7 @@ public class JsToStringGenerationVisitor extends JsVisitor {
         // another
         // ternary expression, but if the test expression is a ternary, it should
         // get parentheses around it.
-        printPair(x, x.getTestExpression());
+        printPair(x, x.getTestExpression(), true);
         spaceOpt();
         p.print('?');
         spaceOpt();
@@ -376,8 +376,8 @@ public class JsToStringGenerationVisitor extends JsVisitor {
         printPair(x, x.getElseExpression());
     }
 
-    private void printPair(JsExpression parent, JsExpression expression) {
-        boolean isNeedParen = parenCalc(parent, expression, false);
+    private void printPair(JsExpression parent, JsExpression expression, boolean wrongAssoc) {
+        boolean isNeedParen = parenCalc(parent, expression, wrongAssoc);
         if (isNeedParen) {
             leftParen();
         }
@@ -385,6 +385,10 @@ public class JsToStringGenerationVisitor extends JsVisitor {
         if (isNeedParen) {
             rightParen();
         }
+    }
+
+    private void printPair(JsExpression parent, JsExpression expression) {
+        printPair(parent, expression, false);
     }
 
     @Override

--- a/js/js.tests/test/org/jetbrains/k2js/test/semantics/MiscTest.java
+++ b/js/js.tests/test/org/jetbrains/k2js/test/semantics/MiscTest.java
@@ -194,4 +194,8 @@ public final class MiscTest extends AbstractExpressionTest {
     public void testKt5058() throws Exception {
         checkFooBoxIsTrue("KT-5058.kt");
     }
+
+    public void testRightAssocForGeneratedConditionalOperator() throws Exception {
+        checkFooBoxIsOk();
+    }
 }

--- a/js/js.translator/testData/expression/misc/cases/rightAssocForGeneratedConditionalOperator.kt
+++ b/js/js.translator/testData/expression/misc/cases/rightAssocForGeneratedConditionalOperator.kt
@@ -1,0 +1,14 @@
+// http://youtrack.jetbrains.com/issue/KT-5320
+// KT-5320 Invalid JS code generated for typecast inside ternary operator
+
+package foo
+
+fun test(x: Any?): Int = if (x as Boolean) 1 else 2;
+
+fun box(): String {
+    assertEquals(1, test(true), "true")
+    assertEquals(2, test(false), "false")
+    assertEquals("OK", if (if (0 < 1) false else true) "Not OK" else "OK")
+
+    return "OK"
+}


### PR DESCRIPTION
There was an error in JsToStringGenerationVisitor for nested conditional operators.
The conditional operator is right associative (see
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Conditional_Operator),
but code in "visitConditional" method assumes the left associativity.
