### PR TITLE
Fix KT-36657

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/findUsages/handlers/KotlinFindUsagesHandler.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/findUsages/handlers/KotlinFindUsagesHandler.kt
@@ -55,7 +55,7 @@ abstract class KotlinFindUsagesHandler<T : PsiElement>(
     }
 
     private fun searchTextOccurrences(element: PsiElement, processor: UsageInfoProcessor, options: FindUsagesOptions): Boolean {
-        if (!options.isSearchForTextOccurrences) return false
+        if (!options.isSearchForTextOccurrences) return true
 
         val scope = options.searchScope
 

--- a/idea/tests/org/jetbrains/kotlin/findUsages/CustomUsageSearcherTest.kt
+++ b/idea/tests/org/jetbrains/kotlin/findUsages/CustomUsageSearcherTest.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.findUsages
+
+import com.intellij.find.findUsages.CustomUsageSearcher
+import com.intellij.find.findUsages.FindUsagesOptions
+import com.intellij.openapi.application.runReadAction
+import com.intellij.psi.PsiElement
+import com.intellij.testFramework.ExtensionTestUtil
+import com.intellij.usageView.UsageInfo
+import com.intellij.usages.Usage
+import com.intellij.usages.UsageInfo2UsageAdapter
+import com.intellij.util.Processor
+import org.jetbrains.kotlin.idea.KotlinFileType
+import org.jetbrains.kotlin.idea.test.KotlinLightCodeInsightFixtureTestCaseBase
+
+class CustomUsageSearcherTest : KotlinLightCodeInsightFixtureTestCaseBase() {
+    fun testAddCustomUsagesForKotlin() {
+        val customUsageSearcher = object : CustomUsageSearcher() {
+            override fun processElementUsages(element: PsiElement, processor: Processor<Usage>, options: FindUsagesOptions) {
+                runReadAction { processor.process(UsageInfo2UsageAdapter(UsageInfo(element))) }
+            }
+        }
+        ExtensionTestUtil.maskExtensions(CustomUsageSearcher.EP_NAME, listOf(customUsageSearcher), testRootDisposable)
+        myFixture.configureByText(KotlinFileType.INSTANCE, """val <caret>selfUsed = 1""")
+
+        val usages = myFixture.getUsageViewTreeTextRepresentation(myFixture.elementAtCaret)
+        assertTrue(usages.contains("val selfUsed"))
+    }
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-36657

Don't stop process (don't return false) if options.isSearchForTextOccurrences is false

options.isSearchForTextOccurrences == false is not valid reason to stop whole find usages process.

Before fix:
options.isSearchForTextOccurrences is false ->
 KotlinFindUsagesHandler#searchTextOccurrences returns false ->
  KotlinFindUsagesHandler#processElementUsages returns false

It leads to problems in places where processElementUsages is called, e.g
code inside com.intellij.find.findUsages.FindUsagesManager#createUsageSearcher never
reaches CustomUsageSearcher.EP_NAME.

It means that you can't provide any custom Usages for Kotlin elements through CustomUsageSearcher.