### PR TITLE
Remove Apache notice added to LGPL license text

### DIFF
--- a/license/third_party/testdata/findbugs_license.txt
+++ b/license/third_party/testdata/findbugs_license.txt
@@ -136,22 +136,6 @@ included without limitation in the term "modification".)
   "Source code" for a work means the preferred form of the work for
 making modifications to it.  For a library, complete source code means
 all the source code for all modules it contains, plus any associated
-/*
- * Copyright 2010-2017 JetBrains s.r.o.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 interface definition files, plus the scripts used to control compilation
 and installation of the library.
 


### PR DESCRIPTION
Somehow an Apache-2.0 license notice with a JetBrains copyright that had
been pasted in the middle of the LGPL license text.
This removes this notice and restores the pristine, unmodified license
text.

This has been detected by running scancode-toolkit that reported this license "sandwich" that was a tad suspicious as both lgpl chunks were incomplete:
```
      "license_expressions": [
        "lgpl-2.1",
        "apache-2.0",
        "lgpl-2.1"
      ],
```

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>