### PR TITLE
Remove imports of javafx from Gradle build files

### DIFF
--- a/compiler/daemon/daemon-common-new/build.gradle.kts
+++ b/compiler/daemon/daemon-common-new/build.gradle.kts
@@ -8,8 +8,6 @@
  * that can be found in the license/LICENSE.txt file.
  */
 
-import com.sun.javafx.scene.CameraHelper.project
-
 plugins {
     java
     kotlin("jvm")

--- a/compiler/daemon/daemon-common/build.gradle.kts
+++ b/compiler/daemon/daemon-common/build.gradle.kts
@@ -1,5 +1,3 @@
-import com.sun.javafx.scene.CameraHelper.project
-
 plugins {
     kotlin("jvm")
     id("jps-compatible")


### PR DESCRIPTION
Added by this commit for some reason: https://github.com/JetBrains/kotlin/commit/ced973b7074f4207859d9709375f2bf28b3e2c55