### PR TITLE
Improve error message

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinMultiplatformExtension.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinMultiplatformExtension.kt
@@ -78,8 +78,8 @@ internal fun <T : KotlinTarget> KotlinTargetsContainerWithPresets.configureOrCre
             throw InvalidUserCodeException(
                 "The target '$targetName' already exists, but it was not created with the '${targetPreset.name}' preset. " +
                         "To configure it, access it by name in `kotlin.targets`" +
-                        " or use the preset function '${existingTarget.preset?.name}'"
-                            .takeIf { existingTarget.preset != null }
+                        " or use the preset function '${existingTarget.preset?.name}'."
+                            .takeIf { existingTarget.preset != null } ?: "."
             )
         }
     }


### PR DESCRIPTION
Fore the case where a target has been created or configured twice with different presets,
avoid showing "null" inside the error message if existing target has not preset,
and append a point.