### PR TITLE
Minor: cleanup grammar for callSuffix and typeReference rules

### DIFF
--- a/grammar/src/expressions.grm
+++ b/grammar/src/expressions.grm
@@ -223,8 +223,7 @@ postfixUnaryOperation
   ;
 
 callSuffix
-  : typeArguments? valueArguments annotatedLambda
-  : typeArguments annotatedLambda
+  : typeArguments? (valueArguments annotatedLambda? | annotatedLambda)
   ;
 
 annotatedLambda

--- a/grammar/src/types.grm
+++ b/grammar/src/types.grm
@@ -18,7 +18,7 @@ type
 
 // If you change this, consider updating TYPE_REF_FIRST in KotlinParsing
 typeReference
-  : "(" typeReference ")"
+  : "(" type ")"
   : functionType
   : userType
   : nullableType


### PR DESCRIPTION
This makes http://kotlinlang.org/docs/reference/grammar.html closer to the actual grammar.