### PR TITLE
[IDEA] Don't mark signature as inapplicable when last argument is empty/incomplete

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/parameterInfo/KotlinFunctionParameterInfoHandler.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/parameterInfo/KotlinFunctionParameterInfoHandler.kt
@@ -519,12 +519,39 @@ abstract class KotlinParameterInfoWithCallHandlerBase<TArgumentList : KtElement,
             return (callToUse.getArgumentMapping(argument) as? ArgumentMatch)?.valueParameter
         }
 
-        val highlightParameterIndex = argumentToParameter(currentArgument)?.index
+        val currentParameter = argumentToParameter(currentArgument)
+        val highlightParameterIndex = currentParameter?.index
 
         val argumentsBeforeCurrent = arguments.subList(0, currentArgumentIndex)
-        if ((argumentsBeforeCurrent + currentArgument).any { argumentToParameter(it) == null }) {
-            // some of arguments before the current one (or the current one) are not mapped to any of the parameters
+        if (argumentsBeforeCurrent.any { argumentToParameter(it) == null }) {
+            // some of arguments before the current one are not mapped to any of the parameters
             return SignatureInfo(resultingDescriptor, ::argumentToParameter, highlightParameterIndex, isGrey = true)
+        }
+
+        if (currentParameter == null) {
+            if (currentArgumentIndex < arguments.lastIndex) {
+                // the current argument is not the last one and it is not mapped to any of the parameters
+                return SignatureInfo(resultingDescriptor, ::argumentToParameter, highlightParameterIndex, isGrey = true)
+            }
+
+            val usedParameters = argumentsBeforeCurrent.mapNotNull { argumentToParameter(it) }
+            val availableParameters = if (call.callType == Call.CallType.ARRAY_SET_METHOD) {
+                resultingDescriptor.valueParameters.dropLast(1)
+            } else {
+                resultingDescriptor.valueParameters
+            } 
+            val noUnusedParametersLeft = (availableParameters - usedParameters).isEmpty()
+
+            if (currentArgument == info.dummyArgument) {
+                val supportsTrailingCommas = call.callElement.languageVersionSettings.supportsFeature(LanguageFeature.TrailingCommas)
+                if (!supportsTrailingCommas && noUnusedParametersLeft) {
+                    // current argument is empty but there are no unused parameters left and trailing commas are not supported
+                    return SignatureInfo(resultingDescriptor, ::argumentToParameter, highlightParameterIndex, isGrey = true)
+                }
+            } else if (noUnusedParametersLeft) {
+                // there are no unused parameters left to which this argument could be matched
+                return SignatureInfo(resultingDescriptor, ::argumentToParameter, highlightParameterIndex, isGrey = true)
+            }
         }
 
         // grey out if not all arguments before the current are matched

--- a/idea/testData/parameterInfo/functionCall/NamedParameter3.kt
+++ b/idea/testData/parameterInfo/functionCall/NamedParameter3.kt
@@ -1,0 +1,10 @@
+open class A(x: Int) {
+    fun m(x: Int, y: Boolean) = 1
+
+    fun d(x: Int) {
+        m(y = false, <caret>)
+    }
+}
+/*
+Text: ([y: Boolean], [x: Int]), Disabled: false, Strikeout: false, Green: true
+*/

--- a/idea/testData/parameterInfo/functionCall/TooManyArgs.kt
+++ b/idea/testData/parameterInfo/functionCall/TooManyArgs.kt
@@ -1,3 +1,4 @@
+// COMPILER_ARGUMENTS: -XXLanguage:-TrailingCommas
 open class A(x: Int) {
     fun m(x: Int, y: Boolean) = 2
 

--- a/idea/testData/parameterInfo/functionCall/TooManyArgs2.kt
+++ b/idea/testData/parameterInfo/functionCall/TooManyArgs2.kt
@@ -1,0 +1,8 @@
+open class A(x: Int) {
+    fun m(x: Int, y: Int) = 2
+
+    fun d(x: Int) {
+        m(1, 2, 3<caret>)
+    }
+}
+//Text: (x: Int, y: Int), Disabled: true, Strikeout: false, Green: true

--- a/idea/testData/parameterInfo/functionCall/TrailingComma.kt
+++ b/idea/testData/parameterInfo/functionCall/TrailingComma.kt
@@ -1,0 +1,10 @@
+open class A(x: Int) {
+    fun m(x: Int, y: Boolean) = 1
+
+    fun d(x: Int) {
+        m(1, false,<caret>)
+    }
+}
+/*
+Text: (x: Int, y: Boolean), Disabled: false, Strikeout: false, Green: true
+*/

--- a/idea/testData/parameterInfo/functionCall/TwoSmartCasts.kt
+++ b/idea/testData/parameterInfo/functionCall/TwoSmartCasts.kt
@@ -1,3 +1,4 @@
+// COMPILER_ARGUMENTS: -XXLanguage:-TrailingCommas
 // See KT-14484
 
 class C {

--- a/idea/tests/org/jetbrains/kotlin/idea/parameterInfo/ParameterInfoTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/parameterInfo/ParameterInfoTestGenerated.java
@@ -221,6 +221,11 @@ public class ParameterInfoTestGenerated extends AbstractParameterInfoTest {
             runTest("idea/testData/parameterInfo/functionCall/NamedParameter2.kt");
         }
 
+        @TestMetadata("NamedParameter3.kt")
+        public void testNamedParameter3() throws Exception {
+            runTest("idea/testData/parameterInfo/functionCall/NamedParameter3.kt");
+        }
+
         @TestMetadata("NoAnnotations.kt")
         public void testNoAnnotations() throws Exception {
             runTest("idea/testData/parameterInfo/functionCall/NoAnnotations.kt");
@@ -344,6 +349,16 @@ public class ParameterInfoTestGenerated extends AbstractParameterInfoTest {
         @TestMetadata("TooManyArgs.kt")
         public void testTooManyArgs() throws Exception {
             runTest("idea/testData/parameterInfo/functionCall/TooManyArgs.kt");
+        }
+
+        @TestMetadata("TooManyArgs2.kt")
+        public void testTooManyArgs2() throws Exception {
+            runTest("idea/testData/parameterInfo/functionCall/TooManyArgs2.kt");
+        }
+
+        @TestMetadata("TrailingComma.kt")
+        public void testTrailingComma() throws Exception {
+            runTest("idea/testData/parameterInfo/functionCall/TrailingComma.kt");
         }
 
         @TestMetadata("TwoFunctions.kt")


### PR DESCRIPTION
This will improve the usability when using named arguments where incomplete arguments can't be mapped to a parameter simply by position.

**Before:**
![idea_parameter_info_named_arguments_before](https://user-images.githubusercontent.com/218061/92175814-8d582000-ee3d-11ea-8f09-dcd4f6bf8f19.png)

**After:**
![idea_parameter_info_named_arguments_after](https://user-images.githubusercontent.com/218061/92175821-90531080-ee3d-11ea-95a4-fe28d735da73.png)

Fixes [KT-24172](https://youtrack.jetbrains.com/issue/KT-24172)