### PR TITLE
Reduce calls to Object.hashCode from LabelNormalizationMethodTransformer

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/LabelNormalizationMethodTransformer.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/LabelNormalizationMethodTransformer.kt
@@ -18,6 +18,7 @@ package org.jetbrains.kotlin.codegen.optimization
 
 import org.jetbrains.kotlin.codegen.optimization.common.removeEmptyCatchBlocks
 import org.jetbrains.kotlin.codegen.optimization.transformer.MethodTransformer
+import org.jetbrains.kotlin.utils.SmartIdentityTable
 import org.jetbrains.org.objectweb.asm.Label
 import org.jetbrains.org.objectweb.asm.tree.*
 import java.lang.IllegalStateException
@@ -29,7 +30,7 @@ class LabelNormalizationMethodTransformer : MethodTransformer() {
 
     private class TransformerForMethod(val methodNode: MethodNode) {
         val instructions = methodNode.instructions
-        val newLabelNodes = hashMapOf<Label, LabelNode>()
+        val newLabelNodes = SmartIdentityTable<Label, LabelNode>()
 
         fun transform() {
             if (rewriteLabelInstructions()) {


### PR DESCRIPTION
Reduce calls to Object.hashCode originating from LabelNormalizationMethodTransformer


Building on the work in #2403, shaves 1% of compilation time on kotlinx.serialization
by using SmartIdentityTable instead of hashMap in LabelNormailizationMethodTransformer.

Metrics on the prior hashMap use in this code:

| What      | Count |
| --------- | ----- |
| instances | 21530 |
| min       | 0     |
| max       | 174   |
| mean      | 4     |
| stddev    | 8.24  |
| median    | 4     |
| 90p       | 8     |
| 95p       | 15    |