### PR TITLE
Fix NPE in KaptJavaLog

### DIFF
--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/javac/KaptJavaLog.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/javac/KaptJavaLog.kt
@@ -82,7 +82,7 @@ class KaptJavaLog(
             }
         }
 
-        if (mapDiagnosticLocations && sourceFile != null && targetElement.tree != null) {
+        if (mapDiagnosticLocations && sourceFile != null && targetElement?.tree != null) {
             val kotlinPosition = stubLineInfo.getPositionInKotlinFile(sourceFile, targetElement.tree)
             val kotlinFile = kotlinPosition?.let { getKotlinSourceFile(it) }
             if (kotlinPosition != null && kotlinFile != null) {


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-44254

See https://issuetracker.google.com/issues/162446295 for more context, but in short: this will fail if the project:
* targets java 8
* consumes external libraries targeting a higher version (java 9+). This includes Android SDK 30's android.jar, which targets java 9
* has `mapDiagnosticLocations` enabled for kapt

targetElement is a nullable type, so this seems like a pretty cut-and-dry NPE fix

CC @gavra0 @yanex 