### PR TITLE
KT-20357: Add sample for reduce, reduceRight and counterparts

### DIFF
--- a/libraries/stdlib/common/src/generated/_Arrays.kt
+++ b/libraries/stdlib/common/src/generated/_Arrays.kt
@@ -12436,6 +12436,8 @@ public inline fun CharArray.none(predicate: (Char) -> Boolean): Boolean {
 
 /**
  * Accumulates value starting with the first element and applying [operation] from left to right to current accumulator value and each element.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduce
  */
 public inline fun <S, T : S> Array<out T>.reduce(operation: (acc: S, T) -> S): S {
     if (isEmpty())
@@ -12449,6 +12451,8 @@ public inline fun <S, T : S> Array<out T>.reduce(operation: (acc: S, T) -> S): S
 
 /**
  * Accumulates value starting with the first element and applying [operation] from left to right to current accumulator value and each element.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduce
  */
 public inline fun ByteArray.reduce(operation: (acc: Byte, Byte) -> Byte): Byte {
     if (isEmpty())
@@ -12462,6 +12466,8 @@ public inline fun ByteArray.reduce(operation: (acc: Byte, Byte) -> Byte): Byte {
 
 /**
  * Accumulates value starting with the first element and applying [operation] from left to right to current accumulator value and each element.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduce
  */
 public inline fun ShortArray.reduce(operation: (acc: Short, Short) -> Short): Short {
     if (isEmpty())
@@ -12475,6 +12481,8 @@ public inline fun ShortArray.reduce(operation: (acc: Short, Short) -> Short): Sh
 
 /**
  * Accumulates value starting with the first element and applying [operation] from left to right to current accumulator value and each element.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduce
  */
 public inline fun IntArray.reduce(operation: (acc: Int, Int) -> Int): Int {
     if (isEmpty())
@@ -12488,6 +12496,8 @@ public inline fun IntArray.reduce(operation: (acc: Int, Int) -> Int): Int {
 
 /**
  * Accumulates value starting with the first element and applying [operation] from left to right to current accumulator value and each element.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduce
  */
 public inline fun LongArray.reduce(operation: (acc: Long, Long) -> Long): Long {
     if (isEmpty())
@@ -12501,6 +12511,8 @@ public inline fun LongArray.reduce(operation: (acc: Long, Long) -> Long): Long {
 
 /**
  * Accumulates value starting with the first element and applying [operation] from left to right to current accumulator value and each element.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduce
  */
 public inline fun FloatArray.reduce(operation: (acc: Float, Float) -> Float): Float {
     if (isEmpty())
@@ -12514,6 +12526,8 @@ public inline fun FloatArray.reduce(operation: (acc: Float, Float) -> Float): Fl
 
 /**
  * Accumulates value starting with the first element and applying [operation] from left to right to current accumulator value and each element.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduce
  */
 public inline fun DoubleArray.reduce(operation: (acc: Double, Double) -> Double): Double {
     if (isEmpty())
@@ -12527,6 +12541,8 @@ public inline fun DoubleArray.reduce(operation: (acc: Double, Double) -> Double)
 
 /**
  * Accumulates value starting with the first element and applying [operation] from left to right to current accumulator value and each element.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduce
  */
 public inline fun BooleanArray.reduce(operation: (acc: Boolean, Boolean) -> Boolean): Boolean {
     if (isEmpty())
@@ -12540,6 +12556,8 @@ public inline fun BooleanArray.reduce(operation: (acc: Boolean, Boolean) -> Bool
 
 /**
  * Accumulates value starting with the first element and applying [operation] from left to right to current accumulator value and each element.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduce
  */
 public inline fun CharArray.reduce(operation: (acc: Char, Char) -> Char): Char {
     if (isEmpty())
@@ -12556,6 +12574,8 @@ public inline fun CharArray.reduce(operation: (acc: Char, Char) -> Char): Char {
  * to current accumulator value and each element with its index in the original array.
  * @param [operation] function that takes the index of an element, current accumulator value
  * and the element itself and calculates the next accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduce
  */
 public inline fun <S, T : S> Array<out T>.reduceIndexed(operation: (index: Int, acc: S, T) -> S): S {
     if (isEmpty())
@@ -12572,6 +12592,8 @@ public inline fun <S, T : S> Array<out T>.reduceIndexed(operation: (index: Int, 
  * to current accumulator value and each element with its index in the original array.
  * @param [operation] function that takes the index of an element, current accumulator value
  * and the element itself and calculates the next accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduce
  */
 public inline fun ByteArray.reduceIndexed(operation: (index: Int, acc: Byte, Byte) -> Byte): Byte {
     if (isEmpty())
@@ -12588,6 +12610,8 @@ public inline fun ByteArray.reduceIndexed(operation: (index: Int, acc: Byte, Byt
  * to current accumulator value and each element with its index in the original array.
  * @param [operation] function that takes the index of an element, current accumulator value
  * and the element itself and calculates the next accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduce
  */
 public inline fun ShortArray.reduceIndexed(operation: (index: Int, acc: Short, Short) -> Short): Short {
     if (isEmpty())
@@ -12604,6 +12628,8 @@ public inline fun ShortArray.reduceIndexed(operation: (index: Int, acc: Short, S
  * to current accumulator value and each element with its index in the original array.
  * @param [operation] function that takes the index of an element, current accumulator value
  * and the element itself and calculates the next accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduce
  */
 public inline fun IntArray.reduceIndexed(operation: (index: Int, acc: Int, Int) -> Int): Int {
     if (isEmpty())
@@ -12620,6 +12646,8 @@ public inline fun IntArray.reduceIndexed(operation: (index: Int, acc: Int, Int) 
  * to current accumulator value and each element with its index in the original array.
  * @param [operation] function that takes the index of an element, current accumulator value
  * and the element itself and calculates the next accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduce
  */
 public inline fun LongArray.reduceIndexed(operation: (index: Int, acc: Long, Long) -> Long): Long {
     if (isEmpty())
@@ -12636,6 +12664,8 @@ public inline fun LongArray.reduceIndexed(operation: (index: Int, acc: Long, Lon
  * to current accumulator value and each element with its index in the original array.
  * @param [operation] function that takes the index of an element, current accumulator value
  * and the element itself and calculates the next accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduce
  */
 public inline fun FloatArray.reduceIndexed(operation: (index: Int, acc: Float, Float) -> Float): Float {
     if (isEmpty())
@@ -12652,6 +12682,8 @@ public inline fun FloatArray.reduceIndexed(operation: (index: Int, acc: Float, F
  * to current accumulator value and each element with its index in the original array.
  * @param [operation] function that takes the index of an element, current accumulator value
  * and the element itself and calculates the next accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduce
  */
 public inline fun DoubleArray.reduceIndexed(operation: (index: Int, acc: Double, Double) -> Double): Double {
     if (isEmpty())
@@ -12668,6 +12700,8 @@ public inline fun DoubleArray.reduceIndexed(operation: (index: Int, acc: Double,
  * to current accumulator value and each element with its index in the original array.
  * @param [operation] function that takes the index of an element, current accumulator value
  * and the element itself and calculates the next accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduce
  */
 public inline fun BooleanArray.reduceIndexed(operation: (index: Int, acc: Boolean, Boolean) -> Boolean): Boolean {
     if (isEmpty())
@@ -12684,6 +12718,8 @@ public inline fun BooleanArray.reduceIndexed(operation: (index: Int, acc: Boolea
  * to current accumulator value and each element with its index in the original array.
  * @param [operation] function that takes the index of an element, current accumulator value
  * and the element itself and calculates the next accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduce
  */
 public inline fun CharArray.reduceIndexed(operation: (index: Int, acc: Char, Char) -> Char): Char {
     if (isEmpty())
@@ -12697,6 +12733,8 @@ public inline fun CharArray.reduceIndexed(operation: (index: Int, acc: Char, Cha
 
 /**
  * Accumulates value starting with last element and applying [operation] from right to left to each element and current accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduceRight
  */
 public inline fun <S, T : S> Array<out T>.reduceRight(operation: (T, acc: S) -> S): S {
     var index = lastIndex
@@ -12710,6 +12748,8 @@ public inline fun <S, T : S> Array<out T>.reduceRight(operation: (T, acc: S) -> 
 
 /**
  * Accumulates value starting with last element and applying [operation] from right to left to each element and current accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduceRight
  */
 public inline fun ByteArray.reduceRight(operation: (Byte, acc: Byte) -> Byte): Byte {
     var index = lastIndex
@@ -12723,6 +12763,8 @@ public inline fun ByteArray.reduceRight(operation: (Byte, acc: Byte) -> Byte): B
 
 /**
  * Accumulates value starting with last element and applying [operation] from right to left to each element and current accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduceRight
  */
 public inline fun ShortArray.reduceRight(operation: (Short, acc: Short) -> Short): Short {
     var index = lastIndex
@@ -12736,6 +12778,8 @@ public inline fun ShortArray.reduceRight(operation: (Short, acc: Short) -> Short
 
 /**
  * Accumulates value starting with last element and applying [operation] from right to left to each element and current accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduceRight
  */
 public inline fun IntArray.reduceRight(operation: (Int, acc: Int) -> Int): Int {
     var index = lastIndex
@@ -12749,6 +12793,8 @@ public inline fun IntArray.reduceRight(operation: (Int, acc: Int) -> Int): Int {
 
 /**
  * Accumulates value starting with last element and applying [operation] from right to left to each element and current accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduceRight
  */
 public inline fun LongArray.reduceRight(operation: (Long, acc: Long) -> Long): Long {
     var index = lastIndex
@@ -12762,6 +12808,8 @@ public inline fun LongArray.reduceRight(operation: (Long, acc: Long) -> Long): L
 
 /**
  * Accumulates value starting with last element and applying [operation] from right to left to each element and current accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduceRight
  */
 public inline fun FloatArray.reduceRight(operation: (Float, acc: Float) -> Float): Float {
     var index = lastIndex
@@ -12775,6 +12823,8 @@ public inline fun FloatArray.reduceRight(operation: (Float, acc: Float) -> Float
 
 /**
  * Accumulates value starting with last element and applying [operation] from right to left to each element and current accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduceRight
  */
 public inline fun DoubleArray.reduceRight(operation: (Double, acc: Double) -> Double): Double {
     var index = lastIndex
@@ -12788,6 +12838,8 @@ public inline fun DoubleArray.reduceRight(operation: (Double, acc: Double) -> Do
 
 /**
  * Accumulates value starting with last element and applying [operation] from right to left to each element and current accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduceRight
  */
 public inline fun BooleanArray.reduceRight(operation: (Boolean, acc: Boolean) -> Boolean): Boolean {
     var index = lastIndex
@@ -12801,6 +12853,8 @@ public inline fun BooleanArray.reduceRight(operation: (Boolean, acc: Boolean) ->
 
 /**
  * Accumulates value starting with last element and applying [operation] from right to left to each element and current accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduceRight
  */
 public inline fun CharArray.reduceRight(operation: (Char, acc: Char) -> Char): Char {
     var index = lastIndex
@@ -12817,6 +12871,8 @@ public inline fun CharArray.reduceRight(operation: (Char, acc: Char) -> Char): C
  * to each element with its index in the original array and current accumulator value.
  * @param [operation] function that takes the index of an element, the element itself
  * and current accumulator value, and calculates the next accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduceRight
  */
 public inline fun <S, T : S> Array<out T>.reduceRightIndexed(operation: (index: Int, T, acc: S) -> S): S {
     var index = lastIndex
@@ -12834,6 +12890,8 @@ public inline fun <S, T : S> Array<out T>.reduceRightIndexed(operation: (index: 
  * to each element with its index in the original array and current accumulator value.
  * @param [operation] function that takes the index of an element, the element itself
  * and current accumulator value, and calculates the next accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduceRight
  */
 public inline fun ByteArray.reduceRightIndexed(operation: (index: Int, Byte, acc: Byte) -> Byte): Byte {
     var index = lastIndex
@@ -12851,6 +12909,8 @@ public inline fun ByteArray.reduceRightIndexed(operation: (index: Int, Byte, acc
  * to each element with its index in the original array and current accumulator value.
  * @param [operation] function that takes the index of an element, the element itself
  * and current accumulator value, and calculates the next accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduceRight
  */
 public inline fun ShortArray.reduceRightIndexed(operation: (index: Int, Short, acc: Short) -> Short): Short {
     var index = lastIndex
@@ -12868,6 +12928,8 @@ public inline fun ShortArray.reduceRightIndexed(operation: (index: Int, Short, a
  * to each element with its index in the original array and current accumulator value.
  * @param [operation] function that takes the index of an element, the element itself
  * and current accumulator value, and calculates the next accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduceRight
  */
 public inline fun IntArray.reduceRightIndexed(operation: (index: Int, Int, acc: Int) -> Int): Int {
     var index = lastIndex
@@ -12885,6 +12947,8 @@ public inline fun IntArray.reduceRightIndexed(operation: (index: Int, Int, acc: 
  * to each element with its index in the original array and current accumulator value.
  * @param [operation] function that takes the index of an element, the element itself
  * and current accumulator value, and calculates the next accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduceRight
  */
 public inline fun LongArray.reduceRightIndexed(operation: (index: Int, Long, acc: Long) -> Long): Long {
     var index = lastIndex
@@ -12902,6 +12966,8 @@ public inline fun LongArray.reduceRightIndexed(operation: (index: Int, Long, acc
  * to each element with its index in the original array and current accumulator value.
  * @param [operation] function that takes the index of an element, the element itself
  * and current accumulator value, and calculates the next accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduceRight
  */
 public inline fun FloatArray.reduceRightIndexed(operation: (index: Int, Float, acc: Float) -> Float): Float {
     var index = lastIndex
@@ -12919,6 +12985,8 @@ public inline fun FloatArray.reduceRightIndexed(operation: (index: Int, Float, a
  * to each element with its index in the original array and current accumulator value.
  * @param [operation] function that takes the index of an element, the element itself
  * and current accumulator value, and calculates the next accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduceRight
  */
 public inline fun DoubleArray.reduceRightIndexed(operation: (index: Int, Double, acc: Double) -> Double): Double {
     var index = lastIndex
@@ -12936,6 +13004,8 @@ public inline fun DoubleArray.reduceRightIndexed(operation: (index: Int, Double,
  * to each element with its index in the original array and current accumulator value.
  * @param [operation] function that takes the index of an element, the element itself
  * and current accumulator value, and calculates the next accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduceRight
  */
 public inline fun BooleanArray.reduceRightIndexed(operation: (index: Int, Boolean, acc: Boolean) -> Boolean): Boolean {
     var index = lastIndex
@@ -12953,6 +13023,8 @@ public inline fun BooleanArray.reduceRightIndexed(operation: (index: Int, Boolea
  * to each element with its index in the original array and current accumulator value.
  * @param [operation] function that takes the index of an element, the element itself
  * and current accumulator value, and calculates the next accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduceRight
  */
 public inline fun CharArray.reduceRightIndexed(operation: (index: Int, Char, acc: Char) -> Char): Char {
     var index = lastIndex

--- a/libraries/stdlib/common/src/generated/_Collections.kt
+++ b/libraries/stdlib/common/src/generated/_Collections.kt
@@ -1834,6 +1834,8 @@ public inline fun <T, C : Iterable<T>> C.onEach(action: (T) -> Unit): C {
 
 /**
  * Accumulates value starting with the first element and applying [operation] from left to right to current accumulator value and each element.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduce
  */
 public inline fun <S, T : S> Iterable<T>.reduce(operation: (acc: S, T) -> S): S {
     val iterator = this.iterator()
@@ -1850,6 +1852,8 @@ public inline fun <S, T : S> Iterable<T>.reduce(operation: (acc: S, T) -> S): S 
  * to current accumulator value and each element with its index in the original collection.
  * @param [operation] function that takes the index of an element, current accumulator value
  * and the element itself and calculates the next accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduce
  */
 public inline fun <S, T : S> Iterable<T>.reduceIndexed(operation: (index: Int, acc: S, T) -> S): S {
     val iterator = this.iterator()
@@ -1864,6 +1868,8 @@ public inline fun <S, T : S> Iterable<T>.reduceIndexed(operation: (index: Int, a
 
 /**
  * Accumulates value starting with last element and applying [operation] from right to left to each element and current accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduceRight
  */
 public inline fun <S, T : S> List<T>.reduceRight(operation: (T, acc: S) -> S): S {
     val iterator = listIterator(size)
@@ -1881,6 +1887,8 @@ public inline fun <S, T : S> List<T>.reduceRight(operation: (T, acc: S) -> S): S
  * to each element with its index in the original list and current accumulator value.
  * @param [operation] function that takes the index of an element, the element itself
  * and current accumulator value, and calculates the next accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduceRight
  */
 public inline fun <S, T : S> List<T>.reduceRightIndexed(operation: (index: Int, T, acc: S) -> S): S {
     val iterator = listIterator(size)

--- a/libraries/stdlib/common/src/generated/_Sequences.kt
+++ b/libraries/stdlib/common/src/generated/_Sequences.kt
@@ -1348,6 +1348,8 @@ public fun <T> Sequence<T>.onEach(action: (T) -> Unit): Sequence<T> {
  * Accumulates value starting with the first element and applying [operation] from left to right to current accumulator value and each element.
  *
  * The operation is _terminal_.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduce
  */
 public inline fun <S, T : S> Sequence<T>.reduce(operation: (acc: S, T) -> S): S {
     val iterator = this.iterator()
@@ -1366,6 +1368,8 @@ public inline fun <S, T : S> Sequence<T>.reduce(operation: (acc: S, T) -> S): S 
  * and the element itself and calculates the next accumulator value.
  *
  * The operation is _terminal_.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduce
  */
 public inline fun <S, T : S> Sequence<T>.reduceIndexed(operation: (index: Int, acc: S, T) -> S): S {
     val iterator = this.iterator()

--- a/libraries/stdlib/common/src/generated/_Strings.kt
+++ b/libraries/stdlib/common/src/generated/_Strings.kt
@@ -1168,6 +1168,8 @@ public inline fun <S : CharSequence> S.onEach(action: (Char) -> Unit): S {
 
 /**
  * Accumulates value starting with the first character and applying [operation] from left to right to current accumulator value and each character.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduce
  */
 public inline fun CharSequence.reduce(operation: (acc: Char, Char) -> Char): Char {
     if (isEmpty())
@@ -1184,6 +1186,8 @@ public inline fun CharSequence.reduce(operation: (acc: Char, Char) -> Char): Cha
  * to current accumulator value and each character with its index in the original char sequence.
  * @param [operation] function that takes the index of a character, current accumulator value
  * and the character itself and calculates the next accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduce
  */
 public inline fun CharSequence.reduceIndexed(operation: (index: Int, acc: Char, Char) -> Char): Char {
     if (isEmpty())
@@ -1197,6 +1201,8 @@ public inline fun CharSequence.reduceIndexed(operation: (index: Int, acc: Char, 
 
 /**
  * Accumulates value starting with last character and applying [operation] from right to left to each character and current accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduceRight
  */
 public inline fun CharSequence.reduceRight(operation: (Char, acc: Char) -> Char): Char {
     var index = lastIndex
@@ -1213,6 +1219,8 @@ public inline fun CharSequence.reduceRight(operation: (Char, acc: Char) -> Char)
  * to each character with its index in the original char sequence and current accumulator value.
  * @param [operation] function that takes the index of a character, the character itself
  * and current accumulator value, and calculates the next accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduceRight
  */
 public inline fun CharSequence.reduceRightIndexed(operation: (index: Int, Char, acc: Char) -> Char): Char {
     var index = lastIndex

--- a/libraries/stdlib/common/src/generated/_UArrays.kt
+++ b/libraries/stdlib/common/src/generated/_UArrays.kt
@@ -5480,6 +5480,8 @@ public inline fun UShortArray.none(predicate: (UShort) -> Boolean): Boolean {
 
 /**
  * Accumulates value starting with the first element and applying [operation] from left to right to current accumulator value and each element.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduce
  */
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes
@@ -5496,6 +5498,8 @@ public inline fun UIntArray.reduce(operation: (acc: UInt, UInt) -> UInt): UInt {
 
 /**
  * Accumulates value starting with the first element and applying [operation] from left to right to current accumulator value and each element.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduce
  */
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes
@@ -5512,6 +5516,8 @@ public inline fun ULongArray.reduce(operation: (acc: ULong, ULong) -> ULong): UL
 
 /**
  * Accumulates value starting with the first element and applying [operation] from left to right to current accumulator value and each element.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduce
  */
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes
@@ -5528,6 +5534,8 @@ public inline fun UByteArray.reduce(operation: (acc: UByte, UByte) -> UByte): UB
 
 /**
  * Accumulates value starting with the first element and applying [operation] from left to right to current accumulator value and each element.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduce
  */
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes
@@ -5547,6 +5555,8 @@ public inline fun UShortArray.reduce(operation: (acc: UShort, UShort) -> UShort)
  * to current accumulator value and each element with its index in the original array.
  * @param [operation] function that takes the index of an element, current accumulator value
  * and the element itself and calculates the next accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduce
  */
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes
@@ -5566,6 +5576,8 @@ public inline fun UIntArray.reduceIndexed(operation: (index: Int, acc: UInt, UIn
  * to current accumulator value and each element with its index in the original array.
  * @param [operation] function that takes the index of an element, current accumulator value
  * and the element itself and calculates the next accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduce
  */
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes
@@ -5585,6 +5597,8 @@ public inline fun ULongArray.reduceIndexed(operation: (index: Int, acc: ULong, U
  * to current accumulator value and each element with its index in the original array.
  * @param [operation] function that takes the index of an element, current accumulator value
  * and the element itself and calculates the next accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduce
  */
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes
@@ -5604,6 +5618,8 @@ public inline fun UByteArray.reduceIndexed(operation: (index: Int, acc: UByte, U
  * to current accumulator value and each element with its index in the original array.
  * @param [operation] function that takes the index of an element, current accumulator value
  * and the element itself and calculates the next accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduce
  */
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes
@@ -5620,6 +5636,8 @@ public inline fun UShortArray.reduceIndexed(operation: (index: Int, acc: UShort,
 
 /**
  * Accumulates value starting with last element and applying [operation] from right to left to each element and current accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduceRight
  */
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes
@@ -5636,6 +5654,8 @@ public inline fun UIntArray.reduceRight(operation: (UInt, acc: UInt) -> UInt): U
 
 /**
  * Accumulates value starting with last element and applying [operation] from right to left to each element and current accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduceRight
  */
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes
@@ -5652,6 +5672,8 @@ public inline fun ULongArray.reduceRight(operation: (ULong, acc: ULong) -> ULong
 
 /**
  * Accumulates value starting with last element and applying [operation] from right to left to each element and current accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduceRight
  */
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes
@@ -5668,6 +5690,8 @@ public inline fun UByteArray.reduceRight(operation: (UByte, acc: UByte) -> UByte
 
 /**
  * Accumulates value starting with last element and applying [operation] from right to left to each element and current accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduceRight
  */
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes
@@ -5687,6 +5711,8 @@ public inline fun UShortArray.reduceRight(operation: (UShort, acc: UShort) -> US
  * to each element with its index in the original array and current accumulator value.
  * @param [operation] function that takes the index of an element, the element itself
  * and current accumulator value, and calculates the next accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduceRight
  */
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes
@@ -5707,6 +5733,8 @@ public inline fun UIntArray.reduceRightIndexed(operation: (index: Int, UInt, acc
  * to each element with its index in the original array and current accumulator value.
  * @param [operation] function that takes the index of an element, the element itself
  * and current accumulator value, and calculates the next accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduceRight
  */
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes
@@ -5727,6 +5755,8 @@ public inline fun ULongArray.reduceRightIndexed(operation: (index: Int, ULong, a
  * to each element with its index in the original array and current accumulator value.
  * @param [operation] function that takes the index of an element, the element itself
  * and current accumulator value, and calculates the next accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduceRight
  */
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes
@@ -5747,6 +5777,8 @@ public inline fun UByteArray.reduceRightIndexed(operation: (index: Int, UByte, a
  * to each element with its index in the original array and current accumulator value.
  * @param [operation] function that takes the index of an element, the element itself
  * and current accumulator value, and calculates the next accumulator value.
+ * 
+ * @sample samples.collections.Collections.Aggregates.reduceRight
  */
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes

--- a/libraries/stdlib/samples/test/samples/collections/collections.kt
+++ b/libraries/stdlib/samples/test/samples/collections/collections.kt
@@ -634,6 +634,28 @@ class Collections {
             val emptyMin = emptyList.minBy { it.length }
             assertPrints(emptyMin, "null")
         }
+
+        @Sample
+        fun reduce() {
+            val strings = listOf("a", "b", "c", "d")
+            assertPrints(strings.reduce { acc, string -> acc + string }, "abcd")
+            assertPrints(strings.reduceIndexed { index, acc, string -> acc + string + index }, "ab1c2d3")
+
+            assertFailsWith<UnsupportedOperationException> {
+                emptyList<Int>().reduce { _, _ -> 0 }
+            }
+        }
+
+        @Sample
+        fun reduceRight() {
+            val strings = listOf("a", "b", "c", "d")
+            assertPrints(strings.reduceRight { string, acc -> acc + string }, "dcba")
+            assertPrints(strings.reduceRightIndexed { index, string, acc -> acc + string + index }, "dc2b1a0")
+
+            assertFailsWith<UnsupportedOperationException> {
+                emptyList<Int>().reduceRight { _, _ -> 0 }
+            }
+        }
     }
 
     class Elements {

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Aggregates.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Aggregates.kt
@@ -659,6 +659,7 @@ object Aggregates : TemplateGroupBase() {
             return accumulator
             """
         }
+        sample("samples.collections.Collections.Aggregates.reduce")
     }
 
     val f_reduceIndexedSuper = fn("reduceIndexed(operation: (index: Int, acc: S, T) -> S)") {
@@ -703,6 +704,7 @@ object Aggregates : TemplateGroupBase() {
             return accumulator
             """
         }
+        sample("samples.collections.Collections.Aggregates.reduce")
     }
 
     val f_reduceRightIndexed = fn("reduceRightIndexed(operation: (index: Int, T, acc: T) -> T)") {
@@ -734,6 +736,7 @@ object Aggregates : TemplateGroupBase() {
             return accumulator
             """
         }
+        sample("samples.collections.Collections.Aggregates.reduceRight")
     }
 
     val f_reduceRightIndexedSuper = fn("reduceRightIndexed(operation: (index: Int, T, acc: S) -> S)") {
@@ -781,6 +784,7 @@ object Aggregates : TemplateGroupBase() {
             return accumulator
             """
         }
+        sample("samples.collections.Collections.Aggregates.reduceRight")
     }
 
     val f_reduce = fn("reduce(operation: (acc: T, T) -> T)") {
@@ -803,6 +807,7 @@ object Aggregates : TemplateGroupBase() {
             return accumulator
             """
         }
+        sample("samples.collections.Collections.Aggregates.reduce")
     }
 
     val f_reduceSuper = fn("reduce(operation: (acc: S, T) -> S)") {
@@ -838,6 +843,7 @@ object Aggregates : TemplateGroupBase() {
             return accumulator
             """
         }
+        sample("samples.collections.Collections.Aggregates.reduce")
     }
 
     val f_reduceRight = fn("reduceRight(operation: (T, acc: T) -> T)") {
@@ -861,6 +867,7 @@ object Aggregates : TemplateGroupBase() {
             return accumulator
             """
         }
+        sample("samples.collections.Collections.Aggregates.reduceRight")
     }
 
     val f_reduceRightSuper = fn("reduceRight(operation: (T, acc: S) -> S)") {
@@ -898,6 +905,7 @@ object Aggregates : TemplateGroupBase() {
             return accumulator
             """
         }
+        sample("samples.collections.Collections.Aggregates.reduceRight")
     }
 
     val f_onEach = fn("onEach(action: (T) -> Unit)") {


### PR DESCRIPTION
This PR adds samples for the `reduce`, `reduceIndexed`, `reduceRight` and `reduceRightIndexed` methods.

The samples also show that an exception is thrown when reduce is applied to an empty collection. This is not documented at present, but this related PR addresses this gap: https://github.com/JetBrains/kotlin/pull/2857