### PR TITLE
KT-23322: Document 'reduce' operation behavior on empty collections

### DIFF
--- a/libraries/stdlib/common/src/generated/_Arrays.kt
+++ b/libraries/stdlib/common/src/generated/_Arrays.kt
@@ -12310,6 +12310,7 @@ public inline fun CharArray.none(predicate: (Char) -> Boolean): Boolean {
 
 /**
  * Accumulates value starting with the first element and applying [operation] from left to right to current accumulator value and each element.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 public inline fun <S, T : S> Array<out T>.reduce(operation: (acc: S, T) -> S): S {
     if (isEmpty())
@@ -12323,6 +12324,7 @@ public inline fun <S, T : S> Array<out T>.reduce(operation: (acc: S, T) -> S): S
 
 /**
  * Accumulates value starting with the first element and applying [operation] from left to right to current accumulator value and each element.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 public inline fun ByteArray.reduce(operation: (acc: Byte, Byte) -> Byte): Byte {
     if (isEmpty())
@@ -12336,6 +12338,7 @@ public inline fun ByteArray.reduce(operation: (acc: Byte, Byte) -> Byte): Byte {
 
 /**
  * Accumulates value starting with the first element and applying [operation] from left to right to current accumulator value and each element.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 public inline fun ShortArray.reduce(operation: (acc: Short, Short) -> Short): Short {
     if (isEmpty())
@@ -12349,6 +12352,7 @@ public inline fun ShortArray.reduce(operation: (acc: Short, Short) -> Short): Sh
 
 /**
  * Accumulates value starting with the first element and applying [operation] from left to right to current accumulator value and each element.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 public inline fun IntArray.reduce(operation: (acc: Int, Int) -> Int): Int {
     if (isEmpty())
@@ -12362,6 +12366,7 @@ public inline fun IntArray.reduce(operation: (acc: Int, Int) -> Int): Int {
 
 /**
  * Accumulates value starting with the first element and applying [operation] from left to right to current accumulator value and each element.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 public inline fun LongArray.reduce(operation: (acc: Long, Long) -> Long): Long {
     if (isEmpty())
@@ -12375,6 +12380,7 @@ public inline fun LongArray.reduce(operation: (acc: Long, Long) -> Long): Long {
 
 /**
  * Accumulates value starting with the first element and applying [operation] from left to right to current accumulator value and each element.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 public inline fun FloatArray.reduce(operation: (acc: Float, Float) -> Float): Float {
     if (isEmpty())
@@ -12388,6 +12394,7 @@ public inline fun FloatArray.reduce(operation: (acc: Float, Float) -> Float): Fl
 
 /**
  * Accumulates value starting with the first element and applying [operation] from left to right to current accumulator value and each element.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 public inline fun DoubleArray.reduce(operation: (acc: Double, Double) -> Double): Double {
     if (isEmpty())
@@ -12401,6 +12408,7 @@ public inline fun DoubleArray.reduce(operation: (acc: Double, Double) -> Double)
 
 /**
  * Accumulates value starting with the first element and applying [operation] from left to right to current accumulator value and each element.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 public inline fun BooleanArray.reduce(operation: (acc: Boolean, Boolean) -> Boolean): Boolean {
     if (isEmpty())
@@ -12414,6 +12422,7 @@ public inline fun BooleanArray.reduce(operation: (acc: Boolean, Boolean) -> Bool
 
 /**
  * Accumulates value starting with the first element and applying [operation] from left to right to current accumulator value and each element.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 public inline fun CharArray.reduce(operation: (acc: Char, Char) -> Char): Char {
     if (isEmpty())
@@ -12430,6 +12439,7 @@ public inline fun CharArray.reduce(operation: (acc: Char, Char) -> Char): Char {
  * to current accumulator value and each element with its index in the original array.
  * @param [operation] function that takes the index of an element, current accumulator value
  * and the element itself and calculates the next accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 public inline fun <S, T : S> Array<out T>.reduceIndexed(operation: (index: Int, acc: S, T) -> S): S {
     if (isEmpty())
@@ -12446,6 +12456,7 @@ public inline fun <S, T : S> Array<out T>.reduceIndexed(operation: (index: Int, 
  * to current accumulator value and each element with its index in the original array.
  * @param [operation] function that takes the index of an element, current accumulator value
  * and the element itself and calculates the next accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 public inline fun ByteArray.reduceIndexed(operation: (index: Int, acc: Byte, Byte) -> Byte): Byte {
     if (isEmpty())
@@ -12462,6 +12473,7 @@ public inline fun ByteArray.reduceIndexed(operation: (index: Int, acc: Byte, Byt
  * to current accumulator value and each element with its index in the original array.
  * @param [operation] function that takes the index of an element, current accumulator value
  * and the element itself and calculates the next accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 public inline fun ShortArray.reduceIndexed(operation: (index: Int, acc: Short, Short) -> Short): Short {
     if (isEmpty())
@@ -12478,6 +12490,7 @@ public inline fun ShortArray.reduceIndexed(operation: (index: Int, acc: Short, S
  * to current accumulator value and each element with its index in the original array.
  * @param [operation] function that takes the index of an element, current accumulator value
  * and the element itself and calculates the next accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 public inline fun IntArray.reduceIndexed(operation: (index: Int, acc: Int, Int) -> Int): Int {
     if (isEmpty())
@@ -12494,6 +12507,7 @@ public inline fun IntArray.reduceIndexed(operation: (index: Int, acc: Int, Int) 
  * to current accumulator value and each element with its index in the original array.
  * @param [operation] function that takes the index of an element, current accumulator value
  * and the element itself and calculates the next accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 public inline fun LongArray.reduceIndexed(operation: (index: Int, acc: Long, Long) -> Long): Long {
     if (isEmpty())
@@ -12510,6 +12524,7 @@ public inline fun LongArray.reduceIndexed(operation: (index: Int, acc: Long, Lon
  * to current accumulator value and each element with its index in the original array.
  * @param [operation] function that takes the index of an element, current accumulator value
  * and the element itself and calculates the next accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 public inline fun FloatArray.reduceIndexed(operation: (index: Int, acc: Float, Float) -> Float): Float {
     if (isEmpty())
@@ -12526,6 +12541,7 @@ public inline fun FloatArray.reduceIndexed(operation: (index: Int, acc: Float, F
  * to current accumulator value and each element with its index in the original array.
  * @param [operation] function that takes the index of an element, current accumulator value
  * and the element itself and calculates the next accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 public inline fun DoubleArray.reduceIndexed(operation: (index: Int, acc: Double, Double) -> Double): Double {
     if (isEmpty())
@@ -12542,6 +12558,7 @@ public inline fun DoubleArray.reduceIndexed(operation: (index: Int, acc: Double,
  * to current accumulator value and each element with its index in the original array.
  * @param [operation] function that takes the index of an element, current accumulator value
  * and the element itself and calculates the next accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 public inline fun BooleanArray.reduceIndexed(operation: (index: Int, acc: Boolean, Boolean) -> Boolean): Boolean {
     if (isEmpty())
@@ -12558,6 +12575,7 @@ public inline fun BooleanArray.reduceIndexed(operation: (index: Int, acc: Boolea
  * to current accumulator value and each element with its index in the original array.
  * @param [operation] function that takes the index of an element, current accumulator value
  * and the element itself and calculates the next accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 public inline fun CharArray.reduceIndexed(operation: (index: Int, acc: Char, Char) -> Char): Char {
     if (isEmpty())
@@ -12571,6 +12589,7 @@ public inline fun CharArray.reduceIndexed(operation: (index: Int, acc: Char, Cha
 
 /**
  * Accumulates value starting with last element and applying [operation] from right to left to each element and current accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 public inline fun <S, T : S> Array<out T>.reduceRight(operation: (T, acc: S) -> S): S {
     var index = lastIndex
@@ -12584,6 +12603,7 @@ public inline fun <S, T : S> Array<out T>.reduceRight(operation: (T, acc: S) -> 
 
 /**
  * Accumulates value starting with last element and applying [operation] from right to left to each element and current accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 public inline fun ByteArray.reduceRight(operation: (Byte, acc: Byte) -> Byte): Byte {
     var index = lastIndex
@@ -12597,6 +12617,7 @@ public inline fun ByteArray.reduceRight(operation: (Byte, acc: Byte) -> Byte): B
 
 /**
  * Accumulates value starting with last element and applying [operation] from right to left to each element and current accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 public inline fun ShortArray.reduceRight(operation: (Short, acc: Short) -> Short): Short {
     var index = lastIndex
@@ -12610,6 +12631,7 @@ public inline fun ShortArray.reduceRight(operation: (Short, acc: Short) -> Short
 
 /**
  * Accumulates value starting with last element and applying [operation] from right to left to each element and current accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 public inline fun IntArray.reduceRight(operation: (Int, acc: Int) -> Int): Int {
     var index = lastIndex
@@ -12623,6 +12645,7 @@ public inline fun IntArray.reduceRight(operation: (Int, acc: Int) -> Int): Int {
 
 /**
  * Accumulates value starting with last element and applying [operation] from right to left to each element and current accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 public inline fun LongArray.reduceRight(operation: (Long, acc: Long) -> Long): Long {
     var index = lastIndex
@@ -12636,6 +12659,7 @@ public inline fun LongArray.reduceRight(operation: (Long, acc: Long) -> Long): L
 
 /**
  * Accumulates value starting with last element and applying [operation] from right to left to each element and current accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 public inline fun FloatArray.reduceRight(operation: (Float, acc: Float) -> Float): Float {
     var index = lastIndex
@@ -12649,6 +12673,7 @@ public inline fun FloatArray.reduceRight(operation: (Float, acc: Float) -> Float
 
 /**
  * Accumulates value starting with last element and applying [operation] from right to left to each element and current accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 public inline fun DoubleArray.reduceRight(operation: (Double, acc: Double) -> Double): Double {
     var index = lastIndex
@@ -12662,6 +12687,7 @@ public inline fun DoubleArray.reduceRight(operation: (Double, acc: Double) -> Do
 
 /**
  * Accumulates value starting with last element and applying [operation] from right to left to each element and current accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 public inline fun BooleanArray.reduceRight(operation: (Boolean, acc: Boolean) -> Boolean): Boolean {
     var index = lastIndex
@@ -12675,6 +12701,7 @@ public inline fun BooleanArray.reduceRight(operation: (Boolean, acc: Boolean) ->
 
 /**
  * Accumulates value starting with last element and applying [operation] from right to left to each element and current accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 public inline fun CharArray.reduceRight(operation: (Char, acc: Char) -> Char): Char {
     var index = lastIndex
@@ -12691,6 +12718,7 @@ public inline fun CharArray.reduceRight(operation: (Char, acc: Char) -> Char): C
  * to each element with its index in the original array and current accumulator value.
  * @param [operation] function that takes the index of an element, the element itself
  * and current accumulator value, and calculates the next accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 public inline fun <S, T : S> Array<out T>.reduceRightIndexed(operation: (index: Int, T, acc: S) -> S): S {
     var index = lastIndex
@@ -12708,6 +12736,7 @@ public inline fun <S, T : S> Array<out T>.reduceRightIndexed(operation: (index: 
  * to each element with its index in the original array and current accumulator value.
  * @param [operation] function that takes the index of an element, the element itself
  * and current accumulator value, and calculates the next accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 public inline fun ByteArray.reduceRightIndexed(operation: (index: Int, Byte, acc: Byte) -> Byte): Byte {
     var index = lastIndex
@@ -12725,6 +12754,7 @@ public inline fun ByteArray.reduceRightIndexed(operation: (index: Int, Byte, acc
  * to each element with its index in the original array and current accumulator value.
  * @param [operation] function that takes the index of an element, the element itself
  * and current accumulator value, and calculates the next accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 public inline fun ShortArray.reduceRightIndexed(operation: (index: Int, Short, acc: Short) -> Short): Short {
     var index = lastIndex
@@ -12742,6 +12772,7 @@ public inline fun ShortArray.reduceRightIndexed(operation: (index: Int, Short, a
  * to each element with its index in the original array and current accumulator value.
  * @param [operation] function that takes the index of an element, the element itself
  * and current accumulator value, and calculates the next accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 public inline fun IntArray.reduceRightIndexed(operation: (index: Int, Int, acc: Int) -> Int): Int {
     var index = lastIndex
@@ -12759,6 +12790,7 @@ public inline fun IntArray.reduceRightIndexed(operation: (index: Int, Int, acc: 
  * to each element with its index in the original array and current accumulator value.
  * @param [operation] function that takes the index of an element, the element itself
  * and current accumulator value, and calculates the next accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 public inline fun LongArray.reduceRightIndexed(operation: (index: Int, Long, acc: Long) -> Long): Long {
     var index = lastIndex
@@ -12776,6 +12808,7 @@ public inline fun LongArray.reduceRightIndexed(operation: (index: Int, Long, acc
  * to each element with its index in the original array and current accumulator value.
  * @param [operation] function that takes the index of an element, the element itself
  * and current accumulator value, and calculates the next accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 public inline fun FloatArray.reduceRightIndexed(operation: (index: Int, Float, acc: Float) -> Float): Float {
     var index = lastIndex
@@ -12793,6 +12826,7 @@ public inline fun FloatArray.reduceRightIndexed(operation: (index: Int, Float, a
  * to each element with its index in the original array and current accumulator value.
  * @param [operation] function that takes the index of an element, the element itself
  * and current accumulator value, and calculates the next accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 public inline fun DoubleArray.reduceRightIndexed(operation: (index: Int, Double, acc: Double) -> Double): Double {
     var index = lastIndex
@@ -12810,6 +12844,7 @@ public inline fun DoubleArray.reduceRightIndexed(operation: (index: Int, Double,
  * to each element with its index in the original array and current accumulator value.
  * @param [operation] function that takes the index of an element, the element itself
  * and current accumulator value, and calculates the next accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 public inline fun BooleanArray.reduceRightIndexed(operation: (index: Int, Boolean, acc: Boolean) -> Boolean): Boolean {
     var index = lastIndex
@@ -12827,6 +12862,7 @@ public inline fun BooleanArray.reduceRightIndexed(operation: (index: Int, Boolea
  * to each element with its index in the original array and current accumulator value.
  * @param [operation] function that takes the index of an element, the element itself
  * and current accumulator value, and calculates the next accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 public inline fun CharArray.reduceRightIndexed(operation: (index: Int, Char, acc: Char) -> Char): Char {
     var index = lastIndex

--- a/libraries/stdlib/common/src/generated/_Collections.kt
+++ b/libraries/stdlib/common/src/generated/_Collections.kt
@@ -1818,6 +1818,7 @@ public inline fun <T, C : Iterable<T>> C.onEach(action: (T) -> Unit): C {
 
 /**
  * Accumulates value starting with the first element and applying [operation] from left to right to current accumulator value and each element.
+ * @throws UnsupportedOperationException if the collection is empty.
  */
 public inline fun <S, T : S> Iterable<T>.reduce(operation: (acc: S, T) -> S): S {
     val iterator = this.iterator()
@@ -1834,6 +1835,7 @@ public inline fun <S, T : S> Iterable<T>.reduce(operation: (acc: S, T) -> S): S 
  * to current accumulator value and each element with its index in the original collection.
  * @param [operation] function that takes the index of an element, current accumulator value
  * and the element itself and calculates the next accumulator value.
+ * @throws UnsupportedOperationException if the collection is empty.
  */
 public inline fun <S, T : S> Iterable<T>.reduceIndexed(operation: (index: Int, acc: S, T) -> S): S {
     val iterator = this.iterator()
@@ -1848,6 +1850,7 @@ public inline fun <S, T : S> Iterable<T>.reduceIndexed(operation: (index: Int, a
 
 /**
  * Accumulates value starting with last element and applying [operation] from right to left to each element and current accumulator value.
+ * @throws UnsupportedOperationException if the list is empty.
  */
 public inline fun <S, T : S> List<T>.reduceRight(operation: (T, acc: S) -> S): S {
     val iterator = listIterator(size)
@@ -1865,6 +1868,7 @@ public inline fun <S, T : S> List<T>.reduceRight(operation: (T, acc: S) -> S): S
  * to each element with its index in the original list and current accumulator value.
  * @param [operation] function that takes the index of an element, the element itself
  * and current accumulator value, and calculates the next accumulator value.
+ * @throws UnsupportedOperationException if the list is empty.
  */
 public inline fun <S, T : S> List<T>.reduceRightIndexed(operation: (index: Int, T, acc: S) -> S): S {
     val iterator = listIterator(size)

--- a/libraries/stdlib/common/src/generated/_Sequences.kt
+++ b/libraries/stdlib/common/src/generated/_Sequences.kt
@@ -1330,6 +1330,7 @@ public fun <T> Sequence<T>.onEach(action: (T) -> Unit): Sequence<T> {
 
 /**
  * Accumulates value starting with the first element and applying [operation] from left to right to current accumulator value and each element.
+ * @throws UnsupportedOperationException if the sequence is empty.
  *
  * The operation is _terminal_.
  */
@@ -1348,6 +1349,7 @@ public inline fun <S, T : S> Sequence<T>.reduce(operation: (acc: S, T) -> S): S 
  * to current accumulator value and each element with its index in the original sequence.
  * @param [operation] function that takes the index of an element, current accumulator value
  * and the element itself and calculates the next accumulator value.
+ * @throws UnsupportedOperationException if the sequence is empty.
  *
  * The operation is _terminal_.
  */

--- a/libraries/stdlib/common/src/generated/_Strings.kt
+++ b/libraries/stdlib/common/src/generated/_Strings.kt
@@ -1152,6 +1152,7 @@ public inline fun <S : CharSequence> S.onEach(action: (Char) -> Unit): S {
 
 /**
  * Accumulates value starting with the first character and applying [operation] from left to right to current accumulator value and each character.
+ * @throws UnsupportedOperationException if the char sequence is empty.
  */
 public inline fun CharSequence.reduce(operation: (acc: Char, Char) -> Char): Char {
     if (isEmpty())
@@ -1168,6 +1169,7 @@ public inline fun CharSequence.reduce(operation: (acc: Char, Char) -> Char): Cha
  * to current accumulator value and each character with its index in the original char sequence.
  * @param [operation] function that takes the index of a character, current accumulator value
  * and the character itself and calculates the next accumulator value.
+ * @throws UnsupportedOperationException if the char sequence is empty.
  */
 public inline fun CharSequence.reduceIndexed(operation: (index: Int, acc: Char, Char) -> Char): Char {
     if (isEmpty())
@@ -1181,6 +1183,7 @@ public inline fun CharSequence.reduceIndexed(operation: (index: Int, acc: Char, 
 
 /**
  * Accumulates value starting with last character and applying [operation] from right to left to each character and current accumulator value.
+ * @throws UnsupportedOperationException if the char sequence is empty.
  */
 public inline fun CharSequence.reduceRight(operation: (Char, acc: Char) -> Char): Char {
     var index = lastIndex
@@ -1197,6 +1200,7 @@ public inline fun CharSequence.reduceRight(operation: (Char, acc: Char) -> Char)
  * to each character with its index in the original char sequence and current accumulator value.
  * @param [operation] function that takes the index of a character, the character itself
  * and current accumulator value, and calculates the next accumulator value.
+ * @throws UnsupportedOperationException if the char sequence is empty.
  */
 public inline fun CharSequence.reduceRightIndexed(operation: (index: Int, Char, acc: Char) -> Char): Char {
     var index = lastIndex

--- a/libraries/stdlib/common/src/generated/_UArrays.kt
+++ b/libraries/stdlib/common/src/generated/_UArrays.kt
@@ -5472,6 +5472,7 @@ public inline fun UShortArray.none(predicate: (UShort) -> Boolean): Boolean {
 
 /**
  * Accumulates value starting with the first element and applying [operation] from left to right to current accumulator value and each element.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes
@@ -5488,6 +5489,7 @@ public inline fun UIntArray.reduce(operation: (acc: UInt, UInt) -> UInt): UInt {
 
 /**
  * Accumulates value starting with the first element and applying [operation] from left to right to current accumulator value and each element.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes
@@ -5504,6 +5506,7 @@ public inline fun ULongArray.reduce(operation: (acc: ULong, ULong) -> ULong): UL
 
 /**
  * Accumulates value starting with the first element and applying [operation] from left to right to current accumulator value and each element.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes
@@ -5520,6 +5523,7 @@ public inline fun UByteArray.reduce(operation: (acc: UByte, UByte) -> UByte): UB
 
 /**
  * Accumulates value starting with the first element and applying [operation] from left to right to current accumulator value and each element.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes
@@ -5539,6 +5543,7 @@ public inline fun UShortArray.reduce(operation: (acc: UShort, UShort) -> UShort)
  * to current accumulator value and each element with its index in the original array.
  * @param [operation] function that takes the index of an element, current accumulator value
  * and the element itself and calculates the next accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes
@@ -5558,6 +5563,7 @@ public inline fun UIntArray.reduceIndexed(operation: (index: Int, acc: UInt, UIn
  * to current accumulator value and each element with its index in the original array.
  * @param [operation] function that takes the index of an element, current accumulator value
  * and the element itself and calculates the next accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes
@@ -5577,6 +5583,7 @@ public inline fun ULongArray.reduceIndexed(operation: (index: Int, acc: ULong, U
  * to current accumulator value and each element with its index in the original array.
  * @param [operation] function that takes the index of an element, current accumulator value
  * and the element itself and calculates the next accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes
@@ -5596,6 +5603,7 @@ public inline fun UByteArray.reduceIndexed(operation: (index: Int, acc: UByte, U
  * to current accumulator value and each element with its index in the original array.
  * @param [operation] function that takes the index of an element, current accumulator value
  * and the element itself and calculates the next accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes
@@ -5612,6 +5620,7 @@ public inline fun UShortArray.reduceIndexed(operation: (index: Int, acc: UShort,
 
 /**
  * Accumulates value starting with last element and applying [operation] from right to left to each element and current accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes
@@ -5628,6 +5637,7 @@ public inline fun UIntArray.reduceRight(operation: (UInt, acc: UInt) -> UInt): U
 
 /**
  * Accumulates value starting with last element and applying [operation] from right to left to each element and current accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes
@@ -5644,6 +5654,7 @@ public inline fun ULongArray.reduceRight(operation: (ULong, acc: ULong) -> ULong
 
 /**
  * Accumulates value starting with last element and applying [operation] from right to left to each element and current accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes
@@ -5660,6 +5671,7 @@ public inline fun UByteArray.reduceRight(operation: (UByte, acc: UByte) -> UByte
 
 /**
  * Accumulates value starting with last element and applying [operation] from right to left to each element and current accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes
@@ -5679,6 +5691,7 @@ public inline fun UShortArray.reduceRight(operation: (UShort, acc: UShort) -> US
  * to each element with its index in the original array and current accumulator value.
  * @param [operation] function that takes the index of an element, the element itself
  * and current accumulator value, and calculates the next accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes
@@ -5699,6 +5712,7 @@ public inline fun UIntArray.reduceRightIndexed(operation: (index: Int, UInt, acc
  * to each element with its index in the original array and current accumulator value.
  * @param [operation] function that takes the index of an element, the element itself
  * and current accumulator value, and calculates the next accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes
@@ -5719,6 +5733,7 @@ public inline fun ULongArray.reduceRightIndexed(operation: (index: Int, ULong, a
  * to each element with its index in the original array and current accumulator value.
  * @param [operation] function that takes the index of an element, the element itself
  * and current accumulator value, and calculates the next accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes
@@ -5739,6 +5754,7 @@ public inline fun UByteArray.reduceRightIndexed(operation: (index: Int, UByte, a
  * to each element with its index in the original array and current accumulator value.
  * @param [operation] function that takes the index of an element, the element itself
  * and current accumulator value, and calculates the next accumulator value.
+ * @throws UnsupportedOperationException if the array is empty.
  */
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Aggregates.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Aggregates.kt
@@ -644,6 +644,7 @@ object Aggregates : TemplateGroupBase() {
             to current accumulator value and each ${f.element} with its index in the original ${f.collection}.
             @param [operation] function that takes the index of ${f.element.prefixWithArticle()}, current accumulator value
             and the ${f.element} itself and calculates the next accumulator value.
+            @throws UnsupportedOperationException if the ${f.collection} is empty.
             """
         }
         returns("T")
@@ -672,6 +673,7 @@ object Aggregates : TemplateGroupBase() {
             to current accumulator value and each ${f.element} with its index in the original ${f.collection}.
             @param [operation] function that takes the index of ${f.element.prefixWithArticle()}, current accumulator value
             and the ${f.element} itself and calculates the next accumulator value.
+            @throws UnsupportedOperationException if the ${f.collection} is empty.
             """
         }
         typeParam("S")
@@ -717,6 +719,7 @@ object Aggregates : TemplateGroupBase() {
             to each ${f.element} with its index in the original ${f.collection} and current accumulator value.
             @param [operation] function that takes the index of ${f.element.prefixWithArticle()}, the ${f.element} itself
             and current accumulator value, and calculates the next accumulator value.
+            @throws UnsupportedOperationException if the ${f.collection} is empty.
             """
         }
         returns("T")
@@ -747,6 +750,7 @@ object Aggregates : TemplateGroupBase() {
             to each ${f.element} with its index in the original ${f.collection} and current accumulator value.
             @param [operation] function that takes the index of ${f.element.prefixWithArticle()}, the ${f.element} itself
             and current accumulator value, and calculates the next accumulator value.
+            @throws UnsupportedOperationException if the ${f.collection} is empty.
             """
         }
         typeParam("S")
@@ -789,7 +793,12 @@ object Aggregates : TemplateGroupBase() {
         inline()
         specialFor(ArraysOfUnsigned) { inlineOnly() }
 
-        doc { "Accumulates value starting with the first ${f.element} and applying [operation] from left to right to current accumulator value and each ${f.element}." }
+        doc {
+            """
+            Accumulates value starting with the first ${f.element} and applying [operation] from left to right to current accumulator value and each ${f.element}.
+            @throws UnsupportedOperationException if the ${f.collection} is empty.
+            """
+        }
         returns("T")
         body {
             """
@@ -810,7 +819,12 @@ object Aggregates : TemplateGroupBase() {
     } builder {
         inline()
 
-        doc { "Accumulates value starting with the first ${f.element} and applying [operation] from left to right to current accumulator value and each ${f.element}." }
+        doc {
+            """
+            Accumulates value starting with the first ${f.element} and applying [operation] from left to right to current accumulator value and each ${f.element}.
+            @throws UnsupportedOperationException if the ${f.collection} is empty.
+            """
+        }
         typeParam("S")
         typeParam("T : S")
         returns("S")
@@ -846,7 +860,12 @@ object Aggregates : TemplateGroupBase() {
         inline()
         specialFor(ArraysOfUnsigned) { inlineOnly() }
 
-        doc { "Accumulates value starting with last ${f.element} and applying [operation] from right to left to each ${f.element} and current accumulator value." }
+        doc {
+            """
+            Accumulates value starting with last ${f.element} and applying [operation] from right to left to each ${f.element} and current accumulator value.
+            @throws UnsupportedOperationException if the ${f.collection} is empty.
+            """
+        }
         returns("T")
         body {
             """
@@ -867,7 +886,12 @@ object Aggregates : TemplateGroupBase() {
         include(Lists, ArraysOfObjects)
     } builder {
         inline()
-        doc { "Accumulates value starting with last ${f.element} and applying [operation] from right to left to each ${f.element} and current accumulator value." }
+        doc {
+            """
+            Accumulates value starting with last ${f.element} and applying [operation] from right to left to each ${f.element} and current accumulator value.
+            @throws UnsupportedOperationException if the ${f.collection} is empty.
+            """
+        }
         typeParam("S")
         typeParam("T : S")
         returns("S")


### PR DESCRIPTION
At present the behavior of the `reduce` method when called on an empty argument is undocumented. I added the info that an `UnsupportedOperationException` is thrown.