### PR TITLE
[JVM_IR] Handle big arity suspend functions in existing lowering.

### DIFF
--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/ir/util/IrTypeUtils.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/ir/util/IrTypeUtils.kt
@@ -52,6 +52,9 @@ fun IrType.isInterface() = classOrNull?.owner?.kind == ClassKind.INTERFACE
 
 fun IrType.isFunctionOrKFunction() = isFunction() || isKFunction()
 
+fun IrType.isSuspendFunctionOrKFunction() = isSuspendFunction() || isKSuspendFunction()
+
+
 @Deprecated(
     "Use org.jetbrains.kotlin.ir.types.isNullable instead.",
     ReplaceWith("this.isNullable()", "org.jetbrains.kotlin.ir.types.isNullable")

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/FunctionNVarargBridgeLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/FunctionNVarargBridgeLowering.kt
@@ -48,7 +48,8 @@ private class FunctionNVarargBridgeLowering(val context: JvmBackendContext) :
     // Change calls to big arity invoke functions to vararg calls.
     override fun visitFunctionAccess(expression: IrFunctionAccessExpression): IrExpression {
         if (expression.valueArgumentsCount < FunctionInvokeDescriptor.BIG_ARITY ||
-            !expression.symbol.owner.parentAsClass.defaultType.isFunctionOrKFunction() ||
+            !(expression.symbol.owner.parentAsClass.defaultType.isFunctionOrKFunction() ||
+                    expression.symbol.owner.parentAsClass.defaultType.isSuspendFunctionOrKFunction()) ||
             expression.symbol.owner.name.asString() != "invoke"
         ) return super.visitFunctionAccess(expression)
 


### PR DESCRIPTION
Now that suspend function views are created in
AddContinuationLowering, we can let the
FunctionNVarargBridgeLowering deal with rewriting of large
arity FunctionN/SuspendFunctionN.