### PR TITLE
KT-15030 Remove redundant calls of conversion methods: false positive for 'toList()'

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/intentions/RemoveRedundantCallsOfConversionMethodsIntention.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/RemoveRedundantCallsOfConversionMethodsIntention.kt
@@ -23,11 +23,13 @@ import org.jetbrains.kotlin.idea.caches.resolve.analyze
 import org.jetbrains.kotlin.idea.core.replaced
 import org.jetbrains.kotlin.idea.inspections.IntentionBasedInspection
 import org.jetbrains.kotlin.js.descriptorUtils.getJetTypeFqName
-import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.KtConstantExpression
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtQualifiedExpression
+import org.jetbrains.kotlin.psi.KtStringTemplateExpression
 import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
 import org.jetbrains.kotlin.resolve.calls.callUtil.getType
 import org.jetbrains.kotlin.types.isFlexible
-import java.util.*
 
 class RemoveRedundantCallsOfConversionMethodsInspection : IntentionBasedInspection<KtQualifiedExpression>(RemoveRedundantCallsOfConversionMethodsIntention::class) {
     override val problemHighlightType = ProblemHighlightType.LIKE_UNUSED_SYMBOL
@@ -35,15 +37,7 @@ class RemoveRedundantCallsOfConversionMethodsInspection : IntentionBasedInspecti
 
 class RemoveRedundantCallsOfConversionMethodsIntention : SelfTargetingRangeIntention<KtQualifiedExpression>(KtQualifiedExpression::class.java, "Remove redundant calls of the conversion method") {
 
-    private val targetClassMap = mapOf("toList()" to List::class.qualifiedName,
-                                       "toSet()" to Set::class.qualifiedName,
-                                       "toMap()" to Map::class.qualifiedName,
-                                       "toMutableList()" to "kotlin.collections.MutableList",
-                                       "toMutableSet()" to "kotlin.collections.MutableSet",
-                                       "toMutableMap()" to "kotlin.collections.MutableMap",
-                                       "toSortedSet()" to SortedSet::class.qualifiedName,
-                                       "toSortedMap()" to SortedMap::class.qualifiedName,
-                                       "toString()" to String::class.qualifiedName,
+    private val targetClassMap = mapOf("toString()" to String::class.qualifiedName,
                                        "toDouble()" to Double::class.qualifiedName,
                                        "toFloat()" to Float::class.qualifiedName,
                                        "toLong()" to Long::class.qualifiedName,

--- a/idea/testData/intentions/removeRedundantCallsOfConversionMethods/list.kt
+++ b/idea/testData/intentions/removeRedundantCallsOfConversionMethods/list.kt
@@ -1,2 +1,0 @@
-// WITH_RUNTIME
-val foo = listOf(1, 2, 3).toList()<caret>

--- a/idea/testData/intentions/removeRedundantCallsOfConversionMethods/list.kt.after
+++ b/idea/testData/intentions/removeRedundantCallsOfConversionMethods/list.kt.after
@@ -1,2 +1,0 @@
-// WITH_RUNTIME
-val foo = listOf(1, 2, 3)

--- a/idea/testData/intentions/removeRedundantCallsOfConversionMethods/list2.kt
+++ b/idea/testData/intentions/removeRedundantCallsOfConversionMethods/list2.kt
@@ -1,2 +1,0 @@
-// WITH_RUNTIME
-val foo = listOf(1, 2, 3).map(Int::toString).toList()<caret>

--- a/idea/testData/intentions/removeRedundantCallsOfConversionMethods/list2.kt.after
+++ b/idea/testData/intentions/removeRedundantCallsOfConversionMethods/list2.kt.after
@@ -1,2 +1,0 @@
-// WITH_RUNTIME
-val foo = listOf(1, 2, 3).map(Int::toString)

--- a/idea/testData/intentions/removeRedundantCallsOfConversionMethods/mutableList.kt
+++ b/idea/testData/intentions/removeRedundantCallsOfConversionMethods/mutableList.kt
@@ -1,2 +1,0 @@
-// WITH_RUNTIME
-val foo = mutableListOf(1, 2, 3).toMutableList()<caret>

--- a/idea/testData/intentions/removeRedundantCallsOfConversionMethods/mutableList.kt.after
+++ b/idea/testData/intentions/removeRedundantCallsOfConversionMethods/mutableList.kt.after
@@ -1,2 +1,0 @@
-// WITH_RUNTIME
-val foo = mutableListOf(1, 2, 3)

--- a/idea/testData/intentions/removeRedundantCallsOfConversionMethods/mutableSet.kt
+++ b/idea/testData/intentions/removeRedundantCallsOfConversionMethods/mutableSet.kt
@@ -1,2 +1,0 @@
-// WITH_RUNTIME
-val foo = mutableSetOf(1, 2, 3).toMutableSet()<caret>

--- a/idea/testData/intentions/removeRedundantCallsOfConversionMethods/mutableSet.kt.after
+++ b/idea/testData/intentions/removeRedundantCallsOfConversionMethods/mutableSet.kt.after
@@ -1,2 +1,0 @@
-// WITH_RUNTIME
-val foo = mutableSetOf(1, 2, 3)

--- a/idea/testData/intentions/removeRedundantCallsOfConversionMethods/platformTypes.kt
+++ b/idea/testData/intentions/removeRedundantCallsOfConversionMethods/platformTypes.kt
@@ -1,5 +1,0 @@
-// WITH_RUNTIME
-// IS_APPLICABLE: false
-import java.util.Collections
-
-val foo = Collections.unmodifiableList(listOf(1)).toMutableList()<caret>

--- a/idea/testData/intentions/removeRedundantCallsOfConversionMethods/safeSortedMap.kt
+++ b/idea/testData/intentions/removeRedundantCallsOfConversionMethods/safeSortedMap.kt
@@ -1,8 +1,0 @@
-// WITH_RUNTIME
-
-import java.util.SortedMap
-
-fun test() {
-    val foo: SortedMap<String, String>? = null
-    foo?.toSortedMap()<caret>
-}

--- a/idea/testData/intentions/removeRedundantCallsOfConversionMethods/safeSortedMap.kt.after
+++ b/idea/testData/intentions/removeRedundantCallsOfConversionMethods/safeSortedMap.kt.after
@@ -1,8 +1,0 @@
-// WITH_RUNTIME
-
-import java.util.SortedMap
-
-fun test() {
-    val foo: SortedMap<String, String>? = null
-    foo
-}

--- a/idea/testData/intentions/removeRedundantCallsOfConversionMethods/set.kt
+++ b/idea/testData/intentions/removeRedundantCallsOfConversionMethods/set.kt
@@ -1,2 +1,0 @@
-// WITH_RUNTIME
-val foo = setOf(1, 2, 3).toSet()<caret>

--- a/idea/testData/intentions/removeRedundantCallsOfConversionMethods/set.kt.after
+++ b/idea/testData/intentions/removeRedundantCallsOfConversionMethods/set.kt.after
@@ -1,2 +1,0 @@
-// WITH_RUNTIME
-val foo = setOf(1, 2, 3)

--- a/idea/testData/intentions/removeRedundantCallsOfConversionMethods/sortedMap.kt
+++ b/idea/testData/intentions/removeRedundantCallsOfConversionMethods/sortedMap.kt
@@ -1,2 +1,0 @@
-// WITH_RUNTIME
-val foo = sortedMapOf(1 to 1).toSortedMap()<caret>

--- a/idea/testData/intentions/removeRedundantCallsOfConversionMethods/sortedMap.kt.after
+++ b/idea/testData/intentions/removeRedundantCallsOfConversionMethods/sortedMap.kt.after
@@ -1,2 +1,0 @@
-// WITH_RUNTIME
-val foo = sortedMapOf(1 to 1)

--- a/idea/testData/intentions/removeRedundantCallsOfConversionMethods/sortedSet.kt
+++ b/idea/testData/intentions/removeRedundantCallsOfConversionMethods/sortedSet.kt
@@ -1,3 +1,0 @@
-// WITH_RUNTIME
-// sortedSetOf returns TreeSet not SortedSet
-val foo = sortedSetOf(1, 2, 3).toSortedSet().toSortedSet()<caret>

--- a/idea/testData/intentions/removeRedundantCallsOfConversionMethods/sortedSet.kt.after
+++ b/idea/testData/intentions/removeRedundantCallsOfConversionMethods/sortedSet.kt.after
@@ -1,3 +1,0 @@
-// WITH_RUNTIME
-// sortedSetOf returns TreeSet not SortedSet
-val foo = sortedSetOf(1, 2, 3).toSortedSet()

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -11607,45 +11607,9 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
             doTest(fileName);
         }
 
-        @TestMetadata("list.kt")
-        public void testList() throws Exception {
-            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/removeRedundantCallsOfConversionMethods/list.kt");
-            doTest(fileName);
-        }
-
-        @TestMetadata("list2.kt")
-        public void testList2() throws Exception {
-            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/removeRedundantCallsOfConversionMethods/list2.kt");
-            doTest(fileName);
-        }
-
         @TestMetadata("long.kt")
         public void testLong() throws Exception {
             String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/removeRedundantCallsOfConversionMethods/long.kt");
-            doTest(fileName);
-        }
-
-        @TestMetadata("mutableList.kt")
-        public void testMutableList() throws Exception {
-            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/removeRedundantCallsOfConversionMethods/mutableList.kt");
-            doTest(fileName);
-        }
-
-        @TestMetadata("mutableSet.kt")
-        public void testMutableSet() throws Exception {
-            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/removeRedundantCallsOfConversionMethods/mutableSet.kt");
-            doTest(fileName);
-        }
-
-        @TestMetadata("platformTypes.kt")
-        public void testPlatformTypes() throws Exception {
-            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/removeRedundantCallsOfConversionMethods/platformTypes.kt");
-            doTest(fileName);
-        }
-
-        @TestMetadata("safeSortedMap.kt")
-        public void testSafeSortedMap() throws Exception {
-            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/removeRedundantCallsOfConversionMethods/safeSortedMap.kt");
             doTest(fileName);
         }
 
@@ -11655,27 +11619,9 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
             doTest(fileName);
         }
 
-        @TestMetadata("set.kt")
-        public void testSet() throws Exception {
-            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/removeRedundantCallsOfConversionMethods/set.kt");
-            doTest(fileName);
-        }
-
         @TestMetadata("short.kt")
         public void testShort() throws Exception {
             String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/removeRedundantCallsOfConversionMethods/short.kt");
-            doTest(fileName);
-        }
-
-        @TestMetadata("sortedMap.kt")
-        public void testSortedMap() throws Exception {
-            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/removeRedundantCallsOfConversionMethods/sortedMap.kt");
-            doTest(fileName);
-        }
-
-        @TestMetadata("sortedSet.kt")
-        public void testSortedSet() throws Exception {
-            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/removeRedundantCallsOfConversionMethods/sortedSet.kt");
             doTest(fileName);
         }
 


### PR DESCRIPTION
 #KT-15030 Fixed

https://youtrack.jetbrains.com/issue/KT-15030