### PR TITLE
JVM_IR: deal with inline class arguments in AddContinuationLowering

### DIFF
--- a/compiler/testData/codegen/box/inlineClasses/unboxParameterOfSuspendLambdaBeforeInvoke.kt
+++ b/compiler/testData/codegen/box/inlineClasses/unboxParameterOfSuspendLambdaBeforeInvoke.kt
@@ -1,7 +1,7 @@
 // IGNORE_BACKEND_FIR: JVM_IR
 // WITH_COROUTINES
 // WITH_RUNTIME
-// IGNORE_BACKEND: JVM_IR, JS_IR
+// IGNORE_BACKEND: JS_IR
 
 import helpers.*
 import kotlin.coroutines.*


### PR DESCRIPTION
Whenever we want the default 0/null value for a type we need to
check if it is a non-nullable inline class type and produce
the right value for the underlying type.