### PR TITLE
Fix Gradle plugin task name in readme.

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -73,7 +73,7 @@ on Windows.
 - `install` - build and install all public artifacts into local maven repository
 - `runIde` - build IDEA plugin and run IDEA with it
 - `coreLibsTest` - build and run stdlib, reflect and kotlin-test tests
-- `gradlePluginsTest` - build and run gradle plugin tests
+- `gradlePluginTest` - build and run gradle plugin tests
 - `compilerTest` - build and run all compiler tests
 - `ideaPluginTest` - build and run all IDEA plugin tests
 


### PR DESCRIPTION
```console
$ ./gradlew gradlePluginsTest
…
FAILURE: Build failed with an exception.

* What went wrong:
Task 'gradlePluginsTest' not found in root project 'kotlin'. Some candidates are: 'gradlePluginTest'.
```

Correct task name: https://github.com/JetBrains/kotlin/blob/55416341871259c6aef9912fce51fba74f1202ac/build.gradle.kts#L324