### PR TITLE
KT-36406 "To ordinary string literal" intention adds unnecessary escapes to characters in template expression

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/intentions/ToOrdinaryStringLiteralIntention.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/ToOrdinaryStringLiteralIntention.kt
@@ -58,10 +58,14 @@ class ToOrdinaryStringLiteralIntention : SelfTargetingOffsetIndependentIntention
         editor?.caretModel?.moveToOffset(offset)
     }
 
-    private fun String.escape(): String = StringUtil.convertLineSeparators(
-        replace("\\", "\\\\").replace("\"", "\\\""),
-        "\\n"
-    )
+    private fun String.escape(escapeLineSeparators: Boolean = true): String {
+        val text = replace("\\", "\\\\").replace("\"", "\\\"")
+        return if (escapeLineSeparators) text.escapeLineSeparators() else text
+    }
+
+    private fun String.escapeLineSeparators(): String {
+        return StringUtil.convertLineSeparators(this, "\\n")
+    }
 
     private fun getTrimIndentCall(
         element: KtStringTemplateExpression,
@@ -82,9 +86,11 @@ class ToOrdinaryStringLiteralIntention : SelfTargetingOffsetIndependentIntention
         }
 
         val stringTemplateText = entries
-            .joinToString(separator = "") { it.text }
+            .joinToString(separator = "") {
+                if (it is KtLiteralStringTemplateEntry) it.text.escape(escapeLineSeparators = false) else it.text
+            }
             .let { if (marginPrefix != null) it.trimMargin(marginPrefix) else it.trimIndent() }
-            .escape()
+            .escapeLineSeparators()
 
         return TrimIndentCall(qualifiedExpression, stringTemplateText)
     }

--- a/idea/testData/intentions/toOrdinaryStringLiteral/quotesInExpression.kt
+++ b/idea/testData/intentions/toOrdinaryStringLiteral/quotesInExpression.kt
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test(list: List<Int>) {
+    val s = <caret>"""foo ${list.joinToString(", ")} bar"""
+}

--- a/idea/testData/intentions/toOrdinaryStringLiteral/quotesInExpression.kt.after
+++ b/idea/testData/intentions/toOrdinaryStringLiteral/quotesInExpression.kt.after
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test(list: List<Int>) {
+    val s = "foo ${list.joinToString(", ")} bar"
+}

--- a/idea/testData/intentions/toOrdinaryStringLiteral/trimIndent10.kt
+++ b/idea/testData/intentions/toOrdinaryStringLiteral/trimIndent10.kt
@@ -1,0 +1,8 @@
+// WITH_RUNTIME
+data class Column(val name: String)
+
+fun test(columns: List<Column>) {
+    val sql = <caret>"""
+        SELECT ${columns.joinToString(", ")} FROM foo
+    """.trimIndent()
+}

--- a/idea/testData/intentions/toOrdinaryStringLiteral/trimIndent10.kt.after
+++ b/idea/testData/intentions/toOrdinaryStringLiteral/trimIndent10.kt.after
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+data class Column(val name: String)
+
+fun test(columns: List<Column>) {
+    val sql = "SELECT ${columns.joinToString(", ")} FROM foo"
+}

--- a/idea/testData/intentions/toOrdinaryStringLiteral/trimIndent11.kt
+++ b/idea/testData/intentions/toOrdinaryStringLiteral/trimIndent11.kt
@@ -1,0 +1,8 @@
+// WITH_RUNTIME
+fun test(list: List<Int>) {
+    val s = <caret>"""
+        "\foo
+        ${list.joinToString(",")}
+        "\bar
+    """.trimIndent()
+}

--- a/idea/testData/intentions/toOrdinaryStringLiteral/trimIndent11.kt.after
+++ b/idea/testData/intentions/toOrdinaryStringLiteral/trimIndent11.kt.after
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test(list: List<Int>) {
+    val s = "\"\\foo\n${list.joinToString(",")}\n\"\\bar"
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -16040,6 +16040,11 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
             runTest("idea/testData/intentions/toOrdinaryStringLiteral/quotesAndSlashes.kt");
         }
 
+        @TestMetadata("quotesInExpression.kt")
+        public void testQuotesInExpression() throws Exception {
+            runTest("idea/testData/intentions/toOrdinaryStringLiteral/quotesInExpression.kt");
+        }
+
         @TestMetadata("simple.kt")
         public void testSimple() throws Exception {
             runTest("idea/testData/intentions/toOrdinaryStringLiteral/simple.kt");
@@ -16048,6 +16053,16 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
         @TestMetadata("trimIndent1.kt")
         public void testTrimIndent1() throws Exception {
             runTest("idea/testData/intentions/toOrdinaryStringLiteral/trimIndent1.kt");
+        }
+
+        @TestMetadata("trimIndent10.kt")
+        public void testTrimIndent10() throws Exception {
+            runTest("idea/testData/intentions/toOrdinaryStringLiteral/trimIndent10.kt");
+        }
+
+        @TestMetadata("trimIndent11.kt")
+        public void testTrimIndent11() throws Exception {
+            runTest("idea/testData/intentions/toOrdinaryStringLiteral/trimIndent11.kt");
         }
 
         @TestMetadata("trimIndent2.kt")


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-36406