### PR TITLE
KT-30393 Remove unnecessary whitespaces between property accessor and its parameter list in formatter

### DIFF
--- a/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/kotlinSpacingRules.kt
+++ b/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/kotlinSpacingRules.kt
@@ -388,6 +388,9 @@ fun createSpacingBuilder(settings: CodeStyleSettings, builderUtil: KotlinSpacing
 
             before(INDICES).spaces(0)
             before(WHERE_KEYWORD).spaces(1)
+
+            afterInside(GET_KEYWORD, PROPERTY_ACCESSOR).spaces(0)
+            afterInside(SET_KEYWORD, PROPERTY_ACCESSOR).spaces(0)
         }
         custom {
 

--- a/idea/testData/formatter/GetterAndSetter.after.kt
+++ b/idea/testData/formatter/GetterAndSetter.after.kt
@@ -1,9 +1,9 @@
 class Test {
     var test: Int
-        get () {
+        get() {
             return 0
         }
-        set (value) {
+        set(value) {
             throw NotSupportedException()
         }
 }

--- a/idea/testData/formatter/PropertyAccessors.after.kt
+++ b/idea/testData/formatter/PropertyAccessors.after.kt
@@ -50,3 +50,7 @@ var prop3: Int // Int
     get() = 1
     // this comment is for setter
     set(value) {}
+
+val prop4: Int
+    get() = 42
+    set(value) {}

--- a/idea/testData/formatter/PropertyAccessors.kt
+++ b/idea/testData/formatter/PropertyAccessors.kt
@@ -53,3 +53,7 @@ var prop3: Int // Int
 get() = 1
 // this comment is for setter
 set(value) {}
+
+val prop4: Int
+    get     () = 42
+    set   (value) {}

--- a/idea/testData/formatter/SpacesInDeclarations.after.kt
+++ b/idea/testData/formatter/SpacesInDeclarations.after.kt
@@ -45,7 +45,7 @@ public var varWithAccessors1: Int
     get() {
         return 1
     }
-    set  (value: Int) { /**/
+    set(value: Int) { /**/
     }
 
 public var varWithAccessors2: Int


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-30393