### PR TITLE
FIR deserializer: proper annotation loading for value parameter of property setter

### DIFF
--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/parameters/ExtensionPropertySetter.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/parameters/ExtensionPropertySetter.txt
@@ -6,7 +6,7 @@ public final annotation class A : R|kotlin/Annotation| {
 public final class Class : R|kotlin/Any| {
     public final var R|kotlin/Int|.foo: R|kotlin/Int|
         public get(): R|kotlin/Int|
-        public set(value: R|kotlin/Int|): R|kotlin/Unit|
+        public set(@R|test/A|() value: R|kotlin/Int|): R|kotlin/Unit|
 
     public constructor(): R|test/Class|
 

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/parameters/PropertySetterInClass.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/parameters/PropertySetterInClass.txt
@@ -6,7 +6,7 @@ public final annotation class A : R|kotlin/Annotation| {
 public final class Class : R|kotlin/Any| {
     public final var foo: R|kotlin/Int|
         public get(): R|kotlin/Int|
-        public set(value: R|kotlin/Int|): R|kotlin/Unit|
+        public set(@R|test/A|() value: R|kotlin/Int|): R|kotlin/Unit|
 
     public constructor(): R|test/Class|
 

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/deserialization/FirMemberDeserializer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/deserialization/FirMemberDeserializer.kt
@@ -25,7 +25,6 @@ import org.jetbrains.kotlin.metadata.ProtoBuf
 import org.jetbrains.kotlin.metadata.deserialization.*
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
-import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.protobuf.MessageLite
 import org.jetbrains.kotlin.serialization.deserialization.ProtoEnumFlags
 import org.jetbrains.kotlin.serialization.deserialization.builtins.BuiltInSerializerProtocol
@@ -233,19 +232,11 @@ class FirMemberDeserializer(private val c: FirDeserializationContext) {
                             c.containerSource, proto, local.nameResolver, local.typeTable, setterFlags
                         )
                     this.symbol = FirPropertyAccessorSymbol()
-                    valueParameters += proto.setterValueParameter.let {
-                        val parameterFlags = if (it.hasFlags()) it.flags else 0
-                        buildValueParameter {
-                            session = c.session
-                            origin = FirDeclarationOrigin.Library
-                            this.returnTypeRef = returnTypeRef
-                            name = if (it.hasName()) c.nameResolver.getName(it.name) else Name.special("<default-setter-parameter>")
-                            this.symbol = FirVariableSymbol(CallableId(FqName.ROOT, name))
-                            isCrossinline = Flags.IS_CROSSINLINE.get(parameterFlags)
-                            isNoinline = Flags.IS_NOINLINE.get(parameterFlags)
-                            isVararg = it.hasVarargElementType()
-                        }
-                    }
+                    valueParameters += local.memberDeserializer.valueParameters(
+                        listOf(proto.setterValueParameter),
+                        proto,
+                        AbstractAnnotationDeserializer.CallableKind.PROPERTY_SETTER
+                    )
                 }
             } else {
                 FirDefaultPropertySetter(null, c.session, FirDeclarationOrigin.Library, returnTypeRef, visibility)


### PR DESCRIPTION
At https://github.com/JetBrains/kotlin/pull/3464/files#diff-aca6498e9ef1b1d053cffda7fb32d750, when there is a non-default property accessor, a corresponding accessor has been built by FIR deserializer. That, however, should have read an annotation associated with the value parameter of setter, if any. (Instead, it always used kind of hard-coded, predefined value parameter.) This is a quick fix for that, by applying https://github.com/JetBrains/kotlin/commit/7834284bece00ffa8fe2b9d2211b963ff2448cb8 to the value parameter of setter.