### PR TITLE
KT-36508 False positive "Replace 'to' with infix form" when 'to' lambda generic type argument is specified explicitly

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/ReplaceToWithInfixFormInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/ReplaceToWithInfixFormInspection.kt
@@ -25,7 +25,8 @@ class ReplaceToWithInfixFormInspection : AbstractKotlinInspection() {
 
     override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
         return dotQualifiedExpressionVisitor(fun(expression) {
-            if (expression.callExpression?.valueArguments?.size != 1) return
+            val callExpression = expression.callExpression ?: return
+            if (callExpression.valueArguments.size != 1 || callExpression.typeArgumentList != null) return
             if (expression.calleeName !in compatibleNames) return
 
             val resolvedCall = expression.resolveToCall() ?: return

--- a/idea/testData/inspectionsLocal/replaceToWithInfixForm/typeArguments.kt
+++ b/idea/testData/inspectionsLocal/replaceToWithInfixForm/typeArguments.kt
@@ -1,0 +1,9 @@
+// PROBLEM: none
+// WITH_RUNTIME
+class Receiver(val x: Int = 0)
+class Argument(val y: Int = 1)
+
+val test = <caret>"".to<String, Receiver.(Argument) -> Unit> {
+    println(x)
+    println(it.y)
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -7153,7 +7153,7 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
         }
 
         public void testAllFilesPresentInRedundantElvisReturnNull() throws Exception {
-            KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/inspectionsLocal/redundantElvisReturnNull"), Pattern.compile("^([\\w\\-_]+)\\.(kt|kts)$"), true);
+            KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("idea/testData/inspectionsLocal/redundantElvisReturnNull"), Pattern.compile("^([\\w\\-_]+)\\.(kt|kts)$"), null, true);
         }
 
         @TestMetadata("basic.kt")
@@ -11183,6 +11183,11 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
         @TestMetadata("nonPair.kt")
         public void testNonPair() throws Exception {
             runTest("idea/testData/inspectionsLocal/replaceToWithInfixForm/nonPair.kt");
+        }
+
+        @TestMetadata("typeArguments.kt")
+        public void testTypeArguments() throws Exception {
+            runTest("idea/testData/inspectionsLocal/replaceToWithInfixForm/typeArguments.kt");
         }
     }
 


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-36508