### PR TITLE
KT-30894 Wrong results of intention "Add names to call arguments" when backticked argument starts from digit

### DIFF
--- a/compiler/psi/src/org/jetbrains/kotlin/psi/KtPsiFactory.kt
+++ b/compiler/psi/src/org/jetbrains/kotlin/psi/KtPsiFactory.kt
@@ -18,6 +18,7 @@ import org.jetbrains.kotlin.lexer.KtModifierKeywordToken
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.psi.psiUtil.isIdentifier
 import org.jetbrains.kotlin.resolve.ImportPath
 import org.jetbrains.kotlin.utils.KotlinExceptionWithAttachments
 import org.jetbrains.kotlin.utils.checkWithAttachment
@@ -524,7 +525,12 @@ class KtPsiFactory @JvmOverloads constructor(private val project: Project, val m
             appendFixedText("(")
 
             if (name != null) {
-                appendName(name)
+                val asString = name.asString()
+                if (asString.isIdentifier()) {
+                    appendName(name)
+                } else {
+                    appendFixedText("`$asString`")
+                }
                 appendFixedText(" = ")
             }
 

--- a/idea/testData/intentions/addNameToArgument/backtickedArgument.kt
+++ b/idea/testData/intentions/addNameToArgument/backtickedArgument.kt
@@ -1,0 +1,6 @@
+fun foo(`1`: Int, `fun`: Int) {
+}
+
+fun main() {
+    foo(1, 2<caret>)
+}

--- a/idea/testData/intentions/addNameToArgument/backtickedArgument.kt.after
+++ b/idea/testData/intentions/addNameToArgument/backtickedArgument.kt.after
@@ -1,0 +1,6 @@
+fun foo(`1`: Int, `fun`: Int) {
+}
+
+fun main() {
+    foo(1, `fun` = 2)
+}

--- a/idea/testData/intentions/addNameToArgument/backtickedArgument2.kt
+++ b/idea/testData/intentions/addNameToArgument/backtickedArgument2.kt
@@ -1,0 +1,6 @@
+fun foo(`1`: Int, `2`: Int) {
+}
+
+fun main() {
+    foo(1, 2<caret>)
+}

--- a/idea/testData/intentions/addNameToArgument/backtickedArgument2.kt.after
+++ b/idea/testData/intentions/addNameToArgument/backtickedArgument2.kt.after
@@ -1,0 +1,6 @@
+fun foo(`1`: Int, `2`: Int) {
+}
+
+fun main() {
+    foo(1, `2` = 2)
+}

--- a/idea/testData/intentions/addNameToArgument/backtickedArgument3.kt
+++ b/idea/testData/intentions/addNameToArgument/backtickedArgument3.kt
@@ -1,0 +1,6 @@
+fun foo(`1`: Int, `2a`: Int) {
+}
+
+fun main() {
+    foo(1, 2<caret>)
+}

--- a/idea/testData/intentions/addNameToArgument/backtickedArgument3.kt.after
+++ b/idea/testData/intentions/addNameToArgument/backtickedArgument3.kt.after
@@ -1,0 +1,6 @@
+fun foo(`1`: Int, `2a`: Int) {
+}
+
+fun main() {
+    foo(1, `2a` = 2)
+}

--- a/idea/testData/intentions/addNameToArgument/backtickedArgument4.kt
+++ b/idea/testData/intentions/addNameToArgument/backtickedArgument4.kt
@@ -1,0 +1,6 @@
+fun foo(`1`: Int, `a`: Int) {
+}
+
+fun main() {
+    foo(1, 2<caret>)
+}

--- a/idea/testData/intentions/addNameToArgument/backtickedArgument4.kt.after
+++ b/idea/testData/intentions/addNameToArgument/backtickedArgument4.kt.after
@@ -1,0 +1,6 @@
+fun foo(`1`: Int, `a`: Int) {
+}
+
+fun main() {
+    foo(1, a = 2)
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -1180,6 +1180,26 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
             runTest("idea/testData/intentions/addNameToArgument/ambiguousCall.kt");
         }
 
+        @TestMetadata("backtickedArgument.kt")
+        public void testBacktickedArgument() throws Exception {
+            runTest("idea/testData/intentions/addNameToArgument/backtickedArgument.kt");
+        }
+
+        @TestMetadata("backtickedArgument2.kt")
+        public void testBacktickedArgument2() throws Exception {
+            runTest("idea/testData/intentions/addNameToArgument/backtickedArgument2.kt");
+        }
+
+        @TestMetadata("backtickedArgument3.kt")
+        public void testBacktickedArgument3() throws Exception {
+            runTest("idea/testData/intentions/addNameToArgument/backtickedArgument3.kt");
+        }
+
+        @TestMetadata("backtickedArgument4.kt")
+        public void testBacktickedArgument4() throws Exception {
+            runTest("idea/testData/intentions/addNameToArgument/backtickedArgument4.kt");
+        }
+
         @TestMetadata("beforeOtherNamed.kt")
         public void testBeforeOtherNamed() throws Exception {
             runTest("idea/testData/intentions/addNameToArgument/beforeOtherNamed.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-30894