### PR TITLE
Rename buildSequence/buildIterator

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3145,7 +3145,7 @@
 
 ### Libraries
 
-- [`KT-16922`](https://youtrack.jetbrains.com/issue/KT-16922) buildSequence/Iterator: Infinite sequence terminates prematurely
+- [`KT-16922`](https://youtrack.jetbrains.com/issue/KT-16922) defineSequence/Iterator: Infinite sequence terminates prematurely
 - [`KT-16923`](https://youtrack.jetbrains.com/issue/KT-16923) Progression iterator doesn't throw after completion
 - [`KT-16994`](https://youtrack.jetbrains.com/issue/KT-16994) Classify sequence operations as stateful/stateless and intermediate/terminal
 - [`KT-9786`](https://youtrack.jetbrains.com/issue/KT-9786) String.trimIndent doc is misleading
@@ -3676,7 +3676,7 @@
 
 ### Standard Library
 - [`KEEP-23`](https://github.com/Kotlin/KEEP/blob/master/proposals/stdlib/group-and-fold.md) Operation to group by key and fold each group simultaneously
-- [`KT-15774`](https://youtrack.jetbrains.com/issue/KT-15774) `buildSequence` and `buildIterator` functions with `yield` and `yieldAll` based on coroutines
+- [`KT-15774`](https://youtrack.jetbrains.com/issue/KT-15774) `defineSequence` and `buildIterator` functions with `yield` and `yieldAll` based on coroutines
 - [`KT-6903`](https://youtrack.jetbrains.com/issue/KT-6903) Add `also` extension, which is like `apply`, but with `it` instead of `this` inside lambda.
 - [`KT-7858`](https://youtrack.jetbrains.com/issue/KT-7858) Add extension function `takeIf` to match a value against predicate and return null when it does not match
 - [`KT-11851`](https://youtrack.jetbrains.com/issue/KT-11851) Provide extension `Map.getValue(key: K): V` which throws or returns default when key is not found

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3676,7 +3676,7 @@
 
 ### Standard Library
 - [`KEEP-23`](https://github.com/Kotlin/KEEP/blob/master/proposals/stdlib/group-and-fold.md) Operation to group by key and fold each group simultaneously
-- [`KT-15774`](https://youtrack.jetbrains.com/issue/KT-15774) `defineSequence` and `buildIterator` functions with `yield` and `yieldAll` based on coroutines
+- [`KT-15774`](https://youtrack.jetbrains.com/issue/KT-15774) `defineSequence` and `defineIterator` functions with `yield` and `yieldAll` based on coroutines
 - [`KT-6903`](https://youtrack.jetbrains.com/issue/KT-6903) Add `also` extension, which is like `apply`, but with `it` instead of `this` inside lambda.
 - [`KT-7858`](https://youtrack.jetbrains.com/issue/KT-7858) Add extension function `takeIf` to match a value against predicate and return null when it does not match
 - [`KT-11851`](https://youtrack.jetbrains.com/issue/KT-11851) Provide extension `Map.getValue(key: K): V` which throws or returns default when key is not found

--- a/compiler/frontend/src/org/jetbrains/kotlin/analyzer/AnalyzerFacade.kt
+++ b/compiler/frontend/src/org/jetbrains/kotlin/analyzer/AnalyzerFacade.kt
@@ -45,7 +45,7 @@ import org.jetbrains.kotlin.resolve.TargetPlatform
 import org.jetbrains.kotlin.storage.StorageManager
 import org.jetbrains.kotlin.storage.getValue
 import java.util.*
-import kotlin.coroutines.experimental.buildSequence
+import kotlin.coroutines.experimental.defineSequence
 
 class ResolverForModule(
     val packageFragmentProvider: PackageFragmentProvider,
@@ -334,7 +334,7 @@ class LazyModuleDependencies<M : ModuleInfo>(
 ) : ModuleDependencies {
     private val dependencies = storageManager.createLazyValue {
         val moduleDescriptor = resolverForProject.descriptorForModule(module)
-        buildSequence {
+        defineSequence {
             if (firstDependency != null) {
                 yield(resolverForProject.descriptorForModule(firstDependency))
             }

--- a/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/DoubleColonExpressionResolver.kt
+++ b/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/DoubleColonExpressionResolver.kt
@@ -51,7 +51,7 @@ import org.jetbrains.kotlin.utils.yieldIfNotNull
 import java.lang.UnsupportedOperationException
 import java.util.*
 import javax.inject.Inject
-import kotlin.coroutines.experimental.buildSequence
+import kotlin.coroutines.experimental.defineSequence
 
 sealed class DoubleColonLHS(val type: KotlinType) {
     /**
@@ -699,13 +699,13 @@ class DoubleColonExpressionResolver(
                 ?.apply { commitTrace() }?.results
         }
 
-        val resultSequence = buildSequence {
+        val resultSequence = defineSequence {
             when (lhs) {
                 is DoubleColonLHS.Type -> {
                     val classifier = lhsType.constructor.declarationDescriptor
                     if (classifier !is ClassDescriptor) {
                         c.trace.report(CALLABLE_REFERENCE_LHS_NOT_A_CLASS.on(expression))
-                        return@buildSequence
+                        return@defineSequence
                     }
 
                     val qualifier = c.trace.get(BindingContext.QUALIFIER, expression.receiverExpression!!)

--- a/compiler/testData/codegen/box/coroutines/suspendFunctionAsCoroutine/ifExpressionInsideCoroutine.kt
+++ b/compiler/testData/codegen/box/coroutines/suspendFunctionAsCoroutine/ifExpressionInsideCoroutine.kt
@@ -8,7 +8,7 @@ import COROUTINES_PACKAGE.*
 import COROUTINES_PACKAGE.intrinsics.*
 
 val f = run {
-    buildSequence {
+    defineSequence {
         if (true) {
             yield("OK")
         }

--- a/compiler/testData/diagnostics/testsWithStdLib/coroutines/release/languageVersionIsNotEqualToApiVersion.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/coroutines/release/languageVersionIsNotEqualToApiVersion.kt
@@ -24,10 +24,10 @@ fun builder(c: <!UNSUPPORTED!>suspend<!> () -> Unit) {}
 }
 
 fun test2() {
-    kotlin.coroutines.experimental.buildSequence<Int> {
+    kotlin.coroutines.experimental.defineSequence<Int> {
         yield(1<!NO_VALUE_FOR_PARAMETER!>)<!>
     }
-    kotlin.sequences.<!UNRESOLVED_REFERENCE!>buildSequence<!><Int> {
+    kotlin.sequences.<!UNRESOLVED_REFERENCE!>defineSequence<!><Int> {
         <!UNRESOLVED_REFERENCE!>yield<!>(1)
     }
 }

--- a/compiler/testData/diagnostics/testsWithStdLib/coroutines/restrictSuspension/outerYield.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/coroutines/restrictSuspension/outerYield.kt
@@ -21,12 +21,12 @@ class RestrictedController<T> {
     }
 }
 
-fun <T> buildSequence(<!UNUSED_PARAMETER!>c<!>: suspend RestrictedController<T>.() -> Unit) {}
+fun <T> defineSequence(<!UNUSED_PARAMETER!>c<!>: suspend RestrictedController<T>.() -> Unit) {}
 suspend fun <T> RestrictedController<T>.yield2(<!UNUSED_PARAMETER!>x<!>: T) {}
 
 fun test() {
-    buildSequence<Int> a@{
-        buildSequence<Int> b@{
+    defineSequence<Int> a@{
+        defineSequence<Int> b@{
             yield(1)
             yield2(1)
             this@b.yield(1)
@@ -45,8 +45,8 @@ fun test() {
         }
     }
 
-    buildSequence<Int> {
-        buildSequence<String> {
+    defineSequence<Int> {
+        defineSequence<String> {
             yield("a")
             yield2("a")
             this.yield("b")
@@ -65,10 +65,10 @@ fun test() {
         }
     }
 
-    buildSequence<Int> a@{
+    defineSequence<Int> a@{
         yield(1)
         yield2(1)
-        buildSequence {
+        defineSequence {
             yield("")
             yield2("")
             this@a.<!ILLEGAL_RESTRICTED_SUSPENDING_FUNCTION_CALL!>yield<!>(1)
@@ -84,7 +84,7 @@ fun test() {
         }
     }
 
-    buildSequence<String> {
+    defineSequence<String> {
         yield("")
         RestrictedController<String>().<!ILLEGAL_RESTRICTED_SUSPENDING_FUNCTION_CALL!>yield<!>("1")
     }

--- a/compiler/tests/org/jetbrains/kotlin/scripts/ScriptProviderTest.kt
+++ b/compiler/tests/org/jetbrains/kotlin/scripts/ScriptProviderTest.kt
@@ -12,7 +12,7 @@ import org.jetbrains.kotlin.test.testFramework.KtUsefulTestCase
 import org.junit.Assert
 import org.junit.Test
 import java.util.concurrent.atomic.AtomicInteger
-import kotlin.coroutines.experimental.buildSequence
+import kotlin.coroutines.experimental.defineSequence
 import kotlin.script.templates.standard.ScriptTemplateWithArgs
 
 class ScriptProviderTest : KtUsefulTestCase() {
@@ -71,7 +71,7 @@ private class TestScriptDefinitionSource(val counter: AtomicInteger, val defGens
 {
     constructor(counter: AtomicInteger, vararg suffixes: String) : this(counter, suffixes.map { { FakeScriptDefinition(it) } })
 
-    override val definitions: Sequence<KotlinScriptDefinition> = buildSequence {
+    override val definitions: Sequence<KotlinScriptDefinition> = defineSequence {
         for (gen in defGens) {
             counter.incrementAndGet()
             yield(gen())

--- a/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/project/getModuleInfo.kt
+++ b/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/project/getModuleInfo.kt
@@ -30,7 +30,7 @@ import org.jetbrains.kotlin.script.getScriptDefinition
 import org.jetbrains.kotlin.utils.addIfNotNull
 import org.jetbrains.kotlin.utils.sure
 import org.jetbrains.kotlin.utils.yieldIfNotNull
-import kotlin.coroutines.experimental.buildSequence
+import kotlin.coroutines.experimental.defineSequence
 
 var PsiFile.forcedModuleInfo: ModuleInfo? by UserDataProperty(Key.create("FORCED_MODULE_INFO"))
 
@@ -123,7 +123,7 @@ private sealed class ModuleInfoCollector<out T>(
             emptySequence()
         },
         virtualFileProcessor = { project, virtualFile, isLibrarySource, isScript ->
-            buildSequence {
+            defineSequence {
                 collectInfosByVirtualFile(
                     project,
                     virtualFile,

--- a/idea/src/org/jetbrains/kotlin/idea/editor/KotlinLiteralCopyPasteProcessor.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/editor/KotlinLiteralCopyPasteProcessor.kt
@@ -35,7 +35,7 @@ import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtStringTemplateExpression
 import org.jetbrains.kotlin.psi.psiUtil.*
 import kotlin.coroutines.experimental.SequenceBuilder
-import kotlin.coroutines.experimental.buildIterator
+import kotlin.coroutines.experimental.defineIterator
 
 private val PsiElement.templateContentRange: TextRange?
     get() = this.getParentOfType<KtStringTemplateExpression>(false)?.let{
@@ -233,7 +233,7 @@ private class TemplateTokenSequence(private val inputString: String) : Sequence<
         if (inputString.isEmpty()) {
             return emptySequence<TemplateChunk>().iterator()
         }
-        return buildIterator {
+        return defineIterator {
             var from = 0
             var to = 0
             while (to < inputString.length) {

--- a/idea/testData/formatter/callChain/KT22071.after.kt
+++ b/idea/testData/formatter/callChain/KT22071.after.kt
@@ -1,6 +1,6 @@
 package templates
 
-import kotlin.coroutines.experimental.buildSequence
+import kotlin.coroutines.experimental.defineSequence
 import kotlin.reflect.KTypeProjection
 import kotlin.reflect.full.createType
 import kotlin.reflect.full.isSubtypeOf
@@ -12,7 +12,7 @@ fun templateGroupOf(vararg templates: MemberTemplate): TemplateGroup = { templat
 
 abstract class TemplateGroupBase : TemplateGroup {
 
-    override fun invoke(): Sequence<MemberTemplate> = buildSequence {
+    override fun invoke(): Sequence<MemberTemplate> = defineSequence {
         with(this@TemplateGroupBase) {
             this::class.members.filter { it.name.startsWith("f_") }.forEach {
                 require(it.parameters.size == 1) { "Member $it violates naming convention" }

--- a/idea/testData/formatter/callChain/KT22071.kt
+++ b/idea/testData/formatter/callChain/KT22071.kt
@@ -1,6 +1,6 @@
 package templates
 
-import kotlin.coroutines.experimental.buildSequence
+import kotlin.coroutines.experimental.defineSequence
 import kotlin.reflect.KTypeProjection
 import kotlin.reflect.full.createType
 import kotlin.reflect.full.isSubtypeOf
@@ -12,7 +12,7 @@ fun templateGroupOf(vararg templates: MemberTemplate): TemplateGroup = { templat
 
 abstract class TemplateGroupBase : TemplateGroup {
 
-    override fun invoke(): Sequence<MemberTemplate> = buildSequence {
+    override fun invoke(): Sequence<MemberTemplate> = defineSequence {
         with(this@TemplateGroupBase) {
             this::class.members.filter { it.name.startsWith("f_") }.forEach {
                     require(it.parameters.size == 1) { "Member $it violates naming convention" }

--- a/idea/tests/org/jetbrains/kotlin/idea/parameterInfo/SuspendingCallHintsTest.kt
+++ b/idea/tests/org/jetbrains/kotlin/idea/parameterInfo/SuspendingCallHintsTest.kt
@@ -20,9 +20,9 @@ class SuspendingCallHintsTest : KotlinLightCodeInsightFixtureTestCase() {
 
     fun testSimple() {
         check(
-            """import kotlin.coroutines.experimental.buildSequence
+            """import kotlin.coroutines.experimental.defineSequence
 
-             val x = buildSequence {<hint text="this: SequenceBuilder<Int>" />
+             val x = defineSequence {<hint text="this: SequenceBuilder<Int>" />
                  <hint text="#" />yield(1)
              } """
         )

--- a/libraries/stdlib/common/src/generated/_Sequences.kt
+++ b/libraries/stdlib/common/src/generated/_Sequences.kt
@@ -1620,7 +1620,7 @@ public fun <T> Sequence<T>.zipWithNext(): Sequence<Pair<T, T>> {
  */
 @SinceKotlin("1.2")
 public fun <T, R> Sequence<T>.zipWithNext(transform: (a: T, b: T) -> R): Sequence<R> {
-    return buildSequence result@ {
+    return defineSequence result@ {
         val iterator = iterator()
         if (!iterator.hasNext()) return@result
         var current = iterator.next()

--- a/libraries/stdlib/coroutines/src/kotlin/sequences/SequenceBuilder.kt
+++ b/libraries/stdlib/coroutines/src/kotlin/sequences/SequenceBuilder.kt
@@ -18,11 +18,11 @@ import kotlin.coroutines.intrinsics.*
  *
  * @see kotlin.sequences.generateSequence
  *
- * @sample samples.collections.Sequences.Building.buildSequenceYieldAll
+ * @sample samples.collections.Sequences.Building.defineSequenceYieldAll
  * @sample samples.collections.Sequences.Building.buildFibonacciSequence
  */
 @SinceKotlin("1.3")
-public fun <T> buildSequence(builderAction: suspend SequenceBuilder<T>.() -> Unit): Sequence<T> = Sequence { buildIterator(builderAction) }
+public fun <T> defineSequence(builderAction: suspend SequenceBuilder<T>.() -> Unit): Sequence<T> = Sequence { buildIterator(builderAction) }
 
 /**
  * Builds an [Iterator] lazily yielding values one by one.
@@ -40,10 +40,10 @@ public fun <T> buildIterator(builderAction: suspend SequenceBuilder<T>.() -> Uni
 /**
  * Builder for a [Sequence] or an [Iterator], provides [yield] and [yieldAll] suspension functions.
  *
- * @see buildSequence
+ * @see defineSequence
  * @see buildIterator
  *
- * @sample samples.collections.Sequences.Building.buildSequenceYieldAll
+ * @sample samples.collections.Sequences.Building.defineSequenceYieldAll
  * @sample samples.collections.Sequences.Building.buildFibonacciSequence
  */
 @RestrictsSuspension
@@ -52,7 +52,7 @@ public abstract class SequenceBuilder<in T> internal constructor() {
     /**
      * Yields a value to the [Iterator] being built.
      *
-     * @sample samples.collections.Sequences.Building.buildSequenceYieldAll
+     * @sample samples.collections.Sequences.Building.defineSequenceYieldAll
      * @sample samples.collections.Sequences.Building.buildFibonacciSequence
      */
     @kotlin.internal.RequireKotlin("1.3") // TODO: This is needed for tests only and can be safely removed after 1.3 is released
@@ -63,7 +63,7 @@ public abstract class SequenceBuilder<in T> internal constructor() {
      *
      * The sequence of values returned by the given iterator can be potentially infinite.
      *
-     * @sample samples.collections.Sequences.Building.buildSequenceYieldAll
+     * @sample samples.collections.Sequences.Building.defineSequenceYieldAll
      */
     @kotlin.internal.RequireKotlin("1.3") // TODO: This is needed for tests only and can be safely removed after 1.3 is released
     public abstract suspend fun yieldAll(iterator: Iterator<T>)
@@ -71,7 +71,7 @@ public abstract class SequenceBuilder<in T> internal constructor() {
     /**
      * Yields a collections of values to the [Iterator] being built.
      *
-     * @sample samples.collections.Sequences.Building.buildSequenceYieldAll
+     * @sample samples.collections.Sequences.Building.defineSequenceYieldAll
      */
     @kotlin.internal.RequireKotlin("1.3") // TODO: This is needed for tests only and can be safely removed after 1.3 is released
     public suspend fun yieldAll(elements: Iterable<T>) {
@@ -84,7 +84,7 @@ public abstract class SequenceBuilder<in T> internal constructor() {
      *
      * The sequence can be potentially infinite.
      *
-     * @sample samples.collections.Sequences.Building.buildSequenceYieldAll
+     * @sample samples.collections.Sequences.Building.defineSequenceYieldAll
      */
     @kotlin.internal.RequireKotlin("1.3") // TODO: This is needed for tests only and can be safely removed after 1.3 is released
     public suspend fun yieldAll(sequence: Sequence<T>) = yieldAll(sequence.iterator())

--- a/libraries/stdlib/coroutines/src/kotlin/sequences/SequenceBuilder.kt
+++ b/libraries/stdlib/coroutines/src/kotlin/sequences/SequenceBuilder.kt
@@ -22,16 +22,16 @@ import kotlin.coroutines.intrinsics.*
  * @sample samples.collections.Sequences.Building.buildFibonacciSequence
  */
 @SinceKotlin("1.3")
-public fun <T> defineSequence(builderAction: suspend SequenceBuilder<T>.() -> Unit): Sequence<T> = Sequence { buildIterator(builderAction) }
+public fun <T> defineSequence(builderAction: suspend SequenceBuilder<T>.() -> Unit): Sequence<T> = Sequence { defineIterator(builderAction) }
 
 /**
  * Builds an [Iterator] lazily yielding values one by one.
  *
- * @sample samples.collections.Sequences.Building.buildIterator
+ * @sample samples.collections.Sequences.Building.defineIterator
  * @sample samples.collections.Iterables.Building.iterable
  */
 @SinceKotlin("1.3")
-public fun <T> buildIterator(builderAction: suspend SequenceBuilder<T>.() -> Unit): Iterator<T> {
+public fun <T> defineIterator(builderAction: suspend SequenceBuilder<T>.() -> Unit): Iterator<T> {
     val iterator = SequenceBuilderIterator<T>()
     iterator.nextStep = builderAction.createCoroutineUnintercepted(receiver = iterator, completion = iterator)
     return iterator
@@ -41,7 +41,7 @@ public fun <T> buildIterator(builderAction: suspend SequenceBuilder<T>.() -> Uni
  * Builder for a [Sequence] or an [Iterator], provides [yield] and [yieldAll] suspension functions.
  *
  * @see defineSequence
- * @see buildIterator
+ * @see defineIterator
  *
  * @sample samples.collections.Sequences.Building.defineSequenceYieldAll
  * @sample samples.collections.Sequences.Building.buildFibonacciSequence

--- a/libraries/stdlib/samples/test/samples/collections/iterables.kt
+++ b/libraries/stdlib/samples/test/samples/collections/iterables.kt
@@ -17,7 +17,7 @@
 package samples.collections
 
 import samples.*
-import kotlin.coroutines.experimental.buildIterator
+import kotlin.coroutines.experimental.defineIterator
 
 @RunWith(Enclosed::class)
 class Iterables {
@@ -27,7 +27,7 @@ class Iterables {
         @Sample
         fun iterable() {
             val iterable = Iterable {
-                buildIterator {
+                defineIterator {
                     yield(42)
                     yieldAll(1..5 step 2)
                 }

--- a/libraries/stdlib/samples/test/samples/collections/sequences.kt
+++ b/libraries/stdlib/samples/test/samples/collections/sequences.kt
@@ -2,7 +2,7 @@ package samples.collections
 
 import samples.*
 import kotlin.test.*
-import kotlin.coroutines.experimental.buildIterator
+import kotlin.coroutines.experimental.defineIterator
 import kotlin.coroutines.experimental.defineSequence
 
 @RunWith(Enclosed::class)
@@ -141,12 +141,12 @@ class Sequences {
         }
 
         @Sample
-        fun buildIterator() {
+        fun defineIterator() {
             val collection = listOf(1, 2, 3)
             val wrappedCollection = object : AbstractCollection<Any>() {
                 override val size: Int = collection.size + 2
 
-                override fun iterator(): Iterator<Any> = buildIterator {
+                override fun iterator(): Iterator<Any> = defineIterator {
                     yield("first")
                     yieldAll(collection)
                     yield("last")

--- a/libraries/stdlib/samples/test/samples/collections/sequences.kt
+++ b/libraries/stdlib/samples/test/samples/collections/sequences.kt
@@ -3,7 +3,7 @@ package samples.collections
 import samples.*
 import kotlin.test.*
 import kotlin.coroutines.experimental.buildIterator
-import kotlin.coroutines.experimental.buildSequence
+import kotlin.coroutines.experimental.defineSequence
 
 @RunWith(Enclosed::class)
 class Sequences {
@@ -112,7 +112,7 @@ class Sequences {
 
         @Sample
         fun buildFibonacciSequence() {
-            fun fibonacci() = buildSequence {
+            fun fibonacci() = defineSequence {
                 var terms = Pair(0, 1)
 
                 // this sequence is infinite
@@ -126,8 +126,8 @@ class Sequences {
         }
 
         @Sample
-        fun buildSequenceYieldAll() {
-            val sequence = buildSequence {
+        fun defineSequenceYieldAll() {
+            val sequence = defineSequence {
                 val start = 0
                 // yielding a single value
                 yield(start)

--- a/libraries/stdlib/src/kotlin/collections/Sequences.kt
+++ b/libraries/stdlib/src/kotlin/collections/Sequences.kt
@@ -563,7 +563,7 @@ public fun <T> Sequence<T>.constrainOnce(): Sequence<T> {
  * The returned sequence is constrained to be iterated only once.
  *
  * @see constrainOnce
- * @see kotlin.coroutines.experimental.buildSequence
+ * @see kotlin.coroutines.experimental.defineSequence
  *
  * @sample samples.collections.Sequences.Building.generateSequence
  */
@@ -580,7 +580,7 @@ public fun <T : Any> generateSequence(nextFunction: () -> T?): Sequence<T> {
  *
  * The sequence can be iterated multiple times, each time starting with [seed].
  *
- * @see kotlin.coroutines.experimental.buildSequence
+ * @see kotlin.coroutines.experimental.defineSequence
  *
  * @sample samples.collections.Sequences.Building.generateSequenceWithSeed
  */
@@ -600,10 +600,9 @@ public fun <T : Any> generateSequence(seed: T?, nextFunction: (T) -> T?): Sequen
  *
  * The sequence can be iterated multiple times.
  *
- * @see kotlin.coroutines.experimental.buildSequence
+ * @see kotlin.coroutines.experimental.defineSequence
  *
  * @sample samples.collections.Sequences.Building.generateSequenceWithLazySeed
  */
 public fun <T : Any> generateSequence(seedFunction: () -> T?, nextFunction: (T) -> T?): Sequence<T> =
     GeneratorSequence(seedFunction, nextFunction)
-

--- a/libraries/stdlib/src/kotlin/collections/SlidingWindow.kt
+++ b/libraries/stdlib/src/kotlin/collections/SlidingWindow.kt
@@ -6,7 +6,7 @@
 package kotlin.collections
 
 import kotlin.*
-import kotlin.coroutines.experimental.buildIterator
+import kotlin.coroutines.experimental.defineIterator
 
 internal fun checkWindowSizeStep(size: Int, step: Int) {
     require(size > 0 && step > 0) {
@@ -24,7 +24,7 @@ internal fun <T> Sequence<T>.windowedSequence(size: Int, step: Int, partialWindo
 
 internal fun <T> windowedIterator(iterator: Iterator<T>, size: Int, step: Int, partialWindows: Boolean, reuseBuffer: Boolean): Iterator<List<T>> {
     if (!iterator.hasNext()) return EmptyIterator
-    return buildIterator<List<T>> {
+    return defineIterator<List<T>> {
         val gap = step - size
         if (gap >= 0) {
             var buffer = ArrayList<T>(size)

--- a/libraries/stdlib/src/kotlin/coroutines/experimental/SequenceBuilder.kt
+++ b/libraries/stdlib/src/kotlin/coroutines/experimental/SequenceBuilder.kt
@@ -16,11 +16,11 @@ import kotlin.coroutines.experimental.intrinsics.*
  *
  * @see kotlin.sequences.generateSequence
  *
- * @sample samples.collections.Sequences.Building.buildSequenceYieldAll
+ * @sample samples.collections.Sequences.Building.defineSequenceYieldAll
  * @sample samples.collections.Sequences.Building.buildFibonacciSequence
  */
 @SinceKotlin("1.1")
-public fun <T> buildSequence(builderAction: suspend SequenceBuilder<T>.() -> Unit): Sequence<T> = Sequence { buildIterator(builderAction) }
+public fun <T> defineSequence(builderAction: suspend SequenceBuilder<T>.() -> Unit): Sequence<T> = Sequence { buildIterator(builderAction) }
 
 /**
  * Builds an [Iterator] lazily yielding values one by one.
@@ -38,10 +38,10 @@ public fun <T> buildIterator(builderAction: suspend SequenceBuilder<T>.() -> Uni
 /**
  * Builder for a [Sequence] or an [Iterator], provides [yield] and [yieldAll] suspension functions.
  *
- * @see buildSequence
+ * @see defineSequence
  * @see buildIterator
  *
- * @sample samples.collections.Sequences.Building.buildSequenceYieldAll
+ * @sample samples.collections.Sequences.Building.defineSequenceYieldAll
  * @sample samples.collections.Sequences.Building.buildFibonacciSequence
  */
 @RestrictsSuspension
@@ -50,7 +50,7 @@ public abstract class SequenceBuilder<in T> internal constructor() {
     /**
      * Yields a value to the [Iterator] being built.
      *
-     * @sample samples.collections.Sequences.Building.buildSequenceYieldAll
+     * @sample samples.collections.Sequences.Building.defineSequenceYieldAll
      * @sample samples.collections.Sequences.Building.buildFibonacciSequence
      */
     public abstract suspend fun yield(value: T)
@@ -60,14 +60,14 @@ public abstract class SequenceBuilder<in T> internal constructor() {
      *
      * The sequence of values returned by the given iterator can be potentially infinite.
      *
-     * @sample samples.collections.Sequences.Building.buildSequenceYieldAll
+     * @sample samples.collections.Sequences.Building.defineSequenceYieldAll
      */
     public abstract suspend fun yieldAll(iterator: Iterator<T>)
 
     /**
      * Yields a collections of values to the [Iterator] being built.
      *
-     * @sample samples.collections.Sequences.Building.buildSequenceYieldAll
+     * @sample samples.collections.Sequences.Building.defineSequenceYieldAll
      */
     public suspend fun yieldAll(elements: Iterable<T>) {
         if (elements is Collection && elements.isEmpty()) return
@@ -79,7 +79,7 @@ public abstract class SequenceBuilder<in T> internal constructor() {
      *
      * The sequence can be potentially infinite.
      *
-     * @sample samples.collections.Sequences.Building.buildSequenceYieldAll
+     * @sample samples.collections.Sequences.Building.defineSequenceYieldAll
      */
     public suspend fun yieldAll(sequence: Sequence<T>) = yieldAll(sequence.iterator())
 }

--- a/libraries/stdlib/src/kotlin/coroutines/experimental/SequenceBuilder.kt
+++ b/libraries/stdlib/src/kotlin/coroutines/experimental/SequenceBuilder.kt
@@ -20,16 +20,16 @@ import kotlin.coroutines.experimental.intrinsics.*
  * @sample samples.collections.Sequences.Building.buildFibonacciSequence
  */
 @SinceKotlin("1.1")
-public fun <T> defineSequence(builderAction: suspend SequenceBuilder<T>.() -> Unit): Sequence<T> = Sequence { buildIterator(builderAction) }
+public fun <T> defineSequence(builderAction: suspend SequenceBuilder<T>.() -> Unit): Sequence<T> = Sequence { defineIterator(builderAction) }
 
 /**
  * Builds an [Iterator] lazily yielding values one by one.
  *
- * @sample samples.collections.Sequences.Building.buildIterator
+ * @sample samples.collections.Sequences.Building.defineIterator
  * @sample samples.collections.Iterables.Building.iterable
  */
 @SinceKotlin("1.1")
-public fun <T> buildIterator(builderAction: suspend SequenceBuilder<T>.() -> Unit): Iterator<T> {
+public fun <T> defineIterator(builderAction: suspend SequenceBuilder<T>.() -> Unit): Iterator<T> {
     val iterator = SequenceBuilderIterator<T>()
     iterator.nextStep = builderAction.createCoroutineUnchecked(receiver = iterator, completion = iterator)
     return iterator
@@ -39,7 +39,7 @@ public fun <T> buildIterator(builderAction: suspend SequenceBuilder<T>.() -> Uni
  * Builder for a [Sequence] or an [Iterator], provides [yield] and [yieldAll] suspension functions.
  *
  * @see defineSequence
- * @see buildIterator
+ * @see defineIterator
  *
  * @sample samples.collections.Sequences.Building.defineSequenceYieldAll
  * @sample samples.collections.Sequences.Building.buildFibonacciSequence

--- a/libraries/stdlib/test/coroutines/SequenceBuilderTest.kt
+++ b/libraries/stdlib/test/coroutines/SequenceBuilderTest.kt
@@ -6,13 +6,13 @@
 package test.coroutines
 
 import kotlin.test.*
-import kotlin.coroutines.experimental.buildSequence
+import kotlin.coroutines.experimental.defineSequence
 import kotlin.coroutines.experimental.buildIterator
 
 class SequenceBuilderTest {
     @Test
     fun testSimple() {
-        val result = buildSequence {
+        val result = defineSequence {
             for (i in 1..3) {
                 yield(2 * i)
             }
@@ -25,7 +25,7 @@ class SequenceBuilderTest {
 
     @Test
     fun testCallHasNextSeveralTimes() {
-        val result = buildSequence {
+        val result = defineSequence {
             yield(1)
         }
 
@@ -46,7 +46,7 @@ class SequenceBuilderTest {
 
     @Test
     fun testManualIteration() {
-        val result = buildSequence {
+        val result = defineSequence {
             yield(1)
             yield(2)
             yield(3)
@@ -74,7 +74,7 @@ class SequenceBuilderTest {
 
     @Test
     fun testEmptySequence() {
-        val result = buildSequence<Int> {}
+        val result = defineSequence<Int> {}
         val iterator = result.iterator()
 
         assertFalse(iterator.hasNext())
@@ -86,10 +86,10 @@ class SequenceBuilderTest {
     @Test
     fun testLaziness() {
         var sharedVar = -2
-        val result = buildSequence {
+        val result = defineSequence {
             while (true) {
                 when (sharedVar) {
-                    -1 -> return@buildSequence
+                    -1 -> return@defineSequence
                     -2 -> error("Invalid state: -2")
                     else -> yield(sharedVar)
                 }
@@ -118,10 +118,10 @@ class SequenceBuilderTest {
     @Test
     fun testExceptionInCoroutine() {
         var sharedVar = -2
-        val result = buildSequence {
+        val result = defineSequence {
             while (true) {
                 when (sharedVar) {
-                    -1 -> return@buildSequence
+                    -1 -> return@defineSequence
                     -2 -> throw UnsupportedOperationException("-2 is unsupported")
                     else -> yield(sharedVar)
                 }
@@ -142,7 +142,7 @@ class SequenceBuilderTest {
     @Test
     fun testParallelIteration() {
         var inc = 0
-        val result = buildSequence {
+        val result = defineSequence {
             for (i in 1..3) {
                 inc++
                 yield(inc * i)
@@ -154,7 +154,7 @@ class SequenceBuilderTest {
 
     @Test
     fun testYieldAllIterator() {
-        val result = buildSequence {
+        val result = defineSequence {
             yieldAll(listOf(1, 2, 3).iterator())
         }
         assertEquals(listOf(1, 2, 3), result.toList())
@@ -162,7 +162,7 @@ class SequenceBuilderTest {
 
     @Test
     fun testYieldAllSequence() {
-        val result = buildSequence {
+        val result = defineSequence {
             yieldAll(sequenceOf(1, 2, 3))
         }
         assertEquals(listOf(1, 2, 3), result.toList())
@@ -170,7 +170,7 @@ class SequenceBuilderTest {
 
     @Test
     fun testYieldAllCollection() {
-        val result = buildSequence {
+        val result = defineSequence {
             yieldAll(listOf(1, 2, 3))
         }
         assertEquals(listOf(1, 2, 3), result.toList())
@@ -178,7 +178,7 @@ class SequenceBuilderTest {
 
     @Test
     fun testYieldAllCollectionMixedFirst() {
-        val result = buildSequence {
+        val result = defineSequence {
             yield(0)
             yieldAll(listOf(1, 2, 3))
         }
@@ -187,7 +187,7 @@ class SequenceBuilderTest {
 
     @Test
     fun testYieldAllCollectionMixedLast() {
-        val result = buildSequence {
+        val result = defineSequence {
             yieldAll(listOf(1, 2, 3))
             yield(4)
         }
@@ -196,7 +196,7 @@ class SequenceBuilderTest {
 
     @Test
     fun testYieldAllCollectionMixedBoth() {
-        val result = buildSequence {
+        val result = defineSequence {
             yield(0)
             yieldAll(listOf(1, 2, 3))
             yield(4)
@@ -206,7 +206,7 @@ class SequenceBuilderTest {
 
     @Test
     fun testYieldAllCollectionMixedLong() {
-        val result = buildSequence {
+        val result = defineSequence {
             yield(0)
             yieldAll(listOf(1, 2, 3))
             yield(4)
@@ -221,7 +221,7 @@ class SequenceBuilderTest {
 
     @Test
     fun testYieldAllCollectionOneEmpty() {
-        val result = buildSequence<Int> {
+        val result = defineSequence<Int> {
             yieldAll(listOf())
         }
         assertEquals(listOf(), result.toList())
@@ -229,7 +229,7 @@ class SequenceBuilderTest {
 
     @Test
     fun testYieldAllCollectionManyEmpty() {
-        val result = buildSequence<Int> {
+        val result = defineSequence<Int> {
             yieldAll(listOf())
             yieldAll(listOf())
             yieldAll(listOf())
@@ -240,7 +240,7 @@ class SequenceBuilderTest {
     @Test
     fun testYieldAllSideEffects() {
         val effects = arrayListOf<Any>()
-        val result = buildSequence {
+        val result = defineSequence {
             effects.add("a")
             yieldAll(listOf(1, 2))
             effects.add("b")

--- a/libraries/stdlib/test/coroutines/SequenceBuilderTest.kt
+++ b/libraries/stdlib/test/coroutines/SequenceBuilderTest.kt
@@ -7,7 +7,7 @@ package test.coroutines
 
 import kotlin.test.*
 import kotlin.coroutines.experimental.defineSequence
-import kotlin.coroutines.experimental.buildIterator
+import kotlin.coroutines.experimental.defineIterator
 
 class SequenceBuilderTest {
     @Test
@@ -278,7 +278,7 @@ class SequenceBuilderTest {
 
     @Test
     fun testInfiniteYieldAll() {
-        val values = buildIterator {
+        val values = defineIterator {
             while (true) {
                 yieldAll((1..5).map { it })
             }

--- a/libraries/tools/binary-compatibility-validator/reference-public-api/kotlin-stdlib-runtime-merged.txt
+++ b/libraries/tools/binary-compatibility-validator/reference-public-api/kotlin-stdlib-runtime-merged.txt
@@ -2068,7 +2068,7 @@ public abstract class kotlin/coroutines/experimental/SequenceBuilder {
 }
 
 public final class kotlin/coroutines/experimental/SequenceBuilderKt {
-	public static final fun buildIterator (Lkotlin/jvm/functions/Function2;)Ljava/util/Iterator;
+	public static final fun defineIterator (Lkotlin/jvm/functions/Function2;)Ljava/util/Iterator;
 	public static final fun defineSequence (Lkotlin/jvm/functions/Function2;)Lkotlin/sequences/Sequence;
 }
 

--- a/libraries/tools/binary-compatibility-validator/reference-public-api/kotlin-stdlib-runtime-merged.txt
+++ b/libraries/tools/binary-compatibility-validator/reference-public-api/kotlin-stdlib-runtime-merged.txt
@@ -2069,7 +2069,7 @@ public abstract class kotlin/coroutines/experimental/SequenceBuilder {
 
 public final class kotlin/coroutines/experimental/SequenceBuilderKt {
 	public static final fun buildIterator (Lkotlin/jvm/functions/Function2;)Ljava/util/Iterator;
-	public static final fun buildSequence (Lkotlin/jvm/functions/Function2;)Lkotlin/sequences/Sequence;
+	public static final fun defineSequence (Lkotlin/jvm/functions/Function2;)Lkotlin/sequences/Sequence;
 }
 
 public final class kotlin/coroutines/experimental/intrinsics/IntrinsicsKt {

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Generators.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Generators.kt
@@ -944,7 +944,7 @@ object Generators : TemplateGroupBase() {
         }
         body(Sequences) {
             """
-            return buildSequence result@ {
+            return defineSequence result@ {
                 val iterator = iterator()
                 if (!iterator.hasNext()) return@result
                 var current = iterator.next()

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/dsl/TemplateGroups.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/dsl/TemplateGroups.kt
@@ -5,7 +5,7 @@
 
 package templates
 
-import kotlin.coroutines.experimental.buildSequence
+import kotlin.coroutines.experimental.defineSequence
 import kotlin.reflect.KTypeProjection
 import kotlin.reflect.full.createType
 import kotlin.reflect.full.isSubtypeOf
@@ -17,7 +17,7 @@ fun templateGroupOf(vararg templates: MemberTemplate): TemplateGroup = { templat
 
 abstract class TemplateGroupBase : TemplateGroup {
 
-    override fun invoke(): Sequence<MemberTemplate> = buildSequence {
+    override fun invoke(): Sequence<MemberTemplate> = defineSequence {
         with(this@TemplateGroupBase) {
             this::class.members.filter { it.name.startsWith("f_") }.forEach {
                 require(it.parameters.size == 1) { "Member $it violates naming convention" }

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/dsl/Templates.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/dsl/Templates.kt
@@ -179,7 +179,7 @@ class FamilyPrimitiveMemberDefinition : MemberTemplateDefinition<PrimitiveType?>
         }
     }
 
-    override fun parametrize(): Sequence<Pair<Family, PrimitiveType?>> = buildSequence {
+    override fun parametrize(): Sequence<Pair<Family, PrimitiveType?>> = defineSequence {
         for ((family, primitives) in familyPrimitives) {
             if (primitives.isEmpty())
                 yield(family to null)

--- a/libraries/tools/kotlinp/test/org/jetbrains/kotlin/kotlinp/test/KotlinpCompilerTestDataTest.kt
+++ b/libraries/tools/kotlinp/test/org/jetbrains/kotlin/kotlinp/test/KotlinpCompilerTestDataTest.kt
@@ -12,7 +12,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import java.io.File
-import kotlin.coroutines.experimental.buildSequence
+import kotlin.coroutines.experimental.defineSequence
 
 @RunWith(Parameterized::class)
 class KotlinpCompilerTestDataTest(private val file: File) {
@@ -41,7 +41,7 @@ class KotlinpCompilerTestDataTest(private val file: File) {
                 "compiler/testData/serialization/builtinsSerializer"
             )
 
-            return buildSequence<Array<*>> {
+            return defineSequence<Array<*>> {
                 for (baseDir in baseDirs) {
                     for (file in File(baseDir).walkTopDown()) {
                         if (file.extension == "kt") {

--- a/plugins/scripting/scripting-cli/src/org/jetbrains/kotlin/scripting/compiler/plugin/ScriptiDefinitionsFromClasspathDiscoverySource.kt
+++ b/plugins/scripting/scripting-cli/src/org/jetbrains/kotlin/scripting/compiler/plugin/ScriptiDefinitionsFromClasspathDiscoverySource.kt
@@ -15,7 +15,7 @@ import java.io.File
 import java.io.IOException
 import java.net.URLClassLoader
 import java.util.jar.JarFile
-import kotlin.coroutines.experimental.buildSequence
+import kotlin.coroutines.experimental.defineSequence
 import kotlin.script.experimental.annotations.KotlinScript
 import kotlin.script.experimental.api.KotlinType
 import kotlin.script.experimental.api.ScriptingEnvironment
@@ -47,7 +47,7 @@ internal fun discoverScriptTemplatesInClasspath(
     baseClassLoader: ClassLoader,
     scriptResolverEnv: Map<String, Any?>,
     messageCollector: MessageCollector
-): Sequence<KotlinScriptDefinition> = buildSequence {
+): Sequence<KotlinScriptDefinition> = defineSequence {
     // TODO: try to find a way to reduce classpath (and classloader) to minimal one needed to load script definition and its dependencies
     val loader = LazyClasspathWithClassLoader(baseClassLoader) { classpath }
 
@@ -135,7 +135,7 @@ internal fun loadScriptTemplatesFromClasspath(
     messageCollector: MessageCollector
 ): Sequence<KotlinScriptDefinition> =
     if (scriptTemplates.isEmpty()) emptySequence()
-    else buildSequence {
+    else defineSequence {
         // trying the direct classloading from baseClassloader first, since this is the most performant variant
         val (initialLoadedDefinitions, initialNotFoundTemplates) = scriptTemplates.partitionMapNotNull {
             loadScriptDefinition(baseClassLoader, it, scriptResolverEnv, messageCollector)


### PR DESCRIPTION
This is related to https://youtrack.jetbrains.com/issue/KT-26678

##### I've followed `defineSequence` and `defineIterator` proposal, disregard this if we decide to choose any other name proposal