### PR TITLE
KT-31404 Redundant 'requireNotNull' or 'checkNotNull' inspection: don't remove first argument

### DIFF
--- a/idea/testData/inspectionsLocal/redundantRequireNotNullCall/usedAsExpression.kt
+++ b/idea/testData/inspectionsLocal/redundantRequireNotNullCall/usedAsExpression.kt
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test(i: Int) {
+    val a = <caret>requireNotNull(i)
+}

--- a/idea/testData/inspectionsLocal/redundantRequireNotNullCall/usedAsExpression.kt.after
+++ b/idea/testData/inspectionsLocal/redundantRequireNotNullCall/usedAsExpression.kt.after
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test(i: Int) {
+    val a = i
+}

--- a/idea/testData/inspectionsLocal/redundantRequireNotNullCall/usedAsExpression2.kt
+++ b/idea/testData/inspectionsLocal/redundantRequireNotNullCall/usedAsExpression2.kt
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test(i: Int) {
+    println(<caret>requireNotNull(i) { "" })
+}

--- a/idea/testData/inspectionsLocal/redundantRequireNotNullCall/usedAsExpression2.kt.after
+++ b/idea/testData/inspectionsLocal/redundantRequireNotNullCall/usedAsExpression2.kt.after
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test(i: Int) {
+    println(i)
+}

--- a/idea/testData/inspectionsLocal/redundantRequireNotNullCall/usedAsExpression3.kt
+++ b/idea/testData/inspectionsLocal/redundantRequireNotNullCall/usedAsExpression3.kt
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test(i: Int) {
+    "${<caret>checkNotNull(i)}"
+}

--- a/idea/testData/inspectionsLocal/redundantRequireNotNullCall/usedAsExpression3.kt.after
+++ b/idea/testData/inspectionsLocal/redundantRequireNotNullCall/usedAsExpression3.kt.after
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test(i: Int) {
+    "${i}"
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -5731,6 +5731,21 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
         public void testRequire() throws Exception {
             runTest("idea/testData/inspectionsLocal/redundantRequireNotNullCall/require.kt");
         }
+
+        @TestMetadata("usedAsExpression.kt")
+        public void testUsedAsExpression() throws Exception {
+            runTest("idea/testData/inspectionsLocal/redundantRequireNotNullCall/usedAsExpression.kt");
+        }
+
+        @TestMetadata("usedAsExpression2.kt")
+        public void testUsedAsExpression2() throws Exception {
+            runTest("idea/testData/inspectionsLocal/redundantRequireNotNullCall/usedAsExpression2.kt");
+        }
+
+        @TestMetadata("usedAsExpression3.kt")
+        public void testUsedAsExpression3() throws Exception {
+            runTest("idea/testData/inspectionsLocal/redundantRequireNotNullCall/usedAsExpression3.kt");
+        }
     }
 
     @TestMetadata("idea/testData/inspectionsLocal/redundantReturnLabel")


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-31404