### PR TITLE
KT-38240 False positive redundant semicolon with `as` cast and `not` unary operator on next line

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantSemicolonInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantSemicolonInspection.kt
@@ -90,9 +90,13 @@ class RedundantSemicolonInspection : AbstractKotlinInspection(), CleanupLocalIns
                 return false
             }
 
-            val prevNameReference = semicolon.getPrevSiblingIgnoringWhitespaceAndComments() as? KtNameReferenceExpression
-            if (prevNameReference != null && prevNameReference.text in softModifierKeywords
-                && semicolon.getNextSiblingIgnoringWhitespaceAndComments() is KtDeclaration
+            val prevSibling = semicolon.getPrevSiblingIgnoringWhitespaceAndComments()
+            val nextSibling = semicolon.getNextSiblingIgnoringWhitespaceAndComments()
+            if (prevSibling.safeAs<KtNameReferenceExpression>()?.text in softModifierKeywords &&
+                nextSibling is KtDeclaration
+            ) return false
+            if (nextSibling.safeAs<KtPrefixExpression>()?.operationToken == KtTokens.EXCL &&
+                semicolon.prevLeaf()?.getStrictParentOfType<KtTypeReference>() != null
             ) return false
 
             return true

--- a/idea/testData/inspectionsLocal/redundantSemicolon/betweenTypeAndNotOperator.kt
+++ b/idea/testData/inspectionsLocal/redundantSemicolon/betweenTypeAndNotOperator.kt
@@ -1,0 +1,9 @@
+// PROBLEM: none
+fun test(a: Any) {
+    foo {
+        val b = a as Boolean;<caret>
+        !b
+    }
+}
+
+fun foo(f: () -> Boolean) {}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -8170,6 +8170,11 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
             runTest("idea/testData/inspectionsLocal/redundantSemicolon/betweenSoftModifierKeywordAndDeclaration3.kt");
         }
 
+        @TestMetadata("betweenTypeAndNotOperator.kt")
+        public void testBetweenTypeAndNotOperator() throws Exception {
+            runTest("idea/testData/inspectionsLocal/redundantSemicolon/betweenTypeAndNotOperator.kt");
+        }
+
         @TestMetadata("companionBeforeFun.kt")
         public void testCompanionBeforeFun() throws Exception {
             runTest("idea/testData/inspectionsLocal/redundantSemicolon/companionBeforeFun.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-38240