### PR TITLE
Refined merging logic #KT-5844 Fixed

### DIFF
--- a/compiler/backend/src/org/jetbrains/jet/codegen/optimization/boxing/BoxingInterpreter.java
+++ b/compiler/backend/src/org/jetbrains/jet/codegen/optimization/boxing/BoxingInterpreter.java
@@ -211,22 +211,12 @@ public class BoxingInterpreter extends OptimizationBasicInterpreter {
             return v;
         }
 
-        if (v instanceof BoxedBasicValue && w == BasicValue.UNINITIALIZED_VALUE) {
-            return v;
-        }
-
-        if (w instanceof BoxedBasicValue && v == BasicValue.UNINITIALIZED_VALUE) {
-            return w;
-        }
-
         if (v instanceof BoxedBasicValue) {
             onMergeFail((BoxedBasicValue) v);
-            return MIXED_VALUE;
         }
 
         if (w instanceof BoxedBasicValue) {
             onMergeFail((BoxedBasicValue) w);
-            return MIXED_VALUE;
         }
 
         return super.merge(v, w);

--- a/compiler/testData/codegen/boxWithStdlib/boxingOptimization/kt5844.kt
+++ b/compiler/testData/codegen/boxWithStdlib/boxingOptimization/kt5844.kt
@@ -1,0 +1,28 @@
+import kotlin.test.assertEquals
+
+fun test1() {
+    val u = when (true) {
+        true -> 42
+        else -> 1.0
+    }
+
+    assertEquals(42, u)
+}
+
+fun test2() {
+    val u = 1L.let {
+        when (it) {
+            is Long -> if (it.toLong() == 2L) it.toLong() else it * 2L // CompilationException
+            else -> it.toDouble()
+        }
+    }
+
+    assertEquals(2L, u)
+}
+
+fun box(): String {
+    test1()
+    test2()
+    return "OK"
+}
+

--- a/compiler/tests/org/jetbrains/jet/codegen/generated/BlackBoxWithStdlibCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/jet/codegen/generated/BlackBoxWithStdlibCodegenTestGenerated.java
@@ -169,6 +169,12 @@ public class BlackBoxWithStdlibCodegenTestGenerated extends AbstractBlackBoxCode
             doTestWithStdlib(fileName);
         }
         
+        @TestMetadata("kt5844.kt")
+        public void testKt5844() throws Exception {
+            String fileName = JetTestUtils.navigationMetadata("compiler/testData/codegen/boxWithStdlib/boxingOptimization/kt5844.kt");
+            doTestWithStdlib(fileName);
+        }
+        
         @TestMetadata("nullCheck.kt")
         public void testNullCheck() throws Exception {
             String fileName = JetTestUtils.navigationMetadata("compiler/testData/codegen/boxWithStdlib/boxingOptimization/nullCheck.kt");


### PR DESCRIPTION
If merging primitives of different integral types (e.g. I and Z) return
INT.
Else return UNINITIALIZED_VALUE

This changes were previously commited and discussed within #509 
