### PR TITLE
Fix problem with trimEnd wiping out valid spans

### DIFF
--- a/libraries/stdlib/src/kotlin/text/Strings.kt
+++ b/libraries/stdlib/src/kotlin/text/Strings.kt
@@ -83,7 +83,7 @@ public inline fun String.trimStart(predicate: (Char) -> Boolean): String
 public inline fun CharSequence.trimEnd(predicate: (Char) -> Boolean): CharSequence {
     for (index in this.indices.reversed())
         if (!predicate(this[index]))
-            return substring(0, index + 1)
+            return subSequence(0, index + 1)
 
     return ""
 }


### PR DESCRIPTION
If I pass in a CharSequence with different spans (ImageSpans, colors, etc), the original trimEnd using substring incorrectly wiped out the spans.
changing to subSequence correctly preserves the span data