### PR TITLE
Support isolating APs that report multiple originating elements

### DIFF
--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/incremental/incrementalProcessors.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/incremental/incrementalProcessors.kt
@@ -124,15 +124,15 @@ internal class AnnotationProcessorDependencyCollector(private val runtimeProcTyp
     }
 }
 
-private fun getSrcFiles(elements: Array<out Element?>): List<File> {
+private fun getSrcFiles(elements: Array<out Element?>): Set<File> {
     return elements.filterNotNull().mapNotNull { elem ->
         var origin = elem
         while (origin.enclosingElement != null && origin.enclosingElement !is PackageElement) {
             origin = origin.enclosingElement
         }
         val uri = (origin as? Symbol.ClassSymbol)?.sourcefile?.toUri()?.takeIf { it.isAbsolute }
-        uri?.let { File(it) }
-    }
+        uri?.let { File(it).canonicalFile }
+    }.toSet()
 }
 
 enum class DeclaredProcType {

--- a/plugins/kapt3/kapt3-base/test/org/jetbrains/kotlin/kapt3/base/incremental/IsolatingIncrementalProcessorTest.kt
+++ b/plugins/kapt3/kapt3-base/test/org/jetbrains/kotlin/kapt3/base/incremental/IsolatingIncrementalProcessorTest.kt
@@ -107,4 +107,17 @@ class IsolationgIncrementalProcessorTest {
             ), isolating[1].getGeneratedToSources()
         )
     }
+
+    @Test
+    fun testIsolatingWithMultipleOriginatingElements() {
+        val srcFiles = listOf("User.java", "Observable.java").map { File(TEST_DATA_DIR, it) }
+        val isolating = listOf(ReportTwoOriginElements().toIsolating())
+        runAnnotationProcessing(srcFiles, isolating, generatedSources)
+
+        assertEquals(
+            mapOf(
+                generatedSources.resolve("test/UserGenerated.java") to File("plugins/kapt3/kapt3-base/testData/runner/incremental/User.java").absoluteFile
+            ), isolating[0].getGeneratedToSources()
+        )
+    }
 }

--- a/plugins/kapt3/kapt3-base/test/org/jetbrains/kotlin/kapt3/base/incremental/fixtures.kt
+++ b/plugins/kapt3/kapt3-base/test/org/jetbrains/kotlin/kapt3/base/incremental/fixtures.kt
@@ -148,3 +148,17 @@ class SimpleGeneratingIfTypeDoesNotExist: SimpleProcessor() {
         return false
     }
 }
+
+open class ReportTwoOriginElements : SimpleProcessor() {
+    override fun process(annotations: MutableSet<out TypeElement>, roundEnv: RoundEnvironment): Boolean {
+        if (annotations.isEmpty()) return false
+
+        roundEnv.getElementsAnnotatedWith(annotations.single()).forEach {
+            it as TypeElement
+            // Report 2 elements from the same file as originating
+            filer.createSourceFile("${it.qualifiedName}Generated", it, it).openWriter().use { it.write("") }
+        }
+
+        return false
+    }
+}


### PR DESCRIPTION
Support isolating APs that report multiple originating elements from the same source file

It is possible for isolating annotation processor to report two or more
originating elements from the same source file when generating
sources/classes/resources. This commit makes sure the source file are
de-duped, so assertion that there is a single source file does not fail.

Test: IsolatingIncrementalProcessorsTest.testIsolatingWithMultipleOriginatingElements

This is improvement to https://youtrack.jetbrains.com/issue/KT-23880