### PR TITLE
Minor: Fix some test cases

### DIFF
--- a/compiler/testData/codegen/bytecodeText/deadCodeElimination/boxing.kt
+++ b/compiler/testData/codegen/bytecodeText/deadCodeElimination/boxing.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 class A
 
 fun foo(x: Any?) {}
@@ -11,13 +10,19 @@ fun box() {
     z!!
 
     foo(1 as java.lang.Integer)
-    
+
     val y: Any? = if (1 == 1) x else A()
     y!!
 }
 
 // 0 IFNULL
+// 0 checkNotNull
+// 0 ATHROW
+
+// JVM_TEMPLATES:
 // 1 IFNONNULL
 // 1 throwNpe
-// 0 ATHROW
-// 0 checkNotNull
+
+// JVM_IR_TEMPLATES:
+// 0 IFNONULL
+// 0 throwNpe

--- a/compiler/testData/codegen/bytecodeText/deadCodeElimination/simpleConstructorNotRedundant.kt
+++ b/compiler/testData/codegen/bytecodeText/deadCodeElimination/simpleConstructorNotRedundant.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 class A
 fun box() {
     val x: A? = A()
@@ -9,12 +8,17 @@ fun box() {
     else {
         y = null
     }
-    
+
     y!!
 }
 
 // 0 IFNULL
-// 1 IFNONNULL
-// 1 throwNpe
 // 0 ATHROW
 // 0 checkNotNull
+// 1 throwNpe
+
+// JVM_TEMPLATES:
+// 1 IFNONNULL
+
+// JVM_IR_TEMPLATES:
+// 0 IFNONNULL

--- a/compiler/testData/codegen/bytecodeText/stringOperations/primitiveToString.kt
+++ b/compiler/testData/codegen/bytecodeText/stringOperations/primitiveToString.kt
@@ -1,15 +1,16 @@
-// IGNORE_BACKEND: JVM_IR
-fun main() {
-    false.toString()
-    1.toByte().toString()
-    1.toShort().toString()
-    1.toString()
-    1L.toString()
-    1.0F.toString()
-    1.0.toString()
-    'c'.toString()
-}
+fun boolConst() = false.toString()
+fun byteConst() = 1.toByte().toString()
+fun shortConst() = 1.toShort().toString()
+fun intConst() = 1.toString()
+fun longConst() = 1L.toString()
+fun floatConst() = 1.0F.toString()
+fun doubleConst() = 1.0.toString()
+fun charConst() = 'c'.toString()
 
 /*Check that all "valueOf" are String ones and there is no boxing*/
+// JVM_TEMPLATES:
 // 8 valueOf
 // 8 INVOKESTATIC java/lang/String.valueOf
+// JVM_IR_TEMPLATES:
+// 0 valueOf
+// 8 LDC \"


### PR DESCRIPTION
As part of #2111, @ting-yuan muted some bytecode text tests for the JVM_IR backend which were optimized away. At the time, the problem was that we were also removing line numbers, and the tests remained so that we would know to come back to this issue again.

Well, turns out that this was fixed at some point (probably before the PR got merged), but the superfluous tests never got removed.