### PR TITLE
JVM_IR: use fresh source map when generating lambda body for inline.

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/SMAP.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/SMAP.kt
@@ -171,6 +171,14 @@ object IdenticalSourceMapper : SourceMapper {
         get() = null
 
     override fun mapLineNumber(lineNumber: Int) = lineNumber
+
+    override fun mapLineNumber(source: Int, sourceName: String, sourcePath: String): Int {
+        throw UnsupportedOperationException(
+            "IdenticalSourceMapper#mapLineNumber($source, $sourceName, $sourcePath)\n"
+                    + "This mapper should not encounter a line number out of range of the current file.\n"
+                    + "This indicates that SMAP generation is missed somewhere."
+        )
+    }
 }
 
 class CallSiteMarker(val lineNumber: Int)

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ClassCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ClassCodegen.kt
@@ -343,7 +343,18 @@ open class ClassCodegen protected constructor(
     }
 
     fun createLocalClassCodegen(klass: IrClass, parentFunction: IrFunction): ClassCodegen =
-            ClassCodegen(klass, context, this, parentFunction, withinInline = withinInline || parentFunction.isInline)
+        ClassCodegen(klass, context, this, parentFunction, withinInline = withinInline || parentFunction.isInline)
+
+    fun createClassCodegenForLambdaBody(parentClass: IrClass, lambda: IrFunction): ClassCodegen =
+        object : ClassCodegen(parentClass, context, parentFunction = parentFunction, withinInline = withinInline) {
+            override fun createClassBuilder(): ClassBuilder {
+                return object : AbstractClassBuilder() {
+                    override fun getVisitor(): ClassVisitor {
+                        TODO("Expect to be _not_ reached")
+                    }
+                }
+            }
+        }
 
     private fun generateField(field: IrField) {
         if (field.origin == IrDeclarationOrigin.FAKE_OVERRIDE) return

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/IrSourceCompilerForInline.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/IrSourceCompilerForInline.kt
@@ -117,8 +117,10 @@ class IrSourceCompilerForInline(
         return SMAPAndMethodNode(node!!, SMAP(classCodegen.getOrCreateSourceMapper().resultMappings))
     }
 
-    override fun generateLambdaBody(lambdaInfo: ExpressionLambda): SMAPAndMethodNode =
-        makeInlineNode((lambdaInfo as IrExpressionLambdaImpl).function, codegen.classCodegen, true)
+    override fun generateLambdaBody(lambdaInfo: ExpressionLambda): SMAPAndMethodNode {
+        val function = (lambdaInfo as IrExpressionLambdaImpl).function
+        return makeInlineNode(function, codegen.classCodegen.createClassCodegenForLambdaBody(codegen.classCodegen.irClass, function), true)
+    }
 
     override fun doCreateMethodNodeFromSource(
         callableDescriptor: FunctionDescriptor,

--- a/compiler/testData/codegen/boxInline/smap/smap.kt
+++ b/compiler/testData/codegen/boxInline/smap/smap.kt
@@ -1,4 +1,4 @@
-// IGNORE_BACKEND_MULTI_MODULE: JVM_IR
+// This test depends on line numbers
 // FILE: 1.kt
 
 package builders

--- a/compiler/testData/codegen/bytecodeText/kt10259.kt
+++ b/compiler/testData/codegen/bytecodeText/kt10259.kt
@@ -17,18 +17,18 @@ inline fun test(s: () -> Unit) {
     s()
 }
 
+// 4 INNERCLASS
+
 // JVM_TEMPLATES
 // 2 INNERCLASS Kt10259Kt\$box\$\$inlined\$test\$lambda\$1\s
 // 2 INNERCLASS Kt10259Kt\$box\$\$inlined\$test\$lambda\$1\$1
-// 4 INNERCLASS
 
 // NB: JVM_IR generates 'INNERCLASS Kt10259Kt$box$1$1' in 'Kt10259Kt'.
 // Although Oracle JVM doesn't check for consistency of InnerClasses attributes,
 // this behavior is equivalent to javac and seems to be correct.
 
 // JVM_IR_TEMPLATES
-// 3 INNERCLASS Kt10259Kt\$box\$1\$1\s
+// 2 INNERCLASS Kt10259Kt\$box\$1\$1\s
 // 2 INNERCLASS Kt10259Kt\$box\$1\$1\$1
-// 5 INNERCLASS
 // 1 class Kt10259Kt\$box\$1\$1\ extends
 // 1 class Kt10259Kt\$box\$1\$1\$1 extends

--- a/compiler/testData/codegen/bytecodeText/kt10259_3.kt
+++ b/compiler/testData/codegen/bytecodeText/kt10259_3.kt
@@ -19,15 +19,16 @@ inline fun test(crossinline s: () -> Unit) {
     }()
 }
 
+// 2 INNERCLASS Kt10259_3Kt\$box\$\$inlined\$test\$1\s
+// 2 INNERCLASS Kt10259_3Kt\$box\$\$inlined\$test\$1\$1\s
+// 13 INNERCLASS
+
 // JVM_TEMPLATES
 // 3 INNERCLASS Kt10259_3Kt\$test\$1 null
 // 2 INNERCLASS Kt10259_3Kt\$test\$1\$1
-// 2 INNERCLASS Kt10259_3Kt\$box\$\$inlined\$test\$1\s
-// 2 INNERCLASS Kt10259_3Kt\$box\$\$inlined\$test\$1\$1\s
 // inlined:
 // 2 INNERCLASS Kt10259_3Kt\$box\$\$inlined\$test\$1\$1\$lambda\$1\s
 // 2 INNERCLASS Kt10259_3Kt\$box\$\$inlined\$test\$1\$1\$lambda\$1\$1\s
-// 13 INNERCLASS
 
 // NB JVM_IR generates
 //  final static INNERCLASS Kt10259_3Kt$box$1$1 null null
@@ -37,10 +38,7 @@ inline fun test(crossinline s: () -> Unit) {
 // this behavior is equivalent to javac and seems to be correct.
 
 // JVM_IR_TEMPLATES
-// 3 INNERCLASS Kt10259_3Kt\$box\$1\$1\s
+// 2 INNERCLASS Kt10259_3Kt\$box\$1\$1\s
 // 2 INNERCLASS Kt10259_3Kt\$box\$1\$1\$1\s
 // 3 INNERCLASS Kt10259_3Kt\$test\$1\s
 // 2 INNERCLASS Kt10259_3Kt\$test\$1\$1\s
-// 2 INNERCLASS Kt10259_3Kt\$box\$\$inlined\$test\$1\s
-// 2 INNERCLASS Kt10259_3Kt\$box\$\$inlined\$test\$1\$1\s
-// 14 INNERCLASS

--- a/compiler/testData/lineNumber/custom/inTheEndOfLambdaArgumentOfInlineCall.kt
+++ b/compiler/testData/lineNumber/custom/inTheEndOfLambdaArgumentOfInlineCall.kt
@@ -15,5 +15,5 @@ inline fun baz() {
 }
 
 fun nop() {}
-// IGNORE_BACKEND: JVM_IR
+
 // 2 20 21 3 4 25 26 5 27 6 9 10 11 14 15 17


### PR DESCRIPTION
Otherwise, file mappings in the source map would be accumulated, resulting in consistent shifting of line numbers (as shown at `smap.kt` test).