### PR TITLE
KT-26142 Update Maven central repository url to latest version

### DIFF
--- a/libraries/tools/kotlin-script-util/src/main/kotlin/org/jetbrains/kotlin/script/util/resolvers/maven.kt
+++ b/libraries/tools/kotlin-script-util/src/main/kotlin/org/jetbrains/kotlin/script/util/resolvers/maven.kt
@@ -30,7 +30,7 @@ import java.net.MalformedURLException
 import java.net.URL
 import java.util.*
 
-val mavenCentral = RemoteRepository("maven-central", "default", "http://repo1.maven.org/maven2/")
+val mavenCentral = RemoteRepository("maven-central", "default", "https://repo.maven.apache.org/maven2/")
 
 class MavenResolver(val reportError: ((String) -> Unit)? = null): Resolver {
 


### PR DESCRIPTION
This PR addresses YouTrack issue: https://youtrack.jetbrains.com/issue/KT-26142

---

Kotlin declares http://repo1.maven.apache.org/maven2 maven-central remote repository url. We could mimic Maven and switch to https://repo.maven.apache.org/maven2.
See issue https://issues.apache.org/jira/browse/MNG-5151 : maven switched to this new url starting from Maven 3.0.4. You can fetch maven 3.5.4 sources, go to "maven-model-builder\src\main\resources\org\apache\maven\model\pom-4.0.0.xml" and see that https://repo.maven.apache.org/maven2 is the new maven-central repo url.

Also, keep in mind that many IDE (at least NetBeans and IntelliJ) can dowload Maven repo index for offline use/search. For Maven projects, IDEs offer you do download index for the new url (https://repo.maven.apache.org/maven2) whereas some projects based on Gradle (Gradle seems to use Kotlin?) offer you to download index from the old url.
Index content is the same, but you will download it twice :-p

We could update "libraries\tools\kotlin-script-util\src\main\kotlin\org\jetbrains\kotlin\script\util\resolvers\maven.kt:33" to use "val mavenCentral = RemoteRepository("maven-central", "default", "https://repo.maven.apache.org/maven2")".