### PR TITLE
KT-23445 Inspection and quickfix to replace `assertTrue(a == b)` with `assertEquals(a, b)`

### DIFF
--- a/idea/resources/inspectionDescriptions/ReplaceAssertBooleanWithAssertEquality.html
+++ b/idea/resources/inspectionDescriptions/ReplaceAssertBooleanWithAssertEquality.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+This inspection reports assert boolean function calls replaceable with assert equality function.
+Example: <b>assertTrue(a == b)</b> can be replaced by <b>assertEquals(a, b)</b>.
+</body>
+</html>

--- a/idea/src/META-INF/plugin.xml
+++ b/idea/src/META-INF/plugin.xml
@@ -2967,6 +2967,15 @@ The Kotlin plugin provides language support in IntelliJ IDEA and Android Studio.
                      language="kotlin"
     />
 
+    <localInspection implementationClass="org.jetbrains.kotlin.idea.inspections.ReplaceAssertBooleanWithAssertEqualityInspection"
+                     displayName="Replace assert boolean with assert equality"
+                     groupPath="Kotlin"
+                     groupName="Style issues"
+                     enabledByDefault="true"
+                     level="INFORMATION"
+                     language="kotlin"
+    />
+
     <referenceImporter implementation="org.jetbrains.kotlin.idea.quickfix.KotlinReferenceImporter"/>
 
     <fileType.fileViewProviderFactory filetype="KJSM" implementationClass="com.intellij.psi.ClassFileViewProviderFactory"/>

--- a/idea/src/META-INF/plugin.xml.173
+++ b/idea/src/META-INF/plugin.xml.173
@@ -2966,6 +2966,15 @@ The Kotlin plugin provides language support in IntelliJ IDEA and Android Studio.
                      language="kotlin"
     />
 
+    <localInspection implementationClass="org.jetbrains.kotlin.idea.inspections.ReplaceAssertBooleanWithAssertEqualityInspection"
+                     displayName="Replace assert boolean with assert equality"
+                     groupPath="Kotlin"
+                     groupName="Style issues"
+                     enabledByDefault="true"
+                     level="INFORMATION"
+                     language="kotlin"
+    />
+
     <referenceImporter implementation="org.jetbrains.kotlin.idea.quickfix.KotlinReferenceImporter"/>
 
     <fileType.fileViewProviderFactory filetype="KJSM" implementationClass="com.intellij.psi.ClassFileViewProviderFactory"/>

--- a/idea/src/META-INF/plugin.xml.181
+++ b/idea/src/META-INF/plugin.xml.181
@@ -2966,6 +2966,15 @@ The Kotlin plugin provides language support in IntelliJ IDEA and Android Studio.
                      language="kotlin"
     />
 
+    <localInspection implementationClass="org.jetbrains.kotlin.idea.inspections.ReplaceAssertBooleanWithAssertEqualityInspection"
+                     displayName="Replace assert boolean with assert equality"
+                     groupPath="Kotlin"
+                     groupName="Style issues"
+                     enabledByDefault="true"
+                     level="INFORMATION"
+                     language="kotlin"
+    />
+
     <referenceImporter implementation="org.jetbrains.kotlin.idea.quickfix.KotlinReferenceImporter"/>
 
     <fileType.fileViewProviderFactory filetype="KJSM" implementationClass="com.intellij.psi.ClassFileViewProviderFactory"/>

--- a/idea/src/META-INF/plugin.xml.183
+++ b/idea/src/META-INF/plugin.xml.183
@@ -2967,6 +2967,15 @@ The Kotlin plugin provides language support in IntelliJ IDEA and Android Studio.
                      language="kotlin"
     />
 
+    <localInspection implementationClass="org.jetbrains.kotlin.idea.inspections.ReplaceAssertBooleanWithAssertEqualityInspection"
+                     displayName="Replace assert boolean with assert equality"
+                     groupPath="Kotlin"
+                     groupName="Style issues"
+                     enabledByDefault="true"
+                     level="INFORMATION"
+                     language="kotlin"
+    />
+
     <referenceImporter implementation="org.jetbrains.kotlin.idea.quickfix.KotlinReferenceImporter"/>
 
     <fileType.fileViewProviderFactory filetype="KJSM" implementationClass="com.intellij.psi.ClassFileViewProviderFactory"/>

--- a/idea/src/META-INF/plugin.xml.as31
+++ b/idea/src/META-INF/plugin.xml.as31
@@ -2966,6 +2966,15 @@ The Kotlin plugin provides language support in IntelliJ IDEA and Android Studio.
                      language="kotlin"
     />
 
+    <localInspection implementationClass="org.jetbrains.kotlin.idea.inspections.ReplaceAssertBooleanWithAssertEqualityInspection"
+                     displayName="Replace assert boolean with assert equality"
+                     groupPath="Kotlin"
+                     groupName="Style issues"
+                     enabledByDefault="true"
+                     level="INFORMATION"
+                     language="kotlin"
+    />
+
     <referenceImporter implementation="org.jetbrains.kotlin.idea.quickfix.KotlinReferenceImporter"/>
 
     <fileType.fileViewProviderFactory filetype="KJSM" implementationClass="com.intellij.psi.ClassFileViewProviderFactory"/>

--- a/idea/src/META-INF/plugin.xml.as32
+++ b/idea/src/META-INF/plugin.xml.as32
@@ -2966,6 +2966,15 @@ The Kotlin plugin provides language support in IntelliJ IDEA and Android Studio.
                      language="kotlin"
     />
 
+    <localInspection implementationClass="org.jetbrains.kotlin.idea.inspections.ReplaceAssertBooleanWithAssertEqualityInspection"
+                     displayName="Replace assert boolean with assert equality"
+                     groupPath="Kotlin"
+                     groupName="Style issues"
+                     enabledByDefault="true"
+                     level="INFORMATION"
+                     language="kotlin"
+    />
+
     <referenceImporter implementation="org.jetbrains.kotlin.idea.quickfix.KotlinReferenceImporter"/>
 
     <fileType.fileViewProviderFactory filetype="KJSM" implementationClass="com.intellij.psi.ClassFileViewProviderFactory"/>

--- a/idea/src/org/jetbrains/kotlin/idea/inspections/ReplaceAssertBooleanWithAssertEqualityInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/ReplaceAssertBooleanWithAssertEqualityInspection.kt
@@ -46,29 +46,20 @@ class ReplaceAssertBooleanWithAssertEqualityInspection : AbstractApplicabilityBa
     }
 
     private fun KtCallExpression.replaceableAssertion(): String? {
-        var result: String? = null
-        val referencedName = (calleeExpression as? KtNameReferenceExpression)?.getReferencedName() ?: return result
-        if (!assertions.contains(referencedName)) {
-            return result
+        val referencedName = (calleeExpression as? KtNameReferenceExpression)?.getReferencedName() ?: return null
+        if (referencedName !in assertions) {
+            return null
         }
 
         if (getCallableDescriptor()?.containingDeclaration?.fqNameSafe != FqName("kotlin.test")) {
-            return result
+            return null
         }
 
-        if (valueArguments.size != 1 && valueArguments.size != 2) return result
-        val binaryExpression = valueArguments.first().getArgumentExpression() as? KtBinaryExpression ?: return result
+        if (valueArguments.size != 1 && valueArguments.size != 2) return null
+        val binaryExpression = valueArguments.first().getArgumentExpression() as? KtBinaryExpression ?: return null
         val operationToken = binaryExpression.operationToken
 
-        assertionMap.entries.forEach {
-            val (assertion, token) = it.key
-            if (referencedName == assertion && operationToken == token) {
-                result = it.value
-                return@forEach
-            }
-        }
-
-        return result
+        return assertionMap[Pair(referencedName, operationToken)]
     }
 
     companion object {

--- a/idea/src/org/jetbrains/kotlin/idea/inspections/ReplaceAssertBooleanWithAssertEqualityInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/ReplaceAssertBooleanWithAssertEqualityInspection.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2010-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.idea.inspections
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.idea.intentions.getCallableDescriptor
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
+
+class ReplaceAssertBooleanWithAssertEqualityInspection : AbstractApplicabilityBasedInspection<KtCallExpression>(KtCallExpression::class.java) {
+
+    override fun inspectionText(element: KtCallExpression) = "Replace assert boolean with assert equality"
+
+    override val defaultFixText = "Replace assert boolean with assert equality"
+
+    override fun fixText(element: KtCallExpression): String {
+        val assertion = element.replaceableAssertion() ?: return defaultFixText
+        return "Replace with '$assertion'"
+    }
+
+    override fun isApplicable(element: KtCallExpression): Boolean {
+        return (element.replaceableAssertion() != null)
+    }
+
+    override fun applyTo(element: PsiElement, project: Project, editor: Editor?) {
+        val expression = element as? KtCallExpression ?: return
+        val condition = expression.valueArguments.first().getArgumentExpression() as? KtBinaryExpression ?: return
+        val left = condition.left ?: return
+        val right = condition.right ?: return
+        val assertion = expression.replaceableAssertion() ?: return
+        val factory = KtPsiFactory(project)
+
+        if (expression.valueArguments.size == 1) {
+            expression.replace(factory.createExpressionByPattern("$assertion($0, $1)", left, right))
+        } else if (expression.valueArguments.size == 2) {
+            val message = expression.valueArguments[1].getArgumentExpression() ?: return
+            expression.replace(factory.createExpressionByPattern("$assertion($0, $1, $2)", left, right, message))
+        }
+    }
+
+    private fun KtCallExpression.replaceableAssertion(): String? {
+        var result: String? = null
+        val referencedName = (calleeExpression as? KtNameReferenceExpression)?.getReferencedName() ?: return result
+        if (!assertions.contains(referencedName)) {
+            return result
+        }
+
+        if (getCallableDescriptor()?.containingDeclaration?.fqNameSafe != FqName("kotlin.test")) {
+            return result
+        }
+
+        if (valueArguments.size != 1 && valueArguments.size != 2) return result
+        val binaryExpression = valueArguments.first().getArgumentExpression() as? KtBinaryExpression ?: return result
+        val operationToken = binaryExpression.operationToken
+
+        assertionMap.entries.forEach {
+            val (assertion, token) = it.key
+            if (referencedName == assertion && operationToken == token) {
+                result = it.value
+                return@forEach
+            }
+        }
+
+        return result
+    }
+
+    companion object {
+        private val assertions = setOf("assertTrue", "assertFalse")
+
+        private val assertionMap = mapOf(
+            Pair("assertTrue", KtTokens.EQEQ) to "assertEquals",
+            Pair("assertTrue", KtTokens.EQEQEQ) to "assertSame",
+            Pair("assertFalse", KtTokens.EQEQ) to "assertNotEquals",
+            Pair("assertFalse", KtTokens.EQEQEQ) to "assertNotSame"
+        )
+    }
+}

--- a/idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality/.inspection
+++ b/idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality/.inspection
@@ -1,0 +1,1 @@
+org.jetbrains.kotlin.idea.inspections.ReplaceAssertBooleanWithAssertEqualityInspection

--- a/idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality/assertFalse.kt
+++ b/idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality/assertFalse.kt
@@ -1,0 +1,9 @@
+// RUNTIME_WITH_KOTLIN_TEST
+// PROBLEM: none
+
+import kotlin.test.*
+
+fun foo() {
+    val isA = false
+    assertFalse<caret>(isA)
+}

--- a/idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality/assertFalseEQEQ.kt
+++ b/idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality/assertFalseEQEQ.kt
@@ -1,0 +1,9 @@
+// RUNTIME_WITH_KOTLIN_TEST
+
+import kotlin.test.*
+
+fun foo() {
+    val a = "a"
+    val b = "b"
+    assertFalse<caret>(a == b)
+}

--- a/idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality/assertFalseEQEQ.kt.after
+++ b/idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality/assertFalseEQEQ.kt.after
@@ -1,0 +1,9 @@
+// RUNTIME_WITH_KOTLIN_TEST
+
+import kotlin.test.*
+
+fun foo() {
+    val a = "a"
+    val b = "b"
+    assertNotEquals(a, b)
+}

--- a/idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality/assertFalseEQEQEQ.kt
+++ b/idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality/assertFalseEQEQEQ.kt
@@ -1,0 +1,9 @@
+// RUNTIME_WITH_KOTLIN_TEST
+
+import kotlin.test.*
+
+fun foo() {
+    val a = "a"
+    val b = "b"
+    assertFalse<caret>(a === b)
+}

--- a/idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality/assertFalseEQEQEQ.kt.after
+++ b/idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality/assertFalseEQEQEQ.kt.after
@@ -1,0 +1,9 @@
+// RUNTIME_WITH_KOTLIN_TEST
+
+import kotlin.test.*
+
+fun foo() {
+    val a = "a"
+    val b = "b"
+    assertNotSame(a, b)
+}

--- a/idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality/assertFalseWithMessage.kt
+++ b/idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality/assertFalseWithMessage.kt
@@ -1,0 +1,9 @@
+// RUNTIME_WITH_KOTLIN_TEST
+
+import kotlin.test.*
+
+fun foo() {
+    val a = "a"
+    val b = "b"
+    assertFalse(<caret>a == b, "message")
+}

--- a/idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality/assertFalseWithMessage.kt.after
+++ b/idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality/assertFalseWithMessage.kt.after
@@ -1,0 +1,9 @@
+// RUNTIME_WITH_KOTLIN_TEST
+
+import kotlin.test.*
+
+fun foo() {
+    val a = "a"
+    val b = "b"
+    assertNotEquals(a, b, "message")
+}

--- a/idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality/assertTrue.kt
+++ b/idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality/assertTrue.kt
@@ -1,0 +1,9 @@
+// RUNTIME_WITH_KOTLIN_TEST
+// PROBLEM: none
+
+import kotlin.test.*
+
+fun foo() {
+    val isA = true
+    assertTrue<caret>(isA)
+}

--- a/idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality/assertTrueEQEQ.kt
+++ b/idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality/assertTrueEQEQ.kt
@@ -1,0 +1,9 @@
+// RUNTIME_WITH_KOTLIN_TEST
+
+import kotlin.test.*
+
+fun foo() {
+    val a = "a"
+    val b = "a"
+    assertTrue<caret>(a == b)
+}

--- a/idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality/assertTrueEQEQ.kt.after
+++ b/idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality/assertTrueEQEQ.kt.after
@@ -1,0 +1,9 @@
+// RUNTIME_WITH_KOTLIN_TEST
+
+import kotlin.test.*
+
+fun foo() {
+    val a = "a"
+    val b = "a"
+    assertEquals(a, b)
+}

--- a/idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality/assertTrueEQEQEQ.kt
+++ b/idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality/assertTrueEQEQEQ.kt
@@ -1,0 +1,9 @@
+// RUNTIME_WITH_KOTLIN_TEST
+
+import kotlin.test.*
+
+fun foo() {
+    val a = "a"
+    val b = "a"
+    assertTrue(<caret>a === b)
+}

--- a/idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality/assertTrueEQEQEQ.kt.after
+++ b/idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality/assertTrueEQEQEQ.kt.after
@@ -1,0 +1,9 @@
+// RUNTIME_WITH_KOTLIN_TEST
+
+import kotlin.test.*
+
+fun foo() {
+    val a = "a"
+    val b = "a"
+    assertSame(a, b)
+}

--- a/idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality/assertTrueWithMessage.kt
+++ b/idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality/assertTrueWithMessage.kt
@@ -1,0 +1,9 @@
+// RUNTIME_WITH_KOTLIN_TEST
+
+import kotlin.test.*
+
+fun foo() {
+    val a = "a"
+    val b = "a"
+    assertTrue(<caret>a == b, "message")
+}

--- a/idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality/assertTrueWithMessage.kt.after
+++ b/idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality/assertTrueWithMessage.kt.after
@@ -1,0 +1,9 @@
+// RUNTIME_WITH_KOTLIN_TEST
+
+import kotlin.test.*
+
+fun foo() {
+    val a = "a"
+    val b = "a"
+    assertEquals(a, b, "message")
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -4180,6 +4180,59 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
         }
     }
 
+    @TestMetadata("idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class ReplaceAssertBooleanWithAssertEquality extends AbstractLocalInspectionTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY, testDataFilePath);
+        }
+
+        public void testAllFilesPresentInReplaceAssertBooleanWithAssertEquality() throws Exception {
+            KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality"), Pattern.compile("^([\\w\\-_]+)\\.(kt|kts)$"), TargetBackend.ANY, true);
+        }
+
+        @TestMetadata("assertFalse.kt")
+        public void testAssertFalse() throws Exception {
+            runTest("idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality/assertFalse.kt");
+        }
+
+        @TestMetadata("assertFalseEQEQ.kt")
+        public void testAssertFalseEQEQ() throws Exception {
+            runTest("idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality/assertFalseEQEQ.kt");
+        }
+
+        @TestMetadata("assertFalseEQEQEQ.kt")
+        public void testAssertFalseEQEQEQ() throws Exception {
+            runTest("idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality/assertFalseEQEQEQ.kt");
+        }
+
+        @TestMetadata("assertFalseWithMessage.kt")
+        public void testAssertFalseWithMessage() throws Exception {
+            runTest("idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality/assertFalseWithMessage.kt");
+        }
+
+        @TestMetadata("assertTrue.kt")
+        public void testAssertTrue() throws Exception {
+            runTest("idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality/assertTrue.kt");
+        }
+
+        @TestMetadata("assertTrueEQEQ.kt")
+        public void testAssertTrueEQEQ() throws Exception {
+            runTest("idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality/assertTrueEQEQ.kt");
+        }
+
+        @TestMetadata("assertTrueEQEQEQ.kt")
+        public void testAssertTrueEQEQEQ() throws Exception {
+            runTest("idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality/assertTrueEQEQEQ.kt");
+        }
+
+        @TestMetadata("assertTrueWithMessage.kt")
+        public void testAssertTrueWithMessage() throws Exception {
+            runTest("idea/testData/inspectionsLocal/replaceAssertBooleanWithAssertEquality/assertTrueWithMessage.kt");
+        }
+    }
+
     @TestMetadata("idea/testData/inspectionsLocal/replacePutWithAssignment")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-23445