### PR TITLE
JVM_IR: Avoid using parent name in name of captures.

### DIFF
--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/LocalDeclarationsLowering.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/LocalDeclarationsLowering.kt
@@ -776,11 +776,9 @@ class LocalDeclarationsLowering(
             if (isSpecial) asString().substring(1, asString().length - 1) else asString()
 
         private fun suggestNameForCapturedValue(declaration: IrValueDeclaration, existing: MutableSet<Name>): Name {
-            val base = if (declaration.name.isSpecial) {
-                val oldName = declaration.name.stripSpecialMarkers()
-                val parentName = (declaration.parent as? IrDeclarationWithName)?.name?.stripSpecialMarkers()
-                if (parentName != null) "$oldName$$parentName" else oldName
-            } else
+            val base = if (declaration.name.isSpecial)
+                declaration.name.stripSpecialMarkers()
+            else
                 declaration.name.asString()
             var chosen = base.synthesizedName
             var suffix = 0

--- a/compiler/testData/codegen/box/coroutines/tailCallOptimizations/innerObjectRetransformation_ir.txt
+++ b/compiler/testData/codegen/box/coroutines/tailCallOptimizations/innerObjectRetransformation_ir.txt
@@ -60,7 +60,7 @@ final class flow/InnerObjectRetransformationKt$check$$inlined$flowWith$1$1 {
 
 @kotlin.Metadata
 public final class flow/InnerObjectRetransformationKt$check$$inlined$flowWith$1 {
-    synthetic final field $this$flowWith$inlined: flow.Flow
+    synthetic final field $this$inlined: flow.Flow
     inner class flow/InnerObjectRetransformationKt$check$$inlined$flowWith$1
     public method <init>(p0: flow.Flow): void
     public @org.jetbrains.annotations.Nullable method collect(@org.jetbrains.annotations.NotNull p0: flow.FlowCollector, @org.jetbrains.annotations.NotNull p1: kotlin.coroutines.Continuation): java.lang.Object
@@ -128,7 +128,7 @@ final class flow/InnerObjectRetransformationKt$flowWith$$inlined$flow$1$1 {
 @kotlin.Metadata
 public final class flow/InnerObjectRetransformationKt$flowWith$$inlined$flow$1 {
     synthetic final field $builderBlock$inlined: kotlin.jvm.functions.Function2
-    synthetic final field $this$flowWith$inlined: flow.Flow
+    synthetic final field $this$inlined: flow.Flow
     inner class flow/InnerObjectRetransformationKt$flowWith$$inlined$flow$1
     public method <init>(p0: kotlin.jvm.functions.Function2, p1: flow.Flow): void
     public @org.jetbrains.annotations.Nullable method collect(@org.jetbrains.annotations.NotNull p0: flow.FlowCollector, @org.jetbrains.annotations.NotNull p1: kotlin.coroutines.Continuation): java.lang.Object
@@ -150,7 +150,7 @@ final class flow/InnerObjectRetransformationKt$flowWith$$inlined$flow$2$1 {
 @kotlin.Metadata
 public final class flow/InnerObjectRetransformationKt$flowWith$$inlined$flow$2 {
     synthetic final field $builderBlock$inlined: kotlin.jvm.functions.Function2
-    synthetic final field $this$flowWith$inlined: flow.Flow
+    synthetic final field $this$inlined: flow.Flow
     inner class flow/InnerObjectRetransformationKt$flowWith$$inlined$flow$2
     public method <init>(p0: kotlin.jvm.functions.Function2, p1: flow.Flow): void
     public @org.jetbrains.annotations.Nullable method collect(@org.jetbrains.annotations.NotNull p0: flow.FlowCollector, @org.jetbrains.annotations.NotNull p1: kotlin.coroutines.Continuation): java.lang.Object

--- a/compiler/testData/codegen/bytecodeText/mangling/parentheses.kt
+++ b/compiler/testData/codegen/bytecodeText/mangling/parentheses.kt
@@ -19,10 +19,5 @@ fun box(): String {
 
 // One instance of each is in kotlin.Metadata.d2
 // 1 \(X\)
-
-// JVM_TEMPLATES
 // 1 \(Y\)
-
-// JVM_IR_TEMPLATES
-// 5 \(Y\)
-// 4 \$this\$\(Y\)
+// 4 \$this


### PR DESCRIPTION
If parent is an anonymous object that could lead to the use
of names such as `$this$no name provided` which is invalid
in dex files.