### PR TITLE
Find Kotlin class with alternative resolve enabled

### DIFF
--- a/idea/idea-jvm/src/org/jetbrains/kotlin/idea/run/KotlinRunConfiguration.java
+++ b/idea/idea-jvm/src/org/jetbrains/kotlin/idea/run/KotlinRunConfiguration.java
@@ -335,7 +335,8 @@ public class KotlinRunConfiguration extends JetRunConfiguration {
             JavaParameters params = new JavaParameters();
             JavaRunConfigurationModule module = myConfiguration.getConfigurationModule();
 
-            int classPathType = getClasspathType(module);
+            int classPathType = DumbService.getInstance(module.getProject()).computeWithAlternativeResolveEnabled(
+                    () -> getClasspathType(module));
 
             String jreHome = myConfiguration.ALTERNATIVE_JRE_PATH_ENABLED ? myConfiguration.ALTERNATIVE_JRE_PATH : null;
             JavaParametersUtil.configureModule(module, params, classPathType, jreHome);


### PR DESCRIPTION
Kotlin run configurations are failing non-deterministically in Android
Studio due to not finding the class while in dumb mode (while AS invokes
Gradle build or in indexing after that).

Fix that by finding class in KotlinRunConfiguration with alternative
resolve enabled.
