### PR TITLE
Fix zipPlugin task

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -802,18 +802,15 @@ val zipPlugin by task<Zip> {
     }
     val destPath = project.findProperty("pluginZipPath") as String?
     val dest = File(destPath ?: "$buildDir/kotlin-plugin.zip")
-    destinationDir = dest.parentFile
-    archiveName = dest.name
-    doFirst {
-        if (destPath == null) throw GradleException("Specify target zip path with 'pluginZipPath' property")
-    }
+    destinationDirectory.set(dest.parentFile)
+    archiveFileName.set(dest.name)
 
     from(src)
     into("Kotlin")
     setExecutablePermissions()
 
     doLast {
-        logger.lifecycle("Plugin artifacts packed to $archivePath")
+        logger.lifecycle("Plugin artifacts packed to $archiveFile")
     }
 }
 


### PR DESCRIPTION
This PR fixes the zipPlugin task by:
1) **Removing the deprecated calls.** Previously, the zipPlugin task would consistently give the following error due do the deprecated calls on L805-806:
```
Could not create task ':zipPlugin'.
> path may not be null or empty string. path='null'
```

2) **Allowing the default destination path for an empty pluginZipPath argument.**  At L804, if destPath were null due to an empty `zipPluginPath` argument, a default path is used. The doFirst block at L807-809 prevents the default path from being used by error'ing prematurely on a null destPath. Therefore, the doFirst block is removed.