### PR TITLE
add links to Scope Functions doc from with, run, let, apply, and also…

### DIFF
--- a/libraries/stdlib/src/kotlin/util/Standard.kt
+++ b/libraries/stdlib/src/kotlin/util/Standard.kt
@@ -33,6 +33,8 @@ public inline fun TODO(reason: String): Nothing = throw NotImplementedError("An 
 
 /**
  * Calls the specified function [block] and returns its result.
+ *
+ * For detailed usage information see the documentation for [scope functions](https://kotlinlang.org/docs/reference/scope-functions.html#run).
  */
 @kotlin.internal.InlineOnly
 public inline fun <R> run(block: () -> R): R {
@@ -44,6 +46,8 @@ public inline fun <R> run(block: () -> R): R {
 
 /**
  * Calls the specified function [block] with `this` value as its receiver and returns its result.
+ *
+ * For detailed usage information see the documentation for [scope functions](https://kotlinlang.org/docs/reference/scope-functions.html#run).
  */
 @kotlin.internal.InlineOnly
 public inline fun <T, R> T.run(block: T.() -> R): R {
@@ -55,6 +59,8 @@ public inline fun <T, R> T.run(block: T.() -> R): R {
 
 /**
  * Calls the specified function [block] with the given [receiver] as its receiver and returns its result.
+ *
+ * For detailed usage information see the documentation for [scope functions](https://kotlinlang.org/docs/reference/scope-functions.html#with).
  */
 @kotlin.internal.InlineOnly
 public inline fun <T, R> with(receiver: T, block: T.() -> R): R {
@@ -66,6 +72,8 @@ public inline fun <T, R> with(receiver: T, block: T.() -> R): R {
 
 /**
  * Calls the specified function [block] with `this` value as its receiver and returns `this` value.
+ *
+ * For detailed usage information see the documentation for [scope functions](https://kotlinlang.org/docs/reference/scope-functions.html#apply).
  */
 @kotlin.internal.InlineOnly
 public inline fun <T> T.apply(block: T.() -> Unit): T {
@@ -78,6 +86,8 @@ public inline fun <T> T.apply(block: T.() -> Unit): T {
 
 /**
  * Calls the specified function [block] with `this` value as its argument and returns `this` value.
+ *
+ * For detailed usage information see the documentation for [scope functions](https://kotlinlang.org/docs/reference/scope-functions.html#also).
  */
 @kotlin.internal.InlineOnly
 @SinceKotlin("1.1")
@@ -91,6 +101,8 @@ public inline fun <T> T.also(block: (T) -> Unit): T {
 
 /**
  * Calls the specified function [block] with `this` value as its argument and returns its result.
+ *
+ * For detailed usage information see the documentation for [scope functions](https://kotlinlang.org/docs/reference/scope-functions.html#let).
  */
 @kotlin.internal.InlineOnly
 public inline fun <T, R> T.let(block: (T) -> R): R {


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-20357

Updates the doc block for the Any class's scope extension functions so they link to the documentation here: https://kotlinlang.org/docs/reference/scope-functions.html