### PR TITLE
IR: deserialize backing field annotations

### DIFF
--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/declarations/lazy/IrLazyField.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/declarations/lazy/IrLazyField.kt
@@ -61,7 +61,11 @@ class IrLazyField(
         symbol.bind(this)
     }
 
-    override val annotations: MutableList<IrConstructorCall> = mutableListOf()
+    override val annotations: MutableList<IrConstructorCall> by lazy {
+        descriptor.backingField?.annotations
+            ?.mapNotNullTo(mutableListOf(), typeTranslator.constantValueGenerator::generateAnnotationConstructorCall)
+            ?: mutableListOf()
+    }
 
     override val descriptor: PropertyDescriptor = symbol.descriptor
 


### PR DESCRIPTION
Probably going to be necessary for handling imported @JvmField annotated declarations.