### PR TITLE
JVM_IR: sidestep defective getMethodAsmFlags when inlining lambdas

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/LambdaInfo.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/LambdaInfo.kt
@@ -189,22 +189,8 @@ internal fun Type.boxReceiverForBoundReference(kotlinType: KotlinType, typeMappe
     AsmUtil.boxType(this, kotlinType, typeMapper)
 
 abstract class ExpressionLambda(protected val typeMapper: KotlinTypeMapper, isCrossInline: Boolean) : LambdaInfo(isCrossInline) {
-
     override fun generateLambdaBody(sourceCompiler: SourceCompilerForInline, reifiedTypeInliner: ReifiedTypeInliner) {
-        val jvmMethodSignature = typeMapper.mapSignatureSkipGeneric(invokeMethodDescriptor)
-        val asmMethod = jvmMethodSignature.asmMethod
-        val methodNode = MethodNode(
-            Opcodes.API_VERSION, AsmUtil.getMethodAsmFlags(invokeMethodDescriptor, OwnerKind.IMPLEMENTATION, sourceCompiler.state),
-            asmMethod.name, asmMethod.descriptor, null, null
-        )
-
-        node = wrapWithMaxLocalCalc(methodNode).let { adapter ->
-            val smap = sourceCompiler.generateLambdaBody(
-                adapter, jvmMethodSignature, this
-            )
-            adapter.visitMaxs(-1, -1)
-            SMAPAndMethodNode(methodNode, smap)
-        }
+        node = sourceCompiler.generateLambdaBody(this)
     }
 }
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -174,7 +174,6 @@ class ExpressionCodegen(
         val endLabel = markNewLabel()
         writeLocalVariablesInTable(info, endLabel)
         writeParameterInLocalVariableTable(startLabel, endLabel)
-        mv.visitEnd()
     }
 
     private fun generateNonNullAssertions() {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/FunctionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/FunctionCodegen.kt
@@ -58,11 +58,12 @@ open class FunctionCodegen(
 
         if (!state.classBuilderMode.generateBodies || flags.and(Opcodes.ACC_ABSTRACT) != 0 || irFunction.isExternal) {
             generateAnnotationDefaultValueIfNeeded(methodVisitor)
-            methodVisitor.visitEnd()
         } else {
             val frameMap = createFrameMapWithReceivers(signature)
             ExpressionCodegen(irFunction, frameMap, InstructionAdapter(methodVisitor), classCodegen, isInlineLambda).generate()
+            methodVisitor.visitMaxs(-1, -1)
         }
+        methodVisitor.visitEnd()
 
         return signature
     }

--- a/compiler/testData/codegen/boxInline/simple/inlineCallInInlineLambda.kt
+++ b/compiler/testData/codegen/boxInline/simple/inlineCallInInlineLambda.kt
@@ -1,0 +1,16 @@
+// FILE: 1.kt
+
+package test
+
+inline fun f(g: (Int) -> Int) = g(2)
+
+inline fun h() = 1
+
+// FILE: 2.kt
+
+import test.*
+
+fun box(): String {
+    val result = f { it + h() }
+    return if (result == 3) "OK" else "fail: $result"
+}

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxInlineCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxInlineCodegenTestGenerated.java
@@ -2914,6 +2914,11 @@ public class BlackBoxInlineCodegenTestGenerated extends AbstractBlackBoxInlineCo
             runTest("compiler/testData/codegen/boxInline/simple/funImportedFromObject.kt");
         }
 
+        @TestMetadata("inlineCallInInlineLambda.kt")
+        public void testInlineCallInInlineLambda() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/simple/inlineCallInInlineLambda.kt");
+        }
+
         @TestMetadata("kt17431.kt")
         public void testKt17431() throws Exception {
             runTest("compiler/testData/codegen/boxInline/simple/kt17431.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/CompileKotlinAgainstInlineKotlinTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/CompileKotlinAgainstInlineKotlinTestGenerated.java
@@ -2914,6 +2914,11 @@ public class CompileKotlinAgainstInlineKotlinTestGenerated extends AbstractCompi
             runTest("compiler/testData/codegen/boxInline/simple/funImportedFromObject.kt");
         }
 
+        @TestMetadata("inlineCallInInlineLambda.kt")
+        public void testInlineCallInInlineLambda() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/simple/inlineCallInInlineLambda.kt");
+        }
+
         @TestMetadata("kt17431.kt")
         public void testKt17431() throws Exception {
             runTest("compiler/testData/codegen/boxInline/simple/kt17431.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxInlineCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxInlineCodegenTestGenerated.java
@@ -2914,6 +2914,11 @@ public class IrBlackBoxInlineCodegenTestGenerated extends AbstractIrBlackBoxInli
             runTest("compiler/testData/codegen/boxInline/simple/funImportedFromObject.kt");
         }
 
+        @TestMetadata("inlineCallInInlineLambda.kt")
+        public void testInlineCallInInlineLambda() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/simple/inlineCallInInlineLambda.kt");
+        }
+
         @TestMetadata("kt17431.kt")
         public void testKt17431() throws Exception {
             runTest("compiler/testData/codegen/boxInline/simple/kt17431.kt");


### PR DESCRIPTION
It uses isStaticMethod to determine whether to set ACC_STATIC, which is not correct (see PR #2341). This results in using incorrectly typed opcodes (as all arguments are shifted by 1) when modifying the inlined lambda's bytecode. For example, in the test added by this commit, these opcodes are inserted to spill the stack into locals before calling another inline function. Without the patch, `ILOAD 0` for the lambda's `it` is considered to refer to a nonexistent `this`, which is spilled with an `ASTORE` instead of `ISTORE`.

Because getMethodAsmFlags is used by the non-IR backend (see PR #2341 again for why changing stuff might not be a good idea), the proposed solution is to ditch it completely and override generateLambdaBody in IrExpressionLambdaImpl to use FunctionCodegen's IR-based flag computation logic.