### PR TITLE
KT-30738 Inspection which replaces `.reduce { acc, i -> acc + i }` with `sum()`

### DIFF
--- a/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/double.kt
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/double.kt
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test(list: List<Double>) {
+    list.fold<caret>(0.0) { acc, i -> acc + i }
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/double.kt.after
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/double.kt.after
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test(list: List<Double>) {
+    list.sum()
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/doubleWithConst.kt
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/doubleWithConst.kt
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+const val ZERO = 0.0
+
+fun test(list: List<Double>) {
+    list.fold<caret>(ZERO) { acc, i -> acc + i }
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/doubleWithConst.kt.after
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/doubleWithConst.kt.after
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+const val ZERO = 0.0
+
+fun test(list: List<Double>) {
+    list.sum()
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/float.kt
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/float.kt
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test(list: List<Float>) {
+    list.fold<caret>(0.0F) { acc, i -> acc + i }
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/float.kt.after
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/float.kt.after
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test(list: List<Float>) {
+    list.sum()
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/floatWithConst.kt
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/floatWithConst.kt
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+const val ZERO = 0.0F
+
+fun test(list: List<Float>) {
+    list.fold<caret>(ZERO) { acc, i -> acc + i }
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/floatWithConst.kt.after
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/floatWithConst.kt.after
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+const val ZERO = 0.0F
+
+fun test(list: List<Float>) {
+    list.sum()
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/int.kt
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/int.kt
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test(list: List<Int>) {
+    list.fold<caret>(0) { acc, i -> acc + i }
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/int.kt.after
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/int.kt.after
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test(list: List<Int>) {
+    list.sum()
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/int2.kt
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/int2.kt
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test(list: List<Int>) {
+    list.fold<caret>(0) { acc, i -> i + acc }
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/int2.kt.after
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/int2.kt.after
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test(list: List<Int>) {
+    list.sum()
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/intWithConst.kt
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/intWithConst.kt
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+const val ZERO = 0
+
+fun test(list: List<Int>) {
+    list.fold<caret>(ZERO) { acc, i -> acc + i }
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/intWithConst.kt.after
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/intWithConst.kt.after
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+const val ZERO = 0
+
+fun test(list: List<Int>) {
+    list.sum()
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/long.kt
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/long.kt
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test(list: List<Long>) {
+    list.fold<caret>(0L) { acc, i -> acc + i }
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/long.kt.after
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/long.kt.after
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test(list: List<Long>) {
+    list.sum()
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/longWithConst.kt
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/longWithConst.kt
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+const val ZERO = 0L
+
+fun test(list: List<Long>) {
+    list.fold<caret>(ZERO) { acc, i -> acc + i }
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/longWithConst.kt.after
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/longWithConst.kt.after
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+const val ZERO = 0L
+
+fun test(list: List<Long>) {
+    list.sum()
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/notAppliable.kt
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/notAppliable.kt
@@ -1,0 +1,5 @@
+// PROBLEM: none
+// WITH_RUNTIME
+fun test(list: List<Int>) {
+    list.fold<caret>(0) { acc, i -> acc + 1 }
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/notAppliable2.kt
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/notAppliable2.kt
@@ -1,0 +1,5 @@
+// PROBLEM: none
+// WITH_RUNTIME
+fun test(list: List<Int>) {
+    list.fold<caret>(0) { acc, i -> 2 + acc }
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/notAppliableWithDifferentInitialType.kt
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/notAppliableWithDifferentInitialType.kt
@@ -1,0 +1,5 @@
+// PROBLEM: none
+// WITH_RUNTIME
+fun test(list: List<Int>) {
+    val sum: Double = list.fold<caret>(0.0) { acc, i -> acc + i }
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/notAppliableWithNotZero.kt
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/notAppliableWithNotZero.kt
@@ -1,0 +1,5 @@
+// PROBLEM: none
+// WITH_RUNTIME
+fun test(list: List<Int>) {
+    list.fold<caret>(1) { acc, i -> acc + i }
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCall/reduceToSum/double.kt
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCall/reduceToSum/double.kt
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test(list: List<Double>) {
+    list.reduce<caret> { acc, i -> acc + i }
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCall/reduceToSum/double.kt.after
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCall/reduceToSum/double.kt.after
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test(list: List<Double>) {
+    list.sum()
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCall/reduceToSum/float.kt
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCall/reduceToSum/float.kt
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test(list: List<Float>) {
+    list.reduce<caret> { acc, i -> acc + i }
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCall/reduceToSum/float.kt.after
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCall/reduceToSum/float.kt.after
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test(list: List<Float>) {
+    list.sum()
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCall/reduceToSum/int.kt
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCall/reduceToSum/int.kt
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test(list: List<Int>) {
+    list.reduce<caret> { acc, i -> acc + i }
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCall/reduceToSum/int.kt.after
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCall/reduceToSum/int.kt.after
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test(list: List<Int>) {
+    list.sum()
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCall/reduceToSum/int2.kt
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCall/reduceToSum/int2.kt
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test(list: List<Int>) {
+    list.reduce<caret> { acc, i -> i + acc }
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCall/reduceToSum/int2.kt.after
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCall/reduceToSum/int2.kt.after
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test(list: List<Int>) {
+    list.sum()
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCall/reduceToSum/long.kt
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCall/reduceToSum/long.kt
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test(list: List<Long>) {
+    list.reduce<caret> { acc, i -> acc + i }
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCall/reduceToSum/long.kt.after
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCall/reduceToSum/long.kt.after
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test(list: List<Long>) {
+    list.sum()
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCall/reduceToSum/notAppliable.kt
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCall/reduceToSum/notAppliable.kt
@@ -1,0 +1,5 @@
+// PROBLEM: none
+// WITH_RUNTIME
+fun test(list: List<Int>) {
+    list.reduce<caret> { acc, i -> acc + 1 }
+}

--- a/idea/testData/inspectionsLocal/collections/simplifiableCall/reduceToSum/notAppliable2.kt
+++ b/idea/testData/inspectionsLocal/collections/simplifiableCall/reduceToSum/notAppliable2.kt
@@ -1,0 +1,5 @@
+// PROBLEM: none
+// WITH_RUNTIME
+fun test(list: List<Int>) {
+    list.reduce<caret> { acc, i -> 2 + acc }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -1643,6 +1643,132 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
             public void testSimple2() throws Exception {
                 runTest("idea/testData/inspectionsLocal/collections/simplifiableCall/simple2.kt");
             }
+
+            @TestMetadata("idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum")
+            @TestDataPath("$PROJECT_ROOT")
+            @RunWith(JUnit3RunnerWithInners.class)
+            public static class FoldToSum extends AbstractLocalInspectionTest {
+                private void runTest(String testDataFilePath) throws Exception {
+                    KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
+                }
+
+                public void testAllFilesPresentInFoldToSum() throws Exception {
+                    KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum"), Pattern.compile("^([\\w\\-_]+)\\.(kt|kts)$"), null, true);
+                }
+
+                @TestMetadata("double.kt")
+                public void testDouble() throws Exception {
+                    runTest("idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/double.kt");
+                }
+
+                @TestMetadata("doubleWithConst.kt")
+                public void testDoubleWithConst() throws Exception {
+                    runTest("idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/doubleWithConst.kt");
+                }
+
+                @TestMetadata("float.kt")
+                public void testFloat() throws Exception {
+                    runTest("idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/float.kt");
+                }
+
+                @TestMetadata("floatWithConst.kt")
+                public void testFloatWithConst() throws Exception {
+                    runTest("idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/floatWithConst.kt");
+                }
+
+                @TestMetadata("int.kt")
+                public void testInt() throws Exception {
+                    runTest("idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/int.kt");
+                }
+
+                @TestMetadata("int2.kt")
+                public void testInt2() throws Exception {
+                    runTest("idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/int2.kt");
+                }
+
+                @TestMetadata("intWithConst.kt")
+                public void testIntWithConst() throws Exception {
+                    runTest("idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/intWithConst.kt");
+                }
+
+                @TestMetadata("long.kt")
+                public void testLong() throws Exception {
+                    runTest("idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/long.kt");
+                }
+
+                @TestMetadata("longWithConst.kt")
+                public void testLongWithConst() throws Exception {
+                    runTest("idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/longWithConst.kt");
+                }
+
+                @TestMetadata("notAppliable.kt")
+                public void testNotAppliable() throws Exception {
+                    runTest("idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/notAppliable.kt");
+                }
+
+                @TestMetadata("notAppliable2.kt")
+                public void testNotAppliable2() throws Exception {
+                    runTest("idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/notAppliable2.kt");
+                }
+
+                @TestMetadata("notAppliableWithDifferentInitialType.kt")
+                public void testNotAppliableWithDifferentInitialType() throws Exception {
+                    runTest("idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/notAppliableWithDifferentInitialType.kt");
+                }
+
+                @TestMetadata("notAppliableWithNotZero.kt")
+                public void testNotAppliableWithNotZero() throws Exception {
+                    runTest("idea/testData/inspectionsLocal/collections/simplifiableCall/foldToSum/notAppliableWithNotZero.kt");
+                }
+            }
+
+            @TestMetadata("idea/testData/inspectionsLocal/collections/simplifiableCall/reduceToSum")
+            @TestDataPath("$PROJECT_ROOT")
+            @RunWith(JUnit3RunnerWithInners.class)
+            public static class ReduceToSum extends AbstractLocalInspectionTest {
+                private void runTest(String testDataFilePath) throws Exception {
+                    KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
+                }
+
+                public void testAllFilesPresentInReduceToSum() throws Exception {
+                    KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("idea/testData/inspectionsLocal/collections/simplifiableCall/reduceToSum"), Pattern.compile("^([\\w\\-_]+)\\.(kt|kts)$"), null, true);
+                }
+
+                @TestMetadata("double.kt")
+                public void testDouble() throws Exception {
+                    runTest("idea/testData/inspectionsLocal/collections/simplifiableCall/reduceToSum/double.kt");
+                }
+
+                @TestMetadata("float.kt")
+                public void testFloat() throws Exception {
+                    runTest("idea/testData/inspectionsLocal/collections/simplifiableCall/reduceToSum/float.kt");
+                }
+
+                @TestMetadata("int.kt")
+                public void testInt() throws Exception {
+                    runTest("idea/testData/inspectionsLocal/collections/simplifiableCall/reduceToSum/int.kt");
+                }
+
+                @TestMetadata("int2.kt")
+                public void testInt2() throws Exception {
+                    runTest("idea/testData/inspectionsLocal/collections/simplifiableCall/reduceToSum/int2.kt");
+                }
+
+                @TestMetadata("long.kt")
+                public void testLong() throws Exception {
+                    runTest("idea/testData/inspectionsLocal/collections/simplifiableCall/reduceToSum/long.kt");
+                }
+
+                @TestMetadata("notAppliable.kt")
+                public void testNotAppliable() throws Exception {
+                    runTest("idea/testData/inspectionsLocal/collections/simplifiableCall/reduceToSum/notAppliable.kt");
+                }
+
+                @TestMetadata("notAppliable2.kt")
+                public void testNotAppliable2() throws Exception {
+                    runTest("idea/testData/inspectionsLocal/collections/simplifiableCall/reduceToSum/notAppliable2.kt");
+                }
+            }
         }
 
         @TestMetadata("idea/testData/inspectionsLocal/collections/simplifiableCallChain")


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-30738