### PR TITLE
Fix type of super

### DIFF
--- a/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/ArgumentsGenerationUtils.kt
+++ b/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/ArgumentsGenerationUtils.kt
@@ -136,7 +136,8 @@ private fun StatementGenerator.generateThisOrSuperReceiver(receiver: ReceiverVal
     val expressionReceiver = receiver as? ExpressionReceiver
         ?: throw AssertionError("'this' or 'super' receiver should be an expression receiver")
     val ktReceiver = expressionReceiver.expression
-    return generateThisReceiver(ktReceiver.startOffsetSkippingComments, ktReceiver.endOffset, expressionReceiver.type, classDescriptor)
+    val type = if (receiver is SuperCallReceiverValue) receiver.thisType else expressionReceiver.type
+    return generateThisReceiver(ktReceiver.startOffsetSkippingComments, ktReceiver.endOffset, type, classDescriptor)
 }
 
 fun StatementGenerator.generateBackingFieldReceiver(

--- a/compiler/testData/ir/irText/classes/qualifiedSuperCalls.txt
+++ b/compiler/testData/ir/irText/classes/qualifiedSuperCalls.txt
@@ -62,9 +62,9 @@ FILE fqName:<root> fileName:/qualifiedSuperCalls.kt
       $this: VALUE_PARAMETER name:<this> type:<root>.CBoth 
       BLOCK_BODY
         CALL 'public open fun foo (): kotlin.Unit declared in <root>.ILeft' superQualifier='CLASS INTERFACE name:ILeft modality:ABSTRACT visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit origin=null
-          $this: GET_VAR '<this>: <root>.CBoth declared in <root>.CBoth.foo' type=<root>.ILeft origin=null
+          $this: GET_VAR '<this>: <root>.CBoth declared in <root>.CBoth.foo' type=<root>.CBoth origin=null
         CALL 'public open fun foo (): kotlin.Unit declared in <root>.IRight' superQualifier='CLASS INTERFACE name:IRight modality:ABSTRACT visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit origin=null
-          $this: GET_VAR '<this>: <root>.CBoth declared in <root>.CBoth.foo' type=<root>.IRight origin=null
+          $this: GET_VAR '<this>: <root>.CBoth declared in <root>.CBoth.foo' type=<root>.CBoth origin=null
     PROPERTY name:bar visibility:public modality:OPEN [val] 
       FUN name:<get-bar> visibility:public modality:OPEN <> ($this:<root>.CBoth) returnType:kotlin.Int 
         correspondingProperty: PROPERTY name:bar visibility:public modality:OPEN [val] 
@@ -76,9 +76,9 @@ FILE fqName:<root> fileName:/qualifiedSuperCalls.kt
           RETURN type=kotlin.Nothing from='public open fun <get-bar> (): kotlin.Int declared in <root>.CBoth'
             CALL 'public final fun plus (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=PLUS
               $this: CALL 'public open fun <get-bar> (): kotlin.Int declared in <root>.ILeft' superQualifier='CLASS INTERFACE name:ILeft modality:ABSTRACT visibility:public superTypes:[kotlin.Any]' type=kotlin.Int origin=GET_PROPERTY
-                $this: GET_VAR '<this>: <root>.CBoth declared in <root>.CBoth.<get-bar>' type=<root>.ILeft origin=null
+                $this: GET_VAR '<this>: <root>.CBoth declared in <root>.CBoth.<get-bar>' type=<root>.CBoth origin=null
               other: CALL 'public open fun <get-bar> (): kotlin.Int declared in <root>.IRight' superQualifier='CLASS INTERFACE name:IRight modality:ABSTRACT visibility:public superTypes:[kotlin.Any]' type=kotlin.Int origin=GET_PROPERTY
-                $this: GET_VAR '<this>: <root>.CBoth declared in <root>.CBoth.<get-bar>' type=<root>.IRight origin=null
+                $this: GET_VAR '<this>: <root>.CBoth declared in <root>.CBoth.<get-bar>' type=<root>.CBoth origin=null
     FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean 
       overridden:
         public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.ILeft

--- a/compiler/testData/ir/irText/classes/superCalls.fir.txt
+++ b/compiler/testData/ir/irText/classes/superCalls.fir.txt
@@ -19,15 +19,16 @@ FILE fqName:<root> fileName:/superCalls.kt
           RETURN type=kotlin.Nothing from='public open fun <get-bar> (): kotlin.String declared in <root>.Base'
             GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:bar type:kotlin.String visibility:public [final] ' type=kotlin.String origin=null
               receiver: GET_VAR '<this>: <root>.Base declared in <root>.Base.<get-bar>' type=<root>.Base origin=null
-    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean 
+    FUN name:hashCode visibility:public modality:OPEN <> ($this:<root>.Base) returnType:kotlin.Int
+      $this: VALUE_PARAMETER name:<this> type:<root>.Base
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun hashCode (): kotlin.Int declared in <root>.Base'
+          CALL 'public open fun hashCode (): kotlin.Int declared in kotlin.Any' type=kotlin.Int origin=null
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean
       overridden:
         public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
       $this: VALUE_PARAMETER name:<this> type:kotlin.Any 
-      VALUE_PARAMETER name:other index:0 type:kotlin.Any? 
-    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int 
-      overridden:
-        public open fun hashCode (): kotlin.Int declared in kotlin.Any
-      $this: VALUE_PARAMETER name:<this> type:kotlin.Any 
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
     FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String 
       overridden:
         public open fun toString (): kotlin.String declared in kotlin.Any
@@ -49,17 +50,16 @@ FILE fqName:<root> fileName:/superCalls.kt
         BLOCK_BODY
           RETURN type=kotlin.Nothing from='public final fun <get-bar> (): kotlin.String declared in <root>.Derived'
             CALL 'public open fun <get-bar> (): kotlin.String declared in <root>.Base' type=kotlin.String origin=null
-    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean 
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:<root>.Base) returnType:kotlin.Int
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in <root>.Base
+      $this: VALUE_PARAMETER name:<this> type:<root>.Base
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean
       overridden:
         public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
       $this: VALUE_PARAMETER name:<this> type:kotlin.Any 
-      VALUE_PARAMETER name:other index:0 type:kotlin.Any? 
-    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int 
-      overridden:
-        public open fun hashCode (): kotlin.Int declared in kotlin.Any
-      $this: VALUE_PARAMETER name:<this> type:kotlin.Any 
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
     FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String 
       overridden:
         public open fun toString (): kotlin.String declared in kotlin.Any
       $this: VALUE_PARAMETER name:<this> type:kotlin.Any 
-

--- a/compiler/testData/ir/irText/classes/superCalls.kt
+++ b/compiler/testData/ir/irText/classes/superCalls.kt
@@ -2,6 +2,8 @@ open class Base {
     open fun foo() {}
 
     open val bar: String = ""
+
+    override fun hashCode() = super.hashCode()
 }
 
 class Derived : Base() {

--- a/compiler/testData/ir/irText/classes/superCalls.txt
+++ b/compiler/testData/ir/irText/classes/superCalls.txt
@@ -19,15 +19,19 @@ FILE fqName:<root> fileName:/superCalls.kt
           RETURN type=kotlin.Nothing from='public open fun <get-bar> (): kotlin.String declared in <root>.Base'
             GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:bar type:kotlin.String visibility:public [final] ' type=kotlin.String origin=null
               receiver: GET_VAR '<this>: <root>.Base declared in <root>.Base.<get-bar>' type=<root>.Base origin=null
-    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean 
+    FUN name:hashCode visibility:public modality:OPEN <> ($this:<root>.Base) returnType:kotlin.Int
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:<root>.Base
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun hashCode (): kotlin.Int declared in <root>.Base'
+          CALL 'public open fun hashCode (): kotlin.Int declared in kotlin.Any' superQualifier='CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:Any modality:OPEN visibility:public superTypes:[]' type=kotlin.Int origin=null
+            $this: GET_VAR '<this>: <root>.Base declared in <root>.Base.hashCode' type=<root>.Base origin=null
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean
       overridden:
         public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
       $this: VALUE_PARAMETER name:<this> type:kotlin.Any 
-      VALUE_PARAMETER name:other index:0 type:kotlin.Any? 
-    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int 
-      overridden:
-        public open fun hashCode (): kotlin.Int declared in kotlin.Any
-      $this: VALUE_PARAMETER name:<this> type:kotlin.Any 
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
     FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String 
       overridden:
         public open fun toString (): kotlin.String declared in kotlin.Any
@@ -44,7 +48,7 @@ FILE fqName:<root> fileName:/superCalls.kt
       $this: VALUE_PARAMETER name:<this> type:<root>.Derived 
       BLOCK_BODY
         CALL 'public open fun foo (): kotlin.Unit declared in <root>.Base' superQualifier='CLASS CLASS name:Base modality:OPEN visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit origin=null
-          $this: GET_VAR '<this>: <root>.Derived declared in <root>.Derived.foo' type=<root>.Base origin=null
+          $this: GET_VAR '<this>: <root>.Derived declared in <root>.Derived.foo' type=<root>.Derived origin=null
     PROPERTY name:bar visibility:public modality:OPEN [val] 
       FUN name:<get-bar> visibility:public modality:OPEN <> ($this:<root>.Derived) returnType:kotlin.String 
         correspondingProperty: PROPERTY name:bar visibility:public modality:OPEN [val] 
@@ -54,16 +58,16 @@ FILE fqName:<root> fileName:/superCalls.kt
         BLOCK_BODY
           RETURN type=kotlin.Nothing from='public open fun <get-bar> (): kotlin.String declared in <root>.Derived'
             CALL 'public open fun <get-bar> (): kotlin.String declared in <root>.Base' superQualifier='CLASS CLASS name:Base modality:OPEN visibility:public superTypes:[kotlin.Any]' type=kotlin.String origin=GET_PROPERTY
-              $this: GET_VAR '<this>: <root>.Derived declared in <root>.Derived.<get-bar>' type=<root>.Base origin=null
+              $this: GET_VAR '<this>: <root>.Derived declared in <root>.Derived.<get-bar>' type=<root>.Derived origin=null
     FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean 
       overridden:
         public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.Base
       $this: VALUE_PARAMETER name:<this> type:kotlin.Any 
       VALUE_PARAMETER name:other index:0 type:kotlin.Any? 
-    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int 
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:<root>.Base) returnType:kotlin.Int
       overridden:
         public open fun hashCode (): kotlin.Int declared in <root>.Base
-      $this: VALUE_PARAMETER name:<this> type:kotlin.Any 
+      $this: VALUE_PARAMETER name:<this> type:<root>.Base
     FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String 
       overridden:
         public open fun toString (): kotlin.String declared in <root>.Base


### PR DESCRIPTION
In the IR there is no real distinction between `super` and `this`. Instead, this distinction is made at the call site where some calls are marked as super calls. This is in contrast to the representation of super in psi, which has a separate representation.

Currently, when we translate from psi to IR, some of this distinction shines through in that this code
```
class A { fun f() = super.hashCode() }
```
gets turned into IR accessing the dispatch receiver of `f` *with type Any instead of type A*.

For technical reasons (invokespecial) this is unfortunate for the JVM backend, in particular in combination with inline classes. I propose that we change this to treat `super` and `this` interchangeably in the IR instead.