### PR TITLE
AndroidExtensionsReferenceSearchExecutor should also require a read a…

### DIFF
--- a/plugins/android-extensions/android-extensions-idea/src/org/jetbrains/kotlin/AndroidExtensionsReferenceSearchExecutor.kt
+++ b/plugins/android-extensions/android-extensions-idea/src/org/jetbrains/kotlin/AndroidExtensionsReferenceSearchExecutor.kt
@@ -35,7 +35,7 @@ import org.jetbrains.kotlin.resolve.lazy.BodyResolveMode
 import org.jetbrains.kotlin.resolve.source.getPsi
 
 
-class AndroidExtensionsReferenceSearchExecutor : QueryExecutorBase<PsiReference, ReferencesSearch.SearchParameters>() {
+class AndroidExtensionsReferenceSearchExecutor : QueryExecutorBase<PsiReference, ReferencesSearch.SearchParameters>(true) {
     override fun processQuery(queryParameters: ReferencesSearch.SearchParameters, consumer: Processor<PsiReference>) {
         val elementToSearch = queryParameters.elementToSearch as? XmlAttributeValue ?: return
         val scopeElements = (queryParameters.effectiveSearchScope as? LocalSearchScope)?.scope ?: return


### PR DESCRIPTION
…ction

... just like AndroidReferenceSearchExecutor does. Otherwise, we get
com.intellij.openapi.application.impl.ApplicationImpl$NoReadAccessException
     [java]    [uitest]         at com.intellij.openapi.application.impl.ApplicationImpl.assertReadAccessAllowed(ApplicationImpl.java:1070)
     [java]    [uitest]         at com.intellij.psi.impl.source.tree.CompositeElement.textToCharArray(CompositeElement.java:291)
     [java]    [uitest]         at com.intellij.psi.impl.source.tree.CompositeElement.getText(CompositeElement.java:261)
     [java]    [uitest]         at com.intellij.psi.impl.source.xml.XmlAttributeValueImpl.getValue(XmlAttributeValueImpl.java:72)
     [java]    [uitest]         at org.jetbrains.android.dom.wrappers.ValueResourceElementWrapper.getValue(ValueResourceElementWrapper.java:458)
     [java]    [uitest]         at org.jetbrains.kotlin.AndroidExtensionsReferenceSearchExecutor.processQuery(AndroidExtensionsReferenceSearchExecutor.kt:42)
     [java]    [uitest]         at org.jetbrains.kotlin.AndroidExtensionsReferenceSearchExecutor.processQuery(AndroidExtensionsReferenceSearchExecutor.kt:38)
     [java]    [uitest]         at com.intellij.openapi.application.QueryExecutorBase.execute(QueryExecutorBase.java:87)
     [java]    [uitest]         at com.intellij.util.ExecutorsQuery.processResults(ExecutorsQuery.java:45)
     [java]    [uitest]         at com.intellij.util.AbstractQuery.forEach(AbstractQuery.java:79)
     [java]    [uitest]         at com.intellij.util.UniqueResultsQuery.process(UniqueResultsQuery.java:66)
     [java]    [uitest]         at com.intellij.util.UniqueResultsQuery.forEach(UniqueResultsQuery.java:56)
     [java]    [uitest]         at com.intellij.psi.search.QuerySearchRequest.runQuery(QuerySearchRequest.java:53)
     [java]    [uitest]         at com.intellij.psi.impl.search.PsiSearchHelperImpl.appendCollectorsFromQueryRequests(PsiSearchHelperImpl.java:635)
     [java]    [uitest]         at com.intellij.psi.impl.search.PsiSearchHelperImpl.processRequests(PsiSearchHelperImpl.java:596)
     [java]    [uitest]         at com.intellij.psi.search.SearchRequestQuery.processResults(SearchRequestQuery.java:45)
     [java]    [uitest]         at com.intellij.util.AbstractQuery.forEach(AbstractQuery.java:79)
     [java]    [uitest]         at com.intellij.util.MergeQuery.processSubQuery(MergeQuery.java:85)
     [java]    [uitest]         at com.intellij.util.MergeQuery.forEach(MergeQuery.java:57)
     [java]    [uitest]         at com.intellij.util.MergeQuery.findFirst(MergeQuery.java:51)
     [java]    [uitest]         at com.intellij.util.UniqueResultsQuery.findFirst(UniqueResultsQuery.java:51)
     [java]    [uitest]         at com.android.tools.idea.editors.theme.ThemeEditorComponent$19.doInBackground(ThemeEditorComponent.java:895)
     [java]    [uitest]         at com.android.tools.idea.editors.theme.ThemeEditorComponent$19.doInBackground(ThemeEditorComponent.java:891)
     [java]    [uitest]         at javax.swing.SwingWorker$1.call(SwingWorker.java:295)
     [java]    [uitest]         at java.util.concurrent.FutureTask.run(FutureTask.java:266)
     [java]    [uitest]         at javax.swing.SwingWorker.run(SwingWorker.java:334)
     [java]    [uitest]         at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
     [java]    [uitest]         at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
     [java]    [uitest]         at java.lang.Thread.run(Thread.java:745)
     [java]    [uitest] [  72230]  ERROR - plication.impl.ApplicationImpl - Android Studio 3.1 Canary  Build #171.SNAPSHOT