### PR TITLE
JVM_IR: lower calls to @JvmStatic functions from other files.

### DIFF
--- a/compiler/testData/codegen/boxInline/defaultValues/lambdaInlining/jvmStaticDefault.kt
+++ b/compiler/testData/codegen/boxInline/defaultValues/lambdaInlining/jvmStaticDefault.kt
@@ -1,6 +1,5 @@
 // FILE: 1.kt
 // SKIP_INLINE_CHECK_IN: inlineFun$default
-// IGNORE_BACKEND: JVM_IR
 // TARGET_BACKEND: JVM
 //WITH_RUNTIME
 package test


### PR DESCRIPTION
Note: this currently results in invalid IR (but valid bytecode) if the @JvmStatic function is imported, because its IR representation is unlowered and therefore has a dispatch receiver, but the call will not.