### PR TITLE
make Kotlin plugin compatible with IDEA 2017.1 builds

### DIFF
--- a/idea/src/META-INF/plugin.xml
+++ b/idea/src/META-INF/plugin.xml
@@ -6,7 +6,7 @@
   <version>@snapshot@</version>
   <vendor url="http://www.jetbrains.com">JetBrains s.r.o.</vendor>
 
-  <idea-version since-build="145.257" until-build="163.*"/>
+  <idea-version since-build="145.257" until-build="171.*"/>
 
   <depends>com.intellij.modules.java</depends>
 


### PR DESCRIPTION
We are creating stable branch for IDEA 2016.3 releases and 'master' branch will have 171.\* build numbers.
