### PR TITLE
Refactor InnerClassesLowering & fix `this` remapping

### DIFF
--- a/compiler/testData/codegen/box/classes/inheritedInnerClass.kt
+++ b/compiler/testData/codegen/box/classes/inheritedInnerClass.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 class Outer() {
   open inner class InnerBase() {
   }

--- a/compiler/testData/codegen/box/classes/inner/kt6708.kt
+++ b/compiler/testData/codegen/box/classes/inner/kt6708.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 open class A() {
     open inner class InnerA
 }

--- a/compiler/testData/codegen/box/classes/propertyInInitializer.kt
+++ b/compiler/testData/codegen/box/classes/propertyInInitializer.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 class Outer() {
   val s = "xyzzy"
 

--- a/compiler/testData/codegen/box/closures/captureInSuperConstructorCall/constructorParameterAndLocalCapturedInLambdaInLocalClass.kt
+++ b/compiler/testData/codegen/box/closures/captureInSuperConstructorCall/constructorParameterAndLocalCapturedInLambdaInLocalClass.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 open class Base(val fn: () -> String)
 
 fun box(): String {

--- a/compiler/testData/codegen/box/closures/captureInSuperConstructorCall/constructorParameterCapturedInLambdaInLocalClass2.kt
+++ b/compiler/testData/codegen/box/closures/captureInSuperConstructorCall/constructorParameterCapturedInLambdaInLocalClass2.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 open class Base(val fn: () -> String)
 
 fun box(): String {

--- a/compiler/testData/codegen/box/closures/captureInSuperConstructorCall/kt13454.kt
+++ b/compiler/testData/codegen/box/closures/captureInSuperConstructorCall/kt13454.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 open class Foo(val x: () -> String)
 
 class Outer {

--- a/compiler/testData/codegen/box/closures/captureInSuperConstructorCall/kt14148.kt
+++ b/compiler/testData/codegen/box/closures/captureInSuperConstructorCall/kt14148.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 interface Test {
     fun test(): String
 }

--- a/compiler/testData/codegen/box/closures/captureInSuperConstructorCall/localCapturedInLambdaInInnerClassInLocalClass.kt
+++ b/compiler/testData/codegen/box/closures/captureInSuperConstructorCall/localCapturedInLambdaInInnerClassInLocalClass.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 open class Base(val fn: () -> String)
 
 fun box(): String {

--- a/compiler/testData/codegen/box/closures/captureInSuperConstructorCall/outerCapturedInFunctionLiteral.kt
+++ b/compiler/testData/codegen/box/closures/captureInSuperConstructorCall/outerCapturedInFunctionLiteral.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 open class Base(val callback: () -> String)
 
 class Outer {

--- a/compiler/testData/codegen/box/closures/captureInSuperConstructorCall/outerCapturedInLambda.kt
+++ b/compiler/testData/codegen/box/closures/captureInSuperConstructorCall/outerCapturedInLambda.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 open class Base(val callback: () -> String)
 
 class Outer {

--- a/compiler/testData/codegen/box/closures/captureInSuperConstructorCall/outerCapturedInLambda2.kt
+++ b/compiler/testData/codegen/box/closures/captureInSuperConstructorCall/outerCapturedInLambda2.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 open class Base(val callback: () -> String)
 
 class Outer {

--- a/compiler/testData/codegen/box/closures/captureInSuperConstructorCall/outerCapturedInLambdaInSecondaryConstructor.kt
+++ b/compiler/testData/codegen/box/closures/captureInSuperConstructorCall/outerCapturedInLambdaInSecondaryConstructor.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 open class Base(val callback: () -> String)
 
 class Outer {

--- a/compiler/testData/codegen/box/closures/captureInSuperConstructorCall/outerCapturedInLambdaInSubExpression.kt
+++ b/compiler/testData/codegen/box/closures/captureInSuperConstructorCall/outerCapturedInLambdaInSubExpression.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 open class Foo(val x: () -> String)
 open class Foo2(val foo: Foo)
 

--- a/compiler/testData/codegen/box/closures/captureInSuperConstructorCall/outerCapturedInNestedLambda.kt
+++ b/compiler/testData/codegen/box/closures/captureInSuperConstructorCall/outerCapturedInNestedLambda.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 open class Base(val callback: () -> String)
 
 class Outer {

--- a/compiler/testData/codegen/box/closures/captureInSuperConstructorCall/outerCapturedInNestedObject.kt
+++ b/compiler/testData/codegen/box/closures/captureInSuperConstructorCall/outerCapturedInNestedObject.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 interface Callback {
     fun invoke(): String
 }

--- a/compiler/testData/codegen/box/closures/captureInSuperConstructorCall/outerCapturedInObject.kt
+++ b/compiler/testData/codegen/box/closures/captureInSuperConstructorCall/outerCapturedInObject.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 interface Callback {
     fun invoke(): String
 }

--- a/compiler/testData/codegen/box/closures/captureInSuperConstructorCall/outerCapturedInObject2.kt
+++ b/compiler/testData/codegen/box/closures/captureInSuperConstructorCall/outerCapturedInObject2.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 interface Callback {
     fun invoke(): String
 }

--- a/compiler/testData/codegen/box/innerNested/innerJavaClass.kt
+++ b/compiler/testData/codegen/box/innerNested/innerJavaClass.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 // TARGET_BACKEND: JVM
 // FILE: JavaClass.java
 

--- a/compiler/testData/codegen/box/innerNested/passingOuterRef.kt
+++ b/compiler/testData/codegen/box/innerNested/passingOuterRef.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 open class A1(y: String) {
     val x = "A1.x,$y"
 }

--- a/compiler/testData/codegen/box/innerNested/superConstructorCall/deepInnerHierarchy.kt
+++ b/compiler/testData/codegen/box/innerNested/superConstructorCall/deepInnerHierarchy.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 open class A(val s: String) {
     open inner class B(s: String): A(s)
 

--- a/compiler/testData/codegen/box/innerNested/superConstructorCall/innerExtendsInnerViaSecondaryConstuctor.kt
+++ b/compiler/testData/codegen/box/innerNested/superConstructorCall/innerExtendsInnerViaSecondaryConstuctor.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 open class Father(val param: String) {
     abstract inner class InClass {
         fun work(): String {

--- a/compiler/testData/codegen/box/innerNested/superConstructorCall/innerExtendsInnerWithProperOuterCapture.kt
+++ b/compiler/testData/codegen/box/innerNested/superConstructorCall/innerExtendsInnerWithProperOuterCapture.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 open class Father(val param: String) {
     abstract inner class InClass {
         fun work(): String {

--- a/compiler/testData/codegen/box/localClasses/innerOfLocalCaptureExtensionReceiver.kt
+++ b/compiler/testData/codegen/box/localClasses/innerOfLocalCaptureExtensionReceiver.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 fun String.bar(): String {
     open class Local {
         fun result() = this@bar

--- a/compiler/testData/codegen/box/secondaryConstructors/innerClasses.kt
+++ b/compiler/testData/codegen/box/secondaryConstructors/innerClasses.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 class Outer {
     val outerProp: String
     constructor(x: String) {

--- a/compiler/testData/codegen/box/secondaryConstructors/innerClassesInheritance.kt
+++ b/compiler/testData/codegen/box/secondaryConstructors/innerClassesInheritance.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 class Outer {
     val outerProp: String
     constructor(x: String) {

--- a/compiler/testData/codegen/box/typealias/innerClassTypeAliasConstructorInSupertypes.kt
+++ b/compiler/testData/codegen/box/typealias/innerClassTypeAliasConstructorInSupertypes.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 class Outer(val x: String) {
     abstract inner class InnerBase
 


### PR DESCRIPTION
Inner class constructors should use the argument instead of reading outer `this` from a field because if such an access happens before a delegating constructor call, e.g. when evaluating an argument, a JVM
bytecode validation error will be thrown. (The only operation on `this` allowed before a delegating constructor call is SETFIELD, and only if the field in question is declared in the same class.)