### PR TITLE
New script dependency resolvers

### DIFF
--- a/libraries/scripting/dependencies-ivy/build.gradle.kts
+++ b/libraries/scripting/dependencies-ivy/build.gradle.kts
@@ -1,0 +1,27 @@
+
+plugins {
+    kotlin("jvm")
+    id("jps-compatible")
+}
+
+jvmTarget = "1.6"
+
+dependencies {
+    compile(kotlinStdlib())
+    compile(project(":kotlin-scripting-dependencies"))
+    compileOnly("org.apache.ivy:ivy:2.4.0")
+    embedded("org.apache.ivy:ivy:2.4.0")
+    compile(commonDep("org.jetbrains.kotlinx", "kotlinx-coroutines-core")) { isTransitive = false }
+    testCompile(commonDep("junit"))
+}
+
+sourceSets {
+    "main" { projectDefault() }
+    "test" { projectDefault() }
+}
+
+publish()
+
+runtimeJar()
+sourcesJar()
+javadocJar()

--- a/libraries/scripting/dependencies-ivy/build.gradle.kts
+++ b/libraries/scripting/dependencies-ivy/build.gradle.kts
@@ -9,9 +9,8 @@ jvmTarget = "1.6"
 dependencies {
     compile(kotlinStdlib())
     compile(project(":kotlin-scripting-dependencies"))
-    compileOnly("org.apache.ivy:ivy:2.4.0")
+    compile("org.apache.ivy:ivy:2.4.0")
     embedded("org.apache.ivy:ivy:2.4.0")
-    compile(commonDep("org.jetbrains.kotlinx", "kotlinx-coroutines-core")) { isTransitive = false }
     testCompile(commonDep("junit"))
 }
 

--- a/libraries/scripting/dependencies-ivy/src/kotlin/script/experimental/IvyDependenciesResolver.kt
+++ b/libraries/scripting/dependencies-ivy/src/kotlin/script/experimental/IvyDependenciesResolver.kt
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package kotlin.script.experimental
+
+import org.apache.ivy.Ivy
+import org.apache.ivy.core.LogOptions
+import org.apache.ivy.core.module.descriptor.DefaultDependencyArtifactDescriptor
+import org.apache.ivy.core.module.descriptor.DefaultDependencyDescriptor
+import org.apache.ivy.core.module.descriptor.DefaultModuleDescriptor
+import org.apache.ivy.core.module.id.ModuleRevisionId
+import org.apache.ivy.core.resolve.ResolveOptions
+import org.apache.ivy.core.settings.IvySettings
+import org.apache.ivy.plugins.parser.xml.XmlModuleDescriptorWriter
+import org.apache.ivy.plugins.resolver.ChainResolver
+import org.apache.ivy.plugins.resolver.IBiblioResolver
+import org.apache.ivy.plugins.resolver.URLResolver
+import org.apache.ivy.util.DefaultMessageLogger
+import org.apache.ivy.util.Message
+import org.jetbrains.kotlin.script.util.resolvers.experimental.GenericArtifactCoordinates
+import org.jetbrains.kotlin.script.util.resolvers.experimental.GenericRepositoryCoordinates
+import org.jetbrains.kotlin.script.util.resolvers.experimental.MavenArtifactCoordinates
+
+class IvyDependenciesResolver : GenericDependenciesResolver {
+    data class IvyArtifactCoordinates(
+        val groupId: String,
+        val artifactName: String,
+        val revision: String,
+        val conf: String? = null,
+        val type: String? = null
+    )
+
+    override fun accepts(artifactCoordinates: GenericArtifactCoordinates) = artifactCoordinates.ivyCoordinates != null
+
+    override fun accepts(repositoryCoordinates: GenericRepositoryCoordinates): Boolean {
+        return repositoryCoordinates.url != null
+    }
+
+    private fun String?.isValidParam() = this?.isNotBlank() ?: false
+
+    val GenericArtifactCoordinates.ivyCoordinates: IvyArtifactCoordinates?
+        get() {
+            if (this is MavenArtifactCoordinates && (groupId.isValidParam() || artifactId.isValidParam())) {
+                return IvyArtifactCoordinates(groupId.orEmpty(), artifactId.orEmpty(), version.orEmpty())
+            } else {
+                val artifactType = string.substringAfterLast('@', "").trim()
+                val stringCoordinates = if (artifactType.isNotEmpty()) string.removeSuffix("@$artifactType") else string
+                if (stringCoordinates.isValidParam() && stringCoordinates.count { it == ':' }.let { it == 2 || it == 3 }) {
+                    val artifactId = stringCoordinates.split(':')
+                    return IvyArtifactCoordinates(
+                        artifactId[0], artifactId[1], artifactId[2],
+                        if (artifactId.size > 3) artifactId[3] else null,
+                        if (artifactType.isNotEmpty()) artifactType else null
+                    )
+                } else {
+                    return null
+                }
+            }
+        }
+
+    override fun resolve(artifactCoordinates: GenericArtifactCoordinates): ResolveArtifactResult =
+        resolveArtifact(artifactCoordinates.ivyCoordinates!!)
+
+
+    private val ivyResolvers = arrayListOf<URLResolver>()
+
+    private fun resolveArtifact(
+        artifact: IvyArtifactCoordinates
+    ): ResolveArtifactResult {
+
+        if (ivyResolvers.isEmpty() || ivyResolvers.none { it.name == "central" }) {
+            ivyResolvers.add(
+                IBiblioResolver().apply {
+                    isM2compatible = true
+                    name = "central"
+                }
+            )
+        }
+        val ivySettings = IvySettings().apply {
+            val resolver =
+                if (ivyResolvers.size == 1) ivyResolvers.first()
+                else ChainResolver().also {
+                    for (resolver in ivyResolvers) {
+                        it.add(resolver)
+                    }
+                }
+            addResolver(resolver)
+            setDefaultResolver(resolver.name)
+        }
+
+        val ivy = Ivy.newInstance(ivySettings)
+
+        with(artifact) {
+            val moduleDescriptor = DefaultModuleDescriptor.newDefaultInstance(
+                ModuleRevisionId.newInstance(groupId, "$artifactName-caller", "working")
+            )
+
+            val depsDescriptor = DefaultDependencyDescriptor(
+                moduleDescriptor,
+                ModuleRevisionId.newInstance(groupId, artifactName, conf, revision),
+                false, false, true
+            )
+            if (type != null) {
+                val depArtifact = DefaultDependencyArtifactDescriptor(depsDescriptor, artifactName, type, type, null, null)
+                depsDescriptor.addDependencyArtifact(conf, depArtifact)
+            }
+            moduleDescriptor.addDependency(depsDescriptor)
+
+            val resolveOptions = ResolveOptions().apply {
+                confs = arrayOf("default")
+                log = LogOptions.LOG_QUIET
+                isOutputReport = false
+            }
+
+
+            //init resolve report
+
+            // TODO: find out why direct resolving doesn't work
+            // val report = ivy.resolve(moduleDescriptor, resolveOptions)
+
+            //creates an ivy configuration file
+            val ivyFile = createTempFile("ivy", ".xml").apply { deleteOnExit() }
+            XmlModuleDescriptorWriter.write(moduleDescriptor, ivyFile)
+
+
+            val report = ivy.resolve(ivyFile.toURI().toURL(), resolveOptions)
+
+            return ResolveArtifactResult.Success(report.allArtifactsReports.map { it.localFile })
+        }
+    }
+
+    override fun addRepository(repositoryCoordinates: GenericRepositoryCoordinates) {
+        val url = repositoryCoordinates.url ?: throw Exception("Invalid Ivy repository URL: ${repositoryCoordinates.string}")
+        ivyResolvers.add(
+            URLResolver().apply {
+                isM2compatible = true
+                name = repositoryCoordinates.name.takeIf { it.isValidParam() } ?: url.host
+                addArtifactPattern("${url.toString().let { if (it.endsWith('/')) it else "$it/" }}$DEFAULT_ARTIFACT_PATTERN")
+            }
+        )
+    }
+
+    companion object {
+        const val DEFAULT_ARTIFACT_PATTERN = "[organisation]/[module]/[revision]/[artifact]-[revision](-[classifier]).[ext]"
+
+        init {
+            Message.setDefaultLogger(DefaultMessageLogger(1))
+        }
+    }
+}

--- a/libraries/scripting/dependencies-maven/build.gradle.kts
+++ b/libraries/scripting/dependencies-maven/build.gradle.kts
@@ -1,0 +1,27 @@
+
+plugins {
+    kotlin("jvm")
+    id("jps-compatible")
+}
+
+jvmTarget = "1.6"
+
+dependencies {
+    compile(kotlinStdlib())
+    compile(project(":kotlin-scripting-dependencies"))
+    compileOnly("org.jetbrains.kotlin:jcabi-aether:1.0-dev-3")
+    compileOnly("org.sonatype.aether:aether-api:1.13.1")
+    compile(commonDep("org.jetbrains.kotlinx", "kotlinx-coroutines-core")) { isTransitive = false }
+    testCompile(commonDep("junit"))
+}
+
+sourceSets {
+    "main" { projectDefault() }
+    "test" { projectDefault() }
+}
+
+publish()
+
+runtimeJar()
+sourcesJar()
+javadocJar()

--- a/libraries/scripting/dependencies-maven/build.gradle.kts
+++ b/libraries/scripting/dependencies-maven/build.gradle.kts
@@ -9,9 +9,8 @@ jvmTarget = "1.6"
 dependencies {
     compile(kotlinStdlib())
     compile(project(":kotlin-scripting-dependencies"))
-    compileOnly("org.jetbrains.kotlin:jcabi-aether:1.0-dev-3")
-    compileOnly("org.sonatype.aether:aether-api:1.13.1")
-    compile(commonDep("org.jetbrains.kotlinx", "kotlinx-coroutines-core")) { isTransitive = false }
+    compile("org.jetbrains.kotlin:jcabi-aether:1.0-dev-3")
+    compile("org.sonatype.aether:aether-api:1.13.1")
     testCompile(commonDep("junit"))
 }
 

--- a/libraries/scripting/dependencies-maven/src/kotlin/script/experimental/MavenDependenciesResolver.kt
+++ b/libraries/scripting/dependencies-maven/src/kotlin/script/experimental/MavenDependenciesResolver.kt
@@ -16,7 +16,7 @@ import java.util.ArrayList
 
 val mavenCentral = RemoteRepository("maven-central", "default", "https://repo.maven.apache.org/maven2/")
 
-class MavenResolver : GenericDependenciesResolver {
+class MavenDependenciesResolver : GenericDependenciesResolver {
 
     override fun accepts(artifactCoordinates: GenericArtifactCoordinates): Boolean =
         artifactCoordinates.mavenArtifact != null

--- a/libraries/scripting/dependencies-maven/src/kotlin/script/experimental/MavenDependencyResolver.kt
+++ b/libraries/scripting/dependencies-maven/src/kotlin/script/experimental/MavenDependencyResolver.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package kotlin.script.experimental
+
+import com.jcabi.aether.Aether
+import org.jetbrains.kotlin.script.util.resolvers.experimental.*
+import org.sonatype.aether.repository.RemoteRepository
+import org.sonatype.aether.resolution.DependencyResolutionException
+import org.sonatype.aether.util.artifact.DefaultArtifact
+import org.sonatype.aether.util.artifact.JavaScopes
+import java.io.File
+import java.util.ArrayList
+
+val mavenCentral = RemoteRepository("maven-central", "default", "https://repo.maven.apache.org/maven2/")
+
+class MavenResolver : GenericDependenciesResolver {
+
+    override fun accepts(artifactCoordinates: GenericArtifactCoordinates): Boolean =
+        artifactCoordinates.mavenArtifact != null
+
+    override fun accepts(repositoryCoordinates: GenericRepositoryCoordinates): Boolean {
+        return repositoryCoordinates.url != null
+    }
+
+    // TODO: make robust
+    val localRepo = File(File(System.getProperty("user.home")!!, ".m2"), "repository")
+
+    val repos: ArrayList<RemoteRepository> = arrayListOf()
+
+    private fun remoteRepositories() = if (repos.isEmpty()) arrayListOf(mavenCentral) else repos
+
+    private fun allRepositories() = remoteRepositories().map { it.url!!.toString() } + localRepo.toString()
+
+    private fun String?.isValidParam() = this?.isNotBlank() ?: false
+
+    private val GenericArtifactCoordinates.mavenArtifact : DefaultArtifact?
+        get() {
+            fun String?.nullIfBlank(): String? = this?.takeUnless(kotlin.String::isBlank)
+
+            return if (this is MavenArtifactCoordinates && (groupId.isValidParam() || artifactId.isValidParam())) {
+                DefaultArtifact(
+                    groupId.nullIfBlank(),
+                    artifactId.nullIfBlank(),
+                    null,
+                    version.nullIfBlank()
+                )
+            } else {
+                val coordinatesString = string
+                if (coordinatesString.isValidParam() && coordinatesString.count { it == ':' } == 2) {
+                    DefaultArtifact(coordinatesString)
+                } else {
+                    null
+                }
+            }
+        }
+
+    override fun resolve(artifactCoordinates: GenericArtifactCoordinates): ResolveArtifactResult {
+
+        val artifactId = artifactCoordinates.mavenArtifact!!
+
+        return try {
+            val deps = Aether(remoteRepositories(), localRepo).resolve(artifactId, JavaScopes.RUNTIME)
+            if (deps != null)
+                ResolveArtifactResult.Success(deps.map { it.file })
+            else {
+                ResolveArtifactResult.Failure(allRepositories().map { ResolveAttemptFailure(it, "$artifactId not found") })
+            }
+        } catch (e: DependencyResolutionException) {
+            ResolveArtifactResult.Failure(allRepositories().map { ResolveAttemptFailure(it, "failed to resolve dependencies") })
+        }
+    }
+
+    override fun addRepository(repositoryCoordinates: GenericRepositoryCoordinates) {
+        val url = repositoryCoordinates.url ?: throw Exception("Invalid Maven repository URL: ${repositoryCoordinates.string}")
+
+        repos.add(
+            RemoteRepository(
+                if (repositoryCoordinates.name.isValidParam()) repositoryCoordinates.name else url.host,
+                "default",
+                url.toString()
+            )
+        )
+    }
+}

--- a/libraries/scripting/dependencies/build.gradle.kts
+++ b/libraries/scripting/dependencies/build.gradle.kts
@@ -1,0 +1,25 @@
+
+plugins {
+    kotlin("jvm")
+    id("jps-compatible")
+}
+
+jvmTarget = "1.6"
+
+dependencies {
+    compile(kotlinStdlib())
+    compile(project(":kotlin-script-util"))
+    compile(commonDep("org.jetbrains.kotlinx", "kotlinx-coroutines-core")) { isTransitive = false }
+    testCompile(commonDep("junit"))
+}
+
+sourceSets {
+    "main" { projectDefault() }
+    "test" { projectDefault() }
+}
+
+publish()
+
+runtimeJar()
+sourcesJar()
+javadocJar()

--- a/libraries/scripting/dependencies/build.gradle.kts
+++ b/libraries/scripting/dependencies/build.gradle.kts
@@ -9,7 +9,6 @@ jvmTarget = "1.6"
 dependencies {
     compile(kotlinStdlib())
     compile(project(":kotlin-script-util"))
-    compile(commonDep("org.jetbrains.kotlinx", "kotlinx-coroutines-core")) { isTransitive = false }
     testCompile(commonDep("junit"))
 }
 

--- a/libraries/scripting/dependencies/src/kotlin/script/experimental/CompoundDependenciesResolver.kt
+++ b/libraries/scripting/dependencies/src/kotlin/script/experimental/CompoundDependenciesResolver.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package kotlin.script.experimental
+
+import org.jetbrains.kotlin.script.util.resolvers.experimental.*
+
+class CompoundDependenciesResolver(private val resolvers: List<GenericDependenciesResolver>) : GenericDependenciesResolver {
+
+    constructor(vararg resolvers: GenericDependenciesResolver) : this(resolvers.toList())
+
+    override fun accepts(artifactCoordinates: GenericArtifactCoordinates): Boolean {
+        return resolvers.any { it.accepts(artifactCoordinates) }
+    }
+
+    override fun accepts(repositoryCoordinates: GenericRepositoryCoordinates): Boolean {
+        return resolvers.any { it.accepts(repositoryCoordinates) }
+    }
+
+    override fun addRepository(repositoryCoordinates: GenericRepositoryCoordinates) {
+        if (resolvers.count { it.tryAddRepository(repositoryCoordinates) } == 0)
+            throw Exception("Failed to detect repository type: ${repositoryCoordinates.string}")
+    }
+
+    override fun resolve(artifactCoordinates: GenericArtifactCoordinates): ResolveArtifactResult {
+
+        val resolveAttempts = mutableListOf<ResolveAttemptFailure>()
+
+        for (resolver in resolvers) {
+            if (resolver.accepts(artifactCoordinates)) {
+                when (val resolveResult = resolver.resolve(artifactCoordinates)) {
+                    is ResolveArtifactResult.Failure -> resolveAttempts.addAll(resolveResult.attempts)
+                    else -> return resolveResult
+                }
+            }
+        }
+        return ResolveArtifactResult.Failure(resolveAttempts)
+    }
+
+}

--- a/libraries/scripting/dependencies/src/kotlin/script/experimental/DirectDependenciesResolver.kt
+++ b/libraries/scripting/dependencies/src/kotlin/script/experimental/DirectDependenciesResolver.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package kotlin.script.experimental
+
+import org.jetbrains.kotlin.script.util.resolvers.experimental.GenericArtifactCoordinates
+import org.jetbrains.kotlin.script.util.resolvers.experimental.GenericRepositoryCoordinates
+import java.io.File
+import java.lang.Exception
+
+class DirectDependenciesResolver : GenericDependenciesResolver {
+
+    private fun makeResolveFailureResult(location: String, message: String) = ResolveArtifactResult.Failure(listOf(ResolveAttemptFailure(location, message)))
+
+    override fun resolve(artifactCoordinates: GenericArtifactCoordinates): ResolveArtifactResult {
+        if(!accepts(artifactCoordinates)) throw IllegalArgumentException("Invalid arguments: $artifactCoordinates")
+        val file = File(artifactCoordinates.string)
+        if(!file.exists()) return makeResolveFailureResult(file.canonicalPath, "File doesn't exist")
+        if(!file.isFile && !file.isDirectory) return makeResolveFailureResult(file.canonicalPath, "Path is neither file nor directory")
+        return ResolveArtifactResult.Success(listOf(file))
+    }
+
+    override fun addRepository(repositoryCoordinates: GenericRepositoryCoordinates) =
+        throw Exception("DirectDependenciesResolver doesn't support adding repositories")
+
+    override fun accepts(repositoryCoordinates: GenericRepositoryCoordinates): Boolean = false
+
+    override fun accepts(artifactCoordinates: GenericArtifactCoordinates): Boolean =
+        !artifactCoordinates.string.isBlank() && !artifactCoordinates.string.contains(':')
+}

--- a/libraries/scripting/dependencies/src/kotlin/script/experimental/DirectDependenciesResolver.kt
+++ b/libraries/scripting/dependencies/src/kotlin/script/experimental/DirectDependenciesResolver.kt
@@ -15,7 +15,7 @@ class DirectDependenciesResolver : GenericDependenciesResolver {
     private fun makeResolveFailureResult(location: String, message: String) = ResolveArtifactResult.Failure(listOf(ResolveAttemptFailure(location, message)))
 
     override fun resolve(artifactCoordinates: GenericArtifactCoordinates): ResolveArtifactResult {
-        if(!accepts(artifactCoordinates)) throw IllegalArgumentException("Invalid arguments: $artifactCoordinates")
+        require(accepts(artifactCoordinates)) { "Invalid artifact coordinates: $artifactCoordinates" }
         val file = File(artifactCoordinates.string)
         if(!file.exists()) return makeResolveFailureResult(file.canonicalPath, "File doesn't exist")
         if(!file.isFile && !file.isDirectory) return makeResolveFailureResult(file.canonicalPath, "Path is neither file nor directory")

--- a/libraries/scripting/dependencies/src/kotlin/script/experimental/FlatLibDirectoryDependenciesResolver.kt
+++ b/libraries/scripting/dependencies/src/kotlin/script/experimental/FlatLibDirectoryDependenciesResolver.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package kotlin.script.experimental
+
+import org.jetbrains.kotlin.script.util.Repository
+import org.jetbrains.kotlin.script.util.resolvers.experimental.BasicRepositoryCoordinates
+import org.jetbrains.kotlin.script.util.resolvers.experimental.GenericArtifactCoordinates
+import org.jetbrains.kotlin.script.util.resolvers.experimental.GenericRepositoryCoordinates
+import java.io.File
+import java.lang.Exception
+
+class FlatLibDirectoryDependenciesResolver(vararg paths: File) : GenericDependenciesResolver {
+
+    override fun addRepository(repositoryCoordinates: GenericRepositoryCoordinates) {
+        val repoDir = repositoryCoordinates.file ?: throw Exception("Invalid repository location: '${repositoryCoordinates.string}'")
+        localRepos.add(repoDir)
+    }
+
+    override fun resolve(artifactCoordinates: GenericArtifactCoordinates): ResolveArtifactResult {
+        if(!accepts(artifactCoordinates)) throw Exception("Path is empty")
+
+        val resolveAttempts = mutableListOf<ResolveAttemptFailure>()
+
+        val path = artifactCoordinates.string
+        for (repo in localRepos) {
+            // TODO: add coordinates and wildcard matching
+            val file = File(repo, path)
+            when {
+                !file.exists() -> resolveAttempts.add(ResolveAttemptFailure(file.canonicalPath, "File not exists"))
+                !file.isFile && !file.isDirectory -> resolveAttempts.add(ResolveAttemptFailure(file.canonicalPath, "Path is neither file nor directory"))
+                else -> return ResolveArtifactResult.Success(listOf(file))
+            }
+        }
+        return ResolveArtifactResult.Failure(resolveAttempts)
+    }
+
+    override fun accepts(artifactCoordinates: GenericArtifactCoordinates): Boolean {
+        return artifactCoordinates.string.takeUnless(String::isBlank)?.let { path ->
+            localRepos.any { File(it, path).exists() }
+        } ?: false
+    }
+
+    override fun accepts(repositoryCoordinates: GenericRepositoryCoordinates): Boolean = repositoryCoordinates.file != null
+
+    private val localRepos = arrayListOf<File>()
+
+    init {
+        for (path in paths) {
+            if (!path.exists() || !path.isDirectory) throw IllegalArgumentException("Invalid flat lib directory repository path '$path'")
+        }
+        localRepos.addAll(paths)
+    }
+
+    companion object {
+
+        fun tryCreate(annotation: Repository): FlatLibDirectoryDependenciesResolver? = tryCreate(
+            BasicRepositoryCoordinates(
+                annotation.url.takeUnless(String::isBlank) ?: annotation.value, annotation.id.takeUnless(String::isBlank)
+            )
+        )
+
+        fun tryCreate(repositoryCoordinates: GenericRepositoryCoordinates): FlatLibDirectoryDependenciesResolver? =
+            repositoryCoordinates.file?.let { FlatLibDirectoryDependenciesResolver(it) }
+    }
+}

--- a/libraries/scripting/dependencies/src/kotlin/script/experimental/FlatLibDirectoryDependenciesResolver.kt
+++ b/libraries/scripting/dependencies/src/kotlin/script/experimental/FlatLibDirectoryDependenciesResolver.kt
@@ -15,12 +15,12 @@ import java.lang.Exception
 class FlatLibDirectoryDependenciesResolver(vararg paths: File) : GenericDependenciesResolver {
 
     override fun addRepository(repositoryCoordinates: GenericRepositoryCoordinates) {
-        val repoDir = repositoryCoordinates.file ?: throw Exception("Invalid repository location: '${repositoryCoordinates.string}'")
+        val repoDir = repositoryCoordinates.file ?: throw IllegalArgumentException("Invalid repository location: '${repositoryCoordinates.string}'")
         localRepos.add(repoDir)
     }
 
     override fun resolve(artifactCoordinates: GenericArtifactCoordinates): ResolveArtifactResult {
-        if(!accepts(artifactCoordinates)) throw Exception("Path is empty")
+        require(accepts(artifactCoordinates)) { "Invalid artifact coordinates: $artifactCoordinates" }
 
         val resolveAttempts = mutableListOf<ResolveAttemptFailure>()
 

--- a/libraries/scripting/dependencies/src/kotlin/script/experimental/GenericDependenciesResolver.kt
+++ b/libraries/scripting/dependencies/src/kotlin/script/experimental/GenericDependenciesResolver.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package kotlin.script.experimental
+
+import org.jetbrains.kotlin.script.util.resolvers.experimental.BasicArtifactCoordinates
+import org.jetbrains.kotlin.script.util.resolvers.experimental.BasicRepositoryCoordinates
+import org.jetbrains.kotlin.script.util.resolvers.experimental.GenericArtifactCoordinates
+import org.jetbrains.kotlin.script.util.resolvers.experimental.GenericRepositoryCoordinates
+import java.io.File
+
+interface GenericDependenciesResolver {
+    fun accepts(repositoryCoordinates: GenericRepositoryCoordinates): Boolean
+    fun accepts(artifactCoordinates: GenericArtifactCoordinates): Boolean
+
+    fun resolve(artifactCoordinates: GenericArtifactCoordinates): ResolveArtifactResult
+    fun addRepository(repositoryCoordinates: GenericRepositoryCoordinates)
+}
+
+data class ResolveAttemptFailure(val location: String, val message: String)
+
+sealed class ResolveArtifactResult {
+    data class Success(val files: Iterable<File>): ResolveArtifactResult()
+
+    data class Failure(val attempts: List<ResolveAttemptFailure>): ResolveArtifactResult()
+}
+
+fun GenericDependenciesResolver.tryResolve(artifactCoordinates: GenericArtifactCoordinates): Iterable<File>? =
+    if (accepts(artifactCoordinates)) resolve(artifactCoordinates).let {
+        when (it) {
+            is ResolveArtifactResult.Success -> it.files
+            else -> null
+        }
+    } else null
+
+fun GenericDependenciesResolver.tryAddRepository(repositoryCoordinates: GenericRepositoryCoordinates) =
+    if (accepts(repositoryCoordinates)) {
+        addRepository(repositoryCoordinates)
+        true
+    } else false
+
+fun GenericDependenciesResolver.tryResolve(artifactCoordinates: String): Iterable<File>? =
+    tryResolve(BasicArtifactCoordinates(artifactCoordinates))
+
+fun GenericDependenciesResolver.tryAddRepository(repositoryCoordinates: String, id: String? = null): Boolean =
+    tryAddRepository(BasicRepositoryCoordinates(repositoryCoordinates, id))

--- a/libraries/scripting/dependencies/src/kotlin/script/experimental/bridges.kt
+++ b/libraries/scripting/dependencies/src/kotlin/script/experimental/bridges.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package kotlin.script.experimental
+
+import org.jetbrains.kotlin.script.util.DependsOn
+import org.jetbrains.kotlin.script.util.Repository
+import org.jetbrains.kotlin.script.util.resolvers.Resolver
+import org.jetbrains.kotlin.script.util.resolvers.experimental.MavenArtifactCoordinates
+import java.io.File
+
+fun GenericDependenciesResolver.asOldResolver() : Resolver {
+    return object: Resolver{
+        override fun tryResolve(dependsOn: DependsOn): Iterable<File>? =
+            tryResolve(
+                with(dependsOn) {
+                    MavenArtifactCoordinates(value, groupId, artifactId, version)
+                }
+            )
+
+        override fun tryAddRepo(annotation: Repository): Boolean =
+            with(annotation) {
+                tryAddRepository(
+                    value.takeIf { it.isNotBlank() } ?: url,
+                    id.takeIf { it.isNotBlank() }
+                )
+            }
+    }
+}

--- a/libraries/scripting/dependencies/src/kotlin/script/experimental/bridges.kt
+++ b/libraries/scripting/dependencies/src/kotlin/script/experimental/bridges.kt
@@ -8,11 +8,14 @@ package kotlin.script.experimental
 import org.jetbrains.kotlin.script.util.DependsOn
 import org.jetbrains.kotlin.script.util.Repository
 import org.jetbrains.kotlin.script.util.resolvers.Resolver
+import org.jetbrains.kotlin.script.util.resolvers.experimental.GenericArtifactCoordinates
+import org.jetbrains.kotlin.script.util.resolvers.experimental.GenericRepositoryCoordinates
+import org.jetbrains.kotlin.script.util.resolvers.experimental.GenericResolver
 import org.jetbrains.kotlin.script.util.resolvers.experimental.MavenArtifactCoordinates
 import java.io.File
 
-fun GenericDependenciesResolver.asOldResolver() : Resolver {
-    return object: Resolver{
+fun GenericDependenciesResolver.asOldResolver(): Resolver =
+    object : Resolver {
         override fun tryResolve(dependsOn: DependsOn): Iterable<File>? =
             tryResolve(
                 with(dependsOn) {
@@ -27,5 +30,18 @@ fun GenericDependenciesResolver.asOldResolver() : Resolver {
                     id.takeIf { it.isNotBlank() }
                 )
             }
+    }
+
+
+fun GenericDependenciesResolver.asOldGenericResolver(): GenericResolver {
+    val me = this
+    return object : GenericResolver {
+        override fun tryAddRepository(repositoryCoordinates: GenericRepositoryCoordinates): Boolean {
+            return me.tryAddRepository(repositoryCoordinates)
+        }
+
+        override fun tryResolve(artifactCoordinates: GenericArtifactCoordinates): Iterable<File>? {
+            return me.tryResolve(artifactCoordinates)
+        }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -201,6 +201,9 @@ include ":kotlin-build-common",
         ":kotlin-scripting-compiler-embeddable",
         ":kotlin-scripting-compiler-impl",
         ":kotlin-scripting-compiler-impl-embeddable",
+        ":kotlin-scripting-dependencies",
+        ":kotlin-scripting-dependencies-maven",
+        ":kotlin-scripting-dependencies-ivy",
         ":kotlin-scripting-jsr223",
         ":kotlin-scripting-jsr223-test",
         ":kotlin-scripting-jsr223-embeddable",
@@ -382,6 +385,9 @@ project(':kotlin-scripting-jvm').projectDir = "$rootDir/libraries/scripting/jvm"
 project(':kotlin-scripting-jvm-host').projectDir = "$rootDir/libraries/scripting/jvm-host" as File
 project(':kotlin-scripting-jvm-host-test').projectDir = "$rootDir/libraries/scripting/jvm-host-test" as File
 project(':kotlin-scripting-jvm-host-embeddable').projectDir = "$rootDir/libraries/scripting/jvm-host-embeddable" as File
+project(':kotlin-scripting-dependencies').projectDir = "$rootDir/libraries/scripting/dependencies" as File
+project(':kotlin-scripting-dependencies-maven').projectDir = "$rootDir/libraries/scripting/dependencies-maven" as File
+project(':kotlin-scripting-dependencies-ivy').projectDir = "$rootDir/libraries/scripting/dependencies-ivy" as File
 project(':kotlin-scripting-jsr223').projectDir = "$rootDir/libraries/scripting/jsr223" as File
 project(':kotlin-scripting-jsr223-test').projectDir = "$rootDir/libraries/scripting/jsr223-test" as File
 project(':kotlin-scripting-jsr223-embeddable').projectDir = "$rootDir/libraries/scripting/jsr223-embeddable" as File


### PR DESCRIPTION
Added new script dependency resolvers that are supposed to replace legacy resolvers in kotlin-script-util. Main reason for new resolvers is to distinguish between two situations: when resolver is not suitable for artifact resolution (based on artifact syntax) and when resolution failed. When dependency resolution failed, a set of resolution attempts with tried addresses and failure reasons are returned in order to provide correct diagnostics for user.