### PR TITLE
KT-37502 False positive "redundant lambda arrow" with inline generic function with reified type in object and anonymous parameter name

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantLambdaArrowInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantLambdaArrowInspection.kt
@@ -90,9 +90,9 @@ class RedundantLambdaArrowInspection : AbstractKotlinInspection() {
 }
 
 private fun KtCallExpression.isApplicableCall(lambdaExpression: KtLambdaExpression, lambdaContext: BindingContext): Boolean {
-    val offset = lambdaExpression.textOffset - textOffset
     val dotQualifiedExpression = parent as? KtDotQualifiedExpression
     return if (dotQualifiedExpression == null) {
+        val offset = lambdaExpression.textOffset - textOffset
         replaceWithCopyWithResolveCheck(
             resolveStrategy = { expr, context ->
                 expr.getResolvedCall(context)?.resultingDescriptor
@@ -103,6 +103,7 @@ private fun KtCallExpression.isApplicableCall(lambdaExpression: KtLambdaExpressi
             }
         )
     } else {
+        val offset = lambdaExpression.textOffset - dotQualifiedExpression.textOffset
         dotQualifiedExpression.replaceWithCopyWithResolveCheck(
             resolveStrategy = { expr, context ->
                 expr.selectorExpression.getResolvedCall(context)?.resultingDescriptor

--- a/idea/testData/inspectionsLocal/redundantLambdaArrow/typeParameter4.kt
+++ b/idea/testData/inspectionsLocal/redundantLambdaArrow/typeParameter4.kt
@@ -1,0 +1,8 @@
+// PROBLEM: none
+object A {
+    fun <T> foo(f: (T) -> Int) {}
+}
+
+fun test() {
+    A.foo { <caret>_: String -> 24 }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -7712,6 +7712,11 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
             runTest("idea/testData/inspectionsLocal/redundantLambdaArrow/typeParameter3_ni.kt");
         }
 
+        @TestMetadata("typeParameter4.kt")
+        public void testTypeParameter4() throws Exception {
+            runTest("idea/testData/inspectionsLocal/redundantLambdaArrow/typeParameter4.kt");
+        }
+
         @TestMetadata("underscore.kt")
         public void testUnderscore() throws Exception {
             runTest("idea/testData/inspectionsLocal/redundantLambdaArrow/underscore.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-37502