### PR TITLE
KT-30128 Change Signature should move lambda outside of parentheses if the arguments are reordered so that the lambda goes last

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeSignatureProcessor.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeSignatureProcessor.kt
@@ -31,11 +31,14 @@ import com.intellij.usageView.UsageViewDescriptor
 import com.intellij.util.containers.MultiMap
 import org.jetbrains.kotlin.idea.KotlinBundle
 import org.jetbrains.kotlin.idea.codeInsight.shorten.performDelayedRefactoringRequests
+import org.jetbrains.kotlin.idea.core.canMoveLambdaOutsideParentheses
+import org.jetbrains.kotlin.idea.core.moveFunctionLiteralOutsideParentheses
 import org.jetbrains.kotlin.idea.refactoring.broadcastRefactoringExit
 import org.jetbrains.kotlin.idea.refactoring.changeSignature.usages.KotlinFunctionCallUsage
 import org.jetbrains.kotlin.idea.refactoring.changeSignature.usages.KotlinImplicitReceiverUsage
 import org.jetbrains.kotlin.idea.refactoring.changeSignature.usages.KotlinUsageInfo
 import org.jetbrains.kotlin.idea.refactoring.changeSignature.usages.KotlinWrapperForJavaUsageInfos
+import org.jetbrains.kotlin.psi.KtCallExpression
 import java.util.*
 
 class KotlinChangeSignatureProcessor(
@@ -136,6 +139,12 @@ class KotlinChangeSignatureProcessor(
     override fun performRefactoring(usages: Array<out UsageInfo>) {
         try {
             super.performRefactoring(usages)
+            usages.forEach {
+                val callExpression = it.element as? KtCallExpression ?: return@forEach
+                if (callExpression.canMoveLambdaOutsideParentheses()) {
+                    callExpression.moveFunctionLiteralOutsideParentheses()
+                }
+            }
             performDelayedRefactoringRequests(myProject)
         } finally {
             changeInfo.invalidate()

--- a/idea/testData/refactoring/changeSignature/MoveLambdaParameterToLastAfter.kt
+++ b/idea/testData/refactoring/changeSignature/MoveLambdaParameterToLastAfter.kt
@@ -1,0 +1,6 @@
+fun <caret>foo(y: Int, x: () -> Unit) {
+}
+
+fun test() {
+    foo(1) { 2 }
+}

--- a/idea/testData/refactoring/changeSignature/MoveLambdaParameterToLastBefore.kt
+++ b/idea/testData/refactoring/changeSignature/MoveLambdaParameterToLastBefore.kt
@@ -1,0 +1,6 @@
+fun <caret>foo(x: () -> Unit, y: Int) {
+}
+
+fun test() {
+    foo({ 2 }, 1)
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeSignatureTest.kt
+++ b/idea/tests/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeSignatureTest.kt
@@ -1618,4 +1618,6 @@ class KotlinChangeSignatureTest : KotlinLightCodeInsightFixtureTestCase() {
             addParameter(parameterInfo)
         }
     }
+
+    fun testMoveLambdaParameterToLast() = doTest { swapParameters(0, 1) }
 }


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-30128