### PR TITLE
Add intrinsic for ULong/UInt.toString on Java 8+

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/intrinsics/IntrinsicMethods.java
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/intrinsics/IntrinsicMethods.java
@@ -175,6 +175,8 @@ public class IntrinsicMethods {
             intrinsicsMap.registerIntrinsic(KOTLIN_UINT.toSafe(), null, "compareTo", 1, java8UIntCompare);
             intrinsicsMap.registerIntrinsic(BUILT_INS_PACKAGE_FQ_NAME, null, "uintCompare", 2, java8UIntCompare);
 
+            intrinsicsMap.registerIntrinsic(KOTLIN_UINT.toSafe(), null, "toString", 0, new Java8UIntToString());
+
             Java8ULongDivide java8ULongDivide = new Java8ULongDivide();
             intrinsicsMap.registerIntrinsic(KOTLIN_ULONG.toSafe(), null, "div", 1, java8ULongDivide);
             intrinsicsMap.registerIntrinsic(BUILT_INS_PACKAGE_FQ_NAME, null, "ulongDivide", 2, java8ULongDivide);
@@ -186,6 +188,8 @@ public class IntrinsicMethods {
             Java8ULongCompare java8ULongCompare = new Java8ULongCompare();
             intrinsicsMap.registerIntrinsic(KOTLIN_ULONG.toSafe(), null, "compareTo", 1, java8ULongCompare);
             intrinsicsMap.registerIntrinsic(BUILT_INS_PACKAGE_FQ_NAME, null, "ulongCompare", 2, java8ULongCompare);
+
+            intrinsicsMap.registerIntrinsic(KOTLIN_ULONG.toSafe(), null, "toString", 0, new Java8ULongToString());
         }
     }
 

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/intrinsics/Java8Unsigned.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/intrinsics/Java8Unsigned.kt
@@ -13,7 +13,8 @@ import org.jetbrains.kotlin.descriptors.PackageFragmentDescriptor
 abstract class UnsignedIntrinsic(private val targetDescriptor: String) : IntrinsicMethod() {
     override fun isApplicableToOverload(descriptor: CallableMemberDescriptor): Boolean {
         if (descriptor.containingDeclaration is PackageFragmentDescriptor) return true
-        val singleValueParameterTypeDescriptor = descriptor.valueParameters.single().type.constructor.declarationDescriptor
+        val valueParameter = descriptor.valueParameters.singleOrNull() ?: return true
+        val singleValueParameterTypeDescriptor = valueParameter.type.constructor.declarationDescriptor
             ?: throw AssertionError("Unexpected descriptor for unsigned intrinsic: $descriptor")
         return singleValueParameterTypeDescriptor.name.asString() == targetDescriptor
     }
@@ -40,6 +41,13 @@ class Java8UIntCompare : UnsignedIntrinsic("UInt") {
         }
 }
 
+class Java8UIntToString : UnsignedIntrinsic("UInt") {
+    override fun toCallable(method: CallableMethod): Callable =
+        createIntrinsicCallable(method) {
+            it.invokestatic("java/lang/Integer", "toUnsignedString", "(I)Ljava/lang/String;", false)
+        }
+}
+
 class Java8ULongDivide : UnsignedIntrinsic("ULong") {
     override fun toCallable(method: CallableMethod): Callable =
         createIntrinsicCallable(method) {
@@ -58,5 +66,12 @@ class Java8ULongCompare : UnsignedIntrinsic("ULong") {
     override fun toCallable(method: CallableMethod): Callable =
         createIntrinsicCallable(method) {
             it.invokestatic("java/lang/Long", "compareUnsigned", "(JJ)I", false)
+        }
+}
+
+class Java8ULongToString : UnsignedIntrinsic("ULong") {
+    override fun toCallable(method: CallableMethod): Callable =
+        createIntrinsicCallable(method) {
+            it.invokestatic("java/lang/Long", "toUnsignedString", "(J)Ljava/lang/String;", false)
         }
 }

--- a/compiler/testData/codegen/box/unsignedTypes/unsignedIntToString.kt
+++ b/compiler/testData/codegen/box/unsignedTypes/unsignedIntToString.kt
@@ -1,0 +1,15 @@
+// KJS_WITH_FULL_RUNTIME
+// WITH_RUNTIME
+
+fun box(): String {
+    val min = 0U.toString()
+    if ("0" != min) throw AssertionError(min)
+
+    val middle = 2_147_483_647U.toString()
+    if ("2147483647" != middle) throw AssertionError(middle)
+
+    val max = 4_294_967_295U.toString()
+    if ("4294967295" != max) throw AssertionError(max)
+
+    return "OK"
+}

--- a/compiler/testData/codegen/box/unsignedTypes/unsignedLongToString.kt
+++ b/compiler/testData/codegen/box/unsignedTypes/unsignedLongToString.kt
@@ -1,0 +1,15 @@
+// KJS_WITH_FULL_RUNTIME
+// WITH_RUNTIME
+
+fun box(): String {
+    val min = 0UL.toString()
+    if ("0" != min) throw AssertionError(min)
+
+    val middle = 9_223_372_036_854_775_807UL.toString()
+    if ("9223372036854775807" != middle) throw AssertionError(middle)
+
+    val max = 18_446_744_073_709_551_615UL.toString()
+    if ("18446744073709551615" != max) throw AssertionError(max)
+
+    return "OK"
+}

--- a/compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedIntToString_jvm18.kt
+++ b/compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedIntToString_jvm18.kt
@@ -1,0 +1,19 @@
+// JVM_TARGET: 1.8
+// WITH_RUNTIME
+// IGNORE_BACKEND: JVM_IR
+
+fun box(): String {
+    val min = 0U.toString()
+    if ("0" != min) throw AssertionError(min)
+
+    val middle = 2_147_483_647U.toString()
+    if ("2147483647" != middle) throw AssertionError(middle)
+
+    val max = 4_294_967_295U.toString()
+    if ("4294967295" != max) throw AssertionError(max)
+
+    return "OK"
+}
+
+// 0 kotlin/UInt.toString
+// 3 INVOKESTATIC java/lang/Integer.toUnsignedString \(I\)Ljava/lang/String;

--- a/compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedLongToString_jvm18.kt
+++ b/compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedLongToString_jvm18.kt
@@ -1,0 +1,19 @@
+// JVM_TARGET: 1.8
+// WITH_RUNTIME
+// IGNORE_BACKEND: JVM_IR
+
+fun box(): String {
+    val min = 0UL.toString()
+    if ("0" != min) throw AssertionError(min)
+
+    val middle = 9_223_372_036_854_775_807UL.toString()
+    if ("9223372036854775807" != middle) throw AssertionError(middle)
+
+    val max = 18_446_744_073_709_551_615UL.toString()
+    if ("18446744073709551615" != max) throw AssertionError(max)
+
+    return "OK"
+}
+
+// 0 kotlin/ULong.toString
+// 3 INVOKESTATIC java/lang/Long.toUnsignedString \(J\)Ljava/lang/String;

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -25185,6 +25185,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             runTest("compiler/testData/codegen/box/unsignedTypes/unsignedIntRemainder.kt");
         }
 
+        @TestMetadata("unsignedIntToString.kt")
+        public void testUnsignedIntToString() throws Exception {
+            runTest("compiler/testData/codegen/box/unsignedTypes/unsignedIntToString.kt");
+        }
+
         @TestMetadata("unsignedLiteralsForMaxLongValue.kt")
         public void testUnsignedLiteralsForMaxLongValue() throws Exception {
             runTest("compiler/testData/codegen/box/unsignedTypes/unsignedLiteralsForMaxLongValue.kt");
@@ -25208,6 +25213,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
         @TestMetadata("unsignedLongRemainder.kt")
         public void testUnsignedLongRemainder() throws Exception {
             runTest("compiler/testData/codegen/box/unsignedTypes/unsignedLongRemainder.kt");
+        }
+
+        @TestMetadata("unsignedLongToString.kt")
+        public void testUnsignedLongToString() throws Exception {
+            runTest("compiler/testData/codegen/box/unsignedTypes/unsignedLongToString.kt");
         }
 
         @TestMetadata("unsignedRangeIterator.kt")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
@@ -3580,6 +3580,11 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
             runTest("compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedIntRemainder_jvm18.kt");
         }
 
+        @TestMetadata("unsignedIntToString_jvm18.kt")
+        public void testUnsignedIntToString_jvm18() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedIntToString_jvm18.kt");
+        }
+
         @TestMetadata("unsignedLongCompare_jvm18.kt")
         public void testUnsignedLongCompare_jvm18() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedLongCompare_jvm18.kt");
@@ -3593,6 +3598,11 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
         @TestMetadata("unsignedLongRemainder_jvm18.kt")
         public void testUnsignedLongRemainder_jvm18() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedLongRemainder_jvm18.kt");
+        }
+
+        @TestMetadata("unsignedLongToString_jvm18.kt")
+        public void testUnsignedLongToString_jvm18() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedLongToString_jvm18.kt");
         }
 
         @TestMetadata("whenByUnsigned.kt")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -25185,6 +25185,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/unsignedTypes/unsignedIntRemainder.kt");
         }
 
+        @TestMetadata("unsignedIntToString.kt")
+        public void testUnsignedIntToString() throws Exception {
+            runTest("compiler/testData/codegen/box/unsignedTypes/unsignedIntToString.kt");
+        }
+
         @TestMetadata("unsignedLiteralsForMaxLongValue.kt")
         public void testUnsignedLiteralsForMaxLongValue() throws Exception {
             runTest("compiler/testData/codegen/box/unsignedTypes/unsignedLiteralsForMaxLongValue.kt");
@@ -25208,6 +25213,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
         @TestMetadata("unsignedLongRemainder.kt")
         public void testUnsignedLongRemainder() throws Exception {
             runTest("compiler/testData/codegen/box/unsignedTypes/unsignedLongRemainder.kt");
+        }
+
+        @TestMetadata("unsignedLongToString.kt")
+        public void testUnsignedLongToString() throws Exception {
+            runTest("compiler/testData/codegen/box/unsignedTypes/unsignedLongToString.kt");
         }
 
         @TestMetadata("unsignedRangeIterator.kt")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -24090,6 +24090,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             runTest("compiler/testData/codegen/box/unsignedTypes/unsignedIntRemainder.kt");
         }
 
+        @TestMetadata("unsignedIntToString.kt")
+        public void testUnsignedIntToString() throws Exception {
+            runTest("compiler/testData/codegen/box/unsignedTypes/unsignedIntToString.kt");
+        }
+
         @TestMetadata("unsignedLiteralsForMaxLongValue.kt")
         public void testUnsignedLiteralsForMaxLongValue() throws Exception {
             runTest("compiler/testData/codegen/box/unsignedTypes/unsignedLiteralsForMaxLongValue.kt");
@@ -24113,6 +24118,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         @TestMetadata("unsignedLongRemainder.kt")
         public void testUnsignedLongRemainder() throws Exception {
             runTest("compiler/testData/codegen/box/unsignedTypes/unsignedLongRemainder.kt");
+        }
+
+        @TestMetadata("unsignedLongToString.kt")
+        public void testUnsignedLongToString() throws Exception {
+            runTest("compiler/testData/codegen/box/unsignedTypes/unsignedLongToString.kt");
         }
 
         @TestMetadata("unsignedRangeIterator.kt")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
@@ -3535,6 +3535,11 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
             runTest("compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedIntRemainder_jvm18.kt");
         }
 
+        @TestMetadata("unsignedIntToString_jvm18.kt")
+        public void testUnsignedIntToString_jvm18() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedIntToString_jvm18.kt");
+        }
+
         @TestMetadata("unsignedLongCompare_jvm18.kt")
         public void testUnsignedLongCompare_jvm18() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedLongCompare_jvm18.kt");
@@ -3548,6 +3553,11 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
         @TestMetadata("unsignedLongRemainder_jvm18.kt")
         public void testUnsignedLongRemainder_jvm18() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedLongRemainder_jvm18.kt");
+        }
+
+        @TestMetadata("unsignedLongToString_jvm18.kt")
+        public void testUnsignedLongToString_jvm18() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedLongToString_jvm18.kt");
         }
 
         @TestMetadata("whenByUnsigned.kt")

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -19360,6 +19360,11 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/unsignedTypes/unsignedIntRemainder.kt");
         }
 
+        @TestMetadata("unsignedIntToString.kt")
+        public void testUnsignedIntToString() throws Exception {
+            runTest("compiler/testData/codegen/box/unsignedTypes/unsignedIntToString.kt");
+        }
+
         @TestMetadata("unsignedLiteralsForMaxLongValue.kt")
         public void testUnsignedLiteralsForMaxLongValue() throws Exception {
             runTest("compiler/testData/codegen/box/unsignedTypes/unsignedLiteralsForMaxLongValue.kt");
@@ -19383,6 +19388,11 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
         @TestMetadata("unsignedLongRemainder.kt")
         public void testUnsignedLongRemainder() throws Exception {
             runTest("compiler/testData/codegen/box/unsignedTypes/unsignedLongRemainder.kt");
+        }
+
+        @TestMetadata("unsignedLongToString.kt")
+        public void testUnsignedLongToString() throws Exception {
+            runTest("compiler/testData/codegen/box/unsignedTypes/unsignedLongToString.kt");
         }
 
         @TestMetadata("unsignedRangeIterator.kt")

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -20515,6 +20515,11 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/unsignedTypes/unsignedIntRemainder.kt");
         }
 
+        @TestMetadata("unsignedIntToString.kt")
+        public void testUnsignedIntToString() throws Exception {
+            runTest("compiler/testData/codegen/box/unsignedTypes/unsignedIntToString.kt");
+        }
+
         @TestMetadata("unsignedLiteralsForMaxLongValue.kt")
         public void testUnsignedLiteralsForMaxLongValue() throws Exception {
             runTest("compiler/testData/codegen/box/unsignedTypes/unsignedLiteralsForMaxLongValue.kt");
@@ -20538,6 +20543,11 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
         @TestMetadata("unsignedLongRemainder.kt")
         public void testUnsignedLongRemainder() throws Exception {
             runTest("compiler/testData/codegen/box/unsignedTypes/unsignedLongRemainder.kt");
+        }
+
+        @TestMetadata("unsignedLongToString.kt")
+        public void testUnsignedLongToString() throws Exception {
+            runTest("compiler/testData/codegen/box/unsignedTypes/unsignedLongToString.kt");
         }
 
         @TestMetadata("unsignedRangeIterator.kt")


### PR DESCRIPTION
Unfortunately this cannot currently be done for the extension overload which accepts a radix due to behavior difference with regard to invalid radix values.