### PR TITLE
Keep com.google dependencies intact

### DIFF
--- a/prepare/compiler/compiler.pro
+++ b/prepare/compiler/compiler.pro
@@ -100,6 +100,8 @@
     public protected *;
 }
 
+-keep class com.google.common.** { *; }
+
 -keep class org.jetbrains.kotlin.container.** { *; }
 
 -keep class org.jetbrains.org.objectweb.asm.Opcodes { *; }


### PR DESCRIPTION
It would be much more preferable if the `com.google` dependencies could be repackaged to live in a different namespace so they don't conflict with the Google-provided packages.  But at the very least, if we're going to include them in the Google package, it's helpful to keep all of them, to avoid subtle compatibility issues when only some classes are overridden.