### PR TITLE
KT-28641 "Remove useless cast" produces a dangling lambda ("Too many arguments" error)

### DIFF
--- a/compiler/psi/src/org/jetbrains/kotlin/psi/KtPsiUtil.java
+++ b/compiler/psi/src/org/jetbrains/kotlin/psi/KtPsiUtil.java
@@ -448,7 +448,7 @@ public class KtPsiUtil {
             }
         }
 
-        if (innerExpression instanceof KtLambdaExpression) {
+        if (innerExpression instanceof KtLambdaExpression || innerExpression.getFirstChild() instanceof KtLambdaExpression) {
             PsiElement prevSibling = PsiTreeUtil.skipWhitespacesAndCommentsBackward(currentInner);
             if (prevSibling != null && prevSibling.getText().endsWith(KtTokens.RPAR.getValue())) return true;
         }

--- a/compiler/psi/src/org/jetbrains/kotlin/psi/KtPsiUtil.java
+++ b/compiler/psi/src/org/jetbrains/kotlin/psi/KtPsiUtil.java
@@ -448,6 +448,11 @@ public class KtPsiUtil {
             }
         }
 
+        if (innerExpression instanceof KtLambdaExpression) {
+            PsiElement prevSibling = PsiTreeUtil.skipWhitespacesAndCommentsBackward(currentInner);
+            if (prevSibling != null && prevSibling.getText().endsWith(KtTokens.RPAR.getValue())) return true;
+        }
+
         if (parentElement instanceof KtCallExpression && currentInner == ((KtCallExpression) parentElement).getCalleeExpression()) {
             KtCallExpression parentCall = (KtCallExpression) parentElement;
             if (innerExpression instanceof KtSimpleNameExpression) return false;

--- a/idea/testData/intentions/removeUnnecessaryParentheses/lambda.kt
+++ b/idea/testData/intentions/removeUnnecessaryParentheses/lambda.kt
@@ -1,0 +1,8 @@
+// IS_APPLICABLE: false
+
+fun main() {
+    foo()
+    <caret>({ foo() } )
+}
+
+fun foo() {}

--- a/idea/testData/intentions/removeUnnecessaryParentheses/lambda2.kt
+++ b/idea/testData/intentions/removeUnnecessaryParentheses/lambda2.kt
@@ -1,0 +1,8 @@
+// IS_APPLICABLE: false
+
+fun main() {
+    foo()
+    <caret>({ foo() } as? () -> Unit)
+}
+
+fun foo() {}

--- a/idea/testData/intentions/removeUnnecessaryParentheses/lambda3.kt
+++ b/idea/testData/intentions/removeUnnecessaryParentheses/lambda3.kt
@@ -1,0 +1,8 @@
+// IS_APPLICABLE: false
+
+fun main() {
+    foo()
+    <caret>({ foo() }.invoke())
+}
+
+fun foo() {}

--- a/idea/testData/quickfix/expressions/removeUselessCastForLambdaInParens1.kt
+++ b/idea/testData/quickfix/expressions/removeUselessCastForLambdaInParens1.kt
@@ -1,0 +1,4 @@
+// "Remove useless cast" "true"
+fun test() {
+    ({ "" } as<caret> () -> String)
+}

--- a/idea/testData/quickfix/expressions/removeUselessCastForLambdaInParens1.kt.after
+++ b/idea/testData/quickfix/expressions/removeUselessCastForLambdaInParens1.kt.after
@@ -1,0 +1,4 @@
+// "Remove useless cast" "true"
+fun test() {
+    { "" }
+}

--- a/idea/testData/quickfix/expressions/removeUselessCastForLambdaInParens2.kt
+++ b/idea/testData/quickfix/expressions/removeUselessCastForLambdaInParens2.kt
@@ -1,0 +1,8 @@
+// "Remove useless cast" "true"
+fun foo() {}
+
+fun test() {
+    foo()
+    // comment
+    ({ "" } as<caret> () -> String)
+}

--- a/idea/testData/quickfix/expressions/removeUselessCastForLambdaInParens2.kt.after
+++ b/idea/testData/quickfix/expressions/removeUselessCastForLambdaInParens2.kt.after
@@ -1,0 +1,8 @@
+// "Remove useless cast" "true"
+fun foo() {}
+
+fun test() {
+    foo()
+    // comment
+    ({ "" })
+}

--- a/idea/testData/quickfix/expressions/removeUselessCastForLambdaInParens3.kt
+++ b/idea/testData/quickfix/expressions/removeUselessCastForLambdaInParens3.kt
@@ -1,0 +1,9 @@
+// "Remove useless cast" "true"
+class A {
+    fun foo() {}
+}
+
+fun test() {
+    A().foo()
+    ({ "" } as<caret> () -> String)
+}

--- a/idea/testData/quickfix/expressions/removeUselessCastForLambdaInParens3.kt.after
+++ b/idea/testData/quickfix/expressions/removeUselessCastForLambdaInParens3.kt.after
@@ -1,0 +1,9 @@
+// "Remove useless cast" "true"
+class A {
+    fun foo() {}
+}
+
+fun test() {
+    A().foo()
+    ({ "" })
+}

--- a/idea/testData/quickfix/expressions/removeUselessCastForLambdaInParens4.kt
+++ b/idea/testData/quickfix/expressions/removeUselessCastForLambdaInParens4.kt
@@ -1,0 +1,5 @@
+// "Remove useless cast" "true"
+fun test() {
+    class A()
+    ({ "" } as<caret> () -> String)
+}

--- a/idea/testData/quickfix/expressions/removeUselessCastForLambdaInParens4.kt.after
+++ b/idea/testData/quickfix/expressions/removeUselessCastForLambdaInParens4.kt.after
@@ -1,0 +1,5 @@
+// "Remove useless cast" "true"
+fun test() {
+    class A()
+    ({ "" })
+}

--- a/idea/testData/quickfix/expressions/removeUselessCastForLambdaInParens5.kt
+++ b/idea/testData/quickfix/expressions/removeUselessCastForLambdaInParens5.kt
@@ -1,0 +1,7 @@
+// "Remove useless cast" "true"
+open class A
+
+fun test() {
+    class B : A()
+    ({ "" } as<caret> () -> String)
+}

--- a/idea/testData/quickfix/expressions/removeUselessCastForLambdaInParens5.kt.after
+++ b/idea/testData/quickfix/expressions/removeUselessCastForLambdaInParens5.kt.after
@@ -1,0 +1,7 @@
+// "Remove useless cast" "true"
+open class A
+
+fun test() {
+    class B : A()
+    ({ "" })
+}

--- a/idea/testData/quickfix/expressions/removeUselessCastForLambdaInParens6.kt
+++ b/idea/testData/quickfix/expressions/removeUselessCastForLambdaInParens6.kt
@@ -1,0 +1,7 @@
+// "Remove useless cast" "true"
+fun foo() {}
+
+fun main() {
+    foo();
+    ({ "" } as<caret> () -> String)
+}

--- a/idea/testData/quickfix/expressions/removeUselessCastForLambdaInParens6.kt.after
+++ b/idea/testData/quickfix/expressions/removeUselessCastForLambdaInParens6.kt.after
@@ -1,0 +1,7 @@
+// "Remove useless cast" "true"
+fun foo() {}
+
+fun main() {
+    foo();
+    { "" }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -14274,6 +14274,21 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
             runTest("idea/testData/intentions/removeUnnecessaryParentheses/elvisRhsEmptyReturn.kt");
         }
 
+        @TestMetadata("lambda.kt")
+        public void testLambda() throws Exception {
+            runTest("idea/testData/intentions/removeUnnecessaryParentheses/lambda.kt");
+        }
+
+        @TestMetadata("lambda2.kt")
+        public void testLambda2() throws Exception {
+            runTest("idea/testData/intentions/removeUnnecessaryParentheses/lambda2.kt");
+        }
+
+        @TestMetadata("lambda3.kt")
+        public void testLambda3() throws Exception {
+            runTest("idea/testData/intentions/removeUnnecessaryParentheses/lambda3.kt");
+        }
+
         @TestMetadata("necessaryParentheses1.kt")
         public void testNecessaryParentheses1() throws Exception {
             runTest("idea/testData/intentions/removeUnnecessaryParentheses/necessaryParentheses1.kt");

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -6674,6 +6674,36 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
             runTest("idea/testData/quickfix/expressions/removeUselessCast.kt");
         }
 
+        @TestMetadata("removeUselessCastForLambdaInParens1.kt")
+        public void testRemoveUselessCastForLambdaInParens1() throws Exception {
+            runTest("idea/testData/quickfix/expressions/removeUselessCastForLambdaInParens1.kt");
+        }
+
+        @TestMetadata("removeUselessCastForLambdaInParens2.kt")
+        public void testRemoveUselessCastForLambdaInParens2() throws Exception {
+            runTest("idea/testData/quickfix/expressions/removeUselessCastForLambdaInParens2.kt");
+        }
+
+        @TestMetadata("removeUselessCastForLambdaInParens3.kt")
+        public void testRemoveUselessCastForLambdaInParens3() throws Exception {
+            runTest("idea/testData/quickfix/expressions/removeUselessCastForLambdaInParens3.kt");
+        }
+
+        @TestMetadata("removeUselessCastForLambdaInParens4.kt")
+        public void testRemoveUselessCastForLambdaInParens4() throws Exception {
+            runTest("idea/testData/quickfix/expressions/removeUselessCastForLambdaInParens4.kt");
+        }
+
+        @TestMetadata("removeUselessCastForLambdaInParens5.kt")
+        public void testRemoveUselessCastForLambdaInParens5() throws Exception {
+            runTest("idea/testData/quickfix/expressions/removeUselessCastForLambdaInParens5.kt");
+        }
+
+        @TestMetadata("removeUselessCastForLambdaInParens6.kt")
+        public void testRemoveUselessCastForLambdaInParens6() throws Exception {
+            runTest("idea/testData/quickfix/expressions/removeUselessCastForLambdaInParens6.kt");
+        }
+
         @TestMetadata("removeUselessCastInParens.kt")
         public void testRemoveUselessCastInParens() throws Exception {
             runTest("idea/testData/quickfix/expressions/removeUselessCastInParens.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-28641