### PR TITLE
Handle reversals of Progressions in ForLoopsLowering.

### DIFF
--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/HeaderInfo.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/HeaderInfo.kt
@@ -13,15 +13,20 @@ import org.jetbrains.kotlin.ir.declarations.IrVariable
 import org.jetbrains.kotlin.ir.descriptors.IrBuiltIns
 import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.ir.expressions.IrConst
+import org.jetbrains.kotlin.ir.expressions.IrConstKind
 import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.impl.IrCallImpl
+import org.jetbrains.kotlin.ir.expressions.impl.IrConstImpl
+import org.jetbrains.kotlin.ir.symbols.IrSymbol
 import org.jetbrains.kotlin.ir.types.IrType
+import org.jetbrains.kotlin.ir.types.getClass
 import org.jetbrains.kotlin.ir.types.isSubtypeOfClass
+import org.jetbrains.kotlin.ir.util.functions
 import org.jetbrains.kotlin.ir.visitors.IrElementVisitor
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.utils.addToStdlib.firstNotNullResult
 
 // TODO: Handle withIndex()
-// TODO: Handle reversed()
 // TODO: Handle Strings/CharSequences
 // TODO: Handle UIntProgression, ULongProgression
 
@@ -62,7 +67,9 @@ internal sealed class HeaderInfo(
     val first: IrExpression,
     val last: IrExpression,
     val step: IrExpression,
-    val isLastInclusive: Boolean
+    val isFirstInclusive: Boolean,
+    val isLastInclusive: Boolean,
+    val isReversed: Boolean
 ) {
     val direction: ProgressionDirection by lazy {
         // If step is a constant (either Int or Long), then we can determine the direction.
@@ -75,6 +82,13 @@ internal sealed class HeaderInfo(
             else -> ProgressionDirection.UNKNOWN
         }
     }
+
+    /**
+     * Returns a copy of this [HeaderInfo] with the values reversed.
+     * I.e., first and last (and their inclusiveness) are swapped, step is negated.
+     * Returns null if the iterable cannot be iterated in reverse.
+     */
+    abstract fun asReversed(): HeaderInfo?
 }
 
 /** Information about a for-loop over a progression. */
@@ -83,14 +97,15 @@ internal class ProgressionHeaderInfo(
     first: IrExpression,
     last: IrExpression,
     step: IrExpression,
+    isFirstInclusive: Boolean = true,
     isLastInclusive: Boolean = true,
-    canOverflow: Boolean? = null,
+    isReversed: Boolean = false,
     val additionalVariables: List<IrVariable> = listOf()
-) : HeaderInfo(progressionType, first, last, step, isLastInclusive) {
+) : HeaderInfo(progressionType, first, last, step, isFirstInclusive, isLastInclusive, isReversed) {
 
-    private val _canOverflow: Boolean? = canOverflow
     val canOverflow: Boolean by lazy {
-        if (_canOverflow != null) return@lazy _canOverflow
+        // Last-exclusive progressions can never overflow.
+        if (!isLastInclusive) return@lazy false
 
         // Induction variable can overflow if it is not a const, or is MAX/MIN_VALUE (depending on direction).
         val lastValue = (last as? IrConst<*>)?.value
@@ -118,6 +133,17 @@ internal class ProgressionHeaderInfo(
         }
         constLimitAsLong == lastValueAsLong
     }
+
+    override fun asReversed() = ProgressionHeaderInfo(
+        progressionType = progressionType,
+        first = last,
+        last = first,
+        step = step.negate(),
+        isFirstInclusive = isLastInclusive,
+        isLastInclusive = isFirstInclusive,
+        isReversed = !isReversed,
+        additionalVariables = additionalVariables
+    )
 }
 
 /** Information about a for-loop over an array. The internal induction variable used is an Int. */
@@ -131,28 +157,72 @@ internal class ArrayHeaderInfo(
     first,
     last,
     step,
-    isLastInclusive = false
-)
+    isFirstInclusive = true,
+    isLastInclusive = false,
+    isReversed = false
+) {
+    // Technically one can easily iterate over an array in reverse by swapping first/last and
+    // negating the step. However, Array.reversed() and Array.reversedArray() return a collection
+    // with a copy of the array elements, which means that the original array can be modified with
+    // no effect on the iteration over the reversed array. That is:
+    //
+    //   val arr = intArrayOf(1, 2, 3, 4)
+    //   for (i in arr.reversed()) {
+    //     arr[0] = 0  // Does not affect iteration over reversed array
+    //     print(i)    // Should print "4321"
+    //   }
+    //
+    // If we simply iterated over `arr` in reverse, then we would get "4320" which is not the right
+    // output. Hence we return null to indicate that we cannot loop over arrays in reverse.
+    override fun asReversed(): HeaderInfo? = null
+}
 
-/** Matches a call to `iterator()` and builds a [HeaderInfo] out of the call's context. */
-internal interface HeaderInfoHandler<T> {
-    val matcher: IrCallMatcher
+/** Return the negated value if the expression is const, otherwise call unaryMinus(). */
+private fun IrExpression.negate(): IrExpression {
+    val stepValue = (this as? IrConst<*>)?.value as? Number
+    return when (stepValue) {
+        is Int -> IrConstImpl(startOffset, endOffset, type, IrConstKind.Int, -stepValue)
+        is Long -> IrConstImpl(startOffset, endOffset, type, IrConstKind.Long, -stepValue)
+        else -> {
+            val unaryMinusFun = type.getClass()!!.functions.first { it.name.asString() == "unaryMinus" }
+            IrCallImpl(startOffset, endOffset, type, unaryMinusFun.symbol, unaryMinusFun.descriptor).apply {
+                dispatchReceiver = this@negate
+            }
+        }
+    }
+}
 
-    fun build(call: IrCall, data: T): HeaderInfo?
+/** Matches an iterable expression and builds a [HeaderInfo] from the expression. */
+internal interface HeaderInfoHandler<E : IrExpression, D> {
+    /** Returns true if the handler can build a [HeaderInfo] from the expression. */
+    fun match(expression: E): Boolean
 
-    fun handle(irCall: IrCall, data: T) = if (matcher(irCall)) {
-        build(irCall, data)
+    /** Builds a [HeaderInfo] from the expression. */
+    fun build(expression: E, data: D, scopeOwner: IrSymbol): HeaderInfo?
+
+    fun handle(expression: E, data: D, scopeOwner: IrSymbol) = if (match(expression)) {
+        build(expression, data, scopeOwner)
     } else {
         null
     }
 }
-internal typealias ProgressionHandler = HeaderInfoHandler<ProgressionType>
 
-/**
- * Handles a call to `iterator()` on more specialized forms of progressions, built using extension
- * and member functions/properties in the stdlib (e.g., `.indices`, `downTo`).
- */
-private class ProgressionHeaderInfoBuilder(val context: CommonBackendContext) : IrElementVisitor<HeaderInfo?, Nothing?> {
+internal interface ExpressionHandler : HeaderInfoHandler<IrExpression, Nothing?> {
+    fun build(expression: IrExpression, scopeOwner: IrSymbol): HeaderInfo?
+    override fun build(expression: IrExpression, data: Nothing?, scopeOwner: IrSymbol) = build(expression, scopeOwner)
+}
+
+/** Matches a call to build an iterable and builds a [HeaderInfo] from the call's context. */
+internal interface HeaderInfoFromCallHandler<D> : HeaderInfoHandler<IrCall, D> {
+    val matcher: IrCallMatcher
+
+    override fun match(expression: IrCall) = matcher(expression)
+}
+
+internal typealias ProgressionHandler = HeaderInfoFromCallHandler<ProgressionType>
+
+internal class HeaderInfoBuilder(context: CommonBackendContext, private val scopeOwnerSymbol: () -> IrSymbol) :
+    IrElementVisitor<HeaderInfo?, Nothing?> {
 
     private val symbols = context.ir.symbols
 
@@ -166,31 +236,33 @@ private class ProgressionHeaderInfoBuilder(val context: CommonBackendContext) : 
         RangeToHandler(context, progressionElementTypes)
     )
 
+    private val reversedHandler = ReversedHandler(context, this)
+
+    private val expressionHandlers = listOf(
+        ArrayIterationHandler(context),
+        DefaultProgressionHandler(context)
+    )
+
     override fun visitElement(element: IrElement, data: Nothing?): HeaderInfo? = null
 
+    /** Builds a [HeaderInfo] for iterable expressions that are calls (e.g., `.reversed()`, `.indices`. */
     override fun visitCall(expression: IrCall, data: Nothing?): HeaderInfo? {
-        // Return the HeaderInfo from the first successful match.
+        // Return the HeaderInfo from the first successful match. First, try to match a `reversed()` call.
+        val reversedHeaderInfo = reversedHandler.handle(expression, null, scopeOwnerSymbol())
+        if (reversedHeaderInfo != null)
+            return reversedHeaderInfo
+
+        // Try to match a call to build a progression (e.g., `.indices`, `downTo`).
         val progressionType = ProgressionType.fromIrType(expression.type, symbols)
-            ?: return null
-        return progressionHandlers.firstNotNullResult { it.handle(expression, progressionType) }
+        val progressionHeaderInfo =
+            progressionType?.run { progressionHandlers.firstNotNullResult { it.handle(expression, this, scopeOwnerSymbol()) } }
+
+        return progressionHeaderInfo ?: super.visitCall(expression, data)
     }
-}
 
-internal class HeaderInfoBuilder(context: CommonBackendContext) {
-    private val progressionHeaderInfoBuilder = ProgressionHeaderInfoBuilder(context)
-    private val arrayIterationHandler = ArrayIterationHandler(context)
-    private val defaultProgressionHandler = DefaultProgressionHandler(context)
-
-    fun build(variable: IrVariable): HeaderInfo? {
-        // TODO: Merge DefaultProgressionHandler into ProgressionHeaderInfoBuilder. Not
-        // straightforward because ProgressionHeaderInfoBuilder works only on calls and not just
-        // any progression expression (i.e., progression may not be a call result).
-
-        // DefaultProgressionHandler must come AFTER ProgressionHeaderInfoBuilder, which handles
-        // more specialized forms of progressions.
-        val initializer = variable.initializer as IrCall
-        return arrayIterationHandler.handle(initializer, null)
-            ?: initializer.dispatchReceiver?.accept(progressionHeaderInfoBuilder, null)
-            ?: defaultProgressionHandler.handle(initializer, null)
+    /** Builds a [HeaderInfo] for iterable expressions not handled in [visitCall]. */
+    override fun visitExpression(expression: IrExpression, data: Nothing?): HeaderInfo? {
+        return expressionHandlers.firstNotNullResult { it.handle(expression, null, scopeOwnerSymbol()) }
+            ?: super.visitExpression(expression, data)
     }
 }

--- a/compiler/testData/codegen/box/arrays/forInReversed/reversedArrayOriginalUpdatedInLoopBody.kt
+++ b/compiler/testData/codegen/box/arrays/forInReversed/reversedArrayOriginalUpdatedInLoopBody.kt
@@ -1,0 +1,18 @@
+// KJS_WITH_FULL_RUNTIME
+// WITH_RUNTIME
+import kotlin.test.*
+
+fun box(): String {
+    val arr = intArrayOf(1, 2, 3, 4)
+    var sum = 0
+    var index = 0
+    for (i in arr.reversedArray()) {
+        // reversedArray() returns a new Array with elements in reversed order.
+        // Modifying the original array should have no effect on the iteration subject.
+        arr[index++] = 0
+        sum = sum * 10 + i
+    }
+    assertEquals(4321, sum)
+
+    return "OK"
+}

--- a/compiler/testData/codegen/box/arrays/forInReversed/reversedArrayReversedArrayOriginalUpdatedInLoopBody.kt
+++ b/compiler/testData/codegen/box/arrays/forInReversed/reversedArrayReversedArrayOriginalUpdatedInLoopBody.kt
@@ -1,0 +1,18 @@
+// KJS_WITH_FULL_RUNTIME
+// WITH_RUNTIME
+import kotlin.test.*
+
+fun box(): String {
+    val arr = intArrayOf(1, 2, 3, 4)
+    var sum = 0
+    var index = arr.size - 1
+    for (i in arr.reversedArray().reversedArray()) {
+        // reversedArray() returns a new Array with elements in reversed order.
+        // Modifying the original array should have no effect on the iteration subject.
+        arr[index--] = 0
+        sum = sum * 10 + i
+    }
+    assertEquals(1234, sum)
+
+    return "OK"
+}

--- a/compiler/testData/codegen/box/arrays/forInReversed/reversedOriginalUpdatedInLoopBody.kt
+++ b/compiler/testData/codegen/box/arrays/forInReversed/reversedOriginalUpdatedInLoopBody.kt
@@ -1,0 +1,18 @@
+// KJS_WITH_FULL_RUNTIME
+// WITH_RUNTIME
+import kotlin.test.*
+
+fun box(): String {
+    val arr = intArrayOf(1, 2, 3, 4)
+    var sum = 0
+    var index = 0
+    for (i in arr.reversed()) {
+        // reversed() returns a new List with elements in reversed order.
+        // Modifying the original array should have no effect on the iteration subject.
+        arr[index++] = 0
+        sum = sum * 10 + i
+    }
+    assertEquals(4321, sum)
+
+    return "OK"
+}

--- a/compiler/testData/codegen/box/arrays/forInReversed/reversedReversedOriginalUpdatedInLoopBody.kt
+++ b/compiler/testData/codegen/box/arrays/forInReversed/reversedReversedOriginalUpdatedInLoopBody.kt
@@ -1,0 +1,18 @@
+// KJS_WITH_FULL_RUNTIME
+// WITH_RUNTIME
+import kotlin.test.*
+
+fun box(): String {
+    val arr = intArrayOf(1, 2, 3, 4)
+    var sum = 0
+    var index = arr.size - 1
+    for (i in arr.reversed().reversed()) {
+        // reversed() returns a new List with elements in reversed order.
+        // Modifying the original array should have no effect on the iteration subject.
+        arr[index--] = 0
+        sum = sum * 10 + i
+    }
+    assertEquals(1234, sum)
+
+    return "OK"
+}

--- a/compiler/testData/codegen/box/ranges/forInReversed/forInReversedReversedArrayIndices.kt
+++ b/compiler/testData/codegen/box/ranges/forInReversed/forInReversedReversedArrayIndices.kt
@@ -1,0 +1,14 @@
+// KJS_WITH_FULL_RUNTIME
+// WITH_RUNTIME
+import kotlin.test.*
+
+fun box(): String {
+    val arr = intArrayOf(1, 1, 1, 1)
+    var sum = 0
+    for (i in arr.indices.reversed().reversed()) {
+        sum = sum * 10 + i + arr[i]
+    }
+    assertEquals(1234, sum)
+
+    return "OK"
+}

--- a/compiler/testData/codegen/box/ranges/forInReversed/forInReversedReversedDownTo.kt
+++ b/compiler/testData/codegen/box/ranges/forInReversed/forInReversedReversedDownTo.kt
@@ -1,35 +1,24 @@
+// WITH_RUNTIME
 import kotlin.test.*
 
 fun box(): String {
     var sum = 0
-    for (i in (1 .. 4).reversed()) {
+    for (i in (4 downTo 1).reversed().reversed()) {
         sum = sum * 10 + i
     }
     assertEquals(4321, sum)
 
     var sumL = 0L
-    for (i in (1L .. 4L).reversed()) {
+    for (i in (4L downTo 1L).reversed().reversed()) {
         sumL = sumL * 10 + i
     }
-    assertEquals(4321L, sumL)
+    assertEquals(4321, sumL)
 
     var sumC = 0
-    for (i in ('1' .. '4').reversed()) {
+    for (i in ('4' downTo '1').reversed().reversed()) {
         sumC = sumC * 10 + i.toInt() - '0'.toInt()
     }
     assertEquals(4321, sumC)
 
     return "OK"
 }
-
-// 0 reversed
-// 0 iterator
-// 0 getStart
-// 0 getEnd
-// 0 getFirst
-// 0 getLast
-// 0 getStep
-// 2 IF_ICMP[LG]T
-// 1 IF[LG]T
-// 3 IF
-// 1 LCMP

--- a/compiler/testData/codegen/box/ranges/forInReversed/forInReversedReversedUntil.kt
+++ b/compiler/testData/codegen/box/ranges/forInReversed/forInReversedReversedUntil.kt
@@ -1,0 +1,24 @@
+// WITH_RUNTIME
+import kotlin.test.*
+
+fun box(): String {
+    var sum = 0
+    for (i in (1 until 5).reversed().reversed()) {
+        sum = sum * 10 + i
+    }
+    assertEquals(1234, sum)
+
+    var sumL = 0L
+    for (i in (1L until 5L).reversed().reversed()) {
+        sumL = sumL * 10 + i
+    }
+    assertEquals(1234, sumL)
+
+    var sumC = 0
+    for (i in ('1' until '5').reversed().reversed()) {
+        sumC = sumC * 10 + i.toInt() - '0'.toInt()
+    }
+    assertEquals(1234, sumC)
+
+    return "OK"
+}

--- a/compiler/testData/codegen/box/ranges/forInReversed/forInReversedReversedUntilWithNonConstBounds.kt
+++ b/compiler/testData/codegen/box/ranges/forInReversed/forInReversedReversedUntilWithNonConstBounds.kt
@@ -1,0 +1,31 @@
+// WITH_RUNTIME
+import kotlin.test.*
+
+fun intLow() = 1
+fun intHigh() = 5
+fun longLow() = 1L
+fun longHigh() = 5L
+fun charLow() = '1'
+fun charHigh() = '5'
+
+fun box(): String {
+    var sum = 0
+    for (i in (intLow() until intHigh()).reversed().reversed()) {
+        sum = sum * 10 + i
+    }
+    assertEquals(1234, sum)
+
+    var sumL = 0L
+    for (i in (longLow() until longHigh()).reversed().reversed()) {
+        sumL = sumL * 10 + i
+    }
+    assertEquals(1234, sumL)
+
+    var sumC = 0
+    for (i in (charLow() until charHigh()).reversed().reversed()) {
+        sumC = sumC * 10 + i.toInt() - '0'.toInt()
+    }
+    assertEquals(1234, sumC)
+
+    return "OK"
+}

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInReversed/ForInReversedReversedRange.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInReversed/ForInReversedReversedRange.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 import kotlin.test.*
 
 fun intRange() = 1 .. 4
@@ -28,3 +27,8 @@ fun box(): String {
 }
 
 // 0 reversed
+// 0 iterator
+// 0 getStart
+// 0 getEnd
+// 3 getFirst
+// 3 getLast

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInReversed/forInReversedCharSequenceIndices.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInReversed/forInReversedCharSequenceIndices.kt
@@ -1,4 +1,5 @@
 // IGNORE_BACKEND: JVM_IR
+// NOTE: Enable once CharSequence.indices is handled
 import kotlin.test.*
 
 fun box(): String {
@@ -13,3 +14,11 @@ fun box(): String {
 }
 
 // 0 reversed
+// 0 iterator
+// 0 getStart
+// 0 getEnd
+// 0 getFirst
+// 0 getLast
+// 0 getStep
+// 1 IF(_ICMPG|L)T
+// 1 IF

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInReversed/forInReversedCollectionIndices.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInReversed/forInReversedCollectionIndices.kt
@@ -1,4 +1,5 @@
 // IGNORE_BACKEND: JVM_IR
+// NOTE: Enable once Collection.indices is handled
 import kotlin.test.*
 
 fun box(): String {
@@ -13,3 +14,11 @@ fun box(): String {
 }
 
 // 0 reversed
+// 0 iterator
+// 0 getStart
+// 0 getEnd
+// 0 getFirst
+// 0 getLast
+// 0 getStep
+// 1 IF(_ICMPG|L)T
+// 1 IF

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInReversed/forInReversedEmptyRangeLiteral.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInReversed/forInReversedEmptyRangeLiteral.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 fun box(): String {
     for (i in (4 .. 1).reversed()) {
         throw AssertionError("Loop should not be executed")
@@ -13,6 +12,7 @@ fun box(): String {
 }
 
 // 0 reversed
+// 0 iterator
 // 0 getStart
 // 0 getEnd
 // 0 getFirst

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInReversed/forInReversedRange.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInReversed/forInReversedRange.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 import kotlin.test.*
 
 fun intRange() = 1 .. 4
@@ -28,3 +27,8 @@ fun box(): String {
 }
 
 // 0 reversed
+// 0 iterator
+// 0 getStart
+// 0 getEnd
+// 3 getFirst
+// 3 getLast

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInReversed/forInReversedReversedArrayIndices.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInReversed/forInReversedReversedArrayIndices.kt
@@ -3,7 +3,7 @@ import kotlin.test.*
 fun box(): String {
     val arr = intArrayOf(1, 1, 1, 1)
     var sum = 0
-    for (i in arr.indices.reversed()) {
+    for (i in arr.indices.reversed().reversed()) {
         sum = sum * 10 + i + arr[i]
     }
     assertEquals(4321, sum)
@@ -18,5 +18,3 @@ fun box(): String {
 // 0 getFirst
 // 0 getLast
 // 0 getStep
-// 1 IF(_ICMPG|L)T
-// 1 IF

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInReversed/forInReversedReversedDownTo.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInReversed/forInReversedReversedDownTo.kt
@@ -2,19 +2,19 @@ import kotlin.test.*
 
 fun box(): String {
     var sum = 0
-    for (i in (4 downTo 1).reversed()) {
+    for (i in (4 downTo 1).reversed().reversed()) {
         sum = sum * 10 + i
     }
     assertEquals(1234, sum)
 
     var sumL = 0L
-    for (i in (4L downTo 1L).reversed()) {
+    for (i in (4L downTo 1L).reversed().reversed()) {
         sumL = sumL * 10 + i
     }
     assertEquals(1234L, sumL)
 
     var sumC = 0
-    for (i in ('4' downTo '1').reversed()) {
+    for (i in ('4' downTo '1').reversed().reversed()) {
         sumC = sumC * 10 + i.toInt() - '0'.toInt()
     }
     assertEquals(1234, sumC)

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInReversed/forInReversedReversedReversedRange.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInReversed/forInReversedReversedReversedRange.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 import kotlin.test.*
 
 fun intRange() = 1 .. 4
@@ -28,3 +27,8 @@ fun box(): String {
 }
 
 // 0 reversed
+// 0 iterator
+// 0 getStart
+// 0 getEnd
+// 3 getFirst
+// 3 getLast

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInReversed/forInReversedReversedUntil.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInReversed/forInReversedReversedUntil.kt
@@ -2,22 +2,19 @@ import kotlin.test.*
 
 fun box(): String {
     var sum = 0
-    for (i in (4 downTo 1).reversed()) {
+    for (i in (1 until 5).reversed().reversed()) {
         sum = sum * 10 + i
     }
-    assertEquals(1234, sum)
 
     var sumL = 0L
-    for (i in (4L downTo 1L).reversed()) {
+    for (i in (1L until 5L).reversed().reversed()) {
         sumL = sumL * 10 + i
     }
-    assertEquals(1234L, sumL)
 
     var sumC = 0
-    for (i in ('4' downTo '1').reversed()) {
+    for (i in ('1' until '5').reversed().reversed()) {
         sumC = sumC * 10 + i.toInt() - '0'.toInt()
     }
-    assertEquals(1234, sumC)
 
     return "OK"
 }
@@ -29,7 +26,7 @@ fun box(): String {
 // 0 getFirst
 // 0 getLast
 // 0 getStep
-// 2 IF_ICMP[LG]T
-// 1 IF[LG]T
+// 2 IF_ICMP[LG]E
+// 1 IF[LG]E
 // 3 IF
 // 1 LCMP

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInReversed/forInReversedUntil.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInReversed/forInReversedUntil.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 import kotlin.test.*
 
 fun box(): String {
@@ -21,3 +20,13 @@ fun box(): String {
 }
 
 // 0 reversed
+// 0 iterator
+// 0 getStart
+// 0 getEnd
+// 0 getFirst
+// 0 getLast
+// 0 getStep
+// 2 IF_ICMP[LG]T
+// 1 IF[LG]T
+// 3 IF
+// 1 LCMP

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -648,6 +648,39 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             }
         }
 
+        @TestMetadata("compiler/testData/codegen/box/arrays/forInReversed")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class ForInReversed extends AbstractBlackBoxCodegenTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInForInReversed() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/codegen/box/arrays/forInReversed"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.JVM, true);
+            }
+
+            @TestMetadata("reversedArrayOriginalUpdatedInLoopBody.kt")
+            public void testReversedArrayOriginalUpdatedInLoopBody() throws Exception {
+                runTest("compiler/testData/codegen/box/arrays/forInReversed/reversedArrayOriginalUpdatedInLoopBody.kt");
+            }
+
+            @TestMetadata("reversedArrayReversedArrayOriginalUpdatedInLoopBody.kt")
+            public void testReversedArrayReversedArrayOriginalUpdatedInLoopBody() throws Exception {
+                runTest("compiler/testData/codegen/box/arrays/forInReversed/reversedArrayReversedArrayOriginalUpdatedInLoopBody.kt");
+            }
+
+            @TestMetadata("reversedOriginalUpdatedInLoopBody.kt")
+            public void testReversedOriginalUpdatedInLoopBody() throws Exception {
+                runTest("compiler/testData/codegen/box/arrays/forInReversed/reversedOriginalUpdatedInLoopBody.kt");
+            }
+
+            @TestMetadata("reversedReversedOriginalUpdatedInLoopBody.kt")
+            public void testReversedReversedOriginalUpdatedInLoopBody() throws Exception {
+                runTest("compiler/testData/codegen/box/arrays/forInReversed/reversedReversedOriginalUpdatedInLoopBody.kt");
+            }
+        }
+
         @TestMetadata("compiler/testData/codegen/box/arrays/multiDecl")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)
@@ -18982,6 +19015,16 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
                 runTest("compiler/testData/codegen/box/ranges/forInReversed/forInReversedRangeLiteralWithNonConstBounds.kt");
             }
 
+            @TestMetadata("forInReversedReversedArrayIndices.kt")
+            public void testForInReversedReversedArrayIndices() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/forInReversed/forInReversedReversedArrayIndices.kt");
+            }
+
+            @TestMetadata("forInReversedReversedDownTo.kt")
+            public void testForInReversedReversedDownTo() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/forInReversed/forInReversedReversedDownTo.kt");
+            }
+
             @TestMetadata("ForInReversedReversedRange.kt")
             public void testForInReversedReversedRange() throws Exception {
                 runTest("compiler/testData/codegen/box/ranges/forInReversed/ForInReversedReversedRange.kt");
@@ -18990,6 +19033,16 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             @TestMetadata("forInReversedReversedReversedRange.kt")
             public void testForInReversedReversedReversedRange() throws Exception {
                 runTest("compiler/testData/codegen/box/ranges/forInReversed/forInReversedReversedReversedRange.kt");
+            }
+
+            @TestMetadata("forInReversedReversedUntil.kt")
+            public void testForInReversedReversedUntil() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/forInReversed/forInReversedReversedUntil.kt");
+            }
+
+            @TestMetadata("forInReversedReversedUntilWithNonConstBounds.kt")
+            public void testForInReversedReversedUntilWithNonConstBounds() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/forInReversed/forInReversedReversedUntilWithNonConstBounds.kt");
             }
 
             @TestMetadata("forInReversedUntil.kt")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
@@ -1971,6 +1971,16 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
                 runTest("compiler/testData/codegen/bytecodeText/forLoop/forInReversed/forInReversedRangeLiteral.kt");
             }
 
+            @TestMetadata("forInReversedReversedArrayIndices.kt")
+            public void testForInReversedReversedArrayIndices() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInReversed/forInReversedReversedArrayIndices.kt");
+            }
+
+            @TestMetadata("forInReversedReversedDownTo.kt")
+            public void testForInReversedReversedDownTo() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInReversed/forInReversedReversedDownTo.kt");
+            }
+
             @TestMetadata("ForInReversedReversedRange.kt")
             public void testForInReversedReversedRange() throws Exception {
                 runTest("compiler/testData/codegen/bytecodeText/forLoop/forInReversed/ForInReversedReversedRange.kt");
@@ -1979,6 +1989,11 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
             @TestMetadata("forInReversedReversedReversedRange.kt")
             public void testForInReversedReversedReversedRange() throws Exception {
                 runTest("compiler/testData/codegen/bytecodeText/forLoop/forInReversed/forInReversedReversedReversedRange.kt");
+            }
+
+            @TestMetadata("forInReversedReversedUntil.kt")
+            public void testForInReversedReversedUntil() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInReversed/forInReversedReversedUntil.kt");
             }
 
             @TestMetadata("forInReversedUntil.kt")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -648,6 +648,39 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             }
         }
 
+        @TestMetadata("compiler/testData/codegen/box/arrays/forInReversed")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class ForInReversed extends AbstractLightAnalysisModeTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInForInReversed() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/codegen/box/arrays/forInReversed"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.JVM, true);
+            }
+
+            @TestMetadata("reversedArrayOriginalUpdatedInLoopBody.kt")
+            public void testReversedArrayOriginalUpdatedInLoopBody() throws Exception {
+                runTest("compiler/testData/codegen/box/arrays/forInReversed/reversedArrayOriginalUpdatedInLoopBody.kt");
+            }
+
+            @TestMetadata("reversedArrayReversedArrayOriginalUpdatedInLoopBody.kt")
+            public void testReversedArrayReversedArrayOriginalUpdatedInLoopBody() throws Exception {
+                runTest("compiler/testData/codegen/box/arrays/forInReversed/reversedArrayReversedArrayOriginalUpdatedInLoopBody.kt");
+            }
+
+            @TestMetadata("reversedOriginalUpdatedInLoopBody.kt")
+            public void testReversedOriginalUpdatedInLoopBody() throws Exception {
+                runTest("compiler/testData/codegen/box/arrays/forInReversed/reversedOriginalUpdatedInLoopBody.kt");
+            }
+
+            @TestMetadata("reversedReversedOriginalUpdatedInLoopBody.kt")
+            public void testReversedReversedOriginalUpdatedInLoopBody() throws Exception {
+                runTest("compiler/testData/codegen/box/arrays/forInReversed/reversedReversedOriginalUpdatedInLoopBody.kt");
+            }
+        }
+
         @TestMetadata("compiler/testData/codegen/box/arrays/multiDecl")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)
@@ -18982,6 +19015,16 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
                 runTest("compiler/testData/codegen/box/ranges/forInReversed/forInReversedRangeLiteralWithNonConstBounds.kt");
             }
 
+            @TestMetadata("forInReversedReversedArrayIndices.kt")
+            public void testForInReversedReversedArrayIndices() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/forInReversed/forInReversedReversedArrayIndices.kt");
+            }
+
+            @TestMetadata("forInReversedReversedDownTo.kt")
+            public void testForInReversedReversedDownTo() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/forInReversed/forInReversedReversedDownTo.kt");
+            }
+
             @TestMetadata("ForInReversedReversedRange.kt")
             public void testForInReversedReversedRange() throws Exception {
                 runTest("compiler/testData/codegen/box/ranges/forInReversed/ForInReversedReversedRange.kt");
@@ -18990,6 +19033,16 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             @TestMetadata("forInReversedReversedReversedRange.kt")
             public void testForInReversedReversedReversedRange() throws Exception {
                 runTest("compiler/testData/codegen/box/ranges/forInReversed/forInReversedReversedReversedRange.kt");
+            }
+
+            @TestMetadata("forInReversedReversedUntil.kt")
+            public void testForInReversedReversedUntil() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/forInReversed/forInReversedReversedUntil.kt");
+            }
+
+            @TestMetadata("forInReversedReversedUntilWithNonConstBounds.kt")
+            public void testForInReversedReversedUntilWithNonConstBounds() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/forInReversed/forInReversedReversedUntilWithNonConstBounds.kt");
             }
 
             @TestMetadata("forInReversedUntil.kt")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -648,6 +648,39 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             }
         }
 
+        @TestMetadata("compiler/testData/codegen/box/arrays/forInReversed")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class ForInReversed extends AbstractIrBlackBoxCodegenTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM_IR, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInForInReversed() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/codegen/box/arrays/forInReversed"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.JVM_IR, true);
+            }
+
+            @TestMetadata("reversedArrayOriginalUpdatedInLoopBody.kt")
+            public void testReversedArrayOriginalUpdatedInLoopBody() throws Exception {
+                runTest("compiler/testData/codegen/box/arrays/forInReversed/reversedArrayOriginalUpdatedInLoopBody.kt");
+            }
+
+            @TestMetadata("reversedArrayReversedArrayOriginalUpdatedInLoopBody.kt")
+            public void testReversedArrayReversedArrayOriginalUpdatedInLoopBody() throws Exception {
+                runTest("compiler/testData/codegen/box/arrays/forInReversed/reversedArrayReversedArrayOriginalUpdatedInLoopBody.kt");
+            }
+
+            @TestMetadata("reversedOriginalUpdatedInLoopBody.kt")
+            public void testReversedOriginalUpdatedInLoopBody() throws Exception {
+                runTest("compiler/testData/codegen/box/arrays/forInReversed/reversedOriginalUpdatedInLoopBody.kt");
+            }
+
+            @TestMetadata("reversedReversedOriginalUpdatedInLoopBody.kt")
+            public void testReversedReversedOriginalUpdatedInLoopBody() throws Exception {
+                runTest("compiler/testData/codegen/box/arrays/forInReversed/reversedReversedOriginalUpdatedInLoopBody.kt");
+            }
+        }
+
         @TestMetadata("compiler/testData/codegen/box/arrays/multiDecl")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)
@@ -18987,6 +19020,16 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
                 runTest("compiler/testData/codegen/box/ranges/forInReversed/forInReversedRangeLiteralWithNonConstBounds.kt");
             }
 
+            @TestMetadata("forInReversedReversedArrayIndices.kt")
+            public void testForInReversedReversedArrayIndices() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/forInReversed/forInReversedReversedArrayIndices.kt");
+            }
+
+            @TestMetadata("forInReversedReversedDownTo.kt")
+            public void testForInReversedReversedDownTo() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/forInReversed/forInReversedReversedDownTo.kt");
+            }
+
             @TestMetadata("ForInReversedReversedRange.kt")
             public void testForInReversedReversedRange() throws Exception {
                 runTest("compiler/testData/codegen/box/ranges/forInReversed/ForInReversedReversedRange.kt");
@@ -18995,6 +19038,16 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             @TestMetadata("forInReversedReversedReversedRange.kt")
             public void testForInReversedReversedReversedRange() throws Exception {
                 runTest("compiler/testData/codegen/box/ranges/forInReversed/forInReversedReversedReversedRange.kt");
+            }
+
+            @TestMetadata("forInReversedReversedUntil.kt")
+            public void testForInReversedReversedUntil() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/forInReversed/forInReversedReversedUntil.kt");
+            }
+
+            @TestMetadata("forInReversedReversedUntilWithNonConstBounds.kt")
+            public void testForInReversedReversedUntilWithNonConstBounds() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/forInReversed/forInReversedReversedUntilWithNonConstBounds.kt");
             }
 
             @TestMetadata("forInReversedUntil.kt")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
@@ -1981,6 +1981,16 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
                 runTest("compiler/testData/codegen/bytecodeText/forLoop/forInReversed/forInReversedRangeLiteral.kt");
             }
 
+            @TestMetadata("forInReversedReversedArrayIndices.kt")
+            public void testForInReversedReversedArrayIndices() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInReversed/forInReversedReversedArrayIndices.kt");
+            }
+
+            @TestMetadata("forInReversedReversedDownTo.kt")
+            public void testForInReversedReversedDownTo() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInReversed/forInReversedReversedDownTo.kt");
+            }
+
             @TestMetadata("ForInReversedReversedRange.kt")
             public void testForInReversedReversedRange() throws Exception {
                 runTest("compiler/testData/codegen/bytecodeText/forLoop/forInReversed/ForInReversedReversedRange.kt");
@@ -1989,6 +1999,11 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
             @TestMetadata("forInReversedReversedReversedRange.kt")
             public void testForInReversedReversedReversedRange() throws Exception {
                 runTest("compiler/testData/codegen/bytecodeText/forLoop/forInReversed/forInReversedReversedReversedRange.kt");
+            }
+
+            @TestMetadata("forInReversedReversedUntil.kt")
+            public void testForInReversedReversedUntil() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInReversed/forInReversedReversedUntil.kt");
             }
 
             @TestMetadata("forInReversedUntil.kt")

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -488,6 +488,39 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             }
         }
 
+        @TestMetadata("compiler/testData/codegen/box/arrays/forInReversed")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class ForInReversed extends AbstractIrJsCodegenBoxTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest0(this::doTest, TargetBackend.JS_IR, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInForInReversed() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/codegen/box/arrays/forInReversed"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.JS_IR, true);
+            }
+
+            @TestMetadata("reversedArrayOriginalUpdatedInLoopBody.kt")
+            public void testReversedArrayOriginalUpdatedInLoopBody() throws Exception {
+                runTest("compiler/testData/codegen/box/arrays/forInReversed/reversedArrayOriginalUpdatedInLoopBody.kt");
+            }
+
+            @TestMetadata("reversedArrayReversedArrayOriginalUpdatedInLoopBody.kt")
+            public void testReversedArrayReversedArrayOriginalUpdatedInLoopBody() throws Exception {
+                runTest("compiler/testData/codegen/box/arrays/forInReversed/reversedArrayReversedArrayOriginalUpdatedInLoopBody.kt");
+            }
+
+            @TestMetadata("reversedOriginalUpdatedInLoopBody.kt")
+            public void testReversedOriginalUpdatedInLoopBody() throws Exception {
+                runTest("compiler/testData/codegen/box/arrays/forInReversed/reversedOriginalUpdatedInLoopBody.kt");
+            }
+
+            @TestMetadata("reversedReversedOriginalUpdatedInLoopBody.kt")
+            public void testReversedReversedOriginalUpdatedInLoopBody() throws Exception {
+                runTest("compiler/testData/codegen/box/arrays/forInReversed/reversedReversedOriginalUpdatedInLoopBody.kt");
+            }
+        }
+
         @TestMetadata("compiler/testData/codegen/box/arrays/multiDecl")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)
@@ -15042,6 +15075,16 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
                 runTest("compiler/testData/codegen/box/ranges/forInReversed/forInReversedRangeLiteralWithNonConstBounds.kt");
             }
 
+            @TestMetadata("forInReversedReversedArrayIndices.kt")
+            public void testForInReversedReversedArrayIndices() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/forInReversed/forInReversedReversedArrayIndices.kt");
+            }
+
+            @TestMetadata("forInReversedReversedDownTo.kt")
+            public void testForInReversedReversedDownTo() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/forInReversed/forInReversedReversedDownTo.kt");
+            }
+
             @TestMetadata("ForInReversedReversedRange.kt")
             public void testForInReversedReversedRange() throws Exception {
                 runTest("compiler/testData/codegen/box/ranges/forInReversed/ForInReversedReversedRange.kt");
@@ -15050,6 +15093,16 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             @TestMetadata("forInReversedReversedReversedRange.kt")
             public void testForInReversedReversedReversedRange() throws Exception {
                 runTest("compiler/testData/codegen/box/ranges/forInReversed/forInReversedReversedReversedRange.kt");
+            }
+
+            @TestMetadata("forInReversedReversedUntil.kt")
+            public void testForInReversedReversedUntil() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/forInReversed/forInReversedReversedUntil.kt");
+            }
+
+            @TestMetadata("forInReversedReversedUntilWithNonConstBounds.kt")
+            public void testForInReversedReversedUntilWithNonConstBounds() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/forInReversed/forInReversedReversedUntilWithNonConstBounds.kt");
             }
 
             @TestMetadata("forInReversedUntil.kt")

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -488,6 +488,39 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             }
         }
 
+        @TestMetadata("compiler/testData/codegen/box/arrays/forInReversed")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class ForInReversed extends AbstractJsCodegenBoxTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest0(this::doTest, TargetBackend.JS, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInForInReversed() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/codegen/box/arrays/forInReversed"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.JS, true);
+            }
+
+            @TestMetadata("reversedArrayOriginalUpdatedInLoopBody.kt")
+            public void testReversedArrayOriginalUpdatedInLoopBody() throws Exception {
+                runTest("compiler/testData/codegen/box/arrays/forInReversed/reversedArrayOriginalUpdatedInLoopBody.kt");
+            }
+
+            @TestMetadata("reversedArrayReversedArrayOriginalUpdatedInLoopBody.kt")
+            public void testReversedArrayReversedArrayOriginalUpdatedInLoopBody() throws Exception {
+                runTest("compiler/testData/codegen/box/arrays/forInReversed/reversedArrayReversedArrayOriginalUpdatedInLoopBody.kt");
+            }
+
+            @TestMetadata("reversedOriginalUpdatedInLoopBody.kt")
+            public void testReversedOriginalUpdatedInLoopBody() throws Exception {
+                runTest("compiler/testData/codegen/box/arrays/forInReversed/reversedOriginalUpdatedInLoopBody.kt");
+            }
+
+            @TestMetadata("reversedReversedOriginalUpdatedInLoopBody.kt")
+            public void testReversedReversedOriginalUpdatedInLoopBody() throws Exception {
+                runTest("compiler/testData/codegen/box/arrays/forInReversed/reversedReversedOriginalUpdatedInLoopBody.kt");
+            }
+        }
+
         @TestMetadata("compiler/testData/codegen/box/arrays/multiDecl")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)
@@ -16212,6 +16245,16 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
                 runTest("compiler/testData/codegen/box/ranges/forInReversed/forInReversedRangeLiteralWithNonConstBounds.kt");
             }
 
+            @TestMetadata("forInReversedReversedArrayIndices.kt")
+            public void testForInReversedReversedArrayIndices() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/forInReversed/forInReversedReversedArrayIndices.kt");
+            }
+
+            @TestMetadata("forInReversedReversedDownTo.kt")
+            public void testForInReversedReversedDownTo() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/forInReversed/forInReversedReversedDownTo.kt");
+            }
+
             @TestMetadata("ForInReversedReversedRange.kt")
             public void testForInReversedReversedRange() throws Exception {
                 runTest("compiler/testData/codegen/box/ranges/forInReversed/ForInReversedReversedRange.kt");
@@ -16220,6 +16263,16 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             @TestMetadata("forInReversedReversedReversedRange.kt")
             public void testForInReversedReversedReversedRange() throws Exception {
                 runTest("compiler/testData/codegen/box/ranges/forInReversed/forInReversedReversedReversedRange.kt");
+            }
+
+            @TestMetadata("forInReversedReversedUntil.kt")
+            public void testForInReversedReversedUntil() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/forInReversed/forInReversedReversedUntil.kt");
+            }
+
+            @TestMetadata("forInReversedReversedUntilWithNonConstBounds.kt")
+            public void testForInReversedReversedUntilWithNonConstBounds() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/forInReversed/forInReversedReversedUntilWithNonConstBounds.kt");
             }
 
             @TestMetadata("forInReversedUntil.kt")

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsLegacyPrimitiveArraysBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsLegacyPrimitiveArraysBoxTestGenerated.java
@@ -352,6 +352,39 @@ public class JsLegacyPrimitiveArraysBoxTestGenerated extends AbstractJsLegacyPri
         }
     }
 
+    @TestMetadata("compiler/testData/codegen/box/arrays/forInReversed")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class ForInReversed extends AbstractJsLegacyPrimitiveArraysBoxTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest0(this::doTest, TargetBackend.JS, testDataFilePath);
+        }
+
+        public void testAllFilesPresentInForInReversed() throws Exception {
+            KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/codegen/box/arrays/forInReversed"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.JS, true);
+        }
+
+        @TestMetadata("reversedArrayOriginalUpdatedInLoopBody.kt")
+        public void testReversedArrayOriginalUpdatedInLoopBody() throws Exception {
+            runTest("compiler/testData/codegen/box/arrays/forInReversed/reversedArrayOriginalUpdatedInLoopBody.kt");
+        }
+
+        @TestMetadata("reversedArrayReversedArrayOriginalUpdatedInLoopBody.kt")
+        public void testReversedArrayReversedArrayOriginalUpdatedInLoopBody() throws Exception {
+            runTest("compiler/testData/codegen/box/arrays/forInReversed/reversedArrayReversedArrayOriginalUpdatedInLoopBody.kt");
+        }
+
+        @TestMetadata("reversedOriginalUpdatedInLoopBody.kt")
+        public void testReversedOriginalUpdatedInLoopBody() throws Exception {
+            runTest("compiler/testData/codegen/box/arrays/forInReversed/reversedOriginalUpdatedInLoopBody.kt");
+        }
+
+        @TestMetadata("reversedReversedOriginalUpdatedInLoopBody.kt")
+        public void testReversedReversedOriginalUpdatedInLoopBody() throws Exception {
+            runTest("compiler/testData/codegen/box/arrays/forInReversed/reversedReversedOriginalUpdatedInLoopBody.kt");
+        }
+    }
+
     @TestMetadata("compiler/testData/codegen/box/arrays/multiDecl")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)


### PR DESCRIPTION
This includes calls to `reversed()` on Progressions, and `reversed()` and `reversedArray()` on Arrays. Note that the non-IR backend does _not_ optimize for-loop over reversed arrays, hence the new bytecode tests for reversed arrays are disabled.

Extracting `HeaderInfo` from iterables is now done in a unified manner, so that we can handle chained calls better, i.e., `ReversedHandler` can reverse `HeaderInfo` from both Progressions and Arrays.