### PR TITLE
KT-31999 "Variable declaration could be moved into `when`" inspection suggests to inline expression containing return (throw) statement

### DIFF
--- a/idea/testData/inspectionsLocal/moveVariableDeclarationIntoWhen/hasBreak.kt
+++ b/idea/testData/inspectionsLocal/moveVariableDeclarationIntoWhen/hasBreak.kt
@@ -1,0 +1,12 @@
+// PROBLEM: none
+fun test() {
+    for (i in 1..10) {
+        val <caret>some = foo(i) ?: break
+        when (some) {
+            "some" -> some
+            else -> ""
+        }
+    }
+}
+
+fun foo(i: Int): String? = ""

--- a/idea/testData/inspectionsLocal/moveVariableDeclarationIntoWhen/hasContinue.kt
+++ b/idea/testData/inspectionsLocal/moveVariableDeclarationIntoWhen/hasContinue.kt
@@ -1,0 +1,12 @@
+// PROBLEM: none
+fun test() {
+    for (i in 1..10) {
+        val <caret>some = foo(i) ?: continue
+        when (some) {
+            "some" -> some
+            else -> ""
+        }
+    }
+}
+
+fun foo(i: Int): String? = ""

--- a/idea/testData/inspectionsLocal/moveVariableDeclarationIntoWhen/hasReturn.kt
+++ b/idea/testData/inspectionsLocal/moveVariableDeclarationIntoWhen/hasReturn.kt
@@ -1,0 +1,8 @@
+// PROBLEM: none
+fun test(str: String?): String? {
+    val <caret>some = str ?: return null
+    return when (some) {
+        "some" -> some
+        else -> ""
+    }
+}

--- a/idea/testData/inspectionsLocal/moveVariableDeclarationIntoWhen/hasReturn2.kt
+++ b/idea/testData/inspectionsLocal/moveVariableDeclarationIntoWhen/hasReturn2.kt
@@ -1,0 +1,8 @@
+// PROBLEM: none
+fun test(str: String?): String? {
+    val <caret>some = if (str != null) str + str else return null
+    return when (some) {
+        "some" -> some
+        else -> ""
+    }
+}

--- a/idea/testData/inspectionsLocal/moveVariableDeclarationIntoWhen/hasThrow.kt
+++ b/idea/testData/inspectionsLocal/moveVariableDeclarationIntoWhen/hasThrow.kt
@@ -1,0 +1,8 @@
+// PROBLEM: none
+fun test(str: String?): String? {
+    val <caret>some = str ?: throw Exception()
+    return when (some) {
+        "some" -> some
+        else -> ""
+    }
+}

--- a/idea/testData/inspectionsLocal/moveVariableDeclarationIntoWhen/hasThrow2.kt
+++ b/idea/testData/inspectionsLocal/moveVariableDeclarationIntoWhen/hasThrow2.kt
@@ -1,0 +1,8 @@
+// PROBLEM: none
+fun test(str: String?): String? {
+    val <caret>some = if (str != null) str + str else throw Exception()
+    return when (some) {
+        "some" -> some
+        else -> ""
+    }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -6093,6 +6093,16 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
             KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/inspectionsLocal/moveVariableDeclarationIntoWhen"), Pattern.compile("^([\\w\\-_]+)\\.(kt|kts)$"), TargetBackend.ANY, true);
         }
 
+        @TestMetadata("hasBreak.kt")
+        public void testHasBreak() throws Exception {
+            runTest("idea/testData/inspectionsLocal/moveVariableDeclarationIntoWhen/hasBreak.kt");
+        }
+
+        @TestMetadata("hasContinue.kt")
+        public void testHasContinue() throws Exception {
+            runTest("idea/testData/inspectionsLocal/moveVariableDeclarationIntoWhen/hasContinue.kt");
+        }
+
         @TestMetadata("hasReturn.kt")
         public void testHasReturn() throws Exception {
             runTest("idea/testData/inspectionsLocal/moveVariableDeclarationIntoWhen/hasReturn.kt");

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -6093,6 +6093,26 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
             KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/inspectionsLocal/moveVariableDeclarationIntoWhen"), Pattern.compile("^([\\w\\-_]+)\\.(kt|kts)$"), TargetBackend.ANY, true);
         }
 
+        @TestMetadata("hasReturn.kt")
+        public void testHasReturn() throws Exception {
+            runTest("idea/testData/inspectionsLocal/moveVariableDeclarationIntoWhen/hasReturn.kt");
+        }
+
+        @TestMetadata("hasReturn2.kt")
+        public void testHasReturn2() throws Exception {
+            runTest("idea/testData/inspectionsLocal/moveVariableDeclarationIntoWhen/hasReturn2.kt");
+        }
+
+        @TestMetadata("hasThrow.kt")
+        public void testHasThrow() throws Exception {
+            runTest("idea/testData/inspectionsLocal/moveVariableDeclarationIntoWhen/hasThrow.kt");
+        }
+
+        @TestMetadata("hasThrow2.kt")
+        public void testHasThrow2() throws Exception {
+            runTest("idea/testData/inspectionsLocal/moveVariableDeclarationIntoWhen/hasThrow2.kt");
+        }
+
         @TestMetadata("inBinaryExpression.kt")
         public void testInBinaryExpression() throws Exception {
             runTest("idea/testData/inspectionsLocal/moveVariableDeclarationIntoWhen/inBinaryExpression.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-31999