### PR TITLE
KT-27354 False positive "Make 'Foo' open" for `data` class inheritance

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/AddModifierFix.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/AddModifierFix.kt
@@ -156,7 +156,7 @@ open class AddModifierFix(
             val classDescriptor = type.constructor.declarationDescriptor as? ClassDescriptor ?: return null
             val declaration = DescriptorToSourceUtils.descriptorToDeclaration(classDescriptor) as? KtClass ?: return null
             if (!declaration.canRefactor()) return null
-            if (declaration.isEnum()) return null
+            if (declaration.isEnum() || declaration.isData()) return null
             return AddModifierFix(declaration, KtTokens.OPEN_KEYWORD)
         }
     }

--- a/idea/testData/quickfix/modifiers/addOpenToClassDeclaration/dataSuperType.kt
+++ b/idea/testData/quickfix/modifiers/addOpenToClassDeclaration/dataSuperType.kt
@@ -1,0 +1,6 @@
+// "Make 'A' open" "false"
+// ERROR: This type is final, so it cannot be inherited from
+// ACTION: Add names to call arguments
+// ACTION: Do not show hints for current method
+data class A(val x: Int)
+class B: A<caret>(42)

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -7960,6 +7960,11 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
                 KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/quickfix/modifiers/addOpenToClassDeclaration"), Pattern.compile("^([\\w\\-_]+)\\.kt$"), TargetBackend.ANY, true);
             }
 
+            @TestMetadata("dataSuperType.kt")
+            public void testDataSuperType() throws Exception {
+                runTest("idea/testData/quickfix/modifiers/addOpenToClassDeclaration/dataSuperType.kt");
+            }
+
             @TestMetadata("enumSupertype.kt")
             public void testEnumSupertype() throws Exception {
                 runTest("idea/testData/quickfix/modifiers/addOpenToClassDeclaration/enumSupertype.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-27354