### PR TITLE
[JVM IR] Fix @JvmOverloads + Parameterless Main

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
@@ -184,15 +184,8 @@ private val syntheticAccessorPhase = makeIrFilePhase(
     prerequisite = setOf(objectClassPhase, staticDefaultFunctionPhase, interfacePhase)
 )
 
-private val mainMethodGenerationPhase = makeIrFilePhase(
-    ::MainMethodGenerationLowering,
-    name = "MainMethodGeneration",
-    description = "Identify parameterless main methods and generate bridge main-methods"
-)
-
 @Suppress("Reformat")
 private val jvmFilePhases =
-        mainMethodGenerationPhase then
         typeAliasAnnotationMethodsPhase then
         stripTypeAliasDeclarationsPhase then
         provisionalFunctionExpressionPhase then
@@ -271,6 +264,8 @@ private val jvmFilePhases =
         replaceKFunctionInvokeWithFunctionInvokePhase then
 
         checkLocalNamesWithOldBackendPhase then
+
+        mainMethodGenerationPhase then
 
         // should be last transformation
         removeDeclarationsThatWouldBeInlined then

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/MainMethodGenerationLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/MainMethodGenerationLowering.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.backend.jvm.lower
 import org.jetbrains.kotlin.backend.common.ClassLoweringPass
 import org.jetbrains.kotlin.backend.common.ir.allParameters
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
+import org.jetbrains.kotlin.backend.common.phaser.makeIrFilePhase
 import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
 import org.jetbrains.kotlin.backend.jvm.JvmLoweredDeclarationOrigin
 import org.jetbrains.kotlin.backend.jvm.ir.getJvmNameFromAnnotation
@@ -23,13 +24,17 @@ import org.jetbrains.kotlin.ir.builders.irReturn
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
-import org.jetbrains.kotlin.ir.expressions.impl.IrConstImpl
 import org.jetbrains.kotlin.ir.types.*
 import org.jetbrains.kotlin.ir.util.functions
-import org.jetbrains.kotlin.ir.util.getAnnotation
 import org.jetbrains.kotlin.name.Name
-import org.jetbrains.kotlin.resolve.DescriptorUtils
 import org.jetbrains.kotlin.types.Variance
+
+internal val mainMethodGenerationPhase = makeIrFilePhase(
+    ::MainMethodGenerationLowering,
+    name = "MainMethodGeneration",
+    description = "Identify parameterless main methods and generate bridge main-methods",
+    prerequisite = setOf(jvmOverloadsAnnotationPhase)
+)
 
 internal class MainMethodGenerationLowering(val context: JvmBackendContext) : ClassLoweringPass {
 

--- a/compiler/testData/codegen/bytecodeText/parameterlessMain/dontGenerateOnJvmNameMain.kt
+++ b/compiler/testData/codegen/bytecodeText/parameterlessMain/dontGenerateOnJvmNameMain.kt
@@ -6,3 +6,5 @@ fun main() {
 fun foo(args: Array<String>) {
 
 }
+
+// 0 INVOKESTATIC DontGenerateOnJvmNameMainKt\.main ()V

--- a/compiler/testData/codegen/bytecodeText/parameterlessMain/dontGenerateOnJvmOverloads.kt
+++ b/compiler/testData/codegen/bytecodeText/parameterlessMain/dontGenerateOnJvmOverloads.kt
@@ -1,0 +1,11 @@
+// IGNORE_BACKEND: JVM
+fun main() {
+  println("FAIL")
+}
+
+@JvmOverloads
+fun Array<String>.main(x: Int = 4, y: String = "Test") {
+    println("OK")
+}
+
+// 0 INVOKESTATIC DontGenerateOnJvmOverloadsKt\.main ()V

--- a/compiler/testData/codegen/bytecodeText/parameterlessMain/dontGenerateOnMain.kt
+++ b/compiler/testData/codegen/bytecodeText/parameterlessMain/dontGenerateOnMain.kt
@@ -5,3 +5,5 @@ fun main() {
 fun main(args: Array<String>) {
 
 }
+
+// 0 INVOKESTATIC DontGenerateOnMainKt\.main ()V

--- a/compiler/testData/codegen/bytecodeText/parameterlessMain/dontGenerateOnMainExtension.kt
+++ b/compiler/testData/codegen/bytecodeText/parameterlessMain/dontGenerateOnMainExtension.kt
@@ -5,3 +5,5 @@ fun main() {
 fun Array<String>.main() {
 
 }
+
+// 0 INVOKESTATIC DontGenerateOnMainExtensionKt\.main ()V

--- a/compiler/testData/codegen/bytecodeText/parameterlessMain/dontGenerateOnNullableArray.kt
+++ b/compiler/testData/codegen/bytecodeText/parameterlessMain/dontGenerateOnNullableArray.kt
@@ -5,3 +5,5 @@ fun main() {
 fun main(args: Array<String>?) {
 
 }
+
+// 0 INVOKESTATIC DontGenerateOnNullableArrayKt\.main ()V

--- a/compiler/testData/codegen/bytecodeText/parameterlessMain/dontGenerateOnVarargsString.kt
+++ b/compiler/testData/codegen/bytecodeText/parameterlessMain/dontGenerateOnVarargsString.kt
@@ -1,0 +1,9 @@
+fun main() {
+
+}
+
+fun main(vararg args: String) {
+
+}
+
+// 0 INVOKESTATIC DontGenerateOnVarargsStringKt\.main ()V

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
@@ -3545,6 +3545,11 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
             runTest("compiler/testData/codegen/bytecodeText/parameterlessMain/dontGenerateOnJvmNameMain.kt");
         }
 
+        @TestMetadata("dontGenerateOnJvmOverloads.kt")
+        public void testDontGenerateOnJvmOverloads() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/parameterlessMain/dontGenerateOnJvmOverloads.kt");
+        }
+
         @TestMetadata("dontGenerateOnMain.kt")
         public void testDontGenerateOnMain() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/parameterlessMain/dontGenerateOnMain.kt");
@@ -3558,6 +3563,11 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
         @TestMetadata("dontGenerateOnNullableArray.kt")
         public void testDontGenerateOnNullableArray() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/parameterlessMain/dontGenerateOnNullableArray.kt");
+        }
+
+        @TestMetadata("dontGenerateOnVarargsString.kt")
+        public void testDontGenerateOnVarargsString() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/parameterlessMain/dontGenerateOnVarargsString.kt");
         }
     }
 

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
@@ -3463,6 +3463,11 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
             runTest("compiler/testData/codegen/bytecodeText/parameterlessMain/dontGenerateOnJvmNameMain.kt");
         }
 
+        @TestMetadata("dontGenerateOnJvmOverloads.kt")
+        public void testDontGenerateOnJvmOverloads() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/parameterlessMain/dontGenerateOnJvmOverloads.kt");
+        }
+
         @TestMetadata("dontGenerateOnMain.kt")
         public void testDontGenerateOnMain() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/parameterlessMain/dontGenerateOnMain.kt");
@@ -3476,6 +3481,11 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
         @TestMetadata("dontGenerateOnNullableArray.kt")
         public void testDontGenerateOnNullableArray() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/parameterlessMain/dontGenerateOnNullableArray.kt");
+        }
+
+        @TestMetadata("dontGenerateOnVarargsString.kt")
+        public void testDontGenerateOnVarargsString() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/parameterlessMain/dontGenerateOnVarargsString.kt");
         }
     }
 


### PR DESCRIPTION
Resolves the interaction of @JvmOverloads annotations and
parameterless main methods.

In the following code, both mechanisms generate methods that
ultimately produce the signature `public static void main(String[] args)`
of which there can be only one (true in general of any signature).

```
fun main() { }

@JvmOverloads
fun main(Array<String> args, x: Int = 42) { }
```

This PR simply shuffles the lowerings around, letting parameterless
main methods detect the presence of the default overload produced by
the annotation.

Additionally, this PR improves the testing of parameterless main
methods by actual bytecode patterns, and not simple check for
successful compilation (as @sfs and I discovered, there are issues in
flagging an error on duplicate signatures on the IR backend).