### PR TITLE
Fix type parameters in WrappedClassConstructorDescriptor

### DIFF
--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/descriptors/WrappedDescriptors.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/descriptors/WrappedDescriptors.kt
@@ -16,10 +16,7 @@ import org.jetbrains.kotlin.ir.descriptors.IrBasedDeclarationDescriptor
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.types.classifierOrFail
 import org.jetbrains.kotlin.ir.types.toKotlinType
-import org.jetbrains.kotlin.ir.util.defaultType
-import org.jetbrains.kotlin.ir.util.dump
-import org.jetbrains.kotlin.ir.util.isAnnotationClass
-import org.jetbrains.kotlin.ir.util.parentAsClass
+import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.resolve.constants.*
 import org.jetbrains.kotlin.resolve.descriptorUtil.classId
@@ -445,7 +442,9 @@ open class WrappedClassConstructorDescriptor(
         (containingDeclaration.containingDeclaration as ClassDescriptor).thisAsReceiverParameter
     }
 
-    override fun getTypeParameters() = owner.typeParameters.map { it.descriptor }
+    override fun getTypeParameters() =
+        (owner.constructedClass.typeParameters + owner.typeParameters).map { it.descriptor }
+
     override fun getValueParameters() = owner.valueParameters.asSequence()
         .mapNotNull { it.descriptor as? ValueParameterDescriptor }
         .toMutableList()

--- a/compiler/testData/ir/irText/classes/delegatingConstructorCallToTypeAliasConstructor.fir.txt
+++ b/compiler/testData/ir/irText/classes/delegatingConstructorCallToTypeAliasConstructor.fir.txt
@@ -36,6 +36,7 @@ FILE fqName:<root> fileName:/delegatingConstructorCallToTypeAliasConstructor.kt
     CONSTRUCTOR visibility:public <> () returnType:<root>.C1 [primary] 
       BLOCK_BODY
         DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> (value: T of <uninitialized parent>) [primary] declared in <root>.Cell'
+          <T>: <none>
           value: CONST String type=kotlin.String value="O"
         INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:C1 modality:FINAL visibility:public superTypes:[<root>.Cell<kotlin.String>]'
     FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean 
@@ -56,6 +57,7 @@ FILE fqName:<root> fileName:/delegatingConstructorCallToTypeAliasConstructor.kt
     CONSTRUCTOR visibility:public <> () returnType:<root>.C2 [primary] 
       BLOCK_BODY
         DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> (value: T of <uninitialized parent>) [primary] declared in <root>.Cell'
+          <T>: <none>
           value: CONST String type=kotlin.String value="K"
         INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:C2 modality:FINAL visibility:public superTypes:[<root>.Cell]'
     FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean 
@@ -71,4 +73,3 @@ FILE fqName:<root> fileName:/delegatingConstructorCallToTypeAliasConstructor.kt
       overridden:
         public open fun toString (): kotlin.String declared in kotlin.Any
       $this: VALUE_PARAMETER name:<this> type:kotlin.Any 
-

--- a/compiler/testData/ir/irText/declarations/fakeOverrides.fir.txt
+++ b/compiler/testData/ir/irText/declarations/fakeOverrides.fir.txt
@@ -65,6 +65,7 @@ FILE fqName:<root> fileName:/fakeOverrides.kt
     CONSTRUCTOR visibility:public <> () returnType:<root>.Test1 [primary] 
       BLOCK_BODY
         DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in <root>.CFoo'
+          <T>: <none>
         INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Test1 modality:FINAL visibility:public superTypes:[<root>.CFoo<kotlin.String>; <root>.IFooStr; <root>.IBar]'
     PROPERTY name:bar visibility:public modality:FINAL [val] 
       FIELD PROPERTY_BACKING_FIELD name:bar type:kotlin.Int visibility:public [final] 
@@ -95,4 +96,3 @@ FILE fqName:<root> fileName:/fakeOverrides.kt
       overridden:
         public open fun toString (): kotlin.String declared in kotlin.Any
       $this: VALUE_PARAMETER name:<this> type:kotlin.Any 
-

--- a/compiler/testData/ir/irText/declarations/parameters/constructor.fir.txt
+++ b/compiler/testData/ir/irText/declarations/parameters/constructor.fir.txt
@@ -87,6 +87,7 @@ FILE fqName:<root> fileName:/constructor.kt
         VALUE_PARAMETER name:i index:1 type:kotlin.Int 
         BLOCK_BODY
           DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> (z: Z of <uninitialized parent>) [primary] declared in <root>.Test2.TestInner'
+            <Z>: <none>
             z: GET_VAR 'z: Z of <uninitialized parent> declared in <root>.Test2.TestInner.<init>' type=Z of <uninitialized parent> origin=null
       FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean 
         overridden:
@@ -185,6 +186,7 @@ FILE fqName:<root> fileName:/constructor.kt
           CONST Int type=kotlin.Int value=42
       BLOCK_BODY
         DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> (x: kotlin.Int) [primary] declared in <root>.Test4'
+          <T>: <none>
           x: CALL 'public final fun plus (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=null
             other: GET_VAR 'y: kotlin.Int declared in <root>.Test4.<init>' type=kotlin.Int origin=null
     FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean 
@@ -200,4 +202,3 @@ FILE fqName:<root> fileName:/constructor.kt
       overridden:
         public open fun toString (): kotlin.String declared in kotlin.Any
       $this: VALUE_PARAMETER name:<this> type:kotlin.Any 
-

--- a/compiler/testData/ir/irText/declarations/parameters/typeParameterBoundedBySubclass.fir.txt
+++ b/compiler/testData/ir/irText/declarations/parameters/typeParameterBoundedBySubclass.fir.txt
@@ -24,6 +24,7 @@ FILE fqName:<root> fileName:/typeParameterBoundedBySubclass.kt
     CONSTRUCTOR visibility:public <> () returnType:<root>.Derived1 [primary] 
       BLOCK_BODY
         DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in <root>.Base1'
+          <T>: <none>
         INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Derived1 modality:FINAL visibility:public superTypes:[<root>.Base1<<root>.Derived1>]'
     FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean 
       overridden:
@@ -86,4 +87,3 @@ FILE fqName:<root> fileName:/typeParameterBoundedBySubclass.kt
       overridden:
         public open fun toString (): kotlin.String declared in kotlin.Any
       $this: VALUE_PARAMETER name:<this> type:kotlin.Any 
-

--- a/compiler/testData/ir/irText/stubs/genericClassInDifferentModule_m2.fir.txt
+++ b/compiler/testData/ir/irText/stubs/genericClassInDifferentModule_m2.fir.txt
@@ -6,6 +6,7 @@ FILE fqName:<root> fileName:/genericClassInDifferentModule_m2.kt
       VALUE_PARAMETER name:x index:0 type:T of <uninitialized parent> 
       BLOCK_BODY
         DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> (x: T of <uninitialized parent>) [primary] declared in <root>.Base'
+          <T>: <none>
           x: GET_VAR 'x: T of <uninitialized parent> declared in <root>.Derived1.<init>' type=T of <uninitialized parent> origin=null
         INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Derived1 modality:FINAL visibility:public superTypes:[<root>.Base<T of <root>.Derived1>]'
     FUN name:foo visibility:public modality:FINAL <Y> ($this:<root>.Derived1, y:Y of <root>.Derived1.foo) returnType:T of <root>.Derived1 
@@ -59,4 +60,3 @@ FILE fqName:<root> fileName:/genericClassInDifferentModule_m2.kt
       overridden:
         public open fun toString (): kotlin.String declared in kotlin.Any
       $this: VALUE_PARAMETER name:<this> type:kotlin.Any 
-


### PR DESCRIPTION
`IrConstructorCall` has type parameters from the constructed class as well as the constructor type parameters. This is currently not implemented in `WrappedClassConstructorDescriptor`, which breaks constructor calls with type arguments generated in an IR lowering pass.

Among other places, you can see the problem in the IR generated by fir2ir, which is why the tests have to be updated.