### PR TITLE
[FIR] Match behavior of prefix inc/decrement with old frontend

### DIFF
--- a/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
@@ -13135,6 +13135,11 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         public void testPrefixNullableIncrement() throws Exception {
             runTest("compiler/testData/codegen/box/increment/prefixNullableIncrement.kt");
         }
+
+        @TestMetadata("prefixVersusPostfixEvaluationOrder.kt")
+        public void testPrefixVersusPostfixEvaluationOrder() throws Exception {
+            runTest("compiler/testData/codegen/box/increment/prefixVersusPostfixEvaluationOrder.kt");
+        }
     }
 
     @TestMetadata("compiler/testData/codegen/box/inference")

--- a/compiler/fir/raw-fir/psi2fir/testData/rawBuilder/expressions/unary.txt
+++ b/compiler/fir/raw-fir/psi2fir/testData/rawBuilder/expressions/unary.txt
@@ -49,9 +49,8 @@ FILE: unary.kt
 
         lval x2: <implicit> =  {
             lval <receiver>: <implicit> = x#
-            lval <unary-result>: <implicit> = R|<local>/<receiver>|.i#.inc#()
-            R|<local>/<receiver>|.i# = R|<local>/<unary-result>|
-            R|<local>/<unary-result>|
+            R|<local>/<receiver>|.i# = R|<local>/<receiver>|.i#.inc#()
+            R|<local>/<receiver>|.i#
         }
 
     }
@@ -67,9 +66,8 @@ FILE: unary.kt
         lval x2: <implicit> =  {
             lval <array>: <implicit> = arr#
             lval <index0>: <implicit> = IntegerLiteral(1)
-            lval <unary-result>: <implicit> = R|<local>/<array>|.get#(R|<local>/<index0>|).inc#()
-            R|<local>/<array>|.set#(R|<local>/<index0>|, R|<local>/<unary-result>|)
-            R|<local>/<unary-result>|
+            R|<local>/<array>|.set#(R|<local>/<index0>|, R|<local>/<array>|.get#(R|<local>/<index0>|).inc#())
+            R|<local>/<array>|.get#(R|<local>/<index0>|)
         }
 
     }
@@ -94,9 +92,8 @@ FILE: unary.kt
         lval x2: <implicit> =  {
             lval <array>: <implicit> = y#.arr#
             lval <index0>: <implicit> = IntegerLiteral(1)
-            lval <unary-result>: <implicit> = R|<local>/<array>|.get#(R|<local>/<index0>|).inc#()
-            R|<local>/<array>|.set#(R|<local>/<index0>|, R|<local>/<unary-result>|)
-            R|<local>/<unary-result>|
+            R|<local>/<array>|.set#(R|<local>/<index0>|, R|<local>/<array>|.get#(R|<local>/<index0>|).inc#())
+            R|<local>/<array>|.get#(R|<local>/<index0>|)
         }
 
     }

--- a/compiler/fir/raw-fir/raw-fir.common/src/org/jetbrains/kotlin/fir/builder/BaseFirBuilder.kt
+++ b/compiler/fir/raw-fir/raw-fir.common/src/org/jetbrains/kotlin/fir/builder/BaseFirBuilder.kt
@@ -389,9 +389,8 @@ abstract class BaseFirBuilder<T>(val baseSession: FirSession, val context: Conte
      *
      * result:
      * {
-     *     val <unary-result> = argument.inc()
-     *     argument = <unary-result>
-     *     ^<unary-result>
+     *     argument = argument.inc()
+     *     argument.inc()
      * }
      *
      */
@@ -475,21 +474,10 @@ abstract class BaseFirBuilder<T>(val baseSession: FirSession, val context: Conte
                 }
             }
 
-            // resultVar is only used for prefix increment/decrement.
-            val resultVar = generateTemporaryVariable(
-                this@BaseFirBuilder.baseSession,
-                desugaredSource,
-                Name.special("<unary-result>"),
-                resultInitializer
-            )
-
             val assignment = unwrappedArgument.generateAssignment(
                 desugaredSource,
                 null,
-                if (prefix && unwrappedArgument.elementType != REFERENCE_EXPRESSION)
-                    generateResolvedAccessExpression(source, resultVar)
-                else
-                    resultInitializer,
+                resultInitializer,
                 FirOperation.ASSIGN, convert
             )
 
@@ -503,9 +491,8 @@ abstract class BaseFirBuilder<T>(val baseSession: FirSession, val context: Conte
 
             if (prefix) {
                 if (unwrappedArgument.elementType != REFERENCE_EXPRESSION) {
-                    statements += resultVar
                     appendAssignment()
-                    statements += generateResolvedAccessExpression(desugaredSource, resultVar)
+                    statements += unwrappedArgument.convert()
                 } else {
                     appendAssignment()
                     statements += generateAccessExpression(desugaredSource, unwrappedArgument.getReferencedNameAsName())
@@ -536,9 +523,8 @@ abstract class BaseFirBuilder<T>(val baseSession: FirSession, val context: Conte
      * result:
      * {
      *     val <receiver> = a
-     *     val <unary-result> = <receiver>.b.inc()
-     *     <receiver>.b = <unary-result>
-     *     ^<unary-result>
+     *     <receiver>.b = <receiver>.b.inc()
+     *     <receiver>.b
      * }
      *
      */
@@ -568,15 +554,17 @@ abstract class BaseFirBuilder<T>(val baseSession: FirSession, val context: Conte
                 }
             ).also { statements += it }
 
-            val firArgument = generateResolvedAccessExpression(argumentReceiverVariable.source, argumentReceiverVariable).let { receiver ->
-                val firArgumentSelector = argumentSelector?.convert() ?: buildErrorExpression {
-                    source = argument.toFirSourceElement()
-                    diagnostic = ConeSimpleDiagnostic("Qualified expression without selector", DiagnosticKind.Syntax)
+            fun getArgument() =
+                generateResolvedAccessExpression(argumentReceiverVariable.source, argumentReceiverVariable).let { receiver ->
+                    val firArgumentSelector = argumentSelector?.convert() ?: buildErrorExpression {
+                        source = argument.toFirSourceElement()
+                        diagnostic = ConeSimpleDiagnostic("Qualified expression without selector", DiagnosticKind.Syntax)
+                    }
+                    firArgumentSelector.also { if (it is FirQualifiedAccessExpression) it.replaceExplicitReceiver(receiver) }
                 }
-                firArgumentSelector.also { if (it is FirQualifiedAccessExpression) it.replaceExplicitReceiver(receiver) }
-            }
 
             // initialValueVar is only used for postfix increment/decrement (stores the argument value before increment/decrement).
+            val firArgument = getArgument()
             val initialValueVar = generateTemporaryVariable(
                 this@BaseFirBuilder.baseSession,
                 desugaredSource,
@@ -598,23 +586,11 @@ abstract class BaseFirBuilder<T>(val baseSession: FirSession, val context: Conte
                 }
             }
 
-            // resultVar is only used for prefix increment/decrement.
-            val resultVar = generateTemporaryVariable(
-                this@BaseFirBuilder.baseSession,
-                desugaredSource,
-                Name.special("<unary-result>"),
-                resultInitializer
-            )
-
             fun appendAssignment() {
                 if (firArgument is FirQualifiedAccessExpression) {
                     statements += buildVariableAssignment {
                         source = desugaredSource
-                        rValue = if (prefix) {
-                            generateResolvedAccessExpression(source, resultVar)
-                        } else {
-                            resultInitializer
-                        }
+                        rValue = resultInitializer
                         explicitReceiver = generateResolvedAccessExpression(argumentReceiverVariable.source, argumentReceiverVariable)
                         calleeReference = buildSimpleNamedReference {
                             source = firArgument.calleeReference.source
@@ -625,9 +601,8 @@ abstract class BaseFirBuilder<T>(val baseSession: FirSession, val context: Conte
             }
 
             if (prefix) {
-                statements += resultVar
                 appendAssignment()
-                statements += generateResolvedAccessExpression(desugaredSource, resultVar)
+                statements += getArgument()
             } else {
                 statements += initialValueVar
                 appendAssignment()

--- a/compiler/testData/codegen/box/defaultArguments/convention/incWithDefaultInGetter.kt
+++ b/compiler/testData/codegen/box/defaultArguments/convention/incWithDefaultInGetter.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 var inc: String = ""
 
 class X {

--- a/compiler/testData/codegen/box/increment/argumentWithSideEffects.kt
+++ b/compiler/testData/codegen/box/increment/argumentWithSideEffects.kt
@@ -1,5 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
-// Currently fails because prefix increment only calls getter once.
 var log = ""
 
 fun <T> logged(value: T): T =

--- a/compiler/testData/codegen/box/increment/prefixVersusPostfixEvaluationOrder.kt
+++ b/compiler/testData/codegen/box/increment/prefixVersusPostfixEvaluationOrder.kt
@@ -1,0 +1,25 @@
+var log = ""
+
+fun doTest(id: String, expected: Int, expectedLog: String, test: () -> Int) {
+    log = ""
+    val actual = test()
+    if (actual != expected) throw AssertionError("$id expected: $expected, actual: $actual")
+    if (log != expectedLog) throw AssertionError("$id expectedLog: $expectedLog, actual: $log")
+}
+
+var x = 0
+    get() = field.also { log += "get;" }
+    set(value: Int) {
+        log += "set;"
+        field = value
+    }
+
+fun box(): String {
+    // NOTE: Getter is currently called twice for prefix increment; 1st for initial value, 2nd for return value. See KT-42077.
+    doTest("++x", 1, "get;set;get;") { ++x }
+    doTest("x++", 1, "get;set;") { x++ }
+    doTest("x--", 2, "get;set;") { x-- }
+    doTest("--x", 0, "get;set;get;") { --x }
+
+    return "OK"
+}

--- a/compiler/testData/codegen/boxInline/property/augAssignmentAndIncOnExtension.kt
+++ b/compiler/testData/codegen/boxInline/property/augAssignmentAndIncOnExtension.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 // FILE: 1.kt
 package test
 

--- a/compiler/testData/codegen/boxInline/property/augAssignmentAndIncOnExtensionInClass.kt
+++ b/compiler/testData/codegen/boxInline/property/augAssignmentAndIncOnExtensionInClass.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 // FILE: 1.kt
 package test
 

--- a/compiler/testData/diagnostics/tests/LValueAssignment.fir.kt
+++ b/compiler/testData/diagnostics/tests/LValueAssignment.fir.kt
@@ -93,7 +93,7 @@ class Test() {
 
     fun testIncompleteSyntax() {
         val s = "s"
-        <!UNRESOLVED_REFERENCE!>++<!>s.<!SYNTAX!><!>
+        ++s.<!SYNTAX!><!>
     }
 
     fun testVariables() {

--- a/compiler/testData/diagnostics/tests/operatorsOverloading/InconsistentGetSet.fir.kt
+++ b/compiler/testData/diagnostics/tests/operatorsOverloading/InconsistentGetSet.fir.kt
@@ -38,7 +38,7 @@ fun testMismatchingArities() {
     <!INAPPLICABLE_CANDIDATE!>MismatchingArities1[0]<!>++
     MismatchingArities1[0] += 1
 
-    ++<!INAPPLICABLE_CANDIDATE!>MismatchingArities2[0]<!>
+    ++<!INAPPLICABLE_CANDIDATE, INAPPLICABLE_CANDIDATE!>MismatchingArities2[0]<!>
     <!INAPPLICABLE_CANDIDATE!>MismatchingArities2[0]<!>++
     MismatchingArities2[0] += 1
 }

--- a/compiler/testData/ir/irText/expressions/incrementDecrement.fir.txt
+++ b/compiler/testData/ir/irText/expressions/incrementDecrement.fir.txt
@@ -101,63 +101,63 @@ FILE fqName:<root> fileName:/incrementDecrement.kt
             CALL 'public final fun <get-arr> (): kotlin.IntArray declared in <root>' type=kotlin.IntArray origin=GET_PROPERTY
           VAR IR_TEMPORARY_VARIABLE name:tmp_4 type:kotlin.Int [val]
             CONST Int type=kotlin.Int value=0
-          VAR IR_TEMPORARY_VARIABLE name:tmp_5 type:kotlin.Int [val]
-            CALL 'public final fun inc (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
-              $this: CALL 'public final fun get (index: kotlin.Int): kotlin.Int [operator] declared in kotlin.IntArray' type=kotlin.Int origin=null
-                $this: GET_VAR 'val tmp_3: kotlin.IntArray [val] declared in <root>.testArrayPrefix' type=kotlin.IntArray origin=null
-                index: GET_VAR 'val tmp_4: kotlin.Int [val] declared in <root>.testArrayPrefix' type=kotlin.Int origin=null
           CALL 'public final fun set (index: kotlin.Int, value: kotlin.Int): kotlin.Unit [operator] declared in kotlin.IntArray' type=kotlin.Unit origin=null
             $this: GET_VAR 'val tmp_3: kotlin.IntArray [val] declared in <root>.testArrayPrefix' type=kotlin.IntArray origin=null
             index: GET_VAR 'val tmp_4: kotlin.Int [val] declared in <root>.testArrayPrefix' type=kotlin.Int origin=null
-            value: GET_VAR 'val tmp_5: kotlin.Int [val] declared in <root>.testArrayPrefix' type=kotlin.Int origin=null
-          GET_VAR 'val tmp_5: kotlin.Int [val] declared in <root>.testArrayPrefix' type=kotlin.Int origin=null
+            value: CALL 'public final fun inc (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
+              $this: CALL 'public final fun get (index: kotlin.Int): kotlin.Int [operator] declared in kotlin.IntArray' type=kotlin.Int origin=null
+                $this: GET_VAR 'val tmp_3: kotlin.IntArray [val] declared in <root>.testArrayPrefix' type=kotlin.IntArray origin=null
+                index: GET_VAR 'val tmp_4: kotlin.Int [val] declared in <root>.testArrayPrefix' type=kotlin.Int origin=null
+          CALL 'public final fun get (index: kotlin.Int): kotlin.Int [operator] declared in kotlin.IntArray' type=kotlin.Int origin=null
+            $this: GET_VAR 'val tmp_3: kotlin.IntArray [val] declared in <root>.testArrayPrefix' type=kotlin.IntArray origin=null
+            index: GET_VAR 'val tmp_4: kotlin.Int [val] declared in <root>.testArrayPrefix' type=kotlin.Int origin=null
       VAR name:a2 type:kotlin.Int [val]
         BLOCK type=kotlin.Int origin=null
-          VAR IR_TEMPORARY_VARIABLE name:tmp_6 type:kotlin.IntArray [val]
+          VAR IR_TEMPORARY_VARIABLE name:tmp_5 type:kotlin.IntArray [val]
             CALL 'public final fun <get-arr> (): kotlin.IntArray declared in <root>' type=kotlin.IntArray origin=GET_PROPERTY
-          VAR IR_TEMPORARY_VARIABLE name:tmp_7 type:kotlin.Int [val]
+          VAR IR_TEMPORARY_VARIABLE name:tmp_6 type:kotlin.Int [val]
             CONST Int type=kotlin.Int value=0
-          VAR IR_TEMPORARY_VARIABLE name:tmp_8 type:kotlin.Int [val]
-            CALL 'public final fun dec (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
-              $this: CALL 'public final fun get (index: kotlin.Int): kotlin.Int [operator] declared in kotlin.IntArray' type=kotlin.Int origin=null
-                $this: GET_VAR 'val tmp_6: kotlin.IntArray [val] declared in <root>.testArrayPrefix' type=kotlin.IntArray origin=null
-                index: GET_VAR 'val tmp_7: kotlin.Int [val] declared in <root>.testArrayPrefix' type=kotlin.Int origin=null
           CALL 'public final fun set (index: kotlin.Int, value: kotlin.Int): kotlin.Unit [operator] declared in kotlin.IntArray' type=kotlin.Unit origin=null
-            $this: GET_VAR 'val tmp_6: kotlin.IntArray [val] declared in <root>.testArrayPrefix' type=kotlin.IntArray origin=null
-            index: GET_VAR 'val tmp_7: kotlin.Int [val] declared in <root>.testArrayPrefix' type=kotlin.Int origin=null
-            value: GET_VAR 'val tmp_8: kotlin.Int [val] declared in <root>.testArrayPrefix' type=kotlin.Int origin=null
-          GET_VAR 'val tmp_8: kotlin.Int [val] declared in <root>.testArrayPrefix' type=kotlin.Int origin=null
+            $this: GET_VAR 'val tmp_5: kotlin.IntArray [val] declared in <root>.testArrayPrefix' type=kotlin.IntArray origin=null
+            index: GET_VAR 'val tmp_6: kotlin.Int [val] declared in <root>.testArrayPrefix' type=kotlin.Int origin=null
+            value: CALL 'public final fun dec (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
+              $this: CALL 'public final fun get (index: kotlin.Int): kotlin.Int [operator] declared in kotlin.IntArray' type=kotlin.Int origin=null
+                $this: GET_VAR 'val tmp_5: kotlin.IntArray [val] declared in <root>.testArrayPrefix' type=kotlin.IntArray origin=null
+                index: GET_VAR 'val tmp_6: kotlin.Int [val] declared in <root>.testArrayPrefix' type=kotlin.Int origin=null
+          CALL 'public final fun get (index: kotlin.Int): kotlin.Int [operator] declared in kotlin.IntArray' type=kotlin.Int origin=null
+            $this: GET_VAR 'val tmp_5: kotlin.IntArray [val] declared in <root>.testArrayPrefix' type=kotlin.IntArray origin=null
+            index: GET_VAR 'val tmp_6: kotlin.Int [val] declared in <root>.testArrayPrefix' type=kotlin.Int origin=null
   FUN name:testArrayPostfix visibility:public modality:FINAL <> () returnType:kotlin.Unit
     BLOCK_BODY
       VAR name:a1 type:kotlin.Int [val]
         BLOCK type=kotlin.Int origin=null
-          VAR IR_TEMPORARY_VARIABLE name:tmp_9 type:kotlin.IntArray [val]
+          VAR IR_TEMPORARY_VARIABLE name:tmp_7 type:kotlin.IntArray [val]
             CALL 'public final fun <get-arr> (): kotlin.IntArray declared in <root>' type=kotlin.IntArray origin=GET_PROPERTY
-          VAR IR_TEMPORARY_VARIABLE name:tmp_10 type:kotlin.Int [val]
+          VAR IR_TEMPORARY_VARIABLE name:tmp_8 type:kotlin.Int [val]
             CONST Int type=kotlin.Int value=0
-          VAR IR_TEMPORARY_VARIABLE name:tmp_11 type:kotlin.Int [val]
+          VAR IR_TEMPORARY_VARIABLE name:tmp_9 type:kotlin.Int [val]
             CALL 'public final fun get (index: kotlin.Int): kotlin.Int [operator] declared in kotlin.IntArray' type=kotlin.Int origin=null
-              $this: GET_VAR 'val tmp_9: kotlin.IntArray [val] declared in <root>.testArrayPostfix' type=kotlin.IntArray origin=null
-              index: GET_VAR 'val tmp_10: kotlin.Int [val] declared in <root>.testArrayPostfix' type=kotlin.Int origin=null
+              $this: GET_VAR 'val tmp_7: kotlin.IntArray [val] declared in <root>.testArrayPostfix' type=kotlin.IntArray origin=null
+              index: GET_VAR 'val tmp_8: kotlin.Int [val] declared in <root>.testArrayPostfix' type=kotlin.Int origin=null
           CALL 'public final fun set (index: kotlin.Int, value: kotlin.Int): kotlin.Unit [operator] declared in kotlin.IntArray' type=kotlin.Unit origin=null
-            $this: GET_VAR 'val tmp_9: kotlin.IntArray [val] declared in <root>.testArrayPostfix' type=kotlin.IntArray origin=null
-            index: GET_VAR 'val tmp_10: kotlin.Int [val] declared in <root>.testArrayPostfix' type=kotlin.Int origin=null
+            $this: GET_VAR 'val tmp_7: kotlin.IntArray [val] declared in <root>.testArrayPostfix' type=kotlin.IntArray origin=null
+            index: GET_VAR 'val tmp_8: kotlin.Int [val] declared in <root>.testArrayPostfix' type=kotlin.Int origin=null
             value: CALL 'public final fun inc (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
-              $this: GET_VAR 'val tmp_11: kotlin.Int [val] declared in <root>.testArrayPostfix' type=kotlin.Int origin=null
-          GET_VAR 'val tmp_11: kotlin.Int [val] declared in <root>.testArrayPostfix' type=kotlin.Int origin=null
+              $this: GET_VAR 'val tmp_9: kotlin.Int [val] declared in <root>.testArrayPostfix' type=kotlin.Int origin=null
+          GET_VAR 'val tmp_9: kotlin.Int [val] declared in <root>.testArrayPostfix' type=kotlin.Int origin=null
       VAR name:a2 type:kotlin.Int [val]
         BLOCK type=kotlin.Int origin=null
-          VAR IR_TEMPORARY_VARIABLE name:tmp_12 type:kotlin.IntArray [val]
+          VAR IR_TEMPORARY_VARIABLE name:tmp_10 type:kotlin.IntArray [val]
             CALL 'public final fun <get-arr> (): kotlin.IntArray declared in <root>' type=kotlin.IntArray origin=GET_PROPERTY
-          VAR IR_TEMPORARY_VARIABLE name:tmp_13 type:kotlin.Int [val]
+          VAR IR_TEMPORARY_VARIABLE name:tmp_11 type:kotlin.Int [val]
             CONST Int type=kotlin.Int value=0
-          VAR IR_TEMPORARY_VARIABLE name:tmp_14 type:kotlin.Int [val]
+          VAR IR_TEMPORARY_VARIABLE name:tmp_12 type:kotlin.Int [val]
             CALL 'public final fun get (index: kotlin.Int): kotlin.Int [operator] declared in kotlin.IntArray' type=kotlin.Int origin=null
-              $this: GET_VAR 'val tmp_12: kotlin.IntArray [val] declared in <root>.testArrayPostfix' type=kotlin.IntArray origin=null
-              index: GET_VAR 'val tmp_13: kotlin.Int [val] declared in <root>.testArrayPostfix' type=kotlin.Int origin=null
+              $this: GET_VAR 'val tmp_10: kotlin.IntArray [val] declared in <root>.testArrayPostfix' type=kotlin.IntArray origin=null
+              index: GET_VAR 'val tmp_11: kotlin.Int [val] declared in <root>.testArrayPostfix' type=kotlin.Int origin=null
           CALL 'public final fun set (index: kotlin.Int, value: kotlin.Int): kotlin.Unit [operator] declared in kotlin.IntArray' type=kotlin.Unit origin=null
-            $this: GET_VAR 'val tmp_12: kotlin.IntArray [val] declared in <root>.testArrayPostfix' type=kotlin.IntArray origin=null
-            index: GET_VAR 'val tmp_13: kotlin.Int [val] declared in <root>.testArrayPostfix' type=kotlin.Int origin=null
+            $this: GET_VAR 'val tmp_10: kotlin.IntArray [val] declared in <root>.testArrayPostfix' type=kotlin.IntArray origin=null
+            index: GET_VAR 'val tmp_11: kotlin.Int [val] declared in <root>.testArrayPostfix' type=kotlin.Int origin=null
             value: CALL 'public final fun dec (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
-              $this: GET_VAR 'val tmp_14: kotlin.Int [val] declared in <root>.testArrayPostfix' type=kotlin.Int origin=null
-          GET_VAR 'val tmp_14: kotlin.Int [val] declared in <root>.testArrayPostfix' type=kotlin.Int origin=null
+              $this: GET_VAR 'val tmp_12: kotlin.Int [val] declared in <root>.testArrayPostfix' type=kotlin.Int origin=null
+          GET_VAR 'val tmp_12: kotlin.Int [val] declared in <root>.testArrayPostfix' type=kotlin.Int origin=null

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -14530,6 +14530,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
         public void testPrefixNullableIncrement() throws Exception {
             runTest("compiler/testData/codegen/box/increment/prefixNullableIncrement.kt");
         }
+
+        @TestMetadata("prefixVersusPostfixEvaluationOrder.kt")
+        public void testPrefixVersusPostfixEvaluationOrder() throws Exception {
+            runTest("compiler/testData/codegen/box/increment/prefixVersusPostfixEvaluationOrder.kt");
+        }
     }
 
     @TestMetadata("compiler/testData/codegen/box/inference")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -14530,6 +14530,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
         public void testPrefixNullableIncrement() throws Exception {
             runTest("compiler/testData/codegen/box/increment/prefixNullableIncrement.kt");
         }
+
+        @TestMetadata("prefixVersusPostfixEvaluationOrder.kt")
+        public void testPrefixVersusPostfixEvaluationOrder() throws Exception {
+            runTest("compiler/testData/codegen/box/increment/prefixVersusPostfixEvaluationOrder.kt");
+        }
     }
 
     @TestMetadata("compiler/testData/codegen/box/inference")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -13135,6 +13135,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         public void testPrefixNullableIncrement() throws Exception {
             runTest("compiler/testData/codegen/box/increment/prefixNullableIncrement.kt");
         }
+
+        @TestMetadata("prefixVersusPostfixEvaluationOrder.kt")
+        public void testPrefixVersusPostfixEvaluationOrder() throws Exception {
+            runTest("compiler/testData/codegen/box/increment/prefixVersusPostfixEvaluationOrder.kt");
+        }
     }
 
     @TestMetadata("compiler/testData/codegen/box/inference")

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
@@ -11280,6 +11280,11 @@ public class IrJsCodegenBoxES6TestGenerated extends AbstractIrJsCodegenBoxES6Tes
         public void testPrefixNullableIncrement() throws Exception {
             runTest("compiler/testData/codegen/box/increment/prefixNullableIncrement.kt");
         }
+
+        @TestMetadata("prefixVersusPostfixEvaluationOrder.kt")
+        public void testPrefixVersusPostfixEvaluationOrder() throws Exception {
+            runTest("compiler/testData/codegen/box/increment/prefixVersusPostfixEvaluationOrder.kt");
+        }
     }
 
     @TestMetadata("compiler/testData/codegen/box/inference")

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -11280,6 +11280,11 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
         public void testPrefixNullableIncrement() throws Exception {
             runTest("compiler/testData/codegen/box/increment/prefixNullableIncrement.kt");
         }
+
+        @TestMetadata("prefixVersusPostfixEvaluationOrder.kt")
+        public void testPrefixVersusPostfixEvaluationOrder() throws Exception {
+            runTest("compiler/testData/codegen/box/increment/prefixVersusPostfixEvaluationOrder.kt");
+        }
     }
 
     @TestMetadata("compiler/testData/codegen/box/inference")

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -11345,6 +11345,11 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
         public void testPrefixNullableIncrement() throws Exception {
             runTest("compiler/testData/codegen/box/increment/prefixNullableIncrement.kt");
         }
+
+        @TestMetadata("prefixVersusPostfixEvaluationOrder.kt")
+        public void testPrefixVersusPostfixEvaluationOrder() throws Exception {
+            runTest("compiler/testData/codegen/box/increment/prefixVersusPostfixEvaluationOrder.kt");
+        }
     }
 
     @TestMetadata("compiler/testData/codegen/box/inference")


### PR DESCRIPTION
...retrieving and returning the new argument value.

Rmoved the temporary variable that was used to store and return the result of the increment. Note: The previous behavior was correct according to spec, but KT-42077 proposes changing the behavior so that getters are only called once.