### PR TITLE
Build string with initial capacity

### DIFF
--- a/libraries/stdlib/src/kotlin/text/StringBuilder.kt
+++ b/libraries/stdlib/src/kotlin/text/StringBuilder.kt
@@ -13,7 +13,7 @@ public inline fun buildString(builderAction: StringBuilder.() -> Unit): String =
  * Builds new string by populating newly created [StringBuilder] initialized with the given capacity using provided [builderAction] and then converting it to [String].
  */
 @kotlin.internal.InlineOnly
-inline fun buildString(length : Int, builderAction: StringBuilder.() -> Unit): String = StringBuilder(length).apply(builderAction).toString()
+inline fun buildString(capacity : Int, builderAction: StringBuilder.() -> Unit): String = StringBuilder(capacity).apply(builderAction).toString()
 
 /**
  * Appends all arguments to the given [Appendable].

--- a/libraries/stdlib/src/kotlin/text/StringBuilder.kt
+++ b/libraries/stdlib/src/kotlin/text/StringBuilder.kt
@@ -10,6 +10,12 @@ package kotlin.text
 public inline fun buildString(builderAction: StringBuilder.() -> Unit): String = StringBuilder().apply(builderAction).toString()
 
 /**
+ * Builds new string by populating newly created [StringBuilder] initialized with the given capacity using provided [builderAction] and then converting it to [String].
+ */
+@kotlin.internal.InlineOnly
+inline fun buildString(length : Int, builderAction: StringBuilder.() -> Unit): String = StringBuilder(length).apply(builderAction).toString()
+
+/**
  * Appends all arguments to the given [Appendable].
  */
 public fun <T : Appendable> T.append(vararg value: CharSequence?): T {

--- a/libraries/stdlib/test/text/StringBuilderJVMTest.kt
+++ b/libraries/stdlib/test/text/StringBuilderJVMTest.kt
@@ -5,6 +5,13 @@ import kotlin.test.*
 import org.junit.Test as test
 
 class StringBuilderJVMTest() {
+
+    @test fun stringBuildWithInitialCapacity() {
+        val s = buildString(123) {
+            assertEquals(123, capacity())
+        }
+    }
+
     @test fun getAndSetChar() {
         val sb = StringBuilder("abc")
         sb[1] = 'z'

--- a/libraries/stdlib/test/text/StringBuilderTest.kt
+++ b/libraries/stdlib/test/text/StringBuilderTest.kt
@@ -5,6 +5,12 @@ import org.junit.Test as test
 
 class StringBuilderTest {
 
+    @test fun stringBuildWithInitialCapacity() {
+        val s = buildString(123) {
+            assertEquals(123, capacity())
+        }
+    }
+
     @test fun stringBuild() {
         val s = buildString {
             append("a")

--- a/libraries/stdlib/test/text/StringBuilderTest.kt
+++ b/libraries/stdlib/test/text/StringBuilderTest.kt
@@ -5,12 +5,6 @@ import org.junit.Test as test
 
 class StringBuilderTest {
 
-    @test fun stringBuildWithInitialCapacity() {
-        val s = buildString(123) {
-            assertEquals(123, capacity())
-        }
-    }
-
     @test fun stringBuild() {
         val s = buildString {
             append("a")


### PR DESCRIPTION
this method helps save computation time when the developer knows or have a good
educated guess about the size of the generated string and have to use control
structures while filling the string builder