### PR TITLE
Rename Throws to JvmThrows with typealias for compatibility.

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/FunctionCodegen.java
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/FunctionCodegen.java
@@ -886,6 +886,9 @@ public class FunctionCodegen {
     public static String[] getThrownExceptions(@NotNull FunctionDescriptor function, @NotNull KotlinTypeMapper mapper) {
         AnnotationDescriptor annotation = function.getAnnotations().findAnnotation(new FqName("kotlin.throws"));
         if (annotation == null) {
+            annotation = function.getAnnotations().findAnnotation(new FqName("kotlin.jvm.JvmThrows"));
+        }
+        if (annotation == null) {
             annotation = function.getAnnotations().findAnnotation(new FqName("kotlin.jvm.Throws"));
         }
 

--- a/core/runtime.jvm/src/kotlin/jvm/annotations/JvmPlatformAnnotations.kt
+++ b/core/runtime.jvm/src/kotlin/jvm/annotations/JvmPlatformAnnotations.kt
@@ -84,9 +84,30 @@ public annotation class JvmSynthetic
  *
  * @property exceptionClasses the list of checked exception classes that may be thrown by the function.
  */
+@Deprecated("Use @JvmThrows instead.", replaceWith = ReplaceWith("JvmThrows"))
+public typealias Throws = JvmThrows
+
+/**
+ * This annotation indicates what exceptions should be declared by a function when compiled to a JVM method.
+ *
+ * Example:
+ *
+ * ```
+ * @JvmThrows(IOException::class)
+ * fun readFile(name: String): String {...}
+ * ```
+ *
+ * will be translated to
+ *
+ * ```
+ * String readFile(String name) throws IOException {...}
+ * ```
+ *
+ * @property exceptionClasses the list of checked exception classes that may be thrown by the function.
+ */
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER, AnnotationTarget.CONSTRUCTOR)
 @Retention(AnnotationRetention.SOURCE)
-public annotation class Throws(vararg val exceptionClasses: KClass<out Throwable>)
+public annotation class JvmThrows(vararg val exceptionClasses: KClass<out Throwable>)
 
 
 /**

--- a/j2k/src/org/jetbrains/kotlin/j2k/Converter.kt
+++ b/j2k/src/org/jetbrains/kotlin/j2k/Converter.kt
@@ -831,7 +831,7 @@ class Converter private constructor(
             val convertedType = typeConverter.convertType(types[index], Nullability.NotNull)
             null to deferredElement<Expression> { ClassLiteralExpression(convertedType.assignPrototype(refElements[index])) }
         }
-        val annotation = Annotation(Identifier.withNoPrototype("Throws"), arguments, newLineAfter = true)
+        val annotation = Annotation(Identifier.withNoPrototype("JvmThrows"), arguments, newLineAfter = true)
         return Annotations(listOf(annotation.assignPrototype(throwsList))).assignPrototype(throwsList)
     }
 

--- a/j2k/testData/fileOrElement/function/extendsBaseWhichExtendsObject.kt
+++ b/j2k/testData/fileOrElement/function/extendsBaseWhichExtendsObject.kt
@@ -11,7 +11,7 @@ internal class Test : Base() {
         return super.equals(o)
     }
 
-    @Throws(CloneNotSupportedException::class)
+    @JvmThrows(CloneNotSupportedException::class)
     override fun clone(): Any {
         return super.clone()
     }
@@ -20,7 +20,7 @@ internal class Test : Base() {
         return super.toString()
     }
 
-    @Throws(Throwable::class)
+    @JvmThrows(Throwable::class)
     override fun finalize() {
         super.finalize()
     }
@@ -35,7 +35,7 @@ internal open class Base {
         return super.equals(o)
     }
 
-    @Throws(CloneNotSupportedException::class)
+    @JvmThrows(CloneNotSupportedException::class)
     protected open fun clone(): Any {
         return super.clone()
     }
@@ -44,7 +44,7 @@ internal open class Base {
         return super.toString()
     }
 
-    @Throws(Throwable::class)
+    @JvmThrows(Throwable::class)
     protected open fun finalize() {
         super.finalize()
     }

--- a/j2k/testData/fileOrElement/function/overrideObject.kt
+++ b/j2k/testData/fileOrElement/function/overrideObject.kt
@@ -12,14 +12,14 @@ internal class X {
         return super.toString()
     }
 
-    @Throws(CloneNotSupportedException::class)
+    @JvmThrows(CloneNotSupportedException::class)
     protected fun clone(): Any {
         return super.clone()
     }
 }
 
 internal class Y : Thread() {
-    @Throws(CloneNotSupportedException::class)
+    @JvmThrows(CloneNotSupportedException::class)
     override fun clone(): Any {
         return super.clone()
     }

--- a/j2k/testData/fileOrElement/function/overrideObject2.kt
+++ b/j2k/testData/fileOrElement/function/overrideObject2.kt
@@ -14,7 +14,7 @@ internal class X : Base() {
         return super.toString()
     }
 
-    @Throws(CloneNotSupportedException::class)
+    @JvmThrows(CloneNotSupportedException::class)
     protected fun clone(): Any {
         return super.clone()
     }

--- a/j2k/testData/fileOrElement/function/throws.kt
+++ b/j2k/testData/fileOrElement/function/throws.kt
@@ -1,2 +1,2 @@
-@Throws(IOException::class, SerializationException::class)
+@JvmThrows(IOException::class, SerializationException::class)
 fun foo()

--- a/j2k/testData/fileOrElement/methodCallExpression/stringMethods.kt
+++ b/j2k/testData/fileOrElement/methodCallExpression/stringMethods.kt
@@ -4,7 +4,7 @@ import java.nio.charset.Charset
 import java.util.*
 
 internal class A {
-    @Throws(Exception::class)
+    @JvmThrows(Exception::class)
     fun constructors() {
         String()
         // TODO: new String("original");
@@ -64,7 +64,7 @@ internal class A {
         s.toCharArray()
     }
 
-    @Throws(Exception::class)
+    @JvmThrows(Exception::class)
     fun specialMethods() {
         val s = "test string"
         s == "test"

--- a/j2k/testData/fileOrElement/methodCallExpression/vararg1.kt
+++ b/j2k/testData/fileOrElement/methodCallExpression/vararg1.kt
@@ -1,7 +1,7 @@
 import java.lang.reflect.Constructor
 
 internal object X {
-    @Throws(Exception::class)
+    @JvmThrows(Exception::class)
     fun <T> foo(constructor: Constructor<T>, args1: Array<Any>, args2: Array<Any>) {
         constructor.newInstance(*args1)
         constructor.newInstance(args1, args2)

--- a/j2k/testData/fileOrElement/tryWithResource/Multiline.kt
+++ b/j2k/testData/fileOrElement/tryWithResource/Multiline.kt
@@ -1,7 +1,7 @@
 import java.io.*
 
 class C {
-    @Throws(IOException::class)
+    @JvmThrows(IOException::class)
     internal fun foo() {
         ByteArrayInputStream(ByteArray(10)).use { stream ->
             // reading something

--- a/j2k/testData/fileOrElement/tryWithResource/MultipleResources.kt
+++ b/j2k/testData/fileOrElement/tryWithResource/MultipleResources.kt
@@ -1,7 +1,7 @@
 import java.io.*
 
 class C {
-    @Throws(IOException::class)
+    @JvmThrows(IOException::class)
     internal fun foo() {
         ByteArrayInputStream(ByteArray(10)).use { input ->
             ByteArrayOutputStream().use { output ->

--- a/j2k/testData/fileOrElement/tryWithResource/Simple.kt
+++ b/j2k/testData/fileOrElement/tryWithResource/Simple.kt
@@ -1,7 +1,7 @@
 import java.io.*
 
 class C {
-    @Throws(IOException::class)
+    @JvmThrows(IOException::class)
     internal fun foo() {
         ByteArrayInputStream(ByteArray(10)).use { stream -> println(stream.read()) }
     }

--- a/j2k/testData/fileOrElement/tryWithResource/WithFinally.kt
+++ b/j2k/testData/fileOrElement/tryWithResource/WithFinally.kt
@@ -1,7 +1,7 @@
 import java.io.*
 
 class C {
-    @Throws(IOException::class)
+    @JvmThrows(IOException::class)
     internal fun foo() {
         try {
             ByteArrayInputStream(ByteArray(10)).use { stream ->

--- a/j2k/testData/fileOrElement/tryWithResource/WithReturnInAnonymousClass.kt
+++ b/j2k/testData/fileOrElement/tryWithResource/WithReturnInAnonymousClass.kt
@@ -1,16 +1,16 @@
 import java.io.*
 
 internal interface I {
-    @Throws(IOException::class)
+    @JvmThrows(IOException::class)
     fun doIt(stream: InputStream): Int
 }
 
 class C {
-    @Throws(IOException::class)
+    @JvmThrows(IOException::class)
     internal fun foo() {
         ByteArrayInputStream(ByteArray(10)).use { stream ->
             bar(object : I {
-                @Throws(IOException::class)
+                @JvmThrows(IOException::class)
                 override fun doIt(stream: InputStream): Int {
                     return stream.available()
                 }
@@ -18,7 +18,7 @@ class C {
         }
     }
 
-    @Throws(IOException::class)
+    @JvmThrows(IOException::class)
     internal fun bar(i: I, stream: InputStream): Int {
         return i.doIt(stream)
     }

--- a/j2k/testData/fileOrElement/tryWithResource/WithReturnInAnonymousClass2.kt
+++ b/j2k/testData/fileOrElement/tryWithResource/WithReturnInAnonymousClass2.kt
@@ -1,16 +1,16 @@
 import java.io.*
 
 internal interface I {
-    @Throws(IOException::class)
+    @JvmThrows(IOException::class)
     fun doIt(stream: InputStream): Int
 }
 
 class C {
-    @Throws(IOException::class)
+    @JvmThrows(IOException::class)
     internal fun foo(): Int {
         ByteArrayInputStream(ByteArray(10)).use { stream ->
             return bar(object : I {
-                @Throws(IOException::class)
+                @JvmThrows(IOException::class)
                 override fun doIt(stream: InputStream): Int {
                     return stream.available()
                 }
@@ -18,7 +18,7 @@ class C {
         }
     }
 
-    @Throws(IOException::class)
+    @JvmThrows(IOException::class)
     internal fun bar(i: I, stream: InputStream): Int {
         return i.doIt(stream)
     }


### PR DESCRIPTION
Unknowns:
 * Should it be an error to specify both `@Throws` and `@JvmThrows`? I don't know how to enforce this.
 * Should there be tests that still use `@Throws` to make sure it doesn't break?
 * Should there be tests for the replace with behavior? Not sure how to write those.

https://youtrack.jetbrains.com/issue/KT-19641