### PR TITLE
Create a single instance of IrIntrinsicMethods per context

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendContext.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendContext.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.backend.common.ir.Ir
 import org.jetbrains.kotlin.backend.common.phaser.PhaseConfig
 import org.jetbrains.kotlin.backend.jvm.descriptors.JvmDeclarationFactory
 import org.jetbrains.kotlin.backend.jvm.descriptors.JvmSharedVariablesManager
+import org.jetbrains.kotlin.backend.jvm.intrinsics.IrIntrinsicMethods
 import org.jetbrains.kotlin.codegen.state.GenerationState
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.incremental.components.NoLookupLocation
@@ -37,6 +38,8 @@ class JvmBackendContext(
 
     private val symbolTable = symbolTable.lazyWrapper
     override val ir = JvmIr(irModuleFragment, this.symbolTable)
+
+    val irIntrinsics = IrIntrinsicMethods(irBuiltIns)
 
     override var inVerbosePhase: Boolean = false
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -115,9 +115,6 @@ class ExpressionCodegen(
 
     var finallyDepth = 0
 
-    /*TODO*/
-    val intrinsics = IrIntrinsicMethods(classCodegen.context.irBuiltIns)
-
     val typeMapper = classCodegen.typeMapper
 
     val returnType = typeMapper.mapReturnType(irFunction.descriptor)
@@ -801,7 +798,7 @@ class ExpressionCodegen(
         // For comparison intrinsics, branch directly based on the comparison instead of
         // materializing a boolean and performing and extra jump.
         if (condition is IrCall) {
-            val intrinsic = intrinsics.getIntrinsic(condition.descriptor.original as CallableMemberDescriptor)
+            val intrinsic = classCodegen.context.irIntrinsics.getIntrinsic(condition.descriptor.original as CallableMemberDescriptor)
             if (intrinsic is ComparisonIntrinsic) {
                 val callable = resolveToCallable(condition, false)
                 (callable as IrIntrinsicFunction).loadArguments(this, data)
@@ -1224,7 +1221,7 @@ class ExpressionCodegen(
     }
 
     private fun resolveToCallable(irCall: IrMemberAccessExpression, isSuper: Boolean): Callable {
-        val intrinsic = intrinsics.getIntrinsic(irCall.descriptor.original as CallableMemberDescriptor)
+        val intrinsic = classCodegen.context.irIntrinsics.getIntrinsic(irCall.descriptor.original as CallableMemberDescriptor)
         if (intrinsic != null) {
             return intrinsic.toCallable(
                 irCall,

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/AnnotationLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/AnnotationLowering.kt
@@ -153,12 +153,8 @@ private class AnnotationLowering(private val context: JvmBackendContext) : FileL
         return context.irBuiltIns.arrayClass.createType(false, listOf(argument))
     }
 
-    private val intrinsics = IrIntrinsicMethods(context.irBuiltIns)
-
-    private fun IrCall.isGetJava(): Boolean {
-        val intrinsic = intrinsics.getIntrinsic(descriptor.original)
-        return intrinsic is KClassJavaProperty
-    }
+    private fun IrCall.isGetJava(): Boolean =
+        context.irIntrinsics.getIntrinsic(descriptor.original) is KClassJavaProperty
 }
 
 private fun IrClassSymbol.getFunctionByName(name: String, numParams: Int): IrSimpleFunctionSymbol =


### PR DESCRIPTION
This improves JVM_IR compilation times a bit.