### PR TITLE
JVM: Generate generic signatures for delegate fields

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/ImplementationBodyCodegen.java
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/ImplementationBodyCodegen.java
@@ -1176,7 +1176,7 @@ public class ImplementationBodyCodegen extends ClassBodyCodegen {
         if (!fieldInfo.generateField) return;
 
         v.newField(JvmDeclarationOrigin.NO_ORIGIN, ACC_PRIVATE | ACC_FINAL | ACC_SYNTHETIC,
-                   fieldInfo.name, fieldInfo.type.getDescriptor(), /*TODO*/null, null);
+                   fieldInfo.name, fieldInfo.type.getDescriptor(), fieldInfo.genericSignature, null);
     }
 
     private void generateDelegates(

--- a/compiler/testData/codegen/bytecodeListing/specialBridges/signatures/genericClass.txt
+++ b/compiler/testData/codegen/bytecodeListing/specialBridges/signatures/genericClass.txt
@@ -17,7 +17,7 @@ public abstract class<<K:Ljava/lang/Object;V:Ljava/lang/Object;>Ljava/lang/Objec
     public <null> method getSize(): int
     public <null> method isEmpty(): boolean
     public bridge final <null> method size(): int
-    private synthetic final field <null> $$delegate_0: java.util.HashMap
+    private synthetic final field <Ljava/util/HashMap<TK;TV;>;> $$delegate_0: java.util.HashMap
 }
 
 @kotlin.Metadata
@@ -39,5 +39,5 @@ public final class<<K:Ljava/lang/Object;V:Ljava/lang/Object;>Ljava/lang/Object;L
     public <null> method getSize(): int
     public <null> method isEmpty(): boolean
     public bridge final <null> method size(): int
-    private synthetic final field <null> $$delegate_0: java.util.HashMap
+    private synthetic final field <Ljava/util/HashMap<TK;TV;>;> $$delegate_0: java.util.HashMap
 }

--- a/compiler/testData/codegen/bytecodeListing/specialBridges/signatures/nonGenericClass.txt
+++ b/compiler/testData/codegen/bytecodeListing/specialBridges/signatures/nonGenericClass.txt
@@ -22,7 +22,7 @@ public abstract class<Ljava/lang/Object;Ljava/util/Map<Ljava/lang/String;Ljava/l
     public @org.jetbrains.annotations.Nullable <null> method remove(@org.jetbrains.annotations.NotNull p0: java.lang.String): java.lang.String
     public bridge final <null> method remove(p0: java.lang.Object): java.lang.Object
     public bridge final <null> method size(): int
-    private synthetic final field <null> $$delegate_0: java.util.HashMap
+    private synthetic final field <Ljava/util/HashMap<Ljava/lang/String;Ljava/lang/String;>;> $$delegate_0: java.util.HashMap
 }
 
 @kotlin.Metadata
@@ -49,5 +49,5 @@ public final class<Ljava/lang/Object;Ljava/util/Map<Ljava/lang/String;Ljava/lang
     public @org.jetbrains.annotations.Nullable <null> method remove(@org.jetbrains.annotations.NotNull p0: java.lang.String): java.lang.String
     public bridge final <null> method remove(p0: java.lang.Object): java.lang.Object
     public bridge final <null> method size(): int
-    private synthetic final field <null> $$delegate_0: java.util.HashMap
+    private synthetic final field <Ljava/util/HashMap<Ljava/lang/String;Ljava/lang/String;>;> $$delegate_0: java.util.HashMap
 }

--- a/compiler/testData/codegen/bytecodeListing/specialBridges/signatures/partiallySpecializedClass.txt
+++ b/compiler/testData/codegen/bytecodeListing/specialBridges/signatures/partiallySpecializedClass.txt
@@ -21,7 +21,7 @@ public abstract class<<V:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/Map<Lja
     public <null> method isEmpty(): boolean
     public synthetic bridge <null> method put(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
     public bridge final <null> method size(): int
-    private synthetic final field <null> $$delegate_0: java.util.HashMap
+    private synthetic final field <Ljava/util/HashMap<Ljava/lang/String;TV;>;> $$delegate_0: java.util.HashMap
 }
 
 @kotlin.Metadata
@@ -47,5 +47,5 @@ public final class<<V:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/Map<Ljava/
     public <null> method isEmpty(): boolean
     public synthetic bridge <null> method put(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
     public bridge final <null> method size(): int
-    private synthetic final field <null> $$delegate_0: java.util.HashMap
+    private synthetic final field <Ljava/util/HashMap<Ljava/lang/String;TV;>;> $$delegate_0: java.util.HashMap
 }


### PR DESCRIPTION
The JVM IR backend already generates generic signatures on `$$delegate_n` fields and this PR changes the JVM backend to do the same.

There was a TODO comment from 2014 for this, so this is probably not very pressing. :)