### PR TITLE
kapt: fix kt-26203

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/build.gradle.kts
@@ -124,6 +124,8 @@ tasks.withType<Test> {
 
     systemProperty("kotlinVersion", rootProject.extra["kotlinVersion"] as String)
     systemProperty("runnerGradleVersion", gradle.gradleVersion)
+    systemProperty("jdk10Home", rootProject.extra["JDK_10"] as String)
+    systemProperty("jdk11Home", rootProject.extra["JDK_11"] as String)
 
     val mavenLocalRepo = System.getProperty("maven.repo.local")
     if (mavenLocalRepo != null) {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kapt3IT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kapt3IT.kt
@@ -19,6 +19,7 @@ package org.jetbrains.kotlin.gradle
 import org.jetbrains.kotlin.gradle.tasks.USING_JVM_INCREMENTAL_COMPILATION_MESSAGE
 import org.jetbrains.kotlin.gradle.util.*
 import org.junit.Assert
+import org.junit.Assume
 import org.junit.Test
 import java.io.File
 import java.util.zip.ZipFile
@@ -66,6 +67,30 @@ class Kapt3WorkersIT : Kapt3IT() {
         project.build("build") {
             assertSuccessful()
         }
+    }
+
+    private fun testSimpleWithCustomJdk(gradleVersion: String, javaHome: File, jdkDescription: String) {
+        val gradleVersionRequired = GradleVersionRequired.AtLeast(gradleVersion)
+
+        Assume.assumeTrue("$jdkDescription isn't available", javaHome.isDirectory)
+        val options = defaultBuildOptions().copy(javaHome = javaHome)
+
+        val project =
+            Project("simple", directoryPrefix = "kapt2", gradleVersionRequirement = gradleVersionRequired)
+        project.build("build", options = options) {
+            assertSuccessful()
+            assertKaptSuccessful()
+        }
+    }
+
+    @Test
+    fun testSimpleWithJdk10() {
+        testSimpleWithCustomJdk("4.7", File(System.getProperty("jdk10Home")!!), "JDK 10")
+    }
+
+    @Test
+    fun testSimpleWithJdk11() {
+        testSimpleWithCustomJdk("5.0", File(System.getProperty("jdk11Home")!!), "JDK 11")
     }
 }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/KaptWithoutKotlincTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/KaptWithoutKotlincTask.kt
@@ -21,6 +21,7 @@ import org.jetbrains.kotlin.gradle.tasks.findToolsJar
 import org.jetbrains.kotlin.utils.PathUtil
 import java.io.File
 import java.io.Serializable
+import java.net.URL
 import java.net.URLClassLoader
 import javax.inject.Inject
 
@@ -98,7 +99,7 @@ open class KaptWithoutKotlincTask @Inject constructor(private val workerExecutor
                 "none" -> IsolationMode.NONE
                 else -> IsolationMode.NONE
             }
-            config.params(optionsForWorker, findToolsJar(), kaptClasspath)
+            config.params(optionsForWorker, findToolsJar()?.toURI()?.toURL()?.toString().orEmpty(), kaptClasspath)
             if (project.findProperty("kapt.workers.log.classloading") == "true") {
                 // for tests
                 config.forkOptions.jvmArgs("-verbose:class")
@@ -110,7 +111,7 @@ open class KaptWithoutKotlincTask @Inject constructor(private val workerExecutor
 
 private class KaptExecution @Inject constructor(
     val optionsForWorker: KaptOptionsForWorker,
-    val toolsJar: File?,
+    val toolsJarURLSpec: String,
     val kaptClasspath: List<File>
 ) : Runnable {
     private companion object {
@@ -125,8 +126,8 @@ private class KaptExecution @Inject constructor(
         val kaptClasspathUrls = kaptClasspath.map { it.toURI().toURL() }.toTypedArray()
         val rootClassLoader = findRootClassLoader()
 
-        val classLoaderWithToolsJar = cachedClassLoaderWithToolsJar ?: if (toolsJar != null && !javacIsAlreadyHere()) {
-            URLClassLoader(arrayOf(toolsJar.toURI().toURL()), rootClassLoader)
+        val classLoaderWithToolsJar = cachedClassLoaderWithToolsJar ?: if (!toolsJarURLSpec.isEmpty() && !javacIsAlreadyHere()) {
+            URLClassLoader(arrayOf(URL(toolsJarURLSpec)), rootClassLoader)
         } else {
             rootClassLoader
         }


### PR DESCRIPTION
Gradle worker throws NPE when the parameter to the runnable is null.
This patch works that around by passing URL spec as String instead of
File?