### PR TITLE
[JVM_IR] Generate line numbers and nops for init blocks.

### DIFF
--- a/compiler/testData/debug/stepping/initBlocks.kt
+++ b/compiler/testData/debug/stepping/initBlocks.kt
@@ -51,10 +51,8 @@ fun box() {
     Zoo()
 }
 
-// IGNORE_BACKEND: JVM_IR
-// The JVM_IR does not generate code that will break on the line
-// containing the `init`, nor the exit from the `init`. It only
-// contains lines for the contents of the init blocks.
+// JVM_IR has an extra step back to the line of the class
+// declaration for the return in the constructor.
 
 // LINENUMBERS
 // test.kt:48 box
@@ -64,6 +62,9 @@ fun box() {
 // test.kt:45 x
 // test.kt:7 <init>
 // test.kt:8 <init>
+// LINENUMBERS JVM_IR
+// test.kt:3 <init>
+// LINENUMBERS
 // test.kt:48 box
 // test.kt:49 box
 // test.kt:11 <init>
@@ -73,6 +74,9 @@ fun box() {
 // test.kt:16 <init>
 // test.kt:17 <init>
 // test.kt:18 <init>
+// LINENUMBERS JVM_IR
+// test.kt:11 <init>
+// LINENUMBERS
 // test.kt:49 box
 // test.kt:50 box
 // test.kt:21 <init>
@@ -85,6 +89,9 @@ fun box() {
 // test.kt:28 <init>
 // test.kt:29 <init>
 // test.kt:30 <init>
+// LINENUMBERS JVM_IR
+// test.kt:21 <init>
+// LINENUMBERS
 // test.kt:50 box
 // test.kt:51 box
 // test.kt:33 <init>
@@ -94,5 +101,8 @@ fun box() {
 // test.kt:39 <init>
 // test.kt:40 <init>
 // test.kt:42 <init>
+// LINENUMBERS JVM_IR
+// test.kt:33 <init>
+// LINENUMBERS
 // test.kt:51 box
 // test.kt:52 box

--- a/compiler/testData/debug/stepping/initBlocksCompanion.kt
+++ b/compiler/testData/debug/stepping/initBlocksCompanion.kt
@@ -1,0 +1,52 @@
+// FILE: test.kt
+
+class A {
+    companion object {
+        val s: String
+
+        init {
+            s = "OK"
+        }
+
+        val x = x()
+
+        init { val a = 32 }
+
+        init {
+            val b = 42
+        }
+
+        init
+        {
+            val c = 43
+        }
+    }
+}
+
+fun x() = ""
+
+fun box() {
+    A.x
+    A.s
+}
+
+// JVM backend has extra steps for getX and getS.
+
+// TODO: since these tests operate as step-into, we do not get any steps
+// in the <clinit> for the companion object. Maybe extend the test infrastructure
+// with directives to set break points in order to test this.
+
+// LINENUMBERS
+// test.kt:29 box
+// test.kt:11 getX
+// LINENUMBERS JVM
+// test.kt:11 getX
+// LINENUMBERS
+// test.kt:29 box
+// test.kt:30 box
+// test.kt:5 getS
+// LINENUMBERS JVM
+// test.kt:5 getS
+// LINENUMBERS
+// test.kt:30 box
+// test.kt:31 box

--- a/compiler/tests/org/jetbrains/kotlin/codegen/debugInformation/IrSteppingTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/debugInformation/IrSteppingTestGenerated.java
@@ -194,6 +194,12 @@ public class IrSteppingTestGenerated extends AbstractIrSteppingTest {
     }
 
     @Test
+    @TestMetadata("initBlocksCompanion.kt")
+    public void testInitBlocksCompanion() throws Exception {
+        runTest("compiler/testData/debug/stepping/initBlocksCompanion.kt");
+    }
+
+    @Test
     @TestMetadata("inlineCallableReference.kt")
     public void testInlineCallableReference() throws Exception {
         runTest("compiler/testData/debug/stepping/inlineCallableReference.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/debugInformation/SteppingTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/debugInformation/SteppingTestGenerated.java
@@ -194,6 +194,12 @@ public class SteppingTestGenerated extends AbstractSteppingTest {
     }
 
     @Test
+    @TestMetadata("initBlocksCompanion.kt")
+    public void testInitBlocksCompanion() throws Exception {
+        runTest("compiler/testData/debug/stepping/initBlocksCompanion.kt");
+    }
+
+    @Test
     @TestMetadata("inlineCallableReference.kt")
     public void testInlineCallableReference() throws Exception {
         runTest("compiler/testData/debug/stepping/inlineCallableReference.kt");

--- a/plugins/kotlin-serialization/kotlin-serialization-compiler/testData/codegen/Basic.ir.txt
+++ b/plugins/kotlin-serialization/kotlin-serialization-compiler/testData/codegen/Basic.ir.txt
@@ -25,6 +25,8 @@ public final class ListOfUsers$$serializer : java/lang/Object, kotlinx/serializa
           ALOAD (0)
           CHECKCAST
           PUTSTATIC (descriptor, Lkotlinx/serialization/SerialDescriptor;)
+        LABEL (L1)
+        LINENUMBER (13)
           RETURN
     }
 
@@ -332,6 +334,8 @@ public final class OptionalUser$$serializer : java/lang/Object, kotlinx/serializ
           ALOAD (0)
           CHECKCAST
           PUTSTATIC (descriptor, Lkotlinx/serialization/SerialDescriptor;)
+        LABEL (L1)
+        LINENUMBER (10)
           RETURN
     }
 
@@ -687,6 +691,8 @@ public final class User$$serializer : java/lang/Object, kotlinx/serialization/in
           ALOAD (0)
           CHECKCAST
           PUTSTATIC (descriptor, Lkotlinx/serialization/SerialDescriptor;)
+        LABEL (L1)
+        LINENUMBER (7)
           RETURN
     }
 


### PR DESCRIPTION
This seems to be what JVM does and it allows you to set a
breakpoint on the init line.