### PR TITLE
Use consistent explicit FileTreeWalk named parameters

### DIFF
--- a/libraries/stdlib/src/kotlin/io/files/FileTreeWalk.kt
+++ b/libraries/stdlib/src/kotlin/io/files/FileTreeWalk.kt
@@ -227,7 +227,7 @@ public class FileTreeWalk private constructor(
      * Sets a callback [function], that is called on any left directory after its files are visited and after it is visited itself.
      */
     public fun onLeave(function: (File) -> Unit): FileTreeWalk {
-        return FileTreeWalk(start, direction, onEnter, function, onFail, maxDepth)
+        return FileTreeWalk(start, direction, onEnter = onEnter, onLeave = function, onFail = onFail, maxDepth = maxDepth)
     }
 
     /**
@@ -236,7 +236,7 @@ public class FileTreeWalk private constructor(
      * [onEnter] and [onLeave] callback functions are called even in this case.
      */
     public fun onFail(function: (File, IOException) -> Unit): FileTreeWalk {
-        return FileTreeWalk(start, direction, onEnter, onLeave, function, maxDepth)
+        return FileTreeWalk(start, direction, onEnter = onEnter, onLeave = onLeave, onFail = function, maxDepth = maxDepth)
     }
 
     /**


### PR DESCRIPTION
Looks like all three functions should use a consistent scheme. Also, it'll be more readable this way, when fun is overloading each param in different cases.