### PR TITLE
KT-15262: Allow generate toString() to include properties with non-default getters

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/actions/generate/KotlinGenerateEqualsWizard.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/actions/generate/KotlinGenerateEqualsWizard.kt
@@ -25,7 +25,9 @@ import com.intellij.openapi.ui.VerticalFlowLayout
 import com.intellij.refactoring.classMembers.AbstractMemberInfoModel
 import com.intellij.ui.NonFocusableCheckBox
 import com.intellij.util.containers.HashMap
+import org.jetbrains.kotlin.descriptors.PropertyDescriptor
 import org.jetbrains.kotlin.idea.KotlinBundle
+import org.jetbrains.kotlin.idea.caches.resolve.unsafeResolveToDescriptor
 import org.jetbrains.kotlin.idea.core.isInheritable
 import org.jetbrains.kotlin.idea.refactoring.memberInfo.KotlinMemberInfo
 import org.jetbrains.kotlin.idea.refactoring.memberInfo.KotlinMemberSelectionPanel
@@ -73,7 +75,12 @@ class KotlinGenerateEqualsWizard(
             } else null
         }
 
-        private fun createMemberInfo(it: KtNamedDeclaration) = KotlinMemberInfo(it).apply { isChecked = true }
+        private fun createMemberInfo(it: KtNamedDeclaration): KotlinMemberInfo {
+            return KotlinMemberInfo(it).apply {
+                val descriptor = it.unsafeResolveToDescriptor()
+                isChecked = (descriptor as? PropertyDescriptor)?.getter?.isDefault ?: true
+            }
+        }
 
         override fun getPsiClass() = klass
 

--- a/idea/src/org/jetbrains/kotlin/idea/actions/generate/KotlinGenerateToStringAction.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/actions/generate/KotlinGenerateToStringAction.kt
@@ -28,6 +28,7 @@ import com.intellij.util.IncorrectOperationException
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
+import org.jetbrains.kotlin.descriptors.PropertyDescriptor
 import org.jetbrains.kotlin.descriptors.VariableDescriptor
 import org.jetbrains.kotlin.idea.KotlinBundle
 import org.jetbrains.kotlin.idea.caches.resolve.analyzeWithContent
@@ -168,11 +169,12 @@ class KotlinGenerateToStringAction : KotlinGenerateMemberActionBase<KotlinGenera
         val superToString = classDescriptor.getSuperClassOrAny().findDeclaredToString(true)!!
 
         val memberChooserObjects = properties.map { DescriptorMemberChooserObject(it, it.unsafeResolveToDescriptor()) }.toTypedArray()
+        val selectedElements = memberChooserObjects.filter { (it.descriptor as? PropertyDescriptor)?.getter?.isDefault ?: true }.toTypedArray()
         val headerPanel = ToStringMemberChooserHeaderPanel(!superToString.builtIns.isMemberOfAny(superToString))
         val chooser = MemberChooser<DescriptorMemberChooserObject>(memberChooserObjects, true, true, project, false, headerPanel).apply {
             title = KotlinBundle.message("action.generate.tostring.name")
             setCopyJavadocVisible(false)
-            selectElements(memberChooserObjects)
+            selectElements(selectedElements)
         }
 
         if (!klass.hasExpectModifier()) {

--- a/idea/src/org/jetbrains/kotlin/idea/actions/generate/utils.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/actions/generate/utils.kt
@@ -41,8 +41,7 @@ fun getPropertiesToUseInGeneratedMember(classOrObject: KtClassOrObject): List<Kt
         classOrObject.declarations.asSequence().filterIsInstance<KtProperty>().filterTo(this) {
             val descriptor = it.unsafeResolveToDescriptor()
             when (descriptor) {
-                is ValueParameterDescriptor -> true
-                is PropertyDescriptor -> descriptor.getter?.isDefault ?: true
+                is ValueParameterDescriptor, is PropertyDescriptor -> true
                 else -> false
             }
         }

--- a/idea/testData/codeInsight/generate/equalsWithHashCode/customAccessors.kt
+++ b/idea/testData/codeInsight/generate/equalsWithHashCode/customAccessors.kt
@@ -4,5 +4,8 @@ class Test {
             field = value.toUpperCase()
         }
     var name: String = ""
+    val age by lazy { 15 + 10 }
+    val color: String
+        get() = "Purple"
     <caret>
 }

--- a/idea/testData/codeInsight/generate/equalsWithHashCode/customAccessors.kt.after
+++ b/idea/testData/codeInsight/generate/equalsWithHashCode/customAccessors.kt.after
@@ -4,6 +4,10 @@ class Test {
             field = value.toUpperCase()
         }
     var name: String = ""
+    val age by lazy { 15 + 10 }
+    val color: String
+        get() = "Purple"
+
     <caret>override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
@@ -12,6 +16,8 @@ class Test {
 
         if (serial != other.serial) return false
         if (name != other.name) return false
+        if (age != other.age) return false
+        if (color != other.color) return false
 
         return true
     }
@@ -19,6 +25,8 @@ class Test {
     override fun hashCode(): Int {
         var result = serial.hashCode()
         result = 31 * result + name.hashCode()
+        result = 31 * result + age
+        result = 31 * result + color.hashCode()
         return result
     }
 

--- a/idea/testData/codeInsight/generate/equalsWithHashCode/explicitDefaultAccessors.kt.after
+++ b/idea/testData/codeInsight/generate/equalsWithHashCode/explicitDefaultAccessors.kt.after
@@ -8,11 +8,19 @@ class Test {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
+
+        other as Test
+
+        if (serial != other.serial) return false
+        if (name != other.name) return false
+
         return true
     }
 
     override fun hashCode(): Int {
-        return javaClass.hashCode()
+        var result = serial.hashCode()
+        result = 31 * result + name.hashCode()
+        return result
     }
 
 }

--- a/idea/testData/codeInsight/generate/toString/multipeTemplates/customAccessors.kt
+++ b/idea/testData/codeInsight/generate/toString/multipeTemplates/customAccessors.kt
@@ -5,5 +5,8 @@ class Test {
             field = value.toUpperCase()
         }
     var name: String = ""
+    val age by lazy { 15 + 10 }
+    val color: String
+        get() = "Purple"
     <caret>
 }

--- a/idea/testData/codeInsight/generate/toString/multipeTemplates/customAccessors.kt.after
+++ b/idea/testData/codeInsight/generate/toString/multipeTemplates/customAccessors.kt.after
@@ -5,10 +5,16 @@ class Test {
             field = value.toUpperCase()
         }
     var name: String = ""
+    val age by lazy { 15 + 10 }
+    val color: String
+        get() = "Purple"
+
     <caret>override fun toString(): String {
         return "Test(" +
                 "serial='$serial', " +
-                "name='$name'" +
+                "name='$name', " +
+                "age=$age, " +
+                "color='$color'" +
                 ")"
     }
 

--- a/idea/testData/codeInsight/generate/toString/singleTemplate/customAccessors.kt
+++ b/idea/testData/codeInsight/generate/toString/singleTemplate/customAccessors.kt
@@ -4,5 +4,8 @@ class Test {
             field = value.toUpperCase()
         }
     var name: String = ""
+    val age by lazy { 15 + 10 }
+    val color: String
+        get() = "Purple"
     <caret>
 }

--- a/idea/testData/codeInsight/generate/toString/singleTemplate/customAccessors.kt.after
+++ b/idea/testData/codeInsight/generate/toString/singleTemplate/customAccessors.kt.after
@@ -4,8 +4,12 @@ class Test {
             field = value.toUpperCase()
         }
     var name: String = ""
+    val age by lazy { 15 + 10 }
+    val color: String
+        get() = "Purple"
+
     <caret>override fun toString(): String {
-        return "Test(serial='$serial', name='$name')"
+        return "Test(serial='$serial', name='$name', age=$age, color='$color')"
     }
 
 }

--- a/idea/testData/codeInsight/generate/toString/singleTemplate/explicitDefaultAccessors.kt.after
+++ b/idea/testData/codeInsight/generate/toString/singleTemplate/explicitDefaultAccessors.kt.after
@@ -6,7 +6,7 @@ class Test {
         get
 
     override fun toString(): String {
-        return "Test()"
+        return "Test(serial='$serial', name='$name')"
     }
 
 }


### PR DESCRIPTION
[KT-15262](https://youtrack.jetbrains.com/issue/KT-15262). This addresses the comment raised in the previous [PR](https://github.com/JetBrains/kotlin/pull/3134#discussion_r428025016). Custom getters are suggested in the toString/ hashCode/equals dialog but they are unselected by default.