### PR TITLE
KT-25697 `Replace with dot call` quickfix breaks formatting

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/ReplaceCallFix.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/ReplaceCallFix.kt
@@ -30,9 +30,9 @@ import org.jetbrains.kotlin.resolve.calls.resolvedCallUtil.getImplicitReceiverVa
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameUnsafe
 
 abstract class ReplaceCallFix(
-        expression: KtQualifiedExpression,
-        private val operation: String,
-        private val notNullNeeded: Boolean = false
+    expression: KtQualifiedExpression,
+    private val operation: String,
+    private val notNullNeeded: Boolean = false
 ) : KotlinQuickFixAction<KtQualifiedExpression>(expression) {
 
     override fun getFamilyName() = text
@@ -45,8 +45,10 @@ abstract class ReplaceCallFix(
     override fun invoke(project: Project, editor: Editor?, file: KtFile) {
         val element = element ?: return
         val elvis = elvisOrEmpty(notNullNeeded)
-        val newExpression = KtPsiFactory(element).createExpressionByPattern("$0$operation$1$elvis",
-                                                                            element.receiverExpression, element.selectorExpression!!)
+        val newExpression = KtPsiFactory(element).createExpressionByPattern(
+            "$0$operation$1$elvis",
+            element.receiverExpression, element.selectorExpression!!
+        )
         val replacement = element.replace(newExpression)
         if (notNullNeeded) {
             replacement.moveCaretToEnd(editor, project)
@@ -55,8 +57,8 @@ abstract class ReplaceCallFix(
 }
 
 class ReplaceImplicitReceiverCallFix(
-        expression: KtExpression,
-        private val notNullNeeded: Boolean
+    expression: KtExpression,
+    private val notNullNeeded: Boolean
 ) : KotlinQuickFixAction<KtExpression>(expression) {
     override fun getFamilyName() = text
 
@@ -74,8 +76,8 @@ class ReplaceImplicitReceiverCallFix(
 }
 
 class ReplaceWithSafeCallFix(
-        expression: KtDotQualifiedExpression,
-        notNullNeeded: Boolean
+    expression: KtDotQualifiedExpression,
+    notNullNeeded: Boolean
 ) : ReplaceCallFix(expression, "?.", notNullNeeded) {
 
     override fun getText() = "Replace with safe (?.) call"
@@ -86,8 +88,7 @@ class ReplaceWithSafeCallFix(
             val qualifiedExpression = psiElement.parent as? KtDotQualifiedExpression
             if (qualifiedExpression != null) {
                 return ReplaceWithSafeCallFix(qualifiedExpression, qualifiedExpression.shouldHaveNotNullType())
-            }
-            else {
+            } else {
                 if (psiElement !is KtNameReferenceExpression) return null
                 if (psiElement.getResolvedCall(psiElement.analyze())?.getImplicitReceiverValue() != null) {
                     val expressionToReplace: KtExpression = psiElement.parent as? KtCallExpression ?: psiElement
@@ -100,8 +101,8 @@ class ReplaceWithSafeCallFix(
 }
 
 class ReplaceWithSafeCallForScopeFunctionFix(
-        expression: KtDotQualifiedExpression,
-        notNullNeeded: Boolean
+    expression: KtDotQualifiedExpression,
+    notNullNeeded: Boolean
 ) : ReplaceCallFix(expression, "?.", notNullNeeded) {
 
     override fun getText() = "Replace scope function with safe (?.) call"
@@ -120,7 +121,7 @@ class ReplaceWithSafeCallForScopeFunctionFix(
             val internalReceiver = (element.parent as? KtDotQualifiedExpression)?.receiverExpression
             val internalReceiverDescriptor = internalReceiver.getResolvedCall(context)?.candidateDescriptor
             val internalResolvedCall = (element.getParentOfType<KtElement>(strict = false))?.getResolvedCall(context)
-                                       ?: return null
+                ?: return null
 
             when (scopeFunctionKind) {
                 ScopeFunctionKind.WITH_PARAMETER -> {
@@ -130,14 +131,16 @@ class ReplaceWithSafeCallForScopeFunctionFix(
                 }
                 ScopeFunctionKind.WITH_RECEIVER -> {
                     if (internalReceiverDescriptor != scopeFunctionLiteralDescriptor.extensionReceiverParameter &&
-                        internalResolvedCall.getImplicitReceiverValue() == null) {
+                        internalResolvedCall.getImplicitReceiverValue() == null
+                    ) {
                         return null
                     }
                 }
             }
 
             return ReplaceWithSafeCallForScopeFunctionFix(
-                    scopeDotQualifiedExpression, scopeDotQualifiedExpression.shouldHaveNotNullType())
+                scopeDotQualifiedExpression, scopeDotQualifiedExpression.shouldHaveNotNullType()
+            )
         }
 
         private fun KtCallExpression.scopeFunctionKind(context: BindingContext): ScopeFunctionKind? {

--- a/idea/testData/quickfix/replaceWithDotCall/comment.kt
+++ b/idea/testData/quickfix/replaceWithDotCall/comment.kt
@@ -1,0 +1,7 @@
+// "Replace with dot call" "true"
+// WITH_RUNTIME
+fun foo(a: String) {
+    val b = a // comment1
+            // comment2
+            ?.<caret>length
+}

--- a/idea/testData/quickfix/replaceWithDotCall/comment.kt.after
+++ b/idea/testData/quickfix/replaceWithDotCall/comment.kt.after
@@ -1,0 +1,7 @@
+// "Replace with dot call" "true"
+// WITH_RUNTIME
+fun foo(a: String) {
+    val b = a // comment1
+            // comment2
+            .length
+}

--- a/idea/testData/quickfix/replaceWithDotCall/lineBreak.kt
+++ b/idea/testData/quickfix/replaceWithDotCall/lineBreak.kt
@@ -1,0 +1,6 @@
+// "Replace with dot call" "true"
+// WITH_RUNTIME
+fun foo(a: String) {
+    val b = a
+            ?.<caret>length
+}

--- a/idea/testData/quickfix/replaceWithDotCall/lineBreak.kt.after
+++ b/idea/testData/quickfix/replaceWithDotCall/lineBreak.kt.after
@@ -1,0 +1,6 @@
+// "Replace with dot call" "true"
+// WITH_RUNTIME
+fun foo(a: String) {
+    val b = a
+            .length
+}

--- a/idea/testData/quickfix/replaceWithSafeCall/comment.kt
+++ b/idea/testData/quickfix/replaceWithSafeCall/comment.kt
@@ -1,0 +1,7 @@
+// "Replace with safe (?.) call" "true"
+// WITH_RUNTIME
+fun foo(a: String?) {
+    val b = a // comment1
+            // comment2
+            .<caret>length
+}

--- a/idea/testData/quickfix/replaceWithSafeCall/comment.kt.after
+++ b/idea/testData/quickfix/replaceWithSafeCall/comment.kt.after
@@ -1,0 +1,7 @@
+// "Replace with safe (?.) call" "true"
+// WITH_RUNTIME
+fun foo(a: String?) {
+    val b = a // comment1
+            // comment2
+            ?.length
+}

--- a/idea/testData/quickfix/replaceWithSafeCall/lineBreak.kt
+++ b/idea/testData/quickfix/replaceWithSafeCall/lineBreak.kt
@@ -1,0 +1,6 @@
+// "Replace with safe (?.) call" "true"
+// WITH_RUNTIME
+fun foo(a: String?) {
+    val b = a
+            .<caret>length
+}

--- a/idea/testData/quickfix/replaceWithSafeCall/lineBreak.kt.after
+++ b/idea/testData/quickfix/replaceWithSafeCall/lineBreak.kt.after
@@ -1,0 +1,6 @@
+// "Replace with safe (?.) call" "true"
+// WITH_RUNTIME
+fun foo(a: String?) {
+    val b = a
+            ?.length
+}

--- a/idea/testData/quickfix/replaceWithSafeCallForScopeFunction/comment.kt
+++ b/idea/testData/quickfix/replaceWithSafeCallForScopeFunction/comment.kt
@@ -1,0 +1,9 @@
+// "Replace scope function with safe (?.) call" "true"
+// WITH_RUNTIME
+fun foo(a: String?) {
+    val b = a // comment1
+            // comment2
+            .let {
+                it<caret>.length
+            }
+}

--- a/idea/testData/quickfix/replaceWithSafeCallForScopeFunction/comment.kt.after
+++ b/idea/testData/quickfix/replaceWithSafeCallForScopeFunction/comment.kt.after
@@ -1,0 +1,9 @@
+// "Replace scope function with safe (?.) call" "true"
+// WITH_RUNTIME
+fun foo(a: String?) {
+    val b = a // comment1
+            // comment2
+            ?.let {
+                it.length
+            }
+}

--- a/idea/testData/quickfix/replaceWithSafeCallForScopeFunction/lineBreak.kt
+++ b/idea/testData/quickfix/replaceWithSafeCallForScopeFunction/lineBreak.kt
@@ -1,0 +1,8 @@
+// "Replace scope function with safe (?.) call" "true"
+// WITH_RUNTIME
+fun foo(a: String?) {
+    val b = a
+            .let {
+                it<caret>.length
+            }
+}

--- a/idea/testData/quickfix/replaceWithSafeCallForScopeFunction/lineBreak.kt.after
+++ b/idea/testData/quickfix/replaceWithSafeCallForScopeFunction/lineBreak.kt.after
@@ -1,0 +1,8 @@
+// "Replace scope function with safe (?.) call" "true"
+// WITH_RUNTIME
+fun foo(a: String?) {
+    val b = a
+            ?.let {
+                it.length
+            }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -10828,9 +10828,19 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
             KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/quickfix/replaceWithDotCall"), Pattern.compile("^([\\w\\-_]+)\\.kt$"), TargetBackend.ANY, true);
         }
 
+        @TestMetadata("comment.kt")
+        public void testComment() throws Exception {
+            runTest("idea/testData/quickfix/replaceWithDotCall/comment.kt");
+        }
+
         @TestMetadata("functionCall.kt")
         public void testFunctionCall() throws Exception {
             runTest("idea/testData/quickfix/replaceWithDotCall/functionCall.kt");
+        }
+
+        @TestMetadata("lineBreak.kt")
+        public void testLineBreak() throws Exception {
+            runTest("idea/testData/quickfix/replaceWithDotCall/lineBreak.kt");
         }
 
         @TestMetadata("normal.kt")
@@ -10886,6 +10896,11 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
             runTest("idea/testData/quickfix/replaceWithSafeCall/assignmentToProperty.kt");
         }
 
+        @TestMetadata("comment.kt")
+        public void testComment() throws Exception {
+            runTest("idea/testData/quickfix/replaceWithSafeCall/comment.kt");
+        }
+
         @TestMetadata("expression.kt")
         public void testExpression() throws Exception {
             runTest("idea/testData/quickfix/replaceWithSafeCall/expression.kt");
@@ -10914,6 +10929,11 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
         @TestMetadata("letWithParameter.kt")
         public void testLetWithParameter() throws Exception {
             runTest("idea/testData/quickfix/replaceWithSafeCall/letWithParameter.kt");
+        }
+
+        @TestMetadata("lineBreak.kt")
+        public void testLineBreak() throws Exception {
+            runTest("idea/testData/quickfix/replaceWithSafeCall/lineBreak.kt");
         }
 
         @TestMetadata("noReplaceWithSafeCallForImplicitReceiver.kt")
@@ -10984,6 +11004,11 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
             runTest("idea/testData/quickfix/replaceWithSafeCallForScopeFunction/assignment.kt");
         }
 
+        @TestMetadata("comment.kt")
+        public void testComment() throws Exception {
+            runTest("idea/testData/quickfix/replaceWithSafeCallForScopeFunction/comment.kt");
+        }
+
         @TestMetadata("let.kt")
         public void testLet() throws Exception {
             runTest("idea/testData/quickfix/replaceWithSafeCallForScopeFunction/let.kt");
@@ -11002,6 +11027,11 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
         @TestMetadata("letWithWrongParam.kt")
         public void testLetWithWrongParam() throws Exception {
             runTest("idea/testData/quickfix/replaceWithSafeCallForScopeFunction/letWithWrongParam.kt");
+        }
+
+        @TestMetadata("lineBreak.kt")
+        public void testLineBreak() throws Exception {
+            runTest("idea/testData/quickfix/replaceWithSafeCallForScopeFunction/lineBreak.kt");
         }
 
         @TestMetadata("notInsideScope.kt")


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-25697