### PR TITLE
Resolve DIR properly in compiler CLI BASH scripts when they are symlinked

### DIFF
--- a/compiler/cli/bin/kotlin
+++ b/compiler/cli/bin/kotlin
@@ -16,7 +16,8 @@
 
 export KOTLIN_RUNNER=1
 
-DIR="${BASH_SOURCE[0]%/*}"
+REAL_SOURCE="$( readlink -f "${BASH_SOURCE[0]}" )"
+DIR="${REAL_SOURCE%/*}"
 : ${DIR:="."}
 
 "${DIR}"/kotlinc "$@"

--- a/compiler/cli/bin/kotlin-dce-js
+++ b/compiler/cli/bin/kotlin-dce-js
@@ -16,7 +16,8 @@
 
 export KOTLIN_COMPILER=org.jetbrains.kotlin.cli.js.dce.K2JSDce
 
-DIR="${BASH_SOURCE[0]%/*}"
+REAL_SOURCE="$( readlink -f "${BASH_SOURCE[0]}" )"
+DIR="${REAL_SOURCE%/*}"
 : ${DIR:="."}
 
 "${DIR}"/kotlinc "$@"

--- a/compiler/cli/bin/kotlinc-js
+++ b/compiler/cli/bin/kotlinc-js
@@ -16,7 +16,8 @@
 
 export KOTLIN_COMPILER=org.jetbrains.kotlin.cli.js.K2JSCompiler
 
-DIR="${BASH_SOURCE[0]%/*}"
+REAL_SOURCE="$( readlink -f "${BASH_SOURCE[0]}" )"
+DIR="${REAL_SOURCE%/*}"
 : ${DIR:="."}
 
 "${DIR}"/kotlinc "$@"

--- a/compiler/cli/bin/kotlinc-jvm
+++ b/compiler/cli/bin/kotlinc-jvm
@@ -14,7 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DIR="${BASH_SOURCE[0]%/*}"
+REAL_SOURCE="$( readlink -f "${BASH_SOURCE[0]}" )"
+DIR="${REAL_SOURCE%/*}"
 : ${DIR:="."}
 
 "${DIR}"/kotlinc "$@"


### PR DESCRIPTION
In case I have symlinks such as
`/usr/local/bin/kotlinc-jvm → /opt/kotlin/1.2.71/bin/kotlinc-jvm`
and try to run Kotlin REPL issuing `$ kotlinc-jvm` I get error like this:
`/usr/local/bin/kotlinc: line 75: /usr/local/bin/kotlin-compiler: No such file or directory`

The reason is that shell variable DIR is not resolved properly in case of such symlinks in these scripts. This patch fixes that.