### PR TITLE
Use spaces instead of tabs to indent -Xlist-phases.

### DIFF
--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/phaser/PhaseConfig.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/phaser/PhaseConfig.kt
@@ -42,7 +42,7 @@ class PhaseConfig(
             val enabled = if (phase in enabled) "(Enabled)" else ""
             val verbose = if (phase in verbose) "(Verbose)" else ""
 
-            println(String.format("%1$-50s %2$-50s %3$-10s", "${"\t".repeat(depth)}${phase.name}:", phase.description, "$enabled $verbose"))
+            println(String.format("%1$-50s %2$-50s %3$-10s", "${"    ".repeat(depth)}${phase.name}:", phase.description, "$enabled $verbose"))
         }
     }
 


### PR DESCRIPTION
In Terminal.app and xterm the output columns get misaligned when using tabs.
Tabbed output only renders correctly when `tabstop=1`.