### PR TITLE
Add companion object to Boolean

### DIFF
--- a/core/builtins/native/kotlin/Boolean.kt
+++ b/core/builtins/native/kotlin/Boolean.kt
@@ -21,6 +21,8 @@ package kotlin
  * represented as values of the primitive type `boolean`.
  */
 public class Boolean private constructor() : Comparable<Boolean> {
+    companion object {}
+
     /**
      * Returns the inverse of this boolean.
      */


### PR DESCRIPTION
This PR adds a companion object to Boolean, as it's the only primitive type without one.

The rationale behind is being able to add discoverable APIs via extensions to the `Boolean` companion, the same way it's currently possible for every other primitive type, like [`Byte`](https://github.com/arrow-kt/arrow/blob/master/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/number.kt#L28-L41), [`String`](https://github.com/arrow-kt/arrow/blob/master/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/string.kt#L16-L31) or [`Short`](https://github.com/arrow-kt/arrow/blob/master/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/number.kt#L211-L224).

YouTrack: https://youtrack.jetbrains.com/issue/KT-7922