### PR TITLE
JVM IR: Avoid getTopLevelClass for performance and Fir

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendContext.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendContext.kt
@@ -107,13 +107,6 @@ class JvmBackendContext(
 
     val inlineClassReplacements = MemoizedInlineClassReplacements()
 
-    internal fun getTopLevelClass(fqName: FqName): IrClassSymbol {
-        val descriptor = state.module.getPackage(fqName.parent()).memberScope.getContributedClassifier(
-            fqName.shortName(), NoLookupLocation.FROM_BACKEND
-        ) as ClassDescriptor? ?: error("Class is not found: $fqName")
-        return referenceClass(descriptor)
-    }
-
     internal fun referenceClass(descriptor: ClassDescriptor): IrClassSymbol =
         symbolTable.referenceClass(descriptor)
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendContext.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendContext.kt
@@ -47,8 +47,7 @@ class JvmBackendContext(
     override val irBuiltIns: IrBuiltIns,
     irModuleFragment: IrModuleFragment,
     symbolTable: SymbolTable,
-    val phaseConfig: PhaseConfig,
-    private val firMode: Boolean
+    val phaseConfig: PhaseConfig
 ) : CommonBackendContext {
     override val transformedFunction: MutableMap<IrFunctionSymbol, IrSimpleFunctionSymbol>
         get() = TODO("not implemented")
@@ -143,7 +142,7 @@ class JvmBackendContext(
         irModuleFragment: IrModuleFragment,
         symbolTable: ReferenceSymbolTable
     ) : Ir<JvmBackendContext>(this, irModuleFragment) {
-        override val symbols = JvmSymbols(this@JvmBackendContext, symbolTable, firMode)
+        override val symbols = JvmSymbols(this@JvmBackendContext, symbolTable)
 
         override fun unfoldInlineClassType(irType: IrType): IrType? {
             return InlineClassAbi.unboxType(irType)

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendFacade.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendFacade.kt
@@ -60,11 +60,10 @@ object JvmBackendFacade {
         irModuleFragment: IrModuleFragment,
         symbolTable: SymbolTable,
         sourceManager: PsiSourceManager,
-        phaseConfig: PhaseConfig,
-        firMode: Boolean = false
+        phaseConfig: PhaseConfig
     ) {
         val context = JvmBackendContext(
-            state, sourceManager, irModuleFragment.irBuiltins, irModuleFragment, symbolTable, phaseConfig, firMode
+            state, sourceManager, irModuleFragment.irBuiltins, irModuleFragment, symbolTable, phaseConfig
         )
         state.irBasedMapAsmMethod = { descriptor ->
             context.methodSignatureMapper.mapAsmMethod(context.referenceFunction(descriptor).owner)

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmIrCodegenFactory.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmIrCodegenFactory.kt
@@ -43,9 +43,7 @@ class JvmIrCodegenFactory(private val phaseConfig: PhaseConfig) : CodegenFactory
         symbolTable: SymbolTable,
         sourceManager: PsiSourceManager
     ) {
-        JvmBackendFacade.doGenerateFilesInternal(
-            state, errorHandler, irModuleFragment, symbolTable, sourceManager, phaseConfig, firMode = true
-        )
+        JvmBackendFacade.doGenerateFilesInternal(state, errorHandler, irModuleFragment, symbolTable, sourceManager, phaseConfig)
     }
 
     override fun createPackageCodegen(state: GenerationState, files: Collection<KtFile>, fqName: FqName): PackageCodegen {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmSymbols.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmSymbols.kt
@@ -67,6 +67,12 @@ class JvmSymbols(
     override val ThrowTypeCastException: IrFunctionSymbol =
         typeCastExceptionClass.constructors.single()
 
+    val unsupportedOperationExceptionClass: IrClassSymbol = createClass(FqName("java.lang.UnsupportedOperationException")) { klass ->
+        klass.addConstructor().apply {
+            addValueParameter("message", irBuiltIns.stringType.makeNullable())
+        }
+    }
+
     private fun createPackage(fqName: FqName): IrPackageFragment =
         IrExternalPackageFragmentImpl(IrExternalPackageFragmentSymbolImpl(EmptyPackageFragmentDescriptor(context.state.module, fqName)))
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/CollectionStubMethodLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/CollectionStubMethodLowering.kt
@@ -27,7 +27,6 @@ import org.jetbrains.kotlin.ir.symbols.IrTypeParameterSymbol
 import org.jetbrains.kotlin.ir.symbols.impl.IrValueParameterSymbolImpl
 import org.jetbrains.kotlin.ir.types.*
 import org.jetbrains.kotlin.ir.util.*
-import org.jetbrains.kotlin.name.FqName
 
 internal val collectionStubMethodLowering = makeIrFilePhase(
     ::CollectionStubMethodLowering,
@@ -86,12 +85,11 @@ private class CollectionStubMethodLowering(val context: JvmBackendContext) : Cla
             for (parameter in function.valueParameters) {
                 valueParameters.add(parameter.copyWithSubstitution(this, substitutionMap))
             }
-            val exception = context.getTopLevelClass(FqName("java.lang.UnsupportedOperationException"))
             // Function body consist only of throwing UnsupportedOperationException statement
             body = context.createIrBuilder(function.symbol).irBlockBody {
                 +irThrow(
                     irCall(
-                        exception.owner.constructors.single {
+                        this@CollectionStubMethodLowering.context.ir.symbols.unsupportedOperationExceptionClass.owner.constructors.single {
                             it.valueParameters.size == 1 && it.valueParameters.single().type.isNullableString()
                         }
                     ).apply {

--- a/compiler/testData/loadJava/compiledKotlin/coroutines/Basic.kt
+++ b/compiler/testData/loadJava/compiledKotlin/coroutines/Basic.kt
@@ -1,5 +1,4 @@
-// IGNORE_BACKEND: JVM_IR
-//ALLOW_AST_ACCESS
+// ALLOW_AST_ACCESS
 
 package test
 class Controller {

--- a/compiler/testData/writeSignature/callableReference/suspendFunctionReference.kt
+++ b/compiler/testData/writeSignature/callableReference/suspendFunctionReference.kt
@@ -1,5 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
-
 interface I
 
 abstract class AbstractTest {


### PR DESCRIPTION
We recently saw a performance regression after merging #2657 on a small benchmark where deserializing `java.lang.String` ended up being a bottleneck. There are currently several symbols in JvmSymbols which we hardcode and some which are deserialized from disk instead (and in Fir mode we always have to hardcode all dependencies).

This PR makes JvmSymbols consistent by hardcoding all dependencies for the IR backend, which results in slightly better performance and allows us to remove the special cases for the Fir backend.