### PR TITLE
KT-9934 Display Quick Documentation for reserved words

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/KotlinQuickDocumentationProvider.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/KotlinQuickDocumentationProvider.kt
@@ -23,7 +23,9 @@ import com.intellij.lang.documentation.AbstractDocumentationProvider
 import com.intellij.lang.documentation.DocumentationMarkup.*
 import com.intellij.lang.java.JavaDocumentationProvider
 import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.editor.Editor
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
 import com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.asJava.LightClassUtil
@@ -44,6 +46,7 @@ import org.jetbrains.kotlin.idea.resolve.frontendService
 import org.jetbrains.kotlin.js.resolve.diagnostics.findPsi
 import org.jetbrains.kotlin.kdoc.psi.api.KDoc
 import org.jetbrains.kotlin.kdoc.psi.impl.KDocSection
+import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.*
 import org.jetbrains.kotlin.renderer.AnnotationArgumentsRenderingPolicy
@@ -130,6 +133,10 @@ class WrapValueParameterHandler(val base: DescriptorRenderer.ValueParametersHand
 
 
 class KotlinQuickDocumentationProvider : AbstractDocumentationProvider() {
+
+    override fun getCustomDocumentationElement(editor: Editor, fil: PsiFile, contextElement: PsiElement?): PsiElement? {
+        return if (contextElement.isModifier()) contextElement else null
+    }
 
     override fun getQuickNavigateInfo(element: PsiElement?, originalElement: PsiElement?): String? {
         return if (element == null) null else getText(element, originalElement, true)
@@ -272,6 +279,11 @@ class KotlinQuickDocumentationProvider : AbstractDocumentationProvider() {
             } else if (element is KtLightDeclaration<*, *>) {
                 val origin = element.kotlinOrigin ?: return null
                 return renderKotlinDeclaration(origin, quickNavigation)
+            } else if (element.isModifier()) {
+                when(element.text) {
+                    KtTokens.LATEINIT_KEYWORD.value -> return """lateinit allows initializing a <a href="http://kotlinlang.org/docs/reference/properties.html#late-initialized-properties-and-variables">non-null property outside of a constructor</a>"""
+                    KtTokens.TAILREC_KEYWORD.value -> return """tailrec marks a function as <a href="http://kotlinlang.org/docs/reference/functions.html#tail-recursive-functions">tail-recursive</a> (allowing the compiler to replace recursion with iteration)"""
+                }
             }
 
             if (quickNavigation) {
@@ -479,5 +491,10 @@ class KotlinQuickDocumentationProvider : AbstractDocumentationProvider() {
                 else -> null
             }
         }
+
+        private fun PsiElement?.isModifier() = this != null
+                                               && parent is KtModifierList
+                                               && KtTokens.MODIFIER_KEYWORDS_ARRAY.firstOrNull { it.value == text } != null
+
     }
 }

--- a/idea/testData/editor/quickDoc/Lateinit.kt
+++ b/idea/testData/editor/quickDoc/Lateinit.kt
@@ -1,0 +1,5 @@
+class Foo {
+    <caret>lateinit var foo: String
+}
+
+//INFO: lateinit allows initializing a <a href="http://kotlinlang.org/docs/reference/properties.html#late-initialized-properties-and-variables">non-null property outside of a constructor</a>

--- a/idea/testData/editor/quickDoc/LateinitName.kt
+++ b/idea/testData/editor/quickDoc/LateinitName.kt
@@ -1,0 +1,5 @@
+class Foo {
+    val <caret>lateinit: String = ""
+}
+
+//INFO: <div class='definition'><pre><a href="psi_element://Foo"><code>Foo</code></a><br>public final val <b>lateinit</b>: String</pre></div>

--- a/idea/testData/editor/quickDoc/Tailrec.kt
+++ b/idea/testData/editor/quickDoc/Tailrec.kt
@@ -1,0 +1,5 @@
+<caret>tailrec fun foo() {
+    foo()
+}
+
+//INFO: tailrec marks a function as <a href="http://kotlinlang.org/docs/reference/functions.html#tail-recursive-functions">tail-recursive</a> (allowing the compiler to replace recursion with iteration)

--- a/idea/testData/editor/quickDoc/TailrecName.kt
+++ b/idea/testData/editor/quickDoc/TailrecName.kt
@@ -1,0 +1,5 @@
+class Foo {
+    val <caret>tailrec: String = ""
+}
+
+//INFO: <div class='definition'><pre><a href="psi_element://Foo"><code>Foo</code></a><br>public final val <b>tailrec</b>: String</pre></div>

--- a/idea/tests/org/jetbrains/kotlin/idea/editor/quickDoc/QuickDocProviderTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/editor/quickDoc/QuickDocProviderTestGenerated.java
@@ -129,6 +129,16 @@ public class QuickDocProviderTestGenerated extends AbstractQuickDocProviderTest 
         runTest("idea/testData/editor/quickDoc/KotlinPackageClassUsedFromJava.java");
     }
 
+    @TestMetadata("Lateinit.kt")
+    public void testLateinit() throws Exception {
+        runTest("idea/testData/editor/quickDoc/Lateinit.kt");
+    }
+
+    @TestMetadata("LateinitName.kt")
+    public void testLateinitName() throws Exception {
+        runTest("idea/testData/editor/quickDoc/LateinitName.kt");
+    }
+
     @TestMetadata("MethodFromStdLib.kt")
     public void testMethodFromStdLib() throws Exception {
         runTest("idea/testData/editor/quickDoc/MethodFromStdLib.kt");
@@ -247,6 +257,16 @@ public class QuickDocProviderTestGenerated extends AbstractQuickDocProviderTest 
     @TestMetadata("Samples.kt")
     public void testSamples() throws Exception {
         runTest("idea/testData/editor/quickDoc/Samples.kt");
+    }
+
+    @TestMetadata("Tailrec.kt")
+    public void testTailrec() throws Exception {
+        runTest("idea/testData/editor/quickDoc/Tailrec.kt");
+    }
+
+    @TestMetadata("TailrecName.kt")
+    public void testTailrecName() throws Exception {
+        runTest("idea/testData/editor/quickDoc/TailrecName.kt");
     }
 
     @TestMetadata("TopLevelMethodFromJava.java")


### PR DESCRIPTION
 #KT-9934 Fixed

@semoro 
As we discussed at Slack, I let you implement the part for reading documentation from resources. 

https://youtrack.jetbrains.com/issue/KT-9934