### PR TITLE
KT-41313: Only load .jar files when locating annotation processors

### DIFF
--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/ProcessorLoader.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/ProcessorLoader.kt
@@ -100,7 +100,7 @@ open class ProcessorLoader(private val options: KaptOptions, private val logger:
                         processSingleInput(it.inputStream())
                     }
                 }
-                file.isFile -> {
+                file.isFile && file.extension.equals("jar", ignoreCase = true) -> {
                     ZipFile(file).use { zipFile ->
                         zipFile.getEntry(serviceFile)?.let { zipEntry ->
                             zipFile.getInputStream(zipEntry).use {

--- a/plugins/kapt3/kapt3-base/test/org/jetbrains/kotlin/kapt3/base/ProcessorLoaderTest.kt
+++ b/plugins/kapt3/kapt3-base/test/org/jetbrains/kotlin/kapt3/base/ProcessorLoaderTest.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.kapt3.base
+
+import org.jetbrains.kotlin.base.kapt3.KaptOptions
+import org.jetbrains.kotlin.kapt3.base.util.WriterBackedKaptLogger
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+class ProcessorLoaderTest {
+
+    @Rule
+    @JvmField
+    val tmp = TemporaryFolder()
+
+    @Test
+    fun testProcessorClasspath() {
+        val kaptOptions = with(KaptOptions.Builder()) {
+            val jar = tmp.newFile("empty.jar").also {
+                ZipOutputStream(it.outputStream()).use {
+                    it.putNextEntry(ZipEntry("fake_entry"))
+                    it.closeEntry()
+                }
+            }
+            processingClasspath.add(jar)
+            sourcesOutputDir = tmp.newFolder()
+            classesOutputDir = tmp.newFolder()
+            stubsOutputDir = tmp.newFolder()
+            build()
+        }
+        val loadedProcessors = ProcessorLoader(kaptOptions, WriterBackedKaptLogger(false)).loadProcessors()
+        Assert.assertTrue(loadedProcessors.processors.isEmpty())
+    }
+
+    @Test
+    fun testProcessorUpperCaseExtensionClasspath() {
+        val kaptOptions = with(KaptOptions.Builder()) {
+            val jar = tmp.newFile("empty.JAR").also {
+                ZipOutputStream(it.outputStream()).use {
+                    it.putNextEntry(ZipEntry("fake_entry"))
+                    it.closeEntry()
+                }
+            }
+            processingClasspath.add(jar)
+            sourcesOutputDir = tmp.newFolder()
+            classesOutputDir = tmp.newFolder()
+            stubsOutputDir = tmp.newFolder()
+            build()
+        }
+        val loadedProcessors = ProcessorLoader(kaptOptions, WriterBackedKaptLogger(false)).loadProcessors()
+        Assert.assertTrue(loadedProcessors.processors.isEmpty())
+    }
+
+    @Test
+    fun testEmptyClasspath() {
+        val kaptOptions = with(KaptOptions.Builder()) {
+            sourcesOutputDir = tmp.newFolder()
+            classesOutputDir = tmp.newFolder()
+            stubsOutputDir = tmp.newFolder()
+            build()
+        }
+        val loadedProcessors = ProcessorLoader(kaptOptions, WriterBackedKaptLogger(false)).loadProcessors()
+        Assert.assertTrue(loadedProcessors.processors.isEmpty())
+    }
+
+    @Test
+    fun testClasspathWithNonJars() {
+        val kaptOptions = with(KaptOptions.Builder()) {
+            processingClasspath.add(tmp.newFile("do-not-load.gz"))
+            sourcesOutputDir = tmp.newFolder()
+            classesOutputDir = tmp.newFolder()
+            stubsOutputDir = tmp.newFolder()
+            build()
+        }
+        val loadedProcessors = ProcessorLoader(kaptOptions, WriterBackedKaptLogger(false)).loadProcessors()
+        Assert.assertTrue(loadedProcessors.processors.isEmpty())
+    }
+}


### PR DESCRIPTION
Previously, we'd only check if file exists and try to load it. However,
some compile classpaths may contain .tar.gz files.

Test: ProcessorLoaderTest