### PR TITLE
KT-15262: Allow generate toString() to include properties with non-default getters

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/actions/generate/utils.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/actions/generate/utils.kt
@@ -40,8 +40,7 @@ fun getPropertiesToUseInGeneratedMember(classOrObject: KtClassOrObject): List<Kt
         classOrObject.declarations.asSequence().filterIsInstance<KtProperty>().filterTo(this) {
             val descriptor = it.unsafeResolveToDescriptor()
             when (descriptor) {
-                is ValueParameterDescriptor -> true
-                is PropertyDescriptor -> descriptor.getter?.isDefault ?: true
+                is ValueParameterDescriptor, is PropertyDescriptor -> true
                 else -> false
             }
         }

--- a/idea/testData/codeInsight/generate/equalsWithHashCode/customAccessors.kt
+++ b/idea/testData/codeInsight/generate/equalsWithHashCode/customAccessors.kt
@@ -4,5 +4,8 @@ class Test {
             field = value.toUpperCase()
         }
     var name: String = ""
+    val age by lazy { 15 + 10 }
+    val color: String
+        get() = "Purple"
     <caret>
 }

--- a/idea/testData/codeInsight/generate/equalsWithHashCode/customAccessors.kt.after
+++ b/idea/testData/codeInsight/generate/equalsWithHashCode/customAccessors.kt.after
@@ -4,6 +4,10 @@ class Test {
             field = value.toUpperCase()
         }
     var name: String = ""
+    val age by lazy { 15 + 10 }
+    val color: String
+        get() = "Purple"
+
     <caret>override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
@@ -12,6 +16,8 @@ class Test {
 
         if (serial != other.serial) return false
         if (name != other.name) return false
+        if (age != other.age) return false
+        if (color != other.color) return false
 
         return true
     }
@@ -19,6 +25,8 @@ class Test {
     override fun hashCode(): Int {
         var result = serial.hashCode()
         result = 31 * result + name.hashCode()
+        result = 31 * result + age
+        result = 31 * result + color.hashCode()
         return result
     }
 

--- a/idea/testData/codeInsight/generate/equalsWithHashCode/explicitDefaultAccessors.kt.after
+++ b/idea/testData/codeInsight/generate/equalsWithHashCode/explicitDefaultAccessors.kt.after
@@ -8,11 +8,19 @@ class Test {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
+
+        other as Test
+
+        if (serial != other.serial) return false
+        if (name != other.name) return false
+
         return true
     }
 
     override fun hashCode(): Int {
-        return javaClass.hashCode()
+        var result = serial.hashCode()
+        result = 31 * result + name.hashCode()
+        return result
     }
 
 }

--- a/idea/testData/codeInsight/generate/toString/multipeTemplates/customAccessors.kt
+++ b/idea/testData/codeInsight/generate/toString/multipeTemplates/customAccessors.kt
@@ -5,5 +5,8 @@ class Test {
             field = value.toUpperCase()
         }
     var name: String = ""
+    val age by lazy { 15 + 10 }
+    val color: String
+        get() = "Purple"
     <caret>
 }

--- a/idea/testData/codeInsight/generate/toString/multipeTemplates/customAccessors.kt.after
+++ b/idea/testData/codeInsight/generate/toString/multipeTemplates/customAccessors.kt.after
@@ -5,10 +5,16 @@ class Test {
             field = value.toUpperCase()
         }
     var name: String = ""
+    val age by lazy { 15 + 10 }
+    val color: String
+        get() = "Purple"
+
     <caret>override fun toString(): String {
         return "Test(" +
                 "serial='$serial', " +
-                "name='$name'" +
+                "name='$name', " +
+                "age=$age, " +
+                "color='$color'" +
                 ")"
     }
 

--- a/idea/testData/codeInsight/generate/toString/singleTemplate/customAccessors.kt
+++ b/idea/testData/codeInsight/generate/toString/singleTemplate/customAccessors.kt
@@ -4,5 +4,8 @@ class Test {
             field = value.toUpperCase()
         }
     var name: String = ""
+    val age by lazy { 15 + 10 }
+    val color: String
+        get() = "Purple"
     <caret>
 }

--- a/idea/testData/codeInsight/generate/toString/singleTemplate/customAccessors.kt.after
+++ b/idea/testData/codeInsight/generate/toString/singleTemplate/customAccessors.kt.after
@@ -4,8 +4,12 @@ class Test {
             field = value.toUpperCase()
         }
     var name: String = ""
+    val age by lazy { 15 + 10 }
+    val color: String
+        get() = "Purple"
+
     <caret>override fun toString(): String {
-        return "Test(serial='$serial', name='$name')"
+        return "Test(serial='$serial', name='$name', age=$age, color='$color')"
     }
 
 }

--- a/idea/testData/codeInsight/generate/toString/singleTemplate/explicitDefaultAccessors.kt.after
+++ b/idea/testData/codeInsight/generate/toString/singleTemplate/explicitDefaultAccessors.kt.after
@@ -6,7 +6,7 @@ class Test {
         get
 
     override fun toString(): String {
-        return "Test()"
+        return "Test(serial='$serial', name='$name')"
     }
 
 }


### PR DESCRIPTION
This resolves [KT-15262](https://youtrack.jetbrains.com/issue/KT-15262), but also has the side effect of allowing properties with non-default getter (i.e delegated properties) to be included in the wizard when generating `toString()`, `equals()` and `hashCode()`. Happy to refine this further if this isn't ideal.