### PR TITLE
FIR: map arguments for overloading indexed access operator

### DIFF
--- a/compiler/testData/codegen/box/defaultArguments/convention/incWithDefaults.kt
+++ b/compiler/testData/codegen/box/defaultArguments/convention/incWithDefaults.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: +ProperArrayConventionSetterWithDefaultCalls
-// IGNORE_BACKEND_FIR: JVM_IR
 var inc: String = ""
 
 class X {

--- a/compiler/testData/codegen/box/defaultArguments/convention/kt16520.kt
+++ b/compiler/testData/codegen/box/defaultArguments/convention/kt16520.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: +ProperArrayConventionSetterWithDefaultCalls
-// IGNORE_BACKEND_FIR: JVM_IR
 var result = "fail"
 
 class A {

--- a/compiler/testData/codegen/box/defaultArguments/convention/plusAssignWithDefaults.kt
+++ b/compiler/testData/codegen/box/defaultArguments/convention/plusAssignWithDefaults.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: +ProperArrayConventionSetterWithDefaultCalls
-// IGNORE_BACKEND_FIR: JVM_IR
 var inc: String = ""
 
 class X {

--- a/compiler/testData/diagnostics/tests/checkArguments/arrayAccessSet.fir.kt
+++ b/compiler/testData/diagnostics/tests/checkArguments/arrayAccessSet.fir.kt
@@ -21,12 +21,12 @@ object Z {
 }
 
 fun test() {
-    <!INAPPLICABLE_CANDIDATE!>A[0] = ""<!>
-    <!INAPPLICABLE_CANDIDATE!>A[0] = 2.72<!>
+    A[0] = ""
+    A[0] = 2.72
 
-    <!INAPPLICABLE_CANDIDATE!>B[0] = ""<!>
-    <!INAPPLICABLE_CANDIDATE!>B[0] = 2.72<!>
-    <!INAPPLICABLE_CANDIDATE!>B[0] = true<!>
+    B[0] = ""
+    B[0] = 2.72
+    B[0] = true
 
     <!INAPPLICABLE_CANDIDATE!>D[0] = ""<!>
     <!INAPPLICABLE_CANDIDATE!>D[0] = 2.72<!>

--- a/compiler/testData/diagnostics/tests/regressions/kt10633.fir.kt
+++ b/compiler/testData/diagnostics/tests/regressions/kt10633.fir.kt
@@ -11,9 +11,9 @@ operator fun Int.set(s: Int, x: String = "", z: Int) {
 }
 
 fun main() {
-    <!INAPPLICABLE_CANDIDATE!>1[2] = 1<!>
+    1[2] = 1
     1.set(2, z = 1)
     1[2] += 1
 
-    1.<!INAPPLICABLE_CANDIDATE!>set<!>(2, 1)
+    1.set(2, 1)
 }

--- a/compiler/testData/ir/irText/expressions/kt28456b.fir.txt
+++ b/compiler/testData/ir/irText/expressions/kt28456b.fir.txt
@@ -47,9 +47,10 @@ FILE fqName:<root> fileName:/kt28456b.kt
   FUN name:testSimpleAssignment visibility:public modality:FINAL <> (a:<root>.A) returnType:kotlin.Unit
     VALUE_PARAMETER name:a index:0 type:<root>.A
     BLOCK_BODY
-      ERROR_CALL 'Unresolved reference: <Inapplicable(INAPPLICABLE_ARGUMENTS_MAPPING_ERROR): /set>#' type=kotlin.Unit
-        CONST Int type=kotlin.Int value=1
-        CONST Int type=kotlin.Int value=0
+      CALL 'public final fun set (i: kotlin.Int, j: kotlin.Int, v: kotlin.Int): kotlin.Unit [operator] declared in <root>' type=kotlin.Unit origin=null
+        $receiver: GET_VAR 'a: <root>.A declared in <root>.testSimpleAssignment' type=<root>.A origin=null
+        i: CONST Int type=kotlin.Int value=1
+        v: CONST Int type=kotlin.Int value=0
   FUN name:testPostfixIncrement visibility:public modality:FINAL <> (a:<root>.A) returnType:kotlin.Int
     VALUE_PARAMETER name:a index:0 type:<root>.A
     BLOCK_BODY
@@ -59,9 +60,10 @@ FILE fqName:<root> fileName:/kt28456b.kt
             CALL 'public final fun get (i: kotlin.Int, a: kotlin.Int, b: kotlin.Int, c: kotlin.Int, d: kotlin.Int): kotlin.Int [operator] declared in <root>' type=kotlin.Int origin=null
               $receiver: GET_VAR 'a: <root>.A declared in <root>.testPostfixIncrement' type=<root>.A origin=null
               i: CONST Int type=kotlin.Int value=1
-          ERROR_CALL 'Unresolved reference: <Inapplicable(INAPPLICABLE_ARGUMENTS_MAPPING_ERROR): /set>#' type=kotlin.Unit
-            CONST Int type=kotlin.Int value=1
-            CALL 'public final fun inc (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
+          CALL 'public final fun set (i: kotlin.Int, j: kotlin.Int, v: kotlin.Int): kotlin.Unit [operator] declared in <root>' type=kotlin.Unit origin=null
+            $receiver: GET_VAR 'a: <root>.A declared in <root>.testPostfixIncrement' type=<root>.A origin=null
+            i: CONST Int type=kotlin.Int value=1
+            v: CALL 'public final fun inc (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
               $this: GET_VAR 'val tmp_0: kotlin.Int [val] declared in <root>.testPostfixIncrement' type=kotlin.Int origin=null
           GET_VAR 'val tmp_0: kotlin.Int [val] declared in <root>.testPostfixIncrement' type=kotlin.Int origin=null
   FUN name:testCompoundAssignment visibility:public modality:FINAL <> (a:<root>.A) returnType:kotlin.Unit
@@ -72,9 +74,10 @@ FILE fqName:<root> fileName:/kt28456b.kt
           GET_VAR 'a: <root>.A declared in <root>.testCompoundAssignment' type=<root>.A origin=null
         VAR IR_TEMPORARY_VARIABLE name:tmp_2 type:kotlin.Int [val]
           CONST Int type=kotlin.Int value=1
-        ERROR_CALL 'Unresolved reference: <Inapplicable(INAPPLICABLE_ARGUMENTS_MAPPING_ERROR): /set>#' type=kotlin.Unit
-          GET_VAR 'val tmp_2: kotlin.Int [val] declared in <root>.testCompoundAssignment' type=kotlin.Int origin=null
-          CALL 'public final fun plus (other: kotlin.Int): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
+        CALL 'public final fun set (i: kotlin.Int, j: kotlin.Int, v: kotlin.Int): kotlin.Unit [operator] declared in <root>' type=kotlin.Unit origin=null
+          $receiver: GET_VAR 'val tmp_1: <root>.A [val] declared in <root>.testCompoundAssignment' type=<root>.A origin=null
+          i: GET_VAR 'val tmp_2: kotlin.Int [val] declared in <root>.testCompoundAssignment' type=kotlin.Int origin=null
+          v: CALL 'public final fun plus (other: kotlin.Int): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
             $this: CALL 'public final fun get (i: kotlin.Int, a: kotlin.Int, b: kotlin.Int, c: kotlin.Int, d: kotlin.Int): kotlin.Int [operator] declared in <root>' type=kotlin.Int origin=null
               $receiver: GET_VAR 'val tmp_1: <root>.A [val] declared in <root>.testCompoundAssignment' type=<root>.A origin=null
               i: GET_VAR 'val tmp_2: kotlin.Int [val] declared in <root>.testCompoundAssignment' type=kotlin.Int origin=null


### PR DESCRIPTION
Users can be overloading [Indexed access operator](https://kotlinlang.org/docs/reference/operator-overloading.html#indexed), and in that case, for `setter`, the last parameter is supposed to be the updated value. By wrapping that one as a named argument, we can handle any other parameters in the middle, which could have default values.