### PR TITLE
KT-22334 Specialized loops using range such as integer..array.size-1

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/range/PrimitiveNumberRangeLiteralRangeValue.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/range/PrimitiveNumberRangeLiteralRangeValue.kt
@@ -113,7 +113,8 @@ private fun ExpressionCodegen.isArraySizeAccess(expression: KtExpression): Boole
     return when {
         expression is KtDotQualifiedExpression -> {
             val selector = expression.selectorExpression
-            asmType(bindingContext.getType(expression.receiverExpression)!!).sort == Type.ARRAY &&
+            val type = bindingContext.getType(expression.receiverExpression) ?: return false
+            asmType(type).sort == Type.ARRAY &&
                     selector is KtNameReferenceExpression &&
                     selector.text == "size"
         }

--- a/compiler/testData/codegen/box/controlStructures/forInArray/forInArraySpecializedToUntil.kt
+++ b/compiler/testData/codegen/box/controlStructures/forInArray/forInArraySpecializedToUntil.kt
@@ -1,79 +1,79 @@
 // WITH_RUNTIME
 
-fun checkByteArray():Boolean {
+fun checkByteArray(): Boolean {
     val byteArray = byteArrayOf(1, 2, 3)
     var sum = 0
-    for (i in 0..byteArray.size-1) {
+    for (i in 0..byteArray.size - 1) {
         sum += byteArray[i]
     }
     if (sum != 6) return false
     return true
 }
 
-fun checkShortArray():Boolean {
+fun checkShortArray(): Boolean {
     val shortArray = shortArrayOf(1, 2, 3)
     var sum = 0
-    for (i in 0..shortArray.size-1) {
+    for (i in 0..shortArray.size - 1) {
         sum += shortArray[i]
     }
     if (sum != 6) return false
     return true
 }
 
-fun checkCharArray():Boolean {
+fun checkCharArray(): Boolean {
     val charArray = charArrayOf('1', '2', '3')
     var sum = ""
-    for (i in 0..charArray.size-1) {
+    for (i in 0..charArray.size - 1) {
         sum += charArray[i]
     }
     if (sum != "123") return false
     return true
 }
 
-fun checkIntArray():Boolean {
+fun checkIntArray(): Boolean {
     val intArray = intArrayOf(1, 2, 3)
     var sum = 0
-    for (i in 0..intArray.size-1) {
+    for (i in 0..intArray.size - 1) {
         sum += intArray[i]
     }
     if (sum != 6) return false
     return true
 }
 
-fun checkLongArray():Boolean {
+fun checkLongArray(): Boolean {
     val longArray = longArrayOf(1L, 2L, 3L)
     var sum = 0L
-    for (i in 0..longArray.size-1) {
+    for (i in 0..longArray.size - 1) {
         sum += longArray[i]
     }
     if (sum != 6L) return false
     return true
 }
 
-fun checkFloatArray():Boolean {
+fun checkFloatArray(): Boolean {
     val floatArray = floatArrayOf(1.1f, 2.2f, 3.3f)
     var sum = 0f
-    for (i in 0..floatArray.size-1) {
+    for (i in 0..floatArray.size - 1) {
         sum += floatArray[i]
     }
     if (sum != (1.1f + 2.2f + 3.3f)) return false
     return true
 }
 
-fun checkDoubleArray():Boolean {
+fun checkDoubleArray(): Boolean {
     val doubleArray = doubleArrayOf(1.1, 2.2, 3.3)
     var sum = 0.0
-    for (i in 0..doubleArray.size-1) {
+    for (i in 0..doubleArray.size - 1) {
         sum += doubleArray[i]
     }
     if (sum != 6.6) return false
     return true
 }
 
-fun checkBooleanArray():Boolean {
+fun checkBooleanArray(): Boolean {
     val booleanArray = booleanArrayOf(false, false, true)
     var result = false
-    for (i in 0..booleanArray.size-1) {
+    for (i in 0..booleanArray.size - 1) {
         result = booleanArray[i]
     }
     return result
@@ -81,20 +81,20 @@ fun checkBooleanArray():Boolean {
 
 class Value(val value: Int) {}
 
-fun checkObjectArray():Boolean {
+fun checkObjectArray(): Boolean {
     val objectArray = arrayOf(Value(1), Value(2), Value(3))
     var sum = 0
-    for (i in 0..objectArray.size-1) {
+    for (i in 0..objectArray.size - 1) {
         sum += objectArray[i].value
     }
     if (sum != 6) return false
     return true
 }
 
-fun checkWithArrayUpdate():Boolean {
+fun checkWithArrayUpdate(): Boolean {
     var intArray = intArrayOf(1, 2, 3)
     var sum = 0
-    for (i in 0..intArray.size-1) {
+    for (i in 0..intArray.size - 1) {
         sum += intArray[i]
         intArray = intArrayOf(4, 5, 6, 7)
     }
@@ -102,10 +102,10 @@ fun checkWithArrayUpdate():Boolean {
     return true
 }
 
-fun checkIntArrayMinusArbitraryConstant():Boolean {
+fun checkIntArrayMinusArbitraryConstant(): Boolean {
     val intArray = intArrayOf(1, 2, 3)
     var sum = 0
-    for (i in 0..intArray.size-2) {
+    for (i in 0..intArray.size - 2) {
         sum += intArray[i]
     }
     if (sum != 3) return false
@@ -116,14 +116,14 @@ fun checkReversedIntArray(): Boolean {
     val intArray = intArrayOf(1, 2, 3)
     var start = 0
     var sum = 0
-    for (i in (start..intArray.size-1).reversed()) {
+    for (i in (start..intArray.size - 1).reversed()) {
         sum += intArray[i]
     }
     if (sum != 6) return false
     return true
 }
 
-fun box() : String {
+fun box(): String {
     // Check that the specialization of 'for (i in 0..array.size-1)' to 'for (i in 0 until array.size)' does not fail on
     // any kind of arrays.
     if (!checkByteArray()) return "Failure"

--- a/compiler/testData/codegen/box/controlStructures/forInArray/forInArraySpecializedToUntil.kt
+++ b/compiler/testData/codegen/box/controlStructures/forInArray/forInArraySpecializedToUntil.kt
@@ -1,0 +1,143 @@
+// WITH_RUNTIME
+
+fun checkByteArray():Boolean {
+    val byteArray = byteArrayOf(1, 2, 3)
+    var sum = 0
+    for (i in 0..byteArray.size-1) {
+        sum += byteArray[i]
+    }
+    if (sum != 6) return false
+    return true
+}
+
+fun checkShortArray():Boolean {
+    val shortArray = shortArrayOf(1, 2, 3)
+    var sum = 0
+    for (i in 0..shortArray.size-1) {
+        sum += shortArray[i]
+    }
+    if (sum != 6) return false
+    return true
+}
+
+fun checkCharArray():Boolean {
+    val charArray = charArrayOf('1', '2', '3')
+    var sum = ""
+    for (i in 0..charArray.size-1) {
+        sum += charArray[i]
+    }
+    if (sum != "123") return false
+    return true
+}
+
+fun checkIntArray():Boolean {
+    val intArray = intArrayOf(1, 2, 3)
+    var sum = 0
+    for (i in 0..intArray.size-1) {
+        sum += intArray[i]
+    }
+    if (sum != 6) return false
+    return true
+}
+
+fun checkLongArray():Boolean {
+    val longArray = longArrayOf(1L, 2L, 3L)
+    var sum = 0L
+    for (i in 0..longArray.size-1) {
+        sum += longArray[i]
+    }
+    if (sum != 6L) return false
+    return true
+}
+
+fun checkFloatArray():Boolean {
+    val floatArray = floatArrayOf(1.1f, 2.2f, 3.3f)
+    var sum = 0f
+    for (i in 0..floatArray.size-1) {
+        sum += floatArray[i]
+    }
+    if (sum != (1.1f + 2.2f + 3.3f)) return false
+    return true
+}
+
+fun checkDoubleArray():Boolean {
+    val doubleArray = doubleArrayOf(1.1, 2.2, 3.3)
+    var sum = 0.0
+    for (i in 0..doubleArray.size-1) {
+        sum += doubleArray[i]
+    }
+    if (sum != 6.6) return false
+    return true
+}
+
+fun checkBooleanArray():Boolean {
+    val booleanArray = booleanArrayOf(false, false, true)
+    var result = false
+    for (i in 0..booleanArray.size-1) {
+        result = booleanArray[i]
+    }
+    return result
+}
+
+class Value(val value: Int) {}
+
+fun checkObjectArray():Boolean {
+    val objectArray = arrayOf(Value(1), Value(2), Value(3))
+    var sum = 0
+    for (i in 0..objectArray.size-1) {
+        sum += objectArray[i].value
+    }
+    if (sum != 6) return false
+    return true
+}
+
+fun checkWithArrayUpdate():Boolean {
+    var intArray = intArrayOf(1, 2, 3)
+    var sum = 0
+    for (i in 0..intArray.size-1) {
+        sum += intArray[i]
+        intArray = intArrayOf(4, 5, 6, 7)
+    }
+    if (sum != 12) return false
+    return true
+}
+
+fun checkIntArrayMinusArbitraryConstant():Boolean {
+    val intArray = intArrayOf(1, 2, 3)
+    var sum = 0
+    for (i in 0..intArray.size-2) {
+        sum += intArray[i]
+    }
+    if (sum != 3) return false
+    return true
+}
+
+fun checkReversedIntArray(): Boolean {
+    val intArray = intArrayOf(1, 2, 3)
+    var start = 0
+    var sum = 0
+    for (i in (start..intArray.size-1).reversed()) {
+        sum += intArray[i]
+    }
+    if (sum != 6) return false
+    return true
+}
+
+fun box() : String {
+    // Check that the specialization of 'for (i in 0..array.size-1)' to 'for (i in 0 until array.size)' does not fail on
+    // any kind of arrays.
+    if (!checkByteArray()) return "Failure"
+    if (!checkShortArray()) return "Failure"
+    if (!checkCharArray()) return "Failure"
+    if (!checkIntArray()) return "Failure"
+    if (!checkLongArray()) return "Failure"
+    if (!checkFloatArray()) return "Failure"
+    if (!checkDoubleArray()) return "Failure"
+    if (!checkBooleanArray()) return "Failure"
+    if (!checkObjectArray()) return "Failure"
+    if (!checkWithArrayUpdate()) return "Failure"
+    if (!checkIntArrayMinusArbitraryConstant()) return "Failure"
+    if (!checkReversedIntArray()) return "Failure"
+
+    return "OK"
+}

--- a/compiler/testData/codegen/box/controlStructures/forInArray/forInArraySpecializedToUntil.kt
+++ b/compiler/testData/codegen/box/controlStructures/forInArray/forInArraySpecializedToUntil.kt
@@ -124,6 +124,17 @@ fun checkReversedIntArray(): Boolean {
     return true
 }
 
+fun checkIntArrayMethodCallBound(): Boolean {
+    val intArray = intArrayOf(1, 2, 3)
+    var start = 0
+    var sum = 0
+    for (i in 0..Math.min(intArray.size, 10) - 1) {
+        sum += intArray[i]
+    }
+    if (sum != 6) return false
+    return true
+}
+
 fun box(): String {
     // Check that the specialization of 'for (i in 0..array.size-1)' to 'for (i in 0 until array.size)' does not fail on
     // any kind of arrays.
@@ -139,6 +150,7 @@ fun box(): String {
     if (!checkWithArrayUpdate()) return "Failure"
     if (!checkIntArrayMinusArbitraryConstant()) return "Failure"
     if (!checkReversedIntArray()) return "Failure"
+    if (!checkIntArrayMethodCallBound()) return "Failure"
 
     return "OK"
 }

--- a/compiler/testData/codegen/box/controlStructures/forInArray/forInArraySpecializedToUntil.kt
+++ b/compiler/testData/codegen/box/controlStructures/forInArray/forInArraySpecializedToUntil.kt
@@ -1,3 +1,4 @@
+// IGNORE_BACKEND: JS
 // WITH_RUNTIME
 
 fun checkByteArray(): Boolean {

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeSpecializedToUntil.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeSpecializedToUntil.kt
@@ -1,7 +1,7 @@
 fun test(): Int {
     val intArray = intArrayOf(1, 2, 3)
     var sum = 0
-    for (i in 0..intArray.size-1) {
+    for (i in 0..intArray.size - 1) {
         sum += intArray[i]
     }
     return sum

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeSpecializedToUntil.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeSpecializedToUntil.kt
@@ -1,0 +1,12 @@
+fun test(): Int {
+    val intArray = intArrayOf(1, 2, 3)
+    var sum = 0
+    for (i in 0..intArray.size-1) {
+        sum += intArray[i]
+    }
+    return sum
+}
+
+// 1 IF_ICMPGE
+// 0 IF_ICMPGT
+// 0 IF_ICMPEQ

--- a/compiler/tests-ir-jvm/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-ir-jvm/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -5141,6 +5141,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
                 KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/codegen/box/controlStructures/forInArray"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.JVM, true);
             }
 
+            @TestMetadata("forInArraySpecializedToUntil.kt")
+            public void testForInArraySpecializedToUntil() throws Exception {
+                String fileName = KotlinTestUtils.navigationMetadata("compiler/testData/codegen/box/controlStructures/forInArray/forInArraySpecializedToUntil.kt");
+                doTest(fileName);
+            }
+
             @TestMetadata("forInArrayWithArrayPropertyUpdatedInLoopBody.kt")
             public void testForInArrayWithArrayPropertyUpdatedInLoopBody() throws Exception {
                 String fileName = KotlinTestUtils.navigationMetadata("compiler/testData/codegen/box/controlStructures/forInArray/forInArrayWithArrayPropertyUpdatedInLoopBody.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -5141,6 +5141,12 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
                 KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/codegen/box/controlStructures/forInArray"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.JVM, true);
             }
 
+            @TestMetadata("forInArraySpecializedToUntil.kt")
+            public void testForInArraySpecializedToUntil() throws Exception {
+                String fileName = KotlinTestUtils.navigationMetadata("compiler/testData/codegen/box/controlStructures/forInArray/forInArraySpecializedToUntil.kt");
+                doTest(fileName);
+            }
+
             @TestMetadata("forInArrayWithArrayPropertyUpdatedInLoopBody.kt")
             public void testForInArrayWithArrayPropertyUpdatedInLoopBody() throws Exception {
                 String fileName = KotlinTestUtils.navigationMetadata("compiler/testData/codegen/box/controlStructures/forInArray/forInArrayWithArrayPropertyUpdatedInLoopBody.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
@@ -1284,6 +1284,12 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
             doTest(fileName);
         }
 
+        @TestMetadata("forInRangeSpecializedToUntil.kt")
+        public void testForInRangeSpecializedToUntil() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("compiler/testData/codegen/bytecodeText/forLoop/forInRangeSpecializedToUntil.kt");
+            doTest(fileName);
+        }
+
         @TestMetadata("forInRangeToCharConst.kt")
         public void testForInRangeToCharConst() throws Exception {
             String fileName = KotlinTestUtils.navigationMetadata("compiler/testData/codegen/bytecodeText/forLoop/forInRangeToCharConst.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -5141,6 +5141,12 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
                 KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/codegen/box/controlStructures/forInArray"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.JVM, true);
             }
 
+            @TestMetadata("forInArraySpecializedToUntil.kt")
+            public void testForInArraySpecializedToUntil() throws Exception {
+                String fileName = KotlinTestUtils.navigationMetadata("compiler/testData/codegen/box/controlStructures/forInArray/forInArraySpecializedToUntil.kt");
+                doTest(fileName);
+            }
+
             @TestMetadata("forInArrayWithArrayPropertyUpdatedInLoopBody.kt")
             public void testForInArrayWithArrayPropertyUpdatedInLoopBody() throws Exception {
                 String fileName = KotlinTestUtils.navigationMetadata("compiler/testData/codegen/box/controlStructures/forInArray/forInArrayWithArrayPropertyUpdatedInLoopBody.kt");

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -5714,7 +5714,13 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             @TestMetadata("forInArraySpecializedToUntil.kt")
             public void testForInArraySpecializedToUntil() throws Exception {
                 String fileName = KotlinTestUtils.navigationMetadata("compiler/testData/codegen/box/controlStructures/forInArray/forInArraySpecializedToUntil.kt");
-                doTest(fileName);
+                try {
+                    doTest(fileName);
+                }
+                catch (Throwable ignore) {
+                    return;
+                }
+                throw new AssertionError("Looks like this test can be unmuted. Remove IGNORE_BACKEND directive for that.");
             }
 
             @TestMetadata("forInArrayWithArrayPropertyUpdatedInLoopBody.kt")

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -5711,6 +5711,12 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
                 KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/codegen/box/controlStructures/forInArray"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.JS, true);
             }
 
+            @TestMetadata("forInArraySpecializedToUntil.kt")
+            public void testForInArraySpecializedToUntil() throws Exception {
+                String fileName = KotlinTestUtils.navigationMetadata("compiler/testData/codegen/box/controlStructures/forInArray/forInArraySpecializedToUntil.kt");
+                doTest(fileName);
+            }
+
             @TestMetadata("forInArrayWithArrayPropertyUpdatedInLoopBody.kt")
             public void testForInArrayWithArrayPropertyUpdatedInLoopBody() throws Exception {
                 String fileName = KotlinTestUtils.navigationMetadata("compiler/testData/codegen/box/controlStructures/forInArray/forInArrayWithArrayPropertyUpdatedInLoopBody.kt");


### PR DESCRIPTION
- Into PrimitiveNumberRangeLiteralRangeValue modifies how bounded
value are created by checking if the high bound range can be modified
to be exclusive instead of inclusive such as the generated code will
be optimized.
- Add black box tests checking that the specialization does not fail
on any kind of arrays.
- Add a bytecode test checking that the code is correctly optimized.

Fix of https://youtrack.jetbrains.com/issue/KT-22334