### PR TITLE
KT-8708 Function to strip leading whitespaces

### DIFF
--- a/compiler/tests/org/jetbrains/kotlin/test/util/jetTestUtils.kt
+++ b/compiler/tests/org/jetbrains/kotlin/test/util/jetTestUtils.kt
@@ -47,34 +47,6 @@ public fun CodeInsightTestFixture.configureWithExtraFile(path: String, vararg ex
     configureByFiles(*(listOf(path) + extraPaths).toTypedArray())
 }
 
-public fun String.trimIndent(): String {
-    val lines = split('\n')
-
-    val firstNonEmpty = lines.firstOrNull { !it.trim().isEmpty() }
-    if (firstNonEmpty == null) {
-        return this
-    }
-
-    val trimmedPrefix = firstNonEmpty.takeWhile { ch -> ch.isWhitespace() }
-    if (trimmedPrefix.isEmpty()) {
-        return this
-    }
-
-    return lines.map { line ->
-        if (line.trim().isEmpty()) {
-            ""
-        }
-        else {
-            if (!line.startsWith(trimmedPrefix)) {
-                throw IllegalArgumentException(
-                        """Invalid line "$line", ${trimmedPrefix.length()} whitespace character are expected""")
-            }
-
-            line.substring(trimmedPrefix.length())
-        }
-    }.joinToString(separator = "\n")
-}
-
 public fun PsiFile.findElementByCommentPrefix(commentText: String): PsiElement? =
         findElementsByCommentPrefix(commentText).keySet().singleOrNull()
 

--- a/idea/tests/org/jetbrains/kotlin/idea/codeInsight/smartEnter/SmartEnterTest.kt
+++ b/idea/tests/org/jetbrains/kotlin/idea/codeInsight/smartEnter/SmartEnterTest.kt
@@ -19,7 +19,6 @@ package org.jetbrains.kotlin.idea.codeInsight.smartEnter
 import org.jetbrains.kotlin.idea.test.JetLightCodeInsightFixtureTestCase
 import com.intellij.openapi.actionSystem.IdeActions
 import org.jetbrains.kotlin.idea.JetFileType
-import org.jetbrains.kotlin.test.util.trimIndent
 import com.intellij.testFramework.LightProjectDescriptor
 import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase
 
@@ -1041,4 +1040,33 @@ class SmartEnterTest : JetLightCodeInsightFixtureTestCase() {
     override fun getProjectDescriptor(): LightProjectDescriptor = LightCodeInsightFixtureTestCase.JAVA_LATEST
 
     private fun String.removeFirstEmptyLines() = this.split("\n").dropWhile { it.isEmpty() }.joinToString(separator = "\n")
+
+    deprecated("use kotlin.trimIndent instead")
+    private fun String.trimIndent(): String {
+        val lines = split('\n')
+
+        val firstNonEmpty = lines.firstOrNull { !it.trim().isEmpty() }
+        if (firstNonEmpty == null) {
+            return this
+        }
+
+        val trimmedPrefix = firstNonEmpty.takeWhile { ch -> ch.isWhitespace() }
+        if (trimmedPrefix.isEmpty()) {
+            return this
+        }
+
+        return lines.map { line ->
+            if (line.trim().isEmpty()) {
+                ""
+            }
+            else {
+                if (!line.startsWith(trimmedPrefix)) {
+                    throw IllegalArgumentException(
+                            """Invalid line "$line", ${trimmedPrefix.length()} whitespace character are expected""")
+                }
+
+                line.substring(trimmedPrefix.length())
+            }
+        }.joinToString(separator = "\n")
+    }
 }

--- a/libraries/stdlib/src/kotlin/text/Indent.kt
+++ b/libraries/stdlib/src/kotlin/text/Indent.kt
@@ -1,0 +1,115 @@
+package kotlin
+
+/**
+ * Trims leading whitespace characters followed by [marginPrefix] from every line of a source string and removes
+ * first and last lines if they are blank (notice difference blank vs empty). Doesn't affect line if it doesn't contain
+ * [marginPrefix] except first and last blank lines
+ *
+ * Do not preserves original line endings
+ *
+ * [marginPrefix] should be non-blank string
+ *
+ * Example
+ * ```kotlin
+ * assertEquals("ABC\n123\n456", """ABC
+ *                             |123
+ *                             |456""".trimMargin())
+ * ```
+ *
+ * @param marginPrefix characters to be used as a margin delimiter. Default is `|` (pipe character)
+ * @return the trimmed String
+ * @see kotlin.isWhitespace
+ * @since M13
+ */
+public fun String.trimMargin(marginPrefix: String = "|"): String =
+    replaceIndentByMargin("", marginPrefix)
+
+/**
+ * Detects indent by [marginPrefix] as it does [trimMargin] and replace it with [newIndent]
+ */
+public fun String.replaceIndentByMargin(newIndent: String = "", marginPrefix: String = "|"): String {
+    require(marginPrefix.isNotBlank()) { "marginPrefix should be non blank string but it is '$marginPrefix'" }
+    val lines = lines()
+
+    return lines.reindent(length() + newIndent.length() * lines.size(), getIndentFunction(newIndent)) { line ->
+        val firstNonWhitespaceIndex = line.indexOfFirst { !it.isWhitespace() }
+
+        when {
+            firstNonWhitespaceIndex == -1 -> null
+            line.startsWith(marginPrefix, firstNonWhitespaceIndex) -> line.substring(firstNonWhitespaceIndex + marginPrefix.length())
+            else -> null
+        }
+    }
+}
+
+/**
+ * Detects a common minimal indent of all the input lines, removes it from every line and also removes first and last
+ * lines if they are blank (notice difference blank vs empty).
+ * Note that blank lines do not affect detected indent level.
+ * Please keep in mind that if there are non-blank lines with no leading whitespace characters (no indent at all) then the
+ * common indent is 0 so this function may do nothing so it is recommended to keep first line empty (will be dropped).
+ *
+ * Do not preserves original line endings
+ *
+ * Example
+ * ```kotlin
+ * assertEquals("ABC\n123\n456", """
+ *                             ABC
+ *                             123
+ *                             456""".trimMargin())
+ * ```
+ *
+ * @return deindented String
+ * @see kotlin.isBlank
+ * @since M13
+ */
+public fun String.trimIndent(): String = replaceIndent("")
+
+/**
+ * Detects a common minimal indent like it does [trimIndent] and replaces it with the specified [newIndent]
+ * @since M13
+ */
+public fun String.replaceIndent(newIndent: String = ""): String {
+    val lines = lines()
+
+    val minCommonIndent = lines
+            .filter { it.isNotBlank() }
+            .map { it.indentWidth() }
+            .min() ?: 0
+
+    return lines.reindent(length() + newIndent.length() * lines.size(), getIndentFunction(newIndent)) { line -> line.drop(minCommonIndent) }
+}
+
+/**
+ * Prepends [indent] to every line of the original string. Does not preserve original line endings
+ */
+public fun String.prependIndent(indent: String = "    "): String =
+    lineSequence()
+    .map {
+        when {
+            it.isBlank() -> {
+                when {
+                    it.length() < indent.length() -> indent
+                    else -> it
+                }
+            }
+            else -> indent + it
+        }
+    }
+    .joinToString("\n")
+
+private fun String.indentWidth(): Int = indexOfFirst { !it.isWhitespace() }.let { if (it == -1) length() else it }
+
+private fun getIndentFunction(indent: String) = when {
+    indent.isEmpty() -> { line: String -> line }
+    else -> { line: String -> "$indent$line" }
+}
+
+private inline fun List<String>.reindent(resultSizeEstimate: Int, indentAddFunction: (String) -> String, indentCutFunction: (String) -> String?) = lastIndex.let { lastLineIndex ->
+    withIndex()
+            .dropWhile { it.index == 0 && it.value.isBlank() }
+            .takeWhile { it.index != lastLineIndex || it.value.isNotBlank() }
+            .map { indentCutFunction(it.value)?.let { cutted -> indentAddFunction(cutted) } ?: it.value }
+            .joinTo(StringBuilder(resultSizeEstimate), "\n")
+            .toString()
+}

--- a/libraries/stdlib/src/kotlin/text/StringBuilderJVM.kt
+++ b/libraries/stdlib/src/kotlin/text/StringBuilderJVM.kt
@@ -1,9 +1,7 @@
 package kotlin
 
-import kotlin.properties.*
-
 /** Line separator for current system. */
-private val LINE_SEPARATOR: String by Delegates.lazy { System.getProperty("line.separator")!! }
+private val LINE_SEPARATOR: String by lazy { System.getProperty("line.separator")!! }
 
 /** Appends a line separator to this Appendable. */
 public fun Appendable.appendln(): Appendable = append(LINE_SEPARATOR)

--- a/libraries/stdlib/src/kotlin/text/Strings.kt
+++ b/libraries/stdlib/src/kotlin/text/Strings.kt
@@ -807,15 +807,25 @@ public fun String.contains(char: Char, ignoreCase: Boolean = false): Boolean =
  * @see kotlin.isWhitespace
  * @since M13
  */
-public fun CharSequence.trimMargin(marginPrefix: String = "|", whitespacePredicate: (Char) -> Boolean = { it.isWhitespace() }): String =
-        toString().lineSequence().map { line ->
-            val content = line.trimStart(whitespacePredicate)
+public fun CharSequence.trimMargin(marginPrefix: String = "|", whitespacePredicate: (Char) -> Boolean = { it.isWhitespace() }): String {
+    val lines = toString().lineSequence()
 
-            when {
-                content.startsWith(marginPrefix) -> content.removePrefix(marginPrefix)
-                else -> line
-            }
-        }.joinTo(StringBuilder(length()), "\n").toString()
+    val lastLineIndex = lines.count() - 1
+
+    return lines
+            .withIndex()
+            .dropWhile { it.index == 0 && it.value.isBlank() }
+            .takeWhile { it.index != lastLineIndex || it.value.isNotBlank() }
+            .map { it.value }
+            .map { line ->
+                val content = line.trimStart(whitespacePredicate)
+
+                when {
+                    content.startsWith(marginPrefix) -> content.removePrefix(marginPrefix)
+                    else -> line
+                }
+            }.joinTo(StringBuilder(length()), "\n").toString()
+}
 
 /**
  * Detects a common minimal indent of all the input lines, removes it from every line and also removes first and last

--- a/libraries/stdlib/src/kotlin/text/Strings.kt
+++ b/libraries/stdlib/src/kotlin/text/Strings.kt
@@ -807,9 +807,9 @@ public fun String.contains(char: Char, ignoreCase: Boolean = false): Boolean =
  * @see kotlin.isWhitespace
  * @since M13
  */
-public fun CharSequence.trimMargin(marginPrefix: String = "|"): String =
+public fun CharSequence.trimMargin(marginPrefix: String = "|", whitespacePredicate: (Char) -> Boolean = { it.isWhitespace() }): String =
         toString().lineSequence().map { line ->
-            val content = line.trimStart()
+            val content = line.trimStart(whitespacePredicate)
 
             when {
                 content.startsWith(marginPrefix) -> content.removePrefix(marginPrefix)

--- a/libraries/stdlib/src/kotlin/text/Strings.kt
+++ b/libraries/stdlib/src/kotlin/text/Strings.kt
@@ -791,6 +791,31 @@ public fun String.contains(seq: CharSequence, ignoreCase: Boolean = false): Bool
 public fun String.contains(char: Char, ignoreCase: Boolean = false): Boolean =
         indexOf(char, ignoreCase = ignoreCase) >= 0
 
+/**
+ * Trims leading whitespace characters followed by [marginPrefix] from every line of a [java.lang.CharSequence].
+ * Always creates a new string even if the original CharSequence is mutable
+ *
+ * Example
+ * ```kotlin
+ * assertEquals("ABC\n123\n456", """ABC
+ *                             |123
+ *                             |456""".trimMargin())
+ * ```
+ *
+ * @param marginPrefix characters to be used as a margin delimiter. Default is `|` (pipe character)
+ * @return the trimmed String
+ * @see kotlin.isWhitespace
+ * @since M13
+ */
+public fun CharSequence.trimMargin(marginPrefix: String = "|"): String =
+        toString().lineSequence().map { line ->
+            val content = line.trimStart()
+
+            when {
+                content.startsWith(marginPrefix) -> content.removePrefix(marginPrefix)
+                else -> line
+            }
+        }.joinTo(StringBuilder(length()), "\n").toString()
 
 // rangesDelimitedBy
 

--- a/libraries/stdlib/src/kotlin/text/Strings.kt
+++ b/libraries/stdlib/src/kotlin/text/Strings.kt
@@ -839,36 +839,22 @@ public fun CharSequence.trimMargin(marginPrefix: String = "|", whitespacePredica
  * @since M13
  */
 public fun CharSequence.trimIndent(): String {
-    val string = toString()
-    val lines = string.lineSequence()
+    val lines = toString().lineSequence()
 
     val minCommonIndent = lines
             .filter { it.isNotBlank() }
             .map { it.indentWidth() }
             .min() ?: 0
 
-    if (minCommonIndent == 0) {
-        return string
-    }
+    val lastLineIndex = lines.count() - 1
 
     return lines
             .withIndex()
             .dropWhile { it.index == 0 && it.value.isBlank() }
+            .takeWhile { it.index != lastLineIndex || it.value.isNotBlank() }
             .map { it.value.drop(minCommonIndent) }
             .joinTo(StringBuilder(length()), "\n")
-            .dropTrailingEmptyLine()
             .toString()
-}
-
-private fun StringBuilder.dropTrailingEmptyLine(): StringBuilder {
-    val trailingLineStart = lastIndexOf("\n")
-    val trailingLine = substring(trailingLineStart)
-
-    if (trailingLine.isBlank()) {
-        delete(trailingLineStart, length())
-    }
-
-    return this
 }
 
 private fun String.indentWidth(): Int = indexOfFirst { !it.isWhitespace() }.let { if (it == -1) length() else it }

--- a/libraries/stdlib/src/kotlin/text/Strings.kt
+++ b/libraries/stdlib/src/kotlin/text/Strings.kt
@@ -1,6 +1,5 @@
 package kotlin
 
-import java.lang
 import java.util.NoSuchElementException
 import kotlin.platform.platformName
 import kotlin.text.MatchResult
@@ -791,86 +790,6 @@ public fun String.contains(seq: CharSequence, ignoreCase: Boolean = false): Bool
  */
 public fun String.contains(char: Char, ignoreCase: Boolean = false): Boolean =
         indexOf(char, ignoreCase = ignoreCase) >= 0
-
-private fun getIndentFunction(indent: String) = when {
-    indent.isEmpty() -> { line: String -> line }
-    else -> { line: String -> "$indent$line" }
-}
-
-private inline fun List<String>.reindent(length: Int, indentAddFunction: (String) -> String, indentCutFunction: (String) -> String) = lastIndex.let { lastLineIndex ->
-    withIndex()
-            .dropWhile { it.index == 0 && it.value.isBlank() }
-            .takeWhile { it.index != lastLineIndex || it.value.isNotBlank() }
-            .map { indentCutFunction(it.value) }
-            .map(indentAddFunction)
-            .joinTo(StringBuilder(length), "\n")
-            .toString()
-}
-
-/**
- * Trims leading whitespace characters followed by [marginPrefix] from every line of a source string and removes
- * first and last lines if they are blank (notice difference blank vs empty).
- * Do not preserves original line endings
- *
- * Example
- * ```kotlin
- * assertEquals("ABC\n123\n456", """ABC
- *                             |123
- *                             |456""".trimMargin())
- * ```
- *
- * @param marginPrefix characters to be used as a margin delimiter. Default is `|` (pipe character)
- * @return the trimmed String
- * @see kotlin.isWhitespace
- * @since M13
- */
-public fun String.trimMargin(marginPrefix: String = "|", newIndent: String = ""): String {
-    require(marginPrefix.isNotBlank()) { "marginPrefix should be non blank string but it is '$marginPrefix'" }
-
-    return lines().reindent(length(), getIndentFunction(newIndent)) { line ->
-        val firstNonWhitespaceIndex = line.indexOfFirst { !it.isWhitespace() }
-
-        when {
-            firstNonWhitespaceIndex == -1 -> line
-            line.startsWith(marginPrefix, firstNonWhitespaceIndex) -> line.substring(firstNonWhitespaceIndex + marginPrefix.length())
-            else -> line
-        }
-    }
-}
-
-/**
- * Detects a common minimal indent of all the input lines, removes it from every line and also removes first and last
- * lines if they are blank (notice difference blank vs empty).
- * Note that blank lines do not affect detected indent level.
- * Please keep in mind that if there are non-blank lines with no leading whitespace characters (no indent at all) then the
- * common indent is 0 so this function may do nothing so it is recommended to keep first line empty (will be dropped).
- *
- * Do not preserves original line endings
- *
- * Example
- * ```kotlin
- * assertEquals("ABC\n123\n456", """
- *                             ABC
- *                             123
- *                             456""".trimMargin())
- * ```
- *
- * @return deindented String
- * @see kotlin.isBlank
- * @since M13
- */
-public fun String.trimIndent(newIndent: String = ""): String {
-    val lines = lines()
-
-    val minCommonIndent = lines
-            .filter { it.isNotBlank() }
-            .map { it.indentWidth() }
-            .min() ?: 0
-
-    return lines.reindent(length(), getIndentFunction(newIndent)) { line -> line.drop(minCommonIndent) }
-}
-
-private fun String.indentWidth(): Int = indexOfFirst { !it.isWhitespace() }.let { if (it == -1) length() else it }
 
 // rangesDelimitedBy
 

--- a/libraries/stdlib/test/text/StringTest.kt
+++ b/libraries/stdlib/test/text/StringTest.kt
@@ -555,5 +555,32 @@ class StringTest {
         assertEquals("-test", "test".replaceFirst("", "-"))
     }
 
+    test fun trimMargin() {
+        // WARNING
+        // DO NOT REFORMAT AS TESTS MAY FAIL DUE TO INDENTATION CHANGE
 
+        assertEquals("ABC\n123\n456", """ABC
+                                      |123
+                                      |456""".trimMargin())
+
+        assertEquals("ABC \n123\n456", """ABC${" "}
+                                      |123
+                                      |456""".trimMargin())
+
+        assertEquals(" ABC\n123\n456", """ ABC
+                                        >>123
+                                        ${"\t"}>>456""".trimMargin(">>"))
+
+        assertEquals("", "".trimMargin())
+
+        assertEquals("\n                            ", """
+                            """.trimMargin())
+
+        assertEquals("\n", """
+                            |""".trimMargin())
+
+        assertEquals("\n\n                            ", """
+                            |
+                            """.trimMargin())
+    }
 }

--- a/libraries/stdlib/test/text/StringTest.kt
+++ b/libraries/stdlib/test/text/StringTest.kt
@@ -576,15 +576,27 @@ class StringTest {
 
         assertEquals("", "".trimMargin())
 
-        assertEquals("\n                            ", """
+        assertEquals("", """
                             """.trimMargin())
 
-        assertEquals("\n", """
+        assertEquals("", """
                             |""".trimMargin())
 
-        assertEquals("\n\n                            ", """
+        assertEquals("", """
                             |
                             """.trimMargin())
+
+        assertEquals("    a", """
+            |    a
+        """.trimMargin())
+
+        assertEquals("    a", """
+            |    a""".trimMargin())
+
+        assertEquals("    a", """ |    a
+        """.trimMargin())
+
+        assertEquals("    a", """ |    a""".trimMargin())
 
         assertEquals("\u0000|ABC", "${"\u0000"}|ABC".trimMargin())
         assertEquals("ABC", "${"\u0000"}|ABC".trimMargin { it < ' ' })

--- a/libraries/stdlib/test/text/StringTest.kt
+++ b/libraries/stdlib/test/text/StringTest.kt
@@ -1,6 +1,9 @@
 package test.text
 
-import kotlin.test.*
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.test.fails
 import org.junit.Test as test
 
 // could not be local inside isEmptyAndBlank, because non-toplevel declarations is not yet supported for JS
@@ -585,5 +588,64 @@ class StringTest {
 
         assertEquals("\u0000|ABC", "${"\u0000"}|ABC".trimMargin())
         assertEquals("ABC", "${"\u0000"}|ABC".trimMargin { it < ' ' })
+    }
+
+    test fun trimIndent() {
+        // WARNING
+        // DO NOT REFORMAT AS TESTS MAY FAIL DUE TO INDENTATION CHANGE
+
+        assertEquals("123", """
+        123
+        """.trimIndent())
+
+        assertEquals("123\n   456", """
+        123
+           456
+           """.trimIndent())
+
+        assertEquals("   123\n456", """
+           123
+        456
+        """.trimIndent())
+
+        assertEquals("   123\n456", """
+           123
+        456""".trimIndent())
+
+        assertEquals("    ", """
+${"    "}
+        """.trimIndent())
+
+        val deindented = """
+                                                            ,.
+                      ,.                     _       oo.   `88P
+                     ]88b              ,o.  d88.    ]88b     '
+                      888   _          Y888o888     d88P     _     _
+                      888 ,888          `Y88888o_  ,888    d88b   d88._____
+                      888,888P ,oooooo.   ;888888b.]88P    888'   d888888888p
+                      888888P d88888888.  J88b'YPP ]88b   ,888    d888P'''888.
+                      8888P' ]88P   `888  d88[     d88P   ]88b    888'    Y88b
+                      8888p  ]88b    888  888      d88[    888    888.    `888
+                     ,88888b  888[   888  888.     d88[    888.   Y88b     Y88[
+                     d88PY88b `888L,d88P  Y88b     Y88b    ]88b   `888     888'
+                     888  Y88b  Y88888P    888.     888.    888.   Y88b   `88P
+                    d88P   888   `'P'      Y888.    `888.   `88P   `Y8P     '
+                    Y8P'    '               `YP      Y8P'     '
+
+                    ____       dXp   _    _        _________
+                  ddXXXXXp     XXP  ,XX  dXb      Yo.XXXXXX      ,oooooo.
+                  X'L_oXXP     XX'   XX[ dXb      dXb            YPPPPXXX'
+                  XYXXXXX     ]XX    dXb dXb      dX8Xooooo         dXXP
+                  XXb`YYXXo.   YXXo_ dXP dXP      YXb''''''       ,XXP'
+                  `XX   `YYXb   `YXXXXP  XX[      ]XX            ,XX'
+                   YXb     YXb     `''   XXXXooL  `XX._____      `XXXXXXXXooooo.
+                   `XP      '             ''''''   YPXXXXXX'       ''''''`''YPPP
+        """.trimIndent()
+
+        assertEquals(23, deindented.lines().size())
+        val indents = deindented.lines().map { "^\\s*".toRegex().match(it)!!.value.length() }
+        assertEquals(0, indents.min())
+        assertEquals(42, indents.max())
+        assertEquals(1, deindented.lines().count { it.isEmpty() })
     }
 }

--- a/libraries/stdlib/test/text/StringTest.kt
+++ b/libraries/stdlib/test/text/StringTest.kt
@@ -582,5 +582,8 @@ class StringTest {
         assertEquals("\n\n                            ", """
                             |
                             """.trimMargin())
+
+        assertEquals("\u0000|ABC", "${"\u0000"}|ABC".trimMargin())
+        assertEquals("ABC", "${"\u0000"}|ABC".trimMargin { it < ' ' })
     }
 }

--- a/libraries/stdlib/test/text/StringTest.kt
+++ b/libraries/stdlib/test/text/StringTest.kt
@@ -566,9 +566,9 @@ class StringTest {
                                       |123
                                       |456""".trimMargin())
 
-        assertEquals("  ABC\n  123\n  456", """ABC
+        assertEquals("ABC\n  123\n  456", """ABC
                                       |123
-                                      |456""".trimMargin(newIndent = "  "))
+                                      |456""".replaceIndentByMargin(newIndent = "  "))
 
         assertEquals("ABC \n123\n456", """ABC${" "}
                                       |123
@@ -626,7 +626,7 @@ class StringTest {
         assertEquals("     123\n  456", """
            123
         456
-        """.trimIndent(newIndent = "  "))
+        """.replaceIndent(newIndent = "  "))
 
         assertEquals("   123\n456", """
            123
@@ -667,5 +667,13 @@ ${"    "}
         assertEquals(0, indents.min())
         assertEquals(42, indents.max())
         assertEquals(1, deindented.lines().count { it.isEmpty() })
+    }
+
+    test fun testIndent() {
+        assertEquals("  ABC\n  123", "ABC\n123".prependIndent("  "))
+        assertEquals("  ABC\n  \n  123", "ABC\n\n123".prependIndent("  "))
+        assertEquals("  ABC\n  \n  123", "ABC\n \n123".prependIndent("  "))
+        assertEquals("  ABC\n   \n  123", "ABC\n   \n123".prependIndent("  "))
+        assertEquals("  ", "".prependIndent("  "))
     }
 }

--- a/libraries/stdlib/test/text/StringTest.kt
+++ b/libraries/stdlib/test/text/StringTest.kt
@@ -566,6 +566,10 @@ class StringTest {
                                       |123
                                       |456""".trimMargin())
 
+        assertEquals("  ABC\n  123\n  456", """ABC
+                                      |123
+                                      |456""".trimMargin(newIndent = "  "))
+
         assertEquals("ABC \n123\n456", """ABC${" "}
                                       |123
                                       |456""".trimMargin())
@@ -599,7 +603,6 @@ class StringTest {
         assertEquals("    a", """ |    a""".trimMargin())
 
         assertEquals("\u0000|ABC", "${"\u0000"}|ABC".trimMargin())
-        assertEquals("ABC", "${"\u0000"}|ABC".trimMargin { it < ' ' })
     }
 
     test fun trimIndent() {
@@ -619,6 +622,11 @@ class StringTest {
            123
         456
         """.trimIndent())
+
+        assertEquals("     123\n  456", """
+           123
+        456
+        """.trimIndent(newIndent = "  "))
 
         assertEquals("   123\n456", """
            123


### PR DESCRIPTION
Function to strip leading whitespace characters before the specified delimiter character (pipe by default). Intended to be partial solution of [KT-6620 Indent safe """ syntax](https://youtrack.jetbrains.com/issue/KT-6620)

`trimMargin` is very similar to `stripMargin` in Scala and Groovy so we can think it is a common solution.

`trimMargin` is works slightly different than `stripMarign` in Scala and Groovy. The main difference is that by default `trimMargin` removes only whitespaces on the contrary `stripMargin` removes all control characters that I believe is wrong. 

However if user really need exact the same behaviour he always can specify custom `whitespacePredicate` like this:

```kotlin
trimMargin { it <= ' ' }
```