### PR TITLE
KT-22880: Add 'convert to object' inspection

### DIFF
--- a/idea/resources/META-INF/plugin-common.xml
+++ b/idea/resources/META-INF/plugin-common.xml
@@ -1793,6 +1793,15 @@
                      language="kotlin"
     />
 
+    <localInspection implementationClass="org.jetbrains.kotlin.idea.inspections.ConvertToObjectDeclarationInspection"
+                     displayName="Class containing only a companion object can be converted to object declaration"
+                     groupPath="Kotlin"
+                     groupName="Style issues"
+                     enabledByDefault="true"
+                     level="INFO"
+                     language="kotlin"
+    />
+
     <localInspection implementationClass="org.jetbrains.kotlin.idea.inspections.conventionNameCalls.ReplaceGetOrSetInspection"
                      displayName="Explicit 'get' or 'set' call"
                      groupPath="Kotlin"

--- a/idea/resources/inspectionDescriptions/ConvertToObjectDeclaration.html
+++ b/idea/resources/inspectionDescriptions/ConvertToObjectDeclaration.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This inspection reports classes containing only companion objects.
+</body>
+</html>

--- a/idea/src/org/jetbrains/kotlin/idea/inspections/ConvertToObjectDeclarationInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/ConvertToObjectDeclarationInspection.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.idea.inspections
+
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.PsiReference
+import com.intellij.psi.search.searches.ReferencesSearch
+import com.intellij.util.containers.MultiMap
+import org.jetbrains.kotlin.descriptors.ClassDescriptor
+import org.jetbrains.kotlin.idea.caches.resolve.analyze
+import org.jetbrains.kotlin.idea.caches.resolve.resolveToDescriptorIfAny
+import org.jetbrains.kotlin.idea.refactoring.checkConflictsInteractively
+import org.jetbrains.kotlin.idea.refactoring.safeDelete.canDeleteElement
+import org.jetbrains.kotlin.idea.util.ImportInsertHelper
+import org.jetbrains.kotlin.idea.util.application.executeWriteCommand
+import org.jetbrains.kotlin.idea.util.getResolutionScope
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.psiUtil.endOffset
+import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
+import org.jetbrains.kotlin.psi.psiUtil.startOffset
+import org.jetbrains.kotlin.psi.synthetics.findClassDescriptor
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
+import org.jetbrains.kotlin.resolve.descriptorUtil.getSuperClassNotAny
+import org.jetbrains.kotlin.resolve.descriptorUtil.getSuperInterfaces
+import org.jetbrains.kotlin.resolve.scopes.DescriptorKindFilter
+import org.jetbrains.kotlin.resolve.scopes.utils.collectDescriptorsFiltered
+
+class ConvertToObjectDeclarationInspection : AbstractKotlinInspection() {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        return classVisitor(fun(clazz: KtClass) {
+            if (clazz.isInner() || clazz.isLocal) return
+            val declarations = clazz.declarations
+            val objDecl = declarations.singleOrNull { it is KtObjectDeclaration } as? KtObjectDeclaration ?: return
+            if (!objDecl.isCompanion()) return
+
+            if (clazz.hasClassUsage()) return
+            if (clazz.primaryConstructor?.hasUsage() == true) return
+            if (declarations.filter { it !is KtObjectDeclaration }.any { it.hasUsage() }) return
+
+            val descriptor = clazz.findClassDescriptor(clazz.analyze())
+            if (descriptor.getSuperClassNotAny() != null || descriptor.getSuperInterfaces().isNotEmpty()) return
+
+            val endRange = clazz.nameIdentifier?.endOffset ?: clazz.getDeclarationKeyword()?.endOffset ?: clazz.endOffset
+            holder.registerProblem(
+                clazz,
+                TextRange(0, endRange - clazz.startOffset),
+                "Can be converted to object declaration",
+                ConvertToObjectDeclarationFix()
+            )
+        })
+    }
+
+    private fun KtClass.hasClassUsage(): Boolean {
+        return ReferencesSearch.search(this).any { ref ->
+            val element = ref.element
+            if (element is KtSimpleNameExpression && element.parent is KtCallExpression) return true
+            val possibleImport = ref.element.getParentOfType<KtImportDirective>(false)
+            if (possibleImport != null && possibleImport.importPath?.fqName == this.fqName) return true
+            if (element.getParentOfType<KtTypeAlias>(false) != null) return true
+            return false
+        }
+    }
+
+    private fun KtDeclaration.hasUsage(): Boolean {
+        val psi = this.originalElement ?: return false
+        return ReferencesSearch.search(psi).any()
+    }
+
+    private class ConvertToObjectDeclarationFix : LocalQuickFix {
+        override fun getFamilyName() = "Convert to object declaration"
+
+        override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+            val clazz = descriptor.psiElement as? KtClass ?: return
+            val clazzDescriptor = clazz.resolveToDescriptorIfAny() ?: return
+            val obj = clazz.declarations.singleOrNull { it is KtObjectDeclaration } as? KtObjectDeclaration ?: return
+            val objName = clazz.name ?: return
+            val currentCompanionReferences = ReferencesSearch.search(obj).toList()
+
+            val conflicts = findConflicts(currentCompanionReferences, clazz.nameAsSafeName, clazzDescriptor)
+            project.checkConflictsInteractively(conflicts) {
+                project.executeWriteCommand(name) {
+                    clazz.declarations.forEach { declaration ->
+                        if (declaration.canDeleteElement() && declaration != obj) declaration.delete()
+                    }
+                    removeCompanionReference(objName, clazzDescriptor, currentCompanionReferences)
+                    obj.setName(objName)
+                    obj.removeModifier(KtTokens.COMPANION_KEYWORD)
+                    clazz.replace(obj)
+                }
+            }
+        }
+
+        private fun findConflicts(
+            references: List<PsiReference>,
+            conflictingName: Name,
+            ignoreDescriptor: ClassDescriptor
+        ): MultiMap<PsiElement, String> {
+            return MultiMap.create<PsiElement, String>().also { conflicts ->
+                for (ref in references) {
+                    val element = ref.element
+                    if (element is KtElement) {
+                        val scope = element.getResolutionScope(element.analyze())
+                        if (scope == null) {
+                            conflicts.putValue(element, "Can't replace reference: " + StringUtil.htmlEmphasize(element.text))
+                            continue
+                        }
+                        val descriptorsByName = scope.collectDescriptorsFiltered(DescriptorKindFilter.ALL, { it == conflictingName })
+                        if (descriptorsByName.any { it != ignoreDescriptor }) {
+                            conflicts.putValue(element, "${element.name} already exists")
+                            continue
+                        }
+                    } else {
+                        conflicts.putValue(element, "Unrecognized reference will be skipped: " + StringUtil.htmlEmphasize(element.text))
+                    }
+                }
+            }
+        }
+
+        private fun removeCompanionReference(objName: String, descriptor: ClassDescriptor, references: Collection<PsiReference>) {
+            references.forEach { ref ->
+                val element = ref.element as? KtElement ?: return@forEach
+                val parent = element.parent
+                if (parent is KtDotQualifiedExpression && parent.selectorExpression == element) {
+                    parent.replace(parent.receiverExpression)
+                } else {
+                    ImportInsertHelper.getInstance(ref.element.project).importDescriptor(element.containingKtFile, descriptor)
+                    element.containingKtFile.importList?.imports?.find { it.importedFqName == descriptor.fqNameSafe }?.delete()
+                    element.replace(KtPsiFactory(element).createNameIdentifier(objName))
+                }
+            }
+        }
+    }
+}

--- a/idea/testData/inspectionsLocal/convertToObjectDeclaration/.inspection
+++ b/idea/testData/inspectionsLocal/convertToObjectDeclaration/.inspection
@@ -1,0 +1,1 @@
+org.jetbrains.kotlin.idea.inspections.ConvertToObjectDeclarationInspection

--- a/idea/testData/inspectionsLocal/convertToObjectDeclaration/abortOnAlias.kt
+++ b/idea/testData/inspectionsLocal/convertToObjectDeclaration/abortOnAlias.kt
@@ -1,0 +1,13 @@
+// PROBLEM: none
+
+import A as T
+
+class <caret>A(val i: Int) {
+    companion object {
+        const val B = 1
+    }
+}
+
+fun test() {
+    val t = T(42)
+}

--- a/idea/testData/inspectionsLocal/convertToObjectDeclaration/abortOnSecondaryConstructorUsage.kt
+++ b/idea/testData/inspectionsLocal/convertToObjectDeclaration/abortOnSecondaryConstructorUsage.kt
@@ -1,0 +1,13 @@
+// PROBLEM: none
+
+class <caret>A(val i: Int) {
+    constructor(): this(42)
+
+    companion object {
+        const val B = 1
+    }
+}
+
+fun main() {
+    val test = A()
+}

--- a/idea/testData/inspectionsLocal/convertToObjectDeclaration/abortOnTypeAlias.kt
+++ b/idea/testData/inspectionsLocal/convertToObjectDeclaration/abortOnTypeAlias.kt
@@ -1,0 +1,13 @@
+// PROBLEM: none
+
+typealias T = A
+
+class <caret>A(val i: Int) {
+    companion object {
+        const val B = 1
+    }
+}
+
+fun test() {
+    val t = T(42)
+}

--- a/idea/testData/inspectionsLocal/convertToObjectDeclaration/accompanyingDeclarations.kt
+++ b/idea/testData/inspectionsLocal/convertToObjectDeclaration/accompanyingDeclarations.kt
@@ -1,0 +1,11 @@
+// PROBLEM: none
+class <caret>A {
+    companion object {
+        const val name = "A"
+    }
+    val test = "B"
+}
+
+fun main(incoming: A) {
+    val out = incoming.test
+}

--- a/idea/testData/inspectionsLocal/convertToObjectDeclaration/existingSuper.kt
+++ b/idea/testData/inspectionsLocal/convertToObjectDeclaration/existingSuper.kt
@@ -1,0 +1,10 @@
+// PROBLEM: none
+
+open class A {}
+open class B {}
+
+class <caret>Test : A() {
+    companion object : B() {
+
+    }
+}

--- a/idea/testData/inspectionsLocal/convertToObjectDeclaration/hasConstructorUsages.kt
+++ b/idea/testData/inspectionsLocal/convertToObjectDeclaration/hasConstructorUsages.kt
@@ -1,0 +1,12 @@
+// PROBLEM: none
+
+class <caret>A {
+    companion object {
+        fun check() {}
+    }
+}
+
+fun test() {
+    val a = A()
+    A.check()
+}

--- a/idea/testData/inspectionsLocal/convertToObjectDeclaration/inheritance.kt
+++ b/idea/testData/inspectionsLocal/convertToObjectDeclaration/inheritance.kt
@@ -1,0 +1,16 @@
+// FIX: Convert to object declaration
+
+open class A {
+    open fun test() = "test"
+}
+
+interface TestInterface {
+    fun inherited(): String
+}
+
+class <caret>B {
+    companion object : A(), TestInterface {
+        override fun test() = "test2"
+        override fun inherited() = "inherited"
+    }
+}

--- a/idea/testData/inspectionsLocal/convertToObjectDeclaration/inheritance.kt.after
+++ b/idea/testData/inspectionsLocal/convertToObjectDeclaration/inheritance.kt.after
@@ -1,0 +1,14 @@
+// FIX: Convert to object declaration
+
+open class A {
+    open fun test() = "test"
+}
+
+interface TestInterface {
+    fun inherited(): String
+}
+
+object B : A(), TestInterface {
+    override fun test() = "test2"
+    override fun inherited() = "inherited"
+}

--- a/idea/testData/inspectionsLocal/convertToObjectDeclaration/nameCollision.kt
+++ b/idea/testData/inspectionsLocal/convertToObjectDeclaration/nameCollision.kt
@@ -1,0 +1,12 @@
+import Main.NotMain
+
+class <caret>Main {
+    companion object NotMain {
+        fun check() {}
+    }
+}
+
+fun main() {
+    class Main
+    NotMain.check()
+}

--- a/idea/testData/inspectionsLocal/convertToObjectDeclaration/named.kt
+++ b/idea/testData/inspectionsLocal/convertToObjectDeclaration/named.kt
@@ -1,0 +1,13 @@
+// WITH_RUNTIME
+
+class <caret>NotificationItemTypeModel {
+    companion object Named {
+        const val ABC = "ABC"
+        const val CDE = "CDE"
+    }
+}
+
+fun main() {
+    println(NotificationItemTypeModel.ABC)
+    println(NotificationItemTypeModel.Named.ABC)
+}

--- a/idea/testData/inspectionsLocal/convertToObjectDeclaration/named.kt.after
+++ b/idea/testData/inspectionsLocal/convertToObjectDeclaration/named.kt.after
@@ -1,0 +1,11 @@
+// WITH_RUNTIME
+
+object NotificationItemTypeModel {
+    const val ABC = "ABC"
+    const val CDE = "CDE"
+}
+
+fun main() {
+    println(NotificationItemTypeModel.ABC)
+    println(NotificationItemTypeModel.ABC)
+}

--- a/idea/testData/inspectionsLocal/convertToObjectDeclaration/refactorCompanionAsImport.kt
+++ b/idea/testData/inspectionsLocal/convertToObjectDeclaration/refactorCompanionAsImport.kt
@@ -1,0 +1,11 @@
+import Owner.<caret>CompTest
+
+class <caret>Owner {
+    companion object CompTest {
+        const val some = ""
+    }
+}
+
+class User {
+    val anything = CompTest.some
+}

--- a/idea/testData/inspectionsLocal/convertToObjectDeclaration/refactorCompanionAsImport.kt.after
+++ b/idea/testData/inspectionsLocal/convertToObjectDeclaration/refactorCompanionAsImport.kt.after
@@ -1,0 +1,7 @@
+object Owner {
+    const val some = ""
+}
+
+class User {
+    val anything = Owner.some
+}

--- a/idea/testData/inspectionsLocal/convertToObjectDeclaration/refactorCompanionReference.kt
+++ b/idea/testData/inspectionsLocal/convertToObjectDeclaration/refactorCompanionReference.kt
@@ -1,0 +1,13 @@
+// FIX: Convert to object declaration
+// WITH_RUNTIME
+
+class <caret>A {
+    companion object {
+        val prop = "test"
+    }
+}
+
+fun main() {
+    println(A.Companion.prop)
+    println(A.prop)
+}

--- a/idea/testData/inspectionsLocal/convertToObjectDeclaration/refactorCompanionReference.kt.after
+++ b/idea/testData/inspectionsLocal/convertToObjectDeclaration/refactorCompanionReference.kt.after
@@ -1,0 +1,11 @@
+// FIX: Convert to object declaration
+// WITH_RUNTIME
+
+object A {
+    val prop = "test"
+}
+
+fun main() {
+    println(A.prop)
+    println(A.prop)
+}

--- a/idea/testData/inspectionsLocal/convertToObjectDeclaration/secondaryConstructor.kt
+++ b/idea/testData/inspectionsLocal/convertToObjectDeclaration/secondaryConstructor.kt
@@ -1,0 +1,7 @@
+class <caret>A(val i: Int) {
+    constructor(): this(42)
+
+    companion object {
+        const val B = 1
+    }
+}

--- a/idea/testData/inspectionsLocal/convertToObjectDeclaration/secondaryConstructor.kt.after
+++ b/idea/testData/inspectionsLocal/convertToObjectDeclaration/secondaryConstructor.kt.after
@@ -1,0 +1,3 @@
+object A {
+    const val B = 1
+}

--- a/idea/testData/inspectionsLocal/convertToObjectDeclaration/simple.kt
+++ b/idea/testData/inspectionsLocal/convertToObjectDeclaration/simple.kt
@@ -1,0 +1,8 @@
+// FIX: Convert to object declaration
+
+class <caret>NotificationItemTypeModel {
+    companion object {
+        const val ABC = "ABC"
+        const val CDE = "CDE"
+    }
+}

--- a/idea/testData/inspectionsLocal/convertToObjectDeclaration/simple.kt.after
+++ b/idea/testData/inspectionsLocal/convertToObjectDeclaration/simple.kt.after
@@ -1,0 +1,6 @@
+// FIX: Convert to object declaration
+
+object NotificationItemTypeModel {
+    const val ABC = "ABC"
+    const val CDE = "CDE"
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -2123,6 +2123,84 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
         }
     }
 
+    @TestMetadata("idea/testData/inspectionsLocal/convertToObjectDeclaration")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class ConvertToObjectDeclaration extends AbstractLocalInspectionTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY, testDataFilePath);
+        }
+
+        @TestMetadata("abortOnAlias.kt")
+        public void testAbortOnAlias() throws Exception {
+            runTest("idea/testData/inspectionsLocal/convertToObjectDeclaration/abortOnAlias.kt");
+        }
+
+        @TestMetadata("abortOnSecondaryConstructorUsage.kt")
+        public void testAbortOnSecondaryConstructorUsage() throws Exception {
+            runTest("idea/testData/inspectionsLocal/convertToObjectDeclaration/abortOnSecondaryConstructorUsage.kt");
+        }
+
+        @TestMetadata("abortOnTypeAlias.kt")
+        public void testAbortOnTypeAlias() throws Exception {
+            runTest("idea/testData/inspectionsLocal/convertToObjectDeclaration/abortOnTypeAlias.kt");
+        }
+
+        @TestMetadata("accompanyingDeclarations.kt")
+        public void testAccompanyingDeclarations() throws Exception {
+            runTest("idea/testData/inspectionsLocal/convertToObjectDeclaration/accompanyingDeclarations.kt");
+        }
+
+        public void testAllFilesPresentInConvertToObjectDeclaration() throws Exception {
+            KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/inspectionsLocal/convertToObjectDeclaration"), Pattern.compile("^([\\w\\-_]+)\\.(kt|kts)$"), TargetBackend.ANY, true);
+        }
+
+        @TestMetadata("existingSuper.kt")
+        public void testExistingSuper() throws Exception {
+            runTest("idea/testData/inspectionsLocal/convertToObjectDeclaration/existingSuper.kt");
+        }
+
+        @TestMetadata("hasConstructorUsages.kt")
+        public void testHasConstructorUsages() throws Exception {
+            runTest("idea/testData/inspectionsLocal/convertToObjectDeclaration/hasConstructorUsages.kt");
+        }
+
+        @TestMetadata("inheritance.kt")
+        public void testInheritance() throws Exception {
+            runTest("idea/testData/inspectionsLocal/convertToObjectDeclaration/inheritance.kt");
+        }
+
+        @TestMetadata("nameCollision.kt")
+        public void testNameCollision() throws Exception {
+            runTest("idea/testData/inspectionsLocal/convertToObjectDeclaration/nameCollision.kt");
+        }
+
+        @TestMetadata("named.kt")
+        public void testNamed() throws Exception {
+            runTest("idea/testData/inspectionsLocal/convertToObjectDeclaration/named.kt");
+        }
+
+        @TestMetadata("refactorCompanionAsImport.kt")
+        public void testRefactorCompanionAsImport() throws Exception {
+            runTest("idea/testData/inspectionsLocal/convertToObjectDeclaration/refactorCompanionAsImport.kt");
+        }
+
+        @TestMetadata("refactorCompanionReference.kt")
+        public void testRefactorCompanionReference() throws Exception {
+            runTest("idea/testData/inspectionsLocal/convertToObjectDeclaration/refactorCompanionReference.kt");
+        }
+
+        @TestMetadata("secondaryConstructor.kt")
+        public void testSecondaryConstructor() throws Exception {
+            runTest("idea/testData/inspectionsLocal/convertToObjectDeclaration/secondaryConstructor.kt");
+        }
+
+        @TestMetadata("simple.kt")
+        public void testSimple() throws Exception {
+            runTest("idea/testData/inspectionsLocal/convertToObjectDeclaration/simple.kt");
+        }
+    }
+
     @TestMetadata("idea/testData/inspectionsLocal/copyWithoutNamedArguments")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)


### PR DESCRIPTION
YouTrack: https://youtrack.jetbrains.com/issue/KT-22880

Converts fragments like:

```
class A {
    companion object {
        val prop = "test"
    }
}
```

to

```
object A {
    val prop = "test"
}
```
and refactors usages of `A.Companion`.