### PR TITLE
KT-35604 Too long quickfix message for "modifier 'open' is not applicable to 'companion object'"

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/AddModifierFix.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/AddModifierFix.kt
@@ -95,6 +95,8 @@ open class AddModifierFix(
                 val nameIdentifier = modifierListOwner.nameIdentifier
                 if (nameIdentifier != null) {
                     name = nameIdentifier.text
+                } else if ((modifierListOwner as? KtObjectDeclaration)?.isCompanion() == true) {
+                    name = "companion object"
                 }
             } else if (modifierListOwner is KtPropertyAccessor) {
                 name = modifierListOwner.namePlaceholder.text

--- a/idea/testData/quickfix/modifiers/openCompanionObject.kt
+++ b/idea/testData/quickfix/modifiers/openCompanionObject.kt
@@ -1,0 +1,6 @@
+// "Make 'companion object' not open" "true"
+class A {
+    <caret>open companion object {
+        fun a(): Int = 1
+    }
+}

--- a/idea/testData/quickfix/modifiers/openCompanionObject.kt.after
+++ b/idea/testData/quickfix/modifiers/openCompanionObject.kt.after
@@ -1,0 +1,6 @@
+// "Make 'companion object' not open" "true"
+class A {
+    companion object {
+        fun a(): Int = 1
+    }
+}

--- a/idea/testData/quickfix/modifiers/openCompanionObject2.kt
+++ b/idea/testData/quickfix/modifiers/openCompanionObject2.kt
@@ -1,0 +1,6 @@
+// "Make 'Foo' not open" "true"
+class A {
+    <caret>open companion object Foo {
+        fun a(): Int = 1
+    }
+}

--- a/idea/testData/quickfix/modifiers/openCompanionObject2.kt.after
+++ b/idea/testData/quickfix/modifiers/openCompanionObject2.kt.after
@@ -1,0 +1,6 @@
+// "Make 'Foo' not open" "true"
+class A {
+    companion object Foo {
+        fun a(): Int = 1
+    }
+}

--- a/idea/testData/quickfix/modifiers/openObject.kt
+++ b/idea/testData/quickfix/modifiers/openObject.kt
@@ -1,0 +1,4 @@
+// "Make 'Foo' not open" "true"
+<caret>open object Foo {
+    fun a(): Int = 1
+}

--- a/idea/testData/quickfix/modifiers/openObject.kt.after
+++ b/idea/testData/quickfix/modifiers/openObject.kt.after
@@ -1,0 +1,4 @@
+// "Make 'Foo' not open" "true"
+object Foo {
+    fun a(): Int = 1
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -8914,6 +8914,16 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
             runTest("idea/testData/quickfix/modifiers/notAnAnnotationClass.kt");
         }
 
+        @TestMetadata("openCompanionObject.kt")
+        public void testOpenCompanionObject() throws Exception {
+            runTest("idea/testData/quickfix/modifiers/openCompanionObject.kt");
+        }
+
+        @TestMetadata("openCompanionObject2.kt")
+        public void testOpenCompanionObject2() throws Exception {
+            runTest("idea/testData/quickfix/modifiers/openCompanionObject2.kt");
+        }
+
         @TestMetadata("openMemberInFinalClass1.kt")
         public void testOpenMemberInFinalClass1() throws Exception {
             runTest("idea/testData/quickfix/modifiers/openMemberInFinalClass1.kt");
@@ -8937,6 +8947,11 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
         @TestMetadata("openModifierInEnum.kt")
         public void testOpenModifierInEnum() throws Exception {
             runTest("idea/testData/quickfix/modifiers/openModifierInEnum.kt");
+        }
+
+        @TestMetadata("openObject.kt")
+        public void testOpenObject() throws Exception {
+            runTest("idea/testData/quickfix/modifiers/openObject.kt");
         }
 
         @TestMetadata("openVarWithPrivateSetter.kt")


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-35604