### PR TITLE
Add reverse-domain version of JS Gradle plugin.

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/resources/META-INF/gradle-plugins/org.jetbrains.kotlin.js.properties
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/resources/META-INF/gradle-plugins/org.jetbrains.kotlin.js.properties
@@ -1,0 +1,1 @@
+implementation-class=org.jetbrains.kotlin.gradle.plugin.Kotlin2JsPluginWrapper


### PR DESCRIPTION
It was the only one missing this recommended naming form.