### PR TITLE
KT-31291: Wrap ASM version in a method to avoid having it inlined

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/incremental/ClassAbiExtractor.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/incremental/ClassAbiExtractor.kt
@@ -9,7 +9,19 @@ import org.jetbrains.org.objectweb.asm.*
 
 const val metadataDescriptor: String = "Lkotlin/Metadata;"
 
-class ClassAbiExtractor(private val writer: ClassWriter) : ClassVisitor(Opcodes.API_VERSION, writer) {
+/**
+ * Use this to get the ASM version, as otherwise value gets inlined which may cause runtime issues if
+ * another plugin adds ASM to the classpath. See https://youtrack.jetbrains.com/issue/KT-31291 for more details.
+ */
+internal val lazyAsmApiVersion = lazy {
+    try {
+        Opcodes::API_VERSION.get()
+    } catch(e: Throwable) {
+        Opcodes.API_VERSION
+    }
+}
+
+class ClassAbiExtractor(private val writer: ClassWriter) : ClassVisitor(lazyAsmApiVersion.value, writer) {
 
     override fun visitMethod(
         access: Int,

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/incremental/ClassTypeExtractorVisitor.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/incremental/ClassTypeExtractorVisitor.kt
@@ -9,7 +9,7 @@ import org.jetbrains.org.objectweb.asm.*
 
 private val toIgnore = setOf("java/lang/Object", "kotlin/Metadata", "org/jetbrains/annotations/NotNull")
 
-class ClassTypeExtractorVisitor(visitor: ClassVisitor) : ClassVisitor(Opcodes.API_VERSION, visitor) {
+class ClassTypeExtractorVisitor(visitor: ClassVisitor) : ClassVisitor(lazyAsmApiVersion.value, visitor) {
 
     private val abiTypes = mutableSetOf<String>()
     private val privateTypes = mutableSetOf<String>()


### PR DESCRIPTION
This commit adds a method to get the value of org.jetbrains.org.objectweb.asm.Oopcodes.API_VERSION.
In general, this should not be a problem, but some Gradle plugins package
Jetbrains ASM version. At runtime, their version may be loaded which may be
different than the one this code was compiled against.