### PR TITLE
JVM IR: Convert interface companion fields to static fields.

### DIFF
--- a/compiler/testData/codegen/box/objects/interfaceCompanion.kt
+++ b/compiler/testData/codegen/box/objects/interfaceCompanion.kt
@@ -1,3 +1,7 @@
+// IGNORE_BACKEND: JVM_IR
+// Inside of the companion we have to access the instance through the local Companion field,
+// not by indirection through the Companion field of the enclosing class.
+// Class initialization might not have finished yet.
 var result = ""
 
 interface A {

--- a/compiler/testData/codegen/bytecodeText/companion/kt14258_5.kt
+++ b/compiler/testData/codegen/bytecodeText/companion/kt14258_5.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 // Checks that accessor are not used because property can be accessed directly.
 
 interface I {

--- a/compiler/testData/codegen/bytecodeText/constProperty/nonConstValHasNoDefaultValue_after.kt
+++ b/compiler/testData/codegen/bytecodeText/constProperty/nonConstValHasNoDefaultValue_after.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: +NoConstantValueAttributeForNonConstVals +JvmFieldInInterface
-// IGNORE_BACKEND: JVM_IR
 
 class C {
     val testClassVal = 100

--- a/compiler/testData/writeFlags/property/classObject/trait/delegatedProtectedVar.kt
+++ b/compiler/testData/writeFlags/property/classObject/trait/delegatedProtectedVar.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 import kotlin.reflect.KProperty
 
 class TestDelegate() {

--- a/compiler/testData/writeFlags/property/classObject/trait/delegatedPublicVal.kt
+++ b/compiler/testData/writeFlags/property/classObject/trait/delegatedPublicVal.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 import kotlin.reflect.KProperty
 
 class TestDelegate() {

--- a/compiler/testData/writeFlags/property/classObject/trait/internalConstVal.kt
+++ b/compiler/testData/writeFlags/property/classObject/trait/internalConstVal.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 interface Test {
   companion object {
     internal const val prop: Int = 0;

--- a/compiler/testData/writeFlags/property/classObject/trait/privateVal.kt
+++ b/compiler/testData/writeFlags/property/classObject/trait/privateVal.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 interface Test {
   companion object {
     private val prop = 0;

--- a/compiler/testData/writeFlags/property/classObject/trait/privateVar.kt
+++ b/compiler/testData/writeFlags/property/classObject/trait/privateVar.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 interface Test {
   companion object {
     private var prop = 0;

--- a/compiler/testData/writeFlags/property/classObject/trait/publicConstVal.kt
+++ b/compiler/testData/writeFlags/property/classObject/trait/publicConstVal.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 interface Test {
   companion object {
     public const val prop: Int = 0;


### PR DESCRIPTION
`MoveCompanionObjectFieldsLowering` replaces fields in a companion object with static fields in the enclosing class. Currently the lowering ignores fields in interface companions (unless they are marked with `@JvmField`). This PR adds support for fields in interface companions, which we do not want to move, but still have to mark as static.