### PR TITLE
Map, Set and List transform extension optimisations

### DIFF
--- a/libraries/stdlib/src/generated/_Snapshots.kt
+++ b/libraries/stdlib/src/generated/_Snapshots.kt
@@ -14,88 +14,77 @@ import java.util.Collections // TODO: it's temporary while we have java.util.Col
  * Returns an ArrayList of all elements
  */
 public fun <T> Array<out T>.toArrayList(): ArrayList<T> {
-    val list = ArrayList<T>(size())
-    for (item in this) list.add(item)
-    return list
+    return this.asList().toArrayList()
 }
 
 /**
  * Returns an ArrayList of all elements
  */
 public fun BooleanArray.toArrayList(): ArrayList<Boolean> {
-    val list = ArrayList<Boolean>(size())
-    for (item in this) list.add(item)
-    return list
+    return this.asList().toArrayList()
 }
 
 /**
  * Returns an ArrayList of all elements
  */
 public fun ByteArray.toArrayList(): ArrayList<Byte> {
-    val list = ArrayList<Byte>(size())
-    for (item in this) list.add(item)
-    return list
+    return this.asList().toArrayList()
 }
 
 /**
  * Returns an ArrayList of all elements
  */
 public fun CharArray.toArrayList(): ArrayList<Char> {
-    val list = ArrayList<Char>(size())
-    for (item in this) list.add(item)
-    return list
+    return this.asList().toArrayList()
 }
 
 /**
  * Returns an ArrayList of all elements
  */
 public fun DoubleArray.toArrayList(): ArrayList<Double> {
-    val list = ArrayList<Double>(size())
-    for (item in this) list.add(item)
-    return list
+    return this.asList().toArrayList()
 }
 
 /**
  * Returns an ArrayList of all elements
  */
 public fun FloatArray.toArrayList(): ArrayList<Float> {
-    val list = ArrayList<Float>(size())
-    for (item in this) list.add(item)
-    return list
+    return this.asList().toArrayList()
 }
 
 /**
  * Returns an ArrayList of all elements
  */
 public fun IntArray.toArrayList(): ArrayList<Int> {
-    val list = ArrayList<Int>(size())
-    for (item in this) list.add(item)
-    return list
+    return this.asList().toArrayList()
 }
 
 /**
  * Returns an ArrayList of all elements
  */
 public fun LongArray.toArrayList(): ArrayList<Long> {
-    val list = ArrayList<Long>(size())
-    for (item in this) list.add(item)
-    return list
+    return this.asList().toArrayList()
 }
 
 /**
  * Returns an ArrayList of all elements
  */
 public fun ShortArray.toArrayList(): ArrayList<Short> {
-    val list = ArrayList<Short>(size())
-    for (item in this) list.add(item)
-    return list
+    return this.asList().toArrayList()
+}
+
+/**
+ * Returns an ArrayList of all elements
+ */
+public fun <T> Collection<T>.toArrayList(): ArrayList<T> {
+    return ArrayList(this)
 }
 
 /**
  * Returns an ArrayList of all elements
  */
 public fun <T> Iterable<T>.toArrayList(): ArrayList<T> {
-    return toCollection(ArrayList<T>(collectionSizeOrDefault(10)))
+    return toCollection(ArrayList<T>())
 }
 
 /**
@@ -257,70 +246,70 @@ public fun <C : MutableCollection<in Char>> String.toCollection(collection: C): 
  * Returns a HashSet of all elements
  */
 public fun <T> Array<out T>.toHashSet(): HashSet<T> {
-    return toCollection(HashSet<T>())
+    return toCollection(HashSet<T>(mapCapacity(size())))
 }
 
 /**
  * Returns a HashSet of all elements
  */
 public fun BooleanArray.toHashSet(): HashSet<Boolean> {
-    return toCollection(HashSet<Boolean>())
+    return toCollection(HashSet<Boolean>(mapCapacity(size())))
 }
 
 /**
  * Returns a HashSet of all elements
  */
 public fun ByteArray.toHashSet(): HashSet<Byte> {
-    return toCollection(HashSet<Byte>())
+    return toCollection(HashSet<Byte>(mapCapacity(size())))
 }
 
 /**
  * Returns a HashSet of all elements
  */
 public fun CharArray.toHashSet(): HashSet<Char> {
-    return toCollection(HashSet<Char>())
+    return toCollection(HashSet<Char>(mapCapacity(size())))
 }
 
 /**
  * Returns a HashSet of all elements
  */
 public fun DoubleArray.toHashSet(): HashSet<Double> {
-    return toCollection(HashSet<Double>())
+    return toCollection(HashSet<Double>(mapCapacity(size())))
 }
 
 /**
  * Returns a HashSet of all elements
  */
 public fun FloatArray.toHashSet(): HashSet<Float> {
-    return toCollection(HashSet<Float>())
+    return toCollection(HashSet<Float>(mapCapacity(size())))
 }
 
 /**
  * Returns a HashSet of all elements
  */
 public fun IntArray.toHashSet(): HashSet<Int> {
-    return toCollection(HashSet<Int>())
+    return toCollection(HashSet<Int>(mapCapacity(size())))
 }
 
 /**
  * Returns a HashSet of all elements
  */
 public fun LongArray.toHashSet(): HashSet<Long> {
-    return toCollection(HashSet<Long>())
+    return toCollection(HashSet<Long>(mapCapacity(size())))
 }
 
 /**
  * Returns a HashSet of all elements
  */
 public fun ShortArray.toHashSet(): HashSet<Short> {
-    return toCollection(HashSet<Short>())
+    return toCollection(HashSet<Short>(mapCapacity(size())))
 }
 
 /**
  * Returns a HashSet of all elements
  */
 public fun <T> Iterable<T>.toHashSet(): HashSet<T> {
-    return toCollection(HashSet<T>())
+    return toCollection(HashSet<T>(mapCapacity(collectionSizeOrDefault(12))))
 }
 
 /**
@@ -343,7 +332,7 @@ public fun <T> Stream<T>.toHashSet(): HashSet<T> {
  * Returns a HashSet of all elements
  */
 public fun String.toHashSet(): HashSet<Char> {
-    return toCollection(HashSet<Char>())
+    return toCollection(HashSet<Char>(mapCapacity(length())))
 }
 
 /**
@@ -453,95 +442,77 @@ public fun <K, V> Map<K, V>.toList(): List<Pair<K, V>> {
  * Returns a List containing all elements
  */
 public fun <T> Array<out T>.toList(): List<T> {
-    val list = ArrayList<T>(size())
-    for (item in this) list.add(item)
-    return list
+    return this.toArrayList()
 }
 
 /**
  * Returns a List containing all elements
  */
 public fun BooleanArray.toList(): List<Boolean> {
-    val list = ArrayList<Boolean>(size())
-    for (item in this) list.add(item)
-    return list
+    return this.toArrayList()
 }
 
 /**
  * Returns a List containing all elements
  */
 public fun ByteArray.toList(): List<Byte> {
-    val list = ArrayList<Byte>(size())
-    for (item in this) list.add(item)
-    return list
+    return this.toArrayList()
 }
 
 /**
  * Returns a List containing all elements
  */
 public fun CharArray.toList(): List<Char> {
-    val list = ArrayList<Char>(size())
-    for (item in this) list.add(item)
-    return list
+    return this.toArrayList()
 }
 
 /**
  * Returns a List containing all elements
  */
 public fun DoubleArray.toList(): List<Double> {
-    val list = ArrayList<Double>(size())
-    for (item in this) list.add(item)
-    return list
+    return this.toArrayList()
 }
 
 /**
  * Returns a List containing all elements
  */
 public fun FloatArray.toList(): List<Float> {
-    val list = ArrayList<Float>(size())
-    for (item in this) list.add(item)
-    return list
+    return this.toArrayList()
 }
 
 /**
  * Returns a List containing all elements
  */
 public fun IntArray.toList(): List<Int> {
-    val list = ArrayList<Int>(size())
-    for (item in this) list.add(item)
-    return list
+    return this.toArrayList()
 }
 
 /**
  * Returns a List containing all elements
  */
 public fun LongArray.toList(): List<Long> {
-    val list = ArrayList<Long>(size())
-    for (item in this) list.add(item)
-    return list
+    return this.toArrayList()
 }
 
 /**
  * Returns a List containing all elements
  */
 public fun ShortArray.toList(): List<Short> {
-    val list = ArrayList<Short>(size())
-    for (item in this) list.add(item)
-    return list
+    return this.toArrayList()
 }
 
 /**
  * Returns a List containing all elements
  */
 public fun <T> Iterable<T>.toList(): List<T> {
-    return toCollection(ArrayList<T>(collectionSizeOrDefault(10)))
+    return this.toArrayList()
 }
 
 /**
  * Returns a List containing all elements
  */
 public fun <T> Sequence<T>.toList(): List<T> {
-    return toCollection(ArrayList<T>())
+    return this.toArrayList()
 }
 
 
@@ -550,21 +521,22 @@ deprecated("Migrate to using Sequence<T> and respective functions")
  * Returns a List containing all elements
  */
 public fun <T> Stream<T>.toList(): List<T> {
-    return toCollection(ArrayList<T>())
+    return this.toArrayList()
 }
 
 /**
  * Returns a List containing all elements
  */
 public fun String.toList(): List<Char> {
-    return toCollection(ArrayList<Char>(length()))
+    return this.toArrayList()
 }
 
 /**
  * Returns Map containing all the values from the given collection indexed by *selector*
  */
 public inline fun <T, K> Array<out T>.toMap(selector: (T) -> K): Map<K, T> {
-    val result = LinkedHashMap<K, T>()
+    val capacity = (size()/.75f) + 1
+    val result = LinkedHashMap<K, T>(Math.max(capacity.toInt(), 16))
     for (element in this) {
         result.put(selector(element), element)
     }
@@ -575,7 +547,8 @@ public inline fun <T, K> Array<out T>.toMap(selector: (T) -> K): Map<K, T> {
  * Returns Map containing all the values from the given collection indexed by *selector*
  */
 public inline fun <K> BooleanArray.toMap(selector: (Boolean) -> K): Map<K, Boolean> {
-    val result = LinkedHashMap<K, Boolean>()
+    val capacity = (size()/.75f) + 1
+    val result = LinkedHashMap<K, Boolean>(Math.max(capacity.toInt(), 16))
     for (element in this) {
         result.put(selector(element), element)
     }
@@ -586,7 +559,8 @@ public inline fun <K> BooleanArray.toMap(selector: (Boolean) -> K): Map<K, Boole
  * Returns Map containing all the values from the given collection indexed by *selector*
  */
 public inline fun <K> ByteArray.toMap(selector: (Byte) -> K): Map<K, Byte> {
-    val result = LinkedHashMap<K, Byte>()
+    val capacity = (size()/.75f) + 1
+    val result = LinkedHashMap<K, Byte>(Math.max(capacity.toInt(), 16))
     for (element in this) {
         result.put(selector(element), element)
     }
@@ -597,7 +571,8 @@ public inline fun <K> ByteArray.toMap(selector: (Byte) -> K): Map<K, Byte> {
  * Returns Map containing all the values from the given collection indexed by *selector*
  */
 public inline fun <K> CharArray.toMap(selector: (Char) -> K): Map<K, Char> {
-    val result = LinkedHashMap<K, Char>()
+    val capacity = (size()/.75f) + 1
+    val result = LinkedHashMap<K, Char>(Math.max(capacity.toInt(), 16))
     for (element in this) {
         result.put(selector(element), element)
     }
@@ -608,7 +583,8 @@ public inline fun <K> CharArray.toMap(selector: (Char) -> K): Map<K, Char> {
  * Returns Map containing all the values from the given collection indexed by *selector*
  */
 public inline fun <K> DoubleArray.toMap(selector: (Double) -> K): Map<K, Double> {
-    val result = LinkedHashMap<K, Double>()
+    val capacity = (size()/.75f) + 1
+    val result = LinkedHashMap<K, Double>(Math.max(capacity.toInt(), 16))
     for (element in this) {
         result.put(selector(element), element)
     }
@@ -619,7 +595,8 @@ public inline fun <K> DoubleArray.toMap(selector: (Double) -> K): Map<K, Double>
  * Returns Map containing all the values from the given collection indexed by *selector*
  */
 public inline fun <K> FloatArray.toMap(selector: (Float) -> K): Map<K, Float> {
-    val result = LinkedHashMap<K, Float>()
+    val capacity = (size()/.75f) + 1
+    val result = LinkedHashMap<K, Float>(Math.max(capacity.toInt(), 16))
     for (element in this) {
         result.put(selector(element), element)
     }
@@ -630,7 +607,8 @@ public inline fun <K> FloatArray.toMap(selector: (Float) -> K): Map<K, Float> {
  * Returns Map containing all the values from the given collection indexed by *selector*
  */
 public inline fun <K> IntArray.toMap(selector: (Int) -> K): Map<K, Int> {
-    val result = LinkedHashMap<K, Int>()
+    val capacity = (size()/.75f) + 1
+    val result = LinkedHashMap<K, Int>(Math.max(capacity.toInt(), 16))
     for (element in this) {
         result.put(selector(element), element)
     }
@@ -641,7 +619,8 @@ public inline fun <K> IntArray.toMap(selector: (Int) -> K): Map<K, Int> {
  * Returns Map containing all the values from the given collection indexed by *selector*
  */
 public inline fun <K> LongArray.toMap(selector: (Long) -> K): Map<K, Long> {
-    val result = LinkedHashMap<K, Long>()
+    val capacity = (size()/.75f) + 1
+    val result = LinkedHashMap<K, Long>(Math.max(capacity.toInt(), 16))
     for (element in this) {
         result.put(selector(element), element)
     }
@@ -652,7 +631,8 @@ public inline fun <K> LongArray.toMap(selector: (Long) -> K): Map<K, Long> {
  * Returns Map containing all the values from the given collection indexed by *selector*
  */
 public inline fun <K> ShortArray.toMap(selector: (Short) -> K): Map<K, Short> {
-    val result = LinkedHashMap<K, Short>()
+    val capacity = (size()/.75f) + 1
+    val result = LinkedHashMap<K, Short>(Math.max(capacity.toInt(), 16))
     for (element in this) {
         result.put(selector(element), element)
     }
@@ -663,7 +643,8 @@ public inline fun <K> ShortArray.toMap(selector: (Short) -> K): Map<K, Short> {
  * Returns Map containing all the values from the given collection indexed by *selector*
  */
 public inline fun <T, K> Iterable<T>.toMap(selector: (T) -> K): Map<K, T> {
-    val result = LinkedHashMap<K, T>()
+    val capacity = (collectionSizeOrDefault(10)/.75f) + 1
+    val result = LinkedHashMap<K, T>(Math.max(capacity.toInt(), 16))
     for (element in this) {
         result.put(selector(element), element)
     }
@@ -698,9 +679,166 @@ public inline fun <T, K> Stream<T>.toMap(selector: (T) -> K): Map<K, T> {
  * Returns Map containing all the values from the given collection indexed by *selector*
  */
 public inline fun <K> String.toMap(selector: (Char) -> K): Map<K, Char> {
-    val result = LinkedHashMap<K, Char>()
+    val capacity = (length()/.75f) + 1
+    val result = LinkedHashMap<K, Char>(Math.max(capacity.toInt(), 16))
     for (element in this) {
         result.put(selector(element), element)
+    }
+    return result
+}
+
+/**
+ * Returns Map containing all the values provided by *transform* and indexed by *selector* from the given collection
+ */
+public inline fun <T, K, V> Array<out T>.toMap(selector: (T) -> K, transform: (T) -> V): Map<K, V> {
+    val capacity = (size()/.75f) + 1
+    val result = LinkedHashMap<K, V>(Math.max(capacity.toInt(), 16))
+    for (element in this) {
+        result.put(selector(element), transform(element))
+    }
+    return result
+}
+
+/**
+ * Returns Map containing all the values provided by *transform* and indexed by *selector* from the given collection
+ */
+public inline fun <K, V> BooleanArray.toMap(selector: (Boolean) -> K, transform: (Boolean) -> V): Map<K, V> {
+    val capacity = (size()/.75f) + 1
+    val result = LinkedHashMap<K, V>(Math.max(capacity.toInt(), 16))
+    for (element in this) {
+        result.put(selector(element), transform(element))
+    }
+    return result
+}
+
+/**
+ * Returns Map containing all the values provided by *transform* and indexed by *selector* from the given collection
+ */
+public inline fun <K, V> ByteArray.toMap(selector: (Byte) -> K, transform: (Byte) -> V): Map<K, V> {
+    val capacity = (size()/.75f) + 1
+    val result = LinkedHashMap<K, V>(Math.max(capacity.toInt(), 16))
+    for (element in this) {
+        result.put(selector(element), transform(element))
+    }
+    return result
+}
+
+/**
+ * Returns Map containing all the values provided by *transform* and indexed by *selector* from the given collection
+ */
+public inline fun <K, V> CharArray.toMap(selector: (Char) -> K, transform: (Char) -> V): Map<K, V> {
+    val capacity = (size()/.75f) + 1
+    val result = LinkedHashMap<K, V>(Math.max(capacity.toInt(), 16))
+    for (element in this) {
+        result.put(selector(element), transform(element))
+    }
+    return result
+}
+
+/**
+ * Returns Map containing all the values provided by *transform* and indexed by *selector* from the given collection
+ */
+public inline fun <K, V> DoubleArray.toMap(selector: (Double) -> K, transform: (Double) -> V): Map<K, V> {
+    val capacity = (size()/.75f) + 1
+    val result = LinkedHashMap<K, V>(Math.max(capacity.toInt(), 16))
+    for (element in this) {
+        result.put(selector(element), transform(element))
+    }
+    return result
+}
+
+/**
+ * Returns Map containing all the values provided by *transform* and indexed by *selector* from the given collection
+ */
+public inline fun <K, V> FloatArray.toMap(selector: (Float) -> K, transform: (Float) -> V): Map<K, V> {
+    val capacity = (size()/.75f) + 1
+    val result = LinkedHashMap<K, V>(Math.max(capacity.toInt(), 16))
+    for (element in this) {
+        result.put(selector(element), transform(element))
+    }
+    return result
+}
+
+/**
+ * Returns Map containing all the values provided by *transform* and indexed by *selector* from the given collection
+ */
+public inline fun <K, V> IntArray.toMap(selector: (Int) -> K, transform: (Int) -> V): Map<K, V> {
+    val capacity = (size()/.75f) + 1
+    val result = LinkedHashMap<K, V>(Math.max(capacity.toInt(), 16))
+    for (element in this) {
+        result.put(selector(element), transform(element))
+    }
+    return result
+}
+
+/**
+ * Returns Map containing all the values provided by *transform* and indexed by *selector* from the given collection
+ */
+public inline fun <K, V> LongArray.toMap(selector: (Long) -> K, transform: (Long) -> V): Map<K, V> {
+    val capacity = (size()/.75f) + 1
+    val result = LinkedHashMap<K, V>(Math.max(capacity.toInt(), 16))
+    for (element in this) {
+        result.put(selector(element), transform(element))
+    }
+    return result
+}
+
+/**
+ * Returns Map containing all the values provided by *transform* and indexed by *selector* from the given collection
+ */
+public inline fun <K, V> ShortArray.toMap(selector: (Short) -> K, transform: (Short) -> V): Map<K, V> {
+    val capacity = (size()/.75f) + 1
+    val result = LinkedHashMap<K, V>(Math.max(capacity.toInt(), 16))
+    for (element in this) {
+        result.put(selector(element), transform(element))
+    }
+    return result
+}
+
+/**
+ * Returns Map containing all the values provided by *transform* and indexed by *selector* from the given collection
+ */
+public inline fun <T, K, V> Iterable<T>.toMap(selector: (T) -> K, transform: (T) -> V): Map<K, V> {
+    val capacity = (collectionSizeOrDefault(10)/.75f) + 1
+    val result = LinkedHashMap<K, V>(Math.max(capacity.toInt(), 16))
+    for (element in this) {
+        result.put(selector(element), transform(element))
+    }
+    return result
+}
+
+/**
+ * Returns Map containing all the values provided by *transform* and indexed by *selector* from the given collection
+ */
+public inline fun <T, K, V> Sequence<T>.toMap(selector: (T) -> K, transform: (T) -> V): Map<K, V> {
+    val result = LinkedHashMap<K, V>()
+    for (element in this) {
+        result.put(selector(element), transform(element))
+    }
+    return result
+}
+
+
+deprecated("Migrate to using Sequence<T> and respective functions")
+/**
+ * Returns Map containing all the values provided by *transform* and indexed by *selector* from the given collection
+ */
+public inline fun <T, K, V> Stream<T>.toMap(selector: (T) -> K, transform: (T) -> V): Map<K, V> {
+    val result = LinkedHashMap<K, V>()
+    for (element in this) {
+        result.put(selector(element), transform(element))
+    }
+    return result
+}
+
+/**
+ * Returns Map containing all the values provided by *transform* and indexed by *selector* from the given collection
+ */
+public inline fun <K, V> String.toMap(selector: (Char) -> K, transform: (Char) -> V): Map<K, V> {
+    val capacity = (length()/.75f) + 1
+    val result = LinkedHashMap<K, V>(Math.max(capacity.toInt(), 16))
+    for (element in this) {
+        result.put(selector(element), transform(element))
     }
     return result
 }
@@ -709,70 +847,70 @@ public inline fun <K> String.toMap(selector: (Char) -> K): Map<K, Char> {
  * Returns a Set of all elements
  */
 public fun <T> Array<out T>.toSet(): Set<T> {
-    return toCollection(LinkedHashSet<T>())
+    return toCollection(LinkedHashSet<T>(mapCapacity(size())))
 }
 
 /**
  * Returns a Set of all elements
  */
 public fun BooleanArray.toSet(): Set<Boolean> {
-    return toCollection(LinkedHashSet<Boolean>())
+    return toCollection(LinkedHashSet<Boolean>(mapCapacity(size())))
 }
 
 /**
  * Returns a Set of all elements
  */
 public fun ByteArray.toSet(): Set<Byte> {
-    return toCollection(LinkedHashSet<Byte>())
+    return toCollection(LinkedHashSet<Byte>(mapCapacity(size())))
 }
 
 /**
  * Returns a Set of all elements
  */
 public fun CharArray.toSet(): Set<Char> {
-    return toCollection(LinkedHashSet<Char>())
+    return toCollection(LinkedHashSet<Char>(mapCapacity(size())))
 }
 
 /**
  * Returns a Set of all elements
  */
 public fun DoubleArray.toSet(): Set<Double> {
-    return toCollection(LinkedHashSet<Double>())
+    return toCollection(LinkedHashSet<Double>(mapCapacity(size())))
 }
 
 /**
  * Returns a Set of all elements
  */
 public fun FloatArray.toSet(): Set<Float> {
-    return toCollection(LinkedHashSet<Float>())
+    return toCollection(LinkedHashSet<Float>(mapCapacity(size())))
 }
 
 /**
  * Returns a Set of all elements
  */
 public fun IntArray.toSet(): Set<Int> {
-    return toCollection(LinkedHashSet<Int>())
+    return toCollection(LinkedHashSet<Int>(mapCapacity(size())))
 }
 
 /**
  * Returns a Set of all elements
  */
 public fun LongArray.toSet(): Set<Long> {
-    return toCollection(LinkedHashSet<Long>())
+    return toCollection(LinkedHashSet<Long>(mapCapacity(size())))
 }
 
 /**
  * Returns a Set of all elements
  */
 public fun ShortArray.toSet(): Set<Short> {
-    return toCollection(LinkedHashSet<Short>())
+    return toCollection(LinkedHashSet<Short>(mapCapacity(size())))
 }
 
 /**
  * Returns a Set of all elements
  */
 public fun <T> Iterable<T>.toSet(): Set<T> {
-    return toCollection(LinkedHashSet<T>())
+    return toCollection(LinkedHashSet<T>(mapCapacity(collectionSizeOrDefault(12))))
 }
 
 /**
@@ -795,7 +933,7 @@ public fun <T> Stream<T>.toSet(): Set<T> {
  * Returns a Set of all elements
  */
 public fun String.toSet(): Set<Char> {
-    return toCollection(LinkedHashSet<Char>())
+    return toCollection(LinkedHashSet<Char>(mapCapacity(length())))
 }
 
 /**

--- a/libraries/stdlib/src/generated/_Snapshots.kt
+++ b/libraries/stdlib/src/generated/_Snapshots.kt
@@ -84,14 +84,14 @@ public fun <T> Collection<T>.toArrayList(): ArrayList<T> {
  * Returns an ArrayList of all elements
  */
 public fun <T> Iterable<T>.toArrayList(): ArrayList<T> {
-    return toCollection(ArrayList<T>())
+    return toCollection(ArrayList<T>(collectionSizeOrDefault(10)))
 }
 
 /**
  * Returns an ArrayList of all elements
  */
 public fun <T> Sequence<T>.toArrayList(): ArrayList<T> {
-    return toCollection(ArrayList<T>())
+    return toCollection(ArrayList<T>(collectionSizeOrDefault(10)))
 }
 
 
@@ -100,7 +100,7 @@ deprecated("Migrate to using Sequence<T> and respective functions")
  * Returns an ArrayList of all elements
  */
 public fun <T> Stream<T>.toArrayList(): ArrayList<T> {
-    return toCollection(ArrayList<T>())
+    return toCollection(ArrayList<T>(collectionSizeOrDefault(10)))
 }
 
 /**

--- a/libraries/stdlib/src/kotlin/collections/JUtil.kt
+++ b/libraries/stdlib/src/kotlin/collections/JUtil.kt
@@ -46,7 +46,7 @@ public fun listOf<T>(vararg values: T): List<T> = if (values.size() == 0) emptyL
 public fun listOf<T>(): List<T> = emptyList()
 
 /** Returns a new read-only ordered set with the given elements. */
-public fun setOf<T>(vararg values: T): Set<T> = if (values.size() == 0) emptySet() else values.toCollection(LinkedHashSet<T>())
+public fun setOf<T>(vararg values: T): Set<T> = if (values.size() == 0) emptySet() else values.toCollection(LinkedHashSet<T>(mapCapacityForValues(values)))
 
 /** Returns an empty read-only set. */
 public fun setOf<T>(): Set<T> = emptySet()
@@ -58,10 +58,10 @@ public fun linkedListOf<T>(vararg values: T): LinkedList<T> = values.toCollectio
 public fun arrayListOf<T>(vararg values: T): ArrayList<T> = values.toCollection(ArrayList(values.size()))
 
 /** Returns a new [HashSet] with the given elements. */
-public fun hashSetOf<T>(vararg values: T): HashSet<T> = values.toCollection(HashSet(values.size()))
+public fun hashSetOf<T>(vararg values: T): HashSet<T> = values.toCollection(HashSet(mapCapacityForValues(values)))
 
 /** Returns a new [LinkedHashSet] with the given elements. */
-public fun linkedSetOf<T>(vararg values: T): LinkedHashSet<T> = values.toCollection(LinkedHashSet(values.size()))
+public fun linkedSetOf<T>(vararg values: T): LinkedHashSet<T> = values.toCollection(LinkedHashSet(mapCapacityForValues(values)))
 
 /**
  * Returns an [IntRange] of the valid indices for this collection.

--- a/libraries/stdlib/src/kotlin/collections/Maps.kt
+++ b/libraries/stdlib/src/kotlin/collections/Maps.kt
@@ -38,7 +38,7 @@ public fun mapOf<K, V>(): Map<K, V> = emptyMap()
  * @sample test.collections.MapTest.createUsingPairs
  */
 public fun <K, V> hashMapOf(vararg values: Pair<K, V>): HashMap<K, V> {
-    val answer = HashMap<K, V>(values.size())
+    val answer = HashMap<K, V>(mapCapacityForValues(values))
     answer.putAll(*values)
     return answer
 }
@@ -51,9 +51,31 @@ public fun <K, V> hashMapOf(vararg values: Pair<K, V>): HashMap<K, V> {
  * @sample test.collections.MapTest.createLinkedMap
  */
 public fun <K, V> linkedMapOf(vararg values: Pair<K, V>): LinkedHashMap<K, V> {
-    val answer = LinkedHashMap<K, V>(values.size())
+    val answer = LinkedHashMap<K, V>(mapCapacityForValues(values))
     answer.putAll(*values)
     return answer
+}
+
+/**
+ * Calculate the initial capacity of a map, based on Guava's com.google.common.collect.Maps approach. This is equivalent
+ * to the Collection constructor for HashSet, (c.size()/.75f) + 1, but provides further optimisations for very small or
+ * very large sizes, allows support non-collection classes, and provides consistency for all map based class construction.
+ */
+
+private val MAX_POWER_OF_TWO: Int = 1 shl (Integer.SIZE - 2)
+
+private fun mapCapacity(expectedSize: Int): Int {
+    if (expectedSize < 3) {
+        return expectedSize + 1
+    }
+    if (expectedSize < MAX_POWER_OF_TWO) {
+        return expectedSize + expectedSize / 3
+    }
+    return Integer.MAX_VALUE // any large value
+}
+
+private fun <T> mapCapacityForValues(values: Array<T>): Int {
+    return mapCapacity(values.size())
 }
 
 /**

--- a/libraries/stdlib/src/kotlin/collections/Maps.kt
+++ b/libraries/stdlib/src/kotlin/collections/Maps.kt
@@ -62,16 +62,18 @@ public fun <K, V> linkedMapOf(vararg values: Pair<K, V>): LinkedHashMap<K, V> {
  * very large sizes, allows support non-collection classes, and provides consistency for all map based class construction.
  */
 
-private val MAX_POWER_OF_TWO: Int = 1 shl (Integer.SIZE - 2)
+private val INT_MAX_VALUE: Int = 0x7fffffff
+private val INT_SIZE: Int = 32
+private val INT_MAX_POWER_OF_TWO: Int = 1 shl (INT_SIZE - 2)
 
 private fun mapCapacity(expectedSize: Int): Int {
     if (expectedSize < 3) {
         return expectedSize + 1
     }
-    if (expectedSize < MAX_POWER_OF_TWO) {
+    if (expectedSize < INT_MAX_POWER_OF_TWO) {
         return expectedSize + expectedSize / 3
     }
-    return Integer.MAX_VALUE // any large value
+    return INT_MAX_VALUE // any large value
 }
 
 private fun <T> mapCapacityForValues(values: Array<T>): Int {

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Snapshots.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Snapshots.kt
@@ -1,6 +1,7 @@
 package templates
 
 import templates.Family.*
+import java.util.ArrayList
 
 fun snapshots(): List<GenericFunction> {
     val templates = arrayListOf<GenericFunction>()
@@ -22,13 +23,19 @@ fun snapshots(): List<GenericFunction> {
     templates add f("toSet()") {
         doc { "Returns a Set of all elements" }
         returns("Set<T>")
-        body { "return toCollection(LinkedHashSet<T>())" }
+        body { "return toCollection(LinkedHashSet<T>(mapCapacity(collectionSizeOrDefault(12))))" }
+        body(Sequences) { "return toCollection(LinkedHashSet<T>())" }
+        body(Strings) { "return toCollection(LinkedHashSet<T>(mapCapacity(length())))" }
+        body(ArraysOfObjects, ArraysOfPrimitives) { "return toCollection(LinkedHashSet<T>(mapCapacity(size())))" }
     }
 
     templates add f("toHashSet()") {
         doc { "Returns a HashSet of all elements" }
         returns("HashSet<T>")
-        body { "return toCollection(HashSet<T>())" }
+        body { "return toCollection(HashSet<T>(mapCapacity(collectionSizeOrDefault(12))))" }
+        body(Sequences) { "return toCollection(HashSet<T>())" }
+        body(Strings) { "return toCollection(HashSet<T>(mapCapacity(length())))" }
+        body(ArraysOfObjects, ArraysOfPrimitives) { "return toCollection(HashSet<T>(mapCapacity(size())))" }
     }
 
     templates add f("toSortedSet()") {
@@ -40,16 +47,10 @@ fun snapshots(): List<GenericFunction> {
     templates add f("toArrayList()") {
         doc { "Returns an ArrayList of all elements" }
         returns("ArrayList<T>")
-        body { "return toCollection(ArrayList<T>(collectionSizeOrDefault(10)))" }
-        body(Sequences) { "return toCollection(ArrayList<T>())" }
+        body { "return toCollection(ArrayList<T>())" }
+        body(Collections) { "return ArrayList(this)" }
         body(Strings) { "return toCollection(ArrayList<T>(length()))" }
-        body(ArraysOfObjects, ArraysOfPrimitives) {
-            """
-            val list = ArrayList<T>(size())
-            for (item in this) list.add(item)
-            return list
-            """
-        }
+        body(ArraysOfObjects, ArraysOfPrimitives) { "return this.asList().toArrayList()" }
     }
 
     templates add f("toList()") {
@@ -69,16 +70,7 @@ fun snapshots(): List<GenericFunction> {
     templates add f("toList()") {
         doc { "Returns a List containing all elements" }
         returns("List<T>")
-        body { "return toCollection(ArrayList<T>(collectionSizeOrDefault(10)))" }
-        body(Sequences) { "return toCollection(ArrayList<T>())" }
-        body(Strings) { "return toCollection(ArrayList<T>(length()))" }
-        body(ArraysOfObjects, ArraysOfPrimitives) {
-            """
-            val list = ArrayList<T>(size())
-            for (item in this) list.add(item)
-            return list
-            """
-        }
+        body { "return this.toArrayList()" }
     }
 
     templates add f("toLinkedList()") {
@@ -96,11 +88,104 @@ fun snapshots(): List<GenericFunction> {
             """
         }
         returns("Map<K, T>")
+
+        /**
+         * Collection size helper methods are private, so we fall back to the calculation from HashSet's Collection
+         * constructor.
+         */
+
         body {
+            """
+            val capacity = (collectionSizeOrDefault(10)/.75f) + 1
+            val result = LinkedHashMap<K, T>(Math.max(capacity.toInt(), 16))
+            for (element in this) {
+                result.put(selector(element), element)
+            }
+            return result
+            """
+        }
+        body(Sequences) {
             """
             val result = LinkedHashMap<K, T>()
             for (element in this) {
                 result.put(selector(element), element)
+            }
+            return result
+            """
+        }
+        body(Strings) {
+            """
+            val capacity = (length()/.75f) + 1
+            val result = LinkedHashMap<K, T>(Math.max(capacity.toInt(), 16))
+            for (element in this) {
+                result.put(selector(element), element)
+            }
+            return result
+            """
+        }
+        body(ArraysOfObjects, ArraysOfPrimitives) {
+            """
+            val capacity = (size()/.75f) + 1
+            val result = LinkedHashMap<K, T>(Math.max(capacity.toInt(), 16))
+            for (element in this) {
+                result.put(selector(element), element)
+            }
+            return result
+            """
+        }
+    }
+
+    templates add f("toMap(selector: (T) -> K, transform: (T) -> V)") {
+        inline(true)
+        typeParam("K")
+        typeParam("V")
+        doc {
+            """
+            Returns Map containing all the values provided by *transform* and indexed by *selector* from the given collection
+            """
+        }
+        returns("Map<K, V>")
+
+        /**
+         * Collection size helper methods are private, so we fall back to the calculation from HashSet's Collection
+         * constructor.
+         */
+
+        body {
+            """
+            val capacity = (collectionSizeOrDefault(10)/.75f) + 1
+            val result = LinkedHashMap<K, V>(Math.max(capacity.toInt(), 16))
+            for (element in this) {
+                result.put(selector(element), transform(element))
+            }
+            return result
+            """
+        }
+        body(Sequences) {
+            """
+            val result = LinkedHashMap<K, V>()
+            for (element in this) {
+                result.put(selector(element), transform(element))
+            }
+            return result
+            """
+        }
+        body(Strings) {
+            """
+            val capacity = (length()/.75f) + 1
+            val result = LinkedHashMap<K, V>(Math.max(capacity.toInt(), 16))
+            for (element in this) {
+                result.put(selector(element), transform(element))
+            }
+            return result
+            """
+        }
+        body(ArraysOfObjects, ArraysOfPrimitives) {
+            """
+            val capacity = (size()/.75f) + 1
+            val result = LinkedHashMap<K, V>(Math.max(capacity.toInt(), 16))
+            for (element in this) {
+                result.put(selector(element), transform(element))
             }
             return result
             """

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Snapshots.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Snapshots.kt
@@ -47,7 +47,7 @@ fun snapshots(): List<GenericFunction> {
     templates add f("toArrayList()") {
         doc { "Returns an ArrayList of all elements" }
         returns("ArrayList<T>")
-        body { "return toCollection(ArrayList<T>())" }
+        body { "return toCollection(ArrayList<T>(collectionSizeOrDefault(10)))" }
         body(Collections) { "return ArrayList(this)" }
         body(Strings) { "return toCollection(ArrayList<T>(length()))" }
         body(ArraysOfObjects, ArraysOfPrimitives) { "return this.asList().toArrayList()" }


### PR DESCRIPTION
After noticing that collections where presized inconsistently, or map sizing didn't consider a load factor, I wrote some quick benchmarks to evaluate the benefits and seems like there's some benefit to be had from doing that consistently. For very small sizes there'll likely be no benefit, but seems like seeing as the surface area is so low, and this is fundamental library code it'd be worthwhile.

Let me know what you think!

## Lists

- Use `Arrays.asList` for the array version of `toArrayList` so list creation becomes an array copy and direct population of the `ArrayList`. Use the `ArrayList(Collection)` constructor for Collections, to simplify that code and optimize for Collections where `toArray` is cheap (I figure worst case should be equivalent to `toCollection`)
- Replace duplicate code in `toList` and just call `toArrayList`

## Maps/Sets

- Where the size of the source is known, pre-calculate the capacity, using the formula used by Guava's Maps
- For the inline function `toMap` where we're unable to get at the private function, use HashSet's formula where the size is known (I'm quite new to Kotlin, and perhaps there's a better way of handling that without polluting the `kotlin` package, let me know if so)
- Add a `toMap` that takes a `transform` in addition to a `selector`, avoiding a separate step for transforming values
- Fix `hashMapOf`/`linkedMapOf` so they use a capacity calculation, instead of `size()`

## Benchmarks

Each iteration creates a collection and adds `(size)` unique elements. `WithSize` passes `(size)` to the capacity constructor, `WithCapacity` uses Guava's capacity approach.

    Benchmark                                      (size)  Mode  Cnt      Score      Error  Units
    CollectionBenchmark.arrayList                      10  avgt   20      0.235 ±    0.014  us/op
    CollectionBenchmark.arrayList                      11  avgt   20      0.254 ±    0.014  us/op
    CollectionBenchmark.arrayList                      16  avgt   20      0.421 ±    0.040  us/op
    CollectionBenchmark.arrayList                      17  avgt   20      0.403 ±    0.020  us/op
    CollectionBenchmark.arrayList                      64  avgt   20      1.544 ±    0.170  us/op
    CollectionBenchmark.arrayList                     256  avgt   20      6.289 ±    0.390  us/op
    CollectionBenchmark.arrayList                    1024  avgt   20     25.944 ±    1.630  us/op
    CollectionBenchmark.arrayList                    4096  avgt   20    112.521 ±    8.597  us/op
    CollectionBenchmark.arrayList                   16384  avgt   20    515.956 ±   37.099  us/op
    CollectionBenchmark.arrayList                  262144  avgt   20   9293.247 ±  532.762  us/op
    CollectionBenchmark.arrayListWithSize              10  avgt   20      0.214 ±    0.013  us/op
    CollectionBenchmark.arrayListWithSize              11  avgt   20      0.233 ±    0.014  us/op
    CollectionBenchmark.arrayListWithSize              16  avgt   20      0.360 ±    0.025  us/op
    CollectionBenchmark.arrayListWithSize              17  avgt   20      0.385 ±    0.026  us/op
    CollectionBenchmark.arrayListWithSize              64  avgt   20      1.405 ±    0.074  us/op
    CollectionBenchmark.arrayListWithSize             256  avgt   20      6.362 ±    0.511  us/op
    CollectionBenchmark.arrayListWithSize            1024  avgt   20     25.637 ±    1.392  us/op
    CollectionBenchmark.arrayListWithSize            4096  avgt   20    111.911 ±    6.505  us/op
    CollectionBenchmark.arrayListWithSize           16384  avgt   20    489.405 ±   47.841  us/op
    CollectionBenchmark.arrayListWithSize          262144  avgt   20   8258.859 ±  292.226  us/op
    CollectionBenchmark.hashMap                        10  avgt   20      0.329 ±    0.022  us/op
    CollectionBenchmark.hashMap                        11  avgt   20      0.341 ±    0.023  us/op
    CollectionBenchmark.hashMap                        16  avgt   20      0.596 ±    0.035  us/op
    CollectionBenchmark.hashMap                        17  avgt   20      0.629 ±    0.028  us/op
    CollectionBenchmark.hashMap                        64  avgt   20      2.650 ±    0.200  us/op
    CollectionBenchmark.hashMap                       256  avgt   20     10.622 ±    0.522  us/op
    CollectionBenchmark.hashMap                      1024  avgt   20     45.414 ±    3.138  us/op
    CollectionBenchmark.hashMap                      4096  avgt   20    216.625 ±   10.586  us/op
    CollectionBenchmark.hashMap                     16384  avgt   20    917.617 ±   58.622  us/op
    CollectionBenchmark.hashMap                    262144  avgt   20  18475.167 ± 1535.835  us/op
    CollectionBenchmark.hashMapWithSize                10  avgt   20      0.374 ±    0.033  us/op
    CollectionBenchmark.hashMapWithSize                11  avgt   20      0.365 ±    0.024  us/op
    CollectionBenchmark.hashMapWithSize                16  avgt   20      0.590 ±    0.031  us/op
    CollectionBenchmark.hashMapWithSize                17  avgt   20      0.550 ±    0.039  us/op
    CollectionBenchmark.hashMapWithSize                64  avgt   20      2.330 ±    0.127  us/op
    CollectionBenchmark.hashMapWithSize               256  avgt   20     10.004 ±    0.440  us/op
    CollectionBenchmark.hashMapWithSize              1024  avgt   20     43.947 ±    2.482  us/op
    CollectionBenchmark.hashMapWithSize              4096  avgt   20    190.050 ±   10.479  us/op
    CollectionBenchmark.hashMapWithSize             16384  avgt   20    852.367 ±   53.681  us/op
    CollectionBenchmark.hashMapWithSize            262144  avgt   20  15852.489 ± 1635.862  us/op
    CollectionBenchmark.hashMapWithCapacity            10  avgt   20      0.312 ±    0.017  us/op
    CollectionBenchmark.hashMapWithCapacity            11  avgt   20      0.354 ±    0.025  us/op
    CollectionBenchmark.hashMapWithCapacity            16  avgt   20      0.528 ±    0.037  us/op
    CollectionBenchmark.hashMapWithCapacity            17  avgt   20      0.542 ±    0.028  us/op
    CollectionBenchmark.hashMapWithCapacity            64  avgt   20      2.190 ±    0.118  us/op
    CollectionBenchmark.hashMapWithCapacity           256  avgt   20     10.233 ±    0.806  us/op
    CollectionBenchmark.hashMapWithCapacity          1024  avgt   20     38.081 ±    2.002  us/op
    CollectionBenchmark.hashMapWithCapacity          4096  avgt   20    164.984 ±   11.515  us/op
    CollectionBenchmark.hashMapWithCapacity         16384  avgt   20    723.480 ±   42.762  us/op
    CollectionBenchmark.hashMapWithCapacity        262144  avgt   20  13487.356 ±  967.791  us/op
    CollectionBenchmark.linkedHashMap                  10  avgt   20      0.395 ±    0.027  us/op
    CollectionBenchmark.linkedHashMap                  11  avgt   20      0.451 ±    0.021  us/op
    CollectionBenchmark.linkedHashMap                  16  avgt   20      0.692 ±    0.017  us/op
    CollectionBenchmark.linkedHashMap                  17  avgt   20      0.730 ±    0.019  us/op
    CollectionBenchmark.linkedHashMap                  64  avgt   20      3.337 ±    0.271  us/op
    CollectionBenchmark.linkedHashMap                 256  avgt   20     12.083 ±    0.685  us/op
    CollectionBenchmark.linkedHashMap                1024  avgt   20     54.267 ±    3.875  us/op
    CollectionBenchmark.linkedHashMap                4096  avgt   20    231.969 ±   16.344  us/op
    CollectionBenchmark.linkedHashMap               16384  avgt   20   1009.412 ±   58.097  us/op
    CollectionBenchmark.linkedHashMap              262144  avgt   20  20386.332 ± 1866.132  us/op
    CollectionBenchmark.linkedHashMapWithSize          10  avgt   20      0.379 ±    0.021  us/op
    CollectionBenchmark.linkedHashMapWithSize          11  avgt   20      0.434 ±    0.029  us/op
    CollectionBenchmark.linkedHashMapWithSize          16  avgt   20      0.651 ±    0.030  us/op
    CollectionBenchmark.linkedHashMapWithSize          17  avgt   20      0.639 ±    0.037  us/op
    CollectionBenchmark.linkedHashMapWithSize          64  avgt   20      2.706 ±    0.133  us/op
    CollectionBenchmark.linkedHashMapWithSize         256  avgt   20     11.287 ±    0.710  us/op
    CollectionBenchmark.linkedHashMapWithSize        1024  avgt   20     47.657 ±    2.702  us/op
    CollectionBenchmark.linkedHashMapWithSize        4096  avgt   20    204.954 ±   14.411  us/op
    CollectionBenchmark.linkedHashMapWithSize       16384  avgt   20    946.632 ±   86.363  us/op
    CollectionBenchmark.linkedHashMapWithSize      262144  avgt   20  17176.821 ± 1295.150  us/op
    CollectionBenchmark.linkedHashMapWithCapacity      10  avgt   20      0.391 ±    0.018  us/op
    CollectionBenchmark.linkedHashMapWithCapacity      11  avgt   20      0.414 ±    0.034  us/op
    CollectionBenchmark.linkedHashMapWithCapacity      16  avgt   20      0.608 ±    0.025  us/op
    CollectionBenchmark.linkedHashMapWithCapacity      17  avgt   20      0.681 ±    0.045  us/op
    CollectionBenchmark.linkedHashMapWithCapacity      64  avgt   20      2.667 ±    0.335  us/op
    CollectionBenchmark.linkedHashMapWithCapacity     256  avgt   20     10.308 ±    0.664  us/op
    CollectionBenchmark.linkedHashMapWithCapacity    1024  avgt   20     43.048 ±    3.239  us/op
    CollectionBenchmark.linkedHashMapWithCapacity    4096  avgt   20    183.209 ±    9.334  us/op
    CollectionBenchmark.linkedHashMapWithCapacity   16384  avgt   20    813.861 ±   80.429  us/op
    CollectionBenchmark.linkedHashMapWithCapacity  262144  avgt   20  14773.805 ±  963.080  us/op

### Source

    package benchmark;

    import com.google.common.primitives.Ints;
    import org.openjdk.jmh.annotations.*;
    import org.openjdk.jmh.runner.Runner;
    import org.openjdk.jmh.runner.RunnerException;
    import org.openjdk.jmh.runner.options.Options;
    import org.openjdk.jmh.runner.options.OptionsBuilder;

    import java.util.*;
    import java.util.concurrent.TimeUnit;

    /**
     * Evaluates the benefit of pre-sizing lists and maps, comparing Guava's approach with passing the size to the default
     * constructors.
     */
    @OutputTimeUnit(TimeUnit.MICROSECONDS)
    @State(Scope.Benchmark)
    @BenchmarkMode(Mode.AverageTime)
    public class CollectionBenchmark {
        // Default array list capacity, then plus one, then default map capacity, plus one; followed n * 4 starting with 16
        @Param({"10", "11", "16", "17", "64", "256", "1024", "4096", "16384", "262144"})
        public int size;

        @Benchmark
        public List<String> arrayList() {
            return add(new ArrayList<>());
        }

        @Benchmark
        public List<String> arrayListWithSize() {
            return add(new ArrayList<>(size));
        }

        @Benchmark
        public Map<String, String> hashMap() {
            return put(new HashMap<>());
        }

        @Benchmark
        public Map<String, String> hashMapWithSize() {
            return put(new HashMap<>(size));
        }

        @Benchmark
        public Map<String, String> hashMapWithCapacity() {
            return put(new HashMap<>(capacity(size)));
        }

        @Benchmark
        public Map<String, String> linkedHashMap() {
            return put(new LinkedHashMap<>());
        }

        @Benchmark
        public Map<String, String> linkedHashMapWithSize() {
            return put(new LinkedHashMap<>(size));
        }

        @Benchmark
        public Map<String, String> linkedHashMapWithCapacity() {
            return put(new LinkedHashMap<>(capacity(size)));
        }

        // Guava Maps capacity method
        static int capacity(int expectedSize) {
            if (expectedSize < 3) {
                return expectedSize + 1;
            }
            if (expectedSize < Ints.MAX_POWER_OF_TWO) {
                return expectedSize + expectedSize / 3;
            }
            return Integer.MAX_VALUE; // any large value
        }

        private Map<String, String> put(Map<String, String> map) {
            for (int i = 0; i < size; i++) {
                map.put(String.valueOf(i), "a");
            }
            return map;
        }

        private <T extends Collection<String>> T add(T collection) {
            for (int i = 0; i < size; i++) {
                collection.add(String.valueOf(i));
            }
            return collection;
        }

        public static void main(String[] args) throws RunnerException {
            Options options = new OptionsBuilder().forks(1).warmupIterations(10).measurementIterations(20).include(CollectionBenchmark.class.getSimpleName()).build();
            new Runner(options).run();
        }
    }
