### PR TITLE
KT-23798 Deprecate Preconditions.error(msg) for illegalState(msg)

### DIFF
--- a/libraries/stdlib/samples/test/samples/misc/preconditions.kt
+++ b/libraries/stdlib/samples/test/samples/misc/preconditions.kt
@@ -10,7 +10,7 @@ class Preconditions {
     fun failWithError() {
         val name: String? = null
 
-        assertFailsWith<IllegalStateException> { val nonNullName = name ?: error("Name is missing") }
+        assertFailsWith<IllegalStateException> { val nonNullName = name ?: illegalState("Name is missing") }
     }
 
     @Sample

--- a/libraries/stdlib/src/kotlin/util/Preconditions.kt
+++ b/libraries/stdlib/src/kotlin/util/Preconditions.kt
@@ -129,4 +129,13 @@ public inline fun <T:Any> checkNotNull(value: T?, lazyMessage: () -> Any): T {
  * @sample samples.misc.Preconditions.failWithError
  */
 @kotlin.internal.InlineOnly
+@Deprecated("Use illegalState(message) instead", ReplaceWith("illegalState(message)"), DeprecationLevel.WARNING)
 public inline fun error(message: Any): Nothing = throw IllegalStateException(message.toString())
+
+/**
+ * Throws an [IllegalStateException] with the given [message].
+ *
+ * @sample samples.misc.Preconditions.failWithError
+ */
+@kotlin.internal.InlineOnly
+public inline fun illegalState(message: Any): Nothing = throw IllegalStateException(message.toString())


### PR DESCRIPTION
This is a suggestion to rename the `error(message)` function in Preconditions.kt. 

This PR is a first step fix for https://youtrack.jetbrains.com/issue/KT-23798 by deprecating the error method and creating a new, nearly identical method named `illegalState(message: Any)`

`error(message)` simply throws an `IllegalStateException(message)` with the message passed to it. 

However, it pollutes the global namespace and prevents others from creating extension methods for their projects (such as sending an error to Android `Log.e`, or their own custom logging / error handling). 

`error(message)`, as it is currently named, can easily be imported accidentally.  Because it throws a runtime exception, it could cause an unexpected crash.

Suggest removing it entirely or renaming it to something more descriptive like: `throwIllegalState(message: Any)` or `illegalState(message: Any)`

(This is my first PR here so please feel free to point me wherever I need to be if I missed anything)