### PR TITLE
JVM IR: Remove type substitutions from ExpressionCodegen

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -453,9 +453,8 @@ class ExpressionCodegen(
             addInlineMarker(mv, isStartNotEnd = false)
         }
 
-        val returnType = callee.returnType
         return when {
-            returnType.substitute(expression.typeSubstitutionMap).isNothing() -> {
+            expression.type.isNothing() -> {
                 mv.aconst(null)
                 mv.athrow()
                 immaterialUnitValue
@@ -467,9 +466,9 @@ class ExpressionCodegen(
                 immaterialUnitValue
             expression.type.isUnit() ->
                 // NewInference allows casting `() -> T` to `() -> Unit`. A CHECKCAST here will fail.
-                MaterialValue(this, callable.asmMethod.returnType, returnType).discard().coerce(expression.type)
+                MaterialValue(this, callable.asmMethod.returnType, callee.returnType).discard().coerce(expression.type)
             else ->
-                MaterialValue(this, callable.asmMethod.returnType, returnType).coerce(expression.type)
+                MaterialValue(this, callable.asmMethod.returnType, callee.returnType).coerce(expression.type)
         }
     }
 

--- a/compiler/testData/codegen/box/bridges/kt1959.kt
+++ b/compiler/testData/codegen/box/bridges/kt1959.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 open class A<T> {
     open fun f(args : Array<T>) {}
 }

--- a/compiler/testData/codegen/box/bridges/overrideAbstractProperty.kt
+++ b/compiler/testData/codegen/box/bridges/overrideAbstractProperty.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 public abstract class AbstractClass<T> {
     public abstract val some: T
 }

--- a/compiler/testData/codegen/box/elvis/kt6694ExactAnnotationForElvis.kt
+++ b/compiler/testData/codegen/box/elvis/kt6694ExactAnnotationForElvis.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 interface PsiElement {
     fun <T: PsiElement> findChildByType(i: Int): T? =
             if (i == 42) JetOperationReferenceExpression() as T else throw Exception()

--- a/compiler/testData/codegen/box/functions/functionExpression/functionExpressionWithThisReference.kt
+++ b/compiler/testData/codegen/box/functions/functionExpression/functionExpressionWithThisReference.kt
@@ -1,6 +1,4 @@
 // IGNORE_BACKEND_FIR: JVM_IR
-// IGNORE_BACKEND: JVM_IR
-// For JVM_IR, NewInference is needed because of KT-26531. See functionExpressionWithThisReferenceNI.kt
 
 fun Int.thisRef1() = fun () = this
 fun Int.thisRef2() = fun (): Int {return this}

--- a/compiler/testData/codegen/box/javaInterop/notNullAssertions/nullableTypeParameter.kt
+++ b/compiler/testData/codegen/box/javaInterop/notNullAssertions/nullableTypeParameter.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 // TARGET_BACKEND: JVM
 interface I {
     fun <T : String> f(x: T?) = x ?: "OK"

--- a/compiler/testData/codegen/box/regressions/noAssertionsWhenNullableTypeParameterReplacedWithIntersectionType.kt
+++ b/compiler/testData/codegen/box/regressions/noAssertionsWhenNullableTypeParameterReplacedWithIntersectionType.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: +NewInference
-// IGNORE_BACKEND_FIR: JVM_IR
 
 class Recursive<T : Recursive<T>> : Generic<PlaceHolder<T>>, MainSupertype
 open class Simple<T> : Generic<T>, MainSupertype

--- a/compiler/testData/codegen/box/statics/inheritedPropertyInObject.kt
+++ b/compiler/testData/codegen/box/statics/inheritedPropertyInObject.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 open class Bar<T>(val prop: String)
 object Foo : Bar<Foo>("OK") {
 

--- a/compiler/testData/compileKotlinAgainstKotlin/useDeserializedFunInterface.kt
+++ b/compiler/testData/compileKotlinAgainstKotlin/useDeserializedFunInterface.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: +NewInference +FunctionalInterfaceConversion +SamConversionPerArgument +SamConversionForKotlinFunctions
-// IGNORE_BACKEND: JVM_IR
 
 // FILE: A.kt
 


### PR DESCRIPTION
Instead, determine whether the return type of a call is Nothing, by looking at the type of the call expression.

CC @kandersen 