### PR TITLE
Correct Android variant compile task name

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-core/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin-core/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt
@@ -199,7 +199,7 @@ open class KotlinAndroidPlugin [Inject] (val scriptHandler: ScriptHandler): Plug
                 val javaTask = variant.getJavaCompile()!!
                 val variantName = variant.getName()
 
-                val kotlinTaskName = "compile${variantName}Kotlin"
+                val kotlinTaskName = "compile${variantName.capitalize()}Kotlin"
                 val kotlinTask: KotlinCompile = project.getTasks().create(kotlinTaskName, javaClass<KotlinCompile>())
                 kotlinTask.kotlinOptions = kotlinOptions
 


### PR DESCRIPTION
Corrects 'compiledebugKotlin' to 'compileDebugKotlin'
