### PR TITLE
KT-27146 False positive "map.put() can be converted to assignment" on `super` keyword with `LinkedHashMap` inheritance

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/ReplacePutWithAssignmentInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/ReplacePutWithAssignmentInspection.kt
@@ -38,6 +38,8 @@ class ReplacePutWithAssignmentInspection : AbstractApplicabilityBasedInspection<
 ) {
 
     override fun isApplicable(element: KtDotQualifiedExpression): Boolean {
+        if (element.receiverExpression is KtSuperExpression) return false
+
         val callExpression = element.callExpression
         if (callExpression?.valueArguments?.size != 2) return false
 

--- a/idea/testData/inspectionsLocal/replacePutWithAssignment/putOnSuper.kt
+++ b/idea/testData/inspectionsLocal/replacePutWithAssignment/putOnSuper.kt
@@ -1,0 +1,8 @@
+// PROBLEM: none
+// RUNTIME_WITH_FULL_JDK
+
+class Test : java.util.LinkedHashMap<String, String>() {
+    fun test() {
+        super.<caret>put("foo", "bar")
+    }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -5071,6 +5071,11 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
             runTest("idea/testData/inspectionsLocal/replacePutWithAssignment/putOnParameter.kt");
         }
 
+        @TestMetadata("putOnSuper.kt")
+        public void testPutOnSuper() throws Exception {
+            runTest("idea/testData/inspectionsLocal/replacePutWithAssignment/putOnSuper.kt");
+        }
+
         @TestMetadata("putOnThis.kt")
         public void testPutOnThis() throws Exception {
             runTest("idea/testData/inspectionsLocal/replacePutWithAssignment/putOnThis.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-27146