### PR TITLE
KT-33617: Handle non-hierarchical URIs for incremental annotation processing

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/java/test/kt33617/MyClass.java
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/java/test/kt33617/MyClass.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package test.kt33617;
+
+public class MyClass {
+}

--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/incremental/classStructureCache.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/incremental/classStructureCache.kt
@@ -9,6 +9,7 @@ import java.io.File
 import java.io.ObjectInputStream
 import java.io.ObjectOutputStream
 import java.io.Serializable
+import java.lang.IllegalArgumentException
 import java.net.URI
 import java.util.regex.Pattern
 
@@ -73,7 +74,23 @@ class JavaClassCache() : Serializable {
         output.writeObject(generatedTypes)
     }
 
-    fun isAlreadyProcessed(sourceFile: URI) = sourceCache.containsKey(sourceFile) || generatedTypes.containsKey(File(sourceFile))
+    fun isAlreadyProcessed(sourceFile: URI): Boolean {
+        if (!sourceFile.isAbsolute) {
+            // we never want to process non-absolute URIs, see https://youtrack.jetbrains.com/issue/KT-33617
+            return true
+        }
+        if (sourceFile.isOpaque) {
+            // we never want to process non-hierarchical URIs, https://youtrack.jetbrains.com/issue/KT-33617
+            return true
+        }
+        return try {
+            val fileFromUri = File(sourceFile)
+            sourceCache.containsKey(sourceFile) || generatedTypes.containsKey(fileFromUri)
+        } catch (e: IllegalArgumentException) {
+            // unable to create File instance, avoid processing these files
+            true
+        }
+    }
 
     /** Used for testing only. */
     internal fun getStructure(sourceFile: File) = sourceCache[sourceFile.toURI()]


### PR DESCRIPTION
JDK9 may decide to load .java files from jar when resolving a type, even
when .class file exists in the same jar. Further on, these files will be
parsed and analyzed, which triggers the listener used by incremental
annotation processing. This commit avoids analyzing those files, and
makes sure URI passed from the compiler are such that a File instance
can be created.

Test: KaptIncrementalWithIsolatingApt.testSourcesInCompileClasspathJars