### PR TITLE
KT-28471: "Add initializer" quickfix initializes non-null variable with null

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/InitializePropertyQuickFixFactory.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/InitializePropertyQuickFixFactory.kt
@@ -58,7 +58,7 @@ object InitializePropertyQuickFixFactory : KotlinIntentionActionsFactory() {
         override fun invoke(project: Project, editor: Editor?, file: KtFile) {
             val element = element ?: return
             val descriptor = element.resolveToDescriptorIfAny() as? PropertyDescriptor ?: return
-            val initializerText = CodeInsightUtils.defaultInitializer(descriptor.type) ?: "null"
+            val initializerText = CodeInsightUtils.defaultInitializer(descriptor.type) ?: "TODO()"
             val initializer = element.setInitializer(KtPsiFactory(project).createExpression(initializerText))!!
             if (editor != null) {
                 PsiDocumentManager.getInstance(project).commitDocument(editor.document)

--- a/idea/testData/quickfix/addInitializer/topLevelPropertyVarClass.kt
+++ b/idea/testData/quickfix/addInitializer/topLevelPropertyVarClass.kt
@@ -1,0 +1,4 @@
+// "Add initializer" "true"
+// WITH_RUNTIME
+class A
+<caret>var label: A

--- a/idea/testData/quickfix/addInitializer/topLevelPropertyVarClass.kt.after
+++ b/idea/testData/quickfix/addInitializer/topLevelPropertyVarClass.kt.after
@@ -1,0 +1,4 @@
+// "Add initializer" "true"
+// WITH_RUNTIME
+class A
+var label: A = TODO()

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -740,6 +740,11 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
             runTest("idea/testData/quickfix/addInitializer/topLevelProperty.kt");
         }
 
+        @TestMetadata("topLevelPropertyVarClass.kt")
+        public void testTopLevelPropertyVarClass() throws Exception {
+            runTest("idea/testData/quickfix/addInitializer/topLevelPropertyVarClass.kt");
+        }
+
         @TestMetadata("topLevelPropertyVarGetterOnly.kt")
         public void testTopLevelPropertyVarGetterOnly() throws Exception {
             runTest("idea/testData/quickfix/addInitializer/topLevelPropertyVarGetterOnly.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-28471

Remove call to `CodeInsightUtils.defaultInitializer(descriptor.type)` in favor of `TODO()`.