### PR TITLE
Simplification of 'getOrElseNullable' and 'getOrPut'

### DIFF
--- a/libraries/stdlib/src/kotlin/collections/Maps.kt
+++ b/libraries/stdlib/src/kotlin/collections/Maps.kt
@@ -251,10 +251,9 @@ internal inline fun <K, V> Map<K, V>.getOrElseNullable(key: K, defaultValue: () 
     val value = get(key)
     if (value == null && !containsKey(key)) {
         return defaultValue()
-    } else {
-        @Suppress("UNCHECKED_CAST")
-        return value as V
     }
+    @Suppress("UNCHECKED_CAST")
+    return value as V
 }
 
 /**
@@ -275,16 +274,8 @@ public fun <K, V> Map<K, V>.getValue(key: K): V = getOrImplicitDefault(key)
  *
  * @sample samples.collections.Maps.Usage.getOrPut
  */
-public inline fun <K, V> MutableMap<K, V>.getOrPut(key: K, defaultValue: () -> V): V {
-    val value = get(key)
-    return if (value == null) {
-        val answer = defaultValue()
-        put(key, answer)
-        answer
-    } else {
-        value
-    }
-}
+public inline fun <K, V> MutableMap<K, V>.getOrPut(key: K, defaultValue: () -> V): V
+        = get(key) ?: defaultValue().also { put(key, it) }
 
 /**
  * Returns an [Iterator] over the entries in the [Map].


### PR DESCRIPTION
This PR removes some statements and also decreases nesting level, which I contend that makes the code easier to read and understand.