### PR TITLE
FIR: smartcast after null check

### DIFF
--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/FirReturnsImpliesAnalyzer.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/FirReturnsImpliesAnalyzer.kt
@@ -27,10 +27,7 @@ import org.jetbrains.kotlin.fir.resolve.dfa.cfg.JumpNode
 import org.jetbrains.kotlin.fir.symbols.AbstractFirBasedSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirPropertyAccessorSymbol
 import org.jetbrains.kotlin.fir.typeContext
-import org.jetbrains.kotlin.fir.types.ConeKotlinType
-import org.jetbrains.kotlin.fir.types.coneType
-import org.jetbrains.kotlin.fir.types.intersectTypesOrNull
-import org.jetbrains.kotlin.fir.types.isNullable
+import org.jetbrains.kotlin.fir.types.*
 import org.jetbrains.kotlin.types.AbstractTypeChecker
 import org.jetbrains.kotlin.types.ConstantValueKind
 import org.jetbrains.kotlin.utils.addIfNotNull
@@ -56,7 +53,7 @@ object FirReturnsImpliesAnalyzer : FirControlFlowChecker() {
                 throw IllegalStateException("Update of all receivers is not possible for this logic system")
 
             override fun ConeKotlinType.isAcceptableForSmartcast(): Boolean {
-                return true
+                return !isNullableNothing
             }
         }
 

--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrImplicitCastInserter.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrImplicitCastInserter.kt
@@ -277,6 +277,14 @@ class Fir2IrImplicitCastInserter(
         return implicitCastOrExpression(data as IrExpression, expressionWithSmartcast.typeRef)
     }
 
+    override fun visitExpressionWithSmartcastToNull(
+        expressionWithSmartcastToNull: FirExpressionWithSmartcastToNull,
+        data: IrElement
+    ): IrElement {
+        // We don't want an implicit cast to Nothing?. This expression just encompasses nullability after null check.
+        return data
+    }
+
     internal fun implicitCastFromDispatchReceiver(
         original: IrExpression,
         originalTypeRef: FirTypeRef,

--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrVisitor.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrVisitor.kt
@@ -420,6 +420,14 @@ class Fir2IrVisitor(
         return implicitCastInserter.visitExpressionWithSmartcast(expressionWithSmartcast, value)
     }
 
+    override fun visitExpressionWithSmartcastToNull(
+        expressionWithSmartcastToNull: FirExpressionWithSmartcastToNull,
+        data: Any?
+    ): IrElement {
+        // This should not be materialized. Generate the expression with the original expression.
+        return convertToIrExpression(expressionWithSmartcastToNull.originalExpression)
+    }
+
     override fun visitCallableReferenceAccess(callableReferenceAccess: FirCallableReferenceAccess, data: Any?): IrElement {
         val explicitReceiverExpression = convertToIrReceiverExpression(
             callableReferenceAccess.explicitReceiver, callableReferenceAccess.calleeReference, callableReferenceAccess

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/ResolveUtils.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/ResolveUtils.kt
@@ -247,9 +247,35 @@ private fun BodyResolveComponents.typeFromSymbol(symbol: AbstractFirBasedSymbol<
     }
 }
 
-fun BodyResolveComponents.transformQualifiedAccessUsingSmartcastInfo(qualifiedAccessExpression: FirQualifiedAccessExpression): FirQualifiedAccessExpression {
+fun BodyResolveComponents.transformQualifiedAccessUsingSmartcastInfo(
+    qualifiedAccessExpression: FirQualifiedAccessExpression
+): FirQualifiedAccessExpression {
     val typesFromSmartCast = dataFlowAnalyzer.getTypeUsingSmartcastInfo(qualifiedAccessExpression) ?: return qualifiedAccessExpression
     val originalType = qualifiedAccessExpression.resultType.coneType
+    // For example, if (x == null) { ... },
+    //   we don't want to smartcast to Nothing?, but we want to record the nullability to its own kind of node.
+    // TODO: should we differentiate x == null v.s. x is Nothing?
+    if (typesFromSmartCast.any { it.isNullableNothing }) {
+        val typesFromSmartcastWithoutNullableNothing =
+            typesFromSmartCast.filterTo(mutableListOf()) { !it.isNullableNothing }.also {
+                it += originalType
+            }
+        val intersectedTypeWithoutNullableNothing =
+            ConeTypeIntersector.intersectTypes(session.inferenceComponents.ctx, typesFromSmartcastWithoutNullableNothing)
+        val intersectedTypeRefWithoutNullableNothing = buildResolvedTypeRef {
+            source = qualifiedAccessExpression.resultType.source?.fakeElement(FirFakeSourceElementKind.SmartCastedTypeRef)
+            type = intersectedTypeWithoutNullableNothing
+            annotations += qualifiedAccessExpression.resultType.annotations
+            delegatedTypeRef = qualifiedAccessExpression.resultType
+        }
+        return buildExpressionWithSmartcastToNull {
+            originalExpression = qualifiedAccessExpression
+            // TODO: Use Nothing? during resolution?
+            typeRef = intersectedTypeRefWithoutNullableNothing
+            // NB: Nothing? in types from smartcast in DFA is recorded here (and the expression kind itself).
+            this.typesFromSmartCast = typesFromSmartCast
+        }
+    }
     val allTypes = typesFromSmartCast.also {
         it += originalType
     }
@@ -259,6 +285,7 @@ fun BodyResolveComponents.transformQualifiedAccessUsingSmartcastInfo(qualifiedAc
         source = qualifiedAccessExpression.resultType.source?.fakeElement(FirFakeSourceElementKind.SmartCastedTypeRef)
         type = intersectedType
         annotations += qualifiedAccessExpression.resultType.annotations
+        delegatedTypeRef = qualifiedAccessExpression.resultType
     }
     return buildExpressionWithSmartcast {
         originalExpression = qualifiedAccessExpression

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/dfa/util.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/dfa/util.kt
@@ -99,7 +99,10 @@ internal val FirElement.symbol: AbstractFirBasedSymbol<*>?
         is FirWhenSubjectExpression -> whenRef.value.subject?.symbol
         is FirSafeCallExpression -> regularQualifiedAccess.symbol
         else -> null
-    }?.takeIf { this.unwrapSmartcastExpression() is FirThisReceiverExpression || (it !is FirFunctionSymbol<*> && it !is FirAccessorSymbol) }
+    }?.takeIf {
+        (this as? FirExpression)?.unwrapSmartcastExpression() is FirThisReceiverExpression ||
+                (it !is FirFunctionSymbol<*> && it !is FirAccessorSymbol)
+    }
 
 @DfaInternals
 internal val FirResolvable.symbol: AbstractFirBasedSymbol<*>?
@@ -110,4 +113,8 @@ internal val FirResolvable.symbol: AbstractFirBasedSymbol<*>?
         else -> null
     }
 
-private fun FirElement.unwrapSmartcastExpression(): FirElement = if (this is FirExpressionWithSmartcast) originalExpression else this
+internal fun FirExpression.unwrapSmartcastExpression(): FirExpression =
+    when (this) {
+        is FirExpressionWithSmartcast -> originalExpression
+        else -> this
+    }

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirDeclarationsResolveTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirDeclarationsResolveTransformer.kt
@@ -22,6 +22,7 @@ import org.jetbrains.kotlin.fir.references.FirResolvedNamedReference
 import org.jetbrains.kotlin.fir.resolve.*
 import org.jetbrains.kotlin.fir.resolve.calls.FirNamedReferenceWithCandidate
 import org.jetbrains.kotlin.fir.resolve.dfa.FirControlFlowGraphReferenceImpl
+import org.jetbrains.kotlin.fir.resolve.dfa.unwrapSmartcastExpression
 import org.jetbrains.kotlin.fir.resolve.inference.extractLambdaInfoFromFunctionalType
 import org.jetbrains.kotlin.fir.resolve.inference.isSuspendFunctionType
 import org.jetbrains.kotlin.fir.resolve.substitution.ConeSubstitutor
@@ -793,7 +794,7 @@ open class FirDeclarationsResolveTransformer(transformer: FirBodyResolveTransfor
         if (variable.returnTypeRef is FirImplicitTypeRef) {
             val resultType = when {
                 initializer != null -> {
-                    val unwrappedInitializer = (initializer as? FirExpressionWithSmartcast)?.originalExpression ?: initializer
+                    val unwrappedInitializer = initializer.unwrapSmartcastExpression()
                     unwrappedInitializer.resultType
                 }
                 variable.getter != null && variable.getter !is FirDefaultPropertyAccessor -> variable.getter?.returnTypeRef

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/contracts/ConeEffectExtractor.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/contracts/ConeEffectExtractor.kt
@@ -118,6 +118,13 @@ class ConeEffectExtractor(
         return expressionWithSmartcast.originalExpression.accept(this, data)
     }
 
+    override fun visitExpressionWithSmartcastToNull(
+        expressionWithSmartcastToNull: FirExpressionWithSmartcastToNull,
+        data: Nothing?
+    ): ConeContractDescriptionElement? {
+        return expressionWithSmartcastToNull.originalExpression.accept(this, data)
+    }
+
     override fun visitQualifiedAccessExpression(
         qualifiedAccessExpression: FirQualifiedAccessExpression,
         data: Nothing?

--- a/compiler/fir/tree/gen/org/jetbrains/kotlin/fir/expressions/FirExpressionWithSmartcastToNull.kt
+++ b/compiler/fir/tree/gen/org/jetbrains/kotlin/fir/expressions/FirExpressionWithSmartcastToNull.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.fir.expressions
+
+import org.jetbrains.kotlin.fir.FirElement
+import org.jetbrains.kotlin.fir.FirSourceElement
+import org.jetbrains.kotlin.fir.references.FirReference
+import org.jetbrains.kotlin.fir.types.ConeKotlinType
+import org.jetbrains.kotlin.fir.types.FirTypeProjection
+import org.jetbrains.kotlin.fir.types.FirTypeRef
+import org.jetbrains.kotlin.fir.visitors.*
+import org.jetbrains.kotlin.fir.FirImplementationDetail
+
+/*
+ * This file was generated automatically
+ * DO NOT MODIFY IT MANUALLY
+ */
+
+abstract class FirExpressionWithSmartcastToNull : FirExpressionWithSmartcast() {
+    abstract override val source: FirSourceElement?
+    abstract override val typeRef: FirTypeRef
+    abstract override val annotations: List<FirAnnotationCall>
+    abstract override val calleeReference: FirReference
+    abstract override val typeArguments: List<FirTypeProjection>
+    abstract override val explicitReceiver: FirExpression?
+    abstract override val dispatchReceiver: FirExpression
+    abstract override val extensionReceiver: FirExpression
+    abstract override val originalExpression: FirQualifiedAccessExpression
+    abstract override val typesFromSmartCast: Collection<ConeKotlinType>
+    abstract override val originalType: FirTypeRef
+
+    override fun <R, D> accept(visitor: FirVisitor<R, D>, data: D): R = visitor.visitExpressionWithSmartcastToNull(this, data)
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <E: FirElement, D> transform(transformer: FirTransformer<D>, data: D): E = 
+        transformer.transformExpressionWithSmartcastToNull(this, data) as E
+
+    @FirImplementationDetail
+    abstract override fun replaceSource(newSource: FirSourceElement?)
+
+    abstract override fun replaceTypeRef(newTypeRef: FirTypeRef)
+
+    abstract override fun replaceCalleeReference(newCalleeReference: FirReference)
+
+    abstract override fun replaceTypeArguments(newTypeArguments: List<FirTypeProjection>)
+
+    abstract override fun replaceExplicitReceiver(newExplicitReceiver: FirExpression?)
+
+    abstract override fun <D> transformAnnotations(transformer: FirTransformer<D>, data: D): FirExpressionWithSmartcastToNull
+
+    abstract override fun <D> transformCalleeReference(transformer: FirTransformer<D>, data: D): FirExpressionWithSmartcastToNull
+
+    abstract override fun <D> transformTypeArguments(transformer: FirTransformer<D>, data: D): FirExpressionWithSmartcastToNull
+
+    abstract override fun <D> transformExplicitReceiver(transformer: FirTransformer<D>, data: D): FirExpressionWithSmartcastToNull
+
+    abstract override fun <D> transformDispatchReceiver(transformer: FirTransformer<D>, data: D): FirExpressionWithSmartcastToNull
+
+    abstract override fun <D> transformExtensionReceiver(transformer: FirTransformer<D>, data: D): FirExpressionWithSmartcastToNull
+}

--- a/compiler/fir/tree/gen/org/jetbrains/kotlin/fir/visitors/FirTransformer.kt
+++ b/compiler/fir/tree/gen/org/jetbrains/kotlin/fir/visitors/FirTransformer.kt
@@ -91,6 +91,7 @@ import org.jetbrains.kotlin.fir.expressions.FirComponentCall
 import org.jetbrains.kotlin.fir.expressions.FirCallableReferenceAccess
 import org.jetbrains.kotlin.fir.expressions.FirThisReceiverExpression
 import org.jetbrains.kotlin.fir.expressions.FirExpressionWithSmartcast
+import org.jetbrains.kotlin.fir.expressions.FirExpressionWithSmartcastToNull
 import org.jetbrains.kotlin.fir.expressions.FirSafeCallExpression
 import org.jetbrains.kotlin.fir.expressions.FirCheckedSafeCallSubject
 import org.jetbrains.kotlin.fir.expressions.FirGetClassCall
@@ -478,6 +479,10 @@ abstract class FirTransformer<in D> : FirVisitor<FirElement, D>() {
 
     open fun transformExpressionWithSmartcast(expressionWithSmartcast: FirExpressionWithSmartcast, data: D): FirStatement {
         return transformElement(expressionWithSmartcast, data)
+    }
+
+    open fun transformExpressionWithSmartcastToNull(expressionWithSmartcastToNull: FirExpressionWithSmartcastToNull, data: D): FirStatement {
+        return transformElement(expressionWithSmartcastToNull, data)
     }
 
     open fun transformSafeCallExpression(safeCallExpression: FirSafeCallExpression, data: D): FirStatement {
@@ -978,6 +983,10 @@ abstract class FirTransformer<in D> : FirVisitor<FirElement, D>() {
 
     final override fun visitExpressionWithSmartcast(expressionWithSmartcast: FirExpressionWithSmartcast, data: D): FirStatement {
         return transformExpressionWithSmartcast(expressionWithSmartcast, data)
+    }
+
+    final override fun visitExpressionWithSmartcastToNull(expressionWithSmartcastToNull: FirExpressionWithSmartcastToNull, data: D): FirStatement {
+        return transformExpressionWithSmartcastToNull(expressionWithSmartcastToNull, data)
     }
 
     final override fun visitSafeCallExpression(safeCallExpression: FirSafeCallExpression, data: D): FirStatement {

--- a/compiler/fir/tree/gen/org/jetbrains/kotlin/fir/visitors/FirVisitor.kt
+++ b/compiler/fir/tree/gen/org/jetbrains/kotlin/fir/visitors/FirVisitor.kt
@@ -91,6 +91,7 @@ import org.jetbrains.kotlin.fir.expressions.FirComponentCall
 import org.jetbrains.kotlin.fir.expressions.FirCallableReferenceAccess
 import org.jetbrains.kotlin.fir.expressions.FirThisReceiverExpression
 import org.jetbrains.kotlin.fir.expressions.FirExpressionWithSmartcast
+import org.jetbrains.kotlin.fir.expressions.FirExpressionWithSmartcastToNull
 import org.jetbrains.kotlin.fir.expressions.FirSafeCallExpression
 import org.jetbrains.kotlin.fir.expressions.FirCheckedSafeCallSubject
 import org.jetbrains.kotlin.fir.expressions.FirGetClassCall
@@ -308,6 +309,8 @@ abstract class FirVisitor<out R, in D> {
     open fun visitThisReceiverExpression(thisReceiverExpression: FirThisReceiverExpression, data: D): R  = visitElement(thisReceiverExpression, data)
 
     open fun visitExpressionWithSmartcast(expressionWithSmartcast: FirExpressionWithSmartcast, data: D): R  = visitElement(expressionWithSmartcast, data)
+
+    open fun visitExpressionWithSmartcastToNull(expressionWithSmartcastToNull: FirExpressionWithSmartcastToNull, data: D): R  = visitElement(expressionWithSmartcastToNull, data)
 
     open fun visitSafeCallExpression(safeCallExpression: FirSafeCallExpression, data: D): R  = visitElement(safeCallExpression, data)
 

--- a/compiler/fir/tree/gen/org/jetbrains/kotlin/fir/visitors/FirVisitorVoid.kt
+++ b/compiler/fir/tree/gen/org/jetbrains/kotlin/fir/visitors/FirVisitorVoid.kt
@@ -91,6 +91,7 @@ import org.jetbrains.kotlin.fir.expressions.FirComponentCall
 import org.jetbrains.kotlin.fir.expressions.FirCallableReferenceAccess
 import org.jetbrains.kotlin.fir.expressions.FirThisReceiverExpression
 import org.jetbrains.kotlin.fir.expressions.FirExpressionWithSmartcast
+import org.jetbrains.kotlin.fir.expressions.FirExpressionWithSmartcastToNull
 import org.jetbrains.kotlin.fir.expressions.FirSafeCallExpression
 import org.jetbrains.kotlin.fir.expressions.FirCheckedSafeCallSubject
 import org.jetbrains.kotlin.fir.expressions.FirGetClassCall
@@ -477,6 +478,10 @@ abstract class FirVisitorVoid : FirVisitor<Unit, Nothing?>() {
 
     open fun visitExpressionWithSmartcast(expressionWithSmartcast: FirExpressionWithSmartcast) {
         visitElement(expressionWithSmartcast)
+    }
+
+    open fun visitExpressionWithSmartcastToNull(expressionWithSmartcastToNull: FirExpressionWithSmartcastToNull) {
+        visitElement(expressionWithSmartcastToNull)
     }
 
     open fun visitSafeCallExpression(safeCallExpression: FirSafeCallExpression) {
@@ -977,6 +982,10 @@ abstract class FirVisitorVoid : FirVisitor<Unit, Nothing?>() {
 
     final override fun visitExpressionWithSmartcast(expressionWithSmartcast: FirExpressionWithSmartcast, data: Nothing?) {
         visitExpressionWithSmartcast(expressionWithSmartcast)
+    }
+
+    final override fun visitExpressionWithSmartcastToNull(expressionWithSmartcastToNull: FirExpressionWithSmartcastToNull, data: Nothing?) {
+        visitExpressionWithSmartcastToNull(expressionWithSmartcastToNull)
     }
 
     final override fun visitSafeCallExpression(safeCallExpression: FirSafeCallExpression, data: Nothing?) {

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/expressions/builder/FirExpressionWithSmartcastToNullBuilder.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/expressions/builder/FirExpressionWithSmartcastToNullBuilder.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.fir.expressions.builder
+
+import org.jetbrains.kotlin.fir.expressions.FirExpressionWithSmartcastToNull
+import org.jetbrains.kotlin.fir.expressions.FirQualifiedAccessExpression
+import org.jetbrains.kotlin.fir.expressions.impl.FirExpressionWithSmartcastToNullImpl
+import org.jetbrains.kotlin.fir.types.ConeKotlinType
+import org.jetbrains.kotlin.fir.types.FirTypeRef
+
+class FirExpressionWithSmartcastToNullBuilder {
+    lateinit var originalExpression: FirQualifiedAccessExpression
+    lateinit var typeRef: FirTypeRef
+    lateinit var typesFromSmartCast: Collection<ConeKotlinType>
+
+    fun build(): FirExpressionWithSmartcastToNull {
+        return FirExpressionWithSmartcastToNullImpl(originalExpression, typeRef, typesFromSmartCast)
+    }
+}
+
+inline fun buildExpressionWithSmartcastToNull(init: FirExpressionWithSmartcastToNullBuilder.() -> Unit): FirExpressionWithSmartcastToNull {
+    return FirExpressionWithSmartcastToNullBuilder().apply(init).build()
+}

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/expressions/impl/FirExpressionWithSmartcastToNullImpl.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/expressions/impl/FirExpressionWithSmartcastToNullImpl.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.fir.expressions.impl
+
+import org.jetbrains.kotlin.fir.FirImplementationDetail
+import org.jetbrains.kotlin.fir.FirSourceElement
+import org.jetbrains.kotlin.fir.expressions.*
+import org.jetbrains.kotlin.fir.references.FirReference
+import org.jetbrains.kotlin.fir.types.ConeKotlinType
+import org.jetbrains.kotlin.fir.types.FirResolvedTypeRef
+import org.jetbrains.kotlin.fir.types.FirTypeProjection
+import org.jetbrains.kotlin.fir.types.FirTypeRef
+import org.jetbrains.kotlin.fir.visitors.FirTransformer
+import org.jetbrains.kotlin.fir.visitors.FirVisitor
+import org.jetbrains.kotlin.fir.visitors.transformSingle
+
+class FirExpressionWithSmartcastToNullImpl(
+    override var originalExpression: FirQualifiedAccessExpression,
+    override val typeRef: FirTypeRef,
+    override val typesFromSmartCast: Collection<ConeKotlinType>
+) : FirExpressionWithSmartcastToNull() {
+    init {
+        assert(originalExpression.typeRef is FirResolvedTypeRef)
+    }
+
+    override val source: FirSourceElement? get() = originalExpression.source
+    override val annotations: List<FirAnnotationCall> get() = originalExpression.annotations
+    override val typeArguments: List<FirTypeProjection> get() = originalExpression.typeArguments
+    override val explicitReceiver: FirExpression? get() = originalExpression.explicitReceiver
+    override val dispatchReceiver: FirExpression get() = originalExpression.dispatchReceiver
+    override val extensionReceiver: FirExpression get() = originalExpression.extensionReceiver
+    override val calleeReference: FirReference get() = originalExpression.calleeReference
+    override val originalType: FirTypeRef get() = originalExpression.typeRef
+
+    override fun <D> transformChildren(transformer: FirTransformer<D>, data: D): FirExpressionWithSmartcastToNull {
+        originalExpression = originalExpression.transformSingle(transformer, data)
+        return this
+    }
+
+    override fun <R, D> acceptChildren(visitor: FirVisitor<R, D>, data: D) {
+        originalExpression.accept(visitor, data)
+    }
+
+    override fun <D> transformCalleeReference(transformer: FirTransformer<D>, data: D): FirExpressionWithSmartcastToNull {
+        throw IllegalStateException()
+    }
+
+    override fun <D> transformExplicitReceiver(transformer: FirTransformer<D>, data: D): FirExpressionWithSmartcastToNull {
+        throw IllegalStateException()
+    }
+
+    override fun <D> transformDispatchReceiver(transformer: FirTransformer<D>, data: D): FirExpressionWithSmartcastToNull {
+        throw IllegalStateException()
+    }
+
+    override fun <D> transformExtensionReceiver(transformer: FirTransformer<D>, data: D): FirExpressionWithSmartcastToNull {
+        throw IllegalStateException()
+    }
+
+    override fun <D> transformTypeArguments(transformer: FirTransformer<D>, data: D): FirExpressionWithSmartcastToNull {
+        throw IllegalStateException()
+    }
+
+    override fun <D> transformAnnotations(transformer: FirTransformer<D>, data: D): FirExpressionWithSmartcastToNull {
+        throw IllegalStateException()
+    }
+
+    override fun replaceTypeArguments(newTypeArguments: List<FirTypeProjection>) {
+        throw IllegalStateException()
+    }
+
+    override fun replaceCalleeReference(newCalleeReference: FirReference) {
+        throw IllegalStateException()
+    }
+
+    override fun replaceExplicitReceiver(newExplicitReceiver: FirExpression?) {
+        throw IllegalStateException()
+    }
+
+    override fun replaceTypeRef(newTypeRef: FirTypeRef) {}
+
+    @FirImplementationDetail
+    override fun replaceSource(newSource: FirSourceElement?) {
+    }
+}

--- a/compiler/fir/tree/tree-generator/src/org/jetbrains/kotlin/fir/tree/generator/FirTreeBuilder.kt
+++ b/compiler/fir/tree/tree-generator/src/org/jetbrains/kotlin/fir/tree/generator/FirTreeBuilder.kt
@@ -108,6 +108,7 @@ object FirTreeBuilder : AbstractFirTreeBuilder() {
     val callableReferenceAccess = element("CallableReferenceAccess", Expression, qualifiedAccessExpression)
     val thisReceiverExpression = element("ThisReceiverExpression", Expression, qualifiedAccessExpression)
     val expressionWithSmartcast = element("ExpressionWithSmartcast", Expression, qualifiedAccessExpression)
+    val expressionWithSmartcastToNull = element("ExpressionWithSmartcastToNull", Expression, expressionWithSmartcast)
     val safeCallExpression = element("SafeCallExpression", Expression, expression)
     val checkedSafeCallSubject = element("CheckedSafeCallSubject", Expression, expression)
     val getClassCall = element("GetClassCall", Expression, expression, call)

--- a/compiler/fir/tree/tree-generator/src/org/jetbrains/kotlin/fir/tree/generator/ImplementationConfigurator.kt
+++ b/compiler/fir/tree/tree-generator/src/org/jetbrains/kotlin/fir/tree/generator/ImplementationConfigurator.kt
@@ -156,6 +156,7 @@ object ImplementationConfigurator : AbstractFirTreeImplementationConfigurator() 
         impl(qualifiedAccessExpression)
 
         noImpl(expressionWithSmartcast)
+        noImpl(expressionWithSmartcastToNull)
 
         impl(getClassCall) {
             default("argument") {

--- a/compiler/fir/tree/tree-generator/src/org/jetbrains/kotlin/fir/tree/generator/NodeConfigurator.kt
+++ b/compiler/fir/tree/tree-generator/src/org/jetbrains/kotlin/fir/tree/generator/NodeConfigurator.kt
@@ -459,6 +459,12 @@ object NodeConfigurator : AbstractFieldConfigurator<FirTreeBuilder>(FirTreeBuild
             +field("originalType", typeRef)
         }
 
+        expressionWithSmartcastToNull.configure {
+            +field("originalExpression", qualifiedAccessExpression)
+            +field("typesFromSmartCast", "Collection<ConeKotlinType>", null, customType = coneKotlinTypeType)
+            +field("originalType", typeRef)
+        }
+
         safeCallExpression.configure {
             +field("receiver", expression).withTransform()
             // Special node that might be used as a reference to receiver of a safe call after null check

--- a/compiler/testData/diagnostics/tests/smartCasts/smartcastToNothingAfterCheckingForNull.fir.kt
+++ b/compiler/testData/diagnostics/tests/smartCasts/smartcastToNothingAfterCheckingForNull.fir.kt
@@ -24,6 +24,6 @@ fun g(x: B<Int>) {
 
     if (y is Nothing?) {
         f(y)
-        <!NONE_APPLICABLE!>g<!>(y)
+        g(y)
     }
 }

--- a/compiler/testData/diagnostics/testsWithStdLib/contracts/smartcasts/throwsEffect.fir.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/contracts/smartcasts/throwsEffect.fir.kt
@@ -26,7 +26,7 @@ fun testSpilling(x: Any?) {
         myAssert(x is String)
         x.length
     }
-    x.<!UNRESOLVED_REFERENCE!>length<!>
+    x<!UNSAFE_CALL!>.<!>length
 }
 
 fun testAssertInIf(x: Any?) {

--- a/compiler/tests-spec/testData/diagnostics/notLinked/contracts/analysis/smartcasts/pos/8.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/contracts/analysis/smartcasts/pos/8.fir.kt
@@ -20,11 +20,11 @@ fun <T> T?.case_3(value_1: Int?, value_2: Boolean): Boolean {
 
 // TESTCASE NUMBER: 4
 fun case_4(value_1: Number, block: (() -> Unit)?): Boolean? {
-    <!WRONG_IMPLIES_CONDITION!>contract {
+    contract {
         returns(true) implies (value_1 is Int)
         returns(false) implies (block == null)
         returns(null) implies (block != null)
-    }<!>
+    }
 
     return value_1 == null
 }

--- a/compiler/tests-spec/testData/diagnostics/notLinked/dfa/neg/1.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/dfa/neg/1.fir.kt
@@ -87,7 +87,7 @@ fun case_6(x: EmptyClass?) {
 
 // TESTCASE NUMBER: 7
 fun case_7() {
-    if (nullableNumberProperty != null || <!EQUALITY_NOT_APPLICABLE!><!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Number?")!>nullableNumberProperty<!> != null is Boolean<!>) {
+    if (nullableNumberProperty != null || <!EQUALITY_NOT_APPLICABLE!><!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Number? & kotlin.Number?")!>nullableNumberProperty<!> != null is Boolean<!>) {
         <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Number?")!>nullableNumberProperty<!>
         <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Number?")!>nullableNumberProperty<!><!UNSAFE_CALL!>.<!>equals(null)
         <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Number?")!>nullableNumberProperty<!>.propT
@@ -262,8 +262,8 @@ fun case_16() {
 
 // TESTCASE NUMBER: 17
 val case_17 = if (nullableIntProperty == null == true == false) 0 else {
-    <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int?")!>nullableIntProperty<!>
-    <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int?")!>nullableIntProperty<!>.<!UNRESOLVED_REFERENCE!>java<!>
+    <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int? & kotlin.Int?")!>nullableIntProperty<!>
+    <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int? & kotlin.Int?")!>nullableIntProperty<!>.<!UNRESOLVED_REFERENCE!>java<!>
 }
 
 //TESTCASE NUMBER: 18
@@ -440,18 +440,18 @@ fun case_25(b: Boolean) {
 // TESTCASE NUMBER: 26
 fun case_26(a: ((Float) -> Int?)?, b: Float?) {
     if (a != null == true == false && b != null == true == false) {
-        val x = <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int?")!><!UNSAFE_IMPLICIT_INVOKE_CALL!>a<!>(<!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Float?")!>b<!>)<!>
+        val x = <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int?")!><!UNSAFE_IMPLICIT_INVOKE_CALL!>a<!>(<!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Float? & kotlin.Float?")!>b<!>)<!>
         if (x != null == true === false) {
-            <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int?")!>x<!>
-            <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int?")!>x<!><!UNSAFE_CALL!>.<!>equals(null)
-            <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int?")!>x<!>.propT
-            <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int?")!>x<!><!UNSAFE_CALL!>.<!>propAny
-            <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int?")!>x<!>.propNullableT
-            <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int?")!>x<!>.propNullableAny
-            <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int?")!>x<!>.funT()
-            <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int?")!>x<!><!UNSAFE_CALL!>.<!>funAny()
-            <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int?")!>x<!>.funNullableT()
-            <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int?")!>x<!>.funNullableAny()
+            <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int? & kotlin.Int?")!>x<!>
+            <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int? & kotlin.Int?")!>x<!><!UNSAFE_CALL!>.<!>equals(null)
+            <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int? & kotlin.Int?")!>x<!>.propT
+            <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int? & kotlin.Int?")!>x<!><!UNSAFE_CALL!>.<!>propAny
+            <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int? & kotlin.Int?")!>x<!>.propNullableT
+            <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int? & kotlin.Int?")!>x<!>.propNullableAny
+            <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int? & kotlin.Int?")!>x<!>.funT()
+            <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int? & kotlin.Int?")!>x<!><!UNSAFE_CALL!>.<!>funAny()
+            <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int? & kotlin.Int?")!>x<!>.funNullableT()
+            <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int? & kotlin.Int?")!>x<!>.funNullableAny()
         }
     }
 }

--- a/compiler/tests-spec/testData/diagnostics/notLinked/dfa/neg/16.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/dfa/neg/16.fir.kt
@@ -18,8 +18,8 @@ fun case_1(x: ClassWithCustomEquals) {
 // TESTCASE NUMBER: 2
 fun case_2(x: ClassWithCustomEquals) {
     if (x == null) {
-        <!DEBUG_INFO_EXPRESSION_TYPE("ClassWithCustomEquals")!>x<!>
-        <!DEBUG_INFO_EXPRESSION_TYPE("ClassWithCustomEquals")!>x<!>.<!UNRESOLVED_REFERENCE!>inv<!>()
+        <!DEBUG_INFO_EXPRESSION_TYPE("ClassWithCustomEquals & ClassWithCustomEquals")!>x<!>
+        <!DEBUG_INFO_EXPRESSION_TYPE("ClassWithCustomEquals & ClassWithCustomEquals")!>x<!>.<!UNRESOLVED_REFERENCE!>inv<!>()
     }
 }
 
@@ -76,8 +76,8 @@ fun case_6(x: ClassWithCustomEquals) {
 // TESTCASE NUMBER: 7
 fun case_7(x: ClassWithCustomEquals) {
     if ((x != null) == false) {
-        <!DEBUG_INFO_EXPRESSION_TYPE("ClassWithCustomEquals")!>x<!>
-        <!DEBUG_INFO_EXPRESSION_TYPE("ClassWithCustomEquals")!>x<!>.<!UNRESOLVED_REFERENCE!>inv<!>()
+        <!DEBUG_INFO_EXPRESSION_TYPE("ClassWithCustomEquals & ClassWithCustomEquals")!>x<!>
+        <!DEBUG_INFO_EXPRESSION_TYPE("ClassWithCustomEquals & ClassWithCustomEquals")!>x<!>.<!UNRESOLVED_REFERENCE!>inv<!>()
     }
 }
 

--- a/compiler/tests-spec/testData/diagnostics/notLinked/dfa/neg/2.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/dfa/neg/2.fir.kt
@@ -37,8 +37,8 @@ fun case_4(x: Any) {
 // TESTCASE NUMBER: 5
 fun case_5(x: Any?) {
     if (!(x !is Nothing?)) {
-        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & kotlin.Nothing")!>x<!>
-        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & kotlin.Nothing")!>x<!><!UNNECESSARY_SAFE_CALL!>?.<!>inv()
+        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & kotlin.Any")!>x<!>
+        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & kotlin.Any")!>x<!><!UNNECESSARY_SAFE_CALL!>?.<!><!UNRESOLVED_REFERENCE!>inv<!>()
     }
 }
 
@@ -61,16 +61,16 @@ fun case_7(x: Any) {
 // TESTCASE NUMBER: 8
 fun case_8(x: Any?) {
     if (!(x is Nothing?)) else {
-        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & kotlin.Nothing?")!>x<!>
-        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & kotlin.Nothing?")!>x<!>?.inv()
+        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & kotlin.Any?")!>x<!>
+        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & kotlin.Any?")!>x<!>?.<!UNRESOLVED_REFERENCE!>inv<!>()
     }
 }
 
 // TESTCASE NUMBER: 9
 fun case_9(x: Any?) {
     if (!!(x !is Nothing?)) else {
-        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & kotlin.Nothing")!>x<!>
-        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & kotlin.Nothing")!>x<!><!UNNECESSARY_SAFE_CALL!>?.<!>inv()
+        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & kotlin.Any")!>x<!>
+        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & kotlin.Any")!>x<!><!UNNECESSARY_SAFE_CALL!>?.<!><!UNRESOLVED_REFERENCE!>inv<!>()
     }
 }
 
@@ -85,7 +85,7 @@ fun case_10(x: Any?) {
 // TESTCASE NUMBER: 11
 fun case_11(x: Any?) {
     if (x is Nothing?) {
-        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & kotlin.Nothing?")!>x<!>
-        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & kotlin.Nothing?")!>x<!>?.inv()
+        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & kotlin.Any?")!>x<!>
+        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & kotlin.Any?")!>x<!>?.<!UNRESOLVED_REFERENCE!>inv<!>()
     }
 }

--- a/compiler/tests-spec/testData/diagnostics/notLinked/dfa/neg/29.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/dfa/neg/29.fir.kt
@@ -9,8 +9,8 @@ fun case_1(a: Any?) {
         if (true) continue
     }
 
-    <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any?")!>a<!>
-    <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any?")!>a<!><!UNSAFE_CALL!>.<!>equals(10)
+    <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & kotlin.Any?")!>a<!>
+    <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & kotlin.Any?")!>a<!><!UNSAFE_CALL!>.<!>equals(10)
 }
 
 // TESTCASE NUMBER: 2

--- a/compiler/tests-spec/testData/diagnostics/notLinked/dfa/neg/33.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/dfa/neg/33.fir.kt
@@ -12,7 +12,7 @@ fun nullableStringArg(number: String?) {}
  */
 fun case_1(x: Int?) {
     if (x == null) {
-        nullableStringArg(<!ARGUMENT_TYPE_MISMATCH, DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int?")!>x<!>)
+        nullableStringArg(<!ARGUMENT_TYPE_MISMATCH, DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int? & kotlin.Int?")!>x<!>)
     }
 }
 
@@ -34,7 +34,7 @@ fun case_2(x: Int?, y: Nothing?) {
  */
 fun case_3(x: Int?) {
     if (x == null) {
-        nullableStringArg(<!ARGUMENT_TYPE_MISMATCH, DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int?")!>x<!>)
+        nullableStringArg(<!ARGUMENT_TYPE_MISMATCH, DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int? & kotlin.Int?")!>x<!>)
     }
 }
 
@@ -45,7 +45,7 @@ fun case_3(x: Int?) {
  */
 fun case_4(x: Int?) {
     if (x == null) {
-        nullableStringArg(<!ARGUMENT_TYPE_MISMATCH, DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int?")!>x<!>)
+        nullableStringArg(<!ARGUMENT_TYPE_MISMATCH, DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int? & kotlin.Int?")!>x<!>)
     }
 }
 
@@ -57,6 +57,6 @@ fun case_4(x: Int?) {
 fun case_5(x: Int?) {
     if (x == null) {
         var y = x
-        nullableStringArg(<!ARGUMENT_TYPE_MISMATCH, DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int?")!>y<!>)
+        nullableStringArg(<!ARGUMENT_TYPE_MISMATCH, DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int? & kotlin.Int?")!>y<!>)
     }
 }

--- a/compiler/tests-spec/testData/diagnostics/notLinked/dfa/neg/38.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/dfa/neg/38.fir.kt
@@ -15,8 +15,8 @@ fun case_1() {
             break@outer
         }
     }
-    <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.String?")!>x<!>
-    <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.String?")!>x<!><!UNSAFE_CALL!>.<!>length
+    <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.String? & kotlin.String?")!>x<!>
+    <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.String? & kotlin.String?")!>x<!><!UNSAFE_CALL!>.<!>length
 }
 
 /*
@@ -32,8 +32,8 @@ fun case_2() {
             break@outer
         }
     }
-    <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.String?")!>x<!>
-    <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.String?")!>x<!><!UNSAFE_CALL!>.<!>length
+    <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.String? & kotlin.String?")!>x<!>
+    <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.String? & kotlin.String?")!>x<!><!UNSAFE_CALL!>.<!>length
 }
 
 /*
@@ -145,8 +145,8 @@ fun case_9() {
         inner@ do {
             x = null
         } while (x != null)
-        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.String?")!>x<!>
-        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.String?")!>x<!><!UNSAFE_CALL!>.<!>length
+        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.String? & kotlin.String?")!>x<!>
+        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.String? & kotlin.String?")!>x<!><!UNSAFE_CALL!>.<!>length
     }
 }
 

--- a/compiler/tests-spec/testData/diagnostics/notLinked/dfa/neg/39.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/dfa/neg/39.fir.kt
@@ -151,8 +151,8 @@ fun case_12() {
     while (true) {
         y += if (x == null) break else 10
     }
-    <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int?")!>x<!>
-    <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int?")!>x<!><!UNSAFE_CALL!>.<!>inv()
+    <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int? & kotlin.Int?")!>x<!>
+    <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int? & kotlin.Int?")!>x<!><!UNSAFE_CALL!>.<!>inv()
 }
 
 // TESTCASE NUMBER: 13

--- a/compiler/tests-spec/testData/diagnostics/notLinked/dfa/neg/45.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/dfa/neg/45.fir.kt
@@ -17,5 +17,5 @@ fun case_1(x: Number?): Long? {
  * ISSUES: KT-22997
  */
 fun case_2(x: Number?): Long? {
-    if (x == null || x is Long) return <!RETURN_TYPE_MISMATCH!>x<!> else return 0L
+    if (x == null || x is Long) return x else return 0L
 }

--- a/compiler/tests-spec/testData/diagnostics/notLinked/dfa/pos/1.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/dfa/pos/1.fir.kt
@@ -122,7 +122,7 @@ fun case_6(x: EmptyClass?) {
 
 // TESTCASE NUMBER: 7
 fun case_7() {
-    if (nullableNumberProperty != null || <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Number?")!>nullableNumberProperty<!> != null) {
+    if (nullableNumberProperty != null || <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Number? & kotlin.Number?")!>nullableNumberProperty<!> != null) {
         <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Number? & kotlin.Number")!>nullableNumberProperty<!>
         <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Number? & kotlin.Number")!>nullableNumberProperty<!>.equals(null)
         <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Number? & kotlin.Number")!>nullableNumberProperty<!>.propT

--- a/compiler/tests-spec/testData/diagnostics/notLinked/dfa/pos/2.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/dfa/pos/2.fir.kt
@@ -288,7 +288,7 @@ fun case_11(b: Boolean) {
         if (z != null || b) {
 
         } else {
-            <!DEBUG_INFO_EXPRESSION_TYPE("<anonymous>?")!>z<!>
+            <!DEBUG_INFO_EXPRESSION_TYPE("<anonymous>? & <anonymous>?")!>z<!>
         }
     }
 }

--- a/compiler/tests-spec/testData/diagnostics/notLinked/dfa/pos/3.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/dfa/pos/3.fir.kt
@@ -16,14 +16,14 @@ import otherpackage.*
 // TESTCASE NUMBER: 1
 fun case_1(x: Any?) {
     if (x == null) {
-        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any?")!>x<!>
+        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & kotlin.Any?")!>x<!>
     }
 }
 
 // TESTCASE NUMBER: 2
 fun case_2(x: Nothing?) {
     if (x == null) {
-        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Nothing?")!>x<!>
+        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Nothing? & kotlin.Nothing?")!>x<!>
     }
 }
 
@@ -38,7 +38,7 @@ fun case_3() {
 // TESTCASE NUMBER: 4
 fun case_4(x: Char?) {
     if (x == null && true) {
-        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Char?")!>x<!>
+        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Char? & kotlin.Char?")!>x<!>
     }
 }
 
@@ -46,7 +46,7 @@ fun case_4(x: Char?) {
 fun case_5() {
     val x: Unit? = null
 
-    if (x == null) <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Unit?")!>x<!>
+    if (x == null) <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Unit? & kotlin.Unit?")!>x<!>
 }
 
 // TESTCASE NUMBER: 6
@@ -54,7 +54,7 @@ fun case_6(x: EmptyClass?) {
     val y = true
 
     if (x == null && !y) {
-        <!DEBUG_INFO_EXPRESSION_TYPE("EmptyClass?")!>x<!>
+        <!DEBUG_INFO_EXPRESSION_TYPE("EmptyClass? & EmptyClass?")!>x<!>
     }
 }
 
@@ -67,8 +67,8 @@ fun case_7() {
 
 // TESTCASE NUMBER: 8
 fun case_8(x: TypealiasNullableString) {
-    if (x == null && <!DEBUG_INFO_EXPRESSION_TYPE("TypealiasNullableString")!>x<!> == null)
-        <!DEBUG_INFO_EXPRESSION_TYPE("TypealiasNullableString")!>x<!>
+    if (x == null && <!DEBUG_INFO_EXPRESSION_TYPE("TypealiasNullableString & TypealiasNullableString")!>x<!> == null)
+        <!DEBUG_INFO_EXPRESSION_TYPE("TypealiasNullableString & TypealiasNullableString")!>x<!>
 }
 
 /*
@@ -105,7 +105,7 @@ fun case_11(x: TypealiasNullableString?, y: TypealiasNullableString) {
         if (y == null) {
             if (nullableStringProperty != null) {
                 if (z == null) {
-                    <!DEBUG_INFO_EXPRESSION_TYPE("TypealiasNullableString?")!>x<!>
+                    <!DEBUG_INFO_EXPRESSION_TYPE("TypealiasNullableString? & TypealiasNullableString?")!>x<!>
                 }
             }
         }
@@ -172,7 +172,7 @@ fun case_14() {
 // TESTCASE NUMBER: 15
 fun case_15(x: TypealiasNullableString) {
     val t = <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.String?")!>if (x != null) "" else {
-        <!DEBUG_INFO_EXPRESSION_TYPE("TypealiasNullableString")!>x<!>
+        <!DEBUG_INFO_EXPRESSION_TYPE("TypealiasNullableString & TypealiasNullableString")!>x<!>
     }<!>
 }
 
@@ -187,13 +187,13 @@ fun case_16() {
 
 // TESTCASE NUMBER: 17
 val case_17 = <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int?")!>if (nullableIntProperty !== null) 0 else {
-    <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int?")!>nullableIntProperty<!>
+    <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int? & kotlin.Int?")!>nullableIntProperty<!>
 }<!>
 
 //TESTCASE NUMBER: 18
 fun case_18(a: DeepObject.A.B.C.D.E.F.G.J?) {
     if (a == null) {
-        <!DEBUG_INFO_EXPRESSION_TYPE("DeepObject.A.B.C.D.E.F.G.J?")!>a<!>
+        <!DEBUG_INFO_EXPRESSION_TYPE("DeepObject.A.B.C.D.E.F.G.J? & DeepObject.A.B.C.D.E.F.G.J?")!>a<!>
     }
 }
 
@@ -249,15 +249,15 @@ fun case_21() {
 // TESTCASE NUMBER: 22
 fun case_22(a: (() -> Unit)?) {
     if (a == null) {
-        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Function0<kotlin.Unit>?")!>a<!>
+        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Function0<kotlin.Unit>? & kotlin.Function0<kotlin.Unit>?")!>a<!>
     }
 }
 
 // TESTCASE NUMBER: 23
 fun case_23(a: ((Float) -> Int?)?, b: Float?) {
     if (a == null && b == null) {
-        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Function1<kotlin.Float, kotlin.Int?>?")!>a<!>
-        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Float?")!>b<!>
+        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Function1<kotlin.Float, kotlin.Int?>? & kotlin.Function1<kotlin.Float, kotlin.Int?>?")!>a<!>
+        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Float? & kotlin.Float?")!>b<!>
         if (a != null) {
             <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Function1<kotlin.Float, kotlin.Int?>? & kotlin.Function1<kotlin.Float, kotlin.Int?>")!>a<!>
         }
@@ -290,13 +290,13 @@ fun case_25(b: Boolean) {
         val z = <!DEBUG_INFO_EXPRESSION_TYPE("<anonymous>?")!>y()<!>
 
         if (z == null) {
-            <!DEBUG_INFO_EXPRESSION_TYPE("<anonymous>?")!>z<!>
+            <!DEBUG_INFO_EXPRESSION_TYPE("<anonymous>? & <anonymous>?")!>z<!>
         }
     }
 }
 
 // TESTCASE NUMBER: 26
-fun case_26(a: Int?, b: Int? = if (a !== null) 0 else <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int?")!>a<!>) {
+fun case_26(a: Int?, b: Int? = if (a !== null) 0 else <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int? & kotlin.Int?")!>a<!>) {
     <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int?")!>a<!>
     <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int?")!>b<!>
 }

--- a/compiler/tests-spec/testData/diagnostics/notLinked/dfa/pos/4.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/dfa/pos/4.fir.kt
@@ -19,14 +19,14 @@ import otherpackage.*
 // TESTCASE NUMBER: 1
 fun case_1(x: Any) {
     if (x === null) {
-        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any")!>x<!>
+        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any & kotlin.Any")!>x<!>
     }
 }
 
 // TESTCASE NUMBER: 2
 fun case_2(x: Nothing) {
     if (x == null) {
-        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Nothing")!>x<!>
+        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Nothing & kotlin.Nothing")!>x<!>
     }
 }
 
@@ -41,7 +41,7 @@ fun case_3() {
 // TESTCASE NUMBER: 4
 fun case_4(x: Char) {
     if (x == null && true) {
-        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Char")!>x<!>
+        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Char & kotlin.Char")!>x<!>
     }
 }
 
@@ -49,7 +49,7 @@ fun case_4(x: Char) {
 fun case_5() {
     val x: Unit = kotlin.Unit
 
-    if (x == null) <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Unit")!>x<!>
+    if (x == null) <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Unit & kotlin.Unit")!>x<!>
 }
 
 // TESTCASE NUMBER: 6
@@ -57,7 +57,7 @@ fun case_6(x: EmptyClass) {
     val y = true
 
     if (x == null && !y) {
-        <!DEBUG_INFO_EXPRESSION_TYPE("EmptyClass")!>x<!>
+        <!DEBUG_INFO_EXPRESSION_TYPE("EmptyClass & EmptyClass")!>x<!>
     }
 }
 
@@ -70,7 +70,7 @@ fun case_7() {
 
 // TESTCASE NUMBER: 8
 fun case_8(x: TypealiasString) {
-    if (x == null && <!DEBUG_INFO_EXPRESSION_TYPE("TypealiasString")!>x<!> == null) <!DEBUG_INFO_EXPRESSION_TYPE("TypealiasString")!>x<!>
+    if (x == null && <!DEBUG_INFO_EXPRESSION_TYPE("TypealiasString & TypealiasString")!>x<!> == null) <!DEBUG_INFO_EXPRESSION_TYPE("TypealiasString & TypealiasString")!>x<!>
 }
 
 // TESTCASE NUMBER: 9
@@ -78,7 +78,7 @@ fun case_9(x: TypealiasString) {
     if (x != null) {
 
     } else if (false) {
-        <!DEBUG_INFO_EXPRESSION_TYPE("TypealiasString")!>x<!>
+        <!DEBUG_INFO_EXPRESSION_TYPE("TypealiasString & TypealiasString")!>x<!>
     }
 }
 
@@ -103,7 +103,7 @@ fun case_11(x: TypealiasString, y: TypealiasString) {
         if (y == null) {
             if (stringProperty != null) {
                 if (false || false || false || z == null || false) {
-                    <!DEBUG_INFO_EXPRESSION_TYPE("TypealiasString")!>x<!>
+                    <!DEBUG_INFO_EXPRESSION_TYPE("TypealiasString & TypealiasString")!>x<!>
                 }
             }
         }
@@ -112,14 +112,14 @@ fun case_11(x: TypealiasString, y: TypealiasString) {
 
 // TESTCASE NUMBER: 12
 fun case_12(x: TypealiasString, y: TypealiasString) = <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.String")!>if (x != null) "1"
-    else if (y !== null) <!DEBUG_INFO_EXPRESSION_TYPE("TypealiasString")!>x<!>
+    else if (y !== null) <!DEBUG_INFO_EXPRESSION_TYPE("TypealiasString & TypealiasString")!>x<!>
     else "-1"<!>
 
 // TESTCASE NUMBER: 13
 fun case_13(x: otherpackage.EmptyClass13) =
     <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any")!>if (x != null) {
         1
-    } else <!DEBUG_INFO_EXPRESSION_TYPE("otherpackage.EmptyClass13")!>x<!><!>
+    } else <!DEBUG_INFO_EXPRESSION_TYPE("otherpackage.EmptyClass13 & otherpackage.EmptyClass13")!>x<!><!>
 
 // TESTCASE NUMBER: 14
 class A14 {
@@ -179,7 +179,7 @@ fun case_16() {
     val x: TypealiasNothing = return
 
     if (x == null) {
-        <!DEBUG_INFO_EXPRESSION_TYPE("TypealiasNothing")!>x<!>
+        <!DEBUG_INFO_EXPRESSION_TYPE("TypealiasNothing & TypealiasNothing")!>x<!>
     }
 }
 
@@ -195,7 +195,7 @@ val case_17 = <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int")!>if (true && true && in
 //TESTCASE NUMBER: 18
 fun case_18(a: DeepObject.A.B.C.D.E.F.G.J) {
     if (a == null) {
-        <!DEBUG_INFO_EXPRESSION_TYPE("DeepObject.A.B.C.D.E.F.G.J")!>a<!>
+        <!DEBUG_INFO_EXPRESSION_TYPE("DeepObject.A.B.C.D.E.F.G.J & DeepObject.A.B.C.D.E.F.G.J")!>a<!>
     }
 }
 
@@ -256,7 +256,7 @@ fun case_22(a: (() -> Unit)) {
 // TESTCASE NUMBER: 23
 fun case_23(a: ((Float) -> Int), b: Float) {
     if (a == null && b == null) {
-        val x = <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int")!>a(<!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Float")!>b<!>)<!>
+        val x = <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int")!>a(<!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Float & kotlin.Float")!>b<!>)<!>
         if (x !== null) {
             <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int")!>x<!>
         }
@@ -276,13 +276,13 @@ fun case_24(a: ((() -> Unit) -> Unit), b: (() -> Unit)) {
 }
 
 // TESTCASE NUMBER: 25
-fun case_25(a: (() -> Unit) -> Unit, b: (() -> Unit) -> Unit = if (a == null) <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Function1<kotlin.Function0<kotlin.Unit>, kotlin.Unit>")!>a<!> else {{}}) {
+fun case_25(a: (() -> Unit) -> Unit, b: (() -> Unit) -> Unit = if (a == null) <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Function1<kotlin.Function0<kotlin.Unit>, kotlin.Unit> & kotlin.Function1<kotlin.Function0<kotlin.Unit>, kotlin.Unit>")!>a<!> else {{}}) {
     <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Function1<kotlin.Function0<kotlin.Unit>, kotlin.Unit>")!>a<!>
     <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Function1<kotlin.Function0<kotlin.Unit>, kotlin.Unit>")!>b<!>
 }
 
 // TESTCASE NUMBER: 26
-fun case_26(a: Int, b: Int = if (a === null) <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int")!>a<!> else 0) {
+fun case_26(a: Int, b: Int = if (a === null) <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int & kotlin.Int")!>a<!> else 0) {
     <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int")!>a<!>
     <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int")!>b<!>
 }

--- a/compiler/tests-spec/testData/diagnostics/notLinked/dfa/pos/40.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/dfa/pos/40.fir.kt
@@ -133,8 +133,8 @@ fun case_13(x: Any?) {
  */
 fun case_14(x: Any?) {
     if (x == null) {
-        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any?")!>x<!>
-        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any?")!>x<!>?.equals(10)
+        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & kotlin.Any?")!>x<!>
+        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & kotlin.Any?")!>x<!>?.equals(10)
         <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any")!>x!!<!>.equals(10)
         <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & kotlin.Any")!>x<!>.equals(10)
     }
@@ -147,8 +147,8 @@ fun case_14(x: Any?) {
  */
 fun case_15(x: Any?) {
     if (x !== null) else {
-        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any?")!>x<!>
-        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any?")!>x<!>?.equals(10)
+        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & kotlin.Any?")!>x<!>
+        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & kotlin.Any?")!>x<!>?.equals(10)
         <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any")!>x!!<!>.equals(10)
         <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & kotlin.Any")!>x<!>.equals(10)
     }

--- a/compiler/tests-spec/testData/diagnostics/notLinked/dfa/pos/68.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/dfa/pos/68.fir.kt
@@ -13,8 +13,8 @@ fun case_1(x: Any?) {
 // TESTCASE NUMBER: 2
 fun case_2(x: Any?) {
     (x as Nothing?)!!
-    <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & kotlin.Nothing?")!>x<!>
-    <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & kotlin.Nothing?")!>x<!><!UNSAFE_CALL!>.<!>inv()
+    <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & kotlin.Any?")!>x<!>
+    <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & kotlin.Any?")!>x<!><!UNSAFE_CALL{LT}!>.<!><!UNRESOLVED_REFERENCE!>inv<!>()
 }
 
 // TESTCASE NUMBER: 3
@@ -36,8 +36,8 @@ fun case_4(x: Any?) {
 // TESTCASE NUMBER: 5
 fun case_5(x: Any?) {
     if (x as Nothing? is Nothing) {
-        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & kotlin.Nothing?")!>x<!>
-        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & kotlin.Nothing?")!>x<!><!UNSAFE_CALL!>.<!>inv()
+        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & kotlin.Any?")!>x<!>
+        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & kotlin.Any?")!>x<!><!UNSAFE_CALL{LT}!>.<!><!UNRESOLVED_REFERENCE!>inv<!>()
     }
 }
 

--- a/compiler/tests-spec/testData/diagnostics/notLinked/dfa/pos/7.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/dfa/pos/7.fir.kt
@@ -39,7 +39,7 @@ fun case_1(x: Any?) {
  */
 fun case_2(x: Nothing?) {
     if (x !== null && x !== null) {
-        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Nothing?")!>x<!>
+        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Nothing? & kotlin.Nothing?")!>x<!>
     }
 }
 
@@ -115,7 +115,7 @@ fun case_6(x: Class?) {
 // TESTCASE NUMBER: 7
 fun case_7() {
     val x: EmptyObject? = null
-    if (x != null || x != null || <!DEBUG_INFO_EXPRESSION_TYPE("EmptyObject?")!>x<!> != null) {
+    if (x != null || x != null || <!DEBUG_INFO_EXPRESSION_TYPE("EmptyObject? & EmptyObject?")!>x<!> != null) {
         <!DEBUG_INFO_EXPRESSION_TYPE("EmptyObject? & EmptyObject")!>x<!>
         <!DEBUG_INFO_EXPRESSION_TYPE("EmptyObject? & EmptyObject")!>x<!>.equals(null)
         <!DEBUG_INFO_EXPRESSION_TYPE("EmptyObject? & EmptyObject")!>x<!>.propT

--- a/compiler/tests-spec/testData/diagnostics/notLinked/dfa/pos/70.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/dfa/pos/70.fir.kt
@@ -25,7 +25,7 @@ fun case_2(): Int? {
     val x: Int? = null
     return when (x != null) {
         false -> {
-            <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int?")!>x<!>
+            <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int? & kotlin.Int?")!>x<!>
         }
         else -> null
     }
@@ -53,7 +53,7 @@ fun case_4(): Int? {
     val x: Int? = null
     return when (x == null) {
         true -> {
-            <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int?")!>x<!>
+            <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Int? & kotlin.Int?")!>x<!>
         }
         else -> null
     }


### PR DESCRIPTION
_Disclaimer_: this is very subtle, so would be my description. Thus, I'm open to long discussion, reviews, other suggestions, etc.

------

The motivation is bb test `nullSmartCast`:
```kt
fun String?.foo() = this ?: "OK"

fun foo(i: Int?): String {
    if (i == null) return i.foo() // Unresolvable
    return "$i"
}

fun box() = foo(null)
```
As expected, candidate `String?.foo()` expects `String?` as an extension receiver type, whereas the actual receiver, `i`, is of `Int?` type. Due to the `null` check, `i`'s type would be technically `Nothing?` after null smartcast, hence the candidate should be applicable.

First, I found that, in the data-flow analysis, while processing `== null`, adding `Nothing?` cast (in an inverted way, which was wrong, btw) has been commented out. With proper type implication after null equality check, the target bb test became green.

------

However, there were a couple regressions which looked like this:
```kt
if (result == NON_NULL_CONST) fail(...)
return result as String
```
At the last return statement, the type of `result` became `Nothing?` that I just added, which caused the runtime casting error. It turned out that, in the data-flow analysis, while processing a general equality, like `left == right`, the logic attempted to add smarter implications: if `left == right` and `right != null`, then `left != null`. Yes, that's right, but it relied on the aforementioned logic of processing `== null` to add the resulting implication.

The problem of reusing `== null` is, since `fir` isn't SSA form, all information inside data-flow analysis is sort of _guided_ by the entering condition. Therefore, the way `== null` adds implications is enumerating all cases: when the condition holds, the involving variable is null, of `Nothing?` type, etc., v.s. otherwise, it is not null, should not be of `Nothing?` type, etc. And there, unwanted condition and effect is added.

So, while processing `left == right`, if we know `right != null`, we can infer `left != null`. But, if we simply reuse `== null` to insert `left != null` against the condition `left == right`, it actually added: `left == right` -> `left != null` _and_ `left != right` -> `left == null` and the latter suddenly made `result` be of `Nothing?` type! Please note that, if `right != null` still holds and if `left != right`, it simply means `left` is something different from `right`, including `null`. It doesn't mean `left` should be `null`. Going back to the original regression example, at the return statement, `result` is simply not equal to non-null constant (including `null`), but we shouldn't conclude `result` is `null`.

To mitigate this, I extended `== null` processing to input condition tester so that users like processing general equality can pick effects under which conditions it wants to add. At this point, all bb tests are good, no more regressions. But then, I found literally tons of regressions in diagnostics tests. :\

------

I didn't investigate every single regression in diagnostic tests (because, really, it was too many), but after seeing couple examples, I noticed what dilemma `fir`'s null smartcast has:
```kt
if (out == null) {
  out?.println()  // type of `out` should remain as-is. With Nothing? cast, unresolvable.
} else {
  out.println()
}
``` 
So, I studied how FE 1.0 works with those cases, and found that
1) for the cast like bb test, `i` after null check is indeed of `Nothing?` type, and that is used to resolve `i.foo()`. BUT, the big difference is, it's not by insertion of type casting. That info is just used during resolution. At the end, there is a separate step that revisits receivers/arguments and adds necessary implicit casts if their type mismatch.
2) for the case like `out?` safe call, since the call candidate's expected type is same as the actual type of the variable, no visible type change is added. Of course no implicit cast at the end, either.

On the other hand, in `fir`, smartcast info accumulated inside data-flow analysis is always _materialized_ into actual type casting (of course, via `FirExpressionWithSmartcast` and then IR type operation with `IMPLICIT_CAST`). Such materialized smartcast affects the following resolution on that specific variable, even though sometimes we need the original type.

Perhaps, the first issue---always materializing smartcast info from data-flow analysis---is out of scope of this PR, and needs bigger discussion. For the second issue---when to smartcast or not, or when to use original type (inside smartcast), one might think of retrieving the original type inside smartcast (if we decide to stick to the current, always-materializing smartcast) under certain conditions, but I can't find good conditions that satisfy all corner cases yet don't look hacky.

Instead, one (maybe equally ad-hoc) solution to resort the issues is to differentiate the use of `Nothing?` from `null` check: for smartcast, don't materialize it. For resolution, if the expected type and argument type are known to be different, and they're both nullable, and the smartcast info from the data-flow analysis indicates the argument is null (via `Nothing?` type), take it! With those, all regressions are gone, and resolutions that must use the fact that the receiver or argument is literally `null` are resolved.