### PR TITLE
KT-13048 "Strip trailing spaces on Save" should not strip trailing spaces inside multiline strings in Kotlin

### DIFF
--- a/idea/resources/META-INF/plugin-common.xml
+++ b/idea/resources/META-INF/plugin-common.xml
@@ -3358,5 +3358,6 @@
 
     <postStartupActivity implementation="org.jetbrains.kotlin.idea.framework.TargetRetrieveActivity"/>
 
+    <stripTrailingSpacesFilterFactory implementation="org.jetbrains.kotlin.idea.editor.KotlinStripTrailingSpacesFilterFactory"/>
   </extensions>
 </idea-plugin>

--- a/idea/src/org/jetbrains/kotlin/idea/editor/KotlinStripTrailingSpacesFilterFactory.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/editor/KotlinStripTrailingSpacesFilterFactory.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.idea.editor
+
+import com.intellij.lang.Language
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.editor.impl.PsiBasedStripTrailingSpacesFilter
+import com.intellij.psi.PsiFile
+import org.jetbrains.kotlin.idea.KotlinLanguage
+import org.jetbrains.kotlin.psi.KtStringTemplateExpression
+import org.jetbrains.kotlin.psi.KtTreeVisitorVoid
+
+class KotlinStripTrailingSpacesFilterFactory : PsiBasedStripTrailingSpacesFilter.Factory() {
+    override fun isApplicableTo(language: Language): Boolean {
+        return language.`is`(KotlinLanguage.INSTANCE)
+    }
+
+    override fun createFilter(document: Document): PsiBasedStripTrailingSpacesFilter {
+        return KotlinStripTrailingSpacesFilter(document)
+    }
+
+    private class KotlinStripTrailingSpacesFilter(document: Document) : PsiBasedStripTrailingSpacesFilter(document) {
+        override fun process(psiFile: PsiFile) {
+            psiFile.accept(object : KtTreeVisitorVoid() {
+                override fun visitStringTemplateExpression(expression: KtStringTemplateExpression) {
+                    disableRange(expression.textRange, false)
+                }
+            })
+        }
+    }
+}

--- a/idea/testData/editor/stripTrailingSpaces/keepTrailingSpacesInRawString.kt
+++ b/idea/testData/editor/stripTrailingSpaces/keepTrailingSpacesInRawString.kt
@@ -1,0 +1,4 @@
+val s =<caret>"""     
+    foo, foo      
+    bar, bar      
+"""     

--- a/idea/testData/editor/stripTrailingSpaces/keepTrailingSpacesInRawString.kt.after
+++ b/idea/testData/editor/stripTrailingSpaces/keepTrailingSpacesInRawString.kt.after
@@ -1,0 +1,4 @@
+val s = """     
+    foo, foo      
+    bar, bar      
+"""

--- a/idea/tests/org/jetbrains/kotlin/idea/editor/StripTrailingSpacesTest.kt
+++ b/idea/tests/org/jetbrains/kotlin/idea/editor/StripTrailingSpacesTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.idea.editor
+
+import com.intellij.openapi.editor.ex.EditorSettingsExternalizable
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.testFramework.EditorTestUtil
+import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase
+import org.jetbrains.kotlin.idea.test.PluginTestCaseBase
+
+class StripTrailingSpacesTest : LightCodeInsightFixtureTestCase() {
+    override fun getTestDataPath(): String {
+        return PluginTestCaseBase.getTestDataPathBase() + "/editor/stripTrailingSpaces/"
+    }
+
+    fun testKeepTrailingSpacesInRawString() {
+        doTest()
+    }
+
+    fun doTest() {
+        myFixture.configureByFile("${getTestName(true)}.kt")
+
+        val editorSettings = EditorSettingsExternalizable.getInstance()
+        val stripSpaces = editorSettings.stripTrailingSpaces
+        try {
+            editorSettings.stripTrailingSpaces = EditorSettingsExternalizable.STRIP_TRAILING_SPACES_WHOLE
+            val doc = myFixture.editor.document
+            EditorTestUtil.performTypingAction(editor, ' ')
+            PsiDocumentManager.getInstance(project).commitDocument(doc)
+            FileDocumentManager.getInstance().saveDocument(doc)
+        } finally {
+            editorSettings.stripTrailingSpaces = stripSpaces
+        }
+
+        myFixture.checkResultByFile("${getTestName(true)}.kt.after")
+    }
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-13048