### PR TITLE
Support symlinked JAVA_HOME

### DIFF
--- a/buildSrc/src/main/kotlin/jdksFinder.kt
+++ b/buildSrc/src/main/kotlin/jdksFinder.kt
@@ -4,6 +4,7 @@ import net.rubygrapefruit.platform.Native
 import net.rubygrapefruit.platform.WindowsRegistry
 import org.gradle.api.GradleException
 import org.gradle.api.Project
+import java.nio.file.Paths
 import java.io.File
 import net.rubygrapefruit.platform.WindowsRegistry.Key.HKEY_LOCAL_MACHINE
 import org.gradle.internal.os.OperatingSystem
@@ -25,7 +26,7 @@ fun Project.getConfiguredJdks(): List<JdkId> {
                 ?: System.getenv(jdkMajorVersion.name)
                 ?: jdkAlternativeVarNames[jdkMajorVersion]?.mapNotNull { System.getenv(it) }?.firstOrNull()
                 ?: continue
-        val explicitJdk = File(explicitJdkEnvVal)
+        val explicitJdk = Paths.get(explicitJdkEnvVal).toRealPath().toFile()
         if (!explicitJdk.isDirectory) {
             throw GradleException("Invalid environment value $jdkMajorVersion: $explicitJdkEnvVal, expecting JDK home path")
         }


### PR DESCRIPTION
When testing for the JAVA_HOME environment variable, expand potential
symlinks first. This is almost guaranteed to be the case in all modern
Linux distributions putting the JDK / JRE behind update-alternatives to
be able to select the *current* version [0], e.g. on Fedora:

  $ ls -l $JAVA_HOME
  lrwxrwxrwx. ... /usr/lib/jvm/java -> /etc/alternatives/java_sdk

[0] https://linux.die.net/man/8/update-alternatives