### PR TITLE
Fix typo in Kotlin doc for contract method

### DIFF
--- a/libraries/stdlib/src/kotlin/contracts/ContractBuilder.kt
+++ b/libraries/stdlib/src/kotlin/contracts/ContractBuilder.kt
@@ -122,7 +122,7 @@ public enum class InvocationKind {
 }
 
 /**
- * Specifies the contact of a function.
+ * Specifies the contract of a function.
  *
  * The contract description must be at the beginning of a function and have at least one effect.
  *


### PR DESCRIPTION
Fix the typo in "Specifies the contact of a function."