### PR TITLE
Add missing dependencies

### DIFF
--- a/.idea/libraries/intellij_core.xml
+++ b/.idea/libraries/intellij_core.xml
@@ -18,12 +18,14 @@
       <root url="jar://$PROJECT_DIR$/ideaSDK/core/util.jar!/" />
       <root url="jar://$PROJECT_DIR$/ideaSDK/core/xpp3-1.1.4-min.jar!/" />
       <root url="jar://$PROJECT_DIR$/ideaSDK/core/xstream-1.4.8.jar!/" />
+      <root url="jar://$PROJECT_DIR$/ideaSDK/lib/jsr305.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
       <root url="jar://$PROJECT_DIR$/dependencies/guava-19.0-sources.jar!/" />
       <root url="jar://$PROJECT_DIR$/ideaSDK/sources/sources.jar!/" />
       <root url="jar://$PROJECT_DIR$/dependencies/asm-src.zip!/" />
+      <root url="jar://$PROJECT_DIR$/ideaSDK/lib/jsr305.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/compiler/tests-common/tests-common.iml
+++ b/compiler/tests-common/tests-common.iml
@@ -29,7 +29,7 @@
     <orderEntry type="library" scope="TEST" name="kotlin-test" level="project" />
     <orderEntry type="library" scope="TEST" name="junit-4.12" level="project" />
     <orderEntry type="library" name="intellij-core" level="project" />
-    <orderEntry type="library" name="idea-full" level="project" />
+    <orderEntry type="library" exported="" name="idea-full" level="project" />
     <orderEntry type="module" module-name="backend.jvm" />
     <orderEntry type="library" name="kotlin-reflect" level="project" />
   </component>


### PR DESCRIPTION
Compilation with -Xuse-javac compiler argument:

1)
`
Error:Kotlin: [Internal Error] org.jetbrains.kotlin.util.KotlinFrontEndException: Exception while analyzing expression at (67,47) in /kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/LazyImportScope.kt:
nameToDirectives.get(name)
	at org.jetbrains.kotlin.types.expressions.ExpressionTypingVisitorDispatcher.logOrThrowException(ExpressionTypingVisitorDispatcher.java:250)
	…
Caused by: com.sun.tools.javac.code.Symbol$CompletionFailure: class file for javax.annotation.Nullable not found
`

/kotlin/compiler/frontend/src/org/jetbrains/kotlin/resolve/lazy/LazyImportScope.kt at (67,47):
`
override fun importsForName(name: Name) = nameToDirectives.get(name)
`
—>
/kotlin/dependencies/guava-19.0-sources.jar!/com/google/common/collect/ListMultimap.java:
`
List<V> get(@Nullable K key);
`

`Nullable` annotation is declared in jsr305.jar. So, guava-19.0.jar has a transitive dependency on jsr305.jar, but `intellij-core` doesn’t include it.

2)
`
Error:Kotlin: [Internal Error] org.jetbrains.kotlin.util.KotlinFrontEndException: Exception while analyzing expression at (140,13) in /kotlin/plugins/kapt3/test/org/jetbrains/kotlin/kapt3/test/AbstractKotlinKapt3IntegrationTest.kt:
KotlinTestUtils.assertEqualsToFile(txtFile, actual)
	at org.jetbrains.kotlin.types.expressions.ExpressionTypingVisitorDispatcher.logOrThrowException(ExpressionTypingVisitorDispatcher.java:250)
        …
Caused by: com.sun.tools.javac.code.Symbol$CompletionFailure: class file for com.intellij.openapi.editor.Editor not found
`

/kotlin/plugins/kapt3/test/org/jetbrains/kotlin/kapt3/test/AbstractKotlinKapt3IntegrationTest.kt at (140,13):
`
KotlinTestUtils.assertEqualsToFile(txtFile, actual)
`
—>
/kotlin/compiler/tests-common/org/jetbrains/kotlin/test/KotlinTestUtils.java
`
public static void assertEqualsToFile(@NotNull File expectedFile, @NotNull Editor editor) { …
`

`com.intellij.openapi.editor.Editor` class is in idea-full (openapi.jar), so we need to make `idea-full` exported in tests-common module.