### PR TITLE
Remove unnecessary parameter null checks in JvmStatic delegate methods.

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/FunctionCodegen.java
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/FunctionCodegen.java
@@ -558,7 +558,7 @@ public class FunctionCodegen {
             mv.visitLabel(methodEntry);
             context.setMethodStartLabel(methodEntry);
 
-            if (!KotlinTypeMapper.isAccessor(functionDescriptor)) {
+            if (!strategy.skipNotNullAssertionsForParameters()) {
                 genNotNullAssertionsForParameters(new InstructionAdapter(mv), parentCodegen.state, functionDescriptor, frameMap);
             }
 
@@ -1382,6 +1382,11 @@ public class FunctionCodegen {
                         stackValue.put(delegateMethod.getReturnType(), iv);
 
                         iv.areturn(delegateMethod.getReturnType());
+                    }
+
+                    @Override
+                    public boolean skipNotNullAssertionsForParameters() {
+                        return false;
                     }
                 }
         );

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/FunctionGenerationStrategy.java
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/FunctionGenerationStrategy.java
@@ -34,6 +34,8 @@ public abstract class FunctionGenerationStrategy {
             @NotNull MemberCodegen<?> parentCodegen
     );
 
+    public abstract boolean skipNotNullAssertionsForParameters();
+
     public MethodVisitor wrapMethodVisitor(@NotNull MethodVisitor mv, int access, @NotNull String name, @NotNull String desc) {
         return mv;
     }
@@ -74,6 +76,12 @@ public abstract class FunctionGenerationStrategy {
         ) {
             ExpressionCodegen codegen = new ExpressionCodegen(mv, frameMap, signature.getReturnType(), context, state, parentCodegen);
             doGenerateBody(codegen, signature);
+        }
+
+        @Override
+        public boolean skipNotNullAssertionsForParameters() {
+            // Assume the strategy injects non-null checks for parameters by default
+            return false;
         }
 
         public abstract void doGenerateBody(@NotNull ExpressionCodegen codegen, @NotNull JvmMethodSignature signature);

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/ImplementationBodyCodegen.java
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/ImplementationBodyCodegen.java
@@ -671,6 +671,11 @@ public class ImplementationBodyCodegen extends ClassBodyCodegen {
                     }
                     iv.areturn(componentType);
                 }
+
+                @Override
+                public boolean skipNotNullAssertionsForParameters() {
+                    return false;
+                }
             });
         }
 
@@ -717,6 +722,11 @@ public class ImplementationBodyCodegen extends ClassBodyCodegen {
                     iv.invokespecial(thisDescriptorType.getInternalName(), "<init>", constructorAsmMethod.getDescriptor(), false);
 
                     iv.areturn(thisDescriptorType);
+                }
+
+                @Override
+                public boolean skipNotNullAssertionsForParameters() {
+                    return false;
                 }
 
                 private void pushCapturedFieldsOnStack(InstructionAdapter iv, MutableClosure closure) {

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/JvmStaticInCompanionObjectGenerator.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/JvmStaticInCompanionObjectGenerator.kt
@@ -44,6 +44,8 @@ class JvmStaticInCompanionObjectGenerator(
                 Synthetic(originElement, staticFunctionDescriptor),
                 staticFunctionDescriptor,
                 object : FunctionGenerationStrategy.CodegenBased(state) {
+                    override fun skipNotNullAssertionsForParameters(): Boolean = true
+
                     override fun doGenerateBody(codegen: ExpressionCodegen, signature: JvmMethodSignature) {
                         val iv = codegen.v
                         val classDescriptor = descriptor.containingDeclaration as ClassDescriptor

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/MemberCodegen.java
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/MemberCodegen.java
@@ -720,6 +720,11 @@ public abstract class MemberCodegen<T extends KtPureElement/* TODO: & KtDeclarat
                     Synthetic(null, original), accessor,
                     new FunctionGenerationStrategy.CodegenBased(state) {
                         @Override
+                        public boolean skipNotNullAssertionsForParameters() {
+                            return true;
+                        }
+
+                        @Override
                         public void doGenerateBody(@NotNull ExpressionCodegen codegen, @NotNull JvmMethodSignature signature) {
                             markLineNumberForElement(element.getPsiOrParent(), codegen.v);
 
@@ -778,6 +783,11 @@ public abstract class MemberCodegen<T extends KtPureElement/* TODO: & KtDeclarat
                     }
 
                     iv.areturn(signature.getReturnType());
+                }
+
+                @Override
+                public boolean skipNotNullAssertionsForParameters() {
+                    return true;
                 }
             }
 

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/MultifileClassCodegen.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/MultifileClassCodegen.kt
@@ -312,6 +312,10 @@ class MultifileClassCodegenImpl(
     }
 
     object DelegateToCompiledMemberGenerationStrategy : FunctionGenerationStrategy() {
+        override fun skipNotNullAssertionsForParameters(): kotlin.Boolean {
+            throw IllegalStateException("shouldn't be called")
+        }
+
         override fun generateBody(mv: MethodVisitor, frameMap: FrameMap, signature: JvmMethodSignature, context: MethodContext, parentCodegen: MemberCodegen<*>) {
             throw IllegalStateException("shouldn't be called")
         }

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/coroutines/CoroutineCodegen.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/coroutines/CoroutineCodegen.kt
@@ -531,6 +531,10 @@ class CoroutineCodegenForNamedFunction private constructor(
 private const val COROUTINE_LAMBDA_PARAMETER_PREFIX = "p$"
 
 private object FailingFunctionGenerationStrategy : FunctionGenerationStrategy() {
+    override fun skipNotNullAssertionsForParameters(): kotlin.Boolean {
+        error("This functions must not be called")
+    }
+
     override fun generateBody(
             mv: MethodVisitor,
             frameMap: FrameMap,

--- a/compiler/testData/codegen/bytecodeText/kt7188.kt
+++ b/compiler/testData/codegen/bytecodeText/kt7188.kt
@@ -1,0 +1,46 @@
+// WITH_RUNTIME
+// TARGET_BACKEND: JVM
+
+// FILE: Dummy.kt
+// Empty body to trigger multifile test mode
+
+// FILE: Test.kt
+class TestMethod {
+    companion object {
+        @JvmStatic
+        fun test(s0: String, s1: String?) = s0 + (s1 ?: "null")
+    }
+}
+
+class TestMethodOverloads {
+    companion object {
+        @JvmStatic
+        @JvmOverloads
+        fun test(s0: String = "s0", s1: String = "s1", s2: String = "s2") = s0 + s1 + s2
+    }
+}
+
+class TestProperty {
+    companion object {
+        @JvmStatic
+        var prop: String = "Blah"
+    }
+}
+
+class TestAccessor {
+    companion object {
+        var prop: String = "Blah" @JvmStatic set
+    }
+}
+
+// @TestMethod.class:
+// 0 INVOKESTATIC kotlin/jvm/internal/Intrinsics.checkParameterIsNotNull \(Ljava/lang/Object;Ljava/lang/String;\)V
+
+// @TestMethodOverloads.class:
+// 0 INVOKESTATIC kotlin/jvm/internal/Intrinsics.checkParameterIsNotNull \(Ljava/lang/Object;Ljava/lang/String;\)V
+
+// @TestProperty.class:
+// 0 INVOKESTATIC kotlin/jvm/internal/Intrinsics.checkParameterIsNotNull \(Ljava/lang/Object;Ljava/lang/String;\)V
+
+// @TestAccessor.class:
+// 0 INVOKESTATIC kotlin/jvm/internal/Intrinsics.checkParameterIsNotNull \(Ljava/lang/Object;Ljava/lang/String;\)V

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
@@ -282,6 +282,12 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
         doTest(fileName);
     }
 
+    @TestMetadata("kt7188.kt")
+    public void testKt7188() throws Exception {
+        String fileName = KotlinTestUtils.navigationMetadata("compiler/testData/codegen/bytecodeText/kt7188.kt");
+        doTest(fileName);
+    }
+
     @TestMetadata("kt7769.kt")
     public void testKt7769() throws Exception {
         String fileName = KotlinTestUtils.navigationMetadata("compiler/testData/codegen/bytecodeText/kt7769.kt");


### PR DESCRIPTION
Remove unnecessary non-null parameter checks inside static delegate methods
created for @JvmStatic companion object methods. Allows function generation
strategy decide if such checks need to be injected.

 #KT-7188 Fixed