### PR TITLE
KT-16722 KtReference should respect its scope when resolving declarations

### DIFF
--- a/idea/idea-analysis/src/org/jetbrains/kotlin/idea/codeInsight/DescriptorToSourceUtilsIde.kt
+++ b/idea/idea-analysis/src/org/jetbrains/kotlin/idea/codeInsight/DescriptorToSourceUtilsIde.kt
@@ -18,6 +18,7 @@ package org.jetbrains.kotlin.idea.codeInsight
 
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import com.intellij.psi.search.GlobalSearchScope
 import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
 import org.jetbrains.kotlin.idea.decompiler.navigation.findDecompiledDeclaration
 import org.jetbrains.kotlin.resolve.DescriptorToSourceUtils
@@ -26,26 +27,26 @@ import org.jetbrains.kotlin.utils.addToStdlib.sequenceOfLazyValues
 object DescriptorToSourceUtilsIde {
     // Returns PSI element for descriptor. If there are many relevant elements (e.g. it is fake override
     // with multiple declarations), finds any of them. It can find declarations in builtins or decompiled code.
-    fun getAnyDeclaration(project: Project, descriptor: DeclarationDescriptor): PsiElement? {
-        return getDeclarationsStream(project, descriptor).firstOrNull()
+    fun getAnyDeclaration(project: Project, descriptor: DeclarationDescriptor, scope: GlobalSearchScope? = null): PsiElement? {
+        return getDeclarationsStream(project, descriptor, scope).firstOrNull()
     }
 
     // Returns all PSI elements for descriptor. It can find declarations in builtins or decompiled code.
-    fun getAllDeclarations(project: Project, targetDescriptor: DeclarationDescriptor): Collection<PsiElement> {
-        val result = getDeclarationsStream(project, targetDescriptor).toHashSet()
+    fun getAllDeclarations(project: Project, targetDescriptor: DeclarationDescriptor, scope: GlobalSearchScope? = null): Collection<PsiElement> {
+        val result = getDeclarationsStream(project, targetDescriptor, scope).toHashSet()
         // filter out elements which are navigate to some other element of the result
         // this is needed to avoid duplicated results for references to declaration in same library source file
         return result.filter { element -> result.none { element != it && it.navigationElement == element } }
     }
 
-    private fun getDeclarationsStream(project: Project, targetDescriptor: DeclarationDescriptor): Sequence<PsiElement> {
+    private fun getDeclarationsStream(project: Project, targetDescriptor: DeclarationDescriptor, scope: GlobalSearchScope?): Sequence<PsiElement> {
         val effectiveReferencedDescriptors = DescriptorToSourceUtils.getEffectiveReferencedDescriptors(targetDescriptor).asSequence()
         return effectiveReferencedDescriptors.flatMap { effectiveReferenced ->
             // References in library sources should be resolved to corresponding decompiled declarations,
             // therefore we put both source declaration and decompiled declaration to stream, and afterwards we filter it in getAllDeclarations
             sequenceOfLazyValues(
                     { DescriptorToSourceUtils.getSourceFromDescriptor(effectiveReferenced)  },
-                    { findDecompiledDeclaration(project, effectiveReferenced) }
+                    { findDecompiledDeclaration(project, effectiveReferenced, scope) }
             )
         }.filterNotNull()
     }

--- a/idea/idea-analysis/src/org/jetbrains/kotlin/idea/references/KtReference.kt
+++ b/idea/idea-analysis/src/org/jetbrains/kotlin/idea/references/KtReference.kt
@@ -97,7 +97,7 @@ abstract class AbstractKtReference<T : KtElement>(element: T)
             return listOfNotNull(psiFacade.findPackage(fqName))
         }
         else {
-            return DescriptorToSourceUtilsIde.getAllDeclarations(expression.project, targetDescriptor)
+            return DescriptorToSourceUtilsIde.getAllDeclarations(expression.project, targetDescriptor, element.resolveScope)
         }
     }
 

--- a/idea/tests/org/jetbrains/kotlin/idea/references/BuiltInsReferenceResolverTest.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/references/BuiltInsReferenceResolverTest.java
@@ -82,7 +82,7 @@ public class BuiltInsReferenceResolverTest extends KotlinLightCodeInsightFixture
 
     public void testAllReferencesResolved() {
         for (DeclarationDescriptor descriptor : getAllStandardDescriptors()) {
-            assertNotNull("Can't resolve " + descriptor, DescriptorToSourceUtilsIde.INSTANCE.getAnyDeclaration(getProject(), descriptor));
+            assertNotNull("Can't resolve " + descriptor, DescriptorToSourceUtilsIde.INSTANCE.getAnyDeclaration(getProject(), descriptor, null));
         }
     }
 


### PR DESCRIPTION
Suggested fix for: https://youtrack.jetbrains.com/issue/KT-16722

Currently, declarations for `KtReference` are searched globally in the project. Normally, this is not a problem, but as soon as multiple different Kotlin libraries exist in the project (e.g. when using Kotlin Gradle build scripts) the wrong declaration might be returned. This is especially annoying if the other declaration doesn't have any sources attached (e.g. for Gradle's Kotlin distribution).

This changes `KtReference` to search declarations only in the resolve scope of its element, which will usually refer to only the libraries of the current module.