### PR TITLE
"Use destructuring declaration" should not be available for top-level and class properties

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/intentions/DestructureIntention.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/DestructureIntention.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2016 JetBrains s.r.o.
+ * Copyright 2010-2017 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -156,7 +156,7 @@ class DestructureIntention : SelfTargetingRangeIntention<KtDeclaration>(
                         else -> null
                     }
                 }
-                is KtVariableDeclaration -> parent
+                is KtProperty -> parent.takeIf { isLocal }
                 is KtFunctionLiteral -> if (!hasParameterSpecification() && lambdaSupported) this else null
                 else -> null
             }

--- a/idea/testData/intentions/destructuringVariables/classProperty.kt
+++ b/idea/testData/intentions/destructuringVariables/classProperty.kt
@@ -1,0 +1,9 @@
+// IS_APPLICABLE: false
+
+data class XY(val x: Int, val y: Int)
+
+fun create() = XY(1, 2)
+
+class Foo {
+    val xy = <caret>create()
+}

--- a/idea/testData/intentions/destructuringVariables/toplevel.kt
+++ b/idea/testData/intentions/destructuringVariables/toplevel.kt
@@ -1,0 +1,7 @@
+// IS_APPLICABLE: false
+
+data class XY(val x: Int, val y: Int)
+
+fun create() = XY(1, 2)
+
+val xy = <caret>create()

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -7814,6 +7814,12 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
             doTest(fileName);
         }
 
+        @TestMetadata("classProperty.kt")
+        public void testClassProperty() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/destructuringVariables/classProperty.kt");
+            doTest(fileName);
+        }
+
         @TestMetadata("noInitializer.kt")
         public void testNoInitializer() throws Exception {
             String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/destructuringVariables/noInitializer.kt");
@@ -7823,6 +7829,12 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
         @TestMetadata("simple.kt")
         public void testSimple() throws Exception {
             String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/destructuringVariables/simple.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("toplevel.kt")
+        public void testToplevel() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/destructuringVariables/toplevel.kt");
             doTest(fileName);
         }
 


### PR DESCRIPTION
Fixes #KT-19167