### PR TITLE
KT-27584 False positive "Move lambda argument out of parentheses" when implementing interface by delegation

### DIFF
--- a/idea/idea-core/src/org/jetbrains/kotlin/idea/core/psiModificationUtils.kt
+++ b/idea/idea-core/src/org/jetbrains/kotlin/idea/core/psiModificationUtils.kt
@@ -123,6 +123,7 @@ fun KtCallExpression.getLastLambdaExpression(): KtLambdaExpression? {
 }
 
 fun KtCallExpression.canMoveLambdaOutsideParentheses(): Boolean {
+    if (getStrictParentOfType<KtDelegatedSuperTypeEntry>() != null) return false
     if (getLastLambdaExpression() == null) return false
 
     val callee = calleeExpression

--- a/idea/testData/inspectionsLocal/moveLambdaOutsideParentheses/delegation.kt
+++ b/idea/testData/inspectionsLocal/moveLambdaOutsideParentheses/delegation.kt
@@ -1,0 +1,4 @@
+// PROBLEM: none
+interface I
+class C1(s: String, f: (String) -> String) : I
+class C2 : I by C1("", <caret>{ "" })

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -3398,6 +3398,11 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
             runTest("idea/testData/inspectionsLocal/moveLambdaOutsideParentheses/ambigousOverload.kt");
         }
 
+        @TestMetadata("delegation.kt")
+        public void testDelegation() throws Exception {
+            runTest("idea/testData/inspectionsLocal/moveLambdaOutsideParentheses/delegation.kt");
+        }
+
         @TestMetadata("functionalValueCall.kt")
         public void testFunctionalValueCall() throws Exception {
             runTest("idea/testData/inspectionsLocal/moveLambdaOutsideParentheses/functionalValueCall.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-27584