### PR TITLE
KT-30601 "Use destructing declaration" produces incorrect code if a field name is shadowed

### DIFF
--- a/idea/testData/intentions/destructuringInLambda/dependentLocal.kt.after
+++ b/idea/testData/intentions/destructuringInLambda/dependentLocal.kt.after
@@ -2,9 +2,9 @@
 
 data class XY(val x: Int, val y: Int)
 fun test(xys: Array<XY>) {
-    xys.forEach { (x, y) ->
+    xys.forEach { (x, y1) ->
         println(x)
-        val y = y + x
+        val y = y1 + x
         println(y)
     }
 }

--- a/idea/testData/intentions/destructuringInLambda/hasSameNameParameter.kt
+++ b/idea/testData/intentions/destructuringInLambda/hasSameNameParameter.kt
@@ -1,0 +1,9 @@
+// WITH_RUNTIME
+data class Event(val timestamp: Int, val otherVar: Int = 1, val otherVar2: String = "")
+
+val listA = listOf(Event(1), Event(2), Event(3))
+val listB = listOf(Event(1), Event(2), Event(3))
+
+fun test2() {
+    listA.zip(listB) { (timestamp), <caret>it2 -> timestamp + it2.timestamp }
+}

--- a/idea/testData/intentions/destructuringInLambda/hasSameNameParameter.kt.after
+++ b/idea/testData/intentions/destructuringInLambda/hasSameNameParameter.kt.after
@@ -1,0 +1,9 @@
+// WITH_RUNTIME
+data class Event(val timestamp: Int, val otherVar: Int = 1, val otherVar2: String = "")
+
+val listA = listOf(Event(1), Event(2), Event(3))
+val listB = listOf(Event(1), Event(2), Event(3))
+
+fun test2() {
+    listA.zip(listB) { (timestamp), (timestamp1) -> timestamp + timestamp1 }
+}

--- a/idea/testData/intentions/destructuringInLambda/hasShadowedVariable.kt
+++ b/idea/testData/intentions/destructuringInLambda/hasShadowedVariable.kt
@@ -1,0 +1,15 @@
+// WITH_RUNTIME
+data class A(var x: Int)
+
+fun convert(f: (A) -> Unit) {}
+
+fun test() {
+    convert <caret>{
+        val x = it.x
+
+        run {
+            val x = 1
+            val z = it.x
+        }
+    }
+}

--- a/idea/testData/intentions/destructuringInLambda/hasShadowedVariable.kt.after
+++ b/idea/testData/intentions/destructuringInLambda/hasShadowedVariable.kt.after
@@ -1,0 +1,14 @@
+// WITH_RUNTIME
+data class A(var x: Int)
+
+fun convert(f: (A) -> Unit) {}
+
+fun test() {
+    convert { (x1) ->
+
+        run {
+            val x = 1
+            val z = x1
+        }
+    }
+}

--- a/idea/testData/intentions/destructuringInLambda/hasShadowedVariable2.kt
+++ b/idea/testData/intentions/destructuringInLambda/hasShadowedVariable2.kt
@@ -1,0 +1,15 @@
+// WITH_RUNTIME
+data class A(var x: Int)
+
+fun convert(f: (A) -> Unit) {}
+
+fun test() {
+    convert { <caret>a ->
+        val x = a.x
+
+        run {
+            val x = 1
+            val z = a.x
+        }
+    }
+}

--- a/idea/testData/intentions/destructuringInLambda/hasShadowedVariable2.kt.after
+++ b/idea/testData/intentions/destructuringInLambda/hasShadowedVariable2.kt.after
@@ -1,0 +1,14 @@
+// WITH_RUNTIME
+data class A(var x: Int)
+
+fun convert(f: (A) -> Unit) {}
+
+fun test() {
+    convert { (x1) ->
+
+        run {
+            val x = 1
+            val z = x1
+        }
+    }
+}

--- a/idea/testData/intentions/destructuringVariables/hasShadowedVariable.kt
+++ b/idea/testData/intentions/destructuringVariables/hasShadowedVariable.kt
@@ -1,0 +1,12 @@
+// WITH_RUNTIME
+fun main() {
+    data class A(var x: Int)
+
+    val <caret>a = A(0)
+    val x = a.x
+
+    run {
+        val x = 1
+        val z = a.x
+    }
+}

--- a/idea/testData/intentions/destructuringVariables/hasShadowedVariable.kt.after
+++ b/idea/testData/intentions/destructuringVariables/hasShadowedVariable.kt.after
@@ -1,0 +1,11 @@
+// WITH_RUNTIME
+fun main() {
+    data class A(var x: Int)
+
+    val (x1) = A(0)
+
+    run {
+        val x = 1
+        val z = x1
+    }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -8150,6 +8150,21 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
             runTest("idea/testData/intentions/destructuringInLambda/fold.kt");
         }
 
+        @TestMetadata("hasSameNameParameter.kt")
+        public void testHasSameNameParameter() throws Exception {
+            runTest("idea/testData/intentions/destructuringInLambda/hasSameNameParameter.kt");
+        }
+
+        @TestMetadata("hasShadowedVariable.kt")
+        public void testHasShadowedVariable() throws Exception {
+            runTest("idea/testData/intentions/destructuringInLambda/hasShadowedVariable.kt");
+        }
+
+        @TestMetadata("hasShadowedVariable2.kt")
+        public void testHasShadowedVariable2() throws Exception {
+            runTest("idea/testData/intentions/destructuringInLambda/hasShadowedVariable2.kt");
+        }
+
         @TestMetadata("invisible.kt")
         public void testInvisible() throws Exception {
             runTest("idea/testData/intentions/destructuringInLambda/invisible.kt");
@@ -8259,6 +8274,11 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
         @TestMetadata("classProperty.kt")
         public void testClassProperty() throws Exception {
             runTest("idea/testData/intentions/destructuringVariables/classProperty.kt");
+        }
+
+        @TestMetadata("hasShadowedVariable.kt")
+        public void testHasShadowedVariable() throws Exception {
+            runTest("idea/testData/intentions/destructuringVariables/hasShadowedVariable.kt");
         }
 
         @TestMetadata("noInitializer.kt")


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-30601
https://youtrack.jetbrains.com/issue/KT-20570