### PR TITLE
KT-36686 Implement members quickfix puts the implementation *before* the data class if it already has a body

### DIFF
--- a/idea/idea-core/src/org/jetbrains/kotlin/idea/core/overrideImplement/OverrideImplementMembersHandler.kt
+++ b/idea/idea-core/src/org/jetbrains/kotlin/idea/core/overrideImplement/OverrideImplementMembersHandler.kt
@@ -146,9 +146,9 @@ abstract class OverrideImplementMembersHandler : LanguageCodeInsightActionHandle
 
             fun ClassDescriptor.findElement(memberDescriptor: CallableMemberDescriptor): KtDeclaration? {
                 return implementedElements[memberDescriptor]
-                    ?: (findCallableMemberBySignature(memberDescriptor)?.source?.getPsi() as? KtDeclaration)?.also {
-                        implementedElements[memberDescriptor] = it
-                    }
+                    ?: (findCallableMemberBySignature(memberDescriptor)?.source?.getPsi() as? KtDeclaration)
+                        ?.takeIf { it != classOrObject }
+                        ?.also { implementedElements[memberDescriptor] = it }
             }
 
             fun getAnchor(selectedElement: KtDeclaration): PsiElement? {

--- a/idea/testData/quickfix/implement/dataClass.kt
+++ b/idea/testData/quickfix/implement/dataClass.kt
@@ -1,0 +1,7 @@
+// "Implement members" "true"
+// WITH_RUNTIME
+interface I {
+    fun foo()
+}
+
+data <caret>class C(val i: Int) : I

--- a/idea/testData/quickfix/implement/dataClass.kt.after
+++ b/idea/testData/quickfix/implement/dataClass.kt.after
@@ -1,0 +1,11 @@
+// "Implement members" "true"
+// WITH_RUNTIME
+interface I {
+    fun foo()
+}
+
+data class C(val i: Int) : I {
+    override fun foo() {
+        TODO("Not yet implemented")
+    }
+}

--- a/idea/testData/quickfix/implement/dataClass2.kt
+++ b/idea/testData/quickfix/implement/dataClass2.kt
@@ -1,0 +1,7 @@
+// "Implement members" "true"
+// WITH_RUNTIME
+interface I {
+    fun foo()
+}
+
+data <caret>class C(val i: Int) : I {}

--- a/idea/testData/quickfix/implement/dataClass2.kt.after
+++ b/idea/testData/quickfix/implement/dataClass2.kt.after
@@ -1,0 +1,11 @@
+// "Implement members" "true"
+// WITH_RUNTIME
+interface I {
+    fun foo()
+}
+
+data class C(val i: Int) : I {
+    override fun foo() {
+        TODO("Not yet implemented")
+    }
+}

--- a/idea/testData/quickfix/implement/dataClass3.kt
+++ b/idea/testData/quickfix/implement/dataClass3.kt
@@ -1,0 +1,9 @@
+// "Implement members" "true"
+// WITH_RUNTIME
+interface I {
+    fun foo()
+}
+
+data <caret>class C(val i: Int) : I {
+    fun bar() {}
+}

--- a/idea/testData/quickfix/implement/dataClass3.kt.after
+++ b/idea/testData/quickfix/implement/dataClass3.kt.after
@@ -1,0 +1,12 @@
+// "Implement members" "true"
+// WITH_RUNTIME
+interface I {
+    fun foo()
+}
+
+data class C(val i: Int) : I {
+    fun bar() {}
+    override fun foo() {
+        TODO("Not yet implemented")
+    }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -7669,6 +7669,21 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
             runTest("idea/testData/quickfix/implement/annotation.kt");
         }
 
+        @TestMetadata("dataClass.kt")
+        public void testDataClass() throws Exception {
+            runTest("idea/testData/quickfix/implement/dataClass.kt");
+        }
+
+        @TestMetadata("dataClass2.kt")
+        public void testDataClass2() throws Exception {
+            runTest("idea/testData/quickfix/implement/dataClass2.kt");
+        }
+
+        @TestMetadata("dataClass3.kt")
+        public void testDataClass3() throws Exception {
+            runTest("idea/testData/quickfix/implement/dataClass3.kt");
+        }
+
         @TestMetadata("doNotAddExpectForVal.kt")
         public void testDoNotAddExpectForVal() throws Exception {
             runTest("idea/testData/quickfix/implement/doNotAddExpectForVal.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-36686