### PR TITLE
Delete output when unable to run KAPT incrementally

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/incremental/ClasspathSnapshot.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/incremental/ClasspathSnapshot.kt
@@ -43,6 +43,8 @@ open class ClasspathSnapshot protected constructor(
 
             return ClasspathSnapshot(cacheDir, classpath, data)
         }
+
+        fun getEmptySnapshot() = UnknownSnapshot
     }
 
     private fun isCompatible(snapshot: ClasspathSnapshot) =


### PR DESCRIPTION
When comparing previous and current classpath snapshots, and it is not
possible to compute the types that changed, make sure to delete the outputs
before invoking KAPT.

Test: KaptIncrementalWithAggregatingApt.testIncompatibleClasspathChanges