### PR TITLE
KT-27651 'Condition is always true' inspection should not be triggered when the condition has references to a named constant

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/ConstantConditionIfInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/ConstantConditionIfInspection.kt
@@ -20,10 +20,7 @@ import org.jetbrains.kotlin.idea.references.mainReference
 import org.jetbrains.kotlin.idea.util.hasNoSideEffects
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.*
-import org.jetbrains.kotlin.psi.psiUtil.containingClass
-import org.jetbrains.kotlin.psi.psiUtil.getChildrenOfType
-import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
-import org.jetbrains.kotlin.psi.psiUtil.startOffset
+import org.jetbrains.kotlin.psi.psiUtil.*
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.bindingContextUtil.isUsedAsExpression
 import org.jetbrains.kotlin.resolve.calls.callUtil.getType
@@ -127,6 +124,7 @@ private fun KtExpression.constantBooleanValue(context: BindingContext): Boolean?
     if (enumEntriesComparison != null) {
         return enumEntriesComparison
     }
+    if (anyDescendantOfType<KtNameReferenceExpression> { true }) return null
     val type = getType(context) ?: return null
     val constantValue = ConstantExpressionEvaluator.getConstant(this, context)?.toConstantValue(type)
     return constantValue?.value as? Boolean

--- a/idea/testData/inspectionsLocal/constantConditionIf/constant.kt
+++ b/idea/testData/inspectionsLocal/constantConditionIf/constant.kt
@@ -1,0 +1,7 @@
+// PROBLEM: none
+const val s = "debug"
+
+fun main() {
+    if (<caret>s == "debug") {
+    }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -2460,6 +2460,11 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
             KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("idea/testData/inspectionsLocal/constantConditionIf"), Pattern.compile("^([\\w\\-_]+)\\.(kt|kts)$"), null, true);
         }
 
+        @TestMetadata("constant.kt")
+        public void testConstant() throws Exception {
+            runTest("idea/testData/inspectionsLocal/constantConditionIf/constant.kt");
+        }
+
         @TestMetadata("delete.kt")
         public void testDelete() throws Exception {
             runTest("idea/testData/inspectionsLocal/constantConditionIf/delete.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-27651