### PR TITLE
KT 13962: Intention to replace Java collection constructor calls with  function calls from stdlib (ArrayList() → arrayListOf())

### DIFF
--- a/idea/resources/META-INF/plugin-common.xml
+++ b/idea/resources/META-INF/plugin-common.xml
@@ -1737,6 +1737,11 @@
       <category>Kotlin</category>
     </intentionAction>
 
+    <intentionAction>
+      <className>org.jetbrains.kotlin.idea.intentions.ConvertCollectionConstructorToFunction</className>
+      <category>Kotlin</category>
+    </intentionAction>
+
     <lang.inspectionSuppressor language="kotlin" implementationClass="org.jetbrains.kotlin.idea.inspections.KotlinInspectionSuppressor"/>
 
     <localInspection implementationClass="org.jetbrains.kotlin.idea.intentions.ObjectLiteralToLambdaInspection"

--- a/idea/resources/intentionDescriptions/ConvertCollectionConstructorToFunction/after.kt.template
+++ b/idea/resources/intentionDescriptions/ConvertCollectionConstructorToFunction/after.kt.template
@@ -1,0 +1,3 @@
+class Person(val name: String)
+
+val persons = <spot>arrayListOf()</spot>

--- a/idea/resources/intentionDescriptions/ConvertCollectionConstructorToFunction/before.kt.template
+++ b/idea/resources/intentionDescriptions/ConvertCollectionConstructorToFunction/before.kt.template
@@ -1,0 +1,3 @@
+class Person(val name: String)
+
+val persons = <spot>ArrayList()</spot>

--- a/idea/resources/intentionDescriptions/ConvertCollectionConstructorToFunction/description.html
+++ b/idea/resources/intentionDescriptions/ConvertCollectionConstructorToFunction/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This intention reports explicit calls of <b>Collection constructor</b> calls which can be replaced by function calls from the stdlib.
+</body>
+</html>

--- a/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertCollectionConstructorToFunction.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertCollectionConstructorToFunction.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.idea.intentions
+
+import com.intellij.openapi.editor.Editor
+import org.jetbrains.kotlin.idea.caches.resolve.resolveToCall
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtPsiFactory
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
+
+class ConvertCollectionConstructorToFunction : SelfTargetingIntention<KtCallExpression>(
+    KtCallExpression::class.java, "Convert Collection constructor to function"
+) {
+
+    private val functionMap = hashMapOf(
+        "java.util.ArrayList.<init>" to "arrayListOf",
+        "kotlin.collections.ArrayList.<init>" to "arrayListOf",
+        "java.util.HashMap.<init>" to "hashMapOf",
+        "kotlin.collections.HashMap.<init>" to "arrayListOf",
+        "java.util.HashSet.<init>" to "hashSetOf",
+        "kotlin.collections.HashSet.<init>" to "arrayListOf",
+        "java.util.LinkedHashMap.<init>" to "linkedMapOf",
+        "kotlin.collections.LinkedHashMap.<init>" to "arrayListOf",
+        "java.util.LinkedHashSet.<init>" to "linkedSetOf",
+        "kotlin.collections.LinkedHashSet.<init>" to "arrayListOf"
+    )
+
+    override fun isApplicableTo(element: KtCallExpression, caretOffset: Int): Boolean {
+        val fq = element.resolveToCall()?.resultingDescriptor?.fqNameSafe?.asString() ?: return false
+        return functionMap.containsKey(fq) && element.valueArguments.size == 0
+    }
+
+    override fun applyTo(element: KtCallExpression, editor: Editor?) {
+        val fq = element.resolveToCall()?.resultingDescriptor?.fqNameSafe?.asString() ?: return
+        val toCall = functionMap[fq] ?: return
+        val convertedCall = KtPsiFactory(element).createIdentifier(toCall)
+        element.calleeExpression?.replace(convertedCall)
+    }
+}

--- a/idea/testData/intentions/convertCollectionConstructorToFunction/.intention
+++ b/idea/testData/intentions/convertCollectionConstructorToFunction/.intention
@@ -1,0 +1,1 @@
+org.jetbrains.kotlin.idea.intentions.ConvertCollectionConstructorToFunction

--- a/idea/testData/intentions/convertCollectionConstructorToFunction/keepArrayListCallWithArgument.kt
+++ b/idea/testData/intentions/convertCollectionConstructorToFunction/keepArrayListCallWithArgument.kt
@@ -1,0 +1,5 @@
+// WITH_RUNTIME
+// IS_APPLICABLE: false
+fun foo() {
+    var list: ArrayList<Int> = <caret>ArrayList(3)
+}

--- a/idea/testData/intentions/convertCollectionConstructorToFunction/replaceArrayListCall.kt
+++ b/idea/testData/intentions/convertCollectionConstructorToFunction/replaceArrayListCall.kt
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun foo() {
+    var list: ArrayList<Int> = <caret>ArrayList()
+}

--- a/idea/testData/intentions/convertCollectionConstructorToFunction/replaceArrayListCall.kt.after
+++ b/idea/testData/intentions/convertCollectionConstructorToFunction/replaceArrayListCall.kt.after
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun foo() {
+    var list: ArrayList<Int> = arrayListOf()
+}

--- a/idea/testData/intentions/convertCollectionConstructorToFunction/replaceArrayListCallWithType.kt
+++ b/idea/testData/intentions/convertCollectionConstructorToFunction/replaceArrayListCallWithType.kt
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun foo() {
+    var list = <caret>ArrayList<Int>()
+}

--- a/idea/testData/intentions/convertCollectionConstructorToFunction/replaceArrayListCallWithType.kt.after
+++ b/idea/testData/intentions/convertCollectionConstructorToFunction/replaceArrayListCallWithType.kt.after
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun foo() {
+    var list = arrayListOf<Int>()
+}

--- a/idea/testData/intentions/convertCollectionConstructorToFunction/replaceHashMapCall.kt
+++ b/idea/testData/intentions/convertCollectionConstructorToFunction/replaceHashMapCall.kt
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+import java.util.HashMap
+
+fun foo() {
+    var list: HashMap<Int, Int> = <caret>HashMap()
+}

--- a/idea/testData/intentions/convertCollectionConstructorToFunction/replaceHashMapCall.kt.after
+++ b/idea/testData/intentions/convertCollectionConstructorToFunction/replaceHashMapCall.kt.after
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+import java.util.HashMap
+
+fun foo() {
+    var list: HashMap<Int, Int> = hashMapOf()
+}

--- a/idea/testData/intentions/convertCollectionConstructorToFunction/replaceHashSetCall.kt
+++ b/idea/testData/intentions/convertCollectionConstructorToFunction/replaceHashSetCall.kt
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+import java.util.HashSet
+
+fun foo() {
+    var list: HashSet<Int> = <caret>HashSet()
+}

--- a/idea/testData/intentions/convertCollectionConstructorToFunction/replaceHashSetCall.kt.after
+++ b/idea/testData/intentions/convertCollectionConstructorToFunction/replaceHashSetCall.kt.after
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+import java.util.HashSet
+
+fun foo() {
+    var list: HashSet<Int> = hashSetOf()
+}

--- a/idea/testData/intentions/convertCollectionConstructorToFunction/replaceLinkedHashSetCall.kt
+++ b/idea/testData/intentions/convertCollectionConstructorToFunction/replaceLinkedHashSetCall.kt
@@ -1,0 +1,7 @@
+// WITH_RUNTIME
+
+import java.util.LinkedHashSet
+
+fun foo() {
+    var list: LinkedHashSet<Int> = <caret>LinkedHashSet()
+}

--- a/idea/testData/intentions/convertCollectionConstructorToFunction/replaceLinkedHashSetCall.kt.after
+++ b/idea/testData/intentions/convertCollectionConstructorToFunction/replaceLinkedHashSetCall.kt.after
@@ -1,0 +1,7 @@
+// WITH_RUNTIME
+
+import java.util.LinkedHashSet
+
+fun foo() {
+    var list: LinkedHashSet<Int> = linkedSetOf()
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -4913,6 +4913,49 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
         }
     }
 
+    @TestMetadata("idea/testData/intentions/convertCollectionConstructorToFunction")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class ConvertCollectionConstructorToFunction extends AbstractIntentionTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY, testDataFilePath);
+        }
+
+        public void testAllFilesPresentInConvertCollectionConstructorToFunction() throws Exception {
+            KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/intentions/convertCollectionConstructorToFunction"), Pattern.compile("^([\\w\\-_]+)\\.(kt|kts)$"), TargetBackend.ANY, true);
+        }
+
+        @TestMetadata("keepArrayListCallWithArgument.kt")
+        public void testKeepArrayListCallWithArgument() throws Exception {
+            runTest("idea/testData/intentions/convertCollectionConstructorToFunction/keepArrayListCallWithArgument.kt");
+        }
+
+        @TestMetadata("replaceArrayListCall.kt")
+        public void testReplaceArrayListCall() throws Exception {
+            runTest("idea/testData/intentions/convertCollectionConstructorToFunction/replaceArrayListCall.kt");
+        }
+
+        @TestMetadata("replaceArrayListCallWithType.kt")
+        public void testReplaceArrayListCallWithType() throws Exception {
+            runTest("idea/testData/intentions/convertCollectionConstructorToFunction/replaceArrayListCallWithType.kt");
+        }
+
+        @TestMetadata("replaceHashMapCall.kt")
+        public void testReplaceHashMapCall() throws Exception {
+            runTest("idea/testData/intentions/convertCollectionConstructorToFunction/replaceHashMapCall.kt");
+        }
+
+        @TestMetadata("replaceHashSetCall.kt")
+        public void testReplaceHashSetCall() throws Exception {
+            runTest("idea/testData/intentions/convertCollectionConstructorToFunction/replaceHashSetCall.kt");
+        }
+
+        @TestMetadata("replaceLinkedHashSetCall.kt")
+        public void testReplaceLinkedHashSetCall() throws Exception {
+            runTest("idea/testData/intentions/convertCollectionConstructorToFunction/replaceLinkedHashSetCall.kt");
+        }
+    }
+
     @TestMetadata("idea/testData/intentions/convertEnumToSealedClass")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)


### PR DESCRIPTION
YouTrack: https://youtrack.jetbrains.com/issue/KT-13962

Example of this intention:

```
fun foo() {
    var list: ArrayList<Int> = ArrayList()
}
```

to
```
fun foo() {
    var list: ArrayList<Int> = arrayListOf()
}
```