### PR TITLE
Make $metadata$ a non-enumerable property

### DIFF
--- a/js/js.translator/testData/kotlin_lib_ecma5.js
+++ b/js/js.translator/testData/kotlin_lib_ecma5.js
@@ -166,7 +166,10 @@ var Kotlin = {};
             constructor.baseInitializer = metadata.baseClass;
         }
 
-        constructor.$metadata$ = metadata;
+        Object.defineProperty(constructor, '$metadata$', {
+            enumerable: false,
+            value: metadata
+        });
         constructor.prototype = prototypeObj;
         Object.defineProperty(constructor, "object", {get: class_object, configurable: true});
         return constructor;
@@ -175,17 +178,21 @@ var Kotlin = {};
     Kotlin.createObjectNow = function (bases, constructor, functions) {
         var noNameClass = Kotlin.createClassNow(bases, constructor, functions);
         var obj = new noNameClass();
-        obj.$metadata$ = {
-            type: Kotlin.TYPE.OBJECT
-        };
-        return  obj;
+        Object.defineProperty(obj, '$metadata$', {
+            enumerable: false,
+            value: {type: Kotlin.TYPE.OBJECT}
+        });
+        return obj;
     };
 
     Kotlin.createTraitNow = function (bases, properties, staticProperties) {
         var obj = function () {};
         copyProperties(obj, staticProperties);
 
-        obj.$metadata$ = computeMetadata(bases, properties);
+        Object.defineProperty(obj, '$metadata$', {
+            enumerable: false,
+            value: computeMetadata(bases, properties)
+        });
         obj.$metadata$.type = Kotlin.TYPE.TRAIT;
 
         obj.prototype = {};


### PR DESCRIPTION
When using a Kotlin-generated JavaScript file, I have encountered problems with `$metadata$` while I was iterating over the properties of an object. I had to add ad-hoc guards to check for the presence of `$metadata$`. For better interop with JavaScript and its libraries, I believe Kotlin should avoid or at least hide these metadata properties on JS objects. For more background: https://gist.github.com/staltz/f5ed815dc54c6433d5f8