### PR TITLE
Remove CandidateWithBoundDispatchReceiverImpl

### DIFF
--- a/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tower/ImplicitScopeTower.kt
+++ b/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tower/ImplicitScopeTower.kt
@@ -54,13 +54,11 @@ interface ScopeTowerLevel {
     fun recordLookup(name: Name)
 }
 
-interface CandidateWithBoundDispatchReceiver {
-    val descriptor: CallableDescriptor
-
+class CandidateWithBoundDispatchReceiver(
+    val dispatchReceiver: ReceiverValueWithSmartCastInfo?,
+    val descriptor: CallableDescriptor,
     val diagnostics: List<ResolutionDiagnostic>
-
-    val dispatchReceiver: ReceiverValueWithSmartCastInfo?
-}
+)
 
 fun getResultApplicability(diagnostics: Collection<KotlinCallDiagnostic>) =
     diagnostics.maxBy { it.candidateApplicability }?.candidateApplicability

--- a/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tower/InvokeProcessors.kt
+++ b/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tower/InvokeProcessors.kt
@@ -214,7 +214,7 @@ private fun ImplicitScopeTower.getExtensionInvokeCandidateDescriptor(
             ?: error("No single synthesized invoke for $invokeDescriptor: $synthesizedInvokes")
 
     // here we don't add SynthesizedDescriptor diagnostic because it should has priority as member
-    return CandidateWithBoundDispatchReceiverImpl(extensionFunctionReceiver, synthesizedInvoke, listOf())
+    return CandidateWithBoundDispatchReceiver(extensionFunctionReceiver, synthesizedInvoke, listOf())
 }
 
 // case 1.(foo())() or (foo())()

--- a/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tower/TowerLevels.kt
+++ b/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tower/TowerLevels.kt
@@ -72,7 +72,7 @@ internal abstract class AbstractScopeTowerLevel(
                 )?.let { diagnostics.add(VisibilityError(it)) }
             }
         }
-        return CandidateWithBoundDispatchReceiverImpl(dispatchReceiver, descriptor, diagnostics)
+        return CandidateWithBoundDispatchReceiver(dispatchReceiver, descriptor, diagnostics)
     }
 
 }

--- a/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tower/TowerUtils.kt
+++ b/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tower/TowerUtils.kt
@@ -38,12 +38,6 @@ val CandidateWithBoundDispatchReceiver.requiresExtensionReceiver: Boolean
 val ResolutionCandidateApplicability.isInapplicable: Boolean
     get() = this in INAPPLICABLE_STATUSES
 
-internal class CandidateWithBoundDispatchReceiverImpl(
-    override val dispatchReceiver: ReceiverValueWithSmartCastInfo?,
-    override val descriptor: CallableDescriptor,
-    override val diagnostics: List<ResolutionDiagnostic>
-) : CandidateWithBoundDispatchReceiver
-
 fun <C : Candidate> C.forceResolution(): C {
     resultingApplicability
     return this


### PR DESCRIPTION
Interface CandidateWithBoundDispatchReceiver had a unique
implementation, which was private.

Turned interface CandidateWithBoundDispatchReceiver into a
class. Removed CandidateWithBoundDispatchReceiverImpl. Removed
string "Impl" suffix at constructor call sites.