### PR TITLE
KT-31749 "Surround with null check" produces incorrect check for 'in' expression

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/SurroundWithNullCheckFix.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/SurroundWithNullCheckFix.kt
@@ -24,6 +24,7 @@ import org.jetbrains.kotlin.diagnostics.Diagnostic
 import org.jetbrains.kotlin.diagnostics.Errors
 import org.jetbrains.kotlin.idea.caches.resolve.analyze
 import org.jetbrains.kotlin.idea.intentions.branchedTransformations.isStableSimpleExpression
+import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.createSmartPointer
 import org.jetbrains.kotlin.psi.psiUtil.getLastParentOfTypeInRow
@@ -67,7 +68,7 @@ class SurroundWithNullCheckFix(
             val nullableExpression =
                 when (parent) {
                     is KtDotQualifiedExpression -> parent.receiverExpression
-                    is KtBinaryExpression -> parent.left
+                    is KtBinaryExpression -> if (parent.operationToken == KtTokens.IN_KEYWORD) parent.right else parent.left
                     is KtCallExpression -> parent.calleeExpression
                     else -> return null
                 } as? KtReferenceExpression ?: return null

--- a/idea/testData/quickfix/surroundWithNullCheck/in.kt
+++ b/idea/testData/quickfix/surroundWithNullCheck/in.kt
@@ -1,0 +1,4 @@
+// "Surround with null check" "true"
+fun test(a: String, b: List<String>?) {
+    a <caret>in b
+}

--- a/idea/testData/quickfix/surroundWithNullCheck/in.kt.after
+++ b/idea/testData/quickfix/surroundWithNullCheck/in.kt.after
@@ -1,0 +1,6 @@
+// "Surround with null check" "true"
+fun test(a: String, b: List<String>?) {
+    if (b != null) {
+        a in b
+    }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixMultiFileTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixMultiFileTestGenerated.java
@@ -333,7 +333,7 @@ public class QuickFixMultiFileTestGenerated extends AbstractQuickFixMultiFileTes
         }
 
         public void testAllFilesPresentInAddSpreadOperatorForArrayAsVarargAfterSam() throws Exception {
-            KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/quickfix/addSpreadOperatorForArrayAsVarargAfterSam"), Pattern.compile("^(\\w+)\\.((before\\.Main\\.\\w+)|(test))$"), true);
+            KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("idea/testData/quickfix/addSpreadOperatorForArrayAsVarargAfterSam"), Pattern.compile("^(\\w+)\\.((before\\.Main\\.\\w+)|(test))$"), null, true);
         }
 
         @TestMetadata("withError.test")

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -1183,7 +1183,7 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
         }
 
         public void testAllFilesPresentInAddSpreadOperatorForArrayAsVarargAfterSam() throws Exception {
-            KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/quickfix/addSpreadOperatorForArrayAsVarargAfterSam"), Pattern.compile("^([\\w\\-_]+)\\.kt$"), true);
+            KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("idea/testData/quickfix/addSpreadOperatorForArrayAsVarargAfterSam"), Pattern.compile("^([\\w\\-_]+)\\.kt$"), null, true);
         }
     }
 
@@ -12474,6 +12474,11 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
         @TestMetadata("expressionUnsafeCall.kt")
         public void testExpressionUnsafeCall() throws Exception {
             runTest("idea/testData/quickfix/surroundWithNullCheck/expressionUnsafeCall.kt");
+        }
+
+        @TestMetadata("in.kt")
+        public void testIn() throws Exception {
+            runTest("idea/testData/quickfix/surroundWithNullCheck/in.kt");
         }
 
         @TestMetadata("infixUnsafeCall.kt")


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-31749