### PR TITLE
JVM IR: Fixes for nested inner classes

### DIFF
--- a/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
@@ -14463,6 +14463,11 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
             runTest("compiler/testData/codegen/box/innerNested/nestedInPackage.kt");
         }
 
+        @TestMetadata("nestedInnerClass.kt")
+        public void testNestedInnerClass() throws Exception {
+            runTest("compiler/testData/codegen/box/innerNested/nestedInnerClass.kt");
+        }
+
         @TestMetadata("nestedObjects.kt")
         public void testNestedObjects() throws Exception {
             runTest("compiler/testData/codegen/box/innerNested/nestedObjects.kt");

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/InnerClassesLowering.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/InnerClassesLowering.kt
@@ -141,7 +141,7 @@ class InnerClassesMemberBodyLowering(val context: BackendContext, private val in
     private fun IrBody.fixThisReference(irClass: IrClass, container: IrDeclaration) {
         val enclosingFunction: IrDeclaration? = run {
             var current: IrDeclaration? = container
-            while (current != null && current !is IrFunction) {
+            while (current != null && current !is IrFunction && current !is IrClass) {
                 current = current.parent as? IrDeclaration
             }
             current

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
@@ -129,10 +129,7 @@ internal val localDeclarationsPhase = makeIrFilePhase(
                         declaration.visibility
 
                 override fun forCapturedField(value: IrValueSymbol): Visibility =
-                    if (value is IrValueParameterSymbol && value.owner.isCrossinline)
-                        JavaVisibilities.PACKAGE_VISIBILITY // avoid requiring a synthetic accessor for it
-                    else
-                        Visibilities.PRIVATE
+                    JavaVisibilities.PACKAGE_VISIBILITY // avoid requiring a synthetic accessor for it
 
                 private fun scopedVisibility(inInlineFunctionScope: Boolean): Visibility =
                     if (inInlineFunctionScope) Visibilities.PUBLIC else JavaVisibilities.PACKAGE_VISIBILITY

--- a/compiler/testData/codegen/box/innerNested/nestedInnerClass.kt
+++ b/compiler/testData/codegen/box/innerNested/nestedInnerClass.kt
@@ -1,0 +1,13 @@
+class A(val x: String) {
+    fun value(): String {
+        return object {
+            inner class Y {
+                val y = x
+            }
+
+            fun value() = Y().y
+        }.value()
+    }
+}
+
+fun box(): String = A("OK").value()

--- a/compiler/testData/codegen/bytecodeListing/annotations/literals.kt
+++ b/compiler/testData/codegen/bytecodeListing/annotations/literals.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 @Target(AnnotationTarget.CLASS)
 annotation class ClsAnn
 

--- a/compiler/testData/codegen/bytecodeListing/annotations/localClassWithCapturedParams.kt
+++ b/compiler/testData/codegen/bytecodeListing/annotations/localClassWithCapturedParams.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 annotation class Simple(val value: String)
 
 fun localCaptured(): Any {

--- a/compiler/testData/codegen/bytecodeListing/coroutines/spilling/booleanParameter_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/coroutines/spilling/booleanParameter_ir.txt
@@ -49,7 +49,7 @@ public abstract class helpers/ContinuationAdapter {
 @kotlin.Metadata
 public final class helpers/CoroutineUtilKt$handleExceptionContinuation$1 {
     // source: 'CoroutineUtil.kt'
-    private synthetic final field $x: kotlin.jvm.functions.Function1
+    synthetic final field $x: kotlin.jvm.functions.Function1
     private final @org.jetbrains.annotations.NotNull field context: kotlin.coroutines.EmptyCoroutineContext
     inner (anonymous) class helpers/CoroutineUtilKt$handleExceptionContinuation$1
     method <init>(p0: kotlin.jvm.functions.Function1): void
@@ -61,7 +61,7 @@ public final class helpers/CoroutineUtilKt$handleExceptionContinuation$1 {
 @kotlin.Metadata
 public final class helpers/CoroutineUtilKt$handleResultContinuation$1 {
     // source: 'CoroutineUtil.kt'
-    private synthetic final field $x: kotlin.jvm.functions.Function1
+    synthetic final field $x: kotlin.jvm.functions.Function1
     private final @org.jetbrains.annotations.NotNull field context: kotlin.coroutines.EmptyCoroutineContext
     inner (anonymous) class helpers/CoroutineUtilKt$handleResultContinuation$1
     method <init>(p0: kotlin.jvm.functions.Function1): void

--- a/compiler/testData/codegen/bytecodeText/fieldsForCapturedValues/extensionLambdaExtensionReceiver.kt
+++ b/compiler/testData/codegen/bytecodeText/fieldsForCapturedValues/extensionLambdaExtensionReceiver.kt
@@ -19,4 +19,4 @@ fun test() {
 // 1 final synthetic LReceiver; \$this_useExtensionLambda
 
 // JVM_IR_TEMPLATES
-// 1 private final synthetic LReceiver; \$this
+// 1 final synthetic LReceiver; \$this

--- a/compiler/testData/codegen/bytecodeText/fieldsForCapturedValues/extensionReceiver.kt
+++ b/compiler/testData/codegen/bytecodeText/fieldsForCapturedValues/extensionReceiver.kt
@@ -10,8 +10,4 @@ fun Receiver.bar() {
     }
 }
 
-// JVM_TEMPLATES
 // 1 final synthetic LReceiver; \$this_bar
-
-// JVM_IR_TEMPLATES
-// 1 private final synthetic LReceiver; \$this_bar

--- a/compiler/testData/codegen/bytecodeText/fieldsForCapturedValues/innerAndOuterThis.kt
+++ b/compiler/testData/codegen/bytecodeText/fieldsForCapturedValues/innerAndOuterThis.kt
@@ -15,9 +15,7 @@ class Outer {
     fun outerFoo() {}
 }
 
-// JVM_TEMPLATES
 // 1 final synthetic LOuter\$Inner; this\$0
 
 // JVM_IR_TEMPLATES
-// 1 private final synthetic LOuter\$Inner; this\$0
-// 1 private final synthetic LOuter; this\$1
+// 1 final synthetic LOuter; this\$1

--- a/compiler/testData/codegen/bytecodeText/fieldsForCapturedValues/labeledExtensionLambdaExtensionReceiver.kt
+++ b/compiler/testData/codegen/bytecodeText/fieldsForCapturedValues/labeledExtensionLambdaExtensionReceiver.kt
@@ -19,4 +19,4 @@ fun test() {
 // 1 final synthetic LReceiver; \$this_label
 
 // JVM_IR_TEMPLATES
-// 1 private final synthetic LReceiver; \$this
+// 1 final synthetic LReceiver; \$this

--- a/compiler/testData/codegen/bytecodeText/fieldsForCapturedValues/multipleExtensionReceivers.kt
+++ b/compiler/testData/codegen/bytecodeText/fieldsForCapturedValues/multipleExtensionReceivers.kt
@@ -22,5 +22,5 @@ fun Foo.test(bar: Bar) {
 // 1 final synthetic LBar; \$this_test
 
 // JVM_IR_TEMPLATES
-// 1 private final synthetic LFoo; \$this_test
-// 1 private final synthetic LBar; \$this_test\$1
+// 1 final synthetic LFoo; \$this_test
+// 1 final synthetic LBar; \$this_test\$1

--- a/compiler/testData/codegen/bytecodeText/fieldsForCapturedValues/outerThis.kt
+++ b/compiler/testData/codegen/bytecodeText/fieldsForCapturedValues/outerThis.kt
@@ -16,4 +16,4 @@ class Outer {
 // 1 final synthetic LOuter\$Inner; this\$0
 
 // JVM_IR_TEMPLATES
-// 1 private final synthetic LOuter; this\$0
+// 2 final synthetic LOuter; this\$0

--- a/compiler/testData/codegen/bytecodeText/fieldsForCapturedValues/outerThisInInnerConstructor.kt
+++ b/compiler/testData/codegen/bytecodeText/fieldsForCapturedValues/outerThisInInnerConstructor.kt
@@ -16,4 +16,4 @@ class Outer {
 // 1 final synthetic LOuter\$Inner; this\$0
 
 // JVM_IR_TEMPLATES
-// 1 private final synthetic LOuter; this\$0
+// 2 final synthetic LOuter; this\$0

--- a/compiler/testData/codegen/bytecodeText/fieldsForCapturedValues/outerThisInInnerInitBlock.kt
+++ b/compiler/testData/codegen/bytecodeText/fieldsForCapturedValues/outerThisInInnerInitBlock.kt
@@ -16,4 +16,4 @@ class Outer {
 // 1 final synthetic LOuter\$Inner; this\$0
 
 // JVM_IR_TEMPLATES
-// 1 private final synthetic LOuter; this\$0
+// 2 final synthetic LOuter; this\$0

--- a/compiler/testData/codegen/bytecodeText/fieldsForCapturedValues/this.kt
+++ b/compiler/testData/codegen/bytecodeText/fieldsForCapturedValues/this.kt
@@ -10,8 +10,4 @@ class Host {
     fun foo() {}
 }
 
-// JVM_TEMPLATES
 // 1 final synthetic LHost; this\$0
-
-// JVM_IR_TEMPLATES
-// 1 private final synthetic LHost; this\$0

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -15688,6 +15688,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             runTest("compiler/testData/codegen/box/innerNested/nestedInPackage.kt");
         }
 
+        @TestMetadata("nestedInnerClass.kt")
+        public void testNestedInnerClass() throws Exception {
+            runTest("compiler/testData/codegen/box/innerNested/nestedInnerClass.kt");
+        }
+
         @TestMetadata("nestedObjects.kt")
         public void testNestedObjects() throws Exception {
             runTest("compiler/testData/codegen/box/innerNested/nestedObjects.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -15688,6 +15688,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/innerNested/nestedInPackage.kt");
         }
 
+        @TestMetadata("nestedInnerClass.kt")
+        public void testNestedInnerClass() throws Exception {
+            runTest("compiler/testData/codegen/box/innerNested/nestedInnerClass.kt");
+        }
+
         @TestMetadata("nestedObjects.kt")
         public void testNestedObjects() throws Exception {
             runTest("compiler/testData/codegen/box/innerNested/nestedObjects.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -14463,6 +14463,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             runTest("compiler/testData/codegen/box/innerNested/nestedInPackage.kt");
         }
 
+        @TestMetadata("nestedInnerClass.kt")
+        public void testNestedInnerClass() throws Exception {
+            runTest("compiler/testData/codegen/box/innerNested/nestedInnerClass.kt");
+        }
+
         @TestMetadata("nestedObjects.kt")
         public void testNestedObjects() throws Exception {
             runTest("compiler/testData/codegen/box/innerNested/nestedObjects.kt");

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
@@ -12518,6 +12518,11 @@ public class IrJsCodegenBoxES6TestGenerated extends AbstractIrJsCodegenBoxES6Tes
             runTest("compiler/testData/codegen/box/innerNested/nestedInPackage.kt");
         }
 
+        @TestMetadata("nestedInnerClass.kt")
+        public void testNestedInnerClass() throws Exception {
+            runTest("compiler/testData/codegen/box/innerNested/nestedInnerClass.kt");
+        }
+
         @TestMetadata("nestedObjects.kt")
         public void testNestedObjects() throws Exception {
             runTest("compiler/testData/codegen/box/innerNested/nestedObjects.kt");

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -12518,6 +12518,11 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/innerNested/nestedInPackage.kt");
         }
 
+        @TestMetadata("nestedInnerClass.kt")
+        public void testNestedInnerClass() throws Exception {
+            runTest("compiler/testData/codegen/box/innerNested/nestedInnerClass.kt");
+        }
+
         @TestMetadata("nestedObjects.kt")
         public void testNestedObjects() throws Exception {
             runTest("compiler/testData/codegen/box/innerNested/nestedObjects.kt");

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -12583,6 +12583,11 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/innerNested/nestedInPackage.kt");
         }
 
+        @TestMetadata("nestedInnerClass.kt")
+        public void testNestedInnerClass() throws Exception {
+            runTest("compiler/testData/codegen/box/innerNested/nestedInnerClass.kt");
+        }
+
         @TestMetadata("nestedObjects.kt")
         public void testNestedObjects() throws Exception {
             runTest("compiler/testData/codegen/box/innerNested/nestedObjects.kt");


### PR DESCRIPTION
- Fix the lookup for the `this` reference in `InnerClassesLowering`. The fix was found by @pyos. This previously caused problems with the compilation of nested inner classes, see the added test.
- Create fields for captured values as package private, same as in the JVM backend. Otherwise, nested inner classes would require accessors. There were also some cases where the fields needed to be package private instead of private anyway, see the unmuted tests.
