### PR TITLE
Log Diagnostic.Kind.NOTE messages at INFO level

### DIFF
--- a/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/javac/KaptJavaLog.kt
+++ b/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/javac/KaptJavaLog.kt
@@ -239,7 +239,7 @@ class KaptJavaLog(
 
                 val errWriter = makeWriter(ERROR)
                 val warnWriter = makeWriter(STRONG_WARNING)
-                val noticeWriter = makeWriter(WARNING)
+                val noticeWriter = makeWriter(INFO)
 
                 KaptJavaLog(
                     kaptContext.project, newContext, errWriter, warnWriter, noticeWriter,


### PR DESCRIPTION
javax.tools.Diagnostic.Kind.NOTE messages from libraries should be equivalent to INFO level, not WARNING level. I think WARNING was used because by default gradle does not output info level (you need to add the `--info` flag).

With the latest version of the Kotlin plugin (org.jetbrains.kotlin:kotlin-gradle-plugin:1.2.21) our builds broke because Kapt was logging  `javax.tools.Diagnostic.Kind.NOTE` messages from annotation processors (in our case `Realm`) as warnings, instead of as info messages which would make more sense. Our build script essentially looks for `warnings found and -Werror specified` messages from kapt output. 

The build script looks something like this:

```
subprojects { subproject ->
    afterEvaluate {
        tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all { task ->
            if (task.name.endsWith("UnitTestKotlin")) {
                kotlinOptions.suppressWarnings = true
            } else {
                kotlinOptions.allWarningsAsErrors = true
            }
        }
        /*
         * Check tasks that are affected by allWarningsAsErrors but are not failed on warnings, such as kapt* tasks.
         * Modified from https://stackoverflow.com/a/33153700
         */
        tasks.all { task ->
            def standardOutput = new StringBuilder()
            def listener = new StandardOutputListener() {
                @Override
                void onOutput(CharSequence output) {
                    standardOutput.append(output)
                }
            }
            doFirst {
                getLogging().addStandardErrorListener(listener)
            }
            doLast {
                getLogging().removeStandardErrorListener(listener)
                if (standardOutput =~ "warnings found and -Werror specified") {
                    throw new GradleException(
                            "warnings found and -Werror specified, from task " + subproject.name + ":" + task.name)
                }
            }
        }
    }
}
```