### PR TITLE
KT-41499 "Convert receiver to parameter" produces code with incorrect order of generic type and function invocation  in case of generic function with lambda as a parameter

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/usages/KotlinFunctionCallUsage.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/usages/KotlinFunctionCallUsage.kt
@@ -77,8 +77,9 @@ class KotlinFunctionCallUsage(
         changeNameIfNeeded(changeInfo, element)
 
         if (element.valueArgumentList == null && changeInfo.isParameterSetOrOrderChanged && element.lambdaArguments.isNotEmpty()) {
-            element.calleeExpression?.let {
-                element.addAfter(KtPsiFactory(element).createCallArguments("()"), it)
+            val anchor = element.typeArgumentList ?: element.calleeExpression
+            if (anchor != null) {
+                element.addAfter(KtPsiFactory(element).createCallArguments("()"), anchor)
             }
         }
         if (element.valueArgumentList != null) {

--- a/idea/testData/intentions/convertReceiverToParameter/usedWithTypeArgumentAndLambdaArgument.kt
+++ b/idea/testData/intentions/convertReceiverToParameter/usedWithTypeArgumentAndLambdaArgument.kt
@@ -1,0 +1,5 @@
+fun <T> <caret>Any.foo(callback: () -> Unit) {}
+
+fun bar() {
+    "".foo<Int> {}
+}

--- a/idea/testData/intentions/convertReceiverToParameter/usedWithTypeArgumentAndLambdaArgument.kt.after
+++ b/idea/testData/intentions/convertReceiverToParameter/usedWithTypeArgumentAndLambdaArgument.kt.after
@@ -1,0 +1,5 @@
+fun <T> foo(any: Any, callback: () -> Unit) {}
+
+fun bar() {
+    foo<Int>("") {}
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -6407,6 +6407,11 @@ public class IntentionTestGenerated extends AbstractIntentionTest {
             runTest("idea/testData/intentions/convertReceiverToParameter/usedInAnonymousObject.kt");
         }
 
+        @TestMetadata("usedWithTypeArgumentAndLambdaArgument.kt")
+        public void testUsedWithTypeArgumentAndLambdaArgument() throws Exception {
+            runTest("idea/testData/intentions/convertReceiverToParameter/usedWithTypeArgumentAndLambdaArgument.kt");
+        }
+
         @TestMetadata("validOverload.kt")
         public void testValidOverload() throws Exception {
             runTest("idea/testData/intentions/convertReceiverToParameter/validOverload.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-41499