### PR TITLE
KT-24352 Method separators: displayed between properties, not displayed between companion object and function

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/highlighter/markers/KotlinLineMarkerProvider.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/highlighter/markers/KotlinLineMarkerProvider.kt
@@ -69,7 +69,10 @@ class KotlinLineMarkerProvider : LineMarkerProviderDescriptor() {
     }
 
     private fun PsiElement?.canHaveSeparator() =
-        this is KtFunction || this is KtClassInitializer || (this is KtProperty && !isLocal)
+        this is KtFunction
+                || this is KtClassInitializer
+                || (this is KtProperty && !isLocal)
+                || ((this is KtObjectDeclaration && this.isCompanion()))
 
     private fun PsiElement.wantsSeparator() = this is KtFunction || StringUtil.getLineBreakCount(text) > 0
 

--- a/idea/testData/codeInsight/lineMarker/MethodSeparators.kt
+++ b/idea/testData/codeInsight/lineMarker/MethodSeparators.kt
@@ -39,4 +39,8 @@ class Foo {
     <lineMarker descr="null">fun</lineMarker> f1() = 1
 
     <lineMarker descr="null">fun</lineMarker> f2() = 2
+
+    <lineMarker descr="null">companion</lineMarker> object {
+        const val C = 1
+    }
 }


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-24352