### PR TITLE
KT-38068 Explicitly declare throw of IOException for `readLine`

### DIFF
--- a/libraries/stdlib/jvm/src/kotlin/io/Console.kt
+++ b/libraries/stdlib/jvm/src/kotlin/io/Console.kt
@@ -7,6 +7,7 @@
 
 package kotlin.io
 
+import java.io.IOException
 import java.io.InputStream
 import java.nio.ByteBuffer
 import java.nio.CharBuffer
@@ -145,6 +146,7 @@ public actual inline fun println() {
  *
  * @return the line read or `null` if the input stream is redirected to a file and the end of file has been reached.
  */
+@Throws(IOException::class)
 fun readLine(): String? = LineReader.readLine(System.`in`, Charset.defaultCharset())
 
 // Singleton object lazy initializes on the first use, internal for tests


### PR DESCRIPTION
The following is copied from [KT-38068](https://youtrack.jetbrains.com/issue/KT-38068)

Current signature:
```kotlin
fun readLine(): String?
```
This function uses `InputStream.read()` from Java. 
It's very error-prone because `readLine` is blocking but can be used in a suspend function without the warning "BlockingMethodInNonBlockingContext" .

Should be modified to
```kotlin
@Throws(IOException::class)
fun readLine(): String?
```
to help create this warning:
![image](https://user-images.githubusercontent.com/12100985/78740614-d177ef00-7989-11ea-88cc-ef6da9c53a3a.png)
