### PR TITLE
KGP: Clean up configurations setup

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/Kapt3KotlinGradleSubplugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/Kapt3KotlinGradleSubplugin.kt
@@ -447,7 +447,13 @@ class Kapt3GradleSubplugin @Inject internal constructor(private val registry: To
                 }
             }
 
-            kaptTask.kaptClasspathConfigurations = kaptClasspathConfigurations
+            val kaptClasspathConfiguration =
+                project.configurations.create("_kaptClasspath_" + kaptTask.name).setExtendsFrom(kaptClasspathConfigurations).also {
+                    it.isVisible = false
+                    it.isCanBeConsumed = false
+                }
+            kaptTask.kaptClasspath.from(kaptClasspathConfiguration)
+            kaptTask.kaptClasspathConfigurationNames.set(kaptClasspathConfigurations.map { it.name })
 
             KaptWithAndroid.androidVariantData(this)?.annotationProcessorOptionProviders?.let {
                 kaptTask.annotationProcessorOptionProviders.add(it)

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/KaptTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/KaptTask.kt
@@ -1,8 +1,9 @@
 package org.jetbrains.kotlin.gradle.internal
 
-import org.gradle.api.artifacts.Configuration
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.ConventionTask
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.tasks.*
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs
 import org.jetbrains.kotlin.gradle.internal.kapt.incremental.ClasspathSnapshot
@@ -41,8 +42,7 @@ abstract class KaptTask : ConventionTask(), TaskWithLocalState {
 
     @get:Classpath
     @get:InputFiles
-    val kaptClasspath: FileCollection
-        get() = objects.fileCollection().from(kaptClasspathConfigurations)
+    abstract val kaptClasspath: ConfigurableFileCollection
 
     @get:Classpath
     @get:InputFiles
@@ -51,7 +51,7 @@ abstract class KaptTask : ConventionTask(), TaskWithLocalState {
     }
 
     @get:Internal
-    internal lateinit var kaptClasspathConfigurations: List<Configuration>
+    internal abstract val kaptClasspathConfigurationNames: ListProperty<String>
 
 
     @get:PathSensitive(PathSensitivity.NONE)
@@ -189,7 +189,7 @@ abstract class KaptTask : ConventionTask(), TaskWithLocalState {
                             + "\nThe following files, containing annotation processors, are not present in KAPT classpath:\n"
                             + processorsAbsentInKaptClasspath.joinToString("\n") { "  '$it'" }
                             + "\nAdd corresponding dependencies to any of the following configurations:\n"
-                            + kaptClasspathConfigurations.joinToString("\n") { " '${it.name}'" }
+                            + kaptClasspathConfigurationNames.get().joinToString("\n") { " '$it'" }
                 )
             } else {
                 logger.warn(

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/KaptWithKotlincTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/KaptWithKotlincTask.kt
@@ -29,7 +29,7 @@ import org.jetbrains.kotlin.gradle.utils.optionalProvider
 import org.jetbrains.kotlin.gradle.utils.toSortedPathsArray
 import java.io.File
 
-open class KaptWithKotlincTask : KaptTask(), CompilerArgumentAwareWithInput<K2JVMCompilerArguments> {
+abstract class KaptWithKotlincTask : KaptTask(), CompilerArgumentAwareWithInput<K2JVMCompilerArguments> {
     @get:Internal
     internal val pluginOptions = CompilerPluginOptions()
 

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/KaptWithoutKotlincTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/KaptWithoutKotlincTask.kt
@@ -24,7 +24,7 @@ import java.net.URL
 import java.net.URLClassLoader
 import javax.inject.Inject
 
-open class KaptWithoutKotlincTask @Inject constructor(private val workerExecutor: WorkerExecutor) : KaptTask() {
+abstract class KaptWithoutKotlincTask @Inject constructor(private val workerExecutor: WorkerExecutor) : KaptTask() {
     @get:InputFiles
     @get:Classpath
     @Suppress("unused")

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/utils/gradleConfigurationUtils.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/utils/gradleConfigurationUtils.kt
@@ -6,11 +6,14 @@
 package org.jetbrains.kotlin.gradle.utils
 
 import org.gradle.api.Project
+import java.lang.RuntimeException
 
 fun Project.addExtendsFromRelation(extendingConfigurationName: String, extendsFromConfigurationName: String, forced: Boolean = true) {
-    if (extendingConfigurationName != extendsFromConfigurationName) {
-        if (forced || configurations.findByName(extendingConfigurationName) != null) {
-            project.dependencies.add(extendingConfigurationName, project.configurations.getByName(extendsFromConfigurationName))
-        }
-    }
+    if (extendingConfigurationName == extendsFromConfigurationName) return
+
+    val extending = configurations.findByName(extendingConfigurationName)
+        ?: if (forced) throw RuntimeException("Configuration $extendingConfigurationName does not exist.")
+        else return
+
+    extending.extendsFrom(configurations.getByName(extendsFromConfigurationName))
 }


### PR DESCRIPTION
KAPT classpath now uses extendsFrom in order to
resolve all configurations as a single graph.

Also, use Configuration.extendsFrom instead of
DependencyHandler.add that is being deprecated
in Gradle 6.7.