### PR TITLE
Improvements for arrays in stdlib (Fixes KT-1313 and KT-6577)

### DIFF
--- a/libraries/stdlib/src/generated/_Arrays.kt
+++ b/libraries/stdlib/src/generated/_Arrays.kt
@@ -10,6 +10,87 @@ import java.util.*
 import java.util.Collections // TODO: it's temporary while we have java.util.Collections in js
 
 /**
+ * Returns the Iterable that wraps the original array
+ */
+public fun <T> Array<out T>.asIterable(): Iterable<T> {
+    return object : Iterable<T> {
+        override fun iterator(): Iterator<T> = this@asIterable.iterator()
+    }
+}
+
+/**
+ * Returns the Iterable that wraps the original array
+ */
+public fun BooleanArray.asIterable(): Iterable<Boolean> {
+    return object : Iterable<Boolean> {
+        override fun iterator(): Iterator<Boolean> = this@asIterable.iterator()
+    }
+}
+
+/**
+ * Returns the Iterable that wraps the original array
+ */
+public fun ByteArray.asIterable(): Iterable<Byte> {
+    return object : Iterable<Byte> {
+        override fun iterator(): Iterator<Byte> = this@asIterable.iterator()
+    }
+}
+
+/**
+ * Returns the Iterable that wraps the original array
+ */
+public fun CharArray.asIterable(): Iterable<Char> {
+    return object : Iterable<Char> {
+        override fun iterator(): Iterator<Char> = this@asIterable.iterator()
+    }
+}
+
+/**
+ * Returns the Iterable that wraps the original array
+ */
+public fun DoubleArray.asIterable(): Iterable<Double> {
+    return object : Iterable<Double> {
+        override fun iterator(): Iterator<Double> = this@asIterable.iterator()
+    }
+}
+
+/**
+ * Returns the Iterable that wraps the original array
+ */
+public fun FloatArray.asIterable(): Iterable<Float> {
+    return object : Iterable<Float> {
+        override fun iterator(): Iterator<Float> = this@asIterable.iterator()
+    }
+}
+
+/**
+ * Returns the Iterable that wraps the original array
+ */
+public fun IntArray.asIterable(): Iterable<Int> {
+    return object : Iterable<Int> {
+        override fun iterator(): Iterator<Int> = this@asIterable.iterator()
+    }
+}
+
+/**
+ * Returns the Iterable that wraps the original array
+ */
+public fun LongArray.asIterable(): Iterable<Long> {
+    return object : Iterable<Long> {
+        override fun iterator(): Iterator<Long> = this@asIterable.iterator()
+    }
+}
+
+/**
+ * Returns the Iterable that wraps the original array
+ */
+public fun ShortArray.asIterable(): Iterable<Short> {
+    return object : Iterable<Short> {
+        override fun iterator(): Iterator<Short> = this@asIterable.iterator()
+    }
+}
+
+/**
  * Returns true if the array is empty
  */
 public fun <T> Array<out T>.isEmpty(): Boolean {

--- a/libraries/stdlib/src/generated/_Elements.kt
+++ b/libraries/stdlib/src/generated/_Elements.kt
@@ -1138,6 +1138,152 @@ public fun <T> Stream<T>.indexOf(element: T): Int {
 }
 
 /**
+ * Returns index of the first element matching the given *predicate*, or -1 if the collection does not contain such element
+ */
+public inline fun <T> Array<out T>.indexOf(predicate: (T) -> Boolean): Int {
+    for (index in indices) {
+        if (predicate(this[index])) {
+            return index
+        }
+    }
+    return -1
+}
+
+/**
+ * Returns index of the first element matching the given *predicate*, or -1 if the collection does not contain such element
+ */
+public inline fun BooleanArray.indexOf(predicate: (Boolean) -> Boolean): Int {
+    for (index in indices) {
+        if (predicate(this[index])) {
+            return index
+        }
+    }
+    return -1
+}
+
+/**
+ * Returns index of the first element matching the given *predicate*, or -1 if the collection does not contain such element
+ */
+public inline fun ByteArray.indexOf(predicate: (Byte) -> Boolean): Int {
+    for (index in indices) {
+        if (predicate(this[index])) {
+            return index
+        }
+    }
+    return -1
+}
+
+/**
+ * Returns index of the first element matching the given *predicate*, or -1 if the collection does not contain such element
+ */
+public inline fun CharArray.indexOf(predicate: (Char) -> Boolean): Int {
+    for (index in indices) {
+        if (predicate(this[index])) {
+            return index
+        }
+    }
+    return -1
+}
+
+/**
+ * Returns index of the first element matching the given *predicate*, or -1 if the collection does not contain such element
+ */
+public inline fun DoubleArray.indexOf(predicate: (Double) -> Boolean): Int {
+    for (index in indices) {
+        if (predicate(this[index])) {
+            return index
+        }
+    }
+    return -1
+}
+
+/**
+ * Returns index of the first element matching the given *predicate*, or -1 if the collection does not contain such element
+ */
+public inline fun FloatArray.indexOf(predicate: (Float) -> Boolean): Int {
+    for (index in indices) {
+        if (predicate(this[index])) {
+            return index
+        }
+    }
+    return -1
+}
+
+/**
+ * Returns index of the first element matching the given *predicate*, or -1 if the collection does not contain such element
+ */
+public inline fun IntArray.indexOf(predicate: (Int) -> Boolean): Int {
+    for (index in indices) {
+        if (predicate(this[index])) {
+            return index
+        }
+    }
+    return -1
+}
+
+/**
+ * Returns index of the first element matching the given *predicate*, or -1 if the collection does not contain such element
+ */
+public inline fun LongArray.indexOf(predicate: (Long) -> Boolean): Int {
+    for (index in indices) {
+        if (predicate(this[index])) {
+            return index
+        }
+    }
+    return -1
+}
+
+/**
+ * Returns index of the first element matching the given *predicate*, or -1 if the collection does not contain such element
+ */
+public inline fun ShortArray.indexOf(predicate: (Short) -> Boolean): Int {
+    for (index in indices) {
+        if (predicate(this[index])) {
+            return index
+        }
+    }
+    return -1
+}
+
+/**
+ * Returns index of the first element matching the given *predicate*, or -1 if the collection does not contain such element
+ */
+public inline fun <T> Iterable<T>.indexOf(predicate: (T) -> Boolean): Int {
+    var index = 0
+    for (item in this) {
+        if (predicate(item))
+            return index
+        index++
+    }
+    return -1
+}
+
+/**
+ * Returns index of the first element matching the given *predicate*, or -1 if the collection does not contain such element
+ */
+public inline fun <T> Stream<T>.indexOf(predicate: (T) -> Boolean): Int {
+    var index = 0
+    for (item in this) {
+        if (predicate(item))
+            return index
+        index++
+    }
+    return -1
+}
+
+/**
+ * Returns index of the first element matching the given *predicate*, or -1 if the collection does not contain such element
+ */
+public inline fun String.indexOf(predicate: (Char) -> Boolean): Int {
+    for (index in indices) {
+        if (predicate(this[index])) {
+            return index
+        }
+    }
+    return -1
+}
+
+/**
  * Returns last element
  */
 public fun <T> Array<out T>.last(): T {
@@ -1626,6 +1772,154 @@ public fun <T> Stream<T>.lastIndexOf(element: T): Int {
         index++
     }
     return lastIndex
+}
+
+/**
+ * Returns index of the last element matching the given *predicate*, or -1 if the collection does not contain such element
+ */
+public inline fun <T> Array<out T>.lastIndexOf(predicate: (T) -> Boolean): Int {
+    for (index in indices.reversed()) {
+        if (predicate(this[index])) {
+            return index
+        }
+    }
+    return -1
+}
+
+/**
+ * Returns index of the last element matching the given *predicate*, or -1 if the collection does not contain such element
+ */
+public inline fun BooleanArray.lastIndexOf(predicate: (Boolean) -> Boolean): Int {
+    for (index in indices.reversed()) {
+        if (predicate(this[index])) {
+            return index
+        }
+    }
+    return -1
+}
+
+/**
+ * Returns index of the last element matching the given *predicate*, or -1 if the collection does not contain such element
+ */
+public inline fun ByteArray.lastIndexOf(predicate: (Byte) -> Boolean): Int {
+    for (index in indices.reversed()) {
+        if (predicate(this[index])) {
+            return index
+        }
+    }
+    return -1
+}
+
+/**
+ * Returns index of the last element matching the given *predicate*, or -1 if the collection does not contain such element
+ */
+public inline fun CharArray.lastIndexOf(predicate: (Char) -> Boolean): Int {
+    for (index in indices.reversed()) {
+        if (predicate(this[index])) {
+            return index
+        }
+    }
+    return -1
+}
+
+/**
+ * Returns index of the last element matching the given *predicate*, or -1 if the collection does not contain such element
+ */
+public inline fun DoubleArray.lastIndexOf(predicate: (Double) -> Boolean): Int {
+    for (index in indices.reversed()) {
+        if (predicate(this[index])) {
+            return index
+        }
+    }
+    return -1
+}
+
+/**
+ * Returns index of the last element matching the given *predicate*, or -1 if the collection does not contain such element
+ */
+public inline fun FloatArray.lastIndexOf(predicate: (Float) -> Boolean): Int {
+    for (index in indices.reversed()) {
+        if (predicate(this[index])) {
+            return index
+        }
+    }
+    return -1
+}
+
+/**
+ * Returns index of the last element matching the given *predicate*, or -1 if the collection does not contain such element
+ */
+public inline fun IntArray.lastIndexOf(predicate: (Int) -> Boolean): Int {
+    for (index in indices.reversed()) {
+        if (predicate(this[index])) {
+            return index
+        }
+    }
+    return -1
+}
+
+/**
+ * Returns index of the last element matching the given *predicate*, or -1 if the collection does not contain such element
+ */
+public inline fun LongArray.lastIndexOf(predicate: (Long) -> Boolean): Int {
+    for (index in indices.reversed()) {
+        if (predicate(this[index])) {
+            return index
+        }
+    }
+    return -1
+}
+
+/**
+ * Returns index of the last element matching the given *predicate*, or -1 if the collection does not contain such element
+ */
+public inline fun ShortArray.lastIndexOf(predicate: (Short) -> Boolean): Int {
+    for (index in indices.reversed()) {
+        if (predicate(this[index])) {
+            return index
+        }
+    }
+    return -1
+}
+
+/**
+ * Returns index of the last element matching the given *predicate*, or -1 if the collection does not contain such element
+ */
+public inline fun <T> Iterable<T>.lastIndexOf(predicate: (T) -> Boolean): Int {
+    var lastIndex = -1
+    var index = 0
+    for (item in this) {
+        if (predicate(item))
+            lastIndex = index
+        index++
+    }
+    return lastIndex
+}
+
+/**
+ * Returns index of the last element matching the given *predicate*, or -1 if the collection does not contain such element
+ */
+public inline fun <T> Stream<T>.lastIndexOf(predicate: (T) -> Boolean): Int {
+    var lastIndex = -1
+    var index = 0
+    for (item in this) {
+        if (predicate(item))
+            lastIndex = index
+        index++
+    }
+    return lastIndex
+}
+
+/**
+ * Returns index of the last element matching the given *predicate*, or -1 if the collection does not contain such element
+ */
+public inline fun String.lastIndexOf(predicate: (Char) -> Boolean): Int {
+    for (index in indices.reversed()) {
+        if (predicate(this[index])) {
+            return index
+        }
+    }
+    return -1
 }
 
 /**

--- a/libraries/stdlib/src/generated/_Snapshots.kt
+++ b/libraries/stdlib/src/generated/_Snapshots.kt
@@ -10,6 +10,133 @@ import java.util.*
 import java.util.Collections // TODO: it's temporary while we have java.util.Collections in js
 
 /**
+ * Returns a list that wraps the original array
+ */
+public fun <T> Array<out T>.asList(): List<T> {
+    return Arrays.asList(*this)
+}
+
+/**
+ * Returns a list that wraps the original array
+ */
+public fun BooleanArray.asList(): List<Boolean> {
+    return object : AbstractList<Boolean>(), RandomAccess {
+        override fun size(): Int = this@asList.size()
+        override fun isEmpty(): Boolean = this@asList.isEmpty()
+        override fun contains(o: Any?): Boolean = this@asList.contains(o as Boolean)
+        override fun iterator(): Iterator<Boolean> = this@asList.iterator()
+        override fun get(index: Int): Boolean = this@asList[index]
+        override fun indexOf(o: Any?): Int = this@asList.indexOf(o as Boolean)
+        override fun lastIndexOf(o: Any?): Int = this@asList.lastIndexOf(o as Boolean)
+    }
+}
+
+/**
+ * Returns a list that wraps the original array
+ */
+public fun ByteArray.asList(): List<Byte> {
+    return object : AbstractList<Byte>(), RandomAccess {
+        override fun size(): Int = this@asList.size()
+        override fun isEmpty(): Boolean = this@asList.isEmpty()
+        override fun contains(o: Any?): Boolean = this@asList.contains(o as Byte)
+        override fun iterator(): Iterator<Byte> = this@asList.iterator()
+        override fun get(index: Int): Byte = this@asList[index]
+        override fun indexOf(o: Any?): Int = this@asList.indexOf(o as Byte)
+        override fun lastIndexOf(o: Any?): Int = this@asList.lastIndexOf(o as Byte)
+    }
+}
+
+/**
+ * Returns a list that wraps the original array
+ */
+public fun CharArray.asList(): List<Char> {
+    return object : AbstractList<Char>(), RandomAccess {
+        override fun size(): Int = this@asList.size()
+        override fun isEmpty(): Boolean = this@asList.isEmpty()
+        override fun contains(o: Any?): Boolean = this@asList.contains(o as Char)
+        override fun iterator(): Iterator<Char> = this@asList.iterator()
+        override fun get(index: Int): Char = this@asList[index]
+        override fun indexOf(o: Any?): Int = this@asList.indexOf(o as Char)
+        override fun lastIndexOf(o: Any?): Int = this@asList.lastIndexOf(o as Char)
+    }
+}
+
+/**
+ * Returns a list that wraps the original array
+ */
+public fun DoubleArray.asList(): List<Double> {
+    return object : AbstractList<Double>(), RandomAccess {
+        override fun size(): Int = this@asList.size()
+        override fun isEmpty(): Boolean = this@asList.isEmpty()
+        override fun contains(o: Any?): Boolean = this@asList.contains(o as Double)
+        override fun iterator(): Iterator<Double> = this@asList.iterator()
+        override fun get(index: Int): Double = this@asList[index]
+        override fun indexOf(o: Any?): Int = this@asList.indexOf(o as Double)
+        override fun lastIndexOf(o: Any?): Int = this@asList.lastIndexOf(o as Double)
+    }
+}
+
+/**
+ * Returns a list that wraps the original array
+ */
+public fun FloatArray.asList(): List<Float> {
+    return object : AbstractList<Float>(), RandomAccess {
+        override fun size(): Int = this@asList.size()
+        override fun isEmpty(): Boolean = this@asList.isEmpty()
+        override fun contains(o: Any?): Boolean = this@asList.contains(o as Float)
+        override fun iterator(): Iterator<Float> = this@asList.iterator()
+        override fun get(index: Int): Float = this@asList[index]
+        override fun indexOf(o: Any?): Int = this@asList.indexOf(o as Float)
+        override fun lastIndexOf(o: Any?): Int = this@asList.lastIndexOf(o as Float)
+    }
+}
+
+/**
+ * Returns a list that wraps the original array
+ */
+public fun IntArray.asList(): List<Int> {
+    return object : AbstractList<Int>(), RandomAccess {
+        override fun size(): Int = this@asList.size()
+        override fun isEmpty(): Boolean = this@asList.isEmpty()
+        override fun contains(o: Any?): Boolean = this@asList.contains(o as Int)
+        override fun iterator(): Iterator<Int> = this@asList.iterator()
+        override fun get(index: Int): Int = this@asList[index]
+        override fun indexOf(o: Any?): Int = this@asList.indexOf(o as Int)
+        override fun lastIndexOf(o: Any?): Int = this@asList.lastIndexOf(o as Int)
+    }
+}
+
+/**
+ * Returns a list that wraps the original array
+ */
+public fun LongArray.asList(): List<Long> {
+    return object : AbstractList<Long>(), RandomAccess {
+        override fun size(): Int = this@asList.size()
+        override fun isEmpty(): Boolean = this@asList.isEmpty()
+        override fun contains(o: Any?): Boolean = this@asList.contains(o as Long)
+        override fun iterator(): Iterator<Long> = this@asList.iterator()
+        override fun get(index: Int): Long = this@asList[index]
+        override fun indexOf(o: Any?): Int = this@asList.indexOf(o as Long)
+        override fun lastIndexOf(o: Any?): Int = this@asList.lastIndexOf(o as Long)
+    }
+}
+
+/**
+ * Returns a list that wraps the original array
+ */
+public fun ShortArray.asList(): List<Short> {
+    return object : AbstractList<Short>(), RandomAccess {
+        override fun size(): Int = this@asList.size()
+        override fun isEmpty(): Boolean = this@asList.isEmpty()
+        override fun contains(o: Any?): Boolean = this@asList.contains(o as Short)
+        override fun iterator(): Iterator<Short> = this@asList.iterator()
+        override fun get(index: Int): Short = this@asList[index]
+        override fun indexOf(o: Any?): Int = this@asList.indexOf(o as Short)
+        override fun lastIndexOf(o: Any?): Int = this@asList.lastIndexOf(o as Short)
+    }
+}
+
+/**
  * Returns an ArrayList of all elements
  */
 public fun <T> Array<out T>.toArrayList(): ArrayList<T> {

--- a/libraries/stdlib/test/collections/ArraysTest.kt
+++ b/libraries/stdlib/test/collections/ArraysTest.kt
@@ -266,6 +266,73 @@ class ArraysTest {
         assertEquals(iter4.toList(), emptyList<String>())
     }
 
+    test fun asList() {
+        // Array of primitives
+        val arr1 = intArray(1, 2, 3, 4, 2, 5)
+        val list1 = arr1.asList()
+
+        assertEquals(list1, arr1.toList())
+
+        assertTrue(2 in list1)
+        assertFalse(0 in list1)
+
+        expect(1) { list1.indexOf(2) }
+        expect(4) { list1.lastIndexOf(2) }
+        expect(-1) { list1.indexOf(6) }
+
+        assertTrue(list1.containsAll(listOf(5, 4, 3)))
+        assertFalse(list1.containsAll(listOf(5, 6, 3)))
+
+        assertEquals(list1.subList(3, 5), listOf(4, 2))
+
+        val iter1 = list1.listIterator(2)
+        expect(2) { iter1.nextIndex() }
+        expect(1) { iter1.previousIndex() }
+        expect(3) {
+            iter1.next()
+            iter1.previous()
+            iter1.next()
+        }
+
+        // Array of objects
+        val arr2 = array("a", "b", "c", "d", "b", "e")
+        val list2 = arr2.asList()
+
+        assertEquals(list2, arr2.toList())
+
+        assertTrue("b" in list2)
+        assertFalse("z" in list2)
+
+        expect(1) { list2.indexOf("b") }
+        expect(4) { list2.lastIndexOf("b") }
+        expect(-1) { list2.indexOf("x") }
+
+        assertTrue(list2.containsAll(listOf("e", "d", "c")))
+        assertFalse(list2.containsAll(listOf("e", "x", "c")))
+
+        assertEquals(list2.subList(3, 5), listOf("d", "b"))
+
+        val iter2 = list2.listIterator(2)
+        expect(2) { iter2.nextIndex() }
+        expect(1) { iter2.previousIndex() }
+        expect("c") {
+            iter2.next()
+            iter2.previous()
+            iter2.next()
+        }
+
+        // Empty arrays
+        val arr3 = IntArray(0)
+        val list3 = arr3.asList()
+
+        assertEquals(list3, emptyList<Int>())
+
+        val arr4 = Array(0, {"$it"})
+        val list4 = arr4.asList()
+
+        assertEquals(list4, emptyList<String>())
+    }
+
     /*
 
     TODO FIXME ASAP: These currently fail on JS due to missing upto() method on numbers

--- a/libraries/stdlib/test/collections/ArraysTest.kt
+++ b/libraries/stdlib/test/collections/ArraysTest.kt
@@ -162,7 +162,37 @@ class ArraysTest {
         expect(0) { array("cat", "dog", "bird").indexOf("cat") }
         expect(1) { array("cat", "dog", "bird").indexOf("dog") }
         expect(2) { array("cat", "dog", "bird").indexOf("bird") }
-        expect(0) { array(null, "dog", null).indexOf(null)}
+        expect(0) { array(null, "dog", null).indexOf(null : String?)}
+
+        expect(-1) { array("cat", "dog", "bird").indexOf {it.contains("p")} }
+        expect(0) { array("cat", "dog", "bird").indexOf {it.startsWith('c')} }
+        expect(1) { array("cat", "dog", "bird").indexOf {it.startsWith('d')} }
+        expect(2) { array("cat", "dog", "bird").indexOf {it.endsWith('d')} }
+
+        expect(-1) { streamOf("cat", "dog", "bird").indexOf {it.contains("p")} }
+        expect(0) { streamOf("cat", "dog", "bird").indexOf {it.startsWith('c')} }
+        expect(1) { streamOf("cat", "dog", "bird").indexOf {it.startsWith('d')} }
+        expect(2) { streamOf("cat", "dog", "bird").indexOf {it.endsWith('d')} }
+    }
+
+    test fun lastIndexOf() {
+        expect(-1) { array("cat", "dog", "bird").lastIndexOf("mouse") }
+        expect(0) { array("cat", "dog", "bird").lastIndexOf("cat") }
+        expect(1) { array("cat", "dog", "bird").lastIndexOf("dog") }
+        expect(2) { array(null, "dog", null).lastIndexOf(null : String?)}
+        expect(3) { array("cat", "dog", "bird", "dog").lastIndexOf("dog") }
+
+        expect(-1) { array("cat", "dog", "bird").lastIndexOf {it.contains("p")} }
+        expect(0) { array("cat", "dog", "bird").lastIndexOf {it.startsWith('c')} }
+        expect(2) { array("cat", "dog", "cap", "bird").lastIndexOf {it.startsWith('c')} }
+        expect(2) { array("cat", "dog", "bird").lastIndexOf {it.endsWith('d')} }
+        expect(3) { array("cat", "dog", "bird", "red").lastIndexOf {it.endsWith('d')} }
+
+        expect(-1) { streamOf("cat", "dog", "bird").lastIndexOf {it.contains("p")} }
+        expect(0) { streamOf("cat", "dog", "bird").lastIndexOf {it.startsWith('c')} }
+        expect(2) { streamOf("cat", "dog", "cap", "bird").lastIndexOf {it.startsWith('c')} }
+        expect(2) { streamOf("cat", "dog", "bird").lastIndexOf {it.endsWith('d')} }
+        expect(3) { streamOf("cat", "dog", "bird", "red").lastIndexOf {it.endsWith('d')} }
     }
 
     test fun plus() {

--- a/libraries/stdlib/test/collections/ArraysTest.kt
+++ b/libraries/stdlib/test/collections/ArraysTest.kt
@@ -245,11 +245,25 @@ class ArraysTest {
     }
 
     test fun asIterable() {
-        val a = intArray(1, 2, 3, 4, 5)
-        val iter = a.asIterable()
-        assertEquals(a.toList(), iter.toList())
-        a[0] = 0
-        assertEquals(a.toList(), iter.toList())
+        val arr1 = intArray(1, 2, 3, 4, 5)
+        val iter1 = arr1.asIterable()
+        assertEquals(arr1.toList(), iter1.toList())
+        arr1[0] = 0
+        assertEquals(arr1.toList(), iter1.toList())
+
+        val arr2 = array("one", "two", "three")
+        val iter2 = arr2.asIterable()
+        assertEquals(arr2.toList(), iter2.toList())
+        arr2[0] = ""
+        assertEquals(arr2.toList(), iter2.toList())
+
+        val arr3 = IntArray(0)
+        val iter3 = arr3.asIterable()
+        assertEquals(iter3.toList(), emptyList<Int>())
+
+        val arr4 = Array(0, {"$it"})
+        val iter4 = arr4.asIterable()
+        assertEquals(iter4.toList(), emptyList<String>())
     }
 
     /*

--- a/libraries/stdlib/test/collections/ArraysTest.kt
+++ b/libraries/stdlib/test/collections/ArraysTest.kt
@@ -214,6 +214,14 @@ class ArraysTest {
         assertEquals(listOf("aab", "aba", "ac"), array("ac", "aab", "aba").toSortedList())
     }
 
+    test fun asIterable() {
+        val a = intArray(1, 2, 3, 4, 5)
+        val iter = a.asIterable()
+        assertEquals(a.toList(), iter.toList())
+        a[0] = 0
+        assertEquals(a.toList(), iter.toList())
+    }
+
     /*
 
     TODO FIXME ASAP: These currently fail on JS due to missing upto() method on numbers

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Arrays.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Arrays.kt
@@ -23,5 +23,18 @@ fun arrays(): List<GenericFunction> {
         }
     }
 
+    templates add f("asIterable()") {
+        only(ArraysOfObjects, ArraysOfPrimitives)
+        doc { "Returns the Iterable that wraps the original array" }
+        returns("Iterable<T>")
+        body {
+            """
+            return object : Iterable<T> {
+                override fun iterator(): Iterator<T> = this@asIterable.iterator()
+            }
+            """
+        }
+    }
+
     return templates
 }

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Elements.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Elements.kt
@@ -69,6 +69,36 @@ fun elements(): List<GenericFunction> {
         }
     }
 
+    templates add f("indexOf(predicate: (T) -> Boolean)") {
+        inline(true)
+        exclude(Lists) // Clashes with List<T>.indexOf(o: Any?)
+
+        doc { "Returns index of the first element matching the given *predicate*, or -1 if the collection does not contain such element" }
+        returns("Int")
+        body {
+            """
+            var index = 0
+            for (item in this) {
+                if (predicate(item))
+                    return index
+                index++
+            }
+            return -1
+            """
+        }
+
+        body(Strings, ArraysOfPrimitives, ArraysOfObjects) {
+            """
+            for (index in indices) {
+                if (predicate(this[index])) {
+                    return index
+                }
+            }
+            return -1
+            """
+        }
+    }
+
     templates add f("lastIndexOf(element: T)") {
         exclude(Strings) // has native implementation
         doc { "Returns last index of *element*, or -1 if the collection does not contain element" }
@@ -113,6 +143,37 @@ fun elements(): List<GenericFunction> {
             }
             return -1
            """
+        }
+    }
+
+    templates add f("lastIndexOf(predicate: (T) -> Boolean)") {
+        inline(true)
+        exclude(Lists) // Clashes with List<T>.lastIndexOf(o: Any?)
+
+        doc { "Returns index of the last element matching the given *predicate*, or -1 if the collection does not contain such element" }
+        returns("Int")
+        body {
+            """
+            var lastIndex = -1
+            var index = 0
+            for (item in this) {
+                if (predicate(item))
+                    lastIndex = index
+                index++
+            }
+            return lastIndex
+            """
+        }
+
+        body(Strings, ArraysOfPrimitives, ArraysOfObjects) {
+            """
+            for (index in indices.reversed()) {
+                if (predicate(this[index])) {
+                    return index
+                }
+            }
+            return -1
+            """
         }
     }
 

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Snapshots.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Snapshots.kt
@@ -87,6 +87,31 @@ fun snapshots(): List<GenericFunction> {
         body { "return toCollection(LinkedList<T>())" }
     }
 
+    templates add f("asList()") {
+        only(ArraysOfObjects, ArraysOfPrimitives)
+        doc { "Returns a list that wraps the original array" }
+        returns("List<T>")
+        body(ArraysOfObjects) {
+            """
+            return Arrays.asList(*this)
+            """
+        }
+
+        body(ArraysOfPrimitives) {
+            """
+            return object : AbstractList<T>(), RandomAccess {
+                override fun size(): Int = this@asList.size()
+                override fun isEmpty(): Boolean = this@asList.isEmpty()
+                override fun contains(o: Any?): Boolean = this@asList.contains(o as T)
+                override fun iterator(): Iterator<T> = this@asList.iterator()
+                override fun get(index: Int): T = this@asList[index]
+                override fun indexOf(o: Any?): Int = this@asList.indexOf(o as T)
+                override fun lastIndexOf(o: Any?): Int = this@asList.lastIndexOf(o as T)
+            }
+            """
+        }
+    }
+
     templates add f("toMap(selector: (T) -> K)") {
         inline(true)
         typeParam("K")


### PR DESCRIPTION
Implemented asIterable and indexOf(predicate) for arrays.

https://youtrack.jetbrains.com/issue/KT-1313
https://youtrack.jetbrains.com/issue/KT-6577