### PR TITLE
README: IntelliJ IDEA 2017.3 is not early access anymore

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -85,7 +85,7 @@ Refer to [libraries/ReadMe.md](libraries/ReadMe.md) for details.
 
 ## Working with the project in IntelliJ IDEA
 
-Working with the Kotlin project requires IntelliJ IDEA 2017.3. You can download an Early Access Preview version of IntelliJ IDEA 2017.3 [here](https://www.jetbrains.com/idea/nextversion/).
+Working with the Kotlin project requires IntelliJ IDEA 2017.3. You can download IntelliJ IDEA 2017.3 [here](https://www.jetbrains.com/idea/download).
 
 To import the project in Intellij choose project directory in Open project dialog. Then, after project opened, Select 
 `File` -> `New...` -> `Module from Existing Sources` in the menu, and select `build.gradle.kts` file in the project's root folder.


### PR DESCRIPTION
update README.md with direct download link to IntelliJ IDEA latest version