### PR TITLE
KT-22704 - Allow expect annotations with actual typealias to Java to have default argument values both in expected and in actual 

### DIFF
--- a/compiler/testData/diagnostics/tests/multiplatform/defaultArguments/annotationsViaActualTypeAlias.kt
+++ b/compiler/testData/diagnostics/tests/multiplatform/defaultArguments/annotationsViaActualTypeAlias.kt
@@ -23,8 +23,7 @@ fun test() {}
 // FILE: jvm.kt
 
 actual typealias A1 = J1
-// TODO: support arguments coming from Java via typealias (KT-22704)
-actual typealias <!ACTUAL_ANNOTATION_CONFLICTING_DEFAULT_ARGUMENT_VALUE!>A2<!> = J2
+actual typealias A2 = J2
 actual typealias A3 = J3
 actual typealias A4 = J4
 actual typealias <!ACTUAL_ANNOTATION_CONFLICTING_DEFAULT_ARGUMENT_VALUE!>A5<!> = J5


### PR DESCRIPTION
This pull request allows removes the conflicting values error for Literals, but not arrays or annotations, because i didn't figure out how to extract the compile time value from a PsiCall. I could traverse the call arguments until they're a literal expression but I don't know if that's the right approach.