### PR TITLE
Proposal API: Add scoping controls for parsing Km types

### DIFF
--- a/libraries/kotlinx-metadata/jvm/src/kotlinx/metadata/jvm/KotlinClassMetadata.kt
+++ b/libraries/kotlinx-metadata/jvm/src/kotlinx/metadata/jvm/KotlinClassMetadata.kt
@@ -35,18 +35,23 @@ sealed class KotlinClassMetadata(val header: KotlinClassHeader) {
 
         /**
          * Visits metadata of this class with a new [KmClass] instance and returns that instance.
+         *
+         * @param scope the scopes to visit.
          */
-        fun toKmClass(): KmClass =
-            KmClass().apply(this::accept)
+        fun toKmClass(scope: Scope.Class = Scope.Class.ALL): KmClass =
+            KmClass().apply {
+                accept(this, scope)
+            }
 
         /**
          * Makes the given visitor visit metadata of this class.
          *
          * @param v the visitor that must visit this class
+         * @param scope the scopes to visit.
          */
-        fun accept(v: KmClassVisitor) {
+        fun accept(v: KmClassVisitor, scope: Scope.Class = Scope.Class.ALL) {
             val (strings, proto) = classData
-            proto.accept(v, strings)
+            proto.accept(v, strings, scope)
         }
 
         /**

--- a/libraries/kotlinx-metadata/src/kotlinx/metadata/Scope.kt
+++ b/libraries/kotlinx-metadata/src/kotlinx/metadata/Scope.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package kotlinx.metadata
+
+/** Scopes for limiting what KmVisitors read. */
+object Scope {
+
+    /** Scopes for [KmDeclarationContainer]. */
+    open class DeclarationContainer internal constructor(
+        @JvmField val functions: Boolean,
+        @JvmField val properties: Boolean,
+        @JvmField val typeAliases: Boolean
+    ) {
+        companion object {
+            val ALL = DeclarationContainer(
+                functions = true,
+                properties = true,
+                typeAliases = true
+            )
+        }
+    }
+
+    /** Scopes for [KmClass]. */
+    class Class(
+        @JvmField val typeParameters: Boolean,
+        @JvmField val constructors: Boolean,
+        @JvmField val superTypes: Boolean,
+        @JvmField val companionObject: Boolean,
+        @JvmField val nestedClasses: Boolean,
+        @JvmField val enumEntries: Boolean,
+        @JvmField val sealedSubClasses: Boolean,
+        @JvmField val extensions: Boolean,
+        functions: Boolean,
+        properties: Boolean,
+        typeAliases: Boolean
+    ) : DeclarationContainer(functions, properties, typeAliases) {
+        companion object {
+            val ALL = Class(
+                typeParameters = true,
+                constructors = true,
+                superTypes = true,
+                companionObject = true,
+                nestedClasses = true,
+                enumEntries = true,
+                sealedSubClasses = true,
+                extensions = true,
+                functions = true,
+                properties = true,
+                typeAliases = true
+            )
+        }
+    }
+}


### PR DESCRIPTION
Right now, Kotlinx-metadata's KmClass types eagerly parse every possibly bit of information. Not every case requires every possible bit of information though, and some performance could be improved by only deserializing what's requested from the underlying proto.

I've started an implementation below with what I'm describing, and can continue figuring this out if this proposal is deemed acceptable/welcomed.

Example use cases (mostly from https://github.com/square/kotlinpoet/issues/755)
- [Moshi kotlin codegen (annotation processor)](https://github.com/square/moshi)
  - Only cares about constructors, properties, and class signature/hierarchy (type parameters, visibility).
  - Doesn't care about enums, inner classes, companion objects, functions.
- [Dagger (annotation processor)](https://github.com/google/dagger)
  - Is just starting kotlin support and cares a lot about processor performance. Right now its support is limited to reading properties, so it could skip almost everything else in KmClass until they add more functionality.
- [CopyDynamic (annotation processor)](https://github.com/zacsweers/copydynamic)
  - Only cares about constructors and class signature
- [Androidx Room (annotation processor)](https://developer.android.com/topic/libraries/architecture/room)
  - Only cares about constructors, properties, and class signature/hierarchy
- [Moshi-sealed (annotation processor)](https://github.com/zacsweers/moshi-sealed)
  - Only cares about sealed class signatures and sealed class hierarchies
- API jar generation
  - Private/internal APIs are parsed currently but don't need to be in the case of API jar generation tools. Examples  Configuration to strip these could allow parsing of only public API (and also turn that around to generate API stubs/jars).

CC @udalov 