### PR TITLE
FIR2IR: handle 'this' as reference to outer object

### DIFF
--- a/compiler/testData/codegen/box/dataClasses/copy/copyInObjectNestedDataClass.kt
+++ b/compiler/testData/codegen/box/dataClasses/copy/copyInObjectNestedDataClass.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 class Bar(val name: String)
 
 abstract class Foo {

--- a/compiler/testData/codegen/box/enum/deepInnerClassInEnumEntryClass.kt
+++ b/compiler/testData/codegen/box/enum/deepInnerClassInEnumEntryClass.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 enum class A {
     X {
         val x = "OK"

--- a/compiler/testData/codegen/box/enum/deepInnerClassInEnumEntryClass2.kt
+++ b/compiler/testData/codegen/box/enum/deepInnerClassInEnumEntryClass2.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 enum class A {
     X {
         val k = "K"

--- a/compiler/testData/codegen/box/enum/innerClassInEnumEntryClass.kt
+++ b/compiler/testData/codegen/box/enum/innerClassInEnumEntryClass.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 enum class A {
     X {
         val x = "OK"

--- a/compiler/testData/codegen/box/enum/innerClassMethodInEnumEntryClass.kt
+++ b/compiler/testData/codegen/box/enum/innerClassMethodInEnumEntryClass.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 enum class A {
     X {
         val x = "OK"

--- a/compiler/testData/codegen/box/enum/kt7257_anonObjectInit.kt
+++ b/compiler/testData/codegen/box/enum/kt7257_anonObjectInit.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 enum class X {
     B {
         val value2 = "K"

--- a/compiler/testData/codegen/box/enum/kt7257_anonObjectMethod.kt
+++ b/compiler/testData/codegen/box/enum/kt7257_anonObjectMethod.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 enum class X {
     B {
         val value2 = "K"

--- a/compiler/testData/codegen/box/enum/kt7257_boundReference1.kt
+++ b/compiler/testData/codegen/box/enum/kt7257_boundReference1.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 enum class X {
     B {
         val k = "K"

--- a/compiler/testData/codegen/box/enum/kt9711_2.kt
+++ b/compiler/testData/codegen/box/enum/kt9711_2.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 enum class IssueState {
 
     FIXED {

--- a/compiler/testData/codegen/box/ir/serializationRegressions/innerClassInEnumEntryClass.kt
+++ b/compiler/testData/codegen/box/ir/serializationRegressions/innerClassInEnumEntryClass.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 
 // MODULE: lib
 // FILE: lib.kt

--- a/compiler/testData/ir/irText/expressions/enumEntryReferenceFromEnumEntryClass.fir.txt
+++ b/compiler/testData/ir/irText/expressions/enumEntryReferenceFromEnumEntryClass.fir.txt
@@ -76,18 +76,18 @@ FILE fqName:<root> fileName:/enumEntryReferenceFromEnumEntryClass.kt
                   ANONYMOUS_INITIALIZER isStatic=false
                     BLOCK_BODY
                       CALL 'public final fun <set-counter> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>.MyEnum.Z' type=kotlin.Unit origin=EQ
-                        $this: GET_OBJECT 'CLASS ENUM_ENTRY name:Z modality:FINAL visibility:private superTypes:[<root>.MyEnum]' type=<root>.MyEnum.Z
+                        $this: GET_VAR '<this>: <root>.MyEnum.Z declared in <root>.MyEnum.Z' type=<root>.MyEnum.Z origin=null
                         <set-?>: CONST Int type=kotlin.Int value=1
                       CALL 'public final fun foo (): kotlin.Unit declared in <root>.MyEnum.Z' type=kotlin.Unit origin=null
-                        $this: GET_OBJECT 'CLASS ENUM_ENTRY name:Z modality:FINAL visibility:private superTypes:[<root>.MyEnum]' type=<root>.MyEnum.Z
+                        $this: GET_VAR '<this>: <root>.MyEnum.Z declared in <root>.MyEnum.Z' type=<root>.MyEnum.Z origin=null
                   FUN name:test visibility:public modality:FINAL <> ($this:<root>.MyEnum.Z.anObject.<no name provided>) returnType:kotlin.Unit
                     $this: VALUE_PARAMETER name:<this> type:<root>.MyEnum.Z.anObject.<no name provided>
                     BLOCK_BODY
                       CALL 'public final fun <set-counter> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>.MyEnum.Z' type=kotlin.Unit origin=EQ
-                        $this: GET_OBJECT 'CLASS ENUM_ENTRY name:Z modality:FINAL visibility:private superTypes:[<root>.MyEnum]' type=<root>.MyEnum.Z
+                        $this: GET_VAR '<this>: <root>.MyEnum.Z declared in <root>.MyEnum.Z' type=<root>.MyEnum.Z origin=null
                         <set-?>: CONST Int type=kotlin.Int value=1
                       CALL 'public final fun foo (): kotlin.Unit declared in <root>.MyEnum.Z' type=kotlin.Unit origin=null
-                        $this: GET_OBJECT 'CLASS ENUM_ENTRY name:Z modality:FINAL visibility:private superTypes:[<root>.MyEnum]' type=<root>.MyEnum.Z
+                        $this: GET_VAR '<this>: <root>.MyEnum.Z declared in <root>.MyEnum.Z' type=<root>.MyEnum.Z origin=null
                   FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
                     overridden:
                       public open fun equals (other: kotlin.Any?): kotlin.Boolean [operator] declared in kotlin.Any

--- a/compiler/testData/ir/irText/singletons/enumEntry.fir.txt
+++ b/compiler/testData/ir/irText/singletons/enumEntry.fir.txt
@@ -29,7 +29,7 @@ FILE fqName:<root> fileName:/enumEntry.kt
             $this: VALUE_PARAMETER name:<this> type:<root>.Z.ENTRY.A
             BLOCK_BODY
               CALL 'public final fun test (): kotlin.Unit declared in <root>.Z.ENTRY' type=kotlin.Unit origin=null
-                $this: GET_OBJECT 'CLASS ENUM_ENTRY name:ENTRY modality:FINAL visibility:private superTypes:[<root>.Z]' type=<root>.Z.ENTRY
+                $this: GET_VAR '<this>: <root>.Z.ENTRY declared in <root>.Z.ENTRY' type=<root>.Z.ENTRY origin=null
           FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
             overridden:
               public open fun equals (other: kotlin.Any?): kotlin.Boolean [operator] declared in kotlin.Any


### PR DESCRIPTION
`InnerClassesLowering` in backend IR expects _implicit_ `this` receiver to be retrieved via `IrGetValue`. During `fir2ir` conversion, _implicit_ `this` and explicit one are mangled, and for anonymous object as an implicit receiver, we passed `IrGetObjectValue` instead, resulting in missed lowering that causes dangling static call.

To distinguish implicit v.s. explicit `this` (without revealing corresponding internal declarations: `FirImplicitThisReference` and `FirExplicitThisReference`), this PR passes the context callee so that we can match the class bound to `this` reference against the context where such `this` receiver is going to be used. Then, for anonymous object case, we can avoid using `IrGetObjectValue` if it is used as an implicit receiver (so that `InnerClassesLowering` can pick it up and convert it to the proper `$outer` field access).