### PR TITLE
KT-33235 Remove "Replace guard clause with kotlin's function call" inspection and tranform it to J2K post-processing

### DIFF
--- a/idea/resources/META-INF/plugin-common.xml
+++ b/idea/resources/META-INF/plugin-common.xml
@@ -3443,7 +3443,7 @@
                      groupPath="Kotlin"
                      groupName="Style issues"
                      enabledByDefault="true"
-                     level="WEAK WARNING"
+                     level="INFORMATION"
                      language="kotlin"
     />
 


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-33235