### PR TITLE
KT-39263 False positive "Variable should be inlined" for override value in  initialized object

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/UnnecessaryVariableInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/UnnecessaryVariableInspection.kt
@@ -28,6 +28,7 @@ import org.jetbrains.kotlin.idea.caches.resolve.resolveToCall
 import org.jetbrains.kotlin.idea.core.NewDeclarationNameValidator
 import org.jetbrains.kotlin.idea.refactoring.inline.KotlinInlineValHandler
 import org.jetbrains.kotlin.idea.util.nameIdentifierTextRangeInThis
+import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.getNextSiblingIgnoringWhitespaceAndComments
 import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
@@ -66,6 +67,7 @@ class UnnecessaryVariableInspection : AbstractApplicabilityBasedInspection<KtPro
         }
 
         private fun statusFor(property: KtProperty): Status? {
+            if (property.hasModifier(KtTokens.OVERRIDE_KEYWORD)) return null
             val enclosingElement = KtPsiUtil.getEnclosingElementForLocalDeclaration(property) ?: return null
             val initializer = property.initializer ?: return null
 

--- a/idea/testData/inspectionsLocal/unnecessaryVariable/override.kt
+++ b/idea/testData/inspectionsLocal/unnecessaryVariable/override.kt
@@ -1,0 +1,17 @@
+// PROBLEM: none
+abstract class Foo {
+    abstract val bar: Int
+    abstract fun baz()
+}
+
+fun println(i: Int) {}
+
+fun test() {
+    val i = 1
+    object : Foo() {
+        override val <caret>bar = i
+        override fun baz() {
+            println(bar)
+        }
+    }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -13399,6 +13399,11 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
             runTest("idea/testData/inspectionsLocal/unnecessaryVariable/it.kt");
         }
 
+        @TestMetadata("override.kt")
+        public void testOverride() throws Exception {
+            runTest("idea/testData/inspectionsLocal/unnecessaryVariable/override.kt");
+        }
+
         @TestMetadata("paramCopy.kt")
         public void testParamCopy() throws Exception {
             runTest("idea/testData/inspectionsLocal/unnecessaryVariable/paramCopy.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-39263