### PR TITLE
#KT-21502 Fixed - Inspection to convert map.put(k, v) to map[k] = v

### DIFF
--- a/idea/resources/inspectionDescriptions/ReplacePutWithArrayAssignment.html
+++ b/idea/resources/inspectionDescriptions/ReplacePutWithArrayAssignment.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This inspection reports <code>put</code> function calls replaceable with the indexing operator (<code>[]</code>).
+</body>
+</html>

--- a/idea/src/META-INF/plugin.xml
+++ b/idea/src/META-INF/plugin.xml
@@ -2681,6 +2681,14 @@
                      language="kotlin"
     />
 
+    <localInspection implementationClass="org.jetbrains.kotlin.idea.inspections.ReplacePutWithArrayAssignmentInspection"
+                     displayName="Replace put with array assign"
+                     groupPath="Kotlin"
+                     groupName="Style issues"
+                     enabledByDefault="true"
+                     level="WEAK WARNING"
+                     language="kotlin"
+    />
     <referenceImporter implementation="org.jetbrains.kotlin.idea.quickfix.KotlinReferenceImporter"/>
 
     <fileType.fileViewProviderFactory filetype="KJSM" implementationClass="com.intellij.psi.ClassFileViewProviderFactory"/>

--- a/idea/src/org/jetbrains/kotlin/idea/inspections/ReplacePutWithArrayAssignmentInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/ReplacePutWithArrayAssignmentInspection.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2010-2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.kotlin.idea.inspections
+
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElementVisitor
+import org.jetbrains.kotlin.builtins.DefaultBuiltIns
+import org.jetbrains.kotlin.descriptors.ClassDescriptor
+import org.jetbrains.kotlin.idea.caches.resolve.analyze
+import org.jetbrains.kotlin.idea.intentions.callExpression
+import org.jetbrains.kotlin.idea.intentions.calleeName
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtPsiFactory
+import org.jetbrains.kotlin.psi.KtVisitorVoid
+import org.jetbrains.kotlin.psi.createExpressionByPattern
+import org.jetbrains.kotlin.psi.psiUtil.endOffset
+import org.jetbrains.kotlin.psi.psiUtil.startOffset
+import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
+import org.jetbrains.kotlin.resolve.calls.resolvedCallUtil.getExplicitReceiverValue
+import org.jetbrains.kotlin.resolve.descriptorUtil.isSubclassOf
+import org.jetbrains.kotlin.resolve.lazy.BodyResolveMode
+
+class ReplacePutWithArrayAssignmentInspection : AbstractKotlinInspection() {
+    private val compatibleNames = setOf("put")
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        return object : KtVisitorVoid() {
+            override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
+                super.visitDotQualifiedExpression(expression)
+                if (expression.callExpression?.valueArguments?.size != 2) return
+
+                if (expression.calleeName !in compatibleNames) return
+
+                val context = expression.analyze(BodyResolveMode.FULL)
+                val resolvedCall = expression.getResolvedCall(context) ?: return
+                val receiverType = resolvedCall.getExplicitReceiverValue()?.type ?: return
+                val receiverClass = receiverType.constructor.declarationDescriptor as? ClassDescriptor ?: return
+                if (receiverClass.isSubclassOf(DefaultBuiltIns.Instance.mutableMap)) {
+                    val argumentOffset = expression.startOffset
+                    val problemDescriptor = holder.manager.createProblemDescriptor(
+                            expression,
+                            TextRange(expression.startOffset - argumentOffset,
+                                      expression.callExpression!!.endOffset - argumentOffset),
+                            "Convert put to array assignment",
+                            ProblemHighlightType.WEAK_WARNING,
+                            isOnTheFly,
+                            ReplacePutWithArrayAssignQuickfix()
+                    )
+                    holder.registerProblem(problemDescriptor)
+                }
+            }
+        }
+    }
+}
+
+class ReplacePutWithArrayAssignQuickfix : LocalQuickFix {
+    override fun getName() = "Convert put to array assignment"
+
+    override fun getFamilyName() = name
+
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        val element = descriptor.psiElement as KtDotQualifiedExpression
+        element.replace(KtPsiFactory(element).createExpressionByPattern("$0[$1] = $2", element.receiverExpression,
+                                                                        element.callExpression?.valueArguments?.get(0)?.getArgumentExpression() ?: return,
+                                                                        element.callExpression?.valueArguments?.get(1)?.getArgumentExpression() ?: return))
+    }
+}

--- a/idea/testData/inspectionsLocal/replacePutWithArrayAssignment/.inspection
+++ b/idea/testData/inspectionsLocal/replacePutWithArrayAssignment/.inspection
@@ -1,0 +1,1 @@
+org.jetbrains.kotlin.idea.inspections.ReplacePutWithArrayAssignmentInspection

--- a/idea/testData/inspectionsLocal/replacePutWithArrayAssignment/nonMap.kt
+++ b/idea/testData/inspectionsLocal/replacePutWithArrayAssignment/nonMap.kt
@@ -1,0 +1,10 @@
+// PROBLEM: none
+
+class A {
+    fun put(x: Int, y: String) {
+    }
+}
+
+fun foo() {
+    A().<caret>put(1, "foo")
+}

--- a/idea/testData/inspectionsLocal/replacePutWithArrayAssignment/putOnParameter.kt
+++ b/idea/testData/inspectionsLocal/replacePutWithArrayAssignment/putOnParameter.kt
@@ -1,0 +1,5 @@
+// WITH_RUNTIME
+
+fun foo(map: MutableMap<Int, String>) {
+    map.<caret>put(42, "foo")
+}

--- a/idea/testData/inspectionsLocal/replacePutWithArrayAssignment/putOnParameter.kt.after
+++ b/idea/testData/inspectionsLocal/replacePutWithArrayAssignment/putOnParameter.kt.after
@@ -1,0 +1,5 @@
+// WITH_RUNTIME
+
+fun foo(map: MutableMap<Int, String>) {
+    map[42] = "foo"
+}

--- a/idea/testData/inspectionsLocal/replacePutWithArrayAssignment/putOnThis.kt
+++ b/idea/testData/inspectionsLocal/replacePutWithArrayAssignment/putOnThis.kt
@@ -1,0 +1,7 @@
+// WITH_RUNTIME
+
+class MyMap() : HashMap<String, String>() {
+    init {
+        this.<caret>put("foo", "bar")
+    }
+}

--- a/idea/testData/inspectionsLocal/replacePutWithArrayAssignment/putOnThis.kt.after
+++ b/idea/testData/inspectionsLocal/replacePutWithArrayAssignment/putOnThis.kt.after
@@ -1,0 +1,7 @@
+// WITH_RUNTIME
+
+class MyMap() : HashMap<String, String>() {
+    init {
+        this["foo"] = "bar"
+    }
+}

--- a/idea/testData/inspectionsLocal/replacePutWithArrayAssignment/putOnVal.kt
+++ b/idea/testData/inspectionsLocal/replacePutWithArrayAssignment/putOnVal.kt
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+
+fun foo() {
+    val map = mutableMapOf(42 to "foo")
+    map.<caret>put(60, "bar")
+}

--- a/idea/testData/inspectionsLocal/replacePutWithArrayAssignment/putOnVal.kt.after
+++ b/idea/testData/inspectionsLocal/replacePutWithArrayAssignment/putOnVal.kt.after
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+
+fun foo() {
+    val map = mutableMapOf(42 to "foo")
+    map[60] = "bar"
+}

--- a/idea/testData/inspectionsLocal/replacePutWithArrayAssignment/putOnVar.kt
+++ b/idea/testData/inspectionsLocal/replacePutWithArrayAssignment/putOnVar.kt
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+
+fun foo() {
+    var map = mutableMapOf(42 to "foo")
+    map.<caret>put(60, "bar")
+}

--- a/idea/testData/inspectionsLocal/replacePutWithArrayAssignment/putOnVar.kt.after
+++ b/idea/testData/inspectionsLocal/replacePutWithArrayAssignment/putOnVar.kt.after
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+
+fun foo() {
+    var map = mutableMapOf(42 to "foo")
+    map[60] = "bar"
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -2142,6 +2142,45 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
         }
     }
 
+    @TestMetadata("idea/testData/inspectionsLocal/replacePutWithArrayAssignment")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class ReplacePutWithArrayAssignment extends AbstractLocalInspectionTest {
+        public void testAllFilesPresentInReplacePutWithArrayAssignment() throws Exception {
+            KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/inspectionsLocal/replacePutWithArrayAssignment"), Pattern.compile("^([\\w\\-_]+)\\.kt$"), TargetBackend.ANY, true);
+        }
+
+        @TestMetadata("nonMap.kt")
+        public void testNonMap() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/inspectionsLocal/replacePutWithArrayAssignment/nonMap.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("putOnParameter.kt")
+        public void testPutOnParameter() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/inspectionsLocal/replacePutWithArrayAssignment/putOnParameter.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("putOnThis.kt")
+        public void testPutOnThis() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/inspectionsLocal/replacePutWithArrayAssignment/putOnThis.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("putOnVal.kt")
+        public void testPutOnVal() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/inspectionsLocal/replacePutWithArrayAssignment/putOnVal.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("putOnVar.kt")
+        public void testPutOnVar() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/inspectionsLocal/replacePutWithArrayAssignment/putOnVar.kt");
+            doTest(fileName);
+        }
+    }
+
     @TestMetadata("idea/testData/inspectionsLocal/replaceRangeToWithUntil")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)


### PR DESCRIPTION
Adds a `ReplacePutWithArrayAssignInspection` which converts expressions of `mutableMap.put(a,b)` to `mutableMap[a] = b`.