### PR TITLE
FIR: record use of backing field symbol to indeed add a backing field

### DIFF
--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrDeclarationStorage.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrDeclarationStorage.kt
@@ -668,8 +668,10 @@ class Fir2IrDeclarationStorage(
                     val setter = property.setter
                     // TODO: this checks are very preliminary, FIR resolve should determine backing field presence itself
                     if (property.isConst || (property.modality != Modality.ABSTRACT && (irParent !is IrClass || !irParent.isInterface))) {
-                        if (initializer != null || getter is FirDefaultPropertyGetter ||
-                            property.isVar && setter is FirDefaultPropertySetter
+                        if (initializer != null ||
+                            getter is FirDefaultPropertyGetter ||
+                            property.isVar && setter is FirDefaultPropertySetter ||
+                            property.backingFieldSymbol.isReferenced
                         ) {
                             backingField = createBackingField(
                                 property, IrDeclarationOrigin.PROPERTY_BACKING_FIELD, descriptor,

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/FirCallResolver.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/FirCallResolver.kt
@@ -515,6 +515,7 @@ class FirCallResolver(
                 val candidate = candidates.single()
                 val coneSymbol = candidate.symbol
                 if (coneSymbol is FirBackingFieldSymbol) {
+                    coneSymbol.isReferenced = true
                     return buildBackingFieldReference {
                         this.source = source
                         resolvedSymbol = coneSymbol

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/symbols/impl/FirVariableSymbol.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/symbols/impl/FirVariableSymbol.kt
@@ -32,7 +32,10 @@ open class FirPropertySymbol(
     constructor(name: Name) : this(CallableId(name))
 }
 
-class FirBackingFieldSymbol(callableId: CallableId) : FirVariableSymbol<FirProperty>(callableId)
+class FirBackingFieldSymbol(
+    callableId: CallableId,
+    var isReferenced: Boolean = false
+) : FirVariableSymbol<FirProperty>(callableId)
 
 class FirDelegateFieldSymbol<D : FirVariable<D>>(callableId: CallableId) : FirVariableSymbol<D>(callableId) {
     val delegate: FirExpression

--- a/compiler/testData/codegen/box/operatorConventions/augmentedAssignmentInInitializer.kt
+++ b/compiler/testData/codegen/box/operatorConventions/augmentedAssignmentInInitializer.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 abstract class A {
     val b = B("O")
 

--- a/compiler/testData/codegen/box/secondaryConstructors/withoutPrimarySimple.kt
+++ b/compiler/testData/codegen/box/secondaryConstructors/withoutPrimarySimple.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 class A {
     val value: String
         get() = field + "K"


### PR DESCRIPTION
The motivation was `secondaryConstructors.withoutPrimarySimple`:
```
class A {
    val value: String
        get() = field + "K"

    constructor(o: String) {
        value = o
    }
}

fun box() = A("O").value
```
Class `A` doesn't have a primary constructor; property `value` is initialized in the secondary constructor; and in the non-default `get`ter of `value`, its initial value stored at the backing field is accessed as `field`. That is, we need a backing field for a property, if it is referred via `field` in its accessors.

To that end, when we transform `field` reference to a qualified access expression, we can mark that that property is referred via `field`. Then, during conversion, we can add the corresponding backing field.