### PR TITLE
Allow suppressing warnings for secondary constructor

### DIFF
--- a/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/KotlinSuppressableWarningProblemGroup.kt
+++ b/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/KotlinSuppressableWarningProblemGroup.kt
@@ -25,7 +25,7 @@ import org.jetbrains.kotlin.idea.quickfix.AnnotationHostKind
 import org.jetbrains.kotlin.idea.quickfix.KotlinSuppressIntentionAction
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
-import java.util.Collections
+import java.util.*
 
 class KotlinSuppressableWarningProblemGroup(
         private val diagnosticFactory: DiagnosticFactory<*>
@@ -109,6 +109,8 @@ private object DeclarationKindDetector : KtVisitor<AnnotationHostKind?, Unit?>()
     override fun visitEnumEntry(d: KtEnumEntry, data: Unit?) = detect(d, "enum entry")
 
     override fun visitParameter(d: KtParameter, data: Unit?) = detect(d, "parameter", newLineNeeded = false)
+
+    override fun visitSecondaryConstructor(constructor: KtSecondaryConstructor, data: Unit?) = detect(constructor, "secondary constructor of")
 
     override fun visitObjectDeclaration(d: KtObjectDeclaration, data: Unit?): AnnotationHostKind? {
         if (d.isCompanion()) return detect(d, "companion object", name = "${d.name} of ${d.getStrictParentOfType<KtClass>()?.name}")

--- a/idea/testData/quickfix/suppress/declarationKinds/secondaryConstructor.kt
+++ b/idea/testData/quickfix/suppress/declarationKinds/secondaryConstructor.kt
@@ -1,0 +1,5 @@
+// "Suppress 'REDUNDANT_NULLABLE' for secondary constructor of C" "true"
+
+class C {
+    constructor(s: String?<caret>?)
+}

--- a/idea/testData/quickfix/suppress/declarationKinds/secondaryConstructor.kt.after
+++ b/idea/testData/quickfix/suppress/declarationKinds/secondaryConstructor.kt.after
@@ -1,0 +1,6 @@
+// "Suppress 'REDUNDANT_NULLABLE' for secondary constructor of C" "true"
+
+class C {
+    @Suppress("REDUNDANT_NULLABLE")
+    constructor(s: String?<caret>?)
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -7476,6 +7476,12 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
                 doTest(fileName);
             }
 
+            @TestMetadata("secondaryConstructor.kt")
+            public void testSecondaryConstructor() throws Exception {
+                String fileName = KotlinTestUtils.navigationMetadata("idea/testData/quickfix/suppress/declarationKinds/secondaryConstructor.kt");
+                doTest(fileName);
+            }
+
             @TestMetadata("trait.kt")
             public void testTrait() throws Exception {
                 String fileName = KotlinTestUtils.navigationMetadata("idea/testData/quickfix/suppress/declarationKinds/trait.kt");


### PR DESCRIPTION
Fixes #KT-12627