### PR TITLE
Bump dukat version

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/NpmVersions.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/NpmVersions.kt
@@ -13,7 +13,7 @@ import org.jetbrains.kotlin.gradle.targets.js.npm.NpmDependency
  * Package versions used by tasks
  */
 class NpmVersions {
-    val dukat = NpmPackageVersion("dukat", "0.0.19")
+    val dukat = NpmPackageVersion("dukat", "0.0.23")
 
     val webpack = NpmPackageVersion("webpack", "4.41.2")
     val webpackCli = NpmPackageVersion("webpack-cli", "3.3.9")


### PR DESCRIPTION
This fixes crashes that make `kotlin.js.experimental.generateKotlinExternals=true` unusable right now.