### PR TITLE
Improve initialization performance of SynchronizedLazyImpl

### DIFF
--- a/libraries/stdlib/jvm/src/kotlin/util/LazyJVM.kt
+++ b/libraries/stdlib/jvm/src/kotlin/util/LazyJVM.kt
@@ -77,10 +77,12 @@ private class SynchronizedLazyImpl<out T>(initializer: () -> T, lock: Any? = nul
             if (compareAndSetState(0, -1)) {
                 val typedValue = initializer!!()
                 _value = typedValue
+                //Immediately release shared lock permanently
                 releaseShared(1)
                 initializer = null
                 return typedValue
             } else {
+                //Waiting threads will block here until shared lock is released
                 acquireSharedInterruptibly(1)
                 val _v2 = _value
                 @Suppress("UNCHECKED_CAST")


### PR DESCRIPTION
The current version of SynchronizedLazyImpl forces all waiting threads to block on a mutex, which can hamper performance when there are many waiting threads and if the initialization block is a time consuming operation. 

This change introduces an [AQS](https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/locks/AbstractQueuedSynchronizer.html) implementation which mimics a BooleanLatch (as described in the AQS javadoc), to allow all waiting reader threads to acquire a shared lock immediately after the value has been initialized, rather then forcing them to acquire a mutex. The value is guaranteed to be initialized by a single writer thread.

