### PR TITLE
Fix Boolean.TYPE does not compile

### DIFF
--- a/j2k/src/org/jetbrains/kotlin/j2k/ExpressionConverter.kt
+++ b/j2k/src/org/jetbrains/kotlin/j2k/ExpressionConverter.kt
@@ -232,29 +232,8 @@ class DefaultExpressionConverter : JavaElementVisitor(), ExpressionConverter {
 
     override fun visitClassObjectAccessExpression(expression: PsiClassObjectAccessExpression) {
         val operand = expression.operand
-        val typeName = operand.type.canonicalText
-        val primitiveType = JvmPrimitiveType.values().firstOrNull { it.javaKeywordName == typeName }
-        val wrapperTypeName = if (primitiveType != null) {
-            primitiveType.wrapperFqName
-        }
-        else if (typeName == "void") { // by unknown reason it's not in JvmPrimitiveType enum
-            FqName("java.lang.Void")
-        }
-        else {
-            val type = converter.convertTypeElement(operand, Nullability.NotNull)
-            result = QualifiedExpression(ClassLiteralExpression(type).assignNoPrototype(), Identifier.withNoPrototype("java"), null)
-            return
-        }
-
-        //TODO: need more correct way to detect if short name is ok
-        val qualifiedName = wrapperTypeName.asString()
-        val classNameToUse = if (qualifiedName in needQualifierNameSet)
-            qualifiedName
-        else
-            wrapperTypeName.shortName().asString()
-        result = QualifiedExpression(Identifier(classNameToUse, false).assignPrototype(operand),
-                                     Identifier.withNoPrototype("TYPE", isNullable = false),
-                                     null)
+        val type = converter.convertTypeElement(operand, Nullability.NotNull)
+        result = QualifiedExpression(ClassLiteralExpression(type).assignNoPrototype(), Identifier.withNoPrototype("java"), null)
     }
 
     override fun visitConditionalExpression(expression: PsiConditionalExpression) {
@@ -907,9 +886,5 @@ class DefaultExpressionConverter : JavaElementVisitor(), ExpressionConverter {
 
     override fun visitExpression(expression: PsiExpression) {
         result = DummyStringExpression(expression.text)
-    }
-
-    companion object {
-        private val needQualifierNameSet = setOf("java.lang.Byte", "java.lang.Double", "java.lang.Float", "java.lang.Long", "java.lang.Short")
     }
 }

--- a/j2k/testData/fileOrElement/classExpression/complexExample.java
+++ b/j2k/testData/fileOrElement/classExpression/complexExample.java
@@ -1,2 +1,2 @@
 //statement
-Class<?>[] constrArgTypes = new Class<?>[]{String[].class, String.class};
+Class<?>[] constrArgTypes = new Class<?>[]{String[].class, String.class, Integer.class, Double.class};

--- a/j2k/testData/fileOrElement/classExpression/complexExample.kt
+++ b/j2k/testData/fileOrElement/classExpression/complexExample.kt
@@ -1,1 +1,1 @@
-val constrArgTypes = arrayOf<Class<*>>(Array<String>::class.java, String::class.java)
+val constrArgTypes = arrayOf<Class<*>>(Array<String>::class.java, String::class.java, Int::class.java, Double::class.java)

--- a/j2k/testData/fileOrElement/classExpression/primitivesAndArrays.java
+++ b/j2k/testData/fileOrElement/classExpression/primitivesAndArrays.java
@@ -1,6 +1,7 @@
 public class A {
     public static void main(String[] args) {
         System.out.println(void.class);
+        System.out.println(boolean.class);
         System.out.println(int.class);
         System.out.println(double.class);
         System.out.println(int[].class);

--- a/j2k/testData/fileOrElement/classExpression/primitivesAndArrays.kt
+++ b/j2k/testData/fileOrElement/classExpression/primitivesAndArrays.kt
@@ -1,8 +1,9 @@
 object A {
     @JvmStatic fun main(args: Array<String>) {
-        println(Void.TYPE)
-        println(Integer.TYPE)
-        println(java.lang.Double.TYPE)
+        println(Unit::class.java)
+        println(Boolean::class.java)
+        println(Int::class.java)
+        println(Double::class.java)
         println(IntArray::class.java)
         println(Array<Any>::class.java)
         println(Array<Array<Any>>::class.java)


### PR DESCRIPTION
#KT-13550 Fixed
https://youtrack.jetbrains.com/issue/KT-13550

Thank you for your advice in https://youtrack.jetbrains.com/issue/KT-13550 .
I was suggested the javaPrimitiveType through the KT-13550.
However, maybe if you are not using the Java class (for example java.lang.Boolean), javaPrimitiveType and java is the same.
Not used Java classes as a result of J2K in the current implementation.
So, I changed to use .java.