### PR TITLE
KT-35525 False positive intention for 'run': "Convert to 'let'" when invoked without receiver

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/ScopeFunctionConversionInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/ScopeFunctionConversionInspection.kt
@@ -79,9 +79,9 @@ private fun getCounterpart(expression: KtCallExpression): String? {
         }
         val bindingContext = callee.analyze(BodyResolveMode.PARTIAL)
         val resolvedCall = callee.getResolvedCall(bindingContext) ?: return null
-        if (resolvedCall.resultingDescriptor.fqNameSafe.asString() == "kotlin.$calleeName" &&
-            nameResolvesToStdlib(expression, bindingContext, counterpartName)
-        ) {
+        val descriptor = resolvedCall.resultingDescriptor
+        if (descriptor.dispatchReceiverParameter == null && descriptor.extensionReceiverParameter == null) return null
+        if (descriptor.fqNameSafe.asString() == "kotlin.$calleeName" && nameResolvesToStdlib(expression, bindingContext, counterpartName)) {
             return counterpartName
         }
     }

--- a/idea/testData/inspectionsLocal/scopeFunctions/runToLet/noReceiver.kt
+++ b/idea/testData/inspectionsLocal/scopeFunctions/runToLet/noReceiver.kt
@@ -1,0 +1,5 @@
+// WITH_RUNTIME
+// PROBLEM: none
+fun hello() {
+    <caret>run { }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -11087,6 +11087,11 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
                 runTest("idea/testData/inspectionsLocal/scopeFunctions/runToLet/capturedIt.kt");
             }
 
+            @TestMetadata("noReceiver.kt")
+            public void testNoReceiver() throws Exception {
+                runTest("idea/testData/inspectionsLocal/scopeFunctions/runToLet/noReceiver.kt");
+            }
+
             @TestMetadata("simple.kt")
             public void testSimple() throws Exception {
                 runTest("idea/testData/inspectionsLocal/scopeFunctions/runToLet/simple.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-35525