### PR TITLE
KT-29469 False positive in "Boolean literal argument without parameter name" inspection for varargs parameters

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/BooleanLiteralArgumentInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/BooleanLiteralArgumentInspection.kt
@@ -16,7 +16,6 @@ import com.intellij.openapi.project.Project
 import org.jetbrains.kotlin.KtNodeTypes
 import org.jetbrains.kotlin.diagnostics.Severity
 import org.jetbrains.kotlin.idea.caches.resolve.analyze
-import org.jetbrains.kotlin.idea.caches.resolve.resolveToCall
 import org.jetbrains.kotlin.idea.intentions.AddNameToArgumentIntention
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtConstantExpression
@@ -38,7 +37,7 @@ class BooleanLiteralArgumentInspection(
             if (valueArguments.takeLastWhile { it != argument }.any { !it.isNamed() }) return
 
             if (argumentExpression.analyze().diagnostics.forElement(argumentExpression).any { it.severity == Severity.ERROR }) return
-            if (call.resolveToCall()?.resultingDescriptor?.hasStableParameterNames() != true) return
+            if (AddNameToArgumentIntention.detectNameToAdd(argument) == null) return
 
             val hasPreviousUnnamedBoolean = valueArguments.asSequence().windowed(size = 2, step = 1).any { (prev, next) ->
                 next == argument && !prev.isNamed() &&

--- a/idea/src/org/jetbrains/kotlin/idea/intentions/AddNameToArgumentIntention.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/AddNameToArgumentIntention.kt
@@ -68,7 +68,7 @@ class AddNameToArgumentIntention : SelfTargetingIntention<KtValueArgument>(
             return true
         }
 
-        private fun detectNameToAdd(argument: KtValueArgument): Name? {
+        fun detectNameToAdd(argument: KtValueArgument): Name? {
             if (argument.isNamed()) return null
             if (argument is KtLambdaArgument) return null
 

--- a/idea/testData/inspectionsLocal/booleanLiteralArgument/vararg.kt
+++ b/idea/testData/inspectionsLocal/booleanLiteralArgument/vararg.kt
@@ -1,0 +1,6 @@
+// PROBLEM: none
+fun foo(vararg b: Boolean) {}
+
+fun test() {
+    foo(true, true, true<caret>)
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -113,6 +113,11 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
         public void testJavaMethod() throws Exception {
             runTest("idea/testData/inspectionsLocal/booleanLiteralArgument/javaMethod.kt");
         }
+
+        @TestMetadata("vararg.kt")
+        public void testVararg() throws Exception {
+            runTest("idea/testData/inspectionsLocal/booleanLiteralArgument/vararg.kt");
+        }
     }
 
     @TestMetadata("idea/testData/inspectionsLocal/branched")


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-29469