### PR TITLE
Eliminate some unnecessary CHECKCAST operations

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/StackValue.java
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/StackValue.java
@@ -372,7 +372,17 @@ public abstract class StackValue {
         }
         else if (toType.getSort() == Type.OBJECT) {
             if (fromType.getSort() == Type.OBJECT || fromType.getSort() == Type.ARRAY) {
-                if (!toType.equals(OBJECT_TYPE)) {
+                // The compiler sometimes unnecessarily casts things like ArrayList to Collection.  This prevents that.
+                boolean unnecessaryCast = false;
+                try {
+                    Class fromClass = Class.forName(fromType.getClassName());
+                    Class toClass = Class.forName(toType.getClassName());
+                    unnecessaryCast = toClass.isAssignableFrom(fromClass);
+                }
+                catch (ClassNotFoundException e) {
+                    // This is expected if fromType or toType are custom classes.
+                }
+                if (!unnecessaryCast && !toType.equals(OBJECT_TYPE)) {
                     v.checkcast(toType);
                 }
             }

--- a/compiler/testData/codegen/bytecodeText/checkcast/kt18311.kt
+++ b/compiler/testData/codegen/bytecodeText/checkcast/kt18311.kt
@@ -1,0 +1,5 @@
+fun unnecessaryCasts(strings: List<String>): List<String> {
+    return strings.filterTo(ArrayList<String>(), { it.length > 5 })
+}
+
+// 2 CHECKCAST

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
@@ -754,6 +754,12 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
             String fileName = KotlinTestUtils.navigationMetadata("compiler/testData/codegen/bytecodeText/checkcast/kt15411.kt");
             doTest(fileName);
         }
+
+        @TestMetadata("kt18311.kt")
+        public void testKt18311() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("compiler/testData/codegen/bytecodeText/checkcast/kt18311.kt");
+            doTest(fileName);
+        }
     }
 
     @TestMetadata("compiler/testData/codegen/bytecodeText/coercionToUnitOptimization")


### PR DESCRIPTION
In certain circumstances, an ArrayList would be cast to a Collection and then back to a List.

This eliminates CHECKCAST operations to weaker types.

#KT-18311 Fixed