### PR TITLE
Update JavaSdkUtil.java

### DIFF
--- a/compiler/util/src/org/jetbrains/kotlin/utils/JavaSdkUtil.java
+++ b/compiler/util/src/org/jetbrains/kotlin/utils/JavaSdkUtil.java
@@ -91,7 +91,7 @@ public class JavaSdkUtil {
       }
     }
 
-    String[] ibmJdkVmJarDirs = {"bin/default", "lib/i386/default", "lib/amd64/default"};
+    String[] ibmJdkVmJarDirs = {"bin/default", "lib/i386/default", "lib/amd64/default", "lib/s390x/default"};
     for (String relativePath : ibmJdkVmJarDirs) {
       File libDir = new File(home, isJre ? relativePath : "jre/" + relativePath);
       File[] vmJarDirs = notNull(libDir.listFiles(FileUtilRt.ALL_DIRECTORIES), ArrayUtil.EMPTY_FILE_ARRAY);


### PR DESCRIPTION
Added path for IBM JDK on platform z/OS
I tried Kotlin on z/OS and the hello world worked, but a more complex sample initially showed errors that java.lang.Object could not be resolved. So I added the -jdk-home parameter and got the error: no class roots are found in the JDK path.
So I looked into the Kotlin sources and found hardcoded paths in the JavaSdkUtil.java source. I changed this at my workstation, added "lib/s390x/default" and added it to kotlin-compiler.jar and now the compile works.
I hope you guys can add it soon.

Thanks, Denis.