### PR TITLE
KT-18738 Misleading quick fix message for an 'open' modifier on an interface member

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixRegistrar.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixRegistrar.kt
@@ -108,7 +108,7 @@ class QuickFixRegistrar : QuickFixContributor {
 
         val removeRedundantModifierFactory = RemoveModifierFix.createRemoveModifierFactory(true)
         REDUNDANT_MODIFIER.registerFactory(removeRedundantModifierFactory)
-        REDUNDANT_OPEN_IN_INTERFACE.registerFactory(RemoveModifierFix.createRemoveModifierFromListOwnerFactory(OPEN_KEYWORD))
+        REDUNDANT_OPEN_IN_INTERFACE.registerFactory(RemoveModifierFix.createRemoveModifierFromListOwnerFactory(OPEN_KEYWORD, true))
         UNNECESSARY_LATEINIT.registerFactory(RemoveModifierFix.createRemoveModifierFromListOwnerFactory(LATEINIT_KEYWORD))
 
         REDUNDANT_PROJECTION.registerFactory(RemoveModifierFix.createRemoveProjectionFactory(true))

--- a/idea/testData/quickfix/modifiers/redundantOpenInInterface.kt
+++ b/idea/testData/quickfix/modifiers/redundantOpenInInterface.kt
@@ -1,4 +1,4 @@
-// "Make 'foo' not open" "true"
+// "Remove redundant 'open' modifier" "true"
 
 interface My {
     <caret>open fun foo()

--- a/idea/testData/quickfix/modifiers/redundantOpenInInterface.kt.after
+++ b/idea/testData/quickfix/modifiers/redundantOpenInInterface.kt.after
@@ -1,4 +1,4 @@
-// "Make 'foo' not open" "true"
+// "Remove redundant 'open' modifier" "true"
 
 interface My {
     fun foo()


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-18738