### PR TITLE
KT-37288 Add toBigInteger overloads for Byte/Short

### DIFF
--- a/libraries/stdlib/jvm/src/kotlin/util/BigIntegers.kt
+++ b/libraries/stdlib/jvm/src/kotlin/util/BigIntegers.kt
@@ -93,6 +93,19 @@ public inline infix fun BigInteger.shl(n: Int): BigInteger = this.shiftLeft(n)
 @kotlin.internal.InlineOnly
 public inline infix fun BigInteger.shr(n: Int): BigInteger = this.shiftRight(n)
 
+/**
+ * Returns the value of this [Byte] number as a [BigInteger].
+ */
+@SinceKotlin("1.3")
+@kotlin.internal.InlineOnly
+public inline fun Byte.toBigInteger(): BigInteger = BigInteger.valueOf(this.toLong())
+
+/**
+ * Returns the value of this [Short] number as a [BigInteger].
+ */
+@SinceKotlin("1.3")
+@kotlin.internal.InlineOnly
+public inline fun Short.toBigInteger(): BigInteger = BigInteger.valueOf(this.toLong())
 
 /**
  * Returns the value of this [Int] number as a [BigInteger].

--- a/libraries/stdlib/jvm/test/numbers/BigNumbersTest.kt
+++ b/libraries/stdlib/jvm/test/numbers/BigNumbersTest.kt
@@ -39,6 +39,8 @@ class BigNumbersTest {
         assertEquals(BigInteger("-1"), -a shr 1)
         assertEquals(BigInteger("-1"), -a shr 2)
 
+        assertEquals(BigInteger("5"), 5.toByte().toBigInteger())
+        assertEquals(BigInteger("7"), 7.toShort().toBigInteger())
         assertEquals(BigInteger("2"), 2.toBigInteger())
         assertEquals(BigInteger("-3"), -3L.toBigInteger())
 


### PR DESCRIPTION
Implementation of [KT-37288](https://youtrack.jetbrains.com/issue/KT-37288).

Adds the following overloads to BigIntegers.kt:
```kotlin
/**
 * Returns the value of this [Byte] number as a [BigInteger].
 */
@SinceKotlin("1.3")
@kotlin.internal.InlineOnly
public inline fun Byte.toBigInteger(): BigInteger = BigInteger.valueOf(this.toLong())

/**
 * Returns the value of this [Short] number as a [BigInteger].
 */
@SinceKotlin("1.3")
@kotlin.internal.InlineOnly
public inline fun Short.toBigInteger(): BigInteger = BigInteger.valueOf(this.toLong())
```

This is my first PR to Kotlin, so please let me know if I haven't followed the proper process.