### PR TITLE
KT-39557 'Add parameter' quick fix messes up parameters order when applying to a receiver call

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/AddFunctionParametersFix.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/AddFunctionParametersFix.kt
@@ -146,7 +146,8 @@ class AddFunctionParametersFix(
                             argument,
                             validator
                         )
-                        descriptor.addParameter(argumentIndex, parameterInfo)
+                        val receiverCount = if (descriptor.receiver != null) 1 else 0
+                        descriptor.addParameter(argumentIndex + receiverCount, parameterInfo)
                         return
                     }
 

--- a/idea/testData/quickfix/changeSignature/addExtensionFunctionParameterForTypeMismatch.kt
+++ b/idea/testData/quickfix/changeSignature/addExtensionFunctionParameterForTypeMismatch.kt
@@ -1,0 +1,8 @@
+// "Add 2nd parameter to function 'bar'" "true"
+interface Foo
+
+private fun Foo.bar(s: String, i: Int) {}
+
+fun test(foo: Foo, b: Boolean) {
+    foo.bar("", b<caret>, 0)
+}

--- a/idea/testData/quickfix/changeSignature/addExtensionFunctionParameterForTypeMismatch.kt.after
+++ b/idea/testData/quickfix/changeSignature/addExtensionFunctionParameterForTypeMismatch.kt.after
@@ -1,0 +1,8 @@
+// "Add 2nd parameter to function 'bar'" "true"
+interface Foo
+
+private fun Foo.bar(s: String, b: Boolean, i: Int) {}
+
+fun test(foo: Foo, b: Boolean) {
+    foo.bar("", b, 0)
+}

--- a/idea/testData/quickfix/changeSignature/addFunctionParameterForTypeMismatch1.kt
+++ b/idea/testData/quickfix/changeSignature/addFunctionParameterForTypeMismatch1.kt
@@ -1,5 +1,4 @@
 // "Add 1st parameter to function 'foo'" "true"
-// DISABLE-ERRORS
 fun foo(i1: Int, i2: Int, i3: Int, i4: Int) {
 }
 

--- a/idea/testData/quickfix/changeSignature/addFunctionParameterForTypeMismatch1.kt.after
+++ b/idea/testData/quickfix/changeSignature/addFunctionParameterForTypeMismatch1.kt.after
@@ -1,5 +1,4 @@
 // "Add 1st parameter to function 'foo'" "true"
-// DISABLE-ERRORS
 fun foo(i11: String, i1: Int, i2: Int, i3: Int, i4: Int) {
 }
 

--- a/idea/testData/quickfix/changeSignature/addFunctionParameterForTypeMismatch2.kt
+++ b/idea/testData/quickfix/changeSignature/addFunctionParameterForTypeMismatch2.kt
@@ -1,5 +1,4 @@
 // "Add 2nd parameter to function 'foo'" "true"
-// DISABLE-ERRORS
 fun foo(i1: Int, i2: Int, i3: Int, i4: Int) {
 }
 

--- a/idea/testData/quickfix/changeSignature/addFunctionParameterForTypeMismatch2.kt.after
+++ b/idea/testData/quickfix/changeSignature/addFunctionParameterForTypeMismatch2.kt.after
@@ -1,5 +1,4 @@
 // "Add 2nd parameter to function 'foo'" "true"
-// DISABLE-ERRORS
 fun foo(i1: Int, i21: String, i2: Int, i3: Int, i4: Int) {
 }
 

--- a/idea/testData/quickfix/changeSignature/addFunctionParameterForTypeMismatch3.kt
+++ b/idea/testData/quickfix/changeSignature/addFunctionParameterForTypeMismatch3.kt
@@ -1,5 +1,4 @@
 // "Add 3rd parameter to function 'foo'" "true"
-// DISABLE-ERRORS
 fun foo(i1: Int, i2: Int, i3: Int, i4: Int) {
 }
 

--- a/idea/testData/quickfix/changeSignature/addFunctionParameterForTypeMismatch3.kt.after
+++ b/idea/testData/quickfix/changeSignature/addFunctionParameterForTypeMismatch3.kt.after
@@ -1,5 +1,4 @@
 // "Add 3rd parameter to function 'foo'" "true"
-// DISABLE-ERRORS
 fun foo(i1: Int, i2: Int, i31: String, i3: Int, i4: Int) {
 }
 

--- a/idea/testData/quickfix/changeSignature/addFunctionParameterForTypeMismatch4.kt
+++ b/idea/testData/quickfix/changeSignature/addFunctionParameterForTypeMismatch4.kt
@@ -1,5 +1,4 @@
 // "Add 4th parameter to function 'foo'" "true"
-// DISABLE-ERRORS
 fun foo(i1: Int, i2: Int, i3: Int, i4: Int) {
 }
 

--- a/idea/testData/quickfix/changeSignature/addFunctionParameterForTypeMismatch4.kt.after
+++ b/idea/testData/quickfix/changeSignature/addFunctionParameterForTypeMismatch4.kt.after
@@ -1,5 +1,4 @@
 // "Add 4th parameter to function 'foo'" "true"
-// DISABLE-ERRORS
 fun foo(i1: Int, i2: Int, i3: Int, i41: String, i4: Int) {
 }
 

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -2243,6 +2243,11 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
             runTest("idea/testData/quickfix/changeSignature/addEnumConstructorParameter5.kt");
         }
 
+        @TestMetadata("addExtensionFunctionParameterForTypeMismatch.kt")
+        public void testAddExtensionFunctionParameterForTypeMismatch() throws Exception {
+            runTest("idea/testData/quickfix/changeSignature/addExtensionFunctionParameterForTypeMismatch.kt");
+        }
+
         @TestMetadata("addForItParameter.kt")
         public void testAddForItParameter() throws Exception {
             runTest("idea/testData/quickfix/changeSignature/addForItParameter.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-39557