### PR TITLE
Mark property as output instead of local state when needed

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/Kapt3KotlinGradleSubplugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/Kapt3KotlinGradleSubplugin.kt
@@ -391,6 +391,11 @@ class Kapt3KotlinGradleSubplugin : KotlinGradleSubplugin<KotlinCompile> {
         kaptTask.isIncremental = project.isIncrementalKapt()
         if (kaptTask.isIncremental) {
             kaptTask.incAptCache = getKaptIncrementalAnnotationProcessingCache()
+            if (isGradleVersionAtLeast(4, 3)) {
+                kaptTask.localState.register(kaptTask.incAptCache)
+            } else {
+                kaptTask.outputs.files(kaptTask.incAptCache).withPropertyName("incrementalAptCache")
+            }
 
             maybeRegisterTransform(project)
             val classStructure = project.configurations.create("_classStructure${taskName}")

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/KaptTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/KaptTask.kt
@@ -57,9 +57,12 @@ abstract class KaptTask : ConventionTask(), TaskWithLocalState {
     @get:InputFiles
     internal var classpathStructure: FileCollection? = null
 
-    /** Output directory that contains caches necessary to support incremental annotation processing. */
-    @get:LocalState
-    @get:Optional
+    /**
+     * Output directory that contains caches necessary to support incremental annotation processing.
+     * [LocalState] should be used here, but in order to be compatible with Gradle 4.2, correct input
+     * annotations are specified during task configuration.
+     */
+    @get:Internal
     var incAptCache: File? = null
 
     @get:OutputDirectory


### PR DESCRIPTION
Kapt task incremental annotation processing cache directory
was using @LocalState annotation that was added in Gradle 4.3.
However, minimum supported version is 4.2, so this commit registers
this directory as output of a task for pre 4.3 versions. This is safe
as caching is enabled only for Gradle 4.3+.

Test: verified manually