### PR TITLE
Handle classpath snapshot changes better

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/test/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/incremental/ClasspathSnapshotTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/test/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/incremental/ClasspathSnapshotTest.kt
@@ -83,6 +83,22 @@ class ClasspathSnapshotTest {
         assertEquals(setOf("library/C", "first/A", "first/B"), diff.names)
     }
 
+    @Test
+    fun testNoChangedFileButPathsChanged() {
+        val dataFile = generateStructureData(
+            ClassData("first/A"),
+            ClassData("first/B").also { it.withAbiDependencies("first/A") }
+        )
+        val firstSnapshot = ClasspathSnapshot.ClasspathSnapshotFactory.createCurrent(tmp.newFolder(), listOf(), setOf(dataFile))
+        firstSnapshot.writeToCache()
+
+        val copyOfDataFile = dataFile.copyTo(tmp.newFile(), overwrite = true)
+        val secondSnapshot = ClasspathSnapshot.ClasspathSnapshotFactory.createCurrent(tmp.newFolder(), listOf(), setOf(copyOfDataFile))
+
+        val diff = secondSnapshot.diff(firstSnapshot, setOf()) as KaptClasspathChanges.Known
+        assertEquals(emptySet<String>(), diff.names)
+    }
+
     private fun generateStructureData(vararg classData: ClassData, outputFile: File = tmp.newFile()): File {
         val data = ClasspathEntryData()
         classData.forEach {


### PR DESCRIPTION
Because Kapt Gradle task uses PathSensitivity.NONE for the input representing
the classpath structure, there are cases when paths of the files may change,
but because content is the same, there will be no incremental changes.

Classpath snapshot comparison did not handle this case correctly, but this
commit fixes that. In more details:
- classpath entries with the same path and that are not reported as changed
will have their information loaded from the previous snapshot
- any other entry (changed path or changed content) will be reloaded

Test: ClasspathSnapshotTest