### PR TITLE
Use separate configuration for resolving native compiler plugin artif…

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-api/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinGradleSubplugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin-api/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinGradleSubplugin.kt
@@ -67,6 +67,7 @@ interface KotlinGradleSubplugin<in KotlinCompile : AbstractCompile> {
     fun getCompilerPluginId(): String
 
     fun getPluginArtifact(): SubpluginArtifact
+    fun getNativeCompilerPluginArtifact(): SubpluginArtifact? = null
 }
 
 open class SubpluginArtifact(val groupId: String, val artifactId: String, val version: String? = null)

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt
@@ -40,6 +40,7 @@ import java.util.concurrent.Callable
 import java.util.jar.Manifest
 
 const val PLUGIN_CLASSPATH_CONFIGURATION_NAME = "kotlinCompilerPluginClasspath"
+const val NATIVE_COMPILER_PLUGIN_CLASSPATH_CONFIGURATION_NAME = "kotlinNativeCompilerPluginClasspath"
 internal const val COMPILER_CLASSPATH_CONFIGURATION_NAME = "kotlinCompilerClasspath"
 val KOTLIN_DSL_NAME = "kotlin"
 val KOTLIN_JS_DSL_NAME = "kotlin2js"

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPluginWrapper.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPluginWrapper.kt
@@ -55,6 +55,9 @@ abstract class KotlinBasePluginWrapper(
             // todo: Consider removing if org.jetbrains.kotlin.cli.jvm.plugins.PluginCliParser stops using parent last classloader
             isTransitive = false
         }
+        project.configurations.maybeCreate(NATIVE_COMPILER_PLUGIN_CLASSPATH_CONFIGURATION_NAME).apply {
+            isTransitive = false
+        }
 
         // TODO: consider only set if if daemon or parallel compilation are enabled, though this way it should be safe too
         System.setProperty(org.jetbrains.kotlin.cli.common.KOTLIN_COMPILER_ENVIRONMENT_KEEPALIVE_PROPERTY, "true")

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinTargetConfigurator.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinTargetConfigurator.kt
@@ -435,7 +435,7 @@ open class KotlinNativeTargetConfigurator(
         SubpluginEnvironment
             .loadSubplugins(project, kotlinPluginVersion)
             .addSubpluginOptions<CommonCompilerArguments>(project, this, compilerPluginOptions)
-        compilerPluginClasspath = project.configurations.getByName(PLUGIN_CLASSPATH_CONFIGURATION_NAME)
+        compilerPluginClasspath = project.configurations.getByName(NATIVE_COMPILER_PLUGIN_CLASSPATH_CONFIGURATION_NAME)
     }
 
     private fun KotlinNativeCompile.registerOutputFiles(outputDirectory: File) {

--- a/libraries/tools/kotlin-serialization/src/main/kotlin/org/jetbrains/kotlinx/serialization/gradle/SerializationSubplugin.kt
+++ b/libraries/tools/kotlin-serialization/src/main/kotlin/org/jetbrains/kotlinx/serialization/gradle/SerializationSubplugin.kt
@@ -42,14 +42,8 @@ class SerializationKotlinGradleSubplugin : KotlinGradleSubplugin<AbstractCompile
         const val SERIALIZATION_ARTIFACT_UNSHADED_NAME = "kotlin-serialization-unshaded"
     }
 
-    private var useUnshaded = false
-
-    override fun isApplicable(project: Project, task: AbstractCompile): Boolean {
-        if (!SerializationGradleSubplugin.isEnabled(project)) return false
-        // Kotlin/Native task is not an AbstractKotlinCompile and uses unshaded compiler
-        if (task !is AbstractKotlinCompile<*>) useUnshaded = true
-        return true
-    }
+    override fun isApplicable(project: Project, task: AbstractCompile): Boolean =
+        SerializationGradleSubplugin.isEnabled(project)
 
     override fun apply(
         project: Project,
@@ -62,11 +56,11 @@ class SerializationKotlinGradleSubplugin : KotlinGradleSubplugin<AbstractCompile
         return emptyList()
     }
 
+    override fun getPluginArtifact(): SubpluginArtifact =
+        SubpluginArtifact(SERIALIZATION_GROUP_NAME, SERIALIZATION_ARTIFACT_NAME)
 
-    override fun getPluginArtifact(): SubpluginArtifact {
-        val artifact = if (useUnshaded) SERIALIZATION_ARTIFACT_UNSHADED_NAME else SERIALIZATION_ARTIFACT_NAME
-        return SubpluginArtifact(SERIALIZATION_GROUP_NAME, artifact)
-    }
+    override fun getNativeCompilerPluginArtifact(): SubpluginArtifact? =
+        SubpluginArtifact(SERIALIZATION_GROUP_NAME, SERIALIZATION_ARTIFACT_UNSHADED_NAME)
 
     override fun getCompilerPluginId() = "org.jetbrains.kotlinx.serialization"
 }


### PR DESCRIPTION
…acts

Kotlin/JVM and Kotlin/JS use shaded compiler, but
Kotlin/Native uses non-shaded one.
Serialization plugin was configured to use either shaded or non-shaded
plugin version, because we used one configuration for resolving
compiler plugins.
This change introduces 'kotlinNativeCompilerPluginClasspath' configuration
for resolving Kotlin/Native compiler plugins.