### PR TITLE
KT-33515: Remove Kotlin sources generated by KAPT

### DIFF
--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/KaptContext.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/KaptContext.kt
@@ -73,6 +73,9 @@ open class KaptContext(val options: KaptOptions, val withJdk: Boolean, val logge
                 }
                 deleteAndCreate(options.sourcesOutputDir)
                 deleteAndCreate(options.classesOutputDir)
+                options.getKotlinGeneratedSourcesDirectory()?.let {
+                    deleteAndCreate(it)
+                }
             }
         } else {
             sourcesToReprocess = SourcesToReprocess.FullRebuild

--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/KaptOptions.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/KaptOptions.kt
@@ -9,6 +9,8 @@ import org.jetbrains.kotlin.kapt3.base.incremental.SourcesToReprocess
 import java.io.File
 import java.nio.file.Files
 
+private const val KAPT_KOTLIN_GENERATED_OPTION_NAME = "kapt.kotlin.generated"
+
 class KaptOptions(
     val projectBaseDir: File?,
     val compileClasspath: List<File>,
@@ -79,6 +81,11 @@ class KaptOptions(
                 mode, detectMemoryLeaks
             )
         }
+    }
+
+    fun getKotlinGeneratedSourcesDirectory(): File? {
+        val value = processingOptions[KAPT_KOTLIN_GENERATED_OPTION_NAME] ?: return null
+        return File(value).takeIf { it.exists() }
     }
 }
 

--- a/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/Kapt3Extension.kt
+++ b/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/Kapt3Extension.kt
@@ -66,8 +66,6 @@ import java.io.Writer
 import java.net.URLClassLoader
 import javax.annotation.processing.Processor
 
-private const val KAPT_KOTLIN_GENERATED_OPTION_NAME = "kapt.kotlin.generated"
-
 class ClasspathBasedKapt3Extension(
     options: KaptOptions,
     logger: MessageCollectorBackedKaptLogger,
@@ -209,15 +207,10 @@ abstract class AbstractKapt3Extension(
                 bindingTrace.bindingContext,
                 module,
                 listOf(options.sourcesOutputDir),
-                listOfNotNull(options.sourcesOutputDir, getKotlinGeneratedSourcesDirectory()),
+                listOfNotNull(options.sourcesOutputDir, options.getKotlinGeneratedSourcesDirectory()),
                 addToEnvironment = true
             )
         }
-    }
-
-    private fun getKotlinGeneratedSourcesDirectory(): File? {
-        val value = options.processingOptions[KAPT_KOTLIN_GENERATED_OPTION_NAME] ?: return null
-        return File(value).takeIf { it.exists() }
     }
 
     private fun runAnnotationProcessing(kaptContext: KaptContext, processors: LoadedProcessors) {


### PR DESCRIPTION
When KAPT is unable to run incrementally make sure to
clean directory that contains generated Kotlin sources.
This location is specified using '-Akapt.kotlin.generated'
option.