### PR TITLE
FIR deserializer: load annotations on extension receiver parameters

### DIFF
--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/withUseSiteTarget/ReceiverTarget.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/withUseSiteTarget/ReceiverTarget.txt
@@ -1,10 +1,10 @@
 public final class A : R|kotlin/Any| {
-    public final fun R|kotlin/String|.myLength(@R|test/Ann|() q: R|kotlin/String|): R|kotlin/Int|
+    @R|test/Ann|() public final fun R|kotlin/String|.myLength(@R|test/Ann|() q: R|kotlin/String|): R|kotlin/Int|
 
-    public final val R|kotlin/String|.myLength2: R|kotlin/Int|
+    @R|test/Ann|() public final val R|kotlin/String|.myLength2: R|kotlin/Int|
         public get(): R|kotlin/Int|
 
-    public final var R|kotlin/String|.myLength3: R|kotlin/Int|
+    @R|test/Ann|() public final var R|kotlin/String|.myLength3: R|kotlin/Int|
         public get(): R|kotlin/Int|
         public set(v: R|kotlin/Int|): R|kotlin/Unit|
 

--- a/compiler/fir/java/src/org/jetbrains/kotlin/fir/java/deserialization/JvmBinaryAnnotationDeserializer.kt
+++ b/compiler/fir/java/src/org/jetbrains/kotlin/fir/java/deserialization/JvmBinaryAnnotationDeserializer.kt
@@ -160,6 +160,18 @@ class JvmBinaryAnnotationDeserializer(
         return findJvmBinaryClassAndLoadMemberAnnotations(containerSource, paramSignature)
     }
 
+    override fun loadExtensionReceiverParameterAnnotations(
+        containerSource: DeserializedContainerSource?,
+        callableProto: MessageLite,
+        nameResolver: NameResolver,
+        typeTable: TypeTable,
+        kind: CallableKind
+    ): List<FirAnnotationCall> {
+        val methodSignature = getCallableSignature(callableProto, nameResolver, typeTable, kind) ?: return emptyList()
+        val paramSignature = MemberSignature.fromMethodSignatureAndParameterIndex(methodSignature, 0)
+        return findJvmBinaryClassAndLoadMemberAnnotations(containerSource, paramSignature)
+    }
+
     private fun computeJvmParameterIndexShift(classProto: ProtoBuf.Class?, message: MessageLite): Int {
         return when (message) {
             is ProtoBuf.Function -> if (message.hasReceiver()) 1 else 0

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/deserialization/AbstractAnnotationDeserializer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/deserialization/AbstractAnnotationDeserializer.kt
@@ -148,6 +148,16 @@ abstract class AbstractAnnotationDeserializer(
         return annotations.map { deserializeAnnotation(it, nameResolver) }
     }
 
+    open fun loadExtensionReceiverParameterAnnotations(
+        containerSource: DeserializedContainerSource?,
+        callableProto: MessageLite,
+        nameResolver: NameResolver,
+        typeTable: TypeTable,
+        kind: CallableKind
+    ): List<FirAnnotationCall> {
+        return emptyList()
+    }
+
     abstract fun loadTypeAnnotations(typeProto: ProtoBuf.Type, nameResolver: NameResolver): List<FirAnnotationCall>
 
     fun deserializeAnnotation(


### PR DESCRIPTION
Annotations can be targeted to extension receiver, like
```
fun @receiver:Ann String.myLength(@Ann q:String) ...
```
and then serialized at receiver type. This PR extends FIR deserializer to deserialize it.