### PR TITLE
Fix scripting REPL completion after literals

### DIFF
--- a/plugins/scripting/scripting-ide-services-test/test/org/jetbrains/kotlin/scripting/ide_services/ReplCompletionAndErrorsAnalysisTest.kt
+++ b/plugins/scripting/scripting-ide-services-test/test/org/jetbrains/kotlin/scripting/ide_services/ReplCompletionAndErrorsAnalysisTest.kt
@@ -62,6 +62,23 @@ class ReplCompletionAndErrorsAnalysisTest : TestCase() {
         }
     }
 
+    @Test
+    fun testNoVariantsAfterLiterals() = test {
+        fun testNoVariants(testCode: String, testCursor: Int? = null) = run {
+            doComplete
+            code = testCode
+            cursor = testCursor ?: testCode.length
+            expect {
+                completionsMode(ComparisonType.EQUALS)
+            }
+        }
+
+        testNoVariants("val x1 = 42")
+        testNoVariants("val x2 = 42.42")
+        testNoVariants("val x3 = 'v'")
+        testNoVariants("val x4 = \"str42\"")
+    }
+
 
     @Test
     fun testPackagesImport() = test {


### PR DESCRIPTION
This PR fixes wrongly suggested variants after numeric, char and string literals in scripting REPL compiler with IDE services