### PR TITLE
Set wantsDiagnostics() in AbstractFilteringTrace

### DIFF
--- a/compiler/frontend/src/org/jetbrains/kotlin/resolve/AbstractFilteringTrace.kt
+++ b/compiler/frontend/src/org/jetbrains/kotlin/resolve/AbstractFilteringTrace.kt
@@ -39,4 +39,6 @@ abstract class AbstractFilteringTrace(
     override fun report(diagnostic: Diagnostic) {
         parentTrace.report(diagnostic)
     }
+
+    override fun wantsDiagnostics(): Boolean = parentTrace.wantsDiagnostics()
 }


### PR DESCRIPTION
report() already delegates to the parentTrace, so
wantsDiagnostics() should delegate to it as well.

cc @dsavvinov who wrote `AbstractFilteringTrace`.
(Does this change look right to you?)

This change came about while investigating Android Lint performance,
which uses `TopDownAnalyzerFacadeForJVM`.