### PR TITLE
KT-32580 "Remove braces" QF for single-expression function with inferred lambda return type: "ClassCastException: class kotlin.reflect.jvm.internal.KClassImpl cannot be cast to class kotlin.jvm.internal.ClassBasedDeclarationContainer"

### DIFF
--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/removeBraces/kt32580.kt
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/removeBraces/kt32580.kt
@@ -1,0 +1,6 @@
+// FIX: Remove braces
+class C {
+    fun f4() = {<caret>
+        "single-expression function which returns lambda"
+    }
+}

--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/removeBraces/kt32580.kt.after
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/removeBraces/kt32580.kt.after
@@ -1,0 +1,4 @@
+// FIX: Remove braces
+class C {
+    fun f4() = "single-expression function which returns lambda"
+}

--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/wrapRun/kt32580.kt
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/wrapRun/kt32580.kt
@@ -1,0 +1,7 @@
+// FIX: Convert to run { ... }
+// WITH_RUNTIME
+class C {
+    fun f4() = {<caret>
+        "single-expression function which returns lambda"
+    }
+}

--- a/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/wrapRun/kt32580.kt.after
+++ b/idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/wrapRun/kt32580.kt.after
@@ -1,0 +1,5 @@
+// FIX: Convert to run { ... }
+// WITH_RUNTIME
+class C {
+    fun f4() = run { "single-expression function which returns lambda" }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -4534,6 +4534,11 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
             public void testGetterReturnsNothing() throws Exception {
                 runTest("idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/removeBraces/getterReturnsNothing.kt");
             }
+
+            @TestMetadata("kt32580.kt")
+            public void testKt32580() throws Exception {
+                runTest("idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/removeBraces/kt32580.kt");
+            }
         }
 
         @TestMetadata("idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/specifyType")
@@ -4589,6 +4594,11 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
             @TestMetadata("getterReturnsNothing.kt")
             public void testGetterReturnsNothing() throws Exception {
                 runTest("idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/wrapRun/getterReturnsNothing.kt");
+            }
+
+            @TestMetadata("kt32580.kt")
+            public void testKt32580() throws Exception {
+                runTest("idea/testData/inspectionsLocal/functionWithLambdaExpressionBody/wrapRun/kt32580.kt");
             }
         }
     }


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-32580