### PR TITLE
Fix typo in expectation files for command line tests.

### DIFF
--- a/compiler/testData/cli/jvm/internalArgOverrideLanguageFeature.out
+++ b/compiler/testData/cli/jvm/internalArgOverrideLanguageFeature.out
@@ -1,7 +1,7 @@
 warning: ATTENTION!
 This build uses unsafe internal compiler arguments:
 
--XXLanguage;+InlineClasses
+-XXLanguage:+InlineClasses
 
 This mode is not recommended for production use,
 as no stability/compatibility guarantees are given on

--- a/compiler/testData/cli/jvm/internalArgOverrideOffLanguageFeature.out
+++ b/compiler/testData/cli/jvm/internalArgOverrideOffLanguageFeature.out
@@ -1,7 +1,7 @@
 warning: ATTENTION!
 This build uses unsafe internal compiler arguments:
 
--XXLanguage;-InlineClasses
+-XXLanguage:-InlineClasses
 
 This mode is not recommended for production use,
 as no stability/compatibility guarantees are given on


### PR DESCRIPTION
The expectations contained ';' instead of ':' which makes two
CLI tests fail.