### PR TITLE
Remove generated sources and classes for full KAPT build

### DIFF
--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/KaptContext.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/KaptContext.kt
@@ -67,10 +67,12 @@ open class KaptContext(val options: KaptOptions, val withJdk: Boolean, val logge
 
             if (sourcesToReprocess == SourcesToReprocess.FullRebuild) {
                 // remove all generated sources and classes
-                options.sourcesOutputDir.deleteRecursively()
-                options.sourcesOutputDir.mkdir()
-                options.classesOutputDir.deleteRecursively()
-                options.classesOutputDir.mkdir()
+                fun deleteAndCreate(dir: File) {
+                    if (!dir.deleteRecursively()) logger.warn("Unable to delete $dir.")
+                    if (!dir.mkdir()) logger.warn("Unable to create $dir.")
+                }
+                deleteAndCreate(options.sourcesOutputDir)
+                deleteAndCreate(options.classesOutputDir)
             }
         } else {
             sourcesToReprocess = SourcesToReprocess.FullRebuild

--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/KaptContext.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/KaptContext.kt
@@ -64,6 +64,14 @@ open class KaptContext(val options: KaptOptions, val withJdk: Boolean, val logge
                 cacheManager?.invalidateAndGetDirtyFiles(
                     options.changedFiles, options.classpathChanges
                 ) ?: SourcesToReprocess.FullRebuild
+
+            if (sourcesToReprocess == SourcesToReprocess.FullRebuild) {
+                // remove all generated sources and classes
+                options.sourcesOutputDir.deleteRecursively()
+                options.sourcesOutputDir.mkdir()
+                options.classesOutputDir.deleteRecursively()
+                options.classesOutputDir.mkdir()
+            }
         } else {
             sourcesToReprocess = SourcesToReprocess.FullRebuild
         }

--- a/plugins/kapt3/kapt3-base/test/org/jetbrains/kotlin/kapt3/base/incremental/IncrementalKaptTest.kt
+++ b/plugins/kapt3/kapt3-base/test/org/jetbrains/kotlin/kapt3/base/incremental/IncrementalKaptTest.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.base.kapt3.KaptOptions
 import org.jetbrains.kotlin.base.kapt3.collectJavaSourceFiles
 import org.jetbrains.kotlin.kapt3.base.KaptContext
 import org.jetbrains.kotlin.kapt3.base.doAnnotationProcessing
+import org.jetbrains.kotlin.kapt3.base.incremental.RuntimeProcType
 import org.jetbrains.kotlin.kapt3.base.incremental.SourcesToReprocess
 import org.jetbrains.kotlin.kapt3.base.util.WriterBackedKaptLogger
 import org.junit.Assert.*
@@ -155,6 +156,69 @@ class IncrementalKaptTest {
 
             it.doAnnotationProcessing(
                 optionsForSecondRun.collectJavaSourceFiles(sourcesToReprocess), listOf(SimpleGeneratingIfTypeDoesNotExist().toIsolating())
+            )
+        }
+
+        assertTrue(outputDir.resolve("test/UserGenerated.java").exists())
+    }
+
+    /** Regression test for KT-31322. */
+    @Test
+    fun testCleanupWithDynamicNonIncremental() {
+        val sourcesDir = tmp.newFolder().resolve("test").also { base ->
+            base.mkdir()
+            listOf("User.java", "Address.java", "Observable.java").map {
+                TEST_DATA_DIR.resolve(it).copyTo(base.resolve(it))
+            }
+        }
+
+        val outputDir = tmp.newFolder()
+        val incrementalCacheDir = tmp.newFolder()
+        val options = KaptOptions.Builder().apply {
+            projectBaseDir = tmp.newFolder()
+            javaSourceRoots.add(sourcesDir)
+
+            sourcesOutputDir = outputDir
+            classesOutputDir = outputDir
+            stubsOutputDir = outputDir
+            incrementalDataOutputDir = outputDir
+
+            incrementalCache = incrementalCacheDir
+        }.build()
+
+        val logger = WriterBackedKaptLogger(isVerbose = true)
+        KaptContext(options, true, logger).use {
+            it.doAnnotationProcessing(
+                options.collectJavaSourceFiles(SourcesToReprocess.FullRebuild),
+                listOf(DynamicProcessor(RuntimeProcType.NON_INCREMENTAL).toDynamic())
+            )
+        }
+
+        val optionsForSecondRun = KaptOptions.Builder().apply {
+            projectBaseDir = tmp.newFolder()
+            javaSourceRoots.add(sourcesDir)
+
+            sourcesOutputDir = outputDir
+            classesOutputDir = outputDir
+            stubsOutputDir = outputDir
+            incrementalDataOutputDir = outputDir
+
+            incrementalCache = incrementalCacheDir
+            changedFiles.add(sourcesDir.resolve("User.java"))
+            flags.add(KaptFlag.INCREMENTAL_APT)
+        }.build()
+
+        KaptContext(optionsForSecondRun, true, logger).use {
+            val sourcesToReprocess =
+                it.cacheManager!!.invalidateAndGetDirtyFiles(optionsForSecondRun.changedFiles, emptyList())
+            assertEquals(SourcesToReprocess.FullRebuild, sourcesToReprocess)
+
+            // check output dir is empty
+            assertEquals(listOf(outputDir), outputDir.walkTopDown().toList())
+
+            it.doAnnotationProcessing(
+                optionsForSecondRun.collectJavaSourceFiles(sourcesToReprocess),
+                listOf(DynamicProcessor(RuntimeProcType.NON_INCREMENTAL).toDynamic())
             )
         }
 


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-31322

When running incremental annotation processing in KAPT,
even if incremental flag is enabled, and full rebuild should
be performed (e.g. in presence of dynamic non-incremental APs),
make sure generated sources and classes are removed.

 #KT-31322 fixed