### PR TITLE
Reduce calls to Object.hashCode from ConstraintSystem(Builder)Impl

### DIFF
--- a/compiler/util/src/org/jetbrains/kotlin/utils/SmartIdentityTable.kt
+++ b/compiler/util/src/org/jetbrains/kotlin/utils/SmartIdentityTable.kt
@@ -27,6 +27,27 @@ class SmartIdentityTable<K, V> {
     val size: Int
         get() = keysArray?.size ?: largeMap!!.size
 
+
+    val keys: Sequence<K>
+        get() = keysArray?.asSequence() ?: largeMap!!.keys.asSequence()
+
+
+    val entries: Sequence<Entry<K, V>>
+        get() {
+            val ka = keysArray
+            return if (ka != null) {
+                val va = valuesArray!!
+                val currentSize = size
+                sequence {
+                    for (i in 0 until currentSize) {
+                        yield(Entry(ka[i], va[i]))
+                    }
+                }
+            } else {
+                largeMap!!.entries.asSequence().map { Entry(it.key, it.value) }
+            }
+        }
+
     operator fun get(key: K): V? {
         return keysArray?.let {
             for ((index, k) in it.withIndex()) {
@@ -80,7 +101,15 @@ class SmartIdentityTable<K, V> {
         }
     }
 
+    fun putAll(other: SmartIdentityTable<K, V>) {
+        for (key in other.keys) {
+            this[key] = other[key]!!
+        }
+    }
+
     companion object {
         private const val ARRAY_UNTIL_SIZE = 10
     }
+
+    data class Entry<K, V>(val key: K, val value: V)
 }


### PR DESCRIPTION
Building on the work in #2403, shaves 1% of compilation time on kotlinx.serialization
by using SmartIdentityTable instead of hashMap in ConstraintSystemImpl and ConstraintSystemBuilderImpl

Metrics on the prior hashMap use in this code:

ConstraintSystemImpl:

| What      | Count |
| --------- | ----- |
| instances | 3223  |
| min       | 0     |
| max       | 3     |
| mean      | 1     |
| stddev    | 0.57  |
| median    | 1     |
| 90p       | 2     |
| 95p       | 2     |

ConstraintSystemBuilderImpl:

| What      | Count |
| --------- | ----- |
| instances | 3227  |
| min       | 0     |
| max       | 3     |
| mean      | 0     |
| stddev    | 1.04  |
| median    | 1     |
| 90p       | 2     |
| 95p       | 2     |