### PR TITLE
FIR: handle object invoke via type alias

### DIFF
--- a/compiler/testData/codegen/box/typealias/typeAliasObjectCallable.kt
+++ b/compiler/testData/codegen/box/typealias/typeAliasObjectCallable.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 object O {
     val x = "OK"
 

--- a/compiler/testData/diagnostics/tests/typealias/typeAliasObjectWithInvoke.fir.kt
+++ b/compiler/testData/diagnostics/tests/typealias/typeAliasObjectWithInvoke.fir.kt
@@ -15,10 +15,10 @@ typealias WI = ObjectWithInvoke
 
 typealias CWI = ClassWithCompanionObjectWithInvoke
 
-val test1 = <!INAPPLICABLE_CANDIDATE!>WI<!>()
+val test1 = WI()
 val test2 = <!INAPPLICABLE_CANDIDATE!>WI<!>(null)
 
 val test3 = CWI()
-val test4 = <!INAPPLICABLE_CANDIDATE!>CWI<!>("")
+val test4 = CWI("")
 val test5 = <!INAPPLICABLE_CANDIDATE!>CWI<!>(null)
 val test5a = <!INAPPLICABLE_CANDIDATE!>ClassWithCompanionObjectWithInvoke<!>(null)


### PR DESCRIPTION
The motivation is bb test `typealias/typeAliasObjectCallable.kt`:
```
object O {
    ...
    operator fun invoke() = ...
}
typealias A = O
fun box(): String = A()
```
Currently, `A()` is resolved as object `O`'s private constructor, resulting in `HIDDEN` applicability of the candidate. Rather, `O.invoke()` should be chosen as the call target. This is because, during `invoke` candidate resolution, only callable symbol and class symbol were assumed and handled. Since type alias has the expand type on it, it could be treated similar to regular class. This PR adds necessary handling of type alias symbol to `invoke` resolution.