### PR TITLE
FIR: account for vararg when creating KFunction type for callable reference

### DIFF
--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/ResolutionStages.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/ResolutionStages.kt
@@ -295,7 +295,10 @@ private fun FirSession.createKFunctionType(
         else -> expectedParameterNumberWithReceiver
     }
     for ((index, valueParameter) in function.valueParameters.withIndex()) {
-        if (expectedParameterNumber == null || index < expectedParameterNumber || valueParameter.defaultValue == null) {
+        if (expectedParameterNumber == null ||
+            index < expectedParameterNumber ||
+            (valueParameter.defaultValue == null && !valueParameter.isVararg)
+        ) {
             parameterTypes += valueParameter.returnTypeRef.coneType
         }
     }

--- a/compiler/testData/codegen/box/callableReference/adaptedReferences/bothWithCoercionToUnit.kt
+++ b/compiler/testData/codegen/box/callableReference/adaptedReferences/bothWithCoercionToUnit.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: +NewInference +FunctionReferenceWithDefaultValueAsOtherType
-// IGNORE_BACKEND_FIR: JVM_IR
 
 fun foo(s: String = "kotlin", vararg t: String): Boolean {
     if (s != "kotlin") throw AssertionError(s)

--- a/compiler/testData/codegen/box/callableReference/adaptedReferences/boundReferences.kt
+++ b/compiler/testData/codegen/box/callableReference/adaptedReferences/boundReferences.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: +NewInference +FunctionReferenceWithDefaultValueAsOtherType
-// IGNORE_BACKEND_FIR: JVM_IR
 // WITH_RUNTIME
 
 import kotlin.test.assertEquals

--- a/compiler/testData/codegen/box/callableReference/adaptedReferences/defaultAfterVararg.kt
+++ b/compiler/testData/codegen/box/callableReference/adaptedReferences/defaultAfterVararg.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: +NewInference +FunctionReferenceWithDefaultValueAsOtherType
-// IGNORE_BACKEND_FIR: JVM_IR
 
 fun foo(vararg a: String, result: String = "OK"): String =
         if (a.size == 0) result else "Fail"

--- a/compiler/testData/codegen/box/callableReference/adaptedReferences/emptyVarargAndDefault.kt
+++ b/compiler/testData/codegen/box/callableReference/adaptedReferences/emptyVarargAndDefault.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: +NewInference +FunctionReferenceWithDefaultValueAsOtherType
-// IGNORE_BACKEND_FIR: JVM_IR
 
 fun foo(x: String = "O", vararg y: String): String =
         if (y.size == 0) x + "K" else "Fail"

--- a/compiler/testData/codegen/box/callableReference/adaptedReferences/inlineBound.kt
+++ b/compiler/testData/codegen/box/callableReference/adaptedReferences/inlineBound.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 
 inline fun foo(x: () -> Unit): String {
     x()

--- a/compiler/testData/codegen/box/callableReference/adaptedReferences/inlineVarargAndDefault.kt
+++ b/compiler/testData/codegen/box/callableReference/adaptedReferences/inlineVarargAndDefault.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: +NewInference +FunctionReferenceWithDefaultValueAsOtherType
-// IGNORE_BACKEND_FIR: JVM_IR
 
 fun foo(vararg l: Long, s: String = "OK"): String =
         if (l.size == 0) s else "Fail"

--- a/compiler/testData/codegen/box/callableReference/adaptedReferences/manyDefaultsAndVararg.kt
+++ b/compiler/testData/codegen/box/callableReference/adaptedReferences/manyDefaultsAndVararg.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: +NewInference +FunctionReferenceWithDefaultValueAsOtherType
-// IGNORE_BACKEND_FIR: JVM_IR
 // WITH_RUNTIME
 
 import kotlin.test.assertEquals

--- a/compiler/testData/codegen/box/callableReference/adaptedReferences/simpleEmptyVararg.kt
+++ b/compiler/testData/codegen/box/callableReference/adaptedReferences/simpleEmptyVararg.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: +NewInference
-// IGNORE_BACKEND_FIR: JVM_IR
 
 fun foo(x: String, vararg y: String): String =
         if (y.size == 0) x + "K" else "Fail"

--- a/compiler/testData/codegen/box/callableReference/adaptedReferences/unboundReferences.kt
+++ b/compiler/testData/codegen/box/callableReference/adaptedReferences/unboundReferences.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: +NewInference +FunctionReferenceWithDefaultValueAsOtherType
-// IGNORE_BACKEND_FIR: JVM_IR
 // WITH_RUNTIME
 
 import kotlin.test.assertEquals

--- a/compiler/testData/codegen/box/callableReference/equality/varargWithDefaults.kt
+++ b/compiler/testData/codegen/box/callableReference/equality/varargWithDefaults.kt
@@ -1,6 +1,5 @@
 // IGNORE_BACKEND: JS, JS_IR, NATIVE
 // IGNORE_BACKEND: JS_IR_ES6
-// IGNORE_BACKEND_FIR: JVM_IR
 // FILE: test.kt
 
 fun checkEqual(x: Any, y: Any) {

--- a/compiler/testData/codegen/box/callableReference/kt37604.kt
+++ b/compiler/testData/codegen/box/callableReference/kt37604.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 
 fun useUnit(fn: () -> Unit) {
     fn.invoke()

--- a/compiler/testData/codegen/box/funInterface/equality/functionReferencesBound.kt
+++ b/compiler/testData/codegen/box/funInterface/equality/functionReferencesBound.kt
@@ -1,5 +1,4 @@
 // IGNORE_BACKEND: JS, JS_IR, JS_IR_ES6, NATIVE
-// IGNORE_BACKEND_FIR: JVM_IR
 // FILE: test.kt
 
 fun checkEqual(x: Any, y: Any) {

--- a/compiler/testData/codegen/box/funInterface/equality/functionReferencesUnbound.kt
+++ b/compiler/testData/codegen/box/funInterface/equality/functionReferencesUnbound.kt
@@ -1,5 +1,4 @@
 // IGNORE_BACKEND: JS, JS_IR, JS_IR_ES6, NATIVE
-// IGNORE_BACKEND_FIR: JVM_IR
 // FILE: test.kt
 
 fun checkEqual(x: Any, y: Any) {

--- a/compiler/testData/codegen/box/funInterface/equality/localFunctionReferences.kt
+++ b/compiler/testData/codegen/box/funInterface/equality/localFunctionReferences.kt
@@ -1,5 +1,4 @@
 // IGNORE_BACKEND: JS, JS_IR, JS_IR_ES6, NATIVE
-// IGNORE_BACKEND_FIR: JVM_IR
 
 fun checkEqual(x: Any, y: Any) {
     if (x != y || y != x) throw AssertionError("$x and $y should be equal")

--- a/compiler/testData/codegen/box/sam/equality/functionReferencesBound.kt
+++ b/compiler/testData/codegen/box/sam/equality/functionReferencesBound.kt
@@ -1,5 +1,4 @@
 // TARGET_BACKEND: JVM
-// IGNORE_BACKEND_FIR: JVM_IR
 // FILE: test.kt
 
 fun checkNotEqual(x: Any, y: Any) {

--- a/compiler/testData/codegen/box/sam/equality/functionReferencesUnbound.kt
+++ b/compiler/testData/codegen/box/sam/equality/functionReferencesUnbound.kt
@@ -1,5 +1,4 @@
 // TARGET_BACKEND: JVM
-// IGNORE_BACKEND_FIR: JVM_IR
 // FILE: test.kt
 
 fun checkNotEqual(x: Any, y: Any) {

--- a/compiler/testData/codegen/box/sam/equality/localFunctionReferences.kt
+++ b/compiler/testData/codegen/box/sam/equality/localFunctionReferences.kt
@@ -1,5 +1,4 @@
 // TARGET_BACKEND: JVM
-// IGNORE_BACKEND_FIR: JVM_IR
 
 fun checkNotEqual(x: Any, y: Any) {
     if (x == y || y == x) throw AssertionError("$x and $y should NOT be equal")

--- a/compiler/testData/diagnostics/tests/callableReference/referenceAdaptationHasDependencyOnApi14.fir.kt
+++ b/compiler/testData/diagnostics/tests/callableReference/referenceAdaptationHasDependencyOnApi14.fir.kt
@@ -13,6 +13,6 @@ fun allOfTheAbove(f: (A) -> Unit): Any = f
 fun test() {
     coercionToUnit(A::foo)
     <!INAPPLICABLE_CANDIDATE!>varargToElement<!>(A::foo)
-    <!INAPPLICABLE_CANDIDATE!>defaultAndVararg<!>(A::foo)
-    <!INAPPLICABLE_CANDIDATE!>allOfTheAbove<!>(A::foo)
+    defaultAndVararg(A::foo)
+    allOfTheAbove(A::foo)
 }

--- a/compiler/testData/ir/irText/expressions/callableReferences/adaptedExtensionFunctions.fir.txt
+++ b/compiler/testData/ir/irText/expressions/callableReferences/adaptedExtensionFunctions.fir.txt
@@ -43,13 +43,13 @@ FILE fqName:<root> fileName:/adaptedExtensionFunctions.kt
     BLOCK_BODY
   FUN name:testExtensionVararg visibility:public modality:FINAL <> () returnType:kotlin.Unit
     BLOCK_BODY
-      ERROR_CALL 'Unresolved reference: <Inapplicable(INAPPLICABLE): [/use]>#' type=IrErrorType
-        FUNCTION_REFERENCE 'public final fun extensionVararg (i: kotlin.Int, vararg s: kotlin.String): kotlin.Unit declared in <root>' type=kotlin.reflect.KFunction3<<root>.C, kotlin.Int, kotlin.Array<out kotlin.String>, kotlin.Unit> origin=null reflectionTarget=<same>
+      CALL 'public final fun use (f: kotlin.Function2<<root>.C, kotlin.Int, kotlin.Unit>): kotlin.Unit declared in <root>' type=kotlin.Unit origin=null
+        f: FUNCTION_REFERENCE 'public final fun extensionVararg (i: kotlin.Int, vararg s: kotlin.String): kotlin.Unit declared in <root>' type=kotlin.reflect.KFunction2<<root>.C, kotlin.Int, kotlin.Unit> origin=null reflectionTarget=<same>
   FUN name:testExtensionDefault visibility:public modality:FINAL <> () returnType:kotlin.Unit
     BLOCK_BODY
       CALL 'public final fun use (f: kotlin.Function2<<root>.C, kotlin.Int, kotlin.Unit>): kotlin.Unit declared in <root>' type=kotlin.Unit origin=null
         f: FUNCTION_REFERENCE 'public final fun extensionDefault (i: kotlin.Int, s: kotlin.String): kotlin.Unit declared in <root>' type=kotlin.reflect.KFunction2<<root>.C, kotlin.Int, kotlin.Unit> origin=null reflectionTarget=<same>
   FUN name:testExtensionBoth visibility:public modality:FINAL <> () returnType:kotlin.Unit
     BLOCK_BODY
-      ERROR_CALL 'Unresolved reference: <Inapplicable(INAPPLICABLE): [/use]>#' type=IrErrorType
-        FUNCTION_REFERENCE 'public final fun extensionBoth (i: kotlin.Int, s: kotlin.String, vararg t: kotlin.String): kotlin.Unit declared in <root>' type=kotlin.reflect.KFunction4<<root>.C, kotlin.Int, kotlin.String, kotlin.Array<out kotlin.String>, kotlin.Unit> origin=null reflectionTarget=<same>
+      CALL 'public final fun use (f: kotlin.Function2<<root>.C, kotlin.Int, kotlin.Unit>): kotlin.Unit declared in <root>' type=kotlin.Unit origin=null
+        f: FUNCTION_REFERENCE 'public final fun extensionBoth (i: kotlin.Int, s: kotlin.String, vararg t: kotlin.String): kotlin.Unit declared in <root>' type=kotlin.reflect.KFunction2<<root>.C, kotlin.Int, kotlin.Unit> origin=null reflectionTarget=<same>

--- a/compiler/testData/ir/irText/expressions/callableReferences/adaptedWithCoercionToUnit.fir.txt
+++ b/compiler/testData/ir/irText/expressions/callableReferences/adaptedWithCoercionToUnit.fir.txt
@@ -29,11 +29,11 @@ FILE fqName:<root> fileName:/adaptedWithCoercionToUnit.kt
       RETURN type=kotlin.Nothing from='public final fun test1 (): kotlin.Unit declared in <root>'
         CALL 'public final fun useUnit1 (fn: kotlin.Function1<kotlin.Int, kotlin.Unit>): kotlin.Unit declared in <root>' type=kotlin.Unit origin=null
           fn: FUNCTION_REFERENCE 'public final fun fn1 (x: kotlin.Int): kotlin.Int declared in <root>' type=kotlin.reflect.KFunction1<kotlin.Int, kotlin.Unit> origin=null reflectionTarget=<same>
-  FUN name:testV0 visibility:public modality:FINAL <> () returnType:IrErrorType
+  FUN name:testV0 visibility:public modality:FINAL <> () returnType:kotlin.Unit
     BLOCK_BODY
-      RETURN type=kotlin.Nothing from='public final fun testV0 (): IrErrorType declared in <root>'
-        ERROR_CALL 'Unresolved reference: <Inapplicable(INAPPLICABLE): [/useUnit0]>#' type=IrErrorType
-          FUNCTION_REFERENCE 'public final fun fnv (vararg xs: kotlin.Int): kotlin.Int declared in <root>' type=kotlin.reflect.KFunction1<kotlin.IntArray, kotlin.Int> origin=null reflectionTarget=<same>
+      RETURN type=kotlin.Nothing from='public final fun testV0 (): kotlin.Unit declared in <root>'
+        CALL 'public final fun useUnit0 (fn: kotlin.Function0<kotlin.Unit>): kotlin.Unit declared in <root>' type=kotlin.Unit origin=null
+          fn: FUNCTION_REFERENCE 'public final fun fnv (vararg xs: kotlin.Int): kotlin.Int declared in <root>' type=kotlin.reflect.KFunction0<kotlin.Unit> origin=null reflectionTarget=<same>
   FUN name:testV1 visibility:public modality:FINAL <> () returnType:IrErrorType
     BLOCK_BODY
       RETURN type=kotlin.Nothing from='public final fun testV1 (): IrErrorType declared in <root>'

--- a/compiler/testData/ir/irText/expressions/callableReferences/boundInlineAdaptedReference.fir.txt
+++ b/compiler/testData/ir/irText/expressions/callableReferences/boundInlineAdaptedReference.fir.txt
@@ -13,6 +13,6 @@ FILE fqName:test fileName:/boundInlineAdaptedReference.kt
         GET_VAR 's: kotlin.String declared in test.id' type=kotlin.String origin=null
   FUN name:test visibility:public modality:FINAL <> () returnType:kotlin.Unit
     BLOCK_BODY
-      ERROR_CALL 'Unresolved reference: <Inapplicable(INAPPLICABLE): [test/foo]>#' type=IrErrorType
-        FUNCTION_REFERENCE 'public final fun id (s: kotlin.String, vararg xs: kotlin.Int): kotlin.String declared in test' type=kotlin.reflect.KFunction2<kotlin.String, kotlin.IntArray, kotlin.String> origin=null reflectionTarget=<same>
+      CALL 'public final fun foo (x: kotlin.Function0<kotlin.Unit>): kotlin.Unit [inline] declared in test' type=kotlin.Unit origin=null
+        x: FUNCTION_REFERENCE 'public final fun id (s: kotlin.String, vararg xs: kotlin.Int): kotlin.String declared in test' type=kotlin.reflect.KFunction0<kotlin.Unit> origin=null reflectionTarget=<same>
           $receiver: CONST String type=kotlin.String value="Fail"

--- a/compiler/testData/ir/irText/expressions/callableReferences/funWithDefaultParametersAsKCallableStar.fir.txt
+++ b/compiler/testData/ir/irText/expressions/callableReferences/funWithDefaultParametersAsKCallableStar.fir.txt
@@ -66,7 +66,7 @@ FILE fqName:<root> fileName:/funWithDefaultParametersAsKCallableStar.kt
   FUN name:testVarargsStar visibility:public modality:FINAL <> () returnType:kotlin.Unit
     BLOCK_BODY
       CALL 'public final fun useKCallableStar (fn: kotlin.reflect.KCallable<*>): kotlin.Unit declared in <root>' type=kotlin.Unit origin=null
-        fn: FUNCTION_REFERENCE 'public final fun varargs (vararg xs: kotlin.String): kotlin.Int declared in <root>' type=kotlin.reflect.KFunction1<kotlin.Array<out kotlin.String>, kotlin.Int> origin=null reflectionTarget=<same>
+        fn: FUNCTION_REFERENCE 'public final fun varargs (vararg xs: kotlin.String): kotlin.Int declared in <root>' type=kotlin.reflect.KFunction0<kotlin.Int> origin=null reflectionTarget=<same>
   FUN name:testCtorStar visibility:public modality:FINAL <> () returnType:kotlin.Unit
     BLOCK_BODY
       CALL 'public final fun useKCallableStar (fn: kotlin.reflect.KCallable<*>): kotlin.Unit declared in <root>' type=kotlin.Unit origin=null

--- a/compiler/testData/ir/irText/expressions/callableReferences/withAdaptedArguments.fir.txt
+++ b/compiler/testData/ir/irText/expressions/callableReferences/withAdaptedArguments.fir.txt
@@ -89,8 +89,8 @@ FILE fqName:<root> fileName:/withAdaptedArguments.kt
       RETURN type=kotlin.Nothing from='public final fun testDefault0 (): kotlin.String declared in <root>'
         CALL 'public final fun use0 (fn: kotlin.Function0<kotlin.String>): kotlin.String declared in <root>' type=kotlin.String origin=null
           fn: FUNCTION_REFERENCE 'public final fun fnWithDefaults (a: kotlin.Int, b: kotlin.Int): kotlin.String declared in <root>' type=kotlin.reflect.KFunction0<kotlin.String> origin=null reflectionTarget=<same>
-  FUN name:testVararg0 visibility:public modality:FINAL <> () returnType:IrErrorType
+  FUN name:testVararg0 visibility:public modality:FINAL <> () returnType:kotlin.String
     BLOCK_BODY
-      RETURN type=kotlin.Nothing from='public final fun testVararg0 (): IrErrorType declared in <root>'
-        ERROR_CALL 'Unresolved reference: <Inapplicable(INAPPLICABLE): [/use0]>#' type=IrErrorType
-          FUNCTION_REFERENCE 'public final fun fnWithVarargs (vararg xs: kotlin.Int): kotlin.String declared in <root>' type=kotlin.reflect.KFunction1<kotlin.IntArray, kotlin.String> origin=null reflectionTarget=<same>
+      RETURN type=kotlin.Nothing from='public final fun testVararg0 (): kotlin.String declared in <root>'
+        CALL 'public final fun use0 (fn: kotlin.Function0<kotlin.String>): kotlin.String declared in <root>' type=kotlin.String origin=null
+          fn: FUNCTION_REFERENCE 'public final fun fnWithVarargs (vararg xs: kotlin.Int): kotlin.String declared in <root>' type=kotlin.reflect.KFunction0<kotlin.String> origin=null reflectionTarget=<same>

--- a/compiler/testData/ir/irText/expressions/funInterface/samConversionOnCallableReference.fir.txt
+++ b/compiler/testData/ir/irText/expressions/funInterface/samConversionOnCallableReference.fir.txt
@@ -31,11 +31,11 @@ FILE fqName:<root> fileName:/samConversionOnCallableReference.kt
       RETURN type=kotlin.Nothing from='public final fun testSamConstructor (): <root>.KRunnable declared in <root>'
         TYPE_OP type=<root>.KRunnable origin=SAM_CONVERSION typeOperand=<root>.KRunnable
           FUNCTION_REFERENCE 'public final fun foo0 (): kotlin.Unit declared in <root>' type=kotlin.reflect.KFunction0<kotlin.Unit> origin=null reflectionTarget=<same>
-  FUN name:testSamCosntructorOnAdapted visibility:public modality:FINAL <> () returnType:IrErrorType
+  FUN name:testSamCosntructorOnAdapted visibility:public modality:FINAL <> () returnType:<root>.KRunnable
     BLOCK_BODY
-      RETURN type=kotlin.Nothing from='public final fun testSamCosntructorOnAdapted (): IrErrorType declared in <root>'
-        ERROR_CALL 'Unresolved reference: <Inapplicable(INAPPLICABLE): [/KRunnable]>#' type=IrErrorType
-          FUNCTION_REFERENCE 'public final fun foo1 (vararg xs: kotlin.Int): kotlin.Int declared in <root>' type=kotlin.reflect.KFunction1<kotlin.IntArray, kotlin.Int> origin=null reflectionTarget=<same>
+      RETURN type=kotlin.Nothing from='public final fun testSamCosntructorOnAdapted (): <root>.KRunnable declared in <root>'
+        TYPE_OP type=<root>.KRunnable origin=SAM_CONVERSION typeOperand=<root>.KRunnable
+          FUNCTION_REFERENCE 'public final fun foo1 (vararg xs: kotlin.Int): kotlin.Int declared in <root>' type=kotlin.reflect.KFunction0<kotlin.Unit> origin=null reflectionTarget=<same>
   FUN name:testSamConversion visibility:public modality:FINAL <> () returnType:kotlin.Unit
     BLOCK_BODY
       CALL 'public final fun use (r: <root>.KRunnable): kotlin.Unit declared in <root>' type=kotlin.Unit origin=null
@@ -43,5 +43,6 @@ FILE fqName:<root> fileName:/samConversionOnCallableReference.kt
           FUNCTION_REFERENCE 'public final fun foo0 (): kotlin.Unit declared in <root>' type=kotlin.reflect.KFunction0<kotlin.Unit> origin=null reflectionTarget=<same>
   FUN name:testSamConversionOnAdapted visibility:public modality:FINAL <> () returnType:kotlin.Unit
     BLOCK_BODY
-      ERROR_CALL 'Unresolved reference: <Inapplicable(INAPPLICABLE): [/use]>#' type=IrErrorType
-        FUNCTION_REFERENCE 'public final fun foo1 (vararg xs: kotlin.Int): kotlin.Int declared in <root>' type=kotlin.reflect.KFunction1<kotlin.IntArray, kotlin.Int> origin=null reflectionTarget=<same>
+      CALL 'public final fun use (r: <root>.KRunnable): kotlin.Unit declared in <root>' type=kotlin.Unit origin=null
+        r: TYPE_OP type=<root>.KRunnable origin=SAM_CONVERSION typeOperand=<root>.KRunnable
+          FUNCTION_REFERENCE 'public final fun foo1 (vararg xs: kotlin.Int): kotlin.Int declared in <root>' type=kotlin.reflect.KFunction0<kotlin.Unit> origin=null reflectionTarget=<same>


### PR DESCRIPTION
The motivation is `callableReference.kt37604`:

```
fun useUnit(fn: () -> Unit) {
    fn.invoke()
}
...
var cWithVarargInit = false

class CWithVararg(vararg x: Int) {
    init {
        cWithVarargInit = true
    }
}

fun box(): String {
    ...
    useUnit(::CWithVararg)
    if (!cWithVarargInit) throw AssertionError("cWithVarargInit")

    return "OK"
```

Other class references with no parameter or default value parameter were resolved well, but that one with `vararg` wasn't. It turns out that, when computing the resulting type for callable reference of the candidate, if it is a class reference, its primary constructor is the call target, and while collecting value parameter of interest, `vararg` is simply missed. Since its use is callable reference, i.e., no arguments, we can ignore `vararg` when computing the `KFunction` argument number, similar to a value parameter with a default value.

With a concrete example, before this change, the resulting type for the candidate was `KFunction1<IntArray, Unit>` even though `vararg x` is not given (since it's a callable reference). After this change, its resulting type is correctly `KFunction0<Unit>`, which is what `useUnit` is expecting.