### PR TITLE
Alias empty list/set/map to java.util.Collections on JVM

### DIFF
--- a/libraries/stdlib/common/src/kotlin/collections/CollectionsH.kt
+++ b/libraries/stdlib/common/src/kotlin/collections/CollectionsH.kt
@@ -38,3 +38,23 @@ internal expect fun <T> arrayOfNulls(reference: Array<T>, size: Int): Array<T>
 internal expect fun <K, V> Map<K, V>.toSingletonMapOrSelf(): Map<K, V>
 internal expect fun <K, V> Map<out K, V>.toSingletonMap(): Map<K, V>
 internal expect fun <T> Array<out T>.copyToArrayOfAny(isVarargs: Boolean): Array<out Any?>
+
+/**
+ * Returns an empty read-only list.  The returned list is serializable (JVM).
+ * @sample samples.collections.Collections.Lists.emptyReadOnlyList
+ */
+expect fun <T> emptyList(): List<T>
+
+/**
+ * Returns an empty read-only set.  The returned set is serializable (JVM).
+ * @sample samples.collections.Collections.Sets.emptyReadOnlySet
+ */
+expect fun <T> emptySet(): Set<T>
+
+/**
+ * Returns an empty read-only map of specified type.
+ *
+ * The returned map is serializable (JVM).
+ * @sample samples.collections.Maps.Instantiation.emptyReadOnlyMap
+ */
+expect fun <K, V> emptyMap(): Map<K, V>

--- a/libraries/stdlib/js/src/kotlin/collections/CollectionsJS.kt
+++ b/libraries/stdlib/js/src/kotlin/collections/CollectionsJS.kt
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package kotlin.collections
+
+public actual fun <T> emptyList(): List<T> = EmptyList
+
+public actual fun <T> emptySet(): Set<T> = EmptySet
+
+public actual fun <K, V> emptyMap(): Map<K, V> = @Suppress("UNCHECKED_CAST") (EmptyMap as Map<K, V>)

--- a/libraries/stdlib/jvm/src/kotlin/collections/CollectionsJVM.kt
+++ b/libraries/stdlib/jvm/src/kotlin/collections/CollectionsJVM.kt
@@ -12,6 +12,8 @@ import kotlin.collections.builders.ListBuilder
 import kotlin.internal.InlineOnly
 import kotlin.internal.apiVersionIsAtLeast
 
+public actual fun <T> emptyList(): List<T> = java.util.Collections.emptyList()
+
 /**
  * Returns an immutable list containing only the specified object [element].
  * The returned list is serializable.

--- a/libraries/stdlib/jvm/src/kotlin/collections/MapsJVM.kt
+++ b/libraries/stdlib/jvm/src/kotlin/collections/MapsJVM.kt
@@ -15,6 +15,7 @@ import java.util.TreeMap
 import java.util.concurrent.ConcurrentMap
 import kotlin.collections.builders.MapBuilder
 
+public actual fun <K, V> emptyMap(): Map<K, V> = java.util.Collections.emptyMap()
 
 /**
  * Returns an immutable map, mapping only the specified key to the

--- a/libraries/stdlib/jvm/src/kotlin/collections/SetsJVM.kt
+++ b/libraries/stdlib/jvm/src/kotlin/collections/SetsJVM.kt
@@ -10,6 +10,7 @@ package kotlin.collections
 
 import kotlin.collections.builders.SetBuilder
 
+public actual fun <T> emptySet(): Set<T> = java.util.Collections.emptySet()
 
 /**
  * Returns an immutable set containing only the specified object [element].

--- a/libraries/stdlib/src/kotlin/collections/Collections.kt
+++ b/libraries/stdlib/src/kotlin/collections/Collections.kt
@@ -65,12 +65,6 @@ private class ArrayAsCollection<T>(val values: Array<out T>, val isVarargs: Bool
 }
 
 /**
- * Returns an empty read-only list.  The returned list is serializable (JVM).
- * @sample samples.collections.Collections.Lists.emptyReadOnlyList
- */
-public fun <T> emptyList(): List<T> = EmptyList
-
-/**
  * Returns a new read-only list of given elements.  The returned list is serializable (JVM).
  * @sample samples.collections.Collections.Lists.readOnlyList
  */

--- a/libraries/stdlib/src/kotlin/collections/Maps.kt
+++ b/libraries/stdlib/src/kotlin/collections/Maps.kt
@@ -11,7 +11,7 @@ package kotlin.collections
 
 import kotlin.contracts.*
 
-private object EmptyMap : Map<Any?, Nothing>, Serializable {
+internal object EmptyMap : Map<Any?, Nothing>, Serializable {
     private const val serialVersionUID: Long = 8246714829545688274
 
     override fun equals(other: Any?): Boolean = other is Map<*, *> && other.isEmpty()
@@ -30,14 +30,6 @@ private object EmptyMap : Map<Any?, Nothing>, Serializable {
 
     private fun readResolve(): Any = EmptyMap
 }
-
-/**
- * Returns an empty read-only map of specified type.
- *
- * The returned map is serializable (JVM).
- * @sample samples.collections.Maps.Instantiation.emptyReadOnlyMap
- */
-public fun <K, V> emptyMap(): Map<K, V> = @Suppress("UNCHECKED_CAST") (EmptyMap as Map<K, V>)
 
 /**
  * Returns a new read-only map with the specified contents, given as a list of pairs

--- a/libraries/stdlib/src/kotlin/collections/Sets.kt
+++ b/libraries/stdlib/src/kotlin/collections/Sets.kt
@@ -28,13 +28,6 @@ internal object EmptySet : Set<Nothing>, Serializable {
     private fun readResolve(): Any = EmptySet
 }
 
-
-/**
- * Returns an empty read-only set.  The returned set is serializable (JVM).
- * @sample samples.collections.Collections.Sets.emptyReadOnlySet
- */
-public fun <T> emptySet(): Set<T> = EmptySet
-
 /**
  * Returns a new read-only set with the given elements.
  * Elements of the set are iterated in the order they were specified.


### PR DESCRIPTION
Unfortunately the implementations have to remain for deserialization purposes. #KT-41333 fixed.

Will need a Kotlin/Native PR similar to the JS changes.