### PR TITLE
Fix #KT-7277 Build fails after project cleaning

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt
@@ -398,13 +398,14 @@ open class KotlinAndroidPlugin [Inject] (val scriptHandler: ScriptHandler, val t
                     val basePlugin: BasePlugin = plugin as BasePlugin
                     val javaSources = project.files(javaSourceList)
                     val androidRT = project.files(AndroidGradleWrapper.getRuntimeJars(basePlugin, androidExt))
-                    val fullClasspath = (javaTask.getClasspath() + (javaSources + androidRT)) - project.files(kotlinTask.property("kotlinDestinationDir"))
+                    val fullClasspath = javaTask.getClasspath() + (javaSources + androidRT)
                     (it as AbstractCompile).setClasspath(fullClasspath)
+
+                    val javacClassPath = javaTask.getClasspath() + project.files(kotlinTask.property("kotlinDestinationDir"))
+                    javaTask.setClasspath(javacClassPath)
                 }
 
                 javaTask.dependsOn(kotlinTaskName)
-                val javacClassPath = javaTask.getClasspath() + project.files(kotlinTask.property("kotlinDestinationDir"))
-                javaTask.setClasspath(javacClassPath)
             }
         }
     }


### PR DESCRIPTION
When you build the project for the first time after cleaning, you lose paths to internal_impl jars of support libraries such as

build/intermediates/exploded-aar/com.android.support/support-v4/21.0.2/libs/internal_impl-21.0.2.jar

They are absent in javaCompile.getClasspath() when javaCompile task starts.

This patch fixes it.
#KT-7277 Fixed