### PR TITLE
KAPT: Fix error reporting

### DIFF
--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/annotationProcessing.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/annotationProcessing.kt
@@ -13,12 +13,8 @@ import com.sun.tools.javac.processing.JavacFiler
 import com.sun.tools.javac.processing.JavacProcessingEnvironment
 import com.sun.tools.javac.tree.JCTree
 import org.jetbrains.kotlin.base.kapt3.KaptFlag
-import org.jetbrains.kotlin.kapt3.base.incremental.GeneratedTypesTaskListener
-import org.jetbrains.kotlin.kapt3.base.incremental.IncrementalProcessor
-import org.jetbrains.kotlin.kapt3.base.incremental.MentionedTypesTaskListener
-import org.jetbrains.kotlin.kapt3.base.util.KaptBaseError
-import org.jetbrains.kotlin.kapt3.base.util.isJava9OrLater
-import org.jetbrains.kotlin.kapt3.base.util.measureTimeMillisWithResult
+import org.jetbrains.kotlin.kapt3.base.incremental.*
+import org.jetbrains.kotlin.kapt3.base.util.*
 import java.io.File
 import javax.annotation.processing.ProcessingEnvironment
 import javax.annotation.processing.Processor
@@ -84,23 +80,14 @@ fun KaptContext.doAnnotationProcessing(
             throw KaptBaseError(KaptBaseError.Kind.EXCEPTION, e.cause ?: e)
         }
 
-        cacheManager?.updateCache(processors)
+        cacheManager?.updateCache(processors, sourcesStructureListener?.failure != null)
 
         sourcesStructureListener?.let {
             if (logger.isVerbose) {
                 logger.info("Analyzing sources structure took ${it.time}[ms].")
             }
         }
-        if (cacheManager != null) {
-            val missingIncrementalSupport = processors.filter { it.isMissingIncrementalSupport() }
-            if (missingIncrementalSupport.isNotEmpty()) {
-                val nonIncremental = missingIncrementalSupport.map { "${it.processorName} (${it.incrementalSupportType})" }
-                logger.warn(
-                    "Incremental annotation processing requested, but support is disabled because the following " +
-                            "processors are not incremental: ${nonIncremental.joinToString()}."
-                )
-            }
-        }
+        reportIfRunningNonIncrementally(sourcesStructureListener, cacheManager, logger, processors)
 
         val log = compilerAfterAP.log
 
@@ -135,6 +122,31 @@ private fun showProcessorTimings(wrappedProcessors: List<ProcessorWrapper>, logg
     logger("Annotation processor stats:")
     wrappedProcessors.forEach { processor ->
         logger(processor.renderSpentTime())
+    }
+}
+
+private fun reportIfRunningNonIncrementally(
+    listener: MentionedTypesTaskListener?,
+    cacheManager: JavaClassCacheManager?,
+    logger: KaptLogger,
+    processors: List<IncrementalProcessor>
+) {
+    listener ?: return
+    cacheManager ?: return
+
+    listener.failure?.let { failure ->
+        logger.warn("\n${failure.failureReason}")
+        logger.info("\n${failure.stacktrace}")
+        return
+    }
+
+    val missingIncrementalSupport = processors.filter { it.isMissingIncrementalSupport() }
+    if (missingIncrementalSupport.isNotEmpty()) {
+        val nonIncremental = missingIncrementalSupport.map { "${it.processorName} (${it.incrementalSupportType})" }
+        logger.warn(
+            "Incremental annotation processing requested, but support is disabled because the following " +
+                    "processors are not incremental: ${nonIncremental.joinToString()}."
+        )
     }
 }
 

--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/incremental/cache.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/incremental/cache.kt
@@ -18,8 +18,8 @@ class JavaClassCacheManager(val file: File) : Closeable {
 
     private var closed = false
 
-    fun updateCache(processors: List<IncrementalProcessor>) {
-        if (!aptCache.updateCache(processors)) {
+    fun updateCache(processors: List<IncrementalProcessor>, failedToAnalyzeSources: Boolean) {
+        if (failedToAnalyzeSources || !aptCache.updateCache(processors)) {
             javaCache.invalidateAll()
         }
     }

--- a/plugins/kapt3/kapt3-base/test/org/jetbrains/kotlin/kapt3/base/incremental/InheritedAnnotationTest.kt
+++ b/plugins/kapt3/kapt3-base/test/org/jetbrains/kotlin/kapt3/base/incremental/InheritedAnnotationTest.kt
@@ -45,7 +45,7 @@ class TestInheritedAnnotation {
                 listOf(processor),
                 generatedSources
             ) { elementUtils, trees -> MentionedTypesTaskListener(cache.javaCache, elementUtils, trees) }
-            cache.updateCache(listOf(processor))
+            cache.updateCache(listOf(processor), false)
         }
     }
 

--- a/plugins/kapt3/kapt3-base/test/org/jetbrains/kotlin/kapt3/base/incremental/ReferencedContantsTest.kt
+++ b/plugins/kapt3/kapt3-base/test/org/jetbrains/kotlin/kapt3/base/incremental/ReferencedContantsTest.kt
@@ -48,7 +48,7 @@ class ReferencedConstantsTest {
                 generatedSources,
                 listOf(compiledClasses)
             ) { elements, trees -> MentionedTypesTaskListener(cache.javaCache, elements, trees) }
-            cache.updateCache(listOf(processor))
+            cache.updateCache(listOf(processor), false)
         }
     }
 

--- a/plugins/kapt3/kapt3-base/test/org/jetbrains/kotlin/kapt3/base/incremental/TestComplexIncrementalAptCache.kt
+++ b/plugins/kapt3/kapt3-base/test/org/jetbrains/kotlin/kapt3/base/incremental/TestComplexIncrementalAptCache.kt
@@ -47,7 +47,7 @@ class TestComplexIncrementalAptCache {
                 listOf(processor),
                 generatedSources
             ) { elements, trees -> MentionedTypesTaskListener(cache.javaCache, elements, trees) }
-            cache.updateCache(listOf(processor))
+            cache.updateCache(listOf(processor), false)
         }
     }
 

--- a/plugins/kapt3/kapt3-base/test/org/jetbrains/kotlin/kapt3/base/incremental/TestSimpleIncrementalAptCache.kt
+++ b/plugins/kapt3/kapt3-base/test/org/jetbrains/kotlin/kapt3/base/incremental/TestSimpleIncrementalAptCache.kt
@@ -72,6 +72,6 @@ class TestSimpleIncrementalAptCache {
             listOf(processor),
             generatedSources
         ) { elementUtils, trees -> MentionedTypesTaskListener(cache.javaCache, elementUtils, trees) }
-        cache.updateCache(listOf(processor))
+        cache.updateCache(listOf(processor), false)
     }
 }


### PR DESCRIPTION
When incremental analysis is unable to run, handle
failure gracefully. More info will be provided by
compiler diagnostics.

Fixes KT-36302