### PR TITLE
KT-37256 False positive `PlatformExtensionReceiverOfInline` inspection if a platform type value is passed to a nullable receiver

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/PlatformExtensionReceiverOfInlineInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/PlatformExtensionReceiverOfInlineInspection.kt
@@ -29,6 +29,7 @@ import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
 import org.jetbrains.kotlin.resolve.calls.smartcasts.DataFlowValueFactory
 import org.jetbrains.kotlin.resolve.lazy.BodyResolveMode
 import org.jetbrains.kotlin.types.isNullabilityFlexible
+import org.jetbrains.kotlin.types.isNullable
 import java.awt.BorderLayout
 import java.util.regex.PatternSyntaxException
 import javax.swing.JPanel
@@ -68,7 +69,7 @@ class PlatformExtensionReceiverOfInlineInspection : AbstractKotlinInspection() {
                 val extensionReceiverType = resolvedCall.extensionReceiver?.type ?: return
                 if (!extensionReceiverType.isNullabilityFlexible()) return
                 val descriptor = resolvedCall.resultingDescriptor as? FunctionDescriptor ?: return
-                if (!descriptor.isInline) return
+                if (!descriptor.isInline || descriptor.extensionReceiverParameter?.type?.isNullable() == true) return
 
                 val receiverExpression = expression.receiverExpression
                 val dataFlowValueFactory = receiverExpression.getResolutionFacade().getFrontendService(DataFlowValueFactory::class.java)

--- a/idea/testData/multiFileInspections/platformExtensionReceiverOfInline/before/NullableReceiverType/NullableReceiverType.iml
+++ b/idea/testData/multiFileInspections/platformExtensionReceiverOfInline/before/NullableReceiverType/NullableReceiverType.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/idea/testData/multiFileInspections/platformExtensionReceiverOfInline/before/NullableReceiverType/src/JavaFoo.java
+++ b/idea/testData/multiFileInspections/platformExtensionReceiverOfInline/before/NullableReceiverType/src/JavaFoo.java
@@ -1,0 +1,5 @@
+public class JavaFoo {
+    public static String foo() {
+        return null;
+    }
+}

--- a/idea/testData/multiFileInspections/platformExtensionReceiverOfInline/before/NullableReceiverType/src/Test.kt
+++ b/idea/testData/multiFileInspections/platformExtensionReceiverOfInline/before/NullableReceiverType/src/Test.kt
@@ -1,0 +1,8 @@
+inline fun String?.contentToByte(): Byte {
+    return 0
+}
+
+fun main() {
+    JavaFoo.foo().toBoolean()
+    JavaFoo.foo().contentToByte()
+}

--- a/idea/testData/multiFileInspections/platformExtensionReceiverOfInline/before/ToBoolean/src/Test.kt
+++ b/idea/testData/multiFileInspections/platformExtensionReceiverOfInline/before/ToBoolean/src/Test.kt
@@ -13,6 +13,8 @@ fun test() {
     }
 }
 
+inline fun String.toBoolean(): Boolean = true
+
 fun String.contentNotInline() {}
 
 class My {

--- a/idea/testData/multiFileInspections/platformExtensionReceiverOfInline/platformExtensionReceiverOfInline.test
+++ b/idea/testData/multiFileInspections/platformExtensionReceiverOfInline/platformExtensionReceiverOfInline.test
@@ -1,5 +1,5 @@
 {
     "inspectionClass": "org.jetbrains.kotlin.idea.inspections.PlatformExtensionReceiverOfInlineInspection",
     "withRuntime": "true",
-    "isMultiModule": "false"
+    "isMultiModule": "true"
 }


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-37256