### PR TITLE
Add Sets.emptySet sample

### DIFF
--- a/libraries/stdlib/samples/test/samples/collections/sets.kt
+++ b/libraries/stdlib/samples/test/samples/collections/sets.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2010-2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package samples.collections
+
+import samples.*
+import kotlin.test.*
+
+@RunWith(Enclosed::class)
+class Sets {
+
+    class Usage {
+
+        @Sample
+        fun emptyReadOnlySet() {
+            val set = setOf<String>()
+            assertTrue(set.isEmpty())
+
+            // another way to create an empty set,
+            // type parameter is inferred from the expected type
+            val other: Set<Int> = emptySet()
+
+            assertTrue(set == other, "Empty sets are equal")
+            assertPrints(set, "[]")
+        }
+    }
+}

--- a/libraries/stdlib/samples/test/samples/collections/sets.kt
+++ b/libraries/stdlib/samples/test/samples/collections/sets.kt
@@ -22,19 +22,16 @@ import kotlin.test.*
 @RunWith(Enclosed::class)
 class Sets {
 
-    class Usage {
+    @Sample
+    fun emptyReadOnlySet() {
+        val set = setOf<String>()
+        assertTrue(set.isEmpty())
 
-        @Sample
-        fun emptyReadOnlySet() {
-            val set = setOf<String>()
-            assertTrue(set.isEmpty())
+        // another way to create an empty set,
+        // type parameter is inferred from the expected type
+        val other: Set<Int> = emptySet()
 
-            // another way to create an empty set,
-            // type parameter is inferred from the expected type
-            val other: Set<Int> = emptySet()
-
-            assertTrue(set == other, "Empty sets are equal")
-            assertPrints(set, "[]")
-        }
+        assertTrue(set == other, "Empty sets are equal")
+        assertPrints(set, "[]")
     }
 }

--- a/libraries/stdlib/src/kotlin/collections/Sets.kt
+++ b/libraries/stdlib/src/kotlin/collections/Sets.kt
@@ -22,7 +22,10 @@ internal object EmptySet : Set<Nothing>, Serializable {
 }
 
 
-/** Returns an empty read-only set.  The returned set is serializable (JVM). */
+/**
+ * Returns an empty read-only set.  The returned set is serializable (JVM).
+ * @sample samples.collections.Sets.Usage.emptyReadOnlySet
+ */
 public fun <T> emptySet(): Set<T> = EmptySet
 /**
  * Returns a new read-only set with the given elements.
@@ -31,7 +34,10 @@ public fun <T> emptySet(): Set<T> = EmptySet
  */
 public fun <T> setOf(vararg elements: T): Set<T> = if (elements.size > 0) elements.toSet() else emptySet()
 
-/** Returns an empty read-only set.  The returned set is serializable (JVM). */
+/**
+ * Returns an empty read-only set.  The returned set is serializable (JVM).
+ * @sample samples.collections.Sets.Usage.emptyReadOnlySet
+ */
 @kotlin.internal.InlineOnly
 public inline fun <T> setOf(): Set<T> = emptySet()
 

--- a/libraries/stdlib/src/kotlin/collections/Sets.kt
+++ b/libraries/stdlib/src/kotlin/collections/Sets.kt
@@ -24,7 +24,7 @@ internal object EmptySet : Set<Nothing>, Serializable {
 
 /**
  * Returns an empty read-only set.  The returned set is serializable (JVM).
- * @sample samples.collections.Sets.Usage.emptyReadOnlySet
+ * @sample samples.collections.Sets.emptyReadOnlySet
  */
 public fun <T> emptySet(): Set<T> = EmptySet
 /**
@@ -36,7 +36,7 @@ public fun <T> setOf(vararg elements: T): Set<T> = if (elements.size > 0) elemen
 
 /**
  * Returns an empty read-only set.  The returned set is serializable (JVM).
- * @sample samples.collections.Sets.Usage.emptyReadOnlySet
+ * @sample samples.collections.Sets.emptyReadOnlySet
  */
 @kotlin.internal.InlineOnly
 public inline fun <T> setOf(): Set<T> = emptySet()


### PR DESCRIPTION
As a part of the work needed for the [Provide samples for all standard library functions issue](https://youtrack.jetbrains.com/issue/KT-20357), I have added a sample for the `Sets.emptySet()` and the `Sets.setOf()` functions.