### PR TITLE
Implements `KAnnotatedElement.hasAnnotation()`

### DIFF
--- a/compiler/testData/codegen/box/reflection/annotations/hasAnnotation.kt
+++ b/compiler/testData/codegen/box/reflection/annotations/hasAnnotation.kt
@@ -1,0 +1,25 @@
+// IGNORE_BACKEND: JS_IR
+// IGNORE_BACKEND: JS, NATIVE
+// WITH_REFLECT
+
+import kotlin.reflect.full.hasAnnotation
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+annotation class Baz
+annotation class Far
+
+@Baz
+@Far
+class Foo
+
+class Bar
+
+fun box(): String {
+    assertFalse(Bar::class.hasAnnotation<Baz>)
+    assertFalse(Bar::class.hasAnnotation<Far>)
+
+    assertTrue(Foo::class.hasAnnotation<Baz>)
+    assertTrue(Foo::class.hasAnnotation<Far>)
+    return "OK"
+}

--- a/core/reflection.jvm/src/kotlin/reflect/full/KAnnotatedElements.kt
+++ b/core/reflection.jvm/src/kotlin/reflect/full/KAnnotatedElements.kt
@@ -26,3 +26,10 @@ import kotlin.reflect.*
 inline fun <reified T : Annotation> KAnnotatedElement.findAnnotation(): T? =
         @Suppress("UNCHECKED_CAST")
         annotations.firstOrNull { it is T } as T?
+
+/**
+ * Returns true if this element is annotated with [T], false otherwise
+ */
+@SinceKotlin("1.4")
+inline fun <reified T : Annotation> KAnnotatedElement.hasAnnotation(): Boolean =
+        findAnnotation<T>() != null


### PR DESCRIPTION
This commit fixes KT-29041, by adding a convenience method to verify if a certain `KAnnotatedElement` has an annotation or not.

I'm not sure how to add tests to this, as there are no tests for KAnnotatedElement nor there are tests for KAnnotatedElements file