### PR TITLE
Add documentation on how merging works for toMap() for Iterables, Arrays and Sequences

### DIFF
--- a/libraries/stdlib/src/kotlin/collections/Maps.kt
+++ b/libraries/stdlib/src/kotlin/collections/Maps.kt
@@ -488,6 +488,7 @@ public inline fun <K, V> Map<out K, V>.filterNot(predicate: (Map.Entry<K, V>) ->
  * Returns a new map containing all key-value pairs from the given collection of pairs.
  *
  * The returned map preserves the entry iteration order of the original collection.
+ * Duplicate keys are ignored except for the last one.
  */
 public fun <K, V> Iterable<Pair<K, V>>.toMap(): Map<K, V> {
     if (this is Collection) {
@@ -510,6 +511,7 @@ public fun <K, V, M : MutableMap<in K, in V>> Iterable<Pair<K, V>>.toMap(destina
  * Returns a new map containing all key-value pairs from the given array of pairs.
  *
  * The returned map preserves the entry iteration order of the original array.
+ * Duplicate keys are ignored except for the last one.
  */
 public fun <K, V> Array<out Pair<K, V>>.toMap(): Map<K, V> = when (size) {
     0 -> emptyMap()
@@ -527,6 +529,7 @@ public fun <K, V, M : MutableMap<in K, in V>> Array<out Pair<K, V>>.toMap(destin
  * Returns a new map containing all key-value pairs from the given sequence of pairs.
  *
  * The returned map preserves the entry iteration order of the original sequence.
+ * Duplicate keys are ignored except for the last one.
  */
 public fun <K, V> Sequence<Pair<K, V>>.toMap(): Map<K, V> = toMap(LinkedHashMap<K, V>()).optimizeReadOnlyMap()
 

--- a/libraries/stdlib/src/kotlin/collections/Maps.kt
+++ b/libraries/stdlib/src/kotlin/collections/Maps.kt
@@ -488,7 +488,7 @@ public inline fun <K, V> Map<out K, V>.filterNot(predicate: (Map.Entry<K, V>) ->
  * Returns a new map containing all key-value pairs from the given collection of pairs.
  *
  * The returned map preserves the entry iteration order of the original collection.
- * Duplicate keys are ignored except for the last one.
+ * If any of two pairs would have the same key the last one gets added to the map.
  */
 public fun <K, V> Iterable<Pair<K, V>>.toMap(): Map<K, V> {
     if (this is Collection) {
@@ -511,7 +511,7 @@ public fun <K, V, M : MutableMap<in K, in V>> Iterable<Pair<K, V>>.toMap(destina
  * Returns a new map containing all key-value pairs from the given array of pairs.
  *
  * The returned map preserves the entry iteration order of the original array.
- * Duplicate keys are ignored except for the last one.
+ * If any of two pairs would have the same key the last one gets added to the map.
  */
 public fun <K, V> Array<out Pair<K, V>>.toMap(): Map<K, V> = when (size) {
     0 -> emptyMap()
@@ -529,7 +529,7 @@ public fun <K, V, M : MutableMap<in K, in V>> Array<out Pair<K, V>>.toMap(destin
  * Returns a new map containing all key-value pairs from the given sequence of pairs.
  *
  * The returned map preserves the entry iteration order of the original sequence.
- * Duplicate keys are ignored except for the last one.
+ * If any of two pairs would have the same key the last one gets added to the map.
  */
 public fun <K, V> Sequence<Pair<K, V>>.toMap(): Map<K, V> = toMap(LinkedHashMap<K, V>()).optimizeReadOnlyMap()
 


### PR DESCRIPTION
I hope I got all occurrences where this behavior is the case. I was wondering how it would behave especially because Java's **Stream.collect(Collectors.toMap())** throws when duplicate keys are encountered