### PR TITLE
KT 14344: Suggest to replace manual range with explicit `indices` call

### DIFF
--- a/idea/resources/META-INF/plugin-common.xml
+++ b/idea/resources/META-INF/plugin-common.xml
@@ -1817,6 +1817,15 @@
                      language="kotlin"
     />
 
+    <localInspection implementationClass="org.jetbrains.kotlin.idea.inspections.ReplaceManualRangeWithIndicesCallsInspection"
+                     displayName="Convert manual ranges to Collection.indices calls"
+                     groupPath="Kotlin"
+                     groupName="Style issues"
+                     enabledByDefault="true"
+                     level="INFO"
+                     language="kotlin"
+    />
+
     <localInspection implementationClass="org.jetbrains.kotlin.idea.intentions.branchedTransformations.intentions.IfThenToElvisInspection"
                      displayName="If-Then foldable to '?:'"
                      groupPath="Kotlin"

--- a/idea/resources/inspectionDescriptions/ReplaceManualRangeWithIndicesCallsInspection.html
+++ b/idea/resources/inspectionDescriptions/ReplaceManualRangeWithIndicesCallsInspection.html
@@ -1,0 +1,4 @@
+<html>
+<body>
+This inspection reports <b>until</b> and <b>..</b> operator usages that are replaceable with <b>Collection.indices</b>.</body>
+</html>

--- a/idea/src/org/jetbrains/kotlin/idea/inspections/ReplaceManualRangeWithIndicesCallsInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/ReplaceManualRangeWithIndicesCallsInspection.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.idea.inspections
+
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.search.searches.ReferencesSearch
+import org.jetbrains.kotlin.idea.intentions.getArguments
+import org.jetbrains.kotlin.idea.intentions.isSizeOrLength
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.*
+
+class ReplaceManualRangeWithIndicesCallsInspection : AbstractKotlinInspection() {
+    val rangeFunctions = setOf("until", "rangeTo")
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) = object : KtVisitorVoid() {
+        override fun visitBinaryExpression(binaryExpression: KtBinaryExpression) {
+            val find = rangeFunctions.find { it == binaryExpression.operationReference.text }
+            if (binaryExpression.operationToken == KtTokens.RANGE || find != null) {
+                val operator = find ?: "rangeTo"
+                visitRange(holder, binaryExpression, binaryExpression.left ?: return, binaryExpression.right ?: return, operator)
+            }
+        }
+
+        override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
+            val find = rangeFunctions.find { it == expression.selectorExpression?.text }
+            if (find != null) {
+                val call = (expression.parent as? KtCallExpression) ?: return
+                val firstArg = call.valueArguments.first().getArgumentExpression() ?: return
+                visitRange(holder, expression, expression.receiverExpression, firstArg, find)
+            }
+        }
+    }
+
+    private fun visitRange(holder: ProblemsHolder, expression: KtExpression, left: KtExpression, right: KtExpression, method: String) {
+        if ((method == "until" && left.toIntConstant() == 0 && right.receiverIfIsSizeOrLengthCall() != null) ||
+            (method == "rangeTo" && left.toIntConstant() == 0 && right.receiverIfIsSizeOrLengthMinusOneCall() != null)) {
+            visitIndicesRange(holder, expression)
+        }
+    }
+
+    private fun visitIndicesRange(holder: ProblemsHolder, range: KtExpression) {
+        val parent = range.parent.parent
+        if (parent is KtForExpression) {
+            val paramElement = parent.loopParameter?.originalElement ?: return
+            val usage = ReferencesSearch.search(paramElement).singleOrNull() ?: return
+            if (usage.element.isIndexInGetter()) {
+                holder.registerProblem(
+                    parent,
+                    "For loop over indices should be replaced with loop over elements",
+                    ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
+                    ReplaceIndexLoopWithCollectionLoopQuickFix()
+                )
+            }
+        } else {
+            holder.registerProblem(
+                range,
+                "Range should be replaced with '.indices' call",
+                ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
+                ReplaceManualRangeWithIndicesCallQuickFix()
+            )
+        }
+    }
+}
+
+class ReplaceManualRangeWithIndicesCallQuickFix : LocalQuickFix {
+    override fun getName() = "Replace with indices"
+
+    override fun getFamilyName() = name
+
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        val element = descriptor.psiElement as KtExpression
+        val args = element.getArguments() ?: return
+        if (args.second is KtBinaryExpression) {
+            val second = (args.second as? KtBinaryExpression) ?: return
+            replaceWithIndices(element, (second.left as? KtDotQualifiedExpression)?.receiverExpression ?: return)
+        } else {
+            replaceWithIndices(element, (args.second as? KtDotQualifiedExpression)?.receiverExpression ?: return)
+        }
+    }
+
+    private fun replaceWithIndices(toReplace: KtExpression, receiver: KtExpression) {
+        toReplace.replace(KtPsiFactory(toReplace).createExpressionByPattern("$0.indices", receiver))
+    }
+}
+
+class ReplaceIndexLoopWithCollectionLoopQuickFix : LocalQuickFix {
+    override fun getName() = "Replace with loop over elements"
+
+    override fun getFamilyName() = name
+
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        val element = descriptor.psiElement as? KtForExpression ?: return
+        val loopParam = element.loopParameter ?: return
+        val loopRange = element.loopRange ?: return
+        val collectionParent = when (loopRange) {
+            is KtDotQualifiedExpression -> (loopRange.parent as? KtCallExpression)?.valueArguments?.firstOrNull()?.getArgumentExpression()
+            is KtBinaryExpression -> loopRange.right
+            else -> null
+        } ?: return
+        val collection = collectionParent.receiverIfIsSizeOrLengthCall() ?: collectionParent.receiverIfIsSizeOrLengthMinusOneCall() ?: return
+        val paramElement = loopParam.originalElement ?: return
+        val usage = ReferencesSearch.search(paramElement).singleOrNull() ?: return
+        val identifier = KtPsiFactory(project).createIdentifier("element")
+        usage.element.parent.parent.replace(identifier)
+        loopParam.replace(identifier)
+        loopRange.replace(collection)
+    }
+}
+
+private fun PsiElement.isIndexInGetter(): Boolean {
+    val parent = this.parent.parent
+    return parent is KtArrayAccessExpression && parent.indexExpressions.singleOrNull() == this
+}
+
+private fun KtExpression.toIntConstant(): Int? {
+    return (this as? KtConstantExpression)?.text?.toIntOrNull()
+}
+
+fun KtExpression.receiverIfIsSizeOrLengthCall(): KtExpression? {
+    if (this.isSizeOrLength()) {
+        return (this as? KtDotQualifiedExpression)?.receiverExpression ?: return null
+    }
+    return null
+}
+
+fun KtExpression.receiverIfIsSizeOrLengthMinusOneCall(): KtExpression? {
+    if (this !is KtBinaryExpression) return null
+    if (this.operationToken != KtTokens.MINUS) return null
+    val collection = this.left?.receiverIfIsSizeOrLengthCall() ?: return null
+    val constant = this.right?.toIntConstant() ?: return null
+    if (constant == 1) return collection
+    return null
+}

--- a/idea/testData/inspectionsLocal/replaceManualRangeWithIndicesCallsInspection/.inspection
+++ b/idea/testData/inspectionsLocal/replaceManualRangeWithIndicesCallsInspection/.inspection
@@ -1,0 +1,1 @@
+org.jetbrains.kotlin.idea.inspections.ReplaceManualRangeWithIndicesCallsInspection

--- a/idea/testData/inspectionsLocal/replaceManualRangeWithIndicesCallsInspection/forNotTarget.kt
+++ b/idea/testData/inspectionsLocal/replaceManualRangeWithIndicesCallsInspection/forNotTarget.kt
@@ -1,0 +1,8 @@
+// WITH_RUNTIME
+// PROBLEM: none
+fun test(args: Array<String>) {
+    val x = arrayOf<String>()
+    for (index in args) {
+        val out = x[index]
+    }
+}

--- a/idea/testData/inspectionsLocal/replaceManualRangeWithIndicesCallsInspection/simpleExpression.kt
+++ b/idea/testData/inspectionsLocal/replaceManualRangeWithIndicesCallsInspection/simpleExpression.kt
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test(args: Array<String>) {
+    val ind = 0..<caret>args.size-1
+}

--- a/idea/testData/inspectionsLocal/replaceManualRangeWithIndicesCallsInspection/simpleExpression.kt.after
+++ b/idea/testData/inspectionsLocal/replaceManualRangeWithIndicesCallsInspection/simpleExpression.kt.after
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test(args: Array<String>) {
+    val ind = args.indices
+}

--- a/idea/testData/inspectionsLocal/replaceManualRangeWithIndicesCallsInspection/simpleExpressionUntil.kt
+++ b/idea/testData/inspectionsLocal/replaceManualRangeWithIndicesCallsInspection/simpleExpressionUntil.kt
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test(args: Array<String>) {
+    val ind = 0 <caret>until args.size
+}

--- a/idea/testData/inspectionsLocal/replaceManualRangeWithIndicesCallsInspection/simpleExpressionUntil.kt.after
+++ b/idea/testData/inspectionsLocal/replaceManualRangeWithIndicesCallsInspection/simpleExpressionUntil.kt.after
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test(args: Array<String>) {
+    val ind = args.indices
+}

--- a/idea/testData/inspectionsLocal/replaceManualRangeWithIndicesCallsInspection/simpleFor.kt
+++ b/idea/testData/inspectionsLocal/replaceManualRangeWithIndicesCallsInspection/simpleFor.kt
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+fun test(args: Array<String>) {
+    for (index in 0..<caret>args.size-1) {
+        val out = args[index]
+    }
+}

--- a/idea/testData/inspectionsLocal/replaceManualRangeWithIndicesCallsInspection/simpleFor.kt.after
+++ b/idea/testData/inspectionsLocal/replaceManualRangeWithIndicesCallsInspection/simpleFor.kt.after
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+fun test(args: Array<String>) {
+    for (element in args) {
+        val out = element
+    }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -7579,6 +7579,39 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
         }
     }
 
+    @TestMetadata("idea/testData/inspectionsLocal/replaceManualRangeWithIndicesCallsInspection")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class ReplaceManualRangeWithIndicesCallsInspection extends AbstractLocalInspectionTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY, testDataFilePath);
+        }
+
+        public void testAllFilesPresentInReplaceManualRangeWithIndicesCallsInspection() throws Exception {
+            KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/inspectionsLocal/replaceManualRangeWithIndicesCallsInspection"), Pattern.compile("^([\\w\\-_]+)\\.(kt|kts)$"), TargetBackend.ANY, true);
+        }
+
+        @TestMetadata("forNotTarget.kt")
+        public void testForNotTarget() throws Exception {
+            runTest("idea/testData/inspectionsLocal/replaceManualRangeWithIndicesCallsInspection/forNotTarget.kt");
+        }
+
+        @TestMetadata("simpleExpression.kt")
+        public void testSimpleExpression() throws Exception {
+            runTest("idea/testData/inspectionsLocal/replaceManualRangeWithIndicesCallsInspection/simpleExpression.kt");
+        }
+
+        @TestMetadata("simpleExpressionUntil.kt")
+        public void testSimpleExpressionUntil() throws Exception {
+            runTest("idea/testData/inspectionsLocal/replaceManualRangeWithIndicesCallsInspection/simpleExpressionUntil.kt");
+        }
+
+        @TestMetadata("simpleFor.kt")
+        public void testSimpleFor() throws Exception {
+            runTest("idea/testData/inspectionsLocal/replaceManualRangeWithIndicesCallsInspection/simpleFor.kt");
+        }
+    }
+
     @TestMetadata("idea/testData/inspectionsLocal/replaceNegatedIsEmptyWithIsNotEmpty")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)


### PR DESCRIPTION
YouTrack: https://youtrack.jetbrains.com/issue/KT-14344

Adds inspection that suggests `0 .. collection.size-1` and `0 until collection.size` → `collection.indices`.