### PR TITLE
[FIR] Capture array and indices, handle varargs in overloaded indexed access operator, keep argument order

### DIFF
--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/generators/CallAndReferenceGenerator.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/generators/CallAndReferenceGenerator.kt
@@ -456,7 +456,7 @@ class CallAndReferenceGenerator(
     }
 
     private fun IrMemberAccessExpression<*>.applyArgumentsWithReorderingIfNeeded(
-        argumentMapping: Map<FirExpression, FirValueParameter>,
+        argumentMapping: LinkedHashMap<FirExpression, FirValueParameter>,
         valueParameters: List<FirValueParameter>,
         annotationMode: Boolean
     ): IrExpression {

--- a/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
@@ -12991,6 +12991,11 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
             KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/increment"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
         }
 
+        @TestMetadata("argumentWithSideEffects.kt")
+        public void testArgumentWithSideEffects() throws Exception {
+            runTest("compiler/testData/codegen/box/increment/argumentWithSideEffects.kt");
+        }
+
         @TestMetadata("arrayElement.kt")
         public void testArrayElement() throws Exception {
             runTest("compiler/testData/codegen/box/increment/arrayElement.kt");

--- a/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
@@ -13016,6 +13016,11 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
             runTest("compiler/testData/codegen/box/increment/classVarargGetSet.kt");
         }
 
+        @TestMetadata("classVarargGetSetEvaluationOrder.kt")
+        public void testClassVarargGetSetEvaluationOrder() throws Exception {
+            runTest("compiler/testData/codegen/box/increment/classVarargGetSetEvaluationOrder.kt");
+        }
+
         @TestMetadata("classWithGetSet.kt")
         public void testClassWithGetSet() throws Exception {
             runTest("compiler/testData/codegen/box/increment/classWithGetSet.kt");
@@ -17860,6 +17865,11 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         @TestMetadata("varargs.kt")
         public void testVarargs() throws Exception {
             runTest("compiler/testData/codegen/box/mixedNamedPosition/varargs.kt");
+        }
+
+        @TestMetadata("varargsEvaluationOrder.kt")
+        public void testVarargsEvaluationOrder() throws Exception {
+            runTest("compiler/testData/codegen/box/mixedNamedPosition/varargsEvaluationOrder.kt");
         }
     }
 
@@ -31534,6 +31544,11 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         @TestMetadata("emptyVarargOfBoxedPrimitiveType.kt")
         public void testEmptyVarargOfBoxedPrimitiveType() throws Exception {
             runTest("compiler/testData/codegen/box/vararg/emptyVarargOfBoxedPrimitiveType.kt");
+        }
+
+        @TestMetadata("evaluationOrder.kt")
+        public void testEvaluationOrder() throws Exception {
+            runTest("compiler/testData/codegen/box/vararg/evaluationOrder.kt");
         }
 
         @TestMetadata("kt1978.kt")

--- a/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
@@ -13011,6 +13011,11 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
             runTest("compiler/testData/codegen/box/increment/classNaryGetSet.kt");
         }
 
+        @TestMetadata("classVarargGetSet.kt")
+        public void testClassVarargGetSet() throws Exception {
+            runTest("compiler/testData/codegen/box/increment/classVarargGetSet.kt");
+        }
+
         @TestMetadata("classWithGetSet.kt")
         public void testClassWithGetSet() throws Exception {
             runTest("compiler/testData/codegen/box/increment/classWithGetSet.kt");

--- a/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxInlineCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxInlineCodegenTestGenerated.java
@@ -594,6 +594,11 @@ public class FirBlackBoxInlineCodegenTestGenerated extends AbstractFirBlackBoxIn
             runTest("compiler/testData/codegen/boxInline/argumentOrder/defaultParametersAndLastVararg.kt");
         }
 
+        @TestMetadata("defaultParametersAndLastVarargWithCorrectOrder.kt")
+        public void testDefaultParametersAndLastVarargWithCorrectOrder() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/argumentOrder/defaultParametersAndLastVarargWithCorrectOrder.kt");
+        }
+
         @TestMetadata("extension.kt")
         public void testExtension() throws Exception {
             runTest("compiler/testData/codegen/boxInline/argumentOrder/extension.kt");
@@ -627,6 +632,11 @@ public class FirBlackBoxInlineCodegenTestGenerated extends AbstractFirBlackBoxIn
         @TestMetadata("varargAndDefaultParameters.kt")
         public void testVarargAndDefaultParameters() throws Exception {
             runTest("compiler/testData/codegen/boxInline/argumentOrder/varargAndDefaultParameters.kt");
+        }
+
+        @TestMetadata("varargAndDefaultParametersWithCorrectOrder.kt")
+        public void testVarargAndDefaultParametersWithCorrectOrder() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/argumentOrder/varargAndDefaultParametersWithCorrectOrder.kt");
         }
     }
 

--- a/compiler/fir/raw-fir/light-tree2fir/src/org/jetbrains/kotlin/fir/lightTree/converter/BaseConverter.kt
+++ b/compiler/fir/raw-fir/light-tree2fir/src/org/jetbrains/kotlin/fir/lightTree/converter/BaseConverter.kt
@@ -115,6 +115,12 @@ open class BaseConverter(
             return null
         }
 
+    override val LighterASTNode?.arrayExpression: LighterASTNode?
+        get() = this?.getFirstChildExpression()
+
+    override val LighterASTNode?.indexExpressions: List<LighterASTNode>?
+        get() = this?.getLastChildExpression()?.getChildrenAsArray()?.filterNotNull()?.filter { it.isExpression() }
+
     fun LighterASTNode.getParent(): LighterASTNode? {
         return tree.getParent(this)
     }

--- a/compiler/fir/raw-fir/psi2fir/src/org/jetbrains/kotlin/fir/builder/RawFirBuilder.kt
+++ b/compiler/fir/raw-fir/psi2fir/src/org/jetbrains/kotlin/fir/builder/RawFirBuilder.kt
@@ -132,6 +132,12 @@ class RawFirBuilder(
     override val PsiElement?.selectorExpression: PsiElement?
         get() = (this as? KtQualifiedExpression)?.selectorExpression
 
+    override val PsiElement?.arrayExpression: PsiElement?
+        get() = (this as? KtArrayAccessExpression)?.arrayExpression
+
+    override val PsiElement?.indexExpressions: List<PsiElement>?
+        get() = (this as? KtArrayAccessExpression)?.indexExpressions
+
     private val KtModifierListOwner.visibility: Visibility
         get() = with(modifierList) {
             when {

--- a/compiler/fir/raw-fir/psi2fir/testData/rawBuilder/expressions/unary.txt
+++ b/compiler/fir/raw-fir/psi2fir/testData/rawBuilder/expressions/unary.txt
@@ -57,14 +57,18 @@ FILE: unary.kt
     }
     public? final? fun test3(arr: Array<Int>): R|kotlin/Unit| {
         lval x1: <implicit> =  {
-            lval <unary>: <implicit> = arr#.get#(IntegerLiteral(0))
-            arr#.set#(IntegerLiteral(0), R|<local>/<unary>|.inc#())
+            lval <array>: <implicit> = arr#
+            lval <index0>: <implicit> = IntegerLiteral(0)
+            lval <unary>: <implicit> = R|<local>/<array>|.get#(R|<local>/<index0>|)
+            R|<local>/<array>|.set#(R|<local>/<index0>|, R|<local>/<unary>|.inc#())
             R|<local>/<unary>|
         }
 
         lval x2: <implicit> =  {
-            lval <unary-result>: <implicit> = arr#.get#(IntegerLiteral(1)).inc#()
-            arr#.set#(IntegerLiteral(1), R|<local>/<unary-result>|)
+            lval <array>: <implicit> = arr#
+            lval <index0>: <implicit> = IntegerLiteral(1)
+            lval <unary-result>: <implicit> = R|<local>/<array>|.get#(R|<local>/<index0>|).inc#()
+            R|<local>/<array>|.set#(R|<local>/<index0>|, R|<local>/<unary-result>|)
             R|<local>/<unary-result>|
         }
 
@@ -80,14 +84,18 @@ FILE: unary.kt
     }
     public? final? fun test4(y: Y): R|kotlin/Unit| {
         lval x1: <implicit> =  {
-            lval <unary>: <implicit> = y#.arr#.get#(IntegerLiteral(0))
-            y#.arr#.set#(IntegerLiteral(0), R|<local>/<unary>|.inc#())
+            lval <array>: <implicit> = y#.arr#
+            lval <index0>: <implicit> = IntegerLiteral(0)
+            lval <unary>: <implicit> = R|<local>/<array>|.get#(R|<local>/<index0>|)
+            R|<local>/<array>|.set#(R|<local>/<index0>|, R|<local>/<unary>|.inc#())
             R|<local>/<unary>|
         }
 
         lval x2: <implicit> =  {
-            lval <unary-result>: <implicit> = y#.arr#.get#(IntegerLiteral(1)).inc#()
-            y#.arr#.set#(IntegerLiteral(1), R|<local>/<unary-result>|)
+            lval <array>: <implicit> = y#.arr#
+            lval <index0>: <implicit> = IntegerLiteral(1)
+            lval <unary-result>: <implicit> = R|<local>/<array>|.get#(R|<local>/<index0>|).inc#()
+            R|<local>/<array>|.set#(R|<local>/<index0>|, R|<local>/<unary-result>|)
             R|<local>/<unary-result>|
         }
 

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/Candidate.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/Candidate.kt
@@ -104,7 +104,6 @@ class Candidate(
 
     var argumentMapping: Map<FirExpression, FirValueParameter>? = null
     var numDefaults: Int = 0
-    var oldToNewArgumentMapping: Map<FirExpression, FirExpression>? = null
     lateinit var typeArgumentMapping: TypeArgumentMapping
     val postponedAtoms = mutableListOf<PostponedResolvedAtom>()
 

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/Candidate.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/Candidate.kt
@@ -102,7 +102,7 @@ class Candidate(
     var usesSAM: Boolean = false
     var usesSuspendConversion: Boolean = false
 
-    var argumentMapping: Map<FirExpression, FirValueParameter>? = null
+    var argumentMapping: LinkedHashMap<FirExpression, FirValueParameter>? = null
     var numDefaults: Int = 0
     lateinit var typeArgumentMapping: TypeArgumentMapping
     val postponedAtoms = mutableListOf<PostponedResolvedAtom>()

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/Candidate.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/Candidate.kt
@@ -104,6 +104,7 @@ class Candidate(
 
     var argumentMapping: Map<FirExpression, FirValueParameter>? = null
     var numDefaults: Int = 0
+    var oldToNewArgumentMapping: Map<FirExpression, FirExpression>? = null
     lateinit var typeArgumentMapping: TypeArgumentMapping
     val postponedAtoms = mutableListOf<PostponedResolvedAtom>()
 

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/FirArgumentsToParametersMapper.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/FirArgumentsToParametersMapper.kt
@@ -29,6 +29,8 @@ data class ArgumentMapping(
     //      fun foo(a: Int, b: Int) {}
     //      foo(b = bar(), a = qux())
     // parameterToCallArgumentMap.values() should be [ 'bar()', 'foo()' ]
+    // TODO: Consider changing this (and other similar declarations like Candidate.argumentMapping) to LinkedHashMap to signify that
+    // order is important. Right now we're assuming that mutableMapOf() will always return a LinkedHashMap.
     val parameterToCallArgumentMap: Map<FirValueParameter, ResolvedCallArgument>,
     val oldToNewArgumentMap: Map<FirExpression, FirExpression>,
     val diagnostics: List<ResolutionDiagnostic>

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/FirArgumentsToParametersMapper.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/FirArgumentsToParametersMapper.kt
@@ -20,6 +20,7 @@ import org.jetbrains.kotlin.fir.scopes.FirScope
 import org.jetbrains.kotlin.name.Name
 import java.util.*
 import kotlin.collections.ArrayList
+import kotlin.collections.LinkedHashMap
 import kotlin.collections.component1
 import kotlin.collections.component2
 import kotlin.collections.set
@@ -29,13 +30,11 @@ data class ArgumentMapping(
     //      fun foo(a: Int, b: Int) {}
     //      foo(b = bar(), a = qux())
     // parameterToCallArgumentMap.values() should be [ 'bar()', 'foo()' ]
-    // TODO: Consider changing this (and other similar declarations like Candidate.argumentMapping) to LinkedHashMap to signify that
-    // order is important. Right now we're assuming that mutableMapOf() will always return a LinkedHashMap.
-    val parameterToCallArgumentMap: Map<FirValueParameter, ResolvedCallArgument>,
+    val parameterToCallArgumentMap: LinkedHashMap<FirValueParameter, ResolvedCallArgument>,
     val diagnostics: List<ResolutionDiagnostic>
 ) {
-    fun toArgumentToParameterMapping(): Map<FirExpression, FirValueParameter> {
-        val argumentToParameterMapping = mutableMapOf<FirExpression, FirValueParameter>()
+    fun toArgumentToParameterMapping(): LinkedHashMap<FirExpression, FirValueParameter> {
+        val argumentToParameterMapping = linkedMapOf<FirExpression, FirValueParameter>()
         parameterToCallArgumentMap.forEach { (valueParameter, resolvedArgument) ->
             when (resolvedArgument) {
                 is ResolvedCallArgument.SimpleArgument -> argumentToParameterMapping[resolvedArgument.callArgument] = valueParameter
@@ -52,7 +51,7 @@ data class ArgumentMapping(
     }
 }
 
-private val EmptyArgumentMapping = ArgumentMapping(emptyMap(), emptyList())
+private val EmptyArgumentMapping = ArgumentMapping(linkedMapOf(), emptyList())
 
 fun BodyResolveComponents.mapArguments(
     arguments: List<FirExpression>,
@@ -108,7 +107,7 @@ private class FirCallArgumentsProcessor(
     private var nameToParameter: Map<Name, FirValueParameter>? = null
     var diagnostics: MutableList<ResolutionDiagnostic>? = null
         private set
-    val result: MutableMap<FirValueParameter, ResolvedCallArgument> = LinkedHashMap()
+    val result: LinkedHashMap<FirValueParameter, ResolvedCallArgument> = LinkedHashMap(function.valueParameters.size)
 
     private enum class State {
         POSITION_ARGUMENTS,

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/FirArgumentsToParametersMapper.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/FirArgumentsToParametersMapper.kt
@@ -32,7 +32,6 @@ data class ArgumentMapping(
     // TODO: Consider changing this (and other similar declarations like Candidate.argumentMapping) to LinkedHashMap to signify that
     // order is important. Right now we're assuming that mutableMapOf() will always return a LinkedHashMap.
     val parameterToCallArgumentMap: Map<FirValueParameter, ResolvedCallArgument>,
-    val oldToNewArgumentMap: Map<FirExpression, FirExpression>,
     val diagnostics: List<ResolutionDiagnostic>
 ) {
     fun toArgumentToParameterMapping(): Map<FirExpression, FirValueParameter> {
@@ -53,7 +52,7 @@ data class ArgumentMapping(
     }
 }
 
-private val EmptyArgumentMapping = ArgumentMapping(emptyMap(), emptyMap(), emptyList())
+private val EmptyArgumentMapping = ArgumentMapping(emptyMap(), emptyList())
 
 fun BodyResolveComponents.mapArguments(
     arguments: List<FirExpression>,
@@ -72,7 +71,6 @@ fun BodyResolveComponents.mapArguments(
 
     // If this is an overloading indexed access operator, it could have default values or a vararg parameter in the middle.
     // For proper argument mapping, wrap the last one, which is supposed to be the updated value, as a named argument.
-    val oldToNewArgumentMap = mutableMapOf<FirExpression, FirExpression>()
     if ((function as? FirSimpleFunction)?.isOperator == true &&
         function.name == Name.identifier("set") &&
         function.valueParameters.any { it.defaultValue != null || it.isVararg }
@@ -86,7 +84,6 @@ fun BodyResolveComponents.mapArguments(
                 name = function.valueParameters.last().name
             }
             argumentsInParenthesis = argumentsInParenthesis.dropLast(1) + listOf(namedV)
-            oldToNewArgumentMap[v] = namedV
         }
     }
 
@@ -97,7 +94,7 @@ fun BodyResolveComponents.mapArguments(
     }
     processor.processDefaultsAndRunChecks()
 
-    return ArgumentMapping(processor.result, oldToNewArgumentMap, processor.diagnostics ?: emptyList())
+    return ArgumentMapping(processor.result, processor.diagnostics ?: emptyList())
 }
 
 private class FirCallArgumentsProcessor(

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/ResolutionStages.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/ResolutionStages.kt
@@ -172,6 +172,7 @@ internal object MapArguments : ResolutionStage() {
         val mapping = context.bodyResolveComponents.mapArguments(callInfo.arguments, function, candidate.originScope)
         candidate.argumentMapping = mapping.toArgumentToParameterMapping()
         candidate.numDefaults = mapping.numDefaults()
+        candidate.oldToNewArgumentMapping = mapping.oldToNewArgumentMap
 
         mapping.diagnostics.forEach(sink::reportDiagnostic)
         sink.yieldIfNeed()

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/ResolutionStages.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/ResolutionStages.kt
@@ -172,7 +172,6 @@ internal object MapArguments : ResolutionStage() {
         val mapping = context.bodyResolveComponents.mapArguments(callInfo.arguments, function, candidate.originScope)
         candidate.argumentMapping = mapping.toArgumentToParameterMapping()
         candidate.numDefaults = mapping.numDefaults()
-        candidate.oldToNewArgumentMapping = mapping.oldToNewArgumentMap
 
         mapping.diagnostics.forEach(sink::reportDiagnostic)
         sink.yieldIfNeed()

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirCallCompletionResultsWriterTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirCallCompletionResultsWriterTransformer.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.fir.*
 import org.jetbrains.kotlin.fir.declarations.*
 import org.jetbrains.kotlin.fir.diagnostics.ConeSimpleDiagnostic
 import org.jetbrains.kotlin.fir.expressions.*
+import org.jetbrains.kotlin.fir.expressions.builder.buildArgumentList
 import org.jetbrains.kotlin.fir.references.builder.buildErrorNamedReference
 import org.jetbrains.kotlin.fir.references.builder.buildResolvedCallableReference
 import org.jetbrains.kotlin.fir.references.builder.buildResolvedNamedReference
@@ -165,6 +166,14 @@ class FirCallCompletionResultsWriterTransformer(
                 val expectedArgumentsTypeMapping = runIf(!calleeReference.isError) { subCandidate.createArgumentsMapping() }
                 result.argumentList.transformArguments(this, expectedArgumentsTypeMapping)
                 if (!calleeReference.isError) {
+                    subCandidate.oldToNewArgumentMapping?.let {
+                        result.replaceArgumentList(buildArgumentList {
+                            source = result.argumentList.source
+                            for (oldArgument in result.argumentList.arguments) {
+                                arguments += it[oldArgument] ?: oldArgument
+                            }
+                        })
+                    }
                     subCandidate.handleVarargs(result.argumentList)
                     subCandidate.argumentMapping?.let {
                         result.replaceArgumentList(buildResolvedArgumentList(it))

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirCallCompletionResultsWriterTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirCallCompletionResultsWriterTransformer.kt
@@ -207,8 +207,12 @@ class FirCallCompletionResultsWriterTransformer(
         withFirArrayOfCallTransformer {
             annotationCall.argumentList.transformArguments(this, expectedArgumentsTypeMapping)
             var index = 0
-            subCandidate.argumentMapping = subCandidate.argumentMapping?.mapKeys { (_, _) ->
-                annotationCall.argumentList.arguments[index++]
+            subCandidate.argumentMapping = subCandidate.argumentMapping?.let {
+                LinkedHashMap<FirExpression, FirValueParameter>(it.size).let { newMapping ->
+                    subCandidate.argumentMapping?.mapKeysTo(newMapping) { (_, _) ->
+                        annotationCall.argumentList.arguments[index++]
+                    }
+                }
             }
         }
         if (!calleeReference.isError) {

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/BodyResolveUtils.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/BodyResolveUtils.kt
@@ -37,8 +37,8 @@ internal inline var FirExpression.resultType: FirTypeRef
 internal fun remapArgumentsWithVararg(
     varargParameter: FirValueParameter,
     varargArrayType: ConeKotlinType,
-    argumentMapping: Map<FirExpression, FirValueParameter>
-): Map<FirExpression, FirValueParameter> {
+    argumentMapping: LinkedHashMap<FirExpression, FirValueParameter>
+): LinkedHashMap<FirExpression, FirValueParameter> {
     // Create a FirVarargArgumentExpression for the vararg arguments.
     // The order of arguments in the mapping must be preserved for FIR2IR, hence we have to find where the vararg arguments end.
     // FIR2IR uses the mapping order to determine if arguments need to be reordered.
@@ -46,7 +46,7 @@ internal fun remapArgumentsWithVararg(
     val varargElementType = varargArrayType.arrayElementType()
     val argumentList = argumentMapping.keys.toList()
     var indexAfterVarargs = argumentList.size
-    val newArgumentMapping = mutableMapOf<FirExpression, FirValueParameter>()
+    val newArgumentMapping = linkedMapOf<FirExpression, FirValueParameter>()
     val varargArgument = buildVarargArgumentsExpression {
         this.varargElementType = varargParameterTypeRef.withReplacedConeType(varargElementType)
         this.typeRef = varargParameterTypeRef.withReplacedConeType(varargArrayType)

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/expressions/FirArgumentUtil.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/expressions/FirArgumentUtil.kt
@@ -22,7 +22,7 @@ fun buildBinaryArgumentList(left: FirExpression, right: FirExpression): FirArgum
 fun buildArraySetArgumentList(rValue: FirExpression, indexes: List<FirExpression>): FirArgumentList =
     FirArraySetArgumentList(rValue, indexes)
 
-fun buildResolvedArgumentList(mapping: Map<FirExpression, FirValueParameter>): FirArgumentList =
+fun buildResolvedArgumentList(mapping: LinkedHashMap<FirExpression, FirValueParameter>): FirArgumentList =
     FirResolvedArgumentList(mapping)
 
 object FirEmptyArgumentList : FirAbstractArgumentList() {

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/expressions/FirExpressionUtil.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/expressions/FirExpressionUtil.kt
@@ -40,7 +40,7 @@ inline val FirCall.arguments: List<FirExpression> get() = argumentList.arguments
 
 inline val FirCall.argument: FirExpression get() = argumentList.arguments.first()
 
-inline val FirCall.argumentMapping: Map<FirExpression, FirValueParameter>?
+inline val FirCall.argumentMapping: LinkedHashMap<FirExpression, FirValueParameter>?
     get() = (argumentList as? FirResolvedArgumentList)?.mapping
 
 fun FirExpression.toResolvedCallableReference(): FirResolvedNamedReference? {

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/expressions/impl/FirResolvedArgumentList.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/expressions/impl/FirResolvedArgumentList.kt
@@ -11,7 +11,7 @@ import org.jetbrains.kotlin.fir.expressions.FirExpression
 import org.jetbrains.kotlin.fir.visitors.FirVisitor
 
 class FirResolvedArgumentList internal constructor(
-    val mapping: Map<FirExpression, FirValueParameter>
+    val mapping: LinkedHashMap<FirExpression, FirValueParameter>
 ) : FirAbstractArgumentList() {
     override val arguments: List<FirExpression>
         get() = mapping.keys.toList()

--- a/compiler/testData/codegen/box/argumentOrder/kt17691.kt
+++ b/compiler/testData/codegen/box/argumentOrder/kt17691.kt
@@ -17,5 +17,4 @@ fun box(): String {
     foo(*arrayOf({ acc4 += "1" }()), y = { acc4 += "2" }())
 
     return if (acc1 == "12" && acc2 == "21" && acc3 == "21" && acc4 == "12") "OK" else "ERROR"
-    return "OK"
 }

--- a/compiler/testData/codegen/box/argumentOrder/kt17691WithEnabledFeature.kt
+++ b/compiler/testData/codegen/box/argumentOrder/kt17691WithEnabledFeature.kt
@@ -1,7 +1,6 @@
 // !LANGUAGE: +UseCorrectExecutionOrderForVarargArguments
 // WITH_RUNTIME
 // KJS_WITH_FULL_RUNTIME
-// IGNORE_BACKEND_FIR: JVM_IR
 
 fun foo(vararg x: Unit, y: Any) {}
 

--- a/compiler/testData/codegen/box/increment/argumentWithSideEffects.kt
+++ b/compiler/testData/codegen/box/increment/argumentWithSideEffects.kt
@@ -1,0 +1,51 @@
+// IGNORE_BACKEND_FIR: JVM_IR
+// Currently fails because prefix increment only calls getter once.
+var log = ""
+
+fun <T> logged(value: T): T =
+    value.also { log += "$value;" }
+
+fun doTest(id: String, expected: Int, expectedLog: String, test: () -> Int) {
+    log = ""
+    val actual = test()
+    if (actual != expected) throw AssertionError("$id expected: $expected, actual: $actual")
+    if (log != expectedLog) throw AssertionError("$id expectedLog: $expectedLog, actual: $log")
+}
+
+object A {
+    var x = 0
+        get() = field.also { log += "get-A.x;" }
+        set(value: Int) {
+            log += "set-A.x;"
+            field = value
+        }
+
+}
+
+fun getA() = A.also { log += "getA();" }
+
+object B {
+    var x = 0
+
+    operator fun get(i1: Int, i2: Int, i3: Int): Int = x.also { log += "get-B($i1, $i2, $i3);" }
+
+    operator fun set(i1: Int, i2: Int, i3: Int, value: Int) {
+        log += "set-B($i1, $i2, $i3, $value);"
+        x = value
+    }
+}
+
+fun getB() = B.also { log += "getB();" }
+
+fun box(): String {
+    // NOTE: Getter is currently called twice for prefix increment; 1st for initial value, 2nd for return value. See KT-42077.
+    doTest("++getA().x", 1, "getA();get-A.x;set-A.x;get-A.x;") { ++getA().x }
+    doTest("getA().x--", 1, "getA();get-A.x;set-A.x;") { getA().x-- }
+
+    doTest("++getB()[1, 2, 3]", 1, "getB();1;2;3;get-B(1, 2, 3);set-B(1, 2, 3, 1);get-B(1, 2, 3);") {
+        ++getB()[logged(1), logged(2), logged(3)]
+    }
+    doTest("getB()[1, 2, 3].x--", 1, "getB();1;2;3;get-B(1, 2, 3);set-B(1, 2, 3, 0);") { getB()[logged(1), logged(2), logged(3)]-- }
+
+    return "OK"
+}

--- a/compiler/testData/codegen/box/increment/classVarargGetSet.kt
+++ b/compiler/testData/codegen/box/increment/classVarargGetSet.kt
@@ -1,0 +1,29 @@
+object A {
+    var x = 0
+    var gets = 0
+    var sets = 0
+
+    operator fun get(vararg va: Int): Int {
+        for (i in va) {
+            gets += i
+        }
+        return x
+    }
+
+    operator fun set(vararg va: Int, value: Int) {
+        for (i in va) {
+            sets += i
+        }
+        x = value
+    }
+}
+
+fun box(): String {
+    A.x = 0
+    val xx = A[1, 2, 3]++
+    if (xx != 0) return "Failed xx: $xx"
+    if (A.x != 1) return "Failed A.x: ${A.x}"
+    if (A.gets != 6) return "Failed A.gets: ${A.gets}"
+    if (A.sets != 6) return "Failed A.sets: ${A.sets}"
+    return "OK"
+}

--- a/compiler/testData/codegen/box/increment/classVarargGetSetEvaluationOrder.kt
+++ b/compiler/testData/codegen/box/increment/classVarargGetSetEvaluationOrder.kt
@@ -1,0 +1,41 @@
+// IGNORE_BACKEND_FIR: JVM_IR
+// Currently fails as the indices (`va`) are evaluated twice (on get and set).
+var log = ""
+
+fun logged(value: String) =
+    value.also { log += value }
+
+object A {
+    var x = ""
+    var gets = ""
+    var sets = ""
+
+    operator fun get(vararg va: String): String {
+        for (s in va) {
+            gets += s
+        }
+        log += "get;"
+        return x
+    }
+
+    operator fun set(vararg va: String, value: String) {
+        for (s in va) {
+            sets += s
+        }
+        log += "set;"
+        x = value
+    }
+}
+
+operator fun String.inc() = this + logged("inc;")
+
+fun box(): String {
+    A.x = "start;"
+    val xx = A[logged("1;"), logged("2;"), logged("3;")]++
+    if (xx != "start;") return "Failed xx: $xx"
+    if (A.x != "start;inc;") return "Failed A.x: ${A.x}"
+    if (A.gets != "1;2;3;") return "Failed A.gets: ${A.gets}"
+    if (A.sets != "1;2;3;") return "Failed A.sets: ${A.sets}"
+    if (log != "1;2;3;get;inc;set;") return "Failed log: $log"
+    return "OK"
+}

--- a/compiler/testData/codegen/box/increment/classVarargGetSetEvaluationOrder.kt
+++ b/compiler/testData/codegen/box/increment/classVarargGetSetEvaluationOrder.kt
@@ -1,5 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
-// Currently fails as the indices (`va`) are evaluated twice (on get and set).
 var log = ""
 
 fun logged(value: String) =

--- a/compiler/testData/codegen/box/mixedNamedPosition/varargs.kt
+++ b/compiler/testData/codegen/box/mixedNamedPosition/varargs.kt
@@ -19,6 +19,7 @@ fun foo3(
 ) = "$p1 $p2 ${p3[0].toInt()} ${p3[1].toInt()}"
 
 fun box(): String {
+    if (foo1(1, 2, p2 = "3", p3 = 4.0) != "1 2 3 4") return "fail 1"
     if (foo1(p1 = *intArrayOf(1, 2), "3", p3 = 4.0) != "1 2 3 4") return "fail 2"
 
     if (foo2(p1 = 1, "2", "3", p3 = 4.0) != "1 2 3 4") return "fail 3"

--- a/compiler/testData/codegen/box/mixedNamedPosition/varargsEvaluationOrder.kt
+++ b/compiler/testData/codegen/box/mixedNamedPosition/varargsEvaluationOrder.kt
@@ -1,0 +1,46 @@
+// !LANGUAGE: +NewInference +MixedNamedArgumentsInTheirOwnPosition
+// IGNORE_BACKEND: JVM
+// See KT-17691: Wrong argument order in resolved call with varargs. (fixed in JVM_IR)
+
+var log = ""
+
+fun <T> logged(value: T): T =
+    value.also { log += " " + value }
+
+fun doTest(id: String, expected: String, expectedLog: String, test: () -> String) {
+    log = ""
+    val actual = test()
+    if (actual != expected) throw AssertionError("$id expected: $expected, actual: $actual")
+    if (log != expectedLog) throw AssertionError("$id expectedLog: $expectedLog, actual: $log")
+}
+
+fun foo1(
+    vararg p1: Int,
+    p2: String,
+    p3: Double
+) = "${p1[0]} ${p1[1]} $p2 ${p3.toInt()}"
+
+fun foo2(
+    p1: Int,
+    vararg p2: String,
+    p3: Double
+) = "$p1 ${p2[0]} ${p2[1]} ${p3.toInt()}"
+
+fun foo3(
+    p1: Int,
+    p2: String,
+    vararg p3: Double
+) = "$p1 $p2 ${p3[0].toInt()} ${p3[1].toInt()}"
+
+fun box(): String {
+    doTest("test1", "1 2 3 4", " 1 2 3 4.5") { foo1(logged(1), logged(2), p2 = logged("3"), p3 = logged(4.5)) }
+    doTest("test2", "1 2 3 4", " 1 2 3 4.5") { foo1(p1 = *intArrayOf(logged(1), logged(2)), logged("3"), p3 = logged(4.5)) }
+
+    doTest("test3", "1 2 3 4", " 1 2 3 4.5") { foo2(p1 = logged(1), logged("2"), logged("3"), p3 = logged(4.5)) }
+    doTest("test4", "1 2 3 4", " 1 2 3 4.5") { foo2(logged(1), p2 = *arrayOf(logged("2"), logged("3")), logged(4.5)) }
+
+    doTest("test5", "1 2 3 4", " 1 2 3.5 4.5") { foo3(p1 = logged(1), logged("2"), logged(3.5), logged(4.5)) }
+    doTest("test6", "1 2 3 4", " 1 2 3.5 4.5") { foo3(p1 = logged(1), logged("2"), p3 = *doubleArrayOf(logged(3.5), logged(4.5))) }
+
+    return "OK"
+}

--- a/compiler/testData/codegen/box/vararg/evaluationOrder.kt
+++ b/compiler/testData/codegen/box/vararg/evaluationOrder.kt
@@ -1,0 +1,45 @@
+var log = ""
+
+fun <T> logged(value: T): T =
+    value.also { log += value }
+
+fun doTest(id: String, expected: String, expectedLog: String, test: () -> String) {
+    log = ""
+    val actual = test()
+    if (actual != expected) throw AssertionError("$id expected: $expected, actual: $actual")
+    if (log != expectedLog) throw AssertionError("$id expectedLog: $expectedLog, actual: $log")
+}
+
+object A {
+    var sets = ""
+
+    fun f(vararg va: String, a: String = "default_a;", b: String): String {
+        var ret = ""
+        for (s in va) {
+            ret += s
+        }
+        return ret + a + b
+    }
+
+    operator fun set(vararg va: String, value: String) {
+        for (s in va) {
+            sets += s
+        }
+        log += "set=$value;"
+    }
+}
+
+operator fun String.inc() = this + logged("inc;")
+
+fun box(): String {
+    doTest("test1", "1;2;3;", "1;2;3;value;set=value;;") {
+        A[logged("1;"), logged("2;"), logged("3;")] = logged("value;")
+        A.sets
+    }
+
+    doTest("test2", "1;2;3;default_a;b;", "1;2;3;b;") { A.f(logged("1;"), logged("2;"), logged("3;"), b = logged("b;")) }
+    doTest("test3", "1;2;3;a;b;", "1;2;3;b;a;") { A.f(logged("1;"), logged("2;"), logged("3;"), b = logged("b;"), a = logged("a;")) }
+    doTest("test4", "1;2;3;a;b;", "1;2;3;a;b;") { A.f(logged("1;"), logged("2;"), logged("3;"), a = logged("a;"), b = logged("b;")) }
+
+    return "OK"
+}

--- a/compiler/testData/codegen/boxInline/argumentOrder/defaultParametersAndLastVarargWithCorrectOrder.kt
+++ b/compiler/testData/codegen/boxInline/argumentOrder/defaultParametersAndLastVarargWithCorrectOrder.kt
@@ -1,6 +1,4 @@
-// !LANGUAGE: -UseCorrectExecutionOrderForVarargArguments
-// IGNORE_BACKEND: JS
-// IGNORE_BACKEND_FIR: JVM_IR
+// !LANGUAGE: +UseCorrectExecutionOrderForVarargArguments
 // NO_CHECK_LAMBDA_INLINING
 // FILE: 1.kt
 // WITH_RUNTIME
@@ -34,7 +32,7 @@ fun box(): String {
                        init = { invokeOrder += " init"; "I" }())
     if (result != "C, R, I") return "fail 1: $result"
 
-    if (invokeOrder != " receiver initconstraints") return "fail 2: $invokeOrder"
+    if (invokeOrder != "constraints receiver init") return "fail 2: $invokeOrder"
 
     result = ""
     invokeOrder = ""
@@ -43,7 +41,7 @@ fun box(): String {
                        receiver = { invokeOrder += " receiver"; "R" }()
     )
     if (result != "C, R, I") return "fail 3: $result"
-    if (invokeOrder != "init receiver constraints") return "fail 4: $invokeOrder"
+    if (invokeOrder != "init constraints receiver") return "fail 4: $invokeOrder"
 
     result = ""
     invokeOrder = ""

--- a/compiler/testData/codegen/boxInline/argumentOrder/varargAndDefaultParameters.kt
+++ b/compiler/testData/codegen/boxInline/argumentOrder/varargAndDefaultParameters.kt
@@ -1,7 +1,9 @@
+// !LANGUAGE: -UseCorrectExecutionOrderForVarargArguments
 // IGNORE_BACKEND: JVM_IR
 // IGNORE_BACKEND: JS, JS_IR
 // IGNORE_BACKEND: JS_IR_ES6
 // IGNORE_BACKEND_MULTI_MODULE: JVM_IR, JVM_MULTI_MODULE_IR_AGAINST_OLD
+// IGNORE_BACKEND_FIR: JVM_IR
 // NO_CHECK_LAMBDA_INLINING
 // FILE: 1.kt
 // WITH_RUNTIME
@@ -35,18 +37,16 @@ fun box(): String {
                        init = { invokeOrder += " init"; "I" }())
     if (result != "C, R, I") return "fail 1: $result"
 
-    //Change test after KT-17691 FIX; and remove cloned test for Native (enable this).
     if (invokeOrder != " receiver initconstraints") return "fail 2: $invokeOrder"
 
     result = ""
     invokeOrder = ""
     result = inlineFun(init = { invokeOrder += "init"; "I" }(),
-                       constraints = *arrayOf({ invokeOrder += "constraints";A("C") }()),
+                       constraints = *arrayOf({ invokeOrder += " constraints";A("C") }()),
                        receiver = { invokeOrder += " receiver"; "R" }()
     )
     if (result != "C, R, I") return "fail 3: $result"
-    //Change test after KT-17691 FIX
-    if (invokeOrder != "init receiverconstraints") return "fail 4: $invokeOrder"
+    if (invokeOrder != "init receiver constraints") return "fail 4: $invokeOrder"
 
     result = ""
     invokeOrder = ""

--- a/compiler/testData/codegen/boxInline/argumentOrder/varargAndDefaultParametersWithCorrectOrder.kt
+++ b/compiler/testData/codegen/boxInline/argumentOrder/varargAndDefaultParametersWithCorrectOrder.kt
@@ -1,11 +1,8 @@
-// !LANGUAGE: -UseCorrectExecutionOrderForVarargArguments
-// IGNORE_BACKEND: JS
-// IGNORE_BACKEND_FIR: JVM_IR
+// !LANGUAGE: +UseCorrectExecutionOrderForVarargArguments
 // NO_CHECK_LAMBDA_INLINING
 // FILE: 1.kt
 // WITH_RUNTIME
 // KJS_WITH_FULL_RUNTIME
-
 package test
 
 open class A(val value: String)
@@ -13,9 +10,9 @@ open class A(val value: String)
 var invokeOrder = ""
 
 inline fun inlineFun(
+        vararg constraints: A,
         receiver: String = { invokeOrder += " default receiver"; "DEFAULT" }(),
-        init: String,
-        vararg constraints: A
+        init: String
 ): String {
     return constraints.map { it.value }.joinToString() + ", " + receiver + ", " + init
 }
@@ -34,7 +31,7 @@ fun box(): String {
                        init = { invokeOrder += " init"; "I" }())
     if (result != "C, R, I") return "fail 1: $result"
 
-    if (invokeOrder != " receiver initconstraints") return "fail 2: $invokeOrder"
+    if (invokeOrder != "constraints receiver init") return "fail 2: $invokeOrder"
 
     result = ""
     invokeOrder = ""
@@ -43,7 +40,7 @@ fun box(): String {
                        receiver = { invokeOrder += " receiver"; "R" }()
     )
     if (result != "C, R, I") return "fail 3: $result"
-    if (invokeOrder != "init receiver constraints") return "fail 4: $invokeOrder"
+    if (invokeOrder != "init constraints receiver") return "fail 4: $invokeOrder"
 
     result = ""
     invokeOrder = ""

--- a/compiler/testData/diagnostics/tests/checkArguments/arrayAccessSet.fir.kt
+++ b/compiler/testData/diagnostics/tests/checkArguments/arrayAccessSet.fir.kt
@@ -28,8 +28,8 @@ fun test() {
     B[0] = 2.72
     B[0] = true
 
-    <!INAPPLICABLE_CANDIDATE!>D[0] = ""<!>
-    <!INAPPLICABLE_CANDIDATE!>D[0] = 2.72<!>
+    D[0] = ""
+    D[0] = 2.72
 
     <!INAPPLICABLE_CANDIDATE!>Z[0] = ""<!>
 }

--- a/compiler/testData/diagnostics/tests/operatorsOverloading/InconsistentGetSet.fir.kt
+++ b/compiler/testData/diagnostics/tests/operatorsOverloading/InconsistentGetSet.fir.kt
@@ -18,8 +18,8 @@ object MismatchingTypes {
 }
 
 fun testMismatchingTypes() {
-    <!INAPPLICABLE_CANDIDATE!>++MismatchingTypes[0]<!>
-    <!INAPPLICABLE_CANDIDATE!>MismatchingTypes[0]++<!>
+    ++<!INAPPLICABLE_CANDIDATE!>MismatchingTypes[0]<!>
+    <!INAPPLICABLE_CANDIDATE!>MismatchingTypes[0]<!>++
     MismatchingTypes[0] += 1
 }
 
@@ -34,8 +34,8 @@ object MismatchingArities2 {
 }
 
 fun testMismatchingArities() {
-    <!INAPPLICABLE_CANDIDATE!>++MismatchingArities1[0]<!>
-    <!INAPPLICABLE_CANDIDATE!>MismatchingArities1[0]++<!>
+    ++<!INAPPLICABLE_CANDIDATE!>MismatchingArities1[0]<!>
+    <!INAPPLICABLE_CANDIDATE!>MismatchingArities1[0]<!>++
     MismatchingArities1[0] += 1
 
     ++<!INAPPLICABLE_CANDIDATE!>MismatchingArities2[0]<!>

--- a/compiler/testData/ir/irText/expressions/arrayAugmentedAssignment1.fir.txt
+++ b/compiler/testData/ir/irText/expressions/arrayAugmentedAssignment1.fir.txt
@@ -77,16 +77,19 @@ FILE fqName:<root> fileName:/arrayAugmentedAssignment1.kt
   FUN name:testMember visibility:public modality:FINAL <> (c:<root>.C) returnType:kotlin.Unit
     VALUE_PARAMETER name:c index:0 type:<root>.C
     BLOCK_BODY
-      VAR IR_TEMPORARY_VARIABLE name:tmp_4 type:kotlin.Int [val]
-        CALL 'public final fun get (index: kotlin.Int): kotlin.Int [operator] declared in kotlin.IntArray' type=kotlin.Int origin=null
-          $this: CALL 'public final fun <get-x> (): kotlin.IntArray declared in <root>.C' type=kotlin.IntArray origin=GET_PROPERTY
-            $this: GET_VAR 'c: <root>.C declared in <root>.testMember' type=<root>.C origin=null
-          index: CONST Int type=kotlin.Int value=0
-      CALL 'public final fun set (index: kotlin.Int, value: kotlin.Int): kotlin.Unit [operator] declared in kotlin.IntArray' type=kotlin.Unit origin=null
-        $this: CALL 'public final fun <get-x> (): kotlin.IntArray declared in <root>.C' type=kotlin.IntArray origin=GET_PROPERTY
+      VAR IR_TEMPORARY_VARIABLE name:tmp_4 type:kotlin.IntArray [val]
+        CALL 'public final fun <get-x> (): kotlin.IntArray declared in <root>.C' type=kotlin.IntArray origin=GET_PROPERTY
           $this: GET_VAR 'c: <root>.C declared in <root>.testMember' type=<root>.C origin=null
-        index: CONST Int type=kotlin.Int value=0
+      VAR IR_TEMPORARY_VARIABLE name:tmp_5 type:kotlin.Int [val]
+        CONST Int type=kotlin.Int value=0
+      VAR IR_TEMPORARY_VARIABLE name:tmp_6 type:kotlin.Int [val]
+        CALL 'public final fun get (index: kotlin.Int): kotlin.Int [operator] declared in kotlin.IntArray' type=kotlin.Int origin=null
+          $this: GET_VAR 'val tmp_4: kotlin.IntArray [val] declared in <root>.testMember' type=kotlin.IntArray origin=null
+          index: GET_VAR 'val tmp_5: kotlin.Int [val] declared in <root>.testMember' type=kotlin.Int origin=null
+      CALL 'public final fun set (index: kotlin.Int, value: kotlin.Int): kotlin.Unit [operator] declared in kotlin.IntArray' type=kotlin.Unit origin=null
+        $this: GET_VAR 'val tmp_4: kotlin.IntArray [val] declared in <root>.testMember' type=kotlin.IntArray origin=null
+        index: GET_VAR 'val tmp_5: kotlin.Int [val] declared in <root>.testMember' type=kotlin.Int origin=null
         value: CALL 'public final fun inc (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
-          $this: GET_VAR 'val tmp_4: kotlin.Int [val] declared in <root>.testMember' type=kotlin.Int origin=null
+          $this: GET_VAR 'val tmp_6: kotlin.Int [val] declared in <root>.testMember' type=kotlin.Int origin=null
       TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
-        GET_VAR 'val tmp_4: kotlin.Int [val] declared in <root>.testMember' type=kotlin.Int origin=null
+        GET_VAR 'val tmp_6: kotlin.Int [val] declared in <root>.testMember' type=kotlin.Int origin=null

--- a/compiler/testData/ir/irText/expressions/complexAugmentedAssignment.fir.txt
+++ b/compiler/testData/ir/irText/expressions/complexAugmentedAssignment.fir.txt
@@ -118,64 +118,62 @@ FILE fqName:<root> fileName:/complexAugmentedAssignment.kt
     BLOCK_BODY
       VAR name:i type:kotlin.Int [var]
         CONST Int type=kotlin.Int value=0
-      VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:kotlin.Int [val]
-        CALL 'public final fun get (index: kotlin.Int): kotlin.Int [operator] declared in kotlin.IntArray' type=kotlin.Int origin=null
-          $this: GET_VAR 'a: kotlin.IntArray declared in <root>.test1' type=kotlin.IntArray origin=null
-          index: BLOCK type=kotlin.Int origin=null
-            VAR IR_TEMPORARY_VARIABLE name:tmp_1 type:kotlin.Int [val]
-              GET_VAR 'var i: kotlin.Int [var] declared in <root>.test1' type=kotlin.Int origin=null
-            SET_VAR 'var i: kotlin.Int [var] declared in <root>.test1' type=kotlin.Unit origin=EQ
-              CALL 'public final fun inc (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
-                $this: GET_VAR 'val tmp_1: kotlin.Int [val] declared in <root>.test1' type=kotlin.Int origin=null
-            GET_VAR 'val tmp_1: kotlin.Int [val] declared in <root>.test1' type=kotlin.Int origin=null
-      CALL 'public final fun set (index: kotlin.Int, value: kotlin.Int): kotlin.Unit [operator] declared in kotlin.IntArray' type=kotlin.Unit origin=null
-        $this: GET_VAR 'a: kotlin.IntArray declared in <root>.test1' type=kotlin.IntArray origin=null
-        index: BLOCK type=kotlin.Int origin=null
+      VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:kotlin.IntArray [val]
+        GET_VAR 'a: kotlin.IntArray declared in <root>.test1' type=kotlin.IntArray origin=null
+      VAR IR_TEMPORARY_VARIABLE name:tmp_1 type:kotlin.Int [val]
+        BLOCK type=kotlin.Int origin=null
           VAR IR_TEMPORARY_VARIABLE name:tmp_2 type:kotlin.Int [val]
             GET_VAR 'var i: kotlin.Int [var] declared in <root>.test1' type=kotlin.Int origin=null
           SET_VAR 'var i: kotlin.Int [var] declared in <root>.test1' type=kotlin.Unit origin=EQ
             CALL 'public final fun inc (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
               $this: GET_VAR 'val tmp_2: kotlin.Int [val] declared in <root>.test1' type=kotlin.Int origin=null
           GET_VAR 'val tmp_2: kotlin.Int [val] declared in <root>.test1' type=kotlin.Int origin=null
+      VAR IR_TEMPORARY_VARIABLE name:tmp_3 type:kotlin.Int [val]
+        CALL 'public final fun get (index: kotlin.Int): kotlin.Int [operator] declared in kotlin.IntArray' type=kotlin.Int origin=null
+          $this: GET_VAR 'val tmp_0: kotlin.IntArray [val] declared in <root>.test1' type=kotlin.IntArray origin=null
+          index: GET_VAR 'val tmp_1: kotlin.Int [val] declared in <root>.test1' type=kotlin.Int origin=null
+      CALL 'public final fun set (index: kotlin.Int, value: kotlin.Int): kotlin.Unit [operator] declared in kotlin.IntArray' type=kotlin.Unit origin=null
+        $this: GET_VAR 'val tmp_0: kotlin.IntArray [val] declared in <root>.test1' type=kotlin.IntArray origin=null
+        index: GET_VAR 'val tmp_1: kotlin.Int [val] declared in <root>.test1' type=kotlin.Int origin=null
         value: CALL 'public final fun inc (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
-          $this: GET_VAR 'val tmp_0: kotlin.Int [val] declared in <root>.test1' type=kotlin.Int origin=null
+          $this: GET_VAR 'val tmp_3: kotlin.Int [val] declared in <root>.test1' type=kotlin.Int origin=null
       TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
-        GET_VAR 'val tmp_0: kotlin.Int [val] declared in <root>.test1' type=kotlin.Int origin=null
+        GET_VAR 'val tmp_3: kotlin.Int [val] declared in <root>.test1' type=kotlin.Int origin=null
   FUN name:test2 visibility:public modality:FINAL <> () returnType:kotlin.Unit
     BLOCK_BODY
-      VAR IR_TEMPORARY_VARIABLE name:tmp_3 type:<root>.X1 [val]
+      VAR IR_TEMPORARY_VARIABLE name:tmp_4 type:<root>.X1 [val]
         GET_OBJECT 'CLASS OBJECT name:X1 modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.X1
-      VAR IR_TEMPORARY_VARIABLE name:tmp_4 type:kotlin.Int [val]
+      VAR IR_TEMPORARY_VARIABLE name:tmp_5 type:kotlin.Int [val]
         CALL 'public final fun <get-x1> (): kotlin.Int declared in <root>.X1' type=kotlin.Int origin=GET_PROPERTY
-          $this: GET_VAR 'val tmp_3: <root>.X1 [val] declared in <root>.test2' type=<root>.X1 origin=null
+          $this: GET_VAR 'val tmp_4: <root>.X1 [val] declared in <root>.test2' type=<root>.X1 origin=null
       CALL 'public final fun <set-x1> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>.X1' type=kotlin.Unit origin=EQ
-        $this: GET_VAR 'val tmp_3: <root>.X1 [val] declared in <root>.test2' type=<root>.X1 origin=null
+        $this: GET_VAR 'val tmp_4: <root>.X1 [val] declared in <root>.test2' type=<root>.X1 origin=null
         <set-?>: CALL 'public final fun inc (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
-          $this: GET_VAR 'val tmp_4: kotlin.Int [val] declared in <root>.test2' type=kotlin.Int origin=null
+          $this: GET_VAR 'val tmp_5: kotlin.Int [val] declared in <root>.test2' type=kotlin.Int origin=null
       TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
-        GET_VAR 'val tmp_4: kotlin.Int [val] declared in <root>.test2' type=kotlin.Int origin=null
-      VAR IR_TEMPORARY_VARIABLE name:tmp_5 type:<root>.X1.X2 [val]
+        GET_VAR 'val tmp_5: kotlin.Int [val] declared in <root>.test2' type=kotlin.Int origin=null
+      VAR IR_TEMPORARY_VARIABLE name:tmp_6 type:<root>.X1.X2 [val]
         GET_OBJECT 'CLASS OBJECT name:X2 modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.X1.X2
-      VAR IR_TEMPORARY_VARIABLE name:tmp_6 type:kotlin.Int [val]
+      VAR IR_TEMPORARY_VARIABLE name:tmp_7 type:kotlin.Int [val]
         CALL 'public final fun <get-x2> (): kotlin.Int declared in <root>.X1.X2' type=kotlin.Int origin=GET_PROPERTY
-          $this: GET_VAR 'val tmp_5: <root>.X1.X2 [val] declared in <root>.test2' type=<root>.X1.X2 origin=null
+          $this: GET_VAR 'val tmp_6: <root>.X1.X2 [val] declared in <root>.test2' type=<root>.X1.X2 origin=null
       CALL 'public final fun <set-x2> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>.X1.X2' type=kotlin.Unit origin=EQ
-        $this: GET_VAR 'val tmp_5: <root>.X1.X2 [val] declared in <root>.test2' type=<root>.X1.X2 origin=null
+        $this: GET_VAR 'val tmp_6: <root>.X1.X2 [val] declared in <root>.test2' type=<root>.X1.X2 origin=null
         <set-?>: CALL 'public final fun inc (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
-          $this: GET_VAR 'val tmp_6: kotlin.Int [val] declared in <root>.test2' type=kotlin.Int origin=null
+          $this: GET_VAR 'val tmp_7: kotlin.Int [val] declared in <root>.test2' type=kotlin.Int origin=null
       TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
-        GET_VAR 'val tmp_6: kotlin.Int [val] declared in <root>.test2' type=kotlin.Int origin=null
-      VAR IR_TEMPORARY_VARIABLE name:tmp_7 type:<root>.X1.X2.X3 [val]
+        GET_VAR 'val tmp_7: kotlin.Int [val] declared in <root>.test2' type=kotlin.Int origin=null
+      VAR IR_TEMPORARY_VARIABLE name:tmp_8 type:<root>.X1.X2.X3 [val]
         GET_OBJECT 'CLASS OBJECT name:X3 modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.X1.X2.X3
-      VAR IR_TEMPORARY_VARIABLE name:tmp_8 type:kotlin.Int [val]
+      VAR IR_TEMPORARY_VARIABLE name:tmp_9 type:kotlin.Int [val]
         CALL 'public final fun <get-x3> (): kotlin.Int declared in <root>.X1.X2.X3' type=kotlin.Int origin=GET_PROPERTY
-          $this: GET_VAR 'val tmp_7: <root>.X1.X2.X3 [val] declared in <root>.test2' type=<root>.X1.X2.X3 origin=null
+          $this: GET_VAR 'val tmp_8: <root>.X1.X2.X3 [val] declared in <root>.test2' type=<root>.X1.X2.X3 origin=null
       CALL 'public final fun <set-x3> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>.X1.X2.X3' type=kotlin.Unit origin=EQ
-        $this: GET_VAR 'val tmp_7: <root>.X1.X2.X3 [val] declared in <root>.test2' type=<root>.X1.X2.X3 origin=null
+        $this: GET_VAR 'val tmp_8: <root>.X1.X2.X3 [val] declared in <root>.test2' type=<root>.X1.X2.X3 origin=null
         <set-?>: CALL 'public final fun inc (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
-          $this: GET_VAR 'val tmp_8: kotlin.Int [val] declared in <root>.test2' type=kotlin.Int origin=null
+          $this: GET_VAR 'val tmp_9: kotlin.Int [val] declared in <root>.test2' type=kotlin.Int origin=null
       TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
-        GET_VAR 'val tmp_8: kotlin.Int [val] declared in <root>.test2' type=kotlin.Int origin=null
+        GET_VAR 'val tmp_9: kotlin.Int [val] declared in <root>.test2' type=kotlin.Int origin=null
   CLASS CLASS name:B modality:FINAL visibility:public superTypes:[kotlin.Any]
     $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.B
     CONSTRUCTOR visibility:public <> (s:kotlin.Int) returnType:<root>.B [primary]

--- a/compiler/testData/ir/irText/expressions/incrementDecrement.fir.txt
+++ b/compiler/testData/ir/irText/expressions/incrementDecrement.fir.txt
@@ -97,51 +97,67 @@ FILE fqName:<root> fileName:/incrementDecrement.kt
     BLOCK_BODY
       VAR name:a1 type:kotlin.Int [val]
         BLOCK type=kotlin.Int origin=null
-          VAR IR_TEMPORARY_VARIABLE name:tmp_3 type:kotlin.Int [val]
+          VAR IR_TEMPORARY_VARIABLE name:tmp_3 type:kotlin.IntArray [val]
+            CALL 'public final fun <get-arr> (): kotlin.IntArray declared in <root>' type=kotlin.IntArray origin=GET_PROPERTY
+          VAR IR_TEMPORARY_VARIABLE name:tmp_4 type:kotlin.Int [val]
+            CONST Int type=kotlin.Int value=0
+          VAR IR_TEMPORARY_VARIABLE name:tmp_5 type:kotlin.Int [val]
             CALL 'public final fun inc (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
               $this: CALL 'public final fun get (index: kotlin.Int): kotlin.Int [operator] declared in kotlin.IntArray' type=kotlin.Int origin=null
-                $this: CALL 'public final fun <get-arr> (): kotlin.IntArray declared in <root>' type=kotlin.IntArray origin=GET_PROPERTY
-                index: CONST Int type=kotlin.Int value=0
+                $this: GET_VAR 'val tmp_3: kotlin.IntArray [val] declared in <root>.testArrayPrefix' type=kotlin.IntArray origin=null
+                index: GET_VAR 'val tmp_4: kotlin.Int [val] declared in <root>.testArrayPrefix' type=kotlin.Int origin=null
           CALL 'public final fun set (index: kotlin.Int, value: kotlin.Int): kotlin.Unit [operator] declared in kotlin.IntArray' type=kotlin.Unit origin=null
-            $this: CALL 'public final fun <get-arr> (): kotlin.IntArray declared in <root>' type=kotlin.IntArray origin=GET_PROPERTY
-            index: CONST Int type=kotlin.Int value=0
-            value: GET_VAR 'val tmp_3: kotlin.Int [val] declared in <root>.testArrayPrefix' type=kotlin.Int origin=null
-          GET_VAR 'val tmp_3: kotlin.Int [val] declared in <root>.testArrayPrefix' type=kotlin.Int origin=null
+            $this: GET_VAR 'val tmp_3: kotlin.IntArray [val] declared in <root>.testArrayPrefix' type=kotlin.IntArray origin=null
+            index: GET_VAR 'val tmp_4: kotlin.Int [val] declared in <root>.testArrayPrefix' type=kotlin.Int origin=null
+            value: GET_VAR 'val tmp_5: kotlin.Int [val] declared in <root>.testArrayPrefix' type=kotlin.Int origin=null
+          GET_VAR 'val tmp_5: kotlin.Int [val] declared in <root>.testArrayPrefix' type=kotlin.Int origin=null
       VAR name:a2 type:kotlin.Int [val]
         BLOCK type=kotlin.Int origin=null
-          VAR IR_TEMPORARY_VARIABLE name:tmp_4 type:kotlin.Int [val]
+          VAR IR_TEMPORARY_VARIABLE name:tmp_6 type:kotlin.IntArray [val]
+            CALL 'public final fun <get-arr> (): kotlin.IntArray declared in <root>' type=kotlin.IntArray origin=GET_PROPERTY
+          VAR IR_TEMPORARY_VARIABLE name:tmp_7 type:kotlin.Int [val]
+            CONST Int type=kotlin.Int value=0
+          VAR IR_TEMPORARY_VARIABLE name:tmp_8 type:kotlin.Int [val]
             CALL 'public final fun dec (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
               $this: CALL 'public final fun get (index: kotlin.Int): kotlin.Int [operator] declared in kotlin.IntArray' type=kotlin.Int origin=null
-                $this: CALL 'public final fun <get-arr> (): kotlin.IntArray declared in <root>' type=kotlin.IntArray origin=GET_PROPERTY
-                index: CONST Int type=kotlin.Int value=0
+                $this: GET_VAR 'val tmp_6: kotlin.IntArray [val] declared in <root>.testArrayPrefix' type=kotlin.IntArray origin=null
+                index: GET_VAR 'val tmp_7: kotlin.Int [val] declared in <root>.testArrayPrefix' type=kotlin.Int origin=null
           CALL 'public final fun set (index: kotlin.Int, value: kotlin.Int): kotlin.Unit [operator] declared in kotlin.IntArray' type=kotlin.Unit origin=null
-            $this: CALL 'public final fun <get-arr> (): kotlin.IntArray declared in <root>' type=kotlin.IntArray origin=GET_PROPERTY
-            index: CONST Int type=kotlin.Int value=0
-            value: GET_VAR 'val tmp_4: kotlin.Int [val] declared in <root>.testArrayPrefix' type=kotlin.Int origin=null
-          GET_VAR 'val tmp_4: kotlin.Int [val] declared in <root>.testArrayPrefix' type=kotlin.Int origin=null
+            $this: GET_VAR 'val tmp_6: kotlin.IntArray [val] declared in <root>.testArrayPrefix' type=kotlin.IntArray origin=null
+            index: GET_VAR 'val tmp_7: kotlin.Int [val] declared in <root>.testArrayPrefix' type=kotlin.Int origin=null
+            value: GET_VAR 'val tmp_8: kotlin.Int [val] declared in <root>.testArrayPrefix' type=kotlin.Int origin=null
+          GET_VAR 'val tmp_8: kotlin.Int [val] declared in <root>.testArrayPrefix' type=kotlin.Int origin=null
   FUN name:testArrayPostfix visibility:public modality:FINAL <> () returnType:kotlin.Unit
     BLOCK_BODY
       VAR name:a1 type:kotlin.Int [val]
         BLOCK type=kotlin.Int origin=null
-          VAR IR_TEMPORARY_VARIABLE name:tmp_5 type:kotlin.Int [val]
+          VAR IR_TEMPORARY_VARIABLE name:tmp_9 type:kotlin.IntArray [val]
+            CALL 'public final fun <get-arr> (): kotlin.IntArray declared in <root>' type=kotlin.IntArray origin=GET_PROPERTY
+          VAR IR_TEMPORARY_VARIABLE name:tmp_10 type:kotlin.Int [val]
+            CONST Int type=kotlin.Int value=0
+          VAR IR_TEMPORARY_VARIABLE name:tmp_11 type:kotlin.Int [val]
             CALL 'public final fun get (index: kotlin.Int): kotlin.Int [operator] declared in kotlin.IntArray' type=kotlin.Int origin=null
-              $this: CALL 'public final fun <get-arr> (): kotlin.IntArray declared in <root>' type=kotlin.IntArray origin=GET_PROPERTY
-              index: CONST Int type=kotlin.Int value=0
+              $this: GET_VAR 'val tmp_9: kotlin.IntArray [val] declared in <root>.testArrayPostfix' type=kotlin.IntArray origin=null
+              index: GET_VAR 'val tmp_10: kotlin.Int [val] declared in <root>.testArrayPostfix' type=kotlin.Int origin=null
           CALL 'public final fun set (index: kotlin.Int, value: kotlin.Int): kotlin.Unit [operator] declared in kotlin.IntArray' type=kotlin.Unit origin=null
-            $this: CALL 'public final fun <get-arr> (): kotlin.IntArray declared in <root>' type=kotlin.IntArray origin=GET_PROPERTY
-            index: CONST Int type=kotlin.Int value=0
+            $this: GET_VAR 'val tmp_9: kotlin.IntArray [val] declared in <root>.testArrayPostfix' type=kotlin.IntArray origin=null
+            index: GET_VAR 'val tmp_10: kotlin.Int [val] declared in <root>.testArrayPostfix' type=kotlin.Int origin=null
             value: CALL 'public final fun inc (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
-              $this: GET_VAR 'val tmp_5: kotlin.Int [val] declared in <root>.testArrayPostfix' type=kotlin.Int origin=null
-          GET_VAR 'val tmp_5: kotlin.Int [val] declared in <root>.testArrayPostfix' type=kotlin.Int origin=null
+              $this: GET_VAR 'val tmp_11: kotlin.Int [val] declared in <root>.testArrayPostfix' type=kotlin.Int origin=null
+          GET_VAR 'val tmp_11: kotlin.Int [val] declared in <root>.testArrayPostfix' type=kotlin.Int origin=null
       VAR name:a2 type:kotlin.Int [val]
         BLOCK type=kotlin.Int origin=null
-          VAR IR_TEMPORARY_VARIABLE name:tmp_6 type:kotlin.Int [val]
+          VAR IR_TEMPORARY_VARIABLE name:tmp_12 type:kotlin.IntArray [val]
+            CALL 'public final fun <get-arr> (): kotlin.IntArray declared in <root>' type=kotlin.IntArray origin=GET_PROPERTY
+          VAR IR_TEMPORARY_VARIABLE name:tmp_13 type:kotlin.Int [val]
+            CONST Int type=kotlin.Int value=0
+          VAR IR_TEMPORARY_VARIABLE name:tmp_14 type:kotlin.Int [val]
             CALL 'public final fun get (index: kotlin.Int): kotlin.Int [operator] declared in kotlin.IntArray' type=kotlin.Int origin=null
-              $this: CALL 'public final fun <get-arr> (): kotlin.IntArray declared in <root>' type=kotlin.IntArray origin=GET_PROPERTY
-              index: CONST Int type=kotlin.Int value=0
+              $this: GET_VAR 'val tmp_12: kotlin.IntArray [val] declared in <root>.testArrayPostfix' type=kotlin.IntArray origin=null
+              index: GET_VAR 'val tmp_13: kotlin.Int [val] declared in <root>.testArrayPostfix' type=kotlin.Int origin=null
           CALL 'public final fun set (index: kotlin.Int, value: kotlin.Int): kotlin.Unit [operator] declared in kotlin.IntArray' type=kotlin.Unit origin=null
-            $this: CALL 'public final fun <get-arr> (): kotlin.IntArray declared in <root>' type=kotlin.IntArray origin=GET_PROPERTY
-            index: CONST Int type=kotlin.Int value=0
+            $this: GET_VAR 'val tmp_12: kotlin.IntArray [val] declared in <root>.testArrayPostfix' type=kotlin.IntArray origin=null
+            index: GET_VAR 'val tmp_13: kotlin.Int [val] declared in <root>.testArrayPostfix' type=kotlin.Int origin=null
             value: CALL 'public final fun dec (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
-              $this: GET_VAR 'val tmp_6: kotlin.Int [val] declared in <root>.testArrayPostfix' type=kotlin.Int origin=null
-          GET_VAR 'val tmp_6: kotlin.Int [val] declared in <root>.testArrayPostfix' type=kotlin.Int origin=null
+              $this: GET_VAR 'val tmp_14: kotlin.Int [val] declared in <root>.testArrayPostfix' type=kotlin.Int origin=null
+          GET_VAR 'val tmp_14: kotlin.Int [val] declared in <root>.testArrayPostfix' type=kotlin.Int origin=null

--- a/compiler/testData/ir/irText/expressions/kt28456.fir.txt
+++ b/compiler/testData/ir/irText/expressions/kt28456.fir.txt
@@ -43,37 +43,43 @@ FILE fqName:<root> fileName:/kt28456.kt
     BLOCK_BODY
       RETURN type=kotlin.Nothing from='public final fun testPostfixIncrement (a: <root>.A): kotlin.Int declared in <root>'
         BLOCK type=kotlin.Int origin=null
-          VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:kotlin.Int [val]
+          VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:<root>.A [val]
+            GET_VAR 'a: <root>.A declared in <root>.testPostfixIncrement' type=<root>.A origin=null
+          VAR IR_TEMPORARY_VARIABLE name:tmp_1 type:kotlin.Int [val]
+            CONST Int type=kotlin.Int value=1
+          VAR IR_TEMPORARY_VARIABLE name:tmp_2 type:kotlin.Int [val]
+            CONST Int type=kotlin.Int value=2
+          VAR IR_TEMPORARY_VARIABLE name:tmp_3 type:kotlin.Int [val]
             CALL 'public final fun get (vararg xs: kotlin.Int): kotlin.Int [operator] declared in <root>' type=kotlin.Int origin=null
-              $receiver: GET_VAR 'a: <root>.A declared in <root>.testPostfixIncrement' type=<root>.A origin=null
+              $receiver: GET_VAR 'val tmp_0: <root>.A [val] declared in <root>.testPostfixIncrement' type=<root>.A origin=null
               xs: VARARG type=kotlin.IntArray varargElementType=kotlin.Int
-                CONST Int type=kotlin.Int value=1
-                CONST Int type=kotlin.Int value=2
+                GET_VAR 'val tmp_1: kotlin.Int [val] declared in <root>.testPostfixIncrement' type=kotlin.Int origin=null
+                GET_VAR 'val tmp_2: kotlin.Int [val] declared in <root>.testPostfixIncrement' type=kotlin.Int origin=null
           CALL 'public final fun set (i: kotlin.Int, j: kotlin.Int, v: kotlin.Int): kotlin.Unit [operator] declared in <root>' type=kotlin.Unit origin=null
-            $receiver: GET_VAR 'a: <root>.A declared in <root>.testPostfixIncrement' type=<root>.A origin=null
-            i: CONST Int type=kotlin.Int value=1
-            j: CONST Int type=kotlin.Int value=2
+            $receiver: GET_VAR 'val tmp_0: <root>.A [val] declared in <root>.testPostfixIncrement' type=<root>.A origin=null
+            i: GET_VAR 'val tmp_1: kotlin.Int [val] declared in <root>.testPostfixIncrement' type=kotlin.Int origin=null
+            j: GET_VAR 'val tmp_2: kotlin.Int [val] declared in <root>.testPostfixIncrement' type=kotlin.Int origin=null
             v: CALL 'public final fun inc (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
-              $this: GET_VAR 'val tmp_0: kotlin.Int [val] declared in <root>.testPostfixIncrement' type=kotlin.Int origin=null
-          GET_VAR 'val tmp_0: kotlin.Int [val] declared in <root>.testPostfixIncrement' type=kotlin.Int origin=null
+              $this: GET_VAR 'val tmp_3: kotlin.Int [val] declared in <root>.testPostfixIncrement' type=kotlin.Int origin=null
+          GET_VAR 'val tmp_3: kotlin.Int [val] declared in <root>.testPostfixIncrement' type=kotlin.Int origin=null
   FUN name:testCompoundAssignment visibility:public modality:FINAL <> (a:<root>.A) returnType:kotlin.Unit
     VALUE_PARAMETER name:a index:0 type:<root>.A
     BLOCK_BODY
       BLOCK type=kotlin.Unit origin=null
-        VAR IR_TEMPORARY_VARIABLE name:tmp_1 type:<root>.A [val]
+        VAR IR_TEMPORARY_VARIABLE name:tmp_4 type:<root>.A [val]
           GET_VAR 'a: <root>.A declared in <root>.testCompoundAssignment' type=<root>.A origin=null
-        VAR IR_TEMPORARY_VARIABLE name:tmp_2 type:kotlin.Int [val]
+        VAR IR_TEMPORARY_VARIABLE name:tmp_5 type:kotlin.Int [val]
           CONST Int type=kotlin.Int value=1
-        VAR IR_TEMPORARY_VARIABLE name:tmp_3 type:kotlin.Int [val]
+        VAR IR_TEMPORARY_VARIABLE name:tmp_6 type:kotlin.Int [val]
           CONST Int type=kotlin.Int value=2
         CALL 'public final fun set (i: kotlin.Int, j: kotlin.Int, v: kotlin.Int): kotlin.Unit [operator] declared in <root>' type=kotlin.Unit origin=null
-          $receiver: GET_VAR 'val tmp_1: <root>.A [val] declared in <root>.testCompoundAssignment' type=<root>.A origin=null
-          i: GET_VAR 'val tmp_2: kotlin.Int [val] declared in <root>.testCompoundAssignment' type=kotlin.Int origin=null
-          j: GET_VAR 'val tmp_3: kotlin.Int [val] declared in <root>.testCompoundAssignment' type=kotlin.Int origin=null
+          $receiver: GET_VAR 'val tmp_4: <root>.A [val] declared in <root>.testCompoundAssignment' type=<root>.A origin=null
+          i: GET_VAR 'val tmp_5: kotlin.Int [val] declared in <root>.testCompoundAssignment' type=kotlin.Int origin=null
+          j: GET_VAR 'val tmp_6: kotlin.Int [val] declared in <root>.testCompoundAssignment' type=kotlin.Int origin=null
           v: CALL 'public final fun plus (other: kotlin.Int): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
             $this: CALL 'public final fun get (vararg xs: kotlin.Int): kotlin.Int [operator] declared in <root>' type=kotlin.Int origin=null
-              $receiver: GET_VAR 'val tmp_1: <root>.A [val] declared in <root>.testCompoundAssignment' type=<root>.A origin=null
+              $receiver: GET_VAR 'val tmp_4: <root>.A [val] declared in <root>.testCompoundAssignment' type=<root>.A origin=null
               xs: VARARG type=kotlin.IntArray varargElementType=kotlin.Int
-                GET_VAR 'val tmp_2: kotlin.Int [val] declared in <root>.testCompoundAssignment' type=kotlin.Int origin=null
-                GET_VAR 'val tmp_3: kotlin.Int [val] declared in <root>.testCompoundAssignment' type=kotlin.Int origin=null
+                GET_VAR 'val tmp_5: kotlin.Int [val] declared in <root>.testCompoundAssignment' type=kotlin.Int origin=null
+                GET_VAR 'val tmp_6: kotlin.Int [val] declared in <root>.testCompoundAssignment' type=kotlin.Int origin=null
             other: CONST Int type=kotlin.Int value=10

--- a/compiler/testData/ir/irText/expressions/kt28456a.fir.txt
+++ b/compiler/testData/ir/irText/expressions/kt28456a.fir.txt
@@ -26,8 +26,13 @@ FILE fqName:<root> fileName:/kt28456a.kt
   FUN name:testSimpleAssignment visibility:public modality:FINAL <> (a:<root>.A) returnType:kotlin.Unit
     VALUE_PARAMETER name:a index:0 type:<root>.A
     BLOCK_BODY
-      ERROR_CALL 'Unresolved reference: <Inapplicable(INAPPLICABLE_ARGUMENTS_MAPPING_ERROR): /set>#' type=kotlin.Unit
-        CONST Int type=kotlin.Int value=1
-        CONST Int type=kotlin.Int value=2
-        CONST Int type=kotlin.Int value=3
-        CONST Int type=kotlin.Int value=0
+      BLOCK type=kotlin.Unit origin=ARGUMENTS_REORDERING_FOR_CALL
+        VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:kotlin.IntArray [val]
+          VARARG type=kotlin.IntArray varargElementType=kotlin.Int
+            CONST Int type=kotlin.Int value=1
+            CONST Int type=kotlin.Int value=2
+            CONST Int type=kotlin.Int value=3
+        CALL 'public final fun set (vararg i: kotlin.Int, v: kotlin.Int): kotlin.Unit [operator] declared in <root>' type=kotlin.Unit origin=null
+          $receiver: GET_VAR 'a: <root>.A declared in <root>.testSimpleAssignment' type=<root>.A origin=null
+          i: GET_VAR 'val tmp_0: kotlin.IntArray [val] declared in <root>.testSimpleAssignment' type=kotlin.IntArray origin=null
+          v: CONST Int type=kotlin.Int value=0

--- a/compiler/testData/ir/irText/expressions/kt28456a.fir.txt
+++ b/compiler/testData/ir/irText/expressions/kt28456a.fir.txt
@@ -26,13 +26,10 @@ FILE fqName:<root> fileName:/kt28456a.kt
   FUN name:testSimpleAssignment visibility:public modality:FINAL <> (a:<root>.A) returnType:kotlin.Unit
     VALUE_PARAMETER name:a index:0 type:<root>.A
     BLOCK_BODY
-      BLOCK type=kotlin.Unit origin=ARGUMENTS_REORDERING_FOR_CALL
-        VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:kotlin.IntArray [val]
-          VARARG type=kotlin.IntArray varargElementType=kotlin.Int
-            CONST Int type=kotlin.Int value=1
-            CONST Int type=kotlin.Int value=2
-            CONST Int type=kotlin.Int value=3
-        CALL 'public final fun set (vararg i: kotlin.Int, v: kotlin.Int): kotlin.Unit [operator] declared in <root>' type=kotlin.Unit origin=null
-          $receiver: GET_VAR 'a: <root>.A declared in <root>.testSimpleAssignment' type=<root>.A origin=null
-          i: GET_VAR 'val tmp_0: kotlin.IntArray [val] declared in <root>.testSimpleAssignment' type=kotlin.IntArray origin=null
-          v: CONST Int type=kotlin.Int value=0
+      CALL 'public final fun set (vararg i: kotlin.Int, v: kotlin.Int): kotlin.Unit [operator] declared in <root>' type=kotlin.Unit origin=null
+        $receiver: GET_VAR 'a: <root>.A declared in <root>.testSimpleAssignment' type=<root>.A origin=null
+        i: VARARG type=kotlin.IntArray varargElementType=kotlin.Int
+          CONST Int type=kotlin.Int value=1
+          CONST Int type=kotlin.Int value=2
+          CONST Int type=kotlin.Int value=3
+        v: CONST Int type=kotlin.Int value=0

--- a/compiler/testData/ir/irText/expressions/kt28456b.fir.txt
+++ b/compiler/testData/ir/irText/expressions/kt28456b.fir.txt
@@ -56,29 +56,33 @@ FILE fqName:<root> fileName:/kt28456b.kt
     BLOCK_BODY
       RETURN type=kotlin.Nothing from='public final fun testPostfixIncrement (a: <root>.A): kotlin.Int declared in <root>'
         BLOCK type=kotlin.Int origin=null
-          VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:kotlin.Int [val]
+          VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:<root>.A [val]
+            GET_VAR 'a: <root>.A declared in <root>.testPostfixIncrement' type=<root>.A origin=null
+          VAR IR_TEMPORARY_VARIABLE name:tmp_1 type:kotlin.Int [val]
+            CONST Int type=kotlin.Int value=1
+          VAR IR_TEMPORARY_VARIABLE name:tmp_2 type:kotlin.Int [val]
             CALL 'public final fun get (i: kotlin.Int, a: kotlin.Int, b: kotlin.Int, c: kotlin.Int, d: kotlin.Int): kotlin.Int [operator] declared in <root>' type=kotlin.Int origin=null
-              $receiver: GET_VAR 'a: <root>.A declared in <root>.testPostfixIncrement' type=<root>.A origin=null
-              i: CONST Int type=kotlin.Int value=1
+              $receiver: GET_VAR 'val tmp_0: <root>.A [val] declared in <root>.testPostfixIncrement' type=<root>.A origin=null
+              i: GET_VAR 'val tmp_1: kotlin.Int [val] declared in <root>.testPostfixIncrement' type=kotlin.Int origin=null
           CALL 'public final fun set (i: kotlin.Int, j: kotlin.Int, v: kotlin.Int): kotlin.Unit [operator] declared in <root>' type=kotlin.Unit origin=null
-            $receiver: GET_VAR 'a: <root>.A declared in <root>.testPostfixIncrement' type=<root>.A origin=null
-            i: CONST Int type=kotlin.Int value=1
+            $receiver: GET_VAR 'val tmp_0: <root>.A [val] declared in <root>.testPostfixIncrement' type=<root>.A origin=null
+            i: GET_VAR 'val tmp_1: kotlin.Int [val] declared in <root>.testPostfixIncrement' type=kotlin.Int origin=null
             v: CALL 'public final fun inc (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
-              $this: GET_VAR 'val tmp_0: kotlin.Int [val] declared in <root>.testPostfixIncrement' type=kotlin.Int origin=null
-          GET_VAR 'val tmp_0: kotlin.Int [val] declared in <root>.testPostfixIncrement' type=kotlin.Int origin=null
+              $this: GET_VAR 'val tmp_2: kotlin.Int [val] declared in <root>.testPostfixIncrement' type=kotlin.Int origin=null
+          GET_VAR 'val tmp_2: kotlin.Int [val] declared in <root>.testPostfixIncrement' type=kotlin.Int origin=null
   FUN name:testCompoundAssignment visibility:public modality:FINAL <> (a:<root>.A) returnType:kotlin.Unit
     VALUE_PARAMETER name:a index:0 type:<root>.A
     BLOCK_BODY
       BLOCK type=kotlin.Unit origin=null
-        VAR IR_TEMPORARY_VARIABLE name:tmp_1 type:<root>.A [val]
+        VAR IR_TEMPORARY_VARIABLE name:tmp_3 type:<root>.A [val]
           GET_VAR 'a: <root>.A declared in <root>.testCompoundAssignment' type=<root>.A origin=null
-        VAR IR_TEMPORARY_VARIABLE name:tmp_2 type:kotlin.Int [val]
+        VAR IR_TEMPORARY_VARIABLE name:tmp_4 type:kotlin.Int [val]
           CONST Int type=kotlin.Int value=1
         CALL 'public final fun set (i: kotlin.Int, j: kotlin.Int, v: kotlin.Int): kotlin.Unit [operator] declared in <root>' type=kotlin.Unit origin=null
-          $receiver: GET_VAR 'val tmp_1: <root>.A [val] declared in <root>.testCompoundAssignment' type=<root>.A origin=null
-          i: GET_VAR 'val tmp_2: kotlin.Int [val] declared in <root>.testCompoundAssignment' type=kotlin.Int origin=null
+          $receiver: GET_VAR 'val tmp_3: <root>.A [val] declared in <root>.testCompoundAssignment' type=<root>.A origin=null
+          i: GET_VAR 'val tmp_4: kotlin.Int [val] declared in <root>.testCompoundAssignment' type=kotlin.Int origin=null
           v: CALL 'public final fun plus (other: kotlin.Int): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
             $this: CALL 'public final fun get (i: kotlin.Int, a: kotlin.Int, b: kotlin.Int, c: kotlin.Int, d: kotlin.Int): kotlin.Int [operator] declared in <root>' type=kotlin.Int origin=null
-              $receiver: GET_VAR 'val tmp_1: <root>.A [val] declared in <root>.testCompoundAssignment' type=<root>.A origin=null
-              i: GET_VAR 'val tmp_2: kotlin.Int [val] declared in <root>.testCompoundAssignment' type=kotlin.Int origin=null
+              $receiver: GET_VAR 'val tmp_3: <root>.A [val] declared in <root>.testCompoundAssignment' type=<root>.A origin=null
+              i: GET_VAR 'val tmp_4: kotlin.Int [val] declared in <root>.testCompoundAssignment' type=kotlin.Int origin=null
             other: CONST Int type=kotlin.Int value=10

--- a/compiler/testData/ir/irText/expressions/kt36956.fir.txt
+++ b/compiler/testData/ir/irText/expressions/kt36956.fir.txt
@@ -58,16 +58,20 @@ FILE fqName:<root> fileName:/kt36956.kt
     FIELD PROPERTY_BACKING_FIELD name:aInt type:kotlin.Float visibility:private [final,static]
       EXPRESSION_BODY
         BLOCK type=kotlin.Float origin=null
-          VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:kotlin.Float [val]
+          VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:<root>.A<kotlin.Float> [val]
+            CALL 'public final fun <get-aFloat> (): <root>.A<kotlin.Float> declared in <root>' type=<root>.A<kotlin.Float> origin=GET_PROPERTY
+          VAR IR_TEMPORARY_VARIABLE name:tmp_1 type:kotlin.Int [val]
+            CONST Int type=kotlin.Int value=1
+          VAR IR_TEMPORARY_VARIABLE name:tmp_2 type:kotlin.Float [val]
             CALL 'public final fun get (i: kotlin.Int): T of <root>.A [operator] declared in <root>.A' type=kotlin.Float origin=null
-              $this: CALL 'public final fun <get-aFloat> (): <root>.A<kotlin.Float> declared in <root>' type=<root>.A<kotlin.Float> origin=GET_PROPERTY
-              i: CONST Int type=kotlin.Int value=1
+              $this: GET_VAR 'val tmp_0: <root>.A<kotlin.Float> [val] declared in <root>.aInt' type=<root>.A<kotlin.Float> origin=null
+              i: GET_VAR 'val tmp_1: kotlin.Int [val] declared in <root>.aInt' type=kotlin.Int origin=null
           CALL 'public final fun set (i: kotlin.Int, v: T of <root>.A): kotlin.Unit [operator] declared in <root>.A' type=kotlin.Unit origin=null
-            $this: CALL 'public final fun <get-aFloat> (): <root>.A<kotlin.Float> declared in <root>' type=<root>.A<kotlin.Float> origin=GET_PROPERTY
-            i: CONST Int type=kotlin.Int value=1
+            $this: GET_VAR 'val tmp_0: <root>.A<kotlin.Float> [val] declared in <root>.aInt' type=<root>.A<kotlin.Float> origin=null
+            i: GET_VAR 'val tmp_1: kotlin.Int [val] declared in <root>.aInt' type=kotlin.Int origin=null
             v: CALL 'public final fun dec (): kotlin.Float [operator] declared in kotlin.Float' type=kotlin.Float origin=null
-              $this: GET_VAR 'val tmp_0: kotlin.Float [val] declared in <root>.aInt' type=kotlin.Float origin=null
-          GET_VAR 'val tmp_0: kotlin.Float [val] declared in <root>.aInt' type=kotlin.Float origin=null
+              $this: GET_VAR 'val tmp_2: kotlin.Float [val] declared in <root>.aInt' type=kotlin.Float origin=null
+          GET_VAR 'val tmp_2: kotlin.Float [val] declared in <root>.aInt' type=kotlin.Float origin=null
     FUN DEFAULT_PROPERTY_ACCESSOR name:<get-aInt> visibility:public modality:FINAL <> () returnType:kotlin.Float
       correspondingProperty: PROPERTY name:aInt visibility:public modality:FINAL [val]
       BLOCK_BODY

--- a/compiler/testData/ir/irText/expressions/lambdaInCAO.fir.txt
+++ b/compiler/testData/ir/irText/expressions/lambdaInCAO.fir.txt
@@ -31,22 +31,22 @@ FILE fqName:<root> fileName:/lambdaInCAO.kt
   FUN name:test3 visibility:public modality:FINAL <> (a:kotlin.Any) returnType:kotlin.Unit
     VALUE_PARAMETER name:a index:0 type:kotlin.Any
     BLOCK_BODY
-      VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:kotlin.Int [val]
-        CALL 'public final fun get (index: kotlin.Function0<kotlin.Unit>): kotlin.Int [operator] declared in <root>' type=kotlin.Int origin=null
-          $receiver: GET_VAR 'a: kotlin.Any declared in <root>.test3' type=kotlin.Any origin=null
-          index: FUN_EXPR type=kotlin.Function0<kotlin.Unit> origin=LAMBDA
-            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> () returnType:kotlin.Unit
-              BLOCK_BODY
-                RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.Unit declared in <root>.test3'
-                  GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Unit modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
-      CALL 'public final fun set (index: kotlin.Function0<kotlin.Unit>, value: kotlin.Int): kotlin.Unit [operator] declared in <root>' type=kotlin.Unit origin=null
-        $receiver: GET_VAR 'a: kotlin.Any declared in <root>.test3' type=kotlin.Any origin=null
-        index: FUN_EXPR type=kotlin.Function0<kotlin.Unit> origin=LAMBDA
+      VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:kotlin.Any [val]
+        GET_VAR 'a: kotlin.Any declared in <root>.test3' type=kotlin.Any origin=null
+      VAR IR_TEMPORARY_VARIABLE name:tmp_1 type:kotlin.Function0<kotlin.Unit> [val]
+        FUN_EXPR type=kotlin.Function0<kotlin.Unit> origin=LAMBDA
           FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> () returnType:kotlin.Unit
             BLOCK_BODY
               RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.Unit declared in <root>.test3'
                 GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Unit modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+      VAR IR_TEMPORARY_VARIABLE name:tmp_2 type:kotlin.Int [val]
+        CALL 'public final fun get (index: kotlin.Function0<kotlin.Unit>): kotlin.Int [operator] declared in <root>' type=kotlin.Int origin=null
+          $receiver: GET_VAR 'val tmp_0: kotlin.Any [val] declared in <root>.test3' type=kotlin.Any origin=null
+          index: GET_VAR 'val tmp_1: kotlin.Function0<kotlin.Unit> [val] declared in <root>.test3' type=kotlin.Function0<kotlin.Unit> origin=null
+      CALL 'public final fun set (index: kotlin.Function0<kotlin.Unit>, value: kotlin.Int): kotlin.Unit [operator] declared in <root>' type=kotlin.Unit origin=null
+        $receiver: GET_VAR 'val tmp_0: kotlin.Any [val] declared in <root>.test3' type=kotlin.Any origin=null
+        index: GET_VAR 'val tmp_1: kotlin.Function0<kotlin.Unit> [val] declared in <root>.test3' type=kotlin.Function0<kotlin.Unit> origin=null
         value: CALL 'public final fun inc (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
-          $this: GET_VAR 'val tmp_0: kotlin.Int [val] declared in <root>.test3' type=kotlin.Int origin=null
+          $this: GET_VAR 'val tmp_2: kotlin.Int [val] declared in <root>.test3' type=kotlin.Int origin=null
       TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
-        GET_VAR 'val tmp_0: kotlin.Int [val] declared in <root>.test3' type=kotlin.Int origin=null
+        GET_VAR 'val tmp_2: kotlin.Int [val] declared in <root>.test3' type=kotlin.Int origin=null

--- a/compiler/testData/ir/irText/expressions/safeCallWithIncrementDecrement.fir.txt
+++ b/compiler/testData/ir/irText/expressions/safeCallWithIncrementDecrement.fir.txt
@@ -96,38 +96,30 @@ FILE fqName:test fileName:/safeCallWithIncrementDecrement.kt
   FUN name:testArrayAccess visibility:public modality:FINAL <> (nc:test.C?) returnType:kotlin.Unit
     VALUE_PARAMETER name:nc index:0 type:test.C?
     BLOCK_BODY
-      VAR IR_TEMPORARY_VARIABLE name:tmp_4 type:kotlin.Int [val]
-        CALL 'public final fun get (index: kotlin.Int): kotlin.Int [operator] declared in test' type=kotlin.Int origin=null
-          $receiver: BLOCK type=kotlin.Int? origin=SAFE_CALL
-            VAR IR_TEMPORARY_VARIABLE name:tmp_5 type:test.C? [val]
-              GET_VAR 'nc: test.C? declared in test.testArrayAccess' type=test.C? origin=null
-            WHEN type=kotlin.Int? origin=null
-              BRANCH
-                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                  arg0: GET_VAR 'val tmp_5: test.C? [val] declared in test.testArrayAccess' type=test.C? origin=null
-                  arg1: CONST Null type=kotlin.Nothing? value=null
-                then: CONST Null type=kotlin.Nothing? value=null
-              BRANCH
-                if: CONST Boolean type=kotlin.Boolean value=true
-                then: CALL 'public final fun <get-p> (): kotlin.Int declared in test' type=kotlin.Int origin=GET_PROPERTY
-                  $receiver: GET_VAR 'val tmp_5: test.C? [val] declared in test.testArrayAccess' type=test.C? origin=null
-          index: CONST Int type=kotlin.Int value=0
-      CALL 'public final fun set (index: kotlin.Int, value: kotlin.Int): kotlin.Unit [operator] declared in test' type=kotlin.Unit origin=null
-        $receiver: BLOCK type=kotlin.Int? origin=SAFE_CALL
-          VAR IR_TEMPORARY_VARIABLE name:tmp_6 type:test.C? [val]
+      VAR IR_TEMPORARY_VARIABLE name:tmp_4 type:kotlin.Int? [val]
+        BLOCK type=kotlin.Int? origin=SAFE_CALL
+          VAR IR_TEMPORARY_VARIABLE name:tmp_5 type:test.C? [val]
             GET_VAR 'nc: test.C? declared in test.testArrayAccess' type=test.C? origin=null
           WHEN type=kotlin.Int? origin=null
             BRANCH
               if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                arg0: GET_VAR 'val tmp_6: test.C? [val] declared in test.testArrayAccess' type=test.C? origin=null
+                arg0: GET_VAR 'val tmp_5: test.C? [val] declared in test.testArrayAccess' type=test.C? origin=null
                 arg1: CONST Null type=kotlin.Nothing? value=null
               then: CONST Null type=kotlin.Nothing? value=null
             BRANCH
               if: CONST Boolean type=kotlin.Boolean value=true
               then: CALL 'public final fun <get-p> (): kotlin.Int declared in test' type=kotlin.Int origin=GET_PROPERTY
-                $receiver: GET_VAR 'val tmp_6: test.C? [val] declared in test.testArrayAccess' type=test.C? origin=null
-        index: CONST Int type=kotlin.Int value=0
+                $receiver: GET_VAR 'val tmp_5: test.C? [val] declared in test.testArrayAccess' type=test.C? origin=null
+      VAR IR_TEMPORARY_VARIABLE name:tmp_6 type:kotlin.Int [val]
+        CONST Int type=kotlin.Int value=0
+      VAR IR_TEMPORARY_VARIABLE name:tmp_7 type:kotlin.Int [val]
+        CALL 'public final fun get (index: kotlin.Int): kotlin.Int [operator] declared in test' type=kotlin.Int origin=null
+          $receiver: GET_VAR 'val tmp_4: kotlin.Int? [val] declared in test.testArrayAccess' type=kotlin.Int? origin=null
+          index: GET_VAR 'val tmp_6: kotlin.Int [val] declared in test.testArrayAccess' type=kotlin.Int origin=null
+      CALL 'public final fun set (index: kotlin.Int, value: kotlin.Int): kotlin.Unit [operator] declared in test' type=kotlin.Unit origin=null
+        $receiver: GET_VAR 'val tmp_4: kotlin.Int? [val] declared in test.testArrayAccess' type=kotlin.Int? origin=null
+        index: GET_VAR 'val tmp_6: kotlin.Int [val] declared in test.testArrayAccess' type=kotlin.Int origin=null
         value: CALL 'public final fun inc (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
-          $this: GET_VAR 'val tmp_4: kotlin.Int [val] declared in test.testArrayAccess' type=kotlin.Int origin=null
+          $this: GET_VAR 'val tmp_7: kotlin.Int [val] declared in test.testArrayAccess' type=kotlin.Int origin=null
       TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
-        GET_VAR 'val tmp_4: kotlin.Int [val] declared in test.testArrayAccess' type=kotlin.Int origin=null
+        GET_VAR 'val tmp_7: kotlin.Int [val] declared in test.testArrayAccess' type=kotlin.Int origin=null

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -14411,6 +14411,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             runTest("compiler/testData/codegen/box/increment/classVarargGetSet.kt");
         }
 
+        @TestMetadata("classVarargGetSetEvaluationOrder.kt")
+        public void testClassVarargGetSetEvaluationOrder() throws Exception {
+            runTest("compiler/testData/codegen/box/increment/classVarargGetSetEvaluationOrder.kt");
+        }
+
         @TestMetadata("classWithGetSet.kt")
         public void testClassWithGetSet() throws Exception {
             runTest("compiler/testData/codegen/box/increment/classWithGetSet.kt");
@@ -19255,6 +19260,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
         @TestMetadata("varargs.kt")
         public void testVarargs() throws Exception {
             runTest("compiler/testData/codegen/box/mixedNamedPosition/varargs.kt");
+        }
+
+        @TestMetadata("varargsEvaluationOrder.kt")
+        public void testVarargsEvaluationOrder() throws Exception {
+            runTest("compiler/testData/codegen/box/mixedNamedPosition/varargsEvaluationOrder.kt");
         }
     }
 
@@ -33300,6 +33310,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
         @TestMetadata("emptyVarargOfBoxedPrimitiveType.kt")
         public void testEmptyVarargOfBoxedPrimitiveType() throws Exception {
             runTest("compiler/testData/codegen/box/vararg/emptyVarargOfBoxedPrimitiveType.kt");
+        }
+
+        @TestMetadata("evaluationOrder.kt")
+        public void testEvaluationOrder() throws Exception {
+            runTest("compiler/testData/codegen/box/vararg/evaluationOrder.kt");
         }
 
         @TestMetadata("kt1978.kt")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -14406,6 +14406,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             runTest("compiler/testData/codegen/box/increment/classNaryGetSet.kt");
         }
 
+        @TestMetadata("classVarargGetSet.kt")
+        public void testClassVarargGetSet() throws Exception {
+            runTest("compiler/testData/codegen/box/increment/classVarargGetSet.kt");
+        }
+
         @TestMetadata("classWithGetSet.kt")
         public void testClassWithGetSet() throws Exception {
             runTest("compiler/testData/codegen/box/increment/classWithGetSet.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -14386,6 +14386,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/increment"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM, true);
         }
 
+        @TestMetadata("argumentWithSideEffects.kt")
+        public void testArgumentWithSideEffects() throws Exception {
+            runTest("compiler/testData/codegen/box/increment/argumentWithSideEffects.kt");
+        }
+
         @TestMetadata("arrayElement.kt")
         public void testArrayElement() throws Exception {
             runTest("compiler/testData/codegen/box/increment/arrayElement.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxInlineCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxInlineCodegenTestGenerated.java
@@ -594,6 +594,11 @@ public class BlackBoxInlineCodegenTestGenerated extends AbstractBlackBoxInlineCo
             runTest("compiler/testData/codegen/boxInline/argumentOrder/defaultParametersAndLastVararg.kt");
         }
 
+        @TestMetadata("defaultParametersAndLastVarargWithCorrectOrder.kt")
+        public void testDefaultParametersAndLastVarargWithCorrectOrder() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/argumentOrder/defaultParametersAndLastVarargWithCorrectOrder.kt");
+        }
+
         @TestMetadata("extension.kt")
         public void testExtension() throws Exception {
             runTest("compiler/testData/codegen/boxInline/argumentOrder/extension.kt");
@@ -627,6 +632,11 @@ public class BlackBoxInlineCodegenTestGenerated extends AbstractBlackBoxInlineCo
         @TestMetadata("varargAndDefaultParameters.kt")
         public void testVarargAndDefaultParameters() throws Exception {
             runTest("compiler/testData/codegen/boxInline/argumentOrder/varargAndDefaultParameters.kt");
+        }
+
+        @TestMetadata("varargAndDefaultParametersWithCorrectOrder.kt")
+        public void testVarargAndDefaultParametersWithCorrectOrder() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/argumentOrder/varargAndDefaultParametersWithCorrectOrder.kt");
         }
     }
 

--- a/compiler/tests/org/jetbrains/kotlin/codegen/CompileKotlinAgainstInlineKotlinTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/CompileKotlinAgainstInlineKotlinTestGenerated.java
@@ -594,6 +594,11 @@ public class CompileKotlinAgainstInlineKotlinTestGenerated extends AbstractCompi
             runTest("compiler/testData/codegen/boxInline/argumentOrder/defaultParametersAndLastVararg.kt");
         }
 
+        @TestMetadata("defaultParametersAndLastVarargWithCorrectOrder.kt")
+        public void testDefaultParametersAndLastVarargWithCorrectOrder() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/argumentOrder/defaultParametersAndLastVarargWithCorrectOrder.kt");
+        }
+
         @TestMetadata("extension.kt")
         public void testExtension() throws Exception {
             runTest("compiler/testData/codegen/boxInline/argumentOrder/extension.kt");
@@ -627,6 +632,11 @@ public class CompileKotlinAgainstInlineKotlinTestGenerated extends AbstractCompi
         @TestMetadata("varargAndDefaultParameters.kt")
         public void testVarargAndDefaultParameters() throws Exception {
             runTest("compiler/testData/codegen/boxInline/argumentOrder/varargAndDefaultParameters.kt");
+        }
+
+        @TestMetadata("varargAndDefaultParametersWithCorrectOrder.kt")
+        public void testVarargAndDefaultParametersWithCorrectOrder() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/argumentOrder/varargAndDefaultParametersWithCorrectOrder.kt");
         }
     }
 

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -14386,6 +14386,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/increment"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM, true);
         }
 
+        @TestMetadata("argumentWithSideEffects.kt")
+        public void testArgumentWithSideEffects() throws Exception {
+            runTest("compiler/testData/codegen/box/increment/argumentWithSideEffects.kt");
+        }
+
         @TestMetadata("arrayElement.kt")
         public void testArrayElement() throws Exception {
             runTest("compiler/testData/codegen/box/increment/arrayElement.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -14406,6 +14406,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/increment/classNaryGetSet.kt");
         }
 
+        @TestMetadata("classVarargGetSet.kt")
+        public void testClassVarargGetSet() throws Exception {
+            runTest("compiler/testData/codegen/box/increment/classVarargGetSet.kt");
+        }
+
         @TestMetadata("classWithGetSet.kt")
         public void testClassWithGetSet() throws Exception {
             runTest("compiler/testData/codegen/box/increment/classWithGetSet.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -14411,6 +14411,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/increment/classVarargGetSet.kt");
         }
 
+        @TestMetadata("classVarargGetSetEvaluationOrder.kt")
+        public void testClassVarargGetSetEvaluationOrder() throws Exception {
+            runTest("compiler/testData/codegen/box/increment/classVarargGetSetEvaluationOrder.kt");
+        }
+
         @TestMetadata("classWithGetSet.kt")
         public void testClassWithGetSet() throws Exception {
             runTest("compiler/testData/codegen/box/increment/classWithGetSet.kt");
@@ -19234,6 +19239,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)
     public static class MixedNamedPosition extends AbstractLightAnalysisModeTest {
+        @TestMetadata("varargsEvaluationOrder.kt")
+        public void ignoreVarargsEvaluationOrder() throws Exception {
+            runTest("compiler/testData/codegen/box/mixedNamedPosition/varargsEvaluationOrder.kt");
+        }
+
         private void runTest(String testDataFilePath) throws Exception {
             KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM, testDataFilePath);
         }
@@ -30934,6 +30944,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
         @TestMetadata("emptyVarargOfBoxedPrimitiveType.kt")
         public void testEmptyVarargOfBoxedPrimitiveType() throws Exception {
             runTest("compiler/testData/codegen/box/vararg/emptyVarargOfBoxedPrimitiveType.kt");
+        }
+
+        @TestMetadata("evaluationOrder.kt")
+        public void testEvaluationOrder() throws Exception {
+            runTest("compiler/testData/codegen/box/vararg/evaluationOrder.kt");
         }
 
         @TestMetadata("kt1978.kt")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -13011,6 +13011,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             runTest("compiler/testData/codegen/box/increment/classNaryGetSet.kt");
         }
 
+        @TestMetadata("classVarargGetSet.kt")
+        public void testClassVarargGetSet() throws Exception {
+            runTest("compiler/testData/codegen/box/increment/classVarargGetSet.kt");
+        }
+
         @TestMetadata("classWithGetSet.kt")
         public void testClassWithGetSet() throws Exception {
             runTest("compiler/testData/codegen/box/increment/classWithGetSet.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -13016,6 +13016,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             runTest("compiler/testData/codegen/box/increment/classVarargGetSet.kt");
         }
 
+        @TestMetadata("classVarargGetSetEvaluationOrder.kt")
+        public void testClassVarargGetSetEvaluationOrder() throws Exception {
+            runTest("compiler/testData/codegen/box/increment/classVarargGetSetEvaluationOrder.kt");
+        }
+
         @TestMetadata("classWithGetSet.kt")
         public void testClassWithGetSet() throws Exception {
             runTest("compiler/testData/codegen/box/increment/classWithGetSet.kt");
@@ -17860,6 +17865,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         @TestMetadata("varargs.kt")
         public void testVarargs() throws Exception {
             runTest("compiler/testData/codegen/box/mixedNamedPosition/varargs.kt");
+        }
+
+        @TestMetadata("varargsEvaluationOrder.kt")
+        public void testVarargsEvaluationOrder() throws Exception {
+            runTest("compiler/testData/codegen/box/mixedNamedPosition/varargsEvaluationOrder.kt");
         }
     }
 
@@ -31534,6 +31544,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         @TestMetadata("emptyVarargOfBoxedPrimitiveType.kt")
         public void testEmptyVarargOfBoxedPrimitiveType() throws Exception {
             runTest("compiler/testData/codegen/box/vararg/emptyVarargOfBoxedPrimitiveType.kt");
+        }
+
+        @TestMetadata("evaluationOrder.kt")
+        public void testEvaluationOrder() throws Exception {
+            runTest("compiler/testData/codegen/box/vararg/evaluationOrder.kt");
         }
 
         @TestMetadata("kt1978.kt")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -12991,6 +12991,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/increment"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
         }
 
+        @TestMetadata("argumentWithSideEffects.kt")
+        public void testArgumentWithSideEffects() throws Exception {
+            runTest("compiler/testData/codegen/box/increment/argumentWithSideEffects.kt");
+        }
+
         @TestMetadata("arrayElement.kt")
         public void testArrayElement() throws Exception {
             runTest("compiler/testData/codegen/box/increment/arrayElement.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxInlineCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxInlineCodegenTestGenerated.java
@@ -594,6 +594,11 @@ public class IrBlackBoxInlineCodegenTestGenerated extends AbstractIrBlackBoxInli
             runTest("compiler/testData/codegen/boxInline/argumentOrder/defaultParametersAndLastVararg.kt");
         }
 
+        @TestMetadata("defaultParametersAndLastVarargWithCorrectOrder.kt")
+        public void testDefaultParametersAndLastVarargWithCorrectOrder() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/argumentOrder/defaultParametersAndLastVarargWithCorrectOrder.kt");
+        }
+
         @TestMetadata("extension.kt")
         public void testExtension() throws Exception {
             runTest("compiler/testData/codegen/boxInline/argumentOrder/extension.kt");
@@ -627,6 +632,11 @@ public class IrBlackBoxInlineCodegenTestGenerated extends AbstractIrBlackBoxInli
         @TestMetadata("varargAndDefaultParameters.kt")
         public void testVarargAndDefaultParameters() throws Exception {
             runTest("compiler/testData/codegen/boxInline/argumentOrder/varargAndDefaultParameters.kt");
+        }
+
+        @TestMetadata("varargAndDefaultParametersWithCorrectOrder.kt")
+        public void testVarargAndDefaultParametersWithCorrectOrder() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/argumentOrder/varargAndDefaultParametersWithCorrectOrder.kt");
         }
     }
 

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrCompileKotlinAgainstInlineKotlinTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrCompileKotlinAgainstInlineKotlinTestGenerated.java
@@ -594,6 +594,11 @@ public class IrCompileKotlinAgainstInlineKotlinTestGenerated extends AbstractIrC
             runTest("compiler/testData/codegen/boxInline/argumentOrder/defaultParametersAndLastVararg.kt");
         }
 
+        @TestMetadata("defaultParametersAndLastVarargWithCorrectOrder.kt")
+        public void testDefaultParametersAndLastVarargWithCorrectOrder() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/argumentOrder/defaultParametersAndLastVarargWithCorrectOrder.kt");
+        }
+
         @TestMetadata("extension.kt")
         public void testExtension() throws Exception {
             runTest("compiler/testData/codegen/boxInline/argumentOrder/extension.kt");
@@ -627,6 +632,11 @@ public class IrCompileKotlinAgainstInlineKotlinTestGenerated extends AbstractIrC
         @TestMetadata("varargAndDefaultParameters.kt")
         public void testVarargAndDefaultParameters() throws Exception {
             runTest("compiler/testData/codegen/boxInline/argumentOrder/varargAndDefaultParameters.kt");
+        }
+
+        @TestMetadata("varargAndDefaultParametersWithCorrectOrder.kt")
+        public void testVarargAndDefaultParametersWithCorrectOrder() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/argumentOrder/varargAndDefaultParametersWithCorrectOrder.kt");
         }
     }
 

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/JvmIrAgainstOldBoxInlineTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/JvmIrAgainstOldBoxInlineTestGenerated.java
@@ -594,6 +594,11 @@ public class JvmIrAgainstOldBoxInlineTestGenerated extends AbstractJvmIrAgainstO
             runTest("compiler/testData/codegen/boxInline/argumentOrder/defaultParametersAndLastVararg.kt");
         }
 
+        @TestMetadata("defaultParametersAndLastVarargWithCorrectOrder.kt")
+        public void testDefaultParametersAndLastVarargWithCorrectOrder() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/argumentOrder/defaultParametersAndLastVarargWithCorrectOrder.kt");
+        }
+
         @TestMetadata("extension.kt")
         public void testExtension() throws Exception {
             runTest("compiler/testData/codegen/boxInline/argumentOrder/extension.kt");
@@ -627,6 +632,11 @@ public class JvmIrAgainstOldBoxInlineTestGenerated extends AbstractJvmIrAgainstO
         @TestMetadata("varargAndDefaultParameters.kt")
         public void testVarargAndDefaultParameters() throws Exception {
             runTest("compiler/testData/codegen/boxInline/argumentOrder/varargAndDefaultParameters.kt");
+        }
+
+        @TestMetadata("varargAndDefaultParametersWithCorrectOrder.kt")
+        public void testVarargAndDefaultParametersWithCorrectOrder() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/argumentOrder/varargAndDefaultParametersWithCorrectOrder.kt");
         }
     }
 

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/JvmOldAgainstIrBoxInlineTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/JvmOldAgainstIrBoxInlineTestGenerated.java
@@ -594,6 +594,11 @@ public class JvmOldAgainstIrBoxInlineTestGenerated extends AbstractJvmOldAgainst
             runTest("compiler/testData/codegen/boxInline/argumentOrder/defaultParametersAndLastVararg.kt");
         }
 
+        @TestMetadata("defaultParametersAndLastVarargWithCorrectOrder.kt")
+        public void testDefaultParametersAndLastVarargWithCorrectOrder() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/argumentOrder/defaultParametersAndLastVarargWithCorrectOrder.kt");
+        }
+
         @TestMetadata("extension.kt")
         public void testExtension() throws Exception {
             runTest("compiler/testData/codegen/boxInline/argumentOrder/extension.kt");
@@ -627,6 +632,11 @@ public class JvmOldAgainstIrBoxInlineTestGenerated extends AbstractJvmOldAgainst
         @TestMetadata("varargAndDefaultParameters.kt")
         public void testVarargAndDefaultParameters() throws Exception {
             runTest("compiler/testData/codegen/boxInline/argumentOrder/varargAndDefaultParameters.kt");
+        }
+
+        @TestMetadata("varargAndDefaultParametersWithCorrectOrder.kt")
+        public void testVarargAndDefaultParametersWithCorrectOrder() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/argumentOrder/varargAndDefaultParametersWithCorrectOrder.kt");
         }
     }
 

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
@@ -11161,6 +11161,11 @@ public class IrJsCodegenBoxES6TestGenerated extends AbstractIrJsCodegenBoxES6Tes
             runTest("compiler/testData/codegen/box/increment/classVarargGetSet.kt");
         }
 
+        @TestMetadata("classVarargGetSetEvaluationOrder.kt")
+        public void testClassVarargGetSetEvaluationOrder() throws Exception {
+            runTest("compiler/testData/codegen/box/increment/classVarargGetSetEvaluationOrder.kt");
+        }
+
         @TestMetadata("classWithGetSet.kt")
         public void testClassWithGetSet() throws Exception {
             runTest("compiler/testData/codegen/box/increment/classWithGetSet.kt");
@@ -14385,6 +14390,11 @@ public class IrJsCodegenBoxES6TestGenerated extends AbstractIrJsCodegenBoxES6Tes
         @TestMetadata("varargs.kt")
         public void testVarargs() throws Exception {
             runTest("compiler/testData/codegen/box/mixedNamedPosition/varargs.kt");
+        }
+
+        @TestMetadata("varargsEvaluationOrder.kt")
+        public void testVarargsEvaluationOrder() throws Exception {
+            runTest("compiler/testData/codegen/box/mixedNamedPosition/varargsEvaluationOrder.kt");
         }
     }
 
@@ -25670,6 +25680,11 @@ public class IrJsCodegenBoxES6TestGenerated extends AbstractIrJsCodegenBoxES6Tes
         @TestMetadata("doNotCopyImmediatelyCreatedArrays.kt")
         public void testDoNotCopyImmediatelyCreatedArrays() throws Exception {
             runTest("compiler/testData/codegen/box/vararg/doNotCopyImmediatelyCreatedArrays.kt");
+        }
+
+        @TestMetadata("evaluationOrder.kt")
+        public void testEvaluationOrder() throws Exception {
+            runTest("compiler/testData/codegen/box/vararg/evaluationOrder.kt");
         }
 
         @TestMetadata("kt1978.kt")

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
@@ -11136,6 +11136,11 @@ public class IrJsCodegenBoxES6TestGenerated extends AbstractIrJsCodegenBoxES6Tes
             KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/increment"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR_ES6, true);
         }
 
+        @TestMetadata("argumentWithSideEffects.kt")
+        public void testArgumentWithSideEffects() throws Exception {
+            runTest("compiler/testData/codegen/box/increment/argumentWithSideEffects.kt");
+        }
+
         @TestMetadata("arrayElement.kt")
         public void testArrayElement() throws Exception {
             runTest("compiler/testData/codegen/box/increment/arrayElement.kt");

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
@@ -11156,6 +11156,11 @@ public class IrJsCodegenBoxES6TestGenerated extends AbstractIrJsCodegenBoxES6Tes
             runTest("compiler/testData/codegen/box/increment/classNaryGetSet.kt");
         }
 
+        @TestMetadata("classVarargGetSet.kt")
+        public void testClassVarargGetSet() throws Exception {
+            runTest("compiler/testData/codegen/box/increment/classVarargGetSet.kt");
+        }
+
         @TestMetadata("classWithGetSet.kt")
         public void testClassWithGetSet() throws Exception {
             runTest("compiler/testData/codegen/box/increment/classWithGetSet.kt");

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenInlineES6TestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenInlineES6TestGenerated.java
@@ -534,6 +534,11 @@ public class IrJsCodegenInlineES6TestGenerated extends AbstractIrJsCodegenInline
             runTest("compiler/testData/codegen/boxInline/argumentOrder/defaultParametersAndLastVararg.kt");
         }
 
+        @TestMetadata("defaultParametersAndLastVarargWithCorrectOrder.kt")
+        public void testDefaultParametersAndLastVarargWithCorrectOrder() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/argumentOrder/defaultParametersAndLastVarargWithCorrectOrder.kt");
+        }
+
         @TestMetadata("extension.kt")
         public void testExtension() throws Exception {
             runTest("compiler/testData/codegen/boxInline/argumentOrder/extension.kt");
@@ -567,6 +572,11 @@ public class IrJsCodegenInlineES6TestGenerated extends AbstractIrJsCodegenInline
         @TestMetadata("varargAndDefaultParameters.kt")
         public void testVarargAndDefaultParameters() throws Exception {
             runTest("compiler/testData/codegen/boxInline/argumentOrder/varargAndDefaultParameters.kt");
+        }
+
+        @TestMetadata("varargAndDefaultParametersWithCorrectOrder.kt")
+        public void testVarargAndDefaultParametersWithCorrectOrder() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/argumentOrder/varargAndDefaultParametersWithCorrectOrder.kt");
         }
     }
 

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -11161,6 +11161,11 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/increment/classVarargGetSet.kt");
         }
 
+        @TestMetadata("classVarargGetSetEvaluationOrder.kt")
+        public void testClassVarargGetSetEvaluationOrder() throws Exception {
+            runTest("compiler/testData/codegen/box/increment/classVarargGetSetEvaluationOrder.kt");
+        }
+
         @TestMetadata("classWithGetSet.kt")
         public void testClassWithGetSet() throws Exception {
             runTest("compiler/testData/codegen/box/increment/classWithGetSet.kt");
@@ -14385,6 +14390,11 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
         @TestMetadata("varargs.kt")
         public void testVarargs() throws Exception {
             runTest("compiler/testData/codegen/box/mixedNamedPosition/varargs.kt");
+        }
+
+        @TestMetadata("varargsEvaluationOrder.kt")
+        public void testVarargsEvaluationOrder() throws Exception {
+            runTest("compiler/testData/codegen/box/mixedNamedPosition/varargsEvaluationOrder.kt");
         }
     }
 
@@ -25670,6 +25680,11 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
         @TestMetadata("doNotCopyImmediatelyCreatedArrays.kt")
         public void testDoNotCopyImmediatelyCreatedArrays() throws Exception {
             runTest("compiler/testData/codegen/box/vararg/doNotCopyImmediatelyCreatedArrays.kt");
+        }
+
+        @TestMetadata("evaluationOrder.kt")
+        public void testEvaluationOrder() throws Exception {
+            runTest("compiler/testData/codegen/box/vararg/evaluationOrder.kt");
         }
 
         @TestMetadata("kt1978.kt")

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -11136,6 +11136,11 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/increment"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR, true);
         }
 
+        @TestMetadata("argumentWithSideEffects.kt")
+        public void testArgumentWithSideEffects() throws Exception {
+            runTest("compiler/testData/codegen/box/increment/argumentWithSideEffects.kt");
+        }
+
         @TestMetadata("arrayElement.kt")
         public void testArrayElement() throws Exception {
             runTest("compiler/testData/codegen/box/increment/arrayElement.kt");

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -11156,6 +11156,11 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/increment/classNaryGetSet.kt");
         }
 
+        @TestMetadata("classVarargGetSet.kt")
+        public void testClassVarargGetSet() throws Exception {
+            runTest("compiler/testData/codegen/box/increment/classVarargGetSet.kt");
+        }
+
         @TestMetadata("classWithGetSet.kt")
         public void testClassWithGetSet() throws Exception {
             runTest("compiler/testData/codegen/box/increment/classWithGetSet.kt");

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenInlineTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenInlineTestGenerated.java
@@ -534,6 +534,11 @@ public class IrJsCodegenInlineTestGenerated extends AbstractIrJsCodegenInlineTes
             runTest("compiler/testData/codegen/boxInline/argumentOrder/defaultParametersAndLastVararg.kt");
         }
 
+        @TestMetadata("defaultParametersAndLastVarargWithCorrectOrder.kt")
+        public void testDefaultParametersAndLastVarargWithCorrectOrder() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/argumentOrder/defaultParametersAndLastVarargWithCorrectOrder.kt");
+        }
+
         @TestMetadata("extension.kt")
         public void testExtension() throws Exception {
             runTest("compiler/testData/codegen/boxInline/argumentOrder/extension.kt");
@@ -567,6 +572,11 @@ public class IrJsCodegenInlineTestGenerated extends AbstractIrJsCodegenInlineTes
         @TestMetadata("varargAndDefaultParameters.kt")
         public void testVarargAndDefaultParameters() throws Exception {
             runTest("compiler/testData/codegen/boxInline/argumentOrder/varargAndDefaultParameters.kt");
+        }
+
+        @TestMetadata("varargAndDefaultParametersWithCorrectOrder.kt")
+        public void testVarargAndDefaultParametersWithCorrectOrder() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/argumentOrder/varargAndDefaultParametersWithCorrectOrder.kt");
         }
     }
 

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -11221,6 +11221,11 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/increment/classNaryGetSet.kt");
         }
 
+        @TestMetadata("classVarargGetSet.kt")
+        public void testClassVarargGetSet() throws Exception {
+            runTest("compiler/testData/codegen/box/increment/classVarargGetSet.kt");
+        }
+
         @TestMetadata("classWithGetSet.kt")
         public void testClassWithGetSet() throws Exception {
             runTest("compiler/testData/codegen/box/increment/classWithGetSet.kt");

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -11201,6 +11201,11 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/increment"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS, true);
         }
 
+        @TestMetadata("argumentWithSideEffects.kt")
+        public void testArgumentWithSideEffects() throws Exception {
+            runTest("compiler/testData/codegen/box/increment/argumentWithSideEffects.kt");
+        }
+
         @TestMetadata("arrayElement.kt")
         public void testArrayElement() throws Exception {
             runTest("compiler/testData/codegen/box/increment/arrayElement.kt");

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -11226,6 +11226,11 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/increment/classVarargGetSet.kt");
         }
 
+        @TestMetadata("classVarargGetSetEvaluationOrder.kt")
+        public void testClassVarargGetSetEvaluationOrder() throws Exception {
+            runTest("compiler/testData/codegen/box/increment/classVarargGetSetEvaluationOrder.kt");
+        }
+
         @TestMetadata("classWithGetSet.kt")
         public void testClassWithGetSet() throws Exception {
             runTest("compiler/testData/codegen/box/increment/classWithGetSet.kt");
@@ -14450,6 +14455,11 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
         @TestMetadata("varargs.kt")
         public void testVarargs() throws Exception {
             runTest("compiler/testData/codegen/box/mixedNamedPosition/varargs.kt");
+        }
+
+        @TestMetadata("varargsEvaluationOrder.kt")
+        public void testVarargsEvaluationOrder() throws Exception {
+            runTest("compiler/testData/codegen/box/mixedNamedPosition/varargsEvaluationOrder.kt");
         }
     }
 
@@ -25685,6 +25695,11 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
         @TestMetadata("doNotCopyImmediatelyCreatedArrays.kt")
         public void testDoNotCopyImmediatelyCreatedArrays() throws Exception {
             runTest("compiler/testData/codegen/box/vararg/doNotCopyImmediatelyCreatedArrays.kt");
+        }
+
+        @TestMetadata("evaluationOrder.kt")
+        public void testEvaluationOrder() throws Exception {
+            runTest("compiler/testData/codegen/box/vararg/evaluationOrder.kt");
         }
 
         @TestMetadata("kt1978.kt")

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenInlineTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenInlineTestGenerated.java
@@ -534,6 +534,11 @@ public class JsCodegenInlineTestGenerated extends AbstractJsCodegenInlineTest {
             runTest("compiler/testData/codegen/boxInline/argumentOrder/defaultParametersAndLastVararg.kt");
         }
 
+        @TestMetadata("defaultParametersAndLastVarargWithCorrectOrder.kt")
+        public void testDefaultParametersAndLastVarargWithCorrectOrder() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/argumentOrder/defaultParametersAndLastVarargWithCorrectOrder.kt");
+        }
+
         @TestMetadata("extension.kt")
         public void testExtension() throws Exception {
             runTest("compiler/testData/codegen/boxInline/argumentOrder/extension.kt");
@@ -567,6 +572,11 @@ public class JsCodegenInlineTestGenerated extends AbstractJsCodegenInlineTest {
         @TestMetadata("varargAndDefaultParameters.kt")
         public void testVarargAndDefaultParameters() throws Exception {
             runTest("compiler/testData/codegen/boxInline/argumentOrder/varargAndDefaultParameters.kt");
+        }
+
+        @TestMetadata("varargAndDefaultParametersWithCorrectOrder.kt")
+        public void testVarargAndDefaultParametersWithCorrectOrder() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/argumentOrder/varargAndDefaultParametersWithCorrectOrder.kt");
         }
     }
 


### PR DESCRIPTION
This also includes a fix (2nd commit) that ensures that vararg arguments are kept in the right order in resolved calls. They were being added to the end (https://youtrack.jetbrains.com/issue/KT-17691), which is the behavior with the non-IR backend with both old and new inference. However with the JVM IR backend, the bug is fixed, hence it should be fixed with FIR as well.