### PR TITLE
Move property to constructor preserves vararg keyword

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/intentions/MovePropertyToConstructorIntention.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/MovePropertyToConstructorIntention.kt
@@ -32,6 +32,7 @@ import org.jetbrains.kotlin.idea.search.usagesSearch.descriptor
 import org.jetbrains.kotlin.idea.util.CommentSaver
 import org.jetbrains.kotlin.idea.util.IdeDescriptorRenderers
 import org.jetbrains.kotlin.lexer.KtModifierKeywordToken
+import org.jetbrains.kotlin.lexer.KtTokens.VARARG_KEYWORD
 import org.jetbrains.kotlin.lexer.KtTokens.LATEINIT_KEYWORD
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
@@ -86,6 +87,7 @@ class MovePropertyToConstructorIntention :
                 element.modifierList?.getModifiersText()?.let(this::append)
                 propertyAnnotationsText?.takeIf(String::isNotBlank)?.let { appendWithSpaceBefore(it) }
                 parameterAnnotationsText?.let { appendWithSpaceBefore(it) }
+                if (constructorParameter.isVarArg) appendWithSpaceBefore(VARARG_KEYWORD.value)
                 appendWithSpaceBefore(element.valOrVarKeyword.text)
                 element.name?.let { appendWithSpaceBefore(it) }
                 constructorParameter.typeReference?.text?.let { append(": $it") }

--- a/idea/testData/quickfix/canBePrimaryConstructorProperty/vararg.kt
+++ b/idea/testData/quickfix/canBePrimaryConstructorProperty/vararg.kt
@@ -1,0 +1,4 @@
+// "Move to constructor" "true"
+class A(vararg strings: String) {
+    val <caret>strings = strings
+}

--- a/idea/testData/quickfix/canBePrimaryConstructorProperty/vararg.kt.after
+++ b/idea/testData/quickfix/canBePrimaryConstructorProperty/vararg.kt.after
@@ -1,0 +1,3 @@
+// "Move to constructor" "true"
+class A(vararg val strings: String) {
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -985,6 +985,12 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
             String fileName = KotlinTestUtils.navigationMetadata("idea/testData/quickfix/canBePrimaryConstructorProperty/simple.kt");
             doTest(fileName);
         }
+
+        @TestMetadata("vararg.kt")
+        public void testVararg() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/quickfix/canBePrimaryConstructorProperty/vararg.kt");
+            doTest(fileName);
+        }
     }
 
     @TestMetadata("idea/testData/quickfix/changeSignature")


### PR DESCRIPTION
 #KT-18035 Fixed