### PR TITLE
[JVM IR] Refactor PromisedValue...

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/PromisedValue.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/PromisedValue.kt
@@ -13,7 +13,6 @@ import org.jetbrains.kotlin.codegen.AsmUtil
 import org.jetbrains.kotlin.codegen.StackValue
 import org.jetbrains.kotlin.ir.types.*
 import org.jetbrains.kotlin.ir.util.parentAsClass
-import org.jetbrains.kotlin.resolve.jvm.AsmTypes
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.org.objectweb.asm.Label
 import org.jetbrains.org.objectweb.asm.Type
@@ -24,7 +23,42 @@ import org.jetbrains.org.objectweb.asm.commons.InstructionAdapter
 abstract class PromisedValue(val codegen: ExpressionCodegen, val type: Type, val irType: IrType) {
     // If this value is immaterial, construct an object on the top of the stack. This
     // must always be done before generating other values or emitting raw bytecode.
-    abstract fun materialize()
+    open fun materializeAt(target: Type, irTarget: IrType) {
+        val erasedSourceType = irType.eraseTypeParameters()
+        val erasedTargetType = irTarget.eraseTypeParameters()
+        val isFromTypeInlineClass = erasedSourceType.classOrNull!!.owner.isInline
+        val isToTypeInlineClass = erasedTargetType.classOrNull!!.owner.isInline
+
+        // Boxing and unboxing kotlin.Result leads to CCE in generated code
+        val doNotCoerceKotlinResultInContinuation =
+            (codegen.irFunction.parentAsClass.origin == JvmLoweredDeclarationOrigin.CONTINUATION_CLASS ||
+                    codegen.irFunction.parentAsClass.origin == JvmLoweredDeclarationOrigin.SUSPEND_LAMBDA)
+                    && (irType.isKotlinResult() || irTarget.isKotlinResult())
+
+        // Coerce inline classes
+        if ((isFromTypeInlineClass || isToTypeInlineClass) && !doNotCoerceKotlinResultInContinuation) {
+            val isFromTypeUnboxed = isFromTypeInlineClass && typeMapper.mapType(erasedSourceType.unboxed) == type
+            val isToTypeUnboxed = isToTypeInlineClass && typeMapper.mapType(erasedTargetType.unboxed) == target
+
+            when {
+                isFromTypeUnboxed && !isToTypeUnboxed -> {
+                    StackValue.boxInlineClass(erasedSourceType.toKotlinType(), mv)
+                    return
+                }
+
+                !isFromTypeUnboxed && isToTypeUnboxed -> {
+                    StackValue.unboxInlineClass(type, erasedTargetType.toKotlinType(), mv)
+                    return
+                }
+            }
+        }
+
+        if (type != target) {
+            StackValue.coerce(type, target, mv)
+        }
+    }
+
+    abstract fun discard()
 
     val mv: InstructionAdapter
         get() = codegen.mv
@@ -38,21 +72,20 @@ abstract class PromisedValue(val codegen: ExpressionCodegen, val type: Type, val
 
 // A value that *has* been fully constructed.
 class MaterialValue(codegen: ExpressionCodegen, type: Type, irType: IrType) : PromisedValue(codegen, type, irType) {
-    override fun materialize() {}
-}
-
-// A value that is only materialized through coercion.
-class ImmaterialValue(codegen: ExpressionCodegen, type: Type, irType: IrType) : PromisedValue(codegen, type, irType) {
-    override fun materialize() {}
+    override fun discard() {
+        if (type !== Type.VOID_TYPE)
+            AsmUtil.pop(mv, type)
+    }
 }
 
 // A value that can be branched on. JVM has certain branching instructions which can be used
 // to optimize these.
-abstract class BooleanValue(codegen: ExpressionCodegen) : PromisedValue(codegen, Type.BOOLEAN_TYPE, codegen.context.irBuiltIns.booleanType) {
+abstract class BooleanValue(codegen: ExpressionCodegen) :
+    PromisedValue(codegen, Type.BOOLEAN_TYPE, codegen.context.irBuiltIns.booleanType) {
     abstract fun jumpIfFalse(target: Label)
     abstract fun jumpIfTrue(target: Label)
 
-    override fun materialize() {
+    override fun materializeAt(target: Type, irTarget: IrType) {
         val const0 = Label()
         val end = Label()
         jumpIfFalse(const0)
@@ -61,103 +94,71 @@ abstract class BooleanValue(codegen: ExpressionCodegen) : PromisedValue(codegen,
         mv.mark(const0)
         mv.iconst(0)
         mv.mark(end)
+        if (Type.BOOLEAN_TYPE != target) {
+            StackValue.coerce(Type.BOOLEAN_TYPE, target, mv)
+        }
     }
 }
 
-// Same as materialize(), but return a representation of the result.
-val PromisedValue.materialized: MaterialValue
-    get() {
-        materialize()
-        return MaterialValue(codegen, type, irType)
+class BooleanConstant(codegen: ExpressionCodegen, val value: Boolean) : BooleanValue(codegen) {
+    override fun jumpIfFalse(target: Label) = if (value) Unit else mv.goTo(target)
+    override fun jumpIfTrue(target: Label) = if (value) mv.goTo(target) else Unit
+    override fun materializeAt(target: Type, irTarget: IrType) {
+        mv.iconst(if (value) 1 else 0)
+        if (Type.BOOLEAN_TYPE != target) {
+            StackValue.coerce(Type.BOOLEAN_TYPE, target, mv)
+        }
     }
 
-// Materialize and disregard this value. Materialization is forced because, presumably,
-// we only wanted the side effects anyway.
-fun PromisedValue.discard(): PromisedValue {
-    materialize()
-    if (type !== Type.VOID_TYPE)
-        AsmUtil.pop(mv, type)
-    return codegen.immaterialUnitValue
+    override fun discard() {}
 }
 
-private val IrType.unboxed: IrType
+fun PromisedValue.coerceToBoolean(): BooleanValue =
+    when (this) {
+        is BooleanValue -> this
+        else -> object : BooleanValue(codegen) {
+            override fun jumpIfFalse(target: Label) =
+                this@coerceToBoolean.materializeAt(Type.BOOLEAN_TYPE, codegen.context.irBuiltIns.booleanType).also { mv.ifeq(target) }
+
+            override fun jumpIfTrue(target: Label) =
+                this@coerceToBoolean.materializeAt(Type.BOOLEAN_TYPE, codegen.context.irBuiltIns.booleanType).also { mv.ifne(target) }
+
+            override fun discard() {
+                this@coerceToBoolean.discard()
+            }
+        }
+    }
+
+
+fun PromisedValue.materializedAt(target: Type, irTarget: IrType): MaterialValue {
+    materializeAt(target, irTarget)
+    return MaterialValue(codegen, target, irTarget)
+}
+
+fun PromisedValue.materialized(): MaterialValue =
+    materializedAt(type, irType)
+
+fun PromisedValue.materializedAt(irTarget: IrType): MaterialValue =
+    materializedAt(typeMapper.mapType(irTarget), irTarget)
+
+fun PromisedValue.materializedAtBoxed(irTarget: IrType): MaterialValue =
+    materializedAt(typeMapper.boxType(irTarget), irTarget)
+
+fun PromisedValue.materialize() {
+    materializeAt(type, irType)
+}
+
+fun PromisedValue.materializeAt(irTarget: IrType) {
+    materializeAt(typeMapper.mapType(irTarget), irTarget)
+}
+
+fun PromisedValue.materializeAtBoxed(irTarget: IrType) {
+    materializeAt(typeMapper.boxType(irTarget), irTarget)
+}
+
+val IrType.unboxed: IrType
     get() = InlineClassAbi.getUnderlyingType(erasedUpperBound)
 
-// On materialization, cast the value to a different type.
-fun PromisedValue.coerce(target: Type, irTarget: IrType): PromisedValue {
-    val erasedSourceType = irType.eraseTypeParameters()
-    val erasedTargetType = irTarget.eraseTypeParameters()
-    val isFromTypeInlineClass = erasedSourceType.classOrNull!!.owner.isInline
-    val isToTypeInlineClass = erasedTargetType.classOrNull!!.owner.isInline
-
-    // Boxing and unboxing kotlin.Result leads to CCE in generated code
-    val doNotCoerceKotlinResultInContinuation =
-        (codegen.irFunction.parentAsClass.origin == JvmLoweredDeclarationOrigin.CONTINUATION_CLASS ||
-                codegen.irFunction.parentAsClass.origin == JvmLoweredDeclarationOrigin.SUSPEND_LAMBDA)
-                && (irType.isKotlinResult() || irTarget.isKotlinResult())
-
-    // Coerce inline classes
-    if ((isFromTypeInlineClass || isToTypeInlineClass) && !doNotCoerceKotlinResultInContinuation) {
-        val isFromTypeUnboxed = isFromTypeInlineClass && typeMapper.mapType(erasedSourceType.unboxed) == type
-        val isToTypeUnboxed = isToTypeInlineClass && typeMapper.mapType(erasedTargetType.unboxed) == target
-
-        when {
-            isFromTypeUnboxed && !isToTypeUnboxed -> return object : PromisedValue(codegen, target, irTarget) {
-                override fun materialize() {
-                    this@coerce.materialize()
-                    StackValue.boxInlineClass(erasedSourceType.toKotlinType(), mv)
-                }
-            }
-            !isFromTypeUnboxed && isToTypeUnboxed -> return object : PromisedValue(codegen, target, irTarget) {
-                override fun materialize() {
-                    val value = this@coerce.materialized
-                    StackValue.unboxInlineClass(value.type, erasedTargetType.toKotlinType(), mv)
-                }
-            }
-        }
-    }
-
-    // All unsafe coercions between irTypes should use the UnsafeCoerce intrinsic
-    return if (type == target) this else object : PromisedValue(codegen, target, irTarget) {
-        override fun materialize() {
-            val value = this@coerce.materialized
-            StackValue.coerce(value.type, type, mv)
-        }
-    }
-}
-
-fun PromisedValue.coerce(irTarget: IrType) =
-    coerce(typeMapper.mapType(irTarget), irTarget)
-
-fun PromisedValue.coerceToBoxed(irTarget: IrType) =
-    coerce(typeMapper.boxType(irTarget), irTarget)
-
-// Same as above, but with a return type that allows conditional jumping.
-fun PromisedValue.coerceToBoolean() =
-    when (val coerced = coerce(Type.BOOLEAN_TYPE, codegen.context.irBuiltIns.booleanType)) {
-        is BooleanValue -> coerced
-        else -> object : BooleanValue(codegen) {
-            override fun jumpIfFalse(target: Label) = coerced.materialize().also { mv.ifeq(target) }
-            override fun jumpIfTrue(target: Label) = coerced.materialize().also { mv.ifne(target) }
-            override fun materialize() = coerced.materialize()
-        }
-    }
-
-// Non-materialized value of Unit type
-// This value is only materialized when calling coerce, which is why it is represented
-// as a MaterialValue even though there is nothing on the stack.
-val ExpressionCodegen.immaterialUnitValue: ImmaterialValue
-    get() = ImmaterialValue(this, Type.VOID_TYPE, context.irBuiltIns.unitType)
-
-// Non-materialized default value for the given type
-fun ExpressionCodegen.defaultValue(irType: IrType): PromisedValue =
-    object : PromisedValue(this, typeMapper.mapType(irType), irType) {
-        override fun materialize() {
-            StackValue.coerce(Type.VOID_TYPE, type, codegen.mv)
-        }
-    }
-
-private fun IrType.isArrayOfKClass(): Boolean =
-    isArray() && this is IrSimpleType && arguments.singleOrNull().let { argument ->
-        argument is IrTypeProjection && argument.type.isKClass()
-    }
+// A Non-materialized value of Unit type that is only materialized through coercion.
+val ExpressionCodegen.unitValue: PromisedValue
+    get() = MaterialValue(this, Type.VOID_TYPE, context.irBuiltIns.unitType)

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/AndAnd.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/AndAnd.kt
@@ -12,7 +12,8 @@ import org.jetbrains.org.objectweb.asm.Label
 
 object AndAnd : IntrinsicMethod() {
 
-    private class BooleanConjunction(val arg0: IrExpression, val arg1: IrExpression, codegen: ExpressionCodegen, val data: BlockInfo) : BooleanValue(codegen) {
+    private class BooleanConjunction(val arg0: IrExpression, val arg1: IrExpression, codegen: ExpressionCodegen, val data: BlockInfo) :
+        BooleanValue(codegen) {
 
         override fun jumpIfFalse(target: Label) {
             arg0.accept(codegen, data).coerceToBoolean().jumpIfFalse(target)
@@ -24,6 +25,13 @@ object AndAnd : IntrinsicMethod() {
             arg0.accept(codegen, data).coerceToBoolean().jumpIfFalse(stayLabel)
             arg1.accept(codegen, data).coerceToBoolean().jumpIfTrue(target)
             mv.visitLabel(stayLabel)
+        }
+
+        override fun discard() {
+            val end = Label()
+            arg0.accept(codegen, data).coerceToBoolean().jumpIfFalse(end)
+            arg1.accept(codegen, data).discard()
+            mv.visitLabel(end)
         }
     }
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/ArrayGet.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/ArrayGet.kt
@@ -24,11 +24,10 @@ import org.jetbrains.org.objectweb.asm.Type
 object ArrayGet : IntrinsicMethod() {
     override fun invoke(expression: IrFunctionAccessExpression, codegen: ExpressionCodegen, data: BlockInfo): PromisedValue? {
         val dispatchReceiver = expression.dispatchReceiver!!
-        val receiver = dispatchReceiver.accept(codegen, data).coerce(dispatchReceiver.type).materialized
+        val receiver = dispatchReceiver.accept(codegen, data).materializedAt(dispatchReceiver.type)
         val elementType = AsmUtil.correctElementType(receiver.type)
         expression.getValueArgument(0)!!.accept(codegen, data)
-            .coerce(Type.INT_TYPE, codegen.context.irBuiltIns.intType)
-            .materialize()
+            .materializeAt(Type.INT_TYPE, codegen.context.irBuiltIns.intType)
         codegen.mv.aload(elementType)
         return MaterialValue(codegen, elementType, expression.type)
     }

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/ArraySet.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/ArraySet.kt
@@ -25,12 +25,12 @@ import org.jetbrains.org.objectweb.asm.Type
 object ArraySet : IntrinsicMethod() {
     override fun invoke(expression: IrFunctionAccessExpression, codegen: ExpressionCodegen, data: BlockInfo): PromisedValue? {
         val dispatchReceiver = expression.dispatchReceiver!!
-        val receiver = dispatchReceiver.accept(codegen, data).coerce(dispatchReceiver.type).materialized
+        val receiver = dispatchReceiver.accept(codegen, data).materializedAt(dispatchReceiver.type)
         val elementType = AsmUtil.correctElementType(receiver.type)
         val elementIrType = receiver.irType.getArrayElementType(codegen.context.irBuiltIns)
-        expression.getValueArgument(0)!!.accept(codegen, data).coerce(Type.INT_TYPE, codegen.context.irBuiltIns.intType).materialize()
-        expression.getValueArgument(1)!!.accept(codegen, data).coerce(elementType, elementIrType).materialize()
+        expression.getValueArgument(0)!!.accept(codegen, data).materializeAt(Type.INT_TYPE, codegen.context.irBuiltIns.intType)
+        expression.getValueArgument(1)!!.accept(codegen, data).materializeAt(elementType, elementIrType)
         codegen.mv.astore(elementType)
-        return codegen.immaterialUnitValue
+        return codegen.unitValue
     }
 }

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/Clone.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/Clone.kt
@@ -25,7 +25,7 @@ import org.jetbrains.org.objectweb.asm.Opcodes
 
 object Clone : IntrinsicMethod() {
     override fun invoke(expression: IrFunctionAccessExpression, codegen: ExpressionCodegen, data: BlockInfo) = with(codegen) {
-        val result = expression.dispatchReceiver!!.accept(this, data).materialized
+        val result = expression.dispatchReceiver!!.accept(this, data).materialized()
         assert(!AsmUtil.isPrimitive(result.type)) { "clone() of primitive type" }
         val opcode = if (expression is IrCall && expression.superQualifierSymbol != null) Opcodes.INVOKESPECIAL else Opcodes.INVOKEVIRTUAL
         mv.visitMethodInsn(opcode, "java/lang/Object", "clone", "()Ljava/lang/Object;", false)

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/CompareTo.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/CompareTo.kt
@@ -84,6 +84,11 @@ class BooleanComparison(val op: IElementType, val a: MaterialValue, val b: Mater
             NumberCompare.patchOpcode(BranchedValue.negatedOperations[NumberCompare.getNumberCompareOpcode(op)]!!, mv, op, a.type)
         mv.visitJumpInsn(opcode, target)
     }
+
+    override fun discard() {
+        b.discard()
+        a.discard()
+    }
 }
 
 
@@ -107,6 +112,11 @@ class NonIEEE754FloatComparison(val op: IElementType, val a: MaterialValue, val 
         invokeStaticComparison(a.type)
         mv.visitJumpInsn(BranchedValue.negatedOperations[numberCompareOpcode]!!, target)
     }
+
+    override fun discard() {
+        b.discard()
+        a.discard()
+    }
 }
 
 class PrimitiveComparison(
@@ -116,8 +126,8 @@ class PrimitiveComparison(
     override fun invoke(expression: IrFunctionAccessExpression, codegen: ExpressionCodegen, data: BlockInfo): PromisedValue? {
         val parameterType = Type.getType(JvmPrimitiveType.get(KotlinBuiltIns.getPrimitiveType(primitiveNumberType)!!).desc)
         val (left, right) = expression.receiverAndArgs()
-        val a = left.accept(codegen, data).coerce(parameterType, left.type).materialized
-        val b = right.accept(codegen, data).coerce(parameterType, right.type).materialized
+        val a = left.accept(codegen, data).materializedAt(parameterType, left.type)
+        val b = right.accept(codegen, data).materializedAt(parameterType, right.type)
 
         val useNonIEEE754Comparison =
             !codegen.context.state.languageVersionSettings.supportsFeature(LanguageFeature.ProperIeee754Comparisons)

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/EnumIntrinsics.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/EnumIntrinsics.kt
@@ -18,7 +18,7 @@ import org.jetbrains.org.objectweb.asm.Type
 object EnumValueOf : IntrinsicMethod() {
     override fun invoke(expression: IrFunctionAccessExpression, codegen: ExpressionCodegen, data: BlockInfo) = with(codegen) {
         val type = expression.getTypeArgument(0)!!
-        val result = expression.getValueArgument(0)!!.accept(this, data).materialized
+        val result = expression.getValueArgument(0)!!.accept(this, data).materialized()
         if (type.isReifiedTypeParameter) {
             // Note that the inliner expects exactly the following sequence of instructions.
             // <REIFIED-OPERATIONS-MARKER>

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/HashCode.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/HashCode.kt
@@ -30,13 +30,13 @@ import org.jetbrains.org.objectweb.asm.Type
 object HashCode : IntrinsicMethod() {
     override fun invoke(expression: IrFunctionAccessExpression, codegen: ExpressionCodegen, data: BlockInfo) = with(codegen) {
         val receiver = expression.dispatchReceiver ?: error("No receiver for hashCode: ${expression.render()}")
-        val result = receiver.accept(this, data).materialized
+        val result = receiver.accept(this, data).materialized()
         val target = context.state.target
         when {
             irFunction.origin == JvmLoweredDeclarationOrigin.INLINE_CLASS_GENERATED_IMPL_METHOD || irFunction.origin == IrDeclarationOrigin.GENERATED_DATA_CLASS_MEMBER ->
                 AsmUtil.genHashCode(mv, mv, result.type, target)
             target == JvmTarget.JVM_1_6 -> {
-                result.coerceToBoxed(receiver.type).materialize()
+                result.materializeAtBoxed(receiver.type)
                 mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "java/lang/Object", "hashCode", "()I", false)
             }
             else -> {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/IntrinsicMethod.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/IntrinsicMethod.kt
@@ -6,12 +6,12 @@
 package org.jetbrains.kotlin.backend.jvm.intrinsics
 
 import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
-import org.jetbrains.kotlin.backend.jvm.codegen.BlockInfo
-import org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen
-import org.jetbrains.kotlin.backend.jvm.codegen.PromisedValue
+import org.jetbrains.kotlin.backend.jvm.codegen.*
+import org.jetbrains.kotlin.codegen.AsmUtil
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrFunctionAccessExpression
 import org.jetbrains.kotlin.ir.expressions.IrMemberAccessExpression
+import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.resolve.jvm.jvmSignature.JvmMethodSignature
 import org.jetbrains.org.objectweb.asm.Type
 import org.jetbrains.org.objectweb.asm.commons.Method
@@ -27,10 +27,10 @@ abstract class IntrinsicMethod {
         with(codegen) {
             val descriptor = methodSignatureMapper.mapSignatureSkipGeneric(expression.symbol.owner)
             val stackValue = toCallable(expression, descriptor, context).invoke(mv, codegen, data)
-            return object : PromisedValue(this, stackValue.type, expression.type) {
-                override fun materialize() = stackValue.put(mv)
-            }
+            stackValue.put(mv)
+            return MaterialValue(this, stackValue.type, expression.type)
         }
+
 
     companion object {
         fun calcReceiverType(call: IrMemberAccessExpression, context: JvmBackendContext): Type {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/Not.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/Not.kt
@@ -27,6 +27,9 @@ object Not : IntrinsicMethod() {
     class BooleanNegation(val value: BooleanValue) : BooleanValue(value.codegen) {
         override fun jumpIfFalse(target: Label) = value.jumpIfTrue(target)
         override fun jumpIfTrue(target: Label) = value.jumpIfFalse(target)
+        override fun discard() {
+            value.discard()
+        }
     }
 
     override fun invoke(expression: IrFunctionAccessExpression, codegen: ExpressionCodegen, data: BlockInfo) =

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/OrOr.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/OrOr.kt
@@ -13,7 +13,8 @@ import org.jetbrains.org.objectweb.asm.Label
 object OrOr : IntrinsicMethod() {
 
     private class BooleanDisjunction(
-        val arg0: IrExpression, val arg1: IrExpression, codegen: ExpressionCodegen, val data: BlockInfo) : BooleanValue(codegen) {
+        val arg0: IrExpression, val arg1: IrExpression, codegen: ExpressionCodegen, val data: BlockInfo
+    ) : BooleanValue(codegen) {
 
         override fun jumpIfFalse(target: Label) {
             val stayLabel = Label()
@@ -25,6 +26,13 @@ object OrOr : IntrinsicMethod() {
         override fun jumpIfTrue(target: Label) {
             arg0.accept(codegen, data).coerceToBoolean().jumpIfTrue(target)
             arg1.accept(codegen, data).coerceToBoolean().jumpIfTrue(target)
+        }
+
+        override fun discard() {
+            val end = Label()
+            arg0.accept(codegen, data).coerceToBoolean().jumpIfTrue(end)
+            arg1.accept(codegen, data).discard()
+            mv.visitLabel(end)
         }
     }
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/ReassignParameter.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/ReassignParameter.kt
@@ -28,6 +28,6 @@ object ReassignParameter : IntrinsicMethod() {
         val parameter = parameterGet?.symbol as? IrValueParameterSymbol
             ?: throw AssertionError("${expression.getValueArgument(0)} is not a get of a parameter")
         codegen.setVariable(parameter, expression.getValueArgument(1)!!, data)
-        return codegen.immaterialUnitValue
+        return codegen.unitValue
     }
 }


### PR DESCRIPTION
... for an _even leaner_ codegen!

This PR combines the notion of coercing and materializing `PromisedValue`s such that we only generate instructions when materializing the value, at the discretion of the value itself.

The interface of `PromisedValue` is now `materializeAt` and `discard`, with the same contract as before: you must call one or the other before generating more code.