### PR TITLE
JVM_IR: More special bridge rewriting.

### DIFF
--- a/compiler/testData/codegen/box/specialBuiltins/removeSetInt.kt
+++ b/compiler/testData/codegen/box/specialBuiltins/removeSetInt.kt
@@ -1,7 +1,6 @@
 // IGNORE_BACKEND_FIR: JVM_IR
 // KJS_WITH_FULL_RUNTIME
 // IGNORE_BACKEND: NATIVE
-// IGNORE_BACKEND: JVM_IR
 class MySet : HashSet<Int>() {
     override fun remove(element: Int): Boolean {
         return super.remove(element)


### PR DESCRIPTION
If there is a concrete method that will have its argument types
remapped to boxed types, make sure to reflect that in the IR so
that code will be generated for a boxed value instead of a
primitive value.