### PR TITLE
a fix for gradle kotlin dsl project config

### DIFF
--- a/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/gradleScriptTemplateProvider.kt
+++ b/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/gradleScriptTemplateProvider.kt
@@ -78,7 +78,7 @@ class GradleScriptTemplatesProvider(project: Project): ScriptTemplatesProvider {
     }
 
     companion object {
-        private val depLibsPrefixes = listOf("gradle-script-kotlin", "gradle-core")
+        private val depLibsPrefixes = listOf("gradle-kotlin-dsl", "gradle-script-kotlin", "gradle-core")
     }
 }
 


### PR DESCRIPTION
Gradle plugin gradle-script-kotlin became gradle-kotlin-dsl, so
KotlinBuildScript now lives inside gradle-kotlin-dsl<skipped>.jar

Adding one more prefix to classpath search, so both old
(gradle-script-kotlin) and new (gradle-kotlin-dsl) versions of
Gradle plugin are supported. See
https://youtrack.jetbrains.com/issue/KT-18557