### PR TITLE
Stop using System.currentTimeMillis for durations

### DIFF
--- a/libraries/stdlib/jvm/src/kotlin/system/Timing.kt
+++ b/libraries/stdlib/jvm/src/kotlin/system/Timing.kt
@@ -9,11 +9,8 @@ package kotlin.system
 /**
  * Executes the given [block] and returns elapsed time in milliseconds.
  */
-public inline fun measureTimeMillis(block: () -> Unit): Long {
-    val start = System.currentTimeMillis()
-    block()
-    return System.currentTimeMillis() - start
-}
+public inline fun measureTimeMillis(block: () -> Unit): Long =
+    measureNanoTime(block) / 1_000_000
 
 /**
  * Executes the given [block] and returns elapsed time in nanoseconds.


### PR DESCRIPTION
`measureTimeMillis` currently uses `Sytem.currentTimeMillis()` to measure elapsed time which is unsafe seeing as it is based on the system's clock which can be changed by the system at any time (for example by NTP or the user).

The new implementation would use `measureNanoTime` internally and calculate the number of milliseconds from that.