### PR TITLE
 KT-11780: Fixed incorrect "No cast needed" warning when casting from extension …

### DIFF
--- a/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/BasicExpressionTypingVisitor.java
+++ b/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/BasicExpressionTypingVisitor.java
@@ -73,6 +73,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import static org.jetbrains.kotlin.builtins.FunctionTypesKt.isExtensionFunctionType;
 import static org.jetbrains.kotlin.diagnostics.Errors.*;
 import static org.jetbrains.kotlin.lexer.KtTokens.*;
 import static org.jetbrains.kotlin.resolve.BindingContext.*;
@@ -305,7 +306,7 @@ public class BasicExpressionTypingVisitor extends ExpressionTypingVisitor {
             return;
         }
         KotlinTypeChecker typeChecker = KotlinTypeChecker.DEFAULT;
-        if (actualType.equals(targetType)) {
+        if (isExactTypeCast(actualType, targetType)) {
             // cast to itself: String as String
             context.trace.report(USELESS_CAST.on(expression));
             return;
@@ -316,8 +317,8 @@ public class BasicExpressionTypingVisitor extends ExpressionTypingVisitor {
         boolean checkExactType = checkExactTypeForUselessCast(expression);
         for (KotlinType possibleType : possibleTypes) {
             boolean castIsUseless = checkExactType
-                                    ? possibleType.equals(targetType)
-                                    : typeChecker.isSubtypeOf(possibleType, targetType);
+                                    ? isExactTypeCast(possibleType, targetType)
+                                    : isUpcast(possibleType, targetType, typeChecker);
             if (castIsUseless) {
                 context.trace.report(USELESS_CAST.on(expression));
                 return;
@@ -326,6 +327,15 @@ public class BasicExpressionTypingVisitor extends ExpressionTypingVisitor {
         if (CastDiagnosticsUtil.isCastErased(actualType, targetType, typeChecker)) {
             context.trace.report(UNCHECKED_CAST.on(expression, actualType, targetType));
         }
+    }
+
+    private static boolean isExactTypeCast(KotlinType candidateType, KotlinType targetType) {
+        return candidateType.equals(targetType) && isExtensionFunctionType(candidateType) == isExtensionFunctionType(targetType);
+    }
+
+    private static boolean isUpcast(KotlinType candidateType, KotlinType targetType, KotlinTypeChecker typeChecker) {
+        return typeChecker.isSubtypeOf(candidateType, targetType) &&
+               isExtensionFunctionType(candidateType) == isExtensionFunctionType(targetType);
     }
 
     // Casting an argument or a receiver to a supertype may be useful to select an exact overload of a method.

--- a/compiler/testData/diagnostics/tests/cast/ExtensionAsNonExtension.kt
+++ b/compiler/testData/diagnostics/tests/cast/ExtensionAsNonExtension.kt
@@ -1,0 +1,3 @@
+fun f(a: (Int) -> Unit) = a as Int.() -> Unit
+
+fun f1(a: Int.() -> Unit) = a as (Int) -> Unit

--- a/compiler/testData/diagnostics/tests/cast/ExtensionAsNonExtension.txt
+++ b/compiler/testData/diagnostics/tests/cast/ExtensionAsNonExtension.txt
@@ -1,0 +1,4 @@
+package
+
+public fun f(/*0*/ a: (kotlin.Int) -> kotlin.Unit): kotlin.Int.() -> kotlin.Unit
+public fun f1(/*0*/ a: kotlin.Int.() -> kotlin.Unit): (kotlin.Int) -> kotlin.Unit

--- a/compiler/tests/org/jetbrains/kotlin/checkers/DiagnosticsTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/checkers/DiagnosticsTestGenerated.java
@@ -2247,6 +2247,12 @@ public class DiagnosticsTestGenerated extends AbstractDiagnosticsTest {
                 doTest(fileName);
             }
 
+            @TestMetadata("ExtensionAsNonExtension.kt")
+            public void testExtensionAsNonExtension() throws Exception {
+                String fileName = KotlinTestUtils.navigationMetadata("compiler/testData/diagnostics/tests/cast/ExtensionAsNonExtension.kt");
+                doTest(fileName);
+            }
+
             @TestMetadata("IsErasedAllowForDerivedWithOneSubstitutedAndOneSameGeneric.kt")
             public void testIsErasedAllowForDerivedWithOneSubstitutedAndOneSameGeneric() throws Exception {
                 String fileName = KotlinTestUtils.navigationMetadata("compiler/testData/diagnostics/tests/cast/IsErasedAllowForDerivedWithOneSubstitutedAndOneSameGeneric.kt");


### PR DESCRIPTION
…function to regular one and vise versa