### PR TITLE
Optimize JVM bytecode for for-loops.

### DIFF
--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/ForLoopsLowering.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/ForLoopsLowering.kt
@@ -8,17 +8,17 @@ package org.jetbrains.kotlin.backend.common.lower.loops
 import org.jetbrains.kotlin.backend.common.CommonBackendContext
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
-import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.common.lower.irIfThen
 import org.jetbrains.kotlin.backend.common.phaser.makeIrFilePhase
 import org.jetbrains.kotlin.ir.IrStatement
-import org.jetbrains.kotlin.ir.builders.*
+import org.jetbrains.kotlin.ir.builders.irCallOp
+import org.jetbrains.kotlin.ir.builders.irGet
+import org.jetbrains.kotlin.ir.builders.irSetVar
 import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.declarations.IrVariable
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.expressions.impl.IrCompositeImpl
-import org.jetbrains.kotlin.ir.expressions.impl.IrConstImpl
 import org.jetbrains.kotlin.ir.symbols.IrVariableSymbol
 import org.jetbrains.kotlin.ir.types.toKotlinType
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
@@ -178,9 +178,7 @@ private class RangeLoopTransformer(
             forLoopInfo.inductionVariable.type.toKotlinType(),
             forLoopInfo.step.type.toKotlinType()
         )
-        if (forLoopInfo is ProgressionLoopHeader) {
-            forLoopInfo.loopVariable = variable
-        }
+        forLoopInfo.loopVariable = variable
         return with(context.createIrBuilder(getScopeOwnerSymbol(), initializer.startOffset, initializer.endOffset)) {
             variable.initializer = forLoopInfo.initializeLoopVariable(symbols, this)
             val increment = irSetVar(

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/ForLoopsLowering.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/ForLoopsLowering.kt
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.common.lower.loops
+
+import org.jetbrains.kotlin.backend.common.CommonBackendContext
+import org.jetbrains.kotlin.backend.common.FileLoweringPass
+import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
+import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
+import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
+import org.jetbrains.kotlin.backend.common.lower.irIfThen
+import org.jetbrains.kotlin.backend.common.phaser.makeIrFilePhase
+import org.jetbrains.kotlin.ir.IrStatement
+import org.jetbrains.kotlin.ir.builders.*
+import org.jetbrains.kotlin.ir.declarations.IrFile
+import org.jetbrains.kotlin.ir.declarations.IrVariable
+import org.jetbrains.kotlin.ir.expressions.*
+import org.jetbrains.kotlin.ir.expressions.impl.IrCompositeImpl
+import org.jetbrains.kotlin.ir.expressions.impl.IrConstImpl
+import org.jetbrains.kotlin.ir.symbols.IrVariableSymbol
+import org.jetbrains.kotlin.ir.types.toKotlinType
+import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
+import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
+import org.jetbrains.kotlin.util.OperatorNameConventions
+
+val forLoopsPhase = makeIrFilePhase(
+    ::ForLoopsLowering,
+    name = "ForLoopsLowering",
+    description = "For loops lowering"
+)
+
+/**
+ * This lowering pass optimizes for-loops.
+ *
+ * Replace iteration over ranges (X.indices, a..b, etc.) and arrays with
+ * simple while loop over primitive induction variable.
+ */
+internal class ForLoopsLowering(val context: CommonBackendContext) : FileLoweringPass {
+
+    private val headerInfoBuilder = HeaderInfoBuilder(context)
+
+    override fun lower(irFile: IrFile) {
+        val oldLoopToNewLoop = mutableMapOf<IrLoop, IrLoop>()
+        val transformer = RangeLoopTransformer(context, oldLoopToNewLoop, headerInfoBuilder)
+        irFile.transformChildrenVoid(transformer)
+        // Update references in break/continue.
+        irFile.transformChildrenVoid(object : IrElementTransformerVoid() {
+            override fun visitBreakContinue(jump: IrBreakContinue): IrExpression {
+                oldLoopToNewLoop[jump.loop]?.let { jump.loop = it }
+                return jump
+            }
+        })
+    }
+}
+
+private class RangeLoopTransformer(
+    val context: CommonBackendContext,
+    val oldLoopToNewLoop: MutableMap<IrLoop, IrLoop>,
+    headerInfoBuilder: HeaderInfoBuilder
+) : IrElementTransformerVoidWithContext() {
+
+    private val symbols = context.ir.symbols
+    private val iteratorToLoopHeader = mutableMapOf<IrVariableSymbol, ForLoopHeader>()
+    private val headerProcessor = HeaderProcessor(context, headerInfoBuilder, this::getScopeOwnerSymbol)
+
+    fun getScopeOwnerSymbol() = currentScope!!.scope.scopeOwnerSymbol
+
+    override fun visitVariable(declaration: IrVariable): IrStatement {
+        val initializer = declaration.initializer
+        if (initializer == null || initializer !is IrCall) {
+            return super.visitVariable(declaration)
+        }
+        return when (initializer.origin) {
+            IrStatementOrigin.FOR_LOOP_ITERATOR ->
+                processHeader(declaration)
+            IrStatementOrigin.FOR_LOOP_NEXT ->
+                processNext(declaration)
+            else -> null
+        } ?: super.visitVariable(declaration)
+    }
+
+    private fun processHeader(variable: IrVariable): IrStatement? {
+        assert(variable.symbol !in iteratorToLoopHeader)
+        val forLoopInfo = headerProcessor.processHeader(variable)
+            ?: return null
+        iteratorToLoopHeader[variable.symbol] = forLoopInfo
+        return IrCompositeImpl(
+            variable.startOffset,
+            variable.endOffset,
+            context.irBuiltIns.unitType,
+            null,
+            forLoopInfo.declarations
+        )
+    }
+
+    /**
+     * This loop
+     *
+     * for (i in first..last step foo) { ... }
+     *
+     * is represented in IR in such a manner:
+     *
+     * val it = (first..last step foo).iterator()
+     * while (it.hasNext()) {
+     *     val i = it.next()
+     *     ...
+     * }
+     *
+     * We transform it into the following loop:
+     *
+     * var it = first
+     * if (it <= last) {  // (it >= last if the progression is decreasing)
+     *     do {
+     *         val i = it++
+     *         ...
+     *     } while (i != last)
+     * }
+     *
+     * In case of iteration over array we transform it into following:
+     * while (i <= array.size - 1) {
+     *     val element = array[i]
+     *     i++
+     *     ...
+     * }
+     */
+    // TODO:  Lower `for (i in a until b)` to loop with precondition: for (i = a; i < b; a++);
+    override fun visitWhileLoop(loop: IrWhileLoop): IrExpression {
+        if (loop.origin != IrStatementOrigin.FOR_LOOP_INNER_WHILE) {
+            return super.visitWhileLoop(loop)
+        }
+        return with(context.createIrBuilder(getScopeOwnerSymbol(), loop.startOffset, loop.endOffset)) {
+            val newBody = loop.body?.transform(this@RangeLoopTransformer, null)?.let {
+                if (it is IrContainerExpression && !it.isTransparentScope) {
+                    IrCompositeImpl(startOffset, endOffset, it.type, it.origin, it.statements)
+                } else {
+                    it
+                }
+            }
+            val loopHeader = getLoopHeader(loop.condition)
+                ?: return super.visitWhileLoop(loop)
+            val newLoop = loopHeader.buildBody(this, loop, newBody)
+            oldLoopToNewLoop[loop] = newLoop
+            // Build a check for an empty progression before the loop.
+            if (loopHeader is ProgressionLoopHeader) {
+                buildEmptinessCheck(newLoop, loopHeader)
+            } else {
+                newLoop
+            }
+        }
+    }
+
+    private fun DeclarationIrBuilder.buildMinValueCondition(forLoopHeader: ForLoopHeader): IrExpression {
+        // Condition for a corner case: for (i in a until Int.MIN_VALUE) {}.
+        // Check if forLoopHeader.bound > MIN_VALUE.
+        val progressionType = forLoopHeader.progressionType
+        val irBuiltIns = context.irBuiltIns
+        val minConst = when (progressionType) {
+            ProgressionType.INT_PROGRESSION -> IrConstImpl
+                .int(startOffset, endOffset, irBuiltIns.intType, Int.MIN_VALUE)
+            ProgressionType.CHAR_PROGRESSION -> IrConstImpl
+                .char(startOffset, endOffset, irBuiltIns.charType, 0.toChar())
+            ProgressionType.LONG_PROGRESSION -> IrConstImpl
+                .long(startOffset, endOffset, irBuiltIns.longType, Long.MIN_VALUE)
+        }
+        val compareTo = symbols.getBinaryOperator(
+            OperatorNameConventions.COMPARE_TO,
+            forLoopHeader.bound.type.toKotlinType(),
+            minConst.type.toKotlinType()
+        )
+        return irCall(irBuiltIns.greaterFunByOperandType[irBuiltIns.int]?.symbol!!).apply {
+            val compareToCall = irCall(compareTo).apply {
+                dispatchReceiver = irGet(forLoopHeader.bound)
+                putValueArgument(0, minConst)
+            }
+            putValueArgument(0, compareToCall)
+            putValueArgument(1, irInt(0))
+        }
+    }
+
+    private fun DeclarationIrBuilder.buildEmptinessCheck(loop: IrLoop, loopHeader: ProgressionLoopHeader): IrExpression {
+        val builtIns = context.irBuiltIns
+        val comparingBuiltIn = loopHeader.comparingFunction(builtIns)
+
+        // Check if inductionVariable <= last (or >= in case of downTo).
+        // TODO: Use comparingBuiltIn directly
+        val compareTo = symbols.getBinaryOperator(
+            OperatorNameConventions.COMPARE_TO,
+            loopHeader.inductionVariable.type.toKotlinType(),
+            loopHeader.last.type.toKotlinType()
+        )
+
+        val check = irCall(comparingBuiltIn).apply {
+            putValueArgument(
+                0,
+                irCallOp(compareTo, compareTo.owner.returnType, irGet(loopHeader.inductionVariable), irGet(loopHeader.last))
+            )
+            putValueArgument(1, irInt(0))
+        }
+
+        // Process closed and open ranges in different manners.
+        return if (loopHeader.closed) {
+            irIfThen(check, loop)   // if (inductionVariable <= last) { loop }
+        } else {
+            // Take into account a corner case: for (i in a until Int.MIN_VALUE) {}.
+            // if (inductionVariable <= last && bound > MIN_VALUE) { loop }
+            irIfThen(check, irIfThen(buildMinValueCondition(loopHeader), loop))
+        }
+    }
+
+    private fun getLoopHeader(oldCondition: IrExpression): ForLoopHeader? {
+        if (oldCondition !is IrCall || oldCondition.origin != IrStatementOrigin.FOR_LOOP_HAS_NEXT) {
+            return null
+        }
+        val irIteratorAccess = oldCondition.dispatchReceiver as? IrGetValue
+            ?: throw AssertionError()
+        // Return null if we didn't lower the corresponding header.
+        return iteratorToLoopHeader[irIteratorAccess.symbol]
+    }
+
+    // Lower getting a next induction variable value.
+    fun processNext(variable: IrVariable): IrExpression? {
+        val initializer = variable.initializer as IrCall
+
+        val iterator = initializer.dispatchReceiver as? IrGetValue
+            ?: throw AssertionError()
+        val forLoopInfo = iteratorToLoopHeader[iterator.symbol]
+            ?: return null  // If we didn't lower a corresponding header.
+        // TODO: Use PLUS_ASSIGN to increment
+        val plusOperator = symbols.getBinaryOperator(
+            OperatorNameConventions.PLUS,
+            forLoopInfo.inductionVariable.type.toKotlinType(),
+            forLoopInfo.step.type.toKotlinType()
+        )
+        if (forLoopInfo is ProgressionLoopHeader) {
+            forLoopInfo.loopVariable = variable
+        }
+        return with(context.createIrBuilder(getScopeOwnerSymbol(), initializer.startOffset, initializer.endOffset)) {
+            variable.initializer = forLoopInfo.initializeLoopVariable(symbols, this)
+            val increment = irSetVar(
+                forLoopInfo.inductionVariable.symbol, irCallOp(
+                    plusOperator, plusOperator.owner.returnType,
+                    irGet(forLoopInfo.inductionVariable),
+                    irGet(forLoopInfo.step)
+                )
+            )
+            IrCompositeImpl(
+                variable.startOffset,
+                variable.endOffset,
+                context.irBuiltIns.unitType,
+                IrStatementOrigin.FOR_LOOP_NEXT,
+                listOf(variable, increment)
+            )
+        }
+    }
+}

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/ForLoopsLowering.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/ForLoopsLowering.kt
@@ -25,7 +25,6 @@ import org.jetbrains.kotlin.ir.types.toKotlinType
 import org.jetbrains.kotlin.ir.util.functions
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
-import org.jetbrains.kotlin.util.OperatorNameConventions
 
 val forLoopsPhase = makeIrFilePhase(
     ::ForLoopsLowering,
@@ -171,12 +170,7 @@ private class RangeLoopTransformer(
             oldLoopToNewLoop[loop] = newLoop
 
             // Surround the new loop with a check for an empty loop, if necessary.
-            if (loopHeader.needsEmptinessCheck) {
-                val notEmptyCondition = loopHeader.buildNotEmptyCondition(this@with)
-                if (notEmptyCondition != null)
-                    return irIfThen(notEmptyCondition, newLoop)
-            }
-            return newLoop
+            return loopHeader.buildNotEmptyConditionIfNecessary(this@with)?.let { irIfThen(it, newLoop) } ?: newLoop
         }
     }
 

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/HeaderInfo.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/HeaderInfo.kt
@@ -58,8 +58,8 @@ internal enum class ProgressionDirection { DECREASING, INCREASING, UNKNOWN }
 // Information about loop that is required by HeaderProcessor to build ForLoopHeader
 internal sealed class HeaderInfo(
     val progressionType: ProgressionType,
-    val lowerBound: IrExpression,
-    val upperBound: IrExpression,
+    val first: IrExpression,
+    val last: IrExpression,
     val step: IrExpression,
     val closed: Boolean
 ) {
@@ -78,22 +78,22 @@ internal sealed class HeaderInfo(
 
 internal class ProgressionHeaderInfo(
     progressionType: ProgressionType,
-    lowerBound: IrExpression,
-    upperBound: IrExpression,
+    first: IrExpression,
+    last: IrExpression,
     step: IrExpression,
     closed: Boolean = true,
     val additionalNotEmptyCondition: IrExpression? = null
-) : HeaderInfo(progressionType, lowerBound, upperBound, step, closed)
+) : HeaderInfo(progressionType, first, last, step, closed)
 
 internal class ArrayHeaderInfo(
-    lowerBound: IrExpression,
-    upperBound: IrExpression,
+    first: IrExpression,
+    last: IrExpression,
     step: IrExpression,
     val arrayVariable: IrVariable
 ) : HeaderInfo(
     ProgressionType.INT_PROGRESSION,
-    lowerBound,
-    upperBound,
+    first,
+    last,
     step,
     closed = false
 )

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/HeaderInfo.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/HeaderInfo.kt
@@ -9,7 +9,6 @@ import org.jetbrains.kotlin.backend.common.CommonBackendContext
 import org.jetbrains.kotlin.backend.common.ir.Symbols
 import org.jetbrains.kotlin.backend.common.lower.matchers.IrCallMatcher
 import org.jetbrains.kotlin.ir.IrElement
-import org.jetbrains.kotlin.ir.declarations.IrValueDeclaration
 import org.jetbrains.kotlin.ir.declarations.IrVariable
 import org.jetbrains.kotlin.ir.descriptors.IrBuiltIns
 import org.jetbrains.kotlin.ir.expressions.IrCall
@@ -52,7 +51,7 @@ internal sealed class HeaderInfo(
     val progressionType: ProgressionType,
     val lowerBound: IrExpression,
     val upperBound: IrExpression,
-    val step: IrExpression?, // null value denotes default step (1)
+    val step: IrExpression,
     val increasing: Boolean,
     val closed: Boolean
 )
@@ -61,7 +60,7 @@ internal class ProgressionHeaderInfo(
     progressionType: ProgressionType,
     lowerBound: IrExpression,
     upperBound: IrExpression,
-    step: IrExpression? = null,
+    step: IrExpression,
     increasing: Boolean = true,
     closed: Boolean = true
 ) : HeaderInfo(progressionType, lowerBound, upperBound, step, increasing, closed)
@@ -69,12 +68,13 @@ internal class ProgressionHeaderInfo(
 internal class ArrayHeaderInfo(
     lowerBound: IrExpression,
     upperBound: IrExpression,
-    val arrayDeclaration: IrValueDeclaration
+    step: IrExpression,
+    val arrayVariable: IrVariable
 ) : HeaderInfo(
     ProgressionType.INT_PROGRESSION,
     lowerBound,
     upperBound,
-    step = null,
+    step,
     increasing = true,
     closed = false
 )
@@ -102,9 +102,9 @@ private class ProgressionHeaderInfoBuilder(val context: CommonBackendContext) : 
 
     private val progressionHandlers = listOf(
         IndicesHandler(context),
-        UntilHandler(progressionElementTypes),
-        DownToHandler(progressionElementTypes),
-        RangeToHandler(progressionElementTypes)
+        UntilHandler(context, progressionElementTypes),
+        DownToHandler(context, progressionElementTypes),
+        RangeToHandler(context, progressionElementTypes)
     )
 
     override fun visitElement(element: IrElement, data: Nothing?): HeaderInfo? = null

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/HeaderInfo.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/HeaderInfo.kt
@@ -26,10 +26,10 @@ import org.jetbrains.kotlin.utils.addToStdlib.firstNotNullResult
 // TODO: Handle UIntProgression, ULongProgression
 
 /** Represents a progression type in the Kotlin stdlib. */
-enum class ProgressionType(val numberCastFunctionName: Name) {
-    INT_PROGRESSION(Name.identifier("toInt")),
-    LONG_PROGRESSION(Name.identifier("toLong")),
-    CHAR_PROGRESSION(Name.identifier("toChar"));
+enum class ProgressionType(val elementCastFunctionName: Name, val stepCastFunctionName: Name) {
+    INT_PROGRESSION(Name.identifier("toInt"), Name.identifier("toInt")),
+    LONG_PROGRESSION(Name.identifier("toLong"), Name.identifier("toLong")),
+    CHAR_PROGRESSION(Name.identifier("toChar"), Name.identifier("toInt"));
 
     /** Returns the [IrType] of the `first`/`last` properties and elements in the progression. */
     fun elementType(builtIns: IrBuiltIns): IrType = when (this) {

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/HeaderInfo.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/HeaderInfo.kt
@@ -36,7 +36,6 @@ internal sealed class HeaderInfo(
     val upperBound: IrExpression,
     val step: IrExpression?, // null value denotes default step (1)
     val increasing: Boolean,
-    val needLastCalculation: Boolean,
     val closed: Boolean
 )
 
@@ -46,9 +45,8 @@ internal class ProgressionHeaderInfo(
     upperBound: IrExpression,
     step: IrExpression? = null,
     increasing: Boolean = true,
-    needLastCalculation: Boolean = false,
     closed: Boolean = true
-) : HeaderInfo(progressionType, lowerBound, upperBound, step, increasing, needLastCalculation, closed)
+) : HeaderInfo(progressionType, lowerBound, upperBound, step, increasing, closed)
 
 internal class ArrayHeaderInfo(
     lowerBound: IrExpression,
@@ -60,7 +58,6 @@ internal class ArrayHeaderInfo(
     upperBound,
     step = null,
     increasing = true,
-    needLastCalculation = false,
     closed = false
 )
 
@@ -89,7 +86,6 @@ private class ProgressionHeaderInfoBuilder(val context: CommonBackendContext) : 
         IndicesHandler(context),
         UntilHandler(progressionElementTypes),
         DownToHandler(progressionElementTypes),
-        StepHandler(context, this),
         RangeToHandler(progressionElementTypes)
     )
 

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/HeaderInfo.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/HeaderInfo.kt
@@ -134,12 +134,20 @@ private class ProgressionHeaderInfoBuilder(val context: CommonBackendContext) : 
 }
 
 internal class HeaderInfoBuilder(context: CommonBackendContext) {
-    private val progressionInfoBuilder = ProgressionHeaderInfoBuilder(context)
+    private val progressionHeaderInfoBuilder = ProgressionHeaderInfoBuilder(context)
     private val arrayIterationHandler = ArrayIterationHandler(context)
+    private val defaultProgressionHandler = DefaultProgressionHandler(context)
 
     fun build(variable: IrVariable): HeaderInfo? {
-        val initializer = variable.initializer!! as IrCall
+        // TODO: Merge DefaultProgressionHandler into ProgressionHeaderInfoBuilder. Not
+        // straightforward because ProgressionHeaderInfoBuilder works only on calls and not just
+        // any progression expression (i.e., progression may not be a call result).
+
+        // DefaultProgressionHandler must come AFTER ProgressionHeaderInfoBuilder, which handles
+        // more specialized forms of progressions.
+        val initializer = variable.initializer as IrCall
         return arrayIterationHandler.handle(initializer, null)
-            ?: initializer.dispatchReceiver?.accept(progressionInfoBuilder, null)
+            ?: initializer.dispatchReceiver?.accept(progressionHeaderInfoBuilder, null)
+            ?: defaultProgressionHandler.handle(initializer, null)
     }
 }

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/HeaderInfo.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/HeaderInfo.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.common.lower.loops
+
+import org.jetbrains.kotlin.backend.common.CommonBackendContext
+import org.jetbrains.kotlin.backend.common.lower.matchers.IrCallMatcher
+import org.jetbrains.kotlin.backend.common.utils.isSubtypeOf
+import org.jetbrains.kotlin.ir.IrElement
+import org.jetbrains.kotlin.ir.declarations.IrValueDeclaration
+import org.jetbrains.kotlin.ir.declarations.IrVariable
+import org.jetbrains.kotlin.ir.expressions.IrCall
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.types.IrType
+import org.jetbrains.kotlin.ir.util.defaultType
+import org.jetbrains.kotlin.ir.visitors.IrElementVisitor
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.utils.addToStdlib.firstNotNullResult
+
+// TODO: Handle withIndex()
+// TODO: Handle reversed()
+// TODO: Handle direct iteration on Ranges/Progressions (e.g., NOT using rangeTo or step)
+// TODO: Handle Strings/CharSequences
+
+enum class ProgressionType(val numberCastFunctionName: Name) {
+    INT_PROGRESSION(Name.identifier("toInt")),
+    LONG_PROGRESSION(Name.identifier("toLong")),
+    CHAR_PROGRESSION(Name.identifier("toChar"));
+}
+
+// Information about loop that is required by HeaderProcessor to build ForLoopHeader
+internal sealed class HeaderInfo(
+    val progressionType: ProgressionType,
+    val lowerBound: IrExpression,
+    val upperBound: IrExpression,
+    val step: IrExpression?, // null value denotes default step (1)
+    val increasing: Boolean,
+    val needLastCalculation: Boolean,
+    val closed: Boolean
+)
+
+internal class ProgressionHeaderInfo(
+    progressionType: ProgressionType,
+    lowerBound: IrExpression,
+    upperBound: IrExpression,
+    step: IrExpression? = null,
+    increasing: Boolean = true,
+    needLastCalculation: Boolean = false,
+    closed: Boolean = true
+) : HeaderInfo(progressionType, lowerBound, upperBound, step, increasing, needLastCalculation, closed)
+
+internal class ArrayHeaderInfo(
+    lowerBound: IrExpression,
+    upperBound: IrExpression,
+    val arrayDeclaration: IrValueDeclaration
+) : HeaderInfo(
+    ProgressionType.INT_PROGRESSION,
+    lowerBound,
+    upperBound,
+    step = null,
+    increasing = true,
+    needLastCalculation = false,
+    closed = false
+)
+
+internal interface HeaderInfoHandler<T> {
+    val matcher: IrCallMatcher
+
+    fun build(call: IrCall, data: T): HeaderInfo?
+
+    fun handle(irCall: IrCall, data: T) = if (matcher(irCall)) {
+        build(irCall, data)
+    } else {
+        null
+    }
+}
+internal typealias ProgressionHandler = HeaderInfoHandler<ProgressionType>
+
+// We need to wrap builder into visitor because of `StepHandler` which has to visit its subtree
+// to get information about underlying progression.
+private class ProgressionHeaderInfoBuilder(val context: CommonBackendContext) : IrElementVisitor<HeaderInfo?, Nothing?> {
+
+    private val symbols = context.ir.symbols
+
+    private val progressionElementTypes = symbols.integerClassesTypes + symbols.char.descriptor.defaultType
+
+    private val progressionHandlers = listOf(
+        IndicesHandler(context),
+        UntilHandler(progressionElementTypes),
+        DownToHandler(progressionElementTypes),
+        StepHandler(context, this),
+        RangeToHandler(progressionElementTypes)
+    )
+
+    private fun IrType.getProgressionType(): ProgressionType? = when {
+        isSubtypeOf(symbols.charProgression.owner.defaultType) -> ProgressionType.CHAR_PROGRESSION
+        isSubtypeOf(symbols.intProgression.owner.defaultType) -> ProgressionType.INT_PROGRESSION
+        isSubtypeOf(symbols.longProgression.owner.defaultType) -> ProgressionType.LONG_PROGRESSION
+        else -> null
+    }
+
+    override fun visitElement(element: IrElement, data: Nothing?): HeaderInfo? = null
+
+    override fun visitCall(expression: IrCall, data: Nothing?): HeaderInfo? {
+        val progressionType = expression.type.getProgressionType()
+            ?: return null
+        return progressionHandlers.firstNotNullResult { it.handle(expression, progressionType) }
+    }
+}
+
+internal class HeaderInfoBuilder(context: CommonBackendContext) {
+    private val progressionInfoBuilder = ProgressionHeaderInfoBuilder(context)
+    private val arrayIterationHandler = ArrayIterationHandler(context)
+
+    fun build(variable: IrVariable): HeaderInfo? {
+        val initializer = variable.initializer!! as IrCall
+        return arrayIterationHandler.handle(initializer, null)
+            ?: initializer.dispatchReceiver?.accept(progressionInfoBuilder, null)
+    }
+}

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/HeaderInfo.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/HeaderInfo.kt
@@ -81,7 +81,8 @@ internal class ProgressionHeaderInfo(
     lowerBound: IrExpression,
     upperBound: IrExpression,
     step: IrExpression,
-    closed: Boolean = true
+    closed: Boolean = true,
+    val additionalNotEmptyCondition: IrExpression? = null
 ) : HeaderInfo(progressionType, lowerBound, upperBound, step, closed)
 
 internal class ArrayHeaderInfo(

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/HeaderInfo.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/HeaderInfo.kt
@@ -37,6 +37,12 @@ enum class ProgressionType(val numberCastFunctionName: Name) {
         ProgressionType.CHAR_PROGRESSION -> builtIns.charType
     }
 
+    /** Returns the [IrType] of the `step` property in the progression. */
+    fun stepType(builtIns: IrBuiltIns): IrType = when (this) {
+        ProgressionType.INT_PROGRESSION, ProgressionType.CHAR_PROGRESSION -> builtIns.intType
+        ProgressionType.LONG_PROGRESSION -> builtIns.longType
+    }
+
     companion object {
         fun fromIrType(irType: IrType, symbols: Symbols<CommonBackendContext>): ProgressionType? = when {
             irType.isSubtypeOfClass(symbols.charProgression) -> ProgressionType.CHAR_PROGRESSION

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/HeaderInfo.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/HeaderInfo.kt
@@ -60,8 +60,7 @@ internal sealed class HeaderInfo(
     val progressionType: ProgressionType,
     val first: IrExpression,
     val last: IrExpression,
-    val step: IrExpression,
-    val closed: Boolean
+    val step: IrExpression
 ) {
     val direction: ProgressionDirection by lazy {
         // If step is a constant (either Int or Long), then we can determine the direction.
@@ -81,9 +80,9 @@ internal class ProgressionHeaderInfo(
     first: IrExpression,
     last: IrExpression,
     step: IrExpression,
-    closed: Boolean = true,
+    val additionalVariables: List<IrVariable> = listOf(),
     val additionalNotEmptyCondition: IrExpression? = null
-) : HeaderInfo(progressionType, first, last, step, closed)
+) : HeaderInfo(progressionType, first, last, step)
 
 internal class ArrayHeaderInfo(
     first: IrExpression,
@@ -94,8 +93,7 @@ internal class ArrayHeaderInfo(
     ProgressionType.INT_PROGRESSION,
     first,
     last,
-    step,
-    closed = false
+    step
 )
 
 internal interface HeaderInfoHandler<T> {

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/HeaderInfo.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/HeaderInfo.kt
@@ -7,14 +7,13 @@ package org.jetbrains.kotlin.backend.common.lower.loops
 
 import org.jetbrains.kotlin.backend.common.CommonBackendContext
 import org.jetbrains.kotlin.backend.common.lower.matchers.IrCallMatcher
-import org.jetbrains.kotlin.backend.common.utils.isSubtypeOf
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.declarations.IrValueDeclaration
 import org.jetbrains.kotlin.ir.declarations.IrVariable
 import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.types.IrType
-import org.jetbrains.kotlin.ir.util.defaultType
+import org.jetbrains.kotlin.ir.types.isSubtypeOfClass
 import org.jetbrains.kotlin.ir.visitors.IrElementVisitor
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.utils.addToStdlib.firstNotNullResult
@@ -95,9 +94,9 @@ private class ProgressionHeaderInfoBuilder(val context: CommonBackendContext) : 
     )
 
     private fun IrType.getProgressionType(): ProgressionType? = when {
-        isSubtypeOf(symbols.charProgression.owner.defaultType) -> ProgressionType.CHAR_PROGRESSION
-        isSubtypeOf(symbols.intProgression.owner.defaultType) -> ProgressionType.INT_PROGRESSION
-        isSubtypeOf(symbols.longProgression.owner.defaultType) -> ProgressionType.LONG_PROGRESSION
+        isSubtypeOfClass(symbols.charProgression) -> ProgressionType.CHAR_PROGRESSION
+        isSubtypeOfClass(symbols.intProgression) -> ProgressionType.INT_PROGRESSION
+        isSubtypeOfClass(symbols.longProgression) -> ProgressionType.LONG_PROGRESSION
         else -> null
     }
 

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/HeaderInfo.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/HeaderInfo.kt
@@ -61,7 +61,8 @@ internal sealed class HeaderInfo(
     val progressionType: ProgressionType,
     val first: IrExpression,
     val last: IrExpression,
-    val step: IrExpression
+    val step: IrExpression,
+    val isLastInclusive: Boolean
 ) {
     val direction: ProgressionDirection by lazy {
         // If step is a constant (either Int or Long), then we can determine the direction.
@@ -82,10 +83,10 @@ internal class ProgressionHeaderInfo(
     first: IrExpression,
     last: IrExpression,
     step: IrExpression,
+    isLastInclusive: Boolean = true,
     canOverflow: Boolean? = null,
-    val additionalVariables: List<IrVariable> = listOf(),
-    val additionalNotEmptyCondition: IrExpression? = null
-) : HeaderInfo(progressionType, first, last, step) {
+    val additionalVariables: List<IrVariable> = listOf()
+) : HeaderInfo(progressionType, first, last, step, isLastInclusive) {
 
     private val _canOverflow: Boolean? = canOverflow
     val canOverflow: Boolean by lazy {
@@ -129,7 +130,8 @@ internal class ArrayHeaderInfo(
     ProgressionType.INT_PROGRESSION,
     first,
     last,
-    step
+    step,
+    isLastInclusive = false
 )
 
 /** Matches a call to `iterator()` and builds a [HeaderInfo] out of the call's context. */

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/HeaderInfo.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/HeaderInfo.kt
@@ -65,7 +65,7 @@ internal sealed class HeaderInfo(
 ) {
     val direction: ProgressionDirection by lazy {
         // If step is a constant (either Int or Long), then we can determine the direction.
-        val stepValue = (step as? IrConst<*>)?.value as? Number?
+        val stepValue = (step as? IrConst<*>)?.value as? Number
         val stepValueAsLong = stepValue?.toLong()
         when {
             stepValueAsLong == null -> ProgressionDirection.UNKNOWN
@@ -82,9 +82,42 @@ internal class ProgressionHeaderInfo(
     first: IrExpression,
     last: IrExpression,
     step: IrExpression,
+    canOverflow: Boolean? = null,
     val additionalVariables: List<IrVariable> = listOf(),
     val additionalNotEmptyCondition: IrExpression? = null
-) : HeaderInfo(progressionType, first, last, step)
+) : HeaderInfo(progressionType, first, last, step) {
+
+    private val _canOverflow: Boolean? = canOverflow
+    val canOverflow: Boolean by lazy {
+        if (_canOverflow != null) return@lazy _canOverflow
+
+        // Induction variable can overflow if it is not a const, or is MAX/MIN_VALUE (depending on direction).
+        val lastValue = (last as? IrConst<*>)?.value
+        val lastValueAsLong = when (lastValue) {
+            is Number -> lastValue.toLong()
+            is Char -> lastValue.toLong()
+            else -> return@lazy true  // If "last" is not a const Number or Char.
+        }
+        val constLimitAsLong = when (direction) {
+            ProgressionDirection.UNKNOWN ->
+                // If we don't know the direction, we can't be sure which limit to use.
+                return@lazy true
+            ProgressionDirection.DECREASING ->
+                when (progressionType) {
+                    ProgressionType.INT_PROGRESSION -> Int.MIN_VALUE.toLong()
+                    ProgressionType.CHAR_PROGRESSION -> Char.MIN_VALUE.toLong()
+                    ProgressionType.LONG_PROGRESSION -> Long.MIN_VALUE
+                }
+            ProgressionDirection.INCREASING ->
+                when (progressionType) {
+                    ProgressionType.INT_PROGRESSION -> Int.MAX_VALUE.toLong()
+                    ProgressionType.CHAR_PROGRESSION -> Char.MAX_VALUE.toLong()
+                    ProgressionType.LONG_PROGRESSION -> Long.MAX_VALUE
+                }
+        }
+        constLimitAsLong == lastValueAsLong
+    }
+}
 
 /** Information about a for-loop over an array. The internal induction variable used is an Int. */
 internal class ArrayHeaderInfo(

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/HeaderProcessor.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/HeaderProcessor.kt
@@ -54,9 +54,10 @@ internal class ProgressionLoopHeader(
 
     val closed = headerInfo.closed
 
-    private val increasing = headerInfo.increasing
+    private val direction = headerInfo.direction
 
-    fun comparingFunction(builtIns: IrBuiltIns) = if (increasing)
+    // TODO: Handle UNKNOWN direction, which requires a complex expression for the emptiness check
+    fun comparingFunction(builtIns: IrBuiltIns) = if (direction == ProgressionDirection.INCREASING)
         builtIns.lessOrEqualFunByOperandType[builtIns.int]?.symbol!!
     else
         builtIns.greaterOrEqualFunByOperandType[builtIns.int]?.symbol!!

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/HeaderProcessor.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/HeaderProcessor.kt
@@ -200,16 +200,8 @@ internal class HeaderProcessor(
                         dispatchReceiver = irGet(upperBoundTmpVariable)
                     }
                 }
-                // In case of `step` we need to calculate the last element.
-                val lastElement =
-                    if (needLastCalculation) {
-                        TODO("Implement and use irGetProgressionLast")
-//                        irGetProgressionLast(progressionType, inductionVariable, lastExpression, stepValue)
-                    } else {
-                        lastExpression
-                    }
                 val lastValue = scope.createTemporaryVariable(
-                    lastElement,
+                    lastExpression,
                     nameHint = "last",
                     origin = IrDeclarationOrigin.FOR_LOOP_IMPLICIT_VARIABLE
                 )
@@ -270,21 +262,4 @@ internal class HeaderProcessor(
             else -> throw IllegalArgumentException()
         }
     }
-
-//    private fun irGetProgressionLast(
-//        progressionType: ProgressionType,
-//        first: IrVariable,
-//        lastExpression: IrExpression,
-//        step: IrVariable
-//    ): IrExpression {
-//        val symbol = symbols.getProgressionLast[progressionType.elementType(context).toKotlinType()]
-//            ?: throw IllegalArgumentException("No `getProgressionLast` for type ${step.type} ${lastExpression.type}")
-//        val startOffset = lastExpression.startOffset
-//        val endOffset = lastExpression.endOffset
-//        return IrCallImpl(startOffset, endOffset, symbol.owner.returnType, symbol).apply {
-//            putValueArgument(0, IrGetValueImpl(startOffset, endOffset, first.type, first.symbol))
-//            putValueArgument(1, lastExpression)
-//            putValueArgument(2, IrGetValueImpl(startOffset, endOffset, step.type, step.symbol))
-//        }
-//    }
 }

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/HeaderProcessor.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/HeaderProcessor.kt
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.common.lower.loops
+
+import org.jetbrains.kotlin.backend.common.CommonBackendContext
+import org.jetbrains.kotlin.backend.common.ir.Symbols
+import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
+import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
+import org.jetbrains.kotlin.backend.common.utils.isSubtypeOf
+import org.jetbrains.kotlin.ir.IrStatement
+import org.jetbrains.kotlin.ir.builders.irCall
+import org.jetbrains.kotlin.ir.builders.irGet
+import org.jetbrains.kotlin.ir.builders.irImplicitCast
+import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
+import org.jetbrains.kotlin.ir.declarations.IrVariable
+import org.jetbrains.kotlin.ir.descriptors.IrBuiltIns
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.IrLoop
+import org.jetbrains.kotlin.ir.expressions.impl.IrCallImpl
+import org.jetbrains.kotlin.ir.expressions.impl.IrConstImpl
+import org.jetbrains.kotlin.ir.expressions.impl.IrDoWhileLoopImpl
+import org.jetbrains.kotlin.ir.expressions.impl.IrWhileLoopImpl
+import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
+import org.jetbrains.kotlin.ir.symbols.IrSymbol
+import org.jetbrains.kotlin.ir.types.*
+import org.jetbrains.kotlin.ir.types.impl.IrStarProjectionImpl
+import org.jetbrains.kotlin.ir.util.functions
+import org.jetbrains.kotlin.ir.util.isNullable
+import org.jetbrains.kotlin.util.OperatorNameConventions
+
+/** Contains information about variables used in the loop. */
+internal sealed class ForLoopHeader(
+    val inductionVariable: IrVariable,
+    val bound: IrVariable,
+    val last: IrVariable,
+    val step: IrVariable,
+    val progressionType: ProgressionType
+) {
+    abstract fun initializeLoopVariable(symbols: Symbols<CommonBackendContext>, builder: DeclarationIrBuilder): IrExpression
+
+    abstract val declarations: List<IrStatement>
+
+    abstract fun buildBody(builder: DeclarationIrBuilder, loop: IrLoop, newBody: IrExpression?): IrLoop
+}
+
+internal class ProgressionLoopHeader(
+    headerInfo: ProgressionHeaderInfo,
+    inductionVariable: IrVariable,
+    bound: IrVariable,
+    last: IrVariable,
+    step: IrVariable,
+    var loopVariable: IrVariable? = null
+) : ForLoopHeader(inductionVariable, bound, last, step, headerInfo.progressionType) {
+
+    val closed = headerInfo.closed
+
+    private val increasing = headerInfo.increasing
+
+    fun comparingFunction(builtIns: IrBuiltIns) = if (increasing)
+        builtIns.lessOrEqualFunByOperandType[builtIns.int]?.symbol!!
+    else
+        builtIns.greaterOrEqualFunByOperandType[builtIns.int]?.symbol!!
+
+    override fun initializeLoopVariable(symbols: Symbols<CommonBackendContext>, builder: DeclarationIrBuilder) = with(builder) {
+        irGet(inductionVariable)
+    }
+
+    override val declarations: List<IrStatement>
+        get() = listOf(inductionVariable, step, bound, last)
+
+    override fun buildBody(builder: DeclarationIrBuilder, loop: IrLoop, newBody: IrExpression?): IrLoop = with(builder) {
+        assert(loopVariable != null)
+        val newCondition = irCall(context.irBuiltIns.booleanNotSymbol).apply {
+            putValueArgument(0, irCall(context.irBuiltIns.eqeqSymbol).apply {
+                putValueArgument(0, irGet(loopVariable!!))
+                putValueArgument(1, irGet(last))
+            })
+        }
+        IrDoWhileLoopImpl(loop.startOffset, loop.endOffset, loop.type, loop.origin).apply {
+            label = loop.label
+            condition = newCondition
+            body = newBody
+        }
+    }
+}
+
+internal class ArrayLoopHeader(
+    headerInfo: ArrayHeaderInfo,
+    inductionVariable: IrVariable,
+    bound: IrVariable,
+    last: IrVariable,
+    step: IrVariable
+) : ForLoopHeader(inductionVariable, bound, last, step, ProgressionType.INT_PROGRESSION) {
+
+    private val arrayDeclaration = headerInfo.arrayDeclaration
+
+    override fun initializeLoopVariable(symbols: Symbols<CommonBackendContext>, builder: DeclarationIrBuilder) = with(builder) {
+        val arrayClass = (arrayDeclaration.type.classifierOrNull) as IrClassSymbol
+        val arrayGetFun = arrayClass.owner.functions.find { it.name.toString() == "get" }!!
+        irCall(arrayGetFun).apply {
+            dispatchReceiver = irGet(arrayDeclaration)
+            putValueArgument(0, irGet(inductionVariable))
+        }
+    }
+
+    override val declarations: List<IrStatement>
+        get() = listOf(arrayDeclaration, inductionVariable, step, bound, last)
+
+    override fun buildBody(builder: DeclarationIrBuilder, loop: IrLoop, newBody: IrExpression?): IrLoop = with(builder) {
+        val builtIns = context.irBuiltIns
+        val callee = builtIns.lessOrEqualFunByOperandType[builtIns.int]?.symbol!!
+        val newCondition = irCall(callee).apply {
+            putValueArgument(0, irGet(inductionVariable))
+            putValueArgument(1, irGet(last))
+        }
+        IrWhileLoopImpl(loop.startOffset, loop.endOffset, loop.type, loop.origin).apply {
+            label = loop.label
+            condition = newCondition
+            body = newBody
+        }
+    }
+}
+
+private fun ProgressionType.elementType(context: CommonBackendContext): IrType = when (this) {
+    ProgressionType.INT_PROGRESSION -> context.irBuiltIns.intType
+    ProgressionType.LONG_PROGRESSION -> context.irBuiltIns.longType
+    ProgressionType.CHAR_PROGRESSION -> context.irBuiltIns.charType
+}
+
+// Given the for loop iterator variable, extract information about iterable subject
+// and create ForLoopHeader from it.
+internal class HeaderProcessor(
+    private val context: CommonBackendContext,
+    private val headerInfoBuilder: HeaderInfoBuilder,
+    private val scopeOwnerSymbol: () -> IrSymbol
+) {
+
+    private val symbols = context.ir.symbols
+
+    fun processHeader(variable: IrVariable): ForLoopHeader? {
+
+        assert(variable.origin == IrDeclarationOrigin.FOR_LOOP_ITERATOR)
+        // Create iterator type with star projections.
+        val iteratorType = symbols.iterator.run {
+            createType(
+                hasQuestionMark = false,
+                arguments = descriptor.declaredTypeParameters.map { IrStarProjectionImpl }
+            )
+        }
+
+        if (!variable.type.isSubtypeOf(iteratorType)) {
+            return null
+        }
+        val builder = context.createIrBuilder(scopeOwnerSymbol(), variable.startOffset, variable.endOffset)
+        // Collect loop info and form the loop header composite.
+        val progressionInfo = headerInfoBuilder.build(variable)
+            ?: return null
+        if (progressionInfo is ArrayHeaderInfo) {
+            progressionInfo.arrayDeclaration.parent = variable.parent
+        }
+        with(builder) {
+            with(progressionInfo) {
+                /**
+                 * For this loop:
+                 * `for (i in a() .. b() step c() step d())`
+                 * We need to call functions in the following order: a, b, c, d.
+                 * So we call b() before step calculations and then call last element calculation function (if required).
+                 */
+                // Due to features of PSI2IR we can obtain nullable arguments here while actually
+                // they are non-nullable (the frontend takes care about this). So we need to cast them to non-nullable.
+                val inductionVariable = scope.createTemporaryVariable(
+                    lowerBound.castIfNecessary(progressionType),
+                    nameHint = "inductionVariable",
+                    isMutable = true,
+                    origin = IrDeclarationOrigin.FOR_LOOP_IMPLICIT_VARIABLE
+                )
+
+                val upperBoundTmpVariable = scope.createTemporaryVariable(
+                    ensureNotNullable(upperBound.castIfNecessary(progressionType)),
+                    nameHint = "upperBound",
+                    origin = IrDeclarationOrigin.FOR_LOOP_IMPLICIT_VARIABLE
+                )
+
+                val stepExpression = if (step != null) {
+                    ensureNotNullable(if (increasing) step else step.unaryMinus())
+                } else {
+                    defaultStep(startOffset, endOffset)
+                }
+
+                val stepValue = scope.createTemporaryVariable(
+                    stepExpression,
+                    nameHint = "step",
+                    origin = IrDeclarationOrigin.FOR_LOOP_IMPLICIT_VARIABLE
+                )
+
+                // Calculate the last element of the progression
+                // The last element can be:
+                //    boundValue, if step is 1 and the range is closed.
+                //    boundValue - 1, if step is 1 and the range is open.
+                //    getProgressionLast(inductionVariable, boundValue, step), if step != 1 and the range is closed.
+                //    getProgressionLast(inductionVariable, boundValue - 1, step), if step != 1 and the range is open.
+                val lastExpression = if (closed) {
+                    irGet(upperBoundTmpVariable)
+                } else {
+                    val decrementSymbol = symbols.getUnaryOperator(OperatorNameConventions.DEC, upperBoundTmpVariable.type.toKotlinType())
+                    irCall(decrementSymbol.owner).apply {
+                        dispatchReceiver = irGet(upperBoundTmpVariable)
+                    }
+                }
+                // In case of `step` we need to calculate the last element.
+                val lastElement =
+                    if (needLastCalculation) {
+                        TODO("Implement and use irGetProgressionLast")
+//                        irGetProgressionLast(progressionType, inductionVariable, lastExpression, stepValue)
+                    } else {
+                        lastExpression
+                    }
+                val lastValue = scope.createTemporaryVariable(
+                    lastElement,
+                    nameHint = "last",
+                    origin = IrDeclarationOrigin.FOR_LOOP_IMPLICIT_VARIABLE
+                )
+
+                return when (progressionInfo) {
+                    is ArrayHeaderInfo -> ArrayLoopHeader(
+                        progressionInfo,
+                        inductionVariable,
+                        upperBoundTmpVariable,
+                        lastValue,
+                        stepValue
+                    )
+                    is ProgressionHeaderInfo -> ProgressionLoopHeader(
+                        progressionInfo,
+                        inductionVariable,
+                        upperBoundTmpVariable,
+                        lastValue,
+                        stepValue
+                    )
+                }
+            }
+        }
+    }
+
+
+    private fun IrExpression.castIfNecessary(progressionType: ProgressionType): IrExpression {
+        return if (type.toKotlinType() == progressionType.elementType(context).toKotlinType()) {
+            this
+        } else {
+            val function = symbols.getFunction(progressionType.numberCastFunctionName, type.toKotlinType())
+            IrCallImpl(startOffset, endOffset, function.owner.returnType, function)
+                .apply { dispatchReceiver = this@castIfNecessary }
+        }
+    }
+
+    private fun DeclarationIrBuilder.ensureNotNullable(expression: IrExpression) =
+        if (expression.type is IrSimpleType && expression.type.isNullable()) {
+            irImplicitCast(expression, expression.type.makeNotNull())
+        } else {
+            expression
+        }
+
+    private fun IrExpression.unaryMinus(): IrExpression {
+        val unaryOperator = symbols.getUnaryOperator(OperatorNameConventions.UNARY_MINUS, type.toKotlinType())
+        return IrCallImpl(startOffset, endOffset, unaryOperator.owner.returnType, unaryOperator).apply {
+            dispatchReceiver = this@unaryMinus
+        }
+    }
+
+    private fun HeaderInfo.defaultStep(startOffset: Int, endOffset: Int): IrExpression {
+        val type = progressionType.elementType(context)
+        val step = if (increasing) 1 else -1
+        return when {
+            type.isInt() || type.isChar() ->
+                IrConstImpl.int(startOffset, endOffset, context.irBuiltIns.intType, step)
+            type.isLong() ->
+                IrConstImpl.long(startOffset, endOffset, context.irBuiltIns.longType, step.toLong())
+            else -> throw IllegalArgumentException()
+        }
+    }
+
+//    private fun irGetProgressionLast(
+//        progressionType: ProgressionType,
+//        first: IrVariable,
+//        lastExpression: IrExpression,
+//        step: IrVariable
+//    ): IrExpression {
+//        val symbol = symbols.getProgressionLast[progressionType.elementType(context).toKotlinType()]
+//            ?: throw IllegalArgumentException("No `getProgressionLast` for type ${step.type} ${lastExpression.type}")
+//        val startOffset = lastExpression.startOffset
+//        val endOffset = lastExpression.endOffset
+//        return IrCallImpl(startOffset, endOffset, symbol.owner.returnType, symbol).apply {
+//            putValueArgument(0, IrGetValueImpl(startOffset, endOffset, first.type, first.symbol))
+//            putValueArgument(1, lastExpression)
+//            putValueArgument(2, IrGetValueImpl(startOffset, endOffset, step.type, step.symbol))
+//        }
+//    }
+}

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/HeaderProcessor.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/HeaderProcessor.kt
@@ -122,12 +122,6 @@ internal class ArrayLoopHeader(
     }
 }
 
-private fun ProgressionType.elementType(context: CommonBackendContext): IrType = when (this) {
-    ProgressionType.INT_PROGRESSION -> context.irBuiltIns.intType
-    ProgressionType.LONG_PROGRESSION -> context.irBuiltIns.longType
-    ProgressionType.CHAR_PROGRESSION -> context.irBuiltIns.charType
-}
-
 // Given the for loop iterator variable, extract information about iterable subject
 // and create ForLoopHeader from it.
 internal class HeaderProcessor(
@@ -228,7 +222,7 @@ internal class HeaderProcessor(
 
 
     private fun IrExpression.castIfNecessary(progressionType: ProgressionType): IrExpression {
-        return if (type.toKotlinType() == progressionType.elementType(context).toKotlinType()) {
+        return if (type.toKotlinType() == progressionType.elementType(context.irBuiltIns).toKotlinType()) {
             this
         } else {
             val function = type.getClass()!!.functions.first { it.name == progressionType.numberCastFunctionName }
@@ -252,7 +246,7 @@ internal class HeaderProcessor(
     }
 
     private fun HeaderInfo.defaultStep(startOffset: Int, endOffset: Int): IrExpression {
-        val type = progressionType.elementType(context)
+        val type = progressionType.elementType(context.irBuiltIns)
         val step = if (increasing) 1 else -1
         return when {
             type.isInt() || type.isChar() ->

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/HeaderProcessor.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/HeaderProcessor.kt
@@ -80,8 +80,7 @@ internal class ProgressionLoopHeader(
             val progressionKotlinType = progressionType.elementType(builtIns).toKotlinType()
             val lessOrEqualFun = builtIns.lessOrEqualFunByOperandType[progressionKotlinType]!!
 
-            // TODO: Additional condition for `for (i in a until MIN_VALUE)` corner case
-            when (headerInfo.direction) {
+            val notEmptyCondition = when (headerInfo.direction) {
                 ProgressionDirection.DECREASING ->
                     // last <= inductionVariable
                     irCall(lessOrEqualFun).apply {
@@ -121,6 +120,11 @@ internal class ProgressionLoopHeader(
                     )
                 }
             }
+
+            if (headerInfo.additionalNotEmptyCondition != null) context.andand(
+                headerInfo.additionalNotEmptyCondition,
+                notEmptyCondition
+            ) else notEmptyCondition
         }
 }
 

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/HeaderProcessor.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/HeaderProcessor.kt
@@ -32,7 +32,8 @@ internal sealed class ForLoopHeader(
     val last: IrVariable,
     val step: IrVariable,
     val progressionType: ProgressionType,
-    val needsEmptinessCheck: Boolean
+    val needsEmptinessCheck: Boolean,
+    var loopVariable: IrVariable? = null
 ) {
     abstract fun initializeLoopVariable(symbols: Symbols<CommonBackendContext>, builder: DeclarationIrBuilder): IrExpression
 
@@ -48,8 +49,7 @@ internal class ProgressionLoopHeader(
     inductionVariable: IrVariable,
     bound: IrVariable,
     last: IrVariable,
-    step: IrVariable,
-    var loopVariable: IrVariable? = null
+    step: IrVariable
 ) : ForLoopHeader(inductionVariable, bound, last, step, headerInfo.progressionType, needsEmptinessCheck = true) {
 
     override fun initializeLoopVariable(symbols: Symbols<CommonBackendContext>, builder: DeclarationIrBuilder) = with(builder) {
@@ -200,14 +200,14 @@ internal class HeaderProcessor(
                 // Due to features of PSI2IR we can obtain nullable arguments here while actually
                 // they are non-nullable (the frontend takes care about this). So we need to cast them to non-nullable.
                 val inductionVariable = scope.createTemporaryVariable(
-                    lowerBound.castIfNecessary(progressionType),
+                    first.castIfNecessary(progressionType),
                     nameHint = "inductionVariable",
                     isMutable = true,
                     origin = IrDeclarationOrigin.FOR_LOOP_IMPLICIT_VARIABLE
                 )
 
                 val upperBoundTmpVariable = scope.createTemporaryVariable(
-                    ensureNotNullable(upperBound.castIfNecessary(progressionType)),
+                    ensureNotNullable(last.castIfNecessary(progressionType)),
                     nameHint = "upperBound",
                     origin = IrDeclarationOrigin.FOR_LOOP_IMPLICIT_VARIABLE
                 )

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/ProgressionHandlers.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/ProgressionHandlers.kt
@@ -27,7 +27,7 @@ import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.types.SimpleType
 
-// TODO: What if functions like Int.rangeTo(Char) will be added to stdlib later?
+/** Builds a [HeaderInfo] for progressions built using the `rangeTo` function. */
 internal class RangeToHandler(private val context: CommonBackendContext, private val progressionElementTypes: Collection<SimpleType>) :
     ProgressionHandler {
     override val matcher = SimpleCalleeMatcher {
@@ -48,6 +48,7 @@ internal class RangeToHandler(private val context: CommonBackendContext, private
         }
 }
 
+/** Builds a [HeaderInfo] for progressions built using the `downTo` extension function. */
 internal class DownToHandler(private val context: CommonBackendContext, private val progressionElementTypes: Collection<SimpleType>) :
     ProgressionHandler {
     override val matcher = SimpleCalleeMatcher {
@@ -67,6 +68,7 @@ internal class DownToHandler(private val context: CommonBackendContext, private 
         }
 }
 
+/** Builds a [HeaderInfo] for progressions built using the `until` extension function. */
 internal class UntilHandler(private val context: CommonBackendContext, private val progressionElementTypes: Collection<SimpleType>) :
     ProgressionHandler {
     override val matcher = SimpleCalleeMatcher {
@@ -133,6 +135,7 @@ internal class UntilHandler(private val context: CommonBackendContext, private v
     }
 }
 
+/** Builds a [HeaderInfo] for progressions built using the `indices` extension property. */
 internal class IndicesHandler(val context: CommonBackendContext) : ProgressionHandler {
 
     override val matcher = SimpleCalleeMatcher {
@@ -171,7 +174,7 @@ internal class DefaultProgressionHandler(private val context: CommonBackendConte
         dispatchReceiver { it != null && ProgressionType.fromIrType(it.type, symbols) != null }
     }
 
-    override fun build(call: IrCall, progressionType: Nothing?): HeaderInfo? =
+    override fun build(call: IrCall, data: Nothing?): HeaderInfo? =
         with(context.createIrBuilder(call.symbol, call.startOffset, call.endOffset)) {
             // Directly use the `first/last/step` properties of the progression.
             val progression = scope.createTemporaryVariable(call.dispatchReceiver!!)
@@ -199,6 +202,7 @@ internal class DefaultProgressionHandler(private val context: CommonBackendConte
         }
 }
 
+/** Builds a [HeaderInfo] for arrays. */
 internal class ArrayIterationHandler(private val context: CommonBackendContext) : HeaderInfoHandler<Nothing?> {
 
     private val intDecFun = ProgressionType.INT_PROGRESSION.decFun(context.irBuiltIns)

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/ProgressionHandlers.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/ProgressionHandlers.kt
@@ -59,8 +59,7 @@ internal class DownToHandler(private val context: CommonBackendContext, private 
                 data,
                 lowerBound = call.extensionReceiver!!,
                 upperBound = call.getValueArgument(0)!!,
-                step = irInt(-1),
-                increasing = false
+                step = irInt(-1)
             )
         }
 }

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/ProgressionHandlers.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/ProgressionHandlers.kt
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.common.lower.loops
+
+import org.jetbrains.kotlin.backend.common.CommonBackendContext
+import org.jetbrains.kotlin.backend.common.ir.Symbols
+import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
+import org.jetbrains.kotlin.backend.common.lower.matchers.IrCallMatcher
+import org.jetbrains.kotlin.backend.common.lower.matchers.SimpleCalleeMatcher
+import org.jetbrains.kotlin.backend.common.lower.matchers.createIrCallMatcher
+import org.jetbrains.kotlin.backend.common.lower.matchers.singleArgumentExtension
+import org.jetbrains.kotlin.builtins.KotlinBuiltIns
+import org.jetbrains.kotlin.ir.builders.irCall
+import org.jetbrains.kotlin.ir.builders.irGet
+import org.jetbrains.kotlin.ir.builders.irInt
+import org.jetbrains.kotlin.ir.expressions.*
+import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
+import org.jetbrains.kotlin.ir.types.*
+import org.jetbrains.kotlin.ir.util.properties
+import org.jetbrains.kotlin.ir.visitors.IrElementVisitor
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.types.SimpleType
+
+// TODO: What if functions like Int.rangeTo(Char) will be added to stdlib later?
+internal class RangeToHandler(val progressionElementTypes: Collection<SimpleType>) : ProgressionHandler {
+    override val matcher = SimpleCalleeMatcher {
+        dispatchReceiver { it != null && it.type.toKotlinType() in progressionElementTypes }
+        fqName { it.pathSegments().last() == Name.identifier("rangeTo") }
+        parameterCount { it == 1 }
+        parameter(0) { it.type.toKotlinType() in progressionElementTypes }
+    }
+
+    override fun build(call: IrCall, data: ProgressionType) =
+        ProgressionHeaderInfo(data, call.dispatchReceiver!!, call.getValueArgument(0)!!)
+}
+
+internal class DownToHandler(val progressionElementTypes: Collection<SimpleType>) : ProgressionHandler {
+    override val matcher = SimpleCalleeMatcher {
+        singleArgumentExtension(FqName("kotlin.ranges.downTo"), progressionElementTypes)
+        parameter(0) { it.type.toKotlinType() in progressionElementTypes }
+    }
+
+    override fun build(call: IrCall, data: ProgressionType): HeaderInfo? =
+        ProgressionHeaderInfo(
+            data,
+            call.extensionReceiver!!,
+            call.getValueArgument(0)!!,
+            increasing = false
+        )
+}
+
+internal class UntilHandler(val progressionElementTypes: Collection<SimpleType>) : ProgressionHandler {
+    override val matcher = SimpleCalleeMatcher {
+        singleArgumentExtension(FqName("kotlin.ranges.until"), progressionElementTypes)
+        parameter(0) { it.type.toKotlinType() in progressionElementTypes }
+    }
+
+    override fun build(call: IrCall, data: ProgressionType): HeaderInfo? =
+        ProgressionHeaderInfo(
+            data,
+            call.extensionReceiver!!,
+            call.getValueArgument(0)!!,
+            closed = false
+        )
+}
+
+internal class IndicesHandler(val context: CommonBackendContext) : ProgressionHandler {
+
+    override val matcher = createIrCallMatcher {
+        callee {
+            fqName { it == FqName("kotlin.collections.<get-indices>") }
+            parameterCount { it == 0 }
+        }
+        // TODO: Handle Collection<*>.indices
+        // TODO: Handle CharSequence.indices
+        extensionReceiver { it != null && KotlinBuiltIns.isArrayOrPrimitiveArray(it.type.toKotlinType()) }
+    }
+
+    override fun build(call: IrCall, data: ProgressionType): HeaderInfo? =
+        with(context.createIrBuilder(call.symbol, call.startOffset, call.endOffset)) {
+            val lowerBound = irInt(0)
+            val arrayClass = (call.extensionReceiver!!.type.classifierOrNull) as IrClassSymbol
+            val arraySizeProperty = arrayClass.owner.properties.find { it.name.toString() == "size" }!!
+            val upperBound = irCall(arraySizeProperty.getter!!).apply {
+                dispatchReceiver = call.extensionReceiver
+            }
+            ProgressionHeaderInfo(data, lowerBound, upperBound, closed = false)
+        }
+
+}
+
+internal class StepHandler(context: CommonBackendContext, val visitor: IrElementVisitor<HeaderInfo?, Nothing?>) : ProgressionHandler {
+    private val symbols = context.ir.symbols
+
+    override val matcher: IrCallMatcher = SimpleCalleeMatcher {
+        singleArgumentExtension(FqName("kotlin.ranges.step"), symbols.progressionClassesTypes)
+        parameter(0) { it.type.isInt() || it.type.isLong() }
+    }
+
+    private fun isDefaultStep(step: IrExpression?) =
+        step == null || (step is IrConst<*> && step.isOne())
+
+    override fun build(call: IrCall, data: ProgressionType): HeaderInfo? {
+        val nestedInfo = call.extensionReceiver!!.accept(visitor, null)
+            ?: return null
+
+        // Due to KT-27607 nested non-default steps could lead to incorrect behaviour.
+        // So disable optimization of such rare cases for now.
+        if (!isDefaultStep(nestedInfo.step)) {
+            return null
+        }
+
+        val newStep = call.getValueArgument(0)!!
+        val (newStepCheck, needBoundCalculation) = irCheckProgressionStep(symbols, data, newStep)
+        return ProgressionHeaderInfo(
+            data,
+            nestedInfo.lowerBound,
+            nestedInfo.upperBound,
+            newStepCheck,
+            nestedInfo.increasing,
+            needBoundCalculation,
+            nestedInfo.closed
+        )
+    }
+
+    private fun IrConst<*>.isOne() = when (kind) {
+        IrConstKind.Long -> value as Long == 1L
+        IrConstKind.Int -> value as Int == 1
+        else -> false
+    }
+
+    private fun IrExpression.isPositiveConst() = this is IrConst<*> &&
+            ((kind == IrConstKind.Long && value as Long > 0) || (kind == IrConstKind.Int && value as Int > 0))
+
+    // Used only by the assert.
+    private fun stepHasRightType(step: IrExpression, progressionType: ProgressionType) = when (progressionType) {
+
+        ProgressionType.CHAR_PROGRESSION,
+        ProgressionType.INT_PROGRESSION -> step.type.makeNotNull().isInt()
+
+        ProgressionType.LONG_PROGRESSION -> step.type.makeNotNull().isLong()
+    }
+
+    private fun irCheckProgressionStep(symbols: Symbols<CommonBackendContext>, progressionType: ProgressionType, step: IrExpression) =
+        if (step.isPositiveConst()) {
+            step to !(step as IrConst<*>).isOne()
+        } else
+            TODO("Implement call to checkProgressionStep")
+//        {
+//            // The frontend checks if the step has a right type (Long for LongProgression and Int for {Int/Char}Progression)
+//            // so there is no need to cast it.
+//            assert(stepHasRightType(step, progressionType))
+//
+//            val symbol = symbols.checkProgressionStep[step.type.makeNotNull().toKotlinType()]
+//                ?: throw IllegalArgumentException("No `checkProgressionStep` for type ${step.type}")
+//            IrCallImpl(step.startOffset, step.endOffset, symbol.owner.returnType, symbol).apply {
+//                putValueArgument(0, step)
+//            } to true
+//        }
+}
+
+internal class ArrayIterationHandler(val context: CommonBackendContext) : HeaderInfoHandler<Nothing?> {
+
+    // No support for rare cases like `T : IntArray` for now.
+    override val matcher = createIrCallMatcher {
+        origin { it == IrStatementOrigin.FOR_LOOP_ITERATOR }
+        dispatchReceiver { it != null && KotlinBuiltIns.isArrayOrPrimitiveArray(it.type.toKotlinType()) }
+    }
+
+    // Consider case like `for (elem in A) { f(elem) }`
+    // If we lower it to `for (i in A.indices) { f(A[i]) }`
+    // Then we will break program behaviour if A is an expression with side-effect.
+    // Instead, we lower it to
+    // ```
+    // val a = A
+    // for (i in a.indices) { f(a[i]) }
+    // ```
+    override fun build(call: IrCall, data: Nothing?): HeaderInfo? =
+        with(context.createIrBuilder(call.symbol, call.startOffset, call.endOffset)) {
+            val arrayReference = scope.createTemporaryVariable(call.dispatchReceiver!!)
+            val arrayClass = (arrayReference.type.classifierOrNull) as IrClassSymbol
+            val arraySizeProperty = arrayClass.owner.properties.find { it.name.toString() == "size" }!!
+            val upperBound = irCall(arraySizeProperty.getter!!).apply {
+                dispatchReceiver = irGet(arrayReference)
+            }
+            ArrayHeaderInfo(irInt(0), upperBound, arrayReference)
+        }
+}

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/ProgressionHandlers.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/ProgressionHandlers.kt
@@ -38,8 +38,8 @@ internal class RangeToHandler(private val context: CommonBackendContext, private
         with(context.createIrBuilder(call.symbol, call.startOffset, call.endOffset)) {
             ProgressionHeaderInfo(
                 data,
-                lowerBound = call.dispatchReceiver!!,
-                upperBound = call.getValueArgument(0)!!,
+                first = call.dispatchReceiver!!,
+                last = call.getValueArgument(0)!!,
                 step = irInt(1)
             )
         }
@@ -57,8 +57,8 @@ internal class DownToHandler(private val context: CommonBackendContext, private 
         with(context.createIrBuilder(call.symbol, call.startOffset, call.endOffset)) {
             ProgressionHeaderInfo(
                 data,
-                lowerBound = call.extensionReceiver!!,
-                upperBound = call.getValueArgument(0)!!,
+                first = call.extensionReceiver!!,
+                last = call.getValueArgument(0)!!,
                 step = irInt(-1)
             )
         }
@@ -98,8 +98,8 @@ internal class UntilHandler(private val context: CommonBackendContext, private v
             // TODO: Do not add additionalEmptinessCondition if "bound" is const and > MIN_VALUE
             ProgressionHeaderInfo(
                 data,
-                lowerBound = call.extensionReceiver!!,
-                upperBound = call.getValueArgument(0)!!,
+                first = call.extensionReceiver!!,
+                last = call.getValueArgument(0)!!,
                 step = irInt(1),
                 closed = false,
                 additionalNotEmptyCondition = buildMinValueConditionIfNecessary(data, call.getValueArgument(0)!!)
@@ -194,8 +194,8 @@ internal class ArrayIterationHandler(val context: CommonBackendContext) : Header
                 dispatchReceiver = irGet(arrayReference)
             }
             ArrayHeaderInfo(
-                lowerBound = irInt(0),
-                upperBound = upperBound,
+                first = irInt(0),
+                last = upperBound,
                 step = irInt(1),
                 arrayVariable = arrayReference
             )

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/ProgressionHandlers.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/ProgressionHandlers.kt
@@ -13,12 +13,15 @@ import org.jetbrains.kotlin.backend.common.lower.matchers.createIrCallMatcher
 import org.jetbrains.kotlin.backend.common.lower.matchers.singleArgumentExtension
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.ir.builders.*
+import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
+import org.jetbrains.kotlin.ir.declarations.IrFunction
+import org.jetbrains.kotlin.ir.descriptors.IrBuiltIns
 import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrStatementOrigin
-import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
-import org.jetbrains.kotlin.ir.types.classifierOrNull
+import org.jetbrains.kotlin.ir.types.getClass
 import org.jetbrains.kotlin.ir.types.toKotlinType
+import org.jetbrains.kotlin.ir.util.functions
 import org.jetbrains.kotlin.ir.util.properties
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
@@ -74,7 +77,14 @@ internal class UntilHandler(private val context: CommonBackendContext, private v
 
     override fun build(call: IrCall, data: ProgressionType): HeaderInfo? =
         with(context.createIrBuilder(call.symbol, call.startOffset, call.endOffset)) {
-            //
+            // `last = bound - 1` for the loop `for (i in first until bound)`.
+            val bound = scope.createTemporaryVariable(
+                call.getValueArgument(0)!!, nameHint = "bound",
+                origin = IrDeclarationOrigin.FOR_LOOP_IMPLICIT_VARIABLE
+            )
+            val decFun = data.decFun(context.irBuiltIns)
+            val last = irCallOp(decFun.symbol, bound.type, call.getValueArgument(0)!!)
+
             // An additional emptiness condition is required for the corner case:
             //
             // ```
@@ -94,15 +104,14 @@ internal class UntilHandler(private val context: CommonBackendContext, private v
             // ```
             // if (first <= last && bound > MIN_VALUE) { /* loop */ }
             // ```
-            //
             // TODO: Do not add additionalEmptinessCondition if "bound" is const and > MIN_VALUE
             ProgressionHeaderInfo(
                 data,
                 first = call.extensionReceiver!!,
-                last = call.getValueArgument(0)!!,
+                last = last,
                 step = irInt(1),
-                closed = false,
-                additionalNotEmptyCondition = buildMinValueConditionIfNecessary(data, call.getValueArgument(0)!!)
+                additionalVariables = listOf(bound),
+                additionalNotEmptyCondition = buildMinValueConditionIfNecessary(data, irGet(bound))
             )
         }
 
@@ -136,68 +145,78 @@ internal class IndicesHandler(val context: CommonBackendContext) : ProgressionHa
 
     override fun build(call: IrCall, data: ProgressionType): HeaderInfo? =
         with(context.createIrBuilder(call.symbol, call.startOffset, call.endOffset)) {
-            val lowerBound = irInt(0)
-            val arrayClass = (call.extensionReceiver!!.type.classifierOrNull) as IrClassSymbol
-            val arraySizeProperty = arrayClass.owner.properties.find { it.name.toString() == "size" }!!
-            val upperBound = irCall(arraySizeProperty.getter!!).apply {
+            // `last = array.size - 1` for the loop `for (i in array.indices)`.
+            val arraySizeProperty = call.extensionReceiver!!.type.getClass()!!.properties.first { it.name.asString() == "size" }
+            val decFun = data.decFun(context.irBuiltIns)
+            val last = irCallOp(decFun.symbol, data.elementType(context.irBuiltIns), irCall(arraySizeProperty.getter!!).apply {
                 dispatchReceiver = call.extensionReceiver
-            }
+            })
+
             ProgressionHeaderInfo(
                 data,
-                lowerBound,
-                upperBound,
-                step = irInt(1),
-                closed = false
+                first = irInt(0),
+                last = last,
+                step = irInt(1)
             )
         }
-
-    private fun DeclarationIrBuilder.buildMinValueConditionIfNecessary(
-        progressionType: ProgressionType,
-        bound: IrExpression
-    ): IrExpression? {
-        val irBuiltIns = context.irBuiltIns
-        val minConst = when (progressionType) {
-            ProgressionType.INT_PROGRESSION -> irInt(Int.MIN_VALUE)
-            ProgressionType.CHAR_PROGRESSION -> irChar(Char.MIN_VALUE)
-            ProgressionType.LONG_PROGRESSION -> irLong(Long.MIN_VALUE)
-        }
-        val progressionKotlinType = progressionType.elementType(irBuiltIns).toKotlinType()
-        return irCall(irBuiltIns.greaterFunByOperandType[progressionKotlinType]!!).apply {
-            putValueArgument(0, bound)
-            putValueArgument(1, minConst)
-        }
-    }
 }
 
-internal class ArrayIterationHandler(val context: CommonBackendContext) : HeaderInfoHandler<Nothing?> {
+internal class ArrayIterationHandler(private val context: CommonBackendContext) : HeaderInfoHandler<Nothing?> {
 
-    // No support for rare cases like `T : IntArray` for now.
+    private val intDecFun = ProgressionType.INT_PROGRESSION.decFun(context.irBuiltIns)
+
     override val matcher = createIrCallMatcher {
         origin { it == IrStatementOrigin.FOR_LOOP_ITERATOR }
+        // TODO: Support rare cases like `T : IntArray`
         dispatchReceiver { it != null && KotlinBuiltIns.isArrayOrPrimitiveArray(it.type.toKotlinType()) }
     }
 
-    // Consider case like `for (elem in A) { f(elem) }`
-    // If we lower it to `for (i in A.indices) { f(A[i]) }`
-    // Then we will break program behaviour if A is an expression with side-effect.
-    // Instead, we lower it to
-    // ```
-    // val a = A
-    // for (i in a.indices) { f(a[i]) }
-    // ```
     override fun build(call: IrCall, data: Nothing?): HeaderInfo? =
         with(context.createIrBuilder(call.symbol, call.startOffset, call.endOffset)) {
-            val arrayReference = scope.createTemporaryVariable(call.dispatchReceiver!!)
-            val arrayClass = (arrayReference.type.classifierOrNull) as IrClassSymbol
-            val arraySizeProperty = arrayClass.owner.properties.find { it.name.toString() == "size" }!!
-            val upperBound = irCall(arraySizeProperty.getter!!).apply {
+            // Consider the case like:
+            //
+            // ```
+            // for (elem in A) { f(elem) }`
+            // ```
+            //
+            // If we lower it to:
+            //
+            // ```
+            // for (i in A.indices) { f(A[i]) }
+            // ```
+            //
+            // ...then we will break program behaviour if `A` is an expression with side-effect. Instead, we lower it to:
+            //
+            // ```
+            // val a = A
+            // for (i in a.indices) { f(a[i]) }
+            // ```
+            val arrayReference = scope.createTemporaryVariable(
+                call.dispatchReceiver!!, nameHint = "array",
+                origin = IrDeclarationOrigin.FOR_LOOP_IMPLICIT_VARIABLE
+            )
+
+            // `last = array.size - 1` for the loop `for (i in array.indices)`.
+            val arraySizeProperty = arrayReference.type.getClass()!!.properties.first { it.name.asString() == "size" }
+            val last = irCallOp(intDecFun.symbol, context.irBuiltIns.intType, irCall(arraySizeProperty.getter!!).apply {
                 dispatchReceiver = irGet(arrayReference)
-            }
+            })
+
             ArrayHeaderInfo(
                 first = irInt(0),
-                last = upperBound,
+                last = last,
                 step = irInt(1),
                 arrayVariable = arrayReference
             )
         }
+}
+
+private fun ProgressionType.decFun(builtIns: IrBuiltIns): IrFunction {
+    val symbol =
+        when (this) {
+            ProgressionType.INT_PROGRESSION -> builtIns.intClass
+            ProgressionType.LONG_PROGRESSION -> builtIns.longClass
+            ProgressionType.CHAR_PROGRESSION -> builtIns.charClass
+        }
+    return symbol.owner.functions.first { it.name.asString() == "dec" }
 }

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/ProgressionHandlers.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/ProgressionHandlers.kt
@@ -212,22 +212,19 @@ internal class ArrayIterationHandler(private val context: CommonBackendContext) 
         with(context.createIrBuilder(call.symbol, call.startOffset, call.endOffset)) {
             // Consider the case like:
             //
-            // ```
-            // for (elem in A) { f(elem) }`
-            // ```
+            //   for (elem in A) { f(elem) }`
             //
             // If we lower it to:
             //
-            // ```
-            // for (i in A.indices) { f(A[i]) }
-            // ```
+            //   for (i in A.indices) { f(A[i]) }
             //
             // ...then we will break program behaviour if `A` is an expression with side-effect. Instead, we lower it to:
             //
-            // ```
-            // val a = A
-            // for (i in a.indices) { f(a[i]) }
-            // ```
+            //   val a = A
+            //   for (i in a.indices) { f(a[i]) }
+            //
+            // This also ensures that the semantics of re-assignment of array variables used in the loop is consistent with the semantics
+            // proposed in https://youtrack.jetbrains.com/issue/KT-21354.
             val arrayReference = scope.createTemporaryVariable(
                 call.dispatchReceiver!!, nameHint = "array",
                 origin = IrDeclarationOrigin.FOR_LOOP_IMPLICIT_VARIABLE

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/matchers/IrCallMatcher.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/matchers/IrCallMatcher.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.common.lower.matchers
+
+import org.jetbrains.kotlin.ir.expressions.IrCall
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.IrStatementOrigin
+
+
+internal interface IrCallMatcher : (IrCall) -> Boolean
+
+/**
+ * IrCallMatcher that puts restrictions only on its callee.
+ */
+internal class SimpleCalleeMatcher(
+    restrictions: IrFunctionMatcherContainer.() -> Unit
+) : IrCallMatcher {
+
+    private val calleeRestriction: IrFunctionMatcher = createIrFunctionRestrictions(restrictions)
+
+    override fun invoke(call: IrCall) = calleeRestriction(call.symbol.owner)
+}
+
+internal class IrCallExtensionReceiverMatcher(
+    val restriction: (IrExpression?) -> Boolean
+) : IrCallMatcher {
+    override fun invoke(call: IrCall) = restriction(call.extensionReceiver)
+}
+
+internal class IrCallDispatchReceiverMatcher(
+    val restriction: (IrExpression?) -> Boolean
+) : IrCallMatcher {
+    override fun invoke(call: IrCall) = restriction(call.dispatchReceiver)
+}
+
+internal class IrCallOriginMatcher(
+    val restriction: (IrStatementOrigin?) -> Boolean
+) : IrCallMatcher {
+    override fun invoke(call: IrCall) = restriction(call.origin)
+}
+
+internal open class IrCallMatcherContainer : IrCallMatcher {
+
+    private val matchers = mutableListOf<IrCallMatcher>()
+
+    fun add(matcher: IrCallMatcher) {
+        matchers += matcher
+    }
+
+    fun extensionReceiver(restriction: (IrExpression?) -> Boolean) =
+        add(IrCallExtensionReceiverMatcher(restriction))
+
+    fun origin(restriction: (IrStatementOrigin?) -> Boolean) =
+        add(IrCallOriginMatcher(restriction))
+
+    fun callee(restrictions: IrFunctionMatcherContainer.() -> Unit) {
+        add(SimpleCalleeMatcher(restrictions))
+    }
+
+    fun dispatchReceiver(restriction: (IrExpression?) -> Boolean) =
+        add(IrCallDispatchReceiverMatcher(restriction))
+
+    override fun invoke(call: IrCall) = matchers.all { it(call) }
+}
+
+internal fun createIrCallMatcher(restrictions: IrCallMatcherContainer.() -> Unit) =
+    IrCallMatcherContainer().apply(restrictions)

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/matchers/IrFunctionMatcher.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/matchers/IrFunctionMatcher.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.common.lower.matchers
+
+import org.jetbrains.kotlin.ir.declarations.IrFunction
+import org.jetbrains.kotlin.ir.declarations.IrValueParameter
+import org.jetbrains.kotlin.ir.types.toKotlinType
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
+import org.jetbrains.kotlin.types.SimpleType
+
+internal interface IrFunctionMatcher : (IrFunction) -> Boolean
+
+internal class ParameterMatcher(
+    val index: Int,
+    val restriction: (IrValueParameter) -> Boolean
+) : IrFunctionMatcher {
+
+    override fun invoke(function: IrFunction): Boolean {
+        val params = function.valueParameters
+        return params.size > index && restriction(params[index])
+    }
+}
+
+internal class DispatchReceiverMatcher(
+    val restriction: (IrValueParameter?) -> Boolean
+) : IrFunctionMatcher {
+
+    override fun invoke(function: IrFunction): Boolean {
+        return restriction(function.dispatchReceiverParameter)
+    }
+}
+
+internal class ExtensionReceiverMatcher(
+    val restriction: (IrValueParameter?) -> Boolean
+) : IrFunctionMatcher {
+
+    override fun invoke(function: IrFunction): Boolean {
+        return restriction(function.extensionReceiverParameter)
+    }
+}
+
+internal class ParameterCountMatcher(
+    val restriction: (Int) -> Boolean
+) : IrFunctionMatcher {
+
+    override fun invoke(function: IrFunction): Boolean {
+        return restriction(function.valueParameters.size)
+    }
+}
+
+internal class FqNameMatcher(
+    val restriction: (FqName) -> Boolean
+) : IrFunctionMatcher {
+
+    override fun invoke(function: IrFunction): Boolean {
+        return restriction(function.descriptor.fqNameSafe)
+    }
+}
+
+internal open class IrFunctionMatcherContainer : IrFunctionMatcher {
+    private val restrictions = mutableListOf<IrFunctionMatcher>()
+
+    fun add(restriction: IrFunctionMatcher) {
+        restrictions += restriction
+    }
+
+    fun fqName(restriction: (FqName) -> Boolean) =
+        add(FqNameMatcher(restriction))
+
+    fun parameterCount(restriction: (Int) -> Boolean) =
+        add(ParameterCountMatcher(restriction))
+
+    fun extensionReceiver(restriction: (IrValueParameter?) -> Boolean) =
+        add(ExtensionReceiverMatcher(restriction))
+
+    fun dispatchReceiver(restriction: (IrValueParameter?) -> Boolean) =
+        add(DispatchReceiverMatcher(restriction))
+
+    fun parameter(index: Int, restriction: (IrValueParameter) -> Boolean) =
+        add(ParameterMatcher(index, restriction))
+
+    override fun invoke(function: IrFunction) = restrictions.all { it(function) }
+}
+
+internal fun createIrFunctionRestrictions(restrictions: IrFunctionMatcherContainer.() -> Unit) =
+    IrFunctionMatcherContainer().apply(restrictions)
+
+internal fun IrFunctionMatcherContainer.singleArgumentExtension(
+    fqName: FqName,
+    types: Collection<SimpleType>
+): IrFunctionMatcherContainer {
+    extensionReceiver { it != null && it.type.toKotlinType() in types }
+    parameterCount { it == 1 }
+    fqName { it == fqName }
+    return this
+}

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
@@ -18,6 +18,7 @@ package org.jetbrains.kotlin.backend.jvm
 
 import org.jetbrains.kotlin.backend.common.CommonBackendContext
 import org.jetbrains.kotlin.backend.common.lower.*
+import org.jetbrains.kotlin.backend.common.lower.loops.forLoopsPhase
 import org.jetbrains.kotlin.backend.common.phaser.*
 import org.jetbrains.kotlin.backend.jvm.lower.*
 import org.jetbrains.kotlin.ir.declarations.IrFile
@@ -86,6 +87,7 @@ val jvmPhases = namedIrFilePhase(
 
             innerClassesPhase then
             innerClassConstructorCallsPhase then
+            forLoopsPhase then
 
             makePatchParentsPhase(2) then
 

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/builders/ExpressionHelpers.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/builders/ExpressionHelpers.kt
@@ -279,6 +279,9 @@ fun IrBuilderWithScope.irImplicitCast(argument: IrExpression, type: IrType) =
 fun IrBuilderWithScope.irInt(value: Int) =
     IrConstImpl.int(startOffset, endOffset, context.irBuiltIns.intType, value)
 
+fun IrBuilderWithScope.irLong(value: Long) =
+    IrConstImpl.long(startOffset, endOffset, context.irBuiltIns.longType, value)
+
 fun IrBuilderWithScope.irString(value: String) =
     IrConstImpl.string(startOffset, endOffset, context.irBuiltIns.stringType, value)
 

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/builders/ExpressionHelpers.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/builders/ExpressionHelpers.kt
@@ -282,6 +282,9 @@ fun IrBuilderWithScope.irInt(value: Int) =
 fun IrBuilderWithScope.irLong(value: Long) =
     IrConstImpl.long(startOffset, endOffset, context.irBuiltIns.longType, value)
 
+fun IrBuilderWithScope.irChar(value: Char) =
+    IrConstImpl.char(startOffset, endOffset, context.irBuiltIns.charType, value)
+
 fun IrBuilderWithScope.irString(value: String) =
     IrConstImpl.string(startOffset, endOffset, context.irBuiltIns.stringType, value)
 

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/builders/ExpressionHelpers.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/builders/ExpressionHelpers.kt
@@ -249,11 +249,12 @@ fun IrBuilderWithScope.irCallOp(
     callee: IrFunctionSymbol,
     type: IrType,
     dispatchReceiver: IrExpression,
-    argument: IrExpression
+    argument: IrExpression? = null
 ): IrCall =
     irCall(callee, type).apply {
         this.dispatchReceiver = dispatchReceiver
-        putValueArgument(0, argument)
+        if (argument != null)
+            putValueArgument(0, argument)
     }
 
 fun IrBuilderWithScope.typeOperator(

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/descriptors/IrBuiltIns.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/descriptors/IrBuiltIns.kt
@@ -178,7 +178,7 @@ class IrBuiltIns(
 
     // TODO switch to IrType
     val primitiveTypes = listOf(bool, char, byte, short, int, long, float, double)
-    val primitiveTypesWithComparisons = listOf(int, long, float, double)
+    val primitiveTypesWithComparisons = listOf(char, byte, short, int, long, float, double)
     val primitiveFloatingPointTypes = listOf(float, double)
 
     val lessFunByOperandType = primitiveTypesWithComparisons.defineComparisonOperatorForEachType(OperatorNames.LESS)

--- a/compiler/testData/codegen/box/ranges/evaluationOrder/forInDownToEvaluationOrder.kt
+++ b/compiler/testData/codegen/box/ranges/evaluationOrder/forInDownToEvaluationOrder.kt
@@ -1,0 +1,21 @@
+// KJS_WITH_FULL_RUNTIME
+// WITH_RUNTIME
+import kotlin.test.*
+
+val log = StringBuilder()
+
+fun logged(message: String, value: Int) =
+    value.also { log.append(message) }
+
+fun box(): String {
+    var sum = 0
+    for (i in logged("start;", 4) downTo logged("end;", 1)) {
+        sum = sum * 10 + i
+    }
+
+    assertEquals(4321, sum)
+
+    assertEquals("start;end;", log.toString())
+
+    return "OK"
+}

--- a/compiler/testData/codegen/box/ranges/evaluationOrder/forInRangeLiteralEvaluationOrder.kt
+++ b/compiler/testData/codegen/box/ranges/evaluationOrder/forInRangeLiteralEvaluationOrder.kt
@@ -1,0 +1,21 @@
+// KJS_WITH_FULL_RUNTIME
+// WITH_RUNTIME
+import kotlin.test.*
+
+val log = StringBuilder()
+
+fun logged(message: String, value: Int) =
+    value.also { log.append(message) }
+
+fun box(): String {
+    var sum = 0
+    for (i in logged("start;", 1)..logged("end;", 4)) {
+        sum = sum * 10 + i
+    }
+
+    assertEquals(1234, sum)
+
+    assertEquals("start;end;", log.toString())
+
+    return "OK"
+}

--- a/compiler/testData/codegen/box/ranges/evaluationOrder/forInReversedDownToEvaluationOrder.kt
+++ b/compiler/testData/codegen/box/ranges/evaluationOrder/forInReversedDownToEvaluationOrder.kt
@@ -1,0 +1,21 @@
+// KJS_WITH_FULL_RUNTIME
+// WITH_RUNTIME
+import kotlin.test.*
+
+val log = StringBuilder()
+
+fun logged(message: String, value: Int) =
+    value.also { log.append(message) }
+
+fun box(): String {
+    var sum = 0
+    for (i in (logged("start;", 4) downTo logged("end;", 1)).reversed()) {
+        sum = sum * 10 + i
+    }
+
+    assertEquals(1234, sum)
+
+    assertEquals("start;end;", log.toString())
+
+    return "OK"
+}

--- a/compiler/testData/codegen/box/ranges/evaluationOrder/forInReversedRangeLiteralEvaluationOrder.kt
+++ b/compiler/testData/codegen/box/ranges/evaluationOrder/forInReversedRangeLiteralEvaluationOrder.kt
@@ -5,15 +5,15 @@ import kotlin.test.*
 val log = StringBuilder()
 
 fun logged(message: String, value: Int) =
-        value.also { log.append(message) }
+    value.also { log.append(message) }
 
 fun box(): String {
-    var s = 0
-    for (i in (logged("start;", 2) downTo logged("end;", 1)).reversed()) {
-        s += i
+    var sum = 0
+    for (i in (logged("start;", 1)..logged("end;", 4)).reversed()) {
+        sum = sum * 10 + i
     }
 
-    assertEquals(3, s)
+    assertEquals(4321, sum)
 
     assertEquals("start;end;", log.toString())
 

--- a/compiler/testData/codegen/box/ranges/evaluationOrder/forInReversedUntilEvaluationOrder.kt
+++ b/compiler/testData/codegen/box/ranges/evaluationOrder/forInReversedUntilEvaluationOrder.kt
@@ -5,15 +5,15 @@ import kotlin.test.*
 val log = StringBuilder()
 
 fun logged(message: String, value: Int) =
-        value.also { log.append(message) }
+    value.also { log.append(message) }
 
 fun box(): String {
-    var s = 0
-    for (i in (logged("start;", 1) until logged("end;", 3)).reversed()) {
-        s += i
+    var sum = 0
+    for (i in (logged("start;", 1) until logged("end;", 5)).reversed()) {
+        sum = sum * 10 + i
     }
 
-    assertEquals(3, s)
+    assertEquals(4321, sum)
 
     assertEquals("start;end;", log.toString())
 

--- a/compiler/testData/codegen/box/ranges/evaluationOrder/forInUntilEvaluationOrder.kt
+++ b/compiler/testData/codegen/box/ranges/evaluationOrder/forInUntilEvaluationOrder.kt
@@ -5,15 +5,15 @@ import kotlin.test.*
 val log = StringBuilder()
 
 fun logged(message: String, value: Int) =
-        value.also { log.append(message) }
+    value.also { log.append(message) }
 
 fun box(): String {
-    var s = 0
-    for (i in (logged("start;", 1) .. logged("end;", 2)).reversed()) {
-        s += i
+    var sum = 0
+    for (i in logged("start;", 1) until logged("end;", 5)) {
+        sum = sum * 10 + i
     }
 
-    assertEquals(3, s)
+    assertEquals(1234, sum)
 
     assertEquals("start;end;", log.toString())
 

--- a/compiler/testData/codegen/box/ranges/forInUntil/forInUntilChar0.kt
+++ b/compiler/testData/codegen/box/ranges/forInUntil/forInUntilChar0.kt
@@ -1,5 +1,3 @@
-// TODO: Enable after corner case is addressed
-// IGNORE_BACKEND: JVM_IR
 // WITH_RUNTIME
 
 import kotlin.test.assertEquals

--- a/compiler/testData/codegen/box/ranges/forInUntil/forInUntilChar0.kt
+++ b/compiler/testData/codegen/box/ranges/forInUntil/forInUntilChar0.kt
@@ -1,3 +1,5 @@
+// TODO: Enable after corner case is addressed
+// IGNORE_BACKEND: JVM_IR
 // WITH_RUNTIME
 
 import kotlin.test.assertEquals

--- a/compiler/testData/codegen/box/ranges/forInUntil/forInUntilMinint.kt
+++ b/compiler/testData/codegen/box/ranges/forInUntil/forInUntilMinint.kt
@@ -1,5 +1,3 @@
-// TODO: Enable after corner case is addressed
-// IGNORE_BACKEND: JVM_IR
 // WITH_RUNTIME
 
 import kotlin.test.assertEquals

--- a/compiler/testData/codegen/box/ranges/forInUntil/forInUntilMinint.kt
+++ b/compiler/testData/codegen/box/ranges/forInUntil/forInUntilMinint.kt
@@ -1,3 +1,5 @@
+// TODO: Enable after corner case is addressed
+// IGNORE_BACKEND: JVM_IR
 // WITH_RUNTIME
 
 import kotlin.test.assertEquals

--- a/compiler/testData/codegen/box/ranges/forInUntil/forInUntilMinlong.kt
+++ b/compiler/testData/codegen/box/ranges/forInUntil/forInUntilMinlong.kt
@@ -1,5 +1,3 @@
-// TODO: Enable after corner case is addressed
-// IGNORE_BACKEND: JVM_IR
 // WITH_RUNTIME
 
 import kotlin.test.assertEquals

--- a/compiler/testData/codegen/box/ranges/forInUntil/forInUntilMinlong.kt
+++ b/compiler/testData/codegen/box/ranges/forInUntil/forInUntilMinlong.kt
@@ -1,3 +1,5 @@
+// TODO: Enable after corner case is addressed
+// IGNORE_BACKEND: JVM_IR
 // WITH_RUNTIME
 
 import kotlin.test.assertEquals

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInDownToCharMinValue.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInDownToCharMinValue.kt
@@ -1,5 +1,7 @@
-fun f() {
-    for (i in 1..2) {
+const val M = Char.MIN_VALUE
+
+fun f(a: Char) {
+    for (i in a downTo M) {
     }
 }
 
@@ -9,4 +11,4 @@ fun f() {
 // 0 getFirst
 // 0 getLast
 // 0 getStep
-// 1 IF_ICMP
+// 2 IF

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInDownToCharMinValue.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInDownToCharMinValue.kt
@@ -1,8 +1,11 @@
 const val M = Char.MIN_VALUE
 
-fun f(a: Char) {
+fun f(a: Char): Int {
+    var n = 0
     for (i in a downTo M) {
+        n++
     }
+    return n
 }
 
 // 0 iterator

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInDownToIntMinValue.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInDownToIntMinValue.kt
@@ -1,5 +1,7 @@
-fun f() {
-    for (i in 1..2) {
+const val M = Int.MIN_VALUE
+
+fun f(a: Int) {
+    for (i in a downTo M) {
     }
 }
 
@@ -9,4 +11,4 @@ fun f() {
 // 0 getFirst
 // 0 getLast
 // 0 getStep
-// 1 IF_ICMP
+// 2 IF_ICMP

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInDownToIntMinValue.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInDownToIntMinValue.kt
@@ -1,8 +1,11 @@
 const val M = Int.MIN_VALUE
 
-fun f(a: Int) {
+fun f(a: Int): Int {
+    var n = 0
     for (i in a downTo M) {
+        n++
     }
+    return n
 }
 
 // 0 iterator
@@ -12,3 +15,4 @@ fun f(a: Int) {
 // 0 getLast
 // 0 getStep
 // 2 IF_ICMP
+// 2 IF

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInDownToLongMinValue.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInDownToLongMinValue.kt
@@ -1,0 +1,15 @@
+const val M = Long.MIN_VALUE
+
+fun f(a: Long) {
+    for (i in a downTo M) {
+    }
+}
+
+// 0 iterator
+// 0 getStart
+// 0 getEnd
+// 0 getFirst
+// 0 getLast
+// 0 getStep
+// 2 LCMP
+// 2 IF

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInDownToLongMinValue.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInDownToLongMinValue.kt
@@ -1,8 +1,11 @@
 const val M = Long.MIN_VALUE
 
-fun f(a: Long) {
+fun f(a: Long): Int {
+    var n = 0
     for (i in a downTo M) {
+        n++
     }
+    return n
 }
 
 // 0 iterator

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInIndices/forInNonOptimizedIndices.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInIndices/forInNonOptimizedIndices.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 import kotlin.test.assertEquals
 
 fun test(coll: Collection<*>?): Int {

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInIndices/forInObjectArrayIndices.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInIndices/forInObjectArrayIndices.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 fun test() {
     var sum = 0
     for (i in arrayOf("", "", "", "").indices) {
@@ -12,6 +11,4 @@ fun test() {
 // 0 getFirst
 // 0 getLast
 
-// 0 IF_ICMPGT
-// 0 IF_ICMPEQ
-// 1 IF_ICMPGE
+// 1 IF_ICMP

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInIndices/forInObjectArrayIndices.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInIndices/forInObjectArrayIndices.kt
@@ -10,5 +10,5 @@ fun test() {
 // 0 getEnd
 // 0 getFirst
 // 0 getLast
-
-// 1 IF_ICMP
+// 1 IF_ICMPGE
+// 1 IF

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInIndices/forInPrimitiveArrayIndices.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInIndices/forInPrimitiveArrayIndices.kt
@@ -10,5 +10,5 @@ fun test() {
 // 0 getEnd
 // 0 getFirst
 // 0 getLast
-
-// 1 IF_ICMP
+// 1 IF_ICMPGE
+// 1 IF

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInIndices/forInPrimitiveArrayIndices.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInIndices/forInPrimitiveArrayIndices.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 fun test() {
     var sum = 0
     for (i in intArrayOf(0, 0, 0, 0).indices) {
@@ -12,6 +11,4 @@ fun test() {
 // 0 getFirst
 // 0 getLast
 
-// 0 IF_ICMPGT
-// 0 IF_ICMPEQ
-// 1 IF_ICMPGE
+// 1 IF_ICMP

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInObjectArray.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInObjectArray.kt
@@ -1,11 +1,15 @@
 fun array() = arrayOfNulls<Any>(4)
 
-fun f() {
+fun f(): Int {
+    var n = 0
     for (i in array()) {
+        n++
     }
+    return n
 }
 
 // 0 iterator
 // 1 INVOKESTATIC .*\.array \(\)
 // 1 ARRAYLENGTH
-// 1 IF_ICMP
+// 1 IF_ICMPGE
+// 1 IF

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInObjectArray.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInObjectArray.kt
@@ -1,0 +1,11 @@
+fun array() = arrayOfNulls<Any>(4)
+
+fun f() {
+    for (i in array()) {
+    }
+}
+
+// 0 iterator
+// 1 INVOKESTATIC .*\.array \(\)
+// 1 ARRAYLENGTH
+// 1 IF_ICMP

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInPrimitiveArray.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInPrimitiveArray.kt
@@ -1,16 +1,21 @@
 fun intArray() = intArrayOf(0, 0, 0, 0)
 fun longArray() = longArrayOf(0, 0, 0, 0)
 
-fun f() {
+fun f(): Int {
+    var n = 0
     for (i in intArray()) {
+        n++
     }
 
     for (i in longArray()) {
+        n++
     }
+    return n
 }
 
 // 0 iterator
 // 1 INVOKESTATIC .*\.intArray \(\)
 // 1 INVOKESTATIC .*\.longArray \(\)
 // 2 ARRAYLENGTH
-// 2 IF_ICMP
+// 2 IF_ICMPGE
+// 2 IF

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInPrimitiveArray.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInPrimitiveArray.kt
@@ -1,0 +1,16 @@
+fun intArray() = intArrayOf(0, 0, 0, 0)
+fun longArray() = longArrayOf(0, 0, 0, 0)
+
+fun f() {
+    for (i in intArray()) {
+    }
+
+    for (i in longArray()) {
+    }
+}
+
+// 0 iterator
+// 1 INVOKESTATIC .*\.intArray \(\)
+// 1 INVOKESTATIC .*\.longArray \(\)
+// 2 ARRAYLENGTH
+// 2 IF_ICMP

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeToCharConst.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeToCharConst.kt
@@ -14,4 +14,5 @@ fun test(): Int {
 // 0 getFirst
 // 0 getLast
 // 0 getStep
-// 1 IF_ICMP
+// 1 IF_ICMPGT
+// 1 IF

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeToCharConst.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeToCharConst.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 const val N = 'Z'
 
 fun test(): Int {
@@ -9,5 +8,10 @@ fun test(): Int {
     return sum
 }
 
-// 0 IF_ICMPEQ
-// 1 IF_ICMPGT
+// 0 iterator
+// 0 getStart
+// 0 getEnd
+// 0 getFirst
+// 0 getLast
+// 0 getStep
+// 1 IF_ICMP

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeToCharMaxValue.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeToCharMaxValue.kt
@@ -1,5 +1,7 @@
-fun f() {
-    for (i in 1..2) {
+const val M = Char.MAX_VALUE
+
+fun f(a: Char) {
+    for (i in a..M) {
     }
 }
 
@@ -9,4 +11,4 @@ fun f() {
 // 0 getFirst
 // 0 getLast
 // 0 getStep
-// 1 IF_ICMP
+// 2 IF_ICMP

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeToCharMaxValue.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeToCharMaxValue.kt
@@ -1,8 +1,11 @@
 const val M = Char.MAX_VALUE
 
-fun f(a: Char) {
+fun f(a: Char): Int {
+    var n = 0
     for (i in a..M) {
+        n++
     }
+    return n
 }
 
 // 0 iterator
@@ -12,3 +15,4 @@ fun f(a: Char) {
 // 0 getLast
 // 0 getStep
 // 2 IF_ICMP
+// 2 IF

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeToConst.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeToConst.kt
@@ -14,4 +14,5 @@ fun test(): Int {
 // 0 getFirst
 // 0 getLast
 // 0 getStep
-// 1 IF_ICMP
+// 1 IF_ICMPGT
+// 1 IF

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeToConst.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeToConst.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 const val N = 42
 
 fun test(): Int {
@@ -9,5 +8,10 @@ fun test(): Int {
     return sum
 }
 
-// 0 IF_ICMPEQ
-// 1 IF_ICMPGT
+// 0 iterator
+// 0 getStart
+// 0 getEnd
+// 0 getFirst
+// 0 getLast
+// 0 getStep
+// 1 IF_ICMP

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeToIntMaxValue.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeToIntMaxValue.kt
@@ -1,8 +1,11 @@
 const val M = Int.MAX_VALUE
 
-fun f(a: Int) {
+fun f(a: Int): Int {
+    var n = 0
     for (i in a..M) {
+        n++
     }
+    return n
 }
 
 // 0 iterator
@@ -12,3 +15,4 @@ fun f(a: Int) {
 // 0 getLast
 // 0 getStep
 // 2 IF_ICMP
+// 2 IF

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeToIntMaxValue.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeToIntMaxValue.kt
@@ -1,5 +1,7 @@
-fun f() {
-    for (i in 1..2) {
+const val M = Int.MAX_VALUE
+
+fun f(a: Int) {
+    for (i in a..M) {
     }
 }
 
@@ -9,4 +11,4 @@ fun f() {
 // 0 getFirst
 // 0 getLast
 // 0 getStep
-// 1 IF_ICMP
+// 2 IF_ICMP

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeToLongConst.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeToLongConst.kt
@@ -1,3 +1,4 @@
+// IGNORE_BACKEND: JVM_IR
 const val N = 42L
 
 fun test(): Long {

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeToLongConst.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeToLongConst.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 const val N = 42L
 
 fun test(): Long {

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeToLongConst.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeToLongConst.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 const val N = 42L
 
 fun test(): Long {
@@ -9,6 +8,14 @@ fun test(): Long {
     return sum
 }
 
+// 0 iterator
+// 0 getStart
+// 0 getEnd
+// 0 getFirst
+// 0 getLast
+// 0 getStep
 // 1 LCMP
 // 0 IFEQ
 // 1 IFGT
+// 0 L2I
+// 0 I2L

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeToLongConst.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeToLongConst.kt
@@ -15,7 +15,7 @@ fun test(): Long {
 // 0 getLast
 // 0 getStep
 // 1 LCMP
-// 0 IFEQ
 // 1 IFGT
+// 1 IF
 // 0 L2I
 // 0 I2L

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeToLongMaxValue.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeToLongMaxValue.kt
@@ -1,5 +1,7 @@
-fun f() {
-    for (i in 1..2) {
+const val M = Long.MAX_VALUE
+
+fun f(a: Long) {
+    for (i in a..M) {
     }
 }
 
@@ -9,4 +11,5 @@ fun f() {
 // 0 getFirst
 // 0 getLast
 // 0 getStep
-// 1 IF_ICMP
+// 2 LCMP
+// 2 IF

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeToLongMaxValue.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeToLongMaxValue.kt
@@ -1,8 +1,11 @@
 const val M = Long.MAX_VALUE
 
-fun f(a: Long) {
+fun f(a: Long): Int {
+    var n = 0
     for (i in a..M) {
+        n++
     }
+    return n
 }
 
 // 0 iterator

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeToQualifiedConst.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeToQualifiedConst.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 object Host {
     const val M = 1
     const val N = 4
@@ -12,5 +11,10 @@ fun test(): Int {
     return s
 }
 
-// 0 IF_ICMPEQ
-// 1 IF_ICMPGT
+// 0 iterator
+// 0 getStart
+// 0 getEnd
+// 0 getFirst
+// 0 getLast
+// 0 getStep
+// 1 IF_ICMP

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeToQualifiedConst.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeToQualifiedConst.kt
@@ -17,4 +17,5 @@ fun test(): Int {
 // 0 getFirst
 // 0 getLast
 // 0 getStep
-// 1 IF_ICMP
+// 1 IF_ICMPGT
+// 1 IF

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithImplicitReceiver.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithImplicitReceiver.kt
@@ -11,3 +11,4 @@ fun Int.digitsUpto(end: Int): Int {
 // 0 getEnd
 // 0 getFirst
 // 0 getLast
+// 0 getStep

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithImplicitReceiver.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithImplicitReceiver.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 fun Int.digitsUpto(end: Int): Int {
     var sum = 0
     for (i in rangeTo(end)) {

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithImplicitReceiver.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithImplicitReceiver.kt
@@ -12,3 +12,5 @@ fun Int.digitsUpto(end: Int): Int {
 // 0 getFirst
 // 0 getLast
 // 0 getStep
+// 2 IF_ICMP
+// 2 IF

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInUntil.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInUntil.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 fun test(): Int {
     var sum = 0
     for (i in 1 until 6) {
@@ -12,4 +11,4 @@ fun test(): Int {
 // 0 getEnd
 // 0 getFirst
 // 0 getLast
-// 1 IF
+// 0 getStep

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInUntil.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInUntil.kt
@@ -12,4 +12,5 @@ fun test(a: Int, b: Int): Int {
 // 0 getFirst
 // 0 getLast
 // 0 getStep
-// 1 IF_ICMP
+// 1 IF_ICMPGE
+// 1 IF

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInUntil.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInUntil.kt
@@ -12,3 +12,4 @@ fun test(): Int {
 // 0 getFirst
 // 0 getLast
 // 0 getStep
+// 1 IF_ICMP

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInUntil.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInUntil.kt
@@ -1,6 +1,6 @@
-fun test(): Int {
+fun test(a: Int, b: Int): Int {
     var sum = 0
-    for (i in 1 until 6) {
+    for (i in a until b) {
         sum = sum * 10 + i
     }
     return sum

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInUntilCharMaxValue.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInUntilCharMaxValue.kt
@@ -1,8 +1,11 @@
 const val M = Char.MAX_VALUE
 
-fun f(a: Char) {
+fun f(a: Char): Int {
+    var n = 0
     for (i in a until M) {
+        n++
     }
+    return n
 }
 
 // 0 iterator
@@ -11,4 +14,5 @@ fun f(a: Char) {
 // 0 getFirst
 // 0 getLast
 // 0 getStep
-// 1 IF_ICMP
+// 1 IF_ICMPGE
+// 1 IF

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInUntilCharMaxValue.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInUntilCharMaxValue.kt
@@ -1,5 +1,7 @@
-fun f() {
-    for (i in 1..2) {
+const val M = Char.MAX_VALUE
+
+fun f(a: Char) {
+    for (i in a until M) {
     }
 }
 

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInUntilIntMaxValue.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInUntilIntMaxValue.kt
@@ -1,8 +1,11 @@
 const val M = Int.MAX_VALUE
 
-fun f(a: Int) {
+fun f(a: Int): Int {
+    var n = 0
     for (i in a until M) {
+        n++
     }
+    return n
 }
 
 // 0 iterator
@@ -11,4 +14,5 @@ fun f(a: Int) {
 // 0 getFirst
 // 0 getLast
 // 0 getStep
-// 1 IF_ICMP
+// 1 IF_ICMPGE
+// 1 IF

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInUntilIntMaxValue.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInUntilIntMaxValue.kt
@@ -1,5 +1,7 @@
-fun f() {
-    for (i in 1..2) {
+const val M = Int.MAX_VALUE
+
+fun f(a: Int) {
+    for (i in a until M) {
     }
 }
 

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInUntilLongMaxValue.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInUntilLongMaxValue.kt
@@ -1,8 +1,11 @@
 const val M = Long.MAX_VALUE
 
-fun f(a: Long) {
+fun f(a: Long): Int {
+    var n = 0
     for (i in a until M) {
+        n++
     }
+    return n
 }
 
 // 0 iterator
@@ -12,4 +15,5 @@ fun f(a: Long) {
 // 0 getLast
 // 0 getStep
 // 1 LCMP
+// 1 IFGE
 // 1 IF

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInUntilLongMaxValue.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInUntilLongMaxValue.kt
@@ -1,0 +1,15 @@
+const val M = Long.MAX_VALUE
+
+fun f(a: Long) {
+    for (i in a until M) {
+    }
+}
+
+// 0 iterator
+// 0 getStart
+// 0 getEnd
+// 0 getFirst
+// 0 getLast
+// 0 getStep
+// 1 LCMP
+// 1 IF

--- a/compiler/testData/codegen/bytecodeText/forLoop/forIntInDownTo.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forIntInDownTo.kt
@@ -12,3 +12,4 @@ fun test(): Int {
 // 0 getFirst
 // 0 getLast
 // 1 IF_ICMP
+// 1 IF

--- a/compiler/testData/codegen/bytecodeText/forLoop/forIntInDownTo.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forIntInDownTo.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 fun test(): Int {
     var sum = 0
     for (i in 4 downTo 1) {
@@ -12,5 +11,4 @@ fun test(): Int {
 // 0 getEnd
 // 0 getFirst
 // 0 getLast
-// 0 IF_ICMPEQ
-// 1 IF_ICMPLT
+// 1 IF_ICMP

--- a/compiler/testData/codegen/bytecodeText/forLoop/primitiveLiteralRange1.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/primitiveLiteralRange1.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 fun f() {
     for (i in 1..2) {
     }

--- a/compiler/testData/codegen/bytecodeText/forLoop/primitiveLiteralRange1.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/primitiveLiteralRange1.kt
@@ -8,3 +8,4 @@ fun f() {
 // 0 getEnd
 // 0 getFirst
 // 0 getLast
+// 0 getStep

--- a/compiler/testData/codegen/bytecodeText/forLoop/primitiveLiteralRange1.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/primitiveLiteralRange1.kt
@@ -9,4 +9,5 @@ fun f() {
 // 0 getFirst
 // 0 getLast
 // 0 getStep
-// 1 IF_ICMP
+// 1 IF_ICMPGT
+// 1 IF

--- a/compiler/testData/codegen/bytecodeText/forLoop/primitiveLiteralRange2.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/primitiveLiteralRange2.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 fun f(a: Int, b: Int) {
     for (i in a..b) {
     }

--- a/compiler/testData/codegen/bytecodeText/forLoop/primitiveLiteralRange2.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/primitiveLiteralRange2.kt
@@ -8,3 +8,4 @@ fun f(a: Int, b: Int) {
 // 0 getEnd
 // 0 getFirst
 // 0 getLast
+// 0 getStep

--- a/compiler/testData/codegen/bytecodeText/forLoop/primitiveLiteralRange2.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/primitiveLiteralRange2.kt
@@ -9,3 +9,4 @@ fun f(a: Int, b: Int) {
 // 0 getFirst
 // 0 getLast
 // 0 getStep
+// 2 IF_ICMP

--- a/compiler/testData/codegen/bytecodeText/forLoop/primitiveLiteralRange2.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/primitiveLiteralRange2.kt
@@ -10,3 +10,4 @@ fun f(a: Int, b: Int) {
 // 0 getLast
 // 0 getStep
 // 2 IF_ICMP
+// 2 IF

--- a/compiler/testData/codegen/bytecodeText/forLoop/primitiveProgression.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/primitiveProgression.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 fun f() {
     for (i in 0..5 step 2) {
     }

--- a/compiler/testData/codegen/bytecodeText/forLoop/primitiveRange.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/primitiveRange.kt
@@ -8,4 +8,3 @@ fun f(r: IntRange) {
 // 0 getEnd
 // 1 getFirst
 // 1 getLast
-// 1 getStep

--- a/compiler/testData/codegen/bytecodeText/forLoop/primitiveRange.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/primitiveRange.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 fun f(r: IntRange) {
     for (i in r) {
     }
@@ -9,3 +8,4 @@ fun f(r: IntRange) {
 // 0 getEnd
 // 1 getFirst
 // 1 getLast
+// 1 getStep

--- a/compiler/testData/codegen/bytecodeText/intRangeNoBoxing.kt
+++ b/compiler/testData/codegen/bytecodeText/intRangeNoBoxing.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 fun Int.until(other: Int) = this..other - 1
 fun foo() {
     val range = 1 until 2

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -18578,6 +18578,49 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             }
         }
 
+        @TestMetadata("compiler/testData/codegen/box/ranges/evaluationOrder")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class EvaluationOrder extends AbstractBlackBoxCodegenTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInEvaluationOrder() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/codegen/box/ranges/evaluationOrder"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.JVM, true);
+            }
+
+            @TestMetadata("forInDownToEvaluationOrder.kt")
+            public void testForInDownToEvaluationOrder() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/evaluationOrder/forInDownToEvaluationOrder.kt");
+            }
+
+            @TestMetadata("forInRangeLiteralEvaluationOrder.kt")
+            public void testForInRangeLiteralEvaluationOrder() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/evaluationOrder/forInRangeLiteralEvaluationOrder.kt");
+            }
+
+            @TestMetadata("forInReversedDownToEvaluationOrder.kt")
+            public void testForInReversedDownToEvaluationOrder() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/evaluationOrder/forInReversedDownToEvaluationOrder.kt");
+            }
+
+            @TestMetadata("forInReversedRangeLiteralEvaluationOrder.kt")
+            public void testForInReversedRangeLiteralEvaluationOrder() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/evaluationOrder/forInReversedRangeLiteralEvaluationOrder.kt");
+            }
+
+            @TestMetadata("forInReversedUntilEvaluationOrder.kt")
+            public void testForInReversedUntilEvaluationOrder() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/evaluationOrder/forInReversedUntilEvaluationOrder.kt");
+            }
+
+            @TestMetadata("forInUntilEvaluationOrder.kt")
+            public void testForInUntilEvaluationOrder() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/evaluationOrder/forInUntilEvaluationOrder.kt");
+            }
+        }
+
         @TestMetadata("compiler/testData/codegen/box/ranges/expression")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)
@@ -18952,34 +18995,6 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             @TestMetadata("forInReversedUntilWithNonConstBounds.kt")
             public void testForInReversedUntilWithNonConstBounds() throws Exception {
                 runTest("compiler/testData/codegen/box/ranges/forInReversed/forInReversedUntilWithNonConstBounds.kt");
-            }
-
-            @TestMetadata("compiler/testData/codegen/box/ranges/forInReversed/evaluationOrder")
-            @TestDataPath("$PROJECT_ROOT")
-            @RunWith(JUnit3RunnerWithInners.class)
-            public static class EvaluationOrder extends AbstractBlackBoxCodegenTest {
-                private void runTest(String testDataFilePath) throws Exception {
-                    KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM, testDataFilePath);
-                }
-
-                public void testAllFilesPresentInEvaluationOrder() throws Exception {
-                    KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/codegen/box/ranges/forInReversed/evaluationOrder"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.JVM, true);
-                }
-
-                @TestMetadata("forInReversedDownToEvaluationOrder.kt")
-                public void testForInReversedDownToEvaluationOrder() throws Exception {
-                    runTest("compiler/testData/codegen/box/ranges/forInReversed/evaluationOrder/forInReversedDownToEvaluationOrder.kt");
-                }
-
-                @TestMetadata("forInReversedRangeLiteralEvaluationOrder.kt")
-                public void testForInReversedRangeLiteralEvaluationOrder() throws Exception {
-                    runTest("compiler/testData/codegen/box/ranges/forInReversed/evaluationOrder/forInReversedRangeLiteralEvaluationOrder.kt");
-                }
-
-                @TestMetadata("forInReversedUntilEvaluationOrder.kt")
-                public void testForInReversedUntilEvaluationOrder() throws Exception {
-                    runTest("compiler/testData/codegen/box/ranges/forInReversed/evaluationOrder/forInReversedUntilEvaluationOrder.kt");
-                }
             }
         }
 

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
@@ -1627,9 +1627,19 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
             runTest("compiler/testData/codegen/bytecodeText/forLoop/forInCharSequence.kt");
         }
 
+        @TestMetadata("forInObjectArray.kt")
+        public void testForInObjectArray() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/forLoop/forInObjectArray.kt");
+        }
+
         @TestMetadata("forInOptimizableUnsignedRange.kt")
         public void testForInOptimizableUnsignedRange() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/forLoop/forInOptimizableUnsignedRange.kt");
+        }
+
+        @TestMetadata("forInPrimitiveArray.kt")
+        public void testForInPrimitiveArray() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/forLoop/forInPrimitiveArray.kt");
         }
 
         @TestMetadata("forInRangeSpecializedToUntil.kt")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
@@ -1627,6 +1627,21 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
             runTest("compiler/testData/codegen/bytecodeText/forLoop/forInCharSequence.kt");
         }
 
+        @TestMetadata("forInDownToCharMinValue.kt")
+        public void testForInDownToCharMinValue() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/forLoop/forInDownToCharMinValue.kt");
+        }
+
+        @TestMetadata("forInDownToIntMinValue.kt")
+        public void testForInDownToIntMinValue() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/forLoop/forInDownToIntMinValue.kt");
+        }
+
+        @TestMetadata("forInDownToLongMinValue.kt")
+        public void testForInDownToLongMinValue() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/forLoop/forInDownToLongMinValue.kt");
+        }
+
         @TestMetadata("forInObjectArray.kt")
         public void testForInObjectArray() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/forLoop/forInObjectArray.kt");
@@ -1652,14 +1667,29 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
             runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeToCharConst.kt");
         }
 
+        @TestMetadata("forInRangeToCharMaxValue.kt")
+        public void testForInRangeToCharMaxValue() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeToCharMaxValue.kt");
+        }
+
         @TestMetadata("forInRangeToConst.kt")
         public void testForInRangeToConst() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeToConst.kt");
         }
 
+        @TestMetadata("forInRangeToIntMaxValue.kt")
+        public void testForInRangeToIntMaxValue() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeToIntMaxValue.kt");
+        }
+
         @TestMetadata("forInRangeToLongConst.kt")
         public void testForInRangeToLongConst() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeToLongConst.kt");
+        }
+
+        @TestMetadata("forInRangeToLongMaxValue.kt")
+        public void testForInRangeToLongMaxValue() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeToLongMaxValue.kt");
         }
 
         @TestMetadata("forInRangeToQualifiedConst.kt")
@@ -1680,6 +1710,21 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
         @TestMetadata("forInUntil.kt")
         public void testForInUntil() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/forLoop/forInUntil.kt");
+        }
+
+        @TestMetadata("forInUntilCharMaxValue.kt")
+        public void testForInUntilCharMaxValue() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/forLoop/forInUntilCharMaxValue.kt");
+        }
+
+        @TestMetadata("forInUntilIntMaxValue.kt")
+        public void testForInUntilIntMaxValue() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/forLoop/forInUntilIntMaxValue.kt");
+        }
+
+        @TestMetadata("forInUntilLongMaxValue.kt")
+        public void testForInUntilLongMaxValue() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/forLoop/forInUntilLongMaxValue.kt");
         }
 
         @TestMetadata("forIntInDownTo.kt")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -18578,6 +18578,49 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             }
         }
 
+        @TestMetadata("compiler/testData/codegen/box/ranges/evaluationOrder")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class EvaluationOrder extends AbstractLightAnalysisModeTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInEvaluationOrder() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/codegen/box/ranges/evaluationOrder"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.JVM, true);
+            }
+
+            @TestMetadata("forInDownToEvaluationOrder.kt")
+            public void testForInDownToEvaluationOrder() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/evaluationOrder/forInDownToEvaluationOrder.kt");
+            }
+
+            @TestMetadata("forInRangeLiteralEvaluationOrder.kt")
+            public void testForInRangeLiteralEvaluationOrder() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/evaluationOrder/forInRangeLiteralEvaluationOrder.kt");
+            }
+
+            @TestMetadata("forInReversedDownToEvaluationOrder.kt")
+            public void testForInReversedDownToEvaluationOrder() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/evaluationOrder/forInReversedDownToEvaluationOrder.kt");
+            }
+
+            @TestMetadata("forInReversedRangeLiteralEvaluationOrder.kt")
+            public void testForInReversedRangeLiteralEvaluationOrder() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/evaluationOrder/forInReversedRangeLiteralEvaluationOrder.kt");
+            }
+
+            @TestMetadata("forInReversedUntilEvaluationOrder.kt")
+            public void testForInReversedUntilEvaluationOrder() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/evaluationOrder/forInReversedUntilEvaluationOrder.kt");
+            }
+
+            @TestMetadata("forInUntilEvaluationOrder.kt")
+            public void testForInUntilEvaluationOrder() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/evaluationOrder/forInUntilEvaluationOrder.kt");
+            }
+        }
+
         @TestMetadata("compiler/testData/codegen/box/ranges/expression")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)
@@ -18952,34 +18995,6 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             @TestMetadata("forInReversedUntilWithNonConstBounds.kt")
             public void testForInReversedUntilWithNonConstBounds() throws Exception {
                 runTest("compiler/testData/codegen/box/ranges/forInReversed/forInReversedUntilWithNonConstBounds.kt");
-            }
-
-            @TestMetadata("compiler/testData/codegen/box/ranges/forInReversed/evaluationOrder")
-            @TestDataPath("$PROJECT_ROOT")
-            @RunWith(JUnit3RunnerWithInners.class)
-            public static class EvaluationOrder extends AbstractLightAnalysisModeTest {
-                private void runTest(String testDataFilePath) throws Exception {
-                    KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM, testDataFilePath);
-                }
-
-                public void testAllFilesPresentInEvaluationOrder() throws Exception {
-                    KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/codegen/box/ranges/forInReversed/evaluationOrder"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.JVM, true);
-                }
-
-                @TestMetadata("forInReversedDownToEvaluationOrder.kt")
-                public void testForInReversedDownToEvaluationOrder() throws Exception {
-                    runTest("compiler/testData/codegen/box/ranges/forInReversed/evaluationOrder/forInReversedDownToEvaluationOrder.kt");
-                }
-
-                @TestMetadata("forInReversedRangeLiteralEvaluationOrder.kt")
-                public void testForInReversedRangeLiteralEvaluationOrder() throws Exception {
-                    runTest("compiler/testData/codegen/box/ranges/forInReversed/evaluationOrder/forInReversedRangeLiteralEvaluationOrder.kt");
-                }
-
-                @TestMetadata("forInReversedUntilEvaluationOrder.kt")
-                public void testForInReversedUntilEvaluationOrder() throws Exception {
-                    runTest("compiler/testData/codegen/box/ranges/forInReversed/evaluationOrder/forInReversedUntilEvaluationOrder.kt");
-                }
             }
         }
 

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -18583,6 +18583,49 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             }
         }
 
+        @TestMetadata("compiler/testData/codegen/box/ranges/evaluationOrder")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class EvaluationOrder extends AbstractIrBlackBoxCodegenTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM_IR, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInEvaluationOrder() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/codegen/box/ranges/evaluationOrder"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.JVM_IR, true);
+            }
+
+            @TestMetadata("forInDownToEvaluationOrder.kt")
+            public void testForInDownToEvaluationOrder() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/evaluationOrder/forInDownToEvaluationOrder.kt");
+            }
+
+            @TestMetadata("forInRangeLiteralEvaluationOrder.kt")
+            public void testForInRangeLiteralEvaluationOrder() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/evaluationOrder/forInRangeLiteralEvaluationOrder.kt");
+            }
+
+            @TestMetadata("forInReversedDownToEvaluationOrder.kt")
+            public void testForInReversedDownToEvaluationOrder() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/evaluationOrder/forInReversedDownToEvaluationOrder.kt");
+            }
+
+            @TestMetadata("forInReversedRangeLiteralEvaluationOrder.kt")
+            public void testForInReversedRangeLiteralEvaluationOrder() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/evaluationOrder/forInReversedRangeLiteralEvaluationOrder.kt");
+            }
+
+            @TestMetadata("forInReversedUntilEvaluationOrder.kt")
+            public void testForInReversedUntilEvaluationOrder() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/evaluationOrder/forInReversedUntilEvaluationOrder.kt");
+            }
+
+            @TestMetadata("forInUntilEvaluationOrder.kt")
+            public void testForInUntilEvaluationOrder() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/evaluationOrder/forInUntilEvaluationOrder.kt");
+            }
+        }
+
         @TestMetadata("compiler/testData/codegen/box/ranges/expression")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)
@@ -18957,34 +19000,6 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             @TestMetadata("forInReversedUntilWithNonConstBounds.kt")
             public void testForInReversedUntilWithNonConstBounds() throws Exception {
                 runTest("compiler/testData/codegen/box/ranges/forInReversed/forInReversedUntilWithNonConstBounds.kt");
-            }
-
-            @TestMetadata("compiler/testData/codegen/box/ranges/forInReversed/evaluationOrder")
-            @TestDataPath("$PROJECT_ROOT")
-            @RunWith(JUnit3RunnerWithInners.class)
-            public static class EvaluationOrder extends AbstractIrBlackBoxCodegenTest {
-                private void runTest(String testDataFilePath) throws Exception {
-                    KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM_IR, testDataFilePath);
-                }
-
-                public void testAllFilesPresentInEvaluationOrder() throws Exception {
-                    KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/codegen/box/ranges/forInReversed/evaluationOrder"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.JVM_IR, true);
-                }
-
-                @TestMetadata("forInReversedDownToEvaluationOrder.kt")
-                public void testForInReversedDownToEvaluationOrder() throws Exception {
-                    runTest("compiler/testData/codegen/box/ranges/forInReversed/evaluationOrder/forInReversedDownToEvaluationOrder.kt");
-                }
-
-                @TestMetadata("forInReversedRangeLiteralEvaluationOrder.kt")
-                public void testForInReversedRangeLiteralEvaluationOrder() throws Exception {
-                    runTest("compiler/testData/codegen/box/ranges/forInReversed/evaluationOrder/forInReversedRangeLiteralEvaluationOrder.kt");
-                }
-
-                @TestMetadata("forInReversedUntilEvaluationOrder.kt")
-                public void testForInReversedUntilEvaluationOrder() throws Exception {
-                    runTest("compiler/testData/codegen/box/ranges/forInReversed/evaluationOrder/forInReversedUntilEvaluationOrder.kt");
-                }
             }
         }
 

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
@@ -1637,6 +1637,21 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
             runTest("compiler/testData/codegen/bytecodeText/forLoop/forInCharSequence.kt");
         }
 
+        @TestMetadata("forInDownToCharMinValue.kt")
+        public void testForInDownToCharMinValue() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/forLoop/forInDownToCharMinValue.kt");
+        }
+
+        @TestMetadata("forInDownToIntMinValue.kt")
+        public void testForInDownToIntMinValue() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/forLoop/forInDownToIntMinValue.kt");
+        }
+
+        @TestMetadata("forInDownToLongMinValue.kt")
+        public void testForInDownToLongMinValue() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/forLoop/forInDownToLongMinValue.kt");
+        }
+
         @TestMetadata("forInObjectArray.kt")
         public void testForInObjectArray() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/forLoop/forInObjectArray.kt");
@@ -1662,14 +1677,29 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
             runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeToCharConst.kt");
         }
 
+        @TestMetadata("forInRangeToCharMaxValue.kt")
+        public void testForInRangeToCharMaxValue() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeToCharMaxValue.kt");
+        }
+
         @TestMetadata("forInRangeToConst.kt")
         public void testForInRangeToConst() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeToConst.kt");
         }
 
+        @TestMetadata("forInRangeToIntMaxValue.kt")
+        public void testForInRangeToIntMaxValue() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeToIntMaxValue.kt");
+        }
+
         @TestMetadata("forInRangeToLongConst.kt")
         public void testForInRangeToLongConst() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeToLongConst.kt");
+        }
+
+        @TestMetadata("forInRangeToLongMaxValue.kt")
+        public void testForInRangeToLongMaxValue() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeToLongMaxValue.kt");
         }
 
         @TestMetadata("forInRangeToQualifiedConst.kt")
@@ -1690,6 +1720,21 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
         @TestMetadata("forInUntil.kt")
         public void testForInUntil() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/forLoop/forInUntil.kt");
+        }
+
+        @TestMetadata("forInUntilCharMaxValue.kt")
+        public void testForInUntilCharMaxValue() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/forLoop/forInUntilCharMaxValue.kt");
+        }
+
+        @TestMetadata("forInUntilIntMaxValue.kt")
+        public void testForInUntilIntMaxValue() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/forLoop/forInUntilIntMaxValue.kt");
+        }
+
+        @TestMetadata("forInUntilLongMaxValue.kt")
+        public void testForInUntilLongMaxValue() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/forLoop/forInUntilLongMaxValue.kt");
         }
 
         @TestMetadata("forIntInDownTo.kt")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
@@ -1637,9 +1637,19 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
             runTest("compiler/testData/codegen/bytecodeText/forLoop/forInCharSequence.kt");
         }
 
+        @TestMetadata("forInObjectArray.kt")
+        public void testForInObjectArray() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/forLoop/forInObjectArray.kt");
+        }
+
         @TestMetadata("forInOptimizableUnsignedRange.kt")
         public void testForInOptimizableUnsignedRange() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/forLoop/forInOptimizableUnsignedRange.kt");
+        }
+
+        @TestMetadata("forInPrimitiveArray.kt")
+        public void testForInPrimitiveArray() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/forLoop/forInPrimitiveArray.kt");
         }
 
         @TestMetadata("forInRangeSpecializedToUntil.kt")

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -14638,6 +14638,49 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             }
         }
 
+        @TestMetadata("compiler/testData/codegen/box/ranges/evaluationOrder")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class EvaluationOrder extends AbstractIrJsCodegenBoxTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest0(this::doTest, TargetBackend.JS_IR, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInEvaluationOrder() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/codegen/box/ranges/evaluationOrder"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.JS_IR, true);
+            }
+
+            @TestMetadata("forInDownToEvaluationOrder.kt")
+            public void testForInDownToEvaluationOrder() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/evaluationOrder/forInDownToEvaluationOrder.kt");
+            }
+
+            @TestMetadata("forInRangeLiteralEvaluationOrder.kt")
+            public void testForInRangeLiteralEvaluationOrder() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/evaluationOrder/forInRangeLiteralEvaluationOrder.kt");
+            }
+
+            @TestMetadata("forInReversedDownToEvaluationOrder.kt")
+            public void testForInReversedDownToEvaluationOrder() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/evaluationOrder/forInReversedDownToEvaluationOrder.kt");
+            }
+
+            @TestMetadata("forInReversedRangeLiteralEvaluationOrder.kt")
+            public void testForInReversedRangeLiteralEvaluationOrder() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/evaluationOrder/forInReversedRangeLiteralEvaluationOrder.kt");
+            }
+
+            @TestMetadata("forInReversedUntilEvaluationOrder.kt")
+            public void testForInReversedUntilEvaluationOrder() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/evaluationOrder/forInReversedUntilEvaluationOrder.kt");
+            }
+
+            @TestMetadata("forInUntilEvaluationOrder.kt")
+            public void testForInUntilEvaluationOrder() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/evaluationOrder/forInUntilEvaluationOrder.kt");
+            }
+        }
+
         @TestMetadata("compiler/testData/codegen/box/ranges/expression")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)
@@ -15012,34 +15055,6 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             @TestMetadata("forInReversedUntilWithNonConstBounds.kt")
             public void testForInReversedUntilWithNonConstBounds() throws Exception {
                 runTest("compiler/testData/codegen/box/ranges/forInReversed/forInReversedUntilWithNonConstBounds.kt");
-            }
-
-            @TestMetadata("compiler/testData/codegen/box/ranges/forInReversed/evaluationOrder")
-            @TestDataPath("$PROJECT_ROOT")
-            @RunWith(JUnit3RunnerWithInners.class)
-            public static class EvaluationOrder extends AbstractIrJsCodegenBoxTest {
-                private void runTest(String testDataFilePath) throws Exception {
-                    KotlinTestUtils.runTest0(this::doTest, TargetBackend.JS_IR, testDataFilePath);
-                }
-
-                public void testAllFilesPresentInEvaluationOrder() throws Exception {
-                    KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/codegen/box/ranges/forInReversed/evaluationOrder"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.JS_IR, true);
-                }
-
-                @TestMetadata("forInReversedDownToEvaluationOrder.kt")
-                public void testForInReversedDownToEvaluationOrder() throws Exception {
-                    runTest("compiler/testData/codegen/box/ranges/forInReversed/evaluationOrder/forInReversedDownToEvaluationOrder.kt");
-                }
-
-                @TestMetadata("forInReversedRangeLiteralEvaluationOrder.kt")
-                public void testForInReversedRangeLiteralEvaluationOrder() throws Exception {
-                    runTest("compiler/testData/codegen/box/ranges/forInReversed/evaluationOrder/forInReversedRangeLiteralEvaluationOrder.kt");
-                }
-
-                @TestMetadata("forInReversedUntilEvaluationOrder.kt")
-                public void testForInReversedUntilEvaluationOrder() throws Exception {
-                    runTest("compiler/testData/codegen/box/ranges/forInReversed/evaluationOrder/forInReversedUntilEvaluationOrder.kt");
-                }
             }
         }
 

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -15808,6 +15808,49 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             }
         }
 
+        @TestMetadata("compiler/testData/codegen/box/ranges/evaluationOrder")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class EvaluationOrder extends AbstractJsCodegenBoxTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest0(this::doTest, TargetBackend.JS, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInEvaluationOrder() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/codegen/box/ranges/evaluationOrder"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.JS, true);
+            }
+
+            @TestMetadata("forInDownToEvaluationOrder.kt")
+            public void testForInDownToEvaluationOrder() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/evaluationOrder/forInDownToEvaluationOrder.kt");
+            }
+
+            @TestMetadata("forInRangeLiteralEvaluationOrder.kt")
+            public void testForInRangeLiteralEvaluationOrder() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/evaluationOrder/forInRangeLiteralEvaluationOrder.kt");
+            }
+
+            @TestMetadata("forInReversedDownToEvaluationOrder.kt")
+            public void testForInReversedDownToEvaluationOrder() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/evaluationOrder/forInReversedDownToEvaluationOrder.kt");
+            }
+
+            @TestMetadata("forInReversedRangeLiteralEvaluationOrder.kt")
+            public void testForInReversedRangeLiteralEvaluationOrder() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/evaluationOrder/forInReversedRangeLiteralEvaluationOrder.kt");
+            }
+
+            @TestMetadata("forInReversedUntilEvaluationOrder.kt")
+            public void testForInReversedUntilEvaluationOrder() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/evaluationOrder/forInReversedUntilEvaluationOrder.kt");
+            }
+
+            @TestMetadata("forInUntilEvaluationOrder.kt")
+            public void testForInUntilEvaluationOrder() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/evaluationOrder/forInUntilEvaluationOrder.kt");
+            }
+        }
+
         @TestMetadata("compiler/testData/codegen/box/ranges/expression")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)
@@ -16182,34 +16225,6 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             @TestMetadata("forInReversedUntilWithNonConstBounds.kt")
             public void testForInReversedUntilWithNonConstBounds() throws Exception {
                 runTest("compiler/testData/codegen/box/ranges/forInReversed/forInReversedUntilWithNonConstBounds.kt");
-            }
-
-            @TestMetadata("compiler/testData/codegen/box/ranges/forInReversed/evaluationOrder")
-            @TestDataPath("$PROJECT_ROOT")
-            @RunWith(JUnit3RunnerWithInners.class)
-            public static class EvaluationOrder extends AbstractJsCodegenBoxTest {
-                private void runTest(String testDataFilePath) throws Exception {
-                    KotlinTestUtils.runTest0(this::doTest, TargetBackend.JS, testDataFilePath);
-                }
-
-                public void testAllFilesPresentInEvaluationOrder() throws Exception {
-                    KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/codegen/box/ranges/forInReversed/evaluationOrder"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.JS, true);
-                }
-
-                @TestMetadata("forInReversedDownToEvaluationOrder.kt")
-                public void testForInReversedDownToEvaluationOrder() throws Exception {
-                    runTest("compiler/testData/codegen/box/ranges/forInReversed/evaluationOrder/forInReversedDownToEvaluationOrder.kt");
-                }
-
-                @TestMetadata("forInReversedRangeLiteralEvaluationOrder.kt")
-                public void testForInReversedRangeLiteralEvaluationOrder() throws Exception {
-                    runTest("compiler/testData/codegen/box/ranges/forInReversed/evaluationOrder/forInReversedRangeLiteralEvaluationOrder.kt");
-                }
-
-                @TestMetadata("forInReversedUntilEvaluationOrder.kt")
-                public void testForInReversedUntilEvaluationOrder() throws Exception {
-                    runTest("compiler/testData/codegen/box/ranges/forInReversed/evaluationOrder/forInReversedUntilEvaluationOrder.kt");
-                }
             }
         }
 


### PR DESCRIPTION
Diffs resulting from the port:
https://github.com/punzki/kotlin-native/compare/master...punzki:for-loop-diff

When ForLoopsLowering is added to the JVM lowering phases, this causes some of the forLoop bytecode tests to pass, and many still fail due to differences in behavior compared to non-IR backend:
- Generated conditions for lowered loop
- Generated temporary variables
- Supported iterables (e.g., withIndex(), CharSequences)
- Means of incrementing induction variable

The phase will be added once more TODOs are resolved and it is more functionally complete, to prevent breaking for loops.