### PR TITLE
KT-27173 "Lift return out of `...`" should work on any of targeted `return` keywords

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/LiftReturnOrAssignmentInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/LiftReturnOrAssignmentInspection.kt
@@ -29,59 +29,59 @@ import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
 class LiftReturnOrAssignmentInspection : AbstractKotlinInspection() {
 
     override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean, session: LocalInspectionToolSession) =
-            object : KtVisitorVoid() {
-                private fun visitIfOrWhenOrTry(expression: KtExpression, keyword: PsiElement) {
-                    if (expression.lineCount() > LINES_LIMIT) return
-                    if (expression.isElseIf()) return
+        object : KtVisitorVoid() {
+            private fun visitIfOrWhenOrTry(expression: KtExpression, keyword: PsiElement) {
+                if (expression.lineCount() > LINES_LIMIT) return
+                if (expression.isElseIf()) return
 
-                    val foldableReturns = BranchedFoldingUtils.getFoldableReturns(expression)
-                    if (foldableReturns?.isNotEmpty() == true) {
-                        val hasOtherReturns = expression.anyDescendantOfType<KtReturnExpression> { it !in foldableReturns }
-                        val isSerious = !hasOtherReturns && foldableReturns.size > 1
-                        val verb = if (isSerious) "should" else "can"
-                        holder.registerProblemWithoutOfflineInformation(
-                                keyword,
-                                "Return $verb be lifted out of '${keyword.text}'",
-                                isOnTheFly,
-                                if (isSerious) ProblemHighlightType.GENERIC_ERROR_OR_WARNING
-                                else ProblemHighlightType.INFORMATION,
-                                LiftReturnOutFix(keyword.text)
-                        )
-                        return
-                    }
-                    val assignmentNumber = BranchedFoldingUtils.getFoldableAssignmentNumber(expression)
-                    if (assignmentNumber > 0) {
-                        val verb = if (assignmentNumber > 1) "should" else "can"
-                        holder.registerProblemWithoutOfflineInformation(
-                                keyword,
-                                "Assignment $verb be lifted out of '${keyword.text}'",
-                                isOnTheFly,
-                                if (assignmentNumber > 1) ProblemHighlightType.GENERIC_ERROR_OR_WARNING
-                                else ProblemHighlightType.INFORMATION,
-                                LiftAssignmentOutFix(keyword.text)
-                        )
-                    }
+                val foldableReturns = BranchedFoldingUtils.getFoldableReturns(expression)
+                if (foldableReturns?.isNotEmpty() == true) {
+                    val hasOtherReturns = expression.anyDescendantOfType<KtReturnExpression> { it !in foldableReturns }
+                    val isSerious = !hasOtherReturns && foldableReturns.size > 1
+                    val verb = if (isSerious) "should" else "can"
+                    holder.registerProblemWithoutOfflineInformation(
+                        keyword,
+                        "Return $verb be lifted out of '${keyword.text}'",
+                        isOnTheFly,
+                        if (isSerious) ProblemHighlightType.GENERIC_ERROR_OR_WARNING
+                        else ProblemHighlightType.INFORMATION,
+                        LiftReturnOutFix(keyword.text)
+                    )
+                    return
                 }
-
-                override fun visitIfExpression(expression: KtIfExpression) {
-                    super.visitIfExpression(expression)
-                    visitIfOrWhenOrTry(expression, expression.ifKeyword)
-                }
-
-                override fun visitWhenExpression(expression: KtWhenExpression) {
-                    super.visitWhenExpression(expression)
-                    visitIfOrWhenOrTry(expression, expression.whenKeyword)
-                }
-
-                override fun visitTryExpression(expression: KtTryExpression) {
-                    super.visitTryExpression(expression)
-                    expression.tryKeyword?.let {
-                        visitIfOrWhenOrTry(expression, it)
-                    }
+                val assignmentNumber = BranchedFoldingUtils.getFoldableAssignmentNumber(expression)
+                if (assignmentNumber > 0) {
+                    val verb = if (assignmentNumber > 1) "should" else "can"
+                    holder.registerProblemWithoutOfflineInformation(
+                        keyword,
+                        "Assignment $verb be lifted out of '${keyword.text}'",
+                        isOnTheFly,
+                        if (assignmentNumber > 1) ProblemHighlightType.GENERIC_ERROR_OR_WARNING
+                        else ProblemHighlightType.INFORMATION,
+                        LiftAssignmentOutFix(keyword.text)
+                    )
                 }
             }
 
-    private class LiftReturnOutFix (private val keyword: String) : LocalQuickFix {
+            override fun visitIfExpression(expression: KtIfExpression) {
+                super.visitIfExpression(expression)
+                visitIfOrWhenOrTry(expression, expression.ifKeyword)
+            }
+
+            override fun visitWhenExpression(expression: KtWhenExpression) {
+                super.visitWhenExpression(expression)
+                visitIfOrWhenOrTry(expression, expression.whenKeyword)
+            }
+
+            override fun visitTryExpression(expression: KtTryExpression) {
+                super.visitTryExpression(expression)
+                expression.tryKeyword?.let {
+                    visitIfOrWhenOrTry(expression, it)
+                }
+            }
+        }
+
+    private class LiftReturnOutFix(private val keyword: String) : LocalQuickFix {
         override fun getName() = "Lift return out of '$keyword'"
 
         override fun getFamilyName() = name
@@ -91,7 +91,7 @@ class LiftReturnOrAssignmentInspection : AbstractKotlinInspection() {
         }
     }
 
-    private class LiftAssignmentOutFix (private val keyword: String) : LocalQuickFix {
+    private class LiftAssignmentOutFix(private val keyword: String) : LocalQuickFix {
         override fun getName() = "Lift assignment out of '$keyword'"
 
         override fun getFamilyName() = name

--- a/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/BranchedFoldingUtils.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/BranchedFoldingUtils.kt
@@ -19,6 +19,7 @@ package org.jetbrains.kotlin.idea.intentions.branchedTransformations
 import org.jetbrains.kotlin.cfg.WhenChecker
 import org.jetbrains.kotlin.diagnostics.Errors
 import org.jetbrains.kotlin.idea.caches.resolve.analyze
+import org.jetbrains.kotlin.idea.core.replaced
 import org.jetbrains.kotlin.idea.intentions.branches
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.*
@@ -206,7 +207,7 @@ object BranchedFoldingUtils {
         expression.replace(psiFactory.createExpressionByPattern("$0 $1 $2", lhs!!, op!!, expression))
     }
 
-    fun foldToReturn(expression: KtExpression) {
+    fun foldToReturn(expression: KtExpression): KtExpression {
         fun KtReturnExpression.replaceWithReturned() {
             replace(returnedExpression!!)
         }
@@ -226,7 +227,7 @@ object BranchedFoldingUtils {
             }
         }
         lift(expression)
-        expression.replace(KtPsiFactory(expression).createExpressionByPattern("return $0", expression))
+        return expression.replaced(KtPsiFactory(expression).createExpressionByPattern("return $0", expression))
     }
 
     private fun KtTryExpression.tryBlockAndCatchBodies(): List<KtExpression?> = listOf(tryBlock) + catchClauses.map { it.catchBody }

--- a/idea/testData/inspectionsLocal/liftOut/ifToReturn/onReturn.kt
+++ b/idea/testData/inspectionsLocal/liftOut/ifToReturn/onReturn.kt
@@ -1,0 +1,7 @@
+// HIGHLIGHT: INFORMATION
+fun test(n: Int): String {
+    if (n == 1)
+        <caret>return "one"
+    else
+        return "two"
+}

--- a/idea/testData/inspectionsLocal/liftOut/ifToReturn/onReturn.kt.after
+++ b/idea/testData/inspectionsLocal/liftOut/ifToReturn/onReturn.kt.after
@@ -1,0 +1,7 @@
+// HIGHLIGHT: INFORMATION
+fun test(n: Int): String {
+    <caret>return if (n == 1)
+        "one"
+    else
+        "two"
+}

--- a/idea/testData/inspectionsLocal/liftOut/ifToReturn/onReturn2.kt
+++ b/idea/testData/inspectionsLocal/liftOut/ifToReturn/onReturn2.kt
@@ -1,0 +1,7 @@
+// HIGHLIGHT: INFORMATION
+fun test(n: Int): String {
+    if (n == 1)
+        return "one"
+    else
+        <caret>return "two"
+}

--- a/idea/testData/inspectionsLocal/liftOut/ifToReturn/onReturn2.kt.after
+++ b/idea/testData/inspectionsLocal/liftOut/ifToReturn/onReturn2.kt.after
@@ -1,0 +1,7 @@
+// HIGHLIGHT: INFORMATION
+fun test(n: Int): String {
+    <caret>return if (n == 1)
+        "one"
+    else
+        "two"
+}

--- a/idea/testData/inspectionsLocal/liftOut/tryToReturn/onReturn.kt
+++ b/idea/testData/inspectionsLocal/liftOut/tryToReturn/onReturn.kt
@@ -1,0 +1,8 @@
+// HIGHLIGHT: INFORMATION
+fun test(): String {
+    try {
+        <caret>return "success"
+    } catch (e: Exception) {
+        throw e
+    }
+}

--- a/idea/testData/inspectionsLocal/liftOut/tryToReturn/onReturn.kt.after
+++ b/idea/testData/inspectionsLocal/liftOut/tryToReturn/onReturn.kt.after
@@ -1,0 +1,8 @@
+// HIGHLIGHT: INFORMATION
+fun test(): String {
+    <caret>return try {
+        "success"
+    } catch (e: Exception) {
+        throw e
+    }
+}

--- a/idea/testData/inspectionsLocal/liftOut/whenToReturn/onReturn.kt
+++ b/idea/testData/inspectionsLocal/liftOut/whenToReturn/onReturn.kt
@@ -1,0 +1,7 @@
+// HIGHLIGHT: INFORMATION
+fun test(n: Int): String {
+    when (n) {
+        1 -> <caret>return "one"
+        else -> return "two"
+    }
+}

--- a/idea/testData/inspectionsLocal/liftOut/whenToReturn/onReturn.kt.after
+++ b/idea/testData/inspectionsLocal/liftOut/whenToReturn/onReturn.kt.after
@@ -1,0 +1,7 @@
+// HIGHLIGHT: INFORMATION
+fun test(n: Int): String {
+    <caret>return when (n) {
+        1 -> "one"
+        else -> "two"
+    }
+}

--- a/idea/testData/inspectionsLocal/liftOut/whenToReturn/onReturn2.kt
+++ b/idea/testData/inspectionsLocal/liftOut/whenToReturn/onReturn2.kt
@@ -1,0 +1,7 @@
+// HIGHLIGHT: INFORMATION
+fun test(n: Int): String {
+    when (n) {
+        1 -> return "one"
+        else -> <caret>return "two"
+    }
+}

--- a/idea/testData/inspectionsLocal/liftOut/whenToReturn/onReturn2.kt.after
+++ b/idea/testData/inspectionsLocal/liftOut/whenToReturn/onReturn2.kt.after
@@ -1,0 +1,7 @@
+// HIGHLIGHT: INFORMATION
+fun test(n: Int): String {
+    <caret>return when (n) {
+        1 -> "one"
+        else -> "two"
+    }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -2865,6 +2865,16 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
                 runTest("idea/testData/inspectionsLocal/liftOut/ifToReturn/innerIfTransformed.kt");
             }
 
+            @TestMetadata("onReturn.kt")
+            public void testOnReturn() throws Exception {
+                runTest("idea/testData/inspectionsLocal/liftOut/ifToReturn/onReturn.kt");
+            }
+
+            @TestMetadata("onReturn2.kt")
+            public void testOnReturn2() throws Exception {
+                runTest("idea/testData/inspectionsLocal/liftOut/ifToReturn/onReturn2.kt");
+            }
+
             @TestMetadata("simpleIf.kt")
             public void testSimpleIf() throws Exception {
                 runTest("idea/testData/inspectionsLocal/liftOut/ifToReturn/simpleIf.kt");
@@ -2996,6 +3006,11 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
                 runTest("idea/testData/inspectionsLocal/liftOut/tryToReturn/inner.kt");
             }
 
+            @TestMetadata("onReturn.kt")
+            public void testOnReturn() throws Exception {
+                runTest("idea/testData/inspectionsLocal/liftOut/tryToReturn/onReturn.kt");
+            }
+
             @TestMetadata("withoutReturn.kt")
             public void testWithoutReturn() throws Exception {
                 runTest("idea/testData/inspectionsLocal/liftOut/tryToReturn/withoutReturn.kt");
@@ -3110,6 +3125,16 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
             @TestMetadata("localReturns.kt")
             public void testLocalReturns() throws Exception {
                 runTest("idea/testData/inspectionsLocal/liftOut/whenToReturn/localReturns.kt");
+            }
+
+            @TestMetadata("onReturn.kt")
+            public void testOnReturn() throws Exception {
+                runTest("idea/testData/inspectionsLocal/liftOut/whenToReturn/onReturn.kt");
+            }
+
+            @TestMetadata("onReturn2.kt")
+            public void testOnReturn2() throws Exception {
+                runTest("idea/testData/inspectionsLocal/liftOut/whenToReturn/onReturn2.kt");
             }
 
             @TestMetadata("otherReturns.kt")


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-27173