### PR TITLE
Make repeat example more expressive

### DIFF
--- a/libraries/stdlib/samples/test/samples/misc/controlFlow.kt
+++ b/libraries/stdlib/samples/test/samples/misc/controlFlow.kt
@@ -16,9 +16,9 @@ class ControlFlow {
             println("Hello")
         }
         
-        // greets with a count
-        repeat(3) { count ->
-            println("Hello with count $count")
+        // greets with an index
+        repeat(3) { index ->
+            println("Hello with index $index")
         }
 
         repeat(0) {

--- a/libraries/stdlib/samples/test/samples/misc/controlFlow.kt
+++ b/libraries/stdlib/samples/test/samples/misc/controlFlow.kt
@@ -13,7 +13,12 @@ class ControlFlow {
     fun repeat() {
         // greets three times
         repeat(3) {
-            println("Hello with count $it")
+            println("Hello")
+        }
+        
+        // greets with a count
+        repeat(3) { count ->
+            println("Hello with count $count")
         }
 
         repeat(0) {

--- a/libraries/stdlib/samples/test/samples/misc/controlFlow.kt
+++ b/libraries/stdlib/samples/test/samples/misc/controlFlow.kt
@@ -13,7 +13,7 @@ class ControlFlow {
     fun repeat() {
         // greets three times
         repeat(3) {
-            println("Hello")
+            println("Hello with count $it")
         }
 
         repeat(0) {


### PR DESCRIPTION
This commit adds the zero-based index of current iteration from the passed HOF "action" of the repeat function to its associated code sample.

related to KT-20357