### PR TITLE
Clean up KAPT incremental tests

### DIFF
--- a/plugins/kapt3/kapt3-base/test/org/jetbrains/kotlin/kapt3/base/incremental/IncrementalKaptTest.kt
+++ b/plugins/kapt3/kapt3-base/test/org/jetbrains/kotlin/kapt3/base/incremental/IncrementalKaptTest.kt
@@ -76,12 +76,10 @@ class IncrementalKaptTest {
         }.build()
 
         KaptContext(optionsForSecondRun, true, logger).use {
-            val sourcesToReprocess =
-                it.cacheManager!!.invalidateAndGetDirtyFiles(optionsForSecondRun.changedFiles, emptyList())
             assertFalse(outputDir.resolve("test/UserGenerated.java").exists())
 
             it.doAnnotationProcessing(
-                optionsForSecondRun.collectJavaSourceFiles(sourcesToReprocess), listOf(SimpleProcessor().toIsolating())
+                optionsForSecondRun.collectJavaSourceFiles(it.sourcesToReprocess), listOf(SimpleProcessor().toIsolating())
             )
         }
 
@@ -90,10 +88,8 @@ class IncrementalKaptTest {
 
         sourcesDir.resolve("User.java").delete()
         KaptContext(optionsForSecondRun, true, logger).use {
-            val sourcesToReprocess = it.cacheManager!!.invalidateAndGetDirtyFiles(optionsForSecondRun.changedFiles, emptyList())
-
             it.doAnnotationProcessing(
-                optionsForSecondRun.collectJavaSourceFiles(sourcesToReprocess), listOf(SimpleProcessor().toIsolating())
+                optionsForSecondRun.collectJavaSourceFiles(it.sourcesToReprocess), listOf(SimpleProcessor().toIsolating())
             )
         }
 
@@ -150,12 +146,10 @@ class IncrementalKaptTest {
         }.build()
 
         KaptContext(optionsForSecondRun, true, logger).use {
-            val sourcesToReprocess =
-                it.cacheManager!!.invalidateAndGetDirtyFiles(optionsForSecondRun.changedFiles, emptyList())
             assertFalse(outputDir.resolve("test/UserGenerated.java").exists())
 
             it.doAnnotationProcessing(
-                optionsForSecondRun.collectJavaSourceFiles(sourcesToReprocess), listOf(SimpleGeneratingIfTypeDoesNotExist().toIsolating())
+                optionsForSecondRun.collectJavaSourceFiles(it.sourcesToReprocess), listOf(SimpleGeneratingIfTypeDoesNotExist().toIsolating())
             )
         }
 
@@ -209,15 +203,13 @@ class IncrementalKaptTest {
         }.build()
 
         KaptContext(optionsForSecondRun, true, logger).use {
-            val sourcesToReprocess =
-                it.cacheManager!!.invalidateAndGetDirtyFiles(optionsForSecondRun.changedFiles, emptyList())
-            assertEquals(SourcesToReprocess.FullRebuild, sourcesToReprocess)
+            assertEquals(SourcesToReprocess.FullRebuild, it.sourcesToReprocess)
 
             // check output dir is empty
             assertEquals(listOf(outputDir), outputDir.walkTopDown().toList())
 
             it.doAnnotationProcessing(
-                optionsForSecondRun.collectJavaSourceFiles(sourcesToReprocess),
+                optionsForSecondRun.collectJavaSourceFiles(it.sourcesToReprocess),
                 listOf(DynamicProcessor(RuntimeProcType.NON_INCREMENTAL).toDynamic())
             )
         }


### PR DESCRIPTION
Remove redundant class to invalidate sources, because it is already
handled in the KaptContext constructor.