### PR TITLE
Configuration caching - register listener only once per project

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinGradleBuildServices.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinGradleBuildServices.kt
@@ -77,9 +77,9 @@ internal class KotlinGradleBuildServices private constructor(
                 listenerRegistryHolder.listenerRegistry!!.onTaskCompletion(kotlinGradleListenerProvider)
             } else {
                 gradle.addBuildListener(services)
-                instance = services
                 log.kotlinDebug(INIT_MESSAGE)
             }
+            instance = services
 
             services.buildStarted()
             return services


### PR DESCRIPTION
To many listeners cause performance issues in Gradle.