### PR TITLE
optimization: stateless properties

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/ExpressionCodegen.java
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/ExpressionCodegen.java
@@ -2574,10 +2574,11 @@ public class ExpressionCodegen extends KtVisitor<StackValue, StackValue> impleme
             fieldName = KotlinTypeMapper.mapDefaultFieldName(propertyDescriptor, isDelegatedProperty);
         }
 
+        boolean isStatic = isStaticBackingField || (isDelegatedProperty && KotlinBuiltIns.isStatelessProperty(delegateType));
         return StackValue.property(propertyDescriptor, backingFieldOwner,
                                    typeMapper.mapType(
                                            isDelegatedProperty && forceField ? delegateType : propertyDescriptor.getOriginal().getType()),
-                                   isStaticBackingField, fieldName, callableGetter, callableSetter, receiver, this, resolvedCall);
+                                   isStatic, fieldName, callableGetter, callableSetter, receiver, this, resolvedCall);
     }
 
     @NotNull

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/ImplementationBodyCodegen.java
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/ImplementationBodyCodegen.java
@@ -342,6 +342,8 @@ public class ImplementationBodyCodegen extends ClassBodyCodegen {
     protected void generateSyntheticParts() {
         generatePropertyMetadataArrayFieldIfNeeded(classAsmType);
 
+        generateStatelessPropertyInitializers();
+
         generateFieldForSingleton();
 
         generateCompanionObjectBackingFieldCopies();

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/MultifileClassPartCodegen.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/MultifileClassPartCodegen.kt
@@ -72,7 +72,7 @@ class MultifileClassPartCodegen(
 
     private val requiresDeferredStaticInitialization =
             shouldGeneratePartHierarchy && file.declarations.any {
-                it is KtProperty && shouldInitializeProperty(it)
+                it is KtProperty && propertyCodegen.shouldInitializeProperty(it)
             }
 
     override fun generate() {

--- a/compiler/frontend/src/org/jetbrains/kotlin/resolve/DelegatedPropertyResolver.kt
+++ b/compiler/frontend/src/org/jetbrains/kotlin/resolve/DelegatedPropertyResolver.kt
@@ -312,7 +312,7 @@ class DelegatedPropertyResolver(
     ): OverloadResolutionResults<FunctionDescriptor> {
         val expectedType = TypeUtils.NO_EXPECTED_TYPE
         val context = ExpressionTypingContext.newContext(trace, initializerScope, dataFlowInfo, expectedType)
-        val propertyHasReceiver = propertyDescriptor.dispatchReceiverParameter != null
+        val propertyHasReceiver = propertyDescriptor.dispatchReceiverParameter != null && !KotlinBuiltIns.isStatelessProperty(delegateExpressionType)
         val arguments = KtPsiFactory(delegateExpression, markGenerated = false).run {
             listOf(
                     createExpression(if (propertyHasReceiver) "this" else "null"),

--- a/core/descriptors/src/org/jetbrains/kotlin/builtins/KotlinBuiltIns.java
+++ b/core/descriptors/src/org/jetbrains/kotlin/builtins/KotlinBuiltIns.java
@@ -57,6 +57,7 @@ public abstract class KotlinBuiltIns {
     public static final FqName BUILT_INS_PACKAGE_FQ_NAME = FqName.topLevel(BUILT_INS_PACKAGE_NAME);
     private static final FqName ANNOTATION_PACKAGE_FQ_NAME = BUILT_INS_PACKAGE_FQ_NAME.child(Name.identifier("annotation"));
     public static final FqName COLLECTIONS_PACKAGE_FQ_NAME = BUILT_INS_PACKAGE_FQ_NAME.child(Name.identifier("collections"));
+    public static final FqName PROPERTIES_PACKAGE_FQ_NAME = BUILT_INS_PACKAGE_FQ_NAME.child(Name.identifier("properties"));
     public static final FqName RANGES_PACKAGE_FQ_NAME = BUILT_INS_PACKAGE_FQ_NAME.child(Name.identifier("ranges"));
     public static final FqName TEXT_PACKAGE_FQ_NAME = BUILT_INS_PACKAGE_FQ_NAME.child(Name.identifier("text"));
 
@@ -321,6 +322,7 @@ public abstract class KotlinBuiltIns {
         public final FqName mutableSet = collectionsFqName("MutableSet");
         public final FqName mutableMap = collectionsFqName("MutableMap");
         public final FqName mutableMapEntry = mutableMap.child(Name.identifier("MutableEntry"));
+        public final FqName statelessProperty = propertiesName("StatelessProperty");
 
         public final FqNameUnsafe kClass = reflect("KClass");
         public final FqNameUnsafe kCallable = reflect("KCallable");
@@ -371,6 +373,11 @@ public abstract class KotlinBuiltIns {
         @NotNull
         private static FqName annotationName(@NotNull String simpleName) {
             return ANNOTATION_PACKAGE_FQ_NAME.child(Name.identifier(simpleName));
+        }
+
+        @NotNull
+        private static FqName propertiesName(@NotNull String simpleName) {
+            return PROPERTIES_PACKAGE_FQ_NAME.child(Name.identifier(simpleName));
         }
     }
 
@@ -1070,6 +1077,10 @@ public abstract class KotlinBuiltIns {
 
     public static boolean isIterableOrNullableIterable(@NotNull KotlinType type) {
         return isConstructedFromGivenClass(type, FQ_NAMES.iterable);
+    }
+
+    public static boolean isStatelessProperty(@NotNull KotlinType type) {
+        return containsAnnotation(type.getConstructor().getDeclarationDescriptor(), FQ_NAMES.statelessProperty);
     }
 
     public static boolean isKClass(@NotNull ClassDescriptor descriptor) {

--- a/libraries/stdlib/src/kotlin/properties/Annotations.kt
+++ b/libraries/stdlib/src/kotlin/properties/Annotations.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2010-2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kotlin.properties
+
+
+/**
+ * Standard property annotations.
+ */
+/**
+ * Specifies that this part of internal API is effectively public exposed by using in public inline function
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.BINARY)
+@MustBeDocumented
+@SinceKotlin("1.1")
+public annotation class StatelessProperty

--- a/libraries/tools/binary-compatibility-validator/reference-public-api/kotlin-stdlib-runtime-merged.txt
+++ b/libraries/tools/binary-compatibility-validator/reference-public-api/kotlin-stdlib-runtime-merged.txt
@@ -2987,6 +2987,9 @@ public abstract interface class kotlin/properties/ReadWriteProperty {
 	public abstract fun setValue (Ljava/lang/Object;Lkotlin/reflect/KProperty;Ljava/lang/Object;)V
 }
 
+public abstract interface annotation class kotlin/properties/StatelessProperty : java/lang/annotation/Annotation {
+}
+
 public class kotlin/ranges/CharProgression : java/lang/Iterable, kotlin/jvm/internal/markers/KMappedMarker {
 	public static final field Companion Lkotlin/ranges/CharProgression$Companion;
 	public fun equals (Ljava/lang/Object;)Z

--- a/libraries/tools/binary-compatibility-validator/reference-public-api/kotlin-stdlib.txt
+++ b/libraries/tools/binary-compatibility-validator/reference-public-api/kotlin-stdlib.txt
@@ -2013,6 +2013,9 @@ public abstract interface class kotlin/properties/ReadWriteProperty {
 	public abstract fun setValue (Ljava/lang/Object;Lkotlin/reflect/KProperty;Ljava/lang/Object;)V
 }
 
+public abstract interface annotation class kotlin/properties/StatelessProperty : java/lang/annotation/Annotation {
+}
+
 public abstract interface class kotlin/ranges/ClosedFloatingPointRange : kotlin/ranges/ClosedRange {
 	public abstract fun contains (Ljava/lang/Comparable;)Z
 	public abstract fun isEmpty ()Z


### PR DESCRIPTION
Please consider proposed optimization:
    Delegate to statically initialized fields if delegate object doesn't have state associated with an object instance.

That might be naive implementation and it misses test so far. 

Please check https://github.com/uujava/kotlin-stateless-properties for example and more details.

