### PR TITLE
"Add names to call arguments" shouldn't appear when the only argument is a trailing lambda

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/intentions/AddNamesToCallArgumentsIntention.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/AddNamesToCallArgumentsIntention.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2016 JetBrains s.r.o.
+ * Copyright 2010-2017 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,7 @@ package org.jetbrains.kotlin.idea.intentions
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.util.TextRange
 import org.jetbrains.kotlin.idea.caches.resolve.analyze
-import org.jetbrains.kotlin.psi.KtCallElement
-import org.jetbrains.kotlin.psi.KtLambdaArgument
-import org.jetbrains.kotlin.psi.KtPsiFactory
-import org.jetbrains.kotlin.psi.KtValueArgument
+import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
 import org.jetbrains.kotlin.resolve.calls.model.ArgumentMatch
 import org.jetbrains.kotlin.resolve.calls.model.ArgumentMatchStatus
@@ -35,7 +32,7 @@ class AddNamesToCallArgumentsIntention : SelfTargetingRangeIntention<KtCallEleme
 ) {
     override fun applicabilityRange(element: KtCallElement): TextRange? {
         val arguments = element.valueArguments
-        if (arguments.all { it.isNamed() }) return null
+        if (arguments.all { it.isNamed() || it is LambdaArgument }) return null
 
         val resolvedCall = element.getResolvedCall(element.analyze(BodyResolveMode.PARTIAL)) ?: return null
         if (!resolvedCall.resultingDescriptor.hasStableParameterNames()) return null

--- a/idea/testData/intentions/addNamesToCallArguments/trailingLambda.kt
+++ b/idea/testData/intentions/addNamesToCallArguments/trailingLambda.kt
@@ -1,0 +1,6 @@
+// IS_APPLICABLE: false
+fun foo(f: () -> Unit) {}
+
+fun bar() {
+    <caret>foo {}
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2016 JetBrains s.r.o.
+ * Copyright 2010-2017 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -470,6 +470,12 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
         @TestMetadata("superClassConstructor.kt")
         public void testSuperClassConstructor() throws Exception {
             String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/addNamesToCallArguments/superClassConstructor.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("trailingLambda.kt")
+        public void testTrailingLambda() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/addNamesToCallArguments/trailingLambda.kt");
             doTest(fileName);
         }
 


### PR DESCRIPTION
Fixes #KT-15501