### PR TITLE
KT-34533 INLINE_CLASS_CONSTRUCTOR_NOT_FINAL_READ_ONLY_PARAMETER: Add quickfix "Add val to parameter"

### DIFF
--- a/compiler/psi/src/org/jetbrains/kotlin/psi/KtClass.kt
+++ b/compiler/psi/src/org/jetbrains/kotlin/psi/KtClass.kt
@@ -34,6 +34,7 @@ open class KtClass : KtClassOrObject {
     fun isData(): Boolean = hasModifier(KtTokens.DATA_KEYWORD)
     fun isSealed(): Boolean = hasModifier(KtTokens.SEALED_KEYWORD)
     fun isInner(): Boolean = hasModifier(KtTokens.INNER_KEYWORD)
+    fun isInline(): Boolean = hasModifier(KtTokens.INLINE_KEYWORD)
 
     override fun getCompanionObjects(): List<KtObjectDeclaration> = body?.allCompanionObjects.orEmpty()
 

--- a/idea/resources-en/messages/KotlinBundle.properties
+++ b/idea/resources-en/messages/KotlinBundle.properties
@@ -1627,6 +1627,7 @@ looking.for.usages.in.java.files=Looking for usages in Java files...
 add.return.at.0=Add return@{0}
 add.0.to.argument=Add ''{0} ='' to argument
 add.val.var.to.parameter.0=Add val/var to parameter ''{0}''
+add.val.to.parameter.0=Add val to parameter ''{0}''
 add.val.var.to.primary.constructor.parameter=Add val/var to primary constructor parameter
 make.primary.constructor.0=Make primary constructor {0}
 change.visibility.modifier=Change visibility modifier

--- a/idea/src/org/jetbrains/kotlin/idea/intentions/AddValVarToConstructorParameterAction.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/AddValVarToConstructorParameterAction.kt
@@ -20,6 +20,7 @@ import org.jetbrains.kotlin.idea.refactoring.ValVarExpression
 import org.jetbrains.kotlin.idea.util.isExpectDeclaration
 import org.jetbrains.kotlin.idea.util.mustHaveValOrVar
 import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.psiUtil.containingClass
 import org.jetbrains.kotlin.psi.psiUtil.createSmartPointer
 import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 import org.jetbrains.kotlin.psi.psiUtil.startOffset
@@ -33,7 +34,7 @@ interface AddValVarToConstructorParameterAction {
 
         element.addBefore(KtPsiFactory(project).createValKeyword(), element.nameIdentifier)
 
-        if (editor == null) return
+        if (element.containingClass()?.isInline() == true || editor == null) return
 
         val parameter = element.createSmartPointer().let {
             PsiDocumentManager.getInstance(project).commitAllDocuments()
@@ -55,7 +56,8 @@ interface AddValVarToConstructorParameterAction {
     ), AddValVarToConstructorParameterAction {
         override fun applicabilityRange(element: KtParameter): TextRange? {
             if (!canInvoke(element)) return null
-            if (element.getStrictParentOfType<KtClass>()?.isData() == true) return null
+            val containingClass = element.getStrictParentOfType<KtClass>()
+            if (containingClass?.isData() == true || containingClass?.isInline() == true) return null
             setTextGetter(KotlinBundle.lazyMessage("add.val.var.to.parameter.0", element.name ?: ""))
             return element.nameIdentifier?.textRange
         }
@@ -66,7 +68,11 @@ interface AddValVarToConstructorParameterAction {
     class QuickFix(parameter: KtParameter) :
         KotlinQuickFixAction<KtParameter>(parameter),
         AddValVarToConstructorParameterAction {
-        override fun getText() = element?.let { KotlinBundle.message("add.val.var.to.parameter.0", it.name ?: "") } ?: ""
+        override fun getText() = element?.let {
+            val key =
+                if (it.getStrictParentOfType<KtClass>()?.isInline() == true) "add.val.to.parameter.0" else "add.val.var.to.parameter.0"
+            KotlinBundle.message(key, it.name ?: "")
+        } ?: ""
 
         override fun getFamilyName() = KotlinBundle.message("add.val.var.to.primary.constructor.parameter")
 

--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/InlineClassConstructorNotValParameterFactory.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/InlineClassConstructorNotValParameterFactory.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.idea.quickfix
+
+import com.intellij.codeInsight.intention.IntentionAction
+import org.jetbrains.kotlin.diagnostics.Diagnostic
+import org.jetbrains.kotlin.diagnostics.Errors
+import org.jetbrains.kotlin.idea.intentions.AddValVarToConstructorParameterAction
+
+object InlineClassConstructorNotValParameterFactory : KotlinSingleIntentionActionFactory() {
+    override fun createAction(diagnostic: Diagnostic): IntentionAction? {
+        val parameter = Errors.INLINE_CLASS_CONSTRUCTOR_NOT_FINAL_READ_ONLY_PARAMETER.cast(diagnostic).psiElement
+        return if (parameter.isMutable)
+            ChangeVariableMutabilityFix(parameter, false)
+        else
+            AddValVarToConstructorParameterAction.QuickFix(parameter)
+    }
+}

--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixRegistrar.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixRegistrar.kt
@@ -658,5 +658,7 @@ class QuickFixRegistrar : QuickFixContributor {
         MISSING_EXCEPTION_IN_THROWS_ON_SUSPEND.registerFactory(AddExceptionToThrowsFix)
         THROWS_LIST_EMPTY.registerFactory(RemoveAnnotationFix)
         INCOMPATIBLE_THROWS_OVERRIDE.registerFactory(RemoveAnnotationFix)
+
+        INLINE_CLASS_CONSTRUCTOR_NOT_FINAL_READ_ONLY_PARAMETER.registerFactory(InlineClassConstructorNotValParameterFactory)
     }
 }

--- a/idea/testData/intentions/addValOrVar/expectInlineClass.kt
+++ b/idea/testData/intentions/addValOrVar/expectInlineClass.kt
@@ -1,2 +1,3 @@
+// IS_APPLICABLE: false
 // DISABLE-ERRORS
 expect inline class A(<caret>a: Int)

--- a/idea/testData/intentions/addValOrVar/expectInlineClass.kt.after
+++ b/idea/testData/intentions/addValOrVar/expectInlineClass.kt.after
@@ -1,2 +1,0 @@
-// DISABLE-ERRORS
-expect inline class A(val a: Int)

--- a/idea/testData/quickfix/inlineClassConstructorNotValParameter/basic.kt
+++ b/idea/testData/quickfix/inlineClassConstructorNotValParameter/basic.kt
@@ -1,0 +1,2 @@
+// "Add val to parameter 'x'" "true"
+inline class Foo(<caret>x: Int)

--- a/idea/testData/quickfix/inlineClassConstructorNotValParameter/basic.kt.after
+++ b/idea/testData/quickfix/inlineClassConstructorNotValParameter/basic.kt.after
@@ -1,0 +1,2 @@
+// "Add val to parameter 'x'" "true"
+inline class Foo(val x: Int)

--- a/idea/testData/quickfix/inlineClassConstructorNotValParameter/var.kt
+++ b/idea/testData/quickfix/inlineClassConstructorNotValParameter/var.kt
@@ -1,0 +1,2 @@
+// "Change to val" "true"
+inline class Foo(<caret>var x: Int)

--- a/idea/testData/quickfix/inlineClassConstructorNotValParameter/var.kt.after
+++ b/idea/testData/quickfix/inlineClassConstructorNotValParameter/var.kt.after
@@ -1,0 +1,2 @@
+// "Change to val" "true"
+inline class Foo(val x: Int)

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixMultiFileTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixMultiFileTestGenerated.java
@@ -3025,6 +3025,19 @@ public class QuickFixMultiFileTestGenerated extends AbstractQuickFixMultiFileTes
         }
     }
 
+    @TestMetadata("idea/testData/quickfix/inlineClassConstructorNotValParameter")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class InlineClassConstructorNotValParameter extends AbstractQuickFixMultiFileTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doTestWithExtraFile, this, testDataFilePath);
+        }
+
+        public void testAllFilesPresentInInlineClassConstructorNotValParameter() throws Exception {
+            KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("idea/testData/quickfix/inlineClassConstructorNotValParameter"), Pattern.compile("^(\\w+)\\.((before\\.Main\\.\\w+)|(test))$"), null, true);
+        }
+    }
+
     @TestMetadata("idea/testData/quickfix/inlineTypeParameterFix")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -8355,6 +8355,29 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
         }
     }
 
+    @TestMetadata("idea/testData/quickfix/inlineClassConstructorNotValParameter")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class InlineClassConstructorNotValParameter extends AbstractQuickFixTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
+        }
+
+        public void testAllFilesPresentInInlineClassConstructorNotValParameter() throws Exception {
+            KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("idea/testData/quickfix/inlineClassConstructorNotValParameter"), Pattern.compile("^([\\w\\-_]+)\\.kt$"), null, true);
+        }
+
+        @TestMetadata("basic.kt")
+        public void testBasic() throws Exception {
+            runTest("idea/testData/quickfix/inlineClassConstructorNotValParameter/basic.kt");
+        }
+
+        @TestMetadata("var.kt")
+        public void testVar() throws Exception {
+            runTest("idea/testData/quickfix/inlineClassConstructorNotValParameter/var.kt");
+        }
+    }
+
     @TestMetadata("idea/testData/quickfix/inlineTypeParameterFix")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-34533