### PR TITLE
[JVM_IR] Ignore fwBackingField stepping test.

### DIFF
--- a/idea/jvm-debugger/jvm-debugger-test/testData/stepping/stepOut/fwBackingField.ir.out
+++ b/idea/jvm-debugger/jvm-debugger-test/testData/stepping/stepOut/fwBackingField.ir.out
@@ -1,3 +1,4 @@
+// IGNORE_BACKEND: JVM_IR
 KotlinFieldBreakpoint created at fwBackingField.kt:5
 KotlinFieldBreakpoint created at fwBackingField.kt:8
 KotlinFieldBreakpoint created at fwBackingField.kt:18


### PR DESCRIPTION
The test relies on fixes not yet landed, so it currently fails.