### PR TITLE
KT-34705 "Move statement down" for penultimate statement with end-of-line comment in constructor leads to moving comma to the end of comment

### DIFF
--- a/idea/testData/codeInsight/moveUpDown/parametersAndArguments/callArgsWithComment1.kt
+++ b/idea/testData/codeInsight/moveUpDown/parametersAndArguments/callArgsWithComment1.kt
@@ -1,0 +1,6 @@
+// MOVE: down
+val x = foo(
+        <caret>a, // a
+        b, // b
+        c // c
+)

--- a/idea/testData/codeInsight/moveUpDown/parametersAndArguments/callArgsWithComment1.kt.after
+++ b/idea/testData/codeInsight/moveUpDown/parametersAndArguments/callArgsWithComment1.kt.after
@@ -1,0 +1,6 @@
+// MOVE: down
+val x = foo(
+        b, // b
+        <caret>a, // a
+        c // c
+)

--- a/idea/testData/codeInsight/moveUpDown/parametersAndArguments/classParamsWithComment1.kt
+++ b/idea/testData/codeInsight/moveUpDown/parametersAndArguments/classParamsWithComment1.kt
@@ -1,0 +1,6 @@
+// MOVE: down
+class A(
+        <caret>val a: Int, // a
+        val b: Int, // b
+        val c: Int // c
+)

--- a/idea/testData/codeInsight/moveUpDown/parametersAndArguments/classParamsWithComment1.kt.after
+++ b/idea/testData/codeInsight/moveUpDown/parametersAndArguments/classParamsWithComment1.kt.after
@@ -1,0 +1,6 @@
+// MOVE: down
+class A(
+        val b: Int, // b
+        <caret>val a: Int, // a
+        val c: Int // c
+)

--- a/idea/testData/codeInsight/moveUpDown/parametersAndArguments/classParamsWithComment2.kt
+++ b/idea/testData/codeInsight/moveUpDown/parametersAndArguments/classParamsWithComment2.kt
@@ -1,0 +1,6 @@
+// MOVE: down
+class A(
+        val b: Int, // b
+        <caret>val a: Int, // a
+        val c: Int // c
+)

--- a/idea/testData/codeInsight/moveUpDown/parametersAndArguments/classParamsWithComment2.kt.after
+++ b/idea/testData/codeInsight/moveUpDown/parametersAndArguments/classParamsWithComment2.kt.after
@@ -1,0 +1,6 @@
+// MOVE: down
+class A(
+        val b: Int, // b
+        val c: Int, // c
+        <caret>val a: Int // a
+)

--- a/idea/testData/codeInsight/moveUpDown/parametersAndArguments/classParamsWithComment3.kt
+++ b/idea/testData/codeInsight/moveUpDown/parametersAndArguments/classParamsWithComment3.kt
@@ -1,0 +1,6 @@
+// MOVE: up
+class A(
+        val b: Int, // b
+        val c: Int, // c
+        <caret>val a: Int // a
+)

--- a/idea/testData/codeInsight/moveUpDown/parametersAndArguments/classParamsWithComment3.kt.after
+++ b/idea/testData/codeInsight/moveUpDown/parametersAndArguments/classParamsWithComment3.kt.after
@@ -1,0 +1,6 @@
+// MOVE: up
+class A(
+        val b: Int, // b
+        <caret>val a: Int, // a
+        val c: Int // c
+)

--- a/idea/testData/codeInsight/moveUpDown/parametersAndArguments/classParamsWithComment4.kt
+++ b/idea/testData/codeInsight/moveUpDown/parametersAndArguments/classParamsWithComment4.kt
@@ -1,0 +1,6 @@
+// MOVE: up
+class A(
+        val b: Int, // b
+        <caret>val a: Int, // a
+        val c: Int // c
+)

--- a/idea/testData/codeInsight/moveUpDown/parametersAndArguments/classParamsWithComment4.kt.after
+++ b/idea/testData/codeInsight/moveUpDown/parametersAndArguments/classParamsWithComment4.kt.after
@@ -1,0 +1,6 @@
+// MOVE: up
+class A(
+        <caret>val a: Int, // a
+        val b: Int, // b
+        val c: Int // c
+)

--- a/idea/tests/org/jetbrains/kotlin/idea/codeInsight/moveUpDown/MoveStatementTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/codeInsight/moveUpDown/MoveStatementTestGenerated.java
@@ -1391,6 +1391,11 @@ public class MoveStatementTestGenerated extends AbstractMoveStatementTest {
             runTest("idea/testData/codeInsight/moveUpDown/parametersAndArguments/callArgs8.kt");
         }
 
+        @TestMetadata("callArgsWithComment1.kt")
+        public void testCallArgsWithComment1() throws Exception {
+            runTest("idea/testData/codeInsight/moveUpDown/parametersAndArguments/callArgsWithComment1.kt");
+        }
+
         @TestMetadata("classParams1.kt")
         public void testClassParams1() throws Exception {
             runTest("idea/testData/codeInsight/moveUpDown/parametersAndArguments/classParams1.kt");
@@ -1429,6 +1434,26 @@ public class MoveStatementTestGenerated extends AbstractMoveStatementTest {
         @TestMetadata("classParams8.kt")
         public void testClassParams8() throws Exception {
             runTest("idea/testData/codeInsight/moveUpDown/parametersAndArguments/classParams8.kt");
+        }
+
+        @TestMetadata("classParamsWithComment1.kt")
+        public void testClassParamsWithComment1() throws Exception {
+            runTest("idea/testData/codeInsight/moveUpDown/parametersAndArguments/classParamsWithComment1.kt");
+        }
+
+        @TestMetadata("classParamsWithComment2.kt")
+        public void testClassParamsWithComment2() throws Exception {
+            runTest("idea/testData/codeInsight/moveUpDown/parametersAndArguments/classParamsWithComment2.kt");
+        }
+
+        @TestMetadata("classParamsWithComment3.kt")
+        public void testClassParamsWithComment3() throws Exception {
+            runTest("idea/testData/codeInsight/moveUpDown/parametersAndArguments/classParamsWithComment3.kt");
+        }
+
+        @TestMetadata("classParamsWithComment4.kt")
+        public void testClassParamsWithComment4() throws Exception {
+            runTest("idea/testData/codeInsight/moveUpDown/parametersAndArguments/classParamsWithComment4.kt");
         }
 
         @TestMetadata("funParams1.kt")


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-34705
https://youtrack.jetbrains.com/issue/KT-34707
https://youtrack.jetbrains.com/issue/KT-34587