### PR TITLE
fix typos in documentation of JsQualifier annotation

### DIFF
--- a/libraries/stdlib/js/src/kotlin/annotations.kt
+++ b/libraries/stdlib/js/src/kotlin/annotations.kt
@@ -138,10 +138,10 @@ annotation class JsNonModule
  * The compiler turns references to `external` declarations either to plain unprefixed names (in case of *plain* modules)
  * or to plain imports.
  * However, if a JavaScript library provides its declarations in packages, you won't be satisfied with this.
- * You can tell the compiler to generate additional prefix before references to `external` declarations using the `@JsQuafier(...)`
+ * You can tell the compiler to generate additional prefix before references to `external` declarations using the `@JsQualifier(...)`
  * annotation.
  *
- * Note that a file marked with the `@JsQulifier(...)` annotation can't contain non-`external` declarations.
+ * Note that a file marked with the `@JsQualifier(...)` annotation can't contain non-`external` declarations.
  *
  * Example:
  *


### PR DESCRIPTION
This PR just contains a fix of a few typos in the documentation of the JsQualifier annotation.

The checklist for this PR:

YES  - You do not have merge commits in PR
YES  - You made a few changes
 NO - You provided the link to related issue from YouTrack
 YES - You can describe changes made in PR
 YES - You made changes related to only one issue
 YES - You are ready to defend your changes on code review
 YES - You didn't touch what you don't understand
 NO - You ran the build locally, and verified new functionality
 NO  - You ran related tests locally, and it passed

