### PR TITLE
Check that classpath entries exist before reading.

### DIFF
--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/incremental/incrementalProcessorDiscovery.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/incremental/incrementalProcessorDiscovery.kt
@@ -41,7 +41,7 @@ private fun processSingleClasspathEntry(rootFile: File): Map<String, DeclaredPro
                 emptyList()
             }
         }
-        rootFile.extension == "jar" -> ZipFile(rootFile).use { zipFile ->
+        rootFile.extension == "jar" && rootFile.exists() -> ZipFile(rootFile).use { zipFile ->
             val content: InputStream? = zipFile.getInputStream(ZipEntry(INCREMENTAL_ANNOTATION_FLAG))
 
             content?.bufferedReader()?.readLines() ?: emptyList()


### PR DESCRIPTION
The new incremental processor causes crashes in cases where nonexistent processor classpath entries are passed (even when the flag is off), which is a change in behavior from before the feature was introduced.