### PR TITLE
Psi2Ir: Separate expressions and statements

### DIFF
--- a/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/fir/Fir2IrTextTestGenerated.java
+++ b/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/fir/Fir2IrTextTestGenerated.java
@@ -1286,6 +1286,11 @@ public class Fir2IrTextTestGenerated extends AbstractFir2IrTextTest {
             runTest("compiler/testData/ir/irText/expressions/whenReturn.kt");
         }
 
+        @TestMetadata("whenReturnUnit.kt")
+        public void testWhenReturnUnit() throws Exception {
+            runTest("compiler/testData/ir/irText/expressions/whenReturnUnit.kt");
+        }
+
         @TestMetadata("whenUnusedExpression.kt")
         public void testWhenUnusedExpression() throws Exception {
             runTest("compiler/testData/ir/irText/expressions/whenUnusedExpression.kt");

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -514,7 +514,7 @@ class ExpressionCodegen(
     override fun visitSetVariable(expression: IrSetVariable, data: BlockInfo): PromisedValue {
         expression.markLineNumber(startOffset = true)
         setVariable(expression.symbol, expression.value, data)
-        return defaultValue(expression.type)
+        return immaterialUnitValue
     }
 
     fun setVariable(symbol: IrValueSymbol, value: IrExpression, data: BlockInfo) {
@@ -746,7 +746,7 @@ class ExpressionCodegen(
         mv.nop()
         val tryAsmType = aTry.asmType
         val tryResult = aTry.tryResult.accept(this, data)
-        val isExpression = true //TODO: more wise check is required
+        val isExpression = !aTry.type.isUnit()
         var savedValue: Int? = null
         if (isExpression) {
             tryResult.coerce(tryAsmType, aTry.type).materialize()

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -594,7 +594,10 @@ class ExpressionCodegen(
         SwitchGenerator(expression, data, this).generate()?.let { return it }
 
         val endLabel = Label()
-        val exhaustive = expression.branches.any { it.condition.isTrueConst() }
+        val exhaustive = expression.branches.any { it.condition.isTrueConst() } && !expression.type.isUnit()
+        assert(exhaustive || expression.type.isUnit()) {
+            "non-exhaustive conditional should return Unit: ${expression.dump()}"
+        }
         for (branch in expression.branches) {
             val elseLabel = Label()
             if (branch.condition.isFalseConst() || branch.condition.isTrueConst()) {
@@ -609,26 +612,21 @@ class ExpressionCodegen(
             } else {
                 branch.condition.accept(this, data).coerceToBoolean().jumpIfFalse(elseLabel)
             }
-            val result = branch.result.accept(this, data).coerce(expression.type).materialized
+            val result = branch.result.accept(this, data)
             if (!exhaustive) {
                 result.discard()
-            } else if (branch.condition.isTrueConst()) {
-                // The rest of the expression is dead code.
-                mv.mark(endLabel)
-                return result
+            } else {
+                val materializedResult = result.coerce(expression.type).materialized
+                if (branch.condition.isTrueConst()) {
+                    // The rest of the expression is dead code.
+                    mv.mark(endLabel)
+                    return materializedResult
+                }
             }
             mv.goTo(endLabel)
             mv.mark(elseLabel)
         }
         mv.mark(endLabel)
-        // NOTE: using a non-exhaustive if/when as an expression is invalid, so it should theoretically
-        //       always return Unit. However, with the current frontend this is not always the case.
-        //       Most notably, 1. when all branches return/break/continue, the type is Nothing;
-        //       2. the frontend may sometimes infer Any instead of Unit, probably due to a bug
-        //       (see compiler/testData/codegen/box/controlStructures/ifIncompatibleBranches.kt).
-        //       It should still be safe to produce a soon-to-be-discarded Unit. (What is not ok is
-        //       inserting *any* code here, though, as its line number will be that of the last line
-        //       of the last branch.)
         return immaterialUnitValue
     }
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/FunctionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/FunctionCodegen.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlin.backend.jvm.codegen
 
 import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
-import org.jetbrains.kotlin.backend.jvm.JvmLoweredDeclarationOrigin
 import org.jetbrains.kotlin.codegen.AsmUtil
 import org.jetbrains.kotlin.codegen.ClassBuilderMode
 import org.jetbrains.kotlin.codegen.visitAnnotableParameterCount

--- a/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/ClassGenerator.kt
+++ b/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/ClassGenerator.kt
@@ -173,7 +173,7 @@ class ClassGenerator(
         delegatedMembers: List<CallableMemberDescriptor>
     ) {
         val ktDelegateExpression = ktEntry.delegateExpression!!
-        val delegateType = getInferredTypeWithImplicitCastsOrFail(ktDelegateExpression)
+        val delegateType = getTypeInferredByFrontendOrFail(ktDelegateExpression)
         val superType = getOrFail(BindingContext.TYPE, ktEntry.typeReference!!)
         val superTypeConstructorDescriptor = superType.constructor.declarationDescriptor
         val superClass = superTypeConstructorDescriptor as? ClassDescriptor

--- a/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/DelegatedPropertyGenerator.kt
+++ b/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/DelegatedPropertyGenerator.kt
@@ -306,7 +306,7 @@ class DelegatedPropertyGenerator(declarationGenerator: DeclarationGenerator) : D
         return if (provideDelegateResolvedCall != null)
             provideDelegateResolvedCall.resultingDescriptor.returnType!!
         else
-            getInferredTypeWithImplicitCastsOrFail(ktDelegate.expression!!)
+            getTypeInferredByFrontendOrFail(ktDelegate.expression!!)
     }
 
     private fun generateInitializerForLocalDelegatedPropertyDelegate(

--- a/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/ErrorExpressionGenerator.kt
+++ b/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/ErrorExpressionGenerator.kt
@@ -66,7 +66,7 @@ class ErrorExpressionGenerator(statementGenerator: StatementGenerator) : Stateme
     }
 
     private fun getErrorExpressionType(ktExpression: KtExpression) =
-        getInferredTypeWithImplicitCasts(ktExpression) ?: ErrorUtils.createErrorType("")
+        getTypeInferredByFrontend(ktExpression) ?: ErrorUtils.createErrorType("")
 
     fun generateErrorSimpleName(ktName: KtSimpleNameExpression): IrExpression = generateErrorExpression(ktName) {
         val type = getErrorExpressionType(ktName).toIrType()

--- a/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/LocalClassGenerator.kt
+++ b/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/LocalClassGenerator.kt
@@ -29,7 +29,7 @@ class LocalClassGenerator(statementGenerator: StatementGenerator) : StatementGen
     fun generateObjectLiteral(ktObjectLiteral: KtObjectLiteralExpression): IrStatement {
         val startOffset = ktObjectLiteral.startOffsetSkippingComments
         val endOffset = ktObjectLiteral.endOffset
-        val objectLiteralType = getInferredTypeWithImplicitCastsOrFail(ktObjectLiteral).toIrType()
+        val objectLiteralType = getTypeInferredByFrontendOrFail(ktObjectLiteral).toIrType()
         val irBlock = IrBlockImpl(startOffset, endOffset, objectLiteralType, IrStatementOrigin.OBJECT_LITERAL)
 
         val irClass = DeclarationGenerator(statementGenerator.context).generateClassOrObjectDeclaration(ktObjectLiteral.objectDeclaration)

--- a/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/LocalFunctionGenerator.kt
+++ b/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/LocalFunctionGenerator.kt
@@ -28,7 +28,7 @@ class LocalFunctionGenerator(statementGenerator: StatementGenerator) : Statement
 
     fun generateLambda(ktLambda: KtLambdaExpression): IrStatement {
         val ktFun = ktLambda.functionLiteral
-        val lambdaExpressionType = getInferredTypeWithImplicitCastsOrFail(ktLambda).toIrType()
+        val lambdaExpressionType = getTypeInferredByFrontendOrFail(ktLambda).toIrType()
         val irLambdaFunction = FunctionGenerator(context).generateLambdaFunctionDeclaration(ktFun)
 
         return IrFunctionExpressionImpl(
@@ -43,7 +43,7 @@ class LocalFunctionGenerator(statementGenerator: StatementGenerator) : Statement
         val irFun = generateFunctionDeclaration(ktFun)
         if (ktFun.name != null) return irFun
 
-        val funExpressionType = getInferredTypeWithImplicitCastsOrFail(ktFun).toIrType()
+        val funExpressionType = getTypeInferredByFrontendOrFail(ktFun).toIrType()
         return IrFunctionExpressionImpl(
             ktFun.startOffset, ktFun.endOffset,
             funExpressionType,

--- a/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/ReflectionReferencesGenerator.kt
+++ b/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/ReflectionReferencesGenerator.kt
@@ -37,7 +37,7 @@ class ReflectionReferencesGenerator(statementGenerator: StatementGenerator) : St
     fun generateClassLiteral(ktClassLiteral: KtClassLiteralExpression): IrExpression {
         val ktArgument = ktClassLiteral.receiverExpression!!
         val lhs = getOrFail(BindingContext.DOUBLE_COLON_LHS, ktArgument)
-        val resultType = getInferredTypeWithImplicitCastsOrFail(ktClassLiteral).toIrType()
+        val resultType = getTypeInferredByFrontendOrFail(ktClassLiteral).toIrType()
 
         return if (lhs is DoubleColonLHS.Expression && !lhs.isObjectQualifier) {
             IrGetClassImpl(
@@ -69,7 +69,7 @@ class ReflectionReferencesGenerator(statementGenerator: StatementGenerator) : St
         ).call { dispatchReceiverValue, extensionReceiverValue ->
             generateCallableReference(
                 ktCallableReference,
-                getInferredTypeWithImplicitCastsOrFail(ktCallableReference),
+                getTypeInferredByFrontendOrFail(ktCallableReference),
                 callBuilder.descriptor,
                 callBuilder.typeArguments
             ).also { irCallableReference ->

--- a/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/StatementGenerator.kt
+++ b/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/StatementGenerator.kt
@@ -161,7 +161,7 @@ class StatementGenerator(
         val isBlockBody = expression.parent is KtDeclarationWithBody && expression.parent !is KtFunctionLiteral
         if (isBlockBody) throw AssertionError("Use IrBlockBody and corresponding body generator to generate blocks as function bodies")
 
-        val returnType = getInferredTypeWithImplicitCasts(expression) ?: context.builtIns.unitType
+        val returnType = getExpressionTypeWithCoercionToUnitOrFail(expression)
         val irBlock = IrBlockImpl(expression.startOffsetSkippingComments, expression.endOffset, returnType.toIrType())
 
         expression.statements.forEach {
@@ -226,14 +226,14 @@ class StatementGenerator(
         context.constantValueGenerator.generateConstantValueAsExpression(
             expression.startOffsetSkippingComments,
             expression.endOffset,
-            constant.toConstantValue(getInferredTypeWithImplicitCastsOrFail(expression))
+            constant.toConstantValue(getTypeInferredByFrontendOrFail(expression))
         )
 
     override fun visitStringTemplateExpression(expression: KtStringTemplateExpression, data: Nothing?): IrStatement {
         val startOffset = expression.startOffsetSkippingComments
         val endOffset = expression.endOffset
 
-        val resultType = getInferredTypeWithImplicitCastsOrFail(expression).toIrType()
+        val resultType = getTypeInferredByFrontendOrFail(expression).toIrType()
         val entries = expression.entries.map { it.genExpr() }.postprocessStringTemplateEntries()
 
         return when (entries.size) {

--- a/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/TryCatchExpressionGenerator.kt
+++ b/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/TryCatchExpressionGenerator.kt
@@ -27,7 +27,7 @@ import org.jetbrains.kotlin.resolve.BindingContext
 
 class TryCatchExpressionGenerator(statementGenerator: StatementGenerator) : StatementGeneratorExtension(statementGenerator) {
     fun generateTryCatch(ktTry: KtTryExpression): IrExpression {
-        val resultType = getInferredTypeWithImplicitCastsOrFail(ktTry).toIrType()
+        val resultType = getExpressionTypeWithCoercionToUnitOrFail(ktTry).toIrType()
         val irTryCatch = IrTryImpl(ktTry.startOffsetSkippingComments, ktTry.endOffset, resultType)
 
         irTryCatch.tryResult = ktTry.tryBlock.genExpr()

--- a/compiler/testData/codegen/boxInline/smap/anonymous/lambda.kt
+++ b/compiler/testData/codegen/boxInline/smap/anonymous/lambda.kt
@@ -1,4 +1,4 @@
-// IGNORE_BACKEND_MULTI_MODULE: JVM_IR
+
 // FILE: 1.kt
 
 package builders

--- a/compiler/testData/codegen/boxInline/smap/anonymous/object.kt
+++ b/compiler/testData/codegen/boxInline/smap/anonymous/object.kt
@@ -1,6 +1,6 @@
 // FILE: 1.kt
 
-// IGNORE_BACKEND_MULTI_MODULE: JVM_IR
+
 package builders
 
 inline fun call(crossinline init: () -> Unit) {

--- a/compiler/testData/codegen/boxInline/smap/newsmap/mappingInInlineFunLambda.kt
+++ b/compiler/testData/codegen/boxInline/smap/newsmap/mappingInInlineFunLambda.kt
@@ -1,4 +1,4 @@
-// IGNORE_BACKEND_MULTI_MODULE: JVM_IR
+
 // FILE: 1.kt
 
 package test

--- a/compiler/testData/codegen/bytecodeText/coroutines/varValueConflictsWithTableSameSort.kt
+++ b/compiler/testData/codegen/bytecodeText/coroutines/varValueConflictsWithTableSameSort.kt
@@ -1,3 +1,4 @@
+// IGNORE_BACKEND: JVM_IR
 // WITH_COROUTINES
 
 import helpers.*
@@ -41,6 +42,9 @@ fun box(): String {
 // 1 LOCALVARIABLE i Ljava/lang/String; L.* 3
 // 1 LOCALVARIABLE s Ljava/lang/String; L.* 3
 // 1 PUTFIELD VarValueConflictsWithTableSameSortKt\$box\$1.L\$0 : Ljava/lang/Object;
-/* 1 load in try/finally */
+/* 1 load in the catch (e: Throwable) { throw e } block which is implicitly wrapped around try/finally */
+// 1 ALOAD 3\s+ATHROW
 /* 1 load in result = s */
+// 1 ALOAD 3\s+PUTFIELD kotlin/jvm/internal/Ref\$ObjectRef\.element
+/* But no further load when spilling 's' to the continuation */
 // 2 ALOAD 3

--- a/compiler/testData/codegen/bytecodeText/statements/tryCatchFinally.kt
+++ b/compiler/testData/codegen/bytecodeText/statements/tryCatchFinally.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 fun z() {}
 
 fun foo() {

--- a/compiler/testData/ir/irCfg/when/whenReturn.txt
+++ b/compiler/testData/ir/irCfg/when/whenReturn.txt
@@ -2,10 +2,10 @@
 // FUN: toString
 BB 0
 CONTENT
-      1 FUN name:toString visibility:public modality:FINAL <> (grade:kotlin.String) returnType:kotlin.String 
+      1 FUN name:toString visibility:public modality:FINAL <> (grade:kotlin.String) returnType:kotlin.String
       2 GET_VAR 'grade: kotlin.String declared in <root>.toString' type=kotlin.String origin=null
-      3 VAR IR_TEMPORARY_VARIABLE name:tmp0_subject type:kotlin.String [val] 
-      4 WHEN type=kotlin.Nothing origin=WHEN
+      3 VAR IR_TEMPORARY_VARIABLE name:tmp0_subject type:kotlin.String [val]
+      4 WHEN type=kotlin.Unit origin=WHEN
       5 GET_VAR 'val tmp0_subject: kotlin.String [val] declared in <root>.toString' type=kotlin.String origin=null
       6 CONST String type=kotlin.String value="A"
 OUTGOING -> BB 1, 5
@@ -47,7 +47,7 @@ CONTENT
       1 CONST String type=kotlin.String value="Excellent"
       2 RETURN type=kotlin.Nothing from='public final fun toString (grade: kotlin.String): kotlin.String declared in <root>'
 OUTGOING -> NONE
-    Function exit: FUN name:toString visibility:public modality:FINAL <> (grade:kotlin.String) returnType:kotlin.String 
+    Function exit: FUN name:toString visibility:public modality:FINAL <> (grade:kotlin.String) returnType:kotlin.String
 BB 6
 INCOMING <- BB 1
     CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
@@ -55,7 +55,7 @@ CONTENT
       1 CONST String type=kotlin.String value="Good"
       2 RETURN type=kotlin.Nothing from='public final fun toString (grade: kotlin.String): kotlin.String declared in <root>'
 OUTGOING -> NONE
-    Function exit: FUN name:toString visibility:public modality:FINAL <> (grade:kotlin.String) returnType:kotlin.String 
+    Function exit: FUN name:toString visibility:public modality:FINAL <> (grade:kotlin.String) returnType:kotlin.String
 BB 7
 INCOMING <- BB 2
     CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
@@ -63,7 +63,7 @@ CONTENT
       1 CONST String type=kotlin.String value="Mediocre"
       2 RETURN type=kotlin.Nothing from='public final fun toString (grade: kotlin.String): kotlin.String declared in <root>'
 OUTGOING -> NONE
-    Function exit: FUN name:toString visibility:public modality:FINAL <> (grade:kotlin.String) returnType:kotlin.String 
+    Function exit: FUN name:toString visibility:public modality:FINAL <> (grade:kotlin.String) returnType:kotlin.String
 BB 8
 INCOMING <- BB 3
     CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
@@ -71,7 +71,7 @@ CONTENT
       1 CONST String type=kotlin.String value="Fair"
       2 RETURN type=kotlin.Nothing from='public final fun toString (grade: kotlin.String): kotlin.String declared in <root>'
 OUTGOING -> NONE
-    Function exit: FUN name:toString visibility:public modality:FINAL <> (grade:kotlin.String) returnType:kotlin.String 
+    Function exit: FUN name:toString visibility:public modality:FINAL <> (grade:kotlin.String) returnType:kotlin.String
 BB 9
 INCOMING <- BB 4
     CONST Boolean type=kotlin.Boolean value=true
@@ -79,7 +79,7 @@ CONTENT
       1 CONST String type=kotlin.String value="Failure"
       2 RETURN type=kotlin.Nothing from='public final fun toString (grade: kotlin.String): kotlin.String declared in <root>'
 OUTGOING -> NONE
-    Function exit: FUN name:toString visibility:public modality:FINAL <> (grade:kotlin.String) returnType:kotlin.String 
+    Function exit: FUN name:toString visibility:public modality:FINAL <> (grade:kotlin.String) returnType:kotlin.String
 BB 10
 INCOMING <- BB 4
     CONST Boolean type=kotlin.Boolean value=true
@@ -87,7 +87,7 @@ CONTENT
       1 CONST String type=kotlin.String value="???"
       2 RETURN type=kotlin.Nothing from='public final fun toString (grade: kotlin.String): kotlin.String declared in <root>'
 OUTGOING -> NONE
-    Function exit: FUN name:toString visibility:public modality:FINAL <> (grade:kotlin.String) returnType:kotlin.String 
+    Function exit: FUN name:toString visibility:public modality:FINAL <> (grade:kotlin.String) returnType:kotlin.String
 
 // END FUN: toString
 

--- a/compiler/testData/ir/irText/declarations/parameters/useNextParamInLambda.txt
+++ b/compiler/testData/ir/irText/declarations/parameters/useNextParamInLambda.txt
@@ -23,15 +23,15 @@ FILE fqName:<root> fileName:/useNextParamInLambda.kt
     BLOCK_BODY
       VAR name:result type:kotlin.String [var]
         CONST String type=kotlin.String value="fail"
-      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
-        TRY type=kotlin.Any
-          try: BLOCK type=kotlin.String origin=null
+      TRY type=kotlin.Unit
+        try: BLOCK type=kotlin.Unit origin=null
+          TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
             CALL 'public final fun f (f1: kotlin.Function0<kotlin.String>, f2: kotlin.Function0<kotlin.String>): kotlin.String declared in <root>' type=kotlin.String origin=null
-          CATCH parameter=val e: java.lang.Exception{ kotlin.Exception } [val] declared in <root>.box
-            VAR CATCH_PARAMETER name:e type:java.lang.Exception{ kotlin.Exception } [val]
-            BLOCK type=kotlin.Unit origin=null
-              SET_VAR 'var result: kotlin.String [var] declared in <root>.box' type=kotlin.Unit origin=EQ
-                CONST String type=kotlin.String value="OK"
+        CATCH parameter=val e: java.lang.Exception{ kotlin.Exception } [val] declared in <root>.box
+          VAR CATCH_PARAMETER name:e type:java.lang.Exception{ kotlin.Exception } [val]
+          BLOCK type=kotlin.Unit origin=null
+            SET_VAR 'var result: kotlin.String [var] declared in <root>.box' type=kotlin.Unit origin=EQ
+              CONST String type=kotlin.String value="OK"
       RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
         CALL 'public final fun plus (other: kotlin.Any?): kotlin.String declared in kotlin.String' type=kotlin.String origin=PLUS
           $this: CALL 'public final fun f (f1: kotlin.Function0<kotlin.String>, f2: kotlin.Function0<kotlin.String>): kotlin.String declared in <root>' type=kotlin.String origin=null

--- a/compiler/testData/ir/irText/expressions/argumentMappedWithError.txt
+++ b/compiler/testData/ir/irText/expressions/argumentMappedWithError.txt
@@ -3,8 +3,7 @@ FILE fqName:<root> fileName:/argumentMappedWithError.kt
     TYPE_PARAMETER name:R index:0 variance: superTypes:[kotlin.Number]
     $receiver: VALUE_PARAMETER name:<this> type:kotlin.Number
     BLOCK_BODY
-      RETURN type=kotlin.Nothing from='public final fun convert <R> (): R of <root>.convert declared in <root>'
-        CALL 'public final fun TODO (): kotlin.Nothing [inline] declared in kotlin' type=kotlin.Nothing origin=null
+      CALL 'public final fun TODO (): kotlin.Nothing [inline] declared in kotlin' type=kotlin.Nothing origin=null
   FUN name:foo visibility:public modality:FINAL <> (arg:kotlin.Number) returnType:kotlin.Unit
     VALUE_PARAMETER name:arg index:0 type:kotlin.Number
     BLOCK_BODY

--- a/compiler/testData/ir/irText/expressions/breakContinueInWhen.txt
+++ b/compiler/testData/ir/irText/expressions/breakContinueInWhen.txt
@@ -23,8 +23,8 @@ FILE fqName:<root> fileName:/breakContinueInWhen.kt
             VAR FOR_LOOP_VARIABLE name:x type:kotlin.Int [val]
               CALL 'public final fun next (): kotlin.Int declared in kotlin.collections.IntIterator' type=kotlin.Int origin=FOR_LOOP_NEXT
                 $this: GET_VAR 'val tmp0_iterator: kotlin.collections.IntIterator [val] declared in <root>.testBreakFor' type=kotlin.collections.IntIterator origin=null
-            BLOCK type=kotlin.Nothing origin=null
-              WHEN type=kotlin.Nothing origin=WHEN
+            BLOCK type=kotlin.Unit origin=null
+              WHEN type=kotlin.Unit origin=WHEN
                 BRANCH
                   if: CALL 'public final fun greater (arg0: kotlin.Int, arg1: kotlin.Int): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=GT
                     arg0: GET_VAR 'var k: kotlin.Int [var] declared in <root>.testBreakFor' type=kotlin.Int origin=null
@@ -39,7 +39,7 @@ FILE fqName:<root> fileName:/breakContinueInWhen.kt
           arg0: GET_VAR 'var k: kotlin.Int [var] declared in <root>.testBreakWhile' type=kotlin.Int origin=null
           arg1: CONST Int type=kotlin.Int value=10
         body: BLOCK type=kotlin.Unit origin=null
-          WHEN type=kotlin.Nothing origin=WHEN
+          WHEN type=kotlin.Unit origin=WHEN
             BRANCH
               if: CALL 'public final fun greater (arg0: kotlin.Int, arg1: kotlin.Int): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=GT
                 arg0: GET_VAR 'var k: kotlin.Int [var] declared in <root>.testBreakWhile' type=kotlin.Int origin=null
@@ -52,7 +52,7 @@ FILE fqName:<root> fileName:/breakContinueInWhen.kt
       BLOCK type=kotlin.Unit origin=null
         DO_WHILE label=null origin=DO_WHILE_LOOP
           body: COMPOSITE type=kotlin.Unit origin=null
-            WHEN type=kotlin.Nothing origin=WHEN
+            WHEN type=kotlin.Unit origin=WHEN
               BRANCH
                 if: CALL 'public final fun greater (arg0: kotlin.Int, arg1: kotlin.Int): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=GT
                   arg0: GET_VAR 'var k: kotlin.Int [var] declared in <root>.testBreakDoWhile' type=kotlin.Int origin=null
@@ -85,8 +85,8 @@ FILE fqName:<root> fileName:/breakContinueInWhen.kt
             VAR FOR_LOOP_VARIABLE name:x type:kotlin.Int [val]
               CALL 'public final fun next (): kotlin.Int declared in kotlin.collections.IntIterator' type=kotlin.Int origin=FOR_LOOP_NEXT
                 $this: GET_VAR 'val tmp0_iterator: kotlin.collections.IntIterator [val] declared in <root>.testContinueFor' type=kotlin.collections.IntIterator origin=null
-            BLOCK type=kotlin.Nothing origin=null
-              WHEN type=kotlin.Nothing origin=WHEN
+            BLOCK type=kotlin.Unit origin=null
+              WHEN type=kotlin.Unit origin=WHEN
                 BRANCH
                   if: CALL 'public final fun greater (arg0: kotlin.Int, arg1: kotlin.Int): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=GT
                     arg0: GET_VAR 'var k: kotlin.Int [var] declared in <root>.testContinueFor' type=kotlin.Int origin=null
@@ -101,7 +101,7 @@ FILE fqName:<root> fileName:/breakContinueInWhen.kt
           arg0: GET_VAR 'var k: kotlin.Int [var] declared in <root>.testContinueWhile' type=kotlin.Int origin=null
           arg1: CONST Int type=kotlin.Int value=10
         body: BLOCK type=kotlin.Unit origin=null
-          WHEN type=kotlin.Nothing origin=WHEN
+          WHEN type=kotlin.Unit origin=WHEN
             BRANCH
               if: CALL 'public final fun greater (arg0: kotlin.Int, arg1: kotlin.Int): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=GT
                 arg0: GET_VAR 'var k: kotlin.Int [var] declared in <root>.testContinueWhile' type=kotlin.Int origin=null
@@ -122,7 +122,7 @@ FILE fqName:<root> fileName:/breakContinueInWhen.kt
                   CALL 'public final fun inc (): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=PREFIX_INCR
                     $this: GET_VAR 'var k: kotlin.Int [var] declared in <root>.testContinueDoWhile' type=kotlin.Int origin=PREFIX_INCR
                 GET_VAR 'var k: kotlin.Int [var] declared in <root>.testContinueDoWhile' type=kotlin.Int origin=PREFIX_INCR
-            WHEN type=kotlin.Nothing origin=WHEN
+            WHEN type=kotlin.Unit origin=WHEN
               BRANCH
                 if: CALL 'public final fun greater (arg0: kotlin.Int, arg1: kotlin.Int): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=GT
                   arg0: GET_VAR 'var k: kotlin.Int [var] declared in <root>.testContinueDoWhile' type=kotlin.Int origin=null

--- a/compiler/testData/ir/irText/expressions/catchParameterAccess.txt
+++ b/compiler/testData/ir/irText/expressions/catchParameterAccess.txt
@@ -9,6 +9,6 @@ FILE fqName:<root> fileName:/catchParameterAccess.kt
               $this: GET_VAR 'f: kotlin.Function0<kotlin.Unit> declared in <root>.test' type=kotlin.Function0<kotlin.Unit> origin=VARIABLE_AS_FUNCTION
           CATCH parameter=val e: java.lang.Exception{ kotlin.Exception } [val] declared in <root>.test
             VAR CATCH_PARAMETER name:e type:java.lang.Exception{ kotlin.Exception } [val]
-            BLOCK type=kotlin.Nothing origin=null
+            BLOCK type=kotlin.Unit origin=null
               THROW type=kotlin.Nothing
                 GET_VAR 'val e: java.lang.Exception{ kotlin.Exception } [val] declared in <root>.test' type=java.lang.Exception{ kotlin.Exception } origin=null

--- a/compiler/testData/ir/irText/expressions/coercionToUnit.txt
+++ b/compiler/testData/ir/irText/expressions/coercionToUnit.txt
@@ -5,9 +5,8 @@ FILE fqName:<root> fileName:/coercionToUnit.kt
         FUN_EXPR type=kotlin.Function0<kotlin.Unit> origin=LAMBDA
           FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> () returnType:kotlin.Unit
             BLOCK_BODY
-              RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.Unit declared in <root>.test1'
-                TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
-                  CONST Int type=kotlin.Int value=42
+              TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+                CONST Int type=kotlin.Int value=42
     FUN DEFAULT_PROPERTY_ACCESSOR name:<get-test1> visibility:public modality:FINAL <> () returnType:kotlin.Function0<kotlin.Unit>
       correspondingProperty: PROPERTY name:test1 visibility:public modality:FINAL [val]
       BLOCK_BODY

--- a/compiler/testData/ir/irText/expressions/enumEntryReferenceFromEnumEntryClass.txt
+++ b/compiler/testData/ir/irText/expressions/enumEntryReferenceFromEnumEntryClass.txt
@@ -53,9 +53,8 @@ FILE fqName:<root> fileName:/enumEntryReferenceFromEnumEntryClass.kt
                     CALL 'public final fun <set-counter> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>.MyEnum.Z' type=kotlin.Unit origin=EQ
                       $this: GET_ENUM 'ENUM_ENTRY name:Z' type=<root>.MyEnum.Z
                       <set-?>: CONST Int type=kotlin.Int value=1
-                    RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.Unit declared in <root>.MyEnum.Z.aLambda'
-                      CALL 'public final fun foo (): kotlin.Unit declared in <root>.MyEnum.Z' type=kotlin.Unit origin=null
-                        $this: GET_ENUM 'ENUM_ENTRY name:Z' type=<root>.MyEnum.Z
+                    CALL 'public final fun foo (): kotlin.Unit declared in <root>.MyEnum.Z' type=kotlin.Unit origin=null
+                      $this: GET_ENUM 'ENUM_ENTRY name:Z' type=<root>.MyEnum.Z
           FUN DEFAULT_PROPERTY_ACCESSOR name:<get-aLambda> visibility:public modality:FINAL <> ($this:<root>.MyEnum.Z) returnType:kotlin.Function0<kotlin.Unit>
             correspondingProperty: PROPERTY name:aLambda visibility:public modality:FINAL [val]
             $this: VALUE_PARAMETER name:<this> type:<root>.MyEnum.Z

--- a/compiler/testData/ir/irText/expressions/forWithBreakContinue.txt
+++ b/compiler/testData/ir/irText/expressions/forWithBreakContinue.txt
@@ -13,7 +13,7 @@ FILE fqName:<root> fileName:/forWithBreakContinue.kt
             VAR FOR_LOOP_VARIABLE name:s type:kotlin.String [val]
               CALL 'public abstract fun next (): T of kotlin.collections.Iterator declared in kotlin.collections.Iterator' type=kotlin.String origin=FOR_LOOP_NEXT
                 $this: GET_VAR 'val tmp0_iterator: kotlin.collections.Iterator<kotlin.String> [val] declared in <root>.testForBreak1' type=kotlin.collections.Iterator<kotlin.String> origin=null
-            BLOCK type=kotlin.Nothing origin=null
+            BLOCK type=kotlin.Unit origin=null
               BREAK label=null loop.label=null
   FUN name:testForBreak2 visibility:public modality:FINAL <> (ss:kotlin.collections.List<kotlin.String>) returnType:kotlin.Unit
     VALUE_PARAMETER name:ss index:0 type:kotlin.collections.List<kotlin.String>
@@ -29,7 +29,7 @@ FILE fqName:<root> fileName:/forWithBreakContinue.kt
             VAR FOR_LOOP_VARIABLE name:s1 type:kotlin.String [val]
               CALL 'public abstract fun next (): T of kotlin.collections.Iterator declared in kotlin.collections.Iterator' type=kotlin.String origin=FOR_LOOP_NEXT
                 $this: GET_VAR 'val tmp0_iterator: kotlin.collections.Iterator<kotlin.String> [val] declared in <root>.testForBreak2' type=kotlin.collections.Iterator<kotlin.String> origin=null
-            BLOCK type=kotlin.Nothing origin=null
+            BLOCK type=kotlin.Unit origin=null
               BLOCK type=kotlin.Unit origin=FOR_LOOP
                 VAR FOR_LOOP_ITERATOR name:tmp1_iterator type:kotlin.collections.Iterator<kotlin.String> [val]
                   CALL 'public abstract fun iterator (): kotlin.collections.Iterator<E of kotlin.collections.List> declared in kotlin.collections.List' type=kotlin.collections.Iterator<kotlin.String> origin=FOR_LOOP_ITERATOR
@@ -41,7 +41,7 @@ FILE fqName:<root> fileName:/forWithBreakContinue.kt
                     VAR FOR_LOOP_VARIABLE name:s2 type:kotlin.String [val]
                       CALL 'public abstract fun next (): T of kotlin.collections.Iterator declared in kotlin.collections.Iterator' type=kotlin.String origin=FOR_LOOP_NEXT
                         $this: GET_VAR 'val tmp1_iterator: kotlin.collections.Iterator<kotlin.String> [val] declared in <root>.testForBreak2' type=kotlin.collections.Iterator<kotlin.String> origin=null
-                    BLOCK type=kotlin.Nothing origin=null
+                    BLOCK type=kotlin.Unit origin=null
                       BREAK label=OUTER loop.label=OUTER
                       BREAK label=INNER loop.label=INNER
                       BREAK label=null loop.label=INNER
@@ -60,7 +60,7 @@ FILE fqName:<root> fileName:/forWithBreakContinue.kt
             VAR FOR_LOOP_VARIABLE name:s type:kotlin.String [val]
               CALL 'public abstract fun next (): T of kotlin.collections.Iterator declared in kotlin.collections.Iterator' type=kotlin.String origin=FOR_LOOP_NEXT
                 $this: GET_VAR 'val tmp0_iterator: kotlin.collections.Iterator<kotlin.String> [val] declared in <root>.testForContinue1' type=kotlin.collections.Iterator<kotlin.String> origin=null
-            BLOCK type=kotlin.Nothing origin=null
+            BLOCK type=kotlin.Unit origin=null
               CONTINUE label=null loop.label=null
   FUN name:testForContinue2 visibility:public modality:FINAL <> (ss:kotlin.collections.List<kotlin.String>) returnType:kotlin.Unit
     VALUE_PARAMETER name:ss index:0 type:kotlin.collections.List<kotlin.String>
@@ -76,7 +76,7 @@ FILE fqName:<root> fileName:/forWithBreakContinue.kt
             VAR FOR_LOOP_VARIABLE name:s1 type:kotlin.String [val]
               CALL 'public abstract fun next (): T of kotlin.collections.Iterator declared in kotlin.collections.Iterator' type=kotlin.String origin=FOR_LOOP_NEXT
                 $this: GET_VAR 'val tmp0_iterator: kotlin.collections.Iterator<kotlin.String> [val] declared in <root>.testForContinue2' type=kotlin.collections.Iterator<kotlin.String> origin=null
-            BLOCK type=kotlin.Nothing origin=null
+            BLOCK type=kotlin.Unit origin=null
               BLOCK type=kotlin.Unit origin=FOR_LOOP
                 VAR FOR_LOOP_ITERATOR name:tmp1_iterator type:kotlin.collections.Iterator<kotlin.String> [val]
                   CALL 'public abstract fun iterator (): kotlin.collections.Iterator<E of kotlin.collections.List> declared in kotlin.collections.List' type=kotlin.collections.Iterator<kotlin.String> origin=FOR_LOOP_ITERATOR
@@ -88,7 +88,7 @@ FILE fqName:<root> fileName:/forWithBreakContinue.kt
                     VAR FOR_LOOP_VARIABLE name:s2 type:kotlin.String [val]
                       CALL 'public abstract fun next (): T of kotlin.collections.Iterator declared in kotlin.collections.Iterator' type=kotlin.String origin=FOR_LOOP_NEXT
                         $this: GET_VAR 'val tmp1_iterator: kotlin.collections.Iterator<kotlin.String> [val] declared in <root>.testForContinue2' type=kotlin.collections.Iterator<kotlin.String> origin=null
-                    BLOCK type=kotlin.Nothing origin=null
+                    BLOCK type=kotlin.Unit origin=null
                       CONTINUE label=OUTER loop.label=OUTER
                       CONTINUE label=INNER loop.label=INNER
                       CONTINUE label=null loop.label=INNER

--- a/compiler/testData/ir/irText/expressions/ifElseIf.txt
+++ b/compiler/testData/ir/irText/expressions/ifElseIf.txt
@@ -36,22 +36,22 @@ FILE fqName:<root> fileName:/ifElseIf.kt
   FUN name:testEmptyBranches2 visibility:public modality:FINAL <> (flag:kotlin.Boolean) returnType:kotlin.Unit
     VALUE_PARAMETER name:flag index:0 type:kotlin.Boolean
     BLOCK_BODY
-      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
-        WHEN type=kotlin.Any origin=IF
-          BRANCH
-            if: GET_VAR 'flag: kotlin.Boolean declared in <root>.testEmptyBranches2' type=kotlin.Boolean origin=null
-            then: BLOCK type=kotlin.Unit origin=null
-          BRANCH
-            if: CONST Boolean type=kotlin.Boolean value=true
-            then: CONST Boolean type=kotlin.Boolean value=true
-      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
-        WHEN type=kotlin.Any origin=IF
-          BRANCH
-            if: GET_VAR 'flag: kotlin.Boolean declared in <root>.testEmptyBranches2' type=kotlin.Boolean origin=null
-            then: CONST Boolean type=kotlin.Boolean value=true
-          BRANCH
-            if: CONST Boolean type=kotlin.Boolean value=true
-            then: BLOCK type=kotlin.Unit origin=null
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: GET_VAR 'flag: kotlin.Boolean declared in <root>.testEmptyBranches2' type=kotlin.Boolean origin=null
+          then: BLOCK type=kotlin.Unit origin=null
+        BRANCH
+          if: CONST Boolean type=kotlin.Boolean value=true
+          then: TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+            CONST Boolean type=kotlin.Boolean value=true
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: GET_VAR 'flag: kotlin.Boolean declared in <root>.testEmptyBranches2' type=kotlin.Boolean origin=null
+          then: TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+            CONST Boolean type=kotlin.Boolean value=true
+        BRANCH
+          if: CONST Boolean type=kotlin.Boolean value=true
+          then: BLOCK type=kotlin.Unit origin=null
   FUN name:testEmptyBranches3 visibility:public modality:FINAL <> (flag:kotlin.Boolean) returnType:kotlin.Unit
     VALUE_PARAMETER name:flag index:0 type:kotlin.Boolean
     BLOCK_BODY

--- a/compiler/testData/ir/irText/expressions/objectReference.txt
+++ b/compiler/testData/ir/irText/expressions/objectReference.txt
@@ -98,9 +98,8 @@ FILE fqName:<root> fileName:/objectReference.kt
                 CALL 'public final fun <set-counter> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>.Z' type=kotlin.Unit origin=EQ
                   $this: GET_OBJECT 'CLASS OBJECT name:Z modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.Z
                   <set-?>: CONST Int type=kotlin.Int value=1
-                RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.Unit declared in <root>.Z.aLambda'
-                  CALL 'public final fun foo (): kotlin.Unit declared in <root>.Z' type=kotlin.Unit origin=null
-                    $this: GET_OBJECT 'CLASS OBJECT name:Z modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.Z
+                CALL 'public final fun foo (): kotlin.Unit declared in <root>.Z' type=kotlin.Unit origin=null
+                  $this: GET_OBJECT 'CLASS OBJECT name:Z modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.Z
       FUN DEFAULT_PROPERTY_ACCESSOR name:<get-aLambda> visibility:public modality:FINAL <> ($this:<root>.Z) returnType:kotlin.Function0<kotlin.Unit>
         correspondingProperty: PROPERTY name:aLambda visibility:public modality:FINAL [val]
         $this: VALUE_PARAMETER name:<this> type:<root>.Z

--- a/compiler/testData/ir/irText/expressions/sam/samConversions.txt
+++ b/compiler/testData/ir/irText/expressions/sam/samConversions.txt
@@ -15,8 +15,7 @@ FILE fqName:<root> fileName:/samConversions.kt
           FUN_EXPR type=kotlin.Function0<kotlin.Unit> origin=LAMBDA
             FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> () returnType:kotlin.Unit
               BLOCK_BODY
-                RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.Unit declared in <root>.test1'
-                  CALL 'public final fun test1 (): kotlin.Unit declared in <root>' type=kotlin.Unit origin=null
+                CALL 'public final fun test1 (): kotlin.Unit declared in <root>' type=kotlin.Unit origin=null
   FUN name:test2 visibility:public modality:FINAL <> ($receiver:<root>.J) returnType:kotlin.Unit
     $receiver: VALUE_PARAMETER name:<this> type:<root>.J
     BLOCK_BODY
@@ -26,8 +25,7 @@ FILE fqName:<root> fileName:/samConversions.kt
           FUN_EXPR type=kotlin.Function0<kotlin.Unit> origin=LAMBDA
             FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> () returnType:kotlin.Unit
               BLOCK_BODY
-                RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.Unit declared in <root>.test2'
-                  CALL 'public final fun test1 (): kotlin.Unit declared in <root>' type=kotlin.Unit origin=null
+                CALL 'public final fun test1 (): kotlin.Unit declared in <root>' type=kotlin.Unit origin=null
   FUN name:test3 visibility:public modality:FINAL <> ($receiver:<root>.J, a:kotlin.Function0<kotlin.Unit>) returnType:kotlin.Unit
     $receiver: VALUE_PARAMETER name:<this> type:<root>.J
     VALUE_PARAMETER name:a index:0 type:kotlin.Function0<kotlin.Unit>

--- a/compiler/testData/ir/irText/expressions/throw.txt
+++ b/compiler/testData/ir/irText/expressions/throw.txt
@@ -10,7 +10,7 @@ FILE fqName:<root> fileName:/throw.kt
         BRANCH
           if: TYPE_OP type=kotlin.Boolean origin=INSTANCEOF typeOperand=kotlin.Throwable
             GET_VAR 'a: kotlin.Any declared in <root>.testImplicitCast' type=kotlin.Any origin=null
-          then: BLOCK type=kotlin.Nothing origin=null
+          then: BLOCK type=kotlin.Unit origin=null
             THROW type=kotlin.Nothing
               TYPE_OP type=kotlin.Throwable origin=IMPLICIT_CAST typeOperand=kotlin.Throwable
                 GET_VAR 'a: kotlin.Any declared in <root>.testImplicitCast' type=kotlin.Any origin=null

--- a/compiler/testData/ir/irText/expressions/tryCatch.txt
+++ b/compiler/testData/ir/irText/expressions/tryCatch.txt
@@ -22,7 +22,7 @@ FILE fqName:<root> fileName:/tryCatch.kt
             BLOCK type=kotlin.Int origin=null
               CALL 'public final fun println (): kotlin.Unit [inline] declared in kotlin.io' type=kotlin.Unit origin=null
               CONST Int type=kotlin.Int value=24
-          finally: TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
-            BLOCK type=kotlin.Int origin=null
-              CALL 'public final fun println (): kotlin.Unit [inline] declared in kotlin.io' type=kotlin.Unit origin=null
+          finally: BLOCK type=kotlin.Unit origin=null
+            CALL 'public final fun println (): kotlin.Unit [inline] declared in kotlin.io' type=kotlin.Unit origin=null
+            TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
               CONST Int type=kotlin.Int value=555

--- a/compiler/testData/ir/irText/expressions/whenReturn.txt
+++ b/compiler/testData/ir/irText/expressions/whenReturn.txt
@@ -2,10 +2,10 @@ FILE fqName:<root> fileName:/whenReturn.kt
   FUN name:toString visibility:public modality:FINAL <> (grade:kotlin.String) returnType:kotlin.String
     VALUE_PARAMETER name:grade index:0 type:kotlin.String
     BLOCK_BODY
-      BLOCK type=kotlin.Nothing origin=WHEN
+      BLOCK type=kotlin.Unit origin=WHEN
         VAR IR_TEMPORARY_VARIABLE name:tmp0_subject type:kotlin.String [val]
           GET_VAR 'grade: kotlin.String declared in <root>.toString' type=kotlin.String origin=null
-        WHEN type=kotlin.Nothing origin=WHEN
+        WHEN type=kotlin.Unit origin=WHEN
           BRANCH
             if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
               arg0: GET_VAR 'val tmp0_subject: kotlin.String [val] declared in <root>.toString' type=kotlin.String origin=null

--- a/compiler/testData/ir/irText/expressions/whenReturnUnit.fir.txt
+++ b/compiler/testData/ir/irText/expressions/whenReturnUnit.fir.txt
@@ -1,0 +1,27 @@
+FILE fqName:<root> fileName:/whenReturnUnit.kt
+  FUN name:run visibility:public modality:FINAL <> (block:kotlin.Function0<kotlin.Unit>) returnType:kotlin.Unit
+    VALUE_PARAMETER name:block index:0 type:kotlin.Function0<kotlin.Unit>
+    BLOCK_BODY
+  FUN name:branch visibility:public modality:FINAL <> (x:kotlin.Int) returnType:kotlin.Unit
+    VALUE_PARAMETER name:x index:0 type:kotlin.Int
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='public final fun branch (x: kotlin.Int): kotlin.Unit declared in <root>'
+        CALL 'public final fun run (block: kotlin.Function0<kotlin.Unit>): kotlin.Unit declared in <root>' type=kotlin.Unit origin=null
+          block: FUN_EXPR type=kotlin.Function0<kotlin.Unit> origin=LAMBDA
+            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> () returnType:kotlin.Unit
+              BLOCK_BODY
+                BLOCK type=kotlin.Unit origin=WHEN
+                  VAR IR_TEMPORARY_VARIABLE name:tmp0_subject type:kotlin.Int [val]
+                  WHEN type=kotlin.Unit origin=WHEN
+                    BRANCH
+                      if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: GET_VAR 'val tmp0_subject: kotlin.Int [val] declared in <root>.branch.<anonymous>' type=kotlin.Int origin=null
+                        arg1: CONST Int type=kotlin.Int value=1
+                      then: CALL 'public final fun TODO (reason: kotlin.String): kotlin.Nothing [inline] declared in kotlin' type=kotlin.Nothing origin=null
+                        reason: CONST String type=kotlin.String value="1"
+                    BRANCH
+                      if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: GET_VAR 'val tmp0_subject: kotlin.Int [val] declared in <root>.branch.<anonymous>' type=kotlin.Int origin=null
+                        arg1: CONST Int type=kotlin.Int value=2
+                      then: CALL 'public final fun TODO (reason: kotlin.String): kotlin.Nothing [inline] declared in kotlin' type=kotlin.Nothing origin=null
+                        reason: CONST String type=kotlin.String value="2"

--- a/compiler/testData/ir/irText/expressions/whenReturnUnit.kt
+++ b/compiler/testData/ir/irText/expressions/whenReturnUnit.kt
@@ -1,0 +1,8 @@
+fun run(block: () -> Unit) {}
+
+fun branch(x: Int) = run {
+    when (x) {
+        1 -> TODO("1")
+        2 -> TODO("2")
+    }
+}

--- a/compiler/testData/ir/irText/expressions/whenReturnUnit.txt
+++ b/compiler/testData/ir/irText/expressions/whenReturnUnit.txt
@@ -1,0 +1,28 @@
+FILE fqName:<root> fileName:/whenReturnUnit.kt
+  FUN name:run visibility:public modality:FINAL <> (block:kotlin.Function0<kotlin.Unit>) returnType:kotlin.Unit
+    VALUE_PARAMETER name:block index:0 type:kotlin.Function0<kotlin.Unit>
+    BLOCK_BODY
+  FUN name:branch visibility:public modality:FINAL <> (x:kotlin.Int) returnType:kotlin.Unit
+    VALUE_PARAMETER name:x index:0 type:kotlin.Int
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='public final fun branch (x: kotlin.Int): kotlin.Unit declared in <root>'
+        CALL 'public final fun run (block: kotlin.Function0<kotlin.Unit>): kotlin.Unit declared in <root>' type=kotlin.Unit origin=null
+          block: FUN_EXPR type=kotlin.Function0<kotlin.Unit> origin=LAMBDA
+            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> () returnType:kotlin.Unit
+              BLOCK_BODY
+                BLOCK type=kotlin.Nothing origin=WHEN
+                  VAR IR_TEMPORARY_VARIABLE name:tmp0_subject type:kotlin.Int [val]
+                    GET_VAR 'x: kotlin.Int declared in <root>.branch' type=kotlin.Int origin=null
+                  WHEN type=kotlin.Nothing origin=WHEN
+                    BRANCH
+                      if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: GET_VAR 'val tmp0_subject: kotlin.Int [val] declared in <root>.branch.<anonymous>' type=kotlin.Int origin=null
+                        arg1: CONST Int type=kotlin.Int value=1
+                      then: CALL 'public final fun TODO (reason: kotlin.String): kotlin.Nothing [inline] declared in kotlin' type=kotlin.Nothing origin=null
+                        reason: CONST String type=kotlin.String value="1"
+                    BRANCH
+                      if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: GET_VAR 'val tmp0_subject: kotlin.Int [val] declared in <root>.branch.<anonymous>' type=kotlin.Int origin=null
+                        arg1: CONST Int type=kotlin.Int value=2
+                      then: CALL 'public final fun TODO (reason: kotlin.String): kotlin.Nothing [inline] declared in kotlin' type=kotlin.Nothing origin=null
+                        reason: CONST String type=kotlin.String value="2"

--- a/compiler/testData/ir/irText/expressions/whenReturnUnit.txt
+++ b/compiler/testData/ir/irText/expressions/whenReturnUnit.txt
@@ -10,10 +10,10 @@ FILE fqName:<root> fileName:/whenReturnUnit.kt
           block: FUN_EXPR type=kotlin.Function0<kotlin.Unit> origin=LAMBDA
             FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> () returnType:kotlin.Unit
               BLOCK_BODY
-                BLOCK type=kotlin.Nothing origin=WHEN
+                BLOCK type=kotlin.Unit origin=WHEN
                   VAR IR_TEMPORARY_VARIABLE name:tmp0_subject type:kotlin.Int [val]
                     GET_VAR 'x: kotlin.Int declared in <root>.branch' type=kotlin.Int origin=null
-                  WHEN type=kotlin.Nothing origin=WHEN
+                  WHEN type=kotlin.Unit origin=WHEN
                     BRANCH
                       if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
                         arg0: GET_VAR 'val tmp0_subject: kotlin.Int [val] declared in <root>.branch.<anonymous>' type=kotlin.Int origin=null

--- a/compiler/testData/ir/irText/expressions/whenUnusedExpression.txt
+++ b/compiler/testData/ir/irText/expressions/whenUnusedExpression.txt
@@ -3,23 +3,25 @@ FILE fqName:<root> fileName:/whenUnusedExpression.kt
     VALUE_PARAMETER name:b index:0 type:kotlin.Boolean
     VALUE_PARAMETER name:i index:1 type:kotlin.Int
     BLOCK_BODY
-      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
-        WHEN type=kotlin.Int? origin=IF
-          BRANCH
-            if: GET_VAR 'b: kotlin.Boolean declared in <root>.test' type=kotlin.Boolean origin=null
-            then: BLOCK type=kotlin.Int? origin=null
-              BLOCK type=kotlin.Int? origin=WHEN
-                VAR IR_TEMPORARY_VARIABLE name:tmp0_subject type:kotlin.Int [val]
-                  GET_VAR 'i: kotlin.Int declared in <root>.test' type=kotlin.Int origin=null
-                WHEN type=kotlin.Int? origin=WHEN
-                  BRANCH
-                    if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                      arg0: GET_VAR 'val tmp0_subject: kotlin.Int [val] declared in <root>.test' type=kotlin.Int origin=null
-                      arg1: CONST Int type=kotlin.Int value=0
-                    then: CONST Int type=kotlin.Int value=1
-                  BRANCH
-                    if: CONST Boolean type=kotlin.Boolean value=true
-                    then: CONST Null type=kotlin.Nothing? value=null
-          BRANCH
-            if: CONST Boolean type=kotlin.Boolean value=true
-            then: CONST Null type=kotlin.Nothing? value=null
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: GET_VAR 'b: kotlin.Boolean declared in <root>.test' type=kotlin.Boolean origin=null
+          then: BLOCK type=kotlin.Unit origin=null
+            BLOCK type=kotlin.Unit origin=WHEN
+              VAR IR_TEMPORARY_VARIABLE name:tmp0_subject type:kotlin.Int [val]
+                GET_VAR 'i: kotlin.Int declared in <root>.test' type=kotlin.Int origin=null
+              WHEN type=kotlin.Unit origin=WHEN
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'val tmp0_subject: kotlin.Int [val] declared in <root>.test' type=kotlin.Int origin=null
+                    arg1: CONST Int type=kotlin.Int value=0
+                  then: TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+                    CONST Int type=kotlin.Int value=1
+                BRANCH
+                  if: CONST Boolean type=kotlin.Boolean value=true
+                  then: TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+                    CONST Null type=kotlin.Nothing? value=null
+        BRANCH
+          if: CONST Boolean type=kotlin.Boolean value=true
+          then: TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+            CONST Null type=kotlin.Nothing? value=null

--- a/compiler/testData/ir/irText/lambdas/nonLocalReturn.txt
+++ b/compiler/testData/ir/irText/lambdas/nonLocalReturn.txt
@@ -33,14 +33,13 @@ FILE fqName:<root> fileName:/nonLocalReturn.kt
         block: FUN_EXPR type=kotlin.Function0<kotlin.Unit> origin=LAMBDA
           FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> () returnType:kotlin.Unit
             BLOCK_BODY
-              RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.Unit declared in <root>.test3'
-                CALL 'public final fun run <R> (block: kotlin.Function0<R of kotlin.run>): R of kotlin.run [inline] declared in kotlin' type=kotlin.Nothing origin=null
-                  <R>: kotlin.Nothing
-                  block: FUN_EXPR type=kotlin.Function0<kotlin.Nothing> origin=LAMBDA
-                    FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> () returnType:kotlin.Nothing
-                      BLOCK_BODY
-                        RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.Unit declared in <root>.test3'
-                          GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Unit modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+              CALL 'public final fun run <R> (block: kotlin.Function0<R of kotlin.run>): R of kotlin.run [inline] declared in kotlin' type=kotlin.Nothing origin=null
+                <R>: kotlin.Nothing
+                block: FUN_EXPR type=kotlin.Function0<kotlin.Nothing> origin=LAMBDA
+                  FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> () returnType:kotlin.Nothing
+                    BLOCK_BODY
+                      RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.Unit declared in <root>.test3'
+                        GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Unit modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
   FUN name:testLrmFoo1 visibility:public modality:FINAL <> (ints:kotlin.collections.List<kotlin.Int>) returnType:kotlin.Unit
     VALUE_PARAMETER name:ints index:0 type:kotlin.collections.List<kotlin.Int>
     BLOCK_BODY
@@ -58,9 +57,8 @@ FILE fqName:<root> fileName:/nonLocalReturn.kt
                     arg1: CONST Int type=kotlin.Int value=0
                   then: RETURN type=kotlin.Nothing from='local final fun <anonymous> (it: kotlin.Int): kotlin.Unit declared in <root>.testLrmFoo1'
                     GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Unit modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
-              RETURN type=kotlin.Nothing from='local final fun <anonymous> (it: kotlin.Int): kotlin.Unit declared in <root>.testLrmFoo1'
-                CALL 'public final fun print (message: kotlin.Int): kotlin.Unit [inline] declared in kotlin.io' type=kotlin.Unit origin=null
-                  message: GET_VAR 'it: kotlin.Int declared in <root>.testLrmFoo1.<anonymous>' type=kotlin.Int origin=null
+              CALL 'public final fun print (message: kotlin.Int): kotlin.Unit [inline] declared in kotlin.io' type=kotlin.Unit origin=null
+                message: GET_VAR 'it: kotlin.Int declared in <root>.testLrmFoo1.<anonymous>' type=kotlin.Int origin=null
   FUN name:testLrmFoo2 visibility:public modality:FINAL <> (ints:kotlin.collections.List<kotlin.Int>) returnType:kotlin.Unit
     VALUE_PARAMETER name:ints index:0 type:kotlin.collections.List<kotlin.Int>
     BLOCK_BODY
@@ -78,6 +76,5 @@ FILE fqName:<root> fileName:/nonLocalReturn.kt
                     arg1: CONST Int type=kotlin.Int value=0
                   then: RETURN type=kotlin.Nothing from='local final fun <anonymous> (it: kotlin.Int): kotlin.Unit declared in <root>.testLrmFoo2'
                     GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Unit modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
-              RETURN type=kotlin.Nothing from='local final fun <anonymous> (it: kotlin.Int): kotlin.Unit declared in <root>.testLrmFoo2'
-                CALL 'public final fun print (message: kotlin.Int): kotlin.Unit [inline] declared in kotlin.io' type=kotlin.Unit origin=null
-                  message: GET_VAR 'it: kotlin.Int declared in <root>.testLrmFoo2.<anonymous>' type=kotlin.Int origin=null
+              CALL 'public final fun print (message: kotlin.Int): kotlin.Unit [inline] declared in kotlin.io' type=kotlin.Unit origin=null
+                message: GET_VAR 'it: kotlin.Int declared in <root>.testLrmFoo2.<anonymous>' type=kotlin.Int origin=null

--- a/compiler/testData/ir/irText/lambdas/samAdapter.txt
+++ b/compiler/testData/ir/irText/lambdas/samAdapter.txt
@@ -6,8 +6,7 @@ FILE fqName:<root> fileName:/samAdapter.kt
           FUN_EXPR type=kotlin.Function0<kotlin.Unit> origin=LAMBDA
             FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> () returnType:kotlin.Unit
               BLOCK_BODY
-                RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.Unit declared in <root>.test1'
-                  CALL 'public final fun println (message: kotlin.Any?): kotlin.Unit [inline] declared in kotlin.io' type=kotlin.Unit origin=null
-                    message: CONST String type=kotlin.String value="Hello, world!"
+                CALL 'public final fun println (message: kotlin.Any?): kotlin.Unit [inline] declared in kotlin.io' type=kotlin.Unit origin=null
+                  message: CONST String type=kotlin.String value="Hello, world!"
       CALL 'public abstract fun run (): kotlin.Unit declared in java.lang.Runnable' type=kotlin.Unit origin=null
         $this: GET_VAR 'val hello: java.lang.Runnable [val] declared in <root>.test1' type=java.lang.Runnable origin=null

--- a/compiler/testData/ir/irText/regressions/integerCoercionToT.txt
+++ b/compiler/testData/ir/irText/regressions/integerCoercionToT.txt
@@ -18,8 +18,7 @@ FILE fqName:<root> fileName:/integerCoercionToT.kt
     TYPE_PARAMETER name:T index:0 variance: superTypes:[<root>.CPointed]
     $receiver: VALUE_PARAMETER name:<this> type:<root>.CPointed
     BLOCK_BODY
-      RETURN type=kotlin.Nothing from='public final fun reinterpret <T> (): T of <root>.reinterpret [inline] declared in <root>'
-        CALL 'public final fun TODO (): kotlin.Nothing [inline] declared in kotlin' type=kotlin.Nothing origin=null
+      CALL 'public final fun TODO (): kotlin.Nothing [inline] declared in kotlin' type=kotlin.Nothing origin=null
   CLASS CLASS name:CInt32VarX modality:FINAL visibility:public superTypes:[<root>.CPointed]
     $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.CInt32VarX<T of <root>.CInt32VarX>
     TYPE_PARAMETER name:T index:0 variance: superTypes:[kotlin.Any?]
@@ -47,8 +46,7 @@ FILE fqName:<root> fileName:/integerCoercionToT.kt
       TYPE_PARAMETER name:T_INT index:0 variance: superTypes:[kotlin.Int]
       $receiver: VALUE_PARAMETER name:<this> type:<root>.CInt32VarX<T_INT of <root>.<get-value>>
       BLOCK_BODY
-        RETURN type=kotlin.Nothing from='public final fun <get-value> <T_INT> (): T_INT of <root>.<get-value> declared in <root>'
-          CALL 'public final fun TODO (): kotlin.Nothing [inline] declared in kotlin' type=kotlin.Nothing origin=null
+        CALL 'public final fun TODO (): kotlin.Nothing [inline] declared in kotlin' type=kotlin.Nothing origin=null
     FUN name:<set-value> visibility:public modality:FINAL <T_INT> ($receiver:<root>.CInt32VarX<T_INT of <root>.<set-value>>, value:T_INT of <root>.<set-value>) returnType:kotlin.Unit
       correspondingProperty: PROPERTY name:value visibility:public modality:FINAL [var]
       TYPE_PARAMETER name:T_INT index:0 variance: superTypes:[kotlin.Int]

--- a/compiler/testData/ir/irText/regressions/kt24114.txt
+++ b/compiler/testData/ir/irText/regressions/kt24114.txt
@@ -12,19 +12,19 @@ FILE fqName:<root> fileName:/kt24114.kt
       WHILE label=null origin=WHILE_LOOP
         condition: CONST Boolean type=kotlin.Boolean value=true
         body: BLOCK type=kotlin.Unit origin=null
-          BLOCK type=kotlin.Nothing origin=WHEN
+          BLOCK type=kotlin.Unit origin=WHEN
             VAR IR_TEMPORARY_VARIABLE name:tmp0_subject type:kotlin.Int [val]
               CALL 'public final fun one (): kotlin.Int declared in <root>' type=kotlin.Int origin=null
-            WHEN type=kotlin.Nothing origin=WHEN
+            WHEN type=kotlin.Unit origin=WHEN
               BRANCH
                 if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
                   arg0: GET_VAR 'val tmp0_subject: kotlin.Int [val] declared in <root>.test1' type=kotlin.Int origin=null
                   arg1: CONST Int type=kotlin.Int value=1
-                then: BLOCK type=kotlin.Nothing origin=null
-                  BLOCK type=kotlin.Nothing origin=WHEN
+                then: BLOCK type=kotlin.Unit origin=null
+                  BLOCK type=kotlin.Unit origin=WHEN
                     VAR IR_TEMPORARY_VARIABLE name:tmp1_subject type:kotlin.Int [val]
                       CALL 'public final fun two (): kotlin.Int declared in <root>' type=kotlin.Int origin=null
-                    WHEN type=kotlin.Nothing origin=WHEN
+                    WHEN type=kotlin.Unit origin=WHEN
                       BRANCH
                         if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
                           arg0: GET_VAR 'val tmp1_subject: kotlin.Int [val] declared in <root>.test1' type=kotlin.Int origin=null
@@ -40,18 +40,18 @@ FILE fqName:<root> fileName:/kt24114.kt
       WHILE label=null origin=WHILE_LOOP
         condition: CONST Boolean type=kotlin.Boolean value=true
         body: BLOCK type=kotlin.Unit origin=null
-          BLOCK type=kotlin.Nothing origin=WHEN
+          BLOCK type=kotlin.Unit origin=WHEN
             VAR IR_TEMPORARY_VARIABLE name:tmp0_subject type:kotlin.Int [val]
               CALL 'public final fun one (): kotlin.Int declared in <root>' type=kotlin.Int origin=null
-            WHEN type=kotlin.Nothing origin=WHEN
+            WHEN type=kotlin.Unit origin=WHEN
               BRANCH
                 if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
                   arg0: GET_VAR 'val tmp0_subject: kotlin.Int [val] declared in <root>.test2' type=kotlin.Int origin=null
                   arg1: CONST Int type=kotlin.Int value=1
-                then: BLOCK type=kotlin.Nothing origin=WHEN
+                then: BLOCK type=kotlin.Unit origin=WHEN
                   VAR IR_TEMPORARY_VARIABLE name:tmp1_subject type:kotlin.Int [val]
                     CALL 'public final fun two (): kotlin.Int declared in <root>' type=kotlin.Int origin=null
-                  WHEN type=kotlin.Nothing origin=WHEN
+                  WHEN type=kotlin.Unit origin=WHEN
                     BRANCH
                       if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
                         arg0: GET_VAR 'val tmp1_subject: kotlin.Int [val] declared in <root>.test2' type=kotlin.Int origin=null

--- a/compiler/testData/ir/irText/regressions/newInference/fixationOrder1.txt
+++ b/compiler/testData/ir/irText/regressions/newInference/fixationOrder1.txt
@@ -3,8 +3,7 @@ FILE fqName:<root> fileName:/fixationOrder1.kt
     TYPE_PARAMETER name:X index:0 variance: superTypes:[kotlin.Any?]
     TYPE_PARAMETER name:Y index:1 variance: superTypes:[kotlin.Any?]
     BLOCK_BODY
-      RETURN type=kotlin.Nothing from='public final fun foo <X, Y> (): kotlin.Function1<X of <root>.foo, Y of <root>.foo> declared in <root>'
-        CALL 'public final fun TODO (): kotlin.Nothing [inline] declared in kotlin' type=kotlin.Nothing origin=null
+      CALL 'public final fun TODO (): kotlin.Nothing [inline] declared in kotlin' type=kotlin.Nothing origin=null
   CLASS INTERFACE name:Inv2 modality:ABSTRACT visibility:public superTypes:[kotlin.Any]
     $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.Inv2<A of <root>.Inv2, B of <root>.Inv2>
     TYPE_PARAMETER name:A index:0 variance: superTypes:[kotlin.Any?]
@@ -29,8 +28,7 @@ FILE fqName:<root> fileName:/fixationOrder1.kt
     VALUE_PARAMETER name:y index:1 type:R of <root>.check
     VALUE_PARAMETER name:f index:2 type:kotlin.Function1<T of <root>.check, R of <root>.check>
     BLOCK_BODY
-      RETURN type=kotlin.Nothing from='public final fun check <T, R> (x: T of <root>.check, y: R of <root>.check, f: kotlin.Function1<T of <root>.check, R of <root>.check>): <root>.Inv2<T of <root>.check, R of <root>.check> declared in <root>'
-        CALL 'public final fun TODO (): kotlin.Nothing [inline] declared in kotlin' type=kotlin.Nothing origin=null
+      CALL 'public final fun TODO (): kotlin.Nothing [inline] declared in kotlin' type=kotlin.Nothing origin=null
   FUN name:test visibility:public modality:FINAL <> () returnType:<root>.Inv2<kotlin.String, kotlin.Int>
     BLOCK_BODY
       RETURN type=kotlin.Nothing from='public final fun test (): <root>.Inv2<kotlin.String, kotlin.Int> declared in <root>'

--- a/compiler/testData/ir/irText/stubs/builtinMap.txt
+++ b/compiler/testData/ir/irText/stubs/builtinMap.txt
@@ -26,11 +26,10 @@ FILE fqName:<root> fileName:/builtinMap.kt
                 FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> ($receiver:java.util.LinkedHashMap<K1 of <root>.plus?, V1 of <root>.plus?>{ kotlin.collections.LinkedHashMap<K1 of <root>.plus?, V1 of <root>.plus?> }) returnType:kotlin.Unit
                   $receiver: VALUE_PARAMETER name:<this> type:java.util.LinkedHashMap<K1 of <root>.plus?, V1 of <root>.plus?>{ kotlin.collections.LinkedHashMap<K1 of <root>.plus?, V1 of <root>.plus?> }
                   BLOCK_BODY
-                    RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.Unit declared in <root>.plus'
-                      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
-                        CALL 'public open fun put (key: K of java.util.LinkedHashMap, value: V of java.util.LinkedHashMap): V of java.util.LinkedHashMap? declared in java.util.LinkedHashMap' type=V1 of <root>.plus? origin=null
-                          $this: GET_VAR '<this>: java.util.LinkedHashMap<K1 of <root>.plus?, V1 of <root>.plus?>{ kotlin.collections.LinkedHashMap<K1 of <root>.plus?, V1 of <root>.plus?> } declared in <root>.plus.<anonymous>' type=java.util.LinkedHashMap<K1 of <root>.plus?, V1 of <root>.plus?>{ kotlin.collections.LinkedHashMap<K1 of <root>.plus?, V1 of <root>.plus?> } origin=null
-                          key: CALL 'public final fun <get-first> (): A of kotlin.Pair declared in kotlin.Pair' type=K1 of <root>.plus origin=GET_PROPERTY
-                            $this: GET_VAR 'pair: kotlin.Pair<K1 of <root>.plus, V1 of <root>.plus> declared in <root>.plus' type=kotlin.Pair<K1 of <root>.plus, V1 of <root>.plus> origin=null
-                          value: CALL 'public final fun <get-second> (): B of kotlin.Pair declared in kotlin.Pair' type=V1 of <root>.plus origin=GET_PROPERTY
-                            $this: GET_VAR 'pair: kotlin.Pair<K1 of <root>.plus, V1 of <root>.plus> declared in <root>.plus' type=kotlin.Pair<K1 of <root>.plus, V1 of <root>.plus> origin=null
+                    TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+                      CALL 'public open fun put (key: K of java.util.LinkedHashMap, value: V of java.util.LinkedHashMap): V of java.util.LinkedHashMap? declared in java.util.LinkedHashMap' type=V1 of <root>.plus? origin=null
+                        $this: GET_VAR '<this>: java.util.LinkedHashMap<K1 of <root>.plus?, V1 of <root>.plus?>{ kotlin.collections.LinkedHashMap<K1 of <root>.plus?, V1 of <root>.plus?> } declared in <root>.plus.<anonymous>' type=java.util.LinkedHashMap<K1 of <root>.plus?, V1 of <root>.plus?>{ kotlin.collections.LinkedHashMap<K1 of <root>.plus?, V1 of <root>.plus?> } origin=null
+                        key: CALL 'public final fun <get-first> (): A of kotlin.Pair declared in kotlin.Pair' type=K1 of <root>.plus origin=GET_PROPERTY
+                          $this: GET_VAR 'pair: kotlin.Pair<K1 of <root>.plus, V1 of <root>.plus> declared in <root>.plus' type=kotlin.Pair<K1 of <root>.plus, V1 of <root>.plus> origin=null
+                        value: CALL 'public final fun <get-second> (): B of kotlin.Pair declared in kotlin.Pair' type=V1 of <root>.plus origin=GET_PROPERTY
+                          $this: GET_VAR 'pair: kotlin.Pair<K1 of <root>.plus, V1 of <root>.plus> declared in <root>.plus' type=kotlin.Pair<K1 of <root>.plus, V1 of <root>.plus> origin=null

--- a/compiler/tests/org/jetbrains/kotlin/ir/IrTextTestCaseGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/ir/IrTextTestCaseGenerated.java
@@ -1286,6 +1286,11 @@ public class IrTextTestCaseGenerated extends AbstractIrTextTestCase {
             runTest("compiler/testData/ir/irText/expressions/whenReturn.kt");
         }
 
+        @TestMetadata("whenReturnUnit.kt")
+        public void testWhenReturnUnit() throws Exception {
+            runTest("compiler/testData/ir/irText/expressions/whenReturnUnit.kt");
+        }
+
         @TestMetadata("whenUnusedExpression.kt")
         public void testWhenUnusedExpression() throws Exception {
             runTest("compiler/testData/ir/irText/expressions/whenUnusedExpression.kt");


### PR DESCRIPTION
Right now psi2ir translates almost all KtExpressions as IrExpressions, even though expressions can sometimes be used as statements. This leads to incorrect IrTypes and related issues.

Consider the following code
```kotlin
fun run(block: () -> Unit) {}

fun branch(x: Int) = run {
    when (x) {
        1 -> TODO("1")
        2 -> TODO("2")
    }
}
```
Here we have a lambda whose body ends with a non-exhaustive conditional statement. The lambda is translated into the following IR:
```kotlin
FUN_EXPR type=kotlin.Function0<kotlin.Unit> origin=LAMBDA
  FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> () returnType:kotlin.Unit
    BLOCK_BODY
!!    RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.Unit declared in <root>.branch'
!!    BLOCK type=kotlin.Nothing origin=WHEN
        VAR IR_TEMPORARY_VARIABLE name:tmp0_subject type:kotlin.Int [val]
          GET_VAR 'x: kotlin.Int declared in <root>.branch' type=kotlin.Int origin=null
!!      WHEN type=kotlin.Nothing origin=WHEN
...
```
There are two problems here.

First, we always wrap the last statement in the body of a lambda in a return, even if - as in this case - this statement is not an expression (this example lead to problems in the IR backend which @pyos fixed in #2706).

Second, the type of the conditional statement is wrong. Since all branches of the conditional statement have type `Nothing`, we assign type `Nothing` to the whole statement, even though the implicit else branch has type `Unit`.

This PR changes the inferred types in psi2ir to always assign type `Unit` to statements and fixes the problem with implicit return statements.