### PR TITLE
[JVM_IR] Rebase test of string concatenation codegen.

### DIFF
--- a/compiler/testData/codegen/bytecodeText/boxingOptimization/maxMinBy.kt
+++ b/compiler/testData/codegen/bytecodeText/boxingOptimization/maxMinBy.kt
@@ -1,6 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
-// TODO KT-36645 Don't box primitive values in string template and string concatenation in JVM_IR
-
 // FILE: list.kt
 
 val intList = listOf(1, 2, 3)
@@ -25,8 +22,6 @@ fun box(): String {
 }
 
 // @BoxKt.class:
-// -- no boxing
-// 0 valueOf
 // -- no compareTo
 // 0 compareTo
 // -- comparisons are properly fused with conditional jumps
@@ -37,3 +32,20 @@ fun box(): String {
 // 4 LCMP
 // 1 IFGE
 // 1 IFLE
+
+// JVM_TEMPLATES
+// -- no boxing but lots of StringBuilder calls
+// 0 valueOf
+// 0 Intrinsics.stringPlus
+// 4 StringBuilder.<init>
+// 8 StringBuilder.append
+// 4 StringBuilder.toString
+
+// JVM_IR_TEMPLATES
+// -- perform boxing and call Intrinsics.stringPlus instead
+// -- of having inlined string builder allocation, appends, and toString
+// 4 valueOf
+// 4 Intrinsics.stringPlus
+// 0 StringBuilder.<init>
+// 0 StringBuilder.append
+// 0 StringBuilder.toString


### PR DESCRIPTION
The JVM IR backend code seems saner to me. The string concatenation
lowering for JVM IR calls the stringPlus intrinsic if there are
only two arguments. That leads to a lot less code:

```
load string
load argument
box argument
call Intrinsics.stringPlus
```

instead of

```
allocate StringBuilder
call StringBuilder.<init>
load string
call StringBuilder.append
load argument
call StringBuilder.append
call StringBuilder.toString
```

This will lead to more boxing, but a lot smaller code. We still
use StringBuilders in JVM IR if there are more than two strings
being concatenated.