### PR TITLE
KT-18715-2: fix broken test

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/intentions/IfThenToElvisIntention.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/branchedTransformations/intentions/IfThenToElvisIntention.kt
@@ -80,7 +80,7 @@ class IfThenToElvisIntention : SelfTargetingOffsetIndependentIntention<KtIfExpre
 
             val factory = KtPsiFactory(element)
 
-            val commentSaver = CommentSaver(element, saveLineBreaks = false)
+            val commentSaver = CommentSaver(element)
 
             val elvis = runWriteAction {
                 val replacedBaseClause = ifThenToSelectData.replacedBaseClause(factory)

--- a/idea/testData/intentions/branched/ifThenToElvis/ifToElvisSwallowComments.kt.after
+++ b/idea/testData/intentions/branched/ifThenToElvis/ifToElvisSwallowComments.kt.after
@@ -1,6 +1,6 @@
 fun foo(arg: Any): Int {
     // 1
     return arg as? Int
-    // 2
-        ?: 10
+// 2
+            ?: 10
 }


### PR DESCRIPTION
- use default value of `false` for `CommentSaver`
- fixed whitespace issues on added test