### PR TITLE
Fix SAM_WITH_RECEIVER_PLUGIN_NAME.

### DIFF
--- a/compiler/util/src/org/jetbrains/kotlin/utils/PathUtil.kt
+++ b/compiler/util/src/org/jetbrains/kotlin/utils/PathUtil.kt
@@ -31,7 +31,7 @@ object PathUtil {
     const val ALLOPEN_PLUGIN_JAR_NAME = "$ALLOPEN_PLUGIN_NAME.jar"
     const val NOARG_PLUGIN_NAME = "noarg-compiler-plugin"
     const val NOARG_PLUGIN_JAR_NAME = "$NOARG_PLUGIN_NAME.jar"
-    const val SAM_WITH_RECEIVER_PLUGIN_NAME = ".jar"
+    const val SAM_WITH_RECEIVER_PLUGIN_NAME = "sam-with-receiver-compiler-plugin"
     const val SAM_WITH_RECEIVER_PLUGIN_JAR_NAME = "$SAM_WITH_RECEIVER_PLUGIN_NAME.jar"
     const val JS_LIB_SRC_JAR_NAME = "kotlin-stdlib-js-sources.jar"
 


### PR DESCRIPTION
SAM_WITH_RECEIVER_PLUGIN_NAME in PathUtil was accidentally broken by
https://github.com/JetBrains/kotlin/commit/4c751cdd529ccc65118968b7f928a4b3e44ce81f#diff-819dacd07c45ba85ba5459d8a09418daR34