### PR TITLE
Testlib fix

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -969,7 +969,7 @@
     <target name="pack-kotlin-test">
         <pack-runtime-jar jar-name="kotlin-test.jar" implementation-title="${manifest.impl.title.kotlin.test}">
             <jar-content>
-                <fileset dir="${output}/classes/kotlin.test" includes="**/*"/>
+                <fileset dir="${output}/classes/kotlin.test" includes="**/*" excludes="kotlin/internal/OnlyInputTypes*,kotlin/internal"/>
             </jar-content>
         </pack-runtime-jar>
     </target>

--- a/libraries/examples/browser-example-with-library/pom.xml
+++ b/libraries/examples/browser-example-with-library/pom.xml
@@ -27,7 +27,7 @@
         </dependency>
         <dependency>
         	<groupId>org.jetbrains.kotlin</groupId>
-        	<artifactId>kotlin.test.junit</artifactId>
+        	<artifactId>kotlin-test-junit</artifactId>
         	<version>${project.version}</version>
         	<scope>test</scope>
         </dependency>

--- a/libraries/examples/browser-example/pom.xml
+++ b/libraries/examples/browser-example/pom.xml
@@ -22,7 +22,7 @@
         </dependency>
         <dependency>
         	<groupId>org.jetbrains.kotlin</groupId>
-        	<artifactId>kotlin.test.junit</artifactId>
+        	<artifactId>kotlin-test-junit</artifactId>
         	<version>${project.version}</version>
         	<scope>test</scope>
         </dependency>

--- a/libraries/kotlin.test/js/pom.xml
+++ b/libraries/kotlin.test/js/pom.xml
@@ -3,13 +3,13 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>kotlin.test.parent</artifactId>
+        <artifactId>kotlin-test-parent</artifactId>
         <groupId>org.jetbrains.kotlin</groupId>
         <version>0.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>kotlin.test.js</artifactId>
+    <artifactId>kotlin-test-js</artifactId>
 
     <build>
         <sourceDirectory>src/main/kotlin</sourceDirectory>

--- a/libraries/kotlin.test/junit/pom.xml
+++ b/libraries/kotlin.test/junit/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>kotlin.test.parent</artifactId>
+        <artifactId>kotlin-test-parent</artifactId>
         <groupId>org.jetbrains.kotlin</groupId>
         <version>0.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>kotlin.test.junit</artifactId>
+    <artifactId>kotlin-test-junit</artifactId>
 
     <dependencies>
 		<dependency>
@@ -18,7 +18,7 @@
 		</dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin.test</artifactId>
+            <artifactId>kotlin-test</artifactId>
             <version>${project.version}</version>
 
             <exclusions>

--- a/libraries/kotlin.test/pom.xml
+++ b/libraries/kotlin.test/pom.xml
@@ -8,7 +8,7 @@
         <version>0.1-SNAPSHOT</version>
     </parent>
 
-    <artifactId>kotlin.test.parent</artifactId>
+    <artifactId>kotlin-test-parent</artifactId>
     <packaging>pom</packaging>
 
     <modules>

--- a/libraries/kotlin.test/shared/pom.xml
+++ b/libraries/kotlin.test/shared/pom.xml
@@ -142,6 +142,15 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>kotlin/internal/OnlyInputTypes*</exclude>
+                                <exclude>kotlin/internal</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
                 </plugins>
             </build>
         </profile>

--- a/libraries/kotlin.test/shared/pom.xml
+++ b/libraries/kotlin.test/shared/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>kotlin.test.parent</artifactId>
+        <artifactId>kotlin-test-parent</artifactId>
         <groupId>org.jetbrains.kotlin</groupId>
         <version>0.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>kotlin.test</artifactId>
+    <artifactId>kotlin-test</artifactId>
 
     <build>
         <sourceDirectory>src/main/kotlin</sourceDirectory>

--- a/libraries/stdlib/pom.xml
+++ b/libraries/stdlib/pom.xml
@@ -21,7 +21,7 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin.test.junit</artifactId>
+            <artifactId>kotlin-test-junit</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>

--- a/libraries/tools/kotlin-compiler-embeddable/pom.xml
+++ b/libraries/tools/kotlin-compiler-embeddable/pom.xml
@@ -46,7 +46,7 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin.test.junit</artifactId>
+            <artifactId>kotlin-test-junit</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>

--- a/libraries/tools/kotlin-js-tests-junit/pom.xml
+++ b/libraries/tools/kotlin-js-tests-junit/pom.xml
@@ -23,7 +23,7 @@
         </dependency>
         <dependency>
         	<groupId>org.jetbrains.kotlin</groupId>
-        	<artifactId>kotlin.test.junit</artifactId>
+        	<artifactId>kotlin-test-junit</artifactId>
         	<version>${project.version}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
1. rename artifact names
2. exclude `OnlyInputTypes` from the jar
