### PR TITLE
Explicitly specify id of `KotlinNonJvmSourceRootConverterProvider`

### DIFF
--- a/idea/resources/META-INF/plugin-common.xml
+++ b/idea/resources/META-INF/plugin-common.xml
@@ -647,7 +647,7 @@
     <projectStructure.sourceRootEditHandler implementation="org.jetbrains.kotlin.idea.roots.ui.KotlinModuleSourceRootEditHandler$Resource"/>
     <projectStructure.sourceRootEditHandler implementation="org.jetbrains.kotlin.idea.roots.ui.KotlinModuleSourceRootEditHandler$TestResource"/>
 
-    <project.converterProvider implementation="org.jetbrains.kotlin.idea.roots.KotlinNonJvmSourceRootConverterProvider"/>
+    <project.converterProvider implementation="org.jetbrains.kotlin.idea.roots.KotlinNonJvmSourceRootConverterProvider" id="kotlin-non-jvm-source-roots"/>
 
     <orderEnumerationHandlerFactory implementation="org.jetbrains.kotlin.idea.roots.KotlinNonJvmOrderEnumerationHandler$Factory"/>
 


### PR DESCRIPTION
IDEA 2020.3 uses `id` from extension definition to avoid creating instance of converter without need.

I do not change `KotlinNonJvmSourceRootConverterProvider` because using of deprecated constructor `ConverterProvider(id)` is still required as you don't have a special branch for 2020.3 IDE.