### PR TITLE
Make context available to suppressors

### DIFF
--- a/compiler/frontend/src/org/jetbrains/kotlin/resolve/diagnostics/KotlinSuppressCache.kt
+++ b/compiler/frontend/src/org/jetbrains/kotlin/resolve/diagnostics/KotlinSuppressCache.kt
@@ -35,6 +35,7 @@ import org.jetbrains.kotlin.util.ExtensionProvider
 
 interface DiagnosticSuppressor {
     fun isSuppressed(diagnostic: Diagnostic): Boolean
+    fun isSuppressed(diagnostic: Diagnostic, bindingContext: BindingContext?): Boolean = isSuppressed(diagnostic)
 
     companion object {
         val EP_NAME: ExtensionPointName<DiagnosticSuppressor> =
@@ -68,7 +69,7 @@ abstract class KotlinSuppressCache {
 
         if (request is DiagnosticSuppressRequest) {
             for (suppressor in diagnosticSuppressors.get()) {
-                if (suppressor.isSuppressed(request.diagnostic)) return true
+                if (isSuppressedByExtension(suppressor, request.diagnostic)) return true
             }
         }
 
@@ -77,6 +78,9 @@ abstract class KotlinSuppressCache {
         return isSuppressedByAnnotated(request.suppressKey, request.severity, annotated, 0)
     }
 
+    open fun isSuppressedByExtension(suppressor: DiagnosticSuppressor, diagnostic: Diagnostic): Boolean {
+        return suppressor.isSuppressed(diagnostic)
+    }
 
     /*
        The cache is optimized for the case where no warnings are suppressed (most frequent one)
@@ -245,5 +249,9 @@ class BindingContextSuppressCache(val context: BindingContext) : KotlinSuppressC
         } else {
             annotated.annotationEntries.mapNotNull { context.get(BindingContext.ANNOTATION, it) }
         }
+    }
+
+    override fun isSuppressedByExtension(suppressor: DiagnosticSuppressor, diagnostic: Diagnostic): Boolean {
+        return suppressor.isSuppressed(diagnostic, context)
     }
 }


### PR DESCRIPTION
We've found that the BindingContext is necessary for any meaningful suppressor.
This change adds the ability for suppressors to use the BindingContext when available.

The change was intentionally formulated to minimize churn/changes to the codebase, but if you would prefer that we have only a single `isSuppressed` method on the interface (specifically, the isSuppressed that includes the BindingContext), I'm happy to update the PR.  Or if you have any other feedback, just let me know.

cc @erokhins 