### PR TITLE
KT-41338 False positive "Redundant 'asSequence' call" when Map.Entry properties are used.

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/collections/RedundantAsSequenceInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/collections/RedundantAsSequenceInspection.kt
@@ -9,6 +9,7 @@ import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.openapi.project.Project
+import org.jetbrains.kotlin.builtins.DefaultBuiltIns
 import org.jetbrains.kotlin.idea.KotlinBundle
 import org.jetbrains.kotlin.idea.caches.resolve.analyze
 import org.jetbrains.kotlin.idea.core.replaced
@@ -21,6 +22,7 @@ import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.getQualifiedExpressionForReceiver
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
+import org.jetbrains.kotlin.resolve.calls.callUtil.getType
 import org.jetbrains.kotlin.resolve.lazy.BodyResolveMode
 
 class RedundantAsSequenceInspection : AbstractKotlinInspection() {
@@ -36,6 +38,8 @@ class RedundantAsSequenceInspection : AbstractKotlinInspection() {
         val parentCall = qualified.getQualifiedExpressionForReceiver()?.callExpression ?: return
 
         val context = qualified.analyze(BodyResolveMode.PARTIAL)
+        val receiverType = qualified.receiverExpression.getType(context) ?: return
+        if (!receiverType.isIterable(DefaultBuiltIns.Instance)) return
         if (call.getResolvedCall(context)?.isCalling(asSequenceFqName) != true) return
         if (!parentCall.isTermination(context)) return
 

--- a/idea/testData/inspectionsLocal/collections/redundantAsSequence/map.kt
+++ b/idea/testData/inspectionsLocal/collections/redundantAsSequence/map.kt
@@ -1,0 +1,5 @@
+// PROBLEM: none
+// WITH_RUNTIME
+fun test(map: Map<String, Int>): Map.Entry<String, Int>? {
+    return map.<caret>asSequence().firstOrNull()
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -1626,6 +1626,11 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
                 runTest("idea/testData/inspectionsLocal/collections/redundantAsSequence/hasLineBreak.kt");
             }
 
+            @TestMetadata("map.kt")
+            public void testMap() throws Exception {
+                runTest("idea/testData/inspectionsLocal/collections/redundantAsSequence/map.kt");
+            }
+
             @TestMetadata("notTermination.kt")
             public void testNotTermination() throws Exception {
                 runTest("idea/testData/inspectionsLocal/collections/redundantAsSequence/notTermination.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-41338