### PR TITLE
JVM_IR: Relax bailout condition for SAM conversion generation.

### DIFF
--- a/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/ArgumentsUtils.kt
+++ b/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/ArgumentsUtils.kt
@@ -135,7 +135,7 @@ private fun KotlinCallArgument.isArrayAssignedAsNamedArgumentInFunction(
     return this.isArrayOrArrayLiteral()
 }
 
-private fun KotlinCallArgument.isArrayOrArrayLiteral(): Boolean {
+fun KotlinCallArgument.isArrayOrArrayLiteral(): Boolean {
     if (this is CollectionLiteralKotlinCallArgument) return true
     if (this !is SimpleKotlinCallArgument) return false
 

--- a/compiler/testData/codegen/box/sam/arrayAsVarargAfterSamArgument.kt
+++ b/compiler/testData/codegen/box/sam/arrayAsVarargAfterSamArgument.kt
@@ -1,6 +1,5 @@
 // !LANGUAGE: +NewInference +SamConversionForKotlinFunctions +SamConversionPerArgument
 // IGNORE_BACKEND_FIR: JVM_IR
-// IGNORE_BACKEND: JVM_IR
 // TARGET_BACKEND: JVM
 
 // FILE: Test.java


### PR DESCRIPTION
Previously, resolved call is expected to have SAM converted argument map
if SamConversionPerArgument is enabled. However, if SAM argument is
followed by vararg parameter and an array _without_ a spread operator is
passed, New Inference left a type mismatch error on a resolved call, which
made that resolved candidate filtered out. Instead, another resolution
result wihtout SAM converted arugment map will be provided.

All other logics, such as adding SAM conversion type op and lowering SAM
conversion and/or call references, are already there for resolved calls
without SAM converted argument map. This change just relaxes the bailout
condition so that array passed to vararg after SAM argument can be
handled in JVM IR.