### PR TITLE
KT-22878 Empty argument list at the call site of custom function named "suspend" shouldn't be reported as unnecessary 

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/intentions/RemoveEmptyParenthesesFromLambdaCallIntention.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/RemoveEmptyParenthesesFromLambdaCallIntention.kt
@@ -43,6 +43,7 @@ class RemoveEmptyParenthesesFromLambdaCallIntention : SelfTargetingRangeIntentio
     override fun applicabilityRange(element: KtValueArgumentList): TextRange? {
         if (element.arguments.isNotEmpty()) return null
         val parent = element.parent as? KtCallExpression ?: return null
+        if (parent.calleeExpression?.text == "suspend") return null
         val singleLambdaArgument = parent.lambdaArguments.singleOrNull() ?: return null
         if (element.getLineNumber(start = false) != singleLambdaArgument.getLineNumber(start = true)) return null
         val prev = element.getPrevSiblingIgnoringWhitespaceAndComments()

--- a/idea/testData/intentions/removeEmptyParenthesesFromLambdaCall/suspend.kt
+++ b/idea/testData/intentions/removeEmptyParenthesesFromLambdaCall/suspend.kt
@@ -1,0 +1,6 @@
+// IS_APPLICABLE: false
+fun suspend(body: () -> Int) {}
+
+fun main() {
+    val wInvokeCall = suspend()<caret> { 42 }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -13146,6 +13146,11 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
         public void testSimple() throws Exception {
             runTest("idea/testData/intentions/removeEmptyParenthesesFromLambdaCall/simple.kt");
         }
+
+        @TestMetadata("suspend.kt")
+        public void testSuspend() throws Exception {
+            runTest("idea/testData/intentions/removeEmptyParenthesesFromLambdaCall/suspend.kt");
+        }
     }
 
     @TestMetadata("idea/testData/intentions/removeEmptyPrimaryConstructor")


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-22878