### PR TITLE
Add mininal test suite to idl2k, remove deprecated ANTLRFileStream

### DIFF
--- a/libraries/stdlib/js/src/org.w3c/org.w3c.dom.kt
+++ b/libraries/stdlib/js/src/org.w3c/org.w3c.dom.kt
@@ -805,6 +805,9 @@ public external abstract class MediaError {
     }
 }
 
+/**
+ * Exposes the JavaScript [AudioTrackList](https://developer.mozilla.org/en/docs/Web/API/AudioTrackList) to Kotlin
+ */
 public external abstract class AudioTrackList : EventTarget {
     open val length: Int
     open var onchange: ((Event) -> dynamic)?
@@ -814,6 +817,9 @@ public external abstract class AudioTrackList : EventTarget {
 }
 @kotlin.internal.InlineOnly inline operator fun AudioTrackList.get(index: Int): AudioTrack? = asDynamic()[index]
 
+/**
+ * Exposes the JavaScript [AudioTrack](https://developer.mozilla.org/en/docs/Web/API/AudioTrack) to Kotlin
+ */
 public external abstract class AudioTrack : UnionAudioTrackOrTextTrackOrVideoTrack {
     open val id: String
     open val kind: String
@@ -822,6 +828,9 @@ public external abstract class AudioTrack : UnionAudioTrackOrTextTrackOrVideoTra
     open var enabled: Boolean
 }
 
+/**
+ * Exposes the JavaScript [VideoTrackList](https://developer.mozilla.org/en/docs/Web/API/VideoTrackList) to Kotlin
+ */
 public external abstract class VideoTrackList : EventTarget {
     open val length: Int
     open val selectedIndex: Int
@@ -832,6 +841,9 @@ public external abstract class VideoTrackList : EventTarget {
 }
 @kotlin.internal.InlineOnly inline operator fun VideoTrackList.get(index: Int): VideoTrack? = asDynamic()[index]
 
+/**
+ * Exposes the JavaScript [VideoTrack](https://developer.mozilla.org/en/docs/Web/API/VideoTrack) to Kotlin
+ */
 public external abstract class VideoTrack : UnionAudioTrackOrTextTrackOrVideoTrack {
     open val id: String
     open val kind: String
@@ -872,6 +884,9 @@ public external abstract class TextTrackCueList {
 }
 @kotlin.internal.InlineOnly inline operator fun TextTrackCueList.get(index: Int): TextTrackCue? = asDynamic()[index]
 
+/**
+ * Exposes the JavaScript [TextTrackCue](https://developer.mozilla.org/en/docs/Web/API/TextTrackCue) to Kotlin
+ */
 public external abstract class TextTrackCue : EventTarget {
     open val track: TextTrack?
     open var id: String
@@ -891,6 +906,9 @@ public external abstract class TimeRanges {
     fun end(index: Int): Double
 }
 
+/**
+ * Exposes the JavaScript [TrackEvent](https://developer.mozilla.org/en/docs/Web/API/TrackEvent) to Kotlin
+ */
 public external open class TrackEvent(type: String, eventInitDict: TrackEventInit = definedExternally) : Event {
     open val track: UnionAudioTrackOrTextTrackOrVideoTrack?
 }
@@ -2726,6 +2744,9 @@ public external abstract class HTMLAppletElement : HTMLElement {
     open var width: String
 }
 
+/**
+ * Exposes the JavaScript [HTMLMarqueeElement](https://developer.mozilla.org/en/docs/Web/API/HTMLMarqueeElement) to Kotlin
+ */
 public external abstract class HTMLMarqueeElement : HTMLElement {
     open var behavior: String
     open var bgColor: String
@@ -2947,6 +2968,9 @@ public external open class MutationObserver(callback: (Array<MutationRecord>, Mu
     fun takeRecords(): Array<MutationRecord>
 }
 
+/**
+ * Exposes the JavaScript [MutationObserverInit](https://developer.mozilla.org/en/docs/Web/API/MutationObserverInit) to Kotlin
+ */
 public external interface MutationObserverInit {
     var childList: Boolean? /* = false */
         get() = definedExternally
@@ -3459,6 +3483,9 @@ public external open class DOMPoint : DOMPointReadOnly {
     override var w: Double
 }
 
+/**
+ * Exposes the JavaScript [DOMPointInit](https://developer.mozilla.org/en/docs/Web/API/DOMPointInit) to Kotlin
+ */
 public external interface DOMPointInit {
     var x: Double? /* = 0.0 */
         get() = definedExternally
@@ -3662,6 +3689,9 @@ public inline fun ScrollOptions(behavior: ScrollBehavior? = ScrollBehavior.AUTO)
     return o
 }
 
+/**
+ * Exposes the JavaScript [ScrollToOptions](https://developer.mozilla.org/en/docs/Web/API/ScrollToOptions) to Kotlin
+ */
 public external interface ScrollToOptions : ScrollOptions {
     var left: Double?
         get() = definedExternally

--- a/libraries/tools/idl2k/build.gradle
+++ b/libraries/tools/idl2k/build.gradle
@@ -20,6 +20,8 @@ dependencies {
     implementation "org.antlr:antlr4-runtime:$antlr4_version"
     implementation project(':kotlin-stdlib')
     implementation "org.jsoup:jsoup:1.8.2"
+
+    testImplementation "junit:junit:4.12"
 }
 
 sourceSets.main.kotlin.srcDirs += file("$buildDir/generated-src/antlr/main/")

--- a/libraries/tools/idl2k/src/main/kotlin/build.kt
+++ b/libraries/tools/idl2k/src/main/kotlin/build.kt
@@ -6,21 +6,6 @@ import java.io.IOException
 import java.net.URL
 import java.util.ArrayList
 import java.util.LinkedHashMap
-import kotlin.collections.HashSet
-import kotlin.collections.List
-import kotlin.collections.Map
-import kotlin.collections.MutableList
-import kotlin.collections.asSequence
-import kotlin.collections.contains
-import kotlin.collections.emptyMap
-import kotlin.collections.fold
-import kotlin.collections.forEach
-import kotlin.collections.map
-import kotlin.collections.mapValues
-import kotlin.collections.plus
-import kotlin.collections.reduce
-import kotlin.collections.set
-import kotlin.collections.sortedBy
 
 class BuildWebIdl(val mdnCacheFile: File, val srcDir: File) {
     val repositoryPre = loadPreliminaryRepository()

--- a/libraries/tools/idl2k/src/main/kotlin/build.kt
+++ b/libraries/tools/idl2k/src/main/kotlin/build.kt
@@ -4,11 +4,23 @@ import org.antlr.v4.runtime.CharStreams
 import java.io.File
 import java.io.IOException
 import java.net.URL
-import java.nio.charset.StandardCharsets
 import java.util.ArrayList
 import java.util.LinkedHashMap
 import kotlin.collections.HashSet
-
+import kotlin.collections.List
+import kotlin.collections.Map
+import kotlin.collections.MutableList
+import kotlin.collections.asSequence
+import kotlin.collections.contains
+import kotlin.collections.emptyMap
+import kotlin.collections.fold
+import kotlin.collections.forEach
+import kotlin.collections.map
+import kotlin.collections.mapValues
+import kotlin.collections.plus
+import kotlin.collections.reduce
+import kotlin.collections.set
+import kotlin.collections.sortedBy
 
 class BuildWebIdl(val mdnCacheFile: File, val srcDir: File) {
     val repositoryPre = loadPreliminaryRepository()
@@ -23,7 +35,7 @@ class BuildWebIdl(val mdnCacheFile: File, val srcDir: File) {
             .sortedBy { it.absolutePath }.fold(Repository(emptyMap(), emptyMap(), emptyMap(), emptyMap())) { acc, e ->
             System.err.flush()
             System.err.println("Parsing ${e.absolutePath}")
-            val fileRepository = parseIDL(CharStreams.fromFileName(e.absolutePath, StandardCharsets.UTF_8))
+            val fileRepository = parseIDL(CharStreams.fromFileName(e.absolutePath, Charsets.UTF_8))
 
             Repository(
                 interfaces = acc.interfaces.mergeReduce(fileRepository.interfaces, ::merge),

--- a/libraries/tools/idl2k/src/main/kotlin/build.kt
+++ b/libraries/tools/idl2k/src/main/kotlin/build.kt
@@ -1,12 +1,13 @@
 package org.jetbrains.idl2k
 
-import org.antlr.v4.runtime.ANTLRFileStream
-import kotlin.collections.HashSet
+import org.antlr.v4.runtime.CharStreams
 import java.io.File
 import java.io.IOException
 import java.net.URL
+import java.nio.charset.StandardCharsets
 import java.util.ArrayList
 import java.util.LinkedHashMap
+import kotlin.collections.HashSet
 
 
 class BuildWebIdl(val mdnCacheFile: File, val srcDir: File) {
@@ -18,16 +19,17 @@ class BuildWebIdl(val mdnCacheFile: File, val srcDir: File) {
             System.exit(1)
         }
 
-        return srcDir.walkTopDown().filter { it.isDirectory || it.extension == "idl" }.asSequence().filter { it.isFile }.toList().sortedBy { it.absolutePath }.fold(Repository(emptyMap(), emptyMap(), emptyMap(), emptyMap())) { acc, e ->
+        return srcDir.walkTopDown().filter { it.isDirectory || it.extension == "idl" }.asSequence().filter { it.isFile }.toList()
+            .sortedBy { it.absolutePath }.fold(Repository(emptyMap(), emptyMap(), emptyMap(), emptyMap())) { acc, e ->
             System.err.flush()
             System.err.println("Parsing ${e.absolutePath}")
-            val fileRepository = parseIDL(ANTLRFileStream(e.absolutePath, "UTF-8"))
+            val fileRepository = parseIDL(CharStreams.fromFileName(e.absolutePath, StandardCharsets.UTF_8))
 
             Repository(
-                    interfaces = acc.interfaces.mergeReduce(fileRepository.interfaces, ::merge),
-                    typeDefs = acc.typeDefs + fileRepository.typeDefs,
-                    externals = acc.externals.merge(fileRepository.externals),
-                    enums = acc.enums + fileRepository.enums
+                interfaces = acc.interfaces.mergeReduce(fileRepository.interfaces, ::merge),
+                typeDefs = acc.typeDefs + fileRepository.typeDefs,
+                externals = acc.externals.merge(fileRepository.externals),
+                enums = acc.enums + fileRepository.enums
             )
         }
     }
@@ -36,7 +38,8 @@ class BuildWebIdl(val mdnCacheFile: File, val srcDir: File) {
         println("Prepare...")
     }
 
-    val repository = repositoryPre.copy(typeDefs = repositoryPre.typeDefs.mapValues { it.value.copy(mapType(repositoryPre, it.value.types)) })
+    val repository =
+        repositoryPre.copy(typeDefs = repositoryPre.typeDefs.mapValues { it.value.copy(mapType(repositoryPre, it.value.types)) })
 
     val definitions = mapDefinitions(repository, repository.interfaces.values).map {
         if (it.name in relocations) {
@@ -91,9 +94,9 @@ class BuildWebIdl(val mdnCacheFile: File, val srcDir: File) {
 }
 
 
-internal fun <K, V> Map<K, List<V>>.reduceValues(reduce: (V, V) -> V = { a, b -> b }): Map<K, V> = mapValues { it.value.reduce(reduce) }
+internal fun <K, V> Map<K, List<V>>.reduceValues(reduce: (V, V) -> V = { _, b -> b }): Map<K, V> = mapValues { it.value.reduce(reduce) }
 
-internal fun <K, V> Map<K, V>.mergeReduce(other: Map<K, V>, reduce: (V, V) -> V = { a, b -> b }): Map<K, V> {
+internal fun <K, V> Map<K, V>.mergeReduce(other: Map<K, V>, reduce: (V, V) -> V = { _, b -> b }): Map<K, V> {
     val result = LinkedHashMap<K, V>(this.size + other.size)
     result.putAll(this)
     other.forEach { e ->
@@ -101,8 +104,7 @@ internal fun <K, V> Map<K, V>.mergeReduce(other: Map<K, V>, reduce: (V, V) -> V 
 
         if (existing == null) {
             result[e.key] = e.value
-        }
-        else {
+        } else {
             result[e.key] = reduce(e.value, existing)
         }
     }
@@ -119,8 +121,7 @@ internal fun <K, V> Map<K, List<V>>.merge(other: Map<K, List<V>>): Map<K, List<V
         val list = result[it.key]
         if (list == null) {
             result[it.key] = ArrayList(it.value)
-        }
-        else {
+        } else {
             list.addAll(it.value)
         }
     }

--- a/libraries/tools/idl2k/src/main/kotlin/idl.kt
+++ b/libraries/tools/idl2k/src/main/kotlin/idl.kt
@@ -21,10 +21,6 @@ import org.antlr.v4.runtime.CommonTokenStream
 import org.antlr.v4.runtime.ParserRuleContext
 import org.antlr.v4.runtime.tree.ParseTree
 import org.antlr.v4.runtime.tree.TerminalNode
-import org.antlr.webidl.WebIDLBaseVisitor
-import org.antlr.webidl.WebIDLLexer
-import org.antlr.webidl.WebIDLParser
-import org.antlr.webidl.WebIDLParser.*
 import java.util.*
 
 data class ExtendedAttribute(val name: String?, val call: String, val arguments: List<Attribute>)
@@ -589,7 +585,7 @@ fun parseIDL(reader: CharStream): Repository {
             declarations.filterIsInstance<InterfaceDefinition>().filter { it.name.isEmpty().not() }.groupBy { it.name }.mapValues { it.value.reduce(::merge) },
             declarations.filterIsInstance<TypedefDefinition>().groupBy { it.name }.mapValues { it.value.first() },
             declarations.filterIsInstance<ExtensionInterfaceDefinition>().groupBy { it.name }.mapValues { it.value.map { it.implements } },
-            declarations.filterIsInstance<EnumDefinition>().groupBy { it.name }.mapValues { it.value.reduce { a, b -> a } }
+            declarations.filterIsInstance<EnumDefinition>().groupBy { it.name }.mapValues { it.value.reduce { a, _ -> a } }
     )
 }
 

--- a/libraries/tools/idl2k/src/main/kotlin/idl.kt
+++ b/libraries/tools/idl2k/src/main/kotlin/idl.kt
@@ -21,6 +21,10 @@ import org.antlr.v4.runtime.CommonTokenStream
 import org.antlr.v4.runtime.ParserRuleContext
 import org.antlr.v4.runtime.tree.ParseTree
 import org.antlr.v4.runtime.tree.TerminalNode
+import org.antlr.webidl.WebIDLBaseVisitor
+import org.antlr.webidl.WebIDLLexer
+import org.antlr.webidl.WebIDLParser
+import org.antlr.webidl.WebIDLParser.*
 import java.util.*
 
 data class ExtendedAttribute(val name: String?, val call: String, val arguments: List<Attribute>)

--- a/libraries/tools/idl2k/src/test/kotlin/Idl2kTest.kt
+++ b/libraries/tools/idl2k/src/test/kotlin/Idl2kTest.kt
@@ -38,7 +38,7 @@ class Idl2kTests {
 
         assertEquals(
             File(testResourcePrefix).resolve(expectedOutputName).readText(),
-            convertIdlToWriter(File("$testResourcePrefix$fileName")).toString()
+            convertIdlToWriter(File(testResourcePrefix).resolve(fileName)).toString()
         )
     }
 

--- a/libraries/tools/idl2k/src/test/kotlin/Idl2kTest.kt
+++ b/libraries/tools/idl2k/src/test/kotlin/Idl2kTest.kt
@@ -33,26 +33,20 @@ class Idl2kTests {
         return stringWriter
     }
 
-    private fun assertIdlCompiledTo(fileName: String, output: String) {
+    private fun assertIdlCompiledTo(fileName: String, expectedOutputName: String) {
+        val testResourcePrefix = "src/test/resources/"
+
         assertEquals(
-            output.trimIndent(),
-            convertIdlToWriter(File(fileName)).toString()
+            File("$testResourcePrefix$expectedOutputName").bufferedReader().use { it.readText() },
+            convertIdlToWriter(File("$testResourcePrefix$fileName")).toString()
         )
     }
 
     @Test
     fun basicTest() {
         assertIdlCompiledTo(
-            "src/test/resources/SomethingNotInCache.idl", """public external open class SomethingNotInCache {
-    open val someReadOnlyParam: dynamic
-    var someWriteableParam: dynamic
-    fun someEmptyMethod(): String
-    fun someMethod(root: dynamic): String
-    fun optionalUsvStringFetcher(name: String): String?
-}
-
-
-"""
+            "SomethingNotInCache.idl",
+            "SomethingNotInCache.kt"
         )
     }
 }

--- a/libraries/tools/idl2k/src/test/kotlin/Idl2kTest.kt
+++ b/libraries/tools/idl2k/src/test/kotlin/Idl2kTest.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2010-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the license/LICENSE.txt file.
+ */
+
+
+import org.jetbrains.idl2k.BuildWebIdl
+import org.jetbrains.idl2k.render
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.io.File
+import java.io.StringWriter
+import java.io.Writer
+
+
+class Idl2kTests {
+
+
+    private fun convertIdlToWriter(file: File): Writer {
+        val nonExistentCache = File.createTempFile("mdnCache", System.nanoTime().toString())
+        val buildWebIdl = BuildWebIdl(nonExistentCache, file)
+
+        val stringWriter = StringWriter()
+        stringWriter.render(
+            "",
+            buildWebIdl.definitions,
+            buildWebIdl.unions,
+            buildWebIdl.repository.enums.values.toList(),
+            buildWebIdl.mdnCache
+        )
+
+        nonExistentCache.delete()
+        return stringWriter
+    }
+
+    private fun assertIdlCompiledTo(fileName: String, output: String) {
+        assertEquals(
+            output.trimIndent(),
+            convertIdlToWriter(File(fileName)).toString()
+        )
+    }
+
+    @Test
+    fun basicTest() {
+        assertIdlCompiledTo(
+            "src/test/resources/SomethingNotInCache.idl", """public external open class SomethingNotInCache {
+    open val someReadOnlyParam: dynamic
+    var someWriteableParam: dynamic
+    fun someEmptyMethod(): String
+    fun someMethod(root: dynamic): String
+    fun optionalUsvStringFetcher(name: String): String?
+}
+
+
+"""
+        )
+    }
+}

--- a/libraries/tools/idl2k/src/test/kotlin/Idl2kTest.kt
+++ b/libraries/tools/idl2k/src/test/kotlin/Idl2kTest.kt
@@ -37,7 +37,7 @@ class Idl2kTests {
         val testResourcePrefix = "src/test/resources/"
 
         assertEquals(
-            File("$testResourcePrefix$expectedOutputName").bufferedReader().use { it.readText() },
+            File(testResourcePrefix).resolve(expectedOutputName).readText(),
             convertIdlToWriter(File("$testResourcePrefix$fileName")).toString()
         )
     }

--- a/libraries/tools/idl2k/src/test/resources/SomethingNotInCache.idl
+++ b/libraries/tools/idl2k/src/test/resources/SomethingNotInCache.idl
@@ -1,0 +1,8 @@
+[Constructor]
+interface SomethingNotInCache {
+ DOMString someEmptyMethod ();
+ DOMString someMethod (SomethingUnknown root);
+ USVString? optionalUsvStringFetcher(USVString name);
+ readonly attribute WhateverUknownParam someReadOnlyParam;
+ attribute WhateverUknownParam someWriteableParam;
+};

--- a/libraries/tools/idl2k/src/test/resources/SomethingNotInCache.kt
+++ b/libraries/tools/idl2k/src/test/resources/SomethingNotInCache.kt
@@ -1,0 +1,8 @@
+public external open class SomethingNotInCache {
+    open val someReadOnlyParam: dynamic
+    var someWriteableParam: dynamic
+    fun someEmptyMethod(): String
+    fun someMethod(root: dynamic): String
+    fun optionalUsvStringFetcher(name: String): String?
+}
+


### PR DESCRIPTION
- There's only one test so far that covers the very basic functionality.
- For this particular PR the goal was not to change the code tested at all, that's the reason there's that two new lines in the generated code.
- parameter .. is never used warning fixed
- ANTLRFileStream is deprecated and removed