### PR TITLE
Completion of keywords (like `constructor`) doesn't insert parentheses/braces if they're already there

### DIFF
--- a/compiler/frontend/src/org/jetbrains/kotlin/psi/psiUtil/psiUtils.kt
+++ b/compiler/frontend/src/org/jetbrains/kotlin/psi/psiUtil/psiUtils.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2016 JetBrains s.r.o.
+ * Copyright 2010-2017 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -143,6 +143,10 @@ inline fun <reified T : PsiElement> PsiElement.getChildrenOfType(): Array<T> {
 
 fun PsiElement.getNextSiblingIgnoringWhitespaceAndComments(withItself: Boolean = false): PsiElement? {
     return siblings(withItself = withItself).filter { it !is PsiWhiteSpace && it !is PsiComment }.firstOrNull()
+}
+
+fun PsiElement.getNextSiblingIgnoringWhitespace(withItself: Boolean = false): PsiElement? {
+    return siblings(withItself = withItself).filter { it !is PsiWhiteSpace }.firstOrNull()
 }
 
 fun PsiElement.getPrevSiblingIgnoringWhitespaceAndComments(withItself: Boolean = false): PsiElement? {

--- a/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/handlers/handlerUtils.kt
+++ b/idea/idea-completion/src/org/jetbrains/kotlin/idea/completion/handlers/handlerUtils.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2015 JetBrains s.r.o.
+ * Copyright 2010-2017 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import com.intellij.openapi.editor.Document
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.codeStyle.CodeStyleManager
 import org.jetbrains.kotlin.idea.completion.KeywordLookupObject
 import org.jetbrains.kotlin.idea.core.moveCaret
@@ -33,6 +34,8 @@ import org.jetbrains.kotlin.psi.KtBlockStringTemplateEntry
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 import org.jetbrains.kotlin.psi.KtPsiFactory
 import org.jetbrains.kotlin.psi.psiUtil.canPlaceAfterSimpleNameEntry
+import org.jetbrains.kotlin.psi.psiUtil.getNextSiblingIgnoringWhitespace
+import org.jetbrains.kotlin.psi.psiUtil.startOffset
 
 fun surroundWithBracesIfInStringTemplate(context: InsertionContext): Boolean {
     val startOffset = context.startOffset
@@ -144,8 +147,20 @@ fun createKeywordConstructLookupElement(
                     val beforeCaret = tailBeforeCaret.indentLinesAfterFirst(newIndent)
                     val afterCaret = tailAfterCaret.indentLinesAfterFirst(newIndent)
 
-                    insertionContext.document.insertString(offset, beforeCaret + afterCaret)
-                    insertionContext.editor.moveCaret(offset + beforeCaret.length)
+                    val element = insertionContext.file.findElementAt(offset)
+
+                    val sibling = when {
+                        element !is PsiWhiteSpace -> element
+                        element.textContains('\n') -> null
+                        else -> element.getNextSiblingIgnoringWhitespace(true)
+                    }
+
+                    if (sibling != null && beforeCaret.trimStart().startsWith(insertionContext.document.getText(TextRange.from(sibling.startOffset, 1)))) {
+                        insertionContext.editor.moveCaret(sibling.startOffset + 1)
+                    } else {
+                        insertionContext.document.insertString(offset, beforeCaret + afterCaret)
+                        insertionContext.editor.moveCaret(offset + beforeCaret.length)
+                    }
                 }
             }
 }

--- a/idea/idea-completion/testData/handlers/keywords/ConstructorPrimary.kt
+++ b/idea/idea-completion/testData/handlers/keywords/ConstructorPrimary.kt
@@ -1,0 +1,5 @@
+class C c<caret>() {
+
+}
+
+// ELEMENT: constructor

--- a/idea/idea-completion/testData/handlers/keywords/ConstructorPrimary.kt.after
+++ b/idea/idea-completion/testData/handlers/keywords/ConstructorPrimary.kt.after
@@ -1,0 +1,5 @@
+class C constructor(<caret>) {
+
+}
+
+// ELEMENT: constructor

--- a/idea/idea-completion/testData/handlers/keywords/IfParansOnNextLine.kt
+++ b/idea/idea-completion/testData/handlers/keywords/IfParansOnNextLine.kt
@@ -1,0 +1,6 @@
+fun other(a: Any) {
+    i<caret>
+    (a as Int).let { println(a + 12) }
+}
+
+// ELEMENT: if

--- a/idea/idea-completion/testData/handlers/keywords/IfParansOnNextLine.kt.after
+++ b/idea/idea-completion/testData/handlers/keywords/IfParansOnNextLine.kt.after
@@ -1,0 +1,6 @@
+fun other(a: Any) {
+    if (<caret>)
+    (a as Int).let { println(a + 12) }
+}
+
+// ELEMENT: if

--- a/idea/idea-completion/tests/org/jetbrains/kotlin/idea/completion/test/handlers/KeywordCompletionHandlerTestGenerated.java
+++ b/idea/idea-completion/tests/org/jetbrains/kotlin/idea/completion/test/handlers/KeywordCompletionHandlerTestGenerated.java
@@ -66,6 +66,12 @@ public class KeywordCompletionHandlerTestGenerated extends AbstractKeywordComple
         doTest(fileName);
     }
 
+    @TestMetadata("ConstructorPrimary.kt")
+    public void testConstructorPrimary() throws Exception {
+        String fileName = KotlinTestUtils.navigationMetadata("idea/idea-completion/testData/handlers/keywords/ConstructorPrimary.kt");
+        doTest(fileName);
+    }
+
     @TestMetadata("Do.kt")
     public void testDo() throws Exception {
         String fileName = KotlinTestUtils.navigationMetadata("idea/idea-completion/testData/handlers/keywords/Do.kt");
@@ -111,6 +117,12 @@ public class KeywordCompletionHandlerTestGenerated extends AbstractKeywordComple
     @TestMetadata("IfLParenth.kt")
     public void testIfLParenth() throws Exception {
         String fileName = KotlinTestUtils.navigationMetadata("idea/idea-completion/testData/handlers/keywords/IfLParenth.kt");
+        doTest(fileName);
+    }
+
+    @TestMetadata("IfParansOnNextLine.kt")
+    public void testIfParansOnNextLine() throws Exception {
+        String fileName = KotlinTestUtils.navigationMetadata("idea/idea-completion/testData/handlers/keywords/IfParansOnNextLine.kt");
         doTest(fileName);
     }
 


### PR DESCRIPTION
Fixes #KT-15603
Fixes #KT-13524