### PR TITLE
Factor duplicated code.

### DIFF
--- a/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tower/ScopeTowerProcessors.kt
+++ b/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tower/ScopeTowerProcessors.kt
@@ -65,13 +65,12 @@ internal abstract class AbstractSimpleScopeTowerProcessor<C : Candidate>(
 ) : SimpleScopeTowerProcessor<C> {
     fun createCandidates(
         collector: Collection<CandidateWithBoundDispatchReceiver>,
-        f:(Boolean)->Boolean,
         kind: ExplicitReceiverKind,
         receiver: ReceiverValueWithSmartCastInfo?
     ) : Collection<C> {
         val result = mutableListOf<C>()
         for (candidate in collector) {
-            if (f(candidate.requiresExtensionReceiver)) {
+            if (candidate.requiresExtensionReceiver == (receiver != null)) {
                 result.add(
                     candidateFactory.createCandidate(
                         candidate,
@@ -98,13 +97,11 @@ internal class ExplicitReceiverScopeTowerProcessor<C : Candidate>(
         return when (data) {
             TowerData.Empty -> createCandidates(
                 MemberScopeTowerLevel(scopeTower, explicitReceiver).collectCandidates(null),
-                { !it },
                 ExplicitReceiverKind.DISPATCH_RECEIVER,
                 null
             )
             is TowerData.TowerLevel -> createCandidates(
                 data.level.collectCandidates(explicitReceiver),
-                { it },
                 ExplicitReceiverKind.EXTENSION_RECEIVER,
                 explicitReceiver
             )
@@ -132,7 +129,6 @@ private class QualifierScopeTowerProcessor<C : Candidate>(
 
         return createCandidates(
             QualifierScopeTowerLevel(scopeTower, qualifier).collectCandidates(null),
-            { !it },
             ExplicitReceiverKind.NO_EXPLICIT_RECEIVER,
             null
         )
@@ -149,13 +145,11 @@ private class NoExplicitReceiverScopeTowerProcessor<C : Candidate>(
     override fun simpleProcess(data: TowerData): Collection<C> = when (data) {
         is TowerData.TowerLevel -> createCandidates(
             data.level.collectCandidates(null),
-            { !it },
             ExplicitReceiverKind.NO_EXPLICIT_RECEIVER,
             null
         )
         is TowerData.BothTowerLevelAndImplicitReceiver -> createCandidates(
             data.level.collectCandidates(data.implicitReceiver),
-            { it },
             ExplicitReceiverKind.NO_EXPLICIT_RECEIVER,
             data.implicitReceiver
         )

--- a/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tower/ScopeTowerProcessors.kt
+++ b/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tower/ScopeTowerProcessors.kt
@@ -54,9 +54,31 @@ class SamePriorityCompositeScopeTowerProcessor<out C>(
 
 }
 
+interface SimpleScopeTowerProcessor<out C> : ScopeTowerProcessor<C> {
+    fun simpleProcess(data: TowerData): Collection<C>
+
+    override fun process(data: TowerData): List<Collection<C>> = listOfNotNull(simpleProcess(data).takeIf { it.isNotEmpty() })
+}
+
 internal abstract class AbstractSimpleScopeTowerProcessor<C : Candidate>(
     val candidateFactory: CandidateFactory<C>
-) : SimpleScopeTowerProcessor<C>
+) : SimpleScopeTowerProcessor<C> {
+    fun resolve(collector: Collection<CandidateWithBoundDispatchReceiver>, f:(Boolean)->Boolean, kind: ExplicitReceiverKind, receiver: ReceiverValueWithSmartCastInfo?) : Collection<C> {
+        val result = mutableListOf<C>()
+        for (candidate in collector) {
+            if (f(candidate.requiresExtensionReceiver)) {
+                result.add(
+                    candidateFactory.createCandidate(
+                        candidate,
+                        kind,
+                        extensionReceiver = receiver
+                    )
+                )
+            }
+        }
+        return result
+    }
+}
 
 private typealias CandidatesCollector =
         ScopeTowerLevel.(extensionReceiver: ReceiverValueWithSmartCastInfo?) -> Collection<CandidateWithBoundDispatchReceiver>
@@ -69,42 +91,18 @@ internal class ExplicitReceiverScopeTowerProcessor<C : Candidate>(
 ) : AbstractSimpleScopeTowerProcessor<C>(context) {
     override fun simpleProcess(data: TowerData): Collection<C> {
         return when (data) {
-            TowerData.Empty -> resolveAsMember()
-            is TowerData.TowerLevel -> resolveAsExtension(data.level)
+            TowerData.Empty -> resolve(
+                MemberScopeTowerLevel(scopeTower, explicitReceiver).collectCandidates(null),
+                { !it },
+                ExplicitReceiverKind.DISPATCH_RECEIVER,
+                null)
+            is TowerData.TowerLevel -> resolve(
+                data.level.collectCandidates(explicitReceiver),
+                { it },
+                ExplicitReceiverKind.EXTENSION_RECEIVER,
+                explicitReceiver)
             else -> emptyList()
         }
-    }
-
-    private fun resolveAsMember(): Collection<C> {
-        val members = mutableListOf<C>()
-        for (memberCandidate in MemberScopeTowerLevel(scopeTower, explicitReceiver).collectCandidates(null)) {
-            if (!memberCandidate.requiresExtensionReceiver) {
-                members.add(
-                    candidateFactory.createCandidate(
-                        memberCandidate,
-                        ExplicitReceiverKind.DISPATCH_RECEIVER,
-                        extensionReceiver = null
-                    )
-                )
-            }
-        }
-        return members
-    }
-
-    private fun resolveAsExtension(level: ScopeTowerLevel): Collection<C> {
-        val extensions = mutableListOf<C>()
-        for (extensionCandidate in level.collectCandidates(explicitReceiver)) {
-            if (extensionCandidate.requiresExtensionReceiver) {
-                extensions.add(
-                    candidateFactory.createCandidate(
-                        extensionCandidate,
-                        ExplicitReceiverKind.EXTENSION_RECEIVER,
-                        extensionReceiver = explicitReceiver
-                    )
-                )
-            }
-        }
-        return extensions
     }
 
     override fun recordLookups(skippedData: Collection<TowerData>, name: Name) {
@@ -125,19 +123,12 @@ private class QualifierScopeTowerProcessor<C : Candidate>(
     override fun simpleProcess(data: TowerData): Collection<C> {
         if (data != TowerData.Empty) return emptyList()
 
-        val staticMembers = mutableListOf<C>()
-        for (towerCandidate in QualifierScopeTowerLevel(scopeTower, qualifier).collectCandidates(null)) {
-            if (!towerCandidate.requiresExtensionReceiver) {
-                staticMembers.add(
-                    candidateFactory.createCandidate(
-                        towerCandidate,
-                        ExplicitReceiverKind.NO_EXPLICIT_RECEIVER,
-                        extensionReceiver = null
-                    )
-                )
-            }
-        }
-        return staticMembers
+        return resolve(
+            QualifierScopeTowerLevel(scopeTower, qualifier).collectCandidates(null),
+            { !it },
+            ExplicitReceiverKind.NO_EXPLICIT_RECEIVER,
+            null
+        )
     }
 
     // QualifierScopeTowerProcessor works only with TowerData.Empty that should not be ignored
@@ -149,36 +140,16 @@ private class NoExplicitReceiverScopeTowerProcessor<C : Candidate>(
     val collectCandidates: CandidatesCollector
 ) : AbstractSimpleScopeTowerProcessor<C>(context) {
     override fun simpleProcess(data: TowerData): Collection<C> = when (data) {
-        is TowerData.TowerLevel -> {
-            val result = mutableListOf<C>()
-            for (towerCandidate in data.level.collectCandidates(null)) {
-                if (!towerCandidate.requiresExtensionReceiver) {
-                    result.add(
-                        candidateFactory.createCandidate(
-                            towerCandidate,
-                            ExplicitReceiverKind.NO_EXPLICIT_RECEIVER,
-                            extensionReceiver = null
-                        )
-                    )
-                }
-            }
-            result
-        }
-        is TowerData.BothTowerLevelAndImplicitReceiver -> {
-            val result = mutableListOf<C>()
-            for (towerCandidate in data.level.collectCandidates(data.implicitReceiver)) {
-                if (towerCandidate.requiresExtensionReceiver) {
-                    result.add(
-                        candidateFactory.createCandidate(
-                            towerCandidate,
-                            ExplicitReceiverKind.NO_EXPLICIT_RECEIVER,
-                            extensionReceiver = data.implicitReceiver
-                        )
-                    )
-                }
-            }
-            result
-        }
+        is TowerData.TowerLevel -> resolve(
+            data.level.collectCandidates(null),
+            { !it },
+            ExplicitReceiverKind.NO_EXPLICIT_RECEIVER,
+            null)
+        is TowerData.BothTowerLevelAndImplicitReceiver -> resolve(
+            data.level.collectCandidates(data.implicitReceiver),
+            { it },
+            ExplicitReceiverKind.NO_EXPLICIT_RECEIVER,
+            data.implicitReceiver)
         else -> emptyList()
     }
 

--- a/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tower/TowerResolver.kt
+++ b/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tower/TowerResolver.kt
@@ -74,12 +74,6 @@ interface ScopeTowerProcessor<out C> {
     fun recordLookups(skippedData: Collection<TowerData>, name: Name)
 }
 
-interface SimpleScopeTowerProcessor<out C> : ScopeTowerProcessor<C> {
-    fun simpleProcess(data: TowerData): Collection<C>
-
-    override fun process(data: TowerData): List<Collection<C>> = listOfNotNull(simpleProcess(data).takeIf { it.isNotEmpty() })
-}
-
 class TowerResolver {
     fun <C : Candidate> runResolve(
         scopeTower: ImplicitScopeTower,


### PR DESCRIPTION
Move SimpleScopeTowerProcessor from TowerResolver into ScopeTowerProcessors.

Lift code duplicated in functions:

  * ExplicitReceiverScopeTowerProcessor.simpleProcess()
  * QualifierScopeTowerProcessor.simpleProcess()
  * NoExplicitReceiverScopeTowerProcessor.simpleProcess()

into AbstractSimpleScopeTowerProcessor. Turn it into a function and call it
in the various context. Incidentally, now useless functions resolveAsMember()
and resolveAsExtension() are  removed.

Many thanks for your contribution, we genuinely appreciate it. 
Make sure that you can say "YES" to each point in this short checklist:

  - You do not have merge commits in PR - yes
  - You made a few changes - yes
  - You provided the link to related issue from YouTrack - irrelevant
  - You can describe changes made in PR - yes
  - You made changes related to only one issue - yes
  - You are ready to defend your changes on code review - yes
  - You didn't touch what you don't understand - partly
  - You ran the build locally, and verified new functionality  - yes
  - You ran related tests locally, and it passed - yes

Thank you for your contribution!
