### PR TITLE
KT-35472: Detect when content of annotation processor changes

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/incremental/ClasspathSnapshot.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/incremental/ClasspathSnapshot.kt
@@ -69,6 +69,10 @@ open class ClasspathSnapshot protected constructor(
         if (!isCompatible(previousSnapshot)) {
             return KaptClasspathChanges.Unknown
         }
+        if (annotationProcessorClasspath.any { it in changedFiles }) {
+            // in case annotation processor classpath changes, we have to run non-incrementally
+            return KaptClasspathChanges.Unknown
+        }
 
         val unchangedBetweenCompilations = dataForFiles.keys.intersect(previousSnapshot.dataForFiles.keys).filter { it !in changedFiles }
         val currentToLoad = dataForFiles.keys.filter { it !in unchangedBetweenCompilations }.also { loadEntriesFor(it) }


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-35472

Even if annotation processor classpath is the same, in case
individual entries change (e.g. bulding annotationo processor
from source), KATP should run non-incrementally.

Test: KaptIncrementalWithIsolatingApt.testUnchangedAnnotationProcessorClasspathButContentChanged