### PR TITLE
Fixed encoding problem between daemon and jps in some cases (KT-9728)

### DIFF
--- a/compiler/daemon/src/org/jetbrains/kotlin/daemon/CompileServiceImpl.kt
+++ b/compiler/daemon/src/org/jetbrains/kotlin/daemon/CompileServiceImpl.kt
@@ -414,8 +414,8 @@ class CompileServiceImpl(
                 compilationsCounter.incrementAndGet()
                 val rpcProfiler = if (daemonOptions.reportPerf) WallAndThreadTotalProfiler() else DummyProfiler()
                 val eventManger = EventMangerImpl()
-                val compilerMessagesStream = PrintStream(BufferedOutputStream(RemoteOutputStreamClient(compilerMessagesStreamProxy, rpcProfiler), 4096))
-                val serviceOutputStream = PrintStream(BufferedOutputStream(RemoteOutputStreamClient(serviceOutputStreamProxy, rpcProfiler), 4096))
+                val compilerMessagesStream = PrintStream(BufferedOutputStream(RemoteOutputStreamClient(compilerMessagesStreamProxy, rpcProfiler), 4096), false, "UTF-8")
+                val serviceOutputStream = PrintStream(BufferedOutputStream(RemoteOutputStreamClient(serviceOutputStreamProxy, rpcProfiler), 4096), false, "UTF-8")
                 try {
                     checkedCompile(args, serviceOutputStream, rpcProfiler) {
                         val res = body(compilerMessagesStream, eventManger, rpcProfiler).code

--- a/jps-plugin/src/org/jetbrains/kotlin/compilerRunner/KotlinCompilerRunner.kt
+++ b/jps-plugin/src/org/jetbrains/kotlin/compilerRunner/KotlinCompilerRunner.kt
@@ -86,7 +86,7 @@ object KotlinCompilerRunner {
             collector: OutputItemsCollector,
             stream: ByteArrayOutputStream,
             exitCode: String) {
-        val reader = BufferedReader(StringReader(stream.toString()))
+        val reader = BufferedReader(StringReader(stream.toString("UTF-8")))
         CompilerOutputParser.parseCompilerMessagesFromReader(messageCollector, reader, collector)
 
         if (INTERNAL_ERROR == exitCode) {
@@ -118,7 +118,7 @@ object KotlinCompilerRunner {
                 KotlinBuilder.LOG.info("Compile in-process")
 
                 val stream = ByteArrayOutputStream()
-                val out = PrintStream(stream)
+                val out = PrintStream(stream, false, "UTF-8")
 
                 // the property should be set at least for parallel builds to avoid parallel building problems (racing between destroying and using environment)
                 // unfortunately it cannot be currently set by default globally, because it breaks many tests


### PR DESCRIPTION
This PR tries to fix this issue: https://youtrack.jetbrains.com/issue/KT-9728

I have two comments related to this:
- Maybe the encoding should be placed in a constant shared between JPS and Daemon but don't know where, so I just used literals for now
- Don't know how to test this so left untested automatically, (but verified that the problem is fixed)

For some reason it seems that PrintStream/StringReader uses different default charsets between the daemon and the jps in some machines, so the fix tries to not use the default, but a known charset.
