### PR TITLE
KT-41295: Friend paths and compiler options compatible with conf caching

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/ConfigurationCacheForAndroidIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/ConfigurationCacheForAndroidIT.kt
@@ -41,6 +41,12 @@ class ConfigurationCacheForAndroidIT : AbstractConfigurationCacheIT() {
         testConfigurationCacheOf(":Lib:compileFlavor1DebugKotlin", ":Android:compileFlavor1DebugKotlin")
     }
 
+    @Test
+    fun testKotlinAndroidProjectTests() = with(Project("AndroidIncrementalMultiModule")) {
+        applyAndroid40Alpha4KotlinVersionWorkaround()
+        testConfigurationCacheOf(":app:compileDebugAndroidTestKotlin", ":app:compileDebugUnitTestKotlin")
+    }
+
     /**
      * Android Gradle plugin 4.0-alpha4 depends on the EAP versions of some o.j.k modules.
      * Force the current Kotlin version, so the EAP versions are not queried from the

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidIncrementalMultiModule/app/src/androidTest/kotlin/Main.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidIncrementalMultiModule/app/src/androidTest/kotlin/Main.kt
@@ -1,0 +1,10 @@
+import com.example.AppDummy
+
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+fun main(args: Array<String>) {
+    println(AppDummy())
+} 

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidIncrementalMultiModule/app/src/test/kotlin/Main.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidIncrementalMultiModule/app/src/test/kotlin/Main.kt
@@ -1,0 +1,10 @@
+import com.example.AppDummy
+
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+fun main(args: Array<String>) {
+    println(AppDummy())
+} 

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/CompilerArgumentsContributor.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/CompilerArgumentsContributor.kt
@@ -99,7 +99,7 @@ internal open class KotlinJvmCompilerArgumentsContributor(
         args.moduleName = moduleName
         logger.kotlinDebug { "args.moduleName = ${args.moduleName}" }
 
-        args.friendPaths = friendPaths
+        args.friendPaths = friendPaths.files.map { it.absolutePath }.toTypedArray()
         logger.kotlinDebug { "args.friendPaths = ${args.friendPaths?.joinToString() ?: "[]"}" }
 
         if (DefaultsOnly in flags) return

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/KotlinCompileCommon.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/KotlinCompileCommon.kt
@@ -70,7 +70,7 @@ open class KotlinCompileCommon : AbstractKotlinCompile<K2MetadataCompilerArgumen
             classpath = classpathList.joinToString(File.pathSeparator)
             destination = destinationDir.canonicalPath
 
-            friendPaths = this@KotlinCompileCommon.friendPaths
+            friendPaths = this@KotlinCompileCommon.friendPaths.files.map { it.absolutePath }.toTypedArray()
             refinesPaths = refinesMetadataPaths.map { it.absolutePath }.toTypedArray()
         }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/Tasks.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/Tasks.kt
@@ -288,15 +288,17 @@ abstract class AbstractKotlinCompile<T : CommonCompilerArguments>() : AbstractKo
     }
 
     @get:Internal // takes part in the compiler arguments
-    val friendPaths: Array<String> by project.provider {
-        taskData.compilation.run {
-            if (this !is AbstractKotlinCompilation<*>) return@run emptyArray<String>()
-            associateWithTransitiveClosure
-                .flatMap { it.output.classesDirs }
-                .plus(friendArtifacts)
-                .map { it.absolutePath }.toTypedArray()
+    val friendPaths: FileCollection = project.files(
+        project.provider {
+            taskData.compilation.run {
+                if (this !is AbstractKotlinCompilation<*>) return@run project.files()
+                mutableListOf<FileCollection>().also { allCollections ->
+                    associateWithTransitiveClosure.forEach { allCollections.add(it.output.classesDirs) }
+                    allCollections.add(friendArtifacts)
+                }
+            }
         }
-    }
+    )
 
     private val kotlinLogger by lazy { GradleKotlinLogger(logger) }
 
@@ -415,7 +417,7 @@ class KotlinJvmCompilerArgumentsProvider
     (taskProvider: KotlinCompile) : KotlinCompileArgumentsProvider<KotlinCompile>(taskProvider) {
 
     val moduleName: String
-    val friendPaths: Array<String>
+    val friendPaths: FileCollection
     val compileClasspath: Iterable<File>
     val destinationDir: File
     internal val kotlinOptions: List<KotlinJvmOptionsImpl?>
@@ -643,10 +645,9 @@ open class Kotlin2JsCompile : AbstractKotlinCompile<K2JSCompilerArguments>(), Ko
     internal val friendDependencies: List<String>
         get() {
             val filter = libraryFilter
-            return friendPaths.filter {
-                val file = File(it)
-                file.exists() && filter(file)
-            }
+            return friendPaths.files.filter {
+                it.exists() && filter(it)
+            }.map { it.absolutePath }
         }
 
     @Suppress("unused")


### PR DESCRIPTION
This change fixes serialization of friend paths and it uses
a file collection to record all friend paths. Also, when
computing the tested classpath for android projects, we now avoid
resolving the file collection until necessary.

In addition to this, this starts removal of cross-task references.
More specifically, KaptGenerateStubsTask is using its own
compilerArgumentsContributor and it does not rely on the
KotlinCompile one.

Fixes: KT-41295
Test: ConfigurationCacheForAndroidIT