### PR TITLE
KT-18424: Add Kotlin Data Class file template

### DIFF
--- a/idea/resources/fileTemplates/internal/Kotlin Data Class.kt.ft
+++ b/idea/resources/fileTemplates/internal/Kotlin Data Class.kt.ft
@@ -1,0 +1,5 @@
+#if (${PACKAGE_NAME} && ${PACKAGE_NAME} != "")package ${PACKAGE_NAME}
+
+#end
+#parse("File Header.java")
+data class ${NAME}()

--- a/idea/resources/fileTemplates/internal/Kotlin Data Class.kt.html
+++ b/idea/resources/fileTemplates/internal/Kotlin Data Class.kt.html
@@ -1,0 +1,14 @@
+<html>
+<body>
+<table border="0" cellpadding="2" cellspacing="0" style="border-collapse: collapse">
+  <tr>
+    <td colspan="3">
+      <font face="verdana" size="-1">
+        This is a built-in template used by <b>IDEA</b> each time you create a
+        Kotlin data class
+      </font>
+    </td>
+  </tr>
+</table>
+</body>
+</html>

--- a/idea/src/org/jetbrains/kotlin/idea/actions/NewKotlinFileAction.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/actions/NewKotlinFileAction.kt
@@ -78,6 +78,7 @@ class NewKotlinFileAction
         builder.setTitle("New Kotlin File/Class")
                 .addKind("File", KotlinFileType.INSTANCE.icon, "Kotlin File")
                 .addKind("Class", KotlinIcons.CLASS, "Kotlin Class")
+                .addKind("Data Class", KotlinIcons.CLASS, "Kotlin Data Class")
                 .addKind("Interface", KotlinIcons.INTERFACE, "Kotlin Interface")
                 .addKind("Enum class", KotlinIcons.ENUM, "Kotlin Enum")
                 .addKind("Object", KotlinIcons.OBJECT, "Kotlin Object")


### PR DESCRIPTION
Just like having a file template for `Class`, there are times that we need to generate a `Data Class` instead of generating a `Class` and modifying it to be a `Data Class`. 

Related feature request: https://youtrack.jetbrains.com/issue/KT-18424