### PR TITLE
IR: introduce builtin removal lowering phase.

### DIFF
--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/BuiltinRemovalLowering.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/BuiltinRemovalLowering.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.common.lower
+
+import org.jetbrains.kotlin.backend.common.FileLoweringPass
+import org.jetbrains.kotlin.backend.common.phaser.makeIrFilePhase
+import org.jetbrains.kotlin.backend.common.CommonBackendContext
+import org.jetbrains.kotlin.ir.declarations.IrFile
+import org.jetbrains.kotlin.ir.expressions.IrCall
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.util.functions
+import org.jetbrains.kotlin.ir.util.irCall
+import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
+import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
+
+val builtinRemovalLoweringPhase = makeIrFilePhase(
+    ::BuiltinRemovalLowering,
+    name = "BuiltinRemovalLowering",
+    description = "Replace usages of builtins with actual library method calls"
+)
+
+class BuiltinRemovalLowering(val context: CommonBackendContext) : FileLoweringPass {
+
+    override fun lower(irFile: IrFile) {
+        irFile.transformChildrenVoid(object : IrElementTransformerVoid() {
+            override fun visitCall(expression: IrCall): IrExpression {
+                expression.transformChildrenVoid(this)
+                return if (expression.symbol == context.irBuiltIns.booleanNotSymbol) {
+                    val booleanNotFunction = context.irBuiltIns.booleanClass.functions.find { it.owner.name.asString() == "not" }
+                        ?: throw AssertionError("Boolean.not function not found")
+                    irCall(expression, booleanNotFunction, dispatchReceiverAsFirstArgument = false, firstArgumentAsDispatchReceiver = true)
+                } else {
+                    expression
+                }
+            }
+        })
+    }
+}

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/JsLoweringPhases.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/JsLoweringPhases.kt
@@ -81,6 +81,12 @@ private val expectDeclarationsRemovingPhase = makeJsModulePhase(
     description = "Remove expect declaration from module fragment"
 )
 
+private val builtinRemovalLoweringPhase = makeJsModulePhase(
+    ::BuiltinRemovalLowering,
+    name = "BuiltinRemovalLowering",
+    description = "Replace usages of builtins with actual library method calls"
+)
+
 private val lateinitLoweringPhase = makeJsModulePhase(
     ::LateinitLowering,
     name = "LateinitLowering",
@@ -341,6 +347,7 @@ val jsPhases = namedIrModulePhase(
     name = "IrModuleLowering",
     description = "IR module lowering",
     lower = expectDeclarationsRemovingPhase then
+            builtinRemovalLoweringPhase then
             functionInliningPhase then
             lateinitLoweringPhase then
             tailrecLoweringPhase then

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
@@ -58,6 +58,7 @@ internal val jvmPhases = namedIrFilePhase(
     name = "IrLowering",
     description = "IR lowering",
     lower = expectDeclarationsRemovingPhase then
+            builtinRemovalLoweringPhase then
             jvmCoercionToUnitPhase then
             fileClassPhase then
             kCallableNamePropertyPhase then

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -10,8 +10,6 @@ import org.jetbrains.kotlin.backend.jvm.intrinsics.ComparisonIntrinsic
 import org.jetbrains.kotlin.backend.jvm.intrinsics.IrIntrinsicFunction
 import org.jetbrains.kotlin.backend.jvm.intrinsics.IrIntrinsicMethods
 import org.jetbrains.kotlin.backend.jvm.lower.CrIrType
-import org.jetbrains.kotlin.backend.jvm.lower.JvmBuiltinOptimizationLowering.Companion.isNegation
-import org.jetbrains.kotlin.backend.jvm.lower.JvmBuiltinOptimizationLowering.Companion.negationArgument
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.codegen.*
 import org.jetbrains.kotlin.codegen.AsmUtil.*
@@ -22,6 +20,7 @@ import org.jetbrains.kotlin.codegen.inline.ReifiedTypeInliner
 import org.jetbrains.kotlin.codegen.inline.ReifiedTypeParametersUsages
 import org.jetbrains.kotlin.codegen.inline.TypeParameterMappings
 import org.jetbrains.kotlin.codegen.intrinsics.JavaClassProperty
+import org.jetbrains.kotlin.codegen.intrinsics.Not
 import org.jetbrains.kotlin.codegen.pseudoInsns.fakeAlwaysFalseIfeq
 import org.jetbrains.kotlin.codegen.pseudoInsns.fakeAlwaysTrueIfeq
 import org.jetbrains.kotlin.codegen.pseudoInsns.fixStackAndJump
@@ -751,8 +750,8 @@ class ExpressionCodegen(
         // Instead of materializing a negated value when used for control flow, flip the branch
         // targets instead. This significantly cuts down the amount of branches and loads of
         // const_0 and const_1 in the generated java bytecode.
-        if (isNegation(condition, classCodegen.context)) {
-            condition = negationArgument(condition as IrCall)
+        if (condition is IrCall && classCodegen.context.state.intrinsics.getIntrinsic(condition.symbol.descriptor) is Not) {
+            condition = condition.dispatchReceiver!!
             jumpIfFalse = !jumpIfFalse
         }
 


### PR DESCRIPTION
The idea is to make sure that the Ir NOT builtin is not used at
all after this lowering and therefore there is only one Boolean
not definition to deal with and not two.