### PR TITLE
Use StringBuilder in String.replace (2x faster)

### DIFF
--- a/libraries/stdlib/jvm/src/kotlin/text/StringsJVM.kt
+++ b/libraries/stdlib/jvm/src/kotlin/text/StringsJVM.kt
@@ -61,10 +61,14 @@ public actual fun String?.equals(other: String?, ignoreCase: Boolean = false): B
  */
 @Suppress("ACTUAL_FUNCTION_WITH_DEFAULT_ARGUMENTS")
 public actual fun String.replace(oldChar: Char, newChar: Char, ignoreCase: Boolean = false): String {
-    if (!ignoreCase)
-        return (this as java.lang.String).replace(oldChar, newChar)
-    else
-        return splitToSequence(oldChar, ignoreCase = ignoreCase).joinToString(separator = newChar.toString())
+    // prefer case-insensitive platform implementation
+    if (!ignoreCase) return (this as java.lang.String).replace(oldChar, newChar)
+
+    return buildString(length) {
+        this@replace.forEach { c ->
+            append(if (c.equals(oldChar, ignoreCase)) newChar else c)
+        }
+    }
 }
 
 /**
@@ -72,9 +76,29 @@ public actual fun String.replace(oldChar: Char, newChar: Char, ignoreCase: Boole
  * with the specified [newValue] string.
  */
 @Suppress("ACTUAL_FUNCTION_WITH_DEFAULT_ARGUMENTS")
-public actual fun String.replace(oldValue: String, newValue: String, ignoreCase: Boolean = false): String =
-    splitToSequence(oldValue, ignoreCase = ignoreCase).joinToString(separator = newValue)
+public actual fun String.replace(oldValue: String, newValue: String, ignoreCase: Boolean = false): String {
+    // prefer case-insensitive platform implementation
+    if (!ignoreCase) return (this as java.lang.String).replace(oldValue, newValue)
 
+    var occurrenceIndex: Int = indexOf(oldValue, 0, ignoreCase)
+    // FAST PATH: no match
+    if (occurrenceIndex < 0) return this
+
+    val oldValueLength = oldValue.length
+    val searchStep = oldValueLength.coerceAtLeast(1)
+    val newLengthHint = length - oldValueLength + newValue.length
+    if (newLengthHint < 0) throw OutOfMemoryError()
+    val stringBuilder = StringBuilder(newLengthHint)
+
+    var i = 0
+    do {
+        stringBuilder.append(this, i, occurrenceIndex).append(newValue)
+        i = occurrenceIndex + oldValueLength
+        if (occurrenceIndex >= length) break
+        occurrenceIndex = indexOf(oldValue, occurrenceIndex + searchStep, ignoreCase)
+    } while (occurrenceIndex > 0)
+    return stringBuilder.append(this, i, length).toString()
+}
 
 /**
  * Returns a new string with the first occurrence of [oldChar] replaced with [newChar].


### PR DESCRIPTION
The current `String.replace` implementation use `splitToSequence`, it is pretty slow.

I made a test project to improve `String.replace`'s performance, available here: https://github.com/fvasco/kotlin-string-replace/blob/master/src/main/kotlin/org/sample/MyBenchmark.kt

Results are:

~~~
Benchmark                     Mode  Cnt        Score       Error  Units
MyBenchmark.replaceNew       thrpt    5  1412205,791 ± 12644,734  ops/s
MyBenchmark.replaceOriginal  thrpt    5   697439,698 ±  5664,105  ops/s
MyBenchmark.replaceRegex     thrpt    5  1098579,545 ± 11091,188  ops/s
~~~

The regex version is a little faster, but it can be considered in order to reduce the bytecode.
The `new` version is the case-insenditive translation of the Java native version.
In both version the platform implementation has been preferred in order to delegate the maintenance.

Original discussion here: https://discuss.kotlinlang.org/t/string-replace-implementation-is-very-poor/19026