### PR TITLE
FIR: fix default constructor visibility for enum entry.

### DIFF
--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrDeclarationStorage.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrDeclarationStorage.kt
@@ -520,16 +520,12 @@ class Fir2IrDeclarationStorage(
     ): IrConstructor {
         val descriptor = WrappedClassConstructorDescriptor()
         val isPrimary = constructor.isPrimary
-        val visibility = when (irParent.modality) {
-            Modality.SEALED -> Visibilities.PRIVATE
-            else -> constructor.visibility
-        }
         classifierStorage.preCacheTypeParameters(constructor)
         val created = constructor.convertWithOffsets { startOffset, endOffset ->
             symbolTable.declareConstructor(startOffset, endOffset, origin, descriptor) { symbol ->
                 IrConstructorImpl(
                     startOffset, endOffset, origin, symbol,
-                    Name.special("<init>"), visibility,
+                    Name.special("<init>"), constructor.visibility,
                     constructor.returnTypeRef.toIrType(),
                     isInline = false, isExternal = false, isPrimary = isPrimary, isExpect = false
                 ).apply {

--- a/compiler/fir/raw-fir/light-tree2fir/src/org/jetbrains/kotlin/fir/lightTree/fir/ClassWrapper.kt
+++ b/compiler/fir/raw-fir/light-tree2fir/src/org/jetbrains/kotlin/fir/lightTree/fir/ClassWrapper.kt
@@ -57,9 +57,10 @@ class ClassWrapper(
         return modifiers.isInner()
     }
 
+    // See DescriptorUtils#getDefaultConstructorVisibility in core.descriptors
     fun defaultConstructorVisibility(): Visibility {
         return when {
-            isObject() || isEnum() -> Visibilities.PRIVATE
+            isObject() || isEnum() || isEnumEntry() -> Visibilities.PRIVATE
             isSealed() -> Visibilities.PRIVATE
             else -> Visibilities.UNKNOWN
         }

--- a/compiler/fir/raw-fir/psi2fir/src/org/jetbrains/kotlin/fir/builder/RawFirBuilder.kt
+++ b/compiler/fir/raw-fir/psi2fir/src/org/jetbrains/kotlin/fir/builder/RawFirBuilder.kt
@@ -544,9 +544,9 @@ class RawFirBuilder(
                 }
             }
 
+            // See DescriptorUtils#getDefaultConstructorVisibility in core.descriptors
             fun defaultVisibility() = when {
-                // TODO: object / enum is HIDDEN (?)
-                owner is KtObjectDeclaration || owner.hasModifier(ENUM_KEYWORD) -> Visibilities.PRIVATE
+                owner is KtObjectDeclaration || owner.hasModifier(ENUM_KEYWORD) || owner is KtEnumEntry -> Visibilities.PRIVATE
                 owner.hasModifier(SEALED_KEYWORD) -> Visibilities.PRIVATE
                 else -> Visibilities.UNKNOWN
             }

--- a/compiler/fir/raw-fir/psi2fir/testData/rawBuilder/declarations/annotation.txt
+++ b/compiler/fir/raw-fir/psi2fir/testData/rawBuilder/declarations/annotation.txt
@@ -30,14 +30,14 @@ FILE: annotation.kt
         }
 
         public final static enum entry FIRST: R|My| = @base() object : R|My| {
-            public? constructor(): R|anonymous| {
+            private constructor(): R|anonymous| {
                 super<R|My|>()
             }
 
         }
 
         public final static enum entry SECOND: R|My| = @base() object : R|My| {
-            public? constructor(): R|anonymous| {
+            private constructor(): R|anonymous| {
                 super<R|My|>()
             }
 

--- a/compiler/fir/raw-fir/psi2fir/testData/rawBuilder/declarations/constructorInObject.txt
+++ b/compiler/fir/raw-fir/psi2fir/testData/rawBuilder/declarations/constructorInObject.txt
@@ -14,7 +14,7 @@ FILE: constructorInObject.kt
         }
 
         public final static enum entry X: R|B| = object : R|B| {
-            public? constructor(): R|anonymous| {
+            private constructor(): R|anonymous| {
                 super<R|B|>()
             }
 

--- a/compiler/fir/raw-fir/psi2fir/testData/rawBuilder/declarations/enums.txt
+++ b/compiler/fir/raw-fir/psi2fir/testData/rawBuilder/declarations/enums.txt
@@ -26,7 +26,7 @@ FILE: enums.kt
             internal get(): Double
 
         public final static enum entry MERCURY: R|Planet| = object : R|Planet| {
-            public? constructor(): R|anonymous| {
+            private constructor(): R|anonymous| {
                 super<R|Planet|>(Double(1.0), Double(2.0))
             }
 
@@ -37,7 +37,7 @@ FILE: enums.kt
         }
 
         public final static enum entry VENERA: R|Planet| = object : R|Planet| {
-            public? constructor(): R|anonymous| {
+            private constructor(): R|anonymous| {
                 super<R|Planet|>(Double(3.0), Double(4.0))
             }
 
@@ -48,7 +48,7 @@ FILE: enums.kt
         }
 
         public final static enum entry EARTH: R|Planet| = object : R|Planet| {
-            public? constructor(): R|anonymous| {
+            private constructor(): R|anonymous| {
                 super<R|Planet|>(Double(5.0), Double(6.0))
             }
 
@@ -89,49 +89,49 @@ FILE: enums.kt
             public? get(): String
 
         public final static enum entry FIX_STACK_BEFORE_JUMP: R|PseudoInsn| = object : R|PseudoInsn| {
-            public? constructor(): R|anonymous| {
+            private constructor(): R|anonymous| {
                 super<R|PseudoInsn|>()
             }
 
         }
 
         public final static enum entry FAKE_ALWAYS_TRUE_IFEQ: R|PseudoInsn| = object : R|PseudoInsn| {
-            public? constructor(): R|anonymous| {
+            private constructor(): R|anonymous| {
                 super<R|PseudoInsn|>(String(()I))
             }
 
         }
 
         public final static enum entry FAKE_ALWAYS_FALSE_IFEQ: R|PseudoInsn| = object : R|PseudoInsn| {
-            public? constructor(): R|anonymous| {
+            private constructor(): R|anonymous| {
                 super<R|PseudoInsn|>(String(()I))
             }
 
         }
 
         public final static enum entry SAVE_STACK_BEFORE_TRY: R|PseudoInsn| = object : R|PseudoInsn| {
-            public? constructor(): R|anonymous| {
+            private constructor(): R|anonymous| {
                 super<R|PseudoInsn|>()
             }
 
         }
 
         public final static enum entry RESTORE_STACK_IN_TRY_CATCH: R|PseudoInsn| = object : R|PseudoInsn| {
-            public? constructor(): R|anonymous| {
+            private constructor(): R|anonymous| {
                 super<R|PseudoInsn|>()
             }
 
         }
 
         public final static enum entry STORE_NOT_NULL: R|PseudoInsn| = object : R|PseudoInsn| {
-            public? constructor(): R|anonymous| {
+            private constructor(): R|anonymous| {
                 super<R|PseudoInsn|>()
             }
 
         }
 
         public final static enum entry AS_NOT_NULL: R|PseudoInsn| = object : R|PseudoInsn| {
-            public? constructor(): R|anonymous| {
+            private constructor(): R|anonymous| {
                 super<R|PseudoInsn|>(String((Ljava/lang/Object;)Ljava/lang/Object;))
             }
 

--- a/compiler/fir/raw-fir/psi2fir/testData/rawBuilder/declarations/enums2.txt
+++ b/compiler/fir/raw-fir/psi2fir/testData/rawBuilder/declarations/enums2.txt
@@ -22,7 +22,7 @@ FILE: enums2.kt
             public? get(): Some
 
         public final static enum entry FIRST: R|SomeEnum| = object : R|SomeEnum| {
-            public? constructor(): R|anonymous| {
+            private constructor(): R|anonymous| {
                 super<R|SomeEnum|>(O1#)
             }
 
@@ -33,7 +33,7 @@ FILE: enums2.kt
         }
 
         public final static enum entry SECOND: R|SomeEnum| = object : R|SomeEnum| {
-            public? constructor(): R|anonymous| {
+            private constructor(): R|anonymous| {
                 super<R|SomeEnum|>(O2#)
             }
 

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirStatusResolveTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirStatusResolveTransformer.kt
@@ -222,9 +222,11 @@ fun FirDeclaration.resolveStatus(
 }
 
 private fun FirDeclaration.resolveVisibility(containingClass: FirClass<*>?): Visibility {
+    // See DescriptorUtils#getDefaultConstructorVisibility in core.descriptors
     if (this is FirConstructor) {
         if (containingClass != null &&
-            (containingClass.classKind == ClassKind.ENUM_CLASS || containingClass.modality == Modality.SEALED)
+            (containingClass.classKind == ClassKind.ENUM_CLASS || containingClass.classKind == ClassKind.ENUM_ENTRY ||
+                    containingClass.modality == Modality.SEALED)
         ) {
             return Visibilities.PRIVATE
         }


### PR DESCRIPTION
Based on `DescriptorUtils#getDefaultConstructorVisibility in core.descriptors`, the visibility for the default constructor is slightly updated to include enum entry as well.