### PR TITLE
kotlin-test: Add documentation for value returned by assertFailsWith

### DIFF
--- a/libraries/kotlin.test/common/src/main/kotlin/kotlin/test/Assertions.kt
+++ b/libraries/kotlin.test/common/src/main/kotlin/kotlin/test/Assertions.kt
@@ -106,6 +106,9 @@ fun assertFails(block: () -> Unit): Throwable = assertFails(null, block)
  * Asserts that given function [block] fails by throwing an exception.
  *
  * If the assertion fails, the specified [message] is used unless it is null as a prefix for the failure message.
+ *
+ * @return An exception that was expected to be thrown and was successfully caught, so it is possible to check any
+ *         property of that exception.
  */
 @SinceKotlin("1.1")
 fun assertFails(message: String?, block: () -> Unit): Throwable {
@@ -121,6 +124,9 @@ fun assertFails(message: String?, block: () -> Unit): Throwable {
 /** Asserts that a [block] fails with a specific exception of type [T] being thrown.
  *
  * If the assertion fails, the specified [message] is used unless it is null as a prefix for the failure message.
+ *
+ * @return An exception that was expected to be thrown and was successfully caught, so it is possible to check any
+ *         property of that exception.
  */
 @InlineOnly
 inline fun <reified T : Throwable> assertFailsWith(message: String? = null, noinline block: () -> Unit): T =

--- a/libraries/kotlin.test/common/src/main/kotlin/kotlin/test/AssertionsH.kt
+++ b/libraries/kotlin.test/common/src/main/kotlin/kotlin/test/AssertionsH.kt
@@ -17,5 +17,8 @@ expect fun todo(block: () -> Unit)
  * Asserts that a [block] fails with a specific exception of type [exceptionClass] being thrown.
  *
  * If the assertion fails, the specified [message] is used unless it is null as a prefix for the failure message.
+ *
+ * @return An exception that was expected to be thrown and was successfully caught, so it is possible to check any
+ *         property of that exception.
  */
 expect fun <T : Throwable> assertFailsWith(exceptionClass: KClass<T>, message: String?, block: () -> Unit): T

--- a/libraries/kotlin.test/js/src/main/kotlin/kotlin/test/JsImpl.kt
+++ b/libraries/kotlin.test/js/src/main/kotlin/kotlin/test/JsImpl.kt
@@ -21,6 +21,9 @@ actual fun todo(block: () -> Unit) {
  * Asserts that a [block] fails with a specific exception of type [exceptionClass] being thrown.
  *
  * If the assertion fails, the specified [message] is used unless it is null as a prefix for the failure message.
+ *
+ * @return An exception that was expected to be thrown and was successfully caught, so it is possible to check any
+ *         property of that exception.
  */
 actual fun <T : Throwable> assertFailsWith(exceptionClass: KClass<T>, message: String?, block: () -> Unit): T {
     val exception = assertFails(message, block)

--- a/libraries/kotlin.test/jvm/src/main/kotlin/AssertionsImpl.kt
+++ b/libraries/kotlin.test/jvm/src/main/kotlin/AssertionsImpl.kt
@@ -36,6 +36,9 @@ private fun <T : Throwable> assertFailsWithImpl(exceptionClass: Class<T>, messag
  * Asserts that a [block] fails with a specific exception of type [exceptionClass] being thrown.
  *
  * If the assertion fails, the specified [message] is used unless it is null as a prefix for the failure message.
+ *
+ * @return An exception that was expected to be thrown and was successfully caught, so it is possible to check any
+ *         property of that exception.
  */
 actual fun <T : Throwable> assertFailsWith(exceptionClass: KClass<T>, message: String?, block: () -> Unit): T =
     assertFailsWithImpl(exceptionClass.java, message, block)


### PR DESCRIPTION
A follow-up after https://youtrack.jetbrains.com/issue/KT-27418