### PR TITLE
KT-23931 Avoid infinite loop into RedundantGotoMethodTransformer

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/RedundantGotoMethodTransformer.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/RedundantGotoMethodTransformer.kt
@@ -45,7 +45,7 @@ class RedundantGotoMethodTransformer : MethodTransformer() {
         val insns = methodNode.instructions.toArray().apply { reverse() }
         val insnsToRemove = arrayListOf<AbstractInsnNode>()
         val currentLabels = hashSetOf<LabelNode>()
-        val labelsToReplace = hashMapOf<LabelNode, JumpInsnNode>()
+        val labelsToReplace = mutableMapOf<LabelNode, JumpInsnNode>()
         var pendingGoto: JumpInsnNode? = null
 
         for (insn in insns) {
@@ -82,17 +82,28 @@ class RedundantGotoMethodTransformer : MethodTransformer() {
 
     private fun rewriteLabelIfNeeded(
         jumpInsn: JumpInsnNode,
-        labelsToReplace: HashMap<LabelNode, JumpInsnNode>
+        labelsToReplace: MutableMap<LabelNode, JumpInsnNode>
     ) {
-        val lastTargetLabel = getLastTargetJumpInsn(jumpInsn, labelsToReplace).label
-        if (lastTargetLabel != jumpInsn.label) {
+        val lastJumpInsn = getLastTargetJumpInsn(jumpInsn, labelsToReplace, mutableListOf())
+        if (lastJumpInsn != null && lastJumpInsn != jumpInsn) {
             // Do not remove the old label because it can be used to define a local variable range.
-            jumpInsn.label = lastTargetLabel
+            jumpInsn.label = lastJumpInsn.label
         }
     }
 
-    private fun getLastTargetJumpInsn(jumpInsn: JumpInsnNode, labelsToReplace: HashMap<LabelNode, JumpInsnNode>): JumpInsnNode {
-        labelsToReplace[jumpInsn.label]?.let { return getLastTargetJumpInsn(it, labelsToReplace) }
+    private fun getLastTargetJumpInsn(
+        jumpInsn: JumpInsnNode,
+        labelsToReplace: MutableMap<LabelNode, JumpInsnNode>,
+        alreadyVisited: MutableList<JumpInsnNode>
+    ): JumpInsnNode? {
+        labelsToReplace[jumpInsn.label]?.let {
+            if (alreadyVisited.contains(it)) {
+                // Cycle detected, do no apply goto optimization
+                return null
+            }
+            alreadyVisited.add(it)
+            return getLastTargetJumpInsn(it, labelsToReplace, alreadyVisited)
+        }
         return jumpInsn
     }
 }

--- a/compiler/testData/codegen/bytecodeText/controlStructures/kt17110.kt
+++ b/compiler/testData/codegen/bytecodeText/controlStructures/kt17110.kt
@@ -12,10 +12,9 @@ fun test(x: Int, y: Int): String {
     return result
 }
 
-fun box(): String {
-    if (test(9, 10) != "c")
-        return "Failures"
-    return "OK"
+fun infiniteLoop() {
+    while(true) {}
 }
 
 // 2 GOTO L7
+// 1 GOTO L1


### PR DESCRIPTION
- Follow-up of 9fb0f5981339d4a4da687fa9722afe3a71a682f5 to avoid
infinite loop during redundant goto otpimization.

Fix of https://youtrack.jetbrains.com/issue/KT-23931