### PR TITLE
Improve Boolean infix functions' documentation

### DIFF
--- a/core/builtins/native/kotlin/Boolean.kt
+++ b/core/builtins/native/kotlin/Boolean.kt
@@ -27,12 +27,14 @@ public class Boolean private constructor() : Comparable<Boolean> {
     public operator fun not(): Boolean
 
     /**
-     * Performs a logical `and` operation between this Boolean and the [other] one.
+     * Performs a logical `and` operation between this Boolean and the [other] one. Unlike the `&&` operator,
+     * this function does not perform short-circuit evaluation. Both `this` and [other] will always be evaluated.
      */
     public infix fun and(other: Boolean): Boolean
 
     /**
-     * Performs a logical `or` operation between this Boolean and the [other] one.
+     * Performs a logical `or` operation between this Boolean and the [other] one. Unlike the `||` operator,
+     * this function does not perform short-circuit evaluation. Both `this` and [other] will always be evaluated.
      */
     public infix fun or(other: Boolean): Boolean
 


### PR DESCRIPTION
I and my coworker @nicholaspark09 notice some differences in the generated bytecode when using the `&&` operator and the `and` infix function. 

For
```kotlin
fun andOperator(a: Boolean, b: Boolean) = a && b
```
the generated bytecode is : 

```
   L0
    LINENUMBER 3 L0
    ILOAD 0
    IFEQ L1
    ILOAD 1
    IFEQ L1
   L2
    ICONST_1
    GOTO L3
   L1
    ICONST_0
   L3
    IRETURN
   L4
```

Whereas for 
```kotlin
  fun andInfixFun(a: Boolean, b: Boolean) = a and b
```
the bytecode is : 
```
L0
    LINENUMBER 5 L0
    ILOAD 0
    ILOAD 1
    IAND
    IRETURN
```

In other words,  the Kotlin `&&` operates in similar fashion to Java `&&` operator performing short-circuit evaluation, whereas the `and` infix function -- like Java `&` operator with `Boolean`  args -- does not.  I think that is an important difference in behavior and therefore it should be denoted on the documentation. 
