### PR TITLE
Add the system classloader as a parent of ReplClassLoader

### DIFF
--- a/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/repl/ReplInterpreter.kt
+++ b/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/repl/ReplInterpreter.kt
@@ -37,7 +37,14 @@ class ReplInterpreter(
             else -> null
         }
     }
-    private val classLoader = ReplClassLoader(URLClassLoader(classpathRoots.map { it.toURI().toURL() }.toTypedArray(), null))
+
+    private val classLoader =
+        ReplClassLoader(
+            URLClassLoader(
+                classpathRoots.map { it.toURI().toURL() }.toTypedArray(),
+                ClassLoader.getSystemClassLoader()
+            )
+        )
 
     private val messageCollector = object : MessageCollector {
         private var hasErrors = false


### PR DESCRIPTION
Issue found while investigating https://youtrack.jetbrains.com/issue/KT-35925.

This fixes a *class not found* exception that happens when launching the autoconfiguration of Spring Boot from the REPL. It happens with JDK 11 but not with 1.8

This is the exception that is fixed:
```
Caused by: java.lang.NoClassDefFoundError: org/ietf/jgss/GSSContext
	at java.base/java.lang.Class.getDeclaredMethods0(Native Method)
	at java.base/java.lang.Class.privateGetDeclaredMethods(Class.java:3166)
	at java.base/java.lang.Class.privateGetPublicMethods(Class.java:3191)
	at java.base/java.lang.Class.privateGetPublicMethods(Class.java:3197)
	at java.base/java.lang.Class.getMethods(Class.java:1904)
	at org.apache.tomcat.util.modeler.modules.MbeansDescriptorsIntrospectionSource.createManagedBean(MbeansDescriptorsIntrospectionSource.java:298)
	at org.apache.tomcat.util.modeler.modules.MbeansDescriptorsIntrospectionSource.execute(MbeansDescriptorsIntrospectionSource.java:78)
	at org.apache.tomcat.util.modeler.modules.MbeansDescriptorsIntrospectionSource.loadDescriptors(MbeansDescriptorsIntrospectionSource.java:71)
	at org.apache.tomcat.util.modeler.Registry.load(Registry.java:582)
	at org.apache.tomcat.util.modeler.Registry.findManagedBean(Registry.java:488)
	at org.apache.tomcat.util.modeler.Registry.registerComponent(Registry.java:611)
	at org.apache.catalina.util.LifecycleMBeanBase.register(LifecycleMBeanBase.java:158)
	at org.apache.catalina.util.LifecycleMBeanBase.initInternal(LifecycleMBeanBase.java:59)
	at org.apache.catalina.realm.RealmBase.initInternal(RealmBase.java:1080)
	at org.apache.catalina.util.LifecycleBase.init(LifecycleBase.java:136)
	... 58 more
Caused by: java.lang.ClassNotFoundException: org.ietf.jgss.GSSContext
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:471)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:588)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
	... 73 more
```

I know why it works for me, but my knowledge of classloading, especially in the context of the REPL, is too thin to know if this is the proper fix, if it could have some undesirable side effects, etc.