### PR TITLE
KT-31601 "Remove redundant let call" changes semantics by introducing multiple safe calls

### DIFF
--- a/idea/testData/inspectionsLocal/simpleRedundantLet/extensionCall.kt
+++ b/idea/testData/inspectionsLocal/simpleRedundantLet/extensionCall.kt
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+fun String.foo() {}
+
+fun test(s: String?) {
+    s?.let<caret> { it.foo() }
+}

--- a/idea/testData/inspectionsLocal/simpleRedundantLet/extensionCall.kt.after
+++ b/idea/testData/inspectionsLocal/simpleRedundantLet/extensionCall.kt.after
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+fun String.foo() {}
+
+fun test(s: String?) {
+    s?.foo()
+}

--- a/idea/testData/inspectionsLocal/simpleRedundantLet/extensionWithNullableReceiverCall.kt
+++ b/idea/testData/inspectionsLocal/simpleRedundantLet/extensionWithNullableReceiverCall.kt
@@ -1,0 +1,10 @@
+// WITH_RUNTIME
+// PROBLEM: none
+class Optional<out T>(val value: T)
+
+fun Any?.foo() = println("foo: $this")
+
+fun main() {
+    val b: Optional<Any?>? = Optional(null)
+    b?.let<caret> { it.value.foo() }
+}

--- a/idea/testData/inspectionsLocal/simpleRedundantLet/extensionWithNullableReceiverCall2.kt
+++ b/idea/testData/inspectionsLocal/simpleRedundantLet/extensionWithNullableReceiverCall2.kt
@@ -1,0 +1,10 @@
+// WITH_RUNTIME
+// PROBLEM: none
+class Optional<out T>(val value: T)
+
+val Any?.foo get() = println("foo: $this")
+
+fun main() {
+    val b: Optional<Any?>? = Optional(null)
+    b?.let<caret> { it.value.foo }
+}

--- a/idea/testData/inspectionsLocal/simpleRedundantLet/extensionWithNullableReceiverCall3.kt
+++ b/idea/testData/inspectionsLocal/simpleRedundantLet/extensionWithNullableReceiverCall3.kt
@@ -1,0 +1,14 @@
+// WITH_RUNTIME
+// PROBLEM: none
+class A(val b: B?)
+class B
+class C(val d: D)
+class D
+
+fun B?.getC(): C {
+    return C(D())
+}
+
+fun test(a: A?) {
+    a?.let<caret> { it.b.getC().d }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -11425,6 +11425,26 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
             runTest("idea/testData/inspectionsLocal/simpleRedundantLet/dotWithComparison.kt");
         }
 
+        @TestMetadata("extensionCall.kt")
+        public void testExtensionCall() throws Exception {
+            runTest("idea/testData/inspectionsLocal/simpleRedundantLet/extensionCall.kt");
+        }
+
+        @TestMetadata("extensionWithNullableReceiverCall.kt")
+        public void testExtensionWithNullableReceiverCall() throws Exception {
+            runTest("idea/testData/inspectionsLocal/simpleRedundantLet/extensionWithNullableReceiverCall.kt");
+        }
+
+        @TestMetadata("extensionWithNullableReceiverCall2.kt")
+        public void testExtensionWithNullableReceiverCall2() throws Exception {
+            runTest("idea/testData/inspectionsLocal/simpleRedundantLet/extensionWithNullableReceiverCall2.kt");
+        }
+
+        @TestMetadata("extensionWithNullableReceiverCall3.kt")
+        public void testExtensionWithNullableReceiverCall3() throws Exception {
+            runTest("idea/testData/inspectionsLocal/simpleRedundantLet/extensionWithNullableReceiverCall3.kt");
+        }
+
         @TestMetadata("functionCall1.kt")
         public void testFunctionCall1() throws Exception {
             runTest("idea/testData/inspectionsLocal/simpleRedundantLet/functionCall1.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-31601