### PR TITLE
JVM IR: Fix inlining of inline class properties in external modules

### DIFF
--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/ir/builders/declarations/declarationBuilders.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/ir/builders/declarations/declarationBuilders.kt
@@ -115,12 +115,13 @@ inline fun IrProperty.addSetter(builder: IrFunctionBuilder.() -> Unit = {}): IrS
     }
 
 fun IrFunctionBuilder.buildFun(originalDescriptor: FunctionDescriptor? = null): IrFunctionImpl {
-    val wrappedDescriptor = if (originalDescriptor is DescriptorWithContainerSource)
-        WrappedFunctionDescriptorWithContainerSource(originalDescriptor.containerSource)
-    else if (originalDescriptor != null)
-        WrappedSimpleFunctionDescriptor(originalDescriptor)
-    else
-        WrappedSimpleFunctionDescriptor()
+    val wrappedDescriptor = when(originalDescriptor) {
+        is DescriptorWithContainerSource -> WrappedFunctionDescriptorWithContainerSource(originalDescriptor.containerSource)
+        is PropertyGetterDescriptor -> WrappedPropertyGetterDescriptor(originalDescriptor.annotations, originalDescriptor.source)
+        is PropertySetterDescriptor -> WrappedPropertySetterDescriptor(originalDescriptor.annotations, originalDescriptor.source)
+        null -> WrappedSimpleFunctionDescriptor()
+        else -> WrappedSimpleFunctionDescriptor(originalDescriptor)
+    }
     return IrFunctionImpl(
         startOffset, endOffset, origin,
         IrSimpleFunctionSymbolImpl(wrappedDescriptor),

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/MethodSignatureMapper.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/MethodSignatureMapper.kt
@@ -74,7 +74,7 @@ class MethodSignatureMapper(private val context: JvmBackendContext) {
         if (nameForSpecialFunction != null) return nameForSpecialFunction
 
         val property = (function as? IrSimpleFunction)?.correspondingPropertySymbol?.owner
-        if (property != null) {
+        if (property != null && function.name.isSpecial) {
             val propertyName = property.name.asString()
             if (property.parent.let { it is IrClass && it.isAnnotationClass }) return propertyName
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/inlineclasses/MemoizedInlineClassReplacements.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/inlineclasses/MemoizedInlineClassReplacements.kt
@@ -28,6 +28,7 @@ import org.jetbrains.kotlin.ir.util.explicitParameters
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.resolve.InlineClassDescriptorResolver
 import org.jetbrains.kotlin.storage.LockBasedStorageManager
+import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 
 class IrReplacementFunction(
     val function: IrFunction,
@@ -196,6 +197,7 @@ class MemoizedInlineClassReplacements {
                 copyTypeParameters(function.constructedClass.typeParameters + function.typeParameters)
             } else {
                 copyTypeParametersFrom(function)
+                correspondingPropertySymbol = function.safeAs<IrSimpleFunction>()?.correspondingPropertySymbol
             }
             body()
         }

--- a/compiler/testData/compileKotlinAgainstKotlin/inlineClassInlineProperty.kt
+++ b/compiler/testData/compileKotlinAgainstKotlin/inlineClassInlineProperty.kt
@@ -1,0 +1,15 @@
+// !LANGUAGE: +InlineClasses
+// FILE: A.kt
+
+package a
+
+inline class S(val value: String) {
+    inline val k: String
+        get() = value + "K"
+}
+
+// FILE: B.kt
+
+fun box(): String {
+    return a.S("O").k
+}

--- a/compiler/tests/org/jetbrains/kotlin/codegen/CompileKotlinAgainstKotlinTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/CompileKotlinAgainstKotlinTestGenerated.java
@@ -133,6 +133,11 @@ public class CompileKotlinAgainstKotlinTestGenerated extends AbstractCompileKotl
         runTest("compiler/testData/compileKotlinAgainstKotlin/inlineClassFromBinaryDependencies.kt");
     }
 
+    @TestMetadata("inlineClassInlineProperty.kt")
+    public void testInlineClassInlineProperty() throws Exception {
+        runTest("compiler/testData/compileKotlinAgainstKotlin/inlineClassInlineProperty.kt");
+    }
+
     @TestMetadata("inlinedConstants.kt")
     public void testInlinedConstants() throws Exception {
         runTest("compiler/testData/compileKotlinAgainstKotlin/inlinedConstants.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrCompileKotlinAgainstKotlinTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrCompileKotlinAgainstKotlinTestGenerated.java
@@ -128,6 +128,11 @@ public class IrCompileKotlinAgainstKotlinTestGenerated extends AbstractIrCompile
         runTest("compiler/testData/compileKotlinAgainstKotlin/inlineClassFromBinaryDependencies.kt");
     }
 
+    @TestMetadata("inlineClassInlineProperty.kt")
+    public void testInlineClassInlineProperty() throws Exception {
+        runTest("compiler/testData/compileKotlinAgainstKotlin/inlineClassInlineProperty.kt");
+    }
+
     @TestMetadata("inlinedConstants.kt")
     public void testInlinedConstants() throws Exception {
         runTest("compiler/testData/compileKotlinAgainstKotlin/inlinedConstants.kt");


### PR DESCRIPTION
Since the inliner uses descriptors to identify external declarations we need to preserve PropertyGetter/SetterDescriptors in the IR backend.

This hit the inline class lowering, which replaces getters/setters with new static functions inside of inline classes. I've not found any other places where this is broken so far, but there is a comment in the IR `MethodSignatureMapper` that we sometimes lose `correspondingPropertySymbols` in the IR backend. Should this happen for external inline properties we'll run into a `NullPointerException` in the inliner (which has nothing to do with this PR, though).