### PR TITLE
Use ModuleOrderEntry instead of ModuleOrderEntryImpl

### DIFF
--- a/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/project/IdeaModuleInfos.kt
+++ b/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/project/IdeaModuleInfos.kt
@@ -11,7 +11,6 @@ import com.intellij.openapi.module.impl.scopes.LibraryScopeBase
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.roots.*
-import com.intellij.openapi.roots.impl.ModuleOrderEntryImpl
 import com.intellij.openapi.roots.impl.libraries.LibraryEx
 import com.intellij.openapi.roots.libraries.Library
 import com.intellij.openapi.util.ModificationTracker
@@ -84,7 +83,7 @@ private fun orderEntryToModuleInfo(project: Project, orderEntry: OrderEntry, for
         }
         is ModuleOrderEntry -> {
             val module = orderEntry.module ?: return emptyList()
-            if (forProduction && orderEntry is ModuleOrderEntryImpl && orderEntry.isProductionOnTestDependency) {
+            if (forProduction && orderEntry.isProductionOnTestDependency) {
                 listOfNotNull(module.testSourceInfo())
             } else {
                 module.toInfos()
@@ -113,7 +112,7 @@ private fun OrderEntry.acceptAsDependency(forProduction: Boolean): Boolean {
     return this !is ExportableOrderEntry
             || !forProduction
             // this is needed for Maven/Gradle projects with "production-on-test" dependency
-            || this is ModuleOrderEntryImpl && isProductionOnTestDependency
+            || this is ModuleOrderEntry && isProductionOnTestDependency
             || scope.isForProductionCompile
 }
 

--- a/idea/idea-gradle/src/org/jetbrains/kotlin/idea/KotlinJavaMPPSourceSetDataService.kt
+++ b/idea/idea-gradle/src/org/jetbrains/kotlin/idea/KotlinJavaMPPSourceSetDataService.kt
@@ -15,7 +15,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.LibraryOrderEntry
 import com.intellij.openapi.roots.ModuleOrderEntry
 import com.intellij.openapi.roots.OrderRootType
-import com.intellij.openapi.roots.impl.ModuleOrderEntryImpl
 import com.intellij.openapi.vfs.VfsUtil
 import org.jetbrains.kotlin.idea.configuration.KotlinTargetData
 import org.jetbrains.kotlin.idea.configuration.kotlinSourceSet
@@ -48,7 +47,7 @@ class KotlinJavaMPPSourceSetDataService : AbstractProjectDataService<GradleSourc
 
             val moduleEntries = rootModel.orderEntries.filterIsInstance<ModuleOrderEntry>()
             moduleEntries.filter { isTestModuleById(it.moduleName, toImport) }.forEach { moduleOrderEntry ->
-                (moduleOrderEntry as? ModuleOrderEntryImpl)?.isProductionOnTestDependency = true
+                moduleOrderEntry.isProductionOnTestDependency = true
             }
             val libraryEntries = rootModel.orderEntries.filterIsInstance<LibraryOrderEntry>()
             libraryEntries.forEach { libraryEntry ->

--- a/idea/idea-gradle/src/org/jetbrains/kotlin/idea/utils.kt
+++ b/idea/idea-gradle/src/org/jetbrains/kotlin/idea/utils.kt
@@ -5,11 +5,10 @@
 
 package org.jetbrains.kotlin.idea
 
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.roots.DependencyScope
 import com.intellij.openapi.roots.ModifiableRootModel
-import com.intellij.openapi.roots.impl.ModuleOrderEntryImpl
-import  com.intellij.openapi.diagnostic.Logger
 
 /**
  * Returns the dependency scope which has flags specific to the both provided scopes
@@ -57,7 +56,7 @@ fun addModuleDependencyIfNeeded(
     dependOnTest: Boolean
 ) {
     val existingEntry = rootModel.findModuleOrderEntry(dependeeModule)
-    val existingDependOnTest = (existingEntry as? ModuleOrderEntryImpl)?.isProductionOnTestDependency ?: false
+    val existingDependOnTest = existingEntry?.isProductionOnTestDependency ?: false
 
     val requiredScope = getScopeContainingBoth(if (testScope) DependencyScope.TEST else DependencyScope.COMPILE, existingEntry?.scope)
     if (existingEntry != null) {
@@ -72,6 +71,6 @@ fun addModuleDependencyIfNeeded(
     }
     rootModel.addModuleOrderEntry(dependeeModule).also {
         it.scope = requiredScope
-        (it as? ModuleOrderEntryImpl)?.isProductionOnTestDependency = dependOnTest || existingDependOnTest
+        it.isProductionOnTestDependency = dependOnTest || existingDependOnTest
     }
 }

--- a/idea/idea-gradle/tests/org/jetbrains/kotlin/gradle/MultiplatformProjectImportingTest.kt
+++ b/idea/idea-gradle/tests/org/jetbrains/kotlin/gradle/MultiplatformProjectImportingTest.kt
@@ -18,8 +18,8 @@ package org.jetbrains.kotlin.gradle
 
 import com.intellij.openapi.roots.DependencyScope
 import com.intellij.openapi.roots.LibraryOrderEntry
+import com.intellij.openapi.roots.ModuleOrderEntry
 import com.intellij.openapi.roots.OrderRootType
-import com.intellij.openapi.roots.impl.ModuleOrderEntryImpl
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.PathUtil
 import junit.framework.TestCase
@@ -43,7 +43,7 @@ class MultiplatformProjectImportingTest : MultiplePluginVersionGradleImportingTe
         val depOrderEntry = getModule(moduleName)
             .rootManager
             .orderEntries
-            .filterIsInstance<ModuleOrderEntryImpl>()
+            .filterIsInstance<ModuleOrderEntry>()
             .first { it.moduleName == depModuleName }
         assert(depOrderEntry.isProductionOnTestDependency == expected)
     }

--- a/idea/idea-gradle/tests/org/jetbrains/kotlin/gradle/projectStructureDSL.kt
+++ b/idea/idea-gradle/tests/org/jetbrains/kotlin/gradle/projectStructureDSL.kt
@@ -10,7 +10,6 @@ import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.rootManager
 import com.intellij.openapi.roots.*
-import com.intellij.openapi.roots.impl.ModuleOrderEntryImpl
 import com.intellij.openapi.util.io.FileUtil
 import org.jetbrains.jps.model.module.JpsModuleSourceRootType
 import org.jetbrains.jps.util.JpsPathUtil
@@ -311,7 +310,7 @@ class ModuleInfo(
 
     private fun checkProductionOnTest(library: ExportableOrderEntry, productionOnTest: Boolean?) {
         if (productionOnTest == null) return
-        val actualFlag = (library as? ModuleOrderEntryImpl)?.isProductionOnTestDependency
+        val actualFlag = (library as? ModuleOrderEntry)?.isProductionOnTestDependency
         if (actualFlag == null) {
             projectInfo.messageCollector.report(
                 "Module '${module.name}': Dependency '${library.presentableName}' has no productionOnTest property"


### PR DESCRIPTION
`isProductionOnTestDependency` function was moved from implementation to
interface. The fix is important for the new IJ project model.

The change has been made on 23 may 2019 (IJ 2019.2 release I guess). (24d4de10f4da2e6391e16fbd37e8d5f303af044a IJ project)