### PR TITLE
KT-31499 "Extend selection" selects escaped identifier name together with backticks

### DIFF
--- a/idea/resources/META-INF/plugin-common.xml
+++ b/idea/resources/META-INF/plugin-common.xml
@@ -614,6 +614,7 @@
     <extendWordSelectionHandler implementation="org.jetbrains.kotlin.idea.editor.wordSelection.KotlinBracketsSelectioner"/>
     <extendWordSelectionHandler implementation="org.jetbrains.kotlin.idea.editor.wordSelection.KotlinLabeledReturnSelectioner"/>
     <extendWordSelectionHandler implementation="org.jetbrains.kotlin.idea.editor.wordSelection.KotlinClassMemberSelectioner"/>
+    <extendWordSelectionHandler implementation="org.jetbrains.kotlin.idea.editor.wordSelection.KotlinEscapedIdentifierSelectioner"/>
     <basicWordSelectionFilter implementation="org.jetbrains.kotlin.idea.editor.wordSelection.KotlinWordSelectionFilter"/>
 
     <typedHandler implementation="org.jetbrains.kotlin.idea.editor.KotlinTypedHandler"/>

--- a/idea/src/org/jetbrains/kotlin/idea/editor/wordSelection/KotlinEscapedIdentifierSelectioner.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/editor/wordSelection/KotlinEscapedIdentifierSelectioner.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.idea.editor.wordSelection
+
+import com.intellij.codeInsight.editorActions.ExtendWordSelectionHandlerBase
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.psiUtil.endOffset
+import org.jetbrains.kotlin.psi.psiUtil.startOffset
+
+class KotlinEscapedIdentifierSelectioner : ExtendWordSelectionHandlerBase() {
+    override fun canSelect(e: PsiElement) = e.node.elementType == KtTokens.IDENTIFIER
+
+    override fun select(e: PsiElement, editorText: CharSequence, cursorOffset: Int, editor: Editor): List<TextRange>? {
+        val text = e.text
+        if (!text.startsWith('`') || !text.endsWith('`')) return null
+        val start = e.startOffset + 1
+        val end = e.endOffset - 1
+        if (start >= end) return null
+        return listOf(TextRange(start, end))
+    }
+}

--- a/idea/testData/wordSelection/EscapedIdentifier/0.kt
+++ b/idea/testData/wordSelection/EscapedIdentifier/0.kt
@@ -1,0 +1,2 @@
+fun `my <caret>function`() {
+}

--- a/idea/testData/wordSelection/EscapedIdentifier/1.kt
+++ b/idea/testData/wordSelection/EscapedIdentifier/1.kt
@@ -1,0 +1,2 @@
+fun `my <selection><caret>function</selection>`() {
+}

--- a/idea/testData/wordSelection/EscapedIdentifier/2.kt
+++ b/idea/testData/wordSelection/EscapedIdentifier/2.kt
@@ -1,0 +1,2 @@
+fun `<selection>my <caret>function</selection>`() {
+}

--- a/idea/testData/wordSelection/EscapedIdentifier/3.kt
+++ b/idea/testData/wordSelection/EscapedIdentifier/3.kt
@@ -1,0 +1,2 @@
+fun <selection>`my <caret>function`</selection>() {
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/WordSelectionTest.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/WordSelectionTest.java
@@ -135,6 +135,8 @@ public class WordSelectionTest extends KotlinLightCodeInsightFixtureTestCase {
     public void testClassMember4() { doTest(); }
     public void testClassMember5() { doTest(); }
 
+    public void testEscapedIdentifier() { doTest(); }
+
     private void doTest() {
         String dirName = getTestName(false);
 


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-31499