### PR TITLE
Added lastMaxBy function to stdlib

### DIFF
--- a/idea/tests/org/jetbrains/kotlin/idea/slicer/SlicerLeafGroupingTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/slicer/SlicerLeafGroupingTestGenerated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 

--- a/idea/tests/org/jetbrains/kotlin/idea/slicer/SlicerNullnessGroupingTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/slicer/SlicerNullnessGroupingTestGenerated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 

--- a/idea/tests/org/jetbrains/kotlin/idea/slicer/SlicerTreeTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/slicer/SlicerTreeTestGenerated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 

--- a/libraries/stdlib/common/src/generated/_Arrays.kt
+++ b/libraries/stdlib/common/src/generated/_Arrays.kt
@@ -11563,6 +11563,204 @@ public inline fun CharArray.forEachIndexed(action: (index: Int, Char) -> Unit): 
 }
 
 /**
+ * Returns the last element yielding the largest value of the given function or `null` if there are no elements.
+ * 
+ * @sample samples.collections.Collections.Aggregates.lastMaxBy
+ */
+public inline fun <T, R : Comparable<R>> Array<out T>.lastMaxBy(selector: (T) -> R): T? {
+    if (isEmpty()) return null
+    var maxElem = this[0]
+    val lastIndex = this.lastIndex
+    if (lastIndex == 0) return maxElem
+    var maxValue = selector(maxElem)
+    for (i in 1..lastIndex) {
+        val e = this[i]
+        val v = selector(e)
+        if (maxValue <= v) {
+            maxElem = e
+            maxValue = v
+        }
+    }
+    return maxElem
+}
+
+/**
+ * Returns the last element yielding the largest value of the given function or `null` if there are no elements.
+ * 
+ * @sample samples.collections.Collections.Aggregates.lastMaxBy
+ */
+public inline fun <R : Comparable<R>> ByteArray.lastMaxBy(selector: (Byte) -> R): Byte? {
+    if (isEmpty()) return null
+    var maxElem = this[0]
+    val lastIndex = this.lastIndex
+    if (lastIndex == 0) return maxElem
+    var maxValue = selector(maxElem)
+    for (i in 1..lastIndex) {
+        val e = this[i]
+        val v = selector(e)
+        if (maxValue <= v) {
+            maxElem = e
+            maxValue = v
+        }
+    }
+    return maxElem
+}
+
+/**
+ * Returns the last element yielding the largest value of the given function or `null` if there are no elements.
+ * 
+ * @sample samples.collections.Collections.Aggregates.lastMaxBy
+ */
+public inline fun <R : Comparable<R>> ShortArray.lastMaxBy(selector: (Short) -> R): Short? {
+    if (isEmpty()) return null
+    var maxElem = this[0]
+    val lastIndex = this.lastIndex
+    if (lastIndex == 0) return maxElem
+    var maxValue = selector(maxElem)
+    for (i in 1..lastIndex) {
+        val e = this[i]
+        val v = selector(e)
+        if (maxValue <= v) {
+            maxElem = e
+            maxValue = v
+        }
+    }
+    return maxElem
+}
+
+/**
+ * Returns the last element yielding the largest value of the given function or `null` if there are no elements.
+ * 
+ * @sample samples.collections.Collections.Aggregates.lastMaxBy
+ */
+public inline fun <R : Comparable<R>> IntArray.lastMaxBy(selector: (Int) -> R): Int? {
+    if (isEmpty()) return null
+    var maxElem = this[0]
+    val lastIndex = this.lastIndex
+    if (lastIndex == 0) return maxElem
+    var maxValue = selector(maxElem)
+    for (i in 1..lastIndex) {
+        val e = this[i]
+        val v = selector(e)
+        if (maxValue <= v) {
+            maxElem = e
+            maxValue = v
+        }
+    }
+    return maxElem
+}
+
+/**
+ * Returns the last element yielding the largest value of the given function or `null` if there are no elements.
+ * 
+ * @sample samples.collections.Collections.Aggregates.lastMaxBy
+ */
+public inline fun <R : Comparable<R>> LongArray.lastMaxBy(selector: (Long) -> R): Long? {
+    if (isEmpty()) return null
+    var maxElem = this[0]
+    val lastIndex = this.lastIndex
+    if (lastIndex == 0) return maxElem
+    var maxValue = selector(maxElem)
+    for (i in 1..lastIndex) {
+        val e = this[i]
+        val v = selector(e)
+        if (maxValue <= v) {
+            maxElem = e
+            maxValue = v
+        }
+    }
+    return maxElem
+}
+
+/**
+ * Returns the last element yielding the largest value of the given function or `null` if there are no elements.
+ * 
+ * @sample samples.collections.Collections.Aggregates.lastMaxBy
+ */
+public inline fun <R : Comparable<R>> FloatArray.lastMaxBy(selector: (Float) -> R): Float? {
+    if (isEmpty()) return null
+    var maxElem = this[0]
+    val lastIndex = this.lastIndex
+    if (lastIndex == 0) return maxElem
+    var maxValue = selector(maxElem)
+    for (i in 1..lastIndex) {
+        val e = this[i]
+        val v = selector(e)
+        if (maxValue <= v) {
+            maxElem = e
+            maxValue = v
+        }
+    }
+    return maxElem
+}
+
+/**
+ * Returns the last element yielding the largest value of the given function or `null` if there are no elements.
+ * 
+ * @sample samples.collections.Collections.Aggregates.lastMaxBy
+ */
+public inline fun <R : Comparable<R>> DoubleArray.lastMaxBy(selector: (Double) -> R): Double? {
+    if (isEmpty()) return null
+    var maxElem = this[0]
+    val lastIndex = this.lastIndex
+    if (lastIndex == 0) return maxElem
+    var maxValue = selector(maxElem)
+    for (i in 1..lastIndex) {
+        val e = this[i]
+        val v = selector(e)
+        if (maxValue <= v) {
+            maxElem = e
+            maxValue = v
+        }
+    }
+    return maxElem
+}
+
+/**
+ * Returns the last element yielding the largest value of the given function or `null` if there are no elements.
+ * 
+ * @sample samples.collections.Collections.Aggregates.lastMaxBy
+ */
+public inline fun <R : Comparable<R>> BooleanArray.lastMaxBy(selector: (Boolean) -> R): Boolean? {
+    if (isEmpty()) return null
+    var maxElem = this[0]
+    val lastIndex = this.lastIndex
+    if (lastIndex == 0) return maxElem
+    var maxValue = selector(maxElem)
+    for (i in 1..lastIndex) {
+        val e = this[i]
+        val v = selector(e)
+        if (maxValue <= v) {
+            maxElem = e
+            maxValue = v
+        }
+    }
+    return maxElem
+}
+
+/**
+ * Returns the last element yielding the largest value of the given function or `null` if there are no elements.
+ * 
+ * @sample samples.collections.Collections.Aggregates.lastMaxBy
+ */
+public inline fun <R : Comparable<R>> CharArray.lastMaxBy(selector: (Char) -> R): Char? {
+    if (isEmpty()) return null
+    var maxElem = this[0]
+    val lastIndex = this.lastIndex
+    if (lastIndex == 0) return maxElem
+    var maxValue = selector(maxElem)
+    for (i in 1..lastIndex) {
+        val e = this[i]
+        val v = selector(e)
+        if (maxValue <= v) {
+            maxElem = e
+            maxValue = v
+        }
+    }
+    return maxElem
+}
+
+/**
  * Returns the largest element or `null` if there are no elements.
  * 
  * If any of elements is `NaN` returns `NaN`.

--- a/libraries/stdlib/common/src/generated/_Collections.kt
+++ b/libraries/stdlib/common/src/generated/_Collections.kt
@@ -1653,6 +1653,28 @@ public inline fun <T> Iterable<T>.forEachIndexed(action: (index: Int, T) -> Unit
 }
 
 /**
+ * Returns the last element yielding the largest value of the given function or `null` if there are no elements.
+ * 
+ * @sample samples.collections.Collections.Aggregates.lastMaxBy
+ */
+public inline fun <T, R : Comparable<R>> Iterable<T>.lastMaxBy(selector: (T) -> R): T? {
+    val iterator = iterator()
+    if (!iterator.hasNext()) return null
+    var maxElem = iterator.next()
+    if (!iterator.hasNext()) return maxElem
+    var maxValue = selector(maxElem)
+    do {
+        val e = iterator.next()
+        val v = selector(e)
+        if (maxValue <= v) {
+            maxElem = e
+            maxValue = v
+        }
+    } while (iterator.hasNext())
+    return maxElem
+}
+
+/**
  * Returns the largest element or `null` if there are no elements.
  * 
  * If any of elements is `NaN` returns `NaN`.

--- a/libraries/stdlib/common/src/generated/_Maps.kt
+++ b/libraries/stdlib/common/src/generated/_Maps.kt
@@ -152,6 +152,16 @@ public inline fun <K, V> Map<out K, V>.forEach(action: (Map.Entry<K, V>) -> Unit
 }
 
 /**
+ * Returns the last entry yielding the largest value of the given function or `null` if there are no entries.
+ * 
+ * @sample samples.collections.Collections.Aggregates.lastMaxBy
+ */
+@kotlin.internal.InlineOnly
+public inline fun <K, V, R : Comparable<R>> Map<out K, V>.lastMaxBy(selector: (Map.Entry<K, V>) -> R): Map.Entry<K, V>? {
+    return entries.lastMaxBy(selector)
+}
+
+/**
  * Returns the first entry yielding the largest value of the given function or `null` if there are no entries.
  * 
  * @sample samples.collections.Collections.Aggregates.maxBy

--- a/libraries/stdlib/common/src/generated/_Sequences.kt
+++ b/libraries/stdlib/common/src/generated/_Sequences.kt
@@ -1117,6 +1117,30 @@ public inline fun <T> Sequence<T>.forEachIndexed(action: (index: Int, T) -> Unit
 }
 
 /**
+ * Returns the last element yielding the largest value of the given function or `null` if there are no elements.
+ *
+ * The operation is _terminal_.
+ * 
+ * @sample samples.collections.Collections.Aggregates.lastMaxBy
+ */
+public inline fun <T, R : Comparable<R>> Sequence<T>.lastMaxBy(selector: (T) -> R): T? {
+    val iterator = iterator()
+    if (!iterator.hasNext()) return null
+    var maxElem = iterator.next()
+    if (!iterator.hasNext()) return maxElem
+    var maxValue = selector(maxElem)
+    do {
+        val e = iterator.next()
+        val v = selector(e)
+        if (maxValue <= v) {
+            maxElem = e
+            maxValue = v
+        }
+    } while (iterator.hasNext())
+    return maxElem
+}
+
+/**
  * Returns the largest element or `null` if there are no elements.
  * 
  * If any of elements is `NaN` returns `NaN`.

--- a/libraries/stdlib/common/src/generated/_Strings.kt
+++ b/libraries/stdlib/common/src/generated/_Strings.kt
@@ -1065,6 +1065,28 @@ public inline fun CharSequence.forEachIndexed(action: (index: Int, Char) -> Unit
 }
 
 /**
+ * Returns the last character yielding the largest value of the given function or `null` if there are no characters.
+ * 
+ * @sample samples.collections.Collections.Aggregates.lastMaxBy
+ */
+public inline fun <R : Comparable<R>> CharSequence.lastMaxBy(selector: (Char) -> R): Char? {
+    if (isEmpty()) return null
+    var maxElem = this[0]
+    val lastIndex = this.lastIndex
+    if (lastIndex == 0) return maxElem
+    var maxValue = selector(maxElem)
+    for (i in 1..lastIndex) {
+        val e = this[i]
+        val v = selector(e)
+        if (maxValue <= v) {
+            maxElem = e
+            maxValue = v
+        }
+    }
+    return maxElem
+}
+
+/**
  * Returns the largest character or `null` if there are no characters.
  */
 public fun CharSequence.max(): Char? {

--- a/libraries/stdlib/common/src/generated/_UArrays.kt
+++ b/libraries/stdlib/common/src/generated/_UArrays.kt
@@ -5031,6 +5031,106 @@ public inline fun UShortArray.forEachIndexed(action: (index: Int, UShort) -> Uni
 }
 
 /**
+ * Returns the last element yielding the largest value of the given function or `null` if there are no elements.
+ * 
+ * @sample samples.collections.Collections.Aggregates.lastMaxBy
+ */
+@SinceKotlin("1.3")
+@ExperimentalUnsignedTypes
+@kotlin.internal.InlineOnly
+public inline fun <R : Comparable<R>> UIntArray.lastMaxBy(selector: (UInt) -> R): UInt? {
+    if (isEmpty()) return null
+    var maxElem = this[0]
+    val lastIndex = this.lastIndex
+    if (lastIndex == 0) return maxElem
+    var maxValue = selector(maxElem)
+    for (i in 1..lastIndex) {
+        val e = this[i]
+        val v = selector(e)
+        if (maxValue <= v) {
+            maxElem = e
+            maxValue = v
+        }
+    }
+    return maxElem
+}
+
+/**
+ * Returns the last element yielding the largest value of the given function or `null` if there are no elements.
+ * 
+ * @sample samples.collections.Collections.Aggregates.lastMaxBy
+ */
+@SinceKotlin("1.3")
+@ExperimentalUnsignedTypes
+@kotlin.internal.InlineOnly
+public inline fun <R : Comparable<R>> ULongArray.lastMaxBy(selector: (ULong) -> R): ULong? {
+    if (isEmpty()) return null
+    var maxElem = this[0]
+    val lastIndex = this.lastIndex
+    if (lastIndex == 0) return maxElem
+    var maxValue = selector(maxElem)
+    for (i in 1..lastIndex) {
+        val e = this[i]
+        val v = selector(e)
+        if (maxValue <= v) {
+            maxElem = e
+            maxValue = v
+        }
+    }
+    return maxElem
+}
+
+/**
+ * Returns the last element yielding the largest value of the given function or `null` if there are no elements.
+ * 
+ * @sample samples.collections.Collections.Aggregates.lastMaxBy
+ */
+@SinceKotlin("1.3")
+@ExperimentalUnsignedTypes
+@kotlin.internal.InlineOnly
+public inline fun <R : Comparable<R>> UByteArray.lastMaxBy(selector: (UByte) -> R): UByte? {
+    if (isEmpty()) return null
+    var maxElem = this[0]
+    val lastIndex = this.lastIndex
+    if (lastIndex == 0) return maxElem
+    var maxValue = selector(maxElem)
+    for (i in 1..lastIndex) {
+        val e = this[i]
+        val v = selector(e)
+        if (maxValue <= v) {
+            maxElem = e
+            maxValue = v
+        }
+    }
+    return maxElem
+}
+
+/**
+ * Returns the last element yielding the largest value of the given function or `null` if there are no elements.
+ * 
+ * @sample samples.collections.Collections.Aggregates.lastMaxBy
+ */
+@SinceKotlin("1.3")
+@ExperimentalUnsignedTypes
+@kotlin.internal.InlineOnly
+public inline fun <R : Comparable<R>> UShortArray.lastMaxBy(selector: (UShort) -> R): UShort? {
+    if (isEmpty()) return null
+    var maxElem = this[0]
+    val lastIndex = this.lastIndex
+    if (lastIndex == 0) return maxElem
+    var maxValue = selector(maxElem)
+    for (i in 1..lastIndex) {
+        val e = this[i]
+        val v = selector(e)
+        if (maxValue <= v) {
+            maxElem = e
+            maxValue = v
+        }
+    }
+    return maxElem
+}
+
+/**
  * Returns the largest element or `null` if there are no elements.
  */
 @SinceKotlin("1.3")

--- a/libraries/stdlib/samples/test/samples/collections/collections.kt
+++ b/libraries/stdlib/samples/test/samples/collections/collections.kt
@@ -654,6 +654,17 @@ class Collections {
         }
 
         @Sample
+        fun lastMaxBy() {
+            val nameToAge = listOf("Alice" to 28, "Bob" to 42, "Carol" to 42)
+            val oldestPerson = nameToAge.lastMaxBy { it.second }
+            assertPrints(oldestPerson, "(Carol, 42)")
+
+            val emptyList = emptyList<Pair<String, Int>>()
+            val emptyLastMax = emptyList.lastMaxBy { it.second }
+            assertPrints(emptyLastMax, "null")
+        }
+
+        @Sample
         fun minBy() {
             val list = listOf("abcd", "abc", "ab", "abcde")
             val shortestString = list.minBy { it.length }

--- a/libraries/stdlib/test/collections/ArraysTest.kt
+++ b/libraries/stdlib/test/collections/ArraysTest.kt
@@ -412,6 +412,25 @@ class ArraysTest {
         expect(2.0, { doubleArrayOf(2.0, 3.0).minBy { it * it } })
     }
 
+    @Test fun lastMaxBy() {
+        expect(null, { arrayOf<Int>().lastMaxBy { it } })
+        expect(1, { arrayOf(1).lastMaxBy { it } })
+        expect('c', { arrayOf(Pair('a', 2), Pair('b', 3), Pair('c', 2)).lastMaxBy { -it.second }?.first })
+        expect(2, { arrayOf(Pair(1, 'b'), Pair(2, 'b'), Pair(3, 'a')).lastMaxBy { "x${it.second}" }?.first })
+        expect(3, { arrayOf(Pair(1, "b"), Pair(2, "abc"), Pair(3, "abc")).lastMaxBy { it.second.length }?.first })
+    }
+
+    @Test fun lastMaxByInPrimitiveArrays() {
+        expect(null, { intArrayOf().lastMaxBy { it } })
+        expect(1, { intArrayOf(1, 1).lastMaxBy { it } })
+        expect(2, { intArrayOf(2, 3, 2).lastMaxBy { -it } })
+        expect(3000000000000, { longArrayOf(3000000000000, 2000000000000, 3000000000000).lastMaxBy { it + 1 } })
+        expect(3, { byteArrayOf(1, 3, 2, 3).lastMaxBy { it * it } })
+        expect(2, { shortArrayOf(3, 2, 2).lastMaxBy { "a" } })
+        expect(3.0F, { floatArrayOf(3.0F, 2.0F, 3.0F).lastMaxBy { it.toString() } })
+        expect(3.0, { doubleArrayOf(2.0, 3.0, 3.0).lastMaxBy { it * it } })
+    }
+
     @Test fun maxBy() {
         expect(null, { arrayOf<Int>().maxBy { it } })
         expect(1, { arrayOf(1).maxBy { it } })

--- a/libraries/stdlib/test/collections/CollectionTest.kt
+++ b/libraries/stdlib/test/collections/CollectionTest.kt
@@ -805,6 +805,16 @@ class CollectionTest {
         expect(3, { listOf(2, 3).asSequence().minBy { -it } })
     }
 
+    @Test fun lastMaxBy() {
+        expect(null, { listOf<Int>().lastMaxBy { it } })
+        expect(1, { listOf(1).lastMaxBy { it } })
+        expect('c', { listOf(Pair('a', 2), Pair('b', 3), Pair('c', 2)).lastMaxBy { -it.second }?.first })
+        expect(2, { listOf(Pair(1, 'b'), Pair(2, 'b'), Pair(3, 'a')).lastMaxBy { "x${it.second}" }?.first })
+        expect(3, { listOf(Pair(1, "b"), Pair(2, "abc"), Pair(3, "abc")).lastMaxBy { it.second.length }?.first })
+        expect(null, { listOf<Int>().asSequence().lastMaxBy { it } })
+        expect('c', { listOf(Pair('a', 2), Pair('b', 3), Pair('c', 2)).asSequence().lastMaxBy { -it.second }?.first })
+    }
+
     @Test fun maxBy() {
         expect(null, { listOf<Int>().maxBy { it } })
         expect(1, { listOf(1).maxBy { it } })

--- a/libraries/stdlib/test/collections/UnsignedArraysTest.kt
+++ b/libraries/stdlib/test/collections/UnsignedArraysTest.kt
@@ -491,6 +491,28 @@ class UnsignedArraysTest {
     }
 
     @Test
+    fun lastMaxBy() {
+        expect(null, { arrayOf<UByte>().lastMaxBy { it + 1 } })
+        expect(1u, { arrayOf<UShort>(1).lastMaxBy { it + 1 } })
+        expect(
+            'c',
+            { arrayOf(Pair<Char, UInt>('a', 2), Pair<Char, UInt>('b', 3), Pair<Char, UInt>('c', 2)).lastMaxBy { it.second - 3 }?.first }
+        )
+        expect(
+            'c',
+            { arrayOf(Pair<Char, ULong>('a', 3), Pair<Char, ULong>('b', 2), Pair<Char, ULong>('c', 3)).lastMaxBy { it.second + 1 }?.first }
+        )
+    }
+
+    @Test
+    fun lastMaxByInUnsignedArrays() {
+        expect(null) { ubyteArrayOf().lastMaxBy { it + 1 } }
+        expect(1u) { ushortArrayOf(1, 1).lastMaxBy { it + 1 } }
+        expect(2u) { uintArrayOf(2, 3, 2).lastMaxBy { it - 3 } }
+        expect(3uL) { ulongArrayOf(3, 2, 3).lastMaxBy { it + 1 } }
+    }
+
+    @Test
     fun maxBy() {
         expect(null) { arrayOf<UByte>().maxBy { it + 1 } }
         expect(1u) { arrayOf<UShort>(1).maxBy { it + 1 } }

--- a/libraries/tools/binary-compatibility-validator/reference-public-api/kotlin-stdlib-runtime-merged.txt
+++ b/libraries/tools/binary-compatibility-validator/reference-public-api/kotlin-stdlib-runtime-merged.txt
@@ -1285,6 +1285,15 @@ public final class kotlin/collections/ArraysKt {
 	public static final fun lastIndexOf ([Ljava/lang/Object;Ljava/lang/Object;)I
 	public static final fun lastIndexOf ([SS)I
 	public static final fun lastIndexOf ([ZZ)I
+	public static final fun lastMaxBy ([BLkotlin/jvm/functions/Function1;)Ljava/lang/Byte;
+	public static final fun lastMaxBy ([CLkotlin/jvm/functions/Function1;)Ljava/lang/Character;
+	public static final fun lastMaxBy ([DLkotlin/jvm/functions/Function1;)Ljava/lang/Double;
+	public static final fun lastMaxBy ([FLkotlin/jvm/functions/Function1;)Ljava/lang/Float;
+	public static final fun lastMaxBy ([ILkotlin/jvm/functions/Function1;)Ljava/lang/Integer;
+	public static final fun lastMaxBy ([JLkotlin/jvm/functions/Function1;)Ljava/lang/Long;
+	public static final fun lastMaxBy ([Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun lastMaxBy ([SLkotlin/jvm/functions/Function1;)Ljava/lang/Short;
+	public static final fun lastMaxBy ([ZLkotlin/jvm/functions/Function1;)Ljava/lang/Boolean;
 	public static final fun lastOrNull ([B)Ljava/lang/Byte;
 	public static final fun lastOrNull ([BLkotlin/jvm/functions/Function1;)Ljava/lang/Byte;
 	public static final fun lastOrNull ([C)Ljava/lang/Character;
@@ -2080,6 +2089,7 @@ public final class kotlin/collections/CollectionsKt {
 	public static final fun last (Ljava/util/List;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun lastIndexOf (Ljava/lang/Iterable;Ljava/lang/Object;)I
 	public static final fun lastIndexOf (Ljava/util/List;Ljava/lang/Object;)I
+	public static final fun lastMaxBy (Ljava/lang/Iterable;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun lastOrNull (Ljava/lang/Iterable;)Ljava/lang/Object;
 	public static final fun lastOrNull (Ljava/lang/Iterable;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun lastOrNull (Ljava/util/List;)Ljava/lang/Object;
@@ -4577,6 +4587,7 @@ public final class kotlin/sequences/SequencesKt {
 	public static final fun last (Lkotlin/sequences/Sequence;)Ljava/lang/Object;
 	public static final fun last (Lkotlin/sequences/Sequence;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun lastIndexOf (Lkotlin/sequences/Sequence;Ljava/lang/Object;)I
+	public static final fun lastMaxBy (Lkotlin/sequences/Sequence;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun lastOrNull (Lkotlin/sequences/Sequence;)Ljava/lang/Object;
 	public static final fun lastOrNull (Lkotlin/sequences/Sequence;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun map (Lkotlin/sequences/Sequence;Lkotlin/jvm/functions/Function1;)Lkotlin/sequences/Sequence;
@@ -4972,6 +4983,7 @@ public final class kotlin/text/StringsKt {
 	public static final fun lastIndexOfAny (Ljava/lang/CharSequence;[CIZ)I
 	public static synthetic fun lastIndexOfAny$default (Ljava/lang/CharSequence;Ljava/util/Collection;IZILjava/lang/Object;)I
 	public static synthetic fun lastIndexOfAny$default (Ljava/lang/CharSequence;[CIZILjava/lang/Object;)I
+	public static final fun lastMaxBy (Ljava/lang/CharSequence;Lkotlin/jvm/functions/Function1;)Ljava/lang/Character;
 	public static final fun lastOrNull (Ljava/lang/CharSequence;)Ljava/lang/Character;
 	public static final fun lastOrNull (Ljava/lang/CharSequence;Lkotlin/jvm/functions/Function1;)Ljava/lang/Character;
 	public static final fun lineSequence (Ljava/lang/CharSequence;)Lkotlin/sequences/Sequence;

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Aggregates.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Aggregates.kt
@@ -417,6 +417,61 @@ object Aggregates : TemplateGroupBase() {
         body(Maps) { "return entries.minWith(comparator)" }
     }
 
+    val f_lastMaxBy = fn("lastMaxBy(selector: (T) -> R)") {
+        includeDefault()
+        include(Maps, CharSequences, ArraysOfUnsigned)
+    } builder {
+        inline()
+        specialFor(ArraysOfUnsigned) { inlineOnly() }
+
+        doc { "Returns the last ${f.element} yielding the largest value of the given function or `null` if there are no ${f.element.pluralize()}." }
+        sample("samples.collections.Collections.Aggregates.lastMaxBy")
+        typeParam("R : Comparable<R>")
+        returns("T?")
+        body {
+            """
+            val iterator = iterator()
+            if (!iterator.hasNext()) return null
+
+            var maxElem = iterator.next()
+            if (!iterator.hasNext()) return maxElem
+            var maxValue = selector(maxElem)
+            do {
+                val e = iterator.next()
+                val v = selector(e)
+                if (maxValue <= v) {
+                    maxElem = e
+                    maxValue = v
+                }
+            } while (iterator.hasNext())
+            return maxElem
+            """
+        }
+        body(CharSequences, ArraysOfObjects, ArraysOfPrimitives, ArraysOfUnsigned) {
+            """
+            if (isEmpty()) return null
+
+            var maxElem = this[0]
+            val lastIndex = this.lastIndex
+            if (lastIndex == 0) return maxElem
+            var maxValue = selector(maxElem)
+            for (i in 1..lastIndex) {
+                val e = this[i]
+                val v = selector(e)
+                if (maxValue <= v) {
+                    maxElem = e
+                    maxValue = v
+                }
+            }
+            return maxElem
+            """
+        }
+        specialFor(Maps) {
+            inlineOnly()
+            body { "return entries.lastMaxBy(selector)" }
+        }
+    }
+
     val f_maxBy = fn("maxBy(selector: (T) -> R)") {
         includeDefault()
         include(Maps, CharSequences, ArraysOfUnsigned)


### PR DESCRIPTION
This is a fix to the problem brought up in this [issue](https://youtrack.jetbrains.com/issue/KT-34966)

This commit adds a new standard library function `lastMaxBy` that replicates the functionality of `maxBy`, but returns the last maximum element instead of the last. It also adds new tests and samples for this function