### PR TITLE
KT-17119 Inspection for (Scala-like) `= { ... }` syntax without expected type in function definition

### DIFF
--- a/idea/resources/META-INF/plugin-common.xml
+++ b/idea/resources/META-INF/plugin-common.xml
@@ -3182,6 +3182,15 @@
                      language="kotlin"
     />
 
+    <localInspection implementationClass="org.jetbrains.kotlin.idea.inspections.FunctionWithLambdaExpressionBodyInspection"
+                     displayName="Function with `= { ... }` and inferred return type"
+                     groupPath="Kotlin"
+                     groupName="Style issues"
+                     enabledByDefault="true"
+                     level="WEAK WARNING"
+                     language="kotlin"
+    />
+
     <referenceImporter implementation="org.jetbrains.kotlin.idea.quickfix.KotlinReferenceImporter"/>
 
     <fileType.fileViewProviderFactory filetype="KJSM" implementationClass="com.intellij.psi.ClassFileViewProviderFactory"/>

--- a/idea/resources/inspectionDescriptions/FunctionWithLambdaExpressionBody.html
+++ b/idea/resources/inspectionDescriptions/FunctionWithLambdaExpressionBody.html
@@ -1,0 +1,10 @@
+<html>
+<body>
+This inspection reports function with `<b>= { ... }</b>` and inferred return type.
+
+<pre>
+fun sum(a: Int, b: Int) = { a + b } // The return type of this function is '() -> Int'.
+</pre>
+
+</body>
+</html>

--- a/idea/src/org/jetbrains/kotlin/idea/inspections/FunctionWithLambdaExpressionBodyInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/FunctionWithLambdaExpressionBodyInspection.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2010-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.idea.inspections
+
+import com.intellij.codeInspection.*
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiComment
+import com.intellij.psi.PsiElement
+import com.intellij.psi.search.searches.ReferencesSearch
+import com.intellij.psi.util.parentOfType
+import org.jetbrains.kotlin.descriptors.CallableDescriptor
+import org.jetbrains.kotlin.idea.caches.resolve.resolveToDescriptorIfAny
+import org.jetbrains.kotlin.idea.core.replaced
+import org.jetbrains.kotlin.idea.core.setType
+import org.jetbrains.kotlin.idea.intentions.SpecifyExplicitLambdaSignatureIntention
+import org.jetbrains.kotlin.idea.quickfix.SpecifyTypeExplicitlyFix
+import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.psiUtil.allChildren
+import org.jetbrains.kotlin.psi.psiUtil.getNonStrictParentOfType
+import org.jetbrains.kotlin.types.typeUtil.isNothing
+
+class FunctionWithLambdaExpressionBodyInspection : AbstractKotlinInspection() {
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) = object : KtVisitorVoid() {
+        override fun visitNamedFunction(function: KtNamedFunction) {
+            check(function)
+        }
+
+        override fun visitPropertyAccessor(accessor: KtPropertyAccessor) {
+            if (accessor.isSetter) return
+            if (accessor.returnTypeReference != null) return
+            check(accessor)
+        }
+
+        private fun check(element: KtDeclarationWithBody) {
+            val callableDeclaration = element.getNonStrictParentOfType<KtCallableDeclaration>() ?: return
+            if (callableDeclaration.typeReference != null) return
+            val lambda = element.bodyExpression as? KtLambdaExpression ?: return
+            val functionLiteral = lambda.functionLiteral
+            if (functionLiteral.arrow != null || functionLiteral.valueParameterList != null) return
+            val lambdaBody = functionLiteral.bodyBlockExpression ?: return
+
+            val file = element.containingKtFile
+            val used = ReferencesSearch.search(callableDeclaration).any()
+            val fixes = listOfNotNull(
+                IntentionWrapper(SpecifyTypeExplicitlyFix(), file),
+                IntentionWrapper(AddArrowIntention(), file),
+                if (!used && lambdaBody.statements.size == 1 && lambdaBody.allChildren.none { it is PsiComment }) RemoveBracesFix() else null,
+                if (!used) WrapRunFix() else null
+            )
+            holder.registerProblem(
+                lambda,
+                "Function with `= { ... }` and inferred return type",
+                ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
+                *fixes.toTypedArray()
+            )
+        }
+    }
+
+    private class AddArrowIntention : SpecifyExplicitLambdaSignatureIntention() {
+        override fun allowCaretInsideElement(element: PsiElement) = true
+    }
+
+    private class RemoveBracesFix : LocalQuickFix {
+        override fun getName() = "Remove braces"
+
+        override fun getFamilyName() = name
+
+        override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+            val lambda = descriptor.psiElement as? KtLambdaExpression ?: return
+            val body = lambda.functionLiteral.bodyExpression ?: return
+            val replaced = lambda.replaced(body)
+            replaced.parentOfType<KtCallableDeclaration>()?.setTypeIfNeed()
+        }
+    }
+
+    private class WrapRunFix : LocalQuickFix {
+        override fun getName() = "Convert to run { ... }"
+
+        override fun getFamilyName() = name
+
+        override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+            val lambda = descriptor.psiElement as? KtLambdaExpression ?: return
+            val body = lambda.functionLiteral.bodyExpression ?: return
+            val replaced = lambda.replaced(KtPsiFactory(lambda).createExpressionByPattern("run { $0 }", body))
+            replaced.parentOfType<KtCallableDeclaration>()?.setTypeIfNeed()
+        }
+    }
+}
+
+private fun KtCallableDeclaration.setTypeIfNeed() {
+    val type = (resolveToDescriptorIfAny() as? CallableDescriptor)?.returnType
+    if (type?.isNothing() == true) {
+        this.setType(type)
+    }
+}

--- a/idea/src/org/jetbrains/kotlin/idea/intentions/SpecifyExplicitLambdaSignatureIntention.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/SpecifyExplicitLambdaSignatureIntention.kt
@@ -31,7 +31,7 @@ import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.lazy.BodyResolveMode
 import org.jetbrains.kotlin.types.isError
 
-class SpecifyExplicitLambdaSignatureIntention : SelfTargetingOffsetIndependentIntention<KtLambdaExpression>(
+open class SpecifyExplicitLambdaSignatureIntention : SelfTargetingOffsetIndependentIntention<KtLambdaExpression>(
     KtLambdaExpression::class.java, "Specify explicit lambda signature"
 ), LowPriorityAction {
 

--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/.inspection
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/.inspection
@@ -1,0 +1,1 @@
+org.jetbrains.kotlin.idea.inspections.FunctionWithLambdaExpressionBodyInspection

--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/addArrow/function.kt
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/addArrow/function.kt
@@ -1,0 +1,2 @@
+// FIX: Specify explicit lambda signature
+fun test(a: Int, b: Int) = <caret>{ a + b }

--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/addArrow/function.kt.after
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/addArrow/function.kt.after
@@ -1,0 +1,2 @@
+// FIX: Specify explicit lambda signature
+fun test(a: Int, b: Int) = { -> a + b }

--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/addArrow/getter.kt
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/addArrow/getter.kt
@@ -1,0 +1,2 @@
+// FIX: Specify explicit lambda signature
+val test get() = <caret>{ "" }

--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/addArrow/getter.kt.after
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/addArrow/getter.kt.after
@@ -1,0 +1,2 @@
+// FIX: Specify explicit lambda signature
+val test get() = { -> "" }

--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/functionHasArrow.kt
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/functionHasArrow.kt
@@ -1,0 +1,2 @@
+// PROBLEM: none
+fun test(a: Int, b: Int) = <caret>{ -> a + b }

--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/functionHasLabel.kt
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/functionHasLabel.kt
@@ -1,0 +1,4 @@
+// PROBLEM: none
+fun test(a: Int, b: Int) = label@<caret>{
+    return@label
+}

--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/functionHasNoExpressionBody.kt
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/functionHasNoExpressionBody.kt
@@ -1,0 +1,2 @@
+// PROBLEM: none
+fun test(a: Int, b: Int) <caret>{ { a + b } }

--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/functionHasNoLambda.kt
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/functionHasNoLambda.kt
@@ -1,0 +1,2 @@
+// PROBLEM: none
+fun test(a: Int, b: Int) = <caret>a + b

--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/functionHasType.kt
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/functionHasType.kt
@@ -1,0 +1,2 @@
+// PROBLEM: none
+fun test(a: Int, b: Int): () -> Int = <caret>{ a + b }

--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/getterHasArrow.kt
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/getterHasArrow.kt
@@ -1,0 +1,2 @@
+// PROBLEM: none
+val test get() = <caret>{ -> "" }

--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/getterHasLabel.kt
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/getterHasLabel.kt
@@ -1,0 +1,5 @@
+// PROBLEM: none
+val test
+    get() = label@<caret>{
+        return@label
+    }

--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/getterHasNoLambda.kt
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/getterHasNoLambda.kt
@@ -1,0 +1,2 @@
+// PROBLEM: none
+val test get() = <caret>""

--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/getterHasType.kt
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/getterHasType.kt
@@ -1,0 +1,2 @@
+// PROBLEM: none
+val test: () -> String get() = <caret>{ "" }

--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/getterHasType2.kt
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/getterHasType2.kt
@@ -1,0 +1,2 @@
+// PROBLEM: none
+val test get(): () -> String = <caret>{ "" }

--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/removeBraces/function.kt
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/removeBraces/function.kt
@@ -1,0 +1,2 @@
+// FIX: Remove braces
+fun test(a: Int, b: Int) = <caret>{ a + b }

--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/removeBraces/function.kt.after
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/removeBraces/function.kt.after
@@ -1,0 +1,2 @@
+// FIX: Remove braces
+fun test(a: Int, b: Int) = a + b

--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/removeBraces/functionReturnsNothing.kt
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/removeBraces/functionReturnsNothing.kt
@@ -1,0 +1,3 @@
+// FIX: Remove braces
+// WITH_RUNTIME
+fun test() = <caret>{ error("") }

--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/removeBraces/functionReturnsNothing.kt.after
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/removeBraces/functionReturnsNothing.kt.after
@@ -1,0 +1,3 @@
+// FIX: Remove braces
+// WITH_RUNTIME
+fun test(): Nothing = error("")

--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/removeBraces/getter.kt
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/removeBraces/getter.kt
@@ -1,0 +1,2 @@
+// FIX: Remove braces
+val test get() = <caret>{ "" }

--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/removeBraces/getter.kt.after
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/removeBraces/getter.kt.after
@@ -1,0 +1,2 @@
+// FIX: Remove braces
+val test get() = ""

--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/removeBraces/getterReturnsNothing.kt
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/removeBraces/getterReturnsNothing.kt
@@ -1,0 +1,3 @@
+// FIX: Remove braces
+// WITH_RUNTIME
+val test get() = <caret>{ error("") }

--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/removeBraces/getterReturnsNothing.kt.after
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/removeBraces/getterReturnsNothing.kt.after
@@ -1,0 +1,3 @@
+// FIX: Remove braces
+// WITH_RUNTIME
+val test: Nothing get() = error("")

--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/specifyType/function.kt
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/specifyType/function.kt
@@ -1,0 +1,2 @@
+// FIX: Specify return type explicitly
+fun test(a: Int, b: Int) = <caret>{ a + b }

--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/specifyType/function.kt.after
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/specifyType/function.kt.after
@@ -1,0 +1,2 @@
+// FIX: Specify return type explicitly
+fun test(a: Int, b: Int): () -> Int = { a + b }

--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/specifyType/getter.kt
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/specifyType/getter.kt
@@ -1,0 +1,2 @@
+// FIX: Specify type explicitly
+val test get() = <caret>{ "" }

--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/specifyType/getter.kt.after
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/specifyType/getter.kt.after
@@ -1,0 +1,2 @@
+// FIX: Specify type explicitly
+val test: () -> String get() = { "" }

--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/wrapRun/function.kt
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/wrapRun/function.kt
@@ -1,0 +1,3 @@
+// FIX: Convert to run { ... }
+// WITH_RUNTIME
+fun test(a: Int, b: Int) = <caret>{ a + b }

--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/wrapRun/function.kt.after
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/wrapRun/function.kt.after
@@ -1,0 +1,3 @@
+// FIX: Convert to run { ... }
+// WITH_RUNTIME
+fun test(a: Int, b: Int) = run { a + b }

--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/wrapRun/functionReturnsNothing.kt
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/wrapRun/functionReturnsNothing.kt
@@ -1,0 +1,3 @@
+// FIX: Convert to run { ... }
+// WITH_RUNTIME
+fun test() = <caret>{ error("") }

--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/wrapRun/functionReturnsNothing.kt.after
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/wrapRun/functionReturnsNothing.kt.after
@@ -1,0 +1,3 @@
+// FIX: Convert to run { ... }
+// WITH_RUNTIME
+fun test(): Nothing = run { error("") }

--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/wrapRun/getter.kt
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/wrapRun/getter.kt
@@ -1,0 +1,3 @@
+// FIX: Convert to run { ... }
+// WITH_RUNTIME
+val test get() = <caret>{ "" }

--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/wrapRun/getter.kt.after
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/wrapRun/getter.kt.after
@@ -1,0 +1,3 @@
+// FIX: Convert to run { ... }
+// WITH_RUNTIME
+val test get() = run { "" }

--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/wrapRun/getterReturnsNothing.kt
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/wrapRun/getterReturnsNothing.kt
@@ -1,0 +1,3 @@
+// FIX: Convert to run { ... }
+// WITH_RUNTIME
+val test get() = <caret>{ error("") }

--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/wrapRun/getterReturnsNothing.kt.after
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/wrapRun/getterReturnsNothing.kt.after
@@ -1,0 +1,3 @@
+// FIX: Convert to run { ... }
+// WITH_RUNTIME
+val test: Nothing get() = run { error("") }

--- a/idea/testData/quickfix/functionWithLambdaExpressionBody/removeBraces/functionHasComment.kt
+++ b/idea/testData/quickfix/functionWithLambdaExpressionBody/removeBraces/functionHasComment.kt
@@ -1,0 +1,11 @@
+// "Remove braces" "false"
+// TOOL: org.jetbrains.kotlin.idea.inspections.FunctionWithLambdaExpressionBodyInspection
+// ACTION: Convert to block body
+// ACTION: Convert to run { ... }
+// ACTION: Specify explicit lambda signature
+// ACTION: Specify explicit lambda signature
+// ACTION: Specify return type explicitly
+fun test(a: Int, b: Int) = <caret>{
+    // comment
+    ""
+}

--- a/idea/testData/quickfix/functionWithLambdaExpressionBody/removeBraces/functionHasMultiStatements.kt
+++ b/idea/testData/quickfix/functionWithLambdaExpressionBody/removeBraces/functionHasMultiStatements.kt
@@ -1,0 +1,13 @@
+// "Remove braces" "false"
+// TOOL: org.jetbrains.kotlin.idea.inspections.FunctionWithLambdaExpressionBodyInspection
+// ACTION: Convert to block body
+// ACTION: Convert to run { ... }
+// ACTION: Specify explicit lambda signature
+// ACTION: Specify explicit lambda signature
+// ACTION: Specify return type explicitly
+fun test(a: Int, b: Int) = <caret>{
+    foo()
+    foo()
+}
+
+fun foo() {}

--- a/idea/testData/quickfix/functionWithLambdaExpressionBody/removeBraces/functionHasNoStatement.kt
+++ b/idea/testData/quickfix/functionWithLambdaExpressionBody/removeBraces/functionHasNoStatement.kt
@@ -1,0 +1,8 @@
+// "Remove braces" "false"
+// TOOL: org.jetbrains.kotlin.idea.inspections.FunctionWithLambdaExpressionBodyInspection
+// ACTION: Convert to block body
+// ACTION: Convert to run { ... }
+// ACTION: Specify explicit lambda signature
+// ACTION: Specify explicit lambda signature
+// ACTION: Specify return type explicitly
+fun test(a: Int, b: Int) = <caret>{}

--- a/idea/testData/quickfix/functionWithLambdaExpressionBody/removeBraces/funtionIsUsed.kt
+++ b/idea/testData/quickfix/functionWithLambdaExpressionBody/removeBraces/funtionIsUsed.kt
@@ -1,0 +1,9 @@
+// "Remove braces" "false"
+// TOOL: org.jetbrains.kotlin.idea.inspections.FunctionWithLambdaExpressionBodyInspection
+// ACTION: Convert to block body
+// ACTION: Specify explicit lambda signature
+// ACTION: Specify explicit lambda signature
+// ACTION: Specify return type explicitly
+fun test(a: Int, b: Int) = <caret>{ a + b }
+
+val foo = test(1, 2)()

--- a/idea/testData/quickfix/functionWithLambdaExpressionBody/removeBraces/getterHasComment.kt
+++ b/idea/testData/quickfix/functionWithLambdaExpressionBody/removeBraces/getterHasComment.kt
@@ -1,0 +1,13 @@
+// "Remove braces" "false"
+// TOOL: org.jetbrains.kotlin.idea.inspections.FunctionWithLambdaExpressionBodyInspection
+// ACTION: Convert property getter to initializer
+// ACTION: Convert to block body
+// ACTION: Convert to run { ... }
+// ACTION: Specify explicit lambda signature
+// ACTION: Specify explicit lambda signature
+// ACTION: Specify type explicitly
+// ACTION: Specify type explicitly
+val test get() = <caret>{
+    // comment
+    ""
+}

--- a/idea/testData/quickfix/functionWithLambdaExpressionBody/removeBraces/getterHasMultiStatements.kt
+++ b/idea/testData/quickfix/functionWithLambdaExpressionBody/removeBraces/getterHasMultiStatements.kt
@@ -1,0 +1,15 @@
+// "Remove braces" "false"
+// TOOL: org.jetbrains.kotlin.idea.inspections.FunctionWithLambdaExpressionBodyInspection
+// ACTION: Convert property getter to initializer
+// ACTION: Convert to block body
+// ACTION: Convert to run { ... }
+// ACTION: Specify explicit lambda signature
+// ACTION: Specify explicit lambda signature
+// ACTION: Specify type explicitly
+// ACTION: Specify type explicitly
+val test get() = <caret>{
+    foo()
+    foo()
+}
+
+fun foo() {}

--- a/idea/testData/quickfix/functionWithLambdaExpressionBody/removeBraces/getterHasNoStatement.kt
+++ b/idea/testData/quickfix/functionWithLambdaExpressionBody/removeBraces/getterHasNoStatement.kt
@@ -1,0 +1,10 @@
+// "Remove braces" "false"
+// TOOL: org.jetbrains.kotlin.idea.inspections.FunctionWithLambdaExpressionBodyInspection
+// ACTION: Convert property getter to initializer
+// ACTION: Convert to block body
+// ACTION: Convert to run { ... }
+// ACTION: Specify explicit lambda signature
+// ACTION: Specify explicit lambda signature
+// ACTION: Specify type explicitly
+// ACTION: Specify type explicitly
+val test get() = <caret>{}

--- a/idea/testData/quickfix/functionWithLambdaExpressionBody/removeBraces/getterIsUsed.kt
+++ b/idea/testData/quickfix/functionWithLambdaExpressionBody/removeBraces/getterIsUsed.kt
@@ -1,0 +1,13 @@
+// "Remove braces" "false"
+// TOOL: org.jetbrains.kotlin.idea.inspections.FunctionWithLambdaExpressionBodyInspection
+// ACTION: Convert property getter to initializer
+// ACTION: Convert to block body
+// ACTION: Specify explicit lambda signature
+// ACTION: Specify explicit lambda signature
+// ACTION: Specify type explicitly
+// ACTION: Specify type explicitly
+val test get() = <caret>{ "" }
+
+fun foo() {
+    test()
+}

--- a/idea/testData/quickfix/functionWithLambdaExpressionBody/wrapRun/funtionIsUsed.kt
+++ b/idea/testData/quickfix/functionWithLambdaExpressionBody/wrapRun/funtionIsUsed.kt
@@ -1,0 +1,9 @@
+// "Convert to run { ... }" "false"
+// TOOL: org.jetbrains.kotlin.idea.inspections.FunctionWithLambdaExpressionBodyInspection
+// ACTION: Convert to block body
+// ACTION: Specify explicit lambda signature
+// ACTION: Specify explicit lambda signature
+// ACTION: Specify return type explicitly
+fun test(a: Int, b: Int) = <caret>{ a + b }
+
+val foo = test(1, 2)()

--- a/idea/testData/quickfix/functionWithLambdaExpressionBody/wrapRun/getterIsUsed.kt
+++ b/idea/testData/quickfix/functionWithLambdaExpressionBody/wrapRun/getterIsUsed.kt
@@ -1,0 +1,13 @@
+// "Convert to run { ... }" "false"
+// TOOL: org.jetbrains.kotlin.idea.inspections.FunctionWithLambdaExpressionBodyInspection
+// ACTION: Convert property getter to initializer
+// ACTION: Convert to block body
+// ACTION: Specify explicit lambda signature
+// ACTION: Specify explicit lambda signature
+// ACTION: Specify type explicitly
+// ACTION: Specify type explicitly
+val test get() = <caret>{ "" }
+
+fun foo() {
+    test()
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -2740,6 +2740,181 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
         }
     }
 
+    @TestMetadata("idea/testData/inspectionsLocal/functionWithLambdaExpressionBody")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class FunctionWithLambdaExpressionBody extends AbstractLocalInspectionTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY, testDataFilePath);
+        }
+
+        public void testAllFilesPresentInFunctionWithLambdaExpressionBody() throws Exception {
+            KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/inspectionsLocal/functionWithLambdaExpressionBody"), Pattern.compile("^([\\w\\-_]+)\\.(kt|kts)$"), TargetBackend.ANY, true);
+        }
+
+        @TestMetadata("functionHasArrow.kt")
+        public void testFunctionHasArrow() throws Exception {
+            runTest("idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/functionHasArrow.kt");
+        }
+
+        @TestMetadata("functionHasLabel.kt")
+        public void testFunctionHasLabel() throws Exception {
+            runTest("idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/functionHasLabel.kt");
+        }
+
+        @TestMetadata("functionHasNoExpressionBody.kt")
+        public void testFunctionHasNoExpressionBody() throws Exception {
+            runTest("idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/functionHasNoExpressionBody.kt");
+        }
+
+        @TestMetadata("functionHasNoLambda.kt")
+        public void testFunctionHasNoLambda() throws Exception {
+            runTest("idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/functionHasNoLambda.kt");
+        }
+
+        @TestMetadata("functionHasType.kt")
+        public void testFunctionHasType() throws Exception {
+            runTest("idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/functionHasType.kt");
+        }
+
+        @TestMetadata("getterHasArrow.kt")
+        public void testGetterHasArrow() throws Exception {
+            runTest("idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/getterHasArrow.kt");
+        }
+
+        @TestMetadata("getterHasLabel.kt")
+        public void testGetterHasLabel() throws Exception {
+            runTest("idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/getterHasLabel.kt");
+        }
+
+        @TestMetadata("getterHasNoLambda.kt")
+        public void testGetterHasNoLambda() throws Exception {
+            runTest("idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/getterHasNoLambda.kt");
+        }
+
+        @TestMetadata("getterHasType.kt")
+        public void testGetterHasType() throws Exception {
+            runTest("idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/getterHasType.kt");
+        }
+
+        @TestMetadata("getterHasType2.kt")
+        public void testGetterHasType2() throws Exception {
+            runTest("idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/getterHasType2.kt");
+        }
+
+        @TestMetadata("idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/addArrow")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class AddArrow extends AbstractLocalInspectionTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInAddArrow() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/addArrow"), Pattern.compile("^([\\w\\-_]+)\\.(kt|kts)$"), TargetBackend.ANY, true);
+            }
+
+            @TestMetadata("function.kt")
+            public void testFunction() throws Exception {
+                runTest("idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/addArrow/function.kt");
+            }
+
+            @TestMetadata("getter.kt")
+            public void testGetter() throws Exception {
+                runTest("idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/addArrow/getter.kt");
+            }
+        }
+
+        @TestMetadata("idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/removeBraces")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class RemoveBraces extends AbstractLocalInspectionTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInRemoveBraces() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/removeBraces"), Pattern.compile("^([\\w\\-_]+)\\.(kt|kts)$"), TargetBackend.ANY, true);
+            }
+
+            @TestMetadata("function.kt")
+            public void testFunction() throws Exception {
+                runTest("idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/removeBraces/function.kt");
+            }
+
+            @TestMetadata("functionReturnsNothing.kt")
+            public void testFunctionReturnsNothing() throws Exception {
+                runTest("idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/removeBraces/functionReturnsNothing.kt");
+            }
+
+            @TestMetadata("getter.kt")
+            public void testGetter() throws Exception {
+                runTest("idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/removeBraces/getter.kt");
+            }
+
+            @TestMetadata("getterReturnsNothing.kt")
+            public void testGetterReturnsNothing() throws Exception {
+                runTest("idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/removeBraces/getterReturnsNothing.kt");
+            }
+        }
+
+        @TestMetadata("idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/specifyType")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class SpecifyType extends AbstractLocalInspectionTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInSpecifyType() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/specifyType"), Pattern.compile("^([\\w\\-_]+)\\.(kt|kts)$"), TargetBackend.ANY, true);
+            }
+
+            @TestMetadata("function.kt")
+            public void testFunction() throws Exception {
+                runTest("idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/specifyType/function.kt");
+            }
+
+            @TestMetadata("getter.kt")
+            public void testGetter() throws Exception {
+                runTest("idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/specifyType/getter.kt");
+            }
+        }
+
+        @TestMetadata("idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/wrapRun")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class WrapRun extends AbstractLocalInspectionTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInWrapRun() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/wrapRun"), Pattern.compile("^([\\w\\-_]+)\\.(kt|kts)$"), TargetBackend.ANY, true);
+            }
+
+            @TestMetadata("function.kt")
+            public void testFunction() throws Exception {
+                runTest("idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/wrapRun/function.kt");
+            }
+
+            @TestMetadata("functionReturnsNothing.kt")
+            public void testFunctionReturnsNothing() throws Exception {
+                runTest("idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/wrapRun/functionReturnsNothing.kt");
+            }
+
+            @TestMetadata("getter.kt")
+            public void testGetter() throws Exception {
+                runTest("idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/wrapRun/getter.kt");
+            }
+
+            @TestMetadata("getterReturnsNothing.kt")
+            public void testGetterReturnsNothing() throws Exception {
+                runTest("idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/wrapRun/getterReturnsNothing.kt");
+            }
+        }
+    }
+
     @TestMetadata("idea/testData/inspectionsLocal/ImplicitNullableNothingType")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixMultiFileTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixMultiFileTestGenerated.java
@@ -2685,6 +2685,45 @@ public class QuickFixMultiFileTestGenerated extends AbstractQuickFixMultiFileTes
         }
     }
 
+    @TestMetadata("idea/testData/quickfix/functionWithLambdaExpressionBody")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class FunctionWithLambdaExpressionBody extends AbstractQuickFixMultiFileTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doTestWithExtraFile, TargetBackend.ANY, testDataFilePath);
+        }
+
+        public void testAllFilesPresentInFunctionWithLambdaExpressionBody() throws Exception {
+            KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/quickfix/functionWithLambdaExpressionBody"), Pattern.compile("^(\\w+)\\.((before\\.Main\\.\\w+)|(test))$"), TargetBackend.ANY, true);
+        }
+
+        @TestMetadata("idea/testData/quickfix/functionWithLambdaExpressionBody/removeBraces")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class RemoveBraces extends AbstractQuickFixMultiFileTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest(this::doTestWithExtraFile, TargetBackend.ANY, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInRemoveBraces() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/quickfix/functionWithLambdaExpressionBody/removeBraces"), Pattern.compile("^(\\w+)\\.((before\\.Main\\.\\w+)|(test))$"), TargetBackend.ANY, true);
+            }
+        }
+
+        @TestMetadata("idea/testData/quickfix/functionWithLambdaExpressionBody/wrapRun")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class WrapRun extends AbstractQuickFixMultiFileTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest(this::doTestWithExtraFile, TargetBackend.ANY, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInWrapRun() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/quickfix/functionWithLambdaExpressionBody/wrapRun"), Pattern.compile("^(\\w+)\\.((before\\.Main\\.\\w+)|(test))$"), TargetBackend.ANY, true);
+            }
+        }
+    }
+
     @TestMetadata("idea/testData/quickfix/implement")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -6775,6 +6775,95 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
         }
     }
 
+    @TestMetadata("idea/testData/quickfix/functionWithLambdaExpressionBody")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class FunctionWithLambdaExpressionBody extends AbstractQuickFixTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY, testDataFilePath);
+        }
+
+        public void testAllFilesPresentInFunctionWithLambdaExpressionBody() throws Exception {
+            KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/quickfix/functionWithLambdaExpressionBody"), Pattern.compile("^([\\w\\-_]+)\\.kt$"), TargetBackend.ANY, true);
+        }
+
+        @TestMetadata("idea/testData/quickfix/functionWithLambdaExpressionBody/removeBraces")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class RemoveBraces extends AbstractQuickFixTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInRemoveBraces() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/quickfix/functionWithLambdaExpressionBody/removeBraces"), Pattern.compile("^([\\w\\-_]+)\\.kt$"), TargetBackend.ANY, true);
+            }
+
+            @TestMetadata("functionHasComment.kt")
+            public void testFunctionHasComment() throws Exception {
+                runTest("idea/testData/quickfix/functionWithLambdaExpressionBody/removeBraces/functionHasComment.kt");
+            }
+
+            @TestMetadata("functionHasMultiStatements.kt")
+            public void testFunctionHasMultiStatements() throws Exception {
+                runTest("idea/testData/quickfix/functionWithLambdaExpressionBody/removeBraces/functionHasMultiStatements.kt");
+            }
+
+            @TestMetadata("functionHasNoStatement.kt")
+            public void testFunctionHasNoStatement() throws Exception {
+                runTest("idea/testData/quickfix/functionWithLambdaExpressionBody/removeBraces/functionHasNoStatement.kt");
+            }
+
+            @TestMetadata("funtionIsUsed.kt")
+            public void testFuntionIsUsed() throws Exception {
+                runTest("idea/testData/quickfix/functionWithLambdaExpressionBody/removeBraces/funtionIsUsed.kt");
+            }
+
+            @TestMetadata("getterHasComment.kt")
+            public void testGetterHasComment() throws Exception {
+                runTest("idea/testData/quickfix/functionWithLambdaExpressionBody/removeBraces/getterHasComment.kt");
+            }
+
+            @TestMetadata("getterHasMultiStatements.kt")
+            public void testGetterHasMultiStatements() throws Exception {
+                runTest("idea/testData/quickfix/functionWithLambdaExpressionBody/removeBraces/getterHasMultiStatements.kt");
+            }
+
+            @TestMetadata("getterHasNoStatement.kt")
+            public void testGetterHasNoStatement() throws Exception {
+                runTest("idea/testData/quickfix/functionWithLambdaExpressionBody/removeBraces/getterHasNoStatement.kt");
+            }
+
+            @TestMetadata("getterIsUsed.kt")
+            public void testGetterIsUsed() throws Exception {
+                runTest("idea/testData/quickfix/functionWithLambdaExpressionBody/removeBraces/getterIsUsed.kt");
+            }
+        }
+
+        @TestMetadata("idea/testData/quickfix/functionWithLambdaExpressionBody/wrapRun")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class WrapRun extends AbstractQuickFixTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInWrapRun() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/quickfix/functionWithLambdaExpressionBody/wrapRun"), Pattern.compile("^([\\w\\-_]+)\\.kt$"), TargetBackend.ANY, true);
+            }
+
+            @TestMetadata("funtionIsUsed.kt")
+            public void testFuntionIsUsed() throws Exception {
+                runTest("idea/testData/quickfix/functionWithLambdaExpressionBody/wrapRun/funtionIsUsed.kt");
+            }
+
+            @TestMetadata("getterIsUsed.kt")
+            public void testGetterIsUsed() throws Exception {
+                runTest("idea/testData/quickfix/functionWithLambdaExpressionBody/wrapRun/getterIsUsed.kt");
+            }
+        }
+    }
+
     @TestMetadata("idea/testData/quickfix/implement")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-17119