### PR TITLE
KT-35320 False positive "Replace explicit parameter 'x' with 'it'" in 'when' expression which returns lambda

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/intentions/ReplaceExplicitFunctionLiteralParamWithItIntention.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/ReplaceExplicitFunctionLiteralParamWithItIntention.kt
@@ -33,6 +33,9 @@ import org.jetbrains.kotlin.idea.core.copied
 import org.jetbrains.kotlin.idea.references.resolveMainReferenceToDescriptors
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.*
+import org.jetbrains.kotlin.psi.psiUtil.anyDescendantOfType
+import org.jetbrains.kotlin.psi.psiUtil.endOffset
+import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
 import org.jetbrains.kotlin.resolve.DescriptorToSourceUtils
 import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
 import org.jetbrains.kotlin.resolve.lazy.BodyResolveMode
@@ -53,6 +56,8 @@ class ReplaceExplicitFunctionLiteralParamWithItIntention : PsiElementBaseIntenti
             }) return false
 
         val lambda = functionLiteral.parent as? KtLambdaExpression ?: return false
+        val lambdaParent = lambda.parent
+        if (lambdaParent is KtWhenEntry || lambdaParent is KtContainerNodeForControlStructureBody) return false
         val call = lambda.getStrictParentOfType<KtCallExpression>()
         if (call != null) {
             val argumentIndex = call.valueArguments.indexOfFirst { it.getArgumentExpression() == lambda }

--- a/idea/testData/intentions/replaceExplicitFunctionLiteralParamWithIt/applicable_InIf.kt
+++ b/idea/testData/intentions/replaceExplicitFunctionLiteralParamWithIt/applicable_InIf.kt
@@ -1,0 +1,4 @@
+fun test(i: Int) {
+    val p: (String) -> Boolean =
+        if (i == 1) { { <caret>s -> true } } else { { s -> false } }
+}

--- a/idea/testData/intentions/replaceExplicitFunctionLiteralParamWithIt/applicable_InIf.kt.after
+++ b/idea/testData/intentions/replaceExplicitFunctionLiteralParamWithIt/applicable_InIf.kt.after
@@ -1,0 +1,4 @@
+fun test(i: Int) {
+    val p: (String) -> Boolean =
+        if (i == 1) { { true } } else { { s -> false } }
+}

--- a/idea/testData/intentions/replaceExplicitFunctionLiteralParamWithIt/applicable_InIfElse.kt
+++ b/idea/testData/intentions/replaceExplicitFunctionLiteralParamWithIt/applicable_InIfElse.kt
@@ -1,0 +1,4 @@
+fun test(i: Int) {
+    val p: (String) -> Boolean =
+        if (i == 1) { { s -> true } } else { { <caret>s -> false } }
+}

--- a/idea/testData/intentions/replaceExplicitFunctionLiteralParamWithIt/applicable_InIfElse.kt.after
+++ b/idea/testData/intentions/replaceExplicitFunctionLiteralParamWithIt/applicable_InIfElse.kt.after
@@ -1,0 +1,4 @@
+fun test(i: Int) {
+    val p: (String) -> Boolean =
+        if (i == 1) { { s -> true } } else { { false } }
+}

--- a/idea/testData/intentions/replaceExplicitFunctionLiteralParamWithIt/applicable_inWhenEntry.kt
+++ b/idea/testData/intentions/replaceExplicitFunctionLiteralParamWithIt/applicable_inWhenEntry.kt
@@ -1,0 +1,9 @@
+fun test(v: Boolean): (String) -> Int {
+    return when (v) {
+        true -> { { <caret>x -> taskOne(x) } }
+        false -> { x -> taskTwo(x) }
+    }
+}
+
+fun taskOne(s: String) = s.length
+fun taskTwo(s: String) = 42

--- a/idea/testData/intentions/replaceExplicitFunctionLiteralParamWithIt/applicable_inWhenEntry.kt.after
+++ b/idea/testData/intentions/replaceExplicitFunctionLiteralParamWithIt/applicable_inWhenEntry.kt.after
@@ -1,0 +1,9 @@
+fun test(v: Boolean): (String) -> Int {
+    return when (v) {
+        true -> { { taskOne(it) } }
+        false -> { x -> taskTwo(x) }
+    }
+}
+
+fun taskOne(s: String) = s.length
+fun taskTwo(s: String) = 42

--- a/idea/testData/intentions/replaceExplicitFunctionLiteralParamWithIt/notApplicable_InIf.kt
+++ b/idea/testData/intentions/replaceExplicitFunctionLiteralParamWithIt/notApplicable_InIf.kt
@@ -1,0 +1,5 @@
+// IS_APPLICABLE: false
+fun test(i: Int) {
+    val p: (String) -> Boolean =
+        if (i == 1) { <caret>s -> true } else { s -> false }
+}

--- a/idea/testData/intentions/replaceExplicitFunctionLiteralParamWithIt/notApplicable_InIfElse.kt
+++ b/idea/testData/intentions/replaceExplicitFunctionLiteralParamWithIt/notApplicable_InIfElse.kt
@@ -1,0 +1,5 @@
+// IS_APPLICABLE: false
+fun test(i: Int) {
+    val p: (String) -> Boolean =
+        if (i == 1) { s -> true } else { <caret>s -> false }
+}

--- a/idea/testData/intentions/replaceExplicitFunctionLiteralParamWithIt/notApplicable_inWhenEntry.kt
+++ b/idea/testData/intentions/replaceExplicitFunctionLiteralParamWithIt/notApplicable_inWhenEntry.kt
@@ -1,0 +1,10 @@
+// IS_APPLICABLE: false
+fun test(v: Boolean): (String) -> Int {
+    return when (v) {
+        true -> { { x -> taskOne(x) } }
+        false -> { <caret>x -> taskTwo(x) }
+    }
+}
+
+fun taskOne(s: String) = s.length
+fun taskTwo(s: String) = 42

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -14629,6 +14629,16 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
             KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("idea/testData/intentions/replaceExplicitFunctionLiteralParamWithIt"), Pattern.compile("^([\\w\\-_]+)\\.(kt|kts)$"), null, true);
         }
 
+        @TestMetadata("applicable_InIf.kt")
+        public void testApplicable_InIf() throws Exception {
+            runTest("idea/testData/intentions/replaceExplicitFunctionLiteralParamWithIt/applicable_InIf.kt");
+        }
+
+        @TestMetadata("applicable_InIfElse.kt")
+        public void testApplicable_InIfElse() throws Exception {
+            runTest("idea/testData/intentions/replaceExplicitFunctionLiteralParamWithIt/applicable_InIfElse.kt");
+        }
+
         @TestMetadata("applicable_cursofOverParamInInnerLiteral.kt")
         public void testApplicable_cursofOverParamInInnerLiteral() throws Exception {
             runTest("idea/testData/intentions/replaceExplicitFunctionLiteralParamWithIt/applicable_cursofOverParamInInnerLiteral.kt");
@@ -14654,6 +14664,11 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
             runTest("idea/testData/intentions/replaceExplicitFunctionLiteralParamWithIt/applicable_inPropertyInitializer.kt");
         }
 
+        @TestMetadata("applicable_inWhenEntry.kt")
+        public void testApplicable_inWhenEntry() throws Exception {
+            runTest("idea/testData/intentions/replaceExplicitFunctionLiteralParamWithIt/applicable_inWhenEntry.kt");
+        }
+
         @TestMetadata("applicable_nestedLiteralsNoUseInside.kt")
         public void testApplicable_nestedLiteralsNoUseInside() throws Exception {
             runTest("idea/testData/intentions/replaceExplicitFunctionLiteralParamWithIt/applicable_nestedLiteralsNoUseInside.kt");
@@ -14662,6 +14677,16 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
         @TestMetadata("applicable_qualifiedExpression.kt")
         public void testApplicable_qualifiedExpression() throws Exception {
             runTest("idea/testData/intentions/replaceExplicitFunctionLiteralParamWithIt/applicable_qualifiedExpression.kt");
+        }
+
+        @TestMetadata("notApplicable_InIf.kt")
+        public void testNotApplicable_InIf() throws Exception {
+            runTest("idea/testData/intentions/replaceExplicitFunctionLiteralParamWithIt/notApplicable_InIf.kt");
+        }
+
+        @TestMetadata("notApplicable_InIfElse.kt")
+        public void testNotApplicable_InIfElse() throws Exception {
+            runTest("idea/testData/intentions/replaceExplicitFunctionLiteralParamWithIt/notApplicable_InIfElse.kt");
         }
 
         @TestMetadata("notApplicable_alreadyUsesImplicitIt.kt")
@@ -14677,6 +14702,11 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
         @TestMetadata("notApplicable_hasMultipleParameters.kt")
         public void testNotApplicable_hasMultipleParameters() throws Exception {
             runTest("idea/testData/intentions/replaceExplicitFunctionLiteralParamWithIt/notApplicable_hasMultipleParameters.kt");
+        }
+
+        @TestMetadata("notApplicable_inWhenEntry.kt")
+        public void testNotApplicable_inWhenEntry() throws Exception {
+            runTest("idea/testData/intentions/replaceExplicitFunctionLiteralParamWithIt/notApplicable_inWhenEntry.kt");
         }
 
         @TestMetadata("notApplicable_itFromOuterLambda.kt")


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-35320