### PR TITLE
Introduce plugin for incremental not null verification of Java in our…

### DIFF
--- a/libraries/tools/kotlin-project-build-internal-helper-plugin/build.gradle.kts
+++ b/libraries/tools/kotlin-project-build-internal-helper-plugin/build.gradle.kts
@@ -1,0 +1,41 @@
+
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.jetbrains.kotlin.pill.PillExtension
+
+plugins {
+    java
+    kotlin("jvm")
+    `java-gradle-plugin`
+    id("jps-compatible")
+}
+
+pill {
+    variant = PillExtension.Variant.FULL
+}
+
+fun DependencyHandler.compileEmbedded(dependencyNotation: String, fn: ExternalModuleDependency.() -> Unit) {
+    embedded(dependencyNotation) { fn() }
+    compileOnly(dependencyNotation) { fn() }
+}
+
+dependencies {
+    implementation(gradleApi())
+    implementation(kotlinStdlib())
+    compileEmbedded(intellijDep()) {
+        isTransitive = false
+        includeJars( "javac2", "asm-all", rootProject = rootProject)
+    }
+    testImplementation("junit:junit:4.12")
+}
+
+tasks.named("jar") {
+    enabled = false
+}
+val shadowJar = tasks.register<ShadowJar>("shadowJar") {
+    from(mainSourceSet.output)
+}
+
+publish()
+sourcesJar()
+javadocJar()
+runtimeJar(shadowJar)

--- a/libraries/tools/kotlin-project-build-internal-helper-plugin/src/main/kotlin/org/jetbrains/kotlin/internal/build/instrumentation/InstrumentationArgs.kt
+++ b/libraries/tools/kotlin-project-build-internal-helper-plugin/src/main/kotlin/org/jetbrains/kotlin/internal/build/instrumentation/InstrumentationArgs.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.internal.build.instrumentation
+
+import java.io.File
+import java.io.ObjectInputStream
+import java.io.ObjectOutputStream
+import java.net.URL
+import java.util.ArrayList
+
+internal class InstrumentationArgs(
+    val filesToProcess: List<File>,
+    val classpathFiles: List<File>,
+    var javaHome: File
+) {
+    companion object {
+        fun writeToFile(args: InstrumentationArgs, file: File) {
+            ObjectOutputStream(file.outputStream().buffered()).use { out ->
+                writeFiles(out, args.filesToProcess)
+                writeFiles(out, args.classpathFiles)
+                out.writeUTF(args.javaHome.absolutePath)
+            }
+        }
+
+        fun readFromFile(file: File): InstrumentationArgs =
+            ObjectInputStream(file.inputStream().buffered()).use { input ->
+                val filesToProcess = readFiles(input)
+                val classpathFiles = readFiles(input)
+                val javaHome = File(input.readUTF())
+                InstrumentationArgs(filesToProcess = filesToProcess, classpathFiles = classpathFiles, javaHome = javaHome)
+            }
+
+        private fun writeFiles(out: ObjectOutputStream, files: List<File>) {
+            out.writeInt(files.size)
+            files.forEach {
+                out.writeUTF(it.absolutePath)
+            }
+        }
+
+        private fun readFiles(input: ObjectInputStream): List<File> {
+            val size = input.readInt()
+            return ArrayList<File>(size).also { files ->
+                repeat(size) {
+                    files.add(File(input.readUTF()))
+                }
+            }
+        }
+    }
+}

--- a/libraries/tools/kotlin-project-build-internal-helper-plugin/src/main/kotlin/org/jetbrains/kotlin/internal/build/instrumentation/JavaRuntimeURLs.kt
+++ b/libraries/tools/kotlin-project-build-internal-helper-plugin/src/main/kotlin/org/jetbrains/kotlin/internal/build/instrumentation/JavaRuntimeURLs.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.internal.build.instrumentation
+
+import java.io.File
+import java.net.URL
+import java.util.ArrayList
+import java.util.HashMap
+
+internal object JavaRuntimeURLs {
+    private val javaRuntimeFilesCache = HashMap<File, List<URL>>()
+
+    fun hasJrt(javaHome: File): Boolean = javaHome.resolve("lib/jrt-fs.jar").isFile
+
+    fun get(javaHome: File): List<URL> =
+        javaRuntimeFilesCache.getOrPut(javaHome) {
+            val urls = ArrayList<URL>()
+
+            arrayOf("lib/rt.jar", "jre/lib/rt.jar", "bundle/Classes/classes.jar")
+                .map { javaHome.resolve(it) }
+                .filter { it.isFile }
+                .mapTo(urls) { it.toURI().toURL() }
+
+            if (hasJrt(javaHome)) {
+                urls.add(URL("jrt", null, javaHome.path.replace(File.separatorChar, '/')))
+            }
+
+            if (urls.isEmpty()) throw RuntimeException("Could not find Java runtime for Java home: $javaHome")
+            urls
+        }
+
+}

--- a/libraries/tools/kotlin-project-build-internal-helper-plugin/src/main/kotlin/org/jetbrains/kotlin/internal/build/instrumentation/NotNullVerifierPlugin.kt
+++ b/libraries/tools/kotlin-project-build-internal-helper-plugin/src/main/kotlin/org/jetbrains/kotlin/internal/build/instrumentation/NotNullVerifierPlugin.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.internal.build.instrumentation
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.tasks.compile.JavaCompile
+import java.io.File
+import kotlin.system.measureTimeMillis
+
+open class NotNullVerifierPlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        project.tasks.withType(JavaCompile::class.java).configureEach { javaCompile ->
+            addNotNullInstrumentationToOutputClasses(javaCompile)
+        }
+    }
+}
+
+internal data class FileSnapshot(val file: File, val lastModified: Long, val size: Long) {
+    constructor(file: File) : this(file = file, lastModified = file.lastModified(), size = file.length())
+}
+
+internal fun addNotNullInstrumentationToOutputClasses(javaCompile: JavaCompile) {
+    val snapshots = HashMap<File, FileSnapshot>()
+    var walkTimeMs = 0L
+    fun forEachOutputClassFile(fn: (File) -> Unit) {
+        walkTimeMs += measureTimeMillis {
+            for (file in javaCompile.destinationDir.walk().filter { it.isFile && it.endsWith(".class") }) {
+                fn(file)
+            }
+        }
+    }
+
+    javaCompile.doFirst {
+        forEachOutputClassFile {
+            snapshots[it] = FileSnapshot(it)
+        }
+    }
+
+    javaCompile.doLast("instrument java classes") {
+        forEachOutputClassFile {
+            val curr = FileSnapshot(it)
+            val prev = snapshots[it]
+
+            if (curr == prev) {
+                // we want to instrument only files with different snapshots
+                snapshots.remove(it)
+            }
+        }
+        val filesToInstrument = snapshots.keys
+        val log = javaCompile.logger
+        log.info("Determined files to instrument in $walkTimeMs ms")
+        log.info("Started adding not-null instrumentation to ${filesToInstrument.size} class files...")
+        if (log.isDebugEnabled) {
+            log.debug("Files to be instrumented: \n${filesToInstrument.map { it.path }.sorted().joinToString("\n")}")
+        }
+        val instrumentationTimeMs = measureTimeMillis {
+            addNotNullVerification(
+                project = javaCompile.project,
+                filesToProcess = filesToInstrument,
+                classpath = javaCompile.classpath.files,
+                javaHome = javaCompile.options.forkOptions.javaHome
+                    ?: File(System.getProperty("java.home")!!)
+            )
+        }
+        log.info("Finished adding not-null instrumentation to ${filesToInstrument.size} class files in $instrumentationTimeMs ms")
+    }
+}

--- a/libraries/tools/kotlin-project-build-internal-helper-plugin/src/main/kotlin/org/jetbrains/kotlin/internal/build/instrumentation/PluginClasspath.kt
+++ b/libraries/tools/kotlin-project-build-internal-helper-plugin/src/main/kotlin/org/jetbrains/kotlin/internal/build/instrumentation/PluginClasspath.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.internal.build.instrumentation
+
+import org.gradle.api.Project
+import java.io.File
+
+internal object PluginClasspath {
+    private var pluginClasspath: List<File>? = null
+
+    fun get(project: Project): List<File> {
+        if (pluginClasspath != null) return pluginClasspath!!
+
+        val buildscriptClasspath = project.rootProject.buildscript.configurations.getByName("classpath")
+        val pluginDependency = buildscriptClasspath.resolvedConfiguration.firstLevelModuleDependencies.first {
+            it.moduleGroup == "org.jetbrains.kotlin" && it.moduleName == "kotlin-project-build-internal-helper-plugin"
+        }
+        val classpath = pluginDependency.allModuleArtifacts.map { it.file }
+        pluginClasspath = classpath
+        return classpath
+    }
+}

--- a/libraries/tools/kotlin-project-build-internal-helper-plugin/src/main/kotlin/org/jetbrains/kotlin/internal/build/instrumentation/instrumentFiles.kt
+++ b/libraries/tools/kotlin-project-build-internal-helper-plugin/src/main/kotlin/org/jetbrains/kotlin/internal/build/instrumentation/instrumentFiles.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+package org.jetbrains.kotlin.internal.build.instrumentation
+
+import com.intellij.compiler.instrumentation.FailSafeClassReader
+import com.intellij.compiler.instrumentation.InstrumentationClassFinder
+import com.intellij.compiler.instrumentation.InstrumenterClassWriter
+import com.intellij.compiler.notNullVerification.NotNullVerifyingInstrumenter
+import org.gradle.api.JavaVersion
+import org.gradle.api.Project
+import org.gradle.internal.os.OperatingSystem
+import org.jetbrains.org.objectweb.asm.ClassWriter
+import java.io.File
+import java.net.URL
+import java.nio.file.Files
+import kotlin.collections.ArrayList
+
+private val notNullAnnotations = arrayOf("org.jetbrains.annotations.NotNull")
+
+internal fun addNotNullVerification(
+    project: Project,
+    filesToProcess: Set<File>,
+    classpath: Iterable<File>,
+    javaHome: File
+) {
+    val instrumentationArgs = InstrumentationArgs(
+        filesToProcess = filesToProcess.toList(), classpathFiles = classpath.toList(), javaHome = javaHome
+    )
+
+    if (JavaRuntimeURLs.hasJrt(javaHome) && JavaVersion.current() < JavaVersion.VERSION_1_9) {
+        instrumentOutOfProcess(instrumentationArgs, project)
+    } else {
+        instrumentInProcess(instrumentationArgs)
+    }
+}
+
+private fun instrumentOutOfProcess(
+    instrumentationArgs: InstrumentationArgs,
+    project: Project
+) {
+    val argFile = Files.createTempFile("instrumentation-args", ".bin").toFile()
+    try {
+        InstrumentationArgs.writeToFile(instrumentationArgs, argFile)
+        project.javaexec { spec ->
+            val executableName = if (OperatingSystem.current().isWindows) "java.exe" else "java"
+            spec.executable = instrumentationArgs.javaHome.resolve("bin/$executableName").path
+            spec.classpath = project.files(PluginClasspath.get(project))
+            spec.main = NotNullInstrumentationCliFacade::class.java.canonicalName
+            spec.args = listOf(argFile.absolutePath)
+        }
+    } finally {
+        argFile.delete()
+    }
+}
+
+object NotNullInstrumentationCliFacade {
+    @JvmStatic
+    fun main(args: Array<String>) {
+        val argFile = File(args.single())
+        val instrumentationArgs = InstrumentationArgs.readFromFile(argFile)
+        instrumentInProcess(instrumentationArgs)
+    }
+}
+
+private fun instrumentInProcess(args: InstrumentationArgs) {
+    val classpathURLs = ArrayList<URL>()
+    args.classpathFiles.mapTo(classpathURLs) { it.toURI().toURL() }
+    classpathURLs.addAll(JavaRuntimeURLs.get(args.javaHome))
+
+    val inputBytes = args.filesToProcess.associateWith { it.readBytes() }
+    val finder = InstrumentationClassFinder(classpathURLs.toTypedArray())
+    val outputBytes = args.filesToProcess.associateWith {
+        val classReader = FailSafeClassReader(inputBytes[it])
+        val classWriter = InstrumenterClassWriter(ClassWriter.COMPUTE_FRAMES, finder)
+        NotNullVerifyingInstrumenter.processClassFile(classReader, classWriter, notNullAnnotations)
+        classWriter.toByteArray()
+    }
+    for ((file, bytes) in outputBytes) {
+        file.writeBytes(bytes)
+    }
+}

--- a/libraries/tools/kotlin-project-build-internal-helper-plugin/src/main/resources/META-INF/gradle-plugins/org.jetbrains.kotlin.internal.build.not.null.instrumentation.properties
+++ b/libraries/tools/kotlin-project-build-internal-helper-plugin/src/main/resources/META-INF/gradle-plugins/org.jetbrains.kotlin.internal.build.not.null.instrumentation.properties
@@ -1,0 +1,1 @@
+implementation-class=org.jetbrains.kotlin.internal.build.instrumentation.NotNullVerifierPlugin

--- a/settings.gradle
+++ b/settings.gradle
@@ -318,6 +318,8 @@ include ":compiler:fir:cones",
         ":compiler:fir:entrypoint",
         ":compiler:fir:analysis-tests"
 
+include ":kotlin-project-build-internal-helper-plugin"
+
 include ":idea:idea-frontend-fir:idea-fir-low-level-api"
 
 include ":prepare:ide-plugin-dependencies:android-extensions-compiler-plugin-for-ide",
@@ -541,6 +543,7 @@ project(':examples:scripting-jvm-embeddable-host').projectDir = "$rootDir/librar
 project(':pill:pill-importer').projectDir = "$rootDir/plugins/pill/pill-importer" as File
 project(':pill:generate-all-tests').projectDir = "$rootDir/plugins/pill/generate-all-tests" as File
 project(':kotlin-imports-dumper-compiler-plugin').projectDir = "$rootDir/plugins/imports-dumper" as File
+project(':kotlin-project-build-internal-helper-plugin').projectDir = "$rootDir/libraries/tools/kotlin-project-build-internal-helper-plugin/" as File
 project(':libraries:kotlin-prepush-hook').projectDir = "$rootDir/libraries/tools/kotlin-prepush-hook" as File
 project(':plugins:jvm-abi-gen').projectDir = "$rootDir/plugins/jvm-abi-gen" as File
 project(':plugins:jvm-abi-gen-embeddable').projectDir = "$rootDir/plugins/jvm-abi-gen/embeddable" as File


### PR DESCRIPTION
… build

Currently adding runtime not null verification
(for methods/args with NotNull annotation) is done non-incrementally
by calling ant task from IJ not null instrumenter in doLast callback of
every JavaCompile task (see gradle/javaInstrumentation.gradle.kts).

That way the instrumentation breaks Gradle Java IC:
it adds additional `checkNotNull<N>` methods into every class
that was not recompiled by the IC, which triggers Gradle Java IC
to consider a lot of files as affected by changes.
According to our benchmarks, this may result in
incremental builds being 2-3 times slower than clean builds.

In order to fix it, this commit introduces a new internal plugin,
which compares JavaCompile's output classes before and after
compilation. Then it performs the instrumentation only on changed
(recompiled) classes.

After bootstrapping the plugin should be used instead of
gradle/javaInstrumentation.gradle.kts script.

    #KTI-129