### PR TITLE
Fix REPL completion after "final" expressions

### DIFF
--- a/plugins/scripting/scripting-ide-services-test/test/org/jetbrains/kotlin/scripting/ide_services/ReplCompletionAndErrorsAnalysisTest.kt
+++ b/plugins/scripting/scripting-ide-services-test/test/org/jetbrains/kotlin/scripting/ide_services/ReplCompletionAndErrorsAnalysisTest.kt
@@ -63,7 +63,7 @@ class ReplCompletionAndErrorsAnalysisTest : TestCase() {
     }
 
     @Test
-    fun testNoVariantsAfterLiterals() = test {
+    fun testNoVariantsAfterFinalExpressions() = test {
         fun testNoVariants(testCode: String, testCursor: Int? = null) = run {
             doComplete
             code = testCode
@@ -77,8 +77,19 @@ class ReplCompletionAndErrorsAnalysisTest : TestCase() {
         testNoVariants("val x2 = 42.42")
         testNoVariants("val x3 = 'v'")
         testNoVariants("val x4 = \"str42\"")
-    }
 
+        testNoVariants("val x5 = 40 + 41 * 42")
+        testNoVariants("val x6 = 40 + 41 * 42", 16) // after 41
+        testNoVariants("val x7 = 40 + 41 * 42", 11) // after 40
+        testNoVariants("6 * (2 + 5)")
+
+        testNoVariants("\"aBc\".capitalize()")
+        testNoVariants(
+            """
+                "abc" + "def"
+            """.trimIndent()
+        )
+    }
 
     @Test
     fun testPackagesImport() = test {

--- a/plugins/scripting/scripting-ide-services/src/org/jetbrains/kotlin/scripting/ide_services/compiler/impl/KJvmReplCompleter.kt
+++ b/plugins/scripting/scripting-ide-services/src/org/jetbrains/kotlin/scripting/ide_services/compiler/impl/KJvmReplCompleter.kt
@@ -23,7 +23,6 @@ import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.endOffset
 import org.jetbrains.kotlin.psi.psiUtil.quoteIfNeeded
 import org.jetbrains.kotlin.psi.psiUtil.startOffset
-import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
 import org.jetbrains.kotlin.renderer.ClassifierNamePolicy
 import org.jetbrains.kotlin.renderer.ParameterNameRenderingPolicy
 import org.jetbrains.kotlin.resolve.BindingContext
@@ -94,12 +93,11 @@ private class KJvmReplCompleter(
 
             val elementParent = element.parent
             if (prefix.isEmpty() && elementParent is KtBinaryExpression) {
-                when (elementParent.node.firstChildNode.elementType) {
-                    KtStubElementTypes.INTEGER_CONSTANT,
-                    KtStubElementTypes.FLOAT_CONSTANT,
-                    KtStubElementTypes.CHARACTER_CONSTANT,
-                    KtStubElementTypes.STRING_TEMPLATE -> return@gen
-                }
+                val parentChildren = elementParent.children
+                if (parentChildren.size == 3 &&
+                    parentChildren[1] is KtOperationReferenceExpression &&
+                    parentChildren[1].text == INSERTED_STRING
+                ) return@gen
             }
 
             isSortNeeded = false


### PR DESCRIPTION
Final expressions here are literals, "closed" function calls, expressions in brackets. Completion variants should not appear after them if they are not followed by by dot (.) or double colon (::).

Note that identifiers are not considered as final expressions.