### PR TITLE
Fixes KT-15540

### DIFF
--- a/core/reflection.jvm/src/kotlin/reflect/full/KAnnotatedElements.kt
+++ b/core/reflection.jvm/src/kotlin/reflect/full/KAnnotatedElements.kt
@@ -24,4 +24,4 @@ import kotlin.reflect.*
  */
 @Suppress("UNCHECKED_CAST")
 inline fun <reified T : Annotation> KAnnotatedElement.findAnnotation(): T? =
-        annotations.first { it is T } as T
+        annotations.firstOrNull { it is T } as T?


### PR DESCRIPTION
This commit fixes NoSuchElementExceptions being thrown when a KFunction has `findAnnotation` called when it does not contain the annotation. Instead it will return null (as it seems to have been intended due to the return type being nullable).