### PR TITLE
N+k attempt to fix parallel compilation

### DIFF
--- a/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/Properties.kt
+++ b/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/Properties.kt
@@ -17,3 +17,11 @@
 package org.jetbrains.kotlin.cli.common
 
 public val KOTLIN_COMPILER_ENVIRONMENT_KEEPALIVE_PROPERTY = "kotlin.environment.keepalive"
+
+
+fun String?.toBooleanLenient(): Boolean? = when (this?.toLowerCase()) {
+    null -> false
+    in listOf("", "yes", "true", "on", "y") -> true
+    in listOf("no", "false", "off", "n") -> false
+    else -> null
+}

--- a/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment.kt
@@ -60,6 +60,7 @@ import org.jetbrains.kotlin.cli.common.messages.CompilerMessageLocation
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity.ERROR
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity.WARNING
+import org.jetbrains.kotlin.cli.common.toBooleanLenient
 import org.jetbrains.kotlin.cli.jvm.config.JVMConfigurationKeys
 import org.jetbrains.kotlin.cli.jvm.config.JavaSourceRoot
 import org.jetbrains.kotlin.cli.jvm.config.JvmClasspathRoot
@@ -258,7 +259,7 @@ public class KotlinCoreEnvironment private constructor(
             val appEnv = getOrCreateApplicationEnvironmentForProduction(configuration, configFilePaths)
             // Disposing of the environment is unsafe in production then parallel builds are enabled, but turning it off universally
             // breaks a lot of tests, therefore it is disabled for production and enabled for tests
-            if (System.getProperty(KOTLIN_COMPILER_ENVIRONMENT_KEEPALIVE_PROPERTY) == null) {
+            if (!(System.getProperty(KOTLIN_COMPILER_ENVIRONMENT_KEEPALIVE_PROPERTY).toBooleanLenient() ?: false)) {
                 // JPS may run many instances of the compiler in parallel (there's an option for compiling independent modules in parallel in IntelliJ)
                 // All projects share the same ApplicationEnvironment, and when the last project is disposed, the ApplicationEnvironment is disposed as well
                 Disposer.register(parentDisposable, object : Disposable {

--- a/compiler/daemon/src/org/jetbrains/kotlin/daemon/CompileServiceImpl.kt
+++ b/compiler/daemon/src/org/jetbrains/kotlin/daemon/CompileServiceImpl.kt
@@ -19,6 +19,7 @@ package org.jetbrains.kotlin.daemon
 import com.intellij.openapi.vfs.impl.ZipHandler
 import org.jetbrains.kotlin.cli.common.CLICompiler
 import org.jetbrains.kotlin.cli.common.ExitCode
+import org.jetbrains.kotlin.cli.common.KOTLIN_COMPILER_ENVIRONMENT_KEEPALIVE_PROPERTY
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.config.Services
 import org.jetbrains.kotlin.daemon.common.*
@@ -74,6 +75,10 @@ class CompileServiceImpl(
         val timer: Timer,
         val onShutdown: () -> Unit
 ) : CompileService {
+
+    init {
+        System.setProperty(KOTLIN_COMPILER_ENVIRONMENT_KEEPALIVE_PROPERTY, "true")
+    }
 
     // wrapped in a class to encapsulate alive check logic
     private class ClientOrSessionProxy(val aliveFlagPath: String?) {

--- a/jps-plugin/src/org/jetbrains/kotlin/compilerRunner/CompilerRunnerUtil.java
+++ b/jps-plugin/src/org/jetbrains/kotlin/compilerRunner/CompilerRunnerUtil.java
@@ -70,7 +70,7 @@ public class CompilerRunnerUtil {
     }
 
     @Nullable
-    public synchronized static Object invokeExecMethod(
+    public static Object invokeExecMethod(
             @NotNull String compilerClassName,
             @NotNull String[] arguments,
             @NotNull CompilerEnvironment environment,

--- a/jps-plugin/src/org/jetbrains/kotlin/compilerRunner/KotlinCompilerRunner.kt
+++ b/jps-plugin/src/org/jetbrains/kotlin/compilerRunner/KotlinCompilerRunner.kt
@@ -17,6 +17,7 @@
 package org.jetbrains.kotlin.compilerRunner
 
 import com.intellij.util.xmlb.XmlSerializerUtil
+import org.jetbrains.jps.api.GlobalOptions
 import org.jetbrains.kotlin.cli.common.ExitCode
 import org.jetbrains.kotlin.cli.common.KOTLIN_COMPILER_ENVIRONMENT_KEEPALIVE_PROPERTY
 import org.jetbrains.kotlin.cli.common.arguments.CommonCompilerArguments
@@ -117,9 +118,8 @@ public object KotlinCompilerRunner {
                 val stream = ByteArrayOutputStream()
                 val out = PrintStream(stream)
 
-// Uncomment after resolving problems with parallel compilation and tests
-//                if (System.getProperty(KOTLIN_COMPILER_ENVIRONMENT_KEEPALIVE_PROPERTY) == null)
-//                    System.setProperty(KOTLIN_COMPILER_ENVIRONMENT_KEEPALIVE_PROPERTY, "")
+                if (java.lang.Boolean.parseBoolean(System.getProperty(GlobalOptions.COMPILE_PARALLEL_OPTION, "false")))
+                    System.setProperty(KOTLIN_COMPILER_ENVIRONMENT_KEEPALIVE_PROPERTY, "true")
 
                 val rc = CompilerRunnerUtil.invokeExecMethod(compilerClassName, argsArray, environment, messageCollector, out)
 
@@ -188,7 +188,7 @@ public object KotlinCompilerRunner {
             KotlinBuilder.LOG.debug("Try to connect to daemon")
             val connection = getDaemonConnection(environment, messageCollector)
 
-            if (connection?.daemon != null) {
+            if (connection.daemon != null) {
                 KotlinBuilder.LOG.info("Connected to daemon")
 
                 val compilerOut = ByteArrayOutputStream()
@@ -203,7 +203,7 @@ public object KotlinCompilerRunner {
                     K2JS_COMPILER -> CompileService.TargetPlatform.JS
                     else -> throw IllegalArgumentException("Unknown compiler type $compilerClassName")
                 }
-                val res = KotlinCompilerClient.incrementalCompile(connection!!.daemon!!, connection.sessionId, targetPlatform, argsArray, services, compilerOut, daemonOut)
+                val res = KotlinCompilerClient.incrementalCompile(connection.daemon!!, connection.sessionId, targetPlatform, argsArray, services, compilerOut, daemonOut)
 
                 processCompilerOutput(messageCollector, collector, compilerOut, res.toString())
                 BufferedReader(StringReader(daemonOut.toString())).forEachLine {

--- a/jps-plugin/src/org/jetbrains/kotlin/compilerRunner/KotlinCompilerRunner.kt
+++ b/jps-plugin/src/org/jetbrains/kotlin/compilerRunner/KotlinCompilerRunner.kt
@@ -118,7 +118,10 @@ public object KotlinCompilerRunner {
                 val stream = ByteArrayOutputStream()
                 val out = PrintStream(stream)
 
-                if (java.lang.Boolean.parseBoolean(System.getProperty(GlobalOptions.COMPILE_PARALLEL_OPTION, "false")))
+                // the property should be set at least for parallel builds to avoid parallel building problems (racing between destroying and using environment)
+                // unfortunately it cannot be currently set by default globally, because it breaks many tests
+                // since there is no reliable way so far to detect running under tests, switching it on only for parallel builds
+                if (System.getProperty(GlobalOptions.COMPILE_PARALLEL_OPTION, "false").toBoolean())
                     System.setProperty(KOTLIN_COMPILER_ENVIRONMENT_KEEPALIVE_PROPERTY, "true")
 
                 val rc = CompilerRunnerUtil.invokeExecMethod(compilerClassName, argsArray, environment, messageCollector, out)
@@ -146,10 +149,6 @@ public object KotlinCompilerRunner {
                 val compilerId = CompilerId.makeCompilerId(File(libPath, "kotlin-compiler.jar"))
                 val daemonOptions = configureDaemonOptions()
                 val daemonJVMOptions = configureDaemonJVMOptions(inheritMemoryLimits = true, inheritAdditionalProperties = true)
-                // the property should be set by default for daemon builds to avoid parallel building problems
-                // but it cannot be currently set by default globally, because it seems breaks many tests
-                // TODO: find out how to get rid of the property and make it the default behavior
-                daemonJVMOptions.jvmParams.add("D$KOTLIN_COMPILER_ENVIRONMENT_KEEPALIVE_PROPERTY")
 
                 val daemonReportMessages = ArrayList<DaemonReportMessage>()
 


### PR DESCRIPTION
enabling parallel compilation
keepalive property controls destruction of the environment
controlling keepalive property in compiler use sites, but in jps taking parallel compilation option into account, so it should be now not set in tests