### PR TITLE
KT-15893 "Array property in data class" inspection could have a quick fix to generate `equals()` and `hashcode()`

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/actions/generate/KotlinGenerateEqualsAndHashcodeAction.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/actions/generate/KotlinGenerateEqualsAndHashcodeAction.kt
@@ -27,6 +27,7 @@ import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.descriptors.VariableDescriptor
+import org.jetbrains.kotlin.idea.caches.resolve.analyze
 import org.jetbrains.kotlin.idea.caches.resolve.analyzeFully
 import org.jetbrains.kotlin.idea.codeInsight.DescriptorToSourceUtilsIde
 import org.jetbrains.kotlin.idea.core.CollectingNameValidator
@@ -35,12 +36,12 @@ import org.jetbrains.kotlin.idea.core.insertMembersAfter
 import org.jetbrains.kotlin.idea.core.quoteIfNeeded
 import org.jetbrains.kotlin.idea.util.IdeDescriptorRenderers
 import org.jetbrains.kotlin.idea.util.application.runWriteAction
-import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.getElementTextWithContext
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.descriptorUtil.builtIns
 import org.jetbrains.kotlin.resolve.descriptorUtil.getSuperClassOrAny
+import org.jetbrains.kotlin.resolve.lazy.BodyResolveMode
 import org.jetbrains.kotlin.resolve.source.getPsi
 import org.jetbrains.kotlin.types.TypeUtils
 import org.jetbrains.kotlin.utils.addIfNotNull
@@ -75,8 +76,22 @@ class KotlinGenerateEqualsAndHashcodeAction : KotlinGenerateMemberActionBase<Kot
                && targetClass !is KtEnumEntry
                && !targetClass.isAnnotation()
                && !targetClass.isInterface()
-               && !targetClass.hasModifier(KtTokens.DATA_KEYWORD)
+               && isValidForDataClass(targetClass)
                && getPropertiesToUseInGeneratedMember(targetClass).isNotEmpty()
+    }
+    
+    private fun isValidForDataClass(targetClass: KtClass): Boolean {
+        if (targetClass.isData()) {
+            val constructor = targetClass.primaryConstructor ?: return false
+            val context by lazy { constructor.analyze(BodyResolveMode.PARTIAL) }
+            return constructor.valueParameters.any { parameter ->
+                parameter.hasValOrVar() && context.get(BindingContext.TYPE, parameter.typeReference)?.let { type ->
+                    KotlinBuiltIns.isArray(type) || KotlinBuiltIns.isPrimitiveArray(type)
+                } ?: false
+            }
+        } else {
+            return true
+        }
     }
 
     override fun prepareMembersInfo(klass: KtClassOrObject, project: Project, editor: Editor?): Info? {

--- a/idea/testData/codeInsight/generate/equalsWithHashCode/dataClassHasArrayProperty.kt
+++ b/idea/testData/codeInsight/generate/equalsWithHashCode/dataClassHasArrayProperty.kt
@@ -1,0 +1,1 @@
+data class A<caret>(val a: IntArray)

--- a/idea/testData/codeInsight/generate/equalsWithHashCode/dataClassHasArrayProperty.kt.after
+++ b/idea/testData/codeInsight/generate/equalsWithHashCode/dataClassHasArrayProperty.kt.after
@@ -1,0 +1,18 @@
+import java.util.Arrays
+
+data class A(val a: IntArray) {
+    <caret>override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other?.javaClass != javaClass) return false
+
+        other as A
+
+        if (!Arrays.equals(a, other.a)) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return Arrays.hashCode(a)
+    }
+}

--- a/idea/testData/quickfix/arrayInDataClass/.inspection
+++ b/idea/testData/quickfix/arrayInDataClass/.inspection
@@ -1,0 +1,1 @@
+org.jetbrains.kotlin.idea.inspections.ArrayInDataClassInspection

--- a/idea/testData/quickfix/arrayInDataClass/test.kt
+++ b/idea/testData/quickfix/arrayInDataClass/test.kt
@@ -1,0 +1,3 @@
+// "Generate equals() and hashCode()" "true"
+// WITH_RUNTIME
+data class A(<caret>val a: IntArray)

--- a/idea/testData/quickfix/arrayInDataClass/test.kt.after
+++ b/idea/testData/quickfix/arrayInDataClass/test.kt.after
@@ -1,0 +1,20 @@
+import java.util.Arrays
+
+// "Generate equals() and hashCode()" "true"
+// WITH_RUNTIME
+data class A(val a: IntArray) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other?.javaClass != javaClass) return false
+
+        other as A
+
+        if (!Arrays.equals(a, other.a)) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return Arrays.hashCode(a)
+    }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/codeInsight/generate/GenerateHashCodeAndEqualsActionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/codeInsight/generate/GenerateHashCodeAndEqualsActionTestGenerated.java
@@ -60,6 +60,12 @@ public class GenerateHashCodeAndEqualsActionTestGenerated extends AbstractGenera
         doTest(fileName);
     }
 
+    @TestMetadata("dataClassHasArrayProperty.kt")
+    public void testDataClassHasArrayProperty() throws Exception {
+        String fileName = KotlinTestUtils.navigationMetadata("idea/testData/codeInsight/generate/equalsWithHashCode/dataClassHasArrayProperty.kt");
+        doTest(fileName);
+    }
+
     @TestMetadata("enum.kt")
     public void testEnum() throws Exception {
         String fileName = KotlinTestUtils.navigationMetadata("idea/testData/codeInsight/generate/equalsWithHashCode/enum.kt");

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -807,6 +807,21 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
         }
     }
 
+    @TestMetadata("idea/testData/quickfix/arrayInDataClass")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class ArrayInDataClass extends AbstractQuickFixTest {
+        public void testAllFilesPresentInArrayInDataClass() throws Exception {
+            KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/quickfix/arrayInDataClass"), Pattern.compile("^([\\w\\-_]+)\\.kt$"), TargetBackend.ANY, true);
+        }
+
+        @TestMetadata("test.kt")
+        public void testTest() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/quickfix/arrayInDataClass/test.kt");
+            doTest(fileName);
+        }
+    }
+
     @TestMetadata("idea/testData/quickfix/autoImports")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)


### PR DESCRIPTION
Fix for https://youtrack.jetbrains.com/issue/KT-15893