### PR TITLE
JVM: move synthetic line number generation to the inliner

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/ScriptCodegen.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/ScriptCodegen.kt
@@ -51,6 +51,7 @@ class ScriptCodegen private constructor(
                     typeMapper.mapSupertype(it.defaultType, null).internalName
                 }.toTypedArray()
         )
+        v.visitSource(scriptDeclaration.containingKtFile.name, null)
         AnnotationCodegen.forClass(v.visitor, this, state).genAnnotations(scriptDescriptor, null, null)
     }
 

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInliner.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInliner.kt
@@ -266,6 +266,7 @@ class MethodInliner(
                         visitInsn(Opcodes.NOP)
                     }
 
+                    inlineOnlySmapSkipper?.onInlineLambdaStart(remappingMethodAdapter, info)
                     addInlineMarker(this, true)
                     val lambdaParameters = info.addAllParameters(nodeRemapper)
 
@@ -302,7 +303,7 @@ class MethodInliner(
                         .put(OBJECT_TYPE, erasedInvokeFunction.returnType, this)
                     setLambdaInlining(false)
                     addInlineMarker(this, false)
-                    inlineOnlySmapSkipper?.markCallSiteLineNumber(remappingMethodAdapter)
+                    inlineOnlySmapSkipper?.onInlineLambdaEnd(remappingMethodAdapter)
                 } else if (isAnonymousConstructorCall(owner, name)) { //TODO add method
                     //TODO add proper message
                     assert(transformationInfo is AnonymousObjectTransformationInfo) {

--- a/compiler/testData/codegen/bytecodeText/lineNumbers/stdlibInlineOnly.kt
+++ b/compiler/testData/codegen/bytecodeText/lineNumbers/stdlibInlineOnly.kt
@@ -1,0 +1,15 @@
+@Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
+@kotlin.internal.InlineOnly
+inline fun <T, R> T.myLet(block: (T) -> R) = block(this)
+
+fun box(): String {
+    val k = "".myLet {
+        it + "K"
+    }
+    return "O".myLet(fun (it: String): String {
+        return it + k
+    })
+}
+
+// See KT-23064 for the problem and InlineOnlySmapSkipper for an explanation.
+// 0 LINENUMBER 65100

--- a/compiler/testData/codegen/bytecodeText/lineNumbers/stdlibInlineOnlyOneLine.kt
+++ b/compiler/testData/codegen/bytecodeText/lineNumbers/stdlibInlineOnlyOneLine.kt
@@ -1,0 +1,11 @@
+@Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
+@kotlin.internal.InlineOnly
+inline fun <T, R> T.myLet(block: (T) -> R) = block(this)
+
+fun box(): String {
+    val k = "".myLet { it + "K" }
+    return "O".myLet(fun (it: String): String { return it + k })
+}
+
+// See KT-23064 for the problem and InlineOnlySmapSkipper for an explanation.
+// 2 LINENUMBER 65100

--- a/compiler/testData/repl/evaluationErrors.repl
+++ b/compiler/testData/repl/evaluationErrors.repl
@@ -6,4 +6,4 @@ java.lang.Exception: hi there
 >>> fun bar(): Nothing = throw AssertionError()
 >>> bar()
 java.lang.AssertionError
-	at Line_3.bar(Unknown Source)
+	at Line_3.bar(Line_3.kts:1)

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
@@ -3381,6 +3381,16 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
             runTest("compiler/testData/codegen/bytecodeText/lineNumbers/singleThen.kt");
         }
 
+        @TestMetadata("stdlibInlineOnly.kt")
+        public void testStdlibInlineOnly() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/lineNumbers/stdlibInlineOnly.kt");
+        }
+
+        @TestMetadata("stdlibInlineOnlyOneLine.kt")
+        public void testStdlibInlineOnlyOneLine() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/lineNumbers/stdlibInlineOnlyOneLine.kt");
+        }
+
         @TestMetadata("tryCatch.kt")
         public void testTryCatch() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/lineNumbers/tryCatch.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
@@ -3426,6 +3426,16 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
             runTest("compiler/testData/codegen/bytecodeText/lineNumbers/singleThen.kt");
         }
 
+        @TestMetadata("stdlibInlineOnly.kt")
+        public void testStdlibInlineOnly() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/lineNumbers/stdlibInlineOnly.kt");
+        }
+
+        @TestMetadata("stdlibInlineOnlyOneLine.kt")
+        public void testStdlibInlineOnlyOneLine() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/lineNumbers/stdlibInlineOnlyOneLine.kt");
+        }
+
         @TestMetadata("tryCatch.kt")
         public void testTryCatch() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/lineNumbers/tryCatch.kt");


### PR DESCRIPTION
This makes the behavior of JVM and JVM_IR the same without having to deal with PSI nodes.