### PR TITLE
KT-26056 J2K: Missing `toInt()` call when char used as array index

### DIFF
--- a/j2k/src/org/jetbrains/kotlin/j2k/CodeConverter.kt
+++ b/j2k/src/org/jetbrains/kotlin/j2k/CodeConverter.kt
@@ -111,6 +111,11 @@ class CodeConverter(
             convertedExpression = BangBangExpression.surroundIfNullable(convertedExpression)
         }
 
+        if (convertedExpression is ArrayAccessExpression && (expression as PsiArrayAccessExpression).indexExpression?.type?.canonicalText == "char") {
+            val newIndex = MethodCallExpression.buildNonNull(convertedExpression.index, "toInt").assignNoPrototype()
+            convertedExpression = ArrayAccessExpression(convertedExpression.expression, newIndex, convertedExpression.lvalue)
+        }
+
         if (actualType.needTypeConversion(expectedType)) {
             val expectedTypeStr = expectedType.canonicalText
             if (expression is PsiLiteralExpression) {

--- a/j2k/src/org/jetbrains/kotlin/j2k/CodeConverter.kt
+++ b/j2k/src/org/jetbrains/kotlin/j2k/CodeConverter.kt
@@ -111,7 +111,7 @@ class CodeConverter(
             convertedExpression = BangBangExpression.surroundIfNullable(convertedExpression)
         }
 
-        if (convertedExpression is ArrayAccessExpression && (expression as PsiArrayAccessExpression).indexExpression?.type?.canonicalText == "char") {
+        if (convertedExpression is ArrayAccessExpression && (expression as PsiArrayAccessExpression).indexExpression?.type?.canonicalText in setOf("char", "byte", "short")) {
             val newIndex = MethodCallExpression.buildNonNull(convertedExpression.index, "toInt").assignNoPrototype()
             convertedExpression = ArrayAccessExpression(convertedExpression.expression, newIndex, convertedExpression.lvalue)
         }

--- a/j2k/testData/fileOrElement/arrayAccessExpression/byteIndex.java
+++ b/j2k/testData/fileOrElement/arrayAccessExpression/byteIndex.java
@@ -1,0 +1,7 @@
+public class Sample {
+    public void foo() {
+        String[] map = {"FOO", "BAR"};
+        byte b = 0;
+        String str = map[b];
+    }
+}

--- a/j2k/testData/fileOrElement/arrayAccessExpression/byteIndex.kt
+++ b/j2k/testData/fileOrElement/arrayAccessExpression/byteIndex.kt
@@ -1,0 +1,7 @@
+class Sample {
+    fun foo() {
+        val map = arrayOf("FOO", "BAR")
+        val b: Byte = 0
+        val str = map[b.toInt()]
+    }
+}

--- a/j2k/testData/fileOrElement/arrayAccessExpression/charIndex.java
+++ b/j2k/testData/fileOrElement/arrayAccessExpression/charIndex.java
@@ -1,0 +1,7 @@
+public class Sample {
+    public void foo() {
+        String[] map = {"FOO", "BAR"};
+        char c = '\0';
+        String str = map[c];
+    }
+}

--- a/j2k/testData/fileOrElement/arrayAccessExpression/charIndex.kt
+++ b/j2k/testData/fileOrElement/arrayAccessExpression/charIndex.kt
@@ -1,0 +1,7 @@
+class Sample {
+    fun foo() {
+        val map = arrayOf("FOO", "BAR")
+        val c = '\u0000'
+        val str = map[c.toInt()]
+    }
+}

--- a/j2k/testData/fileOrElement/arrayAccessExpression/shortIndex.java
+++ b/j2k/testData/fileOrElement/arrayAccessExpression/shortIndex.java
@@ -1,0 +1,7 @@
+public class Sample {
+    public void foo() {
+        String[] map = {"FOO", "BAR"};
+        short s = 0;
+        String str = map[s];
+    }
+}

--- a/j2k/testData/fileOrElement/arrayAccessExpression/shortIndex.kt
+++ b/j2k/testData/fileOrElement/arrayAccessExpression/shortIndex.kt
@@ -1,0 +1,7 @@
+class Sample {
+    fun foo() {
+        val map = arrayOf("FOO", "BAR")
+        val s: Short= 0
+        val str = map[s.toInt()]
+    }
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-26056