### PR TITLE
Resolve type aliases when looking for default arguments to actual method

### DIFF
--- a/compiler/resolution/src/org/jetbrains/kotlin/resolve/multiplatform/ExpectedActualResolver.kt
+++ b/compiler/resolution/src/org/jetbrains/kotlin/resolve/multiplatform/ExpectedActualResolver.kt
@@ -91,7 +91,7 @@ object ExpectedActualResolver {
                             Substitutor(expectedClass.declaredTypeParameters, container.declaredTypeParameters)
                         }
                         else null
-                    areCompatibleCallables(declaration, actual, commonModule, parentSubstitutor = substitutor)
+                    areCompatibleCallables(declaration, actual, parentSubstitutor = substitutor)
                 }
             }
             is ClassifierDescriptorWithTypeParameters -> {
@@ -228,7 +228,7 @@ object ExpectedActualResolver {
     private fun areCompatibleCallables(
         a: CallableMemberDescriptor,
         b: CallableMemberDescriptor,
-        platformModule: ModuleDescriptor,
+        platformModule: ModuleDescriptor = b.module,
         parentSubstitutor: Substitutor? = null
     ): Compatibility {
         assert(a.name == b.name) { "This function should be invoked only for declarations with the same name: $a, $b" }

--- a/compiler/resolution/src/org/jetbrains/kotlin/resolve/multiplatform/ExpectedActualResolver.kt
+++ b/compiler/resolution/src/org/jetbrains/kotlin/resolve/multiplatform/ExpectedActualResolver.kt
@@ -50,7 +50,7 @@ object ExpectedActualResolver {
                     // TODO: support non-source definitions (e.g. from Java)
                     actual.source.containingFile != SourceFile.NO_SOURCE_FILE
                 }.groupBy { actual ->
-                    areCompatibleCallables(expected, actual)
+                    areCompatibleCallables(expected, actual, platformModule)
                 }
             }
             is ClassDescriptor -> {
@@ -91,7 +91,7 @@ object ExpectedActualResolver {
                             Substitutor(expectedClass.declaredTypeParameters, container.declaredTypeParameters)
                         }
                         else null
-                    areCompatibleCallables(declaration, actual, parentSubstitutor = substitutor)
+                    areCompatibleCallables(declaration, actual, commonModule, parentSubstitutor = substitutor)
                 }
             }
             is ClassifierDescriptorWithTypeParameters -> {
@@ -113,7 +113,9 @@ object ExpectedActualResolver {
                 listOf(module.getPackage(containingDeclaration.fqName).memberScope)
             }
             is ClassDescriptor -> {
-                val classes = containingDeclaration.findClassifiersFromModule(module).filterIsInstance<ClassDescriptor>()
+                val classes = containingDeclaration.findClassifiersFromModule(module)
+                    .mapNotNull { if (it is TypeAliasDescriptor) it.classDescriptor else it }
+                    .filterIsInstance<ClassDescriptor>()
                 if (this is ConstructorDescriptor) return classes.flatMap { it.constructors }
 
                 classes.map { it.unsubstitutedMemberScope }
@@ -226,7 +228,7 @@ object ExpectedActualResolver {
     private fun areCompatibleCallables(
         a: CallableMemberDescriptor,
         b: CallableMemberDescriptor,
-        platformModule: ModuleDescriptor = b.module,
+        platformModule: ModuleDescriptor,
         parentSubstitutor: Substitutor? = null
     ): Compatibility {
         assert(a.name == b.name) { "This function should be invoked only for declarations with the same name: $a, $b" }

--- a/compiler/testData/codegen/box/multiplatform/defaultArguments/typeAlias.kt
+++ b/compiler/testData/codegen/box/multiplatform/defaultArguments/typeAlias.kt
@@ -1,0 +1,31 @@
+// !LANGUAGE: +MultiPlatformProjects
+// WITH_RUNTIME
+// FILE: common.kt
+
+expect class Foo() {
+    fun member(a: String, b: Int = 0, c: Double? = null): String
+    fun noDefaultOverrideInExpect(a: String, b: Int = 0, c: Double? = null): String
+}
+
+// FILE: jvm.kt
+
+import kotlin.test.assertEquals
+
+actual typealias Foo = Foo2
+
+class Foo2 constructor() {
+    fun member(a: String, b: Int = 0, c: Double? = null): String = a + "," + b + "," + c
+    fun noDefaultOverrideInExpect(a: String, b: Int, c: Double?): String = a + "," + b + "," + c
+}
+
+fun box(): String {
+    val foo = Foo()
+    assertEquals("OK,0,null", foo.member("OK"))
+    assertEquals("OK,42,null", foo.member("OK", 42))
+    assertEquals("OK,42,3.14", foo.member("OK", 42, 3.14))
+
+    assertEquals("OK,42,3.14", foo.noDefaultOverrideInExpect("OK", 42, 3.14))
+
+
+    return "OK"
+}

--- a/compiler/testData/codegen/boxAgainstJava/multiplatform/annotationsViaActualTypeAliasFromBinary.kt
+++ b/compiler/testData/codegen/boxAgainstJava/multiplatform/annotationsViaActualTypeAliasFromBinary.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 // !LANGUAGE: +MultiPlatformProjects
 // WITH_REFLECT
 // FILE: main.kt

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -15969,6 +15969,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             public void testSuperCall() throws Exception {
                 runTest("compiler/testData/codegen/box/multiplatform/defaultArguments/superCall.kt");
             }
+
+            @TestMetadata("typeAlias.kt")
+            public void testTypeAlias() throws Exception {
+                runTest("compiler/testData/codegen/box/multiplatform/defaultArguments/typeAlias.kt");
+            }
         }
     }
 

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -15969,6 +15969,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             public void testParametersInArgumentValues() throws Exception {
                 runTest("compiler/testData/codegen/box/multiplatform/defaultArguments/parametersInArgumentValues.kt");
             }
+
+            @TestMetadata("typeAlias.kt")
+            public void testTypeAlias() throws Exception {
+                runTest("compiler/testData/codegen/box/multiplatform/defaultArguments/typeAlias.kt");
+            }
         }
     }
 

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -15974,6 +15974,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             public void testSuperCall() throws Exception {
                 runTest("compiler/testData/codegen/box/multiplatform/defaultArguments/superCall.kt");
             }
+
+            @TestMetadata("typeAlias.kt")
+            public void testTypeAlias() throws Exception {
+                runTest("compiler/testData/codegen/box/multiplatform/defaultArguments/typeAlias.kt");
+            }
         }
     }
 

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/IrJsCodegenBoxTestGenerated.java
@@ -12349,6 +12349,11 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             public void testSuperCall() throws Exception {
                 runTest("compiler/testData/codegen/box/multiplatform/defaultArguments/superCall.kt");
             }
+
+            @TestMetadata("typeAlias.kt")
+            public void testTypeAlias() throws Exception {
+                runTest("compiler/testData/codegen/box/multiplatform/defaultArguments/typeAlias.kt");
+            }
         }
     }
 

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -13444,6 +13444,11 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             public void testSuperCall() throws Exception {
                 runTest("compiler/testData/codegen/box/multiplatform/defaultArguments/superCall.kt");
             }
+
+            @TestMetadata("typeAlias.kt")
+            public void testTypeAlias() throws Exception {
+                runTest("compiler/testData/codegen/box/multiplatform/defaultArguments/typeAlias.kt");
+            }
         }
     }
 


### PR DESCRIPTION
This fixes `annotationsViaActualTypeAliasFromBinary.kt`.