### PR TITLE
Logs source roots used by KaptTask

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/KaptTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/KaptTask.kt
@@ -113,6 +113,9 @@ open class KaptTask : ConventionTask(), CompilerArgumentAwareWithInput<K2JVMComp
         }
 
         val compilerRunner = GradleCompilerRunner(project)
+
+        sourceRoots.log(this.name, logger)
+
         val exitCode = compilerRunner.runJvmCompiler(
                 sourceRoots.kotlinSourceFiles,
                 sourceRoots.javaSourceRoots,


### PR DESCRIPTION
- KaptGenerateStubsTask logs its source roots, logs also them
into KaptTask to be homogeneous. It also allow to better
understand what are the inputs used by Tasks related to Kotlin
annotation processor.