### PR TITLE
KT-33060 "Cleanup code" does not remove 'final' keyword for overridden function with non-canonical modifiers order

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/SortModifiersInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/SortModifiersInspection.kt
@@ -73,10 +73,11 @@ private class SortModifiersFix(private val modifiers: List<KtModifierKeywordToke
         val list = descriptor.psiElement as? KtModifierList ?: return
         val owner = list.parent as? KtModifierListOwner ?: return
 
-        modifiers.forEach { owner.removeModifier(it) }
+        val existingModifiers = modifiers.filter { owner.hasModifier(it) }
+        existingModifiers.forEach { owner.removeModifier(it) }
         // We add visibility / modality modifiers after all others,
         // because they can be redundant or not depending on others (e.g. override)
-        modifiers
+        existingModifiers
             .partition { it in KtTokens.VISIBILITY_MODIFIERS || it in KtTokens.MODALITY_MODIFIERS }
             .let { it.second + it.first }
             .forEach { owner.addModifier(it) }

--- a/idea/testData/inspections/cleanup/cleanup.kt
+++ b/idea/testData/inspections/cleanup/cleanup.kt
@@ -112,3 +112,12 @@ object X {
 header class Expected
 
 impl class Actual
+
+// KT-33060
+interface AA {
+    fun foo(key: Any)
+}
+
+class A1 : AA {
+    override final fun foo(key: Any) {}
+}

--- a/idea/testData/inspections/cleanup/cleanup.kt.after
+++ b/idea/testData/inspections/cleanup/cleanup.kt.after
@@ -112,3 +112,12 @@ object X {
 expect class Expected
 
 actual class Actual
+
+// KT-33060
+interface AA {
+    fun foo(key: Any)
+}
+
+class A1 : AA {
+    override fun foo(key: Any) {}
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/KotlinCleanupInspectionTest.kt
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/KotlinCleanupInspectionTest.kt
@@ -25,6 +25,8 @@ class KotlinCleanupInspectionTest(): KotlinLightCodeInsightFixtureTestCase() {
 
     private fun doTest(result: String, vararg files: String) {
         myFixture.enableInspections(KotlinCleanupInspection::class.java)
+        myFixture.enableInspections(SortModifiersInspection::class.java)
+        myFixture.enableInspections(RedundantModalityModifierInspection::class.java)
         myFixture.configureByFiles(*files)
 
         val project = myFixture.project


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-33060