### PR TITLE
KT-27821 Fix `SimplifiableCallChain` inspection quick fix removes comments for intermediate operations

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/collections/SimplifyCallChainFix.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/collections/SimplifyCallChainFix.kt
@@ -26,6 +26,7 @@ import org.jetbrains.kotlin.idea.core.moveFunctionLiteralOutsideParentheses
 import org.jetbrains.kotlin.idea.core.replaced
 import org.jetbrains.kotlin.idea.formatter.commitAndUnblockDocument
 import org.jetbrains.kotlin.idea.intentions.callExpression
+import org.jetbrains.kotlin.idea.util.CommentSaver
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.PsiChildRange
 
@@ -42,6 +43,7 @@ class SimplifyCallChainFix(
     override fun getFamilyName() = name
 
     fun apply(qualifiedExpression: KtQualifiedExpression) {
+        val commentSaver = CommentSaver(qualifiedExpression)
         val factory = KtPsiFactory(qualifiedExpression)
         val firstExpression = qualifiedExpression.receiverExpression
 
@@ -85,6 +87,10 @@ class SimplifyCallChainFix(
         val project = qualifiedExpression.project
         val file = qualifiedExpression.containingKtFile
         val result = qualifiedExpression.replaced(newQualifiedOrCallExpression)
+
+        if (!firstCallHasArguments && !secondCallHasArguments) {
+            commentSaver.restore(result)
+        }
         if (lambdaExpression != null) {
             val callExpression = when (result) {
                 is KtQualifiedExpression -> result.callExpression

--- a/idea/testData/inspectionsLocal/collections/simplifiableCallChain/saveComment.kt
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCallChain/saveComment.kt
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+val v1 = listOf(1, 2, 3, 11, 33, 25, 100)
+    .filter<caret> { it % 2 == 0 } // Some Comment
+    .isNotEmpty() // Some Additional Comment

--- a/idea/testData/inspectionsLocal/collections/simplifiableCallChain/saveComment.kt.after
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCallChain/saveComment.kt.after
@@ -1,0 +1,3 @@
+// WITH_RUNTIME
+val v1 = // Some Comment
+        listOf(1, 2, 3, 11, 33, 25, 100).any { it % 2 == 0 } // Some Additional Comment

--- a/idea/testData/inspectionsLocal/collections/simplifiableCallChain/saveComment2.kt
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCallChain/saveComment2.kt
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+val v1 = listOf(1, 2, 3, 11, 33, 25, 100)
+    .filter<caret> { it % 2 == 0 } // Some Comment
+    .isNotEmpty()

--- a/idea/testData/inspectionsLocal/collections/simplifiableCallChain/saveComment2.kt.after
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCallChain/saveComment2.kt.after
@@ -1,0 +1,3 @@
+// WITH_RUNTIME
+val v1 = // Some Comment
+        listOf(1, 2, 3, 11, 33, 25, 100).any { it % 2 == 0 }

--- a/idea/testData/inspectionsLocal/collections/simplifiableCallChain/saveComment3.kt
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCallChain/saveComment3.kt
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+val v1 = listOf(1, 2, 3, 11, 33, 25, 100)
+    .filter<caret> { it % 2 == 0 }
+    .isNotEmpty() // Some Comment

--- a/idea/testData/inspectionsLocal/collections/simplifiableCallChain/saveComment3.kt.after
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCallChain/saveComment3.kt.after
@@ -1,0 +1,2 @@
+// WITH_RUNTIME
+val v1 = listOf(1, 2, 3, 11, 33, 25, 100).any { it % 2 == 0 } // Some Comment

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -1276,6 +1276,21 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
                 runTest("idea/testData/inspectionsLocal/collections/simplifiableCallChain/mapWithReturn.kt");
             }
 
+            @TestMetadata("saveComment.kt")
+            public void testSaveComment() throws Exception {
+                runTest("idea/testData/inspectionsLocal/collections/simplifiableCallChain/saveComment.kt");
+            }
+
+            @TestMetadata("saveComment2.kt")
+            public void testSaveComment2() throws Exception {
+                runTest("idea/testData/inspectionsLocal/collections/simplifiableCallChain/saveComment2.kt");
+            }
+
+            @TestMetadata("saveComment3.kt")
+            public void testSaveComment3() throws Exception {
+                runTest("idea/testData/inspectionsLocal/collections/simplifiableCallChain/saveComment3.kt");
+            }
+
             @TestMetadata("idea/testData/inspectionsLocal/collections/simplifiableCallChain/primitiveArray")
             @TestDataPath("$PROJECT_ROOT")
             @RunWith(JUnit3RunnerWithInners.class)
@@ -6569,39 +6584,6 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
         }
     }
 
-    @TestMetadata("idea/testData/inspectionsLocal/replaceCollectionCountWithSize")
-    @TestDataPath("$PROJECT_ROOT")
-    @RunWith(JUnit3RunnerWithInners.class)
-    public static class ReplaceCollectionCountWithSize extends AbstractLocalInspectionTest {
-        private void runTest(String testDataFilePath) throws Exception {
-            KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY, testDataFilePath);
-        }
-
-        public void testAllFilesPresentInReplaceCollectionCountWithSize() throws Exception {
-            KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/inspectionsLocal/replaceCollectionCountWithSize"), Pattern.compile("^([\\w\\-_]+)\\.(kt|kts)$"), TargetBackend.ANY, true);
-        }
-
-        @TestMetadata("countOfArray.kt")
-        public void testCountOfArray() throws Exception {
-            runTest("idea/testData/inspectionsLocal/replaceCollectionCountWithSize/countOfArray.kt");
-        }
-
-        @TestMetadata("countOfArrayWithPredicate.kt")
-        public void testCountOfArrayWithPredicate() throws Exception {
-            runTest("idea/testData/inspectionsLocal/replaceCollectionCountWithSize/countOfArrayWithPredicate.kt");
-        }
-
-        @TestMetadata("countOfCollection.kt")
-        public void testCountOfCollection() throws Exception {
-            runTest("idea/testData/inspectionsLocal/replaceCollectionCountWithSize/countOfCollection.kt");
-        }
-
-        @TestMetadata("countOfMap.kt")
-        public void testCountOfMap() throws Exception {
-            runTest("idea/testData/inspectionsLocal/replaceCollectionCountWithSize/countOfMap.kt");
-        }
-    }
-
     @TestMetadata("idea/testData/inspectionsLocal/replaceAssociateFunction")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)
@@ -6865,6 +6847,39 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
             public void testBasic5() throws Exception {
                 runTest("idea/testData/inspectionsLocal/replaceAssociateFunction/associateWithTo/basic5.kt");
             }
+        }
+    }
+
+    @TestMetadata("idea/testData/inspectionsLocal/replaceCollectionCountWithSize")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class ReplaceCollectionCountWithSize extends AbstractLocalInspectionTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY, testDataFilePath);
+        }
+
+        public void testAllFilesPresentInReplaceCollectionCountWithSize() throws Exception {
+            KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/inspectionsLocal/replaceCollectionCountWithSize"), Pattern.compile("^([\\w\\-_]+)\\.(kt|kts)$"), TargetBackend.ANY, true);
+        }
+
+        @TestMetadata("countOfArray.kt")
+        public void testCountOfArray() throws Exception {
+            runTest("idea/testData/inspectionsLocal/replaceCollectionCountWithSize/countOfArray.kt");
+        }
+
+        @TestMetadata("countOfArrayWithPredicate.kt")
+        public void testCountOfArrayWithPredicate() throws Exception {
+            runTest("idea/testData/inspectionsLocal/replaceCollectionCountWithSize/countOfArrayWithPredicate.kt");
+        }
+
+        @TestMetadata("countOfCollection.kt")
+        public void testCountOfCollection() throws Exception {
+            runTest("idea/testData/inspectionsLocal/replaceCollectionCountWithSize/countOfCollection.kt");
+        }
+
+        @TestMetadata("countOfMap.kt")
+        public void testCountOfMap() throws Exception {
+            runTest("idea/testData/inspectionsLocal/replaceCollectionCountWithSize/countOfMap.kt");
         }
     }
 


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-27821