### PR TITLE
`KtLightAnnotationForSourceEntry` fix for smart-pointers creating

### DIFF
--- a/compiler/light-classes/src/org/jetbrains/kotlin/asJava/elements/lightAnnotations.kt
+++ b/compiler/light-classes/src/org/jetbrains/kotlin/asJava/elements/lightAnnotations.kt
@@ -67,7 +67,9 @@ class KtLightAnnotationForSourceEntry(
             val delegate: D,
             private val parent: PsiElement,
             valueOrigin: AnnotationValueOrigin
-    ) : PsiAnnotationMemberValue, PsiElement by delegate {
+    ) : PsiAnnotationMemberValue, PsiCompiledElement, PsiElement by delegate {
+        override fun getMirror(): PsiElement = delegate
+
         val originalExpression: PsiElement? by lazyPub(valueOrigin)
 
         fun getConstantValue(): Any? {
@@ -81,9 +83,11 @@ class KtLightAnnotationForSourceEntry(
         override fun getReferences() = originalExpression?.references.orEmpty()
         override fun getLanguage() = KotlinLanguage.INSTANCE
         override fun getNavigationElement() = originalExpression
+        override fun isPhysical(): Boolean = originalExpression?.containingFile == kotlinOrigin.containingFile
         override fun getTextRange() = originalExpression?.textRange ?: TextRange.EMPTY_RANGE
         override fun getParent() = parent
         override fun getText() = originalExpression?.text.orEmpty()
+        override fun getContainingFile(): PsiFile? = if (isPhysical) kotlinOrigin.containingFile else delegate.containingFile
 
         override fun replace(newElement: PsiElement): PsiElement {
             val value = (newElement as? PsiLiteral)?.value as? String ?: return this

--- a/idea/tests/org/jetbrains/kotlin/asJava/KtLightAnnotationTest.kt
+++ b/idea/tests/org/jetbrains/kotlin/asJava/KtLightAnnotationTest.kt
@@ -240,13 +240,7 @@ class KtLightAnnotationTest : KotlinLightCodeInsightFixtureTestCase() {
             class MyAnnotated {}
         """.trimIndent())
 
-        val annotations = listOf(myFixture.findClass("MyAnnotated")).let {
-            assertEquals(1, it.size)
-            it.first().annotations.apply {
-                assertEquals(1, it.size)
-            }
-        }
-
+        val annotations = myFixture.findClass("MyAnnotated").expectAnnotations(1)
         annotations[0].let { annotation ->
             val annotationAttributeVal = annotation.findAttributeValue("value") as PsiElement
             assertTextAndRange("@Outer(Inner())", annotationAttributeVal)
@@ -377,7 +371,7 @@ class KtLightAnnotationTest : KotlinLightCodeInsightFixtureTestCase() {
     }
 
     private fun PsiModifierListOwner.expectAnnotations(number: Int): Array<PsiAnnotation> =
-            this.annotations.apply {
+            this.modifierList!!.annotations.apply {
                 TestCase.assertEquals("expected one annotation, found ${this.joinToString(", ") { it.qualifiedName ?: "unknown" }}",
                                       number, size)
             }


### PR DESCRIPTION
`LightElementValue` made PsiCompiledElement to make it properly anchorable when creating smartpointers, when still use `kotlinOrigin.containingFile` for it to be able to `registerProblem` on such elements. (refs KT-18054)