### PR TITLE
Use new API from AGP to get JavaCompile task

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/agp25/kotlin/org/jetbrains/kotlin/gradle/plugin/android/Android25ProjectHandler.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/agp25/kotlin/org/jetbrains/kotlin/gradle/plugin/android/Android25ProjectHandler.kt
@@ -88,9 +88,15 @@ class Android25ProjectHandler(kotlinConfigurationTools: KotlinConfigurationTools
         else -> null
     }
 
-    override fun getJavaTask(variantData: BaseVariant): AbstractCompile? =
-            @Suppress("DEPRECATION") // There is always a Java compile task -- the deprecation was for Jack
-            variantData.javaCompile
+    override fun getJavaTask(variantData: BaseVariant): AbstractCompile? {
+        @Suppress("DEPRECATION") // There is always a Java compile task -- the deprecation was for Jack
+        return variantData::class.java.methods.firstOrNull { it.name == "getJavaCompileProvider" }
+            ?.invoke(variantData)
+            .let { taskProvider ->
+                // org.gradle.api.tasks.TaskProvider is added in Gradle 4.8
+                taskProvider!!::class.java.methods.firstOrNull { it.name == "get" }?.invoke(taskProvider) as AbstractCompile?
+            } ?: variantData.javaCompile
+    }
 
     override fun addJavaSourceDirectoryToVariantModel(variantData: BaseVariant, javaSourceDirectory: File) =
             variantData.addJavaSourceFoldersToModel(javaSourceDirectory)


### PR DESCRIPTION
New API for getting the JavaCompile task has been
added to AGP, and the old one is deprecated. It is
now returning TaskProvider<JavaCompile>, which allows
API users to avoid configuring tasks unnecessarily.

This commit does not change anything functionally, it
is only to avoid the warning message, as reporter in
https://issuetracker.google.com/116198439.