### PR TITLE
KT-14899 Quickfix "Create member function" inserts too many semicolons when applied to Enum

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/formatter/KotlinPreFormatProcessor.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/formatter/KotlinPreFormatProcessor.kt
@@ -54,10 +54,11 @@ private class Visitor(var range: TextRange) : KtTreeVisitorVoid() {
                 prevEntry.add(comma)
                 delta += comma.textLength
             }
-        }
-        else {
+        } else {
             val lastEntry = klass.declarations.lastIsInstanceOrNull<KtEnumEntry>()
-            if (lastEntry != null && lastEntry.containsToken(KtTokens.SEMICOLON)) return
+            if (lastEntry != null &&
+                (lastEntry.containsToken(KtTokens.SEMICOLON) || lastEntry.nextSibling?.node?.elementType == KtTokens.SEMICOLON)
+            ) return
             if (lastEntry == null && classBody.containsToken(KtTokens.SEMICOLON)) return
 
             val semicolon = KtPsiFactory(klass).createSemicolon()

--- a/idea/testData/quickfix/createFromUsage/createFunction/call/funOnEnumClass.kt
+++ b/idea/testData/quickfix/createFromUsage/createFunction/call/funOnEnumClass.kt
@@ -1,0 +1,8 @@
+// "Create member function 'Bar.foo'" "true"
+fun foo() {
+    Bar.BAZ.<caret>foo()
+}
+
+enum class Bar {
+    BAZ
+}

--- a/idea/testData/quickfix/createFromUsage/createFunction/call/funOnEnumClass.kt.after
+++ b/idea/testData/quickfix/createFromUsage/createFunction/call/funOnEnumClass.kt.after
@@ -1,0 +1,12 @@
+// "Create member function 'Bar.foo'" "true"
+fun foo() {
+    Bar.BAZ.foo()
+}
+
+enum class Bar {
+    BAZ;
+
+    fun foo() {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+}

--- a/idea/testData/quickfix/createFromUsage/createFunction/call/funOnEnumClass2.kt
+++ b/idea/testData/quickfix/createFromUsage/createFunction/call/funOnEnumClass2.kt
@@ -1,0 +1,8 @@
+// "Create member function 'Bar.foo'" "true"
+fun foo() {
+    Bar.BAZ.<caret>foo()
+}
+
+enum class Bar {
+    BAZ;
+}

--- a/idea/testData/quickfix/createFromUsage/createFunction/call/funOnEnumClass2.kt.after
+++ b/idea/testData/quickfix/createFromUsage/createFunction/call/funOnEnumClass2.kt.after
@@ -1,0 +1,12 @@
+// "Create member function 'Bar.foo'" "true"
+fun foo() {
+    Bar.BAZ.foo()
+}
+
+enum class Bar {
+    BAZ;
+
+    fun foo() {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -3782,6 +3782,16 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
                     runTest("idea/testData/quickfix/createFromUsage/createFunction/call/funOnClassObject.kt");
                 }
 
+                @TestMetadata("funOnEnumClass.kt")
+                public void testFunOnEnumClass() throws Exception {
+                    runTest("idea/testData/quickfix/createFromUsage/createFunction/call/funOnEnumClass.kt");
+                }
+
+                @TestMetadata("funOnEnumClass2.kt")
+                public void testFunOnEnumClass2() throws Exception {
+                    runTest("idea/testData/quickfix/createFromUsage/createFunction/call/funOnEnumClass2.kt");
+                }
+
                 @TestMetadata("funOnLibObject.kt")
                 public void testFunOnLibObject() throws Exception {
                     runTest("idea/testData/quickfix/createFromUsage/createFunction/call/funOnLibObject.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-14899