### PR TITLE
Convert grammar markup from Confuence wiki to Markdown

### DIFF
--- a/grammar/src/attributes.grm
+++ b/grammar/src/attributes.grm
@@ -1,5 +1,5 @@
 /**
-h2. Annotations
+## Annotations
 */
 
 annotations

--- a/grammar/src/class.grm
+++ b/grammar/src/class.grm
@@ -1,11 +1,10 @@
 /**
-h2. Classes
+## Classes
 
-bq. See [Classes and Inheritance]
+See [Classes and Inheritance](classes.html)
 */
 
 /*
-
 internal class Example<X, T : Comparable<X>>(protected val x : Foo<X, T>, y : Some)
     : Bar(x), Foo<X, T> by x, IAbstractSome by y.asAbstract()
     where
@@ -13,7 +12,6 @@ internal class Example<X, T : Comparable<X>>(protected val x : Foo<X, T>, y : So
 {
   // members
 }
-
 */
 
 class
@@ -49,7 +47,7 @@ typeParameter
   ;
 
 /**
-bq. See [Generic classes|Generics#Generic classes]
+See [Generic classes](generics.html)
 */
 
 typeConstraints
@@ -61,5 +59,5 @@ typeConstraint
   : annotations "class" "object" SimpleName ":" type
   ;
 /**
-bq. See [Generic constraints|Generics#Generic constraints]
+See [Generic constraints](generics.html#generic-constraints)
 */

--- a/grammar/src/class_members.grm
+++ b/grammar/src/class_members.grm
@@ -1,5 +1,5 @@
 /**
-h3. Class members
+### Class members
 */
 
 /*
@@ -26,8 +26,6 @@ class Example(a : Foo, i : Int) : Bar(i), Some {
 }
 */
 
-// h5. Grammar
-
 memberDeclaration
   : classObject
   : object
@@ -46,7 +44,7 @@ classObject
   : modifiers "class" object
   ;
 /**
-bq. See [Class objects|Classes and Inheritance#Class objects]
+See [Class objects](classes.html#class-objects)
 */
 
 valueParameters
@@ -96,9 +94,8 @@ property
       ("by" | "=" expression SEMI?)?
       (getter? setter? | setter? getter?) SEMI?
   ;
-
 /**
-bq. See [Properties and Fields]
+See [Properties and Fields](properties.html)
 */
 
 getter
@@ -118,5 +115,5 @@ parameter
 object
   : "object" SimpleName (":" delegationSpecifier{","})? classBody? // Class body can be optional: this is a declaration
 /**
-bq. See [Object expressions and Declarations]
+See [Object expressions and Declarations](object-declarations.html)
 */

--- a/grammar/src/control.grm
+++ b/grammar/src/control.grm
@@ -1,7 +1,7 @@
 /**
-h2. Control structures
+## Control structures
 
-bq. See [Control structures]
+See [Control structures](control-flow.html)
 */
 
 if

--- a/grammar/src/enum.grm
+++ b/grammar/src/enum.grm
@@ -1,7 +1,7 @@
 /**
-h3. Enum classes
+### Enum classes
 
-bq. See [Enum classes]
+See [Enum classes](enum-classes.html)
 */
 
 enumClassBody

--- a/grammar/src/expressions.grm
+++ b/grammar/src/expressions.grm
@@ -1,27 +1,28 @@
 /**
-h2. Expressions
+## Expressions
 
-bq. See [Expressions]
+<!--See [Expressions](expressions.html)-->
 
-h3. Precedence
+### Precedence
 
-||*Precedence*||Title||Symbols||
-|Highest|Postfix|{{\+\+}}, {{\-\-}}, {{.}}, {{?.}}, {{?}}|
-| |Prefix|{{-}}, {{\+}}, {{\+\+}}, {{\-\-}}, {{!}}, [{{@label}}|#LabelName], {{@}}, {{@@}} |
-| |Type RHS|{{:}}, {{as}}, {{as?}} |
-| |Multiplicative|{{*}}, {{/}}, {{%}} |
-| |Additive|{{\+}}, {{-}} |
-| |Range|{{..}} |
-| |Infix function|[{{SimpleName}}|#SimpleName] |
-| |Elvis|{{?:}} |
-| |Named checks|{{in}}, {{\!in}}, {{is}}, {{\!is}} |
-| |Comparison|{{<}}, {{>}}, {{<=}}, {{>=}} |
-| |Equality|{{==}}, {{\!==}}|
-| |Conjunction|{{&&}}|
-| |Disjunction|{{\|\|}}|
-|Lowest|Assignment|{{=}}, {{+=}}, {{-=}}, {{*=}}, {{/=}}, {{%=}}|
+| Precedence | Title | Symbols |
+|------------|-------|---------|
+| Highest    | Postfix | `++`, `--`, `.`, `?.`, `?` |
+| | Prefix | `-`, `+`, `++`, `--`, `!`, [`@label`](#LabelName), `@`, `@@` |
+| | Type RHS | `:`, `as`, `as?` |
+| | Multiplicative | `*`, `/`, `%` |
+| | Additive | `+`, `-` |
+| | Range | `..` |
+| | Infix function | [`SimpleName`](#SimpleName) |
+| | Elvis | `?:` |
+| | Named checks | `in`, `!in`, `is`, `!is` |
+| | Comparison | `<`, `>`, `<=`, `>=` |
+| | Equality | `==`, `\!==` |
+| | Conjunction | `&&` |
+| | Disjunction | `||` |
+| Lowest | Assignment | `=`, `+=`, `-=`, `*=`, `/=`, `%=` |
 
-h3. Rules
+### Rules
 
 */
 
@@ -42,7 +43,6 @@ Decreasing precedence:
   "||"
   assignmentOperator
 */
-
 
 expression
   : disjunction (assignmentOperator disjunction)*
@@ -284,5 +284,3 @@ objectLiteralMember
 factoryMethod
   : accessModifier? SimpleName typeParameters? functionParameters functionBody
   ;
-
-*/

--- a/grammar/src/lexical.grm
+++ b/grammar/src/lexical.grm
@@ -1,5 +1,5 @@
 /**
-h1. Lexical structure
+# Lexical structure
 */
 
 [helper]
@@ -23,7 +23,7 @@ CharacterLiteral
   : <character as in Java>;
 
 /**
-bq. See [Basic types]
+See [Basic types](basic-types.html)
 */
 
 StringWithTemplates
@@ -33,7 +33,7 @@ NoEscapeString
   : <"""-quoted string>;
 
 /**
-bq. See [String templates|Strings#Templates]
+See [String templates](basic-types.html#templates)
 */
 
 SEMI
@@ -46,21 +46,19 @@ SimpleName
   ;
 
 /**
-bq. See [Java interoperability]
+See [Java interoperability](java-interop.html)
 */
 
 FieldName
   : "$" SimpleName;
 
-/**
-bq. See [Properties And Fields]
-*/
+See [Properties And Fields](properties.html)
 
 LabelName
   : "@" SimpleName;
 
 /**
-bq. See [Nonlocal returns and jumps]
+<!--See [Nonlocal returns and jumps](returns.html)-->
 */
 
 /* Symbols:

--- a/grammar/src/modifiers.grm
+++ b/grammar/src/modifiers.grm
@@ -1,5 +1,5 @@
 /**
-h2. Modifiers
+## Modifiers
 */
 
 modifiers

--- a/grammar/src/notation.grm
+++ b/grammar/src/notation.grm
@@ -1,28 +1,28 @@
 /**
-h1. Notation
+# Notation
 
 This section informally explains the grammar notation used below.
 
-h2. Symbols and naming
+## Symbols and naming
 
-_Terminal symbol_ names start with an uppercase letter, e.g. *SimpleName*
-_Nonterminal symbol_ names start with lowercase letter, e.g. *kotlinFile*
-Each _production_ starts with a colon (*:*)
-_Symbol definitions_ may have many productions and are terminated by a semicolon (*;*)
-Symbol definitions may be prepended with _attributes_, e.g. {{start}} attribute denotes a start symbol
+_Terminal symbol_ names start with an uppercase letter, e.g. **SimpleName**.<br>
+_Nonterminal symbol_ names start with lowercase letter, e.g. **kotlinFile**.<br>
+Each _production_ starts with a colon (**:**).<br>
+_Symbol definitions_ may have many productions and are terminated by a semicolon (**;**).<br>
+Symbol definitions may be prepended with _attributes_, e.g. `start` attribute denotes a start symbol.
 
-h2. EBNF expressions
+## EBNF expressions
 
-Operator {color:blue}*|*{color} denotes _alternative_
-Operator {color:blue}*\**{color} denotes _iteration_ (zero or more)
-Operator {color:blue}*+*{color} denotes _iteration_ (one or more)
-Operator {color:blue}*?*{color} denotes _option_ (zero or one)
-alpha{color:blue}*{*{color}beta{color:blue}*}*{color} denotes a nonempty _beta_-separated list of _alpha_'s
+Operator `|` denotes _alternative_.<br>
+Operator `*` denotes _iteration_ (zero or more).<br>
+Operator `+` denotes _iteration_ (one or more).<br>
+Operator `?` denotes _option_ (zero or one).<br>
+alpha`{`beta`}` denotes a nonempty _beta_-separated list of _alpha_'s.
 
-h1. Semicolons
+# Semicolons
 
-[Kotlin] provides "semicolon inference": syntactically, subsentences (e.g., statements, declarations etc) are separated by
-the pseudo-token [SEMI|#SEMI], which stands for "semicolon or newline". In most cases, there's no need for semicolons in
-[Kotlin] code.
+Kotlin provides "semicolon inference": syntactically, subsentences (e.g., statements, declarations etc) are separated by
+the pseudo-token [SEMI](#SEMI), which stands for "semicolon or newline". In most cases, there's no need for semicolons in
+Kotlin code.
 
 */

--- a/grammar/src/toplevel.grm
+++ b/grammar/src/toplevel.grm
@@ -1,7 +1,7 @@
 /**
-h1. Syntax
+# Syntax
 
-*Relevant pages:* [Namespaces]
+<!--Relevant pages: [Namespaces](namespaces.html)-->
 */
 
 
@@ -28,7 +28,7 @@ import
   ;
 
 /**
-bq. See [Imports|Namespaces#Imports]
+<!--See [Imports](namespaces.html#imports)-->
 */
 
 toplevelObject
@@ -48,7 +48,7 @@ package
   ;
 
 /**
-bq. See [Namespaces]
+<!--See [Namespaces](namespaces.html)-->
 */
 
 [undocumented]

--- a/grammar/src/types.grm
+++ b/grammar/src/types.grm
@@ -1,7 +1,7 @@
 /**
-h2. Types
+## Types
 
-bq. See [Types]
+See [Types](basic-types.html)
 */
 
 /*
@@ -14,6 +14,7 @@ Foo<Bar<X>, T, Object> // user type
 
 type
   : annotations typeDescriptor
+  ;
 
 // IF YOU CHANGE THIS, please, update TYPE_FIRST in JetParsing
 typeDescriptor
@@ -46,5 +47,3 @@ optionalProjection
 functionType
   : (type ".")? "(" (parameter | modifiers /*lazy out ref*/ type){","} ")" "->" type?
   ;
-
-////////////////////////////////////////

--- a/grammar/src/when.grm
+++ b/grammar/src/when.grm
@@ -1,7 +1,7 @@
 /**
-h4. Pattern matching
+#### Pattern matching
 
-bq. See [Pattern matching]
+<!--See [Pattern matching](pattern-matching.html)-->
 */
 
 when


### PR DESCRIPTION
Please check the following:

`toplevel.grm`
- lines 4, 31, 51 - link to nonexistent page

`types.grm`
- line 4 - link to right page or not?
- line 17 - added semicolon to the end of block
- line 51 - removed comment

`expressions.grm`
- line 4 - link to nonexistent page

`when.grm`
- line 4 - link to nonexistent page

`lexical.grm`
- line 61 - link to non implemented feature Non-local returns
