### PR TITLE
KT-16661

### DIFF
--- a/libraries/stdlib/src/kotlin/text/Strings.kt
+++ b/libraries/stdlib/src/kotlin/text/Strings.kt
@@ -1222,10 +1222,8 @@ private fun CharSequence.split(delimiter: String, ignoreCase: Boolean, limit: In
         if (!isLimited || result.size < limit - 1) {
             result.add(substring(currentOffset, nextIndex))
             currentOffset = nextIndex + delimiter.length
-            nextIndex = indexOf(delimiter, currentOffset, ignoreCase)
-        } else {
-            result.add(substring(currentOffset, length))
-            return result
+            // Do not search for next occurrence if we're reaching limit
+            nextIndex = if (result.size == limit - 1) -1 else indexOf(delimiter, currentOffset, ignoreCase)
         }
     }
 

--- a/libraries/stdlib/src/kotlin/text/Strings.kt
+++ b/libraries/stdlib/src/kotlin/text/Strings.kt
@@ -1218,19 +1218,14 @@ private fun CharSequence.split(delimiter: String, ignoreCase: Boolean, limit: In
 
     val isLimited = limit > 0
     val result = ArrayList<String>(if (isLimited) limit.coerceAtMost(10) else 10)
-    while (nextIndex != -1) {
-        if (!isLimited || result.size < limit - 1) {
-            result.add(substring(currentOffset, nextIndex))
-            currentOffset = nextIndex + delimiter.length
-            // Do not search for next occurrence if we're reaching limit
-            nextIndex = if (result.size == limit - 1) -1 else indexOf(delimiter, currentOffset, ignoreCase)
-        }
+    while (nextIndex != -1 && (!isLimited || result.size < limit - 1)) {
+        result.add(substring(currentOffset, nextIndex))
+        currentOffset = nextIndex + delimiter.length
+        // Do not search for next occurrence if we're reaching limit
+        nextIndex = if (result.size == limit - 1) break else indexOf(delimiter, currentOffset, ignoreCase)
     }
 
-    if (!isLimited || result.size < limit) {
-        result.add(substring(currentOffset, length))
-    }
-
+    result.add(substring(currentOffset, length))
     return result
 }
 

--- a/libraries/stdlib/src/kotlin/text/Strings.kt
+++ b/libraries/stdlib/src/kotlin/text/Strings.kt
@@ -1213,7 +1213,8 @@ private fun CharSequence.split(delimiter: String, ignoreCase: Boolean, limit: In
     var currentOffset = 0
     var nextIndex = indexOf(delimiter, currentOffset, ignoreCase)
     val isLimited = limit > 0
-    val result = ArrayList<String>()
+    // This condition cannot be moved inside of ctor call because it will kill laziness of internal array allocation
+    val result = if (isLimited) ArrayList<String>(limit.coerceAtMost(10)) else ArrayList<String>()
 
     while (nextIndex != -1) {
         if (!isLimited || result.size < limit - 1) {

--- a/libraries/stdlib/src/kotlin/text/Strings.kt
+++ b/libraries/stdlib/src/kotlin/text/Strings.kt
@@ -1163,8 +1163,16 @@ public fun CharSequence.splitToSequence(vararg delimiters: String, ignoreCase: B
  * the beginning to the end of this string, and matches at each position the first element in [delimiters]
  * that is equal to a delimiter in this instance at that position.
  */
-public fun CharSequence.split(vararg delimiters: String, ignoreCase: Boolean = false, limit: Int = 0): List<String> =
-        rangesDelimitedBy(delimiters, ignoreCase = ignoreCase, limit = limit).asIterable().map { substring(it) }
+public fun CharSequence.split(vararg delimiters: String, ignoreCase: Boolean = false, limit: Int = 0): List<String> {
+    if (delimiters.size == 1) {
+        val delimiter = delimiters[0]
+        if (!delimiter.isEmpty()) {
+            return split(delimiters[0], ignoreCase, limit)
+        }
+    }
+
+    return rangesDelimitedBy(delimiters, ignoreCase = ignoreCase, limit = limit).asIterable().map { substring(it) }
+}
 
 /**
  * Splits this char sequence to a sequence of strings around occurrences of the specified [delimiters].
@@ -1183,8 +1191,51 @@ public fun CharSequence.splitToSequence(vararg delimiters: Char, ignoreCase: Boo
  * @param ignoreCase `true` to ignore character case when matching a delimiter. By default `false`.
  * @param limit The maximum number of substrings to return.
  */
-public fun CharSequence.split(vararg delimiters: Char, ignoreCase: Boolean = false, limit: Int = 0): List<String> =
-        rangesDelimitedBy(delimiters, ignoreCase = ignoreCase, limit = limit).asIterable().map { substring(it) }
+public fun CharSequence.split(vararg delimiters: Char, ignoreCase: Boolean = false, limit: Int = 0): List<String> {
+    if (delimiters.size == 1) {
+        return split(delimiters[0].toString(), ignoreCase, limit)
+    }
+
+    return rangesDelimitedBy(delimiters, ignoreCase = ignoreCase, limit = limit).asIterable().map { substring(it) }
+}
+
+/**
+ * Splits this char sequence to a list of strings around occurrences of the specified [delimiter].
+ * This is specialized version of split which receives single non-empty delimiter and offers better performance
+ *
+ * @param delimiter String used as delimiter
+ * @param ignoreCase `true` to ignore character case when matching a delimiter. By default `false`.
+ * @param limit The maximum number of substrings to return.
+ */
+private fun CharSequence.split(delimiter: String, ignoreCase: Boolean, limit: Int): List<String> {
+    var currentOffset = 0
+    var nextIndex = indexOf(delimiter, currentOffset, ignoreCase)
+    val isLimited = limit > 0
+    val result = ArrayList<String>()
+
+    while (nextIndex != -1) {
+        if (!isLimited || result.size < limit - 1) {
+            result.add(substring(currentOffset, nextIndex))
+            currentOffset = nextIndex + delimiter.length
+            nextIndex = indexOf(delimiter, currentOffset, ignoreCase)
+        } else {
+            result.add(substring(currentOffset, length))
+            currentOffset = length
+            break
+        }
+    }
+
+    if (currentOffset == 0) {
+        result.add(this.toString())
+        return result
+    }
+
+    if (!isLimited || result.size < limit) {
+        result.add(substring(currentOffset, length))
+    }
+
+    return result
+}
 
 /**
  * Splits this char sequence around matches of the given regular expression.

--- a/libraries/stdlib/src/kotlin/text/Strings.kt
+++ b/libraries/stdlib/src/kotlin/text/Strings.kt
@@ -1208,6 +1208,8 @@ public fun CharSequence.split(vararg delimiters: Char, ignoreCase: Boolean = fal
  * @param limit The maximum number of substrings to return.
  */
 private fun CharSequence.split(delimiter: String, ignoreCase: Boolean, limit: Int): List<String> {
+    require(limit >= 0, { "Limit must be non-negative, but was $limit." })
+
     var currentOffset = 0
     var nextIndex = indexOf(delimiter, currentOffset, ignoreCase)
     val isLimited = limit > 0

--- a/libraries/stdlib/src/kotlin/text/Strings.kt
+++ b/libraries/stdlib/src/kotlin/text/Strings.kt
@@ -1226,8 +1226,10 @@ private fun CharSequence.split(delimiter: String, ignoreCase: Boolean, limit: In
     }
 
     if (currentOffset == 0) {
-        result.add(this.toString())
-        return result
+        // If no matches found return single element list
+        // instead of triggering allocation of underlying array in 'result'
+        // Speedup is ~15% for small string
+        return listOf(this.toString())
     }
 
     if (!isLimited || result.size < limit) {

--- a/libraries/stdlib/test/text/StringTest.kt
+++ b/libraries/stdlib/test/text/StringTest.kt
@@ -558,6 +558,15 @@ class StringTest {
         assertEquals(listOf(singleLine.toString()), singleLine.lines())
     }
 
+    @Test fun splitIllegalLimit() = withOneCharSequenceArg("test string") { string ->
+        assertFailsWith<IllegalArgumentException> { string.split(*arrayOf<String>(), limit = -1) }
+        assertFailsWith<IllegalArgumentException> { string.split(*charArrayOf(), limit = -2) }
+        assertFailsWith<IllegalArgumentException> { string.split("", limit = -3) }
+        assertFailsWith<IllegalArgumentException> { string.split('3', limit = -4) }
+        assertFailsWith<IllegalArgumentException> { string.split("1", limit = -5) }
+        assertFailsWith<IllegalArgumentException> { string.split('4', '1', limit = -6) }
+        assertFailsWith<IllegalArgumentException> { string.split("5", "9", limit = -7) }
+    }
 
     @Test fun indexOfAnyChar() = withOneCharSequenceArg("abracadabra") { string ->
         val chars = charArrayOf('d', 'b')

--- a/libraries/stdlib/test/text/StringTest.kt
+++ b/libraries/stdlib/test/text/StringTest.kt
@@ -533,6 +533,9 @@ class StringTest {
         assertEquals(listOf("", "a", "b", "c", ""), (+"abc").split(""))
         assertEquals(listOf("", "a", "b", "b", "a", ""), (+"abba").split("", "a"))
         assertEquals(listOf("", "", "b", "b", "", ""), (+"abba").split("a", ""))
+        assertEquals(listOf("", "bb", ""), (+"abba").split("a", "c"))
+        assertEquals(listOf("", "bb", ""), (+"abba").split('a', 'c'))
+
     }
 
     @Test fun splitSingleDelimiter() = withOneCharSequenceArg { arg1 ->
@@ -543,10 +546,18 @@ class StringTest {
         assertEquals(listOf("abc", "def", "123,456"), (+"abc,def,123,456").split(',', limit = 3))
         assertEquals(listOf("abc", "def", "123,456"), (+"abc,def,123,456").split(",", limit = 3))
 
+        assertEquals(listOf("abc", "def", "123,456,789"), (+"abc,def,123,456,789").split(',', limit = 3))
+        assertEquals(listOf("abc", "def", "123,456,789"), (+"abc,def,123,456,789").split(",", limit = 3))
+
+        assertEquals(listOf("abc", "def", "123,456,789,"), (+"abc,def,123,456,789,").split(',', limit = 3))
+        assertEquals(listOf("abc", "def", "123,456,789,"), (+"abc,def,123,456,789,").split(",", limit = 3))
+
         assertEquals(listOf("abc", "def", "123", "456"), (+"abc<BR>def<br>123<bR>456").split("<BR>", ignoreCase = true))
         assertEquals(listOf("abc", "def<br>123<bR>456"), (+"abc<BR>def<br>123<bR>456").split("<BR>", ignoreCase = false))
 
         assertEquals(listOf("a", "b", "c"), (+"a*b*c").split("*"))
+        assertEquals(listOf("", "bb", ""), (+"abba").split("a"))
+        assertEquals(listOf("", "bb", ""), (+"abba").split('a'))
     }
 
     @Test fun splitToLines() = withOneCharSequenceArg { arg1 ->

--- a/libraries/stdlib/test/text/StringTest.kt
+++ b/libraries/stdlib/test/text/StringTest.kt
@@ -527,13 +527,26 @@ class StringTest {
         assertEquals(listOf("test"), (+"test").split(*arrayOf<String>()), "empty list of delimiters, none matched -> entire string returned")
 
         assertEquals(listOf("abc", "def", "123;456"), (+"abc;def,123;456").split(';', ',', limit = 3))
-        assertEquals(listOf("abc", "def", "123", "456"), (+"abc<BR>def<br>123<bR>456").split("<BR>", ignoreCase = true))
 
         assertEquals(listOf("abc", "def", "123", "456"), (+"abc=-def==123=456").split("==", "=-", "="))
 
         assertEquals(listOf("", "a", "b", "c", ""), (+"abc").split(""))
         assertEquals(listOf("", "a", "b", "b", "a", ""), (+"abba").split("", "a"))
         assertEquals(listOf("", "", "b", "b", "", ""), (+"abba").split("a", ""))
+    }
+
+    @Test fun splitSingleDelimiter() = withOneCharSequenceArg { arg1 ->
+        operator fun String.unaryPlus(): CharSequence = arg1(this)
+
+        assertEquals(listOf(""), (+"").split(";"))
+
+        assertEquals(listOf("abc", "def", "123,456"), (+"abc,def,123,456").split(',', limit = 3))
+        assertEquals(listOf("abc", "def", "123,456"), (+"abc,def,123,456").split(",", limit = 3))
+
+        assertEquals(listOf("abc", "def", "123", "456"), (+"abc<BR>def<br>123<bR>456").split("<BR>", ignoreCase = true))
+        assertEquals(listOf("abc", "def<br>123<bR>456"), (+"abc<BR>def<br>123<bR>456").split("<BR>", ignoreCase = false))
+
+        assertEquals(listOf("a", "b", "c"), (+"a*b*c").split("*"))
     }
 
     @Test fun splitToLines() = withOneCharSequenceArg { arg1 ->

--- a/libraries/stdlib/test/text/StringTest.kt
+++ b/libraries/stdlib/test/text/StringTest.kt
@@ -527,6 +527,7 @@ class StringTest {
         assertEquals(listOf("test"), (+"test").split(*arrayOf<String>()), "empty list of delimiters, none matched -> entire string returned")
 
         assertEquals(listOf("abc", "def", "123;456"), (+"abc;def,123;456").split(';', ',', limit = 3))
+        assertEquals(listOf("abc;def,123;456"), (+"abc;def,123;456").split(';', ',', limit = 1))
 
         assertEquals(listOf("abc", "def", "123", "456"), (+"abc=-def==123=456").split("==", "=-", "="))
 
@@ -551,6 +552,9 @@ class StringTest {
 
         assertEquals(listOf("abc", "def", "123,456,789,"), (+"abc,def,123,456,789,").split(',', limit = 3))
         assertEquals(listOf("abc", "def", "123,456,789,"), (+"abc,def,123,456,789,").split(",", limit = 3))
+
+        assertEquals(listOf("abc,def,123,456,789,"), (+"abc,def,123,456,789,").split(',', limit = 1))
+        assertEquals(listOf("abc,def,123,456,789,"), (+"abc,def,123,456,789,").split(",", limit = 1))
 
         assertEquals(listOf("abc", "def", "123", "456"), (+"abc<BR>def<br>123<bR>456").split("<BR>", ignoreCase = true))
         assertEquals(listOf("abc", "def<br>123<bR>456"), (+"abc<BR>def<br>123<bR>456").split("<BR>", ignoreCase = false))


### PR DESCRIPTION
Performance improvements of `Strings#split`.
For detailed evaluation see [KT-22248](https://youtrack.jetbrains.com/issue/KT-22248) (which is now marked as duplicate of KT-16661)

After 25c6cb0 Kotlin version became consistently faster than Java version for any arguments.

```
Benchmark                 (needle)   Mode  Cnt   Score   Error   Units
SplitBenchmark.splitJava         ,  thrpt   10  57.818 ± 1.740  ops/us
SplitBenchmark.splitJava         a  thrpt   10   6.687 ± 1.353  ops/us
SplitBenchmark.splitKt           ,  thrpt   10  77.459 ± 1.855  ops/us
SplitBenchmark.splitKt           a  thrpt   10  11.378 ± 0.299  ops/us

```