### PR TITLE
[JS] [KT-22228] [KT-19813] Fix testing with asynchronous @BeforeTest and @AfterTest

### DIFF
--- a/libraries/kotlin.test/js/it/js/expected-outcomes.js
+++ b/libraries/kotlin.test/js/it/js/expected-outcomes.js
@@ -4,6 +4,7 @@ module.exports = {
     'SimpleTest testFooWrong': 'pending',
     'TestTest emptyTest': 'pending',
     'AsyncTest checkAsyncOrder': 'pass',
+    'AsyncTest checkAsyncOrderAgain': 'pass',
     'AsyncTest asyncPassing': 'pass',
     'AsyncTest asyncFailing': 'fail',
     'org OrgTest test': 'pass',

--- a/libraries/kotlin.test/js/it/package.json
+++ b/libraries/kotlin.test/js/it/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "jasmine": "^2.9.0",
     "jest": "^20.0.4",
-    "mocha": "^3.4.2",
+    "mocha": "^6.2.2",
     "qunit": "^1.0.0",
     "tape": "~4.10.0"
   },

--- a/libraries/kotlin.test/js/it/src/test/kotlin/MainTest.kt
+++ b/libraries/kotlin.test/js/it/src/test/kotlin/MainTest.kt
@@ -45,8 +45,13 @@ class AsyncTest {
     var log = ""
 
     @BeforeTest
-    fun before() {
-        log = ""
+    fun before() = Promise<Unit> { resolve, _ ->
+        js("setTimeout")({ log += "i"; resolve(Unit) }, 200)
+    }
+
+    @AfterTest
+    fun after() = Promise<Unit> { resolve, _ ->
+        js("setTimeout")({ log = ""; resolve(Unit) }, 200)
     }
 
     fun promise(v: Int) = Promise<Int> { resolve, reject ->
@@ -57,6 +62,8 @@ class AsyncTest {
 
     @Test
     fun checkAsyncOrder(): Promise<Unit> {
+        assertEquals("i", log)
+
         log += 1
 
         val p1 = promise(10)
@@ -64,12 +71,18 @@ class AsyncTest {
         log += 2
 
         val p2 = p1.then { result ->
-            assertEquals(log, "1ab23c")
+            assertEquals("i1ab23c", log)
         }
 
         log += 3
 
         return p2
+    }
+
+    @Test
+    fun checkAsyncOrderAgain(): Promise<Unit> {
+        assertEquals("i", log)
+        return Promise.resolve(Unit)
     }
 
     @Test

--- a/libraries/kotlin.test/js/src/main/kotlin/kotlin/test/FrameworkAdapter.kt
+++ b/libraries/kotlin.test/js/src/main/kotlin/kotlin/test/FrameworkAdapter.kt
@@ -39,4 +39,20 @@ public external interface FrameworkAdapter {
      * @param testFn contains test body invocation
      */
     fun test(name: String, ignored: Boolean, testFn: () -> Any?)
+
+    /**
+     * Declares a before each function.
+     *
+     * @param name the before each function name.
+     * @param beforeFn contains before body invocation
+     */
+    fun beforeEach(name: String, beforeFn: () -> Any?)
+
+    /**
+     * Declares an after each function.
+     *
+     * @param name the after each function name.
+     * @param afterFn contains after body invocation
+     */
+    fun afterEach(name: String, afterFn: () -> Any?)
 }

--- a/libraries/kotlin.test/js/src/main/kotlin/kotlin/test/TestApi.kt
+++ b/libraries/kotlin.test/js/src/main/kotlin/kotlin/test/TestApi.kt
@@ -40,6 +40,8 @@ internal fun setAssertHook(hook: (AssertionResult) -> Unit) {
  *
  * suite('a suite', false, function() {
  *   suite('a subsuite', false, function() {
+ *     beforeEach('before', function() {...});
+ *     afterEach('after', function() {...});
  *     test('a test', false, function() {...});
  *     test('an ignored/pending test', true, function() {...});
  *   });
@@ -55,6 +57,16 @@ internal fun suite(name: String, ignored: Boolean, suiteFn: () -> Unit) {
 @JsName("test")
 internal fun test(name: String, ignored: Boolean, testFn: () -> Unit) {
     adapter().test(name, ignored, testFn)
+}
+
+@JsName("beforeEach")
+internal fun beforeEach(name: String, beforeFn: () -> Unit) {
+    adapter().beforeEach(name, beforeFn)
+}
+
+@JsName("afterEach")
+internal fun afterEach(name: String, afterFn: () -> Unit) {
+    adapter().afterEach(name, afterFn)
 }
 
 internal var currentAdapter: FrameworkAdapter? = null

--- a/libraries/kotlin.test/js/src/main/kotlin/kotlin/test/adapters/BareAdapter.kt
+++ b/libraries/kotlin.test/js/src/main/kotlin/kotlin/test/adapters/BareAdapter.kt
@@ -23,4 +23,12 @@ internal open class BareAdapter : FrameworkAdapter {
             testFn()
         }
     }
+
+    override fun beforeEach(name: String, beforeFn: () -> Any?) {
+        beforeFn()
+    }
+
+    override fun afterEach(name: String, afterFn: () -> Any?) {
+        afterFn()
+    }
 }

--- a/libraries/kotlin.test/js/src/main/kotlin/kotlin/test/adapters/Externals.kt
+++ b/libraries/kotlin.test/js/src/main/kotlin/kotlin/test/adapters/Externals.kt
@@ -12,6 +12,8 @@ internal external object QUnit {
     fun module(name: String, suiteFn: () -> Unit): Unit
     fun test(name: String, testFn: (dynamic) -> Any?): Unit
     fun skip(name: String, testFn: (dynamic) -> Any?): Unit
+    fun beforeEach(name: String, beforeFn: () -> Any?): Unit
+    fun afterEach(name: String, afterFn: () -> Any?): Unit
 }
 
 /*
@@ -22,6 +24,8 @@ internal external fun describe(name: String, fn: () -> Unit)
 internal external fun xdescribe(name: String, fn: () -> Unit)
 internal external fun it(name: String, fn: () -> Any?)
 internal external fun xit(name: String, fn: () -> Any?)
+internal external fun beforeEach(name: String, fn: () -> Any?)
+internal external fun afterEach(name: String, fn: () -> Any?)
 
 internal fun isQUnit() = js("typeof QUnit !== 'undefined'")
 

--- a/libraries/kotlin.test/js/src/main/kotlin/kotlin/test/adapters/JasmineLikeAdapter.kt
+++ b/libraries/kotlin.test/js/src/main/kotlin/kotlin/test/adapters/JasmineLikeAdapter.kt
@@ -27,4 +27,8 @@ internal class JasmineLikeAdapter : FrameworkAdapter {
             it(name, testFn)
         }
     }
+
+    override fun beforeEach(name: String, beforeFn: () -> Any?) = kotlin.test.adapters.beforeEach(name, beforeFn)
+
+    override fun afterEach(name: String, afterFn: () -> Any?) = kotlin.test.adapters.afterEach(name, afterFn)
 }

--- a/libraries/kotlin.test/js/src/main/kotlin/kotlin/test/adapters/QUnitAdapter.kt
+++ b/libraries/kotlin.test/js/src/main/kotlin/kotlin/test/adapters/QUnitAdapter.kt
@@ -42,4 +42,8 @@ internal class QUnitAdapter : FrameworkAdapter {
         }
         possiblePromise
     }
+
+    override fun beforeEach(name: String, beforeFn: () -> Any?) = QUnit.beforeEach(name, beforeFn)
+
+    override fun afterEach(name: String, afterFn: () -> Any?) = QUnit.afterEach(name, afterFn)
 }

--- a/libraries/tools/kotlin-test-js-runner/src/KotlinTestRunner.ts
+++ b/libraries/tools/kotlin-test-js-runner/src/KotlinTestRunner.ts
@@ -2,4 +2,8 @@ export interface KotlinTestRunner {
     suite(name: string, isIgnored: boolean, fn: () => void): void
 
     test(name: string, isIgnored: boolean, fn: () => void): void
+
+    beforeEach(name: string, fn: () => void): void
+
+    afterEach(name: string, fn: () => void): void
 }

--- a/libraries/tools/kotlin-test-js-runner/src/KotlinTestTeamCityConsoleAdapter.ts
+++ b/libraries/tools/kotlin-test-js-runner/src/KotlinTestTeamCityConsoleAdapter.ts
@@ -62,6 +62,12 @@ export function runWithTeamCityConsoleAdapter(
                     revertLogMethods.forEach(revert => revert());
                 }
             });
+        },
+        beforeEach(name: string, fn: () => void): void {
+            runner.beforeEach(name, fn);
+        },
+        afterEach(name: string, fn: () => void): void {
+            runner.afterEach(name, fn);
         }
     }
 }

--- a/libraries/tools/kotlin-test-js-runner/src/KotlinTestsFilter.ts
+++ b/libraries/tools/kotlin-test-js-runner/src/KotlinTestsFilter.ts
@@ -45,6 +45,14 @@ export function runWithFilter(
             } finally {
                 path.pop()
             }
+        },
+
+        beforeEach(name: string, fn: () => void): void {
+            runner.beforeEach(name, fn);
+        },
+
+        afterEach(name: string, fn: () => void): void {
+            runner.afterEach(name, fn);
         }
     };
 }


### PR DESCRIPTION
## Description

This PR fixes the current way of running asynchronous tests in JS.
Currently, as described in [KT-22228](https://youtrack.jetbrains.com/issue/KT-22228) and [KT-19813](https://youtrack.jetbrains.com/issue/KT-19813) there's a way to run asynchronous test with Mocha by returning a promise in test functions.

However, as reported in [this comment](https://youtrack.jetbrains.com/issue/KT-19813#focus=streamItem-27-2684677.0-0), this does not work for `@BeforeTest` and `@AfterTest` annotated methods as the runner does not wait for them to finish before running the test.

This is explained when looking at the generated js code as the before and after method are actually run sequentially inside the generated test method (cf. the *Before* section below) and do not call the framework's (Mocha) `beforeEach` and `afterEach` methods.

This PR fixes this by:
- Adding `beforeEach` and `afterEach` to the `FrameworkAdapter` interface
- Updating `JSTestGenerator` to generate appropriate calls to those methods (cf. *After* section below)
- Updating Mocha from 3.4.2 to 6.2.2 because support for asynchronous `beforeEach` and `afterEach` (with promises) was not present in 3.4.2

**Note:** I noticed the presence of `TestGenerator` in `:compiler:ir:backend.js` which seems to be doing something similar to `JSTestGenerator` (but to IR instead of JS code). I'm not sure of its role and if it needs to be modified as well. But as the integration test was passing I did not investigate further.

## Tests

This was tested by:
- Making the `before` and `after` method asynchronous in the `MainTest` integration test
- Passing `./gradlew :kotlin-test:kotlin-test-js:kotlin-test-js-it:testMocha`

(Tests with Jasmine, Qunit, Jest and Tape all fail on async tests as before)
(I did not find any unit tests using JSTestGenerator class)

### Before

```javascript
    suite('SimpleTest', false, function () {
      test('testFoo', false, function () {
        var tmp$;
        tmp$ = new SimpleTest();
        tmp$.beforeFun();
        try {
          return tmp$.testFoo();
        }
        finally {
          tmp$.afterFun();
        }
      });
      test('testBar', false, function () {
        var tmp$;
        tmp$ = new SimpleTest();
        tmp$.beforeFun();
        try {
          return tmp$.testBar();
        }
        finally {
          tmp$.afterFun();
        }
      });
      test('testFooWrong', true, function () {
        var tmp$;
        tmp$ = new SimpleTest();
        tmp$.beforeFun();
        try {
          return tmp$.testFooWrong();
        }
        finally {
          tmp$.afterFun();
        }
      });
    });
```

### After

```javascript
    suite('SimpleTest', false, function () {
      var instanceSimpleTest = new SimpleTest();
      beforeEach('beforeFun', function () {
        return instanceSimpleTest.beforeFun();
      });
      afterEach('afterFun', function () {
        return instanceSimpleTest.afterFun();
      });
      test('testFoo', false, function () {
        return instanceSimpleTest.testFoo();
      });
      test('testBar', false, function () {
        return instanceSimpleTest.testBar();
      });
      test('testFooWrong', true, function () {
        return instanceSimpleTest.testFooWrong();
      });
    });
```