### PR TITLE
[JVM IR] Mangle variable names for anonymous parameters in lambdas

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmSymbols.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmSymbols.kt
@@ -221,7 +221,7 @@ class JvmSymbols(
                 addValueParameter("completion", continuationType.makeNullable())
             }
             klass.addFunction("invokeSuspend", irBuiltIns.anyNType, Modality.ABSTRACT).apply {
-                addValueParameter("result", resultClassStub.typeWith(irBuiltIns.anyNType))
+                addValueParameter("\$result", resultClassStub.typeWith(irBuiltIns.anyNType))
             }
         }
 
@@ -241,7 +241,7 @@ class JvmSymbols(
             addValueParameter("completion", continuationClass.typeWith(irBuiltIns.anyNType).makeNullable())
         }
         klass.addFunction("invokeSuspend", irBuiltIns.anyNType, Modality.ABSTRACT).apply {
-            addValueParameter("result", resultClassStub.typeWith(irBuiltIns.anyNType))
+            addValueParameter("\$result", resultClassStub.typeWith(irBuiltIns.anyNType))
         }
         klass.addFunction("create", continuationClass.typeWith(irBuiltIns.unitType)).apply {
             addValueParameter("completion", continuationClass.typeWith(irBuiltIns.nothingType))

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -291,10 +291,6 @@ class ExpressionCodegen(
     }
 
     private fun writeValueParameterInLocalVariableTable(param: IrValueParameter, startLabel: Label, endLabel: Label, isReceiver: Boolean) {
-        // TODO: old code has a special treatment for destructuring lambda parameters.
-        // There is no (easy) way to reproduce it with IR structures.
-        // Does not show up in tests, but might come to bite us at some point.
-
         // If the parameter is an extension receiver parameter or a captured extension receiver from enclosing,
         // then generate name accordingly.
         val name = if (param.origin == BOUND_RECEIVER_PARAMETER || isReceiver) {

--- a/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/GeneratorExtensions.kt
+++ b/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/GeneratorExtensions.kt
@@ -5,11 +5,9 @@
 
 package org.jetbrains.kotlin.psi2ir.generators
 
-import org.jetbrains.kotlin.descriptors.CallableDescriptor
-import org.jetbrains.kotlin.descriptors.PropertyDescriptor
-import org.jetbrains.kotlin.descriptors.ValueParameterDescriptor
-import org.jetbrains.kotlin.descriptors.Visibility
+import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.ir.util.StubGeneratorExtensions
+import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.types.KotlinType
 
 open class GeneratorExtensions : StubGeneratorExtensions() {
@@ -34,6 +32,8 @@ open class GeneratorExtensions : StubGeneratorExtensions() {
     }
 
     open fun computeFieldVisibility(descriptor: PropertyDescriptor): Visibility? = null
+
+    open fun computeParameterName(descriptor: ParameterDescriptor): Name = descriptor.name
 
     open val enhancedNullability: EnhancedNullability
         get() = EnhancedNullability

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/SymbolTable.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/SymbolTable.kt
@@ -33,6 +33,7 @@ import org.jetbrains.kotlin.ir.types.impl.IrUninitializedType
 import org.jetbrains.kotlin.ir.visitors.IrElementVisitorVoid
 import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
 import org.jetbrains.kotlin.ir.visitors.acceptVoid
+import org.jetbrains.kotlin.name.Name
 
 interface IrProvider {
     fun getDeclaration(symbol: IrSymbol): IrDeclaration?

--- a/compiler/testData/checkLocalVariablesTable/destructuringInLambdas.kt
+++ b/compiler/testData/checkLocalVariablesTable/destructuringInLambdas.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 data class A(val x: String, val y: Int)
 
 fun foo(a: A, block: (A) -> String): String = block(a)

--- a/compiler/testData/checkLocalVariablesTable/destructuringInlineLambda.kt
+++ b/compiler/testData/checkLocalVariablesTable/destructuringInlineLambda.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 inline fun foo(x: (Int, Station) -> Unit) {
     x(1, Station(null, "", 1))
 }

--- a/compiler/testData/checkLocalVariablesTable/parametersInSuspendLambda/dataClass.kt
+++ b/compiler/testData/checkLocalVariablesTable/parametersInSuspendLambda/dataClass.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 // WITH_RUNTIME
 data class Data(val x: String, val y: Int)
 
@@ -12,9 +11,21 @@ suspend fun foo(data: Data, body: suspend (Data) -> Unit) {
     body(data)
 }
 
+// Parameters (including anonymous destructuring parameters) are moved to fields in the Continuation class for the suspend lambda class.
+// However, in non-IR, the fields are first stored in local variables, and they are not read directly (even for destructuring components).
+// In IR, the fields are directly read from.
+
 // METHOD : DataClassKt$test$2.invokeSuspend(Ljava/lang/Object;)Ljava/lang/Object;
+
+// JVM_TEMPLATES
 // VARIABLE : NAME=$dstr$x_param$y_param TYPE=LData; INDEX=2
 // VARIABLE : NAME=x_param TYPE=Ljava/lang/String; INDEX=3
 // VARIABLE : NAME=y_param TYPE=I INDEX=4
+// VARIABLE : NAME=this TYPE=LDataClassKt$test$2; INDEX=0
+// VARIABLE : NAME=$result TYPE=Ljava/lang/Object; INDEX=1
+
+// JVM_IR_TEMPLATES
+// VARIABLE : NAME=x_param TYPE=Ljava/lang/String; INDEX=2
+// VARIABLE : NAME=y_param TYPE=I INDEX=3
 // VARIABLE : NAME=this TYPE=LDataClassKt$test$2; INDEX=0
 // VARIABLE : NAME=$result TYPE=Ljava/lang/Object; INDEX=1

--- a/compiler/testData/checkLocalVariablesTable/parametersInSuspendLambda/extensionComponents.kt
+++ b/compiler/testData/checkLocalVariablesTable/parametersInSuspendLambda/extensionComponents.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 // WITH_RUNTIME
 class A<T>(val x: String, val y: String, val z: T)
 
@@ -18,10 +17,26 @@ suspend fun B.bar(): String {
 
 suspend fun test() = B.bar()
 
+// Local function bodies (i.e., `A<R>.component3()`) are in a separate class (implementing FunctionN) for non-IR, and are static methods
+// in the enclosing class for IR. Therefore the ordinal in the suspend lambda class name is different for non-IR (`$3`) vs IR (e.g., `$2`).
+//
+// Parameters (including anonymous destructuring parameters) are moved to fields in the Continuation class for the suspend lambda class.
+// However, in non-IR, the fields are first stored in local variables, and they are not read directly (even for destructuring components).
+// In IR, the fields are directly read from.
+
+// JVM_TEMPLATES
 // METHOD : ExtensionComponentsKt$bar$3.invokeSuspend(Ljava/lang/Object;)Ljava/lang/Object;
 // VARIABLE : NAME=$dstr$x_param$y_param$z_param TYPE=LA; INDEX=2
 // VARIABLE : NAME=x_param TYPE=Ljava/lang/String; INDEX=3
 // VARIABLE : NAME=y_param TYPE=Ljava/lang/String; INDEX=4
 // VARIABLE : NAME=z_param TYPE=I INDEX=5
 // VARIABLE : NAME=this TYPE=LExtensionComponentsKt$bar$3; INDEX=0
+// VARIABLE : NAME=$result TYPE=Ljava/lang/Object; INDEX=1
+
+// JVM_IR_TEMPLATES
+// METHOD : ExtensionComponentsKt$bar$2.invokeSuspend(Ljava/lang/Object;)Ljava/lang/Object;
+// VARIABLE : NAME=x_param TYPE=Ljava/lang/String; INDEX=2
+// VARIABLE : NAME=y_param TYPE=Ljava/lang/String; INDEX=3
+// VARIABLE : NAME=z_param TYPE=I INDEX=4
+// VARIABLE : NAME=this TYPE=LExtensionComponentsKt$bar$2; INDEX=0
 // VARIABLE : NAME=$result TYPE=Ljava/lang/Object; INDEX=1

--- a/compiler/testData/checkLocalVariablesTable/parametersInSuspendLambda/generic.kt
+++ b/compiler/testData/checkLocalVariablesTable/parametersInSuspendLambda/generic.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 // WITH_RUNTIME
 
 data class A<T, F>(val x: T, val y: F)
@@ -7,9 +6,21 @@ suspend fun <X, Y> foo(a: A<X, Y>, block: suspend (A<X, Y>) -> String) = block(a
 
 suspend fun test() = foo(A("OK", 1)) { (x_param, y_param) -> x_param + (y_param.toString()) }
 
+// Parameters (including anonymous destructuring parameters) are moved to fields in the Continuation class for the suspend lambda class.
+// However, in non-IR, the fields are first stored in local variables, and they are not read directly (even for destructuring components).
+// In IR, the fields are directly read from.
+
 // METHOD : GenericKt$test$2.invokeSuspend(Ljava/lang/Object;)Ljava/lang/Object;
+
+// JVM_TEMPLATES
 // VARIABLE : NAME=$dstr$x_param$y_param TYPE=LA; INDEX=2
 // VARIABLE : NAME=x_param TYPE=Ljava/lang/String; INDEX=3
 // VARIABLE : NAME=y_param TYPE=I INDEX=4
+// VARIABLE : NAME=this TYPE=LGenericKt$test$2; INDEX=0
+// VARIABLE : NAME=$result TYPE=Ljava/lang/Object; INDEX=1
+
+// JVM_IR_TEMPLATES
+// VARIABLE : NAME=x_param TYPE=Ljava/lang/String; INDEX=2
+// VARIABLE : NAME=y_param TYPE=I INDEX=3
 // VARIABLE : NAME=this TYPE=LGenericKt$test$2; INDEX=0
 // VARIABLE : NAME=$result TYPE=Ljava/lang/Object; INDEX=1

--- a/compiler/testData/checkLocalVariablesTable/parametersInSuspendLambda/inline.kt
+++ b/compiler/testData/checkLocalVariablesTable/parametersInSuspendLambda/inline.kt
@@ -6,6 +6,8 @@ suspend inline fun foo(a: A, block: suspend (A) -> String): String = block(a)
 
 suspend fun test() = foo(A("O", "K")) { (x_param, y_param) -> x_param + y_param }
 
+// TODO: Fix this after other issues in inlining suspend lambdas are resolved.
+
 // METHOD : InlineKt.test(Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 // VARIABLE : NAME=x_param TYPE=Ljava/lang/String; INDEX=6
 // VARIABLE : NAME=y_param TYPE=Ljava/lang/String; INDEX=7

--- a/compiler/testData/checkLocalVariablesTable/parametersInSuspendLambda/otherParameters.kt
+++ b/compiler/testData/checkLocalVariablesTable/parametersInSuspendLambda/otherParameters.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 // WITH_RUNTIME
 data class A(val x: String, val y: String)
 
@@ -6,11 +5,23 @@ suspend fun foo(a: A, block: suspend (Int, A, String) -> String): String = block
 
 suspend fun test() = foo(A("O", "K")) { i_param, (x_param, y_param), v_param -> i_param.toString() + x_param + y_param + v_param }
 
+// Parameters (including anonymous destructuring parameters) are moved to fields in the Continuation class for the suspend lambda class.
+// However, in non-IR, the fields are first stored in local variables, and they are not read directly (even for destructuring components).
+// In IR, the fields are directly read from.
+
 // METHOD : OtherParametersKt$test$2.invokeSuspend(Ljava/lang/Object;)Ljava/lang/Object;
+
+// JVM_TEMPLATES
 // VARIABLE : NAME=i_param TYPE=I INDEX=2
 // VARIABLE : NAME=$dstr$x_param$y_param TYPE=LA; INDEX=3
 // VARIABLE : NAME=v_param TYPE=Ljava/lang/String; INDEX=4
 // VARIABLE : NAME=x_param TYPE=Ljava/lang/String; INDEX=5
 // VARIABLE : NAME=y_param TYPE=Ljava/lang/String; INDEX=6
+// VARIABLE : NAME=this TYPE=LOtherParametersKt$test$2; INDEX=0
+// VARIABLE : NAME=$result TYPE=Ljava/lang/Object; INDEX=1
+
+// JVM_IR_TEMPLATES
+// VARIABLE : NAME=x_param TYPE=Ljava/lang/String; INDEX=2
+// VARIABLE : NAME=y_param TYPE=Ljava/lang/String; INDEX=3
 // VARIABLE : NAME=this TYPE=LOtherParametersKt$test$2; INDEX=0
 // VARIABLE : NAME=$result TYPE=Ljava/lang/Object; INDEX=1

--- a/compiler/testData/checkLocalVariablesTable/parametersInSuspendLambda/parameters.kt
+++ b/compiler/testData/checkLocalVariablesTable/parametersInSuspendLambda/parameters.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 // WITH_RUNTIME
 data class Data(val x: String, val y: Int, val z: Int = 0)
 
@@ -12,12 +11,24 @@ suspend fun foo(data: Data, body: suspend Long.(String, Data, Int) -> Unit) {
     1L.body("OK", data, 1)
 }
 
+// Parameters (including anonymous destructuring parameters) are moved to fields in the Continuation class for the suspend lambda class.
+// However, in non-IR, the fields are first stored in local variables, and they are not read directly (even for destructuring components).
+// In IR, the fields are directly read from.
+
 // METHOD : ParametersKt$test$2.invokeSuspend(Ljava/lang/Object;)Ljava/lang/Object;
+
+// JVM_TEMPLATES
 // VARIABLE : NAME=$this$foo TYPE=J INDEX=2
 // VARIABLE : NAME=str TYPE=Ljava/lang/String; INDEX=4
 // VARIABLE : NAME=$dstr$x$_u24__u24$z TYPE=LData; INDEX=5
 // VARIABLE : NAME=i TYPE=I INDEX=6
 // VARIABLE : NAME=x TYPE=Ljava/lang/String; INDEX=7
 // VARIABLE : NAME=z TYPE=I INDEX=8
+// VARIABLE : NAME=this TYPE=LParametersKt$test$2; INDEX=0
+// VARIABLE : NAME=$result TYPE=Ljava/lang/Object; INDEX=1
+
+// JVM_IR_TEMPLATES
+// VARIABLE : NAME=x TYPE=Ljava/lang/String; INDEX=2
+// VARIABLE : NAME=z TYPE=I INDEX=3
 // VARIABLE : NAME=this TYPE=LParametersKt$test$2; INDEX=0
 // VARIABLE : NAME=$result TYPE=Ljava/lang/Object; INDEX=1

--- a/compiler/testData/checkLocalVariablesTable/parametersInSuspendLambda/underscoreNames.kt
+++ b/compiler/testData/checkLocalVariablesTable/parametersInSuspendLambda/underscoreNames.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 // WITH_RUNTIME
 class A {
     operator fun component1() = "O"
@@ -10,9 +9,21 @@ suspend fun foo(a: A, block: suspend (A) -> String): String = block(a)
 
 suspend fun test() = foo(A()) { (x_param, _, y_param) -> x_param + y_param }
 
+// Parameters (including anonymous destructuring parameters) are moved to fields in the Continuation class for the suspend lambda class.
+// However, in non-IR, the fields are first stored in local variables, and they are not read directly (even for destructuring components).
+// In IR, the fields are directly read from.
+
 // METHOD : UnderscoreNamesKt$test$2.invokeSuspend(Ljava/lang/Object;)Ljava/lang/Object;
+
+// JVM_TEMPLATES
 // VARIABLE : NAME=$dstr$x_param$_u24__u24$y_param TYPE=LA; INDEX=2
 // VARIABLE : NAME=x_param TYPE=Ljava/lang/String; INDEX=3
 // VARIABLE : NAME=y_param TYPE=Ljava/lang/String; INDEX=4
+// VARIABLE : NAME=this TYPE=LUnderscoreNamesKt$test$2; INDEX=0
+// VARIABLE : NAME=$result TYPE=Ljava/lang/Object; INDEX=1
+
+// JVM_IR_TEMPLATES
+// VARIABLE : NAME=x_param TYPE=Ljava/lang/String; INDEX=2
+// VARIABLE : NAME=y_param TYPE=Ljava/lang/String; INDEX=3
 // VARIABLE : NAME=this TYPE=LUnderscoreNamesKt$test$2; INDEX=0
 // VARIABLE : NAME=$result TYPE=Ljava/lang/Object; INDEX=1

--- a/compiler/testData/checkLocalVariablesTable/underscoreNames.kt
+++ b/compiler/testData/checkLocalVariablesTable/underscoreNames.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 data class A(val x: Double = 1.0, val y: String = "", val z: Char = '0')
 
 fun foo(a: A, block: (A, String, Int) -> String): String = block(a, "", 1)

--- a/compiler/testData/ir/irText/lambdas/destructuringInLambda.txt
+++ b/compiler/testData/ir/irText/lambdas/destructuringInLambda.txt
@@ -135,13 +135,13 @@ FILE fqName:<root> fileName:/destructuringInLambda.kt
     FIELD PROPERTY_BACKING_FIELD name:fn type:kotlin.Function1<<root>.A, kotlin.Int> visibility:private [static]
       EXPRESSION_BODY
         FUN_EXPR type=kotlin.Function1<<root>.A, kotlin.Int> origin=LAMBDA
-          FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> (<name for destructuring parameter 0>:<root>.A) returnType:kotlin.Int
-            VALUE_PARAMETER name:<name for destructuring parameter 0> index:0 type:<root>.A
+          FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> ($dstr$_u24__u24$y:<root>.A) returnType:kotlin.Int
+            VALUE_PARAMETER name:$dstr$_u24__u24$y index:0 type:<root>.A
             BLOCK_BODY
               VAR name:y type:kotlin.Int [val]
                 CALL 'public final fun component2 (): kotlin.Int [operator] declared in <root>.A' type=kotlin.Int origin=COMPONENT_N(index=2)
-                  $this: GET_VAR '<name for destructuring parameter 0>: <root>.A declared in <root>.fn.<anonymous>' type=<root>.A origin=DESTRUCTURING_DECLARATION
-              RETURN type=kotlin.Nothing from='local final fun <anonymous> (<name for destructuring parameter 0>: <root>.A): kotlin.Int declared in <root>.fn'
+                  $this: GET_VAR '$dstr$_u24__u24$y: <root>.A declared in <root>.fn.<anonymous>' type=<root>.A origin=DESTRUCTURING_DECLARATION
+              RETURN type=kotlin.Nothing from='local final fun <anonymous> ($dstr$_u24__u24$y: <root>.A): kotlin.Int declared in <root>.fn'
                 CALL 'public final fun plus (other: kotlin.Int): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=PLUS
                   $this: CONST Int type=kotlin.Int value=42
                   other: GET_VAR 'val y: kotlin.Int [val] declared in <root>.fn.<anonymous>' type=kotlin.Int origin=null


### PR DESCRIPTION
This also fixes the same 3 tests fixed by https://github.com/JetBrains/kotlin/pull/2959. However, it's coincidental simply because the Name for a destructuring declaration parameter is no longer "special". The changes in https://github.com/JetBrains/kotlin/pull/2959 are still correct and valid.