### PR TITLE
KT-35175 Clarify documentation for XorWowRandom

### DIFF
--- a/libraries/stdlib/src/kotlin/random/XorWowRandom.kt
+++ b/libraries/stdlib/src/kotlin/random/XorWowRandom.kt
@@ -6,11 +6,14 @@
 package kotlin.random
 
 /**
- * Random number generator, algorithm "xorwow" from p. 5 of Marsaglia, "Xorshift RNGs".
+ * Random number generator, using Marsaglia's "xorwow" algorithm
  *
- * Cycles after 2^160 * (2^32-1) repetitions.
+ * Cycles after 2^192 - 2^32 repetitions.
  *
- * See http://www.jstatsoft.org/v08/i14/paper for details.
+ * For more details, see Marsaglia, George (July 2003). "Xorshift RNGs". Journal of Statistical Software. 8 (14). doi:10.18637/jss.v008.i14
+ *
+ * Available at https://www.jstatsoft.org/v08/i14/paper
+ *
  */
 internal class XorWowRandom
 internal constructor(
@@ -33,6 +36,8 @@ internal constructor(
     }
 
     override fun nextInt(): Int {
+        // Equivalent to the xorxow algorithm
+        // From Marsaglia, G. 2003. Xorshift RNGs. J. Statis. Soft. 8, 14, p. 5
         var t = x
         t = t xor (t ushr 2)
         x = y


### PR DESCRIPTION
This commit changes XorWowRandom.kt documentation to include a HTTPS link instead of a HTTP link, for security purposes.

This commit also changes the same documentation to reflect the real cycles from the `xorwow` algorithm:

    Simple and very fast (125 million/sec), the elements in its cycle of 2^192 − 2^32 easily pass all the tests in Diehard.

 Marsaglia, G. 2003. Xorshift RNGs. J. Statis. Soft. 8, 14, p. 5

 At last, this commit explicits which part of the code is the implementation of the mentioned algorithm.

 Closes KT-35175