### PR TITLE
KT-29556 "Remove redundant 'let' call" doesn't rename parameter with convention `invoke` call

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/intentions/ReplaceSingleLineLetIntention.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/ReplaceSingleLineLetIntention.kt
@@ -28,6 +28,7 @@ import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
 import org.jetbrains.kotlin.psi.psiUtil.getQualifiedExpressionForSelector
 import org.jetbrains.kotlin.psi.psiUtil.startOffset
 import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.bindingContextUtil.getReferenceTargets
 import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
 import org.jetbrains.kotlin.resolve.lazy.BodyResolveMode
 
@@ -200,7 +201,12 @@ class ReplaceSingleLineLetIntention : SelfTargetingOffsetIndependentIntention<Kt
             parameterDescriptor.destructuringVariables.associate { it.name to it }
         else
             mapOf(parameterDescriptor.name to parameterDescriptor)
-        return callExpression.valueArguments.flatMap { arg ->
+
+        val callee = (callExpression.calleeExpression as? KtNameReferenceExpression)?.let {
+            val descriptor = variableDescriptorByName[it.getReferencedNameAsName()]
+            if (descriptor != null && it.getReferenceTargets(context).singleOrNull() == descriptor) listOf(it) else null
+        } ?: emptyList()
+        return callee + callExpression.valueArguments.flatMap { arg ->
             arg.collectDescendantsOfType<KtNameReferenceExpression>().filter {
                 val descriptor = variableDescriptorByName[it.getReferencedNameAsName()]
                 descriptor != null && it.getResolvedCall(context)?.resultingDescriptor == descriptor

--- a/idea/testData/intentions/replaceSingleLineLetIntention/invokeCall.kt
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/invokeCall.kt
@@ -1,0 +1,8 @@
+// WITH_RUNTIME
+class A {
+    operator fun invoke() {}
+}
+
+fun foo(a: A) {
+    a.<caret>let { it() }
+}

--- a/idea/testData/intentions/replaceSingleLineLetIntention/invokeCall.kt.after
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/invokeCall.kt.after
@@ -1,0 +1,8 @@
+// WITH_RUNTIME
+class A {
+    operator fun invoke() {}
+}
+
+fun foo(a: A) {
+    a()
+}

--- a/idea/testData/intentions/replaceSingleLineLetIntention/invokeCall2.kt
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/invokeCall2.kt
@@ -1,0 +1,8 @@
+// WITH_RUNTIME
+class A {
+    operator fun invoke() {}
+}
+
+fun foo(a: A) {
+    a.<caret>let { b -> b() }
+}

--- a/idea/testData/intentions/replaceSingleLineLetIntention/invokeCall2.kt.after
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/invokeCall2.kt.after
@@ -1,0 +1,8 @@
+// WITH_RUNTIME
+class A {
+    operator fun invoke() {}
+}
+
+fun foo(a: A) {
+    a()
+}

--- a/idea/testData/intentions/replaceSingleLineLetIntention/invokeCall3.kt
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/invokeCall3.kt
@@ -1,0 +1,8 @@
+// WITH_RUNTIME
+class A {
+    operator fun invoke() {}
+}
+
+fun foo(a: A) {
+    a.<caret>let { b -> b.invoke() }
+}

--- a/idea/testData/intentions/replaceSingleLineLetIntention/invokeCall3.kt.after
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/invokeCall3.kt.after
@@ -1,0 +1,8 @@
+// WITH_RUNTIME
+class A {
+    operator fun invoke() {}
+}
+
+fun foo(a: A) {
+    a.invoke()
+}

--- a/idea/testData/intentions/replaceSingleLineLetIntention/invokeCall4.kt
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/invokeCall4.kt
@@ -1,0 +1,9 @@
+// IS_APPLICABLE: false
+// WITH_RUNTIME
+class A {
+    operator fun invoke(a: A, i: Int) {}
+}
+
+fun foo(a: A) {
+    a.<caret>let { it(it, 1) }
+}

--- a/idea/testData/intentions/replaceSingleLineLetIntention/invokeCall5.kt
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/invokeCall5.kt
@@ -1,0 +1,9 @@
+// IS_APPLICABLE: false
+// WITH_RUNTIME
+class A {
+    operator fun invoke() {}
+}
+
+fun foo(a: A) {
+    (1 to a).<caret>let { (i, b) -> b() }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -14971,6 +14971,31 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
             runTest("idea/testData/intentions/replaceSingleLineLetIntention/inWithRangeMultipleParam.kt");
         }
 
+        @TestMetadata("invokeCall.kt")
+        public void testInvokeCall() throws Exception {
+            runTest("idea/testData/intentions/replaceSingleLineLetIntention/invokeCall.kt");
+        }
+
+        @TestMetadata("invokeCall2.kt")
+        public void testInvokeCall2() throws Exception {
+            runTest("idea/testData/intentions/replaceSingleLineLetIntention/invokeCall2.kt");
+        }
+
+        @TestMetadata("invokeCall3.kt")
+        public void testInvokeCall3() throws Exception {
+            runTest("idea/testData/intentions/replaceSingleLineLetIntention/invokeCall3.kt");
+        }
+
+        @TestMetadata("invokeCall4.kt")
+        public void testInvokeCall4() throws Exception {
+            runTest("idea/testData/intentions/replaceSingleLineLetIntention/invokeCall4.kt");
+        }
+
+        @TestMetadata("invokeCall5.kt")
+        public void testInvokeCall5() throws Exception {
+            runTest("idea/testData/intentions/replaceSingleLineLetIntention/invokeCall5.kt");
+        }
+
         @TestMetadata("lambdaWithBinaryExpression.kt")
         public void testLambdaWithBinaryExpression() throws Exception {
             runTest("idea/testData/intentions/replaceSingleLineLetIntention/lambdaWithBinaryExpression.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-29556