### PR TITLE
Extend scripting REPL API and implement it

### DIFF
--- a/libraries/scripting/common/src/kotlin/script/experimental/api/replApi.kt
+++ b/libraries/scripting/common/src/kotlin/script/experimental/api/replApi.kt
@@ -22,7 +22,17 @@ typealias ReplCompletionResult = Sequence<SourceCodeCompletionVariant>
 /**
  * Type for [ReplCodeAnalyzer.analyze] return value
  */
-typealias ReplAnalyzerResult = Sequence<ScriptDiagnostic>
+data class ReplAnalyzerResult(
+    /**
+     * Script compile-time errors and warning with their locations
+     */
+    val diagnostics: Sequence<ScriptDiagnostic> = emptySequence(),
+
+    /**
+     * String representing snippet return value, or null, if script returns nothing
+     */
+    val renderedResultType: String? = null,
+)
 
 /**
  * REPL Compiler interface which is used for compiling snippets

--- a/plugins/scripting/scripting-ide-services/src/org/jetbrains/kotlin/scripting/ide_services/compiler/CompletionOptions.kt
+++ b/plugins/scripting/scripting-ide-services/src/org/jetbrains/kotlin/scripting/ide_services/compiler/CompletionOptions.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.scripting.ide_services.compiler
+
+data class CompletionOptions (
+    val filterOutShadowedDescriptors: Boolean = true,
+    val nameFilter: (String, String) -> Boolean = { name, namePart -> name.startsWith(namePart) },
+)

--- a/plugins/scripting/scripting-ide-services/src/org/jetbrains/kotlin/scripting/ide_services/compiler/KJvmReplCompilerWithIdeServices.kt
+++ b/plugins/scripting/scripting-ide-services/src/org/jetbrains/kotlin/scripting/ide_services/compiler/KJvmReplCompilerWithIdeServices.kt
@@ -6,22 +6,30 @@
 package org.jetbrains.kotlin.scripting.ide_services.compiler
 
 import org.jetbrains.kotlin.cli.common.messages.AnalyzerWithCompilerReport
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.descriptors.PropertyDescriptor
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.renderer.DescriptorRenderer
+import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.scripting.compiler.plugin.impl.KJvmReplCompilerBase
+import org.jetbrains.kotlin.scripting.compiler.plugin.impl.ScriptDiagnosticsMessageCollector
 import org.jetbrains.kotlin.scripting.compiler.plugin.impl.failure
 import org.jetbrains.kotlin.scripting.compiler.plugin.impl.withMessageCollector
-import org.jetbrains.kotlin.scripting.ide_services.compiler.impl.IdeLikeReplCodeAnalyzer
-import org.jetbrains.kotlin.scripting.ide_services.compiler.impl.getKJvmCompletion
-import org.jetbrains.kotlin.scripting.ide_services.compiler.impl.prepareCodeForCompletion
+import org.jetbrains.kotlin.scripting.ide_services.compiler.api.DetailsLevel
+import org.jetbrains.kotlin.scripting.ide_services.compiler.api.ReplInspectorResult
+import org.jetbrains.kotlin.scripting.ide_services.compiler.api.ReplSymbolInspector
+import org.jetbrains.kotlin.scripting.ide_services.compiler.impl.*
 import kotlin.script.experimental.api.*
 import kotlin.script.experimental.host.ScriptingHostConfiguration
 import kotlin.script.experimental.jvm.defaultJvmScriptingHostConfiguration
 import kotlin.script.experimental.jvm.util.calcAbsolute
+import kotlin.script.experimental.util.PropertiesCollection
 
 class KJvmReplCompilerWithIdeServices(hostConfiguration: ScriptingHostConfiguration = defaultJvmScriptingHostConfiguration) :
     KJvmReplCompilerBase<IdeLikeReplCodeAnalyzer>(hostConfiguration, {
         IdeLikeReplCodeAnalyzer(it.environment)
     }),
-    ReplCompleter, ReplCodeAnalyzer {
+    ReplCompleter, ReplCodeAnalyzer, ReplSymbolInspector {
 
     override suspend fun complete(
         snippet: SourceCode,
@@ -29,55 +37,34 @@ class KJvmReplCompilerWithIdeServices(hostConfiguration: ScriptingHostConfigurat
         configuration: ScriptCompilationConfiguration
     ): ResultWithDiagnostics<ReplCompletionResult> =
         withMessageCollector(snippet) { messageCollector ->
-            val initialConfiguration = configuration.refineBeforeParsing(snippet).valueOr {
-                return it
-            }
-
-            val cursorAbs = cursor.calcAbsolute(snippet)
-
-            val newText =
-                prepareCodeForCompletion(snippet.text, cursorAbs)
-            val newSnippet = object : SourceCode {
-                override val text: String
-                    get() = newText
-                override val name: String?
-                    get() = snippet.name
-                override val locationId: String?
-                    get() = snippet.locationId
-
-            }
-
-            val compilationState = state.getCompilationState(initialConfiguration)
-
-            val (_, errorHolder, snippetKtFile) = prepareForAnalyze(
-                newSnippet,
-                messageCollector,
-                compilationState,
-                checkSyntaxErrors = false
-            ).valueOr { return@withMessageCollector it }
-
-            val analysisResult =
-                compilationState.analyzerEngine.statelessAnalyzeWithImportedScripts(snippetKtFile, emptyList(), scriptPriority.get() + 1)
-            AnalyzerWithCompilerReport.reportDiagnostics(analysisResult.diagnostics, errorHolder)
-
-            val (_, bindingContext, resolutionFacade, moduleDescriptor) = when (analysisResult) {
-                is IdeLikeReplCodeAnalyzer.ReplLineAnalysisResultWithStateless.Stateless -> {
-                    analysisResult
+            val analyzeResult = analyzeWithCursor(
+                messageCollector, snippet, configuration, cursor
+            ) { snippet, cursorAbs ->
+                val newText =
+                    prepareCodeForCompletion(snippet.text, cursorAbs)
+                object : SourceCode {
+                    override val text: String
+                        get() = newText
+                    override val name: String?
+                        get() = snippet.name
+                    override val locationId: String?
+                        get() = snippet.locationId
                 }
-                else -> return failure(
-                    newSnippet,
-                    messageCollector,
-                    "Unexpected result ${analysisResult::class.java}"
-                )
             }
 
-            return getKJvmCompletion(
-                snippetKtFile,
-                bindingContext,
-                resolutionFacade,
-                moduleDescriptor,
-                cursorAbs
-            ).asSuccess(messageCollector.diagnostics)
+            val completionOptions = configuration[PropertiesCollection.Key("completionOptions", CompletionOptions())]!!
+
+            with(analyzeResult.valueOr { return it }) {
+                return getKJvmCompletion(
+                    ktScript,
+                    bindingContext,
+                    resolutionFacade,
+                    moduleDescriptor,
+                    cursorAbs,
+                    completionOptions.filterOutShadowedDescriptors,
+                    completionOptions.nameFilter,
+                ).asSuccess(messageCollector.diagnostics)
+            }
         }
 
     private fun List<ScriptDiagnostic>.toAnalyzeResult() = (filter {
@@ -115,5 +102,85 @@ class KJvmReplCompilerWithIdeServices(hostConfiguration: ScriptingHostConfigurat
 
             messageCollector.diagnostics.toAnalyzeResult().asSuccess()
         }
+    }
+
+    override suspend fun inspect(
+        snippet: SourceCode,
+        cursor: SourceCode.Position,
+        configuration: ScriptCompilationConfiguration,
+        detailsLevel: DetailsLevel
+    ): ResultWithDiagnostics<ReplInspectorResult> =
+        withMessageCollector(snippet) { messageCollector ->
+            val analyzeResult = analyzeWithCursor(
+                messageCollector, snippet, configuration, cursor
+            )
+
+            with(analyzeResult.valueOr { return it }) {
+                return getKJvmInspections(
+                    snippet.text,
+                    ktScript,
+                    bindingContext,
+                    resolutionFacade,
+                    moduleDescriptor,
+                    cursorAbs,
+                    detailsLevel
+                ).asSuccess(
+                    messageCollector.diagnostics
+                )
+            }
+        }
+
+    private fun analyzeWithCursor(
+        messageCollector: ScriptDiagnosticsMessageCollector,
+        snippet: SourceCode,
+        configuration: ScriptCompilationConfiguration,
+        cursor: SourceCode.Position? = null,
+        getNewSnippet: (SourceCode, Int) -> SourceCode = { code, _ -> code }
+    ): ResultWithDiagnostics<AnalyzeWithCursorResult> {
+        val initialConfiguration = configuration.refineBeforeParsing(snippet).valueOr {
+            return it
+        }
+
+        val cursorAbs = cursor?.calcAbsolute(snippet) ?: -1
+        val newSnippet = if (cursorAbs == -1) snippet else getNewSnippet(snippet, cursorAbs)
+
+        val compilationState = state.getCompilationState(initialConfiguration)
+
+        val (_, errorHolder, snippetKtFile) = prepareForAnalyze(
+            newSnippet,
+            messageCollector,
+            compilationState,
+            checkSyntaxErrors = false
+        ).valueOr { return it }
+
+        val analysisResult =
+            compilationState.analyzerEngine.statelessAnalyzeWithImportedScripts(snippetKtFile, emptyList(), scriptPriority.get() + 1)
+        AnalyzerWithCompilerReport.reportDiagnostics(analysisResult.diagnostics, errorHolder)
+
+        val (_, bindingContext, resolutionFacade, moduleDescriptor, resultProperty) = when (analysisResult) {
+            is IdeLikeReplCodeAnalyzer.ReplLineAnalysisResultWithStateless.Stateless -> {
+                analysisResult
+            }
+            else -> return failure(
+                newSnippet,
+                messageCollector,
+                "Unexpected result ${analysisResult::class.java}"
+            )
+        }
+
+        return AnalyzeWithCursorResult(
+            snippetKtFile, bindingContext, resolutionFacade, moduleDescriptor, cursorAbs, resultProperty
+        ).asSuccess()
+    }
+
+    companion object {
+        data class AnalyzeWithCursorResult(
+            val ktScript: KtFile,
+            val bindingContext: BindingContext,
+            val resolutionFacade: KotlinResolutionFacadeForRepl,
+            val moduleDescriptor: ModuleDescriptor,
+            val cursorAbs: Int,
+            val resultProperty: PropertyDescriptor?,
+        )
     }
 }

--- a/plugins/scripting/scripting-ide-services/src/org/jetbrains/kotlin/scripting/ide_services/compiler/api/replApiIdeExtensions.kt
+++ b/plugins/scripting/scripting-ide-services/src/org/jetbrains/kotlin/scripting/ide_services/compiler/api/replApiIdeExtensions.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.scripting.ide_services.compiler.api
+
+import kotlin.script.experimental.api.ResultWithDiagnostics
+import kotlin.script.experimental.api.ScriptCompilationConfiguration
+import kotlin.script.experimental.api.SourceCode
+
+/**
+ * Type of details level for [ReplSymbolInspector.inspect]
+ *
+ * @property level Numeric representation of details level
+ */
+enum class DetailsLevel(val level: Int) {
+    DEFAULT(0);
+
+    companion object {
+        private val intToLevel = values().associateBy { it.level }
+
+        init {
+            assert(values().size == intToLevel.size) { "Details levels numeric values are not unique" }
+        }
+
+        fun fromInt(level: Int) = intToLevel[level]
+    }
+}
+
+/**
+ * Inspection result representing single descriptor
+ *
+ * @property fullText Full presentation text
+ * @property name Full symbol name
+ * @property type Variable type or function signature
+ * @property icon Descriptor type in a free form
+ * @property documentation KDoc for this declaration (if any)
+ */
+data class SourceCodeInspectionVariant(
+    val fullText: String,
+    val name: String,
+    val type: String,
+    val icon: String,
+    val documentation: String,
+)
+
+/**
+ * Type for [ReplSymbolInspector.inspect]
+ */
+typealias ReplInspectorResult = Sequence<SourceCodeInspectionVariant>
+
+/**
+ * Provides information about symbols in REPL snippets
+ */
+interface ReplSymbolInspector {
+
+    /**
+     * Returns the list of inspection variants in [cursor] position.
+     * Generally <b>doesn't change</b> the internal state of implementing object.
+     *
+     * @param snippet Inspection context
+     * @param cursor Cursor position inside, right before or
+     *   right after the symbol to be inspected
+     * @param configuration Compilation configuration which is used.
+     *   Script should be analyzed, but code generation is not performed
+     * @param detailsLevel Details level on which inspection is performed
+     * @return Sequence of inspection variants:
+     *   - Empty sequence if symbol was not resolved
+     *   - One-element sequence for properties and types
+     *   - Multi-element sequence for functions with several overloads
+     */
+    suspend fun inspect(
+        snippet: SourceCode,
+        cursor: SourceCode.Position,
+        configuration: ScriptCompilationConfiguration,
+        detailsLevel: DetailsLevel = DetailsLevel.DEFAULT,
+    ): ResultWithDiagnostics<ReplInspectorResult>
+}

--- a/plugins/scripting/scripting-ide-services/src/org/jetbrains/kotlin/scripting/ide_services/compiler/impl/KJvmReplInspector.kt
+++ b/plugins/scripting/scripting-ide-services/src/org/jetbrains/kotlin/scripting/ide_services/compiler/impl/KJvmReplInspector.kt
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.scripting.ide_services.compiler.impl
+
+import org.jetbrains.kotlin.backend.common.onlyIf
+import org.jetbrains.kotlin.builtins.isFunctionType
+import org.jetbrains.kotlin.descriptors.*
+import org.jetbrains.kotlin.idea.codeInsight.ReferenceVariantsHelper
+import org.jetbrains.kotlin.idea.kdoc.findKDoc
+import org.jetbrains.kotlin.idea.util.CallTypeAndReceiver
+import org.jetbrains.kotlin.idea.util.getResolutionScope
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.psiUtil.endOffset
+import org.jetbrains.kotlin.psi.psiUtil.quoteIfNeeded
+import org.jetbrains.kotlin.psi.psiUtil.startOffset
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.DescriptorUtils
+import org.jetbrains.kotlin.resolve.scopes.DescriptorKindFilter
+import org.jetbrains.kotlin.resolve.scopes.LexicalScope
+import org.jetbrains.kotlin.scripting.ide_services.compiler.api.DetailsLevel
+import org.jetbrains.kotlin.scripting.ide_services.compiler.api.SourceCodeInspectionVariant
+import java.io.File
+import java.util.*
+import kotlin.script.experimental.api.SourceCodeCompletionVariant
+
+fun getKJvmInspections(
+    codeText: String,
+    ktScript: KtFile,
+    bindingContext: BindingContext,
+    resolutionFacade: KotlinResolutionFacadeForRepl,
+    moduleDescriptor: ModuleDescriptor,
+    cursor: Int,
+    detailsLevel: DetailsLevel
+) = KJvmReplInspector(codeText, ktScript, bindingContext, resolutionFacade, moduleDescriptor, cursor, detailsLevel).getInspections()
+
+private class KJvmReplInspector(
+    private val codeText: String,
+    private val ktScript: KtFile,
+    private val bindingContext: BindingContext,
+    private val resolutionFacade: KotlinResolutionFacadeForRepl,
+    private val moduleDescriptor: ModuleDescriptor,
+    private val cursor: Int,
+    private val detailsLevel: DetailsLevel
+) {
+
+//    val cursor = {
+//        if (cursor >= codeText.length)
+//            codeText.length - 1
+//        else if (cursor == 0)
+//            0
+//        else {
+//            val beforeCur = codeText[cursor - 1]
+//            val afterCur = codeText[cursor]
+//
+//        }
+//    }()
+
+    fun getInspections() = sequence<SourceCodeInspectionVariant> gen@{
+        val element = ktScript.getElementAt(cursor) ?: ktScript.getElementAt(cursor - 1) ?: return@gen
+        val elementText = element.text
+        val nameFilter = { name: Name -> !name.isSpecial && name.identifier == elementText }
+
+        var descriptors: Collection<DeclarationDescriptor>? = null
+        var isSortNeeded = true
+
+        val simpleExpression = when {
+            element is KtSimpleNameExpression -> element
+            element.parent is KtSimpleNameExpression -> element.parent as KtSimpleNameExpression
+            else -> null
+        }
+
+        if (simpleExpression != null) {
+            val inDescriptor = simpleExpression.getResolutionScope(bindingContext, resolutionFacade).ownerDescriptor
+
+            isSortNeeded = false
+            descriptors = ReferenceVariantsHelper(
+                bindingContext,
+                resolutionFacade,
+                moduleDescriptor,
+                VisibilityFilter(inDescriptor)
+            ).getReferenceVariants(
+                simpleExpression,
+                DescriptorKindFilter.ALL,
+                nameFilter,
+                filterOutJavaGettersAndSetters = true,
+                filterOutShadowed = false, // setting to true makes it slower up to 4 times
+                excludeNonInitializedVariable = true,
+                useReceiverType = null
+            )
+
+        } else {
+            val resolutionScope: LexicalScope?
+            val parent = element.parent
+
+            val qualifiedExpression = when {
+                element is KtQualifiedExpression -> {
+                    element
+                }
+                parent is KtQualifiedExpression -> parent
+                else -> null
+            }
+
+            if (qualifiedExpression != null) {
+                val receiverExpression = qualifiedExpression.receiverExpression
+                val expressionType = bindingContext.get(
+                    BindingContext.EXPRESSION_TYPE_INFO,
+                    receiverExpression
+                )?.type
+                if (expressionType != null) {
+                    isSortNeeded = false
+                    descriptors = ReferenceVariantsHelper(
+                        bindingContext,
+                        resolutionFacade,
+                        moduleDescriptor,
+                        { true }
+                    ).getReferenceVariants(
+                        receiverExpression,
+                        CallTypeAndReceiver.DOT(receiverExpression),
+                        DescriptorKindFilter.ALL,
+                        nameFilter
+                    )
+                }
+            } else {
+                resolutionScope = bindingContext.get(
+                    BindingContext.LEXICAL_SCOPE,
+                    element as KtExpression?
+                )
+                descriptors = (resolutionScope?.getContributedDescriptors(
+                    DescriptorKindFilter.ALL,
+                    nameFilter
+                )
+                    ?: return@gen)
+            }
+        }
+
+        if (descriptors == null) {
+            return@gen
+        }
+
+        if (descriptors !is ArrayList<*>) {
+            descriptors = ArrayList(descriptors)
+        }
+
+        //val kDocs = descriptors.map { it.findKDoc() }
+
+        (descriptors as ArrayList<DeclarationDescriptor>)
+            .map {
+                val presentation =
+                    getPresentation(
+                        it
+                    )
+                Triple(it, presentation, (presentation.presentableText + presentation.tailText).toLowerCase())
+            }
+            .onlyIf({ isSortNeeded }) { it.sortedBy { descTriple -> descTriple.third } }
+            .forEach {
+                val descriptor = it.first
+                val (rawName, presentableText, tailText, _, typeText) = it.second
+                if (rawName == elementText) {
+                    val fullName: String = formatName(rawName)
+                    yield(
+                        SourceCodeInspectionVariant(
+                            presentableText,
+                            fullName,
+                            typeText,
+                            getIconFromDescriptor(
+                                descriptor
+                            ),
+                            ""
+                        )
+                    )
+                }
+            }
+    }
+
+    companion object {
+        private fun getPresentation(descriptor: DeclarationDescriptor): DescriptorPresentation {
+            val rawDescriptorName = descriptor.name.asString()
+            val descriptorName = rawDescriptorName.quoteIfNeeded()
+            var presentableText = descriptorName
+            var typeText = ""
+            var tailText = ""
+            when (descriptor) {
+                is FunctionDescriptor -> {
+                    val renderedReturnType = descriptor.returnType?.let { RENDERER.renderType(it) }
+                    val renderedParams = descriptor.valueParameters.map { it.name.asString() to RENDERER.renderType(it.type) }
+
+                    val returnTypeString = renderedReturnType?.let { ": $it" } ?: ""
+                    val parametersString =
+                        renderedParams.joinToString(", ") { it.first + ": " + it.second }
+                    val typeArgsString = descriptor.typeParameters.joinToString(", ") { RENDERER.render(it) }
+                    presentableText = "fun $typeArgsString $descriptorName($parametersString)$returnTypeString"
+
+                    val returnTypeForFunType = renderedReturnType?.let { " -> $it" } ?: " -> Unit"
+                    val parametersTypesString =
+                        renderedParams.joinToString(", ") { it.second }
+                    typeText = "($parametersTypesString)$returnTypeForFunType"
+                }
+                is VariableDescriptor -> {
+                    val outType = descriptor.type
+                    typeText = RENDERER.renderType(outType)
+                    presentableText = "val $descriptorName: $typeText"
+                }
+                is ClassDescriptor -> {
+                    val declaredIn = descriptor.containingDeclaration
+                    typeText = "class"
+                    presentableText = "class $descriptorName"
+                    tailText = " (" + DescriptorUtils.getFqName(declaredIn) + ")"
+                }
+                else -> {
+                    typeText = RENDERER.render(descriptor)
+                }
+            }
+
+            tailText = if (typeText.isEmpty()) tailText else typeText
+
+            return DescriptorPresentation(
+                rawDescriptorName,
+                presentableText,
+                tailText,
+                "",
+                typeText
+            )
+        }
+    }
+}

--- a/plugins/scripting/scripting-ide-services/src/org/jetbrains/kotlin/scripting/ide_services/compiler/impl/descriptorUtils.kt
+++ b/plugins/scripting/scripting-ide-services/src/org/jetbrains/kotlin/scripting/ide_services/compiler/impl/descriptorUtils.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.scripting.ide_services.compiler.impl
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.tree.TokenSet
+import org.jetbrains.kotlin.descriptors.*
+import org.jetbrains.kotlin.descriptors.impl.LocalVariableDescriptor
+import org.jetbrains.kotlin.descriptors.impl.TypeParameterDescriptorImpl
+import org.jetbrains.kotlin.idea.util.IdeDescriptorRenderers
+import org.jetbrains.kotlin.lexer.KtKeywordToken
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.renderer.ClassifierNamePolicy
+import org.jetbrains.kotlin.renderer.ParameterNameRenderingPolicy
+import org.jetbrains.kotlin.types.KotlinType
+import org.jetbrains.kotlin.types.asFlexibleType
+import org.jetbrains.kotlin.types.isFlexible
+import kotlin.script.experimental.api.SourceCodeCompletionVariant
+
+internal fun KtFile.getElementAt(cursorPos: Int): PsiElement? {
+    var element: PsiElement? = findElementAt(cursorPos)
+    while (element !is KtExpression && element != null) {
+        element = element.parent
+    }
+    return element
+}
+
+internal const val DEFAULT_NUMBER_OF_CHARS = 40
+
+internal class VisibilityFilter(
+    private val inDescriptor: DeclarationDescriptor
+) : (DeclarationDescriptor) -> Boolean {
+    override fun invoke(descriptor: DeclarationDescriptor): Boolean {
+        if (descriptor is TypeParameterDescriptor && !isTypeParameterVisible(descriptor)) return false
+
+        if (descriptor is DeclarationDescriptorWithVisibility) {
+            return try {
+                descriptor.visibility.isVisible(null, descriptor, inDescriptor)
+            } catch (e: IllegalStateException) {
+                true
+            }
+        }
+
+        return true
+    }
+
+    private fun isTypeParameterVisible(typeParameter: TypeParameterDescriptor): Boolean {
+        val owner = typeParameter.containingDeclaration
+        var parent: DeclarationDescriptor? = inDescriptor
+        while (parent != null) {
+            if (parent == owner) return true
+            if (parent is ClassDescriptor && !parent.isInner) return false
+            parent = parent.containingDeclaration
+        }
+        return true
+    }
+}
+
+internal fun keywordsCompletionVariants(
+    keywords: TokenSet,
+    prefix: String
+) = sequence {
+    keywords.types.forEach {
+        val token = (it as KtKeywordToken).value
+        if (token.startsWith(prefix)) yield(
+            SourceCodeCompletionVariant(
+                token,
+                token,
+                "keyword",
+                "keyword"
+            )
+        )
+    }
+}
+
+internal val RENDERER =
+    IdeDescriptorRenderers.SOURCE_CODE.withOptions {
+        this.classifierNamePolicy =
+            ClassifierNamePolicy.SHORT
+        this.typeNormalizer =
+            IdeDescriptorRenderers.APPROXIMATE_FLEXIBLE_TYPES
+        this.parameterNameRenderingPolicy =
+            ParameterNameRenderingPolicy.NONE
+        this.renderDefaultAnnotationArguments = false
+        this.typeNormalizer = lambda@{ kotlinType: KotlinType ->
+            if (kotlinType.isFlexible()) {
+                return@lambda kotlinType.asFlexibleType().upperBound
+            }
+            kotlinType
+        }
+    }
+
+internal fun getIconFromDescriptor(descriptor: DeclarationDescriptor): String = when (descriptor) {
+    is FunctionDescriptor -> "method"
+    is PropertyDescriptor -> "property"
+    is LocalVariableDescriptor -> "property"
+    is ClassDescriptor -> "class"
+    is PackageFragmentDescriptor -> "package"
+    is PackageViewDescriptor -> "package"
+    is ValueParameterDescriptor -> "genericValue"
+    is TypeParameterDescriptorImpl -> "class"
+    else -> ""
+}
+
+internal fun formatName(builder: String, symbols: Int = DEFAULT_NUMBER_OF_CHARS): String {
+    return if (builder.length > symbols) {
+        builder.substring(0, symbols) + "..."
+    } else builder
+}
+
+internal data class DescriptorPresentation(
+    val rawName: String,
+    val presentableText: String,
+    val tailText: String,
+    val completionText: String,
+    val typeText: String,
+)


### PR DESCRIPTION
This PR adds the following features to scripring REPL API:
- new method `inspect` which allows to get info about symbols under cursor. Currently only types/signatures are supported;
- completion options which may be passed via compilation configuration. Currently, options include shadowed symbols filtering and names filter;
- `analyze` method now returns text representation of snippet result type, or `null`, if snippet returns nothing. Note that this API change is breaking.

Also, testing infrastructure was slightly refactored, and common code parts of `analyze`, `complete` and `inspect` methods were picked out to a separate private `analyzeWithCursor` method.