### PR TITLE
IR: work around a bug in interface delegation descriptors

### DIFF
--- a/compiler/testData/compileKotlinAgainstKotlin/delegatedDefault.kt
+++ b/compiler/testData/compileKotlinAgainstKotlin/delegatedDefault.kt
@@ -1,0 +1,17 @@
+// FILE: A.kt
+package lib
+
+interface A {
+    fun f(x: String = "OK"): String
+}
+
+class B : A {
+    override fun f(x: String) = x
+}
+
+class C(val x: A) : A by x
+
+// FILE: B.kt
+import lib.*
+
+fun box() = C(B()).f()

--- a/compiler/tests/org/jetbrains/kotlin/codegen/CompileKotlinAgainstKotlinTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/CompileKotlinAgainstKotlinTestGenerated.java
@@ -118,6 +118,11 @@ public class CompileKotlinAgainstKotlinTestGenerated extends AbstractCompileKotl
         runTest("compiler/testData/compileKotlinAgainstKotlin/defaultLambdaRegeneration2.kt");
     }
 
+    @TestMetadata("delegatedDefault.kt")
+    public void testDelegatedDefault() throws Exception {
+        runTest("compiler/testData/compileKotlinAgainstKotlin/delegatedDefault.kt");
+    }
+
     @TestMetadata("doublyNestedClass.kt")
     public void testDoublyNestedClass() throws Exception {
         runTest("compiler/testData/compileKotlinAgainstKotlin/doublyNestedClass.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrCompileKotlinAgainstKotlinTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrCompileKotlinAgainstKotlinTestGenerated.java
@@ -113,6 +113,11 @@ public class IrCompileKotlinAgainstKotlinTestGenerated extends AbstractIrCompile
         runTest("compiler/testData/compileKotlinAgainstKotlin/defaultLambdaRegeneration2.kt");
     }
 
+    @TestMetadata("delegatedDefault.kt")
+    public void testDelegatedDefault() throws Exception {
+        runTest("compiler/testData/compileKotlinAgainstKotlin/delegatedDefault.kt");
+    }
+
     @TestMetadata("doublyNestedClass.kt")
     public void testDoublyNestedClass() throws Exception {
         runTest("compiler/testData/compileKotlinAgainstKotlin/doublyNestedClass.kt");


### PR DESCRIPTION
    interface I {
        fun f(x: Int = 1)
    }
    class C(val y: I) : I by y {
        // implicit `override fun f(x: Int) = y.f(x)` has a default value for `x`
    }

-- the only case where a function with overridden symbols has defaults.