### PR TITLE
Selenium longer per-test timeout

### DIFF
--- a/libraries/tools/kotlin-js-tests-junit/pom.xml
+++ b/libraries/tools/kotlin-js-tests-junit/pom.xml
@@ -25,6 +25,12 @@
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-js-tests</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jetbrains.kotlin</groupId>
+                    <artifactId>kotlin-js-library</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>


### PR DESCRIPTION
Increase time out to 5s because 1s for the whole test suite is too strong restriction + minor code cleanup