### PR TITLE
Test for KT-11750

### DIFF
--- a/compiler/testData/diagnostics/tests/enum/kt11750.kt
+++ b/compiler/testData/diagnostics/tests/enum/kt11750.kt
@@ -1,0 +1,10 @@
+enum class EnumWithName {
+    abc,
+    name,
+    xyz,
+}
+
+enum class EnumWithNameObject {
+    abc;
+    companion object name
+}

--- a/compiler/testData/diagnostics/tests/enum/kt11750.txt
+++ b/compiler/testData/diagnostics/tests/enum/kt11750.txt
@@ -1,0 +1,46 @@
+package
+
+public final enum class EnumWithName : kotlin.Enum<EnumWithName> {
+    enum entry abc
+
+    enum entry name
+
+    enum entry xyz
+
+    private constructor EnumWithName()
+    public final override /*1*/ /*fake_override*/ val name: kotlin.String
+    public final override /*1*/ /*fake_override*/ val ordinal: kotlin.Int
+    protected final override /*1*/ /*fake_override*/ fun clone(): kotlin.Any
+    public final override /*1*/ /*fake_override*/ fun compareTo(/*0*/ other: EnumWithName): kotlin.Int
+    public final override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public final override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+
+    // Static members
+    public final /*synthesized*/ fun valueOf(/*0*/ value: kotlin.String): EnumWithName
+    public final /*synthesized*/ fun values(): kotlin.Array<EnumWithName>
+}
+
+public final enum class EnumWithNameObject : kotlin.Enum<EnumWithNameObject> {
+    enum entry abc
+
+    private constructor EnumWithNameObject()
+    public final override /*1*/ /*fake_override*/ val name: kotlin.String
+    public final override /*1*/ /*fake_override*/ val ordinal: kotlin.Int
+    protected final override /*1*/ /*fake_override*/ fun clone(): kotlin.Any
+    public final override /*1*/ /*fake_override*/ fun compareTo(/*0*/ other: EnumWithNameObject): kotlin.Int
+    public final override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public final override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+
+    public companion object name {
+        private constructor name()
+        public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+        public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+        public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+    }
+
+    // Static members
+    public final /*synthesized*/ fun valueOf(/*0*/ value: kotlin.String): EnumWithNameObject
+    public final /*synthesized*/ fun values(): kotlin.Array<EnumWithNameObject>
+}

--- a/compiler/tests/org/jetbrains/kotlin/checkers/DiagnosticsTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/checkers/DiagnosticsTestGenerated.java
@@ -6045,6 +6045,12 @@ public class DiagnosticsTestGenerated extends AbstractDiagnosticsTest {
                 doTest(fileName);
             }
 
+            @TestMetadata("kt11750.kt")
+            public void testKt11750() throws Exception {
+                String fileName = KotlinTestUtils.navigationMetadata("compiler/testData/diagnostics/tests/enum/kt11750.kt");
+                doTest(fileName);
+            }
+
             @TestMetadata("kt2834.kt")
             public void testKt2834() throws Exception {
                 String fileName = KotlinTestUtils.navigationMetadata("compiler/testData/diagnostics/tests/enum/kt2834.kt");


### PR DESCRIPTION
Compiler is crashing with the following:

```kotlin
  enum class CrashEnum {
    first,
    second,
    name
  }

  enum class AnotherCrashEnum {
    first;
    companion object name
  }
```

i.e., if an enum has entries named `name` or `ordinal`,
or even objects or interfaces with those names,
the compiler would crash. This also causes many errors
in the IDE as the file is being resolved.

Signed-off-by: Eddie Ringle <eddie@ringle.io>