### PR TITLE
IR: more consolidation of synthetic member generation for data class.

### DIFF
--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/generators/DataClassMembersGenerator.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/generators/DataClassMembersGenerator.kt
@@ -5,10 +5,7 @@
 
 package org.jetbrains.kotlin.fir.backend.generators
 
-import org.jetbrains.kotlin.descriptors.CallableDescriptor
-import org.jetbrains.kotlin.descriptors.FunctionDescriptor
-import org.jetbrains.kotlin.descriptors.Modality
-import org.jetbrains.kotlin.descriptors.Visibilities
+import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.fir.backend.Fir2IrComponents
 import org.jetbrains.kotlin.fir.backend.declareThisReceiverParameter
 import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
@@ -20,8 +17,8 @@ import org.jetbrains.kotlin.ir.descriptors.WrappedSimpleFunctionDescriptor
 import org.jetbrains.kotlin.ir.descriptors.WrappedValueParameterDescriptor
 import org.jetbrains.kotlin.ir.expressions.IrMemberAccessExpression
 import org.jetbrains.kotlin.ir.types.IrType
+import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.ir.util.DataClassMembersGenerator
-import org.jetbrains.kotlin.ir.util.defaultType
 import org.jetbrains.kotlin.name.Name
 
 class DataClassMembersGenerator(val components: Fir2IrComponents) {
@@ -30,6 +27,15 @@ class DataClassMembersGenerator(val components: Fir2IrComponents) {
 
     fun generateDataClassMembers(irClass: IrClass): List<Name> =
         MyDataClassMethodsGenerator(irClass, IrDeclarationOrigin.GENERATED_DATA_CLASS_MEMBER).generate()
+
+    fun generateDataClassComponentBody(irFunction: IrFunction) =
+        MyDataClassMethodsGenerator(irFunction.parentAsClass, IrDeclarationOrigin.GENERATED_DATA_CLASS_MEMBER)
+            .generateComponentBody(irFunction)
+
+    fun generateDataClassCopyBody(irFunction: IrFunction) =
+        MyDataClassMethodsGenerator(irFunction.parentAsClass, IrDeclarationOrigin.GENERATED_DATA_CLASS_MEMBER)
+            .generateCopyBody(irFunction)
+
 
     private inner class MyDataClassMethodsGenerator(
         val irClass: IrClass,
@@ -49,6 +55,18 @@ class DataClassMembersGenerator(val components: Fir2IrComponents) {
 
             override fun generateSyntheticFunctionParameterDeclarations(irFunction: IrFunction) {
                 // TODO
+            }
+
+            override fun getBackingField(parameter: ValueParameterDescriptor?, irValueParameter: IrValueParameter?): IrField? =
+                irValueParameter?.let {
+                    irClass.properties.single { irProperty ->
+                        irProperty.name == irValueParameter.name && irProperty.backingField?.type == irValueParameter.type
+                    }.backingField
+                }
+
+            override fun transform(typeParameterDescriptor: TypeParameterDescriptor): IrType {
+                // TODO
+                return components.irBuiltIns.anyType
             }
 
             override fun commitSubstituted(irMemberAccessExpression: IrMemberAccessExpression, descriptor: CallableDescriptor) {
@@ -72,33 +90,45 @@ class DataClassMembersGenerator(val components: Fir2IrComponents) {
                 return emptyList()
             }
 
-            // TODO: consolidate componentN() and copy(...) too?
-
             // TODO: generate equals, hashCode, and toString only if needed
             val equalsFunction = createSyntheticIrFunction(
                 Name.identifier("equals"),
-                components.irBuiltIns.booleanType,
+                components.irBuiltIns.booleanType
             ).apply {
                 valueParameters = listOf(
                     createSyntheticIrParameter(this, Name.identifier("other"), components.irBuiltIns.anyNType)
                 )
             }
             irDataClassMembersGenerator.generateEqualsMethod(equalsFunction, properties)
+            irClass.declarations.add(equalsFunction)
 
             val hashCodeFunction = createSyntheticIrFunction(
                 Name.identifier("hashCode"),
-                components.irBuiltIns.intType,
+                components.irBuiltIns.intType
             )
             irDataClassMembersGenerator.generateHashCodeMethod(hashCodeFunction, properties)
+            irClass.declarations.add(hashCodeFunction)
 
             val toStringFunction = createSyntheticIrFunction(
                 Name.identifier("toString"),
-                components.irBuiltIns.stringType,
+                components.irBuiltIns.stringType
             )
             irDataClassMembersGenerator.generateToStringMethod(toStringFunction, properties)
+            irClass.declarations.add(toStringFunction)
 
             return listOf(equalsFunction.name, hashCodeFunction.name, toStringFunction.name)
         }
+
+        fun generateComponentBody(irFunction: IrFunction) {
+            val index = getComponentIndex(irFunction)!!
+            val valueParameter = irClass.primaryConstructor!!.valueParameters[index - 1]
+            val backingField = irDataClassMembersGenerator.getBackingField(null, valueParameter)!!
+            irDataClassMembersGenerator
+                .generateComponentFunction(irFunction, backingField, valueParameter.startOffset, valueParameter.endOffset)
+        }
+
+        fun generateCopyBody(irFunction: IrFunction) =
+            irDataClassMembersGenerator.generateCopyFunction(irFunction, irClass.primaryConstructor!!.symbol)
 
         private fun createSyntheticIrFunction(name: Name, returnType: IrType): IrFunction {
             val functionDescriptor = WrappedSimpleFunctionDescriptor()
@@ -130,7 +160,7 @@ class DataClassMembersGenerator(val components: Fir2IrComponents) {
             }
         }
 
-        private fun createSyntheticIrParameter(irFunction: IrFunction, name: Name, type: IrType): IrValueParameter {
+        private fun createSyntheticIrParameter(irFunction: IrFunction, name: Name, type: IrType, index: Int = 0): IrValueParameter {
             val descriptor = WrappedValueParameterDescriptor()
             return components.symbolTable.declareValueParameter(
                 UNDEFINED_OFFSET,
@@ -145,7 +175,7 @@ class DataClassMembersGenerator(val components: Fir2IrComponents) {
                     origin,
                     symbol,
                     name,
-                    0,
+                    index,
                     type,
                     null,
                     isCrossinline = false,
@@ -156,5 +186,27 @@ class DataClassMembersGenerator(val components: Fir2IrComponents) {
                 descriptor.bind(this)
             }
         }
+    }
+
+    companion object {
+        private val copyName = Name.identifier("copy")
+
+        fun isCopy(irFunction: IrFunction): Boolean =
+            irFunction.name == copyName
+
+        fun isComponentN(irFunction: IrFunction): Boolean {
+            if (irFunction.name.isSpecial) {
+                return false
+            }
+            val name = irFunction.name.identifier
+            if (!name.startsWith("component")) {
+                return false
+            }
+            val n = getComponentIndex(irFunction)
+            return n != null && n > 0
+        }
+
+        fun getComponentIndex(irFunction: IrFunction): Int? =
+            irFunction.name.identifier.substring("component".length).toIntOrNull()
     }
 }

--- a/compiler/fir/raw-fir/psi2fir/testData/rawBuilder/expressions/annotated.txt
+++ b/compiler/fir/raw-fir/psi2fir/testData/rawBuilder/expressions/annotated.txt
@@ -25,9 +25,7 @@ FILE: annotated.kt
             super<R|kotlin/Any|>()
         }
 
-        public final fun copy(): R|Two| {
-            ^copy R|/Two.Two|()
-        }
+        public final fun copy(): R|Two|
 
     }
     public? final? fun bar(two: Two): R|kotlin/Unit| {

--- a/compiler/fir/raw-fir/psi2fir/testData/rawBuilder/expressions/destructuring.txt
+++ b/compiler/fir/raw-fir/psi2fir/testData/rawBuilder/expressions/destructuring.txt
@@ -13,21 +13,13 @@ FILE: destructuring.kt
         public? final? val third: String = R|<local>/third|
             public? get(): String
 
-        public final fun component1(): Int {
-            ^component1 this@R|/Some|.R|/Some.first|
-        }
+        public final fun component1(): Int
 
-        public final fun component2(): Double {
-            ^component2 this@R|/Some|.R|/Some.second|
-        }
+        public final fun component2(): Double
 
-        public final fun component3(): String {
-            ^component3 this@R|/Some|.R|/Some.third|
-        }
+        public final fun component3(): String
 
-        public final fun copy(first: Int = this@R|/Some|.R|/Some.first|, second: Double = this@R|/Some|.R|/Some.second|, third: String = this@R|/Some|.R|/Some.third|): R|Some| {
-            ^copy R|/Some.Some|(this@R|/Some|.R|/Some.first|, this@R|/Some|.R|/Some.second|, this@R|/Some|.R|/Some.third|)
-        }
+        public final fun copy(first: Int = this@R|/Some|.R|/Some.first|, second: Double = this@R|/Some|.R|/Some.second|, third: String = this@R|/Some|.R|/Some.third|): R|Some|
 
     }
     public? final? fun foo(some: Some): R|kotlin/Unit| {

--- a/compiler/fir/raw-fir/psi2fir/testData/rawBuilder/expressions/for.txt
+++ b/compiler/fir/raw-fir/psi2fir/testData/rawBuilder/expressions/for.txt
@@ -48,17 +48,11 @@ FILE: for.kt
         public? final? val y: Int = R|<local>/y|
             public? get(): Int
 
-        public final fun component1(): Int {
-            ^component1 this@R|/Some|.R|/Some.x|
-        }
+        public final fun component1(): Int
 
-        public final fun component2(): Int {
-            ^component2 this@R|/Some|.R|/Some.y|
-        }
+        public final fun component2(): Int
 
-        public final fun copy(x: Int = this@R|/Some|.R|/Some.x|, y: Int = this@R|/Some|.R|/Some.y|): R|Some| {
-            ^copy R|/Some.Some|(this@R|/Some|.R|/Some.x|, this@R|/Some|.R|/Some.y|)
-        }
+        public final fun copy(x: Int = this@R|/Some|.R|/Some.x|, y: Int = this@R|/Some|.R|/Some.y|): R|Some|
 
     }
     public? final? fun baz(set: Set<Some>): R|kotlin/Unit| {

--- a/compiler/fir/raw-fir/psi2fir/testData/rawBuilder/expressions/lambda.txt
+++ b/compiler/fir/raw-fir/psi2fir/testData/rawBuilder/expressions/lambda.txt
@@ -10,17 +10,11 @@ FILE: lambda.kt
         public? final? val y: Int = R|<local>/y|
             public? get(): Int
 
-        public final fun component1(): Int {
-            ^component1 this@R|/Tuple|.R|/Tuple.x|
-        }
+        public final fun component1(): Int
 
-        public final fun component2(): Int {
-            ^component2 this@R|/Tuple|.R|/Tuple.y|
-        }
+        public final fun component2(): Int
 
-        public final fun copy(x: Int = this@R|/Tuple|.R|/Tuple.x|, y: Int = this@R|/Tuple|.R|/Tuple.y|): R|Tuple| {
-            ^copy R|/Tuple.Tuple|(this@R|/Tuple|.R|/Tuple.x|, this@R|/Tuple|.R|/Tuple.y|)
-        }
+        public final fun copy(x: Int = this@R|/Tuple|.R|/Tuple.x|, y: Int = this@R|/Tuple|.R|/Tuple.y|): R|Tuple|
 
     }
     public? final? inline fun use(f: ( (Tuple) -> Int )): <implicit> {

--- a/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/DataClassMembersGenerator.kt
+++ b/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/DataClassMembersGenerator.kt
@@ -16,23 +16,17 @@
 
 package org.jetbrains.kotlin.psi2ir.generators
 
-import com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.backend.common.DataClassMethodGenerator
 import org.jetbrains.kotlin.descriptors.*
-import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
-import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.declarations.*
-import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrMemberAccessExpression
-import org.jetbrains.kotlin.ir.expressions.impl.IrGetValueImpl
-import org.jetbrains.kotlin.ir.expressions.mapTypeParameters
-import org.jetbrains.kotlin.ir.expressions.mapValueParameters
+import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.util.DataClassMembersGenerator
 import org.jetbrains.kotlin.ir.util.declareSimpleFunctionWithOverrides
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtParameter
-import org.jetbrains.kotlin.psi2ir.endOffsetOrUndefined
-import org.jetbrains.kotlin.psi2ir.startOffsetOrUndefined
+import org.jetbrains.kotlin.psi.psiUtil.endOffset
+import org.jetbrains.kotlin.psi.psiUtil.startOffset
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.DescriptorToSourceUtils
 
@@ -58,38 +52,6 @@ class DataClassMembersGenerator(
             returnType = function.returnType!!.toIrType()
         }
 
-    private inner class MemberFunctionBuilder(
-        val irClass: IrClass,
-        val function: FunctionDescriptor,
-        val origin: IrDeclarationOrigin,
-        startOffset: Int = UNDEFINED_OFFSET,
-        endOffset: Int = UNDEFINED_OFFSET,
-        val irFunction: IrFunction = declareSimpleFunction(startOffset, endOffset, origin, function)
-    ) : IrBlockBodyBuilder(context, Scope(irFunction.symbol), startOffset, endOffset) {
-        inline fun addToClass(builder: MemberFunctionBuilder.(IrFunction) -> Unit): IrFunction {
-            irFunction.buildWithScope {
-                builder(irFunction)
-                irFunction.body = doBuild()
-            }
-
-            irClass.declarations.add(irFunction)
-            return irFunction
-        }
-
-        fun putDefault(parameter: ValueParameterDescriptor, value: IrExpression) {
-            irFunction.putDefault(parameter, irExprBody(value))
-        }
-
-        fun irThis(): IrExpression {
-            val irDispatchReceiverParameter = irFunction.dispatchReceiverParameter!!
-            return IrGetValueImpl(
-                startOffset, endOffset,
-                irDispatchReceiverParameter.type,
-                irDispatchReceiverParameter.symbol
-            )
-        }
-    }
-
     private inner class MyDataClassMethodGenerator(
         ktClassOrObject: KtClassOrObject,
         val irClass: IrClass,
@@ -104,24 +66,17 @@ class DataClassMembersGenerator(
                 FunctionGenerator(declarationGenerator).generateSyntheticFunctionParameterDeclarations(irFunction)
             }
 
+            override fun getBackingField(parameter: ValueParameterDescriptor?, irValueParameter: IrValueParameter?): IrField? =
+                parameter?.let {
+                    val property = getOrFail(BindingContext.VALUE_PARAMETER_AS_PROPERTY, parameter)
+                    return getBackingField(property)
+                }
+
+            override fun transform(typeParameterDescriptor: TypeParameterDescriptor): IrType =
+                typeParameterDescriptor.defaultType.toIrType()
+
             override fun commitSubstituted(irMemberAccessExpression: IrMemberAccessExpression, descriptor: CallableDescriptor) {
                 irMemberAccessExpression.commitSubstituted(descriptor)
-            }
-        }
-
-        private inline fun buildMember(
-            function: FunctionDescriptor,
-            psiElement: PsiElement? = null,
-            body: MemberFunctionBuilder.(IrFunction) -> Unit
-        ) {
-            MemberFunctionBuilder(
-                irClass, function, origin,
-                psiElement.startOffsetOrUndefined, psiElement.endOffsetOrUndefined
-            ).addToClass { irFunction ->
-                irFunction.buildWithScope {
-                    FunctionGenerator(declarationGenerator).generateSyntheticFunctionParameterDeclarations(irFunction)
-                    body(irFunction)
-                }
             }
         }
 
@@ -131,14 +86,10 @@ class DataClassMembersGenerator(
             val ktParameter = DescriptorToSourceUtils.descriptorToDeclaration(parameter)
                 ?: throw AssertionError("No definition for data class constructor parameter $parameter")
 
-            buildMember(function, ktParameter) {
-                +irReturn(irGetField(irThis(), getBackingField(parameter)))
-            }
-        }
-
-        private fun getBackingField(parameter: ValueParameterDescriptor): IrField {
-            val property = getOrFail(BindingContext.VALUE_PARAMETER_AS_PROPERTY, parameter)
-            return irDataClassMembersGenerator.getBackingField(property)
+            val backingField = irDataClassMembersGenerator.getBackingField(parameter, null) ?: return
+            irDataClassMembersGenerator.generateComponentFunction(
+                function, backingField, ktParameter.startOffset, ktParameter.endOffset
+            )
         }
 
         override fun generateCopyFunction(function: FunctionDescriptor, constructorParameters: List<KtParameter>) {
@@ -148,23 +99,7 @@ class DataClassMembersGenerator(
                 ?: throw AssertionError("Data class should have a primary constructor: $classDescriptor")
             val constructorSymbol = context.symbolTable.referenceConstructor(dataClassConstructor)
 
-            buildMember(function, declaration) { irFunction ->
-                function.valueParameters.forEach { parameter ->
-                    putDefault(parameter, irGetField(irThis(), getBackingField(parameter)))
-                }
-                +irReturn(
-                    irCall(
-                        constructorSymbol,
-                        dataClassConstructor.returnType.toIrType()
-                    ).apply {
-                        mapTypeParameters { it.defaultType.toIrType() }
-                        mapValueParameters {
-                            val irValueParameter = irFunction.valueParameters[it.index]
-                            irGet(irValueParameter.type, irValueParameter.symbol)
-                        }
-                    }
-                )
-            }
+            irDataClassMembersGenerator.generateCopyFunction(function, constructorSymbol)
         }
 
         override fun generateEqualsMethod(function: FunctionDescriptor, properties: List<PropertyDescriptor>) =

--- a/compiler/testData/codegen/box/dataClasses/copy/constructorWithDefaultParam.kt
+++ b/compiler/testData/codegen/box/dataClasses/copy/constructorWithDefaultParam.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 data class A(val a: Int = 1, val b: String = "$a") {}
 
 fun box() : String {

--- a/compiler/testData/codegen/box/dataClasses/copy/valInConstructorParams.kt
+++ b/compiler/testData/codegen/box/dataClasses/copy/valInConstructorParams.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 data class A(val a: Int, val b: String) {}
 
 fun box() : String {

--- a/compiler/testData/codegen/box/dataClasses/copy/varInConstructorParams.kt
+++ b/compiler/testData/codegen/box/dataClasses/copy/varInConstructorParams.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 data class A(var a: Int, var b: String) {}
 
 fun box() : String {

--- a/compiler/testData/codegen/box/dataClasses/copy/withGenericParameter.kt
+++ b/compiler/testData/codegen/box/dataClasses/copy/withGenericParameter.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 data class A(val a: Foo<String>) {}
 
 class Foo<T>(val a: T) { }

--- a/compiler/testData/codegen/box/dataClasses/copy/withSecondaryConstructor.kt
+++ b/compiler/testData/codegen/box/dataClasses/copy/withSecondaryConstructor.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 data class A(val o: String, val k: String) {
     constructor() : this("O", "k")
 }

--- a/compiler/testData/ir/irText/classes/dataClassWithArrayMembers.fir.txt
+++ b/compiler/testData/ir/irText/classes/dataClassWithArrayMembers.fir.txt
@@ -117,115 +117,106 @@ FILE fqName:<root> fileName:/dataClassWithArrayMembers.kt
       $this: VALUE_PARAMETER name:<this> type:<root>.Test1
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun component1 (): kotlin.Array<kotlin.String> declared in <root>.Test1'
-          CALL 'public final fun <get-stringArray> (): kotlin.Array<kotlin.String> declared in <root>.Test1' type=kotlin.Array<kotlin.String> origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.component1' type=<root>.Test1 origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:stringArray type:kotlin.Array<kotlin.String> visibility:private [final]' type=kotlin.Array<kotlin.String> origin=null
+            receiver: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.component1' type=<root>.Test1 origin=null
     FUN name:component2 visibility:public modality:FINAL <> ($this:<root>.Test1) returnType:kotlin.CharArray
       $this: VALUE_PARAMETER name:<this> type:<root>.Test1
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun component2 (): kotlin.CharArray declared in <root>.Test1'
-          CALL 'public final fun <get-charArray> (): kotlin.CharArray declared in <root>.Test1' type=kotlin.CharArray origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.component2' type=<root>.Test1 origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:charArray type:kotlin.CharArray visibility:private [final]' type=kotlin.CharArray origin=null
+            receiver: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.component2' type=<root>.Test1 origin=null
     FUN name:component3 visibility:public modality:FINAL <> ($this:<root>.Test1) returnType:kotlin.BooleanArray
       $this: VALUE_PARAMETER name:<this> type:<root>.Test1
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun component3 (): kotlin.BooleanArray declared in <root>.Test1'
-          CALL 'public final fun <get-booleanArray> (): kotlin.BooleanArray declared in <root>.Test1' type=kotlin.BooleanArray origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.component3' type=<root>.Test1 origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:booleanArray type:kotlin.BooleanArray visibility:private [final]' type=kotlin.BooleanArray origin=null
+            receiver: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.component3' type=<root>.Test1 origin=null
     FUN name:component4 visibility:public modality:FINAL <> ($this:<root>.Test1) returnType:kotlin.ByteArray
       $this: VALUE_PARAMETER name:<this> type:<root>.Test1
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun component4 (): kotlin.ByteArray declared in <root>.Test1'
-          CALL 'public final fun <get-byteArray> (): kotlin.ByteArray declared in <root>.Test1' type=kotlin.ByteArray origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.component4' type=<root>.Test1 origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:byteArray type:kotlin.ByteArray visibility:private [final]' type=kotlin.ByteArray origin=null
+            receiver: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.component4' type=<root>.Test1 origin=null
     FUN name:component5 visibility:public modality:FINAL <> ($this:<root>.Test1) returnType:kotlin.ShortArray
       $this: VALUE_PARAMETER name:<this> type:<root>.Test1
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun component5 (): kotlin.ShortArray declared in <root>.Test1'
-          CALL 'public final fun <get-shortArray> (): kotlin.ShortArray declared in <root>.Test1' type=kotlin.ShortArray origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.component5' type=<root>.Test1 origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:shortArray type:kotlin.ShortArray visibility:private [final]' type=kotlin.ShortArray origin=null
+            receiver: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.component5' type=<root>.Test1 origin=null
     FUN name:component6 visibility:public modality:FINAL <> ($this:<root>.Test1) returnType:kotlin.IntArray
       $this: VALUE_PARAMETER name:<this> type:<root>.Test1
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun component6 (): kotlin.IntArray declared in <root>.Test1'
-          CALL 'public final fun <get-intArray> (): kotlin.IntArray declared in <root>.Test1' type=kotlin.IntArray origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.component6' type=<root>.Test1 origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:intArray type:kotlin.IntArray visibility:private [final]' type=kotlin.IntArray origin=null
+            receiver: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.component6' type=<root>.Test1 origin=null
     FUN name:component7 visibility:public modality:FINAL <> ($this:<root>.Test1) returnType:kotlin.LongArray
       $this: VALUE_PARAMETER name:<this> type:<root>.Test1
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun component7 (): kotlin.LongArray declared in <root>.Test1'
-          CALL 'public final fun <get-longArray> (): kotlin.LongArray declared in <root>.Test1' type=kotlin.LongArray origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.component7' type=<root>.Test1 origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:longArray type:kotlin.LongArray visibility:private [final]' type=kotlin.LongArray origin=null
+            receiver: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.component7' type=<root>.Test1 origin=null
     FUN name:component8 visibility:public modality:FINAL <> ($this:<root>.Test1) returnType:kotlin.FloatArray
       $this: VALUE_PARAMETER name:<this> type:<root>.Test1
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun component8 (): kotlin.FloatArray declared in <root>.Test1'
-          CALL 'public final fun <get-floatArray> (): kotlin.FloatArray declared in <root>.Test1' type=kotlin.FloatArray origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.component8' type=<root>.Test1 origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:floatArray type:kotlin.FloatArray visibility:private [final]' type=kotlin.FloatArray origin=null
+            receiver: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.component8' type=<root>.Test1 origin=null
     FUN name:component9 visibility:public modality:FINAL <> ($this:<root>.Test1) returnType:kotlin.DoubleArray
       $this: VALUE_PARAMETER name:<this> type:<root>.Test1
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun component9 (): kotlin.DoubleArray declared in <root>.Test1'
-          CALL 'public final fun <get-doubleArray> (): kotlin.DoubleArray declared in <root>.Test1' type=kotlin.DoubleArray origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.component9' type=<root>.Test1 origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:doubleArray type:kotlin.DoubleArray visibility:private [final]' type=kotlin.DoubleArray origin=null
+            receiver: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.component9' type=<root>.Test1 origin=null
     FUN name:copy visibility:public modality:FINAL <> ($this:<root>.Test1, stringArray:kotlin.Array<kotlin.String>, charArray:kotlin.CharArray, booleanArray:kotlin.BooleanArray, byteArray:kotlin.ByteArray, shortArray:kotlin.ShortArray, intArray:kotlin.IntArray, longArray:kotlin.LongArray, floatArray:kotlin.FloatArray, doubleArray:kotlin.DoubleArray) returnType:<root>.Test1
       $this: VALUE_PARAMETER name:<this> type:<root>.Test1
       VALUE_PARAMETER name:stringArray index:0 type:kotlin.Array<kotlin.String>
         EXPRESSION_BODY
-          CALL 'public final fun <get-stringArray> (): kotlin.Array<kotlin.String> declared in <root>.Test1' type=kotlin.Array<kotlin.String> origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.copy' type=<root>.Test1 origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:stringArray type:kotlin.Array<kotlin.String> visibility:private [final]' type=kotlin.Array<kotlin.String> origin=null
+            receiver: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.copy' type=<root>.Test1 origin=null
       VALUE_PARAMETER name:charArray index:1 type:kotlin.CharArray
         EXPRESSION_BODY
-          CALL 'public final fun <get-charArray> (): kotlin.CharArray declared in <root>.Test1' type=kotlin.CharArray origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.copy' type=<root>.Test1 origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:charArray type:kotlin.CharArray visibility:private [final]' type=kotlin.CharArray origin=null
+            receiver: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.copy' type=<root>.Test1 origin=null
       VALUE_PARAMETER name:booleanArray index:2 type:kotlin.BooleanArray
         EXPRESSION_BODY
-          CALL 'public final fun <get-booleanArray> (): kotlin.BooleanArray declared in <root>.Test1' type=kotlin.BooleanArray origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.copy' type=<root>.Test1 origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:booleanArray type:kotlin.BooleanArray visibility:private [final]' type=kotlin.BooleanArray origin=null
+            receiver: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.copy' type=<root>.Test1 origin=null
       VALUE_PARAMETER name:byteArray index:3 type:kotlin.ByteArray
         EXPRESSION_BODY
-          CALL 'public final fun <get-byteArray> (): kotlin.ByteArray declared in <root>.Test1' type=kotlin.ByteArray origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.copy' type=<root>.Test1 origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:byteArray type:kotlin.ByteArray visibility:private [final]' type=kotlin.ByteArray origin=null
+            receiver: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.copy' type=<root>.Test1 origin=null
       VALUE_PARAMETER name:shortArray index:4 type:kotlin.ShortArray
         EXPRESSION_BODY
-          CALL 'public final fun <get-shortArray> (): kotlin.ShortArray declared in <root>.Test1' type=kotlin.ShortArray origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.copy' type=<root>.Test1 origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:shortArray type:kotlin.ShortArray visibility:private [final]' type=kotlin.ShortArray origin=null
+            receiver: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.copy' type=<root>.Test1 origin=null
       VALUE_PARAMETER name:intArray index:5 type:kotlin.IntArray
         EXPRESSION_BODY
-          CALL 'public final fun <get-intArray> (): kotlin.IntArray declared in <root>.Test1' type=kotlin.IntArray origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.copy' type=<root>.Test1 origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:intArray type:kotlin.IntArray visibility:private [final]' type=kotlin.IntArray origin=null
+            receiver: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.copy' type=<root>.Test1 origin=null
       VALUE_PARAMETER name:longArray index:6 type:kotlin.LongArray
         EXPRESSION_BODY
-          CALL 'public final fun <get-longArray> (): kotlin.LongArray declared in <root>.Test1' type=kotlin.LongArray origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.copy' type=<root>.Test1 origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:longArray type:kotlin.LongArray visibility:private [final]' type=kotlin.LongArray origin=null
+            receiver: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.copy' type=<root>.Test1 origin=null
       VALUE_PARAMETER name:floatArray index:7 type:kotlin.FloatArray
         EXPRESSION_BODY
-          CALL 'public final fun <get-floatArray> (): kotlin.FloatArray declared in <root>.Test1' type=kotlin.FloatArray origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.copy' type=<root>.Test1 origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:floatArray type:kotlin.FloatArray visibility:private [final]' type=kotlin.FloatArray origin=null
+            receiver: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.copy' type=<root>.Test1 origin=null
       VALUE_PARAMETER name:doubleArray index:8 type:kotlin.DoubleArray
         EXPRESSION_BODY
-          CALL 'public final fun <get-doubleArray> (): kotlin.DoubleArray declared in <root>.Test1' type=kotlin.DoubleArray origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.copy' type=<root>.Test1 origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:doubleArray type:kotlin.DoubleArray visibility:private [final]' type=kotlin.DoubleArray origin=null
+            receiver: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.copy' type=<root>.Test1 origin=null
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun copy (stringArray: kotlin.Array<kotlin.String>, charArray: kotlin.CharArray, booleanArray: kotlin.BooleanArray, byteArray: kotlin.ByteArray, shortArray: kotlin.ShortArray, intArray: kotlin.IntArray, longArray: kotlin.LongArray, floatArray: kotlin.FloatArray, doubleArray: kotlin.DoubleArray): <root>.Test1 declared in <root>.Test1'
           CONSTRUCTOR_CALL 'public constructor <init> (stringArray: kotlin.Array<kotlin.String>, charArray: kotlin.CharArray, booleanArray: kotlin.BooleanArray, byteArray: kotlin.ByteArray, shortArray: kotlin.ShortArray, intArray: kotlin.IntArray, longArray: kotlin.LongArray, floatArray: kotlin.FloatArray, doubleArray: kotlin.DoubleArray) [primary] declared in <root>.Test1' type=<root>.Test1 origin=null
-            stringArray: CALL 'public final fun <get-stringArray> (): kotlin.Array<kotlin.String> declared in <root>.Test1' type=IrErrorType origin=GET_PROPERTY
-              $this: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.copy' type=<root>.Test1 origin=null
-            charArray: CALL 'public final fun <get-charArray> (): kotlin.CharArray declared in <root>.Test1' type=IrErrorType origin=GET_PROPERTY
-              $this: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.copy' type=<root>.Test1 origin=null
-            booleanArray: CALL 'public final fun <get-booleanArray> (): kotlin.BooleanArray declared in <root>.Test1' type=IrErrorType origin=GET_PROPERTY
-              $this: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.copy' type=<root>.Test1 origin=null
-            byteArray: CALL 'public final fun <get-byteArray> (): kotlin.ByteArray declared in <root>.Test1' type=IrErrorType origin=GET_PROPERTY
-              $this: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.copy' type=<root>.Test1 origin=null
-            shortArray: CALL 'public final fun <get-shortArray> (): kotlin.ShortArray declared in <root>.Test1' type=IrErrorType origin=GET_PROPERTY
-              $this: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.copy' type=<root>.Test1 origin=null
-            intArray: CALL 'public final fun <get-intArray> (): kotlin.IntArray declared in <root>.Test1' type=IrErrorType origin=GET_PROPERTY
-              $this: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.copy' type=<root>.Test1 origin=null
-            longArray: CALL 'public final fun <get-longArray> (): kotlin.LongArray declared in <root>.Test1' type=IrErrorType origin=GET_PROPERTY
-              $this: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.copy' type=<root>.Test1 origin=null
-            floatArray: CALL 'public final fun <get-floatArray> (): kotlin.FloatArray declared in <root>.Test1' type=IrErrorType origin=GET_PROPERTY
-              $this: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.copy' type=<root>.Test1 origin=null
-            doubleArray: CALL 'public final fun <get-doubleArray> (): kotlin.DoubleArray declared in <root>.Test1' type=IrErrorType origin=GET_PROPERTY
-              $this: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.copy' type=<root>.Test1 origin=null
+            stringArray: GET_VAR 'stringArray: kotlin.Array<kotlin.String> declared in <root>.Test1.copy' type=kotlin.Array<kotlin.String> origin=null
+            charArray: GET_VAR 'charArray: kotlin.CharArray declared in <root>.Test1.copy' type=kotlin.CharArray origin=null
+            booleanArray: GET_VAR 'booleanArray: kotlin.BooleanArray declared in <root>.Test1.copy' type=kotlin.BooleanArray origin=null
+            byteArray: GET_VAR 'byteArray: kotlin.ByteArray declared in <root>.Test1.copy' type=kotlin.ByteArray origin=null
+            shortArray: GET_VAR 'shortArray: kotlin.ShortArray declared in <root>.Test1.copy' type=kotlin.ShortArray origin=null
+            intArray: GET_VAR 'intArray: kotlin.IntArray declared in <root>.Test1.copy' type=kotlin.IntArray origin=null
+            longArray: GET_VAR 'longArray: kotlin.LongArray declared in <root>.Test1.copy' type=kotlin.LongArray origin=null
+            floatArray: GET_VAR 'floatArray: kotlin.FloatArray declared in <root>.Test1.copy' type=kotlin.FloatArray origin=null
+            doubleArray: GET_VAR 'doubleArray: kotlin.DoubleArray declared in <root>.Test1.copy' type=kotlin.DoubleArray origin=null
     FUN GENERATED_DATA_CLASS_MEMBER name:equals visibility:public modality:OPEN <> ($this:<root>.Test1, other:kotlin.Any?) returnType:kotlin.Boolean
       $this: VALUE_PARAMETER GENERATED_DATA_CLASS_MEMBER name:<this> type:<root>.Test1
       VALUE_PARAMETER GENERATED_DATA_CLASS_MEMBER name:other index:0 type:kotlin.Any?
@@ -467,20 +458,19 @@ FILE fqName:<root> fileName:/dataClassWithArrayMembers.kt
       $this: VALUE_PARAMETER name:<this> type:<root>.Test2<T of <root>.Test2>
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun component1 (): kotlin.Array<T of <root>.Test2> declared in <root>.Test2'
-          CALL 'public final fun <get-genericArray> (): kotlin.Array<T of <root>.Test2> declared in <root>.Test2' type=kotlin.Array<T of <root>.Test2> origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test2<T of <root>.Test2> declared in <root>.Test2.component1' type=<root>.Test2<T of <root>.Test2> origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:genericArray type:kotlin.Array<T of <root>.Test2> visibility:private [final]' type=kotlin.Array<T of <root>.Test2> origin=null
+            receiver: GET_VAR '<this>: <root>.Test2<T of <root>.Test2> declared in <root>.Test2.component1' type=<root>.Test2<T of <root>.Test2> origin=null
     FUN name:copy visibility:public modality:FINAL <> ($this:<root>.Test2<T of <root>.Test2>, genericArray:kotlin.Array<T of <root>.Test2>) returnType:<root>.Test2<T of <root>.Test2>
       $this: VALUE_PARAMETER name:<this> type:<root>.Test2<T of <root>.Test2>
       VALUE_PARAMETER name:genericArray index:0 type:kotlin.Array<T of <root>.Test2>
         EXPRESSION_BODY
-          CALL 'public final fun <get-genericArray> (): kotlin.Array<T of <root>.Test2> declared in <root>.Test2' type=kotlin.Array<T of <root>.Test2> origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test2<T of <root>.Test2> declared in <root>.Test2.copy' type=<root>.Test2<T of <root>.Test2> origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:genericArray type:kotlin.Array<T of <root>.Test2> visibility:private [final]' type=kotlin.Array<T of <root>.Test2> origin=null
+            receiver: GET_VAR '<this>: <root>.Test2<T of <root>.Test2> declared in <root>.Test2.copy' type=<root>.Test2<T of <root>.Test2> origin=null
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun copy (genericArray: kotlin.Array<T of <root>.Test2>): <root>.Test2<T of <root>.Test2> declared in <root>.Test2'
           CONSTRUCTOR_CALL 'public constructor <init> (genericArray: kotlin.Array<T of <root>.Test2>) [primary] declared in <root>.Test2' type=<root>.Test2<T of <root>.Test2> origin=null
-            <class: T>: <none>
-            genericArray: CALL 'public final fun <get-genericArray> (): kotlin.Array<T of <root>.Test2> declared in <root>.Test2' type=IrErrorType origin=GET_PROPERTY
-              $this: GET_VAR '<this>: <root>.Test2<T of <root>.Test2> declared in <root>.Test2.copy' type=<root>.Test2<T of <root>.Test2> origin=null
+            <class: T>: kotlin.Any
+            genericArray: GET_VAR 'genericArray: kotlin.Array<T of <root>.Test2> declared in <root>.Test2.copy' type=kotlin.Array<T of <root>.Test2> origin=null
     FUN GENERATED_DATA_CLASS_MEMBER name:equals visibility:public modality:OPEN <> ($this:<root>.Test2<T of <root>.Test2>, other:kotlin.Any?) returnType:kotlin.Boolean
       $this: VALUE_PARAMETER GENERATED_DATA_CLASS_MEMBER name:<this> type:<root>.Test2<T of <root>.Test2>
       VALUE_PARAMETER GENERATED_DATA_CLASS_MEMBER name:other index:0 type:kotlin.Any?
@@ -553,19 +543,18 @@ FILE fqName:<root> fileName:/dataClassWithArrayMembers.kt
       $this: VALUE_PARAMETER name:<this> type:<root>.Test3
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun component1 (): kotlin.Array<kotlin.Any>? declared in <root>.Test3'
-          CALL 'public final fun <get-anyArrayN> (): kotlin.Array<kotlin.Any>? declared in <root>.Test3' type=kotlin.Array<kotlin.Any>? origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test3 declared in <root>.Test3.component1' type=<root>.Test3 origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:anyArrayN type:kotlin.Array<kotlin.Any>? visibility:private [final]' type=kotlin.Array<kotlin.Any>? origin=null
+            receiver: GET_VAR '<this>: <root>.Test3 declared in <root>.Test3.component1' type=<root>.Test3 origin=null
     FUN name:copy visibility:public modality:FINAL <> ($this:<root>.Test3, anyArrayN:kotlin.Array<kotlin.Any>?) returnType:<root>.Test3
       $this: VALUE_PARAMETER name:<this> type:<root>.Test3
       VALUE_PARAMETER name:anyArrayN index:0 type:kotlin.Array<kotlin.Any>?
         EXPRESSION_BODY
-          CALL 'public final fun <get-anyArrayN> (): kotlin.Array<kotlin.Any>? declared in <root>.Test3' type=kotlin.Array<kotlin.Any>? origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test3 declared in <root>.Test3.copy' type=<root>.Test3 origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:anyArrayN type:kotlin.Array<kotlin.Any>? visibility:private [final]' type=kotlin.Array<kotlin.Any>? origin=null
+            receiver: GET_VAR '<this>: <root>.Test3 declared in <root>.Test3.copy' type=<root>.Test3 origin=null
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun copy (anyArrayN: kotlin.Array<kotlin.Any>?): <root>.Test3 declared in <root>.Test3'
           CONSTRUCTOR_CALL 'public constructor <init> (anyArrayN: kotlin.Array<kotlin.Any>?) [primary] declared in <root>.Test3' type=<root>.Test3 origin=null
-            anyArrayN: CALL 'public final fun <get-anyArrayN> (): kotlin.Array<kotlin.Any>? declared in <root>.Test3' type=IrErrorType origin=GET_PROPERTY
-              $this: GET_VAR '<this>: <root>.Test3 declared in <root>.Test3.copy' type=<root>.Test3 origin=null
+            anyArrayN: GET_VAR 'anyArrayN: kotlin.Array<kotlin.Any>? declared in <root>.Test3.copy' type=kotlin.Array<kotlin.Any>? origin=null
     FUN GENERATED_DATA_CLASS_MEMBER name:equals visibility:public modality:OPEN <> ($this:<root>.Test3, other:kotlin.Any?) returnType:kotlin.Boolean
       $this: VALUE_PARAMETER GENERATED_DATA_CLASS_MEMBER name:<this> type:<root>.Test3
       VALUE_PARAMETER GENERATED_DATA_CLASS_MEMBER name:other index:0 type:kotlin.Any?

--- a/compiler/testData/ir/irText/classes/dataClasses.fir.txt
+++ b/compiler/testData/ir/irText/classes/dataClasses.fir.txt
@@ -45,43 +45,40 @@ FILE fqName:<root> fileName:/dataClasses.kt
       $this: VALUE_PARAMETER name:<this> type:<root>.Test1
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun component1 (): kotlin.Int declared in <root>.Test1'
-          CALL 'public final fun <get-x> (): kotlin.Int declared in <root>.Test1' type=kotlin.Int origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.component1' type=<root>.Test1 origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:x type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+            receiver: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.component1' type=<root>.Test1 origin=null
     FUN name:component2 visibility:public modality:FINAL <> ($this:<root>.Test1) returnType:kotlin.String
       $this: VALUE_PARAMETER name:<this> type:<root>.Test1
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun component2 (): kotlin.String declared in <root>.Test1'
-          CALL 'public final fun <get-y> (): kotlin.String declared in <root>.Test1' type=kotlin.String origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.component2' type=<root>.Test1 origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:y type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+            receiver: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.component2' type=<root>.Test1 origin=null
     FUN name:component3 visibility:public modality:FINAL <> ($this:<root>.Test1) returnType:kotlin.Any
       $this: VALUE_PARAMETER name:<this> type:<root>.Test1
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun component3 (): kotlin.Any declared in <root>.Test1'
-          CALL 'public final fun <get-z> (): kotlin.Any declared in <root>.Test1' type=kotlin.Any origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.component3' type=<root>.Test1 origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:z type:kotlin.Any visibility:private [final]' type=kotlin.Any origin=null
+            receiver: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.component3' type=<root>.Test1 origin=null
     FUN name:copy visibility:public modality:FINAL <> ($this:<root>.Test1, x:kotlin.Int, y:kotlin.String, z:kotlin.Any) returnType:<root>.Test1
       $this: VALUE_PARAMETER name:<this> type:<root>.Test1
       VALUE_PARAMETER name:x index:0 type:kotlin.Int
         EXPRESSION_BODY
-          CALL 'public final fun <get-x> (): kotlin.Int declared in <root>.Test1' type=kotlin.Int origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.copy' type=<root>.Test1 origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:x type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+            receiver: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.copy' type=<root>.Test1 origin=null
       VALUE_PARAMETER name:y index:1 type:kotlin.String
         EXPRESSION_BODY
-          CALL 'public final fun <get-y> (): kotlin.String declared in <root>.Test1' type=kotlin.String origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.copy' type=<root>.Test1 origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:y type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+            receiver: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.copy' type=<root>.Test1 origin=null
       VALUE_PARAMETER name:z index:2 type:kotlin.Any
         EXPRESSION_BODY
-          CALL 'public final fun <get-z> (): kotlin.Any declared in <root>.Test1' type=kotlin.Any origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.copy' type=<root>.Test1 origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:z type:kotlin.Any visibility:private [final]' type=kotlin.Any origin=null
+            receiver: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.copy' type=<root>.Test1 origin=null
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun copy (x: kotlin.Int, y: kotlin.String, z: kotlin.Any): <root>.Test1 declared in <root>.Test1'
           CONSTRUCTOR_CALL 'public constructor <init> (x: kotlin.Int, y: kotlin.String, z: kotlin.Any) [primary] declared in <root>.Test1' type=<root>.Test1 origin=null
-            x: CALL 'public final fun <get-x> (): kotlin.Int declared in <root>.Test1' type=IrErrorType origin=GET_PROPERTY
-              $this: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.copy' type=<root>.Test1 origin=null
-            y: CALL 'public final fun <get-y> (): kotlin.String declared in <root>.Test1' type=IrErrorType origin=GET_PROPERTY
-              $this: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.copy' type=<root>.Test1 origin=null
-            z: CALL 'public final fun <get-z> (): kotlin.Any declared in <root>.Test1' type=IrErrorType origin=GET_PROPERTY
-              $this: GET_VAR '<this>: <root>.Test1 declared in <root>.Test1.copy' type=<root>.Test1 origin=null
+            x: GET_VAR 'x: kotlin.Int declared in <root>.Test1.copy' type=kotlin.Int origin=null
+            y: GET_VAR 'y: kotlin.String declared in <root>.Test1.copy' type=kotlin.String origin=null
+            z: GET_VAR 'z: kotlin.Any declared in <root>.Test1.copy' type=kotlin.Any origin=null
     FUN GENERATED_DATA_CLASS_MEMBER name:equals visibility:public modality:OPEN <> ($this:<root>.Test1, other:kotlin.Any?) returnType:kotlin.Boolean
       $this: VALUE_PARAMETER GENERATED_DATA_CLASS_MEMBER name:<this> type:<root>.Test1
       VALUE_PARAMETER GENERATED_DATA_CLASS_MEMBER name:other index:0 type:kotlin.Any?
@@ -193,19 +190,18 @@ FILE fqName:<root> fileName:/dataClasses.kt
       $this: VALUE_PARAMETER name:<this> type:<root>.Test2
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun component1 (): kotlin.Any? declared in <root>.Test2'
-          CALL 'public final fun <get-x> (): kotlin.Any? declared in <root>.Test2' type=kotlin.Any? origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test2 declared in <root>.Test2.component1' type=<root>.Test2 origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:x type:kotlin.Any? visibility:private [final]' type=kotlin.Any? origin=null
+            receiver: GET_VAR '<this>: <root>.Test2 declared in <root>.Test2.component1' type=<root>.Test2 origin=null
     FUN name:copy visibility:public modality:FINAL <> ($this:<root>.Test2, x:kotlin.Any?) returnType:<root>.Test2
       $this: VALUE_PARAMETER name:<this> type:<root>.Test2
       VALUE_PARAMETER name:x index:0 type:kotlin.Any?
         EXPRESSION_BODY
-          CALL 'public final fun <get-x> (): kotlin.Any? declared in <root>.Test2' type=kotlin.Any? origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test2 declared in <root>.Test2.copy' type=<root>.Test2 origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:x type:kotlin.Any? visibility:private [final]' type=kotlin.Any? origin=null
+            receiver: GET_VAR '<this>: <root>.Test2 declared in <root>.Test2.copy' type=<root>.Test2 origin=null
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun copy (x: kotlin.Any?): <root>.Test2 declared in <root>.Test2'
           CONSTRUCTOR_CALL 'public constructor <init> (x: kotlin.Any?) [primary] declared in <root>.Test2' type=<root>.Test2 origin=null
-            x: CALL 'public final fun <get-x> (): kotlin.Any? declared in <root>.Test2' type=IrErrorType origin=GET_PROPERTY
-              $this: GET_VAR '<this>: <root>.Test2 declared in <root>.Test2.copy' type=<root>.Test2 origin=null
+            x: GET_VAR 'x: kotlin.Any? declared in <root>.Test2.copy' type=kotlin.Any? origin=null
     FUN GENERATED_DATA_CLASS_MEMBER name:equals visibility:public modality:OPEN <> ($this:<root>.Test2, other:kotlin.Any?) returnType:kotlin.Boolean
       $this: VALUE_PARAMETER GENERATED_DATA_CLASS_MEMBER name:<this> type:<root>.Test2
       VALUE_PARAMETER GENERATED_DATA_CLASS_MEMBER name:other index:0 type:kotlin.Any?
@@ -322,55 +318,51 @@ FILE fqName:<root> fileName:/dataClasses.kt
       $this: VALUE_PARAMETER name:<this> type:<root>.Test3
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun component1 (): kotlin.Double declared in <root>.Test3'
-          CALL 'public final fun <get-d> (): kotlin.Double declared in <root>.Test3' type=kotlin.Double origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test3 declared in <root>.Test3.component1' type=<root>.Test3 origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:d type:kotlin.Double visibility:private [final]' type=kotlin.Double origin=null
+            receiver: GET_VAR '<this>: <root>.Test3 declared in <root>.Test3.component1' type=<root>.Test3 origin=null
     FUN name:component2 visibility:public modality:FINAL <> ($this:<root>.Test3) returnType:kotlin.Double?
       $this: VALUE_PARAMETER name:<this> type:<root>.Test3
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun component2 (): kotlin.Double? declared in <root>.Test3'
-          CALL 'public final fun <get-dn> (): kotlin.Double? declared in <root>.Test3' type=kotlin.Double? origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test3 declared in <root>.Test3.component2' type=<root>.Test3 origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:dn type:kotlin.Double? visibility:private [final]' type=kotlin.Double? origin=null
+            receiver: GET_VAR '<this>: <root>.Test3 declared in <root>.Test3.component2' type=<root>.Test3 origin=null
     FUN name:component3 visibility:public modality:FINAL <> ($this:<root>.Test3) returnType:kotlin.Float
       $this: VALUE_PARAMETER name:<this> type:<root>.Test3
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun component3 (): kotlin.Float declared in <root>.Test3'
-          CALL 'public final fun <get-f> (): kotlin.Float declared in <root>.Test3' type=kotlin.Float origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test3 declared in <root>.Test3.component3' type=<root>.Test3 origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:f type:kotlin.Float visibility:private [final]' type=kotlin.Float origin=null
+            receiver: GET_VAR '<this>: <root>.Test3 declared in <root>.Test3.component3' type=<root>.Test3 origin=null
     FUN name:component4 visibility:public modality:FINAL <> ($this:<root>.Test3) returnType:kotlin.Float?
       $this: VALUE_PARAMETER name:<this> type:<root>.Test3
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun component4 (): kotlin.Float? declared in <root>.Test3'
-          CALL 'public final fun <get-df> (): kotlin.Float? declared in <root>.Test3' type=kotlin.Float? origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test3 declared in <root>.Test3.component4' type=<root>.Test3 origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:df type:kotlin.Float? visibility:private [final]' type=kotlin.Float? origin=null
+            receiver: GET_VAR '<this>: <root>.Test3 declared in <root>.Test3.component4' type=<root>.Test3 origin=null
     FUN name:copy visibility:public modality:FINAL <> ($this:<root>.Test3, d:kotlin.Double, dn:kotlin.Double?, f:kotlin.Float, df:kotlin.Float?) returnType:<root>.Test3
       $this: VALUE_PARAMETER name:<this> type:<root>.Test3
       VALUE_PARAMETER name:d index:0 type:kotlin.Double
         EXPRESSION_BODY
-          CALL 'public final fun <get-d> (): kotlin.Double declared in <root>.Test3' type=kotlin.Double origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test3 declared in <root>.Test3.copy' type=<root>.Test3 origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:d type:kotlin.Double visibility:private [final]' type=kotlin.Double origin=null
+            receiver: GET_VAR '<this>: <root>.Test3 declared in <root>.Test3.copy' type=<root>.Test3 origin=null
       VALUE_PARAMETER name:dn index:1 type:kotlin.Double?
         EXPRESSION_BODY
-          CALL 'public final fun <get-dn> (): kotlin.Double? declared in <root>.Test3' type=kotlin.Double? origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test3 declared in <root>.Test3.copy' type=<root>.Test3 origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:dn type:kotlin.Double? visibility:private [final]' type=kotlin.Double? origin=null
+            receiver: GET_VAR '<this>: <root>.Test3 declared in <root>.Test3.copy' type=<root>.Test3 origin=null
       VALUE_PARAMETER name:f index:2 type:kotlin.Float
         EXPRESSION_BODY
-          CALL 'public final fun <get-f> (): kotlin.Float declared in <root>.Test3' type=kotlin.Float origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test3 declared in <root>.Test3.copy' type=<root>.Test3 origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:f type:kotlin.Float visibility:private [final]' type=kotlin.Float origin=null
+            receiver: GET_VAR '<this>: <root>.Test3 declared in <root>.Test3.copy' type=<root>.Test3 origin=null
       VALUE_PARAMETER name:df index:3 type:kotlin.Float?
         EXPRESSION_BODY
-          CALL 'public final fun <get-df> (): kotlin.Float? declared in <root>.Test3' type=kotlin.Float? origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test3 declared in <root>.Test3.copy' type=<root>.Test3 origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:df type:kotlin.Float? visibility:private [final]' type=kotlin.Float? origin=null
+            receiver: GET_VAR '<this>: <root>.Test3 declared in <root>.Test3.copy' type=<root>.Test3 origin=null
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun copy (d: kotlin.Double, dn: kotlin.Double?, f: kotlin.Float, df: kotlin.Float?): <root>.Test3 declared in <root>.Test3'
           CONSTRUCTOR_CALL 'public constructor <init> (d: kotlin.Double, dn: kotlin.Double?, f: kotlin.Float, df: kotlin.Float?) [primary] declared in <root>.Test3' type=<root>.Test3 origin=null
-            d: CALL 'public final fun <get-d> (): kotlin.Double declared in <root>.Test3' type=IrErrorType origin=GET_PROPERTY
-              $this: GET_VAR '<this>: <root>.Test3 declared in <root>.Test3.copy' type=<root>.Test3 origin=null
-            dn: CALL 'public final fun <get-dn> (): kotlin.Double? declared in <root>.Test3' type=IrErrorType origin=GET_PROPERTY
-              $this: GET_VAR '<this>: <root>.Test3 declared in <root>.Test3.copy' type=<root>.Test3 origin=null
-            f: CALL 'public final fun <get-f> (): kotlin.Float declared in <root>.Test3' type=IrErrorType origin=GET_PROPERTY
-              $this: GET_VAR '<this>: <root>.Test3 declared in <root>.Test3.copy' type=<root>.Test3 origin=null
-            df: CALL 'public final fun <get-df> (): kotlin.Float? declared in <root>.Test3' type=IrErrorType origin=GET_PROPERTY
-              $this: GET_VAR '<this>: <root>.Test3 declared in <root>.Test3.copy' type=<root>.Test3 origin=null
+            d: GET_VAR 'd: kotlin.Double declared in <root>.Test3.copy' type=kotlin.Double origin=null
+            dn: GET_VAR 'dn: kotlin.Double? declared in <root>.Test3.copy' type=kotlin.Double? origin=null
+            f: GET_VAR 'f: kotlin.Float declared in <root>.Test3.copy' type=kotlin.Float origin=null
+            df: GET_VAR 'df: kotlin.Float? declared in <root>.Test3.copy' type=kotlin.Float? origin=null
     FUN GENERATED_DATA_CLASS_MEMBER name:equals visibility:public modality:OPEN <> ($this:<root>.Test3, other:kotlin.Any?) returnType:kotlin.Boolean
       $this: VALUE_PARAMETER GENERATED_DATA_CLASS_MEMBER name:<this> type:<root>.Test3
       VALUE_PARAMETER GENERATED_DATA_CLASS_MEMBER name:other index:0 type:kotlin.Any?

--- a/compiler/testData/ir/irText/classes/dataClassesGeneric.fir.txt
+++ b/compiler/testData/ir/irText/classes/dataClassesGeneric.fir.txt
@@ -22,20 +22,19 @@ FILE fqName:<root> fileName:/dataClassesGeneric.kt
       $this: VALUE_PARAMETER name:<this> type:<root>.Test1<T of <root>.Test1>
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun component1 (): T of <root>.Test1 declared in <root>.Test1'
-          CALL 'public final fun <get-x> (): T of <root>.Test1 declared in <root>.Test1' type=T of <root>.Test1 origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test1<T of <root>.Test1> declared in <root>.Test1.component1' type=<root>.Test1<T of <root>.Test1> origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:x type:T of <root>.Test1 visibility:private [final]' type=T of <root>.Test1 origin=null
+            receiver: GET_VAR '<this>: <root>.Test1<T of <root>.Test1> declared in <root>.Test1.component1' type=<root>.Test1<T of <root>.Test1> origin=null
     FUN name:copy visibility:public modality:FINAL <> ($this:<root>.Test1<T of <root>.Test1>, x:T of <root>.Test1) returnType:<root>.Test1<T of <root>.Test1>
       $this: VALUE_PARAMETER name:<this> type:<root>.Test1<T of <root>.Test1>
       VALUE_PARAMETER name:x index:0 type:T of <root>.Test1
         EXPRESSION_BODY
-          CALL 'public final fun <get-x> (): T of <root>.Test1 declared in <root>.Test1' type=T of <root>.Test1 origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test1<T of <root>.Test1> declared in <root>.Test1.copy' type=<root>.Test1<T of <root>.Test1> origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:x type:T of <root>.Test1 visibility:private [final]' type=T of <root>.Test1 origin=null
+            receiver: GET_VAR '<this>: <root>.Test1<T of <root>.Test1> declared in <root>.Test1.copy' type=<root>.Test1<T of <root>.Test1> origin=null
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun copy (x: T of <root>.Test1): <root>.Test1<T of <root>.Test1> declared in <root>.Test1'
           CONSTRUCTOR_CALL 'public constructor <init> (x: T of <root>.Test1) [primary] declared in <root>.Test1' type=<root>.Test1<T of <root>.Test1> origin=null
-            <class: T>: <none>
-            x: CALL 'public final fun <get-x> (): T of <root>.Test1 declared in <root>.Test1' type=IrErrorType origin=GET_PROPERTY
-              $this: GET_VAR '<this>: <root>.Test1<T of <root>.Test1> declared in <root>.Test1.copy' type=<root>.Test1<T of <root>.Test1> origin=null
+            <class: T>: kotlin.Any
+            x: GET_VAR 'x: T of <root>.Test1 declared in <root>.Test1.copy' type=T of <root>.Test1 origin=null
     FUN GENERATED_DATA_CLASS_MEMBER name:equals visibility:public modality:OPEN <> ($this:<root>.Test1<T of <root>.Test1>, other:kotlin.Any?) returnType:kotlin.Boolean
       $this: VALUE_PARAMETER GENERATED_DATA_CLASS_MEMBER name:<this> type:<root>.Test1<T of <root>.Test1>
       VALUE_PARAMETER GENERATED_DATA_CLASS_MEMBER name:other index:0 type:kotlin.Any?
@@ -117,20 +116,19 @@ FILE fqName:<root> fileName:/dataClassesGeneric.kt
       $this: VALUE_PARAMETER name:<this> type:<root>.Test2<T of <root>.Test2>
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun component1 (): T of <root>.Test2 declared in <root>.Test2'
-          CALL 'public final fun <get-x> (): T of <root>.Test2 declared in <root>.Test2' type=T of <root>.Test2 origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test2<T of <root>.Test2> declared in <root>.Test2.component1' type=<root>.Test2<T of <root>.Test2> origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:x type:T of <root>.Test2 visibility:private [final]' type=T of <root>.Test2 origin=null
+            receiver: GET_VAR '<this>: <root>.Test2<T of <root>.Test2> declared in <root>.Test2.component1' type=<root>.Test2<T of <root>.Test2> origin=null
     FUN name:copy visibility:public modality:FINAL <> ($this:<root>.Test2<T of <root>.Test2>, x:T of <root>.Test2) returnType:<root>.Test2<T of <root>.Test2>
       $this: VALUE_PARAMETER name:<this> type:<root>.Test2<T of <root>.Test2>
       VALUE_PARAMETER name:x index:0 type:T of <root>.Test2
         EXPRESSION_BODY
-          CALL 'public final fun <get-x> (): T of <root>.Test2 declared in <root>.Test2' type=T of <root>.Test2 origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test2<T of <root>.Test2> declared in <root>.Test2.copy' type=<root>.Test2<T of <root>.Test2> origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:x type:T of <root>.Test2 visibility:private [final]' type=T of <root>.Test2 origin=null
+            receiver: GET_VAR '<this>: <root>.Test2<T of <root>.Test2> declared in <root>.Test2.copy' type=<root>.Test2<T of <root>.Test2> origin=null
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun copy (x: T of <root>.Test2): <root>.Test2<T of <root>.Test2> declared in <root>.Test2'
           CONSTRUCTOR_CALL 'public constructor <init> (x: T of <root>.Test2) [primary] declared in <root>.Test2' type=<root>.Test2<T of <root>.Test2> origin=null
-            <class: T>: <none>
-            x: CALL 'public final fun <get-x> (): T of <root>.Test2 declared in <root>.Test2' type=IrErrorType origin=GET_PROPERTY
-              $this: GET_VAR '<this>: <root>.Test2<T of <root>.Test2> declared in <root>.Test2.copy' type=<root>.Test2<T of <root>.Test2> origin=null
+            <class: T>: kotlin.Any
+            x: GET_VAR 'x: T of <root>.Test2 declared in <root>.Test2.copy' type=T of <root>.Test2 origin=null
     FUN GENERATED_DATA_CLASS_MEMBER name:equals visibility:public modality:OPEN <> ($this:<root>.Test2<T of <root>.Test2>, other:kotlin.Any?) returnType:kotlin.Boolean
       $this: VALUE_PARAMETER GENERATED_DATA_CLASS_MEMBER name:<this> type:<root>.Test2<T of <root>.Test2>
       VALUE_PARAMETER GENERATED_DATA_CLASS_MEMBER name:other index:0 type:kotlin.Any?
@@ -203,20 +201,19 @@ FILE fqName:<root> fileName:/dataClassesGeneric.kt
       $this: VALUE_PARAMETER name:<this> type:<root>.Test3<T of <root>.Test3>
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun component1 (): kotlin.collections.List<T of <root>.Test3> declared in <root>.Test3'
-          CALL 'public final fun <get-x> (): kotlin.collections.List<T of <root>.Test3> declared in <root>.Test3' type=kotlin.collections.List<T of <root>.Test3> origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test3<T of <root>.Test3> declared in <root>.Test3.component1' type=<root>.Test3<T of <root>.Test3> origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:x type:kotlin.collections.List<T of <root>.Test3> visibility:private [final]' type=kotlin.collections.List<T of <root>.Test3> origin=null
+            receiver: GET_VAR '<this>: <root>.Test3<T of <root>.Test3> declared in <root>.Test3.component1' type=<root>.Test3<T of <root>.Test3> origin=null
     FUN name:copy visibility:public modality:FINAL <> ($this:<root>.Test3<T of <root>.Test3>, x:kotlin.collections.List<T of <root>.Test3>) returnType:<root>.Test3<T of <root>.Test3>
       $this: VALUE_PARAMETER name:<this> type:<root>.Test3<T of <root>.Test3>
       VALUE_PARAMETER name:x index:0 type:kotlin.collections.List<T of <root>.Test3>
         EXPRESSION_BODY
-          CALL 'public final fun <get-x> (): kotlin.collections.List<T of <root>.Test3> declared in <root>.Test3' type=kotlin.collections.List<T of <root>.Test3> origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test3<T of <root>.Test3> declared in <root>.Test3.copy' type=<root>.Test3<T of <root>.Test3> origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:x type:kotlin.collections.List<T of <root>.Test3> visibility:private [final]' type=kotlin.collections.List<T of <root>.Test3> origin=null
+            receiver: GET_VAR '<this>: <root>.Test3<T of <root>.Test3> declared in <root>.Test3.copy' type=<root>.Test3<T of <root>.Test3> origin=null
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun copy (x: kotlin.collections.List<T of <root>.Test3>): <root>.Test3<T of <root>.Test3> declared in <root>.Test3'
           CONSTRUCTOR_CALL 'public constructor <init> (x: kotlin.collections.List<T of <root>.Test3>) [primary] declared in <root>.Test3' type=<root>.Test3<T of <root>.Test3> origin=null
-            <class: T>: <none>
-            x: CALL 'public final fun <get-x> (): kotlin.collections.List<T of <root>.Test3> declared in <root>.Test3' type=IrErrorType origin=GET_PROPERTY
-              $this: GET_VAR '<this>: <root>.Test3<T of <root>.Test3> declared in <root>.Test3.copy' type=<root>.Test3<T of <root>.Test3> origin=null
+            <class: T>: kotlin.Any
+            x: GET_VAR 'x: kotlin.collections.List<T of <root>.Test3> declared in <root>.Test3.copy' type=kotlin.collections.List<T of <root>.Test3> origin=null
     FUN GENERATED_DATA_CLASS_MEMBER name:equals visibility:public modality:OPEN <> ($this:<root>.Test3<T of <root>.Test3>, other:kotlin.Any?) returnType:kotlin.Boolean
       $this: VALUE_PARAMETER GENERATED_DATA_CLASS_MEMBER name:<this> type:<root>.Test3<T of <root>.Test3>
       VALUE_PARAMETER GENERATED_DATA_CLASS_MEMBER name:other index:0 type:kotlin.Any?
@@ -288,19 +285,18 @@ FILE fqName:<root> fileName:/dataClassesGeneric.kt
       $this: VALUE_PARAMETER name:<this> type:<root>.Test4
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun component1 (): kotlin.collections.List<kotlin.String> declared in <root>.Test4'
-          CALL 'public final fun <get-x> (): kotlin.collections.List<kotlin.String> declared in <root>.Test4' type=kotlin.collections.List<kotlin.String> origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test4 declared in <root>.Test4.component1' type=<root>.Test4 origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:x type:kotlin.collections.List<kotlin.String> visibility:private [final]' type=kotlin.collections.List<kotlin.String> origin=null
+            receiver: GET_VAR '<this>: <root>.Test4 declared in <root>.Test4.component1' type=<root>.Test4 origin=null
     FUN name:copy visibility:public modality:FINAL <> ($this:<root>.Test4, x:kotlin.collections.List<kotlin.String>) returnType:<root>.Test4
       $this: VALUE_PARAMETER name:<this> type:<root>.Test4
       VALUE_PARAMETER name:x index:0 type:kotlin.collections.List<kotlin.String>
         EXPRESSION_BODY
-          CALL 'public final fun <get-x> (): kotlin.collections.List<kotlin.String> declared in <root>.Test4' type=kotlin.collections.List<kotlin.String> origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test4 declared in <root>.Test4.copy' type=<root>.Test4 origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:x type:kotlin.collections.List<kotlin.String> visibility:private [final]' type=kotlin.collections.List<kotlin.String> origin=null
+            receiver: GET_VAR '<this>: <root>.Test4 declared in <root>.Test4.copy' type=<root>.Test4 origin=null
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun copy (x: kotlin.collections.List<kotlin.String>): <root>.Test4 declared in <root>.Test4'
           CONSTRUCTOR_CALL 'public constructor <init> (x: kotlin.collections.List<kotlin.String>) [primary] declared in <root>.Test4' type=<root>.Test4 origin=null
-            x: CALL 'public final fun <get-x> (): kotlin.collections.List<kotlin.String> declared in <root>.Test4' type=IrErrorType origin=GET_PROPERTY
-              $this: GET_VAR '<this>: <root>.Test4 declared in <root>.Test4.copy' type=<root>.Test4 origin=null
+            x: GET_VAR 'x: kotlin.collections.List<kotlin.String> declared in <root>.Test4.copy' type=kotlin.collections.List<kotlin.String> origin=null
     FUN GENERATED_DATA_CLASS_MEMBER name:equals visibility:public modality:OPEN <> ($this:<root>.Test4, other:kotlin.Any?) returnType:kotlin.Boolean
       $this: VALUE_PARAMETER GENERATED_DATA_CLASS_MEMBER name:<this> type:<root>.Test4
       VALUE_PARAMETER GENERATED_DATA_CLASS_MEMBER name:other index:0 type:kotlin.Any?

--- a/compiler/testData/ir/irText/classes/kt31649.fir.txt
+++ b/compiler/testData/ir/irText/classes/kt31649.fir.txt
@@ -21,19 +21,18 @@ FILE fqName:<root> fileName:/kt31649.kt
       $this: VALUE_PARAMETER name:<this> type:<root>.TestData
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun component1 (): kotlin.Nothing? declared in <root>.TestData'
-          CALL 'public final fun <get-nn> (): kotlin.Nothing? declared in <root>.TestData' type=kotlin.Nothing? origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.TestData declared in <root>.TestData.component1' type=<root>.TestData origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nn type:kotlin.Nothing? visibility:private [final]' type=kotlin.Nothing? origin=null
+            receiver: GET_VAR '<this>: <root>.TestData declared in <root>.TestData.component1' type=<root>.TestData origin=null
     FUN name:copy visibility:public modality:FINAL <> ($this:<root>.TestData, nn:kotlin.Nothing?) returnType:<root>.TestData
       $this: VALUE_PARAMETER name:<this> type:<root>.TestData
       VALUE_PARAMETER name:nn index:0 type:kotlin.Nothing?
         EXPRESSION_BODY
-          CALL 'public final fun <get-nn> (): kotlin.Nothing? declared in <root>.TestData' type=kotlin.Nothing? origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.TestData declared in <root>.TestData.copy' type=<root>.TestData origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nn type:kotlin.Nothing? visibility:private [final]' type=kotlin.Nothing? origin=null
+            receiver: GET_VAR '<this>: <root>.TestData declared in <root>.TestData.copy' type=<root>.TestData origin=null
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun copy (nn: kotlin.Nothing?): <root>.TestData declared in <root>.TestData'
           CONSTRUCTOR_CALL 'public constructor <init> (nn: kotlin.Nothing?) [primary] declared in <root>.TestData' type=<root>.TestData origin=null
-            nn: CALL 'public final fun <get-nn> (): kotlin.Nothing? declared in <root>.TestData' type=IrErrorType origin=GET_PROPERTY
-              $this: GET_VAR '<this>: <root>.TestData declared in <root>.TestData.copy' type=<root>.TestData origin=null
+            nn: GET_VAR 'nn: kotlin.Nothing? declared in <root>.TestData.copy' type=kotlin.Nothing? origin=null
     FUN GENERATED_DATA_CLASS_MEMBER name:equals visibility:public modality:OPEN <> ($this:<root>.TestData, other:kotlin.Any?) returnType:kotlin.Boolean
       $this: VALUE_PARAMETER GENERATED_DATA_CLASS_MEMBER name:<this> type:<root>.TestData
       VALUE_PARAMETER GENERATED_DATA_CLASS_MEMBER name:other index:0 type:kotlin.Any?

--- a/compiler/testData/ir/irText/classes/lambdaInDataClassDefaultParameter.fir.txt
+++ b/compiler/testData/ir/irText/classes/lambdaInDataClassDefaultParameter.fir.txt
@@ -28,19 +28,18 @@ FILE fqName:<root> fileName:/lambdaInDataClassDefaultParameter.kt
       $this: VALUE_PARAMETER name:<this> type:<root>.A
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun component1 (): kotlin.Function2<<root>.A, kotlin.String, kotlin.Unit> declared in <root>.A'
-          CALL 'public final fun <get-runA> (): kotlin.Function2<<root>.A, kotlin.String, kotlin.Unit> declared in <root>.A' type=kotlin.Function2<<root>.A, kotlin.String, kotlin.Unit> origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.A declared in <root>.A.component1' type=<root>.A origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:runA type:kotlin.Function2<<root>.A, kotlin.String, kotlin.Unit> visibility:private [final]' type=kotlin.Function2<<root>.A, kotlin.String, kotlin.Unit> origin=null
+            receiver: GET_VAR '<this>: <root>.A declared in <root>.A.component1' type=<root>.A origin=null
     FUN name:copy visibility:public modality:FINAL <> ($this:<root>.A, runA:kotlin.Function2<<root>.A, kotlin.String, kotlin.Unit>) returnType:<root>.A
       $this: VALUE_PARAMETER name:<this> type:<root>.A
       VALUE_PARAMETER name:runA index:0 type:kotlin.Function2<<root>.A, kotlin.String, kotlin.Unit>
         EXPRESSION_BODY
-          CALL 'public final fun <get-runA> (): kotlin.Function2<<root>.A, kotlin.String, kotlin.Unit> declared in <root>.A' type=kotlin.Function2<<root>.A, kotlin.String, kotlin.Unit> origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.A declared in <root>.A.copy' type=<root>.A origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:runA type:kotlin.Function2<<root>.A, kotlin.String, kotlin.Unit> visibility:private [final]' type=kotlin.Function2<<root>.A, kotlin.String, kotlin.Unit> origin=null
+            receiver: GET_VAR '<this>: <root>.A declared in <root>.A.copy' type=<root>.A origin=null
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun copy (runA: kotlin.Function2<<root>.A, kotlin.String, kotlin.Unit>): <root>.A declared in <root>.A'
           CONSTRUCTOR_CALL 'public constructor <init> (runA: kotlin.Function2<<root>.A, kotlin.String, kotlin.Unit>) [primary] declared in <root>.A' type=<root>.A origin=null
-            runA: CALL 'public final fun <get-runA> (): kotlin.Function2<<root>.A, kotlin.String, kotlin.Unit> declared in <root>.A' type=IrErrorType origin=GET_PROPERTY
-              $this: GET_VAR '<this>: <root>.A declared in <root>.A.copy' type=<root>.A origin=null
+            runA: GET_VAR 'runA: kotlin.Function2<<root>.A, kotlin.String, kotlin.Unit> declared in <root>.A.copy' type=kotlin.Function2<<root>.A, kotlin.String, kotlin.Unit> origin=null
     FUN GENERATED_DATA_CLASS_MEMBER name:equals visibility:public modality:OPEN <> ($this:<root>.A, other:kotlin.Any?) returnType:kotlin.Boolean
       $this: VALUE_PARAMETER GENERATED_DATA_CLASS_MEMBER name:<this> type:<root>.A
       VALUE_PARAMETER GENERATED_DATA_CLASS_MEMBER name:other index:0 type:kotlin.Any?
@@ -134,19 +133,18 @@ FILE fqName:<root> fileName:/lambdaInDataClassDefaultParameter.kt
       $this: VALUE_PARAMETER name:<this> type:<root>.B
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun component1 (): kotlin.Any declared in <root>.B'
-          CALL 'public final fun <get-x> (): kotlin.Any declared in <root>.B' type=kotlin.Any origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.B declared in <root>.B.component1' type=<root>.B origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:x type:kotlin.Any visibility:private [final]' type=kotlin.Any origin=null
+            receiver: GET_VAR '<this>: <root>.B declared in <root>.B.component1' type=<root>.B origin=null
     FUN name:copy visibility:public modality:FINAL <> ($this:<root>.B, x:kotlin.Any) returnType:<root>.B
       $this: VALUE_PARAMETER name:<this> type:<root>.B
       VALUE_PARAMETER name:x index:0 type:kotlin.Any
         EXPRESSION_BODY
-          CALL 'public final fun <get-x> (): kotlin.Any declared in <root>.B' type=kotlin.Any origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.B declared in <root>.B.copy' type=<root>.B origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:x type:kotlin.Any visibility:private [final]' type=kotlin.Any origin=null
+            receiver: GET_VAR '<this>: <root>.B declared in <root>.B.copy' type=<root>.B origin=null
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun copy (x: kotlin.Any): <root>.B declared in <root>.B'
           CONSTRUCTOR_CALL 'public constructor <init> (x: kotlin.Any) [primary] declared in <root>.B' type=<root>.B origin=null
-            x: CALL 'public final fun <get-x> (): kotlin.Any declared in <root>.B' type=IrErrorType origin=GET_PROPERTY
-              $this: GET_VAR '<this>: <root>.B declared in <root>.B.copy' type=<root>.B origin=null
+            x: GET_VAR 'x: kotlin.Any declared in <root>.B.copy' type=kotlin.Any origin=null
     FUN GENERATED_DATA_CLASS_MEMBER name:equals visibility:public modality:OPEN <> ($this:<root>.B, other:kotlin.Any?) returnType:kotlin.Boolean
       $this: VALUE_PARAMETER GENERATED_DATA_CLASS_MEMBER name:<this> type:<root>.B
       VALUE_PARAMETER GENERATED_DATA_CLASS_MEMBER name:other index:0 type:kotlin.Any?

--- a/compiler/testData/ir/irText/declarations/parameters/dataClassMembers.fir.txt
+++ b/compiler/testData/ir/irText/declarations/parameters/dataClassMembers.fir.txt
@@ -36,32 +36,30 @@ FILE fqName:<root> fileName:/dataClassMembers.kt
       $this: VALUE_PARAMETER name:<this> type:<root>.Test<T of <root>.Test>
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun component1 (): T of <root>.Test declared in <root>.Test'
-          CALL 'public final fun <get-x> (): T of <root>.Test declared in <root>.Test' type=T of <root>.Test origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test<T of <root>.Test> declared in <root>.Test.component1' type=<root>.Test<T of <root>.Test> origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:x type:T of <root>.Test visibility:private [final]' type=T of <root>.Test origin=null
+            receiver: GET_VAR '<this>: <root>.Test<T of <root>.Test> declared in <root>.Test.component1' type=<root>.Test<T of <root>.Test> origin=null
     FUN name:component2 visibility:public modality:FINAL <> ($this:<root>.Test<T of <root>.Test>) returnType:kotlin.String
       $this: VALUE_PARAMETER name:<this> type:<root>.Test<T of <root>.Test>
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun component2 (): kotlin.String declared in <root>.Test'
-          CALL 'public final fun <get-y> (): kotlin.String declared in <root>.Test' type=kotlin.String origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test<T of <root>.Test> declared in <root>.Test.component2' type=<root>.Test<T of <root>.Test> origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:y type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+            receiver: GET_VAR '<this>: <root>.Test<T of <root>.Test> declared in <root>.Test.component2' type=<root>.Test<T of <root>.Test> origin=null
     FUN name:copy visibility:public modality:FINAL <> ($this:<root>.Test<T of <root>.Test>, x:T of <root>.Test, y:kotlin.String) returnType:<root>.Test<T of <root>.Test>
       $this: VALUE_PARAMETER name:<this> type:<root>.Test<T of <root>.Test>
       VALUE_PARAMETER name:x index:0 type:T of <root>.Test
         EXPRESSION_BODY
-          CALL 'public final fun <get-x> (): T of <root>.Test declared in <root>.Test' type=T of <root>.Test origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test<T of <root>.Test> declared in <root>.Test.copy' type=<root>.Test<T of <root>.Test> origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:x type:T of <root>.Test visibility:private [final]' type=T of <root>.Test origin=null
+            receiver: GET_VAR '<this>: <root>.Test<T of <root>.Test> declared in <root>.Test.copy' type=<root>.Test<T of <root>.Test> origin=null
       VALUE_PARAMETER name:y index:1 type:kotlin.String
         EXPRESSION_BODY
-          CALL 'public final fun <get-y> (): kotlin.String declared in <root>.Test' type=kotlin.String origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.Test<T of <root>.Test> declared in <root>.Test.copy' type=<root>.Test<T of <root>.Test> origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:y type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+            receiver: GET_VAR '<this>: <root>.Test<T of <root>.Test> declared in <root>.Test.copy' type=<root>.Test<T of <root>.Test> origin=null
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun copy (x: T of <root>.Test, y: kotlin.String): <root>.Test<T of <root>.Test> declared in <root>.Test'
           CONSTRUCTOR_CALL 'public constructor <init> (x: T of <root>.Test, y: kotlin.String) [primary] declared in <root>.Test' type=<root>.Test<T of <root>.Test> origin=null
-            <class: T>: <none>
-            x: CALL 'public final fun <get-x> (): T of <root>.Test declared in <root>.Test' type=IrErrorType origin=GET_PROPERTY
-              $this: GET_VAR '<this>: <root>.Test<T of <root>.Test> declared in <root>.Test.copy' type=<root>.Test<T of <root>.Test> origin=null
-            y: CALL 'public final fun <get-y> (): kotlin.String declared in <root>.Test' type=IrErrorType origin=GET_PROPERTY
-              $this: GET_VAR '<this>: <root>.Test<T of <root>.Test> declared in <root>.Test.copy' type=<root>.Test<T of <root>.Test> origin=null
+            <class: T>: kotlin.Any
+            x: GET_VAR 'x: T of <root>.Test declared in <root>.Test.copy' type=T of <root>.Test origin=null
+            y: GET_VAR 'y: kotlin.String declared in <root>.Test.copy' type=kotlin.String origin=null
     FUN GENERATED_DATA_CLASS_MEMBER name:equals visibility:public modality:OPEN <> ($this:<root>.Test<T of <root>.Test>, other:kotlin.Any?) returnType:kotlin.Boolean
       $this: VALUE_PARAMETER GENERATED_DATA_CLASS_MEMBER name:<this> type:<root>.Test<T of <root>.Test>
       VALUE_PARAMETER GENERATED_DATA_CLASS_MEMBER name:other index:0 type:kotlin.Any?

--- a/compiler/testData/ir/irText/lambdas/destructuringInLambda.fir.txt
+++ b/compiler/testData/ir/irText/lambdas/destructuringInLambda.fir.txt
@@ -33,31 +33,29 @@ FILE fqName:<root> fileName:/destructuringInLambda.kt
       $this: VALUE_PARAMETER name:<this> type:<root>.A
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun component1 (): kotlin.Int declared in <root>.A'
-          CALL 'public final fun <get-x> (): kotlin.Int declared in <root>.A' type=kotlin.Int origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.A declared in <root>.A.component1' type=<root>.A origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:x type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+            receiver: GET_VAR '<this>: <root>.A declared in <root>.A.component1' type=<root>.A origin=null
     FUN name:component2 visibility:public modality:FINAL <> ($this:<root>.A) returnType:kotlin.Int
       $this: VALUE_PARAMETER name:<this> type:<root>.A
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun component2 (): kotlin.Int declared in <root>.A'
-          CALL 'public final fun <get-y> (): kotlin.Int declared in <root>.A' type=kotlin.Int origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.A declared in <root>.A.component2' type=<root>.A origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:y type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+            receiver: GET_VAR '<this>: <root>.A declared in <root>.A.component2' type=<root>.A origin=null
     FUN name:copy visibility:public modality:FINAL <> ($this:<root>.A, x:kotlin.Int, y:kotlin.Int) returnType:<root>.A
       $this: VALUE_PARAMETER name:<this> type:<root>.A
       VALUE_PARAMETER name:x index:0 type:kotlin.Int
         EXPRESSION_BODY
-          CALL 'public final fun <get-x> (): kotlin.Int declared in <root>.A' type=kotlin.Int origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.A declared in <root>.A.copy' type=<root>.A origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:x type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+            receiver: GET_VAR '<this>: <root>.A declared in <root>.A.copy' type=<root>.A origin=null
       VALUE_PARAMETER name:y index:1 type:kotlin.Int
         EXPRESSION_BODY
-          CALL 'public final fun <get-y> (): kotlin.Int declared in <root>.A' type=kotlin.Int origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.A declared in <root>.A.copy' type=<root>.A origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:y type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+            receiver: GET_VAR '<this>: <root>.A declared in <root>.A.copy' type=<root>.A origin=null
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun copy (x: kotlin.Int, y: kotlin.Int): <root>.A declared in <root>.A'
           CONSTRUCTOR_CALL 'public constructor <init> (x: kotlin.Int, y: kotlin.Int) [primary] declared in <root>.A' type=<root>.A origin=null
-            x: CALL 'public final fun <get-x> (): kotlin.Int declared in <root>.A' type=IrErrorType origin=GET_PROPERTY
-              $this: GET_VAR '<this>: <root>.A declared in <root>.A.copy' type=<root>.A origin=null
-            y: CALL 'public final fun <get-y> (): kotlin.Int declared in <root>.A' type=IrErrorType origin=GET_PROPERTY
-              $this: GET_VAR '<this>: <root>.A declared in <root>.A.copy' type=<root>.A origin=null
+            x: GET_VAR 'x: kotlin.Int declared in <root>.A.copy' type=kotlin.Int origin=null
+            y: GET_VAR 'y: kotlin.Int declared in <root>.A.copy' type=kotlin.Int origin=null
     FUN GENERATED_DATA_CLASS_MEMBER name:equals visibility:public modality:OPEN <> ($this:<root>.A, other:kotlin.Any?) returnType:kotlin.Boolean
       $this: VALUE_PARAMETER GENERATED_DATA_CLASS_MEMBER name:<this> type:<root>.A
       VALUE_PARAMETER GENERATED_DATA_CLASS_MEMBER name:other index:0 type:kotlin.Any?

--- a/compiler/testData/ir/irText/types/nullChecks/enhancedNullabilityInForLoop.fir.txt
+++ b/compiler/testData/ir/irText/types/nullChecks/enhancedNullabilityInForLoop.fir.txt
@@ -148,31 +148,29 @@ FILE fqName:<root> fileName:/enhancedNullabilityInForLoop.kt
       $this: VALUE_PARAMETER name:<this> type:<root>.P
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun component1 (): kotlin.Int declared in <root>.P'
-          CALL 'public final fun <get-x> (): kotlin.Int declared in <root>.P' type=kotlin.Int origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.P declared in <root>.P.component1' type=<root>.P origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:x type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+            receiver: GET_VAR '<this>: <root>.P declared in <root>.P.component1' type=<root>.P origin=null
     FUN name:component2 visibility:public modality:FINAL <> ($this:<root>.P) returnType:kotlin.Int
       $this: VALUE_PARAMETER name:<this> type:<root>.P
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun component2 (): kotlin.Int declared in <root>.P'
-          CALL 'public final fun <get-y> (): kotlin.Int declared in <root>.P' type=kotlin.Int origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.P declared in <root>.P.component2' type=<root>.P origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:y type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+            receiver: GET_VAR '<this>: <root>.P declared in <root>.P.component2' type=<root>.P origin=null
     FUN name:copy visibility:public modality:FINAL <> ($this:<root>.P, x:kotlin.Int, y:kotlin.Int) returnType:<root>.P
       $this: VALUE_PARAMETER name:<this> type:<root>.P
       VALUE_PARAMETER name:x index:0 type:kotlin.Int
         EXPRESSION_BODY
-          CALL 'public final fun <get-x> (): kotlin.Int declared in <root>.P' type=kotlin.Int origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.P declared in <root>.P.copy' type=<root>.P origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:x type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+            receiver: GET_VAR '<this>: <root>.P declared in <root>.P.copy' type=<root>.P origin=null
       VALUE_PARAMETER name:y index:1 type:kotlin.Int
         EXPRESSION_BODY
-          CALL 'public final fun <get-y> (): kotlin.Int declared in <root>.P' type=kotlin.Int origin=GET_PROPERTY
-            $this: GET_VAR '<this>: <root>.P declared in <root>.P.copy' type=<root>.P origin=null
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:y type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+            receiver: GET_VAR '<this>: <root>.P declared in <root>.P.copy' type=<root>.P origin=null
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun copy (x: kotlin.Int, y: kotlin.Int): <root>.P declared in <root>.P'
           CONSTRUCTOR_CALL 'public constructor <init> (x: kotlin.Int, y: kotlin.Int) [primary] declared in <root>.P' type=<root>.P origin=null
-            x: CALL 'public final fun <get-x> (): kotlin.Int declared in <root>.P' type=IrErrorType origin=GET_PROPERTY
-              $this: GET_VAR '<this>: <root>.P declared in <root>.P.copy' type=<root>.P origin=null
-            y: CALL 'public final fun <get-y> (): kotlin.Int declared in <root>.P' type=IrErrorType origin=GET_PROPERTY
-              $this: GET_VAR '<this>: <root>.P declared in <root>.P.copy' type=<root>.P origin=null
+            x: GET_VAR 'x: kotlin.Int declared in <root>.P.copy' type=kotlin.Int origin=null
+            y: GET_VAR 'y: kotlin.Int declared in <root>.P.copy' type=kotlin.Int origin=null
     FUN GENERATED_DATA_CLASS_MEMBER name:equals visibility:public modality:OPEN <> ($this:<root>.P, other:kotlin.Any?) returnType:kotlin.Boolean
       $this: VALUE_PARAMETER GENERATED_DATA_CLASS_MEMBER name:<this> type:<root>.P
       VALUE_PARAMETER GENERATED_DATA_CLASS_MEMBER name:other index:0 type:kotlin.Any?


### PR DESCRIPTION
https://github.com/JetBrains/kotlin/pull/3286 covered consolidation of `equals`, `hashCode`, and `toString` for data class. This one covers `componentN` and `copy`.