### PR TITLE
Parcelize: Handle (suspend) function types

### DIFF
--- a/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/ir/IrParcelSerializerFactory.kt
+++ b/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/ir/IrParcelSerializerFactory.kt
@@ -228,7 +228,9 @@ class IrParcelSerializerFactory(symbols: AndroidSymbols) {
             classifier.isEnumClass ->
                 return wrapNullableSerializerIfNeeded(irType, IrEnumParcelSerializer(classifier))
 
-            classifier.isSubclassOfFqName("java.io.Serializable") ->
+            classifier.isSubclassOfFqName("java.io.Serializable")
+                    // Functions and Continuations are always serializable.
+                    || irType.isFunctionTypeOrSubtype() || irType.isSuspendFunctionTypeOrSubtype() ->
                 return serializableSerializer
 
             strict() ->

--- a/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/serializers/ParcelSerializer.kt
+++ b/plugins/android-extensions/android-extensions-compiler/src/org/jetbrains/kotlin/android/parcel/serializers/ParcelSerializer.kt
@@ -301,7 +301,7 @@ interface ParcelSerializer {
         private fun Type.isSparseIntArray() = this.descriptor == "Landroid/util/SparseIntArray;"
         private fun Type.isSparseLongArray() = this.descriptor == "Landroid/util/SparseLongArray;"
         private fun Type.isSparseArray() = this.descriptor == "Landroid/util/SparseArray;"
-        private fun KotlinType.isSerializable() = matchesFqNameWithSupertypes("java.io.Serializable")
+        private fun KotlinType.isSerializable() = matchesFqNameWithSupertypes("java.io.Serializable") || matchesFqNameWithSupertypes("kotlin.Function")
         private fun KotlinType.isException() = matchesFqNameWithSupertypes("java.lang.Exception")
         private fun KotlinType.isIBinder() = matchesFqNameWithSupertypes("android.os.IBinder")
         private fun KotlinType.isIInterface() = matchesFqNameWithSupertypes("android.os.IInterface")

--- a/plugins/android-extensions/android-extensions-compiler/test/org/jetbrains/kotlin/android/parcel/AbstractParcelBoxTest.kt
+++ b/plugins/android-extensions/android-extensions-compiler/test/org/jetbrains/kotlin/android/parcel/AbstractParcelBoxTest.kt
@@ -33,8 +33,18 @@ abstract class AbstractParcelBoxTest : CodegenTestCase() {
                 ?: throw RuntimeException("Unable to get a valid path from 'ideaSdk.androidPlugin.path' property, please point it to the Idea android plugin location")
         }
 
-        val layoutlibJar: File by lazy { File(androidPluginPath, "layoutlib-26.5.0.2.jar") }
-        val layoutlibApiJar: File by lazy { File(androidPluginPath, "layoutlib-api-26.5.0.jar") }
+        val layoutlibJar: File by lazy {
+            File(androidPluginPath).listFiles { _, name ->
+                name.startsWith("layoutlib-") && name.endsWith(".jar")
+                        && !name.startsWith("layoutlib-api-") && !name.startsWith("layoutlib-loader")
+            }?.firstOrNull() ?: error("Unable to locate layoutlib jar in '$androidPluginPath'")
+        }
+
+        val layoutlibApiJar: File by lazy {
+            File(androidPluginPath).listFiles { _, name ->
+                name.startsWith("layoutlib-api-") && name.endsWith(".jar")
+            }?.firstOrNull() ?: error("Unable to locate layoutlib-api jar in '$androidPluginPath'")
+        }
 
         private val JUNIT_GENERATED_TEST_CLASS_BYTES by lazy { constructSyntheticTestClass() }
         private const val JUNIT_GENERATED_TEST_CLASS_FQNAME = "test.JunitTest"

--- a/plugins/android-extensions/android-extensions-compiler/test/org/jetbrains/kotlin/android/parcel/ParcelBoxTestGenerated.java
+++ b/plugins/android-extensions/android-extensions-compiler/test/org/jetbrains/kotlin/android/parcel/ParcelBoxTestGenerated.java
@@ -109,6 +109,11 @@ public class ParcelBoxTestGenerated extends AbstractParcelBoxTest {
         runTest("plugins/android-extensions/android-extensions-compiler/testData/parcel/box/exceptions.kt");
     }
 
+    @TestMetadata("functions.kt")
+    public void testFunctions() throws Exception {
+        runTest("plugins/android-extensions/android-extensions-compiler/testData/parcel/box/functions.kt");
+    }
+
     @TestMetadata("intArray.kt")
     public void testIntArray() throws Exception {
         runTest("plugins/android-extensions/android-extensions-compiler/testData/parcel/box/intArray.kt");

--- a/plugins/android-extensions/android-extensions-compiler/test/org/jetbrains/kotlin/android/parcel/ParcelBoxTestGenerated.java
+++ b/plugins/android-extensions/android-extensions-compiler/test/org/jetbrains/kotlin/android/parcel/ParcelBoxTestGenerated.java
@@ -229,6 +229,11 @@ public class ParcelBoxTestGenerated extends AbstractParcelBoxTest {
         runTest("plugins/android-extensions/android-extensions-compiler/testData/parcel/box/primitiveTypes.kt");
     }
 
+    @TestMetadata("sealedClass.kt")
+    public void testSealedClass() throws Exception {
+        runTest("plugins/android-extensions/android-extensions-compiler/testData/parcel/box/sealedClass.kt");
+    }
+
     @TestMetadata("simple.kt")
     public void testSimple() throws Exception {
         runTest("plugins/android-extensions/android-extensions-compiler/testData/parcel/box/simple.kt");

--- a/plugins/android-extensions/android-extensions-compiler/test/org/jetbrains/kotlin/android/parcel/ParcelIrBoxTestGenerated.java
+++ b/plugins/android-extensions/android-extensions-compiler/test/org/jetbrains/kotlin/android/parcel/ParcelIrBoxTestGenerated.java
@@ -109,6 +109,11 @@ public class ParcelIrBoxTestGenerated extends AbstractParcelIrBoxTest {
         runTest("plugins/android-extensions/android-extensions-compiler/testData/parcel/box/exceptions.kt");
     }
 
+    @TestMetadata("functions.kt")
+    public void testFunctions() throws Exception {
+        runTest("plugins/android-extensions/android-extensions-compiler/testData/parcel/box/functions.kt");
+    }
+
     @TestMetadata("intArray.kt")
     public void testIntArray() throws Exception {
         runTest("plugins/android-extensions/android-extensions-compiler/testData/parcel/box/intArray.kt");

--- a/plugins/android-extensions/android-extensions-compiler/test/org/jetbrains/kotlin/android/parcel/ParcelIrBoxTestGenerated.java
+++ b/plugins/android-extensions/android-extensions-compiler/test/org/jetbrains/kotlin/android/parcel/ParcelIrBoxTestGenerated.java
@@ -229,6 +229,11 @@ public class ParcelIrBoxTestGenerated extends AbstractParcelIrBoxTest {
         runTest("plugins/android-extensions/android-extensions-compiler/testData/parcel/box/primitiveTypes.kt");
     }
 
+    @TestMetadata("sealedClass.kt")
+    public void testSealedClass() throws Exception {
+        runTest("plugins/android-extensions/android-extensions-compiler/testData/parcel/box/sealedClass.kt");
+    }
+
     @TestMetadata("simple.kt")
     public void testSimple() throws Exception {
         runTest("plugins/android-extensions/android-extensions-compiler/testData/parcel/box/simple.kt");

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/functions.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/functions.kt
@@ -1,0 +1,24 @@
+// WITH_RUNTIME
+
+@file:JvmName("TestKt")
+package test
+
+import kotlinx.android.parcel.*
+import android.os.Parcel
+import android.os.Parcelable
+
+@Parcelize
+data class Test(val callback: () -> Int = { 0 }, val suspendCallback: suspend () -> Int = { 0 }) : Parcelable
+
+fun box() = parcelTest { parcel ->
+    val test = Test({ 1 }, { 1 })
+    test.writeToParcel(parcel, 0)
+
+    val bytes = parcel.marshall()
+    parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
+
+    val test2 = readFromParcel<Test>(parcel)
+
+    assert(test.callback() == 1)
+}

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/sealedClass.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/sealedClass.kt
@@ -1,0 +1,33 @@
+// WITH_RUNTIME
+
+@file:JvmName("TestKt")
+package test
+
+import kotlinx.android.parcel.*
+import android.os.Parcel
+import android.os.Parcelable
+
+sealed class Foo : Parcelable {
+    @Parcelize
+    data class A(val x: Int) : Foo()
+
+    @Parcelize
+    data class B (val x: String) : Foo()
+}
+
+@Parcelize
+data class Bar(val a: Foo) : Parcelable
+
+fun box() = parcelTest { parcel ->
+    val first = Bar(Foo.B("OK"))
+
+    first.writeToParcel(parcel, 0)
+
+    val bytes = parcel.marshall()
+    parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
+
+    val second = readFromParcel<Bar>(parcel)
+
+    assert(first == second)
+}

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/customParcelablesSameModule.ir.txt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/customParcelablesSameModule.ir.txt
@@ -18,14 +18,13 @@ public final class k/KotlinParcelable$Creator : java/lang/Object, android/os/Par
           INVOKEVIRTUAL (android/os/Parcel, readInt, ()I)
           ISTORE (2)
         LABEL (L2)
+        LINENUMBER (24)
           NEW
           DUP
-        LABEL (L3)
-        LINENUMBER (24)
           ILOAD (2)
           INVOKESPECIAL (k/KotlinParcelable, <init>, (I)V)
           ARETURN
-        LABEL (L4)
+        LABEL (L3)
     }
 
     public java.lang.Object createFromParcel(android.os.Parcel p0) {
@@ -112,8 +111,6 @@ public final class test/Foo$Creator : java/lang/Object, android/os/Parcelable$Cr
           INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
           NEW
           DUP
-          GETSTATIC (Companion, Lk/KotlinParcelable$Companion;)
-          POP
           GETSTATIC (CREATOR, Lk/KotlinParcelable$Creator;)
           ALOAD (1)
           INVOKEVIRTUAL (k/KotlinParcelable$Creator, createFromParcel, (Landroid/os/Parcel;)Lk/KotlinParcelable;)

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/customSimple.ir.txt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/customSimple.ir.txt
@@ -9,6 +9,7 @@ final class User$Companion : java/lang/Object, kotlinx/android/parcel/Parceler {
 
     public User[] newArray(int size) {
         LABEL (L0)
+        LINENUMBER (10)
           ALOAD (0)
           ILOAD (1)
           INVOKESTATIC (kotlinx/android/parcel/Parceler$DefaultImpls, newArray, (Lkotlinx/android/parcel/Parceler;I)[Ljava/lang/Object;)

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/serializeValue.txt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/serializeValue.txt
@@ -1,7 +1,7 @@
 public final class Test$Creator : java/lang/Object, android/os/Parcelable$Creator {
     public void <init>()
 
-    public final java.lang.Object createFromParcel(android.os.Parcel in) {
+    public final Test createFromParcel(android.os.Parcel in) {
         LABEL (L0)
           ALOAD (1)
           LDC (in)
@@ -18,7 +18,18 @@ public final class Test$Creator : java/lang/Object, android/os/Parcelable$Creato
         LABEL (L1)
     }
 
-    public final java.lang.Object[] newArray(int size)
+    public java.lang.Object createFromParcel(android.os.Parcel p0) {
+        LABEL (L0)
+        LINENUMBER (10)
+          ALOAD (0)
+          ALOAD (1)
+          INVOKEVIRTUAL (Test$Creator, createFromParcel, (Landroid/os/Parcel;)LTest;)
+          ARETURN
+    }
+
+    public final Test[] newArray(int size)
+
+    public java.lang.Object[] newArray(int p0)
 }
 
 public final class Test : java/lang/Object, android/os/Parcelable {

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/size.ir.txt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/size.ir.txt
@@ -15,7 +15,6 @@ public final class Test$Creator : java/lang/Object, android/os/Parcelable$Creato
           INVOKEVIRTUAL (android/os/Parcel, readInt, ()I)
           IFNE (L2)
           ACONST_NULL
-          CHECKCAST
           GOTO (L3)
         LABEL (L2)
           ALOAD (1)
@@ -119,7 +118,6 @@ public final class TestF$Creator : java/lang/Object, android/os/Parcelable$Creat
           INVOKEVIRTUAL (android/os/Parcel, readInt, ()I)
           IFNE (L2)
           ACONST_NULL
-          CHECKCAST
           GOTO (L3)
         LABEL (L2)
           ALOAD (1)


### PR DESCRIPTION
Before #3380, there was a bug in the kotlin-android-extensions where we would not produce error messages for Parcelize under certain circumstances. In most case this just resulted in broken code which failed at runtime, but for `@Parcelize` classes containing function types we ended up producing perfectly valid code (calling `read/writeValue` as far as I can tell). Since functions in Kotlin are always serializable, this works and introducing error messages broke some working code.

This PR adds support for function types in Parcelize. I'm not convinced that this is a good idea, since it'll use java serialization. Maybe we should also add a deprecation warning at the same time?

---

The other two commits in this PR are just updates for the test runner and expectations.