### PR TITLE
KT-31295 Scratches as project files

### DIFF
--- a/generators/tests/org/jetbrains/kotlin/generators/tests/GenerateTests.kt
+++ b/generators/tests/org/jetbrains/kotlin/generators/tests/GenerateTests.kt
@@ -807,9 +807,13 @@ fun main(args: Array<String>) {
         }
 
         testClass<AbstractScratchRunActionTest> {
-            model("scratch", extension = "kts", testMethod = "doCompilingTest", testClassName = "Compiling", recursive = false)
-            model("scratch", extension = "kts", testMethod = "doReplTest", testClassName = "Repl", recursive = false)
-            model("scratch/multiFile", extension = null, testMethod = "doMultiFileTest", recursive = false)
+            model("scratch", extension = "kts", testMethod = "doScratchCompilingTest", testClassName = "ScratchCompiling", recursive = false)
+            model("scratch", extension = "kts", testMethod = "doScratchReplTest", testClassName = "ScratchRepl", recursive = false)
+            model("scratch/multiFile", extension = null, testMethod = "doScratchMultiFileTest", testClassName = "ScratchMultiFile", recursive = false)
+
+            model("worksheet", extension = "ws.kts", testMethod = "doWorksheetCompilingTest", testClassName = "WorksheetCompiling", recursive = false)
+            model("worksheet", extension = "ws.kts", testMethod = "doWorksheetReplTest", testClassName = "WorksheetRepl", recursive = false)
+            model("worksheet/multiFile", extension = null, testMethod = "doWorksheetMultiFileTest", testClassName = "WorksheetMultiFile", recursive = false)
         }
 
         testClass<AbstractScratchLineMarkersTest> {

--- a/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/ScratchFileModuleInfoProvider.kt
+++ b/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/ScratchFileModuleInfoProvider.kt
@@ -27,6 +27,7 @@ import org.jetbrains.kotlin.idea.core.script.scriptRelatedModuleName
 import org.jetbrains.kotlin.idea.scratch.ui.ScratchPanelListener
 import org.jetbrains.kotlin.idea.scratch.ui.ScratchTopPanel
 import org.jetbrains.kotlin.idea.util.application.runWriteAction
+import org.jetbrains.kotlin.idea.util.projectStructure.getModule
 import org.jetbrains.kotlin.parsing.KotlinParserDefinition.Companion.STD_SCRIPT_EXT
 import org.jetbrains.kotlin.parsing.KotlinParserDefinition.Companion.STD_SCRIPT_SUFFIX
 import org.jetbrains.kotlin.psi.KtFile
@@ -67,8 +68,13 @@ class ScratchFileModuleInfoProvider(val project: Project) : ProjectComponent {
                     DaemonCodeAnalyzer.getInstance(project).restart(psiFile)
                 }
 
-                val module = ktFile.virtualFile.scriptRelatedModuleName?.let { ModuleManager.getInstance(project).findModuleByName(it) }
-                if (module != null) {
+                if (file.isKotlinWorksheet) {
+                    panel.hideModuleSelector()
+
+                    val module = file.getModule(project) ?: return
+                    panel.setModule(module)
+                } else {
+                    val module = file.scriptRelatedModuleName?.let { ModuleManager.getInstance(project).findModuleByName(it) } ?: return
                     panel.setModule(module)
                 }
             }

--- a/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/actions/ScratchRunLineMarkerContributor.kt
+++ b/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/actions/ScratchRunLineMarkerContributor.kt
@@ -6,8 +6,6 @@
 package org.jetbrains.kotlin.idea.scratch.actions
 
 import com.intellij.execution.lineMarker.RunLineMarkerContributor
-import com.intellij.ide.scratch.ScratchFileService
-import com.intellij.ide.scratch.ScratchRootType
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiWhiteSpace
@@ -17,6 +15,8 @@ import org.jetbrains.kotlin.idea.core.util.getLineCount
 import org.jetbrains.kotlin.idea.refactoring.getLineNumber
 import org.jetbrains.kotlin.idea.scratch.ScratchExpression
 import org.jetbrains.kotlin.idea.scratch.getEditorWithScratchPanel
+import org.jetbrains.kotlin.idea.scratch.isKotlinScratch
+import org.jetbrains.kotlin.idea.scratch.isKotlinWorksheet
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.findDescendantOfType
 import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
@@ -27,7 +27,7 @@ class ScratchRunLineMarkerContributor : RunLineMarkerContributor() {
         val ktFile = element.containingFile as? KtFile
         if (ktFile?.isScript() != true) return null
         val file = ktFile.virtualFile
-        if (ScratchFileService.getInstance().getRootType(file) !is ScratchRootType) return null
+        if (!(file.isKotlinScratch || file.isKotlinWorksheet)) return null
 
         val declaration = element.getStrictParentOfType<KtNamedDeclaration>()
         if (declaration != null && declaration !is KtParameter && declaration.nameIdentifier == element) {

--- a/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/scratchUtils.kt
+++ b/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/scratchUtils.kt
@@ -5,6 +5,8 @@
 
 package org.jetbrains.kotlin.idea.scratch
 
+import com.intellij.ide.scratch.ScratchFileService
+import com.intellij.ide.scratch.ScratchRootType
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.TextEditor
@@ -13,6 +15,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.Key
 import com.intellij.openapi.vfs.VirtualFile
+import org.jetbrains.kotlin.idea.actions.KOTLIN_WORKSHEET_EXTENSION
 import org.jetbrains.kotlin.idea.scratch.ui.ScratchPanelListener
 import org.jetbrains.kotlin.idea.scratch.ui.ScratchTopPanel
 import org.jetbrains.kotlin.idea.syncPublisherWithDisposeCheck
@@ -22,6 +25,12 @@ internal val LOG = Logger.getInstance("#org.jetbrains.kotlin.idea.scratch")
 internal fun Logger.printDebugMessage(str: String) {
     if (isDebugEnabled) debug("SCRATCH: $str")
 }
+
+val VirtualFile.isKotlinWorksheet: Boolean
+    get() = name.endsWith(".$KOTLIN_WORKSHEET_EXTENSION")
+
+val VirtualFile.isKotlinScratch: Boolean
+    get() = ScratchFileService.getInstance().getRootType(this) is ScratchRootType
 
 fun getEditorWithoutScratchPanel(fileManager: FileEditorManager, virtualFile: VirtualFile): TextEditor? {
     val editor = fileManager.getSelectedEditor(virtualFile) as? TextEditor

--- a/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/ui/ScratchFileHook.kt
+++ b/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/ui/ScratchFileHook.kt
@@ -16,8 +16,6 @@
 
 package org.jetbrains.kotlin.idea.scratch.ui
 
-import com.intellij.ide.scratch.ScratchFileService
-import com.intellij.ide.scratch.ScratchRootType
 import com.intellij.openapi.components.ProjectComponent
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.FileEditorManagerListener
@@ -52,7 +50,7 @@ class ScratchFileHook(val project: Project) : ProjectComponent {
 
     private fun isPluggable(file: VirtualFile): Boolean {
         if (!file.isValid) return false
-        if (ScratchFileService.getInstance().getRootType(file) !is ScratchRootType) return false
+        if (!(file.isKotlinScratch || file.isKotlinWorksheet)) return false
         val psiFile = PsiManager.getInstance(project).findFile(file) ?: return false
         return ScratchFileLanguageProvider.get(psiFile.fileType) != null
     }

--- a/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/ui/ScratchTopPanel.kt
+++ b/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/ui/ScratchTopPanel.kt
@@ -92,6 +92,7 @@ class ScratchTopPanel private constructor(val scratchFile: ScratchFile) : JPanel
     }
 
     private val moduleChooser: ModulesComboBox
+    private val moduleChooserLabel: JLabel
     private val isReplCheckbox: JCheckBox
     private val isMakeBeforeRunCheckbox: JCheckBox
     private val isInteractiveCheckbox: JCheckBox
@@ -104,7 +105,8 @@ class ScratchTopPanel private constructor(val scratchFile: ScratchFile) : JPanel
         add(actionsToolbar.component)
 
         moduleChooser = createModuleChooser(scratchFile.project)
-        add(JLabel("Use classpath of module"))
+        moduleChooserLabel = JLabel("Use classpath of module")
+        add(moduleChooserLabel)
         add(moduleChooser)
 
         isMakeBeforeRunCheckbox = JCheckBox("Make module before Run")
@@ -160,6 +162,11 @@ class ScratchTopPanel private constructor(val scratchFile: ScratchFile) : JPanel
         moduleChooser.selectedModule = module
     }
 
+    fun hideModuleSelector() {
+        moduleChooser.isVisible = false
+        moduleChooserLabel.isVisible = false
+    }
+
     fun addModuleListener(f: (PsiFile, Module?) -> Unit) {
         moduleChooser.addActionListener {
             val selectedModule = moduleChooser.selectedModule
@@ -187,6 +194,9 @@ class ScratchTopPanel private constructor(val scratchFile: ScratchFile) : JPanel
     fun setInteractiveMode(isSelected: Boolean) {
         isInteractiveCheckbox.isSelected = isSelected
     }
+
+    @TestOnly
+    fun isModuleSelectorVisible(): Boolean = moduleChooser.isVisible && moduleChooserLabel.isVisible
 
     private fun changeMakeModuleCheckboxVisibility(isVisible: Boolean) {
         isMakeBeforeRunCheckbox.isVisible = isVisible

--- a/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/ui/ScratchTopPanel.kt
+++ b/idea/idea-jvm/src/org/jetbrains/kotlin/idea/scratch/ui/ScratchTopPanel.kt
@@ -107,7 +107,7 @@ class ScratchTopPanel private constructor(val scratchFile: ScratchFile) : JPanel
         add(JLabel("Use classpath of module"))
         add(moduleChooser)
 
-        isMakeBeforeRunCheckbox = JCheckBox("Make before Run")
+        isMakeBeforeRunCheckbox = JCheckBox("Make module before Run")
         add(isMakeBeforeRunCheckbox)
         isMakeBeforeRunCheckbox.addItemListener {
             scratchFile.saveOptions {

--- a/idea/resources/META-INF/plugin-common.xml
+++ b/idea/resources/META-INF/plugin-common.xml
@@ -51,6 +51,9 @@
     <action id="Kotlin.NewScript" class="org.jetbrains.kotlin.idea.actions.NewKotlinScriptAction">
       <add-to-group group-id="NewGroup" anchor="before" relative-to-action="NewFromTemplate"/>
     </action>
+    <action id="Kotlin.NewWorksheet" class="org.jetbrains.kotlin.idea.actions.NewKotlinWorksheetAction">
+      <add-to-group group-id="NewGroup" anchor="before" relative-to-action="NewFromTemplate"/>
+    </action>
 
     <group id = "ConvertJavaToKotlinGroup">
       <separator/>
@@ -381,6 +384,7 @@
     <internalFileTemplate name="Kotlin Class"/>
     <internalFileTemplate name="Kotlin Enum"/>
     <internalFileTemplate name="Kotlin Interface"/>
+    <internalFileTemplate name="Kotlin Worksheet"/>
     <internalFileTemplate name="Kotlin Script"/>
 
     <gotoSymbolContributor implementation="org.jetbrains.kotlin.idea.goto.KotlinGotoSymbolContributor"/>

--- a/idea/resources/fileTemplates/internal/Kotlin Worksheet.kts.html
+++ b/idea/resources/fileTemplates/internal/Kotlin Worksheet.kts.html
@@ -1,0 +1,14 @@
+<html>
+<body>
+<table border="0" cellpadding="2" cellspacing="0" style="border-collapse: collapse">
+  <tr>
+    <td colspan="3">
+      <font face="verdana" size="-1">
+        This is a built-in template used by <b>IDEA</b> each time you create a
+        Kotlin Worksheet
+      </font>
+    </td>
+  </tr>
+</table>
+</body>
+</html>

--- a/idea/src/org/jetbrains/kotlin/idea/actions/NewKotlinFileAction.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/actions/NewKotlinFileAction.kt
@@ -46,6 +46,7 @@ import org.jetbrains.kotlin.idea.statistics.FUSEventGroups
 import org.jetbrains.kotlin.idea.statistics.KotlinFUSLogger
 import org.jetbrains.kotlin.idea.util.application.runWriteAction
 import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.parsing.KotlinParserDefinition.Companion.STD_SCRIPT_SUFFIX
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtNamedDeclaration
@@ -148,7 +149,7 @@ class NewKotlinFileAction : CreateFileFromTemplateAction(
             get() = NameValidator
 
         private fun findOrCreateTarget(dir: PsiDirectory, name: String, directorySeparators: CharArray): Pair<String, PsiDirectory> {
-            var className = name.substringBeforeLast(".kt")
+            var className = removeKotlinExtensionIfPresent(name)
             var targetDir = dir
 
             for (splitChar in directorySeparators) {
@@ -166,6 +167,13 @@ class NewKotlinFileAction : CreateFileFromTemplateAction(
                 }
             }
             return Pair(className, targetDir)
+        }
+
+        private fun removeKotlinExtensionIfPresent(name: String): String = when {
+            name.endsWith(".$KOTLIN_WORKSHEET_EXTENSION") -> name.removeSuffix(".$KOTLIN_WORKSHEET_EXTENSION")
+            name.endsWith(".$STD_SCRIPT_SUFFIX") -> name.removeSuffix(".$STD_SCRIPT_SUFFIX")
+            name.endsWith(".${KotlinFileType.EXTENSION}") -> name.removeSuffix(".${KotlinFileType.EXTENSION}")
+            else -> name
         }
 
         private fun createFromTemplate(dir: PsiDirectory, className: String, template: FileTemplate): PsiFile? {

--- a/idea/src/org/jetbrains/kotlin/idea/actions/NewKotlinScriptAction.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/actions/NewKotlinScriptAction.kt
@@ -16,11 +16,23 @@ import com.intellij.psi.PsiFile
 import org.jetbrains.kotlin.idea.KotlinIcons
 import org.jetbrains.kotlin.psi.KtFile
 
-class NewKotlinScriptAction : CreateFileFromTemplateAction(
-    "Kotlin Script",
-    "Creates new Kotlin script",
+open class NewKotlinScriptAction(
+    val actionName: String,
+    val description: String,
+    val dialogTitle: String,
+    val templateName: String
+) : CreateFileFromTemplateAction(
+    actionName,
+    description,
     KotlinIcons.SCRIPT
 ), DumbAware {
+
+    constructor() : this(
+        actionName = "Kotlin Script",
+        description = "Creates new Kotlin script",
+        dialogTitle = "New Kotlin Script",
+        templateName = "Kotlin Script"
+    )
 
     override fun postProcess(createdElement: PsiFile, templateName: String?, customProperties: Map<String, String>?) {
         super.postProcess(createdElement, templateName, customProperties)
@@ -33,18 +45,18 @@ class NewKotlinScriptAction : CreateFileFromTemplateAction(
     }
 
     override fun buildDialog(project: Project, directory: PsiDirectory, builder: CreateFileFromTemplateDialog.Builder) {
-        builder.setTitle("New Kotlin Script")
-            .addKind("Kotlin Script", KotlinIcons.SCRIPT, "Kotlin Script")
+        builder.setTitle(dialogTitle)
+            .addKind(actionName, KotlinIcons.SCRIPT, templateName)
     }
 
     override fun createFileFromTemplate(name: String, template: FileTemplate, dir: PsiDirectory) =
         NewKotlinFileAction.createFileFromTemplateWithStat(name, template, dir)
 
-    override fun getActionName(directory: PsiDirectory, newName: String, templateName: String) = "Kotlin Script"
+    override fun getActionName(directory: PsiDirectory, newName: String, templateName: String) = actionName
 
     override fun startInWriteAction() = false
 
     override fun hashCode(): Int = 0
 
-    override fun equals(other: Any?): Boolean = other is NewKotlinScriptAction
+    override fun equals(other: Any?): Boolean = this::class.isInstance(other)
 }

--- a/idea/src/org/jetbrains/kotlin/idea/actions/NewKotlinWorksheetAction.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/actions/NewKotlinWorksheetAction.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.idea.actions
+
+import com.intellij.ide.fileTemplates.FileTemplate
+import com.intellij.psi.PsiDirectory
+import com.intellij.psi.PsiFile
+
+const val KOTLIN_WORKSHEET_EXTENSION: String = "ws.kts"
+
+class NewKotlinWorksheetAction : NewKotlinScriptAction(
+    actionName = "Kotlin Worksheet",
+    description = "Creates new Kotlin Worksheet",
+    dialogTitle = "New Kotlin Worksheet",
+    templateName = "Kotlin Worksheet"
+) {
+
+    override fun createFileFromTemplate(name: String, template: FileTemplate, dir: PsiDirectory): PsiFile? {
+        val kotlinWorksheetTemplate = object : FileTemplate by template {
+            override fun getExtension(): String = KOTLIN_WORKSHEET_EXTENSION
+        }
+
+        return super.createFileFromTemplate(name, kotlinWorksheetTemplate, dir)
+    }
+}

--- a/idea/testData/worksheet/multiFile/inlineFunScriptRuntime/inlineFunScriptRuntime.ws.comp.after
+++ b/idea/testData/worksheet/multiFile/inlineFunScriptRuntime/inlineFunScriptRuntime.ws.comp.after
@@ -1,0 +1,5 @@
+// REPL_MODE: false
+
+import inlineFun.*
+
+foo { 1 + 3 }         // RESULT: 4

--- a/idea/testData/worksheet/multiFile/inlineFunScriptRuntime/inlineFunScriptRuntime.ws.kts
+++ b/idea/testData/worksheet/multiFile/inlineFunScriptRuntime/inlineFunScriptRuntime.ws.kts
@@ -1,0 +1,5 @@
+// REPL_MODE: ~REPL_MODE~
+
+import inlineFun.*
+
+foo { 1 + 3 }

--- a/idea/testData/worksheet/multiFile/inlineFunScriptRuntime/inlineFunScriptRuntime.ws.repl.after
+++ b/idea/testData/worksheet/multiFile/inlineFunScriptRuntime/inlineFunScriptRuntime.ws.repl.after
@@ -1,0 +1,5 @@
+// REPL_MODE: true
+
+import inlineFun.*
+
+foo { 1 + 3 }         // RESULT: res1: kotlin.Int = 4

--- a/idea/testData/worksheet/multiFile/inlineFunScriptRuntime/myFun.kt
+++ b/idea/testData/worksheet/multiFile/inlineFunScriptRuntime/myFun.kt
@@ -1,0 +1,3 @@
+package inlineFun
+
+inline fun foo(f: () -> Int): Int = f()

--- a/idea/testData/worksheet/multiFile/javaDepScriptRuntime/javaDepScriptRuntime.ws.comp.after
+++ b/idea/testData/worksheet/multiFile/javaDepScriptRuntime/javaDepScriptRuntime.ws.comp.after
@@ -1,0 +1,5 @@
+// REPL_MODE: false
+
+import myTest.MyJavaClass
+
+MyJavaClass().test()         // RESULT: 1

--- a/idea/testData/worksheet/multiFile/javaDepScriptRuntime/javaDepScriptRuntime.ws.kts
+++ b/idea/testData/worksheet/multiFile/javaDepScriptRuntime/javaDepScriptRuntime.ws.kts
@@ -1,0 +1,5 @@
+// REPL_MODE: ~REPL_MODE~
+
+import myTest.MyJavaClass
+
+MyJavaClass().test()

--- a/idea/testData/worksheet/multiFile/javaDepScriptRuntime/javaDepScriptRuntime.ws.repl.after
+++ b/idea/testData/worksheet/multiFile/javaDepScriptRuntime/javaDepScriptRuntime.ws.repl.after
@@ -1,0 +1,5 @@
+// REPL_MODE: true
+
+import myTest.MyJavaClass
+
+MyJavaClass().test()         // RESULT: res1: kotlin.Int = 1

--- a/idea/testData/worksheet/multiFile/javaDepScriptRuntime/myTest/MyJavaClass.java
+++ b/idea/testData/worksheet/multiFile/javaDepScriptRuntime/myTest/MyJavaClass.java
@@ -1,0 +1,7 @@
+package myTest;
+
+public class MyJavaClass {
+    public int test() {
+        return 1;
+    }
+}

--- a/idea/testData/worksheet/simpleScriptRuntime.ws.comp.after
+++ b/idea/testData/worksheet/simpleScriptRuntime.ws.comp.after
@@ -1,0 +1,4 @@
+// REPL_MODE: false
+
+val a = 1    // RESULT: val a: Int
+a            // RESULT: 1

--- a/idea/testData/worksheet/simpleScriptRuntime.ws.kts
+++ b/idea/testData/worksheet/simpleScriptRuntime.ws.kts
@@ -1,0 +1,4 @@
+// REPL_MODE: ~REPL_MODE~
+
+val a = 1
+a

--- a/idea/testData/worksheet/simpleScriptRuntime.ws.repl.after
+++ b/idea/testData/worksheet/simpleScriptRuntime.ws.repl.after
@@ -1,0 +1,4 @@
+// REPL_MODE: true
+
+val a = 1
+a            // RESULT: res1: kotlin.Int = 1

--- a/idea/tests/org/jetbrains/kotlin/idea/scratch/AbstractScratchRunActionTest.kt
+++ b/idea/tests/org/jetbrains/kotlin/idea/scratch/AbstractScratchRunActionTest.kt
@@ -192,7 +192,9 @@ abstract class AbstractScratchRunActionTest : FileEditorManagerTestCase() {
         val (_, scratchPanel) = getEditorWithScratchPanel(myManager, myFixture.file.virtualFile)
             ?: error("Couldn't find scratch panel")
 
-        configureOptions(scratchPanel, text, myFixture.module)
+        // We want to check that correct module is selected automatically,
+        // that's why we set `module` to null so it wouldn't be changed
+        configureOptions(scratchPanel, text, null)
 
         return scratchPanel
     }

--- a/idea/tests/org/jetbrains/kotlin/idea/scratch/AbstractScratchRunActionTest.kt
+++ b/idea/tests/org/jetbrains/kotlin/idea/scratch/AbstractScratchRunActionTest.kt
@@ -22,6 +22,7 @@ import com.intellij.testFramework.TestActionEvent
 import com.intellij.util.ui.UIUtil
 import org.jetbrains.kotlin.codegen.forTestCompile.ForTestCompileRuntime
 import org.jetbrains.kotlin.idea.KotlinLanguage
+import org.jetbrains.kotlin.idea.actions.KOTLIN_WORKSHEET_EXTENSION
 import org.jetbrains.kotlin.idea.core.script.ScriptDependenciesManager
 import org.jetbrains.kotlin.idea.highlighter.KotlinHighlightingUtil
 import org.jetbrains.kotlin.idea.scratch.actions.ClearScratchAction
@@ -34,6 +35,7 @@ import org.jetbrains.kotlin.idea.test.KotlinLightProjectDescriptor
 import org.jetbrains.kotlin.idea.test.KotlinWithJdkAndRuntimeLightProjectDescriptor
 import org.jetbrains.kotlin.idea.test.PluginTestCaseBase
 import org.jetbrains.kotlin.idea.util.application.runWriteAction
+import org.jetbrains.kotlin.parsing.KotlinParserDefinition.Companion.STD_SCRIPT_SUFFIX
 import org.jetbrains.kotlin.test.InTextDirectivesUtils
 import org.jetbrains.kotlin.test.KotlinTestUtils
 import org.jetbrains.kotlin.test.MockLibraryUtil
@@ -42,15 +44,34 @@ import org.junit.Assert
 import java.io.File
 
 abstract class AbstractScratchRunActionTest : FileEditorManagerTestCase() {
-    fun doReplTest(fileName: String) {
-        doTest(fileName, true)
+
+    fun doWorksheetReplTest(fileName: String) {
+        doTest(fileName = fileName, isRepl = true, isWorksheet = true)
     }
 
-    fun doCompilingTest(fileName: String) {
-        doTest(fileName, false)
+    fun doScratchReplTest(fileName: String) {
+        doTest(fileName = fileName, isRepl = true, isWorksheet = false)
     }
 
-    fun doMultiFileTest(dirName: String) {
+    fun doWorksheetCompilingTest(fileName: String) {
+        doTest(fileName = fileName, isRepl = false, isWorksheet = true)
+    }
+
+    fun doScratchCompilingTest(fileName: String) {
+        doTest(fileName = fileName, isRepl = false, isWorksheet = false)
+    }
+
+    fun doWorksheetMultiFileTest(dirName: String) {
+        doMultiFileTest(dirName, isWorksheet = true)
+    }
+
+    fun doScratchMultiFileTest(dirName: String) {
+        doMultiFileTest(dirName, isWorksheet = false)
+    }
+
+    private fun doMultiFileTest(dirName: String, isWorksheet: Boolean) {
+        val mainFileExtension = if (isWorksheet) KOTLIN_WORKSHEET_EXTENSION else STD_SCRIPT_SUFFIX
+
         val javaFiles = arrayListOf<File>()
         val kotlinFiles = arrayListOf<File>()
         val baseDir = File(testDataPath, dirName)
@@ -75,23 +96,27 @@ abstract class AbstractScratchRunActionTest : FileEditorManagerTestCase() {
 
         PsiTestUtil.setCompilerOutputPath(myFixture.module, outputDir.path, false)
 
-        val mainFileName = "$dirName/${getTestName(true)}.kts"
-        doCompilingTest(mainFileName)
+        val mainFileName = "$dirName/${getTestName(true)}.$mainFileExtension"
+        doTest(mainFileName, isRepl = false, isWorksheet = isWorksheet)
 
         launchAction(ClearScratchAction())
 
-        doReplTest(mainFileName)
+        doTest(mainFileName, isRepl = true, isWorksheet = isWorksheet)
 
         ModuleRootModificationUtil.updateModel(myFixture.module) { model ->
             model.getModuleExtension(CompilerModuleExtension::class.java).inheritCompilerOutputPath(true)
         }
     }
 
-    fun doTest(fileName: String, isRepl: Boolean) {
+    fun doTest(fileName: String, isRepl: Boolean, isWorksheet: Boolean) {
         val sourceFile = File(testDataPath, fileName)
         val fileText = sourceFile.readText().inlinePropertiesValues(isRepl)
 
-        configureScratchByText(sourceFile.name, fileText)
+        if (isWorksheet) {
+            configureWorksheetByText(sourceFile.name, fileText)
+        } else {
+            configureScratchByText(sourceFile.name, fileText)
+        }
 
         if (!KotlinHighlightingUtil.shouldHighlight(myFixture.file)) error("Highlighting for scratch file is switched off")
 
@@ -159,6 +184,20 @@ abstract class AbstractScratchRunActionTest : FileEditorManagerTestCase() {
         return scratchPanel
     }
 
+    protected fun configureWorksheetByText(name: String, text: String): ScratchTopPanel {
+        val worksheetFile = myFixture.configureByText(name, text).virtualFile
+
+        ScriptDependenciesManager.updateScriptDependenciesSynchronously(worksheetFile, project)
+
+        val (_, scratchPanel) = getEditorWithScratchPanel(myManager, myFixture.file.virtualFile)
+            ?: error("Couldn't find scratch panel")
+
+        configureOptions(scratchPanel, text, myFixture.module)
+
+        return scratchPanel
+    }
+
+
     protected fun launchScratch() {
         val action = RunScratchAction()
         launchAction(action)
@@ -204,6 +243,7 @@ abstract class AbstractScratchRunActionTest : FileEditorManagerTestCase() {
         return when {
             testName.endsWith("WithKotlinTest") -> INSTANCE_WITH_KOTLIN_TEST
             testName.endsWith("NoRuntime") -> INSTANCE_WITHOUT_RUNTIME
+            testName.endsWith("ScriptRuntime") -> INSTANCE_WITH_SCRIPT_RUNTIME
             else -> KotlinWithJdkAndRuntimeLightProjectDescriptor.INSTANCE_FULL_JDK
         }
     }
@@ -243,6 +283,15 @@ abstract class AbstractScratchRunActionTest : FileEditorManagerTestCase() {
         }
 
         private val INSTANCE_WITHOUT_RUNTIME = object : KotlinLightProjectDescriptor() {
+            override fun getSdk() = PluginTestCaseBase.fullJdk()
+        }
+
+        private val INSTANCE_WITH_SCRIPT_RUNTIME = object : KotlinWithJdkAndRuntimeLightProjectDescriptor(
+            arrayListOf(
+                ForTestCompileRuntime.runtimeJarForTests(),
+                ForTestCompileRuntime.scriptRuntimeJarForTests()
+            )
+        ) {
             override fun getSdk() = PluginTestCaseBase.fullJdk()
         }
 

--- a/idea/tests/org/jetbrains/kotlin/idea/scratch/ScratchOptionsTest.kt
+++ b/idea/tests/org/jetbrains/kotlin/idea/scratch/ScratchOptionsTest.kt
@@ -14,7 +14,7 @@ import kotlin.reflect.full.createType
 import kotlin.reflect.full.declaredMemberProperties
 
 @RunWith(JUnit3WithIdeaConfigurationRunner::class)
-class ScratchOptionsSaveTest : AbstractScratchRunActionTest() {
+class ScratchOptionsTest : AbstractScratchRunActionTest() {
 
     fun testOptionsSaveOnClosingFile() {
         val scratchPanelBeforeClosingFile = configureScratchByText("scratch_1.kts", testScratchText())
@@ -50,4 +50,27 @@ class ScratchOptionsSaveTest : AbstractScratchRunActionTest() {
             scratchPanelAfterClosingFile.scratchFile.options.isInteractiveMode
         )
     }
+
+    fun testModuleSelectionPanelIsVisibleForScratchFile() {
+        val scratchTopPanel = configureScratchByText("scratch_1.kts", testScratchText())
+
+        Assert.assertTrue("Module selector should be visible for scratches", scratchTopPanel.isModuleSelectorVisible())
+    }
+
+    fun testModuleSelectionPanelIsHiddenForWorksheetFile() {
+        val scratchTopPanel = configureWorksheetByText("worksheet.ws.kts", testScratchText())
+
+        Assert.assertFalse("Module selector should be hidden for worksheets", scratchTopPanel.isModuleSelectorVisible())
+    }
+
+    fun testCurrentModuleIsAutomaticallySelectedForWorksheetFile() {
+        val scratchTopPanel = configureWorksheetByText("worksheet.ws.kts", testScratchText())
+
+        Assert.assertEquals(
+            "Selected module should be equal to current project module for worksheets",
+            myFixture.module,
+            scratchTopPanel.getModule()
+        )
+    }
+
 }

--- a/idea/tests/org/jetbrains/kotlin/idea/scratch/ScratchRunActionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/scratch/ScratchRunActionTestGenerated.java
@@ -22,12 +22,12 @@ public class ScratchRunActionTestGenerated extends AbstractScratchRunActionTest 
     @TestMetadata("idea/testData/scratch")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)
-    public static class Compiling extends AbstractScratchRunActionTest {
+    public static class ScratchCompiling extends AbstractScratchRunActionTest {
         private void runTest(String testDataFilePath) throws Exception {
-            KotlinTestUtils.runTest(this::doCompilingTest, TargetBackend.ANY, testDataFilePath);
+            KotlinTestUtils.runTest(this::doScratchCompilingTest, TargetBackend.ANY, testDataFilePath);
         }
 
-        public void testAllFilesPresentInCompiling() throws Exception {
+        public void testAllFilesPresentInScratchCompiling() throws Exception {
             KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/scratch"), Pattern.compile("^(.+)\\.kts$"), TargetBackend.ANY, false);
         }
 
@@ -110,12 +110,12 @@ public class ScratchRunActionTestGenerated extends AbstractScratchRunActionTest 
     @TestMetadata("idea/testData/scratch")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)
-    public static class Repl extends AbstractScratchRunActionTest {
+    public static class ScratchRepl extends AbstractScratchRunActionTest {
         private void runTest(String testDataFilePath) throws Exception {
-            KotlinTestUtils.runTest(this::doReplTest, TargetBackend.ANY, testDataFilePath);
+            KotlinTestUtils.runTest(this::doScratchReplTest, TargetBackend.ANY, testDataFilePath);
         }
 
-        public void testAllFilesPresentInRepl() throws Exception {
+        public void testAllFilesPresentInScratchRepl() throws Exception {
             KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/scratch"), Pattern.compile("^(.+)\\.kts$"), TargetBackend.ANY, false);
         }
 
@@ -198,12 +198,12 @@ public class ScratchRunActionTestGenerated extends AbstractScratchRunActionTest 
     @TestMetadata("idea/testData/scratch/multiFile")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)
-    public static class MultiFile extends AbstractScratchRunActionTest {
+    public static class ScratchMultiFile extends AbstractScratchRunActionTest {
         private void runTest(String testDataFilePath) throws Exception {
-            KotlinTestUtils.runTest(this::doMultiFileTest, TargetBackend.ANY, testDataFilePath);
+            KotlinTestUtils.runTest(this::doScratchMultiFileTest, TargetBackend.ANY, testDataFilePath);
         }
 
-        public void testAllFilesPresentInMultiFile() throws Exception {
+        public void testAllFilesPresentInScratchMultiFile() throws Exception {
             KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/scratch/multiFile"), Pattern.compile("^([^\\.]+)$"), TargetBackend.ANY, false);
         }
 
@@ -215,6 +215,65 @@ public class ScratchRunActionTestGenerated extends AbstractScratchRunActionTest 
         @TestMetadata("javaDep")
         public void testJavaDep() throws Exception {
             runTest("idea/testData/scratch/multiFile/javaDep/");
+        }
+    }
+
+    @TestMetadata("idea/testData/worksheet")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class WorksheetCompiling extends AbstractScratchRunActionTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doWorksheetCompilingTest, TargetBackend.ANY, testDataFilePath);
+        }
+
+        public void testAllFilesPresentInWorksheetCompiling() throws Exception {
+            KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/worksheet"), Pattern.compile("^(.+)\\.ws.kts$"), TargetBackend.ANY, false);
+        }
+
+        @TestMetadata("simpleScriptRuntime.ws.kts")
+        public void testSimpleScriptRuntime() throws Exception {
+            runTest("idea/testData/worksheet/simpleScriptRuntime.ws.kts");
+        }
+    }
+
+    @TestMetadata("idea/testData/worksheet")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class WorksheetRepl extends AbstractScratchRunActionTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doWorksheetReplTest, TargetBackend.ANY, testDataFilePath);
+        }
+
+        public void testAllFilesPresentInWorksheetRepl() throws Exception {
+            KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/worksheet"), Pattern.compile("^(.+)\\.ws.kts$"), TargetBackend.ANY, false);
+        }
+
+        @TestMetadata("simpleScriptRuntime.ws.kts")
+        public void testSimpleScriptRuntime() throws Exception {
+            runTest("idea/testData/worksheet/simpleScriptRuntime.ws.kts");
+        }
+    }
+
+    @TestMetadata("idea/testData/worksheet/multiFile")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class WorksheetMultiFile extends AbstractScratchRunActionTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doWorksheetMultiFileTest, TargetBackend.ANY, testDataFilePath);
+        }
+
+        public void testAllFilesPresentInWorksheetMultiFile() throws Exception {
+            KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/worksheet/multiFile"), Pattern.compile("^([^\\.]+)$"), TargetBackend.ANY, false);
+        }
+
+        @TestMetadata("inlineFunScriptRuntime")
+        public void testInlineFunScriptRuntime() throws Exception {
+            runTest("idea/testData/worksheet/multiFile/inlineFunScriptRuntime/");
+        }
+
+        @TestMetadata("javaDepScriptRuntime")
+        public void testJavaDepScriptRuntime() throws Exception {
+            runTest("idea/testData/worksheet/multiFile/javaDepScriptRuntime/");
         }
     }
 }


### PR DESCRIPTION
Allows to open project files with `.ws.kts` extension (`ws` is for `worksheet`) as Kotlin Scratches.

All existing scratch functionality works except for the module selection - it is automatically set to the current module (i.e. to the module in which `.ws.kts` file is located).

https://youtrack.jetbrains.com/issue/KT-31295