### PR TITLE
Adds a kapt setting to the gradle plugin for controlling the generated source output directory

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinGradlePluginIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinGradlePluginIT.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.kotlin.gradle
 
-import org.jetbrains.kotlin.gradle.BaseGradleIT.Project
 import org.junit.Test
 
 class KotlinGradleIT: BaseGradleIT() {
@@ -194,6 +193,20 @@ class KotlinGradleIT: BaseGradleIT() {
             assertFileExists("build/tmp/kapt/main/kotlinGenerated/TestClass.kt")
             assertFileExists("build/classes/main/example/TestClass.class")
             assertFileExists("build/classes/main/example/TestClassCustomized.class")
+        }
+    }
+
+    @Test
+    fun testKaptGeneratedFilesBaseDir() {
+        Project("kaptGeneratedFilesBaseDir", "1.12").build("build") {
+            assertSuccessful()
+
+            assertContains(":compileKotlin")
+            assertContains(":compileJava")
+            assertFileExists("build/tmp/kapt/main/wrappers/annotations.main.txt")
+            assertFileExists("generated/main/TestClassGenerated.java")
+            assertFileExists("build/classes/main/example/TestClass.class")
+            assertFileExists("build/classes/main/example/TestClassGenerated.class")
         }
     }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/test/resources/testProject/kaptGeneratedFilesBaseDir/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin/src/test/resources/testProject/kaptGeneratedFilesBaseDir/build.gradle
@@ -1,0 +1,43 @@
+buildscript {
+    repositories {
+        mavenCentral()
+        maven {
+            url 'file://' + pathToKotlinPlugin
+        }
+    }
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:0.1-SNAPSHOT"
+    }
+}
+
+apply plugin: "java"
+apply plugin: "kotlin"
+
+repositories {
+    maven {
+        url 'file://' + pathToKotlinPlugin
+    }
+    mavenCentral()
+}
+
+dependencies {
+    compile "org.jetbrains.kotlin:kotlin-stdlib:0.1-SNAPSHOT"
+    compile "org.jetbrains.kotlin:annotation-processor-example:0.1-SNAPSHOT"
+    kapt "org.jetbrains.kotlin:annotation-processor-example:0.1-SNAPSHOT"
+}
+
+task show << {
+    buildscript.configurations.classpath.each { println it }
+}
+
+task wrapper(type: Wrapper) {
+    gradleVersion="1.12"
+}
+
+kapt {
+    generateStubs = true
+
+    generatedFilesBaseDir 'generated'
+    generatedFilesBaseDir file('generated')
+    generatedFilesBaseDir { file('generated') }
+}

--- a/libraries/tools/kotlin-gradle-plugin/src/test/resources/testProject/kaptGeneratedFilesBaseDir/src/main/java/test.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/test/resources/testProject/kaptGeneratedFilesBaseDir/src/main/java/test.kt
@@ -1,0 +1,5 @@
+package example
+
+@example.ExampleAnnotation
+public class TestClass {
+}


### PR DESCRIPTION
This patch adds a new setting to kapt for controlling the output directory of generated sources; this doesn't affect the tmp directory used for storing stubs and other data, which is currently left as-is.

Currently, the output directory is hard-coded to be stored under the build directory. However, this presents an issue with IDEs such as IDEA which don't allow marking generated source directories as source while under an excluded directory (such as the build directory). The only current workaround is to manually unexclude build/ and exclude all its subdirs aside from generated/, and then mark generated/ as a src dir every time the project settings are refreshed.

When using an android project, due to android's modified gradle model this isn't an issue, as the build directory itself isn't marked as excluded, only some of its subdirectories. However, when creating a normal application via gradle, the generated sources under the build directory aren't indexed by IDEA properly, and setting idea.modules.generatedSourceDirs has no effect due to the aforementioned limitation. While the application will still compile correctly, the IDE will report missing class errors, as well as being unable to provide autocompletion for generated classes.

The provided patch provides kapt.generatedFilesBaseDir (name taken from the protobuf-gradle-plugin) with 3 overloads, one for String, one for File and one for taking a Closure<File> with a single Project argument, which can override the root generation directory for the current project. If not provided, defaults to the current directory (generated/source/kapt/).

This can be used to put the generated sources under a different directory, which can then be added to the IDE's src directories via gradle plugins, such as using the idea plugin's idea.modules.sourceDirs+generatedSourceDirs.

A caveat of this is that the gradle clean task will no longer delete the directory; it's up to the user to extend the clean task (eg: via clean.doFirst) to clean up the directory.
