### PR TITLE
Kotlin Gradle plugin - use build service to share incremental compilation info

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/compilerRunner/GradleKotlinCompilerRunner.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/compilerRunner/GradleKotlinCompilerRunner.kt
@@ -141,7 +141,7 @@ internal open class GradleCompilerRunner(protected val taskProvider: GradleCompi
         }
 
         val incrementalCompilationEnvironment = environment.incrementalCompilationEnvironment
-        val modulesInfo = incrementalCompilationEnvironment?.let { incrementalModuleInfoProvider }
+        val modulesInfo = incrementalCompilationEnvironment?.let { incrementalModuleInfoProvider.get().info }
         val workArgs = GradleKotlinCompilerWorkArguments(
             projectFiles = ProjectFilesForCompilation(
                 loggerProvider,

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/incremental/incrementalModuleInfo.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/incremental/incrementalModuleInfo.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.incremental
+
+import org.gradle.api.provider.Property
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+import org.jetbrains.kotlin.incremental.IncrementalModuleInfo
+
+/**
+ * Provider of [IncrementalModuleInfo] that allows concrete implementation to e.g use Gradle build services
+ * or rely on some static stats.
+ */
+interface IncrementalModuleInfoProvider {
+    val info: IncrementalModuleInfo
+}
+
+/** A build service used to provide [IncrementalModuleInfo] instance for all tasks. */
+abstract class IncrementalModuleInfoBuildService : BuildService<IncrementalModuleInfoBuildService.Parameters>,
+    IncrementalModuleInfoProvider {
+    abstract class Parameters : BuildServiceParameters {
+        abstract val info: Property<IncrementalModuleInfo>
+    }
+
+    override val info: IncrementalModuleInfo
+        get() = parameters.info.get()
+
+    companion object {
+        // Use class name + class loader in case there are multiple class loaders in the same build
+        fun getServiceName(): String {
+            val clazz = IncrementalModuleInfoBuildService::class.java
+            return clazz.canonicalName + "_" + clazz.classLoader.hashCode()
+        }
+    }
+}


### PR DESCRIPTION
For large projects, incremental comilation mapping information may be quite
large. With configuration caching enabled, each task gets its own copy of that
state, and for a project with 1400 subprojects, this resulted in 3.6GB of additional
state stored (once task graph is cached).

This change introduces IncrementalModuleInfoProvider which allows build service
to be used if configuration caching is enabled, and it falls back to static
constant otherwise.