### PR TITLE
Run KAPT non-incrementally if annotation processor classpath changes

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KaptIncrementalWithIsolatingApt.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KaptIncrementalWithIsolatingApt.kt
@@ -8,7 +8,6 @@ package org.jetbrains.kotlin.gradle
 import org.jetbrains.kotlin.gradle.incapt.IncrementalProcessor
 import org.jetbrains.kotlin.gradle.util.modify
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.File
 import java.util.zip.ZipEntry
@@ -63,6 +62,28 @@ class KaptIncrementalWithIsolatingApt : KaptIncrementalIT() {
                 ),
                 getProcessedSources(output)
             )
+        }
+    }
+
+    @Test
+    fun testChangingAnnotationProcessorClasspath() {
+        val project = getProject()
+
+        project.build("clean", "build") {
+            assertSuccessful()
+        }
+
+        project.gradleBuildScript().appendText(
+            """
+            
+            dependencies {
+                kapt 'com.google.guava:guava:12.0'
+            }
+        """.trimIndent()
+        )
+        project.build("build") {
+            assertSuccessful()
+            assertContains("Unable to use existing data, re-initializing classpath information for KAPT.")
         }
     }
 }

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/KaptTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/KaptTask.kt
@@ -204,8 +204,9 @@ abstract class KaptTask : ConventionTask(), TaskWithLocalState {
         val startTime = System.currentTimeMillis()
 
         val previousSnapshot = ClasspathSnapshot.ClasspathSnapshotFactory.loadFrom(incAptCacheDir)
-        val currentSnapshot =
-            ClasspathSnapshot.ClasspathSnapshotFactory.createCurrent(incAptCacheDir, classpath.files.toList(), allDataFile)
+        val currentSnapshot = ClasspathSnapshot.ClasspathSnapshotFactory.createCurrent(
+            incAptCacheDir, classpath.files.toList(), kaptClasspath.files.toList(), allDataFile
+        )
 
         val classpathChanges = currentSnapshot.diff(previousSnapshot, changedDataFiles)
         currentSnapshot.writeToCache()

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/incremental/ClasspathSnapshot.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/incremental/ClasspathSnapshot.kt
@@ -10,18 +10,21 @@ import java.util.*
 import kotlin.collections.HashMap
 
 private const val CLASSPATH_ENTRIES_FILE = "classpath-entries.bin"
+private const val ANNOTATION_PROCESSOR_CLASSPATH_ENTRIES_FILE = "ap-classpath-entries.bin"
 private const val CLASSPATH_STRUCTURE_FILE = "classpath-structure.bin"
 
 open class ClasspathSnapshot protected constructor(
     private val cacheDir: File,
     private val classpath: List<File>,
+    private val annotationProcessorClasspath: List<File>,
     private val dataForFiles: MutableMap<File, ClasspathEntryData?>
 ) {
     object ClasspathSnapshotFactory {
         fun loadFrom(cacheDir: File): ClasspathSnapshot {
             val classpathEntries = cacheDir.resolve(CLASSPATH_ENTRIES_FILE)
             val classpathStructureData = cacheDir.resolve(CLASSPATH_STRUCTURE_FILE)
-            if (!classpathEntries.exists() || !classpathStructureData.exists()) {
+            val annotationProcessorClasspathEntries= cacheDir.resolve(ANNOTATION_PROCESSOR_CLASSPATH_ENTRIES_FILE)
+            if (!classpathEntries.exists() || !classpathStructureData.exists() || !annotationProcessorClasspathEntries.exists()) {
                 return UnknownSnapshot
             }
 
@@ -30,23 +33,32 @@ open class ClasspathSnapshot protected constructor(
                 it.readObject() as List<File>
             }
 
+            val annotationProcessorClasspathFiles =
+                ObjectInputStream(BufferedInputStream(annotationProcessorClasspathEntries.inputStream())).use {
+                    @Suppress("UNCHECKED_CAST")
+                    it.readObject() as List<File>
+                }
+
             val dataForFiles =
                 ObjectInputStream(BufferedInputStream(classpathStructureData.inputStream())).use {
                     @Suppress("UNCHECKED_CAST")
                     it.readObject() as MutableMap<File, ClasspathEntryData?>
                 }
-            return ClasspathSnapshot(cacheDir, classpathFiles, dataForFiles)
+            return ClasspathSnapshot(cacheDir, classpathFiles, annotationProcessorClasspathFiles, dataForFiles)
         }
 
-        fun createCurrent(cacheDir: File, classpath: List<File>, allStructureData: Set<File>): ClasspathSnapshot {
+        fun createCurrent(cacheDir: File, classpath: List<File>, annotationProcessorClasspath: List<File>, allStructureData: Set<File>): ClasspathSnapshot {
             val data = allStructureData.associateTo(HashMap<File, ClasspathEntryData?>(allStructureData.size)) { it to null }
 
-            return ClasspathSnapshot(cacheDir, classpath, data)
+            return ClasspathSnapshot(cacheDir, classpath, annotationProcessorClasspath, data)
         }
     }
 
     private fun isCompatible(snapshot: ClasspathSnapshot) =
-        this != UnknownSnapshot && snapshot != UnknownSnapshot && classpath == snapshot.classpath
+        this != UnknownSnapshot
+                && snapshot != UnknownSnapshot
+                && classpath == snapshot.classpath
+                && annotationProcessorClasspath == snapshot.annotationProcessorClasspath
 
     /** Compare this snapshot with the specified one only for the specified files. */
     fun diff(previousSnapshot: ClasspathSnapshot, changedFiles: Set<File>): KaptClasspathChanges {
@@ -126,6 +138,11 @@ open class ClasspathSnapshot protected constructor(
             it.writeObject(classpath)
         }
 
+        val annotationProcessorClasspathEntries = cacheDir.resolve(ANNOTATION_PROCESSOR_CLASSPATH_ENTRIES_FILE)
+        ObjectOutputStream(BufferedOutputStream(annotationProcessorClasspathEntries.outputStream())).use {
+            it.writeObject(annotationProcessorClasspath)
+        }
+
         val classpathStructureData = cacheDir.resolve(CLASSPATH_STRUCTURE_FILE)
         ObjectOutputStream(BufferedOutputStream(classpathStructureData.outputStream())).use {
             it.writeObject(dataForFiles)
@@ -177,7 +194,7 @@ open class ClasspathSnapshot protected constructor(
     }
 }
 
-object UnknownSnapshot : ClasspathSnapshot(File(""), emptyList(), mutableMapOf())
+object UnknownSnapshot : ClasspathSnapshot(File(""), emptyList(), emptyList(), mutableMapOf())
 
 sealed class KaptIncrementalChanges {
     object Unknown : KaptIncrementalChanges()


### PR DESCRIPTION
Annotation processor classpath for a KAPT run is recorded, and the current
run is compared against the previous one. If those differ, KAPT should
run non-incrementally.

Test: KaptIncrementalWithIsolatingApt.testChangingAnnotationProcessorClasspath