### PR TITLE
KT-15142 Remove redundant calls of the conversion method wrongly shown for Any?.toString

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/intentions/RemoveRedundantCallsOfConversionMethodsIntention.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/RemoveRedundantCallsOfConversionMethodsIntention.kt
@@ -23,10 +23,7 @@ import org.jetbrains.kotlin.idea.caches.resolve.analyze
 import org.jetbrains.kotlin.idea.core.replaced
 import org.jetbrains.kotlin.idea.inspections.IntentionBasedInspection
 import org.jetbrains.kotlin.js.descriptorUtils.getJetTypeFqName
-import org.jetbrains.kotlin.psi.KtConstantExpression
-import org.jetbrains.kotlin.psi.KtExpression
-import org.jetbrains.kotlin.psi.KtQualifiedExpression
-import org.jetbrains.kotlin.psi.KtStringTemplateExpression
+import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
 import org.jetbrains.kotlin.resolve.calls.callUtil.getType
 import org.jetbrains.kotlin.types.isFlexible
@@ -69,6 +66,7 @@ class RemoveRedundantCallsOfConversionMethodsIntention : SelfTargetingRangeInten
             else -> {
                 getResolvedCall(analyze())?.candidateDescriptor?.returnType?.let {
                     if (it.isFlexible()) null
+                    else if (it.isMarkedNullable && parent !is KtSafeQualifiedExpression) null
                     else it.getJetTypeFqName(false)
                 }
             }

--- a/idea/testData/intentions/removeRedundantCallsOfConversionMethods/nullable.kt
+++ b/idea/testData/intentions/removeRedundantCallsOfConversionMethods/nullable.kt
@@ -1,0 +1,5 @@
+// WITH_RUNTIME
+// IS_APPLICABLE: false
+fun foo(s: String?) {
+    val t: String = s.toString()<caret>
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -11649,6 +11649,12 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
             doTest(fileName);
         }
 
+        @TestMetadata("nullable.kt")
+        public void testNullable() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/removeRedundantCallsOfConversionMethods/nullable.kt");
+            doTest(fileName);
+        }
+
         @TestMetadata("safeString.kt")
         public void testSafeString() throws Exception {
             String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/removeRedundantCallsOfConversionMethods/safeString.kt");


### PR DESCRIPTION
 #KT-15142 Fixed

https://youtrack.jetbrains.com/issue/KT-15142