### PR TITLE
maven-plugin: config for force execution even without kotlin sources

### DIFF
--- a/libraries/tools/kotlin-maven-plugin/src/main/java/org/jetbrains/kotlin/maven/KotlinCompileMojoBase.java
+++ b/libraries/tools/kotlin-maven-plugin/src/main/java/org/jetbrains/kotlin/maven/KotlinCompileMojoBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -43,6 +43,7 @@ import java.util.regex.Pattern;
 import static org.jetbrains.kotlin.maven.Util.joinArrays;
 
 public abstract class KotlinCompileMojoBase<A extends CommonCompilerArguments> extends AbstractMojo {
+
     @Component
     protected PlexusContainer container;
 
@@ -191,7 +192,7 @@ public abstract class KotlinCompileMojoBase<A extends CommonCompilerArguments> e
         getLog().debug("Kotlin version " + KotlinCompilerVersion.VERSION +
                 " (JRE " + System.getProperty("java.runtime.version") + ")");
 
-        if (!hasKotlinFilesInSources()) {
+        if (!hasKotlinFilesInSources() && !isForceExecuteWithoutKotlinSources()) {
             getLog().warn("No sources found skipping Kotlin compile");
             return;
         }
@@ -211,6 +212,10 @@ public abstract class KotlinCompileMojoBase<A extends CommonCompilerArguments> e
         if (exitCode != ExitCode.OK) {
             messageCollector.throwKotlinCompilerException();
         }
+    }
+
+    protected boolean isForceExecuteWithoutKotlinSources() {
+        return false;
     }
 
     @NotNull

--- a/libraries/tools/kotlin-maven-plugin/src/main/java/org/jetbrains/kotlin/maven/kapt/KaptJVMCompilerMojo.java
+++ b/libraries/tools/kotlin-maven-plugin/src/main/java/org/jetbrains/kotlin/maven/kapt/KaptJVMCompilerMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2017 JetBrains s.r.o.
+ * Copyright 2010-2020 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,10 @@ import static org.jetbrains.kotlin.maven.kapt.AnnotationProcessingManager.*;
 /** @noinspection UnusedDeclaration */
 @Mojo(name = "kapt", defaultPhase = LifecyclePhase.PROCESS_SOURCES, requiresDependencyResolution = ResolutionScope.COMPILE)
 public class KaptJVMCompilerMojo extends K2JVMCompileMojo {
+
+    @Parameter
+    private boolean forceExecuteWithoutKotlinSources = false;
+
     @Parameter
     private String[] annotationProcessors;
 
@@ -76,6 +80,11 @@ public class KaptJVMCompilerMojo extends K2JVMCompileMojo {
     private ResolutionErrorHandler resolutionErrorHandler;
 
     private AnnotationProcessingManager cachedAnnotationProcessingManager;
+
+    @Override
+    protected boolean isForceExecuteWithoutKotlinSources() {
+        return forceExecuteWithoutKotlinSources;
+    }
 
     private AnnotationProcessingManager getAnnotationProcessingManager() {
         if (cachedAnnotationProcessingManager != null) {


### PR DESCRIPTION
In case if Kotlin needs to be added to the existing Java/Maven project there is a need to reconfigure `maven-compiler-plugin` to set the proper order of executions. In the end `kotlin-maven-plugin` will be executed first. This can be not an ideal case for projects that are using annotation processing quite heavily. For example project may contain multiple modules and `maven-compiler-plugin` is configured in the root POM to unify the setup once. But in case if configuration contained annotation processing it is recommended to let this be done by `kapt`. But `kapt` does not perform annotation processing for modules where there is only java source code. 

Detailed example:
```
- root-module
-- java-only-module
-- ... other modules
-- java-kotlin-module
```

> `root-module` contains `maven-compiler-plugin` configuration with annotation processors

> other modules are using this single config for build

After adding Kotlin to `java-kotlin-module` there is a need to reconfigure `maven-compiler-plugin`. But after this reconfiguration annotation processing will stop working in modules other than this one.

This is a limitation that can be solved by current PR. The idea is to allow force execution of `kapt` via a dedicated parameter - `forceExecutionWithoutKotlinSources`. The default is still `false` to be compatible.
