### PR TITLE
KT-28596 "Can be replaced with binary operator" shouldn't be suggested when receiver or argument is floating point type

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/conventionNameCalls/ReplaceCallWithBinaryOperatorInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/conventionNameCalls/ReplaceCallWithBinaryOperatorInspection.kt
@@ -187,12 +187,14 @@ class ReplaceCallWithBinaryOperatorInspection : AbstractApplicabilityBasedInspec
     private fun KtDotQualifiedExpression.isFloatingPointNumberEquals(): Boolean {
         val resolvedCall = resolveToCall() ?: return false
         val context = analyze(BodyResolveMode.PARTIAL)
+        val declarationDescriptor = containingDeclarationForPseudocode?.resolveToDescriptorIfAny()
         val dataFlowValueFactory = getResolutionFacade().getFrontendService(DataFlowValueFactory::class.java)
+        val defaultType: (KotlinType, Set<KotlinType>) -> KotlinType = { givenType, stableTypes -> stableTypes.firstOrNull() ?: givenType }
         val receiverType = resolvedCall.getReceiverExpression()?.getKotlinTypeWithPossibleSmartCastToFP(
-            context, containingDeclarationForPseudocode?.resolveToDescriptorIfAny(), languageVersionSettings, dataFlowValueFactory
+            context, declarationDescriptor, languageVersionSettings, dataFlowValueFactory, defaultType
         ) ?: return false
         val argumentType = resolvedCall.getFirstArgumentExpression()?.getKotlinTypeWithPossibleSmartCastToFP(
-            context, containingDeclarationForPseudocode?.resolveToDescriptorIfAny(), languageVersionSettings, dataFlowValueFactory
+            context, declarationDescriptor, languageVersionSettings, dataFlowValueFactory, defaultType
         ) ?: return false
         return receiverType.isFpType() && argumentType.isNumericType() ||
                 argumentType.isFpType() && receiverType.isNumericType()

--- a/idea/testData/inspectionsLocal/conventionNameCalls/replaceCallWithBinaryOperator/equalsDoubleSmartCast2.kt
+++ b/idea/testData/inspectionsLocal/conventionNameCalls/replaceCallWithBinaryOperator/equalsDoubleSmartCast2.kt
@@ -1,0 +1,4 @@
+// FIX: Replace total order equality with IEEE 754 equality
+
+fun test(a: Any, b: Any) =
+    a is Double && b is Int && a.<caret>equals(b)

--- a/idea/testData/inspectionsLocal/conventionNameCalls/replaceCallWithBinaryOperator/equalsDoubleSmartCast2.kt.after
+++ b/idea/testData/inspectionsLocal/conventionNameCalls/replaceCallWithBinaryOperator/equalsDoubleSmartCast2.kt.after
@@ -1,0 +1,4 @@
+// FIX: Replace total order equality with IEEE 754 equality
+
+fun test(a: Any, b: Any) =
+    a is Double && b is Int && a == b

--- a/idea/testData/inspectionsLocal/conventionNameCalls/replaceCallWithBinaryOperator/equalsDoubleSmartCast3.kt
+++ b/idea/testData/inspectionsLocal/conventionNameCalls/replaceCallWithBinaryOperator/equalsDoubleSmartCast3.kt
@@ -1,0 +1,4 @@
+// FIX: Replace total order equality with IEEE 754 equality
+
+fun test(a: Any, b: Any) =
+    a is Int && b is Double && a.<caret>equals(b)

--- a/idea/testData/inspectionsLocal/conventionNameCalls/replaceCallWithBinaryOperator/equalsDoubleSmartCast3.kt.after
+++ b/idea/testData/inspectionsLocal/conventionNameCalls/replaceCallWithBinaryOperator/equalsDoubleSmartCast3.kt.after
@@ -1,0 +1,4 @@
+// FIX: Replace total order equality with IEEE 754 equality
+
+fun test(a: Any, b: Any) =
+    a is Int && b is Double && a == b

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -1679,6 +1679,16 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
                 runTest("idea/testData/inspectionsLocal/conventionNameCalls/replaceCallWithBinaryOperator/equalsDoubleSmartCast.kt");
             }
 
+            @TestMetadata("equalsDoubleSmartCast2.kt")
+            public void testEqualsDoubleSmartCast2() throws Exception {
+                runTest("idea/testData/inspectionsLocal/conventionNameCalls/replaceCallWithBinaryOperator/equalsDoubleSmartCast2.kt");
+            }
+
+            @TestMetadata("equalsDoubleSmartCast3.kt")
+            public void testEqualsDoubleSmartCast3() throws Exception {
+                runTest("idea/testData/inspectionsLocal/conventionNameCalls/replaceCallWithBinaryOperator/equalsDoubleSmartCast3.kt");
+            }
+
             @TestMetadata("equalsDoubleSmartCastFromGeneric.kt")
             public void testEqualsDoubleSmartCastFromGeneric() throws Exception {
                 runTest("idea/testData/inspectionsLocal/conventionNameCalls/replaceCallWithBinaryOperator/equalsDoubleSmartCastFromGeneric.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-28596