### PR TITLE
KT-33056: Fix how parent class loader for KAPT processors is found

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kapt3IT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kapt3IT.kt
@@ -77,9 +77,12 @@ class Kapt3WorkersIT : Kapt3IT() {
 
         val project =
             Project("simple", directoryPrefix = "kapt2", gradleVersionRequirement = gradleVersionRequired)
+
         project.build("build", options = options) {
             assertSuccessful()
             assertKaptSuccessful()
+            // Check added because of https://youtrack.jetbrains.com/issue/KT-33056.
+            assertNotContains("javaslang.match.PatternsProcessor")
         }
     }
 

--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/Kapt.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/Kapt.kt
@@ -62,22 +62,7 @@ object Kapt {
     }
 
     private fun findClassLoaderWithJavac(): ClassLoader {
-        fun Class<*>.toClassFilePath() = name.replace('.', '/') + ".class"
-
-        // find topmost class loader with javac
-        val javacContextPath = Context::class.java.toClassFilePath()
-        val kaptPath = Kapt::class.java.toClassFilePath()
-
-        fun findRightClassLoader(current: ClassLoader): ClassLoader? {
-            if (current.getResource(javacContextPath) != null && current.getResource(kaptPath) == null) {
-                return current
-            }
-
-            val parent = current.parent ?: return null
-            return findRightClassLoader(parent)
-        }
-
-        val kaptClassLoader = Kapt::class.java.classLoader
-        return findRightClassLoader(kaptClassLoader) ?: kaptClassLoader
+        // Class.getClassLoader() may return null if the class is defined in a bootstrap class loader
+        return Context::class.java.classLoader ?: ClassLoader.getSystemClassLoader()
     }
 }


### PR DESCRIPTION
When instantiating annotation processors, the class loader where they
are defined needs to have the correct parent class loader set up. In
order to find the parent class loader, we need to find the most specific
class loader that contains javac compiler classes (and does not contain
e.g. KAPT classes). This commit changes how that search is done, and it
simply returns the class loader in which the com.sun.tools.javac.util.Context
is defined, as the is the class we need on the annotation processor
classpath.