### PR TITLE
Android Extensions: make synthetic import resolution more resilient

### DIFF
--- a/plugins/android-extensions/android-extensions-idea/src/org/jetbrains/kotlin/android/synthetic/idea/res/IDEAndroidLayoutXmlFileManager.kt
+++ b/plugins/android-extensions/android-extensions-idea/src/org/jetbrains/kotlin/android/synthetic/idea/res/IDEAndroidLayoutXmlFileManager.kt
@@ -19,6 +19,7 @@ package org.jetbrains.kotlin.android.synthetic.idea.res
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.roots.ProjectRootModificationTracker
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiManager
 import com.intellij.psi.impl.PsiTreeChangePreprocessor
 import com.intellij.psi.util.CachedValue
 import com.intellij.psi.util.CachedValueProvider
@@ -62,9 +63,13 @@ class IDEAndroidLayoutXmlFileManager(val module: Module) : AndroidLayoutXmlFileM
     }
 
     override fun doExtractResources(layoutGroup: AndroidLayoutGroupData, module: ModuleDescriptor): AndroidLayoutGroup {
-        val layouts = layoutGroup.layouts.filter { it.isValid }.map { layout ->
+        val psiManager = PsiManager.getInstance(project)
+        val layouts = layoutGroup.layouts.map { psiFile ->
+            // Sometimes due to a race of later-invoked runnables, the PsiFile can be invalidated; make sure to refresh if possible,
+            val layout = if (psiFile.isValid) psiFile else psiManager.findFile(psiFile.virtualFile)
+
             val resources = arrayListOf<AndroidResource>()
-            layout.accept(AndroidXmlVisitor { id, widgetType, attribute ->
+            layout?.accept(AndroidXmlVisitor { id, widgetType, attribute ->
                 resources += parseAndroidResource(id, widgetType, attribute.valueElement)
             })
             AndroidLayout(resources)


### PR DESCRIPTION
In commit ec0abb0 (Fix EA-79206: Process only valid layout.xml...) we started to drop layouts with invalid PsiFiles during resolution of (synthetic) package fragments.

In Android Studio we run into invalid files quite often, unfortunately non-deterministically, and it seems to be caused by a race with some invokeLater'ed code from android-ndk; this has the side effect of now showing all the corresponding symbols as unresolved, and the imports themselves are suggested for removal.

As a temporary fix I propose we try again to get a valid PsiFile.

Bug: https://issuetracker.google.com/78547457

Sample invalidation trace for a layout PsiFile:
[invalidation_trace.txt](https://github.com/JetBrains/kotlin/files/2104401/invalidation_trace.txt)
