### PR TITLE
FIR2IR: convert adapted callable reference with vararg

### DIFF
--- a/compiler/testData/codegen/box/callableReference/adaptedReferences/suspendConversion/adaptedWithVarargs.kt
+++ b/compiler/testData/codegen/box/callableReference/adaptedReferences/suspendConversion/adaptedWithVarargs.kt
@@ -1,7 +1,6 @@
 // !LANGUAGE: +SuspendConversion
 // WITH_RUNTIME
 // WITH_COROUTINES
-// IGNORE_BACKEND_FIR: JVM_IR
 
 import helpers.*
 import kotlin.coroutines.*

--- a/compiler/testData/codegen/box/callableReference/adaptedReferences/suspendConversion/inlineAdaptedWithVarargs.kt
+++ b/compiler/testData/codegen/box/callableReference/adaptedReferences/suspendConversion/inlineAdaptedWithVarargs.kt
@@ -1,7 +1,6 @@
 // !LANGUAGE: +SuspendConversion
 // WITH_RUNTIME
 // WITH_COROUTINES
-// IGNORE_BACKEND_FIR: JVM_IR
 
 import helpers.*
 import kotlin.coroutines.*

--- a/compiler/testData/ir/irText/expressions/callableReferences/adaptedWithCoercionToUnit.fir.txt
+++ b/compiler/testData/ir/irText/expressions/callableReferences/adaptedWithCoercionToUnit.fir.txt
@@ -54,3 +54,5 @@ FILE fqName:<root> fileName:/adaptedWithCoercionToUnit.kt
               VALUE_PARAMETER ADAPTER_PARAMETER_FOR_CALLABLE_REFERENCE name:p0 index:0 type:kotlin.Int
               BLOCK_BODY
                 CALL 'public final fun fnv (vararg xs: kotlin.Int): kotlin.Int declared in <root>' type=kotlin.Int origin=null
+                  xs: VARARG type=kotlin.IntArray varargElementType=kotlin.Int
+                    GET_VAR 'p0: kotlin.Int declared in <root>.testV1.fnv' type=kotlin.Int origin=null

--- a/compiler/testData/ir/irText/expressions/callableReferences/suspendConversion.fir.txt
+++ b/compiler/testData/ir/irText/expressions/callableReferences/suspendConversion.fir.txt
@@ -88,6 +88,8 @@ FILE fqName:<root> fileName:/suspendConversion.kt
             VALUE_PARAMETER ADAPTER_PARAMETER_FOR_CALLABLE_REFERENCE name:p0 index:0 type:kotlin.Int
             BLOCK_BODY
               CALL 'public final fun foo2 (vararg xs: kotlin.Int): kotlin.Unit declared in <root>' type=kotlin.Unit origin=null
+                xs: VARARG type=kotlin.IntArray varargElementType=kotlin.Int
+                  GET_VAR 'p0: kotlin.Int declared in <root>.testWithVarargMapped.foo2' type=kotlin.Int origin=null
   FUN name:testWithCoercionToUnit visibility:public modality:FINAL <> () returnType:kotlin.Unit
     BLOCK_BODY
       CALL 'public final fun useSuspend (fn: kotlin.coroutines.SuspendFunction0<kotlin.Unit>): kotlin.Unit declared in <root>' type=kotlin.Unit origin=null

--- a/compiler/testData/ir/irText/expressions/callableReferences/unboundMemberReferenceWithAdaptedArguments.fir.txt
+++ b/compiler/testData/ir/irText/expressions/callableReferences/unboundMemberReferenceWithAdaptedArguments.fir.txt
@@ -67,6 +67,8 @@ FILE fqName:<root> fileName:/unboundMemberReferenceWithAdaptedArguments.kt
             BLOCK_BODY
               CALL 'public open fun foo (vararg xs: kotlin.Int): kotlin.Int declared in <root>.A' type=kotlin.Int origin=null
                 $this: GET_VAR 'p0: <root>.A declared in <root>.testUnbound.foo' type=<root>.A origin=null
+                xs: VARARG type=kotlin.IntArray varargElementType=kotlin.Int
+                  GET_VAR 'p0: <root>.A declared in <root>.testUnbound.foo' type=<root>.A origin=null
   FUN name:testBound visibility:public modality:FINAL <> (a:<root>.A) returnType:kotlin.Unit
     VALUE_PARAMETER name:a index:0 type:<root>.A
     BLOCK_BODY
@@ -78,6 +80,8 @@ FILE fqName:<root> fileName:/unboundMemberReferenceWithAdaptedArguments.kt
             BLOCK_BODY
               CALL 'public open fun foo (vararg xs: kotlin.Int): kotlin.Int declared in <root>.A' type=kotlin.Int origin=null
                 $this: GET_VAR 'receiver: <root>.A declared in <root>.testBound.foo' type=<root>.A origin=ADAPTED_FUNCTION_REFERENCE
+                xs: VARARG type=kotlin.IntArray varargElementType=kotlin.Int
+                  GET_VAR 'p0: kotlin.Int declared in <root>.testBound.foo' type=kotlin.Int origin=null
           FUNCTION_REFERENCE 'local final fun foo (p0: kotlin.Int): kotlin.Unit declared in <root>.testBound' type=kotlin.Function1<kotlin.Int, kotlin.Unit> origin=ADAPTED_FUNCTION_REFERENCE reflectionTarget=null
             $receiver: GET_VAR 'a: <root>.A declared in <root>.testBound' type=<root>.A origin=null
   FUN name:testObject visibility:public modality:FINAL <> () returnType:kotlin.Unit
@@ -90,5 +94,7 @@ FILE fqName:<root> fileName:/unboundMemberReferenceWithAdaptedArguments.kt
             BLOCK_BODY
               CALL 'public final fun foo (vararg xs: kotlin.Int): kotlin.Int declared in <root>.Obj' type=kotlin.Int origin=null
                 $this: GET_VAR 'receiver: <root>.Obj declared in <root>.testObject.foo' type=<root>.Obj origin=ADAPTED_FUNCTION_REFERENCE
+                xs: VARARG type=kotlin.IntArray varargElementType=kotlin.Int
+                  GET_VAR 'p0: kotlin.Int declared in <root>.testObject.foo' type=kotlin.Int origin=null
           FUNCTION_REFERENCE 'local final fun foo (p0: kotlin.Int): kotlin.Unit declared in <root>.testObject' type=kotlin.Function1<kotlin.Int, kotlin.Unit> origin=ADAPTED_FUNCTION_REFERENCE reflectionTarget=null
             $receiver: GET_OBJECT 'CLASS OBJECT name:Obj modality:FINAL visibility:public superTypes:[<root>.A]' type=<root>.Obj

--- a/compiler/testData/ir/irText/expressions/callableReferences/withAdaptationForSam.fir.txt
+++ b/compiler/testData/ir/irText/expressions/callableReferences/withAdaptationForSam.fir.txt
@@ -34,3 +34,5 @@ FILE fqName:<root> fileName:/withAdaptationForSam.kt
               VALUE_PARAMETER ADAPTER_PARAMETER_FOR_CALLABLE_REFERENCE name:p0 index:0 type:kotlin.Int
               BLOCK_BODY
                 CALL 'public final fun withVararg (vararg xs: kotlin.Int): kotlin.Int declared in <root>' type=kotlin.Int origin=null
+                  xs: VARARG type=kotlin.IntArray varargElementType=kotlin.Int
+                    GET_VAR 'p0: kotlin.Int declared in <root>.test.withVararg' type=kotlin.Int origin=null

--- a/compiler/testData/ir/irText/expressions/callableReferences/withArgumentAdaptationAndReceiver.fir.txt
+++ b/compiler/testData/ir/irText/expressions/callableReferences/withArgumentAdaptationAndReceiver.fir.txt
@@ -28,6 +28,8 @@ FILE fqName:<root> fileName:/withArgumentAdaptationAndReceiver.kt
               BLOCK_BODY
                 CALL 'public final fun withVararg (vararg xs: kotlin.Int): kotlin.String declared in <root>.Host' type=kotlin.String origin=null
                   $this: GET_VAR 'receiver: <root>.Host declared in <root>.Host.testImplicitThis.withVararg' type=<root>.Host origin=ADAPTED_FUNCTION_REFERENCE
+                  xs: VARARG type=kotlin.IntArray varargElementType=kotlin.Int
+                    GET_VAR 'p0: kotlin.Int declared in <root>.Host.testImplicitThis.withVararg' type=kotlin.Int origin=null
             FUNCTION_REFERENCE 'local final fun withVararg (p0: kotlin.Int): kotlin.Unit declared in <root>.Host.testImplicitThis' type=kotlin.Function1<kotlin.Int, kotlin.Unit> origin=ADAPTED_FUNCTION_REFERENCE reflectionTarget=null
     FUN name:testBoundReceiverLocalVal visibility:public modality:FINAL <> ($this:<root>.Host) returnType:kotlin.Unit
       $this: VALUE_PARAMETER name:<this> type:<root>.Host
@@ -42,6 +44,8 @@ FILE fqName:<root> fileName:/withArgumentAdaptationAndReceiver.kt
               BLOCK_BODY
                 CALL 'public final fun withVararg (vararg xs: kotlin.Int): kotlin.String declared in <root>.Host' type=kotlin.String origin=null
                   $this: GET_VAR 'receiver: <root>.Host declared in <root>.Host.testBoundReceiverLocalVal.withVararg' type=<root>.Host origin=ADAPTED_FUNCTION_REFERENCE
+                  xs: VARARG type=kotlin.IntArray varargElementType=kotlin.Int
+                    GET_VAR 'p0: kotlin.Int declared in <root>.Host.testBoundReceiverLocalVal.withVararg' type=kotlin.Int origin=null
             FUNCTION_REFERENCE 'local final fun withVararg (p0: kotlin.Int): kotlin.Unit declared in <root>.Host.testBoundReceiverLocalVal' type=kotlin.Function1<kotlin.Int, kotlin.Unit> origin=ADAPTED_FUNCTION_REFERENCE reflectionTarget=null
               $receiver: GET_VAR 'val h: <root>.Host [val] declared in <root>.Host.testBoundReceiverLocalVal' type=<root>.Host origin=null
     FUN name:testBoundReceiverLocalVar visibility:public modality:FINAL <> ($this:<root>.Host) returnType:kotlin.Unit
@@ -59,6 +63,8 @@ FILE fqName:<root> fileName:/withArgumentAdaptationAndReceiver.kt
               BLOCK_BODY
                 CALL 'public final fun withVararg (vararg xs: kotlin.Int): kotlin.String declared in <root>.Host' type=kotlin.String origin=null
                   $this: GET_VAR 'receiver: <root>.Host declared in <root>.Host.testBoundReceiverLocalVar.withVararg' type=<root>.Host origin=ADAPTED_FUNCTION_REFERENCE
+                  xs: VARARG type=kotlin.IntArray varargElementType=kotlin.Int
+                    GET_VAR 'p0: kotlin.Int declared in <root>.Host.testBoundReceiverLocalVar.withVararg' type=kotlin.Int origin=null
             FUNCTION_REFERENCE 'local final fun withVararg (p0: kotlin.Int): kotlin.Unit declared in <root>.Host.testBoundReceiverLocalVar' type=kotlin.Function1<kotlin.Int, kotlin.Unit> origin=ADAPTED_FUNCTION_REFERENCE reflectionTarget=null
               $receiver: GET_VAR 'var h: <root>.Host [var] declared in <root>.Host.testBoundReceiverLocalVar' type=<root>.Host origin=null
     FUN name:testBoundReceiverParameter visibility:public modality:FINAL <> ($this:<root>.Host, h:<root>.Host) returnType:kotlin.Unit
@@ -73,6 +79,8 @@ FILE fqName:<root> fileName:/withArgumentAdaptationAndReceiver.kt
               BLOCK_BODY
                 CALL 'public final fun withVararg (vararg xs: kotlin.Int): kotlin.String declared in <root>.Host' type=kotlin.String origin=null
                   $this: GET_VAR 'receiver: <root>.Host declared in <root>.Host.testBoundReceiverParameter.withVararg' type=<root>.Host origin=ADAPTED_FUNCTION_REFERENCE
+                  xs: VARARG type=kotlin.IntArray varargElementType=kotlin.Int
+                    GET_VAR 'p0: kotlin.Int declared in <root>.Host.testBoundReceiverParameter.withVararg' type=kotlin.Int origin=null
             FUNCTION_REFERENCE 'local final fun withVararg (p0: kotlin.Int): kotlin.Unit declared in <root>.Host.testBoundReceiverParameter' type=kotlin.Function1<kotlin.Int, kotlin.Unit> origin=ADAPTED_FUNCTION_REFERENCE reflectionTarget=null
               $receiver: GET_VAR 'h: <root>.Host declared in <root>.Host.testBoundReceiverParameter' type=<root>.Host origin=null
     FUN name:testBoundReceiverExpression visibility:public modality:FINAL <> ($this:<root>.Host) returnType:kotlin.Unit
@@ -88,6 +96,8 @@ FILE fqName:<root> fileName:/withArgumentAdaptationAndReceiver.kt
               BLOCK_BODY
                 CALL 'public final fun withVararg (vararg xs: kotlin.Int): kotlin.String declared in <root>.Host' type=kotlin.String origin=null
                   $this: GET_VAR 'receiver: <root>.Host declared in <root>.Host.testBoundReceiverExpression.withVararg' type=<root>.Host origin=ADAPTED_FUNCTION_REFERENCE
+                  xs: VARARG type=kotlin.IntArray varargElementType=kotlin.Int
+                    GET_VAR 'p0: kotlin.Int declared in <root>.Host.testBoundReceiverExpression.withVararg' type=kotlin.Int origin=null
             FUNCTION_REFERENCE 'local final fun withVararg (p0: kotlin.Int): kotlin.Unit declared in <root>.Host.testBoundReceiverExpression' type=kotlin.Function1<kotlin.Int, kotlin.Unit> origin=ADAPTED_FUNCTION_REFERENCE reflectionTarget=null
               $receiver: CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in <root>.Host' type=<root>.Host origin=null
     FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]

--- a/compiler/testData/ir/irText/expressions/funInterface/samConversionInVarargs.fir.txt
+++ b/compiler/testData/ir/irText/expressions/funInterface/samConversionInVarargs.fir.txt
@@ -66,3 +66,5 @@ FILE fqName:<root> fileName:/samConversionInVarargs.kt
               VALUE_PARAMETER ADAPTER_PARAMETER_FOR_CALLABLE_REFERENCE name:p0 index:0 type:kotlin.Int
               BLOCK_BODY
                 CALL 'public final fun withVarargOfInt (vararg xs: kotlin.Int): kotlin.String declared in <root>' type=kotlin.String origin=null
+                  xs: VARARG type=kotlin.IntArray varargElementType=kotlin.Int
+                    GET_VAR 'p0: kotlin.Int declared in <root>.testAdaptedCR.withVarargOfInt' type=kotlin.Int origin=null


### PR DESCRIPTION
This is the follow-up of https://github.com/JetBrains/kotlin/pull/3614, where I said:

> Note that, in this PR, only the adaptation on reference type is done. For some other cases, we will need a different conversion for such adapted callable reference, which will reuse #3599.

That PR adapted callable reference type with `vararg` such that the reference can be used in a different form at the use site. This PR now converts such adapted callable reference. All necessary pieces of callable reference conversion were done at #3599. This PR just extends how value argument from the adapter function can be mapped to `vararg` parameter in the adaptee.