### PR TITLE
[FIR2IR] Allow implicit casts from Short and Byte to Int.

### DIFF
--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/generators/OperatorExpressionGenerator.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/generators/OperatorExpressionGenerator.kt
@@ -7,6 +7,9 @@ package org.jetbrains.kotlin.fir.backend.generators
 
 import org.jetbrains.kotlin.fir.backend.*
 import org.jetbrains.kotlin.fir.expressions.*
+import org.jetbrains.kotlin.fir.isByte
+import org.jetbrains.kotlin.fir.isInt
+import org.jetbrains.kotlin.fir.isShort
 import org.jetbrains.kotlin.fir.types.ConeClassLikeType
 import org.jetbrains.kotlin.fir.types.isNullable
 import org.jetbrains.kotlin.ir.builders.primitiveOp1
@@ -149,6 +152,9 @@ internal class OperatorExpressionGenerator(
         val operandClassId = operandType.lookupTag.classId
         val targetClassId = targetType.lookupTag.classId
         if (operandClassId == targetClassId) return this
+
+        if ((targetType.isInt() && !targetType.isNullable) && (operandType.isShort() || operandType.isByte())) return this
+
         val conversionFunction =
             typeConverter.classIdToSymbolMap[operandClassId]?.getSimpleFunction("to${targetType.lookupTag.classId.shortClassName.asString()}")
                 ?: throw AssertionError("No conversion function for $operandType ~> $targetType")

--- a/compiler/testData/ir/irText/expressions/primitiveComparisons.fir.txt
+++ b/compiler/testData/ir/irText/expressions/primitiveComparisons.fir.txt
@@ -5,80 +5,64 @@ FILE fqName:<root> fileName:/primitiveComparisons.kt
     BLOCK_BODY
       RETURN type=kotlin.Nothing from='public final fun btest1 (a: kotlin.Byte, b: kotlin.Byte): kotlin.Boolean declared in <root>'
         CALL 'public final fun greater (arg0: kotlin.Int, arg1: kotlin.Int): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=GT
-          arg0: TYPE_OP type=kotlin.Int origin=IMPLICIT_CAST typeOperand=kotlin.Int
-            GET_VAR 'a: kotlin.Byte declared in <root>.btest1' type=kotlin.Byte origin=null
-          arg1: TYPE_OP type=kotlin.Int origin=IMPLICIT_CAST typeOperand=kotlin.Int
-            GET_VAR 'b: kotlin.Byte declared in <root>.btest1' type=kotlin.Byte origin=null
+          arg0: GET_VAR 'a: kotlin.Byte declared in <root>.btest1' type=kotlin.Byte origin=null
+          arg1: GET_VAR 'b: kotlin.Byte declared in <root>.btest1' type=kotlin.Byte origin=null
   FUN name:btest2 visibility:public modality:FINAL <> (a:kotlin.Byte, b:kotlin.Byte) returnType:kotlin.Boolean
     VALUE_PARAMETER name:a index:0 type:kotlin.Byte
     VALUE_PARAMETER name:b index:1 type:kotlin.Byte
     BLOCK_BODY
       RETURN type=kotlin.Nothing from='public final fun btest2 (a: kotlin.Byte, b: kotlin.Byte): kotlin.Boolean declared in <root>'
         CALL 'public final fun less (arg0: kotlin.Int, arg1: kotlin.Int): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=LT
-          arg0: TYPE_OP type=kotlin.Int origin=IMPLICIT_CAST typeOperand=kotlin.Int
-            GET_VAR 'a: kotlin.Byte declared in <root>.btest2' type=kotlin.Byte origin=null
-          arg1: TYPE_OP type=kotlin.Int origin=IMPLICIT_CAST typeOperand=kotlin.Int
-            GET_VAR 'b: kotlin.Byte declared in <root>.btest2' type=kotlin.Byte origin=null
+          arg0: GET_VAR 'a: kotlin.Byte declared in <root>.btest2' type=kotlin.Byte origin=null
+          arg1: GET_VAR 'b: kotlin.Byte declared in <root>.btest2' type=kotlin.Byte origin=null
   FUN name:btest3 visibility:public modality:FINAL <> (a:kotlin.Byte, b:kotlin.Byte) returnType:kotlin.Boolean
     VALUE_PARAMETER name:a index:0 type:kotlin.Byte
     VALUE_PARAMETER name:b index:1 type:kotlin.Byte
     BLOCK_BODY
       RETURN type=kotlin.Nothing from='public final fun btest3 (a: kotlin.Byte, b: kotlin.Byte): kotlin.Boolean declared in <root>'
         CALL 'public final fun greaterOrEqual (arg0: kotlin.Int, arg1: kotlin.Int): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=GTEQ
-          arg0: TYPE_OP type=kotlin.Int origin=IMPLICIT_CAST typeOperand=kotlin.Int
-            GET_VAR 'a: kotlin.Byte declared in <root>.btest3' type=kotlin.Byte origin=null
-          arg1: TYPE_OP type=kotlin.Int origin=IMPLICIT_CAST typeOperand=kotlin.Int
-            GET_VAR 'b: kotlin.Byte declared in <root>.btest3' type=kotlin.Byte origin=null
+          arg0: GET_VAR 'a: kotlin.Byte declared in <root>.btest3' type=kotlin.Byte origin=null
+          arg1: GET_VAR 'b: kotlin.Byte declared in <root>.btest3' type=kotlin.Byte origin=null
   FUN name:btest4 visibility:public modality:FINAL <> (a:kotlin.Byte, b:kotlin.Byte) returnType:kotlin.Boolean
     VALUE_PARAMETER name:a index:0 type:kotlin.Byte
     VALUE_PARAMETER name:b index:1 type:kotlin.Byte
     BLOCK_BODY
       RETURN type=kotlin.Nothing from='public final fun btest4 (a: kotlin.Byte, b: kotlin.Byte): kotlin.Boolean declared in <root>'
         CALL 'public final fun lessOrEqual (arg0: kotlin.Int, arg1: kotlin.Int): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=LTEQ
-          arg0: TYPE_OP type=kotlin.Int origin=IMPLICIT_CAST typeOperand=kotlin.Int
-            GET_VAR 'a: kotlin.Byte declared in <root>.btest4' type=kotlin.Byte origin=null
-          arg1: TYPE_OP type=kotlin.Int origin=IMPLICIT_CAST typeOperand=kotlin.Int
-            GET_VAR 'b: kotlin.Byte declared in <root>.btest4' type=kotlin.Byte origin=null
+          arg0: GET_VAR 'a: kotlin.Byte declared in <root>.btest4' type=kotlin.Byte origin=null
+          arg1: GET_VAR 'b: kotlin.Byte declared in <root>.btest4' type=kotlin.Byte origin=null
   FUN name:stest1 visibility:public modality:FINAL <> (a:kotlin.Short, b:kotlin.Short) returnType:kotlin.Boolean
     VALUE_PARAMETER name:a index:0 type:kotlin.Short
     VALUE_PARAMETER name:b index:1 type:kotlin.Short
     BLOCK_BODY
       RETURN type=kotlin.Nothing from='public final fun stest1 (a: kotlin.Short, b: kotlin.Short): kotlin.Boolean declared in <root>'
         CALL 'public final fun greater (arg0: kotlin.Int, arg1: kotlin.Int): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=GT
-          arg0: TYPE_OP type=kotlin.Int origin=IMPLICIT_CAST typeOperand=kotlin.Int
-            GET_VAR 'a: kotlin.Short declared in <root>.stest1' type=kotlin.Short origin=null
-          arg1: TYPE_OP type=kotlin.Int origin=IMPLICIT_CAST typeOperand=kotlin.Int
-            GET_VAR 'b: kotlin.Short declared in <root>.stest1' type=kotlin.Short origin=null
+          arg0: GET_VAR 'a: kotlin.Short declared in <root>.stest1' type=kotlin.Short origin=null
+          arg1: GET_VAR 'b: kotlin.Short declared in <root>.stest1' type=kotlin.Short origin=null
   FUN name:stest2 visibility:public modality:FINAL <> (a:kotlin.Short, b:kotlin.Short) returnType:kotlin.Boolean
     VALUE_PARAMETER name:a index:0 type:kotlin.Short
     VALUE_PARAMETER name:b index:1 type:kotlin.Short
     BLOCK_BODY
       RETURN type=kotlin.Nothing from='public final fun stest2 (a: kotlin.Short, b: kotlin.Short): kotlin.Boolean declared in <root>'
         CALL 'public final fun less (arg0: kotlin.Int, arg1: kotlin.Int): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=LT
-          arg0: TYPE_OP type=kotlin.Int origin=IMPLICIT_CAST typeOperand=kotlin.Int
-            GET_VAR 'a: kotlin.Short declared in <root>.stest2' type=kotlin.Short origin=null
-          arg1: TYPE_OP type=kotlin.Int origin=IMPLICIT_CAST typeOperand=kotlin.Int
-            GET_VAR 'b: kotlin.Short declared in <root>.stest2' type=kotlin.Short origin=null
+          arg0: GET_VAR 'a: kotlin.Short declared in <root>.stest2' type=kotlin.Short origin=null
+          arg1: GET_VAR 'b: kotlin.Short declared in <root>.stest2' type=kotlin.Short origin=null
   FUN name:stest3 visibility:public modality:FINAL <> (a:kotlin.Short, b:kotlin.Short) returnType:kotlin.Boolean
     VALUE_PARAMETER name:a index:0 type:kotlin.Short
     VALUE_PARAMETER name:b index:1 type:kotlin.Short
     BLOCK_BODY
       RETURN type=kotlin.Nothing from='public final fun stest3 (a: kotlin.Short, b: kotlin.Short): kotlin.Boolean declared in <root>'
         CALL 'public final fun greaterOrEqual (arg0: kotlin.Int, arg1: kotlin.Int): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=GTEQ
-          arg0: TYPE_OP type=kotlin.Int origin=IMPLICIT_CAST typeOperand=kotlin.Int
-            GET_VAR 'a: kotlin.Short declared in <root>.stest3' type=kotlin.Short origin=null
-          arg1: TYPE_OP type=kotlin.Int origin=IMPLICIT_CAST typeOperand=kotlin.Int
-            GET_VAR 'b: kotlin.Short declared in <root>.stest3' type=kotlin.Short origin=null
+          arg0: GET_VAR 'a: kotlin.Short declared in <root>.stest3' type=kotlin.Short origin=null
+          arg1: GET_VAR 'b: kotlin.Short declared in <root>.stest3' type=kotlin.Short origin=null
   FUN name:stest4 visibility:public modality:FINAL <> (a:kotlin.Short, b:kotlin.Short) returnType:kotlin.Boolean
     VALUE_PARAMETER name:a index:0 type:kotlin.Short
     VALUE_PARAMETER name:b index:1 type:kotlin.Short
     BLOCK_BODY
       RETURN type=kotlin.Nothing from='public final fun stest4 (a: kotlin.Short, b: kotlin.Short): kotlin.Boolean declared in <root>'
         CALL 'public final fun lessOrEqual (arg0: kotlin.Int, arg1: kotlin.Int): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=LTEQ
-          arg0: TYPE_OP type=kotlin.Int origin=IMPLICIT_CAST typeOperand=kotlin.Int
-            GET_VAR 'a: kotlin.Short declared in <root>.stest4' type=kotlin.Short origin=null
-          arg1: TYPE_OP type=kotlin.Int origin=IMPLICIT_CAST typeOperand=kotlin.Int
-            GET_VAR 'b: kotlin.Short declared in <root>.stest4' type=kotlin.Short origin=null
+          arg0: GET_VAR 'a: kotlin.Short declared in <root>.stest4' type=kotlin.Short origin=null
+          arg1: GET_VAR 'b: kotlin.Short declared in <root>.stest4' type=kotlin.Short origin=null
   FUN name:itest1 visibility:public modality:FINAL <> (a:kotlin.Int, b:kotlin.Int) returnType:kotlin.Boolean
     VALUE_PARAMETER name:a index:0 type:kotlin.Int
     VALUE_PARAMETER name:b index:1 type:kotlin.Int

--- a/compiler/testData/ir/irText/expressions/primitiveComparisons.kt
+++ b/compiler/testData/ir/irText/expressions/primitiveComparisons.kt
@@ -1,4 +1,3 @@
-// FIR_IDENTICAL
 fun btest1(a: Byte, b: Byte) = a > b
 fun btest2(a: Byte, b: Byte) = a < b
 fun btest3(a: Byte, b: Byte) = a >= b


### PR DESCRIPTION
This allows the generation of code that avoids boxing when
comparing primitives to boxed primitives.

Split out test expectations for primitive comparisons so the
different IR generation can be dealt with in tests.