### PR TITLE
JVM IR: Parcelize bug fixes

### DIFF
--- a/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/ir/ParcelableIrTransformer.kt
+++ b/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/ir/ParcelableIrTransformer.kt
@@ -301,7 +301,7 @@ class ParcelableIrTransformer(private val context: CommonBackendContext, private
                 val property = properties.first { it.name == parameter.name }
                 val localScope = property.getParcelerScope(toplevelScope)
                 ParcelableProperty(property.backingField!!) {
-                    serializerFactory.get(parameter.type, parcelizeType = defaultType, strict = true, scope = localScope)
+                    serializerFactory.get(parameter.type, parcelizeType = defaultType, scope = localScope)
                 }
             }
         }

--- a/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/AndroidComponentRegistrar.kt
+++ b/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/synthetic/AndroidComponentRegistrar.kt
@@ -110,6 +110,7 @@ class AndroidComponentRegistrar : ComponentRegistrar {
             )
             SyntheticResolveExtension.registerExtension(project, ParcelableResolveExtension())
             ClassBuilderInterceptorExtension.registerExtension(project, ParcelableClinitClassBuilderInterceptorExtension())
+            StorageComponentContainerContributor.registerExtension(project, ParcelizeDeclarationCheckerComponentContainerContributor())
         }
 
         private fun parseVariant(s: String): AndroidVariant? {
@@ -171,10 +172,19 @@ class AndroidExtensionPropertiesComponentContainerContributor : StorageComponent
     override fun registerModuleComponents(
         container: StorageComponentContainer, platform: TargetPlatform, moduleDescriptor: ModuleDescriptor
     ) {
-        if (!platform.isJvm()) return
+        if (platform.isJvm()) {
+            container.useInstance(AndroidExtensionPropertiesCallChecker())
+        }
+    }
+}
 
-        container.useInstance(AndroidExtensionPropertiesCallChecker())
-        container.useInstance(ParcelableDeclarationChecker())
-        container.useInstance(ParcelableAnnotationChecker())
+class ParcelizeDeclarationCheckerComponentContainerContributor : StorageComponentContainerContributor {
+    override fun registerModuleComponents(
+        container: StorageComponentContainer, platform: TargetPlatform, moduleDescriptor: ModuleDescriptor
+    ) {
+        if (platform.isJvm()) {
+            container.useInstance(ParcelableDeclarationChecker())
+            container.useInstance(ParcelableAnnotationChecker())
+        }
     }
 }

--- a/plugins/android-extensions/android-extensions-compiler/test/org/jetbrains/kotlin/android/parcel/ParcelBoxTestGenerated.java
+++ b/plugins/android-extensions/android-extensions-compiler/test/org/jetbrains/kotlin/android/parcel/ParcelBoxTestGenerated.java
@@ -64,6 +64,11 @@ public class ParcelBoxTestGenerated extends AbstractParcelBoxTest {
         runTest("plugins/android-extensions/android-extensions-compiler/testData/parcel/box/charSequence.kt");
     }
 
+    @TestMetadata("customParcelable.kt")
+    public void testCustomParcelable() throws Exception {
+        runTest("plugins/android-extensions/android-extensions-compiler/testData/parcel/box/customParcelable.kt");
+    }
+
     @TestMetadata("customParcelerScoping.kt")
     public void testCustomParcelerScoping() throws Exception {
         runTest("plugins/android-extensions/android-extensions-compiler/testData/parcel/box/customParcelerScoping.kt");

--- a/plugins/android-extensions/android-extensions-compiler/test/org/jetbrains/kotlin/android/parcel/ParcelBytecodeListingTestGenerated.java
+++ b/plugins/android-extensions/android-extensions-compiler/test/org/jetbrains/kotlin/android/parcel/ParcelBytecodeListingTestGenerated.java
@@ -99,6 +99,11 @@ public class ParcelBytecodeListingTestGenerated extends AbstractParcelBytecodeLi
         runTest("plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/serializable.kt");
     }
 
+    @TestMetadata("serializeValue.kt")
+    public void testSerializeValue() throws Exception {
+        runTest("plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/serializeValue.kt");
+    }
+
     @TestMetadata("simple.kt")
     public void testSimple() throws Exception {
         runTest("plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/simple.kt");

--- a/plugins/android-extensions/android-extensions-compiler/test/org/jetbrains/kotlin/android/parcel/ParcelIrBoxTestGenerated.java
+++ b/plugins/android-extensions/android-extensions-compiler/test/org/jetbrains/kotlin/android/parcel/ParcelIrBoxTestGenerated.java
@@ -64,6 +64,11 @@ public class ParcelIrBoxTestGenerated extends AbstractParcelIrBoxTest {
         runTest("plugins/android-extensions/android-extensions-compiler/testData/parcel/box/charSequence.kt");
     }
 
+    @TestMetadata("customParcelable.kt")
+    public void testCustomParcelable() throws Exception {
+        runTest("plugins/android-extensions/android-extensions-compiler/testData/parcel/box/customParcelable.kt");
+    }
+
     @TestMetadata("customParcelerScoping.kt")
     public void testCustomParcelerScoping() throws Exception {
         runTest("plugins/android-extensions/android-extensions-compiler/testData/parcel/box/customParcelerScoping.kt");

--- a/plugins/android-extensions/android-extensions-compiler/test/org/jetbrains/kotlin/android/parcel/ParcelIrBytecodeListingTestGenerated.java
+++ b/plugins/android-extensions/android-extensions-compiler/test/org/jetbrains/kotlin/android/parcel/ParcelIrBytecodeListingTestGenerated.java
@@ -99,6 +99,11 @@ public class ParcelIrBytecodeListingTestGenerated extends AbstractParcelIrByteco
         runTest("plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/serializable.kt");
     }
 
+    @TestMetadata("serializeValue.kt")
+    public void testSerializeValue() throws Exception {
+        runTest("plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/serializeValue.kt");
+    }
+
     @TestMetadata("simple.kt")
     public void testSimple() throws Exception {
         runTest("plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/simple.kt");

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/allPrimitiveTypes.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/allPrimitiveTypes.kt
@@ -51,6 +51,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     val first2 = readFromParcel<PrimitiveTypes>(parcel)
     val second2 = readFromParcel<PrimitiveTypes>(parcel)

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/arraySimple.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/arraySimple.kt
@@ -31,6 +31,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     val first2 = readFromParcel<Test>(parcel)
 

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/arrays.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/arrays.kt
@@ -69,6 +69,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     val first2 = readFromParcel<Test>(parcel)
 

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/binder.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/binder.kt
@@ -35,6 +35,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     val test2 = readFromParcel<ServiceContainer>(parcel)
 }

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/boxedTypes.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/boxedTypes.kt
@@ -34,6 +34,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     val first2 = readFromParcel<BoxedTypes>(parcel)
 

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/bundle.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/bundle.kt
@@ -17,6 +17,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     val test2 = readFromParcel<User>(parcel)
 

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/charSequence.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/charSequence.kt
@@ -17,6 +17,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     val test2 = readFromParcel<Test>(parcel)
 

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/customParcelable.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/customParcelable.kt
@@ -1,0 +1,37 @@
+// IGNORE_BACKEND: JVM
+// See KT-38105
+// Throws IllegalAccessError, since the code tries to access the private companion field directly from the generated User$Creator class.
+// WITH_RUNTIME
+
+@file:JvmName("TestKt")
+package test
+
+import kotlinx.android.parcel.*
+import android.os.Parcel
+import android.os.Parcelable
+
+data class User(val name: String, val age: Int)
+
+@Parcelize
+data class UserParcelable(val user: User) : Parcelable {
+    private companion object : Parceler<UserParcelable> {
+        override fun UserParcelable.write(parcel: Parcel, flags: Int) {
+            parcel.writeString(user.name)
+        }
+
+        override fun create(parcel: Parcel) = UserParcelable(User(parcel.readString(), 0))
+    }
+}
+
+fun box() = parcelTest { parcel ->
+    val userParcelable = UserParcelable(User("John", 20))
+    userParcelable.writeToParcel(parcel, 0)
+
+    val bytes = parcel.marshall()
+    parcel.unmarshall(bytes, 0, bytes.size)
+
+    val userParcelable2 = readFromParcel<UserParcelable>(parcel)
+
+    assert(userParcelable.user.name == userParcelable2.user.name)
+    assert(userParcelable2.user.age == 0)
+}

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/customParcelable.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/customParcelable.kt
@@ -29,6 +29,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     val userParcelable2 = readFromParcel<UserParcelable>(parcel)
 

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/customParcelerScoping.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/customParcelerScoping.kt
@@ -34,6 +34,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     val test2 = readFromParcel<Ints>(parcel)
 

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/customSerializerBoxing.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/customSerializerBoxing.kt
@@ -39,6 +39,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     val test2 = readFromParcel<Test>(parcel)
 

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/customSerializerBoxing.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/customSerializerBoxing.kt
@@ -31,7 +31,7 @@ data class Test(
         @TypeParceler<Long, Parceler2> val c: Long,
         @TypeParceler<Int, Parceler1> val d: List<Int>,
         @TypeParceler<Long, Parceler2> val e: LongArray
-)
+) : Parcelable
 
 fun box() = parcelTest { parcel ->
     val test = Test(5, 5, 50L, listOf(1, 2, 3), longArrayOf(3, 2, 1))

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/customSerializerSimple.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/customSerializerSimple.kt
@@ -32,7 +32,7 @@ data class Test(
         @TypeParceler<String, Parceler1> val b: String,
         @TypeParceler<String, Parceler3> val c: CharSequence,
         val d: @WriteWith<Parceler3> String
-)
+) : Parcelable
 
 fun box() = parcelTest { parcel ->
     val test = Test("Abc", "Abc", "Abc", "Abc")

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/customSerializerSimple.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/customSerializerSimple.kt
@@ -40,6 +40,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     val test2 = readFromParcel<Test>(parcel)
 

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/customSerializerWriteWith.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/customSerializerWriteWith.kt
@@ -41,6 +41,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     val test2 = readFromParcel<Test>(parcel)
 

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/customSerializerWriteWith.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/customSerializerWriteWith.kt
@@ -33,7 +33,7 @@ data class Test(
         val c: List<@WriteWith<Parceler1> String>,
         val d: @WriteWith<Parceler2> List<String>,
         val e: @WriteWith<Parceler2> List<@WriteWith<Parceler1> String>
-)
+) : Parcelable
 
 fun box() = parcelTest { parcel ->
     val test = Test("Abc", "Abc", listOf("A", "bc"), listOf("A", "bc"), listOf("A", "bc"))

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/customSimple.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/customSimple.kt
@@ -28,6 +28,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     val user2 = readFromParcel<User>(parcel)
 

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/enumObject.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/enumObject.kt
@@ -25,6 +25,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     val black2 = readFromParcel<Color>(parcel)
     val obj2 = readFromParcel<Obj>(parcel)

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/enums.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/enums.kt
@@ -20,6 +20,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     val test2 = readFromParcel<Test>(parcel)
     assert(test == test2)

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/exceptions.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/exceptions.kt
@@ -19,6 +19,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     val test2 = readFromParcel<ExceptionContainer>(parcel)
 }

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/intArray.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/intArray.kt
@@ -32,6 +32,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     val film2 = readFromParcel<Film>(parcel)
     assert(film == film2)

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/javaInterop.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/javaInterop.kt
@@ -27,6 +27,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     val second = J.readParcel(parcel)
     assert(first == second)

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/kt19747_2.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/kt19747_2.kt
@@ -25,6 +25,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     val test2 = readFromParcel<J>(parcel)
 

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/kt19749.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/kt19749.kt
@@ -21,6 +21,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     val test2 = readFromParcel<M>(parcel)
 

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/kt20002.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/kt20002.kt
@@ -32,6 +32,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     val first2 = readFromParcel<Test>(parcel)
 

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/kt20021.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/kt20021.kt
@@ -39,6 +39,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     val first2 = readFromParcel<Test>(parcel)
 

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/kt25839.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/kt25839.kt
@@ -22,6 +22,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     readFromParcel<User>(parcel)
     readFromParcel<User2>(parcel)

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/kt26221.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/kt26221.kt
@@ -28,6 +28,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     val foo2 = readFromParcel<Foo>(parcel)
     assert(foo2.values.size() == 1)

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/kt36658.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/kt36658.kt
@@ -17,6 +17,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     readFromParcel<MyObject>(parcel)
 }

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/listKinds.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/listKinds.kt
@@ -43,6 +43,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     val first2 = readFromParcel<Test>(parcel)
 

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/listSimple.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/listSimple.kt
@@ -17,6 +17,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     val first2 = readFromParcel<Test>(parcel)
 

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/lists.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/lists.kt
@@ -31,6 +31,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     val first2 = readFromParcel<Test>(parcel)
 

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/mapKinds.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/mapKinds.kt
@@ -35,6 +35,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     val first2 = readFromParcel<Test>(parcel)
 

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/mapSimple.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/mapSimple.kt
@@ -17,6 +17,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     val first2 = readFromParcel<Test>(parcel)
 

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/maps.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/maps.kt
@@ -33,6 +33,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     val first2 = readFromParcel<Test>(parcel)
 

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/nestedParcelable.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/nestedParcelable.kt
@@ -27,6 +27,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     val test2 = readFromParcel<Test>(parcel)
     assert(test == test2)

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/nullableTypes.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/nullableTypes.kt
@@ -28,6 +28,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     val first2 = readFromParcel<Test>(parcel)
     val second2 = readFromParcel<Test>(parcel)

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/nullableTypesSimple.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/nullableTypesSimple.kt
@@ -19,6 +19,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     val first2 = readFromParcel<Test>(parcel)
     val second2 = readFromParcel<Test>(parcel)

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/objects.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/objects.kt
@@ -24,6 +24,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     val test2 = readFromParcel<Test>(parcel)
     assert(test == test2)

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/persistableBundle.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/persistableBundle.kt
@@ -23,6 +23,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     val test2 = readFromParcel<User>(parcel)
 

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/primitiveTypes.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/primitiveTypes.kt
@@ -29,6 +29,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     val first2 = readFromParcel<PrimitiveTypes>(parcel)
     val second2 = readFromParcel<PrimitiveTypes>(parcel)

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/simple.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/simple.kt
@@ -18,6 +18,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     val user2 = readFromParcel<User>(parcel)
     assert(user == user2)

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/sparseArrays.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/sparseArrays.kt
@@ -25,6 +25,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     val user2 = readFromParcel<User>(parcel)
 

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/sparseBooleanArray.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/sparseBooleanArray.kt
@@ -17,6 +17,7 @@ fun box() = parcelTest { parcel ->
 
     val bytes = parcel.marshall()
     parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
 
     val test2 = readFromParcel<User>(parcel)
 

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/listInsideList.ir.txt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/listInsideList.ir.txt
@@ -10,7 +10,7 @@ public final class Test$Creator : java/lang/Object, android/os/Parcelable$Creato
     public java.lang.Object[] newArray(int size)
 }
 
-public final class Test : java/lang/Object {
+public final class Test : java/lang/Object, android/os/Parcelable {
     public final static android.os.Parcelable$Creator CREATOR
 
     private final java.util.List names

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/listInsideList.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/listInsideList.kt
@@ -2,6 +2,7 @@
 // WITH_RUNTIME
 
 import kotlinx.android.parcel.*
+import android.os.Parcelable
 
 @Parcelize
-class Test(val names: List<List<ArrayList<String>>>)
+class Test(val names: List<List<ArrayList<String>>>) : Parcelable

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/listInsideList.txt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/listInsideList.txt
@@ -6,7 +6,7 @@ public final class Test$Creator : java/lang/Object, android/os/Parcelable$Creato
     public final java.lang.Object[] newArray(int size)
 }
 
-public final class Test : java/lang/Object {
+public final class Test : java/lang/Object, android/os/Parcelable {
     public final static android.os.Parcelable$Creator CREATOR
 
     private final java.util.List names

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/nullableNotNullSize.ir.txt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/nullableNotNullSize.ir.txt
@@ -10,7 +10,7 @@ public final class TestNotNull$Creator : java/lang/Object, android/os/Parcelable
     public java.lang.Object[] newArray(int size)
 }
 
-public final class TestNotNull : java/lang/Object {
+public final class TestNotNull : java/lang/Object, android/os/Parcelable {
     public final static android.os.Parcelable$Creator CREATOR
 
     private final android.util.Size a
@@ -49,7 +49,7 @@ public final class TestNullable$Creator : java/lang/Object, android/os/Parcelabl
     public java.lang.Object[] newArray(int size)
 }
 
-public final class TestNullable : java/lang/Object {
+public final class TestNullable : java/lang/Object, android/os/Parcelable {
     public final static android.os.Parcelable$Creator CREATOR
 
     private final android.util.Size a

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/nullableNotNullSize.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/nullableNotNullSize.kt
@@ -3,9 +3,10 @@
 
 import android.util.Size
 import kotlinx.android.parcel.*
+import android.os.Parcelable
 
 @Parcelize
-class TestNullable(val a: Size?)
+class TestNullable(val a: Size?) : Parcelable
 
 @Parcelize
-class TestNotNull(val a: Size)
+class TestNotNull(val a: Size) : Parcelable

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/nullableNotNullSize.txt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/nullableNotNullSize.txt
@@ -6,7 +6,7 @@ public final class TestNotNull$Creator : java/lang/Object, android/os/Parcelable
     public final java.lang.Object[] newArray(int size)
 }
 
-public final class TestNotNull : java/lang/Object {
+public final class TestNotNull : java/lang/Object, android/os/Parcelable {
     public final static android.os.Parcelable$Creator CREATOR
 
     private final android.util.Size a
@@ -41,7 +41,7 @@ public final class TestNullable$Creator : java/lang/Object, android/os/Parcelabl
     public final java.lang.Object[] newArray(int size)
 }
 
-public final class TestNullable : java/lang/Object {
+public final class TestNullable : java/lang/Object, android/os/Parcelable {
     public final static android.os.Parcelable$Creator CREATOR
 
     private final android.util.Size a

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/serializeValue.ir.txt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/serializeValue.ir.txt
@@ -1,0 +1,80 @@
+public final class Test$Creator : java/lang/Object, android/os/Parcelable$Creator {
+    public void <init>()
+
+    public final Test createFromParcel(android.os.Parcel parcel) {
+        LABEL (L0)
+          ALOAD (1)
+          LDC (parcel)
+          INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
+          NEW
+          DUP
+          ALOAD (1)
+          LDC (LTest;)
+          INVOKEVIRTUAL (java/lang/Class, getClassLoader, ()Ljava/lang/ClassLoader;)
+          INVOKEVIRTUAL (android/os/Parcel, readValue, (Ljava/lang/ClassLoader;)Ljava/lang/Object;)
+          CHECKCAST
+          INVOKESPECIAL (Test, <init>, (LValue;)V)
+          ARETURN
+        LABEL (L1)
+    }
+
+    public java.lang.Object createFromParcel(android.os.Parcel source) {
+        LABEL (L0)
+          ALOAD (0)
+          ALOAD (1)
+          INVOKEVIRTUAL (Test$Creator, createFromParcel, (Landroid/os/Parcel;)LTest;)
+          ARETURN
+        LABEL (L1)
+    }
+
+    public final Test[] newArray(int size)
+
+    public java.lang.Object[] newArray(int size)
+}
+
+public final class Test : java/lang/Object, android/os/Parcelable {
+    public final static android.os.Parcelable$Creator CREATOR
+
+    private final Value value
+
+    static void <clinit>() {
+          NEW
+          DUP
+          INVOKESPECIAL (Test$Creator, <init>, ()V)
+          CHECKCAST
+          PUTSTATIC (CREATOR, Landroid/os/Parcelable$Creator;)
+          RETURN
+    }
+
+    public void <init>(Value value)
+
+    public int describeContents() {
+        LABEL (L0)
+          ICONST_0
+          IRETURN
+        LABEL (L1)
+    }
+
+    public final Value getValue()
+
+    public void writeToParcel(android.os.Parcel out, int flags) {
+        LABEL (L0)
+          ALOAD (1)
+          LDC (out)
+          INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
+          ALOAD (1)
+          ALOAD (0)
+          GETFIELD (value, LValue;)
+          INVOKEVIRTUAL (android/os/Parcel, writeValue, (Ljava/lang/Object;)V)
+          RETURN
+        LABEL (L1)
+    }
+}
+
+public final class Value : java/lang/Object {
+    private final int x
+
+    public void <init>(int x)
+
+    public final int getX()
+}

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/serializeValue.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/serializeValue.kt
@@ -1,0 +1,13 @@
+// This test checks that we create calls to readValue/writeValue if there is no other
+// way of serializing properties. In this case, this would fail at runtime.
+
+// CURIOUS_ABOUT writeToParcel, createFromParcel, <clinit>, describeContents
+// WITH_RUNTIME
+
+import kotlinx.android.parcel.*
+import android.os.Parcelable
+
+class Value(val x: Int)
+
+@Parcelize
+class Test(val value: Value) : Parcelable

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/serializeValue.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/serializeValue.kt
@@ -1,6 +1,3 @@
-// This test checks that we create calls to readValue/writeValue if there is no other
-// way of serializing properties. In this case, this would fail at runtime.
-
 // CURIOUS_ABOUT writeToParcel, createFromParcel, <clinit>, describeContents
 // WITH_RUNTIME
 
@@ -10,4 +7,4 @@ import android.os.Parcelable
 class Value(val x: Int)
 
 @Parcelize
-class Test(val value: Value) : Parcelable
+class Test(val value: @RawValue Value) : Parcelable

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/serializeValue.txt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/serializeValue.txt
@@ -1,0 +1,68 @@
+public final class Test$Creator : java/lang/Object, android/os/Parcelable$Creator {
+    public void <init>()
+
+    public final java.lang.Object createFromParcel(android.os.Parcel in) {
+        LABEL (L0)
+          ALOAD (1)
+          LDC (in)
+          INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
+          NEW
+          DUP
+          ALOAD (1)
+          LDC (LValue;)
+          INVOKEVIRTUAL (java/lang/Class, getClassLoader, ()Ljava/lang/ClassLoader;)
+          INVOKEVIRTUAL (android/os/Parcel, readValue, (Ljava/lang/ClassLoader;)Ljava/lang/Object;)
+          CHECKCAST
+          INVOKESPECIAL (Test, <init>, (LValue;)V)
+          ARETURN
+        LABEL (L1)
+    }
+
+    public final java.lang.Object[] newArray(int size)
+}
+
+public final class Test : java/lang/Object, android/os/Parcelable {
+    public final static android.os.Parcelable$Creator CREATOR
+
+    private final Value value
+
+    static void <clinit>() {
+          NEW
+          DUP
+          INVOKESPECIAL (Test$Creator, <init>, ()V)
+          PUTSTATIC (CREATOR, Landroid/os/Parcelable$Creator;)
+          RETURN
+    }
+
+    public void <init>(Value value)
+
+    public int describeContents() {
+        LABEL (L0)
+          LDC (0)
+          IRETURN
+        LABEL (L1)
+    }
+
+    public final Value getValue()
+
+    public void writeToParcel(android.os.Parcel parcel, int flags) {
+        LABEL (L0)
+          ALOAD (1)
+          LDC (parcel)
+          INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
+          ALOAD (1)
+          ALOAD (0)
+          GETFIELD (value, LValue;)
+          INVOKEVIRTUAL (android/os/Parcel, writeValue, (Ljava/lang/Object;)V)
+          RETURN
+        LABEL (L1)
+    }
+}
+
+public final class Value : java/lang/Object {
+    private final int x
+
+    public void <init>(int x)
+
+    public final int getX()
+}

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/simpleList.ir.txt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/simpleList.ir.txt
@@ -10,7 +10,7 @@ public final class Test$Creator : java/lang/Object, android/os/Parcelable$Creato
     public java.lang.Object[] newArray(int size)
 }
 
-public final class Test : java/lang/Object {
+public final class Test : java/lang/Object, android/os/Parcelable {
     public final static android.os.Parcelable$Creator CREATOR
 
     private final java.util.List names

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/simpleList.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/simpleList.kt
@@ -2,6 +2,7 @@
 // WITH_RUNTIME
 
 import kotlinx.android.parcel.*
+import android.os.Parcelable
 
 @Parcelize
-class Test(val names: List<String>)
+class Test(val names: List<String>) : Parcelable

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/simpleList.txt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/simpleList.txt
@@ -6,7 +6,7 @@ public final class Test$Creator : java/lang/Object, android/os/Parcelable$Creato
     public final java.lang.Object[] newArray(int size)
 }
 
-public final class Test : java/lang/Object {
+public final class Test : java/lang/Object, android/os/Parcelable {
     public final static android.os.Parcelable$Creator CREATOR
 
     private final java.util.List names


### PR DESCRIPTION
- The previous code failed to remap function symbols in overridden symbols and function references, potentially leaving some psi2ir stubs in the generated IR.
- We have to resolve parcelers for properties lazily, as custom parcelizers might have properties for which resolution would fail.