### PR TITLE
Add an extension point for plugin version check during updates. FOR REVIEW ONLY

### DIFF
--- a/idea/src/META-INF/extensions/compiler.xml
+++ b/idea/src/META-INF/extensions/compiler.xml
@@ -47,5 +47,7 @@
                         interface="com.intellij.ide.util.projectWizard.ModuleBuilder"/>
         <extensionPoint qualifiedName="org.jetbrains.kotlin.renameHandler"
                         interface="com.intellij.refactoring.rename.RenameHandler"/>
+        <extensionPoint qualifiedName="org.jetbrains.kotlin.pluginVersionChecker"
+                        interface="org.jetbrains.kotlin.idea.versionCheck.PluginVersionChecker"/>
     </extensionPoints>
 </idea-plugin>

--- a/idea/src/META-INF/plugin.xml
+++ b/idea/src/META-INF/plugin.xml
@@ -2927,6 +2927,7 @@
     <binaryExtension implementation="org.jetbrains.kotlin.idea.util.KotlinJsMetaBinary"/>
 
     <highlighterExtension implementation="org.jetbrains.kotlin.idea.highlighter.dsl.DslHighlighterExtension"/>
+    <pluginVersionChecker implementation="org.jetbrains.kotlin.idea.versionCheck.IdeaPluginVersionChecker"/>
   </extensions>
 
 </idea-plugin>

--- a/idea/src/org/jetbrains/kotlin/idea/KotlinPluginUpdater.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/KotlinPluginUpdater.kt
@@ -27,6 +27,8 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.Alarm
 import com.intellij.util.io.HttpRequests
 import com.intellij.util.text.VersionComparatorUtil
+import org.jetbrains.kotlin.idea.versionCheck.PluginVersionCheckFailed
+import org.jetbrains.kotlin.idea.versionCheck.PluginVersionChecker
 import java.io.File
 import java.io.IOException
 import java.io.PrintWriter
@@ -125,10 +127,10 @@ class KotlinPluginUpdater(val propertiesComponent: PropertiesComponent) : Dispos
         }
         else {
             try {
-                updateStatus = checkUpdatesInMainRepository()
+                updateStatus = checkUpdatesInRepository(null)
 
                 for (host in RepositoryHelper.getPluginHosts().filterNotNull()) {
-                    val customUpdateStatus = checkUpdatesInCustomRepository(host)
+                    val customUpdateStatus = checkUpdatesInRepository(host)
                     updateStatus = updateStatus.mergeWith(customUpdateStatus)
                 }
             }
@@ -148,50 +150,20 @@ class KotlinPluginUpdater(val propertiesComponent: PropertiesComponent) : Dispos
         }, ModalityState.any())
     }
 
-    private fun initPluginDescriptor(newVersion: String): IdeaPluginDescriptor {
-        val originalPlugin = PluginManager.getPlugin(KotlinPluginUtil.KOTLIN_PLUGIN_ID)!!
-        return PluginNode(KotlinPluginUtil.KOTLIN_PLUGIN_ID).apply {
-            version = newVersion
-            name = originalPlugin.name
-            description = originalPlugin.description
-        }
-    }
-
-    private fun checkUpdatesInMainRepository(): PluginUpdateStatus {
-        val buildNumber = ApplicationInfo.getInstance().apiVersion
+     private fun checkUpdatesInRepository(host: String?): PluginUpdateStatus {
         val currentVersion = KotlinPluginUtil.getPluginVersion()
-        val os = URLEncoder.encode(SystemInfo.OS_NAME + " " + SystemInfo.OS_VERSION, CharsetToolkit.UTF8)
-        val uid = PermanentInstallationID.get()
-        val pluginId = KotlinPluginUtil.KOTLIN_PLUGIN_ID.idString
-        val url = "https://plugins.jetbrains.com/plugins/list?pluginId=$pluginId&build=$buildNumber&pluginVersion=$currentVersion&os=$os&uuid=$uid"
-        val responseDoc = HttpRequests.request(url).connect {
-            JDOMUtil.load(it.inputStream)
+        try {
+            val pluginDescriptor = findPluginVersionChecker()?.getLatest(currentVersion, host)
+            return if (pluginDescriptor == null) PluginUpdateStatus.LatestVersionInstalled
+            else updateIfNotLatest(pluginDescriptor, host)
+        } catch (e: PluginVersionCheckFailed) {
+            return PluginUpdateStatus.CheckFailed(e.message!!)
         }
-        if (responseDoc.name != "plugin-repository") {
-            return PluginUpdateStatus.CheckFailed("Unexpected plugin repository response", JDOMUtil.writeElement(responseDoc, "\n"))
-        }
-        if (responseDoc.children.isEmpty()) {
-            // No plugin version compatible with current IDEA build; don't retry updates
-            return PluginUpdateStatus.LatestVersionInstalled
-        }
-        val newVersion = responseDoc.getChild("category")?.getChild("idea-plugin")?.getChild("version")?.text
-        if (newVersion == null) {
-            return PluginUpdateStatus.CheckFailed("Couldn't find plugin version in repository response", JDOMUtil.writeElement(responseDoc, "\n"))
-        }
-        val pluginDescriptor = initPluginDescriptor(newVersion)
-         return updateIfNotLatest(pluginDescriptor, null)
     }
 
-    private fun checkUpdatesInCustomRepository(host: String): PluginUpdateStatus {
-        val plugins = try {
-            RepositoryHelper.loadPlugins(host, null)
-        }
-        catch(e: Exception) {
-            return PluginUpdateStatus.fromException("Checking custom plugin repository $host failed", e)
-        }
-
-        val kotlinPlugin = plugins.find { it.pluginId == KotlinPluginUtil.KOTLIN_PLUGIN_ID } ?: return PluginUpdateStatus.LatestVersionInstalled
-        return updateIfNotLatest(kotlinPlugin, host)
+    private fun findPluginVersionChecker(): PluginVersionChecker? {
+        // TODO(juanch) implement a better strategy to pick a checker if there are multiple ones
+        return PluginVersionChecker.EP_NAME.extensions.firstOrNull()
     }
 
     private fun updateIfNotLatest(kotlinPlugin: IdeaPluginDescriptor, host: String?): PluginUpdateStatus {

--- a/idea/src/org/jetbrains/kotlin/idea/versionCheck/IdeaPluginVersionChecker.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/versionCheck/IdeaPluginVersionChecker.kt
@@ -1,0 +1,70 @@
+package org.jetbrains.kotlin.idea.versionCheck
+
+import com.intellij.ide.plugins.IdeaPluginDescriptor
+import com.intellij.ide.plugins.PluginManager
+import com.intellij.ide.plugins.PluginNode
+import com.intellij.ide.plugins.RepositoryHelper
+import com.intellij.openapi.application.ApplicationInfo
+import com.intellij.openapi.application.PermanentInstallationID
+import com.intellij.openapi.util.JDOMUtil
+import com.intellij.openapi.util.SystemInfo
+import com.intellij.openapi.vfs.CharsetToolkit
+import com.intellij.util.io.HttpRequests
+import com.intellij.util.text.VersionComparatorUtil
+import org.jetbrains.kotlin.idea.KotlinPluginUtil
+import org.jetbrains.kotlin.idea.PluginUpdateStatus
+import java.net.URLEncoder
+
+class IdeaPluginVersionChecker : PluginVersionChecker {
+  override fun getLatest(currentVersion: String?, host: String?): IdeaPluginDescriptor? {
+    if (host == null) {
+      val buildNumber = ApplicationInfo.getInstance().apiVersion
+      val os = URLEncoder.encode(SystemInfo.OS_NAME + " " + SystemInfo.OS_VERSION, CharsetToolkit.UTF8)
+      val uid = PermanentInstallationID.get()
+      return getLatestFromMainRepository(buildNumber, os, uid, currentVersion)
+    }
+    else return getLatestFromCustomRepository(host, currentVersion)
+  }
+
+  private fun getLatestFromMainRepository(buildNumber: String,
+                                          os: String,
+                                          uid: String,
+                                          currentVersion: String?): IdeaPluginDescriptor? {
+    val pluginId = KotlinPluginUtil.KOTLIN_PLUGIN_ID.idString
+    val url = "https://plugins.jetbrains.com/plugins/list?pluginId=$pluginId&build=$buildNumber&pluginVersion=$currentVersion&os=$os&uuid=$uid"
+    val responseDoc = HttpRequests.request(url).connect {
+      JDOMUtil.load(it.inputStream)
+    }
+    if (responseDoc.name != "plugin-repository") {
+      throw PluginVersionCheckFailed("Unexpected plugin repository response: ${JDOMUtil.writeElement(responseDoc, "\n")}")
+    }
+    if (responseDoc.children.isEmpty()) {
+      // No plugin version compatible with current IDEA build; don't retry updates
+      return null;
+    }
+    val newVersion = responseDoc.getChild("category")?.getChild("idea-plugin")?.getChild("version")?.text
+    if (newVersion == null) {
+      throw PluginVersionCheckFailed("Couldn't find plugin version in repository response: ${JDOMUtil.writeElement(responseDoc, "\n")}")
+    }
+    return initPluginDescriptor(newVersion)
+  }
+
+  private fun getLatestFromCustomRepository(host: String, currentVersion: String?): IdeaPluginDescriptor? {
+    val plugins = try {
+      RepositoryHelper.loadPlugins(host, null)
+    }
+    catch (e: Exception) {
+      throw PluginVersionCheckFailed("Checking custom plugin repository $host failed with $e")
+    }
+    return plugins.find { it.pluginId == KotlinPluginUtil.KOTLIN_PLUGIN_ID }
+  }
+
+  private fun initPluginDescriptor(newVersion: String): IdeaPluginDescriptor {
+    val originalPlugin = PluginManager.getPlugin(KotlinPluginUtil.KOTLIN_PLUGIN_ID)!!
+    return PluginNode(KotlinPluginUtil.KOTLIN_PLUGIN_ID).apply {
+      version = newVersion
+      name = originalPlugin.name
+      description = originalPlugin.description
+    }
+  }
+}

--- a/idea/src/org/jetbrains/kotlin/idea/versionCheck/PluginVersionCheckFailed.java
+++ b/idea/src/org/jetbrains/kotlin/idea/versionCheck/PluginVersionCheckFailed.java
@@ -1,0 +1,7 @@
+package org.jetbrains.kotlin.idea.versionCheck;
+
+public class PluginVersionCheckFailed extends Exception {
+  public PluginVersionCheckFailed(String message) {
+    super(message);
+  }
+}

--- a/idea/src/org/jetbrains/kotlin/idea/versionCheck/PluginVersionChecker.java
+++ b/idea/src/org/jetbrains/kotlin/idea/versionCheck/PluginVersionChecker.java
@@ -1,0 +1,18 @@
+package org.jetbrains.kotlin.idea.versionCheck;
+
+import com.intellij.ide.plugins.IdeaPluginDescriptor;
+import com.intellij.openapi.extensions.ExtensionPointName;
+import org.jetbrains.annotations.Nullable;
+
+public interface PluginVersionChecker {
+
+  ExtensionPointName<PluginVersionChecker> EP_NAME = new ExtensionPointName<>("org.jetbrains.kotlin.pluginVersionChecker");
+
+  /** Returns the latest Kotlin plugin version for the current build number, os, and channel.
+   *
+   * @param host plugin download host, null means the default host
+   * @return a nonnull plugin descriptor if there is a newer version to advertise, and null otherwise
+   * @throws PluginVersionCheckFailed if check fails
+   */
+  IdeaPluginDescriptor getLatest(@Nullable String currentVersion, @Nullable String host) throws PluginVersionCheckFailed;
+}


### PR DESCRIPTION
This commit is only for showing an extension point that allows configurations of Kotlin plugin version advertisement.

For convenience, in the pull request, the extension point is defined in the Kotlin plugin itself, instead of in IDEA as planned.