### PR TITLE
KT-26586: Sequence<T>.batch(n) operator implementation and documentation

### DIFF
--- a/libraries/stdlib/common/src/generated/_Sequences.kt
+++ b/libraries/stdlib/common/src/generated/_Sequences.kt
@@ -961,6 +961,20 @@ public fun <T, K> Sequence<T>.distinctBy(selector: (T) -> K): Sequence<T> {
 }
 
 /**
+ * Returns a sequence containing lists having [batchSize] number of elements from the source sequence.
+ *
+ * If the source sequence does not contain a multiplier of [batchSize] elements, then the final element
+ * returned by the resulting sequence will only contain the remaining elements.
+ *
+ * The elements in the resulting sequence are in the same order as they were in the source sequence.
+ *
+ * The operation is _intermediate_ and _stateless_.
+ */
+public fun <T> Sequence<T>.batch(batchSize: Int): Sequence<List<T>> {
+    return BatchSequence(this, batchSize)
+}
+
+/**
  * Returns a mutable set containing all distinct elements from the given sequence.
  * 
  * The returned set preserves the element iteration order of the original sequence.

--- a/libraries/stdlib/src/kotlin/collections/Sequences.kt
+++ b/libraries/stdlib/src/kotlin/collections/Sequences.kt
@@ -515,6 +515,28 @@ constructor(
     }
 }
 
+internal class BatchSequence<T>(private val parent: Sequence<T>, private val batchSize: Int) : Sequence<List<T>> {
+    init {
+        require(batchSize > 0) { "'batchSize' must be one or more" }
+    }
+    override fun iterator() = object : Iterator<List<T>> {
+        private val source = parent.iterator()
+        override fun hasNext() = source.hasNext()
+
+        override fun next(): List<T> {
+            if (!hasNext()) { throw NoSuchElementException() }
+            return mutableListOf<T>().apply {
+                while (source.hasNext()) {
+                    add(source.next())
+                    if (size == batchSize) {
+                        break
+                    }
+                }
+            }
+        }
+    }
+}
+
 internal class DistinctSequence<T, K>(private val source: Sequence<T>, private val keySelector: (T) -> K) : Sequence<T> {
     override fun iterator(): Iterator<T> = DistinctIterator(source.iterator(), keySelector)
 }

--- a/libraries/stdlib/test/collections/SequenceTest.kt
+++ b/libraries/stdlib/test/collections/SequenceTest.kt
@@ -517,6 +517,15 @@ public class SequenceTest {
         assertEquals(listOf(13, 34, 55, 144), sequence.distinctBy { it % 4 }.toList())
     }
 
+    @Test fun batch() {
+        val sequence = (1 until 30).asSequence().batch(10)
+        val list = sequence.toList()
+        assertEquals(3, list.size)
+        assertEquals((1..10).toList(), list[0])
+        assertEquals((11..20).toList(), list[1])
+        assertEquals((21..29).toList(), list[2])
+    }
+
     @Test fun unzip() {
         val seq = sequenceOf(1 to 'a', 2 to 'b', 3 to 'c')
         val (ints, chars) = seq.unzip()


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-26586

The extension function was manually added to the generated _Sequences.kt file.
Does this need to be done elsewhere so it is properly generated?