### PR TITLE
Introduce KotlinInspectionSuppressor

### DIFF
--- a/idea/idea-analysis/src/org/jetbrains/kotlin/idea/inspections/KotlinInspectionSuppressor.kt
+++ b/idea/idea-analysis/src/org/jetbrains/kotlin/idea/inspections/KotlinInspectionSuppressor.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2010-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.idea.inspections
+
+import com.intellij.codeInspection.InspectionSuppressor
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.SuppressManager
+import com.intellij.codeInspection.SuppressQuickFix
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.caches.resolve.KotlinCacheService
+import org.jetbrains.kotlin.diagnostics.Severity
+import org.jetbrains.kotlin.idea.highlighter.createSuppressWarningActions
+
+class KotlinInspectionSuppressor : InspectionSuppressor {
+    override fun getSuppressActions(element: PsiElement?, toolId: String): Array<SuppressQuickFix> {
+        element ?: return emptyArray()
+        return createSuppressWarningActions(element, Severity.WARNING, toolId).map {
+            object : SuppressQuickFix {
+                override fun getFamilyName() = it.familyName
+
+                override fun applyFix(project: Project, descriptor: ProblemDescriptor) = it.invoke(project, null, descriptor.psiElement)
+
+                override fun isAvailable(project: Project, context: PsiElement) = it.isAvailable(project, null, context)
+
+                override fun isSuppressAll() = it.isSuppressAll
+            }
+        }.toTypedArray()
+    }
+
+    override fun isSuppressedFor(element: PsiElement, toolId: String): Boolean {
+        if (SuppressManager.getInstance()!!.isSuppressedFor(element, toolId)) {
+            return true
+        }
+
+        if (KotlinCacheService.getInstance(element.project).getSuppressionCache().isSuppressed(element, toolId, Severity.WARNING)) {
+            return true
+        }
+
+        return false
+    }
+}

--- a/idea/idea-analysis/src/org/jetbrains/kotlin/idea/inspections/KotlinInspectionSuppressor.kt
+++ b/idea/idea-analysis/src/org/jetbrains/kotlin/idea/inspections/KotlinInspectionSuppressor.kt
@@ -22,6 +22,8 @@ class KotlinInspectionSuppressor : InspectionSuppressor {
             object : SuppressQuickFix {
                 override fun getFamilyName() = it.familyName
 
+                override fun getName() = it.text
+
                 override fun applyFix(project: Project, descriptor: ProblemDescriptor) = it.invoke(project, null, descriptor.psiElement)
 
                 override fun isAvailable(project: Project, context: PsiElement) = it.isAvailable(project, null, context)

--- a/idea/src/META-INF/plugin.xml
+++ b/idea/src/META-INF/plugin.xml
@@ -1642,6 +1642,8 @@ The Kotlin plugin provides language support in IntelliJ IDEA and Android Studio.
       <category>Kotlin</category>
     </intentionAction>
 
+    <lang.inspectionSuppressor language="kotlin" implementationClass="org.jetbrains.kotlin.idea.inspections.KotlinInspectionSuppressor"/>
+
     <localInspection implementationClass="org.jetbrains.kotlin.idea.intentions.ObjectLiteralToLambdaInspection"
                      displayName="Object literal can be converted to lambda"
                      groupPath="Kotlin"

--- a/idea/src/META-INF/plugin.xml.172
+++ b/idea/src/META-INF/plugin.xml.172
@@ -1640,6 +1640,8 @@ The Kotlin plugin provides language support in IntelliJ IDEA and Android Studio.
       <category>Kotlin</category>
     </intentionAction>
 
+    <lang.inspectionSuppressor language="kotlin" implementationClass="org.jetbrains.kotlin.idea.inspections.KotlinInspectionSuppressor"/>
+
     <localInspection implementationClass="org.jetbrains.kotlin.idea.intentions.ObjectLiteralToLambdaInspection"
                      displayName="Object literal can be converted to lambda"
                      groupPath="Kotlin"

--- a/idea/src/META-INF/plugin.xml.173
+++ b/idea/src/META-INF/plugin.xml.173
@@ -1640,6 +1640,8 @@ The Kotlin plugin provides language support in IntelliJ IDEA and Android Studio.
       <category>Kotlin</category>
     </intentionAction>
 
+    <lang.inspectionSuppressor language="kotlin" implementationClass="org.jetbrains.kotlin.idea.inspections.KotlinInspectionSuppressor"/>
+
     <localInspection implementationClass="org.jetbrains.kotlin.idea.intentions.ObjectLiteralToLambdaInspection"
                      displayName="Object literal can be converted to lambda"
                      groupPath="Kotlin"

--- a/idea/src/META-INF/plugin.xml.182
+++ b/idea/src/META-INF/plugin.xml.182
@@ -1641,6 +1641,8 @@ The Kotlin plugin provides language support in IntelliJ IDEA and Android Studio.
       <category>Kotlin</category>
     </intentionAction>
 
+    <lang.inspectionSuppressor language="kotlin" implementationClass="org.jetbrains.kotlin.idea.inspections.KotlinInspectionSuppressor"/>
+
     <localInspection implementationClass="org.jetbrains.kotlin.idea.intentions.ObjectLiteralToLambdaInspection"
                      displayName="Object literal can be converted to lambda"
                      groupPath="Kotlin"

--- a/idea/src/META-INF/plugin.xml.as31
+++ b/idea/src/META-INF/plugin.xml.as31
@@ -1640,6 +1640,8 @@ The Kotlin plugin provides language support in IntelliJ IDEA and Android Studio.
       <category>Kotlin</category>
     </intentionAction>
 
+    <lang.inspectionSuppressor language="kotlin" implementationClass="org.jetbrains.kotlin.idea.inspections.KotlinInspectionSuppressor"/>
+
     <localInspection implementationClass="org.jetbrains.kotlin.idea.intentions.ObjectLiteralToLambdaInspection"
                      displayName="Object literal can be converted to lambda"
                      groupPath="Kotlin"

--- a/idea/src/META-INF/plugin.xml.as32
+++ b/idea/src/META-INF/plugin.xml.as32
@@ -1640,6 +1640,8 @@ The Kotlin plugin provides language support in IntelliJ IDEA and Android Studio.
       <category>Kotlin</category>
     </intentionAction>
 
+    <lang.inspectionSuppressor language="kotlin" implementationClass="org.jetbrains.kotlin.idea.inspections.KotlinInspectionSuppressor"/>
+
     <localInspection implementationClass="org.jetbrains.kotlin.idea.intentions.ObjectLiteralToLambdaInspection"
                      displayName="Object literal can be converted to lambda"
                      groupPath="Kotlin"

--- a/idea/testData/quickfix/suppress/external/suppressActive.kt
+++ b/idea/testData/quickfix/suppress/external/suppressActive.kt
@@ -1,0 +1,8 @@
+// "Typo: Change to..." "false"
+// TOOL: com.intellij.spellchecker.inspections.SpellCheckingInspection
+// ACTION: Add 'const' modifier
+// ACTION: Convert property initializer to getter
+// ACTION: To raw string literal
+
+@Suppress("SpellCheckingInspection")
+val str = "<caret>kjsghkjshtiurhuig"

--- a/idea/testData/quickfix/suppress/external/suppressAvailable.kt
+++ b/idea/testData/quickfix/suppress/external/suppressAvailable.kt
@@ -1,4 +1,4 @@
-// "Suppress Warnings" "true"
+// "Suppress 'SpellCheckingInspection' for val str" "true"
 // TOOL: com.intellij.spellchecker.inspections.SpellCheckingInspection
 // ACTION: Add 'const' modifier
 // ACTION: Typo: Change to...
@@ -12,5 +12,6 @@
 // ACTION: Convert property initializer to getter
 // ACTION: Inject language or reference
 // ACTION: To raw string literal
+// ACTION: Suppress 'SpellCheckingInspection' for file suppressAvailable.kt
 
 val str = "<caret>kjsghkjshtiurhuig"

--- a/idea/testData/quickfix/suppress/external/suppressAvailable.kt
+++ b/idea/testData/quickfix/suppress/external/suppressAvailable.kt
@@ -1,0 +1,16 @@
+// "Suppress Warnings" "true"
+// TOOL: com.intellij.spellchecker.inspections.SpellCheckingInspection
+// ACTION: Add 'const' modifier
+// ACTION: Typo: Change to...
+// ACTION: Edit inspection profile setting
+// ACTION: Fix all 'Typo' problems in file
+// ACTION: Run inspection on ...
+// ACTION: Disable inspection
+// ACTION: Save 'kjsghkjshtiurhuig' to project-level dictionary
+// ACTION: Show property type hints
+// ACTION: Edit intention settings
+// ACTION: Convert property initializer to getter
+// ACTION: Inject language or reference
+// ACTION: To raw string literal
+
+val str = "<caret>kjsghkjshtiurhuig"

--- a/idea/testData/quickfix/suppress/external/suppressAvailable.kt.after
+++ b/idea/testData/quickfix/suppress/external/suppressAvailable.kt.after
@@ -1,4 +1,4 @@
-// "Suppress Warnings" "true"
+// "Suppress 'SpellCheckingInspection' for val str" "true"
 // TOOL: com.intellij.spellchecker.inspections.SpellCheckingInspection
 // ACTION: Add 'const' modifier
 // ACTION: Typo: Change to...
@@ -12,6 +12,7 @@
 // ACTION: Convert property initializer to getter
 // ACTION: Inject language or reference
 // ACTION: To raw string literal
+// ACTION: Suppress 'SpellCheckingInspection' for file suppressAvailable.kt
 
 @Suppress("SpellCheckingInspection")
 val str = "kjsghkjshtiurhuig"

--- a/idea/testData/quickfix/suppress/external/suppressAvailable.kt.after
+++ b/idea/testData/quickfix/suppress/external/suppressAvailable.kt.after
@@ -1,0 +1,17 @@
+// "Suppress Warnings" "true"
+// TOOL: com.intellij.spellchecker.inspections.SpellCheckingInspection
+// ACTION: Add 'const' modifier
+// ACTION: Typo: Change to...
+// ACTION: Edit inspection profile setting
+// ACTION: Fix all 'Typo' problems in file
+// ACTION: Run inspection on ...
+// ACTION: Disable inspection
+// ACTION: Save 'kjsghkjshtiurhuig' to project-level dictionary
+// ACTION: Show property type hints
+// ACTION: Edit intention settings
+// ACTION: Convert property initializer to getter
+// ACTION: Inject language or reference
+// ACTION: To raw string literal
+
+@Suppress("SpellCheckingInspection")
+val str = "kjsghkjshtiurhuig"

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixMultiFileTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixMultiFileTestGenerated.java
@@ -3696,6 +3696,19 @@ public class QuickFixMultiFileTestGenerated extends AbstractQuickFixMultiFileTes
             }
         }
 
+        @TestMetadata("idea/testData/quickfix/suppress/external")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class External extends AbstractQuickFixMultiFileTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest(this::doTestWithExtraFile, TargetBackend.ANY, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInExternal() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/quickfix/suppress/external"), Pattern.compile("^(\\w+)\\.((before\\.Main\\.\\w+)|(test))$"), TargetBackend.ANY, true);
+            }
+        }
+
         @TestMetadata("idea/testData/quickfix/suppress/forStatement")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -10286,6 +10286,29 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
             }
         }
 
+        @TestMetadata("idea/testData/quickfix/suppress/external")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class External extends AbstractQuickFixTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInExternal() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/quickfix/suppress/external"), Pattern.compile("^([\\w\\-_]+)\\.kt$"), TargetBackend.ANY, true);
+            }
+
+            @TestMetadata("suppressActive.kt")
+            public void testSuppressActive() throws Exception {
+                runTest("idea/testData/quickfix/suppress/external/suppressActive.kt");
+            }
+
+            @TestMetadata("suppressAvailable.kt")
+            public void testSuppressAvailable() throws Exception {
+                runTest("idea/testData/quickfix/suppress/external/suppressAvailable.kt");
+            }
+        }
+
         @TestMetadata("idea/testData/quickfix/suppress/forStatement")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)


### PR DESCRIPTION
So https://youtrack.jetbrains.com/issue/KT-11154 Fixed
So https://youtrack.jetbrains.com/issue/KT-25169 Fixed

Well, spell checking inspection is now suppressable, I checked it. But I don't know this place well enough and it would be good if somebody else looked attentively at this place. Feel free to merge / rebase it yourself, if it's Ok.