### PR TITLE
KT-35216 <T : AutoCloseable?, R> T.use and <T : Closeable?, R> T.use should have contracts

### DIFF
--- a/libraries/stdlib/jdk7/build.gradle
+++ b/libraries/stdlib/jdk7/build.gradle
@@ -82,7 +82,8 @@ compileKotlin {
             "-Xallow-kotlin-package",
             "-Xmultifile-parts-inherit",
             "-Xnormalize-constructor-calls=enable",
-            "-module-name", project.name
+            "-module-name", project.name,
+            "-Xuse-experimental=kotlin.contracts.ExperimentalContracts",
     ]
 }
 

--- a/libraries/stdlib/jdk7/src/kotlin/AutoCloseable.kt
+++ b/libraries/stdlib/jdk7/src/kotlin/AutoCloseable.kt
@@ -19,6 +19,9 @@
 @file:kotlin.jvm.JvmPackageName("kotlin.jdk7")
 package kotlin
 
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+
 /**
  * Executes the given [block] function on this resource and then closes it down correctly whether an exception
  * is thrown or not.
@@ -32,6 +35,9 @@ package kotlin
 @SinceKotlin("1.2")
 @kotlin.internal.InlineOnly
 public inline fun <T : AutoCloseable?, R> T.use(block: (T) -> R): R {
+    contract {
+        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+    }
     var exception: Throwable? = null
     try {
         return block(this)

--- a/libraries/stdlib/jdk7/test/AutoCloseableContractsTest.kt
+++ b/libraries/stdlib/jdk7/test/AutoCloseableContractsTest.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package kotlin.jdk7.test
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class AutoCloseableContractsTest {
+    @Test
+    fun shouldHaveBlockExactlyOnceContract() {
+        class TestAutoCloseable : AutoCloseable {
+            override fun close() {
+            }
+        }
+
+        val i: Int
+        TestAutoCloseable().use {
+            i = 1
+        }
+        assertEquals(1, i)
+    }
+}

--- a/libraries/stdlib/jvm/src/kotlin/io/Closeable.kt
+++ b/libraries/stdlib/jvm/src/kotlin/io/Closeable.kt
@@ -7,6 +7,8 @@
 package kotlin.io
 
 import java.io.Closeable
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 import kotlin.internal.*
 
 /**
@@ -19,6 +21,9 @@ import kotlin.internal.*
 @InlineOnly
 @RequireKotlin("1.2", versionKind = RequireKotlinVersionKind.COMPILER_VERSION, message = "Requires newer compiler version to be inlined correctly.")
 public inline fun <T : Closeable?, R> T.use(block: (T) -> R): R {
+    contract {
+        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+    }
     var exception: Throwable? = null
     try {
         return block(this)

--- a/libraries/stdlib/jvm/test/io/Closeable.kt
+++ b/libraries/stdlib/jvm/test/io/Closeable.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package test.io
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class CloseableTest {
+    @Test
+    fun shouldHaveBlockExactlyOnceContract() {
+        val i: Int
+        "".byteInputStream().use {
+            i = 1
+        }
+        assertEquals(1, i)
+    }
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-35216