### PR TITLE
KT-41897 `Redundant nullable return type` inspection should not be applied to overridden methods

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantNullableReturnTypeInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantNullableReturnTypeInspection.kt
@@ -20,6 +20,7 @@ import org.jetbrains.kotlin.idea.core.isOverridable
 import org.jetbrains.kotlin.idea.project.languageVersionSettings
 import org.jetbrains.kotlin.idea.resolve.getDataFlowValueFactory
 import org.jetbrains.kotlin.idea.util.textRangeIn
+import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
 import org.jetbrains.kotlin.psi.psiUtil.getParentOfTypes
@@ -45,7 +46,7 @@ class RedundantNullableReturnTypeInspection : AbstractKotlinInspection() {
             if (typeElement.innerType == null) return
             val questionMark = typeElement.questionMarkNode as? LeafPsiElement ?: return
 
-            if (declaration.isOverridable()) return
+            if (declaration.hasModifier(KtTokens.OVERRIDE_KEYWORD) || declaration.isOverridable()) return
 
             val body = when (declaration) {
                 is KtNamedFunction -> declaration.bodyExpression

--- a/idea/testData/inspectionsLocal/redundantNullableReturnType/function/overridden.kt
+++ b/idea/testData/inspectionsLocal/redundantNullableReturnType/function/overridden.kt
@@ -1,0 +1,10 @@
+// PROBLEM: none
+interface I {
+    fun f(): String?
+}
+
+class C : I {
+    override fun f(): String?<caret> {
+        return ""
+    }
+}

--- a/idea/testData/inspectionsLocal/redundantNullableReturnType/property/overridden.kt
+++ b/idea/testData/inspectionsLocal/redundantNullableReturnType/property/overridden.kt
@@ -1,0 +1,9 @@
+// PROBLEM: none
+interface I {
+    val v: String?
+}
+
+class C : I {
+    override val v: String?<caret>
+        get() = ""
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -8249,6 +8249,11 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
                 runTest("idea/testData/inspectionsLocal/redundantNullableReturnType/function/overridable.kt");
             }
 
+            @TestMetadata("overridden.kt")
+            public void testOverridden() throws Exception {
+                runTest("idea/testData/inspectionsLocal/redundantNullableReturnType/function/overridden.kt");
+            }
+
             @TestMetadata("returnNullableForLambda.kt")
             public void testReturnNullableForLambda() throws Exception {
                 runTest("idea/testData/inspectionsLocal/redundantNullableReturnType/function/returnNullableForLambda.kt");
@@ -8305,6 +8310,11 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
             @TestMetadata("initializer.kt")
             public void testInitializer() throws Exception {
                 runTest("idea/testData/inspectionsLocal/redundantNullableReturnType/property/initializer.kt");
+            }
+
+            @TestMetadata("overridden.kt")
+            public void testOverridden() throws Exception {
+                runTest("idea/testData/inspectionsLocal/redundantNullableReturnType/property/overridden.kt");
             }
 
             @TestMetadata("returnNullableFromLambdaInGetter.kt")


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-41897