### PR TITLE
JVM IR: Fix generation of parameterless default constructors

### DIFF
--- a/compiler/testData/codegen/bytecodeText/constructors/enumPrimaryDefaults.kt
+++ b/compiler/testData/codegen/bytecodeText/constructors/enumPrimaryDefaults.kt
@@ -1,0 +1,15 @@
+enum class Enum(val x: Int = 0) {
+    A,
+    B(0) { override fun f() {} };
+    open fun f() {}
+}
+
+// @Enum.class:
+// 0 <init>\(\)V
+// 1 private <init>\(Ljava/lang/String;II\)V
+// 1 synthetic <init>\(Ljava/lang/String;IIILkotlin/jvm/internal/DefaultConstructorMarker;\)V
+// 1 public synthetic <init>\(Ljava/lang/String;IILkotlin/jvm/internal/DefaultConstructorMarker;\)V
+
+// @Enum$B.class:
+// 0 <init>\(\)V
+// 1 <init>\(Ljava/lang/String;I\)V

--- a/compiler/testData/codegen/bytecodeText/constructors/inlineArgumentPrimaryDefaults.kt
+++ b/compiler/testData/codegen/bytecodeText/constructors/inlineArgumentPrimaryDefaults.kt
@@ -1,0 +1,13 @@
+inline class A(val x: Int)
+class B(val a: A = A(0))
+
+// @B.class:
+// 1 private <init>\(I\)V
+// 1 public synthetic <init>\(IILkotlin/jvm/internal/DefaultConstructorMarker;\)V
+// 1 public synthetic <init>\(ILkotlin/jvm/internal/DefaultConstructorMarker;\)V
+
+// JVM_TEMPLATES
+// 1 private <init>\(\)V
+
+// JVM_IR_TEMPLATES
+// 1 public <init>\(\)V

--- a/compiler/testData/codegen/bytecodeText/constructors/inlinePrimaryDefaults.kt
+++ b/compiler/testData/codegen/bytecodeText/constructors/inlinePrimaryDefaults.kt
@@ -1,0 +1,13 @@
+inline class A(val x: Int = 0)
+
+// 0 <init>\(\)V
+// 1 private synthetic <init>\(I\)V
+// 1 public final static synthetic box-impl\(I\)LA;
+
+// JVM_TEMPLATES
+// 1 public static constructor-impl\(I\)I
+// 1 public static synthetic constructor-impl\$default\(IILkotlin/jvm/internal/DefaultConstructorMarker;\)I
+
+// JVM_IR_TEMPLATES
+// 1 public final static constructor-impl\(I\)I
+// 1 public static synthetic constructor-impl\$default\(IILjava/lang/Object;\)I

--- a/compiler/testData/codegen/bytecodeText/constructors/innerPrimaryDefaults.kt
+++ b/compiler/testData/codegen/bytecodeText/constructors/innerPrimaryDefaults.kt
@@ -1,0 +1,11 @@
+class A(val s: String) {
+    inner class B(val x: Int = 0)
+}
+
+// @A.class
+// 1 public <init>\(Ljava/lang/String;\)V
+
+// @A$B.class
+// 0 <init>\(\)V
+// 1 public <init>\(LA;I\)V
+// 1 public synthetic <init>\(LA;IILkotlin/jvm/internal/DefaultConstructorMarker;\)V

--- a/compiler/testData/codegen/bytecodeText/constructors/internalPrimaryDefaults.kt
+++ b/compiler/testData/codegen/bytecodeText/constructors/internalPrimaryDefaults.kt
@@ -1,0 +1,5 @@
+class A internal constructor(val x: Int = 0)
+
+// 1 public <init>\(\)V
+// 1 public <init>\(I\)V
+// 1 public synthetic <init>\(IILkotlin/jvm/internal/DefaultConstructorMarker;\)V

--- a/compiler/testData/codegen/bytecodeText/constructors/localPrimaryDefaults.kt
+++ b/compiler/testData/codegen/bytecodeText/constructors/localPrimaryDefaults.kt
@@ -1,0 +1,16 @@
+class A(val s: String) {
+    fun f(): Int {
+        class B(val x: Int = 0) {
+            fun f(): Int = x
+        }
+        return B().f()
+    }
+}
+
+// @A.class:
+// 1 public <init>\(Ljava/lang/String;\)V
+
+// @A$f$B.class:
+// 0 <init>\(\)V
+// 1 public <init>\(I\)V
+// 1 public synthetic <init>\(IILkotlin/jvm/internal/DefaultConstructorMarker;\)V

--- a/compiler/testData/codegen/bytecodeText/constructors/parameterlessPrimary.kt
+++ b/compiler/testData/codegen/bytecodeText/constructors/parameterlessPrimary.kt
@@ -1,0 +1,5 @@
+class A(val x: Int = 0)
+
+// 1 public <init>\(\)V
+// 1 public <init>\(I\)V
+// 1 public synthetic <init>\(IILkotlin/jvm/internal/DefaultConstructorMarker;\)V

--- a/compiler/testData/codegen/bytecodeText/constructors/privatePrimaryDefaults.kt
+++ b/compiler/testData/codegen/bytecodeText/constructors/privatePrimaryDefaults.kt
@@ -1,0 +1,5 @@
+class A private constructor(val x: Int = 0)
+
+// 0 <init>\(\)V
+// 1 private <init>\(I\)V
+// 1 synthetic <init>\(IILkotlin/jvm/internal/DefaultConstructorMarker;\)V

--- a/compiler/testData/codegen/bytecodeText/constructors/protectedPrimaryDefaults.kt
+++ b/compiler/testData/codegen/bytecodeText/constructors/protectedPrimaryDefaults.kt
@@ -1,0 +1,5 @@
+class A protected constructor(val x: Int = 0)
+
+// 1 protected <init>\(\)V
+// 1 protected <init>\(I\)V
+// 1 synthetic <init>\(IILkotlin/jvm/internal/DefaultConstructorMarker;\)V

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
@@ -1219,6 +1219,64 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
         }
     }
 
+    @TestMetadata("compiler/testData/codegen/bytecodeText/constructors")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class Constructors extends AbstractBytecodeTextTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM, testDataFilePath);
+        }
+
+        public void testAllFilesPresentInConstructors() throws Exception {
+            KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/bytecodeText/constructors"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM, true);
+        }
+
+        @TestMetadata("enumPrimaryDefaults.kt")
+        public void testEnumPrimaryDefaults() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/constructors/enumPrimaryDefaults.kt");
+        }
+
+        @TestMetadata("inlineArgumentPrimaryDefaults.kt")
+        public void testInlineArgumentPrimaryDefaults() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/constructors/inlineArgumentPrimaryDefaults.kt");
+        }
+
+        @TestMetadata("inlinePrimaryDefaults.kt")
+        public void testInlinePrimaryDefaults() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/constructors/inlinePrimaryDefaults.kt");
+        }
+
+        @TestMetadata("innerPrimaryDefaults.kt")
+        public void testInnerPrimaryDefaults() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/constructors/innerPrimaryDefaults.kt");
+        }
+
+        @TestMetadata("internalPrimaryDefaults.kt")
+        public void testInternalPrimaryDefaults() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/constructors/internalPrimaryDefaults.kt");
+        }
+
+        @TestMetadata("localPrimaryDefaults.kt")
+        public void testLocalPrimaryDefaults() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/constructors/localPrimaryDefaults.kt");
+        }
+
+        @TestMetadata("parameterlessPrimary.kt")
+        public void testParameterlessPrimary() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/constructors/parameterlessPrimary.kt");
+        }
+
+        @TestMetadata("privatePrimaryDefaults.kt")
+        public void testPrivatePrimaryDefaults() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/constructors/privatePrimaryDefaults.kt");
+        }
+
+        @TestMetadata("protectedPrimaryDefaults.kt")
+        public void testProtectedPrimaryDefaults() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/constructors/protectedPrimaryDefaults.kt");
+        }
+    }
+
     @TestMetadata("compiler/testData/codegen/bytecodeText/controlStructures")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
@@ -1229,6 +1229,64 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
         }
     }
 
+    @TestMetadata("compiler/testData/codegen/bytecodeText/constructors")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class Constructors extends AbstractIrBytecodeTextTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM_IR, testDataFilePath);
+        }
+
+        public void testAllFilesPresentInConstructors() throws Exception {
+            KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/bytecodeText/constructors"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+        }
+
+        @TestMetadata("enumPrimaryDefaults.kt")
+        public void testEnumPrimaryDefaults() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/constructors/enumPrimaryDefaults.kt");
+        }
+
+        @TestMetadata("inlineArgumentPrimaryDefaults.kt")
+        public void testInlineArgumentPrimaryDefaults() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/constructors/inlineArgumentPrimaryDefaults.kt");
+        }
+
+        @TestMetadata("inlinePrimaryDefaults.kt")
+        public void testInlinePrimaryDefaults() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/constructors/inlinePrimaryDefaults.kt");
+        }
+
+        @TestMetadata("innerPrimaryDefaults.kt")
+        public void testInnerPrimaryDefaults() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/constructors/innerPrimaryDefaults.kt");
+        }
+
+        @TestMetadata("internalPrimaryDefaults.kt")
+        public void testInternalPrimaryDefaults() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/constructors/internalPrimaryDefaults.kt");
+        }
+
+        @TestMetadata("localPrimaryDefaults.kt")
+        public void testLocalPrimaryDefaults() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/constructors/localPrimaryDefaults.kt");
+        }
+
+        @TestMetadata("parameterlessPrimary.kt")
+        public void testParameterlessPrimary() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/constructors/parameterlessPrimary.kt");
+        }
+
+        @TestMetadata("privatePrimaryDefaults.kt")
+        public void testPrivatePrimaryDefaults() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/constructors/privatePrimaryDefaults.kt");
+        }
+
+        @TestMetadata("protectedPrimaryDefaults.kt")
+        public void testProtectedPrimaryDefaults() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/constructors/protectedPrimaryDefaults.kt");
+        }
+    }
+
     @TestMetadata("compiler/testData/codegen/bytecodeText/controlStructures")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)


### PR DESCRIPTION
The JVM backend generates parameterless default constructors in some cases when we have a primary constructor with default values for all arguments. This PR (mostly) implements the same rules 
for the IR backend and fixes the visibility of parameterless default constructors. It also adds a couple of tests for all the special cases.

One difference between the JVM and JVM IR backends is in the handling of parameterless main methods for constructors taking inline class arguments (see `compiler/testData/codegen/bytecodeText/constructors/inlineArgumentPrimaryDefaults.kt`). I think the behavior of the JVM backend is wrong here and I've reported this as [KT-35902](https://youtrack.jetbrains.com/issue/KT-35902).

Another small difference is in the flags used for static replacement constructors of inline classes (`compiler/testData/codegen/bytecodeText/constructors/inlinePrimaryDefaults.kt`). Again, I'm not sure if we shouldn't change this in the JVM backend instead.

For now I've added tests with `JVM(_IR)_TEMPLATES` to document the current behavior.