### PR TITLE
JVM IR: simplify chains of negations in if conditions.

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLoweringPhases.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLoweringPhases.kt
@@ -211,11 +211,16 @@ private val TailrecPhase = makeJvmPhase(
     description = "Handle tailrec calls"
 )
 
-
 private val ToArrayPhase = makeJvmPhase(
     { context, file -> ToArrayLowering(context).lower(file) },
     name = "ToArray",
     description = "Handle toArray functions"
+)
+
+private val NegatedExpressionLowering = makeJvmPhase(
+    { context, file -> NegatedExpressionLowering(context).lower(file) },
+    name = "NegatedExpression",
+    description = "Handle negated expressions"
 )
 
 object IrFileEndPhase : CompilerPhase<BackendContext, IrFile> {
@@ -268,6 +273,7 @@ val jvmPhases = listOf(
 
     TailrecPhase,
     ToArrayPhase,
+    NegatedExpressionLowering,
 
     makePatchParentsPhase(3),
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/NegatedExpressionLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/NegatedExpressionLowering.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.jvm.lower
+
+import org.jetbrains.kotlin.backend.common.FileLoweringPass
+import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
+import org.jetbrains.kotlin.codegen.intrinsics.Not
+import org.jetbrains.kotlin.ir.declarations.IrFile
+import org.jetbrains.kotlin.ir.expressions.IrCall
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
+import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
+
+// TODO: This lowering is currently JvmBackend specific because there are multiple
+// definitions of the boolean 'not' operator. Once there is only the irBuiltins
+// definition this lowering could be shared with other backends.
+class NegatedExpressionLowering(val context: JvmBackendContext) : FileLoweringPass {
+
+    companion object {
+        fun isNegation(expression: IrExpression, context: JvmBackendContext) : Boolean {
+            // TODO: there should be only one representation of the 'not' operator.
+            return expression is IrCall &&
+                    (expression.symbol == context.irBuiltIns.booleanNotSymbol ||
+                            context.state.intrinsics.getIntrinsic(expression.symbol.descriptor) is Not)
+        }
+
+        fun negationArgument(call: IrCall) : IrExpression {
+            // TODO: there should be only one representation of the 'not' operator.
+            // Once there is only the IR definition the negation argument will
+            // always be a value argument and this method can be removed.
+            return call.dispatchReceiver ?: call.getValueArgument(0)!!
+        }
+    }
+
+    override fun lower(irFile: IrFile) {
+        irFile.transformChildrenVoid(object : IrElementTransformerVoid() {
+            override fun visitCall(expression: IrCall): IrExpression {
+                expression.transformChildrenVoid(this)
+                return if (isNegation(expression, context) && isNegation(negationArgument(expression), context))
+                    negationArgument(negationArgument(expression) as IrCall)
+                else
+                    expression
+            }
+        })
+    }
+
+}

--- a/compiler/testData/codegen/bytecodeText/lazyCodegen/negateVarChain.kt
+++ b/compiler/testData/codegen/bytecodeText/lazyCodegen/negateVarChain.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 val two = 2
 
 fun test2() {


### PR DESCRIPTION
Introduce lowering phase that turns !!exp -> exp for the boolean 'not' builtin. This makes sure that code such as

```
if (!!!!!booleanValue) {
    doStuff()
}
```

generates only one branch.