### PR TITLE
KT-31523 ReplaceWith introduces additional argument name for lambda when named argument is used on call-site

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/codeInliner/CodeInliner.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/codeInliner/CodeInliner.kt
@@ -590,7 +590,6 @@ class CodeInliner<TCallElement : KtElement>(
 
             val argument = expr.parent as? KtValueArgument ?: return
             if (argument is KtLambdaArgument) return
-            if (argument.isNamed()) return
             val argumentList = argument.parent as? KtValueArgumentList ?: return
             if (argument != argumentList.arguments.last()) return
             val callExpression = argumentList.parent as? KtCallExpression ?: return

--- a/idea/testData/quickfix/deprecatedSymbolUsage/functionLiteralArguments/keepOutsideWithNamedArgument.kt
+++ b/idea/testData/quickfix/deprecatedSymbolUsage/functionLiteralArguments/keepOutsideWithNamedArgument.kt
@@ -1,0 +1,12 @@
+// "Replace with 'newFun(p1, null, p2)'" "true"
+
+interface I {
+    @Deprecated("", ReplaceWith("newFun(p1, null, p2)"))
+    fun oldFun(p1: String, p2: () -> Boolean)
+
+    fun newFun(p1: String, p2: String?, p3: () -> Boolean)
+}
+
+fun foo(i: I) {
+    i.<caret>oldFun(p1 = "a") { true }
+}

--- a/idea/testData/quickfix/deprecatedSymbolUsage/functionLiteralArguments/keepOutsideWithNamedArgument.kt.after
+++ b/idea/testData/quickfix/deprecatedSymbolUsage/functionLiteralArguments/keepOutsideWithNamedArgument.kt.after
@@ -1,0 +1,12 @@
+// "Replace with 'newFun(p1, null, p2)'" "true"
+
+interface I {
+    @Deprecated("", ReplaceWith("newFun(p1, null, p2)"))
+    fun oldFun(p1: String, p2: () -> Boolean)
+
+    fun newFun(p1: String, p2: String?, p3: () -> Boolean)
+}
+
+fun foo(i: I) {
+    i.<caret>newFun(p1 = "a", p2 = null) { true }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -6509,6 +6509,11 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
             public void testKeepOutside() throws Exception {
                 runTest("idea/testData/quickfix/deprecatedSymbolUsage/functionLiteralArguments/keepOutside.kt");
             }
+
+            @TestMetadata("keepOutsideWithNamedArgument.kt")
+            public void testKeepOutsideWithNamedArgument() throws Exception {
+                runTest("idea/testData/quickfix/deprecatedSymbolUsage/functionLiteralArguments/keepOutsideWithNamedArgument.kt");
+            }
         }
 
         @TestMetadata("idea/testData/quickfix/deprecatedSymbolUsage/imports")


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-31523