### PR TITLE
KT-20907 Secondary constructor is marked as unused by IDE when called by typealias 

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/UnusedSymbolInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/UnusedSymbolInspection.kt
@@ -383,6 +383,13 @@ class UnusedSymbolInspection : AbstractKotlinInspection() {
             if (referenceUsed) return true
         }
 
+        if (declaration is KtSecondaryConstructor) {
+            val containingClass = declaration.containingClass()
+            if (containingClass != null && ReferencesSearch.search(KotlinReferencesSearchParameters(containingClass, useScope)).any {
+                    it.element.getStrictParentOfType<KtTypeAlias>() != null
+                }) return true
+        }
+
         if (declaration is KtCallableDeclaration && declaration.canBeHandledByLightMethods(descriptor)) {
             val lightMethods = declaration.toLightMethods()
             if (lightMethods.isNotEmpty()) {
@@ -396,13 +403,8 @@ class UnusedSymbolInspection : AbstractKotlinInspection() {
 
         if (declaration is KtEnumEntry) {
             val enumClass = declaration.containingClass()?.takeIf { it.isEnum() }
-            if (enumClass != null && ReferencesSearch.search(
-                    KotlinReferencesSearchParameters(
-                        enumClass,
-                        useScope,
-                        kotlinOptions = searchOptions
-                    )
-                ).any(::hasBuiltInEnumFunctionReference)
+            if (enumClass != null
+                && ReferencesSearch.search(KotlinReferencesSearchParameters(enumClass, useScope)).any(::hasBuiltInEnumFunctionReference)
             ) return true
         }
 

--- a/idea/testData/inspectionsLocal/unusedSymbol/secondaryConstructorCalledByTypeAlias.kt
+++ b/idea/testData/inspectionsLocal/unusedSymbol/secondaryConstructorCalledByTypeAlias.kt
@@ -1,0 +1,10 @@
+// PROBLEM: none
+class A(x: Double) {
+    <caret>constructor(i: Int) : this(i.toDouble())
+}
+
+class C {
+    val a = B(1)
+}
+
+typealias B = A

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -12929,6 +12929,11 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
             runTest("idea/testData/inspectionsLocal/unusedSymbol/propertyOfInlineClassType.kt");
         }
 
+        @TestMetadata("secondaryConstructorCalledByTypeAlias.kt")
+        public void testSecondaryConstructorCalledByTypeAlias() throws Exception {
+            runTest("idea/testData/inspectionsLocal/unusedSymbol/secondaryConstructorCalledByTypeAlias.kt");
+        }
+
         @TestMetadata("secondaryLocalClassConstructor.kt")
         public void testSecondaryLocalClassConstructor() throws Exception {
             runTest("idea/testData/inspectionsLocal/unusedSymbol/secondaryLocalClassConstructor.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-20907