### PR TITLE
Remove deprecated method from CommandLineProcessor

### DIFF
--- a/compiler/plugin-api/src/org/jetbrains/kotlin/compiler/plugin/CommandLineProcessor.kt
+++ b/compiler/plugin-api/src/org/jetbrains/kotlin/compiler/plugin/CommandLineProcessor.kt
@@ -24,15 +24,7 @@ interface CommandLineProcessor {
     val pluginOptions: Collection<AbstractCliOption>
 
     @Throws(CliOptionProcessingException::class)
-    fun processOption(option: AbstractCliOption, value: String, configuration: CompilerConfiguration) {
-        @Suppress("DEPRECATION")
-        processOption(option as CliOption, value, configuration)
-    }
-
-    // TODO remove processOption(AbstractCliOption, ...) implementation after removal of this.
-    @Deprecated("Implement processOption(option: AbstractCliOption, value: String, configuration: CompilerConfiguration) instead.")
-    @Throws(CliOptionProcessingException::class)
-    fun processOption(option: CliOption, value: String, configuration: CompilerConfiguration) {}
+    fun processOption(option: AbstractCliOption, value: String, configuration: CompilerConfiguration)
 
     fun <T> CompilerConfiguration.appendList(option: CompilerConfigurationKey<List<T>>, value: T) {
         val paths = getList(option).asMutableList()

--- a/libraries/examples/kotlin-gradle-subplugin-example/src/main/kotlin/example/CompilerPlugin.kt
+++ b/libraries/examples/kotlin-gradle-subplugin-example/src/main/kotlin/example/CompilerPlugin.kt
@@ -20,12 +20,9 @@ import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.config.CompilerConfigurationKey
-import org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
-import org.jetbrains.kotlin.compiler.plugin.CliOption
 import org.jetbrains.kotlin.config.CompilerConfiguration
-import org.jetbrains.kotlin.compiler.plugin.CliOptionProcessingException
-import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
 import com.intellij.mock.MockProject
+import org.jetbrains.kotlin.compiler.plugin.*
 
 public object ExampleConfigurationKeys {
     public val EXAMPLE_KEY: CompilerConfigurationKey<String> = CompilerConfigurationKey.create<String>("example argument")
@@ -40,10 +37,11 @@ public class ExampleCommandLineProcessor : CommandLineProcessor {
     override val pluginId: String = EXAMPLE_PLUGIN_ID
     override val pluginOptions: Collection<CliOption> = listOf(EXAMPLE_OPTION)
 
-    override fun processOption(option: CliOption, value: String, configuration: CompilerConfiguration) {
+
+    override fun processOption(option: AbstractCliOption, value: String, configuration: CompilerConfiguration) {
         when (option) {
             EXAMPLE_OPTION -> configuration.put(ExampleConfigurationKeys.EXAMPLE_KEY, value)
-            else -> throw CliOptionProcessingException("Unknown option: ${option.name}")
+            else -> throw CliOptionProcessingException("Unknown option: ${option.optionName}")
         }
     }
 }


### PR DESCRIPTION
This PR removes the implementation and the usage of the deprecated processOption() from CommandLineProcessor and the ExampleCommandLineProcessor