### PR TITLE
JVM_IR: Use direct field access instead of calling certain accessors.

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
@@ -314,10 +314,9 @@ private val jvmFilePhases =
         staticDefaultFunctionPhase then
         syntheticAccessorPhase then
 
-
         jvmArgumentNullabilityAssertions then
         toArrayPhase then
-        jvmBuiltinOptimizationLoweringPhase then
+        jvmOptimizationLoweringPhase then
         additionalClassAnnotationPhase then
         typeOperatorLowering then
         replaceKFunctionInvokeWithFunctionInvokePhase then

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/PropertiesToFieldsLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/PropertiesToFieldsLowering.kt
@@ -21,6 +21,7 @@ import org.jetbrains.kotlin.ir.expressions.IrFieldAccessExpression
 import org.jetbrains.kotlin.ir.expressions.IrTypeOperator
 import org.jetbrains.kotlin.ir.expressions.impl.*
 import org.jetbrains.kotlin.ir.types.makeNotNull
+import org.jetbrains.kotlin.ir.util.coerceToUnit
 import org.jetbrains.kotlin.ir.util.hasAnnotation
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
@@ -129,16 +130,7 @@ class PropertiesToFieldsLowering(val context: CommonBackendContext) : IrElementT
         if (receiver != null && needBlock) {
             // Evaluate `dispatchReceiver` for the sake of its side effects, then return `setOrGetExpr`.
             return context.createIrBuilder(setOrGetExpr.symbol, setOrGetExpr.startOffset, setOrGetExpr.endOffset).irBlock(setOrGetExpr) {
-                // `coerceToUnit()` is private in InsertImplicitCasts, have to reproduce it here
-                val receiverVoid = IrTypeOperatorCallImpl(
-                    receiver.startOffset, receiver.endOffset,
-                    context.irBuiltIns.unitType,
-                    IrTypeOperator.IMPLICIT_COERCION_TO_UNIT,
-                    context.irBuiltIns.unitType,
-                    receiver
-                )
-
-                +receiverVoid
+                +receiver.coerceToUnit(context.irBuiltIns)
                 setOrGetExpr.receiver = null
                 +setOrGetExpr
             }

--- a/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/transformations/InsertImplicitCasts.kt
+++ b/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/transformations/InsertImplicitCasts.kt
@@ -37,7 +37,7 @@ import org.jetbrains.kotlin.ir.symbols.IrConstructorSymbol
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.impl.originalKotlinType
 import org.jetbrains.kotlin.ir.util.TypeTranslator
-import org.jetbrains.kotlin.ir.util.coerceToUnitIfNeeded
+import org.jetbrains.kotlin.ir.util.coerceToUnit
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
 import org.jetbrains.kotlin.psi2ir.containsNull
@@ -146,7 +146,7 @@ internal class InsertImplicitCasts(
         body.transformPostfix {
             statements.forEachIndexed { i, irStatement ->
                 if (irStatement is IrExpression) {
-                    body.statements[i] = irStatement.coerceToUnit()
+                    body.statements[i] = irStatement.coerceToUnit(irBuiltIns)
                 }
             }
         }
@@ -162,7 +162,7 @@ internal class InsertImplicitCasts(
                         if (i == lastIndex)
                             irStatement.cast(type)
                         else
-                            irStatement.coerceToUnit()
+                            irStatement.coerceToUnit(irBuiltIns)
                 }
             }
         }
@@ -170,7 +170,7 @@ internal class InsertImplicitCasts(
     override fun visitReturn(expression: IrReturn): IrExpression =
         expression.transformPostfix {
             value = if (expression.returnTargetSymbol is IrConstructorSymbol) {
-                value.coerceToUnit()
+                value.coerceToUnit(irBuiltIns)
             } else {
                 val returnTargetDescriptor = expression.returnTarget
                 val isLambdaReturnValue = returnTargetDescriptor is AnonymousFunctionDescriptor
@@ -232,7 +232,7 @@ internal class InsertImplicitCasts(
     override fun visitLoop(loop: IrLoop): IrExpression =
         loop.transformPostfix {
             condition = condition.cast(builtIns.booleanType)
-            body = body?.coerceToUnit()
+            body = body?.coerceToUnit(irBuiltIns)
         }
 
     override fun visitThrow(expression: IrThrow): IrExpression =
@@ -248,7 +248,7 @@ internal class InsertImplicitCasts(
                 aCatch.result = aCatch.result.cast(type)
             }
 
-            finallyExpression = finallyExpression?.coerceToUnit()
+            finallyExpression = finallyExpression?.coerceToUnit(irBuiltIns)
         }
 
     private fun KotlinType.getSubstitutedFunctionTypeForSamType() =
@@ -320,7 +320,7 @@ internal class InsertImplicitCasts(
 
         return when {
             expectedType.isUnit() ->
-                coerceToUnit()
+                coerceToUnit(irBuiltIns)
 
             valueType.isDynamic() && !expectedType.isDynamic() ->
                 if (expectedType.isNullableAny())
@@ -384,14 +384,6 @@ internal class InsertImplicitCasts(
             this
         )
     }
-
-    private fun IrExpression.coerceToUnit(): IrExpression {
-        val valueType = getKotlinType(this)
-        return coerceToUnitIfNeeded(valueType, irBuiltIns)
-    }
-
-    private fun getKotlinType(irExpression: IrExpression) =
-        irExpression.type.originalKotlinType!!
 
     private fun KotlinType.isBuiltInIntegerType(): Boolean =
         KotlinBuiltIns.isByte(this) ||

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/IrUtils.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/IrUtils.kt
@@ -17,6 +17,7 @@ import org.jetbrains.kotlin.ir.expressions.impl.IrConstructorCallImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrTypeOperatorCallImpl
 import org.jetbrains.kotlin.ir.symbols.*
 import org.jetbrains.kotlin.ir.types.*
+import org.jetbrains.kotlin.ir.types.impl.originalKotlinType
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.SpecialNames
 import org.jetbrains.kotlin.psi.psiUtil.endOffset
@@ -151,6 +152,14 @@ fun IrExpression.isNullConst() = this is IrConst<*> && this.kind == IrConstKind.
 fun IrExpression.isTrueConst() = this is IrConst<*> && this.kind == IrConstKind.Boolean && this.value == true
 
 fun IrExpression.isFalseConst() = this is IrConst<*> && this.kind == IrConstKind.Boolean && this.value == false
+
+fun IrExpression.coerceToUnit(builtins: IrBuiltIns): IrExpression {
+    val valueType = getKotlinType(this)
+    return coerceToUnitIfNeeded(valueType, builtins)
+}
+
+private fun getKotlinType(irExpression: IrExpression) =
+    irExpression.type.toKotlinType()
 
 fun IrExpression.coerceToUnitIfNeeded(valueType: KotlinType, irBuiltIns: IrBuiltIns): IrExpression {
     return if (KotlinTypeChecker.DEFAULT.isSubtypeOf(valueType, irBuiltIns.unitType.toKotlinType()))

--- a/compiler/testData/codegen/bytecodeText/accessorForOverridenVal.kt
+++ b/compiler/testData/codegen/bytecodeText/accessorForOverridenVal.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 package b
 
 abstract class B {

--- a/compiler/testData/codegen/bytecodeText/constants/noInlineNonConst.kt
+++ b/compiler/testData/codegen/bytecodeText/constants/noInlineNonConst.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 val x = 1
 
 class A {

--- a/compiler/testData/codegen/bytecodeText/kt3845.kt
+++ b/compiler/testData/codegen/bytecodeText/kt3845.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 class Example
 {
     var a1 = 0


### PR DESCRIPTION
Final default properties accessors that access a backing field
on the same class can be replaced by direct field use.

Perform the optimization late in the pipeline to allow lowerings
to expose more opportunities for optimizations.