### PR TITLE
Clean up test skips introduced in KT-17137

### DIFF
--- a/compiler/testData/codegen/box/arrays/arrayInstanceOf.kt
+++ b/compiler/testData/codegen/box/arrays/arrayInstanceOf.kt
@@ -22,8 +22,5 @@ fun test(createIntNotLong: Boolean): String {
 }
 
 fun box(): String {
-    // Only run this test if primitive array `is` checks work (KT-17137)
-    if ((intArrayOf() as Any) is Array<*>) return "OK"
-
     return test(true) + test(false)
 }

--- a/compiler/testData/codegen/box/arrays/kt2997.kt
+++ b/compiler/testData/codegen/box/arrays/kt2997.kt
@@ -53,9 +53,6 @@ fun foo(a: Any): Int {
 }
 
 fun box(): String {
-    // Only run this test if primitive array `is` checks work (KT-17137)
-    if ((intArrayOf() as Any) is Array<*>) return "OK"
-
     val iA = IntArray(1)
     if (foo(iA) != 1) return "fail int[]"
     val sA = ShortArray(1)

--- a/compiler/testData/codegen/box/arrays/kt7288.kt
+++ b/compiler/testData/codegen/box/arrays/kt7288.kt
@@ -21,9 +21,6 @@ fun test(b: Boolean): String {
 }
 
 fun box(): String {
-    // Only run this test if primitive array `is` checks work (KT-17137)
-    if ((intArrayOf() as Any) is Array<*>) return "OK"
-
     if (test(true) != "OK") return "fail 1: ${test(true)}"
 
     if (test(false) != "OK") return "fail 1: ${test(false)}"

--- a/compiler/testData/codegen/box/ranges/forInIndices/kt13241_Array.kt
+++ b/compiler/testData/codegen/box/ranges/forInIndices/kt13241_Array.kt
@@ -13,9 +13,6 @@ fun test(x: Any): Int {
 }
 
 fun box(): String {
-    // Only run this test if primitive array `is` checks work (KT-17137)
-    if ((intArrayOf() as Any) is Array<*>) return "OK"
-
     assertEquals(123, test(intArrayOf(0, 0, 0, 0)))
     return "OK"
 }

--- a/libraries/stdlib/test/collections/ArraysTest.kt
+++ b/libraries/stdlib/test/collections/ArraysTest.kt
@@ -231,12 +231,6 @@ class ArraysTest {
     }
 
     @Test fun contentDeepToString() {
-        // Don't run this test unless primitive array `is` checks are supported (KT-17137)
-        if ((intArrayOf() as Any) is Array<*>) {
-            assertTrue(true)
-            return
-        }
-
         val arr = arrayOf("aa", 1, null, charArrayOf('d'))
         assertEquals("[aa, 1, null, [d]]", arr.contentDeepToString())
     }


### PR DESCRIPTION
We need to clean these up since primitive array `is` checks should work now.