### PR TITLE
[JVM IR] ProperVisibilityForCompanionObjectInstanceField

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendContext.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendContext.kt
@@ -69,7 +69,7 @@ class JvmBackendContext(
     val typeMapper = IrTypeMapper(this)
     val methodSignatureMapper = MethodSignatureMapper(this)
 
-    override val declarationFactory: JvmDeclarationFactory = JvmDeclarationFactory(methodSignatureMapper)
+    override val declarationFactory: JvmDeclarationFactory = JvmDeclarationFactory(methodSignatureMapper, state.languageVersionSettings)
     override val sharedVariablesManager = JvmSharedVariablesManager(state.module, builtIns, irBuiltIns)
 
     override val mapping: Mapping = DefaultMapping()

--- a/compiler/testData/codegen/bytecodeText/companion/privateCompanionObjectAccessors_after.kt
+++ b/compiler/testData/codegen/bytecodeText/companion/privateCompanionObjectAccessors_after.kt
@@ -1,6 +1,4 @@
 // !LANGUAGE: +ProperVisibilityForCompanionObjectInstanceField
-// IGNORE_BACKEND: JVM_IR
-// ^ TODO implement ProperVisibilityForCompanionObjectInstanceField feature support in JMV_IR
 
 class Host {
     private companion object {

--- a/compiler/testData/codegen/bytecodeText/companion/protectedCompanionObjectAccessors_after.kt
+++ b/compiler/testData/codegen/bytecodeText/companion/protectedCompanionObjectAccessors_after.kt
@@ -1,6 +1,4 @@
 // !LANGUAGE: +ProperVisibilityForCompanionObjectInstanceField
-// IGNORE_BACKEND: JVM_IR
-// ^ TODO implement ProperVisibilityForCompanionObjectInstanceField feature support in JMV_IR
 
 // FILE: Base.kt
 package a

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -6670,6 +6670,7 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
                 runTestWithPackageReplacement("compiler/testData/codegen/box/coroutines/featureIntersection/inlineSuspendFinally.kt", "kotlin.coroutines");
             }
 
+
             @TestMetadata("interfaceMethodWithBody.kt")
             public void testInterfaceMethodWithBody() throws Exception {
                 runTest("compiler/testData/codegen/box/coroutines/featureIntersection/interfaceMethodWithBody.kt");


### PR DESCRIPTION
This PR causes the IR backend to respect the visibility modifier of companion objects.

This causes a slight complication in synthetic accessor lowering: if a protected/private companion object implements a class unrelated to the containing class, accessors for members of superclass must be placed on the companion object, not on the containing class.

 An exception is made for interfaces as this functionality is implemented across JVM targets and <1.8 does not allow implementations (hence, accessors) on interfaces - the static companion object instance field must remain public to avoid the accessor.