### PR TITLE
JVM IR: Overrides + Incremental Compilation Bug

### DIFF
--- a/compiler/testData/compileKotlinAgainstCustomBinaries/separateCompilationRegression/library/library.kt
+++ b/compiler/testData/compileKotlinAgainstCustomBinaries/separateCompilationRegression/library/library.kt
@@ -1,0 +1,7 @@
+interface A {
+    fun foo() = "FAIL"
+}
+
+interface B : A {
+
+}

--- a/compiler/testData/compileKotlinAgainstCustomBinaries/separateCompilationRegression/newlibrary/newlibrary.kt
+++ b/compiler/testData/compileKotlinAgainstCustomBinaries/separateCompilationRegression/newlibrary/newlibrary.kt
@@ -1,0 +1,7 @@
+interface A {
+    fun foo() = "FAIL"
+}
+
+interface B : A {
+    override fun foo() = "OK"
+}

--- a/compiler/testData/compileKotlinAgainstCustomBinaries/separateCompilationRegression/usage.kt
+++ b/compiler/testData/compileKotlinAgainstCustomBinaries/separateCompilationRegression/usage.kt
@@ -1,0 +1,4 @@
+fun box(): String {
+    val x = object : B {}
+    return x.foo()
+}

--- a/compiler/testData/compileKotlinAgainstCustomBinaries/separateCompilationRegressionIr/library/library.kt
+++ b/compiler/testData/compileKotlinAgainstCustomBinaries/separateCompilationRegressionIr/library/library.kt
@@ -1,0 +1,7 @@
+interface A {
+    fun foo() = "FAIL"
+}
+
+interface B : A {
+
+}

--- a/compiler/testData/compileKotlinAgainstCustomBinaries/separateCompilationRegressionIr/newlibrary/newlibrary.kt
+++ b/compiler/testData/compileKotlinAgainstCustomBinaries/separateCompilationRegressionIr/newlibrary/newlibrary.kt
@@ -1,0 +1,7 @@
+interface A {
+    fun foo() = "FAIL"
+}
+
+interface B : A {
+    override fun foo() = "OK"
+}

--- a/compiler/testData/compileKotlinAgainstCustomBinaries/separateCompilationRegressionIr/usage.kt
+++ b/compiler/testData/compileKotlinAgainstCustomBinaries/separateCompilationRegressionIr/usage.kt
@@ -1,0 +1,4 @@
+fun box(): String {
+    val x = object : B {}
+    return x.foo()
+}


### PR DESCRIPTION
This commit introduces two tests illustrating the behaviour of the old
and new JVM backends pertaining to override resolution and its
interaction with separate/incremental compilation of interfaces and
clients of that interface. 

In particular, it reveals a flaw in code generation in the IR backend.

Note that this commit introduces a new, failing test. This PR is intended
as a "ticket".