### PR TITLE
Allow to use Gradle property to configure JDK paths

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -40,6 +40,8 @@ In order to build Kotlin distribution you need to have:
 
 For local development, if you're not working on bytecode generation or the standard library, it's OK to have only JDK 8 installed, and to point all of the environment variables mentioned above to your JDK 8 installation.
 
+You also can use [Gradle properties](https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_properties_and_system_properties) to setup JDK_* variables.
+
 > Note: The JDK 6 for MacOS is not available on Oracle's site. You can [download it here](https://support.apple.com/kb/DL1572). 
 
 ## Building

--- a/buildSrc/src/main/kotlin/jdksFinder.kt
+++ b/buildSrc/src/main/kotlin/jdksFinder.kt
@@ -19,7 +19,8 @@ data class JdkId(val explicit: Boolean, val majorVersion: JdkMajorVersion, var v
 fun Project.getConfiguredJdks(): List<JdkId> {
     val res = arrayListOf<JdkId>()
     for (jdkMajorVersion in JdkMajorVersion.values()) {
-        val explicitJdkEnvVal = System.getenv(jdkMajorVersion.name)
+        val explicitJdkEnvVal = findProperty(jdkMajorVersion.name)?.toString()
+                ?: System.getenv(jdkMajorVersion.name)
                 ?: jdkAlternativeVarNames[jdkMajorVersion]?.mapNotNull { System.getenv(it) }?.firstOrNull()
                 ?: continue
         val explicitJdk = File(explicitJdkEnvVal)


### PR DESCRIPTION
Currently, to build Kotlin we should set environment variables with paths to different versions of JDK, but it's not always useful because for example on Mac it's hard to set a global variable and Gradle uses the daemon, so you cannot just add an environment variable to user's bash config.

This change allows to get JDK paths from Gradle project properties, it allows to set paths to global gradle config or pass it using Gradle command line argument `-D` without passing environment variables to gradle command explicitly or configure IDE.

Properties have higher priority than env variables, to allow override it for particular project or particular gradle run