### PR TITLE
Annotate object INSTANCE field as @NotNull in bytecode

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/MemberCodegen.java
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/MemberCodegen.java
@@ -45,10 +45,7 @@ import org.jetbrains.kotlin.storage.LockBasedStorageManager;
 import org.jetbrains.kotlin.storage.NotNullLazyValue;
 import org.jetbrains.kotlin.types.ErrorUtils;
 import org.jetbrains.kotlin.types.KotlinType;
-import org.jetbrains.org.objectweb.asm.Label;
-import org.jetbrains.org.objectweb.asm.MethodVisitor;
-import org.jetbrains.org.objectweb.asm.Opcodes;
-import org.jetbrains.org.objectweb.asm.Type;
+import org.jetbrains.org.objectweb.asm.*;
 import org.jetbrains.org.objectweb.asm.commons.InstructionAdapter;
 import org.jetbrains.org.objectweb.asm.commons.Method;
 
@@ -704,10 +701,11 @@ public abstract class MemberCodegen<T extends KtPureElement/* TODO: & KtDeclarat
     }
 
     protected void generateConstInstance(@NotNull Type thisAsmType, @NotNull Type fieldAsmType) {
-        v.newField(
+        FieldVisitor field = v.newField(
                 JvmDeclarationOriginKt.OtherOriginFromPure(element), ACC_STATIC | ACC_FINAL | ACC_PUBLIC, JvmAbi.INSTANCE_FIELD,
                 fieldAsmType.getDescriptor(), null, null
         );
+        field.visitAnnotation(Type.getDescriptor(NotNull.class), false);
 
         if (state.getClassBuilderMode().generateBodies) {
             InstructionAdapter iv = createOrGetClInitCodegen().v;

--- a/compiler/testData/asJava/lightClasses/object/SimpleObject.java
+++ b/compiler/testData/asJava/lightClasses/object/SimpleObject.java
@@ -5,6 +5,7 @@ public final class A {
     public static final int cc = 1;
     @org.jetbrains.annotations.NotNull
     public static final java.lang.String cv = "A";
+    @org.jetbrains.annotations.NotNull
     public static final pack.A INSTANCE;
 
     public final int getC() { /* compiled code */ }

--- a/compiler/testData/codegen/bytecodeListing/annotations/kt9320.txt
+++ b/compiler/testData/codegen/bytecodeListing/annotations/kt9320.txt
@@ -18,7 +18,7 @@ public final class Kt9320Kt$foo$v$1 {
 
 @kotlin.Metadata
 final class Kt9320Kt$foo$w$1 {
-    public final static field INSTANCE: Kt9320Kt$foo$w$1
+    public final static @org.jetbrains.annotations.NotNull field INSTANCE: Kt9320Kt$foo$w$1
     inner class Kt9320Kt$foo$w$1
     static method <clinit>(): void
     method <init>(): void

--- a/plugins/jvm-abi-gen/testData/content/class/signatures.txt
+++ b/plugins/jvm-abi-gen/testData/content/class/signatures.txt
@@ -30,7 +30,7 @@ final class test/Class$NestedInnerClass {
 }
 @kotlin.Metadata
 final class test/Class$classPublicMethod$publicMethodLambda$1 {
-    public final static field INSTANCE: test.Class$classPublicMethod$publicMethodLambda$1
+    public final static @org.jetbrains.annotations.NotNull field INSTANCE: test.Class$classPublicMethod$publicMethodLambda$1
     inner class test/Class$classPublicMethod$publicMethodLambda$1
     method <init>(): void
     public final method invoke(p0: int): int

--- a/plugins/kapt3/kapt3-compiler/testData/converter/abstractEnum.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/abstractEnum.txt
@@ -15,6 +15,7 @@ public enum E {
 
     @kotlin.Metadata()
     public static final class Obj {
+        @org.jetbrains.annotations.NotNull()
         public static final E.Obj INSTANCE = null;
 
         private Obj() {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/annotations3.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/annotations3.txt
@@ -15,6 +15,7 @@ import java.lang.System;
 
 @kotlin.Metadata()
 public final class BParceler implements Parceler<B> {
+    @org.jetbrains.annotations.NotNull()
     public static final BParceler INSTANCE = null;
 
     private BParceler() {
@@ -42,6 +43,7 @@ import java.lang.System;
 
 @kotlin.Metadata()
 public final class CParceler implements Parceler<C> {
+    @org.jetbrains.annotations.NotNull()
     public static final CParceler INSTANCE = null;
 
     private CParceler() {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/comments.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/comments.txt
@@ -34,6 +34,7 @@ import java.lang.System;
  */
 @kotlin.Metadata()
 public final class Obj {
+    @org.jetbrains.annotations.NotNull()
     public static final Obj INSTANCE = null;
 
     private Obj() {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt18791.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt18791.txt
@@ -91,6 +91,7 @@ import java.lang.System;
 public final class JJ {
     @org.jetbrains.annotations.NotNull()
     private static final java.lang.String b = null;
+    @org.jetbrains.annotations.NotNull()
     public static final app.JJ INSTANCE = null;
 
     @org.jetbrains.annotations.NotNull()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/nestedClasses.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/nestedClasses.txt
@@ -38,6 +38,7 @@ public final class A {
 
     @kotlin.Metadata()
     public static final class C {
+        @org.jetbrains.annotations.NotNull()
         public static final A.C INSTANCE = null;
 
         private C() {
@@ -150,6 +151,7 @@ public final class Test {
 
     @kotlin.Metadata()
     public static final class NestedObject {
+        @org.jetbrains.annotations.NotNull()
         public static final Test.NestedObject INSTANCE = null;
 
         private NestedObject() {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/nestedClasses2.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/nestedClasses2.txt
@@ -135,6 +135,7 @@ public final class Foo {
 
         @kotlin.Metadata()
         public static final class Zoo {
+            @org.jetbrains.annotations.NotNull()
             public static final Foo.Bar.Zoo INSTANCE = null;
 
             private Zoo() {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/nestedClassesNonRootPackage.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/nestedClassesNonRootPackage.txt
@@ -139,6 +139,7 @@ public final class Foo {
 
         @kotlin.Metadata()
         public static final class Zoo {
+            @org.jetbrains.annotations.NotNull()
             public static final test.Foo.Bar.Zoo INSTANCE = null;
 
             private Zoo() {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/nonExistentClass.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/nonExistentClass.txt
@@ -11,6 +11,7 @@ public final class NonExistentType {
     private static final Function1<ABCDEF, kotlin.Unit> c = null;
     @org.jetbrains.annotations.Nullable()
     private static final ABCDEF<java.lang.String, Function1<java.util.List<ABCDEF>, kotlin.Unit>> d = null;
+    @org.jetbrains.annotations.NotNull()
     public static final NonExistentType INSTANCE = null;
 
     @org.jetbrains.annotations.Nullable()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/nonExistentClassWIthoutCorrection.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/nonExistentClassWIthoutCorrection.txt
@@ -32,6 +32,7 @@ public final class NonExistentType {
     public static error.NonExistentClass coocoo3;
     @org.jetbrains.annotations.NotNull()
     public static error.NonExistentClass coocoo31;
+    @org.jetbrains.annotations.NotNull()
     public static final NonExistentType INSTANCE = null;
 
     @org.jetbrains.annotations.Nullable()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/primitiveTypes.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/primitiveTypes.txt
@@ -36,6 +36,7 @@ public final class PrimitiveTypes {
     public static final java.lang.String stringQuotes = "quotes \" \'\'quotes";
     @org.jetbrains.annotations.NotNull()
     public static final java.lang.String stringRN = "\r\n";
+    @org.jetbrains.annotations.NotNull()
     public static final PrimitiveTypes INSTANCE = null;
 
     public final float getFloatMaxValue() {


### PR DESCRIPTION
[KT-33226](https://youtrack.jetbrains.com/issue/KT-33226)

I believe a change needs to be made to the light classes, but I'm not sure where that needs to take place. Perhaps `ByJvmSignatureIndexer`? But it's not clear to me how to denote annotations there.