### PR TITLE
IR parameter fix

### DIFF
--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/ir/IrUtils.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/ir/IrUtils.kt
@@ -236,7 +236,7 @@ fun IrFunction.copyValueParametersToStatic(
             originalDispatchReceiver.copyTo(
                 target,
                 origin = originalDispatchReceiver.origin,
-                index = originalDispatchReceiver.index + shift++,
+                index = shift++,
                 type = type,
                 name = Name.identifier("\$this")
             )
@@ -247,7 +247,7 @@ fun IrFunction.copyValueParametersToStatic(
             originalExtensionReceiver.copyTo(
                 target,
                 origin = originalExtensionReceiver.origin,
-                index = originalExtensionReceiver.index + shift++,
+                index = shift++,
                 name = Name.identifier("\$receiver")
             )
         )

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -463,12 +463,8 @@ class ExpressionCodegen(
 
     private fun findLocalIndex(irSymbol: IrSymbol): Int {
         val index = frameMap.getIndex(irSymbol)
-        if (index >= 0) {
+        if (index >= 0)
             return index
-        }
-        if (irFunction.dispatchReceiverParameter != null && (irFunction.parent as? IrClass)?.thisReceiver?.symbol == irSymbol) {
-            return 0
-        }
         val dump = if (irSymbol.isBound) irSymbol.owner.dump() else irSymbol.descriptor.toString()
         throw AssertionError("Non-mapped local declaration: $dump\n in ${irFunction.dump()}")
     }

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/CallableReferenceLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/CallableReferenceLowering.kt
@@ -234,7 +234,7 @@ internal class CallableReferenceLowering(val context: JvmBackendContext) : FileL
             functionReferenceClass = buildClass {
                 setSourceRange(irFunctionReference)
                 origin = JvmLoweredDeclarationOrigin.FUNCTION_REFERENCE_IMPL
-                name = "${callee.name}\$${functionReferenceCount++}".synthesizedName
+                name = "${callee.name.safeName()}\$${functionReferenceCount++}".synthesizedName
                 kind = ClassKind.CLASS
                 visibility = Visibilities.PUBLIC
                 modality = Modality.FINAL
@@ -403,7 +403,7 @@ internal class CallableReferenceLowering(val context: JvmBackendContext) : FileL
                                 val argument = when {
                                     !unboundArgsSet.contains(parameter) ->
                                         // Bound parameter - read from field.
-                                        irGetField(irGet(functionReferenceThis.owner), argumentToFieldMap[parameter]!!)
+                                        irGetField(irGet(dispatchReceiverParameter!!), argumentToFieldMap[parameter]!!)
                                     function.isSuspend && unboundIndex == valueParameters.size ->
                                         // For suspend functions the last argument is continuation and it is implicit.
                                         TODO()

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/FunctionNVarargInvokeLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/FunctionNVarargInvokeLowering.kt
@@ -111,7 +111,7 @@ private class FunctionNVarargInvokeLowering(var context: JvmBackendContext) : Cl
                                 target.returnType,
                                 target.returnType.classifierOrFail,
                                 irCall(target).apply {
-                                    dispatchReceiver = irGet(irClass.thisReceiver!!)
+                                    dispatchReceiver = irGet(dispatchReceiverParameter!!)
                                     target.valueParameters.forEachIndexed { i, irValueParameter ->
                                         val type = irValueParameter.type
                                         putValueArgument(


### PR DESCRIPTION
There are two ways of accessing `this` in the IR:
- In a member function we use the `dispatchReceiverParameter`
- In a constructor we use the `thisReceiver` of the constructed class

Right now there are several passes which produce IR which accesses the `thisReceiver` in member functions, necessitating a workaround in ExpressionCodegen. This patch fixes the passes in question and removes the workaround.

There's also an unrelated fix to the parameter indices in SyntheticAccessorLowering. Currently this pass produces static functions with parameter indices < 0. I didn't want to open a separate PR for that.