### PR TITLE
[JVM_IR] Remove line numbers from delegated member functions.

### DIFF
--- a/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/ClassGenerator.kt
+++ b/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/ClassGenerator.kt
@@ -19,6 +19,7 @@ package org.jetbrains.kotlin.psi2ir.generators
 import org.jetbrains.kotlin.backend.common.CodegenUtil
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.descriptors.*
+import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.descriptors.IrImplementingDelegateDescriptorImpl
 import org.jetbrains.kotlin.ir.expressions.IrBlockBody
@@ -305,7 +306,7 @@ class ClassGenerator(
         delegateToDescriptor: FunctionDescriptor
     ): IrSimpleFunction =
         context.symbolTable.declareSimpleFunctionWithOverrides(
-            irDelegate.startOffset, irDelegate.endOffset,
+            UNDEFINED_OFFSET, UNDEFINED_OFFSET,
             IrDeclarationOrigin.DELEGATED_MEMBER,
             delegatedDescriptor
         ).buildWithScope { irFunction ->
@@ -323,8 +324,8 @@ class ClassGenerator(
         delegateToDescriptor: FunctionDescriptor,
         irDelegatedFunction: IrSimpleFunction
     ): IrBlockBody {
-        val startOffset = irDelegate.startOffset
-        val endOffset = irDelegate.endOffset
+        val startOffset = UNDEFINED_OFFSET
+        val endOffset = UNDEFINED_OFFSET
 
         val irBlockBody = context.irFactory.createBlockBody(startOffset, endOffset)
 

--- a/compiler/testData/diagnostics/testsWithJvmBackend/duplicateJvmSignature/accidentalOverrides/delegatedFunctionOverriddenByProperty_ir.kt
+++ b/compiler/testData/diagnostics/testsWithJvmBackend/duplicateJvmSignature/accidentalOverrides/delegatedFunctionOverriddenByProperty_ir.kt
@@ -7,4 +7,4 @@ interface D {
     val x: Int
 }
 
-class C(d: D) : D by <!ACCIDENTAL_OVERRIDE!>d<!>, B
+class <!ACCIDENTAL_OVERRIDE!>C(d: D)<!> : D by d, B

--- a/compiler/testData/diagnostics/testsWithJvmBackend/duplicateJvmSignature/erasure/delegateToTwoTraits_ir.kt
+++ b/compiler/testData/diagnostics/testsWithJvmBackend/duplicateJvmSignature/erasure/delegateToTwoTraits_ir.kt
@@ -9,7 +9,7 @@ interface Bar<T> {
     fun foo(l: List<T>)
 }
 
-class Baz(f: Foo<String>, b: Bar<Int>) :
-    Foo<String> by <!CONFLICTING_JVM_DECLARATIONS!>f<!>,
-    Bar<Int> by <!CONFLICTING_JVM_DECLARATIONS!>b<!> {
+class <!CONFLICTING_JVM_DECLARATIONS!>Baz(f: Foo<String>, b: Bar<Int>)<!> :
+    Foo<String> by f,
+    Bar<Int> by b {
 }

--- a/compiler/testData/diagnostics/testsWithJvmBackend/duplicateJvmSignature/erasure/delegationAndOwnMethod_ir.kt
+++ b/compiler/testData/diagnostics/testsWithJvmBackend/duplicateJvmSignature/erasure/delegationAndOwnMethod_ir.kt
@@ -5,6 +5,6 @@ interface Foo<T> {
     fun foo(l: List<T>)
 }
 
-class Bar(f: Foo<String>): Foo<String> by <!CONFLICTING_JVM_DECLARATIONS!>f<!> {
+class <!CONFLICTING_JVM_DECLARATIONS!>Bar(f: Foo<String>)<!>: Foo<String> by f {
     <!CONFLICTING_JVM_DECLARATIONS!>fun foo(l: List<Int>)<!> {}
 }

--- a/compiler/testData/diagnostics/testsWithJvmBackend/duplicateJvmSignature/erasure/delegationToTraitImplAndOwnMethod_ir.kt
+++ b/compiler/testData/diagnostics/testsWithJvmBackend/duplicateJvmSignature/erasure/delegationToTraitImplAndOwnMethod_ir.kt
@@ -7,7 +7,7 @@ interface Foo<T> {
     }
 }
 
-class Bar(f: Foo<String>): Foo<String> by <!CONFLICTING_JVM_DECLARATIONS!>f<!> {
+class <!CONFLICTING_JVM_DECLARATIONS!>Bar(f: Foo<String>)<!>: Foo<String> by f {
     <!CONFLICTING_JVM_DECLARATIONS!>fun foo(l: List<Int>)<!> {}
 }
 

--- a/compiler/testData/diagnostics/testsWithJvmBackend/duplicateJvmSignature/erasure/superTraitAndDelegationToTraitImpl_ir.kt
+++ b/compiler/testData/diagnostics/testsWithJvmBackend/duplicateJvmSignature/erasure/superTraitAndDelegationToTraitImpl_ir.kt
@@ -9,6 +9,6 @@ interface B {
     fun foo(l: List<Int>) {}
 }
 
-class C(f: A<String>): A<String> by <!ACCIDENTAL_OVERRIDE!>f<!>, B
+class <!ACCIDENTAL_OVERRIDE!>C(f: A<String>)<!>: A<String> by f, B
 
 <!DELEGATED_MEMBER_HIDES_SUPERTYPE_OVERRIDE!>class D<!>(f: A<Int>): A<Int> by f, B

--- a/idea/jvm-debugger/jvm-debugger-test/testData/stepping/custom/smartStepIntoWithDelegates.out
+++ b/idea/jvm-debugger/jvm-debugger-test/testData/stepping/custom/smartStepIntoWithDelegates.out
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 LineBreakpoint created at smartStepIntoWithDelegates.kt:24
 LineBreakpoint created at smartStepIntoWithDelegates.kt:32
 LineBreakpoint created at smartStepIntoWithDelegates.kt:40


### PR DESCRIPTION
This fixes smart step into for delegated member functions.
Additionally, we align on the string "memberFunctionName(...)"
for expression non-null checks for both JVM_IR and JVM
backends.