### PR TITLE
Consider non-existent parent `AttributeContainer`s empty

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/HierarchyAttributeContainer.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/HierarchyAttributeContainer.kt
@@ -30,7 +30,7 @@ class HierarchyAttributeContainer(val parent: AttributeContainer?) : AttributeCo
     override fun <T : Any?> getAttribute(key: Attribute<T>?): T? =
         attributesMap.get(key as Attribute<*>) as T? ?: parent?.getAttribute(key)
 
-    override fun isEmpty(): Boolean = attributesMap.isEmpty() && parent?.isEmpty ?: false
+    override fun isEmpty(): Boolean = attributesMap.isEmpty() && (parent?.isEmpty ?: true)
 
     override fun keySet(): Set<Attribute<*>> = attributesMap.keys + parent?.keySet().orEmpty()
 


### PR DESCRIPTION
Given the prior faulty logic, no tree of `HierarchyAttributeContainer`s would ever report itself as empty (not even a 'tree' consisting of a single, attribute-less/empty HierarchyAttributeContainer), since every tree will have a root, which will lack a parent, and it considered the lack of existence of a parent to mean that that root container is not empty.

// good work on this project, btw :+1: 