### PR TITLE
Check classpath entries exist before reading them.

### DIFF
--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/incremental/incrementalProcessorDiscovery.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/incremental/incrementalProcessorDiscovery.kt
@@ -41,7 +41,7 @@ private fun processSingleClasspathEntry(rootFile: File): Map<String, DeclaredPro
                 emptyList()
             }
         }
-        rootFile.extension == "jar" -> ZipFile(rootFile).use { zipFile ->
+        rootFile.extension == "jar" && rootFile.exists() -> ZipFile(rootFile).use { zipFile ->
             val content: InputStream? = zipFile.getInputStream(ZipEntry(INCREMENTAL_ANNOTATION_FLAG))
 
             content?.bufferedReader()?.readLines() ?: emptyList()


### PR DESCRIPTION
This fixes a potential crash for nonexistent kapt3 classpath entries. Prior to the incremental annotation processing feature being introduced, these would be silently ignored. Even when the incremental annotation processing flag is off, these classpath entries are read, and nonexistent ones trigger an IOException.