### PR TITLE
FIR2IR: use type arguments from fully expanded type

### DIFF
--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrTypeConverter.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrTypeConverter.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.fir.backend
 
 import org.jetbrains.kotlin.fir.backend.generators.AnnotationGenerator
 import org.jetbrains.kotlin.fir.expressions.FirAnnotationCall
+import org.jetbrains.kotlin.fir.resolve.fullyExpandedType
 import org.jetbrains.kotlin.fir.resolve.toSymbol
 import org.jetbrains.kotlin.fir.symbols.StandardClassIds
 import org.jetbrains.kotlin.fir.types.*
@@ -86,7 +87,7 @@ class Fir2IrTypeConverter(
                 }
                 IrSimpleTypeImpl(
                     irSymbol, !typeContext.definitelyNotNull && this.isMarkedNullable,
-                    typeArguments.map { it.toIrTypeArgument() },
+                    fullyExpandedType(session).typeArguments.map { it.toIrTypeArgument() },
                     with(annotationGenerator) { annotations.toIrAnnotations() }
                 )
             }

--- a/compiler/testData/codegen/box/typealias/simple.kt
+++ b/compiler/testData/codegen/box/typealias/simple.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 typealias S = String
 
 typealias SF<T> = (T) -> S

--- a/compiler/testData/ir/irText/classes/delegatingConstructorCallToTypeAliasConstructor.fir.txt
+++ b/compiler/testData/ir/irText/classes/delegatingConstructorCallToTypeAliasConstructor.fir.txt
@@ -61,14 +61,14 @@ FILE fqName:<root> fileName:/delegatingConstructorCallToTypeAliasConstructor.kt
       overridden:
         public open fun toString (): kotlin.String declared in kotlin.Any
       $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-  CLASS CLASS name:C2 modality:FINAL visibility:public superTypes:[<root>.Cell]
+  CLASS CLASS name:C2 modality:FINAL visibility:public superTypes:[<root>.Cell<kotlin.String>]
     $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.C2
     CONSTRUCTOR visibility:public <> () returnType:<root>.C2 [primary]
       BLOCK_BODY
         DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> (value: T of <root>.Cell) [primary] declared in <root>.Cell'
           <T>: kotlin.String
           value: CONST String type=kotlin.String value="K"
-        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:C2 modality:FINAL visibility:public superTypes:[<root>.Cell]'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:C2 modality:FINAL visibility:public superTypes:[<root>.Cell<kotlin.String>]'
     PROPERTY FAKE_OVERRIDE name:value visibility:public modality:FINAL [fake_override,val]
       FUN FAKE_OVERRIDE name:<get-value> visibility:public modality:FINAL <> ($this:<root>.Cell<T of <root>.Cell>) returnType:kotlin.String [fake_override]
         correspondingProperty: PROPERTY FAKE_OVERRIDE name:value visibility:public modality:FINAL [fake_override,val]

--- a/compiler/testData/ir/irText/regressions/integerCoercionToT.fir.txt
+++ b/compiler/testData/ir/irText/regressions/integerCoercionToT.fir.txt
@@ -86,12 +86,12 @@ FILE fqName:<root> fileName:/integerCoercionToT.kt
       overridden:
         public open fun toString (): kotlin.String declared in kotlin.Any
       $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-  FUN name:foo visibility:public modality:FINAL <> (value:<root>.IdType, cv:<root>.CInt32VarX) returnType:kotlin.Unit
+  FUN name:foo visibility:public modality:FINAL <> (value:<root>.IdType, cv:<root>.CInt32VarX<kotlin.Int>) returnType:kotlin.Unit
     VALUE_PARAMETER name:value index:0 type:<root>.IdType
-    VALUE_PARAMETER name:cv index:1 type:<root>.CInt32VarX
+    VALUE_PARAMETER name:cv index:1 type:<root>.CInt32VarX<kotlin.Int>
     BLOCK_BODY
       CALL 'public final fun <set-value> <T_INT> (value: T_INT of <root>.<get-value>): kotlin.Unit declared in <root>' type=kotlin.Unit origin=EQ
         <T_INT>: kotlin.Int
-        $receiver: GET_VAR 'cv: <root>.CInt32VarX declared in <root>.foo' type=<root>.CInt32VarX origin=null
+        $receiver: GET_VAR 'cv: <root>.CInt32VarX<kotlin.Int> declared in <root>.foo' type=<root>.CInt32VarX<kotlin.Int> origin=null
         value: CALL 'public final fun <get-value> (): kotlin.Int declared in <root>.IdType' type=kotlin.Int origin=GET_PROPERTY
           $this: GET_VAR 'value: <root>.IdType declared in <root>.foo' type=<root>.IdType origin=null


### PR DESCRIPTION
because, if the type is a nested type alias (e.g., one of type argument is another type alias), converting the type argument at the current level may lead to mismatched number of type parameters.