### PR TITLE
JVM IR: Mangle interface implementation methods in inline classes

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/inlineclasses/InlineClassAbi.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/inlineclasses/InlineClassAbi.kt
@@ -97,13 +97,13 @@ object InlineClassAbi {
     }
 }
 
-private val IrType.requiresMangling: Boolean
+internal val IrType.requiresMangling: Boolean
     get() {
         val irClass = erasedUpperBound
         return irClass.isInline && irClass.fqNameWhenAvailable != DescriptorUtils.RESULT_FQ_NAME
     }
 
-private val IrFunction.fullValueParameterList: List<IrValueParameter>
+internal val IrFunction.fullValueParameterList: List<IrValueParameter>
     get() = listOfNotNull(extensionReceiverParameter) + valueParameters
 
 internal val IrFunction.hasMangledParameters: Boolean

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/inlineclasses/MemoizedInlineClassReplacements.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/inlineclasses/MemoizedInlineClassReplacements.kt
@@ -124,7 +124,7 @@ class MemoizedInlineClassReplacements {
         }
     }
 
-    private fun createMethodReplacement(function: IrFunction): IrSimpleFunction =
+    internal fun createMethodReplacement(function: IrFunction): IrSimpleFunction =
         buildReplacement(function, function.origin) {
             require(function.dispatchReceiverParameter != null && function is IrSimpleFunction)
             val newValueParameters = ArrayList<IrValueParameter>()

--- a/compiler/testData/codegen/bytecodeText/inlineClasses/mangledInlineClassInterfaceImplementation.kt
+++ b/compiler/testData/codegen/bytecodeText/inlineClasses/mangledInlineClassInterfaceImplementation.kt
@@ -1,0 +1,18 @@
+// !LANGUAGE: +InlineClasses
+
+interface A<T> {
+    fun foo(a: T): String
+}
+
+inline class Foo(val x: Long) : A<Foo> {
+    override fun foo(a: Foo): String = if (x != a.x) "OK" else "FAIL"
+}
+
+fun box(): String {
+    return Foo(0L).foo(Foo(1L))
+}
+
+// 1 public foo-GWb7d6U\(J\)Ljava/lang/String;
+// 1 public synthetic bridge foo\(Ljava/lang/Object;\)Ljava/lang/String;
+// 1 public static foo-GWb7d6U\(JJ\)Ljava/lang/String;
+// 0 foo\(J

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
@@ -2800,6 +2800,11 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
             runTest("compiler/testData/codegen/bytecodeText/inlineClasses/isCheckForInlineClass.kt");
         }
 
+        @TestMetadata("mangledInlineClassInterfaceImplementation.kt")
+        public void testMangledInlineClassInterfaceImplementation() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/inlineClasses/mangledInlineClassInterfaceImplementation.kt");
+        }
+
         @TestMetadata("noActualCallsOfInlineFunctionsOfInlineClass.kt")
         public void testNoActualCallsOfInlineFunctionsOfInlineClass() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/inlineClasses/noActualCallsOfInlineFunctionsOfInlineClass.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
@@ -2845,6 +2845,11 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
             runTest("compiler/testData/codegen/bytecodeText/inlineClasses/isCheckForInlineClass.kt");
         }
 
+        @TestMetadata("mangledInlineClassInterfaceImplementation.kt")
+        public void testMangledInlineClassInterfaceImplementation() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/inlineClasses/mangledInlineClassInterfaceImplementation.kt");
+        }
+
         @TestMetadata("noActualCallsOfInlineFunctionsOfInlineClass.kt")
         public void testNoActualCallsOfInlineFunctionsOfInlineClass() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/inlineClasses/noActualCallsOfInlineFunctionsOfInlineClass.kt");


### PR DESCRIPTION
Fixes [KT-37024](https://youtrack.jetbrains.com/issue/KT-37024).