### PR TITLE
FIR: consider all functions in scope when computing dispatch receiver parameter.

### DIFF
--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrConversionScope.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrConversionScope.kt
@@ -77,17 +77,14 @@ class Fir2IrConversionScope {
     fun parent(): IrDeclarationParent? = parentStack.lastOrNull()
 
     fun lastDispatchReceiverParameter(): IrValueParameter? {
-        var dispatchReceiver = functionStack.lastOrNull()?.dispatchReceiverParameter
-        // Use the dispatch receiver of the containing function
-        dispatchReceiver?.let { return it }
-
-        // Use the dispatch receiver of the enclosing function if any
-        dispatchReceiver = functionStack.elementAtOrNull(functionStack.size - 2)?.dispatchReceiverParameter
-        dispatchReceiver?.let { return it }
+        // Use the dispatch receiver of the containing/enclosing functions (from the last to the first)
+        for (function in functionStack.asReversed()) {
+            function.dispatchReceiverParameter?.let { return it }
+        }
 
         // Use the dispatch receiver of the containing class
-        val lastClassSymbol = classStack.lastOrNull()?.symbol
-        return lastClassSymbol?.owner?.thisReceiver
+        val lastClass = classStack.lastOrNull()
+        return lastClass?.thisReceiver
     }
 
     fun lastClass(): IrClass? = classStack.lastOrNull()

--- a/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
@@ -18285,6 +18285,16 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
             runTest("compiler/testData/codegen/box/properties/classFieldInsideNested.kt");
         }
 
+        @TestMetadata("classFieldInsideNestedLambda.kt")
+        public void testClassFieldInsideNestedLambda() throws Exception {
+            runTest("compiler/testData/codegen/box/properties/classFieldInsideNestedLambda.kt");
+        }
+
+        @TestMetadata("classFieldInsideNestedNestedLambda.kt")
+        public void testClassFieldInsideNestedNestedLambda() throws Exception {
+            runTest("compiler/testData/codegen/box/properties/classFieldInsideNestedNestedLambda.kt");
+        }
+
         @TestMetadata("classObjectProperties.kt")
         public void testClassObjectProperties() throws Exception {
             runTest("compiler/testData/codegen/box/properties/classObjectProperties.kt");

--- a/compiler/testData/codegen/box/properties/classFieldInsideNestedLambda.kt
+++ b/compiler/testData/codegen/box/properties/classFieldInsideNestedLambda.kt
@@ -1,0 +1,6 @@
+class My {
+    val my: String = "O"
+        get() = { { field }() }() + "K"
+}
+
+fun box() = My().my

--- a/compiler/testData/codegen/box/properties/classFieldInsideNestedNestedLambda.kt
+++ b/compiler/testData/codegen/box/properties/classFieldInsideNestedNestedLambda.kt
@@ -1,0 +1,6 @@
+class My {
+    val my: String = "O"
+        get() = { { { field }() }() }() + "K"
+}
+
+fun box() = My().my

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -19806,6 +19806,16 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             runTest("compiler/testData/codegen/box/properties/classFieldInsideNested.kt");
         }
 
+        @TestMetadata("classFieldInsideNestedLambda.kt")
+        public void testClassFieldInsideNestedLambda() throws Exception {
+            runTest("compiler/testData/codegen/box/properties/classFieldInsideNestedLambda.kt");
+        }
+
+        @TestMetadata("classFieldInsideNestedNestedLambda.kt")
+        public void testClassFieldInsideNestedNestedLambda() throws Exception {
+            runTest("compiler/testData/codegen/box/properties/classFieldInsideNestedNestedLambda.kt");
+        }
+
         @TestMetadata("classObjectProperties.kt")
         public void testClassObjectProperties() throws Exception {
             runTest("compiler/testData/codegen/box/properties/classObjectProperties.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -18285,6 +18285,16 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             runTest("compiler/testData/codegen/box/properties/classFieldInsideNested.kt");
         }
 
+        @TestMetadata("classFieldInsideNestedLambda.kt")
+        public void testClassFieldInsideNestedLambda() throws Exception {
+            runTest("compiler/testData/codegen/box/properties/classFieldInsideNestedLambda.kt");
+        }
+
+        @TestMetadata("classFieldInsideNestedNestedLambda.kt")
+        public void testClassFieldInsideNestedNestedLambda() throws Exception {
+            runTest("compiler/testData/codegen/box/properties/classFieldInsideNestedNestedLambda.kt");
+        }
+
         @TestMetadata("classObjectProperties.kt")
         public void testClassObjectProperties() throws Exception {
             runTest("compiler/testData/codegen/box/properties/classObjectProperties.kt");


### PR DESCRIPTION
This is a follow-up of https://github.com/JetBrains/kotlin/pull/3220. Special thanks to @punzki