### PR TITLE
Fix ReadMe for caskroom was removed.

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -44,7 +44,7 @@ You also can use [Gradle properties](https://docs.gradle.org/current/userguide/b
 Note: The JDK 6 for MacOS is not available on Oracle's site. You can install it by
 
 ```bash
-$ brew tap caskroom/versions
+$ brew tap homebrew/cask-versions
 $ brew cask install java6
 ```
 


### PR DESCRIPTION
I encountered an error when I was trying to install JDK6 for MacOS as the ReadMe documentation:

```bash
$ brew tap caskroom/versions
$ brew cask install java6
```

**The error:**

![image](https://user-images.githubusercontent.com/7965577/89848093-410c1e00-dbb8-11ea-9d89-6c2ce0f5ab1c.png)


Follow the prompts and use the `brew tap homebrew/cask-versions` can solve this problem.

