### PR TITLE
[JVM_IR] Avoid safe-call conversions from Byte? and Short? to Int? for

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/Equals.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/Equals.kt
@@ -28,7 +28,6 @@ import org.jetbrains.kotlin.ir.util.isNullConst
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi2ir.generators.hasNoSideEffects
 import org.jetbrains.kotlin.resolve.jvm.AsmTypes
-import org.jetbrains.kotlin.resolve.jvm.AsmTypes.OBJECT_TYPE
 import org.jetbrains.kotlin.resolve.jvm.jvmSignature.JvmMethodSignature
 import org.jetbrains.kotlin.types.isNullable
 import org.jetbrains.kotlin.types.typeUtil.isPrimitiveNumberOrNullableType
@@ -104,12 +103,12 @@ class Equals(val operator: IElementType) : IntrinsicMethod() {
         // could be overridden for the object.
         if ((opToken == IrStatementOrigin.EQEQ || opToken == IrStatementOrigin.EXCLEQ) &&
             ((AsmUtil.isIntOrLongPrimitive(leftType) && !AsmUtil.isPrimitive(rightType)) ||
-                    (AsmUtil.isIntOrLongPrimitive(rightType) && AsmUtil.isBoxedTypeOf(leftType, rightType)))
+                    (AsmUtil.isIntOrLongPrimitive(rightType) && AsmUtil.isBoxedPrimitiveType(leftType)))
         ) {
             val leftIsPrimitive = AsmUtil.isIntOrLongPrimitive(leftType)
             val primitiveType = if (leftIsPrimitive) leftType else rightType
             val nonPrimitiveType = if (leftIsPrimitive) rightType else leftType
-            val useNullCheck = AsmUtil.isBoxedTypeOf(nonPrimitiveType, primitiveType)
+            val useNullCheck = AsmUtil.isBoxedPrimitiveType(nonPrimitiveType)
             return if (leftIsPrimitive) {
                 val loadOther = loadOther(a, leftType)
                 val boxedValue = b.accept(codegen, data).materializedAt(rightType, b.type)

--- a/compiler/testData/codegen/bytecodeText/conditions/noBoxingForBoxedEqPrimitive.kt
+++ b/compiler/testData/codegen/bytecodeText/conditions/noBoxingForBoxedEqPrimitive.kt
@@ -1,5 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
-
 fun testBoolean1(a: Boolean?, b: Boolean) = a == b
 fun testBoolean2(a: Boolean?, b: Boolean) = a != b
 

--- a/compiler/testData/codegen/bytecodeText/conditions/noBoxingForPrimitiveEqBoxed.kt
+++ b/compiler/testData/codegen/bytecodeText/conditions/noBoxingForPrimitiveEqBoxed.kt
@@ -1,5 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
-
 fun testBoolean1(a: Boolean, b: Boolean?) = a == b
 fun testBoolean2(a: Boolean, b: Boolean?) = a != b
 

--- a/compiler/testData/codegen/bytecodeText/intrinsicsCompare/byteSmartCast_after.kt
+++ b/compiler/testData/codegen/bytecodeText/intrinsicsCompare/byteSmartCast_after.kt
@@ -1,6 +1,4 @@
 // !LANGUAGE: +ProperIeee754Comparisons
-// IGNORE_BACKEND: JVM_IR
-
 fun equals3(a: Byte?, b: Byte?) = a != null && b != null && a == b
 
 fun equals4(a: Byte?, b: Byte?) = if (a is Byte && b is Byte) a == b else null!!
@@ -13,9 +11,19 @@ fun less4(a: Byte?, b: Byte?) = if (a is Byte && b is Byte) a < b else true
 
 fun less5(a: Any?, b: Any?) = if (a is Byte && b is Byte) a < b else true
 
+// JVM_TEMPLATES
 // 3 Intrinsics\.areEqual
 // 0 Intrinsics\.compare
 // 4 INVOKEVIRTUAL java/lang/Byte\.byteValue \(\)B
 // 2 INVOKEVIRTUAL java/lang/Number\.intValue \(\)I
 // 0 IFGE
 // 3 IF_ICMPGE
+
+// JVM_IR_TEMPLATES
+// 2 Intrinsics\.areEqual
+// 0 Intrinsics\.compare
+// 4 INVOKEVIRTUAL java/lang/Byte\.byteValue \(\)B
+// 4 INVOKEVIRTUAL java/lang/Number\.byteValue \(\)B
+// 0 IFGE
+// 3 IF_ICMPGE
+

--- a/compiler/testData/codegen/bytecodeText/intrinsicsCompare/byteSmartCast_before.kt
+++ b/compiler/testData/codegen/bytecodeText/intrinsicsCompare/byteSmartCast_before.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: -ProperIeee754Comparisons
-// IGNORE_BACKEND: JVM_IR
 
 fun equals3(a: Byte?, b: Byte?) = a != null && b != null && a == b
 
@@ -21,10 +20,9 @@ fun less5(a: Any?, b: Any?) = if (a is Byte && b is Byte) a < b else true
 // 0 IF_ICMPGE
 
 // JVM_IR_TEMPLATES
-// 3 Intrinsics\.areEqual
+// 2 Intrinsics\.areEqual
 // 0 Intrinsics\.compare
 // 4 INVOKEVIRTUAL java/lang/Byte\.byteValue \(\)B
-// 2 INVOKEVIRTUAL java/lang/Number\.intValue \(\)I
+// 4 INVOKEVIRTUAL java/lang/Number\.byteValue \(\)B
 // 0 IFGE
 // 3 IF_ICMPGE
-// 0 IF_ICMPNE

--- a/compiler/testData/codegen/bytecodeText/intrinsicsCompare/shortSmartCast_after.kt
+++ b/compiler/testData/codegen/bytecodeText/intrinsicsCompare/shortSmartCast_after.kt
@@ -13,6 +13,7 @@ fun less4(a: Short?, b: Short?) = if (a is Short && b is Short) a < b else true
 
 fun less5(a: Any?, b: Any?) = if (a is Short && b is Short) a < b else true
 
+// JVM_TEMPLATES
 // 3 Intrinsics\.areEqual
 // 0 Intrinsics\.compare
 // 4 INVOKEVIRTUAL java/lang/Short\.shortValue \(\)S
@@ -20,3 +21,13 @@ fun less5(a: Any?, b: Any?) = if (a is Short && b is Short) a < b else true
 // 0 IFGE
 // 3 IF_ICMPGE
 // 0 IF_ICMPNE
+
+// JVM_IR_TEMPLATES
+// 2 Intrinsics\.areEqual
+// 0 Intrinsics\.compare
+// 4 INVOKEVIRTUAL java/lang/Short\.shortValue \(\)S
+// 4 INVOKEVIRTUAL java/lang/Number\.shortValue \(\)S
+// 0 IFGE
+// 3 IF_ICMPGE
+// 0 IF_ICMPNE
+

--- a/compiler/testData/codegen/bytecodeText/intrinsicsCompare/shortSmartCast_before.kt
+++ b/compiler/testData/codegen/bytecodeText/intrinsicsCompare/shortSmartCast_before.kt
@@ -20,10 +20,10 @@ fun less5(a: Any?, b: Any?) = if (a is Short && b is Short) a < b else true
 // 0 IF_ICMPGE
 
 // JVM_IR_TEMPLATES
-// 3 Intrinsics\.areEqual
+// 2 Intrinsics\.areEqual
 // 0 Intrinsics\.compare
 // 4 INVOKEVIRTUAL java/lang/Short\.shortValue \(\)S
-// 2 INVOKEVIRTUAL java/lang/Number\.intValue \(\)I
+// 4 INVOKEVIRTUAL java/lang/Number\.shortValue \(\)S
 // 0 IFGE
 // 3 IF_ICMPGE
 // 0 IF_ICMPNE


### PR DESCRIPTION
comparisons.

Having those conversions leads to unnecesary boxing and null checks.

This change does it only for JVM in the optimization lowering. It
is unclear to me if the other backends can get away with something
similar.