### PR TITLE
KT-24869 False positive inspection "Redundant 'suspend' modifier"

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/highlighter/KotlinSuspendCallLineMarkerProvider.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/highlighter/KotlinSuspendCallLineMarkerProvider.kt
@@ -76,10 +76,11 @@ class KotlinSuspendCallLineMarkerProvider : LineMarkerProvider {
 }
 
 private fun KtExpression.isValidCandidateExpression(): Boolean {
+    if (this is KtParenthesizedExpression) return false
     if (this is KtOperationReferenceExpression || this is KtForExpression || this is KtProperty || this is KtNameReferenceExpression) return true
     val parent = parent
     if (parent is KtCallExpression && parent.calleeExpression == this) return true
-    if (this is KtCallExpression && this.calleeExpression is KtCallExpression) return true
+    if (this is KtCallExpression && (calleeExpression is KtCallExpression || calleeExpression is KtParenthesizedExpression)) return true
     return false
 }
 

--- a/idea/testData/inspectionsLocal/redundantSuspend/parenthesized.kt
+++ b/idea/testData/inspectionsLocal/redundantSuspend/parenthesized.kt
@@ -1,0 +1,14 @@
+// PROBLEM: none
+// WITH_RUNTIME
+
+object Foo {
+    val f: suspend SequenceScope<Int>.(low: Int, high: Int) -> Unit = { low, high ->
+        (low until high).forEach {
+            yield(it)
+        }
+    }
+}
+
+<caret>suspend fun SequenceScope<Int>.f2(low: Int, high: Int) {
+    (Foo.f)(low, high)
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -7909,6 +7909,11 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
         public void testOverride() throws Exception {
             runTest("idea/testData/inspectionsLocal/redundantSuspend/override.kt");
         }
+
+        @TestMetadata("parenthesized.kt")
+        public void testParenthesized() throws Exception {
+            runTest("idea/testData/inspectionsLocal/redundantSuspend/parenthesized.kt");
+        }
     }
 
     @TestMetadata("idea/testData/inspectionsLocal/redundantUnitExpression")


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-24869