### PR TITLE
JVM_IR: move classes out of lambdas inlined into initializers

### DIFF
--- a/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
@@ -28930,6 +28930,11 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
             runTest("compiler/testData/codegen/box/secondaryConstructors/generics.kt");
         }
 
+        @TestMetadata("inlineIntoTwoConstructors.kt")
+        public void testInlineIntoTwoConstructors() throws Exception {
+            runTest("compiler/testData/codegen/box/secondaryConstructors/inlineIntoTwoConstructors.kt");
+        }
+
         @TestMetadata("innerClasses.kt")
         public void testInnerClasses() throws Exception {
             runTest("compiler/testData/codegen/box/secondaryConstructors/innerClasses.kt");

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/JvmLocalClassPopupLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/JvmLocalClassPopupLowering.kt
@@ -9,15 +9,29 @@ import org.jetbrains.kotlin.backend.common.ScopeWithIr
 import org.jetbrains.kotlin.backend.common.lower.LocalClassPopupLowering
 import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
 import org.jetbrains.kotlin.backend.jvm.JvmLoweredDeclarationOrigin
-import org.jetbrains.kotlin.ir.declarations.IrAnonymousInitializer
-import org.jetbrains.kotlin.ir.declarations.IrClass
-import org.jetbrains.kotlin.ir.declarations.IrField
+import org.jetbrains.kotlin.backend.jvm.ir.IrInlineReferenceLocator
+import org.jetbrains.kotlin.ir.declarations.*
+import org.jetbrains.kotlin.ir.expressions.IrFunctionReference
 import org.jetbrains.kotlin.ir.util.parentAsClass
 import org.jetbrains.kotlin.ir.util.primaryConstructor
 import org.jetbrains.kotlin.ir.util.render
 import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstanceOrNull
 
 class JvmLocalClassPopupLowering(context: JvmBackendContext) : LocalClassPopupLowering(context) {
+    private val inlineLambdaToScope = mutableMapOf<IrFunction, IrDeclaration>()
+
+    override fun lower(irFile: IrFile) {
+        irFile.accept(object : IrInlineReferenceLocator(context as JvmBackendContext) {
+            override fun visitInlineLambda(
+                argument: IrFunctionReference, callee: IrFunction, parameter: IrValueParameter, scope: IrDeclaration
+            ) {
+                inlineLambdaToScope[argument.symbol.owner] = scope
+            }
+        }, null)
+        super.lower(irFile)
+        inlineLambdaToScope.clear()
+    }
+
     // On JVM, we only pop up local classes in field initializers and anonymous init blocks, so that InitializersLowering would not copy
     // them to each constructor. (Moving all local classes is not possible because of cases where they use reified type parameters,
     // or capture crossinline lambdas.)
@@ -31,9 +45,13 @@ class JvmLocalClassPopupLowering(context: JvmBackendContext) : LocalClassPopupLo
                 klass.origin == JvmLoweredDeclarationOrigin.GENERATED_PROPERTY_REFERENCE
         if (!isLocal) return false
 
-        val container = when (val element = currentScope?.irElement) {
-            is IrAnonymousInitializer -> element.parentAsClass.takeUnless { element.isStatic }
-            is IrField -> element.parentAsClass.takeUnless { element.isStatic }
+        var parent = currentScope?.irElement
+        while (parent is IrFunction) {
+            parent = inlineLambdaToScope[parent] ?: break
+        }
+        val container = when (parent) {
+            is IrAnonymousInitializer -> parent.parentAsClass.takeUnless { parent.isStatic }
+            is IrField -> parent.parentAsClass.takeUnless { parent.isStatic }
             else -> null
         } ?: return false
 

--- a/compiler/testData/codegen/box/secondaryConstructors/inlineIntoTwoConstructors.kt
+++ b/compiler/testData/codegen/box/secondaryConstructors/inlineIntoTwoConstructors.kt
@@ -1,0 +1,10 @@
+inline fun myRun(x: () -> String) = x()
+
+class C {
+    val x = myRun { { "OK" }() }
+
+    constructor(y: Int)
+    constructor(y: String)
+}
+
+fun box(): String = C("").x

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -30526,6 +30526,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             runTest("compiler/testData/codegen/box/secondaryConstructors/generics.kt");
         }
 
+        @TestMetadata("inlineIntoTwoConstructors.kt")
+        public void testInlineIntoTwoConstructors() throws Exception {
+            runTest("compiler/testData/codegen/box/secondaryConstructors/inlineIntoTwoConstructors.kt");
+        }
+
         @TestMetadata("innerClasses.kt")
         public void testInnerClasses() throws Exception {
             runTest("compiler/testData/codegen/box/secondaryConstructors/innerClasses.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -28160,6 +28160,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/secondaryConstructors/generics.kt");
         }
 
+        @TestMetadata("inlineIntoTwoConstructors.kt")
+        public void testInlineIntoTwoConstructors() throws Exception {
+            runTest("compiler/testData/codegen/box/secondaryConstructors/inlineIntoTwoConstructors.kt");
+        }
+
         @TestMetadata("innerClasses.kt")
         public void testInnerClasses() throws Exception {
             runTest("compiler/testData/codegen/box/secondaryConstructors/innerClasses.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -28930,6 +28930,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             runTest("compiler/testData/codegen/box/secondaryConstructors/generics.kt");
         }
 
+        @TestMetadata("inlineIntoTwoConstructors.kt")
+        public void testInlineIntoTwoConstructors() throws Exception {
+            runTest("compiler/testData/codegen/box/secondaryConstructors/inlineIntoTwoConstructors.kt");
+        }
+
         @TestMetadata("innerClasses.kt")
         public void testInnerClasses() throws Exception {
             runTest("compiler/testData/codegen/box/secondaryConstructors/innerClasses.kt");

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
@@ -23521,6 +23521,11 @@ public class IrJsCodegenBoxES6TestGenerated extends AbstractIrJsCodegenBoxES6Tes
             runTest("compiler/testData/codegen/box/secondaryConstructors/generics.kt");
         }
 
+        @TestMetadata("inlineIntoTwoConstructors.kt")
+        public void testInlineIntoTwoConstructors() throws Exception {
+            runTest("compiler/testData/codegen/box/secondaryConstructors/inlineIntoTwoConstructors.kt");
+        }
+
         @TestMetadata("innerClasses.kt")
         public void testInnerClasses() throws Exception {
             runTest("compiler/testData/codegen/box/secondaryConstructors/innerClasses.kt");

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -23521,6 +23521,11 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/secondaryConstructors/generics.kt");
         }
 
+        @TestMetadata("inlineIntoTwoConstructors.kt")
+        public void testInlineIntoTwoConstructors() throws Exception {
+            runTest("compiler/testData/codegen/box/secondaryConstructors/inlineIntoTwoConstructors.kt");
+        }
+
         @TestMetadata("innerClasses.kt")
         public void testInnerClasses() throws Exception {
             runTest("compiler/testData/codegen/box/secondaryConstructors/innerClasses.kt");

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -23536,6 +23536,11 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/secondaryConstructors/generics.kt");
         }
 
+        @TestMetadata("inlineIntoTwoConstructors.kt")
+        public void testInlineIntoTwoConstructors() throws Exception {
+            runTest("compiler/testData/codegen/box/secondaryConstructors/inlineIntoTwoConstructors.kt");
+        }
+
         @TestMetadata("innerClasses.kt")
         public void testInnerClasses() throws Exception {
             runTest("compiler/testData/codegen/box/secondaryConstructors/innerClasses.kt");


### PR DESCRIPTION
Fixes KT-41465