### PR TITLE
Change order of line number geneartion for function call, and also force  line number generation after visiting inline functions

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -268,7 +268,6 @@ class ExpressionCodegen(
         visitStatementContainer(expression, data).coerce(expression.asmType)
 
     override fun visitFunctionAccess(expression: IrFunctionAccessExpression, data: BlockInfo): PromisedValue {
-        expression.markLineNumber(startOffset = true)
         classCodegen.context.irIntrinsics.getIntrinsic(expression.symbol)
             ?.invoke(expression, this, data)?.let { return it.coerce(expression.asmType) }
 
@@ -353,6 +352,7 @@ class ExpressionCodegen(
             }
         }
 
+        expression.markLineNumber(true)
         callGenerator.genCall(
             callable,
             defaultMask.generateOnStackIfNeeded(callGenerator, callee is IrConstructor, this),
@@ -1088,7 +1088,9 @@ class ExpressionCodegen(
     }
 
     override fun markLineNumberAfterInlineIfNeeded() {
-        //TODO
+        // Inline function has its own line number which is in a separate instance of codegen,
+        // therefore we need to reset lastLineNumber to force a line number generation after visiting inline function.
+        lastLineNumber = -1
     }
 
     fun isFinallyMarkerRequired(): Boolean {

--- a/compiler/testData/codegen/box/smap/chainCalls.kt
+++ b/compiler/testData/codegen/box/smap/chainCalls.kt
@@ -84,4 +84,3 @@ fun String.fail(): String {
 fun call(): String {
     return "xxx"
 }
-// IGNORE_BACKEND: JVM_IR

--- a/compiler/testData/codegen/box/smap/infixCalls.kt
+++ b/compiler/testData/codegen/box/smap/infixCalls.kt
@@ -64,4 +64,3 @@ infix fun String.fail(p: String): String {
 fun call(): String {
     return "xxx"
 }
-// IGNORE_BACKEND: JVM_IR

--- a/compiler/testData/codegen/box/smap/simpleCallWithParams.kt
+++ b/compiler/testData/codegen/box/smap/simpleCallWithParams.kt
@@ -108,4 +108,3 @@ inline fun inlineFun(): String {
 fun fail(): String {
     throw AssertionError("fail")
 }
-// IGNORE_BACKEND: JVM_IR


### PR DESCRIPTION
Currently, line number for a function call is only generated for the line when start entering function call, before visiting arguments, therefore missing line number after all function arguments are visited.