### PR TITLE
Formatter: handle spaces between class name and type parameters

### DIFF
--- a/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/kotlinSpacingRules.kt
+++ b/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/kotlinSpacingRules.kt
@@ -182,6 +182,7 @@ fun createSpacingBuilder(settings: CodeStyleSettings, builderUtil: KotlinSpacing
             }
 
             afterInside(CONSTRUCTOR_KEYWORD, PRIMARY_CONSTRUCTOR).spaces(0)
+            betweenInside(IDENTIFIER, TYPE_PARAMETER_LIST, CLASS).spaces(0)
 
             aroundInside(DOT, DOT_QUALIFIED_EXPRESSION).spaces(0)
             aroundInside(SAFE_ACCESS, SAFE_ACCESS_EXPRESSION).spaces(0)

--- a/idea/testData/formatter/ClassTypeParam.after.kt
+++ b/idea/testData/formatter/ClassTypeParam.after.kt
@@ -1,0 +1,2 @@
+class TypeParameter<T> {}
+class TypeParameter<T>()

--- a/idea/testData/formatter/ClassTypeParam.kt
+++ b/idea/testData/formatter/ClassTypeParam.kt
@@ -1,0 +1,2 @@
+class   TypeParameter   <  T  >    {}
+class   TypeParameter   <  T  >    ()

--- a/idea/tests/org/jetbrains/kotlin/formatter/FormatterTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/formatter/FormatterTestGenerated.java
@@ -121,6 +121,12 @@ public class FormatterTestGenerated extends AbstractFormatterTest {
             doTest(fileName);
         }
 
+        @TestMetadata("ClassTypeParam.after.kt")
+        public void testClassTypeParam() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/formatter/ClassTypeParam.after.kt");
+            doTest(fileName);
+        }
+
         @TestMetadata("ColonSpaces.after.kt")
         public void testColonSpaces() throws Exception {
             String fileName = KotlinTestUtils.navigationMetadata("idea/testData/formatter/ColonSpaces.after.kt");


### PR DESCRIPTION
Fixes #KT-12446