### PR TITLE
Semicolon after loop with empty body is not redundant

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantSemicolonInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantSemicolonInspection.kt
@@ -28,6 +28,7 @@ import org.jetbrains.kotlin.psi.KtEnumEntry
 import org.jetbrains.kotlin.psi.KtImportList
 import org.jetbrains.kotlin.psi.KtPackageDirective
 import org.jetbrains.kotlin.psi.psiUtil.nextLeaf
+import org.jetbrains.kotlin.psi.psiUtil.prevLeaf
 
 class RedundantSemicolonInspection : AbstractKotlinInspection(), CleanupLocalInspectionTool {
     override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean, session: LocalInspectionToolSession): PsiElementVisitor {
@@ -57,6 +58,11 @@ class RedundantSemicolonInspection : AbstractKotlinInspection(), CleanupLocalIns
         }
 
         if (semicolon.parent is KtEnumEntry) return false
+
+        (semicolon.prevLeaf()?.parent as? KtLoopExpression)?.let {
+            if (it.body == null)
+                return false
+        }
 
         if (nextLeaf?.nextLeaf { it !is PsiComment }?.node?.elementType == KtTokens.LBRACE) {
             return false // case with statement starting with '{' and call on the previous line

--- a/idea/testData/inspections/redundantSemicolon/Test.kt
+++ b/idea/testData/inspections/redundantSemicolon/Test.kt
@@ -30,3 +30,8 @@ fun bar() {
     a(); // redundant
     b()
 }
+
+fun baz(args: Array<String>) {
+    for (arg in args);
+    while (args.size > 0);
+}


### PR DESCRIPTION
 #KT-12805 Fixed