### PR TITLE
JVM: Fix RuntimeAssertions with BuilderInference (fix for KT-41470)

### DIFF
--- a/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
@@ -12562,6 +12562,11 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
             runTest("compiler/testData/codegen/box/inference/builderInference.kt");
         }
 
+        @TestMetadata("builderInferenceCheckNotNull.kt")
+        public void testBuilderInferenceCheckNotNull() throws Exception {
+            runTest("compiler/testData/codegen/box/inference/builderInferenceCheckNotNull.kt");
+        }
+
         @TestMetadata("builderInferenceLeakingVariable.kt")
         public void testBuilderInferenceLeakingVariable() throws Exception {
             runTest("compiler/testData/codegen/box/inference/builderInferenceLeakingVariable.kt");

--- a/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/RuntimeAssertions.kt
+++ b/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/RuntimeAssertions.kt
@@ -18,6 +18,7 @@ import org.jetbrains.kotlin.resolve.calls.checkers.AdditionalTypeChecker
 import org.jetbrains.kotlin.resolve.calls.checkers.CallChecker
 import org.jetbrains.kotlin.resolve.calls.checkers.CallCheckerContext
 import org.jetbrains.kotlin.resolve.calls.context.ResolutionContext
+import org.jetbrains.kotlin.resolve.calls.inference.model.TypeVariableTypeConstructor
 import org.jetbrains.kotlin.resolve.calls.model.ResolvedCall
 import org.jetbrains.kotlin.resolve.isNullableUnderlyingType
 import org.jetbrains.kotlin.resolve.scopes.receivers.ExpressionReceiver
@@ -103,7 +104,7 @@ object RuntimeAssertionsTypeChecker : AdditionalTypeChecker {
         expressionTypeWithSmartCast: KotlinType,
         c: ResolutionContext<*>
     ) {
-        if (TypeUtils.noExpectedType(c.expectedType) || c.expectedType is StubType) return
+        if (TypeUtils.noExpectedType(c.expectedType) || c.expectedType is StubType || c.expectedType.constructor is TypeVariableTypeConstructor) return
 
         val assertionInfo = RuntimeAssertionInfo.create(
             c.expectedType,

--- a/compiler/testData/codegen/box/inference/builderInferenceCheckNotNull.kt
+++ b/compiler/testData/codegen/box/inference/builderInferenceCheckNotNull.kt
@@ -1,0 +1,39 @@
+// !LANGUAGE: +NewInference
+// WITH_RUNTIME
+import kotlin.experimental.ExperimentalTypeInference
+
+interface Flow<out T> {
+    fun collect(collector: FlowCollector<T>)
+}
+
+interface FlowCollector<in T> {
+    fun emit(value: T)
+}
+
+fun <T> flow(block: FlowCollector<T>.() -> Unit): Flow<T> =
+    object : Flow<T> {
+        override fun collect(collector: FlowCollector<T>) = collector.block()
+    }
+
+fun <T> Flow<T>.collect(action: (value: T) -> Unit): Unit =
+    collect(object : FlowCollector<T> {
+        override fun emit(value: T) = action(value)
+    })
+
+@OptIn(ExperimentalTypeInference::class)
+fun <T, R> Flow<T>.transform(@BuilderInference transform: FlowCollector<R>.(T) -> Unit): Flow<R> =
+    flow { collect { transform(it) } }
+
+// Due to the BuilderInference, the data flow info for the expected type of the argument to
+// emit contains an unsolved type variable, while the type of `transform(it)` is `R`.
+// Since unsolved type variables have no upper bounds, the argument to emit is assumed to
+// be non-nullable, while `R` is nullable and we could insert a checkNotNullExpressionValue
+// unless we deal with unsolved type parameters in `RuntimeAssertions.kt`.
+fun <T, R> Flow<T>.map(transform: (value: T) -> R): Flow<R> =
+    transform { emit(transform(it)) }
+
+fun box(): String {
+    var result: String = "Fail 1"
+    flow<String> { emit("Fail 2") }.map { null }.collect { result = it ?: "OK" }
+    return result
+}

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -13787,6 +13787,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             runTest("compiler/testData/codegen/box/inference/builderInference.kt");
         }
 
+        @TestMetadata("builderInferenceCheckNotNull.kt")
+        public void testBuilderInferenceCheckNotNull() throws Exception {
+            runTest("compiler/testData/codegen/box/inference/builderInferenceCheckNotNull.kt");
+        }
+
         @TestMetadata("builderInferenceLeakingVariable.kt")
         public void testBuilderInferenceLeakingVariable() throws Exception {
             runTest("compiler/testData/codegen/box/inference/builderInferenceLeakingVariable.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -13787,6 +13787,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/inference/builderInference.kt");
         }
 
+        @TestMetadata("builderInferenceCheckNotNull.kt")
+        public void testBuilderInferenceCheckNotNull() throws Exception {
+            runTest("compiler/testData/codegen/box/inference/builderInferenceCheckNotNull.kt");
+        }
+
         @TestMetadata("builderInferenceLeakingVariable.kt")
         public void testBuilderInferenceLeakingVariable() throws Exception {
             runTest("compiler/testData/codegen/box/inference/builderInferenceLeakingVariable.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -12562,6 +12562,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             runTest("compiler/testData/codegen/box/inference/builderInference.kt");
         }
 
+        @TestMetadata("builderInferenceCheckNotNull.kt")
+        public void testBuilderInferenceCheckNotNull() throws Exception {
+            runTest("compiler/testData/codegen/box/inference/builderInferenceCheckNotNull.kt");
+        }
+
         @TestMetadata("builderInferenceLeakingVariable.kt")
         public void testBuilderInferenceLeakingVariable() throws Exception {
             runTest("compiler/testData/codegen/box/inference/builderInferenceLeakingVariable.kt");

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
@@ -10757,6 +10757,11 @@ public class IrJsCodegenBoxES6TestGenerated extends AbstractIrJsCodegenBoxES6Tes
             runTest("compiler/testData/codegen/box/inference/approximateNonTopLevelCapturedTypes.kt");
         }
 
+        @TestMetadata("builderInferenceCheckNotNull.kt")
+        public void testBuilderInferenceCheckNotNull() throws Exception {
+            runTest("compiler/testData/codegen/box/inference/builderInferenceCheckNotNull.kt");
+        }
+
         @TestMetadata("builderInferenceLeakingVariable.kt")
         public void testBuilderInferenceLeakingVariable() throws Exception {
             runTest("compiler/testData/codegen/box/inference/builderInferenceLeakingVariable.kt");

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -10757,6 +10757,11 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/inference/approximateNonTopLevelCapturedTypes.kt");
         }
 
+        @TestMetadata("builderInferenceCheckNotNull.kt")
+        public void testBuilderInferenceCheckNotNull() throws Exception {
+            runTest("compiler/testData/codegen/box/inference/builderInferenceCheckNotNull.kt");
+        }
+
         @TestMetadata("builderInferenceLeakingVariable.kt")
         public void testBuilderInferenceLeakingVariable() throws Exception {
             runTest("compiler/testData/codegen/box/inference/builderInferenceLeakingVariable.kt");

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -10822,6 +10822,11 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/inference/approximateNonTopLevelCapturedTypes.kt");
         }
 
+        @TestMetadata("builderInferenceCheckNotNull.kt")
+        public void testBuilderInferenceCheckNotNull() throws Exception {
+            runTest("compiler/testData/codegen/box/inference/builderInferenceCheckNotNull.kt");
+        }
+
         @TestMetadata("builderInferenceLeakingVariable.kt")
         public void testBuilderInferenceLeakingVariable() throws Exception {
             runTest("compiler/testData/codegen/box/inference/builderInferenceLeakingVariable.kt");


### PR DESCRIPTION
This is a fix for https://youtrack.jetbrains.com/issue/KT-41470