### PR TITLE
JVM_IR: make constructors of named local classes public

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
@@ -17,6 +17,8 @@ import org.jetbrains.kotlin.descriptors.Visibility
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.util.PatchDeclarationParentsVisitor
+import org.jetbrains.kotlin.ir.util.isAnonymousObject
+import org.jetbrains.kotlin.ir.util.parentAsClass
 import org.jetbrains.kotlin.ir.visitors.IrElementVisitorVoid
 import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
 import org.jetbrains.kotlin.ir.visitors.acceptVoid
@@ -122,7 +124,10 @@ internal val localDeclarationsPhase = makeIrFilePhase<CommonBackendContext>(
                     }
 
                 override fun forConstructor(declaration: IrConstructor, inInlineFunctionScope: Boolean): Visibility =
-                    scopedVisibility(inInlineFunctionScope)
+                    if (declaration.parentAsClass.isAnonymousObject)
+                        scopedVisibility(inInlineFunctionScope)
+                    else
+                        declaration.visibility
 
                 private fun scopedVisibility(inInlineFunctionScope: Boolean): Visibility =
                     if (inInlineFunctionScope) Visibilities.PUBLIC else JavaVisibilities.PACKAGE_VISIBILITY

--- a/compiler/testData/writeFlags/function/constructors/localClass.kt
+++ b/compiler/testData/writeFlags/function/constructors/localClass.kt
@@ -1,0 +1,9 @@
+class Foo {
+    fun a() {
+        class S
+    }
+}
+
+// TESTED_OBJECT_KIND: function
+// TESTED_OBJECTS: Foo$a$S, <init>
+// FLAGS: ACC_PUBLIC

--- a/compiler/tests/org/jetbrains/kotlin/codegen/flags/WriteFlagsTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/flags/WriteFlagsTestGenerated.java
@@ -477,6 +477,11 @@ public class WriteFlagsTestGenerated extends AbstractWriteFlagsTest {
                 runTest("compiler/testData/writeFlags/function/constructors/enum.kt");
             }
 
+            @TestMetadata("localClass.kt")
+            public void testLocalClass() throws Exception {
+                runTest("compiler/testData/writeFlags/function/constructors/localClass.kt");
+            }
+
             @TestMetadata("objectInClass.kt")
             public void testObjectInClass() throws Exception {
                 runTest("compiler/testData/writeFlags/function/constructors/objectInClass.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrWriteFlagsTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrWriteFlagsTestGenerated.java
@@ -477,6 +477,11 @@ public class IrWriteFlagsTestGenerated extends AbstractIrWriteFlagsTest {
                 runTest("compiler/testData/writeFlags/function/constructors/enum.kt");
             }
 
+            @TestMetadata("localClass.kt")
+            public void testLocalClass() throws Exception {
+                runTest("compiler/testData/writeFlags/function/constructors/localClass.kt");
+            }
+
             @TestMetadata("objectInClass.kt")
             public void testObjectInClass() throws Exception {
                 runTest("compiler/testData/writeFlags/function/constructors/objectInClass.kt");


### PR DESCRIPTION
They are accessible through reflection