### PR TITLE
KT-13551 Add inspection + intention to replace `.let { it.foo() }` with `.foo()`

### DIFF
--- a/idea/resources/inspectionDescriptions/ReplaceSingleLineLet.html
+++ b/idea/resources/inspectionDescriptions/ReplaceSingleLineLet.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This inspection detects '.let' with only one call with its receiver.
+</body>
+</html>

--- a/idea/resources/intentionDescriptions/ReplaceSingleLineLetIntention/after.kt.template
+++ b/idea/resources/intentionDescriptions/ReplaceSingleLineLetIntention/after.kt.template
@@ -1,0 +1,1 @@
+text?.<spot>length</spot>

--- a/idea/resources/intentionDescriptions/ReplaceSingleLineLetIntention/before.kt.template
+++ b/idea/resources/intentionDescriptions/ReplaceSingleLineLetIntention/before.kt.template
@@ -1,0 +1,1 @@
+text?.let <spot>{ it.length }</spot>

--- a/idea/resources/intentionDescriptions/ReplaceSingleLineLetIntention/description.html
+++ b/idea/resources/intentionDescriptions/ReplaceSingleLineLetIntention/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This intention detects '.let' with only one call with its receiver.
+</body>
+</html>

--- a/idea/src/META-INF/plugin.xml
+++ b/idea/src/META-INF/plugin.xml
@@ -1348,6 +1348,11 @@
       <category>Kotlin</category>
     </intentionAction>
 
+    <intentionAction>
+      <className>org.jetbrains.kotlin.idea.intentions.ReplaceSingleLineLetIntention</className>
+      <category>Kotlin</category>
+    </intentionAction>
+
     <localInspection implementationClass="org.jetbrains.kotlin.idea.intentions.ObjectLiteralToLambdaInspection"
                      displayName="Object literal can be converted to lambda"
                      groupName="Kotlin"
@@ -1767,6 +1772,14 @@
 
     <localInspection implementationClass="org.jetbrains.kotlin.idea.intentions.ReplaceArrayEqualityOpWithArraysEqualsInspection"
                      displayName="Replace '==' with 'Arrays.equals'"
+                     groupName="Kotlin"
+                     enabledByDefault="true"
+                     level="WARNING"
+                     language="kotlin"
+    />
+
+    <localInspection implementationClass="org.jetbrains.kotlin.idea.intentions.ReplaceSingleLineLetInspection"
+                     displayName="Replace single line .let"
                      groupName="Kotlin"
                      enabledByDefault="true"
                      level="WARNING"

--- a/idea/src/org/jetbrains/kotlin/idea/intentions/ReplaceSingleLineLetIntention.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/ReplaceSingleLineLetIntention.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2010-2016 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.kotlin.idea.intentions
+
+import com.intellij.openapi.editor.Editor
+import org.jetbrains.kotlin.idea.caches.resolve.analyze
+import org.jetbrains.kotlin.idea.core.replaced
+import org.jetbrains.kotlin.idea.inspections.IntentionBasedInspection
+import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameUnsafe
+
+class ReplaceSingleLineLetInspection :
+        IntentionBasedInspection<KtCallExpression>(ReplaceSingleLineLetIntention::class)
+
+class ReplaceSingleLineLetIntention : SelfTargetingOffsetIndependentIntention<KtCallExpression>(
+        KtCallExpression::class.java,
+        "Replace single line '.let' call"
+) {
+    override fun applyTo(element: KtCallExpression, editor: Editor?) {
+        val lambdaExpression = element.lambdaArguments[0].getLambdaExpression()
+        val bodyExpression = lambdaExpression.bodyExpression ?: return
+        val dotQualifiedExpression = bodyExpression.children[0] as? KtDotQualifiedExpression ?: return
+        val parameterName = getParameterNameFromLambdaExpression(lambdaExpression)
+        val expressionText = dotQualifiedExpression.text.replace("$parameterName.", "")
+        val newExpression = KtPsiFactory(element.project).createExpression(expressionText)
+        element.replaced(newExpression)
+    }
+
+    override fun isApplicableTo(element: KtCallExpression): Boolean {
+        if (!isLetMethod(element)) return false
+        val lambdaExpression = element.lambdaArguments[0].getLambdaExpression()
+        val bodyExpressions = lambdaExpression.bodyExpression?.children ?: return false
+        if (bodyExpressions.size > 1) return false
+        val dotQualifiedExpression = bodyExpressions[0] as? KtDotQualifiedExpression ?: return false
+        val parameterName = getParameterNameFromLambdaExpression(lambdaExpression) ?: return false
+        val receiverExpression = getLeftMostReceiverExpression(dotQualifiedExpression)
+        if (receiverExpression.text != parameterName) return false
+        return !isUseReceiver(dotQualifiedExpression, parameterName)
+    }
+
+    private fun isLetMethod(element: KtCallExpression): Boolean {
+        if (element.calleeExpression?.text != "let") return false
+        return isMethodCall(element, "kotlin.let")
+    }
+
+    private fun isMethodCall(expression: KtExpression, fqMethodName: String): Boolean {
+        val resolvedCall = expression.getResolvedCall(expression.analyze()) ?: return false
+        return resolvedCall.resultingDescriptor.fqNameUnsafe.asString() == fqMethodName
+    }
+
+    private fun getParameterNameFromLambdaExpression(lambdaExpression: KtLambdaExpression): String? {
+        val parameters = lambdaExpression.valueParameters
+        if (parameters.size > 1) return null
+        return if (parameters.size == 1) parameters[0].text else "it"
+    }
+
+    private fun getLeftMostReceiverExpression(expression: KtDotQualifiedExpression): KtExpression {
+        val receiverExpression = expression.receiverExpression
+        return if (receiverExpression is KtDotQualifiedExpression) getLeftMostReceiverExpression(receiverExpression) else receiverExpression
+    }
+
+    private fun isUseReceiver(expression: KtExpression, receiverName: String): Boolean {
+        if (expression !is KtDotQualifiedExpression) return false
+        val selectorExpression = expression.selectorExpression
+        if ((selectorExpression as? KtCallExpression)?.valueArguments?.singleOrNull { it.text == receiverName } != null) return true
+        if (expression.children.size == 0) return false
+        return isUseReceiver(expression.receiverExpression, receiverName)
+    }
+}

--- a/idea/src/org/jetbrains/kotlin/idea/intentions/ReplaceSingleLineLetIntention.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/ReplaceSingleLineLetIntention.kt
@@ -18,7 +18,6 @@ package org.jetbrains.kotlin.idea.intentions
 
 import com.intellij.openapi.editor.Editor
 import org.jetbrains.kotlin.idea.caches.resolve.analyze
-import org.jetbrains.kotlin.idea.core.replaced
 import org.jetbrains.kotlin.idea.inspections.IntentionBasedInspection
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
@@ -37,8 +36,8 @@ class ReplaceSingleLineLetIntention : SelfTargetingOffsetIndependentIntention<Kt
         val dotQualifiedExpression = bodyExpression.children[0] as? KtDotQualifiedExpression ?: return
         val parameterName = getParameterNameFromLambdaExpression(lambdaExpression)
         val expressionText = dotQualifiedExpression.text.replace("$parameterName.", "")
-        val newExpression = KtPsiFactory(element.project).createExpression(expressionText)
-        element.replaced(newExpression)
+        val newExpression = KtPsiFactory(element.project).createExpression(element.parent.text.replace(element.text, "") + expressionText)
+        element.parent.replace(newExpression)
     }
 
     override fun isApplicableTo(element: KtCallExpression): Boolean {

--- a/idea/testData/intentions/replaceSingleLineLetIntention/.intention
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/.intention
@@ -1,0 +1,1 @@
+org.jetbrains.kotlin.idea.intentions.ReplaceSingleLineLetIntention

--- a/idea/testData/intentions/replaceSingleLineLetIntention/let.kt
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/let.kt
@@ -1,0 +1,8 @@
+// WITH_RUNTIME
+
+fun foo() {
+    val foo: String? = null
+    foo?.let {
+        it.length<caret>
+    }
+}

--- a/idea/testData/intentions/replaceSingleLineLetIntention/let.kt.after
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/let.kt.after
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+
+fun foo() {
+    val foo: String? = null
+    foo?.length
+}

--- a/idea/testData/intentions/replaceSingleLineLetIntention/letMultipleLines.kt
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/letMultipleLines.kt
@@ -1,0 +1,10 @@
+// WITH_RUNTIME
+// IS_APPLICABLE: false
+
+fun foo() {
+    val foo: String? = null
+    foo?.let {
+        it.length<caret>
+        it.length
+    }
+}

--- a/idea/testData/intentions/replaceSingleLineLetIntention/letNoSafeCall.kt
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/letNoSafeCall.kt
@@ -1,0 +1,8 @@
+// WITH_RUNTIME
+
+fun foo() {
+    val foo: String = ""
+    foo.let {
+        it.length<caret>
+    }
+}

--- a/idea/testData/intentions/replaceSingleLineLetIntention/letNoSafeCall.kt.after
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/letNoSafeCall.kt.after
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+
+fun foo() {
+    val foo: String = ""
+    foo.length
+}

--- a/idea/testData/intentions/replaceSingleLineLetIntention/letNotUseParameterReceiver.kt
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/letNotUseParameterReceiver.kt
@@ -1,0 +1,10 @@
+// WITH_RUNTIME
+// IS_APPLICABLE: false
+
+fun foo() {
+    val foo: String? = null
+    foo?.let {
+        text ->
+        "".to("")<caret>
+    }
+}

--- a/idea/testData/intentions/replaceSingleLineLetIntention/letNotUseReceiver.kt
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/letNotUseReceiver.kt
@@ -1,0 +1,9 @@
+// WITH_RUNTIME
+// IS_APPLICABLE: false
+
+fun foo() {
+    val foo: String? = null
+    foo?.let {
+        "".to("")<caret>
+    }
+}

--- a/idea/testData/intentions/replaceSingleLineLetIntention/letUseIt.kt
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/letUseIt.kt
@@ -1,0 +1,9 @@
+// WITH_RUNTIME
+// IS_APPLICABLE: false
+
+fun foo() {
+    val foo: String? = null
+    foo?.let {
+        it.to(it)<caret>
+    }
+}

--- a/idea/testData/intentions/replaceSingleLineLetIntention/letUseItWithMultipleMethodCall1.kt
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/letUseItWithMultipleMethodCall1.kt
@@ -1,0 +1,9 @@
+// WITH_RUNTIME
+// IS_APPLICABLE: false
+
+fun foo() {
+    val foo: String? = null
+    foo?.let {
+        it.to(it).to("").to("")<caret>
+    }
+}

--- a/idea/testData/intentions/replaceSingleLineLetIntention/letUseItWithMultipleMethodCall2.kt
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/letUseItWithMultipleMethodCall2.kt
@@ -1,0 +1,9 @@
+// WITH_RUNTIME
+// IS_APPLICABLE: false
+
+fun foo() {
+    val foo: String? = null
+    foo?.let {
+        it.to("").to(it).to("")<caret>
+    }
+}

--- a/idea/testData/intentions/replaceSingleLineLetIntention/letUseItWithMultipleMethodCall3.kt
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/letUseItWithMultipleMethodCall3.kt
@@ -1,0 +1,9 @@
+// WITH_RUNTIME
+// IS_APPLICABLE: false
+
+fun foo() {
+    val foo: String? = null
+    foo?.let {
+        it.to("").to("").to(it)<caret>
+    }
+}

--- a/idea/testData/intentions/replaceSingleLineLetIntention/letUseParameter.kt
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/letUseParameter.kt
@@ -1,0 +1,10 @@
+// WITH_RUNTIME
+// IS_APPLICABLE: false
+
+fun foo() {
+    val foo: String? = null
+    foo?.let {
+        text ->
+        text.to(text)<caret>
+    }
+}

--- a/idea/testData/intentions/replaceSingleLineLetIntention/letWithMethodCall.kt
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/letWithMethodCall.kt
@@ -1,0 +1,8 @@
+// WITH_RUNTIME
+
+fun foo() {
+    val foo: String? = null
+    foo?.let {
+        it.to("")<caret>
+    }
+}

--- a/idea/testData/intentions/replaceSingleLineLetIntention/letWithMethodCall.kt.after
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/letWithMethodCall.kt.after
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+
+fun foo() {
+    val foo: String? = null
+    foo?.to("")
+}

--- a/idea/testData/intentions/replaceSingleLineLetIntention/letWithMultipleMethodCall.kt
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/letWithMultipleMethodCall.kt
@@ -1,0 +1,9 @@
+// WITH_RUNTIME
+// SKIP_ERRORS_AFTER
+
+fun foo() {
+    val foo: String? = null
+    foo?.let {
+        it.to("").to("")<caret>
+    }
+}

--- a/idea/testData/intentions/replaceSingleLineLetIntention/letWithMultipleMethodCall.kt.after
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/letWithMultipleMethodCall.kt.after
@@ -1,5 +1,4 @@
 // WITH_RUNTIME
-// SKIP_ERRORS_AFTER
 
 fun foo() {
     val foo: String? = null

--- a/idea/testData/intentions/replaceSingleLineLetIntention/letWithMultipleMethodCall.kt.after
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/letWithMultipleMethodCall.kt.after
@@ -1,0 +1,7 @@
+// WITH_RUNTIME
+// SKIP_ERRORS_AFTER
+
+fun foo() {
+    val foo: String? = null
+    foo?.to("").to("")
+}

--- a/idea/testData/intentions/replaceSingleLineLetIntention/letWithParameter.kt
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/letWithParameter.kt
@@ -1,0 +1,9 @@
+// WITH_RUNTIME
+
+fun foo() {
+    val foo: String? = null
+    foo?.let {
+        text ->
+        text.length<caret>
+    }
+}

--- a/idea/testData/intentions/replaceSingleLineLetIntention/letWithParameter.kt.after
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/letWithParameter.kt.after
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+
+fun foo() {
+    val foo: String? = null
+    foo?.length
+}

--- a/idea/testData/intentions/replaceSingleLineLetIntention/sameLets.kt
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/sameLets.kt
@@ -1,0 +1,10 @@
+// WITH_RUNTIME
+
+fun foo() {
+    val foo: String? = null
+    foo?.toString()?.let {
+        it.to("")<caret>
+    }?.let {
+        it.to("")
+    }
+}

--- a/idea/testData/intentions/replaceSingleLineLetIntention/sameLets.kt.after
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/sameLets.kt.after
@@ -2,7 +2,7 @@
 
 fun foo() {
     val foo: String? = null
-    foo?.let {
-        it.to("").to("")<caret>
+    foo?.toString()?.to("")?.let {
+        it.to("")
     }
 }

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -10523,6 +10523,93 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
         }
     }
 
+    @TestMetadata("idea/testData/intentions/replaceSingleLineLetIntention")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class ReplaceSingleLineLetIntention extends AbstractIntentionTest {
+        public void testAllFilesPresentInReplaceSingleLineLetIntention() throws Exception {
+            KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/intentions/replaceSingleLineLetIntention"), Pattern.compile("^([\\w\\-_]+)\\.kt$"), true);
+        }
+
+        @TestMetadata("let.kt")
+        public void testLet() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/replaceSingleLineLetIntention/let.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("letMultipleLines.kt")
+        public void testLetMultipleLines() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/replaceSingleLineLetIntention/letMultipleLines.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("letNoSafeCall.kt")
+        public void testLetNoSafeCall() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/replaceSingleLineLetIntention/letNoSafeCall.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("letNotUseParameterReceiver.kt")
+        public void testLetNotUseParameterReceiver() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/replaceSingleLineLetIntention/letNotUseParameterReceiver.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("letNotUseReceiver.kt")
+        public void testLetNotUseReceiver() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/replaceSingleLineLetIntention/letNotUseReceiver.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("letUseIt.kt")
+        public void testLetUseIt() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/replaceSingleLineLetIntention/letUseIt.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("letUseItWithMultipleMethodCall1.kt")
+        public void testLetUseItWithMultipleMethodCall1() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/replaceSingleLineLetIntention/letUseItWithMultipleMethodCall1.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("letUseItWithMultipleMethodCall2.kt")
+        public void testLetUseItWithMultipleMethodCall2() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/replaceSingleLineLetIntention/letUseItWithMultipleMethodCall2.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("letUseItWithMultipleMethodCall3.kt")
+        public void testLetUseItWithMultipleMethodCall3() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/replaceSingleLineLetIntention/letUseItWithMultipleMethodCall3.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("letUseParameter.kt")
+        public void testLetUseParameter() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/replaceSingleLineLetIntention/letUseParameter.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("letWithMethodCall.kt")
+        public void testLetWithMethodCall() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/replaceSingleLineLetIntention/letWithMethodCall.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("letWithMultipleMethodCall.kt")
+        public void testLetWithMultipleMethodCall() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/replaceSingleLineLetIntention/letWithMultipleMethodCall.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("letWithParameter.kt")
+        public void testLetWithParameter() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/replaceSingleLineLetIntention/letWithParameter.kt");
+            doTest(fileName);
+        }
+    }
+
     @TestMetadata("idea/testData/intentions/replaceSubstringWithDropLast")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -10608,6 +10608,12 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
             String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/replaceSingleLineLetIntention/letWithParameter.kt");
             doTest(fileName);
         }
+
+        @TestMetadata("sameLets.kt")
+        public void testSameLets() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/replaceSingleLineLetIntention/sameLets.kt");
+            doTest(fileName);
+        }
     }
 
     @TestMetadata("idea/testData/intentions/replaceSubstringWithDropLast")


### PR DESCRIPTION
 #KT-13551 Fixed

https://youtrack.jetbrains.com/issue/KT-13551

I'm having a problem with following case.

```kotlin
e?.let {
    it.to("").to("")
}
```

will be this.

```kotlin
e?.to("").to("")
```

And then IDEA report following error.

![2016-09-03 22 04 17](https://cloud.githubusercontent.com/assets/3675458/18224963/80a3f776-7222-11e6-8df5-2adfe50169ea.png)

This error will be disappear if I hit any key to anywhere in editor.
