### PR TITLE
[JVM IR] Do not add collection stubs on specialized implementations

### DIFF
--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/customListIterator.kt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/customListIterator.kt
@@ -1,0 +1,33 @@
+// Ensure the proper collection stubs are added, in
+// particular *not* when specialized implementations are provided.
+class MyList<E> : List<E> {
+    private val elements = ArrayList<E>()
+
+    class MyListIterator<E>(
+        private val list: ArrayList<E>,
+        start: Int,
+        private val end: Int
+    ) : ListIterator<E> {
+        var index = start
+        override fun hasNext() = index < end
+        override fun next() = list[index++]
+        override fun hasPrevious() = index > 0
+        override fun nextIndex() = index + 1
+        override fun previous() = list[--index]
+        override fun previousIndex() = index - 1
+    }
+
+    // List<E> implementation:
+    override fun listIterator(index: Int) = MyListIterator(elements, index, size)
+    override fun listIterator() = listIterator(0)
+    override fun iterator() = listIterator()
+
+    override val size get() = elements.size
+    override fun contains(element: E) = elements.contains(element)
+    override fun containsAll(elements: Collection<E>) = this.elements.containsAll(elements)
+    override operator fun get(index: Int) = elements[index]
+    override fun indexOf(element: E): Int = elements.indexOf(element)
+    override fun lastIndexOf(element: E): Int = elements.lastIndexOf(element)
+    override fun isEmpty() = elements.isEmpty()
+    override fun subList(fromIndex: Int, toIndex: Int) = elements.subList(fromIndex, toIndex)
+}

--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/customListIterator.txt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/customListIterator.txt
@@ -1,0 +1,55 @@
+@kotlin.Metadata
+public final class MyList$MyListIterator {
+    // source: 'customListIterator.kt'
+    private final field end: int
+    private field index: int
+    private final field list: java.util.ArrayList
+    public method <init>(@org.jetbrains.annotations.NotNull p0: java.util.ArrayList, p1: int, p2: int): void
+    public method add(p0: java.lang.Object): void
+    public final method getIndex(): int
+    public method hasNext(): boolean
+    public method hasPrevious(): boolean
+    public method next(): java.lang.Object
+    public method nextIndex(): int
+    public method previous(): java.lang.Object
+    public method previousIndex(): int
+    public method remove(): void
+    public method set(p0: java.lang.Object): void
+    public final method setIndex(p0: int): void
+    public final inner class MyList$MyListIterator
+}
+
+@kotlin.Metadata
+public final class MyList {
+    // source: 'customListIterator.kt'
+    private final field elements: java.util.ArrayList
+    public method <init>(): void
+    public method add(p0: int, p1: java.lang.Object): void
+    public method add(p0: java.lang.Object): boolean
+    public method addAll(p0: int, p1: java.util.Collection): boolean
+    public method addAll(p0: java.util.Collection): boolean
+    public method clear(): void
+    public method contains(p0: java.lang.Object): boolean
+    public method containsAll(@org.jetbrains.annotations.NotNull p0: java.util.Collection): boolean
+    public method get(p0: int): java.lang.Object
+    public method getSize(): int
+    public method indexOf(p0: java.lang.Object): int
+    public method isEmpty(): boolean
+    public @org.jetbrains.annotations.NotNull method iterator(): MyList$MyListIterator
+    public synthetic bridge method iterator(): java.util.Iterator
+    public method lastIndexOf(p0: java.lang.Object): int
+    public @org.jetbrains.annotations.NotNull method listIterator(): MyList$MyListIterator
+    public synthetic bridge method listIterator(): java.util.ListIterator
+    public @org.jetbrains.annotations.NotNull method listIterator(p0: int): MyList$MyListIterator
+    public synthetic bridge method listIterator(p0: int): java.util.ListIterator
+    public method remove(p0: int): java.lang.Object
+    public method remove(p0: java.lang.Object): boolean
+    public method removeAll(p0: java.util.Collection): boolean
+    public method retainAll(p0: java.util.Collection): boolean
+    public method set(p0: int, p1: java.lang.Object): java.lang.Object
+    public bridge final method size(): int
+    public @org.jetbrains.annotations.NotNull method subList(p0: int, p1: int): java.util.List
+    public method toArray(): java.lang.Object[]
+    public method toArray(p0: java.lang.Object[]): java.lang.Object[]
+    public final inner class MyList$MyListIterator
+}

--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/customListIterator_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/customListIterator_ir.txt
@@ -1,0 +1,55 @@
+@kotlin.Metadata
+public final class MyList$MyListIterator {
+    // source: 'customListIterator.kt'
+    private final field end: int
+    private field index: int
+    private final @org.jetbrains.annotations.NotNull field list: java.util.ArrayList
+    public method <init>(@org.jetbrains.annotations.NotNull p0: java.util.ArrayList, p1: int, p2: int): void
+    public method add(p0: java.lang.Object): void
+    public final method getIndex(): int
+    public method hasNext(): boolean
+    public method hasPrevious(): boolean
+    public method next(): java.lang.Object
+    public method nextIndex(): int
+    public method previous(): java.lang.Object
+    public method previousIndex(): int
+    public method remove(): void
+    public method set(p0: java.lang.Object): void
+    public final method setIndex(p0: int): void
+    public final inner class MyList$MyListIterator
+}
+
+@kotlin.Metadata
+public final class MyList {
+    // source: 'customListIterator.kt'
+    private final @org.jetbrains.annotations.NotNull field elements: java.util.ArrayList
+    public method <init>(): void
+    public method add(p0: int, p1: java.lang.Object): void
+    public method add(p0: java.lang.Object): boolean
+    public method addAll(p0: int, p1: java.util.Collection): boolean
+    public method addAll(p0: java.util.Collection): boolean
+    public method clear(): void
+    public method contains(p0: java.lang.Object): boolean
+    public method containsAll(@org.jetbrains.annotations.NotNull p0: java.util.Collection): boolean
+    public method get(p0: int): java.lang.Object
+    public method getSize(): int
+    public method indexOf(p0: java.lang.Object): int
+    public method isEmpty(): boolean
+    public @org.jetbrains.annotations.NotNull method iterator(): MyList$MyListIterator
+    public synthetic bridge method iterator(): java.util.Iterator
+    public method lastIndexOf(p0: java.lang.Object): int
+    public @org.jetbrains.annotations.NotNull method listIterator(): MyList$MyListIterator
+    public synthetic bridge method listIterator(): java.util.ListIterator
+    public @org.jetbrains.annotations.NotNull method listIterator(p0: int): MyList$MyListIterator
+    public synthetic bridge method listIterator(p0: int): java.util.ListIterator
+    public method remove(p0: int): java.lang.Object
+    public method remove(p0: java.lang.Object): boolean
+    public method removeAll(p0: java.util.Collection): boolean
+    public method retainAll(p0: java.util.Collection): boolean
+    public method set(p0: int, p1: java.lang.Object): java.lang.Object
+    public bridge final method size(): int
+    public @org.jetbrains.annotations.NotNull method subList(p0: int, p1: int): java.util.List
+    public method toArray(): java.lang.Object[]
+    public method toArray(p0: java.lang.Object[]): java.lang.Object[]
+    public final inner class MyList$MyListIterator
+}

--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/customMutableListIterator.kt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/customMutableListIterator.kt
@@ -1,0 +1,49 @@
+// Ensure the proper collection stubs are added, in
+// particular *not* when specialized implementations are provided.
+class MyList<E> : MutableList<E> {
+    private val elements = ArrayList<E>()
+
+    class MyListIterator<E>(
+        private val list: ArrayList<E>,
+        start: Int,
+        private val end: Int
+    ) : MutableListIterator<E> {
+        var index = start
+        override fun hasNext() = index < end
+        override fun next() = list[index++]
+        override fun hasPrevious() = index > 0
+        override fun nextIndex() = index + 1
+        override fun previous() = list[--index]
+        override fun previousIndex() = index - 1
+
+        override fun add(element: E) = TODO("not implemented")
+        override fun remove() = TODO("not implemented")
+        override fun set(element: E) = TODO("not implemented")
+    }
+
+    // List<E> implementation:
+    override fun listIterator(index: Int) = MyListIterator(elements, index, size)
+    override fun listIterator() = listIterator(0)
+    override fun iterator() = listIterator()
+
+    override val size get() = elements.size
+    override fun contains(element: E) = elements.contains(element)
+    override fun containsAll(elements: Collection<E>) = this.elements.containsAll(elements)
+    override operator fun get(index: Int) = elements[index]
+    override fun indexOf(element: E): Int = elements.indexOf(element)
+    override fun lastIndexOf(element: E): Int = elements.lastIndexOf(element)
+    override fun isEmpty() = elements.isEmpty()
+    override fun subList(fromIndex: Int, toIndex: Int) = elements.subList(fromIndex, toIndex)
+
+    // MutableList operations
+    override fun add(element: E) = TODO("not implemented")
+    override fun add(index: Int, element: E) = TODO("not implemented")
+    override fun addAll(elements: Collection<E>) = TODO("not implemented")
+    override fun addAll(index: Int, elements: Collection<E>) = TODO("not implemented")
+    override fun clear() = TODO("not implemented")
+    override fun remove(element: E) = TODO("not implemented")
+    override fun removeAt(index: Int) = TODO("not implemented")
+    override fun removeAll(elements: Collection<E>) = TODO("not implemented")
+    override fun retainAll(elements: Collection<E>) = TODO("not implemented")
+    override fun set(index: Int, element: E) = TODO("not implemented")
+}

--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/customMutableListIterator.txt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/customMutableListIterator.txt
@@ -1,0 +1,68 @@
+@kotlin.Metadata
+public final class MyList$MyListIterator {
+    // source: 'customMutableListIterator.kt'
+    private final field end: int
+    private field index: int
+    private final field list: java.util.ArrayList
+    public method <init>(@org.jetbrains.annotations.NotNull p0: java.util.ArrayList, p1: int, p2: int): void
+    public @org.jetbrains.annotations.NotNull method add(p0: java.lang.Object): java.lang.Void
+    public synthetic bridge method add(p0: java.lang.Object): void
+    public final method getIndex(): int
+    public method hasNext(): boolean
+    public method hasPrevious(): boolean
+    public method next(): java.lang.Object
+    public method nextIndex(): int
+    public method previous(): java.lang.Object
+    public method previousIndex(): int
+    public @org.jetbrains.annotations.NotNull method remove(): java.lang.Void
+    public synthetic bridge method remove(): void
+    public @org.jetbrains.annotations.NotNull method set(p0: java.lang.Object): java.lang.Void
+    public synthetic bridge method set(p0: java.lang.Object): void
+    public final method setIndex(p0: int): void
+    public final inner class MyList$MyListIterator
+}
+
+@kotlin.Metadata
+public final class MyList {
+    // source: 'customMutableListIterator.kt'
+    private final field elements: java.util.ArrayList
+    public method <init>(): void
+    public @org.jetbrains.annotations.NotNull method add(p0: int, p1: java.lang.Object): java.lang.Void
+    public synthetic bridge method add(p0: int, p1: java.lang.Object): void
+    public synthetic bridge method add(p0: java.lang.Object): boolean
+    public @org.jetbrains.annotations.NotNull method add(p0: java.lang.Object): java.lang.Void
+    public @org.jetbrains.annotations.NotNull method addAll(@org.jetbrains.annotations.NotNull p0: java.util.Collection): java.lang.Void
+    public @org.jetbrains.annotations.NotNull method addAll(p0: int, @org.jetbrains.annotations.NotNull p1: java.util.Collection): java.lang.Void
+    public synthetic bridge method addAll(p0: int, p1: java.util.Collection): boolean
+    public synthetic bridge method addAll(p0: java.util.Collection): boolean
+    public @org.jetbrains.annotations.NotNull method clear(): java.lang.Void
+    public synthetic bridge method clear(): void
+    public method contains(p0: java.lang.Object): boolean
+    public method containsAll(@org.jetbrains.annotations.NotNull p0: java.util.Collection): boolean
+    public method get(p0: int): java.lang.Object
+    public method getSize(): int
+    public method indexOf(p0: java.lang.Object): int
+    public method isEmpty(): boolean
+    public @org.jetbrains.annotations.NotNull method iterator(): MyList$MyListIterator
+    public synthetic bridge method iterator(): java.util.Iterator
+    public method lastIndexOf(p0: java.lang.Object): int
+    public @org.jetbrains.annotations.NotNull method listIterator(): MyList$MyListIterator
+    public synthetic bridge method listIterator(): java.util.ListIterator
+    public @org.jetbrains.annotations.NotNull method listIterator(p0: int): MyList$MyListIterator
+    public synthetic bridge method listIterator(p0: int): java.util.ListIterator
+    public bridge final method remove(p0: int): java.lang.Object
+    public bridge final method remove(p0: java.lang.Object): boolean
+    public @org.jetbrains.annotations.NotNull method remove(p0: java.lang.Object): java.lang.Void
+    public @org.jetbrains.annotations.NotNull method removeAll(@org.jetbrains.annotations.NotNull p0: java.util.Collection): java.lang.Void
+    public bridge final method removeAll(p0: java.util.Collection): boolean
+    public @org.jetbrains.annotations.NotNull method removeAt(p0: int): java.lang.Void
+    public @org.jetbrains.annotations.NotNull method retainAll(@org.jetbrains.annotations.NotNull p0: java.util.Collection): java.lang.Void
+    public bridge final method retainAll(p0: java.util.Collection): boolean
+    public synthetic bridge method set(p0: int, p1: java.lang.Object): java.lang.Object
+    public @org.jetbrains.annotations.NotNull method set(p0: int, p1: java.lang.Object): java.lang.Void
+    public bridge final method size(): int
+    public @org.jetbrains.annotations.NotNull method subList(p0: int, p1: int): java.util.List
+    public method toArray(): java.lang.Object[]
+    public method toArray(p0: java.lang.Object[]): java.lang.Object[]
+    public final inner class MyList$MyListIterator
+}

--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/customMutableListIterator_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/customMutableListIterator_ir.txt
@@ -1,0 +1,69 @@
+@kotlin.Metadata
+public final class MyList$MyListIterator {
+    // source: 'customMutableListIterator.kt'
+    private final field end: int
+    private field index: int
+    private final @org.jetbrains.annotations.NotNull field list: java.util.ArrayList
+    public method <init>(@org.jetbrains.annotations.NotNull p0: java.util.ArrayList, p1: int, p2: int): void
+    public @org.jetbrains.annotations.NotNull method add(p0: java.lang.Object): java.lang.Void
+    public synthetic bridge method add(p0: java.lang.Object): void
+    public final method getIndex(): int
+    public method hasNext(): boolean
+    public method hasPrevious(): boolean
+    public method next(): java.lang.Object
+    public method nextIndex(): int
+    public method previous(): java.lang.Object
+    public method previousIndex(): int
+    public @org.jetbrains.annotations.NotNull method remove(): java.lang.Void
+    public synthetic bridge method remove(): void
+    public @org.jetbrains.annotations.NotNull method set(p0: java.lang.Object): java.lang.Void
+    public synthetic bridge method set(p0: java.lang.Object): void
+    public final method setIndex(p0: int): void
+    public final inner class MyList$MyListIterator
+}
+
+@kotlin.Metadata
+public final class MyList {
+    // source: 'customMutableListIterator.kt'
+    private final @org.jetbrains.annotations.NotNull field elements: java.util.ArrayList
+    public method <init>(): void
+    public @org.jetbrains.annotations.NotNull method add(p0: int, p1: java.lang.Object): java.lang.Void
+    public synthetic bridge method add(p0: int, p1: java.lang.Object): void
+    public synthetic bridge method add(p0: java.lang.Object): boolean
+    public @org.jetbrains.annotations.NotNull method add(p0: java.lang.Object): java.lang.Void
+    public @org.jetbrains.annotations.NotNull method addAll(@org.jetbrains.annotations.NotNull p0: java.util.Collection): java.lang.Void
+    public @org.jetbrains.annotations.NotNull method addAll(p0: int, @org.jetbrains.annotations.NotNull p1: java.util.Collection): java.lang.Void
+    public synthetic bridge method addAll(p0: int, p1: java.util.Collection): boolean
+    public synthetic bridge method addAll(p0: java.util.Collection): boolean
+    public @org.jetbrains.annotations.NotNull method clear(): java.lang.Void
+    public synthetic bridge method clear(): void
+    public method contains(p0: java.lang.Object): boolean
+    public method containsAll(@org.jetbrains.annotations.NotNull p0: java.util.Collection): boolean
+    public method get(p0: int): java.lang.Object
+    public method getSize(): int
+    public method indexOf(p0: java.lang.Object): int
+    public method isEmpty(): boolean
+    public @org.jetbrains.annotations.NotNull method iterator(): MyList$MyListIterator
+    public synthetic bridge method iterator(): java.util.Iterator
+    public method lastIndexOf(p0: java.lang.Object): int
+    public @org.jetbrains.annotations.NotNull method listIterator(): MyList$MyListIterator
+    public synthetic bridge method listIterator(): java.util.ListIterator
+    public @org.jetbrains.annotations.NotNull method listIterator(p0: int): MyList$MyListIterator
+    public synthetic bridge method listIterator(p0: int): java.util.ListIterator
+    public synthetic bridge method remove(p0: int): java.lang.Object
+    public bridge final method remove(p0: int): java.lang.Void
+    public bridge final method remove(p0: java.lang.Object): boolean
+    public @org.jetbrains.annotations.NotNull method remove(p0: java.lang.Object): java.lang.Void
+    public @org.jetbrains.annotations.NotNull method removeAll(@org.jetbrains.annotations.NotNull p0: java.util.Collection): java.lang.Void
+    public synthetic bridge method removeAll(p0: java.util.Collection): boolean
+    public @org.jetbrains.annotations.NotNull method removeAt(p0: int): java.lang.Void
+    public @org.jetbrains.annotations.NotNull method retainAll(@org.jetbrains.annotations.NotNull p0: java.util.Collection): java.lang.Void
+    public synthetic bridge method retainAll(p0: java.util.Collection): boolean
+    public synthetic bridge method set(p0: int, p1: java.lang.Object): java.lang.Object
+    public @org.jetbrains.annotations.NotNull method set(p0: int, p1: java.lang.Object): java.lang.Void
+    public bridge final method size(): int
+    public @org.jetbrains.annotations.NotNull method subList(p0: int, p1: int): java.util.List
+    public method toArray(): java.lang.Object[]
+    public method toArray(p0: java.lang.Object[]): java.lang.Object[]
+    public final inner class MyList$MyListIterator
+}

--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsForCollection.kt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsForCollection.kt
@@ -1,0 +1,31 @@
+// Ensure the proper collection stubs are added, in
+// particular *not* when specialized implementations are provided.
+
+class MyCollection<E> : Collection<E> {
+    class MyIterator<E> : Iterator<E> {
+        override fun hasNext(): Boolean {
+            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        }
+
+        override fun next(): E {
+            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        }
+    }
+
+    override val size: Int
+        get() = TODO("not implemented") //To change initializer of created properties use File | Settings | File Templates.
+
+    override fun contains(element: E): Boolean {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun containsAll(elements: Collection<E>): Boolean {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun isEmpty(): Boolean {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun iterator() = MyIterator<E>()
+}

--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsForCollection.txt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsForCollection.txt
@@ -1,0 +1,31 @@
+@kotlin.Metadata
+public final class MyCollection$MyIterator {
+    // source: 'noStubsForCollection.kt'
+    public method <init>(): void
+    public method hasNext(): boolean
+    public method next(): java.lang.Object
+    public method remove(): void
+    public final inner class MyCollection$MyIterator
+}
+
+@kotlin.Metadata
+public final class MyCollection {
+    // source: 'noStubsForCollection.kt'
+    public method <init>(): void
+    public method add(p0: java.lang.Object): boolean
+    public method addAll(p0: java.util.Collection): boolean
+    public method clear(): void
+    public method contains(p0: java.lang.Object): boolean
+    public method containsAll(@org.jetbrains.annotations.NotNull p0: java.util.Collection): boolean
+    public method getSize(): int
+    public method isEmpty(): boolean
+    public @org.jetbrains.annotations.NotNull method iterator(): MyCollection$MyIterator
+    public synthetic bridge method iterator(): java.util.Iterator
+    public method remove(p0: java.lang.Object): boolean
+    public method removeAll(p0: java.util.Collection): boolean
+    public method retainAll(p0: java.util.Collection): boolean
+    public bridge final method size(): int
+    public method toArray(): java.lang.Object[]
+    public method toArray(p0: java.lang.Object[]): java.lang.Object[]
+    public final inner class MyCollection$MyIterator
+}

--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsForMapImplementations.kt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsForMapImplementations.kt
@@ -1,0 +1,42 @@
+// Ensure the proper collection stubs are added, in
+// particular *not* when specialized implementations are provided.
+
+// IGNORE_BACKEND: JVM_IR
+// Extra stub generated as override of e.g. `iterator` is not detected.
+// Complicated by the fact the the overrides are properties codegen'ed
+// as methods (e.g. entries -> entrySet)and the need to look at type
+// parameters when determining overrides.
+class MyMap<K, V> : Map<K, V> {
+
+    class MySet<E> : Set<E> {
+        override fun contains(element: E): Boolean {
+            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        }
+
+        override fun iterator(): Iterator<E> {
+            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        }
+        override fun isEmpty(): Boolean {
+            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        }
+        override fun containsAll(elements: Collection<E>): Boolean {
+            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        }
+        override val size: Int
+            get() = TODO("not implemented") //To change initializer of created properties use File | Settings | File Templates.
+    }
+
+    override val entries
+        get() = MySet<Map.Entry<K,V>>()
+    override val keys
+        get() = MySet<K>()
+    override val size: Int
+        get() = TODO("not implemented")
+    override val values
+        get() = ArrayList<V>()
+
+    override fun containsKey(key: K) = TODO("not implemented")
+    override fun containsValue(value: V) = TODO("not implemented")
+    override fun get(key: K) = TODO("not implemented")
+    override fun isEmpty() = TODO("not implemented")
+}

--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsForMapImplementations.txt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsForMapImplementations.txt
@@ -1,0 +1,47 @@
+@kotlin.Metadata
+public final class MyMap$MySet {
+    // source: 'noStubsForMapImplementations.kt'
+    public method <init>(): void
+    public method add(p0: java.lang.Object): boolean
+    public method addAll(p0: java.util.Collection): boolean
+    public method clear(): void
+    public method contains(p0: java.lang.Object): boolean
+    public method containsAll(@org.jetbrains.annotations.NotNull p0: java.util.Collection): boolean
+    public method getSize(): int
+    public method isEmpty(): boolean
+    public @org.jetbrains.annotations.NotNull method iterator(): java.util.Iterator
+    public method remove(p0: java.lang.Object): boolean
+    public method removeAll(p0: java.util.Collection): boolean
+    public method retainAll(p0: java.util.Collection): boolean
+    public bridge final method size(): int
+    public method toArray(): java.lang.Object[]
+    public method toArray(p0: java.lang.Object[]): java.lang.Object[]
+    public final inner class MyMap$MySet
+}
+
+@kotlin.Metadata
+public final class MyMap {
+    // source: 'noStubsForMapImplementations.kt'
+    public method <init>(): void
+    public method clear(): void
+    public bridge final method containsKey(p0: java.lang.Object): boolean
+    public @org.jetbrains.annotations.NotNull method containsKey(p0: java.lang.Object): java.lang.Void
+    public bridge final method containsValue(p0: java.lang.Object): boolean
+    public @org.jetbrains.annotations.NotNull method containsValue(p0: java.lang.Object): java.lang.Void
+    public bridge final method entrySet(): java.util.Set
+    public bridge final method get(p0: java.lang.Object): java.lang.Object
+    public @org.jetbrains.annotations.NotNull method get(p0: java.lang.Object): java.lang.Void
+    public @org.jetbrains.annotations.NotNull method getEntries(): MyMap$MySet
+    public @org.jetbrains.annotations.NotNull method getKeys(): MyMap$MySet
+    public method getSize(): int
+    public @org.jetbrains.annotations.NotNull method getValues(): java.util.ArrayList
+    public synthetic bridge method isEmpty(): boolean
+    public @org.jetbrains.annotations.NotNull method isEmpty(): java.lang.Void
+    public bridge final method keySet(): java.util.Set
+    public method put(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
+    public method putAll(p0: java.util.Map): void
+    public method remove(p0: java.lang.Object): java.lang.Object
+    public bridge final method size(): int
+    public bridge final method values(): java.util.Collection
+    public final inner class MyMap$MySet
+}

--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsForMutableSetIterators.kt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsForMutableSetIterators.kt
@@ -1,0 +1,26 @@
+// Ensure the proper collection stubs are added, in
+// particular *not* when specialized implementations are provided.
+class MySet<E> : MutableSet<E> {
+    val elements: ArrayList<E> = ArrayList<E>()
+
+    override val size: Int
+        get() = TODO("not implemented")
+
+    override fun contains(element: E) = TODO("not implemented")
+    override fun containsAll(elements: Collection<E>) = TODO("not implemented")
+    override fun isEmpty() = TODO("not implemented")
+    override fun add(element: E) = TODO("not implemented")
+    override fun addAll(elements: Collection<E>) = TODO("not implemented")
+    override fun clear() = TODO("not implmented")
+    override fun remove(element: E) = TODO("not implemented")
+    override fun removeAll(elements: Collection<E>) = TODO("not implemented")
+    override fun retainAll(elements: Collection<E>) = TODO("not implemented")
+
+    class MySetIterator<E>(elements: List<E>) : MutableIterator<E> {
+        override fun hasNext() = TODO("not implemented")
+        override fun next() = TODO("not implemented")
+        override fun remove() = TODO("not implemented")
+    }
+
+    override fun iterator() = MySetIterator(elements)
+}

--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsForMutableSetIterators.txt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsForMutableSetIterators.txt
@@ -1,0 +1,45 @@
+@kotlin.Metadata
+public final class MySet$MySetIterator {
+    // source: 'noStubsForMutableSetIterators.kt'
+    public method <init>(@org.jetbrains.annotations.NotNull p0: java.util.List): void
+    public synthetic bridge method hasNext(): boolean
+    public @org.jetbrains.annotations.NotNull method hasNext(): java.lang.Void
+    public synthetic bridge method next(): java.lang.Object
+    public @org.jetbrains.annotations.NotNull method next(): java.lang.Void
+    public @org.jetbrains.annotations.NotNull method remove(): java.lang.Void
+    public synthetic bridge method remove(): void
+    public final inner class MySet$MySetIterator
+}
+
+@kotlin.Metadata
+public final class MySet {
+    // source: 'noStubsForMutableSetIterators.kt'
+    private final @org.jetbrains.annotations.NotNull field elements: java.util.ArrayList
+    public method <init>(): void
+    public synthetic bridge method add(p0: java.lang.Object): boolean
+    public @org.jetbrains.annotations.NotNull method add(p0: java.lang.Object): java.lang.Void
+    public @org.jetbrains.annotations.NotNull method addAll(@org.jetbrains.annotations.NotNull p0: java.util.Collection): java.lang.Void
+    public synthetic bridge method addAll(p0: java.util.Collection): boolean
+    public @org.jetbrains.annotations.NotNull method clear(): java.lang.Void
+    public synthetic bridge method clear(): void
+    public bridge final method contains(p0: java.lang.Object): boolean
+    public @org.jetbrains.annotations.NotNull method contains(p0: java.lang.Object): java.lang.Void
+    public @org.jetbrains.annotations.NotNull method containsAll(@org.jetbrains.annotations.NotNull p0: java.util.Collection): java.lang.Void
+    public bridge final method containsAll(p0: java.util.Collection): boolean
+    public final @org.jetbrains.annotations.NotNull method getElements(): java.util.ArrayList
+    public method getSize(): int
+    public synthetic bridge method isEmpty(): boolean
+    public @org.jetbrains.annotations.NotNull method isEmpty(): java.lang.Void
+    public @org.jetbrains.annotations.NotNull method iterator(): MySet$MySetIterator
+    public synthetic bridge method iterator(): java.util.Iterator
+    public bridge final method remove(p0: java.lang.Object): boolean
+    public @org.jetbrains.annotations.NotNull method remove(p0: java.lang.Object): java.lang.Void
+    public @org.jetbrains.annotations.NotNull method removeAll(@org.jetbrains.annotations.NotNull p0: java.util.Collection): java.lang.Void
+    public bridge final method removeAll(p0: java.util.Collection): boolean
+    public @org.jetbrains.annotations.NotNull method retainAll(@org.jetbrains.annotations.NotNull p0: java.util.Collection): java.lang.Void
+    public bridge final method retainAll(p0: java.util.Collection): boolean
+    public bridge final method size(): int
+    public method toArray(): java.lang.Object[]
+    public method toArray(p0: java.lang.Object[]): java.lang.Object[]
+    public final inner class MySet$MySetIterator
+}

--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsForMutableSetIterators_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsForMutableSetIterators_ir.txt
@@ -1,0 +1,45 @@
+@kotlin.Metadata
+public final class MySet$MySetIterator {
+    // source: 'noStubsForMutableSetIterators.kt'
+    public method <init>(@org.jetbrains.annotations.NotNull p0: java.util.List): void
+    public synthetic bridge method hasNext(): boolean
+    public @org.jetbrains.annotations.NotNull method hasNext(): java.lang.Void
+    public synthetic bridge method next(): java.lang.Object
+    public @org.jetbrains.annotations.NotNull method next(): java.lang.Void
+    public @org.jetbrains.annotations.NotNull method remove(): java.lang.Void
+    public synthetic bridge method remove(): void
+    public final inner class MySet$MySetIterator
+}
+
+@kotlin.Metadata
+public final class MySet {
+    // source: 'noStubsForMutableSetIterators.kt'
+    private final @org.jetbrains.annotations.NotNull field elements: java.util.ArrayList
+    public method <init>(): void
+    public synthetic bridge method add(p0: java.lang.Object): boolean
+    public @org.jetbrains.annotations.NotNull method add(p0: java.lang.Object): java.lang.Void
+    public @org.jetbrains.annotations.NotNull method addAll(@org.jetbrains.annotations.NotNull p0: java.util.Collection): java.lang.Void
+    public synthetic bridge method addAll(p0: java.util.Collection): boolean
+    public @org.jetbrains.annotations.NotNull method clear(): java.lang.Void
+    public synthetic bridge method clear(): void
+    public bridge final method contains(p0: java.lang.Object): boolean
+    public @org.jetbrains.annotations.NotNull method contains(p0: java.lang.Object): java.lang.Void
+    public @org.jetbrains.annotations.NotNull method containsAll(@org.jetbrains.annotations.NotNull p0: java.util.Collection): java.lang.Void
+    public synthetic bridge method containsAll(p0: java.util.Collection): boolean
+    public final @org.jetbrains.annotations.NotNull method getElements(): java.util.ArrayList
+    public method getSize(): int
+    public synthetic bridge method isEmpty(): boolean
+    public @org.jetbrains.annotations.NotNull method isEmpty(): java.lang.Void
+    public @org.jetbrains.annotations.NotNull method iterator(): MySet$MySetIterator
+    public synthetic bridge method iterator(): java.util.Iterator
+    public bridge final method remove(p0: java.lang.Object): boolean
+    public @org.jetbrains.annotations.NotNull method remove(p0: java.lang.Object): java.lang.Void
+    public @org.jetbrains.annotations.NotNull method removeAll(@org.jetbrains.annotations.NotNull p0: java.util.Collection): java.lang.Void
+    public synthetic bridge method removeAll(p0: java.util.Collection): boolean
+    public @org.jetbrains.annotations.NotNull method retainAll(@org.jetbrains.annotations.NotNull p0: java.util.Collection): java.lang.Void
+    public synthetic bridge method retainAll(p0: java.util.Collection): boolean
+    public bridge final method size(): int
+    public method toArray(): java.lang.Object[]
+    public method toArray(p0: java.lang.Object[]): java.lang.Object[]
+    public final inner class MySet$MySetIterator
+}

--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsForSetIterators.kt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsForSetIterators.kt
@@ -1,0 +1,20 @@
+// Ensure the proper collection stubs are added, in
+// particular *not* when specialized implementations are provided.
+
+class MySet<E> : Set<E> {
+    val elements: ArrayList<E> = ArrayList<E>()
+
+    override val size: Int
+        get() = TODO("not implemented")
+
+    override fun contains(element: E) = TODO("not implemented")
+    override fun containsAll(elements: Collection<E>) = TODO("not implemented")
+    override fun isEmpty() = TODO("not implemented")
+
+    class MySetIterator<E>(elements: List<E>) : Iterator<E> {
+        override fun hasNext() = TODO("not implemented")
+        override fun next() = TODO("not implemented")
+    }
+
+    override fun iterator() = MySetIterator(elements)
+}

--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsForSetIterators.txt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsForSetIterators.txt
@@ -1,0 +1,38 @@
+@kotlin.Metadata
+public final class MySet$MySetIterator {
+    // source: 'noStubsForSetIterators.kt'
+    public method <init>(@org.jetbrains.annotations.NotNull p0: java.util.List): void
+    public synthetic bridge method hasNext(): boolean
+    public @org.jetbrains.annotations.NotNull method hasNext(): java.lang.Void
+    public synthetic bridge method next(): java.lang.Object
+    public @org.jetbrains.annotations.NotNull method next(): java.lang.Void
+    public method remove(): void
+    public final inner class MySet$MySetIterator
+}
+
+@kotlin.Metadata
+public final class MySet {
+    // source: 'noStubsForSetIterators.kt'
+    private final @org.jetbrains.annotations.NotNull field elements: java.util.ArrayList
+    public method <init>(): void
+    public method add(p0: java.lang.Object): boolean
+    public method addAll(p0: java.util.Collection): boolean
+    public method clear(): void
+    public bridge final method contains(p0: java.lang.Object): boolean
+    public @org.jetbrains.annotations.NotNull method contains(p0: java.lang.Object): java.lang.Void
+    public @org.jetbrains.annotations.NotNull method containsAll(@org.jetbrains.annotations.NotNull p0: java.util.Collection): java.lang.Void
+    public bridge final method containsAll(p0: java.util.Collection): boolean
+    public final @org.jetbrains.annotations.NotNull method getElements(): java.util.ArrayList
+    public method getSize(): int
+    public synthetic bridge method isEmpty(): boolean
+    public @org.jetbrains.annotations.NotNull method isEmpty(): java.lang.Void
+    public @org.jetbrains.annotations.NotNull method iterator(): MySet$MySetIterator
+    public synthetic bridge method iterator(): java.util.Iterator
+    public method remove(p0: java.lang.Object): boolean
+    public method removeAll(p0: java.util.Collection): boolean
+    public method retainAll(p0: java.util.Collection): boolean
+    public bridge final method size(): int
+    public method toArray(): java.lang.Object[]
+    public method toArray(p0: java.lang.Object[]): java.lang.Object[]
+    public final inner class MySet$MySetIterator
+}

--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsForSetIterators_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsForSetIterators_ir.txt
@@ -1,0 +1,38 @@
+@kotlin.Metadata
+public final class MySet$MySetIterator {
+    // source: 'noStubsForSetIterators.kt'
+    public method <init>(@org.jetbrains.annotations.NotNull p0: java.util.List): void
+    public synthetic bridge method hasNext(): boolean
+    public @org.jetbrains.annotations.NotNull method hasNext(): java.lang.Void
+    public synthetic bridge method next(): java.lang.Object
+    public @org.jetbrains.annotations.NotNull method next(): java.lang.Void
+    public method remove(): void
+    public final inner class MySet$MySetIterator
+}
+
+@kotlin.Metadata
+public final class MySet {
+    // source: 'noStubsForSetIterators.kt'
+    private final @org.jetbrains.annotations.NotNull field elements: java.util.ArrayList
+    public method <init>(): void
+    public method add(p0: java.lang.Object): boolean
+    public method addAll(p0: java.util.Collection): boolean
+    public method clear(): void
+    public bridge final method contains(p0: java.lang.Object): boolean
+    public @org.jetbrains.annotations.NotNull method contains(p0: java.lang.Object): java.lang.Void
+    public @org.jetbrains.annotations.NotNull method containsAll(@org.jetbrains.annotations.NotNull p0: java.util.Collection): java.lang.Void
+    public synthetic bridge method containsAll(p0: java.util.Collection): boolean
+    public final @org.jetbrains.annotations.NotNull method getElements(): java.util.ArrayList
+    public method getSize(): int
+    public synthetic bridge method isEmpty(): boolean
+    public @org.jetbrains.annotations.NotNull method isEmpty(): java.lang.Void
+    public @org.jetbrains.annotations.NotNull method iterator(): MySet$MySetIterator
+    public synthetic bridge method iterator(): java.util.Iterator
+    public method remove(p0: java.lang.Object): boolean
+    public method removeAll(p0: java.util.Collection): boolean
+    public method retainAll(p0: java.util.Collection): boolean
+    public bridge final method size(): int
+    public method toArray(): java.lang.Object[]
+    public method toArray(p0: java.lang.Object[]): java.lang.Object[]
+    public final inner class MySet$MySetIterator
+}

--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsInIterable.kt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsInIterable.kt
@@ -1,0 +1,15 @@
+class MyIterable<E> : Iterable<E> {
+    class MyIterator<E> : Iterator<E> {
+        override fun hasNext(): Boolean {
+            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        }
+
+        override fun next(): E {
+            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        }
+    }
+
+    override fun iterator(): Iterator<E> {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+}

--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsInIterable.txt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsInIterable.txt
@@ -1,0 +1,17 @@
+@kotlin.Metadata
+public final class MyIterable$MyIterator {
+    // source: 'noStubsInIterable.kt'
+    public method <init>(): void
+    public method hasNext(): boolean
+    public method next(): java.lang.Object
+    public method remove(): void
+    public final inner class MyIterable$MyIterator
+}
+
+@kotlin.Metadata
+public final class MyIterable {
+    // source: 'noStubsInIterable.kt'
+    public method <init>(): void
+    public @org.jetbrains.annotations.NotNull method iterator(): java.util.Iterator
+    public final inner class MyIterable$MyIterator
+}

--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsInMutableIterable.kt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsInMutableIterable.kt
@@ -1,0 +1,19 @@
+class MyIterable<E> : MutableIterable<E> {
+    class MyIterator<E> : MutableIterator<E> {
+        override fun hasNext(): Boolean {
+            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        }
+
+        override fun next(): E {
+            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        }
+
+        override fun remove() {
+            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        }
+    }
+
+    override fun iterator(): MutableIterator<E> {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+}

--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsInMutableIterable.txt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsInMutableIterable.txt
@@ -1,0 +1,17 @@
+@kotlin.Metadata
+public final class MyIterable$MyIterator {
+    // source: 'noStubsInMutableIterable.kt'
+    public method <init>(): void
+    public method hasNext(): boolean
+    public method next(): java.lang.Object
+    public method remove(): void
+    public final inner class MyIterable$MyIterator
+}
+
+@kotlin.Metadata
+public final class MyIterable {
+    // source: 'noStubsInMutableIterable.kt'
+    public method <init>(): void
+    public @org.jetbrains.annotations.NotNull method iterator(): java.util.Iterator
+    public final inner class MyIterable$MyIterator
+}

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeListingTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeListingTestGenerated.java
@@ -229,9 +229,49 @@ public class BytecodeListingTestGenerated extends AbstractBytecodeListingTest {
             KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/bytecodeListing/collectionStubs"), Pattern.compile("^(.+)\\.kt$"), null, true);
         }
 
+        @TestMetadata("customListIterator.kt")
+        public void testCustomListIterator() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeListing/collectionStubs/customListIterator.kt");
+        }
+
+        @TestMetadata("customMutableListIterator.kt")
+        public void testCustomMutableListIterator() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeListing/collectionStubs/customMutableListIterator.kt");
+        }
+
+        @TestMetadata("noStubsForCollection.kt")
+        public void testNoStubsForCollection() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsForCollection.kt");
+        }
+
+        @TestMetadata("noStubsForMapImplementations.kt")
+        public void testNoStubsForMapImplementations() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsForMapImplementations.kt");
+        }
+
+        @TestMetadata("noStubsForMutableSetIterators.kt")
+        public void testNoStubsForMutableSetIterators() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsForMutableSetIterators.kt");
+        }
+
+        @TestMetadata("noStubsForSetIterators.kt")
+        public void testNoStubsForSetIterators() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsForSetIterators.kt");
+        }
+
+        @TestMetadata("noStubsInIterable.kt")
+        public void testNoStubsInIterable() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsInIterable.kt");
+        }
+
         @TestMetadata("noStubsInJavaSuperClass.kt")
         public void testNoStubsInJavaSuperClass() throws Exception {
             runTest("compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsInJavaSuperClass.kt");
+        }
+
+        @TestMetadata("noStubsInMutableIterable.kt")
+        public void testNoStubsInMutableIterable() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsInMutableIterable.kt");
         }
 
         @TestMetadata("stubsFromSuperclass.kt")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeListingTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeListingTestGenerated.java
@@ -229,9 +229,49 @@ public class IrBytecodeListingTestGenerated extends AbstractIrBytecodeListingTes
             KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/bytecodeListing/collectionStubs"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
         }
 
+        @TestMetadata("customListIterator.kt")
+        public void testCustomListIterator() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeListing/collectionStubs/customListIterator.kt");
+        }
+
+        @TestMetadata("customMutableListIterator.kt")
+        public void testCustomMutableListIterator() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeListing/collectionStubs/customMutableListIterator.kt");
+        }
+
+        @TestMetadata("noStubsForCollection.kt")
+        public void testNoStubsForCollection() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsForCollection.kt");
+        }
+
+        @TestMetadata("noStubsForMapImplementations.kt")
+        public void testNoStubsForMapImplementations() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsForMapImplementations.kt");
+        }
+
+        @TestMetadata("noStubsForMutableSetIterators.kt")
+        public void testNoStubsForMutableSetIterators() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsForMutableSetIterators.kt");
+        }
+
+        @TestMetadata("noStubsForSetIterators.kt")
+        public void testNoStubsForSetIterators() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsForSetIterators.kt");
+        }
+
+        @TestMetadata("noStubsInIterable.kt")
+        public void testNoStubsInIterable() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsInIterable.kt");
+        }
+
         @TestMetadata("noStubsInJavaSuperClass.kt")
         public void testNoStubsInJavaSuperClass() throws Exception {
             runTest("compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsInJavaSuperClass.kt");
+        }
+
+        @TestMetadata("noStubsInMutableIterable.kt")
+        public void testNoStubsInMutableIterable() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeListing/collectionStubs/noStubsInMutableIterable.kt");
         }
 
         @TestMetadata("stubsFromSuperclass.kt")


### PR DESCRIPTION
Returning user provided types from `iterator`, `listIterator` and
`sublist` should prevent the compiler from adding corresponding
collection stubs, avoiding a JVM Platform declaration clash.