### PR TITLE
JVM IR: Fix line numbers in callable reference classes

### DIFF
--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/LocalDeclarationsLowering.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/LocalDeclarationsLowering.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.backend.common.BackendContext
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.IrElementVisitorVoidWithContext
 import org.jetbrains.kotlin.backend.common.ScopeWithIr
-import org.jetbrains.kotlin.backend.common.descriptors.*
+import org.jetbrains.kotlin.backend.common.descriptors.synthesizedName
 import org.jetbrains.kotlin.backend.common.ir.*
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.ReceiverParameterDescriptor
@@ -17,6 +17,7 @@ import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.descriptors.Visibility
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.IrStatement
+import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
 import org.jetbrains.kotlin.ir.builders.Scope
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrConstructorImpl
@@ -411,9 +412,9 @@ class LocalDeclarationsLowering(
                     0,
                     localClassContext.capturedValueToField.map { (capturedValue, field) ->
                         IrSetFieldImpl(
-                            irClass.startOffset, irClass.endOffset, field.symbol,
-                            IrGetValueImpl(irClass.startOffset, irClass.endOffset, irClass.thisReceiver!!.symbol),
-                            constructorContext.irGet(irClass.startOffset, irClass.endOffset, capturedValue)!!,
+                            UNDEFINED_OFFSET, UNDEFINED_OFFSET, field.symbol,
+                            IrGetValueImpl(UNDEFINED_OFFSET, UNDEFINED_OFFSET, irClass.thisReceiver!!.symbol),
+                            constructorContext.irGet(UNDEFINED_OFFSET, UNDEFINED_OFFSET, capturedValue)!!,
                             context.irBuiltIns.unitType,
                             STATEMENT_ORIGIN_INITIALIZER_OF_FIELD_FOR_CAPTURED_VALUE
                         )

--- a/compiler/testData/debug/stepping/callableReference.kt
+++ b/compiler/testData/debug/stepping/callableReference.kt
@@ -1,0 +1,23 @@
+// FILE: test.kt
+fun box() {
+    var x = false
+    f {
+        x = true
+    }
+}
+
+fun f(block: () -> Unit) {
+    block()
+}
+
+// LINENUMBERS
+// TestKt.box():3
+// TestKt.box():4
+// TestKt.f(kotlin.jvm.functions.Function0):10
+// TestKt$box$1.invoke():5
+// TestKt$box$1.invoke():6
+// TestKt$box$1.invoke():-1
+// TestKt$box$1.invoke():-1
+// TestKt.f(kotlin.jvm.functions.Function0):10
+// TestKt.f(kotlin.jvm.functions.Function0):11
+// TestKt.box():7

--- a/compiler/testData/debug/stepping/inlineCallableReference.kt
+++ b/compiler/testData/debug/stepping/inlineCallableReference.kt
@@ -1,0 +1,20 @@
+// FILE: test.kt
+fun box() {
+    var x = false
+    f {
+        x = true
+    }
+}
+
+inline fun f(block: () -> Unit) {
+    block()
+}
+
+// LINENUMBERS
+// TestKt.box():3
+// TestKt.box():4
+// TestKt.box():10
+// TestKt.box():5
+// TestKt.box():6
+// TestKt.box():11
+// TestKt.box():7

--- a/compiler/testData/debug/stepping/inlineNamedCallableReference.kt
+++ b/compiler/testData/debug/stepping/inlineNamedCallableReference.kt
@@ -1,0 +1,20 @@
+// FILE: test.kt
+fun box() {
+    var x = false
+    f(::g)
+}
+
+inline fun f(block: () -> Unit) {
+    block()
+}
+
+fun g() {}
+
+// LINENUMBERS
+// TestKt.box():3
+// TestKt.box():4
+// TestKt.box():8
+// TestKt.box():4
+// TestKt.g():11
+// TestKt.box():9
+// TestKt.box():5

--- a/compiler/testData/debug/stepping/namedCallableReference.kt
+++ b/compiler/testData/debug/stepping/namedCallableReference.kt
@@ -1,0 +1,23 @@
+// FILE: test.kt
+fun box() {
+    var x = false
+    f(::g)
+}
+
+fun f(block: () -> Unit) {
+    block()
+}
+
+fun g() {}
+
+// LINENUMBERS
+// TestKt.box():3
+// TestKt.box():4
+// TestKt.f(kotlin.jvm.functions.Function0):8
+// TestKt.g():11
+// TestKt$box$1.invoke():4
+// TestKt$box$1.invoke():-1
+// TestKt$box$1.invoke():-1
+// TestKt.f(kotlin.jvm.functions.Function0):8
+// TestKt.f(kotlin.jvm.functions.Function0):9
+// TestKt.box():5

--- a/compiler/testData/lineNumber/custom/functionCallWithLambdaParam.kt
+++ b/compiler/testData/lineNumber/custom/functionCallWithLambdaParam.kt
@@ -12,5 +12,4 @@ fun foo(f: () -> Unit) {
     f()
 }
 
-// IGNORE_BACKEND: JVM_IR
 // 2 6 9 12 13 3 4 7 8

--- a/compiler/tests/org/jetbrains/kotlin/codegen/debugInformation/IrSteppingTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/debugInformation/IrSteppingTestGenerated.java
@@ -32,6 +32,12 @@ public class IrSteppingTestGenerated extends AbstractIrSteppingTest {
     }
 
     @Test
+    @TestMetadata("callableReference.kt")
+    public void testCallableReference() throws Exception {
+        runTest("compiler/testData/debug/stepping/callableReference.kt");
+    }
+
+    @Test
     @TestMetadata("conjunction.kt")
     public void testConjunction() throws Exception {
         runTest("compiler/testData/debug/stepping/conjunction.kt");
@@ -53,6 +59,24 @@ public class IrSteppingTestGenerated extends AbstractIrSteppingTest {
     @TestMetadata("IfTrueThenFalse.kt")
     public void testIfTrueThenFalse() throws Exception {
         runTest("compiler/testData/debug/stepping/IfTrueThenFalse.kt");
+    }
+
+    @Test
+    @TestMetadata("inlineCallableReference.kt")
+    public void testInlineCallableReference() throws Exception {
+        runTest("compiler/testData/debug/stepping/inlineCallableReference.kt");
+    }
+
+    @Test
+    @TestMetadata("inlineNamedCallableReference.kt")
+    public void testInlineNamedCallableReference() throws Exception {
+        runTest("compiler/testData/debug/stepping/inlineNamedCallableReference.kt");
+    }
+
+    @Test
+    @TestMetadata("namedCallableReference.kt")
+    public void testNamedCallableReference() throws Exception {
+        runTest("compiler/testData/debug/stepping/namedCallableReference.kt");
     }
 
     @Test

--- a/compiler/tests/org/jetbrains/kotlin/codegen/debugInformation/SteppingTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/debugInformation/SteppingTestGenerated.java
@@ -32,6 +32,12 @@ public class SteppingTestGenerated extends AbstractSteppingTest {
     }
 
     @Test
+    @TestMetadata("callableReference.kt")
+    public void testCallableReference() throws Exception {
+        runTest("compiler/testData/debug/stepping/callableReference.kt");
+    }
+
+    @Test
     @TestMetadata("conjunction.kt")
     public void testConjunction() throws Exception {
         runTest("compiler/testData/debug/stepping/conjunction.kt");
@@ -53,6 +59,24 @@ public class SteppingTestGenerated extends AbstractSteppingTest {
     @TestMetadata("IfTrueThenFalse.kt")
     public void testIfTrueThenFalse() throws Exception {
         runTest("compiler/testData/debug/stepping/IfTrueThenFalse.kt");
+    }
+
+    @Test
+    @TestMetadata("inlineCallableReference.kt")
+    public void testInlineCallableReference() throws Exception {
+        runTest("compiler/testData/debug/stepping/inlineCallableReference.kt");
+    }
+
+    @Test
+    @TestMetadata("inlineNamedCallableReference.kt")
+    public void testInlineNamedCallableReference() throws Exception {
+        runTest("compiler/testData/debug/stepping/inlineNamedCallableReference.kt");
+    }
+
+    @Test
+    @TestMetadata("namedCallableReference.kt")
+    public void testNamedCallableReference() throws Exception {
+        runTest("compiler/testData/debug/stepping/namedCallableReference.kt");
     }
 
     @Test


### PR DESCRIPTION
In particular, there should be no line numbers in the constructor of a callable reference, since otherwise the debugger (smart) steps into the constructor, which is pretty jarring.