### PR TITLE
KT-28618 Kotlin: convert anonymous function to lambda expression failed if no space at start of lambda expression

### DIFF
--- a/compiler/psi/src/org/jetbrains/kotlin/psi/psiUtil/ktPsiUtil.kt
+++ b/compiler/psi/src/org/jetbrains/kotlin/psi/psiUtil/ktPsiUtil.kt
@@ -164,15 +164,15 @@ fun KtElement.blockExpressionsOrSingle(): Sequence<KtElement> =
 fun KtExpression.lastBlockStatementOrThis(): KtExpression = (this as? KtBlockExpression)?.statements?.lastOrNull() ?: this
 
 fun KtBlockExpression.contentRange(): PsiChildRange {
-    val first = (lBrace?.nextSibling ?: firstChild)
-        ?.siblings(withItself = false)
-        ?.firstOrNull { it !is PsiWhiteSpace }
-    val rBrace = rBrace
+    val lBrace = this.lBrace ?: return PsiChildRange.EMPTY
+    val rBrace = this.rBrace ?: return PsiChildRange.EMPTY
+
+    val first = lBrace.siblings(withItself = false).firstOrNull { it !is PsiWhiteSpace }
     if (first == rBrace) return PsiChildRange.EMPTY
-    val last = rBrace!!
-        .siblings(forward = false, withItself = false)
-        .first { it !is PsiWhiteSpace }
+
+    val last = rBrace.siblings(forward = false, withItself = false).first { it !is PsiWhiteSpace }
     if (last == lBrace) return PsiChildRange.EMPTY
+
     return PsiChildRange(first, last)
 }
 

--- a/idea/testData/intentions/anonymousFunctionToLambda/noSpaceAfterFunctionLeftBrace.kt
+++ b/idea/testData/intentions/anonymousFunctionToLambda/noSpaceAfterFunctionLeftBrace.kt
@@ -1,0 +1,6 @@
+fun foo(f: (Int) -> Boolean) {
+    f(1)
+}
+fun test() {
+    foo(<caret>fun(i: Int): Boolean {return i > 0 })
+}

--- a/idea/testData/intentions/anonymousFunctionToLambda/noSpaceAfterFunctionLeftBrace.kt.after
+++ b/idea/testData/intentions/anonymousFunctionToLambda/noSpaceAfterFunctionLeftBrace.kt.after
@@ -1,0 +1,6 @@
+fun foo(f: (Int) -> Boolean) {
+    f(1)
+}
+fun test() {
+    foo { i -> i > 0 }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -1954,6 +1954,11 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
             runTest("idea/testData/intentions/anonymousFunctionToLambda/moveOut.kt");
         }
 
+        @TestMetadata("noSpaceAfterFunctionLeftBrace.kt")
+        public void testNoSpaceAfterFunctionLeftBrace() throws Exception {
+            runTest("idea/testData/intentions/anonymousFunctionToLambda/noSpaceAfterFunctionLeftBrace.kt");
+        }
+
         @TestMetadata("paramName.kt")
         public void testParamName() throws Exception {
             runTest("idea/testData/intentions/anonymousFunctionToLambda/paramName.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-28618