### PR TITLE
KT-20844 Re-enable stack spilling during inline.

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/InlineCodegen.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/InlineCodegen.kt
@@ -149,12 +149,7 @@ abstract class InlineCodegen<out T : BaseExpressionCodegen>(
         }
     }
 
-    @Suppress("UNREACHABLE_CODE")
     private fun canSkipStackSpillingOnInline(methodNode: MethodNode): Boolean {
-        // TODO: Temporary disable this optimization until
-        // https://issuetracker.google.com/issues/68796377 is fixed
-        // or until d8 substitute dex
-        return false
         // Stack spilling before inline function 'f' call is required if:
         //  - 'f' is a suspend function
         //  - 'f' has try-catch blocks

--- a/compiler/testData/codegen/bytecodeText/storeStackBeforeInline/simple.kt
+++ b/compiler/testData/codegen/bytecodeText/storeStackBeforeInline/simple.kt
@@ -9,6 +9,6 @@ fun foo() : Int {
 }
 
 // fake inline variables occupy 2 ISTOREs.
-// 5 ISTORE
-// 7 ILOAD
+// 3 ISTORE
+// 5 ILOAD
 // 0 InlineMarker


### PR DESCRIPTION
`dx` has entered the final stage of sunset:
https://android-developers.googleblog.com/2020/02/the-path-to-dx-deprecation.html