### PR TITLE
KT-28824 Adds artifact for jvm-abi-gen for use with embeddable compiler

### DIFF
--- a/plugins/jvm-abi-gen/embeddable/build.gradle.kts
+++ b/plugins/jvm-abi-gen/embeddable/build.gradle.kts
@@ -1,0 +1,20 @@
+import org.gradle.jvm.tasks.Jar
+
+description = "ABI generation for Kotlin/JVM (for using with embeddable compiler)"
+
+plugins {
+    `java`
+}
+
+dependencies {
+    embedded(project(":plugins:jvm-abi-gen")) { isTransitive = false }
+}
+
+publish()
+
+val jar: Jar by tasks
+runtimeJar(rewriteDepsToShadedCompiler(jar))
+
+sourcesJar()
+
+javadocJar()

--- a/settings.gradle
+++ b/settings.gradle
@@ -209,6 +209,7 @@ include ":kotlin-build-common",
         ":libraries:tools:mutability-annotations-compat",
         ":include:kotlin-compiler",
         ":plugins:jvm-abi-gen",
+        ":plugins:jvm-abi-gen-embeddable",
 
         // plugin markers:
         ':kotlin-gradle-plugin:plugin-marker',
@@ -391,6 +392,7 @@ project(':pill:generate-all-tests').projectDir = "$rootDir/plugins/pill/generate
 project(':kotlin-imports-dumper-compiler-plugin').projectDir = "$rootDir/plugins/imports-dumper" as File
 project(':libraries:kotlin-prepush-hook').projectDir = "$rootDir/libraries/tools/kotlin-prepush-hook" as File
 project(':plugins:jvm-abi-gen').projectDir = "$rootDir/plugins/jvm-abi-gen" as File
+project(':plugins:jvm-abi-gen-embeddable').projectDir = "$rootDir/plugins/jvm-abi-gen/embeddable" as File
 
 // plugin markers:
 project(':kotlin-gradle-plugin:plugin-marker').projectDir = file("$rootDir/libraries/tools/kotlin-gradle-plugin/plugin-marker")


### PR DESCRIPTION
Adds ":plugin:jvm-abi-gen-embeddable" Gradle target in plugins/jvm-abi-gen/embeddable dir.

Testing: Built artifact locally and used with embeddable compiler.

Resolves https://youtrack.jetbrains.com/issue/KT-28824