### PR TITLE
KT-12074 Building Kotlin maven projects using a parent pom will siletly fail

### DIFF
--- a/libraries/tools/kotlin-maven-plugin-test/src/it/test-multimodule-srcdir-absolute/pom.xml
+++ b/libraries/tools/kotlin-maven-plugin-test/src/it/test-multimodule-srcdir-absolute/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-project</artifactId>
+        <version>1.1-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>test-multimodule-root</artifactId>
+    <packaging>pom</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <modules>
+        <module>sub</module>
+    </modules>
+
+    <build>
+        <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+        <plugins>
+            <plugin>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <version>${project.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/libraries/tools/kotlin-maven-plugin-test/src/it/test-multimodule-srcdir-absolute/sub/pom.xml
+++ b/libraries/tools/kotlin-maven-plugin-test/src/it/test-multimodule-srcdir-absolute/sub/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>test-multimodule-root</artifactId>
+        <version>1.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>test-multimodule-sub</artifactId>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <version>${project.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+
+                        <configuration>
+                            <sourceDirs>
+                                <dir>${project.basedir}/src/main/kotlin</dir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/libraries/tools/kotlin-maven-plugin-test/src/it/test-multimodule-srcdir-absolute/sub/src/main/kotlin/org/jetbrains/HelloWorld.kt
+++ b/libraries/tools/kotlin-maven-plugin-test/src/it/test-multimodule-srcdir-absolute/sub/src/main/kotlin/org/jetbrains/HelloWorld.kt
@@ -1,0 +1,9 @@
+package org.jetbrains
+
+fun main(args : Array<String>) {
+    System.out?.println(getGreeting())
+}
+
+fun getGreeting() : String {
+    return "Hello, World!"
+}

--- a/libraries/tools/kotlin-maven-plugin-test/src/it/test-multimodule-srcdir-absolute/verify.bsh
+++ b/libraries/tools/kotlin-maven-plugin-test/src/it/test-multimodule-srcdir-absolute/verify.bsh
@@ -1,0 +1,8 @@
+source(new File(basedir, "../../../verify-common.bsh").getAbsolutePath());
+
+assertBuildLogHasLineThatContains("kotlin-maven-plugin");
+
+File classFile = new File(basedir, "sub/target/classes/org/jetbrains/HelloWorldKt.class");
+if (!classFile.exists()) {
+    throw new FileNotFoundException("Could not find generated class file: " + classFile);
+}

--- a/libraries/tools/kotlin-maven-plugin-test/src/it/test-multimodule-srcdir/pom.xml
+++ b/libraries/tools/kotlin-maven-plugin-test/src/it/test-multimodule-srcdir/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-project</artifactId>
+        <version>1.1-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>test-multimodule-root</artifactId>
+    <packaging>pom</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <modules>
+        <module>sub</module>
+    </modules>
+
+    <build>
+        <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+        <plugins>
+            <plugin>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <version>${project.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/libraries/tools/kotlin-maven-plugin-test/src/it/test-multimodule-srcdir/sub/pom.xml
+++ b/libraries/tools/kotlin-maven-plugin-test/src/it/test-multimodule-srcdir/sub/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>test-multimodule-root</artifactId>
+        <version>1.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>test-multimodule-sub</artifactId>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <version>${project.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+
+                        <configuration>
+                            <sourceDirs>
+                                <dir>src/main/kotlin</dir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/libraries/tools/kotlin-maven-plugin-test/src/it/test-multimodule-srcdir/sub/src/main/kotlin/org/jetbrains/HelloWorld.kt
+++ b/libraries/tools/kotlin-maven-plugin-test/src/it/test-multimodule-srcdir/sub/src/main/kotlin/org/jetbrains/HelloWorld.kt
@@ -1,0 +1,9 @@
+package org.jetbrains
+
+fun main(args : Array<String>) {
+    System.out?.println(getGreeting())
+}
+
+fun getGreeting() : String {
+    return "Hello, World!"
+}

--- a/libraries/tools/kotlin-maven-plugin-test/src/it/test-multimodule-srcdir/verify.bsh
+++ b/libraries/tools/kotlin-maven-plugin-test/src/it/test-multimodule-srcdir/verify.bsh
@@ -1,0 +1,8 @@
+source(new File(basedir, "../../../verify-common.bsh").getAbsolutePath());
+
+assertBuildLogHasLineThatContains("kotlin-maven-plugin");
+
+File classFile = new File(basedir, "sub/target/classes/org/jetbrains/HelloWorldKt.class");
+if (!classFile.exists()) {
+    throw new FileNotFoundException("Could not find generated class file: " + classFile);
+}

--- a/libraries/tools/kotlin-maven-plugin-test/src/it/test-multimodule/pom.xml
+++ b/libraries/tools/kotlin-maven-plugin-test/src/it/test-multimodule/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-project</artifactId>
+        <version>1.1-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>test-multimodule-root</artifactId>
+    <packaging>pom</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <modules>
+        <module>sub</module>
+    </modules>
+
+    <build>
+        <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+        <plugins>
+            <plugin>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <version>${project.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/libraries/tools/kotlin-maven-plugin-test/src/it/test-multimodule/sub/pom.xml
+++ b/libraries/tools/kotlin-maven-plugin-test/src/it/test-multimodule/sub/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>test-multimodule-root</artifactId>
+        <version>1.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>test-multimodule-sub</artifactId>
+
+    <build>
+        <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+        <plugins>
+            <plugin>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <version>${project.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/libraries/tools/kotlin-maven-plugin-test/src/it/test-multimodule/sub/src/main/kotlin/org/jetbrains/HelloWorld.kt
+++ b/libraries/tools/kotlin-maven-plugin-test/src/it/test-multimodule/sub/src/main/kotlin/org/jetbrains/HelloWorld.kt
@@ -1,0 +1,9 @@
+package org.jetbrains
+
+fun main(args : Array<String>) {
+    System.out?.println(getGreeting())
+}
+
+fun getGreeting() : String {
+    return "Hello, World!"
+}

--- a/libraries/tools/kotlin-maven-plugin-test/src/it/test-multimodule/verify.bsh
+++ b/libraries/tools/kotlin-maven-plugin-test/src/it/test-multimodule/verify.bsh
@@ -1,0 +1,8 @@
+source(new File(basedir, "../../../verify-common.bsh").getAbsolutePath());
+
+assertBuildLogHasLineThatContains("kotlin-maven-plugin");
+
+File classFile = new File(basedir, "sub/target/classes/org/jetbrains/HelloWorldKt.class");
+if (!classFile.exists()) {
+    throw new FileNotFoundException("Could not find generated class file: " + classFile);
+}

--- a/libraries/tools/kotlin-maven-plugin/src/it/simple/expected.log
+++ b/libraries/tools/kotlin-maven-plugin/src/it/simple/expected.log
@@ -1,4 +1,3 @@
 [INFO] Kotlin Compiler version @snapshot@
 [INFO] Compiling Kotlin sources from [/src/main/kotlin]
-[INFO] Classes directory is /target/classes
 [INFO] Module name is test-project

--- a/libraries/tools/kotlin-maven-plugin/src/main/java/org/jetbrains/kotlin/maven/K2JVMCompileMojo.java
+++ b/libraries/tools/kotlin-maven-plugin/src/main/java/org/jetbrains/kotlin/maven/K2JVMCompileMojo.java
@@ -89,11 +89,11 @@ public class K2JVMCompileMojo extends KotlinCompileMojoBase<K2JVMCompilerArgumen
 
         if (!classpathList.isEmpty()) {
             String classPathString = join(classpathList, File.pathSeparator);
-            getLog().info("Classpath: " + classPathString);
+            getLog().debug("Classpath: " + classPathString);
             arguments.classpath = classPathString;
         }
 
-        getLog().info("Classes directory is " + output);
+        getLog().debug("Classes directory is " + output);
         arguments.destination = output;
 
         arguments.moduleName = moduleName;

--- a/libraries/tools/kotlin-maven-plugin/src/main/java/org/jetbrains/kotlin/maven/KotlinTestCompileMojo.java
+++ b/libraries/tools/kotlin-maven-plugin/src/main/java/org/jetbrains/kotlin/maven/KotlinTestCompileMojo.java
@@ -61,7 +61,7 @@ public class KotlinTestCompileMojo extends K2JVMCompileMojo {
     private List<String> sourceDirs;
 
     @Override
-    public List<String> getSources() {
+    public List<String> getSourceFilePaths() {
         if (sourceDirs != null && !sourceDirs.isEmpty()) return sourceDirs;
         return defaultSourceDirs;
     }

--- a/libraries/tools/kotlin-maven-plugin/src/main/java/org/jetbrains/kotlin/maven/KotlinTestJSCompilerMojo.java
+++ b/libraries/tools/kotlin-maven-plugin/src/main/java/org/jetbrains/kotlin/maven/KotlinTestJSCompilerMojo.java
@@ -65,7 +65,7 @@ public class KotlinTestJSCompilerMojo extends K2JSCompilerMojo {
     private List<String> sourceDirs;
 
     @Override
-    public List<String> getSources() {
+    public List<String> getSourceFilePaths() {
         if (sourceDirs != null && !sourceDirs.isEmpty()) return sourceDirs;
         return defaultSourceDirs;
     }


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-12074

We should consider module's basedir if there is relative source directory specified for the execution

Also classpath logging removed that was accidently added back: it shouldn't be shown as it is too verbose