### PR TITLE
Explicitly set utf-8 encoding

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -489,6 +489,7 @@ fun Project.configureJvmProject(javaHome: String, javaVersion: String) {
         options.isFork = true
         options.forkOptions.javaHome = file(javaHome)
         options.compilerArgs.add("-proc:none")
+        options.encoding = "UTF-8"
     }
 
     tasks.withType<KotlinCompile> {


### PR DESCRIPTION
Couldn't build the project without this option because of:

```
> Task :compiler:util:compileJava
/Users/ilyazorin/Development/kotlin/compiler/util/src/org/jetbrains/kotlin/config/MavenComparableVersion.java:58: error: unmappable character for encoding ASCII
 * @author <a href="mailto:hboutemy@apache.org">Herv?? Boutemy</a>
```

I don't know why it suddenly happened, but looks like it [could happen](https://discuss.gradle.org/t/unmappable-character-for-encoding-ascii-when-building-a-utf-8-project/10692/11) and in general, it is a good practice to set up encoding explicitly.