### PR TITLE
KT-24750 Blank line after class header formatter should use user setting

### DIFF
--- a/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/kotlinSpacingRules.kt
+++ b/idea/formatter/src/org/jetbrains/kotlin/idea/formatter/kotlinSpacingRules.kt
@@ -153,13 +153,16 @@ fun createSpacingBuilder(settings: CodeStyleSettings, builderUtil: KotlinSpacing
                     null
                 } else {
                     val minLineFeeds = if (right.requireNode().elementType == FUN || right.requireNode().elementType == PROPERTY)
-                        1
+                        kotlinCommonSettings.BLANK_LINES_AFTER_CLASS_HEADER + 1
                     else
                         0
 
                     builderUtil.createLineFeedDependentSpacing(
-                        1, 1, minLineFeeds,
-                        settings.KEEP_LINE_BREAKS, settings.KEEP_BLANK_LINES_IN_DECLARATIONS,
+                        1,
+                        1,
+                        minLineFeeds,
+                        commonCodeStyleSettings.KEEP_LINE_BREAKS,
+                        commonCodeStyleSettings.KEEP_BLANK_LINES_IN_DECLARATIONS,
                         TextRange(parentPsi.textRange.startOffset, left.requireNode().psi.textRange.startOffset),
                         DependentSpacingRule(DependentSpacingRule.Trigger.HAS_LINE_FEEDS)
                             .registerData(

--- a/idea/testData/formatter/BlankLinesAfterClassHeader.after.kt
+++ b/idea/testData/formatter/BlankLinesAfterClassHeader.after.kt
@@ -1,19 +1,42 @@
 class Foo {
+
     fun bar() {
     }
 }
 
 object Bar {
+
     fun xyzzy() {
     }
+}
+
+object BarS {
+
+    fun xyzzy() {}
 }
 
 val f = object {
     fun foo() {}
 }
 
+class FooCO {
+
+    fun bar() {
+    }
+
+    companion object {
+
+        fun foo() {}
+    }
+}
+
 class FooM
     : IFoo {
+
+    fun bar()
+}
+
+class FooN : IFoo {
 
     fun bar()
 }
@@ -28,6 +51,7 @@ class FooC(
 enum class Foo { Bar, Baz }
 
 class Foo {
+
     fun bar() {}
 }
 

--- a/idea/testData/formatter/BlankLinesAfterClassHeader2.after.kt
+++ b/idea/testData/formatter/BlankLinesAfterClassHeader2.after.kt
@@ -1,45 +1,67 @@
 class Foo {
+
+
     fun bar() {
     }
 }
 
 object Bar {
+
+
     fun xyzzy() {
     }
 }
 
-object BarS { fun xyzzy() {} }
+object BarS {
+
+
+    fun xyzzy() {}
+}
 
 val f = object {
     fun foo() {}
 }
 
 class FooCO {
+
+
     fun bar() {
     }
 
     companion object {
+
+
         fun foo() {}
     }
 }
 
 class FooM
     : IFoo {
+
+
     fun bar()
 }
 
 class FooN : IFoo {
+
+
     fun bar()
 }
 
 class FooC(
         val x: String
 ) {
+
+
     fun bar()
 }
 
-enum class Foo{Bar,Baz}
+enum class Foo { Bar, Baz }
 
-class Foo{fun bar() {}}
+class Foo {
 
-// SET_INT: BLANK_LINES_AFTER_CLASS_HEADER = 1
+
+    fun bar() {}
+}
+
+// SET_INT: BLANK_LINES_AFTER_CLASS_HEADER = 2

--- a/idea/testData/formatter/BlankLinesAfterClassHeader2.kt
+++ b/idea/testData/formatter/BlankLinesAfterClassHeader2.kt
@@ -42,4 +42,4 @@ enum class Foo{Bar,Baz}
 
 class Foo{fun bar() {}}
 
-// SET_INT: BLANK_LINES_AFTER_CLASS_HEADER = 1
+// SET_INT: BLANK_LINES_AFTER_CLASS_HEADER = 2

--- a/idea/tests/org/jetbrains/kotlin/formatter/FormatterTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/formatter/FormatterTestGenerated.java
@@ -95,6 +95,11 @@ public class FormatterTestGenerated extends AbstractFormatterTest {
             runTest("idea/testData/formatter/BlankLinesAfterClassHeader.after.kt");
         }
 
+        @TestMetadata("BlankLinesAfterClassHeader2.after.kt")
+        public void testBlankLinesAfterClassHeader2() throws Exception {
+            runTest("idea/testData/formatter/BlankLinesAfterClassHeader2.after.kt");
+        }
+
         @TestMetadata("BlankLinesBeforeRBrace.after.kt")
         public void testBlankLinesBeforeRBrace() throws Exception {
             runTest("idea/testData/formatter/BlankLinesBeforeRBrace.after.kt");


### PR DESCRIPTION
Fixes; https://youtrack.jetbrains.com/issue/KT-24750

When `Minimum Blank Line` -> `After class header` formatter setting changed, code formatter needs to respect new setting.

| Before | Minimum 1 | Minimum after header 5 and Max line 2 |
| - | - | - |
| <img width="739" alt="Screenshot 2020-03-25 at 15 10 07" src="https://user-images.githubusercontent.com/2559837/77566403-ab0c7b00-6ed6-11ea-94bb-859f8d1e0c2f.png"> | <img width="738" alt="Screenshot 2020-03-25 at 15 10 12" src="https://user-images.githubusercontent.com/2559837/77566417-afd12f00-6ed6-11ea-9207-22b7d397b029.png"> | <img width="736" alt="Screenshot 2020-03-25 at 15 10 31" src="https://user-images.githubusercontent.com/2559837/77566427-b495e300-6ed6-11ea-83e4-a4db50109c98.png"> |


