### PR TITLE
KT-33466 IDE generates incorrect `external override` with body for overriding `open external` method

### DIFF
--- a/idea/idea-core/src/org/jetbrains/kotlin/idea/core/generateUtil.kt
+++ b/idea/idea-core/src/org/jetbrains/kotlin/idea/core/generateUtil.kt
@@ -258,6 +258,8 @@ fun <T : KtDeclaration> insertMembersAfter(
                     }
                 }
 
+                it.removeModifier(KtTokens.EXTERNAL_KEYWORD)
+
                 @Suppress("UNCHECKED_CAST")
                 (body.addAfter(it, afterAnchor) as T).apply { afterAnchor = this }
             }

--- a/idea/testData/codeInsight/overrideImplement/overrideExternalFunction.kt
+++ b/idea/testData/codeInsight/overrideImplement/overrideExternalFunction.kt
@@ -1,0 +1,7 @@
+open class A {
+    open external fun foo()
+}
+
+class B : A() {
+    <caret>
+}

--- a/idea/testData/codeInsight/overrideImplement/overrideExternalFunction.kt.after
+++ b/idea/testData/codeInsight/overrideImplement/overrideExternalFunction.kt.after
@@ -1,0 +1,9 @@
+open class A {
+    open external fun foo()
+}
+
+class B : A() {
+    override fun foo() {
+        super.foo()
+    }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/codeInsight/OverrideImplementTest.kt
+++ b/idea/tests/org/jetbrains/kotlin/idea/codeInsight/OverrideImplementTest.kt
@@ -329,4 +329,8 @@ class OverrideImplementTest : AbstractOverrideImplementTest() {
     fun testEnumClass4() {
         doOverrideFileTest("toString")
     }
+
+    fun testOverrideExternalFunction() {
+        doOverrideFileTest()
+    }
 }


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-33466