### PR TITLE
gradle.kts: improve service initializtion

### DIFF
--- a/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/ScriptConfigurationManager.kt
+++ b/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/ScriptConfigurationManager.kt
@@ -17,6 +17,7 @@
 package org.jetbrains.kotlin.idea.core.script
 
 import com.intellij.openapi.components.ServiceManager
+import com.intellij.openapi.components.serviceIfCreated
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.util.Key
@@ -108,8 +109,8 @@ interface ScriptConfigurationManager {
     fun getAllScriptDependenciesSources(): List<VirtualFile>
 
     companion object {
-        fun getAlreadyInitializedInstance(project: Project): ScriptConfigurationManager? =
-            ServiceManager.getServiceIfCreated(project, ScriptConfigurationManager::class.java)
+        fun getServiceIfCreated(project: Project): ScriptConfigurationManager? =
+            project.serviceIfCreated()
 
         @JvmStatic
         fun getInstance(project: Project): ScriptConfigurationManager =

--- a/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/ScriptConfigurationManager.kt
+++ b/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/ScriptConfigurationManager.kt
@@ -108,6 +108,9 @@ interface ScriptConfigurationManager {
     fun getAllScriptDependenciesSources(): List<VirtualFile>
 
     companion object {
+        fun getAlreadyInitializedInstance(project: Project): ScriptConfigurationManager? =
+            ServiceManager.getServiceIfCreated(project, ScriptConfigurationManager::class.java)
+
         @JvmStatic
         fun getInstance(project: Project): ScriptConfigurationManager =
             ServiceManager.getService(project, ScriptConfigurationManager::class.java)

--- a/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/ScriptDefinitionsManager.kt
+++ b/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/ScriptDefinitionsManager.kt
@@ -84,7 +84,9 @@ class ScriptDefinitionsManager(private val project: Project) : LazyScriptDefinit
     private val scriptDefinitionsCacheLock = ReentrantLock()
     private val scriptDefinitionsCache = SLRUMap<String, ScriptDefinition>(10, 10)
 
-    val configurations = (ScriptConfigurationManager.getInstance(project) as CompositeScriptConfigurationManager)
+    // cache service as it's getter is on the hot path
+    // it is save, since both services are in same plugin
+    val configurations = ScriptConfigurationManager.getInstance(project) as CompositeScriptConfigurationManager
 
     override fun findDefinition(script: SourceCode): ScriptDefinition? {
         val locationId = script.locationId ?: return null

--- a/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/ScriptDefinitionsManager.kt
+++ b/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/ScriptDefinitionsManager.kt
@@ -85,7 +85,7 @@ class ScriptDefinitionsManager(private val project: Project) : LazyScriptDefinit
     private val scriptDefinitionsCache = SLRUMap<String, ScriptDefinition>(10, 10)
 
     // cache service as it's getter is on the hot path
-    // it is save, since both services are in same plugin
+    // it is safe, since both services are in same plugin
     val configurations = ScriptConfigurationManager.getInstance(project) as CompositeScriptConfigurationManager
 
     override fun findDefinition(script: SourceCode): ScriptDefinition? {

--- a/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/ScriptTrafficLightRendererContributor.kt
+++ b/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/ScriptTrafficLightRendererContributor.kt
@@ -28,7 +28,7 @@ class ScriptTrafficLightRendererContributor : TrafficLightRendererContributor {
         override fun getDaemonCodeAnalyzerStatus(severityRegistrar: SeverityRegistrar): DaemonCodeAnalyzerStatus {
             val status = super.getDaemonCodeAnalyzerStatus(severityRegistrar)
 
-            val configurations = ScriptConfigurationManager.getAlreadyInitializedInstance(project)
+            val configurations = ScriptConfigurationManager.getServiceIfCreated(project)
             if (configurations == null) {
                 // services not yet initialized (it should be initialized under the LoadScriptDefinitionsStartupActivity)
                 status.reasonWhySuspended = KotlinIdeaCoreBundle.message("text.loading.kotlin.script.configuration")

--- a/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/ScriptTrafficLightRendererContributor.kt
+++ b/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/ScriptTrafficLightRendererContributor.kt
@@ -27,10 +27,16 @@ class ScriptTrafficLightRendererContributor : TrafficLightRendererContributor {
         TrafficLightRenderer(project, document, file) {
         override fun getDaemonCodeAnalyzerStatus(severityRegistrar: SeverityRegistrar): DaemonCodeAnalyzerStatus {
             val status = super.getDaemonCodeAnalyzerStatus(severityRegistrar)
-            if (!ScriptDefinitionsManager.getInstance(file.project).isReady()) {
+
+            val configurations = ScriptConfigurationManager.getAlreadyInitializedInstance(project)
+            if (configurations == null) {
+                // services not yet initialized (it should be initialized under the LoadScriptDefinitionsStartupActivity)
+                status.reasonWhySuspended = KotlinIdeaCoreBundle.message("text.loading.kotlin.script.configuration")
+                status.errorAnalyzingFinished = false
+            } else if (!ScriptDefinitionsManager.getInstance(file.project).isReady()) {
                 status.reasonWhySuspended = KotlinIdeaCoreBundle.message("text.loading.kotlin.script.definitions")
                 status.errorAnalyzingFinished = false
-             } else if (ScriptConfigurationManager.getInstance(project).isConfigurationLoadingInProgress(file)) {
+            } else if (configurations.isConfigurationLoadingInProgress(file)) {
                 status.reasonWhySuspended = KotlinIdeaCoreBundle.message("text.loading.kotlin.script.configuration")
                 status.errorAnalyzingFinished = false
             }

--- a/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/configuration/CompositeScriptConfigurationManager.kt
+++ b/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/configuration/CompositeScriptConfigurationManager.kt
@@ -49,7 +49,8 @@ class CompositeScriptConfigurationManager(val project: Project) : ScriptConfigur
     private val classpathRoots: ScriptClassRootsCache
         get() = updater.classpathRoots
 
-    private val plugins = ScriptingSupport.EPN.getPoint(project).extensionList
+    private val plugins
+        get() = ScriptingSupport.EPN.getPoint(project).extensionList
 
     val default = DefaultScriptingSupport(this)
 

--- a/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/configuration/listener/ScriptChangesNotifier.kt
+++ b/idea/idea-core/src/org/jetbrains/kotlin/idea/core/script/configuration/listener/ScriptChangesNotifier.kt
@@ -83,10 +83,11 @@ internal class ScriptChangesNotifier(
     }
 
     private val defaultListener = DefaultScriptChangeListener(project)
-    private val listeners: Collection<ScriptChangeListener> = mutableListOf<ScriptChangeListener>().apply {
-        addAll(LISTENER.getPoint(project).extensionList)
-        add(defaultListener)
-    }
+    private val listeners: Collection<ScriptChangeListener>
+        get() = mutableListOf<ScriptChangeListener>().apply {
+            addAll(LISTENER.getPoint(project).extensionList)
+            add(defaultListener)
+        }
 
     private fun getListener(project: Project, file: VirtualFile): ScriptChangeListener? {
         if (project.isDisposed || areListenersDisabled()) return null

--- a/idea/idea-gradle/src/org/jetbrains/kotlin/idea/scripting/gradle/AsyncFileChangeListenerHelper.kt
+++ b/idea/idea-gradle/src/org/jetbrains/kotlin/idea/scripting/gradle/AsyncFileChangeListenerHelper.kt
@@ -33,9 +33,10 @@ fun addVfsListener(
             }
 
             override fun apply() {
+                val fileChangesProcessor = watcher.fileChangesProcessor
                 changedFiles.forEach {
                     LocalFileSystem.getInstance().findFileByPath(it)?.let { f ->
-                        watcher.fileChanged(f.path, f.timeStamp)
+                        fileChangesProcessor(f.path, f.timeStamp)
                     }
                 }
             }

--- a/idea/idea-gradle/src/org/jetbrains/kotlin/idea/scripting/gradle/AsyncFileChangeListenerHelper.kt.193
+++ b/idea/idea-gradle/src/org/jetbrains/kotlin/idea/scripting/gradle/AsyncFileChangeListenerHelper.kt.193
@@ -17,19 +17,22 @@ fun addVfsListener(
 ) {
     VirtualFileManager.getInstance().addAsyncFileListener(
         object : AsyncFileChangeListenerBase() {
+            var fileChangesProcessor = watcher.fileChangesProcessor
+
             override fun isRelevant(path: String): Boolean {
                 return buildRootsManager.maybeAffectedGradleProjectFile(path)
             }
 
             override fun updateFile(file: VirtualFile, event: VFileEvent) {
-                watcher.fileChanged(event.path, file.timeStamp)
+                fileChangesProcessor(event.path, file.timeStamp)
             }
 
             // do nothing
             override fun prepareFileDeletion(file: VirtualFile) {}
             override fun apply() {}
-            override fun reset() {}
-
+            override fun reset() {
+                fileChangesProcessor = watcher.fileChangesProcessor
+            }
         },
         watcher.project
     )

--- a/idea/idea-gradle/src/org/jetbrains/kotlin/idea/scripting/gradle/GradleImportHelper.kt
+++ b/idea/idea-gradle/src/org/jetbrains/kotlin/idea/scripting/gradle/GradleImportHelper.kt
@@ -26,6 +26,7 @@ import org.jetbrains.kotlin.idea.core.script.settings.KotlinScriptingSettings
 import org.jetbrains.kotlin.idea.scripting.gradle.importing.KotlinDslScriptModelResolver
 import org.jetbrains.kotlin.idea.scripting.gradle.roots.GradleBuildRoot
 import org.jetbrains.kotlin.idea.scripting.gradle.roots.GradleBuildRootsManager
+import org.jetbrains.kotlin.scripting.definitions.ScriptDefinitionProvider
 import org.jetbrains.kotlin.scripting.definitions.findScriptDefinition
 import org.jetbrains.plugins.gradle.service.project.GradlePartialResolverPolicy
 import org.jetbrains.plugins.gradle.settings.GradleProjectSettings
@@ -98,10 +99,14 @@ class LoadConfigurationAction : AnAction(
 
     private fun getNotificationVisibility(editor: Editor): Boolean {
         if (!scriptConfigurationsNeedToBeUpdatedBalloon) return false
-
         if (DiffUtil.isDiffEditor(editor)) return false
 
         val project = editor.project ?: return false
+
+        // prevent services initializtion
+        // (all services actually initialized under the ScriptDefinitionProvider during startup activity)
+        if (ScriptDefinitionProvider.getAlreadyCreateInstance(project) == null) return false
+
         val file = getKotlinScriptFile(editor) ?: return false
 
         if (autoReloadScriptConfigurations(project, file)) {

--- a/idea/idea-gradle/src/org/jetbrains/kotlin/idea/scripting/gradle/GradleImportHelper.kt
+++ b/idea/idea-gradle/src/org/jetbrains/kotlin/idea/scripting/gradle/GradleImportHelper.kt
@@ -105,7 +105,7 @@ class LoadConfigurationAction : AnAction(
 
         // prevent services initializtion
         // (all services actually initialized under the ScriptDefinitionProvider during startup activity)
-        if (ScriptDefinitionProvider.getAlreadyCreateInstance(project) == null) return false
+        if (ScriptDefinitionProvider.getServiceIfCreated(project) == null) return false
 
         val file = getKotlinScriptFile(editor) ?: return false
 

--- a/idea/idea-gradle/src/org/jetbrains/kotlin/idea/scripting/gradle/GradleScriptListener.kt
+++ b/idea/idea-gradle/src/org/jetbrains/kotlin/idea/scripting/gradle/GradleScriptListener.kt
@@ -14,15 +14,26 @@ import org.jetbrains.kotlin.idea.scripting.gradle.roots.GradleBuildRootsManager
 class GradleScriptListener(project: Project) : ScriptChangeListener(project) {
     // todo(gradle6): remove
     private val legacy = GradleLegacyScriptListener(project)
-    private val buildRootsManager = GradleBuildRootsManager.getInstance(project)
+
+    private val buildRootsManager
+        get() = GradleBuildRootsManager.getInstance(project)
 
     init {
         // listen changes using VFS events, including gradle-configuration related files
         addVfsListener(this, buildRootsManager)
     }
 
+    // caches services for hot path under vfs changes listener
+    val fileChangesProcessor: (filePath: String, ts: Long) -> Unit
+        get() {
+            val buildRootsManager = buildRootsManager
+            return { filePath, ts ->
+                buildRootsManager.fileChanged(filePath, ts)
+            }
+        }
+
     fun fileChanged(filePath: String, ts: Long) =
-        buildRootsManager.fileChanged(filePath, ts)
+        fileChangesProcessor(filePath, ts)
 
     override fun isApplicable(vFile: VirtualFile) =
         // todo(gradle6): replace with `isCustomScriptingSupport(vFile)`

--- a/idea/idea-gradle/src/org/jetbrains/kotlin/idea/scripting/gradle/GradleScriptListener.kt
+++ b/idea/idea-gradle/src/org/jetbrains/kotlin/idea/scripting/gradle/GradleScriptListener.kt
@@ -23,7 +23,7 @@ class GradleScriptListener(project: Project) : ScriptChangeListener(project) {
         addVfsListener(this, buildRootsManager)
     }
 
-    // caches services for hot path under vfs changes listener
+    // cache buildRootsManager service for hot path under vfs changes listener
     val fileChangesProcessor: (filePath: String, ts: Long) -> Unit
         get() {
             val buildRootsManager = buildRootsManager

--- a/idea/idea-gradle/src/org/jetbrains/kotlin/idea/scripting/gradle/legacy/GradleLegacyScriptConfigurationLoader.kt
+++ b/idea/idea-gradle/src/org/jetbrains/kotlin/idea/scripting/gradle/legacy/GradleLegacyScriptConfigurationLoader.kt
@@ -27,7 +27,8 @@ import org.jetbrains.kotlin.scripting.definitions.ScriptDefinition
  * TODO(gradle6): remove
  */
 class GradleLegacyScriptConfigurationLoader(project: Project) : DefaultScriptConfigurationLoader(project) {
-    private val buildRootsManager = GradleBuildRootsManager.getInstance(project)
+    private val buildRootsManager
+        get() = GradleBuildRootsManager.getInstance(project)
 
     override fun interceptBackgroundLoading(file: VirtualFile, isFirstLoad: Boolean, doLoad: () -> Unit): Boolean {
         if (!isGradleKotlinScript(file)) return false

--- a/idea/idea-gradle/src/org/jetbrains/kotlin/idea/scripting/gradle/legacy/GradleLegacyScriptListener.kt
+++ b/idea/idea-gradle/src/org/jetbrains/kotlin/idea/scripting/gradle/legacy/GradleLegacyScriptListener.kt
@@ -14,7 +14,8 @@ import org.jetbrains.kotlin.idea.scripting.gradle.roots.GradleBuildRootsManager
 // called from GradleScriptListener
 // todo(gradle6): remove
 class GradleLegacyScriptListener(project: Project) : ScriptChangeListener(project) {
-    private val buildRootsManager = GradleBuildRootsManager.getInstance(project)
+    private val buildRootsManager
+        get() = GradleBuildRootsManager.getInstance(project)
 
     override fun isApplicable(vFile: VirtualFile) =
         isGradleKotlinScript(vFile)

--- a/idea/idea-gradle/src/org/jetbrains/kotlin/idea/scripting/gradle/roots/GradleBuildRootsManager.kt
+++ b/idea/idea-gradle/src/org/jetbrains/kotlin/idea/scripting/gradle/roots/GradleBuildRootsManager.kt
@@ -21,7 +21,6 @@ import org.jetbrains.kotlin.idea.core.script.ScriptConfigurationManager
 import org.jetbrains.kotlin.idea.core.script.configuration.CompositeScriptConfigurationManager
 import org.jetbrains.kotlin.idea.core.script.configuration.DefaultScriptingSupport
 import org.jetbrains.kotlin.idea.core.script.configuration.ScriptingSupport
-import org.jetbrains.kotlin.idea.core.script.configuration.ScriptingSupport.Companion.EPN
 import org.jetbrains.kotlin.idea.core.script.ucache.ScriptClassRootsBuilder
 import org.jetbrains.kotlin.idea.core.util.EDT
 import org.jetbrains.kotlin.idea.scripting.gradle.*
@@ -456,6 +455,6 @@ class GradleBuildRootsManager(val project: Project) : GradleBuildRootsLocator(),
 
     companion object {
         fun getInstance(project: Project): GradleBuildRootsManager =
-            EPN.getPoint(project).extensionList.firstIsInstance()
+            ScriptingSupport.EPN.findExtensionOrFail(GradleBuildRootsManager::class.java, project)
     }
 }

--- a/plugins/scripting/scripting-compiler-impl/src/org/jetbrains/kotlin/scripting/definitions/KotlinScriptDefinitionProvider.kt
+++ b/plugins/scripting/scripting-compiler-impl/src/org/jetbrains/kotlin/scripting/definitions/KotlinScriptDefinitionProvider.kt
@@ -27,7 +27,7 @@ interface ScriptDefinitionProvider {
         fun getInstance(project: Project): ScriptDefinitionProvider? =
             ServiceManager.getService(project, ScriptDefinitionProvider::class.java)
 
-        fun getAlreadyCreateInstance(project: Project): ScriptDefinitionProvider? =
+        fun getServiceIfCreated(project: Project): ScriptDefinitionProvider? =
             ServiceManager.getServiceIfCreated(project, ScriptDefinitionProvider::class.java)
     }
 }

--- a/plugins/scripting/scripting-compiler-impl/src/org/jetbrains/kotlin/scripting/definitions/KotlinScriptDefinitionProvider.kt
+++ b/plugins/scripting/scripting-compiler-impl/src/org/jetbrains/kotlin/scripting/definitions/KotlinScriptDefinitionProvider.kt
@@ -26,6 +26,9 @@ interface ScriptDefinitionProvider {
     companion object {
         fun getInstance(project: Project): ScriptDefinitionProvider? =
             ServiceManager.getService(project, ScriptDefinitionProvider::class.java)
+
+        fun getAlreadyCreateInstance(project: Project): ScriptDefinitionProvider? =
+            ServiceManager.getServiceIfCreated(project, ScriptDefinitionProvider::class.java)
     }
 }
 


### PR DESCRIPTION
- prevent analyzing .gradle.kts files until all services are loaded
- remove services caches where it is not required
- replace cached services with cache only during vfs events batch processing
- prevent services loading in actions updating