### PR TITLE
Fix file components order

### DIFF
--- a/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/KotlinGradleWebMultiplatformModuleBuilder.kt
+++ b/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/KotlinGradleWebMultiplatformModuleBuilder.kt
@@ -264,7 +264,7 @@ class KotlinGradleWebMultiplatformModuleBuilder : KotlinGradleAbstractMultiplatf
 
             jvmJar {
                 dependsOn(jsBrowserProductionWebpack)
-                from(new File(jsBrowserProductionWebpack.entry.name, jsBrowserProductionWebpack.outputPath))
+                from(new File(jsBrowserProductionWebpack.destinationDirectory, jsBrowserProductionWebpack.entry.name))
             }
             
             task run(type: JavaExec, dependsOn: [jvmJar]) {

--- a/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/KotlinGradleWebMultiplatformModuleBuilder.kt
+++ b/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/KotlinGradleWebMultiplatformModuleBuilder.kt
@@ -264,7 +264,7 @@ class KotlinGradleWebMultiplatformModuleBuilder : KotlinGradleAbstractMultiplatf
 
             jvmJar {
                 dependsOn(jsBrowserProductionWebpack)
-                from(new File(jsBrowserProductionWebpack.destinationDirectory, jsBrowserProductionWebpack.entry.name))
+                from(jsBrowserProductionWebpack.outputFile)
             }
             
             task run(type: JavaExec, dependsOn: [jvmJar]) {


### PR DESCRIPTION
The path of the webpacked JavaScript file that should be included in the server JAR is constructed by taking the webpack tasks output directory, and appending the filename of the JavaScript module. Previously, the constructor arguments were flipped, leading to an invalid path.

Furthermore, I migrated away from the deprecated `outputPath` property, to the recommended `destinationDirectory` property.

I verified that the code was not working previously, but is working as expected with the suggested changes.