### PR TITLE
KT-19943 Redundant 'toInt' after converting explicit Integer#intValue call

### DIFF
--- a/j2k/src/org/jetbrains/kotlin/j2k/ExpressionConverter.kt
+++ b/j2k/src/org/jetbrains/kotlin/j2k/ExpressionConverter.kt
@@ -449,6 +449,10 @@ class DefaultExpressionConverter : JavaElementVisitor(), ExpressionConverter {
                 val data = SpecialMethod.ConvertCallData(qualifier, arguments.asList(), typeArguments, dot, lPar, rPar, codeConverter)
                 val converted = specialMethod.convertCall(data)
                 if (converted != null) {
+                    qualifier?.type?.let {
+                        if (canRemoveSpecialMethod(specialMethod, it)) return
+                    }
+
                     result = converted
                     return
                 }
@@ -466,6 +470,16 @@ class DefaultExpressionConverter : JavaElementVisitor(), ExpressionConverter {
                                       typeArguments,
                                       isNullable).assignPrototypesFrom(methodExpression)
         methodExpression.assignNoPrototype()
+    }
+
+    private fun canRemoveSpecialMethod(specialMethod: SpecialMethod, psiType: PsiType): Boolean = when {
+        specialMethod == SpecialMethod.NUMBER_BYTE_VALUE && psiType.canonicalText == "java.lang.Byte" -> true
+        specialMethod == SpecialMethod.NUMBER_SHORT_VALUE && psiType.canonicalText == "java.lang.Short" -> true
+        specialMethod == SpecialMethod.NUMBER_INT_VALUE && psiType.canonicalText == "java.lang.Integer" -> true
+        specialMethod == SpecialMethod.NUMBER_LONG_VALUE && psiType.canonicalText == "java.lang.Long" -> true
+        specialMethod == SpecialMethod.NUMBER_FLOAT_VALUE && psiType.canonicalText == "java.lang.Float" -> true
+        specialMethod == SpecialMethod.NUMBER_DOUBLE_VALUE && psiType.canonicalText == "java.lang.Double" -> true
+        else -> false
     }
 
     private fun KtLightMethod.isKotlinExtensionFunction(): Boolean {

--- a/j2k/testData/fileOrElement/issues/kt-19943.java
+++ b/j2k/testData/fileOrElement/issues/kt-19943.java
@@ -1,0 +1,27 @@
+import java.util.List;
+
+public class TestSpecialMethodForTypeValue  {
+    public byte testByte(List<Byte> xs) {
+        return xs.get(0).byteValue();
+    }
+
+    public short testShort(List<Short> xs) {
+        return xs.get(0).shortValue();
+    }
+
+    public int testInt(List<Integer> xs) {
+        return xs.get(0).intValue();
+    }
+
+    public long testLong(List<Long> xs) {
+        return xs.get(0).longValue();
+    }
+
+    public float testFloat(List<Float> xs) {
+        return xs.get(0).floatValue();
+    }
+
+    public double testDouble(List<Double> xs) {
+        return xs.get(0).doubleValue();
+    }
+}

--- a/j2k/testData/fileOrElement/issues/kt-19943.kt
+++ b/j2k/testData/fileOrElement/issues/kt-19943.kt
@@ -1,0 +1,25 @@
+class TestSpecialMethodForTypeValue {
+    fun testByte(xs: List<Byte>): Byte {
+        return xs[0]
+    }
+
+    fun testShort(xs: List<Short>): Short {
+        return xs[0]
+    }
+
+    fun testInt(xs: List<Int>): Int {
+        return xs[0]
+    }
+
+    fun testLong(xs: List<Long>): Long {
+        return xs[0]
+    }
+
+    fun testFloat(xs: List<Float>): Float {
+        return xs[0]
+    }
+
+    fun testDouble(xs: List<Double>): Double {
+        return xs[0]
+    }
+}

--- a/j2k/tests/org/jetbrains/kotlin/j2k/JavaToKotlinConverterForWebDemoTestGenerated.java
+++ b/j2k/tests/org/jetbrains/kotlin/j2k/JavaToKotlinConverterForWebDemoTestGenerated.java
@@ -2951,6 +2951,12 @@ public class JavaToKotlinConverterForWebDemoTestGenerated extends AbstractJavaTo
             doTest(fileName);
         }
 
+        @TestMetadata("kt-19943.java")
+        public void testKt_19943() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("j2k/testData/fileOrElement/issues/kt-19943.java");
+            doTest(fileName);
+        }
+
         @TestMetadata("kt-5294.java")
         public void testKt_5294() throws Exception {
             String fileName = KotlinTestUtils.navigationMetadata("j2k/testData/fileOrElement/issues/kt-5294.java");

--- a/j2k/tests/org/jetbrains/kotlin/j2k/JavaToKotlinConverterSingleFileTestGenerated.java
+++ b/j2k/tests/org/jetbrains/kotlin/j2k/JavaToKotlinConverterSingleFileTestGenerated.java
@@ -2951,6 +2951,12 @@ public class JavaToKotlinConverterSingleFileTestGenerated extends AbstractJavaTo
             doTest(fileName);
         }
 
+        @TestMetadata("kt-19943.java")
+        public void testKt_19943() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("j2k/testData/fileOrElement/issues/kt-19943.java");
+            doTest(fileName);
+        }
+
         @TestMetadata("kt-5294.java")
         public void testKt_5294() throws Exception {
             String fileName = KotlinTestUtils.navigationMetadata("j2k/testData/fileOrElement/issues/kt-5294.java");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-19943