### PR TITLE
KT-20421 fixing code generation for the case when "object" extends "class"

### DIFF
--- a/nj2k/src/org/jetbrains/kotlin/nj2k/printing/JKCodeBuilder.kt
+++ b/nj2k/src/org/jetbrains/kotlin/nj2k/printing/JKCodeBuilder.kt
@@ -222,7 +222,7 @@ internal class JKCodeBuilder(context: NewJ2kConverterContext) {
                             ?.let { it as? JKDelegationConstructorCall }
                     if (delegationCall != null) {
                         printer.par { delegationCall.arguments.accept(this) }
-                    } else if (!superType.isInterface() && primaryConstructor != null) {
+                    } else if (!superType.isInterface() && (primaryConstructor != null || parentClass.isObjectOrCompanionObject)) {
                         printer.print("()")
                     }
                 }

--- a/nj2k/testData/newJ2k/issues/kt-20421.java
+++ b/nj2k/testData/newJ2k/issues/kt-20421.java
@@ -1,0 +1,6 @@
+class Base {
+    static final int F = 0;
+}
+final class A extends Base {
+    static final int F1 = 0;
+}

--- a/nj2k/testData/newJ2k/issues/kt-20421.kt
+++ b/nj2k/testData/newJ2k/issues/kt-20421.kt
@@ -1,0 +1,9 @@
+internal open class Base {
+    companion object {
+        const val F = 0
+    }
+}
+
+internal object A : Base() {
+    const val F1 = 0
+}

--- a/nj2k/tests/org/jetbrains/kotlin/nj2k/NewJavaToKotlinConverterSingleFileTestGenerated.java
+++ b/nj2k/tests/org/jetbrains/kotlin/nj2k/NewJavaToKotlinConverterSingleFileTestGenerated.java
@@ -3043,6 +3043,11 @@ public class NewJavaToKotlinConverterSingleFileTestGenerated extends AbstractNew
             runTest("nj2k/testData/newJ2k/issues/kt-19943.java");
         }
 
+        @TestMetadata("kt-20421.java")
+        public void testKt_20421() throws Exception {
+            runTest("nj2k/testData/newJ2k/issues/kt-20421.java");
+        }
+
         @TestMetadata("kt-21189.java")
         public void testKt_21189() throws Exception {
             runTest("nj2k/testData/newJ2k/issues/kt-21189.java");


### PR DESCRIPTION
The fix will add braces so the code look like: 
```
internal object A : Base() {
    const val F1 = 0
}
```
https://youtrack.jetbrains.com/issue/KT-20421