### PR TITLE
Fix compareCustom function in IrLineNumberTest class, to exclude comment

### DIFF
--- a/compiler/testData/lineNumber/custom/functionCallWithDefault.kt
+++ b/compiler/testData/lineNumber/custom/functionCallWithDefault.kt
@@ -8,5 +8,5 @@ fun foo(i: Int = 1) {
 
 inline fun bar(i: Int = 1) {
 }
-// IGNORE_BACKEND: JVM_IR
+
 // 2 3 13 14 4 7 6 10 9 15

--- a/compiler/tests-common/tests/org/jetbrains/kotlin/codegen/ir/AbstractIrLineNumberTest.kt
+++ b/compiler/tests-common/tests/org/jetbrains/kotlin/codegen/ir/AbstractIrLineNumberTest.kt
@@ -25,7 +25,7 @@ abstract class AbstractIrLineNumberTest : AbstractLineNumberTest() {
     override fun compareCustom(psiFile: KtFile, wholeFile: File) {
         val fileText = psiFile.text
         val expectedLineNumbers = normalize(
-            fileText.substring(fileText.indexOf("//") + 2)
+            fileText.substring(Regex("// \\d+").find(fileText)!!.range.start + 2)
                 .trim().split(" ").map { it.trim() }.toMutableList()
         )
         val actualLineNumbers = normalize(extractActualLineNumbersFromBytecode(classFileFactory, false))


### PR DESCRIPTION
Fix compareCustom function in IrLineNumberTest class, to exclude comment lines that are not related to line number verification.

Unmute a test case should have been unmuted but shadowed by this bug.