### PR TITLE
KT-32365 "Convert to sealed class" intention should not be suggested when no "class" keyword

### DIFF
--- a/compiler/psi/src/org/jetbrains/kotlin/psi/KtClass.kt
+++ b/compiler/psi/src/org/jetbrains/kotlin/psi/KtClass.kt
@@ -52,6 +52,8 @@ open class KtClass : KtClassOrObject {
     override fun getCompanionObjects(): List<KtObjectDeclaration> = getBody()?.allCompanionObjects.orEmpty()
 
     fun getClassOrInterfaceKeyword(): PsiElement? = findChildByType(TokenSet.create(KtTokens.CLASS_KEYWORD, KtTokens.INTERFACE_KEYWORD))
+
+    fun getClassKeyword(): PsiElement? = findChildByType(KtTokens.CLASS_KEYWORD)
 }
 
 fun KtClass.createPrimaryConstructorIfAbsent(): KtPrimaryConstructor {

--- a/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertEnumToSealedClassIntention.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertEnumToSealedClassIntention.kt
@@ -31,6 +31,7 @@ import org.jetbrains.kotlin.psi.psiUtil.startOffset
 
 class ConvertEnumToSealedClassIntention : SelfTargetingRangeIntention<KtClass>(KtClass::class.java, "Convert to sealed class") {
     override fun applicabilityRange(element: KtClass): TextRange? {
+        if (element.getClassKeyword() == null) return null
         val nameIdentifier = element.nameIdentifier ?: return null
         val enumKeyword = element.modifierList?.getModifier(KtTokens.ENUM_KEYWORD) ?: return null
         return TextRange(enumKeyword.startOffset, nameIdentifier.endOffset)

--- a/idea/testData/intentions/convertEnumToSealedClass/noClassKeyword.kt
+++ b/idea/testData/intentions/convertEnumToSealedClass/noClassKeyword.kt
@@ -1,0 +1,4 @@
+// IS_APPLICABLE: false
+enum<caret> Foo {
+    A, B, C
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -4275,6 +4275,11 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
             runTest("idea/testData/intentions/convertEnumToSealedClass/membersOnly.kt");
         }
 
+        @TestMetadata("noClassKeyword.kt")
+        public void testNoClassKeyword() throws Exception {
+            runTest("idea/testData/intentions/convertEnumToSealedClass/noClassKeyword.kt");
+        }
+
         @TestMetadata("notEnum.kt")
         public void testNotEnum() throws Exception {
             runTest("idea/testData/intentions/convertEnumToSealedClass/notEnum.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-32365