### PR TITLE
Add `zip().toMap()` shortcut to Iterable, for `Iterable` and `Sequence` parameters

### DIFF
--- a/libraries/stdlib/src/generated/_Collections.kt
+++ b/libraries/stdlib/src/generated/_Collections.kt
@@ -957,11 +957,39 @@ public fun Collection<Short>.toShortArray(): ShortArray {
 }
 
 /**
+ * Returns a [Map] containing the elements from this [Iterable] as keys
+ * and the elements from the other [Iterable], as values.
+ *
+ * If any of two pairs would have the same key, the last one gets added to the map.
+ *
+ * The returned map preserves the entry iteration order of the original collection.
+ */
+public infix fun <K, V> Iterable<K>.associateWith(values: Iterable<V>): Map<K, V> =
+    associateWith(this, values.iterator())
+
+/**
+ * Returns a [Map] containing the elements from this [Iterable] as keys
+ * and the elements from the [Sequence], as values.
+ *
+ * If any of two pairs would have the same key, the last one gets added to the map.
+ *
+ * The returned map preserves the entry iteration order of the original collection.
+ */
+public infix fun <K, V> Iterable<K>.associateWith(values: Sequence<V>): Map<K, V> =
+    associateWith(this, values.iterator())
+
+private fun <K, V> associateWith(keys: Iterable<K>, values: Iterator<V>): LinkedHashMap<K, V> {
+    val destination = LinkedHashMap<K, V>(mapCapacity(keys.collectionSizeOrDefault(10)).coerceAtLeast(16))
+    keys.forEach { destination[it] = values.next() }
+    return destination
+}
+
+/**
  * Returns a [Map] containing key-value pairs provided by [transform] function
  * applied to elements of the given collection.
- * 
+ *
  * If any of two pairs would have the same key the last one gets added to the map.
- * 
+ *
  * The returned map preserves the entry iteration order of the original collection.
  */
 public inline fun <T, K, V> Iterable<T>.associate(transform: (T) -> Pair<K, V>): Map<K, V> {

--- a/libraries/stdlib/test/collections/MapTest.kt
+++ b/libraries/stdlib/test/collections/MapTest.kt
@@ -257,6 +257,34 @@ class MapTest {
         assertEquals("CCC", map[3])
     }
 
+    @Test fun createWithOtherIterable() {
+        val keys = listOf("a", "b")
+        val map = keys associateWith keys.indices
+        assertEquals(mapOf("a" to 0, "b" to 1), map)
+    }
+
+    @Test fun createWithOtherIterableThatIsBigger() {
+        val map = listOf("a", "b") associateWith 10..20
+        assertEquals(mapOf("a" to 10, "b" to 11), map)
+    }
+
+    @Test fun createWithOtherIterableThatIsSmaller() {
+        assertFailsWith<NoSuchElementException> {
+            listOf("a") associateWith emptyList<Int>()
+        }
+    }
+
+    @Test fun createWithOtherInfiniteSequence() {
+        val map = listOf("a", "b") associateWith generateSequence { 0 }
+        assertEquals(mapOf("a" to 0, "b" to 0), map)
+    }
+
+    @Test fun createWithOtherSequenceThatIsSmaller() {
+        assertFailsWith<NoSuchElementException> {
+            listOf("a") associateWith generateSequence { null }
+        }
+    }
+
     @Test fun createWithPairSelector() {
         val map = listOf("a", "bb", "ccc").associate { it.length to it.toUpperCase() }
         assertEquals(3, map.size)


### PR DESCRIPTION
Fixes: https://youtrack.jetbrains.com/issue/KT-21587
I understood this is not yet final, thought an example may help.
