### PR TITLE
JVM: Generate LVT entry for this in @JvmOverload methods.

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/DefaultParameterValueSubstitutor.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/DefaultParameterValueSubstitutor.kt
@@ -244,8 +244,10 @@ class DefaultParameterValueSubstitutor(val state: GenerationState) {
         val methodEnd = Label()
         mv.visitLabel(methodEnd)
 
+        val thisType = functionDescriptor.dispatchReceiverParameter?.type?.asmType(typeMapper)
+
         FunctionCodegen.generateLocalVariablesForParameters(
-            mv, signature, functionDescriptor, null, methodBegin, methodEnd, remainingParameters, isStatic, state
+            mv, signature, functionDescriptor, thisType, methodBegin, methodEnd, remainingParameters, isStatic, state
         )
 
         FunctionCodegen.endVisit(mv, null, methodElement)

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/JvmOverloadsAnnotationLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/JvmOverloadsAnnotationLowering.kt
@@ -115,7 +115,7 @@ private class JvmOverloadsAnnotationLowering(val context: JvmBackendContext) : C
             is IrConstructor -> {
                 val descriptor = WrappedClassConstructorDescriptor(oldFunction.descriptor.annotations)
                 IrConstructorImpl(
-                    oldFunction.startOffset, oldFunction.endOffset,
+                    UNDEFINED_OFFSET, UNDEFINED_OFFSET,
                     JvmLoweredDeclarationOrigin.JVM_OVERLOADS_WRAPPER,
                     IrConstructorSymbolImpl(descriptor),
                     oldFunction.name,
@@ -131,7 +131,7 @@ private class JvmOverloadsAnnotationLowering(val context: JvmBackendContext) : C
             is IrSimpleFunction -> {
                 val descriptor = WrappedSimpleFunctionDescriptor(oldFunction.descriptor.annotations)
                 IrFunctionImpl(
-                    oldFunction.startOffset, oldFunction.endOffset,
+                    UNDEFINED_OFFSET, UNDEFINED_OFFSET,
                     JvmLoweredDeclarationOrigin.JVM_OVERLOADS_WRAPPER,
                     IrSimpleFunctionSymbolImpl(descriptor),
                     oldFunction.name,

--- a/compiler/testData/checkLocalVariablesTable/jvmOverloads.kt
+++ b/compiler/testData/checkLocalVariablesTable/jvmOverloads.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 // WITH_RUNTIME
 class C {
     @kotlin.jvm.JvmOverloads fun foo(firstParam: Int, secondParam: String = "") {
@@ -6,4 +5,5 @@ class C {
 }
 
 // METHOD : C.foo(I)V
+// VARIABLE : NAME=this TYPE=LC; INDEX=0
 // VARIABLE : NAME=firstParam TYPE=I INDEX=1

--- a/compiler/tests-common/tests/org/jetbrains/kotlin/codegen/AbstractCheckLocalVariablesTableTest.kt
+++ b/compiler/tests-common/tests/org/jetbrains/kotlin/codegen/AbstractCheckLocalVariablesTableTest.kt
@@ -102,11 +102,13 @@ abstract class AbstractCheckLocalVariablesTableTest : CodegenTestCase() {
 
             class Visitor : ClassVisitor(Opcodes.API_VERSION) {
                 var readVariables: MutableList<LocalVariable> = ArrayList()
+                var methodFound = false
 
                 override fun visitMethod(
                     access: Int, name: String, desc: String, signature: String?, exceptions: Array<String>?
                 ): MethodVisitor? {
                     return if (methodName == name + desc) {
+                        methodFound = true
                         object : MethodVisitor(Opcodes.API_VERSION) {
                             override fun visitLocalVariable(
                                 name: String, desc: String, signature: String?, start: Label, end: Label, index: Int
@@ -124,7 +126,7 @@ abstract class AbstractCheckLocalVariablesTableTest : CodegenTestCase() {
 
             cr.accept(visitor, ClassReader.SKIP_FRAMES)
 
-            TestCase.assertFalse("method not found: $methodName", visitor.readVariables.isEmpty())
+            TestCase.assertTrue("method not found: $methodName", visitor.methodFound)
 
             return visitor.readVariables
         }


### PR DESCRIPTION
Since we generate local variable entries for the rest of the arguments
we should do it for the receiver as well.