### PR TITLE
KT-31967 Typo in inspection name: "'+=' create new list under the hood"

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/SuspiciousCollectionReassignmentInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/SuspiciousCollectionReassignmentInspection.kt
@@ -68,7 +68,7 @@ class SuspiciousCollectionReassignmentInspection : AbstractKotlinInspection() {
             val operationReference = binaryExpression.operationReference
             holder.registerProblem(
                 operationReference,
-                "'${operationReference.text}' create new $typeText under the hood",
+                "'${operationReference.text}' creates new $typeText under the hood",
                 ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
                 *fixes.toTypedArray()
             )


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-31967