### PR TITLE
KT-34317 False positive "Redundant 'suspend' modifier" inspection when function reference is used as parameter with declared 'suspend' type

### DIFF
--- a/idea/testData/inspectionsLocal/redundantSuspend/functionReference.kt
+++ b/idea/testData/inspectionsLocal/redundantSuspend/functionReference.kt
@@ -1,0 +1,8 @@
+// PROBLEM: none
+<caret>suspend fun f() {}
+
+fun g(x: suspend () -> Unit) {}
+
+fun test() {
+    g(::f)
+}

--- a/idea/testData/inspectionsLocal/redundantSuspend/functionReference2.kt
+++ b/idea/testData/inspectionsLocal/redundantSuspend/functionReference2.kt
@@ -1,0 +1,4 @@
+// PROBLEM: none
+<caret>suspend fun f() {}
+
+val x: suspend () -> Unit = ::f

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -7905,6 +7905,16 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
             runTest("idea/testData/inspectionsLocal/redundantSuspend/coroutineContext.kt");
         }
 
+        @TestMetadata("functionReference.kt")
+        public void testFunctionReference() throws Exception {
+            runTest("idea/testData/inspectionsLocal/redundantSuspend/functionReference.kt");
+        }
+
+        @TestMetadata("functionReference2.kt")
+        public void testFunctionReference2() throws Exception {
+            runTest("idea/testData/inspectionsLocal/redundantSuspend/functionReference2.kt");
+        }
+
         @TestMetadata("override.kt")
         public void testOverride() throws Exception {
             runTest("idea/testData/inspectionsLocal/redundantSuspend/override.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-34317