### PR TITLE
KT-28838 Group by file structure doesn't work for text search in Kotlin

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/findUsages/KotlinDeclarationGroupRuleProvider.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/findUsages/KotlinDeclarationGroupRuleProvider.kt
@@ -20,6 +20,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.usages.PsiNamedElementUsageGroupBase
 import com.intellij.usages.Usage
 import com.intellij.usages.UsageGroup
+import com.intellij.usages.UsageInfo2UsageAdapter
 import com.intellij.usages.impl.FileStructureGroupRuleProvider
 import com.intellij.usages.rules.PsiElementUsage
 import com.intellij.usages.rules.UsageGroupingRule
@@ -30,9 +31,16 @@ import org.jetbrains.kotlin.psi.psiUtil.parents
 
 class KotlinDeclarationGroupingRule(val level: Int = 0) : UsageGroupingRule {
     override fun groupUsage(usage: Usage): UsageGroup? {
-        val element = (usage as? PsiElementUsage)?.element ?: return null
+        var element = (usage as? PsiElementUsage)?.element ?: return null
 
         if (element.containingFile !is KtFile) return null
+
+        if (element is KtFile) {
+            val offset = (usage as? UsageInfo2UsageAdapter)?.usageInfo?.navigationOffset
+            if (offset != null) {
+                element = element.findElementAt(offset) ?: element
+            }
+        }
 
         val parentList = element.parents.filterIsInstance<KtNamedDeclaration>().filterNot { it is KtProperty && it.isLocal }.toList()
         if (parentList.size <= level) {


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-28838