### PR TITLE
K/N: Properly add modules for KLIBs generated by cinterop

### DIFF
--- a/.idea/dictionaries/dmitriy_dolovov.xml
+++ b/.idea/dictionaries/dmitriy_dolovov.xml
@@ -1,0 +1,8 @@
+<component name="ProjectDictionaryState">
+  <dictionary name="dmitriy.dolovov">
+    <words>
+      <w>klib</w>
+      <w>konan</w>
+    </words>
+  </dictionary>
+</component>

--- a/buildSrc/src/main/kotlin/intellijDependencies.kt
+++ b/buildSrc/src/main/kotlin/intellijDependencies.kt
@@ -130,7 +130,7 @@ fun Project.runIdeTask(name: String, ideaPluginDir: File, ideaSandboxDir: File, 
         workingDir = File(intellijRootDir(), "bin")
 
         jvmArgs(
-            "-Xmx1250m",
+            "-Xmx2048m",
             "-XX:ReservedCodeCacheSize=240m",
             "-XX:+HeapDumpOnOutOfMemoryError",
             "-ea",
@@ -142,7 +142,8 @@ fun Project.runIdeTask(name: String, ideaPluginDir: File, ideaSandboxDir: File, 
             "-Dapple.awt.graphics.UseQuartz=true",
             "-Dsun.io.useCanonCaches=false",
             "-Dplugin.path=${ideaPluginDir.absolutePath}",
-            "-Didea.additional.classpath=../idea-kotlin-runtime/kotlin-runtime.jar,../idea-kotlin-runtime/kotlin-reflect.jar"
+            "-Didea.additional.classpath=../idea-kotlin-runtime/kotlin-runtime.jar,../idea-kotlin-runtime/kotlin-reflect.jar",
+            "-Didea.max.intellisense.filesize=5000"
         )
 
         if (rootProject.findProperty("versions.androidStudioRelease") != null) {

--- a/idea/idea-gradle/native/src/org/jetbrains/konan/gradle/KonanProjectResolver.kt
+++ b/idea/idea-gradle/native/src/org/jetbrains/konan/gradle/KonanProjectResolver.kt
@@ -98,12 +98,8 @@ class KonanProjectResolver : AbstractProjectResolverExtension() {
       val moduleData = ideModule.data
       for (path in libraryPaths) {
         val library = LibraryData(moduleData.owner, path.fileName.toString())
-        if (isDirectory(path)) {
-          library.addPath(LibraryPathType.BINARY, path.resolve("linkdata").toAbsolutePath().toString())
-        }
-        else {
-          library.addPath(LibraryPathType.BINARY, path.toString() + "!/linkdata")
-        }
+        library.addPath(LibraryPathType.BINARY, if(isDirectory(path)) path.toAbsolutePath().toString() else path.toString())
+
         val data = LibraryDependencyData(moduleData, library, LibraryLevel.MODULE)
         ideModule.createChild(ProjectKeys.LIBRARY_DEPENDENCY, data)
       }

--- a/idea/idea-native/src/org/jetbrains/konan/analyser/index/KonanDescriptorManager.kt
+++ b/idea/idea-native/src/org/jetbrains/konan/analyser/index/KonanDescriptorManager.kt
@@ -41,21 +41,21 @@ class KonanDescriptorManager : ApplicationComponent {
   private val stubCache = ContainerUtil.createConcurrentSoftValueMap<VirtualFile, StubTree>()
 
   fun getDescriptor(file: VirtualFile, specifics: LanguageVersionSettings): ModuleDescriptorImpl {
-    val cache = descriptorCache.computeIfAbsent(specifics, {
+    val cache = descriptorCache.computeIfAbsent(specifics) {
       ContainerUtil.createConcurrentSoftValueMap()
-    })
+    }
 
-    return cache.computeIfAbsent(file, {
+    return cache.computeIfAbsent(file) {
       val reader = LibraryReaderImpl(File(file.path), currentAbiVersion)
       reader.moduleDescriptor(specifics)
-    })
+    }
   }
 
   fun parsePackageFragment(file: VirtualFile): KonanLinkData.LinkDataPackageFragment {
-    return protoCache.computeIfAbsent(file, {
+    return protoCache.computeIfAbsent(file) {
       val bytes = file.contentsToByteArray(false)
       org.jetbrains.kotlin.backend.konan.serialization.parsePackageFragment(bytes)
-    })
+    }
   }
 
   fun getStub(file: VirtualFile): StubTree? {

--- a/idea/idea-native/src/org/jetbrains/konan/settings/KonanProjectComponent.kt
+++ b/idea/idea-native/src/org/jetbrains/konan/settings/KonanProjectComponent.kt
@@ -14,8 +14,6 @@ import org.jetbrains.konan.settings.KonanModelProvider.RELOAD_TOPIC
 import org.jetbrains.kotlin.utils.addIfNotNull
 import java.nio.file.Path
 
-private const val LINK_DATA: String = "linkdata"
-
 abstract class KonanProjectComponent(val project: Project) : ProjectComponent {
   companion object {
     fun getInstance(project: Project): KonanProjectComponent = project.getComponent(KonanProjectComponent::class.java)
@@ -80,12 +78,8 @@ abstract class KonanProjectComponent(val project: Project) : ProjectComponent {
       val libraryRootPath = path.toString()
       val libraryRoot: VirtualFile = localFileSystem.refreshAndFindFileByPath(libraryRootPath) ?: continue
 
-      if (libraryRoot.isDirectory) {
-        createLibrary(localFileSystem, "$libraryRootPath/$LINK_DATA")
-      }
-      else { //zip
-        createLibrary(jarFileSystem, "$libraryRootPath!/$LINK_DATA")
-      }
+      // use JAR FS if this is file (*.klib), otherwise - local FS
+      createLibrary(if (libraryRoot.isDirectory) localFileSystem else jarFileSystem, libraryRootPath)
     }
 
     runWriteAction {


### PR DESCRIPTION
1. Don't need to append "/linkdata" to the end of KLIB path
2. Add modules for all KLIBs (both directory- and file-based) found on Gradle dependencies list