### PR TITLE
PSI2IR: copy isPropertyWithPlatformField to GeneratorExtensions

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendFacade.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendFacade.kt
@@ -30,9 +30,9 @@ object JvmBackendFacade {
         errorHandler: CompilationErrorHandler,
         phaseConfig: PhaseConfig
     ) {
+        val extensions = JvmGeneratorExtensions()
         val psi2ir = Psi2IrTranslator(state.languageVersionSettings, mangler = JvmMangler)
-        val psi2irContext = psi2ir.createGeneratorContext(state.module, state.bindingContext, extensions = JvmGeneratorExtensions)
-        val extensions = JvmStubGeneratorExtensions()
+        val psi2irContext = psi2ir.createGeneratorContext(state.module, state.bindingContext, extensions = extensions)
 
         for (extension in IrGenerationExtension.getInstances(state.project)) {
             psi2ir.addPostprocessingStep { module ->
@@ -67,7 +67,7 @@ object JvmBackendFacade {
         symbolTable: SymbolTable,
         sourceManager: PsiSourceManager,
         phaseConfig: PhaseConfig,
-        extensions: JvmStubGeneratorExtensions = JvmStubGeneratorExtensions()
+        extensions: JvmGeneratorExtensions
     ) {
         val context = JvmBackendContext(
             state, sourceManager, irModuleFragment.irBuiltins, irModuleFragment, symbolTable, phaseConfig, extensions.classNameOverride

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmGeneratorExtensions.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmGeneratorExtensions.kt
@@ -65,6 +65,9 @@ object JvmGeneratorExtensions : GeneratorExtensions() {
             descriptor.visibility
         else
             null
+
+    override fun isPropertyWithPlatformField(descriptor: PropertyDescriptor): Boolean =
+        descriptor.hasJvmFieldAnnotation()
 }
 
 class JvmStubGeneratorExtensions : StubGeneratorExtensions() {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmGeneratorExtensions.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmGeneratorExtensions.kt
@@ -13,7 +13,6 @@ import org.jetbrains.kotlin.descriptors.Visibility
 import org.jetbrains.kotlin.ir.builders.declarations.buildClass
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
-import org.jetbrains.kotlin.ir.util.StubGeneratorExtensions
 import org.jetbrains.kotlin.load.java.descriptors.JavaCallableMemberDescriptor
 import org.jetbrains.kotlin.load.java.descriptors.JavaClassDescriptor
 import org.jetbrains.kotlin.load.java.sam.SamAdapterDescriptor
@@ -29,7 +28,7 @@ import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.TypeSubstitutor
 import org.jetbrains.kotlin.types.Variance
 
-object JvmGeneratorExtensions : GeneratorExtensions() {
+class JvmGeneratorExtensions(private val generateFacades: Boolean = true) : GeneratorExtensions() {
     override val samConversion: SamConversion
         get() = JvmSamConversion
 
@@ -66,11 +65,6 @@ object JvmGeneratorExtensions : GeneratorExtensions() {
         else
             null
 
-    override fun isPropertyWithPlatformField(descriptor: PropertyDescriptor): Boolean =
-        descriptor.hasJvmFieldAnnotation()
-}
-
-class JvmStubGeneratorExtensions : StubGeneratorExtensions() {
     val classNameOverride = mutableMapOf<IrClass, JvmClassName>()
 
     override fun computeExternalDeclarationOrigin(descriptor: DeclarationDescriptor): IrDeclarationOrigin? =
@@ -80,6 +74,7 @@ class JvmStubGeneratorExtensions : StubGeneratorExtensions() {
             IrDeclarationOrigin.IR_EXTERNAL_DECLARATION_STUB
 
     override fun generateFacadeClass(source: DeserializedContainerSource): IrClass? {
+        if (!generateFacades) return null
         val jvmPackagePartSource = source as? JvmPackagePartSource ?: return null
         val facadeName = jvmPackagePartSource.facadeClassName ?: jvmPackagePartSource.className
         return buildClass {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmIrCodegenFactory.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmIrCodegenFactory.kt
@@ -41,13 +41,13 @@ class JvmIrCodegenFactory(private val phaseConfig: PhaseConfig) : CodegenFactory
         symbolTable: SymbolTable,
         sourceManager: PsiSourceManager
     ) {
-        val stubGeneratorExtensions = JvmStubGeneratorExtensions()
+        val extensions = JvmGeneratorExtensions()
         val irProviders = generateTypicalIrProviderList(
-            irModuleFragment.descriptor, irModuleFragment.irBuiltins, symbolTable, extensions = stubGeneratorExtensions
+            irModuleFragment.descriptor, irModuleFragment.irBuiltins, symbolTable, extensions = extensions
         )
         ExternalDependenciesGenerator(symbolTable, irProviders).generateUnboundSymbolsAsDependencies()
         JvmBackendFacade.doGenerateFilesInternal(
-            state, errorHandler, irModuleFragment, symbolTable, sourceManager, phaseConfig, stubGeneratorExtensions
+            state, errorHandler, irModuleFragment, symbolTable, sourceManager, phaseConfig, extensions
         )
     }
 

--- a/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/Psi2IrTranslator.kt
+++ b/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/Psi2IrTranslator.kt
@@ -48,17 +48,13 @@ class Psi2IrTranslator(
         moduleDescriptor: ModuleDescriptor,
         ktFiles: Collection<KtFile>,
         bindingContext: BindingContext,
-        generatorExtensions: GeneratorExtensions,
-        stubGeneratorExtensions: StubGeneratorExtensions
+        generatorExtensions: GeneratorExtensions
     ): IrModuleFragment {
         val context = createGeneratorContext(moduleDescriptor, bindingContext, extensions = generatorExtensions)
-        return generateModuleFragment(
-            context, ktFiles,
-            irProviders = generateTypicalIrProviderList(
-                moduleDescriptor, context.irBuiltIns, context.symbolTable,
-                extensions = stubGeneratorExtensions
-            )
+        val irProviders = generateTypicalIrProviderList(
+            moduleDescriptor, context.irBuiltIns, context.symbolTable, extensions = generatorExtensions
         )
+        return generateModuleFragment(context, ktFiles, irProviders)
     }
 
     fun createGeneratorContext(

--- a/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/GeneratorExtensions.kt
+++ b/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/GeneratorExtensions.kt
@@ -8,9 +8,10 @@ package org.jetbrains.kotlin.psi2ir.generators
 import org.jetbrains.kotlin.descriptors.CallableDescriptor
 import org.jetbrains.kotlin.descriptors.PropertyDescriptor
 import org.jetbrains.kotlin.descriptors.Visibility
+import org.jetbrains.kotlin.ir.util.StubGeneratorExtensions
 import org.jetbrains.kotlin.types.KotlinType
 
-open class GeneratorExtensions {
+open class GeneratorExtensions : StubGeneratorExtensions() {
     open val samConversion: SamConversion
         get() = SamConversion
 
@@ -29,6 +30,4 @@ open class GeneratorExtensions {
     }
 
     open fun computeFieldVisibility(descriptor: PropertyDescriptor): Visibility? = null
-
-    open fun isPropertyWithPlatformField(descriptor: PropertyDescriptor): Boolean = false
 }

--- a/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/GeneratorExtensions.kt
+++ b/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/GeneratorExtensions.kt
@@ -29,4 +29,6 @@ open class GeneratorExtensions {
     }
 
     open fun computeFieldVisibility(descriptor: PropertyDescriptor): Visibility? = null
+
+    open fun isPropertyWithPlatformField(descriptor: PropertyDescriptor): Boolean = false
 }

--- a/compiler/testData/compileKotlinAgainstKotlin/jvmField.kt
+++ b/compiler/testData/compileKotlinAgainstKotlin/jvmField.kt
@@ -15,7 +15,7 @@ open class B : A() {
 
 open class C : B() {
     fun test(): String {
-        return super.publicField + super.internalField + super.protectedfield
+        return publicField + super.internalField + super.protectedfield
     }
 }
 

--- a/compiler/testData/compileKotlinAgainstKotlin/jvmFieldInConstructor.kt
+++ b/compiler/testData/compileKotlinAgainstKotlin/jvmFieldInConstructor.kt
@@ -11,7 +11,7 @@ open class B : A()
 
 open class C : B() {
     fun test(): String {
-        return super.publicField + super.internalField + super.protectedfield
+        return publicField + super.internalField + super.protectedfield
     }
 }
 


### PR DESCRIPTION
@udalov your addition of `StubGeneratorExtensions` fixed *direct* accesses to `@JvmField` from other modules, but the fake overrides of these properties still have no fake overrides of fields. When such a fake override is used, a nonexistent accessor is called. (Surprisingly, the two compileKotlinAgainstKotlin tests that have non-static `@JvmField` properties only use them through `super`, managing to avoid the issue by luck.)