### PR TITLE
Include a scripts dependencies in project resolve scope

### DIFF
--- a/idea/idea-analysis/src/org/jetbrains/kotlin/idea/stubindex/KotlinSourceFilterScope.kt
+++ b/idea/idea-analysis/src/org/jetbrains/kotlin/idea/stubindex/KotlinSourceFilterScope.kt
@@ -113,7 +113,7 @@ class KotlinSourceFilterScope private constructor(
             includeProjectSourceFiles = true,
             includeLibrarySourceFiles = false,
             includeClassFiles = true,
-            includeScriptDependencies = false,
+            includeScriptDependencies = true,
             includeScriptsOutsideSourceRoots = true,
             project = project
         )


### PR DESCRIPTION
This resolves an issue with completion/code-assistance not working inside scripts that are contained in a regular modules sources. Previously, only SDK dependencies were showing via auto-imports or code-completion (ctrl-space). This change includes script dependencies in the global project resolve scope to allow this to work.

When a script is included in a project as a regular file to be compiled
it produces a `ModuleSourceInfo` representing its metdata, as opposed to
`ScriptModuleInfo` for the special-cased scratch files and Gradle build
script.

This change includes script dependencies as part of the regular search
scope when attempting to resolve items.

The module info for a script contained within a regular modules sources is produced [here](https://github.com/JetBrains/kotlin/blob/7d5396ac95879062e8d9cfde8eab155c86e483b0/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/project/getModuleInfo.kt#L261) (called by https://github.com/JetBrains/kotlin/blob/7d5396ac95879062e8d9cfde8eab155c86e483b0/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/project/getModuleInfo.kt#L182).

This could maybe be changed to differentiate between `ModuleInfo` produced for a script, and `ModuleInfo` produced for a regular `KtFile`, however this change doesn't seem too intrusive.

I've put together an example repository demonstrating the problem (try to get code assistance in a script file without this patch): https://github.com/garyttierney/kotlin-scripts-imports-reproducer