### PR TITLE
JVM IR: Fix generic signatures for special bridge methods

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/DeclarationOrigins.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/DeclarationOrigins.kt
@@ -51,4 +51,5 @@ interface JvmLoweredDeclarationOrigin : IrDeclarationOrigin {
     object CONTINUATION_CLASS_RESULT_FIELD: IrDeclarationOriginImpl("CONTINUATION_CLASS_RESULT_FIELD", isSynthetic = true)
     object COMPANION_PROPERTY_BACKING_FIELD : IrDeclarationOriginImpl("COMPANION_MOVED_PROPERTY_BACKING_FIELD")
     object FIELD_FOR_STATIC_LAMBDA_INSTANCE : IrDeclarationOriginImpl("FIELD_FOR_STATIC_LAMBDA_INSTANCE")
+    object ABSTRACT_BRIDGE_STUB : IrDeclarationOriginImpl("ABSTRACT_BRIDGE_STUB")
 }

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/FunctionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/FunctionCodegen.kt
@@ -72,7 +72,12 @@ class FunctionCodegen(
         if (irFunction.origin != IrDeclarationOrigin.FUNCTION_FOR_DEFAULT_PARAMETER &&
             irFunction.origin != JvmLoweredDeclarationOrigin.SYNTHETIC_ACCESSOR &&
             irFunction.origin != IrDeclarationOrigin.ENUM_CLASS_SPECIAL_MEMBER &&
-            irFunction.origin != IrDeclarationOrigin.GENERATED_INLINE_CLASS_MEMBER
+            irFunction.origin != IrDeclarationOrigin.GENERATED_INLINE_CLASS_MEMBER &&
+            irFunction.origin != IrDeclarationOrigin.BRIDGE &&
+            irFunction.origin != IrDeclarationOrigin.BRIDGE_SPECIAL &&
+            irFunction.origin != JvmLoweredDeclarationOrigin.ABSTRACT_BRIDGE_STUB &&
+            irFunction.origin != JvmLoweredDeclarationOrigin.TO_ARRAY &&
+            irFunction.origin != IrDeclarationOrigin.IR_BUILTINS_STUB
         ) {
             val skipNullabilityAnnotations = flags and Opcodes.ACC_PRIVATE != 0 || flags and Opcodes.ACC_SYNTHETIC != 0
             object : AnnotationCodegen(classCodegen, context, skipNullabilityAnnotations) {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/BridgeLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/BridgeLowering.kt
@@ -338,7 +338,7 @@ private class BridgeLowering(val context: JvmBackendContext) : FileLoweringPass,
         addFunction {
             updateFrom(irFunction)
             modality = Modality.ABSTRACT
-            origin = IrDeclarationOrigin.DEFINED
+            origin = JvmLoweredDeclarationOrigin.ABSTRACT_BRIDGE_STUB
             name = irFunction.name
             returnType = irFunction.returnType
             isFakeOverride = false

--- a/compiler/testData/codegen/box/jvm8/treeMapBridge.kt
+++ b/compiler/testData/codegen/box/jvm8/treeMapBridge.kt
@@ -1,4 +1,5 @@
 // TARGET_BACKEND: JVM
+// IGNORE_BACKEND_FIR: JVM_IR
 
 // java.lang.NoSuchMethodError: java.util.TreeMap.remove
 // IGNORE_BACKEND: ANDROID

--- a/compiler/testData/codegen/bytecodeListing/immutableCollection.kt
+++ b/compiler/testData/codegen/bytecodeListing/immutableCollection.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 interface ImmutableCollection<out E> : Collection<E> {
     fun add(element: @UnsafeVariance E): ImmutableCollection<E>
     fun addAll(elements: Collection<@UnsafeVariance E>): ImmutableCollection<E>

--- a/compiler/testData/codegen/bytecodeListing/specialBridges/removeAtTwoSpecialBridges.kt
+++ b/compiler/testData/codegen/bytecodeListing/specialBridges/removeAtTwoSpecialBridges.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 open class A0<E> : MutableList<E> {
     override fun add(element: E): Boolean {
         throw UnsupportedOperationException()

--- a/compiler/testData/codegen/bytecodeListing/specialBridges/signatures/genericClass.kt
+++ b/compiler/testData/codegen/bytecodeListing/specialBridges/signatures/genericClass.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 // WITH_SIGNATURES
 
 class GenericMap<K, V> : MutableMap<K, V> by HashMap<K, V>()

--- a/compiler/testData/codegen/bytecodeListing/specialBridges/signatures/nonGenericClass.kt
+++ b/compiler/testData/codegen/bytecodeListing/specialBridges/signatures/nonGenericClass.kt
@@ -1,5 +1,5 @@
-// IGNORE_BACKEND: JVM_IR
 // WITH_SIGNATURES
+// Test expectations differ between JVM and JVM IR backends, because of KT-40277. This should be revisited once KT-40277 is resolved.
 
 class StringStringMap : MutableMap<String, String> by HashMap<String, String>()
 

--- a/compiler/testData/codegen/bytecodeListing/specialBridges/signatures/nonGenericClass_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/specialBridges/signatures/nonGenericClass_ir.txt
@@ -1,0 +1,57 @@
+@kotlin.Metadata
+public abstract class<Ljava/lang/Object;Ljava/util/Map<Ljava/lang/String;Ljava/lang/String;>;Lkotlin/jvm/internal/markers/KMutableMap;>  AbstractStringStringMap {
+    public @org.jetbrains.annotations.NotNull <()Ljava/util/Collection<Ljava/lang/String;>;> method getValues(): java.util.Collection
+    public bridge final <()Ljava/util/Collection<Ljava/lang/String;>;> method values(): java.util.Collection
+    public @org.jetbrains.annotations.NotNull <()Ljava/util/Set<Ljava/lang/String;>;> method getKeys(): java.util.Set
+    public bridge final <()Ljava/util/Set<Ljava/lang/String;>;> method keySet(): java.util.Set
+    public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/String;Ljava/lang/String;>;>;> method entrySet(): java.util.Set
+    public @org.jetbrains.annotations.NotNull <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/String;Ljava/lang/String;>;>;> method getEntries(): java.util.Set
+    public <(Ljava/util/Map<+Ljava/lang/String;+Ljava/lang/String;>;)V> method putAll(@org.jetbrains.annotations.NotNull p0: java.util.Map): void
+    public <null> method <init>(): void
+    public <null> method clear(): void
+    public <null> method containsKey(@org.jetbrains.annotations.NotNull p0: java.lang.String): boolean
+    public bridge final <null> method containsKey(p0: java.lang.Object): boolean
+    public <null> method containsValue(@org.jetbrains.annotations.NotNull p0: java.lang.String): boolean
+    public bridge final <null> method containsValue(p0: java.lang.Object): boolean
+    public @org.jetbrains.annotations.Nullable <null> method get(@org.jetbrains.annotations.NotNull p0: java.lang.String): java.lang.String
+    public synthetic bridge <null> method get(p0: java.lang.Object): java.lang.Object
+    public bridge final <null> method get(p0: java.lang.Object): java.lang.String
+    public <null> method getSize(): int
+    public <null> method isEmpty(): boolean
+    public @org.jetbrains.annotations.Nullable <null> method put(@org.jetbrains.annotations.NotNull p0: java.lang.String, @org.jetbrains.annotations.NotNull p1: java.lang.String): java.lang.String
+    public synthetic bridge <null> method put(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
+    public @org.jetbrains.annotations.Nullable <null> method remove(@org.jetbrains.annotations.NotNull p0: java.lang.String): java.lang.String
+    public synthetic bridge <null> method remove(p0: java.lang.Object): java.lang.Object
+    public bridge final <null> method remove(p0: java.lang.Object): java.lang.String
+    public bridge final <null> method size(): int
+    private synthetic final field <Ljava/util/HashMap<Ljava/lang/String;Ljava/lang/String;>;> $$delegate_0: java.util.HashMap
+}
+
+@kotlin.Metadata
+public final class<Ljava/lang/Object;Ljava/util/Map<Ljava/lang/String;Ljava/lang/String;>;Lkotlin/jvm/internal/markers/KMutableMap;>  StringStringMap {
+    public @org.jetbrains.annotations.NotNull <()Ljava/util/Collection<Ljava/lang/String;>;> method getValues(): java.util.Collection
+    public bridge final <()Ljava/util/Collection<Ljava/lang/String;>;> method values(): java.util.Collection
+    public @org.jetbrains.annotations.NotNull <()Ljava/util/Set<Ljava/lang/String;>;> method getKeys(): java.util.Set
+    public bridge final <()Ljava/util/Set<Ljava/lang/String;>;> method keySet(): java.util.Set
+    public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/String;Ljava/lang/String;>;>;> method entrySet(): java.util.Set
+    public @org.jetbrains.annotations.NotNull <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/String;Ljava/lang/String;>;>;> method getEntries(): java.util.Set
+    public <(Ljava/util/Map<+Ljava/lang/String;+Ljava/lang/String;>;)V> method putAll(@org.jetbrains.annotations.NotNull p0: java.util.Map): void
+    public <null> method <init>(): void
+    public <null> method clear(): void
+    public <null> method containsKey(@org.jetbrains.annotations.NotNull p0: java.lang.String): boolean
+    public bridge final <null> method containsKey(p0: java.lang.Object): boolean
+    public <null> method containsValue(@org.jetbrains.annotations.NotNull p0: java.lang.String): boolean
+    public bridge final <null> method containsValue(p0: java.lang.Object): boolean
+    public @org.jetbrains.annotations.Nullable <null> method get(@org.jetbrains.annotations.NotNull p0: java.lang.String): java.lang.String
+    public synthetic bridge <null> method get(p0: java.lang.Object): java.lang.Object
+    public bridge final <null> method get(p0: java.lang.Object): java.lang.String
+    public <null> method getSize(): int
+    public <null> method isEmpty(): boolean
+    public @org.jetbrains.annotations.Nullable <null> method put(@org.jetbrains.annotations.NotNull p0: java.lang.String, @org.jetbrains.annotations.NotNull p1: java.lang.String): java.lang.String
+    public synthetic bridge <null> method put(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
+    public @org.jetbrains.annotations.Nullable <null> method remove(@org.jetbrains.annotations.NotNull p0: java.lang.String): java.lang.String
+    public synthetic bridge <null> method remove(p0: java.lang.Object): java.lang.Object
+    public bridge final <null> method remove(p0: java.lang.Object): java.lang.String
+    public bridge final <null> method size(): int
+    private synthetic final field <Ljava/util/HashMap<Ljava/lang/String;Ljava/lang/String;>;> $$delegate_0: java.util.HashMap
+}

--- a/compiler/testData/codegen/bytecodeListing/specialBridges/signatures/partiallySpecializedClass.kt
+++ b/compiler/testData/codegen/bytecodeListing/specialBridges/signatures/partiallySpecializedClass.kt
@@ -1,5 +1,5 @@
-// IGNORE_BACKEND: JVM_IR
 // WITH_SIGNATURES
+// Test expectations differ between JVM and JVM IR backends, because of KT-40277. This should be revisited once KT-40277 is resolved.
 
 class StringMap<V> : MutableMap<String, V> by HashMap<String, V>()
 

--- a/compiler/testData/codegen/bytecodeListing/specialBridges/signatures/partiallySpecializedClass_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/specialBridges/signatures/partiallySpecializedClass_ir.txt
@@ -1,0 +1,51 @@
+@kotlin.Metadata
+public abstract class<<V:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/Map<Ljava/lang/String;TV;>;Lkotlin/jvm/internal/markers/KMutableMap;>  AbstractStringMap {
+    public @org.jetbrains.annotations.NotNull <()Ljava/util/Collection<TV;>;> method getValues(): java.util.Collection
+    public bridge final <()Ljava/util/Collection<TV;>;> method values(): java.util.Collection
+    public @org.jetbrains.annotations.NotNull <()Ljava/util/Set<Ljava/lang/String;>;> method getKeys(): java.util.Set
+    public bridge final <()Ljava/util/Set<Ljava/lang/String;>;> method keySet(): java.util.Set
+    public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/String;TV;>;>;> method entrySet(): java.util.Set
+    public @org.jetbrains.annotations.NotNull <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/String;TV;>;>;> method getEntries(): java.util.Set
+    public @org.jetbrains.annotations.Nullable <(Ljava/lang/Object;)TV;> method get(@org.jetbrains.annotations.NotNull p0: java.lang.String): java.lang.Object
+    public bridge final <(Ljava/lang/Object;)TV;> method get(p0: java.lang.Object): java.lang.Object
+    public @org.jetbrains.annotations.Nullable <(Ljava/lang/Object;)TV;> method remove(@org.jetbrains.annotations.NotNull p0: java.lang.String): java.lang.Object
+    public bridge final <(Ljava/lang/Object;)TV;> method remove(p0: java.lang.Object): java.lang.Object
+    public @org.jetbrains.annotations.Nullable <(Ljava/lang/String;TV;)TV;> method put(@org.jetbrains.annotations.NotNull p0: java.lang.String, p1: java.lang.Object): java.lang.Object
+    public <(Ljava/util/Map<+Ljava/lang/String;+TV;>;)V> method putAll(@org.jetbrains.annotations.NotNull p0: java.util.Map): void
+    public <null> method <init>(): void
+    public <null> method clear(): void
+    public <null> method containsKey(@org.jetbrains.annotations.NotNull p0: java.lang.String): boolean
+    public bridge final <null> method containsKey(p0: java.lang.Object): boolean
+    public <null> method containsValue(p0: java.lang.Object): boolean
+    public <null> method getSize(): int
+    public <null> method isEmpty(): boolean
+    public synthetic bridge <null> method put(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
+    public bridge final <null> method size(): int
+    private synthetic final field <Ljava/util/HashMap<Ljava/lang/String;TV;>;> $$delegate_0: java.util.HashMap
+}
+
+@kotlin.Metadata
+public final class<<V:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/Map<Ljava/lang/String;TV;>;Lkotlin/jvm/internal/markers/KMutableMap;>  StringMap {
+    public @org.jetbrains.annotations.NotNull <()Ljava/util/Collection<TV;>;> method getValues(): java.util.Collection
+    public bridge final <()Ljava/util/Collection<TV;>;> method values(): java.util.Collection
+    public @org.jetbrains.annotations.NotNull <()Ljava/util/Set<Ljava/lang/String;>;> method getKeys(): java.util.Set
+    public bridge final <()Ljava/util/Set<Ljava/lang/String;>;> method keySet(): java.util.Set
+    public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/String;TV;>;>;> method entrySet(): java.util.Set
+    public @org.jetbrains.annotations.NotNull <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/String;TV;>;>;> method getEntries(): java.util.Set
+    public @org.jetbrains.annotations.Nullable <(Ljava/lang/Object;)TV;> method get(@org.jetbrains.annotations.NotNull p0: java.lang.String): java.lang.Object
+    public bridge final <(Ljava/lang/Object;)TV;> method get(p0: java.lang.Object): java.lang.Object
+    public @org.jetbrains.annotations.Nullable <(Ljava/lang/Object;)TV;> method remove(@org.jetbrains.annotations.NotNull p0: java.lang.String): java.lang.Object
+    public bridge final <(Ljava/lang/Object;)TV;> method remove(p0: java.lang.Object): java.lang.Object
+    public @org.jetbrains.annotations.Nullable <(Ljava/lang/String;TV;)TV;> method put(@org.jetbrains.annotations.NotNull p0: java.lang.String, p1: java.lang.Object): java.lang.Object
+    public <(Ljava/util/Map<+Ljava/lang/String;+TV;>;)V> method putAll(@org.jetbrains.annotations.NotNull p0: java.util.Map): void
+    public <null> method <init>(): void
+    public <null> method clear(): void
+    public <null> method containsKey(@org.jetbrains.annotations.NotNull p0: java.lang.String): boolean
+    public bridge final <null> method containsKey(p0: java.lang.Object): boolean
+    public <null> method containsValue(p0: java.lang.Object): boolean
+    public <null> method getSize(): int
+    public <null> method isEmpty(): boolean
+    public synthetic bridge <null> method put(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
+    public bridge final <null> method size(): int
+    private synthetic final field <Ljava/util/HashMap<Ljava/lang/String;TV;>;> $$delegate_0: java.util.HashMap
+}

--- a/compiler/testData/codegen/bytecodeText/builtinFunctions/removeAt.kt
+++ b/compiler/testData/codegen/bytecodeText/builtinFunctions/removeAt.kt
@@ -90,18 +90,33 @@ fun box(
 }
 
 /*
-16 INVOKEVIRTUAL A[0-9]+.removeAt \(I\) -> calls in bridges with signature `public final bridge remove\(I\)` + 7 calls from `public synthetic bridge remove\(I\)Ljava/lang/Object;`
-9 INVOKEVIRTUAL A[0-9]+\.remove \(I\) -> calls to A1-A9.removeAt
 1 INVOKEINTERFACE A9\.remove \(I\) -> call A9.removeAt
 1 INVOKEINTERFACE A9\.remove \(Ljava/lang/Object;\) -> call A9.remove
+
+On the JVM backend we have:
+16 INVOKEVIRTUAL A[0-9]+.removeAt \(I\) -> calls in bridges with signature `public final bridge remove\(I\)` + 7 calls from `public synthetic bridge remove\(I\)Ljava/lang/Object;`
+9 INVOKEVIRTUAL A[0-9]+\.remove \(I\) -> calls to A1-A9.removeAt
 1 INVOKEVIRTUAL A10\.remove \(I\) -> one call in 'box' function
+
+On the JVM IR backend we have:
+9 INVOKEVIRTUAL A[0-9]+.removeAt \(I\) -> calls in non-synthetic bridges with signature `public final bridge remove(I)`
+17 INVOKEVIRTUAL A[0-9]+\.remove \(I\) -> calls to A1-A9.removeAt + calls in synthetic bridges with signature `public synthetic bridge remove(I)Ljava/lang/Object;`
+2 INVOKEVIRTUAL A10\.remove \(I\) -> one call in 'box' function + call from synthetic `remove(I)` bridge
+
+This currently differs because of KT-40277, and the test expectations should be revised once KT-40277 is resolved.
 */
 
-// 16 INVOKEVIRTUAL A[0-9]+.removeAt \(I\)
-// 9 INVOKEVIRTUAL A[0-9]+\.remove \(I\)
 // 1 INVOKEINTERFACE A9\.remove \(I\)
 // 1 INVOKEINTERFACE A9\.remove \(Ljava/lang/Object;\)
-// 1 INVOKEVIRTUAL A10\.remove \(I\)
 // 2 INVOKEINTERFACE java\/util\/List.remove \(I\)
 // 2 INVOKEINTERFACE java\/util\/List.remove \(Ljava/lang/Object;\)
 
+// JVM_TEMPLATES:
+// 16 INVOKEVIRTUAL A[0-9]+.removeAt \(I\)
+// 9 INVOKEVIRTUAL A[0-9]+\.remove \(I\)
+// 1 INVOKEVIRTUAL A10\.remove \(I\)
+
+// JVM_IR_TEMPLATES:
+// 9 INVOKEVIRTUAL A[0-9]+.removeAt \(I\)
+// 17 INVOKEVIRTUAL A[0-9]+\.remove \(I\)
+// 2 INVOKEVIRTUAL A10\.remove \(I\)

--- a/compiler/testData/codegen/bytecodeText/mapGetOrDefault.kt
+++ b/compiler/testData/codegen/bytecodeText/mapGetOrDefault.kt
@@ -27,4 +27,14 @@ public class TestMap<K, V> implements Map<K, V> {
 
 class MyMap: TestMap<String, String>()
 
+// The Kotlin version of getOrDefault, which redirects to the default implementation in java.util.Map
+// 1 public bridge getOrDefault\(Ljava/lang/String;Ljava/lang/String;\)Ljava/lang/String;
+
+// Test expectations differ between JVM and JVM IR backends, because of KT-40277. This should be revisited once KT-40277 is resolved.
+
+// JVM_TEMPLATES:
 // 1 public final bridge getOrDefault\(Ljava/lang/Object;Ljava/lang/Object;\)Ljava/lang/Object;
+
+// JVM_IR_TEMPLATES:
+// 1 public final bridge getOrDefault\(Ljava/lang/Object;Ljava/lang/String;\)Ljava/lang/String;
+// 1 public synthetic bridge getOrDefault\(Ljava/lang/Object;Ljava/lang/Object;\)Ljava/lang/Object;


### PR DESCRIPTION
Second attempt at #3163.

We produce special bridge methods for overrides of Java methods which have different names or signatures in the Kotlin standard library. Since these methods are visible to Java (they are non-synthetic bridge methods) we need to produce proper generic signatures to ensure that they are callable from Java.

The JVM backend currently does *not* do this in 6 out of the 7 cases where we have special bridge methods which are generic in Java. This can lead to Java code seeing less precise types for Kotlin collections. It does not break compilation, because of a quirk of javac, which skips the usual override checks for bridge methods (which, as far as I know, are always synthetic in Java).

Rather than replicating the behavior of the JVM backend, this PR tries to produce correct generic types for all generic special bridge methods. This requires additional bridges, but is technically required in order for Java interoperability.

It's worth noting that the behavior of the JVM backend cannot be replicated in a lowering, since the generic signatures created by the JVM backend for special bridges don't necessarily match the method signatures in some cases. See the example in #3163.