### PR TITLE
KT-14156 Add support for star suffix in annotation processor

### DIFF
--- a/plugins/annotation-processing/testData/processors/StarSuffix.kt
+++ b/plugins/annotation-processing/testData/processors/StarSuffix.kt
@@ -1,0 +1,10 @@
+package processors
+
+@Anno1
+class MarkedWithAnno1
+
+@Anno2
+class MarkedWithAnno2
+
+annotation class Anno1
+annotation class Anno2

--- a/plugins/plugins-tests/tests/org/jetbrains/kotlin/annotation/processing/test/processor/ProcessorTests.kt
+++ b/plugins/plugins-tests/tests/org/jetbrains/kotlin/annotation/processing/test/processor/ProcessorTests.kt
@@ -380,4 +380,17 @@ class ProcessorTests : AbstractProcessorTest() {
         assertEquals(1, env.messager.errorCount)
         assertEquals(0, env.messager.warningCount)
     }
+
+    fun testStarSuffix() = test("StarSuffix", "processors.*") { set, roundEnv, env ->
+        assertEquals(2, set.size)
+
+        fun test(annotationName:String, markedElementName:String){
+            val annotation = set.single { it.simpleName.toString() == annotationName}
+            val annotatedElement = roundEnv.getElementsAnnotatedWith(annotation).single()
+            assertEquals(annotatedElement.simpleName.toString(), markedElementName)
+        }
+
+        test("Anno1", "MarkedWithAnno1")
+        test("Anno2", "MarkedWithAnno2")
+    }
 }


### PR DESCRIPTION
[KT-14156](https://youtrack.jetbrains.com/issue/KT-14156) aims to add support for  `@SupportedAnnotationTypes.value`  elements specified in the form of i.e.: `@SupportedAnnotationTypes({"com.querydsl.core.annotations.*","javax.persistence.*"})`

Without this support the kapt2 cannot be used with libraries such as [`QueryDsl`](https://github.com/querydsl/querydsl/blob/master/querydsl-apt/src/main/java/com/querydsl/apt/jpa/JPAAnnotationProcessor.java)
