### PR TITLE
add sample for text version of chunked

### DIFF
--- a/libraries/stdlib/common/src/generated/_Strings.kt
+++ b/libraries/stdlib/common/src/generated/_Strings.kt
@@ -1456,7 +1456,7 @@ public inline fun CharSequence.sumByDouble(selector: (Char) -> Double): Double {
  * 
  * @param size the number of elements to take in each string, must be positive and can be greater than the number of elements in this char sequence.
  * 
- * @sample samples.collections.Collections.Transformations.chunked
+ * @sample samples.text.Strings.chunked
  */
 @SinceKotlin("1.2")
 public fun CharSequence.chunked(size: Int): List<String> {

--- a/libraries/stdlib/samples/test/samples/text/strings.kt
+++ b/libraries/stdlib/samples/test/samples/text/strings.kt
@@ -50,6 +50,15 @@ class Strings {
     }
 
     @Sample
+    fun chunked() {
+        val dnaFragment = "ATTCGCGGCCGCCAA"
+
+        val codons = dnaFragment.chunked(3)
+
+        assertPrints(codons, "[ATT, CGC, GGC, CGC, CAA]")
+    }
+
+    @Sample
     fun chunkedTransform() {
         val codonTable = mapOf("ATT" to "Isoleucine", "CAA" to "Glutamine", "CGC" to "Arginine", "GGC" to "Glycine")
         val dnaFragment = "ATTCGCGGCCGCCAA"

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Generators.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Generators.kt
@@ -868,10 +868,18 @@ object Generators : TemplateGroupBase() {
             @param size the number of elements to take in each ${f.snapshotResult}, must be positive and can be greater than the number of elements in this ${f.collection}.
             """
         }
-        sample("samples.collections.Collections.Transformations.chunked")
-        specialFor(Iterables) { returns("List<List<T>>") }
-        specialFor(Sequences) { returns("Sequence<List<T>>") }
-        specialFor(CharSequences) { returns("List<String>") }
+        specialFor(Iterables) {
+            sample("samples.collections.Collections.Transformations.chunked")
+            returns("List<List<T>>")
+        }
+        specialFor(Sequences) {
+            sample("samples.collections.Collections.Transformations.chunked")
+            returns("Sequence<List<T>>")
+        }
+        specialFor(CharSequences) {
+            sample("samples.text.Strings.chunked")
+            returns("List<String>")
+        }
 
         sequenceClassification(intermediate, stateful)
 


### PR DESCRIPTION
Addresses [KT-35867](https://youtrack.jetbrains.com/issue/KT-35867) for the `chunked()` function.