### PR TITLE
Make parcelize a non-experimental feature

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/AndroidSubplugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/AndroidSubplugin.kt
@@ -123,7 +123,8 @@ class AndroidSubplugin : KotlinGradleSubplugin<KotlinCompile> {
         val sourceSets = androidExtension.sourceSets
 
         val pluginOptions = arrayListOf<SubpluginOption>()
-        pluginOptions += SubpluginOption("features", AndroidExtensionsFeature.VIEWS.featureName)
+        pluginOptions += SubpluginOption("features",
+                                         AndroidExtensionsFeature.parseFeatures(androidExtensionsExtension.features).joinToString(",") { it.featureName })
 
         val mainSourceSet = sourceSets.getByName("main")
         val manifestFile = mainSourceSet.manifest.srcFile

--- a/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/AndroidComponentRegistrar.kt
+++ b/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/AndroidComponentRegistrar.kt
@@ -151,7 +151,7 @@ class AndroidComponentRegistrar : ComponentRegistrar {
         val features = configuration.get(AndroidConfigurationKeys.FEATURES) ?: AndroidExtensionsFeature.values().toSet()
         val isExperimental = configuration.get(AndroidConfigurationKeys.EXPERIMENTAL) == "true"
 
-        if (isExperimental && AndroidExtensionsFeature.PARCELIZE in features) {
+        if (AndroidExtensionsFeature.PARCELIZE in features) {
             registerParcelExtensions(project)
         }
 


### PR DESCRIPTION
It was already being added to the feature list by default, but was only enabled when isExperimental was true.