### PR TITLE
KT-37240 Deterministic order for webpack config patches

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/utils.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/utils.kt
@@ -8,12 +8,13 @@ package org.jetbrains.kotlin.gradle.targets.js
 import java.io.File
 
 fun Appendable.appendConfigsFromDir(confDir: File) {
-    if (!confDir.isDirectory) return
+    val files = confDir.listFiles() ?: return
 
-    confDir.listFiles()
-        ?.toList()
-        ?.filter { it.name.endsWith(".js") }
-        ?.forEach {
+    files.asSequence()
+        .filter { it.isFile }
+        .filter { it.name.endsWith(".js") }
+        .sortedBy { it.name }
+        .forEach {
             appendln("// ${it.name}")
             append(it.readText())
             appendln()

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/utils.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/utils.kt
@@ -12,7 +12,7 @@ fun Appendable.appendConfigsFromDir(confDir: File) {
 
     files.asSequence()
         .filter { it.isFile }
-        .filter { it.name.endsWith(".js") }
+        .filter { it.extension == "js" }
         .sortedBy { it.name }
         .forEach {
             appendln("// ${it.name}")


### PR DESCRIPTION
Additional fix - only files with `js` extension processed (directories excluded)

`listFiles()` already contains 'is directory' check. Duplicated check removed