### PR TITLE
[JVM_IR] Mark delegated member functions as bridges.

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/FunctionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/FunctionCodegen.kt
@@ -168,7 +168,9 @@ class FunctionCodegen(
         }
 
         val isVararg = valueParameters.lastOrNull()?.varargElementType != null
-        val isBridge = origin == IrDeclarationOrigin.BRIDGE || origin == IrDeclarationOrigin.BRIDGE_SPECIAL
+        val isBridge = origin == IrDeclarationOrigin.BRIDGE
+                || origin == IrDeclarationOrigin.BRIDGE_SPECIAL
+                || origin == IrDeclarationOrigin.DELEGATED_MEMBER
         val modalityFlag = when ((this as? IrSimpleFunction)?.modality) {
             Modality.FINAL -> when {
                 origin == JvmLoweredDeclarationOrigin.CLASS_STATIC_INITIALIZER -> 0

--- a/compiler/testData/codegen/bytecodeListing/nullabilityAnnotations/nullabilityAnnotationsOnDelegatedMembers_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/nullabilityAnnotations/nullabilityAnnotationsOnDelegatedMembers_ir.txt
@@ -1,0 +1,12 @@
+@kotlin.Metadata
+public final class JImpl {
+    // source: 'nullabilityAnnotationsOnDelegatedMembers.kt'
+    private synthetic final field $$delegate_0: J
+    public method <init>(@org.jetbrains.annotations.NotNull p0: J): void
+    public bridge @org.jetbrains.annotations.NotNull method returnNotNull(): java.lang.String
+    public bridge @org.jetbrains.annotations.Nullable method returnNullable(): java.lang.String
+    public bridge method returnsFlexible(): java.lang.String
+    public bridge method takeFlexible(p0: java.lang.String): void
+    public bridge method takeNotNull(@org.jetbrains.annotations.NotNull p0: java.lang.String): void
+    public bridge method takeNullable(@org.jetbrains.annotations.Nullable p0: java.lang.String): void
+}

--- a/compiler/testData/codegen/bytecodeListing/rawTypeInSignature_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/rawTypeInSignature_ir.txt
@@ -19,16 +19,16 @@ public final class<<T:Ljava/lang/Number;>Ljava/lang/Object;>  GenericOut {
 @kotlin.Metadata
 public final class<null>  KRaw {
     // source: 'rawTypeInSignature.kt'
-    public <(Ljava/util/List<+Ljava/lang/Object;>;Ljava/util/List;)Ljava/util/List;> method bothRawAndGeneric(p0: java.util.List, p1: java.util.List): java.util.List
+    public bridge <(Ljava/util/List<+Ljava/lang/Object;>;Ljava/util/List;)Ljava/util/List;> method bothRawAndGeneric(p0: java.util.List, p1: java.util.List): java.util.List
     public <null> method <init>(@org.jetbrains.annotations.NotNull p0: JRaw): void
-    public <null> method returnsRawGenericIn(): GenericIn
-    public <null> method returnsRawGenericInv(): GenericInv
-    public <null> method returnsRawGenericOut(): GenericOut
-    public <null> method returnsRawList(): java.util.List
-    public <null> method takesRawGenericIn(p0: GenericIn): void
-    public <null> method takesRawGenericInv(p0: GenericInv): void
-    public <null> method takesRawGenericOut(p0: GenericOut): void
-    public <null> method takesRawList(p0: java.util.List): void
+    public bridge <null> method returnsRawGenericIn(): GenericIn
+    public bridge <null> method returnsRawGenericInv(): GenericInv
+    public bridge <null> method returnsRawGenericOut(): GenericOut
+    public bridge <null> method returnsRawList(): java.util.List
+    public bridge <null> method takesRawGenericIn(p0: GenericIn): void
+    public bridge <null> method takesRawGenericInv(p0: GenericInv): void
+    public bridge <null> method takesRawGenericOut(p0: GenericOut): void
+    public bridge <null> method takesRawList(p0: java.util.List): void
     private synthetic final field <null> $$delegate_0: JRaw
 }
 

--- a/compiler/testData/codegen/bytecodeListing/specialBridges/signatures/genericClass_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/specialBridges/signatures/genericClass_ir.txt
@@ -1,0 +1,45 @@
+@kotlin.Metadata
+public abstract class<<K:Ljava/lang/Object;V:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/Map<TK;TV;>;Lkotlin/jvm/internal/markers/KMutableMap;>  AbstractGenericMap {
+    // source: 'genericClass.kt'
+    public bridge @org.jetbrains.annotations.NotNull <()Ljava/util/Collection<TV;>;> method getValues(): java.util.Collection
+    public bridge final <()Ljava/util/Collection<TV;>;> method values(): java.util.Collection
+    public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<TK;TV;>;>;> method entrySet(): java.util.Set
+    public bridge @org.jetbrains.annotations.NotNull <()Ljava/util/Set<Ljava/util/Map$Entry<TK;TV;>;>;> method getEntries(): java.util.Set
+    public bridge @org.jetbrains.annotations.NotNull <()Ljava/util/Set<TK;>;> method getKeys(): java.util.Set
+    public bridge final <()Ljava/util/Set<TK;>;> method keySet(): java.util.Set
+    public bridge @org.jetbrains.annotations.Nullable <(Ljava/lang/Object;)TV;> method get(p0: java.lang.Object): java.lang.Object
+    public bridge @org.jetbrains.annotations.Nullable <(Ljava/lang/Object;)TV;> method remove(p0: java.lang.Object): java.lang.Object
+    public bridge <(Ljava/util/Map<+TK;+TV;>;)V> method putAll(@org.jetbrains.annotations.NotNull p0: java.util.Map): void
+    public bridge @org.jetbrains.annotations.Nullable <(TK;TV;)TV;> method put(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
+    public <null> method <init>(): void
+    public bridge <null> method clear(): void
+    public bridge <null> method containsKey(p0: java.lang.Object): boolean
+    public bridge <null> method containsValue(p0: java.lang.Object): boolean
+    public bridge <null> method getSize(): int
+    public bridge <null> method isEmpty(): boolean
+    public bridge final <null> method size(): int
+    private synthetic final field <Ljava/util/HashMap<TK;TV;>;> $$delegate_0: java.util.HashMap
+}
+
+@kotlin.Metadata
+public final class<<K:Ljava/lang/Object;V:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/Map<TK;TV;>;Lkotlin/jvm/internal/markers/KMutableMap;>  GenericMap {
+    // source: 'genericClass.kt'
+    public bridge @org.jetbrains.annotations.NotNull <()Ljava/util/Collection<TV;>;> method getValues(): java.util.Collection
+    public bridge final <()Ljava/util/Collection<TV;>;> method values(): java.util.Collection
+    public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<TK;TV;>;>;> method entrySet(): java.util.Set
+    public bridge @org.jetbrains.annotations.NotNull <()Ljava/util/Set<Ljava/util/Map$Entry<TK;TV;>;>;> method getEntries(): java.util.Set
+    public bridge @org.jetbrains.annotations.NotNull <()Ljava/util/Set<TK;>;> method getKeys(): java.util.Set
+    public bridge final <()Ljava/util/Set<TK;>;> method keySet(): java.util.Set
+    public bridge @org.jetbrains.annotations.Nullable <(Ljava/lang/Object;)TV;> method get(p0: java.lang.Object): java.lang.Object
+    public bridge @org.jetbrains.annotations.Nullable <(Ljava/lang/Object;)TV;> method remove(p0: java.lang.Object): java.lang.Object
+    public bridge <(Ljava/util/Map<+TK;+TV;>;)V> method putAll(@org.jetbrains.annotations.NotNull p0: java.util.Map): void
+    public bridge @org.jetbrains.annotations.Nullable <(TK;TV;)TV;> method put(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
+    public <null> method <init>(): void
+    public bridge <null> method clear(): void
+    public bridge <null> method containsKey(p0: java.lang.Object): boolean
+    public bridge <null> method containsValue(p0: java.lang.Object): boolean
+    public bridge <null> method getSize(): int
+    public bridge <null> method isEmpty(): boolean
+    public bridge final <null> method size(): int
+    private synthetic final field <Ljava/util/HashMap<TK;TV;>;> $$delegate_0: java.util.HashMap
+}

--- a/compiler/testData/codegen/bytecodeListing/specialBridges/signatures/nonGenericClass_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/specialBridges/signatures/nonGenericClass_ir.txt
@@ -1,27 +1,27 @@
 @kotlin.Metadata
 public abstract class<Ljava/lang/Object;Ljava/util/Map<Ljava/lang/String;Ljava/lang/String;>;Lkotlin/jvm/internal/markers/KMutableMap;>  AbstractStringStringMap {
     // source: 'nonGenericClass.kt'
-    public @org.jetbrains.annotations.NotNull <()Ljava/util/Collection<Ljava/lang/String;>;> method getValues(): java.util.Collection
+    public bridge @org.jetbrains.annotations.NotNull <()Ljava/util/Collection<Ljava/lang/String;>;> method getValues(): java.util.Collection
     public bridge final <()Ljava/util/Collection<Ljava/lang/String;>;> method values(): java.util.Collection
-    public @org.jetbrains.annotations.NotNull <()Ljava/util/Set<Ljava/lang/String;>;> method getKeys(): java.util.Set
+    public bridge @org.jetbrains.annotations.NotNull <()Ljava/util/Set<Ljava/lang/String;>;> method getKeys(): java.util.Set
     public bridge final <()Ljava/util/Set<Ljava/lang/String;>;> method keySet(): java.util.Set
     public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/String;Ljava/lang/String;>;>;> method entrySet(): java.util.Set
-    public @org.jetbrains.annotations.NotNull <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/String;Ljava/lang/String;>;>;> method getEntries(): java.util.Set
-    public <(Ljava/util/Map<+Ljava/lang/String;+Ljava/lang/String;>;)V> method putAll(@org.jetbrains.annotations.NotNull p0: java.util.Map): void
+    public bridge @org.jetbrains.annotations.NotNull <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/String;Ljava/lang/String;>;>;> method getEntries(): java.util.Set
+    public bridge <(Ljava/util/Map<+Ljava/lang/String;+Ljava/lang/String;>;)V> method putAll(@org.jetbrains.annotations.NotNull p0: java.util.Map): void
     public <null> method <init>(): void
-    public <null> method clear(): void
-    public <null> method containsKey(@org.jetbrains.annotations.NotNull p0: java.lang.String): boolean
+    public bridge <null> method clear(): void
+    public bridge <null> method containsKey(@org.jetbrains.annotations.NotNull p0: java.lang.String): boolean
     public bridge final <null> method containsKey(p0: java.lang.Object): boolean
-    public <null> method containsValue(@org.jetbrains.annotations.NotNull p0: java.lang.String): boolean
+    public bridge <null> method containsValue(@org.jetbrains.annotations.NotNull p0: java.lang.String): boolean
     public bridge final <null> method containsValue(p0: java.lang.Object): boolean
-    public @org.jetbrains.annotations.Nullable <null> method get(@org.jetbrains.annotations.NotNull p0: java.lang.String): java.lang.String
+    public bridge @org.jetbrains.annotations.Nullable <null> method get(@org.jetbrains.annotations.NotNull p0: java.lang.String): java.lang.String
     public synthetic bridge <null> method get(p0: java.lang.Object): java.lang.Object
     public bridge final <null> method get(p0: java.lang.Object): java.lang.String
-    public <null> method getSize(): int
-    public <null> method isEmpty(): boolean
-    public @org.jetbrains.annotations.Nullable <null> method put(@org.jetbrains.annotations.NotNull p0: java.lang.String, @org.jetbrains.annotations.NotNull p1: java.lang.String): java.lang.String
+    public bridge <null> method getSize(): int
+    public bridge <null> method isEmpty(): boolean
+    public bridge @org.jetbrains.annotations.Nullable <null> method put(@org.jetbrains.annotations.NotNull p0: java.lang.String, @org.jetbrains.annotations.NotNull p1: java.lang.String): java.lang.String
     public synthetic bridge <null> method put(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
-    public @org.jetbrains.annotations.Nullable <null> method remove(@org.jetbrains.annotations.NotNull p0: java.lang.String): java.lang.String
+    public bridge @org.jetbrains.annotations.Nullable <null> method remove(@org.jetbrains.annotations.NotNull p0: java.lang.String): java.lang.String
     public synthetic bridge <null> method remove(p0: java.lang.Object): java.lang.Object
     public bridge final <null> method remove(p0: java.lang.Object): java.lang.String
     public bridge final <null> method size(): int
@@ -31,27 +31,27 @@ public abstract class<Ljava/lang/Object;Ljava/util/Map<Ljava/lang/String;Ljava/l
 @kotlin.Metadata
 public final class<Ljava/lang/Object;Ljava/util/Map<Ljava/lang/String;Ljava/lang/String;>;Lkotlin/jvm/internal/markers/KMutableMap;>  StringStringMap {
     // source: 'nonGenericClass.kt'
-    public @org.jetbrains.annotations.NotNull <()Ljava/util/Collection<Ljava/lang/String;>;> method getValues(): java.util.Collection
+    public bridge @org.jetbrains.annotations.NotNull <()Ljava/util/Collection<Ljava/lang/String;>;> method getValues(): java.util.Collection
     public bridge final <()Ljava/util/Collection<Ljava/lang/String;>;> method values(): java.util.Collection
-    public @org.jetbrains.annotations.NotNull <()Ljava/util/Set<Ljava/lang/String;>;> method getKeys(): java.util.Set
+    public bridge @org.jetbrains.annotations.NotNull <()Ljava/util/Set<Ljava/lang/String;>;> method getKeys(): java.util.Set
     public bridge final <()Ljava/util/Set<Ljava/lang/String;>;> method keySet(): java.util.Set
     public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/String;Ljava/lang/String;>;>;> method entrySet(): java.util.Set
-    public @org.jetbrains.annotations.NotNull <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/String;Ljava/lang/String;>;>;> method getEntries(): java.util.Set
-    public <(Ljava/util/Map<+Ljava/lang/String;+Ljava/lang/String;>;)V> method putAll(@org.jetbrains.annotations.NotNull p0: java.util.Map): void
+    public bridge @org.jetbrains.annotations.NotNull <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/String;Ljava/lang/String;>;>;> method getEntries(): java.util.Set
+    public bridge <(Ljava/util/Map<+Ljava/lang/String;+Ljava/lang/String;>;)V> method putAll(@org.jetbrains.annotations.NotNull p0: java.util.Map): void
     public <null> method <init>(): void
-    public <null> method clear(): void
-    public <null> method containsKey(@org.jetbrains.annotations.NotNull p0: java.lang.String): boolean
+    public bridge <null> method clear(): void
+    public bridge <null> method containsKey(@org.jetbrains.annotations.NotNull p0: java.lang.String): boolean
     public bridge final <null> method containsKey(p0: java.lang.Object): boolean
-    public <null> method containsValue(@org.jetbrains.annotations.NotNull p0: java.lang.String): boolean
+    public bridge <null> method containsValue(@org.jetbrains.annotations.NotNull p0: java.lang.String): boolean
     public bridge final <null> method containsValue(p0: java.lang.Object): boolean
-    public @org.jetbrains.annotations.Nullable <null> method get(@org.jetbrains.annotations.NotNull p0: java.lang.String): java.lang.String
+    public bridge @org.jetbrains.annotations.Nullable <null> method get(@org.jetbrains.annotations.NotNull p0: java.lang.String): java.lang.String
     public synthetic bridge <null> method get(p0: java.lang.Object): java.lang.Object
     public bridge final <null> method get(p0: java.lang.Object): java.lang.String
-    public <null> method getSize(): int
-    public <null> method isEmpty(): boolean
-    public @org.jetbrains.annotations.Nullable <null> method put(@org.jetbrains.annotations.NotNull p0: java.lang.String, @org.jetbrains.annotations.NotNull p1: java.lang.String): java.lang.String
+    public bridge <null> method getSize(): int
+    public bridge <null> method isEmpty(): boolean
+    public bridge @org.jetbrains.annotations.Nullable <null> method put(@org.jetbrains.annotations.NotNull p0: java.lang.String, @org.jetbrains.annotations.NotNull p1: java.lang.String): java.lang.String
     public synthetic bridge <null> method put(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
-    public @org.jetbrains.annotations.Nullable <null> method remove(@org.jetbrains.annotations.NotNull p0: java.lang.String): java.lang.String
+    public bridge @org.jetbrains.annotations.Nullable <null> method remove(@org.jetbrains.annotations.NotNull p0: java.lang.String): java.lang.String
     public synthetic bridge <null> method remove(p0: java.lang.Object): java.lang.Object
     public bridge final <null> method remove(p0: java.lang.Object): java.lang.String
     public bridge final <null> method size(): int

--- a/compiler/testData/codegen/bytecodeListing/specialBridges/signatures/partiallySpecializedClass_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/specialBridges/signatures/partiallySpecializedClass_ir.txt
@@ -1,25 +1,25 @@
 @kotlin.Metadata
 public abstract class<<V:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/Map<Ljava/lang/String;TV;>;Lkotlin/jvm/internal/markers/KMutableMap;>  AbstractStringMap {
     // source: 'partiallySpecializedClass.kt'
-    public @org.jetbrains.annotations.NotNull <()Ljava/util/Collection<TV;>;> method getValues(): java.util.Collection
+    public bridge @org.jetbrains.annotations.NotNull <()Ljava/util/Collection<TV;>;> method getValues(): java.util.Collection
     public bridge final <()Ljava/util/Collection<TV;>;> method values(): java.util.Collection
-    public @org.jetbrains.annotations.NotNull <()Ljava/util/Set<Ljava/lang/String;>;> method getKeys(): java.util.Set
+    public bridge @org.jetbrains.annotations.NotNull <()Ljava/util/Set<Ljava/lang/String;>;> method getKeys(): java.util.Set
     public bridge final <()Ljava/util/Set<Ljava/lang/String;>;> method keySet(): java.util.Set
     public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/String;TV;>;>;> method entrySet(): java.util.Set
-    public @org.jetbrains.annotations.NotNull <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/String;TV;>;>;> method getEntries(): java.util.Set
-    public @org.jetbrains.annotations.Nullable <(Ljava/lang/Object;)TV;> method get(@org.jetbrains.annotations.NotNull p0: java.lang.String): java.lang.Object
+    public bridge @org.jetbrains.annotations.NotNull <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/String;TV;>;>;> method getEntries(): java.util.Set
+    public bridge @org.jetbrains.annotations.Nullable <(Ljava/lang/Object;)TV;> method get(@org.jetbrains.annotations.NotNull p0: java.lang.String): java.lang.Object
     public bridge final <(Ljava/lang/Object;)TV;> method get(p0: java.lang.Object): java.lang.Object
-    public @org.jetbrains.annotations.Nullable <(Ljava/lang/Object;)TV;> method remove(@org.jetbrains.annotations.NotNull p0: java.lang.String): java.lang.Object
+    public bridge @org.jetbrains.annotations.Nullable <(Ljava/lang/Object;)TV;> method remove(@org.jetbrains.annotations.NotNull p0: java.lang.String): java.lang.Object
     public bridge final <(Ljava/lang/Object;)TV;> method remove(p0: java.lang.Object): java.lang.Object
-    public @org.jetbrains.annotations.Nullable <(Ljava/lang/String;TV;)TV;> method put(@org.jetbrains.annotations.NotNull p0: java.lang.String, p1: java.lang.Object): java.lang.Object
-    public <(Ljava/util/Map<+Ljava/lang/String;+TV;>;)V> method putAll(@org.jetbrains.annotations.NotNull p0: java.util.Map): void
+    public bridge @org.jetbrains.annotations.Nullable <(Ljava/lang/String;TV;)TV;> method put(@org.jetbrains.annotations.NotNull p0: java.lang.String, p1: java.lang.Object): java.lang.Object
+    public bridge <(Ljava/util/Map<+Ljava/lang/String;+TV;>;)V> method putAll(@org.jetbrains.annotations.NotNull p0: java.util.Map): void
     public <null> method <init>(): void
-    public <null> method clear(): void
-    public <null> method containsKey(@org.jetbrains.annotations.NotNull p0: java.lang.String): boolean
+    public bridge <null> method clear(): void
+    public bridge <null> method containsKey(@org.jetbrains.annotations.NotNull p0: java.lang.String): boolean
     public bridge final <null> method containsKey(p0: java.lang.Object): boolean
-    public <null> method containsValue(p0: java.lang.Object): boolean
-    public <null> method getSize(): int
-    public <null> method isEmpty(): boolean
+    public bridge <null> method containsValue(p0: java.lang.Object): boolean
+    public bridge <null> method getSize(): int
+    public bridge <null> method isEmpty(): boolean
     public synthetic bridge <null> method put(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
     public bridge final <null> method size(): int
     private synthetic final field <Ljava/util/HashMap<Ljava/lang/String;TV;>;> $$delegate_0: java.util.HashMap
@@ -28,25 +28,25 @@ public abstract class<<V:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/Map<Lja
 @kotlin.Metadata
 public final class<<V:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/Map<Ljava/lang/String;TV;>;Lkotlin/jvm/internal/markers/KMutableMap;>  StringMap {
     // source: 'partiallySpecializedClass.kt'
-    public @org.jetbrains.annotations.NotNull <()Ljava/util/Collection<TV;>;> method getValues(): java.util.Collection
+    public bridge @org.jetbrains.annotations.NotNull <()Ljava/util/Collection<TV;>;> method getValues(): java.util.Collection
     public bridge final <()Ljava/util/Collection<TV;>;> method values(): java.util.Collection
-    public @org.jetbrains.annotations.NotNull <()Ljava/util/Set<Ljava/lang/String;>;> method getKeys(): java.util.Set
+    public bridge @org.jetbrains.annotations.NotNull <()Ljava/util/Set<Ljava/lang/String;>;> method getKeys(): java.util.Set
     public bridge final <()Ljava/util/Set<Ljava/lang/String;>;> method keySet(): java.util.Set
     public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/String;TV;>;>;> method entrySet(): java.util.Set
-    public @org.jetbrains.annotations.NotNull <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/String;TV;>;>;> method getEntries(): java.util.Set
-    public @org.jetbrains.annotations.Nullable <(Ljava/lang/Object;)TV;> method get(@org.jetbrains.annotations.NotNull p0: java.lang.String): java.lang.Object
+    public bridge @org.jetbrains.annotations.NotNull <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/String;TV;>;>;> method getEntries(): java.util.Set
+    public bridge @org.jetbrains.annotations.Nullable <(Ljava/lang/Object;)TV;> method get(@org.jetbrains.annotations.NotNull p0: java.lang.String): java.lang.Object
     public bridge final <(Ljava/lang/Object;)TV;> method get(p0: java.lang.Object): java.lang.Object
-    public @org.jetbrains.annotations.Nullable <(Ljava/lang/Object;)TV;> method remove(@org.jetbrains.annotations.NotNull p0: java.lang.String): java.lang.Object
+    public bridge @org.jetbrains.annotations.Nullable <(Ljava/lang/Object;)TV;> method remove(@org.jetbrains.annotations.NotNull p0: java.lang.String): java.lang.Object
     public bridge final <(Ljava/lang/Object;)TV;> method remove(p0: java.lang.Object): java.lang.Object
-    public @org.jetbrains.annotations.Nullable <(Ljava/lang/String;TV;)TV;> method put(@org.jetbrains.annotations.NotNull p0: java.lang.String, p1: java.lang.Object): java.lang.Object
-    public <(Ljava/util/Map<+Ljava/lang/String;+TV;>;)V> method putAll(@org.jetbrains.annotations.NotNull p0: java.util.Map): void
+    public bridge @org.jetbrains.annotations.Nullable <(Ljava/lang/String;TV;)TV;> method put(@org.jetbrains.annotations.NotNull p0: java.lang.String, p1: java.lang.Object): java.lang.Object
+    public bridge <(Ljava/util/Map<+Ljava/lang/String;+TV;>;)V> method putAll(@org.jetbrains.annotations.NotNull p0: java.util.Map): void
     public <null> method <init>(): void
-    public <null> method clear(): void
-    public <null> method containsKey(@org.jetbrains.annotations.NotNull p0: java.lang.String): boolean
+    public bridge <null> method clear(): void
+    public bridge <null> method containsKey(@org.jetbrains.annotations.NotNull p0: java.lang.String): boolean
     public bridge final <null> method containsKey(p0: java.lang.Object): boolean
-    public <null> method containsValue(p0: java.lang.Object): boolean
-    public <null> method getSize(): int
-    public <null> method isEmpty(): boolean
+    public bridge <null> method containsValue(p0: java.lang.Object): boolean
+    public bridge <null> method getSize(): int
+    public bridge <null> method isEmpty(): boolean
     public synthetic bridge <null> method put(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
     public bridge final <null> method size(): int
     private synthetic final field <Ljava/util/HashMap<Ljava/lang/String;TV;>;> $$delegate_0: java.util.HashMap

--- a/idea/jvm-debugger/jvm-debugger-test/testData/stepping/custom/smartStepIntoWithDelegates.out
+++ b/idea/jvm-debugger/jvm-debugger-test/testData/stepping/custom/smartStepIntoWithDelegates.out
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 LineBreakpoint created at smartStepIntoWithDelegates.kt:24
 LineBreakpoint created at smartStepIntoWithDelegates.kt:32
 LineBreakpoint created at smartStepIntoWithDelegates.kt:40


### PR DESCRIPTION
This allows them to have line numbers and at the same time have
smart step into work. Smart step into will step through bridges
to the final target which seems appropriate for these delegating
methods.