### PR TITLE
KT-28851 'Convert parameter to receiver' adds `Array<out T>` wrapper to `vararg` parameter and drops `override` modifier in implementations

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinParameterInfo.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinParameterInfo.kt
@@ -33,6 +33,7 @@ import org.jetbrains.kotlin.psi.psiUtil.quoteIfNeeded
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.DescriptorToSourceUtils
 import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
+import org.jetbrains.kotlin.resolve.calls.components.isVararg
 import org.jetbrains.kotlin.resolve.lazy.BodyResolveMode
 import org.jetbrains.kotlin.resolve.scopes.receivers.ImplicitReceiver
 import org.jetbrains.kotlin.types.isError
@@ -153,7 +154,9 @@ class KotlinParameterInfo @JvmOverloads constructor (
         val defaultRendering = currentTypeInfo.render()
         val typeSubstitutor = inheritedCallable.typeSubstitutor ?: return defaultRendering
         val currentBaseFunction = inheritedCallable.baseFunction.currentCallableDescriptor ?: return defaultRendering
-        val parameterType = currentBaseFunction.valueParameters[parameterIndex].type
+        val parameter = currentBaseFunction.valueParameters[parameterIndex]
+        if (parameter.isVararg) return defaultRendering
+        val parameterType = parameter.type
         if (parameterType.isError) return defaultRendering
         return parameterType.renderTypeWithSubstitution(typeSubstitutor, defaultRendering, true)
     }

--- a/idea/testData/intentions/convertParameterToReceiver/hasVararg.kt
+++ b/idea/testData/intentions/convertParameterToReceiver/hasVararg.kt
@@ -1,0 +1,7 @@
+interface A {
+    fun foo(<caret>s: String, vararg args: Any)
+}
+class B : A {
+    override fun foo(s: String, vararg args: Any) {
+    }
+}

--- a/idea/testData/intentions/convertParameterToReceiver/hasVararg.kt.after
+++ b/idea/testData/intentions/convertParameterToReceiver/hasVararg.kt.after
@@ -1,0 +1,7 @@
+interface A {
+    fun String.foo(vararg args: Any)
+}
+class B : A {
+    override fun String.foo(vararg args: Any) {
+    }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -6046,6 +6046,11 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
             runTest("idea/testData/intentions/convertParameterToReceiver/functionExpressionWithThisConflict.kt");
         }
 
+        @TestMetadata("hasVararg.kt")
+        public void testHasVararg() throws Exception {
+            runTest("idea/testData/intentions/convertParameterToReceiver/hasVararg.kt");
+        }
+
         @TestMetadata("lambdaParameter.kt")
         public void testLambdaParameter() throws Exception {
             runTest("idea/testData/intentions/convertParameterToReceiver/lambdaParameter.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-28851