### PR TITLE
KT-9840 Right parenthesis doesn't appear after class name before the colon

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/KotlinPairMatcher.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/KotlinPairMatcher.kt
@@ -29,6 +29,7 @@ class KotlinPairMatcher : PairedBraceMatcher {
             // KotlinTypedHandler insert paired brace in this case
             false
         } else KtTokens.WHITE_SPACE_OR_COMMENT_BIT_SET.contains(contextType)
+                || contextType === KtTokens.COLON
                 || contextType === KtTokens.SEMICOLON
                 || contextType === KtTokens.COMMA
                 || contextType === KtTokens.RPAR


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-9840