### PR TITLE
Skip annotation processing when there's no AP specified

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kapt3IT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kapt3IT.kt
@@ -56,6 +56,17 @@ class Kapt3WorkersIT : Kapt3IT() {
             assertSubstringCount("Loaded com.sun.tools.javac.util.Context from", 1)
         }
     }
+
+    @Test
+    fun testKaptSkipped() {
+        val gradleVersionRequired = GradleVersionRequired.AtLeast("4.3")
+
+        val project =
+            Project("kaptSkipped", directoryPrefix = "kapt2", gradleVersionRequirement = gradleVersionRequired)
+        project.build("build") {
+            assertSuccessful()
+        }
+    }
 }
 
 open class Kapt3IT : Kapt3BaseIT() {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/kaptSkipped/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/kaptSkipped/build.gradle
@@ -1,0 +1,22 @@
+buildscript {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+    }
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    }
+}
+
+apply plugin: "java"
+apply plugin: "kotlin"
+apply plugin: "kotlin-kapt"
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/kaptSkipped/src/main/java/Referred.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/kaptSkipped/src/main/java/Referred.kt
@@ -1,0 +1,1 @@
+class Referred

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/kaptSkipped/src/main/java/Referring.java
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/kaptSkipped/src/main/java/Referring.java
@@ -1,0 +1,3 @@
+public class Referring {
+    public Referred r;
+}

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/KaptWithoutKotlincTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/KaptWithoutKotlincTask.kt
@@ -79,6 +79,10 @@ open class KaptWithoutKotlincTask @Inject constructor(private val workerExecutor
             kaptFlagsForWorker
         )
 
+        // Skip annotation processing if no annotation processors were provided.
+        if (annotationProcessorFqNames.isEmpty() && kaptClasspath.isEmpty())
+            return
+
         val kaptClasspath = kaptJars + findKotlinStdlibClasspath(project)
 
         workerExecutor.submit(KaptExecution::class.java) { config ->


### PR DESCRIPTION
This also fixes KT-29302 where stub generation is skipped while the
subsequent annotation processing phase anticipates the generated stubs.

This patch addresses cases where kapt.use.worker.api=true. The cases
where kapt.use.worker.api=false are handled in the same place of stub
generation.