### PR TITLE
JVM_IR: Perform asm type conversion for string concat arguments.

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -873,7 +873,7 @@ class ExpressionCodegen(
                 // Use StringBuilder to concatenate.
                 AsmUtil.genStringBuilderConstructor(mv)
                 expression.arguments.forEach {
-                    val stackValue = gen(it, data)
+                    val stackValue = gen(it, it.asmType, data)
                     AsmUtil.genInvokeAppendMethod(mv, stackValue.type, stackValue.kotlinType)
                 }
                 mv.invokevirtual("java/lang/StringBuilder", "toString", "()Ljava/lang/String;", false)

--- a/compiler/testData/codegen/box/dataClasses/unitComponent.kt
+++ b/compiler/testData/codegen/box/dataClasses/unitComponent.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 data class A(val x: Unit)
 
 fun box(): String {


### PR DESCRIPTION
This ensures that the Unit instance is loaded when string
concatenation contains a sub part that is a call of a Unit
return-type method.