### PR TITLE
#KT-17895 Add inspection to replace rangeTo or .. call with until

### DIFF
--- a/idea/resources/inspectionDescriptions/ReplaceRangeToWithUntil.html
+++ b/idea/resources/inspectionDescriptions/ReplaceRangeToWithUntil.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This inspection reports calls to 'rangeTo' or the '..' operator instead of calls to 'until'.
+</body>
+</html>

--- a/idea/src/META-INF/plugin.xml
+++ b/idea/src/META-INF/plugin.xml
@@ -2188,6 +2188,14 @@
                      language="kotlin"
     />
 
+    <localInspection implementationClass="org.jetbrains.kotlin.idea.inspections.ReplaceRangeToWithUntilInspection"
+                     displayName="'rangeTo' or the '..' call can be replaced with 'until'"
+                     groupName="Kotlin"
+                     enabledByDefault="true"
+                     level="WEAK WARNING"
+                     language="kotlin"
+    />
+
     <referenceImporter implementation="org.jetbrains.kotlin.idea.quickfix.KotlinReferenceImporter"/>
 
     <fileType.fileViewProviderFactory filetype="KJSM" implementationClass="com.intellij.psi.ClassFileViewProviderFactory"/>

--- a/idea/src/org/jetbrains/kotlin/idea/inspections/ReplaceRangeToWithUntilInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/ReplaceRangeToWithUntilInspection.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2010-2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.kotlin.idea.inspections
+
+import com.intellij.codeInspection.IntentionWrapper
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElementVisitor
+import org.jetbrains.kotlin.idea.caches.resolve.analyze
+import org.jetbrains.kotlin.idea.intentions.ReplaceRangeToWithUntilIntention
+import org.jetbrains.kotlin.idea.intentions.callExpression
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
+import org.jetbrains.kotlin.resolve.calls.callUtil.getType
+import org.jetbrains.kotlin.resolve.constants.evaluate.ConstantExpressionEvaluator
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameUnsafe
+import org.jetbrains.kotlin.resolve.lazy.BodyResolveMode
+
+private fun KtExpression.getCallableDescriptor() = getResolvedCall(analyze())?.resultingDescriptor
+
+private fun KtExpression.getArguments() = when (this) {
+    is KtBinaryExpression -> this.left to this.right
+    is KtDotQualifiedExpression -> this.receiverExpression to this.callExpression?.valueArguments?.singleOrNull()?.getArgumentExpression()
+    else -> null
+}
+
+private val REGEX_RANGE_TO = """kotlin.(Char|Byte|Short|Int|Long).rangeTo""".toRegex()
+
+class ReplaceRangeToWithUntilInspection : AbstractKotlinInspection() {
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        return object : KtVisitorVoid() {
+            override fun visitExpression(expression: KtExpression) {
+                super.visitExpression(expression)
+
+                if (expression !is KtBinaryExpression && expression !is KtDotQualifiedExpression) return
+
+                val fqName = expression.getCallableDescriptor()?.fqNameUnsafe?.asString() ?: return
+                if (!fqName.matches(REGEX_RANGE_TO)) return
+
+                if (expression.getArguments()?.second?.isMinusOne() != true) return
+
+                holder.registerProblem(
+                        expression,
+                        "'rangeTo' or the '..' call can be replaced with 'until'",
+                        ProblemHighlightType.WEAK_WARNING,
+                        IntentionWrapper(ReplaceRangeToWithUntilIntention(), expression.containingKtFile)
+                )
+            }
+        }
+    }
+
+    private fun KtExpression.isMinusOne(): Boolean {
+        if (this !is KtBinaryExpression) return false
+        if (operationToken != KtTokens.MINUS) return false
+
+        val right = right as? KtConstantExpression ?: return false
+        val context = right.analyze(BodyResolveMode.PARTIAL)
+        val constantValue = ConstantExpressionEvaluator.getConstant(right, context)?.toConstantValue(right.getType(context) ?: return false)
+        val rightValue = (constantValue?.value as? Number)?.toInt() ?: return false
+        return rightValue == 1
+    }
+}

--- a/idea/testData/inspections/replaceRangeToWithUntil/inspectionData/expected.xml
+++ b/idea/testData/inspections/replaceRangeToWithUntil/inspectionData/expected.xml
@@ -1,0 +1,18 @@
+<problems>
+    <problem>
+        <file>test.kt</file>
+        <line>3</line>
+        <module>light_idea_test_case</module>
+        <entry_point TYPE="file" FQNAME="temp:///src/test.kt" />
+        <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'rangeTo' or the '..' call can be replaced with 'until'</problem_class>
+        <description>'rangeTo' or the '..' call can be replaced with 'until'</description>
+    </problem>
+    <problem>
+        <file>test.kt</file>
+        <line>8</line>
+        <module>light_idea_test_case</module>
+        <entry_point TYPE="file" FQNAME="temp:///src/test.kt" />
+        <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'rangeTo' or the '..' call can be replaced with 'until'</problem_class>
+        <description>'rangeTo' or the '..' call can be replaced with 'until'</description>
+    </problem>
+</problems>

--- a/idea/testData/inspections/replaceRangeToWithUntil/inspectionData/inspections.test
+++ b/idea/testData/inspections/replaceRangeToWithUntil/inspectionData/inspections.test
@@ -1,0 +1,1 @@
+// INSPECTION_CLASS: org.jetbrains.kotlin.idea.inspections.ReplaceRangeToWithUntilInspection

--- a/idea/testData/inspections/replaceRangeToWithUntil/test.kt
+++ b/idea/testData/inspections/replaceRangeToWithUntil/test.kt
@@ -1,0 +1,9 @@
+fun foo() {
+    val n = 10
+    for (i in 0 .. n - 1) {}
+}
+
+fun bar() {
+    val n = 10
+    for (i in 0.rangeTo(n - 1)) {}
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/codeInsight/InspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/codeInsight/InspectionTestGenerated.java
@@ -299,6 +299,12 @@ public class InspectionTestGenerated extends AbstractInspectionTest {
             doTest(fileName);
         }
 
+        @TestMetadata("replaceRangeToWithUntil/inspectionData/inspections.test")
+        public void testReplaceRangeToWithUntil_inspectionData_Inspections_test() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/inspections/replaceRangeToWithUntil/inspectionData/inspections.test");
+            doTest(fileName);
+        }
+
         @TestMetadata("spelling/inspectionData/inspections.test")
         public void testSpelling_inspectionData_Inspections_test() throws Exception {
             String fileName = KotlinTestUtils.navigationMetadata("idea/testData/inspections/spelling/inspectionData/inspections.test");


### PR DESCRIPTION
A lot of code for this inspection is duplicated from ReplaceRangeToWithUntilIntention. I don't really know how to share logic properly between two of this since I haven't done it before. If you have any suggestions on how to improve it I will be happy to fix it. Also, if more tests are needed I will be happy to add them as well.

https://youtrack.jetbrains.com/issue/KT-17895
#KT-17895 fixed