### PR TITLE
KT-35475 Applying intention "Redundant curly braces in string template" for label references change semantic

### DIFF
--- a/idea/idea-core/src/org/jetbrains/kotlin/idea/core/psiModificationUtils.kt
+++ b/idea/idea-core/src/org/jetbrains/kotlin/idea/core/psiModificationUtils.kt
@@ -555,8 +555,11 @@ fun KtModifierList.normalize(): KtModifierList {
     }
 }
 
-fun KtBlockStringTemplateEntry.canDropBraces() =
-    (expression is KtNameReferenceExpression || expression is KtThisExpression) && canPlaceAfterSimpleNameEntry(nextSibling)
+fun KtBlockStringTemplateEntry.canDropBraces(): Boolean {
+    val expression = this.expression
+    return (expression is KtNameReferenceExpression || (expression is KtThisExpression && expression.labelQualifier == null))
+            && canPlaceAfterSimpleNameEntry(nextSibling)
+}
 
 fun KtBlockStringTemplateEntry.dropBraces(): KtSimpleNameStringTemplateEntry {
     val name = if (expression is KtThisExpression) {

--- a/idea/testData/inspectionsLocal/removeCurlyBracesFromTemplate/necessaryBrackets8.kt
+++ b/idea/testData/inspectionsLocal/removeCurlyBracesFromTemplate/necessaryBrackets8.kt
@@ -1,0 +1,12 @@
+// PROBLEM: none
+fun main() {
+    "hello".foo()
+}
+
+fun bar(block: Int.() -> Unit) { block(42) }
+
+fun String.foo() = bar {
+    println("this: <caret>${this@foo}")
+}
+
+fun println(s: String) {}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -8232,6 +8232,11 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
             runTest("idea/testData/inspectionsLocal/removeCurlyBracesFromTemplate/necessaryBrackets7.kt");
         }
 
+        @TestMetadata("necessaryBrackets8.kt")
+        public void testNecessaryBrackets8() throws Exception {
+            runTest("idea/testData/inspectionsLocal/removeCurlyBracesFromTemplate/necessaryBrackets8.kt");
+        }
+
         @TestMetadata("unnecessaryBrackets1.kt")
         public void testUnnecessaryBrackets1() throws Exception {
             runTest("idea/testData/inspectionsLocal/removeCurlyBracesFromTemplate/unnecessaryBrackets1.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-35475