### PR TITLE
add samples for CharJVM.kt

### DIFF
--- a/libraries/stdlib/samples/test/samples/text/chars.kt
+++ b/libraries/stdlib/samples/test/samples/text/chars.kt
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the license/LICENSE.txt file.
+ */
+
+package samples.text
+
+import samples.*
+
+class Chars {
+
+    @Sample
+    fun isDefined() {
+        assertPrints('$'.isDefined(), "true")
+    }
+
+    @Sample
+    fun isLetter() {
+        assertPrints('a'.isLetter(), "true")
+        assertPrints('β'.isLetter(), "true")
+
+        assertPrints('+'.isLetter(), "false")
+        assertPrints('1'.isLetter(), "false")
+    }
+
+    @Sample
+    fun isLetterOrDigit() {
+        assertPrints('a'.isLetterOrDigit(), "true")
+        assertPrints('1'.isLetterOrDigit(), "true")
+
+        assertPrints('+'.isLetterOrDigit(), "false")
+    }
+
+    @Sample
+    fun isDigit() {
+        assertPrints('1'.isDigit(), "true")
+
+        assertPrints('a'.isDigit(), "false")
+        assertPrints('+'.isDigit(), "false")
+    }
+
+
+    @Sample
+    fun isIdentifierIgnorable() {
+        assertPrints('\u0000'.isIdentifierIgnorable(), "true")
+        assertPrints('\u000E'.isIdentifierIgnorable(), "true")
+
+        assertPrints('\u0009'.isIdentifierIgnorable(), "false")
+        assertPrints('1'.isIdentifierIgnorable(), "false")
+        assertPrints('a'.isIdentifierIgnorable(), "false")
+    }
+
+
+    @Sample
+    fun isISOControl() {
+        assertPrints('\u0000'.isISOControl(), "true")
+        assertPrints('\u000E'.isISOControl(), "true")
+        assertPrints('\u0009'.isISOControl(), "true")
+
+        assertPrints('1'.isISOControl(), "false")
+        assertPrints('a'.isISOControl(), "false")
+    }
+
+    @Sample
+    fun isJavaIdentifierPart() {
+        assertPrints('a'.isJavaIdentifierPart(), "true")
+        assertPrints('1'.isJavaIdentifierPart(), "true")
+        assertPrints('β'.isJavaIdentifierPart(), "true")
+
+        assertPrints('$'.isJavaIdentifierPart(), "false")
+        assertPrints('+'.isJavaIdentifierPart(), "false")
+        assertPrints(';'.isJavaIdentifierPart(), "false")
+    }
+
+    @Sample
+    fun isJavaIdentifierStart() {
+        assertPrints('a'.isJavaIdentifierStart(), "true")
+        assertPrints('β'.isJavaIdentifierStart(), "true")
+        assertPrints('_'.isJavaIdentifierStart(), "true")
+        assertPrints('$'.isJavaIdentifierStart(), "true")
+
+        assertPrints('1'.isJavaIdentifierStart(), "false")
+        assertPrints(';'.isJavaIdentifierStart(), "false")
+        assertPrints('+'.isJavaIdentifierStart(), "false")
+    }
+
+    @Sample
+    fun isWhitespace() {
+        assertPrints(' '.isWhitespace(), "true")
+        assertPrints('\t'.isWhitespace(), "true")
+
+        assertPrints('1'.isWhitespace(), "false")
+        assertPrints('a'.isWhitespace(), "false")
+    }
+
+    @Sample
+    fun isUpperCase() {
+        assertPrints('A'.isUpperCase(), "true")
+        assertPrints('Ψ'.isUpperCase(), "true")
+
+        assertPrints('a'.isUpperCase(), "false")
+        assertPrints('1'.isUpperCase(), "false")
+        assertPrints('+'.isUpperCase(), "false")
+    }
+
+    @Sample
+    fun isLowerCase() {
+        assertPrints('a'.isLowerCase(), "true")
+        assertPrints('λ'.isLowerCase(), "true")
+
+        assertPrints('A'.isLowerCase(), "false")
+        assertPrints('1'.isLowerCase(), "false")
+        assertPrints('+'.isLowerCase(), "false")
+    }
+
+    @Sample
+    fun toUpperCase() {
+        assertPrints('a'.toUpperCase(), "A")
+        assertPrints('ω'.toUpperCase(), "Ω")
+
+        assertPrints('1'.toUpperCase(), "1")
+        assertPrints('A'.toUpperCase(), "A")
+        assertPrints('+'.toUpperCase(), "+")
+    }
+
+    @Sample
+    fun toLowerCase() {
+        assertPrints('A'.toLowerCase(), "a")
+        assertPrints('Ω'.toLowerCase(), "ω")
+
+        assertPrints('1'.toLowerCase(), "1")
+        assertPrints('a'.toLowerCase(), "a")
+        assertPrints('+'.toLowerCase(), "+")
+    }
+
+
+    @Sample
+    fun isTitleCase() {
+        assertPrints('ǅ'.isTitleCase(), "true")
+        assertPrints('ǈ'.isTitleCase(), "true")
+        assertPrints('ǋ'.isTitleCase(), "true")
+        assertPrints('ǲ'.isTitleCase(), "true")
+
+        assertPrints('1'.isTitleCase(), "false")
+        assertPrints('A'.isTitleCase(), "false")
+        assertPrints('a'.isTitleCase(), "false")
+        assertPrints('+'.isTitleCase(), "false")
+    }
+
+    @Sample
+    fun toTitleCase() {
+        assertPrints('a'.toTitleCase(), "A")
+        assertPrints('ǆ'.toTitleCase(), "ǅ")
+
+        assertPrints('1'.toTitleCase(), "1")
+        assertPrints('+'.toTitleCase(), "+")
+    }
+
+    @Sample
+    fun isHighSurrogate() {
+        assertPrints('\uD800'.isHighSurrogate(), "true")
+        assertPrints('\uDBFF'.isHighSurrogate(), "true")
+
+        assertPrints('A'.isHighSurrogate(), "false")
+        assertPrints('a'.isHighSurrogate(), "false")
+        assertPrints('1'.isHighSurrogate(), "false")
+    }
+
+    @Sample
+    fun isLowSurrogate() {
+        assertPrints('\uDC00'.isLowSurrogate(), "true")
+        assertPrints('\uDFFF'.isLowSurrogate(), "true")
+
+        assertPrints('A'.isLowSurrogate(), "false")
+        assertPrints('a'.isLowSurrogate(), "false")
+        assertPrints('1'.isLowSurrogate(), "false")
+    }
+
+}

--- a/libraries/stdlib/src/kotlin/text/CharJVM.kt
+++ b/libraries/stdlib/src/kotlin/text/CharJVM.kt
@@ -22,24 +22,28 @@ package kotlin.text
 
 /**
  * Returns `true` if this character (Unicode code point) is defined in Unicode.
+ * @sample samples.text.Chars.isDefined
  */
 @kotlin.internal.InlineOnly
 public inline fun Char.isDefined(): Boolean = Character.isDefined(this)
 
 /**
  * Returns `true` if this character is a letter.
+ * @sample samples.text.Chars.isLetter
  */
 @kotlin.internal.InlineOnly
 public inline fun Char.isLetter(): Boolean = Character.isLetter(this)
 
 /**
  * Returns `true` if this character is a letter or digit.
+ * @sample samples.text.Chars.isLetterOrDigit
  */
 @kotlin.internal.InlineOnly
 public inline fun Char.isLetterOrDigit(): Boolean = Character.isLetterOrDigit(this)
 
 /**
  * Returns `true` if this character (Unicode code point) is a digit.
+ * @sample samples.text.Chars.isDigit
  */
 @kotlin.internal.InlineOnly
 public inline fun Char.isDigit(): Boolean = Character.isDigit(this)
@@ -48,24 +52,28 @@ public inline fun Char.isDigit(): Boolean = Character.isDigit(this)
 /**
  * Returns `true` if this character (Unicode code point) should be regarded as an ignorable
  * character in a Java identifier or a Unicode identifier.
+ * @sample samples.text.Chars.isIdentifierIgnorable
  */
 @kotlin.internal.InlineOnly
 public inline fun Char.isIdentifierIgnorable(): Boolean = Character.isIdentifierIgnorable(this)
 
 /**
  * Returns `true` if this character is an ISO control character.
+ * @sample samples.text.Chars.isISOControl
  */
 @kotlin.internal.InlineOnly
 public inline fun Char.isISOControl(): Boolean = Character.isISOControl(this)
 
 /**
  * Returns `true` if this  character (Unicode code point) may be part of a Java identifier as other than the first character.
+ * @sample samples.text.Chars.isJavaIdentifierPart
  */
 @kotlin.internal.InlineOnly
 public inline fun Char.isJavaIdentifierPart(): Boolean = Character.isJavaIdentifierPart(this)
 
 /**
  * Returns `true` if this character is permissible as the first character in a Java identifier.
+ * @sample samples.text.Chars.isJavaIdentifierStart
  */
 @kotlin.internal.InlineOnly
 public inline fun Char.isJavaIdentifierStart(): Boolean = Character.isJavaIdentifierStart(this)
@@ -73,35 +81,41 @@ public inline fun Char.isJavaIdentifierStart(): Boolean = Character.isJavaIdenti
 /**
  * Determines whether a character is whitespace according to the Unicode standard.
  * Returns `true` if the character is whitespace.
+ * @sample samples.text.Chars.isWhitespace
  */
 public fun Char.isWhitespace(): Boolean = Character.isWhitespace(this) || Character.isSpaceChar(this)
 
 /**
  * Returns `true` if this character is upper case.
+ * @sample samples.text.Chars.isUpperCase
  */
 @kotlin.internal.InlineOnly
 public inline fun Char.isUpperCase(): Boolean = Character.isUpperCase(this)
 
 /**
  * Returns `true` if this character is lower case.
+ * @sample samples.text.Chars.isLowerCase
  */
 @kotlin.internal.InlineOnly
 public inline fun Char.isLowerCase(): Boolean = Character.isLowerCase(this)
 
 /**
  * Converts this character to uppercase.
+ * @sample samples.text.Chars.toUpperCase
  */
 @kotlin.internal.InlineOnly
 public inline fun Char.toUpperCase(): Char = Character.toUpperCase(this)
 
 /**
  * Converts this character to lowercase.
+ * @sample samples.text.Chars.toLowerCase
  */
 @kotlin.internal.InlineOnly
 public inline fun Char.toLowerCase(): Char = Character.toLowerCase(this)
 
 /**
  * Returns `true` if this character is a titlecase character.
+ * @sample samples.text.Chars.isTitleCase
  */
 @kotlin.internal.InlineOnly
 public inline fun Char.isTitleCase(): Boolean = Character.isTitleCase(this)
@@ -110,6 +124,7 @@ public inline fun Char.isTitleCase(): Boolean = Character.isTitleCase(this)
  * Converts this character to titlecase.
  *
  * @see Character.toTitleCase
+ * @sample samples.text.Chars.toTitleCase
  */
 @kotlin.internal.InlineOnly
 public inline fun Char.toTitleCase(): Char = Character.toTitleCase(this)
@@ -126,12 +141,14 @@ public val Char.directionality: CharDirectionality get() = CharDirectionality.va
 
 /**
  * Returns `true` if this character is a Unicode high-surrogate code unit (also known as leading-surrogate code unit).
+ * @sample samples.text.Chars.isHighSurrogate
  */
 @kotlin.internal.InlineOnly
 public inline fun Char.isHighSurrogate(): Boolean = Character.isHighSurrogate(this)
 
 /**
  * Returns `true` if this character is a Unicode low-surrogate code unit (also known as trailing-surrogate code unit).
+ * @sample samples.text.Chars.isLowSurrogate
  */
 @kotlin.internal.InlineOnly
 public inline fun Char.isLowSurrogate(): Boolean = Character.isLowSurrogate(this)
@@ -143,7 +160,6 @@ public inline fun Char.isLowSurrogate(): Boolean = Character.isLowSurrogate(this
 //public fun Char.name(): String? = Character.getName(this.toInt())
 
 
-
 internal fun digitOf(char: Char, radix: Int): Int = Character.digit(char.toInt(), radix)
 
 /**
@@ -151,7 +167,7 @@ internal fun digitOf(char: Char, radix: Int): Int = Character.digit(char.toInt()
  */
 @PublishedApi
 internal fun checkRadix(radix: Int): Int {
-    if(radix !in Character.MIN_RADIX..Character.MAX_RADIX) {
+    if (radix !in Character.MIN_RADIX..Character.MAX_RADIX) {
         throw IllegalArgumentException("radix $radix was not in valid range ${Character.MIN_RADIX..Character.MAX_RADIX}")
     }
     return radix


### PR DESCRIPTION
I choose to use `assertPrints` instead of `assertTrue`, because 
`println('a'.isDigit()) // false`
 is more readable than 
`println("'a'.toDigit() is ${'a'.isDigit()}") // false`
