### PR TITLE
JVM_IR: do not generate two nullary constructors

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
@@ -115,7 +115,6 @@ val jvmPhases = namedIrFilePhase<JvmBackendContext>(
             annotationPhase then
             tailrecPhase then
 
-            jvmDefaultConstructorPhase then
             jvmInlineClassPhase then
             defaultArgumentStubPhase then
 
@@ -146,6 +145,7 @@ val jvmPhases = namedIrFilePhase<JvmBackendContext>(
             collectionStubMethodLowering then
             bridgePhase then
             jvmOverloadsAnnotationPhase then
+            jvmDefaultConstructorPhase then
             jvmStaticAnnotationPhase then
             staticDefaultFunctionPhase then
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/JvmDefaultConstructorLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/JvmDefaultConstructorLowering.kt
@@ -20,7 +20,8 @@ import org.jetbrains.kotlin.ir.util.hasDefaultValue
 internal val jvmDefaultConstructorPhase = makeIrFilePhase(
     ::JvmDefaultConstructorLowering,
     name = "JvmDefaultConstructor",
-    description = "Generate default constructors for Java"
+    description = "Generate default constructors for Java",
+    prerequisite = setOf(jvmOverloadsAnnotationPhase)
 )
 
 // Quoted from https://kotlinlang.org/docs/reference/classes.html

--- a/compiler/testData/codegen/box/jvmOverloads/primaryConstructorWithAllDefaults.kt
+++ b/compiler/testData/codegen/box/jvmOverloads/primaryConstructorWithAllDefaults.kt
@@ -1,0 +1,12 @@
+// TARGET_BACKEND: JVM
+
+// WITH_RUNTIME
+
+class C @kotlin.jvm.JvmOverloads constructor(s1: String = "O", s2: String = "K") {
+    public val status: String = s1 + s2
+}
+
+fun box(): String {
+    val c = (C::class.java.getConstructor().newInstance())
+    return c.status
+}

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -14879,6 +14879,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             runTest("compiler/testData/codegen/box/jvmOverloads/primaryConstructor.kt");
         }
 
+        @TestMetadata("primaryConstructorWithAllDefaults.kt")
+        public void testPrimaryConstructorWithAllDefaults() throws Exception {
+            runTest("compiler/testData/codegen/box/jvmOverloads/primaryConstructorWithAllDefaults.kt");
+        }
+
         @TestMetadata("privateClass.kt")
         public void testPrivateClass() throws Exception {
             runTest("compiler/testData/codegen/box/jvmOverloads/privateClass.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -14879,6 +14879,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/jvmOverloads/primaryConstructor.kt");
         }
 
+        @TestMetadata("primaryConstructorWithAllDefaults.kt")
+        public void testPrimaryConstructorWithAllDefaults() throws Exception {
+            runTest("compiler/testData/codegen/box/jvmOverloads/primaryConstructorWithAllDefaults.kt");
+        }
+
         @TestMetadata("privateClass.kt")
         public void testPrivateClass() throws Exception {
             runTest("compiler/testData/codegen/box/jvmOverloads/privateClass.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -14884,6 +14884,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             runTest("compiler/testData/codegen/box/jvmOverloads/primaryConstructor.kt");
         }
 
+        @TestMetadata("primaryConstructorWithAllDefaults.kt")
+        public void testPrimaryConstructorWithAllDefaults() throws Exception {
+            runTest("compiler/testData/codegen/box/jvmOverloads/primaryConstructorWithAllDefaults.kt");
+        }
+
         @TestMetadata("privateClass.kt")
         public void testPrivateClass() throws Exception {
             runTest("compiler/testData/codegen/box/jvmOverloads/privateClass.kt");


### PR DESCRIPTION
when the primary constructor with @JvmOverloads has default values for all arguments.

Bugfix for #2372.