### PR TITLE
Quickfix "Make primary constructor parameter a val" makes the val private now

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/MakeConstructorParameterPropertyFix.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/MakeConstructorParameterPropertyFix.kt
@@ -23,6 +23,7 @@ import com.intellij.psi.PsiFile
 import org.jetbrains.kotlin.diagnostics.Diagnostic
 import org.jetbrains.kotlin.diagnostics.Errors
 import org.jetbrains.kotlin.idea.refactoring.changeSignature.KotlinValVar
+import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 import org.jetbrains.kotlin.psi.KtParameter
@@ -45,6 +46,7 @@ class MakeConstructorParameterPropertyFix(
 
     override fun invoke(project: Project, editor: Editor?, file: KtFile) {
         element.addBefore(kotlinValVar.createKeyword(KtPsiFactory(project))!!, element.firstChild)
+        element.addModifier(KtTokens.PRIVATE_KEYWORD)
     }
 
     companion object Factory : KotlinIntentionActionsFactory() {

--- a/idea/testData/quickfix/makeConstructorParameterProperty/inner.kt.after
+++ b/idea/testData/quickfix/makeConstructorParameterProperty/inner.kt.after
@@ -1,6 +1,6 @@
 // "Make primary constructor parameter 'bar' a property in class 'B'" "true"
 
-class B(val bar: String) {
+class B(private val bar: String) {
 
     inner class A {
         fun foo() {

--- a/idea/testData/quickfix/makeConstructorParameterProperty/val.kt.after
+++ b/idea/testData/quickfix/makeConstructorParameterProperty/val.kt.after
@@ -1,6 +1,6 @@
 // "Make primary constructor parameter 'foo' a property" "true"
 
-class A(val foo: String) {
+class A(private val foo: String) {
     fun bar() {
         val a = foo<caret>
     }

--- a/idea/testData/quickfix/makeConstructorParameterProperty/var.kt.after
+++ b/idea/testData/quickfix/makeConstructorParameterProperty/var.kt.after
@@ -1,6 +1,6 @@
 // "Make primary constructor parameter 'foo' a property" "true"
 
-class A(var foo: String) {
+class A(private var foo: String) {
     fun bar() {
         foo<caret> = ""
     }


### PR DESCRIPTION
Fixes #KT-13187