### PR TITLE
KT-37148 "Remove redundant `.let` call doesn't remove extra calls

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantLetInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantLetInspection.kt
@@ -145,7 +145,7 @@ private fun KtDotQualifiedExpression.applyTo(element: KtCallExpression) {
 }
 
 private fun deleteCall(element: KtCallExpression) {
-    val parent = element.parent as? KtDotQualifiedExpression
+    val parent = element.parent as? KtQualifiedExpression
     if (parent != null) {
         val replacement = parent.selectorExpression?.takeIf { it != element } ?: parent.receiverExpression
         parent.replace(replacement)

--- a/idea/testData/inspectionsLocal/simpleRedundantLet/reference5.kt
+++ b/idea/testData/inspectionsLocal/simpleRedundantLet/reference5.kt
@@ -1,0 +1,2 @@
+// WITH_RUNTIME
+val a = 1?.let<caret> { it }?.let { it }

--- a/idea/testData/inspectionsLocal/simpleRedundantLet/reference5.kt.after
+++ b/idea/testData/inspectionsLocal/simpleRedundantLet/reference5.kt.after
@@ -1,0 +1,2 @@
+// WITH_RUNTIME
+val a = 1?.let { it }

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -7153,7 +7153,7 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
         }
 
         public void testAllFilesPresentInRedundantElvisReturnNull() throws Exception {
-            KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/inspectionsLocal/redundantElvisReturnNull"), Pattern.compile("^([\\w\\-_]+)\\.(kt|kts)$"), true);
+            KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("idea/testData/inspectionsLocal/redundantElvisReturnNull"), Pattern.compile("^([\\w\\-_]+)\\.(kt|kts)$"), null, true);
         }
 
         @TestMetadata("basic.kt")
@@ -12172,6 +12172,11 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
         @TestMetadata("reference4.kt")
         public void testReference4() throws Exception {
             runTest("idea/testData/inspectionsLocal/simpleRedundantLet/reference4.kt");
+        }
+
+        @TestMetadata("reference5.kt")
+        public void testReference5() throws Exception {
+            runTest("idea/testData/inspectionsLocal/simpleRedundantLet/reference5.kt");
         }
 
         @TestMetadata("sameLets.kt")


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-37148