### PR TITLE
JVM_IR: do not generate line number info for temporary loads.

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -422,7 +422,10 @@ class ExpressionCodegen(
     }
 
     override fun visitGetValue(expression: IrGetValue, data: BlockInfo): StackValue {
-        expression.markLineNumber(startOffset = true)
+        // Do not generate line number information for loads from compiler-generated
+        // temporary variables. They do not correspond to variable loads in user code.
+        if (expression.symbol.owner.origin != IrDeclarationOrigin.IR_TEMPORARY_VARIABLE)
+            expression.markLineNumber(startOffset = true)
         return generateLocal(expression.symbol, expression.asmType)
     }
 

--- a/compiler/testData/codegen/bytecodeText/lineNumbers/when.kt
+++ b/compiler/testData/codegen/bytecodeText/lineNumbers/when.kt
@@ -6,5 +6,3 @@ fun foo() {
     }
 }
 // 1 LINENUMBER 3
-// Adding ignore flags below the test since the test relies on line numbers.
-// IGNORE_BACKEND: JVM_IR


### PR DESCRIPTION
Loads from compiler-introduces temporary variables to do not
correspond to loads in user code.