### PR TITLE
KT-32210: Handle long compiler plugin options

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/subpluginUtils.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/subpluginUtils.kt
@@ -54,11 +54,8 @@ internal fun CompilerPluginOptions.withWrappedKaptOptions(
         subpluginOptionsByPluginId.toMutableMap()
 
     resultOptionsByPluginId.compute(Kapt3KotlinGradleSubplugin.KAPT_SUBPLUGIN_ID) { _, kaptOptions ->
-        val changedFilesOption = FilesSubpluginOption("changedFile", changedFiles).takeIf { changedFiles.isNotEmpty() }
-        val classpathChangesOption = SubpluginOption(
-            "classpathChange",
-            classpathChanges.joinToString(separator = File.pathSeparator)
-        ).takeIf { classpathChanges.isNotEmpty() }
+        val changedFilesOption = changedFiles.map { SubpluginOption("changedFile", it.canonicalPath) }
+        val classpathChangesOption = classpathChanges.map { SubpluginOption("classpathChange", it) }
         val processIncrementallyOption = SubpluginOption("processIncrementally", processIncrementally.toString())
         val compiledSourcesOption =
             FilesSubpluginOption("compiledSourcesDir", compiledSourcesDir).takeIf { compiledSourcesDir.isNotEmpty() }

--- a/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/Kapt3Plugin.kt
+++ b/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/Kapt3Plugin.kt
@@ -96,10 +96,10 @@ class Kapt3CommandLineProcessor : CommandLineProcessor {
             STUBS_OUTPUT_DIR_OPTION -> stubsOutputDir = File(value)
             INCREMENTAL_DATA_OUTPUT_DIR_OPTION -> incrementalDataOutputDir = File(value)
 
-            CHANGED_FILES -> changedFiles.addAll(value.split(File.pathSeparator).map { File(it) })
+            CHANGED_FILES -> changedFiles.add(File(value))
             COMPILED_SOURCES_DIR -> compiledSources.addAll(value.split(File.pathSeparator).map { File(it) })
             INCREMENTAL_CACHE -> incrementalCache = File(value)
-            CLASSPATH_CHANGES -> classpathChanges.addAll(value.split(File.pathSeparator).map { it })
+            CLASSPATH_CHANGES -> classpathChanges.add(value)
             PROCESS_INCREMENTALLY -> setFlag(KaptFlag.INCREMENTAL_APT, value)
 
             ANNOTATION_PROCESSOR_CLASSPATH_OPTION -> processingClasspath += File(value)


### PR DESCRIPTION
Some of the KAPT compiler plugin options were longer than 0xFFFF bytes in
UTF-8 encoding, causing UTFDataFormatException when serializing them. This
commit avoids that issue by encoding changed files and changed classpath types
one by one instead of joining them to a single string.