### PR TITLE
KT-19642 Javadoc comment placement is wrong after default parameters inference in J2K

### DIFF
--- a/j2k/src/org/jetbrains/kotlin/j2k/CodeBuilder.kt
+++ b/j2k/src/org/jetbrains/kotlin/j2k/CodeBuilder.kt
@@ -171,7 +171,7 @@ class CodeBuilder(private val topElement: PsiElement?, private var docConverter:
             if (inheritance.commentsInside) {
                 prototype.accept(object : JavaRecursiveElementVisitor() {
                     override fun visitComment(comment: PsiComment) {
-                        if (comment !in notInsideElements && commentsAndSpacesUsed.add(comment)) {
+                        if (comment.parent !is PsiMethod && comment !in notInsideElements && commentsAndSpacesUsed.add(comment)) {
                             appendCommentOrWhiteSpace(comment, true)
                         }
                     }

--- a/j2k/testData/fileOrElement/comments/commentsForConstructors.kt
+++ b/j2k/testData/fileOrElement/comments/commentsForConstructors.kt
@@ -8,8 +8,7 @@ internal class A// this is a primary constructor
 
     // this is a secondary constructor 2
     constructor(s: String) : this(s.length) {} // end of secondary constructor 2 body
-}// this is a secondary constructor 1
-// end of secondary constructor 1 body
+}
 
 internal class B// this constructor will disappear
 (private val x: Int) // end of constructor body


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-19642