### PR TITLE
KT-14570 Remove support of MutableList/MutableSet/MutableMap of RemoveRedundantCallsOfConversionMethodsIntention

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/intentions/RemoveRedundantCallsOfConversionMethodsIntention.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/RemoveRedundantCallsOfConversionMethodsIntention.kt
@@ -26,6 +26,7 @@ import org.jetbrains.kotlin.js.descriptorUtils.getJetTypeFqName
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
 import org.jetbrains.kotlin.resolve.calls.callUtil.getType
+import org.jetbrains.kotlin.types.isFlexible
 import java.util.*
 
 class RemoveRedundantCallsOfConversionMethodsInspection : IntentionBasedInspection<KtQualifiedExpression>(RemoveRedundantCallsOfConversionMethodsIntention::class) {
@@ -71,7 +72,12 @@ class RemoveRedundantCallsOfConversionMethodsIntention : SelfTargetingRangeInten
         return when (this) {
             is KtStringTemplateExpression -> String::class.qualifiedName
             is KtConstantExpression -> getType(analyze())?.getJetTypeFqName(false)
-            else -> getResolvedCall(analyze())?.candidateDescriptor?.returnType?.getJetTypeFqName(false)
+            else -> {
+                getResolvedCall(analyze())?.candidateDescriptor?.returnType?.let {
+                    if (it.isFlexible()) return false
+                    it.getJetTypeFqName(false)
+                }
+            }
         } == qualifiedName
     }
 }

--- a/idea/testData/intentions/removeRedundantCallsOfConversionMethods/platformTypes.kt
+++ b/idea/testData/intentions/removeRedundantCallsOfConversionMethods/platformTypes.kt
@@ -1,0 +1,5 @@
+// WITH_RUNTIME
+// IS_APPLICABLE: false
+import java.util.Collections
+
+val foo = Collections.unmodifiableList(listOf(1)).toMutableList()<caret>

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -11231,6 +11231,12 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
             doTest(fileName);
         }
 
+        @TestMetadata("platformTypes.kt")
+        public void testPlatformTypes() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/removeRedundantCallsOfConversionMethods/platformTypes.kt");
+            doTest(fileName);
+        }
+
         @TestMetadata("safeSortedMap.kt")
         public void testSafeSortedMap() throws Exception {
             String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/removeRedundantCallsOfConversionMethods/safeSortedMap.kt");


### PR DESCRIPTION
 #KT-14570 Fixed

https://youtrack.jetbrains.com/issue/KT-14570
