### PR TITLE
Generate synthetic functions for local functions with default values,…

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/AsmUtil.java
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/AsmUtil.java
@@ -302,7 +302,8 @@ public class AsmUtil {
     }
 
     public static boolean isStaticMethod(OwnerKind kind, CallableMemberDescriptor functionDescriptor) {
-        return isStaticKind(kind) ||
+        return isStaticDeclaration(functionDescriptor) ||
+               isStaticKind(kind) ||
                KotlinTypeMapper.isStaticAccessor(functionDescriptor) ||
                CodegenUtilKt.isJvmStaticInObjectOrClassOrInterface(functionDescriptor);
     }

--- a/compiler/testData/codegen/box/functions/localFunctions/kt3978.kt
+++ b/compiler/testData/codegen/box/functions/localFunctions/kt3978.kt
@@ -1,11 +1,20 @@
-// IGNORE_BACKEND: JVM_IR
-fun box() : String {
+class C() {
+    fun foo(): Int {
+        fun local(i: Int = 1): Int {
+            return i
+        }
+        return local()
+    }
+}
 
-
-    fun local(i: Int = 1) : Int {
+fun box(): String {
+    fun local(i: Int = 1): Int {
         return i
     }
 
-    return if (local() != 1) "fail" else "OK"
-}
+    if (local() != 1) return "Fail 1"
+    if (local(2) != 2) return "Fail 2"
+    if (C().foo() != 1) return "Fail 3"
 
+    return "OK"
+}

--- a/compiler/testData/codegen/box/functions/localFunctions/parameterAsDefaultValue.kt
+++ b/compiler/testData/codegen/box/functions/localFunctions/parameterAsDefaultValue.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 fun foo(): String {
     fun bar(x: String, y: String = x): String {
         return y

--- a/core/descriptors/src/org/jetbrains/kotlin/name/NameUtils.kt
+++ b/core/descriptors/src/org/jetbrains/kotlin/name/NameUtils.kt
@@ -19,7 +19,7 @@ package org.jetbrains.kotlin.name
 import java.util.*
 
 object NameUtils {
-    private val SANITIZE_AS_JAVA_INVALID_CHARACTERS = "[^\\p{L}\\p{Digit}]".toRegex()
+    private val SANITIZE_AS_JAVA_INVALID_CHARACTERS = "[^\\p{L}\\p{Digit}\\$]".toRegex()
 
     @JvmStatic
     fun sanitizeAsJavaIdentifier(name: String): String {


### PR DESCRIPTION
… and invoke them with the correct function descriptor.

This is accomplished by having DefaultArgumentStubGenerator transform StatementContainers (local function declarations are statements) in addition to DeclarationContainers.

Without the changes to AsmUtil, the generated functions are not invoked with the correct descriptor; the enclosing class is included in the descriptor as the dispatch receiver parameter.

This change still does not fix local functions with default values from closures (i.e., KT-5589).