### PR TITLE
Gradle 6.0.1 support. Fix Yarn loading progress logging

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin/build.gradle.kts
@@ -45,7 +45,7 @@ dependencies {
     compileOnly(project(":kotlin-scripting-compiler"))
 
     compile("com.google.code.gson:gson:${rootProject.extra["versions.jar.gson"]}")
-    compile("de.undercouch:gradle-download-task:3.4.3")
+    compile("de.undercouch:gradle-download-task:4.0.2")
     
     compileOnly("com.android.tools.build:gradle:2.0.0")
     compileOnly("com.android.tools.build:gradle-core:2.0.0")


### PR DESCRIPTION
Details - https://github.com/michel-kraemer/gradle-download-task/issues/143

Otherwise - no loading progress log