### PR TITLE
Fix import of `expectedBy` scope dependencies inside composite builds

### DIFF
--- a/idea/idea-gradle/tests/org/jetbrains/kotlin/gradle/MultiplatformProjectImportingTest.kt
+++ b/idea/idea-gradle/tests/org/jetbrains/kotlin/gradle/MultiplatformProjectImportingTest.kt
@@ -119,6 +119,68 @@ class MultiplatformProjectImportingTest : GradleImportingTestCase() {
     }
 
     @Test
+    fun testPlatformToCommonExpectedByDependencyInComposite() {
+        createProjectSubFile("toInclude/settings.gradle", "include ':common', ':jvm', ':js'")
+
+        val kotlinVersion = "1.2.0-beta-74"
+
+        createProjectSubFile("toInclude/build.gradle", """
+             buildscript {
+                repositories {
+                    mavenCentral()
+                    maven { url 'http://dl.bintray.com/kotlin/kotlin-dev' }
+                }
+
+                dependencies {
+                    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
+                }
+            }
+
+            project('common') {
+                apply plugin: 'kotlin-platform-common'
+            }
+
+            project('jvm') {
+                apply plugin: 'kotlin-platform-jvm'
+
+                dependencies {
+                    expectedBy project(':common')
+                }
+            }
+
+            project('js') {
+                apply plugin: 'kotlin-platform-js'
+
+                dependencies {
+                    expectedBy project(':common')
+                }
+            }
+        """)
+
+        createProjectSubFile("settings.gradle", "includeBuild('toInclude')")
+        createProjectSubFile("build.gradle", """
+            buildscript {
+                repositories {
+                    mavenCentral()
+                    maven { url 'http://dl.bintray.com/kotlin/kotlin-dev' }
+                }
+
+                dependencies {
+                    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
+                }
+            }
+
+            apply plugin: 'kotlin'
+        """.trimIndent())
+
+        importProject()
+        assertModuleModuleDepScope("jvm_main", "common_main", DependencyScope.COMPILE)
+        assertModuleModuleDepScope("jvm_test", "common_test", DependencyScope.COMPILE)
+        assertModuleModuleDepScope("js_main", "common_main", DependencyScope.COMPILE)
+        assertModuleModuleDepScope("js_test", "common_test", DependencyScope.COMPILE)
+    }
+
+    @Test
     fun testPlatformToCommonDependencyRoot() {
         createProjectSubFile("settings.gradle", "rootProject.name = 'foo'\ninclude ':jvm', ':js'")
 


### PR DESCRIPTION
Gradle's subproject name/path is only a part of a module ID, when composite build is imported. Included build's name is missing.
It is easy to obtain it, as long as `expectedBy` dependency does not cross gradle build boundary.