### PR TITLE
KT-35536: Fix enum constants in KAPT

### DIFF
--- a/plugins/kapt3/kapt3-compiler/testData/converter/unsafePropertyInitializers.kt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/unsafePropertyInitializers.kt
@@ -22,3 +22,12 @@ object Boo {
     val z = foo()
     fun foo() = "abc"
 }
+
+class HavingState {
+    val state = State.START
+}
+
+enum class State {
+    START,
+    FINISH,
+}

--- a/plugins/kapt3/kapt3-compiler/testData/converter/unsafePropertyInitializers.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/unsafePropertyInitializers.txt
@@ -116,3 +116,37 @@ public final class Foo {
         super();
     }
 }
+
+////////////////////
+
+
+import java.lang.System;
+
+@kotlin.Metadata()
+public final class HavingState {
+    @org.jetbrains.annotations.NotNull()
+    private final State state = State.START;
+
+    @org.jetbrains.annotations.NotNull()
+    public final State getState() {
+        return null;
+    }
+
+    public HavingState() {
+        super();
+    }
+}
+
+////////////////////
+
+
+import java.lang.System;
+
+@kotlin.Metadata()
+public enum State {
+    /*public static final*/ START /* = new State() */,
+    /*public static final*/ FINISH /* = new State() */;
+
+    State() {
+    }
+}


### PR DESCRIPTION
Enum constants are Pair, so make sure to unpack them correctly.