### PR TITLE
Fixing KT-9196 (broken kotlin-compiler-embeddable.jar in M13) by excl…

### DIFF
--- a/libraries/tools/kotlin-compiler-embeddable/pom.xml
+++ b/libraries/tools/kotlin-compiler-embeddable/pom.xml
@@ -7,6 +7,7 @@
     <properties>
         <maven-plugin-anno.version>1.4.1</maven-plugin-anno.version>
         <maven.version>3.0.4</maven.version>
+        <surefire-version>2.16</surefire-version>
         <kotlin.relocated.package>org.jetbrains.kotlin.relocated</kotlin.relocated.package>
     </properties>
 
@@ -46,6 +47,7 @@
     </dependencies>
 
     <build>
+        <testSourceDirectory>test/kotlin</testSourceDirectory>
         <plugins>
 
             <plugin>
@@ -139,6 +141,9 @@
                                 <relocation>
                                     <pattern>org.fusesource</pattern>
                                     <shadedPattern>${kotlin.relocated.package}.org.fusesource</shadedPattern>
+                                    <excludes>
+                                        <exclude>org.fusesource.jansi.internal.CLibrary</exclude>
+                                    </excludes>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.picocontainer</pattern>
@@ -161,6 +166,35 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${project.version}</version>
+
+                <executions>
+                    <execution>
+                        <id>test-compile</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire-version}</version>
+                <executions>
+                    <execution>
+                        <id>integration-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <phase>integration-test</phase>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
     </build>
 </project>

--- a/libraries/tools/kotlin-compiler-embeddable/test/kotlin/org/jetbrains/kotlin/compiler/embeddable/CompilerEmbeddableSmokeTests.kt
+++ b/libraries/tools/kotlin-compiler-embeddable/test/kotlin/org/jetbrains/kotlin/compiler/embeddable/CompilerEmbeddableSmokeTests.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2010-2015 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.kotlin.compiler.embeddable
+
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.io.FileNotFoundException
+import java.io.InputStream
+import kotlin.test.assertEquals
+
+
+private val COMPILER_CLASS_FQN = "org.jetbrains.kotlin.cli.jvm.K2JVMCompiler"
+
+public class CompilerSmokeTest {
+
+    public val _workingDir: TemporaryFolder = TemporaryFolder()
+
+    @Rule
+    public fun getWorkingDir(): TemporaryFolder = _workingDir
+
+    private val javaExecutable = File( File(System.getProperty("java.home"), "bin"), "java")
+
+    private val embeddableJar = File(".").listFiles { it.name.startsWith("kotlin-compiler-embeddable", ignoreCase = true) && it.name.endsWith(".jar", ignoreCase = true) }?.firstOrNull()
+                                ?: throw FileNotFoundException("cannot find kotlin-compiler-embeddable*.jar in the directory " + File(".").absolutePath)
+
+    @Test
+    fun testSmoke() {
+        val (out, code) = runCompiler(File("../test/resources/projects/smoke/Smoke.kt").absolutePath)
+        assertEquals(0, code, "compilation failed:\n" + out)
+    }
+
+
+    private fun createProcess(cmd: List<String>, projectDir: File): Process {
+        val builder = ProcessBuilder(cmd)
+        builder.directory(projectDir)
+        builder.redirectErrorStream(true)
+        return builder.start()
+    }
+
+    private fun runCompiler(vararg arguments: String): Pair<String, Int> {
+        val cmd = listOf(javaExecutable.absolutePath,
+                "-Djava.awt.headless=true",
+                "-cp",
+                embeddableJar.absolutePath,
+                COMPILER_CLASS_FQN) +
+                arguments
+        val proc = createProcess(cmd, _workingDir.root)
+        return readOutput(proc)
+    }
+
+    private fun readOutput(process: Process): Pair<String, Int> {
+        fun InputStream.readFully(): String {
+            val text = reader().readText()
+            close()
+            return text
+        }
+
+        val stdout = process.getInputStream()!!.readFully()
+        System.out.println(stdout)
+        val stderr = process.getErrorStream()!!.readFully()
+        System.err.println(stderr)
+
+        val result = process.waitFor()
+        return stdout to result
+    }
+}

--- a/libraries/tools/kotlin-compiler-embeddable/test/resources/projects/smoke/Smoke.kt
+++ b/libraries/tools/kotlin-compiler-embeddable/test/resources/projects/smoke/Smoke.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2010-2015 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package smoke
+
+fun main(args: Array<String>) {
+    System.out.print(args)
+}


### PR DESCRIPTION
…uding org.fusesource.jansi.internal.CLibrary from relocation, adding smoke test for embeddable jar