### PR TITLE
KT-14390 stop "Remove redundant '.let' call" when receiver is used

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/intentions/ReplaceSingleLineLetIntention.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/ReplaceSingleLineLetIntention.kt
@@ -17,12 +17,11 @@
 package org.jetbrains.kotlin.idea.intentions
 
 import com.intellij.openapi.editor.Editor
-import org.jetbrains.kotlin.idea.caches.resolve.analyze
 import org.jetbrains.kotlin.idea.inspections.IntentionBasedInspection
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.*
-import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
-import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameUnsafe
+import org.jetbrains.kotlin.psi.psiUtil.anyDescendantOfType
+import org.jetbrains.kotlin.psi.psiUtil.findDescendantOfType
 
 class ReplaceSingleLineLetInspection : IntentionBasedInspection<KtCallExpression>(ReplaceSingleLineLetIntention::class) {
     override fun inspectionTarget(element: KtCallExpression) = element.calleeExpression
@@ -86,6 +85,9 @@ class ReplaceSingleLineLetIntention : SelfTargetingOffsetIndependentIntention<Kt
         val parameterName = lambdaExpression.getParameterName() ?: return false
         val receiverExpression = dotQualifiedExpression.getLeftMostReceiverExpression()
         if (receiverExpression.text != parameterName) return false
+        dotQualifiedExpression.selectorExpression?.let {
+            if (it.anyDescendantOfType<KtLambdaExpression>()) return false
+        }
         return !dotQualifiedExpression.receiverUsedAsArgument(parameterName)
     }
 
@@ -102,7 +104,16 @@ class ReplaceSingleLineLetIntention : SelfTargetingOffsetIndependentIntention<Kt
             (receiverExpression as? KtDotQualifiedExpression)?.getLeftMostReceiverExpression() ?: receiverExpression
 
     private fun KtDotQualifiedExpression.receiverUsedAsArgument(receiverName: String): Boolean {
-        if ((selectorExpression as? KtCallExpression)?.valueArguments?.firstOrNull { it.text == receiverName } != null) return true
+        if ((selectorExpression as? KtCallExpression)?.valueArguments.receiverUsedAsValueArguments(receiverName)) return true
         return (receiverExpression as? KtDotQualifiedExpression)?.receiverUsedAsArgument(receiverName) ?: false
+    }
+
+    private fun List<KtValueArgument>?.receiverUsedAsValueArguments(receiverName: String): Boolean {
+        this ?: return false
+        return any {
+            valueArgument ->
+            val ktDotQualifiedExpression = valueArgument.findDescendantOfType<KtDotQualifiedExpression>() ?: return@any valueArgument.text == receiverName
+            ktDotQualifiedExpression.getLeftMostReceiverExpression().text == receiverName || ktDotQualifiedExpression.receiverUsedAsArgument(receiverName)
+        }
     }
 }

--- a/idea/testData/intentions/replaceSingleLineLetIntention/multipleReceiver.kt
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/multipleReceiver.kt
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+// IS_APPLICABLE: false
+
+fun baz(foo: String) {
+    foo.let<caret> { it.substringAfterLast(it.capitalize()) }
+}

--- a/idea/testData/intentions/replaceSingleLineLetIntention/multipleReceiver2.kt
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/multipleReceiver2.kt
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+// IS_APPLICABLE: false
+
+fun baz(foo: String) {
+    foo.let<caret> { it.substringAfterLast("".equals(it).toString()) }
+}

--- a/idea/testData/intentions/replaceSingleLineLetIntention/multipleReceiver3.kt
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/multipleReceiver3.kt
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+// IS_APPLICABLE: false
+
+fun baz(foo: String) {
+    foo.let<caret> { it.substring(0, it.length) }
+}

--- a/idea/testData/intentions/replaceSingleLineLetIntention/receiverWithLambda.kt
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/receiverWithLambda.kt
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+// IS_APPLICABLE: false
+
+fun baz(foo: String) {
+    foo.let<caret> { it.indexOfLast { c -> c == it[0] } }
+}

--- a/idea/testData/intentions/replaceSingleLineLetIntention/receiverWithLambda2.kt
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/receiverWithLambda2.kt
@@ -1,0 +1,9 @@
+// WITH_RUNTIME
+// IS_APPLICABLE: false
+// This should be reported. However, in order to avoid too complecate logic, the intention ignore this case.
+
+import java.util.*
+
+fun baz2(foo: List<String>) {
+    foo.let<caret> { it.binarySearch("", Comparator<kotlin.String> { o1, o2 -> 0 }) }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -11516,6 +11516,36 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
             doTest(fileName);
         }
 
+        @TestMetadata("multipleReceiver.kt")
+        public void testMultipleReceiver() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/replaceSingleLineLetIntention/multipleReceiver.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("multipleReceiver2.kt")
+        public void testMultipleReceiver2() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/replaceSingleLineLetIntention/multipleReceiver2.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("multipleReceiver3.kt")
+        public void testMultipleReceiver3() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/replaceSingleLineLetIntention/multipleReceiver3.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("receiverWithLambda.kt")
+        public void testReceiverWithLambda() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/replaceSingleLineLetIntention/receiverWithLambda.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("receiverWithLambda2.kt")
+        public void testReceiverWithLambda2() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/replaceSingleLineLetIntention/receiverWithLambda2.kt");
+            doTest(fileName);
+        }
+
         @TestMetadata("sameLets.kt")
         public void testSameLets() throws Exception {
             String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/replaceSingleLineLetIntention/sameLets.kt");


### PR DESCRIPTION
 #KT-14390 Fixed

https://youtrack.jetbrains.com/issue/KT-14390