### PR TITLE
KT-17392 - Add initial copyRangeTo proposal

### DIFF
--- a/js/js.libraries/src/core/generated/_ArraysJs.kt
+++ b/js/js.libraries/src/core/generated/_ArraysJs.kt
@@ -13207,6 +13207,86 @@ public fun CharArray.copyOfRange(fromIndex: Int, toIndex: Int): CharArray {
 }
 
 /**
+ * Copies an array from the specified source array [this] with [length], beginning at the specified [srcPos], to the specified position [destPos] of the destination array [dest].
+ */
+@SinceKotlin("1.2")
+public fun ByteArray.copyRangeTo(srcPos: Int, dest: ByteArray, destPos: Int, length: Int): Unit {
+    (dest as dynamic).set((this as dynamic).subarray(srcPos, srcPos + length), destPos)
+}
+
+/**
+ * Copies an array from the specified source array [this] with [length], beginning at the specified [srcPos], to the specified position [destPos] of the destination array [dest].
+ */
+@SinceKotlin("1.2")
+public fun ShortArray.copyRangeTo(srcPos: Int, dest: ShortArray, destPos: Int, length: Int): Unit {
+    (dest as dynamic).set((this as dynamic).subarray(srcPos, srcPos + length), destPos)
+}
+
+/**
+ * Copies an array from the specified source array [this] with [length], beginning at the specified [srcPos], to the specified position [destPos] of the destination array [dest].
+ */
+@SinceKotlin("1.2")
+public fun IntArray.copyRangeTo(srcPos: Int, dest: IntArray, destPos: Int, length: Int): Unit {
+    (dest as dynamic).set((this as dynamic).subarray(srcPos, srcPos + length), destPos)
+}
+
+/**
+ * Copies an array from the specified source array [this] with [length], beginning at the specified [srcPos], to the specified position [destPos] of the destination array [dest].
+ */
+@SinceKotlin("1.2")
+public fun LongArray.copyRangeTo(srcPos: Int, dest: LongArray, destPos: Int, length: Int): Unit {
+    if ((this === dest) && (destPos > srcPos)) {
+       for (n in 0 until length) dest[destPos + length - n - 1] = this[srcPos + length - n - 1]
+    } else {
+       for (n in 0 until length) dest[destPos + n] = this[srcPos + n]
+    }
+}
+
+/**
+ * Copies an array from the specified source array [this] with [length], beginning at the specified [srcPos], to the specified position [destPos] of the destination array [dest].
+ */
+@SinceKotlin("1.2")
+public fun FloatArray.copyRangeTo(srcPos: Int, dest: FloatArray, destPos: Int, length: Int): Unit {
+    (dest as dynamic).set((this as dynamic).subarray(srcPos, srcPos + length), destPos)
+}
+
+/**
+ * Copies an array from the specified source array [this] with [length], beginning at the specified [srcPos], to the specified position [destPos] of the destination array [dest].
+ */
+@SinceKotlin("1.2")
+public fun DoubleArray.copyRangeTo(srcPos: Int, dest: DoubleArray, destPos: Int, length: Int): Unit {
+    (dest as dynamic).set((this as dynamic).subarray(srcPos, srcPos + length), destPos)
+}
+
+/**
+ * Copies an array from the specified source array [this] with [length], beginning at the specified [srcPos], to the specified position [destPos] of the destination array [dest].
+ */
+@SinceKotlin("1.2")
+public fun BooleanArray.copyRangeTo(srcPos: Int, dest: BooleanArray, destPos: Int, length: Int): Unit {
+    (dest as dynamic).set((this as dynamic).subarray(srcPos, srcPos + length), destPos)
+}
+
+/**
+ * Copies an array from the specified source array [this] with [length], beginning at the specified [srcPos], to the specified position [destPos] of the destination array [dest].
+ */
+@SinceKotlin("1.2")
+public fun CharArray.copyRangeTo(srcPos: Int, dest: CharArray, destPos: Int, length: Int): Unit {
+    (dest as dynamic).set((this as dynamic).subarray(srcPos, srcPos + length), destPos)
+}
+
+/**
+ * Copies an array from the specified source array [this] with [length], beginning at the specified [srcPos], to the specified position [destPos] of the destination array [dest].
+ */
+@SinceKotlin("1.2")
+public fun <T> Array<out T>.copyRangeTo(srcPos: Int, dest: Array<out T>, destPos: Int, length: Int): Unit {
+    if ((this === dest) && (destPos > srcPos)) {
+       for (n in 0 until length) dest[destPos + length - n - 1] = this[srcPos + length - n - 1]
+    } else {
+       for (n in 0 until length) dest[destPos + n] = this[srcPos + n]
+    }
+}
+
+/**
  * Returns an array containing all elements of the original array and then the given [element].
  */
 @Suppress("NOTHING_TO_INLINE")

--- a/libraries/stdlib/common/src/generated/_Arrays.kt
+++ b/libraries/stdlib/common/src/generated/_Arrays.kt
@@ -7537,6 +7537,60 @@ public expect fun BooleanArray.copyOfRange(fromIndex: Int, toIndex: Int): Boolea
 public expect fun CharArray.copyOfRange(fromIndex: Int, toIndex: Int): CharArray
 
 /**
+ * Copies an array from the specified source array [this] with [length], beginning at the specified [srcPos], to the specified position [destPos] of the destination array [dest].
+ */
+@SinceKotlin("1.2")
+public expect fun ByteArray.copyRangeTo(srcPos: Int, dest: ByteArray, destPos: Int, length: Int): Unit
+
+/**
+ * Copies an array from the specified source array [this] with [length], beginning at the specified [srcPos], to the specified position [destPos] of the destination array [dest].
+ */
+@SinceKotlin("1.2")
+public expect fun ShortArray.copyRangeTo(srcPos: Int, dest: ShortArray, destPos: Int, length: Int): Unit
+
+/**
+ * Copies an array from the specified source array [this] with [length], beginning at the specified [srcPos], to the specified position [destPos] of the destination array [dest].
+ */
+@SinceKotlin("1.2")
+public expect fun IntArray.copyRangeTo(srcPos: Int, dest: IntArray, destPos: Int, length: Int): Unit
+
+/**
+ * Copies an array from the specified source array [this] with [length], beginning at the specified [srcPos], to the specified position [destPos] of the destination array [dest].
+ */
+@SinceKotlin("1.2")
+public expect fun LongArray.copyRangeTo(srcPos: Int, dest: LongArray, destPos: Int, length: Int): Unit
+
+/**
+ * Copies an array from the specified source array [this] with [length], beginning at the specified [srcPos], to the specified position [destPos] of the destination array [dest].
+ */
+@SinceKotlin("1.2")
+public expect fun FloatArray.copyRangeTo(srcPos: Int, dest: FloatArray, destPos: Int, length: Int): Unit
+
+/**
+ * Copies an array from the specified source array [this] with [length], beginning at the specified [srcPos], to the specified position [destPos] of the destination array [dest].
+ */
+@SinceKotlin("1.2")
+public expect fun DoubleArray.copyRangeTo(srcPos: Int, dest: DoubleArray, destPos: Int, length: Int): Unit
+
+/**
+ * Copies an array from the specified source array [this] with [length], beginning at the specified [srcPos], to the specified position [destPos] of the destination array [dest].
+ */
+@SinceKotlin("1.2")
+public expect fun BooleanArray.copyRangeTo(srcPos: Int, dest: BooleanArray, destPos: Int, length: Int): Unit
+
+/**
+ * Copies an array from the specified source array [this] with [length], beginning at the specified [srcPos], to the specified position [destPos] of the destination array [dest].
+ */
+@SinceKotlin("1.2")
+public expect fun CharArray.copyRangeTo(srcPos: Int, dest: CharArray, destPos: Int, length: Int): Unit
+
+/**
+ * Copies an array from the specified source array [this] with [length], beginning at the specified [srcPos], to the specified position [destPos] of the destination array [dest].
+ */
+@SinceKotlin("1.2")
+public expect fun <T> Array<T>.copyRangeTo(srcPos: Int, dest: Array<T>, destPos: Int, length: Int): Unit
+
+/**
  * Returns an array containing all elements of the original array and then the given [element].
  */
 public expect operator fun <T> Array<T>.plus(element: T): Array<T>

--- a/libraries/stdlib/src/generated/_Arrays.kt
+++ b/libraries/stdlib/src/generated/_Arrays.kt
@@ -13334,6 +13334,87 @@ public inline fun CharArray.copyOfRange(fromIndex: Int, toIndex: Int): CharArray
 }
 
 /**
+ * Copies an array from the specified source array [this] with [length], beginning at the specified [srcPos], to the specified position [destPos] of the destination array [dest].
+ */
+@SinceKotlin("1.2")
+@kotlin.internal.InlineOnly
+public inline fun ByteArray.copyRangeTo(srcPos: Int, dest: ByteArray, destPos: Int, length: Int): Unit {
+    java.lang.System.arraycopy(this, srcPos, dest, destPos, length)
+}
+
+/**
+ * Copies an array from the specified source array [this] with [length], beginning at the specified [srcPos], to the specified position [destPos] of the destination array [dest].
+ */
+@SinceKotlin("1.2")
+@kotlin.internal.InlineOnly
+public inline fun ShortArray.copyRangeTo(srcPos: Int, dest: ShortArray, destPos: Int, length: Int): Unit {
+    java.lang.System.arraycopy(this, srcPos, dest, destPos, length)
+}
+
+/**
+ * Copies an array from the specified source array [this] with [length], beginning at the specified [srcPos], to the specified position [destPos] of the destination array [dest].
+ */
+@SinceKotlin("1.2")
+@kotlin.internal.InlineOnly
+public inline fun IntArray.copyRangeTo(srcPos: Int, dest: IntArray, destPos: Int, length: Int): Unit {
+    java.lang.System.arraycopy(this, srcPos, dest, destPos, length)
+}
+
+/**
+ * Copies an array from the specified source array [this] with [length], beginning at the specified [srcPos], to the specified position [destPos] of the destination array [dest].
+ */
+@SinceKotlin("1.2")
+@kotlin.internal.InlineOnly
+public inline fun LongArray.copyRangeTo(srcPos: Int, dest: LongArray, destPos: Int, length: Int): Unit {
+    java.lang.System.arraycopy(this, srcPos, dest, destPos, length)
+}
+
+/**
+ * Copies an array from the specified source array [this] with [length], beginning at the specified [srcPos], to the specified position [destPos] of the destination array [dest].
+ */
+@SinceKotlin("1.2")
+@kotlin.internal.InlineOnly
+public inline fun FloatArray.copyRangeTo(srcPos: Int, dest: FloatArray, destPos: Int, length: Int): Unit {
+    java.lang.System.arraycopy(this, srcPos, dest, destPos, length)
+}
+
+/**
+ * Copies an array from the specified source array [this] with [length], beginning at the specified [srcPos], to the specified position [destPos] of the destination array [dest].
+ */
+@SinceKotlin("1.2")
+@kotlin.internal.InlineOnly
+public inline fun DoubleArray.copyRangeTo(srcPos: Int, dest: DoubleArray, destPos: Int, length: Int): Unit {
+    java.lang.System.arraycopy(this, srcPos, dest, destPos, length)
+}
+
+/**
+ * Copies an array from the specified source array [this] with [length], beginning at the specified [srcPos], to the specified position [destPos] of the destination array [dest].
+ */
+@SinceKotlin("1.2")
+@kotlin.internal.InlineOnly
+public inline fun BooleanArray.copyRangeTo(srcPos: Int, dest: BooleanArray, destPos: Int, length: Int): Unit {
+    java.lang.System.arraycopy(this, srcPos, dest, destPos, length)
+}
+
+/**
+ * Copies an array from the specified source array [this] with [length], beginning at the specified [srcPos], to the specified position [destPos] of the destination array [dest].
+ */
+@SinceKotlin("1.2")
+@kotlin.internal.InlineOnly
+public inline fun CharArray.copyRangeTo(srcPos: Int, dest: CharArray, destPos: Int, length: Int): Unit {
+    java.lang.System.arraycopy(this, srcPos, dest, destPos, length)
+}
+
+/**
+ * Copies an array from the specified source array [this] with [length], beginning at the specified [srcPos], to the specified position [destPos] of the destination array [dest].
+ */
+@SinceKotlin("1.2")
+@kotlin.internal.InlineOnly
+public inline fun <T> Array<T>.copyRangeTo(srcPos: Int, dest: Array<T>, destPos: Int, length: Int): Unit {
+    java.lang.System.arraycopy(this, srcPos, dest, destPos, length)
+}
+
+/**
  * Returns an array containing all elements of the original array and then the given [element].
  */
 public operator fun <T> Array<T>.plus(element: T): Array<T> {


### PR DESCRIPTION
Initial proposal for:
https://youtrack.jetbrains.com/issue/KT-17392

Lacks tests (I still have to find the right place to put them), but want to get early feedback to do proper changes. For example `copyRangeTo` instead of `copyTo`. I kept the same argument order as `System.arraycopy` using src as receiver.

Also I'm using javascript's `subarray` for convenience: https://developer.mozilla.org/es/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/subarray
But older browsers didn't support it when they first added typed arrays, but we can add a polyfill it using typed array constructors or directly use typed array constructors.

I don't know how to detect at generation level if kotlin is configured for typed arrays, or if it is possible. Should I detect them at runtime to do a plain copy instead of using `.set`?

Also the documentation description will need a review.

After this, I will work on `.fill` in all targets if nobody has done it already in other PR.