### PR TITLE
KT-30985 Missing line break in quick doc for enum constant

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/KotlinQuickDocumentationProvider.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/KotlinQuickDocumentationProvider.kt
@@ -291,7 +291,7 @@ class KotlinQuickDocumentationProvider : AbstractDocumentationProvider() {
                         definition {
                             it.inherit()
                             ordinal?.let {
-                                append("Enum constant ordinal: $ordinal")
+                                append("<br>Enum constant ordinal: $ordinal")
                             }
                         }
                     }

--- a/idea/testData/editor/quickDoc/OnEnumEntry.kt
+++ b/idea/testData/editor/quickDoc/OnEnumEntry.kt
@@ -4,4 +4,4 @@ enum class TestEnum{
 
 
 
-//INFO: <div class='definition'><pre><a href="psi_element://TestEnum"><code>TestEnum</code></a><br>enum entry <b>C</b>Enum constant ordinal: 2</pre></div>
+//INFO: <div class='definition'><pre><a href="psi_element://TestEnum"><code>TestEnum</code></a><br>enum entry <b>C</b><br>Enum constant ordinal: 2</pre></div>

--- a/idea/testData/editor/quickDoc/OnEnumEntryUsage.kt
+++ b/idea/testData/editor/quickDoc/OnEnumEntryUsage.kt
@@ -6,4 +6,4 @@ fun test() {
     TestEnum.<caret>C
 }
 
-//INFO: <div class='definition'><pre><a href="psi_element://TestEnum"><code>TestEnum</code></a><br>enum entry <b>C</b>Enum constant ordinal: 2</pre></div>
+//INFO: <div class='definition'><pre><a href="psi_element://TestEnum"><code>TestEnum</code></a><br>enum entry <b>C</b><br>Enum constant ordinal: 2</pre></div>


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-30985