### PR TITLE
Complete Java usage tracker if analysis extension finishes (KT-27487)

### DIFF
--- a/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/TopDownAnalyzerFacadeForJVM.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/TopDownAnalyzerFacadeForJVM.kt
@@ -91,6 +91,7 @@ object TopDownAnalyzerFacadeForJVM {
         val analysisHandlerExtensions = AnalysisHandlerExtension.getInstances(project)
 
         fun invokeExtensionsOnAnalysisComplete(): AnalysisResult? {
+            container.get<JavaClassesTracker>().onCompletedAnalysis(module)
             for (extension in analysisHandlerExtensions) {
                 val result = extension.analysisCompleted(project, module, trace, files)
                 if (result != null) return result
@@ -108,7 +109,6 @@ object TopDownAnalyzerFacadeForJVM {
         }
 
         container.get<LazyTopDownAnalyzer>().analyzeDeclarations(TopDownAnalysisMode.TopLevelDeclarations, files)
-        container.get<JavaClassesTracker>().onCompletedAnalysis(module)
 
         invokeExtensionsOnAnalysisComplete()?.let { return it }
 


### PR DESCRIPTION
In cases when kapt compiler plugin runs in stubs generation mode,
Java usage tracker was not completed. This caused issues with
the incremental compilation if Java files changed.

E.g. if a constant defined in Java source file changed, stubs
would not be recompiled because the Java usage tracker would
not report changed type. This commit fixes that issue.