### PR TITLE
Implement constant folding in the IR backend for JVM

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
@@ -102,6 +102,7 @@ internal val jvmPhases = namedIrFilePhase(
             tailrecPhase then
             toArrayPhase then
             jvmTypeOperatorLoweringPhase then
+            foldConstantLoweringPhase then
             flattenStringConcatenationPhase then
             jvmBuiltinOptimizationLoweringPhase then
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/FoldConstantLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/FoldConstantLowering.kt
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2010-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.jvm.lower
+
+import org.jetbrains.kotlin.backend.common.FileLoweringPass
+import org.jetbrains.kotlin.backend.common.phaser.makeIrFilePhase
+import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
+import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
+import org.jetbrains.kotlin.ir.declarations.IrFile
+import org.jetbrains.kotlin.ir.descriptors.IrBuiltIns
+import org.jetbrains.kotlin.ir.expressions.IrCall
+import org.jetbrains.kotlin.ir.expressions.IrConst
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.impl.IrConstImpl
+import org.jetbrains.kotlin.ir.types.*
+import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
+import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
+import org.jetbrains.kotlin.resolve.constants.evaluate.evaluateBinary
+import org.jetbrains.kotlin.resolve.constants.evaluate.evaluateUnary
+
+internal val foldConstantLoweringPhase = makeIrFilePhase(
+    ::FoldConstantLowering,
+    name = "FoldConstantLowering",
+    description = "Constant Folding"
+)
+
+/**
+ * A pass to fold constant expressions of most common types.
+ *
+ * For example, the expression "O" + 'K' + (1.toLong() + 2.0) will be folded to "OK3.0" at compile time.
+ *
+ * TODO: constant fields (e.g. Double.NaN)
+ */
+class FoldConstantLowering(private val context: JvmBackendContext) : IrElementTransformerVoid(), FileLoweringPass {
+
+    /**
+     * ID of an unary operator / method.
+     *
+     * An unary operator / method can be identified by its operand type (in full qualified name) and its name.
+     */
+    private data class UnaryOp(
+        val operandType: String,
+        val operatorName: String
+    )
+
+    /**
+     * ID of an binary operator / method.
+     *
+     * An binary operator / method can be identified by its operand types (in full qualified names) and its name.
+     */
+    private data class BinaryOp(
+        val lhsType: String,
+        val rhsType: String,
+        val operatorName: String
+    )
+
+    private data class PrimitiveType<T>(val name: String)
+
+    companion object {
+        private val BYTE = PrimitiveType<Byte>("Byte")
+        private val SHORT = PrimitiveType<Short>("Short")
+        private val INT = PrimitiveType<Int>("Int")
+        private val LONG = PrimitiveType<Long>("Long")
+        private val DOUBLE = PrimitiveType<Double>("Double")
+        private val FLOAT = PrimitiveType<Float>("Float")
+        private val CHAR = PrimitiveType<Char>("Char")
+        private val BOOLEAN = PrimitiveType<Boolean>("Boolean")
+        private val STRING = PrimitiveType<String>("String")
+
+        private val UNARY_OP_TO_EVALUATOR = HashMap<UnaryOp, Function1<Any?, Any>>()
+        private val BINARY_OP_TO_EVALUATOR = HashMap<BinaryOp, Function2<Any?, Any?, Any>>()
+
+        @Suppress("UNCHECKED_CAST")
+        private fun <T> registerBuiltinUnaryOp(operandType: PrimitiveType<T>, operatorName: String, f: (T) -> Any) {
+            UNARY_OP_TO_EVALUATOR[UnaryOp(operandType.name, operatorName)] = f as Function1<Any?, Any>
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        private fun <T> registerBuiltinBinaryOp(operandType: PrimitiveType<T>, operatorName: String, f: (T, T) -> Any) {
+            BINARY_OP_TO_EVALUATOR[BinaryOp(operandType.name, operandType.name, operatorName)] = f as Function2<Any?, Any?, Any>
+        }
+
+        init {
+            // IrBuiltins
+            registerBuiltinUnaryOp(BOOLEAN, IrBuiltIns.OperatorNames.NOT) { !it }
+
+            registerBuiltinBinaryOp(DOUBLE, IrBuiltIns.OperatorNames.LESS) { a, b -> a < b }
+            registerBuiltinBinaryOp(DOUBLE, IrBuiltIns.OperatorNames.LESS_OR_EQUAL) { a, b -> a <= b }
+            registerBuiltinBinaryOp(DOUBLE, IrBuiltIns.OperatorNames.GREATER) { a, b -> a > b }
+            registerBuiltinBinaryOp(DOUBLE, IrBuiltIns.OperatorNames.GREATER_OR_EQUAL) { a, b -> a >= b }
+            registerBuiltinBinaryOp(DOUBLE, IrBuiltIns.OperatorNames.IEEE754_EQUALS) { a, b -> a == b }
+
+            registerBuiltinBinaryOp(FLOAT, IrBuiltIns.OperatorNames.LESS) { a, b -> a < b }
+            registerBuiltinBinaryOp(FLOAT, IrBuiltIns.OperatorNames.LESS_OR_EQUAL) { a, b -> a <= b }
+            registerBuiltinBinaryOp(FLOAT, IrBuiltIns.OperatorNames.GREATER) { a, b -> a > b }
+            registerBuiltinBinaryOp(FLOAT, IrBuiltIns.OperatorNames.GREATER_OR_EQUAL) { a, b -> a >= b }
+            registerBuiltinBinaryOp(FLOAT, IrBuiltIns.OperatorNames.IEEE754_EQUALS) { a, b -> a == b }
+
+            registerBuiltinBinaryOp(INT, IrBuiltIns.OperatorNames.LESS) { a, b -> a < b }
+            registerBuiltinBinaryOp(INT, IrBuiltIns.OperatorNames.LESS_OR_EQUAL) { a, b -> a <= b }
+            registerBuiltinBinaryOp(INT, IrBuiltIns.OperatorNames.GREATER) { a, b -> a > b }
+            registerBuiltinBinaryOp(INT, IrBuiltIns.OperatorNames.GREATER_OR_EQUAL) { a, b -> a >= b }
+            registerBuiltinBinaryOp(INT, IrBuiltIns.OperatorNames.EQEQ) { a, b -> a == b }
+
+            registerBuiltinBinaryOp(LONG, IrBuiltIns.OperatorNames.LESS) { a, b -> a < b }
+            registerBuiltinBinaryOp(LONG, IrBuiltIns.OperatorNames.LESS_OR_EQUAL) { a, b -> a <= b }
+            registerBuiltinBinaryOp(LONG, IrBuiltIns.OperatorNames.GREATER) { a, b -> a > b }
+            registerBuiltinBinaryOp(LONG, IrBuiltIns.OperatorNames.GREATER_OR_EQUAL) { a, b -> a >= b }
+            registerBuiltinBinaryOp(LONG, IrBuiltIns.OperatorNames.EQEQ) { a, b -> a == b }
+        }
+    }
+
+    private fun buildIrConstant(call: IrCall, v: Any): IrExpression {
+        return when {
+            call.type.isInt() -> IrConstImpl.int(call.startOffset, call.endOffset, call.type, v as Int)
+            call.type.isChar() -> IrConstImpl.char(call.startOffset, call.endOffset, call.type, v as Char)
+            call.type.isBoolean() -> IrConstImpl.boolean(call.startOffset, call.endOffset, call.type, v as Boolean)
+            call.type.isByte() -> IrConstImpl.byte(call.startOffset, call.endOffset, call.type, v as Byte)
+            call.type.isShort() -> IrConstImpl.short(call.startOffset, call.endOffset, call.type, v as Short)
+            call.type.isLong() -> IrConstImpl.long(call.startOffset, call.endOffset, call.type, v as Long)
+            call.type.isDouble() -> IrConstImpl.double(call.startOffset, call.endOffset, call.type, v as Double)
+            call.type.isFloat() -> IrConstImpl.float(call.startOffset, call.endOffset, call.type, v as Float)
+            call.type.isString() -> IrConstImpl.string(call.startOffset, call.endOffset, call.type, v as String)
+            else -> throw IllegalArgumentException("Unexpected IrCall return type")
+        }
+    }
+
+    private fun tryFoldingUnaryOps(call: IrCall): IrExpression {
+        val operand = call.dispatchReceiver as? IrConst<*> ?: return call
+        val evaluated = evaluateUnary(
+            call.symbol.owner.name.toString(),
+            operand.kind.toString(),
+            operand.value!!
+        ) ?: return call
+        return buildIrConstant(call, evaluated)
+    }
+
+    private fun tryFoldingBuiltinUnaryOps(call: IrCall): IrExpression {
+        if (call.symbol.owner.origin != IrDeclarationOrigin.IR_BUILTINS_STUB)
+            return call
+
+        val operand = call.getValueArgument(0) as? IrConst<*> ?: return call
+        val evaluator = UNARY_OP_TO_EVALUATOR[UnaryOp(operand.kind.toString(), call.symbol.owner.name.toString())] ?: return call
+
+        return buildIrConstant(call, evaluator(operand.value!!))
+    }
+
+    private fun tryFoldingBinaryOps(call: IrCall): IrExpression {
+        val lhs = call.dispatchReceiver as? IrConst<*> ?: return call
+        val rhs = call.getValueArgument(0) as? IrConst<*> ?: return call
+
+        val evaluated = try {
+            fun String.toNonNullable() = if (this.endsWith('?')) this.dropLast(1) else this
+            evaluateBinary(
+                call.symbol.owner.name.toString(),
+                lhs.kind.toString(),
+                lhs.value!!,
+                // 1. Although some operators have nullable parameters, evaluators deals with non-nullable types only.
+                //    The passed parameters are guaranteed to be non-null, since they are from IrConst.
+                // 2. The operators are registered with prototype as if virtual member functions. They are identified by
+                //    actual_receiver_type.operator_name(parameter_type_in_prototype).
+                call.symbol.owner.valueParameters[0].type.toKotlinType().toString().toNonNullable(),
+                rhs.value!!
+            ) ?: return call
+        } catch (e: Exception) {
+            // Don't cast a runtime exception into compile time. E.g., division by zero.
+            return call
+        }
+
+        return buildIrConstant(call, evaluated)
+    }
+
+    private fun tryFoldingBuiltinBinaryOps(call: IrCall): IrExpression {
+        // Make sure that this is a IrBuiltIn
+        if (call.symbol.owner.origin != IrDeclarationOrigin.IR_BUILTINS_STUB)
+            return call
+
+        val lhs = call.getValueArgument(0) as? IrConst<*> ?: return call
+        val rhs = call.getValueArgument(1) as? IrConst<*> ?: return call
+
+        val evaluated = try {
+            val evaluator =
+                BINARY_OP_TO_EVALUATOR[BinaryOp(lhs.kind.toString(), rhs.kind.toString(), call.symbol.owner.name.toString())] ?: return call
+            evaluator(lhs.value!!, rhs.value!!)
+        } catch (e: Exception) {
+            return call
+        }
+
+        return buildIrConstant(call, evaluated)
+    }
+
+    override fun lower(irFile: IrFile) {
+        irFile.transformChildrenVoid(object : IrElementTransformerVoid() {
+            override fun visitCall(expression: IrCall): IrExpression {
+                expression.transformChildrenVoid(this)
+
+                return when {
+                    expression.extensionReceiver != null -> expression
+                    expression.dispatchReceiver != null && expression.valueArgumentsCount == 0 -> tryFoldingUnaryOps(expression)
+                    expression.dispatchReceiver != null && expression.valueArgumentsCount == 1 -> tryFoldingBinaryOps(expression)
+                    expression.dispatchReceiver == null && expression.valueArgumentsCount == 1 -> tryFoldingBuiltinUnaryOps(expression)
+                    expression.dispatchReceiver == null && expression.valueArgumentsCount == 2 -> tryFoldingBuiltinBinaryOps(expression)
+                    else -> expression
+                }
+            }
+        })
+    }
+}

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/descriptors/IrBuiltIns.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/descriptors/IrBuiltIns.kt
@@ -180,24 +180,24 @@ class IrBuiltIns(
     val primitiveTypesWithComparisons = listOf(int, long, float, double)
     val primitiveFloatingPointTypes = listOf(float, double)
 
-    val lessFunByOperandType = primitiveTypesWithComparisons.defineComparisonOperatorForEachType("less")
-    val lessOrEqualFunByOperandType = primitiveTypesWithComparisons.defineComparisonOperatorForEachType("lessOrEqual")
-    val greaterOrEqualFunByOperandType = primitiveTypesWithComparisons.defineComparisonOperatorForEachType("greaterOrEqual")
-    val greaterFunByOperandType = primitiveTypesWithComparisons.defineComparisonOperatorForEachType("greater")
+    val lessFunByOperandType = primitiveTypesWithComparisons.defineComparisonOperatorForEachType(OperatorNames.LESS)
+    val lessOrEqualFunByOperandType = primitiveTypesWithComparisons.defineComparisonOperatorForEachType(OperatorNames.LESS_OR_EQUAL)
+    val greaterOrEqualFunByOperandType = primitiveTypesWithComparisons.defineComparisonOperatorForEachType(OperatorNames.GREATER_OR_EQUAL)
+    val greaterFunByOperandType = primitiveTypesWithComparisons.defineComparisonOperatorForEachType(OperatorNames.GREATER)
 
     val ieee754equalsFunByOperandType =
         primitiveFloatingPointTypes.associate {
-            it to defineOperator("ieee754equals", bool, listOf(it.makeNullable(), it.makeNullable()))
+            it to defineOperator(OperatorNames.IEEE754_EQUALS, bool, listOf(it.makeNullable(), it.makeNullable()))
         }
 
-    val eqeqeqFun = defineOperator("EQEQEQ", bool, listOf(anyN, anyN))
-    val eqeqFun = defineOperator("EQEQ", bool, listOf(anyN, anyN))
-    val throwNpeFun = defineOperator("THROW_NPE", nothing, listOf())
-    val throwCceFun = defineOperator("THROW_CCE", nothing, listOf())
-    val throwIseFun = defineOperator("THROW_ISE", nothing, listOf())
-    val booleanNotFun = defineOperator("NOT", bool, listOf(bool))
-    val noWhenBranchMatchedExceptionFun = defineOperator("noWhenBranchMatchedException", nothing, listOf())
-    val illegalArgumentExceptionFun = defineOperator("illegalArgumentException", nothing, listOf(string))
+    val eqeqeqFun = defineOperator(OperatorNames.EQEQEQ, bool, listOf(anyN, anyN))
+    val eqeqFun = defineOperator(OperatorNames.EQEQ, bool, listOf(anyN, anyN))
+    val throwNpeFun = defineOperator(OperatorNames.THROW_NPE, nothing, listOf())
+    val throwCceFun = defineOperator(OperatorNames.THROW_CCE, nothing, listOf())
+    val throwIseFun = defineOperator(OperatorNames.THROW_ISE, nothing, listOf())
+    val booleanNotFun = defineOperator(OperatorNames.NOT, bool, listOf(bool))
+    val noWhenBranchMatchedExceptionFun = defineOperator(OperatorNames.NO_WHEN_BRANCH_MATCHED_EXCEPTION, nothing, listOf())
+    val illegalArgumentExceptionFun = defineOperator(OperatorNames.ILLEGAL_ARGUMENT_EXCEPTION, nothing, listOf(string))
 
     val eqeqeq = eqeqeqFun.descriptor
     val eqeq = eqeqFun.descriptor
@@ -252,5 +252,21 @@ class IrBuiltIns(
 
     companion object {
         val KOTLIN_INTERNAL_IR_FQN = FqName("kotlin.internal.ir")
+    }
+
+    object OperatorNames {
+        const val LESS = "less"
+        const val LESS_OR_EQUAL = "lessOrEqual"
+        const val GREATER = "greater"
+        const val GREATER_OR_EQUAL = "greaterOrEqual"
+        const val EQEQ = "EQEQ"
+        const val EQEQEQ = "EQEQEQ"
+        const val IEEE754_EQUALS = "ieee754equals"
+        const val NOT = "NOT"
+        const val THROW_NPE = "THROW_NPE"
+        const val THROW_CCE = "THROW_CCE"
+        const val THROW_ISE = "THROW_ISE"
+        const val NO_WHEN_BRANCH_MATCHED_EXCEPTION = "noWhenBranchMatchedException"
+        const val ILLEGAL_ARGUMENT_EXCEPTION = "illegalArgumentException "
     }
 }

--- a/compiler/testData/codegen/box/constants/comparisonFalse.kt
+++ b/compiler/testData/codegen/box/constants/comparisonFalse.kt
@@ -1,0 +1,16 @@
+// WITH_RUNTIME
+// IGNORE_BACKEND: JS_IR
+fun foo(): Array<Boolean> {
+    return arrayOf(
+        0.0 / 0 == 0.0 / 0,
+        0.0F > -0.0F,
+        0.0.equals(-0.0),
+        (0.0 / 0.0).equals(1.0 / 0.0)
+    )
+}
+
+fun box(): String {
+    if (foo().any { it == true })
+        return "fail: ${foo().contentDeepToString()}"
+    return "OK"
+}

--- a/compiler/testData/codegen/box/constants/comparisonTrue.kt
+++ b/compiler/testData/codegen/box/constants/comparisonTrue.kt
@@ -1,0 +1,23 @@
+// WITH_RUNTIME
+// IGNORE_BACKEND: JS_IR
+fun foo(): Array<Boolean> {
+    return arrayOf(
+        19 < 20.0,
+        12 > 11,
+        3.0F <= 4.0,
+        4.0F >= 4,
+        0.0 / 0 != 0.0 / 0,
+        0.0 == -0.0,
+        123 == 123,
+        123L == 123L,
+        0.0F == -0.0F,
+        0.0.compareTo(-0.0) > 0,
+        (0.0 / 0.0).compareTo(1.0 / 0.0) > 0
+    )
+}
+
+fun box(): String {
+    if (foo().any { it == false })
+        return "fail: ${foo().contentDeepToString()}"
+    return "OK"
+}

--- a/compiler/testData/codegen/box/constants/divisionByZero.kt
+++ b/compiler/testData/codegen/box/constants/divisionByZero.kt
@@ -1,0 +1,25 @@
+// IGNORE_BACKEND: JS_IR
+// IGNORE_BACKEND: JS
+// reason - no error from division by zero in JS
+
+fun expectArithmeticException(f: () -> Unit): Boolean {
+    try {
+        f()
+    } catch (e: ArithmeticException) {
+        return true
+    }
+    return false
+}
+
+fun box(): String {
+    if (!expectArithmeticException { 1 / 0 })
+        return "fail: 1 / 0 didn't throw exception"
+
+    if (!expectArithmeticException { 1 * 2 / 0 })
+        return "fail: 1 * 2 / 0 didn't throw exception"
+
+    if (!expectArithmeticException { 1 * (2 / 0) })
+        return "fail: 1 * (2 / 0) didn't throw exception"
+
+    return "OK"
+}

--- a/compiler/testData/codegen/box/primitiveTypes/kt2269.kt
+++ b/compiler/testData/codegen/box/primitiveTypes/kt2269.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 fun box() : String {
     230?.toByte()?.hashCode()
     9.hashCode()

--- a/compiler/testData/codegen/box/primitiveTypes/kt2269NotOptimizable.kt
+++ b/compiler/testData/codegen/box/primitiveTypes/kt2269NotOptimizable.kt
@@ -1,0 +1,25 @@
+// IGNORE_BACKEND: JVM_IR
+fun identity(x: Int): Int {
+    return when {
+        x < 0 -> identity(x + 1) - 1
+        x > 0 -> identity(x - 1) + 1
+        else -> 0
+    }
+}
+
+fun box() : String {
+    // Just hard enough that the test won't get optimized away at compile time.
+    val twoThirty = identity(230)
+    val nine = identity(9)
+    twoThirty?.toByte()?.hashCode()
+    nine.hashCode()
+
+    if(twoThirty.equals(nine.toByte())) {
+       return "fail"
+    }
+
+    if(twoThirty == nine.toByte().toInt()) {
+       return "fail"
+    }
+    return "OK"
+}

--- a/compiler/testData/codegen/bytecodeText/constants/byte.kt
+++ b/compiler/testData/codegen/bytecodeText/constants/byte.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 val a: Byte = 1 + 10
 
 // 1 BIPUSH 11

--- a/compiler/testData/codegen/bytecodeText/constants/comparisonFalse.kt
+++ b/compiler/testData/codegen/bytecodeText/constants/comparisonFalse.kt
@@ -1,0 +1,22 @@
+// TARGET_BACKEND: JVM_IR
+
+fun foo(): Array<Boolean> {
+    return arrayOf(
+        0.0 / 0 == 0.0 / 0,
+        0.0F > -0.0F,
+        0.0.equals(-0.0),
+        (0.0 / 0.0).equals(1.0 / 0.0)
+    )
+}
+
+// Disabled: current backend doesn't fold them.
+// 4 INVOKESTATIC
+// 4 INVOKESTATIC java/lang/Boolean.valueOf
+// 1 ICONST_1
+// 5 ICONST_0
+// 0 IFEQ
+// 0 IFNE
+// 0 IFGE
+// 0 IFGT
+// 0 IFLE
+// 0 IFLT

--- a/compiler/testData/codegen/bytecodeText/constants/comparisonTrue.kt
+++ b/compiler/testData/codegen/bytecodeText/constants/comparisonTrue.kt
@@ -1,0 +1,29 @@
+// TARGET_BACKEND: JVM_IR
+
+fun foo(): Array<Boolean> {
+    return arrayOf(
+        19 < 20.0,
+        12 > 11,
+        3.0F <= 4.0,
+        4.0F >= 4,
+        0.0 / 0 != 0.0 / 0,
+        0.0 == -0.0,
+        123 == 123,
+        123L == 123L,
+        0.0F == -0.0F,
+        0.0.compareTo(-0.0) > 0,
+        (0.0 / 0.0).compareTo(1.0 / 0.0) > 0
+    )
+}
+
+// Disabled because the current backend doesn't fold them.
+// 11 INVOKESTATIC
+// 11 INVOKESTATIC java/lang/Boolean.valueOf
+// 1 ICONST_0
+// 12 ICONST_1
+// 0 IFEQ
+// 0 IFNE
+// 0 IFGE
+// 0 IFGT
+// 0 IFLE
+// 0 IFLT

--- a/compiler/testData/codegen/bytecodeText/constants/floatingPoints.kt
+++ b/compiler/testData/codegen/bytecodeText/constants/floatingPoints.kt
@@ -1,0 +1,16 @@
+val a = 1.0 + 10
+val b = 2 + 10.0
+val c = 3.0F + 10
+val d = 4 + 10.0F
+val e = 1.0 / 0
+val f = 1 / 0.0
+val g = 0.0 / 0
+val h = 0 / 0.0
+val i = 0.0 / 0.0
+
+// 1 LDC 11.0
+// 1 LDC 12.0
+// 1 LDC 13.0
+// 1 LDC 14.0
+// 2 LDC Infinity
+// 3 LDC NaN

--- a/compiler/testData/codegen/bytecodeText/constants/partialString.kt
+++ b/compiler/testData/codegen/bytecodeText/constants/partialString.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 fun box(): String {
     val z = 1;
     return "O" + "K".toString() + z

--- a/compiler/testData/codegen/bytecodeText/constants/short.kt
+++ b/compiler/testData/codegen/bytecodeText/constants/short.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 val a: Short = 1 + 255
 
 // 1 SIPUSH 256

--- a/compiler/testData/codegen/bytecodeText/constants/string.kt
+++ b/compiler/testData/codegen/bytecodeText/constants/string.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 fun box(): String {
     return "O" + "K".toString() + 1.toLong()
 }

--- a/compiler/testData/codegen/bytecodeText/deadCodeElimination/boxingNotOptimizable.kt
+++ b/compiler/testData/codegen/bytecodeText/deadCodeElimination/boxingNotOptimizable.kt
@@ -1,18 +1,17 @@
-// IGNORE_BACKEND: JVM_IR
 class A
 
 fun foo(x: Any?) {}
 
-fun box() {
+fun box(u: Int) {
     val x: Int? = 1
     x!!
 
-    val z: Int? = if (1 == 1) x else null
+    val z: Int? = if (u == 1) x else null
     z!!
 
     foo(1 as java.lang.Integer)
-    
-    val y: Any? = if (1 == 1) x else A()
+
+    val y: Any? = if (u == 1) x else A()
     y!!
 }
 

--- a/compiler/testData/codegen/bytecodeText/deadCodeElimination/simpleConstructorNotRedundantNotOptimizable.kt
+++ b/compiler/testData/codegen/bytecodeText/deadCodeElimination/simpleConstructorNotRedundantNotOptimizable.kt
@@ -1,15 +1,14 @@
-// IGNORE_BACKEND: JVM_IR
 class A
-fun box() {
+fun box(u: Int) {
     val x: A? = A()
     val y: A?
-    if (1 == 0) {
+    if (u == 0) {
         y = x
     }
     else {
         y = null
     }
-    
+
     y!!
 }
 

--- a/compiler/testData/codegen/bytecodeText/stringOperations/concat.kt
+++ b/compiler/testData/codegen/bytecodeText/stringOperations/concat.kt
@@ -6,9 +6,9 @@ class A() {
 }
 
 
-fun box() : String {
+fun box(a: String, b: String) : String {
 
-    val s = "1" + "2" + 3 + 4L + 5.0 + 6F + '7' + A()
+    val s = a + "1" + "2" + 3 + 4L + b + 5.0 + 6F + '7' + A()
 
     return "OK"
 }

--- a/compiler/testData/codegen/bytecodeText/stringOperations/primitiveToString.kt
+++ b/compiler/testData/codegen/bytecodeText/stringOperations/primitiveToString.kt
@@ -1,3 +1,4 @@
+// IGNORE_BACKEND: JVM_IR
 fun main() {
     false.toString()
     1.toByte().toString()

--- a/compiler/testData/codegen/bytecodeText/stringOperations/primitiveToStringNotOptimizable.kt
+++ b/compiler/testData/codegen/bytecodeText/stringOperations/primitiveToStringNotOptimizable.kt
@@ -1,0 +1,14 @@
+fun main(a: Boolean, b:Byte, c: Short, d: Int, e: Long, f: Float, g: Double, h: Char) {
+    a.toString()
+    b.toString()
+    c.toString()
+    d.toString()
+    e.toString()
+    f.toString()
+    g.toString()
+    h.toString()
+}
+
+/*Check that all "valueOf" are String ones and there is no boxing*/
+// 8 valueOf
+// 8 INVOKESTATIC java/lang/String.valueOf

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -4379,9 +4379,24 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/codegen/box/constants"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.JVM, true);
         }
 
+        @TestMetadata("comparisonFalse.kt")
+        public void testComparisonFalse() throws Exception {
+            runTest("compiler/testData/codegen/box/constants/comparisonFalse.kt");
+        }
+
+        @TestMetadata("comparisonTrue.kt")
+        public void testComparisonTrue() throws Exception {
+            runTest("compiler/testData/codegen/box/constants/comparisonTrue.kt");
+        }
+
         @TestMetadata("constantsInWhen.kt")
         public void testConstantsInWhen() throws Exception {
             runTest("compiler/testData/codegen/box/constants/constantsInWhen.kt");
+        }
+
+        @TestMetadata("divisionByZero.kt")
+        public void testDivisionByZero() throws Exception {
+            runTest("compiler/testData/codegen/box/constants/divisionByZero.kt");
         }
 
         @TestMetadata("float.kt")
@@ -17174,6 +17189,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
         @TestMetadata("kt2269.kt")
         public void testKt2269() throws Exception {
             runTest("compiler/testData/codegen/box/primitiveTypes/kt2269.kt");
+        }
+
+        @TestMetadata("kt2269NotOptimizable.kt")
+        public void testKt2269NotOptimizable() throws Exception {
+            runTest("compiler/testData/codegen/box/primitiveTypes/kt2269NotOptimizable.kt");
         }
 
         @TestMetadata("kt2275.kt")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
@@ -1118,6 +1118,11 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
             runTest("compiler/testData/codegen/bytecodeText/constants/byte.kt");
         }
 
+        @TestMetadata("floatingPoints.kt")
+        public void testFloatingPoints() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/constants/floatingPoints.kt");
+        }
+
         @TestMetadata("inlineUnsignedIntConstant.kt")
         public void testInlineUnsignedIntConstant() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/constants/inlineUnsignedIntConstant.kt");
@@ -1472,6 +1477,11 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
             runTest("compiler/testData/codegen/bytecodeText/deadCodeElimination/boxing.kt");
         }
 
+        @TestMetadata("boxingNotOptimizable.kt")
+        public void testBoxingNotOptimizable() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/deadCodeElimination/boxingNotOptimizable.kt");
+        }
+
         @TestMetadata("emptyVariableRange.kt")
         public void testEmptyVariableRange() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/deadCodeElimination/emptyVariableRange.kt");
@@ -1500,6 +1510,11 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
         @TestMetadata("simpleConstructorNotRedundant.kt")
         public void testSimpleConstructorNotRedundant() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/deadCodeElimination/simpleConstructorNotRedundant.kt");
+        }
+
+        @TestMetadata("simpleConstructorNotRedundantNotOptimizable.kt")
+        public void testSimpleConstructorNotRedundantNotOptimizable() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/deadCodeElimination/simpleConstructorNotRedundantNotOptimizable.kt");
         }
     }
 
@@ -3375,6 +3390,11 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
         @TestMetadata("primitiveToString.kt")
         public void testPrimitiveToString() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/stringOperations/primitiveToString.kt");
+        }
+
+        @TestMetadata("primitiveToStringNotOptimizable.kt")
+        public void testPrimitiveToStringNotOptimizable() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/stringOperations/primitiveToStringNotOptimizable.kt");
         }
 
         @TestMetadata("primitivesAsStringTemplates.kt")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -4379,9 +4379,24 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/codegen/box/constants"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.JVM, true);
         }
 
+        @TestMetadata("comparisonFalse.kt")
+        public void testComparisonFalse() throws Exception {
+            runTest("compiler/testData/codegen/box/constants/comparisonFalse.kt");
+        }
+
+        @TestMetadata("comparisonTrue.kt")
+        public void testComparisonTrue() throws Exception {
+            runTest("compiler/testData/codegen/box/constants/comparisonTrue.kt");
+        }
+
         @TestMetadata("constantsInWhen.kt")
         public void testConstantsInWhen() throws Exception {
             runTest("compiler/testData/codegen/box/constants/constantsInWhen.kt");
+        }
+
+        @TestMetadata("divisionByZero.kt")
+        public void testDivisionByZero() throws Exception {
+            runTest("compiler/testData/codegen/box/constants/divisionByZero.kt");
         }
 
         @TestMetadata("float.kt")
@@ -17174,6 +17189,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
         @TestMetadata("kt2269.kt")
         public void testKt2269() throws Exception {
             runTest("compiler/testData/codegen/box/primitiveTypes/kt2269.kt");
+        }
+
+        @TestMetadata("kt2269NotOptimizable.kt")
+        public void testKt2269NotOptimizable() throws Exception {
+            runTest("compiler/testData/codegen/box/primitiveTypes/kt2269NotOptimizable.kt");
         }
 
         @TestMetadata("kt2275.kt")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -4379,9 +4379,24 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/codegen/box/constants"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.JVM_IR, true);
         }
 
+        @TestMetadata("comparisonFalse.kt")
+        public void testComparisonFalse() throws Exception {
+            runTest("compiler/testData/codegen/box/constants/comparisonFalse.kt");
+        }
+
+        @TestMetadata("comparisonTrue.kt")
+        public void testComparisonTrue() throws Exception {
+            runTest("compiler/testData/codegen/box/constants/comparisonTrue.kt");
+        }
+
         @TestMetadata("constantsInWhen.kt")
         public void testConstantsInWhen() throws Exception {
             runTest("compiler/testData/codegen/box/constants/constantsInWhen.kt");
+        }
+
+        @TestMetadata("divisionByZero.kt")
+        public void testDivisionByZero() throws Exception {
+            runTest("compiler/testData/codegen/box/constants/divisionByZero.kt");
         }
 
         @TestMetadata("float.kt")
@@ -17179,6 +17194,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         @TestMetadata("kt2269.kt")
         public void testKt2269() throws Exception {
             runTest("compiler/testData/codegen/box/primitiveTypes/kt2269.kt");
+        }
+
+        @TestMetadata("kt2269NotOptimizable.kt")
+        public void testKt2269NotOptimizable() throws Exception {
+            runTest("compiler/testData/codegen/box/primitiveTypes/kt2269NotOptimizable.kt");
         }
 
         @TestMetadata("kt2275.kt")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
@@ -1118,6 +1118,21 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
             runTest("compiler/testData/codegen/bytecodeText/constants/byte.kt");
         }
 
+        @TestMetadata("comparisonFalse.kt")
+        public void testComparisonFalse() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/constants/comparisonFalse.kt");
+        }
+
+        @TestMetadata("comparisonTrue.kt")
+        public void testComparisonTrue() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/constants/comparisonTrue.kt");
+        }
+
+        @TestMetadata("floatingPoints.kt")
+        public void testFloatingPoints() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/constants/floatingPoints.kt");
+        }
+
         @TestMetadata("inlineUnsignedIntConstant.kt")
         public void testInlineUnsignedIntConstant() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/constants/inlineUnsignedIntConstant.kt");
@@ -1472,6 +1487,11 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
             runTest("compiler/testData/codegen/bytecodeText/deadCodeElimination/boxing.kt");
         }
 
+        @TestMetadata("boxingNotOptimizable.kt")
+        public void testBoxingNotOptimizable() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/deadCodeElimination/boxingNotOptimizable.kt");
+        }
+
         @TestMetadata("emptyVariableRange.kt")
         public void testEmptyVariableRange() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/deadCodeElimination/emptyVariableRange.kt");
@@ -1500,6 +1520,11 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
         @TestMetadata("simpleConstructorNotRedundant.kt")
         public void testSimpleConstructorNotRedundant() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/deadCodeElimination/simpleConstructorNotRedundant.kt");
+        }
+
+        @TestMetadata("simpleConstructorNotRedundantNotOptimizable.kt")
+        public void testSimpleConstructorNotRedundantNotOptimizable() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/deadCodeElimination/simpleConstructorNotRedundantNotOptimizable.kt");
         }
     }
 
@@ -3375,6 +3400,11 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
         @TestMetadata("primitiveToString.kt")
         public void testPrimitiveToString() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/stringOperations/primitiveToString.kt");
+        }
+
+        @TestMetadata("primitiveToStringNotOptimizable.kt")
+        public void testPrimitiveToStringNotOptimizable() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/stringOperations/primitiveToStringNotOptimizable.kt");
         }
 
         @TestMetadata("primitivesAsStringTemplates.kt")

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -3649,9 +3649,24 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/codegen/box/constants"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.JS_IR, true);
         }
 
+        @TestMetadata("comparisonFalse.kt")
+        public void testComparisonFalse() throws Exception {
+            runTest("compiler/testData/codegen/box/constants/comparisonFalse.kt");
+        }
+
+        @TestMetadata("comparisonTrue.kt")
+        public void testComparisonTrue() throws Exception {
+            runTest("compiler/testData/codegen/box/constants/comparisonTrue.kt");
+        }
+
         @TestMetadata("constantsInWhen.kt")
         public void testConstantsInWhen() throws Exception {
             runTest("compiler/testData/codegen/box/constants/constantsInWhen.kt");
+        }
+
+        @TestMetadata("divisionByZero.kt")
+        public void testDivisionByZero() throws Exception {
+            runTest("compiler/testData/codegen/box/constants/divisionByZero.kt");
         }
 
         @TestMetadata("float.kt")
@@ -13424,6 +13439,11 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
         @TestMetadata("kt2269.kt")
         public void testKt2269() throws Exception {
             runTest("compiler/testData/codegen/box/primitiveTypes/kt2269.kt");
+        }
+
+        @TestMetadata("kt2269NotOptimizable.kt")
+        public void testKt2269NotOptimizable() throws Exception {
+            runTest("compiler/testData/codegen/box/primitiveTypes/kt2269NotOptimizable.kt");
         }
 
         @TestMetadata("kt2275.kt")

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -3659,9 +3659,24 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/codegen/box/constants"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.JS, true);
         }
 
+        @TestMetadata("comparisonFalse.kt")
+        public void testComparisonFalse() throws Exception {
+            runTest("compiler/testData/codegen/box/constants/comparisonFalse.kt");
+        }
+
+        @TestMetadata("comparisonTrue.kt")
+        public void testComparisonTrue() throws Exception {
+            runTest("compiler/testData/codegen/box/constants/comparisonTrue.kt");
+        }
+
         @TestMetadata("constantsInWhen.kt")
         public void testConstantsInWhen() throws Exception {
             runTest("compiler/testData/codegen/box/constants/constantsInWhen.kt");
+        }
+
+        @TestMetadata("divisionByZero.kt")
+        public void testDivisionByZero() throws Exception {
+            runTest("compiler/testData/codegen/box/constants/divisionByZero.kt");
         }
 
         @TestMetadata("float.kt")
@@ -14524,6 +14539,11 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
         @TestMetadata("kt2269.kt")
         public void testKt2269() throws Exception {
             runTest("compiler/testData/codegen/box/primitiveTypes/kt2269.kt");
+        }
+
+        @TestMetadata("kt2269NotOptimizable.kt")
+        public void testKt2269NotOptimizable() throws Exception {
+            runTest("compiler/testData/codegen/box/primitiveTypes/kt2269NotOptimizable.kt");
         }
 
         @TestMetadata("kt2275.kt")


### PR DESCRIPTION
The newly added pass folds the same set of constant functions of the
current backend.

Change-Id: I739bcb3e0fc549a87123422d7ca46e44d61f24dd