### PR TITLE
KT-23461 `Move statement up/down` attaches a comment block to the function being moved

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/codeInsight/upDownMover/KotlinExpressionMover.java
+++ b/idea/src/org/jetbrains/kotlin/idea/codeInsight/upDownMover/KotlinExpressionMover.java
@@ -350,6 +350,28 @@ public class KotlinExpressionMover extends AbstractKotlinUpDownMover {
             }
         }
 
+        if (start == sibling && end == sibling) {
+            PsiElement comment = sibling;
+            while (true) {
+                int nextLine = getElementLine(comment, editor, !down) + (down ? 1 : -1);
+                comment = firstNonWhiteSibling(comment, down);
+                if (comment instanceof PsiComment && getElementLine(comment, editor, down) == nextLine) {
+                    if (down) {
+                        end = comment;
+                    } else {
+                        start = comment;
+                    }
+                }
+                else break;
+            }
+            if (down && end instanceof PsiComment) {
+                PsiElement next = firstNonWhiteSibling(end, true);
+                if (getElementLine(next, editor, true) == getElementLine(end, editor, false) + 1) {
+                    end = next;
+                }
+            }
+        }
+
         return start != null && end != null ? new LineRange(start, end, editor.getDocument()) : null;
     }
 

--- a/idea/testData/codeInsight/moveUpDown/expressions/hasComment1.kt
+++ b/idea/testData/codeInsight/moveUpDown/expressions/hasComment1.kt
@@ -1,0 +1,7 @@
+// MOVE: up
+fun wrap() {
+    // comment1
+    // comment2
+    val b = 42
+    <caret>fun nested() {}
+}

--- a/idea/testData/codeInsight/moveUpDown/expressions/hasComment1.kt.after
+++ b/idea/testData/codeInsight/moveUpDown/expressions/hasComment1.kt.after
@@ -1,0 +1,7 @@
+// MOVE: up
+fun wrap() {
+    <caret>fun nested() {}
+    // comment1
+    // comment2
+    val b = 42
+}

--- a/idea/testData/codeInsight/moveUpDown/expressions/hasComment2.kt
+++ b/idea/testData/codeInsight/moveUpDown/expressions/hasComment2.kt
@@ -1,0 +1,9 @@
+// MOVE: up
+fun wrap() {
+    /*
+        comment1
+        comment2
+     */
+    val b = 42
+    <caret>fun nested() {}
+}

--- a/idea/testData/codeInsight/moveUpDown/expressions/hasComment2.kt.after
+++ b/idea/testData/codeInsight/moveUpDown/expressions/hasComment2.kt.after
@@ -1,0 +1,9 @@
+// MOVE: up
+fun wrap() {
+    <caret>fun nested() {}
+    /*
+        comment1
+        comment2
+     */
+    val b = 42
+}

--- a/idea/testData/codeInsight/moveUpDown/expressions/hasComment3.kt
+++ b/idea/testData/codeInsight/moveUpDown/expressions/hasComment3.kt
@@ -1,0 +1,7 @@
+// MOVE: down
+fun wrap() {
+    <caret>fun nested() {}
+    // comment1
+    // comment2
+    val b = 42
+}

--- a/idea/testData/codeInsight/moveUpDown/expressions/hasComment3.kt.after
+++ b/idea/testData/codeInsight/moveUpDown/expressions/hasComment3.kt.after
@@ -1,0 +1,7 @@
+// MOVE: down
+fun wrap() {
+    // comment1
+    // comment2
+    val b = 42
+    <caret>fun nested() {}
+}

--- a/idea/testData/codeInsight/moveUpDown/expressions/hasComment4.kt
+++ b/idea/testData/codeInsight/moveUpDown/expressions/hasComment4.kt
@@ -1,0 +1,9 @@
+// MOVE: down
+fun wrap() {
+    <caret>fun nested() {}
+    /*
+        comment1
+        comment1
+     */
+    val b = 42
+}

--- a/idea/testData/codeInsight/moveUpDown/expressions/hasComment4.kt.after
+++ b/idea/testData/codeInsight/moveUpDown/expressions/hasComment4.kt.after
@@ -1,0 +1,9 @@
+// MOVE: down
+fun wrap() {
+    /*
+        comment1
+        comment1
+     */
+    val b = 42
+    <caret>fun nested() {}
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/codeInsight/moveUpDown/MoveStatementTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/codeInsight/moveUpDown/MoveStatementTestGenerated.java
@@ -859,6 +859,26 @@ public class MoveStatementTestGenerated extends AbstractMoveStatementTest {
             runTest("idea/testData/codeInsight/moveUpDown/expressions/declaration2.kt");
         }
 
+        @TestMetadata("hasComment1.kt")
+        public void testHasComment1() throws Exception {
+            runTest("idea/testData/codeInsight/moveUpDown/expressions/hasComment1.kt");
+        }
+
+        @TestMetadata("hasComment2.kt")
+        public void testHasComment2() throws Exception {
+            runTest("idea/testData/codeInsight/moveUpDown/expressions/hasComment2.kt");
+        }
+
+        @TestMetadata("hasComment3.kt")
+        public void testHasComment3() throws Exception {
+            runTest("idea/testData/codeInsight/moveUpDown/expressions/hasComment3.kt");
+        }
+
+        @TestMetadata("hasComment4.kt")
+        public void testHasComment4() throws Exception {
+            runTest("idea/testData/codeInsight/moveUpDown/expressions/hasComment4.kt");
+        }
+
         @TestMetadata("If1.kt")
         public void testIf1() throws Exception {
             runTest("idea/testData/codeInsight/moveUpDown/expressions/If1.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-23461