### PR TITLE
JVM_IR: default-initialize variables visible in the LVT

### DIFF
--- a/compiler/testData/codegen/box/when/sealedWhenInitialization.kt
+++ b/compiler/testData/codegen/box/when/sealedWhenInitialization.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 sealed class A {
     object B : A()
 

--- a/compiler/testData/codegen/bytecodeText/coroutines/varValueConflictsWithTableSameSort.kt
+++ b/compiler/testData/codegen/bytecodeText/coroutines/varValueConflictsWithTableSameSort.kt
@@ -1,6 +1,3 @@
-// This test checks, that different variables occupy the same slot
-// In JVM_IR, however, loop variable's lifetime goes beyond the loop itself, thus the test has no sense in JVM_IR
-// IGNORE_BACKEND: JVM_IR
 // WITH_COROUTINES
 
 import helpers.*

--- a/compiler/testData/codegen/bytecodeText/localInitializationLVT/boxing.kt
+++ b/compiler/testData/codegen/bytecodeText/localInitializationLVT/boxing.kt
@@ -1,6 +1,5 @@
 // IGNORE_BACKEND: JVM_IR
 // TODO KT-36648 Captured variables not optimized in JVM_IR
-// TODO KT-36812 Generate proper lifetime intervals for local variables in JVM_IR
 
 fun test(): java.lang.Integer {
     val c: java.lang.Integer

--- a/compiler/testData/codegen/bytecodeText/localInitializationLVT/contract.kt
+++ b/compiler/testData/codegen/bytecodeText/localInitializationLVT/contract.kt
@@ -1,5 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
-// TODO KT-36812 Generate proper lifetime intervals for local variables in JVM_IR
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
@@ -22,4 +20,4 @@ fun doIt(block: () -> Unit) {
 }
 
 // 0 ISTORE 0
-// 1 LOCALVARIABLE c Lkotlin/jvm/internal/Ref\$CharRef; L1 L3 0
+// 1 LOCALVARIABLE c Lkotlin/jvm/internal/Ref\$CharRef;

--- a/compiler/testData/codegen/bytecodeText/localInitializationLVT/contractVar.kt
+++ b/compiler/testData/codegen/bytecodeText/localInitializationLVT/contractVar.kt
@@ -1,5 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
-// TODO KT-36812 Generate proper lifetime intervals for local variables in JVM_IR
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
@@ -22,8 +20,8 @@ fun doIt(block: () -> Unit) {
 }
 
 // 0 ISTORE 0
-// 1 LOCALVARIABLE c Lkotlin/jvm/internal/Ref\$CharRef; L1 L3 0
+// 1 LOCALVARIABLE c Lkotlin/jvm/internal/Ref\$CharRef;
 
 // JVM_IR_TEMPLATES
 // 0 ISTORE 0
-// 1 LOCALVARIABLE c Lkotlin/jvm/internal/Ref\$CharRef; L1 L4 0
+// 1 LOCALVARIABLE c Lkotlin/jvm/internal/Ref\$CharRef;

--- a/compiler/testData/codegen/bytecodeText/localInitializationLVT/ifStatement.kt
+++ b/compiler/testData/codegen/bytecodeText/localInitializationLVT/ifStatement.kt
@@ -1,6 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
-// TODO KT-36812 Generate proper lifetime intervals for local variables in JVM_IR
-
 import kotlin.random.Random
 
 fun test(): Char {
@@ -14,4 +11,4 @@ fun test(): Char {
 }
 
 // 3 ISTORE 0
-// 1 LOCALVARIABLE c C L1 L7 0
+// 1 LOCALVARIABLE c C

--- a/compiler/testData/codegen/bytecodeText/localInitializationLVT/ifStatementVar.kt
+++ b/compiler/testData/codegen/bytecodeText/localInitializationLVT/ifStatementVar.kt
@@ -1,6 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
-// TODO KT-36812 Generate proper lifetime intervals for local variables in JVM_IR
-
 import kotlin.random.Random
 
 fun test(): Char {
@@ -14,4 +11,4 @@ fun test(): Char {
 }
 
 // 3 ISTORE 0
-// 1 LOCALVARIABLE c C L1 L7 0
+// 1 LOCALVARIABLE c C

--- a/compiler/testData/codegen/bytecodeText/localInitializationLVT/ifStatementWithoutBlock.kt
+++ b/compiler/testData/codegen/bytecodeText/localInitializationLVT/ifStatementWithoutBlock.kt
@@ -1,6 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
-// TODO KT-36812 Generate proper lifetime intervals for local variables in JVM_IR
-
 import kotlin.random.Random
 
 fun test(): Char {

--- a/compiler/testData/codegen/bytecodeText/localInitializationLVT/ifStatementWithoutBlockVar.kt
+++ b/compiler/testData/codegen/bytecodeText/localInitializationLVT/ifStatementWithoutBlockVar.kt
@@ -1,6 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
-// TODO KT-36812 Generate proper lifetime intervals for local variables in JVM_IR
-
 import kotlin.random.Random
 
 fun test(): Char {

--- a/compiler/testData/codegen/bytecodeText/localInitializationLVT/inlineClass.kt
+++ b/compiler/testData/codegen/bytecodeText/localInitializationLVT/inlineClass.kt
@@ -1,6 +1,5 @@
 // IGNORE_BACKEND: JVM_IR
 // TODO KT-36648 Captured variables not optimized in JVM_IR
-// TODO KT-36812 Generate proper lifetime intervals for local variables in JVM_IR
 
 fun test(): UInt {
     val c: UInt

--- a/compiler/testData/codegen/bytecodeText/localInitializationLVT/inlineClassVar.kt
+++ b/compiler/testData/codegen/bytecodeText/localInitializationLVT/inlineClassVar.kt
@@ -1,6 +1,5 @@
 // IGNORE_BACKEND: JVM_IR
 // TODO KT-36648 Captured variables not optimized in JVM_IR
-// TODO KT-36812 Generate proper lifetime intervals for local variables in JVM_IR
 
 fun test(): UInt {
     var c: UInt

--- a/compiler/testData/codegen/bytecodeText/localInitializationLVT/lateinit.kt
+++ b/compiler/testData/codegen/bytecodeText/localInitializationLVT/lateinit.kt
@@ -1,6 +1,5 @@
 // IGNORE_BACKEND: JVM_IR
 // TODO KT-36648 Captured variables not optimized in JVM_IR
-// TODO KT-36812 Generate proper lifetime intervals for local variables in JVM_IR
 
 fun test(): Char {
     lateinit var c: Any

--- a/compiler/testData/codegen/bytecodeText/localInitializationLVT/run.kt
+++ b/compiler/testData/codegen/bytecodeText/localInitializationLVT/run.kt
@@ -1,6 +1,5 @@
 // IGNORE_BACKEND: JVM_IR
 // TODO KT-36648 Captured variables not optimized in JVM_IR
-// TODO KT-36812 Generate proper lifetime intervals for local variables in JVM_IR
 
 fun test(): Char {
     val c: Char

--- a/compiler/testData/codegen/bytecodeText/localInitializationLVT/singleBlock.kt
+++ b/compiler/testData/codegen/bytecodeText/localInitializationLVT/singleBlock.kt
@@ -1,6 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
-// TODO KT-36812 Generate proper lifetime intervals for local variables in JVM_IR
-
 fun test(): Char {
     val c: Char
     val l = Any()

--- a/compiler/testData/codegen/bytecodeText/localInitializationLVT/singleBlockVar.kt
+++ b/compiler/testData/codegen/bytecodeText/localInitializationLVT/singleBlockVar.kt
@@ -1,6 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
-// TODO KT-36812 Generate proper lifetime intervals for local variables in JVM_IR
-
 fun test(): Char {
     var c: Char
     val l = Any()

--- a/compiler/testData/codegen/bytecodeText/localInitializationLVT/whenStatement.kt
+++ b/compiler/testData/codegen/bytecodeText/localInitializationLVT/whenStatement.kt
@@ -1,6 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
-// TODO KT-36812 Generate proper lifetime intervals for local variables in JVM_IR
-
 fun test(i: Int): Char {
     val c: Char
     when (i) {
@@ -20,4 +17,4 @@ fun test(i: Int): Char {
 }
 
 // 12 ISTORE 1
-// 1 LOCALVARIABLE c C L1 L16 1
+// 1 LOCALVARIABLE c C

--- a/compiler/testData/codegen/bytecodeText/localInitializationLVT/whenStatementVar.kt
+++ b/compiler/testData/codegen/bytecodeText/localInitializationLVT/whenStatementVar.kt
@@ -1,6 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
-// TODO KT-36812 Generate proper lifetime intervals for local variables in JVM_IR
-
 fun test(i: Int): Char {
     var c: Char
     when (i) {
@@ -20,4 +17,4 @@ fun test(i: Int): Char {
 }
 
 // 12 ISTORE 1
-// 1 LOCALVARIABLE c C L1 L16 1
+// 1 LOCALVARIABLE c C


### PR DESCRIPTION
See KT-36812. Aside from the problem stated there, D8 will throw out the entire LVT if it sees a variable that has not been written to (and will generate incorrect SSA if the slot is reused with a different type).

Note: this only fixes a FIR test because it's missing an `else -> throw` branch, and default initialization satisfies the verifier and masks the incorrect control flow.