### PR TITLE
KT-24694 Move lambda out of parentheses should not be applied for multiple functional parameters

### DIFF
--- a/idea/testData/inspectionsLocal/moveLambdaOutsideParentheses/inapplicableMultiFunctionTypeParameters.kt
+++ b/idea/testData/inspectionsLocal/moveLambdaOutsideParentheses/inapplicableMultiFunctionTypeParameters.kt
@@ -1,0 +1,10 @@
+// PROBLEM: none
+
+fun test(a: (String) -> Unit = {}, b: (String) -> Unit = {}) {
+    a("a")
+    b("b")
+}
+
+fun foo() {
+    test(<caret>{ })
+}

--- a/idea/testData/inspectionsLocal/moveLambdaOutsideParentheses/inapplicableMultiFunctionTypeParameters2.kt
+++ b/idea/testData/inspectionsLocal/moveLambdaOutsideParentheses/inapplicableMultiFunctionTypeParameters2.kt
@@ -1,0 +1,8 @@
+fun test(a: (String) -> Unit = {}, b: (String) -> Unit = {}) {
+    a("a")
+    b("b")
+}
+
+fun foo() {
+    test({ }, { }<caret>)
+}

--- a/idea/testData/inspectionsLocal/moveLambdaOutsideParentheses/inapplicableMultiFunctionTypeParameters2.kt.after
+++ b/idea/testData/inspectionsLocal/moveLambdaOutsideParentheses/inapplicableMultiFunctionTypeParameters2.kt.after
@@ -1,0 +1,8 @@
+fun test(a: (String) -> Unit = {}, b: (String) -> Unit = {}) {
+    a("a")
+    b("b")
+}
+
+fun foo() {
+    test({ }) { }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -2665,6 +2665,16 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
             runTest("idea/testData/inspectionsLocal/moveLambdaOutsideParentheses/inapplicableAlreadyHasFunctionLiteral.kt");
         }
 
+        @TestMetadata("inapplicableMultiFunctionTypeParameters.kt")
+        public void testInapplicableMultiFunctionTypeParameters() throws Exception {
+            runTest("idea/testData/inspectionsLocal/moveLambdaOutsideParentheses/inapplicableMultiFunctionTypeParameters.kt");
+        }
+
+        @TestMetadata("inapplicableMultiFunctionTypeParameters2.kt")
+        public void testInapplicableMultiFunctionTypeParameters2() throws Exception {
+            runTest("idea/testData/inspectionsLocal/moveLambdaOutsideParentheses/inapplicableMultiFunctionTypeParameters2.kt");
+        }
+
         @TestMetadata("inapplicableOptionalParametersAfter.kt")
         public void testInapplicableOptionalParametersAfter() throws Exception {
             runTest("idea/testData/inspectionsLocal/moveLambdaOutsideParentheses/inapplicableOptionalParametersAfter.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-24694