### PR TITLE
KT-20357: Add samples for commonPrefixWith and commonSuffixWith

### DIFF
--- a/libraries/stdlib/samples/test/samples/text/strings.kt
+++ b/libraries/stdlib/samples/test/samples/text/strings.kt
@@ -176,4 +176,19 @@ class Strings {
         val sameString = nonBlank.ifBlank { "def" }
         assertTrue(nonBlank === sameString)
     }
+
+    @Sample
+    fun commonPrefixWith() {
+        assertPrints("Hot_Coffee".commonPrefixWith("Hot_cocoa"), "Hot_")
+        assertPrints("Hot_Coffee".commonPrefixWith("Hot_cocoa", true), "Hot_Co")
+        assertPrints("Hot_Coffee".commonPrefixWith("Iced_Coffee"), "")
+    }
+
+    @Sample
+    fun commonSuffixWith() {
+        assertPrints("Hot_Tea".commonSuffixWith("iced_tea"), "ea")
+        assertPrints("Hot_Tea".commonSuffixWith("iced_tea", true), "_Tea")
+        assertPrints("Hot_Tea".commonSuffixWith("Hot_Coffee"), "")
+    }
+
 }

--- a/libraries/stdlib/src/kotlin/text/Strings.kt
+++ b/libraries/stdlib/src/kotlin/text/Strings.kt
@@ -772,6 +772,7 @@ public fun CharSequence.endsWith(suffix: CharSequence, ignoreCase: Boolean = fal
  * If this and [other] have no common prefix, returns the empty string.
 
  * @param ignoreCase `true` to ignore character case when matching a character. By default `false`.
+ * @sample samples.text.Strings.commonPrefixWith
  */
 public fun CharSequence.commonPrefixWith(other: CharSequence, ignoreCase: Boolean = false): String {
     val shortestLength = minOf(this.length, other.length)
@@ -792,6 +793,7 @@ public fun CharSequence.commonPrefixWith(other: CharSequence, ignoreCase: Boolea
  * If this and [other] have no common suffix, returns the empty string.
 
  * @param ignoreCase `true` to ignore character case when matching a character. By default `false`.
+ * @sample samples.text.Strings.commonSuffixWith
  */
 public fun CharSequence.commonSuffixWith(other: CharSequence, ignoreCase: Boolean = false): String {
     val thisLength = this.length


### PR DESCRIPTION
[KT-20357](https://youtrack.jetbrains.com/issue/KT-20357) - Samples for `commonPrefixWith()` and `commonSuffixWith()`

The samples demonstrate both case-sensitive and case-insensitive matches, plus the behavior when there's no match.  I didn't include a sample demonstrating surrogate pairs, because regardless of whether the input contains surrogate pairs, the function is still called the same way - but if you feel that it's critical to include samples for that, just let me know.
