### PR TITLE
KT-25928 "Let extend" quick fix is suggested in case of nullable/non-null TYPE_MISMATCH collision

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixFactoryForTypeMismatchError.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixFactoryForTypeMismatchError.kt
@@ -44,6 +44,7 @@ import org.jetbrains.kotlin.resolve.calls.model.ResolvedCall
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.KotlinTypeFactory
+import org.jetbrains.kotlin.types.TypeUtils
 import org.jetbrains.kotlin.types.typeUtil.*
 import java.util.*
 
@@ -120,7 +121,9 @@ class QuickFixFactoryForTypeMismatchError : KotlinIntentionActionsFactory() {
             val expressionTypeDeclaration = expressionType.constructor.declarationDescriptor?.let {
                 DescriptorToSourceUtils.descriptorToDeclaration(it)
             } as? KtClassOrObject
-            expressionTypeDeclaration?.let { actions.add(LetImplementInterfaceFix(it, expectedType, expressionType)) }
+            if (expressionTypeDeclaration != null && expectedType != TypeUtils.makeNotNullable(expressionType)) {
+                actions.add(LetImplementInterfaceFix(expressionTypeDeclaration, expectedType, expressionType))
+            }
         }
 
 

--- a/idea/testData/quickfix/typeMismatch/kt25928.kt
+++ b/idea/testData/quickfix/typeMismatch/kt25928.kt
@@ -1,0 +1,9 @@
+// "Let 'Foo?' extend interface 'Foo'" "false"
+// ACTION: Add non-null asserted (!!) call
+// ACTION: Change type of 'x' to 'Foo?'
+// ERROR: Type mismatch: inferred type is Foo? but Foo was expected
+interface Foo
+
+fun test(foo: Foo?) {
+    val x: Foo = foo<caret>
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -11331,6 +11331,11 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
             runTest("idea/testData/quickfix/typeMismatch/kt17404.kt");
         }
 
+        @TestMetadata("kt25928.kt")
+        public void testKt25928() throws Exception {
+            runTest("idea/testData/quickfix/typeMismatch/kt25928.kt");
+        }
+
         @TestMetadata("letClassImplementAdditionalInterface.kt")
         public void testLetClassImplementAdditionalInterface() throws Exception {
             runTest("idea/testData/quickfix/typeMismatch/letClassImplementAdditionalInterface.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-25928