### PR TITLE
KT-20120 fixing bug for Java 9 Deprecated

### DIFF
--- a/nj2k/src/org/jetbrains/kotlin/nj2k/conversions/JavaAnnotationsConversion.kt
+++ b/nj2k/src/org/jetbrains/kotlin/nj2k/conversions/JavaAnnotationsConversion.kt
@@ -28,10 +28,7 @@ class JavaAnnotationsConversion(context: NewJ2kConverterContext) : RecursiveAppl
     private fun processAnnotation(annotation: JKAnnotation) {
         if (annotation.classSymbol.fqName == "java.lang.Deprecated") {
             annotation.classSymbol = symbolProvider.provideClassSymbol("kotlin.Deprecated")
-            if (annotation.arguments.isEmpty()) {
-                annotation.arguments +=
-                    JKAnnotationParameterImpl(JKLiteralExpression("\"\"", JKLiteralExpression.LiteralType.STRING))
-            }
+            annotation.arguments = listOf(JKAnnotationParameterImpl(JKLiteralExpression("\"\"", JKLiteralExpression.LiteralType.STRING)))
         }
         if (annotation.classSymbol.fqName == "java.lang.annotation.Target") {
             annotation.classSymbol = symbolProvider.provideClassSymbol("kotlin.annotation.Target")

--- a/nj2k/testData/newJ2k/annotations/java9Deprecated.java
+++ b/nj2k/testData/newJ2k/annotations/java9Deprecated.java
@@ -1,0 +1,7 @@
+public class Deprecation {
+    @Deprecated() public void deprecate00() {}
+    @Deprecated(forRemoval = false) public void deprecate10() {}
+    @Deprecated(forRemoval = true) public void deprecate20() {}
+    @Deprecated(since = "2.0") public void deprecate01() {}
+    @Deprecated(forRemoval = true, since = "2.0") public void deprecate21() {}
+}

--- a/nj2k/testData/newJ2k/annotations/java9Deprecated.kt
+++ b/nj2k/testData/newJ2k/annotations/java9Deprecated.kt
@@ -1,0 +1,21 @@
+class Deprecation {
+    @Deprecated("")
+    fun deprecate00() {
+    }
+
+    @Deprecated("")
+    fun deprecate10() {
+    }
+
+    @Deprecated("")
+    fun deprecate20() {
+    }
+
+    @Deprecated("")
+    fun deprecate01() {
+    }
+
+    @Deprecated("")
+    fun deprecate21() {
+    }
+}

--- a/nj2k/tests/org/jetbrains/kotlin/nj2k/NewJavaToKotlinConverterSingleFileTestGenerated.java
+++ b/nj2k/tests/org/jetbrains/kotlin/nj2k/NewJavaToKotlinConverterSingleFileTestGenerated.java
@@ -80,6 +80,11 @@ public class NewJavaToKotlinConverterSingleFileTestGenerated extends AbstractNew
             runTest("nj2k/testData/newJ2k/annotations/annotationUsages.java");
         }
 
+        @TestMetadata("java9Deprecated.java")
+        public void testJava9Deprecated() throws Exception {
+            runTest("nj2k/testData/newJ2k/annotations/java9Deprecated.java");
+        }
+
         @TestMetadata("annotationsFromPropertyAccessors.java")
         public void testAnnotationsFromPropertyAccessors() throws Exception {
             runTest("nj2k/testData/newJ2k/annotations/annotationsFromPropertyAccessors.java");


### PR DESCRIPTION
For any @Deprecated with parameters, unconditionally changing it to @Deprecated("") in kotlin.