### PR TITLE
KT-23511 "Remove parameter" quick fix: Remove unused type parameter used as type projection

### DIFF
--- a/idea/testData/quickfix/changeSignature/removeUnusedParameterWithTypeParameter7.kt
+++ b/idea/testData/quickfix/changeSignature/removeUnusedParameterWithTypeParameter7.kt
@@ -1,0 +1,8 @@
+// "Remove parameter 'x'" "true"
+interface TypeHolder<T, U>
+
+fun <T, U> baz(<caret>x: TypeHolder<T, U>) {}
+
+fun test(holder: TypeHolder<String, Int>) {
+    baz(holder)
+}

--- a/idea/testData/quickfix/changeSignature/removeUnusedParameterWithTypeParameter7.kt.after
+++ b/idea/testData/quickfix/changeSignature/removeUnusedParameterWithTypeParameter7.kt.after
@@ -1,0 +1,8 @@
+// "Remove parameter 'x'" "true"
+interface TypeHolder<T, U>
+
+fun baz(<caret>) {}
+
+fun test(holder: TypeHolder<String, Int>) {
+    baz()
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -1673,6 +1673,11 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
             runTest("idea/testData/quickfix/changeSignature/removeUnusedParameterWithTypeParameter6.kt");
         }
 
+        @TestMetadata("removeUnusedParameterWithTypeParameter7.kt")
+        public void testRemoveUnusedParameterWithTypeParameter7() throws Exception {
+            runTest("idea/testData/quickfix/changeSignature/removeUnusedParameterWithTypeParameter7.kt");
+        }
+
         @TestMetadata("removeUnusedPrimaryConstructorParameter.kt")
         public void testRemoveUnusedPrimaryConstructorParameter() throws Exception {
             runTest("idea/testData/quickfix/changeSignature/removeUnusedPrimaryConstructorParameter.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-23511#comment=27-2882256

Fix for this case:
```kt
interface TypeHolder<T, U>

fun <T, U> baz(<caret>x: TypeHolder<T, U>) {}

fun test(holder: TypeHolder<String, Int>) {
    baz(holder)
}
```