### PR TITLE
JVM IR: Respect InlineConstVals

### DIFF
--- a/compiler/testData/codegen/box/constants/kt9532_lv10.kt
+++ b/compiler/testData/codegen/box/constants/kt9532_lv10.kt
@@ -1,5 +1,5 @@
 // !LANGUAGE: -InlineConstVals
-// IGNORE_BACKEND: JVM_IR, JS_IR, NATIVE
+// IGNORE_BACKEND: JS_IR, NATIVE
 // TODO: muted automatically, investigate should it be ran for JS or not
 // IGNORE_BACKEND: JS
 

--- a/compiler/testData/codegen/bytecodeText/constProperty/noInline.kt
+++ b/compiler/testData/codegen/bytecodeText/constProperty/noInline.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: -InlineConstVals
-// IGNORE_BACKEND: JVM_IR
 
 const val z = 0
 

--- a/compiler/testData/codegen/bytecodeText/constProperty/noInlineInCmp.kt
+++ b/compiler/testData/codegen/bytecodeText/constProperty/noInlineInCmp.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: -InlineConstVals
-// IGNORE_BACKEND: JVM_IR
 
 const val z = 0
 

--- a/compiler/testData/codegen/bytecodeText/lazyCodegen/negateConstantCompare.kt
+++ b/compiler/testData/codegen/bytecodeText/lazyCodegen/negateConstantCompare.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: -InlineConstVals
-// IGNORE_BACKEND: JVM_IR
 
 const val one = 1
 const val two = 2

--- a/compiler/testData/codegen/bytecodeText/whenStringOptimization/nonInlinedConst.kt
+++ b/compiler/testData/codegen/bytecodeText/whenStringOptimization/nonInlinedConst.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: -InlineConstVals
-// IGNORE_BACKEND: JVM_IR
 
 const val y = "cde"
 


### PR DESCRIPTION
I'm honestly not sure if this feature is relevant for the IR backends - as far as I can tell, this is merely for compatibility with Kotlin before version 1.1