### PR TITLE
KT-34194: Pass error/NonExistentClass for incremental KAPT run

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KaptIncrementalWithAggregatingApt.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KaptIncrementalWithAggregatingApt.kt
@@ -51,7 +51,8 @@ class KaptIncrementalWithAggregatingApt : KaptIncrementalIT() {
                     fileInWorkingDir("build/tmp/kapt3/stubs/main/bar/UseBKt.java").canonicalPath,
                     fileInWorkingDir("build/tmp/kapt3/stubs/main/bar/B.java").canonicalPath,
                     fileInWorkingDir("build/tmp/kapt3/stubs/main/baz/UtilKt.java").canonicalPath,
-                    fileInWorkingDir("build/tmp/kapt3/stubs/main/foo/A.java").canonicalPath
+                    fileInWorkingDir("build/tmp/kapt3/stubs/main/foo/A.java").canonicalPath,
+                    fileInWorkingDir("build/tmp/kapt3/stubs/main/error/NonExistentClass.java").canonicalPath
                 ), getProcessedSources(output)
             )
         }
@@ -68,7 +69,8 @@ class KaptIncrementalWithAggregatingApt : KaptIncrementalIT() {
                     fileInWorkingDir("build/tmp/kapt3/stubs/main/bar/UseBKt.java").canonicalPath,
                     fileInWorkingDir("build/tmp/kapt3/stubs/main/bar/B.java").canonicalPath,
                     fileInWorkingDir("build/tmp/kapt3/stubs/main/baz/UtilKt.java").canonicalPath,
-                    fileInWorkingDir("build/tmp/kapt3/stubs/main/foo/A.java").canonicalPath
+                    fileInWorkingDir("build/tmp/kapt3/stubs/main/foo/A.java").canonicalPath,
+                    fileInWorkingDir("build/tmp/kapt3/stubs/main/error/NonExistentClass.java").canonicalPath
                 ),
                 getProcessedSources(output)
             )
@@ -95,7 +97,8 @@ class KaptIncrementalWithAggregatingApt : KaptIncrementalIT() {
                     fileInWorkingDir("build/tmp/kapt3/stubs/main/bar/UseBKt.java").canonicalPath,
                     fileInWorkingDir("build/tmp/kapt3/stubs/main/bar/B.java").canonicalPath,
                     fileInWorkingDir("build/tmp/kapt3/stubs/main/baz/UtilKt.java").canonicalPath,
-                    fileInWorkingDir("build/tmp/kapt3/stubs/main/foo/A.java").canonicalPath
+                    fileInWorkingDir("build/tmp/kapt3/stubs/main/foo/A.java").canonicalPath,
+                    fileInWorkingDir("build/tmp/kapt3/stubs/main/error/NonExistentClass.java").canonicalPath
                 ), getProcessedSources(output)
             )
         }
@@ -150,7 +153,8 @@ class KaptIncrementalWithAggregatingApt : KaptIncrementalIT() {
                     fileInWorkingDir("app/build/tmp/kapt3/stubs/main/foo/FooUseAKt.java").canonicalPath,
                     fileInWorkingDir("app/build/tmp/kapt3/stubs/main/foo/FooUseBKt.java").canonicalPath,
                     fileInWorkingDir("app/build/tmp/kapt3/stubs/main/foo/FooUseAAKt.java").canonicalPath,
-                    fileInWorkingDir("app/build/tmp/kapt3/stubs/main/foo/FooUseBBKt.java").canonicalPath
+                    fileInWorkingDir("app/build/tmp/kapt3/stubs/main/foo/FooUseBBKt.java").canonicalPath,
+                    fileInWorkingDir("app/build/tmp/kapt3/stubs/main/error/NonExistentClass.java").canonicalPath
 
                 ), getProcessedSources(output)
             )

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KaptIncrementalWithIsolatingApt.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KaptIncrementalWithIsolatingApt.kt
@@ -48,7 +48,12 @@ class KaptIncrementalWithIsolatingApt : KaptIncrementalIT() {
         project.build("build") {
             assertSuccessful()
 
-            assertEquals(setOf(fileInWorkingDir("build/tmp/kapt3/stubs/main/bar/UseBKt.java").canonicalPath), getProcessedSources(output))
+            assertEquals(
+                setOf(
+                    fileInWorkingDir("build/tmp/kapt3/stubs/main/bar/UseBKt.java").canonicalPath,
+                    fileInWorkingDir("build/tmp/kapt3/stubs/main/error/NonExistentClass.java").canonicalPath
+                ), getProcessedSources(output)
+            )
         }
 
         project.projectFile("B.kt").modify { current ->
@@ -60,7 +65,8 @@ class KaptIncrementalWithIsolatingApt : KaptIncrementalIT() {
             assertEquals(
                 setOf(
                     fileInWorkingDir("build/tmp/kapt3/stubs/main/bar/B.java").canonicalPath,
-                    fileInWorkingDir("build/tmp/kapt3/stubs/main/bar/UseBKt.java").canonicalPath
+                    fileInWorkingDir("build/tmp/kapt3/stubs/main/bar/UseBKt.java").canonicalPath,
+                    fileInWorkingDir("build/tmp/kapt3/stubs/main/error/NonExistentClass.java").canonicalPath
                 ),
                 getProcessedSources(output)
             )

--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/KaptOptions.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/KaptOptions.kt
@@ -148,7 +148,21 @@ fun KaptOptions.collectJavaSourceFiles(sourcesToReprocess: SourcesToReprocess = 
 
     return when (sourcesToReprocess) {
         is SourcesToReprocess.FullRebuild -> allSources()
-        is SourcesToReprocess.Incremental -> sourcesToReprocess.toReprocess.filter { it.exists() }
+        is SourcesToReprocess.Incremental -> {
+            val toReprocess = sourcesToReprocess.toReprocess.filter { it.exists() }
+            if (toReprocess.isNotEmpty()) {
+                // Make sure to add error/NonExistentClass.java when there are sources to re-process, as
+                // this class is never reported as changed. See https://youtrack.jetbrains.com/issue/KT-34194 for details.
+                val nonExistentClass = stubsOutputDir.resolve("error/NonExistentClass.java")
+                if (nonExistentClass.exists()) {
+                    toReprocess + nonExistentClass
+                } else {
+                    toReprocess
+                }
+            } else {
+                emptyList()
+            }
+        }
     }
 }
 


### PR DESCRIPTION
When running KAPT incrementally, make sure to pass error/NonExistentClass.java
when there is at least one source file to process. This is to make sure
APs that must resolve all types are able to do so.

Test: updated KaptIncrementalWithAggregating/WithIsolating