### PR TITLE
[FIR] Fix Fir2Ir translation of library function parameters with defa…

### DIFF
--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrDeclarationStorage.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrDeclarationStorage.kt
@@ -24,10 +24,13 @@ import org.jetbrains.kotlin.fir.symbols.impl.FirFunctionSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirTypeParameterSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirVariableSymbol
 import org.jetbrains.kotlin.fir.types.FirTypeRef
+import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.*
 import org.jetbrains.kotlin.ir.descriptors.*
 import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.impl.IrErrorExpressionImpl
+import org.jetbrains.kotlin.ir.expressions.impl.IrExpressionBodyImpl
 import org.jetbrains.kotlin.ir.symbols.*
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.impl.IrSimpleTypeImpl
@@ -607,6 +610,14 @@ class Fir2IrDeclarationStorage(
                     null, valueParameter.isCrossinline, valueParameter.isNoinline
                 ).apply {
                     descriptor.bind(this)
+                    if (valueParameter.defaultValue != null) {
+                        this.defaultValue = IrExpressionBodyImpl(
+                            IrErrorExpressionImpl(
+                                UNDEFINED_OFFSET, UNDEFINED_OFFSET, type,
+                                "Stub expression for default value of ${valueParameter.name}"
+                            )
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
…ult values.

In the existing implementation, the information that a library function parameter has a default value is lost during Fir2Ir translation, and thus later on, calls to such functions are not converted to the corresponding stubs.

Test cases such as kt5844, which calls kotlin.test.assertEquals, fail with messages like "java.lang.IllegalArgumentException: Null argument in ExpressionCodegen for parameter VALUE_PARAMETER name:message index:2 type:kotlin.String?", due to nonnull checks in ExpressionCodegen.visitFunctionAccess(ExpressionCodegen.kt:421)

Functions defined in the code to be compiled don't have this problem, only those from deserializing jars.

This commit sets default values in IrValueParameterImpl for such parameters during Fir2Ir translation. Now kt5844 passes the nonnull check in ExpressionCodegen.visitFunctionAccess but still fails in a later stage (java.lang.ClassNotFoundException: kotlin.internal.ir.Intrinsic).