### PR TITLE
#KT-26965 Add inspection + quickfix for replacing Collection<T>.count() with .size

### DIFF
--- a/idea/resources/META-INF/plugin-common.xml
+++ b/idea/resources/META-INF/plugin-common.xml
@@ -1753,6 +1753,14 @@
                      level="WEAK WARNING"
                      language="kotlin"
     />
+    <localInspection implementationClass="org.jetbrains.kotlin.idea.inspections.ReplaceCollectionCountWithSizeInspection"
+                     displayName="Collection count can be converted to size"
+                     groupPath="Kotlin"
+                     groupName="Style issues"
+                     enabledByDefault="false"
+                     level="WEAK WARNING"
+                     language="kotlin"
+    />
 
     <localInspection implementationClass="org.jetbrains.kotlin.idea.inspections.DeprecatedCallableAddReplaceWithInspection"
                      displayName="@Deprecated annotation without 'replaceWith' argument"

--- a/idea/resources/inspectionDescriptions/ReplaceCollectionCountWithSize.html
+++ b/idea/resources/inspectionDescriptions/ReplaceCollectionCountWithSize.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This inspection reports usages of collection <code>count()</code>. These function calls can be replaced with <code>size</code>.
+</body>
+</html>

--- a/idea/src/org/jetbrains/kotlin/idea/inspections/ReplaceCollectionCountWithSizeInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/ReplaceCollectionCountWithSizeInspection.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.idea.inspections
+
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElementVisitor
+import org.jetbrains.kotlin.idea.inspections.collections.isCalling
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtPsiFactory
+import org.jetbrains.kotlin.psi.callExpressionVisitor
+
+class ReplaceCollectionCountWithSizeInspection : AbstractKotlinInspection() {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        return callExpressionVisitor { callExpression ->
+            if (callExpression.isCount()) {
+                holder.registerProblem(
+                    callExpression,
+                    "Could be replaced with `size`",
+                    ReplaceCollectionCountWithSizeQuickFix()
+                )
+            }
+        }
+    }
+}
+
+class ReplaceCollectionCountWithSizeQuickFix : LocalQuickFix {
+    override fun getName() = "Replace 'count' with 'size'"
+
+    override fun getFamilyName() = name
+
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        val element = descriptor.psiElement as KtCallExpression
+        element.replace(KtPsiFactory(element).createExpression("size"))
+    }
+}
+
+private fun KtCallExpression.isCount(): Boolean {
+    return this.valueArguments.isEmpty() && isCalling(FqName("kotlin.collections.count"))
+}

--- a/idea/testData/inspectionsLocal/replaceCollectionCountWithSize/.inspection
+++ b/idea/testData/inspectionsLocal/replaceCollectionCountWithSize/.inspection
@@ -1,0 +1,1 @@
+org.jetbrains.kotlin.idea.inspections.ReplaceCollectionCountWithSizeInspection

--- a/idea/testData/inspectionsLocal/replaceCollectionCountWithSize/countOfArray.kt
+++ b/idea/testData/inspectionsLocal/replaceCollectionCountWithSize/countOfArray.kt
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+
+fun foo() {
+    var array = arrayOf(1,2,3)
+    array.<caret>count()
+}

--- a/idea/testData/inspectionsLocal/replaceCollectionCountWithSize/countOfArray.kt.after
+++ b/idea/testData/inspectionsLocal/replaceCollectionCountWithSize/countOfArray.kt.after
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+
+fun foo() {
+    var array = arrayOf(1,2,3)
+    array.size
+}

--- a/idea/testData/inspectionsLocal/replaceCollectionCountWithSize/countOfArrayWithPredicate.kt
+++ b/idea/testData/inspectionsLocal/replaceCollectionCountWithSize/countOfArrayWithPredicate.kt
@@ -1,0 +1,7 @@
+// PROBLEM: none
+// WITH_RUNTIME
+
+fun foo() {
+    var array = arrayOf(1,2,3)
+    array.<caret>count { i -> i == 1 }
+}

--- a/idea/testData/inspectionsLocal/replaceCollectionCountWithSize/countOfCollection.kt
+++ b/idea/testData/inspectionsLocal/replaceCollectionCountWithSize/countOfCollection.kt
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+
+fun foo() {
+    var list = listOf(1,2,3)
+    list.<caret>count()
+}

--- a/idea/testData/inspectionsLocal/replaceCollectionCountWithSize/countOfCollection.kt.after
+++ b/idea/testData/inspectionsLocal/replaceCollectionCountWithSize/countOfCollection.kt.after
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+
+fun foo() {
+    var list = listOf(1,2,3)
+    list.size
+}

--- a/idea/testData/inspectionsLocal/replaceCollectionCountWithSize/countOfMap.kt
+++ b/idea/testData/inspectionsLocal/replaceCollectionCountWithSize/countOfMap.kt
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+
+fun foo() {
+    var map = mapOf(1 to true)
+    map.<caret>count()
+}

--- a/idea/testData/inspectionsLocal/replaceCollectionCountWithSize/countOfMap.kt.after
+++ b/idea/testData/inspectionsLocal/replaceCollectionCountWithSize/countOfMap.kt.after
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+
+fun foo() {
+    var map = mapOf(1 to true)
+    map.size
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -6258,6 +6258,39 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
         }
     }
 
+    @TestMetadata("idea/testData/inspectionsLocal/replaceCollectionCountWithSize")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class ReplaceCollectionCountWithSize extends AbstractLocalInspectionTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY, testDataFilePath);
+        }
+
+        public void testAllFilesPresentInReplaceCollectionCountWithSize() throws Exception {
+            KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/inspectionsLocal/replaceCollectionCountWithSize"), Pattern.compile("^([\\w\\-_]+)\\.(kt|kts)$"), TargetBackend.ANY, true);
+        }
+
+        @TestMetadata("countOfArray.kt")
+        public void testCountOfArray() throws Exception {
+            runTest("idea/testData/inspectionsLocal/replaceCollectionCountWithSize/countOfArray.kt");
+        }
+
+        @TestMetadata("countOfArrayWithPredicate.kt")
+        public void testCountOfArrayWithPredicate() throws Exception {
+            runTest("idea/testData/inspectionsLocal/replaceCollectionCountWithSize/countOfArrayWithPredicate.kt");
+        }
+
+        @TestMetadata("countOfCollection.kt")
+        public void testCountOfCollection() throws Exception {
+            runTest("idea/testData/inspectionsLocal/replaceCollectionCountWithSize/countOfCollection.kt");
+        }
+
+        @TestMetadata("countOfMap.kt")
+        public void testCountOfMap() throws Exception {
+            runTest("idea/testData/inspectionsLocal/replaceCollectionCountWithSize/countOfMap.kt");
+        }
+    }
+
     @TestMetadata("idea/testData/inspectionsLocal/replaceNegatedIsEmptyWithIsNotEmpty")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)


### PR DESCRIPTION
YouTrack: https://youtrack.jetbrains.com/issue/KT-26965.

Covers all cases of [`kotlin-stdlib/kotlin.collections.count`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/count.html).