### PR TITLE
Renamed ContractBuilder.callsInPlace 'lambda' parameter to 'funciton'

### DIFF
--- a/libraries/stdlib/src/kotlin/contracts/ContractBuilder.kt
+++ b/libraries/stdlib/src/kotlin/contracts/ContractBuilder.kt
@@ -81,8 +81,13 @@ public interface ContractBuilder {
     * @sample samples.contracts.callsInPlaceExactlyOnceContract
     * @sample samples.contracts.callsInPlaceUnknownContract
     */
-    @ContractsDsl public fun <R> callsInPlace(lambda: Function<R>, kind: InvocationKind = InvocationKind.UNKNOWN): CallsInPlace
+    @ContractsDsl public fun <R> callsInPlace(function: Function<R>, kind: InvocationKind = InvocationKind.UNKNOWN): CallsInPlace
 }
+
+@ContractsDsl
+@Deprecated("Parameter 'lambda' was renamed to 'function'", ReplaceWith("this.callsInPlace(function = lambda, kind = kind)"))
+public fun <R> ContractBuilder.callsInPlace(lambda: Function<R>, kind: InvocationKind = InvocationKind.UNKNOWN): CallsInPlace =
+    callsInPlace(function = lambda, kind = kind)
 
 /**
  * Specifies how many times a function invokes its function parameter in place.


### PR DESCRIPTION
Purpose: to make clear that it not must only be lambda, but can also be a function reference, anonymous function, or a property reference coerced to getter or setter. Trying to fix a popular misunderstanding that 'lambda' means 'technically an anonymous class'.
Binary compatibility: looks like contracts take place only in Metadata, but no real invocations generated.
Source compatibility: created a deprecated extension-function which should be visible when one writes `callsInPlace(lambda = ...`.
Usages: honestly, I don't know whether this function used inside Kotlin project with named parameters.