### PR TITLE
KT-36160 False positive "Constructor has non-null self reference parameter" with vararg parameter of class

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/SelfReferenceConstructorParameterInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/SelfReferenceConstructorParameterInspection.kt
@@ -37,6 +37,7 @@ class SelfReferenceConstructorParameterInspection : AbstractKotlinInspection() {
         val containingClass = this.containingClass() ?: return null
         val className = containingClass.name ?: return null
         val parameter = this.parameters.firstOrNull { it.typeReference?.text == className } ?: return null
+        if (parameter.isVarArg) return null
 
         val typeReference = parameter.typeReference ?: return null
         val context = analyze(BodyResolveMode.PARTIAL)

--- a/idea/testData/inspectionsLocal/selfReferenceConstructorParameter/vararg.kt
+++ b/idea/testData/inspectionsLocal/selfReferenceConstructorParameter/vararg.kt
@@ -1,0 +1,6 @@
+// PROBLEM: none
+class Foo(vararg children: Foo<caret>)
+
+fun test() {
+    Foo()
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -11248,6 +11248,11 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
         public void testNullable() throws Exception {
             runTest("idea/testData/inspectionsLocal/selfReferenceConstructorParameter/nullable.kt");
         }
+
+        @TestMetadata("vararg.kt")
+        public void testVararg() throws Exception {
+            runTest("idea/testData/inspectionsLocal/selfReferenceConstructorParameter/vararg.kt");
+        }
     }
 
     @TestMetadata("idea/testData/inspectionsLocal/setterBackingFieldAssignment")


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-36160