### PR TITLE
KT-15537: Add inspection + intention to replace IntRange.start/endInclusive with first/last

### DIFF
--- a/idea/resources/META-INF/plugin-common.xml
+++ b/idea/resources/META-INF/plugin-common.xml
@@ -3306,6 +3306,15 @@
                      language="kotlin"
     />
 
+    <localInspection implementationClass="org.jetbrains.kotlin.idea.inspections.ReplaceRangeStartEndInclusiveWithFirstLastInspection"
+                     displayName="Replace Range 'start' or 'endInclusive' with 'first' or 'last'"
+                     groupPath="Kotlin"
+                     groupName="Style issues"
+                     enabledByDefault="true"
+                     level="WEAK WARNING"
+                     language="kotlin"
+    />
+
     <localInspection implementationClass="org.jetbrains.kotlin.idea.inspections.RedundantRequireNotNullCallInspection"
                      displayName="Redundant 'requireNotNull' or 'checkNotNull' call"
                      groupPath="Kotlin"

--- a/idea/resources/inspectionDescriptions/ReplaceRangeStartEndInclusiveWithFirstLast.html
+++ b/idea/resources/inspectionDescriptions/ReplaceRangeStartEndInclusiveWithFirstLast.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+This inspection reports usages of <code>Range</code> <code>start</code> and <code>endInclusive</code>. These properties can be replaced with <code>first</code> and <code>last</code>.
+Example: <b>range.start</b> can be replaced with <b>range.first</b>.
+</body>
+</html>

--- a/idea/src/org/jetbrains/kotlin/idea/inspections/ReplaceRangeStartEndInclusiveWithFirstLastInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/ReplaceRangeStartEndInclusiveWithFirstLastInspection.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.idea.inspections
+
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElementVisitor
+import org.jetbrains.kotlin.descriptors.ClassDescriptor
+import org.jetbrains.kotlin.idea.caches.resolve.resolveToCall
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtPsiFactory
+import org.jetbrains.kotlin.psi.dotQualifiedExpressionVisitor
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameUnsafe
+
+class ReplaceRangeStartEndInclusiveWithFirstLastInspection : AbstractKotlinInspection() {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        return dotQualifiedExpressionVisitor(fun(expression: KtDotQualifiedExpression) {
+            val selectorExpression = expression.selectorExpression ?: return
+            if (selectorExpression.text != "start" && selectorExpression.text != "endInclusive") return
+
+            val resolvedCall = expression.resolveToCall() ?: return
+            val containing = resolvedCall.resultingDescriptor.containingDeclaration as? ClassDescriptor ?: return
+            if (!containing.isRange()) return
+
+            if (selectorExpression.text == "start") {
+                holder.registerProblem(
+                    expression,
+                    "Could be replaced with `first`",
+                    ReplaceIntRangeStartWithFirstQuickFix()
+                )
+            } else if (selectorExpression.text == "endInclusive") {
+                holder.registerProblem(
+                    expression,
+                    "Could be replaced with `last`",
+                    ReplaceIntRangeEndInclusiveWithLastQuickFix()
+                )
+            }
+        })
+    }
+}
+
+private val rangeTypes = setOf(
+    "kotlin.ranges.IntRange",
+    "kotlin.ranges.CharRange",
+    "kotlin.ranges.LongRange",
+    "kotlin.ranges.UIntRange",
+    "kotlin.ranges.ULongRange"
+)
+
+private fun ClassDescriptor.isRange(): Boolean {
+    return rangeTypes.any { this.fqNameUnsafe.asString() == it }
+}
+
+class ReplaceIntRangeStartWithFirstQuickFix : LocalQuickFix {
+    override fun getName() = "Replace 'start' with 'first'"
+
+    override fun getFamilyName() = name
+
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        val element = descriptor.psiElement as KtDotQualifiedExpression
+        val selector = element.selectorExpression ?: return
+        selector.replace(KtPsiFactory(element).createExpression("first"))
+    }
+}
+
+class ReplaceIntRangeEndInclusiveWithLastQuickFix : LocalQuickFix {
+    override fun getName() = "Replace 'endInclusive' with 'last'"
+
+    override fun getFamilyName() = name
+
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        val element = descriptor.psiElement as KtDotQualifiedExpression
+        val selector = element.selectorExpression ?: return
+        selector.replace(KtPsiFactory(element).createExpression("last"))
+    }
+}

--- a/idea/testData/inspectionsLocal/replaceRangeStartEndInclusiveWithFirstLast/.inspection
+++ b/idea/testData/inspectionsLocal/replaceRangeStartEndInclusiveWithFirstLast/.inspection
@@ -1,0 +1,1 @@
+org.jetbrains.kotlin.idea.inspections.ReplaceRangeStartEndInclusiveWithFirstLastInspection

--- a/idea/testData/inspectionsLocal/replaceRangeStartEndInclusiveWithFirstLast/customRange.kt
+++ b/idea/testData/inspectionsLocal/replaceRangeStartEndInclusiveWithFirstLast/customRange.kt
@@ -1,0 +1,11 @@
+// PROBLEM: none
+
+class MyRange : ClosedRange<String> {
+    override val start: String get() = "a"
+    override val endInclusive: String = "z"
+}
+
+fun main() {
+    val range = MyRange()
+    val start = range.<caret>endInclusive
+}

--- a/idea/testData/inspectionsLocal/replaceRangeStartEndInclusiveWithFirstLast/endInclusiveCharRange.kt
+++ b/idea/testData/inspectionsLocal/replaceRangeStartEndInclusiveWithFirstLast/endInclusiveCharRange.kt
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+
+fun foo() {
+    var range : CharRange = 'a' .. 'z'
+    range.<caret>endInclusive
+}

--- a/idea/testData/inspectionsLocal/replaceRangeStartEndInclusiveWithFirstLast/endInclusiveCharRange.kt.after
+++ b/idea/testData/inspectionsLocal/replaceRangeStartEndInclusiveWithFirstLast/endInclusiveCharRange.kt.after
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+
+fun foo() {
+    var range : CharRange = 'a' .. 'z'
+    range.last
+}

--- a/idea/testData/inspectionsLocal/replaceRangeStartEndInclusiveWithFirstLast/endInclusiveIntRange.kt
+++ b/idea/testData/inspectionsLocal/replaceRangeStartEndInclusiveWithFirstLast/endInclusiveIntRange.kt
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+
+fun foo() {
+    var range : IntRange = 1..2
+    range.<caret>endInclusive
+}

--- a/idea/testData/inspectionsLocal/replaceRangeStartEndInclusiveWithFirstLast/endInclusiveIntRange.kt.after
+++ b/idea/testData/inspectionsLocal/replaceRangeStartEndInclusiveWithFirstLast/endInclusiveIntRange.kt.after
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+
+fun foo() {
+    var range : IntRange = 1..2
+    range.last
+}

--- a/idea/testData/inspectionsLocal/replaceRangeStartEndInclusiveWithFirstLast/endInclusiveLongRange.kt
+++ b/idea/testData/inspectionsLocal/replaceRangeStartEndInclusiveWithFirstLast/endInclusiveLongRange.kt
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+
+fun foo() {
+    var range : LongRange = 1L..2L
+    range.<caret>endInclusive
+}

--- a/idea/testData/inspectionsLocal/replaceRangeStartEndInclusiveWithFirstLast/endInclusiveLongRange.kt.after
+++ b/idea/testData/inspectionsLocal/replaceRangeStartEndInclusiveWithFirstLast/endInclusiveLongRange.kt.after
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+
+fun foo() {
+    var range : LongRange = 1L..2L
+    range.last
+}

--- a/idea/testData/inspectionsLocal/replaceRangeStartEndInclusiveWithFirstLast/startCharRange.kt
+++ b/idea/testData/inspectionsLocal/replaceRangeStartEndInclusiveWithFirstLast/startCharRange.kt
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+
+fun foo() {
+    var range : CharRange  = 'a' .. 'z'
+    range.<caret>start
+}

--- a/idea/testData/inspectionsLocal/replaceRangeStartEndInclusiveWithFirstLast/startCharRange.kt.after
+++ b/idea/testData/inspectionsLocal/replaceRangeStartEndInclusiveWithFirstLast/startCharRange.kt.after
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+
+fun foo() {
+    var range : CharRange  = 'a' .. 'z'
+    range.first
+}

--- a/idea/testData/inspectionsLocal/replaceRangeStartEndInclusiveWithFirstLast/startIntRange.kt
+++ b/idea/testData/inspectionsLocal/replaceRangeStartEndInclusiveWithFirstLast/startIntRange.kt
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+
+fun foo() {
+    var range : IntRange = 1..2
+    range.<caret>start
+}

--- a/idea/testData/inspectionsLocal/replaceRangeStartEndInclusiveWithFirstLast/startIntRange.kt.after
+++ b/idea/testData/inspectionsLocal/replaceRangeStartEndInclusiveWithFirstLast/startIntRange.kt.after
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+
+fun foo() {
+    var range : IntRange = 1..2
+    range.first
+}

--- a/idea/testData/inspectionsLocal/replaceRangeStartEndInclusiveWithFirstLast/startLongRange.kt
+++ b/idea/testData/inspectionsLocal/replaceRangeStartEndInclusiveWithFirstLast/startLongRange.kt
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+
+fun foo() {
+    var range : LongRange = 1L..2L
+    range.<caret>start
+}

--- a/idea/testData/inspectionsLocal/replaceRangeStartEndInclusiveWithFirstLast/startLongRange.kt.after
+++ b/idea/testData/inspectionsLocal/replaceRangeStartEndInclusiveWithFirstLast/startLongRange.kt.after
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+
+fun foo() {
+    var range : LongRange = 1L..2L
+    range.first
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -7268,6 +7268,54 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
         }
     }
 
+    @TestMetadata("idea/testData/inspectionsLocal/replaceRangeStartEndInclusiveWithFirstLast")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class ReplaceRangeStartEndInclusiveWithFirstLast extends AbstractLocalInspectionTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY, testDataFilePath);
+        }
+
+        public void testAllFilesPresentInReplaceRangeStartEndInclusiveWithFirstLast() throws Exception {
+            KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/inspectionsLocal/replaceRangeStartEndInclusiveWithFirstLast"), Pattern.compile("^([\\w\\-_]+)\\.(kt|kts)$"), TargetBackend.ANY, true);
+        }
+
+        @TestMetadata("customRange.kt")
+        public void testCustomRange() throws Exception {
+            runTest("idea/testData/inspectionsLocal/replaceRangeStartEndInclusiveWithFirstLast/customRange.kt");
+        }
+
+        @TestMetadata("endInclusiveCharRange.kt")
+        public void testEndInclusiveCharRange() throws Exception {
+            runTest("idea/testData/inspectionsLocal/replaceRangeStartEndInclusiveWithFirstLast/endInclusiveCharRange.kt");
+        }
+
+        @TestMetadata("endInclusiveIntRange.kt")
+        public void testEndInclusiveIntRange() throws Exception {
+            runTest("idea/testData/inspectionsLocal/replaceRangeStartEndInclusiveWithFirstLast/endInclusiveIntRange.kt");
+        }
+
+        @TestMetadata("endInclusiveLongRange.kt")
+        public void testEndInclusiveLongRange() throws Exception {
+            runTest("idea/testData/inspectionsLocal/replaceRangeStartEndInclusiveWithFirstLast/endInclusiveLongRange.kt");
+        }
+
+        @TestMetadata("startCharRange.kt")
+        public void testStartCharRange() throws Exception {
+            runTest("idea/testData/inspectionsLocal/replaceRangeStartEndInclusiveWithFirstLast/startCharRange.kt");
+        }
+
+        @TestMetadata("startIntRange.kt")
+        public void testStartIntRange() throws Exception {
+            runTest("idea/testData/inspectionsLocal/replaceRangeStartEndInclusiveWithFirstLast/startIntRange.kt");
+        }
+
+        @TestMetadata("startLongRange.kt")
+        public void testStartLongRange() throws Exception {
+            runTest("idea/testData/inspectionsLocal/replaceRangeStartEndInclusiveWithFirstLast/startLongRange.kt");
+        }
+    }
+
     @TestMetadata("idea/testData/inspectionsLocal/replaceRangeToWithUntil")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)


### PR DESCRIPTION
This inspection reports usages of IntRange start and endInclusive. These properties can be replaced with equivalent `kotlin.collections` `first` and `last`.

Example: range.start` can be replaced with range.first.

Issue: https://youtrack.jetbrains.com/issue/KT-15537

The issue explicitly mentions `IntRange`, so this has been done, but I would imagine that it should work on all ranges `ClosedRange<T>` which also implement `Iterable<T>` e.g. `LongRange`, `UIntRange`, `CharRange`, etc. Thoughts?