### PR TITLE
JVM_IR: do not do invokeinterface on Object methods

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
@@ -280,6 +280,7 @@ private val jvmFilePhases =
         interfaceDelegationPhase then
         interfaceSuperCallsPhase then
         interfaceDefaultCallsPhase then
+        interfaceObjectCallsPhase then
 
         addContinuationPhase then
 

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/IrUtils.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/IrUtils.kt
@@ -499,20 +499,23 @@ fun irCall(
     call: IrFunctionAccessExpression,
     newFunction: IrFunction,
     receiversAsArguments: Boolean = false,
-    argumentsAsReceivers: Boolean = false
+    argumentsAsReceivers: Boolean = false,
+    newSuperQualifierSymbol: IrClassSymbol? = null
 ): IrCall =
     irCall(
         call,
         newFunction.symbol,
         receiversAsArguments,
-        argumentsAsReceivers
+        argumentsAsReceivers,
+        newSuperQualifierSymbol
     )
 
 fun irCall(
     call: IrFunctionAccessExpression,
     newSymbol: IrFunctionSymbol,
     receiversAsArguments: Boolean = false,
-    argumentsAsReceivers: Boolean = false
+    argumentsAsReceivers: Boolean = false,
+    newSuperQualifierSymbol: IrClassSymbol? = null
 ): IrCall =
     call.run {
         IrCallImpl(
@@ -521,7 +524,8 @@ fun irCall(
             type,
             newSymbol,
             typeArgumentsCount,
-            origin
+            origin,
+            newSuperQualifierSymbol
         ).apply {
             copyTypeAndValueArgumentsFrom(
                 call,

--- a/compiler/testData/codegen/box/super/interfaceHashCode.kt
+++ b/compiler/testData/codegen/box/super/interfaceHashCode.kt
@@ -1,0 +1,8 @@
+// IGNORE_BACKEND_FIR: JVM_IR
+interface I
+class C : I { fun foo() = super<I>.hashCode() }
+
+fun box(): String {
+    C().foo()
+    return "OK"
+}

--- a/compiler/testData/codegen/bytecodeText/hashCode/interfaceHashCode.kt
+++ b/compiler/testData/codegen/bytecodeText/hashCode/interfaceHashCode.kt
@@ -1,0 +1,5 @@
+val x: () -> Unit = {}
+val y = x.hashCode()
+
+// 1 INVOKEVIRTUAL java/lang/Object.hashCode \(\)I
+// 0 INVOKEINTERFACE

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -26717,6 +26717,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             runTest("compiler/testData/codegen/box/super/innerClassQualifiedPropertyAccess.kt");
         }
 
+        @TestMetadata("interfaceHashCode.kt")
+        public void testInterfaceHashCode() throws Exception {
+            runTest("compiler/testData/codegen/box/super/interfaceHashCode.kt");
+        }
+
         @TestMetadata("kt14243.kt")
         public void testKt14243() throws Exception {
             runTest("compiler/testData/codegen/box/super/kt14243.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
@@ -2299,6 +2299,11 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
         public void testHashCode() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/hashCode/hashCode.kt");
         }
+
+        @TestMetadata("interfaceHashCode.kt")
+        public void testInterfaceHashCode() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/hashCode/interfaceHashCode.kt");
+        }
     }
 
     @TestMetadata("compiler/testData/codegen/bytecodeText/ieee754")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -25534,6 +25534,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/super/innerClassQualifiedPropertyAccess.kt");
         }
 
+        @TestMetadata("interfaceHashCode.kt")
+        public void testInterfaceHashCode() throws Exception {
+            runTest("compiler/testData/codegen/box/super/interfaceHashCode.kt");
+        }
+
         @TestMetadata("kt14243.kt")
         public void testKt14243() throws Exception {
             runTest("compiler/testData/codegen/box/super/kt14243.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
@@ -25216,6 +25216,11 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
             runTest("compiler/testData/codegen/box/super/innerClassQualifiedPropertyAccess.kt");
         }
 
+        @TestMetadata("interfaceHashCode.kt")
+        public void testInterfaceHashCode() throws Exception {
+            runTest("compiler/testData/codegen/box/super/interfaceHashCode.kt");
+        }
+
         @TestMetadata("kt14243.kt")
         public void testKt14243() throws Exception {
             runTest("compiler/testData/codegen/box/super/kt14243.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -25216,6 +25216,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             runTest("compiler/testData/codegen/box/super/innerClassQualifiedPropertyAccess.kt");
         }
 
+        @TestMetadata("interfaceHashCode.kt")
+        public void testInterfaceHashCode() throws Exception {
+            runTest("compiler/testData/codegen/box/super/interfaceHashCode.kt");
+        }
+
         @TestMetadata("kt14243.kt")
         public void testKt14243() throws Exception {
             runTest("compiler/testData/codegen/box/super/kt14243.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
@@ -2344,6 +2344,11 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
         public void testHashCode() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/hashCode/hashCode.kt");
         }
+
+        @TestMetadata("interfaceHashCode.kt")
+        public void testInterfaceHashCode() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/hashCode/interfaceHashCode.kt");
+        }
     }
 
     @TestMetadata("compiler/testData/codegen/bytecodeText/ieee754")

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -20742,6 +20742,11 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/super/innerClassQualifiedPropertyAccess.kt");
         }
 
+        @TestMetadata("interfaceHashCode.kt")
+        public void testInterfaceHashCode() throws Exception {
+            runTest("compiler/testData/codegen/box/super/interfaceHashCode.kt");
+        }
+
         @TestMetadata("kt14243.kt")
         public void testKt14243() throws Exception {
             runTest("compiler/testData/codegen/box/super/kt14243.kt");

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -21877,6 +21877,11 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/super/innerClassQualifiedPropertyAccess.kt");
         }
 
+        @TestMetadata("interfaceHashCode.kt")
+        public void testInterfaceHashCode() throws Exception {
+            runTest("compiler/testData/codegen/box/super/interfaceHashCode.kt");
+        }
+
         @TestMetadata("kt14243.kt")
         public void testKt14243() throws Exception {
             runTest("compiler/testData/codegen/box/super/kt14243.kt");


### PR DESCRIPTION
This works on HotSpot, but might confuse other VMs.