### PR TITLE
KT-30627 "Use property access syntax" produces red code if setter argument is a lambda with implicit SAM conversion

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/intentions/UsePropertyAccessSyntaxIntention.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/UsePropertyAccessSyntaxIntention.kt
@@ -182,7 +182,8 @@ class UsePropertyAccessSyntaxIntention :
 
         val isSetUsage = callExpression.valueArguments.size == 1
 
-        if (isSetUsage && callExpression.valueArguments.first() is KtLambdaArgument) {
+        val valueArgumentExpression = callExpression.valueArguments.firstOrNull()?.getArgumentExpression()
+        if (isSetUsage && (valueArgumentExpression is KtLambdaExpression || valueArgumentExpression is KtNamedFunction)) {
             return null
         }
 

--- a/idea/src/org/jetbrains/kotlin/idea/intentions/UsePropertyAccessSyntaxIntention.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/UsePropertyAccessSyntaxIntention.kt
@@ -182,8 +182,10 @@ class UsePropertyAccessSyntaxIntention :
 
         val isSetUsage = callExpression.valueArguments.size == 1
 
-        val valueArgumentExpression = callExpression.valueArguments.firstOrNull()?.getArgumentExpression()
-        if (isSetUsage && (valueArgumentExpression is KtLambdaExpression || valueArgumentExpression is KtNamedFunction)) {
+        val valueArgumentExpression = callExpression.valueArguments.firstOrNull()?.getArgumentExpression()?.takeUnless {
+            it is KtLambdaExpression || it is KtNamedFunction || it is KtCallableReferenceExpression
+        }
+        if (isSetUsage && valueArgumentExpression == null) {
             return null
         }
 

--- a/idea/src/org/jetbrains/kotlin/idea/intentions/UsePropertyAccessSyntaxIntention.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/UsePropertyAccessSyntaxIntention.kt
@@ -182,6 +182,10 @@ class UsePropertyAccessSyntaxIntention :
 
         val isSetUsage = callExpression.valueArguments.size == 1
 
+        if (isSetUsage && callExpression.valueArguments.first() is KtLambdaArgument) {
+            return null
+        }
+
         if (isSetUsage && qualifiedExpression.isUsedAsExpression(bindingContext)) {
             // call to the setter used as expression can be converted in the only case when it's used as body expression for some declaration and its type is Unit
             val parent = qualifiedExpression.parent

--- a/idea/testData/intentions/usePropertyAccessSyntax/setAnonymouseFunctionArgument.1.java
+++ b/idea/testData/intentions/usePropertyAccessSyntax/setAnonymouseFunctionArgument.1.java
@@ -1,0 +1,4 @@
+public class J {
+    public Runnable getR() { return null; }
+    public void setR(Runnable r) {}
+}

--- a/idea/testData/intentions/usePropertyAccessSyntax/setAnonymouseFunctionArgument.kt
+++ b/idea/testData/intentions/usePropertyAccessSyntax/setAnonymouseFunctionArgument.kt
@@ -1,0 +1,7 @@
+// IS_APPLICABLE: false
+// WITH_RUNTIME
+fun test() {
+    J().<caret>setR(fun() { 
+        println("Hello, world!")
+    })
+}

--- a/idea/testData/intentions/usePropertyAccessSyntax/setFunctionReferenceArgument.1.java
+++ b/idea/testData/intentions/usePropertyAccessSyntax/setFunctionReferenceArgument.1.java
@@ -1,0 +1,4 @@
+public class J {
+    public Runnable getR() { return null; }
+    public void setR(Runnable r) {}
+}

--- a/idea/testData/intentions/usePropertyAccessSyntax/setFunctionReferenceArgument.kt
+++ b/idea/testData/intentions/usePropertyAccessSyntax/setFunctionReferenceArgument.kt
@@ -1,0 +1,5 @@
+// IS_APPLICABLE: false
+// WITH_RUNTIME
+fun test() {
+    J().<caret>setR(::test)
+}

--- a/idea/testData/intentions/usePropertyAccessSyntax/setLambdaArgument.1.java
+++ b/idea/testData/intentions/usePropertyAccessSyntax/setLambdaArgument.1.java
@@ -1,0 +1,4 @@
+public class J {
+    public Runnable getR() { return null; }
+    public void setR(Runnable r) {}
+}

--- a/idea/testData/intentions/usePropertyAccessSyntax/setLambdaArgument.kt
+++ b/idea/testData/intentions/usePropertyAccessSyntax/setLambdaArgument.kt
@@ -1,0 +1,5 @@
+// IS_APPLICABLE: false
+// WITH_RUNTIME
+fun test() {
+    J().<caret>setR { println("Hello, world!") }
+}

--- a/idea/testData/intentions/usePropertyAccessSyntax/setLambdaArgument2.1.java
+++ b/idea/testData/intentions/usePropertyAccessSyntax/setLambdaArgument2.1.java
@@ -1,0 +1,4 @@
+public class J {
+    public Runnable getR() { return null; }
+    public void setR(Runnable r) {}
+}

--- a/idea/testData/intentions/usePropertyAccessSyntax/setLambdaArgument2.kt
+++ b/idea/testData/intentions/usePropertyAccessSyntax/setLambdaArgument2.kt
@@ -1,0 +1,5 @@
+// IS_APPLICABLE: false
+// WITH_RUNTIME
+fun test() {
+    J().<caret>setR({ println("Hello, world!") })
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -16643,6 +16643,11 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
             runTest("idea/testData/intentions/usePropertyAccessSyntax/setImplicitReceiver.kt");
         }
 
+        @TestMetadata("setLambdaArgument.kt")
+        public void testSetLambdaArgument() throws Exception {
+            runTest("idea/testData/intentions/usePropertyAccessSyntax/setLambdaArgument.kt");
+        }
+
         @TestMetadata("setReservedWord1.kt")
         public void testSetReservedWord1() throws Exception {
             runTest("idea/testData/intentions/usePropertyAccessSyntax/setReservedWord1.kt");

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -16643,6 +16643,11 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
             runTest("idea/testData/intentions/usePropertyAccessSyntax/setAsExpressionBodyUnqualified.kt");
         }
 
+        @TestMetadata("setFunctionReferenceArgument.kt")
+        public void testSetFunctionReferenceArgument() throws Exception {
+            runTest("idea/testData/intentions/usePropertyAccessSyntax/setFunctionReferenceArgument.kt");
+        }
+
         @TestMetadata("setImplicitReceiver.kt")
         public void testSetImplicitReceiver() throws Exception {
             runTest("idea/testData/intentions/usePropertyAccessSyntax/setImplicitReceiver.kt");

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -16623,6 +16623,11 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
             runTest("idea/testData/intentions/usePropertyAccessSyntax/set.kt");
         }
 
+        @TestMetadata("setAnonymouseFunctionArgument.kt")
+        public void testSetAnonymouseFunctionArgument() throws Exception {
+            runTest("idea/testData/intentions/usePropertyAccessSyntax/setAnonymouseFunctionArgument.kt");
+        }
+
         @TestMetadata("setAsExpressionBody.kt")
         public void testSetAsExpressionBody() throws Exception {
             runTest("idea/testData/intentions/usePropertyAccessSyntax/setAsExpressionBody.kt");
@@ -16646,6 +16651,11 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
         @TestMetadata("setLambdaArgument.kt")
         public void testSetLambdaArgument() throws Exception {
             runTest("idea/testData/intentions/usePropertyAccessSyntax/setLambdaArgument.kt");
+        }
+
+        @TestMetadata("setLambdaArgument2.kt")
+        public void testSetLambdaArgument2() throws Exception {
+            runTest("idea/testData/intentions/usePropertyAccessSyntax/setLambdaArgument2.kt");
         }
 
         @TestMetadata("setReservedWord1.kt")


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-30627