### PR TITLE
Always use '\n' as line separator in GenerateSteppedRangesCodegenTestData

### DIFF
--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -18889,6 +18889,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             @TestDataPath("$PROJECT_ROOT")
             @RunWith(JUnit3RunnerWithInners.class)
             public static class IsInitializedAndDeinitialize extends AbstractLightAnalysisModeTest {
+                @TestMetadata("isInitializedMultiFile.kt")
+                public void ignoreIsInitializedMultiFile() throws Exception {
+                    runTest("compiler/testData/codegen/box/properties/lateinit/isInitializedAndDeinitialize/isInitializedMultiFile.kt");
+                }
+
                 private void runTest(String testDataFilePath) throws Exception {
                     KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM, testDataFilePath);
                 }
@@ -18910,11 +18915,6 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
                 @TestMetadata("innerSubclass.kt")
                 public void testInnerSubclass() throws Exception {
                     runTest("compiler/testData/codegen/box/properties/lateinit/isInitializedAndDeinitialize/innerSubclass.kt");
-                }
-
-                @TestMetadata("isInitializedMultiFile.kt")
-                public void testIsInitializedMultiFile() throws Exception {
-                    runTest("compiler/testData/codegen/box/properties/lateinit/isInitializedAndDeinitialize/isInitializedMultiFile.kt");
                 }
 
                 @TestMetadata("nonInlineLambda.kt")

--- a/compiler/tests/org/jetbrains/kotlin/generators/tests/GenerateSteppedRangesCodegenTestData.kt
+++ b/compiler/tests/org/jetbrains/kotlin/generators/tests/GenerateSteppedRangesCodegenTestData.kt
@@ -162,7 +162,11 @@ object GenerateSteppedRangesCodegenTestData {
         }
         val fullSubdir = File(TEST_DATA_DIR, fullSubdirPath.toString())
         fullSubdir.mkdirs()
-        PrintWriter(File(fullSubdir, fileName)).use {
+        object : PrintWriter(File(fullSubdir, fileName)) {
+            override fun println() {
+                write('\n'.toInt())
+            }
+        }.use {
             with(it) {
                 println("// $PREAMBLE_MESSAGE")
                 println("// KJS_WITH_FULL_RUNTIME")


### PR DESCRIPTION
@max-kammerer - I believe this fixes the line separator issue on Windows. One thing I'm not sure of is if the other generators in the same directory are giving the same problem -- they don't explicitly force a line separator either.