### PR TITLE
KT-13113 Add inspection to detect single-expression string template

### DIFF
--- a/idea/resources/inspectionDescriptions/RemoveSingleExpressionStringTemplate.html
+++ b/idea/resources/inspectionDescriptions/RemoveSingleExpressionStringTemplate.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This inspection reports single-expression String template that can be safely removed
+</body>
+</html>

--- a/idea/src/META-INF/plugin.xml
+++ b/idea/src/META-INF/plugin.xml
@@ -1273,6 +1273,11 @@
       <category>Kotlin</category>
     </intentionAction>
 
+    <intentionAction>
+      <className>org.jetbrains.kotlin.idea.intentions.RemoveSingleExpressionStringTemplateIntention</className>
+      <category>Kotlin</category>
+    </intentionAction>
+
     <localInspection implementationClass="org.jetbrains.kotlin.idea.intentions.ObjectLiteralToLambdaInspection"
                      displayName="Object literal can be converted to lambda"
                      groupName="Kotlin"
@@ -1638,6 +1643,14 @@
 
     <localInspection implementationClass="org.jetbrains.kotlin.idea.intentions.conventionNameCalls.ReplaceCallWithComparisonInspection"
                      displayName="Can be replaced with comparison"
+                     groupName="Kotlin"
+                     enabledByDefault="true"
+                     level="WARNING"
+                     language="kotlin"
+    />
+
+    <localInspection implementationClass="org.jetbrains.kotlin.idea.intentions.RemoveSingleExpressionStringTemplateInspection"
+                     displayName="Remove redundant string template"
                      groupName="Kotlin"
                      enabledByDefault="true"
                      level="WARNING"

--- a/idea/src/org/jetbrains/kotlin/idea/intentions/RemoveSingleExpressionStringTemplateIntention.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/RemoveSingleExpressionStringTemplateIntention.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2010-2016 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.kotlin.idea.intentions
+
+import com.intellij.openapi.editor.Editor
+import org.jetbrains.kotlin.builtins.KotlinBuiltIns
+import org.jetbrains.kotlin.idea.caches.resolve.analyze
+import org.jetbrains.kotlin.idea.inspections.IntentionBasedInspection
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtPsiFactory
+import org.jetbrains.kotlin.psi.KtStringTemplateExpression
+import org.jetbrains.kotlin.resolve.calls.callUtil.getType
+
+class RemoveSingleExpressionStringTemplateInspection : IntentionBasedInspection<KtStringTemplateExpression>(RemoveSingleExpressionStringTemplateIntention())
+
+class RemoveSingleExpressionStringTemplateIntention : SelfTargetingOffsetIndependentIntention<KtStringTemplateExpression>(KtStringTemplateExpression::class.java, "Remove single-expression string template") {
+    override fun isApplicableTo(element: KtStringTemplateExpression) = element.children.size == 1
+
+    override fun applyTo(element: KtStringTemplateExpression, editor: Editor?) {
+        val expression = element.children.getOrNull(0)?.children?.getOrNull(0) as? KtExpression ?: return
+        val type = expression.getType(expression.analyze())
+        val newElement = if (KotlinBuiltIns.isString(type)) expression else KtPsiFactory(element).createExpression("${expression.text}.toString()")
+        element.replace(newElement)
+    }
+}

--- a/idea/testData/intentions/removeSingleExpressionStringTemplate/.intention
+++ b/idea/testData/intentions/removeSingleExpressionStringTemplate/.intention
@@ -1,0 +1,1 @@
+org.jetbrains.kotlin.idea.intentions.RemoveSingleExpressionStringTemplateIntention

--- a/idea/testData/intentions/removeSingleExpressionStringTemplate/emptyString.kt
+++ b/idea/testData/intentions/removeSingleExpressionStringTemplate/emptyString.kt
@@ -1,0 +1,3 @@
+// IS_APPLICABLE: FALSE
+
+val bar = <caret>""

--- a/idea/testData/intentions/removeSingleExpressionStringTemplate/multipleStringTemplate.kt
+++ b/idea/testData/intentions/removeSingleExpressionStringTemplate/multipleStringTemplate.kt
@@ -1,0 +1,4 @@
+// IS_APPLICABLE: FALSE
+
+val foo = "foo"
+val bar = <caret>"$foo$foo"

--- a/idea/testData/intentions/removeSingleExpressionStringTemplate/singleExpressionStringTemplate.kt
+++ b/idea/testData/intentions/removeSingleExpressionStringTemplate/singleExpressionStringTemplate.kt
@@ -1,0 +1,4 @@
+// INTENTION_TEXT: Remove single-expression string template
+
+val foo = "foo"
+val bar = <caret>"$foo"

--- a/idea/testData/intentions/removeSingleExpressionStringTemplate/singleExpressionStringTemplate.kt.after
+++ b/idea/testData/intentions/removeSingleExpressionStringTemplate/singleExpressionStringTemplate.kt.after
@@ -1,0 +1,4 @@
+// INTENTION_TEXT: Remove single-expression string template
+
+val foo = "foo"
+val bar = foo

--- a/idea/testData/intentions/removeSingleExpressionStringTemplate/singleExpressionStringTemplateWithMethodCall.kt
+++ b/idea/testData/intentions/removeSingleExpressionStringTemplate/singleExpressionStringTemplateWithMethodCall.kt
@@ -1,0 +1,3 @@
+// INTENTION_TEXT: Remove single-expression string template
+
+val bar = <caret>"${1.hashCode().toString()}"

--- a/idea/testData/intentions/removeSingleExpressionStringTemplate/singleExpressionStringTemplateWithMethodCall.kt.after
+++ b/idea/testData/intentions/removeSingleExpressionStringTemplate/singleExpressionStringTemplateWithMethodCall.kt.after
@@ -1,0 +1,3 @@
+// INTENTION_TEXT: Remove single-expression string template
+
+val bar = 1.hashCode().toString()

--- a/idea/testData/intentions/removeSingleExpressionStringTemplate/singleExpressionStringTemplateWithNonStringType.kt
+++ b/idea/testData/intentions/removeSingleExpressionStringTemplate/singleExpressionStringTemplateWithNonStringType.kt
@@ -1,0 +1,3 @@
+// INTENTION_TEXT: Remove single-expression string template
+
+val bar = <caret>"${1.hashCode()}"

--- a/idea/testData/intentions/removeSingleExpressionStringTemplate/singleExpressionStringTemplateWithNonStringType.kt.after
+++ b/idea/testData/intentions/removeSingleExpressionStringTemplate/singleExpressionStringTemplateWithNonStringType.kt.after
@@ -1,0 +1,3 @@
+// INTENTION_TEXT: Remove single-expression string template
+
+val bar = 1.hashCode().toString()

--- a/idea/testData/intentions/removeSingleExpressionStringTemplate/stringTemplateWithText.kt
+++ b/idea/testData/intentions/removeSingleExpressionStringTemplate/stringTemplateWithText.kt
@@ -1,0 +1,4 @@
+// IS_APPLICABLE: FALSE
+
+val foo = "foo"
+val bar = <caret>"text$foo"

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -8480,6 +8480,51 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
         }
     }
 
+    @TestMetadata("idea/testData/intentions/removeSingleExpressionStringTemplate")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class RemoveSingleExpressionStringTemplate extends AbstractIntentionTest {
+        public void testAllFilesPresentInRemoveSingleExpressionStringTemplate() throws Exception {
+            KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/intentions/removeSingleExpressionStringTemplate"), Pattern.compile("^([\\w\\-_]+)\\.kt$"), true);
+        }
+
+        @TestMetadata("emptyString.kt")
+        public void testEmptyString() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/removeSingleExpressionStringTemplate/emptyString.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("multipleStringTemplate.kt")
+        public void testMultipleStringTemplate() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/removeSingleExpressionStringTemplate/multipleStringTemplate.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("singleExpressionStringTemplate.kt")
+        public void testSingleExpressionStringTemplate() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/removeSingleExpressionStringTemplate/singleExpressionStringTemplate.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("singleExpressionStringTemplateWithMethodCall.kt")
+        public void testSingleExpressionStringTemplateWithMethodCall() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/removeSingleExpressionStringTemplate/singleExpressionStringTemplateWithMethodCall.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("singleExpressionStringTemplateWithNonStringType.kt")
+        public void testSingleExpressionStringTemplateWithNonStringType() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/removeSingleExpressionStringTemplate/singleExpressionStringTemplateWithNonStringType.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("stringTemplateWithText.kt")
+        public void testStringTemplateWithText() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/removeSingleExpressionStringTemplate/stringTemplateWithText.kt");
+            doTest(fileName);
+        }
+    }
+
     @TestMetadata("idea/testData/intentions/removeUnnecessaryParentheses")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)


### PR DESCRIPTION
 #KT-13113 Fixed

https://youtrack.jetbrains.com/issue/KT-13113

Feature that adds `toString()` to non-String class is discussed at #kontributor channels.