### PR TITLE
Prevent NPE when resolving enum entries and their properties

### DIFF
--- a/compiler/frontend/src/org/jetbrains/kotlin/resolve/DeclarationResolver.kt
+++ b/compiler/frontend/src/org/jetbrains/kotlin/resolve/DeclarationResolver.kt
@@ -21,6 +21,7 @@ import com.google.common.collect.Multimap
 import com.google.common.collect.Sets
 import com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
+import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
 import org.jetbrains.kotlin.descriptors.PropertyDescriptor
 import org.jetbrains.kotlin.diagnostics.Errors
@@ -55,6 +56,9 @@ class DeclarationResolver(
             val descriptorMap = HashMultimap.create<Name, DeclarationDescriptor>()
             for (desc in classDescriptor.unsubstitutedMemberScope.getContributedDescriptors()) {
                 if (desc is ClassDescriptor || desc is PropertyDescriptor) {
+                    if ((desc is ClassDescriptor) && desc.kind == ClassKind.ENUM_ENTRY) {
+                        continue
+                    }
                     descriptorMap.put(desc.name, desc)
                 }
             }


### PR DESCRIPTION
Compiler was crashing with the following:

```kotlin
enum class CrashEnum {
  first,
  second,
  name
}
```

i.e., if an enum had entries named `name` or `ordinal`,
the compiler would crash. This also caused many errors
in the IDE as the file was being resolved.

Signed-off-by: Eddie Ringle <eddie@ringle.io>