### PR TITLE
Exclude additional generated testData/out-min dir in js/js.translator.

### DIFF
--- a/js/js.translator/build.gradle.kts
+++ b/js/js.translator/build.gradle.kts
@@ -28,6 +28,6 @@ sourceSets {
 
 configure<IdeaModel> {
     module {
-        excludeDirs = excludeDirs + files("testData/out-min")
+        excludeDirs = excludeDirs + files("testData/out", "testData/out-min")
     }
 }


### PR DESCRIPTION
This was causing re-indexing in IntelliJ after every time the JS tests are run.

(Credit goes to @sfs for finding the cause and fix! :clap:)