### PR TITLE
FIR: update the type of anonymous function as SAM

### DIFF
--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirCallCompletionResultsWriterTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirCallCompletionResultsWriterTransformer.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.fir.resolve.transformers
 
+import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.fir.*
 import org.jetbrains.kotlin.fir.declarations.*
 import org.jetbrains.kotlin.fir.diagnostics.ConeSimpleDiagnostic
@@ -17,6 +18,8 @@ import org.jetbrains.kotlin.fir.resolve.calls.FirErrorReferenceWithCandidate
 import org.jetbrains.kotlin.fir.resolve.calls.FirNamedReferenceWithCandidate
 import org.jetbrains.kotlin.fir.resolve.calls.varargElementType
 import org.jetbrains.kotlin.fir.resolve.constructFunctionalTypeRef
+import org.jetbrains.kotlin.fir.resolve.createFunctionalType
+import org.jetbrains.kotlin.fir.resolve.firProvider
 import org.jetbrains.kotlin.fir.resolve.inference.inferenceComponents
 import org.jetbrains.kotlin.fir.resolve.inference.isBuiltinFunctionalType
 import org.jetbrains.kotlin.fir.resolve.inference.isSuspendFunctionType
@@ -437,7 +440,26 @@ class FirCallCompletionResultsWriterTransformer(
         anonymousFunction: FirAnonymousFunction,
         data: ExpectedArgumentType?,
     ): CompositeTransformResult<FirStatement> {
-        val expectedType = data?.getExpectedType(anonymousFunction)?.takeIf { it.isBuiltinFunctionalType(session) }
+        val expectedType = data?.getExpectedType(anonymousFunction)?.let { expectedArgumentType ->
+            // From the argument mapping, the expected type of this anonymous function would be:
+            when {
+                // a built-in functional type, no-brainer
+                expectedArgumentType.isBuiltinFunctionalType(session) -> expectedArgumentType
+                // fun interface (a.k.a. SAM), then unwrap it and build a functional type from that interface function
+                expectedArgumentType is ConeClassLikeType -> {
+                    val sam =
+                        (session.firProvider.getFirClassifierByFqName(expectedArgumentType.lookupTag.classId) as? FirClass)
+                            ?.takeIf { it.classKind == ClassKind.INTERFACE }
+                            ?.declarations?.singleOrNull() as? FirSimpleFunction
+                    sam?.let {
+                        createFunctionalType(
+                            sam.valueParameters.map { it.returnTypeRef.coneType }, null, sam.returnTypeRef.coneType, sam.isSuspend
+                        )
+                    }
+                }
+                else -> null
+            }
+        }
 
         var needUpdateLambdaType = false
 

--- a/compiler/testData/codegen/box/coroutines/featureIntersection/funInterface.kt
+++ b/compiler/testData/codegen/box/coroutines/featureIntersection/funInterface.kt
@@ -2,7 +2,6 @@
 // WITH_COROUTINES
 // TARGET_BACKEND: JVM
 // IGNORE_BACKEND: JVM
-// IGNORE_BACKEND_FIR: JVM_IR
 
 import helpers.*
 import kotlin.coroutines.*


### PR DESCRIPTION
The motivation is bb test `coroutines/featureIntersection/funInterface`:
```kt
fun interface Action {
  suspend fun run()
}

suspend fun runAction(a: Action) {
  a.run()
}

fun box() {
  ...
  runAction { // this lambda, as Action#run, should be "suspend"
    ...
  }
}
```
where the type of the lambda passed to `runAction` is still a non-suspend functional type. From the expected argument type, `Action`, which is a functional interface, we can retrieve SAM (`Action#run`) and rebuild the expected type of the lambda correctly.