### PR TITLE
KT-40546 False positive "Convert lambda to reference" with multiple `it` references

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertLambdaToReferenceIntention.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertLambdaToReferenceIntention.kt
@@ -22,6 +22,7 @@ import org.jetbrains.kotlin.idea.util.approximateFlexibleTypes
 import org.jetbrains.kotlin.idea.util.getResolutionScope
 import org.jetbrains.kotlin.incremental.components.NoLookupLocation
 import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.psiUtil.anyDescendantOfType
 import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 import org.jetbrains.kotlin.renderer.render
 import org.jetbrains.kotlin.resolve.BindingContext
@@ -122,8 +123,10 @@ open class ConvertLambdaToReferenceIntention(textGetter: () -> String) : SelfTar
         }
 
         val lambdaValueParameterDescriptors = context[FUNCTION, lambdaExpression.functionLiteral]?.valueParameters ?: return false
-        if (explicitReceiver is KtClassLiteralExpression
-            && explicitReceiver.receiverExpression?.getCallableDescriptor() in lambdaValueParameterDescriptors
+        if (explicitReceiver != null && explicitReceiver !is KtSimpleNameExpression &&
+            explicitReceiver.anyDescendantOfType<KtSimpleNameExpression> {
+                it.getResolvedCall(context)?.resultingDescriptor in lambdaValueParameterDescriptors
+            }
         ) return false
         val explicitReceiverDescriptor = (explicitReceiver as? KtNameReferenceExpression)?.let {
             context[REFERENCE_TARGET, it]

--- a/idea/testData/intentions/convertLambdaToReference/receiverParameter2.kt
+++ b/idea/testData/intentions/convertLambdaToReference/receiverParameter2.kt
@@ -1,0 +1,10 @@
+// IS_APPLICABLE: false
+class A(s: String) {
+    fun bar(s: String) {}
+}
+
+fun foo(f: (String) -> Unit) {}
+
+fun test() {
+    foo { A(it).bar(it) <caret>}
+}

--- a/idea/testData/intentions/convertLambdaToReference/receiverParameter3.kt
+++ b/idea/testData/intentions/convertLambdaToReference/receiverParameter3.kt
@@ -1,0 +1,11 @@
+// IS_APPLICABLE: false
+// WITH_RUNTIME
+class A(s: String) {
+    fun bar(s: String) {}
+}
+
+fun foo(f: (String) -> Unit) {}
+
+fun test() {
+    foo { s -> s.let(::A).bar(s) <caret>}
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -5235,6 +5235,16 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
             runTest("idea/testData/intentions/convertLambdaToReference/receiverParameter.kt");
         }
 
+        @TestMetadata("receiverParameter2.kt")
+        public void testReceiverParameter2() throws Exception {
+            runTest("idea/testData/intentions/convertLambdaToReference/receiverParameter2.kt");
+        }
+
+        @TestMetadata("receiverParameter3.kt")
+        public void testReceiverParameter3() throws Exception {
+            runTest("idea/testData/intentions/convertLambdaToReference/receiverParameter3.kt");
+        }
+
         @TestMetadata("receiverParameterReversed.kt")
         public void testReceiverParameterReversed() throws Exception {
             runTest("idea/testData/intentions/convertLambdaToReference/receiverParameterReversed.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-40546