### PR TITLE
Disabling obsolete "Final Kotlin class or function with Spring annotation" inspection 

### DIFF
--- a/ultimate/resources/META-INF/kotlin-spring.xml
+++ b/ultimate/resources/META-INF/kotlin-spring.xml
@@ -19,7 +19,7 @@
                        groupBundle="resources.messages.SpringBundle"
                        groupKey="inspection.group.code"
                        groupPath="Spring,Spring Core"
-                       enabledByDefault="true"
+                       enabledByDefault="false"
                        level="WARNING"/>
       <localInspection language="kotlin"
                        displayName="Spring Facet Code Configuration (Kotlin)"

--- a/ultimate/resources/inspectionDescriptions/KotlinFinalClassOrFunSpring.html
+++ b/ultimate/resources/inspectionDescriptions/KotlinFinalClassOrFunSpring.html
@@ -1,5 +1,9 @@
 <html>
 <body>
-This inspection reports final Kotlin classes and functions annotated with Spring @Component, @Configuration or @Bean annotations
+This inspection reports final Kotlin classes and functions annotated with Spring @Component, @Configuration or @Bean annotations.
+<!-- tooltip end -->
+<p>
+<b>Deprecated</b>. This inspection is deprecated in favour of more robust <b>"Final declaration can't be overridden at runtime"</b> inspection.
+</p>
 </body>
 </html>


### PR DESCRIPTION
Because Uast-based "Final declaration can't be overridden at runtime" inspection covers it's functionality