### PR TITLE
KT-23510 "Remove parameter" quick fix keeps lambda argument when it's out of parentheses

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/usages/KotlinFunctionCallUsage.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/usages/KotlinFunctionCallUsage.kt
@@ -75,6 +75,11 @@ class KotlinFunctionCallUsage(
 
         changeNameIfNeeded(changeInfo, element)
 
+        if (element.valueArgumentList == null && changeInfo.isParameterSetOrOrderChanged && element.lambdaArguments.isNotEmpty()) {
+            element.calleeExpression?.let {
+                element.addAfter(KtPsiFactory(element).createCallArguments("()"), it)
+            }
+        }
         if (element.valueArgumentList != null) {
             if (changeInfo.isParameterSetOrOrderChanged) {
                 result = updateArgumentsAndReceiver(changeInfo, element, allUsages)

--- a/idea/testData/quickfix/changeSignature/removeFunctionLastLambdaParameter.kt
+++ b/idea/testData/quickfix/changeSignature/removeFunctionLastLambdaParameter.kt
@@ -1,0 +1,4 @@
+// "Remove parameter 'block'" "true"
+fun doNotUse1(<caret>block: () -> Unit) {}
+
+fun useNotUse1() = doNotUse1 { }

--- a/idea/testData/quickfix/changeSignature/removeFunctionLastLambdaParameter.kt.after
+++ b/idea/testData/quickfix/changeSignature/removeFunctionLastLambdaParameter.kt.after
@@ -1,0 +1,4 @@
+// "Remove parameter 'block'" "true"
+fun doNotUse1() {}
+
+fun useNotUse1() = doNotUse1()

--- a/idea/testData/refactoring/changeSignature/AddParameterAfterLambdaParameterAfter.kt
+++ b/idea/testData/refactoring/changeSignature/AddParameterAfterLambdaParameterAfter.kt
@@ -1,0 +1,6 @@
+fun foo(block: () -> Unit, i: Int) {
+}
+
+fun test() {
+    foo({}, 0)
+}

--- a/idea/testData/refactoring/changeSignature/AddParameterAfterLambdaParameterBefore.kt
+++ b/idea/testData/refactoring/changeSignature/AddParameterAfterLambdaParameterBefore.kt
@@ -1,0 +1,6 @@
+fun <caret>foo(block: () -> Unit) {
+}
+
+fun test() {
+    foo {}
+}

--- a/idea/testData/refactoring/changeSignature/RemoveLambdaParameter2After.kt
+++ b/idea/testData/refactoring/changeSignature/RemoveLambdaParameter2After.kt
@@ -1,0 +1,6 @@
+fun foo() {
+}
+
+fun test() {
+    foo()
+}

--- a/idea/testData/refactoring/changeSignature/RemoveLambdaParameter2Before.kt
+++ b/idea/testData/refactoring/changeSignature/RemoveLambdaParameter2Before.kt
@@ -1,0 +1,6 @@
+fun <caret>foo(block: () -> Unit) {
+}
+
+fun test() {
+    foo {}
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -2339,6 +2339,11 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
             runTest("idea/testData/quickfix/changeSignature/removeFunctionFirstParameter.kt");
         }
 
+        @TestMetadata("removeFunctionLastLambdaParameter.kt")
+        public void testRemoveFunctionLastLambdaParameter() throws Exception {
+            runTest("idea/testData/quickfix/changeSignature/removeFunctionLastLambdaParameter.kt");
+        }
+
         @TestMetadata("removeFunctionSecondParameter1.kt")
         public void testRemoveFunctionSecondParameter1() throws Exception {
             runTest("idea/testData/quickfix/changeSignature/removeFunctionSecondParameter1.kt");

--- a/idea/tests/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeSignatureTest.kt
+++ b/idea/tests/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeSignatureTest.kt
@@ -1237,4 +1237,18 @@ class KotlinChangeSignatureTest : KotlinLightCodeInsightFixtureTestCase() {
     fun testKotlinOverridingJavaWithDifferentParamName() = doJavaTest {
         newParameters.add(ParameterInfoImpl(-1, "n", PsiType.INT))
     }
+
+    fun testAddParameterAfterLambdaParameter() = doTest {
+        addParameter(
+            KotlinParameterInfo(
+                callableDescriptor = originalBaseFunctionDescriptor,
+                name = "i",
+                originalTypeInfo = KotlinTypeInfo(false, BUILT_INS.intType),
+                defaultValueForCall = KtPsiFactory(project).createExpression("0")
+            )
+        )
+    }
+
+    fun testRemoveLambdaParameter2() = doTest { removeParameter(0) }
+
 }


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-23510