### PR TITLE
KT-30341 False positive 'Use withIndex() instead of manual index increment' inspection with destructive declaration in 'for' loop

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/matchAndConvert.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/matchAndConvert.kt
@@ -379,6 +379,7 @@ data class IntroduceIndexData(
 )
 
 fun matchIndexToIntroduce(loop: KtForExpression, reformat: Boolean): IntroduceIndexData? {
+    if (loop.destructuringDeclaration != null) return null
     val (inputVariable, indexVariable) = extractLoopData(loop) ?: return null
     if (indexVariable != null) return null // loop is already with "withIndex"
 

--- a/idea/testData/intentions/useWithIndex/destructuringDeclaration.kt
+++ b/idea/testData/intentions/useWithIndex/destructuringDeclaration.kt
@@ -1,0 +1,8 @@
+// WITH_RUNTIME
+// IS_APPLICABLE: false
+fun foo(list: List<Pair<String, String>>) {
+    var index = 0
+    <caret>for ((s1, s2) in list) {
+        index++
+    }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -17538,6 +17538,11 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
             runTest("idea/testData/intentions/useWithIndex/customTypeWithIterator.kt");
         }
 
+        @TestMetadata("destructuringDeclaration.kt")
+        public void testDestructuringDeclaration() throws Exception {
+            runTest("idea/testData/intentions/useWithIndex/destructuringDeclaration.kt");
+        }
+
         @TestMetadata("indexIncrementTwice.kt")
         public void testIndexIncrementTwice() throws Exception {
             runTest("idea/testData/intentions/useWithIndex/indexIncrementTwice.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-30341