### PR TITLE
Change run icon in gutter to default one from IJ Platform (KT-15254)

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/highlighter/KotlinRunLineMarkerContributor.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/highlighter/KotlinRunLineMarkerContributor.kt
@@ -18,6 +18,7 @@ package org.jetbrains.kotlin.idea.highlighter
 
 import com.intellij.execution.lineMarker.ExecutorAction
 import com.intellij.execution.lineMarker.RunLineMarkerContributor
+import com.intellij.icons.AllIcons
 import com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.idea.KotlinIcons
@@ -37,7 +38,7 @@ class KotlinRunLineMarkerContributor : RunLineMarkerContributor() {
         }
 
         if (detector.isMain(function)) {
-            return RunLineMarkerContributor.Info(KotlinIcons.SMALL_LOGO_13, null, ExecutorAction.getActions(0))
+            return RunLineMarkerContributor.Info(AllIcons.RunConfigurations.TestState.Run, null, ExecutorAction.getActions(0))
         }
 
         return null


### PR DESCRIPTION
Kotlin plugin adds very attractive and distractive icon into the gutter for main methods. I propose to use well-known platform icon for that which is suitable and has familiar metaphor instead of just Kotlin logo.