### PR TITLE
[IR] Deal with forward references in default argument lambdas.

### DIFF
--- a/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/fir/Fir2IrTextTestGenerated.java
+++ b/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/fir/Fir2IrTextTestGenerated.java
@@ -581,6 +581,11 @@ public class Fir2IrTextTestGenerated extends AbstractFir2IrTextTest {
             public void testTypeParameterBoundedBySubclass() throws Exception {
                 runTest("compiler/testData/ir/irText/declarations/parameters/typeParameterBoundedBySubclass.kt");
             }
+
+            @TestMetadata("useNextParamInLambda.kt")
+            public void testUseNextParamInLambda() throws Exception {
+                runTest("compiler/testData/ir/irText/declarations/parameters/useNextParamInLambda.kt");
+            }
         }
 
         @TestMetadata("compiler/testData/ir/irText/declarations/provideDelegate")

--- a/compiler/testData/codegen/box/defaultArguments/useNextParamInLambda.kt
+++ b/compiler/testData/codegen/box/defaultArguments/useNextParamInLambda.kt
@@ -1,0 +1,16 @@
+// IGNORE_BACKEND: JS, JS_IR
+
+fun f(
+    f1: () -> String = { f2() },
+    f2: () -> String = { "FAIL" }
+): String = f1()
+
+fun box(): String {
+    var result = "fail"
+    try {
+        f()
+    } catch (e : Exception) {
+        result = "OK"
+    }
+    return f(f2 = { "O" }) + f(f1 = { "K" })
+}

--- a/compiler/testData/ir/irText/declarations/parameters/useNextParamInLambda.fir.txt
+++ b/compiler/testData/ir/irText/declarations/parameters/useNextParamInLambda.fir.txt
@@ -1,0 +1,41 @@
+FILE fqName:<root> fileName:/useNextParamInLambda.kt
+  FUN name:f visibility:public modality:FINAL <> (f1:kotlin.Function0<kotlin.String>, f2:kotlin.Function0<kotlin.String>) returnType:kotlin.String
+    VALUE_PARAMETER name:f1 index:0 type:kotlin.Function0<kotlin.String>
+      EXPRESSION_BODY
+        FUN_EXPR type=kotlin.Function0<IrErrorType> origin=LAMBDA
+          FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> () returnType:IrErrorType
+            BLOCK_BODY
+              ERROR_CALL 'Unresolved reference: <Unresolved name: f2>#' type=IrErrorType
+    VALUE_PARAMETER name:f2 index:1 type:kotlin.Function0<kotlin.String>
+      EXPRESSION_BODY
+        FUN_EXPR type=kotlin.Function0<kotlin.String> origin=LAMBDA
+          FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> () returnType:kotlin.String
+            BLOCK_BODY
+              CONST String type=kotlin.String value="FAIL"
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='public final fun f (f1: kotlin.Function0<kotlin.String>, f2: kotlin.Function0<kotlin.String>): kotlin.String declared in <root>'
+        CALL 'public abstract fun invoke (): kotlin.String declared in kotlin.Function0' type=kotlin.String origin=null
+          $this: GET_VAR 'f1: kotlin.Function0<kotlin.String> declared in <root>.f' type=kotlin.Function0<kotlin.String> origin=null
+  FUN name:box visibility:public modality:FINAL <> () returnType:kotlin.String
+    BLOCK_BODY
+      VAR name:result type:kotlin.String [var]
+        CONST String type=kotlin.String value="fail"
+      TRY type=kotlin.String
+        try: CALL 'public final fun f (f1: kotlin.Function0<kotlin.String>, f2: kotlin.Function0<kotlin.String>): kotlin.String declared in <root>' type=kotlin.String origin=null
+        CATCH parameter=val e: java.lang.Exception [val] declared in <root>.box
+          VAR name:e type:java.lang.Exception [val]
+          BLOCK type=kotlin.Unit origin=null
+            SET_VAR 'var result: kotlin.String [var] declared in <root>.box' type=kotlin.String origin=null
+              CONST String type=kotlin.String value="OK"
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        CALL 'public final fun plus (other: kotlin.Any?): kotlin.String declared in kotlin.String' type=kotlin.String origin=null
+          $this: CALL 'public final fun f (f1: kotlin.Function0<kotlin.String>, f2: kotlin.Function0<kotlin.String>): kotlin.String declared in <root>' type=kotlin.String origin=null
+            f1: FUN_EXPR type=kotlin.Function0<kotlin.String> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> () returnType:kotlin.String
+                BLOCK_BODY
+                  CONST String type=kotlin.String value="O"
+          other: CALL 'public final fun f (f1: kotlin.Function0<kotlin.String>, f2: kotlin.Function0<kotlin.String>): kotlin.String declared in <root>' type=kotlin.String origin=null
+            f1: FUN_EXPR type=kotlin.Function0<kotlin.String> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> () returnType:kotlin.String
+                BLOCK_BODY
+                  CONST String type=kotlin.String value="K"

--- a/compiler/testData/ir/irText/declarations/parameters/useNextParamInLambda.kt
+++ b/compiler/testData/ir/irText/declarations/parameters/useNextParamInLambda.kt
@@ -1,0 +1,14 @@
+fun f(
+    f1: () -> String = { f2() },
+    f2: () -> String = { "FAIL" }
+): String = f1()
+
+fun box(): String {
+    var result = "fail"
+    try {
+        f()
+    } catch (e : Exception) {
+        result = "OK"
+    }
+    return f(f2 = { "O" }) + f(f1 = { "K" })
+}

--- a/compiler/testData/ir/irText/declarations/parameters/useNextParamInLambda.txt
+++ b/compiler/testData/ir/irText/declarations/parameters/useNextParamInLambda.txt
@@ -1,0 +1,48 @@
+FILE fqName:<root> fileName:/useNextParamInLambda.kt
+  FUN name:f visibility:public modality:FINAL <> (f1:kotlin.Function0<kotlin.String>, f2:kotlin.Function0<kotlin.String>) returnType:kotlin.String
+    VALUE_PARAMETER name:f1 index:0 type:kotlin.Function0<kotlin.String>
+      EXPRESSION_BODY
+        FUN_EXPR type=kotlin.Function0<kotlin.String> origin=LAMBDA
+          FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> () returnType:kotlin.String
+            BLOCK_BODY
+              RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.String declared in <root>.f'
+                CALL 'public abstract fun invoke (): R of kotlin.Function0 declared in kotlin.Function0' type=kotlin.String origin=INVOKE
+                  $this: GET_VAR 'f2: kotlin.Function0<kotlin.String> declared in <root>.f' type=kotlin.Function0<kotlin.String> origin=VARIABLE_AS_FUNCTION
+    VALUE_PARAMETER name:f2 index:1 type:kotlin.Function0<kotlin.String>
+      EXPRESSION_BODY
+        FUN_EXPR type=kotlin.Function0<kotlin.String> origin=LAMBDA
+          FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> () returnType:kotlin.String
+            BLOCK_BODY
+              RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.String declared in <root>.f'
+                CONST String type=kotlin.String value="FAIL"
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='public final fun f (f1: kotlin.Function0<kotlin.String>, f2: kotlin.Function0<kotlin.String>): kotlin.String declared in <root>'
+        CALL 'public abstract fun invoke (): R of kotlin.Function0 declared in kotlin.Function0' type=kotlin.String origin=INVOKE
+          $this: GET_VAR 'f1: kotlin.Function0<kotlin.String> declared in <root>.f' type=kotlin.Function0<kotlin.String> origin=VARIABLE_AS_FUNCTION
+  FUN name:box visibility:public modality:FINAL <> () returnType:kotlin.String
+    BLOCK_BODY
+      VAR name:result type:kotlin.String [var]
+        CONST String type=kotlin.String value="fail"
+      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+        TRY type=kotlin.Any
+          try: BLOCK type=kotlin.String origin=null
+            CALL 'public final fun f (f1: kotlin.Function0<kotlin.String>, f2: kotlin.Function0<kotlin.String>): kotlin.String declared in <root>' type=kotlin.String origin=null
+          CATCH parameter=val e: java.lang.Exception{ kotlin.Exception } [val] declared in <root>.box
+            VAR CATCH_PARAMETER name:e type:java.lang.Exception{ kotlin.Exception } [val]
+            BLOCK type=kotlin.Unit origin=null
+              SET_VAR 'var result: kotlin.String [var] declared in <root>.box' type=kotlin.Unit origin=EQ
+                CONST String type=kotlin.String value="OK"
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        CALL 'public final fun plus (other: kotlin.Any?): kotlin.String declared in kotlin.String' type=kotlin.String origin=PLUS
+          $this: CALL 'public final fun f (f1: kotlin.Function0<kotlin.String>, f2: kotlin.Function0<kotlin.String>): kotlin.String declared in <root>' type=kotlin.String origin=null
+            f2: FUN_EXPR type=kotlin.Function0<kotlin.String> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> () returnType:kotlin.String
+                BLOCK_BODY
+                  RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.String declared in <root>.box'
+                    CONST String type=kotlin.String value="O"
+          other: CALL 'public final fun f (f1: kotlin.Function0<kotlin.String>, f2: kotlin.Function0<kotlin.String>): kotlin.String declared in <root>' type=kotlin.String origin=null
+            f1: FUN_EXPR type=kotlin.Function0<kotlin.String> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> () returnType:kotlin.String
+                BLOCK_BODY
+                  RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.String declared in <root>.box'
+                    CONST String type=kotlin.String value="K"

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -8987,6 +8987,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             runTest("compiler/testData/codegen/box/defaultArguments/superCallCheck.kt");
         }
 
+        @TestMetadata("useNextParamInLambda.kt")
+        public void testUseNextParamInLambda() throws Exception {
+            runTest("compiler/testData/codegen/box/defaultArguments/useNextParamInLambda.kt");
+        }
+
         @TestMetadata("useThisInLambda.kt")
         public void testUseThisInLambda() throws Exception {
             runTest("compiler/testData/codegen/box/defaultArguments/useThisInLambda.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -8987,6 +8987,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/defaultArguments/superCallCheck.kt");
         }
 
+        @TestMetadata("useNextParamInLambda.kt")
+        public void testUseNextParamInLambda() throws Exception {
+            runTest("compiler/testData/codegen/box/defaultArguments/useNextParamInLambda.kt");
+        }
+
         @TestMetadata("useThisInLambda.kt")
         public void testUseThisInLambda() throws Exception {
             runTest("compiler/testData/codegen/box/defaultArguments/useThisInLambda.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -7872,6 +7872,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             runTest("compiler/testData/codegen/box/defaultArguments/superCallCheck.kt");
         }
 
+        @TestMetadata("useNextParamInLambda.kt")
+        public void testUseNextParamInLambda() throws Exception {
+            runTest("compiler/testData/codegen/box/defaultArguments/useNextParamInLambda.kt");
+        }
+
         @TestMetadata("useThisInLambda.kt")
         public void testUseThisInLambda() throws Exception {
             runTest("compiler/testData/codegen/box/defaultArguments/useThisInLambda.kt");

--- a/compiler/tests/org/jetbrains/kotlin/ir/IrTextTestCaseGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/ir/IrTextTestCaseGenerated.java
@@ -581,6 +581,11 @@ public class IrTextTestCaseGenerated extends AbstractIrTextTestCase {
             public void testTypeParameterBoundedBySubclass() throws Exception {
                 runTest("compiler/testData/ir/irText/declarations/parameters/typeParameterBoundedBySubclass.kt");
             }
+
+            @TestMetadata("useNextParamInLambda.kt")
+            public void testUseNextParamInLambda() throws Exception {
+                runTest("compiler/testData/ir/irText/declarations/parameters/useNextParamInLambda.kt");
+            }
         }
 
         @TestMetadata("compiler/testData/ir/irText/declarations/provideDelegate")

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -6717,6 +6717,11 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/defaultArguments/simpleFromOtherFile.kt");
         }
 
+        @TestMetadata("useNextParamInLambda.kt")
+        public void testUseNextParamInLambda() throws Exception {
+            runTest("compiler/testData/codegen/box/defaultArguments/useNextParamInLambda.kt");
+        }
+
         @TestMetadata("useThisInLambda.kt")
         public void testUseThisInLambda() throws Exception {
             runTest("compiler/testData/codegen/box/defaultArguments/useThisInLambda.kt");

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -7802,6 +7802,11 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/defaultArguments/simpleFromOtherFile.kt");
         }
 
+        @TestMetadata("useNextParamInLambda.kt")
+        public void testUseNextParamInLambda() throws Exception {
+            runTest("compiler/testData/codegen/box/defaultArguments/useNextParamInLambda.kt");
+        }
+
         @TestMetadata("useThisInLambda.kt")
         public void testUseThisInLambda() throws Exception {
             runTest("compiler/testData/codegen/box/defaultArguments/useThisInLambda.kt");


### PR DESCRIPTION
Rely on the frontend weeding out cases that are not supported.

In psi2ir, introduce all the parameters before processing default
values.

Change the DefaultArgumentStubGenerator to generate code that
matches the behavior of the current backend.