### PR TITLE
Update deprecated doc in project readme.md about mac brew tap

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -44,7 +44,7 @@ You also can use [Gradle properties](https://docs.gradle.org/current/userguide/b
 Note: The JDK 6 for MacOS is not available on Oracle's site. You can install it by
 
 ```bash
-$ brew tap caskroom/versions
+$ brew tap homebrew/cask-versions
 $ brew cask install java6
 ```
 


### PR DESCRIPTION
caskroom/versions moved to homebrew/cask-versions.

## How to reproduce
running
``` sh
$ brew tap caskroom/versions
```
in the command line outputs
``` sh
Error: caskroom/versions was moved. Tap homebrew/cask-versions instead.
```

## fix
run
``` sh
$ brew tap homebrew/cask-versions
```
instead.