### PR TITLE
If incremental KAPT is disabled, do not analyze classpath

### DIFF
--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/ProcessorLoader.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/ProcessorLoader.kt
@@ -55,6 +55,10 @@ open class ProcessorLoader(private val options: KaptOptions, private val logger:
     }
 
     private fun wrapInIncrementalProcessor(processors: List<Processor>, classpath: Iterable<File>): List<IncrementalProcessor> {
+        if (!options[KaptFlag.INCREMENTAL_APT]) {
+            return processors.map { IncrementalProcessor(it, DeclaredProcType.NON_INCREMENTAL) }
+        }
+
         val processorNames = processors.map {it.javaClass.name}.toSet()
 
         val processorsInfo: Map<String, DeclaredProcType> = getIncrementalProcessorsFromClasspath(processorNames, classpath)


### PR DESCRIPTION
When incremental apt mode in KAPT is disabled, do not analyze
classpath to determine the type of the annotation processors. Instead,
just mark them all as non-incremental.