### PR TITLE
JVM_IR: Allow delegated companion objects.

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ClassCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ClassCodegen.kt
@@ -227,7 +227,7 @@ open class ClassCodegen protected constructor(
 
         val descriptor = field.metadata?.descriptor
         if (descriptor != null) {
-            val codegen = if (JvmAbi.isPropertyWithBackingFieldInOuterClass(descriptor)) {
+            val codegen = if (field.origin != IrDeclarationOrigin.DELEGATE && JvmAbi.isPropertyWithBackingFieldInOuterClass(descriptor)) {
                 companionObjectCodegen ?: error("Class with a property moved from the companion must have a companion:\n${irClass.dump()}")
             } else this
             codegen.visitor.serializationBindings.put(JvmSerializationBindings.FIELD_FOR_PROPERTY, descriptor, fieldType to fieldName)

--- a/compiler/testData/loadJava/compiledKotlin/classObject/Delegation.kt
+++ b/compiler/testData/loadJava/compiledKotlin/classObject/Delegation.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 package test
 
 interface T {


### PR DESCRIPTION
This currently leads to a compilation error due to metadata
generation.