### PR TITLE
KT-39502 Scripting: reverse order of Severity enum so that ERROR > INFO

### DIFF
--- a/core/script.runtime/src/kotlin/script/dependencies/resolvers_deprecated.kt
+++ b/core/script.runtime/src/kotlin/script/dependencies/resolvers_deprecated.kt
@@ -26,7 +26,7 @@ typealias Environment = Map<String, Any?>
 
 interface ScriptDependenciesResolver {
 
-    enum class ReportSeverity { FATAL, ERROR, WARNING, INFO, DEBUG }
+    enum class ReportSeverity { DEBUG, INFO, WARNING, ERROR, FATAL }
 
     fun resolve(script: ScriptContents,
                 environment: Environment?,

--- a/core/script.runtime/src/kotlin/script/experimental/dependencies/resolvers.kt
+++ b/core/script.runtime/src/kotlin/script/experimental/dependencies/resolvers.kt
@@ -49,7 +49,7 @@ interface DependenciesResolver : ScriptDependenciesResolver {
 
 data class ScriptReport(val message: String, val severity: Severity = Severity.ERROR, val position: Position? = null) {
     data class Position(val startLine: Int, val startColumn: Int, val endLine: Int? = null, val endColumn: Int? = null)
-    enum class Severity { FATAL, ERROR, WARNING, INFO, DEBUG }
+    enum class Severity { DEBUG, INFO, WARNING, ERROR, FATAL }
 }
 
 fun ScriptDependencies.asSuccess(): ResolveResult.Success = ResolveResult.Success(this)

--- a/libraries/scripting/common/src/kotlin/script/experimental/api/errorHandling.kt
+++ b/libraries/scripting/common/src/kotlin/script/experimental/api/errorHandling.kt
@@ -31,7 +31,7 @@ data class ScriptDiagnostic(
     /**
      * The diagnostic severity
      */
-    enum class Severity { FATAL, ERROR, WARNING, INFO, DEBUG }
+    enum class Severity { DEBUG, INFO, WARNING, ERROR, FATAL }
 
     constructor(
         code: Int,


### PR DESCRIPTION
Pull request for [KT-39502](https://youtrack.jetbrains.com/issue/KT-39502).

Tested with tests in `kotlin.kotlin-scripting-compiler.test`, `kotlin.kotlin-scripting-ide-services-test.test`, and tests from `idea` in `org.jetbrains.kotlin.idea.script`.