### PR TITLE
JVM_IR: fix NPE in interface companion initializers

### DIFF
--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/LowerUtils.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/LowerUtils.kt
@@ -17,7 +17,6 @@
 package org.jetbrains.kotlin.backend.common.lower
 
 import org.jetbrains.kotlin.backend.common.BackendContext
-import org.jetbrains.kotlin.backend.common.CommonBackendContext
 import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.descriptors.impl.ValueParameterDescriptorImpl
 import org.jetbrains.kotlin.ir.IrElement
@@ -32,8 +31,6 @@ import org.jetbrains.kotlin.ir.symbols.IrSymbol
 import org.jetbrains.kotlin.ir.types.IrSimpleType
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.classifierOrFail
-import org.jetbrains.kotlin.ir.util.defaultType
-import org.jetbrains.kotlin.ir.visitors.IrElementTransformer
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 import org.jetbrains.kotlin.ir.visitors.IrElementVisitorVoid
 import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
@@ -212,31 +209,4 @@ fun ParameterDescriptor.copyAsValueParameter(newOwner: CallableDescriptor, index
         source = source
     )
     else -> throw Error("Unexpected parameter descriptor: $this")
-}
-
-fun IrBody.replaceThisByStaticReference(
-    context: CommonBackendContext,
-    irClass: IrClass,
-    oldThisReceiverParameter: IrValueParameter
-): IrBody =
-    transform(ReplaceThisByStaticReference(context, irClass, oldThisReceiverParameter), null)
-
-private class ReplaceThisByStaticReference(
-    val context: CommonBackendContext,
-    val irClass: IrClass,
-    val oldThisReceiverParameter: IrValueParameter
-) : IrElementTransformer<Nothing?> {
-    override fun visitGetValue(expression: IrGetValue, data: Nothing?): IrExpression {
-        val irGetValue = expression
-        if (irGetValue.symbol == oldThisReceiverParameter.symbol) {
-            val instanceField = context.declarationFactory.getFieldForObjectInstance(irClass)
-            return IrGetFieldImpl(
-                expression.startOffset,
-                expression.endOffset,
-                instanceField.symbol,
-                irClass.defaultType
-            )
-        }
-        return super.visitGetValue(irGetValue, data)
-    }
 }

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/DeclarationOrigins.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/DeclarationOrigins.kt
@@ -45,5 +45,6 @@ interface JvmLoweredDeclarationOrigin : IrDeclarationOrigin {
     object GENERATED_ASSERTION_ENABLED_FIELD : IrDeclarationOriginImpl("GENERATED_ASSERTION_ENABLED_FIELD", isSynthetic = true)
     object GENERATED_MAIN_FOR_PARAMETERLESS_MAIN_METHOD : IrDeclarationOriginImpl("GENERATED_MAIN_FOR_PARAMETERLESS_MAIN_METHOD", isSynthetic = true)
     object SUSPEND_FUNCTION_VIEW : IrDeclarationOriginImpl("SUSPEND_FUNCTION_VIEW")
-    object SUSPEND_IMPL_STATIC_FUNCTION :  IrDeclarationOriginImpl("SUSPEND_IMPL_STATIC_FUNCTION", isSynthetic = true)
+    object SUSPEND_IMPL_STATIC_FUNCTION : IrDeclarationOriginImpl("SUSPEND_IMPL_STATIC_FUNCTION", isSynthetic = true)
+    object INTERFACE_COMPANION_PRIVATE_INSTANCE : IrDeclarationOriginImpl("INTERFACE_COMPANION_PRIVATE_INSTANCE", isSynthetic = true)
 }

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/JvmStaticAnnotationLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/JvmStaticAnnotationLowering.kt
@@ -10,12 +10,12 @@ import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.ir.*
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.common.lower.irBlock
-import org.jetbrains.kotlin.backend.common.lower.replaceThisByStaticReference
 import org.jetbrains.kotlin.backend.common.phaser.makeIrFilePhase
 import org.jetbrains.kotlin.backend.common.runOnFilePostfix
 import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
 import org.jetbrains.kotlin.backend.jvm.JvmLoweredDeclarationOrigin
 import org.jetbrains.kotlin.backend.jvm.ir.isInCurrentModule
+import org.jetbrains.kotlin.backend.jvm.ir.replaceThisByStaticReference
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.descriptors.Visibility

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/ObjectClassLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/ObjectClassLowering.kt
@@ -10,17 +10,11 @@ import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
 import org.jetbrains.kotlin.backend.common.phaser.makeIrFilePhase
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
-import org.jetbrains.kotlin.backend.jvm.codegen.isJvmInterface
-import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.ir.IrStatement
-import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
 import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.builders.irExprBody
 import org.jetbrains.kotlin.ir.builders.irGetField
 import org.jetbrains.kotlin.ir.declarations.*
-import org.jetbrains.kotlin.ir.declarations.impl.IrFieldImpl
-import org.jetbrains.kotlin.ir.descriptors.WrappedFieldDescriptor
-import org.jetbrains.kotlin.ir.symbols.impl.IrFieldSymbolImpl
 import org.jetbrains.kotlin.ir.util.*
 
 internal val objectClassPhase = makeIrFilePhase(
@@ -49,39 +43,20 @@ private class ObjectClassLowering(val context: JvmBackendContext) : IrElementTra
         if (!irClass.isObject) return
 
         val publicInstanceField = context.declarationFactory.getFieldForObjectInstance(irClass)
+        val privateInstanceField = context.declarationFactory.getPrivateFieldForObjectInstance(irClass)
 
         val constructor = irClass.constructors.find { it.isPrimary }
             ?: throw AssertionError("Object should have a primary constructor: ${irClass.name}")
 
-        val publicInstanceOwner = if (irClass.isCompanion) parentScope!!.irElement as IrDeclarationContainer else irClass
-        if (irClass.isCompanion && irClass.parentAsClass.isJvmInterface) {
-            // TODO rename to $$INSTANCE
-            // TODO: mark as synthesized
-            val privateFieldDescriptor = WrappedFieldDescriptor()
-            val privateField = IrFieldImpl(
-                UNDEFINED_OFFSET, UNDEFINED_OFFSET,
-                IrDeclarationOrigin.FIELD_FOR_OBJECT_INSTANCE,
-                IrFieldSymbolImpl(privateFieldDescriptor),
-                publicInstanceField.name,
-                irClass.defaultType,
-                Visibilities.PROTECTED/* TODO package local */,
-                isFinal = true,
-                isExternal = false,
-                isStatic = true,
-                isFakeOverride = false
-            ).apply {
-                privateFieldDescriptor.bind(this)
-                parent = irClass
-                with(context.createIrBuilder(symbol)) {
-                    initializer = irExprBody(
-                        irCall(constructor)
-                    )
-                }
-                pendingTransformations.add { parentAsClass.declarations.add(this) }
+        if (privateInstanceField != publicInstanceField) {
+            with(context.createIrBuilder(privateInstanceField.symbol)) {
+                privateInstanceField.initializer = irExprBody(irCall(constructor.symbol))
             }
-
             with(context.createIrBuilder(publicInstanceField.symbol)) {
-                publicInstanceField.initializer = irExprBody(irGetField(null, privateField))
+                publicInstanceField.initializer = irExprBody(irGetField(null, privateInstanceField))
+            }
+            pendingTransformations.add {
+                (privateInstanceField.parent as IrDeclarationContainer).declarations.add(0, privateInstanceField)
             }
         } else {
             with(context.createIrBuilder(publicInstanceField.symbol)) {
@@ -89,9 +64,8 @@ private class ObjectClassLowering(val context: JvmBackendContext) : IrElementTra
             }
         }
 
-        publicInstanceField.parent = publicInstanceOwner
         pendingTransformations.add {
-            publicInstanceOwner.declarations.add(publicInstanceField)
+            (publicInstanceField.parent as IrDeclarationContainer).declarations.add(0, publicInstanceField)
         }
     }
 }

--- a/compiler/testData/codegen/box/objects/interfaceCompanion.kt
+++ b/compiler/testData/codegen/box/objects/interfaceCompanion.kt
@@ -1,5 +1,4 @@
 // IGNORE_BACKEND_FIR: JVM_IR
-// IGNORE_BACKEND: JVM_IR
 // Inside of the companion we have to access the instance through the local Companion field,
 // not by indirection through the Companion field of the enclosing class.
 // Class initialization might not have finished yet.

--- a/compiler/testData/codegen/box/objects/interfaceCompanionObjectReference.kt
+++ b/compiler/testData/codegen/box/objects/interfaceCompanionObjectReference.kt
@@ -1,6 +1,5 @@
 // !LANGUAGE: +NestedClassesInAnnotations
 // IGNORE_BACKEND_FIR: JVM_IR
-// IGNORE_BACKEND: JVM_IR
 // WITH_RUNTIME
 
 import kotlin.test.*

--- a/compiler/testData/codegen/box/objects/selfReferenceToInterfaceCompanionObjectInInlineLambdaInConstructorBody.kt
+++ b/compiler/testData/codegen/box/objects/selfReferenceToInterfaceCompanionObjectInInlineLambdaInConstructorBody.kt
@@ -1,5 +1,4 @@
 // IGNORE_BACKEND_FIR: JVM_IR
-// IGNORE_BACKEND: JVM_IR
 interface Test {
     companion object {
         fun ok() = "OK"


### PR DESCRIPTION
* When referencing the companion itself, they should use the $$INSTANCE field, not the (null until \<clinit\> returns) Companion field of the interface.

* Interface companion init blocks should be made static.