### PR TITLE
Delete module kotlin-build-common included twice

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -60,8 +60,7 @@ gradleEnterprise {
 BuildCacheKt.setupBuildCache(settings)
 
 // modules
-include ":kotlin-build-common",
-        ":benchmarks",
+include ":benchmarks",
         ":compiler",
         ":compiler:util",
         ":compiler:config",


### PR DESCRIPTION
kotlin-build-common included twice in includes