### PR TITLE
Use "implementation" when adding Kotlin dependencies into build scripts.

### DIFF
--- a/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/GroovyBuildScriptManipulator.kt
+++ b/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/GroovyBuildScriptManipulator.kt
@@ -252,7 +252,7 @@ class GroovyBuildScriptManipulator(
     private fun getGroovyDependencySnippet(
         artifactName: String,
         withVersion: Boolean
-    ) = "compile \"org.jetbrains.kotlin:$artifactName${if (withVersion) ":\$kotlin_version" else ""}\""
+    ) = "implementation \"org.jetbrains.kotlin:$artifactName${if (withVersion) ":\$kotlin_version" else ""}\""
 
     private fun getApplyPluginDirective(pluginName: String) = "apply plugin: '$pluginName'"
 

--- a/idea/testData/configuration/android-gradle/androidStudioDefaultShapshot_after.gradle
+++ b/idea/testData/configuration/android-gradle/androidStudioDefaultShapshot_after.gradle
@@ -33,7 +33,7 @@ android {
 
 dependencies {
     compile 'com.android.support:support-v4:13.0.0'
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 
 // VERSION: $VERSION$

--- a/idea/testData/configuration/android-gradle/androidStudioDefault_after.gradle
+++ b/idea/testData/configuration/android-gradle/androidStudioDefault_after.gradle
@@ -27,5 +27,5 @@ android {
 
 dependencies {
     compile 'com.android.support:support-v4:13.0.0'
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/idea/testData/configuration/android-gradle/buildConfigs_after.gradle
+++ b/idea/testData/configuration/android-gradle/buildConfigs_after.gradle
@@ -34,5 +34,5 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/idea/testData/configuration/android-gradle/emptyDependencyList_after.gradle
+++ b/idea/testData/configuration/android-gradle/emptyDependencyList_after.gradle
@@ -18,5 +18,5 @@ android {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/idea/testData/configuration/android-gradle/emptyFile_after.gradle
+++ b/idea/testData/configuration/android-gradle/emptyFile_after.gradle
@@ -12,5 +12,5 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/idea/testData/configuration/android-gradle/gradleExamples/gradleExample0_after.gradle
+++ b/idea/testData/configuration/android-gradle/gradleExamples/gradleExample0_after.gradle
@@ -34,7 +34,7 @@ project.afterEvaluate {
 
 dependencies {
     compile project(':lib')
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 
 buildscript {

--- a/idea/testData/configuration/android-gradle/gradleExamples/gradleExample18_after.gradle
+++ b/idea/testData/configuration/android-gradle/gradleExamples/gradleExample18_after.gradle
@@ -20,7 +20,7 @@ dependencies {
     debugCompile 'com.android.support:support-v13:13.0.0'
 
     compile 'com.google.android.gms:play-services:3.1.36'
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 
 android {

--- a/idea/testData/configuration/android-gradle/gradleExamples/gradleExample22_after.gradle
+++ b/idea/testData/configuration/android-gradle/gradleExamples/gradleExample22_after.gradle
@@ -52,5 +52,5 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/idea/testData/configuration/android-gradle/gradleExamples/gradleExample44_after.gradle
+++ b/idea/testData/configuration/android-gradle/gradleExamples/gradleExample44_after.gradle
@@ -63,5 +63,5 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/idea/testData/configuration/android-gradle/gradleExamples/gradleExample50_after.gradle
+++ b/idea/testData/configuration/android-gradle/gradleExamples/gradleExample50_after.gradle
@@ -27,5 +27,5 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/idea/testData/configuration/android-gradle/gradleExamples/gradleExample58_after.gradle
+++ b/idea/testData/configuration/android-gradle/gradleExamples/gradleExample58_after.gradle
@@ -28,5 +28,5 @@ android.applicationVariants.each { variant ->
     variant.outputFile = file("$project.buildDir/${variant.name}.apk")
 }
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/idea/testData/configuration/android-gradle/gradleExamples/gradleExample5_after.gradle
+++ b/idea/testData/configuration/android-gradle/gradleExamples/gradleExample5_after.gradle
@@ -47,5 +47,5 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/idea/testData/configuration/android-gradle/gradleExamples/gradleExample65_after.gradle
+++ b/idea/testData/configuration/android-gradle/gradleExamples/gradleExample65_after.gradle
@@ -21,7 +21,7 @@ repositories {
 dependencies {
     compile 'com.example.android.multiproject:util:1.0'
     releaseCompile 'com.google.guava:guava:11.0.2'
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 
 android {

--- a/idea/testData/configuration/android-gradle/gradleExamples/gradleExample8_after.gradle
+++ b/idea/testData/configuration/android-gradle/gradleExamples/gradleExample8_after.gradle
@@ -11,7 +11,7 @@ android {
 //
 dependencies {
     compile project(':lib')
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 
 buildscript {

--- a/idea/testData/configuration/android-gradle/helloWorld_after.gradle
+++ b/idea/testData/configuration/android-gradle/helloWorld_after.gradle
@@ -19,5 +19,5 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/idea/testData/configuration/android-gradle/libraryFile_after.gradle
+++ b/idea/testData/configuration/android-gradle/libraryFile_after.gradle
@@ -41,5 +41,5 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/idea/testData/configuration/android-gradle/missedApplyAndroidStatement_after.gradle
+++ b/idea/testData/configuration/android-gradle/missedApplyAndroidStatement_after.gradle
@@ -26,5 +26,5 @@ android {
 
 dependencies {
     compile 'com.android.support:support-v4:13.0.0'
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/idea/testData/configuration/android-gradle/missedBuildscriptBlock_after.gradle
+++ b/idea/testData/configuration/android-gradle/missedBuildscriptBlock_after.gradle
@@ -17,7 +17,7 @@ android {
 
 dependencies {
     compile 'com.android.support:support-v4:13.0.0'
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 buildscript {
     ext.kotlin_version = '$VERSION$'

--- a/idea/testData/configuration/android-gradle/missedRepositoriesInBuildscriptBlock_after.gradle
+++ b/idea/testData/configuration/android-gradle/missedRepositoriesInBuildscriptBlock_after.gradle
@@ -33,7 +33,7 @@ android {
 
 dependencies {
     compile 'com.android.support:support-v4:13.0.0'
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 
 // VERSION: $VERSION$

--- a/idea/testData/configuration/android-gradle/productFlavor_after.gradle
+++ b/idea/testData/configuration/android-gradle/productFlavor_after.gradle
@@ -27,5 +27,5 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }


### PR DESCRIPTION
Currently "compile" is used when kotlin dependencies are added into build
scripts during Kotlin configuration. "compile" is deprecated.