### PR TITLE
Converting property getter to block body must insert explicit return type

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertToBlockBodyIntention.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertToBlockBodyIntention.kt
@@ -19,8 +19,10 @@ package org.jetbrains.kotlin.idea.intentions
 import com.intellij.codeInsight.intention.LowPriorityAction
 import com.intellij.openapi.editor.Editor
 import com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.descriptors.CallableDescriptor
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.idea.caches.resolve.analyze
+import org.jetbrains.kotlin.idea.caches.resolve.resolveToDescriptorIfAny
 import org.jetbrains.kotlin.idea.core.setType
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.resolve.BindingContext
@@ -81,7 +83,17 @@ class ConvertToBlockBodyIntention : SelfTargetingIntention<KtDeclarationWithBody
                     generateBody(!returnType.isUnit() && !returnType.isNothing())
                 }
 
-                is KtPropertyAccessor -> generateBody(declaration.isGetter)
+                is KtPropertyAccessor -> {
+                    val parent = declaration.parent
+                    if (parent is KtProperty && parent.typeReference == null) {
+                        val descriptor = parent.resolveToDescriptorIfAny()
+                        val type = (descriptor as? CallableDescriptor)?.returnType
+
+                        type?.let {parent.setType(it)}
+                    }
+
+                    generateBody(declaration.isGetter)
+                }
 
                 else -> throw RuntimeException("Unknown declaration type: $declaration")
             }

--- a/idea/testData/intentions/convertToBlockBody/getterTypeInferred.kt
+++ b/idea/testData/intentions/convertToBlockBody/getterTypeInferred.kt
@@ -1,0 +1,1 @@
+val foo <caret>get() = "abc"

--- a/idea/testData/intentions/convertToBlockBody/getterTypeInferred.kt.after
+++ b/idea/testData/intentions/convertToBlockBody/getterTypeInferred.kt.after
@@ -1,0 +1,4 @@
+val foo: String
+    get() {
+        return "abc"
+    }

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -6479,6 +6479,12 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
             doTest(fileName);
         }
 
+        @TestMetadata("getterTypeInferred.kt")
+        public void testGetterTypeInferred() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/convertToBlockBody/getterTypeInferred.kt");
+            doTest(fileName);
+        }
+
         @TestMetadata("getterWithThrow.kt")
         public void testGetterWithThrow() throws Exception {
             String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/convertToBlockBody/getterWithThrow.kt");


### PR DESCRIPTION
Fixes #KT-20417

https://youtrack.jetbrains.com/issue/KT-20417