### PR TITLE
KT-34167: Warn when incremental AP does not follow the contract

### DIFF
--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/ProcessorLoader.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/ProcessorLoader.kt
@@ -56,7 +56,7 @@ open class ProcessorLoader(private val options: KaptOptions, private val logger:
 
     private fun wrapInIncrementalProcessor(processors: List<Processor>, classpath: Iterable<File>): List<IncrementalProcessor> {
         if (options.incrementalCache == null) {
-            return processors.map { IncrementalProcessor(it, DeclaredProcType.NON_INCREMENTAL) }
+            return processors.map { IncrementalProcessor(it, DeclaredProcType.NON_INCREMENTAL, logger) }
         }
 
         val processorNames = processors.map {it.javaClass.name}.toSet()
@@ -72,7 +72,7 @@ open class ProcessorLoader(private val options: KaptOptions, private val logger:
                     DeclaredProcType.INCREMENTAL_BUT_OTHER_APS_ARE_NOT
                 }
             } ?: DeclaredProcType.NON_INCREMENTAL
-            IncrementalProcessor(it, procType)
+            IncrementalProcessor(it, procType, logger)
         }
     }
 

--- a/plugins/kapt3/kapt3-base/test/JavaKaptContextTest.kt
+++ b/plugins/kapt3/kapt3-base/test/JavaKaptContextTest.kt
@@ -26,6 +26,7 @@ import javax.lang.model.element.TypeElement
 class JavaKaptContextTest : TestCase() {
     companion object {
         private val TEST_DATA_DIR = File("plugins/kapt3/kapt3-base/testData/runner")
+        val logger = WriterBackedKaptLogger(isVerbose = true)
 
         fun simpleProcessor() = IncrementalProcessor(
             object : AbstractProcessor() {
@@ -52,7 +53,7 @@ class JavaKaptContextTest : TestCase() {
                 }
 
                 override fun getSupportedAnnotationTypes() = setOf("test.MyAnnotation")
-            }, DeclaredProcType.NON_INCREMENTAL
+            }, DeclaredProcType.NON_INCREMENTAL, logger
         )
     }
 
@@ -69,7 +70,6 @@ class JavaKaptContextTest : TestCase() {
             detectMemoryLeaks = DetectMemoryLeaksMode.NONE
         }.build()
 
-        val logger = WriterBackedKaptLogger(isVerbose = true)
         KaptContext(options, true, logger).doAnnotationProcessing(listOf(javaSourceFile), listOf(processor))
     }
 
@@ -99,7 +99,7 @@ class JavaKaptContextTest : TestCase() {
         }
 
         try {
-            doAnnotationProcessing(File(TEST_DATA_DIR, "Simple.java"), IncrementalProcessor(processor, DeclaredProcType.NON_INCREMENTAL), TEST_DATA_DIR)
+            doAnnotationProcessing(File(TEST_DATA_DIR, "Simple.java"), IncrementalProcessor(processor, DeclaredProcType.NON_INCREMENTAL, logger), TEST_DATA_DIR)
         } catch (e: KaptBaseError) {
             assertEquals(KaptBaseError.Kind.EXCEPTION, e.kind)
             assertEquals("Here we are!", e.cause!!.message)

--- a/plugins/kapt3/kapt3-base/test/org/jetbrains/kotlin/kapt3/base/incremental/AnnotationProcessorDependencyCollectorTest.kt
+++ b/plugins/kapt3/kapt3-base/test/org/jetbrains/kotlin/kapt3/base/incremental/AnnotationProcessorDependencyCollectorTest.kt
@@ -8,13 +8,14 @@ package org.jetbrains.kotlin.kapt.base.test.org.jetbrains.kotlin.kapt3.base.incr
 import org.jetbrains.kotlin.kapt3.base.incremental.AnnotationProcessorDependencyCollector
 import org.jetbrains.kotlin.kapt3.base.incremental.RuntimeProcType
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.File
 
 class AnnotationProcessorDependencyCollectorTest {
     @Test
     fun testAggregating() {
-        val aggregating = AnnotationProcessorDependencyCollector(RuntimeProcType.AGGREGATING)
+        val aggregating = AnnotationProcessorDependencyCollector(RuntimeProcType.AGGREGATING) {}
         val generated = listOf("GeneratedA.java", "GeneratedB.java", "GeneratedC.java").map { File(it).toURI() }
         generated.forEach { aggregating.add(it, emptyArray()) }
 
@@ -24,16 +25,18 @@ class AnnotationProcessorDependencyCollectorTest {
 
     @Test
     fun testIsolatingWithoutOrigin() {
-        val isolating = AnnotationProcessorDependencyCollector(RuntimeProcType.ISOLATING)
+        val warnings = mutableListOf<String>()
+        val isolating = AnnotationProcessorDependencyCollector(RuntimeProcType.ISOLATING) { s -> warnings.add(s) }
         isolating.add(File("GeneratedA.java").toURI(), emptyArray())
 
         assertEquals(isolating.getRuntimeType(), RuntimeProcType.NON_INCREMENTAL)
         assertEquals(isolating.getGeneratedToSources(), emptyMap<File, File?>())
+        assertTrue(warnings.single().contains("Expected 1 originating source file when generating"))
     }
 
     @Test
     fun testNonIncremental() {
-        val nonIncremental = AnnotationProcessorDependencyCollector(RuntimeProcType.NON_INCREMENTAL)
+        val nonIncremental = AnnotationProcessorDependencyCollector(RuntimeProcType.NON_INCREMENTAL) {}
         nonIncremental.add(File("GeneratedA.java").toURI(), emptyArray())
         nonIncremental.add(File("GeneratedB.java").toURI(), emptyArray())
 

--- a/plugins/kapt3/kapt3-base/test/org/jetbrains/kotlin/kapt3/base/incremental/IncrementalKaptTest.kt
+++ b/plugins/kapt3/kapt3-base/test/org/jetbrains/kotlin/kapt3/base/incremental/IncrementalKaptTest.kt
@@ -71,7 +71,7 @@ class IncrementalKaptTest {
 
             incrementalCache = incrementalCacheDir
             compiledSources.add(classesOutput)
-            changedFiles.add(sourcesDir.resolve("User.java"))
+            changedFiles.add(sourcesDir.resolve("User.java").canonicalFile)
             flags.add(KaptFlag.INCREMENTAL_APT)
         }.build()
 
@@ -145,7 +145,7 @@ class IncrementalKaptTest {
 
             incrementalCache = incrementalCacheDir
             compiledSources.add(classesOutput)
-            changedFiles.add(sourcesDir.resolve("User.java"))
+            changedFiles.add(sourcesDir.resolve("User.java").canonicalFile)
             flags.add(KaptFlag.INCREMENTAL_APT)
         }.build()
 

--- a/plugins/kapt3/kapt3-base/test/org/jetbrains/kotlin/kapt3/base/incremental/fixtures.kt
+++ b/plugins/kapt3/kapt3-base/test/org/jetbrains/kotlin/kapt3/base/incremental/fixtures.kt
@@ -11,6 +11,7 @@ import com.sun.tools.javac.api.JavacTaskImpl
 import org.jetbrains.kotlin.kapt3.base.incremental.DeclaredProcType
 import org.jetbrains.kotlin.kapt3.base.incremental.IncrementalProcessor
 import org.jetbrains.kotlin.kapt3.base.incremental.RuntimeProcType
+import org.jetbrains.kotlin.kapt3.base.util.WriterBackedKaptLogger
 import java.io.File
 import javax.annotation.processing.AbstractProcessor
 import javax.annotation.processing.Filer
@@ -69,10 +70,12 @@ fun compileSources(srcFiles: Iterable<File>, outputDir: File) {
     }
 }
 
-fun SimpleProcessor.toAggregating() = IncrementalProcessor(this, DeclaredProcType.AGGREGATING)
-fun SimpleProcessor.toIsolating() = IncrementalProcessor(this, DeclaredProcType.ISOLATING)
-fun SimpleProcessor.toNonIncremental() = IncrementalProcessor(this, DeclaredProcType.NON_INCREMENTAL)
-fun DynamicProcessor.toDynamic() = IncrementalProcessor(this, DeclaredProcType.DYNAMIC)
+fun SimpleProcessor.toAggregating() = IncrementalProcessor(this, DeclaredProcType.AGGREGATING, WriterBackedKaptLogger(isVerbose = true))
+fun SimpleProcessor.toIsolating() = IncrementalProcessor(this, DeclaredProcType.ISOLATING, WriterBackedKaptLogger(isVerbose = true))
+fun SimpleProcessor.toNonIncremental() =
+    IncrementalProcessor(this, DeclaredProcType.NON_INCREMENTAL, WriterBackedKaptLogger(isVerbose = true))
+
+fun DynamicProcessor.toDynamic() = IncrementalProcessor(this, DeclaredProcType.DYNAMIC, WriterBackedKaptLogger(isVerbose = true))
 
 open class SimpleProcessor(private val wrongOrigin: Boolean = false, private val generatedSuffix: String = "") : AbstractProcessor() {
     lateinit var filer: Filer

--- a/plugins/kapt3/kapt3-compiler/test/org/jetbrains/kotlin/kapt3/test/AbstractKotlinKapt3IntegrationTest.kt
+++ b/plugins/kapt3/kapt3-compiler/test/org/jetbrains/kotlin/kapt3/test/AbstractKotlinKapt3IntegrationTest.kt
@@ -175,7 +175,7 @@ abstract class AbstractKotlinKapt3IntegrationTest : CodegenTestCase() {
         internal var savedBindings: Map<String, KaptJavaFileObject>? = null
 
         override fun loadProcessors() = LoadedProcessors(
-            processors.map { IncrementalProcessor(it, DeclaredProcType.NON_INCREMENTAL) },
+            processors.map { IncrementalProcessor(it, DeclaredProcType.NON_INCREMENTAL, logger) },
             Kapt3ExtensionForTests::class.java.classLoader)
 
         override fun saveStubs(kaptContext: KaptContext, stubs: List<KaptStub>) {


### PR DESCRIPTION
Isolating incremental AP must report exactly one originating source file.
This commit logs a warning when this constraint is violated.

Test: AnnotationProcessorDependencyCollectorTest.testIsolatingWithoutOrigin