### PR TITLE
remove unused org.jetbrains.kotlin.idea.inspections.gradle.KotlinPlat…

### DIFF
--- a/idea/resources/META-INF/jvm.xml
+++ b/idea/resources/META-INF/jvm.xml
@@ -1,9 +1,4 @@
 <idea-plugin>
-    <extensionPoints>
-        <extensionPoint qualifiedName="org.jetbrains.kotlin.platformGradleDetector"
-                        interface="org.jetbrains.kotlin.idea.inspections.gradle.KotlinPlatformGradleDetector"/>
-    </extensionPoints>
-
     <application-components>
         <component>
             <implementation-class>org.jetbrains.kotlin.idea.JvmPluginStartupComponent</implementation-class>


### PR DESCRIPTION
Remove unsused `org.jetbrains.kotlin.platformGradleDetector` EP.

Not required after https://github.com/JetBrains/kotlin/commit/cc85ac44b30efbee2aff6664b30249fac931344b

Leads to warning in IDEA 2019.3