### PR TITLE
JVM_IR: Fix codegeneration for missing branches.

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -33,6 +33,7 @@ import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.symbols.IrSymbol
+import org.jetbrains.kotlin.ir.types.isNothing
 import org.jetbrains.kotlin.ir.types.toKotlinType
 import org.jetbrains.kotlin.ir.util.dump
 import org.jetbrains.kotlin.ir.util.isNullConst
@@ -240,6 +241,9 @@ class ExpressionCodegen(
     }
 
     override fun visitContainerExpression(expression: IrContainerExpression, data: BlockInfo): StackValue {
+        // Empty blocks with nothing type should not generate a value on the stack. They
+        // arise for if statements with missing branches such as: if (expr) else 42
+        if (expression.statements.size == 0 && expression.type.isNothing()) return none()
         val result = expression.statements.fold(none()) { _, exp ->
             //coerceNotToUnit(r.type, Type.VOID_TYPE)
             exp.accept(this, data)

--- a/compiler/testData/codegen/bytecodeText/boxingOptimization/maxMinBy.kt
+++ b/compiler/testData/codegen/bytecodeText/boxingOptimization/maxMinBy.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 // FILE: list.kt
 
 val intList = listOf(1, 2, 3)

--- a/compiler/testData/lineNumber/if.kt
+++ b/compiler/testData/lineNumber/if.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 fun foo() {
     if (test.lineNumber() > 0) {
         test.lineNumber()


### PR DESCRIPTION
This used to generate an ACONST_NULL instruction leading to incorrect
stack height for code such as:

```
if (condition) else 32
```