### PR TITLE
Fix typo

### DIFF
--- a/compiler/daemon/src/org/jetbrains/kotlin/daemon/CompileServiceImpl.kt
+++ b/compiler/daemon/src/org/jetbrains/kotlin/daemon/CompileServiceImpl.kt
@@ -359,7 +359,7 @@ class CompileServiceImpl(
             }
 
             val artifactChanges = RemoteArtifactChangesProvider(servicesFacade)
-            val changesRegistry = RemoteChangesRegostry(servicesFacade)
+            val changesRegistry = RemoteChangesRegistry(servicesFacade)
 
             val workingDir = servicesFacade.workingDir()
             val versions = commonCacheVersions(workingDir) +

--- a/compiler/daemon/src/org/jetbrains/kotlin/daemon/incremental/RemoteChangesRegistry.kt
+++ b/compiler/daemon/src/org/jetbrains/kotlin/daemon/incremental/RemoteChangesRegistry.kt
@@ -20,7 +20,7 @@ import org.jetbrains.kotlin.daemon.common.IncrementalCompilationServicesFacade
 import org.jetbrains.kotlin.incremental.DirtyData
 import org.jetbrains.kotlin.incremental.multiproject.ChangesRegistry
 
-internal class RemoteChangesRegostry(private val servicesFacade: IncrementalCompilationServicesFacade) : ChangesRegistry {
+internal class RemoteChangesRegistry(private val servicesFacade: IncrementalCompilationServicesFacade) : ChangesRegistry {
     override fun unknownChanges(timestamp: Long) {
         servicesFacade.unknownChanges(timestamp)
     }


### PR DESCRIPTION
Simple typo fix in RemoteChangesReg**o**stry (should be RemoteChangesRegistry)