### PR TITLE
KT-26979 "Lambda argument inside parentheses" inspection is not reported, if function type is actual type argument, but not formal parameter type

### DIFF
--- a/idea/idea-core/src/org/jetbrains/kotlin/idea/core/psiModificationUtils.kt
+++ b/idea/idea-core/src/org/jetbrains/kotlin/idea/core/psiModificationUtils.kt
@@ -45,6 +45,7 @@ import org.jetbrains.kotlin.resolve.calls.model.ArgumentMatch
 import org.jetbrains.kotlin.resolve.lazy.BodyResolveMode
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.isError
+import org.jetbrains.kotlin.types.typeUtil.isTypeParameter
 import org.jetbrains.kotlin.utils.KotlinExceptionWithAttachments
 import org.jetbrains.kotlin.utils.SmartList
 
@@ -138,8 +139,10 @@ fun KtCallExpression.canMoveLambdaOutsideParentheses(): Boolean {
         // if there are functions among candidates but none of them have last function parameter then not show the intention
         if (candidates.isNotEmpty() && candidates.none { candidate ->
                 val params = candidate.valueParameters
-                params.lastOrNull()?.type?.isFunctionOrSuspendFunctionType == true &&
-                        params.count { it.type.isFunctionOrSuspendFunctionType } == lambdaArgumentCount + referenceArgumentCount
+                val lastParamType = params.lastOrNull()?.type
+                (lastParamType?.isFunctionOrSuspendFunctionType == true || lastParamType?.isTypeParameter() == true) && params.count {
+                    it.type.let { type -> type.isFunctionOrSuspendFunctionType || type.isTypeParameter() }
+                } == lambdaArgumentCount + referenceArgumentCount
             }
         ) return false
     }

--- a/idea/testData/inspectionsLocal/moveLambdaOutsideParentheses/typeParameter.kt
+++ b/idea/testData/inspectionsLocal/moveLambdaOutsideParentheses/typeParameter.kt
@@ -1,0 +1,5 @@
+fun <T> foo(t: T) {}
+
+fun test() {
+    foo(<caret>{ "a" })
+}

--- a/idea/testData/inspectionsLocal/moveLambdaOutsideParentheses/typeParameter.kt.after
+++ b/idea/testData/inspectionsLocal/moveLambdaOutsideParentheses/typeParameter.kt.after
@@ -1,0 +1,5 @@
+fun <T> foo(t: T) {}
+
+fun test() {
+    foo { "a" }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -4167,6 +4167,11 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
         public void testSuspendLambda() throws Exception {
             runTest("idea/testData/inspectionsLocal/moveLambdaOutsideParentheses/suspendLambda.kt");
         }
+
+        @TestMetadata("typeParameter.kt")
+        public void testTypeParameter() throws Exception {
+            runTest("idea/testData/inspectionsLocal/moveLambdaOutsideParentheses/typeParameter.kt");
+        }
     }
 
     @TestMetadata("idea/testData/inspectionsLocal/moveSuspiciousCallableReferenceIntoParentheses")


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-26979