### PR TITLE
KT-23134 "Remove single lambda parameter" quick fix applied to a lambda parameter with explicit type breaks ::invoke reference on lambda

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/RemoveSingleLambdaParameterFix.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/RemoveSingleLambdaParameterFix.kt
@@ -21,10 +21,8 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import org.jetbrains.kotlin.diagnostics.Diagnostic
 import org.jetbrains.kotlin.lexer.KtTokens
-import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.kotlin.psi.KtLambdaExpression
-import org.jetbrains.kotlin.psi.KtParameter
-import org.jetbrains.kotlin.psi.KtParameterList
+import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 
 class RemoveSingleLambdaParameterFix(element: KtParameter) : KotlinQuickFixAction<KtParameter>(element) {
     override fun getFamilyName() = "Remove single lambda parameter declaration"
@@ -47,7 +45,10 @@ class RemoveSingleLambdaParameterFix(element: KtParameter) : KotlinQuickFixActio
 
             if (parameterList.parameters.size != 1) return null
 
-            if (parameterList.parent.parent !is KtLambdaExpression) return null
+            val lambda = parameterList.parent.parent as? KtLambdaExpression ?: return null
+
+            val property = lambda.getStrictParentOfType<KtProperty>()
+            if (property != null && property.typeReference == null) return null
 
             return RemoveSingleLambdaParameterFix(parameter)
         }

--- a/idea/testData/quickfix/removeSingleLambdaParameter/propertyWithExplicitType.kt
+++ b/idea/testData/quickfix/removeSingleLambdaParameter/propertyWithExplicitType.kt
@@ -1,0 +1,8 @@
+// "Remove single lambda parameter declaration" "true"
+fun test() {
+    val f: (Int) -> Unit = { <caret>i: Int -> foo() }
+    bar(f)
+}
+
+fun foo() {}
+fun bar(f: (Int) -> Unit) {}

--- a/idea/testData/quickfix/removeSingleLambdaParameter/propertyWithExplicitType.kt.after
+++ b/idea/testData/quickfix/removeSingleLambdaParameter/propertyWithExplicitType.kt.after
@@ -1,0 +1,8 @@
+// "Remove single lambda parameter declaration" "true"
+fun test() {
+    val f: (Int) -> Unit = { foo() }
+    bar(f)
+}
+
+fun foo() {}
+fun bar(f: (Int) -> Unit) {}

--- a/idea/testData/quickfix/removeSingleLambdaParameter/propertyWithImplicitType.kt
+++ b/idea/testData/quickfix/removeSingleLambdaParameter/propertyWithImplicitType.kt
@@ -1,0 +1,10 @@
+// "Remove single lambda parameter declaration" "false"
+// ACTION: Remove explicit lambda parameter types (may break code)
+// ACTION: Rename to _
+fun test() {
+    val f = { <caret>i: Int -> foo() }
+    bar(f)
+}
+
+fun foo() {}
+fun bar(f: (Int) -> Unit) {}

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -9505,6 +9505,16 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
             runTest("idea/testData/quickfix/removeSingleLambdaParameter/multiple.kt");
         }
 
+        @TestMetadata("propertyWithExplicitType.kt")
+        public void testPropertyWithExplicitType() throws Exception {
+            runTest("idea/testData/quickfix/removeSingleLambdaParameter/propertyWithExplicitType.kt");
+        }
+
+        @TestMetadata("propertyWithImplicitType.kt")
+        public void testPropertyWithImplicitType() throws Exception {
+            runTest("idea/testData/quickfix/removeSingleLambdaParameter/propertyWithImplicitType.kt");
+        }
+
         @TestMetadata("simple.kt")
         public void testSimple() throws Exception {
             runTest("idea/testData/quickfix/removeSingleLambdaParameter/simple.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-23134