### PR TITLE
Minor: IGNORE_BACKEND: ANY_FIR -> IGNORE_BACKEND_FIR: ANY

### DIFF
--- a/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/fir/Fir2IrTextTestGenerated.java
+++ b/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/fir/Fir2IrTextTestGenerated.java
@@ -22,11 +22,11 @@ import java.util.regex.Pattern;
 @RunWith(JUnit3RunnerWithInners.class)
 public class Fir2IrTextTestGenerated extends AbstractFir2IrTextTest {
     private void runTest(String testDataFilePath) throws Exception {
-        KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY_FIR, testDataFilePath);
+        KotlinTestUtils.runTestWithCustomIgnoreDirective(this::doTest, TargetBackend.ANY, testDataFilePath, "// IGNORE_BACKEND_FIR: ");
     }
 
     public void testAllFilesPresentInIrText() throws Exception {
-        KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/ir/irText"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.ANY_FIR, true);
+        KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/ir/irText"), Pattern.compile("^(.+)\\.kt$"), null, true);
     }
 
     @TestMetadata("compiler/testData/ir/irText/classes")
@@ -34,7 +34,7 @@ public class Fir2IrTextTestGenerated extends AbstractFir2IrTextTest {
     @RunWith(JUnit3RunnerWithInners.class)
     public static class Classes extends AbstractFir2IrTextTest {
         private void runTest(String testDataFilePath) throws Exception {
-            KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY_FIR, testDataFilePath);
+            KotlinTestUtils.runTestWithCustomIgnoreDirective(this::doTest, TargetBackend.ANY, testDataFilePath, "// IGNORE_BACKEND_FIR: ");
         }
 
         @TestMetadata("abstractMembers.kt")
@@ -43,7 +43,7 @@ public class Fir2IrTextTestGenerated extends AbstractFir2IrTextTest {
         }
 
         public void testAllFilesPresentInClasses() throws Exception {
-            KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/ir/irText/classes"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.ANY_FIR, true);
+            KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/ir/irText/classes"), Pattern.compile("^(.+)\\.kt$"), null, true);
         }
 
         @TestMetadata("annotationClasses.kt")
@@ -227,11 +227,11 @@ public class Fir2IrTextTestGenerated extends AbstractFir2IrTextTest {
     @RunWith(JUnit3RunnerWithInners.class)
     public static class Declarations extends AbstractFir2IrTextTest {
         private void runTest(String testDataFilePath) throws Exception {
-            KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY_FIR, testDataFilePath);
+            KotlinTestUtils.runTestWithCustomIgnoreDirective(this::doTest, TargetBackend.ANY, testDataFilePath, "// IGNORE_BACKEND_FIR: ");
         }
 
         public void testAllFilesPresentInDeclarations() throws Exception {
-            KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/ir/irText/declarations"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.ANY_FIR, true);
+            KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/ir/irText/declarations"), Pattern.compile("^(.+)\\.kt$"), null, true);
         }
 
         @TestMetadata("catchParameterInTopLevelProperty.kt")
@@ -334,11 +334,11 @@ public class Fir2IrTextTestGenerated extends AbstractFir2IrTextTest {
         @RunWith(JUnit3RunnerWithInners.class)
         public static class Annotations extends AbstractFir2IrTextTest {
             private void runTest(String testDataFilePath) throws Exception {
-                KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY_FIR, testDataFilePath);
+                KotlinTestUtils.runTestWithCustomIgnoreDirective(this::doTest, TargetBackend.ANY, testDataFilePath, "// IGNORE_BACKEND_FIR: ");
             }
 
             public void testAllFilesPresentInAnnotations() throws Exception {
-                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/ir/irText/declarations/annotations"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.ANY_FIR, true);
+                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/ir/irText/declarations/annotations"), Pattern.compile("^(.+)\\.kt$"), null, true);
             }
 
             @TestMetadata("annotationsInAnnotationArguments.kt")
@@ -497,11 +497,11 @@ public class Fir2IrTextTestGenerated extends AbstractFir2IrTextTest {
         @RunWith(JUnit3RunnerWithInners.class)
         public static class Multiplatform extends AbstractFir2IrTextTest {
             private void runTest(String testDataFilePath) throws Exception {
-                KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY_FIR, testDataFilePath);
+                KotlinTestUtils.runTestWithCustomIgnoreDirective(this::doTest, TargetBackend.ANY, testDataFilePath, "// IGNORE_BACKEND_FIR: ");
             }
 
             public void testAllFilesPresentInMultiplatform() throws Exception {
-                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/ir/irText/declarations/multiplatform"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.ANY_FIR, true);
+                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/ir/irText/declarations/multiplatform"), Pattern.compile("^(.+)\\.kt$"), null, true);
             }
 
             @TestMetadata("expectClassInherited.kt")
@@ -525,11 +525,11 @@ public class Fir2IrTextTestGenerated extends AbstractFir2IrTextTest {
         @RunWith(JUnit3RunnerWithInners.class)
         public static class Parameters extends AbstractFir2IrTextTest {
             private void runTest(String testDataFilePath) throws Exception {
-                KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY_FIR, testDataFilePath);
+                KotlinTestUtils.runTestWithCustomIgnoreDirective(this::doTest, TargetBackend.ANY, testDataFilePath, "// IGNORE_BACKEND_FIR: ");
             }
 
             public void testAllFilesPresentInParameters() throws Exception {
-                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/ir/irText/declarations/parameters"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.ANY_FIR, true);
+                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/ir/irText/declarations/parameters"), Pattern.compile("^(.+)\\.kt$"), null, true);
             }
 
             @TestMetadata("class.kt")
@@ -603,11 +603,11 @@ public class Fir2IrTextTestGenerated extends AbstractFir2IrTextTest {
         @RunWith(JUnit3RunnerWithInners.class)
         public static class ProvideDelegate extends AbstractFir2IrTextTest {
             private void runTest(String testDataFilePath) throws Exception {
-                KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY_FIR, testDataFilePath);
+                KotlinTestUtils.runTestWithCustomIgnoreDirective(this::doTest, TargetBackend.ANY, testDataFilePath, "// IGNORE_BACKEND_FIR: ");
             }
 
             public void testAllFilesPresentInProvideDelegate() throws Exception {
-                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/ir/irText/declarations/provideDelegate"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.ANY_FIR, true);
+                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/ir/irText/declarations/provideDelegate"), Pattern.compile("^(.+)\\.kt$"), null, true);
             }
 
             @TestMetadata("differentReceivers.kt")
@@ -647,11 +647,11 @@ public class Fir2IrTextTestGenerated extends AbstractFir2IrTextTest {
     @RunWith(JUnit3RunnerWithInners.class)
     public static class Errors extends AbstractFir2IrTextTest {
         private void runTest(String testDataFilePath) throws Exception {
-            KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY_FIR, testDataFilePath);
+            KotlinTestUtils.runTestWithCustomIgnoreDirective(this::doTest, TargetBackend.ANY, testDataFilePath, "// IGNORE_BACKEND_FIR: ");
         }
 
         public void testAllFilesPresentInErrors() throws Exception {
-            KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/ir/irText/errors"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.ANY_FIR, true);
+            KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/ir/irText/errors"), Pattern.compile("^(.+)\\.kt$"), null, true);
         }
 
         @TestMetadata("suppressedNonPublicCall.kt")
@@ -670,11 +670,11 @@ public class Fir2IrTextTestGenerated extends AbstractFir2IrTextTest {
     @RunWith(JUnit3RunnerWithInners.class)
     public static class Expressions extends AbstractFir2IrTextTest {
         private void runTest(String testDataFilePath) throws Exception {
-            KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY_FIR, testDataFilePath);
+            KotlinTestUtils.runTestWithCustomIgnoreDirective(this::doTest, TargetBackend.ANY, testDataFilePath, "// IGNORE_BACKEND_FIR: ");
         }
 
         public void testAllFilesPresentInExpressions() throws Exception {
-            KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/ir/irText/expressions"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.ANY_FIR, true);
+            KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/ir/irText/expressions"), Pattern.compile("^(.+)\\.kt$"), null, true);
         }
 
         @TestMetadata("argumentMappedWithError.kt")
@@ -1332,11 +1332,11 @@ public class Fir2IrTextTestGenerated extends AbstractFir2IrTextTest {
         @RunWith(JUnit3RunnerWithInners.class)
         public static class FloatingPointComparisons extends AbstractFir2IrTextTest {
             private void runTest(String testDataFilePath) throws Exception {
-                KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY_FIR, testDataFilePath);
+                KotlinTestUtils.runTestWithCustomIgnoreDirective(this::doTest, TargetBackend.ANY, testDataFilePath, "// IGNORE_BACKEND_FIR: ");
             }
 
             public void testAllFilesPresentInFloatingPointComparisons() throws Exception {
-                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/ir/irText/expressions/floatingPointComparisons"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.ANY_FIR, true);
+                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/ir/irText/expressions/floatingPointComparisons"), Pattern.compile("^(.+)\\.kt$"), null, true);
             }
 
             @TestMetadata("comparableWithDoubleOrFloat.kt")
@@ -1400,11 +1400,11 @@ public class Fir2IrTextTestGenerated extends AbstractFir2IrTextTest {
         @RunWith(JUnit3RunnerWithInners.class)
         public static class Sam extends AbstractFir2IrTextTest {
             private void runTest(String testDataFilePath) throws Exception {
-                KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY_FIR, testDataFilePath);
+                KotlinTestUtils.runTestWithCustomIgnoreDirective(this::doTest, TargetBackend.ANY, testDataFilePath, "// IGNORE_BACKEND_FIR: ");
             }
 
             public void testAllFilesPresentInSam() throws Exception {
-                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/ir/irText/expressions/sam"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.ANY_FIR, true);
+                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/ir/irText/expressions/sam"), Pattern.compile("^(.+)\\.kt$"), null, true);
             }
 
             @TestMetadata("samByProjectedType.kt")
@@ -1454,11 +1454,11 @@ public class Fir2IrTextTestGenerated extends AbstractFir2IrTextTest {
     @RunWith(JUnit3RunnerWithInners.class)
     public static class Lambdas extends AbstractFir2IrTextTest {
         private void runTest(String testDataFilePath) throws Exception {
-            KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY_FIR, testDataFilePath);
+            KotlinTestUtils.runTestWithCustomIgnoreDirective(this::doTest, TargetBackend.ANY, testDataFilePath, "// IGNORE_BACKEND_FIR: ");
         }
 
         public void testAllFilesPresentInLambdas() throws Exception {
-            KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/ir/irText/lambdas"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.ANY_FIR, true);
+            KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/ir/irText/lambdas"), Pattern.compile("^(.+)\\.kt$"), null, true);
         }
 
         @TestMetadata("anonymousFunction.kt")
@@ -1507,11 +1507,11 @@ public class Fir2IrTextTestGenerated extends AbstractFir2IrTextTest {
     @RunWith(JUnit3RunnerWithInners.class)
     public static class Regressions extends AbstractFir2IrTextTest {
         private void runTest(String testDataFilePath) throws Exception {
-            KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY_FIR, testDataFilePath);
+            KotlinTestUtils.runTestWithCustomIgnoreDirective(this::doTest, TargetBackend.ANY, testDataFilePath, "// IGNORE_BACKEND_FIR: ");
         }
 
         public void testAllFilesPresentInRegressions() throws Exception {
-            KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/ir/irText/regressions"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.ANY_FIR, true);
+            KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/ir/irText/regressions"), Pattern.compile("^(.+)\\.kt$"), null, true);
         }
 
         @TestMetadata("coercionInLoop.kt")
@@ -1539,11 +1539,11 @@ public class Fir2IrTextTestGenerated extends AbstractFir2IrTextTest {
         @RunWith(JUnit3RunnerWithInners.class)
         public static class NewInference extends AbstractFir2IrTextTest {
             private void runTest(String testDataFilePath) throws Exception {
-                KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY_FIR, testDataFilePath);
+                KotlinTestUtils.runTestWithCustomIgnoreDirective(this::doTest, TargetBackend.ANY, testDataFilePath, "// IGNORE_BACKEND_FIR: ");
             }
 
             public void testAllFilesPresentInNewInference() throws Exception {
-                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/ir/irText/regressions/newInference"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.ANY_FIR, true);
+                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/ir/irText/regressions/newInference"), Pattern.compile("^(.+)\\.kt$"), null, true);
             }
 
             @TestMetadata("fixationOrder1.kt")
@@ -1558,11 +1558,11 @@ public class Fir2IrTextTestGenerated extends AbstractFir2IrTextTest {
     @RunWith(JUnit3RunnerWithInners.class)
     public static class Singletons extends AbstractFir2IrTextTest {
         private void runTest(String testDataFilePath) throws Exception {
-            KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY_FIR, testDataFilePath);
+            KotlinTestUtils.runTestWithCustomIgnoreDirective(this::doTest, TargetBackend.ANY, testDataFilePath, "// IGNORE_BACKEND_FIR: ");
         }
 
         public void testAllFilesPresentInSingletons() throws Exception {
-            KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/ir/irText/singletons"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.ANY_FIR, true);
+            KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/ir/irText/singletons"), Pattern.compile("^(.+)\\.kt$"), null, true);
         }
 
         @TestMetadata("companion.kt")
@@ -1586,11 +1586,11 @@ public class Fir2IrTextTestGenerated extends AbstractFir2IrTextTest {
     @RunWith(JUnit3RunnerWithInners.class)
     public static class Stubs extends AbstractFir2IrTextTest {
         private void runTest(String testDataFilePath) throws Exception {
-            KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY_FIR, testDataFilePath);
+            KotlinTestUtils.runTestWithCustomIgnoreDirective(this::doTest, TargetBackend.ANY, testDataFilePath, "// IGNORE_BACKEND_FIR: ");
         }
 
         public void testAllFilesPresentInStubs() throws Exception {
-            KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/ir/irText/stubs"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.ANY_FIR, true);
+            KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/ir/irText/stubs"), Pattern.compile("^(.+)\\.kt$"), null, true);
         }
 
         @TestMetadata("builtinMap.kt")
@@ -1664,7 +1664,7 @@ public class Fir2IrTextTestGenerated extends AbstractFir2IrTextTest {
     @RunWith(JUnit3RunnerWithInners.class)
     public static class Types extends AbstractFir2IrTextTest {
         private void runTest(String testDataFilePath) throws Exception {
-            KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY_FIR, testDataFilePath);
+            KotlinTestUtils.runTestWithCustomIgnoreDirective(this::doTest, TargetBackend.ANY, testDataFilePath, "// IGNORE_BACKEND_FIR: ");
         }
 
         @TestMetadata("abbreviatedTypes.kt")
@@ -1673,7 +1673,7 @@ public class Fir2IrTextTestGenerated extends AbstractFir2IrTextTest {
         }
 
         public void testAllFilesPresentInTypes() throws Exception {
-            KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/ir/irText/types"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.ANY_FIR, true);
+            KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/ir/irText/types"), Pattern.compile("^(.+)\\.kt$"), null, true);
         }
 
         @TestMetadata("asOnPlatformType.kt")

--- a/compiler/testData/ir/irText/classes/initValInLambda.fir.txt
+++ b/compiler/testData/ir/irText/classes/initValInLambda.fir.txt
@@ -1,0 +1,42 @@
+FILE fqName:<root> fileName:/initValInLambda.kt
+  CLASS CLASS name:TestInitValInLambdaCalledOnce modality:FINAL visibility:public superTypes:[kotlin.Any]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.TestInitValInLambdaCalledOnce
+    CONSTRUCTOR visibility:public <> () returnType:<root>.TestInitValInLambdaCalledOnce [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:TestInitValInLambdaCalledOnce modality:FINAL visibility:public superTypes:[kotlin.Any]'
+    PROPERTY name:x visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:x type:kotlin.Int visibility:private [final]
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-x> visibility:public modality:FINAL <> ($this:<root>.TestInitValInLambdaCalledOnce) returnType:kotlin.Int
+        correspondingProperty: PROPERTY name:x visibility:public modality:FINAL [val]
+        $this: VALUE_PARAMETER name:<this> type:<root>.TestInitValInLambdaCalledOnce
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-x> (): kotlin.Int declared in <root>.TestInitValInLambdaCalledOnce'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:x type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+              receiver: GET_VAR '<this>: <root>.TestInitValInLambdaCalledOnce declared in <root>.TestInitValInLambdaCalledOnce.<get-x>' type=<root>.TestInitValInLambdaCalledOnce origin=null
+    ANONYMOUS_INITIALIZER isStatic=false
+      BLOCK_BODY
+        CALL 'public final fun run <T, R> (block: kotlin.Function1<T of kotlin.run, R of kotlin.run>): R of kotlin.run [inline] declared in kotlin' type=kotlin.Nothing origin=null
+          <T>: kotlin.Int
+          <R>: kotlin.Nothing
+          $receiver: CONST Int type=kotlin.Int value=1
+          block: FUN_EXPR type=kotlin.Function1<kotlin.Int, kotlin.Nothing> origin=LAMBDA
+            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> ($this:<root>.TestInitValInLambdaCalledOnce) returnType:kotlin.Nothing
+              $this: VALUE_PARAMETER name:<this> type:<root>.TestInitValInLambdaCalledOnce
+              BLOCK_BODY
+                SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:x type:kotlin.Int visibility:private [final]' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: <root>.TestInitValInLambdaCalledOnce declared in <root>.TestInitValInLambdaCalledOnce' type=<root>.TestInitValInLambdaCalledOnce origin=null
+                  value: CONST Int type=kotlin.Int value=0
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean [operator] declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any

--- a/compiler/testData/ir/irText/classes/initValInLambda.kt
+++ b/compiler/testData/ir/irText/classes/initValInLambda.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: ANY
 class TestInitValInLambdaCalledOnce {
     val x: Int
     init {

--- a/compiler/testData/ir/irText/classes/initValInLambda.kt
+++ b/compiler/testData/ir/irText/classes/initValInLambda.kt
@@ -1,4 +1,4 @@
-// IGNORE_BACKEND: ANY_FIR
+// IGNORE_BACKEND_FIR: ANY
 class TestInitValInLambdaCalledOnce {
     val x: Int
     init {

--- a/compiler/tests-common/tests/org/jetbrains/kotlin/test/InTextDirectivesUtils.java
+++ b/compiler/tests-common/tests/org/jetbrains/kotlin/test/InTextDirectivesUtils.java
@@ -230,8 +230,6 @@ public final class InTextDirectivesUtils {
     }
 
     public static boolean isIgnoredTarget(TargetBackend targetBackend, File file, String ignoreBackendDirectivePrefix) {
-        if (targetBackend == TargetBackend.ANY) return false;
-
         List<String> ignoredBackends = findListWithPrefixes(textWithDirectives(file), ignoreBackendDirectivePrefix);
         return ignoredBackends.contains(targetBackend.name());
     }

--- a/compiler/tests-common/tests/org/jetbrains/kotlin/test/KotlinTestUtils.java
+++ b/compiler/tests-common/tests/org/jetbrains/kotlin/test/KotlinTestUtils.java
@@ -763,10 +763,6 @@ public class KotlinTestUtils {
     }
 
     private static DoTest testWithCustomIgnoreDirective(DoTest test, TargetBackend targetBackend, String ignoreDirective) throws Exception {
-        if (targetBackend == TargetBackend.ANY && !AUTOMATICALLY_MUTE_FAILED_TESTS) {
-            return test;
-        }
-
         return filePath -> {
             File testDataFile = new File(filePath);
 

--- a/compiler/tests-common/tests/org/jetbrains/kotlin/test/TargetBackend.kt
+++ b/compiler/tests-common/tests/org/jetbrains/kotlin/test/TargetBackend.kt
@@ -10,7 +10,6 @@ enum class TargetBackend(
     private val compatibleWithTargetBackend: TargetBackend? = null
 ) {
     ANY(false),
-    ANY_FIR(true, ANY),
     JVM(false),
     JVM_IR(true, JVM),
     JS(false),

--- a/compiler/tests/org/jetbrains/kotlin/generators/tests/GenerateCompilerTests.kt
+++ b/compiler/tests/org/jetbrains/kotlin/generators/tests/GenerateCompilerTests.kt
@@ -587,9 +587,13 @@ fun main(args: Array<String>) {
         }
     }
 
-    testGroup("compiler/fir/fir2ir/tests", "compiler/testData") {
+    testGroup(
+        "compiler/fir/fir2ir/tests", "compiler/testData",
+        testRunnerMethodName = "runTestWithCustomIgnoreDirective",
+        additionalRunnerArguments = listOf("\"// IGNORE_BACKEND_FIR: \"")
+    ) {
         testClass<AbstractFir2IrTextTest> {
-            model("ir/irText", targetBackend = TargetBackend.ANY_FIR)
+            model("ir/irText")
         }
     }
 


### PR DESCRIPTION
for consistency with blackbox tests; see https://github.com/JetBrains/kotlin/pull/2900#discussion_r360024713

Also, unmute a test that was fixed in https://github.com/JetBrains/kotlin/commit/ada7f3da6ca9b9c5fc6b2cbb2ebf23db7d3aef22 while the linked PR was being reviewed.