### PR TITLE
Start scope for destructuring variables after initialization.

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/range/forLoop/AbstractForLoopGenerator.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/range/forLoop/AbstractForLoopGenerator.kt
@@ -101,13 +101,17 @@ abstract class AbstractForLoopGenerator(
             })
         }
 
-        v.visitLabel(destructuringStartLabel)
-
         codegen.initializeDestructuringDeclarationVariables(
             destructuringDeclaration,
             TransientReceiver(elementType),
             StackValue.local(loopParameterVar, asmElementType)
         )
+
+        // Start the scope for the destructuring variables only after a values
+        // has been written to their locals slot. Otherwise, we can generate
+        // type-incorrect locals information because the local could have previously
+        // been used for a value of incompatible type.
+        v.visitLabel(destructuringStartLabel)
     }
 
     protected abstract fun assignToLoopParameter()


### PR DESCRIPTION
If the scope for a local variable is started before a value
has been written, another value from a previous use of the local
slot can be present. That value could have a different type which
would lead to weird debugging situations and also leads to other
tools (such as D8) rejecting the locals information as it is
invalid.

Fixes KT-33959.