### PR TITLE
Corrected the documentation of DownTo to include the [to] value.

### DIFF
--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Ranges.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Ranges.kt
@@ -73,7 +73,7 @@ object RangeOps : TemplateGroupBase() {
             """
             Returns a progression from this value down to the specified [to] value with the step -1.
 
-            The [to] value has to be less than this value.
+            The [to] value has to be less than or equal to this value.
             """
         }
 


### PR DESCRIPTION
The DownTo includes the [to] value.
Example the output of following code snippet is
 for (i in 3 downTo 1){
        println(i)
    }
3
2
1