### PR TITLE
KT-14093 "Make <modifier>" intention available only on modifier when declaration already have a visibility modifier

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/intentions/ChangeVisibilityModifierIntention.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/ChangeVisibilityModifierIntention.kt
@@ -56,14 +56,9 @@ open class ChangeVisibilityModifierIntention protected constructor(
 
         text = defaultText
 
-        val modifierElement = element.visibilityModifier()
-        if (modifierElement != null) {
-            return modifierElement.textRange
-        }
-
         val defaultRange = noModifierYetApplicabilityRange(element) ?: return null
 
-        if (element is KtPrimaryConstructor && defaultRange.isEmpty) {
+        if (element is KtPrimaryConstructor && defaultRange.isEmpty && element.visibilityModifier() == null) {
             text = "Make primary constructor ${modifier.value}" // otherwise it may be confusing
         }
 

--- a/idea/testData/intentions/changeVisibility/private/hasModifier1.kt
+++ b/idea/testData/intentions/changeVisibility/private/hasModifier1.kt
@@ -1,0 +1,1 @@
+internal anno<caret>tation class Ann

--- a/idea/testData/intentions/changeVisibility/private/hasModifier1.kt.after
+++ b/idea/testData/intentions/changeVisibility/private/hasModifier1.kt.after
@@ -1,0 +1,1 @@
+private anno<caret>tation class Ann

--- a/idea/testData/intentions/changeVisibility/private/hasModifier2.kt
+++ b/idea/testData/intentions/changeVisibility/private/hasModifier2.kt
@@ -1,0 +1,1 @@
+internal annotation cla<caret>ss Ann

--- a/idea/testData/intentions/changeVisibility/private/hasModifier2.kt.after
+++ b/idea/testData/intentions/changeVisibility/private/hasModifier2.kt.after
@@ -1,0 +1,1 @@
+private annotation cla<caret>ss Ann

--- a/idea/testData/intentions/changeVisibility/private/hasModifier3.kt
+++ b/idea/testData/intentions/changeVisibility/private/hasModifier3.kt
@@ -1,0 +1,1 @@
+anno<caret>tation internal class Ann

--- a/idea/testData/intentions/changeVisibility/private/hasModifier3.kt.after
+++ b/idea/testData/intentions/changeVisibility/private/hasModifier3.kt.after
@@ -1,0 +1,1 @@
+anno<caret>tation private class Ann

--- a/idea/testData/intentions/changeVisibility/private/hasModifier4.kt
+++ b/idea/testData/intentions/changeVisibility/private/hasModifier4.kt
@@ -1,0 +1,1 @@
+annotation internal cla<caret>ss Ann

--- a/idea/testData/intentions/changeVisibility/private/hasModifier4.kt.after
+++ b/idea/testData/intentions/changeVisibility/private/hasModifier4.kt.after
@@ -1,0 +1,1 @@
+annotation private cla<caret>ss Ann

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -2950,6 +2950,30 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
                 KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/intentions/changeVisibility/private"), Pattern.compile("^([\\w\\-_]+)\\.kt$"), TargetBackend.ANY, true);
             }
 
+            @TestMetadata("hasModifier1.kt")
+            public void testHasModifier1() throws Exception {
+                String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/changeVisibility/private/hasModifier1.kt");
+                doTest(fileName);
+            }
+
+            @TestMetadata("hasModifier2.kt")
+            public void testHasModifier2() throws Exception {
+                String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/changeVisibility/private/hasModifier2.kt");
+                doTest(fileName);
+            }
+
+            @TestMetadata("hasModifier3.kt")
+            public void testHasModifier3() throws Exception {
+                String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/changeVisibility/private/hasModifier3.kt");
+                doTest(fileName);
+            }
+
+            @TestMetadata("hasModifier4.kt")
+            public void testHasModifier4() throws Exception {
+                String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/changeVisibility/private/hasModifier4.kt");
+                doTest(fileName);
+            }
+
             @TestMetadata("noModifierListAnnotation.kt")
             public void testNoModifierListAnnotation() throws Exception {
                 String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/changeVisibility/private/noModifierListAnnotation.kt");


### PR DESCRIPTION
FIx for https://youtrack.jetbrains.com/issue/KT-14093