### PR TITLE
https://patch-diff.githubusercontent.com/raw/JetBrains/kotlin/pull/3157.patch

### DIFF
--- a/libraries/stdlib/common/src/generated/_Arrays.kt
+++ b/libraries/stdlib/common/src/generated/_Arrays.kt
@@ -6015,7 +6015,23 @@ public expect fun CharArray.asList(): List<Char>
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public expect infix fun <T> Array<out T>.contentDeepEquals(other: Array<out T>): Boolean
+
+/**
+ * Returns `true` if the two specified arrays are *deeply* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The specified arrays are also considered deeply equal if both are `null`.
+ * 
+ * If two corresponding elements are nested arrays, they are also compared deeply.
+ * If any of arrays contains itself on any nesting level the behavior is undefined.
+ * 
+ * The elements of other types are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+public expect infix fun <T> Array<out T>?.contentDeepEquals(other: Array<out T>?): Boolean
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
@@ -6024,7 +6040,17 @@ public expect infix fun <T> Array<out T>.contentDeepEquals(other: Array<out T>):
  * If any of arrays contains itself on any nesting level the behavior is undefined.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public expect fun <T> Array<out T>.contentDeepHashCode(): Int
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ * Nested arrays are treated as lists too.
+ * 
+ * If any of arrays contains itself on any nesting level the behavior is undefined.
+ */
+@SinceKotlin("1.4")
+public expect fun <T> Array<out T>?.contentDeepHashCode(): Int
 
 /**
  * Returns a string representation of the contents of this array as if it is a [List].
@@ -6036,7 +6062,20 @@ public expect fun <T> Array<out T>.contentDeepHashCode(): Int
  * @sample samples.collections.Arrays.ContentOperations.contentDeepToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public expect fun <T> Array<out T>.contentDeepToString(): String
+
+/**
+ * Returns a string representation of the contents of this array as if it is a [List].
+ * Nested arrays are treated as lists too.
+ * 
+ * If any of arrays contains itself on any nesting level that reference
+ * is rendered as `"[...]"` to prevent recursion.
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentDeepToString
+ */
+@SinceKotlin("1.4")
+public expect fun <T> Array<out T>?.contentDeepToString(): String
 
 /**
  * Returns `true` if the two specified arrays are *structurally* equal to one another,
@@ -6046,6 +6085,7 @@ public expect fun <T> Array<out T>.contentDeepToString(): String
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public expect infix fun <T> Array<out T>.contentEquals(other: Array<out T>): Boolean
 
 /**
@@ -6056,6 +6096,7 @@ public expect infix fun <T> Array<out T>.contentEquals(other: Array<out T>): Boo
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public expect infix fun ByteArray.contentEquals(other: ByteArray): Boolean
 
 /**
@@ -6066,6 +6107,7 @@ public expect infix fun ByteArray.contentEquals(other: ByteArray): Boolean
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public expect infix fun ShortArray.contentEquals(other: ShortArray): Boolean
 
 /**
@@ -6076,6 +6118,7 @@ public expect infix fun ShortArray.contentEquals(other: ShortArray): Boolean
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public expect infix fun IntArray.contentEquals(other: IntArray): Boolean
 
 /**
@@ -6086,6 +6129,7 @@ public expect infix fun IntArray.contentEquals(other: IntArray): Boolean
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public expect infix fun LongArray.contentEquals(other: LongArray): Boolean
 
 /**
@@ -6096,6 +6140,7 @@ public expect infix fun LongArray.contentEquals(other: LongArray): Boolean
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public expect infix fun FloatArray.contentEquals(other: FloatArray): Boolean
 
 /**
@@ -6106,6 +6151,7 @@ public expect infix fun FloatArray.contentEquals(other: FloatArray): Boolean
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public expect infix fun DoubleArray.contentEquals(other: DoubleArray): Boolean
 
 /**
@@ -6116,6 +6162,7 @@ public expect infix fun DoubleArray.contentEquals(other: DoubleArray): Boolean
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public expect infix fun BooleanArray.contentEquals(other: BooleanArray): Boolean
 
 /**
@@ -6126,61 +6173,215 @@ public expect infix fun BooleanArray.contentEquals(other: BooleanArray): Boolean
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public expect infix fun CharArray.contentEquals(other: CharArray): Boolean
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+public expect infix fun <T> Array<out T>?.contentEquals(other: Array<out T>?): Boolean
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+public expect infix fun ByteArray?.contentEquals(other: ByteArray?): Boolean
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+public expect infix fun ShortArray?.contentEquals(other: ShortArray?): Boolean
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+public expect infix fun IntArray?.contentEquals(other: IntArray?): Boolean
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+public expect infix fun LongArray?.contentEquals(other: LongArray?): Boolean
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+public expect infix fun FloatArray?.contentEquals(other: FloatArray?): Boolean
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+public expect infix fun DoubleArray?.contentEquals(other: DoubleArray?): Boolean
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+public expect infix fun BooleanArray?.contentEquals(other: BooleanArray?): Boolean
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+public expect infix fun CharArray?.contentEquals(other: CharArray?): Boolean
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public expect fun <T> Array<out T>.contentHashCode(): Int
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public expect fun ByteArray.contentHashCode(): Int
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public expect fun ShortArray.contentHashCode(): Int
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public expect fun IntArray.contentHashCode(): Int
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public expect fun LongArray.contentHashCode(): Int
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public expect fun FloatArray.contentHashCode(): Int
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public expect fun DoubleArray.contentHashCode(): Int
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public expect fun BooleanArray.contentHashCode(): Int
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public expect fun CharArray.contentHashCode(): Int
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+public expect fun <T> Array<out T>?.contentHashCode(): Int
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+public expect fun ByteArray?.contentHashCode(): Int
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+public expect fun ShortArray?.contentHashCode(): Int
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+public expect fun IntArray?.contentHashCode(): Int
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+public expect fun LongArray?.contentHashCode(): Int
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+public expect fun FloatArray?.contentHashCode(): Int
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+public expect fun DoubleArray?.contentHashCode(): Int
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+public expect fun BooleanArray?.contentHashCode(): Int
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+public expect fun CharArray?.contentHashCode(): Int
 
 /**
  * Returns a string representation of the contents of the specified array as if it is [List].
@@ -6188,6 +6389,7 @@ public expect fun CharArray.contentHashCode(): Int
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public expect fun <T> Array<out T>.contentToString(): String
 
 /**
@@ -6196,6 +6398,7 @@ public expect fun <T> Array<out T>.contentToString(): String
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public expect fun ByteArray.contentToString(): String
 
 /**
@@ -6204,6 +6407,7 @@ public expect fun ByteArray.contentToString(): String
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public expect fun ShortArray.contentToString(): String
 
 /**
@@ -6212,6 +6416,7 @@ public expect fun ShortArray.contentToString(): String
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public expect fun IntArray.contentToString(): String
 
 /**
@@ -6220,6 +6425,7 @@ public expect fun IntArray.contentToString(): String
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public expect fun LongArray.contentToString(): String
 
 /**
@@ -6228,6 +6434,7 @@ public expect fun LongArray.contentToString(): String
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public expect fun FloatArray.contentToString(): String
 
 /**
@@ -6236,6 +6443,7 @@ public expect fun FloatArray.contentToString(): String
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public expect fun DoubleArray.contentToString(): String
 
 /**
@@ -6244,6 +6452,7 @@ public expect fun DoubleArray.contentToString(): String
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public expect fun BooleanArray.contentToString(): String
 
 /**
@@ -6252,7 +6461,80 @@ public expect fun BooleanArray.contentToString(): String
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public expect fun CharArray.contentToString(): String
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+public expect fun <T> Array<out T>?.contentToString(): String
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+public expect fun ByteArray?.contentToString(): String
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+public expect fun ShortArray?.contentToString(): String
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+public expect fun IntArray?.contentToString(): String
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+public expect fun LongArray?.contentToString(): String
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+public expect fun FloatArray?.contentToString(): String
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+public expect fun DoubleArray?.contentToString(): String
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+public expect fun BooleanArray?.contentToString(): String
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+public expect fun CharArray?.contentToString(): String
 
 /**
  * Copies this array or its subrange into the [destination] array and returns that array.

--- a/libraries/stdlib/common/src/generated/_UArrays.kt
+++ b/libraries/stdlib/common/src/generated/_UArrays.kt
@@ -3015,9 +3015,10 @@ public inline fun ShortArray.asUShortArray(): UShortArray {
  * i.e. contain the same number of the same elements in the same order.
  */
 @SinceKotlin("1.3")
+@kotlin.internal.LowPriorityInOverloadResolution
 @ExperimentalUnsignedTypes
 public infix fun UIntArray.contentEquals(other: UIntArray): Boolean {
-    return storage.contentEquals(other.storage)
+    return this.contentEquals(other)
 }
 
 /**
@@ -3025,9 +3026,10 @@ public infix fun UIntArray.contentEquals(other: UIntArray): Boolean {
  * i.e. contain the same number of the same elements in the same order.
  */
 @SinceKotlin("1.3")
+@kotlin.internal.LowPriorityInOverloadResolution
 @ExperimentalUnsignedTypes
 public infix fun ULongArray.contentEquals(other: ULongArray): Boolean {
-    return storage.contentEquals(other.storage)
+    return this.contentEquals(other)
 }
 
 /**
@@ -3035,9 +3037,10 @@ public infix fun ULongArray.contentEquals(other: ULongArray): Boolean {
  * i.e. contain the same number of the same elements in the same order.
  */
 @SinceKotlin("1.3")
+@kotlin.internal.LowPriorityInOverloadResolution
 @ExperimentalUnsignedTypes
 public infix fun UByteArray.contentEquals(other: UByteArray): Boolean {
-    return storage.contentEquals(other.storage)
+    return this.contentEquals(other)
 }
 
 /**
@@ -3045,45 +3048,126 @@ public infix fun UByteArray.contentEquals(other: UByteArray): Boolean {
  * i.e. contain the same number of the same elements in the same order.
  */
 @SinceKotlin("1.3")
+@kotlin.internal.LowPriorityInOverloadResolution
 @ExperimentalUnsignedTypes
 public infix fun UShortArray.contentEquals(other: UShortArray): Boolean {
-    return storage.contentEquals(other.storage)
+    return this.contentEquals(other)
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ */
+@SinceKotlin("1.4")
+@ExperimentalUnsignedTypes
+public infix fun UIntArray?.contentEquals(other: UIntArray?): Boolean {
+    return this?.storage.contentEquals(other?.storage)
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ */
+@SinceKotlin("1.4")
+@ExperimentalUnsignedTypes
+public infix fun ULongArray?.contentEquals(other: ULongArray?): Boolean {
+    return this?.storage.contentEquals(other?.storage)
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ */
+@SinceKotlin("1.4")
+@ExperimentalUnsignedTypes
+public infix fun UByteArray?.contentEquals(other: UByteArray?): Boolean {
+    return this?.storage.contentEquals(other?.storage)
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ */
+@SinceKotlin("1.4")
+@ExperimentalUnsignedTypes
+public infix fun UShortArray?.contentEquals(other: UShortArray?): Boolean {
+    return this?.storage.contentEquals(other?.storage)
 }
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.3")
+@kotlin.internal.LowPriorityInOverloadResolution
 @ExperimentalUnsignedTypes
 public fun UIntArray.contentHashCode(): Int {
-    return storage.contentHashCode()
+    return this.contentHashCode()
 }
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.3")
+@kotlin.internal.LowPriorityInOverloadResolution
 @ExperimentalUnsignedTypes
 public fun ULongArray.contentHashCode(): Int {
-    return storage.contentHashCode()
+    return this.contentHashCode()
 }
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.3")
+@kotlin.internal.LowPriorityInOverloadResolution
 @ExperimentalUnsignedTypes
 public fun UByteArray.contentHashCode(): Int {
-    return storage.contentHashCode()
+    return this.contentHashCode()
 }
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.3")
+@kotlin.internal.LowPriorityInOverloadResolution
 @ExperimentalUnsignedTypes
 public fun UShortArray.contentHashCode(): Int {
-    return storage.contentHashCode()
+    return this.contentHashCode()
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+@ExperimentalUnsignedTypes
+public fun UIntArray?.contentHashCode(): Int {
+    return this?.storage.contentHashCode()
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+@ExperimentalUnsignedTypes
+public fun ULongArray?.contentHashCode(): Int {
+    return this?.storage.contentHashCode()
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+@ExperimentalUnsignedTypes
+public fun UByteArray?.contentHashCode(): Int {
+    return this?.storage.contentHashCode()
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+@ExperimentalUnsignedTypes
+public fun UShortArray?.contentHashCode(): Int {
+    return this?.storage.contentHashCode()
 }
 
 /**
@@ -3092,9 +3176,10 @@ public fun UShortArray.contentHashCode(): Int {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.3")
+@kotlin.internal.LowPriorityInOverloadResolution
 @ExperimentalUnsignedTypes
 public fun UIntArray.contentToString(): String {
-    return joinToString(", ", "[", "]")
+    return this.contentToString()
 }
 
 /**
@@ -3103,9 +3188,10 @@ public fun UIntArray.contentToString(): String {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.3")
+@kotlin.internal.LowPriorityInOverloadResolution
 @ExperimentalUnsignedTypes
 public fun ULongArray.contentToString(): String {
-    return joinToString(", ", "[", "]")
+    return this.contentToString()
 }
 
 /**
@@ -3114,9 +3200,10 @@ public fun ULongArray.contentToString(): String {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.3")
+@kotlin.internal.LowPriorityInOverloadResolution
 @ExperimentalUnsignedTypes
 public fun UByteArray.contentToString(): String {
-    return joinToString(", ", "[", "]")
+    return this.contentToString()
 }
 
 /**
@@ -3125,9 +3212,54 @@ public fun UByteArray.contentToString(): String {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.3")
+@kotlin.internal.LowPriorityInOverloadResolution
 @ExperimentalUnsignedTypes
 public fun UShortArray.contentToString(): String {
-    return joinToString(", ", "[", "]")
+    return this.contentToString()
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+@ExperimentalUnsignedTypes
+public fun UIntArray?.contentToString(): String {
+    return this?.joinToString(", ", "[", "]") ?: "null"
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+@ExperimentalUnsignedTypes
+public fun ULongArray?.contentToString(): String {
+    return this?.joinToString(", ", "[", "]") ?: "null"
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+@ExperimentalUnsignedTypes
+public fun UByteArray?.contentToString(): String {
+    return this?.joinToString(", ", "[", "]") ?: "null"
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+@ExperimentalUnsignedTypes
+public fun UShortArray?.contentToString(): String {
+    return this?.joinToString(", ", "[", "]") ?: "null"
 }
 
 /**

--- a/libraries/stdlib/js-ir/runtime/collectionsHacks.kt
+++ b/libraries/stdlib/js-ir/runtime/collectionsHacks.kt
@@ -9,7 +9,8 @@ import kotlin.js.*
 
 internal fun arrayToString(array: Array<*>) = array.joinToString(", ", "[", "]") { toString(it) }
 
-internal fun <T> Array<out T>.contentDeepHashCodeInternal(): Int {
+internal fun <T> Array<out T>?.contentDeepHashCodeInternal(): Int {
+    if (this == null) return 0
     var result = 1
     for (element in this) {
         val elementHash = when {
@@ -35,7 +36,7 @@ internal fun <T> T.contentEqualsInternal(other: T): Boolean {
 
     if (a === b) return true
 
-    if (!isArrayish(b) || a.length != b.length) return false
+    if (a == null || b == null || !isArrayish(b) || a.length != b.length) return false
 
     for (i in 0 until a.length) {
         if (!equals(a[i], b[i])) {
@@ -47,6 +48,8 @@ internal fun <T> T.contentEqualsInternal(other: T): Boolean {
 
 internal fun <T> T.contentHashCodeInternal(): Int {
     val a = this.asDynamic()
+    if (a == null) return 0
+
     var result = 1
 
     for (i in 0 until a.length) {

--- a/libraries/stdlib/js-ir/src/generated/_ArraysJs.kt
+++ b/libraries/stdlib/js-ir/src/generated/_ArraysJs.kt
@@ -194,7 +194,25 @@ public actual fun CharArray.asList(): List<Char> {
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual infix fun <T> Array<out T>.contentDeepEquals(other: Array<out T>): Boolean {
+    return this.contentDeepEquals(other)
+}
+
+/**
+ * Returns `true` if the two specified arrays are *deeply* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The specified arrays are also considered deeply equal if both are `null`.
+ * 
+ * If two corresponding elements are nested arrays, they are also compared deeply.
+ * If any of arrays contains itself on any nesting level the behavior is undefined.
+ * 
+ * The elements of other types are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+public actual infix fun <T> Array<out T>?.contentDeepEquals(other: Array<out T>?): Boolean {
     return contentDeepEqualsImpl(other)
 }
 
@@ -205,7 +223,19 @@ public actual infix fun <T> Array<out T>.contentDeepEquals(other: Array<out T>):
  * If any of arrays contains itself on any nesting level the behavior is undefined.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun <T> Array<out T>.contentDeepHashCode(): Int {
+    return this.contentDeepHashCode()
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ * Nested arrays are treated as lists too.
+ * 
+ * If any of arrays contains itself on any nesting level the behavior is undefined.
+ */
+@SinceKotlin("1.4")
+public actual fun <T> Array<out T>?.contentDeepHashCode(): Int {
     return contentDeepHashCodeInternal()
 }
 
@@ -219,7 +249,22 @@ public actual fun <T> Array<out T>.contentDeepHashCode(): Int {
  * @sample samples.collections.Arrays.ContentOperations.contentDeepToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun <T> Array<out T>.contentDeepToString(): String {
+    return this.contentDeepToString()
+}
+
+/**
+ * Returns a string representation of the contents of this array as if it is a [List].
+ * Nested arrays are treated as lists too.
+ * 
+ * If any of arrays contains itself on any nesting level that reference
+ * is rendered as `"[...]"` to prevent recursion.
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentDeepToString
+ */
+@SinceKotlin("1.4")
+public actual fun <T> Array<out T>?.contentDeepToString(): String {
     return contentDeepToStringImpl()
 }
 
@@ -231,8 +276,9 @@ public actual fun <T> Array<out T>.contentDeepToString(): String {
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual infix fun <T> Array<out T>.contentEquals(other: Array<out T>): Boolean {
-    return contentEqualsInternal(other)
+    return this.contentEquals(other)
 }
 
 /**
@@ -243,8 +289,9 @@ public actual infix fun <T> Array<out T>.contentEquals(other: Array<out T>): Boo
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual infix fun ByteArray.contentEquals(other: ByteArray): Boolean {
-    return contentEqualsInternal(other)
+    return this.contentEquals(other)
 }
 
 /**
@@ -255,8 +302,9 @@ public actual infix fun ByteArray.contentEquals(other: ByteArray): Boolean {
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual infix fun ShortArray.contentEquals(other: ShortArray): Boolean {
-    return contentEqualsInternal(other)
+    return this.contentEquals(other)
 }
 
 /**
@@ -267,8 +315,9 @@ public actual infix fun ShortArray.contentEquals(other: ShortArray): Boolean {
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual infix fun IntArray.contentEquals(other: IntArray): Boolean {
-    return contentEqualsInternal(other)
+    return this.contentEquals(other)
 }
 
 /**
@@ -279,8 +328,9 @@ public actual infix fun IntArray.contentEquals(other: IntArray): Boolean {
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual infix fun LongArray.contentEquals(other: LongArray): Boolean {
-    return contentEqualsInternal(other)
+    return this.contentEquals(other)
 }
 
 /**
@@ -291,8 +341,9 @@ public actual infix fun LongArray.contentEquals(other: LongArray): Boolean {
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual infix fun FloatArray.contentEquals(other: FloatArray): Boolean {
-    return contentEqualsInternal(other)
+    return this.contentEquals(other)
 }
 
 /**
@@ -303,8 +354,9 @@ public actual infix fun FloatArray.contentEquals(other: FloatArray): Boolean {
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual infix fun DoubleArray.contentEquals(other: DoubleArray): Boolean {
-    return contentEqualsInternal(other)
+    return this.contentEquals(other)
 }
 
 /**
@@ -315,8 +367,9 @@ public actual infix fun DoubleArray.contentEquals(other: DoubleArray): Boolean {
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual infix fun BooleanArray.contentEquals(other: BooleanArray): Boolean {
-    return contentEqualsInternal(other)
+    return this.contentEquals(other)
 }
 
 /**
@@ -327,7 +380,116 @@ public actual infix fun BooleanArray.contentEquals(other: BooleanArray): Boolean
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual infix fun CharArray.contentEquals(other: CharArray): Boolean {
+    return this.contentEquals(other)
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+public actual infix fun <T> Array<out T>?.contentEquals(other: Array<out T>?): Boolean {
+    return contentEqualsInternal(other)
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+public actual infix fun ByteArray?.contentEquals(other: ByteArray?): Boolean {
+    return contentEqualsInternal(other)
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+public actual infix fun ShortArray?.contentEquals(other: ShortArray?): Boolean {
+    return contentEqualsInternal(other)
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+public actual infix fun IntArray?.contentEquals(other: IntArray?): Boolean {
+    return contentEqualsInternal(other)
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+public actual infix fun LongArray?.contentEquals(other: LongArray?): Boolean {
+    return contentEqualsInternal(other)
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+public actual infix fun FloatArray?.contentEquals(other: FloatArray?): Boolean {
+    return contentEqualsInternal(other)
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+public actual infix fun DoubleArray?.contentEquals(other: DoubleArray?): Boolean {
+    return contentEqualsInternal(other)
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+public actual infix fun BooleanArray?.contentEquals(other: BooleanArray?): Boolean {
+    return contentEqualsInternal(other)
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+public actual infix fun CharArray?.contentEquals(other: CharArray?): Boolean {
     return contentEqualsInternal(other)
 }
 
@@ -335,71 +497,152 @@ public actual infix fun CharArray.contentEquals(other: CharArray): Boolean {
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun <T> Array<out T>.contentHashCode(): Int {
-    return contentHashCodeInternal()
+    return this.contentHashCode()
 }
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun ByteArray.contentHashCode(): Int {
-    return contentHashCodeInternal()
+    return this.contentHashCode()
 }
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun ShortArray.contentHashCode(): Int {
-    return contentHashCodeInternal()
+    return this.contentHashCode()
 }
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun IntArray.contentHashCode(): Int {
-    return contentHashCodeInternal()
+    return this.contentHashCode()
 }
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun LongArray.contentHashCode(): Int {
-    return contentHashCodeInternal()
+    return this.contentHashCode()
 }
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun FloatArray.contentHashCode(): Int {
-    return contentHashCodeInternal()
+    return this.contentHashCode()
 }
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun DoubleArray.contentHashCode(): Int {
-    return contentHashCodeInternal()
+    return this.contentHashCode()
 }
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun BooleanArray.contentHashCode(): Int {
-    return contentHashCodeInternal()
+    return this.contentHashCode()
 }
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun CharArray.contentHashCode(): Int {
+    return this.contentHashCode()
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+public actual fun <T> Array<out T>?.contentHashCode(): Int {
+    return contentHashCodeInternal()
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+public actual fun ByteArray?.contentHashCode(): Int {
+    return contentHashCodeInternal()
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+public actual fun ShortArray?.contentHashCode(): Int {
+    return contentHashCodeInternal()
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+public actual fun IntArray?.contentHashCode(): Int {
+    return contentHashCodeInternal()
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+public actual fun LongArray?.contentHashCode(): Int {
+    return contentHashCodeInternal()
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+public actual fun FloatArray?.contentHashCode(): Int {
+    return contentHashCodeInternal()
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+public actual fun DoubleArray?.contentHashCode(): Int {
+    return contentHashCodeInternal()
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+public actual fun BooleanArray?.contentHashCode(): Int {
+    return contentHashCodeInternal()
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+public actual fun CharArray?.contentHashCode(): Int {
     return contentHashCodeInternal()
 }
 
@@ -409,8 +652,9 @@ public actual fun CharArray.contentHashCode(): Int {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun <T> Array<out T>.contentToString(): String {
-    return joinToString(", ", "[", "]")
+    return this.contentToString()
 }
 
 /**
@@ -419,8 +663,9 @@ public actual fun <T> Array<out T>.contentToString(): String {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun ByteArray.contentToString(): String {
-    return joinToString(", ", "[", "]")
+    return this.contentToString()
 }
 
 /**
@@ -429,8 +674,9 @@ public actual fun ByteArray.contentToString(): String {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun ShortArray.contentToString(): String {
-    return joinToString(", ", "[", "]")
+    return this.contentToString()
 }
 
 /**
@@ -439,8 +685,9 @@ public actual fun ShortArray.contentToString(): String {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun IntArray.contentToString(): String {
-    return joinToString(", ", "[", "]")
+    return this.contentToString()
 }
 
 /**
@@ -449,8 +696,9 @@ public actual fun IntArray.contentToString(): String {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun LongArray.contentToString(): String {
-    return joinToString(", ", "[", "]")
+    return this.contentToString()
 }
 
 /**
@@ -459,8 +707,9 @@ public actual fun LongArray.contentToString(): String {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun FloatArray.contentToString(): String {
-    return joinToString(", ", "[", "]")
+    return this.contentToString()
 }
 
 /**
@@ -469,8 +718,9 @@ public actual fun FloatArray.contentToString(): String {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun DoubleArray.contentToString(): String {
-    return joinToString(", ", "[", "]")
+    return this.contentToString()
 }
 
 /**
@@ -479,8 +729,9 @@ public actual fun DoubleArray.contentToString(): String {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun BooleanArray.contentToString(): String {
-    return joinToString(", ", "[", "]")
+    return this.contentToString()
 }
 
 /**
@@ -489,8 +740,99 @@ public actual fun BooleanArray.contentToString(): String {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun CharArray.contentToString(): String {
-    return joinToString(", ", "[", "]")
+    return this.contentToString()
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+public actual fun <T> Array<out T>?.contentToString(): String {
+    return this?.joinToString(", ", "[", "]") ?: "null"
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+public actual fun ByteArray?.contentToString(): String {
+    return this?.joinToString(", ", "[", "]") ?: "null"
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+public actual fun ShortArray?.contentToString(): String {
+    return this?.joinToString(", ", "[", "]") ?: "null"
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+public actual fun IntArray?.contentToString(): String {
+    return this?.joinToString(", ", "[", "]") ?: "null"
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+public actual fun LongArray?.contentToString(): String {
+    return this?.joinToString(", ", "[", "]") ?: "null"
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+public actual fun FloatArray?.contentToString(): String {
+    return this?.joinToString(", ", "[", "]") ?: "null"
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+public actual fun DoubleArray?.contentToString(): String {
+    return this?.joinToString(", ", "[", "]") ?: "null"
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+public actual fun BooleanArray?.contentToString(): String {
+    return this?.joinToString(", ", "[", "]") ?: "null"
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+public actual fun CharArray?.contentToString(): String {
+    return this?.joinToString(", ", "[", "]") ?: "null"
 }
 
 /**

--- a/libraries/stdlib/js-v1/src/js/arrayUtils.js
+++ b/libraries/stdlib/js-v1/src/js/arrayUtils.js
@@ -44,6 +44,7 @@ Kotlin.isArrayish = function (a) {
 };
 
 Kotlin.arrayToString = function (a) {
+    if (a === null) return "null"
     var toString = Kotlin.isCharArray(a) ? String.fromCharCode : Kotlin.toString;
     return "[" + Array.prototype.map.call(a, function(e) { return toString(e); }).join(", ") + "]";
 };
@@ -56,7 +57,7 @@ Kotlin.arrayEquals = function (a, b) {
     if (a === b) {
         return true;
     }
-    if (!Kotlin.isArrayish(b) || a.length !== b.length) {
+    if (a === null || b === null || !Kotlin.isArrayish(b) || a.length !== b.length) {
         return false;
     }
 
@@ -73,6 +74,7 @@ Kotlin.arrayDeepEquals = function (a, b) {
 };
 
 Kotlin.arrayHashCode = function (arr) {
+    if (arr === null) return 0
     var result = 1;
     for (var i = 0, n = arr.length; i < n; i++) {
         result = ((31 * result | 0) + Kotlin.hashCode(arr[i])) | 0;

--- a/libraries/stdlib/js/src/generated/_ArraysJs.kt
+++ b/libraries/stdlib/js/src/generated/_ArraysJs.kt
@@ -194,8 +194,26 @@ public actual fun CharArray.asList(): List<Char> {
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
-@library("arrayDeepEquals")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual infix fun <T> Array<out T>.contentDeepEquals(other: Array<out T>): Boolean {
+    return this.contentDeepEquals(other)
+}
+
+/**
+ * Returns `true` if the two specified arrays are *deeply* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The specified arrays are also considered deeply equal if both are `null`.
+ * 
+ * If two corresponding elements are nested arrays, they are also compared deeply.
+ * If any of arrays contains itself on any nesting level the behavior is undefined.
+ * 
+ * The elements of other types are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+@library("arrayDeepEquals")
+public actual infix fun <T> Array<out T>?.contentDeepEquals(other: Array<out T>?): Boolean {
     definedExternally
 }
 
@@ -206,8 +224,20 @@ public actual infix fun <T> Array<out T>.contentDeepEquals(other: Array<out T>):
  * If any of arrays contains itself on any nesting level the behavior is undefined.
  */
 @SinceKotlin("1.1")
-@library("arrayDeepHashCode")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun <T> Array<out T>.contentDeepHashCode(): Int {
+    return this.contentDeepHashCode()
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ * Nested arrays are treated as lists too.
+ * 
+ * If any of arrays contains itself on any nesting level the behavior is undefined.
+ */
+@SinceKotlin("1.4")
+@library("arrayDeepHashCode")
+public actual fun <T> Array<out T>?.contentDeepHashCode(): Int {
     definedExternally
 }
 
@@ -221,8 +251,23 @@ public actual fun <T> Array<out T>.contentDeepHashCode(): Int {
  * @sample samples.collections.Arrays.ContentOperations.contentDeepToString
  */
 @SinceKotlin("1.1")
-@library("arrayDeepToString")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun <T> Array<out T>.contentDeepToString(): String {
+    return this.contentDeepToString()
+}
+
+/**
+ * Returns a string representation of the contents of this array as if it is a [List].
+ * Nested arrays are treated as lists too.
+ * 
+ * If any of arrays contains itself on any nesting level that reference
+ * is rendered as `"[...]"` to prevent recursion.
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentDeepToString
+ */
+@SinceKotlin("1.4")
+@library("arrayDeepToString")
+public actual fun <T> Array<out T>?.contentDeepToString(): String {
     definedExternally
 }
 
@@ -234,9 +279,9 @@ public actual fun <T> Array<out T>.contentDeepToString(): String {
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
-@library("arrayEquals")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual infix fun <T> Array<out T>.contentEquals(other: Array<out T>): Boolean {
-    definedExternally
+    return this.contentEquals(other)
 }
 
 /**
@@ -247,9 +292,9 @@ public actual infix fun <T> Array<out T>.contentEquals(other: Array<out T>): Boo
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
-@library("arrayEquals")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual infix fun ByteArray.contentEquals(other: ByteArray): Boolean {
-    definedExternally
+    return this.contentEquals(other)
 }
 
 /**
@@ -260,9 +305,9 @@ public actual infix fun ByteArray.contentEquals(other: ByteArray): Boolean {
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
-@library("arrayEquals")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual infix fun ShortArray.contentEquals(other: ShortArray): Boolean {
-    definedExternally
+    return this.contentEquals(other)
 }
 
 /**
@@ -273,9 +318,9 @@ public actual infix fun ShortArray.contentEquals(other: ShortArray): Boolean {
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
-@library("arrayEquals")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual infix fun IntArray.contentEquals(other: IntArray): Boolean {
-    definedExternally
+    return this.contentEquals(other)
 }
 
 /**
@@ -286,9 +331,9 @@ public actual infix fun IntArray.contentEquals(other: IntArray): Boolean {
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
-@library("arrayEquals")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual infix fun LongArray.contentEquals(other: LongArray): Boolean {
-    definedExternally
+    return this.contentEquals(other)
 }
 
 /**
@@ -299,9 +344,9 @@ public actual infix fun LongArray.contentEquals(other: LongArray): Boolean {
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
-@library("arrayEquals")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual infix fun FloatArray.contentEquals(other: FloatArray): Boolean {
-    definedExternally
+    return this.contentEquals(other)
 }
 
 /**
@@ -312,9 +357,9 @@ public actual infix fun FloatArray.contentEquals(other: FloatArray): Boolean {
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
-@library("arrayEquals")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual infix fun DoubleArray.contentEquals(other: DoubleArray): Boolean {
-    definedExternally
+    return this.contentEquals(other)
 }
 
 /**
@@ -325,9 +370,9 @@ public actual infix fun DoubleArray.contentEquals(other: DoubleArray): Boolean {
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
-@library("arrayEquals")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual infix fun BooleanArray.contentEquals(other: BooleanArray): Boolean {
-    definedExternally
+    return this.contentEquals(other)
 }
 
 /**
@@ -338,8 +383,125 @@ public actual infix fun BooleanArray.contentEquals(other: BooleanArray): Boolean
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
-@library("arrayEquals")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual infix fun CharArray.contentEquals(other: CharArray): Boolean {
+    return this.contentEquals(other)
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+@library("arrayEquals")
+public actual infix fun <T> Array<out T>?.contentEquals(other: Array<out T>?): Boolean {
+    definedExternally
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+@library("arrayEquals")
+public actual infix fun ByteArray?.contentEquals(other: ByteArray?): Boolean {
+    definedExternally
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+@library("arrayEquals")
+public actual infix fun ShortArray?.contentEquals(other: ShortArray?): Boolean {
+    definedExternally
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+@library("arrayEquals")
+public actual infix fun IntArray?.contentEquals(other: IntArray?): Boolean {
+    definedExternally
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+@library("arrayEquals")
+public actual infix fun LongArray?.contentEquals(other: LongArray?): Boolean {
+    definedExternally
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+@library("arrayEquals")
+public actual infix fun FloatArray?.contentEquals(other: FloatArray?): Boolean {
+    definedExternally
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+@library("arrayEquals")
+public actual infix fun DoubleArray?.contentEquals(other: DoubleArray?): Boolean {
+    definedExternally
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+@library("arrayEquals")
+public actual infix fun BooleanArray?.contentEquals(other: BooleanArray?): Boolean {
+    definedExternally
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+@library("arrayEquals")
+public actual infix fun CharArray?.contentEquals(other: CharArray?): Boolean {
     definedExternally
 }
 
@@ -347,80 +509,161 @@ public actual infix fun CharArray.contentEquals(other: CharArray): Boolean {
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
-@library("arrayHashCode")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun <T> Array<out T>.contentHashCode(): Int {
-    definedExternally
+    return this.contentHashCode()
 }
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
-@library("arrayHashCode")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun ByteArray.contentHashCode(): Int {
-    definedExternally
+    return this.contentHashCode()
 }
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
-@library("arrayHashCode")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun ShortArray.contentHashCode(): Int {
-    definedExternally
+    return this.contentHashCode()
 }
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
-@library("arrayHashCode")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun IntArray.contentHashCode(): Int {
-    definedExternally
+    return this.contentHashCode()
 }
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
-@library("arrayHashCode")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun LongArray.contentHashCode(): Int {
-    definedExternally
+    return this.contentHashCode()
 }
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
-@library("arrayHashCode")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun FloatArray.contentHashCode(): Int {
-    definedExternally
+    return this.contentHashCode()
 }
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
-@library("arrayHashCode")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun DoubleArray.contentHashCode(): Int {
-    definedExternally
+    return this.contentHashCode()
 }
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
-@library("arrayHashCode")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun BooleanArray.contentHashCode(): Int {
-    definedExternally
+    return this.contentHashCode()
 }
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
-@library("arrayHashCode")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun CharArray.contentHashCode(): Int {
+    return this.contentHashCode()
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+@library("arrayHashCode")
+public actual fun <T> Array<out T>?.contentHashCode(): Int {
+    definedExternally
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+@library("arrayHashCode")
+public actual fun ByteArray?.contentHashCode(): Int {
+    definedExternally
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+@library("arrayHashCode")
+public actual fun ShortArray?.contentHashCode(): Int {
+    definedExternally
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+@library("arrayHashCode")
+public actual fun IntArray?.contentHashCode(): Int {
+    definedExternally
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+@library("arrayHashCode")
+public actual fun LongArray?.contentHashCode(): Int {
+    definedExternally
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+@library("arrayHashCode")
+public actual fun FloatArray?.contentHashCode(): Int {
+    definedExternally
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+@library("arrayHashCode")
+public actual fun DoubleArray?.contentHashCode(): Int {
+    definedExternally
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+@library("arrayHashCode")
+public actual fun BooleanArray?.contentHashCode(): Int {
+    definedExternally
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+@library("arrayHashCode")
+public actual fun CharArray?.contentHashCode(): Int {
     definedExternally
 }
 
@@ -430,9 +673,9 @@ public actual fun CharArray.contentHashCode(): Int {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
-@library("arrayToString")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun <T> Array<out T>.contentToString(): String {
-    definedExternally
+    return this.contentToString()
 }
 
 /**
@@ -441,9 +684,9 @@ public actual fun <T> Array<out T>.contentToString(): String {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
-@library("arrayToString")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun ByteArray.contentToString(): String {
-    definedExternally
+    return this.contentToString()
 }
 
 /**
@@ -452,9 +695,9 @@ public actual fun ByteArray.contentToString(): String {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
-@library("arrayToString")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun ShortArray.contentToString(): String {
-    definedExternally
+    return this.contentToString()
 }
 
 /**
@@ -463,9 +706,9 @@ public actual fun ShortArray.contentToString(): String {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
-@library("arrayToString")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun IntArray.contentToString(): String {
-    definedExternally
+    return this.contentToString()
 }
 
 /**
@@ -474,9 +717,9 @@ public actual fun IntArray.contentToString(): String {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
-@library("arrayToString")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun LongArray.contentToString(): String {
-    definedExternally
+    return this.contentToString()
 }
 
 /**
@@ -485,9 +728,9 @@ public actual fun LongArray.contentToString(): String {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
-@library("arrayToString")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun FloatArray.contentToString(): String {
-    definedExternally
+    return this.contentToString()
 }
 
 /**
@@ -496,9 +739,9 @@ public actual fun FloatArray.contentToString(): String {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
-@library("arrayToString")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun DoubleArray.contentToString(): String {
-    definedExternally
+    return this.contentToString()
 }
 
 /**
@@ -507,9 +750,9 @@ public actual fun DoubleArray.contentToString(): String {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
-@library("arrayToString")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun BooleanArray.contentToString(): String {
-    definedExternally
+    return this.contentToString()
 }
 
 /**
@@ -518,8 +761,107 @@ public actual fun BooleanArray.contentToString(): String {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
-@library("arrayToString")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun CharArray.contentToString(): String {
+    return this.contentToString()
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+@library("arrayToString")
+public actual fun <T> Array<out T>?.contentToString(): String {
+    definedExternally
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+@library("arrayToString")
+public actual fun ByteArray?.contentToString(): String {
+    definedExternally
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+@library("arrayToString")
+public actual fun ShortArray?.contentToString(): String {
+    definedExternally
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+@library("arrayToString")
+public actual fun IntArray?.contentToString(): String {
+    definedExternally
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+@library("arrayToString")
+public actual fun LongArray?.contentToString(): String {
+    definedExternally
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+@library("arrayToString")
+public actual fun FloatArray?.contentToString(): String {
+    definedExternally
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+@library("arrayToString")
+public actual fun DoubleArray?.contentToString(): String {
+    definedExternally
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+@library("arrayToString")
+public actual fun BooleanArray?.contentToString(): String {
+    definedExternally
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+@library("arrayToString")
+public actual fun CharArray?.contentToString(): String {
     definedExternally
 }
 

--- a/libraries/stdlib/js/src/kotlin/collections/ArraysJs.kt
+++ b/libraries/stdlib/js/src/kotlin/collections/ArraysJs.kt
@@ -9,7 +9,8 @@ package kotlin.collections
 @UseExperimental(ExperimentalUnsignedTypes::class)
 @SinceKotlin("1.3")
 @kotlin.js.JsName("contentDeepHashCodeImpl")
-internal fun <T> Array<out T>.contentDeepHashCodeImpl(): Int {
+internal fun <T> Array<out T>?.contentDeepHashCodeImpl(): Int {
+    if (this == null) return 0
     var result = 1
     for (element in this) {
         val elementHash = when {

--- a/libraries/stdlib/jvm/src/generated/_ArraysJvm.kt
+++ b/libraries/stdlib/jvm/src/generated/_ArraysJvm.kt
@@ -387,9 +387,29 @@ public fun CharArray.binarySearch(element: Char, fromIndex: Int = 0, toIndex: In
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 @JvmName("contentDeepEqualsInline")
 @kotlin.internal.InlineOnly
 public actual inline infix fun <T> Array<out T>.contentDeepEquals(other: Array<out T>): Boolean {
+    return this.contentDeepEquals(other)
+}
+
+/**
+ * Returns `true` if the two specified arrays are *deeply* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The specified arrays are also considered deeply equal if both are `null`.
+ * 
+ * If two corresponding elements are nested arrays, they are also compared deeply.
+ * If any of arrays contains itself on any nesting level the behavior is undefined.
+ * 
+ * The elements of other types are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+@JvmName("contentDeepEqualsNullable")
+@kotlin.internal.InlineOnly
+public actual inline infix fun <T> Array<out T>?.contentDeepEquals(other: Array<out T>?): Boolean {
     if (kotlin.internal.apiVersionIsAtLeast(1, 3, 0))
         return contentDeepEqualsImpl(other)
     else
@@ -403,9 +423,23 @@ public actual inline infix fun <T> Array<out T>.contentDeepEquals(other: Array<o
  * If any of arrays contains itself on any nesting level the behavior is undefined.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 @JvmName("contentDeepHashCodeInline")
 @kotlin.internal.InlineOnly
 public actual inline fun <T> Array<out T>.contentDeepHashCode(): Int {
+    return this.contentDeepHashCode()
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ * Nested arrays are treated as lists too.
+ * 
+ * If any of arrays contains itself on any nesting level the behavior is undefined.
+ */
+@SinceKotlin("1.4")
+@JvmName("contentDeepHashCodeNullable")
+@kotlin.internal.InlineOnly
+public actual inline fun <T> Array<out T>?.contentDeepHashCode(): Int {
     if (kotlin.internal.apiVersionIsAtLeast(1, 3, 0))
         return contentDeepHashCodeImpl()
     else
@@ -422,9 +456,26 @@ public actual inline fun <T> Array<out T>.contentDeepHashCode(): Int {
  * @sample samples.collections.Arrays.ContentOperations.contentDeepToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 @JvmName("contentDeepToStringInline")
 @kotlin.internal.InlineOnly
 public actual inline fun <T> Array<out T>.contentDeepToString(): String {
+    return this.contentDeepToString()
+}
+
+/**
+ * Returns a string representation of the contents of this array as if it is a [List].
+ * Nested arrays are treated as lists too.
+ * 
+ * If any of arrays contains itself on any nesting level that reference
+ * is rendered as `"[...]"` to prevent recursion.
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentDeepToString
+ */
+@SinceKotlin("1.4")
+@JvmName("contentDeepToStringNullable")
+@kotlin.internal.InlineOnly
+public actual inline fun <T> Array<out T>?.contentDeepToString(): String {
     if (kotlin.internal.apiVersionIsAtLeast(1, 3, 0))
         return contentDeepToStringImpl()
     else
@@ -439,9 +490,10 @@ public actual inline fun <T> Array<out T>.contentDeepToString(): String {
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 @kotlin.internal.InlineOnly
 public actual inline infix fun <T> Array<out T>.contentEquals(other: Array<out T>): Boolean {
-    return java.util.Arrays.equals(this, other)
+    return this.contentEquals(other)
 }
 
 /**
@@ -452,9 +504,10 @@ public actual inline infix fun <T> Array<out T>.contentEquals(other: Array<out T
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 @kotlin.internal.InlineOnly
 public actual inline infix fun ByteArray.contentEquals(other: ByteArray): Boolean {
-    return java.util.Arrays.equals(this, other)
+    return this.contentEquals(other)
 }
 
 /**
@@ -465,9 +518,10 @@ public actual inline infix fun ByteArray.contentEquals(other: ByteArray): Boolea
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 @kotlin.internal.InlineOnly
 public actual inline infix fun ShortArray.contentEquals(other: ShortArray): Boolean {
-    return java.util.Arrays.equals(this, other)
+    return this.contentEquals(other)
 }
 
 /**
@@ -478,9 +532,10 @@ public actual inline infix fun ShortArray.contentEquals(other: ShortArray): Bool
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 @kotlin.internal.InlineOnly
 public actual inline infix fun IntArray.contentEquals(other: IntArray): Boolean {
-    return java.util.Arrays.equals(this, other)
+    return this.contentEquals(other)
 }
 
 /**
@@ -491,9 +546,10 @@ public actual inline infix fun IntArray.contentEquals(other: IntArray): Boolean 
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 @kotlin.internal.InlineOnly
 public actual inline infix fun LongArray.contentEquals(other: LongArray): Boolean {
-    return java.util.Arrays.equals(this, other)
+    return this.contentEquals(other)
 }
 
 /**
@@ -504,9 +560,10 @@ public actual inline infix fun LongArray.contentEquals(other: LongArray): Boolea
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 @kotlin.internal.InlineOnly
 public actual inline infix fun FloatArray.contentEquals(other: FloatArray): Boolean {
-    return java.util.Arrays.equals(this, other)
+    return this.contentEquals(other)
 }
 
 /**
@@ -517,9 +574,10 @@ public actual inline infix fun FloatArray.contentEquals(other: FloatArray): Bool
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 @kotlin.internal.InlineOnly
 public actual inline infix fun DoubleArray.contentEquals(other: DoubleArray): Boolean {
-    return java.util.Arrays.equals(this, other)
+    return this.contentEquals(other)
 }
 
 /**
@@ -530,9 +588,10 @@ public actual inline infix fun DoubleArray.contentEquals(other: DoubleArray): Bo
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 @kotlin.internal.InlineOnly
 public actual inline infix fun BooleanArray.contentEquals(other: BooleanArray): Boolean {
-    return java.util.Arrays.equals(this, other)
+    return this.contentEquals(other)
 }
 
 /**
@@ -543,8 +602,135 @@ public actual inline infix fun BooleanArray.contentEquals(other: BooleanArray): 
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 @kotlin.internal.InlineOnly
 public actual inline infix fun CharArray.contentEquals(other: CharArray): Boolean {
+    return this.contentEquals(other)
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+@JvmName("contentEqualsNullable")
+@kotlin.internal.InlineOnly
+public actual inline infix fun <T> Array<out T>?.contentEquals(other: Array<out T>?): Boolean {
+    return java.util.Arrays.equals(this, other)
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+@JvmName("contentEqualsNullable")
+@kotlin.internal.InlineOnly
+public actual inline infix fun ByteArray?.contentEquals(other: ByteArray?): Boolean {
+    return java.util.Arrays.equals(this, other)
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+@JvmName("contentEqualsNullable")
+@kotlin.internal.InlineOnly
+public actual inline infix fun ShortArray?.contentEquals(other: ShortArray?): Boolean {
+    return java.util.Arrays.equals(this, other)
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+@JvmName("contentEqualsNullable")
+@kotlin.internal.InlineOnly
+public actual inline infix fun IntArray?.contentEquals(other: IntArray?): Boolean {
+    return java.util.Arrays.equals(this, other)
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+@JvmName("contentEqualsNullable")
+@kotlin.internal.InlineOnly
+public actual inline infix fun LongArray?.contentEquals(other: LongArray?): Boolean {
+    return java.util.Arrays.equals(this, other)
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+@JvmName("contentEqualsNullable")
+@kotlin.internal.InlineOnly
+public actual inline infix fun FloatArray?.contentEquals(other: FloatArray?): Boolean {
+    return java.util.Arrays.equals(this, other)
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+@JvmName("contentEqualsNullable")
+@kotlin.internal.InlineOnly
+public actual inline infix fun DoubleArray?.contentEquals(other: DoubleArray?): Boolean {
+    return java.util.Arrays.equals(this, other)
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+@JvmName("contentEqualsNullable")
+@kotlin.internal.InlineOnly
+public actual inline infix fun BooleanArray?.contentEquals(other: BooleanArray?): Boolean {
+    return java.util.Arrays.equals(this, other)
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+@JvmName("contentEqualsNullable")
+@kotlin.internal.InlineOnly
+public actual inline infix fun CharArray?.contentEquals(other: CharArray?): Boolean {
     return java.util.Arrays.equals(this, other)
 }
 
@@ -552,80 +738,179 @@ public actual inline infix fun CharArray.contentEquals(other: CharArray): Boolea
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 @kotlin.internal.InlineOnly
 public actual inline fun <T> Array<out T>.contentHashCode(): Int {
-    return java.util.Arrays.hashCode(this)
+    return this.contentHashCode()
 }
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 @kotlin.internal.InlineOnly
 public actual inline fun ByteArray.contentHashCode(): Int {
-    return java.util.Arrays.hashCode(this)
+    return this.contentHashCode()
 }
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 @kotlin.internal.InlineOnly
 public actual inline fun ShortArray.contentHashCode(): Int {
-    return java.util.Arrays.hashCode(this)
+    return this.contentHashCode()
 }
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 @kotlin.internal.InlineOnly
 public actual inline fun IntArray.contentHashCode(): Int {
-    return java.util.Arrays.hashCode(this)
+    return this.contentHashCode()
 }
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 @kotlin.internal.InlineOnly
 public actual inline fun LongArray.contentHashCode(): Int {
-    return java.util.Arrays.hashCode(this)
+    return this.contentHashCode()
 }
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 @kotlin.internal.InlineOnly
 public actual inline fun FloatArray.contentHashCode(): Int {
-    return java.util.Arrays.hashCode(this)
+    return this.contentHashCode()
 }
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 @kotlin.internal.InlineOnly
 public actual inline fun DoubleArray.contentHashCode(): Int {
-    return java.util.Arrays.hashCode(this)
+    return this.contentHashCode()
 }
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 @kotlin.internal.InlineOnly
 public actual inline fun BooleanArray.contentHashCode(): Int {
-    return java.util.Arrays.hashCode(this)
+    return this.contentHashCode()
 }
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 @kotlin.internal.InlineOnly
 public actual inline fun CharArray.contentHashCode(): Int {
+    return this.contentHashCode()
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+@JvmName("contentHashCodeNullable")
+@kotlin.internal.InlineOnly
+public actual inline fun <T> Array<out T>?.contentHashCode(): Int {
+    return java.util.Arrays.hashCode(this)
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+@JvmName("contentHashCodeNullable")
+@kotlin.internal.InlineOnly
+public actual inline fun ByteArray?.contentHashCode(): Int {
+    return java.util.Arrays.hashCode(this)
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+@JvmName("contentHashCodeNullable")
+@kotlin.internal.InlineOnly
+public actual inline fun ShortArray?.contentHashCode(): Int {
+    return java.util.Arrays.hashCode(this)
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+@JvmName("contentHashCodeNullable")
+@kotlin.internal.InlineOnly
+public actual inline fun IntArray?.contentHashCode(): Int {
+    return java.util.Arrays.hashCode(this)
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+@JvmName("contentHashCodeNullable")
+@kotlin.internal.InlineOnly
+public actual inline fun LongArray?.contentHashCode(): Int {
+    return java.util.Arrays.hashCode(this)
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+@JvmName("contentHashCodeNullable")
+@kotlin.internal.InlineOnly
+public actual inline fun FloatArray?.contentHashCode(): Int {
+    return java.util.Arrays.hashCode(this)
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+@JvmName("contentHashCodeNullable")
+@kotlin.internal.InlineOnly
+public actual inline fun DoubleArray?.contentHashCode(): Int {
+    return java.util.Arrays.hashCode(this)
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+@JvmName("contentHashCodeNullable")
+@kotlin.internal.InlineOnly
+public actual inline fun BooleanArray?.contentHashCode(): Int {
+    return java.util.Arrays.hashCode(this)
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+@JvmName("contentHashCodeNullable")
+@kotlin.internal.InlineOnly
+public actual inline fun CharArray?.contentHashCode(): Int {
     return java.util.Arrays.hashCode(this)
 }
 
@@ -635,9 +920,10 @@ public actual inline fun CharArray.contentHashCode(): Int {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 @kotlin.internal.InlineOnly
 public actual inline fun <T> Array<out T>.contentToString(): String {
-    return java.util.Arrays.toString(this)
+    return this.contentToString()
 }
 
 /**
@@ -646,9 +932,10 @@ public actual inline fun <T> Array<out T>.contentToString(): String {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 @kotlin.internal.InlineOnly
 public actual inline fun ByteArray.contentToString(): String {
-    return java.util.Arrays.toString(this)
+    return this.contentToString()
 }
 
 /**
@@ -657,9 +944,10 @@ public actual inline fun ByteArray.contentToString(): String {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 @kotlin.internal.InlineOnly
 public actual inline fun ShortArray.contentToString(): String {
-    return java.util.Arrays.toString(this)
+    return this.contentToString()
 }
 
 /**
@@ -668,9 +956,10 @@ public actual inline fun ShortArray.contentToString(): String {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 @kotlin.internal.InlineOnly
 public actual inline fun IntArray.contentToString(): String {
-    return java.util.Arrays.toString(this)
+    return this.contentToString()
 }
 
 /**
@@ -679,9 +968,10 @@ public actual inline fun IntArray.contentToString(): String {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 @kotlin.internal.InlineOnly
 public actual inline fun LongArray.contentToString(): String {
-    return java.util.Arrays.toString(this)
+    return this.contentToString()
 }
 
 /**
@@ -690,9 +980,10 @@ public actual inline fun LongArray.contentToString(): String {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 @kotlin.internal.InlineOnly
 public actual inline fun FloatArray.contentToString(): String {
-    return java.util.Arrays.toString(this)
+    return this.contentToString()
 }
 
 /**
@@ -701,9 +992,10 @@ public actual inline fun FloatArray.contentToString(): String {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 @kotlin.internal.InlineOnly
 public actual inline fun DoubleArray.contentToString(): String {
-    return java.util.Arrays.toString(this)
+    return this.contentToString()
 }
 
 /**
@@ -712,9 +1004,10 @@ public actual inline fun DoubleArray.contentToString(): String {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 @kotlin.internal.InlineOnly
 public actual inline fun BooleanArray.contentToString(): String {
-    return java.util.Arrays.toString(this)
+    return this.contentToString()
 }
 
 /**
@@ -723,8 +1016,117 @@ public actual inline fun BooleanArray.contentToString(): String {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 @kotlin.internal.InlineOnly
 public actual inline fun CharArray.contentToString(): String {
+    return this.contentToString()
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+@JvmName("contentToStringNullable")
+@kotlin.internal.InlineOnly
+public actual inline fun <T> Array<out T>?.contentToString(): String {
+    return java.util.Arrays.toString(this)
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+@JvmName("contentToStringNullable")
+@kotlin.internal.InlineOnly
+public actual inline fun ByteArray?.contentToString(): String {
+    return java.util.Arrays.toString(this)
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+@JvmName("contentToStringNullable")
+@kotlin.internal.InlineOnly
+public actual inline fun ShortArray?.contentToString(): String {
+    return java.util.Arrays.toString(this)
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+@JvmName("contentToStringNullable")
+@kotlin.internal.InlineOnly
+public actual inline fun IntArray?.contentToString(): String {
+    return java.util.Arrays.toString(this)
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+@JvmName("contentToStringNullable")
+@kotlin.internal.InlineOnly
+public actual inline fun LongArray?.contentToString(): String {
+    return java.util.Arrays.toString(this)
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+@JvmName("contentToStringNullable")
+@kotlin.internal.InlineOnly
+public actual inline fun FloatArray?.contentToString(): String {
+    return java.util.Arrays.toString(this)
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+@JvmName("contentToStringNullable")
+@kotlin.internal.InlineOnly
+public actual inline fun DoubleArray?.contentToString(): String {
+    return java.util.Arrays.toString(this)
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+@JvmName("contentToStringNullable")
+@kotlin.internal.InlineOnly
+public actual inline fun BooleanArray?.contentToString(): String {
+    return java.util.Arrays.toString(this)
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+@JvmName("contentToStringNullable")
+@kotlin.internal.InlineOnly
+public actual inline fun CharArray?.contentToString(): String {
     return java.util.Arrays.toString(this)
 }
 

--- a/libraries/stdlib/jvm/src/kotlin/collections/ArraysJVM.kt
+++ b/libraries/stdlib/jvm/src/kotlin/collections/ArraysJVM.kt
@@ -53,7 +53,7 @@ internal fun copyOfRangeToIndexCheck(toIndex: Int, size: Int) {
 @SinceKotlin("1.3")
 @PublishedApi
 @kotlin.jvm.JvmName("contentDeepHashCode")
-internal fun <T> Array<out T>.contentDeepHashCodeImpl(): Int =
+internal fun <T> Array<out T>?.contentDeepHashCodeImpl(): Int =
 // returns valid result for unsigned arrays by accident:
 // hash code of an inline class, which an unsigned array is,
 // is calculated structurally as in a data class

--- a/libraries/stdlib/jvm/test/PlatformNullTest.kt
+++ b/libraries/stdlib/jvm/test/PlatformNullTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package test.platformNull
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import java.util.Collections
+
+
+class PlatformNullTest {
+
+    @Suppress("HasPlatformType", "UNCHECKED_CAST")
+    fun <T> platformNull() = Collections.singletonList(null as T).first()
+
+    @Test
+    fun arrayContentEquals() {
+        assertTrue(platformNull<IntArray>() contentEquals null)
+        assertTrue(null contentEquals platformNull<LongArray>())
+
+        assertFalse(platformNull<Array<String>>() contentEquals emptyArray<String>())
+        assertFalse(arrayOf("a", "b") contentEquals platformNull<Array<String>>())
+
+        assertFalse(platformNull<UShortArray>() contentEquals ushortArrayOf())
+        assertFalse(ubyteArrayOf() contentEquals platformNull<UByteArray>())
+    }
+
+    @Test
+    fun arrayContentHashCode() {
+        assertEquals(0, platformNull<Array<Int>>().contentHashCode())
+        assertEquals(0, platformNull<CharArray>().contentHashCode())
+        assertEquals(0, platformNull<ShortArray>().contentHashCode())
+        assertEquals(0, platformNull<BooleanArray>().contentHashCode())
+        assertEquals(0, platformNull<UByteArray>().contentHashCode())
+        assertEquals(0, platformNull<UIntArray>().contentHashCode())
+    }
+
+    @Test
+    fun contentToString() {
+        assertEquals("null", platformNull<Array<String>>().contentToString())
+        assertEquals("null", platformNull<CharArray>().contentToString())
+        assertEquals("null", platformNull<DoubleArray>().contentToString())
+        assertEquals("null", platformNull<FloatArray>().contentToString())
+        assertEquals("null", platformNull<ULongArray>().contentToString())
+    }
+
+    @Test
+    fun arrayContentDeepEquals() {
+        assertFalse(platformNull<Array<String>>() contentDeepEquals emptyArray<String>())
+        assertFalse(arrayOf("a", "b") contentDeepEquals platformNull<Array<String>>())
+    }
+
+    @Test
+    fun arrayContentDeepHashCode() {
+        assertEquals(0, platformNull<Array<Int>>().contentDeepHashCode())
+    }
+
+    @Test
+    fun contentDeepToString() {
+        assertEquals("null", platformNull<Array<String>>().contentDeepToString())
+    }
+}

--- a/libraries/stdlib/jvm/test/collections/ArraysJVMTest.kt
+++ b/libraries/stdlib/jvm/test/collections/ArraysJVMTest.kt
@@ -3,7 +3,7 @@
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
-package test.platformNull
+package test.collections
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -12,13 +12,13 @@ import kotlin.test.assertTrue
 import java.util.Collections
 
 
-class PlatformNullTest {
+class ArraysJVMTest {
 
     @Suppress("HasPlatformType", "UNCHECKED_CAST")
     fun <T> platformNull() = Collections.singletonList(null as T).first()
 
     @Test
-    fun arrayContentEquals() {
+    fun contentEquals() {
         assertTrue(platformNull<IntArray>() contentEquals null)
         assertTrue(null contentEquals platformNull<LongArray>())
 
@@ -30,7 +30,7 @@ class PlatformNullTest {
     }
 
     @Test
-    fun arrayContentHashCode() {
+    fun contentHashCode() {
         assertEquals(0, platformNull<Array<Int>>().contentHashCode())
         assertEquals(0, platformNull<CharArray>().contentHashCode())
         assertEquals(0, platformNull<ShortArray>().contentHashCode())
@@ -49,13 +49,13 @@ class PlatformNullTest {
     }
 
     @Test
-    fun arrayContentDeepEquals() {
+    fun contentDeepEquals() {
         assertFalse(platformNull<Array<String>>() contentDeepEquals emptyArray<String>())
         assertFalse(arrayOf("a", "b") contentDeepEquals platformNull<Array<String>>())
     }
 
     @Test
-    fun arrayContentDeepHashCode() {
+    fun contentDeepHashCode() {
         assertEquals(0, platformNull<Array<Int>>().contentDeepHashCode())
     }
 

--- a/libraries/stdlib/src/kotlin/collections/Arrays.kt
+++ b/libraries/stdlib/src/kotlin/collections/Arrays.kt
@@ -72,9 +72,9 @@ public inline fun <C, R> C.ifEmpty(defaultValue: () -> R): R where C : Array<*>,
 @PublishedApi
 @kotlin.jvm.JvmName("contentDeepEquals")
 @kotlin.js.JsName("contentDeepEqualsImpl")
-internal fun <T> Array<out T>.contentDeepEqualsImpl(other: Array<out T>): Boolean {
+internal fun <T> Array<out T>?.contentDeepEqualsImpl(other: Array<out T>?): Boolean {
     if (this === other) return true
-    if (this.size != other.size) return false
+    if (this == null || other == null || this.size != other.size) return false
 
     for (i in indices) {
         val v1 = this[i]
@@ -113,7 +113,8 @@ internal fun <T> Array<out T>.contentDeepEqualsImpl(other: Array<out T>): Boolea
 @PublishedApi
 @kotlin.jvm.JvmName("contentDeepToString")
 @kotlin.js.JsName("contentDeepToStringImpl")
-internal fun <T> Array<out T>.contentDeepToStringImpl(): String {
+internal fun <T> Array<out T>?.contentDeepToStringImpl(): String {
+    if (this == null) return "null"
     val length = size.coerceAtMost((Int.MAX_VALUE - 2) / 5) * 5 + 2 // in order not to overflow Int.MAX_VALUE
     return buildString(length) {
         contentDeepToStringInternal(this, mutableListOf())

--- a/libraries/stdlib/test/collections/ArraysTest.kt
+++ b/libraries/stdlib/test/collections/ArraysTest.kt
@@ -220,6 +220,11 @@ class ArraysTest {
         checkArray(longArrayOf(1, 2, 3), { copyOf() }, { toList() }, { a1, a2 -> a1 contentEquals a2 }, { reverse() })
         checkArray(doubleArrayOf(Double.NaN, -0.0, 0.0, Double.POSITIVE_INFINITY, 1.0),
                    { copyOf() }, { toList() }, { a1, a2 -> a1 contentEquals a2 }, { this[1] = 0.0 })
+
+        assertTrue((null as BooleanArray?) contentEquals null)
+        assertFalse(null contentEquals shortArrayOf(1))
+        assertFalse((emptyArray<String>() as Array<String>?) contentEquals null)
+        assertFalse(null.contentEquals(arrayOf("0", null)))
     }
 
     @Test fun contentDeepEquals() {
@@ -245,6 +250,11 @@ class ArraysTest {
 
         arr5[0][0] = 0.0
         assertTrue(arr5 contentDeepEquals arr6)
+
+        assertTrue((null as Array<String>?) contentDeepEquals null)
+        assertTrue(null contentDeepEquals (null as Array<String>?))
+        assertFalse(arrayOf("") contentDeepEquals null)
+        assertFalse(null contentDeepEquals arrayOf<Any?>(null))
     }
 
     @Test fun contentToString() {
@@ -253,6 +263,8 @@ class ArraysTest {
         intArrayOf(1, 10, 42).let { arr -> assertEquals(arr.asList().toString(), arr.contentToString()) }
         longArrayOf(1L, 5L, Long.MAX_VALUE).let { arr -> assertEquals(arr.asList().toString(), arr.contentToString()) }
         doubleArrayOf(0.0, Double.MAX_VALUE, Double.POSITIVE_INFINITY, Double.NaN).let { arr -> assertEquals(arr.asList().toString(), arr.contentToString()) }
+
+        (null as ByteArray?).let { arr -> assertEquals(arr?.asList().toString(), arr.contentToString()) }
     }
 
     @Test fun contentDeepToString() {
@@ -263,6 +275,8 @@ class ArraysTest {
             doubleArrayOf(3.14), floatArrayOf(1.25f)
         )
         assertEquals("[aa, 1, null, [[foo]], [d], [false], [-1], [-1], [-1], [-1], [4294967295], [18446744073709551615], [65535], [255], [3.14], [1.25]]", arr.contentDeepToString())
+
+        assertEquals("null", (null as Array<Int>?).contentDeepToString())
     }
 
     @Test fun contentDeepToStringNoRecursion() {
@@ -290,6 +304,8 @@ class ArraysTest {
         charArrayOf('a', Char.MAX_VALUE, Char.MIN_VALUE).let { assertEquals(it.toList().hashCode(), it.contentHashCode()) }
         doubleArrayOf(1.0, -0.0, 0.0, Double.NaN, Double.POSITIVE_INFINITY).let { assertEquals(it.toList().hashCode(), it.contentHashCode()) }
         floatArrayOf(1.0f, -0.0f, 0.0f, Float.NaN, Float.POSITIVE_INFINITY).let { assertEquals(it.toList().hashCode(), it.contentHashCode()) }
+
+        (null as IntArray?).let { assertEquals(it?.toList().hashCode(), it.contentHashCode()) }
     }
 
     @Test fun contentDeepHashCode() {
@@ -310,6 +326,8 @@ class ArraysTest {
         val uintList2 = listOf(listOf(1u, 2u), listOf(3u, 4u))
 
         assertEquals(uintList2.hashCode(), uintArray2.contentDeepHashCode())
+
+        assertEquals(0, (null as Array<Any>?).contentDeepHashCode())
     }
 
 

--- a/libraries/stdlib/test/collections/UnsignedArraysTest.kt
+++ b/libraries/stdlib/test/collections/UnsignedArraysTest.kt
@@ -86,6 +86,8 @@ class UnsignedArraysTest {
         uintArrayOf(1u, UInt.MAX_VALUE, UInt.MIN_VALUE).let { assertEquals(it.toList().hashCode(), it.contentHashCode()) }
         ushortArrayOf(1u, UShort.MAX_VALUE, UShort.MIN_VALUE).let { assertEquals(it.toList().hashCode(), it.contentHashCode()) }
         ubyteArrayOf(1u, UByte.MAX_VALUE, UByte.MIN_VALUE).let { assertEquals(it.toList().hashCode(), it.contentHashCode()) }
+
+        (null as ULongArray?).let { assertEquals(it?.toList().hashCode(), it.contentHashCode()) }
     }
 
     @Test
@@ -94,6 +96,8 @@ class UnsignedArraysTest {
         uintArrayOf(1u, UInt.MAX_VALUE, UInt.MIN_VALUE).let { assertEquals(it.toList().toString(), it.contentToString()) }
         ushortArrayOf(1u, UShort.MAX_VALUE, UShort.MIN_VALUE).let { assertEquals(it.toList().toString(), it.contentToString()) }
         ubyteArrayOf(1u, UByte.MAX_VALUE, UByte.MIN_VALUE).let { assertEquals(it.toList().toString(), it.contentToString()) }
+
+        (null as UIntArray?).let { assertEquals(it?.toList().toString(), it.contentToString()) }
     }
 
     @Test
@@ -114,6 +118,10 @@ class UnsignedArraysTest {
             assertTrue(arr contentEquals UByteArray(arr.size, arr::get))
             assertFalse(arr contentEquals UByteArray(arr.size - 1, arr::get))
         }
+
+        assertTrue((null as UShortArray?) contentEquals null)
+        assertFalse(null contentEquals ubyteArrayOf(1u))
+        assertFalse(ulongArrayOf() contentEquals null)
     }
 
     @Test

--- a/libraries/tools/binary-compatibility-validator/reference-public-api/kotlin-stdlib-runtime-merged.txt
+++ b/libraries/tools/binary-compatibility-validator/reference-public-api/kotlin-stdlib-runtime-merged.txt
@@ -2439,18 +2439,30 @@ public final class kotlin/collections/unsigned/UArraysKt {
 	public static synthetic fun binarySearch-K6DWlUc$default ([JJIIILjava/lang/Object;)I
 	public static final fun binarySearch-WpHrYlw ([BBII)I
 	public static synthetic fun binarySearch-WpHrYlw$default ([BBIIILjava/lang/Object;)I
+	public static final fun contentEquals-FGO6Aew ([S[S)Z
+	public static final fun contentEquals-KJPZfPQ ([I[I)Z
 	public static final fun contentEquals-ctEhBpI ([I[I)Z
+	public static final fun contentEquals-kV0jMPg ([B[B)Z
 	public static final fun contentEquals-kdPth3s ([B[B)Z
+	public static final fun contentEquals-lec5QzE ([J[J)Z
 	public static final fun contentEquals-mazbYpA ([S[S)Z
 	public static final fun contentEquals-us8wMrg ([J[J)Z
 	public static final fun contentHashCode--ajY-9A ([I)I
+	public static final fun contentHashCode-2csIQuQ ([B)I
 	public static final fun contentHashCode-GBYM_sE ([B)I
 	public static final fun contentHashCode-QwZRm1k ([J)I
+	public static final fun contentHashCode-XUkPCBk ([I)I
+	public static final fun contentHashCode-d-6D3K8 ([S)I
 	public static final fun contentHashCode-rL5Bavg ([S)I
+	public static final fun contentHashCode-uLth9ew ([J)I
 	public static final fun contentToString--ajY-9A ([I)Ljava/lang/String;
+	public static final fun contentToString-2csIQuQ ([B)Ljava/lang/String;
 	public static final fun contentToString-GBYM_sE ([B)Ljava/lang/String;
 	public static final fun contentToString-QwZRm1k ([J)Ljava/lang/String;
+	public static final fun contentToString-XUkPCBk ([I)Ljava/lang/String;
+	public static final fun contentToString-d-6D3K8 ([S)Ljava/lang/String;
 	public static final fun contentToString-rL5Bavg ([S)Ljava/lang/String;
+	public static final fun contentToString-uLth9ew ([J)Ljava/lang/String;
 	public static final fun drop-PpDY95g ([BI)Ljava/util/List;
 	public static final fun drop-nggk6HY ([SI)Ljava/util/List;
 	public static final fun drop-qFRl0hI ([II)Ljava/util/List;

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/dsl/TypeParameterParsers.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/dsl/TypeParameterParsers.kt
@@ -33,8 +33,8 @@ fun parseTypeParameter(typeString: String): TypeParameter =
 
 fun parseTypeRef(typeRef: String): TypeRef =
     typeRef.trim().run {
-        if (contains('<') && endsWith('>')) {
-            val name = substringBefore('<')
+        if (contains('<') && (endsWith('>') || endsWith(">?"))) {
+            val name = substringBefore('<') + if (endsWith(">?")) "?" else ""
             val params = substringAfter('<').substringBeforeLast('>')
             TypeRef(name, parseArguments(params))
         }


### PR DESCRIPTION
From 26773dd9737363b24610c787c9b833a0158d4267 Mon Sep 17 00:00:00 2001
From: Jinseong Jeon <jsjeon@google.com>
Date: Tue, 3 Mar 2020 15:11:45 -0800
Subject: [PATCH] JVM: missed line number for return expression.

---
 .../kotlin/codegen/ExpressionCodegen.java     |  2 +-
 .../codegen/inline/inlineCodegenUtils.kt      | 17 +++++
 compiler/testData/debug/stepping/if.kt        |  4 +-
 compiler/testData/debug/stepping/smap.kt      | 63 +++++++++++++++++++
 .../IrSteppingTestGenerated.java              |  6 ++
 .../SteppingTestGenerated.java                |  6 ++
 6 files changed, 94 insertions(+), 4 deletions(-)
 create mode 100644 compiler/testData/debug/stepping/smap.kt

diff --git a/compiler/backend/src/org/jetbrains/kotlin/codegen/ExpressionCodegen.java b/compiler/backend/src/org/jetbrains/kotlin/codegen/ExpressionCodegen.java
index aa0651709eef..8d080f46f487 100644
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/ExpressionCodegen.java
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/ExpressionCodegen.java
@@ -1650,7 +1650,7 @@ public StackValue visitReturnExpression(@NotNull KtReturnExpression expression,
 
             Label afterReturnLabel = new Label();
             generateFinallyBlocksIfNeeded(returnType, returnKotlinType, afterReturnLabel);
-
+            markLineNumber(expression, false);
             if (isNonLocalReturn) {
                 generateGlobalReturnFlag(v, nonLocalReturn.labelName);
                 v.visitInsn(returnType.getOpcode(Opcodes.IRETURN));
diff --git a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/inlineCodegenUtils.kt b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/inlineCodegenUtils.kt
index a2aa442efd80..e3fa0a410eb7 100644
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/inlineCodegenUtils.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/inlineCodegenUtils.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.codegen.ASSERTIONS_DISABLED_FIELD_NAME
 import org.jetbrains.kotlin.codegen.AsmUtil
 import org.jetbrains.kotlin.codegen.BaseExpressionCodegen
 import org.jetbrains.kotlin.codegen.MemberCodegen
+import org.jetbrains.kotlin.codegen.TransformationMethodVisitor
 import org.jetbrains.kotlin.codegen.SamWrapperCodegen.SAM_WRAPPER_SUFFIX
 import org.jetbrains.kotlin.codegen.`when`.WhenByEnumsMapping
 import org.jetbrains.kotlin.codegen.binding.CodegenBinding
@@ -310,6 +311,22 @@ internal fun firstLabelInChain(node: LabelNode): LabelNode {
     return curNode
 }
 
+internal val MethodVisitor.bytecode: String?
+    get() {
+        var mv: MethodVisitor? = this
+        if (mv is TransformationMethodVisitor) {
+            mv = mv.traceMethodVisitorIfPossible
+        }
+        if (mv is TraceMethodVisitor) {
+            val sw = StringWriter()
+            val pw = PrintWriter(sw)
+            mv.p.print(pw)
+            pw.close()
+            return sw.toString()
+        }
+        return null
+    }
+
 internal val MethodNode?.nodeText: String
     get() {
         if (this == null) {
diff --git a/compiler/testData/debug/stepping/if.kt b/compiler/testData/debug/stepping/if.kt
index 1fdeb9c2de2d..a82f2377b3ca 100644
--- a/compiler/testData/debug/stepping/if.kt
+++ b/compiler/testData/debug/stepping/if.kt
@@ -13,9 +13,6 @@ inline fun getB(): Int {
     return 1
 }
 
-// IGNORE_BACKEND: JVM_IR
-// old backend is missing a line number after return from inline function call, actually IR backend results seems more right.
-
 // LINENUMBERS
 // TestKt.box():4
 // TestKt.box():13
@@ -24,3 +21,4 @@ inline fun getB(): Int {
 // TestKt.box():5
 // TestKt.box():7
 // TestKt.box():13
+// TestKt.box():7
diff --git a/compiler/testData/debug/stepping/smap.kt b/compiler/testData/debug/stepping/smap.kt
new file mode 100644
index 000000000000..47be0c56b9a0
--- /dev/null
+++ b/compiler/testData/debug/stepping/smap.kt
@@ -0,0 +1,63 @@
+
+// FILE: test.kt
+
+import builders.*
+
+inline fun test(): String {
+    var res = "Fail"
+
+    html {
+        head {
+            res = "OK"
+        }
+    }
+
+    return res
+}
+
+fun box(): String {
+    var expected = test();
+
+    return expected
+}
+
+// FILE: 1.kt
+
+package builders
+
+inline fun init(init: () -> Unit) {
+    init()
+}
+
+inline fun initTag2(init: () -> Unit) {
+    val p = 1;
+    init()
+}
+//{val p = initTag2(init); return p} to remove difference in linenumber processing through MethodNode and MethodVisitor should be: = initTag2(init)
+inline fun head(init: () -> Unit) { val p = initTag2(init); return p}
+
+
+inline fun html(init: () -> Unit) {
+    return init(init)
+}
+
+// LINENUMBERS
+// TestKt.box():19
+// TestKt.box():7
+// TestKt.box():9
+// TestKt.box():18
+// TestKt.box():6
+// TestKt.box():10
+// TestKt.box():14
+// TestKt.box():10
+// TestKt.box():11
+// TestKt.box():11
+// TestKt.box():12
+// TestKt.box():12
+// TestKt.box():14
+// TestKt.box():13
+// TestKt.box():7
+// TestKt.box():18
+// TestKt.box():15
+// TestKt.box():19
+// TestKt.box():21
\ No newline at end of file
diff --git a/compiler/tests/org/jetbrains/kotlin/codegen/debugInformation/IrSteppingTestGenerated.java b/compiler/tests/org/jetbrains/kotlin/codegen/debugInformation/IrSteppingTestGenerated.java
index c614deb883a0..6af4116d6a3f 100644
--- a/compiler/tests/org/jetbrains/kotlin/codegen/debugInformation/IrSteppingTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/debugInformation/IrSteppingTestGenerated.java
@@ -91,6 +91,12 @@ public void testRecursion() throws Exception {
         runTest("compiler/testData/debug/stepping/recursion.kt");
     }
 
+    @Test
+    @TestMetadata("smap.kt")
+    public void testSmap() throws Exception {
+        runTest("compiler/testData/debug/stepping/smap.kt");
+    }
+
     @Test
     @TestMetadata("throwException.kt")
     public void testThrowException() throws Exception {
diff --git a/compiler/tests/org/jetbrains/kotlin/codegen/debugInformation/SteppingTestGenerated.java b/compiler/tests/org/jetbrains/kotlin/codegen/debugInformation/SteppingTestGenerated.java
index 5ed1b0142395..74f07364761b 100644
--- a/compiler/tests/org/jetbrains/kotlin/codegen/debugInformation/SteppingTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/debugInformation/SteppingTestGenerated.java
@@ -91,6 +91,12 @@ public void testRecursion() throws Exception {
         runTest("compiler/testData/debug/stepping/recursion.kt");
     }
 
+    @Test
+    @TestMetadata("smap.kt")
+    public void testSmap() throws Exception {
+        runTest("compiler/testData/debug/stepping/smap.kt");
+    }
+
     @Test
     @TestMetadata("throwException.kt")
     public void testThrowException() throws Exception {