### PR TITLE
Eliminate duplicate call to genSyntheticClassOrObject

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/ClassBodyCodegen.java
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/ClassBodyCodegen.java
@@ -98,12 +98,6 @@ public abstract class ClassBodyCodegen extends MemberCodegen<KtPureClassOrObject
             genClassOrObject(companion);
         }
 
-        // Generate synthetic (non-declared) companion if needed
-        ClassDescriptor companionObjectDescriptor = descriptor.getCompanionObjectDescriptor();
-        if (companionObjectDescriptor instanceof SyntheticClassOrObjectDescriptor) {
-            genSyntheticClassOrObject((SyntheticClassOrObjectDescriptor) companionObjectDescriptor);
-        }
-
         // Generate synthetic nested classes
         Collection<DeclarationDescriptor> classifiers = descriptor
                 .getUnsubstitutedMemberScope()


### PR DESCRIPTION
As far as I can tell (and admittedly I'm not an expert in the Kotlin compiler code), it looks like the new logic iterates over all contributed descriptors, which renders the old logic (which explicitly invokes getCompanionObjectDescriptor) obsolete.  We ran into this last year when rebasing on top of https://github.com/JetBrains/kotlin/commit/527ccaff16ecebbfbcecabd5fbc8af808a296915 and - after a quick conversation with @sandwwraith (email chain dated December 12, 2017) - we unblocked ourselves by deleting a few lines from our local repository.  Now we're looking to upstream our changes, thus this PR.  I think this is correct/safe, but it would be good for someone from jetbrains could do a quick sanity-check.

cc @sandwwraith @erokhins 

Old code:
```
         // Generate synthetic (non-declared) companion if needed
         ClassDescriptor companionObjectDescriptor = descriptor.getCompanionObjectDescriptor();
         if (companionObjectDescriptor instanceof SyntheticClassOrObjectDescriptor) {
             genSyntheticClassOrObject((SyntheticClassOrObjectDescriptor) companionObjectDescriptor);
         }
```

New code (already in repo as of 527cca):
```
        // Generate synthetic nested classes
        Collection<DeclarationDescriptor> classifiers = descriptor
                .getUnsubstitutedMemberScope()
                .getContributedDescriptors(DescriptorKindFilter.CLASSIFIERS, MemberScope.Companion.getALL_NAME_FILTER());
        for (DeclarationDescriptor memberDescriptor : classifiers) {
            if (memberDescriptor instanceof SyntheticClassOrObjectDescriptor) {
                genSyntheticClassOrObject((SyntheticClassOrObjectDescriptor) memberDescriptor);
            }
        }
```

Change-Id: Icb51ee6e56b9928108cc121c78fa50c6354a4b31