### PR TITLE
Add JQuery functions for selecting document and window

### DIFF
--- a/js/js.libraries/src/jquery/common.kt
+++ b/js/js.libraries/src/jquery/common.kt
@@ -3,8 +3,6 @@ package jquery
 import org.w3c.dom.Document
 import org.w3c.dom.Element
 import org.w3c.dom.Window
-import kotlin.browser.document
-import kotlin.browser.window
 
 @native
 public class JQuery() {

--- a/js/js.libraries/src/jquery/common.kt
+++ b/js/js.libraries/src/jquery/common.kt
@@ -1,6 +1,10 @@
 package jquery
 
+import org.w3c.dom.Document
 import org.w3c.dom.Element
+import org.w3c.dom.Window
+import kotlin.browser.document
+import kotlin.browser.window
 
 @native
 public class JQuery() {
@@ -67,5 +71,9 @@ public fun jq(callback: () -> Unit): JQuery = JQuery();
 public fun jq(obj: JQuery): JQuery = JQuery();
 @native("$")
 public fun jq(el: Element): JQuery = JQuery();
+@native("$")
+public fun jq(document: Document): JQuery = JQuery();
+@native("$")
+public fun jq(window: Window): Jquery = JQuery();
 @native("$")
 public fun jq(): JQuery = JQuery();


### PR DESCRIPTION
in JavaScript JQuery it is common to select document (and sometimes window), often followed by a "ready"-call to add event listeners to UI elements.

I did not find a way to do this easily in Kotlin, and that is why I propose this change.