### PR TITLE
KT-21726 "arrayOf can be replaced with literal" inspection quick fix produces incompilable result in presence of spread operator

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/ReplaceArrayOfWithLiteralInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/ReplaceArrayOfWithLiteralInspection.kt
@@ -44,7 +44,10 @@ class ReplaceArrayOfWithLiteralInspection : AbstractKotlinInspection() {
 
                 val parent = expression.parent
                 when (parent) {
-                    is KtValueArgument -> parent.parent.parent as? KtAnnotationEntry ?: return
+                    is KtValueArgument -> {
+                        if (parent.parent.parent !is KtAnnotationEntry) return
+                        if (parent.getSpreadElement() != null && !parent.isNamed()) return
+                    }
                     is KtParameter -> {
                         val constructor = parent.parent.parent as? KtPrimaryConstructor ?: return
                         val containingClass = constructor.getContainingClassOrObject()

--- a/idea/testData/inspectionsLocal/replaceArrayOfWithLiteral/unnamedVararg.kt
+++ b/idea/testData/inspectionsLocal/replaceArrayOfWithLiteral/unnamedVararg.kt
@@ -1,0 +1,7 @@
+// LANGUAGE_VERSION: 1.2
+// PROBLEM: none
+
+annotation class Some(vararg val strings: String)
+
+@Some(*<caret>arrayOf("alpha", "beta", "omega"))
+class My

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -2225,6 +2225,12 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
             doTest(fileName);
         }
 
+        @TestMetadata("unnamedVararg.kt")
+        public void testUnnamedVararg() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/inspectionsLocal/replaceArrayOfWithLiteral/unnamedVararg.kt");
+            doTest(fileName);
+        }
+
         @TestMetadata("vararg.kt")
         public void testVararg() throws Exception {
             String fileName = KotlinTestUtils.navigationMetadata("idea/testData/inspectionsLocal/replaceArrayOfWithLiteral/vararg.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-21726