### PR TITLE
Frontend: Avoid retypechecking the right hand side of assignment operators

### DIFF
--- a/compiler/fir/resolve/tests/org/jetbrains/kotlin/fir/FirDiagnosticsSmokeTestGenerated.java
+++ b/compiler/fir/resolve/tests/org/jetbrains/kotlin/fir/FirDiagnosticsSmokeTestGenerated.java
@@ -9763,6 +9763,11 @@ public class FirDiagnosticsSmokeTestGenerated extends AbstractFirDiagnosticsSmok
             runTest("compiler/testData/diagnostics/tests/inference/functionPlaceholderError.kt");
         }
 
+        @TestMetadata("genericAssignmentOperator.kt")
+        public void testGenericAssignmentOperator() throws Exception {
+            runTest("compiler/testData/diagnostics/tests/inference/genericAssignmentOperator.kt");
+        }
+
         @TestMetadata("hasErrorInConstrainingTypes.kt")
         public void testHasErrorInConstrainingTypes() throws Exception {
             runTest("compiler/testData/diagnostics/tests/inference/hasErrorInConstrainingTypes.kt");

--- a/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/ExpressionTypingVisitorForStatements.java
+++ b/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/ExpressionTypingVisitorForStatements.java
@@ -29,7 +29,9 @@ import org.jetbrains.kotlin.psi.*;
 import org.jetbrains.kotlin.resolve.BindingContext;
 import org.jetbrains.kotlin.resolve.BindingContextUtils;
 import org.jetbrains.kotlin.resolve.TemporaryBindingTrace;
+import org.jetbrains.kotlin.resolve.calls.ArgumentTypeResolver;
 import org.jetbrains.kotlin.resolve.calls.context.CallPosition;
+import org.jetbrains.kotlin.resolve.calls.context.ContextDependency;
 import org.jetbrains.kotlin.resolve.calls.context.TemporaryTraceAndCache;
 import org.jetbrains.kotlin.resolve.calls.model.ResolvedCall;
 import org.jetbrains.kotlin.resolve.calls.results.OverloadResolutionResults;
@@ -37,7 +39,6 @@ import org.jetbrains.kotlin.resolve.calls.results.OverloadResolutionResultsImpl;
 import org.jetbrains.kotlin.resolve.calls.results.OverloadResolutionResultsUtil;
 import org.jetbrains.kotlin.resolve.calls.smartcasts.DataFlowInfo;
 import org.jetbrains.kotlin.resolve.calls.smartcasts.DataFlowValue;
-import org.jetbrains.kotlin.resolve.calls.smartcasts.DataFlowValueFactory;
 import org.jetbrains.kotlin.resolve.lazy.ForceResolveUtil;
 import org.jetbrains.kotlin.resolve.scopes.LexicalWritableScope;
 import org.jetbrains.kotlin.resolve.scopes.receivers.ExpressionReceiver;
@@ -213,6 +214,12 @@ public class ExpressionTypingVisitorForStatements extends ExpressionTypingVisito
             context.trace.report(UNRESOLVED_REFERENCE.on(operationSign, operationSign));
             temporary.commit();
             return rightInfo.clearType();
+        } else if (ArgumentTypeResolver.getFunctionLiteralArgumentIfAny(right, context) == null &&
+                   ArgumentTypeResolver.getCallableReferenceExpressionIfAny(right, context) == null) {
+            // Cache the type info for the right hand side so that we don't evaluate it twice if there is no valid plusAssign.
+            // We skip over function literals and references, since ArgumentTypeResolver will only resolve the shape of the
+            // function type before attempting to resolve the call.
+            facade.getTypeInfo(right, context.replaceContextDependency(ContextDependency.DEPENDENT));
         }
         ExpressionReceiver receiver = ExpressionReceiver.Companion.create(left, leftType, context.trace.getBindingContext());
 

--- a/compiler/testData/diagnostics/tests/inference/genericAssignmentOperator.kt
+++ b/compiler/testData/diagnostics/tests/inference/genericAssignmentOperator.kt
@@ -1,0 +1,9 @@
+class R<T>
+
+fun <T> f(): R<T> = R<T>()
+
+operator fun Int.plusAssign(<!UNUSED_PARAMETER!>y<!>: R<Int>) {}
+
+fun box() {
+    1 += f()
+}

--- a/compiler/testData/diagnostics/tests/inference/genericAssignmentOperator.txt
+++ b/compiler/testData/diagnostics/tests/inference/genericAssignmentOperator.txt
@@ -1,0 +1,12 @@
+package
+
+public fun box(): kotlin.Unit
+public fun </*0*/ T> f(): R<T>
+public operator fun kotlin.Int.plusAssign(/*0*/ y: R<kotlin.Int>): kotlin.Unit
+
+public final class R</*0*/ T> {
+    public constructor R</*0*/ T>()
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}

--- a/compiler/tests/org/jetbrains/kotlin/checkers/DiagnosticsTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/checkers/DiagnosticsTestGenerated.java
@@ -9770,6 +9770,11 @@ public class DiagnosticsTestGenerated extends AbstractDiagnosticsTest {
                 runTest("compiler/testData/diagnostics/tests/inference/functionPlaceholderError.kt");
             }
 
+            @TestMetadata("genericAssignmentOperator.kt")
+            public void testGenericAssignmentOperator() throws Exception {
+                runTest("compiler/testData/diagnostics/tests/inference/genericAssignmentOperator.kt");
+            }
+
             @TestMetadata("hasErrorInConstrainingTypes.kt")
             public void testHasErrorInConstrainingTypes() throws Exception {
                 runTest("compiler/testData/diagnostics/tests/inference/hasErrorInConstrainingTypes.kt");

--- a/compiler/tests/org/jetbrains/kotlin/checkers/javac/DiagnosticsUsingJavacTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/checkers/javac/DiagnosticsUsingJavacTestGenerated.java
@@ -9765,6 +9765,11 @@ public class DiagnosticsUsingJavacTestGenerated extends AbstractDiagnosticsUsing
                 runTest("compiler/testData/diagnostics/tests/inference/functionPlaceholderError.kt");
             }
 
+            @TestMetadata("genericAssignmentOperator.kt")
+            public void testGenericAssignmentOperator() throws Exception {
+                runTest("compiler/testData/diagnostics/tests/inference/genericAssignmentOperator.kt");
+            }
+
             @TestMetadata("hasErrorInConstrainingTypes.kt")
             public void testHasErrorInConstrainingTypes() throws Exception {
                 runTest("compiler/testData/diagnostics/tests/inference/hasErrorInConstrainingTypes.kt");


### PR DESCRIPTION
Right now, we typecheck the right hand side of assignment operators  `x += 1` twice if the left hand side is an assignable lvalue. This can lead to exponential slowdowns in some cases, i.e.,
```kotlin
fun main() {
  var x = 0
  x += try {
    x += try {
      x += ...
      x
    } finally {}
    x
  } finally {}
}
```

In simple cases we can avoid this by typechecking the right hand side before resolution. Note that typechecking `+=` is still slow, though, since there are so many resolution candidates for `plusAssign` in the standard library.