### PR TITLE
tailrec: handle default parameters

### DIFF
--- a/compiler/testData/codegen/box/diagnostics/functions/tailRecursion/defaultArgs.kt
+++ b/compiler/testData/codegen/box/diagnostics/functions/tailRecursion/defaultArgs.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 // DONT_RUN_GENERATED_CODE: JS
 
 tailrec fun test(x : Int = 0, e : Any = "a") {


### PR DESCRIPTION
More precisely, don't copy default parameters as they are always filled
by foo$default.