### PR TITLE
Fix retrieving documentation for overridden methods.

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/kdoc/KDocFinder.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/kdoc/KDocFinder.kt
@@ -46,7 +46,7 @@ object KDocFinder {
 
         if (declaration is CallableDescriptor) {
             for (baseDescriptor in declaration.getOverriddenDescriptors()) {
-                val baseKDoc = findKDoc(baseDescriptor)
+                val baseKDoc = findKDoc(baseDescriptor.getOriginal())
                 if (baseKDoc != null) {
                     return baseKDoc
                 }

--- a/idea/testData/kdoc/finder/Overridden.kt
+++ b/idea/testData/kdoc/finder/Overridden.kt
@@ -1,0 +1,10 @@
+open class Foo() {
+    /**
+     * Doc for method xyzzy
+     */
+    open fun xyzzy(): Int = 0
+}
+
+open class Bar(): Foo() {
+    override fun xyzzy(): Int = 1
+}

--- a/idea/testData/kdoc/finder/OverriddenWithSubstitutedType.kt
+++ b/idea/testData/kdoc/finder/OverriddenWithSubstitutedType.kt
@@ -1,0 +1,10 @@
+open class Foo<T>() {
+    /**
+     * Doc for method xyzzy
+     */
+    open fun xyzzy(): Int = 0
+}
+
+open class Bar(): Foo<String>() {
+    override fun xyzzy(): Int = 1
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/kdoc/KDocFinderTest.kt
+++ b/idea/tests/org/jetbrains/kotlin/idea/kdoc/KDocFinderTest.kt
@@ -16,12 +16,13 @@
 
 package org.jetbrains.kotlin.idea.kdoc
 
-import org.jetbrains.kotlin.idea.PluginTestCaseBase
 import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase
-import org.jetbrains.kotlin.psi.JetFile
-import org.jetbrains.kotlin.idea.caches.resolve.resolveToDescriptor
-import org.junit.Assert
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
+import org.jetbrains.kotlin.idea.PluginTestCaseBase
+import org.jetbrains.kotlin.idea.caches.resolve.resolveToDescriptor
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.psi.JetFile
+import org.junit.Assert
 
 public class KDocFinderTest() : LightPlatformCodeInsightFixtureTestCase() {
     override fun getTestDataPath(): String {
@@ -35,5 +36,14 @@ public class KDocFinderTest() : LightPlatformCodeInsightFixtureTestCase() {
         val constructorDescriptor = descriptor.getUnsubstitutedPrimaryConstructor()
         val doc = KDocFinder.findKDoc(constructorDescriptor)
         Assert.assertEquals("Doc for constructor of class C.", doc!!.getContent())
+    }
+
+    public fun testOverridden() {
+        myFixture.configureByFile(getTestName(false) + ".kt")
+        val declaration = (myFixture.getFile() as JetFile).getDeclarations().single { it.getName() == "Bar" }
+        val descriptor = declaration.resolveToDescriptor() as ClassDescriptor
+        val overriddenFunctionDescriptor = descriptor.getDefaultType().getMemberScope().getFunctions(Name.identifier("xyzzy")).single()
+        val doc = KDocFinder.findKDoc(overriddenFunctionDescriptor)
+        Assert.assertEquals("Doc for method xyzzy", doc!!.getContent())
     }
 }

--- a/idea/tests/org/jetbrains/kotlin/idea/kdoc/KDocFinderTest.kt
+++ b/idea/tests/org/jetbrains/kotlin/idea/kdoc/KDocFinderTest.kt
@@ -46,4 +46,13 @@ public class KDocFinderTest() : LightPlatformCodeInsightFixtureTestCase() {
         val doc = KDocFinder.findKDoc(overriddenFunctionDescriptor)
         Assert.assertEquals("Doc for method xyzzy", doc!!.getContent())
     }
+
+    public fun testOverriddenWithSubstitutedType() {
+        myFixture.configureByFile(getTestName(false) + ".kt")
+        val declaration = (myFixture.getFile() as JetFile).getDeclarations().single { it.getName() == "Bar" }
+        val descriptor = declaration.resolveToDescriptor() as ClassDescriptor
+        val overriddenFunctionDescriptor = descriptor.getDefaultType().getMemberScope().getFunctions(Name.identifier("xyzzy")).single()
+        val doc = KDocFinder.findKDoc(overriddenFunctionDescriptor)
+        Assert.assertEquals("Doc for method xyzzy", doc!!.getContent())
+    }
 }


### PR DESCRIPTION
(The test doesn't actually reproduce the problem because it can't be done in a single-file setup, but it verifies that the basic functionality continues to work.)