### PR TITLE
JVM IR: Use WrappedClassDescriptor in class builder.

### DIFF
--- a/compiler/testData/codegen/box/inlineClasses/functionNameMangling/mangledFunctionsCanBeOverridden.kt
+++ b/compiler/testData/codegen/box/inlineClasses/functionNameMangling/mangledFunctionsCanBeOverridden.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: +InlineClasses
-// IGNORE_BACKEND: JVM_IR
 
 inline class Id(val id: String)
 


### PR DESCRIPTION
We don't lower descriptors in the JVM IR backend, but we still use them for ClassBuilders. This causes a spurious diagnostic related to inline classes which breaks one test.

This PR changes ClassCodegen to pass a WrappedDescriptor to the ClassBuilder instead.