### PR TITLE
Log standard error only on exit status error

### DIFF
--- a/compiler/tests-common/tests/org/jetbrains/kotlin/integration/KotlinIntegrationTestBase.java
+++ b/compiler/tests-common/tests/org/jetbrains/kotlin/integration/KotlinIntegrationTestBase.java
@@ -83,6 +83,8 @@ public abstract class KotlinIntegrationTestBase extends TestCaseWithTmpdir {
         content = content.replaceAll(Pattern.quote(KotlinCompilerVersion.VERSION), "[KotlinVersion]");
         content = content.replaceAll("\\(JRE .+\\)", "(JRE [JREVersion])");
         content = StringUtil.convertLineSeparators(content);
+        content = content.replaceAll("\n.*Picked up [_A-Z]+:.*\n", "\n");
+        content = content.replaceFirst("\nERR:\n\nReturn code:", "\nReturn code:");
         return content;
     }
 


### PR DESCRIPTION
Do not store process standard error messages into execution
log if the process exit code does not indicate an error. Such
messages are warning or important information, not errors, they
should not trigger failures.

FIX KT-22241