### PR TITLE
[JVM] Extend stepping tests with <clinit> stepping.

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -401,6 +401,7 @@ class ExpressionCodegen(
 
                 // IR constructors have no receiver and return the new instance, but on JVM they are void-returning
                 // instance methods named <init>.
+                markLineNumber(expression)
                 mv.anew(asmType)
                 mv.dup()
             }

--- a/compiler/testData/debug/stepping/classObject.kt
+++ b/compiler/testData/debug/stepping/classObject.kt
@@ -23,6 +23,8 @@ fun box() {
 
 // LINENUMBERS
 // test.kt:14 box
+// test.kt:5 <clinit>
+// test.kt:6 <clinit>
 // test.kt:5 getProp0
 // LINENUMBERS JVM
 // test.kt:5 getProp0

--- a/compiler/testData/debug/stepping/constructorCall.kt
+++ b/compiler/testData/debug/stepping/constructorCall.kt
@@ -1,0 +1,33 @@
+// FILE: test.kt
+
+class A(val x: Int)
+
+fun box() {
+    A(1)
+    A(
+        2
+    )
+    A(3
+    )
+    A(
+        4)
+}
+
+// LINENUMBERS
+// test.kt:6 box
+// test.kt:3 <init>
+// test.kt:6 box
+// test.kt:7 box
+// test.kt:8 box
+// test.kt:7 box
+// test.kt:3 <init>
+// test.kt:7 box
+// test.kt:10 box
+// test.kt:3 <init>
+// test.kt:10 box
+// test.kt:12 box
+// test.kt:13 box
+// test.kt:12 box
+// test.kt:3 <init>
+// test.kt:12 box
+// test.kt:14 box

--- a/compiler/testData/debug/stepping/enum.kt
+++ b/compiler/testData/debug/stepping/enum.kt
@@ -1,7 +1,8 @@
 // FILE: test.kt
 
-enum class E {
-    E1;
+enum class E() {
+    A,
+    B;
 
     fun foo() = {
         prop
@@ -10,13 +11,43 @@ enum class E {
     val prop = 22
 }
 
-fun box() {
-    E.E1.foo()
+enum class E2(val y : Int) {
+    C(1),
+    D(
+        2
+    )
 }
 
+fun box() {
+    E.A.foo()
+    E2.C;
+}
+
+// JVM_IR maintains line number information in the class initializer for the
+// initialization of the enum entries. There is line number information for
+// the allocation of the object, for the evaluation of arguments to the
+// constructor, and for the call to the constructor. This is consistent
+// with the line number information generated for normal object allocation.
+
+// JVM has no line number information in <clinit> if there are no arguments
+// to the enum constructor. If there are arguments it has line number information
+// for the evaluation of the arguments constructor and for the constructor call,
+// but not for the allocation of the object.
+
 // LINENUMBERS
-// test.kt:14 box
-// test.kt:6 foo
-// test.kt:8 foo
-// test.kt:14 box
-// test.kt:15 box
+// test.kt:22 box
+// LINENUMBERS JVM_IR
+// test.kt:4 <clinit>
+// test.kt:5 <clinit>
+// LINENUMBERS
+// test.kt:7 foo
+// test.kt:9 foo
+// test.kt:22 box
+// test.kt:23 box
+// test.kt:15 <clinit>
+// LINENUMBERS JVM_IR
+// test.kt:16 <clinit>
+// LINENUMBERS
+// test.kt:17 <clinit>
+// test.kt:16 <clinit>
+// test.kt:24 box

--- a/compiler/testData/debug/stepping/initBlocksCompanion.kt
+++ b/compiler/testData/debug/stepping/initBlocksCompanion.kt
@@ -32,12 +32,19 @@ fun box() {
 
 // JVM backend has extra steps for getX and getS.
 
-// TODO: since these tests operate as step-into, we do not get any steps
-// in the <clinit> for the companion object. Maybe extend the test infrastructure
-// with directives to set break points in order to test this.
-
 // LINENUMBERS
 // test.kt:29 box
+// test.kt:7 <clinit>
+// test.kt:8 <clinit>
+// test.kt:9 <clinit>
+// test.kt:11 <clinit>
+// test.kt:13 <clinit>
+// test.kt:15 <clinit>
+// test.kt:16 <clinit>
+// test.kt:17 <clinit>
+// test.kt:19 <clinit>
+// test.kt:21 <clinit>
+// test.kt:22 <clinit>
 // test.kt:11 getX
 // LINENUMBERS JVM
 // test.kt:11 getX

--- a/compiler/tests/org/jetbrains/kotlin/codegen/debugInformation/IrSteppingTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/debugInformation/IrSteppingTestGenerated.java
@@ -98,6 +98,12 @@ public class IrSteppingTestGenerated extends AbstractIrSteppingTest {
     }
 
     @Test
+    @TestMetadata("constructorCall.kt")
+    public void testConstructorCall() throws Exception {
+        runTest("compiler/testData/debug/stepping/constructorCall.kt");
+    }
+
+    @Test
     @TestMetadata("defaultParameter.kt")
     public void testDefaultParameter() throws Exception {
         runTest("compiler/testData/debug/stepping/defaultParameter.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/debugInformation/SteppingTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/debugInformation/SteppingTestGenerated.java
@@ -98,6 +98,12 @@ public class SteppingTestGenerated extends AbstractSteppingTest {
     }
 
     @Test
+    @TestMetadata("constructorCall.kt")
+    public void testConstructorCall() throws Exception {
+        runTest("compiler/testData/debug/stepping/constructorCall.kt");
+    }
+
+    @Test
     @TestMetadata("defaultParameter.kt")
     public void testDefaultParameter() throws Exception {
         runTest("compiler/testData/debug/stepping/defaultParameter.kt");


### PR DESCRIPTION
In addition, made the stepping information for constructor calls
consistent across JVM_IR and JVM. For JVM_IR that stepping behavior
is consistent for enum constructor calls in <clinit> for JVM it
is not.