### PR TITLE
FIR: extend arrayOf call transformation to other variants

### DIFF
--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirArrayOfCallTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirArrayOfCallTransformer.kt
@@ -23,11 +23,8 @@ internal class FirArrayOfCallTransformer {
         get() {
             val function: FirCallableDeclaration<*> = getOriginalFunction() ?: return false
             return function is FirSimpleFunction &&
-                    // TODO: extend it to other variants, like emptyArray, intArrayOf, floatArrayOf, etc.
-                    function.name.asString() == "arrayOf" &&
                     function.returnTypeRef.isArrayType &&
-                    function.valueParameters.size == 1 && function.valueParameters[0].isVararg &&
-                    arguments.size == 1 &&
+                    isArrayOf(function, arguments) &&
                     function.receiverTypeRef == null
         }
 
@@ -50,5 +47,20 @@ internal class FirArrayOfCallTransformer {
         }.apply {
             replaceTypeRef(typeRef)
         }
+    }
+
+    companion object {
+        private val arrayOfNames = hashSetOf("kotlin/arrayOf") +
+                hashSetOf(
+                    "boolean", "byte", "char", "double", "float", "int", "long", "short",
+                    "ubyte", "uint", "ulong", "ushort"
+                ).map { "kotlin/" + it + "ArrayOf" }
+
+        private fun isArrayOf(function: FirSimpleFunction, arguments: List<FirExpression>): Boolean =
+            when (function.symbol.callableId.toString()) {
+                "kotlin/emptyArray" -> function.valueParameters.isEmpty() && arguments.isEmpty()
+                in arrayOfNames -> function.valueParameters.size == 1 && function.valueParameters[0].isVararg && arguments.size == 1
+                else -> false
+            }
     }
 }

--- a/compiler/testData/codegen/box/annotations/parameters.kt
+++ b/compiler/testData/codegen/box/annotations/parameters.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 // IGNORE_BACKEND: JS_IR
 // IGNORE_BACKEND: JS_IR_ES6
 // TODO: muted automatically, investigate should it be ran for JS or not

--- a/compiler/testData/codegen/box/defaultArguments/constructor/annotationWithEmptyArray.kt
+++ b/compiler/testData/codegen/box/defaultArguments/constructor/annotationWithEmptyArray.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 annotation class Anno(val x: Array<String> = emptyArray())
 
 @Anno fun test1() = 1

--- a/compiler/testData/ir/irText/declarations/annotations/arrayInAnnotationArguments.fir.txt
+++ b/compiler/testData/ir/irText/declarations/annotations/arrayInAnnotationArguments.fir.txt
@@ -57,7 +57,7 @@ FILE fqName:<root> fileName:/arrayInAnnotationArguments.kt
       $this: VALUE_PARAMETER name:<this> type:kotlin.Any
   FUN name:test1 visibility:public modality:FINAL <> () returnType:kotlin.Unit
     annotations:
-      TestAnnWithIntArray(x = CALL 'public final fun intArrayOf (vararg elements: kotlin.Int): kotlin.IntArray declared in kotlin' type=kotlin.IntArray origin=null)
+      TestAnnWithIntArray(x = ['1', '2', '3'])
       TestAnnWithStringArray(x = ['a', 'b', 'c'])
     BLOCK_BODY
   FUN name:test2 visibility:public modality:FINAL <> () returnType:kotlin.Unit


### PR DESCRIPTION
At https://github.com/JetBrains/kotlin/pull/3404, only `arrayOf` call is supported. This is a follow-up to extend it to other variants, such as `emptyArray`, `intArrayOf`, `floatArrayOf`, etc.