### PR TITLE
IR: don't invoke System.exit on a whim

### DIFF
--- a/compiler/util-io/src/org/jetbrains/kotlin/util/WithLogger.kt
+++ b/compiler/util-io/src/org/jetbrains/kotlin/util/WithLogger.kt
@@ -18,7 +18,6 @@ object DummyLogger : Logger {
     override fun error(message: String) = println("e: $message")
     override fun warning(message: String) = println("w: $message")
     override fun fatal(message: String): Nothing {
-        println("e: $message")
-        exitProcess(1)
+        kotlin.error(message)
     }
 }


### PR DESCRIPTION
`exitProcess(1)` delegates to `System.exit(1)`, which results in:
```
Execution failed for task ':js:js.tests:test'. org.gradle.process.internal.ExecException: Process 'Gradle Test Executor 29' finished with non-zero exit value 1
This problem might be caused by incorrect test process configuration.
Please refer to the test execution section in the User Manual at https://docs.gradle.org/5.5/userguide/java_testing.html#sec:test_execution
```