### PR TITLE
JVM/JVM_IR: fix mapping of KClass in annotation classes

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/IrTypeMapper.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/IrTypeMapper.kt
@@ -137,7 +137,7 @@ class IrTypeMapper(private val context: JvmBackendContext) : KotlinTypeMapperBas
                     arrayElementType = AsmTypes.OBJECT_TYPE
                     sw?.writeClass(arrayElementType)
                 } else {
-                    arrayElementType = mapType(memberType, mode.toGenericArgumentMode(variance), sw)
+                    arrayElementType = mapType(memberType, mode.toGenericArgumentMode(variance, ofArray = true), sw)
                 }
                 sw?.writeArrayEnd()
 

--- a/compiler/testData/writeSignature/annotations/kArrayClassOfKClass.kt
+++ b/compiler/testData/writeSignature/annotations/kArrayClassOfKClass.kt
@@ -1,5 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
-
 import kotlin.reflect.KClass
 
 annotation class Ann(val arg: Array<out KClass<out KClass<*>>>)

--- a/compiler/testData/writeSignature/annotations/kClassOfKClass.kt
+++ b/compiler/testData/writeSignature/annotations/kClassOfKClass.kt
@@ -1,0 +1,7 @@
+import kotlin.reflect.KClass
+
+annotation class Ann(val arg: KClass<out KClass<*>>)
+
+// method: Ann::arg
+// jvm signature:     ()Ljava/lang/Class;
+// generic signature: ()Ljava/lang/Class<+Lkotlin/reflect/KClass<*>;>;

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrWriteSignatureTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrWriteSignatureTestGenerated.java
@@ -170,6 +170,11 @@ public class IrWriteSignatureTestGenerated extends AbstractIrWriteSignatureTest 
         public void testKClassInt() throws Exception {
             runTest("compiler/testData/writeSignature/annotations/kClassInt.kt");
         }
+
+        @TestMetadata("kClassOfKClass.kt")
+        public void testKClassOfKClass() throws Exception {
+            runTest("compiler/testData/writeSignature/annotations/kClassOfKClass.kt");
+        }
     }
 
     @TestMetadata("compiler/testData/writeSignature/callableReference")

--- a/compiler/tests/org/jetbrains/kotlin/jvm/compiler/WriteSignatureTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/jvm/compiler/WriteSignatureTestGenerated.java
@@ -169,6 +169,11 @@ public class WriteSignatureTestGenerated extends AbstractWriteSignatureTest {
         public void testKClassInt() throws Exception {
             runTest("compiler/testData/writeSignature/annotations/kClassInt.kt");
         }
+
+        @TestMetadata("kClassOfKClass.kt")
+        public void testKClassOfKClass() throws Exception {
+            runTest("compiler/testData/writeSignature/annotations/kClassOfKClass.kt");
+        }
     }
 
     @TestMetadata("compiler/testData/writeSignature/callableReference")

--- a/core/descriptors.jvm/src/org/jetbrains/kotlin/load/kotlin/typeSignatureMapping.kt
+++ b/core/descriptors.jvm/src/org/jetbrains/kotlin/load/kotlin/typeSignatureMapping.kt
@@ -121,8 +121,8 @@ fun <T : Any> mapType(
                 descriptorTypeWriter?.writeArrayType()
 
                 arrayElementType = mapType(
-                    memberType, factory, mode.toGenericArgumentMode(memberProjection.projectionKind), typeMappingConfiguration,
-                    descriptorTypeWriter, writeGenericType
+                    memberType, factory, mode.toGenericArgumentMode(memberProjection.projectionKind, ofArray = true),
+                    typeMappingConfiguration, descriptorTypeWriter, writeGenericType
                 )
 
                 descriptorTypeWriter?.writeArrayEnd()


### PR DESCRIPTION
 * JVM incorrectly mapped T<KClass<...>> to T<Class<...>> because the annotation-ness of the type mapping mode was inherited one level down into a generic signature independent of T

 * JVM_IR was even worse as it did not use VALUE_FOR_ANNOTATION at all, mapping T<T<KClass<...>> to T<T<Class<...>> as well.

The correct behavior is to map KClass to Class only at top level or as an argument of Array.