### PR TITLE
Refactoring GradleMultiplatformWizardTests

### DIFF
--- a/idea/idea-gradle/build.gradle.kts
+++ b/idea/idea-gradle/build.gradle.kts
@@ -35,6 +35,8 @@ dependencies {
     testCompile(projectTests(":idea"))
     testCompile(projectTests(":idea:idea-test-framework"))
 
+    testCompile("com.willowtreeapps.assertk:assertk-jvm:0.20")
+
     testCompile(intellijPluginDep("gradle"))
     Platform[193].orHigher {
         testCompile(intellijPluginDep("gradle-java"))

--- a/idea/idea-gradle/tests/org/jetbrains/kotlin/gradle/AbstractGradleMultiplatformWizardTest.kt
+++ b/idea/idea-gradle/tests/org/jetbrains/kotlin/gradle/AbstractGradleMultiplatformWizardTest.kt
@@ -46,6 +46,7 @@ import com.intellij.testFramework.UsefulTestCase
 import com.intellij.util.containers.ContainerUtil
 import com.intellij.util.containers.ContainerUtilRt
 import junit.framework.TestCase
+import org.gradle.api.tasks.testing.TestExecutionException
 import org.jetbrains.kotlin.idea.codeInsight.gradle.ExternalSystemImportingTestCase.LATEST_STABLE_GRADLE_PLUGIN_VERSION
 import org.jetbrains.kotlin.idea.codeInsight.gradle.GradleImportingTestCase
 import org.jetbrains.kotlin.idea.configuration.KotlinGradleAbstractMultiplatformModuleBuilder
@@ -215,7 +216,10 @@ abstract class AbstractGradleMultiplatformWizardTest : ProjectWizardTestCase<Abs
             }
         }
         if (errors.isNotEmpty()) {
-            throw RuntimeException(errors.mapValues { it.component2().stackTrace }.toString())
+            throw TestExecutionException(
+                "${errors.size} runs failed: \n" +
+                        " ${errors.map { "TestClass: ${it.component1()}, ExceptionMessage: ${it.component2().localizedMessage} \n" }}"
+            )
         }
     }
 

--- a/idea/idea-gradle/tests/org/jetbrains/kotlin/gradle/AbstractGradleMultiplatformWizardTest.kt
+++ b/idea/idea-gradle/tests/org/jetbrains/kotlin/gradle/AbstractGradleMultiplatformWizardTest.kt
@@ -105,7 +105,7 @@ abstract class AbstractGradleMultiplatformWizardTest : ProjectWizardTestCase<Abs
         systemSettings.setLinkedProjectsSettings(projects)
     }
 
-    fun KotlinGradleAbstractMultiplatformModuleBuilder.buildProject(): Project =
+    protected fun KotlinGradleAbstractMultiplatformModuleBuilder.buildProject(): Project =
         createProject { step ->
             if (step is ProjectTypeStep) {
                 TestCase.assertTrue(step.setSelectedTemplate("Kotlin", this.presentableName))
@@ -123,7 +123,7 @@ abstract class AbstractGradleMultiplatformWizardTest : ProjectWizardTestCase<Abs
             }
         }
 
-    fun Project.checkGradleConfiguration(metadataInside: Boolean = false, mppPluginInside: Boolean = true) {
+    protected fun Project.checkGradleConfiguration(metadataInside: Boolean = false, mppPluginInside: Boolean = true) {
 
         val modules = ModuleManager.getInstance(this).modules
         assertThat(modules, "modules in project").size().isEqualTo(1)
@@ -240,7 +240,7 @@ abstract class AbstractGradleMultiplatformWizardTest : ProjectWizardTestCase<Abs
         }
     }
 
-    fun Project.runGradleTask(taskName: String) {
+    protected fun Project.runGradleTask(taskName: String) {
         val settings = GradleExecutionSettings(null, null, DistributionType.DEFAULT_WRAPPED, false)
         println("Running project task: $taskName")
         GradleExecutionHelper().execute(this.basePath!!, settings) {
@@ -294,7 +294,7 @@ abstract class AbstractGradleMultiplatformWizardTest : ProjectWizardTestCase<Abs
         val native by lazy { defaultNativeTarget.userTargetName }
     }
 
-    fun Project.checkSource(source: String? = null, addChecks: FileChecker.() -> Unit) {
+    protected fun Project.checkSource(source: String? = null, addChecks: FileChecker.() -> Unit) {
         val checker = FileChecker(this)
         checker.addChecks()
         checker.runChecks(source)
@@ -384,7 +384,7 @@ abstract class AbstractGradleMultiplatformWizardTest : ProjectWizardTestCase<Abs
         }
     }
 
-    fun Project.runGradleTestTasks(addTasks: GradleTestTaskRunner.() -> Unit) {
+    protected fun Project.runGradleTestTasks(addTasks: GradleTestTaskRunner.() -> Unit) {
         GradleTestTaskRunner(this)
             .apply(addTasks)
             .runTasks()
@@ -426,7 +426,7 @@ abstract class AbstractGradleMultiplatformWizardTest : ProjectWizardTestCase<Abs
         }
     }
 
-    fun Project.checkTestResult(gradleTask: String, testResultChecks: (TestResultChecker.() -> Unit) = {}) {
+    protected fun Project.checkTestResult(gradleTask: String, testResultChecks: (TestResultChecker.() -> Unit) = {}) {
         TestResultChecker(this, gradleTask).apply {
             testResultChecks()
         }.runCheck()

--- a/idea/idea-gradle/tests/org/jetbrains/kotlin/gradle/AbstractGradleMultiplatformWizardTest.kt
+++ b/idea/idea-gradle/tests/org/jetbrains/kotlin/gradle/AbstractGradleMultiplatformWizardTest.kt
@@ -450,7 +450,9 @@ abstract class AbstractGradleMultiplatformWizardTest : ProjectWizardTestCase<Abs
                 testClassResults.forEach {
                     assertThat(it.results, "test class results").isNotEmpty()
                     println("Finished ${it.classDisplayName}, testCount: ${it.results.count()}")
-                    it.results.forEach { test -> test.resultType.name == "SUCCESS" }
+                    it.results.forEach { test ->
+                        assertThat(test.resultType.name, test.displayName).isEqualTo("SUCCESS")
+                    }
                 }
             }
         }

--- a/idea/idea-gradle/tests/org/jetbrains/kotlin/gradle/GradleMultiplatformWizardTest.kt
+++ b/idea/idea-gradle/tests/org/jetbrains/kotlin/gradle/GradleMultiplatformWizardTest.kt
@@ -69,6 +69,12 @@ class GradleMultiplatformWizardTest : AbstractGradleMultiplatformWizardTest() {
                 main("$jvmMain/$kotlin/$sample/SampleJvm.kt")
                 test("$jvmTest/$kotlin/$sample/SampleTestsJVM.kt")
             }
+            checkSource {
+                isExist("build.gradle") {
+                    contains(iosMain)
+                    contains(iosTest)
+                }
+            }
             checkGradleConfiguration(metadataInside = true)
             runGradleImport()
             runGradleTests("SampleTests", "SampleTestsJVM")
@@ -111,6 +117,14 @@ class GradleMultiplatformWizardTest : AbstractGradleMultiplatformWizardTest() {
                 main("$nativeMain/$kotlin/$sample/Sample${native.capitalize()}.kt")
                 test("$nativeTest/$kotlin/$sample/SampleTestsNative.kt")
             }
+            checkSource{
+                isExist("build.gradle") {
+                    contains(nativeMain)
+                    contains(nativeTest)
+                    contains(jsMain)
+                    contains(jsTest)
+                }
+            }
             checkGradleConfiguration(metadataInside = true)
             runGradleImport()
             runGradleTests("SampleTests", "SampleTestsJVM")
@@ -141,9 +155,10 @@ class GradleMultiplatformWizardTest : AbstractGradleMultiplatformWizardTest() {
                 main("$jsMain/$kotlin/$sample/SampleJs.kt")
                 test("$jsTest/$kotlin/$sample/SampleTestsJS.kt")
             }
-            checkSource{
-                isExist("build.gradle"){
-                    contains("jsMain")
+            checkSource {
+                isExist("build.gradle") {
+                    contains(jsMain)
+                    contains(jsTest)
                 }
             }
             checkGradleConfiguration()

--- a/idea/idea-gradle/tests/org/jetbrains/kotlin/gradle/GradleMultiplatformWizardTest.kt
+++ b/idea/idea-gradle/tests/org/jetbrains/kotlin/gradle/GradleMultiplatformWizardTest.kt
@@ -143,12 +143,6 @@ class GradleMultiplatformWizardTest : AbstractGradleMultiplatformWizardTest() {
             runGradleImport()
 
             runGradleTestTasks {
-                test("allTests") {
-                    testClassCount = 2
-                }
-            }
-
-            runGradleTestTasks {
                 test("jsBrowserTest") {
                     testClassCount = 2
                 }

--- a/idea/idea-gradle/tests/org/jetbrains/kotlin/gradle/GradleMultiplatformWizardTest.kt
+++ b/idea/idea-gradle/tests/org/jetbrains/kotlin/gradle/GradleMultiplatformWizardTest.kt
@@ -77,11 +77,13 @@ class GradleMultiplatformWizardTest : AbstractGradleMultiplatformWizardTest() {
             }
             checkGradleConfiguration(metadataInside = true)
             runGradleImport()
+
             runGradleTestTasks {
                 test("jvmTest") {
                     testClassCount = 2
                 }
             }
+
             if (HostManager.hostIsMac) {
                 runGradleTestTasks {
                     test("${native}Test") {
@@ -139,6 +141,12 @@ class GradleMultiplatformWizardTest : AbstractGradleMultiplatformWizardTest() {
             }
             checkGradleConfiguration(metadataInside = true)
             runGradleImport()
+
+            runGradleTestTasks {
+                test("allTests") {
+                    testClassCount = 2
+                }
+            }
 
             runGradleTestTasks {
                 test("jsBrowserTest") {

--- a/idea/idea-gradle/tests/org/jetbrains/kotlin/gradle/GradleMultiplatformWizardTest.kt
+++ b/idea/idea-gradle/tests/org/jetbrains/kotlin/gradle/GradleMultiplatformWizardTest.kt
@@ -14,7 +14,6 @@ import org.jetbrains.kotlin.idea.configuration.KotlinGradleWebMultiplatformModul
 import org.jetbrains.kotlin.idea.test.KotlinSdkCreationChecker
 import org.jetbrains.kotlin.konan.target.HostManager
 import org.jetbrains.kotlin.test.JUnit3WithIdeaConfigurationRunner
-import org.jetbrains.kotlin.test.runTest
 import org.junit.runner.RunWith
 
 @RunWith(JUnit3WithIdeaConfigurationRunner::class)
@@ -52,7 +51,7 @@ class GradleMultiplatformWizardTest : AbstractGradleMultiplatformWizardTest() {
             checkSource("iosApp") {
                 sourceSetsSize(3)
             }
-            checkProjectStructure(checkMppPlugin = false)
+            checkGradleConfiguration(mppPluginInside = false)
         }
     }
 
@@ -61,7 +60,16 @@ class GradleMultiplatformWizardTest : AbstractGradleMultiplatformWizardTest() {
         val project = builder.buildProject()
 
         with(project) {
-            checkProjectStructure(metadataInside = true)
+            checkSource("src") {
+                sourceSetsSize(6)
+                common("$commonMain/$kotlin/$sample/Sample.kt")
+                test("$commonTest/$kotlin/$sample/SampleTests.kt")
+                main("$iosMain/$kotlin/$sample/SampleIos.kt")
+                test("$iosTest/$kotlin/$sample/SampleTestsNative.kt")
+                main("$jvmMain/$kotlin/$sample/SampleJvm.kt")
+                test("$jvmTest/$kotlin/$sample/SampleTestsJVM.kt")
+            }
+            checkGradleConfiguration(metadataInside = true)
             runGradleImport()
             runGradleTests("SampleTests", "SampleTestsJVM")
 
@@ -81,7 +89,7 @@ class GradleMultiplatformWizardTest : AbstractGradleMultiplatformWizardTest() {
                 isExist("$nativeMain/$kotlin/$sample/Sample${native.capitalize()}.kt")
                 test("$nativeTest/$kotlin/$sample/SampleTests.kt")
             }
-            checkProjectStructure()
+            checkGradleConfiguration()
             runGradleImport()
             runGradleTask("runReleaseExecutable${native.capitalize()}")
         }
@@ -103,7 +111,7 @@ class GradleMultiplatformWizardTest : AbstractGradleMultiplatformWizardTest() {
                 main("$nativeMain/$kotlin/$sample/Sample${native.capitalize()}.kt")
                 test("$nativeTest/$kotlin/$sample/SampleTestsNative.kt")
             }
-            checkProjectStructure(metadataInside = true)
+            checkGradleConfiguration(metadataInside = true)
             runGradleImport()
             runGradleTests("SampleTests", "SampleTestsJVM")
         }
@@ -120,24 +128,28 @@ class GradleMultiplatformWizardTest : AbstractGradleMultiplatformWizardTest() {
     }
 
     fun testWeb() {
-        runTest {
-            val builder = KotlinGradleWebMultiplatformModuleBuilder()
-            val project = builder.buildProject()
+        val builder = KotlinGradleWebMultiplatformModuleBuilder()
+        val project = builder.buildProject()
 
-            with(project) {
-                checkSource("src") {
-                    sourceSetsSize(6)
-                    common("$commonMain/$kotlin/$sample/Sample.kt")
-                    test("$commonTest/$kotlin/$sample/SampleTests.kt")
-                    main("$jvmMain/$kotlin/$sample/SampleJvm.kt")
-                    test("$jvmTest/$kotlin/$sample/SampleTestsJVM.kt")
-                    main("$jsMain/$kotlin/$sample/SampleJs.kt")
-                    test("$jsTest/$kotlin/$sample/SampleTestsJS.kt")
-                }
-                checkProjectStructure()
-               // runGradleImport()
-               // runGradleTests("SampleTests", "SampleTestsJVM")
+        with(project) {
+            checkSource("src") {
+                sourceSetsSize(6)
+                common("$commonMain/$kotlin/$sample/Sample.kt")
+                test("$commonTest/$kotlin/$sample/SampleTests.kt")
+                main("$jvmMain/$kotlin/$sample/SampleJvm.kt")
+                test("$jvmTest/$kotlin/$sample/SampleTestsJVM.kt")
+                main("$jsMain/$kotlin/$sample/SampleJs.kt")
+                test("$jsTest/$kotlin/$sample/SampleTestsJS.kt")
             }
+            checkSource{
+                isExist("build.gradle"){
+                    contains("jsMain")
+                }
+            }
+            checkGradleConfiguration()
+            /* TODO: return after fix KT-35095
+              runGradleImport()
+              runGradleTests("SampleTests", "SampleTestsJVM")*/
         }
     }
 }

--- a/idea/idea-gradle/tests/org/jetbrains/kotlin/gradle/GradleMultiplatformWizardTest.kt
+++ b/idea/idea-gradle/tests/org/jetbrains/kotlin/gradle/GradleMultiplatformWizardTest.kt
@@ -208,8 +208,16 @@ class GradleMultiplatformWizardTest : AbstractGradleMultiplatformWizardTest() {
             }
             checkGradleConfiguration()
             /*  TODO: return after fix KT-35095
-                 runGradleImport()
-                 runGradleTests("SampleTests", "SampleTestsJVM")*/
+            runGradleImport()
+            runGradleTestTasks {
+                test("jsBrowserTest") {
+                    testClassCount = 2
+                }
+
+                test("jvmTest") {
+                    testClassCount = 2
+                }
+            }*/
         }
     }
 }

--- a/idea/idea-gradle/tests/org/jetbrains/kotlin/gradle/GradleMultiplatformWizardTest.kt
+++ b/idea/idea-gradle/tests/org/jetbrains/kotlin/gradle/GradleMultiplatformWizardTest.kt
@@ -77,10 +77,17 @@ class GradleMultiplatformWizardTest : AbstractGradleMultiplatformWizardTest() {
             }
             checkGradleConfiguration(metadataInside = true)
             runGradleImport()
-            runGradleTests("SampleTests", "SampleTestsJVM")
-
+            runGradleTestTasks {
+                test("jvmTest") {
+                    testClassCount = 2
+                }
+            }
             if (HostManager.hostIsMac) {
-                runGradleTask(builder.nativeTestName)
+                runGradleTestTasks {
+                    test("${native}Test") {
+                        testClassCount = 2
+                    }
+                }
             }
         }
     }
@@ -97,6 +104,11 @@ class GradleMultiplatformWizardTest : AbstractGradleMultiplatformWizardTest() {
             }
             checkGradleConfiguration()
             runGradleImport()
+            runGradleTestTasks {
+                test("${native}Test") {
+                    testClassCount = 2
+                }
+            }
             runGradleTask("runReleaseExecutable${native.capitalize()}")
         }
     }
@@ -117,17 +129,31 @@ class GradleMultiplatformWizardTest : AbstractGradleMultiplatformWizardTest() {
                 main("$nativeMain/$kotlin/$sample/Sample${native.capitalize()}.kt")
                 test("$nativeTest/$kotlin/$sample/SampleTestsNative.kt")
             }
-            checkSource{
+            checkSource {
                 isExist("build.gradle") {
+                    contains("group")
+                    contains("version")
                     contains(nativeMain)
                     contains(nativeTest)
-                    contains(jsMain)
-                    contains(jsTest)
                 }
             }
             checkGradleConfiguration(metadataInside = true)
             runGradleImport()
-            runGradleTests("SampleTests", "SampleTestsJVM")
+
+            runGradleTestTasks {
+                test("jsBrowserTest") {
+                    testClassCount = 2
+                }
+                test("jsNodeTest") {
+                    testClassCount = 2
+                }
+                test("jvmTest") {
+                    testClassCount = 2
+                }
+                test("${native}Test") {
+                    testClassCount = 2
+                }
+            }
         }
     }
 
@@ -137,7 +163,20 @@ class GradleMultiplatformWizardTest : AbstractGradleMultiplatformWizardTest() {
 
         with(project) {
             runGradleImport(useQualifiedModuleNames = true)
-            runGradleTests("SampleTests", "SampleTestsJVM")
+            runGradleTestTasks {
+                test("jsBrowserTest") {
+                    testClassCount = 2
+                }
+                test("jsNodeTest") {
+                    testClassCount = 2
+                }
+                test("jvmTest") {
+                    testClassCount = 2
+                }
+                test("${native}Test") {
+                    testClassCount = 2
+                }
+            }
         }
     }
 
@@ -159,12 +198,16 @@ class GradleMultiplatformWizardTest : AbstractGradleMultiplatformWizardTest() {
                 isExist("build.gradle") {
                     contains(jsMain)
                     contains(jsTest)
+                    contains(jvmMain)
+                    contains(jvmTest)
+                    contains(commonMain)
+                    contains(commonTest)
                 }
             }
             checkGradleConfiguration()
-            /* TODO: return after fix KT-35095
-              runGradleImport()
-              runGradleTests("SampleTests", "SampleTestsJVM")*/
+            /*  TODO: return after fix KT-35095
+                 runGradleImport()
+                 runGradleTests("SampleTests", "SampleTestsJVM")*/
         }
     }
 }

--- a/tests/mute.csv
+++ b/tests/mute.csv
@@ -15,4 +15,3 @@ org.jetbrains.kotlin.idea.completion.test.JvmBasicCompletionTestGenerated.Java.S
 org.jetbrains.kotlin.idea.refactoring.move.MultiModuleMoveTestGenerated.testMoveFromJsModuleToJvmModule_MoveFromJsModuleToJvmModule, KT-34106
 org.jetbrains.kotlin.idea.refactoring.move.MultiModuleMoveTestGenerated.testMoveFromJvmModuleToJsModule_MoveFromJvmModuleToJsModule, KT-34106
 org.jetbrains.kotlin.idea.refactoring.move.MultiModuleMoveTestGenerated.testMoveJdkDependentToJsModule_MoveJdkDependentToJsModule, KT-34106
-org.jetbrains.kotlin.gradle.GradleMultiplatformWizardTest.testWeb, KT-35095


### PR DESCRIPTION
 1) made tests more detalized
 2) fixed current method of tests running in tests
 Now test class runs atomized.
 If test not ran or test not found - throws exception
 3) changed type of running tests from methods to gradle tasks
 4) added FileChecker to checking exists of files
 5) added checking generated files in tests, e.g.
   checkSource("src") {
                    sourceSetsSize(6)
                    common("$commonMain/$kotlin/$sample/Sample.kt")
                    test("$commonTest/$kotlin/$sample/SampleTests.kt")
				  }
    Checks that:
        -"src" has 6 folders
		- $commonMain/$kotlin/$sample/Sample.kt is exists and contains "expect" in content    
		- $commonTest/$kotlin/$sample/SampleTests.kt is exists and contains "@Test"
 6) added AssertK library to detalize asserts
 7) switched on "testWeb" and added checks generated files 
 8) added checks of test-result (check count running tests and successful done tests) 