### PR TITLE
Add support for AOSP's nullability annotations.

### DIFF
--- a/compiler/testData/foreignAnnotations/annotations/com/android/annotations/NonNull.java
+++ b/compiler/testData/foreignAnnotations/annotations/com/android/annotations/NonNull.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2011 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.annotations;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.LOCAL_VARIABLE;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Denotes that a parameter, field or method return value can never be null.
+ * <p/>
+ * This is a marker annotation and it has no specific attributes.
+ */
+@Documented
+@Retention(RetentionPolicy.SOURCE)
+@Target({METHOD,PARAMETER,LOCAL_VARIABLE,FIELD})
+public @interface NonNull {
+}

--- a/compiler/testData/foreignAnnotations/annotations/com/android/annotations/Nullable.java
+++ b/compiler/testData/foreignAnnotations/annotations/com/android/annotations/Nullable.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2011 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.annotations;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.LOCAL_VARIABLE;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Denotes that a parameter, field or method return value can be null.
+ * <b>Note</b>: this is the default assumption for most Java APIs and the
+ * default assumption made by most static code checking tools, so usually you
+ * don't need to use this annotation; its primary use is to override a default
+ * wider annotation like {@link NonNullByDefault}.
+ * <p/>
+ * When decorating a method call parameter, this denotes the parameter can
+ * legitimately be null and the method will gracefully deal with it. Typically
+ * used on optional parameters.
+ * <p/>
+ * When decorating a method, this denotes the method might legitimately return
+ * null.
+ * <p/>
+ * This is a marker annotation and it has no specific attributes.
+ */
+@Documented
+@Retention(RetentionPolicy.SOURCE)
+@Target({METHOD, PARAMETER, LOCAL_VARIABLE, FIELD})
+public @interface Nullable {
+}

--- a/compiler/testData/foreignAnnotations/tests/aosp.kt
+++ b/compiler/testData/foreignAnnotations/tests/aosp.kt
@@ -1,0 +1,42 @@
+// !DIAGNOSTICS: -UNUSED_VARIABLE -UNUSED_PARAMETER
+// FILE: A.java
+
+import com.android.annotations.*;
+
+public class A<T> {
+    @Nullable public String field = null;
+
+    @Nullable
+    public String foo(@NonNull String x, @Nullable CharSequence y) {
+        return "";
+    }
+
+    @NonNull
+    public String bar() {
+        return "";
+    }
+
+    @Nullable
+    public T baz(@NonNull T x) { return x; }
+}
+
+// FILE: main.kt
+
+fun main(a: A<String>, a1: A<String?>) {
+    a.foo("", null)?.length
+    a.foo("", null)<!UNSAFE_CALL!>.<!>length
+    a.foo(<!NULL_FOR_NONNULL_TYPE!>null<!>, "")<!UNSAFE_CALL!>.<!>length
+
+    a.bar().length
+    a.bar()<!UNNECESSARY_NOT_NULL_ASSERTION!>!!<!>.length
+
+    a.field?.length
+    a.field<!UNSAFE_CALL!>.<!>length
+
+    a.baz("")<!UNSAFE_CALL!>.<!>length
+    a.baz("")?.length
+    a.baz(<!NULL_FOR_NONNULL_TYPE!>null<!>)<!UNSAFE_CALL!>.<!>length
+
+    a1.baz("")!!.length
+    a1.baz(<!NULL_FOR_NONNULL_TYPE!>null<!>)!!.length
+}

--- a/compiler/testData/foreignAnnotations/tests/aosp.txt
+++ b/compiler/testData/foreignAnnotations/tests/aosp.txt
@@ -1,0 +1,14 @@
+package
+
+public fun main(/*0*/ a: A<kotlin.String>, /*1*/ a1: A<kotlin.String?>): kotlin.Unit
+
+public open class A</*0*/ T : kotlin.Any!> {
+    public constructor A</*0*/ T : kotlin.Any!>()
+    @com.android.annotations.Nullable() public final var field: kotlin.String?
+    @com.android.annotations.NonNull() public open fun bar(): kotlin.String
+    @com.android.annotations.Nullable() public open fun baz(/*0*/ @com.android.annotations.NonNull() x: T): T?
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    @com.android.annotations.Nullable() public open fun foo(/*0*/ @com.android.annotations.NonNull() x: kotlin.String, /*1*/ @com.android.annotations.Nullable() y: kotlin.CharSequence?): kotlin.String?
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}

--- a/compiler/tests/org/jetbrains/kotlin/checkers/ForeignAnnotationsTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/checkers/ForeignAnnotationsTestGenerated.java
@@ -41,6 +41,12 @@ public class ForeignAnnotationsTestGenerated extends AbstractForeignAnnotationsT
         doTest(fileName);
     }
 
+    @TestMetadata("aosp.kt")
+    public void testAosp() throws Exception {
+        String fileName = KotlinTestUtils.navigationMetadata("compiler/testData/foreignAnnotations/tests/aosp.kt");
+        doTest(fileName);
+    }
+
     @TestMetadata("checkerFramework.kt")
     public void testCheckerFramework() throws Exception {
         String fileName = KotlinTestUtils.navigationMetadata("compiler/testData/foreignAnnotations/tests/checkerFramework.kt");

--- a/core/descriptor.loader.java/src/org/jetbrains/kotlin/load/java/JvmAnnotationNames.kt
+++ b/core/descriptor.loader.java/src/org/jetbrains/kotlin/load/java/JvmAnnotationNames.kt
@@ -21,6 +21,7 @@ import org.jetbrains.kotlin.name.FqName
 val NULLABLE_ANNOTATIONS = listOf(
         JvmAnnotationNames.JETBRAINS_NULLABLE_ANNOTATION,
         FqName("android.support.annotation.Nullable"),
+        FqName("com.android.annotations.Nullable"),
         FqName("org.eclipse.jdt.annotation.Nullable"),
         FqName("org.checkerframework.checker.nullness.qual.Nullable"),
         FqName("javax.annotation.Nullable"),
@@ -36,6 +37,7 @@ val NOT_NULL_ANNOTATIONS = listOf(
         JvmAnnotationNames.JETBRAINS_NOT_NULL_ANNOTATION,
         FqName("edu.umd.cs.findbugs.annotations.NonNull"),
         FqName("android.support.annotation.NonNull"),
+        FqName("com.android.annotations.NonNull"),
         FqName("org.eclipse.jdt.annotation.NonNull"),
         FqName("org.checkerframework.checker.nullness.qual.NonNull"),
         FqName("lombok.NonNull")

--- a/core/descriptors/src/org/jetbrains/kotlin/renderer/DescriptorRenderer.kt
+++ b/core/descriptors/src/org/jetbrains/kotlin/renderer/DescriptorRenderer.kt
@@ -200,6 +200,8 @@ object ExcludedTypeAnnotations {
             FqName("org.jetbrains.annotations.Nullable"),
             FqName("android.support.annotation.Nullable"),
             FqName("android.support.annotation.NonNull"),
+            FqName("com.android.annotations.Nullable"),
+            FqName("com.android.annotations.NonNull"),
             FqName("org.eclipse.jdt.annotation.Nullable"),
             FqName("org.eclipse.jdt.annotation.NonNull"),
             FqName("org.checkerframework.checker.nullness.qual.Nullable"),


### PR DESCRIPTION
These are different than 'android.support.annotation' in that they are used on the JVM for projects within AOSP.