### PR TITLE
Generate better code for branches based on comparisons.

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.backend.jvm.codegen
 
 import org.jetbrains.kotlin.backend.jvm.JvmLoweredDeclarationOrigin
+import org.jetbrains.kotlin.backend.jvm.intrinsics.ComparisonIntrinsic
 import org.jetbrains.kotlin.backend.jvm.intrinsics.IrIntrinsicFunction
 import org.jetbrains.kotlin.backend.jvm.intrinsics.IrIntrinsicMethods
 import org.jetbrains.kotlin.backend.jvm.lower.CrIrType
@@ -717,16 +718,18 @@ class ExpressionCodegen(
     private fun genConditionWithOptimizationsIfPossible(branch: IrBranch, data: BlockInfo, elseLabel: Label) {
         var condition = branch.condition
         var jumpIfFalse = true
+
+        // Instead of materializing a negated value when used for control flow, flip the branch
+        // targets instead. This significantly cuts down the amount of branches and loads of
+        // const_0 and const_1 in the generated java bytecode.
         if (isNegation(condition, classCodegen.context)) {
-            // Instead of materializing a negated value when used for control flow, flip the branch
-            // targets instead. This significantly cuts down the amount of branches and loads of
-            // const_0 and const_1 in the generated java bytecode.
             condition = negationArgument(condition as IrCall)
             jumpIfFalse = false
         }
+
+        // Do not materialize null constants to check for null. Instead use the JVM bytecode
+        // ifnull and ifnonnull instructions.
         if (isNullCheck(condition)) {
-            // Do not materialize null constants to check for null. Instead use the JVM bytecode
-            // ifnull and ifnonnull instructions.
             val call = condition as IrCall
             val left = call.getValueArgument(0)!!
             val right = call.getValueArgument(1)!!
@@ -737,10 +740,41 @@ class ExpressionCodegen(
             } else {
                 mv.ifnull(elseLabel)
             }
-        } else {
-            gen(condition, data).put(condition.asmType, mv)
-            BranchedValue.condJump(onStack(condition.asmType), elseLabel, jumpIfFalse, mv)
+            return
         }
+
+        // For comparison intrinsics, branch directly based on the comparison instead of
+        // materializing a boolean and performing and extra jump.
+        if (condition is IrCall) {
+            val intrinsic = intrinsics.getIntrinsic(condition.descriptor.original as CallableMemberDescriptor)
+            if (intrinsic is ComparisonIntrinsic) {
+                val callable = resolveToCallable(condition, false)
+                (callable as IrIntrinsicFunction).loadArguments(this, data)
+                val stackValue = intrinsic.genStackValue(condition, classCodegen.context)
+                BranchedValue.condJump(stackValue, elseLabel, jumpIfFalse, mv)
+                return
+            }
+        }
+
+        // For instance of type operators, branch directly on the instanceof result instead
+        // of materializing a boolean and performing an extra jump.
+        if (condition is IrTypeOperatorCall &&
+            (condition.operator == IrTypeOperator.NOT_INSTANCEOF || condition.operator == IrTypeOperator.INSTANCEOF)) {
+            val asmType = condition.typeOperand.toKotlinType().asmType
+            gen(condition.argument, OBJECT_TYPE, data)
+            val type = boxType(asmType)
+            generateIsCheck(mv, condition.typeOperand.toKotlinType(), type, state.languageVersionSettings.isReleaseCoroutines())
+            val stackValue =
+                if (condition.operator == IrTypeOperator.INSTANCEOF)
+                    onStack(Type.BOOLEAN_TYPE)
+                else
+                    StackValue.not(onStack(Type.BOOLEAN_TYPE))
+            BranchedValue.condJump(stackValue, elseLabel, jumpIfFalse, mv)
+            return
+        }
+
+        gen(condition, data).put(condition.asmType, mv)
+        BranchedValue.condJump(onStack(condition.asmType), elseLabel, jumpIfFalse, mv)
     }
 
     private fun isNullCheck(expression: IrExpression): Boolean {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/IntrinsicMethod.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/IntrinsicMethod.kt
@@ -8,12 +8,17 @@ package org.jetbrains.kotlin.backend.jvm.intrinsics
 import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
 import org.jetbrains.kotlin.codegen.Callable
 import org.jetbrains.kotlin.codegen.CallableMethod
+import org.jetbrains.kotlin.codegen.StackValue
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrMemberAccessExpression
 import org.jetbrains.kotlin.ir.types.toKotlinType
 import org.jetbrains.kotlin.resolve.jvm.jvmSignature.JvmMethodSignature
 import org.jetbrains.org.objectweb.asm.Type
 import org.jetbrains.org.objectweb.asm.commons.Method
+
+interface ComparisonIntrinsic {
+    fun genStackValue(expression: IrMemberAccessExpression, context: JvmBackendContext): StackValue
+}
 
 abstract class IntrinsicMethod {
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/IrIntrinsicFunction.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/IrIntrinsicFunction.kt
@@ -86,6 +86,14 @@ open class IrIntrinsicFunction(
     }
 
     open fun invoke(v: InstructionAdapter, codegen: ExpressionCodegen, data: BlockInfo): StackValue {
+        loadArguments(codegen, data)
+        return StackValue.onStack(genInvokeInstructionWithResult(v))
+    }
+
+    fun loadArguments(
+        codegen: ExpressionCodegen,
+        data: BlockInfo
+    ) {
         val args = listOfNotNull(expression.dispatchReceiver, expression.extensionReceiver) +
                 expression.descriptor.valueParameters.mapIndexed { i, descriptor ->
                     expression.getValueArgument(i) ?: if (descriptor.isVararg)
@@ -104,7 +112,6 @@ open class IrIntrinsicFunction(
                 genArg(irExpression, codegen, i, data)
             }
         }
-        return StackValue.onStack(genInvokeInstructionWithResult(v))
     }
 
     open fun genArg(expression: IrExpression, codegen: ExpressionCodegen, index: Int, data: BlockInfo) {

--- a/compiler/testData/codegen/bytecodeText/conditions/negatedZeroCompare.kt
+++ b/compiler/testData/codegen/bytecodeText/conditions/negatedZeroCompare.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 val a = 1
 
 fun main() {

--- a/compiler/testData/codegen/bytecodeText/conditions/zeroCompare.kt
+++ b/compiler/testData/codegen/bytecodeText/conditions/zeroCompare.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 val a = 1
 
 fun main() {

--- a/compiler/testData/codegen/bytecodeText/lazyCodegen/negateObjectComp.kt
+++ b/compiler/testData/codegen/bytecodeText/lazyCodegen/negateObjectComp.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 val p: Int? = 1;
 val z: Int? = 2;
 

--- a/compiler/testData/codegen/bytecodeText/lazyCodegen/negateObjectCompChaing.kt
+++ b/compiler/testData/codegen/bytecodeText/lazyCodegen/negateObjectCompChaing.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 val p: Int? = 1;
 val z: Int? = 2;
 

--- a/compiler/testData/codegen/bytecodeText/nullCheckOptimization/alreadyCheckedForIs.kt
+++ b/compiler/testData/codegen/bytecodeText/nullCheckOptimization/alreadyCheckedForIs.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 fun test(x: String?) {
     if (x !is String) return
 


### PR DESCRIPTION
For comparison intrinsics and for instanceof checks, make
it possible to get the the stack value produced and branch
on that directly instead of materializing a boolean to
branch on from it.

That reduces code such as

```
    IF_CMPEQ L1
    CONST_0
    GOTO L2
L1: CONST_1
L2: IFEQ L3
```

to just one IF_CMP instruction.