### PR TITLE
parameters in KDoc take precedence over other identifiers

### DIFF
--- a/idea/idea-analysis/src/org/jetbrains/kotlin/idea/kdoc/KDocReference.kt
+++ b/idea/idea-analysis/src/org/jetbrains/kotlin/idea/kdoc/KDocReference.kt
@@ -16,38 +16,24 @@
 
 package org.jetbrains.kotlin.idea.kdoc
 
-import org.jetbrains.kotlin.kdoc.psi.impl.KDocLink
 import com.intellij.openapi.util.TextRange
-import org.jetbrains.kotlin.resolve.BindingContext
-import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
-import org.jetbrains.kotlin.idea.references.JetMultiReference
-import org.jetbrains.kotlin.kdoc.psi.impl.KDocTag
-import org.jetbrains.kotlin.descriptors.CallableDescriptor
 import com.intellij.psi.PsiElement
-import org.jetbrains.kotlin.descriptors.DeclarationDescriptorNonRoot
-import org.jetbrains.kotlin.resolve.scopes.JetScope
-import org.jetbrains.kotlin.descriptors.PackageFragmentDescriptor
-import org.jetbrains.kotlin.descriptors.PackageViewDescriptor
-import org.jetbrains.kotlin.descriptors.ClassDescriptor
-import org.jetbrains.kotlin.descriptors.FunctionDescriptor
-import org.jetbrains.kotlin.descriptors.PropertyDescriptor
-import org.jetbrains.kotlin.resolve.scopes.RedeclarationHandler
-import org.jetbrains.kotlin.resolve.scopes.WritableScopeImpl
-import org.jetbrains.kotlin.resolve.scopes.WritableScope
-import org.jetbrains.kotlin.resolve.scopes.ChainedScope
-import org.jetbrains.kotlin.resolve.FunctionDescriptorUtil
-import org.jetbrains.kotlin.resolve.scopes.JetScopeUtils
-import org.jetbrains.kotlin.kdoc.psi.impl.KDocName
-import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
-import org.jetbrains.kotlin.descriptors.ClassifierDescriptor
+import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.idea.caches.resolve.KotlinCacheService
-import org.jetbrains.kotlin.resolve.lazy.KotlinCodeAnalyzer
-import org.jetbrains.kotlin.resolve.source.PsiSourceElement
-import org.jetbrains.kotlin.psi.JetFile
-import org.jetbrains.kotlin.descriptors.DeclarationDescriptorWithSource
+import org.jetbrains.kotlin.idea.references.JetMultiReference
 import org.jetbrains.kotlin.kdoc.parser.KDocKnownTag
-import com.intellij.psi.PsiReference
-import org.jetbrains.kotlin.idea.caches.resolve.analyze
+import org.jetbrains.kotlin.kdoc.psi.impl.KDocLink
+import org.jetbrains.kotlin.kdoc.psi.impl.KDocName
+import org.jetbrains.kotlin.kdoc.psi.impl.KDocTag
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.psi.JetFile
+import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.FunctionDescriptorUtil
+import org.jetbrains.kotlin.resolve.lazy.KotlinCodeAnalyzer
+import org.jetbrains.kotlin.resolve.scopes.*
+import org.jetbrains.kotlin.resolve.source.PsiSourceElement
+import org.jetbrains.kotlin.utils.Printer
 
 public class KDocReference(element: KDocName): JetMultiReference<KDocName>(element) {
     override fun getTargetDescriptors(context: BindingContext): Collection<DeclarationDescriptor> {
@@ -90,8 +76,16 @@ public fun resolveKDocLink(session: KotlinCodeAnalyzer,
     var result: Collection<DeclarationDescriptor> = listOf(fromDescriptor)
     qualifiedName.forEach { nameComponent ->
         if (result.size() != 1) return listOf()
+        if (!Name.isValidIdentifier(nameComponent)) {
+            return listOf()
+        }
         val scope = getResolutionScope(session, result.first())
-        result = scope.getDescriptors().filter { it.getName().asString() == nameComponent }
+        val variable = scope.getLocalVariable(Name.identifier(nameComponent))
+        if (variable != null) {
+            result = listOf(variable)
+        } else {
+            result = scope.getDescriptors().filter { it.getName().asString() == nameComponent }
+        }
     }
 
     return result

--- a/idea/testData/kdoc/resolve/AmbiguousReference.kt
+++ b/idea/testData/kdoc/resolve/AmbiguousReference.kt
@@ -1,0 +1,12 @@
+class C {
+    fun f1() {
+    }
+
+    /**
+     * The [f<caret>1] references a parameter.
+     */
+    fun f2(f1: String) {
+    }
+}
+
+// REF: f1

--- a/idea/testData/kdoc/resolve/AmbiguousReferenceTypeParameter.kt
+++ b/idea/testData/kdoc/resolve/AmbiguousReferenceTypeParameter.kt
@@ -1,0 +1,12 @@
+class C {
+    class TT {
+    }
+
+    /**
+     * The [T<caret>T] references a type parameter.
+     */
+    class D<TT> {
+    }
+}
+
+// REF: TT

--- a/idea/tests/org/jetbrains/kotlin/idea/kdoc/KdocResolveTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/kdoc/KdocResolveTestGenerated.java
@@ -17,9 +17,10 @@
 package org.jetbrains.kotlin.idea.kdoc;
 
 import com.intellij.testFramework.TestDataPath;
-import org.jetbrains.kotlin.idea.resolve.AbstractReferenceResolveTest;
+import org.jetbrains.kotlin.test.InnerTestClasses;
 import org.jetbrains.kotlin.test.JUnit3RunnerWithInners;
 import org.jetbrains.kotlin.test.JetTestUtils;
+import org.jetbrains.kotlin.idea.resolve.AbstractReferenceResolveTest;
 import org.jetbrains.kotlin.test.TestMetadata;
 import org.junit.runner.RunWith;
 
@@ -39,6 +40,12 @@ public class KdocResolveTestGenerated extends AbstractReferenceResolveTest {
     @TestMetadata("AmbiguousReference.kt")
     public void testAmbiguousReference() throws Exception {
         String fileName = JetTestUtils.navigationMetadata("idea/testData/kdoc/resolve/AmbiguousReference.kt");
+        doTest(fileName);
+    }
+
+    @TestMetadata("AmbiguousReferenceTypeParameter.kt")
+    public void testAmbiguousReferenceTypeParameter() throws Exception {
+        String fileName = JetTestUtils.navigationMetadata("idea/testData/kdoc/resolve/AmbiguousReferenceTypeParameter.kt");
         doTest(fileName);
     }
 

--- a/idea/tests/org/jetbrains/kotlin/idea/kdoc/KdocResolveTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/kdoc/KdocResolveTestGenerated.java
@@ -17,10 +17,9 @@
 package org.jetbrains.kotlin.idea.kdoc;
 
 import com.intellij.testFramework.TestDataPath;
-import org.jetbrains.kotlin.test.InnerTestClasses;
+import org.jetbrains.kotlin.idea.resolve.AbstractReferenceResolveTest;
 import org.jetbrains.kotlin.test.JUnit3RunnerWithInners;
 import org.jetbrains.kotlin.test.JetTestUtils;
-import org.jetbrains.kotlin.idea.resolve.AbstractReferenceResolveTest;
 import org.jetbrains.kotlin.test.TestMetadata;
 import org.junit.runner.RunWith;
 
@@ -35,6 +34,12 @@ import java.util.regex.Pattern;
 public class KdocResolveTestGenerated extends AbstractReferenceResolveTest {
     public void testAllFilesPresentInResolve() throws Exception {
         JetTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/kdoc/resolve"), Pattern.compile("^(.+)\\.kt$"), true);
+    }
+
+    @TestMetadata("AmbiguousReference.kt")
+    public void testAmbiguousReference() throws Exception {
+        String fileName = JetTestUtils.navigationMetadata("idea/testData/kdoc/resolve/AmbiguousReference.kt");
+        doTest(fileName);
     }
 
     @TestMetadata("ClassSelfReference.kt")


### PR DESCRIPTION
#KT-7063 Fixed