### PR TITLE
KT-20357 Add samples to kotlin.coroutines package

### DIFF
--- a/libraries/stdlib/samples/test/samples/coroutines/coroutines.kt
+++ b/libraries/stdlib/samples/test/samples/coroutines/coroutines.kt
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package samples.coroutines
+
+import samples.Sample
+import samples.assertPrints
+import java.util.concurrent.CompletableFuture
+import kotlin.coroutines.*
+
+class Coroutines {
+
+    @Sample
+    fun completableFuture() {
+        class FutureContinuation<T> : CompletableFuture<T>(), Continuation<T> {
+            override val context = EmptyCoroutineContext
+            override fun resumeWith(result: Result<T>) {
+                result.onSuccess { complete(it) }.onFailure { completeExceptionally(it) }
+            }
+        }
+
+        suspend fun <T> CompletableFuture<T>.await(): T =
+            suspendCoroutine { continuation ->
+                whenComplete { result, exception ->
+                    if (exception == null) // the future has been completed normally
+                        continuation.resume(result)
+                    else // the future has completed with an exception
+                        continuation.resumeWithException(exception)
+                }
+            }
+
+        val block: suspend () -> String = {
+            val bar = CompletableFuture.supplyAsync { "bar" }.await()
+            "foo$bar"
+        }
+        val result = FutureContinuation<String>().also { block.startCoroutine(it) }.join()
+        assertPrints(result, "foobar")
+    }
+
+    @Sample
+    fun codeFlow() {
+        // list to track the order of executed code
+        val list = mutableListOf<Int>()
+
+        // suspending lambda which stores its suspension point continuation in a local variable
+        var suspensionPoint: Continuation<Short>? = null
+        val block: suspend () -> Int = {
+            list += 2
+            val resumed = suspendCoroutine<Short> { suspensionPoint = it }
+            list += resumed.toInt()
+            5
+        }
+
+        // create a coroutine from the lambda, start and resume it after the suspension point
+        list += 0
+        val onComplete = Continuation<Int>(EmptyCoroutineContext) { list += it.getOrThrow() }
+        val init = block.createCoroutine(onComplete)
+        list += 1
+        init.resume(Unit) // starts the coroutine
+        list += 3
+        suspensionPoint!!.resume(4)
+        list += 6
+
+        assertPrints(list, "[0, 1, 2, 3, 4, 5, 6]")
+    }
+
+    @Sample
+    fun restrictsSuspension() {
+        @RestrictsSuspension
+        class SuspensionScope {
+            var result: String? = null
+            var continuation: Continuation<Unit>? = null
+            suspend fun suspend() {
+                suspendCoroutine<Unit> { continuation = it }
+                result = "foo"
+            }
+        }
+
+        val block: suspend SuspensionScope.() -> Unit = {
+            // this block can only invoke suspend functions on this receiver
+            // suspendCoroutine<Unit> {} // does no compile
+            this.suspend() // compiles
+        }
+
+        val receiver = SuspensionScope()
+        block.startCoroutine(receiver, Continuation(EmptyCoroutineContext) {})
+        receiver.continuation!!.resume(Unit)
+        assertPrints(receiver.result, "foo")
+    }
+
+    /**
+     * Unfortunately, this class cannot be a local class in a function because of the companion object.
+     * However, the companion object is crucial for the idiomatic definition of a coroutine context element.
+     * Hence this class is included as a comment in sample [auth].
+     */
+    class AuthUser(val name: String) : AbstractCoroutineContextElement(AuthUser) {
+        companion object Key : CoroutineContext.Key<AuthUser>
+    }
+
+    @Sample
+    fun auth() {
+        /*
+         * Assume that we have defined the following class:
+         * class AuthUser(val name: String) : AbstractCoroutineContextElement(AuthUser) {
+         *     companion object Key : CoroutineContext.Key<AuthUser>
+         * }
+         */
+        val block: suspend () -> String = {
+            coroutineContext[AuthUser]?.name ?: throw SecurityException("unauthorized")
+        }
+        block.startCoroutine(Continuation(AuthUser("admin")) { result ->
+            assertPrints(result.getOrThrow(), "admin")
+        })
+    }
+
+    @Sample
+    @Suppress("UNCHECKED_CAST")
+    fun interceptor() {
+        class LoggingContinuation<T>(
+            val cont: Continuation<T>,
+            val logger: (String) -> Unit
+        ) : Continuation<T> {
+            override val context: CoroutineContext = cont.context
+            override fun resumeWith(result: Result<T>) {
+                logger(result.getOrNull().toString())
+                cont.resumeWith(result)
+            }
+        }
+
+        class LoggingInterceptor :
+            AbstractCoroutineContextElement(ContinuationInterceptor), ContinuationInterceptor {
+            val logs = mutableListOf<String>()
+            override fun <T> interceptContinuation(continuation: Continuation<T>) =
+                LoggingContinuation(continuation, logs::add)
+        }
+
+        val logger = LoggingInterceptor()
+        val block: suspend () -> Unit = {}
+        block.startCoroutine(Continuation(logger) {})
+        // the initial continuation is intercepted and the Unit object is logged
+        assertPrints(logger.logs, "[kotlin.Unit]")
+    }
+
+}

--- a/libraries/stdlib/samples/test/samples/coroutines/coroutines.kt
+++ b/libraries/stdlib/samples/test/samples/coroutines/coroutines.kt
@@ -116,7 +116,6 @@ class Coroutines {
     }
 
     @Sample
-    @Suppress("UNCHECKED_CAST")
     fun interceptor() {
         class LoggingContinuation<T>(
             val cont: Continuation<T>,

--- a/libraries/stdlib/src/kotlin/coroutines/Continuation.kt
+++ b/libraries/stdlib/src/kotlin/coroutines/Continuation.kt
@@ -10,6 +10,8 @@ import kotlin.internal.InlineOnly
 
 /**
  * Interface representing a continuation after a suspension point that returns a value of type `T`.
+ *
+ * @sample samples.coroutines.Coroutines.completableFuture
  */
 @SinceKotlin("1.3")
 public interface Continuation<in T> {
@@ -29,6 +31,8 @@ public interface Continuation<in T> {
  * Classes and interfaces marked with this annotation are restricted when used as receivers for extension
  * `suspend` functions. These `suspend` extensions can only invoke other member or extension `suspend` functions on this particular
  * receiver and are restricted from calling arbitrary suspension functions.
+ *
+ * @sample samples.coroutines.Coroutines.restrictsSuspension
  */
 @SinceKotlin("1.3")
 @Target(AnnotationTarget.CLASS)
@@ -37,6 +41,8 @@ public annotation class RestrictsSuspension
 
 /**
  * Resumes the execution of the corresponding coroutine passing [value] as the return value of the last suspension point.
+ *
+ * @sample samples.coroutines.Coroutines.completableFuture
  */
 @SinceKotlin("1.3")
 @InlineOnly
@@ -46,6 +52,8 @@ public inline fun <T> Continuation<T>.resume(value: T): Unit =
 /**
  * Resumes the execution of the corresponding coroutine so that the [exception] is re-thrown right after the
  * last suspension point.
+ *
+ * @sample samples.coroutines.Coroutines.completableFuture
  */
 @SinceKotlin("1.3")
 @InlineOnly
@@ -55,6 +63,8 @@ public inline fun <T> Continuation<T>.resumeWithException(exception: Throwable):
 
 /**
  * Creates a [Continuation] instance with the given [context] and implementation of [resumeWith] method.
+ *
+ * @sample samples.coroutines.Coroutines.codeFlow
  */
 @SinceKotlin("1.3")
 @InlineOnly
@@ -77,6 +87,8 @@ public inline fun <T> Continuation(
  * To start executing the created coroutine, invoke `resume(Unit)` on the returned [Continuation] instance.
  * The [completion] continuation is invoked when the coroutine completes with a result or an exception.
  * Subsequent invocation of any resume function on the resulting continuation will produce an [IllegalStateException].
+ *
+ * @sample samples.coroutines.Coroutines.codeFlow
  */
 @SinceKotlin("1.3")
 @Suppress("UNCHECKED_CAST")
@@ -105,6 +117,8 @@ public fun <R, T> (suspend R.() -> T).createCoroutine(
  * Starts a coroutine without a receiver and with result type [T].
  * This function creates and starts a new, fresh instance of suspendable computation every time it is invoked.
  * The [completion] continuation is invoked when the coroutine completes with a result or an exception.
+ *
+ * @sample samples.coroutines.Coroutines.completableFuture
  */
 @SinceKotlin("1.3")
 @Suppress("UNCHECKED_CAST")
@@ -135,6 +149,9 @@ public fun <R, T> (suspend R.() -> T).startCoroutine(
  * In this function both [Continuation.resume] and [Continuation.resumeWithException] can be used either synchronously in
  * the same stack-frame where the suspension function is run or asynchronously later in the same thread or
  * from a different thread of execution. Subsequent invocation of any resume function will produce an [IllegalStateException].
+ *
+ * @sample samples.coroutines.Coroutines.completableFuture
+ * @sample samples.coroutines.Coroutines.codeFlow
  */
 @SinceKotlin("1.3")
 @InlineOnly
@@ -147,6 +164,8 @@ public suspend inline fun <T> suspendCoroutine(crossinline block: (Continuation<
 
 /**
  * Returns the context of the current coroutine.
+ *
+ * @sample samples.coroutines.Coroutines.auth
  */
 @SinceKotlin("1.3")
 @Suppress("WRONG_MODIFIER_TARGET")

--- a/libraries/stdlib/src/kotlin/coroutines/ContinuationInterceptor.kt
+++ b/libraries/stdlib/src/kotlin/coroutines/ContinuationInterceptor.kt
@@ -15,6 +15,8 @@ package kotlin.coroutines
  * to [getPolymorphicElement] and [minusPolymorphicKey] respectively.
  * [ContinuationInterceptor] subtypes can be extracted from the coroutine context using either [ContinuationInterceptor.Key]
  * or subtype key if it extends [AbstractCoroutineContextKey].
+ *
+ * @sample samples.coroutines.Coroutines.interceptor
  */
 @SinceKotlin("1.3")
 public interface ContinuationInterceptor : CoroutineContext.Element {

--- a/libraries/stdlib/src/kotlin/coroutines/CoroutineContext.kt
+++ b/libraries/stdlib/src/kotlin/coroutines/CoroutineContext.kt
@@ -9,6 +9,8 @@ package kotlin.coroutines
  * Persistent context for the coroutine. It is an indexed set of [Element] instances.
  * An indexed set is a mix between a set and a map.
  * Every element in this set has a unique [Key].
+ *
+ * @sample samples.coroutines.Coroutines.auth
  */
 @SinceKotlin("1.3")
 public interface CoroutineContext {

--- a/libraries/stdlib/src/kotlin/coroutines/CoroutineContextImpl.kt
+++ b/libraries/stdlib/src/kotlin/coroutines/CoroutineContextImpl.kt
@@ -10,8 +10,12 @@ import kotlin.coroutines.CoroutineContext.Key
 
 /**
  * Base class for [CoroutineContext.Element] implementations.
- *
- * @sample samples.coroutines.Coroutines.auth
+ * Example:
+ * ```
+ * class AuthUser(val name: String) : AbstractCoroutineContextElement(AuthUser) {
+ *     companion object Key : CoroutineContext.Key<AuthUser>
+ * }
+ * ```
  */
 @SinceKotlin("1.3")
 public abstract class AbstractCoroutineContextElement(public override val key: Key<*>) : Element

--- a/libraries/stdlib/src/kotlin/coroutines/CoroutineContextImpl.kt
+++ b/libraries/stdlib/src/kotlin/coroutines/CoroutineContextImpl.kt
@@ -10,6 +10,8 @@ import kotlin.coroutines.CoroutineContext.Key
 
 /**
  * Base class for [CoroutineContext.Element] implementations.
+ *
+ * @sample samples.coroutines.Coroutines.auth
  */
 @SinceKotlin("1.3")
 public abstract class AbstractCoroutineContextElement(public override val key: Key<*>) : Element


### PR DESCRIPTION
Some of the samples are heavily inspired by examples found in the [coroutines-examples](https://github.com/Kotlin/coroutines-examples) repository, others are new (e.g. `codeFlow`). In the latter case, my intention was to create samples which clearly show what happens when the code is run in order to get a feeling which part of the code is executed when and where. For me personally, this was an important step to understand the coroutine primitives in the Kotlin standard library.