### PR TITLE
JVM IR: Respect toArray implementations coming from Java

### DIFF
--- a/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
@@ -26643,6 +26643,11 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
             runTest("compiler/testData/codegen/box/toArray/toArrayAlreadyPresent.kt");
         }
 
+        @TestMetadata("toArrayJava.kt")
+        public void testToArrayJava() throws Exception {
+            runTest("compiler/testData/codegen/box/toArray/toArrayJava.kt");
+        }
+
         @TestMetadata("toArrayShouldBePublic.kt")
         public void testToArrayShouldBePublic() throws Exception {
             runTest("compiler/testData/codegen/box/toArray/toArrayShouldBePublic.kt");

--- a/compiler/testData/codegen/box/toArray/toArrayJava.kt
+++ b/compiler/testData/codegen/box/toArray/toArrayJava.kt
@@ -1,0 +1,34 @@
+// TARGET_BACKEND: JVM
+// WITH_RUNTIME
+// FILE: J.java
+
+public class J extends java.util.AbstractCollection<String> {
+    private static java.util.List<String> underlying = java.util.Arrays.asList("FAIL");
+
+    public java.util.Iterator<String> iterator() {
+        return underlying.iterator();
+    }
+
+    public int size() {
+        return underlying.size();
+    }
+
+    public Object[] toArray() {
+        return new String[] { "O" };
+    }
+
+    public <T> T[] toArray(T[] a) {
+        return a;
+    }
+}
+
+// FILE: test.kt
+
+// K must not override toArray, since there is an existing implementation coming from Java with different
+// behavior than the default implementation.
+class K : J()
+
+fun box(): String {
+    val k = K() as java.util.Collection<String>
+    return (k.toArray()[0] as String) + (k.toArray<String>(arrayOf("K"))[0] as String)
+}

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -28159,6 +28159,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             runTest("compiler/testData/codegen/box/toArray/toArrayAlreadyPresent.kt");
         }
 
+        @TestMetadata("toArrayJava.kt")
+        public void testToArrayJava() throws Exception {
+            runTest("compiler/testData/codegen/box/toArray/toArrayJava.kt");
+        }
+
         @TestMetadata("toArrayShouldBePublic.kt")
         public void testToArrayShouldBePublic() throws Exception {
             runTest("compiler/testData/codegen/box/toArray/toArrayShouldBePublic.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -26976,6 +26976,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/toArray/toArrayAlreadyPresent.kt");
         }
 
+        @TestMetadata("toArrayJava.kt")
+        public void testToArrayJava() throws Exception {
+            runTest("compiler/testData/codegen/box/toArray/toArrayJava.kt");
+        }
+
         @TestMetadata("toArrayShouldBePublic.kt")
         public void testToArrayShouldBePublic() throws Exception {
             runTest("compiler/testData/codegen/box/toArray/toArrayShouldBePublic.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -26643,6 +26643,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             runTest("compiler/testData/codegen/box/toArray/toArrayAlreadyPresent.kt");
         }
 
+        @TestMetadata("toArrayJava.kt")
+        public void testToArrayJava() throws Exception {
+            runTest("compiler/testData/codegen/box/toArray/toArrayJava.kt");
+        }
+
         @TestMetadata("toArrayShouldBePublic.kt")
         public void testToArrayShouldBePublic() throws Exception {
             runTest("compiler/testData/codegen/box/toArray/toArrayShouldBePublic.kt");


### PR DESCRIPTION
The JVM IR backend currently ignores existing `toArray` implementations containing platform types, which can lead to potentially wrong behavior (see `testToArrayJava`).