### PR TITLE
KT-38139 False negative "Add suspend modifier" quickfix when suspend function is called in inline lambda

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/AddSuspendModifierFix.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/AddSuspendModifierFix.kt
@@ -8,12 +8,14 @@ package org.jetbrains.kotlin.idea.quickfix
 import com.intellij.codeInsight.intention.IntentionAction
 import org.jetbrains.kotlin.builtins.isFunctionType
 import org.jetbrains.kotlin.cfg.pseudocode.containingDeclarationForPseudocode
+import org.jetbrains.kotlin.codegen.inline.isInlineOrInsideInline
 import org.jetbrains.kotlin.descriptors.ValueDescriptor
 import org.jetbrains.kotlin.diagnostics.Diagnostic
 import org.jetbrains.kotlin.idea.KotlinBundle
 import org.jetbrains.kotlin.idea.caches.resolve.resolveToCall
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 import org.jetbrains.kotlin.resolve.DescriptorToSourceUtils
 
 class AddSuspendModifierFix(
@@ -41,11 +43,25 @@ class AddSuspendModifierFix(
 
     companion object : KotlinSingleIntentionActionFactory() {
         override fun createAction(diagnostic: Diagnostic): IntentionAction? {
-            val element = diagnostic.psiElement
-            val function = (element as? KtElement)?.containingDeclarationForPseudocode as? KtNamedFunction ?: return null
+            val element = diagnostic.psiElement as? KtElement ?: return null
+            val function = element.containingFunction() ?: return null
             val functionName = function.name ?: return null
 
             return AddSuspendModifierFix(function, functionName)
+        }
+
+        private fun KtElement.containingFunction(): KtNamedFunction? {
+            val containingDeclaration = containingDeclarationForPseudocode
+            return if (containingDeclaration is KtFunctionLiteral) {
+                val call = containingDeclaration.getStrictParentOfType<KtCallExpression>()
+                if (call?.resolveToCall()?.resultingDescriptor?.isInlineOrInsideInline() == true) {
+                    containingDeclaration.containingFunction()
+                } else {
+                    null
+                }
+            } else {
+                containingDeclaration as? KtNamedFunction
+            }
         }
     }
 

--- a/idea/testData/quickfix/modifiers/suspend/inLambda.kt
+++ b/idea/testData/quickfix/modifiers/suspend/inLambda.kt
@@ -1,0 +1,11 @@
+// "Make test suspend" "true"
+suspend fun foo() {}
+
+inline fun bar(f: () -> Unit) {
+}
+
+fun test() {
+    bar {
+        <caret>foo()
+    }
+}

--- a/idea/testData/quickfix/modifiers/suspend/inLambda.kt.after
+++ b/idea/testData/quickfix/modifiers/suspend/inLambda.kt.after
@@ -1,0 +1,11 @@
+// "Make test suspend" "true"
+suspend fun foo() {}
+
+inline fun bar(f: () -> Unit) {
+}
+
+suspend fun test() {
+    bar {
+        foo()
+    }
+}

--- a/idea/testData/quickfix/modifiers/suspend/inLambda2.kt
+++ b/idea/testData/quickfix/modifiers/suspend/inLambda2.kt
@@ -1,0 +1,17 @@
+// "Make test suspend" "false"
+// DISABLE-ERRORS
+// ACTION: Convert to single-line lambda
+// ACTION: Enable a trailing comma by default in the formatter
+// ACTION: Introduce import alias
+// ACTION: Move lambda argument into parentheses
+// ACTION: Specify explicit lambda signature
+suspend fun foo() {}
+
+fun bar(f: () -> Unit) {
+}
+
+fun test() {
+    bar {
+        <caret>foo()
+    }
+}

--- a/idea/testData/quickfix/modifiers/suspend/inLambda3.kt
+++ b/idea/testData/quickfix/modifiers/suspend/inLambda3.kt
@@ -1,0 +1,16 @@
+// "Make test suspend" "true"
+suspend fun foo() {}
+
+inline fun bar(f: () -> Unit) {
+}
+
+inline fun baz(f: () -> Unit) {
+}
+
+fun test() {
+    baz {
+        bar {
+            <caret>foo()
+        }
+    }
+}

--- a/idea/testData/quickfix/modifiers/suspend/inLambda3.kt.after
+++ b/idea/testData/quickfix/modifiers/suspend/inLambda3.kt.after
@@ -1,0 +1,16 @@
+// "Make test suspend" "true"
+suspend fun foo() {}
+
+inline fun bar(f: () -> Unit) {
+}
+
+inline fun baz(f: () -> Unit) {
+}
+
+suspend fun test() {
+    baz {
+        bar {
+            foo()
+        }
+    }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -9515,6 +9515,21 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
                 runTest("idea/testData/quickfix/modifiers/suspend/createCoroutine.kt");
             }
 
+            @TestMetadata("inLambda.kt")
+            public void testInLambda() throws Exception {
+                runTest("idea/testData/quickfix/modifiers/suspend/inLambda.kt");
+            }
+
+            @TestMetadata("inLambda2.kt")
+            public void testInLambda2() throws Exception {
+                runTest("idea/testData/quickfix/modifiers/suspend/inLambda2.kt");
+            }
+
+            @TestMetadata("inLambda3.kt")
+            public void testInLambda3() throws Exception {
+                runTest("idea/testData/quickfix/modifiers/suspend/inLambda3.kt");
+            }
+
             @TestMetadata("init.kt")
             public void testInit() throws Exception {
                 runTest("idea/testData/quickfix/modifiers/suspend/init.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-38139