### PR TITLE
Add repeat(times: Long){} overload

### DIFF
--- a/libraries/stdlib/src/kotlin/util/Standard.kt
+++ b/libraries/stdlib/src/kotlin/util/Standard.kt
@@ -151,3 +151,19 @@ public inline fun repeat(times: Int, action: (Int) -> Unit) {
         action(index)
     }
 }
+
+/**
+ * Executes the given function [action] specified number of [times].
+ *
+ * A zero-based index of current iteration is passed as a parameter to [action].
+ *
+ * @sample samples.misc.ControlFlow.repeat
+ */
+@kotlin.internal.InlineOnly
+public inline fun repeat(times: Long, action: (Long) -> Unit) {
+    contract { callsInPlace(action) }
+
+    for (index in 0L until times) {
+        action(index)
+    }
+}


### PR DESCRIPTION
My use case is for use large files with `java.io.RandomAccessFile`. This class uses `Long` for most of its operations, and `repeat(long.toInt()) {...}` isn't sufficient because file pointers can be in the multi-gigabyte range, which `Int`s can't handle.