### PR TITLE
JVM IR: Fix suspend lambda generic signatures

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/AddContinuationLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/AddContinuationLowering.kt
@@ -153,7 +153,7 @@ private class AddContinuationLowering(private val context: JvmBackendContext) : 
                     functionNClass,
                     hasQuestionMark = false,
                     arguments = (info.function.explicitParameters.subList(0, info.arity).map { it.type }
-                            + info.function.continuationType() + info.function.returnType)
+                            + info.function.continuationType() + context.irBuiltIns.anyNType)
                         .map { makeTypeProjection(it, Variance.INVARIANT) },
                     annotations = emptyList()
                 )

--- a/compiler/testData/codegen/box/reflection/genericSignature/suspendFunctionLiteralGenericSignature.kt
+++ b/compiler/testData/codegen/box/reflection/genericSignature/suspendFunctionLiteralGenericSignature.kt
@@ -1,0 +1,73 @@
+// IGNORE_BACKEND_FIR: JVM_IR
+// TARGET_BACKEND: JVM
+// WITH_RUNTIME
+
+import java.util.Date
+
+fun assertEquals(expected: String, actual: Any) {
+    if ("$actual" != expected)
+        throw AssertionError("Fail, expected: $expected, actual: $actual")
+}
+
+fun assertGenericSuper(expected: String, function: Any?) {
+    val clazz = (function as java.lang.Object).getClass()!!
+    val genericSuper = clazz.getGenericInterfaces()[0]!!
+    assertEquals(expected, genericSuper)
+}
+
+val unitFun = suspend { }
+val intFun = suspend { 42 }
+
+fun assertStringParamFun(lambda: suspend (String) -> Unit) {
+    assertEquals(
+        "kotlin.jvm.functions.Function2<java.lang.String, kotlin.coroutines.Continuation<? super kotlin.Unit>, java.lang.Object>",
+        lambda.javaClass.genericInterfaces.single()
+    )
+}
+
+fun assertListFun(lambda: suspend (List<String>) -> Unit) {
+    assertEquals(
+        "kotlin.jvm.functions.Function2<java.util.List<? extends java.lang.String>, kotlin.coroutines.Continuation<? super kotlin.Unit>, java.lang.Object>",
+        lambda.javaClass.genericInterfaces.single()
+    )
+}
+
+fun assertMutableListFun(lambda: suspend (MutableList<Double>) -> MutableList<Int>) {
+    assertEquals(
+        "kotlin.jvm.functions.Function2<java.util.List<java.lang.Double>, kotlin.coroutines.Continuation<? super java.util.List<java.lang.Integer>>, java.lang.Object>",
+        lambda.javaClass.genericInterfaces.single()
+    )
+}
+
+fun assertFunWithIn(lambda: suspend (Comparable<String>) -> Unit) {
+    assertEquals(
+        "kotlin.jvm.functions.Function2<java.lang.Comparable<? super java.lang.String>, kotlin.coroutines.Continuation<? super kotlin.Unit>, java.lang.Object>",
+        lambda.javaClass.genericInterfaces.single()
+    )
+}
+
+fun assertExtensionFun(lambda: suspend Any.() -> Unit) {
+    assertEquals(
+        "kotlin.jvm.functions.Function2<java.lang.Object, kotlin.coroutines.Continuation<? super kotlin.Unit>, java.lang.Object>",
+        lambda.javaClass.genericInterfaces.single()
+    )
+}
+
+fun assertExtensionWithArgFun(lambda: suspend Long.(x: Any) -> Date) {
+    assertEquals(
+        "kotlin.jvm.functions.Function3<java.lang.Long, java.lang.Object, kotlin.coroutines.Continuation<? super java.util.Date>, java.lang.Object>",
+        lambda.javaClass.genericInterfaces.single()
+    )
+}
+
+fun box(): String {
+    assertGenericSuper("kotlin.jvm.functions.Function1<kotlin.coroutines.Continuation<? super kotlin.Unit>, java.lang.Object>", unitFun)
+    assertGenericSuper("kotlin.jvm.functions.Function1<kotlin.coroutines.Continuation<? super java.lang.Integer>, java.lang.Object>", intFun)
+    assertStringParamFun { x: String -> }
+    assertListFun { l: List<String> -> l }
+    assertMutableListFun { l -> null!! }
+    assertFunWithIn { x -> }
+    assertExtensionFun { }
+    assertExtensionWithArgFun { x -> Date() }
+    return "OK"
+}

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -24400,6 +24400,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             public void testSignatureOfSimpleInnerSimpleOuter() throws Exception {
                 runTest("compiler/testData/codegen/box/reflection/genericSignature/signatureOfSimpleInnerSimpleOuter.kt");
             }
+
+            @TestMetadata("suspendFunctionLiteralGenericSignature.kt")
+            public void testSuspendFunctionLiteralGenericSignature() throws Exception {
+                runTest("compiler/testData/codegen/box/reflection/genericSignature/suspendFunctionLiteralGenericSignature.kt");
+            }
         }
 
         @TestMetadata("compiler/testData/codegen/box/reflection/isInstance")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -23217,6 +23217,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             public void testSignatureOfSimpleInnerSimpleOuter() throws Exception {
                 runTest("compiler/testData/codegen/box/reflection/genericSignature/signatureOfSimpleInnerSimpleOuter.kt");
             }
+
+            @TestMetadata("suspendFunctionLiteralGenericSignature.kt")
+            public void testSuspendFunctionLiteralGenericSignature() throws Exception {
+                runTest("compiler/testData/codegen/box/reflection/genericSignature/suspendFunctionLiteralGenericSignature.kt");
+            }
         }
 
         @TestMetadata("compiler/testData/codegen/box/reflection/isInstance")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
@@ -22904,6 +22904,11 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
             public void testSignatureOfSimpleInnerSimpleOuter() throws Exception {
                 runTest("compiler/testData/codegen/box/reflection/genericSignature/signatureOfSimpleInnerSimpleOuter.kt");
             }
+
+            @TestMetadata("suspendFunctionLiteralGenericSignature.kt")
+            public void testSuspendFunctionLiteralGenericSignature() throws Exception {
+                runTest("compiler/testData/codegen/box/reflection/genericSignature/suspendFunctionLiteralGenericSignature.kt");
+            }
         }
 
         @TestMetadata("compiler/testData/codegen/box/reflection/isInstance")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -22904,6 +22904,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             public void testSignatureOfSimpleInnerSimpleOuter() throws Exception {
                 runTest("compiler/testData/codegen/box/reflection/genericSignature/signatureOfSimpleInnerSimpleOuter.kt");
             }
+
+            @TestMetadata("suspendFunctionLiteralGenericSignature.kt")
+            public void testSuspendFunctionLiteralGenericSignature() throws Exception {
+                runTest("compiler/testData/codegen/box/reflection/genericSignature/suspendFunctionLiteralGenericSignature.kt");
+            }
         }
 
         @TestMetadata("compiler/testData/codegen/box/reflection/isInstance")


### PR DESCRIPTION
The generic signatures of the `Function<n>` interface implemented by suspend lambdas should always use a return type of `Object`.

This brings the behavior in line with the JVM backend, although I think we might be generating wrong generic signatures for function types to begin with. Based on the variance declarations in Kotlin, we should be generating signatures of the form `Function1<? super java.lang.Integer, ? extends java.lang.Integer>` for a function `(Int) -> Int`, yet we actually generate invariant type arguments `Function1<java.lang.Integer, java.lang.Integer>`.