### PR TITLE
added javax.annotation.Nonnull

### DIFF
--- a/core/descriptor.loader.java/src/org/jetbrains/kotlin/load/java/JvmAnnotationNames.kt
+++ b/core/descriptor.loader.java/src/org/jetbrains/kotlin/load/java/JvmAnnotationNames.kt
@@ -40,6 +40,7 @@ val NOT_NULL_ANNOTATIONS = listOf(
         FqName("com.android.annotations.NonNull"),
         FqName("org.eclipse.jdt.annotation.NonNull"),
         FqName("org.checkerframework.checker.nullness.qual.NonNull"),
+        FqName("javax.annotation.Nonnull"),
         FqName("lombok.NonNull")
 )
 


### PR DESCRIPTION
Since the equivalent `Nullable` annotation is there, I thought it was odd `Nonnull` was missing.