### PR TITLE
KT-22371 "Create secondary constructor" quick fix is not suggested for supertype constructor reference

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixRegistrar.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixRegistrar.kt
@@ -340,6 +340,7 @@ class QuickFixRegistrar : QuickFixContributor {
 
         NO_VALUE_FOR_PARAMETER.registerFactory(CreateConstructorFromSuperTypeCallActionFactory)
         TOO_MANY_ARGUMENTS.registerFactory(CreateConstructorFromSuperTypeCallActionFactory)
+        NONE_APPLICABLE.registerFactory(CreateConstructorFromSuperTypeCallActionFactory)
 
         UNRESOLVED_REFERENCE_WRONG_RECEIVER.registerFactory(CreateClassFromConstructorCallActionFactory)
         UNRESOLVED_REFERENCE.registerFactory(CreateClassFromConstructorCallActionFactory)

--- a/idea/testData/quickfix/createFromUsage/createSecondaryConstructor/superCallNoneApplicable.kt
+++ b/idea/testData/quickfix/createFromUsage/createSecondaryConstructor/superCallNoneApplicable.kt
@@ -1,0 +1,8 @@
+// "Create secondary constructor" "true"
+
+open class A {
+    constructor(x: Int, y: Int)
+    constructor(x: Int, y: String)
+}
+
+class B : <caret>A(1)

--- a/idea/testData/quickfix/createFromUsage/createSecondaryConstructor/superCallNoneApplicable.kt.after
+++ b/idea/testData/quickfix/createFromUsage/createSecondaryConstructor/superCallNoneApplicable.kt.after
@@ -1,0 +1,9 @@
+// "Create secondary constructor" "true"
+
+open class A {
+    constructor(x: Int, y: Int)
+    constructor(x: Int, y: String)
+    constructor(i: Int)
+}
+
+class B : A(1)

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -3810,6 +3810,11 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
                 runTest("idea/testData/quickfix/createFromUsage/createSecondaryConstructor/superCallNoClass.kt");
             }
 
+            @TestMetadata("superCallNoneApplicable.kt")
+            public void testSuperCallNoneApplicable() throws Exception {
+                runTest("idea/testData/quickfix/createFromUsage/createSecondaryConstructor/superCallNoneApplicable.kt");
+            }
+
             @TestMetadata("thisCall.kt")
             public void testThisCall() throws Exception {
                 runTest("idea/testData/quickfix/createFromUsage/createSecondaryConstructor/thisCall.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-22371