### PR TITLE
KT-39151 False positive inspection to replace Java forEach with Kotlin forEach when using ConcurrentHashMap

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/JavaMapForEachInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/JavaMapForEachInspection.kt
@@ -31,6 +31,7 @@ class JavaMapForEachInspection : AbstractApplicabilityBasedInspection<KtDotQuali
         val callExpression = element.callExpression ?: return false
         val calleeExpression = callExpression.calleeExpression ?: return false
         if (calleeExpression.text != "forEach") return false
+        if (callExpression.valueArguments.size != 1) return false
 
         val lambda = callExpression.lambda() ?: return false
         val lambdaParameters = lambda.valueParameters

--- a/idea/testData/inspectionsLocal/javaMapForEach/notSingleArgument.kt
+++ b/idea/testData/inspectionsLocal/javaMapForEach/notSingleArgument.kt
@@ -1,0 +1,11 @@
+// PROBLEM: none
+// RUNTIME_WITH_FULL_JDK
+import java.util.concurrent.ConcurrentHashMap
+
+fun test(map: ConcurrentHashMap<Int, String>) {
+    map.<caret>forEach(1) { key, value ->
+        foo(key, value)
+    }
+}
+
+fun foo(i: Int, s: String) {}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -5145,6 +5145,11 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
         public void testKotlin2() throws Exception {
             runTest("idea/testData/inspectionsLocal/javaMapForEach/kotlin2.kt");
         }
+
+        @TestMetadata("notSingleArgument.kt")
+        public void testNotSingleArgument() throws Exception {
+            runTest("idea/testData/inspectionsLocal/javaMapForEach/notSingleArgument.kt");
+        }
     }
 
     @TestMetadata("idea/testData/inspectionsLocal/kdocMissingDocumentation")


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-39151