### PR TITLE
FIR: avoid cast exception in Candidate.prepareExpectedType

### DIFF
--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/Arguments.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/Arguments.kt
@@ -308,7 +308,8 @@ internal fun Candidate.resolveArgument(
 
 private fun Candidate.prepareExpectedType(session: FirSession, argument: FirExpression, parameter: FirValueParameter?): ConeKotlinType? {
     if (parameter == null) return null
-    if (parameter.returnTypeRef is FirILTTypeRefPlaceHolder) return argument.resultType.coneType
+    if (parameter.returnTypeRef is FirILTTypeRefPlaceHolder && argument.resultType is FirResolvedTypeRef)
+        return argument.resultType.coneType
     val basicExpectedType = argument.getExpectedType(session, parameter/*, LanguageVersionSettings*/)
     val expectedType = getExpectedTypeWithSAMConversion(session, argument, basicExpectedType) ?: basicExpectedType
     return this.substitutor.substituteOrSelf(expectedType)

--- a/compiler/testData/codegen/box/classes/kt1980.kt
+++ b/compiler/testData/codegen/box/classes/kt1980.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 // KJS_WITH_FULL_RUNTIME
 public inline fun Int.times(body : () -> Unit) {
     var count = this;


### PR DESCRIPTION
The motivation is `Classes.kt1980` where `Int` extension, `times`, that inputs a lambda, is there to test resolutions against `Int.times(Int)`. For that top-level `times`, `fir` simply failed with a cast exception while retrieving the expected type for the argument. That is easy to avoid, since the underlying assumption was, when parameter is integer literal type, the corresponding argument type has been resolved, which is never guaranteed. (In the test, a lambda body is given as an argument, and thus we should discard that candidate, instead of cast exception.)