### PR TITLE
KT-17053 Add inspection to detect use of single callable reference as a lambda body

### DIFF
--- a/idea/resources/inspectionDescriptions/ConvertLambdaToParentheses.html
+++ b/idea/resources/inspectionDescriptions/ConvertLambdaToParentheses.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This inspection reports a lambda expression with one callable reference because it is a common error to replace a lambda with a callable reference without changing curly braces to parentheses.
+</body>
+</html>

--- a/idea/resources/intentionDescriptions/ConvertLambdaToParenthesesIntention/after.kt.template
+++ b/idea/resources/intentionDescriptions/ConvertLambdaToParenthesesIntention/after.kt.template
@@ -1,0 +1,3 @@
+class Person(val name: String)
+
+val persons = listOf("Jack", "Tom").map(::Person)

--- a/idea/resources/intentionDescriptions/ConvertLambdaToParenthesesIntention/after.kt.template
+++ b/idea/resources/intentionDescriptions/ConvertLambdaToParenthesesIntention/after.kt.template
@@ -1,3 +1,3 @@
 class Person(val name: String)
 
-val persons = listOf("Jack", "Tom").map(::Person)
+val persons = listOf("Jack", "Tom").map<spot>(::Person)</spot>

--- a/idea/resources/intentionDescriptions/ConvertLambdaToParenthesesIntention/before.kt.template
+++ b/idea/resources/intentionDescriptions/ConvertLambdaToParenthesesIntention/before.kt.template
@@ -1,3 +1,3 @@
 class Person(val name: String)
 
-val persons = listOf("Jack", "Tom").map { ::Person }
+val persons = listOf("Jack", "Tom").map<spot> { ::Person }</spot>

--- a/idea/resources/intentionDescriptions/ConvertLambdaToParenthesesIntention/before.kt.template
+++ b/idea/resources/intentionDescriptions/ConvertLambdaToParenthesesIntention/before.kt.template
@@ -1,0 +1,3 @@
+class Person(val name: String)
+
+val persons = listOf("Jack", "Tom").map { ::Person }

--- a/idea/resources/intentionDescriptions/ConvertLambdaToParenthesesIntention/description.html
+++ b/idea/resources/intentionDescriptions/ConvertLambdaToParenthesesIntention/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This intention converts a lambda expression with one callable reference to function call with a method reference
+</body>
+</html>

--- a/idea/src/META-INF/plugin.xml
+++ b/idea/src/META-INF/plugin.xml
@@ -1559,6 +1559,11 @@
       <category>Kotlin</category>
     </intentionAction>
 
+    <intentionAction>
+      <className>org.jetbrains.kotlin.idea.intentions.ConvertLambdaToParenthesesIntention</className>
+      <category>Kotlin</category>
+    </intentionAction>
+
     <localInspection implementationClass="org.jetbrains.kotlin.idea.intentions.ObjectLiteralToLambdaInspection"
                      displayName="Object literal can be converted to lambda"
                      groupName="Kotlin"
@@ -2122,6 +2127,13 @@
                      language="JAVA"
     />
 
+    <localInspection implementationClass="org.jetbrains.kotlin.idea.intentions.ConvertLambdaToParenthesesInspection"
+                     displayName="Replace '{}' with '()'"
+                     groupName="Kotlin"
+                     enabledByDefault="true"
+                     level="WARNING"
+                     language="kotlin"
+    />
 
     <referenceImporter implementation="org.jetbrains.kotlin.idea.quickfix.KotlinReferenceImporter"/>
 

--- a/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertLambdaToIntention.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertLambdaToIntention.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2010-2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.kotlin.idea.intentions
+
+import com.intellij.openapi.editor.Editor
+import org.jetbrains.kotlin.descriptors.FunctionDescriptor
+import org.jetbrains.kotlin.idea.caches.resolve.analyze
+import org.jetbrains.kotlin.idea.core.ShortenReferences
+import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.descriptorUtil.hasDefaultValue
+
+abstract class ConvertLambdaToIntention(text: String) : SelfTargetingOffsetIndependentIntention<KtLambdaExpression>(KtLambdaExpression::class.java, text) {
+    abstract fun buildReferenceText(element: KtLambdaExpression): String?
+
+    protected fun KtLambdaArgument.outerCalleeDescriptor(): FunctionDescriptor? {
+        val outerCallExpression = parent as? KtCallExpression ?: return null
+        val context = outerCallExpression.analyze()
+        val outerCallee = outerCallExpression.calleeExpression as? KtReferenceExpression ?: return null
+        return context[BindingContext.REFERENCE_TARGET, outerCallee] as? FunctionDescriptor
+    }
+
+    override fun applyTo(element: KtLambdaExpression, editor: Editor?) {
+        val referenceName = buildReferenceText(element) ?: return
+        val factory = KtPsiFactory(element)
+        val lambdaArgument = element.parent as? KtLambdaArgument
+        if (lambdaArgument == null) {
+            // Without lambda argument syntax, just replace lambda with reference
+            val callableReferenceExpr = factory.createCallableReferenceExpression(referenceName) ?: return
+            (element.replace(callableReferenceExpr) as? KtElement)?.let { ShortenReferences.RETAIN_COMPANION.process(it) }
+        }
+        else {
+            // Otherwise, replace the whole argument list for lambda argument-using call
+            val outerCallExpression = lambdaArgument.parent as? KtCallExpression ?: return
+            val outerCalleeDescriptor = lambdaArgument.outerCalleeDescriptor() ?: return
+            // Parameters with default value
+            val valueParameters = outerCalleeDescriptor.valueParameters
+            val arguments = outerCallExpression.valueArguments.filter { it !is KtLambdaArgument }
+            val useNamedArguments = valueParameters.any { it.hasDefaultValue() } || arguments.any { it.getArgumentName() != null }
+
+            if (useNamedArguments && arguments.size > valueParameters.size) return
+            val newArgumentList = factory.buildValueArgumentList {
+                appendFixedText("(")
+                arguments.forEachIndexed { i, argument ->
+                    if (useNamedArguments) {
+                        val argumentName = argument.getArgumentName()?.asName
+                        val name = argumentName ?: valueParameters[i].name
+                        appendName(name)
+                        appendFixedText(" = ")
+                    }
+                    appendExpression(argument.getArgumentExpression())
+                    appendFixedText(", ")
+                }
+                if (useNamedArguments) {
+                    appendName(valueParameters.last().name)
+                    appendFixedText(" = ")
+                }
+                appendFixedText(referenceName)
+                appendFixedText(")")
+            }
+            val argumentList = outerCallExpression.valueArgumentList
+            if (argumentList == null) {
+                (lambdaArgument.replace(newArgumentList) as? KtElement)?.let { ShortenReferences.RETAIN_COMPANION.process(it) }
+            }
+            else {
+                (argumentList.replace(newArgumentList) as? KtValueArgumentList)?.let {
+                    ShortenReferences.RETAIN_COMPANION.process(it.arguments.last())
+                }
+                lambdaArgument.delete()
+            }
+        }
+    }
+}

--- a/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertLambdaToParenthesesIntention.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertLambdaToParenthesesIntention.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2010-2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.kotlin.idea.intentions
+
+import org.jetbrains.kotlin.idea.caches.resolve.analyze
+import org.jetbrains.kotlin.idea.inspections.IntentionBasedInspection
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtCallableReferenceExpression
+import org.jetbrains.kotlin.psi.KtLambdaExpression
+import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
+
+class ConvertLambdaToParenthesesInspection :
+        IntentionBasedInspection<KtLambdaExpression>(ConvertLambdaToParenthesesIntention::class)
+
+class ConvertLambdaToParenthesesIntention : ConvertLambdaToIntention("Convert lambda '{}' to parentheses '()'") {
+    override fun buildReferenceText(element: KtLambdaExpression): String? {
+        val callableReferenceExpression = element.bodyExpression?.statements?.get(0) as? KtCallableReferenceExpression ?: return null
+        if (callableReferenceExpression.isEmptyLHS) return callableReferenceExpression.text
+        val callableReference = callableReferenceExpression.callableReference
+        val resolvedCall = callableReference.getResolvedCall(callableReference.analyze()) ?: return callableReference.text
+        val receiverValue = resolvedCall.extensionReceiver ?: resolvedCall.dispatchReceiver
+        return "${receiverValue?.type.toString()}${KtTokens.COLONCOLON.value}${callableReferenceExpression.callableReference.text}"
+    }
+
+    override fun isApplicableTo(element: KtLambdaExpression): Boolean {
+        val statements = element.bodyExpression?.statements ?: return false
+        if (statements.size != 1) return false
+        return statements[0] is KtCallableReferenceExpression
+    }
+}

--- a/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertLambdaToReferenceIntention.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertLambdaToReferenceIntention.kt
@@ -17,6 +17,7 @@
 package org.jetbrains.kotlin.idea.intentions
 
 import com.intellij.openapi.editor.Editor
+import com.intellij.util.xml.Convert
 import org.jetbrains.kotlin.builtins.getReturnTypeFromFunctionType
 import org.jetbrains.kotlin.builtins.isExtensionFunctionType
 import org.jetbrains.kotlin.builtins.isFunctionType
@@ -46,15 +47,8 @@ class ConvertLambdaToReferenceInspection : IntentionBasedInspection<KtLambdaExpr
     override fun inspectionTarget(element: KtLambdaExpression) = element.bodyExpression?.statements?.singleOrNull()
 }
 
-class ConvertLambdaToReferenceIntention : SelfTargetingOffsetIndependentIntention<KtLambdaExpression>(
-        KtLambdaExpression::class.java, "Convert lambda to reference"
-) {
-    private fun KtLambdaArgument.outerCalleeDescriptor(): FunctionDescriptor? {
-        val outerCallExpression = parent as? KtCallExpression ?: return null
-        val context = outerCallExpression.analyze()
-        val outerCallee = outerCallExpression.calleeExpression as? KtReferenceExpression ?: return null
-        return context[REFERENCE_TARGET, outerCallee] as? FunctionDescriptor
-    }
+class ConvertLambdaToReferenceIntention : ConvertLambdaToIntention("Convert lambda to reference") {
+    override fun buildReferenceText(element: KtLambdaExpression) = buildReferenceText(lambdaExpression = element, shortTypes = false)
 
     private fun isConvertibleCallInLambda(
             callableExpression: KtExpression,
@@ -158,57 +152,6 @@ class ConvertLambdaToReferenceIntention : SelfTargetingOffsetIndependentIntentio
                                           lambdaExpression = element, lambdaMustReturnUnit = lambdaMustReturnUnit)
             }
             else -> false
-        }
-    }
-
-    override fun applyTo(element: KtLambdaExpression, editor: Editor?) {
-        val referenceName = buildReferenceText(lambdaExpression = element, shortTypes = false) ?: return
-        val factory = KtPsiFactory(element)
-        val lambdaArgument = element.parent as? KtLambdaArgument
-        if (lambdaArgument == null) {
-            // Without lambda argument syntax, just replace lambda with reference
-            val callableReferenceExpr = factory.createCallableReferenceExpression(referenceName) ?: return
-            (element.replace(callableReferenceExpr) as? KtElement)?.let { ShortenReferences.RETAIN_COMPANION.process(it) }
-        }
-        else {
-            // Otherwise, replace the whole argument list for lambda argument-using call
-            val outerCallExpression = lambdaArgument.parent as? KtCallExpression ?: return
-            val outerCalleeDescriptor = lambdaArgument.outerCalleeDescriptor() ?: return
-            // Parameters with default value
-            val valueParameters = outerCalleeDescriptor.valueParameters
-            val arguments = outerCallExpression.valueArguments.filter { it !is KtLambdaArgument }
-            val useNamedArguments = valueParameters.any { it.hasDefaultValue() } || arguments.any { it.getArgumentName() != null }
-
-            if (useNamedArguments && arguments.size > valueParameters.size) return
-            val newArgumentList = factory.buildValueArgumentList {
-                appendFixedText("(")
-                arguments.forEachIndexed { i, argument ->
-                    if (useNamedArguments) {
-                        val argumentName = argument.getArgumentName()?.asName
-                        val name = argumentName ?: valueParameters[i].name
-                        appendName(name)
-                        appendFixedText(" = ")
-                    }
-                    appendExpression(argument.getArgumentExpression())
-                    appendFixedText(", ")
-                }
-                if (useNamedArguments) {
-                    appendName(valueParameters.last().name)
-                    appendFixedText(" = ")
-                }
-                appendFixedText(referenceName)
-                appendFixedText(")")
-            }
-            val argumentList = outerCallExpression.valueArgumentList
-            if (argumentList == null) {
-                (lambdaArgument.replace(newArgumentList) as? KtElement)?.let { ShortenReferences.RETAIN_COMPANION.process(it) }
-            }
-            else {
-                (argumentList.replace(newArgumentList) as? KtValueArgumentList)?.let {
-                    ShortenReferences.RETAIN_COMPANION.process(it.arguments.last())
-                }
-                lambdaArgument.delete()
-            }
         }
     }
 

--- a/idea/testData/intentions/convertLambdaToParentheses/.intention
+++ b/idea/testData/intentions/convertLambdaToParentheses/.intention
@@ -1,0 +1,1 @@
+org.jetbrains.kotlin.idea.intentions.ConvertLambdaToParenthesesIntention

--- a/idea/testData/intentions/convertLambdaToParentheses/defaultParameter.kt
+++ b/idea/testData/intentions/convertLambdaToParentheses/defaultParameter.kt
@@ -1,0 +1,5 @@
+// WITH_RUNTIME
+
+fun foo() {
+    listOf(1,2,3).map {<caret> it::toString }
+}

--- a/idea/testData/intentions/convertLambdaToParentheses/defaultParameter.kt.after
+++ b/idea/testData/intentions/convertLambdaToParentheses/defaultParameter.kt.after
@@ -1,0 +1,5 @@
+// WITH_RUNTIME
+
+fun foo() {
+    listOf(1,2,3).map(Int::toString)
+}

--- a/idea/testData/intentions/convertLambdaToParentheses/it.kt
+++ b/idea/testData/intentions/convertLambdaToParentheses/it.kt
@@ -1,0 +1,5 @@
+// WITH_RUNTIME
+
+fun foo() {
+    listOf(1,2,3).map {<caret> it::toString }
+}

--- a/idea/testData/intentions/convertLambdaToParentheses/it.kt.after
+++ b/idea/testData/intentions/convertLambdaToParentheses/it.kt.after
@@ -1,0 +1,5 @@
+// WITH_RUNTIME
+
+fun foo() {
+    listOf(1,2,3).map(Int::toString)
+}

--- a/idea/testData/intentions/convertLambdaToParentheses/lambdaWithArg.kt
+++ b/idea/testData/intentions/convertLambdaToParentheses/lambdaWithArg.kt
@@ -1,0 +1,13 @@
+// WITH_RUNTIME
+
+fun foo() {
+    x(1) {<caret> ::y }
+}
+
+fun y() {
+
+}
+
+fun x(number: Int, func: () -> Unit) {
+
+}

--- a/idea/testData/intentions/convertLambdaToParentheses/lambdaWithArg.kt.after
+++ b/idea/testData/intentions/convertLambdaToParentheses/lambdaWithArg.kt.after
@@ -1,0 +1,13 @@
+// WITH_RUNTIME
+
+fun foo() {
+    x(1, ::y)
+}
+
+fun y() {
+
+}
+
+fun x(number: Int, func: () -> Unit) {
+
+}

--- a/idea/testData/intentions/convertLambdaToParentheses/multipleLines.kt
+++ b/idea/testData/intentions/convertLambdaToParentheses/multipleLines.kt
@@ -1,0 +1,9 @@
+// WITH_RUNTIME
+// IS_APPLICABLE: false
+
+fun foo() {
+    listOf(1,2,3).map {<caret>
+        println(it)
+        Int::toString
+    }
+}

--- a/idea/testData/intentions/convertLambdaToParentheses/noBody.kt
+++ b/idea/testData/intentions/convertLambdaToParentheses/noBody.kt
@@ -1,0 +1,6 @@
+// IS_APPLICABLE: false
+// WITH_RUNTIME
+
+fun foo() {
+    listOf(1,2,3).map {<caret>}
+}

--- a/idea/testData/intentions/convertLambdaToParentheses/noneCallableRef.kt
+++ b/idea/testData/intentions/convertLambdaToParentheses/noneCallableRef.kt
@@ -1,0 +1,6 @@
+// IS_APPLICABLE: false
+// WITH_RUNTIME
+
+fun foo() {
+    listOf(1,2,3).map {<caret> println(it) }
+}

--- a/idea/testData/intentions/convertLambdaToParentheses/normal.kt
+++ b/idea/testData/intentions/convertLambdaToParentheses/normal.kt
@@ -1,0 +1,5 @@
+// WITH_RUNTIME
+
+fun foo() {
+    listOf(1,2,3).map {<caret> Int::toString }
+}

--- a/idea/testData/intentions/convertLambdaToParentheses/normal.kt.after
+++ b/idea/testData/intentions/convertLambdaToParentheses/normal.kt.after
@@ -1,0 +1,5 @@
+// WITH_RUNTIME
+
+fun foo() {
+    listOf(1,2,3).map(Int::toString)
+}

--- a/idea/testData/intentions/convertLambdaToParentheses/parameter.kt
+++ b/idea/testData/intentions/convertLambdaToParentheses/parameter.kt
@@ -1,0 +1,5 @@
+// WITH_RUNTIME
+
+fun foo() {
+    listOf(1,2,3).map {<caret> bar -> bar::toString }
+}

--- a/idea/testData/intentions/convertLambdaToParentheses/parameter.kt.after
+++ b/idea/testData/intentions/convertLambdaToParentheses/parameter.kt.after
@@ -1,0 +1,5 @@
+// WITH_RUNTIME
+
+fun foo() {
+    listOf(1,2,3).map(Int::toString)
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -4409,6 +4409,12 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
             doTest(fileName);
         }
 
+        @TestMetadata("it.kt")
+        public void testIt() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/convertLambdaToParentheses/it.kt");
+            doTest(fileName);
+        }
+
         @TestMetadata("lambdaWithArg.kt")
         public void testLambdaWithArg() throws Exception {
             String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/convertLambdaToParentheses/lambdaWithArg.kt");

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -4395,6 +4395,57 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
         }
     }
 
+    @TestMetadata("idea/testData/intentions/convertLambdaToParentheses")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class ConvertLambdaToParentheses extends AbstractIntentionTest {
+        public void testAllFilesPresentInConvertLambdaToParentheses() throws Exception {
+            KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/intentions/convertLambdaToParentheses"), Pattern.compile("^([\\w\\-_]+)\\.kt$"), TargetBackend.ANY, true);
+        }
+
+        @TestMetadata("defaultParameter.kt")
+        public void testDefaultParameter() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/convertLambdaToParentheses/defaultParameter.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("lambdaWithArg.kt")
+        public void testLambdaWithArg() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/convertLambdaToParentheses/lambdaWithArg.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("multipleLines.kt")
+        public void testMultipleLines() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/convertLambdaToParentheses/multipleLines.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("noBody.kt")
+        public void testNoBody() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/convertLambdaToParentheses/noBody.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("noneCallableRef.kt")
+        public void testNoneCallableRef() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/convertLambdaToParentheses/noneCallableRef.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("normal.kt")
+        public void testNormal() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/convertLambdaToParentheses/normal.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("parameter.kt")
+        public void testParameter() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/convertLambdaToParentheses/parameter.kt");
+            doTest(fileName);
+        }
+    }
+
     @TestMetadata("idea/testData/intentions/convertLambdaToReference")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)


### PR DESCRIPTION
#KT-17053 Fixed

Issue: https://youtrack.jetbrains.com/issue/KT-17053
Related issue: https://youtrack.jetbrains.com/issue/KT-17051
