### PR TITLE
KT-30816 BasicJvmScriptEvaluator incorrect arg order

### DIFF
--- a/libraries/scripting/jvm-host/src/kotlin/script/experimental/jvmhost/jvmScriptEvaluation.kt
+++ b/libraries/scripting/jvm-host/src/kotlin/script/experimental/jvmhost/jvmScriptEvaluation.kt
@@ -59,11 +59,11 @@ open class BasicJvmScriptEvaluator : ScriptEvaluator {
                     updatedEvalConfiguration[ScriptEvaluationConfiguration.constructorArgs]?.let {
                         args.addAll(it)
                     }
-                    actualEvaluationConfiguration[ScriptEvaluationConfiguration.providedProperties]?.forEach {
-                        args.add(it.value)
-                    }
                     actualEvaluationConfiguration[ScriptEvaluationConfiguration.implicitReceivers]?.let {
                         args.addAll(it)
+                    }
+                    actualEvaluationConfiguration[ScriptEvaluationConfiguration.providedProperties]?.forEach {
+                        args.add(it.value)
                     }
 
                     compiledScript.otherScripts.mapSuccess {

--- a/libraries/scripting/jvm-host/test/kotlin/script/experimental/jvmhost/test/ConstructorArgumentOrderTest.kt
+++ b/libraries/scripting/jvm-host/test/kotlin/script/experimental/jvmhost/test/ConstructorArgumentOrderTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the license/LICENSE.txt file.
+ */
+
+package kotlin.script.experimental.jvmhost.test
+
+import org.junit.Test
+import kotlin.script.experimental.api.ResultWithDiagnostics
+import kotlin.script.experimental.api.implicitReceivers
+import kotlin.script.experimental.api.providedProperties
+import kotlin.test.assertTrue
+
+class ConstructorArgumentsOrderTest {
+
+    @Test
+    fun testScriptWithProvidedProperties() {
+        val res = evalString<ScriptWithProvidedProperties>("""println(providedString)""") {
+            providedProperties("providedString" to "Hello Provided!")
+        }
+
+        assertTrue(
+            res is ResultWithDiagnostics.Success,
+            "test failed:\n  ${res.reports.joinToString("\n  ") { it.message + if (it.exception == null) "" else ": ${it.exception}" }}"
+        )
+    }
+
+    @Test
+    fun testScriptWithImplicitReceiver() {
+        val res = evalString<ScriptWithImplicitReceiver>("""println(receiverString)""") {
+            implicitReceivers(ImplicitReceiverClass("Hello Receiver!"))
+        }
+
+        assertTrue(
+            res is ResultWithDiagnostics.Success,
+            "test failed:\n  ${res.reports.joinToString("\n  ") { it.message + if (it.exception == null) "" else ": ${it.exception}" }}"
+        )
+    }
+
+    @Test
+    fun testScriptWithBoth() {
+        val res = evalString<ScriptWithBoth>("""println(providedString + receiverString)""") {
+            providedProperties("providedString" to "Hello")
+            implicitReceivers(ImplicitReceiverClass(" Both!"))
+        }
+
+        assertTrue(
+            res is ResultWithDiagnostics.Success,
+            "test failed:\n  ${res.reports.joinToString("\n  ") { it.message + if (it.exception == null) "" else ": ${it.exception}" }}"
+        )
+    }
+}

--- a/libraries/scripting/jvm-host/test/kotlin/script/experimental/jvmhost/test/TestScriptDefinitions.kt
+++ b/libraries/scripting/jvm-host/test/kotlin/script/experimental/jvmhost/test/TestScriptDefinitions.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the license/LICENSE.txt file.
+ */
+
+package kotlin.script.experimental.jvmhost.test
+
+import kotlin.script.experimental.annotations.KotlinScript
+import kotlin.script.experimental.api.*
+import kotlin.script.experimental.host.toScriptSource
+import kotlin.script.experimental.jvm.dependenciesFromCurrentContext
+import kotlin.script.experimental.jvm.jvm
+import kotlin.script.experimental.jvmhost.BasicJvmScriptingHost
+import kotlin.script.experimental.jvmhost.createJvmCompilationConfigurationFromTemplate
+
+@KotlinScript(fileExtension = "withboth.kts", compilationConfiguration = ReceiverAndPropertiesConfiguration::class)
+abstract class ScriptWithBoth
+
+@KotlinScript(fileExtension = "withproperties.kts", compilationConfiguration = ProvidedPropertiesConfiguration::class)
+abstract class ScriptWithProvidedProperties
+
+@KotlinScript(fileExtension = "withreceiver.kts", compilationConfiguration = ImplicitReceiverConfiguration::class)
+abstract class ScriptWithImplicitReceiver
+
+object ReceiverAndPropertiesConfiguration : ScriptCompilationConfiguration(
+    {
+        jvm { dependenciesFromCurrentContext(wholeClasspath = true) }
+
+        providedProperties("providedString" to String::class)
+
+        implicitReceivers(ImplicitReceiverClass::class)
+    }
+)
+
+object ProvidedPropertiesConfiguration : ScriptCompilationConfiguration(
+    {
+        jvm { dependenciesFromCurrentContext(wholeClasspath = true) }
+
+        providedProperties("providedString" to String::class)
+    }
+)
+
+object ImplicitReceiverConfiguration : ScriptCompilationConfiguration(
+    {
+        jvm { dependenciesFromCurrentContext(wholeClasspath = true) }
+
+        implicitReceivers(ImplicitReceiverClass::class)
+    }
+)
+
+class ImplicitReceiverClass(val receiverString: String)
+
+inline fun <reified T : Any> evalString(
+    source: String,
+    noinline configure: ScriptEvaluationConfiguration.Builder.() -> Unit
+): ResultWithDiagnostics<EvaluationResult> {
+    val actualConfiguration = createJvmCompilationConfigurationFromTemplate<T>()
+    return BasicJvmScriptingHost()
+        .eval(source.toScriptSource(), actualConfiguration, ScriptEvaluationConfiguration(configure))
+}
+


### PR DESCRIPTION
Change BasicJvmScriptEvaluator to pass constructor parameters in the
correct order, include tests for scripts w/ provided properties, and
implicit receiver, and both.

https://youtrack.jetbrains.com/issue/KT-30816