### PR TITLE
Fix possible intersection of diagnostic tags (diagnostic compiler tests)

### DIFF
--- a/compiler/frontend/src/org/jetbrains/kotlin/checkers/CheckerTestUtil.java
+++ b/compiler/frontend/src/org/jetbrains/kotlin/checkers/CheckerTestUtil.java
@@ -432,6 +432,14 @@ public class CheckerTestUtil {
                 opened.pop();
             }
             while (currentDescriptor != null && i == currentDescriptor.start) {
+                while (!opened.isEmpty()) {
+                    if (currentDescriptor.getEnd() > opened.peek().end) {
+                        closeDiagnosticString(result);
+                        opened.pop();
+                    } else {
+                        break;
+                    }
+                }
                 openDiagnosticsString(result, currentDescriptor, diagnosticToExpectedDiagnostic, withNewInferenceDirective);
                 if (currentDescriptor.getEnd() == i) {
                     closeDiagnosticString(result);


### PR DESCRIPTION
It may happen that the end position of the opened diagnostic will be greater than the end position of the previously open (but not yet closed) diagnostic. That is, the intersection of diagnostic tags.

In this case, an exception will be thrown: `Stack is not empty` (`472` line in the `compiler/frontend/src/org/jetbrains/kotlin/checkers/CheckerTestUtil.java`).

**Example (negative compiler test):**
```
fun foo(value: Int, obj1: List<String>, obj3: Nothing) {
    when {
        value == 14 -> obj3 === obj1 && value = 2
    }
}
```
`VARIABLE_EXPECTED`  diagnostic has a start position `114`, end position — `136`.
`UNREACABLE_CODE`  diagnostic has a start position `119`, end position — `140`.
That is, the diagnostic `VARIABLE_EXPECTED` and `UNREACABLE_CODE` intersect.

This code adds a check before opening of a new diagnostic that already in the open diagnostics (but not yet closed) end position less than end position opening diagnostic. For such diagnostics, the closing tag is immediately inserted (immediately closing diagnostic).