### PR TITLE
[JVM IR] KT-36985: $default respects @Deprecated

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/FunctionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/FunctionCodegen.kt
@@ -134,7 +134,7 @@ class FunctionCodegen(
 
     private fun IrFunction.calculateMethodFlags(): Int {
         if (origin == IrDeclarationOrigin.FUNCTION_FOR_DEFAULT_PARAMETER) {
-            return getVisibilityForDefaultArgumentStub() or Opcodes.ACC_SYNTHETIC.let {
+            return getVisibilityForDefaultArgumentStub() or Opcodes.ACC_SYNTHETIC or deprecationFlags.let {
                 if (this is IrConstructor) it else it or Opcodes.ACC_STATIC
             }
         }

--- a/compiler/testData/codegen/bytecodeListing/annotations/deprecatedJvmOverloads.kt
+++ b/compiler/testData/codegen/bytecodeListing/annotations/deprecatedJvmOverloads.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 // WITH_RUNTIME
 
 class Foo {


### PR DESCRIPTION
`$default` dispatch methods gains `@Deprecated` if the original function
with default arguments has it.