### PR TITLE
Fix documentation for Sets intersect() and subtract()

### DIFF
--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Sets.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Sets.kt
@@ -101,7 +101,7 @@ fun sets(): List<GenericFunction> {
 
     templates add f("intersect(other: Iterable<T>)") {
         exclude(Strings, Sequences)
-        doc { "Returns a set containing all distinct elements from both collections." }
+        doc { "Returns a set containing all elements that are contained by both this set and the specified collection." }
         returns("Set<T>")
         body {
             """
@@ -114,7 +114,7 @@ fun sets(): List<GenericFunction> {
 
     templates add f("subtract(other: Iterable<T>)") {
         exclude(Strings, Sequences)
-        doc { "Returns a set containing all distinct elements from both collections." }
+        doc { "Returns a set containing all elements that are contained by this set and not contained by the specified collection." }
         returns("Set<T>")
         body {
             """


### PR DESCRIPTION
Adds correct documentation for the Sets intersect() and subtract() methods, which had been copied from union().