### PR TITLE
[FIR] unmute testKt14227 with FULL_JDK

### DIFF
--- a/compiler/testData/codegen/box/operatorConventions/kt14227.kt
+++ b/compiler/testData/codegen/box/operatorConventions/kt14227.kt
@@ -1,6 +1,6 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 // WITH_RUNTIME
 // KJS_WITH_FULL_RUNTIME
+// FULL_JDK
 import kotlin.test.*
 
 fun box(): String {


### PR DESCRIPTION
The test used to fail because it has an augmented assignment for
elements in a HashMap of Strings, and "plus" fails to resolve due to
ambiguity: besides String.plus, BigDecimal.plus in the standard
library is also considered. BigDecimal is not resolved and thus
isError returns true. During type checking, the context has
isErrorTypeEqualsAnything set to true, and BigDecimal is now regarded
as a super type of String and BigDecimal.plus is a valid
candidate. Adding the directive "FULL_JDK" enables resolving of
BigDecimal so that BigDecimal.plus is excluded.