### PR TITLE
KT-19666 Fix replacedBaseClause for selector which has implicit receiver

### DIFF
--- a/idea/testData/intentions/branched/ifThenToElvis/kt19666.kt
+++ b/idea/testData/intentions/branched/ifThenToElvis/kt19666.kt
@@ -1,0 +1,13 @@
+// WITH_RUNTIME
+interface Taggable {
+    val tag: String
+}
+
+fun Any.log() {
+    val tag = <caret>if (this is Taggable) {
+        tag
+    }
+    else {
+        this::class.java.simpleName
+    }
+}

--- a/idea/testData/intentions/branched/ifThenToElvis/kt19666.kt.after
+++ b/idea/testData/intentions/branched/ifThenToElvis/kt19666.kt.after
@@ -1,0 +1,8 @@
+// WITH_RUNTIME
+interface Taggable {
+    val tag: String
+}
+
+fun Any.log() {
+    val tag = (this as? Taggable)?.tag ?: this::class.java.simpleName
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -1423,6 +1423,12 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
                 doTest(fileName);
             }
 
+            @TestMetadata("kt19666.kt")
+            public void testKt19666() throws Exception {
+                String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/branched/ifThenToElvis/kt19666.kt");
+                doTest(fileName);
+            }
+
             @TestMetadata("lhsEqualsNull.kt")
             public void testLhsEqualsNull() throws Exception {
                 String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/branched/ifThenToElvis/lhsEqualsNull.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-19666

Should i do something instead of error at IfThenUtils L179?
https://github.com/JetBrains/kotlin/compare/master...sckm:KT-19666?expand=1#diff-d15fa721b5c3a5e0d3e1166ae36958ceR179