### PR TITLE
Allow specifying isolation mode for KAPT workers

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/KaptWithoutKotlincTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/KaptWithoutKotlincTask.kt
@@ -82,7 +82,12 @@ open class KaptWithoutKotlincTask @Inject constructor(private val workerExecutor
         val kaptClasspath = kaptJars + findKotlinStdlibClasspath(project)
 
         workerExecutor.submit(KaptExecution::class.java) { config ->
-            config.isolationMode = IsolationMode.PROCESS
+            val isolationModeStr = project.findProperty("kapt.workers.isolation") as String? ?: "none"
+            config.isolationMode = when(isolationModeStr.toLowerCase()) {
+                "process" -> IsolationMode.PROCESS
+                "none" -> IsolationMode.NONE
+                else -> IsolationMode.NONE
+            }
             config.params(optionsForWorker, findToolsJar(), kaptClasspath)
             if (project.findProperty("kapt.workers.log.classloading") == "true") {
                 // for tests


### PR DESCRIPTION
There are a few isolation modes for Gradle workers. KAPT uses 2 of them.

IsolationMode.NONE is the default. It runs workers in Gradle daemon and
is more memory efficient.

IsolationMode.PROCESS forks workers into individual processes. This
keeps some resource leaking annotation processors from affecting the
rest of compilation.

Users can specify kapt.workers.isolation=process, if they need to use
some annotation processor that are known to be resource leaking.