### PR TITLE
Do fewer unnecessary anonymous object regenerations

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInliner.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInliner.kt
@@ -859,7 +859,7 @@ class MethodInliner(
         needReification: Boolean,
         capturesAnonymousObjectThatMustBeRegenerated: Boolean
     ): AnonymousObjectTransformationInfo {
-        // In objects inside non-default lambdas, all reified type parameters are free (not from the function
+        // In objects inside non-default inline lambdas, all reified type parameters are free (not from the function
         // we're inlining into) so there's nothing to reify:
         //
         //     inline fun <reified T> f(x: () -> KClass<T> = { { T::class }() }) = x()
@@ -867,8 +867,8 @@ class MethodInliner(
         //     fun b() = f<Int> { { Int::class }() } // non-default lambda
         //     inline fun <reified V> c() = f<V> { { V::class }() }
         //
-        // -- in a(), the default lambda captures T so a regeneration is needed; but in b() and c(), the non-default
-        // lambda cannot possibly reference it, while V is not yet bound so regenerating the object while inlining
+        // -- in a(), the default inline lambda captures T so a regeneration is needed; but in b() and c(), the non-default
+        // inline lambda cannot possibly reference it, while V is not yet bound so regenerating the object while inlining
         // the lambda into f() is pointless.
         val inNonDefaultLambda = inliningContext.isInliningLambda && inliningContext.lambdaInfo !is DefaultLambda
         val info = AnonymousObjectTransformationInfo(

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInliner.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInliner.kt
@@ -859,9 +859,20 @@ class MethodInliner(
         needReification: Boolean,
         capturesAnonymousObjectThatMustBeRegenerated: Boolean
     ): AnonymousObjectTransformationInfo {
-
+        // In objects inside non-default lambdas, all reified type parameters are free (not from the function
+        // we're inlining into) so there's nothing to reify:
+        //
+        //     inline fun <reified T> f(x: () -> KClass<T> = { { T::class }() }) = x()
+        //     fun a() = f<Int>()
+        //     fun b() = f<Int> { { Int::class }() } // non-default lambda
+        //     inline fun <reified V> c() = f<V> { { V::class }() }
+        //
+        // -- in a(), the default lambda captures T so a regeneration is needed; but in b() and c(), the non-default
+        // lambda cannot possibly reference it, while V is not yet bound so regenerating the object while inlining
+        // the lambda into f() is pointless.
+        val inNonDefaultLambda = inliningContext.isInliningLambda && inliningContext.lambdaInfo !is DefaultLambda
         val info = AnonymousObjectTransformationInfo(
-            anonymousType, needReification, lambdaMapping,
+            anonymousType, needReification && !inNonDefaultLambda, lambdaMapping,
             inliningContext.classRegeneration,
             isAlreadyRegenerated(anonymousType),
             desc,

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/TransformationInfo.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/TransformationInfo.kt
@@ -97,9 +97,9 @@ class AnonymousObjectTransformationInfo internal constructor(
         nameGenerator: NameGenerator
     ) : this(ownerInternalName, needReification, hashMapOf(), false, alreadyRegenerated, null, isStaticOrigin, nameGenerator)
 
-    override fun shouldRegenerate(sameModule: Boolean): Boolean =
-        !alreadyRegenerated &&
-                (!functionalArguments.isEmpty() || !sameModule || capturedOuterRegenerated || needReification || capturesAnonymousObjectThatMustBeRegenerated)
+    override fun shouldRegenerate(sameModule: Boolean): Boolean = !alreadyRegenerated &&
+            (!sameModule || capturedOuterRegenerated || needReification || capturesAnonymousObjectThatMustBeRegenerated ||
+                    functionalArguments.values.any { it != NonInlineableArgumentForInlineableParameterCalledInSuspend })
 
     override fun canRemoveAfterTransformation(): Boolean {
         // Note: It is unsafe to remove anonymous class that is referenced by GETSTATIC within lambda

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/LocalDeclarationsLowering.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/LocalDeclarationsLowering.kt
@@ -661,7 +661,7 @@ class LocalDeclarationsLowering(
                     localFunctionContext.remapType(p.type),
                     null,
                     isCrossinline = (capturedValue as? IrValueParameterSymbol)?.owner?.isCrossinline == true,
-                    isNoinline = false
+                    isNoinline = (capturedValue as? IrValueParameterSymbol)?.owner?.isNoinline == true
                 ).also {
                     parameterDescriptor.bind(it)
                     it.parent = newDeclaration

--- a/compiler/testData/codegen/boxInline/reified/nonCapturingObjectInLambda.kt
+++ b/compiler/testData/codegen/boxInline/reified/nonCapturingObjectInLambda.kt
@@ -1,3 +1,4 @@
+// CHECK_BYTECODE_LISTING
 // FILE: 1.kt
 package test
 

--- a/compiler/testData/codegen/boxInline/reified/nonCapturingObjectInLambda.txt
+++ b/compiler/testData/codegen/boxInline/reified/nonCapturingObjectInLambda.txt
@@ -1,0 +1,24 @@
+@kotlin.Metadata
+public final class _2Kt$box$$inlined$complicatedCast$1 {
+    inner class _2Kt$box$$inlined$complicatedCast$1
+    public method <init>(): void
+    public final method f(@org.jetbrains.annotations.Nullable p0: java.lang.Object): java.lang.Object
+}
+
+@kotlin.Metadata
+public final class _2Kt$complicatedCast$1$1 {
+    inner class _2Kt$complicatedCast$1$1
+    public method <init>(): void
+    public final method f(@org.jetbrains.annotations.Nullable p0: java.lang.Object): java.lang.Object
+}
+
+@kotlin.Metadata
+public final class _2Kt {
+    public final static @org.jetbrains.annotations.NotNull method box(): java.lang.String
+    public synthetic final static method complicatedCast(@org.jetbrains.annotations.Nullable p0: java.lang.Object): java.lang.Object
+}
+
+@kotlin.Metadata
+public final class test/_1Kt {
+    public final static method myRun(@org.jetbrains.annotations.NotNull p0: kotlin.jvm.functions.Function0): java.lang.Object
+}

--- a/compiler/testData/codegen/boxInline/reified/nonCapturingObjectInLambda_ir.txt
+++ b/compiler/testData/codegen/boxInline/reified/nonCapturingObjectInLambda_ir.txt
@@ -1,0 +1,24 @@
+@kotlin.Metadata
+public final class _2Kt$box$$inlined$complicatedCast$1 {
+    inner class _2Kt$box$$inlined$complicatedCast$1
+    public method <init>(): void
+    public final method f(@org.jetbrains.annotations.Nullable p0: java.lang.Object): java.lang.Object
+}
+
+@kotlin.Metadata
+public final class _2Kt$complicatedCast$1$1 {
+    inner class _2Kt$complicatedCast$1$1
+    public method <init>(): void
+    public final method f(@org.jetbrains.annotations.Nullable p0: java.lang.Object): java.lang.Object
+}
+
+@kotlin.Metadata
+public final class _2Kt {
+    public final static @org.jetbrains.annotations.NotNull method box(): java.lang.String
+    public synthetic final static method complicatedCast(@org.jetbrains.annotations.Nullable p0: java.lang.Object): java.lang.Object
+}
+
+@kotlin.Metadata
+public final class test/_1Kt {
+    public final static method myRun(@org.jetbrains.annotations.NotNull p0: kotlin.jvm.functions.Function0): java.lang.Object
+}

--- a/compiler/testData/codegen/bytecodeListing/coroutines/tcoContinuation_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/coroutines/tcoContinuation_ir.txt
@@ -213,28 +213,6 @@ public final class TcoContinuationKt$transform$$inlined$flow$1$1 {
 }
 
 @kotlin.Metadata
-public final class TcoContinuationKt$transform$$inlined$flow$1$lambda$1$1 {
-    field label: int
-    synthetic field result: java.lang.Object
-    synthetic final field this$0: TcoContinuationKt$transform$$inlined$flow$1$lambda$1
-    inner class TcoContinuationKt$transform$$inlined$flow$1$lambda$1
-    inner class TcoContinuationKt$transform$$inlined$flow$1$lambda$1$1
-    public method <init>(p0: TcoContinuationKt$transform$$inlined$flow$1$lambda$1, p1: kotlin.coroutines.Continuation): void
-    public final @org.jetbrains.annotations.Nullable method invokeSuspend(@org.jetbrains.annotations.NotNull p0: java.lang.Object): java.lang.Object
-}
-
-@kotlin.Metadata
-public final class TcoContinuationKt$transform$$inlined$flow$1$lambda$1 {
-    synthetic final field $this$inlined: FlowCollector
-    synthetic final field $transformer$inlined: kotlin.jvm.functions.Function3
-    inner class TcoContinuationKt$transform$$inlined$flow$1$lambda$1
-    inner class TcoContinuationKt$transform$$inlined$flow$1$lambda$1$1
-    public method <init>(p0: kotlin.jvm.functions.Function3, p1: FlowCollector): void
-    public @org.jetbrains.annotations.Nullable method emit$$forInline(p0: java.lang.Object, @org.jetbrains.annotations.NotNull p1: kotlin.coroutines.Continuation): java.lang.Object
-    public @org.jetbrains.annotations.Nullable method emit(p0: java.lang.Object, @org.jetbrains.annotations.NotNull p1: kotlin.coroutines.Continuation): java.lang.Object
-}
-
-@kotlin.Metadata
 public final class TcoContinuationKt$transform$$inlined$flow$1 {
     synthetic final field $this$inlined: Flow
     synthetic final field $transformer$inlined: kotlin.jvm.functions.Function3
@@ -254,28 +232,6 @@ public final class TcoContinuationKt$transform$$inlined$flow$2$1 {
     inner class TcoContinuationKt$transform$$inlined$flow$2$1
     public method <init>(p0: TcoContinuationKt$transform$$inlined$flow$2, p1: kotlin.coroutines.Continuation): void
     public final @org.jetbrains.annotations.Nullable method invokeSuspend(@org.jetbrains.annotations.NotNull p0: java.lang.Object): java.lang.Object
-}
-
-@kotlin.Metadata
-public final class TcoContinuationKt$transform$$inlined$flow$2$lambda$1$1 {
-    field label: int
-    synthetic field result: java.lang.Object
-    synthetic final field this$0: TcoContinuationKt$transform$$inlined$flow$2$lambda$1
-    inner class TcoContinuationKt$transform$$inlined$flow$2$lambda$1
-    inner class TcoContinuationKt$transform$$inlined$flow$2$lambda$1$1
-    public method <init>(p0: TcoContinuationKt$transform$$inlined$flow$2$lambda$1, p1: kotlin.coroutines.Continuation): void
-    public final @org.jetbrains.annotations.Nullable method invokeSuspend(@org.jetbrains.annotations.NotNull p0: java.lang.Object): java.lang.Object
-}
-
-@kotlin.Metadata
-public final class TcoContinuationKt$transform$$inlined$flow$2$lambda$1 {
-    synthetic final field $this$inlined: FlowCollector
-    synthetic final field $transformer$inlined: kotlin.jvm.functions.Function3
-    inner class TcoContinuationKt$transform$$inlined$flow$2$lambda$1
-    inner class TcoContinuationKt$transform$$inlined$flow$2$lambda$1$1
-    public method <init>(p0: kotlin.jvm.functions.Function3, p1: FlowCollector): void
-    public @org.jetbrains.annotations.Nullable method emit$$forInline(p0: java.lang.Object, @org.jetbrains.annotations.NotNull p1: kotlin.coroutines.Continuation): java.lang.Object
-    public @org.jetbrains.annotations.Nullable method emit(p0: java.lang.Object, @org.jetbrains.annotations.NotNull p1: kotlin.coroutines.Continuation): java.lang.Object
 }
 
 @kotlin.Metadata
@@ -301,28 +257,6 @@ public final class TcoContinuationKt$transform$$inlined$flow$3$1 {
 }
 
 @kotlin.Metadata
-public final class TcoContinuationKt$transform$$inlined$flow$3$lambda$1$1 {
-    field label: int
-    synthetic field result: java.lang.Object
-    synthetic final field this$0: TcoContinuationKt$transform$$inlined$flow$3$lambda$1
-    inner class TcoContinuationKt$transform$$inlined$flow$3$lambda$1
-    inner class TcoContinuationKt$transform$$inlined$flow$3$lambda$1$1
-    public method <init>(p0: TcoContinuationKt$transform$$inlined$flow$3$lambda$1, p1: kotlin.coroutines.Continuation): void
-    public final @org.jetbrains.annotations.Nullable method invokeSuspend(@org.jetbrains.annotations.NotNull p0: java.lang.Object): java.lang.Object
-}
-
-@kotlin.Metadata
-public final class TcoContinuationKt$transform$$inlined$flow$3$lambda$1 {
-    synthetic final field $this$inlined: FlowCollector
-    synthetic final field $transformer$inlined: kotlin.jvm.functions.Function3
-    inner class TcoContinuationKt$transform$$inlined$flow$3$lambda$1
-    inner class TcoContinuationKt$transform$$inlined$flow$3$lambda$1$1
-    public method <init>(p0: kotlin.jvm.functions.Function3, p1: FlowCollector): void
-    public @org.jetbrains.annotations.Nullable method emit$$forInline(p0: java.lang.Object, @org.jetbrains.annotations.NotNull p1: kotlin.coroutines.Continuation): java.lang.Object
-    public @org.jetbrains.annotations.Nullable method emit(p0: java.lang.Object, @org.jetbrains.annotations.NotNull p1: kotlin.coroutines.Continuation): java.lang.Object
-}
-
-@kotlin.Metadata
 public final class TcoContinuationKt$transform$$inlined$flow$3 {
     synthetic final field $this$inlined: Flow
     synthetic final field $transformer$inlined: kotlin.jvm.functions.Function3
@@ -331,6 +265,72 @@ public final class TcoContinuationKt$transform$$inlined$flow$3 {
     public method <init>(p0: Flow, p1: kotlin.jvm.functions.Function3): void
     public @org.jetbrains.annotations.Nullable method collect$$forInline(@org.jetbrains.annotations.NotNull p0: FlowCollector, @org.jetbrains.annotations.NotNull p1: kotlin.coroutines.Continuation): java.lang.Object
     public @org.jetbrains.annotations.Nullable method collect(@org.jetbrains.annotations.NotNull p0: FlowCollector, @org.jetbrains.annotations.NotNull p1: kotlin.coroutines.Continuation): java.lang.Object
+}
+
+@kotlin.Metadata
+public final class TcoContinuationKt$transform$lambda-1$$inlined$collect$1$1 {
+    field label: int
+    synthetic field result: java.lang.Object
+    synthetic final field this$0: TcoContinuationKt$transform$lambda-1$$inlined$collect$1
+    inner class TcoContinuationKt$transform$lambda-1$$inlined$collect$1
+    inner class TcoContinuationKt$transform$lambda-1$$inlined$collect$1$1
+    public method <init>(p0: TcoContinuationKt$transform$lambda-1$$inlined$collect$1, p1: kotlin.coroutines.Continuation): void
+    public final @org.jetbrains.annotations.Nullable method invokeSuspend(@org.jetbrains.annotations.NotNull p0: java.lang.Object): java.lang.Object
+}
+
+@kotlin.Metadata
+public final class TcoContinuationKt$transform$lambda-1$$inlined$collect$1 {
+    synthetic final field $this$inlined: FlowCollector
+    synthetic final field $transformer$inlined: kotlin.jvm.functions.Function3
+    inner class TcoContinuationKt$transform$lambda-1$$inlined$collect$1
+    inner class TcoContinuationKt$transform$lambda-1$$inlined$collect$1$1
+    public method <init>(p0: kotlin.jvm.functions.Function3, p1: FlowCollector): void
+    public @org.jetbrains.annotations.Nullable method emit$$forInline(p0: java.lang.Object, @org.jetbrains.annotations.NotNull p1: kotlin.coroutines.Continuation): java.lang.Object
+    public @org.jetbrains.annotations.Nullable method emit(p0: java.lang.Object, @org.jetbrains.annotations.NotNull p1: kotlin.coroutines.Continuation): java.lang.Object
+}
+
+@kotlin.Metadata
+public final class TcoContinuationKt$transform$lambda-1$$inlined$collect$2$1 {
+    field label: int
+    synthetic field result: java.lang.Object
+    synthetic final field this$0: TcoContinuationKt$transform$lambda-1$$inlined$collect$2
+    inner class TcoContinuationKt$transform$lambda-1$$inlined$collect$2
+    inner class TcoContinuationKt$transform$lambda-1$$inlined$collect$2$1
+    public method <init>(p0: TcoContinuationKt$transform$lambda-1$$inlined$collect$2, p1: kotlin.coroutines.Continuation): void
+    public final @org.jetbrains.annotations.Nullable method invokeSuspend(@org.jetbrains.annotations.NotNull p0: java.lang.Object): java.lang.Object
+}
+
+@kotlin.Metadata
+public final class TcoContinuationKt$transform$lambda-1$$inlined$collect$2 {
+    synthetic final field $this$inlined: FlowCollector
+    synthetic final field $transformer$inlined: kotlin.jvm.functions.Function3
+    inner class TcoContinuationKt$transform$lambda-1$$inlined$collect$2
+    inner class TcoContinuationKt$transform$lambda-1$$inlined$collect$2$1
+    public method <init>(p0: kotlin.jvm.functions.Function3, p1: FlowCollector): void
+    public @org.jetbrains.annotations.Nullable method emit$$forInline(p0: java.lang.Object, @org.jetbrains.annotations.NotNull p1: kotlin.coroutines.Continuation): java.lang.Object
+    public @org.jetbrains.annotations.Nullable method emit(p0: java.lang.Object, @org.jetbrains.annotations.NotNull p1: kotlin.coroutines.Continuation): java.lang.Object
+}
+
+@kotlin.Metadata
+public final class TcoContinuationKt$transform$lambda-1$$inlined$collect$3$1 {
+    field label: int
+    synthetic field result: java.lang.Object
+    synthetic final field this$0: TcoContinuationKt$transform$lambda-1$$inlined$collect$3
+    inner class TcoContinuationKt$transform$lambda-1$$inlined$collect$3
+    inner class TcoContinuationKt$transform$lambda-1$$inlined$collect$3$1
+    public method <init>(p0: TcoContinuationKt$transform$lambda-1$$inlined$collect$3, p1: kotlin.coroutines.Continuation): void
+    public final @org.jetbrains.annotations.Nullable method invokeSuspend(@org.jetbrains.annotations.NotNull p0: java.lang.Object): java.lang.Object
+}
+
+@kotlin.Metadata
+public final class TcoContinuationKt$transform$lambda-1$$inlined$collect$3 {
+    synthetic final field $this$inlined: FlowCollector
+    synthetic final field $transformer$inlined: kotlin.jvm.functions.Function3
+    inner class TcoContinuationKt$transform$lambda-1$$inlined$collect$3
+    inner class TcoContinuationKt$transform$lambda-1$$inlined$collect$3$1
+    public method <init>(p0: kotlin.jvm.functions.Function3, p1: FlowCollector): void
+    public @org.jetbrains.annotations.Nullable method emit$$forInline(p0: java.lang.Object, @org.jetbrains.annotations.NotNull p1: kotlin.coroutines.Continuation): java.lang.Object
+    public @org.jetbrains.annotations.Nullable method emit(p0: java.lang.Object, @org.jetbrains.annotations.NotNull p1: kotlin.coroutines.Continuation): java.lang.Object
 }
 
 @kotlin.Metadata


### PR DESCRIPTION
**Commit 1:**

All reified type parameters referenced by objects in non-default lambdas are from outside the inline call, thus they cannot be substituted yet. This means if the only reason for object regeneration is reification, then regeneration isn't actually necessary.

E.g. in this code:

    inline fun <reified T> f(x: () -> Unit) = x()
    inline fun <reified V> g() = f<V> { { println(V::class.simpleName) }() }

we first inline the lambda into f(), then inline f()-with-lambda into g(). Because the object inside the lambda captures nothing from outside g(), the original class can be used both times.

**Commit 2**:

Same thing, but instead of reified type parameters it's suspend lambdas: if the actual lambda to inline is not known yet (or will never be known because the inline root is not an inline function or the captured parameter is `noinline`), regenerating an object is pointless.

This brings the JVM_IR backend into complete compliance with KT-28064.