### PR TITLE
KT-21612 The "Remove redundant getter" inspection removes the type specifier

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantGetterInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantGetterInspection.kt
@@ -20,6 +20,7 @@ import com.intellij.codeInspection.*
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElementVisitor
 import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 
 class RedundantGetterInspection : AbstractKotlinInspection(), CleanupLocalInspectionTool {
     override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean, session: LocalInspectionToolSession): PsiElementVisitor {
@@ -61,6 +62,12 @@ private class RemoveRedundantGetterFix : LocalQuickFix {
 
     override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
         val accessor = descriptor.psiElement as? KtPropertyAccessor ?: return
+        val property = accessor.getStrictParentOfType<KtProperty>() ?: return
+
+        val accessorReturnType = accessor.returnTypeReference
+        if (accessorReturnType != null && property.typeReference == null && property.initializer == null)
+            property.typeReference = accessorReturnType
+
         accessor.delete()
     }
 }

--- a/idea/testData/inspectionsLocal/redundantGetter/hasType.kt
+++ b/idea/testData/inspectionsLocal/redundantGetter/hasType.kt
@@ -1,0 +1,4 @@
+interface Test {
+    val foo
+        <caret>get(): Int
+}

--- a/idea/testData/inspectionsLocal/redundantGetter/hasType.kt.after
+++ b/idea/testData/inspectionsLocal/redundantGetter/hasType.kt.after
@@ -1,0 +1,3 @@
+interface Test {
+    val foo: Int
+}

--- a/idea/testData/inspectionsLocal/redundantGetter/hasTypeWithPropertyExplicitType.kt
+++ b/idea/testData/inspectionsLocal/redundantGetter/hasTypeWithPropertyExplicitType.kt
@@ -1,0 +1,4 @@
+interface Test {
+    val foo: Int
+        <caret>get(): Int
+}

--- a/idea/testData/inspectionsLocal/redundantGetter/hasTypeWithPropertyExplicitType.kt.after
+++ b/idea/testData/inspectionsLocal/redundantGetter/hasTypeWithPropertyExplicitType.kt.after
@@ -1,0 +1,3 @@
+interface Test {
+    val foo: Int
+}

--- a/idea/testData/inspectionsLocal/redundantGetter/hasTypeWithPropertyInitializer.kt
+++ b/idea/testData/inspectionsLocal/redundantGetter/hasTypeWithPropertyInitializer.kt
@@ -1,0 +1,4 @@
+class Test {
+    val foo = 1
+        <caret>get(): Int = field
+}

--- a/idea/testData/inspectionsLocal/redundantGetter/hasTypeWithPropertyInitializer.kt.after
+++ b/idea/testData/inspectionsLocal/redundantGetter/hasTypeWithPropertyInitializer.kt.after
@@ -1,0 +1,3 @@
+class Test {
+    val foo = 1
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -1694,6 +1694,24 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
             doTest(fileName);
         }
 
+        @TestMetadata("hasType.kt")
+        public void testHasType() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/inspectionsLocal/redundantGetter/hasType.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("hasTypeWithPropertyExplicitType.kt")
+        public void testHasTypeWithPropertyExplicitType() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/inspectionsLocal/redundantGetter/hasTypeWithPropertyExplicitType.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("hasTypeWithPropertyInitializer.kt")
+        public void testHasTypeWithPropertyInitializer() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/inspectionsLocal/redundantGetter/hasTypeWithPropertyInitializer.kt");
+            doTest(fileName);
+        }
+
         @TestMetadata("notFieldExpression.kt")
         public void testNotFieldExpression() throws Exception {
             String fileName = KotlinTestUtils.navigationMetadata("idea/testData/inspectionsLocal/redundantGetter/notFieldExpression.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-21612