### PR TITLE
Fix gradle integration tests on Windows

### DIFF
--- a/buildSrc/src/main/kotlin/tasks.kt
+++ b/buildSrc/src/main/kotlin/tasks.kt
@@ -111,7 +111,12 @@ fun Project.projectTest(taskName: String = "test", parallel: Boolean = false, bo
             (teamcity?.get("teamcity.build.tempDir") as? String)
                 ?: System.getProperty("java.io.tmpdir")
         systemTempRoot.let {
-            subProjectTempRoot = Files.createTempDirectory(File(systemTempRoot).toPath(), project.name + "Project_" + taskName + "_")
+            subProjectTempRoot = if (System.getProperty("os.name")!!.contains("Windows")) {
+                // Aapt2 from Android Gradle Plugin 3.2 and below does not handle long paths on Windows.
+                Files.createTempDirectory(File(systemTempRoot).toPath(), "")
+            } else {
+                Files.createTempDirectory(File(systemTempRoot).toPath(), project.name + "Project_" + taskName + "_")
+            }
             systemProperty("java.io.tmpdir", subProjectTempRoot.toString())
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BaseGradleIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BaseGradleIT.kt
@@ -33,7 +33,8 @@ abstract class BaseGradleIT {
 
     @Before
     fun setUp() {
-        workingDir = createTempDir("BaseGradleIT")
+        // Aapt2 from Android Gradle Plugin 3.2 and below does not handle long paths on Windows.
+        workingDir = createTempDir(if (isWindows) "" else "BaseGradleIT")
         acceptAndroidSdkLicenses()
     }
 


### PR DESCRIPTION
Android Gradle Plugin 3.0 and 3.1 use aapt that does not handle
long paths on Windows. This commit uses shorter paths for the project
working directory on Windows.

Test: running integration tests on Windows