### PR TITLE
Fix two Rename related bugs

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/refactoring/rename/RenameBackingFieldReferenceHandler.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/refactoring/rename/RenameBackingFieldReferenceHandler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2016 JetBrains s.r.o.
+ * Copyright 2010-2017 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
-import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.refactoring.rename.inplace.VariableInplaceRenameHandler
 import org.jetbrains.kotlin.descriptors.impl.SyntheticFieldDescriptor
 import org.jetbrains.kotlin.idea.caches.resolve.analyze
@@ -31,9 +30,7 @@ import org.jetbrains.kotlin.resolve.BindingContext
 
 class RenameBackingFieldReferenceHandler: VariableInplaceRenameHandler() {
     override fun isAvailable(element: PsiElement?, editor: Editor, file: PsiFile): Boolean {
-        val refExpression = PsiTreeUtil.findElementOfClassAtOffset(
-                file, editor.caretModel.offset, KtSimpleNameExpression::class.java, false
-        ) ?: return false
+        val refExpression = file.findElementForRename<KtSimpleNameExpression>(editor.caretModel.offset) ?: return false
         if (refExpression.text != "field") return false
         return refExpression.analyze()[BindingContext.REFERENCE_TARGET, refExpression] is SyntheticFieldDescriptor
     }

--- a/idea/src/org/jetbrains/kotlin/idea/refactoring/rename/RenameKotlinImplicitLambdaParameter.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/refactoring/rename/RenameKotlinImplicitLambdaParameter.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2015 JetBrains s.r.o.
+ * Copyright 2010-2017 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,17 +21,15 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
-import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.refactoring.rename.inplace.VariableInplaceRenameHandler
 import org.jetbrains.kotlin.idea.intentions.ReplaceItWithExplicitFunctionLiteralParamIntention
 import org.jetbrains.kotlin.idea.intentions.isAutoCreatedItUsage
 import org.jetbrains.kotlin.idea.util.application.executeWriteCommand
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 
-class RenameKotlinImplicitLambdaParameter: VariableInplaceRenameHandler() {
+class RenameKotlinImplicitLambdaParameter : VariableInplaceRenameHandler() {
     override fun isAvailable(element: PsiElement?, editor: Editor, file: PsiFile): Boolean {
-        val nameExpression = PsiTreeUtil.findElementOfClassAtOffset(
-                file, editor.caretModel.offset, KtNameReferenceExpression::class.java, false)
+        val nameExpression = file.findElementForRename<KtNameReferenceExpression>(editor.caretModel.offset)
 
         return nameExpression != null && isAutoCreatedItUsage(nameExpression)
     }

--- a/idea/src/org/jetbrains/kotlin/idea/refactoring/rename/renameUtil.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/refactoring/rename/renameUtil.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2015 JetBrains s.r.o.
+ * Copyright 2010-2017 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 package org.jetbrains.kotlin.idea.refactoring.rename
 
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.refactoring.rename.ResolvableCollisionUsageInfo
 import com.intellij.refactoring.rename.UnresolvableCollisionUsageInfo
 import com.intellij.refactoring.util.MoveRenameUsageInfo
@@ -79,4 +81,9 @@ class LostDefaultValuesInOverridingFunctionUsageInfo(
             subParam.addRange(superParam.equalsToken, defaultValue)
         }
     }
+}
+
+inline fun <reified T : PsiElement> PsiFile.findElementForRename(offset: Int): T? {
+    return PsiTreeUtil.findElementOfClassAtOffset(this, offset, T::class.java, false)
+           ?: PsiTreeUtil.findElementOfClassAtOffset(this, (offset - 1).coerceAtLeast(0), T::class.java, false)
 }


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-14401
https://youtrack.jetbrains.com/issue/KT-16605

I manually tested it, but I can't get the automated tests to work.

I tried `SimpleNameReferenceRenameTest` but it always gets the parent element instead of the one behind the caret.

Then I tried `InplaceRenameTest` but it always throws an exception.