### PR TITLE
KT-4844 Support asReversed() for lists

### DIFF
--- a/js/js.translator/testData/kotlin_lib.js
+++ b/js/js.translator/testData/kotlin_lib.js
@@ -431,7 +431,7 @@
                 else {
                     builder += ", ";
                 }
-                builder += iterator.next();
+                builder += Kotlin.toString(iterator.next());
             }
             builder += "]";
             return builder;

--- a/js/js.translator/testData/kotlin_lib.js
+++ b/js/js.translator/testData/kotlin_lib.js
@@ -96,7 +96,7 @@
     };
 
     Kotlin.arrayToString = function (a) {
-        return "[" + a.join(", ") + "]";
+        return "[" + a.map(Kotlin.toString).join(", ") + "]";
     };
 
     Kotlin.compareTo = function (a, b) {
@@ -618,7 +618,7 @@
                 return this.array.slice(0);
             },
             toString: function () {
-                return "[" + this.array.join(", ") + "]";
+                return Kotlin.arrayToString(this.array);
             },
             toJSON: function () {
                 return this.array;

--- a/libraries/stdlib/src/kotlin/collections/ReversedViews.kt
+++ b/libraries/stdlib/src/kotlin/collections/ReversedViews.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2010-2015 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kotlin
+
+import java.util.AbstractList
+import kotlin.platform.platformName
+
+private open class ReversedListReadOnly<T>(protected open val delegate: List<T>) : AbstractList<T>() {
+    override fun size(): Int = delegate.size()
+    override fun get(index: Int): T = delegate[index.flipIndex()]
+
+    protected fun Int.flipIndex(): Int = if (this in 0..size() - 1) size() - this - 1 else throw IndexOutOfBoundsException("index $this should be in range [${0..size() - 1}]")
+    protected fun Int.flipIndexForward(): Int = if (this in 0..size()) size() - this else throw IndexOutOfBoundsException("index $this should be in range [${0..size()}]")
+}
+
+private class ReversedList<T>(protected override val delegate: MutableList<T>) : ReversedListReadOnly<T>(delegate) {
+    override fun clear() = delegate.clear()
+    override fun remove(index: Int): T = delegate.remove(index.flipIndex())
+
+    override fun set(index: Int, element: T): T = delegate.set(index.flipIndex(), element)
+    override fun add(index: Int, element: T) {
+        delegate.add(index.flipIndexForward(), element)
+    }
+}
+
+/**
+ * Returns a reversed immutable view of the original List.
+ * All changes made in the original list will be reflected in the reversed one
+ */
+public fun <T> List<T>.asReversed(): List<T> = ReversedListReadOnly(this)
+
+/**
+ * Returns a reversed mutable view of the original List.
+ * All changes made in the original list will be reflected in the reversed one and vice versa
+ */
+platformName("asReversedMutable")
+public fun <T> MutableList<T>.asReversed(): MutableList<T> = ReversedList(this)
+

--- a/libraries/stdlib/test/collections/CollectionTest.kt
+++ b/libraries/stdlib/test/collections/CollectionTest.kt
@@ -665,5 +665,9 @@ class CollectionTest {
         compare(linkedMapOf(2 to 3), mapOf(2 to 3)) { mapBehavior() }
     }
 
+    test fun toStringTest() {
+        // we need toString() inside pattern because of KT-8666
+        assertEquals("[1, a, null, ${Long.MAX_VALUE.toString()}]", listOf(1, "a", null, Long.MAX_VALUE).toString())
+    }
 }
 

--- a/libraries/stdlib/test/collections/ListSpecificTest.kt
+++ b/libraries/stdlib/test/collections/ListSpecificTest.kt
@@ -60,4 +60,8 @@ class ListSpecificTest {
         assertEquals(3, list.size())
         assertEquals("beverage,location,name", list.join(","))
     }
+
+    Test fun testNullToString() {
+        assertEquals("[null]", listOf<String?>(null).toString())
+    }
 }

--- a/libraries/stdlib/test/collections/ReversedViewsJVMTest.kt
+++ b/libraries/stdlib/test/collections/ReversedViewsJVMTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2010-2015 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package collections
+
+import kotlin.asReversed
+import kotlin.test.assertEquals
+import org.junit.Test as test
+
+/**
+ * We need this test to run only on JVM because we have no mutability support by sub-list implementation for JavaScript
+ */
+class ReversedViewsJVMTest {
+
+    test fun testMutableSubList() {
+        val original = arrayListOf(1, 2, 3, 4)
+        val reversedSubList = original.asReversed().subList(1, 3)
+
+        assertEquals(listOf(3, 2), reversedSubList)
+        reversedSubList.clear()
+        assertEquals(emptyList<Int>(), reversedSubList)
+        assertEquals(listOf(1, 4), original)
+
+        reversedSubList.add(100)
+        assertEquals(listOf(100), reversedSubList)
+        assertEquals(listOf(1, 100, 4), original)
+    }
+
+}

--- a/libraries/stdlib/test/collections/ReversedViewsTest.kt
+++ b/libraries/stdlib/test/collections/ReversedViewsTest.kt
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2010-2015 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package collections
+
+import kotlin.asReversed
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.Test as test
+
+class ReversedViewsTest {
+    test fun testSimple() {
+        assertEquals(listOf(3, 2, 1), listOf(1, 2, 3).asReversed())
+        assertEquals(listOf(3, 2, 1), listOf(1, 2, 3).asReversed().toList())
+    }
+
+    test fun testRandomAccess() {
+        val reversed = listOf(1, 2, 3).asReversed()
+
+        assertEquals(3, reversed[0])
+        assertEquals(2, reversed[1])
+        assertEquals(1, reversed[2])
+    }
+
+    test fun testDoubleReverse() {
+        assertEquals(listOf(1, 2, 3), listOf(1, 2, 3).asReversed().asReversed())
+        assertEquals(listOf(2, 3), listOf(1, 2, 3, 4).asReversed().subList(1, 3).asReversed())
+    }
+
+    test fun testEmpty() {
+        assertEquals(emptyList<Int>(), emptyList<Int>().asReversed())
+    }
+
+    test fun testReversedSubList() {
+        val reversed = (1..10).toList().asReversed()
+        assertEquals(listOf(9, 8, 7), reversed.subList(1, 4))
+    }
+
+    test fun testMutableSimple() {
+        assertEquals(listOf(3, 2, 1), arrayListOf(1, 2, 3).asReversed())
+        assertEquals(listOf(3, 2, 1), arrayListOf(1, 2, 3).asReversed().toList())
+    }
+
+    test fun testMutableDoubleReverse() {
+        assertEquals(listOf(1, 2, 3), arrayListOf(1, 2, 3).asReversed().asReversed())
+        assertEquals(listOf(2, 3), arrayListOf(1, 2, 3, 4).asReversed().subList(1, 3).asReversed())
+    }
+
+    test fun testMutableEmpty() {
+        assertEquals(emptyList<Int>(), arrayListOf<Int>().asReversed())
+    }
+
+    test fun testMutableReversedSubList() {
+        val reversed = (1..10).toArrayList().asReversed()
+        assertEquals(listOf(9, 8, 7), reversed.subList(1, 4))
+    }
+
+    test fun testMutableAdd() {
+        val original = arrayListOf(1, 2, 3)
+        val reversed = original.asReversed()
+
+        reversed.add(0) // add zero at end of reversed
+        assertEquals(listOf(3, 2, 1, 0), reversed)
+        assertEquals(listOf(0, 1, 2, 3), original)
+
+        reversed.add(0, 4) // add four at position 0
+        assertEquals(listOf(4, 3, 2, 1, 0), reversed)
+        assertEquals(listOf(0, 1, 2, 3, 4), original)
+    }
+
+    test fun testMutableSet() {
+        val original = arrayListOf(1, 2, 3)
+        val reversed = original.asReversed()
+
+        reversed.set(0, 300)
+        reversed.set(1, 200)
+        reversed.set(2, 100)
+
+        assertEquals(listOf(100, 200, 300), original)
+        assertEquals(listOf(300, 200, 100), reversed)
+    }
+
+    test fun testMutableRemove() {
+        val original = arrayListOf("a", "b", "c")
+        val reversed = original.asReversed()
+
+        reversed.remove(0) // remove c
+        assertEquals(listOf("a", "b"), original)
+        assertEquals(listOf("b", "a"), reversed)
+
+        reversed.remove(1) // remove a
+        assertEquals(listOf("b"), original)
+
+        reversed.remove(0) // remove remaining b
+        assertEquals(emptyList<String>(), original)
+    }
+
+    test fun testMutableRemoveByObj() {
+        val original = arrayListOf("a", "b", "c")
+        val reversed = original.asReversed()
+
+        reversed.remove("c")
+        assertEquals(listOf("a", "b"), original)
+        assertEquals(listOf("b", "a"), reversed)
+    }
+
+    test fun testMutableClear() {
+        val original = arrayListOf(1, 2, 3)
+        val reversed = original.asReversed()
+
+        reversed.clear()
+
+        assertEquals(emptyList<Int>(), reversed)
+        assertEquals(emptyList<Int>(), original)
+    }
+
+    test fun testContains() {
+        assertTrue { 1 in listOf(1, 2, 3).asReversed() }
+        assertTrue { 1 in arrayListOf(1, 2, 3).asReversed() }
+    }
+
+    test fun testIndexOf() {
+        assertEquals(2, listOf(1, 2, 3).asReversed().indexOf(1))
+        assertEquals(2, arrayListOf(1, 2, 3).asReversed().indexOf(1))
+    }
+
+    test fun testBidirectionalModifications() {
+        val original = arrayListOf(1, 2, 3, 4)
+        val reversed = original.asReversed()
+
+        original.remove(3)
+        assertEquals(listOf(1, 2, 3), original)
+        assertEquals(listOf(3, 2, 1), reversed)
+
+        reversed.remove(2)
+        assertEquals(listOf(2, 3), original)
+        assertEquals(listOf(3, 2), reversed)
+    }
+
+    test fun testGetIOOB() {
+        val success = try {
+            listOf(1, 2, 3).asReversed().get(3)
+            true
+        } catch (expected: IndexOutOfBoundsException) {
+            false
+        }
+
+        assertFalse(success)
+    }
+
+    test fun testSetIOOB() {
+        val success = try {
+            arrayListOf(1, 2, 3).asReversed().set(3, 0)
+            true
+        } catch(expected: IndexOutOfBoundsException) {
+            false
+        }
+
+        assertFalse(success)
+    }
+
+    test fun testAddIOOB() {
+        val success = try {
+            arrayListOf(1, 2, 3).asReversed().add(4, 0)
+            true
+        } catch(expected: IndexOutOfBoundsException) {
+            false
+        }
+
+        assertFalse(success)
+    }
+
+    test fun testRemoveIOOB() {
+        val success = try {
+            arrayListOf(1, 2, 3).asReversed().remove(3)
+            true
+        } catch(expected: IndexOutOfBoundsException) {
+            false
+        }
+
+        assertFalse(success)
+    }
+}

--- a/libraries/stdlib/test/collections/ReversedViewsTest.kt
+++ b/libraries/stdlib/test/collections/ReversedViewsTest.kt
@@ -16,6 +16,8 @@
 
 package collections
 
+import test.collections.behaviors.listBehavior
+import test.collections.compare
 import kotlin.asReversed
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -23,6 +25,15 @@ import kotlin.test.assertTrue
 import org.junit.Test as test
 
 class ReversedViewsTest {
+
+    test fun testBehavior() {
+        val original = listOf(2L, 3L, Long.MAX_VALUE)
+        val reversed = original.reverse()
+        compare(reversed, original.asReversed()) {
+            listBehavior()
+        }
+    }
+
     test fun testSimple() {
         assertEquals(listOf(3, 2, 1), listOf(1, 2, 3).asReversed())
         assertEquals(listOf(3, 2, 1), listOf(1, 2, 3).asReversed().toList())

--- a/libraries/stdlib/test/collections/ReversedViewsTest.kt
+++ b/libraries/stdlib/test/collections/ReversedViewsTest.kt
@@ -26,6 +26,10 @@ import org.junit.Test as test
 
 class ReversedViewsTest {
 
+    test fun testNullToString() {
+        assertEquals("[null]", listOf<String?>(null).asReversed().toString())
+    }
+
     test fun testBehavior() {
         val original = listOf(2L, 3L, Long.MAX_VALUE)
         val reversed = original.reverse()


### PR DESCRIPTION
Introduces `asReversed` extension function. The main difference over `reverse` is that it only creates a view of the original `List`. There are two implementations of it: for `List<T>` and for `MutableList<T>`. In mutable version we also can modify a view returned by `asReversed` and all changes will be reflected in the original list. We also can chain `asReversed` and `subList` and it will still work.

The only thing doesn't work is mutable sublist in JavaScript: our own sub-list implementation doesn't support it yet so it doesn't work with reversed lists too. This is why corresponding test is extracted to JVM only version