### PR TITLE
Make Kotlin Idea plugin aware of the Gradle initscript template

### DIFF
--- a/idea/idea-gradle/src/org/jetbrains/kotlin/idea/core/script/GradleScriptTemplateProvider.kt
+++ b/idea/idea-gradle/src/org/jetbrains/kotlin/idea/core/script/GradleScriptTemplateProvider.kt
@@ -85,6 +85,11 @@ class GradleScriptDefinitionsContributor(private val project: Project): ScriptDe
 
         // KotlinBuildScript should be last because it has wide scriptFilePattern
         val kotlinDslTemplates = loadGradleTemplates(
+            templateClass = "org.gradle.kotlin.dsl.KotlinInitScript",
+            dependencySelector = kotlinDslDependencySelector,
+            additionalResolverClasspath = kotlinDslAdditionalResolverCp
+
+        ) + loadGradleTemplates(
             templateClass = "org.gradle.kotlin.dsl.KotlinSettingsScript",
             dependencySelector = kotlinDslDependencySelector,
             additionalResolverClasspath = kotlinDslAdditionalResolverCp


### PR DESCRIPTION
The next release of the Kotlin DSL to be included in Gradle 4.6 includes support for init scripts.

Init scripts act on the `Gradle` object and thus expose a different API than the other types of scripts which act on `Project` and `Settings` objects.

See gradle/kotlin-dsl#662