### PR TITLE
JVM IR: Don't optimize comparisons between boxed primitive types and null

### DIFF
--- a/compiler/testData/codegen/box/platformTypes/unsafeNullCheckWithPrimitive.kt
+++ b/compiler/testData/codegen/box/platformTypes/unsafeNullCheckWithPrimitive.kt
@@ -1,6 +1,5 @@
 // IGNORE_BACKEND_FIR: JVM_IR
 // TARGET_BACKEND: JVM
-// IGNORE_BACKEND: JVM_IR
 // FILE: Unsound.java
 
 import test.Wrap;
@@ -17,6 +16,4 @@ package test
 
 class Wrap<T>(val x: T)
 
-// JVM IR generates bytecode that fails with NPE because it unwraps the value with `Number.intValue()`,
-// whereas JVM generates a simple null check without unwrapping the box.
 fun box(): String = if ((Unsound.get<Int>() as Wrap<Int>).x == null) "OK" else "Fail"


### PR DESCRIPTION
We currently optimize null checks on primitive types as part of `JvmOptimizationLowering` in the JVM IR backend. However, this is only sound if we are comparing an *unboxed* primitive against null, which we cannot easily determine in the lowering.

In particular, a comparison of the form `x.f() == Null` where `x.f()` returns a primitive type may not be vacuous if we are dealing with a boxed value produced in Java code. And as shown in `testUnsafeNullCheckWithPrimitive` we cannot reliably identify Java values due to type erasure.

This PR just postpones the optimization to codegen time. Funnily enough, this optimization already exists in the `Equals.kt` intrinsic. However, before #3080 this was not enough, since there were still cases where we would produce NPEs due to unnecessary casts.

The first three commits in this PR are from #3080, only 3277ef7 is new.