### PR TITLE
KT-17853: Kotlin.js switched parameters of Math.atan2

### DIFF
--- a/js/js.libraries/src/core/math.kt
+++ b/js/js.libraries/src/core/math.kt
@@ -11,7 +11,7 @@ public external object Math {
     public fun acos(value: Double): Double
     public fun asin(value: Double): Double
     public fun atan(value: Double): Double
-    public fun atan2(x: Double, y: Double): Double
+    public fun atan2(y: Double, x: Double): Double
     public fun cos(value: Double): Double
     public fun sin(value: Double): Double
     public fun exp(value: Double): Double


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-17853
The current exposition of the JavaScript [Math object] switched the parameters names: x and y are inverted which is confusing. 
The correct version is `atan2(y,x)` and not the current `atan2(x,y)`