### PR TITLE
fixed 'since-build' attribute

### DIFF
--- a/idea/src/META-INF/plugin.xml
+++ b/idea/src/META-INF/plugin.xml
@@ -6,7 +6,7 @@
   <version>@snapshot@</version>
   <vendor url="http://www.jetbrains.com">JetBrains s.r.o.</vendor>
 
-  <idea-version since-build="139.1408.1" until-build="139.9999"/>
+  <idea-version since-build="139.1408" until-build="139.9999"/>
 
   <depends optional="true" config-file="junit.xml">JUnit</depends>
   <depends optional="true" config-file="gradle.xml">org.jetbrains.plugins.gradle</depends>


### PR DESCRIPTION
It makes no sense to include attempt number in 'since/until-build' attributes because only one of these builds is publicly available, also the attempt number in these attributes currently confuses Plugin Verifier.