### PR TITLE
KT-20349 Convert lambda to reference for trailing lambda inserts parameter names for all arguments if at least one named argument was passed

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertLambdaToReferenceIntention.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertLambdaToReferenceIntention.kt
@@ -178,16 +178,16 @@ open class ConvertLambdaToReferenceIntention(text: String) :
             // Parameters with default value
             val valueParameters = outerCalleeDescriptor.valueParameters
             val arguments = outerCallExpression.valueArguments.filter { it !is KtLambdaArgument }
-            val useNamedArguments = valueParameters.any { it.hasDefaultValue() } || arguments.any { it.getArgumentName() != null }
+            val isUsingDefaultValue = valueParameters.size - 1 > arguments.size
+            val useNamedArguments = valueParameters.any { it.hasDefaultValue() } && isUsingDefaultValue
+                                    || arguments.any { it.getArgumentName() != null }
 
-            if (useNamedArguments && arguments.size > valueParameters.size) return
             val newArgumentList = factory.buildValueArgumentList {
                 appendFixedText("(")
-                arguments.forEachIndexed { i, argument ->
-                    if (useNamedArguments) {
-                        val argumentName = argument.getArgumentName()?.asName
-                        val name = argumentName ?: valueParameters[i].name
-                        appendName(name)
+                arguments.forEach { argument ->
+                    val argumentName = argument.getArgumentName()
+                    if (useNamedArguments && argumentName != null) {
+                        appendName(argumentName.asName)
                         appendFixedText(" = ")
                     }
                     appendExpression(argument.getArgumentExpression())

--- a/idea/testData/intentions/convertLambdaToReference/defaultNamed2.kt
+++ b/idea/testData/intentions/convertLambdaToReference/defaultNamed2.kt
@@ -4,4 +4,4 @@ class Transformer {
 
 fun bar(x: Int) = x * x
 
-val y = Transformer().transform(2, f = ::bar)
+val y = Transformer().transform(2, y = 3) { <caret>bar(it) }

--- a/idea/testData/intentions/convertLambdaToReference/defaultNamed2.kt.after
+++ b/idea/testData/intentions/convertLambdaToReference/defaultNamed2.kt.after
@@ -4,4 +4,4 @@ class Transformer {
 
 fun bar(x: Int) = x * x
 
-val y = Transformer().transform(2, f = ::bar)
+val y = Transformer().transform(2, y = 3, f = ::bar)

--- a/idea/testData/intentions/convertLambdaToReference/defaultNamed3.kt
+++ b/idea/testData/intentions/convertLambdaToReference/defaultNamed3.kt
@@ -4,4 +4,4 @@ class Transformer {
 
 fun bar(x: Int) = x * x
 
-val y = Transformer().transform(2, f = ::bar)
+val y = Transformer().transform(x = 2, y = 3) { <caret>bar(it) }

--- a/idea/testData/intentions/convertLambdaToReference/defaultNamed3.kt.after
+++ b/idea/testData/intentions/convertLambdaToReference/defaultNamed3.kt.after
@@ -4,4 +4,4 @@ class Transformer {
 
 fun bar(x: Int) = x * x
 
-val y = Transformer().transform(2, f = ::bar)
+val y = Transformer().transform(x = 2, y = 3, f = ::bar)

--- a/idea/testData/intentions/convertLambdaToReference/defaultUnnamed2.kt
+++ b/idea/testData/intentions/convertLambdaToReference/defaultUnnamed2.kt
@@ -4,4 +4,4 @@ class Transformer {
 
 fun bar(x: Int) = x * x
 
-val y = Transformer().transform(2, f = ::bar)
+val y = Transformer().transform { <caret>bar(it) }

--- a/idea/testData/intentions/convertLambdaToReference/defaultUnnamed2.kt.after
+++ b/idea/testData/intentions/convertLambdaToReference/defaultUnnamed2.kt.after
@@ -4,4 +4,4 @@ class Transformer {
 
 fun bar(x: Int) = x * x
 
-val y = Transformer().transform(2, f = ::bar)
+val y = Transformer().transform(f = ::bar)

--- a/idea/testData/intentions/convertLambdaToReference/defaultUnnamed3.kt
+++ b/idea/testData/intentions/convertLambdaToReference/defaultUnnamed3.kt
@@ -4,4 +4,4 @@ class Transformer {
 
 fun bar(x: Int) = x * x
 
-val y = Transformer().transform(2, f = ::bar)
+val y = Transformer().transform(2, 3) { <caret>bar(it) }

--- a/idea/testData/intentions/convertLambdaToReference/defaultUnnamed3.kt.after
+++ b/idea/testData/intentions/convertLambdaToReference/defaultUnnamed3.kt.after
@@ -4,4 +4,4 @@ class Transformer {
 
 fun bar(x: Int) = x * x
 
-val y = Transformer().transform(2, f = ::bar)
+val y = Transformer().transform(2, 3, ::bar)

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -5024,6 +5024,18 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
             doTest(fileName);
         }
 
+        @TestMetadata("defaultNamed2.kt")
+        public void testDefaultNamed2() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/convertLambdaToReference/defaultNamed2.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("defaultNamed3.kt")
+        public void testDefaultNamed3() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/convertLambdaToReference/defaultNamed3.kt");
+            doTest(fileName);
+        }
+
         @TestMetadata("defaultOverridden.kt")
         public void testDefaultOverridden() throws Exception {
             String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/convertLambdaToReference/defaultOverridden.kt");
@@ -5033,6 +5045,18 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
         @TestMetadata("defaultUnnamed.kt")
         public void testDefaultUnnamed() throws Exception {
             String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/convertLambdaToReference/defaultUnnamed.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("defaultUnnamed2.kt")
+        public void testDefaultUnnamed2() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/convertLambdaToReference/defaultUnnamed2.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("defaultUnnamed3.kt")
+        public void testDefaultUnnamed3() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/convertLambdaToReference/defaultUnnamed3.kt");
             doTest(fileName);
         }
 


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-20349