### PR TITLE
kapt: Support same annotation on Foo.baz and Bar.baz

### DIFF
--- a/libraries/tools/kotlin-annotation-processing/src/main/kotlin/org/jetbrains/kotlin/annotation/AnnotationProcessorWrapper.kt
+++ b/libraries/tools/kotlin-annotation-processing/src/main/kotlin/org/jetbrains/kotlin/annotation/AnnotationProcessorWrapper.kt
@@ -37,18 +37,18 @@ class AnnotatedClassDescriptor(classFqName: String) : AnnotatedElementDescriptor
 }
 
 class AnnotatedMethodDescriptor(classFqName: String, public val methodName: String) : AnnotatedElementDescriptor(classFqName) {
-    override fun equals(other: Any?) = other is AnnotatedMethodDescriptor && methodName == other.methodName
+    override fun equals(other: Any?) = other is AnnotatedMethodDescriptor && methodName == other.methodName && classFqName == other.classFqName
 
-    override fun hashCode() = methodName.hashCode()
+    override fun hashCode() = 31 * classFqName.hashCode() + methodName.hashCode()
 }
 class AnnotatedConstructorDescriptor(classFqName: String) : AnnotatedElementDescriptor(classFqName) {
     // use referential equality
 }
 
 class AnnotatedFieldDescriptor(classFqName: String, public val fieldName: String) : AnnotatedElementDescriptor(classFqName) {
-    override fun equals(other: Any?) = other is AnnotatedFieldDescriptor && fieldName == other.fieldName
+    override fun equals(other: Any?) = other is AnnotatedFieldDescriptor && fieldName == other.fieldName && classFqName == other.classFqName
 
-    override fun hashCode() = fieldName.hashCode()
+    override fun hashCode() = 31 * classFqName.hashCode() + fieldName.hashCode()
 }
 
 public abstract class AnnotationProcessorWrapper(

--- a/libraries/tools/kotlin-annotation-processing/src/test/kotlin/org/jetbrains/kotlin/annotation/AnnotationListParseTest.kt
+++ b/libraries/tools/kotlin-annotation-processing/src/test/kotlin/org/jetbrains/kotlin/annotation/AnnotationListParseTest.kt
@@ -39,9 +39,6 @@ public class AnnotationListParseTest {
     fun testNestedClasses() = doTest("nestedClasses")
 
     @Test
-    fun testPlatformStatic() = doTest("platformStatic")
-
-    @Test
     fun testSimple() = doTest("simple")
 
     @Test

--- a/libraries/tools/kotlin-annotation-processing/src/test/resources/parse/fieldAnnotations/annotations.txt
+++ b/libraries/tools/kotlin-annotation-processing/src/test/resources/parse/fieldAnnotations/annotations.txt
@@ -5,3 +5,5 @@ a org.jetbrains.annotations.Nullable 1
 f 1 0/SomeClass annotatedVal
 m 1 0/SomeClass getAnnotatedVal
 f 0 0/SomeClass annotatedVar
+f 0 0/OtherClass annotatedVal
+f 0 0/OtherClass annotatedVar

--- a/libraries/tools/kotlin-annotation-processing/src/test/resources/parse/fieldAnnotations/parsed.txt
+++ b/libraries/tools/kotlin-annotation-processing/src/test/resources/parse/fieldAnnotations/parsed.txt
@@ -1,3 +1,5 @@
+javax.inject.Inject org.test.OtherClass annotatedVal
+javax.inject.Inject org.test.OtherClass annotatedVar
 javax.inject.Inject org.test.SomeClass annotatedVal
 javax.inject.Inject org.test.SomeClass annotatedVar
 org.jetbrains.annotations.Nullable org.test.SomeClass annotatedVal

--- a/libraries/tools/kotlin-annotation-processing/src/test/resources/parse/methodAnnotations/annotations.txt
+++ b/libraries/tools/kotlin-annotation-processing/src/test/resources/parse/methodAnnotations/annotations.txt
@@ -1,5 +1,7 @@
 a javax.inject.Inject 0
 p org.test 0
 m 0 0/SomeClass annotatedFunction
+m 0 0/OtherClass annotatedFunction
 a javax.inject.Named 1
 m 1 0/SomeClass$annotatedFunction$1 invoke
+m 1 0/OtherClass$annotatedFunction$1 invoke

--- a/libraries/tools/kotlin-annotation-processing/src/test/resources/parse/methodAnnotations/parsed.txt
+++ b/libraries/tools/kotlin-annotation-processing/src/test/resources/parse/methodAnnotations/parsed.txt
@@ -1,2 +1,4 @@
+javax.inject.Inject org.test.OtherClass annotatedFunction
 javax.inject.Inject org.test.SomeClass annotatedFunction
+javax.inject.Named org.test.OtherClass.annotatedFunction.1 invoke
 javax.inject.Named org.test.SomeClass.annotatedFunction.1 invoke

--- a/libraries/tools/kotlin-annotation-processing/src/test/resources/parse/platformStatic/annotations.txt
+++ b/libraries/tools/kotlin-annotation-processing/src/test/resources/parse/platformStatic/annotations.txt
@@ -1,9 +1,0 @@
-a kotlin.platform.platformStatic 0
-p org.test 0
-m 0 0/SomeClass$Companion a
-a kotlin.inline 1
-m 1 0/SomeClass$Companion a
-a org.jetbrains.annotations.NotNull 2
-m 2 0/SomeClass$Companion access$init$0
-m 0 0/SomeClass a
-m 1 0/SomeClass a

--- a/libraries/tools/kotlin-annotation-processing/src/test/resources/parse/platformStatic/parsed.txt
+++ b/libraries/tools/kotlin-annotation-processing/src/test/resources/parse/platformStatic/parsed.txt
@@ -1,3 +1,0 @@
-kotlin.inline org.test.SomeClass.Companion a
-kotlin.platform.platformStatic org.test.SomeClass.Companion a
-org.jetbrains.annotations.NotNull org.test.SomeClass.Companion access$init$0


### PR DESCRIPTION
Handle the case where an elements with the same name in two different classes are annotated with the same annotation;
```
class Foo() {
  @Qux
  var baz: Int
}

class Bar() {
  @Qux
  var baz: Int
}
```
In the current implementation only one of the annotations will be sent to the Processor.
The pull request fixes that issue.

`@PlatformStatic` was removed from the source so the test has been removed.
