### PR TITLE
IrBuiltins: refactoring for equality checks

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/AsmUtil.java
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/AsmUtil.java
@@ -848,17 +848,28 @@ public class AsmUtil {
         return StackValue.operation(Type.BOOLEAN_TYPE, v -> {
             left.put(AsmTypes.OBJECT_TYPE, left.kotlinType, v);
             right.put(AsmTypes.OBJECT_TYPE, right.kotlinType, v);
-            genAreEqualCall(v);
-
-            if (opToken == KtTokens.EXCLEQ || opToken == KtTokens.EXCLEQEQEQ) {
-                genInvertBoolean(v);
-            }
-            return Unit.INSTANCE;
+            return genAreEqualCall(v, opToken);
         });
+    }
+
+    @NotNull
+    public static StackValue genEqualsBoxedOnStack(@NotNull IElementType opToken) {
+        return StackValue.operation(Type.BOOLEAN_TYPE, v -> genAreEqualCall(v, opToken));
     }
 
     public static void genAreEqualCall(InstructionAdapter v) {
         v.invokestatic(IntrinsicMethods.INTRINSICS_CLASS_NAME, "areEqual", "(Ljava/lang/Object;Ljava/lang/Object;)Z", false);
+    }
+
+    @NotNull
+    private static Unit genAreEqualCall(InstructionAdapter v, @NotNull IElementType opToken) {
+        genAreEqualCall(v);
+
+        if (opToken == KtTokens.EXCLEQ || opToken == KtTokens.EXCLEQEQEQ) {
+            genInvertBoolean(v);
+        }
+
+        return Unit.INSTANCE;
     }
 
     public static void genIEEE754EqualForNullableTypesCall(InstructionAdapter v, Type left, Type right) {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/IntrinsicMethods.java
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/IntrinsicMethods.java
@@ -95,12 +95,7 @@ public class IntrinsicMethods {
         for (PrimitiveType type : PrimitiveType.values()) {
             FqName typeFqName = type.getTypeFqName();
             Type asmPrimitiveType = AsmTypes.valueTypeForPrimitive(type);
-            if (asmPrimitiveType == Type.FLOAT_TYPE || asmPrimitiveType == Type.DOUBLE_TYPE) {
-                declareIntrinsicFunction(typeFqName, "equals", 1, new TotalOrderEquals(asmPrimitiveType));
-            }
-            else {
-                declareIntrinsicFunction(typeFqName, "equals", 1, EQUALS);
-            }
+            declareIntrinsicFunction(typeFqName, "equals", 1, EQUALS);
             declareIntrinsicFunction(typeFqName, "hashCode", 0, HASH_CODE);
             declareIntrinsicFunction(typeFqName, "toString", 0, TO_STRING);
 

--- a/compiler/testData/codegen/box/dataClasses/doubleParam.kt
+++ b/compiler/testData/codegen/box/dataClasses/doubleParam.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 // IGNORE_BACKEND: JS_IR
 // TODO: muted automatically, investigate should it be ran for JS or not
 // IGNORE_BACKEND: JS

--- a/compiler/testData/codegen/box/dataClasses/floatParam.kt
+++ b/compiler/testData/codegen/box/dataClasses/floatParam.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 // IGNORE_BACKEND: JS_IR
 // TODO: muted automatically, investigate should it be ran for JS or not
 // IGNORE_BACKEND: JS

--- a/compiler/testData/codegen/box/ieee754/dataClass.kt
+++ b/compiler/testData/codegen/box/ieee754/dataClass.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 data class Test(val z1: Double, val z2: Double?)
 
 fun box(): String {


### PR DESCRIPTION
Previously,
* Equals performs IEEE 754 equality check for floating points and
  byte-to-byte checks for other types, including references.
* Ieee754Equals performs IEEE 754 for primitive types
* TotalOrderEquals performs total order equals to all types, including
  floating points.

Now it is simplified,
* Equals performs total order checks for all types.
* Ieee754Equals performs IEEE 754 for primitive types.
* (TotalOrderEquals is removed.)