### PR TITLE
Use "Generate Tests" to regenerate `testLabeledExpression`

### DIFF
--- a/idea/tests/org/jetbrains/kotlin/formatter/FormatterTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/formatter/FormatterTestGenerated.java
@@ -391,6 +391,12 @@ public class FormatterTestGenerated extends AbstractFormatterTest {
             doTest(fileName);
         }
 
+        @TestMetadata("LabeledExpression.after.kt")
+        public void testLabeledExpression() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/formatter/LabeledExpression.after.kt");
+            doTest(fileName);
+        }
+
         @TestMetadata("LambdaArrow.after.kt")
         public void testLambdaArrow() throws Exception {
             String fileName = KotlinTestUtils.navigationMetadata("idea/testData/formatter/LambdaArrow.after.kt");
@@ -508,12 +514,6 @@ public class FormatterTestGenerated extends AbstractFormatterTest {
         @TestMetadata("ReturnExpression.after.kt")
         public void testReturnExpression() throws Exception {
             String fileName = KotlinTestUtils.navigationMetadata("idea/testData/formatter/ReturnExpression.after.kt");
-            doTest(fileName);
-        }
-
-        @TestMetadata("LabeledExpression.after.kt")
-        public void testLabeledExpression() throws Exception {
-            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/formatter/LabeledExpression.after.kt");
             doTest(fileName);
         }
 


### PR DESCRIPTION
It keeps showing the diff when I run "Generate Tests". I think this pull request https://github.com/JetBrains/kotlin/pull/978/files generates test cases without running "Generate Tests". 
