### PR TITLE
KT-29085 False positive "Class member can have 'private' visibility" for a `const val` used in a public inline function

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/MemberVisibilityCanBePrivateInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/MemberVisibilityCanBePrivateInspection.kt
@@ -133,7 +133,7 @@ class MemberVisibilityCanBePrivateInspection : AbstractKotlinInspection() {
             val function = usage.getParentOfTypesAndPredicate<KtDeclarationWithBody>(
                 true, KtNamedFunction::class.java, KtPropertyAccessor::class.java
             ) { true }
-            val insideInlineFun = function?.let { it.hasModifier(KtTokens.INLINE_KEYWORD) && !function.isPrivate() } ?: false
+            val insideInlineFun = function.insideInline() || (function as? KtPropertyAccessor)?.property.insideInline()
             if (insideInlineFun) {
                 otherUsageFound = true
                 false
@@ -144,6 +144,8 @@ class MemberVisibilityCanBePrivateInspection : AbstractKotlinInspection() {
         })
         return inClassUsageFound && !otherUsageFound
     }
+
+    private fun KtModifierListOwner?.insideInline() = this?.let { it.hasModifier(KtTokens.INLINE_KEYWORD) && !it.isPrivate() } ?: false
 
     private fun registerProblem(holder: ProblemsHolder, declaration: KtDeclaration) {
         val modifierListOwner = declaration.getParentOfType<KtModifierListOwner>(false) ?: return

--- a/idea/testData/inspections/memberVisibilityCanBePrivate/inline.kt
+++ b/idea/testData/inspections/memberVisibilityCanBePrivate/inline.kt
@@ -18,7 +18,12 @@ object TT {
     val x: String
         inline get() = baz
 
+    inline val y: String
+        get() = qux
+
     fun bar(s: String) = s
 
     val baz = ""
+
+    val qux = ""
 }


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-29085