### PR TITLE
JVM IR: Fixes to IMPLICIT_NOTNULL casts

### DIFF
--- a/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
@@ -3296,6 +3296,39 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
             }
         }
 
+        @TestMetadata("compiler/testData/codegen/box/casts/javaInterop")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class JavaInterop extends AbstractFirBlackBoxCodegenTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTestWithCustomIgnoreDirective(this::doTest, TargetBackend.JVM_IR, testDataFilePath, "// IGNORE_BACKEND_FIR: ");
+            }
+
+            public void testAllFilesPresentInJavaInterop() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/casts/javaInterop"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+            }
+
+            @TestMetadata("castWithWrongType.kt")
+            public void testCastWithWrongType() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/castWithWrongType.kt");
+            }
+
+            @TestMetadata("implicitNotNullWithWrongType.kt")
+            public void testImplicitNotNullWithWrongType() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/implicitNotNullWithWrongType.kt");
+            }
+
+            @TestMetadata("instanceOfWithWrongType.kt")
+            public void testInstanceOfWithWrongType() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/instanceOfWithWrongType.kt");
+            }
+
+            @TestMetadata("safeCastWithWrongType.kt")
+            public void testSafeCastWithWrongType() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/safeCastWithWrongType.kt");
+            }
+        }
+
         @TestMetadata("compiler/testData/codegen/box/casts/literalExpressionAsGenericArgument")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)

--- a/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
@@ -3323,6 +3323,56 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
                 runTest("compiler/testData/codegen/box/casts/javaInterop/instanceOfWithWrongType.kt");
             }
 
+            @TestMetadata("noNullCheckOnCollectionContains.kt")
+            public void testNoNullCheckOnCollectionContains() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnCollectionContains.kt");
+            }
+
+            @TestMetadata("noNullCheckOnCollectionRemove.kt")
+            public void testNoNullCheckOnCollectionRemove() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnCollectionRemove.kt");
+            }
+
+            @TestMetadata("noNullCheckOnListIndexOf.kt")
+            public void testNoNullCheckOnListIndexOf() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnListIndexOf.kt");
+            }
+
+            @TestMetadata("noNullCheckOnListLastIndexOf.kt")
+            public void testNoNullCheckOnListLastIndexOf() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnListLastIndexOf.kt");
+            }
+
+            @TestMetadata("noNullCheckOnMapContainsKey.kt")
+            public void testNoNullCheckOnMapContainsKey() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnMapContainsKey.kt");
+            }
+
+            @TestMetadata("noNullCheckOnMapContainsValue.kt")
+            public void testNoNullCheckOnMapContainsValue() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnMapContainsValue.kt");
+            }
+
+            @TestMetadata("noNullCheckOnMapGet.kt")
+            public void testNoNullCheckOnMapGet() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnMapGet.kt");
+            }
+
+            @TestMetadata("noNullCheckOnMapRemove.kt")
+            public void testNoNullCheckOnMapRemove() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnMapRemove.kt");
+            }
+
+            @TestMetadata("nullCheckOnMapGetOrDefault.kt")
+            public void testNullCheckOnMapGetOrDefault() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/nullCheckOnMapGetOrDefault.kt");
+            }
+
+            @TestMetadata("nullCheckOnMapRemove2.kt")
+            public void testNullCheckOnMapRemove2() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/nullCheckOnMapRemove2.kt");
+            }
+
             @TestMetadata("safeCastWithWrongType.kt")
             public void testSafeCastWithWrongType() throws Exception {
                 runTest("compiler/testData/codegen/box/casts/javaInterop/safeCastWithWrongType.kt");

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/SpecialBridgeMethods.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/SpecialBridgeMethods.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.backend.common.lower
 import org.jetbrains.kotlin.backend.common.CommonBackendContext
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
+import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.expressions.IrConstKind
 import org.jetbrains.kotlin.ir.expressions.IrExpression
@@ -15,6 +16,7 @@ import org.jetbrains.kotlin.ir.expressions.impl.IrConstImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrGetValueImpl
 import org.jetbrains.kotlin.ir.util.fqNameWhenAvailable
 import org.jetbrains.kotlin.ir.util.parentAsClass
+import org.jetbrains.kotlin.ir.util.render
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 
@@ -103,8 +105,14 @@ class SpecialBridgeMethods(val context: CommonBackendContext) {
         makeDescription(KotlinBuiltIns.FQ_NAMES.mutableList, "removeAt", 1) to BuiltInWithDifferentJvmName(needsGenericSignature = true)
     )
 
-    fun findSpecialWithOverride(irFunction: IrSimpleFunction): Pair<IrSimpleFunction, SpecialMethodWithDefaultInfo>? {
-        irFunction.allOverridden().forEach { overridden ->
+    fun findSpecialWithOverride(
+        irFunction: IrSimpleFunction,
+        includeSelf: Boolean = false
+    ): Pair<IrSimpleFunction, SpecialMethodWithDefaultInfo>? {
+        if (irFunction.parent !is IrClass)
+            return null
+
+        irFunction.allOverridden(includeSelf).forEach { overridden ->
             val description = overridden.toDescription()
             SPECIAL_METHODS_WITH_DEFAULTS_MAP[description]?.let {
                 return Pair(overridden, it)

--- a/compiler/testData/codegen/box/casts/javaInterop/castWithWrongType.kt
+++ b/compiler/testData/codegen/box/casts/javaInterop/castWithWrongType.kt
@@ -1,0 +1,17 @@
+// KT-39520
+// TARGET_BACKEND: JVM
+// FILE: A.java
+public class A<T> {
+    private T value;
+    private A(T x) { value = x; }
+    public static <T> T f() {
+        return ((A<T>) new A(1)).value;
+    }
+}
+
+// FILE: test.kt
+
+fun box(): String {
+    val x = A.f<String>() as Int
+    return if (x == 1) "OK" else "Fail"
+}

--- a/compiler/testData/codegen/box/casts/javaInterop/implicitNotNullWithWrongType.kt
+++ b/compiler/testData/codegen/box/casts/javaInterop/implicitNotNullWithWrongType.kt
@@ -1,0 +1,17 @@
+// KT-39520
+// TARGET_BACKEND: JVM
+// FILE: A.java
+public class A<T> {
+    private T value;
+    private A(T x) { value = x; }
+    public static <T> T f() {
+        return ((A<T>) new A(1)).value;
+    }
+}
+
+// FILE: test.kt
+
+fun box(): String {
+    val x: Any = A.f<String>()
+    return if (x == 1) "OK" else "Fail"
+}

--- a/compiler/testData/codegen/box/casts/javaInterop/instanceOfWithWrongType.kt
+++ b/compiler/testData/codegen/box/casts/javaInterop/instanceOfWithWrongType.kt
@@ -1,0 +1,16 @@
+// KT-39520
+// TARGET_BACKEND: JVM
+// FILE: A.java
+public class A<T> {
+    private T value;
+    private A(T x) { value = x; }
+    public static <T> T f() {
+        return ((A<T>) new A(1)).value;
+    }
+}
+
+// FILE: test.kt
+
+fun box(): String {
+    return if (A.f<String?>() is CharSequence?) "Fail" else "OK"
+}

--- a/compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnCollectionContains.kt
+++ b/compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnCollectionContains.kt
@@ -1,0 +1,12 @@
+// TARGET_BACKEND: JVM
+// WITH_RUNTIME
+// FILE: A.java
+public class A {
+    public static A nil() { return null; }
+}
+
+// FILE: test.kt
+fun box(): String {
+    val m = mapOf<A, String>()
+    return if (A.nil() in m.keys) "Fail" else "OK"
+}

--- a/compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnCollectionRemove.kt
+++ b/compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnCollectionRemove.kt
@@ -1,0 +1,12 @@
+// TARGET_BACKEND: JVM
+// WITH_RUNTIME
+// FILE: A.java
+public class A {
+    public static A nil() { return null; }
+}
+
+// FILE: test.kt
+fun box(): String {
+    val m = mutableMapOf<A, String>()
+    return if (m.remove(A.nil()) == null) "OK" else "Fail"
+}

--- a/compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnListIndexOf.kt
+++ b/compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnListIndexOf.kt
@@ -1,0 +1,12 @@
+// TARGET_BACKEND: JVM
+// WITH_RUNTIME
+// FILE: A.java
+public class A {
+    public static A nil() { return null; }
+}
+
+// FILE: test.kt
+fun box(): String {
+    val l = listOf<A>()
+    return if (l.indexOf(A.nil()) == -1) "OK" else "Fail"
+}

--- a/compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnListLastIndexOf.kt
+++ b/compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnListLastIndexOf.kt
@@ -1,0 +1,12 @@
+// TARGET_BACKEND: JVM
+// WITH_RUNTIME
+// FILE: A.java
+public class A {
+    public static A nil() { return null; }
+}
+
+// FILE: test.kt
+fun box(): String {
+    val l = listOf<A>()
+    return if (l.lastIndexOf(A.nil()) == -1) "OK" else "Fail"
+}

--- a/compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnMapContainsKey.kt
+++ b/compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnMapContainsKey.kt
@@ -1,0 +1,12 @@
+// TARGET_BACKEND: JVM
+// WITH_RUNTIME
+// FILE: A.java
+public class A {
+    public static A nil() { return null; }
+}
+
+// FILE: test.kt
+fun box(): String {
+    val m = mapOf<A, String>()
+    return if (m.containsKey(A.nil())) "Fail" else "OK"
+}

--- a/compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnMapContainsValue.kt
+++ b/compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnMapContainsValue.kt
@@ -1,0 +1,12 @@
+// TARGET_BACKEND: JVM
+// WITH_RUNTIME
+// FILE: A.java
+public class A {
+    public static A nil() { return null; }
+}
+
+// FILE: test.kt
+fun box(): String {
+    val m = mapOf<String, A>()
+    return if (m.containsValue(A.nil())) "Fail" else "OK"
+}

--- a/compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnMapGet.kt
+++ b/compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnMapGet.kt
@@ -1,0 +1,12 @@
+// TARGET_BACKEND: JVM
+// WITH_RUNTIME
+// FILE: A.java
+public class A {
+    public static A nil() { return null; }
+}
+
+// FILE: test.kt
+fun box(): String {
+    val m = mapOf<A, String>()
+    return m[A.nil()] ?: "OK"
+}

--- a/compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnMapRemove.kt
+++ b/compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnMapRemove.kt
@@ -1,0 +1,12 @@
+// TARGET_BACKEND: JVM
+// WITH_RUNTIME
+// FILE: A.java
+public class A {
+    public static A nil() { return null; }
+}
+
+// FILE: test.kt
+fun box(): String {
+    val m = mutableMapOf<A, String>()
+    return if (m.remove(A.nil()) == null) "OK" else "Fail"
+}

--- a/compiler/testData/codegen/box/casts/javaInterop/nullCheckOnMapGetOrDefault.kt
+++ b/compiler/testData/codegen/box/casts/javaInterop/nullCheckOnMapGetOrDefault.kt
@@ -1,0 +1,27 @@
+// IGNORE_BACKEND_FIR: JVM_IR
+// TARGET_BACKEND: JVM
+// JVM_TARGET: 1.8
+// WITH_RUNTIME
+// FULL_JDK
+// FILE: A.java
+public class A {
+    public static A nil() { return null; }
+}
+
+// FILE: test.kt
+fun box(): String {
+    // There is a null check on both arguments of Map.getOrDefault, so we expect this code to throw an exception.
+    // Which exception this is depends on the language version (it's a NullPointerException in Kotlin 1.4).
+    val m = mapOf<A, A>()
+    try {
+        m.getOrDefault(A.nil(), A())
+    } catch (e: Exception) {
+        try {
+            m.getOrDefault(A(), A.nil())
+        } catch (e: Exception) {
+            return "OK"
+        }
+        return "Fail 2"
+    }
+    return "Fail 1"
+}

--- a/compiler/testData/codegen/box/casts/javaInterop/nullCheckOnMapRemove2.kt
+++ b/compiler/testData/codegen/box/casts/javaInterop/nullCheckOnMapRemove2.kt
@@ -1,0 +1,27 @@
+// IGNORE_BACKEND_FIR: JVM_IR
+// TARGET_BACKEND: JVM
+// JVM_TARGET: 1.8
+// WITH_RUNTIME
+// FULL_JDK
+// FILE: A.java
+public class A {
+    public static A nil() { return null; }
+}
+
+// FILE: test.kt
+fun box(): String {
+    // There is a null check on both arguments of MutableMap.remove, so we expect this code to throw an exception.
+    // Which exception this is depends on the language version (it's a NullPointerException in Kotlin 1.4).
+    val m = mutableMapOf<A, A>()
+    try {
+        m.remove(A.nil(), A())
+    } catch (e: Exception) {
+        try {
+            m.remove(A(), A.nil())
+        } catch (e: Exception) {
+            return "OK"
+        }
+        return "Fail 2"
+    }
+    return "Fail 1"
+}

--- a/compiler/testData/codegen/box/casts/javaInterop/safeCastWithWrongType.kt
+++ b/compiler/testData/codegen/box/casts/javaInterop/safeCastWithWrongType.kt
@@ -1,0 +1,16 @@
+// KT-39520
+// TARGET_BACKEND: JVM
+// FILE: A.java
+public class A<T> {
+    private T value;
+    private A(T x) { value = x; }
+    public static <T> T f() {
+        return ((A<T>) new A(1)).value;
+    }
+}
+
+// FILE: test.kt
+
+fun box(): String {
+    return A.f<String>() as? String ?: "OK"
+}

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -3343,6 +3343,56 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
                 runTest("compiler/testData/codegen/box/casts/javaInterop/instanceOfWithWrongType.kt");
             }
 
+            @TestMetadata("noNullCheckOnCollectionContains.kt")
+            public void testNoNullCheckOnCollectionContains() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnCollectionContains.kt");
+            }
+
+            @TestMetadata("noNullCheckOnCollectionRemove.kt")
+            public void testNoNullCheckOnCollectionRemove() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnCollectionRemove.kt");
+            }
+
+            @TestMetadata("noNullCheckOnListIndexOf.kt")
+            public void testNoNullCheckOnListIndexOf() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnListIndexOf.kt");
+            }
+
+            @TestMetadata("noNullCheckOnListLastIndexOf.kt")
+            public void testNoNullCheckOnListLastIndexOf() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnListLastIndexOf.kt");
+            }
+
+            @TestMetadata("noNullCheckOnMapContainsKey.kt")
+            public void testNoNullCheckOnMapContainsKey() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnMapContainsKey.kt");
+            }
+
+            @TestMetadata("noNullCheckOnMapContainsValue.kt")
+            public void testNoNullCheckOnMapContainsValue() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnMapContainsValue.kt");
+            }
+
+            @TestMetadata("noNullCheckOnMapGet.kt")
+            public void testNoNullCheckOnMapGet() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnMapGet.kt");
+            }
+
+            @TestMetadata("noNullCheckOnMapRemove.kt")
+            public void testNoNullCheckOnMapRemove() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnMapRemove.kt");
+            }
+
+            @TestMetadata("nullCheckOnMapGetOrDefault.kt")
+            public void testNullCheckOnMapGetOrDefault() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/nullCheckOnMapGetOrDefault.kt");
+            }
+
+            @TestMetadata("nullCheckOnMapRemove2.kt")
+            public void testNullCheckOnMapRemove2() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/nullCheckOnMapRemove2.kt");
+            }
+
             @TestMetadata("safeCastWithWrongType.kt")
             public void testSafeCastWithWrongType() throws Exception {
                 runTest("compiler/testData/codegen/box/casts/javaInterop/safeCastWithWrongType.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -3316,6 +3316,39 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             }
         }
 
+        @TestMetadata("compiler/testData/codegen/box/casts/javaInterop")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class JavaInterop extends AbstractBlackBoxCodegenTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInJavaInterop() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/casts/javaInterop"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM, true);
+            }
+
+            @TestMetadata("castWithWrongType.kt")
+            public void testCastWithWrongType() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/castWithWrongType.kt");
+            }
+
+            @TestMetadata("implicitNotNullWithWrongType.kt")
+            public void testImplicitNotNullWithWrongType() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/implicitNotNullWithWrongType.kt");
+            }
+
+            @TestMetadata("instanceOfWithWrongType.kt")
+            public void testInstanceOfWithWrongType() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/instanceOfWithWrongType.kt");
+            }
+
+            @TestMetadata("safeCastWithWrongType.kt")
+            public void testSafeCastWithWrongType() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/safeCastWithWrongType.kt");
+            }
+        }
+
         @TestMetadata("compiler/testData/codegen/box/casts/literalExpressionAsGenericArgument")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -3316,6 +3316,39 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             }
         }
 
+        @TestMetadata("compiler/testData/codegen/box/casts/javaInterop")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class JavaInterop extends AbstractLightAnalysisModeTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInJavaInterop() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/casts/javaInterop"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM, true);
+            }
+
+            @TestMetadata("castWithWrongType.kt")
+            public void testCastWithWrongType() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/castWithWrongType.kt");
+            }
+
+            @TestMetadata("implicitNotNullWithWrongType.kt")
+            public void testImplicitNotNullWithWrongType() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/implicitNotNullWithWrongType.kt");
+            }
+
+            @TestMetadata("instanceOfWithWrongType.kt")
+            public void testInstanceOfWithWrongType() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/instanceOfWithWrongType.kt");
+            }
+
+            @TestMetadata("safeCastWithWrongType.kt")
+            public void testSafeCastWithWrongType() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/safeCastWithWrongType.kt");
+            }
+        }
+
         @TestMetadata("compiler/testData/codegen/box/casts/literalExpressionAsGenericArgument")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -3343,6 +3343,56 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
                 runTest("compiler/testData/codegen/box/casts/javaInterop/instanceOfWithWrongType.kt");
             }
 
+            @TestMetadata("noNullCheckOnCollectionContains.kt")
+            public void testNoNullCheckOnCollectionContains() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnCollectionContains.kt");
+            }
+
+            @TestMetadata("noNullCheckOnCollectionRemove.kt")
+            public void testNoNullCheckOnCollectionRemove() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnCollectionRemove.kt");
+            }
+
+            @TestMetadata("noNullCheckOnListIndexOf.kt")
+            public void testNoNullCheckOnListIndexOf() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnListIndexOf.kt");
+            }
+
+            @TestMetadata("noNullCheckOnListLastIndexOf.kt")
+            public void testNoNullCheckOnListLastIndexOf() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnListLastIndexOf.kt");
+            }
+
+            @TestMetadata("noNullCheckOnMapContainsKey.kt")
+            public void testNoNullCheckOnMapContainsKey() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnMapContainsKey.kt");
+            }
+
+            @TestMetadata("noNullCheckOnMapContainsValue.kt")
+            public void testNoNullCheckOnMapContainsValue() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnMapContainsValue.kt");
+            }
+
+            @TestMetadata("noNullCheckOnMapGet.kt")
+            public void testNoNullCheckOnMapGet() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnMapGet.kt");
+            }
+
+            @TestMetadata("noNullCheckOnMapRemove.kt")
+            public void testNoNullCheckOnMapRemove() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnMapRemove.kt");
+            }
+
+            @TestMetadata("nullCheckOnMapGetOrDefault.kt")
+            public void testNullCheckOnMapGetOrDefault() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/nullCheckOnMapGetOrDefault.kt");
+            }
+
+            @TestMetadata("nullCheckOnMapRemove2.kt")
+            public void testNullCheckOnMapRemove2() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/nullCheckOnMapRemove2.kt");
+            }
+
             @TestMetadata("safeCastWithWrongType.kt")
             public void testSafeCastWithWrongType() throws Exception {
                 runTest("compiler/testData/codegen/box/casts/javaInterop/safeCastWithWrongType.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -3296,6 +3296,39 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             }
         }
 
+        @TestMetadata("compiler/testData/codegen/box/casts/javaInterop")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class JavaInterop extends AbstractIrBlackBoxCodegenTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM_IR, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInJavaInterop() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/casts/javaInterop"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+            }
+
+            @TestMetadata("castWithWrongType.kt")
+            public void testCastWithWrongType() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/castWithWrongType.kt");
+            }
+
+            @TestMetadata("implicitNotNullWithWrongType.kt")
+            public void testImplicitNotNullWithWrongType() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/implicitNotNullWithWrongType.kt");
+            }
+
+            @TestMetadata("instanceOfWithWrongType.kt")
+            public void testInstanceOfWithWrongType() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/instanceOfWithWrongType.kt");
+            }
+
+            @TestMetadata("safeCastWithWrongType.kt")
+            public void testSafeCastWithWrongType() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/safeCastWithWrongType.kt");
+            }
+        }
+
         @TestMetadata("compiler/testData/codegen/box/casts/literalExpressionAsGenericArgument")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -3323,6 +3323,56 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
                 runTest("compiler/testData/codegen/box/casts/javaInterop/instanceOfWithWrongType.kt");
             }
 
+            @TestMetadata("noNullCheckOnCollectionContains.kt")
+            public void testNoNullCheckOnCollectionContains() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnCollectionContains.kt");
+            }
+
+            @TestMetadata("noNullCheckOnCollectionRemove.kt")
+            public void testNoNullCheckOnCollectionRemove() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnCollectionRemove.kt");
+            }
+
+            @TestMetadata("noNullCheckOnListIndexOf.kt")
+            public void testNoNullCheckOnListIndexOf() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnListIndexOf.kt");
+            }
+
+            @TestMetadata("noNullCheckOnListLastIndexOf.kt")
+            public void testNoNullCheckOnListLastIndexOf() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnListLastIndexOf.kt");
+            }
+
+            @TestMetadata("noNullCheckOnMapContainsKey.kt")
+            public void testNoNullCheckOnMapContainsKey() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnMapContainsKey.kt");
+            }
+
+            @TestMetadata("noNullCheckOnMapContainsValue.kt")
+            public void testNoNullCheckOnMapContainsValue() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnMapContainsValue.kt");
+            }
+
+            @TestMetadata("noNullCheckOnMapGet.kt")
+            public void testNoNullCheckOnMapGet() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnMapGet.kt");
+            }
+
+            @TestMetadata("noNullCheckOnMapRemove.kt")
+            public void testNoNullCheckOnMapRemove() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/noNullCheckOnMapRemove.kt");
+            }
+
+            @TestMetadata("nullCheckOnMapGetOrDefault.kt")
+            public void testNullCheckOnMapGetOrDefault() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/nullCheckOnMapGetOrDefault.kt");
+            }
+
+            @TestMetadata("nullCheckOnMapRemove2.kt")
+            public void testNullCheckOnMapRemove2() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/javaInterop/nullCheckOnMapRemove2.kt");
+            }
+
             @TestMetadata("safeCastWithWrongType.kt")
             public void testSafeCastWithWrongType() throws Exception {
                 runTest("compiler/testData/codegen/box/casts/javaInterop/safeCastWithWrongType.kt");

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
@@ -2631,6 +2631,19 @@ public class IrJsCodegenBoxES6TestGenerated extends AbstractIrJsCodegenBoxES6Tes
             }
         }
 
+        @TestMetadata("compiler/testData/codegen/box/casts/javaInterop")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class JavaInterop extends AbstractIrJsCodegenBoxES6Test {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest0(this::doTest, TargetBackend.JS_IR_ES6, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInJavaInterop() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/casts/javaInterop"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR_ES6, true);
+            }
+        }
+
         @TestMetadata("compiler/testData/codegen/box/casts/literalExpressionAsGenericArgument")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -2631,6 +2631,19 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             }
         }
 
+        @TestMetadata("compiler/testData/codegen/box/casts/javaInterop")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class JavaInterop extends AbstractIrJsCodegenBoxTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest0(this::doTest, TargetBackend.JS_IR, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInJavaInterop() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/casts/javaInterop"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR, true);
+            }
+        }
+
         @TestMetadata("compiler/testData/codegen/box/casts/literalExpressionAsGenericArgument")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -2631,6 +2631,19 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             }
         }
 
+        @TestMetadata("compiler/testData/codegen/box/casts/javaInterop")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class JavaInterop extends AbstractJsCodegenBoxTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest0(this::doTest, TargetBackend.JS, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInJavaInterop() throws Exception {
+                KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/casts/javaInterop"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS, true);
+            }
+        }
+
         @TestMetadata("compiler/testData/codegen/box/casts/literalExpressionAsGenericArgument")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)


### PR DESCRIPTION
There are two parts to this PR.

The first is a fix for KT-39520, which shows that we have to be very careful when compiling casts, as the type information might be outright wrong and superfluous `CHECKCAST` instructions can lead to runtime errors. The second is a fix for another Java interop issue around `IMPLICIT_NOTNULL` casts on special bridge methods. This issue affects the Kotlin compiler itself and leads to test failures when running the compiler test suite with a version of kotlinc that was compiled with the JVM IR backend.

I've added tests for all cases that are affected.

As a side note, the behavior around `IMPLICIT_NOTNULL` casts is a bit inconsistent. We elide the checks for all special bridge methods except for those which are `@PlatformDependent` (i.e. `MutableMap.remove` with two arguments and `Map.getOrDefault`). We probably want to change this at some point, but for now the behavior of the JVM and JVM IR backends should match.