### PR TITLE
KT-23721 Emit an error when 'tools.jar' is not into plugin classpath

### DIFF
--- a/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/Kapt3Plugin.kt
+++ b/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/Kapt3Plugin.kt
@@ -229,7 +229,7 @@ class Kapt3ComponentRegistrar : ComponentRegistrar {
         try {
             Class.forName(JAVAC_CONTEXT_CLASS)
         } catch (e: ClassNotFoundException) {
-            logger.warn("'$JAVAC_CONTEXT_CLASS' class can't be found ('tools.jar' is absent in the plugin classpath). Kapt won't work.")
+            logger.error("'$JAVAC_CONTEXT_CLASS' class can't be found ('tools.jar' is absent in the plugin classpath). Kapt won't work.")
             return
         }
 


### PR DESCRIPTION
- Since warnings are discarded when there are others errors, replace the
current warning by an error to always display the message and inform the
user that its annotation processor is badly configured.

Fix of https://youtrack.jetbrains.com/issue/KT-23721