### PR TITLE
[JVM IR] Use JVM8 support for unsigned int operations

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
@@ -300,6 +300,8 @@ private val jvmFilePhases =
         anonymousObjectSuperConstructorPhase then
         tailrecPhase then
 
+        jvmStandardLibraryBuiltInsPhase then
+
         forLoopsPhase then
         jvmInlineClassPhase then
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmSymbols.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmSymbols.kt
@@ -616,6 +616,52 @@ class JvmSymbols(
         }
     }
 
+    private val javaLangInteger: IrClassSymbol = createClass(FqName("java.lang.Integer")) { klass ->
+        klass.addFunction("compareUnsigned", irBuiltIns.intType, isStatic = true).apply {
+            addValueParameter("x", irBuiltIns.intType)
+            addValueParameter("y", irBuiltIns.intType)
+        }
+        klass.addFunction("divideUnsigned", irBuiltIns.intType, isStatic = true).apply {
+            addValueParameter("dividend", irBuiltIns.intType)
+            addValueParameter("divisor", irBuiltIns.intType)
+        }
+        klass.addFunction("remainderUnsigned", irBuiltIns.intType, isStatic = true).apply {
+            addValueParameter("dividend", irBuiltIns.intType)
+            addValueParameter("divisor", irBuiltIns.intType)
+        }
+        klass.addFunction("toUnsignedString", irBuiltIns.stringType, isStatic = true).apply {
+            addValueParameter("i", irBuiltIns.intType)
+        }
+    }
+
+    val compareUnsignedInt: IrSimpleFunctionSymbol = javaLangInteger.functionByName("compareUnsigned")
+    val divideUnsignedInt: IrSimpleFunctionSymbol = javaLangInteger.functionByName("divideUnsigned")
+    val remainderUnsignedInt: IrSimpleFunctionSymbol = javaLangInteger.functionByName("remainderUnsigned")
+    val toUnsignedStringInt: IrSimpleFunctionSymbol = javaLangInteger.functionByName("toUnsignedString")
+
+    private val javaLangLong: IrClassSymbol = createClass(FqName("java.lang.Long")) { klass ->
+        klass.addFunction("compareUnsigned", irBuiltIns.intType, isStatic = true).apply {
+            addValueParameter("x", irBuiltIns.longType)
+            addValueParameter("y", irBuiltIns.longType)
+        }
+        klass.addFunction("divideUnsigned", irBuiltIns.longType, isStatic = true).apply {
+            addValueParameter("dividend", irBuiltIns.longType)
+            addValueParameter("divisor", irBuiltIns.longType)
+        }
+        klass.addFunction("remainderUnsigned", irBuiltIns.longType, isStatic = true).apply {
+            addValueParameter("dividend", irBuiltIns.longType)
+            addValueParameter("divisor", irBuiltIns.longType)
+        }
+        klass.addFunction("toUnsignedString", irBuiltIns.stringType, isStatic = true).apply {
+            addValueParameter("i", irBuiltIns.longType)
+        }
+    }
+
+    val compareUnsignedLong: IrSimpleFunctionSymbol = javaLangLong.functionByName("compareUnsigned")
+    val divideUnsignedLong: IrSimpleFunctionSymbol = javaLangLong.functionByName("divideUnsigned")
+    val remainderUnsignedLong: IrSimpleFunctionSymbol = javaLangLong.functionByName("remainderUnsigned")
+    val toUnsignedStringLong: IrSimpleFunctionSymbol = javaLangLong.functionByName("toUnsignedString")
+
     val systemArraycopy: IrSimpleFunctionSymbol = systemClass.functionByName("arraycopy")
 
     val signatureStringIntrinsic: IrSimpleFunctionSymbol =

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/JvmInlineClassLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/JvmInlineClassLowering.kt
@@ -53,7 +53,8 @@ val jvmInlineClassPhase = makeIrFilePhase(
     name = "Inline Classes",
     description = "Lower inline classes",
     // forLoopsPhase may produce UInt and ULong which are inline classes.
-    prerequisite = setOf(forLoopsPhase)
+    // standard library replacements are done on the unmangled names for UInt and ULong classes.
+    prerequisite = setOf(forLoopsPhase, jvmStandardLibraryBuiltInsPhase)
 )
 
 /**

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/JvmOptimizationLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/JvmOptimizationLowering.kt
@@ -46,7 +46,7 @@ class JvmOptimizationLowering(val context: JvmBackendContext) : FileLoweringPass
                 dispatchReceiverParameter != null
 
 
-    private fun getOperandsIfCallToEqeqOrEquals(call: IrCall): Pair<IrExpression, IrExpression>? =
+    private fun getOperandsIfCallToEQEQOrEquals(call: IrCall): Pair<IrExpression, IrExpression>? =
         when {
             call.symbol == context.irBuiltIns.eqeqSymbol -> {
                 val left = call.getValueArgument(0)!!
@@ -103,7 +103,7 @@ class JvmOptimizationLowering(val context: JvmBackendContext) : FileLoweringPass
                     return (expression.dispatchReceiver as IrCall).dispatchReceiver!!
                 }
 
-                getOperandsIfCallToEqeqOrEquals(expression)?.let { (left, right) ->
+                getOperandsIfCallToEQEQOrEquals(expression)?.let { (left, right) ->
                     return when {
                         left.isNullConst() && right.isNullConst() ->
                             IrConstImpl.constTrue(expression.startOffset, expression.endOffset, context.irBuiltIns.booleanType)

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/JvmStandardLibraryBuiltInsLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/JvmStandardLibraryBuiltInsLowering.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.jvm.lower
+
+import org.jetbrains.kotlin.backend.common.FileLoweringPass
+import org.jetbrains.kotlin.backend.common.phaser.makeIrFilePhase
+import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
+import org.jetbrains.kotlin.config.JvmTarget
+import org.jetbrains.kotlin.ir.declarations.IrFile
+import org.jetbrains.kotlin.ir.expressions.IrCall
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.impl.IrCallImpl
+import org.jetbrains.kotlin.ir.symbols.IrFunctionSymbol
+import org.jetbrains.kotlin.ir.types.IrType
+import org.jetbrains.kotlin.ir.util.fqNameForIrSerialization
+import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
+
+internal val jvmStandardLibraryBuiltInsPhase = makeIrFilePhase(
+    ::JvmStandardLibraryBuiltInsLowering,
+    name = "JvmStandardLibraryBuiltInsLowering",
+    description = "Use Java Standard Library implementations of built-ins"
+)
+
+class JvmStandardLibraryBuiltInsLowering(val context: JvmBackendContext) : FileLoweringPass {
+
+    override fun lower(irFile: IrFile) {
+        if (context.state.target < JvmTarget.JVM_1_8) return
+
+        val transformer = object : IrElementTransformerVoid() {
+            override fun visitCall(expression: IrCall): IrExpression {
+                expression.transformChildren(this, null)
+
+                val parentClass = expression.symbol.owner.parent.fqNameForIrSerialization.asString()
+                val functionName = expression.symbol.owner.name.asString()
+                Jvm8builtInReplacements[parentClass to functionName]?.let {
+                    return expression.replaceWithCallTo(it)
+                }
+
+                return expression
+            }
+        }
+
+        irFile.transformChildren(transformer, null)
+    }
+
+    private val Jvm8builtInReplacements = mapOf(
+        ("kotlin.UInt" to "compareTo") to context.ir.symbols.compareUnsignedInt,
+        ("kotlin.UInt" to "div") to context.ir.symbols.divideUnsignedInt,
+        ("kotlin.UInt" to "rem") to context.ir.symbols.remainderUnsignedInt,
+        ("kotlin.UInt" to "toString") to context.ir.symbols.toUnsignedStringInt,
+        ("kotlin.ULong" to "compareTo") to context.ir.symbols.compareUnsignedLong,
+        ("kotlin.ULong" to "div") to context.ir.symbols.divideUnsignedLong,
+        ("kotlin.ULong" to "rem") to context.ir.symbols.remainderUnsignedLong,
+        ("kotlin.ULong" to "toString") to context.ir.symbols.toUnsignedStringLong
+    )
+
+    // Originals are so far only instance methods, and the replacements are
+    // statics, so we copy dispatch receivers to a value argument if needed.
+    private fun IrCall.replaceWithCallTo(replacement: IrFunctionSymbol) =
+        IrCallImpl(
+            startOffset,
+            endOffset,
+            type,
+            replacement
+        ).also { newCall ->
+            var valueArgumentOffset = 0
+            this.dispatchReceiver?.let {
+                newCall.putValueArgument(valueArgumentOffset, it.coerceTo(replacement.owner.valueParameters[valueArgumentOffset].type))
+                valueArgumentOffset++
+            }
+            (0 until valueArgumentsCount).forEach {
+                newCall.putValueArgument(it + valueArgumentOffset, getValueArgument(it)!!.coerceTo(replacement.owner.valueParameters[it].type))
+            }
+        }
+
+    private fun IrExpression.coerceTo(target: IrType): IrExpression =
+        IrCallImpl(
+            startOffset,
+            endOffset,
+            target,
+            context.ir.symbols.unsafeCoerceIntrinsic
+        ).also { call ->
+            call.putTypeArgument(0, type)
+            call.putTypeArgument(1, target)
+            call.putValueArgument(0, this)
+        }
+}

--- a/compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedIntCompare_before.kt
+++ b/compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedIntCompare_before.kt
@@ -1,4 +1,3 @@
-// JVM_TARGET: 1.8
 // WITH_RUNTIME
 
 val ua = 1234U
@@ -12,5 +11,5 @@ fun box(): String {
     return "OK"
 }
 
-// 0 kotlin/UnsignedKt.uintCompare
-// 1 INVOKESTATIC java/lang/Integer.compareUnsigned \(II\)I
+// 1 kotlin/UnsignedKt.uintCompare
+// 0 INVOKESTATIC java/lang/Integer.compareUnsigned \(II\)I

--- a/compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedIntDivide_jvm18.kt
+++ b/compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedIntDivide_jvm18.kt
@@ -1,7 +1,5 @@
 // JVM_TARGET: 1.8
 // WITH_RUNTIME
-// IGNORE_BACKEND: JVM_IR
-// TODO KT-36838 Use potentially intrinsified methods for unsigned available in JDK 1.8+ in JVM_IR
 
 val ua = 1234U
 val ub = 5678U

--- a/compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedIntRemainder_jvm18.kt
+++ b/compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedIntRemainder_jvm18.kt
@@ -1,7 +1,5 @@
 // JVM_TARGET: 1.8
 // WITH_RUNTIME
-// IGNORE_BACKEND: JVM_IR
-// TODO KT-36838 Use potentially intrinsified methods for unsigned available in JDK 1.8+ in JVM_IR
 
 val ua = 1234U
 val ub = 5678U

--- a/compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedIntSmartCasts_jvm18.kt
+++ b/compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedIntSmartCasts_jvm18.kt
@@ -1,0 +1,7 @@
+// JVM_TARGET: 1.8
+// WITH_RUNTIME
+
+fun both(a: Any?, b: Any?) = if (a is UInt && b is UInt) a < b else null!!
+
+// 1 compareUnsigned
+// 0 uintCompare

--- a/compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedIntToString_jvm18.kt
+++ b/compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedIntToString_jvm18.kt
@@ -1,7 +1,5 @@
 // JVM_TARGET: 1.8
 // WITH_RUNTIME
-// IGNORE_BACKEND: JVM_IR
-// TODO KT-36838 Use potentially intrinsified methods for unsigned available in JDK 1.8+ in JVM_IR
 
 fun box(): String {
     val min = 0U.toString()

--- a/compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedLongCompare_jvm18.kt
+++ b/compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedLongCompare_jvm18.kt
@@ -1,7 +1,5 @@
 // JVM_TARGET: 1.8
 // WITH_RUNTIME
-// IGNORE_BACKEND: JVM_IR
-// TODO KT-36838 Use potentially intrinsified methods for unsigned available in JDK 1.8+ in JVM_IR
 
 val ua = 1234UL
 val ub = 5678UL

--- a/compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedLongDivide_jvm18.kt
+++ b/compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedLongDivide_jvm18.kt
@@ -1,7 +1,5 @@
 // JVM_TARGET: 1.8
 // WITH_RUNTIME
-// IGNORE_BACKEND: JVM_IR
-// TODO KT-36838 Use potentially intrinsified methods for unsigned available in JDK 1.8+ in JVM_IR
 
 val ua = 1234UL
 val ub = 5678UL

--- a/compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedLongRemainder_jvm18.kt
+++ b/compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedLongRemainder_jvm18.kt
@@ -1,7 +1,5 @@
 // JVM_TARGET: 1.8
 // WITH_RUNTIME
-// IGNORE_BACKEND: JVM_IR
-// TODO KT-36838 Use potentially intrinsified methods for unsigned available in JDK 1.8+ in JVM_IR
 
 val ua = 1234UL
 val ub = 5678UL

--- a/compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedLongToString_jvm18.kt
+++ b/compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedLongToString_jvm18.kt
@@ -1,7 +1,5 @@
 // JVM_TARGET: 1.8
 // WITH_RUNTIME
-// IGNORE_BACKEND: JVM_IR
-// TODO KT-36838 Use potentially intrinsified methods for unsigned available in JDK 1.8+ in JVM_IR
 
 fun box(): String {
     val min = 0UL.toString()

--- a/compiler/testData/codegen/bytecodeText/unsignedTypes/whenByUnsigned.kt
+++ b/compiler/testData/codegen/bytecodeText/unsignedTypes/whenByUnsigned.kt
@@ -1,6 +1,4 @@
 // WITH_RUNTIME
-// IGNORE_BACKEND: JVM_IR
-// TODO KT-36839 Generate 'when' with unsigned subject using TABLESWITCH/LOOKUPSWITCH in JVM_IR
 
 const val M1: UInt = 2147483648u
 

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
@@ -4483,6 +4483,11 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
             KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/bytecodeText/unsignedTypes"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM, true);
         }
 
+        @TestMetadata("unsignedIntCompare_before.kt")
+        public void testUnsignedIntCompare_before() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedIntCompare_before.kt");
+        }
+
         @TestMetadata("unsignedIntCompare_jvm18.kt")
         public void testUnsignedIntCompare_jvm18() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedIntCompare_jvm18.kt");
@@ -4496,6 +4501,11 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
         @TestMetadata("unsignedIntRemainder_jvm18.kt")
         public void testUnsignedIntRemainder_jvm18() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedIntRemainder_jvm18.kt");
+        }
+
+        @TestMetadata("unsignedIntSmartCasts_jvm18.kt")
+        public void testUnsignedIntSmartCasts_jvm18() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedIntSmartCasts_jvm18.kt");
         }
 
         @TestMetadata("unsignedIntToString_jvm18.kt")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
@@ -4441,6 +4441,11 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
             KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/bytecodeText/unsignedTypes"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
         }
 
+        @TestMetadata("unsignedIntCompare_before.kt")
+        public void testUnsignedIntCompare_before() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedIntCompare_before.kt");
+        }
+
         @TestMetadata("unsignedIntCompare_jvm18.kt")
         public void testUnsignedIntCompare_jvm18() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedIntCompare_jvm18.kt");
@@ -4454,6 +4459,11 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
         @TestMetadata("unsignedIntRemainder_jvm18.kt")
         public void testUnsignedIntRemainder_jvm18() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedIntRemainder_jvm18.kt");
+        }
+
+        @TestMetadata("unsignedIntSmartCasts_jvm18.kt")
+        public void testUnsignedIntSmartCasts_jvm18() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/unsignedTypes/unsignedIntSmartCasts_jvm18.kt");
         }
 
         @TestMetadata("unsignedIntToString_jvm18.kt")


### PR DESCRIPTION
Use the Java Standard Library functions for particular integer and long operations when available (language version 1.8+). 

Emit a JVM Switch instruction when Kotlin "switching" on UInt using an appropriate `when` statement.

See [YouTrack KT-36838](https://youtrack.jetbrains.com/issue/KT-36838).