### PR TITLE
KT-33028, KT-33050: Fix how kapt invokes javac on JDK 9+

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kapt3IT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kapt3IT.kt
@@ -69,14 +69,13 @@ class Kapt3WorkersIT : Kapt3IT() {
         }
     }
 
-    private fun testSimpleWithCustomJdk(gradleVersion: String, javaHome: File, jdkDescription: String) {
-        val gradleVersionRequired = GradleVersionRequired.AtLeast(gradleVersion)
-
-        Assume.assumeTrue("$jdkDescription isn't available", javaHome.isDirectory)
+    @Test
+    fun testSimpleWithJdk10() {
+        val javaHome = File(System.getProperty("jdk10Home")!!)
+        Assume.assumeTrue("JDK 10 isn't available", javaHome.isDirectory)
         val options = defaultBuildOptions().copy(javaHome = javaHome)
 
-        val project =
-            Project("simple", directoryPrefix = "kapt2", gradleVersionRequirement = gradleVersionRequired)
+        val project = Project("simple", directoryPrefix = "kapt2", gradleVersionRequirement = GradleVersionRequired.AtLeast("4.7"))
         project.build("build", options = options) {
             assertSuccessful()
             assertKaptSuccessful()
@@ -84,13 +83,16 @@ class Kapt3WorkersIT : Kapt3IT() {
     }
 
     @Test
-    fun testSimpleWithJdk10() {
-        testSimpleWithCustomJdk("4.7", File(System.getProperty("jdk10Home")!!), "JDK 10")
-    }
-
-    @Test
     fun testSimpleWithJdk11() {
-        testSimpleWithCustomJdk("5.0", File(System.getProperty("jdk11Home")!!), "JDK 11")
+        val javaHome = File(System.getProperty("jdk11Home")!!)
+        Assume.assumeTrue("JDK 11 isn't available", javaHome.isDirectory)
+        val options = defaultBuildOptions().copy(javaHome = javaHome)
+
+        val project = Project("simple", directoryPrefix = "kapt2", gradleVersionRequirement = GradleVersionRequired.AtLeast("5.0"))
+        project.build("build", options = options) {
+            assertSuccessful()
+            assertKaptSuccessful()
+        }
     }
 }
 
@@ -639,6 +641,23 @@ open class Kapt3IT : Kapt3BaseIT() {
             assertFileExists("build/generated/source/kapt/main/demo/DummyGenerated.kt")
             assertTasksExecuted(":compileKotlin")
             assertTasksSkipped(":compileJava")
+        }
+    }
+
+    @Test
+    fun testSimpleWithJdk11AndSourceLevel8() {
+        val javaHome = File(System.getProperty("jdk11Home")!!)
+        Assume.assumeTrue("JDK 11 isn't available", javaHome.isDirectory)
+        val options = defaultBuildOptions().copy(javaHome = javaHome)
+
+        val project = Project("simple", directoryPrefix = "kapt2", gradleVersionRequirement = GradleVersionRequired.AtLeast("5.0")).also {
+            it.setupWorkingDir()
+            it.gradleBuildScript().appendText("\nsourceCompatibility = '8'")
+        }
+        project.build("build", options = options) {
+            assertSuccessful()
+            assertKaptSuccessful()
+            assertContains("Javac options: {-source=1.8}")
         }
     }
 }

--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/KaptContext.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/KaptContext.kt
@@ -94,9 +94,11 @@ open class KaptContext(val options: KaptOptions, val withJdk: Boolean, val logge
 
             put(Option.PROC, "only") // Only process annotations
 
-            if (!withJdk) {
-                @Suppress("SpellCheckingInspection")
-                putJavacOption("BOOTCLASSPATH", "BOOT_CLASS_PATH", "") // No boot classpath
+            if (!withJdk && !isJava9OrLater()) {
+                // No boot classpath for JDK 8 and below. When running on JDK9+ and specifying source level 8 and below,
+                // boot classpath is not set to empty. This is to allow types to be resolved using boot classpath which defaults to
+                // classes defined in java.base module. See https://youtrack.jetbrains.com/issue/KT-33028 for details.
+                put(Option.valueOf("BOOTCLASSPATH"), "")
             }
 
             if (isJava9OrLater()) {


### PR DESCRIPTION
This commit fixes KT-33028 by not setting empty boot classpath when
running on JDK9+. When compiling with -source 8 and below, this allows
classes from java.base module to be available in the boot classpath.

This commit also fixes KT-33050 by passing the source level of Java compile
task in the KAPT javac options. This is important as some annotation processors
are using ProcessingEnvironment.getSourceVersion() in order to decide what
code to generate.

Test: Kapt3IT test added for worker and non-worker invocations