### PR TITLE
Update message on KotlinReflectionInternalError to reflect that typeliases are also unsupported

### DIFF
--- a/core/reflection.jvm/src/kotlin/reflect/jvm/internal/EmptyContainerForLocal.kt
+++ b/core/reflection.jvm/src/kotlin/reflect/jvm/internal/EmptyContainerForLocal.kt
@@ -39,6 +39,6 @@ internal object EmptyContainerForLocal : KDeclarationContainerImpl() {
     override fun getLocalProperty(index: Int): PropertyDescriptor? = null
 
     private fun fail(): Nothing = throw KotlinReflectionInternalError(
-        "Introspecting local functions, lambdas, anonymous functions and local variables is not yet fully supported in Kotlin reflection"
+        "Introspecting local functions, lambdas, anonymous functions, local variables and typealiases is not yet fully supported in Kotlin reflection"
     )
 }


### PR DESCRIPTION
For example, this exception can be triggered by the following snippet:

```kotlin
data class Test(
	val field: String
)

typealias TestAlias = Test

fun main(args: Array<String>) {
	println(::TestAlias)
}
```

with no local functions, lambdas, anonymous functions or local variables in sight.