### PR TITLE
Fallback to fileEntry provided by irFile

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/irCodegenUtils.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/irCodegenUtils.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.backend.common.ir.ir2string
 import org.jetbrains.kotlin.backend.common.lower.allOverridden
 import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
 import org.jetbrains.kotlin.backend.jvm.JvmLoweredDeclarationOrigin
+import org.jetbrains.kotlin.backend.jvm.lower.MultifileFacadeFileEntry
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns.FQ_NAMES
 import org.jetbrains.kotlin.builtins.jvm.JavaToKotlinClassMap
@@ -88,7 +89,10 @@ fun JvmBackendContext.getSourceMapper(declaration: IrClass): SourceMapper {
     // NOTE: apparently inliner requires the source range to cover the
     //       whole file the class is declared in rather than the class only.
     // TODO: revise
-    val endLineNumber = fileEntry?.getSourceRangeInfo(0, fileEntry.maxOffset)?.endLineNumber ?: 0
+    val endLineNumber = when {
+        fileEntry is MultifileFacadeFileEntry -> 0
+        else -> fileEntry?.getSourceRangeInfo(0, fileEntry.maxOffset)?.endLineNumber ?: 0
+    }
     return SourceMapper(
         SourceInfo.createInfoForIr(
             endLineNumber + 1,

--- a/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/PsiSourceManager.kt
+++ b/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/PsiSourceManager.kt
@@ -113,7 +113,7 @@ class PsiSourceManager : SourceManager {
         (irFile.fileEntry as? PsiFileEntry)?.let { ktFileByFileEntry[it] }
 
     override fun getFileEntry(irFile: IrFile): SourceManager.FileEntry? =
-        fileEntriesByIrFile[irFile]
+        fileEntriesByIrFile[irFile] ?: irFile.fileEntry
 
     fun <E : PsiElement> findPsiElement(irElement: IrElement, irFile: IrFile, psiElementClass: KClass<E>): E? {
         val psiFileEntry = fileEntriesByIrFile[irFile] ?: return null


### PR DESCRIPTION
This is necessary for our synthetics which can't easily be registered with the SourceManager fileEntriesByIrFile, but which can be provided a fileEntry on the IR node.