### PR TITLE
Fix KtTypeReference.hasParentheses() to check for both LPAR and RPAR

### DIFF
--- a/compiler/frontend/src/org/jetbrains/kotlin/psi/KtTypeReference.kt
+++ b/compiler/frontend/src/org/jetbrains/kotlin/psi/KtTypeReference.kt
@@ -49,6 +49,6 @@ class KtTypeReference : KtElementImplStub<KotlinPlaceHolderStub<KtTypeReference>
     }
 
     fun hasParentheses(): Boolean {
-        return findChildByType<PsiElement>(KtTokens.LPAR) != null && findChildByType<PsiElement>(KtTokens.LPAR) != null
+        return findChildByType<PsiElement>(KtTokens.LPAR) != null && findChildByType<PsiElement>(KtTokens.RPAR) != null
     }
 }


### PR DESCRIPTION
A year old typo had this redundantly checking for LPAR twice, rather than checking once for LPAR and once for RPAR.