### PR TITLE
Convert function to property shouldn't insert explicit type if it was inferred previously

### DIFF
--- a/compiler/frontend/src/org/jetbrains/kotlin/psi/KtPsiFactory.kt
+++ b/compiler/frontend/src/org/jetbrains/kotlin/psi/KtPsiFactory.kt
@@ -612,7 +612,7 @@ class KtPsiFactory @JvmOverloads constructor(private val project: Project, val m
         private fun placeKeyword() {
             assert(state == State.MODIFIERS)
 
-            if (sb.isNotEmpty()) {
+            if (!sb.endsWith(" ")) {
                 sb.append(" ")
             }
             val keyword = when (target) {
@@ -625,9 +625,9 @@ class KtPsiFactory @JvmOverloads constructor(private val project: Project, val m
             state = State.RECEIVER
         }
 
-        private fun bodyPrefix() = when (target) {
+        private fun bodyPrefix(breakLine: Boolean = true) = when (target) {
             Target.FUNCTION, Target.CONSTRUCTOR -> ""
-            Target.READ_ONLY_PROPERTY -> "\nget()"
+            Target.READ_ONLY_PROPERTY -> (if (breakLine) "\n" else " ") + "get()"
         }
 
         fun modifier(modifier: String): CallableBuilder {
@@ -728,6 +728,16 @@ class KtPsiFactory @JvmOverloads constructor(private val project: Project, val m
             assert(state == State.BODY || state == State.TYPE_CONSTRAINTS)
 
             sb.append(bodyPrefix()).append(" {\n").append(body).append("\n}")
+            state = State.DONE
+
+            return this
+        }
+
+        fun getterExpression(expression: String, breakLine: Boolean = true): CallableBuilder {
+            assert(target == Target.READ_ONLY_PROPERTY)
+            assert(state == State.BODY || state == State.TYPE_CONSTRAINTS)
+
+            sb.append(bodyPrefix(breakLine)).append(" = ").append(expression)
             state = State.DONE
 
             return this

--- a/idea/testData/intentions/convertFunctionToProperty/addExplicitAnonymousType.kt.after
+++ b/idea/testData/intentions/convertFunctionToProperty/addExplicitAnonymousType.kt.after
@@ -3,12 +3,11 @@ interface T {
 }
 
 class A(val n: Int) {
-    val foo: T
-        get() = object : T {
-            override fun bar() {
+    val foo get() = object : T {
+        override fun bar() {
 
-            }
         }
+    }
 }
 
 fun test() {

--- a/idea/testData/intentions/convertFunctionToProperty/addExplicitLocalType.kt.after
+++ b/idea/testData/intentions/convertFunctionToProperty/addExplicitLocalType.kt.after
@@ -2,8 +2,7 @@ fun test() {
     class X
 
     class A(val n: Int) {
-        val foo: X
-            get() = X()
+        val foo get() = X()
     }
 
     val t = A(1).foo

--- a/idea/testData/intentions/convertFunctionToProperty/addExplicitType.kt.after
+++ b/idea/testData/intentions/convertFunctionToProperty/addExplicitType.kt.after
@@ -1,6 +1,5 @@
 class A(val n: Int) {
-    val foo: Boolean
-        get() = n > 1
+    val foo get() = n > 1
 }
 
 fun test() {

--- a/idea/testData/intentions/convertFunctionToProperty/annotationLineBreak.kt
+++ b/idea/testData/intentions/convertFunctionToProperty/annotationLineBreak.kt
@@ -1,0 +1,4 @@
+annotation class X(val s: String)
+
+@X("")
+fun foo<caret>(): String = ""

--- a/idea/testData/intentions/convertFunctionToProperty/annotationLineBreak.kt.after
+++ b/idea/testData/intentions/convertFunctionToProperty/annotationLineBreak.kt.after
@@ -1,0 +1,5 @@
+annotation class X(val s: String)
+
+@X("")
+val foo<caret>: String
+    get() = ""

--- a/idea/testData/intentions/convertFunctionToProperty/comments.kt
+++ b/idea/testData/intentions/convertFunctionToProperty/comments.kt
@@ -1,0 +1,8 @@
+annotation class X(val s: String)
+
+// 1
+@X("") // 2
+/* 3 */ fun foo<caret>(): String {
+    // 4
+    return ""
+}

--- a/idea/testData/intentions/convertFunctionToProperty/comments.kt.after
+++ b/idea/testData/intentions/convertFunctionToProperty/comments.kt.after
@@ -1,0 +1,9 @@
+annotation class X(val s: String)
+
+// 1
+@X("") // 2
+/* 3 */ val foo<caret>: String
+    get() {
+        // 4
+        return ""
+    }

--- a/idea/testData/intentions/convertFunctionToProperty/noExplicitType.kt
+++ b/idea/testData/intentions/convertFunctionToProperty/noExplicitType.kt
@@ -1,0 +1,1 @@
+fun foo<caret>() = ""

--- a/idea/testData/intentions/convertFunctionToProperty/noExplicitType.kt.after
+++ b/idea/testData/intentions/convertFunctionToProperty/noExplicitType.kt.after
@@ -1,0 +1,1 @@
+val foo<caret> get() = ""

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -4031,9 +4031,21 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
             KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/intentions/convertFunctionToProperty"), Pattern.compile("^([\\w\\-_]+)\\.kt$"), TargetBackend.ANY, true);
         }
 
+        @TestMetadata("annotationLineBreak.kt")
+        public void testAnnotationLineBreak() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/convertFunctionToProperty/annotationLineBreak.kt");
+            doTest(fileName);
+        }
+
         @TestMetadata("blockBody.kt")
         public void testBlockBody() throws Exception {
             String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/convertFunctionToProperty/blockBody.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("comments.kt")
+        public void testComments() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/convertFunctionToProperty/comments.kt");
             doTest(fileName);
         }
 
@@ -4100,6 +4112,12 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
         @TestMetadata("localFun.kt")
         public void testLocalFun() throws Exception {
             String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/convertFunctionToProperty/localFun.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("noExplicitType.kt")
+        public void testNoExplicitType() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/convertFunctionToProperty/noExplicitType.kt");
             doTest(fileName);
         }
 


### PR DESCRIPTION
Fixes #KT-14820