### PR TITLE
KT-41211: Use string template instead of concatenation

### DIFF
--- a/compiler/cli/cli-runner/src/org/jetbrains/kotlin/runner/Main.kt
+++ b/compiler/cli/cli-runner/src/org/jetbrains/kotlin/runner/Main.kt
@@ -127,10 +127,10 @@ object Main {
             classpath.addPath(".")
         }
 
-        classpath.addPath(KOTLIN_HOME.toString() + "/lib/kotlin-stdlib.jar")
+        classpath.addPath("$KOTLIN_HOME/lib/kotlin-stdlib.jar")
 
         if (!noReflect) {
-            classpath.addPath(KOTLIN_HOME.toString() + "/lib/kotlin-reflect.jar")
+            classpath.addPath("$KOTLIN_HOME/lib/kotlin-reflect.jar")
         }
 
         if (expression != null) {


### PR DESCRIPTION
This PR contains the following changes:

Updated the path passed as an argument to ```adPath()```
```classpath.addPath(KOTLIN_HOME + "/lib/kotlin-stdlib.jar")```

to:

```classpath.addPath("$KOTLIN_HOME/lib/kotlin-stdlib.jar")```

It now uses String Templates instead of String concatenation.