### PR TITLE
debug information test: handle virtualMachine timeout

### DIFF
--- a/compiler/testData/debug/localVariables/destructuringInLambdas.kt
+++ b/compiler/testData/debug/localVariables/destructuringInLambdas.kt
@@ -12,9 +12,9 @@ fun box() {
 // TestKt:8:
 // A:3: x:java.lang.String, y:int
 // TestKt:8:
-// TestKt:5: $dstr$x$y:A
-// TestKt$box$1:8:
-// TestKt$box$1.invoke(java.lang.Object)+8: a:A, block:TestKt$box$1
+// TestKt:5: a:A, block:TestKt$box$1
+// TestKt$box$1:8: $dstr$x$y:A
+// TestKt$box$1.invoke(java.lang.Object)+8:
 // TestKt:5: a:A, block:TestKt$box$1
 // TestKt:8:
 // TestKt:9:

--- a/compiler/testData/debug/localVariables/localFun.kt
+++ b/compiler/testData/debug/localVariables/localFun.kt
@@ -11,6 +11,6 @@ fun box() {
 // IGNORE_BACKEND: JVM_IR
 // LOCAL VARIABLES
 // TestKt:9:
-// TestKt:4: $fun$bar$1:TestKt$foo$1
+// TestKt:4:
 // TestKt:6: $fun$bar$1:TestKt$foo$1
 // TestKt:10:

--- a/compiler/testData/debug/localVariables/underscoreNames.kt
+++ b/compiler/testData/debug/localVariables/underscoreNames.kt
@@ -28,22 +28,22 @@ fun box() {
 // A:3: x:double, y:java.lang.String, z:char
 // A:3:
 // TestKt:11:
-// TestKt:5: $dstr$x$_u24__u24$y:A, $noName_1:java.lang.String, w:int
-// TestKt$box$1:14:
+// TestKt:5: a:A, block:TestKt$box$1
+// TestKt$box$1:14: $dstr$x$_u24__u24$y:A, $noName_1:java.lang.String, w:int
+// A:3:
 // A:3: x:double, y:java.lang.String, z:char
 // A:3:
-// A:3: $dstr$x$_u24__u24$y:A, $noName_1:java.lang.String, w:int, x:double, y:char
-// TestKt$box$1:14: $dstr$x$_u24__u24$y:A, $noName_1:java.lang.String, w:int, x:double, y:char, a:double, c:char
-// TestKt$box$1:15:
+// TestKt$box$1:14: $dstr$x$_u24__u24$y:A, $noName_1:java.lang.String, w:int, x:double, y:char
+// TestKt$box$1:15: $dstr$x$_u24__u24$y:A, $noName_1:java.lang.String, w:int, x:double, y:char, a:double, c:char
+// A:3:
 // A:3: x:double, y:java.lang.String, z:char
 // A:3:
-// A:3: $dstr$x$_u24__u24$y:A, $noName_1:java.lang.String, w:int, x:double, y:char, a:double, c:char
-// TestKt$box$1:15: $dstr$x$_u24__u24$y:A, $noName_1:java.lang.String, w:int, x:double, y:char, a:double, c:char, _:java.lang.String, d:char
-// TestKt$box$1:17:
-// TestKt:7: $dstr$x$_u24__u24$y:A, $noName_1:java.lang.String, w:int, x:double, y:char, a:double, c:char, _:java.lang.String, d:char
+// TestKt$box$1:15: $dstr$x$_u24__u24$y:A, $noName_1:java.lang.String, w:int, x:double, y:char, a:double, c:char
 // TestKt$box$1:17: $dstr$x$_u24__u24$y:A, $noName_1:java.lang.String, w:int, x:double, y:char, a:double, c:char, _:java.lang.String, d:char
-// TestKt$box$1:21:
-// TestKt$box$1.invoke(java.lang.Object, java.lang.Object, java.lang.Object)+19: a:A, block:TestKt$box$1
+// TestKt:7:
+// TestKt$box$1:17: $dstr$x$_u24__u24$y:A, $noName_1:java.lang.String, w:int, x:double, y:char, a:double, c:char, _:java.lang.String, d:char
+// TestKt$box$1:21: $dstr$x$_u24__u24$y:A, $noName_1:java.lang.String, w:int, x:double, y:char, a:double, c:char, _:java.lang.String, d:char
+// TestKt$box$1.invoke(java.lang.Object, java.lang.Object, java.lang.Object)+19:
 // TestKt:5: a:A, block:TestKt$box$1
 // TestKt:11:
 // TestKt:23:


### PR DESCRIPTION
Keep time out to avoid network related issue interrupt test, but add a retry in case a given timeout is still not sufficient.

Also handle the case where bad code cause test exit test method while keeping test process in suspended state.