### PR TITLE
Psi2Ir: Mark accessors with no bodies as default accessors.

### DIFF
--- a/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/FunctionGenerator.kt
+++ b/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/FunctionGenerator.kt
@@ -112,7 +112,7 @@ class FunctionGenerator(declarationGenerator: DeclarationGenerator) : Declaratio
         declareSimpleFunctionInner(
             descriptor,
             ktAccessor ?: ktProperty,
-            if (ktAccessor != null) IrDeclarationOrigin.DEFINED else IrDeclarationOrigin.DEFAULT_PROPERTY_ACCESSOR
+            if (ktAccessor != null && ktAccessor.hasBody()) IrDeclarationOrigin.DEFINED else IrDeclarationOrigin.DEFAULT_PROPERTY_ACCESSOR
         ).buildWithScope { irAccessor ->
             declarationGenerator.generateScopedTypeParameterDeclarations(irAccessor, descriptor.correspondingProperty.typeParameters)
             irAccessor.returnType = irAccessor.descriptor.returnType!!.toIrType()

--- a/compiler/testData/codegen/box/annotations/annotationsOnLateinitAccessors.kt
+++ b/compiler/testData/codegen/box/annotations/annotationsOnLateinitAccessors.kt
@@ -1,0 +1,31 @@
+// WITH_REFLECT
+// IGNORE_BACKEND: JVM_IR
+// TARGET_BACKEND: JVM
+
+// Please make sure that this test is consistent with the diagnostic test "annotationsTargetingLateinitAccessor.kt"
+
+import kotlin.reflect.KAnnotatedElement
+
+annotation class Ann
+
+fun check(element: KAnnotatedElement, annotationExists: Boolean) {
+    require(element.annotations.isNotEmpty() == annotationExists) { "Fail: $element" }
+}
+
+class LateinitProperties {
+    @get:Ann
+    lateinit var x0: String
+
+    @get:Ann
+    private lateinit var x1: String
+
+    fun test() {
+        check(::x0.getter, annotationExists = true)
+        check(::x1.getter, annotationExists = false)
+    }
+}
+
+fun box(): String {
+    LateinitProperties().test()
+    return "OK"
+}

--- a/compiler/testData/codegen/box/annotations/annotationsOnNonExistentAccessors.kt
+++ b/compiler/testData/codegen/box/annotations/annotationsOnNonExistentAccessors.kt
@@ -1,5 +1,4 @@
 // WITH_REFLECT
-// IGNORE_BACKEND: JVM_IR
 // TARGET_BACKEND: JVM
 
 // Please make sure that this test is consistent with the diagnostic test "annotationsTargetingNonExistentAccessor.kt"
@@ -98,12 +97,6 @@ private class EffetivelyPrivate private constructor(
 }
 
 class Statics {
-    @get:Ann
-    lateinit var y0: String
-
-    @get:Ann
-    private lateinit var y1: String
-
     companion object {
         @JvmField
         @get:Ann
@@ -128,9 +121,6 @@ class Statics {
     }
 
     fun test() {
-        check(::y0.getter, annotationExists = true)
-        check(::y1.getter, annotationExists = false)
-
         check(::x0.getter, annotationExists = false)
         check(::x1.getter, annotationExists = false)
 

--- a/compiler/testData/diagnostics/testsWithStdLib/annotations/annotationsTargetingLateinitAccessors.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/annotations/annotationsTargetingLateinitAccessors.kt
@@ -1,0 +1,14 @@
+// Please make sure that this test is consistent with the blackbox test "annotationsOnLateinitAccessors.kt"
+
+import kotlin.reflect.KProperty
+
+annotation class Ann
+annotation class AnnRepeat
+
+class LateinitProperties {
+    @get:Ann
+    lateinit var y0: String
+
+    <!ANNOTATION_TARGETS_NON_EXISTENT_ACCESSOR!>@get:Ann<!>
+    private lateinit var y1: String
+}

--- a/compiler/testData/diagnostics/testsWithStdLib/annotations/annotationsTargetingLateinitAccessors.txt
+++ b/compiler/testData/diagnostics/testsWithStdLib/annotations/annotationsTargetingLateinitAccessors.txt
@@ -1,0 +1,24 @@
+package
+
+public final annotation class Ann : kotlin.Annotation {
+    public constructor Ann()
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public final annotation class AnnRepeat : kotlin.Annotation {
+    public constructor AnnRepeat()
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public final class LateinitProperties {
+    public constructor LateinitProperties()
+    @get:Ann public final lateinit var y0: kotlin.String
+    @get:Ann private final lateinit var y1: kotlin.String
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}

--- a/compiler/testData/diagnostics/testsWithStdLib/annotations/annotationsTargetingNonExistentAccessor.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/annotations/annotationsTargetingNonExistentAccessor.kt
@@ -62,12 +62,6 @@ class PrivateToThis<in I> {
 }
 
 class Statics {
-    @get:Ann
-    lateinit var y0: String
-
-    <!ANNOTATION_TARGETS_NON_EXISTENT_ACCESSOR!>@get:Ann<!>
-    private lateinit var y1: String
-
     companion object {
         @JvmField
         <!ANNOTATION_TARGETS_NON_EXISTENT_ACCESSOR!>@get:Ann<!>

--- a/compiler/testData/diagnostics/testsWithStdLib/annotations/annotationsTargetingNonExistentAccessor.txt
+++ b/compiler/testData/diagnostics/testsWithStdLib/annotations/annotationsTargetingNonExistentAccessor.txt
@@ -86,8 +86,6 @@ public final class PrivateToThis</*0*/ in I> {
 
 public final class Statics {
     public constructor Statics()
-    @get:Ann public final lateinit var y0: kotlin.String
-    @get:Ann private final lateinit var y1: kotlin.String
     public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
     public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
     public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String

--- a/compiler/testData/ir/irText/declarations/classLevelProperties.txt
+++ b/compiler/testData/ir/irText/declarations/classLevelProperties.txt
@@ -72,7 +72,7 @@ FILE fqName:<root> fileName:/classLevelProperties.kt
           RETURN type=kotlin.Nothing from='public final fun <get-test5> (): kotlin.Int declared in <root>.C'
             GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:test5 type:kotlin.Int visibility:public' type=kotlin.Int origin=null
               receiver: GET_VAR '<this>: <root>.C declared in <root>.C.<get-test5>' type=<root>.C origin=null
-      FUN name:<set-test5> visibility:private modality:FINAL <> ($this:<root>.C, <set-?>:kotlin.Int) returnType:kotlin.Unit
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<set-test5> visibility:private modality:FINAL <> ($this:<root>.C, <set-?>:kotlin.Int) returnType:kotlin.Unit
         correspondingProperty: PROPERTY name:test5 visibility:public modality:FINAL [var]
         $this: VALUE_PARAMETER name:<this> type:<root>.C
         VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Int
@@ -84,7 +84,7 @@ FILE fqName:<root> fileName:/classLevelProperties.kt
       FIELD PROPERTY_BACKING_FIELD name:test6 type:kotlin.Int visibility:public [final]
         EXPRESSION_BODY
           CONST Int type=kotlin.Int value=1
-      FUN name:<get-test6> visibility:public modality:FINAL <> ($this:<root>.C) returnType:kotlin.Int
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-test6> visibility:public modality:FINAL <> ($this:<root>.C) returnType:kotlin.Int
         correspondingProperty: PROPERTY name:test6 visibility:public modality:FINAL [val]
         $this: VALUE_PARAMETER name:<this> type:<root>.C
         BLOCK_BODY

--- a/compiler/testData/ir/irText/declarations/packageLevelProperties.txt
+++ b/compiler/testData/ir/irText/declarations/packageLevelProperties.txt
@@ -53,7 +53,7 @@ FILE fqName:<root> fileName:/packageLevelProperties.kt
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun <get-test5> (): kotlin.Int declared in <root>'
           GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:test5 type:kotlin.Int visibility:public [static]' type=kotlin.Int origin=null
-    FUN name:<set-test5> visibility:private modality:FINAL <> (<set-?>:kotlin.Int) returnType:kotlin.Unit
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<set-test5> visibility:private modality:FINAL <> (<set-?>:kotlin.Int) returnType:kotlin.Unit
       correspondingProperty: PROPERTY name:test5 visibility:public modality:FINAL [var]
       VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Int
       BLOCK_BODY
@@ -63,7 +63,7 @@ FILE fqName:<root> fileName:/packageLevelProperties.kt
     FIELD PROPERTY_BACKING_FIELD name:test6 type:kotlin.Int visibility:public [final,static]
       EXPRESSION_BODY
         CONST Int type=kotlin.Int value=1
-    FUN name:<get-test6> visibility:public modality:FINAL <> () returnType:kotlin.Int
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-test6> visibility:public modality:FINAL <> () returnType:kotlin.Int
       correspondingProperty: PROPERTY name:test6 visibility:public modality:FINAL [val]
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun <get-test6> (): kotlin.Int declared in <root>'

--- a/compiler/testData/ir/irText/expressions/propertyReferences.txt
+++ b/compiler/testData/ir/irText/expressions/propertyReferences.txt
@@ -48,7 +48,7 @@ FILE fqName:<root> fileName:/propertyReferences.kt
           RETURN type=kotlin.Nothing from='public final fun <get-varWithPrivateSet> (): kotlin.Int declared in <root>.C'
             GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:varWithPrivateSet type:kotlin.Int visibility:public' type=kotlin.Int origin=null
               receiver: GET_VAR '<this>: <root>.C declared in <root>.C.<get-varWithPrivateSet>' type=<root>.C origin=null
-      FUN name:<set-varWithPrivateSet> visibility:private modality:FINAL <> ($this:<root>.C, <set-?>:kotlin.Int) returnType:kotlin.Unit
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<set-varWithPrivateSet> visibility:private modality:FINAL <> ($this:<root>.C, <set-?>:kotlin.Int) returnType:kotlin.Unit
         correspondingProperty: PROPERTY name:varWithPrivateSet visibility:public modality:FINAL [var]
         $this: VALUE_PARAMETER name:<this> type:<root>.C
         VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Int
@@ -67,7 +67,7 @@ FILE fqName:<root> fileName:/propertyReferences.kt
           RETURN type=kotlin.Nothing from='public final fun <get-varWithProtectedSet> (): kotlin.Int declared in <root>.C'
             GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:varWithProtectedSet type:kotlin.Int visibility:public' type=kotlin.Int origin=null
               receiver: GET_VAR '<this>: <root>.C declared in <root>.C.<get-varWithProtectedSet>' type=<root>.C origin=null
-      FUN name:<set-varWithProtectedSet> visibility:protected modality:FINAL <> ($this:<root>.C, <set-?>:kotlin.Int) returnType:kotlin.Unit
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<set-varWithProtectedSet> visibility:protected modality:FINAL <> ($this:<root>.C, <set-?>:kotlin.Int) returnType:kotlin.Unit
         correspondingProperty: PROPERTY name:varWithProtectedSet visibility:public modality:FINAL [var]
         $this: VALUE_PARAMETER name:<this> type:<root>.C
         VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Int

--- a/compiler/testData/ir/sourceRanges/declarations/classProperties.txt
+++ b/compiler/testData/ir/sourceRanges/declarations/classProperties.txt
@@ -96,7 +96,7 @@
           @47:4..31 RETURN type=kotlin.Nothing from='public final fun <get-test9> (): kotlin.Int declared in test.Test'
             @47:4..31 GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:test9 type:kotlin.Int visibility:public' type=kotlin.Int origin=null
               @47:4..31 GET_VAR '<this>: test.Test declared in test.Test.<get-test9>' type=test.Test origin=null
-      @47:28..31 FUN name:<set-test9> visibility:private modality:FINAL <> ($this:test.Test, <set-?>:kotlin.Int) returnType:kotlin.Unit
+      @47:28..31 FUN DEFAULT_PROPERTY_ACCESSOR name:<set-test9> visibility:private modality:FINAL <> ($this:test.Test, <set-?>:kotlin.Int) returnType:kotlin.Unit
         @47:20..31 VALUE_PARAMETER name:<this> type:test.Test
         @47:28..31 VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Int
         @47:28..31 BLOCK_BODY
@@ -113,7 +113,7 @@
           @50:4..51:19 RETURN type=kotlin.Nothing from='public final fun <get-test10> (): kotlin.Int declared in test.Test'
             @50:4..51:19 GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:test10 type:kotlin.Int visibility:public' type=kotlin.Int origin=null
               @50:4..51:19 GET_VAR '<this>: test.Test declared in test.Test.<get-test10>' type=test.Test origin=null
-      @51:16..19 FUN name:<set-test10> visibility:private modality:FINAL <> ($this:test.Test, <set-?>:kotlin.Int) returnType:kotlin.Unit
+      @51:16..19 FUN DEFAULT_PROPERTY_ACCESSOR name:<set-test10> visibility:private modality:FINAL <> ($this:test.Test, <set-?>:kotlin.Int) returnType:kotlin.Unit
         @51:8..19 VALUE_PARAMETER name:<this> type:test.Test
         @51:16..19 VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Int
         @51:16..19 BLOCK_BODY

--- a/compiler/testData/ir/sourceRanges/declarations/topLevelProperties.txt
+++ b/compiler/testData/ir/sourceRanges/declarations/topLevelProperties.txt
@@ -72,7 +72,7 @@
       @46:0..27 BLOCK_BODY
         @46:0..27 RETURN type=kotlin.Nothing from='public final fun <get-test9> (): kotlin.Int declared in test'
           @46:0..27 GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:test9 type:kotlin.Int visibility:public [static]' type=kotlin.Int origin=null
-    @46:24..27 FUN name:<set-test9> visibility:private modality:FINAL <> (<set-?>:kotlin.Int) returnType:kotlin.Unit
+    @46:24..27 FUN DEFAULT_PROPERTY_ACCESSOR name:<set-test9> visibility:private modality:FINAL <> (<set-?>:kotlin.Int) returnType:kotlin.Unit
       @46:24..27 VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Int
       @46:24..27 BLOCK_BODY
         @46:24..27 SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:test9 type:kotlin.Int visibility:public [static]' type=kotlin.Unit origin=null
@@ -85,7 +85,7 @@
       @49:0..50:15 BLOCK_BODY
         @49:0..50:15 RETURN type=kotlin.Nothing from='public final fun <get-test10> (): kotlin.Int declared in test'
           @49:0..50:15 GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:test10 type:kotlin.Int visibility:public [static]' type=kotlin.Int origin=null
-    @50:12..15 FUN name:<set-test10> visibility:private modality:FINAL <> (<set-?>:kotlin.Int) returnType:kotlin.Unit
+    @50:12..15 FUN DEFAULT_PROPERTY_ACCESSOR name:<set-test10> visibility:private modality:FINAL <> (<set-?>:kotlin.Int) returnType:kotlin.Unit
       @50:12..15 VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Int
       @50:12..15 BLOCK_BODY
         @50:12..15 SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:test10 type:kotlin.Int visibility:public [static]' type=kotlin.Unit origin=null

--- a/compiler/tests/org/jetbrains/kotlin/checkers/DiagnosticsTestWithStdLibGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/checkers/DiagnosticsTestWithStdLibGenerated.java
@@ -166,6 +166,11 @@ public class DiagnosticsTestWithStdLibGenerated extends AbstractDiagnosticsTestW
             KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/diagnostics/testsWithStdLib/annotations"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.ANY, true);
         }
 
+        @TestMetadata("annotationsTargetingLateinitAccessors.kt")
+        public void testAnnotationsTargetingLateinitAccessors() throws Exception {
+            runTest("compiler/testData/diagnostics/testsWithStdLib/annotations/annotationsTargetingLateinitAccessors.kt");
+        }
+
         @TestMetadata("annotationsTargetingNonExistentAccessor.kt")
         public void testAnnotationsTargetingNonExistentAccessor() throws Exception {
             runTest("compiler/testData/diagnostics/testsWithStdLib/annotations/annotationsTargetingNonExistentAccessor.kt");

--- a/compiler/tests/org/jetbrains/kotlin/checkers/javac/DiagnosticsTestWithStdLibUsingJavacGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/checkers/javac/DiagnosticsTestWithStdLibUsingJavacGenerated.java
@@ -166,6 +166,11 @@ public class DiagnosticsTestWithStdLibUsingJavacGenerated extends AbstractDiagno
             KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/diagnostics/testsWithStdLib/annotations"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.ANY, true);
         }
 
+        @TestMetadata("annotationsTargetingLateinitAccessors.kt")
+        public void testAnnotationsTargetingLateinitAccessors() throws Exception {
+            runTest("compiler/testData/diagnostics/testsWithStdLib/annotations/annotationsTargetingLateinitAccessors.kt");
+        }
+
         @TestMetadata("annotationsTargetingNonExistentAccessor.kt")
         public void testAnnotationsTargetingNonExistentAccessor() throws Exception {
             runTest("compiler/testData/diagnostics/testsWithStdLib/annotations/annotationsTargetingNonExistentAccessor.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -71,6 +71,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             runTest("compiler/testData/codegen/box/annotations/annotationsOnDefault.kt");
         }
 
+        @TestMetadata("annotationsOnLateinitAccessors.kt")
+        public void testAnnotationsOnLateinitAccessors() throws Exception {
+            runTest("compiler/testData/codegen/box/annotations/annotationsOnLateinitAccessors.kt");
+        }
+
         @TestMetadata("annotationsOnNonExistentAccessors.kt")
         public void testAnnotationsOnNonExistentAccessors() throws Exception {
             runTest("compiler/testData/codegen/box/annotations/annotationsOnNonExistentAccessors.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -76,6 +76,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/annotations/annotationsOnDefault.kt");
         }
 
+        @TestMetadata("annotationsOnLateinitAccessors.kt")
+        public void testAnnotationsOnLateinitAccessors() throws Exception {
+            runTest("compiler/testData/codegen/box/annotations/annotationsOnLateinitAccessors.kt");
+        }
+
         @TestMetadata("annotationsOnNonExistentAccessors.kt")
         public void testAnnotationsOnNonExistentAccessors() throws Exception {
             runTest("compiler/testData/codegen/box/annotations/annotationsOnNonExistentAccessors.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -71,6 +71,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             runTest("compiler/testData/codegen/box/annotations/annotationsOnDefault.kt");
         }
 
+        @TestMetadata("annotationsOnLateinitAccessors.kt")
+        public void testAnnotationsOnLateinitAccessors() throws Exception {
+            runTest("compiler/testData/codegen/box/annotations/annotationsOnLateinitAccessors.kt");
+        }
+
         @TestMetadata("annotationsOnNonExistentAccessors.kt")
         public void testAnnotationsOnNonExistentAccessors() throws Exception {
             runTest("compiler/testData/codegen/box/annotations/annotationsOnNonExistentAccessors.kt");


### PR DESCRIPTION
They are currently marked as defined even when they get a default implementation. That makes it hard to figure out if the accessor should be removed when introducing a backing field in the JVM_IR backend.

The only actual change here is to psi2ir/generators/FunctionGenerator.kt. The rest are test changes to make sure that we run all the non-lateinit property annotation tests on the JVM_IR backend. The JVM_IR backend has different behavior from the current backend (on purpose) for lateinit properties and therefore the test has to be split to make sure we do not regress on the parts that work the same.