### PR TITLE
expose AbstractMutableList.modCount in common

### DIFF
--- a/libraries/stdlib/common/src/kotlin/collections/AbstractMutableList.kt
+++ b/libraries/stdlib/common/src/kotlin/collections/AbstractMutableList.kt
@@ -12,6 +12,7 @@ package kotlin.collections
  */
 public expect abstract class AbstractMutableList<E> : MutableList<E> {
     protected constructor()
+    protected var modCount: Int
 
     // From List
 


### PR DESCRIPTION
K/Native didn't have this before, but it does now (looking at the current source), so it is available everywhere. Access to this var is needed for implementing more complex subclasses in a modification-safe manner.