### PR TITLE
FIR2IR: apply IrConstTransformer to other annotation containers with array values

### DIFF
--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/ConversionUtils.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/ConversionUtils.kt
@@ -446,9 +446,6 @@ internal fun FirReference.statementOrigin(): IrStatementOrigin? {
     }
 }
 
-fun FirClass<*>.getPrimaryConstructorIfAny(): FirConstructor? =
-    declarations.filterIsInstance<FirConstructor>().firstOrNull()?.takeIf { it.isPrimary }
-
 internal fun IrDeclarationParent.declareThisReceiverParameter(
     symbolTable: SymbolTable,
     thisType: IrType,

--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrConverter.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrConverter.kt
@@ -10,7 +10,6 @@ import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.backend.generators.AnnotationGenerator
 import org.jetbrains.kotlin.fir.backend.generators.CallAndReferenceGenerator
 import org.jetbrains.kotlin.fir.backend.generators.FakeOverrideGenerator
-import org.jetbrains.kotlin.fir.backend.evaluate.IrConstTransformer
 import org.jetbrains.kotlin.fir.backend.evaluate.evaluateConstants
 import org.jetbrains.kotlin.fir.declarations.*
 import org.jetbrains.kotlin.fir.descriptors.FirModuleDescriptor

--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/evaluate/IrConstTransformer.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/evaluate/IrConstTransformer.kt
@@ -34,7 +34,23 @@ class IrConstTransformer(irModuleFragment: IrModuleFragment) : IrElementTransfor
         return super.visitCall(expression)
     }
 
+    override fun visitValueParameter(declaration: IrValueParameter): IrStatement {
+        declaration.convertToConstInAnnotationsIfPossible()
+        return super.visitValueParameter(declaration)
+    }
+
+    override fun visitConstructor(declaration: IrConstructor): IrStatement {
+        declaration.convertToConstInAnnotationsIfPossible()
+        return super.visitConstructor(declaration)
+    }
+
+    override fun visitEnumEntry(declaration: IrEnumEntry): IrStatement {
+        declaration.convertToConstInAnnotationsIfPossible()
+        return super.visitEnumEntry(declaration)
+    }
+
     override fun visitField(declaration: IrField): IrStatement {
+        declaration.convertToConstInAnnotationsIfPossible()
         val initializer = declaration.initializer
         val expression = initializer?.expression ?: return declaration
         if (expression is IrConst<*>) return declaration
@@ -47,8 +63,23 @@ class IrConstTransformer(irModuleFragment: IrModuleFragment) : IrElementTransfor
         return declaration
     }
 
+    override fun visitFunction(declaration: IrFunction): IrStatement {
+        declaration.convertToConstInAnnotationsIfPossible()
+        return super.visitFunction(declaration)
+    }
+
+    override fun visitProperty(declaration: IrProperty): IrStatement {
+        declaration.convertToConstInAnnotationsIfPossible()
+        return super.visitProperty(declaration)
+    }
+
     override fun visitClass(declaration: IrClass): IrStatement {
-        declaration.annotations.forEach {
+        declaration.convertToConstInAnnotationsIfPossible()
+        return super.visitClass(declaration)
+    }
+
+    private fun IrMutableAnnotationContainer.convertToConstInAnnotationsIfPossible() {
+        annotations.forEach {
             for (i in 0 until it.valueArgumentsCount) {
                 val arg = it.getValueArgument(i) ?: continue
                 if (arg.accept(IrCompileTimeChecker(mode = EvaluationMode.ONLY_BUILTINS), null)) {
@@ -57,7 +88,6 @@ class IrConstTransformer(irModuleFragment: IrModuleFragment) : IrElementTransfor
                 }
             }
         }
-        return super.visitClass(declaration)
     }
 
     private fun IrExpression.convertToConstIfPossible(type: IrType): IrExpression {

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/ResolveUtils.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/ResolveUtils.kt
@@ -21,6 +21,7 @@ import org.jetbrains.kotlin.fir.references.FirErrorNamedReference
 import org.jetbrains.kotlin.fir.references.FirResolvedNamedReference
 import org.jetbrains.kotlin.fir.references.FirSuperReference
 import org.jetbrains.kotlin.fir.references.FirThisReference
+import org.jetbrains.kotlin.fir.references.builder.buildResolvedNamedReference
 import org.jetbrains.kotlin.fir.resolve.calls.FirNamedReferenceWithCandidate
 import org.jetbrains.kotlin.fir.resolve.calls.ImplicitDispatchReceiverValue
 import org.jetbrains.kotlin.fir.resolve.diagnostics.ConeUnresolvedNameError
@@ -457,3 +458,16 @@ private fun FirQualifiedAccess.expressionTypeOrUnitForAssignment(): ConeKotlinTy
     }
     return StandardClassIds.Unit.constructClassLikeType(emptyArray(), isNullable = false)
 }
+
+fun FirAnnotationCall.getCorrespondingConstructorReferenceOrNull(session: FirSession): FirResolvedNamedReference? =
+    annotationTypeRef.safeAs<FirResolvedTypeRef>()?.type?.classId?.let {
+        (session.firSymbolProvider.getClassLikeSymbolByFqName(it) as? FirRegularClassSymbol)?.fir
+            ?.getPrimaryConstructorIfAny()
+            ?.let { annotationConstructor ->
+                buildResolvedNamedReference {
+                    source = this@getCorrespondingConstructorReferenceOrNull.source
+                    name = it.shortClassName
+                    resolvedSymbol = annotationConstructor.symbol
+                }
+            }
+    }

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/FirArgumentsToParametersMapper.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/FirArgumentsToParametersMapper.kt
@@ -26,7 +26,20 @@ data class ArgumentMapping(
     // parameterToCallArgumentMap.values() should be [ 'bar()', 'foo()' ]
     val parameterToCallArgumentMap: Map<FirValueParameter, ResolvedCallArgument>,
     val diagnostics: List<ResolutionDiagnostic>
-)
+) {
+    fun toArgumentToParameterMapping(): Map<FirExpression, FirValueParameter> {
+        val argumentToParameterMapping = mutableMapOf<FirExpression, FirValueParameter>()
+        parameterToCallArgumentMap.forEach { (valueParameter, resolvedArgument) ->
+            when (resolvedArgument) {
+                is ResolvedCallArgument.SimpleArgument -> argumentToParameterMapping[resolvedArgument.callArgument] = valueParameter
+                is ResolvedCallArgument.VarargArgument -> resolvedArgument.arguments.forEach {
+                    argumentToParameterMapping[it] = valueParameter
+                }
+            }
+        }
+        return argumentToParameterMapping
+    }
+}
 
 private val EmptyArgumentMapping = ArgumentMapping(emptyMap(), emptyList())
 

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/ResolverParts.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/ResolverParts.kt
@@ -160,16 +160,7 @@ internal object MapArguments : ResolutionStage() {
         val function = symbol.fir
 
         val mapping = mapArguments(callInfo.arguments, function)
-        val argumentToParameterMapping = mutableMapOf<FirExpression, FirValueParameter>()
-        mapping.parameterToCallArgumentMap.forEach { (valueParameter, resolvedArgument) ->
-            when (resolvedArgument) {
-                is ResolvedCallArgument.SimpleArgument -> argumentToParameterMapping[resolvedArgument.callArgument] = valueParameter
-                is ResolvedCallArgument.VarargArgument -> resolvedArgument.arguments.forEach {
-                    argumentToParameterMapping[it] = valueParameter
-                }
-            }
-        }
-        candidate.argumentMapping = argumentToParameterMapping
+        candidate.argumentMapping = mapping.toArgumentToParameterMapping()
 
         var applicability = CandidateApplicability.RESOLVED
         mapping.diagnostics.forEach {

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirExpressionsResolveTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirExpressionsResolveTransformer.kt
@@ -24,6 +24,7 @@ import org.jetbrains.kotlin.fir.references.impl.FirSimpleNamedReference
 import org.jetbrains.kotlin.fir.resolve.*
 import org.jetbrains.kotlin.fir.resolve.calls.ImplicitDispatchReceiverValue
 import org.jetbrains.kotlin.fir.resolve.calls.candidate
+import org.jetbrains.kotlin.fir.resolve.calls.mapArguments
 import org.jetbrains.kotlin.fir.resolve.diagnostics.*
 import org.jetbrains.kotlin.fir.resolve.transformers.InvocationKindTransformer
 import org.jetbrains.kotlin.fir.resolve.transformers.StoreReceiver
@@ -649,6 +650,14 @@ open class FirExpressionsResolveTransformer(transformer: FirBodyResolveTransform
             (annotationCall.transformChildren(transformer, data) as FirAnnotationCall).also {
                 // TODO: it's temporary incorrect solution until we design resolve and completion for annotation calls
                 it.argumentList.transformArguments(integerLiteralTypeApproximator, null)
+                if (it.arguments.any { arg -> arg is FirNamedArgumentExpression }) {
+                    annotationCall.getCorrespondingConstructorReferenceOrNull(session)?.let { calleeReference ->
+                        val argumentMapping =
+                            mapArguments(it.arguments, calleeReference.resolvedSymbol.fir as FirFunction<*>)
+                                .toArgumentToParameterMapping()
+                        it.replaceArgumentList(buildResolvedArgumentList(argumentMapping))
+                    }
+                }
                 it.replaceResolveStatus(status)
                 dataFlowAnalyzer.exitAnnotationCall(it)
             }.compose()

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/declarations/FirDeclarationUtil.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/declarations/FirDeclarationUtil.kt
@@ -94,6 +94,9 @@ val FirClassSymbol<*>.superConeTypes
 
 val FirClass<*>.superConeTypes get() = superTypeRefs.mapNotNull { it.coneTypeSafe<ConeClassLikeType>() }
 
+fun FirClass<*>.getPrimaryConstructorIfAny(): FirConstructor? =
+    declarations.filterIsInstance<FirConstructor>().firstOrNull()?.takeIf { it.isPrimary }
+
 fun FirRegularClass.collectEnumEntries(): Collection<FirEnumEntry> {
     assert(classKind == ClassKind.ENUM_CLASS)
     return declarations.filterIsInstance<FirEnumEntry>()

--- a/compiler/ir/ir.interpreter/src/org/jetbrains/kotlin/ir/interpreter/Utils.kt
+++ b/compiler/ir/ir.interpreter/src/org/jetbrains/kotlin/ir/interpreter/Utils.kt
@@ -71,7 +71,7 @@ fun Any?.toIrConst(irType: IrType, startOffset: Int = UNDEFINED_OFFSET, endOffse
         constType.isShort() -> IrConstImpl.short(startOffset, endOffset, constType, (this as Number).toShort())
         constType.isInt() -> IrConstImpl.int(startOffset, endOffset, constType, (this as Number).toInt())
         constType.isLong() -> IrConstImpl.long(startOffset, endOffset, constType, (this as Number).toLong())
-        constType.isString() -> IrConstImpl.string(startOffset, endOffset, constType, this as String)
+        constType.isString() -> IrConstImpl.string(startOffset, endOffset, constType, this.toString())
         constType.isFloat() -> IrConstImpl.float(startOffset, endOffset, constType, (this as Number).toFloat())
         constType.isDouble() -> IrConstImpl.double(startOffset, endOffset, constType, (this as Number).toDouble())
         constType.isUByte() -> IrConstImpl.byte(startOffset, endOffset, constType, (this as Number).toByte())

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/types/irTypePredicates.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/types/irTypePredicates.kt
@@ -87,6 +87,8 @@ fun IrType.isLongArray(): Boolean = isNotNullClassType(FqNameUnsafe("kotlin.Long
 fun IrType.isFloatArray(): Boolean = isNotNullClassType(FqNameUnsafe("kotlin.FloatArray"))
 fun IrType.isDoubleArray(): Boolean = isNotNullClassType(FqNameUnsafe("kotlin.DoubleArray"))
 
+fun IrType.isPrimitiveTypeArray(): Boolean = KotlinBuiltIns.FQ_NAMES.arrayClassFqNameToPrimitiveType.keys.any { isNotNullClassType(it) }
+
 fun IrType.isNullableBoolean(): Boolean = isNullableClassType(KotlinBuiltIns.FQ_NAMES._boolean)
 fun IrType.isNullableLong(): Boolean = isNullableClassType(KotlinBuiltIns.FQ_NAMES._long)
 fun IrType.isNullableChar(): Boolean = isNullableClassType(KotlinBuiltIns.FQ_NAMES._char)

--- a/compiler/testData/codegen/box/reflection/createAnnotation/floatingPointParameters.kt
+++ b/compiler/testData/codegen/box/reflection/createAnnotation/floatingPointParameters.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 // IGNORE_BACKEND: JS_IR
 // IGNORE_BACKEND: JS_IR_ES6
 // TODO: muted automatically, investigate should it be ran for JS or not

--- a/compiler/testData/codegen/box/reflection/createAnnotation/primitivesAndArrays.kt
+++ b/compiler/testData/codegen/box/reflection/createAnnotation/primitivesAndArrays.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 // IGNORE_BACKEND: JS_IR
 // IGNORE_BACKEND: JS_IR_ES6
 // TODO: muted automatically, investigate should it be ran for JS or not

--- a/compiler/testData/ir/irText/declarations/annotations/annotationsWithDefaultParameterValues.fir.txt
+++ b/compiler/testData/ir/irText/declarations/annotations/annotationsWithDefaultParameterValues.fir.txt
@@ -57,7 +57,7 @@ FILE fqName:<root> fileName:/annotationsWithDefaultParameterValues.kt
     BLOCK_BODY
   FUN name:test4 visibility:public modality:FINAL <> () returnType:kotlin.Unit
     annotations:
-      A(x = '456', y = <null>)
+      A(x = <null>, y = '456')
     BLOCK_BODY
   FUN name:test5 visibility:public modality:FINAL <> () returnType:kotlin.Unit
     annotations:

--- a/compiler/testData/ir/irText/declarations/annotations/constExpressionsInAnnotationArguments.fir.txt
+++ b/compiler/testData/ir/irText/declarations/annotations/constExpressionsInAnnotationArguments.fir.txt
@@ -38,9 +38,9 @@ FILE fqName:<root> fileName:/constExpressionsInAnnotationArguments.kt
       $this: VALUE_PARAMETER name:<this> type:kotlin.Any
   FUN name:test1 visibility:public modality:FINAL <> () returnType:kotlin.Unit
     annotations:
-      A(x = CALL 'public final fun <get-ONE> (): kotlin.Int declared in <root>' type=kotlin.Int origin=GET_PROPERTY)
+      A(x = '1')
     BLOCK_BODY
   FUN name:test2 visibility:public modality:FINAL <> () returnType:kotlin.Unit
     annotations:
-      A(x = CALL 'public final fun plus (other: kotlin.Int): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null)
+      A(x = '2')
     BLOCK_BODY

--- a/compiler/testData/ir/irText/types/castsInsideCoroutineInference.fir.txt
+++ b/compiler/testData/ir/irText/types/castsInsideCoroutineInference.fir.txt
@@ -63,7 +63,7 @@ FILE fqName:<root> fileName:/castsInsideCoroutineInference.kt
         CALL 'public final fun TODO (): kotlin.Nothing [inline] declared in kotlin' type=kotlin.Nothing origin=null
   FUN name:onCompletion visibility:public modality:FINAL <T> ($receiver:<root>.Flow<T of <root>.onCompletion>, action:kotlin.coroutines.SuspendFunction1<kotlin.Throwable?, kotlin.Unit>) returnType:IrErrorType
     annotations:
-      Deprecated(message = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel, replaceWith = 'binary compatibility with a version w/o FlowCollector receiver', level = <null>)
+      Deprecated(message = 'binary compatibility with a version w/o FlowCollector receiver', replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
     TYPE_PARAMETER name:T index:0 variance: superTypes:[kotlin.Any?]
     $receiver: VALUE_PARAMETER name:<this> type:<root>.Flow<T of <root>.onCompletion>
     VALUE_PARAMETER name:action index:0 type:kotlin.coroutines.SuspendFunction1<kotlin.Throwable?, kotlin.Unit>


### PR DESCRIPTION
The motivation is bb test `CollectionLiterals.collectionLiteralsInArgumentPosition` that _was_ failing due to:
```
@Foo(a = [1f, 2f, 1 / 0f])
fun test1() {}
```

The first commit applies `IrConstTransformer` to all annotation containers, including functions.

------

That reveals another issue: annotation creation with named arguments, like
```
@Deprecated(level=... message="...")
fun foo() ...
```
where `Deprecated` constructor inputs `message`, `level`, and some other parameters in order. When `IrConstTransformer` visits such call in IR element form, no useful information is left, e.g., argument mapping.

Instead, during FIR resolution, arguments inside annotation should be converted to resolved argument list with mapping. The second commit does so. Also, during FIR2IR conversion, correct parameter index is computed for annotation call.

------

However, the target test _was_ still failing, and found that IR interpreter has a primitive array at end, but didn't support to convert it into `IrVararg`. The third commit adds that.

------

Alas, the target test _is_ still failing due to:
```
@Foo(b = ["Hello", ", ", "Kot" + "lin"])
fun test2() {}
```
that requires string concatenation at compile-time. It will also require me to learn more about IR interpreter, so I'd like to make a checking point for now.