### PR TITLE
android extensions - improved parsing layouts. Support <include> tags

### DIFF
--- a/plugins/android-compiler-plugin/src/org/jetbrains/kotlin/lang/resolve/android/AndroidConst.kt
+++ b/plugins/android-compiler-plugin/src/org/jetbrains/kotlin/lang/resolve/android/AndroidConst.kt
@@ -27,9 +27,11 @@ public object AndroidConst {
     val ID_ATTRIBUTE_NO_NAMESPACE: String = "id"
     val ID_ATTRIBUTE: String = "$ANDROID_NAMESPACE:$ID_ATTRIBUTE_NO_NAMESPACE"
     val CLASS_ATTRIBUTE_NO_NAMESPACE: String = "class"
+    val LAYOUT_ATTRIBUTE_NO_NAMESPACE: String = "layout"
 
     val ID_DECLARATION_PREFIX = "@+id/"
     val ID_USAGE_PREFIX = "@id/"
+    val LAYOUT_PREFIX = "@layout/"
 
     val CLEAR_FUNCTION_NAME = "clearFindViewByIdCache"
 }
@@ -40,6 +42,10 @@ public fun idToName(id: String): String? {
     return if (isResourceIdDeclaration(id)) id.replace(AndroidConst.ID_DECLARATION_PREFIX, "")
     else if (isResourceIdUsage(id)) id.replace(AndroidConst.ID_USAGE_PREFIX, "")
     else null
+}
+
+public fun layoutToName(layoutAttr: String?): String? {
+    return layoutAttr?.replace(AndroidConst.LAYOUT_PREFIX, "")
 }
 
 public fun isResourceIdDeclaration(str: String?): Boolean = str?.startsWith(AndroidConst.ID_DECLARATION_PREFIX) ?: false

--- a/plugins/android-compiler-plugin/src/org/jetbrains/kotlin/lang/resolve/android/AndroidUtil.kt
+++ b/plugins/android-compiler-plugin/src/org/jetbrains/kotlin/lang/resolve/android/AndroidUtil.kt
@@ -25,6 +25,7 @@ import com.intellij.psi.PsiClass
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.util.Computable
 import com.intellij.openapi.module.ModuleServiceManager
+import java.util.HashMap
 
 fun isAndroidSyntheticFile(f: PsiFile?): Boolean {
     return f?.getUserData(AndroidConst.ANDROID_USER_PACKAGE) != null
@@ -34,4 +35,20 @@ public fun isAndroidSyntheticElement(element: PsiElement?): Boolean {
     return isAndroidSyntheticFile(ApplicationManager.getApplication().runReadAction(Computable {
         element?.getContainingFile()
     }))
+}
+
+public fun elementCallback(attributesCallback: (String?, String, String?) -> Unit): (String, HashMap<String, String>) -> Unit {
+
+    return { localName, attributesMap ->
+
+        val idAttr = attributesMap[AndroidConst.ID_ATTRIBUTE_NO_NAMESPACE]
+        val classNameAttr = attributesMap[AndroidConst.CLASS_ATTRIBUTE_NO_NAMESPACE]
+        val layoutNameAttr = attributesMap[AndroidConst.LAYOUT_ATTRIBUTE_NO_NAMESPACE]
+
+        val name = if (isResourceDeclarationOrUsage(idAttr)) idToName(idAttr) else null
+        val clazz = classNameAttr ?: localName
+        val layout = layoutToName(layoutNameAttr)
+
+        attributesCallback(name, clazz, layout)
+    }
 }

--- a/plugins/android-compiler-plugin/src/org/jetbrains/kotlin/lang/resolve/android/AndroidXmlHandler.kt
+++ b/plugins/android-compiler-plugin/src/org/jetbrains/kotlin/lang/resolve/android/AndroidXmlHandler.kt
@@ -20,7 +20,7 @@ import org.xml.sax.helpers.DefaultHandler
 import org.xml.sax.Attributes
 import java.util.HashMap
 
-class AndroidXmlHandler(private val elementCallback: (String, String) -> Unit) : DefaultHandler() {
+class AndroidXmlHandler(private val elementCallback: (String, HashMap<String, String>) -> Unit) : DefaultHandler() {
 
     override fun startDocument() {
         super<DefaultHandler>.startDocument()
@@ -32,18 +32,12 @@ class AndroidXmlHandler(private val elementCallback: (String, String) -> Unit) :
 
     override fun startElement(uri: String, localName: String, qName: String, attributes: Attributes) {
         val attributesMap = attributes.toMap()
-        val idAttr = attributesMap[AndroidConst.ID_ATTRIBUTE_NO_NAMESPACE]
-        val classNameAttr = attributesMap[AndroidConst.CLASS_ATTRIBUTE_NO_NAMESPACE] ?: localName
-        if (isResourceDeclarationOrUsage(idAttr)) {
-            val name = idToName(idAttr)
-            if (name != null) elementCallback(name, classNameAttr)
-        }
+        elementCallback(localName, attributesMap)
     }
 
     override fun endElement(uri: String?, localName: String, qName: String) {
 
     }
-
 }
 
 public fun Attributes.toMap(): HashMap<String, String> {
@@ -55,5 +49,3 @@ public fun Attributes.toMap(): HashMap<String, String> {
     }
     return res
 }
-
-

--- a/plugins/android-compiler-plugin/src/org/jetbrains/kotlin/lang/resolve/android/LayoutParser.kt
+++ b/plugins/android-compiler-plugin/src/org/jetbrains/kotlin/lang/resolve/android/LayoutParser.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2010-2015 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.kotlin.lang.resolve.android
+
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.util.Key
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiManager
+
+public class LayoutParser(val resourceManager: AndroidResourceManager,
+                          val psiManager: PsiManager,
+                          val getXmlElements: (PsiFile) -> List<LayoutParser.UIXmlElement>) {
+
+    protected val LOG: Logger = Logger.getInstance(javaClass)
+
+    public data class UIXmlElement(val id: String?, val clazz: String, val layout: String?)
+
+    private val WIDGET_CONTAINER: Key<WidgetContainer> = Key.create<WidgetContainer>("WIDGET_CONTAINER")
+
+    private trait UIElement {
+        val id: String?
+        val parent: WidgetContainer?
+        fun updateId(newId: String): UIElement
+    }
+
+    private class WidgetContainer(override val id: String?, val layout: String, override val parent: WidgetContainer?) : UIElement {
+        override fun updateId(newId: String): UIElement {
+            return WidgetContainer(newId, layout, parent)
+        }
+    }
+
+    private class Widget(override val id: String?, val clazz: String, override val parent: WidgetContainer?) : UIElement {
+        override fun updateId(newId: String): UIElement {
+            return Widget(newId, clazz, parent)
+        }
+    }
+
+    private class UISpecialElement(val name: String) {
+        public companion object {
+            val ELEMENT_MERGE = "merge"
+            val ELEMENT_REQUESTFOCUS = "requestFocus"
+            val ELEMENT_FRAGMENT = "fragment"
+            val REGEX_SPECIAL_ELEMENTS = "$ELEMENT_MERGE|$ELEMENT_REQUESTFOCUS|$ELEMENT_FRAGMENT"
+            public fun isSpecialElement(name: String): Boolean {
+                return name.matches(REGEX_SPECIAL_ELEMENTS)
+            }
+
+            val MERGE = UISpecialElement(ELEMENT_MERGE)
+        }
+    }
+
+    private fun loadLayout(layoutFile: PsiFile, widgetContainer: WidgetContainer?): Pair<List<UIElement>, List<UISpecialElement>> {
+        val xmlElements = getXmlElements(layoutFile)
+        val specialElements = xmlElements.filter { UISpecialElement.isSpecialElement(it.clazz) }.map { UISpecialElement(it.clazz) }
+        val elements = xmlElements.filter { !UISpecialElement.isSpecialElement(it.clazz) }.map {
+            if (it.layout != null) {
+                WidgetContainer(it.id, it.layout, widgetContainer)
+            }
+            else {
+                Widget(it.id, it.clazz, widgetContainer)
+            }
+        }
+        return Pair(elements, specialElements)
+    }
+
+    private fun updateUIElements(parentId: String?, elements: List<UIElement>): List<UIElement> {
+        if (parentId != null) {
+            return elements.mapIndexed { index, elem -> if (index == 0) elem.updateId(parentId!!) else elem }
+        }
+        return elements
+    }
+
+    private fun getPsiFiles(widgetContainers: List<WidgetContainer>): List<PsiFile> {
+        var psiFiles = arrayListOf<PsiFile>()
+        for (container in widgetContainers) {
+            val layoutXmlFile = resourceManager.getMainResDirectory()?.findFileByRelativePath("layout/${container.layout}.xml");
+            val psiLayoutXmlFile = psiManager.findFile(layoutXmlFile)
+            psiLayoutXmlFile.putUserData(WIDGET_CONTAINER, container)
+            psiFiles.add(psiLayoutXmlFile)
+        }
+        return psiFiles
+    }
+
+    public fun parse(file: PsiFile): List<AndroidWidget> {
+
+        fun getWidgets(layoutsFiles: List<PsiFile>, accumulator: List<Widget> = arrayListOf<Widget>()): List<Widget> {
+            val widgetsContainers = arrayListOf<WidgetContainer>()
+            val widgets = arrayListOf<Widget>()
+
+            for (file in layoutsFiles) {
+                val widgetsContainer = file.getUserData(WIDGET_CONTAINER)
+                val parentId: String? = widgetsContainer?.id
+                val (elements, specialElements) = loadLayout(file, widgetsContainer)
+                val skipRootElement = specialElements.firstOrNull()?.equals(UISpecialElement.MERGE) ?: false
+                val updatedElements = if (!skipRootElement) updateUIElements(parentId, elements) else elements
+
+                widgets.addAll(updatedElements.filterIsInstance<Widget>())
+                widgetsContainers.addAll(updatedElements.filterIsInstance<WidgetContainer>())
+            }
+
+            if (widgetsContainers.size() == 0) {
+                return accumulator + widgets
+            } else {
+                val psiFiles = getPsiFiles(widgetsContainers)
+                return accumulator + getWidgets(psiFiles, widgets)
+            }
+        }
+
+        val allWidgets = getWidgets(arrayListOf(file))
+        return  allWidgets.filter { widget -> widget.id != null }.map { widget -> AndroidWidget(widget.id!!, widget.clazz) }
+    }
+
+}

--- a/plugins/android-idea-plugin/src/org/jetbrains/kotlin/plugin/android/AndroidUIXmlVisitor.kt
+++ b/plugins/android-idea-plugin/src/org/jetbrains/kotlin/plugin/android/AndroidUIXmlVisitor.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2010-2015 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.kotlin.plugin.android
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.XmlElementVisitor
+import com.intellij.psi.xml.XmlElement
+import com.intellij.psi.xml.XmlTag
+import java.util.HashMap
+
+class AndroidUIXmlVisitor(private val elementCallback: (String, HashMap<String, String>) -> Unit) : XmlElementVisitor() {
+
+    override fun visitElement(element: PsiElement) {
+        element.acceptChildren(this)
+    }
+
+    override fun visitXmlElement(element: XmlElement?) {
+        element?.acceptChildren(this)
+    }
+
+    override fun visitXmlTag(tag: XmlTag?) {
+        if (tag != null) {
+            val attributesMap = tag.toMap()
+            elementCallback(tag.getLocalName(), attributesMap)
+            tag.acceptChildren(this)
+        }
+    }
+}
+
+public fun XmlTag.toMap(): HashMap<String, String> {
+    val res = HashMap<String, String>()
+    val attributes = getAttributes()
+    for (index in 0..attributes.size() - 1) {
+        val attrName = attributes.get(index).getLocalName()
+        val attrVal = attributes.get(index).getValue()
+        res[attrName] = attrVal
+    }
+    return res
+}
+
+

--- a/plugins/android-idea-plugin/src/org/jetbrains/kotlin/plugin/android/IDEAndroidUIXmlProcessor.kt
+++ b/plugins/android-idea-plugin/src/org/jetbrains/kotlin/plugin/android/IDEAndroidUIXmlProcessor.kt
@@ -20,6 +20,7 @@ import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.module.Module
 import org.jetbrains.kotlin.plugin.android.IDEAndroidResourceManager
 import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiManager
 import org.jetbrains.kotlin.plugin.android.AndroidXmlVisitor
 import com.intellij.psi.impl.*
 import kotlin.properties.*
@@ -42,12 +43,16 @@ class IDEAndroidUIXmlProcessor(val module: Module) : AndroidUIXmlProcessor(modul
     }
 
     override fun parseSingleFile(file: PsiFile): List<AndroidWidget> {
-        val widgets = arrayListOf<AndroidWidget>()
-        file.accept(AndroidXmlVisitor({ id, wClass, valueElement ->
-            widgets.add(AndroidWidget(id, wClass))
-        }))
+        val parser = LayoutParser(resourceManager, PsiManager.getInstance(project), { file ->
+            val xmlElements = arrayListOf<LayoutParser.UIXmlElement>()
+            file.accept(AndroidUIXmlVisitor(
+                    elementCallback({ id, clazz, layoutName ->
+                                        xmlElements.add(LayoutParser.UIXmlElement(id, clazz, layoutName))
+                                    })))
 
-        return widgets
+            xmlElements
+        })
+        return parser.parse(file)
     }
 
 }


### PR DESCRIPTION
Hi. 
Here is my suggestion how to sort out the issue with include tags and other xml elements which can crash compilation. There is a class LayoutParser which recursively traverses layout file and for each encountered include tag propagates id (if present) to the nested widget/container. Properly handles  merge tag.
The < fragment > tag is suppressed for the time being so as to not to cause compilation problems but I think it can be fixed by generating synthetic property something like  
writeSyntheticProperty("Activity", it, "getFragmentManager().findFragmentById(0)")
