### PR TITLE
JVM IR: Fix mangling of @JvmStatic internal function in companion objects

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/JvmStaticAnnotationLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/JvmStaticAnnotationLowering.kt
@@ -21,6 +21,7 @@ import org.jetbrains.kotlin.backend.jvm.ir.copyCorrespondingPropertyFrom
 import org.jetbrains.kotlin.backend.jvm.ir.isInCurrentModule
 import org.jetbrains.kotlin.backend.jvm.ir.replaceThisByStaticReference
 import org.jetbrains.kotlin.descriptors.Modality
+import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.ir.builders.declarations.addFunction
 import org.jetbrains.kotlin.ir.builders.declarations.buildFunWithDescriptorForInlining
 import org.jetbrains.kotlin.ir.builders.irCall
@@ -99,7 +100,9 @@ private class CompanionObjectJvmStaticLowering(val context: JvmBackendContext) :
             // so we do not have a property to link it up to. Therefore, we compute the right name now.
             name = Name.identifier(context.methodSignatureMapper.mapFunctionName(target))
             modality = if (isInterface) Modality.OPEN else target.modality
-            visibility = target.visibility
+            // Since we already mangle the name above we need to reset internal visibilities to public in order
+            // to avoid mangling the same name twice.
+            visibility = if (target.visibility == Visibilities.INTERNAL) Visibilities.PUBLIC else target.visibility
             isSuspend = target.isSuspend
         }.apply {
             copyTypeParametersFrom(target)

--- a/compiler/testData/codegen/bytecodeText/jvmStaticInternalMangling.kt
+++ b/compiler/testData/codegen/bytecodeText/jvmStaticInternalMangling.kt
@@ -1,0 +1,14 @@
+class A {
+    companion object {
+        @JvmStatic
+        internal fun f(): String = "OK"
+    }
+}
+
+fun box(): String {
+    return A.f()
+}
+
+// Check the names of mangled functions
+// 1 public final f\$test_module\(\)Ljava/lang/String;
+// 1 public final static f\$test_module\(\)Ljava/lang/String;

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
@@ -209,6 +209,11 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
         runTest("compiler/testData/codegen/bytecodeText/jvmField.kt");
     }
 
+    @TestMetadata("jvmStaticInternalMangling.kt")
+    public void testJvmStaticInternalMangling() throws Exception {
+        runTest("compiler/testData/codegen/bytecodeText/jvmStaticInternalMangling.kt");
+    }
+
     @TestMetadata("kt10259.kt")
     public void testKt10259() throws Exception {
         runTest("compiler/testData/codegen/bytecodeText/kt10259.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
@@ -209,6 +209,11 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
         runTest("compiler/testData/codegen/bytecodeText/jvmField.kt");
     }
 
+    @TestMetadata("jvmStaticInternalMangling.kt")
+    public void testJvmStaticInternalMangling() throws Exception {
+        runTest("compiler/testData/codegen/bytecodeText/jvmStaticInternalMangling.kt");
+    }
+
     @TestMetadata("kt10259.kt")
     public void testKt10259() throws Exception {
         runTest("compiler/testData/codegen/bytecodeText/kt10259.kt");


### PR DESCRIPTION
Right now the same function gets mangled twice.