### PR TITLE
KT-12515 Quickfix "by Delegates.notNull()" as replacement for "lateinit" for primitive type

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/ConvertLateinitPropertyToNotNullDelegateFix.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/ConvertLateinitPropertyToNotNullDelegateFix.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.idea.quickfix
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import org.jetbrains.kotlin.builtins.KotlinBuiltIns
+import org.jetbrains.kotlin.diagnostics.Diagnostic
+import org.jetbrains.kotlin.idea.caches.resolve.analyze
+import org.jetbrains.kotlin.idea.core.ShortenReferences
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.lazy.BodyResolveMode
+
+class ConvertLateinitPropertyToNotNullDelegateFix(
+    property: KtProperty,
+    private val type: String
+) : KotlinQuickFixAction<KtProperty>(property) {
+    override fun getText() = "Convert to notNull delegate"
+
+    override fun getFamilyName() = text
+
+    override fun invoke(project: Project, editor: Editor?, file: KtFile) {
+        val property = element ?: return
+        val typeReference = property.typeReference ?: return
+        val psiFactory = KtPsiFactory(property)
+        property.removeModifier(KtTokens.LATEINIT_KEYWORD)
+        val propertyDelegate = psiFactory.createPropertyDelegate(
+            psiFactory.createExpression("kotlin.properties.Delegates.notNull<$type>()")
+        )
+        property.addAfter(propertyDelegate, typeReference)
+        property.typeReference = null
+        ShortenReferences.DEFAULT.process(property)
+    }
+
+    companion object : KotlinSingleIntentionActionFactory() {
+        override fun createAction(diagnostic: Diagnostic): KotlinQuickFixAction<KtProperty>? {
+            val modifierList = diagnostic.psiElement.parent as? KtDeclarationModifierList ?: return null
+            val property = modifierList.parent as? KtProperty ?: return null
+            if (!property.hasModifier(KtTokens.LATEINIT_KEYWORD) || !property.isVar || property.hasInitializer()) return null
+            val typeReference = property.typeReference ?: return null
+            val type = property.analyze(BodyResolveMode.PARTIAL)[BindingContext.TYPE, typeReference] ?: return null
+            if (!KotlinBuiltIns.isPrimitiveType(type)) return null
+            return ConvertLateinitPropertyToNotNullDelegateFix(property, type.toString())
+        }
+    }
+}

--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixRegistrar.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixRegistrar.kt
@@ -512,6 +512,7 @@ class QuickFixRegistrar : QuickFixContributor {
         INAPPLICABLE_LATEINIT_MODIFIER.registerFactory(RemoveNullableFix.LATEINIT_FACTORY)
         INAPPLICABLE_LATEINIT_MODIFIER.registerFactory(RemovePartsFromPropertyFix.LateInitFactory)
         INAPPLICABLE_LATEINIT_MODIFIER.registerFactory(RemoveModifierFix.createRemoveLateinitFactory())
+        INAPPLICABLE_LATEINIT_MODIFIER.registerFactory(ConvertLateinitPropertyToNotNullDelegateFix)
 
         VARIABLE_WITH_REDUNDANT_INITIALIZER.registerFactory(RemoveRedundantInitializerFix)
 

--- a/idea/testData/quickfix/convertLateinitPropertyToNotNullDelegate/basic.kt
+++ b/idea/testData/quickfix/convertLateinitPropertyToNotNullDelegate/basic.kt
@@ -1,0 +1,3 @@
+// "Convert to notNull delegate" "true"
+// WITH_RUNTIME
+<caret>lateinit var x: Boolean

--- a/idea/testData/quickfix/convertLateinitPropertyToNotNullDelegate/basic.kt.after
+++ b/idea/testData/quickfix/convertLateinitPropertyToNotNullDelegate/basic.kt.after
@@ -1,0 +1,5 @@
+import kotlin.properties.Delegates
+
+// "Convert to notNull delegate" "true"
+// WITH_RUNTIME
+var x by Delegates.notNull<Boolean>()

--- a/idea/testData/quickfix/convertLateinitPropertyToNotNullDelegate/basic2.kt
+++ b/idea/testData/quickfix/convertLateinitPropertyToNotNullDelegate/basic2.kt
@@ -1,0 +1,3 @@
+// "Convert to notNull delegate" "true"
+// WITH_RUNTIME
+<caret>lateinit var x: Int

--- a/idea/testData/quickfix/convertLateinitPropertyToNotNullDelegate/basic2.kt.after
+++ b/idea/testData/quickfix/convertLateinitPropertyToNotNullDelegate/basic2.kt.after
@@ -1,0 +1,5 @@
+import kotlin.properties.Delegates
+
+// "Convert to notNull delegate" "true"
+// WITH_RUNTIME
+var x by Delegates.notNull<Int>()

--- a/idea/testData/quickfix/convertLateinitPropertyToNotNullDelegate/hasInitializer.kt
+++ b/idea/testData/quickfix/convertLateinitPropertyToNotNullDelegate/hasInitializer.kt
@@ -1,0 +1,8 @@
+// "Convert to notNull delegate" "false"
+// DISABLE-ERRORS
+// ACTION: Make internal
+// ACTION: Make private
+// ACTION: Remove 'lateinit' modifier
+// ACTION: Remove explicit type specification
+// ACTION: Remove initializer from property
+<caret>lateinit var x: Boolean = true

--- a/idea/testData/quickfix/convertLateinitPropertyToNotNullDelegate/noType.kt
+++ b/idea/testData/quickfix/convertLateinitPropertyToNotNullDelegate/noType.kt
@@ -1,0 +1,7 @@
+// "Convert to notNull delegate" "false"
+// DISABLE-ERRORS
+// ACTION: Convert to nullable var
+// ACTION: Make internal
+// ACTION: Make private
+// ACTION: Specify type explicitly
+<caret>lateinit var x

--- a/idea/testData/quickfix/convertLateinitPropertyToNotNullDelegate/notPrimitive.kt
+++ b/idea/testData/quickfix/convertLateinitPropertyToNotNullDelegate/notPrimitive.kt
@@ -1,0 +1,5 @@
+// "Convert to notNull delegate" "false"
+// ACTION: Convert to nullable var
+// ACTION: Make internal
+// ACTION: Make private
+<caret>lateinit var x: String

--- a/idea/testData/quickfix/convertLateinitPropertyToNotNullDelegate/nullablePrimitive.kt
+++ b/idea/testData/quickfix/convertLateinitPropertyToNotNullDelegate/nullablePrimitive.kt
@@ -1,0 +1,7 @@
+// "Convert to notNull delegate" "false"
+// DISABLE-ERRORS
+// ACTION: Make internal
+// ACTION: Make not-nullable
+// ACTION: Make private
+// ACTION: Remove 'lateinit' modifier
+<caret>lateinit var x: Boolean?

--- a/idea/testData/quickfix/convertLateinitPropertyToNotNullDelegate/val.kt
+++ b/idea/testData/quickfix/convertLateinitPropertyToNotNullDelegate/val.kt
@@ -1,0 +1,7 @@
+// "Convert to notNull delegate" "false"
+// DISABLE-ERRORS
+// ACTION: Change to var
+// ACTION: Make internal
+// ACTION: Make private
+// ACTION: Remove 'lateinit' modifier
+<caret>lateinit val x: Boolean

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixMultiFileTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixMultiFileTestGenerated.java
@@ -1399,6 +1399,19 @@ public class QuickFixMultiFileTestGenerated extends AbstractQuickFixMultiFileTes
         }
     }
 
+    @TestMetadata("idea/testData/quickfix/convertLateinitPropertyToNotNullDelegate")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class ConvertLateinitPropertyToNotNullDelegate extends AbstractQuickFixMultiFileTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doTestWithExtraFile, TargetBackend.ANY, testDataFilePath);
+        }
+
+        public void testAllFilesPresentInConvertLateinitPropertyToNotNullDelegate() throws Exception {
+            KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/quickfix/convertLateinitPropertyToNotNullDelegate"), Pattern.compile("^(\\w+)\\.((before\\.Main\\.\\w+)|(test))$"), TargetBackend.ANY, true);
+        }
+    }
+
     @TestMetadata("idea/testData/quickfix/convertPropertyInitializerToGetter")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -2439,6 +2439,54 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
         }
     }
 
+    @TestMetadata("idea/testData/quickfix/convertLateinitPropertyToNotNullDelegate")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class ConvertLateinitPropertyToNotNullDelegate extends AbstractQuickFixTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY, testDataFilePath);
+        }
+
+        public void testAllFilesPresentInConvertLateinitPropertyToNotNullDelegate() throws Exception {
+            KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/quickfix/convertLateinitPropertyToNotNullDelegate"), Pattern.compile("^([\\w\\-_]+)\\.kt$"), TargetBackend.ANY, true);
+        }
+
+        @TestMetadata("basic.kt")
+        public void testBasic() throws Exception {
+            runTest("idea/testData/quickfix/convertLateinitPropertyToNotNullDelegate/basic.kt");
+        }
+
+        @TestMetadata("basic2.kt")
+        public void testBasic2() throws Exception {
+            runTest("idea/testData/quickfix/convertLateinitPropertyToNotNullDelegate/basic2.kt");
+        }
+
+        @TestMetadata("hasInitializer.kt")
+        public void testHasInitializer() throws Exception {
+            runTest("idea/testData/quickfix/convertLateinitPropertyToNotNullDelegate/hasInitializer.kt");
+        }
+
+        @TestMetadata("noType.kt")
+        public void testNoType() throws Exception {
+            runTest("idea/testData/quickfix/convertLateinitPropertyToNotNullDelegate/noType.kt");
+        }
+
+        @TestMetadata("notPrimitive.kt")
+        public void testNotPrimitive() throws Exception {
+            runTest("idea/testData/quickfix/convertLateinitPropertyToNotNullDelegate/notPrimitive.kt");
+        }
+
+        @TestMetadata("nullablePrimitive.kt")
+        public void testNullablePrimitive() throws Exception {
+            runTest("idea/testData/quickfix/convertLateinitPropertyToNotNullDelegate/nullablePrimitive.kt");
+        }
+
+        @TestMetadata("val.kt")
+        public void testVal() throws Exception {
+            runTest("idea/testData/quickfix/convertLateinitPropertyToNotNullDelegate/val.kt");
+        }
+    }
+
     @TestMetadata("idea/testData/quickfix/convertPropertyInitializerToGetter")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-12515