### PR TITLE
KT-31127: add only generated Java sources to JavaCompile inputs

### DIFF
--- a/libraries/examples/annotation-processor-example/src/main/kotlin/example/KotlinFilerGeneratingProcessor.kt
+++ b/libraries/examples/annotation-processor-example/src/main/kotlin/example/KotlinFilerGeneratingProcessor.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package example
+
+import javax.annotation.processing.AbstractProcessor
+import javax.annotation.processing.RoundEnvironment
+import javax.lang.model.SourceVersion
+import javax.lang.model.element.TypeElement
+import javax.tools.StandardLocation
+
+/** Annotation processor that users [javax.annotation.processing.Filer] APIs to generate Kotlin sources. */
+class KotlinFilerGeneratingProcessor : AbstractProcessor() {
+
+    override fun process(annotations: MutableSet<out TypeElement>?, roundEnv: RoundEnvironment): Boolean {
+        val annotatedWith = roundEnv.getElementsAnnotatedWith(KotlinFilerGenerated::class.java)
+
+        for (element in annotatedWith) {
+            val packageName = processingEnv.elementUtils.getPackageOf(element).qualifiedName.toString()
+            val simpleName = element.simpleName.toString()
+
+            processingEnv.filer.createResource(StandardLocation.SOURCE_OUTPUT, packageName, "${simpleName}Generated.kt", element)
+                .openWriter().use {
+                    it.write(
+                        """
+                    package $packageName
+
+                    class ${simpleName}Generated
+                """.trimIndent()
+                    )
+                }
+        }
+        return true
+    }
+
+    override fun getSupportedSourceVersion() = SourceVersion.RELEASE_6
+
+    override fun getSupportedAnnotationTypes(): Set<String> {
+        return setOf(KotlinFilerGenerated::class.java.canonicalName)
+    }
+}

--- a/libraries/examples/annotation-processor-example/src/main/kotlin/example/annotations.kt
+++ b/libraries/examples/annotation-processor-example/src/main/kotlin/example/annotations.kt
@@ -18,3 +18,5 @@ annotation class ExampleBinaryAnnotation
 annotation class ExampleRuntimeAnnotation
 
 annotation class GenError
+
+annotation class KotlinFilerGenerated

--- a/libraries/examples/annotation-processor-example/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/libraries/examples/annotation-processor-example/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,1 +1,2 @@
 example.ExampleAnnotationProcessor
+example.KotlinFilerGeneratingProcessor

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BaseGradleIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BaseGradleIT.kt
@@ -517,6 +517,12 @@ abstract class BaseGradleIT {
         assertTasksNotRealized(*tasks)
     }
 
+    fun CompiledProject.assertTasksSkipped(vararg tasks: String) {
+        for (task in tasks) {
+            assertContains("Skipping task '$task'")
+        }
+    }
+
     fun CompiledProject.getOutputForTask(taskName: String): String {
         val taskOutputRegex = ("(?:\\[LIFECYCLE] \\[class org\\.gradle(?:\\.internal\\.buildevents)?\\.TaskExecutionLogger] :$taskName|" +
                 "\\[org\\.gradle\\.execution\\.plan\\.DefaultPlanExecutor\\] :$taskName.*?started)" +

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/Kapt3KotlinGradleSubplugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/Kapt3KotlinGradleSubplugin.kt
@@ -266,8 +266,6 @@ class Kapt3KotlinGradleSubplugin : KotlinGradleSubplugin<KotlinCompile> {
         pluginOptions += SubpluginOption("aptMode", aptMode)
         disableAnnotationProcessingInJavaTask()
 
-        javaCompile?.source(generatedFilesDir)
-
         pluginOptions += FilesSubpluginOption("sources", listOf(generatedFilesDir))
         pluginOptions += FilesSubpluginOption("classes", listOf(getKaptGeneratedClassesDir(project, sourceSetName)))
 
@@ -527,7 +525,9 @@ private val artifactType = Attribute.of("artifactType", String::class.java)
 
 
 internal fun registerGeneratedJavaSource(kaptTask: KaptTask, javaTask: AbstractCompile) {
-    javaTask.source(kaptTask.destinationDir)
+    val generatedJavaSources = javaTask.project.fileTree(kaptTask.destinationDir)
+    generatedJavaSources.include("**/*.java")
+    javaTask.source(generatedJavaSources)
 }
 
 internal fun Configuration.getNamedDependencies(): List<Dependency> = allDependencies.filter { it.group != null && it.name != null }


### PR DESCRIPTION
This commit changes how generated sources are added to the Gradle JavaCompile
task. Previously, directory was added to sources which caused issues with
annotation processors that only generate Kotlin sources. I.e. JavaCompile task
was executed but no java sources existed.

Now, only generated Java sources are added to the JavaCompile task. This
means that if only Kotlin sources are generated JavaCompile task will be
skipped.

Fixes: https://youtrack.jetbrains.com/issue/KT-31127
Test: Kapt3IT.testKotlinProcessorUsingFiler