### PR TITLE
[JVM_IR] Fix offsets in constant propagation optimization.

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/ConstLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/ConstLowering.kt
@@ -13,8 +13,10 @@ import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
 import org.jetbrains.kotlin.ir.declarations.IrField
 import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
-import org.jetbrains.kotlin.ir.expressions.*
-import org.jetbrains.kotlin.ir.expressions.impl.IrConstImpl
+import org.jetbrains.kotlin.ir.expressions.IrCall
+import org.jetbrains.kotlin.ir.expressions.IrConst
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.IrGetField
 import org.jetbrains.kotlin.ir.expressions.impl.IrGetFieldImpl
 import org.jetbrains.kotlin.ir.types.isPrimitiveType
 import org.jetbrains.kotlin.ir.types.isStringClassType
@@ -40,9 +42,6 @@ fun IrField.constantValue(context: JvmBackendContext? = null): IrConst<*>? {
             (allowImplicitConst && (type.isPrimitiveType() || type.isStringClassType())))
     return if (implicitConst || correspondingPropertySymbol?.owner?.isConst == true) value else null
 }
-
-private fun <T> IrConst<T>.copyWithOffsets(startOffset: Int, endOffset: Int) =
-    IrConstImpl(startOffset, endOffset, type, kind, value)
 
 class ConstLowering(val context: JvmBackendContext) : IrElementTransformerVoid(), FileLoweringPass {
     override fun lower(irFile: IrFile) = irFile.transformChildrenVoid()

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/JvmOptimizationLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/JvmOptimizationLowering.kt
@@ -347,7 +347,7 @@ class JvmOptimizationLowering(val context: JvmBackendContext) : FileLoweringPass
                 // initializer with the constant initializer.
                 val variable = expression.symbol.owner
                 return if (isImmutableTemporaryVariableWithConstantValue(variable))
-                    ((variable as IrVariable).initializer!! as IrConst<*>).copy()
+                    ((variable as IrVariable).initializer!! as IrConst<*>).copyWithOffsets(expression.startOffset, expression.endOffset)
                 else
                     expression
             }

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/IrConst.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/IrConst.kt
@@ -21,6 +21,7 @@ abstract class IrConst<T> : IrExpression(), IrExpressionWithCopy {
     abstract val value: T
 
     abstract override fun copy(): IrConst<T>
+    abstract fun copyWithOffsets(startOffset: Int, endOffset: Int): IrConst<T>
 }
 
 sealed class IrConstKind<T>(val asString: kotlin.String) {

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrConstImpl.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrConstImpl.kt
@@ -34,6 +34,9 @@ class IrConstImpl<T>(
     override fun copy(): IrConst<T> =
         IrConstImpl(startOffset, endOffset, type, kind, value)
 
+    override fun copyWithOffsets(startOffset: Int, endOffset: Int) =
+        IrConstImpl(startOffset, endOffset, type, kind, value)
+
     companion object {
         fun string(startOffset: Int, endOffset: Int, type: IrType, value: String): IrConstImpl<String> =
             IrConstImpl(startOffset, endOffset, type, IrConstKind.String, value)

--- a/compiler/testData/debug/stepping/whenConstant.kt
+++ b/compiler/testData/debug/stepping/whenConstant.kt
@@ -1,0 +1,25 @@
+// FILE: test.kt
+
+fun box() {
+    when (1) {
+        2 ->
+            "2"
+        3 ->
+            "3"
+        else ->
+            "1"
+    }
+}
+
+// JVM_IR and JVM backends have different heuristics for when to use a switch.
+// JVM_IR does not use a switch in this case and therefore steps to the evaluation
+// of the condition for each of the cases.
+
+// LINENUMBERS
+// test.kt:4 box
+// LINENUMBERS JVM_IR
+// test.kt:5 box
+// test.kt:7 box
+// LINENUMBERS
+// test.kt:10 box
+// test.kt:12 box

--- a/compiler/tests/org/jetbrains/kotlin/codegen/debugInformation/IrSteppingTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/debugInformation/IrSteppingTestGenerated.java
@@ -434,6 +434,12 @@ public class IrSteppingTestGenerated extends AbstractIrSteppingTest {
     }
 
     @Test
+    @TestMetadata("whenConstant.kt")
+    public void testWhenConstant() throws Exception {
+        runTest("compiler/testData/debug/stepping/whenConstant.kt");
+    }
+
+    @Test
     @TestMetadata("whenIsChecks.kt")
     public void testWhenIsChecks() throws Exception {
         runTest("compiler/testData/debug/stepping/whenIsChecks.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/debugInformation/SteppingTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/debugInformation/SteppingTestGenerated.java
@@ -434,6 +434,12 @@ public class SteppingTestGenerated extends AbstractSteppingTest {
     }
 
     @Test
+    @TestMetadata("whenConstant.kt")
+    public void testWhenConstant() throws Exception {
+        runTest("compiler/testData/debug/stepping/whenConstant.kt");
+    }
+
+    @Test
     @TestMetadata("whenIsChecks.kt")
     public void testWhenIsChecks() throws Exception {
         runTest("compiler/testData/debug/stepping/whenIsChecks.kt");

--- a/idea/jvm-debugger/jvm-debugger-test/testData/stepping/stepOver/stepOverWhenWithInline.ir.out
+++ b/idea/jvm-debugger/jvm-debugger-test/testData/stepping/stepOver/stepOverWhenWithInline.ir.out
@@ -16,9 +16,12 @@ stepOverWhenWithInline.kt:26
 stepOverWhenWithInline.kt:27
 stepOverWhenWithInline.kt:25
 stepOverWhenWithInline.kt:32
+stepOverWhenWithInline.kt:33
 stepOverWhenWithInline.kt:34
 stepOverWhenWithInline.kt:32
 stepOverWhenWithInline.kt:38
+stepOverWhenWithInline.kt:39
+stepOverWhenWithInline.kt:42
 stepOverWhenWithInline.kt:43
 stepOverWhenWithInline.kt:38
 stepOverWhenWithInline.kt:51

--- a/idea/jvm-debugger/jvm-debugger-test/testData/stepping/stepOver/stepOverWhenWithInline.kt
+++ b/idea/jvm-debugger/jvm-debugger-test/testData/stepping/stepOver/stepOverWhenWithInline.kt
@@ -86,4 +86,7 @@ inline fun foo(f: () -> Int): Int {
 
 fun test(i: Int) = i
 
-// STEP_OVER: 32
+// STEP_OVER: 36
+
+// JVM_IR and JVM backends have different heuristics for when to use a table switch.
+// This results is minor differences in step over behavior.


### PR DESCRIPTION
Loads of temporary variables that contain constants are replaced
with a copy of the constant. This avoids locals loads and stores.
However, the copy of the constant needs to have the offset of
the load and not of the original constant.

Fixes KT-41963.