### PR TITLE
Removed Unused Braces For Companion Objects (String, Enum)

### DIFF
--- a/core/builtins/native/kotlin/Enum.kt
+++ b/core/builtins/native/kotlin/Enum.kt
@@ -22,7 +22,7 @@ package kotlin
  * information on enum classes.
  */
 public abstract class Enum<E : Enum<E>>(name: String, ordinal: Int): Comparable<E> {
-    companion object {}
+    companion object
 
     /**
      * Returns the name of this enum constant, exactly as declared in its enum declaration.

--- a/core/builtins/native/kotlin/String.kt
+++ b/core/builtins/native/kotlin/String.kt
@@ -21,7 +21,7 @@ package kotlin
  * implemented as instances of this class.
  */
 public class String : Comparable<String>, CharSequence {
-    companion object {}
+    companion object
     
     /**
      * Returns a string obtained by concatenating this string with the string representation of the given [other] object.


### PR DESCRIPTION
As far as we know, braces aren't needed for empty classes, constructors, interfaces, objects, etc. So why there are braces for companion objects of String and Enum classes?