### PR TITLE
KAPT: Fix serialization of class structure data

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/incremental/ClasspathAnalyzer.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/incremental/ClasspathAnalyzer.kt
@@ -101,6 +101,7 @@ class ClasspathEntryData : Serializable {
 
     @Transient
     var classAbiHash = mutableMapOf<String, ByteArray>()
+
     @Transient
     var classDependencies = mutableMapOf<String, ClassDependencies>()
 
@@ -111,7 +112,9 @@ class ClasspathEntryData : Serializable {
 
         val names = LinkedHashMap<String, Int>()
         sortedClassDependencies.forEach {
-            names[it.key] = names.size
+            if (it.key !in names) {
+                names[it.key] = names.size
+            }
             it.value.abiTypes.forEach { type ->
                 if (type !in names) names[type] = names.size
             }


### PR DESCRIPTION
When serializing ClasspathEntryData, ids assigned to types were
incorrect, resulting in corrupt data when deserializing files. This
happened if there were dependencies between classes.

Fixes: https://youtrack.jetbrains.com/issue/KT-39876
Test: ClasspathAnalyzerTest