### PR TITLE
KT-26042 False positive "Remove redundant '.let' call" for lambda with destructured arguments

### DIFF
--- a/idea/testData/intentions/replaceSingleLineLetIntention/destructuringDeclaration.kt
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/destructuringDeclaration.kt
@@ -1,0 +1,7 @@
+// WITH_RUNTIME
+
+fun test() {
+    (1 to 2).let<caret> { (i, j) -> foo() }
+}
+
+fun foo() = 0

--- a/idea/testData/intentions/replaceSingleLineLetIntention/destructuringDeclaration.kt.after
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/destructuringDeclaration.kt.after
@@ -1,0 +1,7 @@
+// WITH_RUNTIME
+
+fun test() {
+    foo()
+}
+
+fun foo() = 0

--- a/idea/testData/intentions/replaceSingleLineLetIntention/destructuringDeclaration2.kt
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/destructuringDeclaration2.kt
@@ -1,0 +1,7 @@
+// WITH_RUNTIME
+
+fun test() {
+    (1 to 2).let<caret> { (i, j) -> foo(1, 2) }
+}
+
+fun foo(i: Int, j: Int) = i + j

--- a/idea/testData/intentions/replaceSingleLineLetIntention/destructuringDeclaration2.kt.after
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/destructuringDeclaration2.kt.after
@@ -1,0 +1,7 @@
+// WITH_RUNTIME
+
+fun test() {
+    foo(1, 2)
+}
+
+fun foo(i: Int, j: Int) = i + j

--- a/idea/testData/intentions/replaceSingleLineLetIntention/destructuringDeclaration3.kt
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/destructuringDeclaration3.kt
@@ -1,0 +1,8 @@
+// WITH_RUNTIME
+// IS_APPLICABLE: false
+
+fun test() {
+    (1 to 2).let<caret> { (i, j) -> foo(i, 3) }
+}
+
+fun foo(i: Int, j: Int) = i + j

--- a/idea/testData/intentions/replaceSingleLineLetIntention/destructuringDeclaration4.kt
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/destructuringDeclaration4.kt
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+// IS_APPLICABLE: false
+
+fun test(k: Int) {
+    (1 to 2).let<caret> { (i, j) -> i + k }
+}

--- a/idea/testData/intentions/replaceSingleLineLetIntention/destructuringDeclaration5.kt
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/destructuringDeclaration5.kt
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+// IS_APPLICABLE: false
+
+fun test() {
+    (1 to 2).let<caret> { (i, j) -> i.toLong() }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -13887,6 +13887,31 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
             runTest("idea/testData/intentions/replaceSingleLineLetIntention/comparisons.kt");
         }
 
+        @TestMetadata("destructuringDeclaration.kt")
+        public void testDestructuringDeclaration() throws Exception {
+            runTest("idea/testData/intentions/replaceSingleLineLetIntention/destructuringDeclaration.kt");
+        }
+
+        @TestMetadata("destructuringDeclaration2.kt")
+        public void testDestructuringDeclaration2() throws Exception {
+            runTest("idea/testData/intentions/replaceSingleLineLetIntention/destructuringDeclaration2.kt");
+        }
+
+        @TestMetadata("destructuringDeclaration3.kt")
+        public void testDestructuringDeclaration3() throws Exception {
+            runTest("idea/testData/intentions/replaceSingleLineLetIntention/destructuringDeclaration3.kt");
+        }
+
+        @TestMetadata("destructuringDeclaration4.kt")
+        public void testDestructuringDeclaration4() throws Exception {
+            runTest("idea/testData/intentions/replaceSingleLineLetIntention/destructuringDeclaration4.kt");
+        }
+
+        @TestMetadata("destructuringDeclaration5.kt")
+        public void testDestructuringDeclaration5() throws Exception {
+            runTest("idea/testData/intentions/replaceSingleLineLetIntention/destructuringDeclaration5.kt");
+        }
+
         @TestMetadata("dotWithComparison.kt")
         public void testDotWithComparison() throws Exception {
             runTest("idea/testData/intentions/replaceSingleLineLetIntention/dotWithComparison.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-26042