### PR TITLE
Make `KotlinCompile` task compatible with experimental instant execution mode

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/InstantExecutionIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/InstantExecutionIT.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle
+
+import org.jetbrains.kotlin.gradle.util.findFileByName
+import org.junit.Test
+import java.io.File
+import java.net.URI
+import kotlin.test.fail
+
+class InstantExecutionIT : BaseGradleIT() {
+
+    // A recent enough Gradle 6.0 nightly
+    private val minimumGradleVersion = GradleVersionRequired.AtLeast("6.0-20190823180744+0000")
+
+    @Test
+    fun testCompileKotlin() {
+        kotlinProject().run {
+            instantExecutionOf("compileKotlin") {
+                assertSuccessful()
+                assertTasksExecuted(":compileKotlin")
+            }
+
+            instantExecutionReportFile()?.let { htmlReportFile ->
+                // for debugging, copy report so it's available after the test is finished
+                val htmlReportFile = copyReportToTempDir(htmlReportFile)
+                fail(
+                    "Instant execution problems were found, check ${htmlReportFile.asClickableFileUrl()} for details."
+                )
+            }
+
+            instantExecutionOf("compileKotlin") {
+                assertSuccessful()
+                assertTasksUpToDate(":compileKotlin")
+            }
+        }
+    }
+
+    private fun kotlinProject() = Project(
+        "kotlinProject",
+        gradleVersionRequirement = minimumGradleVersion
+    )
+
+    private fun Project.instantExecutionOf(vararg tasks: String, check: CompiledProject.() -> Unit) =
+        build("-Dorg.gradle.unsafe.instant-execution", *tasks, check = check)
+
+    /**
+     * Copies all files from the directory containing the given [htmlReportFile] to a
+     * fresh temp dir and returns a reference to the copied [htmlReportFile] in the new
+     * directory.
+     */
+    private fun copyReportToTempDir(htmlReportFile: File): File =
+        createTempDir().let { tempDir ->
+            htmlReportFile.parentFile.copyRecursively(tempDir)
+            tempDir.resolve(htmlReportFile.name)
+        }
+
+    /**
+     * The instant execution report file, if exists, indicates problems were
+     * found while caching the task graph.
+     */
+    private fun Project.instantExecutionReportFile() = projectDir
+        .resolve(".instant-execution-state")
+        .findFileByName("instant-execution-report.html")
+
+    private fun File.asClickableFileUrl(): String =
+        URI("file", "", toURI().path, null, null).toString()
+}

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt
@@ -427,7 +427,8 @@ internal abstract class AbstractKotlinPlugin(
             }
             val inspectTask = registerTask(project, "inspectClassesForKotlinIC", InspectClassesForMultiModuleIC::class.java) {
                 it.sourceSetName = SourceSet.MAIN_SOURCE_SET_NAME
-                it.jarTask = jarTask
+                it.archivePath.set(project.provider { jarTask.archivePath.canonicalPath })
+                it.archiveName.set(project.provider { jarTask.archiveName })
                 it.dependsOn(classesTask)
             }
             jarTask.dependsOn(inspectTask.getTaskOrProvider())

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/InspectClassesForMultiModuleIC.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/InspectClassesForMultiModuleIC.kt
@@ -9,16 +9,17 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.file.FileCollection
 import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.tasks.*
-import org.gradle.api.tasks.bundling.AbstractArchiveTask
-import org.gradle.jvm.tasks.Jar
 import org.jetbrains.kotlin.gradle.dsl.KotlinSingleJavaTargetExtension
 import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
 import org.jetbrains.kotlin.gradle.utils.archivePathCompatible
 import java.io.File
 
 internal open class InspectClassesForMultiModuleIC : DefaultTask() {
-    @get:Internal
-    lateinit var jarTask: Jar
+    @get:Input
+    internal val archivePath = project.objects.property(String::class.java)
+
+    @get:Input
+    internal val archiveName = project.objects.property(String::class.java)
 
     @get:Input
     lateinit var sourceSetName: String
@@ -38,10 +39,6 @@ internal open class InspectClassesForMultiModuleIC : DefaultTask() {
             val fileTrees = sourceSet.output.classesDirs.map { project.fileTree(it).include("**/*.class") }
             return project.files(fileTrees)
         }
-
-    @get:Input
-    internal val archivePath: String
-        get() = jarTask.archivePathCompatible.canonicalPath
 
     @TaskAction
     fun run() {

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/Tasks.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/Tasks.kt
@@ -88,8 +88,8 @@ abstract class AbstractKotlinCompileTool<T : CommonToolArguments>
 
     @get:Classpath
     @get:InputFiles
-    internal val computedCompilerClasspath: List<File>
-        get() = compilerClasspath?.takeIf { it.isNotEmpty() }
+    internal val computedCompilerClasspath: List<File> by lazy {
+        compilerClasspath?.takeIf { it.isNotEmpty() }
             ?: compilerJarFile?.let {
                 // a hack to remove compiler jar from the cp, will be dropped when compilerJarFile will be removed
                 listOf(it) + findKotlinCompilerClasspath(project).filter { !it.name.startsWith("kotlin-compiler") }
@@ -108,6 +108,7 @@ abstract class AbstractKotlinCompileTool<T : CommonToolArguments>
                 findKotlinCompilerClasspath(project)
             }
             ?: throw IllegalStateException("Could not find Kotlin Compiler classpath")
+    }
 
 
     protected abstract fun findKotlinCompilerClasspath(project: Project): List<File>
@@ -155,8 +156,9 @@ abstract class AbstractKotlinCompile<T : CommonCompilerArguments>() : AbstractKo
 
     @get:Classpath
     @get:InputFiles
-    val pluginClasspath: FileCollection
-        get() = project.configurations.getByName(PLUGIN_CLASSPATH_CONFIGURATION_NAME)
+    val pluginClasspath: FileCollection by lazy {
+        project.configurations.getByName(PLUGIN_CLASSPATH_CONFIGURATION_NAME)
+    }
 
     @get:Internal
     internal val pluginOptions = CompilerPluginOptions()
@@ -170,11 +172,13 @@ abstract class AbstractKotlinCompile<T : CommonCompilerArguments>() : AbstractKo
         get() = (classpath + additionalClasspath)
             .filterTo(LinkedHashSet(), File::exists)
 
+    @Transient
     private val sourceFilesExtensionsSources: MutableList<Iterable<String>> = mutableListOf()
 
     @get:Input
-    val sourceFilesExtensions: List<String>
-        get() = DEFAULT_KOTLIN_SOURCE_FILES_EXTENSIONS + sourceFilesExtensionsSources.flatten()
+    val sourceFilesExtensions: List<String> by lazy {
+        DEFAULT_KOTLIN_SOURCE_FILES_EXTENSIONS + sourceFilesExtensionsSources.flatten()
+    }
 
     internal fun sourceFilesExtensions(extensions: Iterable<String>) {
         sourceFilesExtensionsSources.add(extensions)
@@ -205,10 +209,11 @@ abstract class AbstractKotlinCompile<T : CommonCompilerArguments>() : AbstractKo
     internal val coroutinesStr: String
         get() = coroutines.name
 
-    private val coroutines: Coroutines
-        get() = kotlinExt.experimental.coroutines
+    private val coroutines: Coroutines by lazy {
+        kotlinExt.experimental.coroutines
             ?: coroutinesFromGradleProperties
             ?: Coroutines.DEFAULT
+    }
 
     @get:Internal
     internal var friendTaskName: String? = null


### PR DESCRIPTION

We are currently experimenting with a new build execution strategy that improves repeated build execution performance by caching configured task graphs. We call it [instant execution](https://gradle.github.io/instant-execution/).

The new strategy imposes a few limitations on how tasks manage state and what sort of state `@TaskAction` methods have access to:
- tasks must be isolated from each other, i.e., no referencing a task instance from another during execution
- required `Project` state (including `Configuration` values) must be explicitly captured in fields otherwise it won't be available for instant execution 

This PR includes an integration test and some examples of the sort of changes that would be necessary to make vanilla `KotlinCompile` tasks compatible with instant execution.  

The biggest challenge seems to be converting the computations performed by `org.jetbrains.kotlin.compilerRunner.GradleCompilerRunner.Companion#buildModulesInfo` and the resulting state to be represented via [Gradle lazy configuration](https://docs.gradle.org/current/userguide/lazy_configuration.html). 