### PR TITLE
Restore KotlinExplicitMovementProvider in as40

### DIFF
--- a/idea/resources/META-INF/git4idea.xml.as40
+++ b/idea/resources/META-INF/git4idea.xml.as40
@@ -1,4 +1,0 @@
-<idea-plugin>
-    <extensions defaultExtensionNs="Git4Idea">
-    </extensions>
-</idea-plugin>


### PR DESCRIPTION
Android Studio 4.0 is based on IDEA 2019.3 which supports this feature.

Fixes https://issuetracker.google.com/149567818.