### PR TITLE
Negating the result of compareTo() is not good

### DIFF
--- a/libraries/stdlib/src/generated/_Ordering.kt
+++ b/libraries/stdlib/src/generated/_Ordering.kt
@@ -156,7 +156,7 @@ public inline fun <T, R : Comparable<R>> Iterable<T>.sortBy(inlineOptions(Inline
  */
 public fun <T : Comparable<T>> Iterable<T>.sortDescending(): List<T> {
     val sortedList = toArrayList()
-    val sortBy: Comparator<T> = comparator<T> {(x: T, y: T) -> -x.compareTo(y) }
+    val sortBy: Comparator<T> = comparator<T> {(x: T, y: T) -> y.compareTo(x) }
     java.util.Collections.sort(sortedList, sortBy)
     return sortedList
 }
@@ -166,7 +166,7 @@ public fun <T : Comparable<T>> Iterable<T>.sortDescending(): List<T> {
  */
 public inline fun <T, R : Comparable<R>> Array<out T>.sortDescendingBy(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) order: (T) -> R): List<T> {
     val sortedList = toArrayList()
-    val sortBy: Comparator<T> = comparator<T> {(x: T, y: T) -> -order(x).compareTo(order(y)) }
+    val sortBy: Comparator<T> = comparator<T> {(x: T, y: T) -> order(y).compareTo(order(x)) }
     java.util.Collections.sort(sortedList, sortBy)
     return sortedList
 }
@@ -176,7 +176,7 @@ public inline fun <T, R : Comparable<R>> Array<out T>.sortDescendingBy(inlineOpt
  */
 public inline fun <T, R : Comparable<R>> Iterable<T>.sortDescendingBy(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) order: (T) -> R): List<T> {
     val sortedList = toArrayList()
-    val sortBy: Comparator<T> = comparator<T> {(x: T, y: T) -> -order(x).compareTo(order(y)) }
+    val sortBy: Comparator<T> = comparator<T> {(x: T, y: T) -> order(y).compareTo(order(x)) }
     java.util.Collections.sort(sortedList, sortBy)
     return sortedList
 }

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Ordering.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Ordering.kt
@@ -80,7 +80,7 @@ fun ordering(): List<GenericFunction> {
         body {
             """
             val sortedList = toArrayList()
-            val sortBy: Comparator<T> = comparator<T> {(x: T, y: T) -> -x.compareTo(y) }
+            val sortBy: Comparator<T> = comparator<T> {(x: T, y: T) -> y.compareTo(x) }
             java.util.Collections.sort(sortedList, sortBy)
             return sortedList
             """
@@ -150,7 +150,7 @@ fun ordering(): List<GenericFunction> {
         body {
             """
             val sortedList = toArrayList()
-            val sortBy: Comparator<T> = comparator<T> {(x: T, y: T) -> -order(x).compareTo(order(y)) }
+            val sortBy: Comparator<T> = comparator<T> {(x: T, y: T) -> order(y).compareTo(order(x)) }
             java.util.Collections.sort(sortedList, sortBy)
             return sortedList
             """


### PR DESCRIPTION
Negating the result of compareTo()/compare() is a questionable or bad programming practice, since if the return value is Integer.MIN_VALUE, negating the return value won't negate the sign of the result. You can achieve the same intended result by reversing the order of the operands rather than by negating the results.
