### PR TITLE
Fix running incremental KAPT on JDK 9

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/build.gradle.kts
@@ -118,6 +118,7 @@ tasks.withType<Test> {
 
     systemProperty("kotlinVersion", rootProject.extra["kotlinVersion"] as String)
     systemProperty("runnerGradleVersion", gradle.gradleVersion)
+    systemProperty("jdk9Home", rootProject.extra["JDK_9"] as String)
     systemProperty("jdk10Home", rootProject.extra["JDK_10"] as String)
     systemProperty("jdk11Home", rootProject.extra["JDK_11"] as String)
 

--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/javac/KaptJavaFileManager.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/javac/KaptJavaFileManager.kt
@@ -5,7 +5,6 @@
 
 package org.jetbrains.kotlin.kapt3.base.javac
 
-import com.sun.tools.javac.file.BaseFileObject
 import com.sun.tools.javac.file.JavacFileManager
 import com.sun.tools.javac.main.Option
 import com.sun.tools.javac.util.Context
@@ -66,8 +65,7 @@ class KaptJavaFileManager(context: Context) : JavacFileManager(context, true, nu
         return when (fileObject.toUri().scheme) {
             "jar", "zip" -> false
             else -> {
-                if (fileObject !is BaseFileObject) return false
-                val typeName = packageName?.let { "$it." } + fileObject.shortName.dropLast(".class".length)
+                val typeName = packageName?.let { "$it." } + File(fileObject.toUri()).name.dropLast(".class".length)
 
                 return typeToIgnore.contains(typeName)
             }


### PR DESCRIPTION
Incremental annotation processing was relying on internal JDK types/method that were removed in JDK 9. This PR fixes that are removes dependency on `BaseFileObject` and `JavacProcessingEnvironment.validImportStringToPattern`.

Fixes KT-33889