### PR TITLE
Run ExpectDeclarationsRemoving in the JVM_IR backend.

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
@@ -37,6 +37,12 @@ private fun makePatchParentsPhase(number: Int) = namedIrFilePhase(
     nlevels = 0
 )
 
+private val expectDeclarationsRemovingPhase = makeIrFilePhase(
+    ::ExpectDeclarationsRemoving,
+    name = "ExpectDeclarationsRemoving",
+    description = "Remove expect declaration from module fragment"
+)
+
 private val propertiesPhase = makeIrFilePhase(
     { context ->
         PropertiesLowering(context, JvmLoweredDeclarationOrigin.SYNTHETIC_METHOD_FOR_PROPERTY_ANNOTATIONS) { propertyName ->
@@ -51,7 +57,8 @@ private val propertiesPhase = makeIrFilePhase(
 internal val jvmPhases = namedIrFilePhase(
     name = "IrLowering",
     description = "IR lowering",
-    lower = jvmCoercionToUnitPhase then
+    lower = expectDeclarationsRemovingPhase then
+            jvmCoercionToUnitPhase then
             fileClassPhase then
             kCallableNamePropertyPhase then
 

--- a/compiler/testData/codegen/box/multiplatform/defaultArguments/bothInExpectAndActual.kt
+++ b/compiler/testData/codegen/box/multiplatform/defaultArguments/bothInExpectAndActual.kt
@@ -1,5 +1,5 @@
 // !LANGUAGE: +MultiPlatformProjects
-// IGNORE_BACKEND: JVM_IR, NATIVE
+// IGNORE_BACKEND: NATIVE
 // FILE: common.kt
 
 public expect fun <T> Array<out T>.copyInto(

--- a/compiler/testData/codegen/box/multiplatform/defaultArguments/bothInExpectAndActual2.kt
+++ b/compiler/testData/codegen/box/multiplatform/defaultArguments/bothInExpectAndActual2.kt
@@ -1,5 +1,5 @@
 // !LANGUAGE: +MultiPlatformProjects
-// IGNORE_BACKEND: JVM_IR, NATIVE
+// IGNORE_BACKEND: NATIVE
 // FILE: common.kt
 
 expect interface I {

--- a/compiler/testData/codegen/box/multiplatform/defaultArguments/constructor.kt
+++ b/compiler/testData/codegen/box/multiplatform/defaultArguments/constructor.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: +MultiPlatformProjects
-// IGNORE_BACKEND: JVM_IR
 // WITH_RUNTIME
 // FILE: common.kt
 

--- a/compiler/testData/codegen/box/multiplatform/defaultArguments/dispatchReceiverValue.kt
+++ b/compiler/testData/codegen/box/multiplatform/defaultArguments/dispatchReceiverValue.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: +MultiPlatformProjects
-// IGNORE_BACKEND: JVM_IR
 
 // FILE: common.kt
 

--- a/compiler/testData/codegen/box/multiplatform/defaultArguments/extensionReceiverValue.kt
+++ b/compiler/testData/codegen/box/multiplatform/defaultArguments/extensionReceiverValue.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: +MultiPlatformProjects
-// IGNORE_BACKEND: JVM_IR
 
 // FILE: common.kt
 

--- a/compiler/testData/codegen/box/multiplatform/defaultArguments/function.kt
+++ b/compiler/testData/codegen/box/multiplatform/defaultArguments/function.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: +MultiPlatformProjects
-// IGNORE_BACKEND: JVM_IR
 // WITH_RUNTIME
 // FILE: common.kt
 

--- a/compiler/testData/codegen/box/multiplatform/defaultArguments/inheritedFromCommonClass.kt
+++ b/compiler/testData/codegen/box/multiplatform/defaultArguments/inheritedFromCommonClass.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: +MultiPlatformProjects
-// IGNORE_BACKEND: JVM_IR
 // WITH_RUNTIME
 // FILE: common.kt
 

--- a/compiler/testData/codegen/box/multiplatform/defaultArguments/inheritedFromExpectedClass.kt
+++ b/compiler/testData/codegen/box/multiplatform/defaultArguments/inheritedFromExpectedClass.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: +MultiPlatformProjects
-// IGNORE_BACKEND: JVM_IR
 // WITH_RUNTIME
 // FILE: common.kt
 

--- a/compiler/testData/codegen/box/multiplatform/defaultArguments/inheritedFromExpectedInterface.kt
+++ b/compiler/testData/codegen/box/multiplatform/defaultArguments/inheritedFromExpectedInterface.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: +MultiPlatformProjects
-// IGNORE_BACKEND: JVM_IR
 
 // FILE: lib.kt
 expect interface I {

--- a/compiler/testData/codegen/box/multiplatform/defaultArguments/inheritedFromExpectedMethod.kt
+++ b/compiler/testData/codegen/box/multiplatform/defaultArguments/inheritedFromExpectedMethod.kt
@@ -1,6 +1,5 @@
 // !LANGUAGE: +MultiPlatformProjects
 // WITH_RUNTIME
-// IGNORE_BACKEND: JVM_IR
 // FILE: common.kt
 
 expect open class C() {

--- a/compiler/testData/codegen/box/multiplatform/defaultArguments/inheritedInExpectedDeclarations.kt
+++ b/compiler/testData/codegen/box/multiplatform/defaultArguments/inheritedInExpectedDeclarations.kt
@@ -1,6 +1,5 @@
 // !LANGUAGE: +MultiPlatformProjects
 // WITH_RUNTIME
-// IGNORE_BACKEND: JVM_IR
 // FILE: common.kt
 
 expect open class A() {

--- a/compiler/testData/codegen/box/multiplatform/defaultArguments/inheritedViaAnotherInterfaceIndirectly.kt
+++ b/compiler/testData/codegen/box/multiplatform/defaultArguments/inheritedViaAnotherInterfaceIndirectly.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: +MultiPlatformProjects
-// IGNORE_BACKEND: JVM_IR
 
 // FILE: lib.kt
 

--- a/compiler/testData/codegen/box/multiplatform/defaultArguments/jvmOverloads.kt
+++ b/compiler/testData/codegen/box/multiplatform/defaultArguments/jvmOverloads.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: +MultiPlatformProjects
-// IGNORE_BACKEND: JVM_IR
 // TARGET_BACKEND: JVM
 // WITH_RUNTIME
 // FILE: J.java

--- a/compiler/testData/codegen/box/multiplatform/defaultArguments/kt23239.kt
+++ b/compiler/testData/codegen/box/multiplatform/defaultArguments/kt23239.kt
@@ -1,6 +1,5 @@
 // !LANGUAGE: +MultiPlatformProjects
 // WITH_RUNTIME
-// IGNORE_BACKEND: JVM_IR
 // FILE: common.kt
 
 expect open class C() {

--- a/compiler/testData/codegen/box/multiplatform/defaultArguments/kt23739.kt
+++ b/compiler/testData/codegen/box/multiplatform/defaultArguments/kt23739.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: +MultiPlatformProjects
-// IGNORE_BACKEND: JVM_IR
 // FILE: common.kt
 
 // A LOT OF LINES

--- a/compiler/testData/codegen/box/multiplatform/defaultArguments/parametersInArgumentValues.kt
+++ b/compiler/testData/codegen/box/multiplatform/defaultArguments/parametersInArgumentValues.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: +MultiPlatformProjects
-// IGNORE_BACKEND: JVM_IR
 
 // FILE: common.kt
 

--- a/compiler/testData/codegen/box/multiplatform/optionalExpectation.kt
+++ b/compiler/testData/codegen/box/multiplatform/optionalExpectation.kt
@@ -1,7 +1,6 @@
 // !LANGUAGE: +MultiPlatformProjects
 // !USE_EXPERIMENTAL: kotlin.ExperimentalMultiplatform
 // IGNORE_BACKEND: NATIVE
-// IGNORE_BACKEND: JVM_IR
 // IGNORE_BACKEND: JS_IR
 // WITH_RUNTIME
 // MODULE: library


### PR DESCRIPTION
The expect/actual mechanism is already implemented in the JS backend and seems to work fine in the JVM backend as well.