### PR TITLE
KT-25968 False positive "Remove redundant backticks" with keyword `yield`

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/RemoveRedundantBackticksInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/RemoveRedundantBackticksInspection.kt
@@ -46,7 +46,7 @@ class RemoveRedundantBackticksInspection : AbstractKotlinInspection() {
     }
 
     private fun isKeyword(text: String): Boolean {
-        return (KtTokens.KEYWORDS.types + KtTokens.SOFT_KEYWORDS.types).any { it.toString() == text }
+        return text == "yield" || (KtTokens.KEYWORDS.types + KtTokens.SOFT_KEYWORDS.types).any { it.toString() == text }
     }
 
     private fun isRedundantBackticks(node: ASTNode): Boolean {
@@ -57,10 +57,12 @@ class RemoveRedundantBackticksInspection : AbstractKotlinInspection() {
     }
 
     private fun registerProblem(holder: ProblemsHolder, element: PsiElement) {
-        holder.registerProblem(element,
-                               "Remove redundant backticks",
-                               ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
-                               RemoveRedundantBackticksQuickFix())
+        holder.registerProblem(
+            element,
+            "Remove redundant backticks",
+            ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
+            RemoveRedundantBackticksQuickFix()
+        )
     }
 }
 

--- a/idea/testData/inspectionsLocal/removeRedundantBackticks/yield.kt
+++ b/idea/testData/inspectionsLocal/removeRedundantBackticks/yield.kt
@@ -1,0 +1,7 @@
+// PROBLEM: none
+
+fun test() {
+    foo(<caret>`yield` = 1)
+}
+
+fun foo(yield: Int) {}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -4500,6 +4500,11 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
         public void testProperty() throws Exception {
             runTest("idea/testData/inspectionsLocal/removeRedundantBackticks/property.kt");
         }
+
+        @TestMetadata("yield.kt")
+        public void testYield() throws Exception {
+            runTest("idea/testData/inspectionsLocal/removeRedundantBackticks/yield.kt");
+        }
     }
 
     @TestMetadata("idea/testData/inspectionsLocal/removeRedundantSpreadOperator")


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-25968