### PR TITLE
Changed kotlin.test.fail method's signature to return Nothing.

### DIFF
--- a/libraries/stdlib/src/kotlin/test/Test.kt
+++ b/libraries/stdlib/src/kotlin/test/Test.kt
@@ -60,7 +60,7 @@ public fun assertNull(actual: Any?, message: String? = null) {
 }
 
 /** Marks a test as having failed if this point in the execution path is reached, with an optional [message]. */
-public fun fail(message: String? = null) {
+public fun fail(message: String? = null): Nothing {
     asserter.fail(message)
 }
 
@@ -100,7 +100,7 @@ public interface Asserter {
      *
      * @param message the message to report.
      */
-    public fun fail(message: String?): Unit
+    public fun fail(message: String?): Nothing
 
     /**
      * Asserts that the specified value is `true`.

--- a/libraries/stdlib/src/kotlin/test/TestJVM.kt
+++ b/libraries/stdlib/src/kotlin/test/TestJVM.kt
@@ -72,7 +72,7 @@ public var asserter: Asserter
  */
 private class DefaultAsserter() : Asserter {
 
-    public override fun fail(message : String?) {
+    public override fun fail(message : String?): Nothing {
         if (message == null)
             throw AssertionError()
         else


### PR DESCRIPTION
Hi, I just updated kotlin.test.fail to return Nothing as that's a better implementation (e.g. it allows you to have a function like this one: *fun getTheFreakingValue(): String = value ?: fail("Value is null!")*).