### PR TITLE
KT-26629 Inspection to replace `==` operator on Double.NaN with `equals` call

### DIFF
--- a/idea/resources/META-INF/plugin-common.xml
+++ b/idea/resources/META-INF/plugin-common.xml
@@ -2365,6 +2365,15 @@
                      language="kotlin"
     />
 
+    <localInspection implementationClass="org.jetbrains.kotlin.idea.inspections.ConvertNaNEqualityInspection"
+                     displayName="Convert equality check with 'NaN' to 'isNaN' call"
+                     groupPath="Kotlin"
+                     groupName="Probable bugs"
+                     enabledByDefault="true"
+                     level="WARNING"
+                     language="kotlin"
+    />
+
     <localInspection implementationClass="org.jetbrains.kotlin.idea.inspections.UnusedEqualsInspection"
                      displayName="Unused equals expression"
                      groupPath="Kotlin"

--- a/idea/resources/inspectionDescriptions/ConvertNaNEquality.html
+++ b/idea/resources/inspectionDescriptions/ConvertNaNEquality.html
@@ -1,0 +1,7 @@
+<html>
+<body>
+This inspection reports an equality check with <b>Double.NaN</b> which can be replaced with <b>a.isNaN()</b>.
+
+For every floating point value <b>a</b>, <b>a == NaN</b> will always result in <b>false</b>.
+</body>
+</html>

--- a/idea/src/org/jetbrains/kotlin/idea/inspections/ConvertNaNEqualityInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/ConvertNaNEqualityInspection.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.idea.inspections
+
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElementVisitor
+import org.jetbrains.kotlin.idea.caches.resolve.resolveToCall
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameUnsafe
+
+class ConvertNaNEqualityInspection : AbstractKotlinInspection() {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        return binaryExpressionVisitor { expression ->
+            if (expression.left.isNaNExpression() || expression.right.isNaNExpression()) {
+                val inverted = when (expression.operationToken) {
+                    KtTokens.EXCLEQ -> true
+                    KtTokens.EQEQ -> false
+                    else -> return@binaryExpressionVisitor
+                }
+                holder.registerProblem(
+                    expression,
+                    "Equality check with NaN should be replaced with 'isNaN()'",
+                    ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
+                    ConvertNaNEqualityQuickFix(inverted)
+                )
+            }
+        }
+    }
+}
+
+private class ConvertNaNEqualityQuickFix(val inverted: Boolean) : LocalQuickFix {
+    override fun getName() = "Replace with 'isNaN()'"
+
+    override fun getFamilyName() = name
+
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        val element = descriptor.psiElement as? KtBinaryExpression ?: return
+
+        val other = when {
+            element.left.isNaNExpression() -> element.right ?: return
+            element.right.isNaNExpression() -> element.left ?: return
+            else -> return
+        }
+        val pattern = if (inverted) "!$0.isNaN()" else "$0.isNaN()"
+        element.replace(KtPsiFactory(element).createExpressionByPattern(pattern, other))
+    }
+}
+
+private val NaNSet = setOf("kotlin.Double.Companion.NaN", "java.lang.Double.NaN", "kotlin.Float.Companion.NaN", "java.lang.Float.NaN")
+
+private fun KtExpression?.isNaNExpression(): Boolean {
+    if (this?.text?.endsWith("NaN") != true) return false
+    val fqName = this.resolveToCall()?.resultingDescriptor?.fqNameUnsafe?.asString()
+    return NaNSet.contains(fqName)
+}

--- a/idea/testData/inspectionsLocal/convertNaNEquality/.inspection
+++ b/idea/testData/inspectionsLocal/convertNaNEquality/.inspection
@@ -1,0 +1,1 @@
+org.jetbrains.kotlin.idea.inspections.ConvertEqualsDoubleNaNInspection

--- a/idea/testData/inspectionsLocal/convertNaNEquality/float.kt
+++ b/idea/testData/inspectionsLocal/convertNaNEquality/float.kt
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test() {
+    val x = 0.5f <caret>!= Float.NaN
+}

--- a/idea/testData/inspectionsLocal/convertNaNEquality/float.kt.after
+++ b/idea/testData/inspectionsLocal/convertNaNEquality/float.kt.after
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test() {
+    val x = !0.5f.isNaN()
+}

--- a/idea/testData/inspectionsLocal/convertNaNEquality/importedProperty.kt
+++ b/idea/testData/inspectionsLocal/convertNaNEquality/importedProperty.kt
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+import kotlin.Double.Companion.NaN
+
+fun test() {
+    val t = NaN ==<caret> 5.0
+}

--- a/idea/testData/inspectionsLocal/convertNaNEquality/importedProperty.kt.after
+++ b/idea/testData/inspectionsLocal/convertNaNEquality/importedProperty.kt.after
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+import kotlin.Double.Companion.NaN
+
+fun test() {
+    val t = 5.0.isNaN()
+}

--- a/idea/testData/inspectionsLocal/convertNaNEquality/inequality.kt
+++ b/idea/testData/inspectionsLocal/convertNaNEquality/inequality.kt
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun main() {
+    val result = 5.0 + 3.0 <caret>!= Double.NaN;
+}

--- a/idea/testData/inspectionsLocal/convertNaNEquality/inequality.kt.after
+++ b/idea/testData/inspectionsLocal/convertNaNEquality/inequality.kt.after
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun main() {
+    val result = !(5.0 + 3.0).isNaN();
+}

--- a/idea/testData/inspectionsLocal/convertNaNEquality/javaDouble.kt
+++ b/idea/testData/inspectionsLocal/convertNaNEquality/javaDouble.kt
@@ -1,0 +1,5 @@
+// RUNTIME_WITH_FULL_JDK
+
+fun test() {
+    val t = java.lang.Double.NaN ==<caret> 5.0
+}

--- a/idea/testData/inspectionsLocal/convertNaNEquality/javaDouble.kt.after
+++ b/idea/testData/inspectionsLocal/convertNaNEquality/javaDouble.kt.after
@@ -1,0 +1,5 @@
+// RUNTIME_WITH_FULL_JDK
+
+fun test() {
+    val t = 5.0.isNaN()
+}

--- a/idea/testData/inspectionsLocal/convertNaNEquality/javaFloatNaN.kt
+++ b/idea/testData/inspectionsLocal/convertNaNEquality/javaFloatNaN.kt
@@ -1,0 +1,6 @@
+// RUNTIME_WITH_FULL_JDK
+
+fun test() {
+    val a = 0.5f
+    val x = a ==<caret> java.lang.Float.NaN
+}

--- a/idea/testData/inspectionsLocal/convertNaNEquality/javaFloatNaN.kt.after
+++ b/idea/testData/inspectionsLocal/convertNaNEquality/javaFloatNaN.kt.after
@@ -1,0 +1,6 @@
+// RUNTIME_WITH_FULL_JDK
+
+fun test() {
+    val a = 0.5f
+    val x = a.isNaN()
+}

--- a/idea/testData/inspectionsLocal/convertNaNEquality/negative.kt
+++ b/idea/testData/inspectionsLocal/convertNaNEquality/negative.kt
@@ -1,0 +1,11 @@
+// WITH_RUNTIME
+// PROBLEM: none
+
+class A {
+    val NaN = 0.3
+}
+
+fun test() {
+    val a = A()
+    val t = a.NaN ==<caret> 0.5
+}

--- a/idea/testData/inspectionsLocal/convertNaNEquality/simple.kt
+++ b/idea/testData/inspectionsLocal/convertNaNEquality/simple.kt
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test() {
+    val t = <caret>5.0 == Double.NaN
+}

--- a/idea/testData/inspectionsLocal/convertNaNEquality/simple.kt.after
+++ b/idea/testData/inspectionsLocal/convertNaNEquality/simple.kt.after
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test() {
+    val t = 5.0.isNaN()
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -2082,6 +2082,54 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
         }
     }
 
+    @TestMetadata("idea/testData/inspectionsLocal/convertNaNEquality")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class ConvertNaNEquality extends AbstractLocalInspectionTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY, testDataFilePath);
+        }
+
+        public void testAllFilesPresentInConvertNaNEquality() throws Exception {
+            KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/inspectionsLocal/convertNaNEquality"), Pattern.compile("^([\\w\\-_]+)\\.(kt|kts)$"), TargetBackend.ANY, true);
+        }
+
+        @TestMetadata("float.kt")
+        public void testFloat() throws Exception {
+            runTest("idea/testData/inspectionsLocal/convertNaNEquality/float.kt");
+        }
+
+        @TestMetadata("importedProperty.kt")
+        public void testImportedProperty() throws Exception {
+            runTest("idea/testData/inspectionsLocal/convertNaNEquality/importedProperty.kt");
+        }
+
+        @TestMetadata("inequality.kt")
+        public void testInequality() throws Exception {
+            runTest("idea/testData/inspectionsLocal/convertNaNEquality/inequality.kt");
+        }
+
+        @TestMetadata("javaDouble.kt")
+        public void testJavaDouble() throws Exception {
+            runTest("idea/testData/inspectionsLocal/convertNaNEquality/javaDouble.kt");
+        }
+
+        @TestMetadata("javaFloatNaN.kt")
+        public void testJavaFloatNaN() throws Exception {
+            runTest("idea/testData/inspectionsLocal/convertNaNEquality/javaFloatNaN.kt");
+        }
+
+        @TestMetadata("negative.kt")
+        public void testNegative() throws Exception {
+            runTest("idea/testData/inspectionsLocal/convertNaNEquality/negative.kt");
+        }
+
+        @TestMetadata("simple.kt")
+        public void testSimple() throws Exception {
+            runTest("idea/testData/inspectionsLocal/convertNaNEquality/simple.kt");
+        }
+    }
+
     @TestMetadata("idea/testData/inspectionsLocal/convertPairConstructorToToFunction")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)


### PR DESCRIPTION
YouTrack: https://youtrack.jetbrains.com/issue/KT-26629

Replaces fragments like `5.0 == Double.NaN` with `5.0.equals(Double.NaN)`.
