### PR TITLE
Incremental KAPT: when unable to process incremental changes, run non-incrementally

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/incremental/ClasspathSnapshot.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/incremental/ClasspathSnapshot.kt
@@ -56,6 +56,8 @@ open class ClasspathSnapshot protected constructor(
         fun getEmptySnapshot() = UnknownSnapshot
     }
 
+    fun getAllDataFiles() = dataForFiles.keys
+
     private fun isCompatible(snapshot: ClasspathSnapshot) =
         this != UnknownSnapshot
                 && snapshot != UnknownSnapshot


### PR DESCRIPTION
Incremental KAPT: when unable to process incremental changes, run non-incrementally

When analyzing incremental changes in the KAPT task, incremental compilation
can handle directory changes, Java source file changes, jar/.class file changes,
and changes to the ABI structure of the classpath. Anything else should cause
a full recompilation.

Test: KaptIncrementalWithIsolatingApt.testNonIncrementalWithUnrecognizedInputs