### PR TITLE
Fix typo in DefaultErrorMessagesAndroid

### DIFF
--- a/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/diagnostic/DefaultErrorMessagesAndroid.kt
+++ b/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/diagnostic/DefaultErrorMessagesAndroid.kt
@@ -45,7 +45,7 @@ object DefaultErrorMessagesAndroid : DefaultErrorMessages.Extension {
                 "'Parcelable' should be a class")
 
         MAP.put(ErrorsAndroid.PARCELABLE_DELEGATE_IS_NOT_ALLOWED,
-                "Delegating 'Parcelable' is now allowed")
+                "Delegating 'Parcelable' is not allowed")
 
         MAP.put(ErrorsAndroid.PARCELABLE_SHOULD_NOT_BE_ENUM_CLASS,
                 "'Parcelable' should not be a 'enum class'")


### PR DESCRIPTION
"Delegating 'Parcelable' is now allowed" -> "Delegating 'Parcelable' is not allowed"