### PR TITLE
Implement a lowering for type operators in the JVM_IR backend

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
@@ -191,6 +191,7 @@ private val jvmFilePhases =
         toArrayPhase then
         jvmBuiltinOptimizationLoweringPhase then
         additionalClassAnnotationPhase then
+        typeOperatorLowering then
 
         recordNamesForKotlinTypeMapperPhase then
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/TypeOperatorLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/TypeOperatorLowering.kt
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.jvm.lower
+
+import org.jetbrains.kotlin.backend.common.FileLoweringPass
+import org.jetbrains.kotlin.backend.common.lower.IrBuildingTransformer
+import org.jetbrains.kotlin.backend.common.lower.at
+import org.jetbrains.kotlin.backend.common.lower.irNot
+import org.jetbrains.kotlin.backend.common.lower.irThrow
+import org.jetbrains.kotlin.backend.common.phaser.makeIrFilePhase
+import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
+import org.jetbrains.kotlin.backend.jvm.codegen.fileParent
+import org.jetbrains.kotlin.backend.jvm.ir.erasedUpperBound
+import org.jetbrains.kotlin.config.ApiVersion
+import org.jetbrains.kotlin.ir.IrElement
+import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
+import org.jetbrains.kotlin.ir.builders.*
+import org.jetbrains.kotlin.ir.declarations.IrDeclaration
+import org.jetbrains.kotlin.ir.declarations.IrFile
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.IrStatementOrigin
+import org.jetbrains.kotlin.ir.expressions.IrTypeOperator
+import org.jetbrains.kotlin.ir.expressions.IrTypeOperatorCall
+import org.jetbrains.kotlin.ir.expressions.impl.IrCompositeImpl
+import org.jetbrains.kotlin.ir.symbols.IrFunctionSymbol
+import org.jetbrains.kotlin.ir.symbols.IrTypeParameterSymbol
+import org.jetbrains.kotlin.ir.types.*
+import org.jetbrains.kotlin.ir.util.render
+import org.jetbrains.kotlin.ir.visitors.IrElementVisitorVoid
+import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
+import org.jetbrains.kotlin.ir.visitors.acceptVoid
+import org.jetbrains.kotlin.utils.addToStdlib.safeAs
+
+// After this pass runs there are only four kinds of IrTypeOperatorCalls left:
+//
+// - IMPLICIT_CAST
+// - SAFE_CAST with reified type parameters
+// - INSTANCEOF with non-nullable type operand or reified type parameters
+// - CAST with non-nullable argument, nullable type operand, or reified type parameters
+//
+// The latter two correspond to the instanceof/checkcast instructions on the JVM, except for
+// the presence of reified type parameters.
+internal val typeOperatorLowering = makeIrFilePhase(
+    ::TypeOperatorLowering,
+    name = "TypeOperatorLowering",
+    description = "Lower IrTypeOperatorCalls to (implicit) casts and instanceof checks"
+)
+
+private class TypeOperatorLowering(private val context: JvmBackendContext) : FileLoweringPass, IrBuildingTransformer(context) {
+    override fun lower(irFile: IrFile) = irFile.transformChildrenVoid()
+
+    private fun IrExpression.transformVoid() = transform(this@TypeOperatorLowering, null)
+
+    private val IrType.isReifiedTypeParameter: Boolean
+        get() = classifierOrNull?.safeAs<IrTypeParameterSymbol>()?.owner?.isReified == true
+
+    private fun lowerInstanceOf(argument: IrExpression, type: IrType) = with(builder) {
+        when {
+            type.isReifiedTypeParameter ->
+                irIs(argument, type)
+            argument.type.isNullable() && type.isNullable() -> {
+                irLetS(argument) { valueSymbol ->
+                    context.oror(
+                        irEqualsNull(irGet(valueSymbol.owner)),
+                        irIs(irGet(valueSymbol.owner), type.makeNotNull())
+                    )
+                }
+            }
+            else -> irIs(argument, type.makeNotNull())
+        }
+    }
+
+    private fun lowerCast(argument: IrExpression, type: IrType): IrExpression = when {
+        type.isReifiedTypeParameter ->
+            builder.irAs(argument, type)
+        argument.type.isNullable() && !type.isNullable() ->
+            with(builder) {
+                irLetS(argument) { valueSymbol ->
+                    irIfNull(
+                        type,
+                        irGet(valueSymbol.owner),
+                        irThrow(irCall(typeCastException).apply {
+                            putValueArgument(0, irString("null cannot be cast to non-null type ${type.render()}"))
+                        }),
+                        lowerCast(irGet(valueSymbol.owner), type.makeNullable())
+                    )
+                }
+            }
+        argument.type.isSubtypeOfClass(type.erasedUpperBound.symbol) ->
+            argument
+        else ->
+            builder.irAs(argument, type)
+    }
+
+    override fun visitTypeOperator(expression: IrTypeOperatorCall): IrExpression = with(builder) {
+        at(expression)
+        return when (expression.operator) {
+            IrTypeOperator.IMPLICIT_COERCION_TO_UNIT ->
+                irComposite(resultType = expression.type) {
+                    +expression.argument.transformVoid()
+                    // TODO: Don't generate these casts in the first place
+                    if (!expression.argument.type.isSubtypeOf(expression.type.makeNullable(), context.irBuiltIns)) {
+                        +IrCompositeImpl(UNDEFINED_OFFSET, UNDEFINED_OFFSET, expression.type)
+                    }
+                }
+
+            // There is no difference between IMPLICIT_CAST and IMPLICIT_INTEGER_COERCION on JVM_IR.
+            // Instead, this is handled in StackValue.coerce.
+            IrTypeOperator.IMPLICIT_INTEGER_COERCION ->
+                irImplicitCast(expression.argument.transformVoid(), expression.typeOperand)
+
+            IrTypeOperator.CAST ->
+                lowerCast(expression.argument.transformVoid(), expression.typeOperand)
+
+            IrTypeOperator.SAFE_CAST ->
+                if (expression.typeOperand.isReifiedTypeParameter) {
+                    expression.transformChildrenVoid()
+                    expression
+                } else {
+                    irLetS(expression.argument.transformVoid(), IrStatementOrigin.SAFE_CALL) { valueSymbol ->
+                        irIfThenElse(
+                            expression.type,
+                            lowerInstanceOf(irGet(valueSymbol.owner), expression.typeOperand.makeNotNull()),
+                            irGet(valueSymbol.owner),
+                            irNull(expression.type)
+                        )
+                    }
+                }
+
+            IrTypeOperator.INSTANCEOF ->
+                lowerInstanceOf(expression.argument.transformVoid(), expression.typeOperand)
+
+            IrTypeOperator.NOT_INSTANCEOF ->
+                irNot(lowerInstanceOf(expression.argument.transformVoid(), expression.typeOperand))
+
+            IrTypeOperator.IMPLICIT_NOTNULL -> {
+                val (startOffset, endOffset) = expression.extents()
+                val source = sourceViewFor(parent as IrDeclaration).subSequence(startOffset, endOffset).toString()
+
+                irLetS(expression.argument.transformVoid()) { valueSymbol ->
+                    irComposite(resultType = expression.type) {
+                        +irCall(checkExpressionValueIsNotNull).apply {
+                            putValueArgument(0, irGet(valueSymbol.owner))
+                            putValueArgument(1, irString(source))
+                        }
+                        +irGet(valueSymbol.owner)
+                    }
+                }
+            }
+
+            else -> {
+                expression.transformChildrenVoid()
+                expression
+            }
+        }
+    }
+
+    private fun IrElement.extents(): Pair<Int, Int> {
+        var startOffset = UNDEFINED_OFFSET
+        var endOffset = UNDEFINED_OFFSET
+        acceptVoid(object : IrElementVisitorVoid {
+            override fun visitElement(element: IrElement) {
+                element.acceptChildrenVoid(this)
+                if (startOffset == UNDEFINED_OFFSET || element.startOffset != UNDEFINED_OFFSET && element.startOffset < startOffset)
+                    startOffset = element.startOffset
+                if (endOffset == UNDEFINED_OFFSET || element.endOffset != UNDEFINED_OFFSET && endOffset < element.endOffset)
+                    endOffset = element.endOffset
+            }
+        })
+        return startOffset to endOffset
+    }
+
+    private fun sourceViewFor(declaration: IrDeclaration) =
+        context.psiSourceManager.getKtFile(declaration.fileParent)!!.viewProvider.contents
+
+    // Since Kotlin 1.4 we throw NullPointerExceptions instead of more specialized exception classes.
+    private val useNullPointerExceptions: Boolean
+        get() = context.state.languageVersionSettings.apiVersion >= ApiVersion.KOTLIN_1_4
+
+    private val typeCastException: IrFunctionSymbol =
+        if (useNullPointerExceptions)
+            context.ir.symbols.ThrowNullPointerException
+        else
+            context.ir.symbols.ThrowTypeCastException
+
+    private val checkExpressionValueIsNotNull: IrFunctionSymbol =
+        if (useNullPointerExceptions)
+            context.ir.symbols.checkNotNullExpressionValue
+        else
+            context.ir.symbols.checkExpressionValueIsNotNull
+}

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/builders/ExpressionHelpers.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/builders/ExpressionHelpers.kt
@@ -19,20 +19,6 @@ import org.jetbrains.kotlin.utils.addToStdlib.assertedCast
 
 val IrBuilderWithScope.parent get() = scope.getLocalDeclarationParent()
 
-inline fun IrBuilderWithScope.irLet(
-    value: IrExpression,
-    origin: IrStatementOrigin? = null,
-    nameHint: String? = null,
-    body: (VariableDescriptor) -> IrExpression
-): IrExpression {
-    val irTemporary = scope.createTemporaryVariable(value, nameHint)
-    val irResult = body(irTemporary.descriptor)
-    val irBlock = IrBlockImpl(startOffset, endOffset, irResult.type, origin)
-    irBlock.statements.add(irTemporary)
-    irBlock.statements.add(irResult)
-    return irBlock
-}
-
 inline fun IrBuilderWithScope.irLetS(
     value: IrExpression,
     origin: IrStatementOrigin? = null,
@@ -185,13 +171,13 @@ fun IrBuilderWithScope.irEqeqeq(arg1: IrExpression, arg2: IrExpression) =
     context.eqeqeq(startOffset, endOffset, arg1, arg2)
 
 fun IrBuilderWithScope.irNull() =
-    IrConstImpl.constNull(startOffset, endOffset, context.irBuiltIns.nothingNType)
+    irNull(context.irBuiltIns.nothingNType)
+
+fun IrBuilderWithScope.irNull(irType: IrType) =
+    IrConstImpl.constNull(startOffset, endOffset, irType)
 
 fun IrBuilderWithScope.irEqualsNull(argument: IrExpression) =
-    primitiveOp2(
-        startOffset, endOffset, context.irBuiltIns.eqeqSymbol, context.irBuiltIns.booleanType, IrStatementOrigin.EQEQ,
-        argument, irNull()
-    )
+    irEquals(argument, irNull())
 
 fun IrBuilderWithScope.irEquals(arg1: IrExpression, arg2: IrExpression, origin: IrStatementOrigin = IrStatementOrigin.EQEQ) =
     primitiveOp2(

--- a/compiler/testData/codegen/box/javaInterop/notNullAssertions/errorMessage.kt
+++ b/compiler/testData/codegen/box/javaInterop/notNullAssertions/errorMessage.kt
@@ -1,0 +1,20 @@
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND: JVM_IR
+// FILE: test.kt
+fun f(x: String) = "Fail 1"
+
+fun box(): String {
+    return try {
+        f(J().s())
+    } catch (e: IllegalStateException) {
+        if (e.message == "J().s() must not be null")
+            "OK"
+        else
+            "Fail: ${e.message}"
+    }
+}
+
+// FILE: J.java
+public class J {
+    public final String s() { return null; }
+}

--- a/compiler/testData/codegen/box/javaInterop/notNullAssertions/staticCallErrorMessage.kt
+++ b/compiler/testData/codegen/box/javaInterop/notNullAssertions/staticCallErrorMessage.kt
@@ -1,0 +1,20 @@
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND: JVM_IR
+// FILE: test.kt
+fun f(x: String) = "Fail 1"
+
+fun box(): String {
+    return try {
+        f(J.s())
+    } catch (e: IllegalStateException) {
+        if (e.message == "J.s() must not be null")
+            "OK"
+        else
+            "Fail: ${e.message}"
+    }
+}
+
+// FILE: J.java
+public class J {
+    public static String s() { return null; }
+}

--- a/compiler/testData/codegen/boxAgainstJava/platformTypes/genericUnit.kt
+++ b/compiler/testData/codegen/boxAgainstJava/platformTypes/genericUnit.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 // FILE: Foo.java
 
 public class Foo {

--- a/compiler/testData/codegen/bytecodeText/inline/reifiedSafeAsWithMutable.kt
+++ b/compiler/testData/codegen/bytecodeText/inline/reifiedSafeAsWithMutable.kt
@@ -2,13 +2,13 @@
 // 'as?' should be generated as a single 'safeAs...' intrinsic call
 // without instanceof or 'is...'.
 
-inline fun <reified T> safeAs(x: Any) {
-    x as? T
+inline fun <reified T> safeAs(x: Any): T? {
+    return x as? T
 }
 
 fun test() {
     val x: Any = arrayListOf("abc", "def")
-    safeAs<MutableList<*>>(x)
+    safeAs<MutableList<*>>(x)?.clear()
 }
 
 // 0 INSTANCEOF java/util/List

--- a/compiler/testData/codegen/bytecodeText/reifiedSafeAsCheck.kt
+++ b/compiler/testData/codegen/bytecodeText/reifiedSafeAsCheck.kt
@@ -1,4 +1,4 @@
-inline fun <reified T> Any?.foo() = this as T
+inline fun <reified T> Any?.foo() = this as? T
 
 inline fun <reified Y> Any?.foo2() = foo<Y?>()
 
@@ -8,7 +8,7 @@ inline fun <reified X> Any?.foo4() = foo2<X?>()
 
 inline fun <reified A> Any?.foo5() = foo<A>()
 
-// 1 ICONST_1\s*LDC "T"\s*INVOKESTATIC kotlin/jvm/internal/Intrinsics.reifiedOperationMarker
+// 1 ICONST_2\s*LDC "T"\s*INVOKESTATIC kotlin/jvm/internal/Intrinsics.reifiedOperationMarker
 // 1 LDC "Y\?"
 // 1 LDC "Z\?"
 // 1 LDC "X\?"

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -14003,6 +14003,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
                 runTest("compiler/testData/codegen/box/javaInterop/notNullAssertions/destructuringAssignmentWithNullabilityAssertionOnExtensionReceiver_lv12.kt");
             }
 
+            @TestMetadata("errorMessage.kt")
+            public void testErrorMessage() throws Exception {
+                runTest("compiler/testData/codegen/box/javaInterop/notNullAssertions/errorMessage.kt");
+            }
+
             @TestMetadata("extensionReceiverParameter.kt")
             public void testExtensionReceiverParameter() throws Exception {
                 runTest("compiler/testData/codegen/box/javaInterop/notNullAssertions/extensionReceiverParameter.kt");
@@ -14076,6 +14081,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             @TestMetadata("paramAssertionMessage.kt")
             public void testParamAssertionMessage() throws Exception {
                 runTest("compiler/testData/codegen/box/javaInterop/notNullAssertions/paramAssertionMessage.kt");
+            }
+
+            @TestMetadata("staticCallErrorMessage.kt")
+            public void testStaticCallErrorMessage() throws Exception {
+                runTest("compiler/testData/codegen/box/javaInterop/notNullAssertions/staticCallErrorMessage.kt");
             }
 
             @TestMetadata("compiler/testData/codegen/box/javaInterop/notNullAssertions/enhancedNullability")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
@@ -354,6 +354,11 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
         runTest("compiler/testData/codegen/bytecodeText/reifiedIsCheckWithNullable.kt");
     }
 
+    @TestMetadata("reifiedSafeAsCheck.kt")
+    public void testReifiedSafeAsCheck() throws Exception {
+        runTest("compiler/testData/codegen/bytecodeText/reifiedSafeAsCheck.kt");
+    }
+
     @TestMetadata("safeAsWithMutable.kt")
     public void testSafeAsWithMutable() throws Exception {
         runTest("compiler/testData/codegen/bytecodeText/safeAsWithMutable.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -14003,6 +14003,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
                 runTest("compiler/testData/codegen/box/javaInterop/notNullAssertions/destructuringAssignmentWithNullabilityAssertionOnExtensionReceiver_lv12.kt");
             }
 
+            @TestMetadata("errorMessage.kt")
+            public void testErrorMessage() throws Exception {
+                runTest("compiler/testData/codegen/box/javaInterop/notNullAssertions/errorMessage.kt");
+            }
+
             @TestMetadata("extensionReceiverParameter.kt")
             public void testExtensionReceiverParameter() throws Exception {
                 runTest("compiler/testData/codegen/box/javaInterop/notNullAssertions/extensionReceiverParameter.kt");
@@ -14076,6 +14081,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             @TestMetadata("paramAssertionMessage.kt")
             public void testParamAssertionMessage() throws Exception {
                 runTest("compiler/testData/codegen/box/javaInterop/notNullAssertions/paramAssertionMessage.kt");
+            }
+
+            @TestMetadata("staticCallErrorMessage.kt")
+            public void testStaticCallErrorMessage() throws Exception {
+                runTest("compiler/testData/codegen/box/javaInterop/notNullAssertions/staticCallErrorMessage.kt");
             }
 
             @TestMetadata("compiler/testData/codegen/box/javaInterop/notNullAssertions/enhancedNullability")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -12888,6 +12888,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
                 runTest("compiler/testData/codegen/box/javaInterop/notNullAssertions/destructuringAssignmentWithNullabilityAssertionOnExtensionReceiver_lv12.kt");
             }
 
+            @TestMetadata("errorMessage.kt")
+            public void testErrorMessage() throws Exception {
+                runTest("compiler/testData/codegen/box/javaInterop/notNullAssertions/errorMessage.kt");
+            }
+
             @TestMetadata("extensionReceiverParameter.kt")
             public void testExtensionReceiverParameter() throws Exception {
                 runTest("compiler/testData/codegen/box/javaInterop/notNullAssertions/extensionReceiverParameter.kt");
@@ -12961,6 +12966,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             @TestMetadata("paramAssertionMessage.kt")
             public void testParamAssertionMessage() throws Exception {
                 runTest("compiler/testData/codegen/box/javaInterop/notNullAssertions/paramAssertionMessage.kt");
+            }
+
+            @TestMetadata("staticCallErrorMessage.kt")
+            public void testStaticCallErrorMessage() throws Exception {
+                runTest("compiler/testData/codegen/box/javaInterop/notNullAssertions/staticCallErrorMessage.kt");
             }
 
             @TestMetadata("compiler/testData/codegen/box/javaInterop/notNullAssertions/enhancedNullability")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
@@ -354,6 +354,11 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
         runTest("compiler/testData/codegen/bytecodeText/reifiedIsCheckWithNullable.kt");
     }
 
+    @TestMetadata("reifiedSafeAsCheck.kt")
+    public void testReifiedSafeAsCheck() throws Exception {
+        runTest("compiler/testData/codegen/bytecodeText/reifiedSafeAsCheck.kt");
+    }
+
     @TestMetadata("safeAsWithMutable.kt")
     public void testSafeAsWithMutable() throws Exception {
         runTest("compiler/testData/codegen/bytecodeText/safeAsWithMutable.kt");


### PR DESCRIPTION
This PR moves some of the logic from ExpressionCodegen/codegenUtils to the IR level, where it can potentially be shared with [JS_IR](https://github.com/JetBrains/kotlin/blob/72f7287ad2897fd97da3f24d256076b3ced3ca75/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/TypeOperatorLowering.kt) and [native](https://github.com/JetBrains/kotlin-native/blob/4da64036c188e3e29dff00ed4dac071fb4412d34/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TypeOperatorLowering.kt) in the future.

I've also added two tests for the error messages around not-null assertions. They are currently disabled on JVM_IR, since the IMPLICIT_NOTNULL casts are missing. With these casts, "testErrorMessage" succeeds while "testStaticCallErrorMessage" fails, since the source offsets for a static call don't include the class name.

Finally, I've changed "testReifiedSafeAsWithMutable" to use the result of the safe cast - otherwise the test checks for suboptimal code and fails when using the lowering.

The first 5 commits in this PR are from #2339.