### PR TITLE
Fixed Readme Slack references

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -113,7 +113,7 @@ From this root project there are Run/Debug Configurations for running IDEA or th
 
 We love contributions! There's [lots to do on Kotlin](https://youtrack.jetbrains.com/issues/KT) and on the
 [standard library](https://youtrack.jetbrains.com/issues/KT?q=%23Kotlin%20%23Unresolved%20and%20(links:%20KT-2554,%20KT-4089%20or%20%23Libraries)) so why not chat with us
-about what you're interested in doing? Please join the #kontributors channel in [our Slack chat](http://kotlinslackin.herokuapp.com/)
+about what you're interested in doing? Please join the #kontributors channel in [our Slack chat](https://kotlinlang.slack.com/messages/kontributors)
 and let us know about your plans.
 
 If you want to find some issues to start off with, try [this query](https://youtrack.jetbrains.com/issues/KT?q=tag:%20%7BUp%20For%20Grabs%7D%20%23Unresolved) which should find all Kotlin issues that marked as "up-for-grabs".

--- a/js/npm.templates/kotlin-compiler/README.md
+++ b/js/npm.templates/kotlin-compiler/README.md
@@ -10,7 +10,7 @@ Welcome to [Kotlin](http://kotlinlang.org/)! Some handy links:
  * [Forum](http://devnet.jetbrains.net/community/kotlin?view=discussions)
  * [Kotlin Blog](http://blog.jetbrains.com/kotlin/)
  * [Follow Kotlin on Twitter](https://twitter.com/kotlin)
- * [Public Slack channel](http://kotlinslackin.herokuapp.com/)
+ * [Public Slack channel](https://kotlinlang.slack.com/messages/getting-started)
  * [TeamCity CI build](https://teamcity.jetbrains.com/project.html?tab=projectOverview&projectId=Kotlin)
 
 ## Editing Kotlin

--- a/js/npm.templates/kotlin/README.md
+++ b/js/npm.templates/kotlin/README.md
@@ -10,7 +10,7 @@ Welcome to [Kotlin](http://kotlinlang.org/)! Some handy links:
  * [Forum](http://devnet.jetbrains.net/community/kotlin?view=discussions)
  * [Kotlin Blog](http://blog.jetbrains.com/kotlin/)
  * [Follow Kotlin on Twitter](https://twitter.com/kotlin)
- * [Public Slack channel](http://kotlinslackin.herokuapp.com/)
+ * [Public Slack channel](https://kotlinlang.slack.com/messages/getting-started)
  * [TeamCity CI build](https://teamcity.jetbrains.com/project.html?tab=projectOverview&projectId=Kotlin)
 
 ## Editing Kotlin


### PR DESCRIPTION
As reported in https://kotlinlang.slack.com/archives/C0922A726/p1500469647698570

Fixes:
![heroku](https://user-images.githubusercontent.com/1841944/28370482-0c362f40-6ca3-11e7-97c9-52979a77058b.png)