### PR TITLE
#KT-13931 fixed

### DIFF
--- a/compiler/testData/codegen/box/ranges/inIntRange.kt
+++ b/compiler/testData/codegen/box/ranges/inIntRange.kt
@@ -1,0 +1,25 @@
+// WITH_RUNTIME
+
+fun box(): String {
+    for (x in 1..10) {
+        assert(x in 1..10)
+        assert(x + 10 !in 1..10)
+    }
+
+    var x = 0
+    assert(0 !in 1..2)
+
+    assert(++x in 1..1)
+    assert(++x !in 1..1)
+
+    assert(sideEffect(x) in 2..3)
+    return "OK"
+}
+
+
+var invocationCounter = 0
+fun sideEffect(x: Int): Int {
+    ++invocationCounter
+    assert(invocationCounter == 1)
+    return x
+}

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -11077,6 +11077,12 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             doTest(fileName);
         }
 
+        @TestMetadata("inIntRange.kt")
+        public void testInIntRange() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("compiler/testData/codegen/box/ranges/inIntRange.kt");
+            doTest(fileName);
+        }
+
         @TestMetadata("multiAssignmentIterationOverIntRange.kt")
         public void testMultiAssignmentIterationOverIntRange() throws Exception {
             String fileName = KotlinTestUtils.navigationMetadata("compiler/testData/codegen/box/ranges/multiAssignmentIterationOverIntRange.kt");


### PR DESCRIPTION
More compact (14 vs 19 bytecodes) contains method for IntRange.
Tested versus "All Jvm Backend Tests" run configuration.
No additional tests were added, there is enough coverage for primitive range 'in' (at least 5 new tests fail when implementation of genInIntRange is incorrect).

Verified that new method is almost the same as classic javac version (except additional label, which is not necessary), now both versions are recognized by decompiler as ` 239 <= x && x <= 250`:
```
  public final static intCmp(I)Z
   L0
    LINENUMBER 7 L0
    SIPUSH 239
    ILOAD 0
    IF_ICMPGT L1
    ILOAD 0
    SIPUSH 250
    IF_ICMPGT L1
   L2
    ICONST_1
    GOTO L3
   L1
    ICONST_0
   L3
    IRETURN
   L4
    LOCALVARIABLE x I L0 L4 0
    MAXSTACK = 2
    MAXLOCALS = 1

  public final static inInt(I)Z
   L0
    LINENUMBER 11 L0
    SIPUSH 239
    ILOAD 0
    IF_ICMPGT L1
    ILOAD 0
    SIPUSH 250
    IF_ICMPGT L1
    ICONST_1
    GOTO L2
   L1
    ICONST_0
   L2
    IRETURN
   L3
    LOCALVARIABLE x I L0 L3 0
    MAXSTACK = 2
    MAXLOCALS = 1
}
```

JMH benchmark doesn't show any difference on my laptop between old and new generated methods.