### PR TITLE
Produce deterministic jar files.

### DIFF
--- a/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/arguments/K2JVMCompilerArguments.kt
+++ b/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/arguments/K2JVMCompilerArguments.kt
@@ -378,6 +378,13 @@ class K2JVMCompilerArguments : CommonCompilerArguments() {
     var noKotlinNothingValueException: Boolean by FreezableVar(false)
 
     @Argument(
+        value = "-Xno-reset-jar-timestamps",
+        description = "Do not reset jar entry timestamps to a fixed date"
+    )
+    var noResetJarTimestamps: Boolean by FreezableVar(false)
+
+
+    @Argument(
         value = "-Xno-unified-null-checks",
         description = "Use pre-1.4 exception types in null checks instead of java.lang.NPE. See KT-22275 for more details"
     )

--- a/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/CompileEnvironmentUtil.java
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/CompileEnvironmentUtil.java
@@ -37,6 +37,9 @@ import java.util.jar.*;
 import static org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity.ERROR;
 
 public class CompileEnvironmentUtil {
+
+    public static long DOS_EPOCH = new GregorianCalendar(1980, Calendar.JANUARY, 1, 0, 0, 0).getTimeInMillis();
+
     @NotNull
     public static ModuleChunk loadModuleChunk(File buildFile, MessageCollector messageCollector) {
         if (!buildFile.exists()) {
@@ -66,13 +69,13 @@ public class CompileEnvironmentUtil {
             JarOutputStream stream = new JarOutputStream(fos);
             JarEntry manifestEntry = new JarEntry(JarFile.MANIFEST_NAME);
             long dosEpoch = new GregorianCalendar(1980, Calendar.JANUARY, 1, 0, 0, 0).getTimeInMillis();
-            manifestEntry.setTime(dosEpoch);
+            manifestEntry.setTime(DOS_EPOCH);
             stream.putNextEntry(manifestEntry);
             manifest.write(new BufferedOutputStream(stream));
 
             for (OutputFile outputFile : outputFiles.asList()) {
                 JarEntry entry = new JarEntry(outputFile.getRelativePath());
-                entry.setTime(dosEpoch);
+                entry.setTime(DOS_EPOCH);
                 stream.putNextEntry(entry);
                 stream.write(outputFile.asByteArray());
             }
@@ -119,6 +122,7 @@ public class CompileEnvironmentUtil {
                 if (e == null) {
                     break;
                 }
+                e.setTime(DOS_EPOCH);
                 if (FileUtilRt.extensionEquals(e.getName(), "class")) {
                     stream.putNextEntry(e);
                     FileUtil.copy(jis, stream);

--- a/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/CompileEnvironmentUtil.java
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/CompileEnvironmentUtil.java
@@ -126,7 +126,7 @@ public class CompileEnvironmentUtil {
                     break;
                 }
                 if (resetJarTimestamps) {
-                  e.setTime(DOS_EPOCH);
+                    e.setTime(DOS_EPOCH);
                 }
                 if (FileUtilRt.extensionEquals(e.getName(), "class")) {
                     stream.putNextEntry(e);

--- a/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/CompileEnvironmentUtil.java
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/CompileEnvironmentUtil.java
@@ -61,9 +61,17 @@ public class CompileEnvironmentUtil {
             if (mainClass != null) {
                 mainAttributes.putValue("Main-Class", mainClass.asString());
             }
-            JarOutputStream stream = new JarOutputStream(fos, manifest);
+
+            JarOutputStream stream = new JarOutputStream(fos);
+            JarEntry manifestEntry = new JarEntry(JarFile.MANIFEST_NAME);
+            manifestEntry.setTime(0L);
+            stream.putNextEntry(manifestEntry);
+            manifest.write(new BufferedOutputStream(stream));
+
             for (OutputFile outputFile : outputFiles.asList()) {
-                stream.putNextEntry(new JarEntry(outputFile.getRelativePath()));
+                JarEntry entry = new JarEntry(outputFile.getRelativePath());
+                entry.setTime(0L);
+                stream.putNextEntry(entry);
                 stream.write(outputFile.asByteArray());
             }
             if (includeRuntime) {

--- a/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/CompileEnvironmentUtil.java
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/CompileEnvironmentUtil.java
@@ -31,6 +31,7 @@ import org.jetbrains.kotlin.utils.ExceptionUtilsKt;
 import org.jetbrains.kotlin.utils.PathUtil;
 
 import java.io.*;
+import java.util.*;
 import java.util.jar.*;
 
 import static org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity.ERROR;
@@ -64,13 +65,14 @@ public class CompileEnvironmentUtil {
 
             JarOutputStream stream = new JarOutputStream(fos);
             JarEntry manifestEntry = new JarEntry(JarFile.MANIFEST_NAME);
-            manifestEntry.setTime(0L);
+            long dosEpoch = new GregorianCalendar(1980, Calendar.JANUARY, 1, 0, 0, 0).getTimeInMillis();
+            manifestEntry.setTime(dosEpoch);
             stream.putNextEntry(manifestEntry);
             manifest.write(new BufferedOutputStream(stream));
 
             for (OutputFile outputFile : outputFiles.asList()) {
                 JarEntry entry = new JarEntry(outputFile.getRelativePath());
-                entry.setTime(0L);
+                entry.setTime(dosEpoch);
                 stream.putNextEntry(entry);
                 stream.write(outputFile.asByteArray());
             }

--- a/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinToJVMBytecodeCompiler.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinToJVMBytecodeCompiler.kt
@@ -88,7 +88,8 @@ object KotlinToJVMBytecodeCompiler {
         val messageCollector = configuration.get(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
         if (jarPath != null) {
             val includeRuntime = configuration.get(JVMConfigurationKeys.INCLUDE_RUNTIME, false)
-            CompileEnvironmentUtil.writeToJar(jarPath, includeRuntime, mainClassFqName, outputFiles)
+            val resetJarTimestamps = !configuration.get(JVMConfigurationKeys.NO_RESET_JAR_TIMESTAMPS, false)
+            CompileEnvironmentUtil.writeToJar(jarPath, includeRuntime, resetJarTimestamps, mainClassFqName, outputFiles)
             if (reportOutputFiles) {
                 val message = OutputMessageUtil.formatOutputMessage(outputFiles.asList().flatMap { it.sourceFiles }.distinct(), jarPath)
                 messageCollector.report(OUTPUT, message)

--- a/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/jvmArguments.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/jvmArguments.kt
@@ -185,6 +185,7 @@ fun CompilerConfiguration.configureAdvancedJvmOptions(arguments: K2JVMCompilerAr
     put(JVMConfigurationKeys.EMIT_JVM_TYPE_ANNOTATIONS, arguments.emitJvmTypeAnnotations)
     put(JVMConfigurationKeys.NO_OPTIMIZED_CALLABLE_REFERENCES, arguments.noOptimizedCallableReferences)
     put(JVMConfigurationKeys.NO_KOTLIN_NOTHING_VALUE_EXCEPTION, arguments.noKotlinNothingValueException)
+    put(JVMConfigurationKeys.NO_RESET_JAR_TIMESTAMPS, arguments.noResetJarTimestamps)
     put(JVMConfigurationKeys.NO_UNIFIED_NULL_CHECKS, arguments.noUnifiedNullChecks)
 
     if (!JVMConstructorCallNormalizationMode.isSupportedValue(arguments.constructorCallNormalizationMode)) {

--- a/compiler/config.jvm/src/org/jetbrains/kotlin/config/JVMConfigurationKeys.java
+++ b/compiler/config.jvm/src/org/jetbrains/kotlin/config/JVMConfigurationKeys.java
@@ -129,6 +129,9 @@ public class JVMConfigurationKeys {
     public static final CompilerConfigurationKey<Boolean> NO_KOTLIN_NOTHING_VALUE_EXCEPTION =
             CompilerConfigurationKey.create("Do not use KotlinNothingValueException available since 1.4");
 
+    public static final CompilerConfigurationKey<Boolean> NO_RESET_JAR_TIMESTAMPS =
+            CompilerConfigurationKey.create("Do not reset timestamps in jar entries");
+
     public static final CompilerConfigurationKey<Boolean> NO_UNIFIED_NULL_CHECKS =
             CompilerConfigurationKey.create("Use pre-1.4 exception types in null checks instead of java.lang.NPE");
 

--- a/compiler/tests/org/jetbrains/kotlin/cli/DeterministicOutputTest.kt
+++ b/compiler/tests/org/jetbrains/kotlin/cli/DeterministicOutputTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.kotlin.cli
+
+import java.io.File
+import java.io.FileInputStream
+import java.util.jar.JarInputStream
+import java.util.zip.ZipEntry
+import kotlin.test.assertEquals
+import org.jetbrains.kotlin.cli.jvm.K2JVMCompiler
+import org.jetbrains.kotlin.cli.jvm.compiler.CompileEnvironmentUtil.DOS_EPOCH
+import org.jetbrains.kotlin.test.KotlinTestUtils
+import org.jetbrains.kotlin.test.testFramework.KtUsefulTestCase
+
+class DeterministicOutputTest : KtUsefulTestCase() {
+
+    fun testDeterministicOutput() {
+        val directory = KotlinTestUtils.getTestDataPathBase() + "/deterministicOutput"
+        val librarySource = File(directory, "A.kt").also {
+            it.writeText("class A")
+        }
+
+        val firstJar = File(directory, "first.jar")
+        AbstractCliTest.executeCompilerGrabOutput(
+            K2JVMCompiler(),
+            listOf(librarySource.path, "-d", firstJar.path, "-include-runtime"))
+
+        val secondJar = File(directory, "second.jar")
+        AbstractCliTest.executeCompilerGrabOutput(
+            K2JVMCompiler(),
+            listOf(librarySource.path, "-d", secondJar.path, "-include-runtime"))
+
+        assertEquals(
+            firstJar.readBytes().toList(),
+            secondJar.readBytes().toList(),
+            "jar contents should be identical if compiler command and inputs are the same")
+        assertAllTimestampsAreReset(firstJar)
+        assertAllTimestampsAreReset(secondJar)
+    }
+
+    private fun assertAllTimestampsAreReset(jar: File) {
+        val zis = JarInputStream(FileInputStream(jar))
+        var entry: ZipEntry? = zis.nextEntry
+        while (entry != null) {
+            assertEquals(entry.time, DOS_EPOCH, "timestamp should be default $entry")
+            entry = zis.nextEntry
+        }
+    }
+}

--- a/compiler/tests/org/jetbrains/kotlin/cli/DeterministicOutputTest.kt
+++ b/compiler/tests/org/jetbrains/kotlin/cli/DeterministicOutputTest.kt
@@ -56,7 +56,7 @@ class DeterministicOutputTest : KtUsefulTestCase() {
         val zis = JarInputStream(FileInputStream(jar))
         var entry: ZipEntry? = zis.nextEntry
         while (entry != null) {
-            assertEquals(entry.time, DOS_EPOCH, "timestamp should be default $entry")
+            assertEquals(entry.time, DOS_EPOCH, "$entry timestamp should be reset")
             entry = zis.nextEntry
         }
     }


### PR DESCRIPTION
This resets all timestamps present in jars produced by kotlinc.

This is important for build systems like bazel that rely on
deterministic outputs. One can revert to the legacy behavior
by using the `-Xno-reset-jar-timestamps` flag.

Before:

```
$ kotlinc ~/test.kt -d /tmp/a.jar
$ kotlinc ~/test.kt -d /tmp/b.jar
$ shasum /tmp/a.jar /tmp/b.jar
1ba022697317f796bd123fb4dc95418a18bcb51a  /tmp/a.jar
6d2a2683470c24928f3fbd6768a4c57f55b0d196  /tmp/b.jar
$ unzip -l /tmp/a.jar
Archive:  /tmp/a.jar
  Length      Date    Time    Name
---------  ---------- -----   ----
       75  09-25-2020 16:48   META-INF/MANIFEST.MF
      683  09-25-2020 16:48   TestKt.class
       28  09-25-2020 16:48   META-INF/main.kotlin_module
---------                     -------
      786                     3 files
```

After:

```
$ kotlinc ~/test.kt -d /tmp/a.jar
$ kotlinc ~/test.kt -d /tmp/b.jar
$ shasum /tmp/a.jar /tmp/b.jar
86b9614fab6973d2d637b804fd460d2d184c9b08  /tmp/a.jar
86b9614fab6973d2d637b804fd460d2d184c9b08  /tmp/b.jar
$ unzip -l /tmp/a.jar
Archive:  /tmp/a.jar
  Length      Date    Time    Name
---------  ---------- -----   ----
       75  01-01-1980 00:00   META-INF/MANIFEST.MF
      590  01-01-1980 00:00   TestKt.class
       36  01-01-1980 00:00   META-INF/main.kotlin_module
---------                     -------
      701                     3 files
```

See https://github.com/JetBrains/kotlin/pull/3226 for a similar change.