### PR TITLE
KT-34049 Formatter breaks string inside template expression with elvis operator

### DIFF
--- a/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/KotlinCommonBlock.kt
+++ b/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/KotlinCommonBlock.kt
@@ -612,7 +612,7 @@ abstract class KotlinCommonBlock(
                         }
                     }
                 }
-                if (nodePsi.operationToken == ELVIS) {
+                if (nodePsi.operationToken == ELVIS && nodePsi.getStrictParentOfType<KtStringTemplateExpression>() == null) {
                     return { childElement ->
                         if (childElement.elementType == OPERATION_REFERENCE) {
                             Wrap.createWrap(settings.kotlinCustomSettings.WRAP_ELVIS_EXPRESSIONS, true)

--- a/idea/testData/formatter/ElvisInStringTemplate.after.kt
+++ b/idea/testData/formatter/ElvisInStringTemplate.after.kt
@@ -1,0 +1,6 @@
+fun test() {
+    val projectExtId: String? = "id"
+    val s = "https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:${projectExtId ?: "Kotlin_dev_Compiler"})"
+}
+
+// SET_INT: WRAP_ELVIS_EXPRESSIONS = 2

--- a/idea/testData/formatter/ElvisInStringTemplate.kt
+++ b/idea/testData/formatter/ElvisInStringTemplate.kt
@@ -1,0 +1,6 @@
+fun test() {
+    val projectExtId: String? = "id"
+    val s = "https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:${projectExtId ?: "Kotlin_dev_Compiler"})"
+}
+
+// SET_INT: WRAP_ELVIS_EXPRESSIONS = 2

--- a/idea/tests/org/jetbrains/kotlin/formatter/FormatterTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/formatter/FormatterTestGenerated.java
@@ -236,6 +236,11 @@ public class FormatterTestGenerated extends AbstractFormatterTest {
             runTest("idea/testData/formatter/ElvisContinuationIndentOptions.after.kt");
         }
 
+        @TestMetadata("ElvisInStringTemplate.after.kt")
+        public void testElvisInStringTemplate() throws Exception {
+            runTest("idea/testData/formatter/ElvisInStringTemplate.after.kt");
+        }
+
         @TestMetadata("ElvisIndent.after.kt")
         public void testElvisIndent() throws Exception {
             runTest("idea/testData/formatter/ElvisIndent.after.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-34049