### PR TITLE
KT-32324 Formatter doesn't insert space after safe cast operator `as?`

### DIFF
--- a/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/kotlinSpacingRules.kt
+++ b/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/kotlinSpacingRules.kt
@@ -301,6 +301,7 @@ fun createSpacingBuilder(settings: CodeStyleSettings, builderUtil: KotlinSpacing
             aroundInside(DOT, USER_TYPE).spaces(0)
 
             around(AS_KEYWORD).spaces(1)
+            around(AS_SAFE).spaces(1)
             around(IS_KEYWORD).spaces(1)
             around(NOT_IS).spaces(1)
             around(IN_KEYWORD).spaces(1)

--- a/idea/testData/formatter/SafeCast.after.kt
+++ b/idea/testData/formatter/SafeCast.after.kt
@@ -1,0 +1,3 @@
+fun main(a: Any) {
+    a as? String
+}

--- a/idea/testData/formatter/SafeCast.kt
+++ b/idea/testData/formatter/SafeCast.kt
@@ -1,0 +1,3 @@
+fun main(a: Any) {
+    a   as?String
+}

--- a/idea/tests/org/jetbrains/kotlin/formatter/FormatterTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/formatter/FormatterTestGenerated.java
@@ -616,6 +616,11 @@ public class FormatterTestGenerated extends AbstractFormatterTest {
             runTest("idea/testData/formatter/RightBracketOnNewLine.after.kt");
         }
 
+        @TestMetadata("SafeCast.after.kt")
+        public void testSafeCast() throws Exception {
+            runTest("idea/testData/formatter/SafeCast.after.kt");
+        }
+
         @TestMetadata("SaveSpacesInDocComments.after.kt")
         public void testSaveSpacesInDocComments() throws Exception {
             runTest("idea/testData/formatter/SaveSpacesInDocComments.after.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-32324