### PR TITLE
KT-32447 Add warning + quickfix to replace 'map() - toMap()' with 'associate()' function

### DIFF
--- a/idea/testData/inspectionsLocal/collections/simplifiableCallChain/mapToMap.kt
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCallChain/mapToMap.kt
@@ -1,0 +1,8 @@
+// FIX: Merge call chain to 'associate'
+// WITH_RUNTIME
+fun getKey(i: Int): Long = 1L
+fun getValue(i: Int): String = ""
+
+fun test(list: List<Int>) {
+    val map: Map<Long, String> = list.<caret>map { getKey(it) to getValue(it) }.toMap()
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCallChain/mapToMap.kt.after
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCallChain/mapToMap.kt.after
@@ -1,0 +1,8 @@
+// FIX: Merge call chain to 'associate'
+// WITH_RUNTIME
+fun getKey(i: Int): Long = 1L
+fun getValue(i: Int): String = ""
+
+fun test(list: List<Int>) {
+    val map: Map<Long, String> = list.associate { getKey(it) to getValue(it) }
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCallChain/mapToMap2.kt
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCallChain/mapToMap2.kt
@@ -1,0 +1,7 @@
+// FIX: Merge call chain to 'associateBy'
+// WITH_RUNTIME
+fun getKey(i: Int): Long = 1L
+
+fun test(list: List<Int>) {
+    val map: Map<Long, Int> = list.<caret>map { getKey(it) to it }.toMap()
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCallChain/mapToMap2.kt.after
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCallChain/mapToMap2.kt.after
@@ -1,0 +1,7 @@
+// FIX: Merge call chain to 'associateBy'
+// WITH_RUNTIME
+fun getKey(i: Int): Long = 1L
+
+fun test(list: List<Int>) {
+    val map: Map<Long, Int> = list.associateBy { getKey(it) }
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCallChain/mapToMap3.kt
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCallChain/mapToMap3.kt
@@ -1,0 +1,7 @@
+// FIX: Merge call chain to 'associateWith'
+// WITH_RUNTIME
+fun getValue(i: Int): String = ""
+
+fun test(list: List<Int>) {
+    val map: Map<Int, String> = list.<caret>map { it to getValue(it) }.toMap()
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCallChain/mapToMap3.kt.after
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCallChain/mapToMap3.kt.after
@@ -1,0 +1,7 @@
+// FIX: Merge call chain to 'associateWith'
+// WITH_RUNTIME
+fun getValue(i: Int): String = ""
+
+fun test(list: List<Int>) {
+    val map: Map<Int, String> = list.associateWith { getValue(it) }
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCallChain/mapToMap4.kt
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCallChain/mapToMap4.kt
@@ -1,0 +1,11 @@
+// FIX: Merge call chain to 'associateWith'
+// WITH_RUNTIME
+fun foo() {}
+
+fun test(list: List<Int>) {
+    val map: Map<Int, Int> = list.<caret>map {
+        foo()
+        foo()
+        it to it
+    }.toMap()
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCallChain/mapToMap4.kt.after
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCallChain/mapToMap4.kt.after
@@ -1,0 +1,11 @@
+// FIX: Merge call chain to 'associateWith'
+// WITH_RUNTIME
+fun foo() {}
+
+fun test(list: List<Int>) {
+    val map: Map<Int, Int> = list.associateWith {
+        foo()
+        foo()
+        it
+    }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -1932,6 +1932,26 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
                 runTest("idea/testData/inspectionsLocal/collections/simplifiableCallChain/mapNotNullWithSuspendFunctionCall.kt");
             }
 
+            @TestMetadata("mapToMap.kt")
+            public void testMapToMap() throws Exception {
+                runTest("idea/testData/inspectionsLocal/collections/simplifiableCallChain/mapToMap.kt");
+            }
+
+            @TestMetadata("mapToMap2.kt")
+            public void testMapToMap2() throws Exception {
+                runTest("idea/testData/inspectionsLocal/collections/simplifiableCallChain/mapToMap2.kt");
+            }
+
+            @TestMetadata("mapToMap3.kt")
+            public void testMapToMap3() throws Exception {
+                runTest("idea/testData/inspectionsLocal/collections/simplifiableCallChain/mapToMap3.kt");
+            }
+
+            @TestMetadata("mapToMap4.kt")
+            public void testMapToMap4() throws Exception {
+                runTest("idea/testData/inspectionsLocal/collections/simplifiableCallChain/mapToMap4.kt");
+            }
+
             @TestMetadata("mapWithReturn.kt")
             public void testMapWithReturn() throws Exception {
                 runTest("idea/testData/inspectionsLocal/collections/simplifiableCallChain/mapWithReturn.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-32447