### PR TITLE
Fix visibility bug in function type

### DIFF
--- a/core/descriptors/src/org/jetbrains/kotlin/descriptors/impl/FunctionDescriptorImpl.java
+++ b/core/descriptors/src/org/jetbrains/kotlin/descriptors/impl/FunctionDescriptorImpl.java
@@ -103,6 +103,9 @@ public abstract class FunctionDescriptorImpl extends DeclarationDescriptorNonRoo
 
     public void setVisibility(@NotNull Visibility visibility) {
         this.visibility = visibility;
+        if (getOriginal() != this && getOriginal() instanceof FunctionDescriptorImpl) {
+            ((FunctionDescriptorImpl) getOriginal()).setVisibility(visibility);
+        }
     }
 
     public void setOperator(boolean isOperator) {


### PR DESCRIPTION
Related YouTrack Issue: [KT-34919](https://youtrack.jetbrains.com/issue/KT-34919)

If a parameter in function type has a name, and extends it from interface, implements it from class then compiler will throw below exception: 
```
exception: java.lang.IllegalStateException: Visibility is unknown yet
        at org.jetbrains.kotlin.descriptors.Visibilities$7.isVisible(Visibilities.java:257)
        at org.jetbrains.kotlin.descriptors.Visibilities.findInvisibleMember(Visibilities.java:341)
        at org.jetbrains.kotlin.descriptors.Visibilities.isVisibleIgnoringReceiver(Visibilities.java:312)
        at org.jetbrains.kotlin.resolve.OverridingUtil$6.invoke(OverridingUtil.java:759)
        at org.jetbrains.kotlin.resolve.OverridingUtil$6.invoke(OverridingUtil.java:755)
        at kotlin.collections.CollectionsKt___CollectionsKt.filter(_Collections.kt:2595)
        at org.jetbrains.kotlin.resolve.OverridingUtil.filterVisibleFakeOverrides(OverridingUtil.java:755)
        at org.jetbrains.kotlin.resolve.OverridingUtil.createAndBindFakeOverride(OverridingUtil.java:657)
        at org.jetbrains.kotlin.resolve.OverridingUtil.createAndBindFakeOverrides(OverridingUtil.java:521)
        at org.jetbrains.kotlin.resolve.OverridingUtil.generateOverridesInFunctionGroup(OverridingUtil.java:456)
        at org.jetbrains.kotlin.resolve.lazy.descriptors.LazyClassMemberScope.generateFakeOverrides(LazyClassMemberScope.kt:157)
        at org.jetbrains.kotlin.resolve.lazy.descriptors.LazyClassMemberScope.getNonDeclaredFunctions(LazyClassMemberScope.kt:221)
        at org.jetbrains.kotlin.resolve.lazy.descriptors.AbstractLazyMemberScope.doGetFunctions(AbstractLazyMemberScope.kt:98)
        at org.jetbrains.kotlin.resolve.lazy.descriptors.AbstractLazyMemberScope.access$doGetFunctions(AbstractLazyMemberScope.kt:36)
        at org.jetbrains.kotlin.resolve.lazy.descriptors.AbstractLazyMemberScope$functionDescriptors$1.invoke(AbstractLazyMemberScope.kt:49)
        at org.jetbrains.kotlin.resolve.lazy.descriptors.AbstractLazyMemberScope$functionDescriptors$1.invoke(AbstractLazyMemberScope.kt:36)
        at org.jetbrains.kotlin.storage.LockBasedStorageManager$MapBasedMemoizedFunction.invoke(LockBasedStorageManager.java:512)
        at org.jetbrains.kotlin.storage.LockBasedStorageManager$MapBasedMemoizedFunctionToNotNull.invoke(LockBasedStorageManager.java:587)
        at org.jetbrains.kotlin.resolve.lazy.descriptors.AbstractLazyMemberScope.getContributedFunctions(AbstractLazyMemberScope.kt:92)
        at org.jetbrains.kotlin.resolve.lazy.descriptors.LazyClassMemberScope.getContributedFunctions(LazyClassMemberScope.kt:200)
        at org.jetbrains.kotlin.resolve.lazy.descriptors.LazyClassMemberScope.computeExtraDescriptors(LazyClassMemberScope.kt:85)
        at org.jetbrains.kotlin.resolve.lazy.descriptors.LazyClassMemberScope$extraDescriptors$1.invoke(LazyClassMemberScope.kt:68)
        at org.jetbrains.kotlin.resolve.lazy.descriptors.LazyClassMemberScope$extraDescriptors$1.invoke(LazyClassMemberScope.kt:49)
        at org.jetbrains.kotlin.storage.LockBasedStorageManager$LockBasedLazyValue.invoke(LockBasedStorageManager.java:355)
        at org.jetbrains.kotlin.storage.LockBasedStorageManager$LockBasedNotNullLazyValue.invoke(LockBasedStorageManager.java:474)
        at org.jetbrains.kotlin.resolve.lazy.descriptors.LazyClassMemberScope.getContributedDescriptors(LazyClassMemberScope.kt:76)
        at org.jetbrains.kotlin.resolve.DescriptorUtils.getAllDescriptors(DescriptorUtils.java:587)
        at org.jetbrains.kotlin.resolve.lazy.descriptors.LazyClassDescriptor.resolveMemberHeaders(LazyClassDescriptor.java:595)
        at org.jetbrains.kotlin.resolve.LazyTopDownAnalyzer.resolveAllHeadersInClasses(LazyTopDownAnalyzer.kt:239)
        at org.jetbrains.kotlin.resolve.LazyTopDownAnalyzer.analyzeDeclarations(LazyTopDownAnalyzer.kt:212)
        at org.jetbrains.kotlin.resolve.LazyTopDownAnalyzer.analyzeDeclarations$default(LazyTopDownAnalyzer.kt:60)
        at org.jetbrains.kotlin.cli.jvm.compiler.TopDownAnalyzerFacadeForJVM.analyzeFilesWithJavaIntegration(TopDownAnalyzerFacadeForJVM.kt:112)
```

Example code:

```kotlin
typealias Runner = (runnable: () -> Unit) -> Unit

interface Scheduler : Runner {
}

class SchedulerImpl : Scheduler {
}
```

Works fine if not has a parameter name

```kotlin
typealias Runner = (() -> Unit) -> Unit

interface Scheduler : Runner {
}

class SchedulerImpl : Scheduler {
}
```

It occurs by https://github.com/JetBrains/kotlin/blob/f03dc621737a2dd712f53d4d2d07eb853efeadcf/core/descriptors/src/org/jetbrains/kotlin/builtins/functions/FunctionInvokeDescriptor.kt#L105
and this: https://github.com/JetBrains/kotlin/blob/0a1b3a8455a5da92b14a0725d9e9b8ec4fc09953/core/descriptors/src/org/jetbrains/kotlin/descriptors/Visibilities.java#L341

So I made it if the setVisibility() called, set visibility for getOriginal() too.
But I'm not sure that is this a right way to fix it, and is this a actually bug. Please review this.