### PR TITLE
JVM_IR: remove most uses of StackValue from ExpressionCodegen

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -67,30 +67,34 @@ class TryInfo(val tryBlock: IrTry) : ExpressionInfo(tryBlock) {
 }
 
 class BlockInfo private constructor(val parent: BlockInfo?) {
-    val variables: MutableList<VariableInfo> = mutableListOf()
-
-    private val infos = Stack<ExpressionInfo>()
+    val variables = mutableListOf<VariableInfo>()
+    val infos = Stack<ExpressionInfo>()
 
     fun create() = BlockInfo(this).apply {
         this@apply.infos.addAll(this@BlockInfo.infos)
     }
 
-    fun addInfo(loop: ExpressionInfo) {
-        infos.add(loop)
-    }
-
-    fun removeInfo(info: ExpressionInfo) {
-        assert(peek() == info)
-        pop()
-    }
-
-    fun pop(): ExpressionInfo = infos.pop()
-
-    fun peek(): ExpressionInfo = infos.peek()
-
     fun isEmpty(): Boolean = infos.isEmpty()
 
     fun hasFinallyBlocks(): Boolean = infos.firstIsInstanceOrNull<TryInfo>() != null
+
+    inline fun <R> withBlock(info: ExpressionInfo, f: (ExpressionInfo) -> R): R {
+        infos.add(info)
+        try {
+            return f(info)
+        } finally {
+            infos.pop()
+        }
+    }
+
+    inline fun <R> handleBlock(f: (ExpressionInfo) -> R): R {
+        val top = infos.pop()
+        try {
+            return f(top)
+        } finally {
+            infos.add(top)
+        }
+    }
 
     companion object {
         fun create() = BlockInfo(null)
@@ -917,12 +921,8 @@ class ExpressionCodegen(
         val endLabel = Label()
         generateLoopJump(loop.condition, data, endLabel, true)
 
-        with(LoopInfo(loop, continueLabel, endLabel)) {
-            data.addInfo(this)
-            loop.body?.let {
-                gen(it, data).discard()
-            }
-            data.removeInfo(this)
+        data.withBlock(LoopInfo(loop, continueLabel, endLabel)) {
+            loop.body?.let { gen(it, data).discard() }
         }
         mv.goTo(continueLabel)
         mv.mark(endLabel)
@@ -945,28 +945,22 @@ class ExpressionCodegen(
             throw UnsupportedOperationException("Target label for break/continue not found")
         }
 
-        val stackElement = data.peek()
-
-        when (stackElement) {
-            is TryInfo -> //noinspection ConstantConditions
-                genFinallyBlockOrGoto(stackElement, null, afterBreakContinueLabel, data)
-            is LoopInfo -> {
-                val loop = expression.loop
-                //noinspection ConstantConditions
-                if (loop == stackElement.loop) {
-                    val label = if (expression is IrBreak) stackElement.breakLabel else stackElement.continueLabel
-                    mv.fixStackAndJump(label)
-                    mv.mark(afterBreakContinueLabel)
-                    return
+        data.handleBlock { stackElement ->
+            when (stackElement) {
+                is TryInfo -> genFinallyBlock(stackElement, null, afterBreakContinueLabel, data)
+                is LoopInfo -> {
+                    val loop = expression.loop
+                    if (loop == stackElement.loop) {
+                        val label = if (expression is IrBreak) stackElement.breakLabel else stackElement.continueLabel
+                        mv.fixStackAndJump(label)
+                        mv.mark(afterBreakContinueLabel)
+                        return
+                    }
                 }
+                else -> throw UnsupportedOperationException("Wrong BlockStackElement in processing stack")
             }
-            else -> throw UnsupportedOperationException("Wrong BlockStackElement in processing stack")
+            generateBreakOrContinueExpression(expression, afterBreakContinueLabel, data)
         }
-
-        data.pop()
-        val result = generateBreakOrContinueExpression(expression, afterBreakContinueLabel, data)
-        data.addInfo(stackElement)
-        return result
     }
 
     override fun visitDoWhileLoop(loop: IrDoWhileLoop, data: BlockInfo): StackValue {
@@ -977,12 +971,8 @@ class ExpressionCodegen(
         mv.fakeAlwaysFalseIfeq(continueLabel)
         mv.fakeAlwaysFalseIfeq(endLabel)
 
-        with(LoopInfo(loop, continueLabel, endLabel)) {
-            data.addInfo(this)
-            loop.body?.let {
-                gen(it, data).discard()
-            }
-            data.removeInfo(this)
+        data.withBlock(LoopInfo(loop, continueLabel, endLabel)) {
+            loop.body?.let { gen(it, data).discard() }
         }
 
         mv.visitLabel(continueLabel)
@@ -994,12 +984,13 @@ class ExpressionCodegen(
 
     override fun visitTry(aTry: IrTry, data: BlockInfo): StackValue {
         aTry.markLineNumber(startOffset = true)
-        val finallyExpression = aTry.finallyExpression
-        val tryInfo = if (finallyExpression != null) TryInfo(aTry) else null
-        if (tryInfo != null) {
-            data.addInfo(tryInfo)
-        }
+        return if (aTry.finallyExpression != null)
+            data.withBlock(TryInfo(aTry)) { visitTryWithInfo(aTry, data, it as TryInfo) }
+        else
+            visitTryWithInfo(aTry, data, null)
+    }
 
+    private fun visitTryWithInfo(aTry: IrTry, data: BlockInfo, tryInfo: TryInfo?): StackValue {
         val tryBlockStart = markNewLabel()
         mv.nop()
         gen(aTry.tryResult, aTry.asmType, data)
@@ -1033,7 +1024,7 @@ class ExpressionCodegen(
 
             genFinallyBlockOrGoto(
                 tryInfo,
-                if (clause != catches.last() || finallyExpression != null) tryCatchBlockEnd else null,
+                if (clause != catches.last() || aTry.finallyExpression != null) tryCatchBlockEnd else null,
                 null,
                 data
             )
@@ -1042,7 +1033,7 @@ class ExpressionCodegen(
         }
 
         //for default catch clause
-        if (finallyExpression != null) {
+        if (aTry.finallyExpression != null) {
             val defaultCatchStart = Label()
             mv.mark(defaultCatchStart)
             val savedException = frame.enterTemp(JAVA_THROWABLE_TYPE)
@@ -1066,10 +1057,6 @@ class ExpressionCodegen(
         }
 
         mv.mark(tryCatchBlockEnd)
-        if (tryInfo != null) {
-            data.removeInfo(tryInfo)
-        }
-
         return aTry.onStack
     }
 
@@ -1097,45 +1084,26 @@ class ExpressionCodegen(
         }
     }
 
-    private fun genFinallyBlockOrGoto(
-        tryInfo: TryInfo?,
-        tryCatchBlockEnd: Label?,
-        afterJumpLabel: Label?,
-        data: BlockInfo
-    ) {
+    private fun genFinallyBlockOrGoto(tryInfo: TryInfo?, tryCatchBlockEnd: Label?, afterJumpLabel: Label?, data: BlockInfo) {
         if (tryInfo != null) {
-            assert(tryInfo.gaps.size % 2 == 0) { "Finally block gaps are inconsistent" }
-
-            val topOfStack = data.pop()
-            assert(topOfStack === tryInfo) { "Top element of stack doesn't equals processing finally block" }
-
-            val tryBlock = tryInfo.tryBlock
-            val finallyStart = markNewLabel()
-            tryInfo.gaps.add(finallyStart)
-
-            //noinspection ConstantConditions
-            gen(tryBlock.finallyExpression!!, Type.VOID_TYPE, data)
-        }
-
-        if (tryCatchBlockEnd != null) {
-            if (tryInfo != null) {
-                tryInfo.tryBlock.finallyExpression!!.markLineNumber(startOffset = false)
-            }
+            data.handleBlock { genFinallyBlock(tryInfo, tryCatchBlockEnd, afterJumpLabel, data) }
+        } else if (tryCatchBlockEnd != null) {
             mv.goTo(tryCatchBlockEnd)
-        }
-
-        if (tryInfo != null) {
-            val finallyEnd = afterJumpLabel ?: Label()
-            if (afterJumpLabel == null) {
-                mv.mark(finallyEnd)
-            }
-            tryInfo.gaps.add(finallyEnd)
-
-            data.addInfo(tryInfo)
         }
     }
 
-    fun generateFinallyBlocksIfNeeded(returnType: Type, afterReturnLabel: Label, data: BlockInfo) {
+    private fun genFinallyBlock(tryInfo: TryInfo, tryCatchBlockEnd: Label?, afterJumpLabel: Label?, data: BlockInfo) {
+        assert(tryInfo.gaps.size % 2 == 0) { "Finally block gaps are inconsistent" }
+        tryInfo.gaps.add(markNewLabel())
+        gen(tryInfo.tryBlock.finallyExpression!!, data).discard()
+        if (tryCatchBlockEnd != null) {
+            tryInfo.tryBlock.finallyExpression!!.markLineNumber(startOffset = false)
+            mv.goTo(tryCatchBlockEnd)
+        }
+        tryInfo.gaps.add(afterJumpLabel ?: markNewLabel())
+    }
+
+    private fun generateFinallyBlocksIfNeeded(returnType: Type, afterReturnLabel: Label, data: BlockInfo) {
         if (data.hasFinallyBlocks()) {
             if (Type.VOID_TYPE != returnType) {
                 val returnValIndex = frame.enterTemp(returnType)
@@ -1150,21 +1118,16 @@ class ExpressionCodegen(
         }
     }
 
-
     private fun doFinallyOnReturn(afterReturnLabel: Label, data: BlockInfo) {
         if (!data.isEmpty()) {
-            val stackElement = data.peek()
-            when (stackElement) {
-                is TryInfo -> genFinallyBlockOrGoto(stackElement, null, afterReturnLabel, data)
-                is LoopInfo -> {
-
+            data.handleBlock { stackElement ->
+                when (stackElement) {
+                    is TryInfo -> genFinallyBlock(stackElement, null, afterReturnLabel, data)
+                    is LoopInfo -> {}
+                    else -> throw UnsupportedOperationException("Wrong BlockStackElement in processing stack")
                 }
-                else -> throw UnsupportedOperationException("Wrong BlockStackElement in processing stack")
+                doFinallyOnReturn(afterReturnLabel, data)
             }
-
-            data.pop()
-            doFinallyOnReturn(afterReturnLabel, data)
-            data.addInfo(stackElement)
         }
     }
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -33,7 +33,6 @@ import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.symbols.IrSymbol
 import org.jetbrains.kotlin.ir.types.IrType
-import org.jetbrains.kotlin.ir.types.isMarkedNullable
 import org.jetbrains.kotlin.ir.types.toKotlinType
 import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.ir.visitors.IrElementVisitor
@@ -58,7 +57,7 @@ import org.jetbrains.org.objectweb.asm.Type
 import org.jetbrains.org.objectweb.asm.commons.InstructionAdapter
 import java.util.*
 
-sealed class ExpressionInfo()
+sealed class ExpressionInfo
 
 class LoopInfo(val loop: IrLoop, val continueLabel: Label, val breakLabel: Label) : ExpressionInfo()
 
@@ -104,26 +103,30 @@ class BlockInfo private constructor(val parent: BlockInfo?) {
 
 class VariableInfo(val declaration: IrVariable, val index: Int, val type: Type, val startLabel: Label)
 
-@Suppress("IMPLICIT_CAST_TO_ANY")
 class ExpressionCodegen(
-    val irFunction: IrFunction,
-    val frame: IrFrameMap,
+    private val irFunction: IrFunction,
+    private val frame: IrFrameMap,
     val mv: InstructionAdapter,
     val classCodegen: ClassCodegen
 ) : IrElementVisitor<StackValue, BlockInfo>, BaseExpressionCodegen {
 
-    /*TODO*/
-    val intrinsics = IrIntrinsicMethods(classCodegen.context.irBuiltIns)
+    private val intrinsics = IrIntrinsicMethods(classCodegen.context.irBuiltIns)
 
     val typeMapper = classCodegen.typeMapper
 
-    val returnType = typeMapper.mapReturnType(irFunction.descriptor)
+    private val state = classCodegen.state
 
-    val state = classCodegen.state
+    private val fileEntry = classCodegen.context.psiSourceManager.getFileEntry(irFunction.fileParent)
 
-    private val sourceManager = classCodegen.context.psiSourceManager
+    override val frameMap: IrFrameMap
+        get() = frame
 
-    private val fileEntry = sourceManager.getFileEntry(irFunction.fileParent)
+    override val visitor: InstructionAdapter
+        get() = mv
+
+    override val inlineNameGenerator: NameGenerator = NameGenerator("${classCodegen.type.internalName}\$todo") // TODO
+
+    override var lastLineNumber: Int = -1
 
     private val KotlinType.asmType: Type
         get() = typeMapper.mapType(this)
@@ -170,6 +173,15 @@ class ExpressionCodegen(
             lastLineNumber = lineNumber
             mv.visitLineNumber(lineNumber, markNewLabel())
         }
+    }
+
+    fun gen(expression: IrElement, type: Type, data: BlockInfo): StackValue {
+        gen(expression, data).put(type, mv)
+        return onStack(type)
+    }
+
+    fun gen(expression: IrElement, data: BlockInfo): StackValue {
+        return expression.accept(this, data)
     }
 
     fun generate() {
@@ -304,9 +316,7 @@ class ExpressionCodegen(
         return expression.onStack
     }
 
-    fun generateNewArray(
-        expression: IrCall, data: BlockInfo
-    ): StackValue {
+    private fun generateNewArray(expression: IrCall, data: BlockInfo): StackValue {
         val args = expression.descriptor.valueParameters
         assert(args.size == 1 || args.size == 2) { "Unknown constructor called: " + args.size + " arguments" }
 
@@ -410,10 +420,6 @@ class ExpressionCodegen(
         return coerceNotToUnit(callable.returnType, returnType, expression.type.toKotlinType())
     }
 
-    override fun visitInstanceInitializerCall(expression: IrInstanceInitializerCall, data: BlockInfo): StackValue {
-        throw AssertionError("Instruction should've been lowered before code generation: ${expression.render()}")
-    }
-
     override fun visitDelegatingConstructorCall(expression: IrDelegatingConstructorCall, data: BlockInfo): StackValue {
         //HACK
         StackValue.local(0, OBJECT_TYPE).put(OBJECT_TYPE, mv)
@@ -431,24 +437,8 @@ class ExpressionCodegen(
             this.markLineNumber(startOffset = true)
         }
 
-        val info = VariableInfo(
-            declaration,
-            index,
-            varType,
-            markNewLabel()
-        )
-        data.variables.add(info)
-
+        data.variables.add(VariableInfo(declaration, index, varType, markNewLabel()))
         return none()
-    }
-
-    fun gen(expression: IrElement, type: Type, data: BlockInfo): StackValue {
-        gen(expression, data).put(type, mv)
-        return onStack(type)
-    }
-
-    fun gen(expression: IrElement, data: BlockInfo): StackValue {
-        return expression.accept(this, data)
     }
 
     override fun visitGetValue(expression: IrGetValue, data: BlockInfo): StackValue {
@@ -499,7 +489,6 @@ class ExpressionCodegen(
         return onStack(AsmTypes.UNIT_TYPE)
     }
 
-
     /**
      * Returns true if the given constant value is the JVM's default value for the given type.
      * See: https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-2.html#jvms-2.3
@@ -522,17 +511,15 @@ class ExpressionCodegen(
     }
 
     private fun findLocalIndex(irSymbol: IrSymbol): Int {
-        return frame.getIndex(irSymbol).apply {
-            if (this < 0) {
-                if (irFunction.dispatchReceiverParameter != null) {
-                    (irFunction.parent as? IrClass)?.takeIf { it.thisReceiver?.symbol == irSymbol }?.let { return 0 }
-                }
-                throw AssertionError(
-                    "Non-mapped local declaration: " +
-                            "${if (irSymbol.isBound) irSymbol.owner.dump() else irSymbol.descriptor} \n in ${irFunction.dump()}"
-                )
-            }
+        val index = frame.getIndex(irSymbol)
+        if (index >= 0) {
+            return index
         }
+        if (irFunction.dispatchReceiverParameter != null && (irFunction.parent as? IrClass)?.thisReceiver?.symbol == irSymbol) {
+            return 0
+        }
+        val dump = if (irSymbol.isBound) irSymbol.owner.dump() else irSymbol.descriptor.toString()
+        throw AssertionError("Non-mapped local declaration: $dump\n in ${irFunction.dump()}")
     }
 
     override fun visitSetVariable(expression: IrSetVariable, data: BlockInfo): StackValue {
@@ -548,9 +535,7 @@ class ExpressionCodegen(
 
     override fun <T> visitConst(expression: IrConst<T>, data: BlockInfo): StackValue {
         expression.markLineNumber(startOffset = true)
-        val value = expression.value
-        val type = expression.asmType
-        StackValue.constant(value, type).put(mv)
+        StackValue.constant(expression.value, expression.asmType).put(mv)
         return expression.onStack
     }
 
@@ -673,6 +658,7 @@ class ExpressionCodegen(
     }
 
     override fun visitReturn(expression: IrReturn, data: BlockInfo): StackValue {
+        val returnType = typeMapper.mapReturnType(irFunction.descriptor)
         val afterReturnLabel = Label()
         gen(expression.value, returnType, data)
         unwindBlockStack(afterReturnLabel, data, null)
@@ -689,12 +675,11 @@ class ExpressionCodegen(
 
         val type = expression.type.toKotlinType()
         val endLabel = Label()
-        var exhaustive = false
         for (branch in expression.branches) {
             val elseLabel = Label()
             if (branch.condition.isFalseConst() || branch.condition.isTrueConst()) {
-                // True or false conditions known at compile time need not be generated. A linenumber and nop are still required
-                // for a debugger to break on the line of the condition.
+                // True or false conditions known at compile time need not be generated. A linenumber and nop
+                // are still required for a debugger to break on the line of the condition.
                 if (branch !is IrElseBranch) {
                     branch.condition.markLineNumber(startOffset = true)
                     mv.nop()
@@ -704,27 +689,20 @@ class ExpressionCodegen(
             } else {
                 genConditionalJumpWithOptimizationsIfPossible(branch.condition, data, elseLabel)
             }
-            gen(branch.result, data).let {
-                coerceNotToUnit(it.type, it.kotlinType, type)
-            }
+            val result = gen(branch.result, data).coerce(type)
             if (branch.condition.isTrueConst()) {
-                exhaustive = true
-                break // The rest of the expression is dead code.
+                // The rest of the expression is dead code.
+                mv.mark(endLabel)
+                return result
             }
             mv.goTo(endLabel)
             mv.mark(elseLabel)
         }
-
-        if (!exhaustive) {
-            // TODO: make all non-exhaustive `if`/`when` return Nothing.
-            if (type.isUnit())
-                putUnitInstance(mv)
-            else if (!type.isNothing())
-                throw AssertionError("non-exhaustive `if`/`when` wants to return $type")
-        }
-
+        // Produce the default value for the type. Doesn't really matter right now, as non-exhaustive
+        // conditionals cannot be used as expressions.
+        val result = none().coerce(type)
         mv.mark(endLabel)
-        return if (type.isNothing()) none() else expression.onStack
+        return result
     }
 
     private fun genConditionalJumpWithOptimizationsIfPossible(
@@ -746,12 +724,13 @@ class ExpressionCodegen(
 
         // Do not materialize null constants to check for null. Instead use the JVM bytecode
         // ifnull and ifnonnull instructions.
-        if (isNullCheck(condition)) {
-            val call = condition as IrCall
-            val left = call.getValueArgument(0)!!
-            val right = call.getValueArgument(1)!!
-            val other = if (left.isNullConst()) right else left
-            gen(other, data).put(other.asmType, mv)
+        if (condition is IrCall
+            && condition.symbol == classCodegen.context.irBuiltIns.eqeqSymbol
+            && (condition.getValueArgument(0)!!.isNullConst() || condition.getValueArgument(1)!!.isNullConst())
+        ) {
+            val left = condition.getValueArgument(0)!!
+            val right = condition.getValueArgument(1)!!
+            gen(if (left.isNullConst()) right else left, data)
             if (jumpIfFalse) {
                 mv.ifnonnull(jumpToLabel)
             } else {
@@ -782,23 +761,14 @@ class ExpressionCodegen(
             gen(condition.argument, OBJECT_TYPE, data)
             val type = boxType(asmType)
             generateIsCheck(mv, condition.typeOperand.toKotlinType(), type, state.languageVersionSettings.isReleaseCoroutines())
-            val stackValue =
-                if (condition.operator == IrTypeOperator.INSTANCEOF)
-                    onStack(Type.BOOLEAN_TYPE)
-                else
-                    StackValue.not(onStack(Type.BOOLEAN_TYPE))
-            BranchedValue.condJump(stackValue, jumpToLabel, jumpIfFalse, mv)
+            if (condition.operator == IrTypeOperator.NOT_INSTANCEOF) {
+                jumpIfFalse = !jumpIfFalse
+            }
+            BranchedValue.condJump(onStack(Type.BOOLEAN_TYPE), jumpToLabel, jumpIfFalse, mv)
             return
         }
 
-        gen(condition, data).put(condition.asmType, mv)
-        BranchedValue.condJump(onStack(condition.asmType), jumpToLabel, jumpIfFalse, mv)
-    }
-
-    private fun isNullCheck(expression: IrExpression): Boolean {
-        return expression is IrCall
-                && expression.symbol == classCodegen.context.irBuiltIns.eqeqSymbol
-                && (expression.getValueArgument(0)!!.isNullConst() || expression.getValueArgument(1)!!.isNullConst())
+        BranchedValue.condJump(gen(condition, data), jumpToLabel, jumpIfFalse, mv)
     }
 
     override fun visitTypeOperator(expression: IrTypeOperatorCall, data: BlockInfo): StackValue {
@@ -1161,7 +1131,7 @@ class ExpressionCodegen(
         }
     }
 
-    internal fun getOrCreateCallGenerator(
+    private fun getOrCreateCallGenerator(
         memberAccessExpression: IrMemberAccessExpression,
         descriptor: CallableDescriptor
     ): IrCallGenerator {
@@ -1199,14 +1169,6 @@ class ExpressionCodegen(
 
         return getOrCreateCallGenerator(descriptor, memberAccessExpression, mappings, false)
     }
-
-    override val frameMap: IrFrameMap
-        get() = frame
-    override val visitor: InstructionAdapter
-        get() = mv
-    override val inlineNameGenerator: NameGenerator = NameGenerator("${classCodegen.type.internalName}\$todo")
-
-    override var lastLineNumber: Int = -1
 
     override fun consumeReifiedOperationMarker(typeParameterDescriptor: TypeParameterDescriptor) {
         //TODO

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -6,10 +6,8 @@
 package org.jetbrains.kotlin.backend.jvm.codegen
 
 import org.jetbrains.kotlin.backend.jvm.JvmLoweredDeclarationOrigin
-import org.jetbrains.kotlin.backend.jvm.intrinsics.IrIntrinsicFunction
 import org.jetbrains.kotlin.backend.jvm.intrinsics.IrIntrinsicMethods
 import org.jetbrains.kotlin.backend.jvm.lower.CrIrType
-import org.jetbrains.kotlin.backend.jvm.lower.JvmBuiltinOptimizationLowering.Companion.isNegation
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.codegen.*
 import org.jetbrains.kotlin.codegen.AsmUtil.*
@@ -111,6 +109,8 @@ class ExpressionCodegen(
     private val intrinsics = IrIntrinsicMethods(classCodegen.context.irBuiltIns)
 
     val typeMapper = classCodegen.typeMapper
+
+    val context = classCodegen.context
 
     private val state = classCodegen.state
 
@@ -304,7 +304,7 @@ class ExpressionCodegen(
         return visitStatementContainer(expression, data).coerce(expression.type)
     }
 
-    override fun visitMemberAccess(expression: IrMemberAccessExpression, data: BlockInfo): StackValue {
+    override fun visitFunctionAccess(expression: IrFunctionAccessExpression, data: BlockInfo): StackValue {
         expression.markLineNumber(startOffset = true)
         return generateCall(expression, null, data)
     }
@@ -343,14 +343,12 @@ class ExpressionCodegen(
         return generateCall(expression, expression.superQualifier, data)
     }
 
-    private fun generateCall(expression: IrMemberAccessExpression, superQualifier: ClassDescriptor?, data: BlockInfo): StackValue {
+    private fun generateCall(expression: IrFunctionAccessExpression, superQualifier: ClassDescriptor?, data: BlockInfo): StackValue {
+        intrinsics.getIntrinsic(expression.descriptor.original as CallableMemberDescriptor)
+            ?.invoke(expression, this, data)?.let { return it }
         val isSuperCall = superQualifier != null
         val callable = resolveToCallable(expression, isSuperCall)
-        return if (callable is IrIntrinsicFunction) {
-            callable.invoke(mv, this, data)
-        } else {
-            generateCall(expression, callable, data, isSuperCall)
-        }
+        return generateCall(expression, callable, data, isSuperCall)
     }
 
     fun generateCall(expression: IrMemberAccessExpression, callable: Callable, data: BlockInfo, isSuperCall: Boolean = false): StackValue {
@@ -1004,15 +1002,6 @@ class ExpressionCodegen(
     }
 
     private fun resolveToCallable(irCall: IrMemberAccessExpression, isSuper: Boolean): Callable {
-        val intrinsic = intrinsics.getIntrinsic(irCall.descriptor.original as CallableMemberDescriptor)
-        if (intrinsic != null) {
-            return intrinsic.toCallable(
-                irCall,
-                typeMapper.mapSignatureSkipGeneric(irCall.descriptor as FunctionDescriptor),
-                classCodegen.context
-            )
-        }
-
         var descriptor = irCall.descriptor
         if (descriptor is TypeAliasConstructorDescriptor) {
             //TODO where is best to unwrap?

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -12,7 +12,6 @@ import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.codegen.*
 import org.jetbrains.kotlin.codegen.AsmUtil.*
 import org.jetbrains.kotlin.codegen.ExpressionCodegen.putReifiedOperationMarkerIfTypeIsReifiedParameter
-import org.jetbrains.kotlin.codegen.StackValue.*
 import org.jetbrains.kotlin.codegen.inline.NameGenerator
 import org.jetbrains.kotlin.codegen.inline.ReifiedTypeInliner
 import org.jetbrains.kotlin.codegen.inline.ReifiedTypeParametersUsages
@@ -147,7 +146,7 @@ class ExpressionCodegen(
     // idempotent and must always be done before generating other values or emitting raw bytecode.
     internal fun StackValue.materialize(): StackValue {
         put(type, kotlinType, mv)
-        return onStack(type, kotlinType)
+        return StackValue.onStack(type, kotlinType)
     }
 
     // Same as above, but if the type is Unit, do not materialize the actual push of a constant value.
@@ -291,7 +290,7 @@ class ExpressionCodegen(
     }
 
     private fun visitStatementContainer(container: IrStatementContainer, data: BlockInfo): StackValue =
-        container.statements.fold(none()) { prev, exp ->
+        container.statements.fold(StackValue.none()) { prev, exp ->
             prev.discard()
             exp.accept(this, data).also { (exp as? IrExpression)?.markEndOfStatementIfNeeded() }
         }
@@ -425,10 +424,10 @@ class ExpressionCodegen(
             mv.athrow()
             return expression.onStack
         } else if (expression.descriptor is ConstructorDescriptor) {
-            return none()
+            return StackValue.none()
         }
 
-        return onStack(callable.returnType, returnType).coerce(expression.type)
+        return StackValue.onStack(callable.returnType, returnType).coerce(expression.type)
     }
 
     override fun visitDelegatingConstructorCall(expression: IrDelegatingConstructorCall, data: BlockInfo): StackValue {
@@ -449,7 +448,7 @@ class ExpressionCodegen(
         }
 
         data.variables.add(VariableInfo(declaration, index, varType, markNewLabel()))
-        return none()
+        return StackValue.none()
     }
 
     override fun visitGetValue(expression: IrGetValue, data: BlockInfo): StackValue {
@@ -492,7 +491,7 @@ class ExpressionCodegen(
             expression.markLineNumber(startOffset = true)
             generateFieldValue(expression, data, true).store(expressionValue.accept(this, data), mv)
         }
-        return none().coerce(expression.type)
+        return StackValue.none().coerce(expression.type)
     }
 
     /**
@@ -527,7 +526,7 @@ class ExpressionCodegen(
         expression.value.markLineNumber(startOffset = true)
         val value = expression.value.accept(this, data)
         StackValue.local(findLocalIndex(expression.symbol), expression.descriptor.asmType).store(value, mv)
-        return none().coerce(expression.type)
+        return StackValue.none().coerce(expression.type)
     }
 
     override fun <T> visitConst(expression: IrConst<T>, data: BlockInfo): StackValue {
@@ -549,7 +548,7 @@ class ExpressionCodegen(
     // TODO maybe remove?
     override fun visitClass(declaration: IrClass, data: BlockInfo): StackValue {
         classCodegen.generateLocalClass(declaration)
-        return none()
+        return StackValue.none()
     }
 
     override fun visitVararg(expression: IrVararg, data: BlockInfo): StackValue {
@@ -657,7 +656,7 @@ class ExpressionCodegen(
         mv.areturn(returnType)
         mv.mark(afterReturnLabel)
         mv.nop()/*TODO check RESTORE_STACK_IN_TRY_CATCH processor*/
-        return none()
+        return StackValue.none()
     }
 
     override fun visitWhen(expression: IrWhen, data: BlockInfo): StackValue {
@@ -690,7 +689,7 @@ class ExpressionCodegen(
         }
         // Produce the default value for the type. Doesn't really matter right now, as non-exhaustive
         // conditionals cannot be used as expressions.
-        val result = none().coerce(expression.type).materializeNonUnit()
+        val result = StackValue.none().coerce(expression.type).materializeNonUnit()
         mv.mark(endLabel)
         return result
     }
@@ -715,7 +714,7 @@ class ExpressionCodegen(
                     mv, expression.typeOperand.toKotlinType(), boxedType, expression.operator == IrTypeOperator.SAFE_CAST,
                     state.languageVersionSettings.isReleaseCoroutines()
                 )
-                onStack(boxedType).coerce(expression.type)
+                StackValue.onStack(boxedType).coerce(expression.type)
             }
 
             IrTypeOperator.INSTANCEOF, IrTypeOperator.NOT_INSTANCEOF -> {
@@ -842,7 +841,7 @@ class ExpressionCodegen(
             ?: throw AssertionError("Target label for break/continue not found")
         mv.fixStackAndJump(if (jump is IrBreak) stackElement.breakLabel else stackElement.continueLabel)
         mv.mark(endLabel)
-        return none()
+        return StackValue.none()
     }
 
     override fun visitDoWhileLoop(loop: IrDoWhileLoop, data: BlockInfo): StackValue {
@@ -953,7 +952,7 @@ class ExpressionCodegen(
         expression.markLineNumber(startOffset = true)
         expression.value.accept(this, data).coerce(AsmTypes.JAVA_THROWABLE_TYPE).materialize()
         mv.athrow()
-        return none()
+        return StackValue.none()
     }
 
     override fun visitGetClass(expression: IrGetClass, data: BlockInfo): StackValue {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -535,14 +535,6 @@ class ExpressionCodegen(
         }
     }
 
-    override fun visitGetObjectValue(expression: IrGetObjectValue, data: BlockInfo): StackValue {
-        throw AssertionError("Instruction should've been lowered before code generation: ${expression.render()}")
-    }
-
-    override fun visitGetEnumValue(expression: IrGetEnumValue, data: BlockInfo): StackValue {
-        throw AssertionError("Instruction should've been lowered before code generation: ${expression.render()}")
-    }
-
     override fun visitSetVariable(expression: IrSetVariable, data: BlockInfo): StackValue {
         expression.markLineNumber(startOffset = true)
         expression.value.markLineNumber(startOffset = true)
@@ -567,7 +559,10 @@ class ExpressionCodegen(
     }
 
     override fun visitElement(element: IrElement, data: BlockInfo): StackValue {
-        TODO("not implemented for $element") //To change body of created functions use File | Settings | File Templates.
+        throw AssertionError(
+            "Unexpected IR element found during code generation. Either code generation for it " +
+                    "is not implemented, or it should have been lowered: ${element.render()}"
+        )
     }
 
     override fun visitClass(declaration: IrClass, data: BlockInfo): StackValue {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlin.backend.jvm.codegen
 
 import org.jetbrains.kotlin.backend.jvm.JvmLoweredDeclarationOrigin
-import org.jetbrains.kotlin.backend.jvm.intrinsics.ComparisonIntrinsic
 import org.jetbrains.kotlin.backend.jvm.intrinsics.IrIntrinsicFunction
 import org.jetbrains.kotlin.backend.jvm.intrinsics.IrIntrinsicMethods
 import org.jetbrains.kotlin.backend.jvm.lower.CrIrType
@@ -713,53 +712,6 @@ class ExpressionCodegen(
         if (isNegation(condition, classCodegen.context)) {
             condition = (condition as IrCall).dispatchReceiver!!
             jumpIfFalse = !jumpIfFalse
-        }
-
-        // Do not materialize null constants to check for null. Instead use the JVM bytecode
-        // ifnull and ifnonnull instructions.
-        if (condition is IrCall
-            && condition.symbol == classCodegen.context.irBuiltIns.eqeqSymbol
-            && (condition.getValueArgument(0)!!.isNullConst() || condition.getValueArgument(1)!!.isNullConst())
-        ) {
-            val left = condition.getValueArgument(0)!!
-            val right = condition.getValueArgument(1)!!
-            (if (left.isNullConst()) right else left).accept(this, data).materialize()
-            if (jumpIfFalse) {
-                mv.ifnonnull(jumpToLabel)
-            } else {
-                mv.ifnull(jumpToLabel)
-            }
-            return
-        }
-
-        // For comparison intrinsics, branch directly based on the comparison instead of
-        // materializing a boolean and performing and extra jump.
-        if (condition is IrCall) {
-            val intrinsic = intrinsics.getIntrinsic(condition.descriptor.original as CallableMemberDescriptor)
-            if (intrinsic is ComparisonIntrinsic) {
-                val callable = resolveToCallable(condition, false)
-                (callable as IrIntrinsicFunction).loadArguments(this, data)
-                val stackValue = intrinsic.genStackValue(condition, classCodegen.context)
-                BranchedValue.condJump(stackValue, jumpToLabel, jumpIfFalse, mv)
-                return
-            }
-        }
-
-        // For instance of type operators, branch directly on the instanceof result instead
-        // of materializing a boolean and performing an extra jump.
-        // TODO after redundant materialization is removed, this will be unnecessary
-        if (condition is IrTypeOperatorCall &&
-            (condition.operator == IrTypeOperator.NOT_INSTANCEOF || condition.operator == IrTypeOperator.INSTANCEOF)
-        ) {
-            val asmType = condition.typeOperand.toKotlinType().asmType
-            condition.argument.accept(this, data).coerce(AsmTypes.OBJECT_TYPE).materialize()
-            val type = boxType(asmType)
-            generateIsCheck(mv, condition.typeOperand.toKotlinType(), type, state.languageVersionSettings.isReleaseCoroutines())
-            if (condition.operator == IrTypeOperator.NOT_INSTANCEOF) {
-                jumpIfFalse = !jumpIfFalse
-            }
-            BranchedValue.condJump(onStack(Type.BOOLEAN_TYPE), jumpToLabel, jumpIfFalse, mv)
-            return
         }
 
         BranchedValue.condJump(condition.accept(this, data), jumpToLabel, jumpIfFalse, mv)

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -58,12 +58,14 @@ import org.jetbrains.org.objectweb.asm.Type
 import org.jetbrains.org.objectweb.asm.commons.InstructionAdapter
 import java.util.*
 
-open class ExpressionInfo(val expression: IrExpression)
+sealed class ExpressionInfo()
 
-class LoopInfo(val loop: IrLoop, val continueLabel: Label, val breakLabel: Label) : ExpressionInfo(loop)
+class LoopInfo(val loop: IrLoop, val continueLabel: Label, val breakLabel: Label) : ExpressionInfo()
 
-class TryInfo(val tryBlock: IrTry) : ExpressionInfo(tryBlock) {
-    val gaps = mutableListOf<Label>()
+class TryInfo(val onExit: IrExpression) : ExpressionInfo() {
+    // Regions corresponding to copy-pasted contents of the `finally` block.
+    // These should not be covered by `catch` clauses.
+    val gaps = mutableListOf<Pair<Label, Label>>()
 }
 
 class BlockInfo private constructor(val parent: BlockInfo?) {
@@ -74,7 +76,7 @@ class BlockInfo private constructor(val parent: BlockInfo?) {
         this@apply.infos.addAll(this@BlockInfo.infos)
     }
 
-    inline fun <R> withBlock(info: ExpressionInfo, f: (ExpressionInfo) -> R): R {
+    inline fun <T : ExpressionInfo, R> withBlock(info: T, f: (T) -> R): R {
         infos.add(info)
         try {
             return f(info)
@@ -995,7 +997,7 @@ class ExpressionCodegen(
     override fun visitTry(aTry: IrTry, data: BlockInfo): StackValue {
         aTry.markLineNumber(startOffset = true)
         return if (aTry.finallyExpression != null)
-            data.withBlock(TryInfo(aTry)) { visitTryWithInfo(aTry, data, it as TryInfo) }
+            data.withBlock(TryInfo(aTry.finallyExpression!!)) { visitTryWithInfo(aTry, data, it) }
         else
             visitTryWithInfo(aTry, data, null)
     }
@@ -1005,9 +1007,7 @@ class ExpressionCodegen(
         mv.nop()
         gen(aTry.tryResult, aTry.asmType, data)
         val tryBlockEnd = markNewLabel()
-
-        val tryRegions = getCurrentTryIntervals(tryInfo, tryBlockStart, tryBlockEnd)
-
+        val tryBlockGaps = tryInfo?.gaps?.toList() ?: listOf()
         val tryCatchBlockEnd = Label()
         if (tryInfo != null) {
             data.handleBlock { genFinallyBlock(tryInfo, tryCatchBlockEnd, null, data) }
@@ -1042,67 +1042,50 @@ class ExpressionCodegen(
                 mv.goTo(tryCatchBlockEnd)
             }
 
-            generateExceptionTable(clauseStart, tryRegions, descriptorType.internalName)
+            genTryCatchCover(clauseStart, tryBlockStart, tryBlockEnd, tryBlockGaps, descriptorType.internalName)
         }
 
-        //for default catch clause
         if (tryInfo != null) {
+            // Generate `try { ... } catch (e: Any?) { <finally>; throw e }` around every part of
+            // the try-catch that is not a copy-pasted `finally` block.
             val defaultCatchStart = markNewLabel()
+            // While keeping this value on the stack should be enough, the bytecode validator will
+            // complain if a catch block does not start with ASTORE.
             val savedException = frame.enterTemp(JAVA_THROWABLE_TYPE)
             mv.store(savedException, JAVA_THROWABLE_TYPE)
-            val defaultCatchEnd = markNewLabel()
 
-            //do it before finally block generation
-            //javac also generates entry in exception table for default catch clause too!!!! so defaultCatchEnd as end parameter
-            val defaultCatchRegions = getCurrentTryIntervals(tryInfo, tryBlockStart, defaultCatchEnd)
-
-            data.handleBlock { genFinallyBlock(tryInfo, null, null, data) }
-
+            val finallyStart = markNewLabel()
+            // Nothing will cover anything after this point, so don't bother recording the gap here.
+            data.handleBlock { gen(aTry.finallyExpression!!, data).discard() }
             mv.load(savedException, JAVA_THROWABLE_TYPE)
             frame.leaveTemp(JAVA_THROWABLE_TYPE)
-
             mv.athrow()
 
-            generateExceptionTable(defaultCatchStart, defaultCatchRegions, null)
+            // Include the ASTORE into the covered region. That's what javac does as well.
+            genTryCatchCover(defaultCatchStart, tryBlockStart, finallyStart, tryInfo.gaps, null)
         }
 
         mv.mark(tryCatchBlockEnd)
+        // TODO: generate a common `finally` for try & catch blocks here? Right now this breaks the inliner.
         return aTry.onStack
     }
 
-    private fun getCurrentTryIntervals(
-        finallyBlockStackElement: TryInfo?,
-        blockStart: Label,
-        blockEnd: Label
-    ): List<Label> {
-        val gapsInBlock = if (finallyBlockStackElement != null) ArrayList<Label>(finallyBlockStackElement.gaps) else emptyList<Label>()
-        assert(gapsInBlock.size % 2 == 0)
-        val blockRegions = ArrayList<Label>(gapsInBlock.size + 2)
-        blockRegions.add(blockStart)
-        blockRegions.addAll(gapsInBlock)
-        blockRegions.add(blockEnd)
-        return blockRegions
-    }
-
-    private fun generateExceptionTable(catchStart: Label, catchedRegions: List<Label>, exception: String?) {
-        var i = 0
-        while (i < catchedRegions.size) {
-            val startRegion = catchedRegions[i]
-            val endRegion = catchedRegions[i + 1]
-            mv.visitTryCatchBlock(startRegion, endRegion, catchStart, exception)
-            i += 2
+    private fun genTryCatchCover(catchStart: Label, tryStart: Label, tryEnd: Label, tryGaps: List<Pair<Label, Label>>, type: String?) {
+        val lastRegionStart = tryGaps.fold(tryStart) { regionStart, (gapStart, gapEnd) ->
+            mv.visitTryCatchBlock(regionStart, gapStart, catchStart, type)
+            gapEnd
         }
+        mv.visitTryCatchBlock(lastRegionStart, tryEnd, catchStart, type)
     }
 
     private fun genFinallyBlock(tryInfo: TryInfo, tryCatchBlockEnd: Label?, afterJumpLabel: Label?, data: BlockInfo) {
-        assert(tryInfo.gaps.size % 2 == 0) { "Finally block gaps are inconsistent" }
-        tryInfo.gaps.add(markNewLabel())
-        gen(tryInfo.tryBlock.finallyExpression!!, data).discard()
+        val gapStart = markNewLabel()
+        gen(tryInfo.onExit, data).discard()
         if (tryCatchBlockEnd != null) {
-            tryInfo.tryBlock.finallyExpression!!.markLineNumber(startOffset = false)
+            tryInfo.onExit.markLineNumber(startOffset = false)
             mv.goTo(tryCatchBlockEnd)
         }
-        tryInfo.gaps.add(afterJumpLabel ?: markNewLabel())
+        tryInfo.gaps.add(gapStart to (afterJumpLabel ?: markNewLabel()))
     }
 
     private fun generateFinallyBlocksIfNeeded(returnType: Type, afterReturnLabel: Label, data: BlockInfo) {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -487,7 +487,7 @@ class ExpressionCodegen(
         // i.e., not in an initializer block or constructor body.
         val skip = irFunction is IrConstructor && irFunction.isPrimary &&
                 expression.origin == null && expressionValue is IrConst<*> &&
-                isDefaultValueForType(expression.symbol.owner.type, expressionValue)
+                isDefaultValueForType(expression.symbol.owner.type.asmType, expressionValue.value)
         if (!skip) {
             expression.markLineNumber(startOffset = true)
             val fieldValue = generateFieldValue(expression, data)
@@ -504,32 +504,16 @@ class ExpressionCodegen(
      * Returns true if the given constant value is the JVM's default value for the given type.
      * See: https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-2.html#jvms-2.3
      */
-    private fun isDefaultValueForType(fieldType: IrType, constExpression: IrConst<*>): Boolean {
-        val value = constExpression.value
-        val type = constExpression.asmType
-        if (isPrimitive(type)) {
-            if (!fieldType.isMarkedNullable() && value is Number) {
-                if (type in setOf(Type.INT_TYPE, Type.BYTE_TYPE, Type.LONG_TYPE, Type.SHORT_TYPE) && value.toLong() == 0L) {
-                    return true
-                }
-                if (type === Type.DOUBLE_TYPE && value.toDouble().equals(0.0)) {
-                    return true
-                }
-                if (type === Type.FLOAT_TYPE && value.toFloat().equals(0.0f)) {
-                    return true
-                }
-            }
-            if (type === Type.BOOLEAN_TYPE && value is Boolean && !value) {
-                return true
-            }
-            if (type === Type.CHAR_TYPE && value is Char && value.toInt() == 0) {
-                return true
-            }
-        } else if (value == null) {
-            return true
+    private fun isDefaultValueForType(type: Type, value: Any?): Boolean =
+        when (type) {
+            Type.BOOLEAN_TYPE -> value is Boolean && !value
+            Type.CHAR_TYPE -> value is Char && value.toInt() == 0
+            Type.BYTE_TYPE, Type.SHORT_TYPE, Type.INT_TYPE, Type.LONG_TYPE -> value is Number && value.toLong() == 0L
+            // Must use `equals` for these two to differentiate between +0.0 and -0.0:
+            Type.FLOAT_TYPE -> value is Number && value.toFloat().equals(0.0f)
+            Type.DOUBLE_TYPE -> value is Number && value.toDouble().equals(0.0)
+            else -> !isPrimitive(type) && value == null
         }
-        return false
-    }
 
     private fun generateLocal(symbol: IrSymbol, type: Type): StackValue {
         val index = findLocalIndex(symbol)

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -999,7 +999,11 @@ class ExpressionCodegen(
         val tryRegions = getCurrentTryIntervals(tryInfo, tryBlockStart, tryBlockEnd)
 
         val tryCatchBlockEnd = Label()
-        genFinallyBlockOrGoto(tryInfo, tryCatchBlockEnd, null, data)
+        if (tryInfo != null) {
+            data.handleBlock { genFinallyBlock(tryInfo, tryCatchBlockEnd, null, data) }
+        } else {
+            mv.goTo(tryCatchBlockEnd)
+        }
 
         val catches = aTry.catches
         for (clause in catches) {
@@ -1022,31 +1026,27 @@ class ExpressionCodegen(
                 index
             )
 
-            genFinallyBlockOrGoto(
-                tryInfo,
-                if (clause != catches.last() || aTry.finallyExpression != null) tryCatchBlockEnd else null,
-                null,
-                data
-            )
+            if (tryInfo != null) {
+                data.handleBlock { genFinallyBlock(tryInfo, tryCatchBlockEnd, null, data) }
+            } else if (clause != catches.last()) {
+                mv.goTo(tryCatchBlockEnd)
+            }
 
             generateExceptionTable(clauseStart, tryRegions, descriptorType.internalName)
         }
 
         //for default catch clause
-        if (aTry.finallyExpression != null) {
-            val defaultCatchStart = Label()
-            mv.mark(defaultCatchStart)
+        if (tryInfo != null) {
+            val defaultCatchStart = markNewLabel()
             val savedException = frame.enterTemp(JAVA_THROWABLE_TYPE)
             mv.store(savedException, JAVA_THROWABLE_TYPE)
-
-            val defaultCatchEnd = Label()
-            mv.mark(defaultCatchEnd)
+            val defaultCatchEnd = markNewLabel()
 
             //do it before finally block generation
             //javac also generates entry in exception table for default catch clause too!!!! so defaultCatchEnd as end parameter
             val defaultCatchRegions = getCurrentTryIntervals(tryInfo, tryBlockStart, defaultCatchEnd)
 
-            genFinallyBlockOrGoto(tryInfo, null, null, data)
+            data.handleBlock { genFinallyBlock(tryInfo, null, null, data) }
 
             mv.load(savedException, JAVA_THROWABLE_TYPE)
             frame.leaveTemp(JAVA_THROWABLE_TYPE)
@@ -1081,14 +1081,6 @@ class ExpressionCodegen(
             val endRegion = catchedRegions[i + 1]
             mv.visitTryCatchBlock(startRegion, endRegion, catchStart, exception)
             i += 2
-        }
-    }
-
-    private fun genFinallyBlockOrGoto(tryInfo: TryInfo?, tryCatchBlockEnd: Label?, afterJumpLabel: Label?, data: BlockInfo) {
-        if (tryInfo != null) {
-            data.handleBlock { genFinallyBlock(tryInfo, tryCatchBlockEnd, afterJumpLabel, data) }
-        } else if (tryCatchBlockEnd != null) {
-            mv.goTo(tryCatchBlockEnd)
         }
     }
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -98,73 +98,6 @@ class BlockInfo private constructor(val parent: BlockInfo?) {
 
 class VariableInfo(val declaration: IrVariable, val index: Int, val type: Type, val startLabel: Label)
 
-// A value that may not have been fully constructed yet. The ability to "roll back" code generation
-// is useful for certain optimizations.
-abstract class PromisedValue(val codegen: ExpressionCodegen, val type: Type) {
-    // If this value is immaterial, construct an object on the top of the stack. This
-    // must always be done before generating other values or emitting raw bytecode.
-    abstract fun materialize()
-}
-
-// A value that *has* been fully constructed.
-class MaterialValue(codegen: ExpressionCodegen, type: Type) : PromisedValue(codegen, type) {
-    override fun materialize() {}
-}
-
-// A value that can be branched on. JVM has certain branching instructions which can be used
-// to optimize these.
-abstract class BooleanValue(codegen: ExpressionCodegen) : PromisedValue(codegen, Type.BOOLEAN_TYPE) {
-    abstract fun jumpIfFalse(target: Label)
-    abstract fun jumpIfTrue(target: Label)
-
-    override fun materialize() {
-        val const0 = Label()
-        val end = Label()
-        jumpIfFalse(const0)
-        codegen.mv.iconst(1)
-        codegen.mv.goTo(end)
-        codegen.mv.mark(const0)
-        codegen.mv.iconst(0)
-        codegen.mv.mark(end)
-    }
-}
-
-// Same as materialize(), but return a representation of the result.
-val PromisedValue.materialized: MaterialValue
-    get() {
-        materialize()
-        return MaterialValue(codegen, type)
-    }
-
-// Materialize and disregard this value. Materialization is forced because, presumably,
-// we only wanted the side effects anyway.
-fun PromisedValue.discard(): MaterialValue {
-    materialize()
-    if (type !== Type.VOID_TYPE)
-        AsmUtil.pop(codegen.mv, type)
-    return MaterialValue(codegen, Type.VOID_TYPE)
-}
-
-// On materialization, cast the value to a different type.
-fun PromisedValue.coerce(target: Type) = when (target) {
-    Type.VOID_TYPE -> discard()
-    type -> this
-    else -> object : PromisedValue(codegen, target) {
-        // TODO remove dependency
-        override fun materialize() = StackValue.coerce(this@coerce.materialized.type, type, codegen.mv)
-    }
-}
-
-// Same as above, but with a return type that allows conditional jumping.
-fun PromisedValue.coerceToBoolean() = when (val coerced = coerce(Type.BOOLEAN_TYPE)) {
-    is BooleanValue -> coerced
-    else -> object : BooleanValue(codegen) {
-        override fun jumpIfFalse(target: Label) = coerced.materialize().also { codegen.mv.ifeq(target) }
-        override fun jumpIfTrue(target: Label) = coerced.materialize().also { codegen.mv.ifne(target) }
-        override fun materialize() = coerced.materialize()
-    }
-}
-
 class ExpressionCodegen(
     private val irFunction: IrFunction,
     private val frame: IrFrameMap,
@@ -208,9 +141,6 @@ class ExpressionCodegen(
     // with the correct type.
     val IrExpression.onStack: MaterialValue
         get() = MaterialValue(this@ExpressionCodegen, asmType)
-
-    val voidValue: MaterialValue
-        get() = MaterialValue(this@ExpressionCodegen, Type.VOID_TYPE)
 
     private fun markNewLabel() = Label().apply { mv.visitLabel(this) }
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -41,7 +41,6 @@ import org.jetbrains.kotlin.resolve.DescriptorUtils.isEnumClass
 import org.jetbrains.kotlin.resolve.calls.components.hasDefaultValue
 import org.jetbrains.kotlin.resolve.inline.InlineUtil
 import org.jetbrains.kotlin.resolve.jvm.AsmTypes
-import org.jetbrains.kotlin.resolve.jvm.AsmTypes.JAVA_THROWABLE_TYPE
 import org.jetbrains.kotlin.resolve.jvm.AsmTypes.OBJECT_TYPE
 import org.jetbrains.kotlin.synthetic.SyntheticJavaPropertyDescriptor
 import org.jetbrains.kotlin.types.KotlinType
@@ -140,25 +139,44 @@ class ExpressionCodegen(
     private val IrExpression.asmType: Type
         get() = type.asmType
 
+    // Assume this expression's result has already been materialized on the stack
+    // with the correct type.
     val IrExpression.onStack: StackValue
         get() = StackValue.onStack(asmType, type.toKotlinType())
 
-    private fun StackValue.discard(): StackValue {
-        coerce(type, Type.VOID_TYPE, mv)
-        return none()
+    // If this value is immaterial, construct an object on the top of the stack. This operation is
+    // idempotent and must always be done before generating other values or emitting raw bytecode.
+    internal fun StackValue.materialize(): StackValue {
+        put(type, kotlinType, mv)
+        return onStack(type, kotlinType)
     }
+
+    // Same as above, but if the type is Unit, do not materialize the actual push of a constant value.
+    // This must be done before fan-in jumping to normalize the stack heights.
+    internal fun StackValue.materializeNonUnit(): StackValue =
+        if (kotlinType != null && kotlinType!!.isUnit())
+            discard().coerce(kotlinType!!)
+        else
+            materialize()
+
+    // Materialize and disregard this value. Materialization is forced because, presumably,
+    // we only wanted the side effects anyway.
+    internal fun StackValue.discard(): StackValue =
+        coerce(Type.VOID_TYPE).materialize()
+
+    // On materialization, cast the value to a different type.
+    private fun StackValue.coerce(targetType: Type): StackValue =
+        CoercionValue(this, targetType, null, null)
 
     private fun StackValue.coerce(toKotlinType: KotlinType): StackValue {
-        coerce(type, kotlinType, toKotlinType.asmType, toKotlinType, mv)
-        return onStack(toKotlinType.asmType, toKotlinType)
+        // Avoid the code in `StackValue` that attempts to CHECKCAST java.lang.Objects into Unit.
+        if (type != Type.VOID_TYPE && toKotlinType.isUnit())
+            return coerce(Type.VOID_TYPE).coerce(toKotlinType)
+        return CoercionValue(this, toKotlinType.asmType, toKotlinType, null)
     }
 
-    internal fun coerceNotToUnit(fromType: Type, fromKotlinType: KotlinType?, toKotlinType: KotlinType): StackValue {
-        // A void should still be materialized as a Unit to avoid stack depth mismatches.
-        if (toKotlinType.isUnit() && fromType != Type.VOID_TYPE)
-            return onStack(fromType, fromKotlinType)
-        return onStack(fromType, fromKotlinType).coerce(toKotlinType)
-    }
+    internal fun StackValue.coerce(toIrType: IrType): StackValue =
+        coerce(toIrType.toKotlinType())
 
     private fun markNewLabel() = Label().apply { mv.visitLabel(this) }
 
@@ -175,13 +193,14 @@ class ExpressionCodegen(
         }
     }
 
+    // TODO remove
     fun gen(expression: IrElement, type: Type, data: BlockInfo): StackValue {
-        gen(expression, data).put(type, mv)
-        return onStack(type)
+        return expression.accept(this, data).coerce(type).materialize()
     }
 
+    // TODO remove
     fun gen(expression: IrElement, data: BlockInfo): StackValue {
-        return expression.accept(this, data)
+        return expression.accept(this, data).materialize()
     }
 
     fun generate() {
@@ -189,18 +208,18 @@ class ExpressionCodegen(
         val startLabel = markNewLabel()
         val info = BlockInfo.create()
         val body = irFunction.body!!
-        val result = gen(body, info)
+        val result = body.accept(this, info)
         // If this function has an expression body, return the result of that expression.
         // Otherwise, if it does not end in a return statement, it must be void-returning,
         // and an explicit return instruction at the end is still required to pass validation.
         if (body !is IrStatementContainer || body.statements.lastOrNull() !is IrReturn) {
-            val returnType = typeMapper.mapReturnType(irFunction.descriptor)
             // Allow setting a breakpoint on the closing brace of a void-returning function
             // without an explicit return, or the `class Something(` line of a primary constructor.
             if (irFunction.origin != JvmLoweredDeclarationOrigin.CLASS_STATIC_INITIALIZER) {
                 irFunction.markLineNumber(startOffset = irFunction is IrConstructor && irFunction.isPrimary)
             }
-            coerce(result.type, returnType, mv)
+            val returnType = typeMapper.mapReturnType(irFunction.descriptor)
+            result.coerce(returnType).materialize()
             mv.areturn(returnType)
         }
         writeLocalVariablesInTable(info)
@@ -272,22 +291,18 @@ class ExpressionCodegen(
         }
     }
 
-    private fun visitStatementContainer(container: IrStatementContainer, data: BlockInfo): StackValue {
-        return container.statements.fold(none()) { prev, exp ->
+    private fun visitStatementContainer(container: IrStatementContainer, data: BlockInfo): StackValue =
+        container.statements.fold(none()) { prev, exp ->
             prev.discard()
-            gen(exp, data).also {
-                (exp as? IrExpression)?.markEndOfStatementIfNeeded()
-            }
+            exp.accept(this, data).also { (exp as? IrExpression)?.markEndOfStatementIfNeeded() }
         }
-    }
 
     override fun visitBlockBody(body: IrBlockBody, data: BlockInfo): StackValue {
         return visitStatementContainer(body, data).discard()
     }
 
     override fun visitContainerExpression(expression: IrContainerExpression, data: BlockInfo): StackValue {
-        val result = visitStatementContainer(expression, data)
-        return coerceNotToUnit(result.type, result.kotlinType, expression.type.toKotlinType())
+        return visitStatementContainer(expression, data).coerce(expression.type)
     }
 
     override fun visitMemberAccess(expression: IrMemberAccessExpression, data: BlockInfo): StackValue {
@@ -306,7 +321,6 @@ class ExpressionCodegen(
     private fun generateNewCall(expression: IrCall, data: BlockInfo): StackValue {
         val type = expression.asmType
         if (type.sort == Type.ARRAY) {
-            //noinspection ConstantConditions
             return generateNewArray(expression, data)
         }
 
@@ -321,8 +335,8 @@ class ExpressionCodegen(
         assert(args.size == 1 || args.size == 2) { "Unknown constructor called: " + args.size + " arguments" }
 
         if (args.size == 1) {
-            val sizeExpression = expression.getValueArgument(0)!!
-            gen(sizeExpression, Type.INT_TYPE, data)
+            // TODO move to the intrinsic
+            expression.getValueArgument(0)!!.accept(this, data).coerce(Type.INT_TYPE).materialize()
             newArrayInstruction(expression.type.toKotlinType())
             return expression.onStack
         }
@@ -409,7 +423,7 @@ class ExpressionCodegen(
         )
 
         val returnType = expression.descriptor.returnType
-        if (returnType != null && KotlinBuiltIns.isNothing(returnType)) {
+        if (returnType != null && returnType.isNothing()) {
             mv.aconst(null)
             mv.athrow()
             return expression.onStack
@@ -417,7 +431,7 @@ class ExpressionCodegen(
             return none()
         }
 
-        return coerceNotToUnit(callable.returnType, returnType, expression.type.toKotlinType())
+        return onStack(callable.returnType, returnType).coerce(expression.type)
     }
 
     override fun visitDelegatingConstructorCall(expression: IrDelegatingConstructorCall, data: BlockInfo): StackValue {
@@ -432,9 +446,9 @@ class ExpressionCodegen(
 
         declaration.markLineNumber(startOffset = true)
 
-        declaration.initializer?.apply {
-            StackValue.local(index, varType).store(gen(this, varType, data), mv)
-            this.markLineNumber(startOffset = true)
+        declaration.initializer?.let {
+            StackValue.local(index, varType).store(it.accept(this, data).coerce(varType), mv)
+            it.markLineNumber(startOffset = true)
         }
 
         data.variables.add(VariableInfo(declaration, index, varType, markNewLabel()))
@@ -446,11 +460,12 @@ class ExpressionCodegen(
         // temporary variables. They do not correspond to variable loads in user code.
         if (expression.symbol.owner.origin != IrDeclarationOrigin.IR_TEMPORARY_VARIABLE)
             expression.markLineNumber(startOffset = true)
-        return generateLocal(expression.symbol, expression.asmType)
+        return StackValue.local(findLocalIndex(expression.symbol), expression.asmType).coerce(expression.type)
     }
 
-    private fun generateFieldValue(expression: IrFieldAccessExpression, data: BlockInfo): StackValue {
+    private fun generateFieldValue(expression: IrFieldAccessExpression, data: BlockInfo, materialize: Boolean): StackValue {
         val receiverValue = expression.receiver?.accept(this, data) ?: StackValue.none()
+        val materialReceiver = if (materialize) receiverValue.materialize() else receiverValue
         val propertyDescriptor = expression.descriptor
 
         val realDescriptor = DescriptorUtils.unwrapFakeOverride(propertyDescriptor)
@@ -460,14 +475,12 @@ class ExpressionCodegen(
         val fieldName = propertyDescriptor.name.asString()
         val isStatic = expression.receiver == null // TODO
 
-        return StackValue.field(fieldType, fieldKotlinType, ownerType, fieldName, isStatic, receiverValue, realDescriptor)
+        return StackValue.field(fieldType, fieldKotlinType, ownerType, fieldName, isStatic, materialReceiver, realDescriptor)
     }
 
     override fun visitGetField(expression: IrGetField, data: BlockInfo): StackValue {
         expression.markLineNumber(startOffset = true)
-        val value = generateFieldValue(expression, data)
-        value.put(mv)
-        return onStack(value.type)
+        return generateFieldValue(expression, data, false).coerce(expression.type)
     }
 
     override fun visitSetField(expression: IrSetField, data: BlockInfo): StackValue {
@@ -480,13 +493,9 @@ class ExpressionCodegen(
                 isDefaultValueForType(expression.symbol.owner.type.asmType, expressionValue.value)
         if (!skip) {
             expression.markLineNumber(startOffset = true)
-            val fieldValue = generateFieldValue(expression, data)
-            fieldValue.store(expressionValue.accept(this, data), mv)
+            generateFieldValue(expression, data, true).store(expressionValue.accept(this, data), mv)
         }
-        // Assignments can be used as expressions, so return a value. Redundant pushes
-        // will be eliminated by the peephole optimizer.
-        putUnitInstance(mv)
-        return onStack(AsmTypes.UNIT_TYPE)
+        return none().coerce(expression.type)
     }
 
     /**
@@ -503,12 +512,6 @@ class ExpressionCodegen(
             Type.DOUBLE_TYPE -> value is Number && value.toDouble().equals(0.0)
             else -> !isPrimitive(type) && value == null
         }
-
-    private fun generateLocal(symbol: IrSymbol, type: Type): StackValue {
-        val index = findLocalIndex(symbol)
-        StackValue.local(index, type).put(mv)
-        return onStack(type)
-    }
 
     private fun findLocalIndex(irSymbol: IrSymbol): Int {
         val index = frame.getIndex(irSymbol)
@@ -527,16 +530,12 @@ class ExpressionCodegen(
         expression.value.markLineNumber(startOffset = true)
         val value = expression.value.accept(this, data)
         StackValue.local(findLocalIndex(expression.symbol), expression.descriptor.asmType).store(value, mv)
-        // Assignments can be used as expressions, so return a value. Redundant pushes
-        // will be eliminated by the peephole optimizer.
-        putUnitInstance(mv)
-        return onStack(AsmTypes.UNIT_TYPE)
+        return none().coerce(expression.type)
     }
 
     override fun <T> visitConst(expression: IrConst<T>, data: BlockInfo): StackValue {
         expression.markLineNumber(startOffset = true)
-        StackValue.constant(expression.value, expression.asmType).put(mv)
-        return expression.onStack
+        return StackValue.constant(expression.value, expression.asmType).coerce(expression.type)
     }
 
     override fun visitExpressionBody(body: IrExpressionBody, data: BlockInfo): StackValue {
@@ -550,6 +549,7 @@ class ExpressionCodegen(
         )
     }
 
+    // TODO maybe remove?
     override fun visitClass(declaration: IrClass, data: BlockInfo): StackValue {
         classCodegen.generateLocalClass(declaration)
         return none()
@@ -575,7 +575,7 @@ class ExpressionCodegen(
                     Type.getType("[Ljava/lang/Object;")
                 else
                     Type.getType("[" + elementType.descriptor)
-                gen(argument, type, data)
+                argument.accept(this, data).coerce(type).materialize()
                 mv.dup()
                 mv.arraylength()
                 mv.invokestatic("java/util/Arrays", "copyOf", Type.getMethodDescriptor(arrayType, arrayType, Type.INT_TYPE), false)
@@ -605,10 +605,10 @@ class ExpressionCodegen(
                     mv.dup()
                     val argument = arguments[i]
                     if (argument is IrSpreadElement) {
-                        gen(argument.expression, OBJECT_TYPE, data)
+                        argument.expression.accept(this, data).coerce(AsmTypes.OBJECT_TYPE).materialize()
                         mv.invokevirtual(owner, "addSpread", "(Ljava/lang/Object;)V", false)
                     } else {
-                        gen(argument, elementType, data)
+                        argument.accept(this, data).coerce(elementType).materialize()
                         mv.invokevirtual(owner, "add", addDescriptor, false)
                     }
                 }
@@ -628,16 +628,10 @@ class ExpressionCodegen(
             val elementKotlinType = classCodegen.context.builtIns.getArrayElementType(outType.toKotlinType())
             for ((i, element) in expression.elements.withIndex()) {
                 mv.dup()
-                StackValue.constant(i).put(mv)
-                val rightSide = gen(element, elementType, data)
-                StackValue
-                    .arrayElement(
-                        elementType,
-                        elementKotlinType,
-                        StackValue.onStack(elementType, outType.toKotlinType()),
-                        StackValue.onStack(Type.INT_TYPE)
-                    )
-                    .store(rightSide, mv)
+                val array = StackValue.onStack(elementType, outType.toKotlinType())
+                val index = StackValue.constant(i).materialize()
+                val value = element.accept(this, data).coerce(elementType).materialize()
+                StackValue.arrayElement(elementType, elementKotlinType, array, index).store(value, mv)
             }
         }
         return expression.onStack
@@ -660,7 +654,7 @@ class ExpressionCodegen(
     override fun visitReturn(expression: IrReturn, data: BlockInfo): StackValue {
         val returnType = typeMapper.mapReturnType(irFunction.descriptor)
         val afterReturnLabel = Label()
-        gen(expression.value, returnType, data)
+        expression.value.accept(this, data).coerce(returnType).materialize()
         unwindBlockStack(afterReturnLabel, data, null)
         expression.markLineNumber(startOffset = true)
         mv.areturn(returnType)
@@ -673,7 +667,6 @@ class ExpressionCodegen(
         expression.markLineNumber(startOffset = true)
         SwitchGenerator(expression, data, this).generate()?.let { return it }
 
-        val type = expression.type.toKotlinType()
         val endLabel = Label()
         for (branch in expression.branches) {
             val elseLabel = Label()
@@ -689,7 +682,7 @@ class ExpressionCodegen(
             } else {
                 genConditionalJumpWithOptimizationsIfPossible(branch.condition, data, elseLabel)
             }
-            val result = gen(branch.result, data).coerce(type)
+            val result = branch.result.accept(this, data).coerce(expression.type).materializeNonUnit()
             if (branch.condition.isTrueConst()) {
                 // The rest of the expression is dead code.
                 mv.mark(endLabel)
@@ -700,7 +693,7 @@ class ExpressionCodegen(
         }
         // Produce the default value for the type. Doesn't really matter right now, as non-exhaustive
         // conditionals cannot be used as expressions.
-        val result = none().coerce(type)
+        val result = none().coerce(expression.type).materializeNonUnit()
         mv.mark(endLabel)
         return result
     }
@@ -730,7 +723,7 @@ class ExpressionCodegen(
         ) {
             val left = condition.getValueArgument(0)!!
             val right = condition.getValueArgument(1)!!
-            gen(if (left.isNullConst()) right else left, data)
+            (if (left.isNullConst()) right else left).accept(this, data).materialize()
             if (jumpIfFalse) {
                 mv.ifnonnull(jumpToLabel)
             } else {
@@ -754,11 +747,12 @@ class ExpressionCodegen(
 
         // For instance of type operators, branch directly on the instanceof result instead
         // of materializing a boolean and performing an extra jump.
+        // TODO after redundant materialization is removed, this will be unnecessary
         if (condition is IrTypeOperatorCall &&
             (condition.operator == IrTypeOperator.NOT_INSTANCEOF || condition.operator == IrTypeOperator.INSTANCEOF)
         ) {
             val asmType = condition.typeOperand.toKotlinType().asmType
-            gen(condition.argument, OBJECT_TYPE, data)
+            condition.argument.accept(this, data).coerce(AsmTypes.OBJECT_TYPE).materialize()
             val type = boxType(asmType)
             generateIsCheck(mv, condition.typeOperand.toKotlinType(), type, state.languageVersionSettings.isReleaseCoroutines())
             if (condition.operator == IrTypeOperator.NOT_INSTANCEOF) {
@@ -768,62 +762,61 @@ class ExpressionCodegen(
             return
         }
 
-        BranchedValue.condJump(gen(condition, data), jumpToLabel, jumpIfFalse, mv)
+        BranchedValue.condJump(condition.accept(this, data), jumpToLabel, jumpIfFalse, mv)
     }
 
     override fun visitTypeOperator(expression: IrTypeOperatorCall, data: BlockInfo): StackValue {
         val asmType = expression.typeOperand.toKotlinType().asmType
-        when (expression.operator) {
+        return when (expression.operator) {
             IrTypeOperator.IMPLICIT_COERCION_TO_UNIT -> {
                 val result = expression.argument.accept(this, data)
                 expression.argument.markEndOfStatementIfNeeded()
-                return result.discard()
+                result.coerce(expression.type)
             }
 
             IrTypeOperator.IMPLICIT_CAST -> {
-                gen(expression.argument, asmType, data)
+                expression.argument.accept(this, data).coerce(expression.type)
             }
 
             IrTypeOperator.CAST, IrTypeOperator.SAFE_CAST -> {
-                val value = expression.argument.accept(this, data)
-                value.put(boxType(value.type), mv)
-                if (value.type === Type.VOID_TYPE) {
-                    StackValue.putUnitInstance(mv)
-                }
+                expression.argument.accept(this, data).coerce(AsmTypes.OBJECT_TYPE).materialize()
                 val boxedType = boxType(asmType)
                 generateAsCast(
                     mv, expression.typeOperand.toKotlinType(), boxedType, expression.operator == IrTypeOperator.SAFE_CAST,
                     state.languageVersionSettings.isReleaseCoroutines()
                 )
-                return onStack(boxedType)
+                onStack(boxedType).coerce(expression.type)
             }
 
             IrTypeOperator.INSTANCEOF, IrTypeOperator.NOT_INSTANCEOF -> {
-                gen(expression.argument, OBJECT_TYPE, data)
+                expression.argument.accept(this, data).coerce(AsmTypes.OBJECT_TYPE).materialize()
                 val type = boxType(asmType)
                 generateIsCheck(mv, expression.typeOperand.toKotlinType(), type, state.languageVersionSettings.isReleaseCoroutines())
                 if (IrTypeOperator.NOT_INSTANCEOF == expression.operator) {
-                    StackValue.not(StackValue.onStack(Type.BOOLEAN_TYPE)).put(mv)
+                    return StackValue.not(expression.onStack)
                 }
+                expression.onStack
             }
 
             IrTypeOperator.IMPLICIT_NOTNULL -> {
-                val value = gen(expression.argument, data)
+                val value = expression.argument.accept(this, data).materialize()
                 mv.dup()
                 mv.visitLdcInsn("TODO provide message for IMPLICIT_NOTNULL") /*TODO*/
                 mv.invokestatic(
                     "kotlin/jvm/internal/Intrinsics", "checkExpressionValueIsNotNull",
                     "(Ljava/lang/Object;Ljava/lang/String;)V", false
                 )
-                StackValue.onStack(value.type).put(asmType, mv)
+                // Unbox primitives.
+                value.coerce(expression.type)
             }
 
             IrTypeOperator.IMPLICIT_INTEGER_COERCION -> {
-                gen(expression.argument, Type.INT_TYPE, data)
-                StackValue.coerce(Type.INT_TYPE, typeMapper.mapType(expression.type.toKotlinType()), mv)
+                // Force-materialize the intermediate int to ensure that it is in fact an int.
+                expression.argument.accept(this, data).coerce(Type.INT_TYPE).materialize().coerce(expression.type)
             }
+
+            else -> throw AssertionError("type operator ${expression.operator} should have been lowered")
         }
-        return expression.onStack
     }
 
     private fun IrExpression.markEndOfStatementIfNeeded() {
@@ -845,8 +838,7 @@ class ExpressionCodegen(
             0 -> StackValue.constant("", expression.asmType)
             1 -> {
                 // Convert single arg to string.
-                val arg = expression.arguments[0]
-                val argStackValue = gen(arg, arg.asmType, data)
+                val argStackValue = expression.arguments[0].accept(this, data).materialize()
                 AsmUtil.genToString(argStackValue, argStackValue.type, argStackValue.kotlinType, typeMapper).put(expression.asmType, mv)
                 expression.onStack
             }
@@ -854,7 +846,7 @@ class ExpressionCodegen(
                 // Use StringBuilder to concatenate.
                 AsmUtil.genStringBuilderConstructor(mv)
                 expression.arguments.forEach {
-                    val stackValue = gen(it, it.asmType, data)
+                    val stackValue = it.accept(this, data).materialize()
                     AsmUtil.genInvokeAppendMethod(mv, stackValue.type, stackValue.kotlinType)
                 }
                 mv.invokevirtual("java/lang/StringBuilder", "toString", "()Ljava/lang/String;", false)
@@ -892,7 +884,7 @@ class ExpressionCodegen(
         generateLoopJump(loop.condition, data, endLabel, true)
 
         data.withBlock(LoopInfo(loop, continueLabel, endLabel)) {
-            loop.body?.let { gen(it, data).discard() }
+            loop.body?.accept(this, data)?.discard()
         }
         mv.goTo(continueLabel)
         mv.mark(endLabel)
@@ -905,7 +897,7 @@ class ExpressionCodegen(
             when {
                 it is TryInfo -> {
                     it.gaps.add(markNewLabel() to endLabel)
-                    gen(it.onExit, data).discard()
+                    it.onExit.accept(this, data).discard()
                 }
                 it is LoopInfo && it.loop == loop -> return it
             }
@@ -932,7 +924,7 @@ class ExpressionCodegen(
         mv.fakeAlwaysFalseIfeq(endLabel)
 
         data.withBlock(LoopInfo(loop, continueLabel, endLabel)) {
-            loop.body?.let { gen(it, data).discard() }
+            loop.body?.accept(this, data)?.discard()
         }
 
         mv.visitLabel(continueLabel)
@@ -953,12 +945,12 @@ class ExpressionCodegen(
     private fun visitTryWithInfo(aTry: IrTry, data: BlockInfo, tryInfo: TryInfo?): StackValue {
         val tryBlockStart = markNewLabel()
         mv.nop()
-        gen(aTry.tryResult, aTry.asmType, data)
+        val tryResult = aTry.tryResult.accept(this, data).coerce(aTry.type).materializeNonUnit()
         val tryBlockEnd = markNewLabel()
         val tryBlockGaps = tryInfo?.gaps?.toList() ?: listOf()
         val tryCatchBlockEnd = Label()
         if (tryInfo != null) {
-            data.handleBlock { gen(tryInfo.onExit, data).discard() }
+            data.handleBlock { tryInfo.onExit.accept(this, data).discard() }
             tryInfo.onExit.markLineNumber(startOffset = false)
             mv.goTo(tryCatchBlockEnd)
             tryInfo.gaps.add(tryBlockEnd to markNewLabel())
@@ -976,7 +968,7 @@ class ExpressionCodegen(
 
             val catchBody = clause.result
             catchBody.markLineNumber(true)
-            gen(catchBody, catchBody.asmType, data)
+            catchBody.accept(this, data).coerce(aTry.type).materializeNonUnit()
 
             frame.leave(clause.catchParameter)
 
@@ -988,7 +980,7 @@ class ExpressionCodegen(
             )
 
             if (tryInfo != null) {
-                data.handleBlock { gen(tryInfo.onExit, data).discard() }
+                data.handleBlock { tryInfo.onExit.accept(this, data).discard() }
                 tryInfo.onExit.markLineNumber(startOffset = false)
                 mv.goTo(tryCatchBlockEnd)
                 tryInfo.gaps.add(clauseEnd to markNewLabel())
@@ -1005,14 +997,14 @@ class ExpressionCodegen(
             val defaultCatchStart = markNewLabel()
             // While keeping this value on the stack should be enough, the bytecode validator will
             // complain if a catch block does not start with ASTORE.
-            val savedException = frame.enterTemp(JAVA_THROWABLE_TYPE)
-            mv.store(savedException, JAVA_THROWABLE_TYPE)
+            val savedException = frame.enterTemp(AsmTypes.JAVA_THROWABLE_TYPE)
+            mv.store(savedException, AsmTypes.JAVA_THROWABLE_TYPE)
 
             val finallyStart = markNewLabel()
             // Nothing will cover anything after this point, so don't bother recording the gap here.
-            data.handleBlock { gen(tryInfo.onExit, data).discard() }
-            mv.load(savedException, JAVA_THROWABLE_TYPE)
-            frame.leaveTemp(JAVA_THROWABLE_TYPE)
+            data.handleBlock { tryInfo.onExit.accept(this, data).discard() }
+            mv.load(savedException, AsmTypes.JAVA_THROWABLE_TYPE)
+            frame.leaveTemp(AsmTypes.JAVA_THROWABLE_TYPE)
             mv.athrow()
 
             // Include the ASTORE into the covered region. That's what javac does as well.
@@ -1021,7 +1013,7 @@ class ExpressionCodegen(
 
         mv.mark(tryCatchBlockEnd)
         // TODO: generate a common `finally` for try & catch blocks here? Right now this breaks the inliner.
-        return aTry.onStack
+        return tryResult
     }
 
     private fun genTryCatchCover(catchStart: Label, tryStart: Label, tryEnd: Label, tryGaps: List<Pair<Label, Label>>, type: String?) {
@@ -1034,7 +1026,7 @@ class ExpressionCodegen(
 
     override fun visitThrow(expression: IrThrow, data: BlockInfo): StackValue {
         expression.markLineNumber(startOffset = true)
-        gen(expression.value, JAVA_THROWABLE_TYPE, data)
+        expression.value.accept(this, data).coerce(AsmTypes.JAVA_THROWABLE_TYPE).materialize()
         mv.athrow()
         return none()
     }
@@ -1056,7 +1048,7 @@ class ExpressionCodegen(
     ) {
         if (classReference !is IrClassReference /* && DescriptorUtils.isObjectQualifier(classReference.descriptor)*/) {
             assert(classReference is IrGetClass)
-            JavaClassProperty.generateImpl(mv, gen((classReference as IrGetClass).argument, data))
+            JavaClassProperty.generateImpl(mv, (classReference as IrGetClass).argument.accept(this, data))
         } else {
             val classType = classReference.classType
             if (classType is CrIrType) {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/PromisedValue.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/PromisedValue.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.jvm.codegen
+
+import org.jetbrains.kotlin.codegen.AsmUtil
+import org.jetbrains.kotlin.codegen.StackValue
+import org.jetbrains.org.objectweb.asm.Label
+import org.jetbrains.org.objectweb.asm.Type
+
+// A value that may not have been fully constructed yet. The ability to "roll back" code generation
+// is useful for certain optimizations.
+abstract class PromisedValue(val codegen: ExpressionCodegen, val type: Type) {
+    // If this value is immaterial, construct an object on the top of the stack. This
+    // must always be done before generating other values or emitting raw bytecode.
+    abstract fun materialize()
+}
+
+// A value that *has* been fully constructed.
+class MaterialValue(codegen: ExpressionCodegen, type: Type) : PromisedValue(codegen, type) {
+    override fun materialize() {}
+}
+
+// A value that can be branched on. JVM has certain branching instructions which can be used
+// to optimize these.
+abstract class BooleanValue(codegen: ExpressionCodegen) : PromisedValue(codegen, Type.BOOLEAN_TYPE) {
+    abstract fun jumpIfFalse(target: Label)
+    abstract fun jumpIfTrue(target: Label)
+
+    override fun materialize() {
+        val const0 = Label()
+        val end = Label()
+        jumpIfFalse(const0)
+        codegen.mv.iconst(1)
+        codegen.mv.goTo(end)
+        codegen.mv.mark(const0)
+        codegen.mv.iconst(0)
+        codegen.mv.mark(end)
+    }
+}
+
+// Same as materialize(), but return a representation of the result.
+val PromisedValue.materialized: MaterialValue
+    get() {
+        materialize()
+        return MaterialValue(codegen, type)
+    }
+
+// Materialize and disregard this value. Materialization is forced because, presumably,
+// we only wanted the side effects anyway.
+fun PromisedValue.discard(): MaterialValue {
+    materialize()
+    if (type !== Type.VOID_TYPE)
+        AsmUtil.pop(codegen.mv, type)
+    return MaterialValue(codegen, Type.VOID_TYPE)
+}
+
+// On materialization, cast the value to a different type.
+fun PromisedValue.coerce(target: Type) = when (target) {
+    type -> this
+    else -> object : PromisedValue(codegen, target) {
+        // TODO remove dependency
+        override fun materialize() = StackValue.coerce(this@coerce.materialized.type, type, codegen.mv)
+    }
+}
+
+// Same as above, but with a return type that allows conditional jumping.
+fun PromisedValue.coerceToBoolean() = when (val coerced = coerce(Type.BOOLEAN_TYPE)) {
+    is BooleanValue -> coerced
+    else -> object : BooleanValue(codegen) {
+        override fun jumpIfFalse(target: Label) = coerced.materialize().also { codegen.mv.ifeq(target) }
+        override fun jumpIfTrue(target: Label) = coerced.materialize().also { codegen.mv.ifne(target) }
+        override fun materialize() = coerced.materialize()
+    }
+}
+
+val ExpressionCodegen.voidValue: MaterialValue
+    get() = MaterialValue(this, Type.VOID_TYPE)

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/SwitchGenerator.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/SwitchGenerator.kt
@@ -6,22 +6,17 @@
 package org.jetbrains.kotlin.backend.jvm.codegen
 
 import org.jetbrains.kotlin.codegen.*
-import org.jetbrains.kotlin.codegen.StackValue.*
 import org.jetbrains.kotlin.codegen.`when`.SwitchCodegen.Companion.preferLookupOverSwitch
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.types.*
 import org.jetbrains.kotlin.ir.util.dump
 import org.jetbrains.kotlin.ir.util.isTrueConst
-import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.org.objectweb.asm.Label
-import org.jetbrains.org.objectweb.asm.Type
 import java.util.*
 
 // TODO: eliminate the temporary variable
 class SwitchGenerator(private val expression: IrWhen, private val data: BlockInfo, private val codegen: ExpressionCodegen) {
-    private val mv = codegen.mv
-
     data class ExpressionToLabel(val expression: IrExpression, val label: Label)
     data class CallToLabel(val call: IrCall, val label: Label)
     data class ValueToLabel(val value: Any?, val label: Label)
@@ -183,17 +178,11 @@ class SwitchGenerator(private val expression: IrWhen, private val data: BlockInf
         return null
     }
 
-    private fun gen(expression: IrElement, data: BlockInfo): StackValue = codegen.gen(expression, data)
-
-    private fun coerceNotToUnit(fromType: Type, fromKotlinType: KotlinType?, toKotlinType: KotlinType): StackValue =
-        codegen.coerceNotToUnit(fromType, fromKotlinType, toKotlinType)
-
     abstract inner class Switch(
         val subject: IrGetValue,
         val elseExpression: IrExpression?,
         val expressionToLabels: ArrayList<ExpressionToLabel>
     ) {
-        protected val endLabel = Label()
         protected val defaultLabel = Label()
 
         open fun shouldOptimize() = false
@@ -202,16 +191,9 @@ class SwitchGenerator(private val expression: IrWhen, private val data: BlockInf
             if (!shouldOptimize())
                 return null
 
-            genSubject()
             genSwitch()
-            genThenExpressions()
-            val result = genElseExpression()
-
-            mv.mark(endLabel)
-            return result
+            return genBranchTargets()
         }
-
-        protected abstract fun genSubject()
 
         protected abstract fun genSwitch()
 
@@ -225,34 +207,31 @@ class SwitchGenerator(private val expression: IrWhen, private val data: BlockInf
             //
             // lookupswitch is 2X as large as tableswitch with the same entries. However, lookupswitch is sparse while tableswitch must
             // enumerate all the entries in the range.
-            if (preferLookupOverSwitch(intCases.size, rangeLength)) {
-                mv.lookupswitch(defaultLabel, intCases.map { it.value as Int }.toIntArray(), intCases.map { it.label }.toTypedArray())
-            } else {
-                val labels = Array(rangeLength.toInt()) { defaultLabel }
-                for (case in intCases)
-                    labels[case.value as Int - caseMin] = case.label
-                mv.tableswitch(caseMin, caseMax, defaultLabel, *labels)
+            with(codegen) {
+                if (preferLookupOverSwitch(intCases.size, rangeLength)) {
+                    mv.lookupswitch(defaultLabel, intCases.map { it.value as Int }.toIntArray(), intCases.map { it.label }.toTypedArray())
+                } else {
+                    val labels = Array(rangeLength.toInt()) { defaultLabel }
+                    for (case in intCases)
+                        labels[case.value as Int - caseMin] = case.label
+                    mv.tableswitch(caseMin, caseMax, defaultLabel, *labels)
+                }
             }
         }
 
-        protected fun genThenExpressions() {
-            for ((thenExpression, label) in expressionToLabels) {
-                mv.visitLabel(label)
-                val stackValue = thenExpression.run { gen(this, data) }
-                coerceNotToUnit(stackValue.type, stackValue.kotlinType, expression.type.toKotlinType())
-                mv.goTo(endLabel)
-            }
-        }
-
-        protected fun genElseExpression(): StackValue {
-            mv.visitLabel(defaultLabel)
-            return if (elseExpression == null) {
-                // There's no else part. Generate Unit if needed.
-                coerceNotToUnit(Type.VOID_TYPE, null, expression.type.toKotlinType())
-            } else {
-                // Generate the else part.
-                val stackValue = gen(elseExpression, data)
-                coerceNotToUnit(stackValue.type, stackValue.kotlinType, expression.type.toKotlinType())
+        protected fun genBranchTargets(): StackValue {
+            with(codegen) {
+                val endLabel = Label()
+                for ((thenExpression, label) in expressionToLabels) {
+                    mv.visitLabel(label)
+                    thenExpression.accept(codegen, data).coerce(expression.type).materializeNonUnit()
+                    mv.goTo(endLabel)
+                }
+                mv.visitLabel(defaultLabel)
+                val stackValue = elseExpression?.accept(codegen, data) ?: StackValue.none()
+                val result = stackValue.coerce(expression.type).materializeNonUnit()
+                mv.mark(endLabel)
+                return result
             }
         }
     }
@@ -267,12 +246,11 @@ class SwitchGenerator(private val expression: IrWhen, private val data: BlockInf
         // IF is more compact when there are only 1 or fewer branches, in addition to else.
         override fun shouldOptimize() = cases.size > 1
 
-        override fun genSubject() {
-            gen(subject, data)
-        }
-
         override fun genSwitch() {
-            genIntSwitch(cases)
+            with(codegen) {
+                subject.accept(codegen, data).materialize()
+                genIntSwitch(cases)
+            }
         }
     }
 
@@ -340,30 +318,29 @@ class SwitchGenerator(private val expression: IrWhen, private val data: BlockInf
         // same bucket). The optimization isn't better than an IF cascade when #switch-targets <= 2.
         override fun shouldOptimize() = hashAndSwitchLabels.size > 2
 
-        override fun genSubject() {
-            if (subject.type.isNullableString()) {
-                val nullLabel = cases.find { it.value == null }?.label ?: defaultLabel
-                gen(subject, data)
-                mv.ifnull(nullLabel)
-            }
-            gen(subject, data)
-            mv.invokevirtual("java/lang/String", "hashCode", "()I", false)
-        }
-
         override fun genSwitch() {
-            genIntSwitch(hashAndSwitchLabels)
-
-            // Multiple strings can be hashed into the same bucket.
-            // Generate an if cascade to resolve that for each bucket.
-            for ((hash, switchLabel) in hashAndSwitchLabels) {
-                mv.visitLabel(switchLabel)
-                for ((string, label) in hashToStringAndExprLabels[hash]!!) {
-                    gen(subject, data)
-                    mv.aconst(string)
-                    mv.invokevirtual("java/lang/String", "equals", "(Ljava/lang/Object;)Z", false)
-                    mv.ifne(label)
+            with(codegen) {
+                if (subject.type.isNullableString()) {
+                    subject.accept(codegen, data).materialize()
+                    mv.ifnull(cases.find { it.value == null }?.label ?: defaultLabel)
                 }
-                mv.goTo(defaultLabel)
+                // Reevaluating the subject is fine here because it is a read of a temporary.
+                subject.accept(codegen, data).materialize()
+                mv.invokevirtual("java/lang/String", "hashCode", "()I", false)
+                genIntSwitch(hashAndSwitchLabels)
+
+                // Multiple strings can be hashed into the same bucket.
+                // Generate an if cascade to resolve that for each bucket.
+                for ((hash, switchLabel) in hashAndSwitchLabels) {
+                    mv.visitLabel(switchLabel)
+                    for ((string, label) in hashToStringAndExprLabels[hash]!!) {
+                        subject.accept(codegen, data).materialize()
+                        mv.aconst(string)
+                        mv.invokevirtual("java/lang/String", "equals", "(Ljava/lang/Object;)Z", false)
+                        mv.ifne(label)
+                    }
+                    mv.goTo(defaultLabel)
+                }
             }
         }
     }

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/ArrayConstructor.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/ArrayConstructor.kt
@@ -34,10 +34,14 @@ object ArrayConstructor : IntrinsicMethod() {
     ): IrIntrinsicFunction {
         return object : IrIntrinsicFunction(expression, signature, context, expression.argTypes(context)) {
 
-            override fun invoke(v: InstructionAdapter, codegen: ExpressionCodegen, data: BlockInfo): StackValue =
-                codegen.generateCall(expression, this, data).let {
-                    return StackValue.onStack(Type.getObjectType("[" + AsmTypes.OBJECT_TYPE.internalName))
+            override fun invoke(v: InstructionAdapter, codegen: ExpressionCodegen, data: BlockInfo): StackValue {
+                // TODO fix this hack
+                val result = codegen.generateCall(expression, this, data)
+                with(codegen) {
+                    result.materialize()
                 }
+                return StackValue.onStack(Type.getObjectType("[" + AsmTypes.OBJECT_TYPE.internalName))
+            }
         }
     }
 }

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/CompareTo.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/CompareTo.kt
@@ -16,16 +16,19 @@
 
 package org.jetbrains.kotlin.backend.jvm.intrinsics
 
+import com.intellij.psi.tree.IElementType
 import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
-import org.jetbrains.kotlin.backend.jvm.codegen.BlockInfo
-import org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen
+import org.jetbrains.kotlin.backend.jvm.codegen.*
 import org.jetbrains.kotlin.codegen.AsmUtil.comparisonOperandType
-import org.jetbrains.kotlin.codegen.StackValue
+import org.jetbrains.kotlin.codegen.BranchedValue
+import org.jetbrains.kotlin.codegen.NumberCompare
+import org.jetbrains.kotlin.codegen.ObjectCompare
 import org.jetbrains.kotlin.ir.expressions.IrFunctionAccessExpression
 import org.jetbrains.kotlin.ir.expressions.IrMemberAccessExpression
 import org.jetbrains.kotlin.lexer.KtSingleValueToken
 import org.jetbrains.kotlin.resolve.jvm.jvmSignature.JvmMethodSignature
 import org.jetbrains.kotlin.types.KotlinType
+import org.jetbrains.org.objectweb.asm.Label
 import org.jetbrains.org.objectweb.asm.Type
 import org.jetbrains.org.objectweb.asm.commons.InstructionAdapter
 import java.lang.UnsupportedOperationException
@@ -62,19 +65,34 @@ class CompareTo : IntrinsicMethod() {
     }
 }
 
+class BooleanComparison(val op: IElementType, val a: MaterialValue, val b: MaterialValue) : BooleanValue(a.codegen) {
+    override fun jumpIfFalse(target: Label) {
+        // TODO 1. get rid of the dependency; 2. take `b.type` into account.
+        val opcode = if (a.type.sort == Type.OBJECT)
+            ObjectCompare.getObjectCompareOpcode(op)
+        else
+            NumberCompare.patchOpcode(NumberCompare.getNumberCompareOpcode(op), codegen.mv, op, a.type)
+        codegen.mv.visitJumpInsn(opcode, target)
+    }
+
+    override fun jumpIfTrue(target: Label) {
+        val opcode = if (a.type.sort == Type.OBJECT)
+            BranchedValue.negatedOperations[ObjectCompare.getObjectCompareOpcode(op)]!!
+        else
+            NumberCompare.patchOpcode(BranchedValue.negatedOperations[NumberCompare.getNumberCompareOpcode(op)]!!, codegen.mv, op, a.type)
+        codegen.mv.visitJumpInsn(opcode, target)
+    }
+}
 
 class PrimitiveComparison(
     private val primitiveNumberType: KotlinType,
     private val operatorToken: KtSingleValueToken
 ) : IntrinsicMethod() {
-    override fun invoke(expression: IrFunctionAccessExpression, codegen: ExpressionCodegen, data: BlockInfo): StackValue? {
+    override fun invoke(expression: IrFunctionAccessExpression, codegen: ExpressionCodegen, data: BlockInfo): PromisedValue? {
         val parameterType = codegen.typeMapper.mapType(primitiveNumberType)
         val (left, right) = expression.receiverAndArgs()
-        return StackValue.cmp(
-            operatorToken,
-            parameterType,
-            codegen.gen(left, parameterType, data),
-            codegen.gen(right, parameterType, data)
-        )
+        val a = left.accept(codegen, data).coerce(parameterType).materialized
+        val b = right.accept(codegen, data).coerce(parameterType).materialized
+        return BooleanComparison(operatorToken, a, b)
     }
 }

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/Concat.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/Concat.kt
@@ -16,55 +16,22 @@
 
 package org.jetbrains.kotlin.backend.jvm.intrinsics
 
-import com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
 import org.jetbrains.kotlin.backend.jvm.codegen.BlockInfo
 import org.jetbrains.kotlin.codegen.*
-import org.jetbrains.kotlin.codegen.AsmUtil.genInvokeAppendMethod
-import org.jetbrains.kotlin.codegen.AsmUtil.genStringBuilderConstructor
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrMemberAccessExpression
-import org.jetbrains.kotlin.lexer.KtTokens
-import org.jetbrains.kotlin.psi.KtBinaryExpression
-import org.jetbrains.kotlin.psi.KtCallableReferenceExpression
-import org.jetbrains.kotlin.psi.KtExpression
-import org.jetbrains.kotlin.resolve.calls.model.ResolvedCall
 import org.jetbrains.kotlin.resolve.jvm.AsmTypes
-import org.jetbrains.kotlin.resolve.jvm.AsmTypes.JAVA_STRING_TYPE
 import org.jetbrains.kotlin.resolve.jvm.jvmSignature.JvmMethodSignature
 import org.jetbrains.org.objectweb.asm.Opcodes
-import org.jetbrains.org.objectweb.asm.Type
 import org.jetbrains.org.objectweb.asm.commons.InstructionAdapter
 
 class Concat : IntrinsicMethod() {
-    fun generateImpl(
-            codegen: ExpressionCodegen,
-            v: InstructionAdapter,
-            returnType: Type,
-            element: PsiElement?,
-            arguments: List<KtExpression>,
-            receiver: StackValue
-    ): Type {
-        if (element is KtBinaryExpression && element.operationReference.getReferencedNameElementType() == KtTokens.PLUS) {
-            // LHS + RHS
-            genStringBuilderConstructor(v)
-            codegen.invokeAppend(v, element.left)
-            codegen.invokeAppend(v, element.right)
-        }
-        else {
-            // LHS?.plus(RHS)
-            receiver.put(AsmTypes.OBJECT_TYPE, v)
-            genStringBuilderConstructor(v)
-            v.swap()
-            genInvokeAppendMethod(v, returnType, null)
-            codegen.invokeAppend(v, arguments.get(0))
-        }
-
-        v.invokevirtual("java/lang/StringBuilder", "toString", "()Ljava/lang/String;", false)
-        return JAVA_STRING_TYPE
-    }
-
-    override fun toCallable(expression: IrMemberAccessExpression, signature: JvmMethodSignature, context: JvmBackendContext): IrIntrinsicFunction {
+    override fun toCallable(
+        expression: IrMemberAccessExpression,
+        signature: JvmMethodSignature,
+        context: JvmBackendContext
+    ): IrIntrinsicFunction {
         val argsTypes = expression.receiverAndArgs().asmTypes(context).toMutableList()
         argsTypes[0] = AsmTypes.JAVA_STRING_TYPE
 
@@ -75,7 +42,11 @@ class Concat : IntrinsicMethod() {
                 v.invokevirtual("java/lang/StringBuilder", "toString", "()Ljava/lang/String;", false)
             }
 
-            override fun invoke(v: InstructionAdapter, codegen: org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen, data: BlockInfo): StackValue {
+            override fun invoke(
+                v: InstructionAdapter,
+                codegen: org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen,
+                data: BlockInfo
+            ): StackValue {
                 v.visitTypeInsn(Opcodes.NEW, "java/lang/StringBuilder")
                 v.dup()
 
@@ -83,7 +54,12 @@ class Concat : IntrinsicMethod() {
             }
 
 
-            override fun genArg(expression: IrExpression, codegen: org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen, index: Int, data: BlockInfo) {
+            override fun genArg(
+                expression: IrExpression,
+                codegen: org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen,
+                index: Int,
+                data: BlockInfo
+            ) {
                 super.genArg(expression, codegen, index, data)
                 if (index == 0) {
                     codegen.mv.invokespecial("java/lang/StringBuilder", "<init>", "(Ljava/lang/String;)V", false)
@@ -91,43 +67,4 @@ class Concat : IntrinsicMethod() {
             }
         }
     }
-
-    override fun toCallable(method: CallableMethod): Callable =
-            object : IntrinsicCallable(method) {
-                override fun invokeMethodWithArguments(
-                        resolvedCall: ResolvedCall<*>,
-                        receiver: StackValue,
-                        codegen: ExpressionCodegen
-                ): StackValue {
-                    if (resolvedCall.call.callElement.parent is KtCallableReferenceExpression) {
-                        // NB we come here only in case of inlined callable reference to String::plus.
-                        // This will map arguments properly, invoking callbacks defined in Callable.
-                        return super.invokeMethodWithArguments(resolvedCall, receiver, codegen)
-                    }
-                    return StackValue.operation(returnType) {
-                        val arguments = resolvedCall.call.valueArguments.map { it.getArgumentExpression()!! }
-                        val actualType = generateImpl(
-                                codegen, it, returnType,
-                                resolvedCall.call.callElement,
-                                arguments,
-                                StackValue.receiver(resolvedCall, receiver, codegen, this)
-                        )
-                        StackValue.coerce(actualType, returnType, it)
-                    }
-                }
-
-                override fun afterReceiverGeneration(v: InstructionAdapter, frameMap: FrameMap) {
-                    v.generateNewInstanceDupAndPlaceBeforeStackTop(frameMap, AsmTypes.JAVA_STRING_TYPE, "java/lang/StringBuilder")
-                    v.invokespecial("java/lang/StringBuilder", "<init>", "(Ljava/lang/String;)V", false)
-                }
-
-                override fun invokeIntrinsic(v: InstructionAdapter) {
-                    // String::plus has type String.(Any?) -> String, thus we have no argument type information
-                    // in case of callable reference passed to a generic function, e.g.:
-                    //      charArrayOf('O', 'K').fold("", String::plus)
-                    // TODO Make String::plus generic, and invoke proper StringBuilder#append.
-                    AsmUtil.genInvokeAppendMethod(v, AsmTypes.OBJECT_TYPE, null)
-                    v.invokevirtual("java/lang/StringBuilder", "toString", "()Ljava/lang/String;", false)
-                }
-            }
 }

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/IntrinsicMethod.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/IntrinsicMethod.kt
@@ -8,17 +8,12 @@ package org.jetbrains.kotlin.backend.jvm.intrinsics
 import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
 import org.jetbrains.kotlin.codegen.Callable
 import org.jetbrains.kotlin.codegen.CallableMethod
-import org.jetbrains.kotlin.codegen.StackValue
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrMemberAccessExpression
 import org.jetbrains.kotlin.ir.types.toKotlinType
 import org.jetbrains.kotlin.resolve.jvm.jvmSignature.JvmMethodSignature
 import org.jetbrains.org.objectweb.asm.Type
 import org.jetbrains.org.objectweb.asm.commons.Method
-
-interface ComparisonIntrinsic {
-    fun genStackValue(expression: IrMemberAccessExpression, context: JvmBackendContext): StackValue
-}
 
 abstract class IntrinsicMethod {
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/IntrinsicMethod.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/IntrinsicMethod.kt
@@ -6,7 +6,12 @@
 package org.jetbrains.kotlin.backend.jvm.intrinsics
 
 import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
+import org.jetbrains.kotlin.backend.jvm.codegen.BlockInfo
+import org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen
+import org.jetbrains.kotlin.codegen.StackValue
+import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.IrFunctionAccessExpression
 import org.jetbrains.kotlin.ir.expressions.IrMemberAccessExpression
 import org.jetbrains.kotlin.ir.types.toKotlinType
 import org.jetbrains.kotlin.resolve.jvm.jvmSignature.JvmMethodSignature
@@ -14,11 +19,18 @@ import org.jetbrains.org.objectweb.asm.Type
 import org.jetbrains.org.objectweb.asm.commons.Method
 
 abstract class IntrinsicMethod {
-    abstract fun toCallable(
+    open fun toCallable(
         expression: IrMemberAccessExpression,
         signature: JvmMethodSignature,
         context: JvmBackendContext
-    ): IrIntrinsicFunction
+    ): IrIntrinsicFunction = TODO("implement toCallable() or invoke() of $this")
+
+    open fun invoke(expression: IrFunctionAccessExpression, codegen: ExpressionCodegen, data: BlockInfo): StackValue? =
+        toCallable(
+            expression,
+            codegen.typeMapper.mapSignatureSkipGeneric(expression.descriptor),
+            codegen.context
+        ).invoke(codegen.mv, codegen, data)
 
     companion object {
         fun calcReceiverType(call: IrMemberAccessExpression, context: JvmBackendContext): Type {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/IntrinsicMethod.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/IntrinsicMethod.kt
@@ -6,8 +6,6 @@
 package org.jetbrains.kotlin.backend.jvm.intrinsics
 
 import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
-import org.jetbrains.kotlin.codegen.Callable
-import org.jetbrains.kotlin.codegen.CallableMethod
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrMemberAccessExpression
 import org.jetbrains.kotlin.ir.types.toKotlinType
@@ -16,18 +14,11 @@ import org.jetbrains.org.objectweb.asm.Type
 import org.jetbrains.org.objectweb.asm.commons.Method
 
 abstract class IntrinsicMethod {
-
-    open fun toCallable(
+    abstract fun toCallable(
         expression: IrMemberAccessExpression,
         signature: JvmMethodSignature,
         context: JvmBackendContext
-    ): IrIntrinsicFunction {
-        TODO()
-    }
-
-    open fun toCallable(method: CallableMethod): Callable {
-        throw UnsupportedOperationException("Not implemented")
-    }
+    ): IrIntrinsicFunction
 
     companion object {
         fun calcReceiverType(call: IrMemberAccessExpression, context: JvmBackendContext): Type {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/JavaClassProperty.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/JavaClassProperty.kt
@@ -16,41 +16,29 @@
 
 package org.jetbrains.kotlin.backend.jvm.intrinsics
 
-import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
-import org.jetbrains.kotlin.backend.jvm.codegen.BlockInfo
-import org.jetbrains.kotlin.codegen.AsmUtil
+import org.jetbrains.kotlin.backend.jvm.codegen.*
 import org.jetbrains.kotlin.codegen.AsmUtil.boxType
 import org.jetbrains.kotlin.codegen.AsmUtil.isPrimitive
-import org.jetbrains.kotlin.codegen.StackValue
-import org.jetbrains.kotlin.ir.expressions.IrMemberAccessExpression
-import org.jetbrains.kotlin.resolve.jvm.jvmSignature.JvmMethodSignature
+import org.jetbrains.kotlin.ir.expressions.IrFunctionAccessExpression
+import org.jetbrains.kotlin.resolve.jvm.AsmTypes
 import org.jetbrains.org.objectweb.asm.Type
-import org.jetbrains.org.objectweb.asm.commons.InstructionAdapter
 
 object JavaClassProperty : IntrinsicMethod() {
-
-    override fun toCallable(expression: IrMemberAccessExpression, signature: JvmMethodSignature, context: JvmBackendContext): IrIntrinsicFunction {
-        return object: IrIntrinsicFunction(expression, signature, context) {
-
-            override fun invoke(v: InstructionAdapter, codegen: org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen, data: BlockInfo): StackValue {
-                val value = codegen.gen(expression.extensionReceiver!!, data)
-                val type = value.type
-                when {
-                    type == Type.VOID_TYPE -> {
-                        StackValue.unit().put(v)
-                        v.invokevirtual("java/lang/Object", "getClass", "()Ljava/lang/Class;", false)
-                    }
-                    isPrimitive(type) -> {
-                        AsmUtil.pop(v, type)
-                        v.getstatic(boxType(type).internalName, "TYPE", "Ljava/lang/Class;")
-                    }
-                    else -> v.invokevirtual("java/lang/Object", "getClass", "()Ljava/lang/Class;", false)
-                }
-
-                return with(codegen) {
-                    expression.onStack
-                }
-            }
+    fun invokeWith(value: PromisedValue) {
+        if (value.type == Type.VOID_TYPE) {
+            return invokeWith(value.coerce(AsmTypes.UNIT_TYPE))
         }
+        if (isPrimitive(value.type)) {
+            value.discard()
+            value.codegen.mv.getstatic(boxType(value.type).internalName, "TYPE", "Ljava/lang/Class;")
+        } else {
+            value.materialize()
+            value.codegen.mv.invokevirtual("java/lang/Object", "getClass", "()Ljava/lang/Class;", false)
+        }
+    }
+
+    override fun invoke(expression: IrFunctionAccessExpression, codegen: ExpressionCodegen, data: BlockInfo): PromisedValue? {
+        invokeWith(expression.extensionReceiver!!.accept(codegen, data))
+        return with(codegen) { expression.onStack }
     }
 }

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/KClassJavaProperty.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/KClassJavaProperty.kt
@@ -18,18 +18,16 @@ package org.jetbrains.kotlin.backend.jvm.intrinsics
 
 import org.jetbrains.kotlin.backend.jvm.codegen.BlockInfo
 import org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen
-import org.jetbrains.kotlin.codegen.StackValue
+import org.jetbrains.kotlin.backend.jvm.codegen.PromisedValue
 import org.jetbrains.kotlin.ir.expressions.IrClassReference
 import org.jetbrains.kotlin.ir.expressions.IrFunctionAccessExpression
 import org.jetbrains.kotlin.ir.expressions.IrGetClass
 
 class KClassJavaProperty : IntrinsicMethod() {
-    override fun invoke(expression: IrFunctionAccessExpression, codegen: ExpressionCodegen, data: BlockInfo): StackValue? {
+    override fun invoke(expression: IrFunctionAccessExpression, codegen: ExpressionCodegen, data: BlockInfo): PromisedValue? {
         val extensionReceiver = expression.extensionReceiver
-        if (extensionReceiver !is IrClassReference && extensionReceiver !is IrGetClass) {
+        if (extensionReceiver !is IrClassReference && extensionReceiver !is IrGetClass)
             return null
-        }
-        codegen.generateClassLiteralReference(extensionReceiver, false, data)
-        return with(codegen) { expression.onStack }
+        return codegen.generateClassLiteralReference(extensionReceiver, false, data)
     }
 }

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/KClassJavaProperty.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/KClassJavaProperty.kt
@@ -16,31 +16,20 @@
 
 package org.jetbrains.kotlin.backend.jvm.intrinsics
 
-import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
 import org.jetbrains.kotlin.backend.jvm.codegen.BlockInfo
+import org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen
 import org.jetbrains.kotlin.codegen.StackValue
-import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.ir.expressions.IrClassReference
+import org.jetbrains.kotlin.ir.expressions.IrFunctionAccessExpression
 import org.jetbrains.kotlin.ir.expressions.IrGetClass
-import org.jetbrains.kotlin.ir.expressions.IrMemberAccessExpression
-import org.jetbrains.kotlin.resolve.jvm.jvmSignature.JvmMethodSignature
-import org.jetbrains.org.objectweb.asm.commons.InstructionAdapter
 
 class KClassJavaProperty : IntrinsicMethod() {
-    override fun toCallable(expression: IrMemberAccessExpression, signature: JvmMethodSignature, context: JvmBackendContext): IrIntrinsicFunction {
-        return object: IrIntrinsicFunction(expression, signature, context) {
-            override fun invoke(v: InstructionAdapter, codegen: org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen, data: BlockInfo): StackValue {
-                val extensionReceiver = expression.extensionReceiver
-                if (extensionReceiver is IrClassReference || extensionReceiver is IrGetClass) {
-                    codegen.generateClassLiteralReference(extensionReceiver, false, data)
-                }
-                else {
-                    codegen.gen(extensionReceiver!!, data)
-                    val mapToCallableMethod = context.state.typeMapper.mapToCallableMethod(expression.descriptor as FunctionDescriptor, false)
-                    mapToCallableMethod.genInvokeInstruction(codegen.mv)
-                }
-                return StackValue.onStack(signature.returnType)
-            }
+    override fun invoke(expression: IrFunctionAccessExpression, codegen: ExpressionCodegen, data: BlockInfo): StackValue? {
+        val extensionReceiver = expression.extensionReceiver
+        if (extensionReceiver !is IrClassReference && extensionReceiver !is IrGetClass) {
+            return null
         }
+        codegen.generateClassLiteralReference(extensionReceiver, false, data)
+        return with(codegen) { expression.onStack }
     }
 }

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/Not.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/Not.kt
@@ -17,20 +17,22 @@
 package org.jetbrains.kotlin.backend.jvm.intrinsics
 
 import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
-import org.jetbrains.kotlin.codegen.Callable
-import org.jetbrains.kotlin.codegen.CallableMethod
-import org.jetbrains.kotlin.codegen.ExpressionCodegen
-import org.jetbrains.kotlin.codegen.StackValue
+import org.jetbrains.kotlin.backend.jvm.codegen.BlockInfo
+import org.jetbrains.kotlin.codegen.*
 import org.jetbrains.kotlin.ir.expressions.IrMemberAccessExpression
 import org.jetbrains.kotlin.psi.KtPrefixExpression
 import org.jetbrains.kotlin.resolve.calls.model.ResolvedCall
 import org.jetbrains.kotlin.resolve.jvm.jvmSignature.JvmMethodSignature
-import org.jetbrains.org.objectweb.asm.Type
+import org.jetbrains.org.objectweb.asm.commons.InstructionAdapter
 
 class Not : IntrinsicMethod() {
     override fun toCallable(expression: IrMemberAccessExpression, signature: JvmMethodSignature, context: JvmBackendContext): IrIntrinsicFunction {
-        return IrIntrinsicFunction.create(expression, signature, context) {
-            StackValue.not(StackValue.onStack(Type.BOOLEAN_TYPE)).put(it)
+        return object : IrIntrinsicFunction(expression, signature, context, expression.argTypes(context)) {
+            override fun invoke(
+                v: InstructionAdapter,
+                codegen: org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen,
+                data: BlockInfo
+            ): StackValue = StackValue.not(expression.dispatchReceiver!!.accept(codegen, data))
         }
     }
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/Not.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/Not.kt
@@ -18,40 +18,24 @@ package org.jetbrains.kotlin.backend.jvm.intrinsics
 
 import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
 import org.jetbrains.kotlin.backend.jvm.codegen.BlockInfo
-import org.jetbrains.kotlin.codegen.*
+import org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen
+import org.jetbrains.kotlin.codegen.StackValue
 import org.jetbrains.kotlin.ir.expressions.IrMemberAccessExpression
-import org.jetbrains.kotlin.psi.KtPrefixExpression
-import org.jetbrains.kotlin.resolve.calls.model.ResolvedCall
 import org.jetbrains.kotlin.resolve.jvm.jvmSignature.JvmMethodSignature
 import org.jetbrains.org.objectweb.asm.commons.InstructionAdapter
 
 class Not : IntrinsicMethod() {
-    override fun toCallable(expression: IrMemberAccessExpression, signature: JvmMethodSignature, context: JvmBackendContext): IrIntrinsicFunction {
+    override fun toCallable(
+        expression: IrMemberAccessExpression,
+        signature: JvmMethodSignature,
+        context: JvmBackendContext
+    ): IrIntrinsicFunction {
         return object : IrIntrinsicFunction(expression, signature, context, expression.argTypes(context)) {
             override fun invoke(
                 v: InstructionAdapter,
-                codegen: org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen,
+                codegen: ExpressionCodegen,
                 data: BlockInfo
-            ): StackValue = StackValue.not(expression.dispatchReceiver!!.accept(codegen, data))
+            ) = StackValue.not(expression.dispatchReceiver!!.accept(codegen, data))
         }
     }
-
-    override fun toCallable(method: CallableMethod): Callable =
-            object : IntrinsicCallable(method) {
-                override fun invokeMethodWithArguments(
-                        resolvedCall: ResolvedCall<*>,
-                        receiver: StackValue,
-                        codegen: ExpressionCodegen
-                ): StackValue {
-                    val element = resolvedCall.call.callElement
-                    val stackValue =
-                            if (element is KtPrefixExpression) {
-                                codegen.gen(element.baseExpression)
-                            }
-                            else {
-                                StackValue.receiver(resolvedCall, receiver, codegen, this)
-                            }
-                    return StackValue.not(stackValue)
-                }
-            }
 }

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/Not.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/Not.kt
@@ -17,11 +17,18 @@
 package org.jetbrains.kotlin.backend.jvm.intrinsics
 
 import org.jetbrains.kotlin.backend.jvm.codegen.BlockInfo
+import org.jetbrains.kotlin.backend.jvm.codegen.BooleanValue
 import org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen
-import org.jetbrains.kotlin.codegen.StackValue
+import org.jetbrains.kotlin.backend.jvm.codegen.coerceToBoolean
 import org.jetbrains.kotlin.ir.expressions.IrFunctionAccessExpression
+import org.jetbrains.org.objectweb.asm.Label
 
 class Not : IntrinsicMethod() {
+    class BooleanNegation(val value: BooleanValue) : BooleanValue(value.codegen) {
+        override fun jumpIfFalse(target: Label) = value.jumpIfTrue(target)
+        override fun jumpIfTrue(target: Label) = value.jumpIfFalse(target)
+    }
+
     override fun invoke(expression: IrFunctionAccessExpression, codegen: ExpressionCodegen, data: BlockInfo) =
-        StackValue.not(expression.dispatchReceiver!!.accept(codegen, data))
+        BooleanNegation(expression.dispatchReceiver!!.accept(codegen, data).coerceToBoolean())
 }

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/Not.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/Not.kt
@@ -16,26 +16,12 @@
 
 package org.jetbrains.kotlin.backend.jvm.intrinsics
 
-import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
 import org.jetbrains.kotlin.backend.jvm.codegen.BlockInfo
 import org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen
 import org.jetbrains.kotlin.codegen.StackValue
-import org.jetbrains.kotlin.ir.expressions.IrMemberAccessExpression
-import org.jetbrains.kotlin.resolve.jvm.jvmSignature.JvmMethodSignature
-import org.jetbrains.org.objectweb.asm.commons.InstructionAdapter
+import org.jetbrains.kotlin.ir.expressions.IrFunctionAccessExpression
 
 class Not : IntrinsicMethod() {
-    override fun toCallable(
-        expression: IrMemberAccessExpression,
-        signature: JvmMethodSignature,
-        context: JvmBackendContext
-    ): IrIntrinsicFunction {
-        return object : IrIntrinsicFunction(expression, signature, context, expression.argTypes(context)) {
-            override fun invoke(
-                v: InstructionAdapter,
-                codegen: ExpressionCodegen,
-                data: BlockInfo
-            ) = StackValue.not(expression.dispatchReceiver!!.accept(codegen, data))
-        }
-    }
+    override fun invoke(expression: IrFunctionAccessExpression, codegen: ExpressionCodegen, data: BlockInfo) =
+        StackValue.not(expression.dispatchReceiver!!.accept(codegen, data))
 }

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/RangeTo.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/RangeTo.kt
@@ -57,33 +57,4 @@ class RangeTo : IntrinsicMethod() {
             }
         }
     }
-//
-//    override fun toCallable(method: CallableMethod): Callable {
-//        val argType = rangeTypeToPrimitiveType(method.returnType)
-//        return object : IntrinsicCallable(
-//                method.returnType,
-//                method.valueParameterTypes.map { argType },
-//                nullOr(method.dispatchReceiverType, argType),
-//                nullOr(method.extensionReceiverType, argType)
-//        ) {
-//            override fun afterReceiverGeneration(v: InstructionAdapter) {
-//                v.anew(returnType)
-//                when (argType.size) {
-//                    1 -> {
-//                        v.dupX1()
-//                        v.swap()
-//                    }
-//                    2 -> {
-//                        v.dup()
-//                        v.dup2X2()
-//                        v.pop2()
-//                    }
-//                }
-//            }
-//
-//            override fun invokeIntrinsic(v: InstructionAdapter) {
-//                v.invokespecial(returnType.internalName, "<init>", Type.getMethodDescriptor(Type.VOID_TYPE, argType, argType), false)
-//            }
-//        }
-//    }
 }

--- a/compiler/testData/codegen/box/primitiveTypes/kt2269NotOptimizable.kt
+++ b/compiler/testData/codegen/box/primitiveTypes/kt2269NotOptimizable.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 fun identity(x: Int): Int {
     return when {
         x < 0 -> identity(x + 1) - 1

--- a/compiler/testData/codegen/bytecodeText/coercionToUnitOptimization/largeMethodWithCoercionToUnit.kt
+++ b/compiler/testData/codegen/bytecodeText/coercionToUnitOptimization/largeMethodWithCoercionToUnit.kt
@@ -1,3 +1,4 @@
+// IGNORE_BACKEND: JVM_IR
 inline fun inlineFunVoid(f: () -> Unit): Unit {
     return f()
 }

--- a/compiler/testData/codegen/bytecodeText/coercionToUnitOptimization/largeMethodWithCoercionToUnit.kt
+++ b/compiler/testData/codegen/bytecodeText/coercionToUnitOptimization/largeMethodWithCoercionToUnit.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 inline fun inlineFunVoid(f: () -> Unit): Unit {
     return f()
 }

--- a/compiler/testData/codegen/bytecodeText/intrinsicsCompare/charSmartCast.kt
+++ b/compiler/testData/codegen/bytecodeText/intrinsicsCompare/charSmartCast.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 fun equals3(a: Char?, b: Char?) = a != null && b != null && a == b
 
 fun equals4(a: Char?, b: Char?) = if (a is Char && b is Char) a == b else null!!

--- a/compiler/testData/codegen/bytecodeText/intrinsicsCompare/longSmartCast.kt
+++ b/compiler/testData/codegen/bytecodeText/intrinsicsCompare/longSmartCast.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 fun equals3(a: Long?, b: Long?) = a != null && b != null && a == b
 
 fun equals4(a: Long?, b: Long?) = if (a is Long && b is Long) a == b else null!!


### PR DESCRIPTION
(Probably easier to look at each commit separately.)

Visiting a node with ExpressionCodegen now produces a PromisedValue, a stripped down version of StackValue. It is not guaranteed to be fully materialized, which helps a lot with some optimizations, in particular those of chained boolean operations. Currently, however, a *partially* materialized value can be returned, so when calling `accept` twice in a row, the first result must be materialized explicitly to avoid interleaving the instruction streams. This might be a barrier to optimizing (n > 1)-ary intrinsics, so perhaps it'd be better to switch to always generating lazy values later.