### PR TITLE
Properly link properties and their getter/setters.

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/MethodSignatureMapper.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/MethodSignatureMapper.kt
@@ -90,22 +90,7 @@ class MethodSignatureMapper(private val context: JvmBackendContext) {
             return mangleMemberNameIfRequired(accessorName, function)
         }
 
-        val functionName = workaroundPropertyAccessorName(function) ?: function.name.asString()
-        return mangleMemberNameIfRequired(functionName, function)
-    }
-
-    // This is a dirty hack which is needed to correctly map names of property accessors whose correspondingPropertySymbol was lost.
-    // The reason it's needed is that it sometimes gets lost during DeepCopyIrTreeWithSymbols because that algorithm doesn't copy
-    // the link to the property when transforming a simple function. This can be fixed but might require a lot of changes in backends,
-    // and will likely be unneeded as soon as we have proper properties in the IR (IrProperty which is a declaration parent).
-    // TODO: remove this hack as soon as IrProperty is a declaration parent
-    private fun workaroundPropertyAccessorName(function: IrFunction): String? {
-        val name = function.name.asString()
-        val ifGetter = name.removeSurrounding("<get-", ">")
-        if (ifGetter != name) return JvmAbi.getterName(ifGetter)
-        val ifSetter = name.removeSurrounding("<set-", ">")
-        if (ifSetter != name) return JvmAbi.setterName(ifSetter)
-        return null
+        return mangleMemberNameIfRequired(function.name.asString(), function)
     }
 
     private fun mangleMemberNameIfRequired(name: String, function: IrFunction): String {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/BridgeLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/BridgeLowering.kt
@@ -335,6 +335,14 @@ private class BridgeLowering(val context: JvmBackendContext) : FileLoweringPass,
             returnType = irFunction.returnType
             isFakeOverride = false
         }.apply {
+            // If the function is a property accessor, link in the new function as the new accessor for the property.
+            correspondingPropertySymbol = irFunction.correspondingPropertySymbol?.also {
+                if (irFunction.isGetter) {
+                    it.owner.getter = this
+                } else {
+                    it.owner.setter = this
+                }
+            }
             copyParametersWithErasure(this@addAbstractMethodStub, irFunction, needsArgumentBoxing)
         }
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/GenerateMultifileFacades.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/GenerateMultifileFacades.kt
@@ -41,6 +41,7 @@ import org.jetbrains.kotlin.ir.visitors.IrElementTransformer
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
 import org.jetbrains.kotlin.load.java.JavaVisibilities
+import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.resolve.jvm.JvmClassName
 
 internal val generateMultifileFacadesPhase = namedIrModulePhase(
@@ -217,7 +218,14 @@ private fun IrSimpleFunction.createMultifileDelegateIfNeeded(
     val function = buildFun {
         updateFrom(target)
         isFakeOverride = shouldGeneratePartHierarchy
-        name = target.name
+        name = if (shouldGeneratePartHierarchy) {
+            target.name
+        } else {
+            // Generating a bridge. If the bridge is targeting a property getter
+            // we need to take care to get the name right. The bridge is not a
+            // property getter itself.
+            Name.identifier(context.methodSignatureMapper.mapFunctionName(target))
+        }
     }
 
     function.copyParameterDeclarationsFrom(target)

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/JvmStaticAnnotationLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/JvmStaticAnnotationLowering.kt
@@ -34,6 +34,7 @@ import org.jetbrains.kotlin.ir.expressions.impl.IrTypeOperatorCallImpl
 import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
+import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.resolve.annotations.JVM_STATIC_ANNOTATION_FQ_NAME
 
 internal val jvmStaticAnnotationPhase = makeIrFilePhase(
@@ -92,7 +93,10 @@ private class CompanionObjectJvmStaticLowering(val context: JvmBackendContext) :
         addFunction {
             returnType = target.returnType
             origin = JvmLoweredDeclarationOrigin.JVM_STATIC_WRAPPER
-            name = target.name
+            // The proxy needs to have the same name as what it is targeting. If that is a property accessor,
+            // we need to make sure that the name is mapped correctly. The static method is not a property accessor,
+            // so we do not have a property to link it up to. Therefore, we compute the right name now.
+            name = Name.identifier(context.methodSignatureMapper.mapFunctionName(target))
             modality = if (isInterface) Modality.OPEN else target.modality
             visibility = target.visibility
             isSuspend = target.isSuspend

--- a/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/ClassGenerator.kt
+++ b/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/ClassGenerator.kt
@@ -275,6 +275,9 @@ class ClassGenerator(
         if (delegatedDescriptor.isVar) {
             irProperty.setter = generateDelegatedFunction(irDelegate, delegatedDescriptor.setter!!, delegateToDescriptor.setter!!)
         }
+
+        irProperty.linkCorrespondingPropertySymbol()
+
         return irProperty
     }
 

--- a/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/DelegatedPropertyGenerator.kt
+++ b/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/DelegatedPropertyGenerator.kt
@@ -86,6 +86,8 @@ class DelegatedPropertyGenerator(declarationGenerator: DeclarationGenerator) : D
             }
         }
 
+        irProperty.linkCorrespondingPropertySymbol()
+
         return irProperty
     }
 

--- a/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/PropertyGenerator.kt
+++ b/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/PropertyGenerator.kt
@@ -76,6 +76,8 @@ class PropertyGenerator(declarationGenerator: DeclarationGenerator) : Declaratio
                 irProperty.setter =
                     FunctionGenerator(declarationGenerator).generateDefaultAccessorForPrimaryConstructorParameter(setter, ktParameter)
             }
+
+            irProperty.linkCorrespondingPropertySymbol()
         }
     }
 
@@ -133,6 +135,8 @@ class PropertyGenerator(declarationGenerator: DeclarationGenerator) : Declaratio
 
             irProperty.getter = generateGetterIfRequired(ktProperty, propertyDescriptor)
             irProperty.setter = generateSetterIfRequired(ktProperty, propertyDescriptor)
+
+            irProperty.linkCorrespondingPropertySymbol()
         }
 
     fun generateFakeOverrideProperty(propertyDescriptor: PropertyDescriptor, ktElement: KtPureElement): IrProperty? {
@@ -158,6 +162,7 @@ class PropertyGenerator(declarationGenerator: DeclarationGenerator) : Declaratio
             this.setter = propertyDescriptor.setter?.let {
                 FunctionGenerator(declarationGenerator).generateFakeOverrideFunction(it, ktElement)
             }
+            this.linkCorrespondingPropertySymbol()
         }
     }
 
@@ -188,4 +193,11 @@ class PropertyGenerator(declarationGenerator: DeclarationGenerator) : Declaratio
                 else -> Visibilities.PRIVATE
             }
 }
+
+internal fun IrProperty.linkCorrespondingPropertySymbol() {
+    backingField?.correspondingPropertySymbol = symbol
+    getter?.correspondingPropertySymbol = symbol
+    setter?.correspondingPropertySymbol = symbol
+}
+
 

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/DeepCopyIrTreeWithSymbols.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/DeepCopyIrTreeWithSymbols.kt
@@ -221,10 +221,13 @@ open class DeepCopyIrTreeWithSymbols(
             isExternal = declaration.isExternal
         ).apply {
             transformAnnotations(declaration)
-            this.backingField = declaration.backingField?.transform()
-            this.getter = declaration.getter?.transform()
-            this.setter = declaration.setter?.transform()
-            this.backingField?.let {
+            this.backingField = declaration.backingField?.transform()?.also {
+                it.correspondingPropertySymbol = symbol
+            }
+            this.getter = declaration.getter?.transform()?.also {
+                it.correspondingPropertySymbol = symbol
+            }
+            this.setter = declaration.setter?.transform()?.also {
                 it.correspondingPropertySymbol = symbol
             }
         }

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/PatchDeclarationParents.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/PatchDeclarationParents.kt
@@ -53,19 +53,6 @@ class PatchDeclarationParentsVisitor() : IrElementVisitorVoid {
         }
     }
 
-    override fun visitProperty(declaration: IrProperty) {
-        declaration.getter?.let {
-            it.correspondingPropertySymbol = declaration.symbol
-        }
-        declaration.setter?.let {
-            it.correspondingPropertySymbol = declaration.symbol
-        }
-        declaration.backingField?.let {
-            it.correspondingPropertySymbol = declaration.symbol
-        }
-        super.visitProperty(declaration)
-    }
-
     private fun patchParent(declaration: IrDeclaration) {
         declaration.parent = declarationParentsStack.peekFirst()
     }

--- a/compiler/testData/codegen/bytecodeText/builtinFunctions/size.kt
+++ b/compiler/testData/codegen/bytecodeText/builtinFunctions/size.kt
@@ -53,10 +53,6 @@ fun box(
     c2.size
 }
 
-/*
-
-*/
-
 // 8 public final bridge size\(\)I
 // 8 INVOKEVIRTUAL A[0-9]+\.size \(\)I
 // 1 INVOKEINTERFACE A9+\.size \(\)I


### PR DESCRIPTION
This allows removing a hack in the MethodSignatureMapper.

When introducing non-getter methods that dispatch to a getter
we have to be careful to use the right name.

DeepCopyIrTreeWithSymbols should create the link between new
properties and their new getter/setter.