### PR TITLE
KT-34894 Action "Add not-null asserted (!!) call" doesn't fix error for properties with omitted `this`

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/ExclExclCallFixes.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/ExclExclCallFixes.kt
@@ -44,6 +44,7 @@ import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
 import org.jetbrains.kotlin.resolve.calls.resolvedCallUtil.getImplicitReceiverValue
 import org.jetbrains.kotlin.resolve.calls.smartcasts.DataFlowValueFactory
 import org.jetbrains.kotlin.resolve.lazy.BodyResolveMode
+import org.jetbrains.kotlin.resolve.scopes.receivers.ExtensionReceiver
 import org.jetbrains.kotlin.types.TypeUtils
 import org.jetbrains.kotlin.types.typeUtil.isSubtypeOf
 import org.jetbrains.kotlin.util.OperatorNameConventions
@@ -130,7 +131,7 @@ class AddExclExclCallFix(psiElement: PsiElement, val checkImplicitReceivers: Boo
             }
             is KtExpression -> {
                 val context = psiElement.analyze()
-                if (checkImplicitReceivers && psiElement.getResolvedCall(context)?.getImplicitReceiverValue() != null) {
+                if (checkImplicitReceivers && psiElement.getResolvedCall(context)?.getImplicitReceiverValue() is ExtensionReceiver) {
                     val expressionToReplace = psiElement.parent as? KtCallExpression ?: psiElement
                     expressionToReplace.expressionForCall(implicitReceiver = true)
                 } else {

--- a/idea/testData/quickfix/addExclExclCall/implicit2.kt
+++ b/idea/testData/quickfix/addExclExclCall/implicit2.kt
@@ -1,0 +1,7 @@
+// "Add non-null asserted (!!) call" "true"
+// WITH_RUNTIME
+fun test(s: String?) {
+    s.run {
+        <caret>length
+    }
+}

--- a/idea/testData/quickfix/addExclExclCall/implicit2.kt.after
+++ b/idea/testData/quickfix/addExclExclCall/implicit2.kt.after
@@ -1,0 +1,7 @@
+// "Add non-null asserted (!!) call" "true"
+// WITH_RUNTIME
+fun test(s: String?) {
+    s.run {
+        this!!.length
+    }
+}

--- a/idea/testData/quickfix/addExclExclCall/implicit3.kt
+++ b/idea/testData/quickfix/addExclExclCall/implicit3.kt
@@ -1,0 +1,12 @@
+// "Add non-null asserted (!!) call" "true"
+class Foo {
+    val project: Project? = null
+
+    fun quux() {
+        baz(<caret>project)
+    }
+
+    fun baz(project: Project) {}
+
+    class Project
+}

--- a/idea/testData/quickfix/addExclExclCall/implicit3.kt.after
+++ b/idea/testData/quickfix/addExclExclCall/implicit3.kt.after
@@ -1,0 +1,12 @@
+// "Add non-null asserted (!!) call" "true"
+class Foo {
+    val project: Project? = null
+
+    fun quux() {
+        baz(project!!)
+    }
+
+    fun baz(project: Project) {}
+
+    class Project
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -593,6 +593,16 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
             runTest("idea/testData/quickfix/addExclExclCall/implicit.kt");
         }
 
+        @TestMetadata("implicit2.kt")
+        public void testImplicit2() throws Exception {
+            runTest("idea/testData/quickfix/addExclExclCall/implicit2.kt");
+        }
+
+        @TestMetadata("implicit3.kt")
+        public void testImplicit3() throws Exception {
+            runTest("idea/testData/quickfix/addExclExclCall/implicit3.kt");
+        }
+
         @TestMetadata("implicitFunctionCall.kt")
         public void testImplicitFunctionCall() throws Exception {
             runTest("idea/testData/quickfix/addExclExclCall/implicitFunctionCall.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-34894