### PR TITLE
Add specific highlight for Enum class

### DIFF
--- a/idea/idea-analysis/resources/org/jetbrains/kotlin/idea/KotlinBundle.properties
+++ b/idea/idea-analysis/resources/org/jetbrains/kotlin/idea/KotlinBundle.properties
@@ -76,6 +76,7 @@ options.kotlin.attribute.descriptor.kdoc.comment=Comments//KDoc//KDoc comment
 options.kotlin.attribute.descriptor.kdoc.tag=Comments//KDoc//KDoc tag
 options.kotlin.attribute.descriptor.kdoc.value=Comments//KDoc//Link in KDoc tag
 options.kotlin.attribute.descriptor.object=Classes and Interfaces//Object
+options.kotlin.attribute.descriptor.enum=Classes and Interfaces//Enum
 options.kotlin.attribute.descriptor.enumEntry=Classes and Interfaces//Enum entry
 options.kotlin.attribute.descriptor.typeAlias=Classes and Interfaces//Type alias
 options.kotlin.attribute.descriptor.var=Properties and Variables//Var (mutable variable, parameter or property)

--- a/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/KotlinHighlightingColors.java
+++ b/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/KotlinHighlightingColors.java
@@ -60,6 +60,7 @@ public class KotlinHighlightingColors {
     public static final TextAttributesKey TRAIT = createTextAttributesKey("KOTLIN_TRAIT", DefaultLanguageHighlighterColors.INTERFACE_NAME);
     public static final TextAttributesKey ANNOTATION = createTextAttributesKey("KOTLIN_ANNOTATION", JavaHighlightingColors.ANNOTATION_NAME_ATTRIBUTES);
     public static final TextAttributesKey OBJECT = createTextAttributesKey("KOTLIN_OBJECT", CLASS);
+    public static final TextAttributesKey ENUM = createTextAttributesKey("KOTLIN_ENUM", JavaHighlightingColors.ENUM_NAME_ATTRIBUTES);
     public static final TextAttributesKey ENUM_ENTRY = createTextAttributesKey("KOTLIN_ENUM_ENTRY", DefaultLanguageHighlighterColors.INSTANCE_FIELD);
     public static final TextAttributesKey TYPE_ALIAS = createTextAttributesKey("KOTLIN_TYPE_ALIAS", CLASS);
 

--- a/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/TypeKindHighlightingVisitor.kt
+++ b/idea/idea-analysis/src/org/jetbrains/kotlin/idea/highlighter/TypeKindHighlightingVisitor.kt
@@ -130,6 +130,7 @@ internal class TypeKindHighlightingVisitor(holder: AnnotationHolder, bindingCont
         ClassKind.INTERFACE -> TRAIT
         ClassKind.ANNOTATION_CLASS -> ANNOTATION
         ClassKind.OBJECT -> OBJECT
+        ClassKind.ENUM_CLASS -> ENUM
         ClassKind.ENUM_ENTRY -> ENUM_ENTRY
         else -> if (descriptor.modality === Modality.ABSTRACT) ABSTRACT_CLASS else CLASS
     }

--- a/idea/src/org/jetbrains/kotlin/idea/highlighter/KotlinColorSettingsPage.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/highlighter/KotlinColorSettingsPage.kt
@@ -90,7 +90,7 @@ var <PACKAGE_PROPERTY_CUSTOM_PROPERTY_DECLARATION><MUTABLE_VARIABLE>globalCounte
 
 <KEYWORD>object</KEYWORD> <OBJECT>Obj</OBJECT>
 
-<KEYWORD>enum</KEYWORD> <KEYWORD>class</KEYWORD> <CLASS>E</CLASS> { <ENUM_ENTRY>A</ENUM_ENTRY>, <ENUM_ENTRY>B</ENUM_ENTRY> }
+<KEYWORD>enum</KEYWORD> <KEYWORD>class</KEYWORD> <ENUM>E</ENUM> { <ENUM_ENTRY>A</ENUM_ENTRY>, <ENUM_ENTRY>B</ENUM_ENTRY> }
 
 <KEYWORD>interface</KEYWORD> <TRAIT>FunctionLike</TRAIT> {
     <BUILTIN_ANNOTATION>operator</BUILTIN_ANNOTATION> <KEYWORD>fun</KEYWORD> <FUNCTION_DECLARATION>invoke</FUNCTION_DECLARATION>() = <NUMBER>1</NUMBER>
@@ -162,6 +162,7 @@ var <PACKAGE_PROPERTY_CUSTOM_PROPERTY_DECLARATION><MUTABLE_VARIABLE>globalCounte
             OptionsBundle.message("options.java.attribute.descriptor.interface") to KotlinHighlightingColors.TRAIT,
             KotlinBundle.message("options.kotlin.attribute.descriptor.annotation") to KotlinHighlightingColors.ANNOTATION,
             KotlinBundle.message("options.kotlin.attribute.descriptor.object") to KotlinHighlightingColors.OBJECT,
+            KotlinBundle.message("options.kotlin.attribute.descriptor.enum") to KotlinHighlightingColors.ENUM,
             KotlinBundle.message("options.kotlin.attribute.descriptor.enumEntry") to KotlinHighlightingColors.ENUM_ENTRY,
             KotlinBundle.message("options.kotlin.attribute.descriptor.typeAlias") to KotlinHighlightingColors.TYPE_ALIAS,
             KotlinBundle.message("options.kotlin.attribute.descriptor.var") to KotlinHighlightingColors.MUTABLE_VARIABLE,


### PR DESCRIPTION
Hi, 

This is a small PR to allow changing highlight for Enum classes.
I took the `Annotation` highlight as an example to make Kotlin's `Enum` inherit `JavaHighlightingColors.ENUM_NAME_ATTRIBUTES`

Hope this helps.
Guillaume