### PR TITLE
[JVM IR] Avoid Redundant special collection bridges

### DIFF
--- a/compiler/testData/codegen/bytecodeListing/specialBridges/noSpecialBridgeIfPresentInSuperClass.kt
+++ b/compiler/testData/codegen/bytecodeListing/specialBridges/noSpecialBridgeIfPresentInSuperClass.kt
@@ -1,3 +1,2 @@
-// IGNORE_BACKEND: JVM_IR
 abstract class A<T> : List<T>
 abstract class B<E> : A<E>()

--- a/compiler/testData/codegen/bytecodeListing/specialBridges/redundantStubForSize.kt
+++ b/compiler/testData/codegen/bytecodeListing/specialBridges/redundantStubForSize.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 open class A1 {
     open val size: Int = 56
 }

--- a/compiler/testData/codegen/bytecodeListing/specialBridges/redundantStubForSize_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/specialBridges/redundantStubForSize_ir.txt
@@ -1,0 +1,27 @@
+@kotlin.Metadata
+public class A1 {
+    private final field size: int
+    public method <init>(): void
+    public method getSize(): int
+}
+
+@kotlin.Metadata
+public final class A2 {
+    public method <init>(): void
+    public method add(@org.jetbrains.annotations.NotNull p0: java.lang.String): boolean
+    public synthetic bridge method add(p0: java.lang.Object): boolean
+    public method addAll(@org.jetbrains.annotations.NotNull p0: java.util.Collection): boolean
+    public method clear(): void
+    public method contains(@org.jetbrains.annotations.NotNull p0: java.lang.String): boolean
+    public bridge final method contains(p0: java.lang.Object): boolean
+    public method containsAll(@org.jetbrains.annotations.NotNull p0: java.util.Collection): boolean
+    public method isEmpty(): boolean
+    public @org.jetbrains.annotations.NotNull method iterator(): java.util.Iterator
+    public method remove(@org.jetbrains.annotations.NotNull p0: java.lang.String): boolean
+    public bridge final method remove(p0: java.lang.Object): boolean
+    public method removeAll(@org.jetbrains.annotations.NotNull p0: java.util.Collection): boolean
+    public method retainAll(@org.jetbrains.annotations.NotNull p0: java.util.Collection): boolean
+    public bridge final method size(): int
+    public @org.jetbrains.annotations.NotNull method toArray(): java.lang.Object[]
+    public @org.jetbrains.annotations.NotNull method toArray(@org.jetbrains.annotations.NotNull p0: java.lang.Object[]): java.lang.Object[]
+}


### PR DESCRIPTION
This PR avoids creating bridges when the resulting bridge signature is precisely that of the bridge-ee, and hence redundant.

The test expectations are a little inscrutable, but the separate expectations for the IR backend is needed as the two backends still disagree on a number of issues orthogonal to this one, like nullability assertions. The key point is the absence of a "getSize" bridge to the size property.