### PR TITLE
Reformat example code in comment

### DIFF
--- a/libraries/kotlin.test/js/src/main/kotlin/kotlin/test/FrameworkAdapter.kt
+++ b/libraries/kotlin.test/js/src/main/kotlin/kotlin/test/FrameworkAdapter.kt
@@ -11,13 +11,13 @@ package kotlin.test
  * The tests structure is defined using internal functions suite and test, which delegate to corresponding functions of a [FrameworkAdapter].
  * Sample test layout:
  *
- * suite('a suite', false, function() {
- *   suite('a subsuite', false, function() {
- *     test('a test', false, function() {...});
- *     test('an ignored/pending test', true, function() {...});
- *   });
- *   suite('an ignored/pending test', true, function() {...});
- * });
+ *     suite('a suite', false, function() {
+ *       suite('a subsuite', false, function() {
+ *         test('a test', false, function() {...});
+ *         test('an ignored/pending test', true, function() {...});
+ *       });
+ *       suite('an ignored/pending test', true, function() {...});
+ *     });
  *
  */
 public external interface FrameworkAdapter {

--- a/libraries/kotlin.test/js/src/main/kotlin/kotlin/test/FrameworkAdapter.kt
+++ b/libraries/kotlin.test/js/src/main/kotlin/kotlin/test/FrameworkAdapter.kt
@@ -11,13 +11,15 @@ package kotlin.test
  * The tests structure is defined using internal functions suite and test, which delegate to corresponding functions of a [FrameworkAdapter].
  * Sample test layout:
  *
- *     suite('a suite', false, function() {
- *       suite('a subsuite', false, function() {
- *         test('a test', false, function() {...});
- *         test('an ignored/pending test', true, function() {...});
- *       });
- *       suite('an ignored/pending test', true, function() {...});
- *     });
+ * ```js
+ * suite('a suite', false, function() {
+ *   suite('a subsuite', false, function() {
+ *     test('a test', false, function() {...});
+ *     test('an ignored/pending test', true, function() {...});
+ *   });
+ *   suite('an ignored/pending test', true, function() {...});
+ * });
+ * ```
  *
  */
 public external interface FrameworkAdapter {


### PR DESCRIPTION
The example code shows up all on one line in the generated docs.

https://kotlinlang.org/api/latest/kotlin.test/kotlin.test/-framework-adapter/ shows

> suite('a suite', false, function() { suite('a subsuite', false, ...

This indents the code block by 4 spaces so that dokka recognizes it as such.  I believe [dokka supports indented code blocks](https://github.com/Kotlin/dokka/releases/tag/0.9.14) but have not regenerated the docs myself.