### PR TITLE
KT-10478  Move-statement doesn't work for methods with single-expression body and lambda as returning type

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/codeInsight/upDownMover/KotlinDeclarationMover.java
+++ b/idea/src/org/jetbrains/kotlin/idea/codeInsight/upDownMover/KotlinDeclarationMover.java
@@ -140,7 +140,17 @@ public class KotlinDeclarationMover extends AbstractKotlinUpDownMover {
     private static KtDeclaration getMovableDeclaration(@Nullable PsiElement element) {
         if (element == null) return null;
 
-        KtDeclaration declaration = PsiTreeUtil.getParentOfType(element, KtDeclaration.class, false);
+        KtDeclaration declaration = null;
+        if (element.getNode().getElementType() == KtTokens.LBRACE) {
+            KtLambdaExpression lambda = PsiTreeUtil.getParentOfType(element, KtLambdaExpression.class, true);
+            KtFunction function = PsiTreeUtil.getParentOfType(lambda, KtFunction.class, true);
+            if (function != null && function.getBodyExpression() == lambda) {
+                declaration = function;
+            }
+        }
+        if (declaration == null) {
+            declaration = PsiTreeUtil.getParentOfType(element, KtDeclaration.class, false);
+        }        
         if (declaration instanceof KtParameter) return null;
         if (declaration instanceof KtTypeParameter) {
             return getMovableDeclaration(declaration.getParent());

--- a/idea/testData/codeInsight/moveUpDown/classBodyDeclarations/function/singleLambdaExpressionFunction1.kt
+++ b/idea/testData/codeInsight/moveUpDown/classBodyDeclarations/function/singleLambdaExpressionFunction1.kt
@@ -1,0 +1,10 @@
+// MOVE: down
+fun a() {
+}
+
+<caret>fun b() = {
+    ""
+}
+
+fun c() {
+}

--- a/idea/testData/codeInsight/moveUpDown/classBodyDeclarations/function/singleLambdaExpressionFunction1.kt.after
+++ b/idea/testData/codeInsight/moveUpDown/classBodyDeclarations/function/singleLambdaExpressionFunction1.kt.after
@@ -1,0 +1,10 @@
+// MOVE: down
+fun a() {
+}
+
+fun c() {
+}
+
+<caret>fun b() = {
+    ""
+}

--- a/idea/testData/codeInsight/moveUpDown/classBodyDeclarations/function/singleLambdaExpressionFunction2.kt
+++ b/idea/testData/codeInsight/moveUpDown/classBodyDeclarations/function/singleLambdaExpressionFunction2.kt
@@ -1,0 +1,10 @@
+// MOVE: up
+fun a() {
+}
+
+fun c() {
+}
+
+<caret>fun b() = {
+    ""
+}

--- a/idea/testData/codeInsight/moveUpDown/classBodyDeclarations/function/singleLambdaExpressionFunction2.kt.after
+++ b/idea/testData/codeInsight/moveUpDown/classBodyDeclarations/function/singleLambdaExpressionFunction2.kt.after
@@ -1,0 +1,10 @@
+// MOVE: up
+fun a() {
+}
+
+<caret>fun b() = {
+    ""
+}
+
+fun c() {
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/codeInsight/moveUpDown/MoveStatementTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/codeInsight/moveUpDown/MoveStatementTestGenerated.java
@@ -399,6 +399,16 @@ public class MoveStatementTestGenerated extends AbstractMoveStatementTest {
             public void testFunctionAtTheScriptEnd() throws Exception {
                 runTest("idea/testData/codeInsight/moveUpDown/classBodyDeclarations/function/functionAtTheScriptEnd.kts");
             }
+
+            @TestMetadata("singleLambdaExpressionFunction1.kt")
+            public void testSingleLambdaExpressionFunction1() throws Exception {
+                runTest("idea/testData/codeInsight/moveUpDown/classBodyDeclarations/function/singleLambdaExpressionFunction1.kt");
+            }
+
+            @TestMetadata("singleLambdaExpressionFunction2.kt")
+            public void testSingleLambdaExpressionFunction2() throws Exception {
+                runTest("idea/testData/codeInsight/moveUpDown/classBodyDeclarations/function/singleLambdaExpressionFunction2.kt");
+            }
         }
 
         @TestMetadata("idea/testData/codeInsight/moveUpDown/classBodyDeclarations/functionAnchors")


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-10478