### PR TITLE
Fix handling of inline classes in DefaultParameterInjector

### DIFF
--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/ir/Ir.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/ir/Ir.kt
@@ -19,8 +19,12 @@ import org.jetbrains.kotlin.ir.declarations.IrPackageFragment
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.IrFunctionSymbol
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
+import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.classOrNull
-import org.jetbrains.kotlin.ir.util.*
+import org.jetbrains.kotlin.ir.util.ReferenceSymbolTable
+import org.jetbrains.kotlin.ir.util.fqNameWhenAvailable
+import org.jetbrains.kotlin.ir.util.getPackageFragment
+import org.jetbrains.kotlin.ir.util.referenceFunction
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.resolve.calls.components.isVararg
@@ -33,6 +37,10 @@ abstract class Ir<out T : CommonBackendContext>(val context: T, val irModule: Ir
     abstract val symbols: Symbols<T>
 
     val defaultParameterDeclarationsCache = mutableMapOf<IrFunction, IrFunction>()
+
+    // If irType is an inline class type, return the underlying type according to the
+    // unfolding rules of the current backend. Otherwise, returns null.
+    open fun unfoldInlineClassType(irType: IrType): IrType? = null
 
     open fun shouldGenerateHandlerParameterForDefaultBodyFun() = false
 }

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/ir/IrUtils.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/ir/IrUtils.kt
@@ -565,7 +565,3 @@ fun copyBodyToStatic(oldFunction: IrFunction, staticFunction: IrFunction) {
             ?.transform(VariableRemapper(mapping), null)
             ?.patchDeclarationParents(staticFunction)
 }
-
-fun IrClass.underlyingType() = if (isInline)
-    constructors.single { it.isPrimary }.valueParameters[0].type
-else defaultType

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/JsIrBackendContext.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/JsIrBackendContext.kt
@@ -29,15 +29,13 @@ import org.jetbrains.kotlin.ir.backend.js.utils.OperatorNames
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrFileImpl
 import org.jetbrains.kotlin.ir.descriptors.IrBuiltIns
-import org.jetbrains.kotlin.ir.symbols.*
-import org.jetbrains.kotlin.ir.types.IrDynamicType
-import org.jetbrains.kotlin.ir.types.IrSimpleType
-import org.jetbrains.kotlin.ir.types.classifierOrFail
+import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
+import org.jetbrains.kotlin.ir.symbols.IrClassifierSymbol
+import org.jetbrains.kotlin.ir.symbols.IrEnumEntrySymbol
+import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
+import org.jetbrains.kotlin.ir.types.*
 import org.jetbrains.kotlin.ir.types.impl.IrDynamicTypeImpl
-import org.jetbrains.kotlin.ir.util.SymbolTable
-import org.jetbrains.kotlin.ir.util.getPropertyGetter
-import org.jetbrains.kotlin.ir.util.getPropertySetter
-import org.jetbrains.kotlin.ir.util.kotlinPackageFqn
+import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.resolve.scopes.MemberScope
@@ -197,6 +195,10 @@ class JsIrBackendContext(
             override val coroutineGetContext = symbolTable.referenceSimpleFunction(getJsInternalFunction(GET_COROUTINE_CONTEXT_NAME))
 
             override val returnIfSuspended = symbolTable.referenceSimpleFunction(getJsInternalFunction("returnIfSuspended"))
+        }
+
+        override fun unfoldInlineClassType(irType: IrType): IrType? {
+            return irType.getInlinedClass()?.typeWith()
         }
 
         override fun shouldGenerateHandlerParameterForDefaultBodyFun() = true

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendContext.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendContext.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.backend.jvm.codegen.IrTypeMapper
 import org.jetbrains.kotlin.backend.jvm.descriptors.JvmDeclarationFactory
 import org.jetbrains.kotlin.backend.jvm.descriptors.JvmSharedVariablesManager
 import org.jetbrains.kotlin.backend.jvm.intrinsics.IrIntrinsicMethods
+import org.jetbrains.kotlin.backend.jvm.lower.inlineclasses.InlineClassAbi
 import org.jetbrains.kotlin.codegen.ClassBuilder
 import org.jetbrains.kotlin.codegen.state.GenerationState
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
@@ -21,6 +22,7 @@ import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.descriptors.IrBuiltIns
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.IrFunctionSymbol
+import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.util.ReferenceSymbolTable
 import org.jetbrains.kotlin.ir.util.SymbolTable
 import org.jetbrains.kotlin.name.FqName
@@ -94,6 +96,10 @@ class JvmBackendContext(
         symbolTable: ReferenceSymbolTable
     ) : Ir<JvmBackendContext>(this, irModuleFragment) {
         override val symbols = JvmSymbols(this@JvmBackendContext, symbolTable, firMode)
+
+        override fun unfoldInlineClassType(irType: IrType): IrType? {
+            return InlineClassAbi.unboxType(irType)
+        }
 
         override fun shouldGenerateHandlerParameterForDefaultBodyFun() = true
     }

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/JvmDefaultParameterInjector.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/JvmDefaultParameterInjector.kt
@@ -5,38 +5,30 @@
 
 package org.jetbrains.kotlin.backend.jvm.lower
 
-import org.jetbrains.kotlin.backend.common.ir.underlyingType
 import org.jetbrains.kotlin.backend.common.lower.DefaultParameterInjector
 import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
-import org.jetbrains.kotlin.ir.IrElement
+import org.jetbrains.kotlin.backend.jvm.lower.inlineclasses.unboxInlineClass
+import org.jetbrains.kotlin.ir.declarations.IrValueParameter
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.impl.IrCallImpl
-import org.jetbrains.kotlin.ir.types.*
+import org.jetbrains.kotlin.ir.types.IrSimpleType
+import org.jetbrains.kotlin.ir.types.IrType
+import org.jetbrains.kotlin.ir.types.classOrNull
 
 class JvmDefaultParameterInjector(context: JvmBackendContext) :
     DefaultParameterInjector(context, skipInline = false, skipExternalMethods = false) {
 
     override val context: JvmBackendContext get() = super.context as JvmBackendContext
 
-    override fun nullConst(expression: IrElement, type: IrType): IrExpression {
-        if (type !is IrSimpleType ||
-            type.hasQuestionMark ||
-            type.classOrNull?.owner?.isInline != true
-        ) {
-            return super.nullConst(expression, type)
-        }
-        val underlyingType = type.classOrNull!!.owner.underlyingType()
-        return IrCallImpl(
-            expression.startOffset, expression.endOffset,
-            type,
-            context.ir.symbols.unsafeCoerceIntrinsicSymbol, context.ir.symbols.unsafeCoerceIntrinsicSymbol.descriptor,
-            typeArgumentsCount = 2,
-            valueArgumentsCount = 1
-        ).apply {
+    override fun nullConst(startOffset: Int, endOffset: Int, type: IrType): IrExpression {
+        if (type !is IrSimpleType || type.hasQuestionMark || type.classOrNull?.owner?.isInline != true)
+            return super.nullConst(startOffset, endOffset, type)
+
+        val underlyingType = type.unboxInlineClass()
+        return IrCallImpl(startOffset, endOffset, type, context.ir.symbols.unsafeCoerceIntrinsicSymbol).apply {
             putTypeArgument(0, underlyingType) // from
             putTypeArgument(1, type) // to
-            putValueArgument(0, super.nullConst(expression, underlyingType))
+            putValueArgument(0, super.nullConst(startOffset, endOffset, underlyingType))
         }
     }
-
 }

--- a/compiler/testData/codegen/bytecodeText/defaultArguments/noEmptyArray.kt
+++ b/compiler/testData/codegen/bytecodeText/defaultArguments/noEmptyArray.kt
@@ -1,0 +1,9 @@
+// IGNORE_BACKEND: JVM_IR
+
+// There is one ANEWARRAY instruction here, to generate the default parameter value.
+fun default(vararg s: String = arrayOf("OK")) = s[0]
+
+// This call on the other hand shouldn't allocate anything.
+fun callDefault() = default()
+
+// 1 ANEWARRAY

--- a/compiler/testData/codegen/bytecodeText/inlineClasses/defaultParametersDontBox.kt
+++ b/compiler/testData/codegen/bytecodeText/inlineClasses/defaultParametersDontBox.kt
@@ -1,0 +1,23 @@
+// LANGUAGE: +InlineClasses
+// IGNORE_BACKEND: JVM_IR
+// FILE: classes.kt
+
+inline class A(val i: Int)
+inline class B(val a: A)
+
+// FILE: test.kt
+
+fun defaultA(a: A = A(1)) = a.i
+fun defaultB(b: B = B(A(1))) = b.a.i
+
+fun box(): String {
+    if (defaultA() != 1) return "Fail 1"
+    if (defaultB() != 1) return "Fail 2"
+    return "OK"
+}
+
+// @TestKt.class:
+// 0 B.box-impl
+// 0 A.box-impl
+// 0 B.unbox-impl
+// 0 A.unbox-impl

--- a/compiler/testData/codegen/bytecodeText/inlineClasses/defaultParametersDontBox.kt
+++ b/compiler/testData/codegen/bytecodeText/inlineClasses/defaultParametersDontBox.kt
@@ -1,5 +1,4 @@
 // LANGUAGE: +InlineClasses
-// IGNORE_BACKEND: JVM_IR
 // FILE: classes.kt
 
 inline class A(val i: Int)

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
@@ -1579,6 +1579,11 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
         public void testMethodHandlerElimination() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/defaultArguments/methodHandlerElimination.kt");
         }
+
+        @TestMetadata("noEmptyArray.kt")
+        public void testNoEmptyArray() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/defaultArguments/noEmptyArray.kt");
+        }
     }
 
     @TestMetadata("compiler/testData/codegen/bytecodeText/directInvoke")
@@ -2446,6 +2451,11 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
         @TestMetadata("checkOuterInlineFunctionCall.kt")
         public void testCheckOuterInlineFunctionCall() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/inlineClasses/checkOuterInlineFunctionCall.kt");
+        }
+
+        @TestMetadata("defaultParametersDontBox.kt")
+        public void testDefaultParametersDontBox() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/inlineClasses/defaultParametersDontBox.kt");
         }
 
         @TestMetadata("equalsIsCalledByInlineClass.kt")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
@@ -1534,6 +1534,11 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
         public void testMethodHandlerElimination() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/defaultArguments/methodHandlerElimination.kt");
         }
+
+        @TestMetadata("noEmptyArray.kt")
+        public void testNoEmptyArray() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/defaultArguments/noEmptyArray.kt");
+        }
     }
 
     @TestMetadata("compiler/testData/codegen/bytecodeText/directInvoke")
@@ -2416,6 +2421,11 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
         @TestMetadata("checkOuterInlineFunctionCall.kt")
         public void testCheckOuterInlineFunctionCall() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/inlineClasses/checkOuterInlineFunctionCall.kt");
+        }
+
+        @TestMetadata("defaultParametersDontBox.kt")
+        public void testDefaultParametersDontBox() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/inlineClasses/defaultParametersDontBox.kt");
         }
 
         @TestMetadata("equalsIsCalledByInlineClass.kt")


### PR DESCRIPTION
There are some cases where `DefaultParameterInjector` adds unnecessary boxing for inline class arguments, since `IrClass.underlyingType` doesn't recursively unfold inline classes. Since the rules for unfolding inline classes differ by backend I've fixed this by adding a new function in the `Ir` class and removing the `IrClass.underlyingType` function.

I've added a test for this, as well as for another issue where default vararg arguments allocate an unnecessary array. I've got a different fix in the works for the latter, but we might as well add the test now.