### PR TITLE
[JVM IR] ForLoopsLowering: Keep IMPLICIT_NOTNULL type-casts from `next()` and `componentN()` calls

### DIFF
--- a/compiler/testData/codegen/box/ranges/javaInterop/javaArrayOfInheritedNotNull.kt
+++ b/compiler/testData/codegen/box/ranges/javaInterop/javaArrayOfInheritedNotNull.kt
@@ -1,0 +1,30 @@
+// !LANGUAGE: +StrictJavaNullabilityAssertions
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND_FIR: JVM_IR
+// WITH_RUNTIME
+
+// FILE: box.kt
+import kotlin.test.*
+
+fun box(): String {
+    val actualValues = mutableListOf<Int>()
+    for (i in JImpl().arrayOfNotNull()) {
+        actualValues += i
+    }
+    assertEquals(listOf(42, -42), actualValues)
+    return "OK"
+}
+
+interface J {
+    fun arrayOfNotNull(): Array<Int>
+}
+
+// FILE: JImpl.java
+public class JImpl implements J {
+    // The only way to get @EnhancedNullability on the array element type (Int) is to override a Kotlin function that
+    // returns `Array<Int>` (where Int is not nullable). `@NotNull Integer[]` makes the array not nullable, not String.
+    @Override
+    public Integer[] arrayOfNotNull() {
+        return new Integer[] { 42, -42 };
+    }
+}

--- a/compiler/testData/codegen/box/ranges/javaInterop/javaArrayOfInheritedNotNullFailFast.kt
+++ b/compiler/testData/codegen/box/ranges/javaInterop/javaArrayOfInheritedNotNullFailFast.kt
@@ -1,0 +1,42 @@
+// !LANGUAGE: +StrictJavaNullabilityAssertions
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND_FIR: JVM_IR
+// IGNORE_BACKEND: JVM
+// WITH_RUNTIME
+
+// Note: This fails on JVM (non-IR) with "Fail: should throw on get() in loop header". The not-null assertion is not generated when
+// assigning to the loop variable. The root cause seems to be that the loop variable is a KtParameter and
+// CodegenAnnotatingVisitor/RuntimeAssertionsOnDeclarationBodyChecker do not analyze the need for not-null assertions on KtParameters.
+
+// FILE: box.kt
+import kotlin.test.*
+
+fun box(): String {
+    // Sanity check to make sure there IS an exception even when not in a for-loop
+    try {
+        val i = JImpl().arrayOfNotNull()[0]
+        return "Fail: should throw on get()"
+    } catch (e: IllegalStateException) {}
+
+    try {
+        for (i in JImpl().arrayOfNotNull()) {
+            return "Fail: should throw on get() in loop header"
+        }
+    }
+    catch (e: IllegalStateException) {}
+    return "OK"
+}
+
+interface J {
+    fun arrayOfNotNull(): Array<Int>
+}
+
+// FILE: JImpl.java
+public class JImpl implements J {
+    // The only way to get @EnhancedNullability on the array element type (Int) is to override a Kotlin function that
+    // returns `Array<Int>` (where Int is not nullable). `@NotNull Integer[]` makes the array not nullable, not String.
+    @Override
+    public Integer[] arrayOfNotNull() {
+        return new Integer[] { null };
+    }
+}

--- a/compiler/testData/codegen/box/ranges/javaInterop/javaArrayOfMaybeNullable.kt
+++ b/compiler/testData/codegen/box/ranges/javaInterop/javaArrayOfMaybeNullable.kt
@@ -1,0 +1,23 @@
+// !LANGUAGE: +StrictJavaNullabilityAssertions
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND_FIR: JVM_IR
+// WITH_RUNTIME
+
+// FILE: box.kt
+import kotlin.test.*
+
+fun box(): String {
+    val actualValues = mutableListOf<Int>()
+    for (i in J.arrayOfMaybeNullable()) {
+        actualValues += i
+    }
+    assertEquals(listOf(42, null), actualValues)
+    return "OK"
+}
+
+// FILE: J.java
+public class J {
+    public static Integer[] arrayOfMaybeNullable() {
+        return new Integer[] { 42, null };
+    }
+}

--- a/compiler/testData/codegen/box/ranges/javaInterop/javaArrayOfMaybeNullableWithNotNullLoopVariable.kt
+++ b/compiler/testData/codegen/box/ranges/javaInterop/javaArrayOfMaybeNullableWithNotNullLoopVariable.kt
@@ -1,0 +1,23 @@
+// !LANGUAGE: +StrictJavaNullabilityAssertions
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND_FIR: JVM_IR
+// WITH_RUNTIME
+
+// FILE: box.kt
+import kotlin.test.*
+
+fun box(): String {
+    val actualValues = mutableListOf<Int>()
+    for (i: Int in J.arrayOfMaybeNullable()) {
+        actualValues += i
+    }
+    assertEquals(listOf(42, -42), actualValues)
+    return "OK"
+}
+
+// FILE: J.java
+public class J {
+    public static Integer[] arrayOfMaybeNullable() {
+        return new Integer[] { 42, -42 };
+    }
+}

--- a/compiler/testData/codegen/box/ranges/javaInterop/javaArrayOfMaybeNullableWithNotNullLoopVariableFailFast.kt
+++ b/compiler/testData/codegen/box/ranges/javaInterop/javaArrayOfMaybeNullableWithNotNullLoopVariableFailFast.kt
@@ -1,0 +1,36 @@
+// !LANGUAGE: +StrictJavaNullabilityAssertions
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND: JVM
+// IGNORE_BACKEND_FIR: JVM_IR
+// WITH_RUNTIME
+
+// Note: This fails on JVM (non-IR) with a NullPointerException in the loop header. The not-null assertion is not generated when
+// assigning to the loop variable. The root cause seems to be that the loop variable is a KtParameter and
+// CodegenAnnotatingVisitor/RuntimeAssertionsOnDeclarationBodyChecker do not analyze the need for not-null assertions on KtParameters.
+// The NPE is due to calling `intValue()` on the null Int; it is expected to be asserted as non-null first.
+
+// FILE: box.kt
+import kotlin.test.*
+
+fun box(): String {
+    // Sanity check to make sure there IS an exception even when not in a for-loop
+    try {
+        val i: Int = J.arrayOfMaybeNullable()[0]
+        return "Fail: should throw on get()"
+    } catch (e: IllegalStateException) {}
+
+    try {
+        for (i: Int in J.arrayOfMaybeNullable()) {
+            return "Fail: should throw on get() in loop header"
+        }
+    }
+    catch (e: IllegalStateException) {}
+    return "OK"
+}
+
+// FILE: J.java
+public class J {
+    public static Integer[] arrayOfMaybeNullable() {
+        return new Integer[] { null };
+    }
+}

--- a/compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfExplicitNotNull.kt
+++ b/compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfExplicitNotNull.kt
@@ -1,0 +1,42 @@
+// !LANGUAGE: +StrictJavaNullabilityAssertions
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND_FIR: JVM_IR
+// WITH_RUNTIME
+
+// FILE: box.kt
+import kotlin.test.*
+
+fun box(): String {
+    val actualValues = mutableListOf<Int>()
+    for (i in J.listOfNotNull()) {
+        actualValues += i
+    }
+    assertEquals(listOf(42, -42), actualValues)
+    return "OK"
+}
+
+// FILE: J.java
+import java.util.*;
+import org.jetbrains.annotations.*;
+
+public class J {
+    public static List<@NotNull Integer> listOfNotNull() {
+        List<Integer> list = new ArrayList<>();
+        list.add(42);
+        list.add(-42);
+        return list;
+    }
+}
+
+// FILE: NotNull.java
+package org.jetbrains.annotations;
+
+import java.lang.annotation.*;
+
+// org.jetbrains.annotations used in the compiler is version 13, whose @NotNull does not support the TYPE_USE target (version 15 does).
+// We're using our own @org.jetbrains.annotations.NotNull for testing purposes.
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE})
+public @interface NotNull {
+}

--- a/compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfExplicitNotNullFailFast.kt
+++ b/compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfExplicitNotNullFailFast.kt
@@ -1,0 +1,51 @@
+// !LANGUAGE: +StrictJavaNullabilityAssertions
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND: JVM
+// IGNORE_BACKEND_FIR: JVM_IR
+// WITH_RUNTIME
+
+// Note: This fails on JVM (non-IR) with "Fail: should throw on get() in loop header". The not-null assertion is not generated when
+// assigning to the loop variable. The root cause seems to be that the loop variable is a KtParameter and
+// CodegenAnnotatingVisitor/RuntimeAssertionsOnDeclarationBodyChecker do not analyze the need for not-null assertions on KtParameters.
+
+// FILE: box.kt
+import kotlin.test.*
+
+fun box(): String {
+    // Sanity check to make sure there IS an exception even when not in a for-loop
+    try {
+        val i = J.listOfNotNull()[0]
+        return "Fail: should throw on get()"
+    } catch (e: IllegalStateException) {}
+
+    try {
+        for (i in J.listOfNotNull()) {
+            return "Fail: should throw on get() in loop header"
+        }
+    }
+    catch (e: IllegalStateException) {}
+    return "OK"
+}
+
+// FILE: J.java
+import java.util.*;
+import org.jetbrains.annotations.*;
+
+public class J {
+    public static List<@NotNull Integer> listOfNotNull() {
+        return Collections.singletonList(null);
+    }
+}
+
+// FILE: NotNull.java
+package org.jetbrains.annotations;
+
+import java.lang.annotation.*;
+
+// org.jetbrains.annotations used in the compiler is version 13, whose @NotNull does not support the TYPE_USE target (version 15 does).
+// We're using our own @org.jetbrains.annotations.NotNull for testing purposes.
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE})
+public @interface NotNull {
+}

--- a/compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfExplicitNullable.kt
+++ b/compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfExplicitNullable.kt
@@ -1,0 +1,42 @@
+// !LANGUAGE: +StrictJavaNullabilityAssertions
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND_FIR: JVM_IR
+// WITH_RUNTIME
+
+// FILE: box.kt
+import kotlin.test.*
+
+fun box(): String {
+    val actualValues = mutableListOf<Int?>()
+    for (i in J.listOfNullable()) {
+        actualValues += i
+    }
+    assertEquals(listOf(42, null), actualValues)
+    return "OK"
+}
+
+// FILE: J.java
+import java.util.*;
+import org.jetbrains.annotations.*;
+
+public class J {
+    public static List<@Nullable Integer> listOfNullable() {
+        List<Integer> list = new ArrayList<>();
+        list.add(42);
+        list.add(null);
+        return list;
+    }
+}
+
+// FILE: Nullable.java
+package org.jetbrains.annotations;
+
+import java.lang.annotation.*;
+
+// org.jetbrains.annotations used in the compiler is version 13, whose @Nullable does not support the TYPE_USE target (version 15 does).
+// We're using our own @org.jetbrains.annotations.Nullable for testing purposes.
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE})
+public @interface Nullable {
+}

--- a/compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfInheritedNotNull.kt
+++ b/compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfInheritedNotNull.kt
@@ -1,0 +1,34 @@
+// !LANGUAGE: +StrictJavaNullabilityAssertions
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND_FIR: JVM_IR
+// WITH_RUNTIME
+
+// FILE: box.kt
+import kotlin.test.*
+
+fun box(): String {
+    val actualValues = mutableListOf<Int>()
+    for (i in JImpl().listOfNotNull()) {
+        actualValues += i
+    }
+    assertEquals(listOf(42, -42), actualValues)
+    return "OK"
+}
+
+interface J {
+    fun listOfNotNull(): List<Int>
+}
+
+// FILE: JImpl.java
+import java.util.*;
+
+public class JImpl implements J {
+    // Type argument (Int) gets @EnhancedNullability because it is not nullable in overridden Kotlin function.
+    @Override
+    public List<Integer> listOfNotNull() {
+        List<Integer> list = new ArrayList<>();
+        list.add(42);
+        list.add(-42);
+        return list;
+    }
+}

--- a/compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfInheritedNotNullFailFast.kt
+++ b/compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfInheritedNotNullFailFast.kt
@@ -1,0 +1,43 @@
+// !LANGUAGE: +StrictJavaNullabilityAssertions
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND: JVM
+// IGNORE_BACKEND_FIR: JVM_IR
+// WITH_RUNTIME
+
+// Note: This fails on JVM (non-IR) with "Fail: should throw on get() in loop header". The not-null assertion is not generated when
+// assigning to the loop variable. The root cause seems to be that the loop variable is a KtParameter and
+// CodegenAnnotatingVisitor/RuntimeAssertionsOnDeclarationBodyChecker do not analyze the need for not-null assertions on KtParameters.
+
+// FILE: box.kt
+import kotlin.test.*
+
+fun box(): String {
+    // Sanity check to make sure there IS an exception even when not in a for-loop
+    try {
+        val i = JImpl().listOfNotNull()[0]
+        return "Fail: should throw on get()"
+    } catch (e: IllegalStateException) {}
+
+    try {
+        for (i in JImpl().listOfNotNull()) {
+            return "Fail: should throw on get() in loop header"
+        }
+    }
+    catch (e: IllegalStateException) {}
+    return "OK"
+}
+
+interface J {
+    fun listOfNotNull(): List<Int>
+}
+
+// FILE: JImpl.java
+import java.util.*;
+
+public class JImpl implements J {
+    // Type argument (Int) gets @EnhancedNullability because it is not nullable in overridden Kotlin function.
+    @Override
+    public List<Integer> listOfNotNull() {
+        return Collections.singletonList(null);
+    }
+}

--- a/compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfMaybeNullable.kt
+++ b/compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfMaybeNullable.kt
@@ -1,0 +1,28 @@
+// !LANGUAGE: +StrictJavaNullabilityAssertions
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND_FIR: JVM_IR
+// WITH_RUNTIME
+
+// FILE: box.kt
+import kotlin.test.*
+
+fun box(): String {
+    val actualValues = mutableListOf<Int>()
+    for (i in J.listOfMaybeNullable()) {
+        actualValues += i
+    }
+    assertEquals(listOf(42, null), actualValues)
+    return "OK"
+}
+
+// FILE: J.java
+import java.util.*;
+
+public class J {
+    public static List<Integer> listOfMaybeNullable() {
+        List<Integer> list = new ArrayList<>();
+        list.add(42);
+        list.add(null);
+        return list;
+    }
+}

--- a/compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfMaybeNullableWithNotNullLoopVariable.kt
+++ b/compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfMaybeNullableWithNotNullLoopVariable.kt
@@ -1,0 +1,28 @@
+// !LANGUAGE: +StrictJavaNullabilityAssertions
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND_FIR: JVM_IR
+// WITH_RUNTIME
+
+// FILE: box.kt
+import kotlin.test.*
+
+fun box(): String {
+    val actualValues = mutableListOf<Int>()
+    for (i: Int in J.listOfMaybeNullable()) {
+        actualValues += i
+    }
+    assertEquals(listOf(42, -42), actualValues)
+    return "OK"
+}
+
+// FILE: J.java
+import java.util.*;
+
+public class J {
+    public static List<Integer> listOfMaybeNullable() {
+        List<Integer> list = new ArrayList<>();
+        list.add(42);
+        list.add(-42);
+        return list;
+    }
+}

--- a/compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfMaybeNullableWithNotNullLoopVariableFailFast.kt
+++ b/compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfMaybeNullableWithNotNullLoopVariableFailFast.kt
@@ -1,0 +1,38 @@
+// !LANGUAGE: +StrictJavaNullabilityAssertions
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND: JVM
+// IGNORE_BACKEND_FIR: JVM_IR
+// WITH_RUNTIME
+
+// Note: This fails on JVM (non-IR) with a NullPointerException in the loop header. The not-null assertion is not generated when
+// assigning to the loop variable. The root cause seems to be that the loop variable is a KtParameter and
+// CodegenAnnotatingVisitor/RuntimeAssertionsOnDeclarationBodyChecker do not analyze the need for not-null assertions on KtParameters.
+// The NPE is due to calling `intValue()` on the null Int; it is expected to be asserted as non-null first.
+
+// FILE: box.kt
+import kotlin.test.*
+
+fun box(): String {
+    // Sanity check to make sure there IS an exception even when not in a for-loop
+    try {
+        val i: Int = J.listOfMaybeNullable()[0]
+        return "Fail: should throw on get()"
+    } catch (e: IllegalStateException) {}
+
+    try {
+        for (i: Int in J.listOfMaybeNullable()) {
+            return "Fail: should throw on get() in loop header"
+        }
+    }
+    catch (e: IllegalStateException) {}
+    return "OK"
+}
+
+// FILE: J.java
+import java.util.*;
+
+public class J {
+    public static List<Integer> listOfMaybeNullable() {
+        return Collections.singletonList(null);
+    }
+}

--- a/compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfNotNullFromStdlib.kt
+++ b/compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfNotNullFromStdlib.kt
@@ -1,0 +1,22 @@
+// !LANGUAGE: +StrictJavaNullabilityAssertions
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND_FIR: JVM_IR
+// WITH_RUNTIME
+// FULL_JDK
+
+import kotlin.test.*
+
+fun box(): String {
+    val map = java.util.LinkedHashMap<Int, Int>()
+    map.put(3, 42)
+    map.put(14, -42)
+
+    // Even though the type parameters on `map` are not nullable, the `values` property is implemented in Java and therefore there is
+    // @EnhancedNullability on its type argument (Int).
+    val actualValues = mutableListOf<Int>()
+    for (v in map.values) {
+        actualValues += v
+    }
+    assertEquals(listOf(42, -42), actualValues)
+    return "OK"
+}

--- a/compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfNotNullFromStdlibToTypedArray.kt
+++ b/compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfNotNullFromStdlibToTypedArray.kt
@@ -1,0 +1,23 @@
+// !LANGUAGE: +StrictJavaNullabilityAssertions
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND_FIR: JVM_IR
+// WITH_RUNTIME
+// FULL_JDK
+
+import kotlin.test.*
+
+fun box(): String {
+    val map = java.util.LinkedHashMap<Int, Int>()
+    map.put(3, 42)
+    map.put(14, -42)
+
+    // Even though the type parameters on `map` are not nullable, the `values` property is implemented in Java and therefore there is
+    // @EnhancedNullability on its type argument (Int), which gets propagated on the call to `toTypedArray()`.
+    // If we simply called `map.toTypedArray()` there would be no @EnhancedNullability on Int.
+    val actualValues = mutableListOf<Int>()
+    for (v in map.values.toTypedArray()) {
+        actualValues += v
+    }
+    assertEquals(listOf(42, -42), actualValues)
+    return "OK"
+}

--- a/compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfNotNullToTypedArray.kt
+++ b/compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfNotNullToTypedArray.kt
@@ -1,0 +1,42 @@
+// !LANGUAGE: +StrictJavaNullabilityAssertions
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND_FIR: JVM_IR
+// WITH_RUNTIME
+
+// FILE: box.kt
+import kotlin.test.*
+
+fun box(): String {
+    val actualValues = mutableListOf<Int>()
+    for (i in J.listOfNotNull().toTypedArray()) {
+        actualValues += i
+    }
+    assertEquals(listOf(42, -42), actualValues)
+    return "OK"
+}
+
+// FILE: J.java
+import java.util.*;
+import org.jetbrains.annotations.*;
+
+public class J {
+    public static List<@NotNull Integer> listOfNotNull() {
+        List<Integer> list = new ArrayList<>();
+        list.add(42);
+        list.add(-42);
+        return list;
+    }
+}
+
+// FILE: NotNull.java
+package org.jetbrains.annotations;
+
+import java.lang.annotation.*;
+
+// org.jetbrains.annotations used in the compiler is version 13, whose @NotNull does not support the TYPE_USE target (version 15 does).
+// We're using our own @org.jetbrains.annotations.NotNull for testing purposes.
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE})
+public @interface NotNull {
+}

--- a/compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfNotNullToTypedArrayFailFast.kt
+++ b/compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfNotNullToTypedArrayFailFast.kt
@@ -1,0 +1,51 @@
+// !LANGUAGE: +StrictJavaNullabilityAssertions
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND_FIR: JVM_IR
+// IGNORE_BACKEND: JVM
+// WITH_RUNTIME
+
+// Note: This fails on JVM (non-IR) with "Fail: should throw on get() in loop header". The not-null assertion is not generated when
+// assigning to the loop variable. The root cause seems to be that the loop variable is a KtParameter and
+// CodegenAnnotatingVisitor/RuntimeAssertionsOnDeclarationBodyChecker do not analyze the need for not-null assertions on KtParameters.
+
+// FILE: box.kt
+import kotlin.test.*
+
+fun box(): String {
+    // Sanity check to make sure there IS an exception even when not in a for-loop
+    try {
+        val i = J.listOfNotNull().toTypedArray()[0]
+        return "Fail: should throw on get()"
+    } catch (e: IllegalStateException) {}
+
+    try {
+        for (i in J.listOfNotNull().toTypedArray()) {
+            return "Fail: should throw on get() in loop header"
+        }
+    }
+    catch (e: IllegalStateException) {}
+    return "OK"
+}
+
+// FILE: J.java
+import java.util.*;
+import org.jetbrains.annotations.*;
+
+public class J {
+    public static List<@NotNull Integer> listOfNotNull() {
+        return Collections.singletonList(null);
+    }
+}
+
+// FILE: NotNull.java
+package org.jetbrains.annotations;
+
+import java.lang.annotation.*;
+
+// org.jetbrains.annotations used in the compiler is version 13, whose @NotNull does not support the TYPE_USE target (version 15 does).
+// We're using our own @org.jetbrains.annotations.NotNull for testing purposes.
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE})
+public @interface NotNull {
+}

--- a/compiler/testData/codegen/box/ranges/javaInterop/javaIteratorOfNotNull.kt
+++ b/compiler/testData/codegen/box/ranges/javaInterop/javaIteratorOfNotNull.kt
@@ -1,0 +1,42 @@
+// !LANGUAGE: +StrictJavaNullabilityAssertions
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND_FIR: JVM_IR
+// WITH_RUNTIME
+
+// FILE: box.kt
+import kotlin.test.*
+
+fun box(): String {
+    val actualValues = mutableListOf<Int>()
+    for (i in J.iteratorOfNotNull()) {
+        actualValues += i
+    }
+    assertEquals(listOf(42, -42), actualValues)
+    return "OK"
+}
+
+// FILE: J.java
+import java.util.*;
+import org.jetbrains.annotations.*;
+
+public class J {
+    public static Iterator<@NotNull Integer> iteratorOfNotNull() {
+        List<Integer> list = new ArrayList<>();
+        list.add(42);
+        list.add(-42);
+        return list.iterator();
+    }
+}
+
+// FILE: NotNull.java
+package org.jetbrains.annotations;
+
+import java.lang.annotation.*;
+
+// org.jetbrains.annotations used in the compiler is version 13, whose @NotNull does not support the TYPE_USE target (version 15 does).
+// We're using our own @org.jetbrains.annotations.NotNull for testing purposes.
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE})
+public @interface NotNull {
+}

--- a/compiler/testData/codegen/box/ranges/javaInterop/javaIteratorOfNotNullFailFast.kt
+++ b/compiler/testData/codegen/box/ranges/javaInterop/javaIteratorOfNotNullFailFast.kt
@@ -1,0 +1,51 @@
+// !LANGUAGE: +StrictJavaNullabilityAssertions
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND: JVM
+// IGNORE_BACKEND_FIR: JVM_IR
+// WITH_RUNTIME
+
+// Note: This fails on JVM (non-IR) with "Fail: should throw on get() in loop header". The not-null assertion is not generated when
+// assigning to the loop variable. The root cause seems to be that the loop variable is a KtParameter and
+// CodegenAnnotatingVisitor/RuntimeAssertionsOnDeclarationBodyChecker do not analyze the need for not-null assertions on KtParameters.
+
+// FILE: box.kt
+import kotlin.test.*
+
+fun box(): String {
+    // Sanity check to make sure there IS an exception even when not in a for-loop
+    try {
+        val i = J.iteratorOfNotNull().next()
+        return "Fail: should throw on get()"
+    } catch (e: IllegalStateException) {}
+
+    try {
+        for (i in J.iteratorOfNotNull()) {
+            return "Fail: should throw on get() in loop header"
+        }
+    }
+    catch (e: IllegalStateException) {}
+    return "OK"
+}
+
+// FILE: J.java
+import java.util.*;
+import org.jetbrains.annotations.*;
+
+public class J {
+    public static Iterator<@NotNull Integer> iteratorOfNotNull() {
+        return Collections.<Integer>singletonList(null).iterator();
+    }
+}
+
+// FILE: NotNull.java
+package org.jetbrains.annotations;
+
+import java.lang.annotation.*;
+
+// org.jetbrains.annotations used in the compiler is version 13, whose @NotNull does not support the TYPE_USE target (version 15 does).
+// We're using our own @org.jetbrains.annotations.NotNull for testing purposes.
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE})
+public @interface NotNull {
+}

--- a/compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaArrayOfInheritedNotNullWithIndex.kt
+++ b/compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaArrayOfInheritedNotNullWithIndex.kt
@@ -1,0 +1,33 @@
+// !LANGUAGE: +StrictJavaNullabilityAssertions
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND_FIR: JVM_IR
+// WITH_RUNTIME
+
+// FILE: box.kt
+import kotlin.test.*
+
+fun box(): String {
+    val actualIndices = mutableListOf<Int>()
+    val actualValues = mutableListOf<Int>()
+    for ((index, i) in JImpl().arrayOfNotNull().withIndex()) {
+        actualIndices += index
+        actualValues += i
+    }
+    assertEquals(listOf(0, 1), actualIndices)
+    assertEquals(listOf(42, -42), actualValues)
+    return "OK"
+}
+
+interface J {
+    fun arrayOfNotNull(): Array<Int>
+}
+
+// FILE: JImpl.java
+public class JImpl implements J {
+    // The only way to get @EnhancedNullability on the array element type (Int) is to override a Kotlin function that
+    // returns `Array<Int>` (where Int is not nullable). `@NotNull Integer[]` makes the array not nullable, not String.
+    @Override
+    public Integer[] arrayOfNotNull() {
+        return new Integer[] { 42, -42 };
+    }
+}

--- a/compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaArrayOfInheritedNotNullWithIndexFailFast.kt
+++ b/compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaArrayOfInheritedNotNullWithIndexFailFast.kt
@@ -1,0 +1,43 @@
+// !LANGUAGE: +StrictJavaNullabilityAssertions
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND: JVM
+// IGNORE_BACKEND_FIR: JVM_IR
+// WITH_RUNTIME
+
+// Note: This fails on JVM (non-IR) with "Fail: should throw on get()". The not-null assertion is not generated when assigning to the
+// variables in the destructuring declaration. The root cause seems to be that
+// CodegenAnnotatingVisitor/RuntimeAssertionsOnDeclarationBodyChecker do not analyze the need for not-null assertions on
+// KtDestructuringDeclarations and their entries.
+
+// FILE: box.kt
+import kotlin.test.*
+
+fun box(): String {
+    // Sanity check to make sure there IS an exception even when not in a for-loop
+    try {
+        val (index, i) = JImpl().arrayOfNotNull().withIndex().first()
+        return "Fail: should throw on get()"
+    } catch (e: IllegalStateException) {}
+
+    try {
+        for ((index, i) in JImpl().arrayOfNotNull().withIndex()) {
+            return "Fail: should throw on get() in loop header"
+        }
+    }
+    catch (e: IllegalStateException) {}
+    return "OK"
+}
+
+interface J {
+    fun arrayOfNotNull(): Array<Int>
+}
+
+// FILE: JImpl.java
+public class JImpl implements J {
+    // The only way to get @EnhancedNullability on the array element type (Int) is to override a Kotlin function that
+    // returns `Array<Int>` (where Int is not nullable). `@NotNull Integer[]` makes the array not nullable, not String.
+    @Override
+    public Integer[] arrayOfNotNull() {
+        return new Integer[] { null };
+    }
+}

--- a/compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaArrayOfMaybeNullableWithIndex.kt
+++ b/compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaArrayOfMaybeNullableWithIndex.kt
@@ -1,0 +1,26 @@
+// !LANGUAGE: +StrictJavaNullabilityAssertions
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND_FIR: JVM_IR
+// WITH_RUNTIME
+
+// FILE: box.kt
+import kotlin.test.*
+
+fun box(): String {
+    val actualIndices = mutableListOf<Int>()
+    val actualValues = mutableListOf<Int>()
+    for ((index, i) in J.arrayOfMaybeNullable().withIndex()) {
+        actualIndices += index
+        actualValues += i
+    }
+    assertEquals(listOf(0, 1), actualIndices)
+    assertEquals(listOf(42, null), actualValues)
+    return "OK"
+}
+
+// FILE: J.java
+public class J {
+    public static Integer[] arrayOfMaybeNullable() {
+        return new Integer[] { 42, null };
+    }
+}

--- a/compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaArrayOfMaybeNullableWithIndexWithNotNullLoopVariable.kt
+++ b/compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaArrayOfMaybeNullableWithIndexWithNotNullLoopVariable.kt
@@ -1,0 +1,26 @@
+// !LANGUAGE: +StrictJavaNullabilityAssertions
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND_FIR: JVM_IR
+// WITH_RUNTIME
+
+// FILE: box.kt
+import kotlin.test.*
+
+fun box(): String {
+    val actualIndices = mutableListOf<Int>()
+    val actualValues = mutableListOf<Int>()
+    for ((index, i: Int) in J.arrayOfMaybeNullable().withIndex()) {
+        actualIndices += index
+        actualValues += i
+    }
+    assertEquals(listOf(0, 1), actualIndices)
+    assertEquals(listOf(42, -42), actualValues)
+    return "OK"
+}
+
+// FILE: J.java
+public class J {
+    public static Integer[] arrayOfMaybeNullable() {
+        return new Integer[] { 42, -42 };
+    }
+}

--- a/compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaArrayOfMaybeNullableWithIndexWithNotNullLoopVariableFailFast.kt
+++ b/compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaArrayOfMaybeNullableWithIndexWithNotNullLoopVariableFailFast.kt
@@ -1,0 +1,33 @@
+// !LANGUAGE: +StrictJavaNullabilityAssertions
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND: JVM, JVM_IR
+// IGNORE_BACKEND_FIR: JVM_IR
+// WITH_RUNTIME
+
+// Note: This fails because explicit types are ignored in destructuring declarations (KT-22392).
+
+// FILE: box.kt
+import kotlin.test.*
+
+fun box(): String {
+    // Sanity check to make sure there IS an exception even when not in a for-loop
+    try {
+        val (index, i: Int) = J.arrayOfMaybeNullable().withIndex().first()
+        return "Fail: should throw on get()"
+    } catch (e: IllegalStateException) {}
+
+    try {
+        for ((index, i: Int) in J.arrayOfMaybeNullable().withIndex()) {
+            return "Fail: should throw on get() in loop header"
+        }
+    }
+    catch (e: IllegalStateException) {}
+    return "OK"
+}
+
+// FILE: J.java
+public class J {
+    public static Integer[] arrayOfMaybeNullable() {
+        return new Integer[] { null };
+    }
+}

--- a/compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaCollectionOfExplicitNotNullWithIndex.kt
+++ b/compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaCollectionOfExplicitNotNullWithIndex.kt
@@ -1,0 +1,45 @@
+// !LANGUAGE: +StrictJavaNullabilityAssertions
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND_FIR: JVM_IR
+// WITH_RUNTIME
+
+// FILE: box.kt
+import kotlin.test.*
+
+fun box(): String {
+    val actualIndices = mutableListOf<Int>()
+    val actualValues = mutableListOf<Int>()
+    for ((index, i) in J.listOfNotNull().withIndex()) {
+        actualIndices += index
+        actualValues += i
+    }
+    assertEquals(listOf(0, 1), actualIndices)
+    assertEquals(listOf(42, -42), actualValues)
+    return "OK"
+}
+
+// FILE: J.java
+import java.util.*;
+import org.jetbrains.annotations.*;
+
+public class J {
+    public static List<@NotNull Integer> listOfNotNull() {
+        List<Integer> list = new ArrayList<>();
+        list.add(42);
+        list.add(-42);
+        return list;
+    }
+}
+
+// FILE: NotNull.java
+package org.jetbrains.annotations;
+
+import java.lang.annotation.*;
+
+// org.jetbrains.annotations used in the compiler is version 13, whose @NotNull does not support the TYPE_USE target (version 15 does).
+// We're using our own @org.jetbrains.annotations.NotNull for testing purposes.
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE})
+public @interface NotNull {
+}

--- a/compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaCollectionOfExplicitNotNullWithIndexFailFast.kt
+++ b/compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaCollectionOfExplicitNotNullWithIndexFailFast.kt
@@ -1,0 +1,52 @@
+// !LANGUAGE: +StrictJavaNullabilityAssertions
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND: JVM
+// IGNORE_BACKEND_FIR: JVM_IR
+// WITH_RUNTIME
+
+// Note: This fails on JVM (non-IR) with "Fail: should throw on get()". The not-null assertion is not generated when assigning to the
+// variables in the destructuring declaration. The root cause seems to be that
+// CodegenAnnotatingVisitor/RuntimeAssertionsOnDeclarationBodyChecker do not analyze the need for not-null assertions on
+// KtDestructuringDeclarations and their entries.
+
+// FILE: box.kt
+import kotlin.test.*
+
+fun box(): String {
+    // Sanity check to make sure there IS an exception even when not in a for-loop
+    try {
+        val (index, i) = J.listOfNotNull().withIndex().first()
+        return "Fail: should throw on get()"
+    } catch (e: IllegalStateException) {}
+
+    try {
+        for ((index, i) in J.listOfNotNull().withIndex()) {
+            return "Fail: should throw on get() in loop header"
+        }
+    }
+    catch (e: IllegalStateException) {}
+    return "OK"
+}
+
+// FILE: J.java
+import java.util.*;
+import org.jetbrains.annotations.*;
+
+public class J {
+    public static List<@NotNull Integer> listOfNotNull() {
+        return Collections.singletonList(null);
+    }
+}
+
+// FILE: NotNull.java
+package org.jetbrains.annotations;
+
+import java.lang.annotation.*;
+
+// org.jetbrains.annotations used in the compiler is version 13, whose @NotNull does not support the TYPE_USE target (version 15 does).
+// We're using our own @org.jetbrains.annotations.NotNull for testing purposes.
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE})
+public @interface NotNull {
+}

--- a/compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaCollectionOfExplicitNullableWithIndex.kt
+++ b/compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaCollectionOfExplicitNullableWithIndex.kt
@@ -1,0 +1,45 @@
+// !LANGUAGE: +StrictJavaNullabilityAssertions
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND_FIR: JVM_IR
+// WITH_RUNTIME
+
+// FILE: box.kt
+import kotlin.test.*
+
+fun box(): String {
+    val actualIndices = mutableListOf<Int>()
+    val actualValues = mutableListOf<Int?>()
+    for ((index, i) in J.listOfNullable().withIndex()) {
+        actualIndices += index
+        actualValues += i
+    }
+    assertEquals(listOf(0, 1), actualIndices)
+    assertEquals(listOf(42, null), actualValues)
+    return "OK"
+}
+
+// FILE: J.java
+import java.util.*;
+import org.jetbrains.annotations.*;
+
+public class J {
+    public static List<@Nullable Integer> listOfNullable() {
+        List<Integer> list = new ArrayList<>();
+        list.add(42);
+        list.add(null);
+        return list;
+    }
+}
+
+// FILE: Nullable.java
+package org.jetbrains.annotations;
+
+import java.lang.annotation.*;
+
+// org.jetbrains.annotations used in the compiler is version 13, whose @Nullable does not support the TYPE_USE target (version 15 does).
+// We're using our own @org.jetbrains.annotations.Nullable for testing purposes.
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE})
+public @interface Nullable {
+}

--- a/compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaCollectionOfMaybeNullableWithIndex.kt
+++ b/compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaCollectionOfMaybeNullableWithIndex.kt
@@ -1,0 +1,31 @@
+// !LANGUAGE: +StrictJavaNullabilityAssertions
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND_FIR: JVM_IR
+// WITH_RUNTIME
+
+// FILE: box.kt
+import kotlin.test.*
+
+fun box(): String {
+    val actualIndices = mutableListOf<Int>()
+    val actualValues = mutableListOf<Int>()
+    for ((index, i) in J.listOfMaybeNullable().withIndex()) {
+        actualIndices += index
+        actualValues += i
+    }
+    assertEquals(listOf(0, 1), actualIndices)
+    assertEquals(listOf(42, null), actualValues)
+    return "OK"
+}
+
+// FILE: J.java
+import java.util.*;
+
+public class J {
+    public static List<Integer> listOfMaybeNullable() {
+        List<Integer> list = new ArrayList<>();
+        list.add(42);
+        list.add(null);
+        return list;
+    }
+}

--- a/compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaCollectionOfMaybeNullableWithIndexWithNotNullLoopVariable.kt
+++ b/compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaCollectionOfMaybeNullableWithIndexWithNotNullLoopVariable.kt
@@ -1,0 +1,31 @@
+// !LANGUAGE: +StrictJavaNullabilityAssertions
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND_FIR: JVM_IR
+// WITH_RUNTIME
+
+// FILE: box.kt
+import kotlin.test.*
+
+fun box(): String {
+    val actualIndices = mutableListOf<Int>()
+    val actualValues = mutableListOf<Int>()
+    for ((index, i: Int) in J.listOfMaybeNullable().withIndex()) {
+        actualIndices += index
+        actualValues += i
+    }
+    assertEquals(listOf(0, 1), actualIndices)
+    assertEquals(listOf(42, -42), actualValues)
+    return "OK"
+}
+
+// FILE: J.java
+import java.util.*;
+
+public class J {
+    public static List<Integer> listOfMaybeNullable() {
+        List<Integer> list = new ArrayList<>();
+        list.add(42);
+        list.add(-42);
+        return list;
+    }
+}

--- a/compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaCollectionOfMaybeNullableWithIndexWithNotNullLoopVariableFailFast.kt
+++ b/compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaCollectionOfMaybeNullableWithIndexWithNotNullLoopVariableFailFast.kt
@@ -1,0 +1,35 @@
+// !LANGUAGE: +StrictJavaNullabilityAssertions
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND: JVM, JVM_IR
+// IGNORE_BACKEND_FIR: JVM_IR
+// WITH_RUNTIME
+
+// Note: This fails because explicit types are ignored in destructuring declarations (KT-22392).
+
+// FILE: box.kt
+import kotlin.test.*
+
+fun box(): String {
+    // Sanity check to make sure there IS an exception even when not in a for-loop
+    try {
+        val (index, i: Int) = J.listOfMaybeNullable().withIndex().first()
+        return "Fail: should throw on get()"
+    } catch (e: IllegalStateException) {}
+
+    try {
+        for ((index, i: Int) in J.listOfMaybeNullable().withIndex()) {
+            return "Fail: should throw on get() in loop header"
+        }
+    }
+    catch (e: IllegalStateException) {}
+    return "OK"
+}
+
+// FILE: J.java
+import java.util.*;
+
+public class J {
+    public static List<Integer> listOfMaybeNullable() {
+        return Collections.singletonList(null);
+    }
+}

--- a/compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaIteratorOfNotNullWithIndex.kt
+++ b/compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaIteratorOfNotNullWithIndex.kt
@@ -1,0 +1,45 @@
+// !LANGUAGE: +StrictJavaNullabilityAssertions
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND_FIR: JVM_IR
+// WITH_RUNTIME
+
+// FILE: box.kt
+import kotlin.test.*
+
+fun box(): String {
+    val actualIndices = mutableListOf<Int>()
+    val actualValues = mutableListOf<Int>()
+    for ((index, i) in J.iteratorOfNotNull().withIndex()) {
+        actualIndices += index
+        actualValues += i
+    }
+    assertEquals(listOf(0, 1), actualIndices)
+    assertEquals(listOf(42, -42), actualValues)
+    return "OK"
+}
+
+// FILE: J.java
+import java.util.*;
+import org.jetbrains.annotations.*;
+
+public class J {
+    public static Iterator<@NotNull Integer> iteratorOfNotNull() {
+        List<Integer> list = new ArrayList<>();
+        list.add(42);
+        list.add(-42);
+        return list.iterator();
+    }
+}
+
+// FILE: NotNull.java
+package org.jetbrains.annotations;
+
+import java.lang.annotation.*;
+
+// org.jetbrains.annotations used in the compiler is version 13, whose @NotNull does not support the TYPE_USE target (version 15 does).
+// We're using our own @org.jetbrains.annotations.NotNull for testing purposes.
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE})
+public @interface NotNull {
+}

--- a/compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaIteratorOfNotNullWithIndexFailFast.kt
+++ b/compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaIteratorOfNotNullWithIndexFailFast.kt
@@ -1,0 +1,52 @@
+// !LANGUAGE: +StrictJavaNullabilityAssertions
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND: JVM
+// IGNORE_BACKEND_FIR: JVM_IR
+// WITH_RUNTIME
+
+// Note: This fails on JVM (non-IR) with "Fail: should throw on get()". The not-null assertion is not generated when assigning to the
+// variables in the destructuring declaration. The root cause seems to be that
+// CodegenAnnotatingVisitor/RuntimeAssertionsOnDeclarationBodyChecker do not analyze the need for not-null assertions on
+// KtDestructuringDeclarations and their entries.
+
+// FILE: box.kt
+import kotlin.test.*
+
+fun box(): String {
+    // Sanity check to make sure there IS an exception even when not in a for-loop
+    try {
+        val (index, i) = J.iteratorOfNotNull().withIndex().next()
+        return "Fail: should throw on get()"
+    } catch (e: IllegalStateException) {}
+
+    try {
+        for ((index, i) in J.iteratorOfNotNull().withIndex()) {
+            return "Fail: should throw on get() in loop header"
+        }
+    }
+    catch (e: IllegalStateException) {}
+    return "OK"
+}
+
+// FILE: J.java
+import java.util.*;
+import org.jetbrains.annotations.*;
+
+public class J {
+    public static Iterator<@NotNull Integer> iteratorOfNotNull() {
+        return Collections.<Integer>singletonList(null).iterator();
+    }
+}
+
+// FILE: NotNull.java
+package org.jetbrains.annotations;
+
+import java.lang.annotation.*;
+
+// org.jetbrains.annotations used in the compiler is version 13, whose @NotNull does not support the TYPE_USE target (version 15 does).
+// We're using our own @org.jetbrains.annotations.NotNull for testing purposes.
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE})
+public @interface NotNull {
+}

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -16946,7 +16946,7 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             }
 
             public void testAllFilesPresentInMultiModule() throws Exception {
-                KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/codegen/box/multiplatform/multiModule"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.JVM, true);
+                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/multiplatform/multiModule"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM, true);
             }
 
             @TestMetadata("expectActualLink.kt")
@@ -20886,6 +20886,192 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             @TestMetadata("forInUntilIntMinValueReversed.kt")
             public void testForInUntilIntMinValueReversed() throws Exception {
                 runTest("compiler/testData/codegen/box/ranges/forWithPossibleOverflow/forInUntilIntMinValueReversed.kt");
+            }
+        }
+
+        @TestMetadata("compiler/testData/codegen/box/ranges/javaInterop")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class JavaInterop extends AbstractBlackBoxCodegenTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInJavaInterop() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/ranges/javaInterop"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM, true);
+            }
+
+            @TestMetadata("javaArrayOfInheritedNotNull.kt")
+            public void testJavaArrayOfInheritedNotNull() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaArrayOfInheritedNotNull.kt");
+            }
+
+            @TestMetadata("javaArrayOfInheritedNotNullFailFast.kt")
+            public void testJavaArrayOfInheritedNotNullFailFast() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaArrayOfInheritedNotNullFailFast.kt");
+            }
+
+            @TestMetadata("javaArrayOfMaybeNullable.kt")
+            public void testJavaArrayOfMaybeNullable() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaArrayOfMaybeNullable.kt");
+            }
+
+            @TestMetadata("javaArrayOfMaybeNullableWithNotNullLoopVariable.kt")
+            public void testJavaArrayOfMaybeNullableWithNotNullLoopVariable() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaArrayOfMaybeNullableWithNotNullLoopVariable.kt");
+            }
+
+            @TestMetadata("javaArrayOfMaybeNullableWithNotNullLoopVariableFailFast.kt")
+            public void testJavaArrayOfMaybeNullableWithNotNullLoopVariableFailFast() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaArrayOfMaybeNullableWithNotNullLoopVariableFailFast.kt");
+            }
+
+            @TestMetadata("javaCollectionOfExplicitNotNull.kt")
+            public void testJavaCollectionOfExplicitNotNull() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfExplicitNotNull.kt");
+            }
+
+            @TestMetadata("javaCollectionOfExplicitNotNullFailFast.kt")
+            public void testJavaCollectionOfExplicitNotNullFailFast() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfExplicitNotNullFailFast.kt");
+            }
+
+            @TestMetadata("javaCollectionOfExplicitNullable.kt")
+            public void testJavaCollectionOfExplicitNullable() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfExplicitNullable.kt");
+            }
+
+            @TestMetadata("javaCollectionOfInheritedNotNull.kt")
+            public void testJavaCollectionOfInheritedNotNull() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfInheritedNotNull.kt");
+            }
+
+            @TestMetadata("javaCollectionOfInheritedNotNullFailFast.kt")
+            public void testJavaCollectionOfInheritedNotNullFailFast() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfInheritedNotNullFailFast.kt");
+            }
+
+            @TestMetadata("javaCollectionOfMaybeNullable.kt")
+            public void testJavaCollectionOfMaybeNullable() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfMaybeNullable.kt");
+            }
+
+            @TestMetadata("javaCollectionOfMaybeNullableWithNotNullLoopVariable.kt")
+            public void testJavaCollectionOfMaybeNullableWithNotNullLoopVariable() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfMaybeNullableWithNotNullLoopVariable.kt");
+            }
+
+            @TestMetadata("javaCollectionOfMaybeNullableWithNotNullLoopVariableFailFast.kt")
+            public void testJavaCollectionOfMaybeNullableWithNotNullLoopVariableFailFast() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfMaybeNullableWithNotNullLoopVariableFailFast.kt");
+            }
+
+            @TestMetadata("javaCollectionOfNotNullFromStdlib.kt")
+            public void testJavaCollectionOfNotNullFromStdlib() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfNotNullFromStdlib.kt");
+            }
+
+            @TestMetadata("javaCollectionOfNotNullFromStdlibToTypedArray.kt")
+            public void testJavaCollectionOfNotNullFromStdlibToTypedArray() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfNotNullFromStdlibToTypedArray.kt");
+            }
+
+            @TestMetadata("javaCollectionOfNotNullToTypedArray.kt")
+            public void testJavaCollectionOfNotNullToTypedArray() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfNotNullToTypedArray.kt");
+            }
+
+            @TestMetadata("javaCollectionOfNotNullToTypedArrayFailFast.kt")
+            public void testJavaCollectionOfNotNullToTypedArrayFailFast() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfNotNullToTypedArrayFailFast.kt");
+            }
+
+            @TestMetadata("javaIteratorOfNotNull.kt")
+            public void testJavaIteratorOfNotNull() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaIteratorOfNotNull.kt");
+            }
+
+            @TestMetadata("javaIteratorOfNotNullFailFast.kt")
+            public void testJavaIteratorOfNotNullFailFast() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaIteratorOfNotNullFailFast.kt");
+            }
+
+            @TestMetadata("compiler/testData/codegen/box/ranges/javaInterop/withIndex")
+            @TestDataPath("$PROJECT_ROOT")
+            @RunWith(JUnit3RunnerWithInners.class)
+            public static class WithIndex extends AbstractBlackBoxCodegenTest {
+                private void runTest(String testDataFilePath) throws Exception {
+                    KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM, testDataFilePath);
+                }
+
+                public void testAllFilesPresentInWithIndex() throws Exception {
+                    KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/ranges/javaInterop/withIndex"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM, true);
+                }
+
+                @TestMetadata("javaArrayOfInheritedNotNullWithIndex.kt")
+                public void testJavaArrayOfInheritedNotNullWithIndex() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaArrayOfInheritedNotNullWithIndex.kt");
+                }
+
+                @TestMetadata("javaArrayOfInheritedNotNullWithIndexFailFast.kt")
+                public void testJavaArrayOfInheritedNotNullWithIndexFailFast() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaArrayOfInheritedNotNullWithIndexFailFast.kt");
+                }
+
+                @TestMetadata("javaArrayOfMaybeNullableWithIndex.kt")
+                public void testJavaArrayOfMaybeNullableWithIndex() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaArrayOfMaybeNullableWithIndex.kt");
+                }
+
+                @TestMetadata("javaArrayOfMaybeNullableWithIndexWithNotNullLoopVariable.kt")
+                public void testJavaArrayOfMaybeNullableWithIndexWithNotNullLoopVariable() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaArrayOfMaybeNullableWithIndexWithNotNullLoopVariable.kt");
+                }
+
+                @TestMetadata("javaArrayOfMaybeNullableWithIndexWithNotNullLoopVariableFailFast.kt")
+                public void testJavaArrayOfMaybeNullableWithIndexWithNotNullLoopVariableFailFast() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaArrayOfMaybeNullableWithIndexWithNotNullLoopVariableFailFast.kt");
+                }
+
+                @TestMetadata("javaCollectionOfExplicitNotNullWithIndex.kt")
+                public void testJavaCollectionOfExplicitNotNullWithIndex() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaCollectionOfExplicitNotNullWithIndex.kt");
+                }
+
+                @TestMetadata("javaCollectionOfExplicitNotNullWithIndexFailFast.kt")
+                public void testJavaCollectionOfExplicitNotNullWithIndexFailFast() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaCollectionOfExplicitNotNullWithIndexFailFast.kt");
+                }
+
+                @TestMetadata("javaCollectionOfExplicitNullableWithIndex.kt")
+                public void testJavaCollectionOfExplicitNullableWithIndex() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaCollectionOfExplicitNullableWithIndex.kt");
+                }
+
+                @TestMetadata("javaCollectionOfMaybeNullableWithIndex.kt")
+                public void testJavaCollectionOfMaybeNullableWithIndex() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaCollectionOfMaybeNullableWithIndex.kt");
+                }
+
+                @TestMetadata("javaCollectionOfMaybeNullableWithIndexWithNotNullLoopVariable.kt")
+                public void testJavaCollectionOfMaybeNullableWithIndexWithNotNullLoopVariable() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaCollectionOfMaybeNullableWithIndexWithNotNullLoopVariable.kt");
+                }
+
+                @TestMetadata("javaCollectionOfMaybeNullableWithIndexWithNotNullLoopVariableFailFast.kt")
+                public void testJavaCollectionOfMaybeNullableWithIndexWithNotNullLoopVariableFailFast() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaCollectionOfMaybeNullableWithIndexWithNotNullLoopVariableFailFast.kt");
+                }
+
+                @TestMetadata("javaIteratorOfNotNullWithIndex.kt")
+                public void testJavaIteratorOfNotNullWithIndex() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaIteratorOfNotNullWithIndex.kt");
+                }
+
+                @TestMetadata("javaIteratorOfNotNullWithIndexFailFast.kt")
+                public void testJavaIteratorOfNotNullWithIndexFailFast() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaIteratorOfNotNullWithIndexFailFast.kt");
+                }
             }
         }
 

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -16941,27 +16941,27 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)
         public static class MultiModule extends AbstractLightAnalysisModeTest {
-            @TestMetadata("expectActualLink.kt")
-            public void ignoreExpectActualLink() throws Exception {
-                runTest("compiler/testData/codegen/box/multiplatform/multiModule/expectActualLink.kt");
-            }
-
-            @TestMetadata("expectActualMemberLink.kt")
-            public void ignoreExpectActualMemberLink() throws Exception {
-                runTest("compiler/testData/codegen/box/multiplatform/multiModule/expectActualMemberLink.kt");
-            }
-
-            @TestMetadata("expectActualTypealiasLink.kt")
-            public void ignoreExpectActualTypealiasLink() throws Exception {
-                runTest("compiler/testData/codegen/box/multiplatform/multiModule/expectActualTypealiasLink.kt");
-            }
-
             private void runTest(String testDataFilePath) throws Exception {
                 KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM, testDataFilePath);
             }
 
             public void testAllFilesPresentInMultiModule() throws Exception {
-                KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/codegen/box/multiplatform/multiModule"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.JVM, true);
+                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/multiplatform/multiModule"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM, true);
+            }
+
+            @TestMetadata("expectActualLink.kt")
+            public void testExpectActualLink() throws Exception {
+                runTest("compiler/testData/codegen/box/multiplatform/multiModule/expectActualLink.kt");
+            }
+
+            @TestMetadata("expectActualMemberLink.kt")
+            public void testExpectActualMemberLink() throws Exception {
+                runTest("compiler/testData/codegen/box/multiplatform/multiModule/expectActualMemberLink.kt");
+            }
+
+            @TestMetadata("expectActualTypealiasLink.kt")
+            public void testExpectActualTypealiasLink() throws Exception {
+                runTest("compiler/testData/codegen/box/multiplatform/multiModule/expectActualTypealiasLink.kt");
             }
         }
     }
@@ -20886,6 +20886,192 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             @TestMetadata("forInUntilIntMinValueReversed.kt")
             public void testForInUntilIntMinValueReversed() throws Exception {
                 runTest("compiler/testData/codegen/box/ranges/forWithPossibleOverflow/forInUntilIntMinValueReversed.kt");
+            }
+        }
+
+        @TestMetadata("compiler/testData/codegen/box/ranges/javaInterop")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class JavaInterop extends AbstractLightAnalysisModeTest {
+            @TestMetadata("javaArrayOfInheritedNotNullFailFast.kt")
+            public void ignoreJavaArrayOfInheritedNotNullFailFast() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaArrayOfInheritedNotNullFailFast.kt");
+            }
+
+            @TestMetadata("javaArrayOfMaybeNullableWithNotNullLoopVariableFailFast.kt")
+            public void ignoreJavaArrayOfMaybeNullableWithNotNullLoopVariableFailFast() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaArrayOfMaybeNullableWithNotNullLoopVariableFailFast.kt");
+            }
+
+            @TestMetadata("javaCollectionOfExplicitNotNullFailFast.kt")
+            public void ignoreJavaCollectionOfExplicitNotNullFailFast() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfExplicitNotNullFailFast.kt");
+            }
+
+            @TestMetadata("javaCollectionOfInheritedNotNullFailFast.kt")
+            public void ignoreJavaCollectionOfInheritedNotNullFailFast() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfInheritedNotNullFailFast.kt");
+            }
+
+            @TestMetadata("javaCollectionOfMaybeNullableWithNotNullLoopVariableFailFast.kt")
+            public void ignoreJavaCollectionOfMaybeNullableWithNotNullLoopVariableFailFast() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfMaybeNullableWithNotNullLoopVariableFailFast.kt");
+            }
+
+            @TestMetadata("javaCollectionOfNotNullToTypedArrayFailFast.kt")
+            public void ignoreJavaCollectionOfNotNullToTypedArrayFailFast() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfNotNullToTypedArrayFailFast.kt");
+            }
+
+            @TestMetadata("javaIteratorOfNotNullFailFast.kt")
+            public void ignoreJavaIteratorOfNotNullFailFast() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaIteratorOfNotNullFailFast.kt");
+            }
+
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInJavaInterop() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/ranges/javaInterop"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM, true);
+            }
+
+            @TestMetadata("javaArrayOfInheritedNotNull.kt")
+            public void testJavaArrayOfInheritedNotNull() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaArrayOfInheritedNotNull.kt");
+            }
+
+            @TestMetadata("javaArrayOfMaybeNullable.kt")
+            public void testJavaArrayOfMaybeNullable() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaArrayOfMaybeNullable.kt");
+            }
+
+            @TestMetadata("javaArrayOfMaybeNullableWithNotNullLoopVariable.kt")
+            public void testJavaArrayOfMaybeNullableWithNotNullLoopVariable() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaArrayOfMaybeNullableWithNotNullLoopVariable.kt");
+            }
+
+            @TestMetadata("javaCollectionOfExplicitNotNull.kt")
+            public void testJavaCollectionOfExplicitNotNull() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfExplicitNotNull.kt");
+            }
+
+            @TestMetadata("javaCollectionOfExplicitNullable.kt")
+            public void testJavaCollectionOfExplicitNullable() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfExplicitNullable.kt");
+            }
+
+            @TestMetadata("javaCollectionOfInheritedNotNull.kt")
+            public void testJavaCollectionOfInheritedNotNull() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfInheritedNotNull.kt");
+            }
+
+            @TestMetadata("javaCollectionOfMaybeNullable.kt")
+            public void testJavaCollectionOfMaybeNullable() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfMaybeNullable.kt");
+            }
+
+            @TestMetadata("javaCollectionOfMaybeNullableWithNotNullLoopVariable.kt")
+            public void testJavaCollectionOfMaybeNullableWithNotNullLoopVariable() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfMaybeNullableWithNotNullLoopVariable.kt");
+            }
+
+            @TestMetadata("javaCollectionOfNotNullFromStdlib.kt")
+            public void testJavaCollectionOfNotNullFromStdlib() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfNotNullFromStdlib.kt");
+            }
+
+            @TestMetadata("javaCollectionOfNotNullFromStdlibToTypedArray.kt")
+            public void testJavaCollectionOfNotNullFromStdlibToTypedArray() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfNotNullFromStdlibToTypedArray.kt");
+            }
+
+            @TestMetadata("javaCollectionOfNotNullToTypedArray.kt")
+            public void testJavaCollectionOfNotNullToTypedArray() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfNotNullToTypedArray.kt");
+            }
+
+            @TestMetadata("javaIteratorOfNotNull.kt")
+            public void testJavaIteratorOfNotNull() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaIteratorOfNotNull.kt");
+            }
+
+            @TestMetadata("compiler/testData/codegen/box/ranges/javaInterop/withIndex")
+            @TestDataPath("$PROJECT_ROOT")
+            @RunWith(JUnit3RunnerWithInners.class)
+            public static class WithIndex extends AbstractLightAnalysisModeTest {
+                @TestMetadata("javaArrayOfInheritedNotNullWithIndexFailFast.kt")
+                public void ignoreJavaArrayOfInheritedNotNullWithIndexFailFast() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaArrayOfInheritedNotNullWithIndexFailFast.kt");
+                }
+
+                @TestMetadata("javaArrayOfMaybeNullableWithIndexWithNotNullLoopVariableFailFast.kt")
+                public void ignoreJavaArrayOfMaybeNullableWithIndexWithNotNullLoopVariableFailFast() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaArrayOfMaybeNullableWithIndexWithNotNullLoopVariableFailFast.kt");
+                }
+
+                @TestMetadata("javaCollectionOfExplicitNotNullWithIndexFailFast.kt")
+                public void ignoreJavaCollectionOfExplicitNotNullWithIndexFailFast() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaCollectionOfExplicitNotNullWithIndexFailFast.kt");
+                }
+
+                @TestMetadata("javaCollectionOfMaybeNullableWithIndexWithNotNullLoopVariableFailFast.kt")
+                public void ignoreJavaCollectionOfMaybeNullableWithIndexWithNotNullLoopVariableFailFast() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaCollectionOfMaybeNullableWithIndexWithNotNullLoopVariableFailFast.kt");
+                }
+
+                @TestMetadata("javaIteratorOfNotNullWithIndexFailFast.kt")
+                public void ignoreJavaIteratorOfNotNullWithIndexFailFast() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaIteratorOfNotNullWithIndexFailFast.kt");
+                }
+
+                private void runTest(String testDataFilePath) throws Exception {
+                    KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM, testDataFilePath);
+                }
+
+                public void testAllFilesPresentInWithIndex() throws Exception {
+                    KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/ranges/javaInterop/withIndex"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM, true);
+                }
+
+                @TestMetadata("javaArrayOfInheritedNotNullWithIndex.kt")
+                public void testJavaArrayOfInheritedNotNullWithIndex() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaArrayOfInheritedNotNullWithIndex.kt");
+                }
+
+                @TestMetadata("javaArrayOfMaybeNullableWithIndex.kt")
+                public void testJavaArrayOfMaybeNullableWithIndex() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaArrayOfMaybeNullableWithIndex.kt");
+                }
+
+                @TestMetadata("javaArrayOfMaybeNullableWithIndexWithNotNullLoopVariable.kt")
+                public void testJavaArrayOfMaybeNullableWithIndexWithNotNullLoopVariable() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaArrayOfMaybeNullableWithIndexWithNotNullLoopVariable.kt");
+                }
+
+                @TestMetadata("javaCollectionOfExplicitNotNullWithIndex.kt")
+                public void testJavaCollectionOfExplicitNotNullWithIndex() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaCollectionOfExplicitNotNullWithIndex.kt");
+                }
+
+                @TestMetadata("javaCollectionOfExplicitNullableWithIndex.kt")
+                public void testJavaCollectionOfExplicitNullableWithIndex() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaCollectionOfExplicitNullableWithIndex.kt");
+                }
+
+                @TestMetadata("javaCollectionOfMaybeNullableWithIndex.kt")
+                public void testJavaCollectionOfMaybeNullableWithIndex() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaCollectionOfMaybeNullableWithIndex.kt");
+                }
+
+                @TestMetadata("javaCollectionOfMaybeNullableWithIndexWithNotNullLoopVariable.kt")
+                public void testJavaCollectionOfMaybeNullableWithIndexWithNotNullLoopVariable() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaCollectionOfMaybeNullableWithIndexWithNotNullLoopVariable.kt");
+                }
+
+                @TestMetadata("javaIteratorOfNotNullWithIndex.kt")
+                public void testJavaIteratorOfNotNullWithIndex() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaIteratorOfNotNullWithIndex.kt");
+                }
             }
         }
 

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
@@ -15796,7 +15796,7 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
             }
 
             public void testAllFilesPresentInMultiModule() throws Exception {
-                KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/codegen/box/multiplatform/multiModule"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.JVM_IR, true);
+                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/multiplatform/multiModule"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
             }
 
             @TestMetadata("expectActualLink.kt")
@@ -19370,6 +19370,192 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
             @TestMetadata("forInUntilIntMinValueReversed.kt")
             public void testForInUntilIntMinValueReversed() throws Exception {
                 runTest("compiler/testData/codegen/box/ranges/forWithPossibleOverflow/forInUntilIntMinValueReversed.kt");
+            }
+        }
+
+        @TestMetadata("compiler/testData/codegen/box/ranges/javaInterop")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class JavaInterop extends AbstractFirBlackBoxCodegenTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTestWithCustomIgnoreDirective(this::doTest, TargetBackend.JVM_IR, testDataFilePath, "// IGNORE_BACKEND_FIR: ");
+            }
+
+            public void testAllFilesPresentInJavaInterop() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/ranges/javaInterop"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+            }
+
+            @TestMetadata("javaArrayOfInheritedNotNull.kt")
+            public void testJavaArrayOfInheritedNotNull() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaArrayOfInheritedNotNull.kt");
+            }
+
+            @TestMetadata("javaArrayOfInheritedNotNullFailFast.kt")
+            public void testJavaArrayOfInheritedNotNullFailFast() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaArrayOfInheritedNotNullFailFast.kt");
+            }
+
+            @TestMetadata("javaArrayOfMaybeNullable.kt")
+            public void testJavaArrayOfMaybeNullable() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaArrayOfMaybeNullable.kt");
+            }
+
+            @TestMetadata("javaArrayOfMaybeNullableWithNotNullLoopVariable.kt")
+            public void testJavaArrayOfMaybeNullableWithNotNullLoopVariable() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaArrayOfMaybeNullableWithNotNullLoopVariable.kt");
+            }
+
+            @TestMetadata("javaArrayOfMaybeNullableWithNotNullLoopVariableFailFast.kt")
+            public void testJavaArrayOfMaybeNullableWithNotNullLoopVariableFailFast() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaArrayOfMaybeNullableWithNotNullLoopVariableFailFast.kt");
+            }
+
+            @TestMetadata("javaCollectionOfExplicitNotNull.kt")
+            public void testJavaCollectionOfExplicitNotNull() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfExplicitNotNull.kt");
+            }
+
+            @TestMetadata("javaCollectionOfExplicitNotNullFailFast.kt")
+            public void testJavaCollectionOfExplicitNotNullFailFast() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfExplicitNotNullFailFast.kt");
+            }
+
+            @TestMetadata("javaCollectionOfExplicitNullable.kt")
+            public void testJavaCollectionOfExplicitNullable() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfExplicitNullable.kt");
+            }
+
+            @TestMetadata("javaCollectionOfInheritedNotNull.kt")
+            public void testJavaCollectionOfInheritedNotNull() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfInheritedNotNull.kt");
+            }
+
+            @TestMetadata("javaCollectionOfInheritedNotNullFailFast.kt")
+            public void testJavaCollectionOfInheritedNotNullFailFast() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfInheritedNotNullFailFast.kt");
+            }
+
+            @TestMetadata("javaCollectionOfMaybeNullable.kt")
+            public void testJavaCollectionOfMaybeNullable() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfMaybeNullable.kt");
+            }
+
+            @TestMetadata("javaCollectionOfMaybeNullableWithNotNullLoopVariable.kt")
+            public void testJavaCollectionOfMaybeNullableWithNotNullLoopVariable() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfMaybeNullableWithNotNullLoopVariable.kt");
+            }
+
+            @TestMetadata("javaCollectionOfMaybeNullableWithNotNullLoopVariableFailFast.kt")
+            public void testJavaCollectionOfMaybeNullableWithNotNullLoopVariableFailFast() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfMaybeNullableWithNotNullLoopVariableFailFast.kt");
+            }
+
+            @TestMetadata("javaCollectionOfNotNullFromStdlib.kt")
+            public void testJavaCollectionOfNotNullFromStdlib() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfNotNullFromStdlib.kt");
+            }
+
+            @TestMetadata("javaCollectionOfNotNullFromStdlibToTypedArray.kt")
+            public void testJavaCollectionOfNotNullFromStdlibToTypedArray() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfNotNullFromStdlibToTypedArray.kt");
+            }
+
+            @TestMetadata("javaCollectionOfNotNullToTypedArray.kt")
+            public void testJavaCollectionOfNotNullToTypedArray() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfNotNullToTypedArray.kt");
+            }
+
+            @TestMetadata("javaCollectionOfNotNullToTypedArrayFailFast.kt")
+            public void testJavaCollectionOfNotNullToTypedArrayFailFast() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfNotNullToTypedArrayFailFast.kt");
+            }
+
+            @TestMetadata("javaIteratorOfNotNull.kt")
+            public void testJavaIteratorOfNotNull() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaIteratorOfNotNull.kt");
+            }
+
+            @TestMetadata("javaIteratorOfNotNullFailFast.kt")
+            public void testJavaIteratorOfNotNullFailFast() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaIteratorOfNotNullFailFast.kt");
+            }
+
+            @TestMetadata("compiler/testData/codegen/box/ranges/javaInterop/withIndex")
+            @TestDataPath("$PROJECT_ROOT")
+            @RunWith(JUnit3RunnerWithInners.class)
+            public static class WithIndex extends AbstractFirBlackBoxCodegenTest {
+                private void runTest(String testDataFilePath) throws Exception {
+                    KotlinTestUtils.runTestWithCustomIgnoreDirective(this::doTest, TargetBackend.JVM_IR, testDataFilePath, "// IGNORE_BACKEND_FIR: ");
+                }
+
+                public void testAllFilesPresentInWithIndex() throws Exception {
+                    KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/ranges/javaInterop/withIndex"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+                }
+
+                @TestMetadata("javaArrayOfInheritedNotNullWithIndex.kt")
+                public void testJavaArrayOfInheritedNotNullWithIndex() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaArrayOfInheritedNotNullWithIndex.kt");
+                }
+
+                @TestMetadata("javaArrayOfInheritedNotNullWithIndexFailFast.kt")
+                public void testJavaArrayOfInheritedNotNullWithIndexFailFast() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaArrayOfInheritedNotNullWithIndexFailFast.kt");
+                }
+
+                @TestMetadata("javaArrayOfMaybeNullableWithIndex.kt")
+                public void testJavaArrayOfMaybeNullableWithIndex() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaArrayOfMaybeNullableWithIndex.kt");
+                }
+
+                @TestMetadata("javaArrayOfMaybeNullableWithIndexWithNotNullLoopVariable.kt")
+                public void testJavaArrayOfMaybeNullableWithIndexWithNotNullLoopVariable() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaArrayOfMaybeNullableWithIndexWithNotNullLoopVariable.kt");
+                }
+
+                @TestMetadata("javaArrayOfMaybeNullableWithIndexWithNotNullLoopVariableFailFast.kt")
+                public void testJavaArrayOfMaybeNullableWithIndexWithNotNullLoopVariableFailFast() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaArrayOfMaybeNullableWithIndexWithNotNullLoopVariableFailFast.kt");
+                }
+
+                @TestMetadata("javaCollectionOfExplicitNotNullWithIndex.kt")
+                public void testJavaCollectionOfExplicitNotNullWithIndex() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaCollectionOfExplicitNotNullWithIndex.kt");
+                }
+
+                @TestMetadata("javaCollectionOfExplicitNotNullWithIndexFailFast.kt")
+                public void testJavaCollectionOfExplicitNotNullWithIndexFailFast() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaCollectionOfExplicitNotNullWithIndexFailFast.kt");
+                }
+
+                @TestMetadata("javaCollectionOfExplicitNullableWithIndex.kt")
+                public void testJavaCollectionOfExplicitNullableWithIndex() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaCollectionOfExplicitNullableWithIndex.kt");
+                }
+
+                @TestMetadata("javaCollectionOfMaybeNullableWithIndex.kt")
+                public void testJavaCollectionOfMaybeNullableWithIndex() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaCollectionOfMaybeNullableWithIndex.kt");
+                }
+
+                @TestMetadata("javaCollectionOfMaybeNullableWithIndexWithNotNullLoopVariable.kt")
+                public void testJavaCollectionOfMaybeNullableWithIndexWithNotNullLoopVariable() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaCollectionOfMaybeNullableWithIndexWithNotNullLoopVariable.kt");
+                }
+
+                @TestMetadata("javaCollectionOfMaybeNullableWithIndexWithNotNullLoopVariableFailFast.kt")
+                public void testJavaCollectionOfMaybeNullableWithIndexWithNotNullLoopVariableFailFast() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaCollectionOfMaybeNullableWithIndexWithNotNullLoopVariableFailFast.kt");
+                }
+
+                @TestMetadata("javaIteratorOfNotNullWithIndex.kt")
+                public void testJavaIteratorOfNotNullWithIndex() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaIteratorOfNotNullWithIndex.kt");
+                }
+
+                @TestMetadata("javaIteratorOfNotNullWithIndexFailFast.kt")
+                public void testJavaIteratorOfNotNullWithIndexFailFast() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaIteratorOfNotNullWithIndexFailFast.kt");
+                }
             }
         }
 

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -15796,7 +15796,7 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             }
 
             public void testAllFilesPresentInMultiModule() throws Exception {
-                KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/codegen/box/multiplatform/multiModule"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.JVM_IR, true);
+                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/multiplatform/multiModule"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
             }
 
             @TestMetadata("expectActualLink.kt")
@@ -19370,6 +19370,192 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             @TestMetadata("forInUntilIntMinValueReversed.kt")
             public void testForInUntilIntMinValueReversed() throws Exception {
                 runTest("compiler/testData/codegen/box/ranges/forWithPossibleOverflow/forInUntilIntMinValueReversed.kt");
+            }
+        }
+
+        @TestMetadata("compiler/testData/codegen/box/ranges/javaInterop")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class JavaInterop extends AbstractIrBlackBoxCodegenTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM_IR, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInJavaInterop() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/ranges/javaInterop"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+            }
+
+            @TestMetadata("javaArrayOfInheritedNotNull.kt")
+            public void testJavaArrayOfInheritedNotNull() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaArrayOfInheritedNotNull.kt");
+            }
+
+            @TestMetadata("javaArrayOfInheritedNotNullFailFast.kt")
+            public void testJavaArrayOfInheritedNotNullFailFast() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaArrayOfInheritedNotNullFailFast.kt");
+            }
+
+            @TestMetadata("javaArrayOfMaybeNullable.kt")
+            public void testJavaArrayOfMaybeNullable() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaArrayOfMaybeNullable.kt");
+            }
+
+            @TestMetadata("javaArrayOfMaybeNullableWithNotNullLoopVariable.kt")
+            public void testJavaArrayOfMaybeNullableWithNotNullLoopVariable() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaArrayOfMaybeNullableWithNotNullLoopVariable.kt");
+            }
+
+            @TestMetadata("javaArrayOfMaybeNullableWithNotNullLoopVariableFailFast.kt")
+            public void testJavaArrayOfMaybeNullableWithNotNullLoopVariableFailFast() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaArrayOfMaybeNullableWithNotNullLoopVariableFailFast.kt");
+            }
+
+            @TestMetadata("javaCollectionOfExplicitNotNull.kt")
+            public void testJavaCollectionOfExplicitNotNull() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfExplicitNotNull.kt");
+            }
+
+            @TestMetadata("javaCollectionOfExplicitNotNullFailFast.kt")
+            public void testJavaCollectionOfExplicitNotNullFailFast() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfExplicitNotNullFailFast.kt");
+            }
+
+            @TestMetadata("javaCollectionOfExplicitNullable.kt")
+            public void testJavaCollectionOfExplicitNullable() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfExplicitNullable.kt");
+            }
+
+            @TestMetadata("javaCollectionOfInheritedNotNull.kt")
+            public void testJavaCollectionOfInheritedNotNull() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfInheritedNotNull.kt");
+            }
+
+            @TestMetadata("javaCollectionOfInheritedNotNullFailFast.kt")
+            public void testJavaCollectionOfInheritedNotNullFailFast() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfInheritedNotNullFailFast.kt");
+            }
+
+            @TestMetadata("javaCollectionOfMaybeNullable.kt")
+            public void testJavaCollectionOfMaybeNullable() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfMaybeNullable.kt");
+            }
+
+            @TestMetadata("javaCollectionOfMaybeNullableWithNotNullLoopVariable.kt")
+            public void testJavaCollectionOfMaybeNullableWithNotNullLoopVariable() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfMaybeNullableWithNotNullLoopVariable.kt");
+            }
+
+            @TestMetadata("javaCollectionOfMaybeNullableWithNotNullLoopVariableFailFast.kt")
+            public void testJavaCollectionOfMaybeNullableWithNotNullLoopVariableFailFast() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfMaybeNullableWithNotNullLoopVariableFailFast.kt");
+            }
+
+            @TestMetadata("javaCollectionOfNotNullFromStdlib.kt")
+            public void testJavaCollectionOfNotNullFromStdlib() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfNotNullFromStdlib.kt");
+            }
+
+            @TestMetadata("javaCollectionOfNotNullFromStdlibToTypedArray.kt")
+            public void testJavaCollectionOfNotNullFromStdlibToTypedArray() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfNotNullFromStdlibToTypedArray.kt");
+            }
+
+            @TestMetadata("javaCollectionOfNotNullToTypedArray.kt")
+            public void testJavaCollectionOfNotNullToTypedArray() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfNotNullToTypedArray.kt");
+            }
+
+            @TestMetadata("javaCollectionOfNotNullToTypedArrayFailFast.kt")
+            public void testJavaCollectionOfNotNullToTypedArrayFailFast() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfNotNullToTypedArrayFailFast.kt");
+            }
+
+            @TestMetadata("javaIteratorOfNotNull.kt")
+            public void testJavaIteratorOfNotNull() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaIteratorOfNotNull.kt");
+            }
+
+            @TestMetadata("javaIteratorOfNotNullFailFast.kt")
+            public void testJavaIteratorOfNotNullFailFast() throws Exception {
+                runTest("compiler/testData/codegen/box/ranges/javaInterop/javaIteratorOfNotNullFailFast.kt");
+            }
+
+            @TestMetadata("compiler/testData/codegen/box/ranges/javaInterop/withIndex")
+            @TestDataPath("$PROJECT_ROOT")
+            @RunWith(JUnit3RunnerWithInners.class)
+            public static class WithIndex extends AbstractIrBlackBoxCodegenTest {
+                private void runTest(String testDataFilePath) throws Exception {
+                    KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM_IR, testDataFilePath);
+                }
+
+                public void testAllFilesPresentInWithIndex() throws Exception {
+                    KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/ranges/javaInterop/withIndex"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+                }
+
+                @TestMetadata("javaArrayOfInheritedNotNullWithIndex.kt")
+                public void testJavaArrayOfInheritedNotNullWithIndex() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaArrayOfInheritedNotNullWithIndex.kt");
+                }
+
+                @TestMetadata("javaArrayOfInheritedNotNullWithIndexFailFast.kt")
+                public void testJavaArrayOfInheritedNotNullWithIndexFailFast() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaArrayOfInheritedNotNullWithIndexFailFast.kt");
+                }
+
+                @TestMetadata("javaArrayOfMaybeNullableWithIndex.kt")
+                public void testJavaArrayOfMaybeNullableWithIndex() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaArrayOfMaybeNullableWithIndex.kt");
+                }
+
+                @TestMetadata("javaArrayOfMaybeNullableWithIndexWithNotNullLoopVariable.kt")
+                public void testJavaArrayOfMaybeNullableWithIndexWithNotNullLoopVariable() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaArrayOfMaybeNullableWithIndexWithNotNullLoopVariable.kt");
+                }
+
+                @TestMetadata("javaArrayOfMaybeNullableWithIndexWithNotNullLoopVariableFailFast.kt")
+                public void testJavaArrayOfMaybeNullableWithIndexWithNotNullLoopVariableFailFast() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaArrayOfMaybeNullableWithIndexWithNotNullLoopVariableFailFast.kt");
+                }
+
+                @TestMetadata("javaCollectionOfExplicitNotNullWithIndex.kt")
+                public void testJavaCollectionOfExplicitNotNullWithIndex() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaCollectionOfExplicitNotNullWithIndex.kt");
+                }
+
+                @TestMetadata("javaCollectionOfExplicitNotNullWithIndexFailFast.kt")
+                public void testJavaCollectionOfExplicitNotNullWithIndexFailFast() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaCollectionOfExplicitNotNullWithIndexFailFast.kt");
+                }
+
+                @TestMetadata("javaCollectionOfExplicitNullableWithIndex.kt")
+                public void testJavaCollectionOfExplicitNullableWithIndex() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaCollectionOfExplicitNullableWithIndex.kt");
+                }
+
+                @TestMetadata("javaCollectionOfMaybeNullableWithIndex.kt")
+                public void testJavaCollectionOfMaybeNullableWithIndex() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaCollectionOfMaybeNullableWithIndex.kt");
+                }
+
+                @TestMetadata("javaCollectionOfMaybeNullableWithIndexWithNotNullLoopVariable.kt")
+                public void testJavaCollectionOfMaybeNullableWithIndexWithNotNullLoopVariable() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaCollectionOfMaybeNullableWithIndexWithNotNullLoopVariable.kt");
+                }
+
+                @TestMetadata("javaCollectionOfMaybeNullableWithIndexWithNotNullLoopVariableFailFast.kt")
+                public void testJavaCollectionOfMaybeNullableWithIndexWithNotNullLoopVariableFailFast() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaCollectionOfMaybeNullableWithIndexWithNotNullLoopVariableFailFast.kt");
+                }
+
+                @TestMetadata("javaIteratorOfNotNullWithIndex.kt")
+                public void testJavaIteratorOfNotNullWithIndex() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaIteratorOfNotNullWithIndex.kt");
+                }
+
+                @TestMetadata("javaIteratorOfNotNullWithIndexFailFast.kt")
+                public void testJavaIteratorOfNotNullWithIndexFailFast() throws Exception {
+                    runTest("compiler/testData/codegen/box/ranges/javaInterop/withIndex/javaIteratorOfNotNullWithIndexFailFast.kt");
+                }
             }
         }
 

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -12921,7 +12921,7 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             }
 
             public void testAllFilesPresentInMultiModule() throws Exception {
-                KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/codegen/box/multiplatform/multiModule"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.JS_IR, true);
+                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/multiplatform/multiModule"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR, true);
             }
 
             @TestMetadata("expectActualLink.kt")
@@ -16491,6 +16491,32 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             @TestMetadata("forInUntilIntMinValueReversed.kt")
             public void testForInUntilIntMinValueReversed() throws Exception {
                 runTest("compiler/testData/codegen/box/ranges/forWithPossibleOverflow/forInUntilIntMinValueReversed.kt");
+            }
+        }
+
+        @TestMetadata("compiler/testData/codegen/box/ranges/javaInterop")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class JavaInterop extends AbstractIrJsCodegenBoxTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest0(this::doTest, TargetBackend.JS_IR, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInJavaInterop() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/ranges/javaInterop"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR, true);
+            }
+
+            @TestMetadata("compiler/testData/codegen/box/ranges/javaInterop/withIndex")
+            @TestDataPath("$PROJECT_ROOT")
+            @RunWith(JUnit3RunnerWithInners.class)
+            public static class WithIndex extends AbstractIrJsCodegenBoxTest {
+                private void runTest(String testDataFilePath) throws Exception {
+                    KotlinTestUtils.runTest0(this::doTest, TargetBackend.JS_IR, testDataFilePath);
+                }
+
+                public void testAllFilesPresentInWithIndex() throws Exception {
+                    KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/ranges/javaInterop/withIndex"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR, true);
+                }
             }
         }
 

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -14061,7 +14061,7 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             }
 
             public void testAllFilesPresentInMultiModule() throws Exception {
-                KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("compiler/testData/codegen/box/multiplatform/multiModule"), Pattern.compile("^(.+)\\.kt$"), TargetBackend.JS, true);
+                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/multiplatform/multiModule"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS, true);
             }
 
             @TestMetadata("expectActualLink.kt")
@@ -17671,6 +17671,32 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             @TestMetadata("forInUntilIntMinValueReversed.kt")
             public void testForInUntilIntMinValueReversed() throws Exception {
                 runTest("compiler/testData/codegen/box/ranges/forWithPossibleOverflow/forInUntilIntMinValueReversed.kt");
+            }
+        }
+
+        @TestMetadata("compiler/testData/codegen/box/ranges/javaInterop")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class JavaInterop extends AbstractJsCodegenBoxTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest0(this::doTest, TargetBackend.JS, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInJavaInterop() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/ranges/javaInterop"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS, true);
+            }
+
+            @TestMetadata("compiler/testData/codegen/box/ranges/javaInterop/withIndex")
+            @TestDataPath("$PROJECT_ROOT")
+            @RunWith(JUnit3RunnerWithInners.class)
+            public static class WithIndex extends AbstractJsCodegenBoxTest {
+                private void runTest(String testDataFilePath) throws Exception {
+                    KotlinTestUtils.runTest0(this::doTest, TargetBackend.JS, testDataFilePath);
+                }
+
+                public void testAllFilesPresentInWithIndex() throws Exception {
+                    KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/ranges/javaInterop/withIndex"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS, true);
+                }
             }
         }
 


### PR DESCRIPTION
There were issues when we have iterables from Java where the element type has "not null" type information (i.e., `@EnhancedNullability`).

We discovered this issue when compiling OkHttp with JVM_IR, specifically here is where it breaks: https://github.com/square/okhttp/blob/e1d9cd2d905b6209253a868429eb4b9b49ee7a99/okhttp/src/main/java/okhttp3/internal/cache/DiskLruCache.kt#L637

@dnpetrov I could use a look here since you recently did some work around `@EnhancedNullability` in JVM_IR. If you search for `// IGNORE_BACKEND: JVM` you will see some behavioral differences between JVM IR and non-IR. (For example, see`compiler/testData/codegen/box/ranges/javaInterop/javaCollectionOfExplicitNotNullFailFast.kt`.) The not-null assertion is not generated when assigning to the loop variable (could be in a destructuring declaration or not). The root cause seems to be that the loop variable is a `KtParameter` and `CodegenAnnotatingVisitor/RuntimeAssertionsOnDeclarationBodyChecker` do not analyze the need for not-null assertions on KtParameters (or `KtDestructuringDeclaration/Entry`).