### PR TITLE
Avoid accidentally configuring the publications deferred configuration

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt
@@ -522,7 +522,7 @@ open class GradleUtils(val scriptHandler: ScriptHandler, val project: ProjectInt
         return configuration.getResolvedConfiguration().getFiles { true }
     }
 
-    public fun kotlinPluginVersion(): String = project.getProperties()["kotlin.gradle.plugin.version"] as String
+    public fun kotlinPluginVersion(): String = project.property("kotlin.gradle.plugin.version") as String
     public fun kotlinPluginArtifactCoordinates(artifact: String): String = "org.jetbrains.kotlin:${artifact}:${kotlinPluginVersion()}"
     public fun kotlinJsLibraryCoordinates(): String = kotlinPluginArtifactCoordinates("kotlin-js-library")
 

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt
@@ -522,7 +522,7 @@ open class GradleUtils(val scriptHandler: ScriptHandler, val project: ProjectInt
         return configuration.getResolvedConfiguration().getFiles { true }
     }
 
-    public fun kotlinPluginVersion(): String = project.property("kotlin.gradle.plugin.version") as String
+    public fun kotlinPluginVersion(): String = project.hasProperty("kotlin.gradle.plugin.version") ? project.property("kotlin.gradle.plugin.version") as String : null
     public fun kotlinPluginArtifactCoordinates(artifact: String): String = "org.jetbrains.kotlin:${artifact}:${kotlinPluginVersion()}"
     public fun kotlinJsLibraryCoordinates(): String = kotlinPluginArtifactCoordinates("kotlin-js-library")
 


### PR DESCRIPTION
Gradle projects that use the `maven-publish` plugin break when the Kotlin plugin is applied due to `project.getProperties` causing the extension holder to be configured:

```
> Cannot configure the 'publishing' extension after it has been accessed.
```

The configuration happens here (had to set a breakpoint to catch this, the exception doesn't indicate where it was first configured):

```
"main@1" prio=5 tid=0x1 nid=NA runnable
  java.lang.Thread.State: RUNNABLE
      at org.gradle.api.internal.plugins.ExtensionsStorage$DeferredConfigurableExtensionHolder.configureNow(ExtensionsStorage.java:181)
      at org.gradle.api.internal.plugins.ExtensionsStorage$DeferredConfigurableExtensionHolder.get(ExtensionsStorage.java:162)
      at org.gradle.api.internal.plugins.ExtensionsStorage.getAsMap(ExtensionsStorage.java:50)
      at org.gradle.api.internal.plugins.DefaultConvention$ExtensionsDynamicObject.getProperties(DefaultConvention.java:168)
      at org.gradle.api.internal.CompositeDynamicObject.getProperties(CompositeDynamicObject.java:130)
      at org.gradle.api.internal.project.AbstractProject$4.create(AbstractProject.java:747)
      at org.gradle.api.internal.project.AbstractProject$4.create(AbstractProject.java:745)
      at org.gradle.util.SingleMessageLogger.whileDisabled(SingleMessageLogger.java:166)
      at org.gradle.api.internal.project.AbstractProject.getProperties(AbstractProject.java:745)
      at org.jetbrains.kotlin.gradle.plugin.GradleUtils.kotlinPluginVersion(KotlinPlugin.kt:533)
      at org.jetbrains.kotlin.gradle.plugin.GradleUtils.kotlinPluginArtifactCoordinates(KotlinPlugin.kt:534)
      at org.jetbrains.kotlin.gradle.plugin.GradleUtils.resolveKotlinPluginDependency(KotlinPlugin.kt:538)
      at org.jetbrains.kotlin.gradle.plugin.AbstractKotlinPlugin.apply(KotlinPlugin.kt:244)
      at org.jetbrains.kotlin.gradle.plugin.KotlinPlugin.apply(KotlinPlugin.kt:265)
      at org.jetbrains.kotlin.gradle.plugin.KotlinPlugin.apply(KotlinPlugin.kt:259)
      at org.jetbrains.kotlin.gradle.plugin.KotlinBasePluginWrapper.apply(KotlinPluginWrapper.kt:39)
      at org.jetbrains.kotlin.gradle.plugin.KotlinBasePluginWrapper.apply(KotlinPluginWrapper.kt:20)
      at org.gradle.api.internal.plugins.ImperativeOnlyPluginApplicator.applyImperative(ImperativeOn
```

I tried a build locally so I could test this change, but I ran into:

```
runner:
     [echo] Cleaning /Users/dannyt/Projects/github/JetBrains/kotlin/dist/classes/runner
    [mkdir] Created dir: /Users/dannyt/Projects/github/JetBrains/kotlin/dist/classes/runner
  [kotlinc] Compiling [/Users/dannyt/Projects/github/JetBrains/kotlin/compiler/cli/cli-runner/src] => [/Users/dannyt/Projects/github/JetBrains/kotlin/dist/classes/runner]
  [kotlinc] /Users/dannyt/Projects/github/JetBrains/kotlin/compiler/cli/cli-runner/src/org/jetbrains/kotlin/runner/Classpath.kt:19:8: error: unresolved reference: java
  [kotlinc] import java.io.File
  [kotlinc]        ^
  [kotlinc] /Users/dannyt/Projects/github/JetBrains/kotlin/compiler/cli/cli-runner/src/org/jetbrains/kotlin/runner/Classpath.kt:20:8: error: unresolved reference: java
  [kotlinc] import java.net.URL
  [kotlinc]        ^
```

Not sure what I'm missing - must be something obvious I'm missing. I'm confident this will fix it, as extra properties are considered by this method:

https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html#property(java.lang.String)
