### PR TITLE
[KT-39312] Lazily realize configuration in gradle plugin

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/kotlinTargets.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/kotlinTargets.kt
@@ -113,8 +113,14 @@ abstract class AbstractKotlinTarget(
                         ?: project.configurations.create(kotlinUsageContext.name).also { configuration ->
                             configuration.isCanBeConsumed = false
                             configuration.isCanBeResolved = false
-                            configuration.dependencies.addAll(kotlinUsageContext.dependencies)
-                            configuration.dependencyConstraints.addAll(kotlinUsageContext.dependencyConstraints)
+                            // Lazily realize configuration.
+                            val dependencies = project.objects.listProperty(Dependency::class.java)
+                                .value(project.provider { configuration.incoming.dependencies })
+                            val dependencyConstraints = project.objects.listProperty(DependencyConstraint::class.java)
+                                .value(project.provider { configuration.incoming.dependencyConstraints })
+
+                            configuration.dependencies.addAllLater(dependencies)
+                            configuration.dependencyConstraints.addAllLater(dependencyConstraints)
                             configuration.artifacts.addAll(kotlinUsageContext.artifacts)
 
                             val attributes = kotlinUsageContext.attributes


### PR DESCRIPTION
Kotlin is trying to realize the dependency constraints on some of the java configurations at configuration-time. There are some gradle plugins that make an assumption that other plugins evaluate constraints lazily since they themselves can add additional constraints. 

More details and context in https://github.com/palantir/gradle-consistent-versions/issues/423#issuecomment-586376289.

I have run ./gradlew gradlePluginTest locally and tests pass.