### PR TITLE
KT-34511 kotlin.KotlinNullPointerException after using intention Replace Java Map.forEach with Kotlin's forEach for Map with Pairs as keys

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/JavaMapForEachInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/JavaMapForEachInspection.kt
@@ -32,7 +32,8 @@ class JavaMapForEachInspection : AbstractApplicabilityBasedInspection<KtDotQuali
         if (calleeExpression.text != "forEach") return false
 
         val lambda = callExpression.lambda() ?: return false
-        if (lambda.valueParameters.size != 2) return false
+        val lambdaParameters = lambda.valueParameters
+        if (lambdaParameters.size != 2 || lambdaParameters.any { it.destructuringDeclaration != null }) return false
 
         val context = element.analyze(BodyResolveMode.PARTIAL)
         if (!element.receiverExpression.getType(context).isMap(DefaultBuiltIns.Instance)) return false

--- a/idea/testData/inspectionsLocal/javaMapForEach/destructuringDeclaration.kt
+++ b/idea/testData/inspectionsLocal/javaMapForEach/destructuringDeclaration.kt
@@ -1,0 +1,10 @@
+// PROBLEM: none
+// RUNTIME_WITH_FULL_JDK
+fun test(map: Map<Int, String>) {
+    val mapOfPairs = mapOf<Pair<Int, Int>, Int>()
+    mapOfPairs.<caret>forEach { (first, second), value ->
+        println(first)
+        println(second)
+        println(value)
+    }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -5061,6 +5061,11 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
             KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/inspectionsLocal/javaMapForEach"), Pattern.compile("^([\\w\\-_]+)\\.(kt|kts)$"), true);
         }
 
+        @TestMetadata("destructuringDeclaration.kt")
+        public void testDestructuringDeclaration() throws Exception {
+            runTest("idea/testData/inspectionsLocal/javaMapForEach/destructuringDeclaration.kt");
+        }
+
         @TestMetadata("java.kt")
         public void testJava() throws Exception {
             runTest("idea/testData/inspectionsLocal/javaMapForEach/java.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-34511