### PR TITLE
KT-26056 J2K: Missing `toInt()` call when char used as array index

### DIFF
--- a/j2k/src/org/jetbrains/kotlin/j2k/CodeConverter.kt
+++ b/j2k/src/org/jetbrains/kotlin/j2k/CodeConverter.kt
@@ -114,9 +114,14 @@ class CodeConverter(
         if (actualType.needTypeConversion(expectedType)) {
             val expectedTypeStr = expectedType.canonicalText
             if (expression is PsiLiteralExpression) {
-                if (actualType.canonicalText == "char" && expression.parent !is PsiExpressionList) {
-                    expression.getTypeConversionMethod(expectedType)?.also {
-                        convertedExpression = MethodCallExpression.buildNonNull(convertedExpression, it)
+                if (actualType.canonicalText == "char") {
+                    if (expression.parent !is PsiExpressionList) {
+                        expression.getTypeConversionMethod(expectedType)?.also {
+                            convertedExpression = MethodCallExpression.buildNonNull(convertedExpression, it)
+                        }
+                    }
+                    else if (expectedTypeStr == "int") {
+                        convertedExpression = MethodCallExpression.buildNonNull(convertedExpression, "toInt")
                     }
                 }
                 else if (expectedTypeStr == "float" || expectedTypeStr == "double") {

--- a/j2k/testData/fileOrElement/methodCallExpression/charAsInt.java
+++ b/j2k/testData/fileOrElement/methodCallExpression/charAsInt.java
@@ -1,0 +1,7 @@
+public class A {
+    public void foo() {
+        bar('a');
+    }
+
+    public void bar(int i) {}
+}

--- a/j2k/testData/fileOrElement/methodCallExpression/charAsInt.kt
+++ b/j2k/testData/fileOrElement/methodCallExpression/charAsInt.kt
@@ -1,0 +1,7 @@
+class A {
+    fun foo() {
+        bar('a'.toInt())
+    }
+
+    fun bar(i: Int) {}
+}

--- a/j2k/tests/org/jetbrains/kotlin/j2k/JavaToKotlinConverterForWebDemoTestGenerated.java
+++ b/j2k/tests/org/jetbrains/kotlin/j2k/JavaToKotlinConverterForWebDemoTestGenerated.java
@@ -3164,6 +3164,11 @@ public class JavaToKotlinConverterForWebDemoTestGenerated extends AbstractJavaTo
             runTest("j2k/testData/fileOrElement/methodCallExpression/callWithKeywords.java");
         }
 
+        @TestMetadata("charAsInt.java")
+        public void testCharAsInt() throws Exception {
+            runTest("j2k/testData/fileOrElement/methodCallExpression/charAsInt.java");
+        }
+
         @TestMetadata("collectionsMethods.java")
         public void testCollectionsMethods() throws Exception {
             runTest("j2k/testData/fileOrElement/methodCallExpression/collectionsMethods.java");

--- a/j2k/tests/org/jetbrains/kotlin/j2k/JavaToKotlinConverterSingleFileTestGenerated.java
+++ b/j2k/tests/org/jetbrains/kotlin/j2k/JavaToKotlinConverterSingleFileTestGenerated.java
@@ -3164,6 +3164,11 @@ public class JavaToKotlinConverterSingleFileTestGenerated extends AbstractJavaTo
             runTest("j2k/testData/fileOrElement/methodCallExpression/callWithKeywords.java");
         }
 
+        @TestMetadata("charAsInt.java")
+        public void testCharAsInt() throws Exception {
+            runTest("j2k/testData/fileOrElement/methodCallExpression/charAsInt.java");
+        }
+
         @TestMetadata("collectionsMethods.java")
         public void testCollectionsMethods() throws Exception {
             runTest("j2k/testData/fileOrElement/methodCallExpression/collectionsMethods.java");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-26056