### PR TITLE
Kotlin-test: floating point assertions.

### DIFF
--- a/libraries/kotlin.test/common/src/main/kotlin/kotlin/test/Assertions.kt
+++ b/libraries/kotlin.test/common/src/main/kotlin/kotlin/test/Assertions.kt
@@ -75,6 +75,18 @@ fun <@OnlyInputTypes T> assertNotEquals(illegal: T, actual: T, message: String? 
     asserter.assertNotEquals(message, illegal, actual)
 }
 
+/** Asserts that [actual] is not within a [delta] value of the [illegal] value with an optional [message]. */
+@SinceKotlin("1.4")
+fun assertNotEquals(illegal: Double, actual: Double, delta: Double, message: String? = null) {
+    asserter.assertNotEquals(message, illegal, actual, delta)
+}
+
+/** Asserts that [actual] is not within a [delta] value of the [illegal] value with an optional [message]. */
+@SinceKotlin("1.4")
+fun assertNotEquals(illegal: Float, actual: Float, delta: Float, message: String? = null) {
+    asserter.assertNotEquals(message, illegal, actual, delta)
+}
+
 /** Asserts that [expected] is the same instance as [actual], with an optional [message]. */
 fun <@OnlyInputTypes T> assertSame(expected: T, actual: T, message: String? = null) {
     asserter.assertSame(message, expected, actual)
@@ -285,6 +297,26 @@ interface Asserter {
      */
     fun assertNotEquals(message: String?, illegal: Any?, actual: Any?): Unit {
         assertTrue({ messagePrefix(message) + "Illegal value: <$actual>." }, actual != illegal)
+    }
+
+    /**
+     * Asserts that the specified values are not within a delta.
+     *
+     * @param message the message to report if the assertion fails.
+     */
+    @SinceKotlin("1.4")
+    fun assertNotEquals(message: String?, illegal: Double, actual: Double, delta: Double): Unit {
+        assertTrue({ messagePrefix(message) + "Illegal value <$illegal> with delta <$delta>, actual <$actual>" }, abs(illegal - actual) > delta)
+    }
+
+    /**
+     * Asserts that the specified values are not within a delta.
+     *
+     * @param message the message to report if the assertion fails.
+     */
+    @SinceKotlin("1.4")
+    fun assertNotEquals(message: String?, illegal: Float, actual: Float, delta: Float): Unit {
+        assertTrue({ messagePrefix(message) + "Illegal value <$illegal> with delta <$delta>, actual <$actual>" }, abs(illegal - actual) > delta)
     }
 
     /**

--- a/libraries/kotlin.test/common/src/main/kotlin/kotlin/test/Assertions.kt
+++ b/libraries/kotlin.test/common/src/main/kotlin/kotlin/test/Assertions.kt
@@ -15,6 +15,7 @@ package kotlin.test
 import kotlin.contracts.*
 import kotlin.internal.*
 import kotlin.jvm.JvmName
+import kotlin.math.abs
 import kotlin.native.concurrent.ThreadLocal
 import kotlin.reflect.KClass
 
@@ -55,6 +56,18 @@ fun assertFalse(actual: Boolean, message: String? = null) {
 /** Asserts that the [expected] value is equal to the [actual] value, with an optional [message]. */
 fun <@OnlyInputTypes T> assertEquals(expected: T, actual: T, message: String? = null) {
     asserter.assertEquals(message, expected, actual)
+}
+
+/** Asserts that [actual] is within a [delta] value of the [expected] value with an optional [message]. */
+@SinceKotlin("1.4")
+fun assertEquals(expected: Double, actual: Double, delta: Double, message: String? = null) {
+    asserter.assertEquals(message, expected, actual, delta)
+}
+
+/** Asserts that [actual] is within a [delta] value of the [expected] value with an optional [message]. */
+@SinceKotlin("1.4")
+fun assertEquals(expected: Float, actual: Float, delta: Float, message: String? = null) {
+    asserter.assertEquals(message, expected, actual, delta)
 }
 
 /** Asserts that the [actual] value is not equal to the illegal value, with an optional [message]. */
@@ -243,6 +256,26 @@ interface Asserter {
      */
     fun assertEquals(message: String?, expected: Any?, actual: Any?): Unit {
         assertTrue({ messagePrefix(message) + "Expected <$expected>, actual <$actual>." }, actual == expected)
+    }
+
+    /**
+     * Asserts that the specified values are within a delta.
+     *
+     * @param message the message to report if the assertion fails.
+     */
+    @SinceKotlin("1.4")
+    fun assertEquals(message: String?, expected: Double, actual: Double, delta: Double): Unit {
+        assertTrue({ messagePrefix(message) + "Expected value <$expected> with delta <$delta>, actual <$actual>" }, abs(expected - actual) <= delta)
+    }
+
+    /**
+     * Asserts that the specified values are within a delta.
+     *
+     * @param message the message to report if the assertion fails.
+     */
+    @SinceKotlin("1.4")
+    fun assertEquals(message: String?, expected: Float, actual: Float, delta: Float): Unit {
+        assertTrue({ messagePrefix(message) + "Expected value <$expected> with delta <$delta>, actual <$actual>" }, abs(expected - actual) <= delta)
     }
 
     /**

--- a/libraries/kotlin.test/common/src/test/kotlin/kotlin/test/tests/BasicAssertionsTest.kt
+++ b/libraries/kotlin.test/common/src/test/kotlin/kotlin/test/tests/BasicAssertionsTest.kt
@@ -88,6 +88,26 @@ class BasicAssertionsTest {
     }
 
     @Test
+    fun testAssertEqualsDouble() {
+        assertEquals(0.01, 0.02, .01)
+    }
+
+    @Test
+    fun testAssertEqualsDoubleFails() {
+        checkFailedAssertion { assertEquals(0.01, 1.03, .01) }
+    }
+
+    @Test
+    fun testAssertEqualsFloat() {
+        assertEquals(0.01f, 0.02f, .01f)
+    }
+
+    @Test
+    fun testAssertEqualsFloatFails() {
+        checkFailedAssertion { assertEquals(0.01f, 1.03f, .01f) }
+    }
+
+    @Test
     fun testAssertTrue() {
         assertTrue(true)
         assertTrue { true }

--- a/libraries/kotlin.test/common/src/test/kotlin/kotlin/test/tests/BasicAssertionsTest.kt
+++ b/libraries/kotlin.test/common/src/test/kotlin/kotlin/test/tests/BasicAssertionsTest.kt
@@ -108,6 +108,26 @@ class BasicAssertionsTest {
     }
 
     @Test
+    fun testAssertNotEqualsDouble() {
+        assertNotEquals(0.1, 0.3, 0.1)
+    }
+
+    @Test
+    fun testAssertNotEqualsDoubleFails() {
+        checkFailedAssertion { assertNotEquals(0.1, 0.11, 0.1) }
+    }
+
+    @Test
+    fun testAssertNotEqualsFloat() {
+        assertNotEquals(0.1f, 0.3f, 0.1f)
+    }
+
+    @Test
+    fun testAssertNotEqualsFloatFails() {
+        checkFailedAssertion { assertNotEquals(0.1f, 0.11f, .1f) }
+    }
+
+    @Test
     fun testAssertTrue() {
         assertTrue(true)
         assertTrue { true }

--- a/libraries/kotlin.test/junit/src/main/kotlin/JUnitSupport.kt
+++ b/libraries/kotlin.test/junit/src/main/kotlin/JUnitSupport.kt
@@ -46,6 +46,16 @@ object JUnitAsserter : Asserter {
         Assert.assertNotEquals(message, illegal, actual)
     }
 
+    @SinceKotlin("1.4")
+    override fun assertNotEquals(message: String?, illegal: Double, actual: Double, delta: Double) {
+        Assert.assertNotEquals(message, illegal, actual, delta)
+    }
+
+    @SinceKotlin("1.4")
+    override fun assertNotEquals(message: String?, illegal: Float, actual: Float, delta: Float) {
+        Assert.assertNotEquals(message, illegal, actual, delta)
+    }
+
     override fun assertSame(message: String?, expected: Any?, actual: Any?) {
         Assert.assertSame(message, expected, actual)
     }

--- a/libraries/kotlin.test/junit/src/main/kotlin/JUnitSupport.kt
+++ b/libraries/kotlin.test/junit/src/main/kotlin/JUnitSupport.kt
@@ -32,6 +32,16 @@ object JUnitAsserter : Asserter {
         Assert.assertEquals(message, expected, actual)
     }
 
+    @SinceKotlin("1.4")
+    override fun assertEquals(message: String?, expected: Double, actual: Double, delta: Double) {
+        Assert.assertEquals(message, expected, actual, delta)
+    }
+
+    @SinceKotlin("1.4")
+    override fun assertEquals(message: String?, expected: Float, actual: Float, delta: Float) {
+        Assert.assertEquals(message, expected, actual, delta)
+    }
+
     override fun assertNotEquals(message: String?, illegal: Any?, actual: Any?) {
         Assert.assertNotEquals(message, illegal, actual)
     }

--- a/libraries/kotlin.test/junit5/src/main/kotlin/JUnitSupport.kt
+++ b/libraries/kotlin.test/junit5/src/main/kotlin/JUnitSupport.kt
@@ -32,6 +32,16 @@ object JUnit5Asserter : Asserter {
         Assertions.assertEquals(expected, actual, message)
     }
 
+    @SinceKotlin("1.4")
+    override fun assertEquals(message: String?, expected: Double, actual: Double, delta: Double) {
+        Assertions.assertEquals(expected, actual, delta, message)
+    }
+
+    @SinceKotlin("1.4")
+    override fun assertEquals(message: String?, expected: Float, actual: Float, delta: Float) {
+        Assertions.assertEquals(expected, actual, delta, message)
+    }
+
     override fun assertNotEquals(message: String?, illegal: Any?, actual: Any?) {
         Assertions.assertNotEquals(illegal, actual, message)
     }

--- a/libraries/kotlin.test/testng/src/main/kotlin/TestNGSupport.kt
+++ b/libraries/kotlin.test/testng/src/main/kotlin/TestNGSupport.kt
@@ -46,6 +46,16 @@ object TestNGAsserter : Asserter {
         Assert.assertNotEquals(actual, illegal, message)
     }
 
+    @SinceKotlin("1.4")
+    override fun assertNotEquals(message: String?, illegal: Double, actual: Double, delta: Double) {
+        Assert.assertNotEquals(actual, illegal, delta, message)
+    }
+
+    @SinceKotlin("1.4")
+    override fun assertNotEquals(message: String?, illegal: Float, actual: Float, delta: Float) {
+        Assert.assertNotEquals(actual, illegal, delta, message)
+    }
+
     override fun assertSame(message: String?, expected: Any?, actual: Any?) {
         Assert.assertSame(actual, expected, message)
     }

--- a/libraries/kotlin.test/testng/src/main/kotlin/TestNGSupport.kt
+++ b/libraries/kotlin.test/testng/src/main/kotlin/TestNGSupport.kt
@@ -32,6 +32,16 @@ object TestNGAsserter : Asserter {
         Assert.assertEquals(actual, expected, message)
     }
 
+    @SinceKotlin("1.4")
+    override fun assertEquals(message: String?, expected: Double, actual: Double, delta: Double) {
+        Assert.assertEquals(actual, expected, delta, message)
+    }
+
+    @SinceKotlin("1.4")
+    override fun assertEquals(message: String?, expected: Float, actual: Float, delta: Float) {
+        Assert.assertEquals(actual, expected, delta, message)
+    }
+
     override fun assertNotEquals(message: String?, illegal: Any?, actual: Any?) {
         Assert.assertNotEquals(actual, illegal, message)
     }


### PR DESCRIPTION
Add Float and Double implementations of `assertEquals` and `assertNotEquals` that take a delta for comparing floating point values within a tolerance.

Fixes [KT-8364](https://youtrack.jetbrains.com/issue/KT-8364)