### PR TITLE
Change UNINITIALIZED_VALUE from object to Any()

### DIFF
--- a/libraries/stdlib/src/kotlin/util/Lazy.kt
+++ b/libraries/stdlib/src/kotlin/util/Lazy.kt
@@ -105,7 +105,7 @@ public enum class LazyThreadSafetyMode {
 }
 
 
-private object UNINITIALIZED_VALUE
+private val UNINITIALIZED_VALUE = Any()
 
 private class SynchronizedLazyImpl<out T>(initializer: () -> T, lock: Any? = null) : Lazy<T>, Serializable {
     private var initializer: (() -> T)? = initializer


### PR DESCRIPTION
This shouldn't change any behavior as `UNINITIALIZED_VALUE` is only used to check for reference equality.
However, this change saves a class since `object` creates a single use class, by using instead a field.