### PR TITLE
KT-19629 "Convert to primary constructor" quick fix should not move `init{...}` section down

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertSecondaryConstructorToPrimaryIntention.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertSecondaryConstructorToPrimaryIntention.kt
@@ -181,10 +181,15 @@ class ConvertSecondaryConstructorToPrimaryIntention : SelfTargetingRangeIntentio
         with (constructorInClass.replace(constructor)) {
             constructorCommentSaver.restore(this)
         }
-        element.delete()
 
-        if ((initializer.body as? KtBlockExpression)?.statements?.isNotEmpty() ?: false) {
-            klass.addDeclaration(initializer)
+        if ((initializer.body as? KtBlockExpression)?.statements?.isNotEmpty() == true) {
+            val nextSiblings = element.parent.children.takeLastWhile { it !== element }
+            if (nextSiblings.isEmpty() || nextSiblings.any { it is KtProperty })
+                klass.addDeclaration(initializer)
+            else
+                klass.addDeclarationBefore(initializer, nextSiblings.firstOrNull())
         }
+
+        element.delete()
     }
 }

--- a/idea/testData/intentions/convertSecondaryConstructorToPrimary/init.kt
+++ b/idea/testData/intentions/convertSecondaryConstructorToPrimary/init.kt
@@ -7,4 +7,6 @@ class ConvertToInit {
         foo()
         bar()
     }
+
+    fun baz() {}
 }

--- a/idea/testData/intentions/convertSecondaryConstructorToPrimary/init.kt.after
+++ b/idea/testData/intentions/convertSecondaryConstructorToPrimary/init.kt.after
@@ -8,4 +8,5 @@ class ConvertToInit() {
         bar()
     }
 
+    fun baz() {}
 }

--- a/idea/testData/intentions/convertSecondaryConstructorToPrimary/varArg.kt
+++ b/idea/testData/intentions/convertSecondaryConstructorToPrimary/varArg.kt
@@ -7,4 +7,6 @@ class WithVarArg {
     constructor(<caret>vararg zz: String) {
         x = listOf(*zz)
     }
+
+    fun foo() {}
 }

--- a/idea/testData/intentions/convertSecondaryConstructorToPrimary/varArg.kt.after
+++ b/idea/testData/intentions/convertSecondaryConstructorToPrimary/varArg.kt.after
@@ -8,4 +8,5 @@ class WithVarArg(vararg zz: String) {
         x = listOf(*zz)
     }
 
+    fun foo() {}
 }


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-19629