### PR TITLE
KT-39200 False positive "Redundant qualifier name" with same-named member object and companion property

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/RemoveRedundantQualifierNameInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/RemoveRedundantQualifierNameInspection.kt
@@ -61,6 +61,7 @@ class RemoveRedundantQualifierNameInspection : AbstractKotlinInspection(), Clean
                 val expressionParent = expression.parent
                 if (expressionParent is KtDotQualifiedExpression || expressionParent is KtPackageDirective || expressionParent is KtImportDirective) return
                 val expressionForAnalyze = expression.firstExpressionWithoutReceiver() ?: return
+                if (expressionForAnalyze.selectorExpression?.text == expressionParent.getNonStrictParentOfType<KtProperty>()?.name) return
 
                 val originalExpression: KtExpression = expressionForAnalyze.parent as? KtClassLiteralExpression ?: expressionForAnalyze
 

--- a/idea/testData/inspectionsLocal/removeRedundantQualifierName/notApplicableSameNameVariable.kt
+++ b/idea/testData/inspectionsLocal/removeRedundantQualifierName/notApplicableSameNameVariable.kt
@@ -1,0 +1,8 @@
+// PROBLEM: none
+sealed class Foo {
+    object BAR : Foo()
+
+    companion object {
+        val BAR: Foo = <caret>Foo.BAR
+    }
+}

--- a/idea/testData/inspectionsLocal/removeRedundantQualifierName/notApplicableSameNameVariable2.kt
+++ b/idea/testData/inspectionsLocal/removeRedundantQualifierName/notApplicableSameNameVariable2.kt
@@ -1,0 +1,9 @@
+// PROBLEM: none
+// WITH_RUNTIME
+sealed class Foo {
+    object BAR : Foo()
+
+    companion object {
+        val BAR: Foo by lazy { <caret>Foo.BAR }
+    }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -9521,6 +9521,16 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
             runTest("idea/testData/inspectionsLocal/removeRedundantQualifierName/notApplicableOuterClass.kt");
         }
 
+        @TestMetadata("notApplicableSameNameVariable.kt")
+        public void testNotApplicableSameNameVariable() throws Exception {
+            runTest("idea/testData/inspectionsLocal/removeRedundantQualifierName/notApplicableSameNameVariable.kt");
+        }
+
+        @TestMetadata("notApplicableSameNameVariable2.kt")
+        public void testNotApplicableSameNameVariable2() throws Exception {
+            runTest("idea/testData/inspectionsLocal/removeRedundantQualifierName/notApplicableSameNameVariable2.kt");
+        }
+
         @TestMetadata("notApplicableThis.kt")
         public void testNotApplicableThis() throws Exception {
             runTest("idea/testData/inspectionsLocal/removeRedundantQualifierName/notApplicableThis.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-39200