### PR TITLE
Optimize dependency handling during import of Gradle project

### DIFF
--- a/idea/idea-android/src/org/jetbrains/kotlin/android/configure/AndroidGradleModelFacade.kt
+++ b/idea/idea-android/src/org/jetbrains/kotlin/android/configure/AndroidGradleModelFacade.kt
@@ -61,7 +61,7 @@ class AndroidGradleModelFacade : KotlinGradleModelFacade {
     override fun getDependencyModules(ideModule: DataNode<ModuleData>, gradleIdeaProject: IdeaProject): Collection<DataNode<ModuleData>> {
         val ideProject = ideModule.parent as DataNode<ProjectData>
         ExternalSystemApiUtil.find(ideModule, AndroidProjectKeys.JAVA_MODULE_MODEL)?.let { javaModuleModel ->
-            val moduleNames = javaModuleModel.data.javaModuleDependencies.map { it.moduleName }
+            val moduleNames = javaModuleModel.data.javaModuleDependencies.map { it.moduleName }.toHashSet()
             return findModulesByNames(moduleNames, gradleIdeaProject, ideProject)
         }
         ExternalSystemApiUtil.find(ideModule, AndroidProjectKeys.ANDROID_MODEL)?.let { androidModel ->

--- a/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/KotlinGradleProjectResolverExtension.kt
+++ b/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/KotlinGradleProjectResolverExtension.kt
@@ -53,6 +53,8 @@ var DataNode<out ModuleData>.implementedModuleName
         by CopyableDataNodeUserDataProperty(Key.create<String>("IMPLEMENTED_MODULE_NAME"))
 
 class KotlinGradleProjectResolverExtension : AbstractProjectResolverExtension() {
+    val isAndroidProjectKey = Key.findKeyByName("IS_ANDROID_PROJECT_KEY")
+
     override fun getToolingExtensionsClasses(): Set<Class<out Any>> {
         return setOf(KotlinGradleModelBuilder::class.java, Unit::class.java)
     }
@@ -63,7 +65,6 @@ class KotlinGradleProjectResolverExtension : AbstractProjectResolverExtension() 
 
     private fun useModulePerSourceSet(): Boolean {
         // See AndroidGradleProjectResolver
-        val isAndroidProjectKey = Key.findKeyByName("IS_ANDROID_PROJECT_KEY")
         if (isAndroidProjectKey != null && resolverCtx.getUserData(isAndroidProjectKey) == true) {
             return false
         }


### PR DESCRIPTION
Calls to `ExternalSystemApiUtil.findFirstRecursively` can take a lot of time on large projects.
Also, `Key.findKeyByName` is slow and deprecated.