### PR TITLE
JVM IR: Hide constructors with inline class parameters

### DIFF
--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/ir/builders/declarations/declarationBuilders.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/ir/builders/declarations/declarationBuilders.kt
@@ -127,7 +127,7 @@ fun IrFunctionBuilder.buildFun(originalDescriptor: FunctionDescriptor? = null): 
     }
 }
 
-fun IrFunctionBuilder.buildConstructor(): IrConstructor {
+fun IrFunctionBuilder.buildConstructor(): IrConstructorImpl {
     val wrappedDescriptor = WrappedClassConstructorDescriptor()
     return IrConstructorImpl(
         startOffset, endOffset, origin,
@@ -179,13 +179,13 @@ fun IrDeclarationContainer.addFunction(
         }
     }
 
-inline fun buildConstructor(builder: IrFunctionBuilder.() -> Unit): IrConstructor =
+inline fun buildConstructor(builder: IrFunctionBuilder.() -> Unit): IrConstructorImpl =
     IrFunctionBuilder().run {
         builder()
         buildConstructor()
     }
 
-inline fun IrClass.addConstructor(builder: IrFunctionBuilder.() -> Unit = {}): IrConstructor =
+inline fun IrClass.addConstructor(builder: IrFunctionBuilder.() -> Unit = {}): IrConstructorImpl =
     buildConstructor {
         builder()
         returnType = defaultType

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmSymbols.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmSymbols.kt
@@ -427,6 +427,16 @@ class JvmSymbols(
     }
 
     val systemArraycopy: IrSimpleFunctionSymbol = systemClass.functionByName("arraycopy")
+
+    val signatureStringIntrinsic: IrSimpleFunctionSymbol =
+        buildFun {
+            name = Name.special("<signature-string>")
+            origin = IrDeclarationOrigin.IR_BUILTINS_STUB
+        }.apply {
+            parent = kotlinJvmInternalPackage
+            addValueParameter("v", irBuiltIns.anyNType)
+            returnType = irBuiltIns.stringType
+        }.symbol
 }
 
 private fun IrClassSymbol.functionByName(name: String): IrSimpleFunctionSymbol =

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/FunctionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/FunctionCodegen.kt
@@ -49,8 +49,7 @@ open class FunctionCodegen(
         val flags = calculateMethodFlags(functionView.isStatic)
         var methodVisitor = createMethod(flags, signature)
 
-        val hasSyntheticFlag = flags.and(Opcodes.ACC_SYNTHETIC) != 0
-        if (state.generateParametersMetadata && !hasSyntheticFlag) {
+        if (state.generateParametersMetadata && flags.and(Opcodes.ACC_SYNTHETIC) == 0) {
             generateParameterNames(irFunction, methodVisitor, signature, state)
         }
 
@@ -65,7 +64,7 @@ open class FunctionCodegen(
         // super constructor arguments, there shouldn't be any annotations on them other than @NonNull,
         // and those are meaningless on synthetic parameters. (Also, the inliner cannot handle them and
         // will throw an exception if we generate any.)
-        if (irFunction !is IrConstructor || (!hasSyntheticFlag && !irFunction.parentAsClass.isAnonymousObject)) {
+        if (irFunction !is IrConstructor || !irFunction.parentAsClass.isAnonymousObject) {
             generateParameterAnnotations(functionView, methodVisitor, signature, classCodegen, context)
         }
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/IrInlineCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/IrInlineCodegen.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.backend.jvm.codegen
 import org.jetbrains.kotlin.backend.common.descriptors.WrappedSimpleFunctionDescriptor
 import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
 import org.jetbrains.kotlin.backend.jvm.ir.isInlineParameter
+import org.jetbrains.kotlin.backend.jvm.ir.isLambda
 import org.jetbrains.kotlin.codegen.IrExpressionLambda
 import org.jetbrains.kotlin.codegen.JvmKotlinType
 import org.jetbrains.kotlin.codegen.StackValue
@@ -197,7 +198,7 @@ fun isInlineIrExpression(argumentExpression: IrExpression) =
         else -> false
     }
 
-fun IrBlock.isInlineIrBlock(): Boolean = origin == IrStatementOrigin.LAMBDA || origin == IrStatementOrigin.ANONYMOUS_FUNCTION
+fun IrBlock.isInlineIrBlock(): Boolean = origin.isLambda
 
 fun IrFunction.isInlineFunctionCall(context: JvmBackendContext) =
     (!context.state.isInlineDisabled || typeParameters.any { it.isReified }) && isInline

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/MethodSignatureMapper.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/MethodSignatureMapper.kt
@@ -30,8 +30,11 @@ import org.jetbrains.kotlin.ir.expressions.IrConst
 import org.jetbrains.kotlin.ir.expressions.IrFunctionAccessExpression
 import org.jetbrains.kotlin.ir.types.*
 import org.jetbrains.kotlin.ir.util.*
-import org.jetbrains.kotlin.load.java.*
+import org.jetbrains.kotlin.load.java.BuiltinMethodsWithSpecialGenericSignature
+import org.jetbrains.kotlin.load.java.JvmAbi
 import org.jetbrains.kotlin.load.java.descriptors.JavaClassDescriptor
+import org.jetbrains.kotlin.load.java.getJvmMethodNameIfSpecial
+import org.jetbrains.kotlin.load.java.getOverriddenBuiltinReflectingJvmDescriptor
 import org.jetbrains.kotlin.load.kotlin.TypeMappingMode
 import org.jetbrains.kotlin.load.kotlin.forceSingleValueParameterBoxing
 import org.jetbrains.kotlin.load.kotlin.getJvmModuleNameForDeserializedDescriptor
@@ -214,13 +217,6 @@ class MethodSignatureMapper(private val context: JvmBackendContext) {
         val receiverParameter = function.extensionReceiverParameter
         if (receiverParameter != null) {
             writeParameter(sw, JvmMethodParameterKind.RECEIVER, receiverParameter.type, function)
-        }
-
-        // This is needed because mapSignature is currently invoked in CallableReferenceLowering before InnerClassesLowering where
-        // this parameter is transformed to a normal value parameter.
-        // TODO: do not call mapSignature in CallableReferenceLowering
-        if (function is IrConstructor && function.dispatchReceiverParameter != null) {
-            writeParameter(sw, JvmMethodParameterKind.VALUE, function.dispatchReceiverParameter!!.type, function)
         }
 
         for (parameter in function.valueParameters) {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/irCodegenUtils.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/irCodegenUtils.kt
@@ -188,18 +188,6 @@ private fun IrDeclarationWithVisibility.specialCaseVisibility(kind: OwnerKind?):
         return Opcodes.ACC_PRIVATE
     }
 
-//    if (kind !== OwnerKind.ERASED_INLINE_CLASS &&
-//        memberDescriptor is ConstructorDescriptor &&
-//        memberDescriptor !is AccessorForConstructorDescriptor &&
-//        shouldHideConstructorDueToInlineClassTypeValueParameters(memberDescriptor)
-//    ) {
-    if (kind !== OwnerKind.ERASED_INLINE_CLASS &&
-        this is IrConstructor &&
-        shouldHideDueToInlineClassTypeValueParameters()
-    ) {
-        return Opcodes.ACC_PRIVATE
-    }
-
 //    if (memberDescriptor.isEffectivelyInlineOnly()) {
     if (isEffectivelyInlineOnly()) {
         return Opcodes.ACC_PRIVATE
@@ -285,30 +273,6 @@ private fun IrDeclarationWithVisibility.specialCaseVisibility(kind: OwnerKind?):
 
     return null
 }
-
-/* From inlineClassManglingRules.kt */
-fun IrConstructor.shouldHideDueToInlineClassTypeValueParameters() =
-    !Visibilities.isPrivate(visibility) &&
-            !parentAsClass.isInline &&
-            parentAsClass.modality !== Modality.SEALED &&
-            valueParameters.any { it.type.requiresFunctionNameMangling() }
-
-fun IrType.requiresFunctionNameMangling(): Boolean =
-    isInlineClassThatRequiresMangling() || isTypeParameterWithUpperBoundThatRequiresMangling()
-
-fun IrType.isInlineClassThatRequiresMangling() =
-    safeAs<IrSimpleType>()?.classifier?.owner?.safeAs<IrClass>()?.let {
-        it.isInline && !it.isDontMangleClass()
-    } ?: false
-
-fun IrClass.isDontMangleClass() =
-    fqNameWhenAvailable != DescriptorUtils.RESULT_FQ_NAME
-
-fun IrType.isTypeParameterWithUpperBoundThatRequiresMangling() =
-    safeAs<IrSimpleType>()?.classifier?.owner.safeAs<IrTypeParameter>()?.let { param ->
-        param.superTypes.any { it.requiresFunctionNameMangling() }
-    } ?: false
-
 
 /* Borrowed from InlineUtil. */
 private tailrec fun isInlineOrContainedInInline(declaration: IrDeclaration?): Boolean = when {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/IrIntrinsicMethods.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/IrIntrinsicMethods.kt
@@ -96,7 +96,8 @@ class IrIntrinsicMethods(val irBuiltIns: IrBuiltIns, val symbols: JvmSymbols) {
                 irBuiltIns.checkNotNullSymbol.toKey()!! to IrCheckNotNull,
                 irBuiltIns.andandSymbol.toKey()!! to AndAnd,
                 irBuiltIns.ororSymbol.toKey()!! to OrOr,
-                symbols.unsafeCoerceIntrinsic.toKey()!! to UnsafeCoerce
+                symbols.unsafeCoerceIntrinsic.toKey()!! to UnsafeCoerce,
+                symbols.signatureStringIntrinsic.toKey()!! to SignatureString
             ) +
                     numberConversionMethods() +
                     unaryFunForPrimitives("plus", UnaryPlus) +

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/SignatureString.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/SignatureString.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.jvm.intrinsics
+
+import org.jetbrains.kotlin.backend.jvm.codegen.BlockInfo
+import org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen
+import org.jetbrains.kotlin.backend.jvm.codegen.PromisedValue
+import org.jetbrains.kotlin.ir.expressions.IrFunctionAccessExpression
+import org.jetbrains.kotlin.ir.expressions.IrFunctionReference
+import org.jetbrains.kotlin.resolve.DescriptorUtils
+import org.jetbrains.kotlin.resolve.jvm.AsmTypes
+
+/**
+ * Computes the JVM signature of a given IrFunction. The function is passed as an IrFunctionReference
+ * to the single argument of the intrinsic.
+ */
+object SignatureString : IntrinsicMethod() {
+    override fun invoke(expression: IrFunctionAccessExpression, codegen: ExpressionCodegen, data: BlockInfo): PromisedValue? {
+        val function = (expression.getValueArgument(0) as IrFunctionReference).symbol.owner
+
+        // TODO do not use descriptors
+        val declaration = codegen.context.referenceFunction(
+            DescriptorUtils.unwrapFakeOverride(function.descriptor).original
+        ).owner
+
+        val method = codegen.context.methodSignatureMapper.mapAsmMethod(declaration)
+        val descriptor = method.name + method.descriptor
+
+        return object : PromisedValue(codegen, AsmTypes.JAVA_STRING_TYPE, codegen.context.irBuiltIns.stringType) {
+            override fun materialize() {
+                codegen.mv.aconst(descriptor)
+            }
+        }
+    }
+}

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/ir/IrUtils.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/ir/IrUtils.kt
@@ -9,12 +9,15 @@ import org.jetbrains.kotlin.backend.common.lower.IrLoweringContext
 import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
 import org.jetbrains.kotlin.backend.jvm.JvmSymbols
 import org.jetbrains.kotlin.backend.jvm.codegen.isJvmInterface
+import org.jetbrains.kotlin.backend.jvm.lower.inlineclasses.hasMangledParameters
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
+import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
 import org.jetbrains.kotlin.ir.builders.IrBuilderWithScope
 import org.jetbrains.kotlin.ir.builders.Scope
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.descriptors.IrBuiltIns
+import org.jetbrains.kotlin.ir.expressions.IrConst
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.IrSymbol
 import org.jetbrains.kotlin.ir.symbols.IrTypeParameterSymbol
@@ -95,6 +98,9 @@ fun IrType.getArrayElementType(irBuiltIns: IrBuiltIns): IrType =
         ((this as IrSimpleType).arguments.single() as IrTypeProjection).type
     else
         irBuiltIns.primitiveArrayElementTypes.getValue(this.classOrNull!!)
+
+val IrConstructor.shouldBeHidden: Boolean
+    get() = !Visibilities.isPrivate(visibility) && !constructedClass.isInline && hasMangledParameters
 
 // An IR builder with a reference to the JvmBackendContext
 class JvmIrBuilder(

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/ir/IrUtils.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/ir/IrUtils.kt
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.ir.builders.IrBuilderWithScope
 import org.jetbrains.kotlin.ir.builders.Scope
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.descriptors.IrBuiltIns
-import org.jetbrains.kotlin.ir.expressions.IrConst
+import org.jetbrains.kotlin.ir.expressions.IrStatementOrigin
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.IrSymbol
 import org.jetbrains.kotlin.ir.symbols.IrTypeParameterSymbol
@@ -98,6 +98,9 @@ fun IrType.getArrayElementType(irBuiltIns: IrBuiltIns): IrType =
         ((this as IrSimpleType).arguments.single() as IrTypeProjection).type
     else
         irBuiltIns.primitiveArrayElementTypes.getValue(this.classOrNull!!)
+
+val IrStatementOrigin?.isLambda
+    get() = this == IrStatementOrigin.LAMBDA || this == IrStatementOrigin.ANONYMOUS_FUNCTION
 
 val IrConstructor.shouldBeHidden: Boolean
     get() = !Visibilities.isPrivate(visibility) && !constructedClass.isInline && hasMangledParameters

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/ir/IrUtils.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/ir/IrUtils.kt
@@ -99,7 +99,7 @@ fun IrType.getArrayElementType(irBuiltIns: IrBuiltIns): IrType =
     else
         irBuiltIns.primitiveArrayElementTypes.getValue(this.classOrNull!!)
 
-val IrStatementOrigin?.isLambda
+val IrStatementOrigin?.isLambda: Boolean
     get() = this == IrStatementOrigin.LAMBDA || this == IrStatementOrigin.ANONYMOUS_FUNCTION
 
 val IrConstructor.shouldBeHidden: Boolean

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/CallableReferenceLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/CallableReferenceLowering.kt
@@ -48,9 +48,6 @@ internal val callableReferencePhase = makeIrFilePhase(
     description = "Handle callable references"
 )
 
-private val IrStatementOrigin?.isLambda
-    get() = this == IrStatementOrigin.LAMBDA || this == IrStatementOrigin.ANONYMOUS_FUNCTION
-
 internal class InlineReferenceLocator(private val context: JvmBackendContext) : IrElementVisitorVoidWithContext() {
     val inlineReferences = mutableSetOf<IrFunctionReference>()
 
@@ -379,11 +376,7 @@ internal class CallableReferenceLowering(private val context: JvmBackendContext)
         private fun createGetSignatureMethod(superFunction: IrSimpleFunction): IrSimpleFunction = buildOverride(superFunction).apply {
             body = context.createJvmIrBuilder(symbol, startOffset, endOffset).run {
                 irExprBody(irCall(backendContext.ir.symbols.signatureStringIntrinsic).apply {
-                    putValueArgument(0, with(irFunctionReference) {
-                        IrFunctionReferenceImpl(
-                            startOffset, endOffset, type, symbol, descriptor, typeArgumentsCount, valueArgumentsCount, origin
-                        )
-                    })
+                    putValueArgument(0, irFunctionReference.deepCopyWithSymbols(symbol.owner))
                 })
             }
         }

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/CallableReferenceLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/CallableReferenceLowering.kt
@@ -19,7 +19,7 @@ import org.jetbrains.kotlin.backend.jvm.codegen.isInlineIrExpression
 import org.jetbrains.kotlin.backend.jvm.ir.createJvmIrBuilder
 import org.jetbrains.kotlin.backend.jvm.ir.irArray
 import org.jetbrains.kotlin.backend.jvm.ir.isInlineParameter
-import org.jetbrains.kotlin.backend.jvm.ir.shouldBeHidden
+import org.jetbrains.kotlin.backend.jvm.ir.isLambda
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.ir.IrElement
@@ -32,6 +32,7 @@ import org.jetbrains.kotlin.ir.builders.declarations.buildClass
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.expressions.impl.IrClassReferenceImpl
+import org.jetbrains.kotlin.ir.expressions.impl.IrFunctionReferenceImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrInstanceInitializerCallImpl
 import org.jetbrains.kotlin.ir.types.*
 import org.jetbrains.kotlin.ir.util.*
@@ -40,8 +41,6 @@ import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
 import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.name.SpecialNames
-import org.jetbrains.kotlin.resolve.DescriptorUtils
-import org.jetbrains.org.objectweb.asm.Type
 
 internal val callableReferencePhase = makeIrFilePhase(
     ::CallableReferenceLowering,
@@ -378,24 +377,14 @@ internal class CallableReferenceLowering(private val context: JvmBackendContext)
             get() = (metadata as? MetadataSource.Function)?.descriptor?.name ?: name
 
         private fun createGetSignatureMethod(superFunction: IrSimpleFunction): IrSimpleFunction = buildOverride(superFunction).apply {
-            val codegenContext = context
-            body = context.createIrBuilder(symbol, startOffset, endOffset).run {
-                // TODO do not use descriptors
-                val declaration = codegenContext.referenceFunction(
-                    DescriptorUtils.unwrapFakeOverride(irFunctionReference.symbol.descriptor).original
-                ).owner
-                val method = codegenContext.methodSignatureMapper.mapAsmMethod(declaration)
-                // HACK: When referencing a constructor taking inline class parameters, we will actually
-                //       end up calling a public bridge method with an additional argument.
-                // TODO: Don't compute signatures in CallableReferenceLowering
-                val descriptor = if (declaration is IrConstructor && declaration.shouldBeHidden) {
-                    val marker =
-                        codegenContext.typeMapper.mapType(codegenContext.ir.symbols.defaultConstructorMarker.owner.defaultType)
-                    Type.getMethodDescriptor(method.returnType, *method.argumentTypes, marker)
-                } else {
-                    method.descriptor
-                }
-                irExprBody(irString(method.name + descriptor))
+            body = context.createJvmIrBuilder(symbol, startOffset, endOffset).run {
+                irExprBody(irCall(backendContext.ir.symbols.signatureStringIntrinsic).apply {
+                    putValueArgument(0, with(irFunctionReference) {
+                        IrFunctionReferenceImpl(
+                            startOffset, endOffset, type, symbol, descriptor, typeArgumentsCount, valueArgumentsCount, origin
+                        )
+                    })
+                })
             }
         }
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/CallableReferenceLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/CallableReferenceLowering.kt
@@ -38,6 +38,7 @@ import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
 import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
 import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.name.SpecialNames
 import org.jetbrains.kotlin.resolve.DescriptorUtils
 
 internal val callableReferencePhase = makeIrFilePhase(
@@ -175,7 +176,7 @@ internal class CallableReferenceLowering(private val context: JvmBackendContext)
             // A callable reference results in a synthetic class, while a lambda is not synthetic.
             // We don't produce GENERATED_SAM_IMPLEMENTATION, which is always synthetic.
             origin = if (isLambda) JvmLoweredDeclarationOrigin.LAMBDA_IMPL else JvmLoweredDeclarationOrigin.FUNCTION_REFERENCE_IMPL
-            name = Name.special("<function reference to ${callee.fqNameWhenAvailable}>")
+            name = SpecialNames.NO_NAME_PROVIDED
         }.apply {
             parent = currentDeclarationParent
             superTypes += superType

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/PropertyReferenceLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/PropertyReferenceLowering.kt
@@ -33,6 +33,7 @@ import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
 import org.jetbrains.kotlin.load.java.JavaVisibilities
 import org.jetbrains.kotlin.load.java.JvmAbi
 import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.name.SpecialNames
 import org.jetbrains.kotlin.types.Variance
 
 internal val propertyReferencePhase = makeIrFilePhase(
@@ -227,7 +228,7 @@ internal class PropertyReferenceLowering(val context: JvmBackendContext) : Class
                 val superClass = propertyReferenceKindFor(expression).interfaceSymbol.owner
                 val referenceClass = buildClass {
                     setSourceRange(expression)
-                    name = Name.special("<property reference to ${(expression.symbol.owner as IrDeclarationWithName).fqNameWhenAvailable}>")
+                    name = SpecialNames.NO_NAME_PROVIDED
                     origin = JvmLoweredDeclarationOrigin.GENERATED_PROPERTY_REFERENCE
                     visibility = Visibilities.LOCAL
                 }.apply {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/RemoveDeclarationsThatWouldBeInlinedLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/RemoveDeclarationsThatWouldBeInlinedLowering.kt
@@ -8,13 +8,13 @@ package org.jetbrains.kotlin.backend.jvm.lower
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.phaser.makeIrFilePhase
 import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
+import org.jetbrains.kotlin.backend.jvm.ir.isLambda
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.expressions.IrFunctionReference
-import org.jetbrains.kotlin.ir.expressions.IrStatementOrigin
 import org.jetbrains.kotlin.ir.visitors.*
 
 internal val removeDeclarationsThatWouldBeInlined = makeIrFilePhase(
@@ -36,8 +36,10 @@ private class RemoveDeclarationsThatWouldBeInlinedLowering(val context: JvmBacke
             override fun visitElement(element: IrElement) = element.acceptChildrenVoid(this)
 
             override fun visitFunctionReference(expression: IrFunctionReference) {
-                assert(expression.origin == IrStatementOrigin.LAMBDA || expression.origin == IrStatementOrigin.ANONYMOUS_FUNCTION)
-                loweredLambdasToDelete.add(expression.symbol.owner)
+                if (expression.origin.isLambda) {
+                    loweredLambdasToDelete.add(expression.symbol.owner)
+                }
+
                 expression.acceptChildrenVoid(this)
             }
         })

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/SyntheticAccessorLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/SyntheticAccessorLowering.kt
@@ -11,10 +11,10 @@ import org.jetbrains.kotlin.backend.common.ir.copyTypeParametersFrom
 import org.jetbrains.kotlin.backend.common.ir.copyValueParametersToStatic
 import org.jetbrains.kotlin.backend.common.ir.passTypeArgumentsFrom
 import org.jetbrains.kotlin.backend.common.ir.remapTypeParameters
-import org.jetbrains.kotlin.backend.common.phaser.makeIrFilePhase
 import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
 import org.jetbrains.kotlin.backend.jvm.JvmLoweredDeclarationOrigin
 import org.jetbrains.kotlin.backend.jvm.intrinsics.receiverAndArgs
+import org.jetbrains.kotlin.backend.jvm.ir.shouldBeHidden
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.descriptors.Visibility
@@ -24,6 +24,7 @@ import org.jetbrains.kotlin.ir.builders.declarations.addValueParameter
 import org.jetbrains.kotlin.ir.builders.declarations.buildConstructor
 import org.jetbrains.kotlin.ir.builders.declarations.buildFun
 import org.jetbrains.kotlin.ir.declarations.*
+import org.jetbrains.kotlin.ir.declarations.impl.IrConstructorImpl
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.expressions.impl.*
 import org.jetbrains.kotlin.ir.symbols.*
@@ -32,10 +33,13 @@ import org.jetbrains.kotlin.ir.types.classifierOrNull
 import org.jetbrains.kotlin.ir.types.isSubtypeOfClass
 import org.jetbrains.kotlin.ir.types.makeNullable
 import org.jetbrains.kotlin.ir.util.*
+import org.jetbrains.kotlin.ir.visitors.IrElementVisitorVoid
+import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
 import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
 import org.jetbrains.kotlin.load.java.JavaVisibilities
 import org.jetbrains.kotlin.load.java.JvmAbi
 import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 
 internal class SyntheticAccessorLowering(val context: JvmBackendContext) : IrElementTransformerVoidWithContext(), FileLoweringPass {
     private val pendingTransformations = mutableListOf<Function0<Unit>>()
@@ -43,6 +47,44 @@ internal class SyntheticAccessorLowering(val context: JvmBackendContext) : IrEle
 
     override fun lower(irFile: IrFile) {
         inlineLambdaToCallSite.putAll(InlineReferenceLocator.scan(context, irFile).lambdaToCallSite)
+
+        // Unconditionally add bridges for hidden constructors
+        irFile.acceptChildrenVoid(object: IrElementVisitorVoid {
+            override fun visitElement(element: IrElement) = element.acceptChildrenVoid(this)
+
+            private fun handleConstructor(declaration: IrConstructor) {
+                if (!declaration.shouldBeHidden)
+                    return
+
+                declaration.visibility = Visibilities.PRIVATE
+
+                functionMap.computeIfAbsent(declaration.symbol) {
+                    declaration.makeConstructorAccessor().also { accessor ->
+                        // There's a special case in the JVM backend for serializing the metadata of hidden
+                        // constructors - we serialize the descriptor of the original constructor, but the
+                        // signature of the bridge. We implement this special case in the JVM IR backend by
+                        // attaching the metadata directly to the bridge. We also have to move all annotations
+                        // to the bridge method. Parameter annotations are already moved by the copyTo method.
+                        accessor.metadata = declaration.metadata
+                        declaration.safeAs<IrConstructorImpl>()?.metadata = null
+                        accessor.annotations += declaration.annotations
+                        declaration.annotations.clear()
+                        declaration.valueParameters.forEach { it.annotations.clear() }
+                    }.symbol
+                }
+            }
+
+            override fun visitConstructor(declaration: IrConstructor) {
+                handleConstructor(declaration)
+                super.visitConstructor(declaration)
+            }
+
+            override fun visitConstructorCall(expression: IrConstructorCall) {
+                handleConstructor(expression.symbol.owner)
+                super.visitConstructorCall(expression)
+            }
+        })
+
         irFile.transformChildrenVoid(this)
         pendingTransformations.forEach { it() }
     }
@@ -108,7 +150,7 @@ internal class SyntheticAccessorLowering(val context: JvmBackendContext) : IrEle
             classes.lastOrNull { parent is IrClass && it.isSubclassOf(parent) } ?: classes.last()
         } else parent
 
-    private fun IrConstructor.makeConstructorAccessor(): IrConstructor {
+    private fun IrConstructor.makeConstructorAccessor(): IrConstructorImpl {
         val source = this
 
         return buildConstructor {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/inlineclasses/InlineClassAbi.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/inlineclasses/InlineClassAbi.kt
@@ -91,14 +91,19 @@ object InlineClassAbi {
     }
 }
 
-internal val IrType.requiresMangling: Boolean
+private val IrType.requiresMangling: Boolean
     get() {
         val irClass = erasedUpperBound
         return irClass.isInline && irClass.fqNameWhenAvailable != DescriptorUtils.RESULT_FQ_NAME
     }
 
-internal val IrFunction.fullValueParameterList: List<IrValueParameter>
+private val IrFunction.fullValueParameterList: List<IrValueParameter>
     get() = listOfNotNull(extensionReceiverParameter) + valueParameters
+
+internal val IrFunction.hasMangledParameters: Boolean
+    get() = dispatchReceiverParameter?.type?.getClass()?.isInline == true ||
+            fullValueParameterList.any { it.type.requiresMangling } ||
+            (this is IrConstructor && constructedClass.isInline)
 
 internal val IrClass.inlineClassFieldName: Name
     get() = primaryConstructor!!.valueParameters.single().name

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/inlineclasses/MemoizedInlineClassReplacements.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/inlineclasses/MemoizedInlineClassReplacements.kt
@@ -20,7 +20,6 @@ import org.jetbrains.kotlin.ir.declarations.impl.IrFunctionImpl
 import org.jetbrains.kotlin.ir.descriptors.IrBuiltIns
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.symbols.IrValueParameterSymbol
-import org.jetbrains.kotlin.ir.types.getClass
 import org.jetbrains.kotlin.ir.types.impl.IrSimpleTypeImpl
 import org.jetbrains.kotlin.ir.types.impl.IrStarProjectionImpl
 import org.jetbrains.kotlin.ir.util.constructedClass
@@ -56,11 +55,6 @@ class MemoizedInlineClassReplacements {
                 else -> null
             }
         }
-
-    private val IrFunction.hasMangledParameters: Boolean
-        get() = dispatchReceiverParameter?.type?.getClass()?.isInline == true ||
-                fullValueParameterList.any { it.type.requiresMangling } ||
-                (this is IrConstructor && constructedClass.isInline)
 
     private val IrFunction.hasStaticReplacement: Boolean
         get() = origin != IrDeclarationOrigin.FAKE_OVERRIDE &&

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/declarations/IrConstructor.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/declarations/IrConstructor.kt
@@ -17,11 +17,14 @@
 package org.jetbrains.kotlin.ir.declarations
 
 import org.jetbrains.kotlin.descriptors.ClassConstructorDescriptor
+import org.jetbrains.kotlin.descriptors.Visibility
 import org.jetbrains.kotlin.ir.symbols.IrConstructorSymbol
 
 
 interface IrConstructor : IrFunction, IrSymbolDeclaration<IrConstructorSymbol> {
     override val descriptor: ClassConstructorDescriptor
+
+    override var visibility: Visibility
 
     val isPrimary: Boolean
 }

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/declarations/impl/IrFunctionBase.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/declarations/impl/IrFunctionBase.kt
@@ -31,7 +31,7 @@ abstract class IrFunctionBase(
     endOffset: Int,
     origin: IrDeclarationOrigin,
     override val name: Name,
-    override val visibility: Visibility,
+    override var visibility: Visibility,
     override val isInline: Boolean,
     override val isExternal: Boolean,
     returnType: IrType

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/declarations/lazy/IrLazyFunctionBase.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/declarations/lazy/IrLazyFunctionBase.kt
@@ -23,7 +23,7 @@ abstract class IrLazyFunctionBase(
     endOffset: Int,
     origin: IrDeclarationOrigin,
     override val name: Name,
-    override val visibility: Visibility,
+    override var visibility: Visibility,
     override val isInline: Boolean,
     override val isExternal: Boolean,
     stubGenerator: DeclarationStubGenerator,

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/constructorWithInlineClassParameters.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/constructorWithInlineClassParameters.kt
@@ -1,4 +1,4 @@
-// IGNORE_BACKEND: JS_IR, JS, NATIVE, JVM_IR
+// IGNORE_BACKEND: JS_IR, JS, NATIVE
 // WITH_REFLECT
 import kotlin.test.assertEquals
 

--- a/compiler/testData/codegen/box/reflection/mapping/constructor.kt
+++ b/compiler/testData/codegen/box/reflection/mapping/constructor.kt
@@ -27,11 +27,7 @@ fun check(f: KFunction<Any>) {
 
 fun box(): String {
     check(::K)
-
-    // Workaround KT-8596
-    val nested = K::Nested
-    check(nested)
-
+    check(K::Nested)
     check(K::Inner)
     check(::Secondary)
 

--- a/compiler/testData/codegen/box/reflection/mapping/constructorWithInlineClassParameters.kt
+++ b/compiler/testData/codegen/box/reflection/mapping/constructorWithInlineClassParameters.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 // TARGET_BACKEND: JVM
 // WITH_REFLECT
 import kotlin.reflect.full.primaryConstructor

--- a/compiler/testData/codegen/bytecodeText/inlineClasses/constructorBridge.kt
+++ b/compiler/testData/codegen/bytecodeText/inlineClasses/constructorBridge.kt
@@ -1,0 +1,10 @@
+// !LANGUAGE: +InlineClasses
+// FILE: test.kt
+inline class A(val x: String)
+class B(val y: A)
+
+fun box() =
+    B(A("OK")).y.x
+
+// @TestKt.class:
+// 1 INVOKESPECIAL B.<init> \(Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;\)V

--- a/compiler/testData/writeFlags/function/constructors/withMangledArguments.kt
+++ b/compiler/testData/writeFlags/function/constructors/withMangledArguments.kt
@@ -1,0 +1,11 @@
+inline class A(val x: Int)
+
+class B(val y: A)
+
+// TESTED_OBJECT_KIND: function
+// TESTED_OBJECTS: A, <init>
+// FLAGS: ACC_PRIVATE, ACC_SYNTHETIC
+
+// TESTED_OBJECT_KIND: function
+// TESTED_OBJECTS: B, <init>
+// FLAGS: ACC_PRIVATE

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
@@ -2478,6 +2478,11 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
             runTest("compiler/testData/codegen/bytecodeText/inlineClasses/checkOuterInlineFunctionCall.kt");
         }
 
+        @TestMetadata("constructorBridge.kt")
+        public void testConstructorBridge() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/inlineClasses/constructorBridge.kt");
+        }
+
         @TestMetadata("defaultParametersDontBox.kt")
         public void testDefaultParametersDontBox() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/inlineClasses/defaultParametersDontBox.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/flags/WriteFlagsTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/flags/WriteFlagsTestGenerated.java
@@ -481,6 +481,11 @@ public class WriteFlagsTestGenerated extends AbstractWriteFlagsTest {
             public void testTopLevelObject() throws Exception {
                 runTest("compiler/testData/writeFlags/function/constructors/topLevelObject.kt");
             }
+
+            @TestMetadata("withMangledArguments.kt")
+            public void testWithMangledArguments() throws Exception {
+                runTest("compiler/testData/writeFlags/function/constructors/withMangledArguments.kt");
+            }
         }
 
         @TestMetadata("compiler/testData/writeFlags/function/deprecatedFlag")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
@@ -2448,6 +2448,11 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
             runTest("compiler/testData/codegen/bytecodeText/inlineClasses/checkOuterInlineFunctionCall.kt");
         }
 
+        @TestMetadata("constructorBridge.kt")
+        public void testConstructorBridge() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/inlineClasses/constructorBridge.kt");
+        }
+
         @TestMetadata("defaultParametersDontBox.kt")
         public void testDefaultParametersDontBox() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/inlineClasses/defaultParametersDontBox.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrWriteFlagsTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrWriteFlagsTestGenerated.java
@@ -481,6 +481,11 @@ public class IrWriteFlagsTestGenerated extends AbstractIrWriteFlagsTest {
             public void testTopLevelObject() throws Exception {
                 runTest("compiler/testData/writeFlags/function/constructors/topLevelObject.kt");
             }
+
+            @TestMetadata("withMangledArguments.kt")
+            public void testWithMangledArguments() throws Exception {
+                runTest("compiler/testData/writeFlags/function/constructors/withMangledArguments.kt");
+            }
         }
 
         @TestMetadata("compiler/testData/writeFlags/function/deprecatedFlag")

--- a/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KDeclarationContainerImpl.kt
+++ b/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KDeclarationContainerImpl.kt
@@ -136,7 +136,7 @@ internal abstract class KDeclarationContainerImpl : ClassBasedDeclarationContain
             }
 
             val allMembers = getProperties(Name.identifier(name)).joinToString("\n") { descriptor ->
-                DescriptorRenderer.DEBUG_TEXT.render(descriptor) + " | " + RuntimeTypeMapper.mapPropertySignature(descriptor)
+                DescriptorRenderer.DEBUG_TEXT.render(descriptor) + " | " + RuntimeTypeMapper.mapPropertySignature(descriptor).asString()
             }
             throw KotlinReflectionInternalError(
                 "Property '$name' (JVM signature: $signature) not resolved in $this:" +
@@ -155,7 +155,7 @@ internal abstract class KDeclarationContainerImpl : ClassBasedDeclarationContain
 
         if (functions.size != 1) {
             val allMembers = members.joinToString("\n") { descriptor ->
-                DescriptorRenderer.DEBUG_TEXT.render(descriptor) + " | " + RuntimeTypeMapper.mapSignature(descriptor)
+                DescriptorRenderer.DEBUG_TEXT.render(descriptor) + " | " + RuntimeTypeMapper.mapSignature(descriptor).asString()
             }
             throw KotlinReflectionInternalError(
                 "Function '$name' (JVM signature: $signature) not resolved in $this:" +

--- a/plugins/kotlin-serialization/kotlin-serialization-compiler/testData/codegen/Basic.ir.txt
+++ b/plugins/kotlin-serialization/kotlin-serialization-compiler/testData/codegen/Basic.ir.txt
@@ -483,7 +483,6 @@ public final class OptionalUser$$serializer : java/lang/Object, kotlinx/serializ
           ALOAD (2)
           INVOKESTATIC (OptionalUser, access$prop$getUser$2, (LOptionalUser;)LUser;)
           INVOKEINTERFACE (kotlinx/serialization/CompositeEncoder, encodeSerializableElement, (Lkotlinx/serialization/SerialDescriptor;ILkotlinx/serialization/SerializationStrategy;Ljava/lang/Object;)V)
-          GOTO (L6)
         LABEL (L6)
           ALOAD (4)
           ALOAD (3)
@@ -618,10 +617,8 @@ public final class OptionalUser : java/lang/Object {
         LABEL (L0)
           ALOAD (0)
           ACONST_NULL
-          CHECKCAST
           ICONST_1
           ACONST_NULL
-          CHECKCAST
           INVOKESPECIAL (OptionalUser, <init>, (LUser;ILkotlin/jvm/internal/DefaultConstructorMarker;)V)
           RETURN
         LABEL (L1)


### PR DESCRIPTION
On the JVM backend, we hide constructors taking inline class parameters and call them through public bridge methods. This PR implements the same feature in the JVM IR backend.