### PR TITLE
Improve incremental KAPT logging

### DIFF
--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/ProcessorLoader.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/ProcessorLoader.kt
@@ -65,7 +65,6 @@ open class ProcessorLoader(private val options: KaptOptions, private val logger:
 
         val nonIncremental = processorNames.filter { !processorsInfo.containsKey(it) }
         return if (nonIncremental.isNotEmpty()) {
-            logger.info("Incremental KAPT support is disabled. Processors that are not incremental: ${nonIncremental.joinToString()}.")
             processors.map { IncrementalProcessor(it, DeclaredProcType.NON_INCREMENTAL) }
         } else {
             processors.map { IncrementalProcessor(it, processorsInfo.getValue(it.javaClass.name)) }

--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/incremental/incrementalProcessors.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/incremental/incrementalProcessors.kt
@@ -23,6 +23,8 @@ class IncrementalProcessor(private val processor: Processor, val kind: DeclaredP
 
     private var dependencyCollector = lazy { createDependencyCollector() }
 
+    val processorName: String = processor.javaClass.name
+
     override fun init(processingEnv: ProcessingEnvironment) {
         if (kind == DeclaredProcType.NON_INCREMENTAL) {
             processor.init(processingEnv)


### PR DESCRIPTION
This commit improves incremental KAPT logging. It reports processor
stats using their actual names. Also, warning is printed if incremental
annotation processing is requested, but not all APs are incremental