### PR TITLE
[IDEA] Mark used parameters as disabled in parameter info popup

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/parameterInfo/KotlinFunctionParameterInfoHandler.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/parameterInfo/KotlinFunctionParameterInfoHandler.kt
@@ -233,6 +233,7 @@ abstract class KotlinParameterInfoWithCallHandlerBase<TArgumentList : KtElement,
 
         var boldStartOffset = -1
         var boldEndOffset = -1
+        var disabledBeforeHighlight = false
         val text = buildString {
             val usedParameterIndices = HashSet<Int>()
             var namedMode = false
@@ -245,11 +246,21 @@ abstract class KotlinParameterInfoWithCallHandlerBase<TArgumentList : KtElement,
 
             val includeParameterNames = !substitutedDescriptor.hasSynthesizedParameterNames()
 
-            fun appendParameter(parameter: ValueParameterDescriptor, named: Boolean = false) {
+            fun appendParameter(
+                parameter: ValueParameterDescriptor,
+                named: Boolean = false,
+                markUsedUnusedParameterBorder: Boolean = false
+            ) {
                 argumentIndex++
 
                 if (length > 0) {
                     append(", ")
+                    if (markUsedUnusedParameterBorder) {
+                        // mark the space after the comma as bold; bold text needs to be at least one character long
+                        boldStartOffset = length - 1
+                        boldEndOffset = length
+                        disabledBeforeHighlight = true
+                    }
                 }
 
                 val highlightParameter = parameter.index == highlightParameterIndex
@@ -283,7 +294,7 @@ abstract class KotlinParameterInfoWithCallHandlerBase<TArgumentList : KtElement,
                     if (argumentIndex != parameter.index) {
                         namedMode = true
                     }
-                    appendParameter(parameter)
+                    appendParameter(parameter, markUsedUnusedParameterBorder = highlightParameterIndex == null && boldStartOffset == -1)
                 }
             }
 
@@ -295,7 +306,15 @@ abstract class KotlinParameterInfoWithCallHandlerBase<TArgumentList : KtElement,
 
         val color = if (itemToShow.isResolvedToDescriptor) GREEN_BACKGROUND else context.defaultParameterColor
 
-        context.setupUIComponentPresentation(text, boldStartOffset, boldEndOffset, isGrey, itemToShow.isDeprecatedAtCallSite, false, color)
+        context.setupUIComponentPresentation(
+            text,
+            boldStartOffset,
+            boldEndOffset,
+            isGrey,
+            itemToShow.isDeprecatedAtCallSite,
+            disabledBeforeHighlight,
+            color
+        )
 
         return true
     }

--- a/idea/testData/parameterInfo/functionCall/NamedParameter3.kt
+++ b/idea/testData/parameterInfo/functionCall/NamedParameter3.kt
@@ -6,5 +6,5 @@ open class A(x: Int) {
     }
 }
 /*
-Text: ([y: Boolean], [x: Int]), Disabled: false, Strikeout: false, Green: true
+Text: (<disabled>[y: Boolean],</disabled><highlight> </highlight>[x: Int]), Disabled: false, Strikeout: false, Green: true
 */

--- a/idea/testData/parameterInfo/functionCall/NamedParameter4.kt
+++ b/idea/testData/parameterInfo/functionCall/NamedParameter4.kt
@@ -1,0 +1,10 @@
+open class A(x: Int) {
+    fun m(a: String = "a", b: String = "b", c: String = "c", d: String = "d") = 1
+
+    fun d(x: Int) {
+        m(b = "x", d = "x", <caret>)
+    }
+}
+/*
+Text: (<disabled>[b: String = "b"], [d: String = "d"],</disabled><highlight> </highlight>[a: String = "a"], [c: String = "c"]), Disabled: false, Strikeout: false, Green: true
+*/

--- a/idea/tests/org/jetbrains/kotlin/idea/parameterInfo/MockParameterInfoUIContext.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/parameterInfo/MockParameterInfoUIContext.java
@@ -27,22 +27,36 @@ public class MockParameterInfoUIContext implements ParameterInfoUIContext {
     public String setupUIComponentPresentation(String text, int highlightStartOffset, int highlightEndOffset,
                                              boolean isDisabled, boolean strikeout,
                                              boolean isDisabledBeforeHighlight, Color background) {
-        String highlightedText;
+        String taggedText;
         if (highlightStartOffset != -1 && highlightEndOffset != -1) {
-            highlightedText = text.substring(0, highlightStartOffset)
-                              + "<highlight>"
-                              + text.substring(highlightStartOffset, highlightEndOffset)
-                              + "</highlight>"
-                              + text.substring(highlightEndOffset);
+            StringBuilder sb = new StringBuilder();
+            if (isDisabledBeforeHighlight) {
+                sb.append("<disabled>");
+            }
+
+            sb.append(text, 0, highlightStartOffset);
+
+            if (isDisabledBeforeHighlight) {
+                sb.append("</disabled>");
+            }
+
+            sb.append("<highlight>");
+            sb.append(text, highlightStartOffset, highlightEndOffset);
+            sb.append("</highlight>");
+
+            sb.append(text, highlightEndOffset, text.length());
+
+            taggedText = sb.toString();
         }
         else {
-            highlightedText = text;
+            taggedText = text;
         }
 
-        String resultText = "Text: (" + highlightedText + "), " +
+        String resultText = "Text: (" + taggedText + "), " +
                             "Disabled: " + isDisabled + ", " +
                             "Strikeout: " + strikeout + ", " +
                             "Green: " + KotlinParameterInfoWithCallHandlerBase.GREEN_BACKGROUND.equals(background);
+
         result.add(resultText);
 
         // return value not used, just return something

--- a/idea/tests/org/jetbrains/kotlin/idea/parameterInfo/ParameterInfoTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/parameterInfo/ParameterInfoTestGenerated.java
@@ -226,6 +226,11 @@ public class ParameterInfoTestGenerated extends AbstractParameterInfoTest {
             runTest("idea/testData/parameterInfo/functionCall/NamedParameter3.kt");
         }
 
+        @TestMetadata("NamedParameter4.kt")
+        public void testNamedParameter4() throws Exception {
+            runTest("idea/testData/parameterInfo/functionCall/NamedParameter4.kt");
+        }
+
         @TestMetadata("NoAnnotations.kt")
         public void testNoAnnotations() throws Exception {
             runTest("idea/testData/parameterInfo/functionCall/NoAnnotations.kt");


### PR DESCRIPTION
When using named arguments the IDE might be unable to map the current argument to a parameter. In that case this change marks already used parameters as disabled. That way developers can easily see which parameters have not been used yet.

![idea_parameter_info_unused_parameters_variant_1](https://user-images.githubusercontent.com/218061/92270909-22632380-eee7-11ea-84ec-6cd4b99a9515.png)


Fixes [KTIJ-128](https://youtrack.jetbrains.com/issue/KTIJ-128)