### PR TITLE
Expand the fix from commit 6c274cecff3 to cover AndroidX

### DIFF
--- a/compiler/frontend.java/src/org/jetbrains/kotlin/load/java/sam/SingleAbstractMethodUtils.java
+++ b/compiler/frontend.java/src/org/jetbrains/kotlin/load/java/sam/SingleAbstractMethodUtils.java
@@ -148,7 +148,7 @@ public class SingleAbstractMethodUtils {
         // Otherwise android data binding can cause resolve re-entrance
         // For details see KT-18687, KT-16149
         // TODO: prevent resolve re-entrance on architecture level, or (alternatively) ask data binding owners not to do it
-        if (DescriptorUtilsKt.getFqNameSafe(klass).asString().equals("android.databinding.DataBindingComponent")) {
+        if (DescriptorUtilsKt.getFqNameSafe(klass).asString().endsWith(".databinding.DataBindingComponent")) {
             return null;
         }
 


### PR DESCRIPTION
Android Studio users who migrated to AndroidX are running into the
databinding deadlock again: https://issuetracker.google.com/111788726