### PR TITLE
JVM IR: Handle special case visibility rules for callable references

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendContext.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendContext.kt
@@ -53,7 +53,7 @@ class JvmBackendContext(
     val irIntrinsics = IrIntrinsicMethods(irBuiltIns, ir.symbols)
 
     // TODO: also store info for EnclosingMethod
-    internal class LocalClassInfo(val internalName: String)
+    internal class LocalClassInfo(val internalName: String, val inInlineScope: Boolean)
 
     private val localClassInfo = mutableMapOf<IrAttributeContainer, LocalClassInfo>()
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -542,7 +542,7 @@ class ExpressionCodegen(
         )
 
     override fun visitClass(declaration: IrClass, data: BlockInfo): PromisedValue {
-        classCodegen.generateLocalClass(declaration, irFunction.isInline).also {
+        classCodegen.generateLocalClass(declaration).also {
             closureReifiedMarkers[declaration] = it
         }
         return immaterialUnitValue

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/FunctionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/FunctionCodegen.kt
@@ -106,7 +106,7 @@ open class FunctionCodegen(
             }
         }
 
-        val visibility = AsmUtil.getVisibilityAccessFlag(irFunction.visibility) ?: error("Unmapped visibility ${irFunction.visibility}")
+        val visibility = irFunction.getVisibilityAccessFlag(classCodegen.context)
         val staticFlag = if (isStatic) Opcodes.ACC_STATIC else 0
         val varargFlag = if (irFunction.valueParameters.any { it.varargElementType != null }) Opcodes.ACC_VARARGS else 0
         val deprecation = irFunction.deprecationFlags

--- a/compiler/testData/writeFlags/callableReference/visibility/functionReference.kt
+++ b/compiler/testData/writeFlags/callableReference/visibility/functionReference.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 class A {
     fun foo() {}
 

--- a/compiler/testData/writeFlags/callableReference/visibility/propertyReference.kt
+++ b/compiler/testData/writeFlags/callableReference/visibility/propertyReference.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 class A {
     val foo = ""
 

--- a/compiler/testData/writeFlags/function/constructors/objectLiteral.kt
+++ b/compiler/testData/writeFlags/function/constructors/objectLiteral.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 class Foo {
   fun a() {
     val s = object { }

--- a/compiler/testData/writeFlags/inline/inlineOnly.kt
+++ b/compiler/testData/writeFlags/inline/inlineOnly.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 class MyClass {
     @Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
     @kotlin.internal.InlineOnly

--- a/compiler/testData/writeFlags/lambda/simpleLambda.kt
+++ b/compiler/testData/writeFlags/lambda/simpleLambda.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 class Foo {
     fun foo() = { }
 }


### PR DESCRIPTION
A class for a callable reference is package private by default and public when it is used inside of an inline function.

Since we are moving functions around during compilation, we have to record this information early in the compilation pipeline. Fortunately, `InventNamesForLocalClasses` already provides infrastructure to record information about local classes and we can reuse this to mark classes which were defined in the body of an inline function.