### PR TITLE
KT-41249 Enable highlighting in live templates

### DIFF
--- a/idea/idea-live-templates/src/org/jetbrains/kotlin/idea/liveTemplates/KotlinTemplateContextType.java
+++ b/idea/idea-live-templates/src/org/jetbrains/kotlin/idea/liveTemplates/KotlinTemplateContextType.java
@@ -83,6 +83,12 @@ public abstract class KotlinTemplateContextType extends TemplateContextType {
         return element != null && isInContext(element);
     }
 
+    @Nullable
+    @Override
+    public SyntaxHighlighter createHighlighter() {
+        return SyntaxHighlighterFactory.getSyntaxHighlighter(KotlinLanguage.INSTANCE, null, null);
+    }
+
     protected boolean isCommentInContext() {
         return false;
     }


### PR DESCRIPTION
`KotlinTemplateContextType` was not overriding `createHighlighter`. As a consequence, live templates and structural search templates were missing highlighting and basic completion.

This would fix [KT-41249](https://youtrack.jetbrains.com/issue/KT-41249), [KT-39725](https://youtrack.jetbrains.com/issue/KT-39725), and [KT-39939](https://youtrack.jetbrains.com/issue/KT-39939).