### PR TITLE
Add method CharSequence.occurencesOf

### DIFF
--- a/libraries/stdlib/src/kotlin/text/Strings.kt
+++ b/libraries/stdlib/src/kotlin/text/Strings.kt
@@ -1190,6 +1190,8 @@ private fun computePrefixFunction(pattern: CharSequence): IntArray {
  * Returns a list of indices where the pattern occurs in this String. This method
  * searches character by character and thus does not support regular expressions
  * as input for the pattern.
+ * For a pattern longer than the text, an empty sequence is returned. If the pattern
+ * is empty, all indices are matched.
  *
  * @param [pattern] The pattern to look for in this String. Regular expressions
  *                 are not supported
@@ -1200,8 +1202,12 @@ private fun computePrefixFunction(pattern: CharSequence): IntArray {
  */
 public fun CharSequence.occurrencesOf(pattern: CharSequence, ignoreCase: Boolean = false): Sequence<Int> {
 
-    if (pattern.isEmpty() || pattern.length > this.length) {
+    if (pattern.length > this.length) {
         return emptySequence()
+    }
+
+    if (pattern.isEmpty()) {
+        return indices.asSequence()
     }
 
     if (pattern.length == 1) {

--- a/libraries/stdlib/src/kotlin/text/Strings.kt
+++ b/libraries/stdlib/src/kotlin/text/Strings.kt
@@ -1187,17 +1187,30 @@ private fun computePrefixFunction(pattern: CharSequence): IntArray {
 }
 
 /**
- * Returns a list of indices where the pattern occurs in this String. This method
+ * Returns a sequence of indices where the char occurs in this CharSequence.
+ *
+ * @param [char] The character to look for in the string
+ * @param [ignoreCase] If true, characters are matched even if one is upper and the other is
+ *                 lower case
+ *
+ * @return A list of indices where the supplied [char] occurs in the text.
+ */
+public fun CharSequence.occurrencesOf(char: Char, ignoreCase: Boolean = false): Sequence<Int> {
+    return indices.asSequence().filter { this[it].equals(char, ignoreCase) }
+}
+
+/**
+ * Returns a sequence of indices where the pattern occurs in this CharSequence. This method
  * searches character by character and thus does not support regular expressions
  * as input for the pattern.
  * For a pattern longer than the text, an empty sequence is returned. If the pattern
- * is empty, all indices are matched.
+ * is empty, all indices plus an empty occurrence at the end are matched.
  *
  * @param [pattern] The pattern to look for in this String. Regular expressions
  *                 are not supported
  * @param [ignoreCase] If true, characters are matched even if one is upper and the other is
  *                 lower case
- * @param [matchOverlapping] If true, also match overlapping occurences.
+ * @param [matchOverlapping] If true, also match overlapping occurrences.
  *
  * @return A list of indices where the supplied [pattern] starts in the text.
  */
@@ -1208,11 +1221,11 @@ public fun CharSequence.occurrencesOf(pattern: CharSequence, ignoreCase: Boolean
     }
 
     if (pattern.isEmpty()) {
-        return indices.asSequence()
+        return (0..length).asSequence()
     }
 
     if (pattern.length == 1) {
-        return indices.asSequence().filter { this[it].equals(pattern[0], ignoreCase) }
+        return occurrencesOf(pattern[0], ignoreCase)
     }
 
     // Non-trivial pattern matching, perform computation

--- a/libraries/stdlib/src/kotlin/text/Strings.kt
+++ b/libraries/stdlib/src/kotlin/text/Strings.kt
@@ -1200,7 +1200,7 @@ private fun computePrefixFunction(pattern: CharSequence): IntArray {
  */
 public fun CharSequence.occurrencesOf(pattern: CharSequence, ignoreCase: Boolean = false): Sequence<Int> {
 
-    if (isEmpty() || pattern.isEmpty()) {
+    if (pattern.isEmpty() || pattern.length > this.length) {
         return emptySequence()
     }
 

--- a/libraries/stdlib/src/kotlin/text/Strings.kt
+++ b/libraries/stdlib/src/kotlin/text/Strings.kt
@@ -1174,7 +1174,7 @@ private fun computePrefixFunction(pattern: CharSequence): IntArray {
     var matches = 0
     for (i in 1..pattern.length - 1) {
         while (matches > 0 && pattern[matches] != pattern[i]) {
-            matches = resultTable[matches]
+            matches = resultTable[matches - 1]
         }
 
         if (pattern[matches] == pattern[i]) {

--- a/libraries/stdlib/src/kotlin/text/Strings.kt
+++ b/libraries/stdlib/src/kotlin/text/Strings.kt
@@ -1197,10 +1197,11 @@ private fun computePrefixFunction(pattern: CharSequence): IntArray {
  *                 are not supported
  * @param [ignoreCase] If true, characters are matched even if one is upper and the other is
  *                 lower case
+ * @param [matchOverlapping] If true, also match overlapping occurences.
  *
  * @return A list of indices where the supplied [pattern] starts in the text.
  */
-public fun CharSequence.occurrencesOf(pattern: CharSequence, ignoreCase: Boolean = false): Sequence<Int> {
+public fun CharSequence.occurrencesOf(pattern: CharSequence, ignoreCase: Boolean = false, matchOverlapping: Boolean = false): Sequence<Int> {
 
     if (pattern.length > this.length) {
         return emptySequence()
@@ -1231,7 +1232,7 @@ public fun CharSequence.occurrencesOf(pattern: CharSequence, ignoreCase: Boolean
                 matches++
             }
             if (matches == pattern.length) {
-                matches = prefixFunction[matches - 1]
+                matches = if (matchOverlapping) prefixFunction[matches - 1] else 0
                 i++
                 return@generateSequence i - pattern.length
             }

--- a/libraries/stdlib/src/kotlin/text/Strings.kt
+++ b/libraries/stdlib/src/kotlin/text/Strings.kt
@@ -1168,16 +1168,19 @@ public fun CharSequence.lines(): List<String> = lineSequence().toList()
  * the length of the longest suffix of a substring of pattern from 0 to i
  * that is also a prefix of the pattern itself.
  */
-private fun computePrefixFunction(pattern: CharSequence): IntArray {
+private fun computePrefixFunction(pattern: CharSequence, ignoreCase: Boolean): IntArray {
     val resultTable = IntArray(pattern.length)
 
     var matches = 0
     for (i in 1..pattern.length - 1) {
-        while (matches > 0 && pattern[matches] != pattern[i]) {
+        var charMatches = pattern[matches].equals(pattern[i], ignoreCase)
+
+        while (matches > 0 && !charMatches) {
             matches = resultTable[matches - 1]
+            charMatches = pattern[matches].equals(pattern[i], ignoreCase)
         }
 
-        if (pattern[matches] == pattern[i]) {
+        if (charMatches) {
             matches++
         }
         resultTable[i] = matches
@@ -1231,17 +1234,19 @@ public fun CharSequence.occurrencesOf(pattern: CharSequence, ignoreCase: Boolean
     // Non-trivial pattern matching, perform computation
     // using Knuth-Morris-Pratt
 
-    val prefixFunction = computePrefixFunction(pattern)
+    val prefixFunction = computePrefixFunction(pattern, ignoreCase)
 
     var i = 0
     var matches = 0
     return generateSequence {
         while (i < length) {
-            while (matches > 0 && !pattern[matches].equals(this[i], ignoreCase)) {
+            var charMatches = pattern[matches].equals(this[i], ignoreCase)
+            while (matches > 0 && !charMatches) {
                 matches = prefixFunction[matches - 1]
+                charMatches = pattern[matches].equals(this[i], ignoreCase)
             }
 
-            if (pattern[matches].equals(this[i], ignoreCase)) {
+            if (charMatches) {
                 matches++
             }
             if (matches == pattern.length) {

--- a/libraries/stdlib/src/kotlin/text/Strings.kt
+++ b/libraries/stdlib/src/kotlin/text/Strings.kt
@@ -1162,3 +1162,77 @@ public fun CharSequence.lineSequence(): Sequence<String> = splitToSequence("\r\n
  * * Splits this char sequence to a list of lines delimited by any of the following character sequences: CRLF, LF or CR.
  */
 public fun CharSequence.lines(): List<String> = lineSequence().toList()
+
+/**
+ * For each i in [0, length), this function computes
+ * the length of the longest suffix of a substring of pattern from 0 to i
+ * that is also a prefix of the pattern itself.
+ */
+private fun computePrefixFunction(pattern: CharSequence): IntArray {
+    val resultTable = IntArray(pattern.length)
+
+    var matches = 0
+    for (i in 1..pattern.length - 1) {
+        while (matches > 0 && pattern[matches] != pattern[i]) {
+            matches = resultTable[matches]
+        }
+
+        if (pattern[matches] == pattern[i]) {
+            matches++
+        }
+        resultTable[i] = matches
+    }
+
+    return resultTable
+}
+
+/**
+ * Returns a list of indices where the pattern occurs in this String. This method
+ * searches character by character and thus does not support regular expressions
+ * as input for the pattern.
+ *
+ * @param [pattern] The pattern to look for in this String. Regular expressions
+ *                 are not supported
+ * @param [ignoreCase] If true, characters are matched even if one is upper and the other is
+ *                 lower case
+ *
+ * @return A list of indices where the supplied [pattern] starts in the text.
+ */
+public fun CharSequence.occurrencesOf(pattern: CharSequence, ignoreCase: Boolean = false): Sequence<Int> {
+
+    if (isEmpty() || pattern.isEmpty()) {
+        return emptySequence()
+    }
+
+    if (pattern.length == 1) {
+        return indices.asSequence().filter { this[it].equals(pattern[0], ignoreCase) }
+    }
+
+    // Non-trivial pattern matching, perform computation
+    // using Knuth-Morris-Pratt
+
+    val prefixFunction = computePrefixFunction(pattern)
+
+    var i = 0
+    var matches = 0
+    return generateSequence {
+        while (i < length) {
+            while (matches > 0 && !pattern[matches].equals(this[i], ignoreCase)) {
+                matches = prefixFunction[matches - 1]
+            }
+
+            if (pattern[matches].equals(this[i], ignoreCase)) {
+                matches++
+            }
+            if (matches == pattern.length) {
+                matches = prefixFunction[matches - 1]
+                i++
+                return@generateSequence i - pattern.length
+            }
+
+            i++
+        }
+
+        return@generateSequence null
+    }
+}

--- a/libraries/stdlib/test/text/StringTest.kt
+++ b/libraries/stdlib/test/text/StringTest.kt
@@ -31,6 +31,7 @@ fun assertContentEquals(expected: String, actual: CharSequence, message: String?
 
 // helper predicates available on both platforms
 fun Char.isAsciiDigit() = this in '0'..'9'
+
 fun Char.isAsciiLetter() = this in 'A'..'Z' || this in 'a'..'z'
 fun Char.isAsciiUpperCase() = this in 'A'..'Z'
 
@@ -39,18 +40,17 @@ class StringTest {
     @test fun isEmptyAndBlank() = withOneCharSequenceArg { arg1 ->
 
         val cases = listOf(
-            IsEmptyCase(null,              isNull = true),
-            IsEmptyCase("",                isEmpty = true, isBlank = true),
-            IsEmptyCase("  \r\n\t\u00A0",  isBlank = true),
-            IsEmptyCase(" Some ")
+                IsEmptyCase(null, isNull = true),
+                IsEmptyCase("", isEmpty = true, isBlank = true),
+                IsEmptyCase("  \r\n\t\u00A0", isBlank = true),
+                IsEmptyCase(" Some ")
         )
 
         for (case in cases) {
             val value = case.value?.let { arg1(it) }
             assertEquals(case.isNull || case.isEmpty, value.isNullOrEmpty(), "failed for case '$value'")
             assertEquals(case.isNull || case.isBlank, value.isNullOrBlank(), "failed for case '$value'")
-            if (value != null)
-            {
+            if (value != null) {
                 assertEquals(case.isEmpty, value.isEmpty(), "failed for case '$value'")
                 assertEquals(case.isBlank, value.isBlank(), "failed for case '$value'")
             }
@@ -81,7 +81,7 @@ class StringTest {
 
     @test fun startsWithStringForCharSequence() = withTwoCharSequenceArgs { arg1, arg2 ->
         fun String.startsWithCs(prefix: String, ignoreCase: Boolean = false): Boolean =
-            arg1(this).startsWith(arg2(prefix), ignoreCase)
+                arg1(this).startsWith(arg2(prefix), ignoreCase)
 
         assertTrue("abcd".startsWithCs("ab"))
         assertTrue("abcd".startsWithCs("abcd"))
@@ -109,8 +109,8 @@ class StringTest {
 
     @test fun endsWithStringForCharSequence() = withTwoCharSequenceArgs { arg1, arg2 ->
         fun String.endsWithCs(suffix: String, ignoreCase: Boolean = false): Boolean =
-            arg1(this).endsWith(arg2(suffix), ignoreCase)
-        
+                arg1(this).endsWith(arg2(suffix), ignoreCase)
+
         assertTrue("abcd".endsWithCs("d"))
         assertTrue("abcd".endsWithCs("abcd"))
         assertFalse("abcd".endsWithCs("b"))
@@ -123,7 +123,7 @@ class StringTest {
 
     @test fun startsWithChar() = withOneCharSequenceArg { arg1 ->
         fun String.startsWith(char: Char, ignoreCase: Boolean = false): Boolean =
-            arg1(this).startsWith(char, ignoreCase)
+                arg1(this).startsWith(char, ignoreCase)
 
         assertTrue("abcd".startsWith('a'))
         assertFalse("abcd".startsWith('b'))
@@ -134,7 +134,7 @@ class StringTest {
 
     @test fun endsWithChar() = withOneCharSequenceArg { arg1 ->
         fun String.endsWith(char: Char, ignoreCase: Boolean = false): Boolean =
-            arg1(this).endsWith(char, ignoreCase)
+                arg1(this).endsWith(char, ignoreCase)
 
         assertTrue("abcd".endsWith('d'))
         assertFalse("abcd".endsWith('b'))
@@ -145,7 +145,7 @@ class StringTest {
 
     @test fun commonPrefix() = withTwoCharSequenceArgs { arg1, arg2 ->
         fun String.commonPrefixWith(other: String, ignoreCase: Boolean = false): String =
-            arg1(this).commonPrefixWith(arg2(other), ignoreCase)
+                arg1(this).commonPrefixWith(arg2(other), ignoreCase)
 
         assertEquals("", "".commonPrefixWith(""))
         assertEquals("", "any".commonPrefixWith(""))
@@ -164,7 +164,7 @@ class StringTest {
 
     @test fun commonSuffix() = withTwoCharSequenceArgs { arg1, arg2 ->
         fun String.commonSuffixWith(other: String, ignoreCase: Boolean = false): String =
-            arg1(this).commonSuffixWith(arg2(other), ignoreCase)
+                arg1(this).commonSuffixWith(arg2(other), ignoreCase)
 
         assertEquals("", "".commonSuffixWith(""))
         assertEquals("", "any".commonSuffixWith(""))
@@ -175,7 +175,7 @@ class StringTest {
         assertEquals("strö", "strö".commonSuffixWith("BISTRÖ", ignoreCase = true))
         assertEquals("", "yearly".commonSuffixWith("HARDLY", ignoreCase = false))
         // surrogate pairs
-        val dth54  = "\uD83C\uDC58" // domino tile horizontal 5-4
+        val dth54 = "\uD83C\uDC58" // domino tile horizontal 5-4
         val kimono = "\uD83D\uDC58" // kimono
         assertEquals("", dth54.commonSuffixWith(kimono))
         assertEquals("$dth54", "d$dth54".commonSuffixWith("s$dth54"))
@@ -259,7 +259,7 @@ class StringTest {
         assertContentEquals("sae text", s.removeRange(2, 5))
         assertContentEquals("sa text", s.removeRange(2..5))
 
-        assertContentEquals(s.toString(), s.removeRange(2,2))
+        assertContentEquals(s.toString(), s.removeRange(2, 2))
 
         // symmetry with indices
         assertContentEquals("", s.removeRange(s.indices))
@@ -318,7 +318,7 @@ class StringTest {
 
     @test fun stringIterator() = withOneCharSequenceArg("239") { data ->
         var sum = 0
-        for(c in data)
+        for (c in data)
             sum += (c - '0')
         assertTrue(sum == 14)
     }
@@ -339,8 +339,8 @@ class StringTest {
         assertContentEquals("a", "\ra".trimStartCS())
         assertContentEquals("a", "\na".trimStartCS())
 
-        assertContentEquals("a=", arg1("-=-=a=").trimStart('-','='))
-        assertContentEquals("123a", arg1("ab123a").trimStart {  !it.isAsciiDigit() })
+        assertContentEquals("a=", arg1("-=-=a=").trimStart('-', '='))
+        assertContentEquals("123a", arg1("ab123a").trimStart { !it.isAsciiDigit() })
     }
 
     @test fun trimEnd() = withOneCharSequenceArg { arg1 ->
@@ -359,20 +359,20 @@ class StringTest {
         assertContentEquals("a", "a\r".trimEndCS())
         assertContentEquals("a", "a\n".trimEndCS())
 
-        assertContentEquals("=a", arg1("=a=-=-").trimEnd('-','='))
+        assertContentEquals("=a", arg1("=a=-=-").trimEnd('-', '='))
         assertContentEquals("ab123", arg1("ab123a").trimEnd { !it.isAsciiDigit() })
     }
 
     @test fun trimStartAndEnd() = withOneCharSequenceArg { arg1 ->
         val examples = arrayOf("a",
-                " a ",
-                "  a  ",
-                "  a b  ",
-                "\ta\tb\t",
-                "\t\ta\t\t",
-                "\ra\r",
-                "\na\n",
-                " \u00A0 a \u00A0 "
+                               " a ",
+                               "  a  ",
+                               "  a b  ",
+                               "\ta\tb\t",
+                               "\t\ta\t\t",
+                               "\ra\r",
+                               "\na\n",
+                               " \u00A0 a \u00A0 "
         )
 
         for ((source, example) in examples.map { it to arg1(it) }) {
@@ -381,7 +381,7 @@ class StringTest {
         }
 
         val examplesForPredicate = arrayOf("123",
-                "-=123=-"
+                                           "-=123=-"
         )
 
         val trimChars = charArrayOf('-', '=')
@@ -604,7 +604,7 @@ class StringTest {
         assertEquals(4, string.lastIndexOf('e'))
         assertEquals(2, string.lastIndexOf('e', 3))
 
-        for (startIndex in -1..string.length+1) {
+        for (startIndex in -1..string.length + 1) {
             assertEquals(string.indexOfAny(charArrayOf('e'), startIndex), string.indexOf('e', startIndex))
             assertEquals(string.lastIndexOfAny(charArrayOf('e'), startIndex), string.lastIndexOf('e', startIndex))
         }
@@ -620,7 +620,7 @@ class StringTest {
         assertEquals(2, string.lastIndexOf('e', 3, ignoreCase = true))
 
 
-        for (startIndex in -1..string.length+1){
+        for (startIndex in -1..string.length + 1) {
             assertEquals(string.indexOfAny(charArrayOf('e'), startIndex, ignoreCase = true), string.indexOf('E', startIndex, ignoreCase = true))
             assertEquals(string.lastIndexOfAny(charArrayOf('E'), startIndex, ignoreCase = true), string.lastIndexOf('e', startIndex, ignoreCase = true))
         }
@@ -682,8 +682,8 @@ class StringTest {
 
     @test fun replaceFirst() {
         val input = "AbbabA"
-        assertEquals("Abb${'$'}bA", input.replaceFirst('a','$'))
-        assertEquals("${'$'}bbabA", input.replaceFirst('a','$', ignoreCase = true))
+        assertEquals("Abb${'$'}bA", input.replaceFirst('a', '$'))
+        assertEquals("${'$'}bbabA", input.replaceFirst('a', '$', ignoreCase = true))
         // doesn't pass in Rhino JS
         // assertEquals("schrodinger", "schrÖdinger".replaceFirst('ö', 'o', ignoreCase = true))
 
@@ -712,6 +712,16 @@ class StringTest {
             assertEquals(1, list.size)
             assertEquals(s.toString(), list[0])
         }
+    }
+
+    @test fun occurencesOf() {
+        assertEquals("abaabaaababac".occurrencesOf("abaa").toList(), listOf(0, 3))
+        assertEquals("Abaabaaababac".occurrencesOf("abaa").toList(), listOf(3))
+        assertEquals("Abaabaaababac".occurrencesOf("abaa", ignoreCase = true).toList(), listOf(0, 3))
+        assertEquals("multi\nline\nstring\nmulti".occurrencesOf("multi").toList(), listOf(0, 18))
+        assertEquals("aaba".occurrencesOf("a").toList(), listOf(0, 1, 3))
+        assertEquals("".occurrencesOf("abc").count(), 0)
+        assertEquals("abc".occurrencesOf("").count(), 0)
     }
 
     @test fun forEach() = withOneCharSequenceArg("abcd1234") { data ->
@@ -836,7 +846,7 @@ class StringTest {
     @test fun fold() = withOneCharSequenceArg { arg1 ->
         // calculate number of digits in the string
         val data = arg1("a1b2c3def")
-        val result = data.fold(0, { digits, c -> if(c.isAsciiDigit()) digits + 1 else digits } )
+        val result = data.fold(0, { digits, c -> if (c.isAsciiDigit()) digits + 1 else digits })
         assertEquals(3, result)
 
         //simulate all method
@@ -849,7 +859,7 @@ class StringTest {
     @test fun foldRight() = withOneCharSequenceArg { arg1 ->
         // calculate number of digits in the string
         val data = arg1("a1b2c3def")
-        val result = data.foldRight(0, { c, digits -> if(c.isAsciiDigit()) digits + 1 else digits })
+        val result = data.foldRight(0, { c, digits -> if (c.isAsciiDigit()) digits + 1 else digits })
         assertEquals(3, result)
 
         //simulate all method
@@ -917,8 +927,8 @@ class StringTest {
         // group characters by their case
         val result = data.groupBy { it.isAsciiUpperCase() }
         assertEquals(2, result.size)
-        assertEquals(listOf('a','b','b','a','c'), result[false])
-        assertEquals(listOf('A','A','B','D'), result[true])
+        assertEquals(listOf('a', 'b', 'b', 'a', 'c'), result[false])
+        assertEquals(listOf('A', 'A', 'B', 'D'), result[true])
     }
 
     @test fun joinToString() {
@@ -1152,4 +1162,5 @@ ${"    "}
         assertEquals("  ABC\n   \n  123", "ABC\n   \n123".prependIndent("  "))
         assertEquals("  ", "".prependIndent("  "))
     }
+
 }

--- a/libraries/stdlib/test/text/StringTest.kt
+++ b/libraries/stdlib/test/text/StringTest.kt
@@ -715,12 +715,28 @@ class StringTest {
     }
 
     @test fun occurencesOf() {
+        // Multiple overlapping occurances
         assertEquals("abaabaaababac".occurrencesOf("abaa").toList(), listOf(0, 3))
         assertEquals("Abaabaaababac".occurrencesOf("abaa").toList(), listOf(3))
         assertEquals("Abaabaaababac".occurrencesOf("abaa", ignoreCase = true).toList(), listOf(0, 3))
+        assertEquals("abaabaaababac".occurrencesOf("abAa", ignoreCase = true).toList(), listOf(0, 3))
+        // Big and small theta
+        assertEquals("\u0398\u0398\u0398".occurrencesOf("\u0398\u0398").toList(), listOf(0, 1))
+        assertEquals("\u03b8\u0398\u0398".occurrencesOf("\u0398\u0398").toList(), listOf(1))
+
+        // Special character test
         assertEquals("multi\nline\nstring\nmulti".occurrencesOf("multi").toList(), listOf(0, 18))
-        assertEquals("aaba".occurrencesOf("a").toList(), listOf(0, 1, 3))
-        assertEquals("".occurrencesOf("abc").count(), 0)
+
+        // Single character test
+        assertEquals("aabA".occurrencesOf("a").toList(), listOf(0, 1))
+        assertEquals("aabA".occurrencesOf("a", ignoreCase = true).toList(), listOf(0, 1, 3))
+        assertEquals("aabA".occurrencesOf("A", ignoreCase = true).toList(), listOf(0, 1, 3))
+        // Big and small theta
+        assertEquals("\u0398\u0398\u0398".occurrencesOf("\u0398").toList(), listOf(0, 1, 2))
+        assertEquals("\u03b8\u0398\u0398".occurrencesOf("\u0398").toList(), listOf(1, 2))
+
+        // Early return test
+        assertEquals("z".occurrencesOf("abc").count(), 0)
         assertEquals("abc".occurrencesOf("").count(), 0)
     }
 

--- a/libraries/stdlib/test/text/StringTest.kt
+++ b/libraries/stdlib/test/text/StringTest.kt
@@ -110,7 +110,7 @@ class StringTest {
     @test fun endsWithStringForCharSequence() = withTwoCharSequenceArgs { arg1, arg2 ->
         fun String.endsWithCs(suffix: String, ignoreCase: Boolean = false): Boolean =
             arg1(this).endsWith(arg2(suffix), ignoreCase)
-        
+
         assertTrue("abcd".endsWithCs("d"))
         assertTrue("abcd".endsWithCs("abcd"))
         assertFalse("abcd".endsWithCs("b"))
@@ -737,7 +737,7 @@ class StringTest {
 
         // Early return test
         assertEquals("z".occurrencesOf("abc").count(), 0)
-        assertEquals("abc".occurrencesOf("").count(), 0)
+        assertEquals("abc".occurrencesOf("").toList(), listOf(0, 1, 2))
     }
 
     @test fun forEach() = withOneCharSequenceArg("abcd1234") { data ->

--- a/libraries/stdlib/test/text/StringTest.kt
+++ b/libraries/stdlib/test/text/StringTest.kt
@@ -721,6 +721,8 @@ class StringTest {
         assertEquals(listOf(0, 3), "Abaabaaababac".occurrencesOf("abaa", ignoreCase = true, matchOverlapping = true).toList())
         assertEquals(listOf(0, 3), "abaabaaababac".occurrencesOf("abAa", ignoreCase = true, matchOverlapping = true).toList())
         assertEquals(listOf(0, 4), "AAABAAABAAAB".occurrencesOf("AAABAAAB", matchOverlapping = true).toList())
+        assertEquals(listOf(0, 3), "AABAABAABA".occurrencesOf("aaBaAba", matchOverlapping = true, ignoreCase = true).toList())
+        assertEquals(emptyList(), "AABAABAABA".occurrencesOf("aaBaAba", matchOverlapping = true, ignoreCase = false).toList())
 
         // Big and small theta
         assertEquals(listOf(0, 1), "\u0398\u0398\u0398".occurrencesOf("\u0398\u0398", matchOverlapping = true).toList())

--- a/libraries/stdlib/test/text/StringTest.kt
+++ b/libraries/stdlib/test/text/StringTest.kt
@@ -727,10 +727,16 @@ class StringTest {
         // Special character test
         assertEquals("multi\nline\nstring\nmulti".occurrencesOf("multi").toList(), listOf(0, 18))
 
-        // Single character test
+        // Single character test as string
         assertEquals("aabA".occurrencesOf("a").toList(), listOf(0, 1))
         assertEquals("aabA".occurrencesOf("a", ignoreCase = true).toList(), listOf(0, 1, 3))
         assertEquals("aabA".occurrencesOf("A", ignoreCase = true).toList(), listOf(0, 1, 3))
+
+        // Single character test as character
+        assertEquals("aabA".occurrencesOf('a').toList(), listOf(0, 1))
+        assertEquals("aabA".occurrencesOf('a', ignoreCase = true).toList(), listOf(0, 1, 3))
+        assertEquals("aabA".occurrencesOf('A', ignoreCase = true).toList(), listOf(0, 1, 3))
+
         // Big and small theta
         assertEquals("\u0398\u0398\u0398".occurrencesOf("\u0398").toList(), listOf(0, 1, 2))
         assertEquals("\u03b8\u0398\u0398".occurrencesOf("\u0398").toList(), listOf(1, 2))
@@ -738,9 +744,9 @@ class StringTest {
 
         // Early return test
         assertEquals("z".occurrencesOf("abc").count(), 0)
-        assertEquals("abc".occurrencesOf("").toList(), listOf(0, 1, 2))
+        assertEquals("abc".occurrencesOf("").toList(), listOf(0, 1, 2, 3))
 
-        // Tests for non-overlappning option
+        // Tests for non-overlapping option
         assertEquals("Abaabaaababac".occurrencesOf("abaa", matchOverlapping = false).toList(), listOf(3))
         assertEquals("Abaabaaababac".occurrencesOf("abaa", ignoreCase = true, matchOverlapping = false).toList(), listOf(0))
     }

--- a/libraries/stdlib/test/text/StringTest.kt
+++ b/libraries/stdlib/test/text/StringTest.kt
@@ -31,7 +31,6 @@ fun assertContentEquals(expected: String, actual: CharSequence, message: String?
 
 // helper predicates available on both platforms
 fun Char.isAsciiDigit() = this in '0'..'9'
-
 fun Char.isAsciiLetter() = this in 'A'..'Z' || this in 'a'..'z'
 fun Char.isAsciiUpperCase() = this in 'A'..'Z'
 
@@ -40,17 +39,18 @@ class StringTest {
     @test fun isEmptyAndBlank() = withOneCharSequenceArg { arg1 ->
 
         val cases = listOf(
-                IsEmptyCase(null, isNull = true),
-                IsEmptyCase("", isEmpty = true, isBlank = true),
-                IsEmptyCase("  \r\n\t\u00A0", isBlank = true),
-                IsEmptyCase(" Some ")
+            IsEmptyCase(null,              isNull = true),
+            IsEmptyCase("",                isEmpty = true, isBlank = true),
+            IsEmptyCase("  \r\n\t\u00A0",  isBlank = true),
+            IsEmptyCase(" Some ")
         )
 
         for (case in cases) {
             val value = case.value?.let { arg1(it) }
             assertEquals(case.isNull || case.isEmpty, value.isNullOrEmpty(), "failed for case '$value'")
             assertEquals(case.isNull || case.isBlank, value.isNullOrBlank(), "failed for case '$value'")
-            if (value != null) {
+            if (value != null)
+            {
                 assertEquals(case.isEmpty, value.isEmpty(), "failed for case '$value'")
                 assertEquals(case.isBlank, value.isBlank(), "failed for case '$value'")
             }
@@ -81,7 +81,7 @@ class StringTest {
 
     @test fun startsWithStringForCharSequence() = withTwoCharSequenceArgs { arg1, arg2 ->
         fun String.startsWithCs(prefix: String, ignoreCase: Boolean = false): Boolean =
-                arg1(this).startsWith(arg2(prefix), ignoreCase)
+            arg1(this).startsWith(arg2(prefix), ignoreCase)
 
         assertTrue("abcd".startsWithCs("ab"))
         assertTrue("abcd".startsWithCs("abcd"))
@@ -109,8 +109,8 @@ class StringTest {
 
     @test fun endsWithStringForCharSequence() = withTwoCharSequenceArgs { arg1, arg2 ->
         fun String.endsWithCs(suffix: String, ignoreCase: Boolean = false): Boolean =
-                arg1(this).endsWith(arg2(suffix), ignoreCase)
-
+            arg1(this).endsWith(arg2(suffix), ignoreCase)
+        
         assertTrue("abcd".endsWithCs("d"))
         assertTrue("abcd".endsWithCs("abcd"))
         assertFalse("abcd".endsWithCs("b"))
@@ -123,7 +123,7 @@ class StringTest {
 
     @test fun startsWithChar() = withOneCharSequenceArg { arg1 ->
         fun String.startsWith(char: Char, ignoreCase: Boolean = false): Boolean =
-                arg1(this).startsWith(char, ignoreCase)
+            arg1(this).startsWith(char, ignoreCase)
 
         assertTrue("abcd".startsWith('a'))
         assertFalse("abcd".startsWith('b'))
@@ -134,7 +134,7 @@ class StringTest {
 
     @test fun endsWithChar() = withOneCharSequenceArg { arg1 ->
         fun String.endsWith(char: Char, ignoreCase: Boolean = false): Boolean =
-                arg1(this).endsWith(char, ignoreCase)
+            arg1(this).endsWith(char, ignoreCase)
 
         assertTrue("abcd".endsWith('d'))
         assertFalse("abcd".endsWith('b'))
@@ -145,7 +145,7 @@ class StringTest {
 
     @test fun commonPrefix() = withTwoCharSequenceArgs { arg1, arg2 ->
         fun String.commonPrefixWith(other: String, ignoreCase: Boolean = false): String =
-                arg1(this).commonPrefixWith(arg2(other), ignoreCase)
+            arg1(this).commonPrefixWith(arg2(other), ignoreCase)
 
         assertEquals("", "".commonPrefixWith(""))
         assertEquals("", "any".commonPrefixWith(""))
@@ -164,7 +164,7 @@ class StringTest {
 
     @test fun commonSuffix() = withTwoCharSequenceArgs { arg1, arg2 ->
         fun String.commonSuffixWith(other: String, ignoreCase: Boolean = false): String =
-                arg1(this).commonSuffixWith(arg2(other), ignoreCase)
+            arg1(this).commonSuffixWith(arg2(other), ignoreCase)
 
         assertEquals("", "".commonSuffixWith(""))
         assertEquals("", "any".commonSuffixWith(""))
@@ -175,7 +175,7 @@ class StringTest {
         assertEquals("strö", "strö".commonSuffixWith("BISTRÖ", ignoreCase = true))
         assertEquals("", "yearly".commonSuffixWith("HARDLY", ignoreCase = false))
         // surrogate pairs
-        val dth54 = "\uD83C\uDC58" // domino tile horizontal 5-4
+        val dth54  = "\uD83C\uDC58" // domino tile horizontal 5-4
         val kimono = "\uD83D\uDC58" // kimono
         assertEquals("", dth54.commonSuffixWith(kimono))
         assertEquals("$dth54", "d$dth54".commonSuffixWith("s$dth54"))
@@ -259,7 +259,7 @@ class StringTest {
         assertContentEquals("sae text", s.removeRange(2, 5))
         assertContentEquals("sa text", s.removeRange(2..5))
 
-        assertContentEquals(s.toString(), s.removeRange(2, 2))
+        assertContentEquals(s.toString(), s.removeRange(2,2))
 
         // symmetry with indices
         assertContentEquals("", s.removeRange(s.indices))
@@ -318,7 +318,7 @@ class StringTest {
 
     @test fun stringIterator() = withOneCharSequenceArg("239") { data ->
         var sum = 0
-        for (c in data)
+        for(c in data)
             sum += (c - '0')
         assertTrue(sum == 14)
     }
@@ -339,8 +339,8 @@ class StringTest {
         assertContentEquals("a", "\ra".trimStartCS())
         assertContentEquals("a", "\na".trimStartCS())
 
-        assertContentEquals("a=", arg1("-=-=a=").trimStart('-', '='))
-        assertContentEquals("123a", arg1("ab123a").trimStart { !it.isAsciiDigit() })
+        assertContentEquals("a=", arg1("-=-=a=").trimStart('-','='))
+        assertContentEquals("123a", arg1("ab123a").trimStart {  !it.isAsciiDigit() })
     }
 
     @test fun trimEnd() = withOneCharSequenceArg { arg1 ->
@@ -359,20 +359,20 @@ class StringTest {
         assertContentEquals("a", "a\r".trimEndCS())
         assertContentEquals("a", "a\n".trimEndCS())
 
-        assertContentEquals("=a", arg1("=a=-=-").trimEnd('-', '='))
+        assertContentEquals("=a", arg1("=a=-=-").trimEnd('-','='))
         assertContentEquals("ab123", arg1("ab123a").trimEnd { !it.isAsciiDigit() })
     }
 
     @test fun trimStartAndEnd() = withOneCharSequenceArg { arg1 ->
         val examples = arrayOf("a",
-                               " a ",
-                               "  a  ",
-                               "  a b  ",
-                               "\ta\tb\t",
-                               "\t\ta\t\t",
-                               "\ra\r",
-                               "\na\n",
-                               " \u00A0 a \u00A0 "
+                " a ",
+                "  a  ",
+                "  a b  ",
+                "\ta\tb\t",
+                "\t\ta\t\t",
+                "\ra\r",
+                "\na\n",
+                " \u00A0 a \u00A0 "
         )
 
         for ((source, example) in examples.map { it to arg1(it) }) {
@@ -381,7 +381,7 @@ class StringTest {
         }
 
         val examplesForPredicate = arrayOf("123",
-                                           "-=123=-"
+                "-=123=-"
         )
 
         val trimChars = charArrayOf('-', '=')
@@ -604,7 +604,7 @@ class StringTest {
         assertEquals(4, string.lastIndexOf('e'))
         assertEquals(2, string.lastIndexOf('e', 3))
 
-        for (startIndex in -1..string.length + 1) {
+        for (startIndex in -1..string.length+1) {
             assertEquals(string.indexOfAny(charArrayOf('e'), startIndex), string.indexOf('e', startIndex))
             assertEquals(string.lastIndexOfAny(charArrayOf('e'), startIndex), string.lastIndexOf('e', startIndex))
         }
@@ -620,7 +620,7 @@ class StringTest {
         assertEquals(2, string.lastIndexOf('e', 3, ignoreCase = true))
 
 
-        for (startIndex in -1..string.length + 1) {
+        for (startIndex in -1..string.length+1){
             assertEquals(string.indexOfAny(charArrayOf('e'), startIndex, ignoreCase = true), string.indexOf('E', startIndex, ignoreCase = true))
             assertEquals(string.lastIndexOfAny(charArrayOf('E'), startIndex, ignoreCase = true), string.lastIndexOf('e', startIndex, ignoreCase = true))
         }
@@ -682,8 +682,8 @@ class StringTest {
 
     @test fun replaceFirst() {
         val input = "AbbabA"
-        assertEquals("Abb${'$'}bA", input.replaceFirst('a', '$'))
-        assertEquals("${'$'}bbabA", input.replaceFirst('a', '$', ignoreCase = true))
+        assertEquals("Abb${'$'}bA", input.replaceFirst('a','$'))
+        assertEquals("${'$'}bbabA", input.replaceFirst('a','$', ignoreCase = true))
         // doesn't pass in Rhino JS
         // assertEquals("schrodinger", "schrÖdinger".replaceFirst('ö', 'o', ignoreCase = true))
 
@@ -846,7 +846,7 @@ class StringTest {
     @test fun fold() = withOneCharSequenceArg { arg1 ->
         // calculate number of digits in the string
         val data = arg1("a1b2c3def")
-        val result = data.fold(0, { digits, c -> if (c.isAsciiDigit()) digits + 1 else digits })
+        val result = data.fold(0, { digits, c -> if(c.isAsciiDigit()) digits + 1 else digits } )
         assertEquals(3, result)
 
         //simulate all method
@@ -859,7 +859,7 @@ class StringTest {
     @test fun foldRight() = withOneCharSequenceArg { arg1 ->
         // calculate number of digits in the string
         val data = arg1("a1b2c3def")
-        val result = data.foldRight(0, { c, digits -> if (c.isAsciiDigit()) digits + 1 else digits })
+        val result = data.foldRight(0, { c, digits -> if(c.isAsciiDigit()) digits + 1 else digits })
         assertEquals(3, result)
 
         //simulate all method
@@ -927,8 +927,8 @@ class StringTest {
         // group characters by their case
         val result = data.groupBy { it.isAsciiUpperCase() }
         assertEquals(2, result.size)
-        assertEquals(listOf('a', 'b', 'b', 'a', 'c'), result[false])
-        assertEquals(listOf('A', 'A', 'B', 'D'), result[true])
+        assertEquals(listOf('a','b','b','a','c'), result[false])
+        assertEquals(listOf('A','A','B','D'), result[true])
     }
 
     @test fun joinToString() {
@@ -1162,5 +1162,4 @@ ${"    "}
         assertEquals("  ABC\n   \n  123", "ABC\n   \n123".prependIndent("  "))
         assertEquals("  ", "".prependIndent("  "))
     }
-
 }

--- a/libraries/stdlib/test/text/StringTest.kt
+++ b/libraries/stdlib/test/text/StringTest.kt
@@ -714,41 +714,44 @@ class StringTest {
         }
     }
 
-    @test fun occurencesOf() {
-        // Multiple overlapping occurances
-        assertEquals("abaabaaababac".occurrencesOf("abaa", matchOverlapping = true).toList(), listOf(0, 3))
-        assertEquals("Abaabaaababac".occurrencesOf("abaa", matchOverlapping = true).toList(), listOf(3))
-        assertEquals("Abaabaaababac".occurrencesOf("abaa", ignoreCase = true, matchOverlapping = true).toList(), listOf(0, 3))
-        assertEquals("abaabaaababac".occurrencesOf("abAa", ignoreCase = true, matchOverlapping = true).toList(), listOf(0, 3))
+    @test fun occurrencesOf() {
+        // Multiple overlapping occurrences
+        assertEquals(listOf(0, 3), "abaabaaababac".occurrencesOf("abaa", matchOverlapping = true).toList())
+        assertEquals(listOf(3), "Abaabaaababac".occurrencesOf("abaa", matchOverlapping = true).toList())
+        assertEquals(listOf(0, 3), "Abaabaaababac".occurrencesOf("abaa", ignoreCase = true, matchOverlapping = true).toList())
+        assertEquals(listOf(0, 3), "abaabaaababac".occurrencesOf("abAa", ignoreCase = true, matchOverlapping = true).toList())
+        assertEquals(listOf(0, 4), "AAABAAABAAAB".occurrencesOf("AAABAAAB", matchOverlapping = true).toList())
+
         // Big and small theta
-        assertEquals("\u0398\u0398\u0398".occurrencesOf("\u0398\u0398", matchOverlapping = true).toList(), listOf(0, 1))
-        assertEquals("\u03b8\u0398\u0398".occurrencesOf("\u0398\u0398").toList(), listOf(1))
+        assertEquals(listOf(0, 1), "\u0398\u0398\u0398".occurrencesOf("\u0398\u0398", matchOverlapping = true).toList())
+        assertEquals(listOf(1), "\u03b8\u0398\u0398".occurrencesOf("\u0398\u0398").toList())
 
         // Special character test
-        assertEquals("multi\nline\nstring\nmulti".occurrencesOf("multi").toList(), listOf(0, 18))
+        assertEquals(listOf(0, 18), "multi\nline\nstring\nmulti".occurrencesOf("multi").toList())
 
         // Single character test as string
-        assertEquals("aabA".occurrencesOf("a").toList(), listOf(0, 1))
-        assertEquals("aabA".occurrencesOf("a", ignoreCase = true).toList(), listOf(0, 1, 3))
-        assertEquals("aabA".occurrencesOf("A", ignoreCase = true).toList(), listOf(0, 1, 3))
+        assertEquals(listOf(0, 1), "aabA".occurrencesOf("a").toList())
+        assertEquals(listOf(0, 1, 3), "aabA".occurrencesOf("a", ignoreCase = true).toList())
+        assertEquals(listOf(0, 1, 3), "aabA".occurrencesOf("A", ignoreCase = true).toList())
 
         // Single character test as character
-        assertEquals("aabA".occurrencesOf('a').toList(), listOf(0, 1))
-        assertEquals("aabA".occurrencesOf('a', ignoreCase = true).toList(), listOf(0, 1, 3))
-        assertEquals("aabA".occurrencesOf('A', ignoreCase = true).toList(), listOf(0, 1, 3))
+        assertEquals(listOf(0, 1), "aabA".occurrencesOf('a').toList())
+        assertEquals(listOf(0, 1, 3), "aabA".occurrencesOf('a', ignoreCase = true).toList())
+        assertEquals(listOf(0, 1, 3), "aabA".occurrencesOf('A', ignoreCase = true).toList())
 
         // Big and small theta
-        assertEquals("\u0398\u0398\u0398".occurrencesOf("\u0398").toList(), listOf(0, 1, 2))
-        assertEquals("\u03b8\u0398\u0398".occurrencesOf("\u0398").toList(), listOf(1, 2))
-        assertEquals("\u03b8\u0398\u0398".occurrencesOf("\u0398", ignoreCase = true).toList(), listOf(0, 1, 2))
+        assertEquals(listOf(0, 1, 2), "\u0398\u0398\u0398".occurrencesOf("\u0398").toList())
+        assertEquals(listOf(1, 2), "\u03b8\u0398\u0398".occurrencesOf("\u0398").toList())
+        assertEquals(listOf(0, 1, 2), "\u03b8\u0398\u0398".occurrencesOf("\u0398", ignoreCase = true).toList())
 
         // Early return test
-        assertEquals("z".occurrencesOf("abc").count(), 0)
-        assertEquals("abc".occurrencesOf("").toList(), listOf(0, 1, 2, 3))
+        assertEquals(0, "z".occurrencesOf("abc").count())
+        assertEquals(listOf(0, 1, 2, 3), "abc".occurrencesOf("").toList())
 
         // Tests for non-overlapping option
-        assertEquals("Abaabaaababac".occurrencesOf("abaa", matchOverlapping = false).toList(), listOf(3))
-        assertEquals("Abaabaaababac".occurrencesOf("abaa", ignoreCase = true, matchOverlapping = false).toList(), listOf(0))
+        assertEquals(listOf(3), "Abaabaaababac".occurrencesOf("abaa", matchOverlapping = false).toList())
+        assertEquals(listOf(0), "Abaabaaababac".occurrencesOf("abaa", ignoreCase = true, matchOverlapping = false).toList())
+        assertEquals(emptyList<Int>(), "AAABAAABAAAB".occurrencesOf("AAABAAB").toList())
     }
 
     @test fun forEach() = withOneCharSequenceArg("abcd1234") { data ->

--- a/libraries/stdlib/test/text/StringTest.kt
+++ b/libraries/stdlib/test/text/StringTest.kt
@@ -716,12 +716,12 @@ class StringTest {
 
     @test fun occurencesOf() {
         // Multiple overlapping occurances
-        assertEquals("abaabaaababac".occurrencesOf("abaa").toList(), listOf(0, 3))
-        assertEquals("Abaabaaababac".occurrencesOf("abaa").toList(), listOf(3))
-        assertEquals("Abaabaaababac".occurrencesOf("abaa", ignoreCase = true).toList(), listOf(0, 3))
-        assertEquals("abaabaaababac".occurrencesOf("abAa", ignoreCase = true).toList(), listOf(0, 3))
+        assertEquals("abaabaaababac".occurrencesOf("abaa", matchOverlapping = true).toList(), listOf(0, 3))
+        assertEquals("Abaabaaababac".occurrencesOf("abaa", matchOverlapping = true).toList(), listOf(3))
+        assertEquals("Abaabaaababac".occurrencesOf("abaa", ignoreCase = true, matchOverlapping = true).toList(), listOf(0, 3))
+        assertEquals("abaabaaababac".occurrencesOf("abAa", ignoreCase = true, matchOverlapping = true).toList(), listOf(0, 3))
         // Big and small theta
-        assertEquals("\u0398\u0398\u0398".occurrencesOf("\u0398\u0398").toList(), listOf(0, 1))
+        assertEquals("\u0398\u0398\u0398".occurrencesOf("\u0398\u0398", matchOverlapping = true).toList(), listOf(0, 1))
         assertEquals("\u03b8\u0398\u0398".occurrencesOf("\u0398\u0398").toList(), listOf(1))
 
         // Special character test
@@ -734,10 +734,15 @@ class StringTest {
         // Big and small theta
         assertEquals("\u0398\u0398\u0398".occurrencesOf("\u0398").toList(), listOf(0, 1, 2))
         assertEquals("\u03b8\u0398\u0398".occurrencesOf("\u0398").toList(), listOf(1, 2))
+        assertEquals("\u03b8\u0398\u0398".occurrencesOf("\u0398", ignoreCase = true).toList(), listOf(0, 1, 2))
 
         // Early return test
         assertEquals("z".occurrencesOf("abc").count(), 0)
         assertEquals("abc".occurrencesOf("").toList(), listOf(0, 1, 2))
+
+        // Tests for non-overlappning option
+        assertEquals("Abaabaaababac".occurrencesOf("abaa", matchOverlapping = false).toList(), listOf(3))
+        assertEquals("Abaabaaababac".occurrencesOf("abaa", ignoreCase = true, matchOverlapping = false).toList(), listOf(0))
     }
 
     @test fun forEach() = withOneCharSequenceArg("abcd1234") { data ->


### PR DESCRIPTION
Related KEEP proposal: [KEEP-20](https://github.com/Kotlin/KEEP/issues/20).

The goal of this pull request is to add an extension method `CharSequence.occurencesOf`, taking two parameters:
1. A pattern to look for in the receiver
2. A flag `ignoreCase`.

It returns a lazy sequence of indices at which the pattern occurs in the receiver.

It is based on the evidentially `O(n)` Knuth-Morris-Pratt algorithm, where `n` is the length of the text to search in. Using `indexOf` repeatedly would have runtime `O(nk)`, where `k` is the length of the pattern.

An abstract use case would be finding all occurences of a short pattern of length `k` in a long text of length `n`, which would be `O(nk)` with `indexOf`, but is `O(n)` with `occurencesOf`. A more concrete use case: Suppose we have a large number of texts (perhaps in a search engine) we would like to run a search query against. With `occurencesOf`, we could get all relevant parts of the text very efficiently, maybe get a substring of the occurence 100 chars before and after, obtaining a summary of where the word occurs. 

This PR of course also includes tests.
