### PR TITLE
fix for KT-29471

### DIFF
--- a/plugins/jvm-abi-gen/test/org/jetbrains/kotlin/jvm/abi/CompileAgainstJvmAbiTestGenerated.java
+++ b/plugins/jvm-abi-gen/test/org/jetbrains/kotlin/jvm/abi/CompileAgainstJvmAbiTestGenerated.java
@@ -45,6 +45,11 @@ public class CompileAgainstJvmAbiTestGenerated extends AbstractCompileAgainstJvm
     }
 
     @TestMetadata("inlineReifiedFunction")
+    public void testInlineAnonymousObject() throws Exception {
+        runTest("plugins/jvm-abi-gen/testData/compile/inlineAnonymousObject/");
+    }
+
+    @TestMetadata("inlineReifiedFunction")
     public void testInlineReifiedFunction() throws Exception {
         runTest("plugins/jvm-abi-gen/testData/compile/inlineReifiedFunction/");
     }

--- a/plugins/jvm-abi-gen/test/org/jetbrains/kotlin/jvm/abi/CompileAgainstJvmAbiTestGenerated.java
+++ b/plugins/jvm-abi-gen/test/org/jetbrains/kotlin/jvm/abi/CompileAgainstJvmAbiTestGenerated.java
@@ -44,7 +44,7 @@ public class CompileAgainstJvmAbiTestGenerated extends AbstractCompileAgainstJvm
         runTest("plugins/jvm-abi-gen/testData/compile/clinit/");
     }
 
-    @TestMetadata("inlineReifiedFunction")
+    @TestMetadata("inlineAnonymousObject")
     public void testInlineAnonymousObject() throws Exception {
         runTest("plugins/jvm-abi-gen/testData/compile/inlineAnonymousObject/");
     }

--- a/plugins/jvm-abi-gen/testData/compile/inlineAnonymousObject/app/app.kt
+++ b/plugins/jvm-abi-gen/testData/compile/inlineAnonymousObject/app/app.kt
@@ -1,0 +1,13 @@
+package app
+
+import lib.*
+
+fun runAppAndReturnOk(): String {
+    val a = lib.getCounter { 100 }
+    val x = a.getInt()
+    if (x != 100) error("a returned $x but expected '100'")
+    val y = a.getInt()
+    if (y != 101) error("a returned $y but expected '101'")
+
+    return "OK"
+}

--- a/plugins/jvm-abi-gen/testData/compile/inlineAnonymousObject/lib/lib.kt
+++ b/plugins/jvm-abi-gen/testData/compile/inlineAnonymousObject/lib/lib.kt
@@ -1,0 +1,11 @@
+package lib
+
+interface Interface {
+    fun getInt(): Int
+}
+
+inline fun getCounter(crossinline init: () -> Int): Interface =
+    object : Interface {
+        var value = init()
+        override fun getInt(): Int = value++
+    }


### PR DESCRIPTION
Proposed fix for KT-29471: preserve objects in scope of inline functions so they can be referenced by the inlined code.  Include test case that fails without this change.