### PR TITLE
KT-9183 - Annotation processing isn't processing all field and method annotations unless the names are unique

### DIFF
--- a/libraries/tools/kotlin-annotation-processing/src/main/kotlin/org/jetbrains/kotlin/annotation/AnnotationProcessorWrapper.kt
+++ b/libraries/tools/kotlin-annotation-processing/src/main/kotlin/org/jetbrains/kotlin/annotation/AnnotationProcessorWrapper.kt
@@ -37,18 +37,19 @@ class AnnotatedClassDescriptor(classFqName: String) : AnnotatedElementDescriptor
 }
 
 class AnnotatedMethodDescriptor(classFqName: String, public val methodName: String) : AnnotatedElementDescriptor(classFqName) {
-    override fun equals(other: Any?) = other is AnnotatedMethodDescriptor && methodName == other.methodName
+    override fun equals(other: Any?) = other is AnnotatedMethodDescriptor && methodName == other.methodName && classFqName == other.classFqName
 
-    override fun hashCode() = methodName.hashCode()
+    override fun hashCode() =  methodName.hashCode() + classFqName.hashCode()
 }
+
 class AnnotatedConstructorDescriptor(classFqName: String) : AnnotatedElementDescriptor(classFqName) {
     // use referential equality
 }
 
 class AnnotatedFieldDescriptor(classFqName: String, public val fieldName: String) : AnnotatedElementDescriptor(classFqName) {
-    override fun equals(other: Any?) = other is AnnotatedFieldDescriptor && fieldName == other.fieldName
+    override fun equals(other: Any?) = other is AnnotatedFieldDescriptor && fieldName == other.fieldName && classFqName == other.classFqName
 
-    override fun hashCode() = fieldName.hashCode()
+    override fun hashCode() = fieldName.hashCode() + classFqName.hashCode()
 }
 
 public abstract class AnnotationProcessorWrapper(

--- a/libraries/tools/kotlin-annotation-processing/src/test/kotlin/org/jetbrains/kotlin/annotation/AnnotationListParseTest.kt
+++ b/libraries/tools/kotlin-annotation-processing/src/test/kotlin/org/jetbrains/kotlin/annotation/AnnotationListParseTest.kt
@@ -47,6 +47,8 @@ public class AnnotationListParseTest {
     @Test
     fun testDeclarations() = doTest("classDeclarations")
 
+    @Test
+    fun testSameMethodDifferentClasses() = doTest("sameMethodDifferentClasses")
 
     private val resourcesRootFile = File("src/test/resources/parse")
 
@@ -91,7 +93,7 @@ public class AnnotationListParseTest {
             Assert.fail("Expected data file did not exist. Generating: " + expectedFile)
         }
 
-        val expectedText = expectedFile.readText().replace(lineSeparator, "\n")
+        val expectedText = expectedFile.readText().replace(lineSeparator, "\n").trim('\n', ' ', '\t')
 
         assertEquals(expectedText, actualText)
     }

--- a/libraries/tools/kotlin-annotation-processing/src/test/resources/parse/platformStatic/parsed.txt
+++ b/libraries/tools/kotlin-annotation-processing/src/test/resources/parse/platformStatic/parsed.txt
@@ -1,3 +1,5 @@
+kotlin.inline org.test.SomeClass a
 kotlin.inline org.test.SomeClass.Companion a
+kotlin.platform.platformStatic org.test.SomeClass a
 kotlin.platform.platformStatic org.test.SomeClass.Companion a
 org.jetbrains.annotations.NotNull org.test.SomeClass.Companion access$init$0

--- a/libraries/tools/kotlin-annotation-processing/src/test/resources/parse/sameMethodDifferentClasses/annotations.txt
+++ b/libraries/tools/kotlin-annotation-processing/src/test/resources/parse/sameMethodDifferentClasses/annotations.txt
@@ -1,0 +1,6 @@
+a org.test.SomeAnnotation 0
+p org.test 0
+d 0/SomeClass
+m 0 0/SomeClass annotatedFunction
+d 0/AnotherClass
+m 0 0/AnotherClass annotatedFunction

--- a/libraries/tools/kotlin-annotation-processing/src/test/resources/parse/sameMethodDifferentClasses/parsed.txt
+++ b/libraries/tools/kotlin-annotation-processing/src/test/resources/parse/sameMethodDifferentClasses/parsed.txt
@@ -1,0 +1,4 @@
+org.test.SomeAnnotation org.test.AnotherClass annotatedFunction
+org.test.SomeAnnotation org.test.SomeClass annotatedFunction
+org.test.AnotherClass
+org.test.SomeClass


### PR DESCRIPTION
Took a stab at fixing what I thought the bug with - https://youtrack.jetbrains.com/issue/KT-9183 - was

I believe there are probably a few issues with kapt processing (i.e incremental builds), but the one which was blocking me was that field names and method names had to be unique across annotations.   

This change broke the original `AnnotationListParseTest.testPlatformStatic` test. I updated the test to, so that it doesn't fail, but I thought I should bring it to your attention.

Hopefully it helps, if only to provide a test which shows my problem.