### PR TITLE
KT-38404 Add API for getting annotations and their locations

### DIFF
--- a/libraries/examples/scripting/jvm-maven-deps/script/src/org/jetbrains/kotlin/script/examples/jvm/resolve/maven/scriptDef.kt
+++ b/libraries/examples/scripting/jvm-maven-deps/script/src/org/jetbrains/kotlin/script/examples/jvm/resolve/maven/scriptDef.kt
@@ -38,10 +38,10 @@ object ScriptWithMavenDepsConfiguration : ScriptCompilationConfiguration(
 private val resolver = CompoundDependenciesResolver(FileSystemDependenciesResolver(), MavenDependenciesResolver())
 
 fun configureMavenDepsOnAnnotations(context: ScriptConfigurationRefinementContext): ResultWithDiagnostics<ScriptCompilationConfiguration> {
-    val annotations = context.collectedData?.get(ScriptCollectedData.foundAnnotations)?.takeIf { it.isNotEmpty() }
+    val annotations = context.collectedData?.get(ScriptCollectedData.collectedAnnotations)?.takeIf { it.isNotEmpty() }
         ?: return context.compilationConfiguration.asSuccess()
     return runBlocking {
-        resolver.resolveFromAnnotations(annotations)
+        resolver.resolveFromScriptSourceAnnotations(annotations)
     }.onSuccess {
         context.compilationConfiguration.with {
             dependencies.append(JvmDependency(it))

--- a/libraries/scripting/common/src/kotlin/script/experimental/api/errorHandling.kt
+++ b/libraries/scripting/common/src/kotlin/script/experimental/api/errorHandling.kt
@@ -33,6 +33,14 @@ data class ScriptDiagnostic(
      */
     enum class Severity { FATAL, ERROR, WARNING, INFO, DEBUG }
 
+    constructor(
+        code: Int,
+        message: String,
+        severity: Severity = Severity.ERROR,
+        locationWithId: SourceCode.LocationWithId?,
+        exception: Throwable? = null
+    ) : this(code, message, severity, locationWithId?.codeLocationId, locationWithId?.locationInText, exception)
+
     override fun toString(): String = render()
 
     /**
@@ -212,6 +220,12 @@ fun makeFailureResult(message: String, path: String? = null, location: SourceCod
     ResultWithDiagnostics.Failure(message.asErrorDiagnostics(ScriptDiagnostic.unspecifiedError, path, location))
 
 /**
+ * Makes Failure result with diagnostic [message] with optional [locationWithId]
+ */
+fun makeFailureResult(message: String, locationWithId: SourceCode.LocationWithId?): ResultWithDiagnostics.Failure =
+    ResultWithDiagnostics.Failure(message.asErrorDiagnostics(ScriptDiagnostic.unspecifiedError, locationWithId))
+
+/**
  * Converts the receiver Throwable to the Failure results wrapper with optional [customMessage], [path] and [location]
  */
 fun Throwable.asDiagnostics(
@@ -224,6 +238,17 @@ fun Throwable.asDiagnostics(
     ScriptDiagnostic(code, customMessage ?: message ?: "$this", severity, path, location, this)
 
 /**
+ * Converts the receiver Throwable to the Failure results wrapper with optional [customMessage], [locationWithId]
+ */
+fun Throwable.asDiagnostics(
+    code: Int = ScriptDiagnostic.unspecifiedException,
+    customMessage: String? = null,
+    locationWithId: SourceCode.LocationWithId?,
+    severity: ScriptDiagnostic.Severity = ScriptDiagnostic.Severity.ERROR
+): ScriptDiagnostic =
+    ScriptDiagnostic(code, customMessage ?: message ?: "$this", severity, locationWithId, this)
+
+/**
  * Converts the receiver String to error diagnostic report with optional [path] and [location]
  */
 fun String.asErrorDiagnostics(
@@ -232,6 +257,15 @@ fun String.asErrorDiagnostics(
     location: SourceCode.Location? = null
 ): ScriptDiagnostic =
     ScriptDiagnostic(code, this, ScriptDiagnostic.Severity.ERROR, path, location)
+
+/**
+ * Converts the receiver String to error diagnostic report with optional [locationWithId]
+ */
+fun String.asErrorDiagnostics(
+    code: Int = ScriptDiagnostic.unspecifiedError,
+    locationWithId: SourceCode.LocationWithId?
+): ScriptDiagnostic =
+    ScriptDiagnostic(code, this, ScriptDiagnostic.Severity.ERROR, locationWithId)
 
 /**
  * Extracts the result value from the receiver wrapper or null if receiver represents a Failure

--- a/libraries/scripting/common/src/kotlin/script/experimental/api/scriptData.kt
+++ b/libraries/scripting/common/src/kotlin/script/experimental/api/scriptData.kt
@@ -51,7 +51,29 @@ interface SourceCode {
      * @param end optional range location end position (after the last char)
      */
     data class Location(val start: Position, val end: Position? = null) : Serializable
+
+    /**
+     * The source code location including the path to the file
+     * @param codeLocationId the file path or other script location identifier (see [SourceCode.locationId])
+     * @param locationInText concrete location of the source code in file
+     */
+    data class LocationWithId(val codeLocationId: String, val locationInText: Location) : Serializable
 }
+
+/**
+ * Annotation found during script source parsing along with its location
+ */
+data class ScriptSourceAnnotation<out A : Annotation>(
+    /**
+     * Annotation found during script source parsing
+     */
+    val annotation: A,
+
+    /**
+     * Location of annotation is script
+     */
+    val location: SourceCode.LocationWithId?
+)
 
 /**
  * The interface for the source code located externally
@@ -90,6 +112,13 @@ class ScriptCollectedData(properties: Map<PropertiesCollection.Key<*>, Any>) : P
  * The script file-level annotations found during script source parsing
  */
 val ScriptCollectedDataKeys.foundAnnotations by PropertiesCollection.key<List<Annotation>>()
+
+/**
+ * The script file-level annotations and their locations found during script source parsing
+ */
+val ScriptCollectedDataKeys.collectedAnnotations by PropertiesCollection.key<List<ScriptSourceAnnotation<*>>>(getDefaultValue = {
+    get(ScriptCollectedData.foundAnnotations)?.map { ScriptSourceAnnotation(it, null) }
+})
 
 /**
  * The facade to the script data for compilation configuration refinement callbacks

--- a/libraries/scripting/common/src/kotlin/script/experimental/util/filterByAnnotationType.kt
+++ b/libraries/scripting/common/src/kotlin/script/experimental/util/filterByAnnotationType.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package kotlin.script.experimental.util
+
+import kotlin.script.experimental.api.*
+
+inline fun <reified A : Annotation> Iterable<ScriptSourceAnnotation<*>>.filterByAnnotationType(
+): List<ScriptSourceAnnotation<A>> = filter { it.annotation is A }
+    .map {
+        @Suppress("UNCHECKED_CAST")
+        it as ScriptSourceAnnotation<A>
+    }

--- a/libraries/scripting/dependencies-maven/build.gradle.kts
+++ b/libraries/scripting/dependencies-maven/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     testCompile(projectTests(":kotlin-scripting-dependencies"))
     testCompile(commonDep("junit"))
     testRuntimeOnly("org.slf4j:slf4j-nop:1.7.30")
+    testImplementation(kotlin("reflect"))
 }
 
 sourceSets {

--- a/libraries/scripting/dependencies-maven/test/kotlin/script/experimental/test/MavenResolverTest.kt
+++ b/libraries/scripting/dependencies-maven/test/kotlin/script/experimental/test/MavenResolverTest.kt
@@ -9,14 +9,18 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Assert
 import java.io.File
 import kotlin.contracts.ExperimentalContracts
+import kotlin.reflect.full.primaryConstructor
 import kotlin.script.experimental.dependencies.maven.MavenDependenciesResolver
 import kotlin.script.experimental.api.ResultWithDiagnostics
 import kotlin.script.experimental.api.valueOrThrow
+import kotlin.script.experimental.dependencies.DependsOn
+import kotlin.script.experimental.dependencies.Repository
+import kotlin.script.experimental.dependencies.resolveFromAnnotations
 
 @ExperimentalContracts
 class MavenResolverTest : ResolversTestBase() {
 
-    fun resolveAndCheck(coordinates: String, checkBody: (Iterable<File>) -> Boolean = { true } ) {
+    fun resolveAndCheck(coordinates: String, checkBody: (Iterable<File>) -> Boolean = { true }) {
         val resolver = MavenDependenciesResolver()
         val result = runBlocking { resolver.resolve(coordinates) }
         if (result is ResultWithDiagnostics.Failure) {
@@ -43,5 +47,49 @@ class MavenResolverTest : ResolversTestBase() {
         resolveAndCheck("org.javamoney:moneta:pom:1.3") { files ->
             files.any { it.extension == "pom" }
         }
+    }
+
+    fun testResolveFromAnnotationsWillResolveTheSameRegardlessOfAnnotationOrder() {
+        val dependsOnConstructor = DependsOn::class.primaryConstructor!!
+        val repositoryConstructor = Repository::class.primaryConstructor!!
+
+        // @DepensOn("eu.jrie.jetbrains:kotlin-shell-core:0.2")
+        val dependsOn = dependsOnConstructor.callBy(
+            mapOf(
+                dependsOnConstructor.parameters.first() to arrayOf("eu.jrie.jetbrains:kotlin-shell-core:0.2")
+            )
+        )
+
+        // @Repository("https://dl.bintray.com/kotlin/kotlin-eap", "https://dl.bintray.com/jakubriegel/kotlin-shell")
+        val repositories = repositoryConstructor.callBy(
+            mapOf(
+                repositoryConstructor.parameters.first() to arrayOf(
+                    "https://dl.bintray.com/kotlin/kotlin-eap",
+                    "https://dl.bintray.com/jakubriegel/kotlin-shell"
+                )
+            )
+        )
+
+        val annotationsWithReposFirst = listOf(repositories, dependsOn)
+        val annotationsWithDependsOnFirst = listOf(dependsOn, repositories)
+
+        val filesWithReposFirst = runBlocking {
+            MavenDependenciesResolver().resolveFromAnnotations(annotationsWithReposFirst)
+        }.valueOrThrow()
+
+        val filesWithDependsOnFirst = runBlocking {
+            MavenDependenciesResolver().resolveFromAnnotations(annotationsWithDependsOnFirst)
+        }.valueOrThrow()
+
+        // Tests that the jar was resolved
+        assert(
+            filesWithReposFirst.any { it.name.startsWith("kotlin-shell-core-") && it.extension == "jar" }
+        )
+        assert(
+            filesWithDependsOnFirst.any { it.name.startsWith("kotlin-shell-core-") && it.extension == "jar" }
+        )
+
+        // Test that the the same files are resolved regardless of annotation order
+        assertEquals(filesWithReposFirst.map { it.name }.sorted(), filesWithDependsOnFirst.map { it.name }.sorted())
     }
 }

--- a/libraries/scripting/dependencies/src/kotlin/script/experimental/dependencies/CompoundDependenciesResolver.kt
+++ b/libraries/scripting/dependencies/src/kotlin/script/experimental/dependencies/CompoundDependenciesResolver.kt
@@ -8,6 +8,8 @@ package kotlin.script.experimental.dependencies
 import java.io.File
 import kotlin.script.experimental.api.ResultWithDiagnostics
 import kotlin.script.experimental.api.ScriptDiagnostic
+import kotlin.script.experimental.api.SourceCode
+import kotlin.script.experimental.api.asSuccess
 import kotlin.script.experimental.dependencies.impl.makeResolveFailureResult
 
 class CompoundDependenciesResolver(private val resolvers: List<ExternalDependenciesResolver>) : ExternalDependenciesResolver {
@@ -22,25 +24,53 @@ class CompoundDependenciesResolver(private val resolvers: List<ExternalDependenc
         return resolvers.any { it.acceptsRepository(repositoryCoordinates) }
     }
 
-    override fun addRepository(repositoryCoordinates: RepositoryCoordinates) {
-        if (resolvers.count { it.tryAddRepository(repositoryCoordinates) } == 0)
-            throw Exception("Failed to detect repository type: $repositoryCoordinates")
+    override fun addRepository(
+        repositoryCoordinates: RepositoryCoordinates,
+        sourceCodeLocation: SourceCode.LocationWithId?
+    ): ResultWithDiagnostics<Boolean> {
+        var success = false
+        var repositoryAdded = false
+        val reports = mutableListOf<ScriptDiagnostic>()
+
+        for (resolver in resolvers) {
+            if (resolver.acceptsRepository(repositoryCoordinates)) {
+                when (val resolveResult = resolver.addRepository(repositoryCoordinates, sourceCodeLocation)) {
+                    is ResultWithDiagnostics.Success -> {
+                        success = true
+                        repositoryAdded = repositoryAdded || resolveResult.value
+                        reports.addAll(resolveResult.reports)
+                    }
+                    is ResultWithDiagnostics.Failure -> reports.addAll(resolveResult.reports)
+                }
+            }
+        }
+
+        return when {
+            success -> repositoryAdded.asSuccess(reports)
+            reports.isEmpty() -> makeResolveFailureResult(
+                "No suitable dependency resolver found for artifact '$repositoryCoordinates'",
+                sourceCodeLocation
+            )
+            else -> ResultWithDiagnostics.Failure(reports)
+        }
     }
 
-    override suspend fun resolve(artifactCoordinates: String): ResultWithDiagnostics<List<File>> {
-
+    override suspend fun resolve(
+        artifactCoordinates: String,
+        sourceCodeLocation: SourceCode.LocationWithId?
+    ): ResultWithDiagnostics<List<File>> {
         val reports = mutableListOf<ScriptDiagnostic>()
 
         for (resolver in resolvers) {
             if (resolver.acceptsArtifact(artifactCoordinates)) {
-                when (val resolveResult = resolver.resolve(artifactCoordinates)) {
+                when (val resolveResult = resolver.resolve(artifactCoordinates, sourceCodeLocation)) {
                     is ResultWithDiagnostics.Failure -> reports.addAll(resolveResult.reports)
                     else -> return resolveResult
                 }
             }
         }
         return if (reports.count() == 0) {
-            makeResolveFailureResult("No suitable dependency resolver found for artifact '$artifactCoordinates'")
+            makeResolveFailureResult("No suitable dependency resolver found for artifact '$artifactCoordinates'", sourceCodeLocation)
         } else {
             ResultWithDiagnostics.Failure(reports)
         }

--- a/libraries/scripting/dependencies/src/kotlin/script/experimental/dependencies/ExternalDependenciesResolver.kt
+++ b/libraries/scripting/dependencies/src/kotlin/script/experimental/dependencies/ExternalDependenciesResolver.kt
@@ -7,6 +7,7 @@ package kotlin.script.experimental.dependencies
 
 import java.io.File
 import kotlin.script.experimental.api.ResultWithDiagnostics
+import kotlin.script.experimental.api.SourceCode
 import kotlin.script.experimental.api.valueOrNull
 
 open class RepositoryCoordinates(val string: String)
@@ -16,23 +17,21 @@ interface ExternalDependenciesResolver {
     fun acceptsRepository(repositoryCoordinates: RepositoryCoordinates): Boolean
     fun acceptsArtifact(artifactCoordinates: String): Boolean
 
-    suspend fun resolve(artifactCoordinates: String): ResultWithDiagnostics<List<File>>
-    fun addRepository(repositoryCoordinates: RepositoryCoordinates)
+    suspend fun resolve(
+        artifactCoordinates: String,
+        sourceCodeLocation: SourceCode.LocationWithId? = null
+    ): ResultWithDiagnostics<List<File>>
+
+    fun addRepository(
+        repositoryCoordinates: RepositoryCoordinates,
+        sourceCodeLocation: SourceCode.LocationWithId? = null
+    ): ResultWithDiagnostics<Boolean>
 }
 
 fun ExternalDependenciesResolver.acceptsRepository(repositoryCoordinates: String): Boolean =
     acceptsRepository(RepositoryCoordinates(repositoryCoordinates))
 
-fun ExternalDependenciesResolver.addRepository(repositoryCoordinates: String) = addRepository(RepositoryCoordinates(repositoryCoordinates))
-
-suspend fun ExternalDependenciesResolver.tryResolve(artifactCoordinates: String): List<File>? =
-    if (acceptsArtifact(artifactCoordinates)) resolve(artifactCoordinates).valueOrNull() else null
-
-fun ExternalDependenciesResolver.tryAddRepository(repositoryCoordinates: String) =
-    tryAddRepository(RepositoryCoordinates(repositoryCoordinates))
-
-fun ExternalDependenciesResolver.tryAddRepository(repositoryCoordinates: RepositoryCoordinates) =
-    if (acceptsRepository(repositoryCoordinates)) {
-        addRepository(repositoryCoordinates)
-        true
-    } else false
+fun ExternalDependenciesResolver.addRepository(
+    repositoryCoordinates: String,
+    sourceCodeLocation: SourceCode.LocationWithId? = null
+) = addRepository(RepositoryCoordinates(repositoryCoordinates), sourceCodeLocation)

--- a/libraries/scripting/dependencies/src/kotlin/script/experimental/dependencies/FileSystemDependenciesResolver.kt
+++ b/libraries/scripting/dependencies/src/kotlin/script/experimental/dependencies/FileSystemDependenciesResolver.kt
@@ -7,6 +7,8 @@ package kotlin.script.experimental.dependencies
 
 import java.io.File
 import kotlin.script.experimental.api.ResultWithDiagnostics
+import kotlin.script.experimental.api.SourceCode
+import kotlin.script.experimental.api.asSuccess
 import kotlin.script.experimental.dependencies.impl.makeResolveFailureResult
 import kotlin.script.experimental.dependencies.impl.toRepositoryUrlOrNull
 
@@ -18,13 +20,24 @@ class FileSystemDependenciesResolver(vararg paths: File) : ExternalDependenciesR
     private fun RepositoryCoordinates.toFilePath() =
         (this.toRepositoryUrlOrNull()?.takeIf { it.protocol == "file" }?.path ?: string).toRepositoryFileOrNull()
 
-    override fun addRepository(repositoryCoordinates: RepositoryCoordinates) {
+    override fun addRepository(
+        repositoryCoordinates: RepositoryCoordinates,
+        sourceCodeLocation: SourceCode.LocationWithId?
+    ): ResultWithDiagnostics<Boolean> {
+        if (!acceptsRepository(repositoryCoordinates)) return false.asSuccess()
+
         val repoDir = repositoryCoordinates.toFilePath()
-            ?: throw IllegalArgumentException("Invalid repository location: '${repositoryCoordinates}'")
+            ?: return makeResolveFailureResult("Invalid repository location: '${repositoryCoordinates}'", sourceCodeLocation)
+
         localRepos.add(repoDir)
+
+        return true.asSuccess()
     }
 
-    override suspend fun resolve(artifactCoordinates: String): ResultWithDiagnostics<List<File>> {
+    override suspend fun resolve(
+        artifactCoordinates: String,
+        sourceCodeLocation: SourceCode.LocationWithId?
+    ): ResultWithDiagnostics<List<File>> {
         if (!acceptsArtifact(artifactCoordinates)) throw IllegalArgumentException("Path is invalid")
 
         val messages = mutableListOf<String>()
@@ -38,7 +51,7 @@ class FileSystemDependenciesResolver(vararg paths: File) : ExternalDependenciesR
                 else -> return ResultWithDiagnostics.Success(listOf(file))
             }
         }
-        return makeResolveFailureResult(messages)
+        return makeResolveFailureResult(messages, sourceCodeLocation)
     }
 
     override fun acceptsArtifact(artifactCoordinates: String) =

--- a/libraries/scripting/dependencies/src/kotlin/script/experimental/dependencies/annotations.kt
+++ b/libraries/scripting/dependencies/src/kotlin/script/experimental/dependencies/annotations.kt
@@ -6,9 +6,8 @@
 package kotlin.script.experimental.dependencies
 
 import java.io.File
-import kotlin.script.experimental.api.ResultWithDiagnostics
-import kotlin.script.experimental.api.flatMapSuccess
-import kotlin.script.experimental.api.makeFailureResult
+import kotlin.script.experimental.api.*
+import kotlin.script.experimental.util.filterByAnnotationType
 
 /**
  * A common annotation that could be used in a script to denote a dependency
@@ -33,22 +32,44 @@ annotation class Repository(vararg val repositoriesCoordinates: String)
 /**
  * An extension function that configures repositories and resolves artifacts denoted by the [Repository] and [DependsOn] annotations
  */
-suspend fun ExternalDependenciesResolver.resolveFromAnnotations(annotations: Iterable<Annotation>): ResultWithDiagnostics<List<File>> {
-    annotations.forEach { annotation ->
+suspend fun ExternalDependenciesResolver.resolveFromScriptSourceAnnotations(
+    annotations: Iterable<ScriptSourceAnnotation<*>>
+): ResultWithDiagnostics<List<File>> {
+    val reports = mutableListOf<ScriptDiagnostic>()
+    annotations.forEach { (annotation, locationWithId) ->
         when (annotation) {
             is Repository -> {
                 for (coordinates in annotation.repositoriesCoordinates) {
-                    if (!tryAddRepository(coordinates))
-                        return makeFailureResult("Unrecognized repository coordinates: $coordinates")
+                    val added = addRepository(coordinates, locationWithId)
+                        .also { reports.addAll(it.reports) }
+                        .valueOr { return it }
+
+                    if (!added)
+                        return reports + makeFailureResult(
+                            "Unrecognized repository coordinates: $coordinates",
+                            locationWithId = locationWithId
+                        )
                 }
             }
             is DependsOn -> {}
-            else -> return makeFailureResult("Unknown annotation ${annotation.javaClass}")
+            else -> return reports + makeFailureResult("Unknown annotation ${annotation.javaClass}", locationWithId = locationWithId)
         }
     }
-    return annotations.filterIsInstance(DependsOn::class.java)
-        .flatMap { it.artifactsCoordinates.asIterable() }
-        .flatMapSuccess { artifactCoordinates ->
-            resolve(artifactCoordinates)
+
+    return reports + annotations.filterByAnnotationType<DependsOn>()
+        .flatMapSuccess { (annotation, locationWithId) ->
+            annotation.artifactsCoordinates.asIterable().flatMapSuccess { artifactCoordinates ->
+                resolve(artifactCoordinates, locationWithId)
+            }
         }
+}
+
+/**
+ * An extension function that configures repositories and resolves artifacts denoted by the [Repository] and [DependsOn] annotations
+ */
+suspend fun ExternalDependenciesResolver.resolveFromAnnotations(
+    annotations: Iterable<Annotation>
+): ResultWithDiagnostics<List<File>> {
+    val scriptSourceAnnotations = annotations.map { ScriptSourceAnnotation(it, null) }
+    return resolveFromScriptSourceAnnotations(scriptSourceAnnotations)
 }

--- a/libraries/scripting/dependencies/src/kotlin/script/experimental/dependencies/impl/resolverUtils.kt
+++ b/libraries/scripting/dependencies/src/kotlin/script/experimental/dependencies/impl/resolverUtils.kt
@@ -10,11 +10,16 @@ import java.net.URL
 import kotlin.script.experimental.dependencies.RepositoryCoordinates
 import kotlin.script.experimental.api.ResultWithDiagnostics
 import kotlin.script.experimental.api.ScriptDiagnostic
+import kotlin.script.experimental.api.SourceCode
 
-fun makeResolveFailureResult(message: String) = makeResolveFailureResult(listOf(message))
+fun makeResolveFailureResult(message: String, location: SourceCode.LocationWithId? = null) = makeResolveFailureResult(listOf(message), location)
 
-fun makeResolveFailureResult(messages: Iterable<String>) =
-    ResultWithDiagnostics.Failure(messages.map { ScriptDiagnostic(ScriptDiagnostic.unspecifiedError, it, ScriptDiagnostic.Severity.WARNING) })
+fun makeResolveFailureResult(messages: Iterable<String>, location: SourceCode.LocationWithId? = null) =
+    ResultWithDiagnostics.Failure(
+        messages.map {
+            ScriptDiagnostic(ScriptDiagnostic.unspecifiedError, it, ScriptDiagnostic.Severity.WARNING, location)
+        }
+    )
 
 fun RepositoryCoordinates.toRepositoryUrlOrNull(): URL? =
     try {

--- a/libraries/scripting/dependencies/test/kotlin/script/experimental/test/ResolversTest.kt
+++ b/libraries/scripting/dependencies/test/kotlin/script/experimental/test/ResolversTest.kt
@@ -9,6 +9,8 @@ import java.io.File
 import kotlin.contracts.ExperimentalContracts
 import kotlin.script.experimental.dependencies.*
 import kotlin.script.experimental.api.ResultWithDiagnostics
+import kotlin.script.experimental.api.SourceCode
+import kotlin.script.experimental.api.asSuccess
 import kotlin.script.experimental.dependencies.impl.makeResolveFailureResult
 
 @ExperimentalContracts
@@ -83,14 +85,23 @@ class ResolversTest : ResolversTestBase() {
 
         override fun acceptsArtifact(artifactCoordinates: String): Boolean = acceptsArt(artifactCoordinates)
 
-        override suspend fun resolve(artifactCoordinates: String): ResultWithDiagnostics<List<File>> {
+        override suspend fun resolve(
+            artifactCoordinates: String,
+            sourceCodeLocation: SourceCode.LocationWithId?
+        ): ResultWithDiagnostics<List<File>> {
             if (!acceptsArtifact(artifactCoordinates)) throw Exception("Path is invalid")
-            val file = doResolve(artifactCoordinates) ?: return makeResolveFailureResult("Failed to resolve '$artifactCoordinates'")
+            val file = doResolve(artifactCoordinates)
+                ?: return makeResolveFailureResult("Failed to resolve '$artifactCoordinates'", sourceCodeLocation)
             return ResultWithDiagnostics.Success(listOf(file))
         }
 
-        override fun addRepository(repositoryCoordinates: RepositoryCoordinates) {
+        override fun addRepository(
+            repositoryCoordinates: RepositoryCoordinates,
+            sourceCodeLocation: SourceCode.LocationWithId?
+        ): ResultWithDiagnostics<Boolean> {
+            if (!acceptsRepository(repositoryCoordinates)) return false.asSuccess()
             addRepo(repositoryCoordinates.string)
+            return true.asSuccess()
         }
 
         override fun acceptsRepository(repositoryCoordinates: RepositoryCoordinates): Boolean {

--- a/libraries/tools/kotlin-main-kts/src/org/jetbrains/kotlin/mainKts/scriptDef.kt
+++ b/libraries/tools/kotlin-main-kts/src/org/jetbrains/kotlin/mainKts/scriptDef.kt
@@ -24,6 +24,7 @@ import kotlin.script.experimental.jvmhost.CompiledScriptJarsCache
 import kotlin.script.experimental.jvmhost.jsr223.configureProvidedPropertiesFromJsr223Context
 import kotlin.script.experimental.jvmhost.jsr223.importAllBindings
 import kotlin.script.experimental.jvmhost.jsr223.jsr223
+import kotlin.script.experimental.util.filterByAnnotationType
 
 @Suppress("unused")
 @KotlinScript(
@@ -117,22 +118,22 @@ class MainKtsConfigurator : RefineScriptCompilationConfigurationHandler {
             )
         }
 
-        val annotations = context.collectedData?.get(ScriptCollectedData.foundAnnotations)?.takeIf { it.isNotEmpty() }
+        val annotations = context.collectedData?.get(ScriptCollectedData.collectedAnnotations)?.takeIf { it.isNotEmpty() }
             ?: return context.compilationConfiguration.asSuccess()
 
         val scriptBaseDir = (context.script as? FileBasedScriptSource)?.file?.parentFile
-        val importedSources = annotations.flatMap {
-            (it as? Import)?.paths?.map { sourceName ->
+        val importedSources = annotations.filterByAnnotationType<Import>().flatMap {
+            it.annotation.paths.map { sourceName ->
                 FileScriptSource(scriptBaseDir?.resolve(sourceName) ?: File(sourceName))
-            } ?: emptyList()
+            }
         }
-        val compileOptions = annotations.flatMap {
-            (it as? CompilerOptions)?.options?.toList() ?: emptyList()
+        val compileOptions = annotations.filterByAnnotationType<CompilerOptions>().flatMap {
+            it.annotation.options.toList()
         }
 
         val resolveResult = try {
             runBlocking {
-                resolver.resolveFromAnnotations( annotations.filter { it is DependsOn || it is Repository })
+                resolver.resolveFromScriptSourceAnnotations(annotations.filter { it.annotation is DependsOn || it.annotation is Repository })
             }
         } catch (e: Throwable) {
             ResultWithDiagnostics.Failure(*diagnostics.toTypedArray(), e.asDiagnostics(path = context.script.locationId))

--- a/plugins/scripting/scripting-compiler-impl/src/org/jetbrains/kotlin/scripting/resolve/refineCompilationConfiguration.kt
+++ b/plugins/scripting/scripting-compiler-impl/src/org/jetbrains/kotlin/scripting/resolve/refineCompilationConfiguration.kt
@@ -6,11 +6,13 @@
 package org.jetbrains.kotlin.scripting.resolve
 
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.editor.Document
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.openapi.vfs.CharsetToolkit
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
 import com.intellij.testFramework.LightVirtualFile
@@ -18,6 +20,8 @@ import kotlinx.coroutines.runBlocking
 import org.jetbrains.kotlin.idea.KotlinLanguage
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.psiUtil.endOffset
+import org.jetbrains.kotlin.psi.psiUtil.startOffset
 import org.jetbrains.kotlin.scripting.definitions.KotlinScriptDefinition
 import org.jetbrains.kotlin.scripting.definitions.ScriptDefinition
 import org.jetbrains.kotlin.scripting.withCorrectExtension
@@ -41,7 +45,9 @@ internal fun VirtualFile.loadAnnotations(
 ): List<Annotation> =
 // TODO_R: report error on failure to load annotation class
     ApplicationManager.getApplication().runReadAction<List<Annotation>> {
-        this.getAnnotationEntries(project).construct(classLoader, acceptedAnnotations, project)
+        this.getAnnotationEntries(project)
+            .construct(classLoader, acceptedAnnotations, project)
+            .map { it.first }
     }
 
 internal fun VirtualFile.getAnnotationEntries(project: Project): Iterable<KtAnnotationEntry> {
@@ -55,8 +61,7 @@ internal fun VirtualFile.getAnnotationEntries(project: Project): Iterable<KtAnno
  * The implementation of the SourceCode for a script located in a virtual file
  */
 open class VirtualFileScriptSource(val virtualFile: VirtualFile, private val preloadedText: String? = null) :
-    FileBasedScriptSource()
-{
+    FileBasedScriptSource() {
     override val file: File get() = File(virtualFile.path)
     override val externalLocation: URL get() = URL(virtualFile.url)
     override val text: String by lazy { preloadedText ?: virtualFile.inputStream.bufferedReader().readText() }
@@ -354,27 +359,60 @@ fun getScriptCollectedData(
                 jvmGetScriptingClass(ann, contextClassLoader, hostConfiguration) as? KClass<Annotation> // TODO errors
             }
         }.orEmpty()
-    val annotations = scriptFile.annotationEntries.construct(contextClassLoader, acceptedAnnotations, project)
+    val annotations = scriptFile.annotationEntries.construct(
+        contextClassLoader,
+        acceptedAnnotations,
+        project,
+        scriptFile.viewProvider.document,
+        scriptFile.virtualFilePath
+    )
     return ScriptCollectedData(
         mapOf(
-            ScriptCollectedData.foundAnnotations to annotations
+            ScriptCollectedData.collectedAnnotations to annotations,
+            ScriptCollectedData.foundAnnotations to annotations.map { it.annotation }
         )
     )
 }
 
 private fun Iterable<KtAnnotationEntry>.construct(
+    classLoader: ClassLoader?, acceptedAnnotations: List<KClass<out Annotation>>, project: Project, document: Document?, filePath: String
+): List<ScriptSourceAnnotation<*>> = construct(classLoader, acceptedAnnotations, project).map { (annotation, psiAnn) ->
+    ScriptSourceAnnotation(
+        annotation = annotation,
+        location = document?.let { document ->
+            SourceCode.LocationWithId(
+                codeLocationId = filePath,
+                locationInText = psiAnn.location(document)
+            )
+        }
+    )
+}
+
+private fun Iterable<KtAnnotationEntry>.construct(
     classLoader: ClassLoader?, acceptedAnnotations: List<KClass<out Annotation>>, project: Project
-): List<Annotation> =
+): List<Pair<Annotation, KtAnnotationEntry>> =
     mapNotNull { psiAnn ->
         // TODO: consider advanced matching using semantic similar to actual resolving
         acceptedAnnotations.find { ann ->
             psiAnn.typeName.let { it == ann.simpleName || it == ann.qualifiedName }
         }?.let {
             @Suppress("UNCHECKED_CAST")
-            (constructAnnotation(
+            constructAnnotation(
                 psiAnn,
                 (classLoader ?: ClassLoader.getSystemClassLoader()).loadClass(it.qualifiedName).kotlin as KClass<out Annotation>,
                 project
-            ))
+            ) to psiAnn
         }
     }
+
+private fun PsiElement.location(document: Document): SourceCode.Location {
+    val start = document.offsetToPosition(startOffset)
+    val end = if (endOffset > startOffset) document.offsetToPosition(endOffset) else null
+    return SourceCode.Location(start, end)
+}
+
+private fun Document.offsetToPosition(offset: Int): SourceCode.Position {
+    val line = getLineNumber(offset)
+    val column = offset - getLineStartOffset(line)
+    return SourceCode.Position(line + 1, column + 1, offset)
+}

--- a/plugins/scripting/scripting-compiler/testData/compiler/compileTimeFibonacci/supported.fib.kts
+++ b/plugins/scripting/scripting-compiler/testData/compiler/compileTimeFibonacci/supported.fib.kts
@@ -1,0 +1,7 @@
+
+@file:Fib(4)
+
+println("fib(1)=${FIB_1}")
+println("fib(2)=${FIB_2}")
+println("fib(3)=${FIB_3}")
+println("fib(4)=${FIB_4}")

--- a/plugins/scripting/scripting-compiler/testData/compiler/compileTimeFibonacci/unsupported.fib.kts
+++ b/plugins/scripting/scripting-compiler/testData/compiler/compileTimeFibonacci/unsupported.fib.kts
@@ -1,0 +1,5 @@
+
+@file:Fib(number = 4)
+@file:Fib(number = 0)
+
+print("fib(4)=${FIB_4}")

--- a/plugins/scripting/scripting-compiler/tests/org/jetbrains/kotlin/scripting/compiler/test/CompileTimeFibonacciTest.kt
+++ b/plugins/scripting/scripting-compiler/tests/org/jetbrains/kotlin/scripting/compiler/test/CompileTimeFibonacciTest.kt
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.scripting.compiler.test
+
+import com.intellij.openapi.Disposable
+import junit.framework.TestCase
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.jetbrains.kotlin.script.loadScriptingPlugin
+import org.jetbrains.kotlin.scripting.compiler.plugin.TestDisposable
+import org.jetbrains.kotlin.scripting.compiler.plugin.impl.ScriptJvmCompilerFromEnvironment
+import org.jetbrains.kotlin.scripting.configuration.ScriptingConfigurationKeys
+import org.jetbrains.kotlin.scripting.definitions.ScriptDefinition
+import org.jetbrains.kotlin.scripting.definitions.ScriptDefinitionProvider
+import org.jetbrains.kotlin.test.ConfigurationKind
+import org.jetbrains.kotlin.test.KotlinTestUtils
+import org.jetbrains.kotlin.test.TestJdkKind
+import org.junit.Assert
+import java.io.File
+import kotlin.script.experimental.annotations.KotlinScript
+import kotlin.script.experimental.api.*
+import kotlin.script.experimental.host.ScriptingHostConfiguration
+import kotlin.script.experimental.host.toScriptSource
+import kotlin.script.experimental.jvm.*
+import kotlin.script.experimental.util.filterByAnnotationType
+
+
+private const val testDataPath = "plugins/scripting/scripting-compiler/testData/compiler/compileTimeFibonacci"
+
+class CompileTimeFibonacciTest : TestCase() {
+    private val testRootDisposable: Disposable = TestDisposable()
+
+    fun testFibonacciWithSupportedNumbersImplementsTheCorrectConstants() {
+        val outputLines = runScript("supported.fib.kts")
+            .valueOr { failure ->
+                val message = failure.reports.joinToString("\n") { it.message }
+                kotlin.test.fail("supported.fib.kts was expected to succeed:\n\n${message}")
+            }
+            .lines()
+            .filter { it.isNotBlank() }
+
+        Assert.assertEquals(4, outputLines.count())
+        Assert.assertEquals("fib(1)=1", outputLines[0])
+        Assert.assertEquals("fib(2)=1", outputLines[1])
+        Assert.assertEquals("fib(3)=2", outputLines[2])
+        Assert.assertEquals("fib(4)=3", outputLines[3])
+    }
+
+    // This tests if the annotations delivered with the correct location
+    // and that scripts can return error messages at the location of the annotation
+    fun testFibonacciWithUnsupportedNumbersEmitsErrorAtLocation() {
+        when (val result = runScript("unsupported.fib.kts")) {
+            is ResultWithDiagnostics.Success ->
+                kotlin.test.fail("supported.fib.kts was expected to fail with a compiler error from refinement")
+
+            is ResultWithDiagnostics.Failure -> {
+                val error = result.reports.first()
+
+                val expectedErrorMessage = """
+                    (plugins/scripting/scripting-compiler/testData/compiler/compileTimeFibonacci/unsupported.fib.kts:3:1) Fibonacci of non-positive numbers like 0 are not supported
+                """.trimIndent()
+                Assert.assertEquals(expectedErrorMessage, error.message)
+                // TODO: the location is not in the diagnostics because the `MessageCollector` defined in KotlinTestUtils,
+                //  throws the reports as `AssertionException`s. Evaluate using a different compiler configuration.
+//                Assert.assertEquals(3, error.location?.start?.line)
+//                Assert.assertEquals(1, error.location?.start?.col)
+//                Assert.assertEquals(3, error.location?.end?.line)
+//                Assert.assertEquals(14, error.location?.end?.col)
+            }
+        }
+    }
+
+    private fun runScript(scriptPath: String): ResultWithDiagnostics<String> {
+        val source = File(testDataPath, scriptPath).toScriptSource()
+        return compileScript(source)
+            .onSuccess { compiled ->
+                captureOut {
+                    val evaluator = BasicJvmScriptEvaluator()
+                    runBlocking {
+                        evaluator(compiled)
+                    }
+                }.asSuccess()
+            }
+    }
+
+    private fun compileScript(
+        script: SourceCode
+    ): ResultWithDiagnostics<CompiledScript> {
+        val configuration = KotlinTestUtils.newConfiguration(ConfigurationKind.NO_KOTLIN_REFLECT, TestJdkKind.FULL_JDK).apply {
+            val hostConfiguration = ScriptingHostConfiguration(defaultJvmScriptingHostConfiguration)
+            add(
+                ScriptingConfigurationKeys.SCRIPT_DEFINITIONS,
+                ScriptDefinition.FromTemplate(hostConfiguration, CompileTimeFibonacci::class, ScriptDefinition::class)
+            )
+            loadScriptingPlugin(this)
+        }
+
+        val environment = KotlinCoreEnvironment.createForTests(testRootDisposable, configuration, EnvironmentConfigFiles.JVM_CONFIG_FILES)
+        val scriptCompiler = ScriptJvmCompilerFromEnvironment(environment)
+        val scriptDefinition = ScriptDefinitionProvider.getInstance(environment.project)!!.findDefinition(script)!!
+
+        val scriptCompilationConfiguration = scriptDefinition.compilationConfiguration.with {
+            jvm {
+                dependenciesFromCurrentContext(wholeClasspath = true)
+            }
+        }
+
+        return scriptCompiler.compile(script, scriptCompilationConfiguration)
+    }
+}
+
+// Test Script with Compile Time Fibonacci Computation
+
+@KotlinScript(
+    fileExtension = "fib.kts",
+    compilationConfiguration = CompileTimeFibonacciConfiguration::class
+)
+abstract class CompileTimeFibonacci
+
+object CompileTimeFibonacciConfiguration : ScriptCompilationConfiguration(
+    {
+        fun fibUntil(number: Int): List<Int> {
+            require(number > 0)
+            if (number == 1) {
+                return listOf(1)
+            }
+            if (number == 2) {
+                return listOf(1, 1)
+            }
+
+            val previous = fibUntil(number - 1)
+            return previous + (previous.secondToLast() + previous.last())
+        }
+
+        defaultImports(Fib::class)
+        jvm {
+            dependenciesFromCurrentContext(wholeClasspath = true)
+        }
+        refineConfiguration {
+            onAnnotations(Fib::class) { context: ScriptConfigurationRefinementContext ->
+                val maxFibonacciNumber = context
+                    .collectedData
+                    ?.get(ScriptCollectedData.collectedAnnotations)
+                    ?.filterByAnnotationType<Fib>()
+                    ?.mapSuccess { (fib, location) ->
+                        fib.number.takeIf { it > 0 }?.asSuccess()
+                            ?: makeFailureResult(
+                                message = "Fibonacci of non-positive numbers like ${fib.number} are not supported",
+                                locationWithId = location
+                            )
+                    }
+                    ?.valueOr { return@onAnnotations it }
+                    ?.max() ?: return@onAnnotations context.compilationConfiguration.asSuccess()
+
+                val sourceCode = fibUntil(maxFibonacciNumber)
+                    .mapIndexed { index, number -> "val FIB_${index + 1} = $number" }
+                    .joinToString("\n")
+
+                val file = createTempFile("CompileTimeFibonacci", ".fib.kts")
+                    .apply {
+                        deleteOnExit()
+                        writeText(sourceCode)
+                    }
+
+                ScriptCompilationConfiguration(context.compilationConfiguration) {
+                    importScripts.append(file.toScriptSource())
+                }.asSuccess()
+            }
+        }
+    }
+)
+
+@Target(AnnotationTarget.FILE)
+@Repeatable
+@Retention(AnnotationRetention.SOURCE)
+annotation class Fib(val number: Int)
+
+private fun <T> List<T>.secondToLast(): T = this[count() - 2]


### PR DESCRIPTION
***Note** This PR is still a work in progress and needs to be tested properly*

This adds an additional key to ScriptCollectedData to get an array of annotations with their location in the script source code...

This addition allows the Script Developers to emit errors and warnings on the usage of their Annotations directly in the user's code. 

For the purpose of not making this a breaking change, it was added as a separate key in the collected data dictionary. However, if we consider the existence of two APIs to read the annotations to be too complicated, we can decide to make this a breaking change.

Additionally I added the optional location param to `ExternalDependenciesResolver.resolve`, to allow the dependency resolver to emit diagnostics on the precise location as well. This constitutes a breaking change on everyone who implemented their own `ExternalDependenciesResolver`, however this API does not seem to be widely used.