### PR TITLE
YarnSetupTask: Remove a too coarse "onlyIf" in the init block

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/yarn/YarnSetupTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/yarn/YarnSetupTask.kt
@@ -28,10 +28,6 @@ open class YarnSetupTask : DefaultTask() {
     init {
         group = NodeJsRootPlugin.TASKS_GROUP_NAME
         description = "Download and install a local yarn version"
-
-        onlyIf {
-            !settings.installationDir.exists()
-        }
     }
 
     @Action


### PR DESCRIPTION
"installationDir" is the non-version specific top-level Yarn
installation directory simply called "yarn". Checking for its existence
is not sufficient to be able to skip the task, as another version than
the requested one could be installed below the "yarn" directory.

Instead of taking the version into account in this check, simply remove
it as the version-specific installation directory at "env.home" is
already marked as an "OutputDirectory", so Gradle itself already takes
care of skipping task execution if the output files were created before.