### PR TITLE
FIR: update argument mapping while transforming integer operator.

### DIFF
--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/IntegerLiteralTypeApproximationTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/IntegerLiteralTypeApproximationTransformer.kt
@@ -77,13 +77,28 @@ class IntegerLiteralTypeApproximationTransformer(
         // e.g. Byte doesn't have `and` in member scope. It's an extension
         if (resultSymbol == null) return functionCall.compose()
         functionCall.resultType = data?.let { functionCall.resultType.resolvedTypeFromPrototype(it) } ?: resultSymbol.fir.returnTypeRef
+        // If the original call has argument mapping, values in that mapping refer to value parameters in that original symbol. We should
+        // map those original value parameters back to indices, and then renew the argument mapping with new value parameters in the result
+        // symbol. Otherwise, while putting the value argument to the converted IR call, it will encounter an unknown value parameter,
+        // resulting in an out-of-bound error.
+        val newArgumentMapping =
+            functionCall.argumentMapping?.mapValues { (_, oldValueParameter) ->
+                val index = operator.valueParameters.indexOf(oldValueParameter)
+                if (index != -1) resultSymbol.fir.valueParameters[index] else oldValueParameter
+            }
         return functionCall.transformCalleeReference(
             StoreCalleeReference,
             buildResolvedNamedReference {
                 name = operator.name
                 resolvedSymbol = resultSymbol!!
             }
-        ).compose()
+        ).let {
+            val transformedFunctionCall = it
+            newArgumentMapping?.let {
+                transformedFunctionCall.replaceArgumentList(buildResolvedArgumentList(newArgumentMapping))
+            }
+            transformedFunctionCall
+        }.compose()
     }
 
     override fun transformOperatorCall(operatorCall: FirOperatorCall, data: ConeKotlinType?): CompositeTransformResult<FirStatement> {


### PR DESCRIPTION
`FirIntegerOperator` is converted via integer approximator, which didn't take into account argument mapping in the call. As a result, transformed call has old argument mapping whose values refer to value parameters in the original call symbol. During argument reordering, conversion of such unknown value parameter led to out-of-bound error for now.