### PR TITLE
JVM IR: Implement visibility rules for CallableReferences

### DIFF
--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/ClosureAnnotator.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/ClosureAnnotator.kt
@@ -30,17 +30,7 @@ import org.jetbrains.kotlin.ir.symbols.IrValueSymbol
 import org.jetbrains.kotlin.ir.util.isLocal
 import org.jetbrains.kotlin.ir.visitors.IrElementVisitorVoid
 import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
-import kotlin.collections.List
-import kotlin.collections.emptyList
-import kotlin.collections.filterTo
-import kotlin.collections.firstOrNull
-import kotlin.collections.forEach
-import kotlin.collections.getOrElse
-import kotlin.collections.mutableListOf
-import kotlin.collections.mutableMapOf
-import kotlin.collections.mutableSetOf
 import kotlin.collections.set
-import kotlin.collections.toList
 
 class Closure(val capturedValues: List<IrValueSymbol> = emptyList())
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
@@ -13,11 +13,11 @@ import org.jetbrains.kotlin.backend.jvm.lower.*
 import org.jetbrains.kotlin.codegen.OwnerKind
 import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.descriptors.Visibilities
-import org.jetbrains.kotlin.ir.declarations.IrDeclarationWithName
-import org.jetbrains.kotlin.ir.declarations.IrFile
-import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.descriptors.Visibility
+import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.util.PatchDeclarationParentsVisitor
 import org.jetbrains.kotlin.ir.visitors.acceptVoid
+import org.jetbrains.kotlin.load.java.JavaVisibilities
 import org.jetbrains.kotlin.load.java.JvmAbi
 import org.jetbrains.kotlin.name.NameUtils
 
@@ -90,10 +90,29 @@ private val propertiesPhase = makeIrFilePhase<JvmBackendContext>(
 
 internal val localDeclarationsPhase = makeIrFilePhase<CommonBackendContext>(
     { context ->
-        LocalDeclarationsLowering(context, object : LocalNameProvider {
-            override fun localName(declaration: IrDeclarationWithName): String =
-                NameUtils.sanitizeAsJavaIdentifier(super.localName(declaration))
-        }, Visibilities.PUBLIC)
+        LocalDeclarationsLowering(
+            context,
+            object : LocalNameProvider {
+                override fun localName(declaration: IrDeclarationWithName): String =
+                    NameUtils.sanitizeAsJavaIdentifier(super.localName(declaration))
+            },
+            object : VisibilityPolicy {
+                override fun forClass(declaration: IrClass, inInlineFunctionScope: Boolean): Visibility =
+                    if (declaration.origin == JvmLoweredDeclarationOrigin.LAMBDA_IMPL ||
+                        declaration.origin == JvmLoweredDeclarationOrigin.FUNCTION_REFERENCE_IMPL ||
+                        declaration.origin == JvmLoweredDeclarationOrigin.GENERATED_PROPERTY_REFERENCE) {
+                        scopedVisibility(inInlineFunctionScope)
+                    } else {
+                        declaration.visibility
+                    }
+
+                override fun forConstructor(declaration: IrConstructor, inInlineFunctionScope: Boolean): Visibility =
+                    scopedVisibility(inInlineFunctionScope)
+
+                private fun scopedVisibility(inInlineFunctionScope: Boolean): Visibility =
+                    if (inInlineFunctionScope) Visibilities.PUBLIC else JavaVisibilities.PACKAGE_VISIBILITY
+            }
+        )
     },
     name = "JvmLocalDeclarations",
     description = "Move local declarations to classes",

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/FunctionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/FunctionCodegen.kt
@@ -106,7 +106,7 @@ open class FunctionCodegen(
             }
         }
 
-        val visibility = AsmUtil.getVisibilityAccessFlag(irFunction.visibility) ?: error("Unmapped visibility ${irFunction.visibility}")
+        val visibility = irFunction.getVisibilityAccessFlag()
         val staticFlag = if (isStatic) Opcodes.ACC_STATIC else 0
         val varargFlag = if (irFunction.valueParameters.any { it.varargElementType != null }) Opcodes.ACC_VARARGS else 0
         val deprecation = irFunction.deprecationFlags

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/irCodegenUtils.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/irCodegenUtils.kt
@@ -167,7 +167,7 @@ private fun IrClass.innerAccessFlagsForModalityAndKind(): Int {
     return 0
 }
 
-private fun IrDeclarationWithVisibility.getVisibilityAccessFlag(kind: OwnerKind? = null): Int =
+fun IrDeclarationWithVisibility.getVisibilityAccessFlag(kind: OwnerKind? = null): Int =
     specialCaseVisibility(kind)
         ?: visibilityToAccessFlag[visibility]
         ?: throw IllegalStateException("$visibility is not a valid visibility in backend for ${ir2string(this)}")
@@ -223,9 +223,9 @@ private fun IrDeclarationWithVisibility.specialCaseVisibility(kind: OwnerKind?):
 //    if (memberDescriptor is ConstructorDescriptor && isAnonymousObject(memberDescriptor.containingDeclaration)) {
 //        return getVisibilityAccessFlagForAnonymous(memberDescriptor.containingDeclaration as ClassDescriptor)
 //    }
-    if (this is IrConstructor && parentAsClass.isAnonymousObject) {
-        return parentAsClass.getVisibilityAccessFlagForAnonymous()
-    }
+//    if (this is IrConstructor && parentAsClass.isAnonymousObject) {
+//        return parentAsClass.getVisibilityAccessFlagForAnonymous()
+//    }
 
 //    TODO: when is this applicable?
 //    if (memberDescriptor is SyntheticJavaPropertyDescriptor) {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/CallableReferenceLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/CallableReferenceLowering.kt
@@ -172,7 +172,6 @@ internal class CallableReferenceLowering(private val context: JvmBackendContext)
             functionReferenceClass.addConstructor {
                 setSourceRange(irFunctionReference)
                 origin = JvmLoweredDeclarationOrigin.FUNCTION_REFERENCE_IMPL
-                visibility = if (inInlineFunctionScope) Visibilities.PUBLIC else JavaVisibilities.PACKAGE_VISIBILITY
                 returnType = functionReferenceClass.defaultType
                 isPrimary = true
             }.apply {
@@ -380,9 +379,6 @@ internal class CallableReferenceLowering(private val context: JvmBackendContext)
 
     private val currentDeclarationParent
         get() = allScopes.last { it.irElement is IrDeclarationParent }.irElement as IrDeclarationParent
-
-    private val inInlineFunctionScope: Boolean
-        get() = allScopes.any { scope -> (scope.irElement as? IrFunction)?.isInline ?: false }
 
     private fun IrClassSymbol.functionByName(name: String) = owner.functions.single { it.name.asString() == name }
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/PropertyReferenceLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/PropertyReferenceLowering.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
 import org.jetbrains.kotlin.backend.jvm.JvmLoweredDeclarationOrigin
 import org.jetbrains.kotlin.backend.jvm.ir.createJvmIrBuilder
 import org.jetbrains.kotlin.backend.jvm.ir.irArrayOf
+import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.builders.declarations.addFunction
@@ -29,6 +30,7 @@ import org.jetbrains.kotlin.ir.types.impl.IrSimpleTypeImpl
 import org.jetbrains.kotlin.ir.types.impl.makeTypeProjection
 import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
+import org.jetbrains.kotlin.load.java.JavaVisibilities
 import org.jetbrains.kotlin.load.java.JvmAbi
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.types.Variance
@@ -135,20 +137,17 @@ internal class PropertyReferenceLowering(val context: JvmBackendContext) : Class
             propertyReferenceKind(!it.isFinal, if (it.isStatic || expression.dispatchReceiver != null) 0 else 1)
         } ?: throw AssertionError("property has no getter and no field: ${expression.dump()}")
 
-    private data class PropertyCacheKey(val symbol: IrSymbol, val reflected: Boolean)
-    private data class PropertyClassCacheKey(val symbol: IrSymbol, val boundReceiver: Boolean)
     private data class PropertyInstance(val initializer: IrExpression, val index: Int)
 
     override fun lower(irClass: IrClass) {
-        val kProperties = mutableMapOf<PropertyCacheKey, PropertyInstance>()
-        val kPropertyClasses = mutableMapOf<PropertyClassCacheKey, IrClass>()
+        val kProperties = mutableMapOf<IrSymbol, PropertyInstance>()
         val kPropertiesField = buildField {
             name = Name.identifier(JvmAbi.DELEGATED_PROPERTIES_ARRAY_NAME)
             type = kPropertiesFieldType
             origin = JvmLoweredDeclarationOrigin.GENERATED_PROPERTY_REFERENCE
             isFinal = true
             isStatic = true
-            // TODO: make the visibility package-local. Currently it's more permissive to allow access from inline functions.
+            visibility = JavaVisibilities.PACKAGE_VISIBILITY
         }
         var localPropertiesInClass = 0
 
@@ -165,20 +164,14 @@ internal class PropertyReferenceLowering(val context: JvmBackendContext) : Class
                 cachedKProperty(expression)
 
             private fun cachedKProperty(expression: IrCallableReference): IrExpression {
-                // Reflected implementation does not support partial application; also, cannot cache instances with arguments.
-                if (expression.dispatchReceiver != null || expression.extensionReceiver != null)
+                if (expression.origin != IrStatementOrigin.PROPERTY_REFERENCE_FOR_DELEGATE)
                     return createSpecializedKProperty(expression)
 
                 // For delegated properties, the getter and setter contain a reference each as the second argument to getValue
                 // and setValue. Since it's highly unlikely that anyone will call get/set on these, optimize for space.
-                val useReflectedImpl = expression.origin == IrStatementOrigin.PROPERTY_REFERENCE_FOR_DELEGATE
                 return context.createIrBuilder(currentScope!!.scope.scopeOwnerSymbol, expression.startOffset, expression.endOffset).run {
-                    val (_, index) = kProperties.getOrPut(PropertyCacheKey(expression.symbol, useReflectedImpl)) {
-                        val kProperty = if (useReflectedImpl)
-                            createReflectedKProperty(expression)
-                        else
-                            createSpecializedKProperty(expression)
-                        PropertyInstance(kProperty, kProperties.size)
+                    val (_, index) = kProperties.getOrPut(expression.symbol) {
+                        PropertyInstance(createReflectedKProperty(expression), kProperties.size)
                     }
                     irCall(arrayItemGetter).apply {
                         dispatchReceiver = irGetField(null, kPropertiesField)
@@ -218,17 +211,16 @@ internal class PropertyReferenceLowering(val context: JvmBackendContext) : Class
             // and then `C()::property` -> `C$property$0(C())`.
             //
             private fun createSpecializedKProperty(expression: IrCallableReference): IrExpression {
-                val bound = expression.dispatchReceiver != null || expression.extensionReceiver != null
-                val referenceClass = kPropertyClasses.getOrPut(PropertyClassCacheKey(expression.symbol, bound)) {
-                    createKPropertySubclass(expression)
-                }
-                return context.createIrBuilder(currentScope!!.scope.scopeOwnerSymbol, expression.startOffset, expression.endOffset).run {
-                    irCall(referenceClass.constructors.single()).apply {
-                        var index = 0
-                        expression.dispatchReceiver?.let { putValueArgument(index++, it) }
-                        expression.extensionReceiver?.let { putValueArgument(index++, it) }
+                val referenceClass = createKPropertySubclass(expression)
+                return context.createIrBuilder(currentScope!!.scope.scopeOwnerSymbol, expression.startOffset, expression.endOffset)
+                    .irBlock {
+                        +referenceClass
+                        +irCall(referenceClass.constructors.single()).apply {
+                            var index = 0
+                            expression.dispatchReceiver?.let { putValueArgument(index++, it) }
+                            expression.extensionReceiver?.let { putValueArgument(index++, it) }
+                        }
                     }
-                }
             }
 
             private fun createKPropertySubclass(expression: IrCallableReference): IrClass {
@@ -237,6 +229,7 @@ internal class PropertyReferenceLowering(val context: JvmBackendContext) : Class
                     setSourceRange(expression)
                     name = Name.special("<property reference to ${(expression.symbol.owner as IrDeclarationWithName).fqNameWhenAvailable}>")
                     origin = JvmLoweredDeclarationOrigin.GENERATED_PROPERTY_REFERENCE
+                    visibility = Visibilities.LOCAL
                 }.apply {
                     parent = irClass
                     superTypes += IrSimpleTypeImpl(superClass.symbol, false, listOf(), listOf())
@@ -317,7 +310,7 @@ internal class PropertyReferenceLowering(val context: JvmBackendContext) : Class
         })
 
         // Put the new field at the beginning so that static delegated properties with initializers work correctly.
-        // Since we do not cache property references with bound receivers, the new field does not reference anything else.
+        // Since we do not cache property references, the new field does not reference anything else.
         if (kProperties.isNotEmpty()) {
             irClass.declarations.add(0, kPropertiesField.apply {
                 parent = irClass
@@ -328,8 +321,7 @@ internal class PropertyReferenceLowering(val context: JvmBackendContext) : Class
             })
 
             context.localDelegatedProperties[irClass.attributeOwnerId as IrClass] =
-                kProperties.mapNotNull { it.key.symbol as? IrLocalDelegatedPropertySymbol }
+                kProperties.keys.filterIsInstance<IrLocalDelegatedPropertySymbol>()
         }
-        irClass.declarations.addAll(0, kPropertyClasses.values)
     }
 }

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/declarations/IrClass.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/declarations/IrClass.kt
@@ -19,6 +19,7 @@ package org.jetbrains.kotlin.ir.declarations
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.Modality
+import org.jetbrains.kotlin.descriptors.Visibility
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.types.IrType
 
@@ -27,6 +28,8 @@ interface IrClass :
     IrDeclarationContainer, IrTypeParametersContainer, IrAttributeContainer {
 
     override val descriptor: ClassDescriptor
+
+    override var visibility: Visibility
 
     val kind: ClassKind
     val modality: Modality

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/declarations/impl/IrClassImpl.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/declarations/impl/IrClassImpl.kt
@@ -37,7 +37,7 @@ class IrClassImpl(
     override val symbol: IrClassSymbol,
     override val name: Name,
     override val kind: ClassKind,
-    override val visibility: Visibility,
+    override var visibility: Visibility,
     override val modality: Modality,
     override val isCompanion: Boolean,
     override val isInner: Boolean,

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/declarations/lazy/IrLazyClass.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/declarations/lazy/IrLazyClass.kt
@@ -27,7 +27,7 @@ class IrLazyClass(
     override val symbol: IrClassSymbol,
     override val name: Name,
     override val kind: ClassKind,
-    override val visibility: Visibility,
+    override var visibility: Visibility,
     override val modality: Modality,
     override val isCompanion: Boolean,
     override val isInner: Boolean,

--- a/compiler/testData/writeFlags/callableReference/visibility/functionReference.kt
+++ b/compiler/testData/writeFlags/callableReference/visibility/functionReference.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 class A {
     fun foo() {}
 

--- a/compiler/testData/writeFlags/callableReference/visibility/propertyReference.kt
+++ b/compiler/testData/writeFlags/callableReference/visibility/propertyReference.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 class A {
     val foo = ""
 

--- a/compiler/testData/writeFlags/function/constructors/objectLiteral.kt
+++ b/compiler/testData/writeFlags/function/constructors/objectLiteral.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 class Foo {
   fun a() {
     val s = object { }

--- a/compiler/testData/writeFlags/inline/inlineOnly.kt
+++ b/compiler/testData/writeFlags/inline/inlineOnly.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 class MyClass {
     @Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
     @kotlin.internal.InlineOnly

--- a/compiler/testData/writeFlags/lambda/simpleLambda.kt
+++ b/compiler/testData/writeFlags/lambda/simpleLambda.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 class Foo {
     fun foo() = { }
 }


### PR DESCRIPTION
This is a new implementation of #2523, which moves the logic for setting the visibility of callable references into several lowerings instead of keeping it in the backend.