### PR TITLE
JVM_IR: fix lifting of arguments to object super constructors

### DIFF
--- a/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
@@ -310,6 +310,11 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
             runTest("compiler/testData/codegen/box/argumentOrder/argumentOrderInObjectSuperCall.kt");
         }
 
+        @TestMetadata("argumentOrderInObjectSuperCallWithPlatformType.kt")
+        public void testArgumentOrderInObjectSuperCallWithPlatformType() throws Exception {
+            runTest("compiler/testData/codegen/box/argumentOrder/argumentOrderInObjectSuperCallWithPlatformType.kt");
+        }
+
         @TestMetadata("argumentOrderInSuperCall.kt")
         public void testArgumentOrderInSuperCall() throws Exception {
             runTest("compiler/testData/codegen/box/argumentOrder/argumentOrderInSuperCall.kt");

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/AnonymousObjectSuperConstructorLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/AnonymousObjectSuperConstructorLowering.kt
@@ -21,6 +21,7 @@ import org.jetbrains.kotlin.ir.declarations.IrVariable
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.expressions.impl.IrConstructorCallImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrGetValueImpl
+import org.jetbrains.kotlin.ir.expressions.impl.IrTypeOperatorCallImpl
 import org.jetbrains.kotlin.ir.util.transformInPlace
 
 internal val anonymousObjectSuperConstructorPhase = makeIrFilePhase(
@@ -78,16 +79,19 @@ private class AnonymousObjectSuperConstructorLowering(val context: JvmBackendCon
             )
         }
 
+        fun IrExpression.transform(remapping: Map<IrVariable, IrValueParameter>): IrExpression =
+            when (this) {
+                is IrConst<*> -> this
+                is IrGetValue -> IrGetValueImpl(startOffset, endOffset, remapping[symbol.owner]?.symbol ?: symbol)
+                is IrTypeOperatorCall ->
+                    IrTypeOperatorCallImpl(startOffset, endOffset, type, operator, typeOperand, argument.transform(remapping))
+                else -> IrGetValueImpl(startOffset, endOffset, addArgument(this).symbol)
+            }
+
         fun IrDelegatingConstructorCall.transform(lift: List<IrVariable>) = apply {
             val remapping = lift.associateWith { addArgument(it.initializer!!) }
-            for (i in 0 until symbol.owner.valueParameters.size) {
-                val argument = getValueArgument(i) ?: continue
-                val mapped = when (argument) {
-                    is IrConst<*> -> null
-                    is IrGetValue -> remapping[argument.symbol.owner]
-                    else -> addArgument(argument)
-                } ?: continue
-                putValueArgument(i, IrGetValueImpl(argument.startOffset, argument.endOffset, mapped.symbol))
+            for (i in symbol.owner.valueParameters.indices) {
+                putValueArgument(i, getValueArgument(i)?.transform(remapping))
             }
         }
 

--- a/compiler/testData/codegen/box/argumentOrder/argumentOrderInObjectSuperCallWithPlatformType.kt
+++ b/compiler/testData/codegen/box/argumentOrder/argumentOrderInObjectSuperCallWithPlatformType.kt
@@ -1,0 +1,13 @@
+// TARGET_PLATFORM: JVM
+// FILE: A.java
+public class A {
+    public static String f() {
+        return "O";
+    }
+}
+// FILE: a.kt
+open class C(x: String, y: String) {
+    val result = x + y
+}
+
+fun box() = object : C(y = "K", x = A.f()) {}.result

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -310,6 +310,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             runTest("compiler/testData/codegen/box/argumentOrder/argumentOrderInObjectSuperCall.kt");
         }
 
+        @TestMetadata("argumentOrderInObjectSuperCallWithPlatformType.kt")
+        public void testArgumentOrderInObjectSuperCallWithPlatformType() throws Exception {
+            runTest("compiler/testData/codegen/box/argumentOrder/argumentOrderInObjectSuperCallWithPlatformType.kt");
+        }
+
         @TestMetadata("argumentOrderInSuperCall.kt")
         public void testArgumentOrderInSuperCall() throws Exception {
             runTest("compiler/testData/codegen/box/argumentOrder/argumentOrderInSuperCall.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -310,6 +310,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/argumentOrder/argumentOrderInObjectSuperCall.kt");
         }
 
+        @TestMetadata("argumentOrderInObjectSuperCallWithPlatformType.kt")
+        public void testArgumentOrderInObjectSuperCallWithPlatformType() throws Exception {
+            runTest("compiler/testData/codegen/box/argumentOrder/argumentOrderInObjectSuperCallWithPlatformType.kt");
+        }
+
         @TestMetadata("argumentOrderInSuperCall.kt")
         public void testArgumentOrderInSuperCall() throws Exception {
             runTest("compiler/testData/codegen/box/argumentOrder/argumentOrderInSuperCall.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -310,6 +310,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             runTest("compiler/testData/codegen/box/argumentOrder/argumentOrderInObjectSuperCall.kt");
         }
 
+        @TestMetadata("argumentOrderInObjectSuperCallWithPlatformType.kt")
+        public void testArgumentOrderInObjectSuperCallWithPlatformType() throws Exception {
+            runTest("compiler/testData/codegen/box/argumentOrder/argumentOrderInObjectSuperCallWithPlatformType.kt");
+        }
+
         @TestMetadata("argumentOrderInSuperCall.kt")
         public void testArgumentOrderInSuperCall() throws Exception {
             runTest("compiler/testData/codegen/box/argumentOrder/argumentOrderInSuperCall.kt");


### PR DESCRIPTION
If the arguments are reordered, they can not only be reads of temporary variables, but also implicit type casts of said reads.

Fixes #KT-42002