### PR TITLE
KT-29416 False positive "Redundant property getter" for `external` getter

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantGetterInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantGetterInspection.kt
@@ -8,16 +8,19 @@ package org.jetbrains.kotlin.idea.inspections
 import com.intellij.codeInspection.*
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElementVisitor
+import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.*
 
 class RedundantGetterInspection : AbstractKotlinInspection(), CleanupLocalInspectionTool {
     override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean, session: LocalInspectionToolSession): PsiElementVisitor {
         return propertyAccessorVisitor { accessor ->
             if (accessor.isRedundantGetter()) {
-                holder.registerProblem(accessor,
-                                       "Redundant getter",
-                                       ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
-                                       RemoveRedundantGetterFix())
+                holder.registerProblem(
+                    accessor,
+                    "Redundant getter",
+                    ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
+                    RemoveRedundantGetterFix()
+                )
             }
         }
     }
@@ -25,6 +28,7 @@ class RedundantGetterInspection : AbstractKotlinInspection(), CleanupLocalInspec
 
 private fun KtPropertyAccessor.isRedundantGetter(): Boolean {
     if (!isGetter) return false
+    if (hasModifier(KtTokens.EXTERNAL_KEYWORD)) return false
     if (annotationEntries.isNotEmpty()) return false
     val expression = bodyExpression ?: return true
     if (expression is KtNameReferenceExpression) {

--- a/idea/testData/inspectionsLocal/redundantGetter/external.kt
+++ b/idea/testData/inspectionsLocal/redundantGetter/external.kt
@@ -1,0 +1,5 @@
+// PROBLEM: none
+class Foo {
+    val foo: String
+        external <caret>get
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -4974,6 +4974,11 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
             runTest("idea/testData/inspectionsLocal/redundantGetter/default.kt");
         }
 
+        @TestMetadata("external.kt")
+        public void testExternal() throws Exception {
+            runTest("idea/testData/inspectionsLocal/redundantGetter/external.kt");
+        }
+
         @TestMetadata("fieldExpression.kt")
         public void testFieldExpression() throws Exception {
             runTest("idea/testData/inspectionsLocal/redundantGetter/fieldExpression.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-29416