### PR TITLE
.gitignore: remove duplicates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,6 @@ build/
 !**/test/**/build
 *.iml
 !**/testData/**/*.iml
-.idea/modules.xml
 .idea/libraries/Gradle*.xml
 .idea/libraries/Maven*.xml
 .idea/modules


### PR DESCRIPTION
Remove duplicate `.idea/modules.xml` from `.gitignore`.

Another declaration is in L33.
https://github.com/JetBrains/kotlin/pull/1416/files#diff-a084b794bc0759e7a6b77810e01874f2L33