### PR TITLE
Forward stdout and stderr logger of out of process though gradle logger

### DIFF
--- a/compiler/compiler-runner/src/org/jetbrains/kotlin/compilerRunner/KotlinLogger.kt
+++ b/compiler/compiler-runner/src/org/jetbrains/kotlin/compilerRunner/KotlinLogger.kt
@@ -10,6 +10,5 @@ interface KotlinLogger {
     fun warn(msg: String)
     fun info(msg: String)
     fun debug(msg: String)
-
     val isDebugEnabled: Boolean
 }

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/compilerRunner/reportUtils.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/compilerRunner/reportUtils.kt
@@ -24,6 +24,7 @@ import org.jetbrains.kotlin.cli.common.messages.MessageRenderer
 import org.jetbrains.kotlin.config.KotlinCompilerVersion
 import org.jetbrains.kotlin.daemon.client.DaemonReportingTargets
 import org.jetbrains.kotlin.daemon.client.launchProcessWithFallback
+import org.jetbrains.kotlin.gradle.logging.GradleKotlinLogger
 import org.jetbrains.org.objectweb.asm.ClassReader
 import org.jetbrains.org.objectweb.asm.ClassVisitor
 import org.jetbrains.org.objectweb.asm.FieldVisitor
@@ -82,12 +83,20 @@ internal fun runToolInSeparateProcess(
     // important to read inputStream, otherwise the process may hang on some systems
     val readErrThread = thread {
         process.errorStream!!.bufferedReader().forEachLine {
-            System.err.println(it)
+            logger.error(it)
         }
     }
-    process.inputStream!!.bufferedReader().forEachLine {
-        System.out.println(it)
+
+    if (logger is GradleKotlinLogger) {
+        process.inputStream!!.bufferedReader().forEachLine {
+            logger.lifecycle(it)
+        }
+    } else {
+        process.inputStream!!.bufferedReader().forEachLine {
+            System.out.println(it)
+        }
     }
+
     readErrThread.join()
 
     val exitCode = process.waitFor()

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/logging/GradleKotlinLogger.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/logging/GradleKotlinLogger.kt
@@ -25,6 +25,10 @@ internal class GradleKotlinLogger(private val log: Logger) : KotlinLogger {
         log.warn(msg)
     }
 
+    fun lifecycle(msg: String) {
+        log.lifecycle(msg)
+    }
+
     override val isDebugEnabled: Boolean
         get() = log.isDebugEnabled
 }


### PR DESCRIPTION
Instead of forwarding the external process output directly to stdout / stderr we forward the output through the gradle logging system which allows associate output to the producing gradle tasks. 

This fix in combination with https://github.com/gradle/gradle/pull/8807 will result in better user experience when using kotlin plugin with gradle and gradle build scans.

This is a fix for https://youtrack.jetbrains.com/issue/KT-30596

