### PR TITLE
JVM_IR: fix load check in inliner (should accept primitives too)

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInliner.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInliner.kt
@@ -901,7 +901,7 @@ class MethodInliner(
 
             var cur: AbstractInsnNode? = node.instructions.first
             while (cur != null) {
-                if (cur is VarInsnNode && cur.opcode == Opcodes.ALOAD && map.contains(cur.`var`)) {
+                if (cur is VarInsnNode && cur.opcode in Opcodes.ILOAD..Opcodes.ALOAD && map.contains(cur.`var`)) {
                     val varIndex = cur.`var`
                     val capturedParamDesc = map[varIndex]!!
 

--- a/compiler/testData/codegen/boxInline/capture/captureInlinable.kt
+++ b/compiler/testData/codegen/boxInline/capture/captureInlinable.kt
@@ -1,5 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
-// IGNORE_BACKEND_MULTI_MODULE: JVM_IR
 // FILE: 1.kt
 
 package test

--- a/compiler/testData/codegen/boxInline/capture/captureInlinableAndOther.kt
+++ b/compiler/testData/codegen/boxInline/capture/captureInlinableAndOther.kt
@@ -1,5 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
-// IGNORE_BACKEND_MULTI_MODULE: JVM_IR
 // FILE: 1.kt
 
 package test

--- a/compiler/testData/codegen/boxInline/lambdaTransformation/regeneratedLambdaName.kt
+++ b/compiler/testData/codegen/boxInline/lambdaTransformation/regeneratedLambdaName.kt
@@ -1,5 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
-// IGNORE_BACKEND_MULTI_MODULE: JVM_IR
 // FILE: 1.kt
 
 package test


### PR DESCRIPTION
Part of #2643, sort of. This used to be fixed with a patch to `ParametersBuilder`, but it turns out the root cause of the bug is much simpler: primitive-typed captures were not replaced with `$$$$something` placeholders.