### PR TITLE
Add argument list parentheses wrapping format settings; part of KT-9423

### DIFF
--- a/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/kotlinSpacingRules.kt
+++ b/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/kotlinSpacingRules.kt
@@ -87,6 +87,31 @@ fun createSpacingBuilder(settings: CodeStyleSettings, builderUtil: KotlinSpacing
                 }
             }
             inPosition(parent = VALUE_PARAMETER_LIST, right = VALUE_PARAMETER).customRule(parameterWithDocCommentRule)
+
+
+            fun createParameterListParanthesesBreakRule(breakNeeded: Boolean): (ASTBlock, ASTBlock, ASTBlock) -> Spacing {
+                return {
+                    parent: ASTBlock, left: ASTBlock, right: ASTBlock ->
+                    if (breakNeeded) {
+                        Spacing.createDependentLFSpacing(0, 0, parent.textRange,
+                                                         commonCodeStyleSettings.KEEP_LINE_BREAKS,
+                                                         commonCodeStyleSettings.KEEP_BLANK_LINES_IN_CODE)
+                    }
+                    else {
+                        createSpacing(0, 0, 0, commonCodeStyleSettings.KEEP_LINE_BREAKS, commonCodeStyleSettings.KEEP_BLANK_LINES_IN_CODE)
+                    }
+                }
+            }
+
+            inPosition(parent = VALUE_PARAMETER_LIST, left = LPAR, right = VALUE_PARAMETER)
+                    .customRule(createParameterListParanthesesBreakRule(commonCodeStyleSettings.METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE))
+            inPosition(parent = VALUE_PARAMETER_LIST, left = VALUE_PARAMETER, right = RPAR)
+                    .customRule(createParameterListParanthesesBreakRule(commonCodeStyleSettings.METHOD_PARAMETERS_RPAREN_ON_NEXT_LINE))
+
+            inPosition(parent = VALUE_ARGUMENT_LIST, left = LPAR, right = VALUE_ARGUMENT)
+                    .customRule(createParameterListParanthesesBreakRule(commonCodeStyleSettings.CALL_PARAMETERS_LPAREN_ON_NEXT_LINE))
+            inPosition(parent = VALUE_ARGUMENT_LIST, left = VALUE_ARGUMENT, right = RPAR)
+                    .customRule(createParameterListParanthesesBreakRule(commonCodeStyleSettings.CALL_PARAMETERS_RPAREN_ON_NEXT_LINE))
         }
 
         simple {
@@ -204,12 +229,8 @@ fun createSpacingBuilder(settings: CodeStyleSettings, builderUtil: KotlinSpacing
             after(LPAR).spaces(0)
             before(RPAR).spaces(0)
 
-            afterInside(LPAR, VALUE_PARAMETER_LIST).spaces(0)
-            beforeInside(RPAR, VALUE_PARAMETER_LIST).spaces(0)
             afterInside(LT, TYPE_PARAMETER_LIST).spaces(0)
             beforeInside(GT, TYPE_PARAMETER_LIST).spaces(0)
-            afterInside(LPAR, VALUE_ARGUMENT_LIST).spaces(0)
-            beforeInside(RPAR, VALUE_ARGUMENT_LIST).spaces(0)
             afterInside(LT, TYPE_ARGUMENT_LIST).spaces(0)
             beforeInside(GT, TYPE_ARGUMENT_LIST).spaces(0)
             before(TYPE_ARGUMENT_LIST).spaces(0)

--- a/idea/src/org/jetbrains/kotlin/idea/formatter/KotlinLanguageCodeStyleSettingsProvider.java
+++ b/idea/src/org/jetbrains/kotlin/idea/formatter/KotlinLanguageCodeStyleSettingsProvider.java
@@ -205,7 +205,11 @@ public class KotlinLanguageCodeStyleSettingsProvider extends LanguageCodeStyleSe
                         "CATCH_ON_NEW_LINE",
                         "FINALLY_ON_NEW_LINE",
                         "CALL_PARAMETERS_WRAP",
-                        "METHOD_PARAMETERS_WRAP"
+                        "METHOD_PARAMETERS_WRAP",
+                        "CALL_PARAMETERS_LPAREN_ON_NEXT_LINE",
+                        "CALL_PARAMETERS_RPAREN_ON_NEXT_LINE",
+                        "METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE",
+                        "METHOD_PARAMETERS_RPAREN_ON_NEXT_LINE"
                 );
                 consumer.renameStandardOption(CodeStyleSettingsCustomizable.WRAPPING_SWITCH_STATEMENT, "'when' statements");
                 consumer.showCustomOption(KotlinCodeStyleSettings.class, "ALIGN_IN_COLUMNS_CASE_BRANCH", "Align 'when' branches in columns",

--- a/idea/testData/formatter/parameterList/ArgumentListLeftParentheseOnNextLine.after.kt
+++ b/idea/testData/formatter/parameterList/ArgumentListLeftParentheseOnNextLine.after.kt
@@ -1,0 +1,24 @@
+// SET_INT: CALL_PARAMETERS_WRAP = 2
+// SET_TRUE: ALIGN_MULTILINE_PARAMETERS_IN_CALLS
+// SET_TRUE: CALL_PARAMETERS_LPAREN_ON_NEXT_LINE
+// RIGHT_MARGIN: 30
+
+fun foo() {
+    testtest()
+
+    testtesttesttesttesttesttesttesttest()
+
+    testtest(foofoo)
+
+    testtesttesttest(foofoofoofoofoofoofoofoofoofoofoofoo)
+
+    testtest(
+            foobar,
+            barfoo)
+
+    testtesttesttest(
+            foofoo,
+            barbar,
+            foobar,
+            barfoo)
+}

--- a/idea/testData/formatter/parameterList/ArgumentListLeftParentheseOnNextLine.kt
+++ b/idea/testData/formatter/parameterList/ArgumentListLeftParentheseOnNextLine.kt
@@ -1,0 +1,18 @@
+// SET_INT: CALL_PARAMETERS_WRAP = 2
+// SET_TRUE: ALIGN_MULTILINE_PARAMETERS_IN_CALLS
+// SET_TRUE: CALL_PARAMETERS_LPAREN_ON_NEXT_LINE
+// RIGHT_MARGIN: 30
+
+fun foo() {
+    testtest()
+
+    testtesttesttesttesttesttesttesttest()
+
+    testtest(foofoo)
+
+    testtesttesttest(foofoofoofoofoofoofoofoofoofoofoofoo)
+
+    testtest(foobar, barfoo)
+
+    testtesttesttest(foofoo, barbar, foobar, barfoo)
+}

--- a/idea/testData/formatter/parameterList/ArgumentListRightParentheseOnNextLine.after.kt
+++ b/idea/testData/formatter/parameterList/ArgumentListRightParentheseOnNextLine.after.kt
@@ -1,0 +1,24 @@
+// SET_INT: CALL_PARAMETERS_WRAP = 2
+// SET_TRUE: ALIGN_MULTILINE_PARAMETERS_IN_CALLS
+// SET_TRUE: CALL_PARAMETERS_RPAREN_ON_NEXT_LINE
+// RIGHT_MARGIN: 30
+
+fun foo() {
+    testtest()
+
+    testtesttesttesttesttesttesttesttest()
+
+    testtest(foofoo)
+
+    testtesttesttest(foofoofoofoofoofoofoofoofoofoofoofoo)
+
+    testtest(foobar,
+             barfoo
+    )
+
+    testtesttesttest(foofoo,
+                     barbar,
+                     foobar,
+                     barfoo
+    )
+}

--- a/idea/testData/formatter/parameterList/ArgumentListRightParentheseOnNextLine.kt
+++ b/idea/testData/formatter/parameterList/ArgumentListRightParentheseOnNextLine.kt
@@ -1,0 +1,18 @@
+// SET_INT: CALL_PARAMETERS_WRAP = 2
+// SET_TRUE: ALIGN_MULTILINE_PARAMETERS_IN_CALLS
+// SET_TRUE: CALL_PARAMETERS_RPAREN_ON_NEXT_LINE
+// RIGHT_MARGIN: 30
+
+fun foo() {
+    testtest()
+
+    testtesttesttesttesttesttesttesttest()
+
+    testtest(foofoo)
+
+    testtesttesttest(foofoofoofoofoofoofoofoofoofoofoofoo)
+
+    testtest(foobar, barfoo)
+
+    testtesttesttest(foofoo, barbar, foobar, barfoo)
+}

--- a/idea/testData/formatter/parameterList/ParametersListLeftParentheseOnNextLine.after.kt
+++ b/idea/testData/formatter/parameterList/ParametersListLeftParentheseOnNextLine.after.kt
@@ -1,0 +1,96 @@
+// SET_INT: METHOD_PARAMETERS_WRAP = 2
+// SET_TRUE: ALIGN_MULTILINE_PARAMETERS
+// SET_TRUE: METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE
+// RIGHT_MARGIN: 30
+
+fun testtest()
+
+fun testtesttesttesttesttesttesttesttest()
+
+fun testtest(foofoo: Int)
+
+fun testtesttesttest(foofoo: Int)
+
+fun test(
+        foo: Int,
+        bar: Int)
+
+fun testtesttesttest(
+        foofoo: Int,
+        barbar: Int,
+        foobar: Int,
+        barfoo: Int)
+
+fun test() {
+    for (foo: Int in bar) {
+
+    }
+
+    for (foofoofoofoofoofoo: Int in bar) {
+
+    }
+
+    try {
+
+    } catch (bar: Exception) {
+
+    } catch (barbarbarbarbar: Exception) {
+
+    }
+}
+
+class LongLongLongLongNameCLass
+class ShorName
+class SN
+
+class A(
+        longLongLongLongNameCLass1: LongLongLongLongNameCLass,
+        longLongLongLongNameCLass2: LongLongLongLongNameCLass,
+        longLongLongLongNameCLass3: LongLongLongLongNameCLass) {
+    constructor(
+            longLongLongLongNameCLass1: LongLongLongLongNameCLass,
+            longLongLongLongNameCLass2: LongLongLongLongNameCLass,
+            longLongLongLongNameCLass3: LongLongLongLongNameCLass) {
+    }
+}
+
+class B(
+        a: LongLongLongLongNameCLass,
+        b: LongLongLongLongNameCLass,
+        c: LongLongLongLongNameCLass) {
+    constructor(
+            a: LongLongLongLongNameCLass,
+            b: LongLongLongLongNameCLass,
+            c: LongLongLongLongNameCLass) {
+    }
+}
+
+class C(
+        sn1: ShorName,
+        sn2: ShorName,
+        sn3: ShorName,
+        sn4: ShorName,
+        sn5: ShorName,
+        sn6: ShorName,
+        sn6: ShorName,
+        sn8: ShorName,
+        sn9: ShorName) {
+    constructor(
+            sn1: ShorName,
+            sn2: ShorName,
+            sn3: ShorName,
+            sn4: ShorName,
+            sn5: ShorName,
+            sn6: ShorName,
+            sn6: ShorName,
+            sn8: ShorName,
+            sn9: ShorName) {
+    }
+}
+
+class H(
+        sn1: SN,
+        sn2: SN) {
+    constructor(sn1: SN) {
+    }
+}

--- a/idea/testData/formatter/parameterList/ParametersListLeftParentheseOnNextLine.kt
+++ b/idea/testData/formatter/parameterList/ParametersListLeftParentheseOnNextLine.kt
@@ -1,0 +1,60 @@
+// SET_INT: METHOD_PARAMETERS_WRAP = 2
+// SET_TRUE: ALIGN_MULTILINE_PARAMETERS
+// SET_TRUE: METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE
+// RIGHT_MARGIN: 30
+
+fun testtest()
+
+fun testtesttesttesttesttesttesttesttest()
+
+fun testtest(foofoo: Int)
+
+fun testtesttesttest(foofoo: Int)
+
+fun test(foo: Int, bar: Int)
+
+fun testtesttesttest(foofoo: Int, barbar: Int, foobar: Int, barfoo: Int)
+
+fun test() {
+    for (foo: Int in bar) {
+
+    }
+
+    for (foofoofoofoofoofoo: Int in bar) {
+
+    }
+
+    try {
+
+    }
+    catch (bar: Exception) {
+
+    }
+    catch (barbarbarbarbar: Exception) {
+
+    }
+}
+
+class LongLongLongLongNameCLass
+class ShorName
+class SN
+
+class A(longLongLongLongNameCLass1: LongLongLongLongNameCLass, longLongLongLongNameCLass2: LongLongLongLongNameCLass, longLongLongLongNameCLass3: LongLongLongLongNameCLass) {
+    constructor(longLongLongLongNameCLass1: LongLongLongLongNameCLass, longLongLongLongNameCLass2: LongLongLongLongNameCLass, longLongLongLongNameCLass3: LongLongLongLongNameCLass) {
+    }
+}
+
+class B(a: LongLongLongLongNameCLass, b: LongLongLongLongNameCLass, c: LongLongLongLongNameCLass) {
+    constructor(a: LongLongLongLongNameCLass, b: LongLongLongLongNameCLass, c: LongLongLongLongNameCLass) {
+    }
+}
+
+class C(sn1: ShorName, sn2: ShorName, sn3: ShorName, sn4: ShorName, sn5: ShorName, sn6: ShorName, sn6: ShorName, sn8: ShorName, sn9: ShorName) {
+    constructor(sn1: ShorName, sn2: ShorName, sn3: ShorName, sn4: ShorName, sn5: ShorName, sn6: ShorName, sn6: ShorName, sn8: ShorName, sn9: ShorName) {
+    }
+}
+
+class H(sn1: SN, sn2: SN) {
+    constructor(sn1: SN) {
+    }
+}

--- a/idea/testData/formatter/parameterList/ParametersListRightParentheseOnNextLine.after.kt
+++ b/idea/testData/formatter/parameterList/ParametersListRightParentheseOnNextLine.after.kt
@@ -1,0 +1,96 @@
+// SET_INT: METHOD_PARAMETERS_WRAP = 2
+// SET_TRUE: ALIGN_MULTILINE_PARAMETERS
+// SET_TRUE: METHOD_PARAMETERS_RPAREN_ON_NEXT_LINE
+// RIGHT_MARGIN: 30
+
+fun testtest()
+
+fun testtesttesttesttesttesttesttesttest()
+
+fun testtest(foofoo: Int)
+
+fun testtesttesttest(foofoo: Int)
+
+fun test(foo: Int,
+         bar: Int
+)
+
+fun testtesttesttest(foofoo: Int,
+                     barbar: Int,
+                     foobar: Int,
+                     barfoo: Int
+)
+
+fun test() {
+    for (foo: Int in bar) {
+
+    }
+
+    for (foofoofoofoofoofoo: Int in bar) {
+
+    }
+
+    try {
+
+    } catch (bar: Exception) {
+
+    } catch (barbarbarbarbar: Exception) {
+
+    }
+}
+
+class LongLongLongLongNameCLass
+class ShorName
+class SN
+
+class A(longLongLongLongNameCLass1: LongLongLongLongNameCLass,
+        longLongLongLongNameCLass2: LongLongLongLongNameCLass,
+        longLongLongLongNameCLass3: LongLongLongLongNameCLass
+) {
+    constructor(longLongLongLongNameCLass1: LongLongLongLongNameCLass,
+                longLongLongLongNameCLass2: LongLongLongLongNameCLass,
+                longLongLongLongNameCLass3: LongLongLongLongNameCLass
+    ) {
+    }
+}
+
+class B(a: LongLongLongLongNameCLass,
+        b: LongLongLongLongNameCLass,
+        c: LongLongLongLongNameCLass
+) {
+    constructor(a: LongLongLongLongNameCLass,
+                b: LongLongLongLongNameCLass,
+                c: LongLongLongLongNameCLass
+    ) {
+    }
+}
+
+class C(sn1: ShorName,
+        sn2: ShorName,
+        sn3: ShorName,
+        sn4: ShorName,
+        sn5: ShorName,
+        sn6: ShorName,
+        sn6: ShorName,
+        sn8: ShorName,
+        sn9: ShorName
+) {
+    constructor(sn1: ShorName,
+                sn2: ShorName,
+                sn3: ShorName,
+                sn4: ShorName,
+                sn5: ShorName,
+                sn6: ShorName,
+                sn6: ShorName,
+                sn8: ShorName,
+                sn9: ShorName
+    ) {
+    }
+}
+
+class H(sn1: SN,
+        sn2: SN
+) {
+    constructor(sn1: SN) {
+    }
+}

--- a/idea/testData/formatter/parameterList/ParametersListRightParentheseOnNextLine.kt
+++ b/idea/testData/formatter/parameterList/ParametersListRightParentheseOnNextLine.kt
@@ -1,0 +1,60 @@
+// SET_INT: METHOD_PARAMETERS_WRAP = 2
+// SET_TRUE: ALIGN_MULTILINE_PARAMETERS
+// SET_TRUE: METHOD_PARAMETERS_RPAREN_ON_NEXT_LINE
+// RIGHT_MARGIN: 30
+
+fun testtest()
+
+fun testtesttesttesttesttesttesttesttest()
+
+fun testtest(foofoo: Int)
+
+fun testtesttesttest(foofoo: Int)
+
+fun test(foo: Int, bar: Int)
+
+fun testtesttesttest(foofoo: Int, barbar: Int, foobar: Int, barfoo: Int)
+
+fun test() {
+    for (foo: Int in bar) {
+
+    }
+
+    for (foofoofoofoofoofoo: Int in bar) {
+
+    }
+
+    try {
+
+    }
+    catch (bar: Exception) {
+
+    }
+    catch (barbarbarbarbar: Exception) {
+
+    }
+}
+
+class LongLongLongLongNameCLass
+class ShorName
+class SN
+
+class A(longLongLongLongNameCLass1: LongLongLongLongNameCLass, longLongLongLongNameCLass2: LongLongLongLongNameCLass, longLongLongLongNameCLass3: LongLongLongLongNameCLass) {
+    constructor(longLongLongLongNameCLass1: LongLongLongLongNameCLass, longLongLongLongNameCLass2: LongLongLongLongNameCLass, longLongLongLongNameCLass3: LongLongLongLongNameCLass) {
+    }
+}
+
+class B(a: LongLongLongLongNameCLass, b: LongLongLongLongNameCLass, c: LongLongLongLongNameCLass) {
+    constructor(a: LongLongLongLongNameCLass, b: LongLongLongLongNameCLass, c: LongLongLongLongNameCLass) {
+    }
+}
+
+class C(sn1: ShorName, sn2: ShorName, sn3: ShorName, sn4: ShorName, sn5: ShorName, sn6: ShorName, sn6: ShorName, sn8: ShorName, sn9: ShorName) {
+    constructor(sn1: ShorName, sn2: ShorName, sn3: ShorName, sn4: ShorName, sn5: ShorName, sn6: ShorName, sn6: ShorName, sn8: ShorName, sn9: ShorName) {
+    }
+}
+
+class H(sn1: SN, sn2: SN) {
+    constructor(sn1: SN) {
+    }
+}

--- a/idea/tests/org/jetbrains/kotlin/formatter/FormatterTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/formatter/FormatterTestGenerated.java
@@ -886,6 +886,18 @@ public class FormatterTestGenerated extends AbstractFormatterTest {
                 doTest(fileName);
             }
 
+            @TestMetadata("ArgumentListLeftParentheseOnNextLine.after.kt")
+            public void testArgumentListLeftParentheseOnNextLine() throws Exception {
+                String fileName = KotlinTestUtils.navigationMetadata("idea/testData/formatter/parameterList/ArgumentListLeftParentheseOnNextLine.after.kt");
+                doTest(fileName);
+            }
+
+            @TestMetadata("ArgumentListRightParentheseOnNextLine.after.kt")
+            public void testArgumentListRightParentheseOnNextLine() throws Exception {
+                String fileName = KotlinTestUtils.navigationMetadata("idea/testData/formatter/parameterList/ArgumentListRightParentheseOnNextLine.after.kt");
+                doTest(fileName);
+            }
+
             @TestMetadata("ArgumentListWrapAlways.after.kt")
             public void testArgumentListWrapAlways() throws Exception {
                 String fileName = KotlinTestUtils.navigationMetadata("idea/testData/formatter/parameterList/ArgumentListWrapAlways.after.kt");
@@ -919,6 +931,18 @@ public class FormatterTestGenerated extends AbstractFormatterTest {
             @TestMetadata("ParameterListWrapAsNeeded.after.kt")
             public void testParameterListWrapAsNeeded() throws Exception {
                 String fileName = KotlinTestUtils.navigationMetadata("idea/testData/formatter/parameterList/ParameterListWrapAsNeeded.after.kt");
+                doTest(fileName);
+            }
+
+            @TestMetadata("ParametersListLeftParentheseOnNextLine.after.kt")
+            public void testParametersListLeftParentheseOnNextLine() throws Exception {
+                String fileName = KotlinTestUtils.navigationMetadata("idea/testData/formatter/parameterList/ParametersListLeftParentheseOnNextLine.after.kt");
+                doTest(fileName);
+            }
+
+            @TestMetadata("ParametersListRightParentheseOnNextLine.after.kt")
+            public void testParametersListRightParentheseOnNextLine() throws Exception {
+                String fileName = KotlinTestUtils.navigationMetadata("idea/testData/formatter/parameterList/ParametersListRightParentheseOnNextLine.after.kt");
                 doTest(fileName);
             }
         }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/38703/27153015-88d1c700-5158-11e7-86b7-0298b6cec737.png)

These settings allow easier follow [long class header convention](https://kotlinlang.org/docs/reference/coding-conventions.html#class-header-formatting) and such formatting is heavily used in my team.

Ported from Java. I am not sure about single argument wrapping. I suppose it is a bug and don't belong in this feature because it happens of wrapper settings in [KotlinCommonBlock.kt](https://github.com/JetBrains/kotlin/blob/master/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/KotlinCommonBlock.kt). 