### PR TITLE
KT-7615 workaround for crash on Android ART caused by "private constructor" in DescriptorBasedProperty

### DIFF
--- a/core/reflection.jvm/src/kotlin/reflect/jvm/internal/DescriptorBasedProperty.kt
+++ b/core/reflection.jvm/src/kotlin/reflect/jvm/internal/DescriptorBasedProperty.kt
@@ -27,7 +27,8 @@ import org.jetbrains.kotlin.serialization.jvm.JvmProtoBuf
 import java.lang.reflect.Field
 import java.lang.reflect.Method
 
-abstract class DescriptorBasedProperty private constructor(
+abstract class DescriptorBasedProperty protected constructor (
+        /* KT-7615 workaround - preventing crash on Android ART by increasing constructor visibility from private */
         container: KCallableContainerImpl,
         name: String,
         receiverParameterDesc: String?,


### PR DESCRIPTION
#KT-7615 Fixed