### PR TITLE
Move getColon from KtClass to KtClassOrObject

### DIFF
--- a/compiler/psi/src/org/jetbrains/kotlin/psi/KtClass.kt
+++ b/compiler/psi/src/org/jetbrains/kotlin/psi/KtClass.kt
@@ -23,8 +23,6 @@ open class KtClass : KtClassOrObject {
     private val _stub: KotlinClassStub?
         get() = stub as? KotlinClassStub
 
-    fun getColon(): PsiElement? = findChildByType(KtTokens.COLON)
-
     fun getProperties(): List<KtProperty> = body?.properties.orEmpty()
 
     fun isInterface(): Boolean =

--- a/compiler/psi/src/org/jetbrains/kotlin/psi/KtClassOrObject.kt
+++ b/compiler/psi/src/org/jetbrains/kotlin/psi/KtClassOrObject.kt
@@ -35,6 +35,8 @@ abstract class KtClassOrObject :
     constructor(node: ASTNode) : super(node)
     constructor(stub: KotlinClassOrObjectStub<out KtClassOrObject>, nodeType: IStubElementType<*, *>) : super(stub, nodeType)
 
+    fun getColon(): PsiElement? = findChildByType(KtTokens.COLON)
+
     fun getSuperTypeList(): KtSuperTypeList? = getStubOrPsiChild(KtStubElementTypes.SUPER_TYPE_LIST)
 
     override fun getSuperTypeListEntries(): List<KtSuperTypeListEntry> = getSuperTypeList()?.entries.orEmpty()
@@ -61,7 +63,7 @@ abstract class KtClassOrObject :
         if (specifierList.entries.size > 1) {
             EditCommaSeparatedListHelper.removeItem<KtElement>(superTypeListEntry)
         } else {
-            deleteChildRange(findChildByType<PsiElement>(KtTokens.COLON) ?: specifierList, specifierList)
+            deleteChildRange(getColon() ?: specifierList, specifierList)
         }
     }
 


### PR DESCRIPTION
Currently it is only possible to get the colon(`:`) from classes.
This changes makes it possible to retrieve the colon from KtObjectDeclarations as well.