### PR TITLE
KT-30082 False positive "redundant `.let` call" for lambda functions stored in nullable references

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/intentions/ReplaceSingleLineLetIntention.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/ReplaceSingleLineLetIntention.kt
@@ -19,6 +19,7 @@ package org.jetbrains.kotlin.idea.intentions
 import com.intellij.openapi.editor.Editor
 import org.jetbrains.kotlin.descriptors.impl.ValueParameterDescriptorImpl
 import org.jetbrains.kotlin.idea.caches.resolve.analyze
+import org.jetbrains.kotlin.idea.caches.resolve.resolveToCall
 import org.jetbrains.kotlin.idea.core.replaced
 import org.jetbrains.kotlin.idea.inspections.IntentionBasedInspection
 import org.jetbrains.kotlin.idea.intentions.branchedTransformations.lineCount
@@ -29,6 +30,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getQualifiedExpressionForSelector
 import org.jetbrains.kotlin.psi.psiUtil.startOffset
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
+import org.jetbrains.kotlin.resolve.calls.model.VariableAsFunctionResolvedCall
 import org.jetbrains.kotlin.resolve.lazy.BodyResolveMode
 
 class ReplaceSingleLineLetInspection : IntentionBasedInspection<KtCallExpression>(
@@ -178,7 +180,7 @@ class ReplaceSingleLineLetIntention : SelfTargetingOffsetIndependentIntention<Kt
             receiver is KtNameReferenceExpression &&
                     receiver.getReferencedName() == parameterName &&
                     !nameUsed(parameterName, except = receiver)
-        }
+        } && callExpression?.resolveToCall() !is VariableAsFunctionResolvedCall
 
     private fun KtDotQualifiedExpression.hasLambdaExpression() = selectorExpression?.anyDescendantOfType<KtLambdaExpression>() ?: false
 

--- a/idea/testData/intentions/replaceSingleLineLetIntention/functionInVariableCall.kt
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/functionInVariableCall.kt
@@ -1,0 +1,7 @@
+// IS_APPLICABLE: false
+// WITH_RUNTIME
+class Foo(val bar: () -> Int)
+
+fun bar(foo: Foo?) {
+    foo?.<caret>let { it.bar() }
+}

--- a/idea/testData/intentions/replaceSingleLineLetIntention/functionInVariableInvokeCall.kt
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/functionInVariableInvokeCall.kt
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+class Foo(val bar: () -> Int)
+
+fun bar(foo: Foo?) {
+    foo?.<caret>let { it.bar.invoke() }
+}

--- a/idea/testData/intentions/replaceSingleLineLetIntention/functionInVariableInvokeCall.kt.after
+++ b/idea/testData/intentions/replaceSingleLineLetIntention/functionInVariableInvokeCall.kt.after
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+class Foo(val bar: () -> Int)
+
+fun bar(foo: Foo?) {
+    foo?.bar?.invoke()
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -15174,6 +15174,16 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
             runTest("idea/testData/intentions/replaceSingleLineLetIntention/functionCallOnSafeCall.kt");
         }
 
+        @TestMetadata("functionInVariableCall.kt")
+        public void testFunctionInVariableCall() throws Exception {
+            runTest("idea/testData/intentions/replaceSingleLineLetIntention/functionInVariableCall.kt");
+        }
+
+        @TestMetadata("functionInVariableInvokeCall.kt")
+        public void testFunctionInVariableInvokeCall() throws Exception {
+            runTest("idea/testData/intentions/replaceSingleLineLetIntention/functionInVariableInvokeCall.kt");
+        }
+
         @TestMetadata("in.kt")
         public void testIn() throws Exception {
             runTest("idea/testData/intentions/replaceSingleLineLetIntention/in.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-30082