### PR TITLE
KT-11865 "Create secondary constructor" quick fix always inserts parameter-less call to `this()`

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/CallableBuilder.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/CallableBuilder.kt
@@ -582,12 +582,20 @@ class CallableBuilder(val config: CallableBuilderConfiguration) {
 
                 if (declarationInPlace is KtSecondaryConstructor) {
                     val containingClass = declarationInPlace.containingClassOrObject!!
-                    if (containingClass.primaryConstructorParameters.isNotEmpty()) {
+                    val primaryConstructorParameters = containingClass.primaryConstructorParameters
+                    if (primaryConstructorParameters.isNotEmpty()) {
                         declarationInPlace.replaceImplicitDelegationCallWithExplicit(true)
                     } else if ((receiverClassDescriptor as ClassDescriptor).getSuperClassOrAny().constructors
                             .all { it.valueParameters.isNotEmpty() }
                     ) {
                         declarationInPlace.replaceImplicitDelegationCallWithExplicit(false)
+                    }
+                    if (declarationInPlace.valueParameters.size > primaryConstructorParameters.size) {
+                        val delegationCallArgumentList = declarationInPlace.getDelegationCall().valueArgumentList
+                        primaryConstructorParameters.forEach {
+                            val name = it.name
+                            if (name != null) delegationCallArgumentList?.addArgument(psiFactory.createArgument(name))
+                        }
                     }
                 }
 

--- a/idea/testData/quickfix/createFromUsage/createSecondaryConstructor/tooManyArguments.kt
+++ b/idea/testData/quickfix/createFromUsage/createSecondaryConstructor/tooManyArguments.kt
@@ -1,0 +1,7 @@
+// "Create secondary constructor" "true"
+
+class CtorPrimary(val f1: Int)
+
+fun construct() {
+    val v6 = CtorPrimary(1, 2<caret>)
+}

--- a/idea/testData/quickfix/createFromUsage/createSecondaryConstructor/tooManyArguments.kt.after
+++ b/idea/testData/quickfix/createFromUsage/createSecondaryConstructor/tooManyArguments.kt.after
@@ -1,0 +1,9 @@
+// "Create secondary constructor" "true"
+
+class CtorPrimary(val f1: Int) {
+    constructor(f1: Int, i: Int) : this(f1)
+}
+
+fun construct() {
+    val v6 = CtorPrimary(1, 2)
+}

--- a/idea/testData/quickfix/createFromUsage/createSecondaryConstructor/tooManyArguments.kt.after
+++ b/idea/testData/quickfix/createFromUsage/createSecondaryConstructor/tooManyArguments.kt.after
@@ -1,9 +1,9 @@
 // "Create secondary constructor" "true"
 
-class CtorPrimary(val f1: Int) {
-    constructor(f1: Int, i: Int) : this(f1)
+class CtorPrimary(val f1: Int, val f2: Int?) {
+    constructor(f1: Int, f2: Int, i: Int) : this(f1, f2)
 }
 
 fun construct() {
-    val v6 = CtorPrimary(1, 2)
+    val v6 = CtorPrimary(1, 2, 3)
 }

--- a/idea/testData/quickfix/createFromUsage/createSecondaryConstructor/tooManyArgumentsWithImcompatibleType.kt
+++ b/idea/testData/quickfix/createFromUsage/createSecondaryConstructor/tooManyArgumentsWithImcompatibleType.kt
@@ -1,6 +1,7 @@
 // "Create secondary constructor" "true"
+// DISABLE-ERRORS
 
-class CtorPrimary(val f1: Int, val f2: Int?)
+class CtorPrimary(val f1: Int, val f2: String)
 
 fun construct() {
     val v6 = CtorPrimary(1, 2, 3<caret>)

--- a/idea/testData/quickfix/createFromUsage/createSecondaryConstructor/tooManyArgumentsWithImcompatibleType.kt.after
+++ b/idea/testData/quickfix/createFromUsage/createSecondaryConstructor/tooManyArgumentsWithImcompatibleType.kt.after
@@ -1,0 +1,10 @@
+// "Create secondary constructor" "true"
+// DISABLE-ERRORS
+
+class CtorPrimary(val f1: Int, val f2: String) {
+    constructor(f1: Int, f2: Int, i: Int) : this()
+}
+
+fun construct() {
+    val v6 = CtorPrimary(1, 2, 3)
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -4886,6 +4886,11 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
                 runTest("idea/testData/quickfix/createFromUsage/createSecondaryConstructor/thisCall.kt");
             }
 
+            @TestMetadata("tooManyArguments.kt")
+            public void testTooManyArguments() throws Exception {
+                runTest("idea/testData/quickfix/createFromUsage/createSecondaryConstructor/tooManyArguments.kt");
+            }
+
             @TestMetadata("wrongExpectedType.kt")
             public void testWrongExpectedType() throws Exception {
                 runTest("idea/testData/quickfix/createFromUsage/createSecondaryConstructor/wrongExpectedType.kt");

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -4891,6 +4891,11 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
                 runTest("idea/testData/quickfix/createFromUsage/createSecondaryConstructor/tooManyArguments.kt");
             }
 
+            @TestMetadata("tooManyArgumentsWithImcompatibleType.kt")
+            public void testTooManyArgumentsWithImcompatibleType() throws Exception {
+                runTest("idea/testData/quickfix/createFromUsage/createSecondaryConstructor/tooManyArgumentsWithImcompatibleType.kt");
+            }
+
             @TestMetadata("wrongExpectedType.kt")
             public void testWrongExpectedType() throws Exception {
                 runTest("idea/testData/quickfix/createFromUsage/createSecondaryConstructor/wrongExpectedType.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-11865