### PR TITLE
[IDEA] Add KotlinClassConstructorInfoHandler for showing parameter info of parameterized super class constructor.

### DIFF
--- a/idea/resources/META-INF/plugin-common.xml
+++ b/idea/resources/META-INF/plugin-common.xml
@@ -380,6 +380,7 @@
     <codeInsight.parameterInfo language="kotlin" implementationClass="org.jetbrains.kotlin.idea.parameterInfo.KotlinArrayAccessParameterInfoHandler"/>
     <codeInsight.parameterInfo language="kotlin" implementationClass="org.jetbrains.kotlin.idea.parameterInfo.KotlinClassTypeArgumentInfoHandler"/>
     <codeInsight.parameterInfo language="kotlin" implementationClass="org.jetbrains.kotlin.idea.parameterInfo.KotlinFunctionTypeArgumentInfoHandler"/>
+    <codeInsight.parameterInfo language="kotlin" implementationClass="org.jetbrains.kotlin.idea.parameterInfo.KotlinClassConstructorInfoHandler"/>
     <codeInsight.parameterNameHints language="kotlin" implementationClass="org.jetbrains.kotlin.idea.codeInsight.hints.KotlinInlayParameterHintsProvider"/>
 
     <codeInsight.inlayProvider language="kotlin" implementationClass="org.jetbrains.kotlin.idea.codeInsight.hints.KotlinReferencesTypeHintsProvider"/>

--- a/idea/src/org/jetbrains/kotlin/idea/parameterInfo/KotlinTypeArgumentInfoHandler.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/parameterInfo/KotlinTypeArgumentInfoHandler.kt
@@ -18,10 +18,7 @@ package org.jetbrains.kotlin.idea.parameterInfo
 
 import com.intellij.codeInsight.lookup.LookupElement
 import com.intellij.lang.parameterInfo.*
-import org.jetbrains.kotlin.descriptors.ClassDescriptor
-import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
-import org.jetbrains.kotlin.descriptors.FunctionDescriptor
-import org.jetbrains.kotlin.descriptors.TypeParameterDescriptor
+import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.idea.caches.resolve.analyze
 import org.jetbrains.kotlin.idea.caches.resolve.getResolutionFacade
 import org.jetbrains.kotlin.idea.core.resolveCandidates
@@ -40,12 +37,25 @@ import org.jetbrains.kotlin.types.typeUtil.TypeNullability
 import org.jetbrains.kotlin.types.typeUtil.isAnyOrNullableAny
 import org.jetbrains.kotlin.types.typeUtil.nullability
 
+class KotlinClassConstructorInfoHandler : KotlinTypeArgumentInfoHandlerBase<ClassConstructorDescriptor>() {
+    override fun fetchTypeParameters(descriptor: ClassConstructorDescriptor): List<TypeParameterDescriptor> = descriptor.typeParameters
+
+    override fun findParameterOwners(argumentList: KtTypeArgumentList): Collection<ClassConstructorDescriptor>? {
+        val userType = argumentList.parent as? KtUserType ?: return null
+        val descriptors = userType.referenceExpression?.resolveMainReferenceToDescriptors()?.mapNotNull { it as? ClassConstructorDescriptor }
+        return descriptors?.takeIf { it.isNotEmpty() }
+    }
+
+    override fun getArgumentListAllowedParentClasses() = setOf(KtUserType::class.java)
+}
+
 class KotlinClassTypeArgumentInfoHandler : KotlinTypeArgumentInfoHandlerBase<ClassDescriptor>() {
     override fun fetchTypeParameters(descriptor: ClassDescriptor) = descriptor.typeConstructor.parameters
 
     override fun findParameterOwners(argumentList: KtTypeArgumentList): Collection<ClassDescriptor>? {
         val userType = argumentList.parent as? KtUserType ?: return null
-        return userType.referenceExpression?.resolveMainReferenceToDescriptors()?.mapNotNull { it as? ClassDescriptor }
+        val descriptors = userType.referenceExpression?.resolveMainReferenceToDescriptors()?.mapNotNull { it as? ClassDescriptor }
+        return descriptors?.takeIf { it.isNotEmpty() }
     }
 
     override fun getArgumentListAllowedParentClasses() = setOf(KtUserType::class.java)

--- a/idea/testData/parameterInfo/typeArguments/ParameterizedClassConstructor.kt
+++ b/idea/testData/parameterInfo/typeArguments/ParameterizedClassConstructor.kt
@@ -1,0 +1,13 @@
+open class Parameterized<A, C: Cloneable, R: Runnable>
+
+class AC
+class CC : Cloneable
+class RC : Runnable {
+    override fun run() {}
+}
+
+fun use(p: Parameterized<AC, CC, RC>) {}
+
+class UsageClass : Parameterized<AC, CC<caret>, RC>()
+
+//Text: (A, <highlight>C : Cloneable</highlight>, R : Runnable), Disabled: false, Strikeout: false, Green: false

--- a/idea/testData/parameterInfo/typeArguments/ParameterizedClassConstructor.kt
+++ b/idea/testData/parameterInfo/typeArguments/ParameterizedClassConstructor.kt
@@ -6,8 +6,6 @@ class RC : Runnable {
     override fun run() {}
 }
 
-fun use(p: Parameterized<AC, CC, RC>) {}
-
 class UsageClass : Parameterized<AC, CC<caret>, RC>()
 
 //Text: (A, <highlight>C : Cloneable</highlight>, R : Runnable), Disabled: false, Strikeout: false, Green: false

--- a/idea/tests/org/jetbrains/kotlin/idea/parameterInfo/ParameterInfoTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/parameterInfo/ParameterInfoTestGenerated.java
@@ -439,6 +439,11 @@ public class ParameterInfoTestGenerated extends AbstractParameterInfoTest {
             runTest("idea/testData/parameterInfo/typeArguments/Overloads.kt");
         }
 
+        @TestMetadata("ParameterizedClassConstructor.kt")
+        public void testParameterizedClassConstructor() throws Exception {
+            runTest("idea/testData/parameterInfo/typeArguments/ParameterizedClassConstructor.kt");
+        }
+
         @TestMetadata("Reified.kt")
         public void testReified() throws Exception {
             runTest("idea/testData/parameterInfo/typeArguments/Reified.kt");


### PR DESCRIPTION
Fixes [KT-41617](https://youtrack.jetbrains.com/issue/KT-41617).