### PR TITLE
[IR] introduced additional field 'inlineFunctionSymbol' to IrReturnableBlock

### DIFF
--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/inline/FunctionInlining.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/inline/FunctionInlining.kt
@@ -194,7 +194,7 @@ internal class FunctionInlining(val context: Context): IrElementTransformerVoidW
                 symbol = irReturnableBlockSymbol,
                 origin = if (isCoroutineIntrinsicCall) CoroutineIntrinsicLambdaOrigin else null,
                 statements = statements,
-                sourceFileSymbol = sourceFile.symbol
+                inlineFunctionSymbol = callee.symbol
             ).apply {
                 transformChildrenVoid(object : IrElementTransformerVoid() {
                     override fun visitReturn(expression: IrReturn): IrExpression {

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/IrBlock.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/IrBlock.kt
@@ -19,6 +19,7 @@ package org.jetbrains.kotlin.ir.expressions
 import org.jetbrains.kotlin.ir.declarations.IrReturnTarget
 import org.jetbrains.kotlin.ir.declarations.IrSymbolOwner
 import org.jetbrains.kotlin.ir.symbols.IrFileSymbol
+import org.jetbrains.kotlin.ir.symbols.IrFunctionSymbol
 import org.jetbrains.kotlin.ir.symbols.IrReturnableBlockSymbol
 
 interface IrContainerExpression : IrExpression, IrStatementContainer {
@@ -40,4 +41,5 @@ interface IrReturnableBlock : IrBlock, IrSymbolOwner, IrReturnTarget {
     override val symbol: IrReturnableBlockSymbol
     val sourceFileSymbol: IrFileSymbol?
     val sourceFileName: String
+    val inlineFunctionSymbol: IrFunctionSymbol?
 }

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/IrBlock.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/IrBlock.kt
@@ -18,9 +18,11 @@ package org.jetbrains.kotlin.ir.expressions
 
 import org.jetbrains.kotlin.ir.declarations.IrReturnTarget
 import org.jetbrains.kotlin.ir.declarations.IrSymbolOwner
+import org.jetbrains.kotlin.ir.declarations.name
 import org.jetbrains.kotlin.ir.symbols.IrFileSymbol
 import org.jetbrains.kotlin.ir.symbols.IrFunctionSymbol
 import org.jetbrains.kotlin.ir.symbols.IrReturnableBlockSymbol
+import org.jetbrains.kotlin.ir.util.file
 
 interface IrContainerExpression : IrExpression, IrStatementContainer {
     val origin: IrStatementOrigin?
@@ -39,7 +41,13 @@ interface IrComposite : IrContainerExpression {
 
 interface IrReturnableBlock : IrBlock, IrSymbolOwner, IrReturnTarget {
     override val symbol: IrReturnableBlockSymbol
-    val sourceFileSymbol: IrFileSymbol?
-    val sourceFileName: String
     val inlineFunctionSymbol: IrFunctionSymbol?
 }
+
+val IrReturnableBlock.sourceFileSymbol: IrFileSymbol?
+    get() = inlineFunctionSymbol?.owner?.file?.symbol
+
+@Deprecated("Please avoid using it")
+val IrReturnableBlock.sourceFileName: String
+    get() = sourceFileSymbol?.owner?.name ?: "no source file"
+

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrBlockImpl.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrBlockImpl.kt
@@ -21,7 +21,6 @@ import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.expressions.IrBlock
 import org.jetbrains.kotlin.ir.expressions.IrReturnableBlock
 import org.jetbrains.kotlin.ir.expressions.IrStatementOrigin
-import org.jetbrains.kotlin.ir.symbols.IrFileSymbol
 import org.jetbrains.kotlin.ir.symbols.IrFunctionSymbol
 import org.jetbrains.kotlin.ir.symbols.IrReturnableBlockSymbol
 import org.jetbrains.kotlin.ir.symbols.impl.IrReturnableBlockSymbolImpl
@@ -71,7 +70,6 @@ class IrReturnableBlockImpl(
         type: IrType,
         override val symbol: IrReturnableBlockSymbol,
         origin: IrStatementOrigin? = null,
-        override val sourceFileSymbol: IrFileSymbol? = null,
         override val inlineFunctionSymbol: IrFunctionSymbol? = null
 ) :
     IrContainerExpressionBase(startOffset, endOffset, type, origin),
@@ -86,38 +84,14 @@ class IrReturnableBlockImpl(
         symbol: IrReturnableBlockSymbol,
         origin: IrStatementOrigin?,
         statements: List<IrStatement>,
-        sourceFileSymbol: IrFileSymbol? = null,
         inlineFunctionSymbol: IrFunctionSymbol? = null
-    ) : this(startOffset, endOffset, type, symbol, origin, sourceFileSymbol, inlineFunctionSymbol) {
-        this.statements.addAll(statements)
-    }
-
-    constructor(
-        startOffset: Int,
-        endOffset: Int,
-        type: IrType,
-        descriptor: FunctionDescriptor,
-        origin: IrStatementOrigin? = null,
-        sourceFileSymbol: IrFileSymbol? = null
-    ) : this(startOffset, endOffset, type, IrReturnableBlockSymbolImpl(descriptor), origin, sourceFileSymbol)
-
-    constructor(
-        startOffset: Int,
-        endOffset: Int,
-        type: IrType,
-        descriptor: FunctionDescriptor,
-        origin: IrStatementOrigin?,
-        statements: List<IrStatement>,
-        sourceFileSymbol: IrFileSymbol? = null
-    ) : this(startOffset, endOffset, type, descriptor, origin, sourceFileSymbol) {
+    ) : this(startOffset, endOffset, type, symbol, origin, inlineFunctionSymbol) {
         this.statements.addAll(statements)
     }
 
     init {
         symbol.bind(this)
     }
-
-    override val sourceFileName: String = sourceFileSymbol?.owner?.fileEntry?.name ?: "no source file"
 
     override fun <R, D> accept(visitor: IrElementVisitor<R, D>, data: D): R =
         visitor.visitBlock(this, data)

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrBlockImpl.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrBlockImpl.kt
@@ -18,11 +18,11 @@ package org.jetbrains.kotlin.ir.expressions.impl
 
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.ir.IrStatement
-import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.expressions.IrBlock
 import org.jetbrains.kotlin.ir.expressions.IrReturnableBlock
 import org.jetbrains.kotlin.ir.expressions.IrStatementOrigin
 import org.jetbrains.kotlin.ir.symbols.IrFileSymbol
+import org.jetbrains.kotlin.ir.symbols.IrFunctionSymbol
 import org.jetbrains.kotlin.ir.symbols.IrReturnableBlockSymbol
 import org.jetbrains.kotlin.ir.symbols.impl.IrReturnableBlockSymbolImpl
 import org.jetbrains.kotlin.ir.types.IrType
@@ -66,12 +66,13 @@ fun IrBlockImpl.inlineStatement(statement: IrStatement) {
 }
 
 class IrReturnableBlockImpl(
-    startOffset: Int,
-    endOffset: Int,
-    type: IrType,
-    override val symbol: IrReturnableBlockSymbol,
-    origin: IrStatementOrigin? = null,
-    override val sourceFileSymbol: IrFileSymbol? = null
+        startOffset: Int,
+        endOffset: Int,
+        type: IrType,
+        override val symbol: IrReturnableBlockSymbol,
+        origin: IrStatementOrigin? = null,
+        override val sourceFileSymbol: IrFileSymbol? = null,
+        override val inlineFunctionSymbol: IrFunctionSymbol? = null
 ) :
     IrContainerExpressionBase(startOffset, endOffset, type, origin),
     IrReturnableBlock {
@@ -85,8 +86,9 @@ class IrReturnableBlockImpl(
         symbol: IrReturnableBlockSymbol,
         origin: IrStatementOrigin?,
         statements: List<IrStatement>,
-        sourceFileSymbol: IrFileSymbol? = null
-    ) : this(startOffset, endOffset, type, symbol, origin, sourceFileSymbol) {
+        sourceFileSymbol: IrFileSymbol? = null,
+        inlineFunctionSymbol: IrFunctionSymbol? = null
+    ) : this(startOffset, endOffset, type, symbol, origin, sourceFileSymbol, inlineFunctionSymbol) {
         this.statements.addAll(statements)
     }
 

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/DeepCopyIrTreeWithSymbols.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/DeepCopyIrTreeWithSymbols.kt
@@ -374,7 +374,7 @@ open class DeepCopyIrTreeWithSymbols(
                 symbolRemapper.getReferencedReturnableBlock(expression.symbol),
                 mapStatementOrigin(expression.origin),
                 expression.statements.map { it.transform() },
-                expression.sourceFileSymbol
+                expression.inlineFunctionSymbol
             )
         else
             IrBlockImpl(


### PR DESCRIPTION
This change let backend calculate and bind right function to the code block on generation debug information
e.g. for Kotlin/Native backend this let codegnerator to produce DILocation(..., inlinedAt:..) with correct value
for inlinedAt parameter, thus signifiacntly improve behaviour of debugger.

https://github.com/JetBrains/kotlin-native/pull/2849