### PR TITLE
Register KotlinModelBuilder for kotlin-android plugin

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/model/KotlinProjectIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/model/KotlinProjectIT.kt
@@ -142,25 +142,120 @@ class KotlinProjectIT : BaseGradleIT() {
             "DEFAULT"
         )
 
-        val expectedSourceSetNames = listOf("release", "debug", "releaseUnitTest", "debugUnitTest", "debugAndroidTest")
         assertTrue(kotlinProject.expectedByDependencies.isEmpty())
         assertEquals(5, kotlinProject.sourceSets.size)
 
-        fun verifySourceSet(sourceSet: SourceSet) {
-            // These are unused in Android projects so will be empty.
-            assertEquals(0, sourceSet.sourceDirectories.size)
-            assertEquals(0, sourceSet.resourcesDirectories.size)
-            assertEquals(project.projectDir.resolve("build/tmp/kotlin-classes/${sourceSet.name}"), sourceSet.classesOutputDirectory)
-            // This value is just a placeholder since this information is obtained from the Android Plugin models.
-            assertEquals(project.projectDir.resolve("build/tmp/kotlin-classes/${sourceSet.name}"), sourceSet.resourcesOutputDirectory)
-            assertNotEquals(0, sourceSet.compilerArguments.currentArguments.size)
-            assertNotEquals(0, sourceSet.compilerArguments.defaultArguments.size)
+        val sourceSets = kotlinProject.sourceSets.sortedBy { it.name }
+
+        fun SourceSet.verifySourceSet(
+            name: String, type: SourceSet.SourceSetType, friends: List<String>, sources: List<String>, resources: List<String>,
+            classesOutputDir: String, resourcesOutputDir: String
+        ) {
+            assertEquals(name, name)
+            assertEquals(type, this.type)
+
+            assertEquals(friends.size, friendSourceSets.size)
+            assertEquals(friends, friendSourceSets)
+
+            assertEquals(sources.size, sourceDirectories.size)
+            assertEquals(sources.map { project.projectDir.resolve(it) }, sourceDirectories)
+
+            assertEquals(resources.size, resourcesDirectories.size)
+            assertEquals(resources.map { project.projectDir.resolve(it) }, resourcesDirectories)
+
+            assertEquals(project.projectDir.resolve(classesOutputDir), classesOutputDirectory)
+            assertEquals(project.projectDir.resolve(resourcesOutputDir), resourcesOutputDirectory)
+
+            assertNotEquals(0, compilerArguments.currentArguments.size)
+            assertNotEquals(0, compilerArguments.defaultArguments.size)
         }
 
-        assertEquals(0, kotlinProject.sourceSets.filter {
-            verifySourceSet(it)
-            expectedSourceSetNames.contains(it.name)
-        }.size)
+        sourceSets[0].verifySourceSet(
+            "debug",
+            SourceSet.SourceSetType.PRODUCTION,
+            listOf(),
+            listOf(
+                "app/src/debug/kotlin",
+                "app/src/debug/java",
+                "app/src/main/kotlin",
+                "app/src/main/java"
+            ),
+            listOf(
+                "app/src/debug/resources",
+                "app/src/main/resources"
+            ),
+            "app/build/tmp/kotlin-classes/debug", "app/build/processedResources/debug"
+        )
+        sourceSets[1].verifySourceSet(
+            "debugAndroidTest",
+            SourceSet.SourceSetType.TEST,
+            listOf("debug"),
+            listOf(
+                "app/src/debugAndroidTest/kotlin",
+                "app/src/androidTest/kotlin",
+                "app/src/androidTest/java",
+                "app/src/androidTestDebug/kotlin",
+                "app/src/androidTestDebug/java"
+            ),
+            listOf(
+                "app/src/debugAndroidTest/resources",
+                "app/src/androidTest/resources",
+                "app/src/androidTestDebug/resources"
+            ),
+            "app/build/tmp/kotlin-classes/debugAndroidTest", "app/build/processedResources/debugAndroidTest"
+        )
+        sourceSets[2].verifySourceSet(
+            "debugUnitTest",
+            SourceSet.SourceSetType.TEST,
+            listOf("debug"),
+            listOf(
+                "app/src/debugUnitTest/kotlin",
+                "app/src/test/kotlin",
+                "app/src/test/java",
+                "app/src/testDebug/kotlin",
+                "app/src/testDebug/java"
+            ),
+            listOf(
+                "app/src/debugUnitTest/resources",
+                "app/src/test/resources",
+                "app/src/testDebug/resources"
+            ),
+            "app/build/tmp/kotlin-classes/debugUnitTest", "app/build/processedResources/debugUnitTest"
+        )
+        sourceSets[3].verifySourceSet(
+            "release",
+            SourceSet.SourceSetType.PRODUCTION,
+            listOf(),
+            listOf(
+                "app/src/release/kotlin",
+                "app/src/release/java",
+                "app/src/main/kotlin",
+                "app/src/main/java"
+            ),
+            listOf(
+                "app/src/release/resources",
+                "app/src/main/resources"
+            ),
+            "app/build/tmp/kotlin-classes/release", "app/build/processedResources/release"
+        )
+        sourceSets[4].verifySourceSet(
+            "releaseUnitTest",
+            SourceSet.SourceSetType.TEST,
+            listOf("release"),
+            listOf(
+                "app/src/releaseUnitTest/kotlin",
+                "app/src/test/kotlin",
+                "app/src/test/java",
+                "app/src/testRelease/kotlin",
+                "app/src/testRelease/java"
+            ),
+            listOf(
+                "app/src/releaseUnitTest/resources",
+                "app/src/test/resources",
+                "app/src/testRelease/resources"
+            ),
+            "app/build/tmp/kotlin-classes/releaseUnitTest", "app/build/processedResources/releaseUnitTest"
+        )
     }
 
     @Test

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/model/builder/KotlinModelBuilder.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/model/builder/KotlinModelBuilder.kt
@@ -26,7 +26,7 @@ import org.jetbrains.kotlin.gradle.tasks.AbstractKotlinCompile
 
 /**
  * [ToolingModelBuilder] for [KotlinProject] models.
- * This model builder is registered for base Kotlin JVM, Kotlin JS and Kotlin Common plugins.
+ * This model builder is registered for base Kotlin JVM (including Android), Kotlin JS and Kotlin Common plugins.
  */
 class KotlinModelBuilder(private val kotlinPluginVersion: String) : ToolingModelBuilder {
 
@@ -42,7 +42,9 @@ class KotlinModelBuilder(private val kotlinPluginVersion: String) : ToolingModel
                 project.name,
                 kotlinPluginVersion,
                 projectType,
-                kotlinCompileTasks.mapNotNull { it.createSourceSet(project, projectType) },
+                kotlinCompileTasks.mapNotNull {
+                    if (project.isAndroid()) it.createAndroidSourceSet() else it.createSourceSet(project, projectType)
+                },
                 getExpectedByDependencies(project),
                 kotlinCompileTasks.first()!!.createExperimentalFeatures()
             )
@@ -51,9 +53,14 @@ class KotlinModelBuilder(private val kotlinPluginVersion: String) : ToolingModel
     }
 
     companion object {
+        private fun Project.isAndroid(): Boolean {
+            return project.plugins.hasPlugin("kotlin-android")
+        }
 
         private fun getProjectType(project: Project): KotlinProject.ProjectType {
-            return if (project.plugins.hasPlugin("kotlin") || project.plugins.hasPlugin("kotlin-platform-jvm")) {
+            return if (project.plugins.hasPlugin("kotlin") || project.plugins.hasPlugin("kotlin-platform-jvm") ||
+                project.isAndroid()
+            ) {
                 KotlinProject.ProjectType.PLATFORM_JVM
             } else if (project.plugins.hasPlugin("kotlin2js") || project.plugins.hasPlugin("kotlin-platform-js")) {
                 KotlinProject.ProjectType.PLATFORM_JS
@@ -89,6 +96,24 @@ class KotlinModelBuilder(private val kotlinPluginVersion: String) : ToolingModel
                     createCompilerArguments()
                 )
             } else null
+        }
+
+        /**
+         * The [SourceSet] returned by this method is not intended to be complete, most of the information here is exposed by the
+         * Android Gradle plugin and as such is not populated here. The important information here that is required by
+         * Android Studio are the [CompilerArguments].
+         */
+        private fun AbstractKotlinCompile<*>.createAndroidSourceSet(): SourceSet {
+            return SourceSetImpl(
+                sourceSetName,
+                if (sourceSetName.contains("test", true)) SourceSet.SourceSetType.TEST else SourceSet.SourceSetType.PRODUCTION,
+                findFriendSourceSets(),
+                emptyList(), // Obtained from the Android model
+                emptyList(), // Obtained from the Android model
+                destinationDir,
+                destinationDir, // Obtained from the Android model
+                createCompilerArguments()
+            )
         }
 
         private fun AbstractKotlinCompile<*>.findFriendSourceSets(): Collection<String> {

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/model/builder/KotlinModelBuilder.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/model/builder/KotlinModelBuilder.kt
@@ -23,6 +23,7 @@ import org.jetbrains.kotlin.gradle.plugin.KOTLIN_JS_DSL_NAME
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 import org.jetbrains.kotlin.gradle.plugin.getConvention
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinAndroidTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.allKotlinSourceSets
 import org.jetbrains.kotlin.gradle.tasks.AbstractKotlinCompile
 
 /**
@@ -102,18 +103,16 @@ class KotlinModelBuilder(private val kotlinPluginVersion: String, private val an
         }
 
         /**
-         * The [SourceSet] returned by this method is not intended to be complete, most of the information here is exposed by the
-         * Android Gradle plugin and as such is not populated here. The important information here that is required by
-         * Android Studio are the [CompilerArguments].
+         * Constructs the Android [SourceSet] that should be returned to the IDE for each compile task/variant.
          */
         private fun AbstractKotlinCompile<*>.createAndroidSourceSet(androidTarget: KotlinAndroidTarget): SourceSet {
             val variantName = sourceSetName
             val compilation = androidTarget.compilations.getByName(variantName)
             // Merge all sources and resource dirs from the different Source Sets that make up this variant.
-            val sources = compilation.kotlinSourceSets.flatMap {
+            val sources = compilation.allKotlinSourceSets.flatMap {
                 it.kotlin.srcDirs
             }.distinctBy { it.absolutePath }
-            val resources = compilation.kotlinSourceSets.flatMap {
+            val resources = compilation.allKotlinSourceSets.flatMap {
                 it.resources.srcDirs
             }.distinctBy { it.absolutePath }
             return SourceSetImpl(

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt
@@ -352,7 +352,7 @@ internal abstract class AbstractKotlinPlugin(
 
         configureAttributes(target)
         configureProjectGlobalSettings(project, kotlinPluginVersion)
-        registry.register(KotlinModelBuilder(kotlinPluginVersion))
+        registry.register(KotlinModelBuilder(kotlinPluginVersion, null))
     }
 
     companion object {
@@ -571,7 +571,7 @@ internal open class KotlinAndroidPlugin(
             project, androidTarget, tasksProvider,
             kotlinPluginVersion
         )
-        registry.register(KotlinModelBuilder(kotlinPluginVersion))
+        registry.register(KotlinModelBuilder(kotlinPluginVersion, androidTarget))
     }
 
     companion object {

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt
@@ -559,7 +559,8 @@ internal open class Kotlin2JsPlugin(
 }
 
 internal open class KotlinAndroidPlugin(
-    private val kotlinPluginVersion: String
+    private val kotlinPluginVersion: String,
+    private val registry: ToolingModelBuilderRegistry
 ) : Plugin<Project> {
 
     override fun apply(project: Project) {
@@ -570,6 +571,7 @@ internal open class KotlinAndroidPlugin(
             project, androidTarget, tasksProvider,
             kotlinPluginVersion
         )
+        registry.register(KotlinModelBuilder(kotlinPluginVersion))
     }
 
     companion object {
@@ -733,7 +735,7 @@ abstract class AbstractAndroidProjectHandler<V>(private val kotlinConfigurationT
         kotlinTask.destinationDir = File(project.buildDir, "tmp/kotlin-classes/$variantDataName")
         kotlinTask.description = "Compiles the $variantDataName kotlin."
 
-        // Register the source only after the task is created, because tne task is required for that:
+        // Register the source only after the task is created, because the task is required for that:
         compilation.source(defaultSourceSet)
         configureSources(kotlinTask, variantData, compilation)
 

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPluginWrapper.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPluginWrapper.kt
@@ -116,7 +116,7 @@ open class KotlinAndroidPluginWrapper @Inject constructor(
     protected val registry: ToolingModelBuilderRegistry
 ) : KotlinBasePluginWrapper(fileResolver) {
     override fun getPlugin(project: Project, kotlinGradleBuildServices: KotlinGradleBuildServices): Plugin<Project> =
-        KotlinAndroidPlugin(kotlinPluginVersion)
+        KotlinAndroidPlugin(kotlinPluginVersion, registry)
 }
 
 open class Kotlin2JsPluginWrapper @Inject constructor(

--- a/libraries/tools/kotlin-gradle-plugin/src/test/kotlin/org/jetbrains/kotlin/gradle/model/builder/KotlinModelBuilderTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/test/kotlin/org/jetbrains/kotlin/gradle/model/builder/KotlinModelBuilderTest.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.gradle.model.builder
 
 import org.jetbrains.kotlin.gradle.model.KotlinProject
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinAndroidTarget
 import org.junit.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -13,7 +14,7 @@ import kotlin.test.assertTrue
 class KotlinModelBuilderTest {
     @Test
     fun testCanBuild() {
-        val modelBuilder = KotlinModelBuilder("version")
+        val modelBuilder = KotlinModelBuilder("version", null)
         assertTrue(modelBuilder.canBuild(KotlinProject::class.java.name))
         assertFalse(modelBuilder.canBuild("wrongModel"))
     }

--- a/libraries/tools/kotlin-gradle-plugin/src/test/kotlin/org/jetbrains/kotlin/gradle/model/builder/KotlinModelBuilderTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/test/kotlin/org/jetbrains/kotlin/gradle/model/builder/KotlinModelBuilderTest.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlin.gradle.model.builder
 
 import org.jetbrains.kotlin.gradle.model.KotlinProject
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinAndroidTarget
 import org.junit.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue


### PR DESCRIPTION
This change ensures that the KotlinModelBuilder is registered for the kotlin-android plugin. This is required since the Android IDEA plugin (and Android Studio) lacks the information needed to configure the Kotlin facet. Information we are unable to get from the Android specific models include, compiler arguments and co-routine support.

This change also ensures that the KotlinProject that is built for Android projects has its project type set to PLATFORM_JVM and that the above information is set correctly on the model. Note: for some fields that we obtain from the Android Gradle Plugin we leave empty or return placeholder values.