### PR TITLE
KT-24632 Quick fix to add getter and setter shouldn't use `field` when it is not allowed

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/intentions/AddAccessorIntentions.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/AddAccessorIntentions.kt
@@ -27,21 +27,22 @@ import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtPsiFactory
 
 abstract class AbstractAddAccessorsIntention(
-        private val addGetter: Boolean,
-        private val addSetter: Boolean
+    private val addGetter: Boolean,
+    private val addSetter: Boolean
 ) : SelfTargetingRangeIntention<KtProperty>(KtProperty::class.java, createFamilyName(addGetter, addSetter)) {
 
     override fun applicabilityRange(element: KtProperty): TextRange? {
         if (element.isLocal || element.isAbstract() || element.hasDelegate() ||
             element.hasModifier(KtTokens.LATEINIT_KEYWORD) ||
-            element.hasModifier(KtTokens.CONST_KEYWORD)) {
+            element.hasModifier(KtTokens.CONST_KEYWORD)
+        ) {
             return null
         }
         val descriptor = element.resolveToDescriptorIfAny() as? CallableMemberDescriptor ?: return null
         if (descriptor.isExpect) return null
 
         if (addSetter && (!element.isVar || element.setter != null)) return null
-        if (addGetter && element.getter != null) return null
+        if (addGetter && ((element.typeReference == null && element.initializer == null) || element.getter != null)) return null
         return element.nameIdentifier?.textRange
     }
 

--- a/idea/testData/intentions/addPropertyAccessors/both/noType.kt
+++ b/idea/testData/intentions/addPropertyAccessors/both/noType.kt
@@ -1,0 +1,4 @@
+// IS_APPLICABLE: false
+// SKIP_ERRORS_BEFORE
+// SKIP_ERRORS_AFTER
+var x<caret>

--- a/idea/testData/intentions/addPropertyAccessors/getter/noType.kt
+++ b/idea/testData/intentions/addPropertyAccessors/getter/noType.kt
@@ -1,0 +1,4 @@
+// IS_APPLICABLE: false
+// SKIP_ERRORS_BEFORE
+// SKIP_ERRORS_AFTER
+var x<caret>

--- a/idea/testData/intentions/addPropertyAccessors/setter/noType.kt
+++ b/idea/testData/intentions/addPropertyAccessors/setter/noType.kt
@@ -1,0 +1,3 @@
+// SKIP_ERRORS_BEFORE
+// SKIP_ERRORS_AFTER
+var x<caret>

--- a/idea/testData/intentions/addPropertyAccessors/setter/noType.kt.after
+++ b/idea/testData/intentions/addPropertyAccessors/setter/noType.kt.after
@@ -1,0 +1,6 @@
+// SKIP_ERRORS_BEFORE
+// SKIP_ERRORS_AFTER
+var x
+    set(value) {
+        field = value
+    }

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -1475,6 +1475,11 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
                 runTest("idea/testData/intentions/addPropertyAccessors/both/local.kt");
             }
 
+            @TestMetadata("noType.kt")
+            public void testNoType() throws Exception {
+                runTest("idea/testData/intentions/addPropertyAccessors/both/noType.kt");
+            }
+
             @TestMetadata("top.kt")
             public void testTop() throws Exception {
                 runTest("idea/testData/intentions/addPropertyAccessors/both/top.kt");
@@ -1543,6 +1548,11 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
                 runTest("idea/testData/intentions/addPropertyAccessors/getter/local.kt");
             }
 
+            @TestMetadata("noType.kt")
+            public void testNoType() throws Exception {
+                runTest("idea/testData/intentions/addPropertyAccessors/getter/noType.kt");
+            }
+
             @TestMetadata("top.kt")
             public void testTop() throws Exception {
                 runTest("idea/testData/intentions/addPropertyAccessors/getter/top.kt");
@@ -1604,6 +1614,11 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
             @TestMetadata("local.kt")
             public void testLocal() throws Exception {
                 runTest("idea/testData/intentions/addPropertyAccessors/setter/local.kt");
+            }
+
+            @TestMetadata("noType.kt")
+            public void testNoType() throws Exception {
+                runTest("idea/testData/intentions/addPropertyAccessors/setter/noType.kt");
             }
 
             @TestMetadata("top.kt")


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-24632