### PR TITLE
JVM: check inline call site line numbers in stepping tests

### DIFF
--- a/compiler/testData/debug/stepping/for.kt
+++ b/compiler/testData/debug/stepping/for.kt
@@ -10,12 +10,12 @@ inline fun foo(n: Int) {}
 // LINENUMBERS
 // test.kt:3
 // test.kt:4
-// test.kt:8
+// test.kt:8 @ test.kt:4
 // test.kt:3
 // test.kt:4
-// test.kt:8
+// test.kt:8 @ test.kt:4
 // test.kt:3
 // test.kt:4
-// test.kt:8
+// test.kt:8 @ test.kt:4
 // test.kt:3
 // test.kt:6

--- a/compiler/testData/debug/stepping/if.kt
+++ b/compiler/testData/debug/stepping/if.kt
@@ -15,10 +15,10 @@ inline fun getB(): Int {
 
 // LINENUMBERS
 // test.kt:4
-// test.kt:13
+// test.kt:13 @ test.kt:4
 // test.kt:5
 // test.kt:10
 // test.kt:5
 // test.kt:7
-// test.kt:13
+// test.kt:13 @ test.kt:7
 // test.kt:7

--- a/compiler/testData/debug/stepping/inlineCallableReference.kt
+++ b/compiler/testData/debug/stepping/inlineCallableReference.kt
@@ -13,8 +13,11 @@ inline fun f(block: () -> Unit) {
 // LINENUMBERS
 // test.kt:3
 // test.kt:4
-// test.kt:10
+// test.kt:10 @ test.kt:4
 // test.kt:5
 // test.kt:6
-// test.kt:11
+// test.kt:11 @ test.kt:4
 // test.kt:7
+
+// line 11 has incorrect call site (:5)
+// IGNORE_BACKEND: JVM, JVM_IR

--- a/compiler/testData/debug/stepping/inlineCallsInInlineLambda.kt
+++ b/compiler/testData/debug/stepping/inlineCallsInInlineLambda.kt
@@ -1,0 +1,23 @@
+// FILE: test.kt
+inline fun f(x: () -> Unit) = x()
+inline fun g() {}
+
+fun box() {
+    f {
+        g()
+        g()
+    }
+}
+
+// LINENUMBERS
+// test.kt:6
+// test.kt:2 @ test.kt:6
+// test.kt:7
+// test.kt:3 @ test.kt:7
+// test.kt:8
+// test.kt:3 @ test.kt:8
+// test.kt:9
+// test.kt:10
+
+// lines 3 have incorrect call sites (KT-35006)
+// IGNORE_BACKEND: JVM, JVM_IR

--- a/compiler/testData/debug/stepping/inlineNamedCallableReference.kt
+++ b/compiler/testData/debug/stepping/inlineNamedCallableReference.kt
@@ -13,8 +13,11 @@ fun g() {}
 // LINENUMBERS
 // test.kt:3
 // test.kt:4
-// test.kt:8
+// test.kt:8 @ test.kt:4
 // test.kt:4
 // test.kt:11
-// test.kt:9
+// test.kt:9 @ test.kt:4
 // test.kt:5
+
+// line 9 has incorrect call site (:5)
+// IGNORE_BACKEND: JVM, JVM_IR

--- a/compiler/testData/debug/stepping/nestedInline.kt
+++ b/compiler/testData/debug/stepping/nestedInline.kt
@@ -43,21 +43,24 @@ inline fun html(init: () -> Unit) {
 
 // LINENUMBERS
 // test.kt:19
-// test.kt:7
-// test.kt:9
-// 1.kt:18
-// 1.kt:6
-// test.kt:10
-// 1.kt:14
-// 1.kt:10
-// 1.kt:11
-// test.kt:11
-// test.kt:12
-// 1.kt:12
-// 1.kt:14
-// test.kt:13
-// 1.kt:7
-// 1.kt:18
-// test.kt:15
+// test.kt:7 @ test.kt:19
+// test.kt:9 @ test.kt:19
+// 1.kt:18 @ test.kt:19
+// 1.kt:6 @ test.kt:19
+// test.kt:10 @ test.kt:19
+// 1.kt:14 @ test.kt:19
+// 1.kt:10 @ test.kt:19
+// 1.kt:11 @ test.kt:19
+// test.kt:11 @ test.kt:19
+// test.kt:12 @ test.kt:19
+// 1.kt:12 @ test.kt:19
+// 1.kt:14 @ test.kt:19
+// test.kt:13 @ test.kt:19
+// 1.kt:7 @ test.kt:19
+// 1.kt:18 @ test.kt:19
+// test.kt:15 @ test.kt:19
 // test.kt:19
 // test.kt:21
+
+// some lines have incorrect call sites (:20 and :21)
+// IGNORE_BACKEND: JVM, JVM_IR

--- a/compiler/tests-common/tests/org/jetbrains/kotlin/codegen/debugInformation/AbstractDebugTest.kt
+++ b/compiler/tests-common/tests/org/jetbrains/kotlin/codegen/debugInformation/AbstractDebugTest.kt
@@ -15,9 +15,12 @@ import com.sun.jdi.request.EventRequest.SUSPEND_ALL
 import com.sun.jdi.request.StepRequest
 import com.sun.tools.jdi.SocketAttachingConnector
 import org.jetbrains.kotlin.backend.common.output.SimpleOutputFileCollection
+import org.jetbrains.kotlin.checkers.forceEnableFeatures
 import org.jetbrains.kotlin.cli.common.output.writeAllTo
 import org.jetbrains.kotlin.codegen.*
 import org.jetbrains.kotlin.codegen.forTestCompile.ForTestCompileRuntime
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.test.ConfigurationKind
 import org.jetbrains.kotlin.test.KotlinTestUtils
 import org.jetbrains.kotlin.test.clientserver.TestProcessServer
@@ -118,6 +121,11 @@ abstract class AbstractDebugTest : CodegenTestCase() {
     @After
     public override fun tearDown() {
         super.tearDown()
+    }
+
+    override fun updateConfiguration(configuration: CompilerConfiguration) {
+        super.updateConfiguration(configuration)
+        configuration.forceEnableFeatures(LanguageFeature.CorrectSourceMappingSyntax)
     }
 
     internal fun invokeBoxInSeparateProcess(classLoader: URLClassLoader, aClass: Class<*>, port: Int): String {

--- a/compiler/tests-common/tests/org/jetbrains/kotlin/codegen/debugInformation/AbstractSteppingTest.kt
+++ b/compiler/tests-common/tests/org/jetbrains/kotlin/codegen/debugInformation/AbstractSteppingTest.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.codegen.debugInformation
 
+import com.sun.jdi.Location
 import com.sun.jdi.VirtualMachine
 import com.sun.jdi.event.Event
 import com.sun.jdi.event.LocatableEvent
@@ -47,18 +48,33 @@ abstract class AbstractSteppingTest : AbstractDebugTest() {
         loggedItems.add(event)
     }
 
+    private fun Location.toString(stratum: String): String =
+        "${sourceName(stratum)}:${lineNumber(stratum)}"
+
     override fun checkResult(wholeFile: File, loggedItems: List<Any>) {
         val expectedLineNumbers = wholeFile
             .readLines()
             .dropWhile { !it.startsWith(LINENUMBER_PREFIX) }
-            .drop(1)
-            .map { it.drop(3).trim() }
-            .joinToString("\n")
-        val actualLineNumbers = loggedItems
-            .map { event ->
-                val location = (event as LocatableEvent).location()
-                "${location.sourceName()}:${location.lineNumber()}"
+            .drop(1).joinToString("\n") { it.drop(2).trim() }
+        val linesWithCallSites = mutableMapOf<Any?, Set<Int>>()
+        val actualLineNumbers = loggedItems.map { event ->
+            val location = (event as LocatableEvent).location()
+            val parentType = location.declaringType()
+            // If a line number is not in KotlinDebug at all, calling `location.lineNumber("KotlinDebug")`
+            // will produce some undefined garbage, so we need to check this first.
+            val parentTypeCallSites = linesWithCallSites.getOrPut(parentType) {
+                // If the KotlinDebug stratum is not present at all, `allLineLocations` will instead return
+                // the default stratum, i.e. Kotlin; we don't want to treat *all* lines as call sites.
+                if ("KotlinDebug" !in parentType.availableStrata())
+                    setOf()
+                else
+                    parentType.allLineLocations("KotlinDebug", null).mapTo(mutableSetOf()) { it.lineNumber("Java") }
             }
+            if (location.lineNumber("Java") in parentTypeCallSites)
+                "${location.toString("Kotlin")} @ ${location.toString("KotlinDebug")}"
+            else
+                location.toString("Kotlin")
+        }
         TestCase.assertEquals(expectedLineNumbers, actualLineNumbers.joinToString("\n"))
     }
 }

--- a/compiler/tests/org/jetbrains/kotlin/codegen/debugInformation/IrSteppingTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/debugInformation/IrSteppingTestGenerated.java
@@ -74,6 +74,12 @@ public class IrSteppingTestGenerated extends AbstractIrSteppingTest {
     }
 
     @Test
+    @TestMetadata("inlineCallsInInlineLambda.kt")
+    public void testInlineCallsInInlineLambda() throws Exception {
+        runTest("compiler/testData/debug/stepping/inlineCallsInInlineLambda.kt");
+    }
+
+    @Test
     @TestMetadata("inlineNamedCallableReference.kt")
     public void testInlineNamedCallableReference() throws Exception {
         runTest("compiler/testData/debug/stepping/inlineNamedCallableReference.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/debugInformation/SteppingTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/debugInformation/SteppingTestGenerated.java
@@ -74,6 +74,12 @@ public class SteppingTestGenerated extends AbstractSteppingTest {
     }
 
     @Test
+    @TestMetadata("inlineCallsInInlineLambda.kt")
+    public void testInlineCallsInInlineLambda() throws Exception {
+        runTest("compiler/testData/debug/stepping/inlineCallsInInlineLambda.kt");
+    }
+
+    @Test
     @TestMetadata("inlineNamedCallableReference.kt")
     public void testInlineNamedCallableReference() throws Exception {
         runTest("compiler/testData/debug/stepping/inlineNamedCallableReference.kt");


### PR DESCRIPTION
Note: I've modified the test data to what *should* be generated, not the output right now: there are still some issues, such as KT-37704 and KT-35006.