### PR TITLE
KT-25006 Add inspection "'equals()' between objects of inconvertible primitive / enum / string types"

### DIFF
--- a/idea/resources/META-INF/plugin-common.xml
+++ b/idea/resources/META-INF/plugin-common.xml
@@ -3379,6 +3379,15 @@
                      language="kotlin"
     />
 
+    <localInspection implementationClass="org.jetbrains.kotlin.idea.inspections.KotlinEqualsBetweenInconvertibleTypesInspection"
+                     displayName="'equals()' between objects of inconvertible types"
+                     groupPath="Kotlin"
+                     groupName="Probable bugs"
+                     enabledByDefault="true"
+                     level="WARNING"
+                     language="kotlin"
+    />
+
     <referenceImporter implementation="org.jetbrains.kotlin.idea.quickfix.KotlinReferenceImporter"/>
 
     <fileType.fileViewProviderFactory filetype="KJSM" implementationClass="com.intellij.psi.ClassFileViewProviderFactory"/>

--- a/idea/resources/inspectionDescriptions/KotlinEqualsBetweenInconvertibleTypes.html
+++ b/idea/resources/inspectionDescriptions/KotlinEqualsBetweenInconvertibleTypes.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This inspection reports <b>equals()</b> between objects of inconvertible primitive / enum / string types.
+</body>
+</html>

--- a/idea/src/org/jetbrains/kotlin/idea/inspections/KotlinEqualsBetweenInconvertibleTypesInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/KotlinEqualsBetweenInconvertibleTypesInspection.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license 
+ * that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.idea.inspections
+
+import com.intellij.codeInspection.ProblemsHolder
+import org.jetbrains.kotlin.builtins.KotlinBuiltIns
+import org.jetbrains.kotlin.idea.caches.resolve.analyze
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtSimpleNameExpression
+import org.jetbrains.kotlin.psi.callExpressionVisitor
+import org.jetbrains.kotlin.psi.psiUtil.getQualifiedExpressionForSelector
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.lazy.BodyResolveMode
+import org.jetbrains.kotlin.types.KotlinType
+import org.jetbrains.kotlin.types.typeUtil.isEnum
+import org.jetbrains.kotlin.util.OperatorNameConventions
+
+class KotlinEqualsBetweenInconvertibleTypesInspection : AbstractKotlinInspection() {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) = callExpressionVisitor(fun(call) {
+        val callee = call.calleeExpression as? KtSimpleNameExpression ?: return
+        val identifier = callee.getReferencedNameAsName()
+        if (identifier != OperatorNameConventions.EQUALS) return
+        val receiver = call.getQualifiedExpressionForSelector()?.receiverExpression ?: return
+        val argument = call.valueArguments.singleOrNull()?.getArgumentExpression() ?: return
+        if (call.analyze(BodyResolveMode.PARTIAL).isInconvertibleTypes(receiver, argument)) {
+            holder.registerProblem(callee, "'equals()' between objects of inconvertible types")
+        }
+    })
+
+    companion object {
+        fun BindingContext.isInconvertibleTypes(expr1: KtExpression?, expr2: KtExpression?): Boolean {
+            if (expr1 == null || expr2 == null) return false
+            val type1 = getType(expr1)?.takeIf { it.isTargetType() } ?: return false
+            val type2 = getType(expr2)?.takeIf { it.isTargetType() } ?: return false
+            return type1 != type2
+        }
+
+        private fun KotlinType.isTargetType(): Boolean {
+            return KotlinBuiltIns.isPrimitiveType(this) || KotlinBuiltIns.isString(this) || isEnum()
+        }
+    }
+}

--- a/idea/src/org/jetbrains/kotlin/idea/inspections/conventionNameCalls/ReplaceCallWithBinaryOperatorInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/conventionNameCalls/ReplaceCallWithBinaryOperatorInspection.kt
@@ -28,6 +28,7 @@ import org.jetbrains.kotlin.idea.caches.resolve.getResolutionFacade
 import org.jetbrains.kotlin.idea.caches.resolve.resolveToCall
 import org.jetbrains.kotlin.idea.caches.resolve.resolveToDescriptorIfAny
 import org.jetbrains.kotlin.idea.inspections.AbstractApplicabilityBasedInspection
+import org.jetbrains.kotlin.idea.inspections.KotlinEqualsBetweenInconvertibleTypesInspection
 import org.jetbrains.kotlin.idea.intentions.callExpression
 import org.jetbrains.kotlin.idea.intentions.conventionNameCalls.isAnyEquals
 import org.jetbrains.kotlin.idea.intentions.isOperatorOrCompatible
@@ -155,6 +156,11 @@ class ReplaceCallWithBinaryOperatorInspection : AbstractApplicabilityBasedInspec
         return when (identifier) {
             OperatorNameConventions.EQUALS -> {
                 if (!dotQualified.isAnyEquals()) return null
+                with(KotlinEqualsBetweenInconvertibleTypesInspection) {
+                    val receiver = dotQualified.receiverExpression
+                    val argument = dotQualified.callExpression?.valueArguments?.singleOrNull()?.getArgumentExpression()
+                    if (dotQualified.analyze(BodyResolveMode.PARTIAL).isInconvertibleTypes(receiver, argument)) return null
+                }
                 val prefixExpression = dotQualified.getWrappingPrefixExpressionIfAny()
                 if (prefixExpression != null && prefixExpression.operationToken == KtTokens.EXCL) KtTokens.EXCLEQ
                 else KtTokens.EQEQ

--- a/idea/testData/inspectionsLocal/conventionNameCalls/replaceCallWithBinaryOperator/equalsBetweenInconvertibleTypes.kt
+++ b/idea/testData/inspectionsLocal/conventionNameCalls/replaceCallWithBinaryOperator/equalsBetweenInconvertibleTypes.kt
@@ -1,0 +1,3 @@
+// PROBLEM: none
+
+val x = 2.<caret>equals("")

--- a/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/.inspection
+++ b/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/.inspection
@@ -1,0 +1,1 @@
+org.jetbrains.kotlin.idea.inspections.KotlinEqualsBetweenInconvertibleTypesInspection

--- a/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/enumEqEnum.kt
+++ b/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/enumEqEnum.kt
@@ -1,0 +1,8 @@
+// PROBLEM: none
+
+fun test(x: E1, y: E1): Boolean {
+    return x.<caret>equals(y)
+}
+
+enum class E1
+

--- a/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/enumEqEnum2.kt
+++ b/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/enumEqEnum2.kt
@@ -1,0 +1,9 @@
+// FIX: none
+
+fun test(x: E1, y: E2): Boolean {
+    return x.<caret>equals(y)
+}
+
+enum class E1
+
+enum class E2

--- a/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/enumEqInt.kt
+++ b/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/enumEqInt.kt
@@ -1,0 +1,7 @@
+// FIX: none
+
+fun test(x: E1, y: Int): Boolean {
+    return x.<caret>equals(y)
+}
+
+enum class E1

--- a/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/enumEqString.kt
+++ b/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/enumEqString.kt
@@ -1,0 +1,7 @@
+// FIX: none
+
+fun test(x: E1, y: String): Boolean {
+    return x.<caret>equals(y)
+}
+
+enum class E1

--- a/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/enumEqUserType.kt
+++ b/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/enumEqUserType.kt
@@ -1,0 +1,9 @@
+// PROBLEM: none
+
+fun test(x: E1, y: Foo): Boolean {
+    return x.<caret>equals(y)
+}
+
+class Foo
+
+enum class E1

--- a/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/intEqEnum.kt
+++ b/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/intEqEnum.kt
@@ -1,0 +1,7 @@
+// FIX: none
+
+fun test(x: Int, y: E1): Boolean {
+    return x.<caret>equals(y)
+}
+
+enum class E1

--- a/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/intEqInt.kt
+++ b/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/intEqInt.kt
@@ -1,0 +1,5 @@
+// PROBLEM: none
+
+fun test(x: Int, y: Int): Boolean {
+    return x.<caret>equals(y)
+}

--- a/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/intEqLong.kt
+++ b/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/intEqLong.kt
@@ -1,0 +1,5 @@
+// FIX: none
+
+fun test(x: Int, y: Long): Boolean {
+    return x.<caret>equals(y)
+}

--- a/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/intEqString.kt
+++ b/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/intEqString.kt
@@ -1,0 +1,5 @@
+// FIX: none
+
+fun test(x: Int, y: String): Boolean {
+    return x.<caret>equals(y)
+}

--- a/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/intEqUserType.kt
+++ b/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/intEqUserType.kt
@@ -1,0 +1,7 @@
+// PROBLEM: none
+
+fun test(x: Int, y: Foo): Boolean {
+    return x.<caret>equals(y)
+}
+
+class Foo

--- a/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/nullableEnumEqString.kt
+++ b/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/nullableEnumEqString.kt
@@ -1,0 +1,6 @@
+// FIX: none
+enum class E1
+
+fun test(x: E1?, y: String): Boolean? {
+    return x?.<caret>equals(y)
+}

--- a/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/nullableIntEqString.kt
+++ b/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/nullableIntEqString.kt
@@ -1,0 +1,4 @@
+// FIX: none
+fun test(x: Int?, y: String): Boolean? {
+    return x?.<caret>equals(y)
+}

--- a/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/nullableStringEqInt.kt
+++ b/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/nullableStringEqInt.kt
@@ -1,0 +1,4 @@
+// FIX: none
+fun test(x: String?, y: Int): Boolean? {
+    return x?.<caret>equals(y)
+}

--- a/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/nullableStringEqString.kt
+++ b/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/nullableStringEqString.kt
@@ -1,0 +1,4 @@
+// PROBLEM: none
+fun test() {
+    System.getProperty("some")?.<caret>equals("true")
+}

--- a/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/stringEqEnum.kt
+++ b/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/stringEqEnum.kt
@@ -1,0 +1,7 @@
+// FIX: none
+
+fun test(x: String, y: E1): Boolean {
+    return x.<caret>equals(y)
+}
+
+enum class E1

--- a/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/stringEqInt.kt
+++ b/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/stringEqInt.kt
@@ -1,0 +1,5 @@
+// FIX: none
+
+fun test(x: String, y: Int): Boolean {
+    return x.<caret>equals(y)
+}

--- a/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/stringEqNullableEnum.kt
+++ b/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/stringEqNullableEnum.kt
@@ -1,0 +1,6 @@
+// FIX: none
+enum class E1
+
+fun test(x: String, y: E1?): Boolean? {
+    return x.<caret>equals(y)
+}

--- a/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/stringEqNullableInt.kt
+++ b/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/stringEqNullableInt.kt
@@ -1,0 +1,4 @@
+// FIX: none
+fun test(x: String, y: Int?): Boolean? {
+    return x.<caret>equals(y)
+}

--- a/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/stringEqNullableString.kt
+++ b/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/stringEqNullableString.kt
@@ -1,0 +1,4 @@
+// PROBLEM: none
+fun test(x: String, y: String?): Boolean? {
+    return x.<caret>equals(y)
+}

--- a/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/stringEqString.kt
+++ b/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/stringEqString.kt
@@ -1,0 +1,5 @@
+// PROBLEM: none
+
+fun test(x: String, y: String): Boolean {
+    return x.<caret>equals(y)
+}

--- a/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/stringEqUserType.kt
+++ b/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/stringEqUserType.kt
@@ -1,0 +1,7 @@
+// PROBLEM: none
+
+fun test(x: String, y: Foo): Boolean {
+    return x.<caret>equals(y)
+}
+
+class Foo

--- a/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/userTypeEqInt.kt
+++ b/idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/userTypeEqInt.kt
@@ -1,0 +1,7 @@
+// PROBLEM: none
+
+fun test(x: Foo, y: Int): Boolean {
+    return x.<caret>equals(y)
+}
+
+class Foo

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -3675,6 +3675,26 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
             runTest("idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/intEqUserType.kt");
         }
 
+        @TestMetadata("nullableEnumEqString.kt")
+        public void testNullableEnumEqString() throws Exception {
+            runTest("idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/nullableEnumEqString.kt");
+        }
+
+        @TestMetadata("nullableIntEqString.kt")
+        public void testNullableIntEqString() throws Exception {
+            runTest("idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/nullableIntEqString.kt");
+        }
+
+        @TestMetadata("nullableStringEqInt.kt")
+        public void testNullableStringEqInt() throws Exception {
+            runTest("idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/nullableStringEqInt.kt");
+        }
+
+        @TestMetadata("nullableStringEqString.kt")
+        public void testNullableStringEqString() throws Exception {
+            runTest("idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/nullableStringEqString.kt");
+        }
+
         @TestMetadata("stringEqEnum.kt")
         public void testStringEqEnum() throws Exception {
             runTest("idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/stringEqEnum.kt");
@@ -3683,6 +3703,21 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
         @TestMetadata("stringEqInt.kt")
         public void testStringEqInt() throws Exception {
             runTest("idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/stringEqInt.kt");
+        }
+
+        @TestMetadata("stringEqNullableEnum.kt")
+        public void testStringEqNullableEnum() throws Exception {
+            runTest("idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/stringEqNullableEnum.kt");
+        }
+
+        @TestMetadata("stringEqNullableInt.kt")
+        public void testStringEqNullableInt() throws Exception {
+            runTest("idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/stringEqNullableInt.kt");
+        }
+
+        @TestMetadata("stringEqNullableString.kt")
+        public void testStringEqNullableString() throws Exception {
+            runTest("idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/stringEqNullableString.kt");
         }
 
         @TestMetadata("stringEqString.kt")

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -2492,6 +2492,11 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
                 runTest("idea/testData/inspectionsLocal/conventionNameCalls/replaceCallWithBinaryOperator/equals.kt");
             }
 
+            @TestMetadata("equalsBetweenInconvertibleTypes.kt")
+            public void testEqualsBetweenInconvertibleTypes() throws Exception {
+                runTest("idea/testData/inspectionsLocal/conventionNameCalls/replaceCallWithBinaryOperator/equalsBetweenInconvertibleTypes.kt");
+            }
+
             @TestMetadata("equalsCompareTo.kt")
             public void testEqualsCompareTo() throws Exception {
                 runTest("idea/testData/inspectionsLocal/conventionNameCalls/replaceCallWithBinaryOperator/equalsCompareTo.kt");
@@ -3605,6 +3610,94 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
         @TestMetadata("simple.kt")
         public void testSimple() throws Exception {
             runTest("idea/testData/inspectionsLocal/emptyRange/simple.kt");
+        }
+    }
+
+    @TestMetadata("idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class EqualsBetweenInconvertibleTypes extends AbstractLocalInspectionTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY, testDataFilePath);
+        }
+
+        public void testAllFilesPresentInEqualsBetweenInconvertibleTypes() throws Exception {
+            KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes"), Pattern.compile("^([\\w\\-_]+)\\.(kt|kts)$"), TargetBackend.ANY, true);
+        }
+
+        @TestMetadata("enumEqEnum.kt")
+        public void testEnumEqEnum() throws Exception {
+            runTest("idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/enumEqEnum.kt");
+        }
+
+        @TestMetadata("enumEqEnum2.kt")
+        public void testEnumEqEnum2() throws Exception {
+            runTest("idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/enumEqEnum2.kt");
+        }
+
+        @TestMetadata("enumEqInt.kt")
+        public void testEnumEqInt() throws Exception {
+            runTest("idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/enumEqInt.kt");
+        }
+
+        @TestMetadata("enumEqString.kt")
+        public void testEnumEqString() throws Exception {
+            runTest("idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/enumEqString.kt");
+        }
+
+        @TestMetadata("enumEqUserType.kt")
+        public void testEnumEqUserType() throws Exception {
+            runTest("idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/enumEqUserType.kt");
+        }
+
+        @TestMetadata("intEqEnum.kt")
+        public void testIntEqEnum() throws Exception {
+            runTest("idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/intEqEnum.kt");
+        }
+
+        @TestMetadata("intEqInt.kt")
+        public void testIntEqInt() throws Exception {
+            runTest("idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/intEqInt.kt");
+        }
+
+        @TestMetadata("intEqLong.kt")
+        public void testIntEqLong() throws Exception {
+            runTest("idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/intEqLong.kt");
+        }
+
+        @TestMetadata("intEqString.kt")
+        public void testIntEqString() throws Exception {
+            runTest("idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/intEqString.kt");
+        }
+
+        @TestMetadata("intEqUserType.kt")
+        public void testIntEqUserType() throws Exception {
+            runTest("idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/intEqUserType.kt");
+        }
+
+        @TestMetadata("stringEqEnum.kt")
+        public void testStringEqEnum() throws Exception {
+            runTest("idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/stringEqEnum.kt");
+        }
+
+        @TestMetadata("stringEqInt.kt")
+        public void testStringEqInt() throws Exception {
+            runTest("idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/stringEqInt.kt");
+        }
+
+        @TestMetadata("stringEqString.kt")
+        public void testStringEqString() throws Exception {
+            runTest("idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/stringEqString.kt");
+        }
+
+        @TestMetadata("stringEqUserType.kt")
+        public void testStringEqUserType() throws Exception {
+            runTest("idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/stringEqUserType.kt");
+        }
+
+        @TestMetadata("userTypeEqInt.kt")
+        public void testUserTypeEqInt() throws Exception {
+            runTest("idea/testData/inspectionsLocal/equalsBetweenInconvertibleTypes/userTypeEqInt.kt");
         }
     }
 


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-25006