### PR TITLE
New REPL Api

### DIFF
--- a/libraries/scripting/common/src/kotlin/script/experimental/api/replApi.kt
+++ b/libraries/scripting/common/src/kotlin/script/experimental/api/replApi.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package kotlin.script.experimental.api
+
+class CodeSnippet(val code: SourceCode, val id: String? = null)
+
+interface CompiledSnippet {
+
+    val previous: CompiledSnippet?
+
+    val snippetId: String?
+
+    val configuration: ScriptCompilationConfiguration
+}
+
+interface ReplCompiler {
+
+    // TODO: replace with special result returned from 'invoke'
+    fun isComplete(snippets: CodeSnippet, configuration: ScriptCompilationConfiguration): ResultWithDiagnostics<Boolean>
+
+    operator fun invoke(
+        snippets: Iterable<CodeSnippet>,
+        configuration: ScriptCompilationConfiguration,
+        lastCompiledSnippet: CompiledSnippet?
+    )
+            : ResultWithDiagnostics<CompiledSnippet>
+}
+
+interface EvaluatedSnippet {
+
+    val previous: EvaluatedSnippet?
+
+    val result: Any?
+
+    val hasResult: Boolean
+
+    val snippetId: String?
+
+    val configuration: ScriptEvaluationConfiguration
+}
+
+interface ReplEvaluator {
+
+    val lastEvaluatedSnippet: EvaluatedSnippet?
+
+    // asserts that snippet sequence is valid
+    operator fun invoke(snippet: CompiledSnippet, configuration: ScriptEvaluationConfiguration)
+            : ResultWithDiagnostics<EvaluatedSnippet>
+}

--- a/libraries/scripting/jvm/src/kotlin/script/experimental/jvm/util/replApi.kt
+++ b/libraries/scripting/jvm/src/kotlin/script/experimental/jvm/util/replApi.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package kotlin.script.experimental.jvm.util
+
+import kotlin.script.experimental.api.EvaluatedSnippet
+
+interface JvmEvaluatedSnippet : EvaluatedSnippet {
+
+    val snippetObject: Any
+}


### PR DESCRIPTION
New API for REPL: separate `Compiler` and `Evaluator` states represented by `CompiledSnippet` and `EvaluatedSnippet` interfaces