### PR TITLE
Add support for proxies to scripts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,8 @@ buildscript {
     val repos = listOfNotNull(
             bootstrapKotlinRepo,
             "https://jcenter.bintray.com/",
-            "https://plugins.gradle.org/m2")
+            "https://plugins.gradle.org/m2",
+            "https://oss.sonatype.org/content/repositories/snapshots")
 
     extra["repos"] = repos
 

--- a/libraries/tools/kotlin-script-util/build.gradle.kts
+++ b/libraries/tools/kotlin-script-util/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
     compileOnly(project(":compiler:cli"))
     compileOnly(project(":compiler:daemon-common"))
     compile(project(":kotlin-daemon-client"))
-    compileOnly("com.jcabi:jcabi-aether:0.10.1")
+    compileOnly("com.jcabi:jcabi-aether:1.0-SNAPSHOT")
     compileOnly("org.sonatype.aether:aether-api:1.13.1")
     compileOnly("org.apache.maven:maven-core:3.0.3")
     testCompileOnly(project(":compiler:cli"))
@@ -17,7 +17,7 @@ dependencies {
     testRuntime(project(":kotlin-reflect"))
     testCompile(commonDep("junit:junit"))
     testRuntime(projectRuntimeJar(":kotlin-compiler"))
-    testRuntime("com.jcabi:jcabi-aether:0.10.1")
+    testRuntime("com.jcabi:jcabi-aether:1.0-SNAPSHOT")
     testRuntime("org.sonatype.aether:aether-api:1.13.1")
     testRuntime("org.apache.maven:maven-core:3.0.3")
 }


### PR DESCRIPTION
Update jcabi-aether dependency from 0.10.1 to 1.0-SNAPSHOT. In order to
do that, add https://oss.sonatype.org/content/repositories/snapshots to
this list of repositories :-(

Script dependencies are resolved using jcabi-aether. Unfortunately "stable"
release (0.10.1) does not support proxies. Therefore, script dependencies
are not pulled behind a proxy. Issue is fixed in SNAPSHOT release of
jcabi-aether.

FIXED: KT-22363