### PR TITLE
JVM IR: Generate public SAM wrappers in inline function scope

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
@@ -207,9 +207,9 @@ private val jvmFilePhases =
         singletonReferencesPhase then
 
         callableReferencePhase then
+        singleAbstractMethodPhase then
         localDeclarationsPhase then
 
-        singleAbstractMethodPhase then
         addContinuationPhase then
 
         jvmOverloadsAnnotationPhase then

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/SingleAbstractMethodLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/SingleAbstractMethodLowering.kt
@@ -92,7 +92,7 @@ class SingleAbstractMethodLowering(val context: CommonBackendContext) : FileLowe
                     val instance = irCall(implementation.constructors.single()).apply {
                         putValueArgument(0, irGet(invokableVariable))
                     }
-                    irIfNull(superType, irGet(invokableVariable), irNull(), instance)
+                    +irIfNull(superType, irGet(invokableVariable), irNull(), instance)
                 }
             } else {
                 irCall(implementation.constructors.single()).apply { putValueArgument(0, invokable) }

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/SingleAbstractMethodLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/SingleAbstractMethodLowering.kt
@@ -14,14 +14,19 @@ import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.common.lower.irBlock
 import org.jetbrains.kotlin.backend.common.phaser.makeIrFilePhase
 import org.jetbrains.kotlin.backend.jvm.JvmLoweredDeclarationOrigin
-import org.jetbrains.kotlin.backend.jvm.localDeclarationsPhase
-import org.jetbrains.kotlin.codegen.SamWrapperCodegen
+import org.jetbrains.kotlin.backend.jvm.ir.erasedUpperBound
+import org.jetbrains.kotlin.codegen.SamWrapperCodegen.FUNCTION_FIELD_NAME
+import org.jetbrains.kotlin.codegen.SamWrapperCodegen.SAM_WRAPPER_SUFFIX
 import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.Visibilities
+import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.builders.declarations.*
-import org.jetbrains.kotlin.ir.declarations.*
+import org.jetbrains.kotlin.ir.declarations.IrClass
+import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
+import org.jetbrains.kotlin.ir.declarations.IrFile
+import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrTypeOperator
 import org.jetbrains.kotlin.ir.expressions.IrTypeOperatorCall
@@ -29,61 +34,82 @@ import org.jetbrains.kotlin.ir.expressions.impl.IrInstanceInitializerCallImpl
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.classifierOrFail
 import org.jetbrains.kotlin.ir.types.isNullable
-import org.jetbrains.kotlin.ir.util.constructors
-import org.jetbrains.kotlin.ir.util.fqNameWhenAvailable
-import org.jetbrains.kotlin.ir.util.functions
-import org.jetbrains.kotlin.ir.util.isNullConst
+import org.jetbrains.kotlin.ir.types.makeNullable
+import org.jetbrains.kotlin.ir.util.*
+import org.jetbrains.kotlin.load.java.JavaVisibilities
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.util.OperatorNameConventions
 
 internal val singleAbstractMethodPhase = makeIrFilePhase(
     ::SingleAbstractMethodLowering,
     name = "SingleAbstractMethod",
-    description = "Replace SAM conversions with instances of interface-implementing classes",
-    prerequisite = setOf(localDeclarationsPhase)
+    description = "Replace SAM conversions with instances of interface-implementing classes"
 )
 
 class SingleAbstractMethodLowering(val context: CommonBackendContext) : FileLoweringPass, IrElementTransformerVoidWithContext() {
+    // SAM wrappers are cached, either in the file class (if it exists), or in a top-level enclosing class.
+    // In the latter case, the names of SAM wrappers depend on the order of classes in the file. For example:
+    //
+    //    class A {
+    //      fun f(run: () -> Unit) = Runnable(run)
+    //    }
+    //
+    //    class B {
+    //      fun g(run: () -> Unit) = Runnable(run)
+    //      fun h(p: (String) -> Boolean) = Predicate(p)
+    //    }
+    //
+    // This code creates two SAM wrappers, `A$sam$java_lang_Runnable$0`, which is used in both
+    // `A.f` and `B.g`, as well as `B$sam$java_util_function_Predicate$0`, which is used in `B.h`.
+    //
+    // Additionally, we need to cache SAM wrappers inside inline functions separately from those
+    // outside of inline functions. Outside of inline functions we generate package private wrappers
+    // with name prefix "sam$". In the scope of an inline function we generate public wrappers with
+    // name prefix "sam$i$".
+    //
+    // Coming from the frontend, every SAM interface is associated with exactly one function type
+    // (see SamType.getKotlinFunctionType). This is why we can cache implementations just based on
+    // the superType.
     private val cachedImplementations = mutableMapOf<IrType, IrClass>()
+    private val inlineCachedImplementations = mutableMapOf<IrType, IrClass>()
     private var enclosingClass: IrClass? = null
 
-    // SAM wrappers are cached, either in the file class (if it exists), or in the top-level enclosing class.
-    private inline fun <R> withCacheFor(irClass: IrClass?, block: () -> R): R {
-        enclosingClass = enclosingClass ?: irClass
-        val result = block()
-        if (irClass != null && enclosingClass === irClass) {
-            cachedImplementations.values.mapTo(irClass.declarations) {
-                it.parent = irClass
-                it
-            }
-            cachedImplementations.clear()
-        }
-        return result
-    }
-
     override fun lower(irFile: IrFile) {
-        val fileClass = irFile.declarations.filterIsInstance<IrClass>().find { it.origin == IrDeclarationOrigin.FILE_CLASS }
-        withCacheFor(fileClass) { irFile.transformChildrenVoid() }
+        enclosingClass = irFile.declarations.filterIsInstance<IrClass>().find { it.origin == IrDeclarationOrigin.FILE_CLASS }
+        irFile.transformChildrenVoid()
+
+        for (wrapper in cachedImplementations.values + inlineCachedImplementations.values) {
+            val parentClass = wrapper.parent as IrClass
+            parentClass.declarations += wrapper
+        }
     }
 
-    override fun visitClassNew(declaration: IrClass) =
-        withCacheFor(declaration) { super.visitClassNew(declaration) }
+    override fun visitClassNew(declaration: IrClass): IrStatement {
+        enclosingClass = enclosingClass ?: declaration
+        super.visitClassNew(declaration)
+        if (enclosingClass == declaration)
+            enclosingClass = null
+        return declaration
+    }
 
     override fun visitTypeOperator(expression: IrTypeOperatorCall): IrExpression {
         if (expression.operator != IrTypeOperator.SAM_CONVERSION)
             return super.visitTypeOperator(expression)
-        val superType = expression.typeOperand
+        // TODO: We have to erase type parameters here, since we cache SAM wrappers based on the erased
+        //       underlying representation. We should do the same for the underlying function type, otherwise
+        //       we end up with wrong generic information.
+        val erasedSuperType = expression.typeOperand.erasedUpperBound.defaultType
+        val superType = if (expression.typeOperand.isNullable()) erasedSuperType.makeNullable() else erasedSuperType
         val invokable = expression.argument.transform(this, null)
         context.createIrBuilder(currentScope!!.scope.scopeOwnerSymbol).apply {
             // Do not generate a wrapper class for null, it has no invoke() anyway.
             if (invokable.isNullConst())
                 return invokable
 
-            // Coming from the frontend, every SAM interface is associated with exactly one function type
-            // (see SamType.getKotlinFunctionType). That's why we can cache implementations just based on
-            // the superType. Type parameters should have been erased before we get here.
-            val implementation = cachedImplementations.getOrPut(superType) {
-                createObjectProxy(superType, invokable.type)
+            val inInlineFunctionScope = allScopes.any { scope -> (scope.irElement as? IrFunction)?.isInline ?: false }
+            val cache = if (inInlineFunctionScope) inlineCachedImplementations else cachedImplementations
+            val implementation = cache.getOrPut(superType) {
+                createObjectProxy(superType, invokable.type, inInlineFunctionScope)
             }
 
             return if (superType.isNullable() && invokable.type.isNullable()) {
@@ -102,28 +128,29 @@ class SingleAbstractMethodLowering(val context: CommonBackendContext) : FileLowe
 
     // Construct a class that wraps an invokable object into an implementation of an interface:
     //     class sam$n(private val invokable: F) : Interface { override fun method(...) = invokable(...) }
-    private fun createObjectProxy(superType: IrType, invokableType: IrType): IrClass {
+    private fun createObjectProxy(superType: IrType, invokableType: IrType, generatePublicWrapper: Boolean): IrClass {
         val superClass = superType.classifierOrFail.owner as IrClass
         // The language documentation prohibits casting lambdas to classes, but if it was allowed,
         // the `irDelegatingConstructorCall` in the constructor below would need to be modified.
         assert(superClass.kind == ClassKind.INTERFACE) { "SAM conversion to an abstract class not allowed" }
 
-        // TODO: In the scope of an inline function, we need to generate a *public* sam wrapper with a name of the form
-        //       sam$i$superClassFqName$0 (note the additiona $i compared to the name below)
         val superFqName = superClass.fqNameWhenAvailable!!.asString().replace('.', '_')
-        val wrapperName = Name.identifier("sam\$$superFqName${SamWrapperCodegen.SAM_WRAPPER_SUFFIX}")
+        val inlinePrefix = if (generatePublicWrapper) "\$i" else ""
+        val wrapperName = Name.identifier("sam$inlinePrefix\$$superFqName$SAM_WRAPPER_SUFFIX")
 
+        val wrapperVisibility = if (generatePublicWrapper) Visibilities.PUBLIC else JavaVisibilities.PACKAGE_VISIBILITY
         val subclass = buildClass {
             name = wrapperName
             origin = JvmLoweredDeclarationOrigin.GENERATED_SAM_IMPLEMENTATION
+            visibility = wrapperVisibility
         }.apply {
             createImplicitParameterDeclarationWithWrappedDescriptor()
-            // TODO convert all type parameters to upper bounds? See the kt11696 test.
             superTypes += superType
+            parent = enclosingClass!!
         }
 
         val field = subclass.addField {
-            name = Name.identifier(SamWrapperCodegen.FUNCTION_FIELD_NAME)
+            name = Name.identifier(FUNCTION_FIELD_NAME)
             type = invokableType
             origin = subclass.origin
             visibility = Visibilities.PRIVATE
@@ -132,6 +159,7 @@ class SingleAbstractMethodLowering(val context: CommonBackendContext) : FileLowe
         subclass.addConstructor {
             origin = subclass.origin
             isPrimary = true
+            visibility = wrapperVisibility
         }.apply {
             val parameter = addValueParameter {
                 name = field.name

--- a/compiler/testData/codegen/box/sam/inlinedSamWrapper.kt
+++ b/compiler/testData/codegen/box/sam/inlinedSamWrapper.kt
@@ -1,0 +1,76 @@
+// TARGET_BACKEND: JVM
+// WITH_RUNTIME
+// FILE: MyRunnable.java
+public interface MyRunnable {
+    public void run();
+}
+
+// FILE: Foo.kt
+package foo
+import MyRunnable
+
+class A {
+    inline fun doWork(noinline job: () -> Unit) {
+        Runnable(job).run()
+    }
+
+    fun doNoninlineWork(job: () -> Unit) {
+        Runnable(job).run()
+    }
+}
+
+class B {
+    inline fun doWork(noinline job: () -> Unit) {
+        Runnable(job).run()
+    }
+
+    fun doNonInlineWork(job: () -> Unit) {
+        MyRunnable(job).run()
+    }
+}
+
+// FILE: test.kt
+import foo.A
+import foo.B
+
+fun classForName(name: String): Class<*>? =
+    try {
+        java.lang.Class.forName(name)
+    } catch (e: Throwable) {
+        null
+    }
+
+fun box(): String {
+    var result = false
+    A().doWork { result = true }
+    if (!result) return "Fail 1"
+
+    result = false
+    A().doNoninlineWork { result = true }
+    if (!result) return "Fail 2"
+
+    result = false
+    B().doWork { result = true }
+    if (!result) return "Fail 3"
+
+    result = false
+    B().doNonInlineWork { result = true }
+    if (!result) return "Fail 4"
+
+    val inlineWrapperA = classForName("foo.A\$sam\$i\$java_lang_Runnable$0")
+    if (inlineWrapperA == null) return "Fail 5: Can't find sam wrapper"
+    if (inlineWrapperA.modifiers and 1 == 0) return "Fail 6: inline sam wrapper is non-public"
+
+    val wrapperA = classForName("foo.A\$sam\$java_lang_Runnable$0")
+    if (wrapperA == null) return "Fail 7: Can't find sam wrapper"
+    if (wrapperA.modifiers and 1 != 0) return "Fail 8: non-inline sam wrapper is public"
+
+    val inlineWrapperB = classForName("foo.B\$sam\$i\$java_lang_Runnable$0")
+    if (inlineWrapperB != null) return "Fail 9: sam wrapper not cached"
+
+    val wrapperB = classForName("foo.B\$sam\$MyRunnable$0")
+    if (wrapperB == null) return "Fail 10: Can't find sam wrapper"
+    if (wrapperB.modifiers and 1 != 0) return "Fail 11: non-inline sam wrapper is public"
+
+    return "OK"
+}

--- a/compiler/testData/codegen/box/sam/nullableSam.kt
+++ b/compiler/testData/codegen/box/sam/nullableSam.kt
@@ -1,0 +1,26 @@
+// TARGET_BACKEND: JVM
+// WITH_RUNTIME
+
+// FILE: Test.java
+
+public class Test {
+    public static boolean isNull(Runnable r) {
+        if (r == null)
+            return true;
+        r.run();
+        return false;
+    }
+}
+
+// FILE: test.kt
+
+fun nullableFun(fromNull: Boolean): (() -> Unit)? =
+    if (fromNull) null else {{}}
+
+fun box(): String {
+    if (!Test.isNull(nullableFun(true))) return "Fail 1"
+    if (Test.isNull(nullableFun(false))) return "Fail 2"
+    if (!Test.isNull(null)) return "Fail 3"
+    if (Test.isNull {}) return "Fail 4"
+    return "OK"
+}

--- a/compiler/testData/codegen/box/sam/predicateSamWrapper.kt
+++ b/compiler/testData/codegen/box/sam/predicateSamWrapper.kt
@@ -1,0 +1,38 @@
+// TARGET_BACKEND: JVM
+// WITH_RUNTIME
+// FULL_JDK
+// FILE: test.kt
+// Test that SAM wrappers with type parameters are cached properly.
+class A {
+    fun stringPredicate(string: String, p: (String) -> Boolean): Boolean {
+        return java.util.function.Predicate<String>(p).test(string)
+    }
+
+    fun intPredicate(int: Int, p: (Int) -> Boolean): Boolean {
+        return java.util.function.Predicate<Int>(p).test(int)
+    }
+}
+
+fun wrapStringPredicate(p: (String) -> Boolean): java.util.function.Predicate<String> =
+    java.util.function.Predicate<String>(p)
+
+fun wrapIntPredicate(p: (Int) -> Boolean): java.util.function.Predicate<Int> =
+    java.util.function.Predicate<Int>(p)
+
+fun box(): String {
+    if (!A().stringPredicate("OK") { it == "OK"}) return "Fail 1"
+    if (!A().intPredicate(0) { it == 0 }) return "Fail 2"
+
+    try {
+        java.lang.Class.forName("TestKt\$sam\$java_util_function_Predicate$0")
+    } catch (e: Throwable) {
+        return "Fail 3: sam wrapper not found"
+    }
+
+    val stringPredicateWrapperClass = wrapStringPredicate { true }::class.java
+    val intPredicateWrapperClass = wrapIntPredicate { false }::class.java
+    if (stringPredicateWrapperClass !== intPredicateWrapperClass)
+        return "Fail 4: sam wrapper not cached"
+
+    return "OK"
+}

--- a/compiler/testData/codegen/bytecodeText/sam/samWrapperForNullableInitialization.kt
+++ b/compiler/testData/codegen/bytecodeText/sam/samWrapperForNullableInitialization.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 // FILE: JFoo.java
 
 import org.jetbrains.annotations.Nullable;
@@ -17,8 +16,16 @@ fun test() {
     JFoo.foo2({}, runnable())
 }
 
-// @TestKt.class:
 // 2 NEW
+
+// JVM_TEMPLATES
+// @TestKt.class:
 // 0 IFNONNULL
 // 1 IFNULL
 // 1 ACONST_NULL
+
+// JVM_IR_TEMPLATES
+// @TestKt.class
+// 1 IFNONNULL
+// 0 IFNULL
+// 2 ACONST_NULL

--- a/compiler/testData/compileKotlinAgainstKotlin/copySamOnInline2.kt
+++ b/compiler/testData/compileKotlinAgainstKotlin/copySamOnInline2.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 // FILE: A.kt
 // FULL_JDK
 

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -23690,6 +23690,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             runTest("compiler/testData/codegen/box/sam/castFromAny.kt");
         }
 
+        @TestMetadata("inlinedSamWrapper.kt")
+        public void testInlinedSamWrapper() throws Exception {
+            runTest("compiler/testData/codegen/box/sam/inlinedSamWrapper.kt");
+        }
+
         @TestMetadata("kt17091.kt")
         public void testKt17091() throws Exception {
             runTest("compiler/testData/codegen/box/sam/kt17091.kt");
@@ -23725,6 +23730,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             runTest("compiler/testData/codegen/box/sam/kt24825.kt");
         }
 
+        @TestMetadata("nullableSam.kt")
+        public void testNullableSam() throws Exception {
+            runTest("compiler/testData/codegen/box/sam/nullableSam.kt");
+        }
+
         @TestMetadata("partialSam.kt")
         public void testPartialSam() throws Exception {
             runTest("compiler/testData/codegen/box/sam/partialSam.kt");
@@ -23733,6 +23743,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
         @TestMetadata("partialSamKT.kt")
         public void testPartialSamKT() throws Exception {
             runTest("compiler/testData/codegen/box/sam/partialSamKT.kt");
+        }
+
+        @TestMetadata("predicateSamWrapper.kt")
+        public void testPredicateSamWrapper() throws Exception {
+            runTest("compiler/testData/codegen/box/sam/predicateSamWrapper.kt");
         }
 
         @TestMetadata("receiverEvaluatedOnce.kt")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -23690,6 +23690,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/sam/castFromAny.kt");
         }
 
+        @TestMetadata("inlinedSamWrapper.kt")
+        public void testInlinedSamWrapper() throws Exception {
+            runTest("compiler/testData/codegen/box/sam/inlinedSamWrapper.kt");
+        }
+
         @TestMetadata("kt17091.kt")
         public void testKt17091() throws Exception {
             runTest("compiler/testData/codegen/box/sam/kt17091.kt");
@@ -23725,6 +23730,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/sam/kt24825.kt");
         }
 
+        @TestMetadata("nullableSam.kt")
+        public void testNullableSam() throws Exception {
+            runTest("compiler/testData/codegen/box/sam/nullableSam.kt");
+        }
+
         @TestMetadata("partialSam.kt")
         public void testPartialSam() throws Exception {
             runTest("compiler/testData/codegen/box/sam/partialSam.kt");
@@ -23733,6 +23743,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
         @TestMetadata("partialSamKT.kt")
         public void testPartialSamKT() throws Exception {
             runTest("compiler/testData/codegen/box/sam/partialSamKT.kt");
+        }
+
+        @TestMetadata("predicateSamWrapper.kt")
+        public void testPredicateSamWrapper() throws Exception {
+            runTest("compiler/testData/codegen/box/sam/predicateSamWrapper.kt");
         }
 
         @TestMetadata("receiverEvaluatedOnce.kt")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -22590,6 +22590,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             runTest("compiler/testData/codegen/box/sam/castFromAny.kt");
         }
 
+        @TestMetadata("inlinedSamWrapper.kt")
+        public void testInlinedSamWrapper() throws Exception {
+            runTest("compiler/testData/codegen/box/sam/inlinedSamWrapper.kt");
+        }
+
         @TestMetadata("kt17091.kt")
         public void testKt17091() throws Exception {
             runTest("compiler/testData/codegen/box/sam/kt17091.kt");
@@ -22625,6 +22630,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             runTest("compiler/testData/codegen/box/sam/kt24825.kt");
         }
 
+        @TestMetadata("nullableSam.kt")
+        public void testNullableSam() throws Exception {
+            runTest("compiler/testData/codegen/box/sam/nullableSam.kt");
+        }
+
         @TestMetadata("partialSam.kt")
         public void testPartialSam() throws Exception {
             runTest("compiler/testData/codegen/box/sam/partialSam.kt");
@@ -22633,6 +22643,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         @TestMetadata("partialSamKT.kt")
         public void testPartialSamKT() throws Exception {
             runTest("compiler/testData/codegen/box/sam/partialSamKT.kt");
+        }
+
+        @TestMetadata("predicateSamWrapper.kt")
+        public void testPredicateSamWrapper() throws Exception {
+            runTest("compiler/testData/codegen/box/sam/predicateSamWrapper.kt");
         }
 
         @TestMetadata("receiverEvaluatedOnce.kt")


### PR DESCRIPTION
This PR fixes the visibility of generated SAM wrappers (public inside the scope of an inline function and package private otherwise) and makes the caching scheme match the current backend.

There is still some work left to do in order to make `singleAbstractMethodPhase` produce correct IR types, but at least the generated code is correct.