### PR TITLE
JVM IR: Do not create accessors for enum entry constructors

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/SyntheticAccessorLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/SyntheticAccessorLowering.kt
@@ -582,12 +582,16 @@ internal class SyntheticAccessorLowering(val context: JvmBackendContext) : IrEle
         // `internal` maps to public and requires no accessor.
         if (!withSuper && !declaration.visibility.isPrivate && !declaration.visibility.isProtected) return true
 
-        //`toArray` is always accessible cause mapped to public functions
+        // `toArray` is always accessible cause mapped to public functions
         if (symbolOwner is IrSimpleFunction && (symbolOwner.isNonGenericToArray(context) || symbolOwner.isGenericToArray(context))) {
             if (symbolOwner.parentAsClass.isCollectionSubClass) {
                 return true
             }
         }
+
+        // EnumEntry constructors are always accessible (they are only called from the enclosing Enum class)
+        if (symbolOwner is IrConstructor && symbolOwner.parentClassOrNull?.isEnumEntry == true)
+            return true
 
         // If local variables are accessible by Kotlin rules, they also are by Java rules.
         val ownerClass = declaration.parent as? IrClass ?: return true

--- a/compiler/testData/codegen/bytecodeText/enum/constructorAccessors.kt
+++ b/compiler/testData/codegen/bytecodeText/enum/constructorAccessors.kt
@@ -1,0 +1,15 @@
+enum class E(private val value: Int) {
+    A(0) {
+        override fun f() {}
+    },
+    B(1) {
+        override fun f() {}
+    };
+
+    abstract fun f()
+}
+
+// The JVM BE creates an accessor for the constructor of `E`, but not for the constructors of the enum entry classes E$A and E$B.
+// 1 public synthetic <init>\(Ljava/lang/String;IILkotlin/jvm/internal/DefaultConstructorMarker;\)V
+// 2 INVOKESPECIAL E.<init> \(Ljava/lang/String;IILkotlin/jvm/internal/DefaultConstructorMarker;\)V
+// 3 kotlin/jvm/internal/DefaultConstructorMarker;\)

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
@@ -1870,6 +1870,11 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
             KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/bytecodeText/enum"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM, true);
         }
 
+        @TestMetadata("constructorAccessors.kt")
+        public void testConstructorAccessors() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/enum/constructorAccessors.kt");
+        }
+
         @TestMetadata("enumCheckcasts.kt")
         public void testEnumCheckcasts() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/enum/enumCheckcasts.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
@@ -1825,6 +1825,11 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
             KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/bytecodeText/enum"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
         }
 
+        @TestMetadata("constructorAccessors.kt")
+        public void testConstructorAccessors() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/enum/constructorAccessors.kt");
+        }
+
         @TestMetadata("enumCheckcasts.kt")
         public void testEnumCheckcasts() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/enum/enumCheckcasts.kt");


### PR DESCRIPTION
Enum entry constructors are package private and only called from the enclosing enum class, so we don't need to generate accessors.