### PR TITLE
KT-33211 Quickfix "add parameter" for method references should infer functional type instead of KFunction

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/AddFunctionParametersFix.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/AddFunctionParametersFix.kt
@@ -24,6 +24,8 @@ import com.intellij.psi.PsiNamedElement
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.PsiSearchHelper
 import com.intellij.psi.search.searches.ReferencesSearch
+import org.jetbrains.kotlin.builtins.isKFunctionType
+import org.jetbrains.kotlin.builtins.isKSuspendFunctionType
 import org.jetbrains.kotlin.descriptors.ConstructorDescriptor
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.diagnostics.Diagnostic
@@ -32,7 +34,6 @@ import org.jetbrains.kotlin.diagnostics.Errors
 import org.jetbrains.kotlin.idea.KotlinBundle
 import org.jetbrains.kotlin.idea.caches.resolve.analyze
 import org.jetbrains.kotlin.idea.core.CollectingNameValidator
-import org.jetbrains.kotlin.idea.intentions.isKFunction
 import org.jetbrains.kotlin.idea.intentions.reflectToRegularFunctionType
 import org.jetbrains.kotlin.idea.refactoring.changeSignature.*
 import org.jetbrains.kotlin.idea.util.application.runReadAction
@@ -194,7 +195,7 @@ class AddFunctionParametersFix(
         val name = getNewArgumentName(argument, validator)
         val expression = argument.getArgumentExpression()
         val type = (expression?.let { getDataFlowAwareTypes(it).firstOrNull() } ?: functionDescriptor.builtIns.nullableAnyType).let {
-            if (it.isKFunction()) it.reflectToRegularFunctionType() else it
+            if (it.isKFunctionType || it.isKSuspendFunctionType) it.reflectToRegularFunctionType() else it
         }
         return KotlinParameterInfo(functionDescriptor, -1, name, KotlinTypeInfo(false, null)).apply {
             currentTypeInfo = KotlinTypeInfo(false, type)

--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixFactoryForTypeMismatchError.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixFactoryForTypeMismatchError.kt
@@ -20,8 +20,7 @@ import com.intellij.codeInsight.intention.IntentionAction
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.psi.util.PsiTreeUtil
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
-import org.jetbrains.kotlin.builtins.functions.FunctionClassDescriptor
-import org.jetbrains.kotlin.builtins.getFunctionalClassKind
+import org.jetbrains.kotlin.builtins.isKFunctionType
 import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.diagnostics.Diagnostic
 import org.jetbrains.kotlin.diagnostics.Errors
@@ -30,7 +29,6 @@ import org.jetbrains.kotlin.idea.caches.resolve.analyzeWithContent
 import org.jetbrains.kotlin.idea.caches.resolve.findModuleDescriptor
 import org.jetbrains.kotlin.idea.caches.resolve.getResolutionFacade
 import org.jetbrains.kotlin.idea.core.quickfix.QuickFixUtil
-import org.jetbrains.kotlin.idea.intentions.isKFunction
 import org.jetbrains.kotlin.idea.intentions.reflectToRegularFunctionType
 import org.jetbrains.kotlin.idea.project.languageVersionSettings
 import org.jetbrains.kotlin.idea.util.approximateWithResolvableType
@@ -50,10 +48,12 @@ import org.jetbrains.kotlin.resolve.calls.model.ResolvedCall
 import org.jetbrains.kotlin.resolve.constants.IntegerValueTypeConstant
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 import org.jetbrains.kotlin.types.KotlinType
-import org.jetbrains.kotlin.types.KotlinTypeFactory
 import org.jetbrains.kotlin.types.TypeUtils
 import org.jetbrains.kotlin.types.TypeUtils.NO_EXPECTED_TYPE
-import org.jetbrains.kotlin.types.typeUtil.*
+import org.jetbrains.kotlin.types.typeUtil.isInterface
+import org.jetbrains.kotlin.types.typeUtil.isSignedOrUnsignedNumberType
+import org.jetbrains.kotlin.types.typeUtil.isSubtypeOf
+import org.jetbrains.kotlin.types.typeUtil.makeNullable
 import java.util.*
 
 //TODO: should use change signature to deal with cases of multiple overridden descriptors
@@ -179,7 +179,7 @@ class QuickFixFactoryForTypeMismatchError : KotlinIntentionActionsFactory() {
         ) {
             val scope = callable.getResolutionScope(context, callable.getResolutionFacade())
             val typeToInsert = expressionType.approximateWithResolvableType(scope, false)
-            if (typeToInsert.isKFunction()) {
+            if (typeToInsert.isKFunctionType) {
                 actions.add(createFix(callable, typeToInsert.reflectToRegularFunctionType()))
             }
             actions.add(createFix(callable, typeToInsert))

--- a/idea/testData/quickfix/changeSignature/addFunctionParameterWithAnonymousFunction.kt
+++ b/idea/testData/quickfix/changeSignature/addFunctionParameterWithAnonymousFunction.kt
@@ -1,0 +1,6 @@
+// "Add parameter to function 'baz'" "true"
+fun baz() {}
+
+fun foo() {
+    baz(fun(i: Int): String { return i.toString() }<caret>)
+}

--- a/idea/testData/quickfix/changeSignature/addFunctionParameterWithAnonymousFunction.kt.after
+++ b/idea/testData/quickfix/changeSignature/addFunctionParameterWithAnonymousFunction.kt.after
@@ -1,0 +1,6 @@
+// "Add parameter to function 'baz'" "true"
+fun baz(function: (Int) -> String) {}
+
+fun foo() {
+    baz(fun(i: Int): String { return i.toString() }<caret>)
+}

--- a/idea/testData/quickfix/changeSignature/addFunctionParameterWithFunctionReference.kt
+++ b/idea/testData/quickfix/changeSignature/addFunctionParameterWithFunctionReference.kt
@@ -1,0 +1,8 @@
+// "Add parameter to function 'baz'" "true"
+fun bar(): Int = 42
+
+fun baz() {}
+
+fun foo() {
+    baz(::bar<caret>)
+}

--- a/idea/testData/quickfix/changeSignature/addFunctionParameterWithFunctionReference.kt.after
+++ b/idea/testData/quickfix/changeSignature/addFunctionParameterWithFunctionReference.kt.after
@@ -1,0 +1,8 @@
+// "Add parameter to function 'baz'" "true"
+fun bar(): Int = 42
+
+fun baz(kFunction0: () -> Int) {}
+
+fun foo() {
+    baz(::bar)
+}

--- a/idea/testData/quickfix/changeSignature/addFunctionParameterWithLambda.kt
+++ b/idea/testData/quickfix/changeSignature/addFunctionParameterWithLambda.kt
@@ -1,0 +1,6 @@
+// "Add parameter to function 'baz'" "true"
+fun baz() {}
+
+fun foo() {
+    baz { i: Int -> i.toString() }<caret>
+}

--- a/idea/testData/quickfix/changeSignature/addFunctionParameterWithLambda.kt.after
+++ b/idea/testData/quickfix/changeSignature/addFunctionParameterWithLambda.kt.after
@@ -1,0 +1,6 @@
+// "Add parameter to function 'baz'" "true"
+fun baz(function: (Int) -> String) {}
+
+fun foo() {
+    baz { i: Int -> i.toString() }<caret>
+}

--- a/idea/testData/quickfix/changeSignature/addFunctionParameterWithSuspendFunctionReference.kt
+++ b/idea/testData/quickfix/changeSignature/addFunctionParameterWithSuspendFunctionReference.kt
@@ -1,0 +1,8 @@
+// "Add parameter to function 'baz'" "true"
+suspend fun bar(): Int = 42
+
+suspend fun baz() {}
+
+suspend fun foo() {
+    baz(::bar<caret>)
+}

--- a/idea/testData/quickfix/changeSignature/addFunctionParameterWithSuspendFunctionReference.kt.after
+++ b/idea/testData/quickfix/changeSignature/addFunctionParameterWithSuspendFunctionReference.kt.after
@@ -1,0 +1,8 @@
+// "Add parameter to function 'baz'" "true"
+suspend fun bar(): Int = 42
+
+suspend fun baz(kSuspendFunction0: suspend () -> Int) {}
+
+suspend fun foo() {
+    baz(::bar)
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -2348,6 +2348,11 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
             runTest("idea/testData/quickfix/changeSignature/addFunctionParameterWithSmartcastedArgument.kt");
         }
 
+        @TestMetadata("addFunctionParameterWithSuspendFunctionReference.kt")
+        public void testAddFunctionParameterWithSuspendFunctionReference() throws Exception {
+            runTest("idea/testData/quickfix/changeSignature/addFunctionParameterWithSuspendFunctionReference.kt");
+        }
+
         @TestMetadata("addNothingReturnType.kt")
         public void testAddNothingReturnType() throws Exception {
             runTest("idea/testData/quickfix/changeSignature/addNothingReturnType.kt");

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -2323,6 +2323,21 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
             runTest("idea/testData/quickfix/changeSignature/addFunctionParameterLongNameRuntime.kt");
         }
 
+        @TestMetadata("addFunctionParameterWithAnonymousFunction.kt")
+        public void testAddFunctionParameterWithAnonymousFunction() throws Exception {
+            runTest("idea/testData/quickfix/changeSignature/addFunctionParameterWithAnonymousFunction.kt");
+        }
+
+        @TestMetadata("addFunctionParameterWithFunctionReference.kt")
+        public void testAddFunctionParameterWithFunctionReference() throws Exception {
+            runTest("idea/testData/quickfix/changeSignature/addFunctionParameterWithFunctionReference.kt");
+        }
+
+        @TestMetadata("addFunctionParameterWithLambda.kt")
+        public void testAddFunctionParameterWithLambda() throws Exception {
+            runTest("idea/testData/quickfix/changeSignature/addFunctionParameterWithLambda.kt");
+        }
+
         @TestMetadata("addFunctionParameterWithSmartCast.kt")
         public void testAddFunctionParameterWithSmartCast() throws Exception {
             runTest("idea/testData/quickfix/changeSignature/addFunctionParameterWithSmartCast.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-33211