### PR TITLE
KT-22949 NPE on conversion of `run`/`apply` with explicit lambda signature to `let`/`also`

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/ScopeFunctionConversionInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/ScopeFunctionConversionInspection.kt
@@ -154,6 +154,9 @@ abstract class ConvertScopeFunctionFix(private val counterpartName: String) : Lo
         val functionLiteral = lambda.getLambdaExpression()?.functionLiteral ?: return
         val lambdaDescriptor = bindingContext[FUNCTION, functionLiteral] ?: return
 
+        functionLiteral.valueParameterList?.delete()
+        functionLiteral.arrow?.delete()
+
         val replacements = ReplacementCollection()
         analyzeLambda(bindingContext, lambda, lambdaDescriptor, replacements)
         callee.replace(KtPsiFactory(project).createExpression(counterpartName) as KtNameReferenceExpression)
@@ -205,6 +208,7 @@ class ConvertScopeFunctionToParameter(counterpartName: String) : ConvertScopeFun
         lambda.accept(object : KtTreeVisitorVoid() {
             override fun visitSimpleNameExpression(expression: KtSimpleNameExpression) {
                 super.visitSimpleNameExpression(expression)
+                if (expression is KtOperationReferenceExpression) return
                 val resolvedCall = expression.getResolvedCall(bindingContext) ?: return
                 val dispatchReceiverTarget = resolvedCall.dispatchReceiver?.getReceiverTargetDescriptor(bindingContext)
                 val extensionReceiverTarget = resolvedCall.extensionReceiver?.getReceiverTargetDescriptor(bindingContext)

--- a/idea/testData/inspectionsLocal/scopeFunctions/applyToAlso/arrow.kt
+++ b/idea/testData/inspectionsLocal/scopeFunctions/applyToAlso/arrow.kt
@@ -1,0 +1,9 @@
+// WITH_RUNTIME
+// FIX: Convert to 'also'
+
+fun foo() {
+    "".<caret>apply {
+        ->
+        println(this)
+    }
+}

--- a/idea/testData/inspectionsLocal/scopeFunctions/applyToAlso/arrow.kt.after
+++ b/idea/testData/inspectionsLocal/scopeFunctions/applyToAlso/arrow.kt.after
@@ -1,0 +1,8 @@
+// WITH_RUNTIME
+// FIX: Convert to 'also'
+
+fun foo() {
+    "".<caret>also {
+        println(it)
+    }
+}

--- a/idea/testData/inspectionsLocal/scopeFunctions/applyToAlso/thisInOperation.kt
+++ b/idea/testData/inspectionsLocal/scopeFunctions/applyToAlso/thisInOperation.kt
@@ -1,0 +1,8 @@
+// WITH_RUNTIME
+// FIX: Convert to 'also'
+
+fun foo() {
+    "".<caret>apply {
+        println(this + this)
+    }
+}

--- a/idea/testData/inspectionsLocal/scopeFunctions/applyToAlso/thisInOperation.kt.after
+++ b/idea/testData/inspectionsLocal/scopeFunctions/applyToAlso/thisInOperation.kt.after
@@ -1,0 +1,8 @@
+// WITH_RUNTIME
+// FIX: Convert to 'also'
+
+fun foo() {
+    "".<caret>also {
+        println(it + it)
+    }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -3653,6 +3653,12 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
                 KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/inspectionsLocal/scopeFunctions/applyToAlso"), Pattern.compile("^([\\w\\-_]+)\\.(kt|kts)$"), TargetBackend.ANY, true);
             }
 
+            @TestMetadata("arrow.kt")
+            public void testArrow() throws Exception {
+                String fileName = KotlinTestUtils.navigationMetadata("idea/testData/inspectionsLocal/scopeFunctions/applyToAlso/arrow.kt");
+                doTest(fileName);
+            }
+
             @TestMetadata("doubleNestedLambdas.kt")
             public void testDoubleNestedLambdas() throws Exception {
                 String fileName = KotlinTestUtils.navigationMetadata("idea/testData/inspectionsLocal/scopeFunctions/applyToAlso/doubleNestedLambdas.kt");
@@ -3686,6 +3692,12 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
             @TestMetadata("simple.kt")
             public void testSimple() throws Exception {
                 String fileName = KotlinTestUtils.navigationMetadata("idea/testData/inspectionsLocal/scopeFunctions/applyToAlso/simple.kt");
+                doTest(fileName);
+            }
+
+            @TestMetadata("thisInOperation.kt")
+            public void testThisInOperation() throws Exception {
+                String fileName = KotlinTestUtils.navigationMetadata("idea/testData/inspectionsLocal/scopeFunctions/applyToAlso/thisInOperation.kt");
                 doTest(fileName);
             }
 


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-22949
https://youtrack.jetbrains.com/issue/KT-22950