### PR TITLE
KT-18832: Fix incompatibility of kotlin-gradle-plugin with Java 9

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin/build.gradle
@@ -35,8 +35,8 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-compiler-runner:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-annotation-processing:$kotlin_version"
 
-    compile 'commons-io:commons-io:2.4'
-    compile 'commons-lang:commons-lang:2.4'
+    compile 'commons-io:commons-io:2.5'
+    compile 'commons-lang:commons-lang:2.5'
 
     compileOnly 'com.android.tools.build:gradle:2.0.0'
     compileOnly 'org.codehaus.groovy:groovy-all:2.3.9'


### PR DESCRIPTION
Use latest 2.x versions of Commons IO/Lang to fix incompatibility of with versioning scheme of Java 9.