### PR TITLE
Mark Result and runCatching as available since 1.3

### DIFF
--- a/libraries/stdlib/coroutines/src/kotlin/Result.kt
+++ b/libraries/stdlib/coroutines/src/kotlin/Result.kt
@@ -109,6 +109,7 @@ public inline class Result<out T> @PublishedApi internal constructor(
  * make sure that this class is not exposed in ABI.
  */
 @PublishedApi
+@SinceKotlin("1.3")
 internal fun createFailure(exception: Throwable): Any =
     Result.Failure(exception)
 
@@ -127,6 +128,7 @@ internal fun Result<*>.throwOnFailure() {
  * catching and encapsulating any thrown exception as a failure.
  */
 @InlineOnly
+@SinceKotlin("1.3")
 public inline fun <R> runCatching(block: () -> R): Result<R> {
     return try {
         Result.success(block())
@@ -140,6 +142,7 @@ public inline fun <R> runCatching(block: () -> R): Result<R> {
  * if invocation was successful, catching and encapsulating any thrown exception as a failure.
  */
 @InlineOnly
+@SinceKotlin("1.3")
 public inline fun <T, R> T.runCatching(block: T.() -> R): Result<R> {
     return try {
         Result.success(block())

--- a/libraries/stdlib/coroutines/src/kotlin/Result.kt
+++ b/libraries/stdlib/coroutines/src/kotlin/Result.kt
@@ -119,6 +119,7 @@ internal fun createFailure(exception: Throwable): Any =
  * add some exception-augmenting logic here (if needed).
  */
 @PublishedApi
+@SinceKotlin("1.3")
 internal fun Result<*>.throwOnFailure() {
     if (value is Result.Failure) throw value.exception
 }
@@ -160,6 +161,7 @@ public inline fun <T, R> T.runCatching(block: T.() -> R): Result<R> {
  * This function is shorthand for `getOrElse { throw it }` (see [getOrElse]).
  */
 @InlineOnly
+@SinceKotlin("1.3")
 public inline fun <T> Result<T>.getOrThrow(): T {
     throwOnFailure()
     return value as T
@@ -174,6 +176,7 @@ public inline fun <T> Result<T>.getOrThrow(): T {
  * This function is shorthand for `fold(onSuccess = { it }, onFailure = onFailure)` (see [fold]).
  */
 @InlineOnly
+@SinceKotlin("1.3")
 public inline fun <R, T : R> Result<T>.getOrElse(onFailure: (exception: Throwable) -> R): R {
     contract {
         callsInPlace(onFailure, InvocationKind.AT_MOST_ONCE)
@@ -191,6 +194,7 @@ public inline fun <R, T : R> Result<T>.getOrElse(onFailure: (exception: Throwabl
  * This function is shorthand for `getOrElse { defaultValue }` (see [getOrElse]).
  */
 @InlineOnly
+@SinceKotlin("1.3")
 public inline fun <R, T : R> Result<T>.getOrDefault(defaultValue: R): R {
     if (isFailure) return defaultValue
     return value as T
@@ -203,6 +207,7 @@ public inline fun <R, T : R> Result<T>.getOrDefault(defaultValue: R): R {
  * Note, that an exception thrown by [onSuccess] or by [onFailure] function is rethrown by this function.
  */
 @InlineOnly
+@SinceKotlin("1.3")
 public inline fun <R, T> Result<T>.fold(
     onSuccess: (value: T) -> R,
     onFailure: (exception: Throwable) -> R
@@ -228,6 +233,7 @@ public inline fun <R, T> Result<T>.fold(
  * See [mapCatching] for an alternative that encapsulates exceptions.
  */
 @InlineOnly
+@SinceKotlin("1.3")
 public inline fun <R, T> Result<T>.map(transform: (value: T) -> R): Result<R> {
     contract {
         callsInPlace(transform, InvocationKind.AT_MOST_ONCE)
@@ -247,6 +253,7 @@ public inline fun <R, T> Result<T>.map(transform: (value: T) -> R): Result<R> {
  * See [map] for an alternative that rethrows exceptions.
  */
 @InlineOnly
+@SinceKotlin("1.3")
 public inline fun <R, T> Result<T>.mapCatching(transform: (value: T) -> R): Result<R> {
     return when {
         isSuccess -> runCatching { transform(value as T) }
@@ -263,6 +270,7 @@ public inline fun <R, T> Result<T>.mapCatching(transform: (value: T) -> R): Resu
  * See [recoverCatching] for an alternative that encapsulates exceptions.
  */
 @InlineOnly
+@SinceKotlin("1.3")
 public inline fun <R, T: R> Result<T>.recover(transform: (exception: Throwable) -> R): Result<R> {
     contract {
         callsInPlace(transform, InvocationKind.AT_MOST_ONCE)
@@ -282,6 +290,7 @@ public inline fun <R, T: R> Result<T>.recover(transform: (exception: Throwable) 
  * See [recover] for an alternative that rethrows exceptions.
  */
 @InlineOnly
+@SinceKotlin("1.3")
 public inline fun <R, T: R> Result<T>.recoverCatching(transform: (exception: Throwable) -> R): Result<R> {
     val value = value // workaround for inline classes BE bug
     return when(val exception = exceptionOrNull()) {
@@ -297,6 +306,7 @@ public inline fun <R, T: R> Result<T>.recoverCatching(transform: (exception: Thr
  * Returns the original `Result` unchanged.
  */
 @InlineOnly
+@SinceKotlin("1.3")
 public inline fun <T> Result<T>.onFailure(action: (exception: Throwable) -> Unit): Result<T> {
     contract {
         callsInPlace(action, InvocationKind.AT_MOST_ONCE)
@@ -310,6 +320,7 @@ public inline fun <T> Result<T>.onFailure(action: (exception: Throwable) -> Unit
  * Returns the original `Result` unchanged.
  */
 @InlineOnly
+@SinceKotlin("1.3")
 public inline fun <T> Result<T>.onSuccess(action: (value: T) -> Unit): Result<T> {
     contract {
         callsInPlace(action, InvocationKind.AT_MOST_ONCE)

--- a/libraries/stdlib/coroutines/src/kotlin/Result.kt
+++ b/libraries/stdlib/coroutines/src/kotlin/Result.kt
@@ -16,6 +16,7 @@ import kotlin.jvm.JvmField
  * or a failure with an arbitrary [Throwable] exception.
  */
 @Suppress("NON_PUBLIC_PRIMARY_CONSTRUCTOR_OF_INLINE_CLASS")
+@SinceKotlin("1.3")
 public inline class Result<out T> @PublishedApi internal constructor(
     @PublishedApi
     internal val value: Any?


### PR DESCRIPTION
## Context
Coroutines will be added to the stdlib of Kotlin 1.3.

`Result` and `runCatching` are two examples which come with it.
Currently they are marked as available since Kotlin 1.0 in the API documentation.

This PR attempts to change this for the Result class and the other functions defined in the `Result.kt` file.

## Considerations
This is my first contribution to kotlin and I have not used the `@SinceKotlin` annotation before.
I'm unsure whether it is sufficient to place it on top of the class or if I need to also place it on top of `PublishedApi` internal functions as well.
