### PR TITLE
Stubs don't break KtTypeAlias::isTopLevel

### DIFF
--- a/compiler/psi/src/org/jetbrains/kotlin/psi/KtTypeAlias.kt
+++ b/compiler/psi/src/org/jetbrains/kotlin/psi/KtTypeAlias.kt
@@ -33,7 +33,7 @@ class KtTypeAlias : KtTypeParameterListOwnerStub<KotlinTypeAliasStub>, KtNamedDe
         visitor.visitTypeAlias(this, data)
 
     fun isTopLevel(): Boolean =
-        stub?.isTopLevel() ?: parent is KtFile
+        stub?.isTopLevel() ?: (parent is KtFile)
 
     @IfNotParsed
     fun getTypeAliasKeyword(): PsiElement? =


### PR DESCRIPTION
`foo ?: bar is baz` is parsed as `(foo ?: bar) is baz`. So, if stub is non-null, this always returns `False`, because `Boolean` is definitely not a `KtFile`. See https://pl.kotl.in/6DtggcImf 

This Kotlin's "most vexing parse" badly needs a diagnostics.