### PR TITLE
Inline AndroidFacet.getAllResourceDirectories() usage

### DIFF
--- a/plugins/android-extensions/android-extensions-idea/src/org/jetbrains/kotlin/android/synthetic/idea/AndroidSimpleNameReferenceExtension.kt
+++ b/plugins/android-extensions/android-extensions-idea/src/org/jetbrains/kotlin/android/synthetic/idea/AndroidSimpleNameReferenceExtension.kt
@@ -67,7 +67,7 @@ class AndroidSimpleNameReferenceExtension : SimpleNameReferenceExtension {
             return false
         }
 
-        val resourceDirectories = AndroidFacet.getInstance(element)?.allResourceDirectories ?: return false
+        val resourceDirectories = AndroidFacet.getInstance(element)?.resourceFolderManager?.folders ?: return false
         val resourceDirectory = virtualFile.parent?.parent ?: return false
         return resourceDirectories.any { it == resourceDirectory }
     }


### PR DESCRIPTION
The method is deprecated and will be removed.