### PR TITLE
FIR2IR: make local storage track scopes, including anonymous init

### DIFF
--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrDeclarationStorage.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrDeclarationStorage.kt
@@ -153,6 +153,7 @@ class Fir2IrDeclarationStorage(
         symbolTable.enterScope(declaration)
         if (declaration is IrSimpleFunction ||
             declaration is IrConstructor ||
+            declaration is IrAnonymousInitializer ||
             declaration is IrProperty ||
             declaration is IrEnumEntry
         ) {
@@ -163,6 +164,7 @@ class Fir2IrDeclarationStorage(
     fun leaveScope(declaration: IrDeclaration) {
         if (declaration is IrSimpleFunction ||
             declaration is IrConstructor ||
+            declaration is IrAnonymousInitializer ||
             declaration is IrProperty ||
             declaration is IrEnumEntry
         ) {

--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrLocalStorage.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrLocalStorage.kt
@@ -16,12 +16,12 @@ import org.jetbrains.kotlin.ir.declarations.IrVariable
 
 class Fir2IrLocalStorage {
 
-    private val cacheStack = mutableListOf<Fir2IrCallableCache>()
+    private val cacheStack = mutableListOf<Fir2IrScopeCache>()
 
     private val localClassCache = mutableMapOf<FirClass<*>, IrClass>()
 
     fun enterCallable() {
-        cacheStack += Fir2IrCallableCache()
+        cacheStack += Fir2IrScopeCache()
     }
 
     fun leaveCallable() {

--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrScopeCache.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrScopeCache.kt
@@ -7,12 +7,11 @@ package org.jetbrains.kotlin.fir.backend
 
 import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.fir.declarations.*
-import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.declarations.IrValueParameter
 import org.jetbrains.kotlin.ir.declarations.IrVariable
 
-class Fir2IrCallableCache {
+class Fir2IrScopeCache {
     private val parameterCache = mutableMapOf<FirValueParameter, IrValueParameter>()
 
     private val variableCache = mutableMapOf<FirVariable<*>, IrVariable>()

--- a/compiler/testData/codegen/box/closures/kt10044.kt
+++ b/compiler/testData/codegen/box/closures/kt10044.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 open class JClass() {
     fun test(): String {
         return "OK"


### PR DESCRIPTION
because, e.g., local function could be defined in an anonymous initializer, which is not a callable. In that case, `cacheStack` in the local storage is empty, and thus no callable cache to put parameter, variable, and local function.

------

An alternative is, whenever we want to put those into a callable cache, we can make sure there is indeed a callable in the conversion scope. This sounds over engineered, time-consuming task without visible effects. :\