### PR TITLE
FIR: consider functions with defaults to be more specific 

### DIFF
--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/DefaultArgumentStubGenerator.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/DefaultArgumentStubGenerator.kt
@@ -46,7 +46,7 @@ open class DefaultArgumentStubGenerator(
     }
 
     override fun transformFlat(declaration: IrDeclaration): List<IrDeclaration>? {
-        if (declaration is IrFunction) {
+        if (declaration is IrFunction && !declaration.isFakeOverride) {
             return lower(declaration)
         }
 

--- a/compiler/testData/codegen/box/defaultArguments/implementedByFake.kt
+++ b/compiler/testData/codegen/box/defaultArguments/implementedByFake.kt
@@ -1,3 +1,4 @@
+// Fake override in B not bridging between I.g(String) and A.g(Object)
 // IGNORE_BACKEND_FIR: JVM_IR
 
 interface I<T> {

--- a/compiler/testData/codegen/box/delegation/withDefaultParameters.kt
+++ b/compiler/testData/codegen/box/delegation/withDefaultParameters.kt
@@ -1,5 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
-
 var log = ""
 fun log(a: String) {
     log += a + ";"

--- a/compiler/testData/codegen/box/increment/postfixIncrementOnShortSmartCast.kt
+++ b/compiler/testData/codegen/box/increment/postfixIncrementOnShortSmartCast.kt
@@ -1,3 +1,7 @@
+// `10` is inferred to be `Int`, smart casting `i` to `Int & Short` instead,
+// so there's an ambiguity between `Int.plus` and `Short.plus`.
+// IGNORE_BACKEND_FIR: JVM_IR
+
 public fun box() : String {
     var i : Short?
     i = 10


### PR DESCRIPTION
so that calls with missing arguments are correctly directed to the default implementation.

A function with more defaults and a function with a more specific return type are incomparable and should both be considered during overload resolution.