### PR TITLE
Report non-incremental annotation processors correctly

### DIFF
--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/ProcessorLoader.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/ProcessorLoader.kt
@@ -64,10 +64,15 @@ open class ProcessorLoader(private val options: KaptOptions, private val logger:
         val processorsInfo: Map<String, DeclaredProcType> = getIncrementalProcessorsFromClasspath(processorNames, classpath)
 
         val nonIncremental = processorNames.filter { !processorsInfo.containsKey(it) }
-        return if (nonIncremental.isNotEmpty()) {
-            processors.map { IncrementalProcessor(it, DeclaredProcType.NON_INCREMENTAL) }
-        } else {
-            processors.map { IncrementalProcessor(it, processorsInfo.getValue(it.javaClass.name)) }
+        return processors.map {
+            val procType = processorsInfo[it.javaClass.name]?.let {
+                if (nonIncremental.isEmpty()) {
+                    it
+                } else {
+                    DeclaredProcType.INCREMENTAL_BUT_OTHER_APS_ARE_NOT
+                }
+            } ?: DeclaredProcType.NON_INCREMENTAL
+            IncrementalProcessor(it, procType)
         }
     }
 

--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/incremental/incrementalProcessors.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/incremental/incrementalProcessors.kt
@@ -19,14 +19,15 @@ import javax.tools.JavaFileObject
 
 private val ALLOWED_RUNTIME_TYPES = setOf(RuntimeProcType.AGGREGATING.name, RuntimeProcType.ISOLATING.name)
 
-class IncrementalProcessor(private val processor: Processor, val kind: DeclaredProcType) : Processor by processor {
+class IncrementalProcessor(private val processor: Processor, private val kind: DeclaredProcType) : Processor by processor {
 
     private var dependencyCollector = lazy { createDependencyCollector() }
 
     val processorName: String = processor.javaClass.name
+    val incrementalSupportType: String = kind.name
 
     override fun init(processingEnv: ProcessingEnvironment) {
-        if (kind == DeclaredProcType.NON_INCREMENTAL) {
+        if (!kind.canRunIncrementally) {
             processor.init(processingEnv)
         } else {
             val originalFiler = processingEnv.filer
@@ -58,6 +59,12 @@ class IncrementalProcessor(private val processor: Processor, val kind: DeclaredP
         return AnnotationProcessorDependencyCollector(type)
     }
 
+    fun isMissingIncrementalSupport(): Boolean {
+        if (kind == DeclaredProcType.NON_INCREMENTAL) return true
+
+        return kind == DeclaredProcType.DYNAMIC && getRuntimeType() == RuntimeProcType.NON_INCREMENTAL
+    }
+    fun isUnableToRunIncrementally() = !kind.canRunIncrementally
     fun getGeneratedToSources() = dependencyCollector.value.getGeneratedToSources()
     fun getRuntimeType(): RuntimeProcType = dependencyCollector.value.getRuntimeType()
 }
@@ -137,19 +144,23 @@ private fun getSrcFiles(elements: Array<out Element?>): Set<File> {
     }.toSet()
 }
 
-enum class DeclaredProcType {
-    AGGREGATING {
+enum class DeclaredProcType(val canRunIncrementally: Boolean) {
+    AGGREGATING(true) {
         override fun toRuntimeType() = RuntimeProcType.AGGREGATING
     },
-    ISOLATING {
+    ISOLATING(true) {
         override fun toRuntimeType() = RuntimeProcType.ISOLATING
     },
-    DYNAMIC {
+    DYNAMIC(true) {
         override fun toRuntimeType() = throw IllegalStateException("This should not be used")
     },
-    NON_INCREMENTAL {
+    NON_INCREMENTAL(false) {
         override fun toRuntimeType() = RuntimeProcType.NON_INCREMENTAL
-    };
+    },
+    INCREMENTAL_BUT_OTHER_APS_ARE_NOT(false) {
+        override fun toRuntimeType() = RuntimeProcType.NON_INCREMENTAL
+    },
+    ;
 
     abstract fun toRuntimeType(): RuntimeProcType
 }


### PR DESCRIPTION
This commit fixes an issue when all APs would be reported as non-incremental,
even if only a single one is non-incremental. Now, additional declared type
is added that is used to denote processors that are incremental, but have
been forced to run non-incrementally in presence of non-incremental APs.

This means that only APs that do not support incremental annotation processing,
or APs that are dynamic and are non-incremental at runtime will be reported.