### PR TITLE
[JVM_IR] Fix expectations for parcelize tests.

### DIFF
--- a/plugins/parcelize/parcelize-compiler/testData/codegen/customParcelablesSameModule.ir.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/customParcelablesSameModule.ir.txt
@@ -29,6 +29,7 @@ public final class k/KotlinParcelable$Creator : java/lang/Object, android/os/Par
 
     public java.lang.Object createFromParcel(android.os.Parcel p0) {
         LABEL (L0)
+        LINENUMBER (21)
           ALOAD (0)
           ALOAD (1)
           INVOKEVIRTUAL (k/KotlinParcelable$Creator, createFromParcel, (Landroid/os/Parcel;)Lk/KotlinParcelable;)

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/customSimple.ir.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/customSimple.ir.txt
@@ -20,6 +20,7 @@ final class User$Companion : java/lang/Object, kotlinx/parcelize/Parceler {
 
     public java.lang.Object[] newArray(int size) {
         LABEL (L0)
+        LINENUMBER (10)
           ALOAD (0)
           ILOAD (1)
           INVOKEVIRTUAL (User$Companion, newArray, (I)[LUser;)

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/customSimpleDeprecated.ir.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/customSimpleDeprecated.ir.txt
@@ -21,6 +21,7 @@ final class User$Companion : java/lang/Object, kotlinx/android/parcel/Parceler {
 
     public java.lang.Object[] newArray(int size) {
         LABEL (L0)
+        LINENUMBER (10)
           ALOAD (0)
           ILOAD (1)
           INVOKEVIRTUAL (User$Companion, newArray, (I)[LUser;)

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/customSimpleWithNewArray.ir.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/customSimpleWithNewArray.ir.txt
@@ -18,6 +18,7 @@ final class User$Companion : java/lang/Object, kotlinx/parcelize/Parceler {
 
     public java.lang.Object[] newArray(int size) {
         LABEL (L0)
+        LINENUMBER (10)
           ALOAD (0)
           ILOAD (1)
           INVOKEVIRTUAL (User$Companion, newArray, (I)[LUser;)


### PR DESCRIPTION
The generated bridges now have line numbers as for the JVM
backend. There are some extra (irrelevant) labels in the JVM_IR
bytecode listing compared to JVM so expectations can still not
be shared even though they are closer.