### PR TITLE
Annotation descriptor value arguments are made recursion tolerant #KT-6367 Fixed

### DIFF
--- a/compiler/testData/diagnostics/testsWithStdLib/annotations/RecursiveDeprecated.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/annotations/RecursiveDeprecated.kt
@@ -1,0 +1,9 @@
+// KT-6367 / EA-75125: 
+// Recursion detected on input: AssertionError in IDE and ClassCastException in the compiler
+
+@Deprecated(<!TYPE_MISMATCH!><!DEPRECATION!>bar<!>()<!>)
+fun bar() = null
+
+<!DEPRECATED_JAVA_ANNOTATION!>@java.lang.Deprecated(<!TOO_MANY_ARGUMENTS!><!DEPRECATION!>foo<!>()<!>)<!>
+fun foo() = "x"
+

--- a/compiler/testData/diagnostics/testsWithStdLib/annotations/RecursiveDeprecated.txt
+++ b/compiler/testData/diagnostics/testsWithStdLib/annotations/RecursiveDeprecated.txt
@@ -1,0 +1,4 @@
+package
+
+@kotlin.Deprecated() public fun bar(): kotlin.Nothing?
+@java.lang.Deprecated() public fun foo(): kotlin.String

--- a/compiler/tests/org/jetbrains/kotlin/checkers/DiagnosticsTestWithStdLibGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/checkers/DiagnosticsTestWithStdLibGenerated.java
@@ -193,6 +193,12 @@ public class DiagnosticsTestWithStdLibGenerated extends AbstractDiagnosticsTestW
             doTest(fileName);
         }
 
+        @TestMetadata("RecursiveDeprecated.kt")
+        public void testRecursiveDeprecated() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("compiler/testData/diagnostics/testsWithStdLib/annotations/RecursiveDeprecated.kt");
+            doTest(fileName);
+        }
+
         @TestMetadata("Synchronized.kt")
         public void testSynchronized() throws Exception {
             String fileName = KotlinTestUtils.navigationMetadata("compiler/testData/diagnostics/testsWithStdLib/annotations/Synchronized.kt");


### PR DESCRIPTION
Also EA-75125 Fixed

This PR should be probably used in Kotlin 1.1