### PR TITLE
FIR deserializer: load annotations on inner classes

### DIFF
--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/classMembers/ClassObjectPropertyField.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/classMembers/ClassObjectPropertyField.txt
@@ -7,7 +7,7 @@ public final class Class : R|kotlin/Any| {
     public constructor(): R|test/Class|
 
     public final companion object Companion : R|kotlin/Any| {
-        public final var property: R|kotlin/Int|
+        @FIELD:R|test/Anno|() public final var property: R|kotlin/Int|
             public get(): R|kotlin/Int|
             public set(value: R|kotlin/Int|): R|kotlin/Unit|
 

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/classMembers/ClassObjectPropertyField.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/classMembers/ClassObjectPropertyField.txt
@@ -7,7 +7,7 @@ public final class Class : R|kotlin/Any| {
     public constructor(): R|test/Class|
 
     public final companion object Companion : R|kotlin/Any| {
-        @FIELD:R|test/Anno|() public final var property: R|kotlin/Int|
+        public final var property: R|kotlin/Int|
             public get(): R|kotlin/Int|
             public set(value: R|kotlin/Int|): R|kotlin/Unit|
 

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/classMembers/HiddenConstructorWithInlineClassParameters.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/classMembers/HiddenConstructorWithInlineClassParameters.txt
@@ -10,7 +10,7 @@ public sealed class Sealed : R|kotlin/Any| {
     @R|test/Ann|() private constructor(@R|test/Ann|() z: R|test/Z|): R|test/Sealed|
 
     public final class Derived : R|test/Sealed| {
-        public constructor(z: R|test/Z|): R|test/Sealed.Derived|
+        @R|test/Ann|() public constructor(z: R|test/Z|): R|test/Sealed.Derived|
 
     }
 

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/parameters/InnerClassConstructor.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/parameters/InnerClassConstructor.txt
@@ -13,7 +13,7 @@ public final class Outer : R|kotlin/Any| {
         public final val y: R|kotlin/String|
             public get(): R|kotlin/String|
 
-        public constructor(y: R|kotlin/String|): R|test/Outer.Inner|
+        public constructor(@R|test/A|(s = String(inner)) y: R|kotlin/String|): R|test/Outer.Inner|
 
     }
 
@@ -21,7 +21,7 @@ public final class Outer : R|kotlin/Any| {
         public final val x: R|kotlin/String|
             public get(): R|kotlin/String|
 
-        public constructor(x: R|kotlin/String|): R|test/Outer.Nested|
+        public constructor(@R|test/A|(s = String(nested)) x: R|kotlin/String|): R|test/Outer.Nested|
 
     }
 

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/propertiesWithoutBackingFields/ClassObject.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/propertiesWithoutBackingFields/ClassObject.txt
@@ -7,7 +7,7 @@ public final class Class : R|kotlin/Any| {
     public constructor(): R|test/Class|
 
     public final companion object Companion : R|kotlin/Any| {
-        public final val property: R|kotlin/Int|
+        @PROPERTY:R|test/Anno|() public final val property: R|kotlin/Int|
             public get(): R|kotlin/Int|
 
         private constructor(): R|test/Class.Companion|

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/propertiesWithoutBackingFields/TraitClassObject.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/propertiesWithoutBackingFields/TraitClassObject.txt
@@ -5,7 +5,7 @@ public final annotation class Anno : R|kotlin/Annotation| {
 
 public abstract interface Trait : R|kotlin/Any| {
     public final companion object Companion : R|kotlin/Any| {
-        public final val property: R|kotlin/Int|
+        @PROPERTY:R|test/Anno|() public final val property: R|kotlin/Int|
             public get(): R|kotlin/Int|
 
         private constructor(): R|test/Trait.Companion|

--- a/compiler/fir/java/src/org/jetbrains/kotlin/fir/java/deserialization/JvmBinaryAnnotationDeserializer.kt
+++ b/compiler/fir/java/src/org/jetbrains/kotlin/fir/java/deserialization/JvmBinaryAnnotationDeserializer.kt
@@ -30,6 +30,8 @@ class JvmBinaryAnnotationDeserializer(
     kotlinBinaryClass: KotlinJvmBinaryClass,
     byteContent: ByteArray?
 ) : AbstractAnnotationDeserializer(session) {
+    // TODO: In order to properly load annotations on fields inside a companion object,
+    //  we need binary classes for both the companion class and the enclosing class.
     private val annotationInfo by lazy(LazyThreadSafetyMode.PUBLICATION) {
         session.loadMemberAnnotations(kotlinBinaryClass, byteContent)
     }

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/deserialization/AbstractAnnotationDeserializer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/deserialization/AbstractAnnotationDeserializer.kt
@@ -32,7 +32,6 @@ import org.jetbrains.kotlin.metadata.deserialization.Flags
 import org.jetbrains.kotlin.metadata.deserialization.NameResolver
 import org.jetbrains.kotlin.metadata.deserialization.TypeTable
 import org.jetbrains.kotlin.protobuf.MessageLite
-import org.jetbrains.kotlin.serialization.deserialization.ProtoContainer
 import org.jetbrains.kotlin.serialization.deserialization.builtins.BuiltInSerializerProtocol
 import org.jetbrains.kotlin.serialization.deserialization.descriptors.DeserializedContainerSource
 import org.jetbrains.kotlin.serialization.deserialization.getClassId

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/deserialization/AbstractAnnotationDeserializer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/deserialization/AbstractAnnotationDeserializer.kt
@@ -42,6 +42,9 @@ abstract class AbstractAnnotationDeserializer(
 ) {
     protected val protocol = BuiltInSerializerProtocol
 
+    open fun inheritAnnotationInfo(parent: AbstractAnnotationDeserializer) {
+    }
+
     enum class CallableKind {
         PROPERTY,
         PROPERTY_GETTER,

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/deserialization/ClassDeserialization.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/deserialization/ClassDeserialization.kt
@@ -73,16 +73,19 @@ fun deserializeClassToSymbol(
         isInline = Flags.IS_INLINE_CLASS.get(classProto.flags)
     }
     val isSealed = modality == Modality.SEALED
+    val annotationDeserializer = defaultAnnotationDeserializer ?: FirBuiltinAnnotationDeserializer(session)
     val context =
         parentContext?.childContext(
             classProto.typeParameterList,
             nameResolver,
             TypeTable(classProto.typeTable),
             classId.relativeClassName,
+            containerSource,
+            annotationDeserializer,
             status.isInner
         ) ?: FirDeserializationContext.createForClass(
             classId, classProto, nameResolver, session,
-            defaultAnnotationDeserializer ?: FirBuiltinAnnotationDeserializer(session),
+            annotationDeserializer,
             FirConstDeserializer(session, (containerSource as? KotlinJvmBinarySourceElement)?.binaryClass),
             containerSource
         )
@@ -164,9 +167,6 @@ fun deserializeClassToSymbol(
             generateValueOfFunction(session, classId.packageFqName, classId.relativeClassName)
         }
 
-        if (isSealed) {
-
-        }
         addCloneForArrayIfNeeded(classId)
         addSerializableIfNeeded(classId)
     }.also {

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/deserialization/ClassDeserialization.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/deserialization/ClassDeserialization.kt
@@ -89,6 +89,11 @@ fun deserializeClassToSymbol(
             FirConstDeserializer(session, (containerSource as? KotlinJvmBinarySourceElement)?.binaryClass),
             containerSource
         )
+    if (status.isCompanion) {
+        parentContext?.let {
+            context.annotationDeserializer.inheritAnnotationInfo(it.annotationDeserializer)
+        }
+    }
     buildRegularClass {
         this.session = session
         origin = FirDeclarationOrigin.Library

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/deserialization/FirMemberDeserializer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/deserialization/FirMemberDeserializer.kt
@@ -29,7 +29,6 @@ import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.protobuf.MessageLite
 import org.jetbrains.kotlin.serialization.deserialization.ProtoEnumFlags
-import org.jetbrains.kotlin.serialization.deserialization.builtins.BuiltInSerializerProtocol
 import org.jetbrains.kotlin.serialization.deserialization.descriptors.DeserializedContainerSource
 import org.jetbrains.kotlin.serialization.deserialization.getName
 
@@ -55,6 +54,8 @@ class FirDeserializationContext(
         nameResolver: NameResolver = this.nameResolver,
         typeTable: TypeTable = this.typeTable,
         relativeClassName: FqName? = this.relativeClassName,
+        containerSource: DeserializedContainerSource? = this.containerSource,
+        annotationDeserializer: AbstractAnnotationDeserializer = this.annotationDeserializer,
         capturesTypeParameters: Boolean = true
     ): FirDeserializationContext = FirDeserializationContext(
         nameResolver, typeTable, versionRequirementTable, session, packageFqName, relativeClassName,


### PR DESCRIPTION
This is a follow-up work on https://github.com/JetBrains/kotlin/pull/3512, which fixed parameter shifts for constructors of inner classes and enums, but only enum tests were affected.

It turns out that, when visiting inner classes, deserializer in the parent context, i.e., outer class, has been always used. When creating "child" context, we need a fresh deserializer that loads that child class of interest. To do so, in the 1st commit, container source and annotation deserializer are passed down to child context creation accordingly.

That revealed one subtle case: annotations on fields inside a companion object whose actual field declared in the outer class. In that case, we need loaded annotation info from the outer, enclosing class, in addition to the companion class. The 2nd commit adds a logic to inherit annotation info from the parent deserializer.