### PR TITLE
KT-33503: Avoid analyzing module-info.class in KAPT classpath

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/incremental/ClasspathAnalyzer.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/incremental/ClasspathAnalyzer.kt
@@ -13,6 +13,7 @@ import java.security.MessageDigest
 import java.util.zip.ZipFile
 
 const val CLASS_STRUCTURE_ARTIFACT_TYPE = "class-structure"
+private const val MODULE_INFO = "module-info.class"
 
 class StructureArtifactTransform : ArtifactTransform() {
     override fun transform(input: File): MutableList<File> {
@@ -37,7 +38,9 @@ private fun visitDirectory(directory: File): ClasspathEntryData {
     val entryData = ClasspathEntryData()
 
     directory.walk().filter {
-        it.extension == "class" && !it.relativeTo(directory).toString().toLowerCase().startsWith("meta-inf")
+        it.extension == "class"
+                && !it.relativeTo(directory).toString().toLowerCase().startsWith("meta-inf")
+                && it.name != MODULE_INFO
     }.forEach {
         val internalName = it.relativeTo(directory).invariantSeparatorsPath.dropLast(".class".length)
         BufferedInputStream(it.inputStream()).use { inputStream ->
@@ -56,7 +59,10 @@ private fun visitJar(jar: File): ClasspathEntryData {
         while (entries.hasMoreElements()) {
             val entry = entries.nextElement()
 
-            if (entry.name.endsWith("class") && !entry.name.toLowerCase().startsWith("meta-inf")) {
+            if (entry.name.endsWith("class")
+                && !entry.name.toLowerCase().startsWith("meta-inf")
+                && entry.name != MODULE_INFO
+            ) {
                 BufferedInputStream(zipFile.getInputStream(entry)).use { inputStream ->
                     analyzeInputStream(inputStream, entry.name.dropLast(".class".length), entryData)
                 }

--- a/libraries/tools/kotlin-gradle-plugin/src/test/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/incremental/ClasspathAnalyzerTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/test/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/incremental/ClasspathAnalyzerTest.kt
@@ -26,7 +26,8 @@ class ClasspathAnalyzerTest {
             dir.resolve("test").mkdirs()
             dir.resolve("test/A.class").writeBytes(emptyClass("test/A"))
             dir.resolve("test/B.class").writeBytes(emptyClass("test/B"))
-            dir.resolve("ignore.txt").writeBytes(emptyClass("test/B"))
+            dir.resolve("ignore.txt").writeText("")
+            dir.resolve("module-info.class").writeText("")
             dir.resolve("META-INF/versions/9/A.class").also {
                 it.parentFile.mkdirs()
                 it.writeBytes(emptyClass("A"))
@@ -58,6 +59,9 @@ class ClasspathAnalyzerTest {
                 it.closeEntry()
 
                 it.putNextEntry(ZipEntry("ignored.txt"))
+                it.closeEntry()
+
+                it.putNextEntry(ZipEntry("module-info.class"))
                 it.closeEntry()
 
                 it.putNextEntry(ZipEntry("META-INF/versions/9/test/A.class"))


### PR DESCRIPTION
When analyzing classpath changes for incremental KAPT, avoid
analyzing module-info.class files.

Test: ClasspathAnalyzerTest