### PR TITLE
KT-19977 Convert Lambda to reference produces red code when wrong implicit receiver is in scope

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertLambdaToReferenceIntention.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertLambdaToReferenceIntention.kt
@@ -29,11 +29,13 @@ import org.jetbrains.kotlin.idea.inspections.IntentionBasedInspection
 import org.jetbrains.kotlin.idea.project.languageVersionSettings
 import org.jetbrains.kotlin.idea.util.IdeDescriptorRenderers
 import org.jetbrains.kotlin.idea.util.approximateFlexibleTypes
+import org.jetbrains.kotlin.idea.util.getResolutionScope
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.resolve.BindingContext.FUNCTION
 import org.jetbrains.kotlin.resolve.BindingContext.REFERENCE_TARGET
 import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
 import org.jetbrains.kotlin.resolve.descriptorUtil.hasDefaultValue
+import org.jetbrains.kotlin.resolve.scopes.utils.getImplicitReceiversHierarchy
 import org.jetbrains.kotlin.synthetic.SyntheticJavaPropertyDescriptor
 import org.jetbrains.kotlin.types.isDynamic
 import org.jetbrains.kotlin.types.isError
@@ -222,10 +224,14 @@ open class ConvertLambdaToReferenceIntention(text: String) :
                     val calleeReferenceExpression = singleStatement.calleeExpression as? KtNameReferenceExpression ?: return null
                     val context = singleStatement.analyze()
                     val resolvedCall = calleeReferenceExpression.getResolvedCall(context) ?: return null
-                    if (resolvedCall.dispatchReceiver != null || resolvedCall.extensionReceiver != null)
-                        "this::${singleStatement.getCallReferencedName()}"
+                    val receiver = resolvedCall.dispatchReceiver ?: resolvedCall.extensionReceiver
+                    val receiverText = if (receiver == null)
+                        ""
+                    else if (lambdaExpression.getResolutionScope().getImplicitReceiversHierarchy().size == 1)
+                        "this"
                     else
-                        "::${singleStatement.getCallReferencedName()}"
+                        receiver.type.constructor.declarationDescriptor?.name?.let { "this@$it" } ?: return null
+                    "$receiverText::${singleStatement.getCallReferencedName()}"
                 }
                 is KtDotQualifiedExpression -> {
                     val selector = singleStatement.selectorExpression

--- a/idea/testData/intentions/convertLambdaToReference/extentionOuterScope.kt
+++ b/idea/testData/intentions/convertLambdaToReference/extentionOuterScope.kt
@@ -1,0 +1,13 @@
+// IS_APPLICABLE: true
+// WITH_RUNTIME
+
+class Test {
+    fun test() {
+        with(Any()) {
+            val f = { s: String<caret> -> foo(s) }
+        }
+    }
+
+}
+
+fun Test.foo(s: String) {}

--- a/idea/testData/intentions/convertLambdaToReference/extentionOuterScope.kt.after
+++ b/idea/testData/intentions/convertLambdaToReference/extentionOuterScope.kt.after
@@ -1,0 +1,13 @@
+// IS_APPLICABLE: true
+// WITH_RUNTIME
+
+class Test {
+    fun test() {
+        with(Any()) {
+            val f = this@Test::foo
+        }
+    }
+
+}
+
+fun Test.foo(s: String) {}

--- a/idea/testData/intentions/convertLambdaToReference/memberOuterScope.kt
+++ b/idea/testData/intentions/convertLambdaToReference/memberOuterScope.kt
@@ -1,0 +1,11 @@
+// IS_APPLICABLE: true
+// WITH_RUNTIME
+
+class Test {
+    fun test() {
+        with(Any()) {
+            val f = { s: String<caret> -> foo(s) }
+        }
+    }
+    fun foo(s: String) {}
+}

--- a/idea/testData/intentions/convertLambdaToReference/memberOuterScope.kt.after
+++ b/idea/testData/intentions/convertLambdaToReference/memberOuterScope.kt.after
@@ -1,0 +1,11 @@
+// IS_APPLICABLE: true
+// WITH_RUNTIME
+
+class Test {
+    fun test() {
+        with(Any()) {
+            val f = this@Test::foo
+        }
+    }
+    fun foo(s: String) {}
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -5120,6 +5120,12 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
             doTest(fileName);
         }
 
+        @TestMetadata("extentionOuterScope.kt")
+        public void testExtentionOuterScope() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/convertLambdaToReference/extentionOuterScope.kt");
+            doTest(fileName);
+        }
+
         @TestMetadata("fqNameForReceiver.kt")
         public void testFqNameForReceiver() throws Exception {
             String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/convertLambdaToReference/fqNameForReceiver.kt");
@@ -5195,6 +5201,12 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
         @TestMetadata("memberInLambdaArgument.kt")
         public void testMemberInLambdaArgument() throws Exception {
             String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/convertLambdaToReference/memberInLambdaArgument.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("memberOuterScope.kt")
+        public void testMemberOuterScope() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/intentions/convertLambdaToReference/memberOuterScope.kt");
             doTest(fileName);
         }
 


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-19977