### PR TITLE
KT-31985 Gradle, JS: webpack not working on windows

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/NpmProject.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/NpmProject.kt
@@ -53,8 +53,16 @@ open class NpmProject(val compilation: KotlinJsCompilation) {
 
     fun useTool(exec: ExecSpec, tool: String, vararg args: String) {
         exec.workingDir = dir
-        exec.executable = project.nodeJs.root.environment.nodeExecutable
-        exec.args = listOf(require(tool)) + args
+
+        // Workaround for Windows
+        val environment = project.nodeJs.root.environment
+        if (environment.isWindows) {
+            exec.executable = "${require(tool)}.cmd"
+            exec.args = args.asList()
+        } else {
+            exec.executable = environment.nodeExecutable
+            exec.args = listOf(require(tool)) + args
+        }
     }
 
     /**

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/webpack/KotlinWebpackConfigWriter.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/webpack/KotlinWebpackConfigWriter.kt
@@ -195,14 +195,17 @@ data class KotlinWebpackConfigWriter(
     private fun Appendable.appendEntry() {
         if (entry == null || outputPath == null) return
 
+        val quotedEntryPath = jsQuotedString(entry.canonicalPath)
+        val quotedOutputPath = jsQuotedString(outputPath.canonicalPath)
+
         //language=JavaScript 1.8
         appendln(
             """
                 // entry
                 if (!config.entry) config.entry = [];
-                config.entry.push('${entry.canonicalPath}');
+                config.entry.push($quotedEntryPath);
                 config.output = {
-                    path: '${outputPath.canonicalPath}',
+                    path: $quotedOutputPath,
                     filename: '${entry.name}'
                 };
                 


### PR DESCRIPTION
It fixes webpack config's separator and bin for windows
As for bin, I think it is only Workaround (hope for next eap :smile: ), not only full solution.

I think, it's best to use "bin" field of package.json (https://docs.npmjs.com/files/package.json#bin), not ".bin" folder of node_modules. Because there is "no-bin-links" mode (https://docs.npmjs.com/cli/install), and it will be perfect if Kotlin/JS will support it, because bin-links is very convinient if we use pure npm, but automatic tools (like Kotlin/JS) can calculate executable without it. 
Now you require bins in ["useTool"](https://github.com/JetBrains/kotlin/blob/cf5577dfa6173eedbcfde71e5bb6921b0e9f9193/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/NpmProject.kt#L54) as usual module.
So my opinion, that it should be resolved [similarly](https://github.com/JetBrains/kotlin/blob/1c0519b0a2b125048f7bba5cd2692987cd9d2b9b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/NpmProjectModules.kt#L63) like usual modules with only difference that it is neccessary to find "bin" field in package.json