### PR TITLE
KT-29494 Don't report BooleanLiteralArgumentInspection in batch (offline) mode with INFORMATION severity

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/BooleanLiteralArgumentInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/BooleanLiteralArgumentInspection.kt
@@ -48,9 +48,10 @@ class BooleanLiteralArgumentInspection(
                 fixes += AddNamesToLastBooleanArgumentsFix()
             }
             fixes += IntentionWrapper(AddNameToArgumentIntention(), argument.containingKtFile)
-            holder.registerProblem(
+            holder.registerProblemWithoutOfflineInformation(
                 argument,
                 "Boolean literal argument without parameter name",
+                isOnTheFly,
                 if (reportSingle || hasPreviousUnnamedBoolean) GENERIC_ERROR_OR_WARNING else INFORMATION,
                 *fixes.toTypedArray()
             )


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-29494