### PR TITLE
KT-25807: Fix Parcelize annotation implementing Parcelable.Creator<T>

### DIFF
--- a/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/ParcelableResolveExtension.kt
+++ b/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/ParcelableResolveExtension.kt
@@ -44,6 +44,11 @@ open class ParcelableResolveExtension : SyntheticResolveExtension {
             return module.findClassAcrossModuleDependencies(ClassId.topLevel(FqName("android.os.Parcel")))?.defaultType
         }
 
+        fun resolveParcelableCreatorClassType(module: ModuleDescriptor): SimpleType? {
+            val creatorClassId = ClassId(FqName("android.os"), FqName("Parcelable.Creator"), false)
+            return module.findClassAcrossModuleDependencies(creatorClassId)?.defaultType
+        }
+
         fun createMethod(
                 classDescriptor: ClassDescriptor,
                 componentKind: ParcelableSyntheticComponent.ComponentKind,

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/javaInterop.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/javaInterop.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM
 // This issue affects AIDL generated files, as reported in KT-25807
 // WITH_RUNTIME
 // FILE: J.java

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/IBinderIInterface.txt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/IBinderIInterface.txt
@@ -1,7 +1,7 @@
 public final class User$Creator : java/lang/Object, android/os/Parcelable$Creator {
     public void <init>()
 
-    public final java.lang.Object createFromParcel(android.os.Parcel in) {
+    public final User createFromParcel(android.os.Parcel in) {
         LABEL (L0)
           ALOAD (1)
           LDC (in)
@@ -44,7 +44,18 @@ public final class User$Creator : java/lang/Object, android/os/Parcelable$Creato
         LABEL (L4)
     }
 
-    public final java.lang.Object[] newArray(int size)
+    public java.lang.Object createFromParcel(android.os.Parcel p0) {
+        LABEL (L0)
+        LINENUMBER (10)
+          ALOAD (0)
+          ALOAD (1)
+          INVOKEVIRTUAL (User$Creator, createFromParcel, (Landroid/os/Parcel;)LUser;)
+          ARETURN
+    }
+
+    public final User[] newArray(int size)
+
+    public java.lang.Object[] newArray(int p0)
 }
 
 public final class User : java/lang/Object, android/os/Parcelable {

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/customDescribeContents.txt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/customDescribeContents.txt
@@ -1,9 +1,13 @@
 public final class User$Creator : java/lang/Object, android/os/Parcelable$Creator {
     public void <init>()
 
-    public final java.lang.Object createFromParcel(android.os.Parcel in)
+    public final User createFromParcel(android.os.Parcel in)
 
-    public final java.lang.Object[] newArray(int size)
+    public java.lang.Object createFromParcel(android.os.Parcel p0)
+
+    public final User[] newArray(int size)
+
+    public java.lang.Object[] newArray(int p0)
 }
 
 public final class User : java/lang/Object, android/os/Parcelable {

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/customParcelablesDifferentModule.txt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/customParcelablesDifferentModule.txt
@@ -1,7 +1,7 @@
 public final class test/Foo$Creator : java/lang/Object, android/os/Parcelable$Creator {
     public void <init>()
 
-    public final java.lang.Object createFromParcel(android.os.Parcel in) {
+    public final test.Foo createFromParcel(android.os.Parcel in) {
         LABEL (L0)
           ALOAD (1)
           LDC (in)
@@ -18,7 +18,18 @@ public final class test/Foo$Creator : java/lang/Object, android/os/Parcelable$Cr
         LABEL (L1)
     }
 
-    public final java.lang.Object[] newArray(int size)
+    public java.lang.Object createFromParcel(android.os.Parcel p0) {
+        LABEL (L0)
+        LINENUMBER (11)
+          ALOAD (0)
+          ALOAD (1)
+          INVOKEVIRTUAL (test/Foo$Creator, createFromParcel, (Landroid/os/Parcel;)Ltest/Foo;)
+          ARETURN
+    }
+
+    public final test.Foo[] newArray(int size)
+
+    public java.lang.Object[] newArray(int p0)
 }
 
 public final class test/Foo : java/lang/Object, android/os/Parcelable {

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/customParcelablesSameModule.txt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/customParcelablesSameModule.txt
@@ -104,7 +104,7 @@ public final class k/KotlinParcelable : java/lang/Object, android/os/Parcelable 
 public final class test/Foo$Creator : java/lang/Object, android/os/Parcelable$Creator {
     public void <init>()
 
-    public final java.lang.Object createFromParcel(android.os.Parcel in) {
+    public final test.Foo createFromParcel(android.os.Parcel in) {
         LABEL (L0)
           ALOAD (1)
           LDC (in)
@@ -121,7 +121,18 @@ public final class test/Foo$Creator : java/lang/Object, android/os/Parcelable$Cr
         LABEL (L1)
     }
 
-    public final java.lang.Object[] newArray(int size)
+    public java.lang.Object createFromParcel(android.os.Parcel p0) {
+        LABEL (L0)
+        LINENUMBER (9)
+          ALOAD (0)
+          ALOAD (1)
+          INVOKEVIRTUAL (test/Foo$Creator, createFromParcel, (Landroid/os/Parcel;)Ltest/Foo;)
+          ARETURN
+    }
+
+    public final test.Foo[] newArray(int size)
+
+    public java.lang.Object[] newArray(int p0)
 }
 
 public final class test/Foo : java/lang/Object, android/os/Parcelable {

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/customSimple.txt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/customSimple.txt
@@ -35,7 +35,7 @@ final class User$Companion : java/lang/Object, kotlinx/android/parcel/Parceler {
 public final class User$Creator : java/lang/Object, android/os/Parcelable$Creator {
     public void <init>()
 
-    public final java.lang.Object createFromParcel(android.os.Parcel in) {
+    public final User createFromParcel(android.os.Parcel in) {
         LABEL (L0)
           ALOAD (1)
           LDC (in)
@@ -47,12 +47,30 @@ public final class User$Creator : java/lang/Object, android/os/Parcelable$Creato
         LABEL (L1)
     }
 
-    public final java.lang.Object[] newArray(int size) {
+    public java.lang.Object createFromParcel(android.os.Parcel p0) {
+        LABEL (L0)
+        LINENUMBER (9)
+          ALOAD (0)
+          ALOAD (1)
+          INVOKEVIRTUAL (User$Creator, createFromParcel, (Landroid/os/Parcel;)LUser;)
+          ARETURN
+    }
+
+    public final User[] newArray(int size) {
         LABEL (L0)
           ILOAD (1)
           ANEWARRAY
           ARETURN
         LABEL (L1)
+    }
+
+    public java.lang.Object[] newArray(int p0) {
+        LABEL (L0)
+        LINENUMBER (9)
+          ALOAD (0)
+          ILOAD (1)
+          INVOKEVIRTUAL (User$Creator, newArray, (I)[LUser;)
+          ARETURN
     }
 }
 

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/customSimpleWithNewArray.txt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/customSimpleWithNewArray.txt
@@ -33,15 +33,26 @@ final class User$Companion : java/lang/Object, kotlinx/android/parcel/Parceler {
 public final class User$Creator : java/lang/Object, android/os/Parcelable$Creator {
     public void <init>()
 
-    public final java.lang.Object createFromParcel(android.os.Parcel in)
+    public final User createFromParcel(android.os.Parcel in)
 
-    public final java.lang.Object[] newArray(int size) {
+    public java.lang.Object createFromParcel(android.os.Parcel p0)
+
+    public final User[] newArray(int size) {
         LABEL (L0)
           GETSTATIC (Companion, LUser$Companion;)
           ILOAD (1)
           INVOKEVIRTUAL (User$Companion, newArray, (I)[Ljava/lang/Object;)
           ARETURN
         LABEL (L1)
+    }
+
+    public java.lang.Object[] newArray(int p0) {
+        LABEL (L0)
+        LINENUMBER (9)
+          ALOAD (0)
+          ILOAD (1)
+          INVOKEVIRTUAL (User$Creator, newArray, (I)[LUser;)
+          ARETURN
     }
 }
 

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/describeContentsFromSuperType.txt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/describeContentsFromSuperType.txt
@@ -13,9 +13,13 @@ public abstract class AbstractUser : java/lang/Object, android/os/Parcelable {
 public final class User$Creator : java/lang/Object, android/os/Parcelable$Creator {
     public void <init>()
 
-    public final java.lang.Object createFromParcel(android.os.Parcel in)
+    public final User createFromParcel(android.os.Parcel in)
 
-    public final java.lang.Object[] newArray(int size)
+    public java.lang.Object createFromParcel(android.os.Parcel p0)
+
+    public final User[] newArray(int size)
+
+    public java.lang.Object[] newArray(int p0)
 }
 
 public final class User : AbstractUser {

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/duplicatingClinit.txt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/duplicatingClinit.txt
@@ -9,9 +9,13 @@ public final class User$Companion : java/lang/Object {
 public final class User$Creator : java/lang/Object, android/os/Parcelable$Creator {
     public void <init>()
 
-    public final java.lang.Object createFromParcel(android.os.Parcel in)
+    public final User createFromParcel(android.os.Parcel in)
 
-    public final java.lang.Object[] newArray(int size)
+    public java.lang.Object createFromParcel(android.os.Parcel p0)
+
+    public final User[] newArray(int size)
+
+    public java.lang.Object[] newArray(int p0)
 }
 
 public final class User : java/lang/Object, android/os/Parcelable {

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/efficientParcelable.txt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/efficientParcelable.txt
@@ -1,7 +1,7 @@
 public final class test/Bar$Creator : java/lang/Object, android/os/Parcelable$Creator {
     public void <init>()
 
-    public final java.lang.Object createFromParcel(android.os.Parcel in) {
+    public final test.Bar createFromParcel(android.os.Parcel in) {
         LABEL (L0)
           ALOAD (1)
           LDC (in)
@@ -26,7 +26,18 @@ public final class test/Bar$Creator : java/lang/Object, android/os/Parcelable$Cr
         LABEL (L4)
     }
 
-    public final java.lang.Object[] newArray(int size)
+    public java.lang.Object createFromParcel(android.os.Parcel p0) {
+        LABEL (L0)
+        LINENUMBER (13)
+          ALOAD (0)
+          ALOAD (1)
+          INVOKEVIRTUAL (test/Bar$Creator, createFromParcel, (Landroid/os/Parcel;)Ltest/Bar;)
+          ARETURN
+    }
+
+    public final test.Bar[] newArray(int size)
+
+    public java.lang.Object[] newArray(int p0)
 }
 
 public final class test/Bar : java/lang/Object, android/os/Parcelable {
@@ -78,7 +89,7 @@ public final class test/Bar : java/lang/Object, android/os/Parcelable {
 public final class test/Foo$Creator : java/lang/Object, android/os/Parcelable$Creator {
     public void <init>()
 
-    public final java.lang.Object createFromParcel(android.os.Parcel in) {
+    public final test.Foo createFromParcel(android.os.Parcel in) {
         LABEL (L0)
           ALOAD (1)
           LDC (in)
@@ -95,7 +106,18 @@ public final class test/Foo$Creator : java/lang/Object, android/os/Parcelable$Cr
         LABEL (L1)
     }
 
-    public final java.lang.Object[] newArray(int size)
+    public java.lang.Object createFromParcel(android.os.Parcel p0) {
+        LABEL (L0)
+        LINENUMBER (10)
+          ALOAD (0)
+          ALOAD (1)
+          INVOKEVIRTUAL (test/Foo$Creator, createFromParcel, (Landroid/os/Parcel;)Ltest/Foo;)
+          ARETURN
+    }
+
+    public final test.Foo[] newArray(int size)
+
+    public java.lang.Object[] newArray(int p0)
 }
 
 public final class test/Foo : java/lang/Object, android/os/Parcelable {

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/kt25839.txt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/kt25839.txt
@@ -1,7 +1,7 @@
 public final class test/SomeClass$Creator : java/lang/Object, android/os/Parcelable$Creator {
     public void <init>()
 
-    public final java.lang.Object createFromParcel(android.os.Parcel in) {
+    public final test.SomeClass createFromParcel(android.os.Parcel in) {
         LABEL (L0)
           ALOAD (1)
           LDC (in)
@@ -23,7 +23,18 @@ public final class test/SomeClass$Creator : java/lang/Object, android/os/Parcela
         LABEL (L4)
     }
 
-    public final java.lang.Object[] newArray(int size)
+    public java.lang.Object createFromParcel(android.os.Parcel p0) {
+        LABEL (L0)
+        LINENUMBER (10)
+          ALOAD (0)
+          ALOAD (1)
+          INVOKEVIRTUAL (test/SomeClass$Creator, createFromParcel, (Landroid/os/Parcel;)Ltest/SomeClass;)
+          ARETURN
+    }
+
+    public final test.SomeClass[] newArray(int size)
+
+    public java.lang.Object[] newArray(int p0)
 }
 
 public final class test/SomeClass : java/lang/Object, android/os/Parcelable {

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/listInsideList.txt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/listInsideList.txt
@@ -1,9 +1,13 @@
 public final class Test$Creator : java/lang/Object, android/os/Parcelable$Creator {
     public void <init>()
 
-    public final java.lang.Object createFromParcel(android.os.Parcel in)
+    public final Test createFromParcel(android.os.Parcel in)
 
-    public final java.lang.Object[] newArray(int size)
+    public java.lang.Object createFromParcel(android.os.Parcel p0)
+
+    public final Test[] newArray(int size)
+
+    public java.lang.Object[] newArray(int p0)
 }
 
 public final class Test : java/lang/Object {

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/nullableNotNullSize.txt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/nullableNotNullSize.txt
@@ -1,9 +1,13 @@
 public final class TestNotNull$Creator : java/lang/Object, android/os/Parcelable$Creator {
     public void <init>()
 
-    public final java.lang.Object createFromParcel(android.os.Parcel in)
+    public final TestNotNull createFromParcel(android.os.Parcel in)
 
-    public final java.lang.Object[] newArray(int size)
+    public java.lang.Object createFromParcel(android.os.Parcel p0)
+
+    public final TestNotNull[] newArray(int size)
+
+    public java.lang.Object[] newArray(int p0)
 }
 
 public final class TestNotNull : java/lang/Object {
@@ -36,9 +40,13 @@ public final class TestNotNull : java/lang/Object {
 public final class TestNullable$Creator : java/lang/Object, android/os/Parcelable$Creator {
     public void <init>()
 
-    public final java.lang.Object createFromParcel(android.os.Parcel in)
+    public final TestNullable createFromParcel(android.os.Parcel in)
 
-    public final java.lang.Object[] newArray(int size)
+    public java.lang.Object createFromParcel(android.os.Parcel p0)
+
+    public final TestNullable[] newArray(int size)
+
+    public java.lang.Object[] newArray(int p0)
 }
 
 public final class TestNullable : java/lang/Object {

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/parcelable.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/parcelable.kt
@@ -11,11 +11,19 @@ class JavaClass {
     }
 }
 
+//FILE: android/os/Parcel.java
+package android.os;
+
+public class Parcel {}
+
 //FILE: android/os/Parcelable.java
 package android.os;
 
 public interface Parcelable {
-    public static interface Creator<T> {}
+    public static interface Creator<T> {
+        T createFromParcel(Parcel source);
+        T[] newArray(int size);
+    }
 }
 
 

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/parcelable.txt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/parcelable.txt
@@ -1,7 +1,7 @@
 public final class test/Foo$Creator : java/lang/Object, android/os/Parcelable$Creator {
     public void <init>()
 
-    public final java.lang.Object createFromParcel(android.os.Parcel in) {
+    public final test.Foo createFromParcel(android.os.Parcel in) {
         LABEL (L0)
           ALOAD (1)
           LDC (in)
@@ -17,7 +17,18 @@ public final class test/Foo$Creator : java/lang/Object, android/os/Parcelable$Cr
         LABEL (L1)
     }
 
-    public final java.lang.Object[] newArray(int size)
+    public java.lang.Object createFromParcel(android.os.Parcel p0) {
+        LABEL (L0)
+        LINENUMBER (8)
+          ALOAD (0)
+          ALOAD (1)
+          INVOKEVIRTUAL (test/Foo$Creator, createFromParcel, (Landroid/os/Parcel;)Ltest/Foo;)
+          ARETURN
+    }
+
+    public final test.Foo[] newArray(int size)
+
+    public java.lang.Object[] newArray(int p0)
 }
 
 public final class test/Foo : java/lang/Object, android/os/Parcelable {

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/serializable.txt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/serializable.txt
@@ -13,7 +13,7 @@ public final class SerializableSimple : java/lang/Object, java/io/Serializable {
 public final class User$Creator : java/lang/Object, android/os/Parcelable$Creator {
     public void <init>()
 
-    public final java.lang.Object createFromParcel(android.os.Parcel in) {
+    public final User createFromParcel(android.os.Parcel in) {
         LABEL (L0)
           ALOAD (1)
           LDC (in)
@@ -31,7 +31,18 @@ public final class User$Creator : java/lang/Object, android/os/Parcelable$Creato
         LABEL (L1)
     }
 
-    public final java.lang.Object[] newArray(int size)
+    public java.lang.Object createFromParcel(android.os.Parcel p0) {
+        LABEL (L0)
+        LINENUMBER (11)
+          ALOAD (0)
+          ALOAD (1)
+          INVOKEVIRTUAL (User$Creator, createFromParcel, (Landroid/os/Parcel;)LUser;)
+          ARETURN
+    }
+
+    public final User[] newArray(int size)
+
+    public java.lang.Object[] newArray(int p0)
 }
 
 public final class User : java/lang/Object, android/os/Parcelable {

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/simple.txt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/simple.txt
@@ -4,7 +4,7 @@ public final class User$Creator : java/lang/Object, android/os/Parcelable$Creato
             0 this: LUser$Creator;
     }
 
-    public final java.lang.Object createFromParcel(android.os.Parcel in) {
+    public final User createFromParcel(android.os.Parcel in) {
         Local variables:
             0 this: LUser$Creator;
             1 in: Landroid/os/Parcel;
@@ -35,11 +35,22 @@ public final class User$Creator : java/lang/Object, android/os/Parcelable$Creato
         LABEL (L4)
     }
 
-    public final java.lang.Object[] newArray(int size) {
+    public java.lang.Object createFromParcel(android.os.Parcel p0) {
+        LABEL (L0)
+        LINENUMBER (9)
+          ALOAD (0)
+          ALOAD (1)
+          INVOKEVIRTUAL (User$Creator, createFromParcel, (Landroid/os/Parcel;)LUser;)
+          ARETURN
+    }
+
+    public final User[] newArray(int size) {
         Local variables:
             0 this: LUser$Creator;
             1 size: I
     }
+
+    public java.lang.Object[] newArray(int p0)
 }
 
 public final class User : java/lang/Object, android/os/Parcelable {

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/simpleList.txt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/simpleList.txt
@@ -1,9 +1,13 @@
 public final class Test$Creator : java/lang/Object, android/os/Parcelable$Creator {
     public void <init>()
 
-    public final java.lang.Object createFromParcel(android.os.Parcel in)
+    public final Test createFromParcel(android.os.Parcel in)
 
-    public final java.lang.Object[] newArray(int size)
+    public java.lang.Object createFromParcel(android.os.Parcel p0)
+
+    public final Test[] newArray(int size)
+
+    public java.lang.Object[] newArray(int p0)
 }
 
 public final class Test : java/lang/Object {

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/size.txt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/size.txt
@@ -1,7 +1,7 @@
 public final class Test$Creator : java/lang/Object, android/os/Parcelable$Creator {
     public void <init>()
 
-    public final java.lang.Object createFromParcel(android.os.Parcel in) {
+    public final Test createFromParcel(android.os.Parcel in) {
         LABEL (L0)
           ALOAD (1)
           LDC (in)
@@ -25,7 +25,18 @@ public final class Test$Creator : java/lang/Object, android/os/Parcelable$Creato
         LABEL (L4)
     }
 
-    public final java.lang.Object[] newArray(int size)
+    public java.lang.Object createFromParcel(android.os.Parcel p0) {
+        LABEL (L0)
+        LINENUMBER (10)
+          ALOAD (0)
+          ALOAD (1)
+          INVOKEVIRTUAL (Test$Creator, createFromParcel, (Landroid/os/Parcel;)LTest;)
+          ARETURN
+    }
+
+    public final Test[] newArray(int size)
+
+    public java.lang.Object[] newArray(int p0)
 }
 
 public final class Test : java/lang/Object, android/os/Parcelable {
@@ -91,7 +102,7 @@ public final class Test : java/lang/Object, android/os/Parcelable {
 public final class TestF$Creator : java/lang/Object, android/os/Parcelable$Creator {
     public void <init>()
 
-    public final java.lang.Object createFromParcel(android.os.Parcel in) {
+    public final TestF createFromParcel(android.os.Parcel in) {
         LABEL (L0)
           ALOAD (1)
           LDC (in)
@@ -115,7 +126,18 @@ public final class TestF$Creator : java/lang/Object, android/os/Parcelable$Creat
         LABEL (L4)
     }
 
-    public final java.lang.Object[] newArray(int size)
+    public java.lang.Object createFromParcel(android.os.Parcel p0) {
+        LABEL (L0)
+        LINENUMBER (13)
+          ALOAD (0)
+          ALOAD (1)
+          INVOKEVIRTUAL (TestF$Creator, createFromParcel, (Landroid/os/Parcel;)LTestF;)
+          ARETURN
+    }
+
+    public final TestF[] newArray(int size)
+
+    public java.lang.Object[] newArray(int p0)
 }
 
 public final class TestF : java/lang/Object, android/os/Parcelable {


### PR DESCRIPTION
The JVM backend for `@Parcelize` currently ignores the generic type on `Parcelable.Creator<T>`, Consequently code requiring the correct `Parcelable` return type must cast from `Object`. This is particularly unsuitable for generated code such as AIDL, see https://youtrack.jetbrains.com/issue/KT-25807

Until the IR implementation in https://github.com/JetBrains/kotlin/pull/3271 is merged and becomes default, this PR provides a fix by implementing the generic interface as follows:
- Returning the relevant `Parcelable` type (`T`)
- Specifying the overridden methods, enabling the backend to generate suitable synthetic bridges
- Providing explicit class and field signatures to specify the type

Tests are updated accordingly, supported by a partial cherry-pick of https://github.com/JetBrains/kotlin/pull/3271/commits/e3c3e67e687f84886882048e7e339c28166b5056 from https://github.com/JetBrains/kotlin/pull/3271, with Steven's blessing. It should be noted that the unit tests for `android-extensions-compiler` were broken on master and do not appear to be included in CI.

These can be run as follows:
```
gradlew :plugins:android-extensions-compiler:test --tests "org.jetbrains.kotlin.android.parcel.*"
```