### PR TITLE
KT-36735 Inspection 'Replace 'toString' with string template' miss curly braces and generates wrong code for constructor calls

### DIFF
--- a/idea/testData/inspectionsLocal/replaceToStringWithStringTemplate/callExpression.kt
+++ b/idea/testData/inspectionsLocal/replaceToStringWithStringTemplate/callExpression.kt
@@ -1,0 +1,3 @@
+data class Num(val x: Int)
+
+fun demo(x: Int) = Num(x).toString()<caret>

--- a/idea/testData/inspectionsLocal/replaceToStringWithStringTemplate/callExpression.kt.after
+++ b/idea/testData/inspectionsLocal/replaceToStringWithStringTemplate/callExpression.kt.after
@@ -1,0 +1,3 @@
+data class Num(val x: Int)
+
+fun demo(x: Int) = "${Num(x)}"

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -10906,6 +10906,11 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
             KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("idea/testData/inspectionsLocal/replaceToStringWithStringTemplate"), Pattern.compile("^([\\w\\-_]+)\\.(kt|kts)$"), null, true);
         }
 
+        @TestMetadata("callExpression.kt")
+        public void testCallExpression() throws Exception {
+            runTest("idea/testData/inspectionsLocal/replaceToStringWithStringTemplate/callExpression.kt");
+        }
+
         @TestMetadata("nonReference.kt")
         public void testNonReference() throws Exception {
             runTest("idea/testData/inspectionsLocal/replaceToStringWithStringTemplate/nonReference.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-36735