### PR TITLE
KT-23608 AE “Failed to create expression from text” after applying quick fix “Convert too long character literal to string”

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/TooLongCharLiteralToStringFix.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/TooLongCharLiteralToStringFix.kt
@@ -10,7 +10,7 @@ import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtPsiFactory
 
 class TooLongCharLiteralToStringFix(
-        element: KtConstantExpression
+    element: KtConstantExpression
 ) : KotlinQuickFixAction<KtConstantExpression>(element) {
     override fun getText(): String = "Convert too long character literal to string"
 
@@ -22,8 +22,9 @@ class TooLongCharLiteralToStringFix(
         }
 
         val newStringContent = text
-                .slice(1..text.length - 2)
-                .replace("\"", "\\\"")
+            .slice(1..text.length - 2)
+            .replace("\\\"", "\"")
+            .replace("\"", "\\\"")
         val newElement = KtPsiFactory(element).createStringTemplate(newStringContent)
 
         element.replace(newElement)

--- a/idea/testData/quickfix/tooLongCharLiteralToString/ecapedDoubleQuotesShouldNotBeEscaped.kt
+++ b/idea/testData/quickfix/tooLongCharLiteralToString/ecapedDoubleQuotesShouldNotBeEscaped.kt
@@ -1,0 +1,5 @@
+// "Convert too long character literal to string" "true"
+
+fun foo() {
+    'foo\"bar'<caret>
+}

--- a/idea/testData/quickfix/tooLongCharLiteralToString/ecapedDoubleQuotesShouldNotBeEscaped.kt.after
+++ b/idea/testData/quickfix/tooLongCharLiteralToString/ecapedDoubleQuotesShouldNotBeEscaped.kt.after
@@ -1,0 +1,5 @@
+// "Convert too long character literal to string" "true"
+
+fun foo() {
+    "foo\"bar"
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -11276,6 +11276,12 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
             String fileName = KotlinTestUtils.navigationMetadata("idea/testData/quickfix/tooLongCharLiteralToString/doubleQuotesShouldBeEscaped.kt");
             doTest(fileName);
         }
+
+        @TestMetadata("ecapedDoubleQuotesShouldNotBeEscaped.kt")
+        public void testEcapedDoubleQuotesShouldNotBeEscaped() throws Exception {
+            String fileName = KotlinTestUtils.navigationMetadata("idea/testData/quickfix/tooLongCharLiteralToString/ecapedDoubleQuotesShouldNotBeEscaped.kt");
+            doTest(fileName);
+        }
     }
 
     @TestMetadata("idea/testData/quickfix/typeAddition")


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-23608