### PR TITLE
Make 'sample' function overwrite samples list instead of adding

### DIFF
--- a/libraries/stdlib/common/src/generated/_UArrays.kt
+++ b/libraries/stdlib/common/src/generated/_UArrays.kt
@@ -4010,6 +4010,8 @@ public fun UShortArray.sort(): Unit {
  * 
  * @throws IndexOutOfBoundsException if [fromIndex] is less than zero or [toIndex] is greater than the size of this array.
  * @throws IllegalArgumentException if [fromIndex] is greater than [toIndex].
+ * 
+ * @sample samples.collections.Arrays.Sorting.sortRangeOfArray
  */
 @SinceKotlin("1.4")
 @ExperimentalUnsignedTypes
@@ -4026,6 +4028,8 @@ public fun UIntArray.sort(fromIndex: Int = 0, toIndex: Int = size): Unit {
  * 
  * @throws IndexOutOfBoundsException if [fromIndex] is less than zero or [toIndex] is greater than the size of this array.
  * @throws IllegalArgumentException if [fromIndex] is greater than [toIndex].
+ * 
+ * @sample samples.collections.Arrays.Sorting.sortRangeOfArray
  */
 @SinceKotlin("1.4")
 @ExperimentalUnsignedTypes
@@ -4042,6 +4046,8 @@ public fun ULongArray.sort(fromIndex: Int = 0, toIndex: Int = size): Unit {
  * 
  * @throws IndexOutOfBoundsException if [fromIndex] is less than zero or [toIndex] is greater than the size of this array.
  * @throws IllegalArgumentException if [fromIndex] is greater than [toIndex].
+ * 
+ * @sample samples.collections.Arrays.Sorting.sortRangeOfArray
  */
 @SinceKotlin("1.4")
 @ExperimentalUnsignedTypes
@@ -4058,6 +4064,8 @@ public fun UByteArray.sort(fromIndex: Int = 0, toIndex: Int = size): Unit {
  * 
  * @throws IndexOutOfBoundsException if [fromIndex] is less than zero or [toIndex] is greater than the size of this array.
  * @throws IllegalArgumentException if [fromIndex] is greater than [toIndex].
+ * 
+ * @sample samples.collections.Arrays.Sorting.sortRangeOfArray
  */
 @SinceKotlin("1.4")
 @ExperimentalUnsignedTypes

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Arrays.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Arrays.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -1326,7 +1326,7 @@ object ArrayOps : TemplateGroupBase() {
         specialFor(ArraysOfObjects) {
             sample("samples.collections.Arrays.Sorting.sortRangeOfArrayOfComparable")
         }
-        specialFor(ArraysOfPrimitives) {
+        specialFor(ArraysOfPrimitives, ArraysOfUnsigned) {
             sample("samples.collections.Arrays.Sorting.sortRangeOfArray")
         }
         returns("Unit")

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Sequence.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Sequence.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2018 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -43,8 +43,9 @@ object SequenceOps : TemplateGroupBase() {
             Creates a [Sequence] instance that wraps the original ${f.collection} returning its ${f.element.pluralize()} when being iterated.
             """
         }
-        if (f in listOf(ArraysOfPrimitives, ArraysOfObjects, Iterables))
+        specialFor(ArraysOfPrimitives, ArraysOfObjects, Iterables) {
             sample("samples.collections.Sequences.Building.sequenceFrom${f.doc.collection.capitalize()}")
+        }
 
         returns("Sequence<T>")
         body {

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/dsl/MemberBuilder.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/dsl/MemberBuilder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2018 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -45,7 +45,7 @@ class MemberBuilder(
 
     var doc: String? = null; private set
 
-    val samples = mutableListOf<String>()
+    var samples = listOf<String>()
 
     val sequenceClassification = mutableListOf<SequenceClass>()
     var deprecate: Deprecation? = null; private set
@@ -134,8 +134,8 @@ class MemberBuilder(
     @Deprecated("Use specialFor", ReplaceWith("specialFor(*fs) { doc(valueBuilder) }"))
     fun doc(vararg fs: Family, valueBuilder: DocExtensions.() -> String) = specialFor(*fs) { doc(valueBuilder) }
 
-    fun sample(sampleRef: String) {
-        samples += sampleRef
+    fun sample(vararg sampleRef: String) {
+        samples = sampleRef.asList()
     }
 
     fun body(valueBuilder: () -> String) {


### PR DESCRIPTION
It's more common for a function to have the single sample, and it's more convenient to override it in `specialFor` blocks, rather than to append another one.