### PR TITLE
Add IrProviders to IrPluginContext

### DIFF
--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/extensions/IrGenerationExtension.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/extensions/IrGenerationExtension.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.extensions.ProjectExtensionDescriptor
 import org.jetbrains.kotlin.ir.builders.IrGeneratorContext
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import org.jetbrains.kotlin.ir.descriptors.IrBuiltIns
+import org.jetbrains.kotlin.ir.util.IrProvider
 import org.jetbrains.kotlin.ir.util.SymbolTable
 import org.jetbrains.kotlin.ir.util.TypeTranslator
 import org.jetbrains.kotlin.resolve.BindingContext
@@ -23,7 +24,8 @@ class IrPluginContext(
     val symbolTable: SymbolTable,
     val typeTranslator: TypeTranslator,
     override val irBuiltIns: IrBuiltIns,
-    val symbols: BuiltinSymbolsBase = BuiltinSymbolsBase(irBuiltIns.builtIns, symbolTable)
+    val symbols: BuiltinSymbolsBase = BuiltinSymbolsBase(irBuiltIns.builtIns, symbolTable),
+    val irProviders: List<IrProvider>
 ) : IrGeneratorContext()
 
 interface IrGenerationExtension {

--- a/compiler/ir/serialization.js/src/org/jetbrains/kotlin/ir/backend/js/klib.kt
+++ b/compiler/ir/serialization.js/src/org/jetbrains/kotlin/ir/backend/js/klib.kt
@@ -274,7 +274,8 @@ fun GeneratorContext.generateModuleFragmentWithPlugins(
                     languageVersionSettings,
                     symbolTable,
                     typeTranslator,
-                    irBuiltIns
+                    irBuiltIns,
+                    irProviders = irProviders
                 )
             )
         }


### PR DESCRIPTION
Needed to allow IR symbol binding in IR plugins after https://github.com/JetBrains/kotlin/commit/a2d8e2435fbd93e52ee047d8e0dbf61adf945dd9

This change becomes less necessary after https://youtrack.jetbrains.com/issue/KT-37255 gets fixed, but even after https://youtrack.jetbrains.com/issue/KT-37255, it seems likely that we will want to provide plugins with a way of binding symbols that were introduced by the plugin and thus not referenced when symbols were generated by Psi2Ir.

We are still in the process of rebasing, so I haven't yet been able to test this exact change (we tested a similar change applied against an older revision), but I think this gets us what we need here, and wanted to post it for your review.  We can merge now or wait until the rebase is completely done on our end.

cc @erokhins 