### PR TITLE
KT-38692: Clean-up outputs on non-incremental run

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/Tasks.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/Tasks.kt
@@ -334,6 +334,8 @@ abstract class AbstractKotlinCompile<T : CommonCompilerArguments>() : AbstractKo
 
         if (!isIncrementalCompilationEnabled()) {
             clearLocalState("IC is disabled")
+        } else if (!inputs.isIncremental) {
+            clearLocalState("Task cannot run incrementally")
         }
 
         try {


### PR DESCRIPTION
Always clean all outputs on non-incremental run of the
Kotlin compile task. This fixes KT-38692.

Test: KotlinGradlePluginIT.testIncrementalWhenNoKotlinSources