### PR TITLE
Add support for RxJava3's nullability annotations

### DIFF
--- a/compiler/testData/foreignAnnotations/tests/rxjava3.kt
+++ b/compiler/testData/foreignAnnotations/tests/rxjava3.kt
@@ -1,0 +1,42 @@
+// !DIAGNOSTICS: -UNUSED_VARIABLE -UNUSED_PARAMETER
+// FILE: A.java
+
+import io.reactivex.rxjava3.annotations.*;
+
+public class A<T> {
+    @Nullable public String field = null;
+
+    @Nullable
+    public String foo(@NonNull String x, @Nullable CharSequence y) {
+        return "";
+    }
+
+    @NonNull
+    public String bar() {
+        return "";
+    }
+
+    @Nullable
+    public T baz(@NonNull T x) { return x; }
+}
+
+// FILE: main.kt
+
+fun main(a: A<String>, a1: A<String?>) {
+    a.foo("", null)?.length
+    a.foo("", null)<!UNSAFE_CALL!>.<!>length
+    a.foo(<!NULL_FOR_NONNULL_TYPE!>null<!>, "")<!UNSAFE_CALL!>.<!>length
+
+    a.bar().length
+    a.bar()<!UNNECESSARY_NOT_NULL_ASSERTION!>!!<!>.length
+
+    a.field?.length
+    a.field<!UNSAFE_CALL!>.<!>length
+
+    a.baz("")<!UNSAFE_CALL!>.<!>length
+    a.baz("")?.length
+    a.baz(<!NULL_FOR_NONNULL_TYPE!>null<!>)<!UNSAFE_CALL!>.<!>length
+
+    a1.baz("")!!.length
+    a1.baz(<!NULL_FOR_NONNULL_TYPE!>null<!>)!!.length
+}

--- a/compiler/testData/foreignAnnotations/tests/rxjava3.txt
+++ b/compiler/testData/foreignAnnotations/tests/rxjava3.txt
@@ -1,0 +1,14 @@
+package
+
+public fun main(/*0*/ a: A<kotlin.String>, /*1*/ a1: A<kotlin.String?>): kotlin.Unit
+
+public open class A</*0*/ T : kotlin.Any!> {
+    public constructor A</*0*/ T : kotlin.Any!>()
+    @io.reactivex.rxjava3.annotations.Nullable public final var field: kotlin.String?
+    @io.reactivex.rxjava3.annotations.NonNull public open fun bar(): kotlin.String
+    @io.reactivex.rxjava3.annotations.Nullable public open fun baz(/*0*/ @io.reactivex.rxjava3.annotations.NonNull x: T): T?
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    @io.reactivex.rxjava3.annotations.Nullable public open fun foo(/*0*/ @io.reactivex.rxjava3.annotations.NonNull x: kotlin.String, /*1*/ @io.reactivex.rxjava3.annotations.Nullable y: kotlin.CharSequence?): kotlin.String?
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}

--- a/compiler/tests/org/jetbrains/kotlin/checkers/ForeignAnnotationsNoAnnotationInClasspathTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/checkers/ForeignAnnotationsNoAnnotationInClasspathTestGenerated.java
@@ -83,6 +83,11 @@ public class ForeignAnnotationsNoAnnotationInClasspathTestGenerated extends Abst
         runTest("compiler/testData/foreignAnnotations/tests/rxjava.kt");
     }
 
+    @TestMetadata("rxjava3.kt")
+    public void testRxjava() throws Exception {
+        runTest("compiler/testData/foreignAnnotations/tests/rxjava3.kt");
+    }
+
     @TestMetadata("compiler/testData/foreignAnnotations/tests/jsr305")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)

--- a/compiler/tests/org/jetbrains/kotlin/checkers/ForeignAnnotationsNoAnnotationInClasspathWithPsiClassReadingTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/checkers/ForeignAnnotationsNoAnnotationInClasspathWithPsiClassReadingTestGenerated.java
@@ -83,6 +83,11 @@ public class ForeignAnnotationsNoAnnotationInClasspathWithPsiClassReadingTestGen
         runTest("compiler/testData/foreignAnnotations/tests/rxjava.kt");
     }
 
+    @TestMetadata("rxjava3.kt")
+    public void testRxjava() throws Exception {
+        runTest("compiler/testData/foreignAnnotations/tests/rxjava3.kt");
+    }
+
     @TestMetadata("compiler/testData/foreignAnnotations/tests/jsr305")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)

--- a/compiler/tests/org/jetbrains/kotlin/checkers/ForeignAnnotationsTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/checkers/ForeignAnnotationsTestGenerated.java
@@ -83,6 +83,11 @@ public class ForeignAnnotationsTestGenerated extends AbstractForeignAnnotationsT
         runTest("compiler/testData/foreignAnnotations/tests/rxjava.kt");
     }
 
+    @TestMetadata("rxjava3.kt")
+    public void testRxjava3() throws Exception {
+        runTest("compiler/testData/foreignAnnotations/tests/rxjava3.kt");
+    }
+
     @TestMetadata("compiler/testData/foreignAnnotations/tests/jsr305")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)

--- a/compiler/tests/org/jetbrains/kotlin/checkers/javac/JavacForeignAnnotationsTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/checkers/javac/JavacForeignAnnotationsTestGenerated.java
@@ -83,6 +83,11 @@ public class JavacForeignAnnotationsTestGenerated extends AbstractJavacForeignAn
         runTest("compiler/testData/foreignAnnotations/tests/rxjava.kt");
     }
 
+    @TestMetadata("rxjava3.kt")
+    public void testRxjava3() throws Exception {
+        runTest("compiler/testData/foreignAnnotations/tests/rxjava3.kt");
+    }
+
     @TestMetadata("compiler/testData/foreignAnnotations/tests/jsr305")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)

--- a/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/JvmAnnotationNames.kt
+++ b/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/JvmAnnotationNames.kt
@@ -31,7 +31,8 @@ val NULLABLE_ANNOTATIONS = listOf(
     FqName("edu.umd.cs.findbugs.annotations.CheckForNull"),
     FqName("edu.umd.cs.findbugs.annotations.Nullable"),
     FqName("edu.umd.cs.findbugs.annotations.PossiblyNull"),
-    FqName("io.reactivex.annotations.Nullable")
+    FqName("io.reactivex.annotations.Nullable"),
+    FqName("io.reactivex.rxjava3.annotations.Nullable")
 )
 
 val JAVAX_NONNULL_ANNOTATION = FqName("javax.annotation.Nonnull")
@@ -47,7 +48,8 @@ val NOT_NULL_ANNOTATIONS = listOf(
     FqName("org.eclipse.jdt.annotation.NonNull"),
     FqName("org.checkerframework.checker.nullness.qual.NonNull"),
     FqName("lombok.NonNull"),
-    FqName("io.reactivex.annotations.NonNull")
+    FqName("io.reactivex.annotations.NonNull"),
+    FqName("io.reactivex.rxjava3.annotations.NonNull")
 )
 
 val COMPATQUAL_NULLABLE_ANNOTATION = FqName("org.checkerframework.checker.nullness.compatqual.NullableDecl")


### PR DESCRIPTION
The annotations in RxJava3 moved from `io.reactivex.annotations` to `io.reactivex.rxjava3.annotations`. This pull pull request is just adding support to `JvmAnnotationNames` for the repacked annotations.