### PR TITLE
KT-16585: Use gradle's built in input task checking

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BaseMultiGradleVersionIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BaseMultiGradleVersionIT.kt
@@ -1,0 +1,17 @@
+package org.jetbrains.kotlin.gradle
+
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameter
+import org.junit.runners.Parameterized.Parameters
+
+@RunWith(Parameterized::class)
+open class BaseMultiGradleVersionIT : BaseGradleIT() {
+    @Parameter lateinit var gradleVersion: String
+
+    companion object {
+        @JvmStatic
+        @Parameters(name = "Test with Gradle version {0}")
+        fun params() = listOf("2.10", "2.14.1", "3.2", "3.3", "3.4").map { arrayOf(it) }
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinGradlePluginIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinGradlePluginIT.kt
@@ -428,37 +428,4 @@ class KotlinGradleIT: BaseGradleIT() {
             assertSuccessful()
         }
     }
-
-    @Test
-    fun testGradleJavaIcWorking() {
-        val project = Project("kotlinJavaProject", "2.14.1")
-        project.setupWorkingDir()
-
-        val buildScript = File(project.projectDir, "build.gradle")
-
-        buildScript.modify { "$it\n" + "compileJava.options.incremental = true" }
-        project.build("build") {
-            assertSuccessful()
-        }
-
-        // Then modify a Java source and check that compileJava is incremental:
-        File(project.projectDir, "src/main/java/demo/HelloWorld.java").modify { "$it\n" + "class NewClass { }" }
-        project.build("build") {
-            assertSuccessful()
-            assertNotContains("not incremental")
-            assertContains("Incremental compilation")
-        }
-
-        // Then modify a Kotlin source and check that Gradle sees that Java is not up-to-date:
-        File(project.projectDir, "src/main/kotlin/helloWorld.kt").modify {
-            it.trim('\r', '\n').trimEnd('}') + "\nval z: Int = 0 }"
-        }
-        project.build("build") {
-            assertSuccessful()
-            assertContains(":compileKotlin")
-            assertNotContains(":compileJava UP-TO-DATE")
-            assertNotContains("not incremental")
-            assertNotContains("None of the classes needs to be compiled!")
-        }
-    }
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinGradlePluginMultiVersionIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinGradlePluginMultiVersionIT.kt
@@ -1,0 +1,49 @@
+package org.jetbrains.kotlin.gradle
+
+import org.jetbrains.kotlin.gradle.util.modify
+import org.junit.Test
+import java.io.File
+
+class KotlinGradlePluginMultiVersionIT : BaseMultiGradleVersionIT() {
+    @Test
+    fun testJavaIcCompatibility() {
+        val version = gradleVersion.split(".").map(String::toInt)
+        val expectIncrementalCompilation = version.let { (major, minor) -> major > 2 || major == 2 && minor >= 14 }
+        val expectVerboseIncrementalLogs = version.let { (major, minor) -> major < 3 || major == 3 && minor < 4 }
+
+        val project = Project("kotlinJavaProject", gradleVersion)
+        project.setupWorkingDir()
+
+        val buildScript = File(project.projectDir, "build.gradle")
+
+        buildScript.modify { "$it\n" + "compileJava.options.incremental = true" }
+        project.build("build") {
+            assertSuccessful()
+        }
+
+        // Then modify a Java source and check that compileJava is incremental:
+        File(project.projectDir, "src/main/java/demo/HelloWorld.java").modify { "$it\n" + "class NewClass { }" }
+        project.build("build") {
+            assertSuccessful()
+            if (expectIncrementalCompilation && expectVerboseIncrementalLogs)
+                assertContains("Incremental compilation")
+            if (expectIncrementalCompilation)
+                assertNotContains("not incremental") else
+                assertContains("not incremental")
+        }
+
+        // Then modify a Kotlin source and check that Gradle sees that Java is not up-to-date:
+        File(project.projectDir, "src/main/kotlin/helloWorld.kt").modify {
+            it.trim('\r', '\n').trimEnd('}') + "\nval z: Int = 0 }"
+        }
+        project.build("build") {
+            assertSuccessful()
+            assertContains(":compileKotlin")
+            assertNotContains(":compileJava UP-TO-DATE")
+            if (expectIncrementalCompilation)
+                assertNotContains("not incremental") else
+                assertContains("not incremental")
+            assertNotContains("None of the classes needs to be compiled!")
+        }
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt
@@ -554,15 +554,8 @@ private fun configureJavaTask(kotlinTask: KotlinCompile, javaTask: AbstractCompi
     // Since we cannot update classpath statically, java not able to detect changes in the classpath after kotlin compiler.
     // Therefore this (probably inefficient since java cannot decide "uptodateness" by the list of changed class files, but told
     // explicitly being out of date whenever any kotlin files are compiled
-    kotlinTask.anyClassesCompiled = false
 
-    javaTask.outputs.upToDateWhen { task ->
-        val kotlinClassesCompiled = kotlinTask.anyClassesCompiled
-        if (kotlinClassesCompiled) {
-            logger.info("Marking $task out of date, because kotlin classes are changed")
-        }
-        !kotlinClassesCompiled
-    }
+    javaTask.inputs.dir(kotlinTask.destinationDir!!)
 
     javaTask.dependsOn(kotlinTask.name)
     /*

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt
@@ -34,6 +34,7 @@ import org.jetbrains.kotlin.gradle.internal.initKapt
 import org.jetbrains.kotlin.gradle.plugin.android.AndroidGradleWrapper
 import org.jetbrains.kotlin.gradle.plugin.android.KotlinJillTask
 import org.jetbrains.kotlin.gradle.tasks.*
+import org.jetbrains.kotlin.gradle.utils.ParsedGradleVersion
 import org.jetbrains.kotlin.gradle.utils.getDeclaredFieldInHierarchy
 import org.jetbrains.kotlin.incremental.configureMultiProjectIncrementalCompilation
 import org.jetbrains.kotlin.incremental.multiproject.ArtifactDifferenceRegistryProviderAndroidWrapper
@@ -551,8 +552,22 @@ internal open class KotlinAndroidPlugin(
 }
 
 private fun configureJavaTask(kotlinTask: KotlinCompile, javaTask: AbstractCompile, logger: Logger) {
+    // Gradle Java IC in older Gradle versions (before 2.14) cannot check .class directories updates.
+    // To make it work, reset the up-to-date status of compileJava with this flag.
+    kotlinTask.anyClassesCompiled = false
+    javaTask.outputs.upToDateWhen { task ->
+        val gradleSupportsJavaIcWithClassesDirs = ParsedGradleVersion.parse(javaTask.project.gradle.gradleVersion)
+                                                          ?.let { it >= ParsedGradleVersion(2, 14) } ?: false
+        val kotlinClassesCompiled = kotlinTask.anyClassesCompiled
+        if (!gradleSupportsJavaIcWithClassesDirs && kotlinClassesCompiled) {
+            logger.info("Marking $task out of date, because kotlin classes are changed")
+            return@upToDateWhen false
+        }
+        true
+    }
+
     // Make Gradle check if the javaTask up-to-date based on the Kotlin classes
-    javaTask.inputs.dir(kotlinTask.destinationDir!!)
+    javaTask.inputs.dir(kotlinTask.destinationDir)
 
     javaTask.dependsOn(kotlinTask.name)
     /*

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt
@@ -551,10 +551,7 @@ internal open class KotlinAndroidPlugin(
 }
 
 private fun configureJavaTask(kotlinTask: KotlinCompile, javaTask: AbstractCompile, logger: Logger) {
-    // Since we cannot update classpath statically, java not able to detect changes in the classpath after kotlin compiler.
-    // Therefore this (probably inefficient since java cannot decide "uptodateness" by the list of changed class files, but told
-    // explicitly being out of date whenever any kotlin files are compiled
-
+    // Make Gradle check if the javaTask up-to-date based on the Kotlin classes
     javaTask.inputs.dir(kotlinTask.destinationDir!!)
 
     javaTask.dependsOn(kotlinTask.name)


### PR DESCRIPTION
This is the beginning of a fix for KT-16585.
The up to date when block was trying to replicate gradle's directory update check.

There are other problems that are detailed in KT-16585 that need to be fixed.


**Contributor gripe**
I been able to actually compile this code. I found setting up my environment to test this code was far more complicated than I expected.