### PR TITLE
KT-34713 "Condition is always 'false'": quickfix "Delete expression" doesn't remove `else` keyword (may break control flow)

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/ConstantConditionIfInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/ConstantConditionIfInspection.kt
@@ -12,6 +12,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElementVisitor
 import com.intellij.psi.search.LocalSearchScope
 import com.intellij.psi.search.searches.ReferencesSearch
+import org.jetbrains.kotlin.KtNodeTypes
 import org.jetbrains.kotlin.idea.KotlinBundle
 import org.jetbrains.kotlin.idea.caches.resolve.analyze
 import org.jetbrains.kotlin.idea.core.replaced
@@ -116,6 +117,10 @@ class ConstantConditionIfInspection : AbstractKotlinInspection() {
         }
 
         override fun applyFix(ifExpression: KtIfExpression) {
+            val parent = ifExpression.parent
+            if (parent.node.elementType == KtNodeTypes.ELSE) {
+                (parent.parent as? KtIfExpression)?.elseKeyword?.delete()
+            }
             ifExpression.delete()
         }
     }

--- a/idea/testData/inspectionsLocal/constantConditionIf/endWithElseIf2.kt
+++ b/idea/testData/inspectionsLocal/constantConditionIf/endWithElseIf2.kt
@@ -1,0 +1,13 @@
+// WITH_RUNTIME
+
+fun main() {
+    foo(true);
+}
+fun foo(someBool:Boolean) {
+    if (someBool) {
+        println("test1");
+    } else if (<caret>false) {
+        println("test2");
+    }
+    println("test3");
+}

--- a/idea/testData/inspectionsLocal/constantConditionIf/endWithElseIf2.kt.after
+++ b/idea/testData/inspectionsLocal/constantConditionIf/endWithElseIf2.kt.after
@@ -1,0 +1,11 @@
+// WITH_RUNTIME
+
+fun main() {
+    foo(true);
+}
+fun foo(someBool:Boolean) {
+    if (someBool) {
+        println("test1");
+    }
+    println("test3");
+}

--- a/idea/testData/inspectionsLocal/constantConditionIf/expressionElseIfBlock2.kt
+++ b/idea/testData/inspectionsLocal/constantConditionIf/expressionElseIfBlock2.kt
@@ -1,0 +1,16 @@
+// WITH_RUNTIME
+
+fun foo(x: Int) {}
+
+fun bar(s: String?) {
+    if (s == null) {
+        1
+    }
+    else if (<caret>false) {
+        foo(1)
+        2
+    }
+    else {
+        3
+    }
+}

--- a/idea/testData/inspectionsLocal/constantConditionIf/expressionElseIfBlock2.kt.after
+++ b/idea/testData/inspectionsLocal/constantConditionIf/expressionElseIfBlock2.kt.after
@@ -1,0 +1,12 @@
+// WITH_RUNTIME
+
+fun foo(x: Int) {}
+
+fun bar(s: String?) {
+    if (s == null) {
+        1
+    }
+    else {
+        3
+    }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -2470,6 +2470,11 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
             runTest("idea/testData/inspectionsLocal/constantConditionIf/endWithElseIf.kt");
         }
 
+        @TestMetadata("endWithElseIf2.kt")
+        public void testEndWithElseIf2() throws Exception {
+            runTest("idea/testData/inspectionsLocal/constantConditionIf/endWithElseIf2.kt");
+        }
+
         @TestMetadata("endWithElseIfNoBraces.kt")
         public void testEndWithElseIfNoBraces() throws Exception {
             runTest("idea/testData/inspectionsLocal/constantConditionIf/endWithElseIfNoBraces.kt");
@@ -2533,6 +2538,11 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
         @TestMetadata("expressionElseIfBlock.kt")
         public void testExpressionElseIfBlock() throws Exception {
             runTest("idea/testData/inspectionsLocal/constantConditionIf/expressionElseIfBlock.kt");
+        }
+
+        @TestMetadata("expressionElseIfBlock2.kt")
+        public void testExpressionElseIfBlock2() throws Exception {
+            runTest("idea/testData/inspectionsLocal/constantConditionIf/expressionElseIfBlock2.kt");
         }
 
         @TestMetadata("noStatements.kt")


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-34713