### PR TITLE
Long.toBigDecimal(): avoid new BigDecimal instance

### DIFF
--- a/libraries/stdlib/src/kotlin/util/BigDecimals.kt
+++ b/libraries/stdlib/src/kotlin/util/BigDecimals.kt
@@ -105,7 +105,7 @@ public inline fun Int.toBigDecimal(mathContext: MathContext): BigDecimal = BigDe
  */
 @SinceKotlin("1.2")
 @kotlin.internal.InlineOnly
-public inline fun Long.toBigDecimal(): BigDecimal = BigDecimal(this)
+public inline fun Long.toBigDecimal(): BigDecimal = BigDecimal.valueOf(this)
 
 /**
  * Returns the value of this [Long] number as a [BigDecimal].

--- a/libraries/stdlib/src/kotlin/util/BigDecimals.kt
+++ b/libraries/stdlib/src/kotlin/util/BigDecimals.kt
@@ -89,7 +89,7 @@ public inline operator fun BigDecimal.dec(): BigDecimal = this.subtract(BigDecim
  */
 @SinceKotlin("1.2")
 @kotlin.internal.InlineOnly
-public inline fun Int.toBigDecimal(): BigDecimal = BigDecimal(this)
+public inline fun Int.toBigDecimal(): BigDecimal = BigDecimal.valueOf(this)
 
 
 /**

--- a/libraries/stdlib/src/kotlin/util/BigDecimals.kt
+++ b/libraries/stdlib/src/kotlin/util/BigDecimals.kt
@@ -89,7 +89,7 @@ public inline operator fun BigDecimal.dec(): BigDecimal = this.subtract(BigDecim
  */
 @SinceKotlin("1.2")
 @kotlin.internal.InlineOnly
-public inline fun Int.toBigDecimal(): BigDecimal = BigDecimal.valueOf(this)
+public inline fun Int.toBigDecimal(): BigDecimal = BigDecimal.valueOf(this.toLong())
 
 
 /**


### PR DESCRIPTION
...by calling BigDecimal.valueOf(this), which doesn't create a new BigDecimal instance if the argument falls in the range [0..10].
(there's a `private static final BigDecimal[] zeroThroughTen` cache in BigDecimal.java with 11 BigDecimal instances)

Here's the bytecode diff for the Int receiver:
```patch
--- inline fun Int.toBigDecimal()
+++ inline fun Int.toBigDecimal()
@@ -4,10 +4,12 @@
   @Lkotlin/internal/InlineOnly;() // invisible
    L0
     LINENUMBER 92 L0
-    NEW java/math/BigDecimal
+    ILOAD 0
+    I2L
+    INVOKESTATIC java/math/BigDecimal.valueOf (J)Ljava/math/BigDecimal;
     DUP
-    ILOAD 0
-    INVOKESPECIAL java/math/BigDecimal.<init> (I)V
+    LDC "BigDecimal.valueOf(this.toLong())"
+    INVOKESTATIC kotlin/jvm/internal/Intrinsics.checkExpressionValueIsNotNull (Ljava/lang/Object;Ljava/lang/String;)V
     ARETURN
    L1
     LOCALVARIABLE $receiver I L0 L1 0
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jetbrains/kotlin/1545)
<!-- Reviewable:end -->
