### PR TITLE
Avoid PsiFile searching when resolving imported scripts descriptors.

### DIFF
--- a/plugins/scripting/scripting-compiler-impl/src/org/jetbrains/kotlin/scripting/resolve/refineCompilationConfiguration.kt
+++ b/plugins/scripting/scripting-compiler-impl/src/org/jetbrains/kotlin/scripting/resolve/refineCompilationConfiguration.kt
@@ -114,7 +114,7 @@ abstract class ScriptCompilationConfigurationWrapper(val script: SourceCode) {
     abstract val dependenciesSources: List<File>
     abstract val javaHome: File?
     abstract val defaultImports: List<String>
-    abstract val importedScripts: List<File>
+    abstract val importedScripts: List<SourceCode>
 
     override fun equals(other: Any?): Boolean = script == (other as? ScriptCompilationConfigurationWrapper)?.script
 
@@ -141,9 +141,8 @@ abstract class ScriptCompilationConfigurationWrapper(val script: SourceCode) {
         override val defaultImports: List<String>
             get() = configuration?.get(ScriptCompilationConfiguration.defaultImports).orEmpty()
 
-        override val importedScripts: List<File>
-            get() = configuration?.get(ScriptCompilationConfiguration.importScripts)
-                ?.mapNotNull { (it as? FileBasedScriptSource)?.file }.orEmpty()
+        override val importedScripts: List<SourceCode>
+            get() = configuration?.get(ScriptCompilationConfiguration.importScripts).orEmpty()
 
         @Suppress("OverridingDeprecatedMember")
         override val legacyDependencies: ScriptDependencies?
@@ -178,8 +177,8 @@ abstract class ScriptCompilationConfigurationWrapper(val script: SourceCode) {
         override val defaultImports: List<String>
             get() = legacyDependencies?.imports.orEmpty()
 
-        override val importedScripts: List<File>
-            get() = legacyDependencies?.scripts.orEmpty()
+        override val importedScripts: List<SourceCode>
+            get() = legacyDependencies?.scripts?.map { FileScriptSource(it) }.orEmpty()
 
         override val configuration: ScriptCompilationConfiguration?
             get() {

--- a/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/dependencies/ScriptsCompilationDependencies.kt
+++ b/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/dependencies/ScriptsCompilationDependencies.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.scripting.definitions.ScriptDependenciesProvider
 import java.io.File
+import kotlin.script.experimental.host.FileBasedScriptSource
 
 data class ScriptsCompilationDependencies(
     val classpath: List<File>,
@@ -45,8 +46,10 @@ fun collectScriptsCompilationDependencies(
                 if (refinedConfiguration != null) {
                     collectedClassPath.addAll(refinedConfiguration.dependenciesClassPath)
 
-                    val sourceDependenciesRoots = refinedConfiguration.importedScripts.map {
-                        KotlinSourceRoot(it.absolutePath, false)
+                    val sourceDependenciesRoots = refinedConfiguration.importedScripts.mapNotNull {
+                        // TODO: support any kind of ScriptSource.
+                        val path = (it as? FileBasedScriptSource)?.file?.path ?: return@mapNotNull null
+                        KotlinSourceRoot(path, false)
                     }
                     val sourceDependencies =
                         createSourceFilesFromSourceRoots(


### PR DESCRIPTION
Doing this allows to import FileBasedScriptSource's and correctly resolve imported descriptors.

An even better fix would be to also correctly support StringScriptSource's.