### PR TITLE
JVM: Improve line number handling for suspend calls.

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/common/Util.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/common/Util.kt
@@ -34,6 +34,16 @@ val AbstractInsnNode.isMeaningful: Boolean
             else -> true
         }
 
+val AbstractInsnNode.isBranchOrCall: Boolean
+    get() =
+        when(this.type) {
+            AbstractInsnNode.JUMP_INSN,
+            AbstractInsnNode.TABLESWITCH_INSN,
+            AbstractInsnNode.LOOKUPSWITCH_INSN,
+            AbstractInsnNode.METHOD_INSN -> true
+            else -> false
+        }
+
 class InsnSequence(val from: AbstractInsnNode, val to: AbstractInsnNode?) : Sequence<AbstractInsnNode> {
     constructor(insnList: InsnList) : this(insnList.first, null)
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -150,11 +150,7 @@ class ExpressionCodegen(
         if (fileEntry != null) {
             val lineNumber = fileEntry.getLineNumber(offset) + 1
             assert(lineNumber > 0)
-            // State-machine builder splits the sequence of instructions into states inside state-machine, adding additional LINENUMBERs
-            // between them for debugger to stop on suspension. Thus, it requires as much LINENUMBER information as possible to be present,
-            // otherwise, any exception will have incorrect line number. See elvisLineNumber.kt test.
-            // TODO: Remove unneeded LINENUMBERs after building the state-machine.
-            if (lastLineNumber != lineNumber || irFunction.isSuspend || irFunction.isInvokeSuspendOfLambda(context)) {
+            if (lastLineNumber != lineNumber) {
                 lastLineNumber = lineNumber
                 mv.visitLineNumber(lineNumber, markNewLabel())
             }

--- a/compiler/testData/codegen/box/coroutines/debug/multipleSuspendCallsOnSameLine.kt
+++ b/compiler/testData/codegen/box/coroutines/debug/multipleSuspendCallsOnSameLine.kt
@@ -1,0 +1,94 @@
+// TARGET_BACKEND: JVM
+// WITH_RUNTIME
+// WITH_COROUTINES
+// FULL_JDK
+
+import helpers.*
+import kotlin.coroutines.*
+import kotlin.coroutines.intrinsics.*
+
+fun builder(c: suspend () -> Unit) {
+    c.startCoroutine(EmptyContinuation)
+}
+
+suspend fun mightThrow(b: Boolean): Int {
+    if (b) throw RuntimeException()
+    return 1
+}
+
+fun multipleCalls(b: Boolean) = builder {
+    mightThrow(b) + mightThrow(!b)
+}
+
+fun multipleCalls2(b: Boolean) = builder {
+    mightThrow(b) + mightThrow(!b)
+    throw RuntimeException()
+}
+
+var i = 0
+
+suspend fun throwEverySecondCall(): Int {
+    if ((i++ % 2) == 1) throw RuntimeException()
+    return 1
+}
+
+fun multipleCalls3() = builder {
+    throwEverySecondCall() + throwEverySecondCall()
+    throwEverySecondCall()
+}
+
+fun multipleCalls4() = builder {
+    throwEverySecondCall() + throwEverySecondCall()
+}
+
+fun box(): String {
+    try {
+        multipleCalls(true)
+        return "FAIL 0"
+    } catch (e: RuntimeException) {
+        if (e.stackTrace[0].lineNumber != 15) return "FAIL 1 ${e.stackTrace[0].lineNumber}"
+        if (e.stackTrace[1].lineNumber != 20) return "FAIL 2 ${e.stackTrace[1].lineNumber}"
+    }
+
+    try {
+        multipleCalls(false)
+        return "FAIL 3"
+    } catch (e: RuntimeException) {
+        if (e.stackTrace[0].lineNumber != 15) return "FAIL 4 ${e.stackTrace[0].lineNumber}"
+        if (e.stackTrace[1].lineNumber != 20) return "FAIL 5 ${e.stackTrace[1].lineNumber}"
+    }
+
+    try {
+        multipleCalls2(true)
+        return "FAIL 6"
+    } catch (e: RuntimeException) {
+        if (e.stackTrace[0].lineNumber != 15) return "FAIL 7 ${e.stackTrace[0].lineNumber}"
+        if (e.stackTrace[1].lineNumber != 24) return "FAIL 8 ${e.stackTrace[1].lineNumber}"
+    }
+
+    try {
+        multipleCalls2(false)
+        return "FAIL 9"
+    } catch (e: RuntimeException) {
+        if (e.stackTrace[0].lineNumber != 15) return "FAIL 10 ${e.stackTrace[0].lineNumber}"
+        if (e.stackTrace[1].lineNumber != 24) return "FAIL 11 ${e.stackTrace[1].lineNumber}"
+    }
+
+    try {
+        multipleCalls3()
+        return "FAIL 12"
+    } catch (e: RuntimeException) {
+        if (e.stackTrace[0].lineNumber != 31) return "FAIL 13 ${e.stackTrace[0].lineNumber}"
+        if (e.stackTrace[1].lineNumber != 36) return "FAIL 14 ${e.stackTrace[1].lineNumber}"
+    }
+
+    try {
+        multipleCalls4()
+        return "FAIL 15"
+    } catch (e: RuntimeException) {
+        if (e.stackTrace[0].lineNumber != 31) return "FAIL 16 ${e.stackTrace[0].lineNumber}"
+        if (e.stackTrace[1].lineNumber != 41) return "FAIL 17 ${e.stackTrace[1].lineNumber}"
+    }
+
+    return "OK"
+}

--- a/compiler/testData/codegen/box/coroutines/debug/throwsOnSameLine.kt
+++ b/compiler/testData/codegen/box/coroutines/debug/throwsOnSameLine.kt
@@ -3,7 +3,6 @@
 // WITH_COROUTINES
 // FULL_JDK
 
-
 import helpers.*
 import kotlin.coroutines.*
 import kotlin.coroutines.intrinsics.*
@@ -12,30 +11,28 @@ fun builder(c: suspend () -> Unit) {
     c.startCoroutine(EmptyContinuation)
 }
 
-suspend fun returnsNull() = null
-
-fun withLineBreak() = builder {
-    returnsNull()
-        ?: throw RuntimeException()
+suspend fun mightReturnNull(b: Boolean): String? {
+    return if (b) null else "asdf"
 }
 
-fun withoutLineBreak() = builder {
-    returnsNull() ?: throw RuntimeException()
+fun throwOnSameLine(b: Boolean) = builder {
+    if (mightReturnNull(b) == null) throw RuntimeException() else throw RuntimeException()
+    throw RuntimeException()
 }
 
 fun box(): String {
     try {
-        withLineBreak()
+        throwOnSameLine(true)
         return "FAIL 0"
     } catch (e: RuntimeException) {
         if (e.stackTrace[0].lineNumber != 19) return "FAIL 1 ${e.stackTrace[0].lineNumber}"
     }
 
     try {
-        withoutLineBreak()
+        throwOnSameLine(false)
         return "FAIL 2"
     } catch (e: RuntimeException) {
-        if (e.stackTrace[0].lineNumber != 23) return "FAIL 3 ${e.stackTrace[0].lineNumber}"
+        if (e.stackTrace[0].lineNumber != 19) return "FAIL 3 ${e.stackTrace[0].lineNumber}"
     }
 
     return "OK"

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -6935,9 +6935,19 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
                 runTest("compiler/testData/codegen/box/coroutines/debug/fqName.kt");
             }
 
+            @TestMetadata("multipleSuspendCallsOnSameLine.kt")
+            public void testMultipleSuspendCallsOnSameLine() throws Exception {
+                runTest("compiler/testData/codegen/box/coroutines/debug/multipleSuspendCallsOnSameLine.kt");
+            }
+
             @TestMetadata("runtimeDebugMetadata.kt")
             public void testRuntimeDebugMetadata() throws Exception {
                 runTest("compiler/testData/codegen/box/coroutines/debug/runtimeDebugMetadata.kt");
+            }
+
+            @TestMetadata("throwsOnSameLine.kt")
+            public void testThrowsOnSameLine() throws Exception {
+                runTest("compiler/testData/codegen/box/coroutines/debug/throwsOnSameLine.kt");
             }
         }
 

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -6935,9 +6935,19 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
                 runTest("compiler/testData/codegen/box/coroutines/debug/fqName.kt");
             }
 
+            @TestMetadata("multipleSuspendCallsOnSameLine.kt")
+            public void testMultipleSuspendCallsOnSameLine() throws Exception {
+                runTest("compiler/testData/codegen/box/coroutines/debug/multipleSuspendCallsOnSameLine.kt");
+            }
+
             @TestMetadata("runtimeDebugMetadata.kt")
             public void testRuntimeDebugMetadata() throws Exception {
                 runTest("compiler/testData/codegen/box/coroutines/debug/runtimeDebugMetadata.kt");
+            }
+
+            @TestMetadata("throwsOnSameLine.kt")
+            public void testThrowsOnSameLine() throws Exception {
+                runTest("compiler/testData/codegen/box/coroutines/debug/throwsOnSameLine.kt");
             }
         }
 

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -6385,9 +6385,19 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
                 runTest("compiler/testData/codegen/box/coroutines/debug/fqName.kt");
             }
 
+            @TestMetadata("multipleSuspendCallsOnSameLine.kt")
+            public void testMultipleSuspendCallsOnSameLine() throws Exception {
+                runTest("compiler/testData/codegen/box/coroutines/debug/multipleSuspendCallsOnSameLine.kt");
+            }
+
             @TestMetadata("runtimeDebugMetadata.kt")
             public void testRuntimeDebugMetadata() throws Exception {
                 runTest("compiler/testData/codegen/box/coroutines/debug/runtimeDebugMetadata.kt");
+            }
+
+            @TestMetadata("throwsOnSameLine.kt")
+            public void testThrowsOnSameLine() throws Exception {
+                runTest("compiler/testData/codegen/box/coroutines/debug/throwsOnSameLine.kt");
             }
         }
 


### PR DESCRIPTION
Take branching and method calls into account when finding the line
number of the continuation. If there is no line number before
branching instructions or method calls, the following code is
still on the line of the suspend call itself.

This fixes a couple of issues with incorrect line numbers for
multiple throws on the same line or multipe suspend calls on
the same line.

In addition, it avoids the need to spam the method node with
repeated line number instructions in the IR backend.