### PR TITLE
KT-14131

### DIFF
--- a/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/kotlinSpacingRules.kt
+++ b/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/kotlinSpacingRules.kt
@@ -156,6 +156,9 @@ fun createSpacingBuilder(settings: CodeStyleSettings, builderUtil: KotlinSpacing
             betweenInside(RETURN_KEYWORD, LABEL_QUALIFIER, RETURN).spaces(0)
             afterInside(RETURN_KEYWORD, RETURN).spaces(1)
             afterInside(LABEL_QUALIFIER, RETURN).spaces(1)
+            betweenInside(LABEL_QUALIFIER, EOL_COMMENT, LABELED_EXPRESSION).spacing(0, Int.MAX_VALUE, 0, true, codeStyleSettings.KEEP_BLANK_LINES_IN_CODE)
+            betweenInside(LABEL_QUALIFIER, BLOCK_COMMENT, LABELED_EXPRESSION).spacing(0, Int.MAX_VALUE, 0, true, codeStyleSettings.KEEP_BLANK_LINES_IN_CODE)
+            afterInside(LABEL_QUALIFIER, LABELED_EXPRESSION).spaces(1)
 
             betweenInside(FUN_KEYWORD, VALUE_PARAMETER_LIST, FUN).spacing(0, 0, 0, false, 0)
             after(FUN_KEYWORD).spaces(1)

--- a/idea/testData/formatter/LabeledExpression.after.kt
+++ b/idea/testData/formatter/LabeledExpression.after.kt
@@ -1,0 +1,40 @@
+fun test1() {
+    loop@ while (true) {
+
+    }
+}
+
+fun test2() {
+    listOf(1).forEach lit@ {
+        if (it == 0) return@lit
+        print(it)
+    }
+}
+
+fun test3() {
+    l1@
+
+
+    /*comment*/ {
+
+    }
+
+    l2@    /*comment*/ {
+
+    }
+}
+
+fun test4() {
+    l1@
+
+
+    //eol comment
+    {
+
+    }
+
+    l2@    //eol comment
+    {
+
+    }
+}

--- a/idea/testData/formatter/LabeledExpression.kt
+++ b/idea/testData/formatter/LabeledExpression.kt
@@ -1,0 +1,40 @@
+fun test1() {
+    loop@    while(true) {
+
+    }
+}
+
+fun test2() {
+    listOf(1).forEach lit@    {
+        if (it == 0) return@lit
+        print(it)
+    }
+}
+
+fun test3() {
+    l1@
+
+
+    /*comment*/ {
+
+    }
+
+    l2@    /*comment*/ {
+
+    }
+}
+
+fun test4() {
+    l1@
+
+
+    //eol comment
+    {
+
+    }
+
+    l2@    //eol comment
+    {
+
+    }
+}

--- a/idea/testData/intentions/moveLambdaInsideParentheses/moveLabeledLambda2.kt.after
+++ b/idea/testData/intentions/moveLambdaInsideParentheses/moveLabeledLambda2.kt.after
@@ -1,6 +1,6 @@
 // IS_APPLICABLE: true
 fun foo() {
-    bar(l@{ it * 3 })
+    bar(l@ { it * 3 })
 }
 
 fun bar(b: (Int) -> Int) {

--- a/idea/tests/org/jetbrains/kotlin/formatter/FormatterTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/formatter/FormatterTestGenerated.java
@@ -511,6 +511,12 @@ public class FormatterTestGenerated extends AbstractFormatterTest {
             doTest(fileName);
         }
 
+        @TestMetadata("LabeledExpression.after.kt")
+        public void testLabeledExpression() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/formatter/LabeledExpression.after.kt");
+            doTest(fileName);
+        }
+
         @TestMetadata("RightBracketOnNewLine.after.kt")
         public void testRightBracketOnNewLine() throws Exception {
             String fileName = KotlinTestUtils.navigationMetadata("idea/testData/formatter/RightBracketOnNewLine.after.kt");


### PR DESCRIPTION
Judging by examples in documentation, 1 space between label and expression is expected. Other tests (e.g. PrimaryConstructor.after.kt) suggest that spaces between label and comment should be left as they are.