### PR TITLE
KT-16764 Extend Java source directory set instead of copying srcDirs

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/SimpleKotlinGradleIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/SimpleKotlinGradleIT.kt
@@ -55,6 +55,13 @@ class SimpleKotlinGradleIT : BaseGradleIT() {
     }
 
     @Test
+    fun testSrcDirTaskDependency() {
+        Project("srcDirTaskDependency", "3.3").build("clean", "build") {
+            assertSuccessful()
+        }
+    }
+
+    @Test
     fun testLanguageVersion() {
         Project("languageVersion", GRADLE_VERSION).build("build") {
             assertFailed()

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/srcDirTaskDependency/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/srcDirTaskDependency/build.gradle
@@ -1,0 +1,41 @@
+buildscript {
+    repositories {
+        mavenLocal()
+    }
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    }
+}
+
+apply plugin: 'kotlin'
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+}
+
+task generateSources {
+    outputs.dir('generated')
+
+    doLast {
+        def file = new File('generated/test/TestClass.java')
+        file.parentFile.mkdirs()
+        file.text = """
+            package test;
+
+            public class TestClass {
+
+            }
+        """
+    }
+}
+
+clean {
+    delete(tasks.generateSources)
+}
+
+sourceSets.main.java.srcDir(tasks.generateSources)

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/srcDirTaskDependency/src/main/kotlin/test.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/srcDirTaskDependency/src/main/kotlin/test.kt
@@ -1,0 +1,5 @@
+import test.TestClass
+
+fun main(args: Array<String>) {
+    TestClass()
+}

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt
@@ -129,6 +129,7 @@ internal class Kotlin2JvmSourceSetProcessor(
 
     override fun doTargetSpecificProcessing() {
         val aptConfiguration = project.createAptConfiguration(sourceSet.name, kotlinPluginVersion)
+        kotlinSourceSet.kotlin.source(sourceSet.java)
 
         project.afterEvaluate { project ->
             if (project != null) {
@@ -153,8 +154,6 @@ internal class Kotlin2JvmSourceSetProcessor(
                 } else {
                     removeAnnotationProcessingPluginClasspathEntry(kotlinTask)
                 }
-
-                sourceSet.java.srcDirs.forEach { kotlinSourceSet.kotlin.srcDir(it) }
 
                 // KotlinCompile.source(kotlinDirSet) should be called only after all java roots are added to kotlinDirSet
                 // otherwise some java roots can be ignored


### PR DESCRIPTION
See https://youtrack.jetbrains.com/issue/KT-16764

Starting with Gradle 3.2, Gradle supports defining file collections with task dependencies as source directory for `SourceDirectorySet` (e.g. to generate some source before compiling the project). Normally, Gradle will automatically run them before compiling the sources.

The Kotlin plugin breaks this by copying the plain source directories (as `File`s) to the Kotlin source set.

Gradle has the `SourceDirectorySet.source(SourceDirectorySet)` method as a solution for this which allows extending another source directory set. It's backward compatible all the way back to Gradle 1.0 and will also handle task dependencies properly in newer Gradle versions. Gradle will lazily evaluate the extended source directory set when using this method so it is no longer necessary to apply it in the `afterEvaluate` block.

I've added a new Gradle plugin integration test that will only pass with the fix. The existing tests for extra custom source directories in the Java source set also pass successfully with my changes.