### PR TITLE
JVM_IR: cache signatures in BridgeLowering

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/BridgeLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/BridgeLowering.kt
@@ -30,7 +30,6 @@ import org.jetbrains.kotlin.ir.types.*
 import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 import org.jetbrains.kotlin.name.Name
-import org.jetbrains.kotlin.resolve.DescriptorUtils
 import org.jetbrains.kotlin.util.OperatorNameConventions
 import org.jetbrains.kotlin.utils.getOrPutNullable
 import org.jetbrains.org.objectweb.asm.Type
@@ -482,8 +481,10 @@ private class BridgeLowering(val context: JvmBackendContext) : FileLoweringPass,
     private fun IrBuilderWithScope.irCastIfNeeded(expression: IrExpression, to: IrType): IrExpression =
         if (expression.type == to || to.isAny() || to.isNullableAny()) expression else irImplicitCast(expression, to)
 
+    private val signatureCache = mutableMapOf<IrFunction, Method>()
+
     private val IrFunction.jvmMethod: Method
-        get() = context.methodSignatureMapper.mapAsmMethod(this)
+        get() = signatureCache.getOrPut(this) { context.methodSignatureMapper.mapAsmMethod(this) }
 }
 
 private fun IrDeclaration.comesFromJava() = parentAsClass.origin == IrDeclarationOrigin.IR_EXTERNAL_JAVA_DECLARATION_STUB


### PR DESCRIPTION
`mapAsmMethod` is somewhat slow, so this helps if there are a lot of overrides of same methods and/or deep class hierarchies in a single file (though it would probably help more if lowerings were not reconstructed for every file).