### PR TITLE
Coroutines: Fix RedundantLocalsEliminationMethodTransformer

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/coroutines/RedundantLocalsEliminationMethodTransformer.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/coroutines/RedundantLocalsEliminationMethodTransformer.kt
@@ -5,177 +5,127 @@
 
 package org.jetbrains.kotlin.codegen.coroutines
 
-import org.jetbrains.kotlin.codegen.inline.nodeText
 import org.jetbrains.kotlin.codegen.optimization.boxing.isUnitInstance
 import org.jetbrains.kotlin.codegen.optimization.common.MethodAnalyzer
 import org.jetbrains.kotlin.codegen.optimization.common.asSequence
 import org.jetbrains.kotlin.codegen.optimization.common.removeAll
 import org.jetbrains.kotlin.codegen.optimization.fixStack.top
 import org.jetbrains.kotlin.codegen.optimization.transformer.MethodTransformer
-import org.jetbrains.kotlin.resolve.jvm.AsmTypes
 import org.jetbrains.org.objectweb.asm.Opcodes
-import org.jetbrains.org.objectweb.asm.Type
-import org.jetbrains.org.objectweb.asm.tree.*
-import org.jetbrains.org.objectweb.asm.tree.analysis.BasicInterpreter
-import org.jetbrains.org.objectweb.asm.tree.analysis.BasicValue
-import org.jetbrains.org.objectweb.asm.tree.analysis.Frame
+import org.jetbrains.org.objectweb.asm.tree.AbstractInsnNode
+import org.jetbrains.org.objectweb.asm.tree.LabelNode
+import org.jetbrains.org.objectweb.asm.tree.MethodNode
+import org.jetbrains.org.objectweb.asm.tree.VarInsnNode
+import org.jetbrains.org.objectweb.asm.tree.analysis.SourceInterpreter
+import org.jetbrains.org.objectweb.asm.tree.analysis.SourceValue
 
-private class PossibleSpilledValue(val source: AbstractInsnNode, type: Type?) : BasicValue(type) {
-    val usages = mutableSetOf<AbstractInsnNode>()
+// A [SourceInterpreter] which keeps track of all use sites for "GETSTATIC Unit" instructions.
+private class SourceInterpreterWithUnitUsage : SourceInterpreter(Opcodes.API_VERSION) {
+    val unitUsageInformation = mutableMapOf<AbstractInsnNode, MutableSet<AbstractInsnNode>>()
 
-    override fun toString(): String = when {
-        source.opcode == Opcodes.ALOAD -> "" + (source as VarInsnNode).`var`
-        source.isUnitInstance() -> "U"
-        else -> error("unreachable")
-    }
-
-    override fun equals(other: Any?): Boolean =
-        other is PossibleSpilledValue && source == other.source
-
-    override fun hashCode(): Int = super.hashCode() xor source.hashCode()
-}
-
-private object NonSpillableValue : BasicValue(AsmTypes.OBJECT_TYPE) {
-    override fun equals(other: Any?): Boolean = other is NonSpillableValue
-
-    override fun toString(): String = "N"
-}
-
-private object ConstructedValue : BasicValue(AsmTypes.OBJECT_TYPE) {
-    override fun equals(other: Any?): Boolean = other is ConstructedValue
-
-    override fun toString(): String = "C"
-}
-
-fun BasicValue?.nonspillable(): BasicValue? = if (this?.type?.sort == Type.OBJECT) NonSpillableValue else this
-
-private class RedundantSpillingInterpreter : BasicInterpreter(Opcodes.API_VERSION) {
-    val possibleSpilledValues = mutableSetOf<PossibleSpilledValue>()
-
-    override fun newOperation(insn: AbstractInsnNode): BasicValue? {
-        if (insn.opcode == Opcodes.NEW) return ConstructedValue
-        val basicValue = super.newOperation(insn)
-        return if (insn.isUnitInstance())
-            // Unit instances come from inlining suspend functions returning Unit.
-            // They can be spilled before they are eventually popped.
-            // Track them.
-            PossibleSpilledValue(insn, basicValue.type).also { possibleSpilledValues += it }
-        else basicValue.nonspillable()
-    }
-
-    override fun copyOperation(insn: AbstractInsnNode, value: BasicValue?): BasicValue? =
-        when (value) {
-            is ConstructedValue -> value
-            is PossibleSpilledValue -> {
-                value.usages += insn
-                if (insn.opcode == Opcodes.ALOAD || insn.opcode == Opcodes.ASTORE) value
-                else value.nonspillable()
+    private fun markUnitUsage(use: AbstractInsnNode, defs: SourceValue?) {
+        defs?.insns?.forEach { def ->
+            if (def.isUnitInstance()) {
+                unitUsageInformation.getOrPut(def) { mutableSetOf() } += use
             }
-            else -> value?.nonspillable()
         }
-
-    override fun naryOperation(insn: AbstractInsnNode, values: MutableList<out BasicValue?>): BasicValue? {
-        for (value in values.filterIsInstance<PossibleSpilledValue>()) {
-            value.usages += insn
-        }
-        return super.naryOperation(insn, values)?.nonspillable()
     }
 
-    override fun merge(v: BasicValue?, w: BasicValue?): BasicValue? =
-        if (v is PossibleSpilledValue && w is PossibleSpilledValue && v.source == w.source) v
-        else v?.nonspillable()
+    fun run(internalClassName: String, methodNode: MethodNode): SourceFrames {
+        val sourceFrames = MethodAnalyzer<SourceValue>(internalClassName, methodNode, this).analyze()
+        // The ASM analyzer does not visit POP instructions, so we do so here.
+        for ((insn, frame) in methodNode.instructions.asSequence().zip(sourceFrames.asSequence())) {
+            if (frame != null && insn.opcode == Opcodes.POP) {
+                markUnitUsage(insn, frame.top())
+            }
+        }
+        return sourceFrames
+    }
+
+    override fun copyOperation(insn: AbstractInsnNode, value: SourceValue?): SourceValue? {
+        markUnitUsage(insn, value)
+        return super.copyOperation(insn, value)
+    }
+
+    override fun unaryOperation(insn: AbstractInsnNode, value: SourceValue?): SourceValue {
+        markUnitUsage(insn, value)
+        return super.unaryOperation(insn, value)
+    }
+
+    override fun binaryOperation(insn: AbstractInsnNode, value1: SourceValue?, value2: SourceValue?): SourceValue {
+        markUnitUsage(insn, value1)
+        markUnitUsage(insn, value2)
+        return super.binaryOperation(insn, value1, value2)
+    }
+
+    override fun ternaryOperation(insn: AbstractInsnNode, value1: SourceValue?, value2: SourceValue?, value3: SourceValue?): SourceValue {
+        markUnitUsage(insn, value1)
+        markUnitUsage(insn, value2)
+        markUnitUsage(insn, value3)
+        return super.ternaryOperation(insn, value1, value2, value3)
+    }
+
+    override fun naryOperation(insn: AbstractInsnNode, values: List<SourceValue>?): SourceValue {
+        values?.forEach { markUnitUsage(insn, it) }
+        return super.naryOperation(insn, values)
+    }
 }
 
-// Inliner emits a lot of locals during inlining.
-// Remove all of them since these locals are
-//  1) going to be spilled into continuation object
-//  2) breaking tail-call elimination
+/**
+ * This pass removes unused Unit values and locals. These typically occur as a result of inlining and could
+ * end up spilling into the continuation object or breaking tail-call elimination.
+ *
+ * Concretely, we remove "GETSTATIC kotlin/Unit.INSTANCE" instructions if they are unused, or all uses are either
+ * POP instructions, or ASTORE instructions to locals which are never read and are not named local variables.
+ *
+ * This pass does not touch [suspensionPoints], as later passes rely on the bytecode patterns around suspension points.
+ */
 internal class RedundantLocalsEliminationMethodTransformer(private val suspensionPoints: List<SuspensionPoint>) : MethodTransformer() {
     override fun transform(internalClassName: String, methodNode: MethodNode) {
-        val interpreter = RedundantSpillingInterpreter()
-        val frames = MethodAnalyzer<BasicValue>(internalClassName, methodNode, interpreter).analyze()
+        val interpreter = SourceInterpreterWithUnitUsage()
+        val sourceFrames = interpreter.run(internalClassName, methodNode)
 
+        // Mark all ASTORE instructions which are read later or are visible in the debugger.
+        val liveStores = mutableSetOf<AbstractInsnNode>()
         val toDelete = mutableSetOf<AbstractInsnNode>()
-        for (spilledValue in interpreter.possibleSpilledValues.filter { it.usages.isNotEmpty() }) {
-            @Suppress("UNCHECKED_CAST")
-            val aloads = spilledValue.usages.filter { it.opcode == Opcodes.ALOAD } as List<VarInsnNode>
-
-            if (aloads.isEmpty()) continue
-
-            val slot = aloads.first().`var`
-
-            if (aloads.any { it.`var` != slot }) continue
-            for (aload in aloads) {
-                methodNode.instructions.set(aload, spilledValue.source.clone())
-            }
-
-            toDelete.addAll(spilledValue.usages.filter { it.opcode == Opcodes.ASTORE })
-            toDelete.add(spilledValue.source)
-        }
-
-        for (pop in methodNode.instructions.asSequence().filter { it.opcode == Opcodes.POP }) {
-            val value = (frames[methodNode.instructions.indexOf(pop)]?.top() as? PossibleSpilledValue) ?: continue
-            if (value.usages.isEmpty() && value.source !in suspensionPoints) {
-                toDelete.add(pop)
-                toDelete.add(value.source)
-            }
-        }
-
-        // Remove unreachable instructions to simplify further analyses
-        for (index in frames.indices) {
-            if (frames[index] == null) {
-                val insn = methodNode.instructions[index]
+        for ((insn, frame) in methodNode.instructions.asSequence().zip(sourceFrames.asSequence())) {
+            if (frame == null) {
+                // Mark all unreachable instructions for deletion. That is except for labels, which may be attached to a local variable.
                 if (insn !is LabelNode) {
-                    toDelete.add(insn)
+                    toDelete += insn
+                }
+            } else if (insn is VarInsnNode) {
+                when (insn.opcode) {
+                    Opcodes.ALOAD ->
+                        liveStores += frame.getLocal(insn.`var`)?.insns ?: continue
+                    Opcodes.ASTORE ->
+                        // Stores to local variables need to be preserved, since they are visible in the debugger.
+                        if (methodNode.localVariables?.any { it.index == insn.`var` } == true)
+                            liveStores += insn
                 }
             }
+        }
+
+        // Mark all "GETSTATIC kotlin/Unit.INSTANCE" instructions which are only used as the
+        // single argument to dead stores for deletion.
+        outer@ for ((unit, uses) in interpreter.unitUsageInformation) {
+            if (unit in suspensionPoints)
+                continue
+
+            for (use in uses) {
+                if ((use.opcode != Opcodes.ASTORE || use in liveStores) && use.opcode != Opcodes.POP) {
+                    continue@outer
+                }
+
+                val index = methodNode.instructions.indexOf(use)
+                if (sourceFrames[index]?.top()?.insns?.size != 1) {
+                    continue@outer
+                }
+            }
+            toDelete += unit
+            toDelete += uses
         }
 
         methodNode.instructions.removeAll(toDelete)
     }
-
-    private fun AbstractInsnNode.clone() = when (this) {
-        is FieldInsnNode -> FieldInsnNode(opcode, owner, name, desc)
-        is VarInsnNode -> VarInsnNode(opcode, `var`)
-        is InsnNode -> InsnNode(opcode)
-        is TypeInsnNode -> TypeInsnNode(opcode, desc)
-        else -> error("clone of $this is not implemented yet")
-    }
-}
-
-// Handy debugging routing
-@Suppress("unused")
-fun MethodNode.nodeTextWithFrames(frames: Array<*>): String {
-    var insns = nodeText.split("\n")
-    val first = insns.indexOfLast { it.trim().startsWith("@") } + 1
-    var last = insns.indexOfFirst { it.trim().startsWith("LOCALVARIABLE") }
-    if (last < 0) last = insns.size
-    val prefix = insns.subList(0, first).joinToString(separator = "\n")
-    val postfix = insns.subList(last, insns.size).joinToString(separator = "\n")
-    insns = insns.subList(first, last)
-    if (insns.any { it.contains("TABLESWITCH") }) {
-        var insideTableSwitch = false
-        var buffer = ""
-        val res = arrayListOf<String>()
-        for (insn in insns) {
-            if (insn.contains("TABLESWITCH")) {
-                insideTableSwitch = true
-            }
-            if (insideTableSwitch) {
-                buffer += insn
-                if (insn.contains("default")) {
-                    insideTableSwitch = false
-                    res += buffer
-                    buffer = ""
-                    continue
-                }
-            } else {
-                res += insn
-            }
-        }
-        insns = res
-    }
-    return prefix + "\n" + insns.withIndex().joinToString(separator = "\n") { (index, insn) ->
-        if (index >= frames.size) "N/A\t$insn" else "${frames[index]}\t$insn"
-    } + "\n" + postfix
 }

--- a/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
@@ -8296,6 +8296,11 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
                 runTestWithPackageReplacement("compiler/testData/codegen/box/coroutines/unitTypeReturn/coroutineReturn.kt", "kotlin.coroutines");
             }
 
+            @TestMetadata("inlineUnitFunction.kt")
+            public void testInlineUnitFunction() throws Exception {
+                runTest("compiler/testData/codegen/box/coroutines/unitTypeReturn/inlineUnitFunction.kt");
+            }
+
             @TestMetadata("interfaceDelegation.kt")
             public void testInterfaceDelegation() throws Exception {
                 runTest("compiler/testData/codegen/box/coroutines/unitTypeReturn/interfaceDelegation.kt");

--- a/compiler/testData/codegen/box/coroutines/unitTypeReturn/inlineUnitFunction.kt
+++ b/compiler/testData/codegen/box/coroutines/unitTypeReturn/inlineUnitFunction.kt
@@ -1,0 +1,7 @@
+suspend fun f(x: Any?) {
+    x?.let { Unit } ?: Unit
+}
+
+fun box(): String {
+    return "OK"
+}

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -9491,6 +9491,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
                 runTestWithPackageReplacement("compiler/testData/codegen/box/coroutines/unitTypeReturn/coroutineReturn.kt", "kotlin.coroutines");
             }
 
+            @TestMetadata("inlineUnitFunction.kt")
+            public void testInlineUnitFunction() throws Exception {
+                runTest("compiler/testData/codegen/box/coroutines/unitTypeReturn/inlineUnitFunction.kt");
+            }
+
             @TestMetadata("interfaceDelegation.kt")
             public void testInterfaceDelegation() throws Exception {
                 runTest("compiler/testData/codegen/box/coroutines/unitTypeReturn/interfaceDelegation.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -9491,6 +9491,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
                 runTestWithPackageReplacement("compiler/testData/codegen/box/coroutines/unitTypeReturn/coroutineReturn.kt", "kotlin.coroutines");
             }
 
+            @TestMetadata("inlineUnitFunction.kt")
+            public void testInlineUnitFunction() throws Exception {
+                runTest("compiler/testData/codegen/box/coroutines/unitTypeReturn/inlineUnitFunction.kt");
+            }
+
             @TestMetadata("interfaceDelegation.kt")
             public void testInterfaceDelegation() throws Exception {
                 runTest("compiler/testData/codegen/box/coroutines/unitTypeReturn/interfaceDelegation.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -8296,6 +8296,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
                 runTestWithPackageReplacement("compiler/testData/codegen/box/coroutines/unitTypeReturn/coroutineReturn.kt", "kotlin.coroutines");
             }
 
+            @TestMetadata("inlineUnitFunction.kt")
+            public void testInlineUnitFunction() throws Exception {
+                runTest("compiler/testData/codegen/box/coroutines/unitTypeReturn/inlineUnitFunction.kt");
+            }
+
             @TestMetadata("interfaceDelegation.kt")
             public void testInterfaceDelegation() throws Exception {
                 runTest("compiler/testData/codegen/box/coroutines/unitTypeReturn/interfaceDelegation.kt");

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
@@ -7021,6 +7021,11 @@ public class IrJsCodegenBoxES6TestGenerated extends AbstractIrJsCodegenBoxES6Tes
                 runTestWithPackageReplacement("compiler/testData/codegen/box/coroutines/unitTypeReturn/coroutineReturn.kt", "kotlin.coroutines");
             }
 
+            @TestMetadata("inlineUnitFunction.kt")
+            public void testInlineUnitFunction() throws Exception {
+                runTest("compiler/testData/codegen/box/coroutines/unitTypeReturn/inlineUnitFunction.kt");
+            }
+
             @TestMetadata("interfaceDelegation.kt")
             public void testInterfaceDelegation() throws Exception {
                 runTest("compiler/testData/codegen/box/coroutines/unitTypeReturn/interfaceDelegation.kt");

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -7031,6 +7031,11 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
                 runTestWithPackageReplacement("compiler/testData/codegen/box/coroutines/unitTypeReturn/coroutineReturn.kt", "kotlin.coroutines");
             }
 
+            @TestMetadata("inlineUnitFunction.kt")
+            public void testInlineUnitFunction() throws Exception {
+                runTest("compiler/testData/codegen/box/coroutines/unitTypeReturn/inlineUnitFunction.kt");
+            }
+
             @TestMetadata("interfaceDelegation.kt")
             public void testInterfaceDelegation() throws Exception {
                 runTest("compiler/testData/codegen/box/coroutines/unitTypeReturn/interfaceDelegation.kt");

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -7031,6 +7031,11 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
                 runTestWithPackageReplacement("compiler/testData/codegen/box/coroutines/unitTypeReturn/coroutineReturn.kt", "kotlin.coroutines");
             }
 
+            @TestMetadata("inlineUnitFunction.kt")
+            public void testInlineUnitFunction() throws Exception {
+                runTest("compiler/testData/codegen/box/coroutines/unitTypeReturn/inlineUnitFunction.kt");
+            }
+
             @TestMetadata("interfaceDelegation.kt")
             public void testInterfaceDelegation() throws Exception {
                 runTest("compiler/testData/codegen/box/coroutines/unitTypeReturn/interfaceDelegation.kt");


### PR DESCRIPTION
`RedundantLocalsEliminationMethodTransformer` does not take control flow joins into account when collecting use sites for Unit values. For example, in code such as
```kotlin
x?.let { Unit } ?: Unit
```
the transformer will erroneously remove the `GETSTATIC kotlin/Unit.INSTANCE` instruction from the lambda argument to `let`, leading to incompatible stack heights at the join point after the safe call.

The transformer also does not preserve stores to local variables. This is probably a non-issue in practice, since we're talking about local variables of type Unit, but is still something we should take into account.

This PR changes `RedundantLocalsEliminationMethodTransformer` to use ASMs `SourceInterpreter` to compute usage information for all instructions, instead of a custom interpreter which only collects liveness information for use sites of unit values.