### PR TITLE
JVM, JVM IR: Specialize equality for inline classes to avoid boxing

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/AsmUtil.java
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/AsmUtil.java
@@ -1164,6 +1164,15 @@ public class AsmUtil {
         }
     }
 
+    public static void pop2(@NotNull MethodVisitor v, @NotNull Type topOfStack, @NotNull Type afterTop) {
+        if (topOfStack.getSize() == 1 && afterTop.getSize() == 1) {
+            v.visitInsn(POP2);
+        } else {
+            pop(v, topOfStack);
+            pop(v, afterTop);
+        }
+    }
+
     public static void pop2(@NotNull MethodVisitor v, @NotNull Type type) {
         if (type.getSize() == 2) {
             v.visitInsn(Opcodes.POP2);
@@ -1203,6 +1212,29 @@ public class AsmUtil {
         }
         else {
             throw new UnsupportedOperationException();
+        }
+    }
+
+    // Duplicate the element afterTop and push it on the top of the stack.
+    public static void dupSecond(@NotNull InstructionAdapter v, @NotNull Type topOfStack, @NotNull Type afterTop) {
+        if (afterTop.getSize() == 0) {
+            return;
+        }
+
+        if (topOfStack.getSize() == 0) {
+            dup(v, afterTop);
+        } else if (topOfStack.getSize() == 1 && afterTop.getSize() == 1) {
+            v.dup2();
+            v.pop();
+        } else {
+            swap(v, topOfStack, afterTop);
+            if (topOfStack.getSize() == 1 && afterTop.getSize() == 2) {
+                v.dup2X1();
+            } else if (topOfStack.getSize() == 2 && afterTop.getSize() == 1) {
+                v.dupX2();
+            } else /* top = 2, after top = 2 */ {
+                v.dup2X2();
+            }
         }
     }
 

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/ErasedInlineClassBodyCodegen.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/ErasedInlineClassBodyCodegen.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.codegen
 
+import org.jetbrains.kotlin.codegen.AsmUtil.genTotalOrderEqualsForExpressionOnStack
 import org.jetbrains.kotlin.codegen.context.ClassContext
 import org.jetbrains.kotlin.codegen.state.GenerationState
 import org.jetbrains.kotlin.codegen.state.KotlinTypeMapper
@@ -17,6 +18,7 @@ import org.jetbrains.kotlin.resolve.jvm.AsmTypes
 import org.jetbrains.kotlin.resolve.jvm.diagnostics.Synthetic
 import org.jetbrains.kotlin.resolve.jvm.jvmSignature.JvmMethodGenericSignature
 import org.jetbrains.kotlin.resolve.jvm.jvmSignature.JvmMethodSignature
+import org.jetbrains.org.objectweb.asm.Type
 
 class ErasedInlineClassBodyCodegen(
     aClass: KtClass,
@@ -109,10 +111,16 @@ class ErasedInlineClassBodyCodegen(
 
 
                 override fun doGenerateBody(codegen: ExpressionCodegen, signature: JvmMethodSignature) {
-                    val iv = codegen.v
-                    iv.aconst(null)
-                    iv.athrow()
+                    val firstIndex = codegen.frameMap.getIndex(specializedEqualsDescriptor.valueParameters[0])
+                    val secondIndex = codegen.frameMap.getIndex(specializedEqualsDescriptor.valueParameters[1])
+                    val asmType = signature.valueParameters[0].asmType
+                    val left = StackValue.local(firstIndex, asmType)
+                    val right = StackValue.local(secondIndex, asmType)
+                    genTotalOrderEqualsForExpressionOnStack(left, right, asmType).put(Type.BOOLEAN_TYPE, codegen.v)
+                    codegen.v.areturn(Type.BOOLEAN_TYPE)
                 }
+
+                override fun skipNotNullAssertionsForParameters(): Boolean = true
             }
         )
     }

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/FunctionsFromAnyGeneratorImpl.java
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/FunctionsFromAnyGeneratorImpl.java
@@ -251,25 +251,7 @@ public class FunctionsFromAnyGeneratorImpl extends FunctionsFromAnyGenerator {
                 return Unit.INSTANCE;
             });
 
-            if (asmType.getSort() == Type.FLOAT) {
-                thisPropertyValue.put(asmType, kotlinType, iv);
-                otherPropertyValue.put(asmType, kotlinType, iv);
-                iv.invokestatic("java/lang/Float", "compare", "(FF)I", false);
-                iv.ifne(ne);
-            }
-            else if (asmType.getSort() == Type.DOUBLE) {
-                thisPropertyValue.put(asmType, kotlinType, iv);
-                otherPropertyValue.put(asmType, kotlinType, iv);
-                iv.invokestatic("java/lang/Double", "compare", "(DD)I", false);
-                iv.ifne(ne);
-            }
-            else {
-                StackValue value = genEqualsForExpressionsOnStack(
-                        KtTokens.EQEQ, thisPropertyValue, otherPropertyValue
-                );
-                value.put(Type.BOOLEAN_TYPE, iv);
-                iv.ifeq(ne);
-            }
+            genTotalOrderEqualsForExpressionOnStack(thisPropertyValue, otherPropertyValue, asmType).condJump(ne, iv, true);
         }
 
         iv.mark(eq);

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/StackValue.java
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/StackValue.java
@@ -621,7 +621,7 @@ public abstract class StackValue {
         return false;
     }
 
-    private static boolean isUnboxedInlineClass(@NotNull KotlinType kotlinType, @NotNull Type actualType) {
+    public static boolean isUnboxedInlineClass(@NotNull KotlinType kotlinType, @NotNull Type actualType) {
         return KotlinTypeMapper.mapUnderlyingTypeOfInlineClassType(kotlinType).equals(actualType);
     }
 

--- a/compiler/frontend/src/org/jetbrains/kotlin/resolve/InlineClassDescriptorResolver.kt
+++ b/compiler/frontend/src/org/jetbrains/kotlin/resolve/InlineClassDescriptorResolver.kt
@@ -19,6 +19,7 @@ object InlineClassDescriptorResolver {
     @JvmField
     val UNBOX_METHOD_NAME = Name.identifier("unbox")
 
+    @JvmField
     val SPECIALIZED_EQUALS_NAME = Name.identifier("equals-impl0")
 
     val BOXING_VALUE_PARAMETER_NAME = Name.identifier("v")

--- a/compiler/frontend/src/org/jetbrains/kotlin/resolve/InlineClassDescriptorResolver.kt
+++ b/compiler/frontend/src/org/jetbrains/kotlin/resolve/InlineClassDescriptorResolver.kt
@@ -19,12 +19,12 @@ object InlineClassDescriptorResolver {
     @JvmField
     val UNBOX_METHOD_NAME = Name.identifier("unbox")
 
-    private val SPECIALIZED_EQUALS_NAME = Name.identifier("equals-impl0")
+    val SPECIALIZED_EQUALS_NAME = Name.identifier("equals-impl0")
 
-    private val BOXING_VALUE_PARAMETER_NAME = Name.identifier("v")
+    val BOXING_VALUE_PARAMETER_NAME = Name.identifier("v")
 
-    private val SPECIALIZED_EQUALS_FIRST_PARAMETER_NAME = Name.identifier("p1")
-    private val SPECIALIZED_EQUALS_SECOND_PARAMETER_NAME = Name.identifier("p2")
+    val SPECIALIZED_EQUALS_FIRST_PARAMETER_NAME = Name.identifier("p1")
+    val SPECIALIZED_EQUALS_SECOND_PARAMETER_NAME = Name.identifier("p2")
 
     @JvmStatic
     fun createBoxFunctionDescriptor(owner: ClassDescriptor): SimpleFunctionDescriptor? =

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/DeclarationOrigins.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/DeclarationOrigins.kt
@@ -39,5 +39,6 @@ interface JvmLoweredDeclarationOrigin : IrDeclarationOrigin {
     object GENERATED_SAM_IMPLEMENTATION : IrDeclarationOriginImpl("GENERATED_SAM_IMPLEMENTATION", isSynthetic = true)
     object ENUM_MAPPINGS_FOR_WHEN : IrDeclarationOriginImpl("ENUM_MAPPINGS_FOR_WHEN", isSynthetic = true)
     object SYNTHETIC_INLINE_CLASS_MEMBER : IrDeclarationOriginImpl("SYNTHETIC_INLINE_CLASS_MEMBER", isSynthetic = true)
+    object INLINE_CLASS_GENERATED_IMPL_METHOD : IrDeclarationOriginImpl("INLINE_CLASS_GENERATED_IMPL_METHOD")
     object GENERATED_ASSERTION_ENABLED_FIELD : IrDeclarationOriginImpl("GENERATED_ASSERTION_ENABLED_FIELD", isSynthetic = true)
 }

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -193,6 +193,8 @@ class ExpressionCodegen(
             return
 
         val isSyntheticOrBridge = irFunction.origin.isSynthetic ||
+                // TODO: Implement this as a lowering, so that we can more easily exclude generated methods.
+                irFunction.origin == JvmLoweredDeclarationOrigin.INLINE_CLASS_GENERATED_IMPL_METHOD ||
                 // Although these are accessible from Java, the functions they bridge to already have the assertions.
                 irFunction.origin == IrDeclarationOrigin.BRIDGE_SPECIAL ||
                 irFunction.origin == JvmLoweredDeclarationOrigin.DEFAULT_IMPLS_BRIDGE ||

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/Equals.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/Equals.kt
@@ -9,14 +9,13 @@ import com.intellij.psi.tree.IElementType
 import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
 import org.jetbrains.kotlin.backend.jvm.codegen.*
 import org.jetbrains.kotlin.codegen.AsmUtil
-import org.jetbrains.kotlin.codegen.AsmUtil.*
+import org.jetbrains.kotlin.codegen.AsmUtil.isPrimitive
 import org.jetbrains.kotlin.codegen.StackValue
 import org.jetbrains.kotlin.codegen.intrinsics.IntrinsicMethods
 import org.jetbrains.kotlin.ir.expressions.IrFunctionAccessExpression
-import org.jetbrains.kotlin.ir.expressions.IrMemberAccessExpression
 import org.jetbrains.kotlin.ir.expressions.IrStatementOrigin
+import org.jetbrains.kotlin.ir.types.classOrNull
 import org.jetbrains.kotlin.ir.types.toKotlinType
-import org.jetbrains.kotlin.ir.util.isInlined
 import org.jetbrains.kotlin.ir.util.isNullConst
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.resolve.jvm.AsmTypes
@@ -44,7 +43,7 @@ class Equals(val operator: IElementType) : IntrinsicMethod() {
         val rightType = with(codegen) { b.asmType }
         val opToken = expression.origin
         val useEquals = opToken !== IrStatementOrigin.EQEQEQ && opToken !== IrStatementOrigin.EXCLEQEQ &&
-                (a.type.isInlined() || b.type.isInlined() ||
+                (a.type.classOrNull?.owner?.isInline == true || b.type.classOrNull?.owner?.isInline == true ||
                 // `==` is `equals` for objects and floating-point numbers. In the latter case, the difference
                 // is that `equals` is a total order (-0 < +0 and NaN == NaN) and `===` is IEEE754-compliant.
                 !isPrimitive(leftType) || leftType != rightType || leftType == Type.FLOAT_TYPE || leftType == Type.DOUBLE_TYPE)

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/Equals.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/Equals.kt
@@ -9,12 +9,15 @@ import com.intellij.psi.tree.IElementType
 import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
 import org.jetbrains.kotlin.backend.jvm.codegen.*
 import org.jetbrains.kotlin.codegen.AsmUtil
+import org.jetbrains.kotlin.codegen.AsmUtil.genAreEqualCall
 import org.jetbrains.kotlin.codegen.AsmUtil.isPrimitive
 import org.jetbrains.kotlin.codegen.StackValue
 import org.jetbrains.kotlin.codegen.intrinsics.IntrinsicMethods
+import org.jetbrains.kotlin.codegen.pseudoInsns.fakeAlwaysFalseIfeq
+import org.jetbrains.kotlin.codegen.pseudoInsns.fakeAlwaysTrueIfeq
 import org.jetbrains.kotlin.ir.expressions.IrFunctionAccessExpression
 import org.jetbrains.kotlin.ir.expressions.IrStatementOrigin
-import org.jetbrains.kotlin.ir.types.classOrNull
+import org.jetbrains.kotlin.ir.types.isNullable
 import org.jetbrains.kotlin.ir.types.toKotlinType
 import org.jetbrains.kotlin.ir.util.isNullConst
 import org.jetbrains.kotlin.lexer.KtTokens
@@ -28,6 +31,12 @@ import org.jetbrains.org.objectweb.asm.Type
 import org.jetbrains.org.objectweb.asm.commons.InstructionAdapter
 
 class Equals(val operator: IElementType) : IntrinsicMethod() {
+    private class BooleanConstantFalseCheck(val value: PromisedValue) : BooleanValue(value.codegen) {
+        override fun materialize() = value.discard().let { mv.iconst(0) }
+        override fun jumpIfFalse(target: Label) = value.discard().let { mv.fakeAlwaysTrueIfeq(target) }
+        override fun jumpIfTrue(target: Label) = value.discard().let { mv.fakeAlwaysFalseIfeq(target) }
+    }
+
     private class BooleanNullCheck(val value: PromisedValue) : BooleanValue(value.codegen) {
         override fun jumpIfFalse(target: Label) = value.materialize().also { mv.ifnonnull(target) }
         override fun jumpIfTrue(target: Label) = value.materialize().also { mv.ifnull(target) }
@@ -36,25 +45,31 @@ class Equals(val operator: IElementType) : IntrinsicMethod() {
     override fun invoke(expression: IrFunctionAccessExpression, codegen: ExpressionCodegen, data: BlockInfo): PromisedValue? {
         val (a, b) = expression.receiverAndArgs()
         if (a.isNullConst() || b.isNullConst()) {
-            return BooleanNullCheck(if (a.isNullConst()) b.accept(codegen, data) else a.accept(codegen, data))
+            val value = if (a.isNullConst()) b.accept(codegen, data) else a.accept(codegen, data)
+            return if (a.type.isNullable() && b.type.isNullable())
+                BooleanNullCheck(value)
+            else
+                BooleanConstantFalseCheck(value)
         }
 
         val leftType = with(codegen) { a.asmType }
         val rightType = with(codegen) { b.asmType }
         val opToken = expression.origin
         val useEquals = opToken !== IrStatementOrigin.EQEQEQ && opToken !== IrStatementOrigin.EXCLEQEQ &&
-                (a.type.classOrNull?.owner?.isInline == true || b.type.classOrNull?.owner?.isInline == true ||
                 // `==` is `equals` for objects and floating-point numbers. In the latter case, the difference
                 // is that `equals` is a total order (-0 < +0 and NaN == NaN) and `===` is IEEE754-compliant.
-                !isPrimitive(leftType) || leftType != rightType || leftType == Type.FLOAT_TYPE || leftType == Type.DOUBLE_TYPE)
-        val operandType = if (!isPrimitive(leftType) || useEquals) AsmTypes.OBJECT_TYPE else leftType
-        val aValue = a.accept(codegen, data).coerce(operandType, a.type).materialized
-        val bValue = b.accept(codegen, data).coerce(operandType, b.type).materialized
-        if (useEquals) {
-            AsmUtil.genAreEqualCall(codegen.mv)
-            return MaterialValue(codegen, Type.BOOLEAN_TYPE, codegen.context.irBuiltIns.booleanType)
+                (!isPrimitive(leftType) || leftType != rightType || leftType == Type.FLOAT_TYPE || leftType == Type.DOUBLE_TYPE)
+        return if (useEquals) {
+            a.accept(codegen, data).coerce(AsmTypes.OBJECT_TYPE, codegen.context.irBuiltIns.anyNType).materialize()
+            b.accept(codegen, data).coerce(AsmTypes.OBJECT_TYPE, codegen.context.irBuiltIns.anyNType).materialize()
+            genAreEqualCall(codegen.mv)
+            MaterialValue(codegen, Type.BOOLEAN_TYPE, codegen.context.irBuiltIns.booleanType)
+        } else {
+            val operandType = if (!isPrimitive(leftType)) AsmTypes.OBJECT_TYPE else leftType
+            val aValue = a.accept(codegen, data).coerce(operandType, a.type).materialized
+            val bValue = b.accept(codegen, data).coerce(operandType, b.type).materialized
+            BooleanComparison(operator, aValue, bValue)
         }
-        return BooleanComparison(operator, aValue, bValue)
     }
 }
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/HashCode.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/HashCode.kt
@@ -16,6 +16,7 @@
 
 package org.jetbrains.kotlin.backend.jvm.intrinsics
 
+import org.jetbrains.kotlin.backend.jvm.JvmLoweredDeclarationOrigin
 import org.jetbrains.kotlin.backend.jvm.codegen.*
 import org.jetbrains.kotlin.codegen.AsmUtil
 import org.jetbrains.kotlin.config.JvmTarget
@@ -32,7 +33,7 @@ object HashCode : IntrinsicMethod() {
         val result = receiver.accept(this, data).materialized
         val target = context.state.target
         when {
-            irFunction.origin == IrDeclarationOrigin.GENERATED_INLINE_CLASS_MEMBER || irFunction.origin == IrDeclarationOrigin.GENERATED_DATA_CLASS_MEMBER ->
+            irFunction.origin == JvmLoweredDeclarationOrigin.INLINE_CLASS_GENERATED_IMPL_METHOD || irFunction.origin == IrDeclarationOrigin.GENERATED_DATA_CLASS_MEMBER ->
                 AsmUtil.genHashCode(mv, mv, result.type, target)
             target == JvmTarget.JVM_1_6 -> {
                 result.coerceToBoxed(receiver.type).materialize()

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/JavaClassProperty.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/JavaClassProperty.kt
@@ -20,7 +20,7 @@ import org.jetbrains.kotlin.backend.jvm.codegen.*
 import org.jetbrains.kotlin.codegen.AsmUtil.boxType
 import org.jetbrains.kotlin.codegen.AsmUtil.isPrimitive
 import org.jetbrains.kotlin.ir.expressions.IrFunctionAccessExpression
-import org.jetbrains.kotlin.ir.util.isInlined
+import org.jetbrains.kotlin.ir.types.classOrNull
 import org.jetbrains.kotlin.resolve.jvm.AsmTypes
 import org.jetbrains.org.objectweb.asm.Type
 
@@ -34,7 +34,7 @@ object JavaClassProperty : IntrinsicMethod() {
         when {
             value.type == Type.VOID_TYPE ->
                 invokeGetClass(value.coerce(AsmTypes.UNIT_TYPE, value.codegen.context.irBuiltIns.unitType))
-            value.irType.isInlined() ->
+            value.irType.classOrNull?.owner?.isInline == true ->
                 invokeGetClass(value.coerceToBoxed(value.irType))
             isPrimitive(value.type) -> {
                 value.discard()

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/inlineclasses/InlineClassAbi.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/inlineclasses/InlineClassAbi.kt
@@ -11,7 +11,6 @@ import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.types.*
 import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.load.java.JvmAbi
-import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.resolve.DescriptorUtils
 
@@ -29,6 +28,7 @@ object InlineClassAbi {
         val klass = type.classOrNull?.owner ?: return null
         if (!klass.isInline) return null
 
+        // TODO: Apply type substitutions
         val underlyingType = getUnderlyingType(klass).unboxInlineClass()
         if (!type.isNullable())
             return underlyingType

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/inlineclasses/MemoizedInlineClassReplacements.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/inlineclasses/MemoizedInlineClassReplacements.kt
@@ -157,6 +157,9 @@ class MemoizedInlineClassReplacements {
     private fun buildReplacement(function: IrFunction, body: IrFunctionImpl.() -> Unit) =
         buildFunWithDescriptorForInlining(function.descriptor) {
             updateFrom(function)
+            if (function.origin == IrDeclarationOrigin.GENERATED_INLINE_CLASS_MEMBER) {
+                origin = JvmLoweredDeclarationOrigin.INLINE_CLASS_GENERATED_IMPL_METHOD
+            }
             name = mangledNameFor(function)
             returnType = function.returnType
         }.apply {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/inlineclasses/MemoizedInlineClassReplacements.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/inlineclasses/MemoizedInlineClassReplacements.kt
@@ -11,18 +11,23 @@ import org.jetbrains.kotlin.backend.common.ir.copyTypeParametersFrom
 import org.jetbrains.kotlin.backend.common.ir.createDispatchReceiverParameter
 import org.jetbrains.kotlin.backend.jvm.JvmLoweredDeclarationOrigin
 import org.jetbrains.kotlin.backend.jvm.lower.inlineclasses.InlineClassAbi.mangledNameFor
+import org.jetbrains.kotlin.codegen.state.KotlinTypeMapper
 import org.jetbrains.kotlin.ir.builders.declarations.addValueParameter
 import org.jetbrains.kotlin.ir.builders.declarations.buildFun
 import org.jetbrains.kotlin.ir.builders.declarations.buildFunWithDescriptorForInlining
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrFunctionImpl
+import org.jetbrains.kotlin.ir.descriptors.IrBuiltIns
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.symbols.IrValueParameterSymbol
 import org.jetbrains.kotlin.ir.types.getClass
+import org.jetbrains.kotlin.ir.types.impl.IrSimpleTypeImpl
+import org.jetbrains.kotlin.ir.types.impl.IrStarProjectionImpl
 import org.jetbrains.kotlin.ir.util.constructedClass
 import org.jetbrains.kotlin.ir.util.defaultType
 import org.jetbrains.kotlin.ir.util.explicitParameters
 import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.resolve.InlineClassDescriptorResolver
 import org.jetbrains.kotlin.storage.LockBasedStorageManager
 
 class IrReplacementFunction(
@@ -73,14 +78,14 @@ class MemoizedInlineClassReplacements {
         storageManager.createMemoizedFunction { irClass ->
             require(irClass.isInline)
             buildFun {
-                name = Name.identifier("box-impl")
+                name = Name.identifier(KotlinTypeMapper.BOX_JVM_METHOD_NAME)
                 origin = JvmLoweredDeclarationOrigin.SYNTHETIC_INLINE_CLASS_MEMBER
                 returnType = irClass.defaultType
             }.apply {
                 parent = irClass
                 copyTypeParametersFrom(irClass)
                 addValueParameter {
-                    name = Name.identifier("v")
+                    name = InlineClassDescriptorResolver.BOXING_VALUE_PARAMETER_NAME
                     type = InlineClassAbi.getUnderlyingType(irClass)
                 }
             }
@@ -94,7 +99,7 @@ class MemoizedInlineClassReplacements {
         storageManager.createMemoizedFunction { irClass ->
             require(irClass.isInline)
             buildFun {
-                name = Name.identifier("unbox-impl")
+                name = Name.identifier(KotlinTypeMapper.UNBOX_JVM_METHOD_NAME)
                 origin = JvmLoweredDeclarationOrigin.SYNTHETIC_INLINE_CLASS_MEMBER
                 returnType = InlineClassAbi.getUnderlyingType(irClass)
             }.apply {
@@ -102,6 +107,32 @@ class MemoizedInlineClassReplacements {
                 createDispatchReceiverParameter()
             }
         }
+
+    private val specializedEqualsCache = storageManager.createCacheWithNotNullValues<IrClass, IrSimpleFunction>()
+    fun getSpecializedEqualsMethod(irClass: IrClass, irBuiltIns: IrBuiltIns): IrSimpleFunction {
+        require(irClass.isInline)
+        return specializedEqualsCache.computeIfAbsent(irClass) {
+            buildFun {
+                name = InlineClassDescriptorResolver.SPECIALIZED_EQUALS_NAME
+                // TODO: Revisit this once we allow user defined equals methods in inline classes.
+                origin = JvmLoweredDeclarationOrigin.INLINE_CLASS_GENERATED_IMPL_METHOD
+                returnType = irBuiltIns.booleanType
+            }.apply {
+                parent = irClass
+                // We ignore type arguments here, since there is no good way to go from type arguments to types in the IR anyway.
+                val typeArgument =
+                    IrSimpleTypeImpl(null, irClass.symbol, false, List(irClass.typeParameters.size) { IrStarProjectionImpl }, listOf())
+                addValueParameter {
+                    name = InlineClassDescriptorResolver.SPECIALIZED_EQUALS_FIRST_PARAMETER_NAME
+                    type = typeArgument
+                }
+                addValueParameter {
+                    name = InlineClassDescriptorResolver.SPECIALIZED_EQUALS_SECOND_PARAMETER_NAME
+                    type = typeArgument
+                }
+            }
+        }
+    }
 
     private fun createMethodReplacement(function: IrFunction): IrReplacementFunction? {
         require(function.dispatchReceiverParameter != null && function is IrSimpleFunction)

--- a/compiler/testData/codegen/box/inlineClasses/callSpecializedEqualsViaReflection.kt
+++ b/compiler/testData/codegen/box/inlineClasses/callSpecializedEqualsViaReflection.kt
@@ -15,11 +15,7 @@ fun box(): String {
         Simple::class.java.getDeclaredMethod(name, String::class.java, String::class.java)
             ?: return "$name not found"
 
-    val result = try {
-        specializedEquals.invoke(null, "a", "b")
-    } catch (e: InvocationTargetException) {
-        return if (e.targetException is NullPointerException) "OK" else "${e.targetException}"
-    }
-
-    return if (result == false) "OK" else "Fail"
+    if (specializedEquals.invoke(null, "a", "b") as Boolean)
+        return "Fail"
+    return "OK"
 }

--- a/compiler/testData/codegen/box/inlineClasses/callSpecializedEqualsViaReflection.kt
+++ b/compiler/testData/codegen/box/inlineClasses/callSpecializedEqualsViaReflection.kt
@@ -1,6 +1,5 @@
 // WITH_REFLECT
 // FULL_JDK
-// IGNORE_BACKEND: JVM_IR
 // TARGET_BACKEND: JVM
 
 import java.lang.reflect.InvocationTargetException
@@ -16,11 +15,11 @@ fun box(): String {
         Simple::class.java.getDeclaredMethod(name, String::class.java, String::class.java)
             ?: return "$name not found"
 
-    try {
+    val result = try {
         specializedEquals.invoke(null, "a", "b")
     } catch (e: InvocationTargetException) {
         return if (e.targetException is NullPointerException) "OK" else "${e.targetException}"
     }
 
-    return "Reserved method invoked successfully"
+    return if (result == false) "OK" else "Fail"
 }

--- a/compiler/testData/codegen/box/inlineClasses/defaultParameterValues/defaultValueOfInlineClassTypeInInlineFun.kt
+++ b/compiler/testData/codegen/box/inlineClasses/defaultParameterValues/defaultValueOfInlineClassTypeInInlineFun.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: +InlineClasses
-// IGNORE_BACKEND: JVM_IR
 
 inline class Z(val int: Int)
 inline class L(val long: Long)

--- a/compiler/testData/codegen/box/inlineClasses/equalityChecksInlineClassNonNull.kt
+++ b/compiler/testData/codegen/box/inlineClasses/equalityChecksInlineClassNonNull.kt
@@ -1,0 +1,50 @@
+// !LANGUAGE: +InlineClasses
+
+inline class Inner(val w: String)
+inline class A(val x: Inner)
+
+fun isNullVacuousLeft(s: A) = s == null
+fun isNullVacuousRight(s: A) = null == s
+fun isNullLeft(s: A?) = s == null
+fun isNullRight(s: A?) = null == s
+fun isEqualSame(s: A, t: A) = s == t
+fun isEqualAnyLeft(s: A, t: Any?) = s == t
+fun isEqualAnyRight(s: Any?, t: A) = s == t
+fun isEqualSameNullable(s: A?, t: A?) = s == t
+fun isEqualAnyNullableLeft(s: A?, t: Any?) = s == t
+fun isEqualAnyNullableRight(s: Any?, t: A?) = s == t
+
+fun box(): String {
+    if (isNullVacuousLeft(A(Inner("")))) return "Fail 1"
+    if (isNullVacuousRight(A(Inner("")))) return "Fail 2"
+    if (isNullLeft(A(Inner("")))) return "Fail 3"
+    if (isNullRight(A(Inner("")))) return "Fail 4"
+    if (!isNullLeft(null)) return "Fail 5"
+    if (!isNullRight(null)) return "Fail 6"
+    if (!isEqualSame(A(Inner("")), A(Inner("")))) return "Fail 7"
+    if (isEqualSame(A(Inner("")), A(Inner("a")))) return "Fail 8"
+    if (isEqualAnyLeft(A(Inner("")), Inner(""))) return "Fail 9"
+    if (isEqualAnyLeft(A(Inner("")), null)) return "Fail 10"
+    if (!isEqualAnyLeft(A(Inner("")), A(Inner("")))) return "Fail 11"
+    if (isEqualAnyRight(Inner(""), A(Inner("")))) return "Fail 12"
+    if (isEqualAnyRight(null, A(Inner("")))) return "Fail 13"
+    if (!isEqualAnyRight(A(Inner("")), A(Inner("")))) return "Fail 14"
+    if (!isEqualSameNullable(null, null)) return "Fail 15"
+    if (!isEqualSameNullable(A(Inner("")), A(Inner("")))) return "Fail 16"
+    if (isEqualSameNullable(null, A(Inner("")))) return "Fail 17"
+    if (isEqualSameNullable(A(Inner("")), null)) return "Fail 18"
+    if (isEqualSameNullable(A(Inner("")), A(Inner("a")))) return "Fail 19"
+    if (!isEqualAnyNullableLeft(null, null)) return "Fail 20"
+    if (!isEqualAnyNullableLeft(A(Inner("")), A(Inner("")))) return "Fail 21"
+    if (isEqualAnyNullableLeft(A(Inner("")), "")) return "Fail 22"
+    if (isEqualAnyNullableLeft(null, Inner(""))) return "Fail 23"
+    if (isEqualAnyNullableLeft(A(Inner("")), null)) return "Fail 24"
+    if (isEqualAnyNullableLeft(A(Inner("")), A(Inner("a")))) return "Fail 25"
+    if (!isEqualAnyNullableRight(null, null)) return "Fail 26"
+    if (!isEqualAnyNullableRight(A(Inner("a")), A(Inner("a")))) return "Fail 27"
+    if (isEqualAnyNullableRight(Inner(""), A(Inner("")))) return "Fail 28"
+    if (isEqualAnyNullableRight(Inner(""), null)) return "Fail 29"
+    if (isEqualAnyNullableRight(null, A(Inner("")))) return "Fail 30"
+    if (isEqualAnyNullableRight(A(Inner("a")), A(Inner("b")))) return "Fail 31"
+    return "OK"
+}

--- a/compiler/testData/codegen/box/inlineClasses/equalityChecksMixedNullability.kt
+++ b/compiler/testData/codegen/box/inlineClasses/equalityChecksMixedNullability.kt
@@ -1,0 +1,14 @@
+// !LANGUAGE: +InlineClasses
+
+inline class A(val a: String)
+
+fun isEqualNA(x: A?, y: A) = x == y
+fun isEqualAN(x: A, y: A?) = x == y
+
+fun box(): String {
+    if (isEqualNA(null, A(""))) return "Fail 1"
+    if (isEqualAN(A(""), null)) return "Fail 2"
+    if (!isEqualNA(A(""), A(""))) return "Fail 3"
+    if (!isEqualAN(A(""), A(""))) return "Fail 4"
+    return "OK"
+}

--- a/compiler/testData/codegen/box/inlineClasses/equalityChecksNegatedInlineClassNonNull.kt
+++ b/compiler/testData/codegen/box/inlineClasses/equalityChecksNegatedInlineClassNonNull.kt
@@ -1,0 +1,50 @@
+// !LANGUAGE: +InlineClasses
+
+inline class Inner(val w: String)
+inline class A(val x: Inner)
+
+fun isNotNullVacuousLeft(s: A) = s != null
+fun isNotNullVacuousRight(s: A) = null != s
+fun isNotNullLeft(s: A?) = s != null
+fun isNotNullRight(s: A?) = null != s
+fun isNotEqualSame(s: A, t: A) = s != t
+fun isNotEqualAnyLeft(s: A, t: Any?) = s != t
+fun isNotEqualAnyRight(s: Any?, t: A) = s != t
+fun isNotEqualSameNullable(s: A?, t: A?) = s != t
+fun isNotEqualAnyNullableLeft(s: A?, t: Any?) = s != t
+fun isNotEqualAnyNullableRight(s: Any?, t: A?) = s != t
+
+fun box(): String {
+    if (!isNotNullVacuousLeft(A(Inner("")))) return "Fail 1"
+    if (!isNotNullVacuousRight(A(Inner("")))) return "Fail 2"
+    if (!isNotNullLeft(A(Inner("")))) return "Fail 3"
+    if (!isNotNullRight(A(Inner("")))) return "Fail 4"
+    if (isNotNullLeft(null)) return "Fail 5"
+    if (isNotNullRight(null)) return "Fail 6"
+    if (isNotEqualSame(A(Inner("")), A(Inner("")))) return "Fail 7"
+    if (!isNotEqualSame(A(Inner("")), A(Inner("a")))) return "Fail 8"
+    if (!isNotEqualAnyLeft(A(Inner("")), Inner(""))) return "Fail 9"
+    if (!isNotEqualAnyLeft(A(Inner("")), null)) return "Fail 10"
+    if (isNotEqualAnyLeft(A(Inner("")), A(Inner("")))) return "Fail 11"
+    if (!isNotEqualAnyRight(Inner(""), A(Inner("")))) return "Fail 12"
+    if (!isNotEqualAnyRight(null, A(Inner("")))) return "Fail 13"
+    if (isNotEqualAnyRight(A(Inner("")), A(Inner("")))) return "Fail 14"
+    if (isNotEqualSameNullable(null, null)) return "Fail 15"
+    if (isNotEqualSameNullable(A(Inner("")), A(Inner("")))) return "Fail 16"
+    if (!isNotEqualSameNullable(null, A(Inner("")))) return "Fail 17"
+    if (!isNotEqualSameNullable(A(Inner("")), null)) return "Fail 18"
+    if (!isNotEqualSameNullable(A(Inner("")), A(Inner("a")))) return "Fail 19"
+    if (isNotEqualAnyNullableLeft(null, null)) return "Fail 20"
+    if (isNotEqualAnyNullableLeft(A(Inner("")), A(Inner("")))) return "Fail 21"
+    if (!isNotEqualAnyNullableLeft(A(Inner("")), "")) return "Fail 22"
+    if (!isNotEqualAnyNullableLeft(null, Inner(""))) return "Fail 23"
+    if (!isNotEqualAnyNullableLeft(A(Inner("")), null)) return "Fail 24"
+    if (!isNotEqualAnyNullableLeft(A(Inner("")), A(Inner("a")))) return "Fail 25"
+    if (isNotEqualAnyNullableRight(null, null)) return "Fail 26"
+    if (isNotEqualAnyNullableRight(A(Inner("a")), A(Inner("a")))) return "Fail 27"
+    if (!isNotEqualAnyNullableRight(Inner(""), A(Inner("")))) return "Fail 28"
+    if (!isNotEqualAnyNullableRight(Inner(""), null)) return "Fail 29"
+    if (!isNotEqualAnyNullableRight(null, A(Inner("")))) return "Fail 30"
+    if (!isNotEqualAnyNullableRight(A(Inner("a")), A(Inner("b")))) return "Fail 31"
+    return "OK"
+}

--- a/compiler/testData/codegen/box/inlineClasses/equalityChecksNegatedNonNull.kt
+++ b/compiler/testData/codegen/box/inlineClasses/equalityChecksNegatedNonNull.kt
@@ -1,0 +1,49 @@
+// !LANGUAGE: +InlineClasses
+
+inline class A(val x: String)
+
+fun isNotNullVacuousLeft(s: A) = s != null
+fun isNotNullVacuousRight(s: A) = null != s
+fun isNotNullLeft(s: A?) = s != null
+fun isNotNullRight(s: A?) = null != s
+fun isNotEqualSame(s: A, t: A) = s != t
+fun isNotEqualAnyLeft(s: A, t: Any?) = s != t
+fun isNotEqualAnyRight(s: Any?, t: A) = s != t
+fun isNotEqualSameNullable(s: A?, t: A?) = s != t
+fun isNotEqualAnyNullableLeft(s: A?, t: Any?) = s != t
+fun isNotEqualAnyNullableRight(s: Any?, t: A?) = s != t
+
+fun box(): String {
+    if (!isNotNullVacuousLeft(A(""))) return "Fail 1"
+    if (!isNotNullVacuousRight(A(""))) return "Fail 2"
+    if (!isNotNullLeft(A(""))) return "Fail 3"
+    if (!isNotNullRight(A(""))) return "Fail 4"
+    if (isNotNullLeft(null)) return "Fail 5"
+    if (isNotNullRight(null)) return "Fail 6"
+    if (isNotEqualSame(A(""), A(""))) return "Fail 7"
+    if (!isNotEqualSame(A("a"), A("b"))) return "Fail 8"
+    if (!isNotEqualAnyLeft(A(""), "")) return "Fail 9"
+    if (!isNotEqualAnyLeft(A(""), null)) return "Fail 10"
+    if (isNotEqualAnyLeft(A(""), A(""))) return "Fail 11"
+    if (!isNotEqualAnyRight("", A(""))) return "Fail 12"
+    if (!isNotEqualAnyRight(null, A(""))) return "Fail 13"
+    if (isNotEqualAnyRight(A(""), A(""))) return "Fail 14"
+    if (isNotEqualSameNullable(null, null)) return "Fail 15"
+    if (isNotEqualSameNullable(A(""), A(""))) return "Fail 16"
+    if (!isNotEqualSameNullable(null, A(""))) return "Fail 17"
+    if (!isNotEqualSameNullable(A(""), null)) return "Fail 18"
+    if (!isNotEqualSameNullable(A(""), A("a"))) return "Fail 19"
+    if (isNotEqualAnyNullableLeft(null, null)) return "Fail 20"
+    if (isNotEqualAnyNullableLeft(A(""), A(""))) return "Fail 21"
+    if (!isNotEqualAnyNullableLeft(A(""), "")) return "Fail 22"
+    if (!isNotEqualAnyNullableLeft(null, "")) return "Fail 23"
+    if (!isNotEqualAnyNullableLeft(A(""), null)) return "Fail 24"
+    if (!isNotEqualAnyNullableLeft(A(""), A("a"))) return "Fail 25"
+    if (isNotEqualAnyNullableRight(null, null)) return "Fail 26"
+    if (isNotEqualAnyNullableRight(A(""), A(""))) return "Fail 27"
+    if (!isNotEqualAnyNullableRight("", A(""))) return "Fail 28"
+    if (!isNotEqualAnyNullableRight("", null)) return "Fail 29"
+    if (!isNotEqualAnyNullableRight(null, A(""))) return "Fail 30"
+    if (!isNotEqualAnyNullableRight(A(""), A("a"))) return "Fail 31"
+    return "OK"
+}

--- a/compiler/testData/codegen/box/inlineClasses/equalityChecksNegatedNonNull.kt
+++ b/compiler/testData/codegen/box/inlineClasses/equalityChecksNegatedNonNull.kt
@@ -12,6 +12,8 @@ fun isNotEqualAnyRight(s: Any?, t: A) = s != t
 fun isNotEqualSameNullable(s: A?, t: A?) = s != t
 fun isNotEqualAnyNullableLeft(s: A?, t: Any?) = s != t
 fun isNotEqualAnyNullableRight(s: Any?, t: A?) = s != t
+fun isNotEqualNullableUnboxedLeft(s: A, t: A?) = s != t
+fun isNotEqualNullableUnboxedRight(s: A?, t: A) = s != t
 
 fun box(): String {
     if (!isNotNullVacuousLeft(A(""))) return "Fail 1"
@@ -45,5 +47,11 @@ fun box(): String {
     if (!isNotEqualAnyNullableRight("", null)) return "Fail 29"
     if (!isNotEqualAnyNullableRight(null, A(""))) return "Fail 30"
     if (!isNotEqualAnyNullableRight(A(""), A("a"))) return "Fail 31"
+    if (!isNotEqualNullableUnboxedLeft(A(""), A("a"))) return "Fail 32"
+    if (isNotEqualNullableUnboxedLeft(A(""), A(""))) return "Fail 33"
+    if (!isNotEqualNullableUnboxedRight(A(""), A("a"))) return "Fail 34"
+    if (isNotEqualNullableUnboxedRight(A("a"), A("a"))) return "Fail 35"
+    if (!isNotEqualNullableUnboxedLeft(A(""), null)) return "Fail 36"
+    if (!isNotEqualNullableUnboxedRight(null, A(""))) return "Fail 37"
     return "OK"
 }

--- a/compiler/testData/codegen/box/inlineClasses/equalityChecksNegatedNullable.kt
+++ b/compiler/testData/codegen/box/inlineClasses/equalityChecksNegatedNullable.kt
@@ -1,0 +1,61 @@
+// !LANGUAGE: +InlineClasses
+
+inline class A(val x: Any?)
+
+fun isNotNullVacuousLeft(s: A) = s != null
+fun isNotNullVacuousRight(s: A) = null != s
+fun isNotNullLeft(s: A?) = s != null
+fun isNotNullRight(s: A?) = null != s
+fun isNotEqualSame(s: A, t: A) = s != t
+fun isNotEqualAnyLeft(s: A, t: Any?) = s != t
+fun isNotEqualAnyRight(s: Any?, t: A) = s != t
+fun isNotEqualSameNullable(s: A?, t: A?) = s != t
+fun isNotEqualAnyNullableLeft(s: A?, t: Any?) = s != t
+fun isNotEqualAnyNullableRight(s: Any?, t: A?) = s != t
+
+fun box(): String {
+    if (!isNotNullVacuousLeft(A(0))) return "Fail 1"
+    if (!isNotNullVacuousRight(A(0))) return "Fail 2"
+    if (!isNotNullLeft(A(0))) return "Fail 3"
+    if (!isNotNullRight(A(0))) return "Fail 4"
+    if (isNotNullLeft(null)) return "Fail 5"
+    if (isNotNullRight(null)) return "Fail 6"
+    if (isNotEqualSame(A(0), A(0))) return "Fail 7"
+    if (!isNotEqualSame(A(0), A(1))) return "Fail 8"
+    if (!isNotEqualAnyLeft(A(0), 0)) return "Fail 9"
+    if (!isNotEqualAnyLeft(A(0), null)) return "Fail 10"
+    if (isNotEqualAnyLeft(A(0), A(0))) return "Fail 11"
+    if (!isNotEqualAnyRight(0, A(0))) return "Fail 12"
+    if (!isNotEqualAnyRight(null, A(0))) return "Fail 13"
+    if (isNotEqualAnyRight(A(0), A(0))) return "Fail 14"
+    if (isNotEqualSameNullable(null, null)) return "Fail 15"
+    if (isNotEqualSameNullable(A(0), A(0))) return "Fail 16"
+    if (!isNotEqualSameNullable(null, A(0))) return "Fail 17"
+    if (!isNotEqualSameNullable(A(0), null)) return "Fail 18"
+    if (!isNotEqualSameNullable(A(0), A(1))) return "Fail 19"
+    if (isNotEqualAnyNullableLeft(null, null)) return "Fail 20"
+    if (isNotEqualAnyNullableLeft(A(0), A(0))) return "Fail 21"
+    if (!isNotEqualAnyNullableLeft(A(0), 0)) return "Fail 22"
+    if (!isNotEqualAnyNullableLeft(null, 0)) return "Fail 23"
+    if (!isNotEqualAnyNullableLeft(A(0), null)) return "Fail 24"
+    if (!isNotEqualAnyNullableLeft(A(0), A(1))) return "Fail 25"
+    if (isNotEqualAnyNullableRight(null, null)) return "Fail 26"
+    if (isNotEqualAnyNullableRight(A(0), A(0))) return "Fail 27"
+    if (!isNotEqualAnyNullableRight(0, A(0))) return "Fail 28"
+    if (!isNotEqualAnyNullableRight(0, null)) return "Fail 29"
+    if (!isNotEqualAnyNullableRight(null, A(0))) return "Fail 30"
+    if (!isNotEqualAnyNullableRight(A(0), A(1))) return "Fail 31"
+
+    if (!isNotNullVacuousLeft(A(null))) return "Fail 32"
+    if (!isNotNullVacuousRight(A(null))) return "Fail 33"
+    if (!isNotNullLeft(A(null))) return "Fail 34"
+    if (!isNotNullRight(A(null))) return "Fail 35"
+    if (!isNotEqualAnyLeft(A(null), null)) return "Fail 36"
+    if (!isNotEqualAnyRight(null, A(null))) return "Fail 37"
+    if (!isNotEqualAnyNullableLeft(A(null), null)) return "Fail 38"
+    if (!isNotEqualAnyNullableRight(null, A(null))) return "Fail 39"
+    if (!isNotEqualSameNullable(A(null), null)) return "Fail 42"
+    if (!isNotEqualSameNullable(null, A(null))) return "Fail 43"
+
+    return "OK"
+}

--- a/compiler/testData/codegen/box/inlineClasses/equalityChecksNegatedNullable.kt
+++ b/compiler/testData/codegen/box/inlineClasses/equalityChecksNegatedNullable.kt
@@ -12,6 +12,8 @@ fun isNotEqualAnyRight(s: Any?, t: A) = s != t
 fun isNotEqualSameNullable(s: A?, t: A?) = s != t
 fun isNotEqualAnyNullableLeft(s: A?, t: Any?) = s != t
 fun isNotEqualAnyNullableRight(s: Any?, t: A?) = s != t
+fun isNotEqualNullableUnboxedLeft(s: A, t: A?) = s != t
+fun isNotEqualNullableUnboxedRight(s: A?, t: A) = s != t
 
 fun box(): String {
     if (!isNotNullVacuousLeft(A(0))) return "Fail 1"
@@ -56,6 +58,16 @@ fun box(): String {
     if (!isNotEqualAnyNullableRight(null, A(null))) return "Fail 39"
     if (!isNotEqualSameNullable(A(null), null)) return "Fail 42"
     if (!isNotEqualSameNullable(null, A(null))) return "Fail 43"
+
+    if (!isNotEqualNullableUnboxedLeft(A(0), A(1))) return "Fail 44"
+    if (isNotEqualNullableUnboxedLeft(A(0), A(0))) return "Fail 45"
+    if (!isNotEqualNullableUnboxedRight(A(0), A(1))) return "Fail 46"
+    if (isNotEqualNullableUnboxedRight(A(1), A(1))) return "Fail 47"
+    if (!isNotEqualNullableUnboxedLeft(A(0), null)) return "Fail 48"
+    if (!isNotEqualNullableUnboxedRight(null, A(1))) return "Fail 49"
+
+    if (!isNotEqualNullableUnboxedRight(null, A(null))) return "Fail 50"
+    if (!isNotEqualNullableUnboxedLeft(A(null), null)) return "Fail 51"
 
     return "OK"
 }

--- a/compiler/testData/codegen/box/inlineClasses/equalityChecksNegatedPrimitive.kt
+++ b/compiler/testData/codegen/box/inlineClasses/equalityChecksNegatedPrimitive.kt
@@ -1,0 +1,49 @@
+// !LANGUAGE: +InlineClasses
+
+inline class A(val x: Int)
+
+fun isNotNullVacuousLeft(s: A) = s != null
+fun isNotNullVacuousRight(s: A) = null != s
+fun isNotNullLeft(s: A?) = s != null
+fun isNotNullRight(s: A?) = null != s
+fun isNotEqualSame(s: A, t: A) = s != t
+fun isNotEqualAnyLeft(s: A, t: Any?) = s != t
+fun isNotEqualAnyRight(s: Any?, t: A) = s != t
+fun isNotEqualSameNullable(s: A?, t: A?) = s != t
+fun isNotEqualAnyNullableLeft(s: A?, t: Any?) = s != t
+fun isNotEqualAnyNullableRight(s: Any?, t: A?) = s != t
+
+fun box(): String {
+    if (!isNotNullVacuousLeft(A(0))) return "Fail 1"
+    if (!isNotNullVacuousRight(A(0))) return "Fail 2"
+    if (!isNotNullLeft(A(0))) return "Fail 3"
+    if (!isNotNullRight(A(0))) return "Fail 4"
+    if (isNotNullLeft(null)) return "Fail 5"
+    if (isNotNullRight(null)) return "Fail 6"
+    if (isNotEqualSame(A(0), A(0))) return "Fail 7"
+    if (!isNotEqualSame(A(0), A(1))) return "Fail 8"
+    if (!isNotEqualAnyLeft(A(0), 0)) return "Fail 9"
+    if (!isNotEqualAnyLeft(A(0), null)) return "Fail 10"
+    if (isNotEqualAnyLeft(A(0), A(0))) return "Fail 11"
+    if (!isNotEqualAnyRight(0, A(0))) return "Fail 12"
+    if (!isNotEqualAnyRight(null, A(0))) return "Fail 13"
+    if (isNotEqualAnyRight(A(0), A(0))) return "Fail 14"
+    if (isNotEqualSameNullable(null, null)) return "Fail 15"
+    if (isNotEqualSameNullable(A(0), A(0))) return "Fail 16"
+    if (!isNotEqualSameNullable(null, A(0))) return "Fail 17"
+    if (!isNotEqualSameNullable(A(0), null)) return "Fail 18"
+    if (!isNotEqualSameNullable(A(0), A(1))) return "Fail 19"
+    if (isNotEqualAnyNullableLeft(null, null)) return "Fail 20"
+    if (isNotEqualAnyNullableLeft(A(0), A(0))) return "Fail 21"
+    if (!isNotEqualAnyNullableLeft(A(0), 0)) return "Fail 22"
+    if (!isNotEqualAnyNullableLeft(null, 0)) return "Fail 23"
+    if (!isNotEqualAnyNullableLeft(A(0), null)) return "Fail 24"
+    if (!isNotEqualAnyNullableLeft(A(0), A(1))) return "Fail 25"
+    if (isNotEqualAnyNullableRight(null, null)) return "Fail 26"
+    if (isNotEqualAnyNullableRight(A(0), A(0))) return "Fail 27"
+    if (!isNotEqualAnyNullableRight(0, A(0))) return "Fail 28"
+    if (!isNotEqualAnyNullableRight(0, null)) return "Fail 29"
+    if (!isNotEqualAnyNullableRight(null, A(0))) return "Fail 30"
+    if (!isNotEqualAnyNullableRight(A(0), A(1))) return "Fail 31"
+    return "OK"
+}

--- a/compiler/testData/codegen/box/inlineClasses/equalityChecksNegatedPrimitive.kt
+++ b/compiler/testData/codegen/box/inlineClasses/equalityChecksNegatedPrimitive.kt
@@ -12,6 +12,8 @@ fun isNotEqualAnyRight(s: Any?, t: A) = s != t
 fun isNotEqualSameNullable(s: A?, t: A?) = s != t
 fun isNotEqualAnyNullableLeft(s: A?, t: Any?) = s != t
 fun isNotEqualAnyNullableRight(s: Any?, t: A?) = s != t
+fun isNotEqualNullableUnboxedLeft(s: A, t: A?) = s != t
+fun isNotEqualNullableUnboxedRight(s: A?, t: A) = s != t
 
 fun box(): String {
     if (!isNotNullVacuousLeft(A(0))) return "Fail 1"
@@ -45,5 +47,11 @@ fun box(): String {
     if (!isNotEqualAnyNullableRight(0, null)) return "Fail 29"
     if (!isNotEqualAnyNullableRight(null, A(0))) return "Fail 30"
     if (!isNotEqualAnyNullableRight(A(0), A(1))) return "Fail 31"
+    if (!isNotEqualNullableUnboxedLeft(A(0), A(1))) return "Fail 32"
+    if (isNotEqualNullableUnboxedLeft(A(0), A(0))) return "Fail 33"
+    if (!isNotEqualNullableUnboxedRight(A(0), A(1))) return "Fail 34"
+    if (isNotEqualNullableUnboxedRight(A(1), A(1))) return "Fail 35"
+    if (!isNotEqualNullableUnboxedLeft(A(0), null)) return "Fail 36"
+    if (!isNotEqualNullableUnboxedRight(null, A(1))) return "Fail 37"
     return "OK"
 }

--- a/compiler/testData/codegen/box/inlineClasses/equalityChecksNonNull.kt
+++ b/compiler/testData/codegen/box/inlineClasses/equalityChecksNonNull.kt
@@ -1,0 +1,49 @@
+// !LANGUAGE: +InlineClasses
+
+inline class A(val x: String)
+
+fun isNullVacuousLeft(s: A) = s == null
+fun isNullVacuousRight(s: A) = null == s
+fun isNullLeft(s: A?) = s == null
+fun isNullRight(s: A?) = null == s
+fun isEqualSame(s: A, t: A) = s == t
+fun isEqualAnyLeft(s: A, t: Any?) = s == t
+fun isEqualAnyRight(s: Any?, t: A) = s == t
+fun isEqualSameNullable(s: A?, t: A?) = s == t
+fun isEqualAnyNullableLeft(s: A?, t: Any?) = s == t
+fun isEqualAnyNullableRight(s: Any?, t: A?) = s == t
+
+fun box(): String {
+    if (isNullVacuousLeft(A(""))) return "Fail 1"
+    if (isNullVacuousRight(A(""))) return "Fail 2"
+    if (isNullLeft(A(""))) return "Fail 3"
+    if (isNullRight(A(""))) return "Fail 4"
+    if (!isNullLeft(null)) return "Fail 5"
+    if (!isNullRight(null)) return "Fail 6"
+    if (!isEqualSame(A(""), A(""))) return "Fail 7"
+    if (isEqualSame(A("a"), A("b"))) return "Fail 8"
+    if (isEqualAnyLeft(A(""), "")) return "Fail 9"
+    if (isEqualAnyLeft(A(""), null)) return "Fail 10"
+    if (!isEqualAnyLeft(A(""), A(""))) return "Fail 11"
+    if (isEqualAnyRight("", A(""))) return "Fail 12"
+    if (isEqualAnyRight(null, A(""))) return "Fail 13"
+    if (!isEqualAnyRight(A(""), A(""))) return "Fail 14"
+    if (!isEqualSameNullable(null, null)) return "Fail 15"
+    if (!isEqualSameNullable(A(""), A(""))) return "Fail 16"
+    if (isEqualSameNullable(null, A(""))) return "Fail 17"
+    if (isEqualSameNullable(A(""), null)) return "Fail 18"
+    if (isEqualSameNullable(A(""), A("a"))) return "Fail 19"
+    if (!isEqualAnyNullableLeft(null, null)) return "Fail 20"
+    if (!isEqualAnyNullableLeft(A(""), A(""))) return "Fail 21"
+    if (isEqualAnyNullableLeft(A(""), "")) return "Fail 22"
+    if (isEqualAnyNullableLeft(null, "")) return "Fail 23"
+    if (isEqualAnyNullableLeft(A(""), null)) return "Fail 24"
+    if (isEqualAnyNullableLeft(A(""), A("a"))) return "Fail 25"
+    if (!isEqualAnyNullableRight(null, null)) return "Fail 26"
+    if (!isEqualAnyNullableRight(A(""), A(""))) return "Fail 27"
+    if (isEqualAnyNullableRight("", A(""))) return "Fail 28"
+    if (isEqualAnyNullableRight("", null)) return "Fail 29"
+    if (isEqualAnyNullableRight(null, A(""))) return "Fail 30"
+    if (isEqualAnyNullableRight(A(""), A("a"))) return "Fail 31"
+    return "OK"
+}

--- a/compiler/testData/codegen/box/inlineClasses/equalityChecksNonNull.kt
+++ b/compiler/testData/codegen/box/inlineClasses/equalityChecksNonNull.kt
@@ -12,6 +12,8 @@ fun isEqualAnyRight(s: Any?, t: A) = s == t
 fun isEqualSameNullable(s: A?, t: A?) = s == t
 fun isEqualAnyNullableLeft(s: A?, t: Any?) = s == t
 fun isEqualAnyNullableRight(s: Any?, t: A?) = s == t
+fun isEqualNullableUnboxedLeft(s: A, t: A?) = s == t
+fun isEqualNullableUnboxedRight(s: A?, t: A) = s == t
 
 fun box(): String {
     if (isNullVacuousLeft(A(""))) return "Fail 1"
@@ -45,5 +47,11 @@ fun box(): String {
     if (isEqualAnyNullableRight("", null)) return "Fail 29"
     if (isEqualAnyNullableRight(null, A(""))) return "Fail 30"
     if (isEqualAnyNullableRight(A(""), A("a"))) return "Fail 31"
+    if (isEqualNullableUnboxedLeft(A(""), A("a"))) return "Fail 32"
+    if (!isEqualNullableUnboxedLeft(A(""), A(""))) return "Fail 33"
+    if (isEqualNullableUnboxedRight(A(""), A("a"))) return "Fail 34"
+    if (!isEqualNullableUnboxedRight(A("a"), A("a"))) return "Fail 35"
+    if (isEqualNullableUnboxedLeft(A(""), null)) return "Fail 36"
+    if (isEqualNullableUnboxedRight(null, A(""))) return "Fail 37"
     return "OK"
 }

--- a/compiler/testData/codegen/box/inlineClasses/equalityChecksNullable.kt
+++ b/compiler/testData/codegen/box/inlineClasses/equalityChecksNullable.kt
@@ -1,0 +1,61 @@
+// !LANGUAGE: +InlineClasses
+
+inline class A(val x: Any?)
+
+fun isNullVacuousLeft(s: A) = s == null
+fun isNullVacuousRight(s: A) = null == s
+fun isNullLeft(s: A?) = s == null
+fun isNullRight(s: A?) = null == s
+fun isEqualSame(s: A, t: A) = s == t
+fun isEqualAnyLeft(s: A, t: Any?) = s == t
+fun isEqualAnyRight(s: Any?, t: A) = s == t
+fun isEqualSameNullable(s: A?, t: A?) = s == t
+fun isEqualAnyNullableLeft(s: A?, t: Any?) = s == t
+fun isEqualAnyNullableRight(s: Any?, t: A?) = s == t
+
+fun box(): String {
+    if (isNullVacuousLeft(A(0))) return "Fail 1"
+    if (isNullVacuousRight(A(0))) return "Fail 2"
+    if (isNullLeft(A(0))) return "Fail 3"
+    if (isNullRight(A(0))) return "Fail 4"
+    if (!isNullLeft(null)) return "Fail 5"
+    if (!isNullRight(null)) return "Fail 6"
+    if (!isEqualSame(A(0), A(0))) return "Fail 7"
+    if (isEqualSame(A(0), A(1))) return "Fail 8"
+    if (isEqualAnyLeft(A(0), 0)) return "Fail 9"
+    if (isEqualAnyLeft(A(0), null)) return "Fail 10"
+    if (!isEqualAnyLeft(A(0), A(0))) return "Fail 11"
+    if (isEqualAnyRight(0, A(0))) return "Fail 12"
+    if (isEqualAnyRight(null, A(0))) return "Fail 13"
+    if (!isEqualAnyRight(A(0), A(0))) return "Fail 14"
+    if (!isEqualSameNullable(null, null)) return "Fail 15"
+    if (!isEqualSameNullable(A(0), A(0))) return "Fail 16"
+    if (isEqualSameNullable(null, A(0))) return "Fail 17"
+    if (isEqualSameNullable(A(0), null)) return "Fail 18"
+    if (isEqualSameNullable(A(0), A(1))) return "Fail 19"
+    if (!isEqualAnyNullableLeft(null, null)) return "Fail 20"
+    if (!isEqualAnyNullableLeft(A(0), A(0))) return "Fail 21"
+    if (isEqualAnyNullableLeft(A(0), 0)) return "Fail 22"
+    if (isEqualAnyNullableLeft(null, 0)) return "Fail 23"
+    if (isEqualAnyNullableLeft(A(0), null)) return "Fail 24"
+    if (isEqualAnyNullableLeft(A(0), A(1))) return "Fail 25"
+    if (!isEqualAnyNullableRight(null, null)) return "Fail 26"
+    if (!isEqualAnyNullableRight(A(0), A(0))) return "Fail 27"
+    if (isEqualAnyNullableRight(0, A(0))) return "Fail 28"
+    if (isEqualAnyNullableRight(0, null)) return "Fail 29"
+    if (isEqualAnyNullableRight(null, A(0))) return "Fail 30"
+    if (isEqualAnyNullableRight(A(0), A(1))) return "Fail 31"
+
+    if (isNullVacuousLeft(A(null))) return "Fail 32"
+    if (isNullVacuousRight(A(null))) return "Fail 33"
+    if (isNullLeft(A(null))) return "Fail 34"
+    if (isNullRight(A(null))) return "Fail 35"
+    if (isEqualAnyLeft(A(null), null)) return "Fail 36"
+    if (isEqualAnyRight(null, A(null))) return "Fail 37"
+    if (isEqualAnyNullableLeft(A(null), null)) return "Fail 38"
+    if (isEqualAnyNullableRight(null, A(null))) return "Fail 39"
+    if (isEqualSameNullable(A(null), null)) return "Fail 42"
+    if (isEqualSameNullable(null, A(null))) return "Fail 43"
+
+    return "OK"
+}

--- a/compiler/testData/codegen/box/inlineClasses/equalityChecksNullable.kt
+++ b/compiler/testData/codegen/box/inlineClasses/equalityChecksNullable.kt
@@ -12,6 +12,8 @@ fun isEqualAnyRight(s: Any?, t: A) = s == t
 fun isEqualSameNullable(s: A?, t: A?) = s == t
 fun isEqualAnyNullableLeft(s: A?, t: Any?) = s == t
 fun isEqualAnyNullableRight(s: Any?, t: A?) = s == t
+fun isEqualNullableUnboxedLeft(s: A, t: A?) = s == t
+fun isEqualNullableUnboxedRight(s: A?, t: A) = s == t
 
 fun box(): String {
     if (isNullVacuousLeft(A(0))) return "Fail 1"
@@ -56,6 +58,16 @@ fun box(): String {
     if (isEqualAnyNullableRight(null, A(null))) return "Fail 39"
     if (isEqualSameNullable(A(null), null)) return "Fail 42"
     if (isEqualSameNullable(null, A(null))) return "Fail 43"
+
+    if (isEqualNullableUnboxedLeft(A(0), A(1))) return "Fail 44"
+    if (!isEqualNullableUnboxedLeft(A(0), A(0))) return "Fail 45"
+    if (isEqualNullableUnboxedRight(A(0), A(1))) return "Fail 46"
+    if (!isEqualNullableUnboxedRight(A(1), A(1))) return "Fail 47"
+    if (isEqualNullableUnboxedLeft(A(0), null)) return "Fail 48"
+    if (isEqualNullableUnboxedRight(null, A(1))) return "Fail 49"
+
+    if (isEqualNullableUnboxedRight(null, A(null))) return "Fail 50"
+    if (isEqualNullableUnboxedLeft(A(null), null)) return "Fail 51"
 
     return "OK"
 }

--- a/compiler/testData/codegen/box/inlineClasses/equalityChecksPrimitive.kt
+++ b/compiler/testData/codegen/box/inlineClasses/equalityChecksPrimitive.kt
@@ -1,0 +1,49 @@
+// !LANGUAGE: +InlineClasses
+
+inline class A(val x: Int)
+
+fun isNullVacuousLeft(s: A) = s == null
+fun isNullVacuousRight(s: A) = null == s
+fun isNullLeft(s: A?) = s == null
+fun isNullRight(s: A?) = null == s
+fun isEqualSame(s: A, t: A) = s == t
+fun isEqualAnyLeft(s: A, t: Any?) = s == t
+fun isEqualAnyRight(s: Any?, t: A) = s == t
+fun isEqualSameNullable(s: A?, t: A?) = s == t
+fun isEqualAnyNullableLeft(s: A?, t: Any?) = s == t
+fun isEqualAnyNullableRight(s: Any?, t: A?) = s == t
+
+fun box(): String {
+    if (isNullVacuousLeft(A(0))) return "Fail 1"
+    if (isNullVacuousRight(A(0))) return "Fail 2"
+    if (isNullLeft(A(0))) return "Fail 3"
+    if (isNullRight(A(0))) return "Fail 4"
+    if (!isNullLeft(null)) return "Fail 5"
+    if (!isNullRight(null)) return "Fail 6"
+    if (!isEqualSame(A(0), A(0))) return "Fail 7"
+    if (isEqualSame(A(0), A(1))) return "Fail 8"
+    if (isEqualAnyLeft(A(0), 0)) return "Fail 9"
+    if (isEqualAnyLeft(A(0), null)) return "Fail 10"
+    if (!isEqualAnyLeft(A(0), A(0))) return "Fail 11"
+    if (isEqualAnyRight(0, A(0))) return "Fail 12"
+    if (isEqualAnyRight(null, A(0))) return "Fail 13"
+    if (!isEqualAnyRight(A(0), A(0))) return "Fail 14"
+    if (!isEqualSameNullable(null, null)) return "Fail 15"
+    if (!isEqualSameNullable(A(0), A(0))) return "Fail 16"
+    if (isEqualSameNullable(null, A(0))) return "Fail 17"
+    if (isEqualSameNullable(A(0), null)) return "Fail 18"
+    if (isEqualSameNullable(A(0), A(1))) return "Fail 19"
+    if (!isEqualAnyNullableLeft(null, null)) return "Fail 20"
+    if (!isEqualAnyNullableLeft(A(0), A(0))) return "Fail 21"
+    if (isEqualAnyNullableLeft(A(0), 0)) return "Fail 22"
+    if (isEqualAnyNullableLeft(null, 0)) return "Fail 23"
+    if (isEqualAnyNullableLeft(A(0), null)) return "Fail 24"
+    if (isEqualAnyNullableLeft(A(0), A(1))) return "Fail 25"
+    if (!isEqualAnyNullableRight(null, null)) return "Fail 26"
+    if (!isEqualAnyNullableRight(A(0), A(0))) return "Fail 27"
+    if (isEqualAnyNullableRight(0, A(0))) return "Fail 28"
+    if (isEqualAnyNullableRight(0, null)) return "Fail 29"
+    if (isEqualAnyNullableRight(null, A(0))) return "Fail 30"
+    if (isEqualAnyNullableRight(A(0), A(1))) return "Fail 31"
+    return "OK"
+}

--- a/compiler/testData/codegen/box/inlineClasses/equalityChecksPrimitive.kt
+++ b/compiler/testData/codegen/box/inlineClasses/equalityChecksPrimitive.kt
@@ -12,6 +12,8 @@ fun isEqualAnyRight(s: Any?, t: A) = s == t
 fun isEqualSameNullable(s: A?, t: A?) = s == t
 fun isEqualAnyNullableLeft(s: A?, t: Any?) = s == t
 fun isEqualAnyNullableRight(s: Any?, t: A?) = s == t
+fun isEqualNullableUnboxedLeft(s: A, t: A?) = s == t
+fun isEqualNullableUnboxedRight(s: A?, t: A) = s == t
 
 fun box(): String {
     if (isNullVacuousLeft(A(0))) return "Fail 1"
@@ -45,5 +47,11 @@ fun box(): String {
     if (isEqualAnyNullableRight(0, null)) return "Fail 29"
     if (isEqualAnyNullableRight(null, A(0))) return "Fail 30"
     if (isEqualAnyNullableRight(A(0), A(1))) return "Fail 31"
+    if (isEqualNullableUnboxedLeft(A(0), A(1))) return "Fail 32"
+    if (!isEqualNullableUnboxedLeft(A(0), A(0))) return "Fail 33"
+    if (isEqualNullableUnboxedRight(A(0), A(1))) return "Fail 34"
+    if (!isEqualNullableUnboxedRight(A(1), A(1))) return "Fail 35"
+    if (isEqualNullableUnboxedLeft(A(0), null)) return "Fail 36"
+    if (isEqualNullableUnboxedRight(null, A(1))) return "Fail 37"
     return "OK"
 }

--- a/compiler/testData/codegen/box/inlineClasses/equalsCallsLeftArgument.kt
+++ b/compiler/testData/codegen/box/inlineClasses/equalsCallsLeftArgument.kt
@@ -1,0 +1,14 @@
+// !LANGUAGE: +InlineClasses
+
+inline class A(val x: String)
+
+class B {
+    override fun equals(other: Any?) = true
+}
+
+fun box(): String {
+    val x: Any? = B()
+    val y: A = A("")
+    if (x != y) return "Fail"
+    return "OK"
+}

--- a/compiler/testData/codegen/box/inlineClasses/equalsEvaluationOrderInlineClass.kt
+++ b/compiler/testData/codegen/box/inlineClasses/equalsEvaluationOrderInlineClass.kt
@@ -1,0 +1,33 @@
+// !LANGUAGE: +InlineClasses
+
+inline class Inner(val x: Int)
+inline class A(val x: Inner)
+
+var i = 0
+
+fun set1(): A {
+    i = 1
+    return A(Inner(0))
+}
+
+fun test1(n: Int): A {
+    if (i != 1)
+        throw IllegalStateException("Fail $n")
+    i = 0
+    return A(Inner(0))
+}
+
+fun set1Boxed(): Any? = set1()
+fun test1Boxed(n: Int): Any? = test1(n)
+
+fun box(): String {
+    try {
+        set1() == test1(1)
+        set1Boxed() == test1(2)
+        set1() == test1Boxed(3)
+        set1Boxed() == test1Boxed(4)
+    } catch (e: IllegalStateException) {
+        return e.message ?: "Fail no message"
+    }
+    return "OK"
+}

--- a/compiler/testData/codegen/box/inlineClasses/equalsEvaluationOrderNonNull.kt
+++ b/compiler/testData/codegen/box/inlineClasses/equalsEvaluationOrderNonNull.kt
@@ -1,0 +1,32 @@
+// !LANGUAGE: +InlineClasses
+
+inline class A(val x: String = "")
+
+var i = 0
+
+fun set1(): A {
+    i = 1
+    return A()
+}
+
+fun test1(n: Int): A {
+    if (i != 1)
+        throw IllegalStateException("Fail $n")
+    i = 0
+    return A()
+}
+
+fun set1Boxed(): Any? = set1()
+fun test1Boxed(n: Int): Any? = test1(n)
+
+fun box(): String {
+    try {
+        set1() == test1(1)
+        set1Boxed() == test1(2)
+        set1() == test1Boxed(3)
+        set1Boxed() == test1Boxed(4)
+    } catch (e: IllegalStateException) {
+        return e.message ?: "Fail no message"
+    }
+    return "OK"
+}

--- a/compiler/testData/codegen/box/inlineClasses/equalsEvaluationOrderNullable.kt
+++ b/compiler/testData/codegen/box/inlineClasses/equalsEvaluationOrderNullable.kt
@@ -1,0 +1,32 @@
+// !LANGUAGE: +InlineClasses
+
+inline class A(val x: Any? = null)
+
+var i = 0
+
+fun set1(): A {
+    i = 1
+    return A()
+}
+
+fun test1(n: Int): A {
+    if (i != 1)
+        throw IllegalStateException("Fail $n")
+    i = 0
+    return A()
+}
+
+fun set1Boxed(): Any? = set1()
+fun test1Boxed(n: Int): Any? = test1(n)
+
+fun box(): String {
+    try {
+        set1() == test1(1)
+        set1Boxed() == test1(2)
+        set1() == test1Boxed(3)
+        set1Boxed() == test1Boxed(4)
+    } catch (e: IllegalStateException) {
+        return e.message ?: "Fail no message"
+    }
+    return "OK"
+}

--- a/compiler/testData/codegen/box/inlineClasses/equalsEvaluationOrderPrimitive.kt
+++ b/compiler/testData/codegen/box/inlineClasses/equalsEvaluationOrderPrimitive.kt
@@ -1,0 +1,32 @@
+// !LANGUAGE: +InlineClasses
+
+inline class A(val x: Int = 0)
+
+var i = 0
+
+fun set1(): A {
+    i = 1
+    return A()
+}
+
+fun test1(n: Int): A {
+    if (i != 1)
+        throw IllegalStateException("Fail $n")
+    i = 0
+    return A()
+}
+
+fun set1Boxed(): Any? = set1()
+fun test1Boxed(n: Int): Any? = test1(n)
+
+fun box(): String {
+    try {
+        set1() == test1(1)
+        set1Boxed() == test1(2)
+        set1() == test1Boxed(3)
+        set1Boxed() == test1Boxed(4)
+    } catch (e: IllegalStateException) {
+        return e.message ?: "Fail no message"
+    }
+    return "OK"
+}

--- a/compiler/testData/codegen/box/inlineClasses/inlineClassWithCustomEquals.kt
+++ b/compiler/testData/codegen/box/inlineClasses/inlineClassWithCustomEquals.kt
@@ -1,3 +1,4 @@
+// IGNORE_BACKEND: JVM
 // IGNORE_BACKEND: JVM_IR
 // !LANGUAGE: +InlineClasses
 

--- a/compiler/testData/codegen/box/inlineClasses/inlineClassWithCustomEquals.kt
+++ b/compiler/testData/codegen/box/inlineClasses/inlineClassWithCustomEquals.kt
@@ -1,3 +1,4 @@
+// IGNORE_BACKEND: JVM_IR
 // !LANGUAGE: +InlineClasses
 
 @file:Suppress("RESERVED_MEMBER_INSIDE_INLINE_CLASS")

--- a/compiler/testData/codegen/box/inlineClasses/inlineFunctionInsideInlineClass.kt
+++ b/compiler/testData/codegen/box/inlineClasses/inlineFunctionInsideInlineClass.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: +InlineClasses
-// IGNORE_BACKEND: JVM_IR
 
 inline class Foo(val x: Int) {
     inline fun inc(): Foo = Foo(x + 1)

--- a/compiler/testData/codegen/box/inlineClasses/resultRunCatchingOrElse.kt
+++ b/compiler/testData/codegen/box/inlineClasses/resultRunCatchingOrElse.kt
@@ -1,0 +1,42 @@
+inline class Result<out T>(val value: Any?) {
+    fun exceptionOrNull(): Throwable? =
+        when (value) {
+            is Failure -> value.exception
+            else -> null
+        }
+
+    public companion object {
+        public inline fun <T> success(value: T): Result<T> =
+            Result(value)
+
+        public inline fun <T> failure(exception: Throwable): Result<T> =
+            Result(Failure(exception))
+    }
+
+    class Failure(
+        val exception: Throwable
+    )
+}
+
+inline fun <T, R> T.runCatching(block: T.() -> R): Result<R> {
+    return try {
+        Result.success(block())
+    } catch (e: Throwable) {
+        Result.failure(e)
+    }
+}
+
+
+inline fun <R, T : R> Result<T>.getOrElse(onFailure: (exception: Throwable) -> R): R {
+    return when (val exception = exceptionOrNull()) {
+        null -> value as T
+        else -> onFailure(exception)
+    }
+}
+
+
+class A {
+    fun f() = runCatching { "OK" }.getOrElse { throw it }
+}
+
+fun box(): String = A().f()

--- a/compiler/testData/codegen/bytecodeText/inlineClasses/assertionsForParametersOfInlineClassTypes.kt
+++ b/compiler/testData/codegen/bytecodeText/inlineClasses/assertionsForParametersOfInlineClassTypes.kt
@@ -2,7 +2,7 @@
 
 inline class AsNonNullPrimitive(val i: Int)
 inline class AsNonNullReference(val s: String)
-// ^ JVM: 5 assertions (constructor, box method, erased constructor, 2 assertions in equals--impl)
+// ^ JVM: 3 assertions (constructor, box method, erased constructor)
 //   JVM IR: 1 assertion (erased constructor)
 
 fun nonNullPrimitive(a: AsNonNullPrimitive) {}
@@ -14,7 +14,7 @@ fun asNullablePrimitive(c: AsNonNullPrimitive?) {}
 fun asNullableReference(c: AsNonNullReference?) {}
 
 // JVM_TEMPLATES
-// 8 checkParameterIsNotNull
+// 6 checkParameterIsNotNull
 // 0 checkNotNullParameter
 
 // JVM_IR_TEMPLATES

--- a/compiler/testData/codegen/bytecodeText/inlineClasses/assertionsForParametersOfInlineClassTypes.kt
+++ b/compiler/testData/codegen/bytecodeText/inlineClasses/assertionsForParametersOfInlineClassTypes.kt
@@ -1,9 +1,9 @@
 // !LANGUAGE: +InlineClasses
-// IGNORE_BACKEND: JVM_IR
 
 inline class AsNonNullPrimitive(val i: Int)
 inline class AsNonNullReference(val s: String)
-// ^ 5 assertions (constructor, box method, erased constructor, 2 assertions in equals--impl)
+// ^ JVM: 5 assertions (constructor, box method, erased constructor, 2 assertions in equals--impl)
+//   JVM IR: 1 assertion (erased constructor)
 
 fun nonNullPrimitive(a: AsNonNullPrimitive) {}
 
@@ -13,5 +13,10 @@ fun AsNonNullReference.nonNullReferenceExtension(b1: AsNonNullReference) {} // 2
 fun asNullablePrimitive(c: AsNonNullPrimitive?) {}
 fun asNullableReference(c: AsNonNullReference?) {}
 
+// JVM_TEMPLATES
 // 8 checkParameterIsNotNull
+// 0 checkNotNullParameter
+
+// JVM_IR_TEMPLATES
+// 4 checkParameterIsNotNull
 // 0 checkNotNullParameter

--- a/compiler/testData/codegen/bytecodeText/inlineClasses/equalsDoesNotBox.kt
+++ b/compiler/testData/codegen/bytecodeText/inlineClasses/equalsDoesNotBox.kt
@@ -21,6 +21,10 @@ fun isEqualAnyLeftA(s: A, t: Any?) = s == t
 fun isEqualSameNullableA(s: A?, t: A?) = s == t
 fun isEqualAnyNullableLeftA(s: A?, t: Any?) = s == t
 fun isEqualAnyNullableRightA(s: Any?, t: A?) = s == t
+// unbox, equals-impl0
+fun isEqualLeftNullableRightUnboxedA(s: A?, t: A) = s == t
+// equals-impl
+fun isEqualRightNullableLeftUnboxedA(s: A, t: A?) = s == t
 
 // FILE: b.kt
 
@@ -42,6 +46,9 @@ fun isEqualSameNullableB(s: B?, t: B?) = s == t
 fun isEqualAnyNullableLeftB(s: B?, t: Any?) = s == t
 // boxes
 // fun isEqualAnyNullableRightB(s: Any?, t: B?) = s == t
+// equals-impl0
+fun isEqualLeftNullableRightUnboxedB(s: B?, t: B) = s == t
+fun isEqualRightNullableLeftUnboxedB(s: B, t: B?) = s == t
 
 // FILE: c.kt
 
@@ -61,24 +68,28 @@ fun isEqualAnyLeftC(s: C, t: Any?) = s == t
 fun isEqualSameNullableC(s: C?, t: C?) = s == t
 fun isEqualAnyNullableLeftC(s: C?, t: Any?) = s == t
 fun isEqualAnyNullableRightC(s: Any?, t: C?) = s == t
+// unbox, equals-impl0
+fun isEqualLeftNullableRightUnboxedC(s: C?, t: C) = s == t
+// equals-impl
+fun isEqualRightNullableLeftUnboxedC(s: C, t: C?) = s == t
 
 // @AKt.class:
 // 0 INVOKESTATIC A.box-impl
-// 0 INVOKEVIRTUAL A.unbox-impl
-// 1 INVOKESTATIC A.equals-impl \(
-// 1 INVOKESTATIC A.equals-impl0
+// 1 INVOKEVIRTUAL A.unbox-impl
+// 2 INVOKESTATIC A.equals-impl \(
+// 2 INVOKESTATIC A.equals-impl0
 // 3 INVOKESTATIC kotlin/jvm/internal/Intrinsics.areEqual
 
 // @BKt.class:
 // 0 INVOKESTATIC B.box-impl
 // 0 INVOKEVIRTUAL B.unbox-impl
 // 2 INVOKESTATIC B.equals-impl \(
-// 2 INVOKESTATIC B.equals-impl0
+// 4 INVOKESTATIC B.equals-impl0
 // 0 INVOKESTATIC kotlin/jvm/internal/Intrinsics.areEqual
 
 // @CKt.class:
 // 0 INVOKESTATIC C.box-impl
-// 0 INVOKEVIRTUAL C.unbox-impl
-// 1 INVOKESTATIC C.equals-impl \(
-// 1 INVOKESTATIC C.equals-impl0
+// 1 INVOKEVIRTUAL C.unbox-impl
+// 2 INVOKESTATIC C.equals-impl \(
+// 2 INVOKESTATIC C.equals-impl0
 // 3 INVOKESTATIC kotlin/jvm/internal/Intrinsics.areEqual

--- a/compiler/testData/codegen/bytecodeText/inlineClasses/equalsDoesNotBox.kt
+++ b/compiler/testData/codegen/bytecodeText/inlineClasses/equalsDoesNotBox.kt
@@ -1,0 +1,84 @@
+// FILE: inlineClasses.kt
+inline class A(val x: Int)
+inline class B(val x: String)
+inline class C(val x: Any?)
+
+// FILE: a.kt
+
+// False
+fun isNullVacuousLeftA(s: A) = s == null
+fun isNullVacuousRightA(s: A) = null == s
+// IFNONNULL
+fun isNullLeftA(s: A?) = s == null
+fun isNullRightA(s: A?) = null == s
+// equals-impl0
+fun isEqualSameA(s: A, t: A) = s == t
+// equals-impl
+fun isEqualAnyLeftA(s: A, t: Any?) = s == t
+// boxes
+// fun isEqualAnyRightA(s: Any?, t: A) = s == t
+// Intrinsics.areEqual
+fun isEqualSameNullableA(s: A?, t: A?) = s == t
+fun isEqualAnyNullableLeftA(s: A?, t: Any?) = s == t
+fun isEqualAnyNullableRightA(s: Any?, t: A?) = s == t
+
+// FILE: b.kt
+
+// False
+fun isNullVacuousLeftB(s: B) = s == null
+fun isNullVacuousRightB(s: B) = null == s
+// IFNONNULL
+fun isNullLeftB(s: B?) = s == null
+fun isNullRightB(s: B?) = null == s
+// equals-impl0
+fun isEqualSameB(s: B, t: B) = s == t
+// equals-impl
+fun isEqualAnyLeftB(s: B, t: Any?) = s == t
+// boxes
+// fun isEqualAnyRightB(s: Any?, t: B) = s == t
+// equals-impl0
+fun isEqualSameNullableB(s: B?, t: B?) = s == t
+// equals-impl
+fun isEqualAnyNullableLeftB(s: B?, t: Any?) = s == t
+// boxes
+// fun isEqualAnyNullableRightB(s: Any?, t: B?) = s == t
+
+// FILE: c.kt
+
+// False
+fun isNullVacuousLeftC(s: C) = s == null
+fun isNullVacuousRightC(s: C) = null == s
+// IFNONULL
+fun isNullLeftC(s: C?) = s == null
+fun isNullRightC(s: C?) = null == s
+// equals-impl0
+fun isEqualSameC(s: C, t: C) = s == t
+// equals-impl
+fun isEqualAnyLeftC(s: C, t: Any?) = s == t
+// boxes
+// fun isEqualAnyRightC(s: Any?, t: C) = s == t
+// Intrinsics.areEqual
+fun isEqualSameNullableC(s: C?, t: C?) = s == t
+fun isEqualAnyNullableLeftC(s: C?, t: Any?) = s == t
+fun isEqualAnyNullableRightC(s: Any?, t: C?) = s == t
+
+// @AKt.class:
+// 0 INVOKESTATIC A.box-impl
+// 0 INVOKEVIRTUAL A.unbox-impl
+// 1 INVOKESTATIC A.equals-impl \(
+// 1 INVOKESTATIC A.equals-impl0
+// 3 INVOKESTATIC kotlin/jvm/internal/Intrinsics.areEqual
+
+// @BKt.class:
+// 0 INVOKESTATIC B.box-impl
+// 0 INVOKEVIRTUAL B.unbox-impl
+// 2 INVOKESTATIC B.equals-impl \(
+// 2 INVOKESTATIC B.equals-impl0
+// 0 INVOKESTATIC kotlin/jvm/internal/Intrinsics.areEqual
+
+// @CKt.class:
+// 0 INVOKESTATIC C.box-impl
+// 0 INVOKEVIRTUAL C.unbox-impl
+// 1 INVOKESTATIC C.equals-impl \(
+// 1 INVOKESTATIC C.equals-impl0
+// 3 INVOKESTATIC kotlin/jvm/internal/Intrinsics.areEqual

--- a/compiler/testData/codegen/bytecodeText/inlineClasses/noActualCallsOfInlineFunctionsOfInlineClass.kt
+++ b/compiler/testData/codegen/bytecodeText/inlineClasses/noActualCallsOfInlineFunctionsOfInlineClass.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: +InlineClasses
-// IGNORE_BACKEND: JVM_IR
 
 inline class Foo(val x: Int) {
     inline fun inlineInc(): Foo = Foo(x + 1)

--- a/compiler/testData/codegen/bytecodeText/inlineClasses/resultApiDoesntCallSpecializedEquals.kt
+++ b/compiler/testData/codegen/bytecodeText/inlineClasses/resultApiDoesntCallSpecializedEquals.kt
@@ -1,0 +1,12 @@
+// !API_VERSION: 1.3
+// WITH_RUNTIME
+// FILE: test.kt
+fun test() {
+    val result = Result.success("yes!")
+    val other = Result.success("nope")
+    if (result == other) println("==")
+    if (result != other) println("!=")
+}
+
+// @TestKt.class:
+// 0 INVOKESTATIC kotlin/Result.equals-impl0

--- a/compiler/testData/codegen/bytecodeText/inlineClasses/resultApiDoesntUseBox.kt
+++ b/compiler/testData/codegen/bytecodeText/inlineClasses/resultApiDoesntUseBox.kt
@@ -35,4 +35,4 @@ fun test() {
 // 0 INVOKESTATIC Result.box-impl
 // 0 INVOKESTATIC Result.unbox-impl
 // 0 Result\$Failure
-// 52 Result
+// 46 Result

--- a/compiler/testData/codegen/bytecodeText/inlineClasses/resultApiDoesntUseBox.kt
+++ b/compiler/testData/codegen/bytecodeText/inlineClasses/resultApiDoesntUseBox.kt
@@ -1,3 +1,4 @@
+// IGNORE_BACKEND: JVM
 // IGNORE_BACKEND: JVM_IR
 // WITH_COROUTINES
 // FILE: test.kt
@@ -14,25 +15,24 @@ fun test() {
     val other = Result.success("nope")
     if (result == other) println("==")
     if (result != other) println("!=")
-    if (result.equals(other)) println("equals")
-    if (!result.equals(other)) println("!equals")
+    if (result.equals(other)) println("equals") // Boxes (JVM, JVM_IR)
+    if (!result.equals(other)) println("!equals") // Boxes (JVM, JVM_IR)
 
     println(result.hashCode())
     println(result.toString())
-    println("$result")
+    println("$result") // Boxes (JVM_IR)
 
     val ans1 = runCatching { 42 }
-    println(ans1)
+    println(ans1) // Boxes (JVM, JVM_IR)
 
     val ans2 = 42.runCatching { this }
-    println(ans2)
+    println(ans2) // Boxes (JVM, JVM_IR)
 
     println(result.getOrElse { "oops" })
     println(result.getOrDefault("oops"))
 }
 
 // @TestKt.class:
-// 0 INVOKESTATIC Result.box-impl
-// 0 INVOKESTATIC Result.unbox-impl
+// 0 INVOKESTATIC kotlin/Result.box-impl
+// 0 INVOKEVIRTUAL kotlin/Result.unbox-impl
 // 0 Result\$Failure
-// 46 Result

--- a/compiler/testData/codegen/bytecodeText/inlineClasses/resultApiDoesntUseBox.kt
+++ b/compiler/testData/codegen/bytecodeText/inlineClasses/resultApiDoesntUseBox.kt
@@ -1,6 +1,4 @@
-// IGNORE_BACKEND: JVM
-// IGNORE_BACKEND: JVM_IR
-// WITH_COROUTINES
+// WITH_RUNTIME
 // FILE: test.kt
 fun test() {
     val result = Result.success("yes!")
@@ -12,21 +10,8 @@ fun test() {
     println(failure.getOrNull())
     println(failure.exceptionOrNull())
 
-    val other = Result.success("nope")
-    if (result == other) println("==")
-    if (result != other) println("!=")
-    if (result.equals(other)) println("equals") // Boxes (JVM, JVM_IR)
-    if (!result.equals(other)) println("!equals") // Boxes (JVM, JVM_IR)
-
     println(result.hashCode())
     println(result.toString())
-    println("$result") // Boxes (JVM_IR)
-
-    val ans1 = runCatching { 42 }
-    println(ans1) // Boxes (JVM, JVM_IR)
-
-    val ans2 = 42.runCatching { this }
-    println(ans2) // Boxes (JVM, JVM_IR)
 
     println(result.getOrElse { "oops" })
     println(result.getOrDefault("oops"))

--- a/compiler/testData/codegen/bytecodeText/inlineClasses/resultApiEqualsDoesntBox.kt
+++ b/compiler/testData/codegen/bytecodeText/inlineClasses/resultApiEqualsDoesntBox.kt
@@ -1,0 +1,14 @@
+// !API_VERSION: LATEST
+// WITH_RUNTIME
+// FILE: test.kt
+fun test() {
+    val result = Result.success("yes!")
+    val other = Result.success("nope")
+    if (result == other) println("==")
+    if (result != other) println("!=")
+}
+
+// @TestKt.class:
+// 0 INVOKESTATIC kotlin/Result.box-impl
+// 0 INVOKEVIRTUAL kotlin/Result.unbox-impl
+// 2 INVOKESTATIC kotlin/Result.equals-impl0

--- a/compiler/testData/codegen/bytecodeText/inlineClasses/resultApiRunCatchingDoesntBox.kt
+++ b/compiler/testData/codegen/bytecodeText/inlineClasses/resultApiRunCatchingDoesntBox.kt
@@ -1,0 +1,16 @@
+// IGNORE_BACKEND: JVM
+// IGNORE_BACKEND: JVM_IR
+// WITH_RUNTIME
+// FILE: test.kt
+fun test() {
+    val ans1 = runCatching { 42 }
+    println(ans1)
+
+    val ans2 = 42.runCatching { this }
+    println(ans2)
+}
+
+// @TestKt.class:
+// 0 INVOKESTATIC kotlin/Result.box-impl
+// 0 INVOKEVIRTUAL kotlin/Result.unbox-impl
+// 0 Result\$Failure

--- a/compiler/testData/codegen/bytecodeText/inlineClasses/resultApiStringInterpolationDoesntBox.kt
+++ b/compiler/testData/codegen/bytecodeText/inlineClasses/resultApiStringInterpolationDoesntBox.kt
@@ -1,0 +1,11 @@
+// IGNORE_BACKEND: JVM_IR
+// WITH_RUNTIME
+// FILE: test.kt
+fun test() {
+    val result = Result.success("yes!")
+    println("$result")
+}
+
+// @TestKt.class:
+// 0 INVOKESTATIC kotlin/Result.box-impl
+// 0 INVOKEVIRTUAL kotlin/Result.unbox-impl

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -12380,9 +12380,79 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             runTest("compiler/testData/codegen/box/inlineClasses/emptyConstructorForInlineClass.kt");
         }
 
+        @TestMetadata("equalityChecksInlineClassNonNull.kt")
+        public void testEqualityChecksInlineClassNonNull() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksInlineClassNonNull.kt");
+        }
+
+        @TestMetadata("equalityChecksMixedNullability.kt")
+        public void testEqualityChecksMixedNullability() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksMixedNullability.kt");
+        }
+
+        @TestMetadata("equalityChecksNegatedInlineClassNonNull.kt")
+        public void testEqualityChecksNegatedInlineClassNonNull() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksNegatedInlineClassNonNull.kt");
+        }
+
+        @TestMetadata("equalityChecksNegatedNonNull.kt")
+        public void testEqualityChecksNegatedNonNull() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksNegatedNonNull.kt");
+        }
+
+        @TestMetadata("equalityChecksNegatedNullable.kt")
+        public void testEqualityChecksNegatedNullable() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksNegatedNullable.kt");
+        }
+
+        @TestMetadata("equalityChecksNegatedPrimitive.kt")
+        public void testEqualityChecksNegatedPrimitive() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksNegatedPrimitive.kt");
+        }
+
+        @TestMetadata("equalityChecksNonNull.kt")
+        public void testEqualityChecksNonNull() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksNonNull.kt");
+        }
+
+        @TestMetadata("equalityChecksNullable.kt")
+        public void testEqualityChecksNullable() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksNullable.kt");
+        }
+
+        @TestMetadata("equalityChecksPrimitive.kt")
+        public void testEqualityChecksPrimitive() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksPrimitive.kt");
+        }
+
         @TestMetadata("equalityForBoxesOfNullableValuesOfInlineClass.kt")
         public void testEqualityForBoxesOfNullableValuesOfInlineClass() throws Exception {
             runTest("compiler/testData/codegen/box/inlineClasses/equalityForBoxesOfNullableValuesOfInlineClass.kt");
+        }
+
+        @TestMetadata("equalsCallsLeftArgument.kt")
+        public void testEqualsCallsLeftArgument() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalsCallsLeftArgument.kt");
+        }
+
+        @TestMetadata("equalsEvaluationOrderInlineClass.kt")
+        public void testEqualsEvaluationOrderInlineClass() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalsEvaluationOrderInlineClass.kt");
+        }
+
+        @TestMetadata("equalsEvaluationOrderNonNull.kt")
+        public void testEqualsEvaluationOrderNonNull() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalsEvaluationOrderNonNull.kt");
+        }
+
+        @TestMetadata("equalsEvaluationOrderNullable.kt")
+        public void testEqualsEvaluationOrderNullable() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalsEvaluationOrderNullable.kt");
+        }
+
+        @TestMetadata("equalsEvaluationOrderPrimitive.kt")
+        public void testEqualsEvaluationOrderPrimitive() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalsEvaluationOrderPrimitive.kt");
         }
 
         @TestMetadata("equalsOperatorWithGenericCall.kt")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -12800,6 +12800,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             runTest("compiler/testData/codegen/box/inlineClasses/resultInlining.kt");
         }
 
+        @TestMetadata("resultRunCatchingOrElse.kt")
+        public void testResultRunCatchingOrElse() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/resultRunCatchingOrElse.kt");
+        }
+
         @TestMetadata("secondaryConstructorWithVararg.kt")
         public void testSecondaryConstructorWithVararg() throws Exception {
             runTest("compiler/testData/codegen/box/inlineClasses/secondaryConstructorWithVararg.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
@@ -2603,9 +2603,29 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
             runTest("compiler/testData/codegen/bytecodeText/inlineClasses/propertySetterWithInlineClassTypeArgument.kt");
         }
 
+        @TestMetadata("resultApiDoesntCallSpecializedEquals.kt")
+        public void testResultApiDoesntCallSpecializedEquals() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/inlineClasses/resultApiDoesntCallSpecializedEquals.kt");
+        }
+
         @TestMetadata("resultApiDoesntUseBox.kt")
         public void testResultApiDoesntUseBox() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/inlineClasses/resultApiDoesntUseBox.kt");
+        }
+
+        @TestMetadata("resultApiEqualsDoesntBox.kt")
+        public void testResultApiEqualsDoesntBox() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/inlineClasses/resultApiEqualsDoesntBox.kt");
+        }
+
+        @TestMetadata("resultApiRunCatchingDoesntBox.kt")
+        public void testResultApiRunCatchingDoesntBox() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/inlineClasses/resultApiRunCatchingDoesntBox.kt");
+        }
+
+        @TestMetadata("resultApiStringInterpolationDoesntBox.kt")
+        public void testResultApiStringInterpolationDoesntBox() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/inlineClasses/resultApiStringInterpolationDoesntBox.kt");
         }
 
         @TestMetadata("resultMangling.kt")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
@@ -2483,6 +2483,11 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
             runTest("compiler/testData/codegen/bytecodeText/inlineClasses/defaultParametersDontBox.kt");
         }
 
+        @TestMetadata("equalsDoesNotBox.kt")
+        public void testEqualsDoesNotBox() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/inlineClasses/equalsDoesNotBox.kt");
+        }
+
         @TestMetadata("equalsIsCalledByInlineClass.kt")
         public void testEqualsIsCalledByInlineClass() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/inlineClasses/equalsIsCalledByInlineClass.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -12805,6 +12805,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/inlineClasses/resultInlining.kt");
         }
 
+        @TestMetadata("resultRunCatchingOrElse.kt")
+        public void testResultRunCatchingOrElse() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/resultRunCatchingOrElse.kt");
+        }
+
         @TestMetadata("secondaryConstructorWithVararg.kt")
         public void testSecondaryConstructorWithVararg() throws Exception {
             runTest("compiler/testData/codegen/box/inlineClasses/secondaryConstructorWithVararg.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -12395,9 +12395,79 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/inlineClasses/emptyConstructorForInlineClass.kt");
         }
 
+        @TestMetadata("equalityChecksInlineClassNonNull.kt")
+        public void testEqualityChecksInlineClassNonNull() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksInlineClassNonNull.kt");
+        }
+
+        @TestMetadata("equalityChecksMixedNullability.kt")
+        public void testEqualityChecksMixedNullability() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksMixedNullability.kt");
+        }
+
+        @TestMetadata("equalityChecksNegatedInlineClassNonNull.kt")
+        public void testEqualityChecksNegatedInlineClassNonNull() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksNegatedInlineClassNonNull.kt");
+        }
+
+        @TestMetadata("equalityChecksNegatedNonNull.kt")
+        public void testEqualityChecksNegatedNonNull() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksNegatedNonNull.kt");
+        }
+
+        @TestMetadata("equalityChecksNegatedNullable.kt")
+        public void testEqualityChecksNegatedNullable() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksNegatedNullable.kt");
+        }
+
+        @TestMetadata("equalityChecksNegatedPrimitive.kt")
+        public void testEqualityChecksNegatedPrimitive() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksNegatedPrimitive.kt");
+        }
+
+        @TestMetadata("equalityChecksNonNull.kt")
+        public void testEqualityChecksNonNull() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksNonNull.kt");
+        }
+
+        @TestMetadata("equalityChecksNullable.kt")
+        public void testEqualityChecksNullable() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksNullable.kt");
+        }
+
+        @TestMetadata("equalityChecksPrimitive.kt")
+        public void testEqualityChecksPrimitive() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksPrimitive.kt");
+        }
+
         @TestMetadata("equalityForBoxesOfNullableValuesOfInlineClass.kt")
         public void testEqualityForBoxesOfNullableValuesOfInlineClass() throws Exception {
             runTest("compiler/testData/codegen/box/inlineClasses/equalityForBoxesOfNullableValuesOfInlineClass.kt");
+        }
+
+        @TestMetadata("equalsCallsLeftArgument.kt")
+        public void testEqualsCallsLeftArgument() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalsCallsLeftArgument.kt");
+        }
+
+        @TestMetadata("equalsEvaluationOrderInlineClass.kt")
+        public void testEqualsEvaluationOrderInlineClass() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalsEvaluationOrderInlineClass.kt");
+        }
+
+        @TestMetadata("equalsEvaluationOrderNonNull.kt")
+        public void testEqualsEvaluationOrderNonNull() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalsEvaluationOrderNonNull.kt");
+        }
+
+        @TestMetadata("equalsEvaluationOrderNullable.kt")
+        public void testEqualsEvaluationOrderNullable() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalsEvaluationOrderNullable.kt");
+        }
+
+        @TestMetadata("equalsEvaluationOrderPrimitive.kt")
+        public void testEqualsEvaluationOrderPrimitive() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalsEvaluationOrderPrimitive.kt");
         }
 
         @TestMetadata("equalsOperatorWithGenericCall.kt")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -12197,6 +12197,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/inlineClasses/fieldNameClash.kt");
         }
 
+        @TestMetadata("inlineClassWithCustomEquals.kt")
+        public void ignoreInlineClassWithCustomEquals() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/inlineClassWithCustomEquals.kt");
+        }
+
         @TestMetadata("simpleSecondaryConstructor.kt")
         public void ignoreSimpleSecondaryConstructor() throws Exception {
             runTest("compiler/testData/codegen/box/inlineClasses/simpleSecondaryConstructor.kt");
@@ -12453,11 +12458,6 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
         @TestMetadata("inlineClassValuesInsideStrings.kt")
         public void testInlineClassValuesInsideStrings() throws Exception {
             runTest("compiler/testData/codegen/box/inlineClasses/inlineClassValuesInsideStrings.kt");
-        }
-
-        @TestMetadata("inlineClassWithCustomEquals.kt")
-        public void testInlineClassWithCustomEquals() throws Exception {
-            runTest("compiler/testData/codegen/box/inlineClasses/inlineClassWithCustomEquals.kt");
         }
 
         @TestMetadata("inlineClassWithDefaultFunctionsFromAny.kt")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -11685,6 +11685,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             runTest("compiler/testData/codegen/box/inlineClasses/resultInlining.kt");
         }
 
+        @TestMetadata("resultRunCatchingOrElse.kt")
+        public void testResultRunCatchingOrElse() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/resultRunCatchingOrElse.kt");
+        }
+
         @TestMetadata("secondaryConstructorWithVararg.kt")
         public void testSecondaryConstructorWithVararg() throws Exception {
             runTest("compiler/testData/codegen/box/inlineClasses/secondaryConstructorWithVararg.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -11265,9 +11265,79 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             runTest("compiler/testData/codegen/box/inlineClasses/emptyConstructorForInlineClass.kt");
         }
 
+        @TestMetadata("equalityChecksInlineClassNonNull.kt")
+        public void testEqualityChecksInlineClassNonNull() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksInlineClassNonNull.kt");
+        }
+
+        @TestMetadata("equalityChecksMixedNullability.kt")
+        public void testEqualityChecksMixedNullability() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksMixedNullability.kt");
+        }
+
+        @TestMetadata("equalityChecksNegatedInlineClassNonNull.kt")
+        public void testEqualityChecksNegatedInlineClassNonNull() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksNegatedInlineClassNonNull.kt");
+        }
+
+        @TestMetadata("equalityChecksNegatedNonNull.kt")
+        public void testEqualityChecksNegatedNonNull() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksNegatedNonNull.kt");
+        }
+
+        @TestMetadata("equalityChecksNegatedNullable.kt")
+        public void testEqualityChecksNegatedNullable() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksNegatedNullable.kt");
+        }
+
+        @TestMetadata("equalityChecksNegatedPrimitive.kt")
+        public void testEqualityChecksNegatedPrimitive() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksNegatedPrimitive.kt");
+        }
+
+        @TestMetadata("equalityChecksNonNull.kt")
+        public void testEqualityChecksNonNull() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksNonNull.kt");
+        }
+
+        @TestMetadata("equalityChecksNullable.kt")
+        public void testEqualityChecksNullable() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksNullable.kt");
+        }
+
+        @TestMetadata("equalityChecksPrimitive.kt")
+        public void testEqualityChecksPrimitive() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksPrimitive.kt");
+        }
+
         @TestMetadata("equalityForBoxesOfNullableValuesOfInlineClass.kt")
         public void testEqualityForBoxesOfNullableValuesOfInlineClass() throws Exception {
             runTest("compiler/testData/codegen/box/inlineClasses/equalityForBoxesOfNullableValuesOfInlineClass.kt");
+        }
+
+        @TestMetadata("equalsCallsLeftArgument.kt")
+        public void testEqualsCallsLeftArgument() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalsCallsLeftArgument.kt");
+        }
+
+        @TestMetadata("equalsEvaluationOrderInlineClass.kt")
+        public void testEqualsEvaluationOrderInlineClass() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalsEvaluationOrderInlineClass.kt");
+        }
+
+        @TestMetadata("equalsEvaluationOrderNonNull.kt")
+        public void testEqualsEvaluationOrderNonNull() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalsEvaluationOrderNonNull.kt");
+        }
+
+        @TestMetadata("equalsEvaluationOrderNullable.kt")
+        public void testEqualsEvaluationOrderNullable() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalsEvaluationOrderNullable.kt");
+        }
+
+        @TestMetadata("equalsEvaluationOrderPrimitive.kt")
+        public void testEqualsEvaluationOrderPrimitive() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalsEvaluationOrderPrimitive.kt");
         }
 
         @TestMetadata("equalsOperatorWithGenericCall.kt")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
@@ -2453,6 +2453,11 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
             runTest("compiler/testData/codegen/bytecodeText/inlineClasses/defaultParametersDontBox.kt");
         }
 
+        @TestMetadata("equalsDoesNotBox.kt")
+        public void testEqualsDoesNotBox() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/inlineClasses/equalsDoesNotBox.kt");
+        }
+
         @TestMetadata("equalsIsCalledByInlineClass.kt")
         public void testEqualsIsCalledByInlineClass() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/inlineClasses/equalsIsCalledByInlineClass.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
@@ -2573,9 +2573,29 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
             runTest("compiler/testData/codegen/bytecodeText/inlineClasses/propertySetterWithInlineClassTypeArgument.kt");
         }
 
+        @TestMetadata("resultApiDoesntCallSpecializedEquals.kt")
+        public void testResultApiDoesntCallSpecializedEquals() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/inlineClasses/resultApiDoesntCallSpecializedEquals.kt");
+        }
+
         @TestMetadata("resultApiDoesntUseBox.kt")
         public void testResultApiDoesntUseBox() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/inlineClasses/resultApiDoesntUseBox.kt");
+        }
+
+        @TestMetadata("resultApiEqualsDoesntBox.kt")
+        public void testResultApiEqualsDoesntBox() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/inlineClasses/resultApiEqualsDoesntBox.kt");
+        }
+
+        @TestMetadata("resultApiRunCatchingDoesntBox.kt")
+        public void testResultApiRunCatchingDoesntBox() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/inlineClasses/resultApiRunCatchingDoesntBox.kt");
+        }
+
+        @TestMetadata("resultApiStringInterpolationDoesntBox.kt")
+        public void testResultApiStringInterpolationDoesntBox() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/inlineClasses/resultApiStringInterpolationDoesntBox.kt");
         }
 
         @TestMetadata("resultMangling.kt")

--- a/core/metadata.jvm/src/org/jetbrains/kotlin/metadata/jvm/deserialization/JvmMetadataVersion.kt
+++ b/core/metadata.jvm/src/org/jetbrains/kotlin/metadata/jvm/deserialization/JvmMetadataVersion.kt
@@ -27,7 +27,7 @@ class JvmMetadataVersion(versionArray: IntArray, val isStrictSemantics: Boolean)
 
     companion object {
         @JvmField
-        val INSTANCE = JvmMetadataVersion(1, 1, 15)
+        val INSTANCE = JvmMetadataVersion(1, 1, 16)
 
         @JvmField
         val INVALID_VERSION = JvmMetadataVersion()

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -10085,6 +10085,11 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/inlineClasses/resultInlining.kt");
         }
 
+        @TestMetadata("resultRunCatchingOrElse.kt")
+        public void testResultRunCatchingOrElse() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/resultRunCatchingOrElse.kt");
+        }
+
         @TestMetadata("secondaryConstructorWithVararg.kt")
         public void testSecondaryConstructorWithVararg() throws Exception {
             runTest("compiler/testData/codegen/box/inlineClasses/secondaryConstructorWithVararg.kt");

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -9720,9 +9720,79 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/inlineClasses/emptyConstructorForInlineClass.kt");
         }
 
+        @TestMetadata("equalityChecksInlineClassNonNull.kt")
+        public void testEqualityChecksInlineClassNonNull() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksInlineClassNonNull.kt");
+        }
+
+        @TestMetadata("equalityChecksMixedNullability.kt")
+        public void testEqualityChecksMixedNullability() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksMixedNullability.kt");
+        }
+
+        @TestMetadata("equalityChecksNegatedInlineClassNonNull.kt")
+        public void testEqualityChecksNegatedInlineClassNonNull() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksNegatedInlineClassNonNull.kt");
+        }
+
+        @TestMetadata("equalityChecksNegatedNonNull.kt")
+        public void testEqualityChecksNegatedNonNull() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksNegatedNonNull.kt");
+        }
+
+        @TestMetadata("equalityChecksNegatedNullable.kt")
+        public void testEqualityChecksNegatedNullable() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksNegatedNullable.kt");
+        }
+
+        @TestMetadata("equalityChecksNegatedPrimitive.kt")
+        public void testEqualityChecksNegatedPrimitive() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksNegatedPrimitive.kt");
+        }
+
+        @TestMetadata("equalityChecksNonNull.kt")
+        public void testEqualityChecksNonNull() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksNonNull.kt");
+        }
+
+        @TestMetadata("equalityChecksNullable.kt")
+        public void testEqualityChecksNullable() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksNullable.kt");
+        }
+
+        @TestMetadata("equalityChecksPrimitive.kt")
+        public void testEqualityChecksPrimitive() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksPrimitive.kt");
+        }
+
         @TestMetadata("equalityForBoxesOfNullableValuesOfInlineClass.kt")
         public void testEqualityForBoxesOfNullableValuesOfInlineClass() throws Exception {
             runTest("compiler/testData/codegen/box/inlineClasses/equalityForBoxesOfNullableValuesOfInlineClass.kt");
+        }
+
+        @TestMetadata("equalsCallsLeftArgument.kt")
+        public void testEqualsCallsLeftArgument() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalsCallsLeftArgument.kt");
+        }
+
+        @TestMetadata("equalsEvaluationOrderInlineClass.kt")
+        public void testEqualsEvaluationOrderInlineClass() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalsEvaluationOrderInlineClass.kt");
+        }
+
+        @TestMetadata("equalsEvaluationOrderNonNull.kt")
+        public void testEqualsEvaluationOrderNonNull() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalsEvaluationOrderNonNull.kt");
+        }
+
+        @TestMetadata("equalsEvaluationOrderNullable.kt")
+        public void testEqualsEvaluationOrderNullable() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalsEvaluationOrderNullable.kt");
+        }
+
+        @TestMetadata("equalsEvaluationOrderPrimitive.kt")
+        public void testEqualsEvaluationOrderPrimitive() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalsEvaluationOrderPrimitive.kt");
         }
 
         @TestMetadata("equalsOperatorWithGenericCall.kt")

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -10875,9 +10875,79 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/inlineClasses/emptyConstructorForInlineClass.kt");
         }
 
+        @TestMetadata("equalityChecksInlineClassNonNull.kt")
+        public void testEqualityChecksInlineClassNonNull() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksInlineClassNonNull.kt");
+        }
+
+        @TestMetadata("equalityChecksMixedNullability.kt")
+        public void testEqualityChecksMixedNullability() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksMixedNullability.kt");
+        }
+
+        @TestMetadata("equalityChecksNegatedInlineClassNonNull.kt")
+        public void testEqualityChecksNegatedInlineClassNonNull() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksNegatedInlineClassNonNull.kt");
+        }
+
+        @TestMetadata("equalityChecksNegatedNonNull.kt")
+        public void testEqualityChecksNegatedNonNull() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksNegatedNonNull.kt");
+        }
+
+        @TestMetadata("equalityChecksNegatedNullable.kt")
+        public void testEqualityChecksNegatedNullable() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksNegatedNullable.kt");
+        }
+
+        @TestMetadata("equalityChecksNegatedPrimitive.kt")
+        public void testEqualityChecksNegatedPrimitive() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksNegatedPrimitive.kt");
+        }
+
+        @TestMetadata("equalityChecksNonNull.kt")
+        public void testEqualityChecksNonNull() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksNonNull.kt");
+        }
+
+        @TestMetadata("equalityChecksNullable.kt")
+        public void testEqualityChecksNullable() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksNullable.kt");
+        }
+
+        @TestMetadata("equalityChecksPrimitive.kt")
+        public void testEqualityChecksPrimitive() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalityChecksPrimitive.kt");
+        }
+
         @TestMetadata("equalityForBoxesOfNullableValuesOfInlineClass.kt")
         public void testEqualityForBoxesOfNullableValuesOfInlineClass() throws Exception {
             runTest("compiler/testData/codegen/box/inlineClasses/equalityForBoxesOfNullableValuesOfInlineClass.kt");
+        }
+
+        @TestMetadata("equalsCallsLeftArgument.kt")
+        public void testEqualsCallsLeftArgument() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalsCallsLeftArgument.kt");
+        }
+
+        @TestMetadata("equalsEvaluationOrderInlineClass.kt")
+        public void testEqualsEvaluationOrderInlineClass() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalsEvaluationOrderInlineClass.kt");
+        }
+
+        @TestMetadata("equalsEvaluationOrderNonNull.kt")
+        public void testEqualsEvaluationOrderNonNull() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalsEvaluationOrderNonNull.kt");
+        }
+
+        @TestMetadata("equalsEvaluationOrderNullable.kt")
+        public void testEqualsEvaluationOrderNullable() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalsEvaluationOrderNullable.kt");
+        }
+
+        @TestMetadata("equalsEvaluationOrderPrimitive.kt")
+        public void testEqualsEvaluationOrderPrimitive() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/equalsEvaluationOrderPrimitive.kt");
         }
 
         @TestMetadata("equalsOperatorWithGenericCall.kt")

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -11240,6 +11240,11 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/inlineClasses/resultInlining.kt");
         }
 
+        @TestMetadata("resultRunCatchingOrElse.kt")
+        public void testResultRunCatchingOrElse() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/resultRunCatchingOrElse.kt");
+        }
+
         @TestMetadata("secondaryConstructorWithVararg.kt")
         public void testSecondaryConstructorWithVararg() throws Exception {
             runTest("compiler/testData/codegen/box/inlineClasses/secondaryConstructorWithVararg.kt");


### PR DESCRIPTION
Currently, when we compare values of an inline class type we always box both arguments and call `Intrinsics.areEqual`. This also applies to the `Result` type which is used in coroutines. There is a test (`testResultApiDoesntBox`) which claims to check that this is not the case, but unfortunately the test is currently broken.

This PR implements support for the `equals-impl0` method which is present in inline classes and uses it to avoid boxing when comparing values of an inline class type. Additionally, there are many cases where comparing a value of an inline class type to `null` can use `IFNULL` and related instructions, instead of falling back to `Intrinsics.areEqual`. This fixes [KT-30785](https://youtrack.jetbrains.com/issue/KT-30785), and some of the changes will also be necessary to support [KT-24874](https://youtrack.jetbrains.com/issue/KT-24874).

Concretely, the PR only specializes calls of the form `x == y` where `x` is an unboxed value of inline class type. If `y` is similarly unboxed, we use the `equals-impl0` method, otherwise we use `equals-impl`. There is one case where we have to add additional null-checks at the moment, namely when `x` is a nullable value of an inline class wrapper around a reference type. Strictly speaking, this is not necessary right now, since the `equals-impl0` method is generated by the compiler and handles the case where `x` is `null`, but it might cause problems in the future if we want to permit user defined equality checks.