### PR TITLE
FIR: special visibility handling for monitor{Enter|Exit}

### DIFF
--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrDeclarationStorage.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrDeclarationStorage.kt
@@ -355,7 +355,9 @@ class Fir2IrDeclarationStorage(
         factory: (IrSimpleFunctionSymbol) -> IrSimpleFunction
     ): IrSimpleFunction {
         if (signature == null) {
-            val descriptor = WrappedSimpleFunctionDescriptor()
+            val descriptor =
+                if (containerSource != null) WrappedFunctionDescriptorWithContainerSource(containerSource)
+                else WrappedSimpleFunctionDescriptor()
             return symbolTable.declareSimpleFunction(descriptor, factory).apply { descriptor.bind(this) }
         }
         return symbolTable.declareSimpleFunction(signature, { Fir2IrSimpleFunctionSymbol(signature, containerSource) }, factory)
@@ -601,7 +603,9 @@ class Fir2IrDeclarationStorage(
         factory: (IrPropertySymbol) -> IrProperty
     ): IrProperty {
         if (signature == null) {
-            val descriptor = WrappedPropertyDescriptor()
+            val descriptor =
+                if (containerSource != null) WrappedPropertyDescriptorWithContainerSource(containerSource)
+                else WrappedPropertyDescriptor()
             return symbolTable.declareProperty(0, 0, IrDeclarationOrigin.DEFINED, descriptor, isDelegated = false, factory).apply {
                 descriptor.bind(this)
             }

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/ResolutionStages.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/ResolutionStages.kt
@@ -438,7 +438,7 @@ internal object CheckVisibility : CheckerStage() {
                         canSeePrivateMemberOf(containingDeclarations, ownerId, session)
                     }
                 } else {
-                    false
+                    declaration is FirSimpleFunction && declaration.isAllowedToBeAccessedFromOutside()
                 }
             }
             Visibilities.PROTECTED -> {
@@ -459,6 +459,16 @@ internal object CheckVisibility : CheckerStage() {
             return false
         }
         return true
+    }
+
+    // monitorEnter/monitorExit are the only functions which are accessed "illegally" (see kotlin/util/Synchronized.kt).
+    // Since they are intrinsified in the codegen, FIR should treat it as visible.
+    private fun FirSimpleFunction.isAllowedToBeAccessedFromOutside(): Boolean {
+        if (!isFromLibrary) return false
+        val packageName = symbol.callableId.packageName.asString()
+        val name = name.asString()
+        return packageName == "kotlin.jvm.internal.unsafe" &&
+                (name == "monitorEnter" || name == "monitorExit")
     }
 
     private fun AbstractFirBasedSymbol<*>.getOwnerId(): ClassId? {

--- a/compiler/testData/codegen/box/intrinsics/monitorEnterMonitorExit.kt
+++ b/compiler/testData/codegen/box/intrinsics/monitorEnterMonitorExit.kt
@@ -1,5 +1,4 @@
 // TARGET_BACKEND: JVM
-// IGNORE_BACKEND_FIR: JVM_IR
 // WITH_RUNTIME
 
 import kotlin.jvm.internal.unsafe.*


### PR DESCRIPTION
`monitor{Enter|Exit}` are defined in `kotlin.jvm.internal.unsafe.MonitorKt` with `private` visibility, but they're "intrinsics." During visibility check in resolution, we need a special handling to allow them to be accessed from anywhere.

IR functions for those, however, had an incorrect `parent`: external package fragment, in lieu of facade class. `SymbolTable` walks through registered symbols and returns those with `DescriptorWithContainerSource` (which usually refers to such facade class), and then stub generator will update `parent` of those symbols with the facade class. Therefore, `fir` should have used `DescriptorWithContainerSource` if container source is available.

Such correct `parent` class setting matters because backend's synthetic accessor lowering depends on it. Proper accessor lowering also matters because the final codegen, which looks up pre-defined intrinsics and replaces them with pre-defined instructions, searches for lowered accessor, like `access$monitor{Enter|Exit}`.