### PR TITLE
[JVM IR] Enable IR validation and fix all duplication errors

### DIFF
--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/phaser/DumperVerifier.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/phaser/DumperVerifier.kt
@@ -5,6 +5,10 @@
 
 package org.jetbrains.kotlin.backend.common.phaser
 
+import org.jetbrains.kotlin.backend.common.CheckDeclarationParentsVisitor
+import org.jetbrains.kotlin.backend.common.CommonBackendContext
+import org.jetbrains.kotlin.backend.common.IrValidator
+import org.jetbrains.kotlin.backend.common.IrValidatorConfig
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.util.dump
@@ -118,3 +122,16 @@ fun <Data, Context> dumpToStdout(
     }
 
 val defaultDumper = makeDumpAction(dumpToStdout(::dumpIrElement) + dumpToFile("ir", ::dumpIrElement))
+
+fun <Fragment : IrElement> validationCallback(context: CommonBackendContext, fragment: Fragment) {
+    val validatorConfig = IrValidatorConfig(
+        abortOnError = true,
+        ensureAllNodesAreDifferent = true,
+        checkTypes = false,
+        checkDescriptors = false
+    )
+    fragment.accept(IrValidator(context, validatorConfig), null)
+    fragment.accept(CheckDeclarationParentsVisitor, null)
+}
+
+val validationAction = makeVerifyAction(::validationCallback)

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/phaser/PhaseBuilders.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/phaser/PhaseBuilders.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.backend.common.phaser
 import org.jetbrains.kotlin.backend.common.CommonBackendContext
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.lower
+import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 
@@ -54,7 +55,7 @@ fun <Context : CommonBackendContext> namedIrModulePhase(
     preconditions: Set<Checker<IrModuleFragment>> = emptySet(),
     postconditions: Set<Checker<IrModuleFragment>> = emptySet(),
     stickyPostconditions: Set<Checker<IrModuleFragment>> = lower.stickyPostconditions,
-    actions: Set<Action<IrModuleFragment, Context>> = setOf(defaultDumper),
+    actions: Set<Action<IrModuleFragment, Context>> = setOf(defaultDumper, validationAction),
     nlevels: Int = 1
 ) = SameTypeNamedPhaseWrapper(
     name,
@@ -76,7 +77,7 @@ fun <Context : CommonBackendContext> namedIrFilePhase(
     preconditions: Set<Checker<IrFile>> = emptySet(),
     postconditions: Set<Checker<IrFile>> = emptySet(),
     stickyPostconditions: Set<Checker<IrFile>> = lower.stickyPostconditions,
-    actions: Set<Action<IrFile, Context>> = setOf(defaultDumper),
+    actions: Set<Action<IrFile, Context>> = setOf(defaultDumper, validationAction),
     nlevels: Int = 1
 ) = SameTypeNamedPhaseWrapper(
     name,
@@ -88,6 +89,38 @@ fun <Context : CommonBackendContext> namedIrFilePhase(
     stickyPostconditions,
     actions,
     nlevels
+)
+
+fun <Context : CommonBackendContext, Element : IrElement> makeCustomPhase(
+    op: (Context, Element) -> Unit,
+    description: String,
+    name: String,
+    prerequisite: Set<AnyNamedPhase> = emptySet(),
+    preconditions: Set<Checker<Element>> = emptySet(),
+    postconditions: Set<Checker<Element>> = emptySet(),
+    stickyPostconditions: Set<Checker<Element>> = emptySet(),
+    actions: Set<Action<Element, Context>> = setOf(defaultDumper, validationAction),
+    nlevels: Int = 1
+) = SameTypeNamedPhaseWrapper(
+    name,
+    description,
+    prerequisite,
+    preconditions = preconditions,
+    postconditions = postconditions,
+    stickyPostconditions = stickyPostconditions,
+    actions = actions,
+    nlevels = nlevels,
+    lower = object : SameTypeCompilerPhase<Context, Element> {
+        override fun invoke(
+            phaseConfig: PhaseConfig,
+            phaserState: PhaserState<Element>,
+            context: Context,
+            input: Element
+        ): Element {
+            op(context, input)
+            return input
+        }
+    }
 )
 
 fun <Context : CommonBackendContext> namedUnitPhase(
@@ -160,7 +193,7 @@ fun <Context : CommonBackendContext> makeIrFilePhase(
     preconditions: Set<Checker<IrFile>> = emptySet(),
     postconditions: Set<Checker<IrFile>> = emptySet(),
     stickyPostconditions: Set<Checker<IrFile>> = emptySet(),
-    actions: Set<Action<IrFile, Context>> = setOf(defaultDumper)
+    actions: Set<Action<IrFile, Context>> = setOf(defaultDumper, validationAction)
 ) = namedIrFilePhase(
     name, description, prerequisite,
     preconditions = preconditions,
@@ -184,7 +217,7 @@ fun <Context : CommonBackendContext> makeIrModulePhase(
     preconditions: Set<Checker<IrModuleFragment>> = emptySet(),
     postconditions: Set<Checker<IrModuleFragment>> = emptySet(),
     stickyPostconditions: Set<Checker<IrModuleFragment>> = emptySet(),
-    actions: Set<Action<IrModuleFragment, Context>> = setOf(defaultDumper)
+    actions: Set<Action<IrModuleFragment, Context>> = setOf(defaultDumper, validationAction)
 ) = namedIrModulePhase(
     name, description, prerequisite,
     preconditions=preconditions,

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/JsLoweringPhases.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/JsLoweringPhases.kt
@@ -21,19 +21,6 @@ private fun DeclarationContainerLoweringPass.runOnFilesPostfix(files: Iterable<I
 
 private fun ClassLoweringPass.runOnFilesPostfix(moduleFragment: IrModuleFragment) = moduleFragment.files.forEach { runOnFilePostfix(it) }
 
-private fun validationCallback(context: JsIrBackendContext, module: IrModuleFragment) {
-    val validatorConfig = IrValidatorConfig(
-        abortOnError = true,
-        ensureAllNodesAreDifferent = true,
-        checkTypes = false,
-        checkDescriptors = false
-    )
-    module.accept(IrValidator(context, validatorConfig), null)
-    module.accept(CheckDeclarationParentsVisitor, null)
-}
-
-val validationAction = makeVerifyAction(::validationCallback)
-
 private fun makeJsModulePhase(
     lowering: (JsIrBackendContext) -> FileLoweringPass,
     name: String,

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
@@ -37,6 +37,18 @@ private fun makePatchParentsPhase(number: Int) = namedIrFilePhase(
     nlevels = 0
 )
 
+private val validateIrBeforeLowering = makeCustomPhase<JvmBackendContext, IrModuleFragment>(
+    { context, module -> validationCallback(context, module) },
+    name = "ValidateIrBeforeLowering",
+    description = "Validate IR before lowering"
+)
+
+private val validateIrAfterLowering = makeCustomPhase<JvmBackendContext, IrModuleFragment>(
+    { context, module -> validationCallback(context, module) },
+    name = "ValidateIrAfterLowering",
+    description = "Validate IR after lowering"
+)
+
 private val stripTypeAliasDeclarationsPhase = makeIrFilePhase<CommonBackendContext>(
     { StripTypeAliasDeclarationsLowering() },
     name = "StripTypeAliasDeclarations",
@@ -231,10 +243,12 @@ private val jvmFilePhases =
 val jvmPhases = namedIrModulePhase(
     name = "IrLowering",
     description = "IR lowering",
+    // TODO: Add validateIrBeforeLowering. Currently fails FIR tests.
     lower = expectDeclarationsRemovingPhase then
             fileClassPhase then
             performByIrFile(lower = jvmFilePhases) then
-            generateMultifileFacadesPhase
+            generateMultifileFacadesPhase then
+            validateIrAfterLowering
 )
 
 class JvmLower(val context: JvmBackendContext) {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/ConstLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/ConstLowering.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.ir.expressions.IrConst
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrGetField
+import org.jetbrains.kotlin.ir.util.deepCopyWithSymbols
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
 
@@ -30,7 +31,7 @@ fun IrField.constantValue(implicitConst: Boolean = false): IrConst<*>? {
     // Kotlin fields are only inlined if explicitly `const` to avoid making the values part of the ABI.
     val inline = correspondingPropertySymbol?.owner?.isConst == true ||
             (isStatic && isFinal && (origin == IrDeclarationOrigin.IR_EXTERNAL_JAVA_DECLARATION_STUB || implicitConst))
-    return if (inline) initializer?.expression as? IrConst<*> else null
+    return if (inline) (initializer?.expression as? IrConst<*>)?.copy() else null
 }
 
 class ConstLowering(val context: CommonBackendContext) : IrElementTransformerVoid(), FileLoweringPass {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/JvmBuiltinOptimizationLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/JvmBuiltinOptimizationLowering.kt
@@ -272,7 +272,7 @@ class JvmBuiltinOptimizationLowering(val context: JvmBackendContext) : FileLower
                 // initializer with the constant initializer.
                 val variable = expression.symbol.owner
                 return if (isImmutableTemporaryVariableWithConstantValue(variable))
-                    (variable as IrVariable).initializer!!
+                    ((variable as IrVariable).initializer!! as IrConst<*>).copy()
                 else
                     expression
             }

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/MoveCompanionObjectFieldsLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/MoveCompanionObjectFieldsLowering.kt
@@ -27,6 +27,7 @@ import org.jetbrains.kotlin.ir.symbols.IrFieldSymbol
 import org.jetbrains.kotlin.ir.symbols.impl.IrAnonymousInitializerSymbolImpl
 import org.jetbrains.kotlin.ir.symbols.impl.IrFieldSymbolImpl
 import org.jetbrains.kotlin.ir.symbols.impl.IrVariableSymbolImpl
+import org.jetbrains.kotlin.ir.util.deepCopyWithSymbols
 import org.jetbrains.kotlin.ir.util.hasAnnotation
 import org.jetbrains.kotlin.ir.util.isObject
 import org.jetbrains.kotlin.ir.util.patchDeclarationParents
@@ -224,7 +225,7 @@ private class MoveOrCopyCompanionObjectFieldsLowering(val context: CommonBackend
         if (oldInitializer != null) {
             field.initializer = oldInitializer
                 .replaceThisByStaticReference(context, propertyParent, propertyParent.thisReceiver!!)
-                .patchDeclarationParents(field) as IrExpressionBody
+                .deepCopyWithSymbols(field) as IrExpressionBody
         }
 
         return field

--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/WasmLoweringPhases.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/WasmLoweringPhases.kt
@@ -20,19 +20,6 @@ import org.jetbrains.kotlin.ir.util.patchDeclarationParents
 
 private fun ClassLoweringPass.runOnFilesPostfix(moduleFragment: IrModuleFragment) = moduleFragment.files.forEach { runOnFilePostfix(it) }
 
-private fun validationCallback(context: WasmBackendContext, module: IrModuleFragment) {
-    val validatorConfig = IrValidatorConfig(
-        abortOnError = true,
-        ensureAllNodesAreDifferent = true,
-        checkTypes = false,
-        checkDescriptors = false
-    )
-    module.accept(IrValidator(context, validatorConfig), null)
-    module.accept(CheckDeclarationParentsVisitor, null)
-}
-
-val validationAction = makeVerifyAction(::validationCallback)
-
 private fun makeWasmModulePhase(
     lowering: (WasmBackendContext) -> FileLoweringPass,
     name: String,


### PR DESCRIPTION
@gogabr - I cherry-picked your change into my branch. Thanks for sharing that! I had to disable the IR validation _before_ lowering because it fails one of the FIR tests (`org.jetbrains.kotlin.cli.CliTestGenerated$Jvm.testFirHello`).