### PR TITLE
Add documentation for @JvmSynthetic

### DIFF
--- a/libraries/stdlib/jvm/runtime/kotlin/jvm/annotations/JvmPlatformAnnotations.kt
+++ b/libraries/stdlib/jvm/runtime/kotlin/jvm/annotations/JvmPlatformAnnotations.kt
@@ -65,6 +65,15 @@ public actual annotation class JvmMultifileClass
 @SinceKotlin("1.2")
 internal annotation class JvmPackageName(val name: String)
 
+/**
+ * Sets `ACC_SYNTHETIC` flag on the annotated target in the Java bytecode.
+ *
+ * Synthetic targets become inaccessible for Java sources at compile time while still being accessible for Kotlin sources.
+ * Marking target as synthetic is a binary compatible change, already compiled Java code will be able to access such target.
+ *
+ * This annotation is intended for *rare cases* when API designer needs to hide Kotlin-specific target from Java API
+ * while keeping it a part of Kotlin API so the resulting API is idiomatic for both languages.
+ */
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER, AnnotationTarget.FIELD)
 @Retention(AnnotationRetention.SOURCE)
 public annotation class JvmSynthetic


### PR DESCRIPTION
Docs on this annotation were missing since its addition to the stdlib & compiler support.

This PR adds missing documentation while highlighting that the annotation is not intended for mass use, but rather for *rare cases*. 

I've tried to keep the style of the text consistent with other documentation within the file.

Use case: https://github.com/gojuno/koptional/pull/30