### PR TITLE
 JVM_IR: defer some branch optimizations to codegen.

### DIFF
--- a/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/BranchingExpressionGenerator.kt
+++ b/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/BranchingExpressionGenerator.kt
@@ -77,7 +77,7 @@ class BranchingExpressionGenerator(statementGenerator: StatementGenerator) : Sta
         if (irBranches.size == 1) {
             val irBranch0 = irBranches[0]
             return buildStatement(ktIf.startOffsetSkippingComments, ktIf.endOffset) {
-                irIfThenMaybeElse(resultType, irBranch0.condition, irBranch0.result, irElseResult)
+                irIfThenMaybeElse(resultType, irBranch0.condition, irBranch0.result, irElseResult, IrStatementOrigin.IF)
             }
         }
 

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/builders/ExpressionHelpers.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/builders/ExpressionHelpers.kt
@@ -117,22 +117,34 @@ fun IrBuilderWithScope.irBranch(condition: IrExpression, result: IrExpression) =
 fun IrBuilderWithScope.irElseBranch(expression: IrExpression) =
     IrElseBranchImpl(startOffset, endOffset, irTrue(), expression)
 
-fun IrBuilderWithScope.irIfThen(type: IrType, condition: IrExpression, thenPart: IrExpression) =
-    IrIfThenElseImpl(startOffset, endOffset, type).apply {
+fun IrBuilderWithScope.irIfThen(type: IrType, condition: IrExpression, thenPart: IrExpression, origin: IrStatementOrigin? = null) =
+    IrIfThenElseImpl(startOffset, endOffset, type, origin).apply {
         branches.add(IrBranchImpl(startOffset, endOffset, condition, thenPart))
     }
 
-fun IrBuilderWithScope.irIfThenElse(type: IrType, condition: IrExpression, thenPart: IrExpression, elsePart: IrExpression) =
-    IrIfThenElseImpl(startOffset, endOffset, type).apply {
+fun IrBuilderWithScope.irIfThenElse(
+    type: IrType,
+    condition: IrExpression,
+    thenPart: IrExpression,
+    elsePart: IrExpression,
+    origin: IrStatementOrigin? = null
+) =
+    IrIfThenElseImpl(startOffset, endOffset, type, origin).apply {
         branches.add(IrBranchImpl(startOffset, endOffset, condition, thenPart))
         branches.add(irElseBranch(elsePart))
     }
 
-fun IrBuilderWithScope.irIfThenMaybeElse(type: IrType, condition: IrExpression, thenPart: IrExpression, elsePart: IrExpression?) =
+fun IrBuilderWithScope.irIfThenMaybeElse(
+    type: IrType,
+    condition: IrExpression,
+    thenPart: IrExpression,
+    elsePart: IrExpression?,
+    origin: IrStatementOrigin? = null
+) =
     if (elsePart != null)
-        irIfThenElse(type, condition, thenPart, elsePart)
+        irIfThenElse(type, condition, thenPart, elsePart, origin)
     else
-        irIfThen(type, condition, thenPart)
+        irIfThen(type, condition, thenPart, origin)
 
 fun IrBuilderWithScope.irIfNull(type: IrType, subject: IrExpression, thenPart: IrExpression, elsePart: IrExpression) =
     irIfThenElse(type, irEqualsNull(subject), thenPart, elsePart)

--- a/compiler/testData/codegen/box/controlStructures/ifConst1.kt
+++ b/compiler/testData/codegen/box/controlStructures/ifConst1.kt
@@ -1,0 +1,19 @@
+fun foo(b: Boolean): String {
+    return if (b) {
+        "OK"
+    } else if (false) {
+        "fail: reached unreachable code at line 5"
+    } else if (true) {
+        "fail: reached unexpected code at line 7"
+    } else if (true) {
+        "fail: reached unreachable code at line 9"
+    } else if (b) {
+        "fail: reached unreachable code at line 11"
+    } else {
+        "fail: reached unreachable code at line 13"
+    }
+}
+
+fun box(): String {
+    return foo(true)
+}

--- a/compiler/testData/codegen/box/controlStructures/ifConst2.kt
+++ b/compiler/testData/codegen/box/controlStructures/ifConst2.kt
@@ -1,0 +1,19 @@
+fun foo(b: Boolean): String {
+    return if (b) {
+        "fail: reached unexpected code at line 3"
+    } else if (false) {
+        "fail: reached unreachable code at line 5"
+    } else if (true) {
+        "OK"
+    } else if (true) {
+        "fail: reached unreachable code at line 9"
+    } else if (b) {
+        "fail: reached unreachable code at line 11"
+    } else {
+        "fail: reached unreachable code at line 13"
+    }
+}
+
+fun box(): String {
+    return foo(false)
+}

--- a/compiler/testData/codegen/bytecodeText/controlStructures/ifConsts.kt
+++ b/compiler/testData/codegen/bytecodeText/controlStructures/ifConsts.kt
@@ -1,0 +1,19 @@
+fun foo(b: Boolean): Int {
+    return if (b) {
+        100
+    } else if (false) {
+        101
+    } else if (true) {
+        102
+    } else if (true) {
+        103
+    } else if (b) {
+        104
+    } else {
+        105
+    }
+}
+
+// 2 BIPUSH
+// 1 BIPUSH 100
+// 1 BIPUSH 102

--- a/compiler/testData/codegen/bytecodeText/lineNumbers/ifConsts.kt
+++ b/compiler/testData/codegen/bytecodeText/lineNumbers/ifConsts.kt
@@ -1,0 +1,35 @@
+fun cond() = false
+
+fun bar() {}
+
+fun foo() {
+    if (cond()) {
+        bar()
+    } else if (true) {
+        bar()
+    } else {
+        bar()
+    }
+
+    if (false) {
+        bar()
+    } else if (true) {
+        bar()
+    } else {
+        bar()
+    }
+
+    if (true) {
+        bar()
+    } else if (false) {
+        bar()
+    } else {
+        bar()
+    }
+}
+
+// 1 LINENUMBER 6
+// 1 LINENUMBER 8
+// 1 LINENUMBER 14
+// 1 LINENUMBER 16
+// 1 LINENUMBER 22

--- a/compiler/testData/codegen/bytecodeText/lineNumbers/ifFalse.kt
+++ b/compiler/testData/codegen/bytecodeText/lineNumbers/ifFalse.kt
@@ -1,0 +1,7 @@
+fun foo(): Int {
+    if (false) {
+        return 1
+    }
+    return 2
+}
+// 1 LINENUMBER 2

--- a/compiler/testData/codegen/bytecodeText/lineNumbers/ifFalseElse.kt
+++ b/compiler/testData/codegen/bytecodeText/lineNumbers/ifFalseElse.kt
@@ -1,0 +1,8 @@
+fun foo(): Int {
+    if (false) {
+        return 1
+    } else {
+        return 2
+    }
+}
+// 1 LINENUMBER 2

--- a/compiler/testData/codegen/bytecodeText/lineNumbers/ifTrue.kt
+++ b/compiler/testData/codegen/bytecodeText/lineNumbers/ifTrue.kt
@@ -1,0 +1,7 @@
+fun foo(): Int {
+    if (true) {
+        return 1
+    }
+    return 2
+}
+// 1 LINENUMBER 2

--- a/compiler/testData/codegen/bytecodeText/lineNumbers/ifTrueElse.kt
+++ b/compiler/testData/codegen/bytecodeText/lineNumbers/ifTrueElse.kt
@@ -1,0 +1,8 @@
+fun foo(): Int {
+    if (true) {
+        return 1
+    } else {
+        return 2
+    }
+}
+// 1 LINENUMBER 2

--- a/compiler/testData/ir/irCfg/loop/digitCount.txt
+++ b/compiler/testData/ir/irCfg/loop/digitCount.txt
@@ -14,7 +14,7 @@ BB 1
 INCOMING <- BB 0, 4
     Do..while entry: DO_WHILE label=null origin=DO_WHILE_LOOP
 CONTENT
-      1 WHEN type=kotlin.Unit origin=null
+      1 WHEN type=kotlin.Unit origin=IF
       2 GET_VAR 'value-parameter m: Int' type=kotlin.Int origin=null
       3 GET_VAR 'number: Int' type=kotlin.Int origin=null
       4 CONST Int type=kotlin.Int value=10
@@ -31,10 +31,10 @@ CONTENT
       4 GET_VAR 'tmp0: Int' type=kotlin.Int origin=null
       5 TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
 OUTGOING -> BB 3
-    When exit: WHEN type=kotlin.Unit origin=null
+    When exit: WHEN type=kotlin.Unit origin=IF
 BB 3
 INCOMING <- BB 2
-    When exit: WHEN type=kotlin.Unit origin=null
+    When exit: WHEN type=kotlin.Unit origin=IF
 CONTENT
       1 SET_VAR 'number: Int' type=kotlin.Unit origin=DIVEQ
       2 GET_VAR 'number: Int' type=kotlin.Int origin=null

--- a/compiler/testData/ir/irCfg/loop/isPerfect.txt
+++ b/compiler/testData/ir/irCfg/loop/isPerfect.txt
@@ -29,7 +29,7 @@ CONTENT
       1 GET_VAR 'tmp0_iterator: IntIterator' type=kotlin.collections.IntIterator origin=null
       2 CALL 'next(): Int' type=kotlin.Int origin=FOR_LOOP_NEXT
       3 VAR FOR_LOOP_VARIABLE name:m type:kotlin.Int flags:val
-      4 WHEN type=kotlin.Unit origin=null
+      4 WHEN type=kotlin.Unit origin=IF
       5 GET_VAR 'value-parameter n: Int' type=kotlin.Int origin=null
       6 GET_VAR 'm: Int' type=kotlin.Int origin=null
       7 CALL 'rem(Int): Int' type=kotlin.Int origin=PERC
@@ -48,7 +48,7 @@ INCOMING <- BB 2
     CALL 'greater(Int, Int): Boolean' type=kotlin.Boolean origin=GT
 CONTENT
       1 SET_VAR 'sum: Int' type=kotlin.Unit origin=PLUSEQ
-      2 WHEN type=kotlin.Unit origin=null
+      2 WHEN type=kotlin.Unit origin=IF
       3 GET_VAR 'sum: Int' type=kotlin.Int origin=null
       4 GET_VAR 'value-parameter n: Int' type=kotlin.Int origin=null
 OUTGOING -> BB 5, 6

--- a/compiler/testData/ir/irCfg/when/expressionIf.txt
+++ b/compiler/testData/ir/irCfg/when/expressionIf.txt
@@ -3,7 +3,7 @@
 BB 0
 CONTENT
       1 FUN name:max visibility:public modality:FINAL <> (x:kotlin.Int, y:kotlin.Int) returnType:kotlin.Int flags:
-      2 WHEN type=kotlin.Int origin=null
+      2 WHEN type=kotlin.Int origin=IF
       3 GET_VAR 'value-parameter x: Int' type=kotlin.Int origin=null
       4 GET_VAR 'value-parameter y: Int' type=kotlin.Int origin=null
 OUTGOING -> BB 1, 2
@@ -20,17 +20,17 @@ INCOMING <- BB 0
 CONTENT
       1 GET_VAR 'value-parameter x: Int' type=kotlin.Int origin=null
 OUTGOING -> BB 4
-    When exit: WHEN type=kotlin.Int origin=null
+    When exit: WHEN type=kotlin.Int origin=IF
 BB 3
 INCOMING <- BB 1
     CONST Boolean type=kotlin.Boolean value=true
 CONTENT
       1 GET_VAR 'value-parameter y: Int' type=kotlin.Int origin=null
 OUTGOING -> BB 4
-    When exit: WHEN type=kotlin.Int origin=null
+    When exit: WHEN type=kotlin.Int origin=IF
 BB 4
 INCOMING <- BB 2, 3
-    When exit: WHEN type=kotlin.Int origin=null
+    When exit: WHEN type=kotlin.Int origin=IF
 CONTENT
       1 RETURN type=kotlin.Nothing from='max(Int, Int): Int'
 OUTGOING -> NONE

--- a/compiler/testData/ir/irCfg/when/ifChain.txt
+++ b/compiler/testData/ir/irCfg/when/ifChain.txt
@@ -3,7 +3,7 @@
 BB 0
 CONTENT
       1 FUN name:minBiRoot visibility:public modality:FINAL <> (a:kotlin.Double, b:kotlin.Double, c:kotlin.Double) returnType:kotlin.Double flags:
-      2 WHEN type=kotlin.Unit origin=null
+      2 WHEN type=kotlin.Unit origin=IF
       3 GET_VAR 'value-parameter a: Double' type=kotlin.Double origin=null
       4 CONST Double type=kotlin.Double value=0.0
 OUTGOING -> BB 1, 6
@@ -12,7 +12,7 @@ BB 1
 INCOMING <- BB 0
     CALL 'ieee754equals(Double?, Double?): Boolean' type=kotlin.Boolean origin=EQEQ
 CONTENT
-      1 WHEN type=kotlin.Unit origin=null
+      1 WHEN type=kotlin.Unit origin=IF
       2 GET_VAR 'value-parameter b: Double' type=kotlin.Double origin=null
       3 CONST Double type=kotlin.Double value=0.0
 OUTGOING -> BB 2, 3
@@ -34,7 +34,7 @@ CONTENT
       3 GET_VAR 'value-parameter b: Double' type=kotlin.Double origin=null
       4 CALL 'div(Double): Double' type=kotlin.Double origin=DIV
       5 VAR name:bc type:kotlin.Double flags:val
-      6 WHEN type=kotlin.Unit origin=null
+      6 WHEN type=kotlin.Unit origin=IF
       7 GET_VAR 'bc: Double' type=kotlin.Double origin=null
       8 CONST Double type=kotlin.Double value=0.0
 OUTGOING -> BB 4, 5
@@ -70,7 +70,7 @@ CONTENT
       8 CALL 'times(Double): Double' type=kotlin.Double origin=MUL
       9 CALL 'minus(Double): Double' type=kotlin.Double origin=MINUS
      10 VAR name:d type:kotlin.Double flags:val
-     11 WHEN type=kotlin.Unit origin=null
+     11 WHEN type=kotlin.Unit origin=IF
      12 GET_VAR 'd: Double' type=kotlin.Double origin=null
      13 CONST Double type=kotlin.Double value=0.0
 OUTGOING -> BB 7, 8
@@ -105,7 +105,7 @@ CONTENT
      16 CALL 'times(Double): Double' type=kotlin.Double origin=MUL
      17 CALL 'div(Double): Double' type=kotlin.Double origin=DIV
      18 VAR name:y2 type:kotlin.Double flags:val
-     19 WHEN type=kotlin.Double origin=null
+     19 WHEN type=kotlin.Double origin=IF
      20 GET_VAR 'y1: Double' type=kotlin.Double origin=null
      21 GET_VAR 'y2: Double' type=kotlin.Double origin=null
 OUTGOING -> BB 9, 10
@@ -122,20 +122,20 @@ INCOMING <- BB 8
 CONTENT
       1 GET_VAR 'y1: Double' type=kotlin.Double origin=null
 OUTGOING -> BB 12
-    When exit: WHEN type=kotlin.Double origin=null
+    When exit: WHEN type=kotlin.Double origin=IF
 BB 11
 INCOMING <- BB 9
     CONST Boolean type=kotlin.Boolean value=true
 CONTENT
       1 GET_VAR 'y2: Double' type=kotlin.Double origin=null
 OUTGOING -> BB 12
-    When exit: WHEN type=kotlin.Double origin=null
+    When exit: WHEN type=kotlin.Double origin=IF
 BB 12
 INCOMING <- BB 10, 11
-    When exit: WHEN type=kotlin.Double origin=null
+    When exit: WHEN type=kotlin.Double origin=IF
 CONTENT
       1 VAR name:y3 type:kotlin.Double flags:val
-      2 WHEN type=kotlin.Double origin=null
+      2 WHEN type=kotlin.Double origin=IF
       3 GET_VAR 'y3: Double' type=kotlin.Double origin=null
       4 CONST Double type=kotlin.Double value=0.0
 OUTGOING -> BB 13, 14
@@ -152,7 +152,7 @@ INCOMING <- BB 12
 CONTENT
       1 CONST Double type=kotlin.Double value=4.0
 OUTGOING -> BB 16
-    When exit: WHEN type=kotlin.Double origin=null
+    When exit: WHEN type=kotlin.Double origin=IF
 BB 15
 INCOMING <- BB 13
     CONST Boolean type=kotlin.Boolean value=true
@@ -160,10 +160,10 @@ CONTENT
       1 GET_VAR 'y3: Double' type=kotlin.Double origin=null
       2 CALL 'unaryMinus(): Double' type=kotlin.Double origin=UMINUS
 OUTGOING -> BB 16
-    When exit: WHEN type=kotlin.Double origin=null
+    When exit: WHEN type=kotlin.Double origin=IF
 BB 16
 INCOMING <- BB 14, 15
-    When exit: WHEN type=kotlin.Double origin=null
+    When exit: WHEN type=kotlin.Double origin=IF
 CONTENT
       1 RETURN type=kotlin.Nothing from='minBiRoot(Double, Double, Double): Double'
 OUTGOING -> NONE

--- a/compiler/testData/ir/irJsText/dynamic/dynamicWithImplicitCast.txt
+++ b/compiler/testData/ir/irJsText/dynamic/dynamicWithImplicitCast.txt
@@ -3,7 +3,7 @@ FILE fqName:<root> fileName:/dynamicWithImplicitCast.kt
     VALUE_PARAMETER name:d index:0 type:dynamic flags:
     BLOCK_BODY
       RETURN type=kotlin.Nothing from='test1(dynamic): Int'
-        WHEN type=kotlin.Int origin=null
+        WHEN type=kotlin.Int origin=IF
           BRANCH
             if: TYPE_OP type=kotlin.Boolean origin=INSTANCEOF typeOperand=kotlin.String
               typeOperand: CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:String modality:FINAL visibility:public flags: superTypes:[kotlin.Comparable<kotlin.String>; kotlin.CharSequence]
@@ -19,7 +19,7 @@ FILE fqName:<root> fileName:/dynamicWithImplicitCast.kt
     VALUE_PARAMETER name:d index:0 type:dynamic flags:
     BLOCK_BODY
       RETURN type=kotlin.Nothing from='test2(dynamic): Int'
-        WHEN type=kotlin.Int origin=null
+        WHEN type=kotlin.Int origin=IF
           BRANCH
             if: TYPE_OP type=kotlin.Boolean origin=INSTANCEOF typeOperand=kotlin.Array<*>
               typeOperand: CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:Array modality:FINAL visibility:public flags: superTypes:[kotlin.Any]

--- a/compiler/testData/ir/irText/expressions/breakContinueInLoopHeader.txt
+++ b/compiler/testData/ir/irText/expressions/breakContinueInLoopHeader.txt
@@ -119,7 +119,7 @@ FILE fqName:<root> fileName:/breakContinueInLoopHeader.kt
                       CALL 'inc(): Int' type=kotlin.Int origin=PREFIX_INCR
                         $this: GET_VAR 'j: Int' type=kotlin.Int origin=PREFIX_INCR
                     GET_VAR 'j: Int' type=kotlin.Int origin=PREFIX_INCR
-              condition: WHEN type=kotlin.Boolean origin=null
+              condition: WHEN type=kotlin.Boolean origin=IF
                 BRANCH
                   if: CALL 'greaterOrEqual(Int, Int): Boolean' type=kotlin.Boolean origin=GTEQ
                     arg0: GET_VAR 'j: Int' type=kotlin.Int origin=null
@@ -128,7 +128,7 @@ FILE fqName:<root> fileName:/breakContinueInLoopHeader.kt
                 BRANCH
                   if: CONST Boolean type=kotlin.Boolean value=true
                   then: BREAK label=null loop.label=Inner
-          WHEN type=kotlin.Unit origin=null
+          WHEN type=kotlin.Unit origin=IF
             BRANCH
               if: CALL 'EQEQ(Any?, Any?): Boolean' type=kotlin.Boolean origin=EQEQ
                 arg0: GET_VAR 'i: Int' type=kotlin.Int origin=null

--- a/compiler/testData/ir/irText/expressions/elvis.txt
+++ b/compiler/testData/ir/irText/expressions/elvis.txt
@@ -50,14 +50,14 @@ FILE fqName:<root> fileName:/elvis.kt
     VALUE_PARAMETER name:a index:0 type:kotlin.Any? flags:
     VALUE_PARAMETER name:b index:1 type:kotlin.Any? flags:
     BLOCK_BODY
-      WHEN type=kotlin.Unit origin=null
+      WHEN type=kotlin.Unit origin=IF
         BRANCH
           if: TYPE_OP type=kotlin.Boolean origin=NOT_INSTANCEOF typeOperand=kotlin.String
             typeOperand: CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:String modality:FINAL visibility:public flags: superTypes:[kotlin.Comparable<kotlin.String>; kotlin.CharSequence; java.io.Serializable]
             GET_VAR 'value-parameter b: Any?' type=kotlin.Any? origin=null
           then: RETURN type=kotlin.Nothing from='test3(Any?, Any?): String'
             CONST String type=kotlin.String value=""
-      WHEN type=kotlin.Unit origin=null
+      WHEN type=kotlin.Unit origin=IF
         BRANCH
           if: TYPE_OP type=kotlin.Boolean origin=NOT_INSTANCEOF typeOperand=kotlin.String?
             typeOperand: CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:String modality:FINAL visibility:public flags: superTypes:[kotlin.Comparable<kotlin.String>; kotlin.CharSequence; java.io.Serializable]

--- a/compiler/testData/ir/irText/expressions/floatingPointComparisons/eqeqRhsConditionPossiblyAffectingLhs.txt
+++ b/compiler/testData/ir/irText/expressions/floatingPointComparisons/eqeqRhsConditionPossiblyAffectingLhs.txt
@@ -5,7 +5,7 @@ FILE fqName:<root> fileName:/eqeqRhsConditionPossiblyAffectingLhs.kt
       RETURN type=kotlin.Nothing from='test(Any): Boolean'
         CALL 'EQEQ(Any?, Any?): Boolean' type=kotlin.Boolean origin=EQEQ
           arg0: GET_VAR 'value-parameter x: Any' type=kotlin.Any origin=null
-          arg1: WHEN type=kotlin.Double origin=null
+          arg1: WHEN type=kotlin.Double origin=IF
             BRANCH
               if: TYPE_OP type=kotlin.Boolean origin=NOT_INSTANCEOF typeOperand=kotlin.Double
                 typeOperand: CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:Double modality:FINAL visibility:public flags: superTypes:[kotlin.Number; kotlin.Comparable<kotlin.Double>; java.io.Serializable]

--- a/compiler/testData/ir/irText/expressions/floatingPointComparisons/whenByFloatingPoint.txt
+++ b/compiler/testData/ir/irText/expressions/floatingPointComparisons/whenByFloatingPoint.txt
@@ -18,7 +18,7 @@ FILE fqName:<root> fileName:/whenByFloatingPoint.kt
   FUN name:testSmartCastInWhenSubject visibility:public modality:FINAL <> (x:kotlin.Any) returnType:kotlin.Int flags:
     VALUE_PARAMETER name:x index:0 type:kotlin.Any flags:
     BLOCK_BODY
-      WHEN type=kotlin.Unit origin=null
+      WHEN type=kotlin.Unit origin=IF
         BRANCH
           if: TYPE_OP type=kotlin.Boolean origin=NOT_INSTANCEOF typeOperand=kotlin.Double
             typeOperand: CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:Double modality:FINAL visibility:public flags: superTypes:[kotlin.Number; kotlin.Comparable<kotlin.Double>; java.io.Serializable]
@@ -44,7 +44,7 @@ FILE fqName:<root> fileName:/whenByFloatingPoint.kt
     VALUE_PARAMETER name:x index:0 type:kotlin.Double flags:
     VALUE_PARAMETER name:y index:1 type:kotlin.Any flags:
     BLOCK_BODY
-      WHEN type=kotlin.Unit origin=null
+      WHEN type=kotlin.Unit origin=IF
         BRANCH
           if: TYPE_OP type=kotlin.Boolean origin=NOT_INSTANCEOF typeOperand=kotlin.Double
             typeOperand: CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:Double modality:FINAL visibility:public flags: superTypes:[kotlin.Number; kotlin.Comparable<kotlin.Double>; java.io.Serializable]
@@ -94,14 +94,14 @@ FILE fqName:<root> fileName:/whenByFloatingPoint.kt
     VALUE_PARAMETER name:x index:0 type:kotlin.Any flags:
     VALUE_PARAMETER name:y index:1 type:kotlin.Any flags:
     BLOCK_BODY
-      WHEN type=kotlin.Unit origin=null
+      WHEN type=kotlin.Unit origin=IF
         BRANCH
           if: TYPE_OP type=kotlin.Boolean origin=NOT_INSTANCEOF typeOperand=kotlin.Double
             typeOperand: CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:Double modality:FINAL visibility:public flags: superTypes:[kotlin.Number; kotlin.Comparable<kotlin.Double>; java.io.Serializable]
             GET_VAR 'value-parameter x: Any' type=kotlin.Any origin=null
           then: RETURN type=kotlin.Nothing from='testSmartCastToDifferentTypes(Any, Any): Int'
             CONST Int type=kotlin.Int value=-1
-      WHEN type=kotlin.Unit origin=null
+      WHEN type=kotlin.Unit origin=IF
         BRANCH
           if: TYPE_OP type=kotlin.Boolean origin=NOT_INSTANCEOF typeOperand=kotlin.Float
             typeOperand: CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:Float modality:FINAL visibility:public flags: superTypes:[kotlin.Number; kotlin.Comparable<kotlin.Float>; java.io.Serializable]
@@ -143,7 +143,7 @@ FILE fqName:<root> fileName:/whenByFloatingPoint.kt
               if: CALL 'EQEQ(Any?, Any?): Boolean' type=kotlin.Boolean origin=EQEQ
                 arg0: GET_VAR 'tmp0_subject: Any' type=kotlin.Any origin=null
                 arg1: CALL 'foo(Double): Double' type=kotlin.Double origin=null
-                  x: WHEN type=kotlin.Double origin=null
+                  x: WHEN type=kotlin.Double origin=IF
                     BRANCH
                       if: TYPE_OP type=kotlin.Boolean origin=NOT_INSTANCEOF typeOperand=kotlin.Double
                         typeOperand: CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:Double modality:FINAL visibility:public flags: superTypes:[kotlin.Number; kotlin.Comparable<kotlin.Double>; java.io.Serializable]

--- a/compiler/testData/ir/irText/expressions/implicitCastToNonNull.txt
+++ b/compiler/testData/ir/irText/expressions/implicitCastToNonNull.txt
@@ -3,7 +3,7 @@ FILE fqName:<root> fileName:/implicitCastToNonNull.kt
     VALUE_PARAMETER name:x index:0 type:kotlin.String? flags:
     BLOCK_BODY
       RETURN type=kotlin.Nothing from='test1(String?): Int'
-        WHEN type=kotlin.Int origin=null
+        WHEN type=kotlin.Int origin=IF
           BRANCH
             if: CALL 'EQEQ(Any?, Any?): Boolean' type=kotlin.Boolean origin=EQEQ
               arg0: GET_VAR 'value-parameter x: String?' type=kotlin.String? origin=null
@@ -18,7 +18,7 @@ FILE fqName:<root> fileName:/implicitCastToNonNull.kt
     VALUE_PARAMETER name:x index:0 type:T flags:
     BLOCK_BODY
       RETURN type=kotlin.Nothing from='test2(T): Int'
-        WHEN type=kotlin.Int origin=null
+        WHEN type=kotlin.Int origin=IF
           BRANCH
             if: CALL 'EQEQ(Any?, Any?): Boolean' type=kotlin.Boolean origin=EQEQ
               arg0: GET_VAR 'value-parameter x: T' type=T origin=null
@@ -33,7 +33,7 @@ FILE fqName:<root> fileName:/implicitCastToNonNull.kt
     VALUE_PARAMETER name:x index:0 type:kotlin.Any flags:
     BLOCK_BODY
       RETURN type=kotlin.Nothing from='test3(Any): Int'
-        WHEN type=kotlin.Int origin=null
+        WHEN type=kotlin.Int origin=IF
           BRANCH
             if: TYPE_OP type=kotlin.Boolean origin=NOT_INSTANCEOF typeOperand=T
               typeOperand: TYPE_PARAMETER name:T index:0 variance: superTypes:[kotlin.CharSequence?]
@@ -50,7 +50,7 @@ FILE fqName:<root> fileName:/implicitCastToNonNull.kt
     VALUE_PARAMETER name:x index:0 type:kotlin.Any? flags:
     BLOCK_BODY
       RETURN type=kotlin.Nothing from='test4(Any?): Int'
-        WHEN type=kotlin.Int origin=null
+        WHEN type=kotlin.Int origin=IF
           BRANCH
             if: TYPE_OP type=kotlin.Boolean origin=NOT_INSTANCEOF typeOperand=T
               typeOperand: TYPE_PARAMETER name:T index:0 variance: superTypes:[kotlin.CharSequence]
@@ -68,7 +68,7 @@ FILE fqName:<root> fileName:/implicitCastToNonNull.kt
     VALUE_PARAMETER name:x index:0 type:T flags:
     VALUE_PARAMETER name:fn index:1 type:kotlin.Function1<S, kotlin.Unit> flags:
     BLOCK_BODY
-      WHEN type=kotlin.Unit origin=null
+      WHEN type=kotlin.Unit origin=IF
         BRANCH
           if: CALL 'NOT(Boolean): Boolean' type=kotlin.Boolean origin=EXCLEQ
             arg0: CALL 'EQEQ(Any?, Any?): Boolean' type=kotlin.Boolean origin=EXCLEQ

--- a/compiler/testData/ir/irText/expressions/implicitCastToTypeParameter.txt
+++ b/compiler/testData/ir/irText/expressions/implicitCastToTypeParameter.txt
@@ -4,7 +4,7 @@ FILE fqName:<root> fileName:/implicitCastToTypeParameter.kt
     $receiver: VALUE_PARAMETER name:<this> type:kotlin.Any flags:
     BLOCK_BODY
       RETURN type=kotlin.Nothing from='test1() on Any: T?'
-        WHEN type=T? origin=null
+        WHEN type=T? origin=IF
           BRANCH
             if: TYPE_OP type=kotlin.Boolean origin=INSTANCEOF typeOperand=T
               typeOperand: TYPE_PARAMETER name:T index:0 variance: superTypes:[kotlin.Any]
@@ -38,7 +38,7 @@ FILE fqName:<root> fileName:/implicitCastToTypeParameter.kt
       $receiver: VALUE_PARAMETER name:<this> type:Foo<T> flags:
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='<get-asT>() on Foo<T>: T?'
-          WHEN type=T? origin=null
+          WHEN type=T? origin=IF
             BRANCH
               if: TYPE_OP type=kotlin.Boolean origin=INSTANCEOF typeOperand=T
                 typeOperand: TYPE_PARAMETER name:T index:0 variance: superTypes:[kotlin.Any]

--- a/compiler/testData/ir/irText/expressions/kt24804.txt
+++ b/compiler/testData/ir/irText/expressions/kt24804.txt
@@ -16,18 +16,18 @@ FILE fqName:<root> fileName:/kt24804.kt
               CALL 'plus(Int): Int' type=kotlin.Int origin=PLUSEQ
                 $this: GET_VAR 'z: Int' type=kotlin.Int origin=PLUSEQ
                 other: CONST Int type=kotlin.Int value=1
-            WHEN type=kotlin.Unit origin=null
+            WHEN type=kotlin.Unit origin=IF
               BRANCH
                 if: CALL 'greater(Int, Int): Boolean' type=kotlin.Boolean origin=GT
                   arg0: GET_VAR 'z: Int' type=kotlin.Int origin=null
                   arg1: CONST Int type=kotlin.Int value=100
                 then: RETURN type=kotlin.Nothing from='run(Boolean, Boolean): String'
                   CONST String type=kotlin.String value="NOT_OK"
-            WHEN type=kotlin.Unit origin=null
+            WHEN type=kotlin.Unit origin=IF
               BRANCH
                 if: GET_VAR 'value-parameter x: Boolean' type=kotlin.Boolean origin=null
                 then: CONTINUE label=l2 loop.label=l2
-            WHEN type=kotlin.Unit origin=null
+            WHEN type=kotlin.Unit origin=IF
               BRANCH
                 if: GET_VAR 'value-parameter y: Boolean' type=kotlin.Boolean origin=null
                 then: CONTINUE label=l2 loop.label=l2

--- a/compiler/testData/ir/irText/expressions/kt27933.txt
+++ b/compiler/testData/ir/irText/expressions/kt27933.txt
@@ -3,7 +3,7 @@ FILE fqName:<root> fileName:/kt27933.kt
     BLOCK_BODY
       VAR name:r type:kotlin.String flags:var
         CONST String type=kotlin.String value=""
-      WHEN type=kotlin.Unit origin=null
+      WHEN type=kotlin.Unit origin=IF
         BRANCH
           if: CALL 'NOT(Boolean): Boolean' type=kotlin.Boolean origin=EXCLEQ
             arg0: CALL 'EQEQ(Any?, Any?): Boolean' type=kotlin.Boolean origin=EXCLEQ
@@ -16,7 +16,7 @@ FILE fqName:<root> fileName:/kt27933.kt
             CALL 'plus(Any?): String' type=kotlin.String origin=PLUSEQ
               $this: GET_VAR 'r: String' type=kotlin.String origin=PLUSEQ
               other: CONST String type=kotlin.String value="O"
-      WHEN type=kotlin.Unit origin=null
+      WHEN type=kotlin.Unit origin=IF
         BRANCH
           if: CALL 'EQEQ(Any?, Any?): Boolean' type=kotlin.Boolean origin=EQEQ
             arg0: GET_VAR 'r: String' type=kotlin.String origin=null

--- a/compiler/testData/ir/irText/expressions/sam/samConversions.txt
+++ b/compiler/testData/ir/irText/expressions/sam/samConversions.txt
@@ -54,7 +54,7 @@ FILE fqName:<root> fileName:/samConversions.kt
         $this: GET_VAR 'this@test4: J' type=J origin=null
         r: TYPE_OP type=java.lang.Runnable? origin=SAM_CONVERSION typeOperand=java.lang.Runnable?
           typeOperand: CLASS IR_EXTERNAL_DECLARATION_STUB INTERFACE name:Runnable modality:ABSTRACT visibility:public flags: superTypes:[kotlin.Any]
-          WHEN type=kotlin.Function0<kotlin.Unit> origin=null
+          WHEN type=kotlin.Function0<kotlin.Unit> origin=IF
             BRANCH
               if: GET_VAR 'value-parameter flag: Boolean' type=kotlin.Boolean origin=null
               then: GET_VAR 'value-parameter a: () -> Unit' type=kotlin.Function0<kotlin.Unit> origin=null

--- a/compiler/testData/ir/irText/expressions/sam/samConversionsWithSmartCasts.txt
+++ b/compiler/testData/ir/irText/expressions/sam/samConversionsWithSmartCasts.txt
@@ -2,7 +2,7 @@ FILE fqName:<root> fileName:/samConversionsWithSmartCasts.kt
   FUN name:test1 visibility:public modality:FINAL <> (a:kotlin.Function0<kotlin.Unit>) returnType:kotlin.Unit flags:
     VALUE_PARAMETER name:a index:0 type:kotlin.Function0<kotlin.Unit> flags:
     BLOCK_BODY
-      WHEN type=kotlin.Unit origin=null
+      WHEN type=kotlin.Unit origin=IF
         BRANCH
           if: TYPE_OP type=kotlin.Boolean origin=INSTANCEOF typeOperand=java.lang.Runnable
             typeOperand: CLASS IR_EXTERNAL_DECLARATION_STUB INTERFACE name:Runnable modality:ABSTRACT visibility:public flags: superTypes:[kotlin.Any]
@@ -15,7 +15,7 @@ FILE fqName:<root> fileName:/samConversionsWithSmartCasts.kt
   FUN name:test2 visibility:public modality:FINAL <> (a:kotlin.Function0<kotlin.Unit>) returnType:kotlin.Unit flags:
     VALUE_PARAMETER name:a index:0 type:kotlin.Function0<kotlin.Unit> flags:
     BLOCK_BODY
-      WHEN type=kotlin.Unit origin=null
+      WHEN type=kotlin.Unit origin=IF
         BRANCH
           if: TYPE_OP type=kotlin.Boolean origin=INSTANCEOF typeOperand=java.lang.Runnable
             typeOperand: CLASS IR_EXTERNAL_DECLARATION_STUB INTERFACE name:Runnable modality:ABSTRACT visibility:public flags: superTypes:[kotlin.Any]
@@ -29,7 +29,7 @@ FILE fqName:<root> fileName:/samConversionsWithSmartCasts.kt
   FUN name:test3 visibility:public modality:FINAL <> (a:kotlin.Function0<kotlin.Unit>) returnType:kotlin.Unit flags:
     VALUE_PARAMETER name:a index:0 type:kotlin.Function0<kotlin.Unit> flags:
     BLOCK_BODY
-      WHEN type=kotlin.Unit origin=null
+      WHEN type=kotlin.Unit origin=IF
         BRANCH
           if: TYPE_OP type=kotlin.Boolean origin=INSTANCEOF typeOperand=java.lang.Runnable
             typeOperand: CLASS IR_EXTERNAL_DECLARATION_STUB INTERFACE name:Runnable modality:ABSTRACT visibility:public flags: superTypes:[kotlin.Any]
@@ -47,7 +47,7 @@ FILE fqName:<root> fileName:/samConversionsWithSmartCasts.kt
     VALUE_PARAMETER name:a index:0 type:kotlin.Function0<kotlin.Unit> flags:
     VALUE_PARAMETER name:b index:1 type:kotlin.Function0<kotlin.Unit> flags:
     BLOCK_BODY
-      WHEN type=kotlin.Unit origin=null
+      WHEN type=kotlin.Unit origin=IF
         BRANCH
           if: TYPE_OP type=kotlin.Boolean origin=INSTANCEOF typeOperand=java.lang.Runnable
             typeOperand: CLASS IR_EXTERNAL_DECLARATION_STUB INTERFACE name:Runnable modality:ABSTRACT visibility:public flags: superTypes:[kotlin.Any]
@@ -64,7 +64,7 @@ FILE fqName:<root> fileName:/samConversionsWithSmartCasts.kt
   FUN name:test5 visibility:public modality:FINAL <> (a:kotlin.Any) returnType:kotlin.Unit flags:
     VALUE_PARAMETER name:a index:0 type:kotlin.Any flags:
     BLOCK_BODY
-      WHEN type=kotlin.Unit origin=null
+      WHEN type=kotlin.Unit origin=IF
         BRANCH
           if: TYPE_OP type=kotlin.Boolean origin=INSTANCEOF typeOperand=java.lang.Runnable
             typeOperand: CLASS IR_EXTERNAL_DECLARATION_STUB INTERFACE name:Runnable modality:ABSTRACT visibility:public flags: superTypes:[kotlin.Any]
@@ -78,7 +78,7 @@ FILE fqName:<root> fileName:/samConversionsWithSmartCasts.kt
   FUN name:test5x visibility:public modality:FINAL <> (a:kotlin.Any) returnType:kotlin.Unit flags:
     VALUE_PARAMETER name:a index:0 type:kotlin.Any flags:
     BLOCK_BODY
-      WHEN type=kotlin.Unit origin=null
+      WHEN type=kotlin.Unit origin=IF
         BRANCH
           if: TYPE_OP type=kotlin.Boolean origin=INSTANCEOF typeOperand=java.lang.Runnable
             typeOperand: CLASS IR_EXTERNAL_DECLARATION_STUB INTERFACE name:Runnable modality:ABSTRACT visibility:public flags: superTypes:[kotlin.Any]

--- a/compiler/testData/ir/irText/expressions/setFieldWithImplicitCast.txt
+++ b/compiler/testData/ir/irText/expressions/setFieldWithImplicitCast.txt
@@ -9,7 +9,7 @@ FILE fqName:<root> fileName:/Derived.kt
       $this: VALUE_PARAMETER name:<this> type:Derived flags:
       VALUE_PARAMETER name:v index:0 type:kotlin.Any flags:
       BLOCK_BODY
-        WHEN type=kotlin.Unit origin=null
+        WHEN type=kotlin.Unit origin=IF
           BRANCH
             if: TYPE_OP type=kotlin.Boolean origin=INSTANCEOF typeOperand=kotlin.String
               typeOperand: CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:String modality:FINAL visibility:public flags: superTypes:[kotlin.Comparable<kotlin.String>; kotlin.CharSequence; java.io.Serializable]

--- a/compiler/testData/ir/irText/expressions/smartCasts.txt
+++ b/compiler/testData/ir/irText/expressions/smartCasts.txt
@@ -18,7 +18,7 @@ FILE fqName:<root> fileName:/smartCasts.kt
   FUN name:test1 visibility:public modality:FINAL <> (x:kotlin.Any) returnType:kotlin.Unit flags:
     VALUE_PARAMETER name:x index:0 type:kotlin.Any flags:
     BLOCK_BODY
-      WHEN type=kotlin.Unit origin=null
+      WHEN type=kotlin.Unit origin=IF
         BRANCH
           if: TYPE_OP type=kotlin.Boolean origin=NOT_INSTANCEOF typeOperand=kotlin.String
             typeOperand: CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:String modality:FINAL visibility:public flags: superTypes:[kotlin.Comparable<kotlin.String>; kotlin.CharSequence; java.io.Serializable]
@@ -47,7 +47,7 @@ FILE fqName:<root> fileName:/smartCasts.kt
   FUN name:test2 visibility:public modality:FINAL <> (x:kotlin.Any) returnType:kotlin.String flags:
     VALUE_PARAMETER name:x index:0 type:kotlin.Any flags:
     BLOCK_BODY
-      WHEN type=kotlin.Unit origin=null
+      WHEN type=kotlin.Unit origin=IF
         BRANCH
           if: TYPE_OP type=kotlin.Boolean origin=NOT_INSTANCEOF typeOperand=kotlin.String
             typeOperand: CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:String modality:FINAL visibility:public flags: superTypes:[kotlin.Comparable<kotlin.String>; kotlin.CharSequence; java.io.Serializable]
@@ -62,7 +62,7 @@ FILE fqName:<root> fileName:/smartCasts.kt
   FUN name:test3 visibility:public modality:FINAL <> (x:kotlin.Any) returnType:kotlin.String flags:
     VALUE_PARAMETER name:x index:0 type:kotlin.Any flags:
     BLOCK_BODY
-      WHEN type=kotlin.Unit origin=null
+      WHEN type=kotlin.Unit origin=IF
         BRANCH
           if: TYPE_OP type=kotlin.Boolean origin=NOT_INSTANCEOF typeOperand=kotlin.String
             typeOperand: CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:String modality:FINAL visibility:public flags: superTypes:[kotlin.Comparable<kotlin.String>; kotlin.CharSequence; java.io.Serializable]

--- a/compiler/testData/ir/irText/expressions/smartCastsWithDestructuring.txt
+++ b/compiler/testData/ir/irText/expressions/smartCastsWithDestructuring.txt
@@ -42,7 +42,7 @@ FILE fqName:<root> fileName:/smartCastsWithDestructuring.kt
   FUN name:test visibility:public modality:FINAL <> (x:I1) returnType:kotlin.Unit flags:
     VALUE_PARAMETER name:x index:0 type:I1 flags:
     BLOCK_BODY
-      WHEN type=kotlin.Unit origin=null
+      WHEN type=kotlin.Unit origin=IF
         BRANCH
           if: TYPE_OP type=kotlin.Boolean origin=NOT_INSTANCEOF typeOperand=I2
             typeOperand: CLASS INTERFACE name:I2 modality:ABSTRACT visibility:public flags: superTypes:[kotlin.Any]

--- a/compiler/testData/ir/irText/expressions/throw.txt
+++ b/compiler/testData/ir/irText/expressions/throw.txt
@@ -6,7 +6,7 @@ FILE fqName:<root> fileName:/throw.kt
   FUN name:testImplicitCast visibility:public modality:FINAL <> (a:kotlin.Any) returnType:kotlin.Unit flags:
     VALUE_PARAMETER name:a index:0 type:kotlin.Any flags:
     BLOCK_BODY
-      WHEN type=kotlin.Unit origin=null
+      WHEN type=kotlin.Unit origin=IF
         BRANCH
           if: TYPE_OP type=kotlin.Boolean origin=INSTANCEOF typeOperand=kotlin.Throwable
             typeOperand: CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:Throwable modality:OPEN visibility:public flags: superTypes:[kotlin.Any; java.io.Serializable]

--- a/compiler/testData/ir/irText/expressions/tryCatchWithImplicitCast.txt
+++ b/compiler/testData/ir/irText/expressions/tryCatchWithImplicitCast.txt
@@ -2,7 +2,7 @@ FILE fqName:<root> fileName:/tryCatchWithImplicitCast.kt
   FUN name:testImplicitCast visibility:public modality:FINAL <> (a:kotlin.Any) returnType:kotlin.Unit flags:
     VALUE_PARAMETER name:a index:0 type:kotlin.Any flags:
     BLOCK_BODY
-      WHEN type=kotlin.Unit origin=null
+      WHEN type=kotlin.Unit origin=IF
         BRANCH
           if: TYPE_OP type=kotlin.Boolean origin=NOT_INSTANCEOF typeOperand=kotlin.String
             typeOperand: CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:String modality:FINAL visibility:public flags: superTypes:[kotlin.Comparable<kotlin.String>; kotlin.CharSequence; java.io.Serializable]

--- a/compiler/testData/ir/irText/expressions/useImportedMember.txt
+++ b/compiler/testData/ir/irText/expressions/useImportedMember.txt
@@ -160,7 +160,7 @@ FILE fqName:<root> fileName:/useImportedMember.kt
       $this: VALUE_PARAMETER name:<this> type:kotlin.Any flags:
   FUN name:box visibility:public modality:FINAL <> () returnType:kotlin.String flags:
     BLOCK_BODY
-      WHEN type=kotlin.Unit origin=null
+      WHEN type=kotlin.Unit origin=IF
         BRANCH
           if: CALL 'NOT(Boolean): Boolean' type=kotlin.Boolean origin=EXCLEQ
             arg0: CALL 'EQEQ(Any?, Any?): Boolean' type=kotlin.Boolean origin=EXCLEQ
@@ -170,7 +170,7 @@ FILE fqName:<root> fileName:/useImportedMember.kt
               arg1: CONST Int type=kotlin.Int value=1
           then: RETURN type=kotlin.Nothing from='box(): String'
             CONST String type=kotlin.String value="1"
-      WHEN type=kotlin.Unit origin=null
+      WHEN type=kotlin.Unit origin=IF
         BRANCH
           if: CALL 'NOT(Boolean): Boolean' type=kotlin.Boolean origin=EXCLEQ
             arg0: CALL 'EQEQ(Any?, Any?): Boolean' type=kotlin.Boolean origin=EXCLEQ
@@ -180,7 +180,7 @@ FILE fqName:<root> fileName:/useImportedMember.kt
               arg1: CONST Int type=kotlin.Int value=2
           then: RETURN type=kotlin.Nothing from='box(): String'
             CONST String type=kotlin.String value="2"
-      WHEN type=kotlin.Unit origin=null
+      WHEN type=kotlin.Unit origin=IF
         BRANCH
           if: CALL 'NOT(Boolean): Boolean' type=kotlin.Boolean origin=EXCLEQ
             arg0: CALL 'EQEQ(Any?, Any?): Boolean' type=kotlin.Boolean origin=EXCLEQ
@@ -190,7 +190,7 @@ FILE fqName:<root> fileName:/useImportedMember.kt
               arg1: CONST Int type=kotlin.Int value=3
           then: RETURN type=kotlin.Nothing from='box(): String'
             CONST String type=kotlin.String value="3"
-      WHEN type=kotlin.Unit origin=null
+      WHEN type=kotlin.Unit origin=IF
         BRANCH
           if: CALL 'NOT(Boolean): Boolean' type=kotlin.Boolean origin=EXCLEQ
             arg0: CALL 'EQEQ(Any?, Any?): Boolean' type=kotlin.Boolean origin=EXCLEQ
@@ -202,7 +202,7 @@ FILE fqName:<root> fileName:/useImportedMember.kt
       CALL '<set-p>(Int): Unit' type=kotlin.Unit origin=EQ
         $this: GET_OBJECT 'C' type=C
         <set-?>: CONST Int type=kotlin.Int value=5
-      WHEN type=kotlin.Unit origin=null
+      WHEN type=kotlin.Unit origin=IF
         BRANCH
           if: CALL 'NOT(Boolean): Boolean' type=kotlin.Boolean origin=EXCLEQ
             arg0: CALL 'EQEQ(Any?, Any?): Boolean' type=kotlin.Boolean origin=EXCLEQ
@@ -211,7 +211,7 @@ FILE fqName:<root> fileName:/useImportedMember.kt
               arg1: CONST Int type=kotlin.Int value=5
           then: RETURN type=kotlin.Nothing from='box(): String'
             CONST String type=kotlin.String value="5"
-      WHEN type=kotlin.Unit origin=null
+      WHEN type=kotlin.Unit origin=IF
         BRANCH
           if: CALL 'NOT(Boolean): Boolean' type=kotlin.Boolean origin=EXCLEQ
             arg0: CALL 'EQEQ(Any?, Any?): Boolean' type=kotlin.Boolean origin=EXCLEQ
@@ -221,7 +221,7 @@ FILE fqName:<root> fileName:/useImportedMember.kt
               arg1: CONST Int type=kotlin.Int value=6
           then: RETURN type=kotlin.Nothing from='box(): String'
             CONST String type=kotlin.String value="6"
-      WHEN type=kotlin.Unit origin=null
+      WHEN type=kotlin.Unit origin=IF
         BRANCH
           if: CALL 'NOT(Boolean): Boolean' type=kotlin.Boolean origin=EXCLEQ
             arg0: CALL 'EQEQ(Any?, Any?): Boolean' type=kotlin.Boolean origin=EXCLEQ
@@ -232,7 +232,7 @@ FILE fqName:<root> fileName:/useImportedMember.kt
               arg1: CONST String type=kotlin.String value="7"
           then: RETURN type=kotlin.Nothing from='box(): String'
             CONST String type=kotlin.String value="7"
-      WHEN type=kotlin.Unit origin=null
+      WHEN type=kotlin.Unit origin=IF
         BRANCH
           if: CALL 'NOT(Boolean): Boolean' type=kotlin.Boolean origin=EXCLEQ
             arg0: CALL 'EQEQ(Any?, Any?): Boolean' type=kotlin.Boolean origin=EXCLEQ
@@ -243,7 +243,7 @@ FILE fqName:<root> fileName:/useImportedMember.kt
               arg1: CONST String type=kotlin.String value="8"
           then: RETURN type=kotlin.Nothing from='box(): String'
             CONST String type=kotlin.String value="8"
-      WHEN type=kotlin.Unit origin=null
+      WHEN type=kotlin.Unit origin=IF
         BRANCH
           if: CALL 'NOT(Boolean): Boolean' type=kotlin.Boolean origin=EXCLEQ
             arg0: CALL 'EQEQ(Any?, Any?): Boolean' type=kotlin.Boolean origin=EXCLEQ
@@ -254,7 +254,7 @@ FILE fqName:<root> fileName:/useImportedMember.kt
               arg1: CONST Int type=kotlin.Int value=9
           then: RETURN type=kotlin.Nothing from='box(): String'
             CONST String type=kotlin.String value="9"
-      WHEN type=kotlin.Unit origin=null
+      WHEN type=kotlin.Unit origin=IF
         BRANCH
           if: CALL 'NOT(Boolean): Boolean' type=kotlin.Boolean origin=EXCLEQ
             arg0: CALL 'EQEQ(Any?, Any?): Boolean' type=kotlin.Boolean origin=EXCLEQ
@@ -265,7 +265,7 @@ FILE fqName:<root> fileName:/useImportedMember.kt
               arg1: CONST String type=kotlin.String value="10"
           then: RETURN type=kotlin.Nothing from='box(): String'
             CONST String type=kotlin.String value="10"
-      WHEN type=kotlin.Unit origin=null
+      WHEN type=kotlin.Unit origin=IF
         BRANCH
           if: CALL 'NOT(Boolean): Boolean' type=kotlin.Boolean origin=EXCLEQ
             arg0: CALL 'EQEQ(Any?, Any?): Boolean' type=kotlin.Boolean origin=EXCLEQ

--- a/compiler/testData/ir/irText/expressions/varargWithImplicitCast.txt
+++ b/compiler/testData/ir/irText/expressions/varargWithImplicitCast.txt
@@ -2,7 +2,7 @@ FILE fqName:<root> fileName:/varargWithImplicitCast.kt
   FUN name:testScalar visibility:public modality:FINAL <> (a:kotlin.Any) returnType:kotlin.IntArray flags:
     VALUE_PARAMETER name:a index:0 type:kotlin.Any flags:
     BLOCK_BODY
-      WHEN type=kotlin.Unit origin=null
+      WHEN type=kotlin.Unit origin=IF
         BRANCH
           if: TYPE_OP type=kotlin.Boolean origin=NOT_INSTANCEOF typeOperand=kotlin.Int
             typeOperand: CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:Int modality:FINAL visibility:public flags: superTypes:[kotlin.Number; kotlin.Comparable<kotlin.Int>; java.io.Serializable]
@@ -18,7 +18,7 @@ FILE fqName:<root> fileName:/varargWithImplicitCast.kt
   FUN name:testSpread visibility:public modality:FINAL <> (a:kotlin.Any) returnType:kotlin.IntArray flags:
     VALUE_PARAMETER name:a index:0 type:kotlin.Any flags:
     BLOCK_BODY
-      WHEN type=kotlin.Unit origin=null
+      WHEN type=kotlin.Unit origin=IF
         BRANCH
           if: TYPE_OP type=kotlin.Boolean origin=NOT_INSTANCEOF typeOperand=kotlin.IntArray
             typeOperand: CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:IntArray modality:FINAL visibility:public flags: superTypes:[kotlin.Any; kotlin.Cloneable; java.io.Serializable]

--- a/compiler/testData/ir/irText/expressions/whileDoWhile.txt
+++ b/compiler/testData/ir/irText/expressions/whileDoWhile.txt
@@ -72,7 +72,7 @@ FILE fqName:<root> fileName:/whileDoWhile.kt
     BLOCK_BODY
       VAR name:a type:kotlin.Any? flags:val
         CONST Null type=kotlin.Nothing? value=null
-      WHEN type=kotlin.Unit origin=null
+      WHEN type=kotlin.Unit origin=IF
         BRANCH
           if: TYPE_OP type=kotlin.Boolean origin=INSTANCEOF typeOperand=kotlin.Boolean
             typeOperand: CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:Boolean modality:FINAL visibility:public flags: superTypes:[kotlin.Comparable<kotlin.Boolean>; java.io.Serializable]

--- a/compiler/testData/ir/irText/lambdas/nonLocalReturn.txt
+++ b/compiler/testData/ir/irText/lambdas/nonLocalReturn.txt
@@ -56,7 +56,7 @@ FILE fqName:<root> fileName:/nonLocalReturn.kt
           FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> (it:kotlin.Int) returnType:kotlin.Unit flags:
             VALUE_PARAMETER name:it index:0 type:kotlin.Int flags:
             BLOCK_BODY
-              WHEN type=kotlin.Unit origin=null
+              WHEN type=kotlin.Unit origin=IF
                 BRANCH
                   if: CALL 'EQEQ(Any?, Any?): Boolean' type=kotlin.Boolean origin=EQEQ
                     arg0: GET_VAR 'value-parameter it: Int' type=kotlin.Int origin=null
@@ -77,7 +77,7 @@ FILE fqName:<root> fileName:/nonLocalReturn.kt
           FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> (it:kotlin.Int) returnType:kotlin.Unit flags:
             VALUE_PARAMETER name:it index:0 type:kotlin.Int flags:
             BLOCK_BODY
-              WHEN type=kotlin.Unit origin=null
+              WHEN type=kotlin.Unit origin=IF
                 BRANCH
                   if: CALL 'EQEQ(Any?, Any?): Boolean' type=kotlin.Boolean origin=EQEQ
                     arg0: GET_VAR 'value-parameter it: Int' type=kotlin.Int origin=null

--- a/compiler/testData/ir/irText/regressions/coercionInLoop.txt
+++ b/compiler/testData/ir/irText/regressions/coercionInLoop.txt
@@ -13,7 +13,7 @@ FILE fqName:<root> fileName:/coercionInLoop.kt
         condition: CALL 'hasNext(): Boolean' type=kotlin.Boolean origin=null
           $this: GET_VAR 'x: DoubleIterator' type=kotlin.collections.DoubleIterator origin=null
         body: BLOCK type=kotlin.Unit origin=null
-          WHEN type=kotlin.Unit origin=null
+          WHEN type=kotlin.Unit origin=IF
             BRANCH
               if: CALL 'NOT(Boolean): Boolean' type=kotlin.Boolean origin=EXCLEQ
                 arg0: CALL 'ieee754equals(Double?, Double?): Boolean' type=kotlin.Boolean origin=EXCLEQ

--- a/compiler/testData/ir/irText/stubs/builtinMap.txt
+++ b/compiler/testData/ir/irText/stubs/builtinMap.txt
@@ -6,7 +6,7 @@ FILE fqName:<root> fileName:/builtinMap.kt
     VALUE_PARAMETER name:pair index:0 type:kotlin.Pair<K1, V1> flags:
     BLOCK_BODY
       RETURN type=kotlin.Nothing from='plus(Pair<K1, V1>) on Map<out K1, V1>: Map<K1, V1>'
-        WHEN type=kotlin.collections.Map<K1, V1> origin=null
+        WHEN type=kotlin.collections.Map<K1, V1> origin=IF
           BRANCH
             if: CALL 'isEmpty(): Boolean' type=kotlin.Boolean origin=null
               $this: GET_VAR 'this@plus: Map<out K1, V1>' type=kotlin.collections.Map<out K1, V1> origin=null

--- a/compiler/testData/ir/irText/types/intersectionType2.txt
+++ b/compiler/testData/ir/irText/types/intersectionType2.txt
@@ -94,7 +94,7 @@ FILE fqName:<root> fileName:/intersectionType2.kt
                 VAR name:nn type:C flags:val
                   CALL 'constructor C()' type=C origin=null
                 VAR name:c type:kotlin.Any flags:val
-                  WHEN type=kotlin.Any origin=null
+                  WHEN type=kotlin.Any origin=IF
                     BRANCH
                       if: CONST Boolean type=kotlin.Boolean value=true
                       then: GET_VAR 'mm: B' type=B origin=null

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -4673,6 +4673,16 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             runTest("compiler/testData/codegen/box/controlStructures/forUserType.kt");
         }
 
+        @TestMetadata("ifConst1.kt")
+        public void testIfConst1() throws Exception {
+            runTest("compiler/testData/codegen/box/controlStructures/ifConst1.kt");
+        }
+
+        @TestMetadata("ifConst2.kt")
+        public void testIfConst2() throws Exception {
+            runTest("compiler/testData/codegen/box/controlStructures/ifConst2.kt");
+        }
+
         @TestMetadata("inRangeConditionsInWhen.kt")
         public void testInRangeConditionsInWhen() throws Exception {
             runTest("compiler/testData/codegen/box/controlStructures/inRangeConditionsInWhen.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
@@ -1106,6 +1106,11 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
             KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/codegen/bytecodeText/controlStructures"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.JVM, true);
         }
 
+        @TestMetadata("ifConsts.kt")
+        public void testIfConsts() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/controlStructures/ifConsts.kt");
+        }
+
         @TestMetadata("kt17110.kt")
         public void testKt17110() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/controlStructures/kt17110.kt");
@@ -2640,9 +2645,34 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
             KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/codegen/bytecodeText/lineNumbers"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.JVM, true);
         }
 
+        @TestMetadata("ifConsts.kt")
+        public void testIfConsts() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/lineNumbers/ifConsts.kt");
+        }
+
         @TestMetadata("ifElse.kt")
         public void testIfElse() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/lineNumbers/ifElse.kt");
+        }
+
+        @TestMetadata("ifFalse.kt")
+        public void testIfFalse() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/lineNumbers/ifFalse.kt");
+        }
+
+        @TestMetadata("ifFalseElse.kt")
+        public void testIfFalseElse() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/lineNumbers/ifFalseElse.kt");
+        }
+
+        @TestMetadata("ifTrue.kt")
+        public void testIfTrue() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/lineNumbers/ifTrue.kt");
+        }
+
+        @TestMetadata("ifTrueElse.kt")
+        public void testIfTrueElse() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/lineNumbers/ifTrueElse.kt");
         }
 
         @TestMetadata("singleThen.kt")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -4673,6 +4673,16 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/controlStructures/forUserType.kt");
         }
 
+        @TestMetadata("ifConst1.kt")
+        public void testIfConst1() throws Exception {
+            runTest("compiler/testData/codegen/box/controlStructures/ifConst1.kt");
+        }
+
+        @TestMetadata("ifConst2.kt")
+        public void testIfConst2() throws Exception {
+            runTest("compiler/testData/codegen/box/controlStructures/ifConst2.kt");
+        }
+
         @TestMetadata("inRangeConditionsInWhen.kt")
         public void testInRangeConditionsInWhen() throws Exception {
             runTest("compiler/testData/codegen/box/controlStructures/inRangeConditionsInWhen.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -4673,6 +4673,16 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             runTest("compiler/testData/codegen/box/controlStructures/forUserType.kt");
         }
 
+        @TestMetadata("ifConst1.kt")
+        public void testIfConst1() throws Exception {
+            runTest("compiler/testData/codegen/box/controlStructures/ifConst1.kt");
+        }
+
+        @TestMetadata("ifConst2.kt")
+        public void testIfConst2() throws Exception {
+            runTest("compiler/testData/codegen/box/controlStructures/ifConst2.kt");
+        }
+
         @TestMetadata("inRangeConditionsInWhen.kt")
         public void testInRangeConditionsInWhen() throws Exception {
             runTest("compiler/testData/codegen/box/controlStructures/inRangeConditionsInWhen.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
@@ -1106,6 +1106,11 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
             KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/codegen/bytecodeText/controlStructures"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.JVM_IR, true);
         }
 
+        @TestMetadata("ifConsts.kt")
+        public void testIfConsts() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/controlStructures/ifConsts.kt");
+        }
+
         @TestMetadata("kt17110.kt")
         public void testKt17110() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/controlStructures/kt17110.kt");
@@ -2640,9 +2645,34 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
             KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/codegen/bytecodeText/lineNumbers"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.JVM_IR, true);
         }
 
+        @TestMetadata("ifConsts.kt")
+        public void testIfConsts() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/lineNumbers/ifConsts.kt");
+        }
+
         @TestMetadata("ifElse.kt")
         public void testIfElse() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/lineNumbers/ifElse.kt");
+        }
+
+        @TestMetadata("ifFalse.kt")
+        public void testIfFalse() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/lineNumbers/ifFalse.kt");
+        }
+
+        @TestMetadata("ifFalseElse.kt")
+        public void testIfFalseElse() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/lineNumbers/ifFalseElse.kt");
+        }
+
+        @TestMetadata("ifTrue.kt")
+        public void testIfTrue() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/lineNumbers/ifTrue.kt");
+        }
+
+        @TestMetadata("ifTrueElse.kt")
+        public void testIfTrueElse() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/lineNumbers/ifTrueElse.kt");
         }
 
         @TestMetadata("singleThen.kt")

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/IrJsCodegenBoxTestGenerated.java
@@ -3858,6 +3858,16 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/controlStructures/forUserType.kt");
         }
 
+        @TestMetadata("ifConst1.kt")
+        public void testIfConst1() throws Exception {
+            runTest("compiler/testData/codegen/box/controlStructures/ifConst1.kt");
+        }
+
+        @TestMetadata("ifConst2.kt")
+        public void testIfConst2() throws Exception {
+            runTest("compiler/testData/codegen/box/controlStructures/ifConst2.kt");
+        }
+
         @TestMetadata("inRangeConditionsInWhen.kt")
         public void testInRangeConditionsInWhen() throws Exception {
             runTest("compiler/testData/codegen/box/controlStructures/inRangeConditionsInWhen.kt");

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -3868,6 +3868,16 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/controlStructures/forUserType.kt");
         }
 
+        @TestMetadata("ifConst1.kt")
+        public void testIfConst1() throws Exception {
+            runTest("compiler/testData/codegen/box/controlStructures/ifConst1.kt");
+        }
+
+        @TestMetadata("ifConst2.kt")
+        public void testIfConst2() throws Exception {
+            runTest("compiler/testData/codegen/box/controlStructures/ifConst2.kt");
+        }
+
         @TestMetadata("inRangeConditionsInWhen.kt")
         public void testInRangeConditionsInWhen() throws Exception {
             runTest("compiler/testData/codegen/box/controlStructures/inRangeConditionsInWhen.kt");


### PR DESCRIPTION
Specifically, defer the removal of hand-written "if (true)" from
JvmBuiltinOptimizationLowering into codegen so that appropriate debug
info (and a NOP) can be inserted.

Some optimization in visitBlock in JvmBuiltinOptimizationLowering depends on the removal of the "if (true)" in visitWhen. Therefore, it cannot be deferred (unless we move the logic into visiBlock to make it even more complicated). Fortunately, the optimization in visitBlock only cares about compiler generated constructs, which is transparent to users and need no debug info. To defer the optimization for non-compiler generated constructs, cl:1260 marks "hand-written" ifs by setting origin to IF so that
* compiler generate stuffs have origin == null and can be removed in IR.
* hand-written stuffs have origin == IF and can only be removed, with correct debug info generated, in ExpressionCodegen.
