### PR TITLE
Fix test expectations.

### DIFF
--- a/compiler/testData/codegen/bytecodeText/mangling/parentheses.kt
+++ b/compiler/testData/codegen/bytecodeText/mangling/parentheses.kt
@@ -20,4 +20,6 @@ fun box(): String {
 // One instance of each is in kotlin.Metadata.d2
 // 1 \(X\)
 // 1 \(Y\)
+
+// JVM_IR_TEMPLATES
 // 4 \$this


### PR DESCRIPTION
Do not check for occurrences of "this" on the current backend.
I accidentally unified the checking for the two backends
without checking that it worked (used the wrong test suite to
test).