### PR TITLE
JVM IR: Cache inline class replacements at the module level

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendContext.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendContext.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.backend.jvm.descriptors.JvmDeclarationFactory
 import org.jetbrains.kotlin.backend.jvm.descriptors.JvmSharedVariablesManager
 import org.jetbrains.kotlin.backend.jvm.intrinsics.IrIntrinsicMethods
 import org.jetbrains.kotlin.backend.jvm.lower.inlineclasses.InlineClassAbi
+import org.jetbrains.kotlin.backend.jvm.lower.inlineclasses.MemoizedInlineClassReplacements
 import org.jetbrains.kotlin.codegen.ClassBuilder
 import org.jetbrains.kotlin.codegen.state.GenerationState
 import org.jetbrains.kotlin.descriptors.ClassConstructorDescriptor
@@ -86,6 +87,8 @@ class JvmBackendContext(
     val suspendFunctionViews = mutableMapOf<IrFunction, IrFunction>()
 
     val staticDefaultStubs = mutableMapOf<IrFunctionSymbol, IrFunction>()
+
+    val inlineClassReplacements = MemoizedInlineClassReplacements()
 
     internal fun getTopLevelClass(fqName: FqName): IrClassSymbol {
         val descriptor = state.module.getPackage(fqName.parent()).memberScope.getContributedClassifier(

--- a/compiler/testData/codegen/boxInline/inlineClasses/inlineFunctionInsideInlineClassesBox.kt
+++ b/compiler/testData/codegen/boxInline/inlineClasses/inlineFunctionInsideInlineClassesBox.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: +InlineClasses
-// IGNORE_BACKEND: JVM_IR
 
 // FILE: 1.kt
 


### PR DESCRIPTION
Currently, we are caching inline class replacements at the file level, which breaks when you have an inline function taking inline class arguments defined in a different file in the same module. This PR just moves the cache to the backend context, effectively caching at the level of modules instead.