### PR TITLE
KT-23512 "Remove redundant receiver" quick fix makes generic function call incompilable when type could be inferred from removed receiver only

### DIFF
--- a/idea/testData/inspectionsLocal/unusedReceiverParameter/functionWithTypeParameter.kt
+++ b/idea/testData/inspectionsLocal/unusedReceiverParameter/functionWithTypeParameter.kt
@@ -1,0 +1,5 @@
+fun <T> <caret>T.foo() {}
+
+fun test() {
+    "".foo()
+}

--- a/idea/testData/inspectionsLocal/unusedReceiverParameter/functionWithTypeParameter.kt.after
+++ b/idea/testData/inspectionsLocal/unusedReceiverParameter/functionWithTypeParameter.kt.after
@@ -1,0 +1,5 @@
+fun foo() {}
+
+fun test() {
+    foo()
+}

--- a/idea/testData/inspectionsLocal/unusedReceiverParameter/functionWithTypeParameter2.kt
+++ b/idea/testData/inspectionsLocal/unusedReceiverParameter/functionWithTypeParameter2.kt
@@ -1,0 +1,5 @@
+fun <T> <caret>T.foo(t: T) {}
+
+fun test() {
+    "".foo("")
+}

--- a/idea/testData/inspectionsLocal/unusedReceiverParameter/functionWithTypeParameter2.kt.after
+++ b/idea/testData/inspectionsLocal/unusedReceiverParameter/functionWithTypeParameter2.kt.after
@@ -1,0 +1,5 @@
+fun <T> foo(t: T) {}
+
+fun test() {
+    foo("")
+}

--- a/idea/testData/inspectionsLocal/unusedReceiverParameter/functionWithTypeParameter3.kt
+++ b/idea/testData/inspectionsLocal/unusedReceiverParameter/functionWithTypeParameter3.kt
@@ -1,0 +1,7 @@
+interface TypeHolder<T, U>
+
+fun <T, U> <caret>TypeHolder<T, U>.foo() {}
+
+fun test(holder: TypeHolder<String, Int>) {
+    holder.foo()
+}

--- a/idea/testData/inspectionsLocal/unusedReceiverParameter/functionWithTypeParameter3.kt.after
+++ b/idea/testData/inspectionsLocal/unusedReceiverParameter/functionWithTypeParameter3.kt.after
@@ -1,0 +1,7 @@
+interface TypeHolder<T, U>
+
+fun foo() {}
+
+fun test(holder: TypeHolder<String, Int>) {
+    foo()
+}

--- a/idea/testData/inspectionsLocal/unusedReceiverParameter/functionWithTypeParameterInClass.kt
+++ b/idea/testData/inspectionsLocal/unusedReceiverParameter/functionWithTypeParameterInClass.kt
@@ -1,0 +1,7 @@
+class Test<T> {
+    fun <caret>T.foo() {}
+
+    fun test(t: T) {
+        t.foo()
+    }
+}

--- a/idea/testData/inspectionsLocal/unusedReceiverParameter/functionWithTypeParameterInClass.kt.after
+++ b/idea/testData/inspectionsLocal/unusedReceiverParameter/functionWithTypeParameterInClass.kt.after
@@ -1,0 +1,7 @@
+class Test<T> {
+    fun foo() {}
+
+    fun test(t: T) {
+        foo()
+    }
+}

--- a/idea/testData/inspectionsLocal/unusedReceiverParameter/functionWithTypeParameterInClass2.kt
+++ b/idea/testData/inspectionsLocal/unusedReceiverParameter/functionWithTypeParameterInClass2.kt
@@ -1,0 +1,7 @@
+class Test<T> {
+    fun <U> <caret>U.foo() {}
+
+    fun test() {
+        "".foo()
+    }
+}

--- a/idea/testData/inspectionsLocal/unusedReceiverParameter/functionWithTypeParameterInClass2.kt.after
+++ b/idea/testData/inspectionsLocal/unusedReceiverParameter/functionWithTypeParameterInClass2.kt.after
@@ -1,0 +1,7 @@
+class Test<T> {
+    fun foo() {}
+
+    fun test() {
+        foo()
+    }
+}

--- a/idea/testData/inspectionsLocal/unusedReceiverParameter/propertyWithTypeParameter.kt
+++ b/idea/testData/inspectionsLocal/unusedReceiverParameter/propertyWithTypeParameter.kt
@@ -1,0 +1,6 @@
+val <T> <caret>T.bar: Int
+    get() = 1
+
+fun test() {
+    "".bar
+}

--- a/idea/testData/inspectionsLocal/unusedReceiverParameter/propertyWithTypeParameter.kt.after
+++ b/idea/testData/inspectionsLocal/unusedReceiverParameter/propertyWithTypeParameter.kt.after
@@ -1,0 +1,6 @@
+val bar: Int
+    get() = 1
+
+fun test() {
+    bar
+}

--- a/idea/testData/inspectionsLocal/unusedReceiverParameter/propertyWithTypeParameterInClass.kt
+++ b/idea/testData/inspectionsLocal/unusedReceiverParameter/propertyWithTypeParameterInClass.kt
@@ -1,0 +1,8 @@
+class Test<T> {
+    val <caret>T.bar: Int
+        get() = 1
+
+    fun test(t: T) {
+        t.bar
+    }
+}

--- a/idea/testData/inspectionsLocal/unusedReceiverParameter/propertyWithTypeParameterInClass.kt.after
+++ b/idea/testData/inspectionsLocal/unusedReceiverParameter/propertyWithTypeParameterInClass.kt.after
@@ -1,0 +1,8 @@
+class Test<T> {
+    val bar: Int
+        get() = 1
+
+    fun test(t: T) {
+        bar
+    }
+}

--- a/idea/testData/inspectionsLocal/unusedReceiverParameter/propertyWithTypeParameterInClass2.kt
+++ b/idea/testData/inspectionsLocal/unusedReceiverParameter/propertyWithTypeParameterInClass2.kt
@@ -1,0 +1,8 @@
+class Test<T> {
+    val <S> <caret>S.bar: Int
+        get() = 1
+
+    fun test() {
+        "".bar
+    }
+}

--- a/idea/testData/inspectionsLocal/unusedReceiverParameter/propertyWithTypeParameterInClass2.kt.after
+++ b/idea/testData/inspectionsLocal/unusedReceiverParameter/propertyWithTypeParameterInClass2.kt.after
@@ -1,0 +1,8 @@
+class Test<T> {
+    val bar: Int
+        get() = 1
+
+    fun test() {
+        bar
+    }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -6140,6 +6140,31 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
             runTest("idea/testData/inspectionsLocal/unusedReceiverParameter/functionInSameClass2.kt");
         }
 
+        @TestMetadata("functionWithTypeParameter.kt")
+        public void testFunctionWithTypeParameter() throws Exception {
+            runTest("idea/testData/inspectionsLocal/unusedReceiverParameter/functionWithTypeParameter.kt");
+        }
+
+        @TestMetadata("functionWithTypeParameter2.kt")
+        public void testFunctionWithTypeParameter2() throws Exception {
+            runTest("idea/testData/inspectionsLocal/unusedReceiverParameter/functionWithTypeParameter2.kt");
+        }
+
+        @TestMetadata("functionWithTypeParameter3.kt")
+        public void testFunctionWithTypeParameter3() throws Exception {
+            runTest("idea/testData/inspectionsLocal/unusedReceiverParameter/functionWithTypeParameter3.kt");
+        }
+
+        @TestMetadata("functionWithTypeParameterInClass.kt")
+        public void testFunctionWithTypeParameterInClass() throws Exception {
+            runTest("idea/testData/inspectionsLocal/unusedReceiverParameter/functionWithTypeParameterInClass.kt");
+        }
+
+        @TestMetadata("functionWithTypeParameterInClass2.kt")
+        public void testFunctionWithTypeParameterInClass2() throws Exception {
+            runTest("idea/testData/inspectionsLocal/unusedReceiverParameter/functionWithTypeParameterInClass2.kt");
+        }
+
         @TestMetadata("infix.kt")
         public void testInfix() throws Exception {
             runTest("idea/testData/inspectionsLocal/unusedReceiverParameter/infix.kt");
@@ -6158,6 +6183,21 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
         @TestMetadata("propertyInSameClass.kt")
         public void testPropertyInSameClass() throws Exception {
             runTest("idea/testData/inspectionsLocal/unusedReceiverParameter/propertyInSameClass.kt");
+        }
+
+        @TestMetadata("propertyWithTypeParameter.kt")
+        public void testPropertyWithTypeParameter() throws Exception {
+            runTest("idea/testData/inspectionsLocal/unusedReceiverParameter/propertyWithTypeParameter.kt");
+        }
+
+        @TestMetadata("propertyWithTypeParameterInClass.kt")
+        public void testPropertyWithTypeParameterInClass() throws Exception {
+            runTest("idea/testData/inspectionsLocal/unusedReceiverParameter/propertyWithTypeParameterInClass.kt");
+        }
+
+        @TestMetadata("propertyWithTypeParameterInClass2.kt")
+        public void testPropertyWithTypeParameterInClass2() throws Exception {
+            runTest("idea/testData/inspectionsLocal/unusedReceiverParameter/propertyWithTypeParameterInClass2.kt");
         }
     }
 


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-23512