### PR TITLE
KT-5071 Properly surround a function invocation in string template by curly braces

### DIFF
--- a/compiler/psi/src/org/jetbrains/kotlin/psi/KtPsiFactory.kt
+++ b/compiler/psi/src/org/jetbrains/kotlin/psi/KtPsiFactory.kt
@@ -404,6 +404,11 @@ class KtPsiFactory @JvmOverloads constructor(private val project: Project, val m
         return stringTemplateExpression.entries[0] as KtSimpleNameStringTemplateEntry
     }
 
+    fun createLiteralStringTemplateEntry(literal: String): KtLiteralStringTemplateEntry {
+        val stringTemplateExpression = createExpression("\"$literal\"") as KtStringTemplateExpression
+        return stringTemplateExpression.entries[0] as KtLiteralStringTemplateEntry
+    }
+
     fun createStringTemplate(content: String) = createExpression("\"$content\"") as KtStringTemplateExpression
 
     fun createPackageDirective(fqName: FqName): KtPackageDirective {

--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/ChangeToFunctionInvocationFix.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/ChangeToFunctionInvocationFix.kt
@@ -28,11 +28,21 @@ class ChangeToFunctionInvocationFix(element: KtExpression) : KotlinQuickFixActio
 
     public override fun invoke(project: Project, editor: Editor?, file: KtFile) {
         val element = element ?: return
-        val nextLiteralString = element.parent.nextSibling as? KtLiteralStringTemplateEntry
-        val parentheses = nextLiteralString?.text
-            ?.takeIf { it.startsWith("(") && it.endsWith(")") }?.also { nextLiteralString.delete() }
-            ?: "()"
-        element.replace(KtPsiFactory(file).createExpressionByPattern("$0$1", element, parentheses))
+        val psiFactory = KtPsiFactory(element)
+        val nextLiteralStringEntry = element.parent.nextSibling as? KtLiteralStringTemplateEntry
+        val nextText = nextLiteralStringEntry?.text
+        if (nextText != null && nextText.startsWith("(") && nextText.contains(")")) {
+            val parentheses = nextText.takeWhile { it != ')' } + ")"
+            val newNextText = nextText.removePrefix(parentheses)
+            if (newNextText.isNotEmpty()) {
+                nextLiteralStringEntry.replace(psiFactory.createLiteralStringTemplateEntry(newNextText))
+            } else {
+                nextLiteralStringEntry.delete()
+            }
+            element.replace(KtPsiFactory(file).createExpressionByPattern("$0$1", element, parentheses))
+        } else {
+            element.replace(KtPsiFactory(file).createExpressionByPattern("$0()", element))
+        }
     }
 
     companion object : KotlinSingleIntentionActionFactory() {

--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/ChangeToFunctionInvocationFix.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/ChangeToFunctionInvocationFix.kt
@@ -19,10 +19,7 @@ package org.jetbrains.kotlin.idea.quickfix
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import org.jetbrains.kotlin.diagnostics.Diagnostic
-import org.jetbrains.kotlin.psi.KtExpression
-import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.kotlin.psi.KtPsiFactory
-import org.jetbrains.kotlin.psi.createExpressionByPattern
+import org.jetbrains.kotlin.psi.*
 
 class ChangeToFunctionInvocationFix(element: KtExpression) : KotlinQuickFixAction<KtExpression>(element) {
     override fun getFamilyName() = "Change to function invocation"
@@ -31,7 +28,11 @@ class ChangeToFunctionInvocationFix(element: KtExpression) : KotlinQuickFixActio
 
     public override fun invoke(project: Project, editor: Editor?, file: KtFile) {
         val element = element ?: return
-        element.replace(KtPsiFactory(file).createExpressionByPattern("$0()", element))
+        val nextLiteralString = element.parent.nextSibling as? KtLiteralStringTemplateEntry
+        val parentheses = nextLiteralString?.text
+            ?.takeIf { it.startsWith("(") && it.endsWith(")") }?.also { nextLiteralString.delete() }
+            ?: "()"
+        element.replace(KtPsiFactory(file).createExpressionByPattern("$0$1", element, parentheses))
     }
 
     companion object : KotlinSingleIntentionActionFactory() {

--- a/idea/testData/quickfix/variables/changeToFunctionInvocation/inStringTemplate.kt
+++ b/idea/testData/quickfix/variables/changeToFunctionInvocation/inStringTemplate.kt
@@ -1,0 +1,6 @@
+// "Change to function invocation" "true"
+fun foo() {}
+
+fun test(){
+    "$foo<caret>"
+}

--- a/idea/testData/quickfix/variables/changeToFunctionInvocation/inStringTemplate.kt.after
+++ b/idea/testData/quickfix/variables/changeToFunctionInvocation/inStringTemplate.kt.after
@@ -1,0 +1,6 @@
+// "Change to function invocation" "true"
+fun foo() {}
+
+fun test(){
+    "${foo()}"
+}

--- a/idea/testData/quickfix/variables/changeToFunctionInvocation/inStringTemplate2.kt
+++ b/idea/testData/quickfix/variables/changeToFunctionInvocation/inStringTemplate2.kt
@@ -1,0 +1,6 @@
+// "Change to function invocation" "true"
+fun foo() {}
+
+fun test(){
+    "$foo<caret>()"
+}

--- a/idea/testData/quickfix/variables/changeToFunctionInvocation/inStringTemplate2.kt.after
+++ b/idea/testData/quickfix/variables/changeToFunctionInvocation/inStringTemplate2.kt.after
@@ -1,0 +1,6 @@
+// "Change to function invocation" "true"
+fun foo() {}
+
+fun test(){
+    "${foo()}"
+}

--- a/idea/testData/quickfix/variables/changeToFunctionInvocation/inStringTemplate3.kt
+++ b/idea/testData/quickfix/variables/changeToFunctionInvocation/inStringTemplate3.kt
@@ -1,0 +1,6 @@
+// "Change to function invocation" "true"
+fun bar(i: Int, j: Int) {}
+
+fun test(){
+    "$bar<caret>(1, 2)"
+}

--- a/idea/testData/quickfix/variables/changeToFunctionInvocation/inStringTemplate3.kt.after
+++ b/idea/testData/quickfix/variables/changeToFunctionInvocation/inStringTemplate3.kt.after
@@ -1,0 +1,6 @@
+// "Change to function invocation" "true"
+fun bar(i: Int, j: Int) {}
+
+fun test(){
+    "${bar(1, 2)}"
+}

--- a/idea/testData/quickfix/variables/changeToFunctionInvocation/inStringTemplate4.kt
+++ b/idea/testData/quickfix/variables/changeToFunctionInvocation/inStringTemplate4.kt
@@ -1,0 +1,6 @@
+// "Change to function invocation" "true"
+fun foo() {}
+
+fun test(){
+    "$foo<caret>("
+}

--- a/idea/testData/quickfix/variables/changeToFunctionInvocation/inStringTemplate4.kt.after
+++ b/idea/testData/quickfix/variables/changeToFunctionInvocation/inStringTemplate4.kt.after
@@ -1,0 +1,6 @@
+// "Change to function invocation" "true"
+fun foo() {}
+
+fun test(){
+    "${foo()}("
+}

--- a/idea/testData/quickfix/variables/changeToFunctionInvocation/inStringTemplate5.kt
+++ b/idea/testData/quickfix/variables/changeToFunctionInvocation/inStringTemplate5.kt
@@ -1,0 +1,6 @@
+// "Change to function invocation" "true"
+fun bar(i: Int, j: Int) {}
+
+fun test(s: String){
+    "$bar<caret>(1, 2) sometext $s"
+}

--- a/idea/testData/quickfix/variables/changeToFunctionInvocation/inStringTemplate5.kt.after
+++ b/idea/testData/quickfix/variables/changeToFunctionInvocation/inStringTemplate5.kt.after
@@ -1,0 +1,6 @@
+// "Change to function invocation" "true"
+fun bar(i: Int, j: Int) {}
+
+fun test(s: String){
+    "${bar(1, 2)} sometext $s"
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -12730,6 +12730,26 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
             public void testFunInvWithoutParentheses() throws Exception {
                 runTest("idea/testData/quickfix/variables/changeToFunctionInvocation/funInvWithoutParentheses.kt");
             }
+
+            @TestMetadata("inStringTemplate.kt")
+            public void testInStringTemplate() throws Exception {
+                runTest("idea/testData/quickfix/variables/changeToFunctionInvocation/inStringTemplate.kt");
+            }
+
+            @TestMetadata("inStringTemplate2.kt")
+            public void testInStringTemplate2() throws Exception {
+                runTest("idea/testData/quickfix/variables/changeToFunctionInvocation/inStringTemplate2.kt");
+            }
+
+            @TestMetadata("inStringTemplate3.kt")
+            public void testInStringTemplate3() throws Exception {
+                runTest("idea/testData/quickfix/variables/changeToFunctionInvocation/inStringTemplate3.kt");
+            }
+
+            @TestMetadata("inStringTemplate4.kt")
+            public void testInStringTemplate4() throws Exception {
+                runTest("idea/testData/quickfix/variables/changeToFunctionInvocation/inStringTemplate4.kt");
+            }
         }
 
         @TestMetadata("idea/testData/quickfix/variables/changeToPropertyAccess")

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -12750,6 +12750,11 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
             public void testInStringTemplate4() throws Exception {
                 runTest("idea/testData/quickfix/variables/changeToFunctionInvocation/inStringTemplate4.kt");
             }
+
+            @TestMetadata("inStringTemplate5.kt")
+            public void testInStringTemplate5() throws Exception {
+                runTest("idea/testData/quickfix/variables/changeToFunctionInvocation/inStringTemplate5.kt");
+            }
         }
 
         @TestMetadata("idea/testData/quickfix/variables/changeToPropertyAccess")


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-5071