### PR TITLE
Added extension file for View visibility

### DIFF
--- a/plugins/android-extensions/android-extensions-runtime/src/kotlinx/android/extensions/Views.kt
+++ b/plugins/android-extensions/android-extensions-runtime/src/kotlinx/android/extensions/Views.kt
@@ -1,0 +1,21 @@
+package gvfiqst.speso.app.util.extensions
+
+import android.view.View
+
+var View.visible: Boolean
+    get() = visibility == View.VISIBLE
+    set(value) {
+        visibility = if (value) View.VISIBLE else View.GONE
+    }
+
+var View.invisible: Boolean
+    get() = visibility == View.INVISIBLE
+    set(value) {
+        visibility = if (value) View.INVISIBLE else View.VISIBLE
+    }
+
+var View.gone: Boolean
+    get() = visibility == View.GONE
+    set(value) {
+        visibility = if (value) View.GONE else View.VISIBLE
+    }

--- a/plugins/android-extensions/android-extensions-runtime/src/kotlinx/android/extensions/Views.kt
+++ b/plugins/android-extensions/android-extensions-runtime/src/kotlinx/android/extensions/Views.kt
@@ -1,4 +1,4 @@
-package gvfiqst.speso.app.util.extensions
+package kotlinx.android.extensions
 
 import android.view.View
 


### PR DESCRIPTION
Added 3 extension properties to ease the work with View.setVisibility(int)

examples:

- `view.gone = myModel.isNotAvailable()` equivalent to ` if (myModel.isNotAvailable()) view.visibility = View.GONE else view.visibility = View.VISIBLE`
- `view.visible= myModel.isAvailable()` equivalent to ` if (myModel.isAvailable()) view.visibility = View.VISIBLE else view.visibility = View.GONE`
- `view.invisible = myModel.isNotAvailable()` equivalent to ` if (myModel.isNotAvailable) view.visibility = View.INVISIBLE else view.visibility = View.VISIBLE`
- `if (view.visible) { ... }` equivalent to `if (view.visibility == View.VISIBLE) { ... }`
- `if (view.invisible) { ... }` equivalent to `if (view.visibility == View.INVISIBLE) { ... }`
-  `if (view.gone) { ... }` equivalent to `if (view.visibility == View.GONE) { ... }`