### PR TITLE
Check cancelation in KotlinJavaPsiFacade.findPackage()

### DIFF
--- a/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/KotlinJavaPsiFacade.java
+++ b/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/KotlinJavaPsiFacade.java
@@ -228,6 +228,8 @@ public class KotlinJavaPsiFacade {
     }
 
     public PsiPackage findPackage(@NotNull String qualifiedName, GlobalSearchScope searchScope) {
+        ProgressIndicatorAndCompilationCanceledStatus.checkCanceled();
+
         PackageCache cache = SoftReference.dereference(packageCache);
         if (cache == null) {
             packageCache = new SoftReference<>(cache = new PackageCache());


### PR DESCRIPTION
This may help with some UI freezes caused by KT-33394, although
it does not fix the underlying performance problem.