### PR TITLE
add inspection for calls to a data class' copy method without named arguments.

### DIFF
--- a/idea/resources/inspectionDescriptions/CopyWithoutNamedArguments.html
+++ b/idea/resources/inspectionDescriptions/CopyWithoutNamedArguments.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This inspection reports calls to a data class' copy method without named arguments.
+</body>
+</html>

--- a/idea/src/META-INF/plugin.xml
+++ b/idea/src/META-INF/plugin.xml
@@ -2141,6 +2141,14 @@
                      language="kotlin"
     />
 
+    <localInspection implementationClass="org.jetbrains.kotlin.idea.inspections.CopyWithoutNamedArgumentsInspection"
+                     displayName="'copy' method of data class is called without named arguments"
+                     groupName="Kotlin"
+                     enabledByDefault="true"
+                     level="WARNING"
+                     language="kotlin"
+    />
+
     <referenceImporter implementation="org.jetbrains.kotlin.idea.quickfix.KotlinReferenceImporter"/>
 
     <fileType.fileViewProviderFactory filetype="KJSM" implementationClass="com.intellij.psi.ClassFileViewProviderFactory"/>

--- a/idea/src/org/jetbrains/kotlin/idea/inspections/CopyWithoutNamedArgumentsInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/CopyWithoutNamedArgumentsInspection.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2010-2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.kotlin.idea.inspections
+
+import com.intellij.codeInspection.IntentionWrapper
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElementVisitor
+import org.jetbrains.kotlin.descriptors.ClassDescriptor
+import org.jetbrains.kotlin.idea.caches.resolve.analyze
+import org.jetbrains.kotlin.idea.intentions.AddNamesToCallArgumentsIntention
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
+import org.jetbrains.kotlin.psi.KtVisitorVoid
+import org.jetbrains.kotlin.psi.psiUtil.referenceExpression
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.DataClassDescriptorResolver
+import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
+import org.jetbrains.kotlin.resolve.lazy.BodyResolveMode
+
+class CopyWithoutNamedArgumentsInspection : AbstractKotlinInspection() {
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        return object : KtVisitorVoid() {
+            override fun visitCallExpression(expression: KtCallExpression) {
+                super.visitCallExpression(expression)
+
+                val reference = expression.referenceExpression() as? KtNameReferenceExpression ?: return
+                if (reference.getReferencedNameAsName() != DataClassDescriptorResolver.COPY_METHOD_NAME) return
+                if (expression.valueArguments.none { !it.isNamed() }) return
+
+                val context = expression.analyze(BodyResolveMode.PARTIAL)
+                val call = expression.getResolvedCall(context) ?: return
+                val receiver = call.dispatchReceiver?.type?.constructor?.declarationDescriptor as? ClassDescriptor ?: return
+
+                if (!receiver.isData) return
+                if (call.candidateDescriptor != context[BindingContext.DATA_CLASS_COPY_FUNCTION, receiver]) return
+
+                holder.registerProblem(
+                        expression,
+                        "'copy' method of data class is called without named arguments",
+                        ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
+                        IntentionWrapper(AddNamesToCallArgumentsIntention(), expression.containingKtFile)
+                )
+            }
+        }
+    }
+
+}

--- a/idea/testData/inspections/copyWithoutNamedArguments/inspectionData/expected.xml
+++ b/idea/testData/inspections/copyWithoutNamedArguments/inspectionData/expected.xml
@@ -1,0 +1,10 @@
+<problems>
+    <problem>
+        <file>test.kt</file>
+        <line>10</line>
+        <module>light_idea_test_case</module>
+        <entry_point TYPE="file" FQNAME="temp:///src/test.kt" />
+        <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'copy' method of data class is called without named arguments</problem_class>
+        <description>'copy' method of data class is called without named arguments</description>
+    </problem>
+</problems>

--- a/idea/testData/inspections/copyWithoutNamedArguments/inspectionData/inspections.test
+++ b/idea/testData/inspections/copyWithoutNamedArguments/inspectionData/inspections.test
@@ -1,0 +1,1 @@
+// INSPECTION_CLASS: org.jetbrains.kotlin.idea.inspections.CopyWithoutNamedArgumentsInspection

--- a/idea/testData/inspections/copyWithoutNamedArguments/test.kt
+++ b/idea/testData/inspections/copyWithoutNamedArguments/test.kt
@@ -1,0 +1,15 @@
+data class Foo(val a: String) {
+    fun copy(i: Int) {}
+}
+
+class Foo2() {
+    fun copy(i: Int) {}
+}
+
+fun bar(f: Foo, f2: Foo2) {
+    f.copy("")
+    f.copy()
+    f.copy(a = "")
+    f.copy(1)
+    f2.copy(1)
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/codeInsight/InspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/codeInsight/InspectionTestGenerated.java
@@ -173,6 +173,12 @@ public class InspectionTestGenerated extends AbstractInspectionTest {
             doTest(fileName);
         }
 
+        @TestMetadata("copyWithoutNamedArguments/inspectionData/inspections.test")
+        public void testCopyWithoutNamedArguments_inspectionData_Inspections_test() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/inspections/copyWithoutNamedArguments/inspectionData/inspections.test");
+            doTest(fileName);
+        }
+
         @TestMetadata("dataClassPrivateConstructor/inspectionData/inspections.test")
         public void testDataClassPrivateConstructor_inspectionData_Inspections_test() throws Exception {
             String fileName = KotlinTestUtils.navigationMetadata("idea/testData/inspections/dataClassPrivateConstructor/inspectionData/inspections.test");


### PR DESCRIPTION
Fixes #KT-17660