### PR TITLE
Spring-Kotlin: Gutter repaired (KT-20550, KT-20566)

### DIFF
--- a/ultimate/testData/spring/core/gutter/autowiredConstructor/autowiredConstructor.test
+++ b/ultimate/testData/spring/core/gutter/autowiredConstructor/autowiredConstructor.test
@@ -2,7 +2,7 @@
     springConfig: ["config.xml"],
     file: "Bean.kt",
     icon: "SpringBeanMethod",
-    tooltip: "Navigate to the spring bean ",
+    tooltip: "Navigate to the spring bean",
     naming: "bean",
     targets: ["bean"]
 }

--- a/ultimate/tests/org/jetbrains/kotlin/idea/spring/tests/gutter/AbstractSpringClassAnnotatorTest.kt
+++ b/ultimate/tests/org/jetbrains/kotlin/idea/spring/tests/gutter/AbstractSpringClassAnnotatorTest.kt
@@ -73,7 +73,8 @@ abstract class AbstractSpringClassAnnotatorTest : KotlinLightCodeInsightFixtureT
             val iconName = config.getString("icon")
             val icon = SpringApiIcons::class.java.getField(iconName)[null]
 
-            val gutterMark = myFixture.findGutter(fileName)!!.let {
+            val gutter = myFixture.findGutter(fileName) ?: throw AssertionError("no gutter for '$fileName'")
+            val gutterMark = gutter.let {
                 if (it.icon == icon) it
                 else myFixture.findGuttersAtCaret().let { gutters ->
                     gutters.firstOrNull() { it.icon == icon }


### PR DESCRIPTION
Platform now allows Gutter to be placed only on leafs elements, this patch fixes it for Spring-Kotlin.