### PR TITLE
Restore `buildSequence` and `buildIterator` samples

### DIFF
--- a/libraries/stdlib/coroutines-experimental/src/kotlin/coroutines/experimental/SequenceBuilder.kt
+++ b/libraries/stdlib/coroutines-experimental/src/kotlin/coroutines/experimental/SequenceBuilder.kt
@@ -17,8 +17,8 @@ import kotlin.experimental.ExperimentalTypeInference
  *
  * @see kotlin.sequences.generateSequence
  *
- * @sample samples.collections.Sequences.Building.buildSequenceYieldAll
- * @sample samples.collections.Sequences.Building.buildFibonacciSequence
+ * @sample samples.collections.Sequences.Building.buildDeprecatedSequenceYieldAll
+ * @sample samples.collections.Sequences.Building.buildDeprecatedFibonacciSequence
  */
 @SinceKotlin("1.1")
 public fun <T> buildSequence(@BuilderInference builderAction: suspend SequenceBuilder<T>.() -> Unit): Sequence<T> = Sequence { buildIterator(builderAction) }
@@ -26,8 +26,8 @@ public fun <T> buildSequence(@BuilderInference builderAction: suspend SequenceBu
 /**
  * Builds an [Iterator] lazily yielding values one by one.
  *
- * @sample samples.collections.Sequences.Building.buildIterator
- * @sample samples.collections.Iterables.Building.iterable
+ * @sample samples.collections.Sequences.Building.buildDeprecatedIterator
+ * @sample samples.collections.Iterables.Building.iterableDeprecated
  */
 @SinceKotlin("1.1")
 public fun <T> buildIterator(@BuilderInference builderAction: suspend SequenceBuilder<T>.() -> Unit): Iterator<T> {
@@ -42,8 +42,8 @@ public fun <T> buildIterator(@BuilderInference builderAction: suspend SequenceBu
  * @see buildSequence
  * @see buildIterator
  *
- * @sample samples.collections.Sequences.Building.buildSequenceYieldAll
- * @sample samples.collections.Sequences.Building.buildFibonacciSequence
+ * @sample samples.collections.Sequences.Building.buildDeprecatedSequenceYieldAll
+ * @sample samples.collections.Sequences.Building.buildDeprecatedFibonacciSequence
  */
 @RestrictsSuspension
 @SinceKotlin("1.1")
@@ -51,8 +51,8 @@ public abstract class SequenceBuilder<in T> internal constructor() {
     /**
      * Yields a value to the [Iterator] being built.
      *
-     * @sample samples.collections.Sequences.Building.buildSequenceYieldAll
-     * @sample samples.collections.Sequences.Building.buildFibonacciSequence
+     * @sample samples.collections.Sequences.Building.buildDeprecatedSequenceYieldAll
+     * @sample samples.collections.Sequences.Building.buildDeprecatedFibonacciSequence
      */
     public abstract suspend fun yield(value: T)
 
@@ -61,14 +61,14 @@ public abstract class SequenceBuilder<in T> internal constructor() {
      *
      * The sequence of values returned by the given iterator can be potentially infinite.
      *
-     * @sample samples.collections.Sequences.Building.buildSequenceYieldAll
+     * @sample samples.collections.Sequences.Building.buildDeprecatedSequenceYieldAll
      */
     public abstract suspend fun yieldAll(iterator: Iterator<T>)
 
     /**
      * Yields a collections of values to the [Iterator] being built.
      *
-     * @sample samples.collections.Sequences.Building.buildSequenceYieldAll
+     * @sample samples.collections.Sequences.Building.buildDeprecatedSequenceYieldAll
      */
     public suspend fun yieldAll(elements: Iterable<T>) {
         if (elements is Collection && elements.isEmpty()) return
@@ -80,7 +80,7 @@ public abstract class SequenceBuilder<in T> internal constructor() {
      *
      * The sequence can be potentially infinite.
      *
-     * @sample samples.collections.Sequences.Building.buildSequenceYieldAll
+     * @sample samples.collections.Sequences.Building.buildDeprecatedSequenceYieldAll
      */
     public suspend fun yieldAll(sequence: Sequence<T>) = yieldAll(sequence.iterator())
 }

--- a/libraries/stdlib/samples/test/samples/collections/iterables.kt
+++ b/libraries/stdlib/samples/test/samples/collections/iterables.kt
@@ -41,6 +41,24 @@ class Iterables {
             }
         }
 
+        @Sample
+        fun iterableDeprecated() {
+            val iterable = Iterable {
+                buildIterator {
+                    yield(42)
+                    yieldAll(1..5 step 2)
+                }
+            }
+            val result = iterable.mapIndexed { index, value -> "$index: $value" }
+            assertPrints(result, "[0: 42, 1: 1, 2: 3, 3: 5]")
+
+            // can be iterated many times
+            repeat(2) {
+                val sum = iterable.sum()
+                assertPrints(sum, "51")
+            }
+        }
+
     }
 
     class Operations {

--- a/libraries/stdlib/samples/test/samples/collections/sequences.kt
+++ b/libraries/stdlib/samples/test/samples/collections/sequences.kt
@@ -140,12 +140,58 @@ class Sequences {
         }
 
         @Sample
+        fun buildDeprecatedFibonacciSequence() {
+            fun fibonacci() = buildSequence {
+                var terms = Pair(0, 1)
+
+                // this sequence is infinite
+                while (true) {
+                    yield(terms.first)
+                    terms = Pair(terms.second, terms.first + terms.second)
+                }
+            }
+
+            assertPrints(fibonacci().take(10).toList(), "[0, 1, 1, 2, 3, 5, 8, 13, 21, 34]")
+        }
+
+        @Sample
+        fun buildDeprecatedSequenceYieldAll() {
+            val sequence = buildSequence {
+                val start = 0
+                // yielding a single value
+                yield(start)
+                // yielding an iterable
+                yieldAll(1..5 step 2)
+                // yielding an infinite sequence
+                yieldAll(generateSequence(8) { it * 3 })
+            }
+
+            assertPrints(sequence.take(7).toList(), "[0, 1, 3, 5, 8, 24, 72]")
+        }
+
+        @Sample
         fun buildIterator() {
             val collection = listOf(1, 2, 3)
             val wrappedCollection = object : AbstractCollection<Any>() {
                 override val size: Int = collection.size + 2
 
                 override fun iterator(): Iterator<Any> = iterator {
+                    yield("first")
+                    yieldAll(collection)
+                    yield("last")
+                }
+            }
+
+            assertPrints(wrappedCollection, "[first, 1, 2, 3, last]")
+        }
+
+        @Sample
+        fun buildDeprecatedIterator() {
+            val collection = listOf(1, 2, 3)
+            val wrappedCollection = object : AbstractCollection<Any>() {
+                override val size: Int = collection.size + 2
+
+                override fun iterator(): Iterator<Any> = buildIterator {
                     yield("first")
                     yieldAll(collection)
                     yield("last")


### PR DESCRIPTION
It seems that `buildSequence` and `buildIterator` samples were accidentally
replaced by `sequence` and `iterator` ones.
All samples in [SequenceBuilder docs](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.coroutines.experimental/-sequence-builder/index.html) are irrelevant to experimental builders

In this pull-request I duplicate the [SequenceScope docs](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.sequences/-sequence-scope/index.html) samples, replace 1.3 builders with 1.2 experimental ones and update paths to samples in experimental package