### PR TITLE
don't complete KDoc tag names if we have a non-empty prefix which is not...

### DIFF
--- a/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/KDocCompletionContributor.kt
+++ b/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/KDocCompletionContributor.kt
@@ -104,6 +104,9 @@ object KDocTagCompletionProvider: CompletionProvider<CompletionParameters>() {
                 StandardPatterns.character().javaIdentifierPart() or singleCharPattern('@'),
                 StandardPatterns.character().javaIdentifierStart() or singleCharPattern('@'))
 
+        if (prefix.length() > 0 && !prefix.startsWith('@')) {
+            return
+        }
         val resultWithPrefix = result.withPrefixMatcher(prefix)
         KDocKnownTag.values().forEach {
             resultWithPrefix.addElement(LookupElementBuilder.create("@" + it.name().toLowerCase()))

--- a/idea/idea-completion/testData/kdoc/NotTagName.kt
+++ b/idea/idea-completion/testData/kdoc/NotTagName.kt
@@ -1,0 +1,7 @@
+/**
+ * p<caret>
+ */
+fun f(x: Int): Int {
+}
+
+// ABSENT: @param

--- a/idea/idea-completion/tests/org/jetbrains/kotlin/idea/completion/test/KDocCompletionTestGenerated.java
+++ b/idea/idea-completion/tests/org/jetbrains/kotlin/idea/completion/test/KDocCompletionTestGenerated.java
@@ -41,6 +41,12 @@ public class KDocCompletionTestGenerated extends AbstractJvmBasicCompletionTest 
         doTest(fileName);
     }
 
+    @TestMetadata("NotTagName.kt")
+    public void testNotTagName() throws Exception {
+        String fileName = JetTestUtils.navigationMetadata("idea/idea-completion/testData/kdoc/NotTagName.kt");
+        doTest(fileName);
+    }
+
     @TestMetadata("ParamTag.kt")
     public void testParamTag() throws Exception {
         String fileName = JetTestUtils.navigationMetadata("idea/idea-completion/testData/kdoc/ParamTag.kt");


### PR DESCRIPTION
... a tag name

 #KT-7476 Fixed