### PR TITLE
KT-31008 Fix fat dSYM Info.plist copying

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/native/tasks/FatFrameworkTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/native/tasks/FatFrameworkTask.kt
@@ -316,7 +316,7 @@ open class FatFrameworkTask: DefaultTask() {
         // TODO: handle bundle id.
         project.copy {
             it.from(dsymInputs.values.first().infoPlist)
-            it.into(fatDsym.infoPlist)
+            it.into(fatDsym.infoPlist.parentFile)
         }
     }
 


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-31008

I tested it on my project and it does fix the issue.
The fix is consistent with [another use](https://github.com/JetBrains/kotlin/blob/977d3ef840604959c90d950f94d2fc6069eb556c/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/native/tasks/FatFrameworkTask.kt#L268) of `project.copy` in the same file.

Would it be possible to include it into a 1.3.30 bugfix release?