### PR TITLE
FIR: distinguish anonymous object as enum entry when scoping

### DIFF
--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirDeclarationsResolveTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirDeclarationsResolveTransformer.kt
@@ -400,7 +400,11 @@ open class FirDeclarationsResolveTransformer(transformer: FirBodyResolveTransfor
                 this.type = type
             }
         }
-        var result = withScopesForClass(null, anonymousObject, type) {
+        val labelName =
+            if (anonymousObject.classKind == ClassKind.ENUM_ENTRY) {
+                anonymousObject.getPrimaryConstructorIfAny()?.symbol?.callableId?.className?.shortName()
+            } else null
+        var result = withScopesForClass(labelName, anonymousObject, type) {
             transformDeclarationContent(anonymousObject, data).single as FirAnonymousObject
         }
         if (!implicitTypeOnly && result.controlFlowGraphReference == FirEmptyControlFlowGraphReference) {

--- a/compiler/testData/codegen/box/enum/innerClassMethodInEnumEntryClass2.kt
+++ b/compiler/testData/codegen/box/enum/innerClassMethodInEnumEntryClass2.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 enum class A {
     X {
         val x = "OK"


### PR DESCRIPTION
so that `this` reference with the enum entry name as label can be resolved.

The motivation is `enum.innerClassMethodInEnumEntryClass2`:
```
enum class A {
    X {
        val x = ...
        inner class Inner {
            fun foo() = this@X.x
        }
        ...
    };
    ...
}
```
where `this@X` was not resolved because, in the implicit receiver stack, there was nothing associated with the label `X`. Declaration resolver definitely visited the enum entry, but it is an anonymous object, and for all anonymous objects, labels were ignored. However, an anonymous object as enum entry has the name for label: enum entry name itself! That can be retrieved from the primary constructor.