### PR TITLE
Do not suggest 'Convert to secondary constructor' for annotation classes

### DIFF
--- a/idea/testData/intentions/convertPrimaryConstructorToSecondary/annotationClass.kt
+++ b/idea/testData/intentions/convertPrimaryConstructorToSecondary/annotationClass.kt
@@ -1,0 +1,3 @@
+// IS_APPLICABLE: false
+
+annotation class ValueMatters<caret>(val value: String)

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -5012,6 +5012,12 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
             doTest(fileName);
         }
 
+        @TestMetadata("annotationClass.kt")
+        public void testAnnotationClass() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/convertPrimaryConstructorToSecondary/annotationClass.kt");
+            doTest(fileName);
+        }
+
         @TestMetadata("defaultValueChain.kt")
         public void testDefaultValueChain() throws Exception {
             String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/convertPrimaryConstructorToSecondary/defaultValueChain.kt");


### PR DESCRIPTION
 #KT-17408 Fixed