### PR TITLE
Fix the problem with code completion of type extension method

### DIFF
--- a/idea/ide-common/src/org/jetbrains/kotlin/idea/util/ShadowedDeclarationsFilter.kt
+++ b/idea/ide-common/src/org/jetbrains/kotlin/idea/util/ShadowedDeclarationsFilter.kt
@@ -246,6 +246,15 @@ class ShadowedDeclarationsFilter(
                 if (p1.varargElementType != p2.varargElementType) return false // both should be vararg or or both not
                 if (p1.type != p2.type) return false
             }
+
+            val typeParameters1 = function.typeParameters
+            val typeParameters2 = other.function.typeParameters
+            if (typeParameters1.size != typeParameters2.size) return false
+            for (i in typeParameters1.indices) {
+                val t1 = typeParameters1[i]
+                val t2 = typeParameters2[i]
+                if (t1.upperBounds != t2.upperBounds) return false
+            }
             return true
         }
 

--- a/idea/idea-completion/testData/basic/common/shadowing/ExtensionShadows.kt
+++ b/idea/idea-completion/testData/basic/common/shadowing/ExtensionShadows.kt
@@ -1,0 +1,13 @@
+class Shadow {
+    fun shade() {}
+}
+
+fun <X> Shadow.shade() {}
+
+fun context() {
+    Shadow().sha<caret>
+}
+
+// EXIST: { lookupString: "shade", itemText: "shade", tailText: "()", typeText: "Unit" }
+// EXIST: { lookupString: "shade", itemText: "shade", tailText: "() for Shadow in <root>", typeText: "Unit" }
+// NOTHING_ELSE

--- a/idea/idea-completion/testData/basic/common/shadowing/PreferMoreSpecificExtensionGenericWithMultipleParam.kt
+++ b/idea/idea-completion/testData/basic/common/shadowing/PreferMoreSpecificExtensionGenericWithMultipleParam.kt
@@ -1,0 +1,9 @@
+fun <T, S> List<T>.xxx(t: T){}
+fun <T, W> Iterable<T>.xxx(t: T){}
+
+fun foo() {
+    listOf(1).xx<caret>
+}
+
+// EXIST: { lookupString: "xxx", itemText: "xxx", tailText: "(t: Int) for List<T> in <root>", typeText: "Unit" }
+// NOTHING_ELSE

--- a/idea/idea-completion/tests/org/jetbrains/kotlin/idea/completion/test/JSBasicCompletionTestGenerated.java
+++ b/idea/idea-completion/tests/org/jetbrains/kotlin/idea/completion/test/JSBasicCompletionTestGenerated.java
@@ -2110,6 +2110,11 @@ public class JSBasicCompletionTestGenerated extends AbstractJSBasicCompletionTes
                 KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/idea-completion/testData/basic/common/shadowing"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.ANY, true);
             }
 
+            @TestMetadata("ExtensionShadows.kt")
+            public void testExtensionShadows() throws Exception {
+                runTest("idea/idea-completion/testData/basic/common/shadowing/ExtensionShadows.kt");
+            }
+
             @TestMetadata("InInitializer1.kt")
             public void testInInitializer1() throws Exception {
                 runTest("idea/idea-completion/testData/basic/common/shadowing/InInitializer1.kt");
@@ -2198,6 +2203,11 @@ public class JSBasicCompletionTestGenerated extends AbstractJSBasicCompletionTes
             @TestMetadata("PreferMoreSpecificExtensionGeneric.kt")
             public void testPreferMoreSpecificExtensionGeneric() throws Exception {
                 runTest("idea/idea-completion/testData/basic/common/shadowing/PreferMoreSpecificExtensionGeneric.kt");
+            }
+
+            @TestMetadata("PreferMoreSpecificExtensionGenericWithMultipleParam.kt")
+            public void testPreferMoreSpecificExtensionGenericWithMultipleParam() throws Exception {
+                runTest("idea/idea-completion/testData/basic/common/shadowing/PreferMoreSpecificExtensionGenericWithMultipleParam.kt");
             }
 
             @TestMetadata("PreferMoreSpecificExtensionGenericWithParam.kt")

--- a/idea/idea-completion/tests/org/jetbrains/kotlin/idea/completion/test/JvmBasicCompletionTestGenerated.java
+++ b/idea/idea-completion/tests/org/jetbrains/kotlin/idea/completion/test/JvmBasicCompletionTestGenerated.java
@@ -2110,6 +2110,11 @@ public class JvmBasicCompletionTestGenerated extends AbstractJvmBasicCompletionT
                 KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/idea-completion/testData/basic/common/shadowing"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.ANY, true);
             }
 
+            @TestMetadata("ExtensionShadows.kt")
+            public void testExtensionShadows() throws Exception {
+                runTest("idea/idea-completion/testData/basic/common/shadowing/ExtensionShadows.kt");
+            }
+
             @TestMetadata("InInitializer1.kt")
             public void testInInitializer1() throws Exception {
                 runTest("idea/idea-completion/testData/basic/common/shadowing/InInitializer1.kt");
@@ -2198,6 +2203,11 @@ public class JvmBasicCompletionTestGenerated extends AbstractJvmBasicCompletionT
             @TestMetadata("PreferMoreSpecificExtensionGeneric.kt")
             public void testPreferMoreSpecificExtensionGeneric() throws Exception {
                 runTest("idea/idea-completion/testData/basic/common/shadowing/PreferMoreSpecificExtensionGeneric.kt");
+            }
+
+            @TestMetadata("PreferMoreSpecificExtensionGenericWithMultipleParam.kt")
+            public void testPreferMoreSpecificExtensionGenericWithMultipleParam() throws Exception {
+                runTest("idea/idea-completion/testData/basic/common/shadowing/PreferMoreSpecificExtensionGenericWithMultipleParam.kt");
             }
 
             @TestMetadata("PreferMoreSpecificExtensionGenericWithParam.kt")


### PR DESCRIPTION
KT-23834 Fixed

---

It seems the test case https://github.com/shiraji/kotlin/blob/57f956de55acae3073998bac2579cce1bd99003d/idea/idea-completion/tests/org/jetbrains/kotlin/idea/completion/test/JvmBasicCompletionTestGenerated.java#L335 fails in master branch. I don't think this test case is related to this PR. (It seems suggesting kotlin.js in Jvm environment.)