### PR TITLE
JVM_IR: add accessors for protected members in divergent hierarchies

### DIFF
--- a/compiler/testData/codegen/boxAgainstJava/visibility/protectedAndPackage/protectedAccessor.kt
+++ b/compiler/testData/codegen/boxAgainstJava/visibility/protectedAndPackage/protectedAccessor.kt
@@ -1,0 +1,21 @@
+// FILE: protectedPack/A.java
+package protectedPack;
+
+public class A {
+    protected final String field;
+
+    public A(String value) {
+        field = value;
+    }
+}
+
+// FILE: B.kt
+import protectedPack.A
+
+class B(value: String) : A(value) {
+    inner class C : A(field) {
+        val result = field
+    }
+}
+
+fun box(): String = B("OK").C().result

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxAgainstJavaCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxAgainstJavaCodegenTestGenerated.java
@@ -1087,6 +1087,11 @@ public class BlackBoxAgainstJavaCodegenTestGenerated extends AbstractBlackBoxAga
                 runTest("compiler/testData/codegen/boxAgainstJava/visibility/protectedAndPackage/overrideProtectedFunInPackage.kt");
             }
 
+            @TestMetadata("protectedAccessor.kt")
+            public void testProtectedAccessor() throws Exception {
+                runTest("compiler/testData/codegen/boxAgainstJava/visibility/protectedAndPackage/protectedAccessor.kt");
+            }
+
             @TestMetadata("protectedFunInPackage.kt")
             public void testProtectedFunInPackage() throws Exception {
                 runTest("compiler/testData/codegen/boxAgainstJava/visibility/protectedAndPackage/protectedFunInPackage.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxAgainstJavaCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxAgainstJavaCodegenTestGenerated.java
@@ -1087,6 +1087,11 @@ public class IrBlackBoxAgainstJavaCodegenTestGenerated extends AbstractIrBlackBo
                 runTest("compiler/testData/codegen/boxAgainstJava/visibility/protectedAndPackage/overrideProtectedFunInPackage.kt");
             }
 
+            @TestMetadata("protectedAccessor.kt")
+            public void testProtectedAccessor() throws Exception {
+                runTest("compiler/testData/codegen/boxAgainstJava/visibility/protectedAndPackage/protectedAccessor.kt");
+            }
+
             @TestMetadata("protectedFunInPackage.kt")
             public void testProtectedFunInPackage() throws Exception {
                 runTest("compiler/testData/codegen/boxAgainstJava/visibility/protectedAndPackage/protectedFunInPackage.kt");


### PR DESCRIPTION
Class B : A cannot access a protected field of A through a reference to an instance of C : A.