### PR TITLE
JVM IR: Fix names of fake local variables for inline arguments

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/ir/IrInlineReferenceLocator.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/ir/IrInlineReferenceLocator.kt
@@ -49,7 +49,7 @@ internal open class IrInlineReferenceLocator(private val context: JvmBackendCont
                 handleInlineFunctionCallableReferenceParam(reference)
                 if (valueArgument is IrBlock && valueArgument.origin.isLambda) {
                     val declaration = if (parameter.isCrossinline) null else currentScope!!.irElement as IrDeclaration
-                    handleInlineFunctionLambdaParam(reference.symbol.owner, function, declaration)
+                    handleInlineFunctionLambdaParam(reference, function, declaration)
                 }
             }
         }
@@ -60,8 +60,8 @@ internal open class IrInlineReferenceLocator(private val context: JvmBackendCont
         inlineReferences.add(valueArgument)
     }
 
-    open fun handleInlineFunctionLambdaParam(lambda: IrFunction, callee: IrFunction, callSite: IrDeclaration?) {
-        lambdaToCallSite[lambda] = callSite
+    open fun handleInlineFunctionLambdaParam(lambdaReference: IrFunctionReference, callee: IrFunction, callSite: IrDeclaration?) {
+        lambdaToCallSite[lambdaReference.symbol.owner] = callSite
     }
 
     companion object {

--- a/compiler/tests-common/tests/org/jetbrains/kotlin/codegen/ir/AbstractIrCheckLocalVariablesTableTest.kt
+++ b/compiler/tests-common/tests/org/jetbrains/kotlin/codegen/ir/AbstractIrCheckLocalVariablesTableTest.kt
@@ -32,11 +32,6 @@ abstract class AbstractIrCheckLocalVariablesTableTest : AbstractCheckLocalVariab
         return list.map { it.toString() }
             // Ignore local index.
             .map { line -> line.replaceFirst("INDEX=\\d+".toRegex(), "INDEX=*") }
-            // Ignore the names of local functions which have integer names in
-            // the current backend and more descriptive names with the JVM_IR
-            // backend.
-            .map { line -> line.replace("\\\$\\d+".toRegex(), "\\\$*") }
-            .map { line -> line.replace("\\\$lambda-\\d+".toRegex(), "\\\$*") }
             .sorted()
     }
 
@@ -45,10 +40,6 @@ abstract class AbstractIrCheckLocalVariablesTableTest : AbstractCheckLocalVariab
             .filter { line -> line.startsWith("// VARIABLE ") }
             // Ignore local index.
             .map { line -> line.replaceFirst("INDEX=\\d+".toRegex(), "INDEX=*") }
-            // Ignore the names of local functions which have integer names in
-            // the current backend and more descriptive names with the JVM_IR
-            // backend.
-            .map { line -> line.replace("\\\$\\d+".toRegex(), "\\\$*") }
             .sorted()
     }
 


### PR DESCRIPTION
The debugger [looks for marker variables](https://github.com/JetBrains/kotlin/blob/0b7c11c96e844488dff632763cd6d64377274b99/idea/jvm-debugger/jvm-debugger-core/src/org/jetbrains/kotlin/idea/debugger/debuggerUtil.kt#L60) of the form `$i$a$-functionName-lambdaClassName` to determine whether we are inside of an inline argument, where `lambdaClassName` is the name which would have been generated for the class implementing the argument lambda.

This PR implements the same naming convention in the IR backend (which is simple, since the work is already done in `InventNamesForLocalClasses`).

Note that the PR doesn't fix any new tests, it just makes some existing tests more strict.