### PR TITLE
JVM: Use the correct line number for suspend calls.

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/coroutines/CoroutineTransformerMethodVisitor.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/coroutines/CoroutineTransformerMethodVisitor.kt
@@ -146,7 +146,8 @@ class CoroutineTransformerMethodVisitor(
         val suspensionPointLineNumbers = suspensionPoints.map { findSuspensionPointLineNumber(it) }
 
         val continuationLabels = suspensionPoints.withIndex().map {
-            transformCallAndReturnContinuationLabel(it.index + 1, it.value, methodNode, suspendMarkerVarIndex)
+            transformCallAndReturnContinuationLabel(
+                it.index + 1, it.value, methodNode, suspendMarkerVarIndex, suspensionPointLineNumbers[it.index])
         }
 
         methodNode.instructions.apply {
@@ -702,11 +703,12 @@ class CoroutineTransformerMethodVisitor(
         id: Int,
         suspension: SuspensionPoint,
         methodNode: MethodNode,
-        suspendMarkerVarIndex: Int
+        suspendMarkerVarIndex: Int,
+        suspendPointLineNumber: LineNumberNode?
     ): LabelNode {
         val continuationLabel = LabelNode()
         val continuationLabelAfterLoadedResult = LabelNode()
-        val suspendElementLineNumber = lineNumber
+        val suspendElementLineNumber = suspendPointLineNumber?.line ?: lineNumber
         var nextLineNumberNode = suspension.suspensionCallEnd.findNextOrNull { it is LineNumberNode } as? LineNumberNode
         with(methodNode.instructions) {
             // Save state

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -150,11 +150,7 @@ class ExpressionCodegen(
         if (fileEntry != null) {
             val lineNumber = fileEntry.getLineNumber(offset) + 1
             assert(lineNumber > 0)
-            // State-machine builder splits the sequence of instructions into states inside state-machine, adding additional LINENUMBERs
-            // between them for debugger to stop on suspension. Thus, it requires as much LINENUMBER information as possible to be present,
-            // otherwise, any exception will have incorrect line number. See elvisLineNumber.kt test.
-            // TODO: Remove unneeded LINENUMBERs after building the state-machine.
-            if (lastLineNumber != lineNumber || irFunction.isSuspend || irFunction.isInvokeSuspendOfLambda(context)) {
+            if (lastLineNumber != lineNumber) {
                 lastLineNumber = lineNumber
                 mv.visitLineNumber(lineNumber, markNewLabel())
             }


### PR DESCRIPTION
We compute the actual line number of the suspend call and then
throw it away instead of using it. Therefore, we had to generate
more line number instructions in order to pick up the right one.
With this change we don't have to do that.