### PR TITLE
Fix java version parsing in KAPT

### DIFF
--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/util/java9Utils.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/util/java9Utils.kt
@@ -25,7 +25,7 @@ import org.jetbrains.kotlin.kapt3.base.plus
 
 fun isJava9OrLater(): Boolean = !System.getProperty("java.version").startsWith("1.")
 fun isJava11OrLater(): Boolean {
-    val majorVersion = System.getProperty("java.version").substringBefore(".", "")
+    val majorVersion = System.getProperty("java.version").substringBefore(".")
     if (majorVersion.isEmpty()) return false
 
     return try {


### PR DESCRIPTION
Handle case when "java.version" returns
"11" or "12". Previously, we expected it to
contain at least one dot in the version string.