### PR TITLE
Add org.gradle.api.Nullable to NULLABLE_ANNOTATIONS list

### DIFF
--- a/core/descriptor.loader.java/src/org/jetbrains/kotlin/load/java/JvmAnnotationNames.kt
+++ b/core/descriptor.loader.java/src/org/jetbrains/kotlin/load/java/JvmAnnotationNames.kt
@@ -29,7 +29,8 @@ val NULLABLE_ANNOTATIONS = listOf(
         FqName("edu.umd.cs.findbugs.annotations.CheckForNull"),
         FqName("edu.umd.cs.findbugs.annotations.Nullable"),
         FqName("edu.umd.cs.findbugs.annotations.PossiblyNull"),
-        FqName("io.reactivex.annotations.Nullable")
+        FqName("io.reactivex.annotations.Nullable"),
+        FqName("org.gradle.api.Nullable")
 )
 
 val JAVAX_NONNULL_ANNOTATION = FqName("javax.annotation.Nonnull")


### PR DESCRIPTION
See https://github.com/gradle/gradle/blob/master/subprojects/base-services/src/main/java/org/gradle/api/Nullable.java

It predates `javax.annotation` and is used in the Gradle Java API.
Having this annotation acknowledged by Kotlin will make working with the [Gradle Kotlin DSL](https://github.com/gradle/kotlin-dsl) nicer.

The change is pretty trivial, please tell me if some coverage is needed and where to add it.