### PR TITLE
Make IrDeclaration.origin mutable

### DIFF
--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/declarations/IrDeclaration.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/declarations/IrDeclaration.kt
@@ -30,7 +30,7 @@ interface IrSymbolOwner : IrElement {
 
 interface IrDeclaration : IrStatement, IrAnnotationContainer {
     val descriptor: DeclarationDescriptor
-    val origin: IrDeclarationOrigin
+    var origin: IrDeclarationOrigin
 
     var parent: IrDeclarationParent
 

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/declarations/impl/IrDeclarationBase.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/declarations/impl/IrDeclarationBase.kt
@@ -25,7 +25,7 @@ import org.jetbrains.kotlin.ir.expressions.IrCall
 abstract class IrDeclarationBase(
     startOffset: Int,
     endOffset: Int,
-    override val origin: IrDeclarationOrigin
+    override var origin: IrDeclarationOrigin
 ) : IrElementBase(startOffset, endOffset),
     IrDeclaration {
 

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/declarations/lazy/IrLazyDeclarationBase.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/declarations/lazy/IrLazyDeclarationBase.kt
@@ -23,7 +23,7 @@ import kotlin.reflect.KProperty
 abstract class IrLazyDeclarationBase(
     startOffset: Int,
     endOffset: Int,
-    override val origin: IrDeclarationOrigin,
+    override var origin: IrDeclarationOrigin,
     private val stubGenerator: DeclarationStubGenerator,
     protected val typeTranslator: TypeTranslator
 ) : IrElementBase(startOffset, endOffset), IrDeclaration {


### PR DESCRIPTION
When plugins perform various IR transforms, it sometimes becomes necessary to modify the origin of a declaration.  When the origin is a `val`, this requires creating a new declaration and copying the old values into the new declaration.  Unfortunately, this also requires applying a transform over the entire module to rewrite references from the old declaration to the new declaration, which ends up becoming a rather complex codepath for what would otherwise be a straightforward lowering transformation.

By making the `origin` field be a `var` instead of a `val`, these lowering transformations can be dramatically simplified.

cc @udalov @erokhins 