### PR TITLE
KT-39604 "Package directive doesn't match file location" quick fix does not insert a space between keyword `package` and the package name

### DIFF
--- a/compiler/psi/src/org/jetbrains/kotlin/psi/KtPackageDirective.java
+++ b/compiler/psi/src/org/jetbrains/kotlin/psi/KtPackageDirective.java
@@ -137,6 +137,7 @@ public class KtPackageDirective extends KtModifierListOwnerStub<KotlinPlaceHolde
         PsiElement keyword = getPackageKeyword();
         if (keyword != null) {
             addAfter(newExpression, keyword);
+            addAfter(psiFactory.createWhiteSpace(), keyword);
             return;
         }
 

--- a/idea/testData/multiFileLocalInspections/reconcilePackageWithDirectory/changeToNonDefaultPackageFromRootWithPackageKeyword/after/com/example/test.kt
+++ b/idea/testData/multiFileLocalInspections/reconcilePackageWithDirectory/changeToNonDefaultPackageFromRootWithPackageKeyword/after/com/example/test.kt
@@ -1,0 +1,3 @@
+package com.example
+
+class Foo

--- a/idea/testData/multiFileLocalInspections/reconcilePackageWithDirectory/changeToNonDefaultPackageFromRootWithPackageKeyword/before/com/example/test.kt
+++ b/idea/testData/multiFileLocalInspections/reconcilePackageWithDirectory/changeToNonDefaultPackageFromRootWithPackageKeyword/before/com/example/test.kt
@@ -1,0 +1,3 @@
+<caret>package
+
+class Foo

--- a/idea/testData/multiFileLocalInspections/reconcilePackageWithDirectory/changeToNonDefaultPackageFromRootWithPackageKeyword/changeToNonDefaultPackageFromRootWithPackageKeyword.test
+++ b/idea/testData/multiFileLocalInspections/reconcilePackageWithDirectory/changeToNonDefaultPackageFromRootWithPackageKeyword/changeToNonDefaultPackageFromRootWithPackageKeyword.test
@@ -1,0 +1,5 @@
+{
+  "mainFile": "com/example/test.kt",
+  "inspectionClass": "org.jetbrains.kotlin.idea.refactoring.move.changePackage.PackageDirectoryMismatchInspection",
+  "fix": "Change file's package to 'com.example'"
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/MultiFileLocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/MultiFileLocalInspectionTestGenerated.java
@@ -78,6 +78,11 @@ public class MultiFileLocalInspectionTestGenerated extends AbstractMultiFileLoca
         runTest("idea/testData/multiFileLocalInspections/reconcilePackageWithDirectory/changeToNonDefaultPackageFromRoot/changeToNonDefaultPackageFromRoot.test");
     }
 
+    @TestMetadata("reconcilePackageWithDirectory/changeToNonDefaultPackageFromRootWithPackageKeyword/changeToNonDefaultPackageFromRootWithPackageKeyword.test")
+    public void testReconcilePackageWithDirectory_changeToNonDefaultPackageFromRootWithPackageKeyword_ChangeToNonDefaultPackageFromRootWithPackageKeyword() throws Exception {
+        runTest("idea/testData/multiFileLocalInspections/reconcilePackageWithDirectory/changeToNonDefaultPackageFromRootWithPackageKeyword/changeToNonDefaultPackageFromRootWithPackageKeyword.test");
+    }
+
     @TestMetadata("reconcilePackageWithDirectory/innerClass/innerClass.test")
     public void testReconcilePackageWithDirectory_innerClass_InnerClass() throws Exception {
         runTest("idea/testData/multiFileLocalInspections/reconcilePackageWithDirectory/innerClass/innerClass.test");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-39604