### PR TITLE
KT-16298: Fix plugin trying to remove cache already removed by clean

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinGradleBuildServices.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinGradleBuildServices.kt
@@ -103,7 +103,12 @@ internal class KotlinGradleBuildServices private constructor(gradle: Gradle): Bu
             }
         }
 
-        buildCacheStorage.flush(memoryCachesOnly = false)
+
+        if (workingDir.exists()) {
+            // The working directory may have been removed by the clean task.
+            // https://youtrack.jetbrains.com/issue/KT-16298
+            buildCacheStorage.flush(memoryCachesOnly = false)
+        }
         buildCacheStorage.close()
 
         gradle.removeListener(this)


### PR DESCRIPTION
Not totally sure if this will fix the issue (or even compile). I think this should ensure that the cache isn't flushed if the directory no longer exists.

(Not sure where you can find a copy of the JDK 1.6 these days for OSX (a link on the readme would be really useful)).