### PR TITLE
Upgrade agp version for ConfigurationCacheForAndroidIT

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/ConfigurationCacheForAndroidIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/ConfigurationCacheForAndroidIT.kt
@@ -18,14 +18,7 @@ class ConfigurationCacheForAndroidIT : AbstractConfigurationCacheIT() {
             androidHome = KotlinTestUtils.findAndroidSdk(),
             androidGradlePluginVersion = androidGradlePluginVersion,
             configurationCache = true,
-            /* AGP causes a configuration cache problem:
-                 - plugin 'com.android.internal.application': registration of listener on 'TaskExecutionGraph.addTaskExecutionListener' is unsupported
-
-               which causes tests to fail when configuration-cache-problems=fail is used.
-               However, everything works fine with WARN level reporting.
-               TODO: switch to FAIL when AGP no longer causes the cache problem
-             */
-            configurationCacheProblems = ConfigurationCacheProblems.WARN
+            configurationCacheProblems = ConfigurationCacheProblems.FAIL
         )
 
     @Test

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/ConfigurationCacheIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/ConfigurationCacheIT.kt
@@ -52,7 +52,7 @@ abstract class AbstractConfigurationCacheIT : BaseGradleIT() {
     override fun defaultBuildOptions() =
         super.defaultBuildOptions().copy(configurationCache = true)
 
-    override val defaultGradleVersion: GradleVersionRequired = GradleVersionRequired.AtLeast("6.6-rc-3")
+    override val defaultGradleVersion: GradleVersionRequired = GradleVersionRequired.AtLeast("6.6.1")
 
     protected fun Project.testConfigurationCacheOf(
         vararg taskNames: String,

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/util/AGPVersion.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/util/AGPVersion.kt
@@ -25,6 +25,6 @@ class AGPVersion private constructor(private val versionNumber: VersionNumber) {
         val v3_4_1 = fromString("3.4.1")
         val v3_6_0 = fromString("3.6.0")
         val v4_1_0 = fromString("4.1.0-beta02")
-        val v4_2_0 = fromString("4.2.0-alpha07")
+        val v4_2_0 = fromString("4.2.0-alpha10")
     }
 }


### PR DESCRIPTION
The new agp version contains the fix regarding build listeners which
will allow kgp run config caching test without warnings.

Fixes: n/a
Test: existing