### PR TITLE
KT-34959 False positive "Redundant overriding method" with different implemented/overridden signatures

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/KotlinRedundantOverrideInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/KotlinRedundantOverrideInspection.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.idea.caches.resolve.analyze
+import org.jetbrains.kotlin.idea.caches.resolve.resolveToCall
 import org.jetbrains.kotlin.idea.caches.resolve.resolveToDescriptorIfAny
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.load.java.JavaVisibilities
@@ -57,8 +58,15 @@ class KotlinRedundantOverrideInspection : AbstractKotlinInspection(), CleanupLoc
             val superCallElement = qualifiedExpression.selectorExpression as? KtCallElement ?: return
             if (!isSameFunctionName(superCallElement, function)) return
             if (!isSameArguments(superCallElement, function)) return
+
             val context = function.analyze()
             val functionDescriptor = context[BindingContext.FUNCTION, function]
+            val functionParams = functionDescriptor?.valueParameters.orEmpty()
+            val superCallFunctionParams = superCallElement.resolveToCall()?.resultingDescriptor?.valueParameters.orEmpty()
+            if (functionParams.size == superCallFunctionParams.size
+                && functionParams.zip(superCallFunctionParams).any { it.first.type != it.second.type }
+            ) return
+
             if (function.hasDerivedProperty(functionDescriptor, context)) return
             val overriddenDescriptors = functionDescriptor?.original?.overriddenDescriptors
             if (overriddenDescriptors?.any { it is JavaMethodDescriptor && it.visibility == JavaVisibilities.PACKAGE_VISIBILITY } == true) return

--- a/idea/testData/inspectionsLocal/redundantOverride/callDifferentSuperMethod2.kt
+++ b/idea/testData/inspectionsLocal/redundantOverride/callDifferentSuperMethod2.kt
@@ -1,0 +1,16 @@
+// PROBLEM: none
+
+interface I {
+    fun foo(parent: String)
+}
+
+open class A {
+    open fun foo(parent: Any) {}
+
+}
+
+class B : A(), I {
+    override <caret>fun foo(parent: String) {
+        super.foo(parent)
+    }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -7452,6 +7452,11 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
             runTest("idea/testData/inspectionsLocal/redundantOverride/callDifferentSuperMethod.kt");
         }
 
+        @TestMetadata("callDifferentSuperMethod2.kt")
+        public void testCallDifferentSuperMethod2() throws Exception {
+            runTest("idea/testData/inspectionsLocal/redundantOverride/callDifferentSuperMethod2.kt");
+        }
+
         @TestMetadata("classAndInterface.kt")
         public void testClassAndInterface() throws Exception {
             runTest("idea/testData/inspectionsLocal/redundantOverride/classAndInterface.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-34959