### PR TITLE
Psi2Ir: Fix for SAM conversion with new inference

### DIFF
--- a/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
@@ -15065,6 +15065,11 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
             runTest("compiler/testData/codegen/box/javaInterop/genericSamProjectedOutWithNewInference.kt");
         }
 
+        @TestMetadata("genericSamSmartcast.kt")
+        public void testGenericSamSmartcast() throws Exception {
+            runTest("compiler/testData/codegen/box/javaInterop/genericSamSmartcast.kt");
+        }
+
         @TestMetadata("lambdaInstanceOf.kt")
         public void testLambdaInstanceOf() throws Exception {
             runTest("compiler/testData/codegen/box/javaInterop/lambdaInstanceOf.kt");

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/ExternalDependenciesGenerator.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/ExternalDependenciesGenerator.kt
@@ -16,7 +16,6 @@
 
 package org.jetbrains.kotlin.ir.util
 
-import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.config.LanguageVersionSettings
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.ir.declarations.IrDeclaration
@@ -32,11 +31,6 @@ class ExternalDependenciesGenerator(
     private val languageVersionSettings: LanguageVersionSettings
 ) {
     fun generateUnboundSymbolsAsDependencies() {
-        if (languageVersionSettings.supportsFeature(LanguageFeature.NewInference)) {
-            require(symbolTable.unboundTypeParameters.isEmpty()) {
-                "Unbound type parameters are forbidden: ${symbolTable.unboundTypeParameters}"
-            }
-        }
         // There should be at most one DeclarationStubGenerator (none in closed world?)
         irProviders.singleOrNull { it is DeclarationStubGenerator }?.let {
             (it as DeclarationStubGenerator).unboundSymbolGeneration = true

--- a/compiler/testData/codegen/box/javaInterop/genericSamProjectedOutWithNewInference.kt
+++ b/compiler/testData/codegen/box/javaInterop/genericSamProjectedOutWithNewInference.kt
@@ -1,6 +1,4 @@
 // TARGET_BACKEND: JVM
-// IGNORE_BACKEND: JVM_IR
-
 // FILE: example/Hello.java
 
 package example;

--- a/compiler/testData/codegen/box/javaInterop/genericSamSmartcast.kt
+++ b/compiler/testData/codegen/box/javaInterop/genericSamSmartcast.kt
@@ -1,0 +1,21 @@
+// TARGET_BACKEND: JVM
+// FILE: A.java
+public class A<T> {
+    public interface I<T> {
+        String apply(T x);
+    }
+
+    public String call(I<T> block) { return block.apply(null); }
+}
+
+// FILE: test.kt
+fun f(x: Any): String {
+    if (x is A<*>) {
+        return x.call { y: Any? -> "OK" }
+    }
+    return "Fail"
+}
+
+fun box(): String {
+    return f(A<Int>())
+}

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -16290,6 +16290,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             runTest("compiler/testData/codegen/box/javaInterop/genericSamProjectedOutWithNewInference.kt");
         }
 
+        @TestMetadata("genericSamSmartcast.kt")
+        public void testGenericSamSmartcast() throws Exception {
+            runTest("compiler/testData/codegen/box/javaInterop/genericSamSmartcast.kt");
+        }
+
         @TestMetadata("lambdaInstanceOf.kt")
         public void testLambdaInstanceOf() throws Exception {
             runTest("compiler/testData/codegen/box/javaInterop/lambdaInstanceOf.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -16290,6 +16290,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/javaInterop/genericSamProjectedOutWithNewInference.kt");
         }
 
+        @TestMetadata("genericSamSmartcast.kt")
+        public void testGenericSamSmartcast() throws Exception {
+            runTest("compiler/testData/codegen/box/javaInterop/genericSamSmartcast.kt");
+        }
+
         @TestMetadata("lambdaInstanceOf.kt")
         public void testLambdaInstanceOf() throws Exception {
             runTest("compiler/testData/codegen/box/javaInterop/lambdaInstanceOf.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -15065,6 +15065,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             runTest("compiler/testData/codegen/box/javaInterop/genericSamProjectedOutWithNewInference.kt");
         }
 
+        @TestMetadata("genericSamSmartcast.kt")
+        public void testGenericSamSmartcast() throws Exception {
+            runTest("compiler/testData/codegen/box/javaInterop/genericSamSmartcast.kt");
+        }
+
         @TestMetadata("lambdaInstanceOf.kt")
         public void testLambdaInstanceOf() throws Exception {
             runTest("compiler/testData/codegen/box/javaInterop/lambdaInstanceOf.kt");


### PR DESCRIPTION
This is a fix for (part of?) the issue underlying [KT-41268](https://youtrack.jetbrains.com/issue/KT-41268).

In code such as
```java
public class A<T> {
    public interface I<T> {
        String apply(T x);
    }

    public String call(I<T> block) { return block.apply(null); }
}
```
```kotlin
(x as A<*>).call { y: Any? -> "OK" }
```
The argument to `A.call` is approximated to `Nothing`, yet the SAM conversion succeeds, since the underlying function type is approximated to `(Any?) -> String`. In such cases we cannot rely on the type information in `NewResolvedCallImpl` when using new inference and need to fall back to the same code which handles SAM conversion for old inference.

This is consistent with the JVM backend. See e.g., [CodegenAnnotatingVisitor.java:799-801](https://github.com/JetBrains/kotlin/blob/5b53663eb8893109723a7df3f31dadc18c606448/compiler/backend/src/org/jetbrains/kotlin/codegen/binding/CodegenAnnotatingVisitor.java#L799).