### PR TITLE
[JVM_IR] Rebase fwBackingField stepping test.

### DIFF
--- a/idea/jvm-debugger/jvm-debugger-test/testData/stepping/stepOut/fwBackingField.ir.out
+++ b/idea/jvm-debugger/jvm-debugger-test/testData/stepping/stepOut/fwBackingField.ir.out
@@ -22,8 +22,8 @@ fwBackingField.kt:24
 fwBackingField.kt:25
 fwBackingField.kt:26
 fwBackingField.kt:61
-fwBackingField.kt:29
-fwBackingField.kt:29
+fwBackingField.kt:31
+fwBackingField.kt:33
 fwBackingField.kt:61
 fwBackingField.kt:36
 fwBackingField.kt:37


### PR DESCRIPTION
The difference is that JVM_IR generates line numbers for the
constructor field initialization.

In this case:

```
29: class B {
30:   // comment
31:   val bPropVal: Int,
32:   // comment
33:   var bProbVar: Int
34: ) {
```

the line numbers for the field initializations are 31 and 33 where
in the current backend the whole constructor has line number 29.