### PR TITLE
FIR2IR: discard fake overrides for property accessors according to base visibility

### DIFF
--- a/compiler/testData/codegen/box/syntheticAccessors/kt10047.kt
+++ b/compiler/testData/codegen/box/syntheticAccessors/kt10047.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 // FILE: a.kt
 
 package test2


### PR DESCRIPTION
> Otherwise, IR validation failed: "Overrides private declaration ..."

This is supposed to be part of https://github.com/JetBrains/kotlin/pull/3252, which missed substitution case.