### PR TITLE
KT-38790 "Convert sealed subclass to object" for data classes doesn't remove 'data' keyword

### DIFF
--- a/idea/testData/inspectionsLocal/convertSealedSubClassToObject/annotation.kt
+++ b/idea/testData/inspectionsLocal/convertSealedSubClassToObject/annotation.kt
@@ -1,0 +1,5 @@
+// PROBLEM: none
+// DISABLE-ERRORS
+sealed class Bar
+
+annotation <caret>class Foo : Bar()

--- a/idea/testData/inspectionsLocal/convertSealedSubClassToObject/data.kt
+++ b/idea/testData/inspectionsLocal/convertSealedSubClassToObject/data.kt
@@ -1,0 +1,5 @@
+// PROBLEM: none
+// DISABLE-ERRORS
+sealed class Bar
+
+data <caret>class Foo : Bar()

--- a/idea/testData/inspectionsLocal/convertSealedSubClassToObject/enum.kt
+++ b/idea/testData/inspectionsLocal/convertSealedSubClassToObject/enum.kt
@@ -1,0 +1,5 @@
+// PROBLEM: none
+// DISABLE-ERRORS
+sealed class Bar
+
+enum <caret>class Foo : Bar()

--- a/idea/testData/inspectionsLocal/convertSealedSubClassToObject/inner.kt
+++ b/idea/testData/inspectionsLocal/convertSealedSubClassToObject/inner.kt
@@ -1,0 +1,5 @@
+// PROBLEM: none
+// DISABLE-ERRORS
+sealed class Bar
+
+inner <caret>class Foo : Bar()

--- a/idea/testData/inspectionsLocal/convertSealedSubClassToObject/sealed.kt
+++ b/idea/testData/inspectionsLocal/convertSealedSubClassToObject/sealed.kt
@@ -1,0 +1,4 @@
+// PROBLEM: none
+sealed class Bar
+
+sealed <caret>class Foo : Bar()

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -3350,6 +3350,11 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
             KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("idea/testData/inspectionsLocal/convertSealedSubClassToObject"), Pattern.compile("^([\\w\\-_]+)\\.(kt|kts)$"), null, true);
         }
 
+        @TestMetadata("annotation.kt")
+        public void testAnnotation() throws Exception {
+            runTest("idea/testData/inspectionsLocal/convertSealedSubClassToObject/annotation.kt");
+        }
+
         @TestMetadata("baseEquals.kt")
         public void testBaseEquals() throws Exception {
             runTest("idea/testData/inspectionsLocal/convertSealedSubClassToObject/baseEquals.kt");
@@ -3380,6 +3385,16 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
             runTest("idea/testData/inspectionsLocal/convertSealedSubClassToObject/convertSubClassWithoutParentheses.kt");
         }
 
+        @TestMetadata("data.kt")
+        public void testData() throws Exception {
+            runTest("idea/testData/inspectionsLocal/convertSealedSubClassToObject/data.kt");
+        }
+
+        @TestMetadata("enum.kt")
+        public void testEnum() throws Exception {
+            runTest("idea/testData/inspectionsLocal/convertSealedSubClassToObject/enum.kt");
+        }
+
         @TestMetadata("fakeState.kt")
         public void testFakeState() throws Exception {
             runTest("idea/testData/inspectionsLocal/convertSealedSubClassToObject/fakeState.kt");
@@ -3388,6 +3403,11 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
         @TestMetadata("generic.kt")
         public void testGeneric() throws Exception {
             runTest("idea/testData/inspectionsLocal/convertSealedSubClassToObject/generic.kt");
+        }
+
+        @TestMetadata("inner.kt")
+        public void testInner() throws Exception {
+            runTest("idea/testData/inspectionsLocal/convertSealedSubClassToObject/inner.kt");
         }
 
         @TestMetadata("noEquals.kt")
@@ -3413,6 +3433,11 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
         @TestMetadata("ownState.kt")
         public void testOwnState() throws Exception {
             runTest("idea/testData/inspectionsLocal/convertSealedSubClassToObject/ownState.kt");
+        }
+
+        @TestMetadata("sealed.kt")
+        public void testSealed() throws Exception {
+            runTest("idea/testData/inspectionsLocal/convertSealedSubClassToObject/sealed.kt");
         }
 
         @TestMetadata("sealedEquals.kt")


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-38790