### PR TITLE
Support for gradle subplugins in Kotlin2JS compilation

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-api/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinGradleSubplugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin-api/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinGradleSubplugin.kt
@@ -23,10 +23,10 @@ import org.gradle.api.tasks.compile.AbstractCompile
 class SubpluginOption(val key: String, val value: String)
 
 interface KotlinGradleSubplugin<in KotlinCompile : AbstractCompile> {
-    fun isApplicable(project: Project, task: KotlinCompile): Boolean
-    
+    fun isApplicable(project: Project, task: AbstractCompile): Boolean
+
     fun apply(
-            project: Project, 
+            project: Project,
             kotlinCompile: KotlinCompile,
             javaCompile: AbstractCompile,
             variantData: Any?,

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/AndroidSubplugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/AndroidSubplugin.kt
@@ -74,7 +74,8 @@ class AndroidExtensionsSubpluginIndicator : Plugin<Project> {
 }
 
 class AndroidSubplugin : KotlinGradleSubplugin<KotlinCompile> {
-    override fun isApplicable(project: Project, task: KotlinCompile): Boolean {
+    override fun isApplicable(project: Project, task: AbstractCompile): Boolean {
+        if (task !is KotlinCompile) return false
         try {
             project.extensions.getByName("android") as? BaseExtension ?: return false
         } catch (e: UnknownDomainObjectException) {
@@ -89,7 +90,7 @@ class AndroidSubplugin : KotlinGradleSubplugin<KotlinCompile> {
     override fun apply(
             project: Project,
             kotlinCompile: KotlinCompile,
-            javaCompile: AbstractCompile, 
+            javaCompile: AbstractCompile,
             variantData: Any?,
             androidProjectHandler: Any?,
             javaSourceSet: SourceSet?

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/Kapt3KotlinGradleSubplugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/Kapt3KotlinGradleSubplugin.kt
@@ -84,7 +84,7 @@ class Kapt3KotlinGradleSubplugin : KotlinGradleSubplugin<KotlinCompile> {
 
     private val kotlinToKaptGenerateStubsTasksMap = mutableMapOf<KotlinCompile, KaptGenerateStubsTask>()
 
-    override fun isApplicable(project: Project, task: KotlinCompile) = Kapt3GradleSubplugin.isEnabled(project)
+    override fun isApplicable(project: Project, task: AbstractCompile) = task is KotlinCompile && Kapt3GradleSubplugin.isEnabled(project)
 
     fun getKaptGeneratedDir(project: Project, sourceSetName: String): File {
         return File(project.project.buildDir, "generated/source/kapt/$sourceSetName")
@@ -123,7 +123,7 @@ class Kapt3KotlinGradleSubplugin : KotlinGradleSubplugin<KotlinCompile> {
     }
 
     override fun apply(
-            project: Project, 
+            project: Project,
             kotlinCompile: KotlinCompile,
             javaCompile: AbstractCompile,
             variantData: Any?,

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt
@@ -21,6 +21,7 @@ import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetOutput
 import org.gradle.api.tasks.compile.AbstractCompile
 import org.gradle.api.tasks.compile.JavaCompile
+import org.jetbrains.kotlin.cli.common.arguments.CommonCompilerArguments
 import org.jetbrains.kotlin.com.intellij.openapi.util.io.FileUtil
 import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtil.compareVersionNumbers
 import org.jetbrains.kotlin.com.intellij.util.ReflectionUtil
@@ -269,7 +270,11 @@ internal class Kotlin2JsSourceSetProcessor(
         createCleanSourceMapTask()
 
         // outputFile can be set later during the configuration phase, get it only after the phase:
-        project.afterEvaluate {
+        project.afterEvaluate { project ->
+            val subpluginEnvironment: SubpluginEnvironment = loadSubplugins(project)
+            val appliedPlugins = subpluginEnvironment.addSubpluginOptions(
+                    project, kotlinTask, kotlinTask, null, null, sourceSet)
+
             kotlinTask.kotlinOptions.outputFile = File(kotlinTask.outputFile).absolutePath
             val outputDir = File(kotlinTask.outputFile).parentFile
 
@@ -285,6 +290,10 @@ internal class Kotlin2JsSourceSetProcessor(
             if (!isSeparateClassesDirSupported) {
                 sourceSet.output.setClassesDir(kotlinTask.destinationDir)
             }
+
+            appliedPlugins
+                    .flatMap { it.getSubpluginKotlinTasks(project, kotlinTask) }
+                    .forEach { it.source(kotlinSourceSet.kotlin) }
         }
     }
 
@@ -694,7 +703,7 @@ private fun removeAnnotationProcessingPluginClasspathEntry(kotlinCompile: Kotlin
 private fun loadSubplugins(project: Project): SubpluginEnvironment {
     try {
         val subplugins = ServiceLoader.load(KotlinGradleSubplugin::class.java, project.buildscript.classLoader)
-                .map { @Suppress("UNCHECKED_CAST") (it as KotlinGradleSubplugin<KotlinCompile>) }
+                .map { @Suppress("UNCHECKED_CAST") (it as KotlinGradleSubplugin<AbstractCompile>) }
 
         return SubpluginEnvironment(project.resolveSubpluginArtifacts(subplugins), subplugins)
     } catch (e: NoClassDefFoundError) {
@@ -704,9 +713,9 @@ private fun loadSubplugins(project: Project): SubpluginEnvironment {
     }
 }
 
-internal fun Project.resolveSubpluginArtifacts(
-        subplugins: List<KotlinGradleSubplugin<KotlinCompile>>
-): Map<KotlinGradleSubplugin<KotlinCompile>, List<File>> {
+internal fun <T: AbstractCompile> Project.resolveSubpluginArtifacts(
+        subplugins: List<KotlinGradleSubplugin<T>>
+): Map<KotlinGradleSubplugin<T>, List<File>> {
     fun Project.getResolvedArtifacts() = buildscript.configurations.getByName("classpath")
             .resolvedConfiguration.resolvedArtifacts
 
@@ -716,7 +725,7 @@ internal fun Project.resolveSubpluginArtifacts(
         resolvedClasspathArtifacts += rootProject.getResolvedArtifacts()
     }
 
-    val subpluginClasspaths = hashMapOf<KotlinGradleSubplugin<KotlinCompile>, List<File>>()
+    val subpluginClasspaths = hashMapOf<KotlinGradleSubplugin<T>, List<File>>()
 
     for (subplugin in subplugins) {
         val file = resolvedClasspathArtifacts
@@ -733,18 +742,18 @@ internal fun Project.resolveSubpluginArtifacts(
 }
 
 internal class SubpluginEnvironment(
-        val subpluginClasspaths: Map<KotlinGradleSubplugin<KotlinCompile>, List<File>>,
-        val subplugins: List<KotlinGradleSubplugin<KotlinCompile>>
+        val subpluginClasspaths: Map<KotlinGradleSubplugin<AbstractCompile>, List<File>>,
+        val subplugins: List<KotlinGradleSubplugin<AbstractCompile>>
 ) {
 
-    fun addSubpluginOptions(
+    fun <C: CommonCompilerArguments> addSubpluginOptions(
             project: Project,
-            kotlinTask: KotlinCompile,
+            kotlinTask: AbstractKotlinCompile<C>,
             javaTask: AbstractCompile,
             variantData: Any?,
             androidProjectHandler: AbstractAndroidProjectHandler<out Any?>?,
             javaSourceSet: SourceSet?
-    ): List<KotlinGradleSubplugin<KotlinCompile>> {
+    ): List<KotlinGradleSubplugin<AbstractKotlinCompile<C>>> {
         val pluginOptions = kotlinTask.pluginOptions
 
         val appliedSubplugins = subplugins.filter { it.isApplicable(project, kotlinTask) }


### PR DESCRIPTION
Because ServiceLoader can't check generic argument of
KotlinGradleSubplugin in runtime, we have to manually check the type in
`isApplicable`.