### PR TITLE
Psi2Ir: Bind unbound type parameters

### DIFF
--- a/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
@@ -14356,6 +14356,11 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
             runTest("compiler/testData/codegen/box/javaInterop/lambdaInstanceOf.kt");
         }
 
+        @TestMetadata("samUnboundTypeParameter.kt")
+        public void testSamUnboundTypeParameter() throws Exception {
+            runTest("compiler/testData/codegen/box/javaInterop/samUnboundTypeParameter.kt");
+        }
+
         @TestMetadata("compiler/testData/codegen/box/javaInterop/generics")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/DeclarationStubGenerator.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/DeclarationStubGenerator.kt
@@ -120,6 +120,8 @@ class DeclarationStubGenerator(
                 generatePropertyStub(descriptor)
             is TypeAliasDescriptor ->
                 generateTypeAliasStub(descriptor)
+            is TypeParameterDescriptor ->
+                generateOrGetTypeParameterStub(descriptor)
             else ->
                 throw AssertionError("Unexpected member descriptor: $descriptor")
         }

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/ExternalDependenciesGenerator.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/ExternalDependenciesGenerator.kt
@@ -65,6 +65,7 @@ private val SymbolTable.allUnbound: List<IrSymbol>
         r.addAll(unboundSimpleFunctions)
         r.addAll(unboundProperties)
         r.addAll(unboundTypeAliases)
+        r.addAll(unboundTypeParameters)
         return r
     }
 

--- a/compiler/testData/codegen/box/javaInterop/samUnboundTypeParameter.kt
+++ b/compiler/testData/codegen/box/javaInterop/samUnboundTypeParameter.kt
@@ -1,0 +1,22 @@
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND_FIR: JVM_IR
+// !LANGUAGE: -NewInference
+// WITH_RUNTIME
+// FILE: Base.java
+import java.lang.Runnable;
+import java.lang.IllegalStateException;
+
+public class Base<T> {
+    public <S> S add(Base<S> value, Runnable block) { return null; }
+}
+
+// FILE: Derived.kt
+class Derived<T>(val value: T) : Base<T>() {
+    init {
+        add(this) {}
+    }
+}
+
+fun box(): String {
+    return Derived("OK").value
+}

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -15571,6 +15571,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             runTest("compiler/testData/codegen/box/javaInterop/lambdaInstanceOf.kt");
         }
 
+        @TestMetadata("samUnboundTypeParameter.kt")
+        public void testSamUnboundTypeParameter() throws Exception {
+            runTest("compiler/testData/codegen/box/javaInterop/samUnboundTypeParameter.kt");
+        }
+
         @TestMetadata("compiler/testData/codegen/box/javaInterop/generics")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -15571,6 +15571,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/javaInterop/lambdaInstanceOf.kt");
         }
 
+        @TestMetadata("samUnboundTypeParameter.kt")
+        public void testSamUnboundTypeParameter() throws Exception {
+            runTest("compiler/testData/codegen/box/javaInterop/samUnboundTypeParameter.kt");
+        }
+
         @TestMetadata("compiler/testData/codegen/box/javaInterop/generics")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -14356,6 +14356,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             runTest("compiler/testData/codegen/box/javaInterop/lambdaInstanceOf.kt");
         }
 
+        @TestMetadata("samUnboundTypeParameter.kt")
+        public void testSamUnboundTypeParameter() throws Exception {
+            runTest("compiler/testData/codegen/box/javaInterop/samUnboundTypeParameter.kt");
+        }
+
         @TestMetadata("compiler/testData/codegen/box/javaInterop/generics")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)


### PR DESCRIPTION
Without NewInference we sometimes generate unbound type parameters, which end up breaking at random points during lowering. This PR fixes the problem for the JVM IR backend. I'm not sure if the same thing can happen in the JS_IR or NATIVE backends, though.