### PR TITLE
CoroutineNonBlockingContextChecker:

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/blockingCallsDetection/CoroutineNonBlockingContextChecker.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/blockingCallsDetection/CoroutineNonBlockingContextChecker.kt
@@ -8,7 +8,7 @@ package org.jetbrains.kotlin.idea.inspections.blockingCallsDetection
 import com.intellij.codeInspection.blockingCallsDetection.NonBlockingContextChecker
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
-import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.util.parentsOfType
 import org.jetbrains.kotlin.builtins.getReceiverTypeFromFunctionType
 import org.jetbrains.kotlin.builtins.isBuiltinFunctionalType
 import org.jetbrains.kotlin.builtins.isSuspendFunctionType
@@ -19,6 +19,8 @@ import org.jetbrains.kotlin.idea.project.getLanguageVersionSettings
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
+import org.jetbrains.kotlin.psi.psiUtil.getParentOfTypes
 import org.jetbrains.kotlin.psi.psiUtil.parents
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.callUtil.getParameterForArgument
@@ -40,9 +42,9 @@ class CoroutineNonBlockingContextChecker : NonBlockingContextChecker {
 
         val containingLambda = element.parents
             .firstOrNull { it is KtLambdaExpression && it.analyze().get(BindingContext.LAMBDA_INVOCATIONS, it) == null }
-        val containingArgument = PsiTreeUtil.getParentOfType(containingLambda, KtValueArgument::class.java)
+        val containingArgument = containingLambda?.getParentOfType<KtValueArgument>(true, KtCallableDeclaration::class.java)
         if (containingArgument != null) {
-            val callExpression = PsiTreeUtil.getParentOfType(containingArgument, KtCallExpression::class.java) ?: return false
+            val callExpression = containingArgument.getParentOfType<KtCallExpression>(true) ?: return false
             val call = callExpression.resolveToCall(BodyResolveMode.PARTIAL) ?: return false
 
             val argumentDescriptor = call.getFirstArgument()?.resolveToCall()?.resultingDescriptor
@@ -61,8 +63,16 @@ class CoroutineNonBlockingContextChecker : NonBlockingContextChecker {
             return hasRestrictSuspensionAnnotation != true && type.isSuspendFunctionType
         }
 
-        val callingMethod = PsiTreeUtil.getParentOfType(element, KtNamedFunction::class.java) ?: return false
-        return callingMethod.hasModifier(KtTokens.SUSPEND_KEYWORD)
+        if (containingLambda == null) {
+            return element.parentsOfType<KtNamedFunction>()
+                .take(2)
+                .firstOrNull { function -> function.nameIdentifier != null }
+                ?.hasModifier(KtTokens.SUSPEND_KEYWORD) ?: false
+        }
+        val containingPropertyOrFunction: KtCallableDeclaration? =
+            containingLambda.getParentOfTypes(true, KtProperty::class.java, KtNamedFunction::class.java)
+        if (containingPropertyOrFunction?.typeReference?.hasModifier(KtTokens.SUSPEND_KEYWORD) == true) return true
+        return containingPropertyOrFunction?.hasModifier(KtTokens.SUSPEND_KEYWORD) == true
     }
 
     private fun ResolvedCall<*>.getFirstArgument(): KtExpression? =

--- a/idea/testData/inspections/blockingCallsDetection/LambdaAssignmentCheck.kt
+++ b/idea/testData/inspections/blockingCallsDetection/LambdaAssignmentCheck.kt
@@ -1,0 +1,21 @@
+@file:Suppress("UNUSED_VARIABLE")
+
+import kotlin.coroutines.*
+import java.lang.Thread.sleep
+
+class LambdaAssignmentCheck {
+    fun returnSuspend(): suspend () -> Unit = {
+        Thread.<warning descr="Inappropriate blocking method call">sleep</warning>(1)
+    }
+
+    fun assignToSuspendType() {
+        val suspendType: suspend () -> Unit = {
+            Thread.<warning descr="Inappropriate blocking method call">sleep</warning>(2)
+        }
+    }
+
+    suspend fun lambdaNotInvoked() {
+        //no warning should be present
+        val fn1 = { Thread.sleep(3) }
+    }
+}

--- a/idea/testData/inspections/blockingCallsDetection/NestedFunctionsInsideSuspendLambda.kt
+++ b/idea/testData/inspections/blockingCallsDetection/NestedFunctionsInsideSuspendLambda.kt
@@ -1,11 +1,19 @@
-fun <T> runBlocking(<warning descr="[UNUSED_PARAMETER] Parameter 'block' is never used">block</warning>: suspend CoroutineScope.() -> T): T = TODO()
+@file:Suppress("UNUSED_VARIABLE", "UNUSED_PARAMETER")
+
+fun <T> runBlocking(block: suspend CoroutineScope.() -> T): T = TODO()
 
 class CoroutineScope
 
 fun test() {
     runBlocking {
         repeat(1) {
-            java.lang.Thread.<warning descr="Inappropriate blocking method call">sleep</warning>(2)
+            java.lang.Thread.<warning descr="Inappropriate blocking method call">sleep</warning>(1)
         }
     }
+}
+
+suspend fun test2() {
+    val unused1 = run { Thread.<warning descr="Inappropriate blocking method call">sleep</warning>(2) }
+
+    val unused2 = run (fun() {Thread.<warning descr="Inappropriate blocking method call">sleep</warning>(3)})
 }

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/CoroutineNonBlockingontextDetectionTest.kt
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/CoroutineNonBlockingontextDetectionTest.kt
@@ -46,4 +46,9 @@ class CoroutineNonBlockingContextDetectionTest : KotlinLightCodeInsightFixtureTe
         myFixture.configureByFile("DispatchersTypeCheck.kt")
         myFixture.testHighlighting(true, false, false, "DispatchersTypeCheck.kt")
     }
+
+    fun testLambdaInSuspendDeclaration() {
+        myFixture.configureByFile("LambdaAssignmentCheck.kt")
+        myFixture.testHighlighting(true, false, false, "LambdaAssignmentCheck.kt")
+    }
 }


### PR DESCRIPTION
added check inside lambdas assigned to suspend properties and functions (KT-30540)

removed false positives when lambda inside suspend isn't actually called (KT-30321)