### PR TITLE
Change contributing section of "this query" link to finding open Kotlin issue

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -107,7 +107,7 @@ We love contributions! There's [lots to do on Kotlin](http://youtrack.jetbrains.
 about what you're interested in doing? Please join the #kontributors channel in [our Slack chat](http://kotlinslackin.herokuapp.com/)
 and let us know about your plans.
 
-If you want to find some issues to start off with, try [this query](https://youtrack.jetbrains.com/issues?q=tag%3A+%7BUp+For+Grabs%7D+%23Unresolved) which should find all issues that marked as "up-for-grabs".
+If you want to find some issues to start off with, try [this query](https://youtrack.jetbrains.com/issues/KT?q=tag:%20%7BUp%20For%20Grabs%7D%20%23Unresolved) which should find all Kotlin issues that marked as "up-for-grabs".
 
 Currently only committers can assign issues to themselves so just add a comment if you're starting work on it.
 


### PR DESCRIPTION
I would link to start contributing kotlin and noticed "this query" link is not related with Kotlin issues. I believe Kotlin repo's contributing section should show open kotlin issues.

Sorry if I skip steps before sending pull request.