### PR TITLE
KT-22420 Intention to replace a = b with b.also { a = it }

### DIFF
--- a/idea/resources-en/intentionDescriptions/ConvertVariableAssignmentToExpressionIntention/after.kt.template
+++ b/idea/resources-en/intentionDescriptions/ConvertVariableAssignmentToExpressionIntention/after.kt.template
@@ -1,0 +1,4 @@
+var x = 5
+fun foo() {
+    <spot>10.also { x = it }</spot>
+}

--- a/idea/resources-en/intentionDescriptions/ConvertVariableAssignmentToExpressionIntention/before.kt.template
+++ b/idea/resources-en/intentionDescriptions/ConvertVariableAssignmentToExpressionIntention/before.kt.template
@@ -1,0 +1,4 @@
+var x = 5
+fun foo() {
+    <spot>x = 10</spot>
+}

--- a/idea/resources-en/intentionDescriptions/ConvertVariableAssignmentToExpressionIntention/description.html
+++ b/idea/resources-en/intentionDescriptions/ConvertVariableAssignmentToExpressionIntention/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This intention converts a <b>variable assignment</b> to a variable assignment expression.
+</body>
+</html>

--- a/idea/resources-en/messages/KotlinBundle.properties
+++ b/idea/resources-en/messages/KotlinBundle.properties
@@ -1738,6 +1738,7 @@ convert.to.0.as.1=Convert to ''{0} as {1}''
 convert.to.0.unsafecast.1=Convert to ''{0}.unsafeCast<{1}>()''
 convert.to.unsafecast.call=Convert to unsafeCast() call
 convert.to.array.parameter=Convert to array parameter
+convert.to.assignment.expression=Convert assignment to assignment expression
 create.kotlin.subclass=Create Kotlin subclass
 use.destructuring.declaration=Use destructuring declaration
 implement.as.constructor.parameter=Implement as constructor parameter

--- a/idea/resources/META-INF/inspections.xml
+++ b/idea/resources/META-INF/inspections.xml
@@ -586,6 +586,11 @@
     </intentionAction>
 
     <intentionAction>
+      <className>org.jetbrains.kotlin.idea.intentions.ConvertVariableAssignmentToExpressionIntention</className>
+      <category>Kotlin</category>
+    </intentionAction>
+
+    <intentionAction>
       <className>org.jetbrains.kotlin.idea.intentions.MergeIfsIntention</className>
       <category>Kotlin</category>
     </intentionAction>

--- a/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertVariableAssignmentToExpressionIntention.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertVariableAssignmentToExpressionIntention.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.idea.intentions
+
+import com.intellij.openapi.editor.Editor
+import org.jetbrains.kotlin.idea.KotlinBundle
+import org.jetbrains.kotlin.idea.references.KtSimpleReference
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.*
+
+class ConvertVariableAssignmentToExpressionIntention : SelfTargetingIntention<KtBinaryExpression>(
+    KtBinaryExpression::class.java,
+    KotlinBundle.lazyMessage("convert.to.assignment.expression"),
+) {
+    override fun isApplicableTo(element: KtBinaryExpression, caretOffset: Int): Boolean {
+        if (element.operationToken == KtTokens.EQ) return true
+        return false
+    }
+
+    override fun applyTo(element: KtBinaryExpression, editor: Editor?) {
+        val left = element.left ?: return
+        val right = element.right ?: return
+        val newElement = KtPsiFactory(element.project).createExpressionByPattern("$0.also { $1 = it }", right, left)
+        element.replace(newElement)
+    }
+}

--- a/idea/testData/intentions/convertVariableAssignmentToExpression/.intention
+++ b/idea/testData/intentions/convertVariableAssignmentToExpression/.intention
@@ -1,0 +1,1 @@
+org.jetbrains.kotlin.idea.intentions.ConvertVariableAssignmentToExpressionIntention

--- a/idea/testData/intentions/convertVariableAssignmentToExpression/complexLhs.kt
+++ b/idea/testData/intentions/convertVariableAssignmentToExpression/complexLhs.kt
@@ -1,0 +1,8 @@
+// WITH_RUNTIME
+object X {
+    var string = "foo"
+}
+
+fun main() {
+    X.string <caret>= "bar"
+}

--- a/idea/testData/intentions/convertVariableAssignmentToExpression/complexLhs.kt.after
+++ b/idea/testData/intentions/convertVariableAssignmentToExpression/complexLhs.kt.after
@@ -1,0 +1,8 @@
+// WITH_RUNTIME
+object X {
+    var string = "foo"
+}
+
+fun main() {
+    "bar".also { X.string = it }
+}

--- a/idea/testData/intentions/convertVariableAssignmentToExpression/complexRhs.kt
+++ b/idea/testData/intentions/convertVariableAssignmentToExpression/complexRhs.kt
@@ -1,0 +1,9 @@
+// WITH_RUNTIME
+object X {
+    var string = "foo"
+}
+
+var target = "baz"
+fun main() {
+    target <caret>= X.string
+}

--- a/idea/testData/intentions/convertVariableAssignmentToExpression/complexRhs.kt.after
+++ b/idea/testData/intentions/convertVariableAssignmentToExpression/complexRhs.kt.after
@@ -1,0 +1,9 @@
+// WITH_RUNTIME
+object X {
+    var string = "foo"
+}
+
+var target = "baz"
+fun main() {
+    X.string.also { target = it }
+}

--- a/idea/testData/intentions/convertVariableAssignmentToExpression/noAssignment.kt
+++ b/idea/testData/intentions/convertVariableAssignmentToExpression/noAssignment.kt
@@ -1,0 +1,5 @@
+// IS_APPLICABLE: false
+var x = 0
+fun main() {
+    x <caret>== 10
+}

--- a/idea/testData/intentions/convertVariableAssignmentToExpression/simple.kt
+++ b/idea/testData/intentions/convertVariableAssignmentToExpression/simple.kt
@@ -1,0 +1,5 @@
+// WITH_RUNTIME
+var x = 5
+fun foo() {
+    x <caret>= 10
+}

--- a/idea/testData/intentions/convertVariableAssignmentToExpression/simple.kt.after
+++ b/idea/testData/intentions/convertVariableAssignmentToExpression/simple.kt.after
@@ -1,0 +1,5 @@
+// WITH_RUNTIME
+var x = 5
+fun foo() {
+    10.also { x = it }
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -8210,6 +8210,39 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
         }
     }
 
+    @TestMetadata("idea/testData/intentions/convertVariableAssignmentToExpression")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class ConvertVariableAssignmentToExpression extends AbstractIntentionTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
+        }
+
+        public void testAllFilesPresentInConvertVariableAssignmentToExpression() throws Exception {
+            KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("idea/testData/intentions/convertVariableAssignmentToExpression"), Pattern.compile("^([\\w\\-_]+)\\.(kt|kts)$"), null, true);
+        }
+
+        @TestMetadata("complexLhs.kt")
+        public void testComplexLhs() throws Exception {
+            runTest("idea/testData/intentions/convertVariableAssignmentToExpression/complexLhs.kt");
+        }
+
+        @TestMetadata("complexRhs.kt")
+        public void testComplexRhs() throws Exception {
+            runTest("idea/testData/intentions/convertVariableAssignmentToExpression/complexRhs.kt");
+        }
+
+        @TestMetadata("noAssignment.kt")
+        public void testNoAssignment() throws Exception {
+            runTest("idea/testData/intentions/convertVariableAssignmentToExpression/noAssignment.kt");
+        }
+
+        @TestMetadata("simple.kt")
+        public void testSimple() throws Exception {
+            runTest("idea/testData/intentions/convertVariableAssignmentToExpression/simple.kt");
+        }
+    }
+
     @TestMetadata("idea/testData/intentions/copyConcatenatedStringToClipboard")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-22420

This commit adds `ConvertVariableAssignmentToExpressionIntention`, which converts `a = b` to `b.also { a = it }`.