### PR TITLE
KT-29238 Non-canonical modifiers order inspection incorrectly includes annotations into range

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/SortModifiersInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/SortModifiersInspection.kt
@@ -7,12 +7,15 @@ package org.jetbrains.kotlin.idea.inspections
 
 import com.intellij.codeInspection.*
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElementVisitor
 import org.jetbrains.kotlin.lexer.KtModifierKeywordToken
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.addRemoveModifier.sortModifiers
 import org.jetbrains.kotlin.psi.psiUtil.allChildren
+import org.jetbrains.kotlin.psi.psiUtil.endOffset
+import org.jetbrains.kotlin.psi.psiUtil.startOffset
 
 class SortModifiersInspection : AbstractKotlinInspection(), CleanupLocalInspectionTool {
 
@@ -36,6 +39,8 @@ class SortModifiersInspection : AbstractKotlinInspection(), CleanupLocalInspecti
                 if (modifiers.isEmpty()) return
 
                 val startElement = modifierElements.firstOrNull { it.node.elementType is KtModifierKeywordToken } ?: return
+                val endElement = modifierElements.lastOrNull { it.node.elementType is KtModifierKeywordToken } ?: return
+                val rangeInElement = TextRange(startElement.startOffset, endElement.endOffset).shiftLeft(list.startOffset)
 
                 val sortedModifiers = sortModifiers(modifiers)
                 if (modifiers == sortedModifiers && !modifiersBeforeAnnotations) return
@@ -46,8 +51,8 @@ class SortModifiersInspection : AbstractKotlinInspection(), CleanupLocalInspecti
                     "Non-canonical modifiers order"
 
                 val descriptor = holder.manager.createProblemDescriptor(
-                    startElement,
                     list,
+                    rangeInElement,
                     message,
                     ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
                     isOnTheFly,

--- a/idea/testData/inspectionsLocal/sortModifiers/annotatedBefore2.kt
+++ b/idea/testData/inspectionsLocal/sortModifiers/annotatedBefore2.kt
@@ -1,0 +1,5 @@
+// PROBLEM: none
+annotation class Ann
+
+<caret>@Ann
+abstract internal class Test

--- a/idea/testData/inspectionsLocal/sortModifiers/annotation2.kt
+++ b/idea/testData/inspectionsLocal/sortModifiers/annotation2.kt
@@ -1,0 +1,4 @@
+// PROBLEM: none
+annotation class Test
+
+internal abstract <caret>@Test /* this is a test */ class MyTest

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -7128,9 +7128,19 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
             runTest("idea/testData/inspectionsLocal/sortModifiers/annotatedBefore.kt");
         }
 
+        @TestMetadata("annotatedBefore2.kt")
+        public void testAnnotatedBefore2() throws Exception {
+            runTest("idea/testData/inspectionsLocal/sortModifiers/annotatedBefore2.kt");
+        }
+
         @TestMetadata("annotation.kt")
         public void testAnnotation() throws Exception {
             runTest("idea/testData/inspectionsLocal/sortModifiers/annotation.kt");
+        }
+
+        @TestMetadata("annotation2.kt")
+        public void testAnnotation2() throws Exception {
+            runTest("idea/testData/inspectionsLocal/sortModifiers/annotation2.kt");
         }
 
         @TestMetadata("annotationGroup.kt")


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-29238