### PR TITLE
Allow tests to be run in parallel.

### DIFF
--- a/compiler/build.gradle.kts
+++ b/compiler/build.gradle.kts
@@ -3,6 +3,10 @@ import org.gradle.api.tasks.bundling.Jar
 import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompile
 
+tasks.withType<Test> {
+    maxParallelForks = Math.max(Runtime.getRuntime().availableProcessors() / 2, 1)
+}
+
 plugins {
     kotlin("jvm")
     id("jps-compatible")

--- a/compiler/tests-common/tests/org/jetbrains/kotlin/checkers/AbstractForeignAnnotationsNoAnnotationInClasspathTest.kt
+++ b/compiler/tests-common/tests/org/jetbrains/kotlin/checkers/AbstractForeignAnnotationsNoAnnotationInClasspathTest.kt
@@ -22,7 +22,11 @@ import org.jetbrains.kotlin.test.KotlinTestUtils
 import java.io.File
 
 abstract class AbstractForeignAnnotationsNoAnnotationInClasspathTest : AbstractForeignAnnotationsTest() {
-    private val compiledJavaPath = KotlinTestUtils.tmpDir("java-compiled-files")
+    // This should be executed after setUp runs, since setUp changes the root folder
+    // for temporary files.
+    private val compiledJavaPath by lazy {
+        KotlinTestUtils.tmpDir("java-compiled-files")
+    }
 
     override fun getExtraClasspath(): List<File> {
         val foreignAnnotations = createJarWithForeignAnnotations()

--- a/compiler/tests-common/tests/org/jetbrains/kotlin/checkers/KotlinMultiFileTestWithJava.java
+++ b/compiler/tests-common/tests/org/jetbrains/kotlin/checkers/KotlinMultiFileTestWithJava.java
@@ -43,13 +43,6 @@ public abstract class KotlinMultiFileTestWithJava<M, F> extends KtUsefulTestCase
         coroutinesPackage = "";
     }
 
-    @Override
-    protected void tearDown() throws Exception {
-        if (javaFilesDir != null) FileUtil.delete(javaFilesDir);
-        if (kotlinSourceRoot != null) FileUtil.delete(kotlinSourceRoot);
-        super.tearDown();
-    }
-
     public class ModuleAndDependencies {
         final M module;
         final List<String> dependencies;

--- a/compiler/tests-common/tests/org/jetbrains/kotlin/test/KotlinTestUtils.java
+++ b/compiler/tests-common/tests/org/jetbrains/kotlin/test/KotlinTestUtils.java
@@ -413,9 +413,7 @@ public class KotlinTestUtils {
 
     @NotNull
     public static File tmpDirForTest(@NotNull String testClassName, @NotNull String testName) throws IOException {
-        File answer = normalizeFile(FileUtil.createTempDirectory(testClassName, testName));
-        deleteOnShutdown(answer);
-        return answer;
+        return normalizeFile(FileUtil.createTempDirectory(testClassName, testName, false));
     }
 
     @NotNull
@@ -425,10 +423,7 @@ public class KotlinTestUtils {
 
     @NotNull
     public static File tmpDir(String name) throws IOException {
-        // We should use this form. otherwise directory will be deleted on each test.
-        File answer = normalizeFile(FileUtil.createTempDirectory(new File(System.getProperty("java.io.tmpdir")), name, ""));
-        deleteOnShutdown(answer);
-        return answer;
+        return normalizeFile(FileUtil.createTempDirectory(name, "", false));
     }
 
     private static File normalizeFile(File file) throws IOException {
@@ -436,18 +431,6 @@ public class KotlinTestUtils {
         // for example, on Windows, if a canonical path contains any space from FileUtil.createTempDirectory we will get
         // a File with short names (8.3) in its path and it will break some normalization passes in tests.
         return file.getCanonicalFile();
-    }
-
-    private static void deleteOnShutdown(File file) {
-        if (filesToDelete.isEmpty()) {
-            ShutDownTracker.getInstance().registerShutdownTask(() -> {
-                for (File victim : filesToDelete) {
-                    FileUtil.delete(victim);
-                }
-            });
-        }
-
-        filesToDelete.add(file);
     }
 
     @NotNull

--- a/compiler/tests-common/tests/org/jetbrains/kotlin/test/testFramework/KtUsefulTestCase.java
+++ b/compiler/tests-common/tests/org/jetbrains/kotlin/test/testFramework/KtUsefulTestCase.java
@@ -76,7 +76,7 @@ public abstract class KtUsefulTestCase extends TestCase {
     private static final String ourPathToKeep = null;
     private final List<String> myPathsToKeep = new ArrayList<>();
 
-    private String myTempDir;
+    private File myTempDir;
 
     static {
         // Radar #5755208: Command line Java applications need a way to launch without a Dock icon.
@@ -100,8 +100,8 @@ public abstract class KtUsefulTestCase extends TestCase {
         String testName =  FileUtil.sanitizeFileName(getTestName(true));
         if (StringUtil.isEmptyOrSpaces(testName)) testName = "";
         testName = new File(testName).getName(); // in case the test name contains file separators
-        myTempDir = new File(ORIGINAL_TEMP_DIR, TEMP_DIR_MARKER + testName).getPath();
-        FileUtil.resetCanonicalTempPathCache(myTempDir);
+        myTempDir = FileUtil.createTempDirectory(TEMP_DIR_MARKER, testName, false);
+        FileUtil.resetCanonicalTempPathCache(myTempDir.getPath());
         boolean isStressTest = isStressTest();
         ApplicationInfoImpl.setInStressTest(isStressTest);
         // turn off Disposer debugging for performance tests
@@ -119,7 +119,7 @@ public abstract class KtUsefulTestCase extends TestCase {
             Disposer.setDebugMode(oldDisposerDebug);
             FileUtil.resetCanonicalTempPathCache(ORIGINAL_TEMP_DIR);
             if (hasTmpFilesToKeep()) {
-                File[] files = new File(myTempDir).listFiles();
+                File[] files = myTempDir.listFiles();
                 if (files != null) {
                     for (File file : files) {
                         if (!shouldKeepTmpFile(file)) {
@@ -127,9 +127,8 @@ public abstract class KtUsefulTestCase extends TestCase {
                         }
                     }
                 }
-            }
-            else {
-                FileUtil.delete(new File(myTempDir));
+            } else {
+                FileUtil.delete(myTempDir);
             }
         }
 

--- a/compiler/tests/org/jetbrains/kotlin/daemon/CompilerDaemonTest.kt
+++ b/compiler/tests/org/jetbrains/kotlin/daemon/CompilerDaemonTest.kt
@@ -16,6 +16,7 @@
 
 package org.jetbrains.kotlin.daemon
 
+import com.intellij.openapi.util.io.FileUtil
 import junit.framework.TestCase
 import org.jetbrains.kotlin.cli.AbstractCliTest
 import org.jetbrains.kotlin.cli.common.messages.MessageRenderer
@@ -357,8 +358,8 @@ class CompilerDaemonTest : KotlinIntegrationTestBase() {
 
     fun testDaemonExitsOnClientFlagDeletedWithActiveSessions() {
         val daemonOptions = DaemonOptions(autoshutdownIdleSeconds = 1000, shutdownDelayMilliseconds = 1, runFilesPath = File(tmpdir, getTestName(true)).absolutePath)
-        val clientFlag = createTempFile(getTestName(true), "-client.alive")
-        val sessionFlag = createTempFile(getTestName(true), "-session.alive")
+        val clientFlag = FileUtil.createTempFile(getTestName(true), "-client.alive")
+        val sessionFlag = FileUtil.createTempFile(getTestName(true), "-session.alive")
         try {
             withLogFile("kotlin-daemon-test") { logFile ->
                 val daemonJVMOptions = makeTestDaemonJvmOptions(logFile)
@@ -383,8 +384,8 @@ class CompilerDaemonTest : KotlinIntegrationTestBase() {
 
     fun testDaemonExitsOnClientFlagDeletedWithAllSessionsReleased() {
         val daemonOptions = DaemonOptions(autoshutdownIdleSeconds = 1000, shutdownDelayMilliseconds = 1, runFilesPath = File(tmpdir, getTestName(true)).absolutePath)
-        val clientFlag = createTempFile(getTestName(true), "-client.alive")
-        val sessionFlag = createTempFile(getTestName(true), "-session.alive")
+        val clientFlag = FileUtil.createTempFile(getTestName(true), "-client.alive")
+        val sessionFlag = FileUtil.createTempFile(getTestName(true), "-session.alive")
         try {
             withLogFile("kotlin-daemon-test") { logFile ->
                 val daemonJVMOptions = makeTestDaemonJvmOptions(logFile)
@@ -412,8 +413,8 @@ class CompilerDaemonTest : KotlinIntegrationTestBase() {
 
     fun testDaemonCancelShutdownOnANewClient() {
         val daemonOptions = DaemonOptions(autoshutdownIdleSeconds = 1000, shutdownDelayMilliseconds = 3000, runFilesPath = File(tmpdir, getTestName(true)).absolutePath)
-        val clientFlag = createTempFile(getTestName(true), "-client.alive")
-        val clientFlag2 = createTempFile(getTestName(true), "-client.alive")
+        val clientFlag = FileUtil.createTempFile(getTestName(true), "-client.alive")
+        val clientFlag2 = FileUtil.createTempFile(getTestName(true), "-client.alive")
         try {
             withLogFile("kotlin-daemon-test") { logFile ->
                 val daemonJVMOptions = makeTestDaemonJvmOptions(logFile)
@@ -454,7 +455,7 @@ class CompilerDaemonTest : KotlinIntegrationTestBase() {
      *  (the same solution is used in kotlin daemon client - see next commit)
      */
     fun testDaemonExecutionViaIntermediateProcess() {
-        val clientAliveFile = createTempFile("kotlin-daemon-transitive-run-test", ".run")
+        val clientAliveFile = FileUtil.createTempFile("kotlin-daemon-transitive-run-test", ".run")
         val daemonOptions = makeTestDaemonOptions(getTestName(true))
         val jar = tmpdir.absolutePath + File.separator + "hello.jar"
         val args = listOf(
@@ -911,7 +912,7 @@ fun restoreSystemProperty(propertyName: String, backupValue: String?) {
 }
 
 internal inline fun withFlagFile(prefix: String, suffix: String? = null, body: (File) -> Unit) {
-    val file = createTempFile(prefix, suffix)
+    val file = FileUtil.createTempFile(prefix, suffix)
     try {
         body(file)
     }
@@ -921,7 +922,7 @@ internal inline fun withFlagFile(prefix: String, suffix: String? = null, body: (
 }
 
 internal inline fun withLogFile(prefix: String, suffix: String = ".log", printLogOnException: Boolean = true, body: (File) -> Unit) {
-    val logFile = createTempFile(prefix, suffix)
+    val logFile = FileUtil.createTempFile(prefix, suffix)
     try {
         body(logFile)
     }

--- a/js/js.tests/build.gradle.kts
+++ b/js/js.tests/build.gradle.kts
@@ -2,6 +2,10 @@ import com.moowork.gradle.node.NodeExtension
 import com.moowork.gradle.node.npm.NpmTask
 import org.gradle.internal.os.OperatingSystem
 
+tasks.withType<Test> {
+    maxParallelForks = Math.max(Runtime.getRuntime().availableProcessors() / 2, 1)
+}
+
 plugins {
     kotlin("jvm")
     id("jps-compatible")

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/interop/ScriptEngineV8.kt
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/interop/ScriptEngineV8.kt
@@ -9,9 +9,20 @@ import com.eclipsesource.v8.V8
 import com.eclipsesource.v8.V8Array
 import com.eclipsesource.v8.V8Object
 import com.eclipsesource.v8.utils.V8ObjectUtils
+import com.intellij.openapi.util.io.FileUtil
 import java.io.File
 
 class ScriptEngineV8 : ScriptEngine {
+    companion object {
+        // It's important that this is not created per test, but rather per process.
+        val LIBRARY_PATH_BASE = FileUtil.createTempDirectory(
+            File(System.getProperty("java.io.tmpdir")),
+            "j2v8_library_path",
+            "",
+            true
+        ).path
+    }
+
     override fun <T> releaseObject(t: T) {
         (t as? V8Object)?.release()
     }
@@ -22,7 +33,7 @@ class ScriptEngineV8 : ScriptEngine {
         return context.also { v8result.release() }
     }
 
-    private val myRuntime: V8 = V8.createV8Runtime("global")
+    private val myRuntime: V8 = V8.createV8Runtime("global", LIBRARY_PATH_BASE)
 
     @Suppress("UNCHECKED_CAST")
     override fun <T> eval(script: String): T {


### PR DESCRIPTION
Parallel tests are currently broken for two reasons.

- Tests sometimes use the same root for temporary directories (e.g., /tmp/unitTest_simple), which is deleted once one of the tests finishes.
- There are several places in the code which delete temporary directories. The root temporary directory for a test is always deleted in the `shutDown` method. Other temporary directories are deleted by the `com.intellij.openapi.util.io.FileUtil` class when the test runner shuts down. Some of these temporary directories are also redundantly handled by the `com.intellij.openapi.util.ShutDownTracker` class. The latter two cause problems when running tests in parallel since they may attempt to delete files which are still in use.

This PR fixes these problems by consolidating all temporary files for a test under the root temporary directory for this test and deleting this directory once in the `shutDown` method.