### PR TITLE
Use `getPropertyGetter()` in ForLoopsLowering to retrieve property getters

### DIFF
--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/ir/util/IrBackendUtils.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/ir/util/IrBackendUtils.kt
@@ -17,25 +17,32 @@
 package org.jetbrains.kotlin.ir.util
 
 import org.jetbrains.kotlin.backend.common.atMostOne
+import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrProperty
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.IrFieldSymbol
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
-import org.jetbrains.kotlin.name.Name
 
-fun IrClassSymbol.getPropertyDeclaration(name: String) =
-    this.owner.declarations.filterIsInstance<IrProperty>()
-        .atMostOne { it.descriptor.name == Name.identifier(name) }
+fun IrClass.getPropertyDeclaration(name: String) =
+    declarations.filterIsInstance<IrProperty>().atMostOne { it.name.asString() == name }
 
-fun IrClassSymbol.getSimpleFunction(name: String): IrSimpleFunctionSymbol? =
-        owner.findDeclaration<IrSimpleFunction> { it.name.asString() == name }?.symbol
+fun IrClass.getSimpleFunction(name: String): IrSimpleFunctionSymbol? =
+    findDeclaration<IrSimpleFunction> { it.name.asString() == name }?.symbol
 
-fun IrClassSymbol.getPropertyGetter(name: String): IrSimpleFunctionSymbol? =
-    this.getPropertyDeclaration(name)?.getter?.symbol ?: this.getSimpleFunction("<get-$name>")
+fun IrClass.getPropertyGetter(name: String): IrSimpleFunctionSymbol? =
+    getPropertyDeclaration(name)?.getter?.symbol
+        ?: getSimpleFunction("<get-$name>").also { assert(it?.owner?.correspondingPropertySymbol?.owner?.name?.asString() == name) }
 
-fun IrClassSymbol.getPropertySetter(name: String): IrSimpleFunctionSymbol? =
-    this.getPropertyDeclaration(name)?.setter?.symbol ?: this.getSimpleFunction("<set-$name>")
+fun IrClass.getPropertySetter(name: String): IrSimpleFunctionSymbol? =
+    getPropertyDeclaration(name)?.setter?.symbol
+        ?: getSimpleFunction("<set-$name>").also { assert(it?.owner?.correspondingPropertySymbol?.owner?.name?.asString() == name) }
 
-fun IrClassSymbol.getPropertyField(name: String): IrFieldSymbol? =
-    this.getPropertyDeclaration(name)?.backingField?.symbol
+fun IrClass.getPropertyField(name: String): IrFieldSymbol? =
+    getPropertyDeclaration(name)?.backingField?.symbol
+
+fun IrClassSymbol.getPropertyDeclaration(name: String) = owner.getPropertyDeclaration(name)
+fun IrClassSymbol.getSimpleFunction(name: String): IrSimpleFunctionSymbol? = owner.getSimpleFunction(name)
+fun IrClassSymbol.getPropertyGetter(name: String): IrSimpleFunctionSymbol? = owner.getPropertyGetter(name)
+fun IrClassSymbol.getPropertySetter(name: String): IrSimpleFunctionSymbol? = owner.getPropertySetter(name)
+fun IrClassSymbol.getPropertyField(name: String): IrFieldSymbol? = owner.getPropertyField(name)


### PR DESCRIPTION
...getters instead of directly retrieving the property first. When the IR backend is used to compile the standard library, the progression classes (in sources) are lowered, and therefore do not have properties anymore (only fields and functions).