### PR TITLE
KT-34371 "Surround with lambda" quickfix is not available for suspend lambda parameters.

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/SurroundWithLambdaFix.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/SurroundWithLambdaFix.kt
@@ -4,7 +4,7 @@ import com.intellij.codeInsight.intention.HighPriorityAction
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import org.jetbrains.kotlin.builtins.isFunctionType
+import org.jetbrains.kotlin.builtins.isFunctionOrSuspendFunctionType
 import org.jetbrains.kotlin.diagnostics.Diagnostic
 import org.jetbrains.kotlin.diagnostics.Errors
 import org.jetbrains.kotlin.diagnostics.rendering.DefaultErrorMessages
@@ -67,7 +67,7 @@ class SurroundWithLambdaFix(
                 }
             }
 
-            if (!expectedType.isFunctionType) return null
+            if (!expectedType.isFunctionOrSuspendFunctionType) return null
             if (expectedType.arguments.size != 1) return null
             val lambdaReturnType = expectedType.arguments[0].type
 

--- a/idea/testData/quickfix/typeMismatch/paramTypeLambdaMatchSuspend.kt
+++ b/idea/testData/quickfix/typeMismatch/paramTypeLambdaMatchSuspend.kt
@@ -1,0 +1,6 @@
+// "Surround with lambda" "true"
+fun foo(action: suspend () -> String) {}
+
+fun usage() {
+    foo("oraora"<caret>)
+}

--- a/idea/testData/quickfix/typeMismatch/paramTypeLambdaMatchSuspend.kt.after
+++ b/idea/testData/quickfix/typeMismatch/paramTypeLambdaMatchSuspend.kt.after
@@ -1,0 +1,6 @@
+// "Surround with lambda" "true"
+fun foo(action: suspend () -> String) {}
+
+fun usage() {
+    foo({ "oraora" })
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -13445,6 +13445,11 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
             runTest("idea/testData/quickfix/typeMismatch/paramTypeLambdaMatchSubclass.kt");
         }
 
+        @TestMetadata("paramTypeLambdaMatchSuspend.kt")
+        public void testParamTypeLambdaMatchSuspend() throws Exception {
+            runTest("idea/testData/quickfix/typeMismatch/paramTypeLambdaMatchSuspend.kt");
+        }
+
         @TestMetadata("paramTypeLambdaMismatch.kt")
         public void testParamTypeLambdaMismatch() throws Exception {
             runTest("idea/testData/quickfix/typeMismatch/paramTypeLambdaMismatch.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-34371