### PR TITLE
KT-39421 KJS: False positive "Implicit (unsafe) cast from dynamic" inspection for Any? parameter

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/UnsafeCastFromDynamicInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/UnsafeCastFromDynamicInspection.kt
@@ -20,6 +20,7 @@ import org.jetbrains.kotlin.resolve.lazy.BodyResolveMode
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.TypeUtils
 import org.jetbrains.kotlin.types.isDynamic
+import org.jetbrains.kotlin.types.typeUtil.isNullableAny
 
 class UnsafeCastFromDynamicInspection : AbstractKotlinInspection() {
     override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean, session: LocalInspectionToolSession): PsiElementVisitor =
@@ -28,7 +29,9 @@ class UnsafeCastFromDynamicInspection : AbstractKotlinInspection() {
             val expectedType = context[BindingContext.EXPECTED_EXPRESSION_TYPE, expression] ?: return
             val actualType = expression.getType(context) ?: return
 
-            if (actualType.isDynamic() && !expectedType.isDynamic() && !TypeUtils.noExpectedType(expectedType)) {
+            if (actualType.isDynamic() && !expectedType.isDynamic() && !expectedType.isNullableAny() &&
+                !TypeUtils.noExpectedType(expectedType)
+            ) {
                 holder.registerProblem(
                     expression,
                     KotlinBundle.message("implicit.unsafe.cast.from.dynamic.to.0", expectedType),

--- a/idea/testData/inspectionsLocal/unsafeCastFromDynamic/nullableAny.kt
+++ b/idea/testData/inspectionsLocal/unsafeCastFromDynamic/nullableAny.kt
@@ -1,0 +1,8 @@
+// JS
+// PROBLEM: none
+fun test(b: dynamic) {
+    foo(<caret>b)
+}
+
+fun foo(o: Any?) {
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -13623,6 +13623,11 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
             runTest("idea/testData/inspectionsLocal/unsafeCastFromDynamic/nullable.kt");
         }
 
+        @TestMetadata("nullableAny.kt")
+        public void testNullableAny() throws Exception {
+            runTest("idea/testData/inspectionsLocal/unsafeCastFromDynamic/nullableAny.kt");
+        }
+
         @TestMetadata("simple.kt")
         public void testSimple() throws Exception {
             runTest("idea/testData/inspectionsLocal/unsafeCastFromDynamic/simple.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-39421