### PR TITLE
Provide template for pull requests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+Many thanks for your contribution, we genuinely appreciate it. 
+Make sure that you can say "YES" to each point in this short checklist:
+
+  - You do not have merge commits in PR
+  - You made a small number of changes
+  - You provided the link to related issue from YouTrack
+  - You can describe changes made is PR
+  - You made changes related to only one issue
+  - You are ready to defend your changes on code review
+  - You don't touch what you don't understand
+  - You ran the build locally, and it passed
+
+Thank you for your contribution!


### PR DESCRIPTION
It's been a long time since GitHub introduced templates for the pull request.
It would be helpful to have one in kotlin, with some quick checklist for new people.