### PR TITLE
The new release shouldn't have an existing version

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,6 @@
 ## Changelog
 
-## 1.3.72 - IDE plugins update
+## 1.3.73 - IDE plugins update
 
 ### Backend. JVM
 


### PR DESCRIPTION
Kotlin 1.3.72 has already been released, is this an unintentional mistake?