### PR TITLE
KT-20891 Add mapNotNull() and mapIndexedNotNull() for primitive arrays

### DIFF
--- a/js/js.libraries/src/core/generated/_ArraysJs.kt
+++ b/js/js.libraries/src/core/generated/_ArraysJs.kt
@@ -7859,12 +7859,180 @@ public inline fun <T, R : Any> Array<out T>.mapIndexedNotNull(transform: (index:
 }
 
 /**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element and its index in the original array.
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public inline fun <R : Any> ByteArray.mapIndexedNotNull(transform: (index: Int, Byte) -> R?): List<R> {
+    return mapIndexedNotNullTo(ArrayList<R>(), transform)
+}
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element and its index in the original array.
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public inline fun <R : Any> ShortArray.mapIndexedNotNull(transform: (index: Int, Short) -> R?): List<R> {
+    return mapIndexedNotNullTo(ArrayList<R>(), transform)
+}
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element and its index in the original array.
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public inline fun <R : Any> IntArray.mapIndexedNotNull(transform: (index: Int, Int) -> R?): List<R> {
+    return mapIndexedNotNullTo(ArrayList<R>(), transform)
+}
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element and its index in the original array.
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public inline fun <R : Any> LongArray.mapIndexedNotNull(transform: (index: Int, Long) -> R?): List<R> {
+    return mapIndexedNotNullTo(ArrayList<R>(), transform)
+}
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element and its index in the original array.
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public inline fun <R : Any> FloatArray.mapIndexedNotNull(transform: (index: Int, Float) -> R?): List<R> {
+    return mapIndexedNotNullTo(ArrayList<R>(), transform)
+}
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element and its index in the original array.
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public inline fun <R : Any> DoubleArray.mapIndexedNotNull(transform: (index: Int, Double) -> R?): List<R> {
+    return mapIndexedNotNullTo(ArrayList<R>(), transform)
+}
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element and its index in the original array.
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public inline fun <R : Any> BooleanArray.mapIndexedNotNull(transform: (index: Int, Boolean) -> R?): List<R> {
+    return mapIndexedNotNullTo(ArrayList<R>(), transform)
+}
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element and its index in the original array.
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public inline fun <R : Any> CharArray.mapIndexedNotNull(transform: (index: Int, Char) -> R?): List<R> {
+    return mapIndexedNotNullTo(ArrayList<R>(), transform)
+}
+
+/**
  * Applies the given [transform] function to each element and its index in the original array
  * and appends only the non-null results to the given [destination].
  * @param [transform] function that takes the index of an element and the element itself
  * and returns the result of the transform applied to the element.
  */
 public inline fun <T, R : Any, C : MutableCollection<in R>> Array<out T>.mapIndexedNotNullTo(destination: C, transform: (index: Int, T) -> R?): C {
+    forEachIndexed { index, element -> transform(index, element)?.let { destination.add(it) } }
+    return destination
+}
+
+/**
+ * Applies the given [transform] function to each element and its index in the original array
+ * and appends only the non-null results to the given [destination].
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public inline fun <R : Any, C : MutableCollection<in R>> ByteArray.mapIndexedNotNullTo(destination: C, transform: (index: Int, Byte) -> R?): C {
+    forEachIndexed { index, element -> transform(index, element)?.let { destination.add(it) } }
+    return destination
+}
+
+/**
+ * Applies the given [transform] function to each element and its index in the original array
+ * and appends only the non-null results to the given [destination].
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public inline fun <R : Any, C : MutableCollection<in R>> ShortArray.mapIndexedNotNullTo(destination: C, transform: (index: Int, Short) -> R?): C {
+    forEachIndexed { index, element -> transform(index, element)?.let { destination.add(it) } }
+    return destination
+}
+
+/**
+ * Applies the given [transform] function to each element and its index in the original array
+ * and appends only the non-null results to the given [destination].
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public inline fun <R : Any, C : MutableCollection<in R>> IntArray.mapIndexedNotNullTo(destination: C, transform: (index: Int, Int) -> R?): C {
+    forEachIndexed { index, element -> transform(index, element)?.let { destination.add(it) } }
+    return destination
+}
+
+/**
+ * Applies the given [transform] function to each element and its index in the original array
+ * and appends only the non-null results to the given [destination].
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public inline fun <R : Any, C : MutableCollection<in R>> LongArray.mapIndexedNotNullTo(destination: C, transform: (index: Int, Long) -> R?): C {
+    forEachIndexed { index, element -> transform(index, element)?.let { destination.add(it) } }
+    return destination
+}
+
+/**
+ * Applies the given [transform] function to each element and its index in the original array
+ * and appends only the non-null results to the given [destination].
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public inline fun <R : Any, C : MutableCollection<in R>> FloatArray.mapIndexedNotNullTo(destination: C, transform: (index: Int, Float) -> R?): C {
+    forEachIndexed { index, element -> transform(index, element)?.let { destination.add(it) } }
+    return destination
+}
+
+/**
+ * Applies the given [transform] function to each element and its index in the original array
+ * and appends only the non-null results to the given [destination].
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public inline fun <R : Any, C : MutableCollection<in R>> DoubleArray.mapIndexedNotNullTo(destination: C, transform: (index: Int, Double) -> R?): C {
+    forEachIndexed { index, element -> transform(index, element)?.let { destination.add(it) } }
+    return destination
+}
+
+/**
+ * Applies the given [transform] function to each element and its index in the original array
+ * and appends only the non-null results to the given [destination].
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public inline fun <R : Any, C : MutableCollection<in R>> BooleanArray.mapIndexedNotNullTo(destination: C, transform: (index: Int, Boolean) -> R?): C {
+    forEachIndexed { index, element -> transform(index, element)?.let { destination.add(it) } }
+    return destination
+}
+
+/**
+ * Applies the given [transform] function to each element and its index in the original array
+ * and appends only the non-null results to the given [destination].
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public inline fun <R : Any, C : MutableCollection<in R>> CharArray.mapIndexedNotNullTo(destination: C, transform: (index: Int, Char) -> R?): C {
     forEachIndexed { index, element -> transform(index, element)?.let { destination.add(it) } }
     return destination
 }
@@ -7995,10 +8163,146 @@ public inline fun <T, R : Any> Array<out T>.mapNotNull(transform: (T) -> R?): Li
 }
 
 /**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element in the original array.
+ */
+public inline fun <R : Any> ByteArray.mapNotNull(transform: (Byte) -> R?): List<R> {
+    return mapNotNullTo(ArrayList<R>(), transform)
+}
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element in the original array.
+ */
+public inline fun <R : Any> ShortArray.mapNotNull(transform: (Short) -> R?): List<R> {
+    return mapNotNullTo(ArrayList<R>(), transform)
+}
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element in the original array.
+ */
+public inline fun <R : Any> IntArray.mapNotNull(transform: (Int) -> R?): List<R> {
+    return mapNotNullTo(ArrayList<R>(), transform)
+}
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element in the original array.
+ */
+public inline fun <R : Any> LongArray.mapNotNull(transform: (Long) -> R?): List<R> {
+    return mapNotNullTo(ArrayList<R>(), transform)
+}
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element in the original array.
+ */
+public inline fun <R : Any> FloatArray.mapNotNull(transform: (Float) -> R?): List<R> {
+    return mapNotNullTo(ArrayList<R>(), transform)
+}
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element in the original array.
+ */
+public inline fun <R : Any> DoubleArray.mapNotNull(transform: (Double) -> R?): List<R> {
+    return mapNotNullTo(ArrayList<R>(), transform)
+}
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element in the original array.
+ */
+public inline fun <R : Any> BooleanArray.mapNotNull(transform: (Boolean) -> R?): List<R> {
+    return mapNotNullTo(ArrayList<R>(), transform)
+}
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element in the original array.
+ */
+public inline fun <R : Any> CharArray.mapNotNull(transform: (Char) -> R?): List<R> {
+    return mapNotNullTo(ArrayList<R>(), transform)
+}
+
+/**
  * Applies the given [transform] function to each element in the original array
  * and appends only the non-null results to the given [destination].
  */
 public inline fun <T, R : Any, C : MutableCollection<in R>> Array<out T>.mapNotNullTo(destination: C, transform: (T) -> R?): C {
+    forEach { element -> transform(element)?.let { destination.add(it) } }
+    return destination
+}
+
+/**
+ * Applies the given [transform] function to each element in the original array
+ * and appends only the non-null results to the given [destination].
+ */
+public inline fun <R : Any, C : MutableCollection<in R>> ByteArray.mapNotNullTo(destination: C, transform: (Byte) -> R?): C {
+    forEach { element -> transform(element)?.let { destination.add(it) } }
+    return destination
+}
+
+/**
+ * Applies the given [transform] function to each element in the original array
+ * and appends only the non-null results to the given [destination].
+ */
+public inline fun <R : Any, C : MutableCollection<in R>> ShortArray.mapNotNullTo(destination: C, transform: (Short) -> R?): C {
+    forEach { element -> transform(element)?.let { destination.add(it) } }
+    return destination
+}
+
+/**
+ * Applies the given [transform] function to each element in the original array
+ * and appends only the non-null results to the given [destination].
+ */
+public inline fun <R : Any, C : MutableCollection<in R>> IntArray.mapNotNullTo(destination: C, transform: (Int) -> R?): C {
+    forEach { element -> transform(element)?.let { destination.add(it) } }
+    return destination
+}
+
+/**
+ * Applies the given [transform] function to each element in the original array
+ * and appends only the non-null results to the given [destination].
+ */
+public inline fun <R : Any, C : MutableCollection<in R>> LongArray.mapNotNullTo(destination: C, transform: (Long) -> R?): C {
+    forEach { element -> transform(element)?.let { destination.add(it) } }
+    return destination
+}
+
+/**
+ * Applies the given [transform] function to each element in the original array
+ * and appends only the non-null results to the given [destination].
+ */
+public inline fun <R : Any, C : MutableCollection<in R>> FloatArray.mapNotNullTo(destination: C, transform: (Float) -> R?): C {
+    forEach { element -> transform(element)?.let { destination.add(it) } }
+    return destination
+}
+
+/**
+ * Applies the given [transform] function to each element in the original array
+ * and appends only the non-null results to the given [destination].
+ */
+public inline fun <R : Any, C : MutableCollection<in R>> DoubleArray.mapNotNullTo(destination: C, transform: (Double) -> R?): C {
+    forEach { element -> transform(element)?.let { destination.add(it) } }
+    return destination
+}
+
+/**
+ * Applies the given [transform] function to each element in the original array
+ * and appends only the non-null results to the given [destination].
+ */
+public inline fun <R : Any, C : MutableCollection<in R>> BooleanArray.mapNotNullTo(destination: C, transform: (Boolean) -> R?): C {
+    forEach { element -> transform(element)?.let { destination.add(it) } }
+    return destination
+}
+
+/**
+ * Applies the given [transform] function to each element in the original array
+ * and appends only the non-null results to the given [destination].
+ */
+public inline fun <R : Any, C : MutableCollection<in R>> CharArray.mapNotNullTo(destination: C, transform: (Char) -> R?): C {
     forEach { element -> transform(element)?.let { destination.add(it) } }
     return destination
 }

--- a/libraries/stdlib/common/src/generated/_Arrays.kt
+++ b/libraries/stdlib/common/src/generated/_Arrays.kt
@@ -4609,12 +4609,140 @@ public expect inline fun <R> CharArray.mapIndexed(transform: (index: Int, Char) 
 public expect inline fun <T, R : Any> Array<out T>.mapIndexedNotNull(transform: (index: Int, T) -> R?): List<R>
 
 /**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element and its index in the original array.
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public expect inline fun <R : Any> ByteArray.mapIndexedNotNull(transform: (index: Int, Byte) -> R?): List<R>
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element and its index in the original array.
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public expect inline fun <R : Any> ShortArray.mapIndexedNotNull(transform: (index: Int, Short) -> R?): List<R>
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element and its index in the original array.
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public expect inline fun <R : Any> IntArray.mapIndexedNotNull(transform: (index: Int, Int) -> R?): List<R>
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element and its index in the original array.
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public expect inline fun <R : Any> LongArray.mapIndexedNotNull(transform: (index: Int, Long) -> R?): List<R>
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element and its index in the original array.
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public expect inline fun <R : Any> FloatArray.mapIndexedNotNull(transform: (index: Int, Float) -> R?): List<R>
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element and its index in the original array.
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public expect inline fun <R : Any> DoubleArray.mapIndexedNotNull(transform: (index: Int, Double) -> R?): List<R>
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element and its index in the original array.
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public expect inline fun <R : Any> BooleanArray.mapIndexedNotNull(transform: (index: Int, Boolean) -> R?): List<R>
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element and its index in the original array.
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public expect inline fun <R : Any> CharArray.mapIndexedNotNull(transform: (index: Int, Char) -> R?): List<R>
+
+/**
  * Applies the given [transform] function to each element and its index in the original array
  * and appends only the non-null results to the given [destination].
  * @param [transform] function that takes the index of an element and the element itself
  * and returns the result of the transform applied to the element.
  */
 public expect inline fun <T, R : Any, C : MutableCollection<in R>> Array<out T>.mapIndexedNotNullTo(destination: C, transform: (index: Int, T) -> R?): C
+
+/**
+ * Applies the given [transform] function to each element and its index in the original array
+ * and appends only the non-null results to the given [destination].
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public expect inline fun <R : Any, C : MutableCollection<in R>> ByteArray.mapIndexedNotNullTo(destination: C, transform: (index: Int, Byte) -> R?): C
+
+/**
+ * Applies the given [transform] function to each element and its index in the original array
+ * and appends only the non-null results to the given [destination].
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public expect inline fun <R : Any, C : MutableCollection<in R>> ShortArray.mapIndexedNotNullTo(destination: C, transform: (index: Int, Short) -> R?): C
+
+/**
+ * Applies the given [transform] function to each element and its index in the original array
+ * and appends only the non-null results to the given [destination].
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public expect inline fun <R : Any, C : MutableCollection<in R>> IntArray.mapIndexedNotNullTo(destination: C, transform: (index: Int, Int) -> R?): C
+
+/**
+ * Applies the given [transform] function to each element and its index in the original array
+ * and appends only the non-null results to the given [destination].
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public expect inline fun <R : Any, C : MutableCollection<in R>> LongArray.mapIndexedNotNullTo(destination: C, transform: (index: Int, Long) -> R?): C
+
+/**
+ * Applies the given [transform] function to each element and its index in the original array
+ * and appends only the non-null results to the given [destination].
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public expect inline fun <R : Any, C : MutableCollection<in R>> FloatArray.mapIndexedNotNullTo(destination: C, transform: (index: Int, Float) -> R?): C
+
+/**
+ * Applies the given [transform] function to each element and its index in the original array
+ * and appends only the non-null results to the given [destination].
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public expect inline fun <R : Any, C : MutableCollection<in R>> DoubleArray.mapIndexedNotNullTo(destination: C, transform: (index: Int, Double) -> R?): C
+
+/**
+ * Applies the given [transform] function to each element and its index in the original array
+ * and appends only the non-null results to the given [destination].
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public expect inline fun <R : Any, C : MutableCollection<in R>> BooleanArray.mapIndexedNotNullTo(destination: C, transform: (index: Int, Boolean) -> R?): C
+
+/**
+ * Applies the given [transform] function to each element and its index in the original array
+ * and appends only the non-null results to the given [destination].
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public expect inline fun <R : Any, C : MutableCollection<in R>> CharArray.mapIndexedNotNullTo(destination: C, transform: (index: Int, Char) -> R?): C
 
 /**
  * Applies the given [transform] function to each element and its index in the original array
@@ -4695,10 +4823,106 @@ public expect inline fun <R, C : MutableCollection<in R>> CharArray.mapIndexedTo
 public expect inline fun <T, R : Any> Array<out T>.mapNotNull(transform: (T) -> R?): List<R>
 
 /**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element in the original array.
+ */
+public expect inline fun <R : Any> ByteArray.mapNotNull(transform: (Byte) -> R?): List<R>
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element in the original array.
+ */
+public expect inline fun <R : Any> ShortArray.mapNotNull(transform: (Short) -> R?): List<R>
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element in the original array.
+ */
+public expect inline fun <R : Any> IntArray.mapNotNull(transform: (Int) -> R?): List<R>
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element in the original array.
+ */
+public expect inline fun <R : Any> LongArray.mapNotNull(transform: (Long) -> R?): List<R>
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element in the original array.
+ */
+public expect inline fun <R : Any> FloatArray.mapNotNull(transform: (Float) -> R?): List<R>
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element in the original array.
+ */
+public expect inline fun <R : Any> DoubleArray.mapNotNull(transform: (Double) -> R?): List<R>
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element in the original array.
+ */
+public expect inline fun <R : Any> BooleanArray.mapNotNull(transform: (Boolean) -> R?): List<R>
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element in the original array.
+ */
+public expect inline fun <R : Any> CharArray.mapNotNull(transform: (Char) -> R?): List<R>
+
+/**
  * Applies the given [transform] function to each element in the original array
  * and appends only the non-null results to the given [destination].
  */
 public expect inline fun <T, R : Any, C : MutableCollection<in R>> Array<out T>.mapNotNullTo(destination: C, transform: (T) -> R?): C
+
+/**
+ * Applies the given [transform] function to each element in the original array
+ * and appends only the non-null results to the given [destination].
+ */
+public expect inline fun <R : Any, C : MutableCollection<in R>> ByteArray.mapNotNullTo(destination: C, transform: (Byte) -> R?): C
+
+/**
+ * Applies the given [transform] function to each element in the original array
+ * and appends only the non-null results to the given [destination].
+ */
+public expect inline fun <R : Any, C : MutableCollection<in R>> ShortArray.mapNotNullTo(destination: C, transform: (Short) -> R?): C
+
+/**
+ * Applies the given [transform] function to each element in the original array
+ * and appends only the non-null results to the given [destination].
+ */
+public expect inline fun <R : Any, C : MutableCollection<in R>> IntArray.mapNotNullTo(destination: C, transform: (Int) -> R?): C
+
+/**
+ * Applies the given [transform] function to each element in the original array
+ * and appends only the non-null results to the given [destination].
+ */
+public expect inline fun <R : Any, C : MutableCollection<in R>> LongArray.mapNotNullTo(destination: C, transform: (Long) -> R?): C
+
+/**
+ * Applies the given [transform] function to each element in the original array
+ * and appends only the non-null results to the given [destination].
+ */
+public expect inline fun <R : Any, C : MutableCollection<in R>> FloatArray.mapNotNullTo(destination: C, transform: (Float) -> R?): C
+
+/**
+ * Applies the given [transform] function to each element in the original array
+ * and appends only the non-null results to the given [destination].
+ */
+public expect inline fun <R : Any, C : MutableCollection<in R>> DoubleArray.mapNotNullTo(destination: C, transform: (Double) -> R?): C
+
+/**
+ * Applies the given [transform] function to each element in the original array
+ * and appends only the non-null results to the given [destination].
+ */
+public expect inline fun <R : Any, C : MutableCollection<in R>> BooleanArray.mapNotNullTo(destination: C, transform: (Boolean) -> R?): C
+
+/**
+ * Applies the given [transform] function to each element in the original array
+ * and appends only the non-null results to the given [destination].
+ */
+public expect inline fun <R : Any, C : MutableCollection<in R>> CharArray.mapNotNullTo(destination: C, transform: (Char) -> R?): C
 
 /**
  * Applies the given [transform] function to each element of the original array

--- a/libraries/stdlib/src/generated/_Arrays.kt
+++ b/libraries/stdlib/src/generated/_Arrays.kt
@@ -7929,12 +7929,180 @@ public inline fun <T, R : Any> Array<out T>.mapIndexedNotNull(transform: (index:
 }
 
 /**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element and its index in the original array.
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public inline fun <R : Any> ByteArray.mapIndexedNotNull(transform: (index: Int, Byte) -> R?): List<R> {
+    return mapIndexedNotNullTo(ArrayList<R>(), transform)
+}
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element and its index in the original array.
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public inline fun <R : Any> ShortArray.mapIndexedNotNull(transform: (index: Int, Short) -> R?): List<R> {
+    return mapIndexedNotNullTo(ArrayList<R>(), transform)
+}
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element and its index in the original array.
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public inline fun <R : Any> IntArray.mapIndexedNotNull(transform: (index: Int, Int) -> R?): List<R> {
+    return mapIndexedNotNullTo(ArrayList<R>(), transform)
+}
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element and its index in the original array.
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public inline fun <R : Any> LongArray.mapIndexedNotNull(transform: (index: Int, Long) -> R?): List<R> {
+    return mapIndexedNotNullTo(ArrayList<R>(), transform)
+}
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element and its index in the original array.
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public inline fun <R : Any> FloatArray.mapIndexedNotNull(transform: (index: Int, Float) -> R?): List<R> {
+    return mapIndexedNotNullTo(ArrayList<R>(), transform)
+}
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element and its index in the original array.
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public inline fun <R : Any> DoubleArray.mapIndexedNotNull(transform: (index: Int, Double) -> R?): List<R> {
+    return mapIndexedNotNullTo(ArrayList<R>(), transform)
+}
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element and its index in the original array.
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public inline fun <R : Any> BooleanArray.mapIndexedNotNull(transform: (index: Int, Boolean) -> R?): List<R> {
+    return mapIndexedNotNullTo(ArrayList<R>(), transform)
+}
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element and its index in the original array.
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public inline fun <R : Any> CharArray.mapIndexedNotNull(transform: (index: Int, Char) -> R?): List<R> {
+    return mapIndexedNotNullTo(ArrayList<R>(), transform)
+}
+
+/**
  * Applies the given [transform] function to each element and its index in the original array
  * and appends only the non-null results to the given [destination].
  * @param [transform] function that takes the index of an element and the element itself
  * and returns the result of the transform applied to the element.
  */
 public inline fun <T, R : Any, C : MutableCollection<in R>> Array<out T>.mapIndexedNotNullTo(destination: C, transform: (index: Int, T) -> R?): C {
+    forEachIndexed { index, element -> transform(index, element)?.let { destination.add(it) } }
+    return destination
+}
+
+/**
+ * Applies the given [transform] function to each element and its index in the original array
+ * and appends only the non-null results to the given [destination].
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public inline fun <R : Any, C : MutableCollection<in R>> ByteArray.mapIndexedNotNullTo(destination: C, transform: (index: Int, Byte) -> R?): C {
+    forEachIndexed { index, element -> transform(index, element)?.let { destination.add(it) } }
+    return destination
+}
+
+/**
+ * Applies the given [transform] function to each element and its index in the original array
+ * and appends only the non-null results to the given [destination].
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public inline fun <R : Any, C : MutableCollection<in R>> ShortArray.mapIndexedNotNullTo(destination: C, transform: (index: Int, Short) -> R?): C {
+    forEachIndexed { index, element -> transform(index, element)?.let { destination.add(it) } }
+    return destination
+}
+
+/**
+ * Applies the given [transform] function to each element and its index in the original array
+ * and appends only the non-null results to the given [destination].
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public inline fun <R : Any, C : MutableCollection<in R>> IntArray.mapIndexedNotNullTo(destination: C, transform: (index: Int, Int) -> R?): C {
+    forEachIndexed { index, element -> transform(index, element)?.let { destination.add(it) } }
+    return destination
+}
+
+/**
+ * Applies the given [transform] function to each element and its index in the original array
+ * and appends only the non-null results to the given [destination].
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public inline fun <R : Any, C : MutableCollection<in R>> LongArray.mapIndexedNotNullTo(destination: C, transform: (index: Int, Long) -> R?): C {
+    forEachIndexed { index, element -> transform(index, element)?.let { destination.add(it) } }
+    return destination
+}
+
+/**
+ * Applies the given [transform] function to each element and its index in the original array
+ * and appends only the non-null results to the given [destination].
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public inline fun <R : Any, C : MutableCollection<in R>> FloatArray.mapIndexedNotNullTo(destination: C, transform: (index: Int, Float) -> R?): C {
+    forEachIndexed { index, element -> transform(index, element)?.let { destination.add(it) } }
+    return destination
+}
+
+/**
+ * Applies the given [transform] function to each element and its index in the original array
+ * and appends only the non-null results to the given [destination].
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public inline fun <R : Any, C : MutableCollection<in R>> DoubleArray.mapIndexedNotNullTo(destination: C, transform: (index: Int, Double) -> R?): C {
+    forEachIndexed { index, element -> transform(index, element)?.let { destination.add(it) } }
+    return destination
+}
+
+/**
+ * Applies the given [transform] function to each element and its index in the original array
+ * and appends only the non-null results to the given [destination].
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public inline fun <R : Any, C : MutableCollection<in R>> BooleanArray.mapIndexedNotNullTo(destination: C, transform: (index: Int, Boolean) -> R?): C {
+    forEachIndexed { index, element -> transform(index, element)?.let { destination.add(it) } }
+    return destination
+}
+
+/**
+ * Applies the given [transform] function to each element and its index in the original array
+ * and appends only the non-null results to the given [destination].
+ * @param [transform] function that takes the index of an element and the element itself
+ * and returns the result of the transform applied to the element.
+ */
+public inline fun <R : Any, C : MutableCollection<in R>> CharArray.mapIndexedNotNullTo(destination: C, transform: (index: Int, Char) -> R?): C {
     forEachIndexed { index, element -> transform(index, element)?.let { destination.add(it) } }
     return destination
 }
@@ -8065,10 +8233,146 @@ public inline fun <T, R : Any> Array<out T>.mapNotNull(transform: (T) -> R?): Li
 }
 
 /**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element in the original array.
+ */
+public inline fun <R : Any> ByteArray.mapNotNull(transform: (Byte) -> R?): List<R> {
+    return mapNotNullTo(ArrayList<R>(), transform)
+}
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element in the original array.
+ */
+public inline fun <R : Any> ShortArray.mapNotNull(transform: (Short) -> R?): List<R> {
+    return mapNotNullTo(ArrayList<R>(), transform)
+}
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element in the original array.
+ */
+public inline fun <R : Any> IntArray.mapNotNull(transform: (Int) -> R?): List<R> {
+    return mapNotNullTo(ArrayList<R>(), transform)
+}
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element in the original array.
+ */
+public inline fun <R : Any> LongArray.mapNotNull(transform: (Long) -> R?): List<R> {
+    return mapNotNullTo(ArrayList<R>(), transform)
+}
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element in the original array.
+ */
+public inline fun <R : Any> FloatArray.mapNotNull(transform: (Float) -> R?): List<R> {
+    return mapNotNullTo(ArrayList<R>(), transform)
+}
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element in the original array.
+ */
+public inline fun <R : Any> DoubleArray.mapNotNull(transform: (Double) -> R?): List<R> {
+    return mapNotNullTo(ArrayList<R>(), transform)
+}
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element in the original array.
+ */
+public inline fun <R : Any> BooleanArray.mapNotNull(transform: (Boolean) -> R?): List<R> {
+    return mapNotNullTo(ArrayList<R>(), transform)
+}
+
+/**
+ * Returns a list containing only the non-null results of applying the given [transform] function
+ * to each element in the original array.
+ */
+public inline fun <R : Any> CharArray.mapNotNull(transform: (Char) -> R?): List<R> {
+    return mapNotNullTo(ArrayList<R>(), transform)
+}
+
+/**
  * Applies the given [transform] function to each element in the original array
  * and appends only the non-null results to the given [destination].
  */
 public inline fun <T, R : Any, C : MutableCollection<in R>> Array<out T>.mapNotNullTo(destination: C, transform: (T) -> R?): C {
+    forEach { element -> transform(element)?.let { destination.add(it) } }
+    return destination
+}
+
+/**
+ * Applies the given [transform] function to each element in the original array
+ * and appends only the non-null results to the given [destination].
+ */
+public inline fun <R : Any, C : MutableCollection<in R>> ByteArray.mapNotNullTo(destination: C, transform: (Byte) -> R?): C {
+    forEach { element -> transform(element)?.let { destination.add(it) } }
+    return destination
+}
+
+/**
+ * Applies the given [transform] function to each element in the original array
+ * and appends only the non-null results to the given [destination].
+ */
+public inline fun <R : Any, C : MutableCollection<in R>> ShortArray.mapNotNullTo(destination: C, transform: (Short) -> R?): C {
+    forEach { element -> transform(element)?.let { destination.add(it) } }
+    return destination
+}
+
+/**
+ * Applies the given [transform] function to each element in the original array
+ * and appends only the non-null results to the given [destination].
+ */
+public inline fun <R : Any, C : MutableCollection<in R>> IntArray.mapNotNullTo(destination: C, transform: (Int) -> R?): C {
+    forEach { element -> transform(element)?.let { destination.add(it) } }
+    return destination
+}
+
+/**
+ * Applies the given [transform] function to each element in the original array
+ * and appends only the non-null results to the given [destination].
+ */
+public inline fun <R : Any, C : MutableCollection<in R>> LongArray.mapNotNullTo(destination: C, transform: (Long) -> R?): C {
+    forEach { element -> transform(element)?.let { destination.add(it) } }
+    return destination
+}
+
+/**
+ * Applies the given [transform] function to each element in the original array
+ * and appends only the non-null results to the given [destination].
+ */
+public inline fun <R : Any, C : MutableCollection<in R>> FloatArray.mapNotNullTo(destination: C, transform: (Float) -> R?): C {
+    forEach { element -> transform(element)?.let { destination.add(it) } }
+    return destination
+}
+
+/**
+ * Applies the given [transform] function to each element in the original array
+ * and appends only the non-null results to the given [destination].
+ */
+public inline fun <R : Any, C : MutableCollection<in R>> DoubleArray.mapNotNullTo(destination: C, transform: (Double) -> R?): C {
+    forEach { element -> transform(element)?.let { destination.add(it) } }
+    return destination
+}
+
+/**
+ * Applies the given [transform] function to each element in the original array
+ * and appends only the non-null results to the given [destination].
+ */
+public inline fun <R : Any, C : MutableCollection<in R>> BooleanArray.mapNotNullTo(destination: C, transform: (Boolean) -> R?): C {
+    forEach { element -> transform(element)?.let { destination.add(it) } }
+    return destination
+}
+
+/**
+ * Applies the given [transform] function to each element in the original array
+ * and appends only the non-null results to the given [destination].
+ */
+public inline fun <R : Any, C : MutableCollection<in R>> CharArray.mapNotNullTo(destination: C, transform: (Char) -> R?): C {
     forEach { element -> transform(element)?.let { destination.add(it) } }
     return destination
 }

--- a/libraries/stdlib/test/collections/ArraysTest.kt
+++ b/libraries/stdlib/test/collections/ArraysTest.kt
@@ -106,7 +106,7 @@ class ArraysTest {
         assertEquals(0.toShort(), arr[0])
         assertEquals(1.toShort(), arr[1])
     }
-    
+
     @Test fun intArray() {
         val arr = IntArray(2)
 
@@ -114,7 +114,7 @@ class ArraysTest {
         assertEquals(0, arr[0])
         assertEquals(0, arr[1])
     }
-    
+
     @Test fun intArrayInit() {
         val arr = IntArray(2) { it.toInt() }
 
@@ -122,7 +122,7 @@ class ArraysTest {
         assertEquals(0.toInt(), arr[0])
         assertEquals(1.toInt(), arr[1])
     }
-    
+
     @Test fun longArray() {
         val arr = LongArray(2)
 
@@ -148,7 +148,7 @@ class ArraysTest {
         assertEquals(expected, arr[0])
         assertEquals(expected, arr[1])
     }
-    
+
     @Test fun floatArrayInit() {
         val arr = FloatArray(2) { it.toFloat() }
 
@@ -1050,8 +1050,27 @@ class ArraysTest {
         assertEquals(listOf(2, 3), arrayOf("", "bc", "def").mapNotNull { if (it.isEmpty()) null else it.length })
     }
 
+    @Test fun mapNotNullInPrimitiveArrays() {
+        assertEquals(listOf(2, 4), intArrayOf(0, 1, 2).mapNotNull { if (it == 0) null else it * 2 })
+        assertEquals(listOf(2, 4), shortArrayOf(0, 1, 2).mapNotNull { if (it == 0.toShort()) null else it * 2 })
+        assertEquals(listOf(0x0, 0x4), byteArrayOf(0x0, 0x1, 0x2).mapNotNull { if (it == 0x1.toByte()) null else it * 2 })
+//        this following does not pass on PhantomJS due to incorrectly generated JS (the result is not wrapped with toBoxedChar)
+//        assertEquals(listOf('c', 'c'), charArrayOf('a', 'a', 'c', 'c').mapNotNull { if (it == 'a') null else it })
+        assertEquals(listOf(2.0, 4.0), doubleArrayOf(0.0, 1.0, 2.0).mapNotNull { if (it == 0.0) null else it * 2 })
+        assertEquals(listOf(2.0f, 4.0f), floatArrayOf(0.0f, 1.0f, 2.0f).mapNotNull { if (it == 0f) null else it * 2 })
+        assertEquals(listOf(2L, 4L), longArrayOf(0L, 1L, 2L).mapNotNull { if (it == 0L) null else it * 2 })
+    }
+
     @Test fun mapIndexedNotNull() {
         assertEquals(listOf(2), arrayOf("a", null, "test").mapIndexedNotNull { index, it -> it?.run { if (index != 0) length / index else null  } })
+    }
+
+    @Test fun mapIndexedNotNullInPrimitiveArrays() {
+        assertEquals(listOf("0;1", "2;3"), intArrayOf(1, 2, 3).mapIndexedNotNull { index, it -> if (it % 2 == 0) null else "$index;$it" })
+        assertEquals(listOf("0;1", "2;3"), shortArrayOf(1, 2, 3).mapIndexedNotNull { index, it -> if (it == 2.toShort()) null else "$index;$it" })
+        assertEquals(listOf("0;1", "2;3"), byteArrayOf(0x1, 0x2, 0x3).mapIndexedNotNull { index, it -> if (it == 0x2.toByte()) null else "$index;$it" })
+        assertEquals(listOf("0;a", "2;c"), charArrayOf('a', 'b', 'c').mapIndexedNotNull { index, it -> if (it == 'b') null else "$index;$it" })
+        assertEquals(listOf("0;0", "2;2"), longArrayOf(0L, 1L, 2L).mapIndexedNotNull { index, it -> if (it == 1L) null else "$index;$it" })
     }
 
     @Test fun flattenArray() {

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Mapping.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Mapping.kt
@@ -85,7 +85,6 @@ fun mapping(): List<GenericFunction> {
     templates add f("mapNotNull(transform: (T) -> R?)") {
         inline(true)
         include(Maps, CharSequences)
-        exclude(ArraysOfPrimitives)
         typeParam("R : Any")
         returns("List<R>")
         doc { f ->
@@ -109,7 +108,6 @@ fun mapping(): List<GenericFunction> {
     templates add f("mapIndexedNotNull(transform: (index: Int, T) -> R?)") {
         inline(true)
         include(CharSequences)
-        exclude(ArraysOfPrimitives)
         typeParam("R : Any")
         returns("List<R>")
         doc { f ->
@@ -183,7 +181,6 @@ fun mapping(): List<GenericFunction> {
     templates add f("mapNotNullTo(destination: C, transform: (T) -> R?)") {
         inline(true)
         include(Maps, CharSequences)
-        exclude(ArraysOfPrimitives)
         typeParam("R : Any")
         typeParam("C : MutableCollection<in R>")
         returns("C")
@@ -204,7 +201,6 @@ fun mapping(): List<GenericFunction> {
     templates add f("mapIndexedNotNullTo(destination: C, transform: (index: Int, T) -> R?)") {
         inline(true)
         include(CharSequences)
-        exclude(ArraysOfPrimitives)
         typeParam("R : Any")
         typeParam("C : MutableCollection<in R>")
         returns("C")


### PR DESCRIPTION
This PR fixes [KT-20891](https://youtrack.jetbrains.com/issue/KT-20891).

It adds 4 extension functions for all primitive arrays:
* `mapNotNull()`
* `mapNotNullTo()`
* `mapIndexedNotNull()`
* `mapIndexedNotNullTo()`