### PR TITLE
Add data annotation to JeName for equals/hashCode

### DIFF
--- a/plugins/java-model-wrappers/src/org/jetbrains/kotlin/java/model/JeName.kt
+++ b/plugins/java-model-wrappers/src/org/jetbrains/kotlin/java/model/JeName.kt
@@ -20,7 +20,7 @@ import javax.lang.model.element.Name
 
 fun JeName(name: String?) = name?.let { JeName(it) } ?: JeName.EMPTY
 
-class JeName(val name: String) : Name, CharSequence by name {
+data class JeName(val name: String) : Name, CharSequence by name {
     override fun contentEquals(cs: CharSequence?) = cs?.toString() == name
     
     override fun toString() = name


### PR DESCRIPTION
The docs say that this class must obey the equals contract (https://docs.oracle.com/javase/7/docs/api/javax/lang/model/element/Name.html)