### PR TITLE
FIR deserializer: fix parameter shift for constructor of inner classes and enums

### DIFF
--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/parameters/EnumConstructor.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/parameters/EnumConstructor.txt
@@ -15,7 +15,7 @@ public final enum class E : R|kotlin/Enum<test/E>| {
     public final val y: R|kotlin/Int|
         public get(): R|kotlin/Int|
 
-    private constructor(x: R|kotlin/String|, y: R|kotlin/Int|): R|test/E|
+    private constructor(@R|test/A|() x: R|kotlin/String|, @R|test/B|() y: R|kotlin/Int|): R|test/E|
 
     public final static fun values(): R|kotlin/Array<test/E>| {
     }

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/deserialization/AbstractAnnotationDeserializer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/deserialization/AbstractAnnotationDeserializer.kt
@@ -135,6 +135,7 @@ abstract class AbstractAnnotationDeserializer(
         containerSource: DeserializedContainerSource?,
         callableProto: MessageLite,
         valueParameterProto: ProtoBuf.ValueParameter,
+        classProto: ProtoBuf.Class?,
         nameResolver: NameResolver,
         typeTable: TypeTable,
         kind: CallableKind,

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/deserialization/ClassDeserialization.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/deserialization/ClassDeserialization.kt
@@ -100,7 +100,6 @@ fun deserializeClassToSymbol(
         typeParameters += context.typeDeserializer.ownTypeParameters.map { it.fir }
         if (status.isInner)
             typeParameters += parentContext?.allTypeParameters?.map { buildOuterClassTypeParameterRef { this.symbol = it } }.orEmpty()
-//        annotations += context.annotationDeserializer.loadClassAnnotations(classProto, context.nameResolver)
 
         val typeDeserializer = context.typeDeserializer
         val classDeserializer = context.memberDeserializer
@@ -114,12 +113,21 @@ fun deserializeClassToSymbol(
             buildResolvedTypeRef { type = it }
         }
 
-        addDeclarations(classProto.functionList.map(classDeserializer::loadFunction))
-        addDeclarations(classProto.propertyList.map(classDeserializer::loadProperty))
+        addDeclarations(
+            classProto.functionList.map {
+                classDeserializer.loadFunction(it, classProto)
+            }
+        )
+
+        addDeclarations(
+            classProto.propertyList.map {
+                classDeserializer.loadProperty(it, classProto)
+            }
+        )
 
         addDeclarations(
             classProto.constructorList.map {
-                classDeserializer.loadConstructor(it, this)
+                classDeserializer.loadConstructor(it, classProto, this)
             }
         )
 
@@ -167,7 +175,8 @@ fun deserializeClassToSymbol(
                 ClassId.fromString(nameResolver.getQualifiedClassName(nameIndex))
             }
         }
-        (it.annotations as MutableList<FirAnnotationCall>) += context.annotationDeserializer.loadClassAnnotations(classProto, context.nameResolver)
+        (it.annotations as MutableList<FirAnnotationCall>) +=
+            context.annotationDeserializer.loadClassAnnotations(classProto, context.nameResolver)
     }
 }
 


### PR DESCRIPTION
When computing shifted index for value parameter in constructor, we need to know the kind of the enclosing class, e.g., whether it's enum or inner class. To be general, whenever value parameters are visited, the containing class's proto will be passed.