### PR TITLE
JVM_IR: Restore lost top-level declaration check in annotation gen.

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ClassCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ClassCodegen.kt
@@ -296,7 +296,7 @@ open class ClassCodegen protected constructor(
     // See FileBasedKotlinClass.convertAnnotationVisitor
     override fun addInnerClassInfoFromAnnotation(innerClass: IrClass) {
         var current: IrDeclaration? = innerClass
-        while (current != null) {
+        while (current != null && !current.isTopLevelDeclaration) {
             if (current is IrClass) {
                 innerClasses.add(current)
             }


### PR DESCRIPTION
When moving away from descriptors, this top-level declaration check
was lost. That leads to many useless annotation elements in
inner classes attributes for annotations that are not inner classes.