### PR TITLE
KT-13588 Allow to convert empty Unit returning functions to expression form

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertToBlockBodyIntention.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertToBlockBodyIntention.kt
@@ -61,11 +61,11 @@ class ConvertToBlockBodyIntention : SelfTargetingIntention<KtDeclarationWithBody
 
             fun generateBody(returnsValue: Boolean): KtExpression {
                 val bodyType = body.analyze().getType(body)
+                val factory = KtPsiFactory(declaration)
+                if (bodyType != null && bodyType.isUnit() && body is KtNameReferenceExpression) return factory.createEmptyBody()
                 val unitWhenAsResult = (bodyType == null || bodyType.isUnit()) && body.resultingWhens().isNotEmpty()
                 val needReturn = returnsValue &&
                                  (bodyType == null || (!bodyType.isUnit() && !bodyType.isNothing()))
-
-                val factory = KtPsiFactory(declaration)
                 val statement = if (needReturn || unitWhenAsResult) factory.createExpressionByPattern("return $0", body) else body
                 return factory.createSingleStatementBlock(statement)
             }

--- a/idea/testData/intentions/convertToBlockBody/funWithCustomUnitClass.kt
+++ b/idea/testData/intentions/convertToBlockBody/funWithCustomUnitClass.kt
@@ -1,0 +1,5 @@
+// WITH_RUNTIME
+
+object Unit
+
+fun <caret>foo() = Unit

--- a/idea/testData/intentions/convertToBlockBody/funWithCustomUnitClass.kt.after
+++ b/idea/testData/intentions/convertToBlockBody/funWithCustomUnitClass.kt.after
@@ -1,0 +1,7 @@
+// WITH_RUNTIME
+
+object Unit
+
+fun foo(): Unit {
+    return Unit
+}

--- a/idea/testData/intentions/convertToBlockBody/funWithThrow.kt
+++ b/idea/testData/intentions/convertToBlockBody/funWithThrow.kt
@@ -1,3 +1,4 @@
 // WITH_RUNTIME
+import java.lang.UnsupportedOperationException
 
 fun <caret>foo(): String = throw UnsupportedOperationException()

--- a/idea/testData/intentions/convertToBlockBody/funWithThrow.kt.after
+++ b/idea/testData/intentions/convertToBlockBody/funWithThrow.kt.after
@@ -1,4 +1,5 @@
 // WITH_RUNTIME
+import java.lang.UnsupportedOperationException
 
 fun <caret>foo(): String {
     throw UnsupportedOperationException()

--- a/idea/testData/intentions/convertToBlockBody/funWithUnit.kt
+++ b/idea/testData/intentions/convertToBlockBody/funWithUnit.kt
@@ -1,0 +1,3 @@
+// WITH_RUNTIME
+
+fun <caret>foo() = Unit

--- a/idea/testData/intentions/convertToBlockBody/funWithUnit.kt.after
+++ b/idea/testData/intentions/convertToBlockBody/funWithUnit.kt.after
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+
+fun foo() {
+}

--- a/idea/testData/intentions/convertToBlockBody/getterWithThrow.kt
+++ b/idea/testData/intentions/convertToBlockBody/getterWithThrow.kt
@@ -1,4 +1,5 @@
 // WITH_RUNTIME
+import java.lang.UnsupportedOperationException
 
 val foo: String
     <caret>get() = throw UnsupportedOperationException()

--- a/idea/testData/intentions/convertToBlockBody/getterWithThrow.kt.after
+++ b/idea/testData/intentions/convertToBlockBody/getterWithThrow.kt.after
@@ -1,4 +1,5 @@
 // WITH_RUNTIME
+import java.lang.UnsupportedOperationException
 
 val foo: String
     get() {

--- a/idea/testData/intentions/convertToBlockBody/nothingFun.kt
+++ b/idea/testData/intentions/convertToBlockBody/nothingFun.kt
@@ -1,3 +1,4 @@
 // WITH_RUNTIME
+import java.lang.UnsupportedOperationException
 
 fun <caret>foo(): Nothing = throw UnsupportedOperationException()

--- a/idea/testData/intentions/convertToBlockBody/nothingFun.kt.after
+++ b/idea/testData/intentions/convertToBlockBody/nothingFun.kt.after
@@ -1,4 +1,5 @@
 // WITH_RUNTIME
+import java.lang.UnsupportedOperationException
 
 fun foo(): Nothing {
     throw UnsupportedOperationException()

--- a/idea/testData/intentions/convertToExpressionBody/funWithEmptyBody.kt
+++ b/idea/testData/intentions/convertToExpressionBody/funWithEmptyBody.kt
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+
+fun <caret>foo() {
+}

--- a/idea/testData/intentions/convertToExpressionBody/funWithEmptyBody.kt.after
+++ b/idea/testData/intentions/convertToExpressionBody/funWithEmptyBody.kt.after
@@ -1,0 +1,3 @@
+// WITH_RUNTIME
+
+fun foo() = Unit

--- a/idea/testData/intentions/convertToExpressionBody/funWithEmptyBody2.kt
+++ b/idea/testData/intentions/convertToExpressionBody/funWithEmptyBody2.kt
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+
+fun <caret>foo(): Unit {
+}

--- a/idea/testData/intentions/convertToExpressionBody/funWithEmptyBody2.kt.after
+++ b/idea/testData/intentions/convertToExpressionBody/funWithEmptyBody2.kt.after
@@ -1,0 +1,3 @@
+// WITH_RUNTIME
+
+fun foo(): Unit = Unit

--- a/idea/testData/intentions/convertToExpressionBody/funWithImplicitUnitTypeWithThrow.kt
+++ b/idea/testData/intentions/convertToExpressionBody/funWithImplicitUnitTypeWithThrow.kt
@@ -1,4 +1,5 @@
 // WITH_RUNTIME
+import java.lang.UnsupportedOperationException
 
 fun foo() {
     <caret>throw UnsupportedOperationException()

--- a/idea/testData/intentions/convertToExpressionBody/funWithImplicitUnitTypeWithThrow.kt.after
+++ b/idea/testData/intentions/convertToExpressionBody/funWithImplicitUnitTypeWithThrow.kt.after
@@ -1,3 +1,4 @@
 // WITH_RUNTIME
+import java.lang.UnsupportedOperationException
 
 fun foo()<selection>: Unit</selection> = throw UnsupportedOperationException()

--- a/idea/testData/intentions/convertToExpressionBody/funWithNothingType.kt
+++ b/idea/testData/intentions/convertToExpressionBody/funWithNothingType.kt
@@ -1,4 +1,5 @@
 // WITH_RUNTIME
+import java.lang.UnsupportedOperationException
 
 fun foo(): Nothing {
     <caret>throw UnsupportedOperationException()

--- a/idea/testData/intentions/convertToExpressionBody/funWithNothingType.kt.after
+++ b/idea/testData/intentions/convertToExpressionBody/funWithNothingType.kt.after
@@ -1,3 +1,4 @@
 // WITH_RUNTIME
+import java.lang.UnsupportedOperationException
 
 fun foo()<selection>: Nothing</selection> = throw UnsupportedOperationException()

--- a/idea/testData/intentions/convertToExpressionBody/funWithUnitTypeWithThrow.kt
+++ b/idea/testData/intentions/convertToExpressionBody/funWithUnitTypeWithThrow.kt
@@ -1,4 +1,5 @@
 // WITH_RUNTIME
+import java.lang.UnsupportedOperationException
 
 fun foo(): Unit {
     <caret>throw UnsupportedOperationException()

--- a/idea/testData/intentions/convertToExpressionBody/funWithUnitTypeWithThrow.kt.after
+++ b/idea/testData/intentions/convertToExpressionBody/funWithUnitTypeWithThrow.kt.after
@@ -1,3 +1,4 @@
 // WITH_RUNTIME
+import java.lang.UnsupportedOperationException
 
 fun foo()<selection>: Unit</selection> = throw UnsupportedOperationException()

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -4615,9 +4615,21 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
             doTest(fileName);
         }
 
+        @TestMetadata("funWithCustomUnitClass.kt")
+        public void testFunWithCustomUnitClass() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/convertToBlockBody/funWithCustomUnitClass.kt");
+            doTest(fileName);
+        }
+
         @TestMetadata("funWithThrow.kt")
         public void testFunWithThrow() throws Exception {
             String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/convertToBlockBody/funWithThrow.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("funWithUnit.kt")
+        public void testFunWithUnit() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/convertToBlockBody/funWithUnit.kt");
             doTest(fileName);
         }
 
@@ -4930,6 +4942,18 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
         @TestMetadata("expressionWithReturns2.kt")
         public void testExpressionWithReturns2() throws Exception {
             String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/convertToExpressionBody/expressionWithReturns2.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("funWithEmptyBody.kt")
+        public void testFunWithEmptyBody() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/convertToExpressionBody/funWithEmptyBody.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("funWithEmptyBody2.kt")
+        public void testFunWithEmptyBody2() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/convertToExpressionBody/funWithEmptyBody2.kt");
             doTest(fileName);
         }
 


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-13588

This pull request includes a commit that fixes failing test cases for `ConvertToBlockBodyIntention`/`ConvertToExpressionBodyIntention`.