### PR TITLE
KT-39981: Fix JVM Parcelize use of Parceler

### DIFF
--- a/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/ParcelableCodegenExtension.kt
+++ b/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/ParcelableCodegenExtension.kt
@@ -226,7 +226,7 @@ open class ParcelableCodegenExtension : ParcelableExtensionBase, ExpressionCodeg
 
                 v.getstatic(containerAsmType.internalName, companionFieldName, companionAsmType.descriptor)
                 v.load(1, PARCEL_TYPE)
-                v.invokevirtual(companionAsmType.internalName, "create", "(${PARCEL_TYPE.descriptor})Ljava/lang/Object;", false)
+                v.invokevirtual(companionAsmType.internalName, "create", "(${PARCEL_TYPE.descriptor})$containerAsmType", false)
             }
             else {
                 v.anew(containerAsmType)
@@ -367,8 +367,8 @@ open class ParcelableCodegenExtension : ParcelableExtensionBase, ExpressionCodeg
 
                     v.getstatic(containerAsmType.internalName, companionFieldName, companionAsmType.descriptor)
                     v.load(1, Type.INT_TYPE)
-                    v.invokevirtual(companionAsmType.internalName, "newArray", "(I)[Ljava/lang/Object;", false)
-                    v.areturn(Type.getType("[Ljava/lang/Object;"))
+                    v.invokevirtual(companionAsmType.internalName, "newArray", "(I)[$parcelableAsmType", false)
+                    v.areturn(Type.getType("[$parcelableAsmType"))
 
                     return@write
                 }
@@ -376,7 +376,7 @@ open class ParcelableCodegenExtension : ParcelableExtensionBase, ExpressionCodeg
 
             v.load(1, Type.INT_TYPE)
             v.newarray(parcelableAsmType)
-            v.areturn(Type.getType("[L$parcelableAsmType;"))
+            v.areturn(Type.getType("[$parcelableAsmType"))
         }
     }
 

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/customNewArray.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/customNewArray.kt
@@ -1,0 +1,40 @@
+// WITH_RUNTIME
+
+@file:JvmName("TestKt")
+package test
+
+import kotlinx.android.parcel.*
+import android.os.Parcel
+import android.os.Parcelable
+
+@Parcelize
+data class User(val firstName: String, val secondName: String, val age: Int) : Parcelable {
+    companion object : Parceler<User> {
+        override fun User.write(parcel: Parcel, flags: Int) {
+            parcel.writeString(firstName)
+            parcel.writeString(secondName)
+        }
+
+        override fun create(parcel: Parcel) = User(parcel.readString(), parcel.readString(), 0)
+
+        override fun newArray(size: Int) = arrayOfNulls<User>(size) as Array<User>
+    }
+}
+
+fun box() = parcelTest { parcel ->
+    val user = User("John", "Smith", 20)
+    val user2 = User("Joe", "Bloggs", 30)
+    val array = arrayOf(user, user2)
+    parcel.writeTypedArray(array, 0)
+
+    val bytes = parcel.marshall()
+    parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
+
+    val creator = User::class.java.getDeclaredField("CREATOR").get(null) as Parcelable.Creator<User>
+    val result = parcel.createTypedArray(creator)
+
+    assert(result.size == 2)
+    assert(result[0].firstName == user.firstName)
+    assert(result[1].firstName == user2.firstName)
+}

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/kt39981.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/kt39981.kt
@@ -1,0 +1,21 @@
+// WITH_RUNTIME
+
+@file:JvmName("TestKt")
+package test
+
+import kotlinx.android.parcel.*
+import android.os.Parcel
+import android.os.Parcelable
+
+@Parcelize class TestParcel : Parcelable {
+    companion object : Parceler<TestParcel> {
+        override fun create(parcel: Parcel): TestParcel {
+            return TestParcel()
+        }
+        override fun TestParcel.write(parcel: Parcel, flags: Int) {}
+    }
+}
+
+fun box() = parcelTest { parcel ->
+    TestParcel()
+}

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/newArray.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/newArray.kt
@@ -1,0 +1,29 @@
+// WITH_RUNTIME
+
+@file:JvmName("TestKt")
+package test
+
+import kotlinx.android.parcel.*
+import android.os.Parcel
+import android.os.Parcelable
+
+@Parcelize
+data class User(val firstName: String, val secondName: String, val age: Int) : Parcelable
+
+fun box() = parcelTest { parcel ->
+    val user = User("John", "Smith", 20)
+    val user2 = User("Joe", "Bloggs", 30)
+    val array = arrayOf(user, user2)
+    parcel.writeTypedArray(array, 0)
+
+    val bytes = parcel.marshall()
+    parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
+
+    val creator = User::class.java.getDeclaredField("CREATOR").get(null) as Parcelable.Creator<User>
+    val result = parcel.createTypedArray(creator)
+
+    assert(result.size == 2)
+    assert(result[0].firstName == user.firstName)
+    assert(result[1].firstName == user2.firstName)
+}

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/customParcelablesSameModule.ir.txt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/customParcelablesSameModule.ir.txt
@@ -112,8 +112,6 @@ public final class test/Foo$Creator : java/lang/Object, android/os/Parcelable$Cr
           INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
           NEW
           DUP
-          GETSTATIC (Companion, Lk/KotlinParcelable$Companion;)
-          POP
           GETSTATIC (CREATOR, Lk/KotlinParcelable$Creator;)
           ALOAD (1)
           INVOKEVIRTUAL (k/KotlinParcelable$Creator, createFromParcel, (Landroid/os/Parcel;)Lk/KotlinParcelable;)

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/customSimple.txt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/customSimple.txt
@@ -42,7 +42,7 @@ public final class User$Creator : java/lang/Object, android/os/Parcelable$Creato
           INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
           GETSTATIC (Companion, LUser$Companion;)
           ALOAD (1)
-          INVOKEVIRTUAL (User$Companion, create, (Landroid/os/Parcel;)Ljava/lang/Object;)
+          INVOKEVIRTUAL (User$Companion, create, (Landroid/os/Parcel;)LUser;)
           ARETURN
         LABEL (L1)
     }

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/customSimpleWithNewArray.txt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/customSimpleWithNewArray.txt
@@ -41,7 +41,7 @@ public final class User$Creator : java/lang/Object, android/os/Parcelable$Creato
         LABEL (L0)
           GETSTATIC (Companion, LUser$Companion;)
           ILOAD (1)
-          INVOKEVIRTUAL (User$Companion, newArray, (I)[Ljava/lang/Object;)
+          INVOKEVIRTUAL (User$Companion, newArray, (I)[LUser;)
           ARETURN
         LABEL (L1)
     }

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/serializeValue.txt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/serializeValue.txt
@@ -1,7 +1,7 @@
 public final class Test$Creator : java/lang/Object, android/os/Parcelable$Creator {
     public void <init>()
 
-    public final java.lang.Object createFromParcel(android.os.Parcel in) {
+    public final Test createFromParcel(android.os.Parcel in) {
         LABEL (L0)
           ALOAD (1)
           LDC (in)
@@ -18,7 +18,18 @@ public final class Test$Creator : java/lang/Object, android/os/Parcelable$Creato
         LABEL (L1)
     }
 
-    public final java.lang.Object[] newArray(int size)
+    public java.lang.Object createFromParcel(android.os.Parcel p0) {
+        LABEL (L0)
+        LINENUMBER (10)
+          ALOAD (0)
+          ALOAD (1)
+          INVOKEVIRTUAL (Test$Creator, createFromParcel, (Landroid/os/Parcel;)LTest;)
+          ARETURN
+    }
+
+    public final Test[] newArray(int size)
+
+    public java.lang.Object[] newArray(int p0)
 }
 
 public final class Test : java/lang/Object, android/os/Parcelable {


### PR DESCRIPTION
The JVM backend for `@Parcelize` updated in https://github.com/JetBrains/kotlin/pull/3316 does not use `Parceler` correctly. Currently some calls are made to synthetic methods returning `Object`, rather than those returning the generic type `T`. Consequently attempts to use `Parceler` can fail as seen in https://youtrack.jetbrains.com/issue/KT-39981

This PR provides the following:
- Adds an explicit test for KT-39981
- Calls the correct variant of `create` and `newArray`
- Adds box tests for `newArray` handling, with and without custom `Parceler`
- Updates Parcelize codegen expected values for JVM
- Also updates Parcelize codegen expected value for the IR variant of customParcelablesSameModule
