### PR TITLE
KT-12887 Extend selection should select call's invoked expression

### DIFF
--- a/idea/src/META-INF/plugin.xml
+++ b/idea/src/META-INF/plugin.xml
@@ -484,6 +484,7 @@
     <extendWordSelectionHandler implementation="org.jetbrains.kotlin.idea.editor.wordSelection.KotlinDeclarationSelectioner"/>
     <extendWordSelectionHandler implementation="org.jetbrains.kotlin.idea.editor.wordSelection.KotlinListSelectioner"/>
     <extendWordSelectionHandler implementation="org.jetbrains.kotlin.idea.editor.wordSelection.KotlinStringLiteralSelectioner"/>
+    <extendWordSelectionHandler implementation="org.jetbrains.kotlin.idea.editor.wordSelection.KotlinInvokedExpressionSelectioner"/>
     <basicWordSelectionFilter implementation="org.jetbrains.kotlin.idea.editor.wordSelection.KotlinWordSelectionFilter"/>
 
     <typedHandler implementation="org.jetbrains.kotlin.idea.editor.KotlinTypedHandler"/>

--- a/idea/src/org/jetbrains/kotlin/idea/editor/wordSelection/KotlinInvokedExpressionSelectioner.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/editor/wordSelection/KotlinInvokedExpressionSelectioner.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2010-2016 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.kotlin.idea.editor.wordSelection
+
+import com.intellij.codeInsight.editorActions.ExtendWordSelectionHandlerBase
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
+import org.jetbrains.kotlin.psi.psiUtil.endOffset
+import org.jetbrains.kotlin.psi.psiUtil.startOffset
+
+class KotlinInvokedExpressionSelectioner : ExtendWordSelectionHandlerBase() {
+    override fun canSelect(e: PsiElement?): Boolean {
+        return e is KtDotQualifiedExpression
+    }
+
+    override fun select(e: PsiElement?, editorText: CharSequence?, cursorOffset: Int, editor: Editor): List<TextRange>? {
+        if (e !is KtDotQualifiedExpression) return null
+        val endOffset = e.selectorExpression?.children?.firstOrNull { it is KtNameReferenceExpression }?.endOffset ?: return null
+        return listOf(TextRange(e.startOffset, endOffset))
+    }
+}

--- a/idea/testData/wordSelection/InvokedExpression/0.kt
+++ b/idea/testData/wordSelection/InvokedExpression/0.kt
@@ -1,0 +1,4 @@
+fun foo() {
+    val bar = 1
+    <caret>bar.and(1.and(1)).and(1)
+}

--- a/idea/testData/wordSelection/InvokedExpression/1.kt
+++ b/idea/testData/wordSelection/InvokedExpression/1.kt
@@ -1,0 +1,4 @@
+fun foo() {
+    val bar = 1
+    <selection><caret>bar</selection>.and(1.and(1)).and(1)
+}

--- a/idea/testData/wordSelection/InvokedExpression/2.kt
+++ b/idea/testData/wordSelection/InvokedExpression/2.kt
@@ -1,0 +1,4 @@
+fun foo() {
+    val bar = 1
+    <selection><caret>bar.and</selection>(1.and(1)).and(1)
+}

--- a/idea/testData/wordSelection/InvokedExpression/3.kt
+++ b/idea/testData/wordSelection/InvokedExpression/3.kt
@@ -1,0 +1,4 @@
+fun foo() {
+    val bar = 1
+    <selection><caret>bar.and(1.and(1))</selection>.and(1)
+}

--- a/idea/testData/wordSelection/InvokedExpression/4.kt
+++ b/idea/testData/wordSelection/InvokedExpression/4.kt
@@ -1,0 +1,4 @@
+fun foo() {
+    val bar = 1
+    <selection><caret>bar.and(1.and(1)).and</selection>(1)
+}

--- a/idea/testData/wordSelection/InvokedExpression/5.kt
+++ b/idea/testData/wordSelection/InvokedExpression/5.kt
@@ -1,0 +1,4 @@
+fun foo() {
+    val bar = 1
+    <selection><caret>bar.and(1.and(1)).and(1)</selection>
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/WordSelectionTest.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/WordSelectionTest.java
@@ -74,6 +74,10 @@ public class WordSelectionTest extends KotlinLightCodeInsightFixtureTestCase {
 
     public void testMultiDeclaration() { doTest(); }
 
+    public void testInvokedExpression() {
+        doTest();
+    }
+
     private void doTest() {
         String dirName = getTestName(false);
 


### PR DESCRIPTION
 #KT-12887 fixed

This probably conflicts with #898