### PR TITLE
JVM IR: Callable reference SMAP fixes

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/SMAP.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/SMAP.kt
@@ -183,6 +183,7 @@ object IdenticalSourceMapper : SourceMapper {
         get() = null
 
     override fun mapLineNumber(lineNumber: Int) = lineNumber
+    override fun mapLineNumber(source: Int, sourceName: String, sourcePath: String) = source
 }
 
 class CallSiteMarker(val lineNumber: Int)

--- a/compiler/testData/codegen/box/controlStructures/breakContinueInExpressions/kt17384.kt
+++ b/compiler/testData/codegen/box/controlStructures/breakContinueInExpressions/kt17384.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 fun returnNullable(): String? = null
 
 inline fun Array<String>.matchAll(fn: (String) -> Unit) {

--- a/compiler/testData/codegen/boxInline/anonymousObject/capturedLambdaInInline3.kt
+++ b/compiler/testData/codegen/boxInline/anonymousObject/capturedLambdaInInline3.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 // FILE: 1.kt
 
 package test

--- a/compiler/testData/codegen/boxInline/anonymousObject/kt14011.kt
+++ b/compiler/testData/codegen/boxInline/anonymousObject/kt14011.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 // FILE: 1.kt
 package test
 

--- a/compiler/testData/codegen/boxInline/anonymousObject/kt14011_2.kt
+++ b/compiler/testData/codegen/boxInline/anonymousObject/kt14011_2.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 // FILE: 1.kt
 package test
 

--- a/compiler/testData/codegen/boxInline/anonymousObject/safeCall.kt
+++ b/compiler/testData/codegen/boxInline/anonymousObject/safeCall.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 // FILE: 1.kt
 
 package test

--- a/compiler/testData/codegen/boxInline/anonymousObject/safeCall_2.kt
+++ b/compiler/testData/codegen/boxInline/anonymousObject/safeCall_2.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 // FILE: 1.kt
 
 package test

--- a/compiler/testData/codegen/boxInline/anonymousObject/sam/kt17091.kt
+++ b/compiler/testData/codegen/boxInline/anonymousObject/sam/kt17091.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 // FILE: 1.kt
 // FULL_JDK
 

--- a/compiler/testData/codegen/boxInline/anonymousObject/twoCapturedReceivers/kt8668.kt
+++ b/compiler/testData/codegen/boxInline/anonymousObject/twoCapturedReceivers/kt8668.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 // FILE: 1.kt
 
 package test

--- a/compiler/testData/codegen/boxInline/complex/with.kt
+++ b/compiler/testData/codegen/boxInline/complex/with.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 // FILE: 1.kt
 // WITH_RUNTIME
 package test

--- a/compiler/testData/codegen/boxInline/defaultValues/lambdaInlining/receiverClash2.kt
+++ b/compiler/testData/codegen/boxInline/defaultValues/lambdaInlining/receiverClash2.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 // FILE: 1.kt
 // SKIP_INLINE_CHECK_IN: inlineFun$default
 package test

--- a/compiler/testData/codegen/boxInline/lambdaClassClash/lambdaClassClash.kt
+++ b/compiler/testData/codegen/boxInline/lambdaClassClash/lambdaClassClash.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 // FILE: 1.kt
 
 package zzz

--- a/compiler/testData/codegen/boxInline/lambdaTransformation/lambdaInLambdaNoInline.kt
+++ b/compiler/testData/codegen/boxInline/lambdaTransformation/lambdaInLambdaNoInline.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 // FILE: 1.kt
 
 package test

--- a/compiler/testData/codegen/boxInline/simple/rootConstructor.kt
+++ b/compiler/testData/codegen/boxInline/simple/rootConstructor.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 // FILE: 1.kt
 
 package test

--- a/compiler/testData/codegen/boxInline/smap/anonymous/lambda.kt
+++ b/compiler/testData/codegen/boxInline/smap/anonymous/lambda.kt
@@ -1,5 +1,5 @@
 // FILE: 1.kt
-// IGNORE_BACKEND: JVM_IR
+
 package builders
 
 inline fun call(crossinline init: () -> Unit) {

--- a/compiler/testData/codegen/boxInline/smap/defaultLambda/defaultLambdaInAnonymous.kt
+++ b/compiler/testData/codegen/boxInline/smap/defaultLambda/defaultLambdaInAnonymous.kt
@@ -1,6 +1,5 @@
 // FILE: 1.kt
 // SKIP_INLINE_CHECK_IN: lParams$default
-// IGNORE_BACKEND: JVM_IR
 package test
 //A lot of blank lines [Don't delete]
 //A lot of blank lines [Don't delete]

--- a/compiler/testData/codegen/boxInline/smap/defaultLambda/inlineAnonymousInDefault.kt
+++ b/compiler/testData/codegen/boxInline/smap/defaultLambda/inlineAnonymousInDefault.kt
@@ -1,6 +1,5 @@
 // FILE: 1.kt
 // SKIP_INLINE_CHECK_IN: lParams$default
-// IGNORE_BACKEND: JVM_IR
 package test
 //A lot of blank lines [Don't delete]
 //A lot of blank lines [Don't delete]

--- a/compiler/testData/codegen/boxInline/smap/defaultLambda/inlineAnonymousInDefault2.kt
+++ b/compiler/testData/codegen/boxInline/smap/defaultLambda/inlineAnonymousInDefault2.kt
@@ -1,6 +1,5 @@
 // FILE: 1.kt
 // SKIP_INLINE_CHECK_IN: lParams$default
-// IGNORE_BACKEND: JVM_IR
 package test
 //A lot of blank lines [Don't delete]
 //A lot of blank lines [Don't delete]

--- a/compiler/testData/codegen/boxInline/special/loopInStoreLoadChains2.kt
+++ b/compiler/testData/codegen/boxInline/special/loopInStoreLoadChains2.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 // FILE: 1.kt
 inline fun cycle(p: String): String {
     var z = p

--- a/compiler/testData/writeFlags/inline/lostInnerClass3.kt
+++ b/compiler/testData/writeFlags/inline/lostInnerClass3.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 interface Introspector {
     fun test() {
         class SchemaRetriever(val transaction: String) {


### PR DESCRIPTION
This is a separate PR for the SMAP change from #2483. In particular, the first 8 commits are from #2483, only 743fbd2 is actually new.