### PR TITLE
KT-34258: Make sure to clean up stale files even if no Kotlin sources

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/Tasks.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/Tasks.kt
@@ -285,7 +285,8 @@ abstract class AbstractKotlinCompile<T : CommonCompilerArguments>() : AbstractKo
 
         logger.kotlinDebug { "All kotlin sources: ${allKotlinSources.pathsAsStringRelativeTo(project.rootProject.projectDir)}" }
 
-        if (allKotlinSources.isEmpty()) {
+        if (!inputs.isIncremental && allKotlinSources.isEmpty()) {
+            // Skip running only if non-incremental run. Otherwise, we may need to do some cleanup.
             logger.kotlinDebug { "No Kotlin files found, skipping Kotlin compiler task" }
             return
         }


### PR DESCRIPTION
If running incrementally, even if there aren't any Kotlin sources to
compile, there could be stale output files that need to be removed. E.g
stub generation must have generated .java files removed if all Kotlin
sources are removed. Kotlin compile task will be skipped only if there
are no Kotlin sources and task run is non-incremental.

Test: KaptIncrementalIT.testRemoveAllKotlinSources