### PR TITLE
KAPT: do not discover incremental APs only if cache is not set

### DIFF
--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/ProcessorLoader.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/ProcessorLoader.kt
@@ -55,7 +55,7 @@ open class ProcessorLoader(private val options: KaptOptions, private val logger:
     }
 
     private fun wrapInIncrementalProcessor(processors: List<Processor>, classpath: Iterable<File>): List<IncrementalProcessor> {
-        if (!options[KaptFlag.INCREMENTAL_APT]) {
+        if (options.incrementalCache == null) {
             return processors.map { IncrementalProcessor(it, DeclaredProcType.NON_INCREMENTAL) }
         }
 


### PR DESCRIPTION
KaptFlag.INCREMENTAL_APT is used to indicate that KAPT run
should try to be incremental because changes to input files and
classpath have been detected. However, first run of the Gradle
task will set this flag to false, which means that all APs will be
detected as non-incremental in the first run. Further on, this means
that the dependency caches will be invalid, and all subsequent runs
will be non-incremental as well.

This commit uses existence of dependency cache to determine if incremental
APs should be discovered. The regression was introduced in
72fdc648ffcb598656c7c318a5fa6726e74d64bd.

Test: ./gradlew :kotlin-gradle-plugin-integration-tests:testAdvanceGradleVersion --tests *KaptIncrementalWith*\
 && ./gradlew :kotlin-gradle-plugin-integration-tests:test --tests *KaptIncrementalWith*