### PR TITLE
JVM IR: Generate fewer CHECKCAST instructions

### DIFF
--- a/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
@@ -10096,6 +10096,11 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
             runTest("compiler/testData/codegen/box/exclExcl/genericNull.kt");
         }
 
+        @TestMetadata("nullExclExcl.kt")
+        public void testNullExclExcl() throws Exception {
+            runTest("compiler/testData/codegen/box/exclExcl/nullExclExcl.kt");
+        }
+
         @TestMetadata("primitive.kt")
         public void testPrimitive() throws Exception {
             runTest("compiler/testData/codegen/box/exclExcl/primitive.kt");

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -166,11 +166,11 @@ class ExpressionCodegen(
     }
 
     // TODO remove
-    fun gen(expression: IrExpression, type: Type, irType: IrType, data: BlockInfo): StackValue {
+    fun gen(expression: IrExpression, type: Type, irType: IrType, data: BlockInfo, forceCast: Boolean = false): StackValue {
         if (expression.attributeOwnerId === context.fakeContinuation) {
             addFakeContinuationMarker(mv)
         } else {
-            expression.accept(this, data).materializeAt(type, irType)
+            expression.accept(this, data).materializeAt(type, irType, forceCast)
         }
         return StackValue.onStack(type, irType.toKotlinType())
     }
@@ -699,7 +699,7 @@ class ExpressionCodegen(
             if (!exhaustive) {
                 result.discard()
             } else {
-                val materializedResult = result.materializedAt(expression.type)
+                val materializedResult = result.materializedAt(expression.type, forceCast = true)
                 if (branch.condition.isTrueConst()) {
                     // The rest of the expression is dead code.
                     mv.mark(endLabel)

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/FunctionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/FunctionCodegen.kt
@@ -242,19 +242,17 @@ open class FunctionCodegen(
             ?.expression
     }
 
-    private fun IrFrameMap.enterDispatchReceiver(parameter: IrValueParameter) {
-        val type = classCodegen.typeMapper.mapTypeAsDeclaration(parameter.type)
-        enter(parameter, type)
-    }
-
     private fun createFrameMapWithReceivers(): IrFrameMap {
         val frameMap = IrFrameMap()
 
         if (irFunction is IrConstructor) {
-            frameMap.enterDispatchReceiver(irFunction.constructedClass.thisReceiver!!)
-        } else if (irFunction.dispatchReceiverParameter != null) {
-            frameMap.enterDispatchReceiver(irFunction.dispatchReceiverParameter!!)
+            irFunction.constructedClass.thisReceiver
+        } else {
+            irFunction.dispatchReceiverParameter
+        }?.let { dispatchReceiverParameter ->
+            frameMap.enter(dispatchReceiverParameter, classCodegen.typeMapper.mapTypeAsDeclaration(dispatchReceiverParameter.type))
         }
+
         irFunction.extensionReceiverParameter?.let {
             frameMap.enter(it, classCodegen.typeMapper.mapType(it))
         }

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/IrInlineCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/IrInlineCodegen.kt
@@ -124,7 +124,7 @@ class IrInlineCodegen(
                     // Do not reuse locals for receivers. While it's actually completely fine, the non-IR
                     // backend does not do it for internal reasons, and here we replicate the debugging
                     // experience.
-                -> codegen.gen(argumentExpression, parameterType, irValueParameter.type, blockInfo)
+                -> codegen.gen(argumentExpression, parameterType, irValueParameter.type, blockInfo, forceCast = true)
             }
 
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/UnsafeCoerce.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/UnsafeCoerce.kt
@@ -29,9 +29,9 @@ object UnsafeCoerce : IntrinsicMethod() {
         val arg = expression.getValueArgument(0)!!
         val result = arg.accept(codegen, data)
         return object : PromisedValue(codegen, toType, to) {
-            override fun materializeAt(target: Type, irTarget: IrType) {
+            override fun materializeAt(target: Type, irTarget: IrType, forceCast: Boolean) {
                 result.materializeAt(fromType, from)
-                super.materializeAt(target, irTarget)
+                super.materializeAt(target, irTarget, forceCast)
             }
 
             override fun discard() {

--- a/compiler/testData/codegen/box/exclExcl/nullExclExcl.kt
+++ b/compiler/testData/codegen/box/exclExcl/nullExclExcl.kt
@@ -1,0 +1,8 @@
+fun box(): String {
+    try {
+        null!!
+    } catch (e: Exception) {
+        return "OK"
+    }
+    return "Fail"
+}

--- a/compiler/testData/codegen/bytecodeText/boxedNotNumberTypeOnUnboxing.kt
+++ b/compiler/testData/codegen/bytecodeText/boxedNotNumberTypeOnUnboxing.kt
@@ -1,34 +1,34 @@
 fun test(p: Int?) {
     if (p != null) {
-        p.toByte() //intValue & I2B
-        p.toShort() //intValue & I2S
-        p.toInt() //intValue
-        p.toLong() //intValue & I2L
-        p.toFloat() //intValue & I2F
-        p.toDouble() //intValue & I2D
+        val b = p.toByte() //intValue & I2B
+        val s = p.toShort() //intValue & I2S
+        val i = p.toInt() //intValue
+        val l = p.toLong() //intValue & I2L
+        val f = p.toFloat() //intValue & I2F
+        val d = p.toDouble() //intValue & I2D
     }
 }
 
 fun test(p: Byte?) {
     if (p != null) {
-        p.toByte() //byteValue
-        p.toShort() //byteValue & I2S
-        p.toInt() //byteValue
-        p.toLong() //byteValue & I2L
-        p.toFloat() //byteValue & I2F
-        p.toDouble() //byteValue & I2D
+        val b = p.toByte() //byteValue
+        val s = p.toShort() //byteValue & I2S
+        val i = p.toInt() //byteValue
+        val l = p.toLong() //byteValue & I2L
+        val f = p.toFloat() //byteValue & I2F
+        val d = p.toDouble() //byteValue & I2D
     }
 }
 
 
 fun test(p: Char?) {
     if (p != null) {
-        p.toByte() //charValue & I2B
-        p.toShort() //charValue & I2S
-        p.toInt() //charValue
-        p.toLong() //charValue & I2L
-        p.toFloat() //charValue & I2F
-        p.toDouble() //charValue & I2D
+        val b = p.toByte() //charValue & I2B
+        val s = p.toShort() //charValue & I2S
+        val i = p.toInt() //charValue
+        val l = p.toLong() //charValue & I2L
+        val f = p.toFloat() //charValue & I2F
+        val d = p.toDouble() //charValue & I2D
     }
 }
 

--- a/compiler/testData/codegen/bytecodeText/enum/noCheckcastInClinit.kt
+++ b/compiler/testData/codegen/bytecodeText/enum/noCheckcastInClinit.kt
@@ -1,0 +1,21 @@
+enum class A {
+    ONE {
+        override fun toString(): String = "1"
+    },
+    TWO,
+    THREE {
+        override fun toString(): String = "3"
+    }
+}
+
+// There is always one CHECKCAST in the `valueOf` method, since this calls a library function which returns an `Enum`.
+// 1 CHECKCAST A
+
+// The JVM backend produces one additional CHECKCAST instruction in `values`
+// JVM_TEMPLATES:
+// 1 CHECKCAST \[LA;
+// 2 CHECKCAST
+
+// The JVM_IR backend does not use clone to copy the `$VALUES` array, so there is no CHECKCAST in `values`.
+// JVM_IR_TEMPLATES:
+// 1 CHECKCAST

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -11241,6 +11241,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             runTest("compiler/testData/codegen/box/exclExcl/genericNull.kt");
         }
 
+        @TestMetadata("nullExclExcl.kt")
+        public void testNullExclExcl() throws Exception {
+            runTest("compiler/testData/codegen/box/exclExcl/nullExclExcl.kt");
+        }
+
         @TestMetadata("primitive.kt")
         public void testPrimitive() throws Exception {
             runTest("compiler/testData/codegen/box/exclExcl/primitive.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
@@ -1806,6 +1806,11 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
         public void testKt18731_2() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/enum/kt18731_2.kt");
         }
+
+        @TestMetadata("noCheckcastInClinit.kt")
+        public void testNoCheckcastInClinit() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/enum/noCheckcastInClinit.kt");
+        }
     }
 
     @TestMetadata("compiler/testData/codegen/bytecodeText/exclExcl")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -11241,6 +11241,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/exclExcl/genericNull.kt");
         }
 
+        @TestMetadata("nullExclExcl.kt")
+        public void testNullExclExcl() throws Exception {
+            runTest("compiler/testData/codegen/box/exclExcl/nullExclExcl.kt");
+        }
+
         @TestMetadata("primitive.kt")
         public void testPrimitive() throws Exception {
             runTest("compiler/testData/codegen/box/exclExcl/primitive.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -10096,6 +10096,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             runTest("compiler/testData/codegen/box/exclExcl/genericNull.kt");
         }
 
+        @TestMetadata("nullExclExcl.kt")
+        public void testNullExclExcl() throws Exception {
+            runTest("compiler/testData/codegen/box/exclExcl/nullExclExcl.kt");
+        }
+
         @TestMetadata("primitive.kt")
         public void testPrimitive() throws Exception {
             runTest("compiler/testData/codegen/box/exclExcl/primitive.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
@@ -1761,6 +1761,11 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
         public void testKt18731_2() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/enum/kt18731_2.kt");
         }
+
+        @TestMetadata("noCheckcastInClinit.kt")
+        public void testNoCheckcastInClinit() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/enum/noCheckcastInClinit.kt");
+        }
     }
 
     @TestMetadata("compiler/testData/codegen/bytecodeText/exclExcl")

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -8636,6 +8636,11 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/exclExcl/genericNull.kt");
         }
 
+        @TestMetadata("nullExclExcl.kt")
+        public void testNullExclExcl() throws Exception {
+            runTest("compiler/testData/codegen/box/exclExcl/nullExclExcl.kt");
+        }
+
         @TestMetadata("primitive.kt")
         public void testPrimitive() throws Exception {
             runTest("compiler/testData/codegen/box/exclExcl/primitive.kt");

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -8636,6 +8636,11 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/exclExcl/genericNull.kt");
         }
 
+        @TestMetadata("nullExclExcl.kt")
+        public void testNullExclExcl() throws Exception {
+            runTest("compiler/testData/codegen/box/exclExcl/nullExclExcl.kt");
+        }
+
         @TestMetadata("primitive.kt")
         public void testPrimitive() throws Exception {
             runTest("compiler/testData/codegen/box/exclExcl/primitive.kt");


### PR DESCRIPTION
Plus some small codegen fixes. Generating redundant CHECKCAST instructions can end up confusing tools which look for specific bytecode patterns. That's what the `testNoCheckcastInClinit` is about.