### PR TITLE
KT-33050: Pass source version to KAPT for JDK12+

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/Kapt3KotlinGradleSubplugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/Kapt3KotlinGradleSubplugin.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.gradle.internal
 import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.api.AndroidSourceSet
 import com.android.builder.model.SourceProvider
+import com.intellij.openapi.util.SystemInfo
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -431,8 +432,13 @@ class Kapt3KotlinGradleSubplugin : KotlinGradleSubplugin<KotlinCompile> {
         }
 
         val dslJavacOptions = kaptExtension.getJavacOptions().toMutableMap()
-        if (javaCompile != null && "-source" !in dslJavacOptions && "--release" !in dslJavacOptions) {
-            dslJavacOptions["-source"] = javaCompile.sourceCompatibility
+        if (javaCompile != null && "-source" !in dslJavacOptions && "--source" !in dslJavacOptions && "--release" !in dslJavacOptions) {
+            val sourceOptionKey = if (SystemInfo.isJavaVersionAtLeast(12, 0, 0)) {
+                "--source"
+            } else {
+                "-source"
+            }
+            dslJavacOptions[sourceOptionKey] = javaCompile.sourceCompatibility
         }
         if (kaptTask is KaptWithKotlincTask) {
             if (kaptTask.isIncremental) {


### PR DESCRIPTION
In JDK 12+ source version should be passed using --source option,
instead of -source. This commit uses correct option based on the
JDK current build is using.

Fixes KT-33050