### PR TITLE
Fix gradle integeration and KAPT tests

### DIFF
--- a/compiler/tests-common/tests/org/jetbrains/kotlin/test/KotlinTestUtils.java
+++ b/compiler/tests-common/tests/org/jetbrains/kotlin/test/KotlinTestUtils.java
@@ -605,11 +605,11 @@ public class KotlinTestUtils {
         return new File(jdk9);
     }
 
-    @NotNull
+    @Nullable
     public static File getJdk11Home() {
         String jdk11 = System.getenv("JDK_11");
         if (jdk11 == null) {
-            throw new AssertionError("Environment variable JDK_11 is not set!");
+            return null;
         }
         return new File(jdk11);
     }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BuildCacheIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BuildCacheIT.kt
@@ -29,22 +29,6 @@ class BuildCacheIT : BaseGradleIT() {
     }
 
     @Test
-    fun testNoCacheWithGradlePre43() = with(Project("simpleProject", GradleVersionRequired.Exact("4.2"))) {
-        // Check that even with the build cache enabled, the Kotlin tasks are not cacheable with Gradle < 4.3:
-        val optionsWithCache = defaultBuildOptions().copy(withBuildCache = true)
-
-        build("assemble", options = optionsWithCache) {
-            assertSuccessful()
-            assertNotContains("Packing task ':compileKotlin'")
-        }
-        build("clean", "assemble", options = optionsWithCache) {
-            assertSuccessful()
-            assertNotContains(":compileKotlin FROM-CACHE")
-            assertContains(":compileJava FROM-CACHE")
-        }
-    }
-
-    @Test
     fun testKotlinCachingEnabledFlag() = with(Project("simpleProject", GRADLE_VERSION)) {
         prepareLocalBuildCache()
 
@@ -70,6 +54,7 @@ class BuildCacheIT : BaseGradleIT() {
         build("clean", "assemble") {
             assertSuccessful()
             assertContains(":compileKotlin FROM-CACHE")
+            assertContains(":compileJava FROM-CACHE")
         }
     }
 

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KaptIncrementalWithIsolatingApt.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KaptIncrementalWithIsolatingApt.kt
@@ -97,7 +97,7 @@ class KaptIncrementalWithIsolatingApt : KaptIncrementalIT() {
             
             tasks.whenTaskAdded {
                 if (it.name == "kaptKotlin") {
-                  it.getInputs().files("${additionalInputs.canonicalPath}")
+                  it.getInputs().files("${additionalInputs.invariantSeparatorsPath}")
                 }
             }
         """.trimIndent()

--- a/plugins/kapt3/kapt3-compiler/test/org/jetbrains/kotlin/kapt3/test/java9TestUtils.kt
+++ b/plugins/kapt3/kapt3-compiler/test/org/jetbrains/kotlin/kapt3/test/java9TestUtils.kt
@@ -36,7 +36,7 @@ interface CustomJdkTestLauncher {
 
     fun doTestWithJdk11(mainClass: Class<*>, arg: String) {
         if (isJava9OrLater()) return
-        doTestCustomJdk(mainClass, arg, KotlinTestUtils.getJdk11Home())
+        KotlinTestUtils.getJdk11Home()?.let { doTestCustomJdk(mainClass, arg, it) }
     }
 
     private fun doTestCustomJdk(mainClass: Class<*>, arg: String, javaHome: File) {


### PR DESCRIPTION
Fix test failure on Windows, where backslash was not escaped
in a build file. Also, remove obsolete test for Gradle 4.2,
because 4.3 is the minimum supported version.

Also, run KAPT JDK 11 tests only if there is JDK_11 path specified.