### PR TITLE
KT-33526 False positive "Redundant qualifier name" with enum constant initialized with companion object field

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/RemoveRedundantQualifierNameInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/RemoveRedundantQualifierNameInspection.kt
@@ -42,6 +42,13 @@ class RemoveRedundantQualifierNameInspection : AbstractKotlinInspection(), Clean
                 else
                     expressionForAnalyze
 
+                val parentEnumEntry = expressionForAnalyze.getStrictParentOfType<KtEnumEntry>()
+                if (parentEnumEntry != null) {
+                    val companionObject = (expressionForAnalyze.receiverExpression.mainReference?.resolve() as? KtObjectDeclaration)
+                        ?.takeIf { it.isCompanion() }
+                    if (companionObject?.containingClass() == parentEnumEntry.getStrictParentOfType<KtClass>()) return
+                }
+
                 val context = originalExpression.analyze()
 
                 val originalDescriptor = expressionForAnalyze.getQualifiedElementSelector()

--- a/idea/testData/inspectionsLocal/removeRedundantQualifierName/notApplicableCompanionInEnumEntry.kt
+++ b/idea/testData/inspectionsLocal/removeRedundantQualifierName/notApplicableCompanionInEnumEntry.kt
@@ -1,0 +1,9 @@
+// PROBLEM: none
+enum class C(val i: Int) {
+    ONE(<caret>C.K)
+    ;
+
+    companion object {
+        const val K = 1
+    }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -8329,6 +8329,11 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
             runTest("idea/testData/inspectionsLocal/removeRedundantQualifierName/notApplicableCompanion.kt");
         }
 
+        @TestMetadata("notApplicableCompanionInEnumEntry.kt")
+        public void testNotApplicableCompanionInEnumEntry() throws Exception {
+            runTest("idea/testData/inspectionsLocal/removeRedundantQualifierName/notApplicableCompanionInEnumEntry.kt");
+        }
+
         @TestMetadata("notApplicableCompanionOtherName.kt")
         public void testNotApplicableCompanionOtherName() throws Exception {
             runTest("idea/testData/inspectionsLocal/removeRedundantQualifierName/notApplicableCompanionOtherName.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-33526