### PR TITLE
[Kapt] Pass current ClassLoader as parent class loader by default (KT…

### DIFF
--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/ProcessorLoader.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/ProcessorLoader.kt
@@ -21,7 +21,7 @@ class ProcessorLoader(
 ) : Closeable {
     private var annotationProcessingClassLoader: URLClassLoader? = null
 
-    fun loadProcessors(parentClassLoader: ClassLoader = ClassLoader.getSystemClassLoader()): List<Processor> {
+    fun loadProcessors(parentClassLoader: ClassLoader = javaClass.classLoader): List<Processor> {
         clearJarURLCache()
 
         val classpath = (paths.annotationProcessingClasspath + paths.compileClasspath).distinct()


### PR DESCRIPTION
…-24540)
[Youtrack: KT-24540](https://youtrack.jetbrains.com/issue/KT-24540)

There is a bug with how Kapt creates the `ClassLoader` used to instantiate annotation processors, particularly the ones that depend on `tools.jar`. The `SystemClassLoader` is used by default as the parent `ClassLoader`, but it may or may not include `tools.jar`, which causes Kapt runtime errors. I've personally seen this manifest in a couple of different ways:

In this example: https://github.com/felipecsl/kapt-classloader-bug. This project is built with Gradle and has an annotation processor that depends on tools.jar. During Kapt, the `Trees` class is loaded twice (once in Kapt itself and once in the annotation processor) by two separate `ClassLoaders`, which causes a `ClassCastException` since a `Class` cannot be loaded by two different `ClassLoaders`.

In this example: https://github.com/mmdango/okbuck_kapt_mwe. The project is built with Buck and uses Butterknife which depends on `tools.jar`. In this case, the `ClassLoader` that Kapt creates doesn't have `tools.jar` at all, causing a `ClassNotFoundException`.

I'm proposing to pass in by default the current `ClassLoader` as the parent `ClassLoader` for annotation processors. This fixes the errors seen in the above projects.