### PR TITLE
KT-29969 Making var arg kParameters default to empty array no argument given

### DIFF
--- a/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
@@ -22515,6 +22515,11 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
                 runTest("compiler/testData/codegen/box/reflection/callBy/defaultInSuperInterface.kt");
             }
 
+            @TestMetadata("emptyVarArg.kt")
+            public void testEmptyVarArg() throws Exception {
+                runTest("compiler/testData/codegen/box/reflection/callBy/emptyVarArg.kt");
+            }
+
             @TestMetadata("extensionFunction.kt")
             public void testExtensionFunction() throws Exception {
                 runTest("compiler/testData/codegen/box/reflection/callBy/extensionFunction.kt");

--- a/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
@@ -22520,6 +22520,11 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
                 runTest("compiler/testData/codegen/box/reflection/callBy/emptyVarArg.kt");
             }
 
+            @TestMetadata("emptyVarArgAnnotationConstructor.kt")
+            public void testEmptyVarArgAnnotationConstructor() throws Exception {
+                runTest("compiler/testData/codegen/box/reflection/callBy/emptyVarArgAnnotationConstructor.kt");
+            }
+
             @TestMetadata("extensionFunction.kt")
             public void testExtensionFunction() throws Exception {
                 runTest("compiler/testData/codegen/box/reflection/callBy/extensionFunction.kt");

--- a/compiler/testData/codegen/box/reflection/callBy/emptyVarArg.kt
+++ b/compiler/testData/codegen/box/reflection/callBy/emptyVarArg.kt
@@ -1,0 +1,15 @@
+// IGNORE_BACKEND_FIR: JVM_IR
+// IGNORE_BACKEND: JS_IR
+// IGNORE_BACKEND: JS, NATIVE
+
+// WITH_REFLECT
+
+import kotlin.test.assertEquals
+
+fun join(vararg strings: String) = strings.toList().joinToString("")
+
+fun box(): String {
+    val f = ::join
+    assertEquals("", f.callBy(emptyMap()))
+    return "OK"
+}

--- a/compiler/testData/codegen/box/reflection/callBy/emptyVarArg.kt
+++ b/compiler/testData/codegen/box/reflection/callBy/emptyVarArg.kt
@@ -8,8 +8,12 @@ import kotlin.test.assertEquals
 
 fun join(vararg strings: String) = strings.toList().joinToString("")
 
+fun sum(vararg bytes: Byte) = bytes.toList().fold(0) { acc, el -> acc + el }
+
 fun box(): String {
-    val f = ::join
-    assertEquals("", f.callBy(emptyMap()))
+    val j = ::join
+    val s = ::sum
+    assertEquals("", j.callBy(emptyMap()))
+    assertEquals(0, s.callBy(emptyMap()))
     return "OK"
 }

--- a/compiler/testData/codegen/box/reflection/callBy/emptyVarArgAnnotationConstructor.kt
+++ b/compiler/testData/codegen/box/reflection/callBy/emptyVarArgAnnotationConstructor.kt
@@ -1,0 +1,18 @@
+// IGNORE_BACKEND_FIR: JVM_IR
+// IGNORE_BACKEND: JS_IR
+// IGNORE_BACKEND: JS, NATIVE
+
+// WITH_REFLECT
+
+import kotlin.reflect.*
+import kotlin.reflect.full.*
+import kotlin.test.assert
+
+annotation class Foo(vararg val strings: String)
+
+fun box(): String {
+    val constructor = Foo::class.primaryConstructor!!
+    val annotation = constructor.callBy(emptyMap())
+    assert(annotation.strings.isEmpty())
+    return "OK"
+}

--- a/compiler/testData/codegen/box/reflection/callBy/emptyVarArgAnnotationConstructor.kt
+++ b/compiler/testData/codegen/box/reflection/callBy/emptyVarArgAnnotationConstructor.kt
@@ -10,9 +10,16 @@ import kotlin.test.assert
 
 annotation class Foo(vararg val strings: String)
 
+annotation class Bar(vararg val bytes: Byte)
+
 fun box(): String {
-    val constructor = Foo::class.primaryConstructor!!
-    val annotation = constructor.callBy(emptyMap())
-    assert(annotation.strings.isEmpty())
+    val fooConstructor = Foo::class.primaryConstructor!!
+    val foo = fooConstructor.callBy(emptyMap())
+    assert(foo.strings.isEmpty())
+
+    val barConstructor = Bar::class.primaryConstructor!!
+    val bar = barConstructor.callBy(emptyMap())
+    assert(bar.bytes.isEmpty())
+
     return "OK"
 }

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -24036,6 +24036,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
                 runTest("compiler/testData/codegen/box/reflection/callBy/emptyVarArg.kt");
             }
 
+            @TestMetadata("emptyVarArgAnnotationConstructor.kt")
+            public void testEmptyVarArgAnnotationConstructor() throws Exception {
+                runTest("compiler/testData/codegen/box/reflection/callBy/emptyVarArgAnnotationConstructor.kt");
+            }
+
             @TestMetadata("extensionFunction.kt")
             public void testExtensionFunction() throws Exception {
                 runTest("compiler/testData/codegen/box/reflection/callBy/extensionFunction.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -24031,6 +24031,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
                 runTest("compiler/testData/codegen/box/reflection/callBy/defaultInSuperInterface.kt");
             }
 
+            @TestMetadata("emptyVarArg.kt")
+            public void testEmptyVarArg() throws Exception {
+                runTest("compiler/testData/codegen/box/reflection/callBy/emptyVarArg.kt");
+            }
+
             @TestMetadata("extensionFunction.kt")
             public void testExtensionFunction() throws Exception {
                 runTest("compiler/testData/codegen/box/reflection/callBy/extensionFunction.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -22848,6 +22848,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
                 runTest("compiler/testData/codegen/box/reflection/callBy/defaultInSuperInterface.kt");
             }
 
+            @TestMetadata("emptyVarArg.kt")
+            public void testEmptyVarArg() throws Exception {
+                runTest("compiler/testData/codegen/box/reflection/callBy/emptyVarArg.kt");
+            }
+
             @TestMetadata("extensionFunction.kt")
             public void testExtensionFunction() throws Exception {
                 runTest("compiler/testData/codegen/box/reflection/callBy/extensionFunction.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -22853,6 +22853,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
                 runTest("compiler/testData/codegen/box/reflection/callBy/emptyVarArg.kt");
             }
 
+            @TestMetadata("emptyVarArgAnnotationConstructor.kt")
+            public void testEmptyVarArgAnnotationConstructor() throws Exception {
+                runTest("compiler/testData/codegen/box/reflection/callBy/emptyVarArgAnnotationConstructor.kt");
+            }
+
             @TestMetadata("extensionFunction.kt")
             public void testExtensionFunction() throws Exception {
                 runTest("compiler/testData/codegen/box/reflection/callBy/extensionFunction.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -22520,6 +22520,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
                 runTest("compiler/testData/codegen/box/reflection/callBy/emptyVarArg.kt");
             }
 
+            @TestMetadata("emptyVarArgAnnotationConstructor.kt")
+            public void testEmptyVarArgAnnotationConstructor() throws Exception {
+                runTest("compiler/testData/codegen/box/reflection/callBy/emptyVarArgAnnotationConstructor.kt");
+            }
+
             @TestMetadata("extensionFunction.kt")
             public void testExtensionFunction() throws Exception {
                 runTest("compiler/testData/codegen/box/reflection/callBy/extensionFunction.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -22515,6 +22515,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
                 runTest("compiler/testData/codegen/box/reflection/callBy/defaultInSuperInterface.kt");
             }
 
+            @TestMetadata("emptyVarArg.kt")
+            public void testEmptyVarArg() throws Exception {
+                runTest("compiler/testData/codegen/box/reflection/callBy/emptyVarArg.kt");
+            }
+
             @TestMetadata("extensionFunction.kt")
             public void testExtensionFunction() throws Exception {
                 runTest("compiler/testData/codegen/box/reflection/callBy/extensionFunction.kt");

--- a/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KCallableImpl.kt
+++ b/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KCallableImpl.kt
@@ -135,7 +135,7 @@ internal abstract class KCallableImpl<out R> : KCallable<R> {
                     anyOptional = true
                 }
                 parameter.isVararg -> {
-                    arguments.add(emptyArray<Any>())
+                    arguments.add(parameter.type.asArrayType()?.emptyArray())
                 }
                 else -> {
                     throw IllegalArgumentException("No argument provided for a required parameter: $parameter")
@@ -177,7 +177,7 @@ internal abstract class KCallableImpl<out R> : KCallable<R> {
                     args[parameter] ?: throw IllegalArgumentException("Annotation argument value cannot be null ($parameter)")
                 }
                 parameter.isOptional -> null
-                parameter.isVararg -> emptyArray<Any>()
+                parameter.isVararg -> parameter.type.asArrayType()?.emptyArray()
                 else -> throw IllegalArgumentException("No argument provided for a required parameter: $parameter")
             }
         }

--- a/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KCallableImpl.kt
+++ b/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KCallableImpl.kt
@@ -134,6 +134,9 @@ internal abstract class KCallableImpl<out R> : KCallable<R> {
                     mask = mask or (1 shl (index % Integer.SIZE))
                     anyOptional = true
                 }
+                parameter.isVararg -> {
+                    arguments.add(emptyArray<Any>())
+                }
                 else -> {
                     throw IllegalArgumentException("No argument provided for a required parameter: $parameter")
                 }
@@ -174,6 +177,7 @@ internal abstract class KCallableImpl<out R> : KCallable<R> {
                     args[parameter] ?: throw IllegalArgumentException("Annotation argument value cannot be null ($parameter)")
                 }
                 parameter.isOptional -> null
+                parameter.isVararg -> emptyArray<Any>()
                 else -> throw IllegalArgumentException("No argument provided for a required parameter: $parameter")
             }
         }

--- a/core/reflection.jvm/src/kotlin/reflect/jvm/internal/util.kt
+++ b/core/reflection.jvm/src/kotlin/reflect/jvm/internal/util.kt
@@ -36,12 +36,9 @@ import org.jetbrains.kotlin.serialization.deserialization.DeserializationContext
 import org.jetbrains.kotlin.serialization.deserialization.MemberDeserializer
 import kotlin.jvm.internal.FunctionReference
 import kotlin.jvm.internal.PropertyReference
-import kotlin.reflect.KClass
-import kotlin.reflect.KType
 import kotlin.reflect.KVisibility
 import kotlin.reflect.full.IllegalCallableAccessException
 import kotlin.reflect.jvm.internal.calls.createAnnotationInstance
-import kotlin.reflect.jvm.jvmErasure
 import org.jetbrains.kotlin.descriptors.runtime.components.ReflectAnnotationSource
 import org.jetbrains.kotlin.descriptors.runtime.components.ReflectKotlinClass
 import org.jetbrains.kotlin.descriptors.runtime.components.RuntimeSourceElementFactory
@@ -49,7 +46,6 @@ import org.jetbrains.kotlin.descriptors.runtime.components.tryLoadClass
 import org.jetbrains.kotlin.descriptors.runtime.structure.ReflectJavaAnnotation
 import org.jetbrains.kotlin.descriptors.runtime.structure.ReflectJavaClass
 import org.jetbrains.kotlin.descriptors.runtime.structure.safeClassLoader
-import java.lang.reflect.Array as ReflectArray
 
 internal val JVM_STATIC = FqName("kotlin.jvm.JvmStatic")
 
@@ -199,10 +195,3 @@ internal fun <M : MessageLite, D : CallableDescriptor> deserializeToDescriptor(
     )
     return MemberDeserializer(context).createDescriptor(proto)
 }
-
-@Suppress("UNCHECKED_CAST")
-internal fun KType.asArrayType(): KClass<Array<*>>? = jvmErasure
-    .takeIf { it.java.isArray }
-    ?.let { it as KClass<Array<*>> }
-
-internal fun KClass<Array<*>>.emptyArray() = ReflectArray.newInstance(java.componentType, 0)

--- a/core/reflection.jvm/src/kotlin/reflect/jvm/internal/util.kt
+++ b/core/reflection.jvm/src/kotlin/reflect/jvm/internal/util.kt
@@ -36,9 +36,12 @@ import org.jetbrains.kotlin.serialization.deserialization.DeserializationContext
 import org.jetbrains.kotlin.serialization.deserialization.MemberDeserializer
 import kotlin.jvm.internal.FunctionReference
 import kotlin.jvm.internal.PropertyReference
+import kotlin.reflect.KClass
+import kotlin.reflect.KType
 import kotlin.reflect.KVisibility
 import kotlin.reflect.full.IllegalCallableAccessException
 import kotlin.reflect.jvm.internal.calls.createAnnotationInstance
+import kotlin.reflect.jvm.jvmErasure
 import org.jetbrains.kotlin.descriptors.runtime.components.ReflectAnnotationSource
 import org.jetbrains.kotlin.descriptors.runtime.components.ReflectKotlinClass
 import org.jetbrains.kotlin.descriptors.runtime.components.RuntimeSourceElementFactory
@@ -46,6 +49,7 @@ import org.jetbrains.kotlin.descriptors.runtime.components.tryLoadClass
 import org.jetbrains.kotlin.descriptors.runtime.structure.ReflectJavaAnnotation
 import org.jetbrains.kotlin.descriptors.runtime.structure.ReflectJavaClass
 import org.jetbrains.kotlin.descriptors.runtime.structure.safeClassLoader
+import java.lang.reflect.Array as ReflectArray
 
 internal val JVM_STATIC = FqName("kotlin.jvm.JvmStatic")
 
@@ -195,3 +199,10 @@ internal fun <M : MessageLite, D : CallableDescriptor> deserializeToDescriptor(
     )
     return MemberDeserializer(context).createDescriptor(proto)
 }
+
+@Suppress("UNCHECKED_CAST")
+internal fun KType.asArrayType(): KClass<Array<*>>? = jvmErasure
+    .takeIf { it.java.isArray }
+    ?.let { it as KClass<Array<*>> }
+
+internal fun KClass<Array<*>>.emptyArray() = ReflectArray.newInstance(java.componentType, 0)

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -19116,6 +19116,11 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
                 runTest("compiler/testData/codegen/box/reflection/callBy/emptyVarArg.kt");
             }
 
+            @TestMetadata("emptyVarArgAnnotationConstructor.kt")
+            public void testEmptyVarArgAnnotationConstructor() throws Exception {
+                runTest("compiler/testData/codegen/box/reflection/callBy/emptyVarArgAnnotationConstructor.kt");
+            }
+
             @TestMetadata("extensionFunction.kt")
             public void testExtensionFunction() throws Exception {
                 runTest("compiler/testData/codegen/box/reflection/callBy/extensionFunction.kt");

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -19111,6 +19111,11 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
                 runTest("compiler/testData/codegen/box/reflection/callBy/defaultInSuperInterface.kt");
             }
 
+            @TestMetadata("emptyVarArg.kt")
+            public void testEmptyVarArg() throws Exception {
+                runTest("compiler/testData/codegen/box/reflection/callBy/emptyVarArg.kt");
+            }
+
             @TestMetadata("extensionFunction.kt")
             public void testExtensionFunction() throws Exception {
                 runTest("compiler/testData/codegen/box/reflection/callBy/extensionFunction.kt");

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -19171,6 +19171,11 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
                 runTest("compiler/testData/codegen/box/reflection/callBy/defaultInSuperInterface.kt");
             }
 
+            @TestMetadata("emptyVarArg.kt")
+            public void testEmptyVarArg() throws Exception {
+                runTest("compiler/testData/codegen/box/reflection/callBy/emptyVarArg.kt");
+            }
+
             @TestMetadata("extensionFunction.kt")
             public void testExtensionFunction() throws Exception {
                 runTest("compiler/testData/codegen/box/reflection/callBy/extensionFunction.kt");

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -19176,6 +19176,11 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
                 runTest("compiler/testData/codegen/box/reflection/callBy/emptyVarArg.kt");
             }
 
+            @TestMetadata("emptyVarArgAnnotationConstructor.kt")
+            public void testEmptyVarArgAnnotationConstructor() throws Exception {
+                runTest("compiler/testData/codegen/box/reflection/callBy/emptyVarArgAnnotationConstructor.kt");
+            }
+
             @TestMetadata("extensionFunction.kt")
             public void testExtensionFunction() throws Exception {
                 runTest("compiler/testData/codegen/box/reflection/callBy/extensionFunction.kt");


### PR DESCRIPTION
Fixes: [KT-29969](https://youtrack.jetbrains.com/issue/KT-29969)

`KCallable.callBy` did not allow for empty `vararg` parameters

