### PR TITLE
Add KCallable.parameterCount()

### DIFF
--- a/core/builtins/src/kotlin/reflect/KCallable.kt
+++ b/core/builtins/src/kotlin/reflect/KCallable.kt
@@ -29,6 +29,14 @@ public actual interface KCallable<out R> : KAnnotatedElement {
     public val parameters: List<KParameter>
 
     /**
+     * Parameters required to make a call to this callable.
+     * If this callable requires a `this` instance or an extension receiver parameter,
+     * they come first in the list in that order.
+     */
+    public val parameterCount: Int
+
+
+    /**
      * The type of values returned by this callable.
      */
     public val returnType: KType

--- a/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KCallableImpl.kt
+++ b/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KCallableImpl.kt
@@ -70,6 +70,30 @@ internal abstract class KCallableImpl<out R> : KCallable<R> {
     override val parameters: List<KParameter>
         get() = _parameters()
 
+    private val _parameterCount = ReflectProperties.lazySoft {
+        val descriptor = descriptor
+        var result = 0
+
+        if (!isBound) {
+            val instanceReceiver = descriptor.instanceReceiverParameter
+            if (instanceReceiver != null) {
+                result++
+            }
+
+            val extensionReceiver = descriptor.extensionReceiverParameter
+            if (extensionReceiver != null) {
+                result++
+            }
+        }
+
+        result += descriptor.valueParameters.size
+
+        result
+    }
+
+    override val parameterCount: Int
+        get() = _parameterCount()
+
     private val _returnType = ReflectProperties.lazySoft {
         KTypeImpl(descriptor.returnType!!) {
             extractContinuationArgument() ?: caller.returnType

--- a/idea/idea-analysis/src/org/jetbrains/kotlin/idea/inspections/IntentionBasedInspection.kt
+++ b/idea/idea-analysis/src/org/jetbrains/kotlin/idea/inspections/IntentionBasedInspection.kt
@@ -49,7 +49,7 @@ abstract class IntentionBasedInspection<TElement : PsiElement> private construct
 
     val intention: SelfTargetingRangeIntention<TElement> by lazy {
         val intentionClass = intentionInfo.intention
-        intentionClass.constructors.single { it.parameters.isEmpty() }.call().apply {
+        intentionClass.constructors.single { it.parameterCount == 0 }.call().apply {
             inspection = this@IntentionBasedInspection
         }
     }

--- a/libraries/stdlib/jvm/runtime/kotlin/jvm/internal/CallableReference.java
+++ b/libraries/stdlib/jvm/runtime/kotlin/jvm/internal/CallableReference.java
@@ -7,7 +7,12 @@ package kotlin.jvm.internal;
 
 import kotlin.SinceKotlin;
 import kotlin.jvm.KotlinReflectionNotSupportedError;
-import kotlin.reflect.*;
+import kotlin.reflect.KCallable;
+import kotlin.reflect.KDeclarationContainer;
+import kotlin.reflect.KParameter;
+import kotlin.reflect.KType;
+import kotlin.reflect.KTypeParameter;
+import kotlin.reflect.KVisibility;
 
 import java.io.ObjectStreamException;
 import java.io.Serializable;
@@ -115,6 +120,11 @@ public abstract class CallableReference implements KCallable, Serializable {
     @Override
     public List<KParameter> getParameters() {
         return getReflected().getParameters();
+    }
+
+    @Override
+    public int getParameterCount() {
+        return getReflected().getParameterCount();
     }
 
     @Override

--- a/plugins/scripting/scripting-compiler-impl/src/org/jetbrains/kotlin/scripting/resolve/KotlinScriptDefinitionFromAnnotatedTemplate.kt
+++ b/plugins/scripting/scripting-compiler-impl/src/org/jetbrains/kotlin/scripting/resolve/KotlinScriptDefinitionFromAnnotatedTemplate.kt
@@ -88,7 +88,7 @@ open class KotlinScriptDefinitionFromAnnotatedTemplate(
 
         fun sameSignature(left: KFunction<*>, right: KFunction<*>): Boolean =
                 left.name == right.name &&
-                left.parameters.size == right.parameters.size &&
+                left.parameterCount == right.parameterCount &&
                 left.parameters.zip(right.parameters).all {
                     it.first.kind == KParameter.Kind.INSTANCE ||
                     it.first.type == it.second.type


### PR DESCRIPTION
Hello, originally the idea of those changes was born while improving `BeanUtils.instantiateClass` in Spring Framework here: https://github.com/spring-projects/spring-framework/pull/24104

It turned out that current implementation of `kotlin.reflect.KCallable` doesn't provide a separate method to get parameter count, this is why `KCallable.parameters()` is used. This method allocates and stores list of `KParameter` which is not always necessary for the cases when we need only to get param count (e.g. when it is 0 we can call no-args constructor).

In Java `java.lang.reflect.Method` originally provided only `getParameterTypes()` method, which cloned underlying array. Later `Method.getParameterCount()` was introduced for the sake of performance (it is allocation-free), see https://bugs.openjdk.java.net/browse/JDK-8004729

Usage of `KCallable.parameterCount()` allows to postpone or even rid unnecessary object allocation.