### PR TITLE
[FIR] Fixed computeTypeArguments() & added diagnostic for type args

### DIFF
--- a/compiler/fir/analysis-tests/testData/resolve/diagnostics/projectionsOnNonClassTypeArguments.kt
+++ b/compiler/fir/analysis-tests/testData/resolve/diagnostics/projectionsOnNonClassTypeArguments.kt
@@ -1,0 +1,8 @@
+class A<in T, out K>
+class B
+
+fun test() {
+    val a1 = A<<!PROJECTION_ON_NON_CLASS_TYPE_ARGUMENT!>in Int<!>, <!PROJECTION_ON_NON_CLASS_TYPE_ARGUMENT!>out B<!>>()
+    val a2 = A<Int, B>()
+    val a3 = A<<!PROJECTION_ON_NON_CLASS_TYPE_ARGUMENT!>*<!>, <!PROJECTION_ON_NON_CLASS_TYPE_ARGUMENT!>*<!>>()
+}

--- a/compiler/fir/analysis-tests/testData/resolve/diagnostics/projectionsOnNonClassTypeArguments.txt
+++ b/compiler/fir/analysis-tests/testData/resolve/diagnostics/projectionsOnNonClassTypeArguments.txt
@@ -1,0 +1,18 @@
+FILE: projectionsOnNonClassTypeArguments.kt
+    public final class A<in T, out K> : R|kotlin/Any| {
+        public constructor<in T, out K>(): R|A<T, K>| {
+            super<R|kotlin/Any|>()
+        }
+
+    }
+    public final class B : R|kotlin/Any| {
+        public constructor(): R|B| {
+            super<R|kotlin/Any|>()
+        }
+
+    }
+    public final fun test(): R|kotlin/Unit| {
+        lval a1: R|A<kotlin/Int, B>| = R|/A.A|<in R|kotlin/Int|, out R|B|>()
+        lval a2: R|A<kotlin/Int, B>| = R|/A.A|<R|kotlin/Int|, R|B|>()
+        lval a3: R|A<kotlin/Any?, kotlin/Any?>| = R|/A.A|<*, *>()
+    }

--- a/compiler/fir/analysis-tests/tests/org/jetbrains/kotlin/fir/FirDiagnosticsTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests/org/jetbrains/kotlin/fir/FirDiagnosticsTestGenerated.java
@@ -901,6 +901,11 @@ public class FirDiagnosticsTestGenerated extends AbstractFirDiagnosticsTest {
             runTest("compiler/fir/analysis-tests/testData/resolve/diagnostics/notASupertype.kt");
         }
 
+        @TestMetadata("projectionsOnNonClassTypeArguments.kt")
+        public void testProjectionsOnNonClassTypeArguments() throws Exception {
+            runTest("compiler/fir/analysis-tests/testData/resolve/diagnostics/projectionsOnNonClassTypeArguments.kt");
+        }
+
         @TestMetadata("qualifiedSupertypeExtendedByOtherSupertype.kt")
         public void testQualifiedSupertypeExtendedByOtherSupertype() throws Exception {
             runTest("compiler/fir/analysis-tests/testData/resolve/diagnostics/qualifiedSupertypeExtendedByOtherSupertype.kt");

--- a/compiler/fir/analysis-tests/tests/org/jetbrains/kotlin/fir/FirDiagnosticsWithLightTreeTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests/org/jetbrains/kotlin/fir/FirDiagnosticsWithLightTreeTestGenerated.java
@@ -901,6 +901,11 @@ public class FirDiagnosticsWithLightTreeTestGenerated extends AbstractFirDiagnos
             runTest("compiler/fir/analysis-tests/testData/resolve/diagnostics/notASupertype.kt");
         }
 
+        @TestMetadata("projectionsOnNonClassTypeArguments.kt")
+        public void testProjectionsOnNonClassTypeArguments() throws Exception {
+            runTest("compiler/fir/analysis-tests/testData/resolve/diagnostics/projectionsOnNonClassTypeArguments.kt");
+        }
+
         @TestMetadata("qualifiedSupertypeExtendedByOtherSupertype.kt")
         public void testQualifiedSupertypeExtendedByOtherSupertype() throws Exception {
             runTest("compiler/fir/analysis-tests/testData/resolve/diagnostics/qualifiedSupertypeExtendedByOtherSupertype.kt");

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/expression/DefaultExpressionCheckers.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/expression/DefaultExpressionCheckers.kt
@@ -13,6 +13,7 @@ object CommonExpressionCheckers : ExpressionCheckers() {
         FirSuperclassNotAccessibleFromInterfaceChecker,
         FirAbstractSuperCallChecker,
         FirQualifiedSupertypeExtendedByOtherSupertypeChecker,
+        FirProjectionsOnNonClassTypeArgumentChecker
     )
     override val functionCallCheckers: List<FirFunctionCallChecker> = listOf()
 }

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/expression/FirProjectionsOnNonClassTypeArgumentChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/expression/FirProjectionsOnNonClassTypeArgumentChecker.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.fir.analysis.checkers.expression
+
+import org.jetbrains.kotlin.fir.FirSourceElement
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.analysis.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors
+import org.jetbrains.kotlin.fir.expressions.FirQualifiedAccessExpression
+import org.jetbrains.kotlin.fir.types.FirStarProjection
+import org.jetbrains.kotlin.fir.types.FirTypeProjectionWithVariance
+import org.jetbrains.kotlin.types.Variance
+
+object FirProjectionsOnNonClassTypeArgumentChecker : FirQualifiedAccessChecker() {
+    override fun check(functionCall: FirQualifiedAccessExpression, context: CheckerContext, reporter: DiagnosticReporter) {
+        for (it in functionCall.typeArguments) {
+            when (it) {
+                is FirStarProjection -> reporter.report(it.source)
+                is FirTypeProjectionWithVariance -> {
+                    if (it.variance != Variance.INVARIANT) {
+                        reporter.report(it.source)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun DiagnosticReporter.report(source: FirSourceElement?) {
+        source?.let {
+            report(FirErrors.PROJECTION_ON_NON_CLASS_TYPE_ARGUMENT.on(it))
+        }
+    }
+}

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/FirErrors.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/FirErrors.kt
@@ -78,6 +78,9 @@ object FirErrors {
     val DEPRECATED_MODIFIER_PAIR by error2<FirSourceElement, PsiElement, KtModifierKeywordToken, KtModifierKeywordToken>()
     val INCOMPATIBLE_MODIFIERS by error2<FirSourceElement, PsiElement, KtModifierKeywordToken, KtModifierKeywordToken>()
 
+    // projection
+    val PROJECTION_ON_NON_CLASS_TYPE_ARGUMENT by error0<FirSourceElement, PsiElement>()
+
     // Control flow diagnostics
     val UNINITIALIZED_VARIABLE by error1<FirSourceElement, PsiElement, FirPropertySymbol>()
 }

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirCallCompletionResultsWriterTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirCallCompletionResultsWriterTransformer.kt
@@ -32,6 +32,7 @@ import org.jetbrains.kotlin.fir.scopes.impl.withReplacedConeType
 import org.jetbrains.kotlin.fir.types.*
 import org.jetbrains.kotlin.fir.types.builder.buildErrorTypeRef
 import org.jetbrains.kotlin.fir.types.builder.buildResolvedTypeRef
+import org.jetbrains.kotlin.fir.types.builder.buildStarProjection
 import org.jetbrains.kotlin.fir.types.builder.buildTypeProjectionWithVariance
 import org.jetbrains.kotlin.fir.types.impl.ConeTypeParameterTypeImpl
 import org.jetbrains.kotlin.fir.visitors.*
@@ -331,7 +332,7 @@ class FirCallCompletionResultsWriterTransformer(
     private fun computeTypeArguments(
         access: FirQualifiedAccess,
         candidate: Candidate
-    ): List<FirTypeProjectionWithVariance> {
+    ): List<FirTypeProjection> {
         return computeTypeArgumentTypes(candidate)
             .mapIndexed { index, type ->
                 when (val argument = access.typeArguments.getOrNull(index)) {
@@ -341,6 +342,11 @@ class FirCallCompletionResultsWriterTransformer(
                             source = argument.source
                             this.typeRef = typeRef.withReplacedConeType(type)
                             variance = argument.variance
+                        }
+                    }
+                    is FirStarProjection -> {
+                        buildStarProjection {
+                            source = argument.source
                         }
                     }
                     else -> {

--- a/compiler/testData/diagnostics/tests/ProjectionOnFunctionArgumentErrror.fir.kt
+++ b/compiler/testData/diagnostics/tests/ProjectionOnFunctionArgumentErrror.fir.kt
@@ -1,4 +1,4 @@
 fun test() {
     fun <T> foo(){}
-    foo<in Int>()
+    foo<<!PROJECTION_ON_NON_CLASS_TYPE_ARGUMENT!>in Int<!>>()
 }

--- a/compiler/testData/diagnostics/tests/StarsInFunctionCalls.fir.kt
+++ b/compiler/testData/diagnostics/tests/StarsInFunctionCalls.fir.kt
@@ -6,10 +6,10 @@ fun <A, B, C> getTTT(x : Any) {}
 fun foo(a : Any?) {}
 
 public fun main() {
-    getT<*>()
+    getT<<!PROJECTION_ON_NON_CLASS_TYPE_ARGUMENT!>*<!>>()
     <!UNRESOLVED_REFERENCE!>ggetT<!><*>()
-    getTT<*, *>()
-    getTT<*, Int>()
-    getTT<Int, *>()
-    foo(getTTT<Int, *, Int>(1))
+    getTT<<!PROJECTION_ON_NON_CLASS_TYPE_ARGUMENT!>*<!>, <!PROJECTION_ON_NON_CLASS_TYPE_ARGUMENT!>*<!>>()
+    getTT<<!PROJECTION_ON_NON_CLASS_TYPE_ARGUMENT!>*<!>, Int>()
+    getTT<Int, <!PROJECTION_ON_NON_CLASS_TYPE_ARGUMENT!>*<!>>()
+    foo(getTTT<Int, <!PROJECTION_ON_NON_CLASS_TYPE_ARGUMENT!>*<!>, Int>(1))
 }

--- a/compiler/testData/diagnostics/tests/modifiers/incompatibleVarianceModifiers.fir.kt
+++ b/compiler/testData/diagnostics/tests/modifiers/incompatibleVarianceModifiers.fir.kt
@@ -19,5 +19,5 @@ class A {
 }
 
 fun test4(a: A) {
-    a.bar<out out Int>()
+    a.bar<<!PROJECTION_ON_NON_CLASS_TYPE_ARGUMENT!>out out Int<!>>()
 }

--- a/compiler/testData/diagnostics/tests/qualifiedExpression/nullCalleeExpression.fir.kt
+++ b/compiler/testData/diagnostics/tests/qualifiedExpression/nullCalleeExpression.fir.kt
@@ -1,4 +1,4 @@
 // !WITH_NEW_INFERENCE
 // NI_EXPECTED_FILE
 
-val unwrapped = some.<!SYNTAX!><<!><!UNRESOLVED_REFERENCE!>cabc<!><!UNRESOLVED_REFERENCE!><!SYNTAX!>$Wrapper<!><out Any>::unwrap<!>
+val unwrapped = some.<!SYNTAX!><<!><!UNRESOLVED_REFERENCE!>cabc<!><!UNRESOLVED_REFERENCE!><!SYNTAX!>$Wrapper<!><<!PROJECTION_ON_NON_CLASS_TYPE_ARGUMENT!>out Any<!>>::unwrap<!>

--- a/compiler/testData/diagnostics/tests/typealias/projectionsInTypeAliasConstructor.fir.kt
+++ b/compiler/testData/diagnostics/tests/typealias/projectionsInTypeAliasConstructor.fir.kt
@@ -2,5 +2,5 @@ class In<in T>(val x: Any)
 
 typealias InAlias<T> = In<T>
 
-val test1 = In<out String>("")
-val test2 = InAlias<out String>("")
+val test1 = In<<!PROJECTION_ON_NON_CLASS_TYPE_ARGUMENT!>out String<!>>("")
+val test2 = InAlias<<!PROJECTION_ON_NON_CLASS_TYPE_ARGUMENT!>out String<!>>("")

--- a/compiler/testData/diagnostics/tests/typealias/typeAliasConstructorForProjection.fir.kt
+++ b/compiler/testData/diagnostics/tests/typealias/typeAliasConstructorForProjection.fir.kt
@@ -11,5 +11,5 @@ typealias CT<T> = C<T>
 val test1 = CStar()
 val test2 = CIn()
 val test3 = COut()
-val test4 = CT<*>()
+val test4 = CT<<!PROJECTION_ON_NON_CLASS_TYPE_ARGUMENT!>*<!>>()
 val test5 = CT<CT<*>>()


### PR DESCRIPTION
`computeTypeArguments()` used to lose `StarProjection` instances replacing them with `TypeProjectionWithVariance`. Added a checker for PROJECTION_ON_NON_CLASS_TYPE_ARGUMENT as well. 