### PR TITLE
Fix test for static default methods in KotlinTypeMapper

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/state/KotlinTypeMapper.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/state/KotlinTypeMapper.kt
@@ -910,7 +910,8 @@ class KotlinTypeMapper @JvmOverloads constructor(
         val isConstructor = isConstructor(jvmSignature)
         val descriptor = getDefaultDescriptor(
             jvmSignature,
-            if (isStaticMethod(kind, functionDescriptor) || isConstructor) null else ownerType.descriptor,
+            if (isStaticMethod(kind, functionDescriptor) || isStaticDeclaration(functionDescriptor) || isConstructor)
+                null else ownerType.descriptor,
             functionDescriptor.unwrapFrontendVersion()
         )
 


### PR DESCRIPTION
The function `isStaticMethod` makes its decision based on the kind and annotation, but doesn't check whether the function has a null dispatch receiver. Apparently this case never happens in the current backend, but I had to add this test for #2326.