### PR TITLE
Use getJavaMemberDescriptor to resolve jvm classes.

### DIFF
--- a/idea/idea-core/src/org/jetbrains/kotlin/idea/core/KotlinIndicesHelper.kt
+++ b/idea/idea-core/src/org/jetbrains/kotlin/idea/core/KotlinIndicesHelper.kt
@@ -234,7 +234,7 @@ class KotlinIndicesHelper(
     fun getJvmClassesByName(name: String): Collection<ClassDescriptor> {
         return PsiShortNamesCache.getInstance(project).getClassesByName(name, scope)
                 .filter { it in scope && it.containingFile != null }
-                .mapNotNull { it.resolveToDescriptor(resolutionFacade) }
+                .mapNotNull { it.getJavaMemberDescriptor() as? ClassDescriptor }
                 .filter(descriptorFilter)
                 .toSet()
     }


### PR DESCRIPTION
This change is to address AEs in Android Studio like:

https://youtrack.jetbrains.com/issue/KT-22799

Android Studio has received quite some reports with similar stack traces.