### PR TITLE
Remove which dependency from startup scripts

### DIFF
--- a/compiler/cli/bin/kotlin
+++ b/compiler/cli/bin/kotlin
@@ -16,4 +16,7 @@
 
 export KOTLIN_RUNNER=1
 
-"$(dirname "$(which "$0")")"/kotlinc "$@"
+DIR="${BASH_SOURCE[0]%/*}"
+: ${DIR:="."}
+
+"${DIR}"/kotlinc "$@"

--- a/compiler/cli/bin/kotlinc-js
+++ b/compiler/cli/bin/kotlinc-js
@@ -16,4 +16,7 @@
 
 export KOTLIN_COMPILER=org.jetbrains.kotlin.cli.js.K2JSCompiler
 
-"$(dirname "$(which "$0")")"/kotlinc "$@"
+DIR="${BASH_SOURCE[0]%/*}"
+: ${DIR:="."}
+
+"${DIR}"/kotlinc "$@"

--- a/compiler/cli/bin/kotlinc-jvm
+++ b/compiler/cli/bin/kotlinc-jvm
@@ -14,4 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"$(dirname "$(which "$0")")"/kotlinc "$@"
+DIR="${BASH_SOURCE[0]%/*}"
+: ${DIR:="."}
+
+"${DIR}"/kotlinc "$@"


### PR DESCRIPTION
I would like to get rid of the startup scripts' dependency on `which`.
Some lightweight Linux distributions do not ship with the command by default (in my case NixOS) and Kotlin seems to require it as a dependency only for its startup scripts.

Rather than relying on `dirname` and `which`, we should be able to just use built-in `bash` functionality.

I wrote a short script that verifies equivalent functionality:

```bash
echo $0
echo "$(dirname "$(which "$0")")" #Current version
echo "${0%/*}" #Proposed version
```

```
~> ./paths.sh
./paths.sh
.
.
~> /Users/tsteinbach/paths.sh
/Users/tsteinbach/paths.sh
/Users/tsteinbach
/Users/tsteinbach
~> ln -s /Users/tsteinbach/paths.sh /Users/tsteinbach/Desktop/paths.sh
~> /Users/tsteinbach/Desktop/paths.sh
/Users/tsteinbach/Desktop/paths.sh
/Users/tsteinbach/Desktop
/Users/tsteinbach/Desktop
```

The behaviour for direct access and via symbolic links is identical.