### PR TITLE
KT-22038 Inspection to replace the usage of Java Collections methods on subtypes of MutableList with the methods from Kotlin stdlib

### DIFF
--- a/idea/testData/inspectionsLocal/javaCollectionsStaticMethod/sortArrayList.kt
+++ b/idea/testData/inspectionsLocal/javaCollectionsStaticMethod/sortArrayList.kt
@@ -1,0 +1,7 @@
+// RUNTIME_WITH_FULL_JDK
+import java.util.*
+
+fun test () {
+    val list: ArrayList<Int> = ArrayList()
+    <caret>Collections.sort(list)
+}

--- a/idea/testData/inspectionsLocal/javaCollectionsStaticMethod/sortArrayList.kt.after
+++ b/idea/testData/inspectionsLocal/javaCollectionsStaticMethod/sortArrayList.kt.after
@@ -1,0 +1,7 @@
+// RUNTIME_WITH_FULL_JDK
+import java.util.*
+
+fun test () {
+    val list: ArrayList<Int> = ArrayList()
+    list.sort()
+}

--- a/idea/testData/inspectionsLocal/javaCollectionsStaticMethod/sortLinkedList.kt
+++ b/idea/testData/inspectionsLocal/javaCollectionsStaticMethod/sortLinkedList.kt
@@ -1,0 +1,7 @@
+// RUNTIME_WITH_FULL_JDK
+import java.util.*
+
+fun test () {
+    val list: LinkedList<String> = LinkedList()
+    <caret>Collections.sort(list)
+}

--- a/idea/testData/inspectionsLocal/javaCollectionsStaticMethod/sortLinkedList.kt.after
+++ b/idea/testData/inspectionsLocal/javaCollectionsStaticMethod/sortLinkedList.kt.after
@@ -1,0 +1,7 @@
+// RUNTIME_WITH_FULL_JDK
+import java.util.*
+
+fun test () {
+    val list: LinkedList<String> = LinkedList()
+    list.sort()
+}

--- a/idea/testData/inspectionsLocal/javaCollectionsStaticMethod/sortVector.kt
+++ b/idea/testData/inspectionsLocal/javaCollectionsStaticMethod/sortVector.kt
@@ -1,0 +1,7 @@
+// RUNTIME_WITH_FULL_JDK
+import java.util.*
+
+fun test () {
+    val list: Vector<String> = Vector()
+    <caret>Collections.sort(list)
+}

--- a/idea/testData/inspectionsLocal/javaCollectionsStaticMethod/sortVector.kt.after
+++ b/idea/testData/inspectionsLocal/javaCollectionsStaticMethod/sortVector.kt.after
@@ -1,0 +1,7 @@
+// RUNTIME_WITH_FULL_JDK
+import java.util.*
+
+fun test () {
+    val list: Vector<String> = Vector()
+    list.sort()
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -1545,9 +1545,27 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
             doTest(fileName);
         }
 
+        @TestMetadata("sortArrayList.kt")
+        public void testSortArrayList() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/inspectionsLocal/javaCollectionsStaticMethod/sortArrayList.kt");
+            doTest(fileName);
+        }
+
         @TestMetadata("sortImmutableList.kt")
         public void testSortImmutableList() throws Exception {
             String fileName = KotlinTestUtils.navigationMetadata("idea/testData/inspectionsLocal/javaCollectionsStaticMethod/sortImmutableList.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("sortLinkedList.kt")
+        public void testSortLinkedList() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/inspectionsLocal/javaCollectionsStaticMethod/sortLinkedList.kt");
+            doTest(fileName);
+        }
+
+        @TestMetadata("sortVector.kt")
+        public void testSortVector() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/inspectionsLocal/javaCollectionsStaticMethod/sortVector.kt");
             doTest(fileName);
         }
 


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-22038