### PR TITLE
[JVM IR] Use `append(Char)` for 1-length string literals in string templates and plus concatenations

### DIFF
--- a/compiler/testData/codegen/bytecodeText/kt5016.kt
+++ b/compiler/testData/codegen/bytecodeText/kt5016.kt
@@ -1,6 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
-// TODO KT-36638 Use 'java/lang/StringBuilder.append (C)Ljava/lang/StringBuilder;' when appending single character in JVM_IR
-
 // KT-5016 wrong StringBuilder append method invoked
 class kt5016 {
     fun f1(name : String) : String {
@@ -10,4 +7,6 @@ class kt5016 {
 
 // 0 INVOKEVIRTUAL java/lang/StringBuilder.append \(Ljava/lang/Object;\)Ljava/lang/StringBuilder
 // 2 INVOKEVIRTUAL java/lang/StringBuilder.append \(Ljava/lang/String;\)Ljava/lang/StringBuilder
+// 1 INVOKEVIRTUAL java/lang/StringBuilder.append \(C\)Ljava/lang/StringBuilder
+// 3 INVOKEVIRTUAL java/lang/StringBuilder.append
 // 1 INVOKEVIRTUAL java/lang/StringBuilder.toString

--- a/compiler/testData/codegen/bytecodeText/kt5016int.kt
+++ b/compiler/testData/codegen/bytecodeText/kt5016int.kt
@@ -1,6 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
-// TODO KT-36638 Use 'java/lang/StringBuilder.append (C)Ljava/lang/StringBuilder;' when appending single character in JVM_IR
-
 // KT-5016 wrong StringBuilder append method invoked
 class kt5016int {
     fun f1(num : Int) : String {
@@ -11,4 +8,6 @@ class kt5016int {
 // 0 INVOKEVIRTUAL java/lang/StringBuilder.append \(Ljava/lang/Object;\)Ljava/lang/StringBuilder
 // 1 INVOKEVIRTUAL java/lang/StringBuilder.append \(Ljava/lang/String;\)Ljava/lang/StringBuilder
 // 1 INVOKEVIRTUAL java/lang/StringBuilder.append \(I\)Ljava/lang/StringBuilder
+// 1 INVOKEVIRTUAL java/lang/StringBuilder.append \(C\)Ljava/lang/StringBuilder
+// 3 INVOKEVIRTUAL java/lang/StringBuilder.append
 // 1 INVOKEVIRTUAL java/lang/StringBuilder.toString

--- a/compiler/testData/codegen/bytecodeText/kt5016intOrNull.kt
+++ b/compiler/testData/codegen/bytecodeText/kt5016intOrNull.kt
@@ -1,6 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
-// TODO KT-36638 Use 'java/lang/StringBuilder.append (C)Ljava/lang/StringBuilder;' when appending single character in JVM_IR
-
 // KT-5016 wrong StringBuilder append method invoked
 class kt5016intOrNull {
     fun f1(num : Int?) : String {
@@ -10,4 +7,6 @@ class kt5016intOrNull {
 
 // 1 INVOKEVIRTUAL java/lang/StringBuilder.append \(Ljava/lang/Object;\)Ljava/lang/StringBuilder
 // 1 INVOKEVIRTUAL java/lang/StringBuilder.append \(Ljava/lang/String;\)Ljava/lang/StringBuilder
+// 1 INVOKEVIRTUAL java/lang/StringBuilder.append \(C\)Ljava/lang/StringBuilder
+// 3 INVOKEVIRTUAL java/lang/StringBuilder.append
 // 1 INVOKEVIRTUAL java/lang/StringBuilder.toString

--- a/compiler/testData/codegen/bytecodeText/stringOperations/useAppendCharForOneCharStringInTemplate.kt
+++ b/compiler/testData/codegen/bytecodeText/stringOperations/useAppendCharForOneCharStringInTemplate.kt
@@ -1,0 +1,6 @@
+fun test(s: String, i: Int) = "${"x"}${s}${" "}${i}${"y"}"
+
+// 1 INVOKEVIRTUAL java/lang/StringBuilder.append \(Ljava/lang/String;\)Ljava/lang/StringBuilder
+// 1 INVOKEVIRTUAL java/lang/StringBuilder.append \(I\)Ljava/lang/StringBuilder
+// 3 INVOKEVIRTUAL java/lang/StringBuilder.append \(C\)Ljava/lang/StringBuilder
+// 5 INVOKEVIRTUAL java/lang/StringBuilder.append

--- a/compiler/testData/codegen/bytecodeText/stringOperations/useAppendCharForOneCharStringInTemplate_2.kt
+++ b/compiler/testData/codegen/bytecodeText/stringOperations/useAppendCharForOneCharStringInTemplate_2.kt
@@ -1,0 +1,6 @@
+fun test(s: String, i: Int) = "x${s} ${i}y"
+
+// 1 INVOKEVIRTUAL java/lang/StringBuilder.append \(Ljava/lang/String;\)Ljava/lang/StringBuilder
+// 1 INVOKEVIRTUAL java/lang/StringBuilder.append \(I\)Ljava/lang/StringBuilder
+// 3 INVOKEVIRTUAL java/lang/StringBuilder.append \(C\)Ljava/lang/StringBuilder
+// 5 INVOKEVIRTUAL java/lang/StringBuilder.append

--- a/compiler/testData/codegen/bytecodeText/stringOperations/useAppendCharForOneCharStringUsingPlus.kt
+++ b/compiler/testData/codegen/bytecodeText/stringOperations/useAppendCharForOneCharStringUsingPlus.kt
@@ -1,0 +1,16 @@
+fun test(s: String, i: Int) = "x" + s + " " + i + "y"
+
+// The IR is equivalent for this test and "useAppendCharForOneCharStringInTemplate*.kt" because there is an optimization for 1-length
+// string literals in any string concatenation, whether using templates or + operator (see JvmStringConcatenationLowering).
+// However, for the non-IR backend, `append(String)` will still be used for these 1-length strings.
+
+// JVM_TEMPLATES
+// 4 INVOKEVIRTUAL java/lang/StringBuilder.append \(Ljava/lang/String;\)Ljava/lang/StringBuilder
+// 1 INVOKEVIRTUAL java/lang/StringBuilder.append \(I\)Ljava/lang/StringBuilder
+// 5 INVOKEVIRTUAL java/lang/StringBuilder.append
+
+// JVM_IR_TEMPLATES
+// 1 INVOKEVIRTUAL java/lang/StringBuilder.append \(Ljava/lang/String;\)Ljava/lang/StringBuilder
+// 1 INVOKEVIRTUAL java/lang/StringBuilder.append \(I\)Ljava/lang/StringBuilder
+// 3 INVOKEVIRTUAL java/lang/StringBuilder.append \(C\)Ljava/lang/StringBuilder
+// 5 INVOKEVIRTUAL java/lang/StringBuilder.append

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
@@ -4224,6 +4224,21 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
         public void testStringPlus() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/stringOperations/stringPlus.kt");
         }
+
+        @TestMetadata("useAppendCharForOneCharStringInTemplate.kt")
+        public void testUseAppendCharForOneCharStringInTemplate() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/stringOperations/useAppendCharForOneCharStringInTemplate.kt");
+        }
+
+        @TestMetadata("useAppendCharForOneCharStringInTemplate_2.kt")
+        public void testUseAppendCharForOneCharStringInTemplate_2() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/stringOperations/useAppendCharForOneCharStringInTemplate_2.kt");
+        }
+
+        @TestMetadata("useAppendCharForOneCharStringUsingPlus.kt")
+        public void testUseAppendCharForOneCharStringUsingPlus() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/stringOperations/useAppendCharForOneCharStringUsingPlus.kt");
+        }
     }
 
     @TestMetadata("compiler/testData/codegen/bytecodeText/toArray")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
@@ -4142,6 +4142,21 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
         public void testStringPlus() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/stringOperations/stringPlus.kt");
         }
+
+        @TestMetadata("useAppendCharForOneCharStringInTemplate.kt")
+        public void testUseAppendCharForOneCharStringInTemplate() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/stringOperations/useAppendCharForOneCharStringInTemplate.kt");
+        }
+
+        @TestMetadata("useAppendCharForOneCharStringInTemplate_2.kt")
+        public void testUseAppendCharForOneCharStringInTemplate_2() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/stringOperations/useAppendCharForOneCharStringInTemplate_2.kt");
+        }
+
+        @TestMetadata("useAppendCharForOneCharStringUsingPlus.kt")
+        public void testUseAppendCharForOneCharStringUsingPlus() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/stringOperations/useAppendCharForOneCharStringUsingPlus.kt");
+        }
     }
 
     @TestMetadata("compiler/testData/codegen/bytecodeText/toArray")


### PR DESCRIPTION
This is slightly more efficient and mirrors the behavior of the non-IR backend for templates (but not for plus concatenations).

Well, in theory it is more efficient but in practice, any performance benefit is likely negligible. I just noticed the difference in bytecode and I figured why not make the calls match up better? 🙂