### PR TITLE
KT-30565 False positive "Suspicious 'var' property" inspection with annotated default property getter

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/SuspiciousVarPropertyInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/SuspiciousVarPropertyInspection.kt
@@ -40,7 +40,7 @@ class SuspiciousVarPropertyInspection : AbstractKotlinInspection() {
 
     companion object {
         private fun KtPropertyAccessor.hasBackingFieldReference(): Boolean {
-            val bodyExpression = this.bodyExpression ?: return false
+            val bodyExpression = this.bodyExpression ?: return true
             return bodyExpression.isBackingFieldReference(property) || bodyExpression.anyDescendantOfType<KtNameReferenceExpression> {
                 it.isBackingFieldReference(property)
             }

--- a/idea/testData/inspectionsLocal/suspiciousVarProperty/hasBackingFieldRef3.kt
+++ b/idea/testData/inspectionsLocal/suspiciousVarProperty/hasBackingFieldRef3.kt
@@ -1,0 +1,5 @@
+// PROBLEM: none
+class Test {
+    <caret>var foo: Int? = null
+        get
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -8219,6 +8219,11 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
             runTest("idea/testData/inspectionsLocal/suspiciousVarProperty/hasBackingFieldRef2.kt");
         }
 
+        @TestMetadata("hasBackingFieldRef3.kt")
+        public void testHasBackingFieldRef3() throws Exception {
+            runTest("idea/testData/inspectionsLocal/suspiciousVarProperty/hasBackingFieldRef3.kt");
+        }
+
         @TestMetadata("hasSetter.kt")
         public void testHasSetter() throws Exception {
             runTest("idea/testData/inspectionsLocal/suspiciousVarProperty/hasSetter.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-30565