### PR TITLE
JVM_IR: Backwards compatible handling of default tailrec params.

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
@@ -223,6 +223,12 @@ private val syntheticAccessorPhase = makeIrFilePhase(
     prerequisite = setOf(objectClassPhase, staticDefaultFunctionPhase, interfacePhase)
 )
 
+private val tailrecPhase = makeIrFilePhase<JvmBackendContext>(
+    ::JvmTailrecLowering,
+    name = "Tailrec",
+    description = "Handle tailrec calls"
+)
+
 @Suppress("Reformat")
 private val jvmFilePhases =
         typeAliasAnnotationMethodsPhase then

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/JvmTailrecLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/JvmTailrecLowering.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.jvm.lower
+
+import org.jetbrains.kotlin.backend.common.lower.TailrecLowering
+import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
+import org.jetbrains.kotlin.config.LanguageFeature
+import org.jetbrains.kotlin.config.languageVersionSettings
+
+class JvmTailrecLowering(context: JvmBackendContext) : TailrecLowering(context) {
+    override fun useProperComputationOrderOfTailrecDefaultParameters(): Boolean =
+        context.ir.context.configuration.languageVersionSettings.supportsFeature(LanguageFeature.ProperComputationOrderOfTailrecDefaultParameters)
+}

--- a/compiler/testData/codegen/box/diagnostics/functions/tailRecursion/defaultArgsWithSideEffectsOld.kt
+++ b/compiler/testData/codegen/box/diagnostics/functions/tailRecursion/defaultArgsWithSideEffectsOld.kt
@@ -1,7 +1,5 @@
 // !LANGUAGE: -ProperComputationOrderOfTailrecDefaultParameters
-// IGNORE_BACKEND_FIR: JVM_IR
 // TARGET_BACKEND: JVM
-// IGNORE_BACKEND: JVM_IR
 
 var counter = 0
 fun calc(counter: Int) = if (counter % 2 == 0) "K" else "O"


### PR DESCRIPTION
Before 1.4 tailrec function default arguments were evaluated
right-to-left instead of left-to-right. This is controlled
by a compile-time flag. This change adds support for the
right-to-left evaluation order when that flag is not set.