### PR TITLE
run configuration: use default logic of creating new run configurations

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/run/JetRunConfiguration.java
+++ b/idea/src/org/jetbrains/kotlin/idea/run/JetRunConfiguration.java
@@ -84,11 +84,6 @@ public class JetRunConfiguration extends ModuleBasedConfiguration<RunConfigurati
         return Arrays.asList(ModuleManager.getInstance(getProject()).getModules());
     }
 
-    @Override
-    protected ModuleBasedConfiguration createInstance() {
-        return new JetRunConfiguration(getName(), getConfigurationModule(), getFactory());
-    }
-
     @NotNull
     @Override
     public SettingsEditor<? extends RunConfiguration> getConfigurationEditor() {


### PR DESCRIPTION
…to avoid sharing RunConfigurationModule instances between different run configurations (KT-12204)