### PR TITLE
Support classpath argument when running scripts using the -script flag

### DIFF
--- a/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/K2JVMCompiler.java
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/K2JVMCompiler.java
@@ -176,7 +176,7 @@ public class K2JVMCompiler extends CLICompiler<K2JVMCompilerArguments> {
                 List<String> scriptArgs = arguments.freeArgs.subList(1, arguments.freeArgs.size());
                 JetCoreEnvironment environment =
                         JetCoreEnvironment.createForProduction(rootDisposable, configuration, EnvironmentConfigFiles.JVM_CONFIG_FILES);
-                KotlinToJVMBytecodeCompiler.compileAndExecuteScript(paths, environment, scriptArgs);
+                KotlinToJVMBytecodeCompiler.compileAndExecuteScript(configuration, paths, environment, scriptArgs);
             }
             else {
                 JetCoreEnvironment environment =

--- a/compiler/tests/org/jetbrains/kotlin/scripts/ScriptTest.java
+++ b/compiler/tests/org/jetbrains/kotlin/scripts/ScriptTest.java
@@ -91,7 +91,7 @@ public class ScriptTest {
 
             try {
                 JetScriptDefinitionProvider.getInstance(environment.getProject()).markFileAsScript(environment.getSourceFiles().get(0));
-                return KotlinToJVMBytecodeCompiler.compileScript(paths, environment);
+                return KotlinToJVMBytecodeCompiler.compileScript(configuration, paths, environment);
             }
             catch (CompilationException e) {
                 messageCollector.report(CompilerMessageSeverity.EXCEPTION, OutputMessageUtil.renderException(e),


### PR DESCRIPTION
I was trying to use the scripting facilities together with library of mine but was unable to add additional dependencies to the classpath. Since it worked in the REPL (using :load fileName.kts) I searched the code and wrote a patch which I think resolves the (known) issue (there is a TODO in the code).

I hope the fix fulfils the required standard, otherwise it can serve as a starting point for subsequent work.