### PR TITLE
Fix typo in expression precedence table

### DIFF
--- a/grammar/src/expressions.grm
+++ b/grammar/src/expressions.grm
@@ -17,7 +17,7 @@
 | | Elvis | `?:` |
 | | Named checks | `in`, `!in`, `is`, `!is` |
 | | Comparison | `<`, `>`, `<=`, `>=` |
-| | Equality | `==`, `\!==` |
+| | Equality | `==`, `!==` |
 | | Conjunction | `&&` |
 | | Disjunction | `||` |
 | Lowest | Assignment | `=`, `+=`, `-=`, `*=`, `/=`, `%=` |


### PR DESCRIPTION
The backslash renders at https://kotlinlang.org/docs/reference/grammar.html#precedence.