### PR TITLE
<boxed_value> == <primitive_value> converted to reference equality in Kotlin #KT-1234 Fixed

### DIFF
--- a/j2k/src/org/jetbrains/kotlin/j2k/ExpressionConverter.kt
+++ b/j2k/src/org/jetbrains/kotlin/j2k/ExpressionConverter.kt
@@ -197,6 +197,8 @@ class DefaultExpressionConverter : JavaElementVisitor(), ExpressionConverter {
             is PsiPrimitiveType, is PsiArrayType -> return true
 
             is PsiClassType -> {
+                if (right?.type is PsiPrimitiveType) return true
+
                 val psiClass = type.resolve() ?: return false
                 if (!psiClass.hasModifierProperty(PsiModifier.FINAL)) return false
                 if (psiClass.isEnum) return true


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-19634