### PR TITLE
KT-34686 False positive "Constructor parameter is never used as a property" if property is used as a reference

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/CanBeParameterInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/CanBeParameterInspection.kt
@@ -99,7 +99,7 @@ class CanBeParameterInspection : AbstractKotlinInspection() {
             // Find all references and check them
             val references = ReferencesSearch.search(parameter, restrictedScope)
             if (references.none()) return
-            if (references.any { it.usedAsPropertyIn(klass) }) return
+            if (references.any { it.element.parent is KtCallableReferenceExpression || it.usedAsPropertyIn(klass) }) return
             holder.registerProblem(
                 valOrVar,
                 "Constructor parameter is never used as a property",

--- a/idea/testData/inspections/canBeParameter/test.kt
+++ b/idea/testData/inspections/canBeParameter/test.kt
@@ -151,3 +151,8 @@ class UsedInObjectSuper(val bar456: String) {
         object : Base1(bar456) {}
     }
 }
+
+// NO
+class Foo(<caret>var baz: String) {
+    var bar = ::baz
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-34686