### PR TITLE
JVM IR: Fix special bridge generation with external Kotlin dependencies

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/MethodSignatureMapper.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/MethodSignatureMapper.kt
@@ -201,7 +201,7 @@ class MethodSignatureMapper(private val context: JvmBackendContext) {
         mapSignature(function, false)
 
     private fun mapSignature(function: IrFunction, skipGenericSignature: Boolean, skipSpecial: Boolean = false): JvmMethodGenericSignature {
-        if (function is IrLazyFunctionBase && function.initialSignatureFunction != null) {
+        if (function is IrLazyFunctionBase && !function.isFakeOverride && function.initialSignatureFunction != null) {
             // Overrides of special builtin in Kotlin classes always have special signature
             if ((function as? IrSimpleFunction)?.getDifferentNameForJvmBuiltinFunction() == null ||
                 (function.parent as? IrClass)?.origin == IrDeclarationOrigin.IR_EXTERNAL_JAVA_DECLARATION_STUB

--- a/compiler/testData/compileKotlinAgainstKotlin/specialBridgesInDependencies.kt
+++ b/compiler/testData/compileKotlinAgainstKotlin/specialBridgesInDependencies.kt
@@ -1,0 +1,18 @@
+// WITH_RUNTIME
+// FILE: A.kt
+
+package a
+
+open class A : ArrayList<String>()
+
+// FILE: B.kt
+
+import a.A
+
+class B : A()
+
+fun box(): String {
+    val b = B()
+    b += "OK"
+    return b.single()
+}

--- a/compiler/tests/org/jetbrains/kotlin/codegen/CompileKotlinAgainstKotlinTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/CompileKotlinAgainstKotlinTestGenerated.java
@@ -353,6 +353,11 @@ public class CompileKotlinAgainstKotlinTestGenerated extends AbstractCompileKotl
         runTest("compiler/testData/compileKotlinAgainstKotlin/simpleValAnonymousObject.kt");
     }
 
+    @TestMetadata("specialBridgesInDependencies.kt")
+    public void testSpecialBridgesInDependencies() throws Exception {
+        runTest("compiler/testData/compileKotlinAgainstKotlin/specialBridgesInDependencies.kt");
+    }
+
     @TestMetadata("starImportEnum.kt")
     public void testStarImportEnum() throws Exception {
         runTest("compiler/testData/compileKotlinAgainstKotlin/starImportEnum.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrCompileKotlinAgainstKotlinTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrCompileKotlinAgainstKotlinTestGenerated.java
@@ -348,6 +348,11 @@ public class IrCompileKotlinAgainstKotlinTestGenerated extends AbstractIrCompile
         runTest("compiler/testData/compileKotlinAgainstKotlin/simpleValAnonymousObject.kt");
     }
 
+    @TestMetadata("specialBridgesInDependencies.kt")
+    public void testSpecialBridgesInDependencies() throws Exception {
+        runTest("compiler/testData/compileKotlinAgainstKotlin/specialBridgesInDependencies.kt");
+    }
+
     @TestMetadata("starImportEnum.kt")
     public void testStarImportEnum() throws Exception {
         runTest("compiler/testData/compileKotlinAgainstKotlin/starImportEnum.kt");


### PR DESCRIPTION
In the descriptor hierarchy we replace special bridge methods with their Kotlin equivalents, which leads to some differences between external and local Kotlin declarations. This carries over to the IR declarations, where we use `initialSignatureFunction` to map a declaration back to its original (non-substituted) declaration. For fake overrides, this has the unintended effect of mapping to the original non-substituted version in a superclass, which causes the method signature mapper to return wrong results for fake overrides (which are only used in bridge generation).

Ideally, we should avoid `initialSignatureFunction` altogether and this is what I tried first. This currently fails because there are too many places in the IR backend which still use descriptors. When the IR structures deviate from what is expected for descriptors we then run into assertion failures when applying descriptor utilities on wrapped descriptors.