### PR TITLE
Used System.nanoTime() for measuring elapsed time

### DIFF
--- a/libraries/stdlib/jvm/src/kotlin/system/Timing.kt
+++ b/libraries/stdlib/jvm/src/kotlin/system/Timing.kt
@@ -9,11 +9,7 @@ package kotlin.system
 /**
  * Executes the given [block] and returns elapsed time in milliseconds.
  */
-public inline fun measureTimeMillis(block: () -> Unit): Long {
-    val start = System.currentTimeMillis()
-    block()
-    return System.currentTimeMillis() - start
-}
+public inline fun measureTimeMillis(block: () -> Unit): Long = measureNanoTime(block) / 1000000L
 
 /**
  * Executes the given [block] and returns elapsed time in nanoseconds.


### PR DESCRIPTION
System.currentTimeMillis() is less accurate for measuring elapsed time, as System.nanoTime() is guaranteed to have at least as good accuracy.

According to the [Oracle docs](https://docs.oracle.com/javase/7/docs/api/java/lang/System.html#currentTimeMillis()):
> while the unit of time of the return value is a millisecond, the granularity of the value depends on the underlying operating system and may be larger. For example, many operating systems measure time in units of tens of milliseconds. 

Whereas, nanotime:
> This method can only be used to measure elapsed time and is not related to any other notion of system or wall-clock time. The value returned represents nanoseconds since some fixed but arbitrary origin time (perhaps in the future, so values may be negative).