### PR TITLE
Use 8.3 paths on Windows

### DIFF
--- a/compiler/cli/bin/kotlinc.bat
+++ b/compiler/cli/bin/kotlinc.bat
@@ -14,4 +14,4 @@ rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 rem See the License for the specific language governing permissions and
 rem limitations under the License.
 
-call %~dp0kotlinc-jvm.bat %*
+call %~dps0kotlinc-jvm.bat %*


### PR DESCRIPTION
Modified kotlinc.bat to use the 8.3 versions of the paths to deal with paths with spaces.