### PR TITLE
Remove broken KotlinType.toIrType function

### DIFF
--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/descriptors/IrBuiltIns.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/descriptors/IrBuiltIns.kt
@@ -17,7 +17,6 @@ import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.types.IrSimpleType
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.impl.IrSimpleTypeImpl
-import org.jetbrains.kotlin.ir.types.toIrType
 import org.jetbrains.kotlin.ir.types.withHasQuestionMark
 import org.jetbrains.kotlin.ir.util.SymbolTable
 import org.jetbrains.kotlin.ir.util.TypeTranslator

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/types/irTypes.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/types/irTypes.kt
@@ -129,28 +129,3 @@ fun IrClassifierSymbol.typeWith(arguments: List<IrType>): IrSimpleType =
     )
 
 fun IrClass.typeWith(arguments: List<IrType>) = this.symbol.typeWith(arguments)
-
-fun KotlinType.toIrType(symbolTable: SymbolTable? = null): IrType? {
-    if (isDynamic()) return IrDynamicTypeImpl(null, listOf(), Variance.INVARIANT)
-
-    val symbol = constructor.declarationDescriptor?.getSymbol(symbolTable) ?: return null
-
-    val arguments = this.arguments.map { projection ->
-        when (projection) {
-            is TypeProjectionImpl -> IrTypeProjectionImpl(projection.type.toIrType(symbolTable)!!, projection.projectionKind)
-            is StarProjectionImpl -> IrStarProjectionImpl
-            else -> error(projection)
-        }
-    }
-
-    // TODO
-    val annotations = listOf()
-    return IrSimpleTypeImpl(null, symbol, isMarkedNullable, arguments, annotations)
-}
-
-// TODO: this function creates unbound symbol which is the great source of problems
-private fun ClassifierDescriptor.getSymbol(symbolTable: SymbolTable?): IrClassifierSymbol = when (this) {
-    is ClassDescriptor -> symbolTable?.referenceClass(this) ?: IrClassSymbolImpl(this)
-    is TypeParameterDescriptor -> symbolTable?.referenceTypeParameter(this) ?: IrTypeParameterSymbolImpl(this)
-    else -> TODO()
-}


### PR DESCRIPTION
The KotlinType.toIrType function sometimes produces unbound symbols and was used in IrIntrinsicFunction and SharedVariablesManager.

This change removes the broken function and changes SharedVariableManager to use IrType consistently and IrIntrinsicFunction to use KotlinType consistently.

Note that I haven't checked whether this function is used by kotline-native (build problems), so you may want to hold off on merging the changes to `compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/types/irTypes.kt`.