### PR TITLE
Apply inline fun use() to AutoCloseable

### DIFF
--- a/libraries/stdlib/src/kotlin/io/ReadWrite.kt
+++ b/libraries/stdlib/src/kotlin/io/ReadWrite.kt
@@ -145,7 +145,7 @@ public fun URL.readBytes(): ByteArray = openStream().use { it.readBytes() }
  * @param block a function to process this closable resource.
  * @return the result of [block] function on this closable resource.
  */
-public inline fun <T : Closeable, R> T.use(block: (T) -> R): R {
+public inline fun <T : AutoCloseable, R> T.use(block: (T) -> R): R {
     var closed = false
     try {
         return block(this)


### PR DESCRIPTION
The Java 7 try-with-resources statement operates on all `AutoCloseable` resources, not just the `Closeable` (legacy) ones. E.g. JDBC resources are `AutoCloseable`, not `Closeable`