### PR TITLE
FIR: introduce & use various comparators to sort members while de/serialization

### DIFF
--- a/compiler/fir/analysis-tests/testData/builtIns/kotlin-collections.txt
+++ b/compiler/fir/analysis-tests/testData/builtIns/kotlin-collections.txt
@@ -136,6 +136,15 @@ public abstract class LongIterator : R|kotlin/collections/Iterator<kotlin/Long>|
 }
 
 public abstract interface Map<K, out V> : R|kotlin/Any| {
+    public abstract interface Entry<out K, out V> : R|kotlin/Any| {
+        public abstract val key: R|K|
+            public get(): R|K|
+
+        public abstract val value: R|V|
+            public get(): R|V|
+
+    }
+
     public abstract fun containsKey(key: R|K|): R|kotlin/Boolean|
 
     public abstract fun containsValue(value: R|V|): R|kotlin/Boolean|
@@ -157,15 +166,6 @@ public abstract interface Map<K, out V> : R|kotlin/Any| {
 
     public abstract val values: R|kotlin/collections/Collection<V>|
         public get(): R|kotlin/collections/Collection<V>|
-
-    public abstract interface Entry<out K, out V> : R|kotlin/Any| {
-        public abstract val key: R|K|
-            public get(): R|K|
-
-        public abstract val value: R|V|
-            public get(): R|V|
-
-    }
 
 }
 
@@ -239,6 +239,11 @@ public abstract interface MutableListIterator<T> : R|kotlin/collections/ListIter
 }
 
 public abstract interface MutableMap<K, V> : R|kotlin/collections/Map<K, V>| {
+    public abstract interface MutableEntry<K, V> : R|kotlin/collections/Map.Entry<K, V>| {
+        public abstract fun setValue(newValue: R|V|): R|V|
+
+    }
+
     public abstract fun clear(): R|kotlin/Unit|
 
     public abstract fun put(key: R|K|, value: R|V|): R|V?|
@@ -257,11 +262,6 @@ public abstract interface MutableMap<K, V> : R|kotlin/collections/Map<K, V>| {
 
     public abstract val values: R|kotlin/collections/MutableCollection<V>|
         public get(): R|kotlin/collections/MutableCollection<V>|
-
-    public abstract interface MutableEntry<K, V> : R|kotlin/collections/Map.Entry<K, V>| {
-        public abstract fun setValue(newValue: R|V|): R|V|
-
-    }
 
 }
 

--- a/compiler/fir/analysis-tests/testData/builtIns/kotlin-ranges.txt
+++ b/compiler/fir/analysis-tests/testData/builtIns/kotlin-ranges.txt
@@ -1,4 +1,11 @@
 public open class CharProgression : R|kotlin/collections/Iterable<kotlin/Char>| {
+    public final companion object Companion : R|kotlin/Any| {
+        public final fun fromClosedRange(rangeStart: R|kotlin/Char|, rangeEnd: R|kotlin/Char|, step: R|kotlin/Int|): R|kotlin/ranges/CharProgression|
+
+        private constructor(): R|kotlin/ranges/CharProgression.Companion|
+
+    }
+
     public open operator fun equals(other: R|kotlin/Any?|): R|kotlin/Boolean|
 
     public open fun hashCode(): R|kotlin/Int|
@@ -19,13 +26,6 @@ public open class CharProgression : R|kotlin/collections/Iterable<kotlin/Char>| 
         public get(): R|kotlin/Int|
 
     internal constructor(start: R|kotlin/Char|, endInclusive: R|kotlin/Char|, step: R|kotlin/Int|): R|kotlin/ranges/CharProgression|
-
-    public final companion object Companion : R|kotlin/Any| {
-        public final fun fromClosedRange(rangeStart: R|kotlin/Char|, rangeEnd: R|kotlin/Char|, step: R|kotlin/Int|): R|kotlin/ranges/CharProgression|
-
-        private constructor(): R|kotlin/ranges/CharProgression.Companion|
-
-    }
 
 }
 
@@ -53,6 +53,14 @@ internal final class CharProgressionIterator : R|kotlin/collections/CharIterator
 }
 
 public final class CharRange : R|kotlin/ranges/CharProgression|, R|kotlin/ranges/ClosedRange<kotlin/Char>| {
+    public final companion object Companion : R|kotlin/Any| {
+        public final val EMPTY: R|kotlin/ranges/CharRange|
+            public get(): R|kotlin/ranges/CharRange|
+
+        private constructor(): R|kotlin/ranges/CharRange.Companion|
+
+    }
+
     public open operator fun contains(value: R|kotlin/Char|): R|kotlin/Boolean|
 
     public open operator fun equals(other: R|kotlin/Any?|): R|kotlin/Boolean|
@@ -71,14 +79,6 @@ public final class CharRange : R|kotlin/ranges/CharProgression|, R|kotlin/ranges
 
     public constructor(start: R|kotlin/Char|, endInclusive: R|kotlin/Char|): R|kotlin/ranges/CharRange|
 
-    public final companion object Companion : R|kotlin/Any| {
-        public final val EMPTY: R|kotlin/ranges/CharRange|
-            public get(): R|kotlin/ranges/CharRange|
-
-        private constructor(): R|kotlin/ranges/CharRange.Companion|
-
-    }
-
 }
 
 public abstract interface ClosedRange<T> : R|kotlin/Any| {
@@ -95,6 +95,13 @@ public abstract interface ClosedRange<T> : R|kotlin/Any| {
 }
 
 public open class IntProgression : R|kotlin/collections/Iterable<kotlin/Int>| {
+    public final companion object Companion : R|kotlin/Any| {
+        public final fun fromClosedRange(rangeStart: R|kotlin/Int|, rangeEnd: R|kotlin/Int|, step: R|kotlin/Int|): R|kotlin/ranges/IntProgression|
+
+        private constructor(): R|kotlin/ranges/IntProgression.Companion|
+
+    }
+
     public open operator fun equals(other: R|kotlin/Any?|): R|kotlin/Boolean|
 
     public open fun hashCode(): R|kotlin/Int|
@@ -115,13 +122,6 @@ public open class IntProgression : R|kotlin/collections/Iterable<kotlin/Int>| {
         public get(): R|kotlin/Int|
 
     internal constructor(start: R|kotlin/Int|, endInclusive: R|kotlin/Int|, step: R|kotlin/Int|): R|kotlin/ranges/IntProgression|
-
-    public final companion object Companion : R|kotlin/Any| {
-        public final fun fromClosedRange(rangeStart: R|kotlin/Int|, rangeEnd: R|kotlin/Int|, step: R|kotlin/Int|): R|kotlin/ranges/IntProgression|
-
-        private constructor(): R|kotlin/ranges/IntProgression.Companion|
-
-    }
 
 }
 
@@ -149,6 +149,14 @@ internal final class IntProgressionIterator : R|kotlin/collections/IntIterator| 
 }
 
 public final class IntRange : R|kotlin/ranges/IntProgression|, R|kotlin/ranges/ClosedRange<kotlin/Int>| {
+    public final companion object Companion : R|kotlin/Any| {
+        public final val EMPTY: R|kotlin/ranges/IntRange|
+            public get(): R|kotlin/ranges/IntRange|
+
+        private constructor(): R|kotlin/ranges/IntRange.Companion|
+
+    }
+
     public open operator fun contains(value: R|kotlin/Int|): R|kotlin/Boolean|
 
     public open operator fun equals(other: R|kotlin/Any?|): R|kotlin/Boolean|
@@ -167,17 +175,16 @@ public final class IntRange : R|kotlin/ranges/IntProgression|, R|kotlin/ranges/C
 
     public constructor(start: R|kotlin/Int|, endInclusive: R|kotlin/Int|): R|kotlin/ranges/IntRange|
 
-    public final companion object Companion : R|kotlin/Any| {
-        public final val EMPTY: R|kotlin/ranges/IntRange|
-            public get(): R|kotlin/ranges/IntRange|
-
-        private constructor(): R|kotlin/ranges/IntRange.Companion|
-
-    }
-
 }
 
 public open class LongProgression : R|kotlin/collections/Iterable<kotlin/Long>| {
+    public final companion object Companion : R|kotlin/Any| {
+        public final fun fromClosedRange(rangeStart: R|kotlin/Long|, rangeEnd: R|kotlin/Long|, step: R|kotlin/Long|): R|kotlin/ranges/LongProgression|
+
+        private constructor(): R|kotlin/ranges/LongProgression.Companion|
+
+    }
+
     public open operator fun equals(other: R|kotlin/Any?|): R|kotlin/Boolean|
 
     public open fun hashCode(): R|kotlin/Int|
@@ -198,13 +205,6 @@ public open class LongProgression : R|kotlin/collections/Iterable<kotlin/Long>| 
         public get(): R|kotlin/Long|
 
     internal constructor(start: R|kotlin/Long|, endInclusive: R|kotlin/Long|, step: R|kotlin/Long|): R|kotlin/ranges/LongProgression|
-
-    public final companion object Companion : R|kotlin/Any| {
-        public final fun fromClosedRange(rangeStart: R|kotlin/Long|, rangeEnd: R|kotlin/Long|, step: R|kotlin/Long|): R|kotlin/ranges/LongProgression|
-
-        private constructor(): R|kotlin/ranges/LongProgression.Companion|
-
-    }
 
 }
 
@@ -232,6 +232,14 @@ internal final class LongProgressionIterator : R|kotlin/collections/LongIterator
 }
 
 public final class LongRange : R|kotlin/ranges/LongProgression|, R|kotlin/ranges/ClosedRange<kotlin/Long>| {
+    public final companion object Companion : R|kotlin/Any| {
+        public final val EMPTY: R|kotlin/ranges/LongRange|
+            public get(): R|kotlin/ranges/LongRange|
+
+        private constructor(): R|kotlin/ranges/LongRange.Companion|
+
+    }
+
     public open operator fun contains(value: R|kotlin/Long|): R|kotlin/Boolean|
 
     public open operator fun equals(other: R|kotlin/Any?|): R|kotlin/Boolean|
@@ -249,14 +257,6 @@ public final class LongRange : R|kotlin/ranges/LongProgression|, R|kotlin/ranges
         public get(): R|kotlin/Long|
 
     public constructor(start: R|kotlin/Long|, endInclusive: R|kotlin/Long|): R|kotlin/ranges/LongRange|
-
-    public final companion object Companion : R|kotlin/Any| {
-        public final val EMPTY: R|kotlin/ranges/LongRange|
-            public get(): R|kotlin/ranges/LongRange|
-
-        private constructor(): R|kotlin/ranges/LongRange.Companion|
-
-    }
 
 }
 

--- a/compiler/fir/analysis-tests/testData/builtIns/kotlin.txt
+++ b/compiler/fir/analysis-tests/testData/builtIns/kotlin.txt
@@ -43,6 +43,8 @@ public open class Any {
 }
 
 public final class Array<T> : R|kotlin/Any|, R|kotlin/Cloneable|, R|java/io/Serializable| {
+    public final override fun clone(): R|kotlin/Array<T>|
+
     public final operator fun get(index: R|kotlin/Int|): R|T|
 
     public final operator fun iterator(): R|kotlin/collections/Iterator<T>|
@@ -54,11 +56,14 @@ public final class Array<T> : R|kotlin/Any|, R|kotlin/Cloneable|, R|java/io/Seri
 
     public constructor<T>(size: R|kotlin/Int|, init: R|(kotlin/Int) -> T|): R|kotlin/Array<T>|
 
-    public final override fun clone(): R|kotlin/Array<T>|
-
 }
 
 public final class Boolean : R|kotlin/Comparable<kotlin/Boolean>|, R|java/io/Serializable| {
+    @R|kotlin/SinceKotlin|(version = String(1.3)) public final companion object Companion : R|kotlin/Any| {
+        private constructor(): R|kotlin/Boolean.Companion|
+
+    }
+
     public final infix fun and(other: R|kotlin/Boolean|): R|kotlin/Boolean|
 
     public open operator fun compareTo(other: R|kotlin/Boolean|): R|kotlin/Int|
@@ -71,14 +76,11 @@ public final class Boolean : R|kotlin/Comparable<kotlin/Boolean>|, R|java/io/Ser
 
     private constructor(): R|kotlin/Boolean|
 
-    @R|kotlin/SinceKotlin|(version = String(1.3)) public final companion object Companion : R|kotlin/Any| {
-        private constructor(): R|kotlin/Boolean.Companion|
-
-    }
-
 }
 
 public final class BooleanArray : R|kotlin/Any|, R|kotlin/Cloneable|, R|java/io/Serializable| {
+    public final override fun clone(): R|kotlin/BooleanArray|
+
     public final operator fun get(index: R|kotlin/Int|): R|kotlin/Boolean|
 
     public final operator fun iterator(): R|kotlin/collections/BooleanIterator|
@@ -92,11 +94,26 @@ public final class BooleanArray : R|kotlin/Any|, R|kotlin/Cloneable|, R|java/io/
 
     public constructor(size: R|kotlin/Int|): R|kotlin/BooleanArray|
 
-    public final override fun clone(): R|kotlin/BooleanArray|
-
 }
 
 public final class Byte : R|kotlin/Number|, R|kotlin/Comparable<kotlin/Byte>|, R|java/io/Serializable| {
+    public final companion object Companion : R|kotlin/Any| {
+        public final const val MAX_VALUE: R|kotlin/Byte| = Byte(127)
+            public get(): R|kotlin/Byte|
+
+        public final const val MIN_VALUE: R|kotlin/Byte| = Byte(-128)
+            public get(): R|kotlin/Byte|
+
+        @PROPERTY:R|kotlin/SinceKotlin|(version = String(1.3)) public final const val SIZE_BITS: R|kotlin/Int| = Int(8)
+            public get(): R|kotlin/Int|
+
+        @PROPERTY:R|kotlin/SinceKotlin|(version = String(1.3)) public final const val SIZE_BYTES: R|kotlin/Int| = Int(1)
+            public get(): R|kotlin/Int|
+
+        private constructor(): R|kotlin/Byte.Companion|
+
+    }
+
     public open operator fun compareTo(other: R|kotlin/Byte|): R|kotlin/Int|
 
     public final operator fun compareTo(other: R|kotlin/Double|): R|kotlin/Int|
@@ -201,26 +218,11 @@ public final class Byte : R|kotlin/Number|, R|kotlin/Comparable<kotlin/Byte>|, R
 
     private constructor(): R|kotlin/Byte|
 
-    public final companion object Companion : R|kotlin/Any| {
-        public final const val MAX_VALUE: R|kotlin/Byte| = Byte(127)
-            public get(): R|kotlin/Byte|
-
-        public final const val MIN_VALUE: R|kotlin/Byte| = Byte(-128)
-            public get(): R|kotlin/Byte|
-
-        @PROPERTY:R|kotlin/SinceKotlin|(version = String(1.3)) public final const val SIZE_BITS: R|kotlin/Int| = Int(8)
-            public get(): R|kotlin/Int|
-
-        @PROPERTY:R|kotlin/SinceKotlin|(version = String(1.3)) public final const val SIZE_BYTES: R|kotlin/Int| = Int(1)
-            public get(): R|kotlin/Int|
-
-        private constructor(): R|kotlin/Byte.Companion|
-
-    }
-
 }
 
 public final class ByteArray : R|kotlin/Any|, R|kotlin/Cloneable|, R|java/io/Serializable| {
+    public final override fun clone(): R|kotlin/ByteArray|
+
     public final operator fun get(index: R|kotlin/Int|): R|kotlin/Byte|
 
     public final operator fun iterator(): R|kotlin/collections/ByteIterator|
@@ -234,41 +236,9 @@ public final class ByteArray : R|kotlin/Any|, R|kotlin/Cloneable|, R|java/io/Ser
 
     public constructor(size: R|kotlin/Int|): R|kotlin/ByteArray|
 
-    public final override fun clone(): R|kotlin/ByteArray|
-
 }
 
 public final class Char : R|kotlin/Comparable<kotlin/Char>|, R|java/io/Serializable| {
-    public open operator fun compareTo(other: R|kotlin/Char|): R|kotlin/Int|
-
-    public final operator fun dec(): R|kotlin/Char|
-
-    public final operator fun inc(): R|kotlin/Char|
-
-    public final operator fun minus(other: R|kotlin/Char|): R|kotlin/Int|
-
-    public final operator fun minus(other: R|kotlin/Int|): R|kotlin/Char|
-
-    public final operator fun plus(other: R|kotlin/Int|): R|kotlin/Char|
-
-    public final operator fun rangeTo(other: R|kotlin/Char|): R|kotlin/ranges/CharRange|
-
-    public final fun toByte(): R|kotlin/Byte|
-
-    public final fun toChar(): R|kotlin/Char|
-
-    public final fun toDouble(): R|kotlin/Double|
-
-    public final fun toFloat(): R|kotlin/Float|
-
-    public final fun toInt(): R|kotlin/Int|
-
-    public final fun toLong(): R|kotlin/Long|
-
-    public final fun toShort(): R|kotlin/Short|
-
-    private constructor(): R|kotlin/Char|
-
     public final companion object Companion : R|kotlin/Any| {
         public final const val MAX_HIGH_SURROGATE: R|kotlin/Char| = Char(56319)
             public get(): R|kotlin/Char|
@@ -304,9 +274,41 @@ public final class Char : R|kotlin/Comparable<kotlin/Char>|, R|java/io/Serializa
 
     }
 
+    public open operator fun compareTo(other: R|kotlin/Char|): R|kotlin/Int|
+
+    public final operator fun dec(): R|kotlin/Char|
+
+    public final operator fun inc(): R|kotlin/Char|
+
+    public final operator fun minus(other: R|kotlin/Char|): R|kotlin/Int|
+
+    public final operator fun minus(other: R|kotlin/Int|): R|kotlin/Char|
+
+    public final operator fun plus(other: R|kotlin/Int|): R|kotlin/Char|
+
+    public final operator fun rangeTo(other: R|kotlin/Char|): R|kotlin/ranges/CharRange|
+
+    public final fun toByte(): R|kotlin/Byte|
+
+    public final fun toChar(): R|kotlin/Char|
+
+    public final fun toDouble(): R|kotlin/Double|
+
+    public final fun toFloat(): R|kotlin/Float|
+
+    public final fun toInt(): R|kotlin/Int|
+
+    public final fun toLong(): R|kotlin/Long|
+
+    public final fun toShort(): R|kotlin/Short|
+
+    private constructor(): R|kotlin/Char|
+
 }
 
 public final class CharArray : R|kotlin/Any|, R|kotlin/Cloneable|, R|java/io/Serializable| {
+    public final override fun clone(): R|kotlin/CharArray|
+
     public final operator fun get(index: R|kotlin/Int|): R|kotlin/Char|
 
     public final operator fun iterator(): R|kotlin/collections/CharIterator|
@@ -319,8 +321,6 @@ public final class CharArray : R|kotlin/Any|, R|kotlin/Cloneable|, R|java/io/Ser
     public constructor(size: R|kotlin/Int|, init: R|(kotlin/Int) -> kotlin/Char|): R|kotlin/CharArray|
 
     public constructor(size: R|kotlin/Int|): R|kotlin/CharArray|
-
-    public final override fun clone(): R|kotlin/CharArray|
 
 }
 
@@ -368,20 +368,46 @@ public abstract interface Comparable<in T> : R|kotlin/Any| {
 }
 
 public final enum class DeprecationLevel : R|kotlin/Enum<kotlin/DeprecationLevel>| {
+    public final static fun valueOf(value: R|kotlin/String|): R|kotlin/DeprecationLevel| {
+    }
+
+    public final static fun values(): R|kotlin/Array<kotlin/DeprecationLevel>| {
+    }
+
     private constructor(): R|kotlin/DeprecationLevel|
 
     public final static enum entry WARNING: R|kotlin/DeprecationLevel|
     public final static enum entry ERROR: R|kotlin/DeprecationLevel|
     public final static enum entry HIDDEN: R|kotlin/DeprecationLevel|
-    public final static fun values(): R|kotlin/Array<kotlin/DeprecationLevel>| {
-    }
-
-    public final static fun valueOf(value: R|kotlin/String|): R|kotlin/DeprecationLevel| {
-    }
-
 }
 
 public final class Double : R|kotlin/Number|, R|kotlin/Comparable<kotlin/Double>|, R|java/io/Serializable| {
+    public final companion object Companion : R|kotlin/Any| {
+        public final const val MAX_VALUE: R|kotlin/Double| = Double(1.7976931348623157E308)
+            public get(): R|kotlin/Double|
+
+        public final const val MIN_VALUE: R|kotlin/Double| = Double(4.9E-324)
+            public get(): R|kotlin/Double|
+
+        public final const val NEGATIVE_INFINITY: R|kotlin/Double| = Double(-Infinity)
+            public get(): R|kotlin/Double|
+
+        public final const val NaN: R|kotlin/Double| = Double(NaN)
+            public get(): R|kotlin/Double|
+
+        public final const val POSITIVE_INFINITY: R|kotlin/Double| = Double(Infinity)
+            public get(): R|kotlin/Double|
+
+        @PROPERTY:R|kotlin/SinceKotlin|(version = String(1.4)) public final const val SIZE_BITS: R|kotlin/Int| = Int(64)
+            public get(): R|kotlin/Int|
+
+        @PROPERTY:R|kotlin/SinceKotlin|(version = String(1.4)) public final const val SIZE_BYTES: R|kotlin/Int| = Int(8)
+            public get(): R|kotlin/Int|
+
+        private constructor(): R|kotlin/Double.Companion|
+
+    }
+
     public final operator fun compareTo(other: R|kotlin/Byte|): R|kotlin/Int|
 
     public open operator fun compareTo(other: R|kotlin/Double|): R|kotlin/Int|
@@ -478,35 +504,11 @@ public final class Double : R|kotlin/Number|, R|kotlin/Comparable<kotlin/Double>
 
     private constructor(): R|kotlin/Double|
 
-    public final companion object Companion : R|kotlin/Any| {
-        public final const val MAX_VALUE: R|kotlin/Double| = Double(1.7976931348623157E308)
-            public get(): R|kotlin/Double|
-
-        public final const val MIN_VALUE: R|kotlin/Double| = Double(4.9E-324)
-            public get(): R|kotlin/Double|
-
-        public final const val NEGATIVE_INFINITY: R|kotlin/Double| = Double(-Infinity)
-            public get(): R|kotlin/Double|
-
-        public final const val NaN: R|kotlin/Double| = Double(NaN)
-            public get(): R|kotlin/Double|
-
-        public final const val POSITIVE_INFINITY: R|kotlin/Double| = Double(Infinity)
-            public get(): R|kotlin/Double|
-
-        @PROPERTY:R|kotlin/SinceKotlin|(version = String(1.4)) public final const val SIZE_BITS: R|kotlin/Int| = Int(64)
-            public get(): R|kotlin/Int|
-
-        @PROPERTY:R|kotlin/SinceKotlin|(version = String(1.4)) public final const val SIZE_BYTES: R|kotlin/Int| = Int(8)
-            public get(): R|kotlin/Int|
-
-        private constructor(): R|kotlin/Double.Companion|
-
-    }
-
 }
 
 public final class DoubleArray : R|kotlin/Any|, R|kotlin/Cloneable|, R|java/io/Serializable| {
+    public final override fun clone(): R|kotlin/DoubleArray|
+
     public final operator fun get(index: R|kotlin/Int|): R|kotlin/Double|
 
     public final operator fun iterator(): R|kotlin/collections/DoubleIterator|
@@ -520,8 +522,6 @@ public final class DoubleArray : R|kotlin/Any|, R|kotlin/Cloneable|, R|java/io/S
 
     public constructor(size: R|kotlin/Int|): R|kotlin/DoubleArray|
 
-    public final override fun clone(): R|kotlin/DoubleArray|
-
 }
 
 @R|kotlin/annotation/Target|() @R|kotlin/annotation/Retention|(value = R|kotlin/annotation/AnnotationRetention.BINARY|()) @R|kotlin/annotation/MustBeDocumented|() @R|kotlin/SinceKotlin|(version = String(1.1)) public final annotation class DslMarker : R|kotlin/Annotation| {
@@ -530,6 +530,11 @@ public final class DoubleArray : R|kotlin/Any|, R|kotlin/Cloneable|, R|java/io/S
 }
 
 public abstract class Enum<E> : R|kotlin/Comparable<E>|, R|java/io/Serializable| {
+    public final companion object Companion : R|kotlin/Any| {
+        private constructor(): R|kotlin/Enum.Companion|
+
+    }
+
     protected final fun clone(): R|kotlin/Any|
 
     public final operator fun compareTo(other: R|E|): R|kotlin/Int|
@@ -548,11 +553,6 @@ public abstract class Enum<E> : R|kotlin/Comparable<E>|, R|java/io/Serializable|
 
     public constructor<E>(name: R|kotlin/String| = STUB, ordinal: R|kotlin/Int| = STUB): R|kotlin/Enum<E>|
 
-    public final companion object Companion : R|kotlin/Any| {
-        private constructor(): R|kotlin/Enum.Companion|
-
-    }
-
 }
 
 @R|kotlin/annotation/Target|() @R|kotlin/annotation/MustBeDocumented|() public final annotation class ExtensionFunctionType : R|kotlin/Annotation| {
@@ -561,6 +561,32 @@ public abstract class Enum<E> : R|kotlin/Comparable<E>|, R|java/io/Serializable|
 }
 
 public final class Float : R|kotlin/Number|, R|kotlin/Comparable<kotlin/Float>|, R|java/io/Serializable| {
+    public final companion object Companion : R|kotlin/Any| {
+        public final const val MAX_VALUE: R|kotlin/Float| = Float(3.4028235E38)
+            public get(): R|kotlin/Float|
+
+        public final const val MIN_VALUE: R|kotlin/Float| = Float(1.4E-45)
+            public get(): R|kotlin/Float|
+
+        public final const val NEGATIVE_INFINITY: R|kotlin/Float| = Float(-Infinity)
+            public get(): R|kotlin/Float|
+
+        public final const val NaN: R|kotlin/Float| = Float(NaN)
+            public get(): R|kotlin/Float|
+
+        public final const val POSITIVE_INFINITY: R|kotlin/Float| = Float(Infinity)
+            public get(): R|kotlin/Float|
+
+        @PROPERTY:R|kotlin/SinceKotlin|(version = String(1.4)) public final const val SIZE_BITS: R|kotlin/Int| = Int(32)
+            public get(): R|kotlin/Int|
+
+        @PROPERTY:R|kotlin/SinceKotlin|(version = String(1.4)) public final const val SIZE_BYTES: R|kotlin/Int| = Int(4)
+            public get(): R|kotlin/Int|
+
+        private constructor(): R|kotlin/Float.Companion|
+
+    }
+
     public final operator fun compareTo(other: R|kotlin/Byte|): R|kotlin/Int|
 
     public final operator fun compareTo(other: R|kotlin/Double|): R|kotlin/Int|
@@ -657,35 +683,11 @@ public final class Float : R|kotlin/Number|, R|kotlin/Comparable<kotlin/Float>|,
 
     private constructor(): R|kotlin/Float|
 
-    public final companion object Companion : R|kotlin/Any| {
-        public final const val MAX_VALUE: R|kotlin/Float| = Float(3.4028235E38)
-            public get(): R|kotlin/Float|
-
-        public final const val MIN_VALUE: R|kotlin/Float| = Float(1.4E-45)
-            public get(): R|kotlin/Float|
-
-        public final const val NEGATIVE_INFINITY: R|kotlin/Float| = Float(-Infinity)
-            public get(): R|kotlin/Float|
-
-        public final const val NaN: R|kotlin/Float| = Float(NaN)
-            public get(): R|kotlin/Float|
-
-        public final const val POSITIVE_INFINITY: R|kotlin/Float| = Float(Infinity)
-            public get(): R|kotlin/Float|
-
-        @PROPERTY:R|kotlin/SinceKotlin|(version = String(1.4)) public final const val SIZE_BITS: R|kotlin/Int| = Int(32)
-            public get(): R|kotlin/Int|
-
-        @PROPERTY:R|kotlin/SinceKotlin|(version = String(1.4)) public final const val SIZE_BYTES: R|kotlin/Int| = Int(4)
-            public get(): R|kotlin/Int|
-
-        private constructor(): R|kotlin/Float.Companion|
-
-    }
-
 }
 
 public final class FloatArray : R|kotlin/Any|, R|kotlin/Cloneable|, R|java/io/Serializable| {
+    public final override fun clone(): R|kotlin/FloatArray|
+
     public final operator fun get(index: R|kotlin/Int|): R|kotlin/Float|
 
     public final operator fun iterator(): R|kotlin/collections/FloatIterator|
@@ -699,14 +701,29 @@ public final class FloatArray : R|kotlin/Any|, R|kotlin/Cloneable|, R|java/io/Se
 
     public constructor(size: R|kotlin/Int|): R|kotlin/FloatArray|
 
-    public final override fun clone(): R|kotlin/FloatArray|
-
 }
 
 public abstract interface Function<out R> : R|kotlin/Any| {
 }
 
 public final class Int : R|kotlin/Number|, R|kotlin/Comparable<kotlin/Int>|, R|java/io/Serializable| {
+    public final companion object Companion : R|kotlin/Any| {
+        public final const val MAX_VALUE: R|kotlin/Int| = Int(2147483647)
+            public get(): R|kotlin/Int|
+
+        public final const val MIN_VALUE: R|kotlin/Int| = Int(-2147483648)
+            public get(): R|kotlin/Int|
+
+        @PROPERTY:R|kotlin/SinceKotlin|(version = String(1.3)) public final const val SIZE_BITS: R|kotlin/Int| = Int(32)
+            public get(): R|kotlin/Int|
+
+        @PROPERTY:R|kotlin/SinceKotlin|(version = String(1.3)) public final const val SIZE_BYTES: R|kotlin/Int| = Int(4)
+            public get(): R|kotlin/Int|
+
+        private constructor(): R|kotlin/Int.Companion|
+
+    }
+
     public final infix fun and(other: R|kotlin/Int|): R|kotlin/Int|
 
     public final operator fun compareTo(other: R|kotlin/Byte|): R|kotlin/Int|
@@ -825,26 +842,11 @@ public final class Int : R|kotlin/Number|, R|kotlin/Comparable<kotlin/Int>|, R|j
 
     private constructor(): R|kotlin/Int|
 
-    public final companion object Companion : R|kotlin/Any| {
-        public final const val MAX_VALUE: R|kotlin/Int| = Int(2147483647)
-            public get(): R|kotlin/Int|
-
-        public final const val MIN_VALUE: R|kotlin/Int| = Int(-2147483648)
-            public get(): R|kotlin/Int|
-
-        @PROPERTY:R|kotlin/SinceKotlin|(version = String(1.3)) public final const val SIZE_BITS: R|kotlin/Int| = Int(32)
-            public get(): R|kotlin/Int|
-
-        @PROPERTY:R|kotlin/SinceKotlin|(version = String(1.3)) public final const val SIZE_BYTES: R|kotlin/Int| = Int(4)
-            public get(): R|kotlin/Int|
-
-        private constructor(): R|kotlin/Int.Companion|
-
-    }
-
 }
 
 public final class IntArray : R|kotlin/Any|, R|kotlin/Cloneable|, R|java/io/Serializable| {
+    public final override fun clone(): R|kotlin/IntArray|
+
     public final operator fun get(index: R|kotlin/Int|): R|kotlin/Int|
 
     public final operator fun iterator(): R|kotlin/collections/IntIterator|
@@ -858,11 +860,26 @@ public final class IntArray : R|kotlin/Any|, R|kotlin/Cloneable|, R|java/io/Seri
 
     public constructor(size: R|kotlin/Int|): R|kotlin/IntArray|
 
-    public final override fun clone(): R|kotlin/IntArray|
-
 }
 
 public final class Long : R|kotlin/Number|, R|kotlin/Comparable<kotlin/Long>|, R|java/io/Serializable| {
+    public final companion object Companion : R|kotlin/Any| {
+        public final const val MAX_VALUE: R|kotlin/Long| = Long(9223372036854775807)
+            public get(): R|kotlin/Long|
+
+        public final const val MIN_VALUE: R|kotlin/Long| = Long(-9223372036854775808)
+            public get(): R|kotlin/Long|
+
+        @PROPERTY:R|kotlin/SinceKotlin|(version = String(1.3)) public final const val SIZE_BITS: R|kotlin/Int| = Int(64)
+            public get(): R|kotlin/Int|
+
+        @PROPERTY:R|kotlin/SinceKotlin|(version = String(1.3)) public final const val SIZE_BYTES: R|kotlin/Int| = Int(8)
+            public get(): R|kotlin/Int|
+
+        private constructor(): R|kotlin/Long.Companion|
+
+    }
+
     public final infix fun and(other: R|kotlin/Long|): R|kotlin/Long|
 
     public final operator fun compareTo(other: R|kotlin/Byte|): R|kotlin/Int|
@@ -981,26 +998,11 @@ public final class Long : R|kotlin/Number|, R|kotlin/Comparable<kotlin/Long>|, R
 
     private constructor(): R|kotlin/Long|
 
-    public final companion object Companion : R|kotlin/Any| {
-        public final const val MAX_VALUE: R|kotlin/Long| = Long(9223372036854775807)
-            public get(): R|kotlin/Long|
-
-        public final const val MIN_VALUE: R|kotlin/Long| = Long(-9223372036854775808)
-            public get(): R|kotlin/Long|
-
-        @PROPERTY:R|kotlin/SinceKotlin|(version = String(1.3)) public final const val SIZE_BITS: R|kotlin/Int| = Int(64)
-            public get(): R|kotlin/Int|
-
-        @PROPERTY:R|kotlin/SinceKotlin|(version = String(1.3)) public final const val SIZE_BYTES: R|kotlin/Int| = Int(8)
-            public get(): R|kotlin/Int|
-
-        private constructor(): R|kotlin/Long.Companion|
-
-    }
-
 }
 
 public final class LongArray : R|kotlin/Any|, R|kotlin/Cloneable|, R|java/io/Serializable| {
+    public final override fun clone(): R|kotlin/LongArray|
+
     public final operator fun get(index: R|kotlin/Int|): R|kotlin/Long|
 
     public final operator fun iterator(): R|kotlin/collections/LongIterator|
@@ -1013,8 +1015,6 @@ public final class LongArray : R|kotlin/Any|, R|kotlin/Cloneable|, R|java/io/Ser
     public constructor(size: R|kotlin/Int|, init: R|(kotlin/Int) -> kotlin/Long|): R|kotlin/LongArray|
 
     public constructor(size: R|kotlin/Int|): R|kotlin/LongArray|
-
-    public final override fun clone(): R|kotlin/LongArray|
 
 }
 
@@ -1067,6 +1067,23 @@ public abstract class Number : R|kotlin/Any|, R|java/io/Serializable| {
 }
 
 public final class Short : R|kotlin/Number|, R|kotlin/Comparable<kotlin/Short>|, R|java/io/Serializable| {
+    public final companion object Companion : R|kotlin/Any| {
+        public final const val MAX_VALUE: R|kotlin/Short| = Short(32767)
+            public get(): R|kotlin/Short|
+
+        public final const val MIN_VALUE: R|kotlin/Short| = Short(-32768)
+            public get(): R|kotlin/Short|
+
+        @PROPERTY:R|kotlin/SinceKotlin|(version = String(1.3)) public final const val SIZE_BITS: R|kotlin/Int| = Int(16)
+            public get(): R|kotlin/Int|
+
+        @PROPERTY:R|kotlin/SinceKotlin|(version = String(1.3)) public final const val SIZE_BYTES: R|kotlin/Int| = Int(2)
+            public get(): R|kotlin/Int|
+
+        private constructor(): R|kotlin/Short.Companion|
+
+    }
+
     public final operator fun compareTo(other: R|kotlin/Byte|): R|kotlin/Int|
 
     public final operator fun compareTo(other: R|kotlin/Double|): R|kotlin/Int|
@@ -1171,26 +1188,11 @@ public final class Short : R|kotlin/Number|, R|kotlin/Comparable<kotlin/Short>|,
 
     private constructor(): R|kotlin/Short|
 
-    public final companion object Companion : R|kotlin/Any| {
-        public final const val MAX_VALUE: R|kotlin/Short| = Short(32767)
-            public get(): R|kotlin/Short|
-
-        public final const val MIN_VALUE: R|kotlin/Short| = Short(-32768)
-            public get(): R|kotlin/Short|
-
-        @PROPERTY:R|kotlin/SinceKotlin|(version = String(1.3)) public final const val SIZE_BITS: R|kotlin/Int| = Int(16)
-            public get(): R|kotlin/Int|
-
-        @PROPERTY:R|kotlin/SinceKotlin|(version = String(1.3)) public final const val SIZE_BYTES: R|kotlin/Int| = Int(2)
-            public get(): R|kotlin/Int|
-
-        private constructor(): R|kotlin/Short.Companion|
-
-    }
-
 }
 
 public final class ShortArray : R|kotlin/Any|, R|kotlin/Cloneable|, R|java/io/Serializable| {
+    public final override fun clone(): R|kotlin/ShortArray|
+
     public final operator fun get(index: R|kotlin/Int|): R|kotlin/Short|
 
     public final operator fun iterator(): R|kotlin/collections/ShortIterator|
@@ -1204,8 +1206,6 @@ public final class ShortArray : R|kotlin/Any|, R|kotlin/Cloneable|, R|java/io/Se
 
     public constructor(size: R|kotlin/Int|): R|kotlin/ShortArray|
 
-    public final override fun clone(): R|kotlin/ShortArray|
-
 }
 
 @R|kotlin/annotation/Target|() @R|kotlin/annotation/Retention|(value = R|kotlin/annotation/AnnotationRetention.BINARY|()) @R|kotlin/annotation/MustBeDocumented|() public final annotation class SinceKotlin : R|kotlin/Annotation| {
@@ -1217,6 +1217,11 @@ public final class ShortArray : R|kotlin/Any|, R|kotlin/Cloneable|, R|java/io/Se
 }
 
 public final class String : R|kotlin/Comparable<kotlin/String>|, R|kotlin/CharSequence|, R|java/io/Serializable| {
+    public final companion object Companion : R|kotlin/Any| {
+        private constructor(): R|kotlin/String.Companion|
+
+    }
+
     public open operator fun compareTo(other: R|kotlin/String|): R|kotlin/Int|
 
     public open operator fun get(index: R|kotlin/Int|): R|kotlin/Char|
@@ -1229,11 +1234,6 @@ public final class String : R|kotlin/Comparable<kotlin/String>|, R|kotlin/CharSe
         public get(): R|kotlin/Int|
 
     public constructor(): R|kotlin/String|
-
-    public final companion object Companion : R|kotlin/Any| {
-        private constructor(): R|kotlin/String.Companion|
-
-    }
 
 }
 

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/AnnotationInAnnotationArguments.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/AnnotationInAnnotationArguments.txt
@@ -4,15 +4,15 @@
 }
 
 public final enum class E : R|kotlin/Enum<test/E>| {
-    private constructor(): R|test/E|
-
-    public final static enum entry ENTRY: R|test/E|
-    public final static fun values(): R|kotlin/Array<test/E>| {
-    }
-
     public final static fun valueOf(value: R|kotlin/String|): R|test/E| {
     }
 
+    public final static fun values(): R|kotlin/Array<test/E>| {
+    }
+
+    private constructor(): R|test/E|
+
+    public final static enum entry ENTRY: R|test/E|
 }
 
 public final annotation class EnumOption : R|kotlin/Annotation| {

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/EnumArgumentWithCustomToString.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/EnumArgumentWithCustomToString.txt
@@ -1,13 +1,13 @@
 public final enum class E : R|kotlin/Enum<test/E>| {
-    private constructor(): R|test/E|
-
-    public final static enum entry CAKE: R|test/E|
-    public final static fun values(): R|kotlin/Array<test/E>| {
-    }
-
     public final static fun valueOf(value: R|kotlin/String|): R|test/E| {
     }
 
+    public final static fun values(): R|kotlin/Array<test/E>| {
+    }
+
+    private constructor(): R|test/E|
+
+    public final static enum entry CAKE: R|test/E|
 }
 
 public final annotation class EnumAnno : R|kotlin/Annotation| {

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/classMembers/ClassObjectPropertyField.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/classMembers/ClassObjectPropertyField.txt
@@ -4,8 +4,6 @@ public final annotation class Anno : R|kotlin/Annotation| {
 }
 
 public final class Class : R|kotlin/Any| {
-    public constructor(): R|test/Class|
-
     public final companion object Companion : R|kotlin/Any| {
         @FIELD:R|test/Anno|() public final var property: R|kotlin/Int|
             public get(): R|kotlin/Int|
@@ -14,5 +12,7 @@ public final class Class : R|kotlin/Any| {
         private constructor(): R|test/Class.Companion|
 
     }
+
+    public constructor(): R|test/Class|
 
 }

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/classMembers/EnumEntry.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/classMembers/EnumEntry.txt
@@ -15,17 +15,17 @@ public final annotation class Bnno : R|kotlin/Annotation| {
 }
 
 public final enum class Eee : R|kotlin/Enum<test/Eee>| {
+    public final static fun valueOf(value: R|kotlin/String|): R|test/Eee| {
+    }
+
+    public final static fun values(): R|kotlin/Array<test/Eee>| {
+    }
+
     private constructor(): R|test/Eee|
 
     public final static enum entry Entry1: R|test/Eee|
     public final static enum entry Entry2: R|test/Eee|
     public final static enum entry Entry3: R|test/Eee|
     public final static enum entry Entry4: R|test/Eee|
-    public final static fun values(): R|kotlin/Array<test/Eee>| {
-    }
-
-    public final static fun valueOf(value: R|kotlin/String|): R|test/Eee| {
-    }
-
 }
 

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/classMembers/HiddenConstructorWithInlineClassParameters.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/classMembers/HiddenConstructorWithInlineClassParameters.txt
@@ -4,15 +4,15 @@ public final annotation class Ann : R|kotlin/Annotation| {
 }
 
 public sealed class Sealed : R|kotlin/Any| {
-    public final val z: R|test/Z|
-        public get(): R|test/Z|
-
-    @R|test/Ann|() private constructor(@R|test/Ann|() z: R|test/Z|): R|test/Sealed|
-
     public final class Derived : R|test/Sealed| {
         @R|test/Ann|() public constructor(z: R|test/Z|): R|test/Sealed.Derived|
 
     }
+
+    public final val z: R|test/Z|
+        public get(): R|test/Z|
+
+    @R|test/Ann|() private constructor(@R|test/Ann|() z: R|test/Z|): R|test/Sealed|
 
 }
 

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/classes/AnnotationInClassObject.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/classes/AnnotationInClassObject.txt
@@ -1,25 +1,25 @@
 public final class A : R|kotlin/Any| {
-    public constructor(): R|test/A|
-
     public final companion object Companion : R|kotlin/Any| {
-        private constructor(): R|test/A.Companion|
-
         public final annotation class Anno1 : R|kotlin/Annotation| {
             public constructor(): R|test/A.Companion.Anno1|
 
         }
 
         public final class B : R|kotlin/Any| {
-            public constructor(): R|test/A.Companion.B|
-
             public final annotation class Anno2 : R|kotlin/Annotation| {
                 public constructor(): R|test/A.Companion.B.Anno2|
 
             }
 
+            public constructor(): R|test/A.Companion.B|
+
         }
 
+        private constructor(): R|test/A.Companion|
+
     }
+
+    public constructor(): R|test/A|
 
 }
 

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/classes/ClassInClassObject.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/classes/ClassInClassObject.txt
@@ -4,16 +4,16 @@ public final annotation class Anno : R|kotlin/Annotation| {
 }
 
 public final class Class : R|kotlin/Any| {
-    public constructor(): R|test/Class|
-
     public final companion object Companion : R|kotlin/Any| {
-        private constructor(): R|test/Class.Companion|
-
         @R|test/Anno|() public final class Nested : R|kotlin/Any| {
             public constructor(): R|test/Class.Companion.Nested|
 
         }
 
+        private constructor(): R|test/Class.Companion|
+
     }
+
+    public constructor(): R|test/Class|
 
 }

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/classes/ClassObject.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/classes/ClassObject.txt
@@ -4,11 +4,11 @@ public final annotation class Anno : R|kotlin/Annotation| {
 }
 
 public final class Class : R|kotlin/Any| {
-    public constructor(): R|test/Class|
-
     @R|test/Anno|() public final companion object Companion : R|kotlin/Any| {
         private constructor(): R|test/Class.Companion|
 
     }
+
+    public constructor(): R|test/Class|
 
 }

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/classes/ClassObjectInStaticNestedClass.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/classes/ClassObjectInStaticNestedClass.txt
@@ -1,9 +1,5 @@
 public final class A : R|kotlin/Any| {
-    public constructor(): R|test/A|
-
     public final class B : R|kotlin/Any| {
-        public constructor(): R|test/A.B|
-
         public final companion object Companion : R|kotlin/Any| {
             public final val TEST: R|kotlin/Int|
                 public get(): R|kotlin/Int|
@@ -12,6 +8,10 @@ public final class A : R|kotlin/Any| {
 
         }
 
+        public constructor(): R|test/A.B|
+
     }
+
+    public constructor(): R|test/A|
 
 }

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/classes/Deprecated.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/classes/Deprecated.txt
@@ -1,6 +1,4 @@
 @R|kotlin/Deprecated|(message = String(Class)) public final class Class : R|kotlin/Any| {
-    public constructor(): R|test/Class|
-
     @R|kotlin/Deprecated|(message = String(companion object)) public final companion object Companion : R|kotlin/Any| {
         private constructor(): R|test/Class.Companion|
 
@@ -15,5 +13,7 @@
         public constructor(): R|test/Class.Nested|
 
     }
+
+    public constructor(): R|test/Class|
 
 }

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/classes/EnumArgument.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/classes/EnumArgument.txt
@@ -7,8 +7,6 @@ public final annotation class Anno : R|kotlin/Annotation| {
 }
 
 @R|test/Anno|(t = R|java/lang/annotation/ElementType.METHOD|()) public final class Class : R|kotlin/Any| {
-    public constructor(): R|test/Class|
-
     @R|test/Anno|(t = R|java/lang/annotation/ElementType.ANNOTATION_TYPE|()) public final companion object Companion : R|kotlin/Any| {
         private constructor(): R|test/Class.Companion|
 
@@ -23,5 +21,7 @@ public final annotation class Anno : R|kotlin/Annotation| {
         public constructor(): R|test/Class.Nested|
 
     }
+
+    public constructor(): R|test/Class|
 
 }

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/classes/NestedAnnotation.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/classes/NestedAnnotation.txt
@@ -1,10 +1,10 @@
 public final class A : R|kotlin/Any| {
-    public constructor(): R|test/A|
-
     public final annotation class Anno : R|kotlin/Annotation| {
         public constructor(): R|test/A.Anno|
 
     }
+
+    public constructor(): R|test/A|
 
 }
 

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/classes/NestedClass.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/classes/NestedClass.txt
@@ -4,8 +4,6 @@ public final annotation class Anno : R|kotlin/Annotation| {
 }
 
 public final class Class : R|kotlin/Any| {
-    public constructor(): R|test/Class|
-
     @R|test/Anno|() public final inner class Inner : R|kotlin/Any| {
         public constructor(): R|test/Class.Inner|
 
@@ -15,5 +13,7 @@ public final class Class : R|kotlin/Any| {
         public constructor(): R|test/Class.Nested|
 
     }
+
+    public constructor(): R|test/Class|
 
 }

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/parameters/EnumConstructor.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/parameters/EnumConstructor.txt
@@ -9,6 +9,12 @@ public final annotation class B : R|kotlin/Annotation| {
 }
 
 public final enum class E : R|kotlin/Enum<test/E>| {
+    public final static fun valueOf(value: R|kotlin/String|): R|test/E| {
+    }
+
+    public final static fun values(): R|kotlin/Array<test/E>| {
+    }
+
     public final val x: R|kotlin/String|
         public get(): R|kotlin/String|
 
@@ -16,12 +22,6 @@ public final enum class E : R|kotlin/Enum<test/E>| {
         public get(): R|kotlin/Int|
 
     private constructor(@R|test/A|() x: R|kotlin/String|, @R|test/B|() y: R|kotlin/Int|): R|test/E|
-
-    public final static fun values(): R|kotlin/Array<test/E>| {
-    }
-
-    public final static fun valueOf(value: R|kotlin/String|): R|test/E| {
-    }
 
 }
 

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/parameters/InnerClassConstructor.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/parameters/InnerClassConstructor.txt
@@ -7,8 +7,6 @@ public final annotation class A : R|kotlin/Annotation| {
 }
 
 public final class Outer : R|kotlin/Any| {
-    public constructor(): R|test/Outer|
-
     public final inner class Inner : R|kotlin/Any| {
         public final val y: R|kotlin/String|
             public get(): R|kotlin/String|
@@ -24,5 +22,7 @@ public final class Outer : R|kotlin/Any| {
         public constructor(@R|test/A|(s = String(nested)) x: R|kotlin/String|): R|test/Outer.Nested|
 
     }
+
+    public constructor(): R|test/Outer|
 
 }

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/propertiesWithoutBackingFields/ClassObject.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/propertiesWithoutBackingFields/ClassObject.txt
@@ -4,8 +4,6 @@ public final annotation class Anno : R|kotlin/Annotation| {
 }
 
 public final class Class : R|kotlin/Any| {
-    public constructor(): R|test/Class|
-
     public final companion object Companion : R|kotlin/Any| {
         @PROPERTY:R|test/Anno|() public final val property: R|kotlin/Int|
             public get(): R|kotlin/Int|
@@ -13,5 +11,7 @@ public final class Class : R|kotlin/Any| {
         private constructor(): R|test/Class.Companion|
 
     }
+
+    public constructor(): R|test/Class|
 
 }

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/propertiesWithoutBackingFields/NestedTrait.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/propertiesWithoutBackingFields/NestedTrait.txt
@@ -4,12 +4,12 @@ public final annotation class Anno : R|kotlin/Annotation| {
 }
 
 public final class Class : R|kotlin/Any| {
-    public constructor(): R|test/Class|
-
     public abstract interface Trait : R|kotlin/Any| {
         public abstract val property: R|kotlin/Int|
             public get(): R|kotlin/Int|
 
     }
+
+    public constructor(): R|test/Class|
 
 }

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/types/ClassLiteralArgument.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/types/ClassLiteralArgument.txt
@@ -25,12 +25,12 @@ public final class Generic<T> : R|kotlin/Any| {
 }
 
 public final class InnerGeneric<A, B> : R|kotlin/Any| {
-    public constructor<A, B>(): R|test/InnerGeneric<A, B>|
-
     public final inner class Inner<in C, D : R|A|, A, B> : R|kotlin/Any| {
         public constructor<in C, D : R|A|>(): R|test/InnerGeneric.Inner<C, D, A, B>|
 
     }
+
+    public constructor<A, B>(): R|test/InnerGeneric<A, B>|
 
 }
 

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/class/ClassInnerClass.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/class/ClassInnerClass.txt
@@ -1,9 +1,9 @@
 public final class Outer : R|kotlin/Any| {
-    public constructor(): R|test/Outer|
-
     public final inner class Inner : R|kotlin/Any| {
         public constructor(): R|test/Outer.Inner|
 
     }
+
+    public constructor(): R|test/Outer|
 
 }

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/class/ClassMemberConflict.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/class/ClassMemberConflict.txt
@@ -1,9 +1,4 @@
 public final class ConstructorTypeParamClassObjectConflict<test> : R|kotlin/Any| {
-    public final val some: R|kotlin/Int|
-        public get(): R|kotlin/Int|
-
-    public constructor<test>(): R|test/ConstructorTypeParamClassObjectConflict<test>|
-
     public final companion object Companion : R|kotlin/Any| {
         public final val test: R|kotlin/Int|
             public get(): R|kotlin/Int|
@@ -12,33 +7,30 @@ public final class ConstructorTypeParamClassObjectConflict<test> : R|kotlin/Any|
 
     }
 
+    public final val some: R|kotlin/Int|
+        public get(): R|kotlin/Int|
+
+    public constructor<test>(): R|test/ConstructorTypeParamClassObjectConflict<test>|
+
 }
 
 public final class ConstructorTypeParamClassObjectTypeConflict<test> : R|kotlin/Any| {
+    public final companion object Companion : R|kotlin/Any| {
+        public abstract interface test : R|kotlin/Any| {
+        }
+
+        private constructor(): R|test/ConstructorTypeParamClassObjectTypeConflict.Companion|
+
+    }
+
     public final val some: R|test?|
         public get(): R|test?|
 
     public constructor<test>(): R|test/ConstructorTypeParamClassObjectTypeConflict<test>|
 
-    public final companion object Companion : R|kotlin/Any| {
-        private constructor(): R|test/ConstructorTypeParamClassObjectTypeConflict.Companion|
-
-        public abstract interface test : R|kotlin/Any| {
-        }
-
-    }
-
 }
 
 public final class TestClassObjectAndClassConflict : R|kotlin/Any| {
-    public final val bla: R|kotlin/String|
-        public get(): R|kotlin/String|
-
-    public final val some: R|kotlin/String|
-        public get(): R|kotlin/String|
-
-    public constructor(): R|test/TestClassObjectAndClassConflict|
-
     public final companion object Companion : R|kotlin/Any| {
         public final val bla: R|kotlin/Int|
             public get(): R|kotlin/Int|
@@ -47,14 +39,17 @@ public final class TestClassObjectAndClassConflict : R|kotlin/Any| {
 
     }
 
-}
+    public final val bla: R|kotlin/String|
+        public get(): R|kotlin/String|
 
-public final class TestConstructorParamClassObjectConflict : R|kotlin/Any| {
     public final val some: R|kotlin/String|
         public get(): R|kotlin/String|
 
-    public constructor(test: R|kotlin/String|): R|test/TestConstructorParamClassObjectConflict|
+    public constructor(): R|test/TestClassObjectAndClassConflict|
 
+}
+
+public final class TestConstructorParamClassObjectConflict : R|kotlin/Any| {
     public final companion object Companion : R|kotlin/Any| {
         public final val test: R|kotlin/Int|
             public get(): R|kotlin/Int|
@@ -63,17 +58,14 @@ public final class TestConstructorParamClassObjectConflict : R|kotlin/Any| {
 
     }
 
-}
-
-public final class TestConstructorValClassObjectConflict : R|kotlin/Any| {
     public final val some: R|kotlin/String|
         public get(): R|kotlin/String|
 
-    public final val test: R|kotlin/String|
-        public get(): R|kotlin/String|
+    public constructor(test: R|kotlin/String|): R|test/TestConstructorParamClassObjectConflict|
 
-    public constructor(test: R|kotlin/String|): R|test/TestConstructorValClassObjectConflict|
+}
 
+public final class TestConstructorValClassObjectConflict : R|kotlin/Any| {
     public final companion object Companion : R|kotlin/Any| {
         public final val test: R|kotlin/Int|
             public get(): R|kotlin/Int|
@@ -82,4 +74,13 @@ public final class TestConstructorValClassObjectConflict : R|kotlin/Any| {
 
     }
 
+    public final val some: R|kotlin/String|
+        public get(): R|kotlin/String|
+
+    public final val test: R|kotlin/String|
+        public get(): R|kotlin/String|
+
+    public constructor(test: R|kotlin/String|): R|test/TestConstructorValClassObjectConflict|
+
 }
+

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/class/EnumWithGenericConstructorParameter.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/class/EnumWithGenericConstructorParameter.txt
@@ -1,11 +1,11 @@
 public final enum class EnumWithGenericConstructorParameter : R|kotlin/Enum<test/EnumWithGenericConstructorParameter>| {
-    private constructor(list: R|kotlin/collections/List<kotlin/String>?|): R|test/EnumWithGenericConstructorParameter|
+    public final static fun valueOf(value: R|kotlin/String|): R|test/EnumWithGenericConstructorParameter| {
+    }
 
     public final static fun values(): R|kotlin/Array<test/EnumWithGenericConstructorParameter>| {
     }
 
-    public final static fun valueOf(value: R|kotlin/String|): R|test/EnumWithGenericConstructorParameter| {
-    }
+    private constructor(list: R|kotlin/collections/List<kotlin/String>?|): R|test/EnumWithGenericConstructorParameter|
 
 }
 

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/class/EnumWithPrimitiveConstructorParameter.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/class/EnumWithPrimitiveConstructorParameter.txt
@@ -1,11 +1,11 @@
 public final enum class EnumWithPrimitiveConstructorParameter : R|kotlin/Enum<test/EnumWithPrimitiveConstructorParameter>| {
-    private constructor(b: R|kotlin/Boolean|): R|test/EnumWithPrimitiveConstructorParameter|
+    public final static fun valueOf(value: R|kotlin/String|): R|test/EnumWithPrimitiveConstructorParameter| {
+    }
 
     public final static fun values(): R|kotlin/Array<test/EnumWithPrimitiveConstructorParameter>| {
     }
 
-    public final static fun valueOf(value: R|kotlin/String|): R|test/EnumWithPrimitiveConstructorParameter| {
-    }
+    private constructor(b: R|kotlin/Boolean|): R|test/EnumWithPrimitiveConstructorParameter|
 
 }
 

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/class/InnerClassExtendInnerClass.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/class/InnerClassExtendInnerClass.txt
@@ -1,6 +1,4 @@
 public final class Outer : R|kotlin/Any| {
-    public constructor(): R|test/Outer|
-
     public open inner class Inner1 : R|kotlin/Any| {
         public constructor(): R|test/Outer.Inner1|
 
@@ -10,5 +8,7 @@ public final class Outer : R|kotlin/Any| {
         public constructor(): R|test/Outer.Inner2|
 
     }
+
+    public constructor(): R|test/Outer|
 
 }

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/class/InnerGenericClass.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/class/InnerGenericClass.txt
@@ -1,9 +1,9 @@
 public final class Outer : R|kotlin/Any| {
-    public constructor(): R|test/Outer|
-
     public final inner class Inner<T> : R|kotlin/Any| {
         public constructor<T>(): R|test/Outer.Inner<T>|
 
     }
+
+    public constructor(): R|test/Outer|
 
 }

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/class/InnerTypes.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/class/InnerTypes.txt
@@ -1,11 +1,5 @@
 public final class Outer<E, F> : R|kotlin/Any| {
-    public final fun bar(x: R|test/Outer.Inner2<kotlin/String, kotlin/Double>|, y: R|test/Outer.Inner2<E, F>|): R|kotlin/Unit|
-
-    public constructor<E, F>(): R|test/Outer<E, F>|
-
     public final inner class Inner<G, H, E, F> : R|kotlin/Any| {
-        public constructor<G, H>(): R|test/Outer.Inner<G, H, E, F>|
-
         public final inner class Inner3<I, G, H, E, F> : R|kotlin/Any| {
             public final fun foo(x: R|test/Outer.Inner<G, kotlin/Int, kotlin/String, F>|, y: R|test/Outer.Inner<E, kotlin/Double, E, F>|, z: R|test/Outer.Inner.Inner3<kotlin/Double, G, kotlin/Int, kotlin/String, F>|, w: R|test/Outer.Inner.Inner3<*, G, H, E, F>|): R|kotlin/Unit|
 
@@ -13,12 +7,18 @@ public final class Outer<E, F> : R|kotlin/Any| {
 
         }
 
+        public constructor<G, H>(): R|test/Outer.Inner<G, H, E, F>|
+
     }
 
     public final inner class Inner2<E, F> : R|kotlin/Any| {
         public constructor(): R|test/Outer.Inner2<E, F>|
 
     }
+
+    public final fun bar(x: R|test/Outer.Inner2<kotlin/String, kotlin/Double>|, y: R|test/Outer.Inner2<E, F>|): R|kotlin/Unit|
+
+    public constructor<E, F>(): R|test/Outer<E, F>|
 
 }
 

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/class/NamedObjectInClass.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/class/NamedObjectInClass.txt
@@ -1,6 +1,4 @@
 public final class Outer : R|kotlin/Any| {
-    public constructor(): R|test/Outer|
-
     public final object Obj : R|kotlin/Any| {
         public final fun f(): R|kotlin/String|
 
@@ -10,5 +8,7 @@ public final class Outer : R|kotlin/Any| {
         private constructor(): R|test/Outer.Obj|
 
     }
+
+    public constructor(): R|test/Outer|
 
 }

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/class/NamedObjectInClassObject.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/class/NamedObjectInClassObject.txt
@@ -1,9 +1,5 @@
 public final class Outer : R|kotlin/Any| {
-    public constructor(): R|test/Outer|
-
     public final companion object Companion : R|kotlin/Any| {
-        private constructor(): R|test/Outer.Companion|
-
         public final object Obj : R|kotlin/Any| {
             public final fun f(): R|kotlin/String|
 
@@ -14,6 +10,10 @@ public final class Outer : R|kotlin/Any| {
 
         }
 
+        private constructor(): R|test/Outer.Companion|
+
     }
+
+    public constructor(): R|test/Outer|
 
 }

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/class/NamedObjectInNamedObject.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/class/NamedObjectInNamedObject.txt
@@ -1,6 +1,4 @@
 public final object Outer : R|kotlin/Any| {
-    private constructor(): R|test/Outer|
-
     public final object Obj : R|kotlin/Any| {
         public final fun f(): R|kotlin/String|
 
@@ -10,5 +8,7 @@ public final object Outer : R|kotlin/Any| {
         private constructor(): R|test/Outer.Obj|
 
     }
+
+    private constructor(): R|test/Outer|
 
 }

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/class/NestedClass.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/class/NestedClass.txt
@@ -1,9 +1,9 @@
 public final class Outer : R|kotlin/Any| {
-    public constructor(): R|test/Outer|
-
     public final class Nested : R|kotlin/Any| {
         public constructor(): R|test/Outer.Nested|
 
     }
+
+    public constructor(): R|test/Outer|
 
 }

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/class/NestedClassExtendNestedClass.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/class/NestedClassExtendNestedClass.txt
@@ -1,6 +1,4 @@
 public final class Outer : R|kotlin/Any| {
-    public constructor(): R|test/Outer|
-
     public open class Nested1 : R|kotlin/Any| {
         public constructor(): R|test/Outer.Nested1|
 
@@ -10,5 +8,7 @@ public final class Outer : R|kotlin/Any| {
         public constructor(): R|test/Outer.Nested2|
 
     }
+
+    public constructor(): R|test/Outer|
 
 }

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/class/NestedGenericClass.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/class/NestedGenericClass.txt
@@ -1,9 +1,9 @@
 public final class Outer : R|kotlin/Any| {
-    public constructor(): R|test/Outer|
-
     public final class Nested<T> : R|kotlin/Any| {
         public constructor<T>(): R|test/Outer.Nested<T>|
 
     }
+
+    public constructor(): R|test/Outer|
 
 }

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/class/SealedClass.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/class/SealedClass.txt
@@ -9,12 +9,12 @@ public final class Inheritor3 : R|test/SealedClass| {
 }
 
 public sealed class SealedClass : R|kotlin/Any| {
-    private constructor(): R|test/SealedClass|
-
     public final class Inheritor1 : R|test/SealedClass| {
         public constructor(): R|test/SealedClass.Inheritor1|
 
     }
+
+    private constructor(): R|test/SealedClass|
 
 }
 

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/classObject/ClassObjectDeclaresVal.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/classObject/ClassObjectDeclaresVal.txt
@@ -1,6 +1,4 @@
 public final class ClassObjectDeclaresProperty : R|kotlin/Any| {
-    public constructor(): R|test/ClassObjectDeclaresProperty|
-
     public final companion object Companion : R|kotlin/Any| {
         public final val i: R|kotlin/Int|
             public get(): R|kotlin/Int|
@@ -8,5 +6,7 @@ public final class ClassObjectDeclaresProperty : R|kotlin/Any| {
         private constructor(): R|test/ClassObjectDeclaresProperty.Companion|
 
     }
+
+    public constructor(): R|test/ClassObjectDeclaresProperty|
 
 }

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/classObject/ClassObjectDeclaresVar.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/classObject/ClassObjectDeclaresVar.txt
@@ -1,6 +1,4 @@
 public final class ClassObjectDeclaresProperty : R|kotlin/Any| {
-    public constructor(): R|test/ClassObjectDeclaresProperty|
-
     public final companion object Companion : R|kotlin/Any| {
         public final var s: R|kotlin/String|
             public get(): R|kotlin/String|
@@ -9,5 +7,7 @@ public final class ClassObjectDeclaresProperty : R|kotlin/Any| {
         private constructor(): R|test/ClassObjectDeclaresProperty.Companion|
 
     }
+
+    public constructor(): R|test/ClassObjectDeclaresProperty|
 
 }

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/classObject/ClassObjectDefaultVisibility.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/classObject/ClassObjectDefaultVisibility.txt
@@ -1,75 +1,75 @@
 public final class Int : R|kotlin/Any| {
-    public constructor(): R|test/Int|
-
     public final companion object Companion : R|kotlin/Any| {
         private constructor(): R|test/Int.Companion|
 
     }
 
+    public constructor(): R|test/Int|
+
 }
 
 public final class Outer : R|kotlin/Any| {
-    public constructor(): R|test/Outer|
-
     public final class Int : R|kotlin/Any| {
-        public constructor(): R|test/Outer.Int|
-
         public final companion object Companion : R|kotlin/Any| {
             private constructor(): R|test/Outer.Int.Companion|
 
         }
 
+        public constructor(): R|test/Outer.Int|
+
     }
 
     private final class Pri : R|kotlin/Any| {
-        public constructor(): R|test/Outer.Pri|
-
         public final companion object Companion : R|kotlin/Any| {
             private constructor(): R|test/Outer.Pri.Companion|
 
         }
 
+        public constructor(): R|test/Outer.Pri|
+
     }
 
     protected final class Pro : R|kotlin/Any| {
-        public constructor(): R|test/Outer.Pro|
-
         public final companion object Companion : R|kotlin/Any| {
             private constructor(): R|test/Outer.Pro.Companion|
 
         }
 
+        public constructor(): R|test/Outer.Pro|
+
     }
 
     public final class Pub : R|kotlin/Any| {
-        public constructor(): R|test/Outer.Pub|
-
         public final companion object Companion : R|kotlin/Any| {
             private constructor(): R|test/Outer.Pub.Companion|
 
         }
 
+        public constructor(): R|test/Outer.Pub|
+
     }
+
+    public constructor(): R|test/Outer|
 
 }
 
 private final class Pri : R|kotlin/Any| {
-    public constructor(): R|test/Pri|
-
     public final companion object Companion : R|kotlin/Any| {
         private constructor(): R|test/Pri.Companion|
 
     }
 
+    public constructor(): R|test/Pri|
+
 }
 
 public final class Pub : R|kotlin/Any| {
-    public constructor(): R|test/Pub|
-
     public final companion object Companion : R|kotlin/Any| {
         private constructor(): R|test/Pub.Companion|
 
     }
+
+    public constructor(): R|test/Pub|
 
 }
 

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/classObject/ClassObjectExplicitVisibility.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/classObject/ClassObjectExplicitVisibility.txt
@@ -1,90 +1,90 @@
 internal final class IntInt : R|kotlin/Any| {
-    public constructor(): R|test/IntInt|
-
     internal final companion object Companion : R|kotlin/Any| {
         private constructor(): R|test/IntInt.Companion|
 
     }
 
+    public constructor(): R|test/IntInt|
+
 }
 
 internal final class IntPri : R|kotlin/Any| {
-    public constructor(): R|test/IntPri|
-
     private final companion object Companion : R|kotlin/Any| {
         private constructor(): R|test/IntPri.Companion|
 
     }
 
+    public constructor(): R|test/IntPri|
+
 }
 
 internal final class IntPub : R|kotlin/Any| {
-    public constructor(): R|test/IntPub|
-
     public final companion object Companion : R|kotlin/Any| {
         private constructor(): R|test/IntPub.Companion|
 
     }
 
+    public constructor(): R|test/IntPub|
+
 }
 
 private final class PriInt : R|kotlin/Any| {
-    public constructor(): R|test/PriInt|
-
     internal final companion object Companion : R|kotlin/Any| {
         private constructor(): R|test/PriInt.Companion|
 
     }
 
+    public constructor(): R|test/PriInt|
+
 }
 
 private final class PriPri : R|kotlin/Any| {
-    public constructor(): R|test/PriPri|
-
     private final companion object Companion : R|kotlin/Any| {
         private constructor(): R|test/PriPri.Companion|
 
     }
 
+    public constructor(): R|test/PriPri|
+
 }
 
 private final class PriPub : R|kotlin/Any| {
-    public constructor(): R|test/PriPub|
-
     public final companion object Companion : R|kotlin/Any| {
         private constructor(): R|test/PriPub.Companion|
 
     }
 
+    public constructor(): R|test/PriPub|
+
 }
 
 public final class PubInt : R|kotlin/Any| {
-    public constructor(): R|test/PubInt|
-
     internal final companion object Companion : R|kotlin/Any| {
         private constructor(): R|test/PubInt.Companion|
 
     }
 
+    public constructor(): R|test/PubInt|
+
 }
 
 public final class PubPri : R|kotlin/Any| {
-    public constructor(): R|test/PubPri|
-
     private final companion object Companion : R|kotlin/Any| {
         private constructor(): R|test/PubPri.Companion|
 
     }
 
+    public constructor(): R|test/PubPri|
+
 }
 
 public final class PubPub : R|kotlin/Any| {
-    public constructor(): R|test/PubPub|
-
     public final companion object Companion : R|kotlin/Any| {
         private constructor(): R|test/PubPub.Companion|
 
     }
+
+    public constructor(): R|test/PubPub|
 
 }
 

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/classObject/ClassObjectExtendsTrait.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/classObject/ClassObjectExtendsTrait.txt
@@ -2,11 +2,11 @@ public abstract interface Bbb : R|kotlin/Any| {
 }
 
 public final class ClassObjectextendsTrait : R|kotlin/Any| {
-    public constructor(): R|test/ClassObjectextendsTrait|
-
     public final companion object Companion : R|test/Bbb| {
         private constructor(): R|test/ClassObjectextendsTrait.Companion|
 
     }
+
+    public constructor(): R|test/ClassObjectextendsTrait|
 
 }

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/classObject/ClassObjectExtendsTraitWithTP.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/classObject/ClassObjectExtendsTraitWithTP.txt
@@ -2,11 +2,11 @@ public abstract interface Bbb<P> : R|kotlin/Any| {
 }
 
 public final class ClassObjectExtendsTraitWithTP : R|kotlin/Any| {
-    public constructor(): R|test/ClassObjectExtendsTraitWithTP|
-
     public final companion object Companion : R|test/Bbb<kotlin/String>| {
         private constructor(): R|test/ClassObjectExtendsTraitWithTP.Companion|
 
     }
+
+    public constructor(): R|test/ClassObjectExtendsTraitWithTP|
 
 }

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/classObject/ClassObjectInClassStaticFields.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/classObject/ClassObjectInClassStaticFields.txt
@@ -1,6 +1,4 @@
 public final class Test : R|kotlin/Any| {
-    public constructor(): R|test/Test|
-
     public final companion object Companion : R|kotlin/Any| {
         public final fun incProp4(): R|kotlin/Unit|
 
@@ -32,5 +30,7 @@ public final class Test : R|kotlin/Any| {
         private constructor(): R|test/Test.Companion|
 
     }
+
+    public constructor(): R|test/Test|
 
 }

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/classObject/ClassObjectPropertyInClass.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/classObject/ClassObjectPropertyInClass.txt
@@ -1,9 +1,4 @@
 public final class A : R|kotlin/Any| {
-    public final val other: R|kotlin/Int|
-        public get(): R|kotlin/Int|
-
-    public constructor(): R|test/A|
-
     public final companion object Companion : R|kotlin/Any| {
         public final val some: R|kotlin/Int|
             public get(): R|kotlin/Int|
@@ -11,5 +6,10 @@ public final class A : R|kotlin/Any| {
         private constructor(): R|test/A.Companion|
 
     }
+
+    public final val other: R|kotlin/Int|
+        public get(): R|kotlin/Int|
+
+    public constructor(): R|test/A|
 
 }

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/classObject/Delegation.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/classObject/Delegation.txt
@@ -1,14 +1,14 @@
 public final class A : R|test/T| {
-    public open fun foo(): R|kotlin/Int|
-
-    public constructor(): R|test/A|
-
     public final companion object Companion : R|test/T| {
         public open fun foo(): R|kotlin/Int|
 
         private constructor(): R|test/A.Companion|
 
     }
+
+    public open fun foo(): R|kotlin/Int|
+
+    public constructor(): R|test/A|
 
 }
 

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/classObject/InnerClassInClassObject.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/classObject/InnerClassInClassObject.txt
@@ -1,6 +1,4 @@
 public final class TestFirst : R|kotlin/Any| {
-    public constructor(): R|test/TestFirst|
-
     public final companion object Companion : R|kotlin/Any| {
         public final fun testing(a: R|test/TestFirst.InnerClass|): R|kotlin/Int|
 
@@ -19,5 +17,7 @@ public final class TestFirst : R|kotlin/Any| {
         public constructor(): R|test/TestFirst.NotInnerClass|
 
     }
+
+    public constructor(): R|test/TestFirst|
 
 }

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/classObject/NamedClassObject.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/classObject/NamedClassObject.txt
@@ -1,11 +1,11 @@
 public final class NamedClassObject : R|kotlin/Any| {
-    public constructor(): R|test/NamedClassObject|
-
     public final companion object Named : R|kotlin/Any| {
         public final fun f(): R|kotlin/Int|
 
         private constructor(): R|test/NamedClassObject.Named|
 
     }
+
+    public constructor(): R|test/NamedClassObject|
 
 }

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/classObject/SimpleClassObject.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/classObject/SimpleClassObject.txt
@@ -1,9 +1,9 @@
 public final class SimpleClassObject : R|kotlin/Any| {
-    public constructor(): R|test/SimpleClassObject|
-
     public final companion object Companion : R|kotlin/Any| {
         private constructor(): R|test/SimpleClassObject.Companion|
 
     }
+
+    public constructor(): R|test/SimpleClassObject|
 
 }

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/constructor/InnerClassConstructorWithDefArgs.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/constructor/InnerClassConstructorWithDefArgs.txt
@@ -1,9 +1,9 @@
 public final class A : R|kotlin/Any| {
-    public constructor(): R|test/A|
-
     public final class TestConstructor : R|kotlin/Any| {
         public constructor(p: R|kotlin/Int| = STUB): R|test/A.TestConstructor|
 
     }
+
+    public constructor(): R|test/A|
 
 }

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/enum/EnumVisibility.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/enum/EnumVisibility.txt
@@ -1,36 +1,36 @@
 internal final enum class In : R|kotlin/Enum<test/In>| {
-    private constructor(): R|test/In|
-
-    public final static enum entry A: R|test/In|
-    public final static fun values(): R|kotlin/Array<test/In>| {
-    }
-
     public final static fun valueOf(value: R|kotlin/String|): R|test/In| {
     }
 
+    public final static fun values(): R|kotlin/Array<test/In>| {
+    }
+
+    private constructor(): R|test/In|
+
+    public final static enum entry A: R|test/In|
 }
 
 private final enum class Pr : R|kotlin/Enum<test/Pr>| {
-    private constructor(): R|test/Pr|
-
-    public final static enum entry A: R|test/Pr|
-    public final static fun values(): R|kotlin/Array<test/Pr>| {
-    }
-
     public final static fun valueOf(value: R|kotlin/String|): R|test/Pr| {
     }
 
+    public final static fun values(): R|kotlin/Array<test/Pr>| {
+    }
+
+    private constructor(): R|test/Pr|
+
+    public final static enum entry A: R|test/Pr|
 }
 
 public final enum class Pu : R|kotlin/Enum<test/Pu>| {
-    private constructor(): R|test/Pu|
-
-    public final static enum entry A: R|test/Pu|
-    public final static fun values(): R|kotlin/Array<test/Pu>| {
-    }
-
     public final static fun valueOf(value: R|kotlin/String|): R|test/Pu| {
     }
 
+    public final static fun values(): R|kotlin/Array<test/Pu>| {
+    }
+
+    private constructor(): R|test/Pu|
+
+    public final static enum entry A: R|test/Pu|
 }
 

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/enum/EnumWithConstuctor.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/enum/EnumWithConstuctor.txt
@@ -1,4 +1,10 @@
 public final enum class En : R|kotlin/Enum<test/En>| {
+    public final static fun valueOf(value: R|kotlin/String|): R|test/En| {
+    }
+
+    public final static fun values(): R|kotlin/Array<test/En>| {
+    }
+
     public final val b: R|kotlin/Boolean|
         public get(): R|kotlin/Boolean|
 
@@ -10,11 +16,5 @@ public final enum class En : R|kotlin/Enum<test/En>| {
     public final static enum entry E1: R|test/En|
     public final static enum entry E2: R|test/En|
     public final static enum entry E3: R|test/En|
-    public final static fun values(): R|kotlin/Array<test/En>| {
-    }
-
-    public final static fun valueOf(value: R|kotlin/String|): R|test/En| {
-    }
-
 }
 

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/enum/EnumWithInnerClasses.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/enum/EnumWithInnerClasses.txt
@@ -1,11 +1,4 @@
 public final enum class Enum : R|kotlin/Enum<test/Enum>| {
-    public final fun f(): R|kotlin/Int|
-
-    public final val c: R|kotlin/Int|
-        public get(): R|kotlin/Int|
-
-    private constructor(): R|test/Enum|
-
     public final inner class Inner : R|kotlin/Any| {
         public constructor(): R|test/Enum.Inner|
 
@@ -19,13 +12,20 @@ public final enum class Enum : R|kotlin/Enum<test/Enum>| {
     public abstract interface Trait : R|kotlin/Any| {
     }
 
-    public final static enum entry ENTRY1: R|test/Enum|
-    public final static enum entry ENTRY2: R|test/Enum|
-    public final static fun values(): R|kotlin/Array<test/Enum>| {
-    }
+    public final fun f(): R|kotlin/Int|
 
     public final static fun valueOf(value: R|kotlin/String|): R|test/Enum| {
     }
 
+    public final static fun values(): R|kotlin/Array<test/Enum>| {
+    }
+
+    public final val c: R|kotlin/Int|
+        public get(): R|kotlin/Int|
+
+    private constructor(): R|test/Enum|
+
+    public final static enum entry ENTRY1: R|test/Enum|
+    public final static enum entry ENTRY2: R|test/Enum|
 }
 

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/enum/InnerEnum.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/enum/InnerEnum.txt
@@ -1,17 +1,17 @@
 public final class A : R|kotlin/Any| {
-    public constructor(): R|test/A|
-
     public final enum class E : R|kotlin/Enum<test/A.E>| {
-        private constructor(): R|test/A.E|
-
-        public final static enum entry ENTRY: R|test/A.E|
-        public final static fun values(): R|kotlin/Array<test/A.E>| {
-        }
-
         public final static fun valueOf(value: R|kotlin/String|): R|test/A.E| {
         }
 
+        public final static fun values(): R|kotlin/Array<test/A.E>| {
+        }
+
+        private constructor(): R|test/A.E|
+
+        public final static enum entry ENTRY: R|test/A.E|
     }
+
+    public constructor(): R|test/A|
 
 }
 

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/enum/InnerEnumExistingClassObject.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/enum/InnerEnumExistingClassObject.txt
@@ -1,22 +1,22 @@
 public final class A : R|kotlin/Any| {
-    public constructor(): R|test/A|
-
     public final companion object Companion : R|kotlin/Any| {
         private constructor(): R|test/A.Companion|
 
     }
 
     public final enum class E : R|kotlin/Enum<test/A.E>| {
-        private constructor(): R|test/A.E|
-
-        public final static enum entry ENTRY: R|test/A.E|
-        public final static fun values(): R|kotlin/Array<test/A.E>| {
-        }
-
         public final static fun valueOf(value: R|kotlin/String|): R|test/A.E| {
         }
 
+        public final static fun values(): R|kotlin/Array<test/A.E>| {
+        }
+
+        private constructor(): R|test/A.E|
+
+        public final static enum entry ENTRY: R|test/A.E|
     }
+
+    public constructor(): R|test/A|
 
 }
 

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/enum/SimpleEnum.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/enum/SimpleEnum.txt
@@ -1,12 +1,12 @@
 public final enum class MyEnum : R|kotlin/Enum<test/MyEnum>| {
-    private constructor(): R|test/MyEnum|
-
-    public final static enum entry ENTRY: R|test/MyEnum|
-    public final static fun values(): R|kotlin/Array<test/MyEnum>| {
-    }
-
     public final static fun valueOf(value: R|kotlin/String|): R|test/MyEnum| {
     }
 
+    public final static fun values(): R|kotlin/Array<test/MyEnum>| {
+    }
+
+    private constructor(): R|test/MyEnum|
+
+    public final static enum entry ENTRY: R|test/MyEnum|
 }
 

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/fromLoadJava/ClassObjectAnnotation.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/fromLoadJava/ClassObjectAnnotation.txt
@@ -1,14 +1,14 @@
 public final class Some : R|kotlin/Any| {
-    public constructor(): R|test/Some|
-
     public final companion object Companion : R|kotlin/Any| {
-        private constructor(): R|test/Some.Companion|
-
         public final annotation class TestAnnotation : R|kotlin/Annotation| {
             public constructor(): R|test/Some.Companion.TestAnnotation|
 
         }
 
+        private constructor(): R|test/Some.Companion|
+
     }
+
+    public constructor(): R|test/Some|
 
 }

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/fromLoadJava/Enum.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/fromLoadJava/Enum.txt
@@ -1,13 +1,13 @@
 public final enum class Test : R|kotlin/Enum<test/Test>| {
+    public final static fun valueOf(value: R|kotlin/String|): R|test/Test| {
+    }
+
+    public final static fun values(): R|kotlin/Array<test/Test>| {
+    }
+
     private constructor(a: R|kotlin/Int|): R|test/Test|
 
     public final static enum entry A: R|test/Test|
     public final static enum entry B: R|test/Test|
-    public final static fun values(): R|kotlin/Array<test/Test>| {
-    }
-
-    public final static fun valueOf(value: R|kotlin/String|): R|test/Test| {
-    }
-
 }
 

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/fromLoadJava/InheritMethodsDifferentReturnTypes.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/fromLoadJava/InheritMethodsDifferentReturnTypes.txt
@@ -1,6 +1,4 @@
 public final class InheritMethodsDifferentReturnTypes : R|kotlin/Any| {
-    public constructor(): R|test/InheritMethodsDifferentReturnTypes|
-
     public abstract interface Sub : R|test/InheritMethodsDifferentReturnTypes.Super1|, R|test/InheritMethodsDifferentReturnTypes.Super2| {
     }
 
@@ -17,5 +15,7 @@ public final class InheritMethodsDifferentReturnTypes : R|kotlin/Any| {
         public abstract fun foo(): R|kotlin/String?|
 
     }
+
+    public constructor(): R|test/InheritMethodsDifferentReturnTypes|
 
 }

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/fromLoadJava/InheritMethodsDifferentReturnTypesGeneric.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/fromLoadJava/InheritMethodsDifferentReturnTypesGeneric.txt
@@ -1,6 +1,4 @@
 public final class InheritMethodsDifferentReturnTypesGeneric : R|kotlin/Any| {
-    public constructor(): R|test/InheritMethodsDifferentReturnTypesGeneric|
-
     public abstract interface Sub : R|test/InheritMethodsDifferentReturnTypesGeneric.Super1<kotlin/String, kotlin/CharSequence>|, R|test/InheritMethodsDifferentReturnTypesGeneric.Super2<kotlin/CharSequence, kotlin/String>| {
     }
 
@@ -17,5 +15,7 @@ public final class InheritMethodsDifferentReturnTypesGeneric : R|kotlin/Any| {
         public abstract fun foo(): R|FF?|
 
     }
+
+    public constructor(): R|test/InheritMethodsDifferentReturnTypesGeneric|
 
 }

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/fromLoadJava/InnerClass.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/fromLoadJava/InnerClass.txt
@@ -1,9 +1,9 @@
 public open class InnerClass : R|kotlin/Any| {
-    public constructor(): R|test/InnerClass|
-
     public open inner class Inner : R|kotlin/Any| {
         public constructor(): R|test/InnerClass.Inner|
 
     }
+
+    public constructor(): R|test/InnerClass|
 
 }

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/fromLoadJava/NestedClass.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/fromLoadJava/NestedClass.txt
@@ -1,9 +1,9 @@
 public open class NestedClass : R|kotlin/Any| {
-    public constructor(): R|test/NestedClass|
-
     public open class Nested : R|kotlin/Any| {
         public constructor(): R|test/NestedClass.Nested|
 
     }
+
+    public constructor(): R|test/NestedClass|
 
 }

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/fromLoadJava/ObjectInClass.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/fromLoadJava/ObjectInClass.txt
@@ -1,11 +1,11 @@
 public final class A : R|kotlin/Any| {
-    public constructor(): R|test/A|
-
     public final object B : R|kotlin/Any| {
         public final fun foo(a: R|kotlin/Int|): R|kotlin/String|
 
         private constructor(): R|test/A.B|
 
     }
+
+    public constructor(): R|test/A|
 
 }

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/fromLoadJava/UnboundWildcard.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/fromLoadJava/UnboundWildcard.txt
@@ -1,9 +1,10 @@
 public final class UnboundWildcard : R|kotlin/Any| {
+    public abstract interface MyClass<T : R|kotlin/CharSequence?|> : R|kotlin/Any| {
+    }
+
     public final fun foo(): R|test/UnboundWildcard.MyClass<*>?|
 
     public constructor(): R|test/UnboundWildcard|
 
-    public abstract interface MyClass<T : R|kotlin/CharSequence?|> : R|kotlin/Any| {
-    }
-
 }
+

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/fromLoadJava/kotlinSignature/StarProjection.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/fromLoadJava/kotlinSignature/StarProjection.txt
@@ -1,9 +1,10 @@
 public final class StarProjection : R|kotlin/Any| {
+    public abstract interface MyClass<T : R|kotlin/CharSequence?|> : R|kotlin/Any| {
+    }
+
     public final fun foo(): R|test/StarProjection.MyClass<*>|
 
     public constructor(): R|test/StarProjection|
 
-    public abstract interface MyClass<T : R|kotlin/CharSequence?|> : R|kotlin/Any| {
-    }
-
 }
+

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/memberOrder/EnumEntries.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/memberOrder/EnumEntries.txt
@@ -1,4 +1,10 @@
 public final enum class E : R|kotlin/Enum<test/E>| {
+    public final static fun valueOf(value: R|kotlin/String|): R|test/E| {
+    }
+
+    public final static fun values(): R|kotlin/Array<test/E>| {
+    }
+
     private constructor(): R|test/E|
 
     public final static enum entry ONE: R|test/E|
@@ -9,11 +15,5 @@ public final enum class E : R|kotlin/Enum<test/E>| {
     public final static enum entry SIX: R|test/E|
     public final static enum entry SEVEN: R|test/E|
     public final static enum entry EIGHT: R|test/E|
-    public final static fun values(): R|kotlin/Array<test/E>| {
-    }
-
-    public final static fun valueOf(value: R|kotlin/String|): R|test/E| {
-    }
-
 }
 

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/memberOrder/ExtensionMembers.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/memberOrder/ExtensionMembers.txt
@@ -1,17 +1,17 @@
 public final class A : R|kotlin/Any| {
     public final fun f1(): R|kotlin/Unit|
 
-    public final fun f2(): R|kotlin/Unit|
-
-    public final fun f3(): R|kotlin/Unit|
-
     public final fun R|kotlin/Int|.f1(): R|kotlin/Unit|
 
     public final fun R|kotlin/String|.f1(): R|kotlin/Unit|
 
+    public final fun f2(): R|kotlin/Unit|
+
     public final fun R|kotlin/Int|.f2(): R|kotlin/Unit|
 
     public final fun R|kotlin/String|.f2(): R|kotlin/Unit|
+
+    public final fun f3(): R|kotlin/Unit|
 
     public final fun R|kotlin/Int|.f3(): R|kotlin/Unit|
 
@@ -20,10 +20,10 @@ public final class A : R|kotlin/Any| {
     public final val c: R|kotlin/Int|
         public get(): R|kotlin/Int|
 
-    public final val d: R|kotlin/Int|
+    public final val R|kotlin/Int|.c: R|kotlin/Int|
         public get(): R|kotlin/Int|
 
-    public final val R|kotlin/Int|.c: R|kotlin/Int|
+    public final val d: R|kotlin/Int|
         public get(): R|kotlin/Int|
 
     public final val R|kotlin/Int|.d: R|kotlin/Int|

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/memberOrder/ExtensionPropertiesNameClash.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/memberOrder/ExtensionPropertiesNameClash.txt
@@ -2,13 +2,13 @@ public final class A : R|kotlin/Any| {
     public final val a: R|kotlin/Int|
         public get(): R|kotlin/Int|
 
-    public final val c: R|kotlin/Int|
-        public get(): R|kotlin/Int|
-
     public final val R|kotlin/Int|.a: R|kotlin/Int|
         public get(): R|kotlin/Int|
 
     public final val R|kotlin/Int|.b: R|kotlin/Int|
+        public get(): R|kotlin/Int|
+
+    public final val c: R|kotlin/Int|
         public get(): R|kotlin/Int|
 
     public final val R|kotlin/Int|.c: R|kotlin/Int|

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/memberOrder/InnerClasses.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/memberOrder/InnerClasses.txt
@@ -1,6 +1,4 @@
 public final class O : R|kotlin/Any| {
-    public constructor(): R|test/O|
-
     public final class A1 : R|kotlin/Any| {
         public constructor(): R|test/O.A1|
 
@@ -26,5 +24,7 @@ public final class O : R|kotlin/Any| {
 
     public abstract interface C2 : R|kotlin/Any| {
     }
+
+    public constructor(): R|test/O|
 
 }

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/nested/DeepInnerGeneric.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/nested/DeepInnerGeneric.txt
@@ -1,12 +1,6 @@
 public final class A<TA> : R|kotlin/Any| {
-    public constructor<TA>(): R|test/A<TA>|
-
     public final inner class B<TB, TA> : R|kotlin/Any| {
-        public constructor<TB>(): R|test/A.B<TB, TA>|
-
         public final inner class C<TC, TB, TA> : R|kotlin/Any| {
-            public constructor<TC>(): R|test/A.B.C<TC, TB, TA>|
-
             public final inner class D<TD, TC, TB, TA> : R|kotlin/Any| {
                 public final fun bar(ta: R|TA|, tb: R|TB|, tc: R|TC|, td: R|TD|): R|test/A.B.C.D<TD, TC, TB, TA>|
 
@@ -16,8 +10,14 @@ public final class A<TA> : R|kotlin/Any| {
 
             }
 
+            public constructor<TC>(): R|test/A.B.C<TC, TB, TA>|
+
         }
 
+        public constructor<TB>(): R|test/A.B<TB, TA>|
+
     }
+
+    public constructor<TA>(): R|test/A<TA>|
 
 }

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/nested/InnerClassReferencesOuterTP.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/nested/InnerClassReferencesOuterTP.txt
@@ -1,10 +1,10 @@
 public final class InnerClassReferencesOuterTP<P> : R|kotlin/Any| {
-    public constructor<P>(): R|test/InnerClassReferencesOuterTP<P>|
-
     public final inner class Inner<Q : R|P|, P> : R|kotlin/Any| {
         public constructor<Q : R|P|>(): R|test/InnerClassReferencesOuterTP.Inner<Q, P>|
 
     }
+
+    public constructor<P>(): R|test/InnerClassReferencesOuterTP<P>|
 
 }
 

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/nested/MembersReferenceOuterTP.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/nested/MembersReferenceOuterTP.txt
@@ -1,6 +1,4 @@
 public final class MembersReferenceOuterTP<P> : R|kotlin/Any| {
-    public constructor<P>(): R|test/MembersReferenceOuterTP<P>|
-
     public final inner class Inner<P> : R|kotlin/Any| {
         public final fun <Q : R|P|> f(): R|kotlin/Unit|
 
@@ -15,6 +13,8 @@ public final class MembersReferenceOuterTP<P> : R|kotlin/Any| {
         public constructor(): R|test/MembersReferenceOuterTP.Inner<P>|
 
     }
+
+    public constructor<P>(): R|test/MembersReferenceOuterTP<P>|
 
 }
 

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/prop/Const.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/prop/Const.txt
@@ -10,8 +10,6 @@ public final object A : R|kotlin/Any| {
 }
 
 public final class B : R|kotlin/Any| {
-    public constructor(): R|test/B|
-
     public final companion object Companion : R|kotlin/Any| {
         public final const val inCompanion: R|kotlin/Int| = Int(3)
             public get(): R|kotlin/Int|
@@ -19,6 +17,8 @@ public final class B : R|kotlin/Any| {
         private constructor(): R|test/B.Companion|
 
     }
+
+    public constructor(): R|test/B|
 
 }
 

--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/prop/NonConstValWithConstantValueAttribute.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/prop/NonConstValWithConstantValueAttribute.txt
@@ -2,11 +2,6 @@ public final val nonConstVal1: R|kotlin/Int|
     public get(): R|kotlin/Int|
 
 public final class C : R|kotlin/Any| {
-    public final val nonConstVal2: R|kotlin/Int|
-        public get(): R|kotlin/Int|
-
-    public constructor(): R|test/C|
-
     public final companion object Companion : R|kotlin/Any| {
         public final val nonConstVal3: R|kotlin/Int|
             public get(): R|kotlin/Int|
@@ -14,6 +9,11 @@ public final class C : R|kotlin/Any| {
         private constructor(): R|test/C.Companion|
 
     }
+
+    public final val nonConstVal2: R|kotlin/Int|
+        public get(): R|kotlin/Int|
+
+    public constructor(): R|test/C|
 
 }
 

--- a/compiler/fir/fir-deserialization/src/org/jetbrains/kotlin/fir/deserialization/ClassDeserialization.kt
+++ b/compiler/fir/fir-deserialization/src/org/jetbrains/kotlin/fir/deserialization/ClassDeserialization.kt
@@ -172,6 +172,17 @@ fun deserializeClassToSymbol(
 
         addCloneForArrayIfNeeded(classId)
         addSerializableIfNeeded(classId)
+
+        declarations.sortWith(object : Comparator<FirDeclaration> {
+            override fun compare(a: FirDeclaration, b: FirDeclaration): Int {
+                // Reorder members based on their type and name only.
+                // See FE 1.0's [DeserializedMemberScope#addMembers].
+                if (a is FirMemberDeclaration && b is FirMemberDeclaration) {
+                    return FirMemberDeclarationComparator.TypeAndNameComparator.compare(a, b)
+                }
+                return 0
+            }
+        })
     }.also {
         if (isSealed) {
             it.sealedInheritors = classProto.sealedSubclassFqNameList.map { nameIndex ->

--- a/compiler/fir/fir-serialization/src/org/jetbrains/kotlin/fir/serialization/FirElementSerializer.kt
+++ b/compiler/fir/fir-serialization/src/org/jetbrains/kotlin/fir/serialization/FirElementSerializer.kt
@@ -129,10 +129,10 @@ class FirElementSerializer private constructor(
             }
         }
 
-        // TODO: member sorting, see KT-20980
         val callableMembers =
             extension.customClassMembersProducer?.getCallableMembers(klass)
                 ?: klass.declarations.filterIsInstance<FirCallableMemberDeclaration<*>>()
+                    .sortedWith(FirCallableMemberDeclarationComparator)
 
         for (declaration in callableMembers) {
             if (declaration !is FirEnumEntry && declaration.isStatic) continue // ??? Miss values() & valueOf()

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/declarations/FirCallableMemberDeclarationComparator.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/declarations/FirCallableMemberDeclarationComparator.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.fir.declarations
+
+import org.jetbrains.kotlin.fir.render
+import org.jetbrains.kotlin.fir.types.FirTypeRefComparator
+
+object FirCallableMemberDeclarationComparator : Comparator<FirCallableMemberDeclaration<*>> {
+    override fun compare(a: FirCallableMemberDeclaration<*>, b: FirCallableMemberDeclaration<*>): Int {
+        val typeAndNameDiff = FirMemberDeclarationComparator.TypeAndNameComparator.compare(a, b)
+        if (typeAndNameDiff != 0) {
+            return typeAndNameDiff
+        }
+
+        // Compare the receiver type if any.
+        if (a.receiverTypeRef != null || b.receiverTypeRef != null) {
+            val aHasReceiverType = if (a.receiverTypeRef != null) 1 else 0
+            val bHasReceiverType = if (b.receiverTypeRef != null) 1 else 0
+            val receiverTypePresenceDiff = aHasReceiverType - bHasReceiverType
+            if (receiverTypePresenceDiff != 0) {
+                return receiverTypePresenceDiff
+            }
+            assert(a.receiverTypeRef != null && b.receiverTypeRef != null)
+        }
+
+        // Compare the return type.
+        val returnTypeDiff = FirTypeRefComparator.compare(a.returnTypeRef, b.returnTypeRef)
+        if (returnTypeDiff != 0) {
+            return returnTypeDiff
+        }
+
+        // Compare the value parameters for functions.
+        if (a is FirFunction<*>) {
+            require(b is FirFunction<*>) {
+                "TypeAndNameComparator is inconsistent: ${a.render()} v.s. ${b.render()}"
+            }
+            val valueParameterSizeDiff = a.valueParameters.size - b.valueParameters.size
+            if (valueParameterSizeDiff != 0) {
+                return valueParameterSizeDiff
+            }
+            for ((aValueParameter, bValueParameter) in a.valueParameters.zip(b.valueParameters)) {
+                val valueParameterDiff = FirValueParameterComparator.compare(aValueParameter, bValueParameter)
+                if (valueParameterDiff != 0) {
+                    return valueParameterDiff
+                }
+            }
+        }
+
+        // Compare the type parameters.
+        val typeParameterSizeDiff = a.typeParameters.size - b.typeParameters.size
+        if (typeParameterSizeDiff != 0) {
+            return typeParameterSizeDiff
+        }
+        for ((aTypeParameter, bTypeParameter) in a.typeParameters.zip(b.typeParameters)) {
+            val typeParameterDiff = FirTypeParameterRefComparator.compare(aTypeParameter, bTypeParameter)
+            if (typeParameterDiff != 0) {
+                return typeParameterDiff
+            }
+        }
+
+        // Lastly, compare the fully qualified package name.
+        return a.symbol.callableId.packageName.asString().compareTo(b.symbol.callableId.packageName.asString())
+    }
+}

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/declarations/FirMemberDeclarationComparator.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/declarations/FirMemberDeclarationComparator.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.fir.declarations
+
+import org.jetbrains.kotlin.fir.render
+import org.jetbrains.kotlin.fir.types.FirTypeRefComparator
+import org.jetbrains.kotlin.name.Name
+
+object FirMemberDeclarationComparator : Comparator<FirMemberDeclaration> {
+    // Comparing different kinds of callable members by assigning distinct priorities to those members.
+    object TypeAndNameComparator : Comparator<FirMemberDeclaration> {
+        private val FirMemberDeclaration.priority : Int
+            get() = when (this) {
+                is FirEnumEntry -> 7
+                is FirConstructor -> 6
+                is FirProperty -> 5
+                is FirField -> 4
+                is FirFunction<*> -> 3
+                is FirClass<*> -> 2
+                is FirTypeAlias -> 1
+                else -> 0
+            }
+
+        private val FirMemberDeclaration.name : Name
+            get() = when (this) {
+                is FirCallableMemberDeclaration<*> ->
+                    this.symbol.callableId.callableName
+                is FirClass<*> ->
+                    this.classId.shortClassName
+                is FirTypeAlias ->
+                    this.name
+                else ->
+                    error("Unsupported name retrieval for ${render()}")
+            }
+
+        override fun compare(a: FirMemberDeclaration, b: FirMemberDeclaration): Int {
+            val priorityDiff = a.priority - b.priority
+            if (priorityDiff != 0) {
+                return priorityDiff
+            }
+            // Never reorder enum entries.
+            if (a is FirEnumEntry) {
+                require(b is FirEnumEntry) {
+                    "priority is inconsistent: ${a.render()} v.s. ${b.render()}"
+                }
+                return 0
+            }
+
+            return a.name.compareTo(b.name)
+        }
+    }
+
+    override fun compare(a: FirMemberDeclaration, b: FirMemberDeclaration): Int {
+        if (a is FirCallableMemberDeclaration<*> && b is FirCallableMemberDeclaration<*>) {
+            return FirCallableMemberDeclarationComparator.compare(a, b)
+        }
+
+        val typeAndNameDiff = TypeAndNameComparator.compare(a, b)
+        if (typeAndNameDiff != 0) {
+            return typeAndNameDiff
+        }
+
+        // Note that names are already compared. Check other details per kind.
+        when (a) {
+            is FirClass<*> -> {
+                require(b is FirClass<*>) {
+                    "priority is inconsistent: ${a.render()} v.s. ${b.render()}"
+                }
+                return a.classId.packageFqName.asString().compareTo(b.classId.packageFqName.asString())
+            }
+            is FirTypeAlias -> {
+                require(b is FirTypeAlias) {
+                    "priority is inconsistent: ${a.render()} v.s. ${b.render()}"
+                }
+                return FirTypeRefComparator.compare(a.expandedTypeRef, b.expandedTypeRef)
+            }
+            else ->
+                error("Unsupported member declaration comparison: ${a.render()} v.s. ${b.render()}")
+        }
+    }
+}

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/declarations/FirTypeParameterRefComparator.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/declarations/FirTypeParameterRefComparator.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.fir.declarations
+
+import org.jetbrains.kotlin.fir.declarations.impl.FirConstructedClassTypeParameterRef
+import org.jetbrains.kotlin.fir.declarations.impl.FirOuterClassTypeParameterRef
+import org.jetbrains.kotlin.fir.render
+import org.jetbrains.kotlin.fir.types.FirTypeRefComparator
+
+object FirTypeParameterRefComparator : Comparator<FirTypeParameterRef> {
+    private val FirTypeParameterRef.priority : Int
+        get() = when (this) {
+            is FirConstructedClassTypeParameterRef -> 3
+            is FirOuterClassTypeParameterRef -> 2
+            is FirTypeParameter -> 1
+            else -> 0
+        }
+
+    override fun compare(a: FirTypeParameterRef, b: FirTypeParameterRef): Int {
+        val priorityDiff = a.priority - b.priority
+        if (priorityDiff != 0) {
+            return priorityDiff
+        }
+        when (a) {
+            is FirConstructedClassTypeParameterRef -> {
+                require(b is FirConstructedClassTypeParameterRef) {
+                    "priority is inconsistent: ${a.render()} v.s. ${b.render()}"
+                }
+                return a.symbol.name.compareTo(b.symbol.name)
+            }
+            is FirOuterClassTypeParameterRef -> {
+                require(b is FirOuterClassTypeParameterRef) {
+                    "priority is inconsistent: ${a.render()} v.s. ${b.render()}"
+                }
+                return a.symbol.name.compareTo(b.symbol.name)
+            }
+            is FirTypeParameter -> {
+                require(b is FirTypeParameter) {
+                    "priority is inconsistent: ${a.render()} v.s. ${b.render()}"
+                }
+                val nameDiff = a.symbol.name.compareTo(b.symbol.name)
+                if (nameDiff != 0) {
+                    return nameDiff
+                }
+                val varianceDiff = a.variance.ordinal - b.variance.ordinal
+                if (varianceDiff != 0) {
+                    return varianceDiff
+                }
+                val boundsSizeDiff = a.bounds.size - b.bounds.size
+                if (boundsSizeDiff != 0) {
+                    return boundsSizeDiff
+                }
+                for ((aBound, bBound) in a.bounds.zip(b.bounds)) {
+                    val boundDiff = FirTypeRefComparator.compare(aBound, bBound)
+                    if (boundDiff != 0) {
+                        return boundDiff
+                    }
+                }
+                return 0
+            }
+            else ->
+                error("Unsupported type parameter reference comparison: ${a.render()} v.s. ${b.render()}")
+        }
+    }
+}

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/declarations/FirValueParameterComparator.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/declarations/FirValueParameterComparator.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.fir.declarations
+
+import org.jetbrains.kotlin.fir.types.FirTypeRefComparator
+
+object FirValueParameterComparator : Comparator<FirValueParameter> {
+    override fun compare(a: FirValueParameter, b: FirValueParameter): Int {
+        val valueParameterNameDiff = a.name.compareTo(b.name)
+        if (valueParameterNameDiff != 0) {
+            return valueParameterNameDiff
+        }
+
+        val valueParameterTypeDiff = FirTypeRefComparator.compare(a.returnTypeRef, b.returnTypeRef)
+        if (valueParameterTypeDiff != 0) {
+            return valueParameterTypeDiff
+        }
+
+        val aHasDefaultValue = if (a.defaultValue != null) 1 else 0
+        val bHasDefaultValue = if (b.defaultValue != null) 1 else 0
+        val defaultValueDiff = aHasDefaultValue - bHasDefaultValue
+        if (defaultValueDiff != 0) {
+            return defaultValueDiff
+        }
+
+        val aIsVararg = if (a.isVararg) 1 else 0
+        val bIsVararg = if (b.isVararg) 1 else 0
+        return aIsVararg - bIsVararg
+    }
+}

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/types/ConeKotlinTypeComparator.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/types/ConeKotlinTypeComparator.kt
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.fir.types
+
+object ConeKotlinTypeComparator : Comparator<ConeKotlinType> {
+    private val ConeKotlinType.priority : Int
+        get() = when (this) {
+            is ConeKotlinErrorType -> 8
+            is ConeLookupTagBasedType -> 7
+            is ConeFlexibleType -> 6
+            is ConeCapturedType -> 5
+            is ConeDefinitelyNotNullType -> 4
+            is ConeIntersectionType -> 3
+            is ConeStubType -> 2
+            is ConeIntegerLiteralType -> 1
+            else -> 0
+        }
+
+    private fun compare(a: ConeTypeProjection, b: ConeTypeProjection): Int {
+        val kindDiff = a.kind.ordinal - b.kind.ordinal
+        if (kindDiff != 0) {
+            return kindDiff
+        }
+        when (a) {
+            is ConeStarProjection -> return 0
+            is ConeKotlinTypeProjectionIn -> {
+                require(b is ConeKotlinTypeProjectionIn) {
+                    "ordinal is inconsistent: $a v.s. $b"
+                }
+                return compare(a.type, b.type)
+            }
+            is ConeKotlinTypeProjectionOut -> {
+                require(b is ConeKotlinTypeProjectionOut) {
+                    "ordinal is inconsistent: $a v.s. $b"
+                }
+                return compare(a.type, b.type)
+            }
+            else -> {
+                assert(a is ConeKotlinType && b is ConeKotlinType) {
+                    "Expect INVARIANT: $a v.s. $b"
+                }
+                return compare(a as ConeKotlinType, b as ConeKotlinType)
+            }
+        }
+    }
+
+    private fun compare(a: Array<out ConeTypeProjection>, b: Array<out ConeTypeProjection>): Int {
+        val sizeDiff = a.size - b.size
+        if (sizeDiff != 0) {
+            return sizeDiff
+        }
+        for ((aTypeProjection, bTypeProjection) in a.zip(b)) {
+            val typeProjectionDiff = compare(aTypeProjection, bTypeProjection)
+            if (typeProjectionDiff != 0) {
+                return typeProjectionDiff
+            }
+        }
+        return 0
+    }
+
+    private fun compare(a: ConeNullability, b: ConeNullability): Int {
+        return a.ordinal - b.ordinal
+    }
+
+    override fun compare(a: ConeKotlinType, b: ConeKotlinType): Int {
+        val priorityDiff = a.priority - b.priority
+        if (priorityDiff != 0) {
+            return priorityDiff
+        }
+
+        when (a) {
+            is ConeKotlinErrorType -> {
+                require(b is ConeKotlinErrorType) {
+                    "priority is inconsistent: ${a.render()} v.s. ${b.render()}"
+                }
+                return a.hashCode() - b.hashCode()
+            }
+            is ConeLookupTagBasedType -> {
+                require(b is ConeLookupTagBasedType) {
+                    "priority is inconsistent: ${a.render()} v.s. ${b.render()}"
+                }
+                val nameDiff = a.lookupTag.name.compareTo(b.lookupTag.name)
+                if (nameDiff != 0) {
+                    return nameDiff
+                }
+                val nullabilityDiff = compare(a.nullability, b.nullability)
+                if (nullabilityDiff != 0) {
+                    return nullabilityDiff
+                }
+                return compare(a.typeArguments, b.typeArguments)
+            }
+            is ConeFlexibleType -> {
+                require(b is ConeFlexibleType) {
+                    "priority is inconsistent: ${a.render()} v.s. ${b.render()}"
+                }
+                val lowerBoundDiff = compare(a.lowerBound, b.lowerBound)
+                if (lowerBoundDiff != 0) {
+                    return lowerBoundDiff
+                }
+                return compare(a.upperBound, b.upperBound)
+            }
+            is ConeCapturedType -> {
+                require(b is ConeCapturedType) {
+                    "priority is inconsistent: ${a.render()} v.s. ${b.render()}"
+                }
+                val aHasLowerType = if (a.lowerType != null) 1 else 0
+                val bHasLowerType = if (b.lowerType != null) 1 else 0
+                val hasLowerTypeDiff = aHasLowerType - bHasLowerType
+                if (hasLowerTypeDiff != 0) {
+                    return hasLowerTypeDiff
+                }
+                if (a.lowerType != null && b.lowerType != null) {
+                    val lowerTypeDiff = compare(a.lowerType!!, b.lowerType!!)
+                    if (lowerTypeDiff != 0) {
+                        return lowerTypeDiff
+                    }
+                }
+                val nullabilityDiff = compare(a.nullability, b.nullability)
+                if (nullabilityDiff != 0) {
+                    return nullabilityDiff
+                }
+                return a.constructor.hashCode() - b.constructor.hashCode()
+            }
+            is ConeDefinitelyNotNullType -> {
+                require(b is ConeDefinitelyNotNullType) {
+                    "priority is inconsistent: ${a.render()} v.s. ${b.render()}"
+                }
+                return compare(a.original, b.original)
+            }
+            is ConeIntersectionType -> {
+                require(b is ConeIntersectionType) {
+                    "priority is inconsistent: ${a.render()} v.s. ${b.render()}"
+                }
+                val sizeDiff = a.intersectedTypes.size - b.intersectedTypes.size
+                if (sizeDiff != 0) {
+                    return 0
+                }
+                // Can't compare individual types from each side, since their orders are not guaranteed.
+                return a.hashCode() - b.hashCode()
+            }
+            is ConeStubType -> {
+                require(b is ConeStubType) {
+                    "priority is inconsistent: ${a.render()} v.s. ${b.render()}"
+                }
+                val nameDiff = a.variable.typeConstructor.name.compareTo(b.variable.typeConstructor.name)
+                if (nameDiff != 0) {
+                    return nameDiff
+                }
+                return compare(a.nullability, b.nullability)
+            }
+            is ConeIntegerLiteralType -> {
+                require(b is ConeIntegerLiteralType) {
+                    "priority is inconsistent: ${a.render()} v.s. ${b.render()}"
+                }
+                val valueDiff = a.value - b.value
+                if (valueDiff != 0L) {
+                    return valueDiff.toInt()
+                }
+                val nullabilityDiff = compare(a.nullability, b.nullability)
+                if (nullabilityDiff != 0) {
+                    return nullabilityDiff
+                }
+                // Can't compare individual types from each side, since their orders are not guaranteed.
+                return a.hashCode() - b.hashCode()
+            }
+            else ->
+                error("Unsupported type comparison: ${a.render()} v.s. ${b.render()}")
+        }
+    }
+}

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/types/FirTypeProjectionComparator.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/types/FirTypeProjectionComparator.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.fir.types
+
+import org.jetbrains.kotlin.fir.render
+
+object FirTypeProjectionComparator : Comparator<FirTypeProjection> {
+    private val FirTypeProjection.priority : Int
+        get() = when (this) {
+            is FirTypeProjectionWithVariance -> 2
+            is FirStarProjection -> 1
+            else -> 0
+        }
+
+    override fun compare(a: FirTypeProjection, b: FirTypeProjection): Int {
+        val priorityDiff = a.priority - b.priority
+        if (priorityDiff != 0) {
+            return priorityDiff
+        }
+
+        when (a) {
+            is FirTypeProjectionWithVariance -> {
+                require(b is FirTypeProjectionWithVariance) {
+                    "priority is inconsistent: ${a.render()} v.s. ${b.render()}"
+                }
+                val typeRefDiff = FirTypeRefComparator.compare(a.typeRef, b.typeRef)
+                if (typeRefDiff != 0) {
+                    return typeRefDiff
+                }
+                return a.variance.ordinal - b.variance.ordinal
+            }
+            is FirStarProjection -> {
+                return 0
+            }
+            else ->
+                error("Unsupported type projection comparison: ${a.render()} v.s. ${b.render()}")
+        }
+    }
+}

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/types/FirTypeRefComparator.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/types/FirTypeRefComparator.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.fir.types
+
+import org.jetbrains.kotlin.fir.render
+import org.jetbrains.kotlin.fir.types.impl.FirImplicitBuiltinTypeRef
+
+object FirTypeRefComparator : Comparator<FirTypeRef> {
+    private val FirTypeRef.priority : Int
+        get() = when (this) {
+            is FirUserTypeRef -> 3
+            is FirImplicitBuiltinTypeRef -> 2
+            is FirResolvedTypeRef -> 1
+            else -> 0
+        }
+
+    override fun compare(a: FirTypeRef, b: FirTypeRef): Int {
+        val priorityDiff = a.priority - b.priority
+        if (priorityDiff != 0) {
+            return priorityDiff
+        }
+
+        when (a) {
+            is FirUserTypeRef -> {
+                require(b is FirUserTypeRef) {
+                    "priority is inconsistent: ${a.render()} v.s. ${b.render()}"
+                }
+                val qualifierSizeDiff = a.qualifier.size - b.qualifier.size
+                if (qualifierSizeDiff != 0) {
+                    return qualifierSizeDiff
+                }
+                for ((aQualifier, bQualifier) in a.qualifier.zip(b.qualifier)) {
+                    val qualifierNameDiff = aQualifier.name.compareTo(bQualifier.name)
+                    if (qualifierNameDiff != 0) {
+                        return qualifierNameDiff
+                    }
+                    val typeArgumentSizeDiff =
+                        aQualifier.typeArgumentList.typeArguments.size - bQualifier.typeArgumentList.typeArguments.size
+                    if (typeArgumentSizeDiff != 0) {
+                        return typeArgumentSizeDiff
+                    }
+                    val typeArguments = aQualifier.typeArgumentList.typeArguments.zip(bQualifier.typeArgumentList.typeArguments)
+                    for ((aTypeArgument, bTypeArgument) in typeArguments) {
+                        val typeArgumentDiff = FirTypeProjectionComparator.compare(aTypeArgument, bTypeArgument)
+                        if (typeArgumentDiff != 0) {
+                            return typeArgumentDiff
+                        }
+                    }
+                }
+                return 0
+            }
+            is FirImplicitBuiltinTypeRef -> {
+                require(b is FirImplicitBuiltinTypeRef) {
+                    "priority is inconsistent: ${a.render()} v.s. ${b.render()}"
+                }
+                return a.id.shortClassName.compareTo(b.id.shortClassName)
+            }
+            is FirResolvedTypeRef -> {
+                require(b is FirResolvedTypeRef) {
+                    "priority is inconsistent: ${a.render()} v.s. ${b.render()}"
+                }
+                return ConeKotlinTypeComparator.compare(a.type, b.type)
+            }
+            else ->
+                error("Unsupported type reference comparison: ${a.render()} v.s. ${b.render()}")
+        }
+    }
+}


### PR DESCRIPTION
As per https://youtrack.jetbrains.com/issue/KT-20980, it's not easy to remove member sorting in deserialization, which also implies that we need to do member sorting in serialization as a counterpart. To sort members, FE 1.0 uses [MemberComparator](https://github.com/JetBrains/kotlin/blob/master/core/descriptors/src/org/jetbrains/kotlin/resolve/MemberComparator.java) that is based on descriptor rendering. `fir` also has its own element rendering (`FirElement.render(...)`), but it is obvious that such rendering will visit unnecessary parts too. Thus, in this PR, an old-fashioned, tedious, yet less exhaustive comparators are introduced to sort member declarations in `fir`.

As a result, test data that list deserialized members are sorted. In particular,
1) they are "clustered", based on element kind. The notion of _priority_ and actual numbers conform to what FE 1.0 use; and
2) inside the cluster, they are "sorted" in an organized way, starting from name, return type, value parameters, etc.

In particular, you can see 1) less important (?) members are placed later, like constructor, compared to properties and functions that need more frequent searching; and 2) even in properties and functions, now extension ones with the same name are clustered.