### PR TITLE
Replicate old backend's naming logic for captured receiver parameter and extension receiver parameters.

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.backend.jvm.codegen
 
+import org.jetbrains.kotlin.backend.common.lower.BOUND_RECEIVER_PARAMETER
 import org.jetbrains.kotlin.backend.jvm.JvmLoweredDeclarationOrigin
 import org.jetbrains.kotlin.backend.jvm.intrinsics.IrIntrinsicMethods
 import org.jetbrains.kotlin.backend.jvm.intrinsics.JavaClassProperty
@@ -20,6 +21,7 @@ import org.jetbrains.kotlin.codegen.pseudoInsns.fakeAlwaysFalseIfeq
 import org.jetbrains.kotlin.codegen.pseudoInsns.fixStackAndJump
 import org.jetbrains.kotlin.codegen.signature.BothSignatureWriter
 import org.jetbrains.kotlin.config.isReleaseCoroutines
+import org.jetbrains.kotlin.config.languageVersionSettings
 import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.declarations.*
@@ -204,18 +206,29 @@ class ExpressionCodegen(
         }
         val extensionReceiverParameter = irFunction.extensionReceiverParameter
         if (extensionReceiverParameter != null) {
-            writeValueParameterInLocalVariableTable(extensionReceiverParameter, startLabel, endLabel)
+            writeValueParameterInLocalVariableTable(extensionReceiverParameter, startLabel, endLabel, true)
         }
         for (param in irFunction.valueParameters) {
-            writeValueParameterInLocalVariableTable(param, startLabel, endLabel)
+            writeValueParameterInLocalVariableTable(param, startLabel, endLabel, false)
         }
     }
 
-    private fun writeValueParameterInLocalVariableTable(param: IrValueParameter, startLabel: Label, endLabel: Label) {
+    private fun writeValueParameterInLocalVariableTable(param: IrValueParameter, startLabel: Label, endLabel: Label, isReceiver: Boolean) {
         // TODO: old code has a special treatment for destructuring lambda parameters.
         // There is no (easy) way to reproduce it with IR structures.
         // Does not show up in tests, but might come to bite us at some point.
-        val name = param.name.asString()
+
+        // If the parameter is an extension receiver parameter or a captured extension receiver from enclosing,
+        // then generate name accordingly.
+        val name = if (param.origin == BOUND_RECEIVER_PARAMETER || isReceiver) {
+            getNameForReceiverParameter(
+                irFunction.descriptor,
+                typeMapper.kotlinTypeMapper.bindingContext,
+                context.configuration.languageVersionSettings
+            )
+        } else {
+            param.name.asString()
+        }
 
         val type = typeMapper.mapType(param)
         // NOTE: we expect all value parameters to be present in the frame.

--- a/compiler/testData/checkLocalVariablesTable/kt11117.kt
+++ b/compiler/testData/checkLocalVariablesTable/kt11117.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 class A(val value: String)
 
 fun A.test(): String {

--- a/compiler/testData/checkLocalVariablesTable/receiverParameter.kt
+++ b/compiler/testData/checkLocalVariablesTable/receiverParameter.kt
@@ -1,0 +1,10 @@
+class A() {
+    fun String.test() {
+
+    }
+}
+
+
+// METHOD : A.test(Ljava/lang/String;)V
+// VARIABLE : NAME=this TYPE=LA; INDEX=0
+// VARIABLE : NAME=$this$test TYPE=Ljava/lang/String; INDEX=1

--- a/compiler/tests/org/jetbrains/kotlin/codegen/CheckLocalVariablesTableTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/CheckLocalVariablesTableTestGenerated.java
@@ -104,6 +104,11 @@ public class CheckLocalVariablesTableTestGenerated extends AbstractCheckLocalVar
         runTest("compiler/testData/checkLocalVariablesTable/localFun.kt");
     }
 
+    @TestMetadata("receiverParameter.kt")
+    public void testReceiverParameter() throws Exception {
+        runTest("compiler/testData/checkLocalVariablesTable/receiverParameter.kt");
+    }
+
     @TestMetadata("underscoreNames.kt")
     public void testUnderscoreNames() throws Exception {
         runTest("compiler/testData/checkLocalVariablesTable/underscoreNames.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrCheckLocalVariablesTableTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrCheckLocalVariablesTableTestGenerated.java
@@ -104,6 +104,11 @@ public class IrCheckLocalVariablesTableTestGenerated extends AbstractIrCheckLoca
         runTest("compiler/testData/checkLocalVariablesTable/localFun.kt");
     }
 
+    @TestMetadata("receiverParameter.kt")
+    public void testReceiverParameter() throws Exception {
+        runTest("compiler/testData/checkLocalVariablesTable/receiverParameter.kt");
+    }
+
     @TestMetadata("underscoreNames.kt")
     public void testUnderscoreNames() throws Exception {
         runTest("compiler/testData/checkLocalVariablesTable/underscoreNames.kt");


### PR DESCRIPTION
Replicate old backend's naming logic for captured receiver parameter in constructors and extension receiver parameters.

Currently names for captured receiver parameter and extension receiver parameter are not transformed.

Also added a LVT test for extension receiver parameter (Only captured receiver parameter test is available now)