### PR TITLE
[JVM IR] Interface Delegation by Property should use existing field

### DIFF
--- a/compiler/testData/codegen/box/delegation/delegationToVal.kt
+++ b/compiler/testData/codegen/box/delegation/delegationToVal.kt
@@ -1,5 +1,4 @@
 // IGNORE_BACKEND_FIR: JVM_IR
-// IGNORE_BACKEND: JVM_IR
 // TARGET_BACKEND: JVM
 
 // WITH_RUNTIME
@@ -37,7 +36,7 @@ fun box(): String {
 
     try {
         Test2::class.java.getDeclaredField("\$\$delegate_0")
-        return "\$\$delegate_0 field generated for class Test but should not"
+        return "\$\$delegate_0 field generated for class Test2 but should not"
     }
     catch (e: NoSuchFieldException) {
         // ok


### PR DESCRIPTION
When a property backed by a final field is the delegate for interface implementation by delegation, the backend should reuse the backing field rather than introduce a new, extraneous `$$delegate_n` field.