### PR TITLE
Don't overwrite plugin classpaths #KT-18022

### DIFF
--- a/libraries/tools/kotlin-maven-plugin/src/main/java/org/jetbrains/kotlin/maven/KotlinCompileMojoBase.java
+++ b/libraries/tools/kotlin-maven-plugin/src/main/java/org/jetbrains/kotlin/maven/KotlinCompileMojoBase.java
@@ -480,10 +480,18 @@ public abstract class KotlinCompileMojoBase<A extends CommonCompilerArguments> e
 
         List<String> pluginClassPaths = getCompilerPluginClassPaths();
         if (pluginClassPaths != null && !pluginClassPaths.isEmpty()) {
-            if (getLog().isDebugEnabled()) {
-                getLog().debug("Plugin classpaths are: " + Joiner.on(", ").join(pluginClassPaths));
+            if (arguments.pluginClasspaths == null || arguments.pluginClasspaths.length == 0) {
+                arguments.pluginClasspaths = pluginClassPaths.toArray(new String[pluginClassPaths.size()]);
+            } else {
+                for (String path : pluginClassPaths) {
+                    arguments.pluginClasspaths = ArrayUtil.append(arguments.pluginClasspaths, path);
+                }
             }
-            arguments.pluginClasspaths = pluginClassPaths.toArray(new String[pluginClassPaths.size()]);
+
+            if (getLog().isDebugEnabled()) {
+                getLog().debug("Plugin classpaths are: " + Joiner.on(", ").join(arguments.pluginClasspaths));
+            }
+
         }
 
         List<String> pluginArguments;


### PR DESCRIPTION
When the kotlin maven compiler plugin detects dependencies it overwrites `arguments.pluginClasspaths` with the classpaths of the detected dependencies. However, `arguments.pluginClasspaths` may have already been set by the compiler plugin earlier on if the `kapt` goal is enabled.

This pull request addresses this by merging the kapt classpaths and the detected classpaths, rather than having one overwrite the other.

#KT-18022 fixed.