### PR TITLE
Reduce UI freezes by preparing affected Gradle project files lists in advance

### DIFF
--- a/idea/idea-gradle/src/org/jetbrains/kotlin/idea/scripting/gradle/AsyncFileChangeListenerHelper.kt
+++ b/idea/idea-gradle/src/org/jetbrains/kotlin/idea/scripting/gradle/AsyncFileChangeListenerHelper.kt
@@ -9,12 +9,15 @@ import com.intellij.openapi.externalSystem.service.project.autoimport.AsyncFileC
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.openapi.vfs.newvfs.events.VFileEvent
+import java.util.*
 
 fun addVfsListener(watcher: GradleScriptInputsWatcher) {
     VirtualFileManager.getInstance().addAsyncFileListener(
         object : AsyncFileChangeListenerBase() {
+
+            private var files: Set<String> = Collections.emptySet()
+
             override fun isRelevant(path: String): Boolean {
-                val files = getAffectedGradleProjectFiles(watcher.project)
                 return isInAffectedGradleProjectFiles(files, path)
             }
 
@@ -25,7 +28,9 @@ fun addVfsListener(watcher: GradleScriptInputsWatcher) {
             // do nothing
             override fun prepareFileDeletion(file: VirtualFile) {}
             override fun apply() {}
-            override fun reset() {}
+            override fun reset() {
+                files = getAffectedGradleProjectFiles(watcher.project)
+            }
 
         },
         watcher.project,

--- a/idea/idea-gradle/src/org/jetbrains/kotlin/idea/scripting/gradle/AsyncFileChangeListenerHelper.kt.201
+++ b/idea/idea-gradle/src/org/jetbrains/kotlin/idea/scripting/gradle/AsyncFileChangeListenerHelper.kt.201
@@ -9,12 +9,15 @@ import com.intellij.openapi.externalSystem.autoimport.AsyncFileChangeListenerBas
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.openapi.vfs.newvfs.events.VFileEvent
+import java.util.*
 
 fun addVfsListener(watcher: GradleScriptInputsWatcher) {
     VirtualFileManager.getInstance().addAsyncFileListener(
         object : AsyncFileChangeListenerBase() {
+
+            private var files: Set<String> = Collections.emptySet();
+
             override fun isRelevant(path: String): Boolean {
-                val files = getAffectedGradleProjectFiles(watcher.project)
                 return isInAffectedGradleProjectFiles(files, path)
             }
 
@@ -24,7 +27,9 @@ fun addVfsListener(watcher: GradleScriptInputsWatcher) {
 
             // do nothing
             override fun apply() {}
-            override fun init() {}
+            override fun init() {
+                files = getAffectedGradleProjectFiles(watcher.project)
+            }
 
         },
         watcher.project,


### PR DESCRIPTION
isRelevant() method is a hotspot, as it is called for each file in bulk VFS event.
As there can be hundreds of files in each event, we should keep operations minimal.