### PR TITLE
KT-19634 <boxed_value> == <primitive_value> converted to reference equality in Kotlin

### DIFF
--- a/j2k/src/org/jetbrains/kotlin/j2k/ExpressionConverter.kt
+++ b/j2k/src/org/jetbrains/kotlin/j2k/ExpressionConverter.kt
@@ -197,6 +197,8 @@ class DefaultExpressionConverter : JavaElementVisitor(), ExpressionConverter {
             is PsiPrimitiveType, is PsiArrayType -> return true
 
             is PsiClassType -> {
+                if (right?.type is PsiPrimitiveType) return true
+
                 val psiClass = type.resolve() ?: return false
                 if (!psiClass.hasModifierProperty(PsiModifier.FINAL)) return false
                 if (psiClass.isEnum) return true

--- a/j2k/testData/fileOrElement/issues/kt-19634.java
+++ b/j2k/testData/fileOrElement/issues/kt-19634.java
@@ -1,0 +1,5 @@
+public class TestBoxedEqEqPrimitive {
+    public boolean test(Double value) {
+        return value == 3.14;
+    }
+}

--- a/j2k/testData/fileOrElement/issues/kt-19634.kt
+++ b/j2k/testData/fileOrElement/issues/kt-19634.kt
@@ -1,0 +1,5 @@
+class TestBoxedEqEqPrimitive {
+    fun test(value: Double?): Boolean {
+        return value == 3.14
+    }
+}

--- a/j2k/tests/org/jetbrains/kotlin/j2k/JavaToKotlinConverterForWebDemoTestGenerated.java
+++ b/j2k/tests/org/jetbrains/kotlin/j2k/JavaToKotlinConverterForWebDemoTestGenerated.java
@@ -2927,6 +2927,12 @@ public class JavaToKotlinConverterForWebDemoTestGenerated extends AbstractJavaTo
             doTest(fileName);
         }
 
+        @TestMetadata("kt-19634.java")
+        public void testKt_19634() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("j2k/testData/fileOrElement/issues/kt-19634.java");
+            doTest(fileName);
+        }
+
         @TestMetadata("kt-5294.java")
         public void testKt_5294() throws Exception {
             String fileName = KotlinTestUtils.navigationMetadata("j2k/testData/fileOrElement/issues/kt-5294.java");

--- a/j2k/tests/org/jetbrains/kotlin/j2k/JavaToKotlinConverterSingleFileTestGenerated.java
+++ b/j2k/tests/org/jetbrains/kotlin/j2k/JavaToKotlinConverterSingleFileTestGenerated.java
@@ -2927,6 +2927,12 @@ public class JavaToKotlinConverterSingleFileTestGenerated extends AbstractJavaTo
             doTest(fileName);
         }
 
+        @TestMetadata("kt-19634.java")
+        public void testKt_19634() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("j2k/testData/fileOrElement/issues/kt-19634.java");
+            doTest(fileName);
+        }
+
         @TestMetadata("kt-5294.java")
         public void testKt_5294() throws Exception {
             String fileName = KotlinTestUtils.navigationMetadata("j2k/testData/fileOrElement/issues/kt-5294.java");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-19634