### PR TITLE
KT-17708 - Remove "Move to class body" intention for annotation parameters

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/intentions/MovePropertyToClassBodyIntention.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/MovePropertyToClassBodyIntention.kt
@@ -29,7 +29,9 @@ import org.jetbrains.kotlin.resolve.lazy.BodyResolveMode
 
 
 class MovePropertyToClassBodyIntention : SelfTargetingIntention<KtParameter>(KtParameter::class.java, "Move to class body") {
-    override fun isApplicableTo(element: KtParameter, caretOffset: Int): Boolean = element.isPropertyParameter()
+    override fun isApplicableTo(element: KtParameter, caretOffset: Int): Boolean {
+        return element.isPropertyParameter() && (element.ownerFunction as KtPrimaryConstructor).isNotContainedInAnnotation()
+    }
 
     override fun applyTo(element: KtParameter, editor: Editor?) {
         val parentClass = PsiTreeUtil.getParentOfType(element, KtClass::class.java) ?: return
@@ -97,4 +99,6 @@ class MovePropertyToClassBodyIntention : SelfTargetingIntention<KtParameter>(KtP
         nextSibling?.delete() // ':' symbol after use site
         delete()
     }
+
+    fun KtPrimaryConstructor.isNotContainedInAnnotation() = !getContainingClassOrObject().isAnnotation()
 }

--- a/idea/testData/quickfix/typeOfAnnotationMember/star.kt
+++ b/idea/testData/quickfix/typeOfAnnotationMember/star.kt
@@ -1,5 +1,4 @@
 // "Replace array of boxed with array of primitive" "false"
-// ACTION: Move to class body
 // ERROR: Invalid type of annotation member
 annotation class SuperAnnotation(
         val foo: <caret>Array<*>,

--- a/idea/testData/quickfix/typeOfAnnotationMember/string.kt
+++ b/idea/testData/quickfix/typeOfAnnotationMember/string.kt
@@ -1,5 +1,4 @@
 // "Replace array of boxed with array of primitive" "false"
-// ACTION: Move to class body
 annotation class SuperAnnotation(
         val str: <caret>Array<String>
 )


### PR DESCRIPTION
As I understand, annotation classes cannot have a body. Consequently, the "Move to class body" intention should not be available for annotation parameters.

#KT-17708 Fixed