### PR TITLE
KT-40879 False positive "Redundant 'inner' modifier" when calling another inner class with empty constructor

### DIFF
--- a/idea/testData/inspectionsLocal/redundantInnerClassModifier/extendJavaNestedClass.1.java
+++ b/idea/testData/inspectionsLocal/redundantInnerClassModifier/extendJavaNestedClass.1.java
@@ -1,0 +1,3 @@
+public class Java {
+    public abstract class NestedClass {}
+}

--- a/idea/testData/inspectionsLocal/redundantInnerClassModifier/extendJavaNestedClass.kt
+++ b/idea/testData/inspectionsLocal/redundantInnerClassModifier/extendJavaNestedClass.kt
@@ -1,0 +1,4 @@
+// PROBLEM: none
+class Test : Java() {
+    <caret>inner class Foo : Java.NestedClass()
+}

--- a/idea/testData/inspectionsLocal/redundantInnerClassModifier/extendJavaNestedInterface.1.java
+++ b/idea/testData/inspectionsLocal/redundantInnerClassModifier/extendJavaNestedInterface.1.java
@@ -1,0 +1,3 @@
+public class Java {
+    public interface NestedInterface {}
+}

--- a/idea/testData/inspectionsLocal/redundantInnerClassModifier/extendJavaNestedInterface.1.java.after
+++ b/idea/testData/inspectionsLocal/redundantInnerClassModifier/extendJavaNestedInterface.1.java.after
@@ -1,0 +1,3 @@
+public class Java {
+    public interface NestedInterface {}
+}

--- a/idea/testData/inspectionsLocal/redundantInnerClassModifier/extendJavaNestedInterface.kt
+++ b/idea/testData/inspectionsLocal/redundantInnerClassModifier/extendJavaNestedInterface.kt
@@ -1,0 +1,3 @@
+class Test : Java() {
+    <caret>inner class Foo : Java.NestedInterface
+}

--- a/idea/testData/inspectionsLocal/redundantInnerClassModifier/extendJavaNestedInterface.kt.after
+++ b/idea/testData/inspectionsLocal/redundantInnerClassModifier/extendJavaNestedInterface.kt.after
@@ -1,0 +1,3 @@
+class Test : Java() {
+    class Foo : Java.NestedInterface
+}

--- a/idea/testData/inspectionsLocal/redundantInnerClassModifier/extendJavaNestedStaticClass.1.java
+++ b/idea/testData/inspectionsLocal/redundantInnerClassModifier/extendJavaNestedStaticClass.1.java
@@ -1,0 +1,3 @@
+public class Java {
+    public abstract static class NestedStaticClass {}
+}

--- a/idea/testData/inspectionsLocal/redundantInnerClassModifier/extendJavaNestedStaticClass.1.java.after
+++ b/idea/testData/inspectionsLocal/redundantInnerClassModifier/extendJavaNestedStaticClass.1.java.after
@@ -1,0 +1,3 @@
+public class Java {
+    public abstract static class NestedStaticClass {}
+}

--- a/idea/testData/inspectionsLocal/redundantInnerClassModifier/extendJavaNestedStaticClass.kt
+++ b/idea/testData/inspectionsLocal/redundantInnerClassModifier/extendJavaNestedStaticClass.kt
@@ -1,0 +1,3 @@
+class Test : Java() {
+    <caret>inner class Foo2 : Java.NestedStaticClass()
+}

--- a/idea/testData/inspectionsLocal/redundantInnerClassModifier/extendJavaNestedStaticClass.kt.after
+++ b/idea/testData/inspectionsLocal/redundantInnerClassModifier/extendJavaNestedStaticClass.kt.after
@@ -1,0 +1,3 @@
+class Test : Java() {
+    class Foo2 : Java.NestedStaticClass()
+}

--- a/idea/testData/inspectionsLocal/redundantInnerClassModifier/hasConstructorCallOfOuterClassMember.kt
+++ b/idea/testData/inspectionsLocal/redundantInnerClassModifier/hasConstructorCallOfOuterClassMember.kt
@@ -1,0 +1,8 @@
+// PROBLEM: none
+class Test {
+    private <caret>inner class Inner {
+        val inner2 = Inner2()
+    }
+
+    private inner class Inner2
+}

--- a/idea/testData/inspectionsLocal/redundantInnerClassModifier/hasConstructorCallOfOuterClassMember2.kt
+++ b/idea/testData/inspectionsLocal/redundantInnerClassModifier/hasConstructorCallOfOuterClassMember2.kt
@@ -1,0 +1,8 @@
+// PROBLEM: none
+class Test {
+    private <caret>inner class Inner {
+        val inner2 = Inner2()
+    }
+
+    private inner class Inner2()
+}

--- a/idea/testData/inspectionsLocal/redundantInnerClassModifier/hasConstructorCallOfOuterClassMember3.kt
+++ b/idea/testData/inspectionsLocal/redundantInnerClassModifier/hasConstructorCallOfOuterClassMember3.kt
@@ -1,0 +1,7 @@
+class Test {
+    private <caret>inner class Inner {
+        val inner2 = Inner2()
+    }
+
+    private class Inner2
+}

--- a/idea/testData/inspectionsLocal/redundantInnerClassModifier/hasConstructorCallOfOuterClassMember3.kt.after
+++ b/idea/testData/inspectionsLocal/redundantInnerClassModifier/hasConstructorCallOfOuterClassMember3.kt.after
@@ -1,0 +1,7 @@
+class Test {
+    private class Inner {
+        val inner2 = Inner2()
+    }
+
+    private class Inner2
+}

--- a/idea/testData/inspectionsLocal/redundantInnerClassModifier/hasOuterClassMemberReferenceInSuperTypeConstructorCall.kt
+++ b/idea/testData/inspectionsLocal/redundantInnerClassModifier/hasOuterClassMemberReferenceInSuperTypeConstructorCall.kt
@@ -1,0 +1,11 @@
+// PROBLEM: none
+abstract class Base(val x: Int)
+
+open class Outer(val x: Int) {
+    <caret>inner class Inner {
+        fun useX() {
+            object : Base(x) {
+            }
+        }
+    }
+}

--- a/idea/testData/inspectionsLocal/redundantInnerClassModifier/hasOuterClassMemberReferenceInSuperTypeConstructorCall2.kt
+++ b/idea/testData/inspectionsLocal/redundantInnerClassModifier/hasOuterClassMemberReferenceInSuperTypeConstructorCall2.kt
@@ -1,0 +1,6 @@
+// PROBLEM: none
+class A(private val someText: String) {
+    private <caret>inner class B() : C(someText)
+}
+
+abstract class C(private val text: String)

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -7941,6 +7941,36 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
             runTest("idea/testData/inspectionsLocal/redundantInnerClassModifier/extendInnerClass2.kt");
         }
 
+        @TestMetadata("extendJavaNestedClass.kt")
+        public void testExtendJavaNestedClass() throws Exception {
+            runTest("idea/testData/inspectionsLocal/redundantInnerClassModifier/extendJavaNestedClass.kt");
+        }
+
+        @TestMetadata("extendJavaNestedInterface.kt")
+        public void testExtendJavaNestedInterface() throws Exception {
+            runTest("idea/testData/inspectionsLocal/redundantInnerClassModifier/extendJavaNestedInterface.kt");
+        }
+
+        @TestMetadata("extendJavaNestedStaticClass.kt")
+        public void testExtendJavaNestedStaticClass() throws Exception {
+            runTest("idea/testData/inspectionsLocal/redundantInnerClassModifier/extendJavaNestedStaticClass.kt");
+        }
+
+        @TestMetadata("hasConstructorCallOfOuterClassMember.kt")
+        public void testHasConstructorCallOfOuterClassMember() throws Exception {
+            runTest("idea/testData/inspectionsLocal/redundantInnerClassModifier/hasConstructorCallOfOuterClassMember.kt");
+        }
+
+        @TestMetadata("hasConstructorCallOfOuterClassMember2.kt")
+        public void testHasConstructorCallOfOuterClassMember2() throws Exception {
+            runTest("idea/testData/inspectionsLocal/redundantInnerClassModifier/hasConstructorCallOfOuterClassMember2.kt");
+        }
+
+        @TestMetadata("hasConstructorCallOfOuterClassMember3.kt")
+        public void testHasConstructorCallOfOuterClassMember3() throws Exception {
+            runTest("idea/testData/inspectionsLocal/redundantInnerClassModifier/hasConstructorCallOfOuterClassMember3.kt");
+        }
+
         @TestMetadata("hasOuterClassMemberReference.kt")
         public void testHasOuterClassMemberReference() throws Exception {
             runTest("idea/testData/inspectionsLocal/redundantInnerClassModifier/hasOuterClassMemberReference.kt");
@@ -7964,6 +7994,16 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
         @TestMetadata("hasOuterClassMemberReference5.kt")
         public void testHasOuterClassMemberReference5() throws Exception {
             runTest("idea/testData/inspectionsLocal/redundantInnerClassModifier/hasOuterClassMemberReference5.kt");
+        }
+
+        @TestMetadata("hasOuterClassMemberReferenceInSuperTypeConstructorCall.kt")
+        public void testHasOuterClassMemberReferenceInSuperTypeConstructorCall() throws Exception {
+            runTest("idea/testData/inspectionsLocal/redundantInnerClassModifier/hasOuterClassMemberReferenceInSuperTypeConstructorCall.kt");
+        }
+
+        @TestMetadata("hasOuterClassMemberReferenceInSuperTypeConstructorCall2.kt")
+        public void testHasOuterClassMemberReferenceInSuperTypeConstructorCall2() throws Exception {
+            runTest("idea/testData/inspectionsLocal/redundantInnerClassModifier/hasOuterClassMemberReferenceInSuperTypeConstructorCall2.kt");
         }
 
         @TestMetadata("hasOuterClassTypeReference.kt")


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-40879
https://youtrack.jetbrains.com/issue/KT-41223
https://youtrack.jetbrains.com/issue/KT-41311
https://youtrack.jetbrains.com/issue/KT-41680
