### PR TITLE
JVM IR: Mark lateinit fields as NotNull

### DIFF
--- a/compiler/testData/codegen/bytecodeListing/lateInitNotNull.kt
+++ b/compiler/testData/codegen/bytecodeListing/lateInitNotNull.kt
@@ -1,0 +1,5 @@
+// Test to ensure that we mark the backing field of a lateinit property
+// as NotNull, even though the field is nullable in the JVM IR backend.
+class A {
+    lateinit var x: A
+}

--- a/compiler/testData/codegen/bytecodeListing/lateInitNotNull.txt
+++ b/compiler/testData/codegen/bytecodeListing/lateInitNotNull.txt
@@ -1,0 +1,7 @@
+@kotlin.Metadata
+public final class A {
+    public @org.jetbrains.annotations.NotNull field x: A
+    public method <init>(): void
+    public final @org.jetbrains.annotations.NotNull method getX(): A
+    public final method setX(@org.jetbrains.annotations.NotNull p0: A): void
+}

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeListingTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeListingTestGenerated.java
@@ -74,6 +74,11 @@ public class BytecodeListingTestGenerated extends AbstractBytecodeListingTest {
         runTest("compiler/testData/codegen/bytecodeListing/jvmStaticWithDefaultParameters.kt");
     }
 
+    @TestMetadata("lateInitNotNull.kt")
+    public void testLateInitNotNull() throws Exception {
+        runTest("compiler/testData/codegen/bytecodeListing/lateInitNotNull.kt");
+    }
+
     @TestMetadata("noCollectionStubMethodsInInterface.kt")
     public void testNoCollectionStubMethodsInInterface() throws Exception {
         runTest("compiler/testData/codegen/bytecodeListing/noCollectionStubMethodsInInterface.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeListingTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeListingTestGenerated.java
@@ -74,6 +74,11 @@ public class IrBytecodeListingTestGenerated extends AbstractIrBytecodeListingTes
         runTest("compiler/testData/codegen/bytecodeListing/jvmStaticWithDefaultParameters.kt");
     }
 
+    @TestMetadata("lateInitNotNull.kt")
+    public void testLateInitNotNull() throws Exception {
+        runTest("compiler/testData/codegen/bytecodeListing/lateInitNotNull.kt");
+    }
+
     @TestMetadata("noCollectionStubMethodsInInterface.kt")
     public void testNoCollectionStubMethodsInInterface() throws Exception {
         runTest("compiler/testData/codegen/bytecodeListing/noCollectionStubMethodsInInterface.kt");


### PR DESCRIPTION
This is needed for compatibility with the JVM backend.