### PR TITLE
Use new API for getting the raw Android resources

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/agp25/kotlin/org/jetbrains/kotlin/gradle/plugin/android/Android25ProjectHandler.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/agp25/kotlin/org/jetbrains/kotlin/gradle/plugin/android/Android25ProjectHandler.kt
@@ -92,6 +92,13 @@ class Android25ProjectHandler(kotlinConfigurationTools: KotlinConfigurationTools
             variantData.addJavaSourceFoldersToModel(javaSourceDirectory)
 
     override fun getResDirectories(variantData: BaseVariant): List<File> {
+        val getAllResourcesMethod =
+            variantData::class.java.methods.firstOrNull { it.name == "getAllRawAndroidResources" }
+        if (getAllResourcesMethod != null) {
+            val allResources = getAllResourcesMethod.invoke(variantData) as FileCollection
+            return allResources.files.toList()
+        }
+
         return variantData.mergeResources?.computeResourceSetList0() ?: emptyList()
     }
 


### PR DESCRIPTION
A new method has been added in the Android Gradle
plugin 3.3.0. This commit switches from ussing the
MergeResources task, and uses getAllRawAndroidResources
API instead.

Test: manually verified