### PR TITLE
JVM IR: Avoid unnecessary CHECKCASTs in enum classes

### DIFF
--- a/compiler/testData/codegen/bytecodeText/enum/enumCheckcasts.kt
+++ b/compiler/testData/codegen/bytecodeText/enum/enumCheckcasts.kt
@@ -1,0 +1,12 @@
+enum class Foo {
+    A, B, C { override fun result() = "OK" };
+    open fun result() = "Fail"
+}
+
+// JVM_TEMPLATES:
+// There are two CHECKCASTs, one in Foo.valueOf and one in Foo.values
+// 2 CHECKCAST
+
+// JVM_IR_TEMPLATES:
+// There should be only one CHECKCAST in Foo.valueOf
+// 1 CHECKCAST

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
@@ -1855,6 +1855,11 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
             KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/bytecodeText/enum"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM, true);
         }
 
+        @TestMetadata("enumCheckcasts.kt")
+        public void testEnumCheckcasts() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/enum/enumCheckcasts.kt");
+        }
+
         @TestMetadata("kt18731.kt")
         public void testKt18731() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/enum/kt18731.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
@@ -1810,6 +1810,11 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
             KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/bytecodeText/enum"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
         }
 
+        @TestMetadata("enumCheckcasts.kt")
+        public void testEnumCheckcasts() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/enum/enumCheckcasts.kt");
+        }
+
         @TestMetadata("kt18731.kt")
         public void testKt18731() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/enum/kt18731.kt");


### PR DESCRIPTION
This is a small optimization to remove CHECKCAST instructions from Enum class initializers.

The background is that we had a bug with an internal tool which tries to parse the bytecode in an enum class initializer and looks for patterns such as 
```
LDC "C"
ICONST_2
ACONST_NULL
INVOKESPECIAL Foo$C.<init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
<...>
PUTSTATIC Foo.C : LFoo;
```
We currently generate an unnecessary CHECKCAST instruction before the PUTSTATIC, which ended up breaking the tool.

I originally tried to fix this by just generating fewer CHECKCAST instructions in general (that was what #3171 was about), but doing this correctly is fairly complicated and expensive.