### PR TITLE
IR: don't attempt to move defaults to `actual` in another module

### DIFF
--- a/compiler/testData/codegen/boxAgainstJava/multiplatform/annotationsViaActualTypeAliasFromBinary.kt
+++ b/compiler/testData/codegen/boxAgainstJava/multiplatform/annotationsViaActualTypeAliasFromBinary.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: +MultiPlatformProjects
-// IGNORE_BACKEND: JVM_IR
 // WITH_REFLECT
 // FILE: main.kt
 

--- a/compiler/testData/compileKotlinAgainstKotlin/expectClassActualTypeAlias.kt
+++ b/compiler/testData/compileKotlinAgainstKotlin/expectClassActualTypeAlias.kt
@@ -1,0 +1,12 @@
+// !LANGUAGE: +MultiPlatformProjects
+// FILE: impl.kt
+class A(val result: String = "OK")
+
+// FILE: multiplatform.kt
+expect class B(result: String = "FAIL")
+
+actual typealias B = A
+
+fun box(): String {
+    return B().result
+}

--- a/compiler/tests/org/jetbrains/kotlin/codegen/CompileKotlinAgainstKotlinTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/CompileKotlinAgainstKotlinTestGenerated.java
@@ -128,6 +128,11 @@ public class CompileKotlinAgainstKotlinTestGenerated extends AbstractCompileKotl
         runTest("compiler/testData/compileKotlinAgainstKotlin/enum.kt");
     }
 
+    @TestMetadata("expectClassActualTypeAlias.kt")
+    public void testExpectClassActualTypeAlias() throws Exception {
+        runTest("compiler/testData/compileKotlinAgainstKotlin/expectClassActualTypeAlias.kt");
+    }
+
     @TestMetadata("inlineClassFromBinaryDependencies.kt")
     public void testInlineClassFromBinaryDependencies() throws Exception {
         runTest("compiler/testData/compileKotlinAgainstKotlin/inlineClassFromBinaryDependencies.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrCompileKotlinAgainstKotlinTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrCompileKotlinAgainstKotlinTestGenerated.java
@@ -123,6 +123,11 @@ public class IrCompileKotlinAgainstKotlinTestGenerated extends AbstractIrCompile
         runTest("compiler/testData/compileKotlinAgainstKotlin/enum.kt");
     }
 
+    @TestMetadata("expectClassActualTypeAlias.kt")
+    public void testExpectClassActualTypeAlias() throws Exception {
+        runTest("compiler/testData/compileKotlinAgainstKotlin/expectClassActualTypeAlias.kt");
+    }
+
     @TestMetadata("inlineClassFromBinaryDependencies.kt")
     public void testInlineClassFromBinaryDependencies() throws Exception {
         runTest("compiler/testData/compileKotlinAgainstKotlin/inlineClassFromBinaryDependencies.kt");


### PR DESCRIPTION
May happen when a function in an `expect` class is aliased through an `actual typealias`; the matching declaration is filtered out in `ExpectedActualResolver.findActualForExpected` as it has no source.