### PR TITLE
KT-26047 Refactor -> Rename: Overridden method renaming in generic class doesn't rename base method

### DIFF
--- a/idea/testData/refactoring/rename/renameKotlinFunctionInGenericClass/after/RenameKotlinFunctionInGenericClass.kt
+++ b/idea/testData/refactoring/rename/renameKotlinFunctionInGenericClass/after/RenameKotlinFunctionInGenericClass.kt
@@ -1,0 +1,12 @@
+package test
+
+open class A<T> {
+    open fun bar() {
+    }
+}
+
+class B<T> : A<T>() {
+    override fun bar() {
+        super.bar()
+    }
+}

--- a/idea/testData/refactoring/rename/renameKotlinFunctionInGenericClass/before/RenameKotlinFunctionInGenericClass.kt
+++ b/idea/testData/refactoring/rename/renameKotlinFunctionInGenericClass/before/RenameKotlinFunctionInGenericClass.kt
@@ -1,0 +1,12 @@
+package test
+
+open class A<T> {
+    open fun foo() {
+    }
+}
+
+class B<T> : A<T>() {
+    override fun foo() {
+        super.foo()
+    }
+}

--- a/idea/testData/refactoring/rename/renameKotlinFunctionInGenericClass/renameKotlinFunctionInGenericClass.test
+++ b/idea/testData/refactoring/rename/renameKotlinFunctionInGenericClass/renameKotlinFunctionInGenericClass.test
@@ -1,0 +1,6 @@
+{
+  "type": "KOTLIN_FUNCTION",
+  "classId": "test/A",
+  "oldName": "foo",
+  "newName": "bar"
+}

--- a/idea/testData/refactoring/rename/renameKotlinFunctionInGenericClass/renameKotlinFunctionInGenericClassFromSubclass.test
+++ b/idea/testData/refactoring/rename/renameKotlinFunctionInGenericClass/renameKotlinFunctionInGenericClassFromSubclass.test
@@ -1,0 +1,6 @@
+{
+  "type": "KOTLIN_FUNCTION",
+  "classId": "test/B",
+  "oldName": "foo",
+  "newName": "bar"
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/refactoring/rename/RenameTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/refactoring/rename/RenameTestGenerated.java
@@ -813,6 +813,16 @@ public class RenameTestGenerated extends AbstractRenameTest {
         runTest("idea/testData/refactoring/rename/renameKotlinFunctionInEnum/renameKotlinFunctionInEnumFromSubclass.test");
     }
 
+    @TestMetadata("renameKotlinFunctionInGenericClass/renameKotlinFunctionInGenericClass.test")
+    public void testRenameKotlinFunctionInGenericClass_RenameKotlinFunctionInGenericClass() throws Exception {
+        runTest("idea/testData/refactoring/rename/renameKotlinFunctionInGenericClass/renameKotlinFunctionInGenericClass.test");
+    }
+
+    @TestMetadata("renameKotlinFunctionInGenericClass/renameKotlinFunctionInGenericClassFromSubclass.test")
+    public void testRenameKotlinFunctionInGenericClass_RenameKotlinFunctionInGenericClassFromSubclass() throws Exception {
+        runTest("idea/testData/refactoring/rename/renameKotlinFunctionInGenericClass/renameKotlinFunctionInGenericClassFromSubclass.test");
+    }
+
     @TestMetadata("renameKotlinFunctionParameterWithByNameUsages/renameKotlinFunctionParameterWithByNameUsages.test")
     public void testRenameKotlinFunctionParameterWithByNameUsages_RenameKotlinFunctionParameterWithByNameUsages() throws Exception {
         runTest("idea/testData/refactoring/rename/renameKotlinFunctionParameterWithByNameUsages/renameKotlinFunctionParameterWithByNameUsages.test");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-26047