### PR TITLE
KT-16476 Extend selection (Select Word) doesn't select just KDoc if cursor is just before the KDoc

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/editor/wordSelection/KotlinDeclarationSelectioner.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/editor/wordSelection/KotlinDeclarationSelectioner.kt
@@ -55,6 +55,10 @@ class KotlinDeclarationSelectioner : ExtendWordSelectionHandlerBase() {
             .siblings(forward = false, withItself = true)
             .first { it !is PsiComment && it !is PsiWhiteSpace }
 
+        if (firstComment != null && cursorOffset <= firstComment.startOffset) {
+            result.addRange(editorText, TextRange(firstComment.startOffset, firstComment.endOffset))
+        }
+
         if (firstComment != null || lastComment != null) {
             val startOffset = minOf(
                 firstComment?.startOffset ?: Int.MAX_VALUE,

--- a/idea/testData/wordSelection/DeclarationWithDocComment/0.kt
+++ b/idea/testData/wordSelection/DeclarationWithDocComment/0.kt
@@ -1,0 +1,13 @@
+class C {
+    fun foo() {
+    }
+
+<caret>    /**
+     * comment
+     */
+    fun bar() {
+    }
+
+    fun baz() {
+    }
+}

--- a/idea/testData/wordSelection/DeclarationWithDocComment/1.kt
+++ b/idea/testData/wordSelection/DeclarationWithDocComment/1.kt
@@ -1,0 +1,13 @@
+class C {
+    fun foo() {
+    }
+
+<selection><caret>    /**
+     * comment
+     */
+</selection>    fun bar() {
+    }
+
+    fun baz() {
+    }
+}

--- a/idea/testData/wordSelection/DeclarationWithDocComment/2.kt
+++ b/idea/testData/wordSelection/DeclarationWithDocComment/2.kt
@@ -1,0 +1,13 @@
+class C {
+    fun foo() {
+    }
+
+<selection><caret>    /**
+     * comment
+     */
+    fun bar() {
+    }
+</selection>
+    fun baz() {
+    }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/WordSelectionTest.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/WordSelectionTest.java
@@ -123,6 +123,7 @@ public class WordSelectionTest extends KotlinLightCodeInsightFixtureTestCase {
     public void testDeclarationWithComment2() { doTest(); }
     public void testDeclarationWithComment3() { doTest(); }
     public void testDeclarationWithComment4() { doTest(); }
+    public void testDeclarationWithDocComment() { doTest(); }
 
     public void testLeftBrace() { doTest(); }
     public void testRightBrace() { doTest(); }


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-16476