### PR TITLE
Fix KotlinCoreEnvironment projectCount disposable

### DIFF
--- a/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment.kt
@@ -475,10 +475,13 @@ class KotlinCoreEnvironment private constructor(
                 if (System.getProperty(KOTLIN_COMPILER_ENVIRONMENT_KEEPALIVE_PROPERTY).toBooleanLenient() != true) {
                     // JPS may run many instances of the compiler in parallel (there's an option for compiling independent modules in parallel in IntelliJ)
                     // All projects share the same ApplicationEnvironment, and when the last project is disposed, the ApplicationEnvironment is disposed as well
-                    Disposer.register(parentDisposable, Disposable {
-                        synchronized(APPLICATION_LOCK) {
-                            if (--ourProjectCount <= 0) {
-                                disposeApplicationEnvironment()
+                    @Suppress("ObjectLiteralToLambda") // Disposer tree depends on identity of disposables.
+                    Disposer.register(parentDisposable, object : Disposable {
+                        override fun dispose() {
+                            synchronized(APPLICATION_LOCK) {
+                                if (--ourProjectCount <= 0) {
+                                    disposeApplicationEnvironment()
+                                }
                             }
                         }
                     })


### PR DESCRIPTION
The disposable which decrements ourProjectCount was a non-capturing
lambda, meaning it had a single identity and could only be registered
in the Disposer tree once. Therefore the application environment
would never be disposed if ourProjectCount ever went above 1.