### PR TITLE
Update usage of deprecated sourceMappingURL format

### DIFF
--- a/js/js.translator/src/org/jetbrains/kotlin/js/sourceMap/SourceMap3Builder.java
+++ b/js/js.translator/src/org/jetbrains/kotlin/js/sourceMap/SourceMap3Builder.java
@@ -152,7 +152,7 @@ public class SourceMap3Builder implements SourceMapBuilder {
 
     @Override
     public void addLink() {
-        textOutput.print("\n//@ sourceMappingURL=");
+        textOutput.print("\n//# sourceMappingURL=");
         textOutput.print(generatedFile.getName());
         textOutput.print(".map\n");
     }


### PR DESCRIPTION
The usage of `//@` in sourceMappingURL pragmas was deprecated in favor of `//#`. 
The deprecation happened in 2013, and was motivated by incompatibilities in IE.

The Chromium and Mozilla issues tracking the change:

https://bugs.chromium.org/p/chromium/issues/detail?id=239660
https://bugzilla.mozilla.org/show_bug.cgi?id=870361


And the Mozilla documentation on the warning that is issued as a result of using the deprecated syntax:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Deprecated_source_map_pragma