### PR TITLE
kotlinc refers CLASSPATH env.

### DIFF
--- a/compiler/cli/bin/kotlinc
+++ b/compiler/cli/bin/kotlinc
@@ -71,4 +71,8 @@ else
     kotlin_app=("${KOTLIN_HOME}/lib/kotlin-preloader.jar" "org.jetbrains.kotlin.preloading.Preloader" "-cp" "${KOTLIN_HOME}/lib/kotlin-compiler.jar" $KOTLIN_COMPILER)
 fi
 
-"${JAVACMD:=java}" $JAVA_OPTS "${java_args[@]}" -cp "${kotlin_app[@]}" "${kotlin_args[@]}"
+if [ -n "$CLASSPATH" ]; then
+    "${JAVACMD:=java}" $JAVA_OPTS "${java_args[@]}" -cp "${kotlin_app[@]}" -cp $CLASSPATH "${kotlin_args[@]}"
+else
+    "${JAVACMD:=java}" $JAVA_OPTS "${java_args[@]}" -cp "${kotlin_app[@]}" "${kotlin_args[@]}"
+fi


### PR DESCRIPTION
java/javac commands refer the CLASSPATH environment.
kotlin/kotlincc commands doesn't refer the CLASSPATH environment.
If using java library(ex. jackson-*.jar) at comiling or running, need to -cp parameters for kotlin/kotlinc commands.
If kotlin/kotlinc commands can refers the CLASSPATH environment, setting once and run anytime.

For example,
before:
```bash
export CLASSPATH=lib/jackson-core-2.9.2.jar:lib//Users/okumura/Documents/modules/java/jackson-databind-2.9.2.jar:lib/jackson-annotations-2.9.2.jar
kotlinc -cp $CLASSPATH Sample1.kt
kotlinc -cp $CLASSPATH Sample2.kt
javac Sample3.java
kotlin -cp $CLASSPATH Sample1Kt
kotlin -cp $CLASSPATH Sample2Kt
java Sample3
```
after:
```sh
export CLASSPATH=lib/jackson-core-2.9.2.jar:lib//Users/okumura/Documents/modules/java/jackson-databind-2.9.2.jar:lib/jackson-annotations-2.9.2.jar
kotlinc Sample1.kt
kotlinc Sample2.kt
javac Sample3.java
kotlin Sample1Kt
kotlin Sample2Kt
java Sample3
```
