### PR TITLE
Fixes KT-1494 Inspection to highlight missing documentation for public declarations

### DIFF
--- a/idea/idea-analysis/src/org/jetbrains/kotlin/idea/inspections/IntentionBasedInspection.kt
+++ b/idea/idea-analysis/src/org/jetbrains/kotlin/idea/inspections/IntentionBasedInspection.kt
@@ -122,15 +122,15 @@ abstract class IntentionBasedInspection<TElement : KtElement>(
             editor?.caretModel?.moveToOffset(startElement.textOffset)
             intention.applyTo(startElement as TElement, editor)
         }
-
-        private fun PsiElement.findExistingEditor(): Editor? {
-            val file = containingFile?.virtualFile ?: return null
-            val document = FileDocumentManager.getInstance().getDocument(file) ?: return null
-
-            val editorFactory = EditorFactory.getInstance()
-
-            val editors = editorFactory.getEditors(document)
-            return if (editors.isEmpty()) null else editors[0]
-        }
     }
+}
+
+fun PsiElement.findExistingEditor(): Editor? {
+    val file = containingFile?.virtualFile ?: return null
+    val document = FileDocumentManager.getInstance().getDocument(file) ?: return null
+
+    val editorFactory = EditorFactory.getInstance()
+
+    val editors = editorFactory.getEditors(document)
+    return if (editors.isEmpty()) null else editors[0]
 }

--- a/idea/idea-analysis/src/org/jetbrains/kotlin/idea/kdoc/KDocMissingDocumentationInspection.kt
+++ b/idea/idea-analysis/src/org/jetbrains/kotlin/idea/kdoc/KDocMissingDocumentationInspection.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2010-2016 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.kotlin.idea.kdoc
+
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementVisitor
+import org.jetbrains.kotlin.idea.inspections.AbstractKotlinInspection
+import org.jetbrains.kotlin.idea.references.mainReference
+import org.jetbrains.kotlin.kdoc.psi.impl.KDocName
+
+class KDocMissingDocumentationInspection(): AbstractKotlinInspection() {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor =
+            KDocMissingDocumentationInspection(holder)
+
+    private class KDocMissingDocumentationInspection(private val holder: ProblemsHolder): PsiElementVisitor() {
+        override fun visitElement(element: PsiElement) {
+            if (element is KDocName) {
+                val ref = element.mainReference
+                if (ref.resolve() == null) {
+                    holder.registerProblem(ref)
+                }
+            }
+        }
+    }
+}

--- a/idea/idea-analysis/src/org/jetbrains/kotlin/idea/kdoc/KDocMissingDocumentationInspection.kt
+++ b/idea/idea-analysis/src/org/jetbrains/kotlin/idea/kdoc/KDocMissingDocumentationInspection.kt
@@ -16,7 +16,13 @@
 
 package org.jetbrains.kotlin.idea.kdoc
 
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.EditorFactory
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
 import org.jetbrains.kotlin.descriptors.CallableMemberDescriptor
@@ -24,7 +30,14 @@ import org.jetbrains.kotlin.descriptors.MemberDescriptor
 import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.idea.caches.resolve.resolveToDescriptor
 import org.jetbrains.kotlin.idea.inspections.AbstractKotlinInspection
+import org.jetbrains.kotlin.kdoc.psi.impl.KDocImpl
+import org.jetbrains.kotlin.lexer.KtModifierKeywordToken
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtModifierListOwner
 import org.jetbrains.kotlin.psi.KtNamedDeclaration
+import org.jetbrains.kotlin.psi.addRemoveModifier.removeModifier
+import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
+import org.jetbrains.kotlin.psi.psiUtil.startOffset
 import org.jetbrains.kotlin.resolve.source.getPsi
 
 class KDocMissingDocumentationInspection(): AbstractKotlinInspection() {
@@ -42,10 +55,34 @@ class KDocMissingDocumentationInspection(): AbstractKotlinInspection() {
                                            (descriptor as? CallableMemberDescriptor)?.overriddenDescriptors
                                                    ?.any { (it.source.getPsi() as? KtNamedDeclaration)?.docComment != null } ?: false
                     if (!hasDocumentation) {
-                        holder.registerProblem(nameIdentifier, "Missing documentation")
+                        holder.registerProblem(nameIdentifier, "Missing documentation", AddDocumentationFix())
                     }
                 }
             }
+        }
+    }
+
+    class AddDocumentationFix : LocalQuickFix {
+        override fun getName(): String = "Add documentation"
+
+        override fun getFamilyName(): String = name
+
+        override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+            val declaration = descriptor.psiElement.getParentOfType<KtNamedDeclaration>(true)
+                              ?: throw IllegalStateException("Can't find declaration")
+            declaration.addBefore(KDocElementFactory(project).createKDocFromText("/**  */"), declaration.firstChild)
+            val editor = descriptor.psiElement.findExistingEditor()
+            editor?.caretModel?.moveToOffset(declaration.startOffset + 4)
+        }
+
+        private fun PsiElement.findExistingEditor(): Editor? {
+            val file = containingFile?.virtualFile ?: return null
+            val document = FileDocumentManager.getInstance().getDocument(file) ?: return null
+
+            val editorFactory = EditorFactory.getInstance()
+
+            val editors = editorFactory.getEditors(document)
+            return if (editors.isEmpty()) null else editors[0]
         }
     }
 }

--- a/idea/idea-analysis/src/org/jetbrains/kotlin/idea/kdoc/KDocMissingDocumentationInspection.kt
+++ b/idea/idea-analysis/src/org/jetbrains/kotlin/idea/kdoc/KDocMissingDocumentationInspection.kt
@@ -37,12 +37,12 @@ class KDocMissingDocumentationInspection(): AbstractKotlinInspection() {
             if (element is KtNamedDeclaration) {
                 val nameIdentifier = element.nameIdentifier
                 val descriptor = element.resolveToDescriptor() as? MemberDescriptor;
-                if (nameIdentifier != null && descriptor != null && descriptor.visibility == Visibilities.PUBLIC) {
+                if (nameIdentifier != null && descriptor?.visibility == Visibilities.PUBLIC) {
                     val hasDocumentation = element.docComment != null ||
                                            (descriptor as? CallableMemberDescriptor)?.overriddenDescriptors
                                                    ?.any { (it.source.getPsi() as? KtNamedDeclaration)?.docComment != null } ?: false
                     if (!hasDocumentation) {
-                        holder.registerProblem(nameIdentifier, "Missing Documentation")
+                        holder.registerProblem(nameIdentifier, "Missing documentation")
                     }
                 }
             }

--- a/idea/idea-analysis/src/org/jetbrains/kotlin/idea/kdoc/KDocMissingDocumentationInspection.kt
+++ b/idea/idea-analysis/src/org/jetbrains/kotlin/idea/kdoc/KDocMissingDocumentationInspection.kt
@@ -20,45 +20,12 @@ import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
 import org.jetbrains.kotlin.descriptors.CallableMemberDescriptor
+import org.jetbrains.kotlin.descriptors.MemberDescriptor
 import org.jetbrains.kotlin.descriptors.Visibilities
-import org.jetbrains.kotlin.descriptors.Visibility
 import org.jetbrains.kotlin.idea.caches.resolve.resolveToDescriptor
 import org.jetbrains.kotlin.idea.inspections.AbstractKotlinInspection
-import org.jetbrains.kotlin.lexer.KtModifierKeywordToken
-import org.jetbrains.kotlin.lexer.KtTokens
-import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtNamedDeclaration
-import org.jetbrains.kotlin.psi.psiUtil.visibilityModifierType
-import org.jetbrains.kotlin.resolve.OverridingUtil
-
-fun KtDeclaration.implicitVisibility(): KtModifierKeywordToken? {
-    val defaultVisibilityKeyword = if (hasModifier(KtTokens.OVERRIDE_KEYWORD)) {
-        (resolveToDescriptor() as? CallableMemberDescriptor)
-                ?.overriddenDescriptors
-                ?.let { OverridingUtil.findMaxVisibility(it) }
-                ?.toKeywordToken()
-    }
-    else {
-        KtTokens.DEFAULT_VISIBILITY_KEYWORD
-    }
-    return defaultVisibilityKeyword
-}
-
-fun Visibility.toKeywordToken(): KtModifierKeywordToken {
-    val normalized = normalize()
-    when (normalized) {
-        Visibilities.PUBLIC -> return KtTokens.PUBLIC_KEYWORD
-        Visibilities.PROTECTED -> return KtTokens.PROTECTED_KEYWORD
-        Visibilities.INTERNAL -> return KtTokens.INTERNAL_KEYWORD
-        else -> {
-            if (Visibilities.isPrivate(normalized)) {
-                return KtTokens.PRIVATE_KEYWORD
-            }
-            error("Unexpected visibility '$normalized'")
-        }
-    }
-}
-
+import org.jetbrains.kotlin.resolve.source.getPsi
 
 class KDocMissingDocumentationInspection(): AbstractKotlinInspection() {
     override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor =
@@ -66,10 +33,18 @@ class KDocMissingDocumentationInspection(): AbstractKotlinInspection() {
 
     private class KDocMissingDocumentationInspection(private val holder: ProblemsHolder): PsiElementVisitor() {
         override fun visitElement(element: PsiElement) {
-            if (element is KtNamedDeclaration &&
-                !element.hasModifier(KtTokens.OVERRIDE_KEYWORD) && element.visibilityModifierType() ?: element.implicitVisibility() == KtTokens.PUBLIC_KEYWORD &&
-                element.docComment == null) {
-                element.nameIdentifier?.let { holder.registerProblem(it, "Missing Documentation") }
+
+            if (element is KtNamedDeclaration) {
+                val nameIdentifier = element.nameIdentifier
+                val descriptor = element.resolveToDescriptor() as? MemberDescriptor;
+                if (nameIdentifier != null && descriptor != null && descriptor.visibility == Visibilities.PUBLIC) {
+                    val hasDocumentation = element.docComment != null ||
+                                           (descriptor as? CallableMemberDescriptor)?.overriddenDescriptors
+                                                   ?.any { (it.source.getPsi() as? KtNamedDeclaration)?.docComment != null } ?: false
+                    if (!hasDocumentation) {
+                        holder.registerProblem(nameIdentifier, "Missing Documentation")
+                    }
+                }
             }
         }
     }

--- a/idea/idea-analysis/src/org/jetbrains/kotlin/idea/kdoc/KDocMissingDocumentationInspection.kt
+++ b/idea/idea-analysis/src/org/jetbrains/kotlin/idea/kdoc/KDocMissingDocumentationInspection.kt
@@ -20,8 +20,9 @@ import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
 import org.jetbrains.kotlin.idea.inspections.AbstractKotlinInspection
+import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtNamedDeclaration
-import org.jetbrains.kotlin.psi.psiUtil.isPrivate
+import org.jetbrains.kotlin.psi.psiUtil.visibilityModifierType
 
 class KDocMissingDocumentationInspection(): AbstractKotlinInspection() {
     override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor =
@@ -29,9 +30,8 @@ class KDocMissingDocumentationInspection(): AbstractKotlinInspection() {
 
     private class KDocMissingDocumentationInspection(private val holder: ProblemsHolder): PsiElementVisitor() {
         override fun visitElement(element: PsiElement) {
-            if (element is KtNamedDeclaration && !element.isPrivate() && element.docComment == null) {
-                val nameIdentifier = element.nameIdentifier
-                if (nameIdentifier != null) holder.registerProblem(nameIdentifier, "Missing Documentation")
+            if (element is KtNamedDeclaration && element.visibilityModifierType() == KtTokens.PUBLIC_KEYWORD && element.docComment == null) {
+                element.nameIdentifier?.let { holder.registerProblem(it, "Missing Documentation") }
             }
         }
     }

--- a/idea/idea-analysis/src/org/jetbrains/kotlin/idea/kdoc/KDocMissingDocumentationInspection.kt
+++ b/idea/idea-analysis/src/org/jetbrains/kotlin/idea/kdoc/KDocMissingDocumentationInspection.kt
@@ -30,6 +30,7 @@ import org.jetbrains.kotlin.descriptors.MemberDescriptor
 import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.idea.caches.resolve.resolveToDescriptor
 import org.jetbrains.kotlin.idea.inspections.AbstractKotlinInspection
+import org.jetbrains.kotlin.idea.inspections.findExistingEditor
 import org.jetbrains.kotlin.kdoc.psi.impl.KDocImpl
 import org.jetbrains.kotlin.lexer.KtModifierKeywordToken
 import org.jetbrains.kotlin.lexer.KtTokens
@@ -73,16 +74,6 @@ class KDocMissingDocumentationInspection(): AbstractKotlinInspection() {
             declaration.addBefore(KDocElementFactory(project).createKDocFromText("/**  */"), declaration.firstChild)
             val editor = descriptor.psiElement.findExistingEditor()
             editor?.caretModel?.moveToOffset(declaration.startOffset + 4)
-        }
-
-        private fun PsiElement.findExistingEditor(): Editor? {
-            val file = containingFile?.virtualFile ?: return null
-            val document = FileDocumentManager.getInstance().getDocument(file) ?: return null
-
-            val editorFactory = EditorFactory.getInstance()
-
-            val editors = editorFactory.getEditors(document)
-            return if (editors.isEmpty()) null else editors[0]
         }
     }
 }

--- a/idea/idea-analysis/src/org/jetbrains/kotlin/idea/kdoc/KDocMissingDocumentationInspection.kt
+++ b/idea/idea-analysis/src/org/jetbrains/kotlin/idea/kdoc/KDocMissingDocumentationInspection.kt
@@ -20,8 +20,8 @@ import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
 import org.jetbrains.kotlin.idea.inspections.AbstractKotlinInspection
-import org.jetbrains.kotlin.idea.references.mainReference
-import org.jetbrains.kotlin.kdoc.psi.impl.KDocName
+import org.jetbrains.kotlin.psi.KtNamedDeclaration
+import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 
 class KDocMissingDocumentationInspection(): AbstractKotlinInspection() {
     override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor =
@@ -29,11 +29,9 @@ class KDocMissingDocumentationInspection(): AbstractKotlinInspection() {
 
     private class KDocMissingDocumentationInspection(private val holder: ProblemsHolder): PsiElementVisitor() {
         override fun visitElement(element: PsiElement) {
-            if (element is KDocName) {
-                val ref = element.mainReference
-                if (ref.resolve() == null) {
-                    holder.registerProblem(ref)
-                }
+            if (element is KtNamedDeclaration && !element.isPrivate() && element.docComment == null) {
+                val nameIdentifier = element.nameIdentifier
+                if (nameIdentifier != null) holder.registerProblem(nameIdentifier, "Missing Documentation")
             }
         }
     }

--- a/idea/src/META-INF/plugin.xml
+++ b/idea/src/META-INF/plugin.xml
@@ -1320,7 +1320,7 @@
     />
 
     <localInspection implementationClass="org.jetbrains.kotlin.idea.kdoc.KDocMissingDocumentationInspection"
-                     displayName="Missing KDoc for non-private declarations"
+                     displayName="Missing KDoc comments for public declarations"
                      groupName="Kotlin"
                      enabledByDefault="true"
                      level="WARNING"

--- a/idea/src/META-INF/plugin.xml
+++ b/idea/src/META-INF/plugin.xml
@@ -1319,6 +1319,13 @@
                      level="WARNING"
     />
 
+    <localInspection implementationClass="org.jetbrains.kotlin.idea.kdoc.KDocMissingDocumentationInspection"
+                     displayName="Missing Documentation for public entities"
+                     groupName="Kotlin"
+                     enabledByDefault="true"
+                     level="WARNING"
+    />
+
     <localInspection implementationClass="org.jetbrains.kotlin.idea.refactoring.move.changePackage.PackageDirectoryMismatchInspection"
                      displayName="Package name does not match containing directory"
                      groupName="Kotlin"

--- a/idea/src/META-INF/plugin.xml
+++ b/idea/src/META-INF/plugin.xml
@@ -1320,7 +1320,7 @@
     />
 
     <localInspection implementationClass="org.jetbrains.kotlin.idea.kdoc.KDocMissingDocumentationInspection"
-                     displayName="Missing Documentation for public entities"
+                     displayName="Missing KDoc for non-private declarations"
                      groupName="Kotlin"
                      enabledByDefault="true"
                      level="WARNING"

--- a/idea/testData/kdoc/highlighting/MissingDocumentation.kt
+++ b/idea/testData/kdoc/highlighting/MissingDocumentation.kt
@@ -1,0 +1,6 @@
+/**
+ * [<warning descr="Cannot resolve symbol 'unresolvedLink'">unresolvedLink</warning>]
+ */
+fun foo() {}
+
+// NO_CHECK_INFOS

--- a/idea/testData/kdoc/highlighting/MissingDocumentation.kt
+++ b/idea/testData/kdoc/highlighting/MissingDocumentation.kt
@@ -1,6 +1,6 @@
 
-public fun <warning descr="Missing Documentation">publicUndocumentedFun</warning>() {}
-fun <warning descr="Missing Documentation">defaultUndocumentedFun</warning>() {}
+public fun <warning descr="Missing documentation">publicUndocumentedFun</warning>() {}
+fun <warning descr="Missing documentation">defaultUndocumentedFun</warning>() {}
 
 /** Some documentation */
 public fun publicDocumentedFun() {}
@@ -13,8 +13,8 @@ internal fun internalUndocumentedFun() {}
 
 
 
-public class <warning descr="Missing Documentation">publicUndocumentedClass</warning>() {}
-class <warning descr="Missing Documentation">defaultUndocumentedClass</warning>() {}
+public class <warning descr="Missing documentation">publicUndocumentedClass</warning>() {}
+class <warning descr="Missing documentation">defaultUndocumentedClass</warning>() {}
 
 /** Some documentation */
 public class publicDocumentedClass() {}
@@ -29,8 +29,8 @@ internal class internalUndocumentedClass() {}
 
 private open class Properties {
 
-    public open val <warning descr="Missing Documentation">publicUndocumentedProperty</warning>: Int = 0
-    open val <warning descr="Missing Documentation">defaultUndocumentedProperty</warning>: Int = 0
+    public open val <warning descr="Missing documentation">publicUndocumentedProperty</warning>: Int = 0
+    open val <warning descr="Missing documentation">defaultUndocumentedProperty</warning>: Int = 0
 
     /** Some documentation */
     public open val publicDocumentedProperty: Int = 0
@@ -51,14 +51,14 @@ private open class Properties {
 }
 
 private open class ChildClass : Properties() {
-    override val <warning descr="Missing Documentation">publicUndocumentedProperty</warning>: Int = 4
-    override val <warning descr="Missing Documentation">defaultUndocumentedProperty</warning>: Int = 4
+    override val <warning descr="Missing documentation">publicUndocumentedProperty</warning>: Int = 4
+    override val <warning descr="Missing documentation">defaultUndocumentedProperty</warning>: Int = 4
     override val publicDocumentedProperty: Int = 4
     override val defaultDocumentedProperty: Int = 4
 
     /** Some documentation */
     override public val internalUndocumentedProperty: Int = 4
-    override public val <warning descr="Missing Documentation">protectedUndocumentedProperty</warning>: Int = 4
+    override public val <warning descr="Missing documentation">protectedUndocumentedProperty</warning>: Int = 4
     override public val protectedDocumentedProperty: Int = 4
 }
 

--- a/idea/testData/kdoc/highlighting/MissingDocumentation.kt
+++ b/idea/testData/kdoc/highlighting/MissingDocumentation.kt
@@ -27,24 +27,43 @@ internal class internalUndocumentedClass() {}
 
 
 
-private class Properties {
+private open class Properties {
 
-    public val <warning descr="Missing Documentation">publicUndocumentedProperty</warning>: Int = 0
-    val <warning descr="Missing Documentation">defaultUndocumentedProperty</warning>: Int = 0
-
-    /** Some documentation */
-    public val publicDocumentedProperty: Int = 0
+    public open val <warning descr="Missing Documentation">publicUndocumentedProperty</warning>: Int = 0
+    open val <warning descr="Missing Documentation">defaultUndocumentedProperty</warning>: Int = 0
 
     /** Some documentation */
-    val defaultDocumentedProperty: Int = 0
+    public open val publicDocumentedProperty: Int = 0
+
+    /** Some documentation */
+    open val defaultDocumentedProperty: Int = 0
 
     private val privateUndocumentedProperty: Int = 0
-    internal val internalUndocumentedProperty: Int = 0
+    internal open val internalUndocumentedProperty: Int = 0
 
 
-    protected val protectedUndocumentedProperty: Int = 0
+    protected open val protectedUndocumentedProperty: Int = 0
     protected class protectedUndocumentedClass {}
     protected fun protectedUndocumentedFun() {}
+
+    /** Some documentation */
+    protected open val protectedDocumentedProperty: Int = 0
+}
+
+private open class ChildClass : Properties() {
+    override val <warning descr="Missing Documentation">publicUndocumentedProperty</warning>: Int = 4
+    override val <warning descr="Missing Documentation">defaultUndocumentedProperty</warning>: Int = 4
+    override val publicDocumentedProperty: Int = 4
+    override val defaultDocumentedProperty: Int = 4
+
+    /** Some documentation */
+    override public val internalUndocumentedProperty: Int = 4
+    override public val <warning descr="Missing Documentation">protectedUndocumentedProperty</warning>: Int = 4
+    override public val protectedDocumentedProperty: Int = 4
+}
+
+private class GrandChildClass : ChildClass() {
+    override public val internalUndocumentedProperty: Int = 6
 }
 
 // NO_CHECK_INFOS

--- a/idea/testData/kdoc/highlighting/MissingDocumentation.kt
+++ b/idea/testData/kdoc/highlighting/MissingDocumentation.kt
@@ -1,21 +1,27 @@
 
 public fun <warning descr="Missing Documentation">publicUndocumentedFun</warning>() {}
+fun <warning descr="Missing Documentation">defaultUndocumentedFun</warning>() {}
 
 /** Some documentation */
 public fun publicDocumentedFun() {}
 
-fun defaultUndocumentedFun() {}
+/** Some documentation */
+fun defaultDocumentedFun() {}
+
 private fun privateUndocumentedFun() {}
 internal fun internalUndocumentedFun() {}
 
 
 
 public class <warning descr="Missing Documentation">publicUndocumentedClass</warning>() {}
+class <warning descr="Missing Documentation">defaultUndocumentedClass</warning>() {}
 
 /** Some documentation */
 public class publicDocumentedClass() {}
 
-class defaultUndocumentedClass() {}
+/** Some documentation */
+class defaultDocumentedClass() {}
+
 private class privateUndocumentedClass() {}
 internal class internalUndocumentedClass() {}
 
@@ -24,11 +30,14 @@ internal class internalUndocumentedClass() {}
 private class Properties {
 
     public val <warning descr="Missing Documentation">publicUndocumentedProperty</warning>: Int = 0
+    val <warning descr="Missing Documentation">defaultUndocumentedProperty</warning>: Int = 0
 
     /** Some documentation */
     public val publicDocumentedProperty: Int = 0
 
-    val defaultUndocumentedProperty: Int = 0
+    /** Some documentation */
+    val defaultDocumentedProperty: Int = 0
+
     private val privateUndocumentedProperty: Int = 0
     internal val internalUndocumentedProperty: Int = 0
     protected val protectedUndocumentedProperty: Int = 0

--- a/idea/testData/kdoc/highlighting/MissingDocumentation.kt
+++ b/idea/testData/kdoc/highlighting/MissingDocumentation.kt
@@ -1,6 +1,22 @@
+
+fun <warning descr="Missing Documentation">undocumentedFun</warning>() {}
+
 /**
- * [<warning descr="Cannot resolve symbol 'unresolvedLink'">unresolvedLink</warning>]
+ * Some documentation
  */
-fun foo() {}
+fun documentedFun() {}
+
+private fun privateUndocumentedFun() {}
+
+
+class <warning descr="Missing Documentation">undocumentedClass</warning>() {}
+
+/**
+ * Some documentation
+ */
+class documentedClass() {}
+
+private fun privateUndocumentedClass() {}
+
 
 // NO_CHECK_INFOS

--- a/idea/testData/kdoc/highlighting/MissingDocumentation.kt
+++ b/idea/testData/kdoc/highlighting/MissingDocumentation.kt
@@ -40,7 +40,11 @@ private class Properties {
 
     private val privateUndocumentedProperty: Int = 0
     internal val internalUndocumentedProperty: Int = 0
+
+
     protected val protectedUndocumentedProperty: Int = 0
+    protected class protectedUndocumentedClass {}
+    protected fun protectedUndocumentedFun() {}
 }
 
 // NO_CHECK_INFOS

--- a/idea/testData/kdoc/highlighting/MissingDocumentation.kt
+++ b/idea/testData/kdoc/highlighting/MissingDocumentation.kt
@@ -1,22 +1,37 @@
 
-fun <warning descr="Missing Documentation">undocumentedFun</warning>() {}
+public fun <warning descr="Missing Documentation">publicUndocumentedFun</warning>() {}
 
-/**
- * Some documentation
- */
-fun documentedFun() {}
+/** Some documentation */
+public fun publicDocumentedFun() {}
 
+fun defaultUndocumentedFun() {}
 private fun privateUndocumentedFun() {}
+internal fun internalUndocumentedFun() {}
 
 
-class <warning descr="Missing Documentation">undocumentedClass</warning>() {}
 
-/**
- * Some documentation
- */
-class documentedClass() {}
+public class <warning descr="Missing Documentation">publicUndocumentedClass</warning>() {}
 
-private fun privateUndocumentedClass() {}
+/** Some documentation */
+public class publicDocumentedClass() {}
 
+class defaultUndocumentedClass() {}
+private class privateUndocumentedClass() {}
+internal class internalUndocumentedClass() {}
+
+
+
+private class Properties {
+
+    public val <warning descr="Missing Documentation">publicUndocumentedProperty</warning>: Int = 0
+
+    /** Some documentation */
+    public val publicDocumentedProperty: Int = 0
+
+    val defaultUndocumentedProperty: Int = 0
+    private val privateUndocumentedProperty: Int = 0
+    internal val internalUndocumentedProperty: Int = 0
+    protected val protectedUndocumentedProperty: Int = 0
+}
 
 // NO_CHECK_INFOS

--- a/idea/testData/quickfix/kdocMissingDocumentation/.inspection
+++ b/idea/testData/quickfix/kdocMissingDocumentation/.inspection
@@ -1,0 +1,1 @@
+org.jetbrains.kotlin.idea.kdoc.KDocMissingDocumentationInspection

--- a/idea/testData/quickfix/kdocMissingDocumentation/simple.kt
+++ b/idea/testData/quickfix/kdocMissingDocumentation/simple.kt
@@ -1,0 +1,4 @@
+// "Add documentation" "true"
+
+class <caret>C {
+}

--- a/idea/testData/quickfix/kdocMissingDocumentation/simple.kt.after
+++ b/idea/testData/quickfix/kdocMissingDocumentation/simple.kt.after
@@ -1,0 +1,5 @@
+// "Add documentation" "true"
+
+/** <caret> */
+class C {
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/kdoc/AbstractKDocHighlightingTest.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/kdoc/AbstractKDocHighlightingTest.java
@@ -23,5 +23,6 @@ public abstract class AbstractKDocHighlightingTest extends AbstractHighlightingT
     protected void setUp() {
         super.setUp();
         myFixture.enableInspections(KDocUnresolvedReferenceInspection.class);
+        myFixture.enableInspections(KDocMissingDocumentationInspection.class);
     }
 }

--- a/idea/tests/org/jetbrains/kotlin/idea/kdoc/KDocHighlightingTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/kdoc/KDocHighlightingTestGenerated.java
@@ -35,6 +35,12 @@ public class KDocHighlightingTestGenerated extends AbstractKDocHighlightingTest 
         KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/kdoc/highlighting"), Pattern.compile("^(.+)\\.kt$"), true);
     }
 
+    @TestMetadata("MissingDocumentation.kt")
+    public void testMissingDocumentation() throws Exception {
+        String fileName = KotlinTestUtils.navigationMetadata("idea/testData/kdoc/highlighting/MissingDocumentation.kt");
+        doTest(fileName);
+    }
+
     @TestMetadata("UnresolvedReference.kt")
     public void testUnresolvedReference() throws Exception {
         String fileName = KotlinTestUtils.navigationMetadata("idea/testData/kdoc/highlighting/UnresolvedReference.kt");

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -4584,6 +4584,21 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
         }
     }
 
+    @TestMetadata("idea/testData/quickfix/kdocMissingDocumentation")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class KdocMissingDocumentation extends AbstractQuickFixTest {
+        public void testAllFilesPresentInKdocMissingDocumentation() throws Exception {
+            KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/quickfix/kdocMissingDocumentation"), Pattern.compile("^([\\w\\-_]+)\\.kt$"), true);
+        }
+
+        @TestMetadata("simple.kt")
+        public void testSimple() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/quickfix/kdocMissingDocumentation/simple.kt");
+            doTest(fileName);
+        }
+    }
+
     @TestMetadata("idea/testData/quickfix/libraries")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-1494

Currently, this checks for explicitly public declarations. Need suggestions on handling these scenarios:
- Should overriden public elements also be highlighted? What if the element in super class is protected and it has been made public in overriding class?
- When visibility is not specified, it is public implicitly. In this case should inspection report problems?