### PR TITLE
KT-23880: Enable incremental APT mode with KAPT by default

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/Kapt3KotlinGradleSubplugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/Kapt3KotlinGradleSubplugin.kt
@@ -124,7 +124,7 @@ class Kapt3KotlinGradleSubplugin : KotlinGradleSubplugin<KotlinCompile> {
         }
 
         fun Project.isIncrementalKapt(): Boolean {
-            return hasProperty(INCREMENTAL_APT) && property(INCREMENTAL_APT) == "true"
+            return !(hasProperty(INCREMENTAL_APT) && property(INCREMENTAL_APT) == "false")
         }
 
         fun Project.isInfoAsWarnings(): Boolean {


### PR DESCRIPTION
The feature has been present since 1.3.30 behind a flag. This
commit enables it by default.

Before this PR is merged, https://github.com/JetBrains/kotlin/pull/2462 should be merged as KaptIncrementalIT.testAddNewLine test fails without it.