### PR TITLE
KT-31127: register only generated Java sources to AGP

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidLibraryKotlinProject/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidLibraryKotlinProject/build.gradle
@@ -1,0 +1,29 @@
+buildscript {
+    repositories {
+        mavenLocal()
+        maven { url 'https://maven.google.com' }
+        jcenter()
+    }
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath('com.android.tools.build:gradle:' + android_tools_version)
+    }
+}
+
+repositories {
+    mavenLocal()
+    maven { url 'https://maven.google.com' }
+    jcenter()
+}
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+android {
+    compileSdkVersion 23
+    buildToolsVersion "25.0.2"
+}
+
+dependencies {
+    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidLibraryKotlinProject/gradle.properties
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidLibraryKotlinProject/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-XX:MaxPermSize=512m

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidLibraryKotlinProject/src/main/AndroidManifest.xml
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidLibraryKotlinProject/src/main/AndroidManifest.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="org.jetbrains.kotlin.gradle.test.android.libalfa"
+          android:versionCode="1"
+          android:versionName="1.0" >
+
+  <application/>
+
+</manifest>

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidLibraryKotlinProject/src/main/kotlin/Dummy.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidLibraryKotlinProject/src/main/kotlin/Dummy.kt
@@ -1,0 +1,3 @@
+package demo
+
+class Dummy

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidLibraryKotlinProject/src/main/kotlin/Greeter.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidLibraryKotlinProject/src/main/kotlin/Greeter.kt
@@ -1,0 +1,3 @@
+package demo
+
+open class Greeter(val greeting: String)

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidLibraryKotlinProject/src/main/kotlin/dummyUtil.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidLibraryKotlinProject/src/main/kotlin/dummyUtil.kt
@@ -1,0 +1,3 @@
+package demo
+
+fun dummyFun() {}

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/android/Android25ProjectHandler.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/android/Android25ProjectHandler.kt
@@ -191,6 +191,7 @@ class Android25ProjectHandler(
             javaTask: AbstractCompile
         ) {
             val kaptSourceOutput = project.fileTree(kaptTask.destinationDir).builtBy(kaptTask)
+            kaptSourceOutput.include("**/*.java")
             variantData.registerExternalAptJavaOutput(kaptSourceOutput)
             variantData.dataBindingDependencyArtifactsIfSupported?.let { kaptTask.dependsOn(it) }
         }


### PR DESCRIPTION
When adding generated Java sources to AGP using Variant API,
add only Java sources. This was already done in
a6ae4494167c9d4cca23995457c59fb2daedad39 for Java projects, and this
commit fixes the same issue for Android projects.

Test: Kapt3Android33IT.testKotlinProcessorUsingFiler