### PR TITLE
[JVM IR] Fix `lambdaInLocalFunction.kt`

### DIFF
--- a/compiler/testData/codegen/box/reflection/enclosing/lambdaInLocalFunction.kt
+++ b/compiler/testData/codegen/box/reflection/enclosing/lambdaInLocalFunction.kt
@@ -1,8 +1,10 @@
 // IGNORE_BACKEND_FIR: JVM_IR
-// IGNORE_BACKEND: JVM_IR
 // TARGET_BACKEND: JVM
 
 // WITH_REFLECT
+// WITH_HELPERS
+
+import helpers.*
 
 fun box(): String {
     fun foo(): Any {
@@ -10,11 +12,16 @@ fun box(): String {
     }
 
     val javaClass = foo().javaClass
-    val enclosingMethod = javaClass.getEnclosingMethod()
-    if (enclosingMethod?.getName() != "invoke") return "method: $enclosingMethod"
 
-    val enclosingClass = javaClass.getEnclosingClass()!!.getName()
-    if (enclosingClass != "LambdaInLocalFunctionKt\$box$1") return "enclosing class: $enclosingClass"
+    // The enclosing method is a local function, which are in a separate class (implementing FunctionN) for non-IR, and are static methods
+    // in the enclosing class for IR.
+    val actualEnclosingMethod = javaClass.getEnclosingMethod()!!.getName()
+    val expectedEnclosingMethod = if (getTargetBackend() == "JVM_IR") "box\$foo" else "invoke"
+    if (actualEnclosingMethod != expectedEnclosingMethod) return "method: $actualEnclosingMethod"
+
+    val actualEnclosingClass = javaClass.getEnclosingClass()!!.getName()
+    val expectedEnclosingClass = if (getTargetBackend() == "JVM_IR") "LambdaInLocalFunctionKt" else "LambdaInLocalFunctionKt\$box\$1"
+    if (actualEnclosingClass != expectedEnclosingClass) return "enclosing class: $actualEnclosingClass"
 
     val declaringClass = javaClass.getDeclaringClass()
     if (declaringClass != null) return "anonymous function has a declaring class: $declaringClass"

--- a/compiler/testData/codegen/box/reflection/enclosing/lambdaInLocalFunction.kt
+++ b/compiler/testData/codegen/box/reflection/enclosing/lambdaInLocalFunction.kt
@@ -16,11 +16,11 @@ fun box(): String {
     // The enclosing method is a local function, which are in a separate class (implementing FunctionN) for non-IR, and are static methods
     // in the enclosing class for IR.
     val actualEnclosingMethod = javaClass.getEnclosingMethod()!!.getName()
-    val expectedEnclosingMethod = if (getTargetBackend() == "JVM_IR") "box\$foo" else "invoke"
+    val expectedEnclosingMethod = if (isIR()) "box\$foo" else "invoke"
     if (actualEnclosingMethod != expectedEnclosingMethod) return "method: $actualEnclosingMethod"
 
     val actualEnclosingClass = javaClass.getEnclosingClass()!!.getName()
-    val expectedEnclosingClass = if (getTargetBackend() == "JVM_IR") "LambdaInLocalFunctionKt" else "LambdaInLocalFunctionKt\$box\$1"
+    val expectedEnclosingClass = if (isIR()) "LambdaInLocalFunctionKt" else "LambdaInLocalFunctionKt\$box\$1"
     if (actualEnclosingClass != expectedEnclosingClass) return "enclosing class: $actualEnclosingClass"
 
     val declaringClass = javaClass.getDeclaringClass()

--- a/compiler/tests-common/tests/org/jetbrains/kotlin/TestHelperGenerator.kt
+++ b/compiler/tests-common/tests/org/jetbrains/kotlin/TestHelperGenerator.kt
@@ -6,8 +6,10 @@
 package org.jetbrains.kotlin
 
 import org.jetbrains.kotlin.resolve.DescriptorUtils
+import org.jetbrains.kotlin.test.TargetBackend
 
-fun createTextForHelpers(isReleaseCoroutines: Boolean, checkStateMachine: Boolean, checkTailCallOptimization: Boolean): String {
+// Add the directive `// WITH_COROUTINES` to use these helpers in codegen tests (see TestFiles.java).
+fun createTextForCoroutineHelpers(isReleaseCoroutines: Boolean, checkStateMachine: Boolean, checkTailCallOptimization: Boolean): String {
     val coroutinesPackage =
         if (isReleaseCoroutines)
             DescriptorUtils.COROUTINES_PACKAGE_FQ_NAME_RELEASE.asString()
@@ -188,3 +190,11 @@ fun createTextForHelpers(isReleaseCoroutines: Boolean, checkStateMachine: Boolea
             |${if (checkTailCallOptimization) checkTailCallOptimizationString else ""}
         """.trimMargin()
 }
+
+// Add the directive `// WITH_HELPERS` to use these helpers in codegen tests (see CodegenTestCase.java).
+fun createTextForCodegenTestHelpers(backend: TargetBackend) =
+    """
+        |package helpers
+        |
+        |fun getTargetBackend() = "${backend.name}"
+    """.trimMargin()

--- a/compiler/tests-common/tests/org/jetbrains/kotlin/TestHelperGenerator.kt
+++ b/compiler/tests-common/tests/org/jetbrains/kotlin/TestHelperGenerator.kt
@@ -196,5 +196,5 @@ fun createTextForCodegenTestHelpers(backend: TargetBackend) =
     """
         |package helpers
         |
-        |fun getTargetBackend() = "${backend.name}"
+        |fun isIR() = ${backend.isIR}
     """.trimMargin()

--- a/compiler/tests-common/tests/org/jetbrains/kotlin/codegen/CodegenTestCase.java
+++ b/compiler/tests-common/tests/org/jetbrains/kotlin/codegen/CodegenTestCase.java
@@ -16,6 +16,7 @@ import kotlin.io.FilesKt;
 import kotlin.text.Charsets;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.kotlin.TestHelperGeneratorKt;
 import org.jetbrains.kotlin.TestsCompilerError;
 import org.jetbrains.kotlin.TestsCompiletimeError;
 import org.jetbrains.kotlin.backend.common.output.OutputFile;
@@ -783,7 +784,7 @@ public abstract class CodegenTestCase extends KtUsefulTestCase {
             expectedText = expectedText.replace("COROUTINES_PACKAGE", coroutinesPackage);
         }
 
-        List<TestFile> testFiles = createTestFiles(file, expectedText, coroutinesPackage);
+        List<TestFile> testFiles = createTestFiles(file, expectedText);
 
         doMultiFileTest(file, testFiles);
     }
@@ -794,14 +795,18 @@ public abstract class CodegenTestCase extends KtUsefulTestCase {
     }
 
     @NotNull
-    private static List<TestFile> createTestFiles(File file, String expectedText, String coroutinesPackage) {
-        return TestFiles.createTestFiles(file.getName(), expectedText, new TestFiles.TestFileFactoryNoModules<TestFile>() {
+    private List<TestFile> createTestFiles(File file, String expectedText) {
+        List testFiles = TestFiles.createTestFiles(file.getName(), expectedText, new TestFiles.TestFileFactoryNoModules<TestFile>() {
             @NotNull
             @Override
             public TestFile create(@NotNull String fileName, @NotNull String text, @NotNull Map<String, String> directives) {
                 return new TestFile(fileName, text);
             }
         }, coroutinesPackage);
+        if (InTextDirectivesUtils.isDirectiveDefined(expectedText, "WITH_HELPERS")) {
+            testFiles.add(new TestFile("CodegenTestHelpers.kt", TestHelperGeneratorKt.createTextForCodegenTestHelpers(getBackend())));
+        }
+        return testFiles;
     }
 
     @NotNull

--- a/compiler/tests-common/tests/org/jetbrains/kotlin/test/TestFiles.java
+++ b/compiler/tests-common/tests/org/jetbrains/kotlin/test/TestFiles.java
@@ -8,7 +8,7 @@ package org.jetbrains.kotlin.test;
 import com.google.common.collect.Lists;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.jetbrains.kotlin.CoroutineTestUtilKt;
+import org.jetbrains.kotlin.TestHelperGeneratorKt;
 
 import java.util.Collections;
 import java.util.List;
@@ -113,7 +113,8 @@ public class TestFiles {
                     factory.createFile(
                             supportModule,
                             "CoroutineUtil.kt",
-                            CoroutineTestUtilKt.createTextForHelpers(isReleaseCoroutines, checkStateMachine, checkTailCallOptimization),
+                            TestHelperGeneratorKt.createTextForCoroutineHelpers(
+                                    isReleaseCoroutines, checkStateMachine, checkTailCallOptimization),
                             directives
                     ));
         }


### PR DESCRIPTION
@udalov Rather than checking if the enclosing class/method is consistent with at least one representation, I decided to use a helper method that returns the target backend under test that we can check against.