### PR TITLE
Ensure ForLoopsLowering only handles the CharSequence.iterator() stdlib extension function

### DIFF
--- a/compiler/testData/codegen/box/ranges/forInCharSequenceWithCustomIterator.kt
+++ b/compiler/testData/codegen/box/ranges/forInCharSequenceWithCustomIterator.kt
@@ -1,0 +1,65 @@
+// KJS_WITH_FULL_RUNTIME
+// WITH_RUNTIME
+import kotlin.test.*
+
+open class CharSequenceWithExtensionIterator(val s: String) : CharSequence {
+    fun get(foo: String): Char = TODO("shouldn't be called!")
+    override val length = s.length
+    override fun subSequence(startIndex: Int, endIndex: Int) = s.subSequence(startIndex, endIndex)
+    override fun get(index: Int) = s.get(index)
+}
+
+// Returns no characters
+operator fun CharSequenceWithExtensionIterator.iterator() = object : CharIterator() {
+    public override fun nextChar() = TODO()
+    public override fun hasNext() = false
+}
+
+class CharSequenceWithMemberIterator(s: String) : CharSequenceWithExtensionIterator(s) {
+    // Returns characters in reverse
+    operator fun iterator() = object : CharIterator() {
+        private var index = 0
+        public override fun nextChar() = get(length - ++index)
+        public override fun hasNext() = index < length
+    }
+}
+
+fun collectChars(cs: CharSequence): String {
+    val result = StringBuilder()
+    for (c in cs) {
+        result.append(c)
+    }
+    return result.toString()
+}
+
+fun <T : CharSequence> collectCharsTypeParam(cs: T): String {
+    val result = StringBuilder()
+    for (c in cs) {
+        result.append(c)
+    }
+    return result.toString()
+}
+
+fun box(): String {
+    val csWithExtIt = CharSequenceWithExtensionIterator("1234")
+    val csWithExtItResult = StringBuilder()
+    for (c in csWithExtIt) {
+        csWithExtItResult.append(c)
+    }
+    assertEquals("", csWithExtItResult.toString())
+
+    val csWithMemIt = CharSequenceWithMemberIterator("1234")
+    val csWithMemItResult = StringBuilder()
+    for (c in csWithMemIt) {
+        csWithMemItResult.append(c)
+    }
+    assertEquals("4321", csWithMemItResult.toString())
+
+    // The CharSequence.iterator() extension method should be invoked in all the following calls
+    assertEquals("1234", collectChars(csWithExtIt))
+    assertEquals("1234", collectCharsTypeParam(csWithExtIt))
+    assertEquals("1234", collectChars(csWithMemIt))
+    assertEquals("1234", collectCharsTypeParam(csWithMemIt))
+
+    return "OK"
+}

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -19325,6 +19325,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             runTest("compiler/testData/codegen/box/ranges/forInCharSequenceLengthIncreasedInLoopBody.kt");
         }
 
+        @TestMetadata("forInCharSequenceWithCustomIterator.kt")
+        public void testForInCharSequenceWithCustomIterator() throws Exception {
+            runTest("compiler/testData/codegen/box/ranges/forInCharSequenceWithCustomIterator.kt");
+        }
+
         @TestMetadata("forInCharSequenceWithMultipleGetFunctions.kt")
         public void testForInCharSequenceWithMultipleGetFunctions() throws Exception {
             runTest("compiler/testData/codegen/box/ranges/forInCharSequenceWithMultipleGetFunctions.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -19325,6 +19325,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/ranges/forInCharSequenceLengthIncreasedInLoopBody.kt");
         }
 
+        @TestMetadata("forInCharSequenceWithCustomIterator.kt")
+        public void testForInCharSequenceWithCustomIterator() throws Exception {
+            runTest("compiler/testData/codegen/box/ranges/forInCharSequenceWithCustomIterator.kt");
+        }
+
         @TestMetadata("forInCharSequenceWithMultipleGetFunctions.kt")
         public void testForInCharSequenceWithMultipleGetFunctions() throws Exception {
             runTest("compiler/testData/codegen/box/ranges/forInCharSequenceWithMultipleGetFunctions.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -17885,6 +17885,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             runTest("compiler/testData/codegen/box/ranges/forInCharSequenceLengthIncreasedInLoopBody.kt");
         }
 
+        @TestMetadata("forInCharSequenceWithCustomIterator.kt")
+        public void testForInCharSequenceWithCustomIterator() throws Exception {
+            runTest("compiler/testData/codegen/box/ranges/forInCharSequenceWithCustomIterator.kt");
+        }
+
         @TestMetadata("forInCharSequenceWithMultipleGetFunctions.kt")
         public void testForInCharSequenceWithMultipleGetFunctions() throws Exception {
             runTest("compiler/testData/codegen/box/ranges/forInCharSequenceWithMultipleGetFunctions.kt");

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -15070,6 +15070,11 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/ranges/forInCharSequenceLengthIncreasedInLoopBody.kt");
         }
 
+        @TestMetadata("forInCharSequenceWithCustomIterator.kt")
+        public void testForInCharSequenceWithCustomIterator() throws Exception {
+            runTest("compiler/testData/codegen/box/ranges/forInCharSequenceWithCustomIterator.kt");
+        }
+
         @TestMetadata("forInCharSequenceWithMultipleGetFunctions.kt")
         public void testForInCharSequenceWithMultipleGetFunctions() throws Exception {
             runTest("compiler/testData/codegen/box/ranges/forInCharSequenceWithMultipleGetFunctions.kt");

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -16225,6 +16225,11 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/ranges/forInCharSequenceLengthIncreasedInLoopBody.kt");
         }
 
+        @TestMetadata("forInCharSequenceWithCustomIterator.kt")
+        public void testForInCharSequenceWithCustomIterator() throws Exception {
+            runTest("compiler/testData/codegen/box/ranges/forInCharSequenceWithCustomIterator.kt");
+        }
+
         @TestMetadata("forInCharSequenceWithMultipleGetFunctions.kt")
         public void testForInCharSequenceWithMultipleGetFunctions() throws Exception {
             runTest("compiler/testData/codegen/box/ranges/forInCharSequenceWithMultipleGetFunctions.kt");


### PR DESCRIPTION
We only want to handle the known extension function for `CharSequence` in the standard library (top level `kotlin.text.iterator`). The behavior of this iterator is well-defined and can be lowered. `CharSequences` can have their own iterators, either as a member or extension function, and the behavior of those custom iterators is unknown.