### PR TITLE
Add Map<K, V?>.filterValuesNotNull()

### DIFF
--- a/libraries/stdlib/samples/test/samples/collections/maps.kt
+++ b/libraries/stdlib/samples/test/samples/collections/maps.kt
@@ -239,6 +239,17 @@ class Maps {
         }
 
         @Sample
+        fun filterValuesNotNull() {
+            val originalMap: Map<String, Int?> = mapOf("key1" to 1, "key2" to 2, "key3" to null)
+
+            // value type is no longer nullable
+            val filteredMap: Map<String, Int> = originalMap.filterValuesNotNull()
+            assertPrints(filteredMap, "{key1=1, key2=2}")
+            // original map has not changed
+            assertPrints(originalMap, "{key1=1, key2=2, key3=null}")
+        }
+
+        @Sample
         fun filterTo() {
             val originalMap = mapOf("key1" to 1, "key2" to 2, "key3" to 3)
             val destinationMap = mutableMapOf("key40" to 40, "key50" to 50)

--- a/libraries/stdlib/src/kotlin/collections/Maps.kt
+++ b/libraries/stdlib/src/kotlin/collections/Maps.kt
@@ -483,6 +483,15 @@ public inline fun <K, V> Map<out K, V>.filterValues(predicate: (V) -> Boolean): 
     return result
 }
 
+/**
+ * Returns a map containing all key-value pairs with nonnull values.
+ *
+ * The returned map preserves the entry iteration order of the original map.
+ * @sample samples.collections.Maps.Filtering.filterValuesNotNull
+ */
+@Suppress("UNCHECKED_CAST")
+public fun <K, V> Map<out K, V?>.filterValuesNotNull(): Map<K, V> =
+    this.filterValues { it != null } as Map<K, V>
 
 /**
  * Appends all entries matching the given [predicate] into the mutable map given as [destination] parameter.

--- a/libraries/stdlib/test/collections/MapTest.kt
+++ b/libraries/stdlib/test/collections/MapTest.kt
@@ -333,6 +333,10 @@ class MapTest {
 
         val filteredByValue2 = map.filterValues { it % 2 == 0 }
         assertEquals(mapOf("a" to 2, "c" to 2), filteredByValue2)
+
+        val mapWithNulls = mapOf(1 to "one", 2 to null, 3 to "three")
+        val filteredNotNull: Map<Int, String> = mapWithNulls.filterValuesNotNull()
+        assertEquals(mapOf(1 to "one", 3 to "three"), filteredNotNull)
     }
 
     @Test fun filterOutProjectedTo() {


### PR DESCRIPTION
Since `myMap.filterValues { it != null }` does not change the type to `Map<K, V>`, users either have to do an unchecked cast or implement this functionality themselves.