### PR TITLE
JVM IR: Mangle delegated properties with inline class type (fix KT-40125)

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/inlineclasses/MemoizedInlineClassReplacements.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/inlineclasses/MemoizedInlineClassReplacements.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.backend.jvm.ir.isStaticInlineClassReplacement
 import org.jetbrains.kotlin.backend.jvm.lower.inlineclasses.InlineClassAbi.mangledNameFor
 import org.jetbrains.kotlin.codegen.state.KotlinTypeMapper
 import org.jetbrains.kotlin.descriptors.Modality
+import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.ir.builders.declarations.addValueParameter
 import org.jetbrains.kotlin.ir.builders.declarations.buildFun
 import org.jetbrains.kotlin.ir.builders.declarations.buildFunWithDescriptorForInlining
@@ -45,7 +46,7 @@ class MemoizedInlineClassReplacements(private val mangleReturnTypes: Boolean) {
             when {
                 // Don't mangle anonymous or synthetic functions
                 it.origin == IrDeclarationOrigin.LOCAL_FUNCTION_FOR_LAMBDA ||
-                        it.origin == IrDeclarationOrigin.DELEGATED_PROPERTY_ACCESSOR ||
+                        (it.origin == IrDeclarationOrigin.DELEGATED_PROPERTY_ACCESSOR && it.visibility == Visibilities.LOCAL) ||
                         it.isStaticInlineClassReplacement ||
                         it.origin.isSynthetic -> null
 

--- a/compiler/testData/codegen/bytecodeText/inlineClasses/delegatedPropertyMangling.kt
+++ b/compiler/testData/codegen/bytecodeText/inlineClasses/delegatedPropertyMangling.kt
@@ -1,0 +1,22 @@
+// LANGUAGE: +InlineClasses
+import kotlin.reflect.KProperty
+
+inline class I(val x: Int)
+
+interface A {
+    val i: I
+}
+
+class Delegate {
+    operator fun getValue(thisRef: Any?, prop: KProperty<*>): I {
+        return I(1)
+    }
+}
+
+class B : A {
+    override val i by Delegate()
+}
+
+// 1 public final getValue-lPtA-2M\(Ljava/lang/Object;Lkotlin/reflect/KProperty;\)I
+// 1 public getI-lPtA-2M\(\)I
+// 1 public abstract getI-lPtA-2M\(\)I

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
@@ -2856,6 +2856,11 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
             runTest("compiler/testData/codegen/bytecodeText/inlineClasses/defaultParametersDontBox.kt");
         }
 
+        @TestMetadata("delegatedPropertyMangling.kt")
+        public void testDelegatedPropertyMangling() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/inlineClasses/delegatedPropertyMangling.kt");
+        }
+
         @TestMetadata("equalsDoesNotBox.kt")
         public void testEqualsDoesNotBox() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/inlineClasses/equalsDoesNotBox.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
@@ -2941,6 +2941,11 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
             runTest("compiler/testData/codegen/bytecodeText/inlineClasses/defaultParametersDontBox.kt");
         }
 
+        @TestMetadata("delegatedPropertyMangling.kt")
+        public void testDelegatedPropertyMangling() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/inlineClasses/delegatedPropertyMangling.kt");
+        }
+
         @TestMetadata("equalsDoesNotBox.kt")
         public void testEqualsDoesNotBox() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/inlineClasses/equalsDoesNotBox.kt");


### PR DESCRIPTION
We have to avoid mangling local delegated properties in `MemoizedInlineClassReplacements`, since they do not have corresponding properties. It turns out that the check for this was overly broad and also excluded delegated properties in classes.