### PR TITLE
Allow dependency versions to be omitted for Gradle plugin

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt
@@ -1,40 +1,42 @@
 package org.jetbrains.kotlin.gradle.plugin
 
-import org.gradle.api.Plugin
-import org.gradle.api.Project
-import org.gradle.api.tasks.SourceSet
-import org.jetbrains.kotlin.gradle.internal.KotlinSourceSetImpl
-import org.gradle.api.internal.project.ProjectInternal
-import org.gradle.api.internal.HasConvention
-import org.jetbrains.kotlin.gradle.internal.KotlinSourceSet
-import java.io.File
-import org.gradle.api.Action
-import org.gradle.api.tasks.compile.AbstractCompile
 import com.android.build.gradle.BaseExtension
-import com.android.build.gradle.api.AndroidSourceSet
 import com.android.build.gradle.BasePlugin
+import com.android.build.gradle.api.AndroidSourceSet
 import com.android.build.gradle.internal.variant.BaseVariantData
 import com.android.build.gradle.internal.variant.BaseVariantOutputData
-import org.gradle.api.artifacts.dsl.DependencyHandler
-import org.gradle.api.artifacts.ConfigurationContainer
-import org.gradle.api.initialization.dsl.ScriptHandler
-import org.jetbrains.kotlin.gradle.plugin.android.AndroidGradleWrapper
-import javax.inject.Inject
-import org.gradle.api.file.SourceDirectorySet
-import kotlin.properties.Delegates
-import org.gradle.api.tasks.Delete
 import groovy.lang.Closure
+import org.gradle.api.Action
+import org.gradle.api.Plugin
+import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ConfigurationContainer
+import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.file.FileCollection
-import org.jetbrains.kotlin.gradle.tasks.KotlinTasksProvider
-import java.util.ServiceLoader
-import org.gradle.api.logging.*
-import org.gradle.api.plugins.*
+import org.gradle.api.file.SourceDirectorySet
+import org.gradle.api.initialization.dsl.ScriptHandler
+import org.gradle.api.internal.HasConvention
+import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.api.logging.Logging
+import org.gradle.api.plugins.ExtensionAware
+import org.gradle.api.plugins.JavaBasePlugin
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.plugins.JavaPluginConvention
+import org.gradle.api.tasks.Delete
+import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.compile.AbstractCompile
 import org.gradle.api.tasks.compile.JavaCompile
 import org.jetbrains.kotlin.gradle.internal.AnnotationProcessingManager
+import org.jetbrains.kotlin.gradle.internal.KotlinSourceSet
+import org.jetbrains.kotlin.gradle.internal.KotlinSourceSetImpl
 import org.jetbrains.kotlin.gradle.internal.initKapt
+import org.jetbrains.kotlin.gradle.plugin.android.AndroidGradleWrapper
+import org.jetbrains.kotlin.gradle.tasks.KotlinTasksProvider
+import java.io.File
 import java.net.URL
+import java.util.*
 import java.util.jar.Manifest
+import javax.inject.Inject
 
 val KOTLIN_AFTER_JAVA_TASK_SUFFIX = "AfterJava"
 
@@ -139,8 +141,7 @@ class Kotlin2JvmSourceSetProcessor(
         }
 
         val kotlinAnnotationProcessingDep = cachedKotlinAnnotationProcessingDep ?: run {
-            val projectVersion = loadKotlinVersionFromResource(project.getLogger())
-            val dep = "org.jetbrains.kotlin:kotlin-annotation-processing:$projectVersion"
+            val dep = "org.jetbrains.kotlin:kotlin-annotation-processing"
             cachedKotlinAnnotationProcessingDep = dep
             dep
         }
@@ -237,6 +238,7 @@ abstract class AbstractKotlinPlugin @Inject constructor(val scriptHandler: Scrip
         project.getPlugins().apply(javaClass<JavaPlugin>())
 
         configureSourceSetDefaults(project as ProjectInternal, javaBasePlugin, javaPluginConvention)
+        configureResolutionStrategy(project)
     }
 
     open protected fun configureSourceSetDefaults(project: ProjectInternal,
@@ -245,6 +247,18 @@ abstract class AbstractKotlinPlugin @Inject constructor(val scriptHandler: Scrip
         javaPluginConvention.getSourceSets()?.all(Action<SourceSet> { sourceSet ->
             if (sourceSet != null) {
                 buildSourceSetProcessor(project, javaBasePlugin, sourceSet).run()
+            }
+        })
+    }
+
+    private fun configureResolutionStrategy(project: Project) {
+        val projectVersion = loadKotlinVersionFromResource(project.logger)
+        project.configurations.all(Action<Configuration> { configuration ->
+            configuration.resolutionStrategy.eachDependency { details ->
+                val requested = details.requested
+                if (requested.group.equals("org.jetbrains.kotlin") && requested.version.isEmpty()) {
+                    details.useTarget("${requested.group}:${requested.name}:$projectVersion")
+                }
             }
         })
     }
@@ -287,8 +301,7 @@ open class KotlinAndroidPlugin @Inject constructor(val scriptHandler: ScriptHand
 
         val aptConfigurations = hashMapOf<String, Configuration>()
 
-        val projectVersion = loadKotlinVersionFromResource(log)
-        val kotlinAnnotationProcessingDep = "org.jetbrains.kotlin:kotlin-annotation-processing:$projectVersion"
+        val kotlinAnnotationProcessingDep = "org.jetbrains.kotlin:kotlin-annotation-processing"
 
         ext.getSourceSets().all(Action<AndroidSourceSet> { sourceSet ->
             if (sourceSet is HasConvention) {

--- a/libraries/tools/kotlin-gradle-plugin/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinGradlePluginIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinGradlePluginIT.kt
@@ -37,6 +37,17 @@ class KotlinGradleIT: BaseGradleIT() {
         }
     }
 
+    @Test
+    fun testKotlinOmitVersion() {
+        val project = Project("kotlinProjectOmitVersion", "1.6")
+
+        project.build("build") {
+            assertSuccessful()
+            assertReportExists()
+            assertContains(":compileKotlin", ":compileTestKotlin")
+        }
+    }
+
     // For corresponding documentation, see https://docs.gradle.org/current/userguide/gradle_daemon.html
     // Setting user.variant to different value implies a new daemon process will be created.
     // In order to stop daemon process, special exit task is used ( System.exit(0) ).

--- a/libraries/tools/kotlin-gradle-plugin/src/test/resources/testProject/kotlinProjectOmitVersion/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin/src/test/resources/testProject/kotlinProjectOmitVersion/build.gradle
@@ -1,0 +1,43 @@
+buildscript {
+  repositories {
+    mavenCentral()
+    maven {
+        url 'file://' + pathToKotlinPlugin
+    }
+  }
+  dependencies {
+    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:0.1-SNAPSHOT'
+  }
+}
+
+apply plugin: "kotlin"
+
+
+repositories {
+  maven {
+     url 'file://' + pathToKotlinPlugin
+  }
+  mavenCentral()
+}
+
+dependencies {
+    compile 'com.google.guava:guava:12.0'
+    testCompile  'org.testng:testng:6.8'
+    compile  'org.jetbrains.kotlin:kotlin-stdlib'
+}
+
+test {
+    useTestNG()
+}
+
+task show << {
+   buildscript.configurations.classpath.each { println it }
+}
+
+task wrapper(type: Wrapper) {
+  gradleVersion="1.4"
+}
+
+task exit << {
+    System.exit(0)
+}

--- a/libraries/tools/kotlin-gradle-plugin/src/test/resources/testProject/kotlinProjectOmitVersion/src/main/kotlin/helloWorld.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/test/resources/testProject/kotlinProjectOmitVersion/src/main/kotlin/helloWorld.kt
@@ -1,0 +1,22 @@
+package demo
+
+import com.google.common.primitives.Ints
+import com.google.common.base.Joiner
+import java.util.ArrayList
+
+class KotlinGreetingJoiner(val greeter : Greeter) {
+
+    val names = ArrayList<String?>()
+
+    fun addName(name : String?): Unit{
+        names.add(name)
+    }
+
+    fun getJoinedGreeting() : String? {
+        val joiner = Joiner.on(" and ").skipNulls();
+        return "${greeter.greeting} ${joiner.join(names)}"
+    }
+}
+
+public open class Greeter(val greeting : String)
+

--- a/libraries/tools/kotlin-gradle-plugin/src/test/resources/testProject/kotlinProjectOmitVersion/src/test/kotlin/tests.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/test/resources/testProject/kotlinProjectOmitVersion/src/test/kotlin/tests.kt
@@ -1,0 +1,21 @@
+package demo 
+
+import com.google.common.primitives.Ints
+import com.google.common.base.Joiner
+import org.testng.Assert.*
+import org.testng.annotations.AfterMethod
+import org.testng.annotations.BeforeMethod
+import org.testng.annotations.Test as test
+
+class TestSource() {
+    @test fun f() {
+        val example : KotlinGreetingJoiner = KotlinGreetingJoiner(Greeter("Hi"))
+        example.addName("Harry")
+        example.addName("Ron")
+        example.addName(null)
+        example.addName("Hermione")
+
+        assertEquals(example.getJoinedGreeting(), "Hi Harry and Ron and Hermione")
+    }
+}
+


### PR DESCRIPTION
This allows the plugin to provide the Kotlin version (if omitted) to `org.jetbrains.kotlin` dependencies:

```
dependencies {
  compile 'org.jetbrains.kotlin:kotlin-stdlib'
}
```

Avoids having to resort to extension properties to keep the version consistent in the build (and once the plugin is in the Gradle plugin portal, will simplify the example to a plugins block and a dependencies block).
