### PR TITLE
KT-31645 Fix yarn downloading on Windows

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/yarn/YarnSetupTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/yarn/YarnSetupTask.kt
@@ -50,7 +50,7 @@ open class YarnSetupTask : DefaultTask() {
     }
 
     private fun extract(archive: File, destination: File) {
-        val dirInTar = archive.name.removeSuffix(".tar.gz") + File.separator
+        val dirInTar = archive.name.removeSuffix(".tar.gz")
         project.copy {
             it.from(project.tarTree(archive))
             it.into(destination)


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-31645

According to docs (https://docs.gradle.org/current/javadoc/org/gradle/api/file/FileCopyDetails.html#getPath--)  FileCopyDetails uses '/' as separator regardless of platform, on Windows standard separator is '\'
Addditionally, it returns the path relative to the root of destination
So separator is unnecessary to remove