### PR TITLE
KT-28969 TYPE_MISMATCH in array vs non-array case: two quick fixes exist for annotation and none of them adds array literal

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixFactoryForTypeMismatchError.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixFactoryForTypeMismatchError.kt
@@ -22,6 +22,7 @@ import com.intellij.psi.util.PsiTreeUtil
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.builtins.functions.FunctionClassDescriptor
 import org.jetbrains.kotlin.builtins.getFunctionalClassKind
+import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.diagnostics.Diagnostic
 import org.jetbrains.kotlin.diagnostics.Errors
 import org.jetbrains.kotlin.diagnostics.rendering.DefaultErrorMessages
@@ -29,6 +30,7 @@ import org.jetbrains.kotlin.idea.caches.resolve.analyzeWithContent
 import org.jetbrains.kotlin.idea.caches.resolve.findModuleDescriptor
 import org.jetbrains.kotlin.idea.caches.resolve.getResolutionFacade
 import org.jetbrains.kotlin.idea.core.quickfix.QuickFixUtil
+import org.jetbrains.kotlin.idea.project.languageVersionSettings
 import org.jetbrains.kotlin.idea.util.approximateWithResolvableType
 import org.jetbrains.kotlin.idea.util.getResolutionScope
 import org.jetbrains.kotlin.name.FqName
@@ -239,6 +241,9 @@ class QuickFixFactoryForTypeMismatchError : KotlinIntentionActionsFactory() {
                 || KotlinBuiltIns.isPrimitiveArray(expectedType)
             ) {
                 actions.add(AddArrayOfTypeFix(diagnosticElement, expectedType))
+                if (diagnosticElement.languageVersionSettings.supportsFeature(LanguageFeature.ArrayLiteralsInAnnotations)) {
+                    actions.add(WrapWithArrayLiteralFix(diagnosticElement))
+                }
             }
         }
 

--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/WrapWithArrayLiteralFix.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/WrapWithArrayLiteralFix.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.idea.quickfix
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtPsiFactory
+import org.jetbrains.kotlin.psi.createExpressionByPattern
+
+class WrapWithArrayLiteralFix(expression: KtExpression) : KotlinQuickFixAction<KtExpression>(expression) {
+
+    override fun getFamilyName() = "Wrap with array literal"
+
+    override fun getText() = "Wrap with []"
+
+    override fun invoke(project: Project, editor: Editor?, file: KtFile) {
+        val element = element ?: return
+        element.replace(KtPsiFactory(project).createExpressionByPattern("[$0]", element))
+    }
+}

--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/WrapWithCollectionLiteralCallFix.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/WrapWithCollectionLiteralCallFix.kt
@@ -9,11 +9,9 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import org.jetbrains.kotlin.idea.core.replaced
 import org.jetbrains.kotlin.idea.intentions.branchedTransformations.isNullExpression
-import org.jetbrains.kotlin.psi.KtExpression
-import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.kotlin.psi.KtPsiFactory
-import org.jetbrains.kotlin.psi.createExpressionByPattern
+import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.endOffset
+import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.Variance
 import org.jetbrains.kotlin.types.typeUtil.isSubtypeOf
@@ -46,6 +44,8 @@ class WrapWithCollectionLiteralCallFix private constructor(
 
     companion object {
         fun create(expectedType: KotlinType, expressionType: KotlinType, element: KtExpression): List<WrapWithCollectionLiteralCallFix> {
+            if (element.getStrictParentOfType<KtAnnotationEntry>() != null) return emptyList()
+
             val collectionType =
                 with(ConvertCollectionFix) {
                     expectedType.getCollectionType(acceptNullableTypes = true)

--- a/idea/testData/quickfix/typeMismatch/wrapWithArrayLiteral.kt
+++ b/idea/testData/quickfix/typeMismatch/wrapWithArrayLiteral.kt
@@ -1,0 +1,6 @@
+// "Wrap with []" "true"
+
+annotation class Foo(val value: Array<String>)
+
+@Foo(value = "abc"<caret>)
+class Bar

--- a/idea/testData/quickfix/typeMismatch/wrapWithArrayLiteral.kt.after
+++ b/idea/testData/quickfix/typeMismatch/wrapWithArrayLiteral.kt.after
@@ -1,0 +1,6 @@
+// "Wrap with []" "true"
+
+annotation class Foo(val value: Array<String>)
+
+@Foo(value = ["abc"])
+class Bar

--- a/idea/testData/quickfix/typeMismatch/wrapWithCollectionLiteral/inAnnotation.kt
+++ b/idea/testData/quickfix/typeMismatch/wrapWithCollectionLiteral/inAnnotation.kt
@@ -1,0 +1,14 @@
+// "Wrap element with 'arrayOf' call" "false"
+// ERROR: Type mismatch: inferred type is String but Array<String> was expected
+// ACTION: Add arrayOf wrapper
+// ACTION: Change parameter 'value' type of primary constructor of class 'Foo' to 'String'
+// ACTION: Create test
+// ACTION: Make internal
+// ACTION: Make private
+// ACTION: To raw string literal
+// ACTION: Wrap with []
+
+annotation class Foo(val value: Array<String>)
+
+@Foo(value = "abc"<caret>)
+class Bar

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -12394,6 +12394,11 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
             runTest("idea/testData/quickfix/typeMismatch/when3.kt");
         }
 
+        @TestMetadata("wrapWithArrayLiteral.kt")
+        public void testWrapWithArrayLiteral() throws Exception {
+            runTest("idea/testData/quickfix/typeMismatch/wrapWithArrayLiteral.kt");
+        }
+
         @TestMetadata("idea/testData/quickfix/typeMismatch/casts")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -12810,6 +12810,11 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
                 KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/quickfix/typeMismatch/wrapWithCollectionLiteral"), Pattern.compile("^([\\w\\-_]+)\\.kt$"), TargetBackend.ANY, true);
             }
 
+            @TestMetadata("inAnnotation.kt")
+            public void testInAnnotation() throws Exception {
+                runTest("idea/testData/quickfix/typeMismatch/wrapWithCollectionLiteral/inAnnotation.kt");
+            }
+
             @TestMetadata("noMutableList.kt")
             public void testNoMutableList() throws Exception {
                 runTest("idea/testData/quickfix/typeMismatch/wrapWithCollectionLiteral/noMutableList.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-28969