### PR TITLE
Simplify detailed receiver

### DIFF
--- a/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/NewResolutionOldInference.kt
+++ b/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/NewResolutionOldInference.kt
@@ -163,11 +163,8 @@ class NewResolutionOldInference(
         kind: ResolutionKind,
         tracing: TracingStrategy
     ): OverloadResolutionResultsImpl<D> {
-        val explicitReceiver = context.call.explicitReceiver
-        val detailedReceiver = if (explicitReceiver is QualifierReceiver?) {
-            explicitReceiver
-        } else {
-            context.transformToReceiverWithSmartCastInfo(explicitReceiver as ReceiverValue)
+        val detailedReceiver = context.call.explicitReceiver.let {
+            if (it is QualifierReceiver?) it else context.transformToReceiverWithSmartCastInfo(it as ReceiverValue)
         }
 
         val dynamicScope = dynamicCallableDescriptors.createDynamicDescriptorScope(context.call, context.scope.ownerDescriptor)


### PR DESCRIPTION
Use let in order to define detailedReceiver in a single statement