### PR TITLE
KT-30614: String templates suggest removing curly braces for backtick escaped identifiers

### DIFF
--- a/idea/idea-core/src/org/jetbrains/kotlin/idea/core/psiModificationUtils.kt
+++ b/idea/idea-core/src/org/jetbrains/kotlin/idea/core/psiModificationUtils.kt
@@ -521,7 +521,7 @@ fun KtBlockStringTemplateEntry.canDropBraces() =
     expression is KtNameReferenceExpression && canPlaceAfterSimpleNameEntry(nextSibling)
 
 fun KtBlockStringTemplateEntry.dropBraces(): KtSimpleNameStringTemplateEntry {
-    val name = (expression as KtNameReferenceExpression).getReferencedName()
+    val name = (expression as KtNameReferenceExpression).getReferencedNameElement().text
     val newEntry = KtPsiFactory(this).createSimpleNameStringTemplateEntry(name)
     return replaced(newEntry)
 }

--- a/idea/src/org/jetbrains/kotlin/idea/intentions/RemoveCurlyBracesFromTemplateIntention.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/RemoveCurlyBracesFromTemplateIntention.kt
@@ -22,9 +22,11 @@ import org.jetbrains.kotlin.idea.core.dropBraces
 import org.jetbrains.kotlin.idea.inspections.IntentionBasedInspection
 import org.jetbrains.kotlin.psi.KtBlockStringTemplateEntry
 
-class RemoveCurlyBracesFromTemplateInspection : IntentionBasedInspection<KtBlockStringTemplateEntry>(RemoveCurlyBracesFromTemplateIntention::class)
+class RemoveCurlyBracesFromTemplateInspection :
+    IntentionBasedInspection<KtBlockStringTemplateEntry>(RemoveCurlyBracesFromTemplateIntention::class)
 
-class RemoveCurlyBracesFromTemplateIntention : SelfTargetingOffsetIndependentIntention<KtBlockStringTemplateEntry>(KtBlockStringTemplateEntry::class.java, "Remove curly braces") {
+class RemoveCurlyBracesFromTemplateIntention :
+    SelfTargetingOffsetIndependentIntention<KtBlockStringTemplateEntry>(KtBlockStringTemplateEntry::class.java, "Remove curly braces") {
     override fun isApplicableTo(element: KtBlockStringTemplateEntry) = element.canDropBraces()
 
     override fun applyTo(element: KtBlockStringTemplateEntry, editor: Editor?) {

--- a/idea/testData/intentions/removeCurlyBracesFromTemplate/unnecessaryBrackets7.kt
+++ b/idea/testData/intentions/removeCurlyBracesFromTemplate/unnecessaryBrackets7.kt
@@ -1,0 +1,4 @@
+// IS_APPLICABLE: true
+fun foo(`object`: Any) {
+    val bar = "$<caret>{`object`}"
+}

--- a/idea/testData/intentions/removeCurlyBracesFromTemplate/unnecessaryBrackets7.kt.after
+++ b/idea/testData/intentions/removeCurlyBracesFromTemplate/unnecessaryBrackets7.kt.after
@@ -1,0 +1,4 @@
+// IS_APPLICABLE: true
+fun foo(`object`: Any) {
+    val bar = "$`object`"
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -13785,6 +13785,11 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
         public void testUnnecessaryBrackets6() throws Exception {
             runTest("idea/testData/intentions/removeCurlyBracesFromTemplate/unnecessaryBrackets6.kt");
         }
+
+        @TestMetadata("unnecessaryBrackets7.kt")
+        public void testUnnecessaryBrackets7() throws Exception {
+            runTest("idea/testData/intentions/removeCurlyBracesFromTemplate/unnecessaryBrackets7.kt");
+        }
     }
 
     @TestMetadata("idea/testData/intentions/removeEmptyClassBody")


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-30614