### PR TITLE
Fix Different Default and Fallback on Compiler Execution Strategy

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/compilerRunner/GradleKotlinCompilerRunner.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/compilerRunner/GradleKotlinCompilerRunner.kt
@@ -150,8 +150,9 @@ internal class GradleCompilerRunner(private val project: Project) : KotlinCompil
             kotlinDebug { "Kotlin compiler args: ${argsArray.joinToString(" ")}" }
         }
 
+        val gradleDaemonUsed = System.getProperty("org.gradle.daemon")?.let(String::toBoolean) ?: true
         val executionStrategy = System.getProperty(KOTLIN_COMPILER_EXECUTION_STRATEGY_PROPERTY) ?: DAEMON_EXECUTION_STRATEGY
-        if (executionStrategy == DAEMON_EXECUTION_STRATEGY) {
+        if (executionStrategy == DAEMON_EXECUTION_STRATEGY && gradleDaemonUsed) {
             val daemonExitCode = compileWithDaemon(compilerClassName, compilerArgs, environment)
 
             if (daemonExitCode != null) {
@@ -162,11 +163,9 @@ internal class GradleCompilerRunner(private val project: Project) : KotlinCompil
             }
         }
 
-        val isGradleDaemonUsed = System.getProperty("org.gradle.daemon")?.let(String::toBoolean)
-        return if (executionStrategy == IN_PROCESS_EXECUTION_STRATEGY || isGradleDaemonUsed == false) {
+        return if (executionStrategy == IN_PROCESS_EXECUTION_STRATEGY) {
             compileInProcess(argsArray, compilerClassName, environment)
-        }
-        else {
+        } else {
             compileOutOfProcess(argsArray, compilerClassName, environment)
         }
     }


### PR DESCRIPTION
Having default and fallback values are different creates some problem for us that in order to solve we need to do some workaround :)

**Problem:**
We have ["Error unmarshaling return header"](https://youtrack.jetbrains.com/issue/KT-17601) and in order to fix, we tried to set `-Dkotlin.compiler.execution.strategy=in-process` but then we got into ["ClassLoader"](https://youtrack.jetbrains.com/issue/KT-20233) issue. Then we realised if you set something different then "in-process" (by accident) it works!

Digging into source code, lead us to figure out that if you don't set the strategy at all, default strategy is "daemon" but if you set anything at all then it goes into either `compileInProcess` or `compileOutOfProcess`. But we cannot set "in-process" because of mentioned issue. 

Right now, our work around is to set "out-of-process" to skip `compileWithDaemon` and fallback to `compileInProcess`. 

**Fix:**
Having daemon check with strategy in same time and decide if it is required. Have it `true` as default in order not to change behaviour. But still make sure, when `org.gradle.daemon` is false; we can set `kotlin.compiler.execution.strategy` to `in-process` to actually run `compileInProcess`.

**Credits:**
Thanks to [Daniel Hartwich](https://github.com/dhartwich1991) and [Svyatoslav Chatchenko](https://github.com/MyDogTom) to looking into and trying to figure out source of the problem.

**Related Issues:**
https://youtrack.jetbrains.com/issue/KT-17601
https://youtrack.jetbrains.com/issue/KT-20233
