### PR TITLE
FIR serializer: regard property accessors with modifiers as non-default

### DIFF
--- a/compiler/fir/fir-serialization/src/org/jetbrains/kotlin/fir/serialization/FirElementSerializer.kt
+++ b/compiler/fir/fir-serialization/src/org/jetbrains/kotlin/fir/serialization/FirElementSerializer.kt
@@ -667,15 +667,18 @@ class FirElementSerializer private constructor(
     }
 
     private fun getAccessorFlags(accessor: FirPropertyAccessor, property: FirProperty): Int {
+        // [FirDefaultPropertyAccessor]---a property accessor without body---can still hold other information, such as annotations,
+        // user-contributed visibility, and modifiers, such as `external` or `inline`.
         val isDefault = accessor is FirDefaultPropertyAccessor &&
-                accessor.annotations.isEmpty() && accessor.visibility == property.visibility
+                accessor.annotations.isEmpty() && accessor.visibility == property.visibility &&
+                !accessor.isExternal && !accessor.isInline
         return Flags.getAccessorFlags(
             accessor.nonSourceAnnotations(session).isNotEmpty(),
             ProtoEnumFlags.visibility(normalizeVisibility(accessor)),
             ProtoEnumFlags.modality(accessor.modality!!),
             !isDefault,
-            accessor.status.isExternal,
-            accessor.status.isInline
+            accessor.isExternal,
+            accessor.isInline
         )
     }
 

--- a/compiler/testData/codegen/box/reflection/modifiers/functions.kt
+++ b/compiler/testData/codegen/box/reflection/modifiers/functions.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: +ReleaseCoroutines
-// IGNORE_BACKEND_FIR: JVM_IR
 // IGNORE_BACKEND: JS_IR
 // IGNORE_BACKEND: JS_IR_ES6
 // TODO: muted automatically, investigate should it be ran for JS or not


### PR DESCRIPTION
Even though the name of `FirDefaultPropertyAccessor` implies that it's default, it just means it doesn't have body. It can have some other information, e.g., annotations, user-contributed visibility (like `val x private get`), and modifiers (like `val y external get`). Those are technically not default, and their serialized flags should indicate that. Otherwise, reflective inspection via property reference won't catch such attributes.