### PR TITLE
KT-31397 NONE_APPLICABLE quick fix suggests to re-create function if its argument expression contains unresolved operator

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createCallable/CreateCallableFromCallActionFactory.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/createCallable/CreateCallableFromCallActionFactory.kt
@@ -67,7 +67,8 @@ sealed class CreateCallableFromCallActionFactory<E : KtExpression>(
 
             Errors.NO_VALUE_FOR_PARAMETER,
             Errors.TOO_MANY_ARGUMENTS,
-            Errors.NONE_APPLICABLE -> diagElement.getNonStrictParentOfType<KtCallExpression>()
+            Errors.NONE_APPLICABLE ->
+                if (diagElement is KtOperationReferenceExpression) null else diagElement.getNonStrictParentOfType<KtCallExpression>()
 
             Errors.TYPE_MISMATCH -> (diagElement.parent as? KtValueArgument)?.getStrictParentOfType<KtCallExpression>()
 

--- a/idea/testData/quickfix/createFromUsage/createFunction/call/binaryOperationInCall.kt
+++ b/idea/testData/quickfix/createFromUsage/createFunction/call/binaryOperationInCall.kt
@@ -1,0 +1,21 @@
+// "Create function 'operate'" "false"
+// ACTION: Add 'p =' to argument
+// ACTION: Create extension function 'Operated.plus'
+// ACTION: Create member function 'Operated.plus'
+// ACTION: Flip '+'
+// ACTION: Replace overloaded operator with function call
+// DISABLE-ERRORS
+class OperandA
+class OperandB
+class OperandC
+class Operated {
+    operator fun plus(o: OperandA) {}
+    operator fun plus(o: OperandB) {}
+}
+
+fun operate(p: Any?) {}
+
+fun combine() {
+    operate(Operated() + OperandA())
+    operate(Operated() <caret>+ OperandC())
+}

--- a/idea/testData/quickfix/createFromUsage/createFunction/call/unaryOperationInCall.kt
+++ b/idea/testData/quickfix/createFromUsage/createFunction/call/unaryOperationInCall.kt
@@ -1,0 +1,13 @@
+// "Create function 'operate'" "false"
+// ACTION: Add 'p =' to argument
+// ACTION: Create extension function 'Operated.unaryPlus'
+// ACTION: Create member function 'Operated.unaryPlus'
+// ACTION: Replace overloaded operator with function call
+// DISABLE-ERRORS
+class Operated
+
+fun operate(p: Any?) {}
+
+fun combine() {
+    operate(<caret>+Operated())
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -3915,6 +3915,11 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
                     runTest("idea/testData/quickfix/createFromUsage/createFunction/call/argumentTypeMismatch.kt");
                 }
 
+                @TestMetadata("binaryOperationInCall.kt")
+                public void testBinaryOperationInCall() throws Exception {
+                    runTest("idea/testData/quickfix/createFromUsage/createFunction/call/binaryOperationInCall.kt");
+                }
+
                 @TestMetadata("callInAnnotationEntry.kt")
                 public void testCallInAnnotationEntry() throws Exception {
                     runTest("idea/testData/quickfix/createFromUsage/createFunction/call/callInAnnotationEntry.kt");
@@ -4218,6 +4223,11 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
                 @TestMetadata("topLevelFunPlacement.kt")
                 public void testTopLevelFunPlacement() throws Exception {
                     runTest("idea/testData/quickfix/createFromUsage/createFunction/call/topLevelFunPlacement.kt");
+                }
+
+                @TestMetadata("unaryOperationInCall.kt")
+                public void testUnaryOperationInCall() throws Exception {
+                    runTest("idea/testData/quickfix/createFromUsage/createFunction/call/unaryOperationInCall.kt");
                 }
 
                 @TestMetadata("unitFun.kt")


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-31397