### PR TITLE
KT-19554: KT-34069: J2K: Converting Java code with 'continue' under 'switch' in 'for' produces code that doesn't parse

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -95,6 +95,113 @@
         <option name="INDENT_SIZE" value="2" />
         <option name="CONTINUATION_INDENT_SIZE" value="4" />
       </indentOptions>
+      <arrangement>
+        <rules>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>xmlns:android</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>xmlns:.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:id</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:name</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>name</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>style</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>ANDROID_ATTRIBUTE_ORDER</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>.*</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+        </rules>
+      </arrangement>
     </codeStyleSettings>
     <codeStyleSettings language="kotlin">
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -30,7 +30,7 @@
     <option name="myDefaultNotNull" value="org.jetbrains.annotations.NotNull" />
     <option name="myNullables">
       <value>
-        <list size="11">
+        <list size="12">
           <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.Nullable" />
           <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nullable" />
           <item index="2" class="java.lang.String" itemvalue="javax.annotation.CheckForNull" />
@@ -42,12 +42,13 @@
           <item index="8" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableType" />
           <item index="9" class="java.lang.String" itemvalue="androidx.annotation.RecentlyNullable" />
           <item index="10" class="java.lang.String" itemvalue="com.android.annotations.Nullable" />
+          <item index="11" class="java.lang.String" itemvalue="android.annotation.Nullable" />
         </list>
       </value>
     </option>
     <option name="myNotNulls">
       <value>
-        <list size="11">
+        <list size="12">
           <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.NotNull" />
           <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nonnull" />
           <item index="2" class="java.lang.String" itemvalue="javax.validation.constraints.NotNull" />
@@ -59,6 +60,7 @@
           <item index="8" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullType" />
           <item index="9" class="java.lang.String" itemvalue="androidx.annotation.RecentlyNonNull" />
           <item index="10" class="java.lang.String" itemvalue="com.android.annotations.NonNull" />
+          <item index="11" class="java.lang.String" itemvalue="android.annotation.NonNull" />
         </list>
       </value>
     </option>
@@ -66,7 +68,7 @@
   <component name="ProjectResources">
     <default-html-doctype>http://www.w3.org/1999/xhtml</default-html-doctype>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="JDK" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
   <component name="PsiViewerSettings">

--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="org.jetbrains.plugins.gradle.execution.test.runner.AllInPackageGradleConfigurationProducer" />
+        <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestClassGradleConfigurationProducer" />
+        <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestMethodGradleConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -582,6 +582,11 @@ tasks {
         dependsOn(":idea:test")
     }
 
+    register("j2k") {
+        dependsOn(":nj2k:test")
+    }
+
+
     register("idea-plugin-additional-tests") {
         dependsOn("dist")
         dependsOn(

--- a/nj2k/build.gradle.kts
+++ b/nj2k/build.gradle.kts
@@ -5,6 +5,14 @@ plugins {
     id("jps-compatible")
 }
 
+//tasks.test {
+//    filter {
+//        //include specific method in any of the tests
+//        includeTestsMatching("*Switch*")
+//
+//    }
+//}
+
 dependencies {
     testRuntime(intellijDep())
 

--- a/nj2k/src/org/jetbrains/kotlin/nj2k/ConversionsRunner.kt
+++ b/nj2k/src/org/jetbrains/kotlin/nj2k/ConversionsRunner.kt
@@ -58,6 +58,8 @@ object ConversionsRunner {
         SwitchStatementConversion(context),
         LiteralConversion(context),
         ForConversion(context),
+        ContinueStatementConversion(context),
+        LabeledStatementConversion(context),
         ArrayOperationsConversion(context),
         EqualsOperatorConversion(context),
         TypeMappingConversion(context),
@@ -79,9 +81,7 @@ object ConversionsRunner {
         RemoveRedundantQualifiersForCallsConversion(context),
         FilterImportsConversion(context),
         MoveInitBlocksToTheEndConversion(context),
-        AddElementsInfoConversion(context),
-        ContinueStatementConversion(context),
-        LabeledStatementConversion(context)
+        AddElementsInfoConversion(context)
     )
 
     fun doApply(trees: List<JKTreeRoot>, context: NewJ2kConverterContext) {

--- a/nj2k/src/org/jetbrains/kotlin/nj2k/ConversionsRunner.kt
+++ b/nj2k/src/org/jetbrains/kotlin/nj2k/ConversionsRunner.kt
@@ -58,7 +58,6 @@ object ConversionsRunner {
         SwitchStatementConversion(context),
         LiteralConversion(context),
         ForConversion(context),
-        LabeledStatementConversion(context),
         ArrayOperationsConversion(context),
         EqualsOperatorConversion(context),
         TypeMappingConversion(context),
@@ -80,7 +79,9 @@ object ConversionsRunner {
         RemoveRedundantQualifiersForCallsConversion(context),
         FilterImportsConversion(context),
         MoveInitBlocksToTheEndConversion(context),
-        AddElementsInfoConversion(context)
+        AddElementsInfoConversion(context),
+        ContinueStatementConversion(context),
+        LabeledStatementConversion(context)
     )
 
     fun doApply(trees: List<JKTreeRoot>, context: NewJ2kConverterContext) {

--- a/nj2k/src/org/jetbrains/kotlin/nj2k/NewCodeBuilder.kt
+++ b/nj2k/src/org/jetbrains/kotlin/nj2k/NewCodeBuilder.kt
@@ -556,13 +556,26 @@ class NewCodeBuilder(context: NewJ2kConverterContext) {
         }
 
         override fun visitWhileStatementRaw(whileStatement: JKWhileStatement) {
+            printWhile(printer, whileStatement.condition, whileStatement.body)
+        }
+
+        override fun visitKtConvertedFromForLoopSyntheticWhileStatementRaw(
+            ktConvertedFromForLoopSyntheticWhileStatement: JKKtConvertedFromForLoopSyntheticWhileStatement
+        ) {
+            ktConvertedFromForLoopSyntheticWhileStatement.variableDeclaration.accept(this)
+            printer.printlnWithNoIndent()
+            printWhile(printer, ktConvertedFromForLoopSyntheticWhileStatement.condition, ktConvertedFromForLoopSyntheticWhileStatement.body)
+
+        }
+
+        private fun printWhile(printer: JKPrinter, condition: JKExpression, body: JKStatement) {
             printer.print("while(")
-            whileStatement.condition.accept(this)
+            condition.accept(this)
             printer.printWithNoIndent(")")
-            if (whileStatement.body.isEmpty()) {
+            if (body.isEmpty()) {
                 printer.printWithNoIndent(";")
             } else {
-                whileStatement.body.accept(this)
+                body.accept(this)
             }
         }
 
@@ -587,14 +600,6 @@ class NewCodeBuilder(context: NewJ2kConverterContext) {
         }
 
         override fun visitStubExpressionRaw(stubExpression: JKStubExpression) {
-        }
-
-        override fun visitKtConvertedFromForLoopSyntheticWhileStatementRaw(
-            ktConvertedFromForLoopSyntheticWhileStatement: JKKtConvertedFromForLoopSyntheticWhileStatement
-        ) {
-            ktConvertedFromForLoopSyntheticWhileStatement.variableDeclaration.accept(this)
-            printer.printlnWithNoIndent()
-            ktConvertedFromForLoopSyntheticWhileStatement.whileStatement.accept(this)
         }
 
         override fun visitNewExpressionRaw(newExpression: JKNewExpression) {

--- a/nj2k/src/org/jetbrains/kotlin/nj2k/conversions/ContinueStatementConversion.kt
+++ b/nj2k/src/org/jetbrains/kotlin/nj2k/conversions/ContinueStatementConversion.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.nj2k.conversions
+
+import com.intellij.psi.*
+import org.jetbrains.kotlin.nj2k.*
+import org.jetbrains.kotlin.nj2k.tree.*
+
+// This conversion is for converting 'continue' keywords to labeled ones. If the 'continue' keywords in 'switch'
+// is allowed by the kotlin syntax, convertForInStatement and convertWhileStatement in this class can be removed.
+class ContinueStatementConversion(context: NewJ2kConverterContext) : RecursiveApplicableConversionBase(context) {
+    private val loop = JKNameIdentifier("loop")
+
+    override fun applyToElement(element: JKTreeElement): JKTreeElement {
+        if (element is JKKtConvertedFromForLoopSyntheticWhileStatement) {
+            return recurse(convertSyntheticWhileStatement(element))
+        }
+
+        if (element is JKForInStatement) {
+            convertForInStatement(element)?.also { return it }
+        }
+
+        if (element is JKWhileStatement) {
+            convertWhileStatement(element)?.also { return it }
+        }
+
+        return recurse(element)
+    }
+
+    private fun convertForInStatement(loopStatement: JKForInStatement): JKStatement? {
+        var needLabel = false
+        val continueStatementConverter = object : RecursiveApplicableConversionBase(context) {
+            override fun applyToElement(element: JKTreeElement): JKTreeElement {
+                if (element !is JKContinueStatement) return recurse(element)
+                val elementPsi = element.psi<PsiContinueStatement>()!!
+                val loopPsi = loopStatement.psi<PsiWhileStatement>()
+                    ?: loopStatement.psi<PsiForStatement>()
+                    ?: loopStatement.psi<PsiForeachStatement>()
+                if (elementPsi.findContinuedStatement()?.toContinuedLoop() != loopPsi) return recurse(element)
+                if (element.parentIsWhenCase() && element.label is JKLabelEmpty) {
+                    element.label = JKLabelText(loop.copyTreeAndDetach())
+                    needLabel = true
+                }
+                return element
+            }
+        }
+        val body = continueStatementConverter.applyToElement(loopStatement::body.detached())
+        if (!needLabel || body !is JKStatement) {
+            return null
+        }
+        return JKLabeledExpression(
+            JKForInStatement(
+                loopStatement.declaration.detached(loopStatement),
+                loopStatement.iterationExpression.detached(loopStatement),
+                body
+            ),
+            listOf(loop.copyTreeAndDetach())
+        ).asStatement()
+    }
+
+    private fun convertWhileStatement(loopStatement: JKWhileStatement): JKStatement? {
+        if (loopStatement.parent is JKKtConvertedFromForLoopSyntheticWhileStatement) {
+            return null
+        }
+        var needLabel = false
+        val continueStatementConverter = object : RecursiveApplicableConversionBase(context) {
+            override fun applyToElement(element: JKTreeElement): JKTreeElement {
+                if (element !is JKContinueStatement) return recurse(element)
+                val elementPsi = element.psi<PsiContinueStatement>()!!
+                val loopPsi = loopStatement.psi<PsiWhileStatement>() ?: loopStatement.psi<PsiForStatement>()
+                if (elementPsi.findContinuedStatement()?.toContinuedLoop() != loopPsi) return recurse(element)
+                if (element.parentIsWhenCase() && element.label is JKLabelEmpty) {
+                    element.label = JKLabelText(loop.copyTreeAndDetach())
+                    needLabel = true
+                }
+                return element
+            }
+        }
+        val body = continueStatementConverter.applyToElement(loopStatement::body.detached())
+        if (!needLabel || body !is JKStatement) {
+            return null
+        }
+        return JKLabeledExpression(
+            JKWhileStatement(
+                loopStatement.condition.detached(loopStatement),
+                body
+            ),
+            listOf(loop.copyTreeAndDetach())
+        ).asStatement()
+    }
+
+    private fun convertSyntheticWhileStatement(loopStatement: JKKtConvertedFromForLoopSyntheticWhileStatement): JKStatement {
+        var needLabel = false
+        val continueStatementConverter = object : RecursiveApplicableConversionBase(context) {
+            override fun applyToElement(element: JKTreeElement): JKTreeElement {
+                if (element !is JKContinueStatement) return recurse(element)
+                val elementPsi = element.psi<PsiContinueStatement>()!!
+                if (elementPsi.findContinuedStatement()?.toContinuedLoop() != loopStatement.whileStatement.psi<PsiForStatement>()) {
+                    return recurse(element)
+                }
+                if (element.parentIsWhenCase() && element.label is JKLabelEmpty) {
+                    element.label = JKLabelText(loop.copyTreeAndDetach())
+                    needLabel = true
+                }
+                val statements = loopStatement.forLoopUpdaters.map { it.copyTreeAndDetach() } + element.copyTreeAndDetach()
+                return if (element.parent is JKBlock)
+                    JKBlockStatementWithoutBrackets(statements)
+                else JKBlockStatement(JKBlockImpl(statements))
+            }
+        }
+        val body = continueStatementConverter.applyToElement(loopStatement.whileStatement::body.detached())
+        if (needLabel) {
+            return JKBlockStatementWithoutBrackets(
+                listOf(
+                    loopStatement::variableDeclaration.detached(),
+                    JKLabeledExpression(
+                        JKWhileStatement(
+                            loopStatement.whileStatement::condition.detached(),
+                            body as JKStatement
+                        ),
+                        listOf(loop.copyTreeAndDetach())
+                    ).asStatement()
+                )
+            )
+        }
+        return JKKtConvertedFromForLoopSyntheticWhileStatement(
+            loopStatement::variableDeclaration.detached(),
+            JKWhileStatement(
+                loopStatement.whileStatement::condition.detached(),
+                body as JKStatement
+            )
+        )
+    }
+
+    private fun JKElement.parentIsWhenCase(): Boolean {
+        return when (this.parent) {
+            is JKKtWhenCase -> true
+            is JKWhileStatement, is JKForInStatement -> false
+            null -> false
+            else -> this.parent?.parent?.parentIsWhenCase() ?: false
+        }
+    }
+
+    private fun PsiStatement.toContinuedLoop(): PsiLoopStatement? {
+        return when (this) {
+            is PsiLoopStatement -> this
+            is PsiLabeledStatement -> statement?.toContinuedLoop()
+            else -> null
+        }
+    }
+}

--- a/nj2k/src/org/jetbrains/kotlin/nj2k/conversions/ContinueStatementConversion.kt
+++ b/nj2k/src/org/jetbrains/kotlin/nj2k/conversions/ContinueStatementConversion.kt
@@ -9,9 +9,10 @@ import com.intellij.psi.*
 import org.jetbrains.kotlin.nj2k.*
 import org.jetbrains.kotlin.nj2k.tree.*
 
-// This conversion is for converting 'continue' keywords to labeled ones. If the 'continue' keywords in 'switch'
-// is allowed by the kotlin syntax, ContinueStatementConverter, convertForInStatement and convertWhileStatement
-// in this file can be removed.
+// This conversion is for converting continue statements. For example, this adds updaters in converted while loops, and attaches
+// labels named 'loop' to continue statements inner 'when' in loops and their corresponding loops for avoiding syntax errors.
+// If the 'continue' keywords in 'switch' is allowed by the kotlin syntax, ContinueStatementConverter, convertForInStatement and
+// convertWhileStatement in this file can be removed.
 class ContinueStatementConversion(context: NewJ2kConverterContext) : RecursiveApplicableConversionBase(context) {
     override fun applyToElement(element: JKTreeElement): JKTreeElement {
         if (element is JKKtConvertedFromForLoopSyntheticWhileStatement) {

--- a/nj2k/src/org/jetbrains/kotlin/nj2k/conversions/ContinueStatementConversion.kt
+++ b/nj2k/src/org/jetbrains/kotlin/nj2k/conversions/ContinueStatementConversion.kt
@@ -41,27 +41,6 @@ class ContinueStatementConversion(context: NewJ2kConverterContext) : RecursiveAp
             labelChanged = true
         }
 
-        val continueStatementConverter = object : RecursiveApplicableConversionBase(context) {
-            override fun applyToElement(element: JKTreeElement): JKTreeElement {
-                if (element !is JKContinueStatement) return recurse(element)
-                val elementPsi = element.psi<PsiContinueStatement>() ?: return recurse(element)
-                if (elementPsi.findContinuedStatement()?.toContinuedLoop() != loopStatement.psi) return recurse(element)
-                if (element.parentIsWhenCase() && element.label is JKLabelEmpty) {
-                    element.label = JKLabelText(JKNameIdentifier(loopLabel))
-                    if (!labelChanged) {
-                        needLabel = true
-                    }
-                }
-                if (loopStatement !is JKKtConvertedFromForLoopSyntheticWhileStatement) {
-                    return element
-                }
-                val statements = loopStatement.forLoopUpdaters.map { it.copyTreeAndDetach() } + element.copyTreeAndDetach()
-                return if (element.parent is JKBlock)
-                    JKBlockStatementWithoutBrackets(statements)
-                else JKBlockStatement(JKBlockImpl(statements))
-            }
-        }
-
         fun convertContinue(element: JKTreeElement): JKTreeElement {
             if (element !is JKContinueStatement) return applyRecursive(element, ::convertContinue)
             val elementPsi = element.psi<PsiContinueStatement>() ?: return applyRecursive(element, ::convertContinue)

--- a/nj2k/src/org/jetbrains/kotlin/nj2k/conversions/ContinueStatementConversion.kt
+++ b/nj2k/src/org/jetbrains/kotlin/nj2k/conversions/ContinueStatementConversion.kt
@@ -61,7 +61,12 @@ class ContinueStatementConversion(context: NewJ2kConverterContext) : RecursiveAp
             return loopStatement
         }
         if (!needLabel) {
-            return blockStatement(loopStatement.copyTreeAndDetach())
+            loopStatement.parent.let {
+                if (it != null) {
+                    loopStatement.detached(it)
+                }
+            }
+            return blockStatement(loopStatement)
         }
 
         val labeledLoop = JKLabeledExpression(

--- a/nj2k/src/org/jetbrains/kotlin/nj2k/conversions/ForConversion.kt
+++ b/nj2k/src/org/jetbrains/kotlin/nj2k/conversions/ForConversion.kt
@@ -48,11 +48,10 @@ class ForConversion(context: NewJ2kConverterContext) : RecursiveApplicableConver
         val convertedFromForLoopSyntheticWhileStatement =
             JKKtConvertedFromForLoopSyntheticWhileStatement(
                 loopStatement::initializer.detached(),
-                whileStatement
+                whileStatement,
+                // To use updaters information in ContinueStatementConversion later.
+                loopStatement.updaters.map { it.copyTreeAndDetach() }
             )
-
-        // To use updaters information in ContinueStatementConversion later.
-        convertedFromForLoopSyntheticWhileStatement.forLoopUpdaters = loopStatement.updaters.map { it.copyTreeAndDetach() }
 
         val notNeedParentBlock = loopStatement.parent is JKBlock
                 || loopStatement.parent is JKLabeledExpression && loopStatement.parent?.parent is JKBlock

--- a/nj2k/src/org/jetbrains/kotlin/nj2k/conversions/ForConversion.kt
+++ b/nj2k/src/org/jetbrains/kotlin/nj2k/conversions/ForConversion.kt
@@ -47,7 +47,7 @@ class ForConversion(context: NewJ2kConverterContext) : RecursiveApplicableConver
                 val elementPsi = element.psi<PsiContinueStatement>()!!
                 if (elementPsi.findContinuedStatement() != loopStatement.psi<PsiForeachStatement>()) return recurse(element)
                 if (element.parent is JKKtWhenCase && element.label is JKLabelEmpty) {
-                    element.label = JKLabelText(loop)
+                    element.label = JKLabelText(loop.copyTreeAndDetach())
                     needLabel = true
                 }
                 return element
@@ -61,7 +61,7 @@ class ForConversion(context: NewJ2kConverterContext) : RecursiveApplicableConver
                     loopStatement.iterationExpression.detached(loopStatement),
                     body
                 ),
-                listOf(loop)
+                listOf(loop.copyTreeAndDetach())
             ).asStatement()
         }
         return null
@@ -91,7 +91,7 @@ class ForConversion(context: NewJ2kConverterContext) : RecursiveApplicableConver
                 loopStatement::initializer.detached(),
                 JKLabeledExpression(
                     whileStatement,
-                    listOf(loop)
+                    listOf(loop.copyTreeAndDetach())
                 ).asStatement()
             )
         )
@@ -107,7 +107,7 @@ class ForConversion(context: NewJ2kConverterContext) : RecursiveApplicableConver
                 val elementPsi = element.psi<PsiContinueStatement>()!!
                 if (elementPsi.findContinuedStatement()?.toContinuedLoop() != loopStatement.psi<PsiForStatement>()) return recurse(element)
                 if (element.parent is JKKtWhenCase && element.label is JKLabelEmpty) {
-                    element.label = JKLabelText(loop)
+                    element.label = JKLabelText(loop.copyTreeAndDetach())
                     needLabel = true
                 }
                 val statements = loopStatement.updaters.map { it.copyTreeAndDetach() } + element.copyTreeAndDetach()
@@ -212,7 +212,7 @@ class ForConversion(context: NewJ2kConverterContext) : RecursiveApplicableConver
                 val elementPsi = element.psi<PsiContinueStatement>()!!
                 if (elementPsi.findContinuedStatement()?.toContinuedLoop() != loopStatement.psi<PsiForStatement>()) return recurse(element)
                 if (element.parent is JKKtWhenCase && element.label is JKLabelEmpty) {
-                    element.label = JKLabelText(loop)
+                    element.label = JKLabelText(loop.copyTreeAndDetach())
                     needLabel = true
                 }
                 return element
@@ -228,13 +228,13 @@ class ForConversion(context: NewJ2kConverterContext) : RecursiveApplicableConver
         if (needLabel) {
             return JKLabeledExpression(
                 forInStatement,
-                listOf(loop)
+                listOf(loop.copyTreeAndDetach())
             ).asStatement()
         }
 
         return forInStatement
     }
-
+    
     private fun PsiStatement.toContinuedLoop(): PsiLoopStatement? {
         return when (this) {
             is PsiLoopStatement -> this

--- a/nj2k/src/org/jetbrains/kotlin/nj2k/conversions/ForConversion.kt
+++ b/nj2k/src/org/jetbrains/kotlin/nj2k/conversions/ForConversion.kt
@@ -57,20 +57,14 @@ class ForConversion(context: NewJ2kConverterContext) : RecursiveApplicableConver
         // To use psi information in ContinueStatementConversion later.
         convertedFromForLoopSyntheticWhileStatement.psi = loopStatement.psi<PsiForStatement>()!!
 
-        val notNeedParentBlock = loopStatement.parent is JKBlock
-                || loopStatement.parent is JKLabeledExpression && loopStatement.parent?.parent is JKBlock
-
-        return when {
-            loopStatement.hasNameConflict() ->
-                JKExpressionStatement(
-                    runExpression(
-                        convertedFromForLoopSyntheticWhileStatement,
-                        symbolProvider
-                    )
+        return if (loopStatement.hasNameConflict()) {
+            JKExpressionStatement(
+                runExpression(
+                    convertedFromForLoopSyntheticWhileStatement,
+                    symbolProvider
                 )
-            !notNeedParentBlock -> blockStatement(convertedFromForLoopSyntheticWhileStatement)
-            else -> convertedFromForLoopSyntheticWhileStatement
-        }
+            )
+        } else convertedFromForLoopSyntheticWhileStatement
     }
 
     private fun createWhileBody(loopStatement: JKJavaForLoopStatement): JKStatement {

--- a/nj2k/src/org/jetbrains/kotlin/nj2k/conversions/LabeledStatementConversion.kt
+++ b/nj2k/src/org/jetbrains/kotlin/nj2k/conversions/LabeledStatementConversion.kt
@@ -29,7 +29,10 @@ class LabeledStatementConversion(context : NewJ2kConverterContext) : RecursiveAp
                 listOf(
                     convertedFromForLoopSyntheticWhileStatement::variableDeclaration.detached(),
                     JKLabeledExpression(
-                        convertedFromForLoopSyntheticWhileStatement::whileStatement.detached(),
+                        JKWhileStatement(
+                            convertedFromForLoopSyntheticWhileStatement::condition.detached(),
+                            convertedFromForLoopSyntheticWhileStatement::body.detached()
+                        ),
                         labeledStatement::labels.detached()
                     ).asStatement()
                 )

--- a/nj2k/src/org/jetbrains/kotlin/nj2k/conversions/MatchBasedConversion.kt
+++ b/nj2k/src/org/jetbrains/kotlin/nj2k/conversions/MatchBasedConversion.kt
@@ -11,36 +11,8 @@ import org.jetbrains.kotlin.nj2k.tree.JKTreeElement
 
 
 abstract class MatchBasedConversion(override val context: NewJ2kConverterContext) : SequentialBaseConversion {
-    fun <R : JKTreeElement, T> applyRecursive(element: R, data: T, func: (JKTreeElement, T) -> JKTreeElement): R =
+    inline fun <R : JKTreeElement, T> applyRecursive(element: R, data: T, func: (JKTreeElement, T) -> JKTreeElement): R =
         org.jetbrains.kotlin.nj2k.tree.applyRecursive(element, data, ::onElementChanged, func)
-
-    fun <R : JKTreeElement> applyRecursive(element: R, func: (JKTreeElement) -> JKTreeElement): R {
-        return applyRecursive(element, null) { it, _ -> func(it) }
-    }
-
-    private inline fun <T> applyRecursiveToList(
-        element: JKTreeElement,
-        child: List<JKTreeElement>,
-        iter: MutableListIterator<Any>,
-        data: T,
-        func: (JKTreeElement, T) -> JKTreeElement
-    ): List<JKTreeElement> {
-
-        val newChild = child.map {
-            func(it, data)
-        }
-
-        child.forEach { it.detach(element) }
-        iter.set(child)
-        newChild.forEach { it.attach(element) }
-        newChild.zip(child).forEach { (old, new) ->
-            if (old !== new) {
-                onElementChanged(new, old)
-            }
-        }
-        return newChild
-    }
-
 
     abstract fun onElementChanged(new: JKTreeElement, old: JKTreeElement)
 }

--- a/nj2k/src/org/jetbrains/kotlin/nj2k/conversions/RecursiveApplicableConversionBase.kt
+++ b/nj2k/src/org/jetbrains/kotlin/nj2k/conversions/RecursiveApplicableConversionBase.kt
@@ -9,20 +9,34 @@ import org.jetbrains.kotlin.nj2k.NewJ2kConverterContext
 import org.jetbrains.kotlin.nj2k.tree.JKTreeElement
 
 
-abstract class RecursiveApplicableConversionBase(context: NewJ2kConverterContext) : MatchBasedConversion(context) {
-    override fun onElementChanged(new: JKTreeElement, old: JKTreeElement) {
+abstract class StatefulRecursiveApplicableConversionBase<S>(context: NewJ2kConverterContext) : MatchBasedConversion(context) {
+    open val initialState: S? = null
+
+    final override fun onElementChanged(new: JKTreeElement, old: JKTreeElement) {
         somethingChanged = true
     }
 
-    override fun runConversion(treeRoot: JKTreeElement, context: NewJ2kConverterContext): Boolean {
-        val root = applyToElement(treeRoot)
+    final override fun runConversion(treeRoot: JKTreeElement, context: NewJ2kConverterContext): Boolean {
+        val root = applyToElement(treeRoot, initialState)
         assert(root === treeRoot)
         return somethingChanged
     }
 
-    protected var somethingChanged = false
+    private var somethingChanged = false
+
+    abstract fun applyToElement(element: JKTreeElement, state: S?): JKTreeElement
+
+    fun <T : JKTreeElement> recurse(element: T, state: S?): T = applyRecursive(element, state, ::applyToElement)
+}
+
+abstract class RecursiveApplicableConversionBase(context: NewJ2kConverterContext) :
+    StatefulRecursiveApplicableConversionBase<Nothing>(context) {
+
+    final override val initialState = null
 
     abstract fun applyToElement(element: JKTreeElement): JKTreeElement
 
-    fun <T : JKTreeElement> recurse(element: T): T = applyRecursive(element, ::applyToElement)
+    final override fun applyToElement(element: JKTreeElement, state: Nothing?): JKTreeElement = applyToElement(element)
+
+    fun <T : JKTreeElement> recurse(element: T): T = recurse(element, null)
 }

--- a/nj2k/src/org/jetbrains/kotlin/nj2k/tree/statements.kt
+++ b/nj2k/src/org/jetbrains/kotlin/nj2k/tree/statements.kt
@@ -84,21 +84,15 @@ class JKKtWhenStatement(
 
 class JKKtConvertedFromForLoopSyntheticWhileStatement(
     variableDeclaration: JKStatement,
-    whileStatement: JKWhileStatement,
+    condition: JKExpression,
+    body: JKStatement,
     forLoopUpdaters: List<JKStatement>
 ) : JKLoopStatement() {
     var variableDeclaration: JKStatement by child(variableDeclaration)
-    var whileStatement: JKWhileStatement by child(whileStatement)
+    var condition by child(condition)
+    override var body by child(body)
     // For the use in ContinueStatementConverter
     var forLoopUpdaters: List<JKStatement> by children(forLoopUpdaters)
-
-    // No child check because the parent of whileStatement.body is whileStatement
-    // and check will fail.
-    override var body: JKStatement
-        get() = whileStatement.body
-        set(v) {
-            whileStatement.body = v
-        }
 
     override fun accept(visitor: JKVisitor) = visitor.visitKtConvertedFromForLoopSyntheticWhileStatement(this)
 }

--- a/nj2k/src/org/jetbrains/kotlin/nj2k/tree/statements.kt
+++ b/nj2k/src/org/jetbrains/kotlin/nj2k/tree/statements.kt
@@ -29,10 +29,10 @@ class JKDoWhileStatement(body: JKStatement, condition: JKExpression) : JKLoopSta
     override fun accept(visitor: JKVisitor) = visitor.visitDoWhileStatement(this)
 }
 
-class JKForInStatement(declaration: JKDeclaration, iterationExpression: JKExpression, body: JKStatement) : JKStatement() {
+class JKForInStatement(declaration: JKDeclaration, iterationExpression: JKExpression, body: JKStatement) : JKLoopStatement() {
     var declaration: JKDeclaration by child(declaration)
     var iterationExpression: JKExpression by child(iterationExpression)
-    var body: JKStatement by child(body)
+    override var body by child(body)
     override fun accept(visitor: JKVisitor) = visitor.visitForInStatement(this)
 }
 
@@ -84,12 +84,22 @@ class JKKtWhenStatement(
 
 class JKKtConvertedFromForLoopSyntheticWhileStatement(
     variableDeclaration: JKStatement,
-    whileStatement: JKWhileStatement
-) : JKStatement() {
+    whileStatement: JKWhileStatement,
+    forLoopUpdaters: List<JKStatement>
+) : JKLoopStatement() {
     var variableDeclaration: JKStatement by child(variableDeclaration)
     var whileStatement: JKWhileStatement by child(whileStatement)
     // For the use in ContinueStatementConverter
-    var forLoopUpdaters: List<JKStatement> = listOf()
+    var forLoopUpdaters: List<JKStatement> by children(forLoopUpdaters)
+
+    // No child check because the parent of whileStatement.body is whileStatement
+    // and check will fail.
+    override var body: JKStatement
+        get() = whileStatement.body
+        set(v) {
+            whileStatement.body = v
+        }
+
     override fun accept(visitor: JKVisitor) = visitor.visitKtConvertedFromForLoopSyntheticWhileStatement(this)
 }
 

--- a/nj2k/src/org/jetbrains/kotlin/nj2k/tree/statements.kt
+++ b/nj2k/src/org/jetbrains/kotlin/nj2k/tree/statements.kt
@@ -88,6 +88,8 @@ class JKKtConvertedFromForLoopSyntheticWhileStatement(
 ) : JKStatement() {
     var variableDeclaration: JKStatement by child(variableDeclaration)
     var whileStatement: JKWhileStatement by child(whileStatement)
+    // For the use in ContinueStatementConverter
+    var forLoopUpdaters: List<JKStatement> = listOf()
     override fun accept(visitor: JKVisitor) = visitor.visitKtConvertedFromForLoopSyntheticWhileStatement(this)
 }
 

--- a/nj2k/testData/newJ2k/switch/KT-19554.java
+++ b/nj2k/testData/newJ2k/switch/KT-19554.java
@@ -1,0 +1,23 @@
+public class TestContinueInSwitchInFor {
+    public void foo(char[] cc) {
+        int a = 0;
+        int b = 0;
+        int c = 0;
+        for (int i = 0; i < cc.length && cc[i] != ';'; ++i) {
+            switch (cc[i]) {
+                case ' ':
+                    continue;
+                case 'a':
+                    a++;
+                    break;
+                case 'b':
+                    b++;
+                    break;
+                case 'c':
+                    c++;
+                    break;
+            }
+        }
+        System.out.println("a = " + a + "; b = " + b + "; c = " + c);
+    }
+}

--- a/nj2k/testData/newJ2k/switch/KT-19554.java
+++ b/nj2k/testData/newJ2k/switch/KT-19554.java
@@ -40,4 +40,40 @@ public class TestContinueInSwitchInFor {
         }
         System.out.println("a = " + a + "; b = " + b + "; c = " + c);
     }
+
+    public void fooWithNestedLabel(char[] cc) {
+        Loop: for (int i = 0; i < cc.length && cc[i] != ';'; ++i) {
+            switch (cc[i]) {
+                case ' ':
+                    continue;
+                case 'a':
+                    a++;
+                    break;
+                case 'b':
+                    b++;
+                    break;
+                case 'c':
+                    c++;
+                    break;
+                case 'x':
+                    for (int i = 0; i < cc.length && cc[i] != ';'; ++i) {
+                        switch (cc[i]) {
+                            case ' ':
+                                continue Loop;
+                            case 'a':
+                                a++;
+                                break;
+                            case 'b':
+                                b++;
+                                break;
+                            case 'c':
+                                c++;
+                                break;
+                        }
+                        break;
+                    }
+            }
+        }
+        System.out.println("a = " + a + "; b = " + b + "; c = " + c);
+    }
 }

--- a/nj2k/testData/newJ2k/switch/KT-19554.java
+++ b/nj2k/testData/newJ2k/switch/KT-19554.java
@@ -1,12 +1,32 @@
 public class TestContinueInSwitchInFor {
+    private int a = 0;
+    private int b = 0;
+    private int c = 0;
+
     public void foo(char[] cc) {
-        int a = 0;
-        int b = 0;
-        int c = 0;
         for (int i = 0; i < cc.length && cc[i] != ';'; ++i) {
             switch (cc[i]) {
                 case ' ':
                     continue;
+                case 'a':
+                    a++;
+                    break;
+                case 'b':
+                    b++;
+                    break;
+                case 'c':
+                    c++;
+                    break;
+            }
+        }
+        System.out.println("a = " + a + "; b = " + b + "; c = " + c);
+    }
+
+    public void fooWithLabel(char[] cc) {
+        Loop: for (int i = 0; i < cc.length && cc[i] != ';'; ++i) {
+            switch (cc[i]) {
+                case ' ':
+                    continue Loop;
                 case 'a':
                     a++;
                     break;

--- a/nj2k/testData/newJ2k/switch/KT-19554.kt
+++ b/nj2k/testData/newJ2k/switch/KT-19554.kt
@@ -1,14 +1,32 @@
 class TestContinueInSwitchInFor {
+    private var a = 0
+    private var b = 0
+    private var c = 0
+
     fun foo(cc: CharArray) {
-        var a = 0
-        var b = 0
-        var c = 0
         var i = 0
         loop@ while (i < cc.size && cc[i] != ';') {
             when (cc[i]) {
                 ' ' -> {
                     ++i
                     continue@loop
+                }
+                'a' -> a++
+                'b' -> b++
+                'c' -> c++
+            }
+            ++i
+        }
+        println("a = $a; b = $b; c = $c")
+    }
+
+    fun fooWithLabel(cc: CharArray) {
+        var i = 0
+        Loop@ while (i < cc.size && cc[i] != ';') {
+            when (cc[i]) {
+                ' ' -> {
+                    ++i
+                    continue@Loop
                 }
                 'a' -> a++
                 'b' -> b++

--- a/nj2k/testData/newJ2k/switch/KT-19554.kt
+++ b/nj2k/testData/newJ2k/switch/KT-19554.kt
@@ -1,0 +1,21 @@
+class TestContinueInSwitchInFor {
+    fun foo(cc: CharArray) {
+        var a = 0
+        var b = 0
+        var c = 0
+        var i = 0
+        loop@ while (i < cc.size && cc[i] != ';') {
+            when (cc[i]) {
+                ' ' -> {
+                    ++i
+                    continue@loop
+                }
+                'a' -> a++
+                'b' -> b++
+                'c' -> c++
+            }
+            ++i
+        }
+        println("a = $a; b = $b; c = $c")
+    }
+}

--- a/nj2k/testData/newJ2k/switch/KT-19554.kt
+++ b/nj2k/testData/newJ2k/switch/KT-19554.kt
@@ -36,4 +36,36 @@ class TestContinueInSwitchInFor {
         }
         println("a = $a; b = $b; c = $c")
     }
+
+    fun fooWithNestedLabel(cc: CharArray) {
+        var i = 0
+        Loop@ while (i < cc.size && cc[i] != ';') {
+            when (cc[i]) {
+                ' ' -> {
+                    ++i
+                    continue@Loop
+                }
+                'a' -> a++
+                'b' -> b++
+                'c' -> c++
+                'x' -> run {
+                    var i = 0
+                    while (i < cc.size && cc[i] != ';') {
+                        when (cc[i]) {
+                            ' ' -> {
+                                ++i
+                                continue@Loop
+                            }
+                            'a' -> a++
+                            'b' -> b++
+                            'c' -> c++
+                        }
+                        break
+                    }
+                }
+            }
+            ++i
+        }
+        println("a = $a; b = $b; c = $c")
+    }
 }

--- a/nj2k/testData/newJ2k/switch/KT-34069.java
+++ b/nj2k/testData/newJ2k/switch/KT-34069.java
@@ -25,6 +25,28 @@ public class TestContinueInSwitchInForeach {
         System.out.println("a = " + a + "; b = " + b + "; c = " + c);
     }
 
+    public void fooWithLabel(char[] cc) {
+        Loop: for (char ccc : cc) {
+            if (ccc == ';') {
+                continue;
+            }
+            switch (ccc) {
+                case ' ':
+                    continue Loop;
+                case 'a':
+                    a++;
+                    break;
+                case 'b':
+                    b++;
+                    break;
+                case 'c':
+                    c++;
+                    break;
+            }
+        }
+        System.out.println("a = " + a + "; b = " + b + "; c = " + c);
+    }
+
     public void bar(char[] cc) {
         for (int i = 0; i < 10; i++) {
             switch (cc[i]) {
@@ -32,6 +54,27 @@ public class TestContinueInSwitchInForeach {
                     continue;
                 case ' ':
                     continue;
+                case 'a':
+                    a++;
+                    break;
+                case 'b':
+                    b++;
+                    break;
+                case 'c':
+                    c++;
+                    break;
+            }
+        }
+        System.out.println("a = " + a + "; b = " + b + "; c = " + c);
+    }
+
+    public void barWithLabel(char[] cc) {
+        Loop: for (int i = 0; i < 10; i++) {
+            switch (cc[i]) {
+                case ';':
+                    continue Loop;
+                case ' ':
+                    continue Loop;
                 case 'a':
                     a++;
                     break;

--- a/nj2k/testData/newJ2k/switch/KT-34069.java
+++ b/nj2k/testData/newJ2k/switch/KT-34069.java
@@ -1,0 +1,48 @@
+public class TestContinueInSwitchInForeach {
+    private int a = 0;
+    private int b = 0;
+    private int c = 0;
+
+    public void foo(char[] cc) {
+        for (char ccc : cc) {
+            if (ccc == ';') {
+                continue;
+            }
+            switch (ccc) {
+                case ' ':
+                    continue;
+                case 'a':
+                    a++;
+                    break;
+                case 'b':
+                    b++;
+                    break;
+                case 'c':
+                    c++;
+                    break;
+            }
+        }
+        System.out.println("a = " + a + "; b = " + b + "; c = " + c);
+    }
+
+    public void bar(char[] cc) {
+        for (int i = 0; i < 10; i++) {
+            switch (cc[i]) {
+                case ';':
+                    continue;
+                case ' ':
+                    continue;
+                case 'a':
+                    a++;
+                    break;
+                case 'b':
+                    b++;
+                    break;
+                case 'c':
+                    c++;
+                    break;
+            }
+        }
+        System.out.println("a = " + a + "; b = " + b + "; c = " + c);
+    }
+}

--- a/nj2k/testData/newJ2k/switch/KT-34069.kt
+++ b/nj2k/testData/newJ2k/switch/KT-34069.kt
@@ -18,11 +18,39 @@ class TestContinueInSwitchInForeach {
         println("a = $a; b = $b; c = $c")
     }
 
+    fun fooWithLabel(cc: CharArray) {
+        Loop@ for (ccc in cc) {
+            if (ccc == ';') {
+                continue
+            }
+            when (ccc) {
+                ' ' -> continue@Loop
+                'a' -> a++
+                'b' -> b++
+                'c' -> c++
+            }
+        }
+        println("a = $a; b = $b; c = $c")
+    }
+
     fun bar(cc: CharArray) {
         loop@ for (i in 0..9) {
             when (cc[i]) {
                 ';' -> continue@loop
                 ' ' -> continue@loop
+                'a' -> a++
+                'b' -> b++
+                'c' -> c++
+            }
+        }
+        println("a = $a; b = $b; c = $c")
+    }
+
+    fun barWithLabel(cc: CharArray) {
+        Loop@ for (i in 0..9) {
+            when (cc[i]) {
+                ';' -> continue@Loop
+                ' ' -> continue@Loop
                 'a' -> a++
                 'b' -> b++
                 'c' -> c++

--- a/nj2k/testData/newJ2k/switch/KT-34069.kt
+++ b/nj2k/testData/newJ2k/switch/KT-34069.kt
@@ -1,0 +1,33 @@
+class TestContinueInSwitchInForeach {
+    private var a = 0
+    private var b = 0
+    private var c = 0
+
+    fun foo(cc: CharArray) {
+        loop@ for (ccc in cc) {
+            if (ccc == ';') {
+                continue
+            }
+            when (ccc) {
+                ' ' -> continue@loop
+                'a' -> a++
+                'b' -> b++
+                'c' -> c++
+            }
+        }
+        println("a = $a; b = $b; c = $c")
+    }
+
+    fun bar(cc: CharArray) {
+        loop@ for (i in 0..9) {
+            when (cc[i]) {
+                ';' -> continue@loop
+                ' ' -> continue@loop
+                'a' -> a++
+                'b' -> b++
+                'c' -> c++
+            }
+        }
+        println("a = $a; b = $b; c = $c")
+    }
+}

--- a/nj2k/testData/newJ2k/switch/continueAndBreakWithLabel.kt
+++ b/nj2k/testData/newJ2k/switch/continueAndBreakWithLabel.kt
@@ -1,7 +1,7 @@
 fun foo() {
-    Loop@ while (true) {
+    Loop@ loop@ while (true) {
         when (take()) {
-            1 -> continue
+            1 -> continue@loop
             2 -> {
                 println("2")
                 return

--- a/nj2k/testData/newJ2k/switch/continueAndBreakWithLabel.kt
+++ b/nj2k/testData/newJ2k/switch/continueAndBreakWithLabel.kt
@@ -1,7 +1,7 @@
 fun foo() {
-    Loop@ loop@ while (true) {
+    Loop@ while (true) {
         when (take()) {
-            1 -> continue@loop
+            1 -> continue@Loop
             2 -> {
                 println("2")
                 return

--- a/nj2k/tests/org/jetbrains/kotlin/nj2k/NewJavaToKotlinConverterSingleFileTestGenerated.java
+++ b/nj2k/tests/org/jetbrains/kotlin/nj2k/NewJavaToKotlinConverterSingleFileTestGenerated.java
@@ -4615,6 +4615,11 @@ public class NewJavaToKotlinConverterSingleFileTestGenerated extends AbstractNew
             runTest("nj2k/testData/newJ2k/switch/KT-19554.java");
         }
 
+        @TestMetadata("KT-34069.java")
+        public void testKT_34069() throws Exception {
+            runTest("nj2k/testData/newJ2k/switch/KT-34069.java");
+        }
+
         @TestMetadata("kt-539.java")
         public void testKt_539() throws Exception {
             runTest("nj2k/testData/newJ2k/switch/kt-539.java");

--- a/nj2k/tests/org/jetbrains/kotlin/nj2k/NewJavaToKotlinConverterSingleFileTestGenerated.java
+++ b/nj2k/tests/org/jetbrains/kotlin/nj2k/NewJavaToKotlinConverterSingleFileTestGenerated.java
@@ -4610,6 +4610,11 @@ public class NewJavaToKotlinConverterSingleFileTestGenerated extends AbstractNew
             runTest("nj2k/testData/newJ2k/switch/KT-13552.java");
         }
 
+        @TestMetadata("KT-19554.java")
+        public void testKT_19554() throws Exception {
+            runTest("nj2k/testData/newJ2k/switch/KT-19554.java");
+        }
+
         @TestMetadata("kt-539.java")
         public void testKt_539() throws Exception {
             runTest("nj2k/testData/newJ2k/switch/kt-539.java");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-19554
https://youtrack.jetbrains.com/issue/KT-34069
