### PR TITLE
JS: Avoid declaration skeleton body generation in case of external class or object

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/CallableBuilder.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/CallableBuilder.kt
@@ -459,7 +459,13 @@ class CallableBuilder(val config: CallableBuilderConfiguration) {
                         val body = when {
                             callableInfo.kind == CallableKind.SECONDARY_CONSTRUCTOR -> ""
                             callableInfo.isAbstract -> ""
+                            containingElement is KtClass && containingElement.hasModifier(KtTokens.EXTERNAL_KEYWORD) -> ""
+                            containingElement is KtObjectDeclaration && containingElement.hasModifier(KtTokens.EXTERNAL_KEYWORD) -> ""
+                            containingElement is KtObjectDeclaration && containingElement.isCompanion()
+                                && containingElement.parent.parent is KtClass
+                                && (containingElement.parent.parent as KtClass).hasModifier(KtTokens.EXTERNAL_KEYWORD) -> ""
                             else -> "{}"
+
                         }
                         @Suppress("USELESS_CAST") // KT-10755
                         if (callableInfo is FunctionInfo) {

--- a/idea/testData/quickfix/migration/jsExternal/funPlacementOnCompanionObjectJsRuntime.kt
+++ b/idea/testData/quickfix/migration/jsExternal/funPlacementOnCompanionObjectJsRuntime.kt
@@ -1,0 +1,10 @@
+// "Create member function 'A.Companion.foo'" "true"
+// JS
+
+external class A {
+    companion object
+}
+
+fun test() {
+    A.<caret>foo()
+}

--- a/idea/testData/quickfix/migration/jsExternal/funPlacementOnCompanionObjectJsRuntime.kt.after
+++ b/idea/testData/quickfix/migration/jsExternal/funPlacementOnCompanionObjectJsRuntime.kt.after
@@ -1,0 +1,12 @@
+// "Create member function 'A.Companion.foo'" "true"
+// JS
+
+external class A {
+    companion object {
+        fun foo()
+    }
+}
+
+fun test() {
+    A.foo()
+}

--- a/idea/testData/quickfix/migration/jsExternal/funPlacementOnExternalClassJsRuntime.kt
+++ b/idea/testData/quickfix/migration/jsExternal/funPlacementOnExternalClassJsRuntime.kt
@@ -1,0 +1,8 @@
+// "Create member function 'A.foo'" "true"
+// JS
+
+external class A
+
+fun test() {
+    A().<caret>foo()
+}

--- a/idea/testData/quickfix/migration/jsExternal/funPlacementOnExternalClassJsRuntime.kt.after
+++ b/idea/testData/quickfix/migration/jsExternal/funPlacementOnExternalClassJsRuntime.kt.after
@@ -1,0 +1,10 @@
+// "Create member function 'A.foo'" "true"
+// JS
+
+external class A {
+    fun foo()
+}
+
+fun test() {
+    A().foo()
+}

--- a/idea/testData/quickfix/migration/jsExternal/funPlacementOnExternalObjectJsRuntime.kt
+++ b/idea/testData/quickfix/migration/jsExternal/funPlacementOnExternalObjectJsRuntime.kt
@@ -1,0 +1,8 @@
+// "Create member function 'A.foo'" "true"
+// JS
+
+external object A
+
+fun test() {
+    A.<caret>foo()
+}

--- a/idea/testData/quickfix/migration/jsExternal/funPlacementOnExternalObjectJsRuntime.kt.after
+++ b/idea/testData/quickfix/migration/jsExternal/funPlacementOnExternalObjectJsRuntime.kt.after
@@ -1,0 +1,10 @@
+// "Create member function 'A.foo'" "true"
+// JS
+
+external object A {
+    fun foo()
+}
+
+fun test() {
+    A.foo()
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -6529,6 +6529,24 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
                 doTest(fileName);
             }
 
+            @TestMetadata("funPlacementOnCompanionObjectJsRuntime.kt")
+            public void testFunPlacementOnCompanionObjectJsRuntime() throws Exception {
+                String fileName = KotlinTestUtils.navigationMetadata("idea/testData/quickfix/migration/jsExternal/funPlacementOnCompanionObjectJsRuntime.kt");
+                doTest(fileName);
+            }
+
+            @TestMetadata("funPlacementOnExternalClassJsRuntime.kt")
+            public void testFunPlacementOnExternalClassJsRuntime() throws Exception {
+                String fileName = KotlinTestUtils.navigationMetadata("idea/testData/quickfix/migration/jsExternal/funPlacementOnExternalClassJsRuntime.kt");
+                doTest(fileName);
+            }
+
+            @TestMetadata("funPlacementOnExternalObjectJsRuntime.kt")
+            public void testFunPlacementOnExternalObjectJsRuntime() throws Exception {
+                String fileName = KotlinTestUtils.navigationMetadata("idea/testData/quickfix/migration/jsExternal/funPlacementOnExternalObjectJsRuntime.kt");
+                doTest(fileName);
+            }
+
             @TestMetadata("nativeExtensionFunBlockBodyJsRuntime.kt")
             public void testNativeExtensionFunBlockBodyJsRuntime() throws Exception {
                 String fileName = KotlinTestUtils.navigationMetadata("idea/testData/quickfix/migration/jsExternal/nativeExtensionFunBlockBodyJsRuntime.kt");


### PR DESCRIPTION
When you are working on a Kotlin JS project and you would like to tell Kotlin that a certain declaration is written in pure JavaScript, you should mark it with external modifier. According to the [reference](https://kotlinlang.org/docs/reference/js-interop.html) you should omit bodies of external declarations.

Currently when you're using "Create member function" quick fix on an external class or object, Idea generates you the function body as well, which is syntactically incorrect, and you have to remove these every time. This can be painfully especially when you're working on a interop library.

This pull request address this by extending "declaration skeleton" generation logic take into account three cases.

- creating member function on an external class declaration
- creating member function on an external object declaration
- creating member function on an companion object within an external class declaration (and only class declaration since 'companion' modifier is not applicable inside an object)