### PR TITLE
#KT-6274 Fixed

### DIFF
--- a/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/Errors.java
+++ b/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/Errors.java
@@ -667,6 +667,7 @@ public interface Errors {
     DiagnosticFactory3<KtExpression, DeclarationDescriptor, Visibility, DeclarationDescriptor> INVISIBLE_SETTER = DiagnosticFactory3.create(ERROR);
 
     DiagnosticFactory1<PsiElement, KtKeywordToken> VAL_OR_VAR_ON_LOOP_PARAMETER = DiagnosticFactory1.create(ERROR);
+    DiagnosticFactory1<PsiElement, KtKeywordToken> VAL_OR_VAR_ON_LOOP_MULTI_PARAMETER = DiagnosticFactory1.create(ERROR);
     DiagnosticFactory1<PsiElement, KtKeywordToken> VAL_OR_VAR_ON_FUN_PARAMETER = DiagnosticFactory1.create(ERROR);
     DiagnosticFactory1<PsiElement, KtKeywordToken> VAL_OR_VAR_ON_CATCH_PARAMETER = DiagnosticFactory1.create(ERROR);
     DiagnosticFactory1<PsiElement, KtKeywordToken> VAL_OR_VAR_ON_SECONDARY_CONSTRUCTOR_PARAMETER = DiagnosticFactory1.create(ERROR);

--- a/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/rendering/DefaultErrorMessages.java
+++ b/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/rendering/DefaultErrorMessages.java
@@ -264,6 +264,7 @@ public class DefaultErrorMessages {
         MAP.put(VARIABLE_EXPECTED, "Variable expected");
 
         MAP.put(VAL_OR_VAR_ON_LOOP_PARAMETER, "''{0}'' on loop parameter is not allowed", TO_STRING);
+        MAP.put(VAL_OR_VAR_ON_LOOP_MULTI_PARAMETER, "''{0}'' on loop parameter is not allowed", TO_STRING);
         MAP.put(VAL_OR_VAR_ON_FUN_PARAMETER, "''{0}'' on function parameter is not allowed", TO_STRING);
         MAP.put(VAL_OR_VAR_ON_CATCH_PARAMETER, "''{0}'' on catch parameter is not allowed", TO_STRING);
         MAP.put(VAL_OR_VAR_ON_SECONDARY_CONSTRUCTOR_PARAMETER, "''{0}'' on secondary constructor parameter is not allowed", TO_STRING);

--- a/compiler/frontend/src/org/jetbrains/kotlin/psi/KtMultiDeclaration.java
+++ b/compiler/frontend/src/org/jetbrains/kotlin/psi/KtMultiDeclaration.java
@@ -29,7 +29,7 @@ import java.util.List;
 
 import static org.jetbrains.kotlin.lexer.KtTokens.*;
 
-public class KtMultiDeclaration extends KtDeclarationImpl {
+public class KtMultiDeclaration extends KtDeclarationImpl implements KtValVarKeywordProvider {
     public KtMultiDeclaration(@NotNull ASTNode node) {
         super(node);
     }

--- a/compiler/frontend/src/org/jetbrains/kotlin/psi/KtParameter.java
+++ b/compiler/frontend/src/org/jetbrains/kotlin/psi/KtParameter.java
@@ -31,7 +31,7 @@ import org.jetbrains.kotlin.psi.typeRefHelpers.TypeRefHelpersKt;
 import java.util.Collections;
 import java.util.List;
 
-public class KtParameter extends KtNamedDeclarationStub<KotlinParameterStub> implements KtCallableDeclaration {
+public class KtParameter extends KtNamedDeclarationStub<KotlinParameterStub> implements KtCallableDeclaration, KtValVarKeywordProvider {
 
     public KtParameter(@NotNull ASTNode node) {
         super(node);

--- a/compiler/frontend/src/org/jetbrains/kotlin/psi/KtValVarKeywordProvider.java
+++ b/compiler/frontend/src/org/jetbrains/kotlin/psi/KtValVarKeywordProvider.java
@@ -19,6 +19,7 @@ package org.jetbrains.kotlin.psi;
 import com.intellij.psi.PsiElement;
 import org.jetbrains.annotations.Nullable;
 
-public interface KtVariableDeclaration extends KtCallableDeclaration, KtWithExpressionInitializer, KtValVarKeywordProvider {
-    boolean isVar();
+public interface KtValVarKeywordProvider extends PsiElement {
+    @Nullable
+    PsiElement getValOrVarKeyword();
 }

--- a/compiler/frontend/src/org/jetbrains/kotlin/resolve/ModifiersChecker.java
+++ b/compiler/frontend/src/org/jetbrains/kotlin/resolve/ModifiersChecker.java
@@ -163,7 +163,7 @@ public class ModifiersChecker {
         }
 
         public void checkParameterHasNoValOrVar(
-                @NotNull KtParameter parameter,
+                @NotNull KtValVarKeywordProvider parameter,
                 @NotNull DiagnosticFactory1<PsiElement, KtKeywordToken> diagnosticFactory
         ) {
             PsiElement valOrVar = parameter.getValOrVarKeyword();

--- a/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/ControlStructureTypingVisitor.java
+++ b/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/ControlStructureTypingVisitor.java
@@ -407,6 +407,7 @@ public class ControlStructureTypingVisitor extends ExpressionTypingVisitor {
                         loopScope, multiParameter, iteratorNextAsReceiver, loopRange, context
                 );
                 components.modifiersChecker.withTrace(context.trace).checkModifiersForMultiDeclaration(multiParameter);
+                components.modifiersChecker.withTrace(context.trace).checkParameterHasNoValOrVar(multiParameter, VAL_OR_VAR_ON_LOOP_MULTI_PARAMETER);
                 components.identifierChecker.checkDeclaration(multiParameter, context.trace);
             }
         }

--- a/compiler/testData/diagnostics/tests/controlStructures/valVarLoopParameter.kt
+++ b/compiler/testData/diagnostics/tests/controlStructures/valVarLoopParameter.kt
@@ -1,9 +1,32 @@
+class Pair {
+    operator fun component1(): Int = null!!
+    operator fun component2(): Int = null!!
+}
+
+class Coll {
+    operator fun iterator(): It = It()
+}
+
+class It {
+    operator fun next() = Pair()
+    operator fun hasNext() = false
+}
+
+
 fun f() {
     for (<!VAL_OR_VAR_ON_LOOP_PARAMETER!>val<!> i in 1..4) {
 
     }
 
     for (<!VAL_OR_VAR_ON_LOOP_PARAMETER!>var<!> i in 1..4) {
+
+    }
+
+    for (<!VAL_OR_VAR_ON_LOOP_MULTI_PARAMETER!>val<!> (i,j) in Coll()) {
+
+    }
+
+    for (<!VAL_OR_VAR_ON_LOOP_MULTI_PARAMETER!>var<!> (i,j) in Coll()) {
 
     }
 }

--- a/compiler/testData/diagnostics/tests/controlStructures/valVarLoopParameter.txt
+++ b/compiler/testData/diagnostics/tests/controlStructures/valVarLoopParameter.txt
@@ -1,3 +1,29 @@
 package
 
 public fun f(): kotlin.Unit
+
+public final class Coll {
+    public constructor Coll()
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public final operator fun iterator(): It
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public final class It {
+    public constructor It()
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public final operator fun hasNext(): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public final operator fun next(): Pair
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public final class Pair {
+    public constructor Pair()
+    public final operator fun component1(): kotlin.Int
+    public final operator fun component2(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}

--- a/compiler/testData/diagnostics/tests/declarationChecks/DataFlowInMultiDeclInFor.kt
+++ b/compiler/testData/diagnostics/tests/declarationChecks/DataFlowInMultiDeclInFor.kt
@@ -8,7 +8,7 @@ class A {
 }
 
 fun foo(list: List<A>) {
-    for (var (c1, c2, c3) in list) {
+    for (<!VAL_OR_VAR_ON_LOOP_MULTI_PARAMETER!>var<!> (c1, c2, c3) in list) {
         <!UNUSED_VALUE!>c1 =<!> 1
         c3 + 1
     }

--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixRegistrar.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixRegistrar.kt
@@ -164,6 +164,7 @@ public class QuickFixRegistrar : QuickFixContributor {
         val removeValVarFromParameterFixFactory = RemoveValVarFromParameterFix.createFactory()
         VAL_OR_VAR_ON_FUN_PARAMETER.registerFactory(removeValVarFromParameterFixFactory)
         VAL_OR_VAR_ON_LOOP_PARAMETER.registerFactory(removeValVarFromParameterFixFactory)
+        VAL_OR_VAR_ON_LOOP_MULTI_PARAMETER.registerFactory(removeValVarFromParameterFixFactory)
         VAL_OR_VAR_ON_CATCH_PARAMETER.registerFactory(removeValVarFromParameterFixFactory)
         VAL_OR_VAR_ON_SECONDARY_CONSTRUCTOR_PARAMETER.registerFactory(removeValVarFromParameterFixFactory)
 

--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/RemoveValVarFromParameterFix.java
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/RemoveValVarFromParameterFix.java
@@ -27,12 +27,13 @@ import org.jetbrains.kotlin.diagnostics.Diagnostic;
 import org.jetbrains.kotlin.idea.JetBundle;
 import org.jetbrains.kotlin.psi.KtFile;
 import org.jetbrains.kotlin.psi.KtParameter;
+import org.jetbrains.kotlin.psi.KtValVarKeywordProvider;
 import org.jetbrains.kotlin.psi.psiUtil.PsiUtilsKt;
 
-public class RemoveValVarFromParameterFix extends KotlinQuickFixAction<KtParameter> {
+public class RemoveValVarFromParameterFix extends KotlinQuickFixAction<KtValVarKeywordProvider> {
     private final String varOrVal;
 
-    public RemoveValVarFromParameterFix(@NotNull KtParameter element) {
+    public RemoveValVarFromParameterFix(@NotNull KtValVarKeywordProvider element) {
         super(element);
         PsiElement valOrVarNode = element.getValOrVarKeyword();
         assert valOrVarNode != null : "Val or var node not found for " + PsiUtilsKt.getElementTextWithContext(element);
@@ -64,7 +65,7 @@ public class RemoveValVarFromParameterFix extends KotlinQuickFixAction<KtParamet
             @Nullable
             @Override
             public IntentionAction createAction(@NotNull Diagnostic diagnostic) {
-                return new RemoveValVarFromParameterFix((KtParameter) diagnostic.getPsiElement().getParent());
+                return new RemoveValVarFromParameterFix((KtValVarKeywordProvider) diagnostic.getPsiElement().getParent());
             }
         };
     }

--- a/idea/src/org/jetbrains/kotlin/idea/refactoring/rename/AutomaticVariableRenamer.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/refactoring/rename/AutomaticVariableRenamer.kt
@@ -32,10 +32,7 @@ import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.VariableDescriptor
 import org.jetbrains.kotlin.idea.caches.resolve.resolveToDescriptor
-import org.jetbrains.kotlin.psi.KtNamedDeclaration
-import org.jetbrains.kotlin.psi.KtParameter
-import org.jetbrains.kotlin.psi.KtVariableDeclaration
-import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.isAncestor
 import org.jetbrains.kotlin.resolve.DescriptorUtils
 import org.jetbrains.kotlin.resolve.descriptorUtil.builtIns
@@ -59,7 +56,7 @@ public class AutomaticVariableRenamer(
                     usageElement,
                     javaClass<KtVariableDeclaration>(),
                     javaClass<KtParameter>()
-            ) ?: continue
+            ) as KtCallableDeclaration? ?: continue
 
             if (parameterOrVariable.getTypeReference()?.isAncestor(usageElement) != true) continue
 

--- a/idea/testData/quickfix/variables/removeValVarFromParameter/loopMultiParameter.kt
+++ b/idea/testData/quickfix/variables/removeValVarFromParameter/loopMultiParameter.kt
@@ -1,0 +1,12 @@
+// "Remove 'val' from parameter" "true"
+class Pair<A, B>
+{
+    operator fun component1(): A = null!!
+    operator fun component2(): B = null!!
+}
+
+fun f(list: List<Pair<String, String>>) {
+    for (val<caret> (x,y) in list) {
+
+    }
+}

--- a/idea/testData/quickfix/variables/removeValVarFromParameter/loopMultiParameter.kt.after
+++ b/idea/testData/quickfix/variables/removeValVarFromParameter/loopMultiParameter.kt.after
@@ -1,0 +1,12 @@
+// "Remove 'val' from parameter" "true"
+class Pair<A, B>
+{
+    operator fun component1(): A = null!!
+    operator fun component2(): B = null!!
+}
+
+fun f(list: List<Pair<String, String>>) {
+    for ((x,y) in list) {
+
+    }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -6851,6 +6851,12 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
                 doTest(fileName);
             }
 
+            @TestMetadata("loopMultiParameter.kt")
+            public void testLoopMultiParameter() throws Exception {
+                String fileName = JetTestUtils.navigationMetadata("idea/testData/quickfix/variables/removeValVarFromParameter/loopMultiParameter.kt");
+                doTest(fileName);
+            }
+
             @TestMetadata("loopParameter.kt")
             public void testLoopParameter() throws Exception {
                 String fileName = JetTestUtils.navigationMetadata("idea/testData/quickfix/variables/removeValVarFromParameter/loopParameter.kt");


### PR DESCRIPTION
I think it is very convenient to add interface ``KtValVarKeywordProvider`` for the classes who have ``getValOrVarKeyword`` method in order to fix the bug. However I was forced to add unsafe cast to ``AutomaticVariableRenamer.kt``.

I also fixed ``DataFlowInMultiDeclInFor.kt`` test because it became failing due to my changes. This test case looks a little bit strange now because ``var`` keyword is not allowed in ``for`` loops. 