### PR TITLE
Improve reliability of simulator test runner

### DIFF
--- a/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/KotlinGradleMobileSharedMultiplatformModuleBuilder.kt
+++ b/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/KotlinGradleMobileSharedMultiplatformModuleBuilder.kt
@@ -192,7 +192,7 @@ class KotlinGradleMobileSharedMultiplatformModuleBuilder : KotlinGradleAbstractM
                 doLast {
                     def binary = kotlin.targets.$nativeTargetName.binaries.getTest('DEBUG').outputFile
                     exec {
-                        commandLine 'xcrun', 'simctl', 'spawn', device, binary.absolutePath
+                        commandLine 'xcrun', 'simctl', '--standalone', 'spawn', device, binary.absolutePath
                     }
                 }
             }

--- a/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/KotlinGradleMobileSharedMultiplatformModuleBuilder.kt
+++ b/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/KotlinGradleMobileSharedMultiplatformModuleBuilder.kt
@@ -192,7 +192,7 @@ class KotlinGradleMobileSharedMultiplatformModuleBuilder : KotlinGradleAbstractM
                 doLast {
                     def binary = kotlin.targets.$nativeTargetName.binaries.getTest('DEBUG').outputFile
                     exec {
-                        commandLine 'xcrun', 'simctl', '--standalone', 'spawn', device, binary.absolutePath
+                        commandLine 'xcrun', 'simctl', 'spawn', '--standalone', device, binary.absolutePath
                     }
                 }
             }


### PR DESCRIPTION
With a recent Xcode (10.3) or macOS (10.14.6) upgrade, I've been consistently running into issues getting the test runner to work (example: https://dev.azure.com/autodeskoss/coroutineworker/_build/results?buildId=24&view=logs). Switching to standalone mode, which I believe has something to do with hinting to simctl that it doesn't need to fully boot a simulator (i.e. just execute the binary), makes multiplatform/native tests run more reliably in these scenarios.
