### PR TITLE
KT-22042

### DIFF
--- a/libraries/stdlib/src/kotlin/text/Strings.kt
+++ b/libraries/stdlib/src/kotlin/text/Strings.kt
@@ -807,12 +807,25 @@ private fun CharSequence.findAnyOf(chars: CharArray, startIndex: Int, ignoreCase
         return if (index < 0) -1 else index
     }
 
-    val indices = if (!last) startIndex.coerceAtLeast(0)..lastIndex else startIndex.coerceAtMost(lastIndex) downTo 0
-    for (index in indices) {
-        val charAtIndex = get(index)
-        val matchingCharIndex = chars.indexOfFirst { it.equals(charAtIndex, ignoreCase) }
-        if (matchingCharIndex >= 0)
-            return index
+    // Split it to two loops to avoid implicit IntRange allocation
+    when (last) {
+        true -> {
+            for (index in startIndex.coerceAtMost(lastIndex) downTo 0) {
+                val charAtIndex = get(index)
+                val matchingCharIndex = chars.indexOfFirst { it.equals(charAtIndex, ignoreCase) }
+                if (matchingCharIndex >= 0)
+                    return index
+            }
+        }
+
+        false -> {
+            for (index in startIndex.coerceAtLeast(0)..lastIndex) {
+                val charAtIndex = get(index)
+                val matchingCharIndex = chars.indexOfFirst { it.equals(charAtIndex, ignoreCase) }
+                if (matchingCharIndex >= 0)
+                    return index
+            }
+        }
     }
 
     return -1

--- a/libraries/stdlib/src/kotlin/text/Strings.kt
+++ b/libraries/stdlib/src/kotlin/text/Strings.kt
@@ -800,11 +800,11 @@ public fun CharSequence.commonSuffixWith(other: CharSequence, ignoreCase: Boolea
 
 // indexOfAny()
 
-private fun CharSequence.findAnyOf(chars: CharArray, startIndex: Int, ignoreCase: Boolean, last: Boolean): Pair<Int, Char>? {
+private fun CharSequence.findAnyOf(chars: CharArray, startIndex: Int, ignoreCase: Boolean, last: Boolean): Int {
     if (!ignoreCase && chars.size == 1 && this is String) {
         val char = chars.single()
         val index = if (!last) nativeIndexOf(char, startIndex) else nativeLastIndexOf(char, startIndex)
-        return if (index < 0) null else index to char
+        return if (index < 0) -1 else index
     }
 
     val indices = if (!last) startIndex.coerceAtLeast(0)..lastIndex else startIndex.coerceAtMost(lastIndex) downTo 0
@@ -812,10 +812,10 @@ private fun CharSequence.findAnyOf(chars: CharArray, startIndex: Int, ignoreCase
         val charAtIndex = get(index)
         val matchingCharIndex = chars.indexOfFirst { it.equals(charAtIndex, ignoreCase) }
         if (matchingCharIndex >= 0)
-            return index to chars[matchingCharIndex]
+            return index
     }
 
-    return null
+    return -1
 }
 
 /**
@@ -827,7 +827,7 @@ private fun CharSequence.findAnyOf(chars: CharArray, startIndex: Int, ignoreCase
  *
  */
 public fun CharSequence.indexOfAny(chars: CharArray, startIndex: Int = 0, ignoreCase: Boolean = false): Int =
-    findAnyOf(chars, startIndex, ignoreCase, last = false)?.first ?: -1
+    findAnyOf(chars, startIndex, ignoreCase, last = false)
 
 /**
  * Finds the index of the last occurrence of any of the specified [chars] in this char sequence,
@@ -839,7 +839,7 @@ public fun CharSequence.indexOfAny(chars: CharArray, startIndex: Int = 0, ignore
  *
  */
 public fun CharSequence.lastIndexOfAny(chars: CharArray, startIndex: Int = lastIndex, ignoreCase: Boolean = false): Int =
-    findAnyOf(chars, startIndex, ignoreCase, last = true)?.first ?: -1
+    findAnyOf(chars, startIndex, ignoreCase, last = true)
 
 
 private fun CharSequence.indexOf(other: CharSequence, startIndex: Int, endIndex: Int, ignoreCase: Boolean, last: Boolean = false): Int {
@@ -1109,7 +1109,8 @@ private class DelimitedRangesSequence(private val input: CharSequence, private v
 private fun CharSequence.rangesDelimitedBy(delimiters: CharArray, startIndex: Int = 0, ignoreCase: Boolean = false, limit: Int = 0): Sequence<IntRange> {
     require(limit >= 0, { "Limit must be non-negative, but was $limit." })
 
-    return DelimitedRangesSequence(this, startIndex, limit, { startIndex -> findAnyOf(delimiters, startIndex, ignoreCase = ignoreCase, last = false)?.let { it.first to 1 } })
+    return DelimitedRangesSequence(this, startIndex, limit, { startIndex ->
+        findAnyOf(delimiters, startIndex, ignoreCase = ignoreCase, last = false).let { if (it == -1) null else it to 1 } })
 }
 
 


### PR DESCRIPTION
Performance fix for KT-22042.
Performance data on android (emulated by `-XX:TieredStopAtLevel=1`) looks impressive,

Before
```
Benchmark                                      Mode  Cnt     Score    Error   Units
AnyOfBenchmark.indexOfAny                      avgt   20    36.251 ±  0.697   ns/op
AnyOfBenchmark.indexOfAny:·gc.alloc.rate       avgt   20   656.478 ± 12.139  MB/sec
AnyOfBenchmark.indexOfAny:·gc.alloc.rate.norm  avgt   20    24.944 ±  0.002    B/op
```

After
```
Benchmark                                      Mode  Cnt   Score    Error   Units
AnyOfBenchmark.indexOfAny                      avgt   20  20.041 ±  1.723   ns/op
AnyOfBenchmark.indexOfAny:·gc.alloc.rate       avgt   20  ≈ 10⁻³           MB/sec
AnyOfBenchmark.indexOfAny:·gc.alloc.rate.norm  avgt   20  ≈ 10⁻⁵             B/op
```

Benchmark 
```
    private val haystack = "haystack"
    private val needles = listOf("_", "!")

    @Benchmark
    fun indexOfAny(): Int {
        return haystack.lastIndexOfAny(needles, 0)
    }
```

I didn't touch `findAnyOf` which receives `Collection<String>` as parameter because it already looks complicated enough due to `instance of String` check.
One of the solutions may be to inline `findAnyOf` into `indexOfAny`/`lastIndexOfAny`, eliminate pair allocation and eliminate range allocation without switches because `last` will be inlined as well, but it will introduce additional code duplication. If you think it's okay I can fix it in this branch.

I've ran only tests for stdlib, which seems to fully cover changed methods, but I'm not sure whether it's enough
