### PR TITLE
correctly implement JetSimpleNameReference.getTextRange() so that it doe...

### DIFF
--- a/idea/idea-analysis/src/org/jetbrains/kotlin/idea/references/JetSimpleNameReference.kt
+++ b/idea/idea-analysis/src/org/jetbrains/kotlin/idea/references/JetSimpleNameReference.kt
@@ -61,7 +61,11 @@ public class JetSimpleNameReference(
         return super.isReferenceTo(element)
     }
 
-    override fun getRangeInElement(): TextRange = TextRange(0, getElement().getTextLength())
+    override fun getRangeInElement(): TextRange {
+        val element = getElement().getReferencedNameElement()
+        val startOffset = getElement().getTextRange().getStartOffset()
+        return element.getTextRange().shiftRight(-startOffset)
+    }
 
     override fun canRename(): Boolean {
         if (expression.getParentOfTypeAndBranch<JetWhenConditionInRange>(strict = true){ getOperationReference() } != null) return false

--- a/idea/testData/refactoring/rename/inplace/LabelFromFunction.kt
+++ b/idea/testData/refactoring/rename/inplace/LabelFromFunction.kt
@@ -1,0 +1,5 @@
+fun xyzzy(): Any {
+    fun b<caret>ar(): Int {
+        return@bar 1
+    }
+}

--- a/idea/testData/refactoring/rename/inplace/LabelFromFunction.kt.after
+++ b/idea/testData/refactoring/rename/inplace/LabelFromFunction.kt.after
@@ -1,0 +1,5 @@
+fun xyzzy(): Any {
+    fun foo(): Int {
+        return@foo 1
+    }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/refactoring/InplaceRenameTest.kt
+++ b/idea/tests/org/jetbrains/kotlin/idea/refactoring/InplaceRenameTest.kt
@@ -124,6 +124,10 @@ public class InplaceRenameTest : LightPlatformCodeInsightTestCase() {
         doTestInplaceRename(null)
     }
 
+    public fun testLabelFromFunction() {
+        doTestInplaceRename("foo")
+    }
+
     private fun doTestInplaceRename(newName: String?) {
         configureByFile(getTestName(false) + ".kt")
         val element = TargetElementUtilBase.findTargetElement(


### PR DESCRIPTION
...sn't include the @ character for references in labels

 #KT-7560 Fixed