### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -9,7 +9,7 @@ Welcome to [Kotlin](https://kotlinlang.org/)! Some handy links:
 
  * [Kotlin Site](https://kotlinlang.org/)
  * [Getting Started Guide](https://kotlinlang.org/docs/tutorials/getting-started.html)
- * [Try Kotlin](http://try.kotlinlang.org/)
+ * [Try Kotlin](https://try.kotlinlang.org/)
  * [Kotlin Standard Library](https://kotlinlang.org/api/latest/jvm/stdlib/index.html)
  * [Issue Tracker](https://youtrack.jetbrains.com/issues/KT)
  * [Forum](https://discuss.kotlinlang.org/)


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### HTTPS Corrected URLs 
Was | Now 
--- | --- 
http://try.kotlinlang.org/ | https://try.kotlinlang.org/ 
