### PR TITLE
FIR2IR: make the scope of body of do-while loop transparent

### DIFF
--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrVisitor.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrVisitor.kt
@@ -604,10 +604,17 @@ class Fir2IrVisitor(
         val type =
             (statements.lastOrNull() as? FirExpression)?.typeRef?.toIrType() ?: irBuiltIns.unitType
         return convertWithOffsets { startOffset, endOffset ->
-            IrBlockImpl(
-                startOffset, endOffset, type, origin,
-                mapToIrStatements().filterNotNull()
-            )
+            if (origin == IrStatementOrigin.DO_WHILE_LOOP) {
+                IrCompositeImpl(
+                    startOffset, endOffset, type, origin,
+                    mapToIrStatements().filterNotNull()
+                )
+            } else {
+                IrBlockImpl(
+                    startOffset, endOffset, type, origin,
+                    mapToIrStatements().filterNotNull()
+                )
+            }
         }
     }
 
@@ -776,7 +783,7 @@ class Fir2IrVisitor(
             ).apply {
                 loopMap[doWhileLoop] = this
                 label = doWhileLoop.label?.name
-                body = doWhileLoop.block.convertToIrExpressionOrBlock()
+                body = doWhileLoop.block.convertToIrExpressionOrBlock(origin)
                 condition = convertToIrExpression(doWhileLoop.condition)
                 loopMap.remove(doWhileLoop)
             }

--- a/compiler/testData/codegen/box/controlStructures/kt3280.kt
+++ b/compiler/testData/codegen/box/controlStructures/kt3280.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 fun foo() {
     var x = 0
     do {

--- a/compiler/testData/ir/irText/declarations/localVarInDoWhile.fir.txt
+++ b/compiler/testData/ir/irText/declarations/localVarInDoWhile.fir.txt
@@ -2,7 +2,7 @@ FILE fqName:<root> fileName:/localVarInDoWhile.kt
   FUN name:foo visibility:public modality:FINAL <> () returnType:kotlin.Unit
     BLOCK_BODY
       DO_WHILE label=null origin=DO_WHILE_LOOP
-        body: BLOCK type=kotlin.Unit origin=null
+        body: COMPOSITE type=kotlin.Unit origin=DO_WHILE_LOOP
           VAR name:x type:kotlin.Int [val]
             CONST Int type=kotlin.Int value=42
         condition: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ

--- a/compiler/testData/ir/irText/expressions/breakContinueInLoopHeader.fir.txt
+++ b/compiler/testData/ir/irText/expressions/breakContinueInLoopHeader.fir.txt
@@ -115,7 +115,7 @@ FILE fqName:<root> fileName:/breakContinueInLoopHeader.kt
           VAR name:j type:kotlin.Int [var]
             CONST Int type=kotlin.Int value=0
           DO_WHILE label=Inner origin=DO_WHILE_LOOP
-            body: BLOCK type=kotlin.Int origin=null
+            body: COMPOSITE type=kotlin.Int origin=DO_WHILE_LOOP
               VAR IR_TEMPORARY_VARIABLE name:tmp_7 type:kotlin.Int [val]
                 GET_VAR 'var j: kotlin.Int [var] declared in <root>.test5' type=kotlin.Int origin=null
               SET_VAR 'var j: kotlin.Int [var] declared in <root>.test5' type=kotlin.Unit origin=EQ

--- a/compiler/testData/ir/irText/expressions/breakContinueInWhen.fir.txt
+++ b/compiler/testData/ir/irText/expressions/breakContinueInWhen.fir.txt
@@ -108,7 +108,7 @@ FILE fqName:<root> fileName:/breakContinueInWhen.kt
       VAR name:s type:kotlin.String [var]
         CONST String type=kotlin.String value=""
       DO_WHILE label=null origin=DO_WHILE_LOOP
-        body: BLOCK type=kotlin.Unit origin=null
+        body: COMPOSITE type=kotlin.Unit origin=DO_WHILE_LOOP
           VAR IR_TEMPORARY_VARIABLE name:tmp_2 type:kotlin.Int [val]
             GET_VAR 'var k: kotlin.Int [var] declared in <root>.testContinueDoWhile' type=kotlin.Int origin=null
           SET_VAR 'var k: kotlin.Int [var] declared in <root>.testContinueDoWhile' type=kotlin.Unit origin=EQ

--- a/compiler/testData/ir/irText/expressions/kt24804.fir.txt
+++ b/compiler/testData/ir/irText/expressions/kt24804.fir.txt
@@ -10,7 +10,7 @@ FILE fqName:<root> fileName:/kt24804.kt
       VAR name:z type:kotlin.Int [var]
         CONST Int type=kotlin.Int value=10
       DO_WHILE label=l2 origin=DO_WHILE_LOOP
-        body: BLOCK type=kotlin.Unit origin=null
+        body: COMPOSITE type=kotlin.Unit origin=DO_WHILE_LOOP
           SET_VAR 'var z: kotlin.Int [var] declared in <root>.run' type=kotlin.Unit origin=EQ
             CALL 'public final fun plus (other: kotlin.Int): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
               $this: GET_VAR 'var z: kotlin.Int [var] declared in <root>.run' type=kotlin.Int origin=null

--- a/compiler/testData/ir/irText/expressions/whileDoWhile.fir.txt
+++ b/compiler/testData/ir/irText/expressions/whileDoWhile.fir.txt
@@ -31,7 +31,7 @@ FILE fqName:<root> fileName:/whileDoWhile.kt
               $this: GET_VAR 'val tmp_1: kotlin.Int [val] declared in <root>.test' type=kotlin.Int origin=null
           GET_VAR 'val tmp_1: kotlin.Int [val] declared in <root>.test' type=kotlin.Int origin=null
       DO_WHILE label=null origin=DO_WHILE_LOOP
-        body: BLOCK type=kotlin.Unit origin=null
+        body: COMPOSITE type=kotlin.Unit origin=DO_WHILE_LOOP
         condition: CALL 'public final fun less (arg0: kotlin.Int, arg1: kotlin.Int): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=LT
           arg0: GET_VAR 'var x: kotlin.Int [var] declared in <root>.test' type=kotlin.Int origin=null
           arg1: CONST Int type=kotlin.Int value=0
@@ -47,7 +47,7 @@ FILE fqName:<root> fileName:/whileDoWhile.kt
           arg0: GET_VAR 'var x: kotlin.Int [var] declared in <root>.test' type=kotlin.Int origin=null
           arg1: CONST Int type=kotlin.Int value=15
       DO_WHILE label=null origin=DO_WHILE_LOOP
-        body: BLOCK type=kotlin.Int origin=null
+        body: COMPOSITE type=kotlin.Int origin=DO_WHILE_LOOP
           VAR IR_TEMPORARY_VARIABLE name:tmp_3 type:kotlin.Int [val]
             GET_VAR 'var x: kotlin.Int [var] declared in <root>.test' type=kotlin.Int origin=null
           SET_VAR 'var x: kotlin.Int [var] declared in <root>.test' type=kotlin.Unit origin=EQ
@@ -71,6 +71,6 @@ FILE fqName:<root> fileName:/whileDoWhile.kt
                 GET_VAR 'val a: kotlin.Any? [val] declared in <root>.testSmartcastInCondition' type=kotlin.Any? origin=null
               body: BLOCK type=kotlin.Unit origin=WHILE_LOOP
             DO_WHILE label=null origin=DO_WHILE_LOOP
-              body: BLOCK type=kotlin.Unit origin=null
+              body: COMPOSITE type=kotlin.Unit origin=DO_WHILE_LOOP
               condition: TYPE_OP type=kotlin.Boolean origin=IMPLICIT_CAST typeOperand=kotlin.Boolean
                 GET_VAR 'val a: kotlin.Any? [val] declared in <root>.testSmartcastInCondition' type=kotlin.Any? origin=null


### PR DESCRIPTION
by using `IrComposite`, not just `IrBlock`.

Otherwise, tests like `kt3280`, which has a loop condition that refers to a local variable inside the loop body, would fail due to the missing variables in the scope stack (in IR backend).