### PR TITLE
JVM IR: Fix visibility for $assertionsDisabled fields

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/AssertionLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/AssertionLowering.kt
@@ -29,6 +29,7 @@ import org.jetbrains.kotlin.ir.expressions.impl.IrCompositeImpl
 import org.jetbrains.kotlin.ir.types.getClass
 import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformer
+import org.jetbrains.kotlin.load.java.JavaVisibilities
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.util.OperatorNameConventions
 
@@ -140,6 +141,7 @@ fun IrClass.buildAssertionsDisabledField(backendContext: JvmBackendContext, topL
     buildField {
         name = Name.identifier(ASSERTIONS_DISABLED_FIELD_NAME)
         origin = JvmLoweredDeclarationOrigin.GENERATED_ASSERTION_ENABLED_FIELD
+        visibility = JavaVisibilities.PACKAGE_VISIBILITY
         type = backendContext.irBuiltIns.booleanType
         isFinal = true
         isStatic = true

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/InterfaceLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/InterfaceLowering.kt
@@ -161,14 +161,15 @@ internal class InterfaceLowering(val context: JvmBackendContext) : IrElementTran
             context.localDelegatedProperties[irClass.attributeOwnerId as IrClass] = emptyList<IrLocalDelegatedPropertySymbol>()
         }
 
-        // Move $$delegatedProperties array
-        val delegatedPropertyArray = irClass.declarations.filterIsInstance<IrField>()
-            .singleOrNull { it.origin == JvmLoweredDeclarationOrigin.GENERATED_PROPERTY_REFERENCE }
-        if (delegatedPropertyArray != null) {
-            irClass.declarations.remove(delegatedPropertyArray)
-            defaultImplsIrClass.declarations.add(0, delegatedPropertyArray)
-            delegatedPropertyArray.parent = defaultImplsIrClass
-            delegatedPropertyArray.initializer?.patchDeclarationParents(defaultImplsIrClass)
+        // Move $$delegatedProperties array and $assertionsDisabled field
+        for (field in irClass.declarations.filterIsInstance<IrField>()) {
+            if (field.origin != JvmLoweredDeclarationOrigin.GENERATED_PROPERTY_REFERENCE && field.origin != JvmLoweredDeclarationOrigin.GENERATED_ASSERTION_ENABLED_FIELD)
+                continue
+
+            irClass.declarations.remove(field)
+            defaultImplsIrClass.declarations.add(0, field)
+            field.parent = defaultImplsIrClass
+            field.initializer?.patchDeclarationParents(defaultImplsIrClass)
         }
     }
 

--- a/compiler/testData/codegen/bytecodeText/assert/jvmNestedClass.kt
+++ b/compiler/testData/codegen/bytecodeText/assert/jvmNestedClass.kt
@@ -1,6 +1,5 @@
 // This test is ignored until KT-36794 is fixed.
 // IGNORE_BACKEND: JVM
-// IGNORE_BACKEND: JVM_IR
 // KOTLIN_CONFIGURATION_FLAGS: ASSERTIONS_MODE=jvm
 
 class Outer {


### PR DESCRIPTION
It should be package private, as stated in `compiler/testData/codegen/bytecodeText/assert/jvmNestedClass.kt`.