### PR TITLE
generate correct bytecode for constructors using infix call syntax

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/ExpressionCodegen.java
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/ExpressionCodegen.java
@@ -2910,6 +2910,10 @@ public class ExpressionCodegen extends JetVisitor<StackValue, StackValue> implem
             ResolvedCall<?> resolvedCall = getResolvedCallWithAssert(expression, bindingContext);
             FunctionDescriptor descriptor = (FunctionDescriptor) resolvedCall.getResultingDescriptor();
 
+            if (descriptor instanceof ConstructorDescriptor) {
+                return generateConstructorCall(resolvedCall, expressionType(expression));
+            }
+
             Callable callable = resolveToCallable(descriptor, false);
             if (callable instanceof IntrinsicMethod) {
                 Type returnType = typeMapper.mapType(descriptor);

--- a/compiler/testData/codegen/box/innerNested/innerInfixCall.kt
+++ b/compiler/testData/codegen/box/innerNested/innerInfixCall.kt
@@ -1,0 +1,15 @@
+class Z() {
+
+    inner class Z2(val s: String) {
+
+    }
+
+    fun a(): String {
+        val s = Z() Z2 "OK"
+        return s.s
+    }
+}
+
+fun box(): String {
+     return Z().a()
+}

--- a/compiler/tests/org/jetbrains/kotlin/codegen/generated/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/generated/BlackBoxCodegenTestGenerated.java
@@ -4041,6 +4041,12 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             doTest(fileName);
         }
 
+        @TestMetadata("innerInfixCall.kt")
+        public void testInnerInfixCall() throws Exception {
+            String fileName = JetTestUtils.navigationMetadata("compiler/testData/codegen/box/innerNested/innerInfixCall.kt");
+            doTest(fileName);
+        }
+
         @TestMetadata("innerLabeledThis.kt")
         public void testInnerLabeledThis() throws Exception {
             String fileName = JetTestUtils.navigationMetadata("compiler/testData/codegen/box/innerNested/innerLabeledThis.kt");


### PR DESCRIPTION
#KT-4589 Fixed