### PR TITLE
escape identifiers in generated super method call in Override/Implement

### DIFF
--- a/idea/idea-core/src/org/jetbrains/kotlin/idea/core/codeInsight/OverrideImplementMethodsHandler.java
+++ b/idea/idea-core/src/org/jetbrains/kotlin/idea/core/codeInsight/OverrideImplementMethodsHandler.java
@@ -248,9 +248,9 @@ public abstract class OverrideImplementMethodsHandler implements LanguageCodeIns
             StringBuilder builder = new StringBuilder();
             builder.append("super");
             if (classOrObject.getDelegationSpecifiers().size() > 1) {
-                builder.append("<").append(descriptor.getContainingDeclaration().getName()).append(">");
+                builder.append("<").append(DescriptorRenderer.COMPACT.renderName(descriptor.getContainingDeclaration().getName())).append(">");
             }
-            builder.append(".").append(descriptor.getName());
+            builder.append(".").append(DescriptorRenderer.COMPACT.renderName(descriptor.getName()));
 
             if (descriptor instanceof FunctionDescriptor) {
                 builder.append("(");
@@ -260,7 +260,7 @@ public abstract class OverrideImplementMethodsHandler implements LanguageCodeIns
                         builder.append(", ");
                     }
                     first = false;
-                    builder.append(parameterDescriptor.getName());
+                    builder.append(DescriptorRenderer.COMPACT.renderName(parameterDescriptor.getName()));
                 }
                 builder.append(")");
             }

--- a/idea/testData/codeInsight/overrideImplement/escapeIdentifiers.kt
+++ b/idea/testData/codeInsight/overrideImplement/escapeIdentifiers.kt
@@ -1,0 +1,7 @@
+open class A {
+    open fun foo(`object` : Any): Int = 0
+}
+
+class C : A {
+    <caret>
+}

--- a/idea/testData/codeInsight/overrideImplement/escapeIdentifiers.kt.after
+++ b/idea/testData/codeInsight/overrideImplement/escapeIdentifiers.kt.after
@@ -1,0 +1,9 @@
+open class A {
+    open fun foo(`object` : Any): Int = 0
+}
+
+class C : A {
+    override fun foo(`object`: Any): Int {
+        <selection><caret>return super.foo(`object`)</selection>
+    }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/codeInsight/OverrideImplementTest.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/codeInsight/OverrideImplementTest.java
@@ -201,4 +201,8 @@ public final class OverrideImplementTest extends AbstractOverrideImplementTest {
     public void testStarProjections() {
         doImplementFileTest();
     }
+
+    public void testEscapeIdentifiers() {
+        doOverrideFileTest();
+    }
 }


### PR DESCRIPTION
 #KT-6669 Fixed