### PR TITLE
KT-18407: Do not show "Move to constructor" intention for properties declared in interfaces

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/CanBePrimaryConstructorPropertyInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/CanBePrimaryConstructorPropertyInspection.kt
@@ -23,6 +23,7 @@ import org.jetbrains.kotlin.descriptors.ClassConstructorDescriptor
 import org.jetbrains.kotlin.descriptors.ValueParameterDescriptor
 import org.jetbrains.kotlin.idea.caches.resolve.analyzeFully
 import org.jetbrains.kotlin.idea.intentions.MovePropertyToConstructorIntention
+import org.jetbrains.kotlin.idea.refactoring.isInterfaceClass
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtReferenceExpression
@@ -55,6 +56,8 @@ class CanBePrimaryConstructorPropertyInspection : AbstractKotlinInspection() {
 
                 val assignedParameter = DescriptorToSourceUtils.descriptorToDeclaration(assignedDescriptor) as? KtParameter ?: return
                 if (property.containingClassOrObject !== assignedParameter.containingClassOrObject) return
+
+                if (property.containingClassOrObject?.isInterfaceClass() ?: false) return
 
                 holder.registerProblem(holder.manager.createProblemDescriptor(
                         nameIdentifier,

--- a/idea/testData/intentions/movePropertyToConstructor/declaredInInterface.kt
+++ b/idea/testData/intentions/movePropertyToConstructor/declaredInInterface.kt
@@ -1,0 +1,5 @@
+// IS_APPLICABLE: false
+
+interface MyInterface {
+    val <caret>prop5: Int
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -11624,6 +11624,12 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
             doTest(fileName);
         }
 
+        @TestMetadata("declaredInInterface.kt")
+        public void testDeclaredInInterface() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/movePropertyToConstructor/declaredInInterface.kt");
+            doTest(fileName);
+        }
+
         @TestMetadata("delegated.kt")
         public void testDelegated() throws Exception {
             String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/movePropertyToConstructor/delegated.kt");


### PR DESCRIPTION
#KT-18407 Fixed