### PR TITLE
* exclude showing of KotlinWithLibraryConfigurators in Kobalt based p…

### DIFF
--- a/idea/idea-analysis/src/org/jetbrains/kotlin/idea/configuration/KotlinModuleTypeManager.java
+++ b/idea/idea-analysis/src/org/jetbrains/kotlin/idea/configuration/KotlinModuleTypeManager.java
@@ -27,4 +27,5 @@ public abstract class KotlinModuleTypeManager {
 
     public abstract boolean isAndroidGradleModule(@NotNull Module module);
     public abstract boolean isGradleModule(@NotNull Module module);
+    public abstract boolean isKobaltModule(@NotNull Module module);
 }

--- a/idea/src/org/jetbrains/kotlin/idea/KotlinModuleTypeManagerImpl.java
+++ b/idea/src/org/jetbrains/kotlin/idea/KotlinModuleTypeManagerImpl.java
@@ -43,4 +43,9 @@ public class KotlinModuleTypeManagerImpl extends KotlinModuleTypeManager {
     public boolean isGradleModule(@NotNull Module module) {
         return ExternalSystemApiUtil.isExternalSystemAwareModule(KotlinLibraryUtilKt.getGRADLE_SYSTEM_ID(), module);
     }
+
+    @Override
+    public boolean isKobaltModule(@NotNull Module module) {
+        return ExternalSystemApiUtil.isExternalSystemAwareModule(KotlinLibraryUtilKt.getKOBALT_SYSTEM_ID(), module);
+    }
 }

--- a/idea/src/org/jetbrains/kotlin/idea/KotlinPluginUtil.java
+++ b/idea/src/org/jetbrains/kotlin/idea/KotlinPluginUtil.java
@@ -49,6 +49,10 @@ public class KotlinPluginUtil {
         return KotlinModuleTypeManager.getInstance().isGradleModule(module);
     }
 
+    public static boolean isKobaltModule(@NotNull Module module) {
+        return KotlinModuleTypeManager.getInstance().isKobaltModule(module);
+    }
+
     public static boolean isMavenModule(@NotNull Module module) {
         // This constant could be acquired from MavenProjectsManager, but we don't want to depend on the Maven plugin...
         // See MavenProjectsManager.isMavenizedModule()

--- a/idea/src/org/jetbrains/kotlin/idea/configuration/KotlinWithLibraryConfigurator.java
+++ b/idea/src/org/jetbrains/kotlin/idea/configuration/KotlinWithLibraryConfigurator.java
@@ -80,7 +80,8 @@ public abstract class KotlinWithLibraryConfigurator implements KotlinProjectConf
     protected static boolean isApplicable(@NotNull Module module) {
         return !KotlinPluginUtil.isAndroidGradleModule(module) &&
                !KotlinPluginUtil.isMavenModule(module) &&
-               !KotlinPluginUtil.isGradleModule(module);
+               !KotlinPluginUtil.isGradleModule(module) &&
+               !KotlinPluginUtil.isKobaltModule(module);
     }
 
     protected abstract boolean isConfigured(@NotNull Module module);

--- a/idea/src/org/jetbrains/kotlin/idea/framework/KotlinLibraryUtil.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/framework/KotlinLibraryUtil.kt
@@ -38,10 +38,12 @@ fun <LP : LibraryProperties<out Any>> getLibraryProperties(provider: LibraryPres
 
 private val MAVEN_SYSTEM_ID = ProjectSystemId("MAVEN")
 val GRADLE_SYSTEM_ID = ProjectSystemId("GRADLE")
+val KOBALT_SYSTEM_ID = ProjectSystemId("KOBALT")
 
 private fun isExternalLibrary(library: Library): Boolean {
     return ExternalSystemApiUtil.isExternalSystemLibrary(library, ProjectSystemId.IDE) ||
            ExternalSystemApiUtil.isExternalSystemLibrary(library, GRADLE_SYSTEM_ID) ||
+           ExternalSystemApiUtil.isExternalSystemLibrary(library, KOBALT_SYSTEM_ID) ||
            ExternalSystemApiUtil.isExternalSystemLibrary(library, MAVEN_SYSTEM_ID)
 }
 


### PR DESCRIPTION
Kobalt have its own Kotlin libs configurator: https://github.com/cbeust/kobalt-intellij-plugin/blob/master/src/com/beust/kobalt/intellij/configurator/KotlinKobaltProjectConfigurator.kt
Doesn't need to show up Java/JS default configurators to not confuse users.