### PR TITLE
Optimize JVM byte code generation for conditional conjunction

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/AndAnd.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/AndAnd.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.jvm.intrinsics
+
+import org.jetbrains.kotlin.backend.jvm.codegen.*
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.IrFunctionAccessExpression
+import org.jetbrains.org.objectweb.asm.Label
+
+object AndAnd : IntrinsicMethod() {
+
+    private class BooleanConjunction(val arg0: IrExpression, val arg1: IrExpression, val codegen: ExpressionCodegen, val data: BlockInfo) : BooleanValue(codegen.mv) {
+
+        override fun jumpIfFalse(target: Label) {
+            arg0.accept(codegen, data).coerceToBoolean().jumpIfFalse(target)
+            arg1.accept(codegen, data).coerceToBoolean().jumpIfFalse(target)
+        }
+
+        override fun jumpIfTrue(target: Label) {
+            val stayLabel = Label()
+            arg0.accept(codegen, data).coerceToBoolean().jumpIfFalse(stayLabel)
+            arg1.accept(codegen, data).coerceToBoolean().jumpIfTrue(target)
+            mv.visitLabel(stayLabel)
+        }
+    }
+
+    override fun invoke(expression: IrFunctionAccessExpression, codegen: ExpressionCodegen, data: BlockInfo): PromisedValue? {
+        val (left, right) = expression.receiverAndArgs()
+        return BooleanConjunction(left, right, codegen, data)
+    }
+}

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/IrIntrinsicMethods.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/IrIntrinsicMethods.kt
@@ -31,6 +31,10 @@ class IrIntrinsicMethods(irBuiltIns: IrBuiltIns) {
 
     val intrinsics = IntrinsicMethods()
 
+    val andandSymbol = irBuiltIns.run { defineOperator(OperatorNames.ANDAND, bool, listOf(bool, bool)) }
+
+    private val andand = andandSymbol.descriptor
+
     private val irMapping = hashMapOf<CallableMemberDescriptor, IntrinsicMethod>()
 
     private fun createPrimitiveComparisonIntrinsics(typeToIrFun: Map<SimpleType, IrSimpleFunctionSymbol>, operator: KtSingleValueToken) {
@@ -55,6 +59,8 @@ class IrIntrinsicMethods(irBuiltIns: IrBuiltIns) {
         irMapping[irBuiltIns.noWhenBranchMatchedException] = IrNoWhenBranchMatchedException()
         irMapping[irBuiltIns.illegalArgumentException] = IrIllegalArgumentException()
         irMapping[irBuiltIns.throwNpe] = ThrowNPE()
+
+        irMapping[andand] = AndAnd
     }
 
     fun getIntrinsic(descriptor: CallableMemberDescriptor): IntrinsicMethod? {
@@ -63,5 +69,9 @@ class IrIntrinsicMethods(irBuiltIns: IrBuiltIns) {
             return intrinsics.getIntrinsic(DescriptorUtils.unwrapFakeOverride(descriptor.correspondingProperty))
         }
         return irMapping[descriptor.original]
+    }
+
+    private object OperatorNames {
+        const val ANDAND = "ANDAND"
     }
 }

--- a/compiler/testData/codegen/box/intrinsics/nonShortCircuitAnd.kt
+++ b/compiler/testData/codegen/box/intrinsics/nonShortCircuitAnd.kt
@@ -1,0 +1,18 @@
+var s = ""
+
+fun o(): Boolean {
+    s += "O"
+    return false
+}
+
+fun k(): Boolean {
+    s += "K"
+    return true
+}
+
+fun box(): String {
+    val b = o() and k()
+    if (b)
+        return "fail: b should be false"
+    return s
+}

--- a/compiler/testData/codegen/bytecodeText/conditions/conjunction.kt
+++ b/compiler/testData/codegen/bytecodeText/conditions/conjunction.kt
@@ -3,7 +3,7 @@ val b = false
 val c = false
 
 fun main() {
-    if (!(a && b && c)) {
+    if (a && b && c) {
         "then"
     } else {
         "else"
@@ -12,7 +12,7 @@ fun main() {
 
 // 0 ICONST_0
 // 0 ICONST_1
-// 2 IFEQ
-// 1 IFNE
+// 3 IFEQ
+// 0 IFNE
 // 3 IF
 // 1 GOTO

--- a/compiler/testData/codegen/bytecodeText/conditions/conjunctionInDoWhile.kt
+++ b/compiler/testData/codegen/bytecodeText/conditions/conjunctionInDoWhile.kt
@@ -3,11 +3,9 @@ val b = false
 val c = false
 
 fun main() {
-    if (!(a && b && c)) {
-        "then"
-    } else {
-        "else"
-    }
+    do {
+        "loop"
+    } while (a && b && c)
 }
 
 // 0 ICONST_0
@@ -15,4 +13,4 @@ fun main() {
 // 2 IFEQ
 // 1 IFNE
 // 3 IF
-// 1 GOTO
+// 0 GOTO

--- a/compiler/testData/codegen/bytecodeText/conditions/conjunctionInWhile.kt
+++ b/compiler/testData/codegen/bytecodeText/conditions/conjunctionInWhile.kt
@@ -1,13 +1,10 @@
-// IGNORE_BACKEND: JVM_IR
 val a = false
 val b = false
 val c = false
 
 fun main() {
-    if (a && b && c) {
-        "then"
-    } else {
-        "else"
+    while (a && b && c) {
+        "loop"
     }
 }
 

--- a/compiler/testData/lineNumber/custom/ifThenElseFalse.kt
+++ b/compiler/testData/lineNumber/custom/ifThenElseFalse.kt
@@ -1,0 +1,10 @@
+fun cond() = false
+
+fun foo() {
+    if (cond())
+        cond()
+    else
+         false
+}
+
+// 1 4 5 7 8

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -13477,6 +13477,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             runTest("compiler/testData/codegen/box/intrinsics/longRangeWithExplicitDot.kt");
         }
 
+        @TestMetadata("nonShortCircuitAnd.kt")
+        public void testNonShortCircuitAnd() throws Exception {
+            runTest("compiler/testData/codegen/box/intrinsics/nonShortCircuitAnd.kt");
+        }
+
         @TestMetadata("prefixIncDec.kt")
         public void testPrefixIncDec() throws Exception {
             runTest("compiler/testData/codegen/box/intrinsics/prefixIncDec.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
@@ -894,9 +894,19 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
             KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/codegen/bytecodeText/conditions"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.JVM, true);
         }
 
-        @TestMetadata("conjuction.kt")
-        public void testConjuction() throws Exception {
-            runTest("compiler/testData/codegen/bytecodeText/conditions/conjuction.kt");
+        @TestMetadata("conjunction.kt")
+        public void testConjunction() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/conditions/conjunction.kt");
+        }
+
+        @TestMetadata("conjunctionInDoWhile.kt")
+        public void testConjunctionInDoWhile() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/conditions/conjunctionInDoWhile.kt");
+        }
+
+        @TestMetadata("conjunctionInWhile.kt")
+        public void testConjunctionInWhile() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/conditions/conjunctionInWhile.kt");
         }
 
         @TestMetadata("disjunction.kt")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -13477,6 +13477,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/intrinsics/longRangeWithExplicitDot.kt");
         }
 
+        @TestMetadata("nonShortCircuitAnd.kt")
+        public void testNonShortCircuitAnd() throws Exception {
+            runTest("compiler/testData/codegen/box/intrinsics/nonShortCircuitAnd.kt");
+        }
+
         @TestMetadata("prefixIncDec.kt")
         public void testPrefixIncDec() throws Exception {
             runTest("compiler/testData/codegen/box/intrinsics/prefixIncDec.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LineNumberTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LineNumberTestGenerated.java
@@ -181,6 +181,11 @@ public class LineNumberTestGenerated extends AbstractLineNumberTest {
             runTest("compiler/testData/lineNumber/custom/ifThenElse.kt");
         }
 
+        @TestMetadata("ifThenElseFalse.kt")
+        public void testIfThenElseFalse() throws Exception {
+            runTest("compiler/testData/lineNumber/custom/ifThenElseFalse.kt");
+        }
+
         @TestMetadata("inTheEndOfLambdaArgumentOfInlineCall.kt")
         public void testInTheEndOfLambdaArgumentOfInlineCall() throws Exception {
             runTest("compiler/testData/lineNumber/custom/inTheEndOfLambdaArgumentOfInlineCall.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -13482,6 +13482,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             runTest("compiler/testData/codegen/box/intrinsics/longRangeWithExplicitDot.kt");
         }
 
+        @TestMetadata("nonShortCircuitAnd.kt")
+        public void testNonShortCircuitAnd() throws Exception {
+            runTest("compiler/testData/codegen/box/intrinsics/nonShortCircuitAnd.kt");
+        }
+
         @TestMetadata("prefixIncDec.kt")
         public void testPrefixIncDec() throws Exception {
             runTest("compiler/testData/codegen/box/intrinsics/prefixIncDec.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
@@ -894,9 +894,19 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
             KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/codegen/bytecodeText/conditions"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.JVM_IR, true);
         }
 
-        @TestMetadata("conjuction.kt")
-        public void testConjuction() throws Exception {
-            runTest("compiler/testData/codegen/bytecodeText/conditions/conjuction.kt");
+        @TestMetadata("conjunction.kt")
+        public void testConjunction() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/conditions/conjunction.kt");
+        }
+
+        @TestMetadata("conjunctionInDoWhile.kt")
+        public void testConjunctionInDoWhile() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/conditions/conjunctionInDoWhile.kt");
+        }
+
+        @TestMetadata("conjunctionInWhile.kt")
+        public void testConjunctionInWhile() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/conditions/conjunctionInWhile.kt");
         }
 
         @TestMetadata("disjunction.kt")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrLineNumberTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrLineNumberTestGenerated.java
@@ -181,6 +181,11 @@ public class IrLineNumberTestGenerated extends AbstractIrLineNumberTest {
             runTest("compiler/testData/lineNumber/custom/ifThenElse.kt");
         }
 
+        @TestMetadata("ifThenElseFalse.kt")
+        public void testIfThenElseFalse() throws Exception {
+            runTest("compiler/testData/lineNumber/custom/ifThenElseFalse.kt");
+        }
+
         @TestMetadata("inTheEndOfLambdaArgumentOfInlineCall.kt")
         public void testInTheEndOfLambdaArgumentOfInlineCall() throws Exception {
             runTest("compiler/testData/lineNumber/custom/inTheEndOfLambdaArgumentOfInlineCall.kt");

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -10837,6 +10837,11 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/intrinsics/longRangeWithExplicitDot.kt");
         }
 
+        @TestMetadata("nonShortCircuitAnd.kt")
+        public void testNonShortCircuitAnd() throws Exception {
+            runTest("compiler/testData/codegen/box/intrinsics/nonShortCircuitAnd.kt");
+        }
+
         @TestMetadata("prefixIncDec.kt")
         public void testPrefixIncDec() throws Exception {
             runTest("compiler/testData/codegen/box/intrinsics/prefixIncDec.kt");

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -11982,6 +11982,11 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/intrinsics/longRangeWithExplicitDot.kt");
         }
 
+        @TestMetadata("nonShortCircuitAnd.kt")
+        public void testNonShortCircuitAnd() throws Exception {
+            runTest("compiler/testData/codegen/box/intrinsics/nonShortCircuitAnd.kt");
+        }
+
         @TestMetadata("prefixIncDec.kt")
         public void testPrefixIncDec() throws Exception {
             runTest("compiler/testData/codegen/box/intrinsics/prefixIncDec.kt");


### PR DESCRIPTION
Implement an intrinsic method for boolean.and operation, and replace
ANDAND condition with a call to such intrinsic method.

Also added a new test case to make sure existing non-shortcircuit "and" function is not being shadowed by other functions.