### PR TITLE
[JVM_IR] Use iinc for incrementing Int variables.

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/IntrinsicMethod.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/IntrinsicMethod.kt
@@ -7,11 +7,9 @@ package org.jetbrains.kotlin.backend.jvm.intrinsics
 
 import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
 import org.jetbrains.kotlin.backend.jvm.codegen.*
-import org.jetbrains.kotlin.codegen.AsmUtil
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrFunctionAccessExpression
 import org.jetbrains.kotlin.ir.expressions.IrMemberAccessExpression
-import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.resolve.jvm.jvmSignature.JvmMethodSignature
 import org.jetbrains.org.objectweb.asm.Type
 import org.jetbrains.org.objectweb.asm.commons.Method
@@ -26,7 +24,7 @@ abstract class IntrinsicMethod {
     open fun invoke(expression: IrFunctionAccessExpression, codegen: ExpressionCodegen, data: BlockInfo): PromisedValue? =
         with(codegen) {
             val descriptor = methodSignatureMapper.mapSignatureSkipGeneric(expression.symbol.owner)
-            val stackValue = toCallable(expression, descriptor, context).invoke(mv, codegen, data)
+            val stackValue = toCallable(expression, descriptor, context).invoke(mv, codegen, data, expression)
             stackValue.put(mv)
             return MaterialValue(this, stackValue.type, expression.type)
         }

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/IrIllegalArgumentException.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/IrIllegalArgumentException.kt
@@ -21,7 +21,6 @@ import org.jetbrains.kotlin.backend.jvm.codegen.BlockInfo
 import org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen
 import org.jetbrains.kotlin.codegen.StackValue
 import org.jetbrains.kotlin.ir.expressions.IrFunctionAccessExpression
-import org.jetbrains.kotlin.ir.expressions.IrMemberAccessExpression
 import org.jetbrains.kotlin.resolve.jvm.AsmTypes.JAVA_STRING_TYPE
 import org.jetbrains.kotlin.resolve.jvm.jvmSignature.JvmMethodSignature
 import org.jetbrains.org.objectweb.asm.Type
@@ -46,10 +45,16 @@ object IrIllegalArgumentException : IntrinsicMethod() {
                 v.athrow()
             }
 
-            override fun invoke(v: InstructionAdapter, codegen: ExpressionCodegen, data: BlockInfo): StackValue {
+            override fun invoke(
+                v: InstructionAdapter,
+                codegen: ExpressionCodegen,
+                data: BlockInfo,
+                expression: IrFunctionAccessExpression
+            ): StackValue {
+                codegen.markLineNumber(expression)
                 v.anew(exceptionTypeDescriptor)
                 v.dup()
-                return super.invoke(v, codegen, data)
+                return super.invoke(v, codegen, data, expression)
             }
         }
     }

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/IrIntrinsicFunction.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/IrIntrinsicFunction.kt
@@ -65,8 +65,14 @@ open class IrIntrinsicFunction(
         return returnType
     }
 
-    open fun invoke(v: InstructionAdapter, codegen: ExpressionCodegen, data: BlockInfo): StackValue {
+    open fun invoke(
+        v: InstructionAdapter,
+        codegen: ExpressionCodegen,
+        data: BlockInfo,
+        expression: IrFunctionAccessExpression
+    ): StackValue {
         loadArguments(codegen, data)
+        codegen.markLineNumber(expression)
         return StackValue.onStack(genInvokeInstructionWithResult(v))
     }
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/RangeTo.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/RangeTo.kt
@@ -50,10 +50,16 @@ object RangeTo : IntrinsicMethod() {
                 v.invokespecial(signature.returnType.internalName, "<init>", Type.getMethodDescriptor(Type.VOID_TYPE, argType, argType), false)
             }
 
-            override fun invoke(v: InstructionAdapter, codegen: ExpressionCodegen, data: BlockInfo): StackValue {
+            override fun invoke(
+                v: InstructionAdapter,
+                codegen: ExpressionCodegen,
+                data: BlockInfo,
+                expression: IrFunctionAccessExpression
+            ): StackValue {
+                codegen.markLineNumber(expression)
                 v.anew(returnType)
                 v.dup()
-                return super.invoke(v, codegen, data)
+                return super.invoke(v, codegen, data, expression)
             }
         }
     }

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/JvmOptimizationLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/JvmOptimizationLowering.kt
@@ -40,10 +40,6 @@ class JvmOptimizationLowering(val context: JvmBackendContext) : FileLoweringPass
                     context.state.intrinsics.getIntrinsic(expression.symbol.descriptor) is Not
     }
 
-    private fun hasNoSideEffectsForNullCompare(expression: IrExpression): Boolean {
-        return expression.type.isPrimitiveType() && (expression is IrConst<*> || expression is IrGetValue)
-    }
-
     private val IrFunction.isObjectEquals
         get() = name.asString() == "equals" &&
                 valueParameters.count() == 1 &&

--- a/compiler/testData/codegen/bytecodeText/iincGeneration.kt
+++ b/compiler/testData/codegen/bytecodeText/iincGeneration.kt
@@ -1,0 +1,41 @@
+fun main(args: Array<String>) {
+    var i = 10
+
+    // -- 4 of these fit in iinc instructions
+    i += 1
+    i += 127
+    i += 128
+    i += -1
+    i += -128
+    i += -129
+
+    // -- 4 of these fit in iinc instructions
+    i -= 1
+    i -= 128
+    i -= 129
+    i -= -1
+    i -= -127
+    i -= -128
+
+    // -- 4 of these fit in iinc instructions
+    i = i + 1
+    i = i + 127
+    i = i + 128
+    i = i + -1
+    i = i + -128
+    i = i + -129
+
+    // -- 4 of these fit in iinc instructions
+    i = i - 1
+    i = i - 128
+    i = i - 129
+    i = i - -1
+    i = i - -127
+    i = i - -128
+}
+
+// JVM_IR_TEMPLATES
+// 16 IINC
+
+// JVM_TEMPLATES
+// 0 IINC

--- a/compiler/testData/codegen/bytecodeText/prefixIntVarIncrement.kt
+++ b/compiler/testData/codegen/bytecodeText/prefixIntVarIncrement.kt
@@ -1,6 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
-// KT-36641 TODO Generate IINC instruction for prefix increment in JVM_IR
-
 fun main(args: Array<String>) {
     var i = 10
     ++i

--- a/compiler/testData/debug/stepping/iincStepping.kt
+++ b/compiler/testData/debug/stepping/iincStepping.kt
@@ -1,0 +1,47 @@
+//FILE: test.kt
+fun box() {
+    var i = 0
+    ++i
+    i += 1
+    i +=
+        1
+    i -= 1
+    i -=
+        1
+    i = i + 1
+    i =
+        i + 1
+    i =
+        i +
+            1
+}
+
+// IGNORE_BACKEND: JVM
+// The current backend has strange stepping behavior for assignments.
+// It generates the line number for the assignment first, and then
+// the evaluation of the right hand side with line numbers.
+// That leads to the line number with the assignment typically
+// not being hit at all as it has no instructions. Also, stepping
+// through the evaluation of the right hand side and then hitting
+// the line number for the actual assignment makes more sense as
+// that is the actual evaluation order.
+
+// LINENUMBERS
+// test.kt:3
+// test.kt:4
+// test.kt:5
+// test.kt:6
+// test.kt:7
+// test.kt:6
+// test.kt:8
+// test.kt:9
+// test.kt:10
+// test.kt:9
+// test.kt:11
+// test.kt:13
+// test.kt:12
+// test.kt:15
+// test.kt:16
+// test.kt:15
+// test.kt:14
+// test.kt:17

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
@@ -124,6 +124,11 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
         runTest("compiler/testData/codegen/bytecodeText/flagsInMultiFileInherit.kt");
     }
 
+    @TestMetadata("iincGeneration.kt")
+    public void testIincGeneration() throws Exception {
+        runTest("compiler/testData/codegen/bytecodeText/iincGeneration.kt");
+    }
+
     @TestMetadata("inheritedPropertyAnnotations.kt")
     public void testInheritedPropertyAnnotations() throws Exception {
         runTest("compiler/testData/codegen/bytecodeText/inheritedPropertyAnnotations.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/debugInformation/IrSteppingTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/debugInformation/IrSteppingTestGenerated.java
@@ -68,6 +68,12 @@ public class IrSteppingTestGenerated extends AbstractIrSteppingTest {
     }
 
     @Test
+    @TestMetadata("iincStepping.kt")
+    public void testIincStepping() throws Exception {
+        runTest("compiler/testData/debug/stepping/iincStepping.kt");
+    }
+
+    @Test
     @TestMetadata("inlineCallableReference.kt")
     public void testInlineCallableReference() throws Exception {
         runTest("compiler/testData/debug/stepping/inlineCallableReference.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/debugInformation/SteppingTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/debugInformation/SteppingTestGenerated.java
@@ -68,6 +68,12 @@ public class SteppingTestGenerated extends AbstractSteppingTest {
     }
 
     @Test
+    @TestMetadata("iincStepping.kt")
+    public void testIincStepping() throws Exception {
+        runTest("compiler/testData/debug/stepping/iincStepping.kt");
+    }
+
+    @Test
     @TestMetadata("inlineCallableReference.kt")
     public void testInlineCallableReference() throws Exception {
         runTest("compiler/testData/debug/stepping/inlineCallableReference.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
@@ -124,6 +124,11 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
         runTest("compiler/testData/codegen/bytecodeText/flagsInMultiFileInherit.kt");
     }
 
+    @TestMetadata("iincGeneration.kt")
+    public void testIincGeneration() throws Exception {
+        runTest("compiler/testData/codegen/bytecodeText/iincGeneration.kt");
+    }
+
     @TestMetadata("inheritedPropertyAnnotations.kt")
     public void testInheritedPropertyAnnotations() throws Exception {
         runTest("compiler/testData/codegen/bytecodeText/inheritedPropertyAnnotations.kt");


### PR DESCRIPTION
Fix line number generation for assignments where the right-hand
side of the assignment is not on the same line.

Fix line number generation for intrinsics functions where the
function is not on the same line as the last argument.

Be careful to not break stepping behavior with the iinc
optimizations.