### PR TITLE
KT-33796 INVISIBLE_SETTER: quick fix "Make '<set-attribute>' public" does not remove redundant setter

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/ChangeVisibilityFix.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/ChangeVisibilityFix.kt
@@ -27,12 +27,15 @@ import org.jetbrains.kotlin.idea.core.canBeInternal
 import org.jetbrains.kotlin.idea.core.canBePrivate
 import org.jetbrains.kotlin.idea.core.canBeProtected
 import org.jetbrains.kotlin.idea.core.setVisibility
+import org.jetbrains.kotlin.idea.inspections.RemoveRedundantSetterFix
+import org.jetbrains.kotlin.idea.inspections.isRedundantSetter
 import org.jetbrains.kotlin.idea.util.runOnExpectAndAllActuals
 import org.jetbrains.kotlin.lexer.KtModifierKeywordToken
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtModifierListOwner
+import org.jetbrains.kotlin.psi.KtPropertyAccessor
 import org.jetbrains.kotlin.resolve.ExposedVisibilityChecker
 
 open class ChangeVisibilityFix(
@@ -51,6 +54,11 @@ open class ChangeVisibilityFix(
         }
 
         element?.setVisibility(visibilityModifier)
+
+        val propertyAccessor = element as? KtPropertyAccessor
+        if (propertyAccessor?.isRedundantSetter() == true) {
+            RemoveRedundantSetterFix.removeRedundantSetter(propertyAccessor)
+        }
     }
 
     protected class ChangeToPublicFix(element: KtModifierListOwner, elementName: String) :

--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/ChangeVisibilityFix.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/ChangeVisibilityFix.kt
@@ -36,6 +36,7 @@ import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtModifierListOwner
 import org.jetbrains.kotlin.psi.KtPropertyAccessor
+import org.jetbrains.kotlin.psi.psiUtil.createSmartPointer
 import org.jetbrains.kotlin.resolve.ExposedVisibilityChecker
 
 open class ChangeVisibilityFix(
@@ -48,14 +49,15 @@ open class ChangeVisibilityFix(
     override fun getFamilyName() = "Make $visibilityModifier"
 
     override fun invoke(project: Project, editor: Editor?, file: KtFile) {
-        val originalElement = element
+        val pointer = element?.createSmartPointer()
+        val originalElement = pointer?.element
         if (originalElement is KtDeclaration) {
             originalElement.runOnExpectAndAllActuals { it.setVisibility(visibilityModifier) }
         }
 
-        element?.setVisibility(visibilityModifier)
+        pointer?.element?.setVisibility(visibilityModifier)
 
-        val propertyAccessor = element as? KtPropertyAccessor
+        val propertyAccessor = pointer?.element as? KtPropertyAccessor
         if (propertyAccessor?.isRedundantSetter() == true) {
             RemoveRedundantSetterFix.removeRedundantSetter(propertyAccessor)
         }

--- a/idea/testData/quickfix/increaseVisibility/privateSetterToInternal.kt
+++ b/idea/testData/quickfix/increaseVisibility/privateSetterToInternal.kt
@@ -1,0 +1,12 @@
+// "Make '<set-attribute>' internal" "true"
+// ACTION: "Make '<set-attribute>' public"
+
+class Demo {
+    var attribute = "a"
+        private set
+}
+
+fun main() {
+    val c = Demo()
+    <caret>c.attribute = "test"
+}

--- a/idea/testData/quickfix/increaseVisibility/privateSetterToInternal.kt.after
+++ b/idea/testData/quickfix/increaseVisibility/privateSetterToInternal.kt.after
@@ -1,0 +1,12 @@
+// "Make '<set-attribute>' internal" "true"
+// ACTION: "Make '<set-attribute>' public"
+
+class Demo {
+    var attribute = "a"
+        internal set
+}
+
+fun main() {
+    val c = Demo()
+    c.attribute = "test"
+}

--- a/idea/testData/quickfix/increaseVisibility/privateSetterToPublic.kt
+++ b/idea/testData/quickfix/increaseVisibility/privateSetterToPublic.kt
@@ -1,0 +1,12 @@
+// "Make '<set-attribute>' public" "true"
+// ACTION: "Make '<set-attribute>' internal"
+
+class Demo {
+    var attribute = "a"
+        private set
+}
+
+fun main() {
+    val c = Demo()
+    <caret>c.attribute = "test"
+}

--- a/idea/testData/quickfix/increaseVisibility/privateSetterToPublic.kt.after
+++ b/idea/testData/quickfix/increaseVisibility/privateSetterToPublic.kt.after
@@ -1,0 +1,11 @@
+// "Make '<set-attribute>' public" "true"
+// ACTION: "Make '<set-attribute>' internal"
+
+class Demo {
+    var attribute = "a"
+}
+
+fun main() {
+    val c = Demo()
+    <caret>c.attribute = "test"
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -7790,6 +7790,16 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
             runTest("idea/testData/quickfix/increaseVisibility/privateSealedClassInheritance.kt");
         }
 
+        @TestMetadata("privateSetterToInternal.kt")
+        public void testPrivateSetterToInternal() throws Exception {
+            runTest("idea/testData/quickfix/increaseVisibility/privateSetterToInternal.kt");
+        }
+
+        @TestMetadata("privateSetterToPublic.kt")
+        public void testPrivateSetterToPublic() throws Exception {
+            runTest("idea/testData/quickfix/increaseVisibility/privateSetterToPublic.kt");
+        }
+
         @TestMetadata("protectedMemberToPublicSingleFile.kt")
         public void testProtectedMemberToPublicSingleFile() throws Exception {
             runTest("idea/testData/quickfix/increaseVisibility/protectedMemberToPublicSingleFile.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-33796