### PR TITLE
JVM_IR: place suspend markers in faux lambdas around inline references

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/CoroutineCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/CoroutineCodegen.kt
@@ -102,7 +102,6 @@ internal fun IrFunction.shouldContainSuspendMarkers(): Boolean = !isInvokeSuspen
         origin != JvmLoweredDeclarationOrigin.SYNTHETIC_ACCESSOR &&
         origin != JvmLoweredDeclarationOrigin.DEFAULT_IMPLS_BRIDGE &&
         origin != JvmLoweredDeclarationOrigin.DEFAULT_IMPLS_BRIDGE_TO_SYNTHETIC &&
-        origin != JvmLoweredDeclarationOrigin.GENERATED_MEMBER_IN_CALLABLE_REFERENCE &&
         origin != IrDeclarationOrigin.BRIDGE &&
         origin != IrDeclarationOrigin.BRIDGE_SPECIAL &&
         origin != IrDeclarationOrigin.DELEGATED_MEMBER &&

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/InlineCallableReferenceToLambda.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/InlineCallableReferenceToLambda.kt
@@ -12,7 +12,6 @@ import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.common.lower.irBlock
 import org.jetbrains.kotlin.backend.common.phaser.makeIrFilePhase
 import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
-import org.jetbrains.kotlin.backend.jvm.JvmLoweredDeclarationOrigin
 import org.jetbrains.kotlin.backend.jvm.ir.IrInlineReferenceLocator
 import org.jetbrains.kotlin.backend.jvm.ir.createJvmIrBuilder
 import org.jetbrains.kotlin.backend.jvm.ir.irArray
@@ -78,7 +77,7 @@ internal class InlineCallableReferenceToLambdaPhase(val context: JvmBackendConte
         return irBuilder.irBlock(expression, IrStatementOrigin.LAMBDA) {
             val function = buildFun {
                 setSourceRange(expression)
-                origin = JvmLoweredDeclarationOrigin.GENERATED_MEMBER_IN_CALLABLE_REFERENCE
+                origin = IrDeclarationOrigin.LOCAL_FUNCTION_FOR_LAMBDA
                 name = Name.identifier("stub_for_inline")
                 visibility = Visibilities.LOCAL
                 returnType = field.type
@@ -135,7 +134,7 @@ internal class InlineCallableReferenceToLambdaPhase(val context: JvmBackendConte
 
             val function = buildFun {
                 setSourceRange(expression)
-                origin = JvmLoweredDeclarationOrigin.GENERATED_MEMBER_IN_CALLABLE_REFERENCE
+                origin = IrDeclarationOrigin.LOCAL_FUNCTION_FOR_LAMBDA
                 name = Name.identifier("stub_for_inlining")
                 visibility = Visibilities.LOCAL
                 returnType = referencedFunction.returnType

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/TailCallOptimizationLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/TailCallOptimizationLowering.kt
@@ -46,7 +46,7 @@ private class TailCallOptimizationLowering(private val context: JvmBackendContex
         }, null)
     }
 
-    private fun IrExpression.coerceToUnit() = IrTypeOperatorCallImpl(
+    private fun IrExpression.coerceToUnit() = if (type == context.irBuiltIns.unitType) this else IrTypeOperatorCallImpl(
         startOffset, endOffset, context.irBuiltIns.unitType, IrTypeOperator.IMPLICIT_COERCION_TO_UNIT, context.irBuiltIns.unitType, this
     )
 }
@@ -75,7 +75,7 @@ private class TailCallOptimizationData(val function: IrSimpleFunction) {
     init {
         when (val body = function.body) {
             is IrBlockBody -> body.statements.findTailCall(returnsUnit)?.findCallsOnTailPositionWithoutImmediateReturn()
-            is IrExpressionBody -> body.expression.findCallsOnTailPositionWithoutImmediateReturn()
+            is IrExpressionBody -> body.expression.findCallsOnTailPositionWithoutImmediateReturn(immediateReturn = true)
         }
     }
 }

--- a/compiler/testData/codegen/boxInline/suspend/callableReference/nonTailCall.kt
+++ b/compiler/testData/codegen/boxInline/suspend/callableReference/nonTailCall.kt
@@ -1,0 +1,36 @@
+// WITH_RUNTIME
+// WITH_COROUTINES
+// NO_CHECK_LAMBDA_INLINING
+// FILE: 1.kt
+import kotlin.coroutines.intrinsics.*
+import kotlin.coroutines.*
+
+class Delayed(val run: suspend() -> Unit)
+
+inline fun asyncThenAddK(crossinline block: suspend () -> Unit) =
+    Delayed {
+        block()
+        result += "K"
+    }
+
+suspend fun pause(): Unit = suspendCoroutineUninterceptedOrReturn { cont ->
+    cont.resume(Unit)
+    COROUTINE_SUSPENDED
+}
+
+var result = ""
+
+suspend fun addO(): Unit {
+    pause()
+    result += "O"
+}
+
+// FILE: 2.kt
+import kotlin.coroutines.intrinsics.*
+import kotlin.coroutines.*
+import helpers.*
+
+fun box(): String {
+    suspend { asyncThenAddK(::addO).run() }.startCoroutine(EmptyContinuation)
+    return result
+}

--- a/compiler/testData/codegen/boxInline/suspend/callableReference/unitReturn.kt
+++ b/compiler/testData/codegen/boxInline/suspend/callableReference/unitReturn.kt
@@ -1,0 +1,33 @@
+// WITH_RUNTIME
+// WITH_COROUTINES
+// NO_CHECK_LAMBDA_INLINING
+// FILE: 1.kt
+import kotlin.coroutines.intrinsics.*
+import kotlin.coroutines.*
+
+class Delayed(val run: suspend() -> Unit)
+
+inline fun async(crossinline block: suspend () -> Unit) =
+    Delayed { block() }
+
+suspend fun pause(): Unit = suspendCoroutineUninterceptedOrReturn { cont ->
+    cont.resume(Unit)
+    COROUTINE_SUSPENDED
+}
+
+var result = ""
+
+suspend fun addOK(): Unit {
+    pause()
+    result += "OK"
+}
+
+// FILE: 2.kt
+import kotlin.coroutines.intrinsics.*
+import kotlin.coroutines.*
+import helpers.*
+
+fun box(): String {
+    suspend { async(::addOK).run() }.startCoroutine(EmptyContinuation)
+    return result
+}

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxInlineCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxInlineCodegenTestGenerated.java
@@ -3885,9 +3885,19 @@ public class BlackBoxInlineCodegenTestGenerated extends AbstractBlackBoxInlineCo
                 KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/boxInline/suspend/callableReference"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM, true);
             }
 
+            @TestMetadata("nonTailCall.kt")
+            public void testNonTailCall() throws Exception {
+                runTest("compiler/testData/codegen/boxInline/suspend/callableReference/nonTailCall.kt");
+            }
+
             @TestMetadata("simple.kt")
             public void testSimple() throws Exception {
                 runTest("compiler/testData/codegen/boxInline/suspend/callableReference/simple.kt");
+            }
+
+            @TestMetadata("unitReturn.kt")
+            public void testUnitReturn() throws Exception {
+                runTest("compiler/testData/codegen/boxInline/suspend/callableReference/unitReturn.kt");
             }
         }
 

--- a/compiler/tests/org/jetbrains/kotlin/codegen/CompileKotlinAgainstInlineKotlinTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/CompileKotlinAgainstInlineKotlinTestGenerated.java
@@ -3885,9 +3885,19 @@ public class CompileKotlinAgainstInlineKotlinTestGenerated extends AbstractCompi
                 KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/boxInline/suspend/callableReference"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM, true);
             }
 
+            @TestMetadata("nonTailCall.kt")
+            public void testNonTailCall() throws Exception {
+                runTest("compiler/testData/codegen/boxInline/suspend/callableReference/nonTailCall.kt");
+            }
+
             @TestMetadata("simple.kt")
             public void testSimple() throws Exception {
                 runTest("compiler/testData/codegen/boxInline/suspend/callableReference/simple.kt");
+            }
+
+            @TestMetadata("unitReturn.kt")
+            public void testUnitReturn() throws Exception {
+                runTest("compiler/testData/codegen/boxInline/suspend/callableReference/unitReturn.kt");
             }
         }
 

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxInlineCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxInlineCodegenTestGenerated.java
@@ -3780,9 +3780,19 @@ public class IrBlackBoxInlineCodegenTestGenerated extends AbstractIrBlackBoxInli
                 KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/boxInline/suspend/callableReference"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
             }
 
+            @TestMetadata("nonTailCall.kt")
+            public void testNonTailCall() throws Exception {
+                runTest("compiler/testData/codegen/boxInline/suspend/callableReference/nonTailCall.kt");
+            }
+
             @TestMetadata("simple.kt")
             public void testSimple() throws Exception {
                 runTest("compiler/testData/codegen/boxInline/suspend/callableReference/simple.kt");
+            }
+
+            @TestMetadata("unitReturn.kt")
+            public void testUnitReturn() throws Exception {
+                runTest("compiler/testData/codegen/boxInline/suspend/callableReference/unitReturn.kt");
             }
         }
 

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrCompileKotlinAgainstInlineKotlinTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrCompileKotlinAgainstInlineKotlinTestGenerated.java
@@ -3780,9 +3780,19 @@ public class IrCompileKotlinAgainstInlineKotlinTestGenerated extends AbstractIrC
                 KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/boxInline/suspend/callableReference"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
             }
 
+            @TestMetadata("nonTailCall.kt")
+            public void testNonTailCall() throws Exception {
+                runTest("compiler/testData/codegen/boxInline/suspend/callableReference/nonTailCall.kt");
+            }
+
             @TestMetadata("simple.kt")
             public void testSimple() throws Exception {
                 runTest("compiler/testData/codegen/boxInline/suspend/callableReference/simple.kt");
+            }
+
+            @TestMetadata("unitReturn.kt")
+            public void testUnitReturn() throws Exception {
+                runTest("compiler/testData/codegen/boxInline/suspend/callableReference/unitReturn.kt");
             }
         }
 

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenInlineTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenInlineTestGenerated.java
@@ -3355,9 +3355,19 @@ public class IrJsCodegenInlineTestGenerated extends AbstractIrJsCodegenInlineTes
                 KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/boxInline/suspend/callableReference"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR, true);
             }
 
+            @TestMetadata("nonTailCall.kt")
+            public void testNonTailCall() throws Exception {
+                runTest("compiler/testData/codegen/boxInline/suspend/callableReference/nonTailCall.kt");
+            }
+
             @TestMetadata("simple.kt")
             public void testSimple() throws Exception {
                 runTest("compiler/testData/codegen/boxInline/suspend/callableReference/simple.kt");
+            }
+
+            @TestMetadata("unitReturn.kt")
+            public void testUnitReturn() throws Exception {
+                runTest("compiler/testData/codegen/boxInline/suspend/callableReference/unitReturn.kt");
             }
         }
 

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenInlineTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenInlineTestGenerated.java
@@ -3355,9 +3355,19 @@ public class JsCodegenInlineTestGenerated extends AbstractJsCodegenInlineTest {
                 KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/boxInline/suspend/callableReference"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS, true);
             }
 
+            @TestMetadata("nonTailCall.kt")
+            public void testNonTailCall() throws Exception {
+                runTest("compiler/testData/codegen/boxInline/suspend/callableReference/nonTailCall.kt");
+            }
+
             @TestMetadata("simple.kt")
             public void testSimple() throws Exception {
                 runTest("compiler/testData/codegen/boxInline/suspend/callableReference/simple.kt");
+            }
+
+            @TestMetadata("unitReturn.kt")
+            public void testUnitReturn() throws Exception {
+                runTest("compiler/testData/codegen/boxInline/suspend/callableReference/unitReturn.kt");
             }
         }
 


### PR DESCRIPTION
Otherwise, the assumption that coroutine codegen makes about every inlined function already having the markers breaks and it is no longer true that calls to inline lambdas do not require them.