### PR TITLE
Add download link for JDK6 on MacOS to Readme.md

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -37,6 +37,8 @@ In order to build Kotlin distribution you need to have:
         JDK_17="path to JDK 1.7"
         JDK_18="path to JDK 1.8"
 
+> Note: The JDK 6 for MacOS is not available on Oracle's site. You can [download it here](https://support.apple.com/kb/DL1572). 
+
 ## Building
 
 To build this project, first time you try to build you need to run this:


### PR DESCRIPTION
Reduce the barrier to entry for working on Kotlin by providing a download link for the MacOS JDK6 in the ReadMe.

One of the big things that prevented me from being able to contribute and test my previous fix was not being able to find a copy of the JDK 6 to run on MacOS.

Providing a link directly in the Readme will help new developers dive in and contribute easier.

It certainly would have helped me.