### PR TITLE
KT-31291: KAPT - make sure ASM version is not inlined

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/incremental/ClassAbiExtractor.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/incremental/ClassAbiExtractor.kt
@@ -15,7 +15,8 @@ const val metadataDescriptor: String = "Lkotlin/Metadata;"
  */
 internal val lazyAsmApiVersion = lazy {
     try {
-        Opcodes::API_VERSION.get()
+        val field = Opcodes::class.java.getField("API_VERSION")
+        field.get(null) as Int
     } catch(e: Throwable) {
         Opcodes.API_VERSION
     }


### PR DESCRIPTION
Switch to Java reflection when getting the ASM version used
to analyze classes. Using Kotlin reflection resulted in the constant
being inlined.

Fixes KT-31291
Fixes KT-33493