### PR TITLE
KT-34464: Add schema to build report path to make it clickable in the IDE

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinGradlePluginIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinGradlePluginIT.kt
@@ -815,7 +815,7 @@ class KotlinGradleIT : BaseGradleIT() {
     fun testBuildReportSmokeTest() = with(Project("simpleProject")) {
         build("assemble", "-Pkotlin.build.report.enable=true") {
             assertSuccessful()
-            assertContains("Kotlin build report is written to")
+            assertContains("Kotlin build report is written to file://")
         }
     }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/report/KotlinBuildReporter.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/report/KotlinBuildReporter.kt
@@ -115,7 +115,7 @@ internal class KotlinBuildReporter(
         val logger = result.gradle?.rootProject?.logger
         try {
             perfReportFile.writeText(buildInfo(result) + taskOverview() + tasksSb.toString())
-            logger?.lifecycle("Kotlin build report is written to ${perfReportFile.canonicalPath}")
+            logger?.lifecycle("Kotlin build report is written to file://${perfReportFile.canonicalPath}")
         } catch (e: Throwable) {
             logger?.error("Could not write Kotlin build report to ${perfReportFile.canonicalPath}", e)
         }


### PR DESCRIPTION
Closes [KT-34464](https://youtrack.jetbrains.com/issue/KT-34464).

**Before:**
<img width="1337" alt="Screen Shot 2020-05-15 at 4 25 58 PM" src="https://user-images.githubusercontent.com/1186186/82094148-7e046980-96ca-11ea-84c0-4bad7e45dbf1.png">

**After:**
<img width="1392" alt="Screen Shot 2020-05-15 at 4 31 21 PM" src="https://user-images.githubusercontent.com/1186186/82094144-7ba20f80-96ca-11ea-8cfa-601b75512d7e.png">