### PR TITLE
Sort class members to ensure deterministic builds

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/DeterministicBuildIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/DeterministicBuildIT.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle
+
+import org.jetbrains.kotlin.gradle.util.allJavaFiles
+import org.junit.Test
+import java.io.File
+import kotlin.test.assertEquals
+
+/** Tests that the outputs of a build are deterministic. */
+class DeterministicBuildIT : BaseGradleIT() {
+
+    @Test
+    fun `test KaptGenerateStubsTask - KT-40882`() = with(
+        Project("simple", directoryPrefix = "kapt2")
+    ) {
+        setupWorkingDir()
+        projectDir
+            .resolve("src/main/java/Foo.kt")
+            .writeText(
+                """
+                class Foo : Bar {
+                    // The fields and methods are ordered such that any sorting by KGP will be detected.
+                    val fooField1 = 1
+                    val fooField3 = 3
+                    val fooField2 = 2
+                    fun fooMethod1() {}
+                    fun fooMethod3() {}
+                    fun fooMethod2() {}
+                }
+                """.trimIndent()
+            )
+        projectDir
+            .resolve("src/main/java/Bar.kt")
+            .writeText(
+                """
+                interface Bar {
+                    val barField1 = 1
+                    val barField3 = 3
+                    val barField2 = 2
+                    fun barMethod1() {}
+                    fun barMethod3() {}
+                    fun barMethod2() {}
+                }
+                """.trimIndent()
+            )
+
+        val buildAndSnapshotStubFiles: () -> Map<File, String> = {
+            lateinit var stubFiles: Map<File, String>
+            build(":kaptGenerateStubsKotlin") {
+                assertSuccessful()
+                assertTasksExecuted(":kaptGenerateStubsKotlin")
+                stubFiles = fileInWorkingDir("build/tmp/kapt3/stubs").allJavaFiles().map {
+                    it to it.readText()
+                }.toMap()
+            }
+            stubFiles
+        }
+
+        // Run the first build
+        val stubFilesAfterFirstBuild = buildAndSnapshotStubFiles()
+
+        // Make a change
+        projectDir.resolve("src/main/java/Foo.kt").also {
+            it.writeText(
+                """
+                class Foo : Bar {
+                    val fooField1 = 1
+                    val fooField3 = 3
+                    val fooField2 = 2
+                    fun fooMethod1() { println("Method body changed!") }
+                    fun fooMethod3() {}
+                    fun fooMethod2() {}
+                }
+                """.trimIndent()
+            )
+        }
+
+        // Run the second build
+        val stubFilesAfterSecondBuild = buildAndSnapshotStubFiles()
+
+        // Check that the build outputs are deterministic
+        assertEquals(stubFilesAfterFirstBuild.size, stubFilesAfterSecondBuild.size)
+        for (file in stubFilesAfterFirstBuild.keys) {
+            val fileContentsAfterFirstBuild = stubFilesAfterFirstBuild[file]
+            val fileContentsAfterSecondBuild = stubFilesAfterSecondBuild[file]
+            assertEquals(fileContentsAfterFirstBuild, fileContentsAfterSecondBuild)
+        }
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kapt3IT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kapt3IT.kt
@@ -398,9 +398,9 @@ open class Kapt3IT : Kapt3BaseIT() {
             val actual = getErrorMessages()
             // try as 0 starting lines first, then as 1 starting line
             try {
-                Assert.assertEquals(genJavaErrorString(8, 16), actual)
+                Assert.assertEquals(genJavaErrorString(8, 15), actual)
             } catch (e: AssertionError) {
-                Assert.assertEquals(genJavaErrorString(9, 17), actual)
+                Assert.assertEquals(genJavaErrorString(9, 16), actual)
             }
         }
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/abstractEnum.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/abstractEnum.txt
@@ -5,12 +5,12 @@ public enum E {
     /*public static final*/ X /* = new E() */,
     /*public static final*/ Y /* = new E() */;
 
+    E() {
+    }
+
     public abstract void a();
 
     public final void b() {
-    }
-
-    E() {
     }
 
     @kotlin.Metadata()
@@ -42,13 +42,13 @@ public enum E2 {
     /*public static final*/ X /* = new E2() */,
     /*public static final*/ Y /* = new E2() */;
 
-    public abstract void a();
-
     E2(int n) {
     }
 
     E2(java.lang.String s) {
     }
+
+    public abstract void a();
 }
 
 ////////////////////
@@ -63,12 +63,12 @@ public enum E3 {
     @org.jetbrains.annotations.NotNull()
     private final java.lang.String a = null;
 
+    E3(java.lang.String a) {
+    }
+
     @org.jetbrains.annotations.NotNull()
     public final java.lang.String getA() {
         return null;
-    }
-
-    E3(java.lang.String a) {
     }
 }
 
@@ -86,6 +86,9 @@ public enum E4 {
     private final long c = 0L;
     private final boolean d = false;
 
+    E4(java.lang.String a, int b, long c, boolean d) {
+    }
+
     @org.jetbrains.annotations.NotNull()
     public final java.lang.String getA() {
         return null;
@@ -101,8 +104,5 @@ public enum E4 {
 
     public final boolean getD() {
         return false;
-    }
-
-    E4(java.lang.String a, int b, long c, boolean d) {
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/abstractMethods.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/abstractMethods.txt
@@ -3,15 +3,15 @@ import java.lang.System;
 @kotlin.Metadata()
 public abstract class Base {
 
+    public Base() {
+        super();
+    }
+
     protected abstract void doJob(@org.jetbrains.annotations.NotNull()
     java.lang.String job, int delay);
 
     protected abstract <T extends java.lang.CharSequence>void doJobGeneric(@org.jetbrains.annotations.NotNull()
     T job, int delay);
-
-    public Base() {
-        super();
-    }
 }
 
 ////////////////////
@@ -22,6 +22,10 @@ import java.lang.System;
 @kotlin.Metadata()
 public final class Impl extends Base {
 
+    public Impl() {
+        super();
+    }
+
     @java.lang.Override()
     protected void doJob(@org.jetbrains.annotations.NotNull()
     java.lang.String job, int delay) {
@@ -30,9 +34,5 @@ public final class Impl extends Base {
     @java.lang.Override()
     protected <T extends java.lang.CharSequence>void doJobGeneric(@org.jetbrains.annotations.NotNull()
     T job, int delay) {
-    }
-
-    public Impl() {
-        super();
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/aliasedImports.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/aliasedImports.txt
@@ -4,37 +4,14 @@ import a.b.ABC;
 
 @kotlin.Metadata()
 public final class Test {
-    public Test.MyDate date;
-    public java.util.concurrent.TimeUnit timeUnit;
-    public java.util.concurrent.TimeUnit microseconds;
     public a.b.ABC abc;
     public bcd bcd;
+    public Test.MyDate date;
+    public java.util.concurrent.TimeUnit microseconds;
+    public java.util.concurrent.TimeUnit timeUnit;
 
-    @org.jetbrains.annotations.NotNull()
-    public final Test.MyDate getDate() {
-        return null;
-    }
-
-    public final void setDate(@org.jetbrains.annotations.NotNull()
-    Test.MyDate p0) {
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final java.util.concurrent.TimeUnit getTimeUnit() {
-        return null;
-    }
-
-    public final void setTimeUnit(@org.jetbrains.annotations.NotNull()
-    java.util.concurrent.TimeUnit p0) {
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final java.util.concurrent.TimeUnit getMicroseconds() {
-        return null;
-    }
-
-    public final void setMicroseconds(@org.jetbrains.annotations.NotNull()
-    java.util.concurrent.TimeUnit p0) {
+    public Test() {
+        super();
     }
 
     @org.jetbrains.annotations.NotNull()
@@ -42,26 +19,53 @@ public final class Test {
         return null;
     }
 
-    public final void setAbc(@org.jetbrains.annotations.NotNull()
-    a.b.ABC p0) {
-    }
-
     @org.jetbrains.annotations.NotNull()
     public final bcd getBcd() {
         return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final Test.MyDate getDate() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final java.util.concurrent.TimeUnit getMicroseconds() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final java.util.concurrent.TimeUnit getTimeUnit() {
+        return null;
+    }
+
+    public final void setAbc(@org.jetbrains.annotations.NotNull()
+    a.b.ABC p0) {
     }
 
     public final void setBcd(@org.jetbrains.annotations.NotNull()
     bcd p0) {
     }
 
-    public Test() {
-        super();
+    public final void setDate(@org.jetbrains.annotations.NotNull()
+    Test.MyDate p0) {
+    }
+
+    public final void setMicroseconds(@org.jetbrains.annotations.NotNull()
+    java.util.concurrent.TimeUnit p0) {
+    }
+
+    public final void setTimeUnit(@org.jetbrains.annotations.NotNull()
+    java.util.concurrent.TimeUnit p0) {
     }
 
     @kotlin.Metadata()
     public static final class MyDate {
         public Test.MyDate date2;
+
+        public MyDate() {
+            super();
+        }
 
         @org.jetbrains.annotations.NotNull()
         public final Test.MyDate getDate2() {
@@ -70,10 +74,6 @@ public final class Test {
 
         public final void setDate2(@org.jetbrains.annotations.NotNull()
         Test.MyDate p0) {
-        }
-
-        public MyDate() {
-            super();
         }
     }
 }
@@ -89,6 +89,10 @@ import a.b.ABC;
 public final class Test2 {
     public java.util.Date date;
 
+    public Test2() {
+        super();
+    }
+
     @org.jetbrains.annotations.NotNull()
     public final java.util.Date getDate() {
         return null;
@@ -96,9 +100,5 @@ public final class Test2 {
 
     public final void setDate(@org.jetbrains.annotations.NotNull()
     java.util.Date p0) {
-    }
-
-    public Test2() {
-        super();
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/annotations.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/annotations.txt
@@ -14,23 +14,23 @@ import java.lang.System;
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 public abstract @interface Anno2 {
 
-    public abstract int i() default 5;
-
-    public abstract java.lang.String s() default "ABC";
-
-    public abstract int[] ii() default {1, 2, 3};
-
-    public abstract java.lang.String[] ss() default {"A", "B"};
-
     public abstract Anno1 a();
+
+    public abstract java.lang.Class<?>[] classes();
+
+    public abstract java.lang.Class<?> clazz();
 
     public abstract Colors color() default Colors.BLACK;
 
     public abstract Colors[] colors() default {Colors.BLACK, Colors.WHITE};
 
-    public abstract java.lang.Class<?> clazz();
+    public abstract int i() default 5;
 
-    public abstract java.lang.Class<?>[] classes();
+    public abstract int[] ii() default {1, 2, 3};
+
+    public abstract java.lang.String s() default "ABC";
+
+    public abstract java.lang.String[] ss() default {"A", "B"};
 }
 
 ////////////////////
@@ -103,15 +103,14 @@ public final class TestAnno2 {
     @Anno3(value = "field")
     private java.lang.String b = "property initializer";
 
+    public TestAnno2() {
+        super();
+    }
+
     @Anno1()
     public final void a(@org.jetbrains.annotations.NotNull()
     @Anno3(value = "param-pam-pam")
     java.lang.String param) {
-    }
-
-    @Anno3(value = "property")
-    @java.lang.Deprecated()
-    public static void getB$annotations() {
     }
 
     @org.jetbrains.annotations.NotNull()
@@ -120,13 +119,14 @@ public final class TestAnno2 {
         return null;
     }
 
+    @Anno3(value = "property")
+    @java.lang.Deprecated()
+    public static void getB$annotations() {
+    }
+
     @Anno3(value = "setter")
     public final void setB(@org.jetbrains.annotations.NotNull()
     @Anno3(value = "setparam")
     java.lang.String p0) {
-    }
-
-    public TestAnno2() {
-        super();
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/annotations2.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/annotations2.txt
@@ -23,10 +23,10 @@ public final class AnnotationsTest {
         super();
     }
 
-    @Anno(value = "top-level-fun")
-    public static final void topLevelFun(@org.jetbrains.annotations.NotNull()
-    @Anno(value = "top-level-fun-receiver")
-    java.lang.String $this$topLevelFun) {
+    @org.jetbrains.annotations.NotNull()
+    public static final java.lang.String getTopLevelVal(@Anno(value = "top-level-val-receiver")
+    int $this$topLevelVal) {
+        return null;
     }
 
     @Anno(value = "top-level-val")
@@ -34,10 +34,10 @@ public final class AnnotationsTest {
     public static void getTopLevelVal$annotations(int p0) {
     }
 
-    @org.jetbrains.annotations.NotNull()
-    public static final java.lang.String getTopLevelVal(@Anno(value = "top-level-val-receiver")
-    int $this$topLevelVal) {
-        return null;
+    @Anno(value = "top-level-fun")
+    public static final void topLevelFun(@org.jetbrains.annotations.NotNull()
+    @Anno(value = "top-level-fun-receiver")
+    java.lang.String $this$topLevelFun) {
     }
 }
 
@@ -56,13 +56,13 @@ public enum Enum {
     /*public static final*/ BLACK /* = new Enum() */;
     private final int x = 0;
 
-    public final int getX() {
-        return 0;
-    }
-
     @Anno(value = "enum-constructor")
     Enum(@Anno(value = "x")
     int x) {
+    }
+
+    public final int getX() {
+        return 0;
     }
 }
 
@@ -78,21 +78,23 @@ public abstract class Test {
     @org.jetbrains.annotations.NotNull()
     private java.lang.String v;
 
+    @Anno(value = "test-constructor")
+    protected Test(@org.jetbrains.annotations.NotNull()
+    @Anno(value = "v-param")
+    java.lang.String v) {
+        super();
+    }
+
     @org.jetbrains.annotations.NotNull()
     @Anno(value = "abstract-method")
     public abstract java.lang.String abstractMethod();
 
-    @Anno(value = "abstract-val")
-    @java.lang.Deprecated()
-    public static void getAbstractVal$annotations() {
-    }
-
     @org.jetbrains.annotations.NotNull()
     public abstract java.lang.String getAbstractVal();
 
-    @Anno(value = "v-property")
+    @Anno(value = "abstract-val")
     @java.lang.Deprecated()
-    public static void getV$annotations() {
+    public static void getAbstractVal$annotations() {
     }
 
     @org.jetbrains.annotations.NotNull()
@@ -101,16 +103,14 @@ public abstract class Test {
         return null;
     }
 
+    @Anno(value = "v-property")
+    @java.lang.Deprecated()
+    public static void getV$annotations() {
+    }
+
     @Anno(value = "v-set")
     public final void setV(@org.jetbrains.annotations.NotNull()
     @Anno(value = "v-setparam")
     java.lang.String p0) {
-    }
-
-    @Anno(value = "test-constructor")
-    protected Test(@org.jetbrains.annotations.NotNull()
-    @Anno(value = "v-param")
-    java.lang.String v) {
-        super();
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/annotationsWithTargets.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/annotationsWithTargets.txt
@@ -16,10 +16,8 @@ public final class Bar {
     @FieldAnno()
     private final java.lang.String a = "";
 
-    @Anno()
-    @PropertyAnno()
-    @java.lang.Deprecated()
-    public static void getA$annotations() {
+    public Bar() {
+        super();
     }
 
     @org.jetbrains.annotations.NotNull()
@@ -27,8 +25,10 @@ public final class Bar {
         return null;
     }
 
-    public Bar() {
-        super();
+    @Anno()
+    @PropertyAnno()
+    @java.lang.Deprecated()
+    public static void getA$annotations() {
     }
 }
 
@@ -43,13 +43,13 @@ public final class Baz {
     @FieldAnno()
     public final java.lang.String a = "";
 
+    public Baz() {
+        super();
+    }
+
     @Anno()
     @java.lang.Deprecated()
     public static void getA$annotations() {
-    }
-
-    public Baz() {
-        super();
     }
 }
 
@@ -76,9 +76,11 @@ public final class Foo {
     @FieldAnno()
     private final java.lang.String a = null;
 
-    @PropertyAnno()
-    @java.lang.Deprecated()
-    public static void getA$annotations() {
+    public Foo(@org.jetbrains.annotations.NotNull()
+    @Anno()
+    @ParameterAnno()
+    java.lang.String a) {
+        super();
     }
 
     @org.jetbrains.annotations.NotNull()
@@ -86,11 +88,9 @@ public final class Foo {
         return null;
     }
 
-    public Foo(@org.jetbrains.annotations.NotNull()
-    @Anno()
-    @ParameterAnno()
-    java.lang.String a) {
-        super();
+    @PropertyAnno()
+    @java.lang.Deprecated()
+    public static void getA$annotations() {
     }
 }
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/comments.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/comments.txt
@@ -17,11 +17,11 @@ public enum EnumError {
     /*public static final*/ One /* = new EnumError() */,
     /*public static final*/ Two /* = new EnumError() */;
 
-    @org.jetbrains.annotations.NotNull()
-    public abstract java.lang.String doIt();
-
     EnumError() {
     }
+
+    @org.jetbrains.annotations.NotNull()
+    public abstract java.lang.String doIt();
 }
 
 ////////////////////
@@ -65,6 +65,31 @@ public final class Test {
     @org.jetbrains.annotations.NotNull()
     private final java.lang.String prop2 = "";
 
+    public Test() {
+        super();
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final java.lang.String getProp2() {
+        return null;
+    }
+
+    /**
+     * prop2.
+     */
+    @Anno()
+    @java.lang.Deprecated()
+    public static void getProp2$annotations() {
+    }
+
+    /**
+     * get.
+     */
+    @org.jetbrains.annotations.NotNull()
+    public final java.lang.String getProp3() {
+        return null;
+    }
+
     /**
      * method().
      */
@@ -85,35 +110,10 @@ public final class Test {
     }
 
     /**
-     * prop2.
-     */
-    @Anno()
-    @java.lang.Deprecated()
-    public static void getProp2$annotations() {
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final java.lang.String getProp2() {
-        return null;
-    }
-
-    /**
-     * get.
-     */
-    @org.jetbrains.annotations.NotNull()
-    public final java.lang.String getProp3() {
-        return null;
-    }
-
-    /**
      * set.
      */
     public final void setProp3(@org.jetbrains.annotations.NotNull()
     java.lang.String v) {
-    }
-
-    public Test() {
-        super();
     }
 }
 
@@ -132,14 +132,14 @@ public final class Test2 {
     @org.jetbrains.annotations.NotNull()
     private final java.lang.String a = null;
 
-    @org.jetbrains.annotations.NotNull()
-    public final java.lang.String getA() {
-        return null;
-    }
-
     public Test2(@org.jetbrains.annotations.NotNull()
     java.lang.String a) {
         super();
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final java.lang.String getA() {
+        return null;
     }
 }
 
@@ -156,14 +156,14 @@ public final class Test3 {
     @org.jetbrains.annotations.NotNull()
     private final java.lang.String a = null;
 
-    @org.jetbrains.annotations.NotNull()
-    public final java.lang.String getA() {
-        return null;
-    }
-
     protected Test3(@org.jetbrains.annotations.NotNull()
     java.lang.String a) {
         super();
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final java.lang.String getA() {
+        return null;
     }
 }
 
@@ -175,11 +175,11 @@ import java.lang.System;
 @kotlin.Metadata()
 public final class Test4 {
 
-    public final void method() {
-    }
-
     public Test4() {
         super();
+    }
+
+    public final void method() {
     }
 }
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/dataClass.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/dataClass.txt
@@ -2,28 +2,11 @@ import java.lang.System;
 
 @kotlin.Metadata()
 public final class User {
+    private final int age = 0;
     @org.jetbrains.annotations.NotNull()
     private final java.lang.String firstName = null;
     @org.jetbrains.annotations.NotNull()
     private final java.lang.String secondName = null;
-    private final int age = 0;
-
-    public final void procedure() {
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final java.lang.String getFirstName() {
-        return null;
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final java.lang.String getSecondName() {
-        return null;
-    }
-
-    public final int getAge() {
-        return 0;
-    }
 
     public User(@org.jetbrains.annotations.NotNull()
     java.lang.String firstName, @org.jetbrains.annotations.NotNull()
@@ -52,9 +35,23 @@ public final class User {
         return null;
     }
 
-    @org.jetbrains.annotations.NotNull()
     @java.lang.Override()
-    public java.lang.String toString() {
+    public boolean equals(@org.jetbrains.annotations.Nullable()
+    java.lang.Object p0) {
+        return false;
+    }
+
+    public final int getAge() {
+        return 0;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final java.lang.String getFirstName() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final java.lang.String getSecondName() {
         return null;
     }
 
@@ -63,9 +60,12 @@ public final class User {
         return 0;
     }
 
+    public final void procedure() {
+    }
+
+    @org.jetbrains.annotations.NotNull()
     @java.lang.Override()
-    public boolean equals(@org.jetbrains.annotations.Nullable()
-    java.lang.Object p0) {
-        return false;
+    public java.lang.String toString() {
+        return null;
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/defaultImpls.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/defaultImpls.txt
@@ -26,12 +26,12 @@ public abstract interface Intf {
         private static final int BLACK = 1;
         public static final int WHITE = 2;
 
-        public final int getBLACK() {
-            return 0;
-        }
-
         private Companion() {
             super();
+        }
+
+        public final int getBLACK() {
+            return 0;
         }
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/defaultParameterValueOff.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/defaultParameterValueOff.txt
@@ -16,116 +16,36 @@ import java.lang.System;
 
 @kotlin.Metadata()
 public final class Foo {
-    private final boolean z = false;
     private final byte b = 0;
     private final char c = '\u0000';
     private final char c2 = '\u0000';
-    private final short sh = 0;
-    private final int i = 0;
-    private final long l = 0L;
-    private final float f = 0.0F;
-    private final double d = 0.0;
-    @org.jetbrains.annotations.NotNull()
-    private final java.lang.String s = null;
-    @org.jetbrains.annotations.NotNull()
-    private final int[] iarr = null;
-    @org.jetbrains.annotations.NotNull()
-    private final long[] larr = null;
-    @org.jetbrains.annotations.NotNull()
-    private final double[] darr = null;
-    @org.jetbrains.annotations.NotNull()
-    private final java.lang.String[] sarr = null;
     @org.jetbrains.annotations.NotNull()
     private final java.lang.Class<?> cl = null;
     @org.jetbrains.annotations.NotNull()
     private final java.lang.Class<?>[] clarr = null;
+    private final double d = 0.0;
+    @org.jetbrains.annotations.NotNull()
+    private final double[] darr = null;
     @org.jetbrains.annotations.NotNull()
     private final Em em = null;
     @org.jetbrains.annotations.NotNull()
     private final Em[] emarr = null;
-
-    public final void foo(int a) {
-    }
-
-    public final boolean getZ() {
-        return false;
-    }
-
-    public final byte getB() {
-        return 0;
-    }
-
-    public final char getC() {
-        return '\u0000';
-    }
-
-    public final char getC2() {
-        return '\u0000';
-    }
-
-    public final short getSh() {
-        return 0;
-    }
-
-    public final int getI() {
-        return 0;
-    }
-
-    public final long getL() {
-        return 0L;
-    }
-
-    public final float getF() {
-        return 0.0F;
-    }
-
-    public final double getD() {
-        return 0.0;
-    }
-
+    private final float f = 0.0F;
+    private final int i = 0;
     @org.jetbrains.annotations.NotNull()
-    public final java.lang.String getS() {
-        return null;
-    }
-
+    private final int[] iarr = null;
+    private final long l = 0L;
     @org.jetbrains.annotations.NotNull()
-    public final int[] getIarr() {
-        return null;
-    }
-
+    private final long[] larr = null;
     @org.jetbrains.annotations.NotNull()
-    public final long[] getLarr() {
-        return null;
-    }
-
+    private final java.lang.String s = null;
     @org.jetbrains.annotations.NotNull()
-    public final double[] getDarr() {
-        return null;
-    }
+    private final java.lang.String[] sarr = null;
+    private final short sh = 0;
+    private final boolean z = false;
 
-    @org.jetbrains.annotations.NotNull()
-    public final java.lang.String[] getSarr() {
-        return null;
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final java.lang.Class<?> getCl() {
-        return null;
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final java.lang.Class<?>[] getClarr() {
-        return null;
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final Em getEm() {
-        return null;
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final Em[] getEmarr() {
-        return null;
+    public Foo() {
+        super();
     }
 
     public Foo(boolean z, byte b, char c, char c2, short sh, int i, long l, float f, double d, @org.jetbrains.annotations.NotNull()
@@ -141,7 +61,87 @@ public final class Foo {
         super();
     }
 
-    public Foo() {
-        super();
+    public final void foo(int a) {
+    }
+
+    public final byte getB() {
+        return 0;
+    }
+
+    public final char getC() {
+        return '\u0000';
+    }
+
+    public final char getC2() {
+        return '\u0000';
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final java.lang.Class<?> getCl() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final java.lang.Class<?>[] getClarr() {
+        return null;
+    }
+
+    public final double getD() {
+        return 0.0;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final double[] getDarr() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final Em getEm() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final Em[] getEmarr() {
+        return null;
+    }
+
+    public final float getF() {
+        return 0.0F;
+    }
+
+    public final int getI() {
+        return 0;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final int[] getIarr() {
+        return null;
+    }
+
+    public final long getL() {
+        return 0L;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final long[] getLarr() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final java.lang.String getS() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final java.lang.String[] getSarr() {
+        return null;
+    }
+
+    public final short getSh() {
+        return 0;
+    }
+
+    public final boolean getZ() {
+        return false;
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/defaultParameterValueOn.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/defaultParameterValueOn.txt
@@ -16,116 +16,36 @@ import java.lang.System;
 
 @kotlin.Metadata()
 public final class Foo {
-    private final boolean z = true;
     private final byte b = (byte)0;
     private final char c = 'c';
     private final char c2 = '\n';
-    private final short sh = (short)10;
-    private final int i = 10;
-    private final long l = -10L;
-    private final float f = 1.0F;
-    private final double d = -1.0;
-    @org.jetbrains.annotations.NotNull()
-    private final java.lang.String s = "foo";
-    @org.jetbrains.annotations.NotNull()
-    private final int[] iarr = {1, 2, 3};
-    @org.jetbrains.annotations.NotNull()
-    private final long[] larr = {-1L, 0L, 1L};
-    @org.jetbrains.annotations.NotNull()
-    private final double[] darr = {7.3};
-    @org.jetbrains.annotations.NotNull()
-    private final java.lang.String[] sarr = {"a", "bc"};
     @org.jetbrains.annotations.NotNull()
     private final java.lang.Class<?> cl = null;
     @org.jetbrains.annotations.NotNull()
     private final java.lang.Class<?>[] clarr = null;
+    private final double d = -1.0;
+    @org.jetbrains.annotations.NotNull()
+    private final double[] darr = {7.3};
     @org.jetbrains.annotations.NotNull()
     private final Em em = Em.BAR;
     @org.jetbrains.annotations.NotNull()
     private final Em[] emarr = {Em.FOO, Em.BAR};
-
-    public final void foo(int a) {
-    }
-
-    public final boolean getZ() {
-        return false;
-    }
-
-    public final byte getB() {
-        return 0;
-    }
-
-    public final char getC() {
-        return '\u0000';
-    }
-
-    public final char getC2() {
-        return '\u0000';
-    }
-
-    public final short getSh() {
-        return 0;
-    }
-
-    public final int getI() {
-        return 0;
-    }
-
-    public final long getL() {
-        return 0L;
-    }
-
-    public final float getF() {
-        return 0.0F;
-    }
-
-    public final double getD() {
-        return 0.0;
-    }
-
+    private final float f = 1.0F;
+    private final int i = 10;
     @org.jetbrains.annotations.NotNull()
-    public final java.lang.String getS() {
-        return null;
-    }
-
+    private final int[] iarr = {1, 2, 3};
+    private final long l = -10L;
     @org.jetbrains.annotations.NotNull()
-    public final int[] getIarr() {
-        return null;
-    }
-
+    private final long[] larr = {-1L, 0L, 1L};
     @org.jetbrains.annotations.NotNull()
-    public final long[] getLarr() {
-        return null;
-    }
-
+    private final java.lang.String s = "foo";
     @org.jetbrains.annotations.NotNull()
-    public final double[] getDarr() {
-        return null;
-    }
+    private final java.lang.String[] sarr = {"a", "bc"};
+    private final short sh = (short)10;
+    private final boolean z = true;
 
-    @org.jetbrains.annotations.NotNull()
-    public final java.lang.String[] getSarr() {
-        return null;
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final java.lang.Class<?> getCl() {
-        return null;
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final java.lang.Class<?>[] getClarr() {
-        return null;
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final Em getEm() {
-        return null;
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final Em[] getEmarr() {
-        return null;
+    public Foo() {
+        super();
     }
 
     public Foo(boolean z, byte b, char c, char c2, short sh, int i, long l, float f, double d, @org.jetbrains.annotations.NotNull()
@@ -141,7 +61,87 @@ public final class Foo {
         super();
     }
 
-    public Foo() {
-        super();
+    public final void foo(int a) {
+    }
+
+    public final byte getB() {
+        return 0;
+    }
+
+    public final char getC() {
+        return '\u0000';
+    }
+
+    public final char getC2() {
+        return '\u0000';
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final java.lang.Class<?> getCl() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final java.lang.Class<?>[] getClarr() {
+        return null;
+    }
+
+    public final double getD() {
+        return 0.0;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final double[] getDarr() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final Em getEm() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final Em[] getEmarr() {
+        return null;
+    }
+
+    public final float getF() {
+        return 0.0F;
+    }
+
+    public final int getI() {
+        return 0;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final int[] getIarr() {
+        return null;
+    }
+
+    public final long getL() {
+        return 0L;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final long[] getLarr() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final java.lang.String getS() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final java.lang.String[] getSarr() {
+        return null;
+    }
+
+    public final short getSh() {
+        return 0;
+    }
+
+    public final boolean getZ() {
+        return false;
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/deprecated.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/deprecated.txt
@@ -21,17 +21,12 @@ public final class Foo {
     @java.lang.Deprecated()
     private final int prop = 0;
 
+    public Foo() {
+        super();
+    }
+
     @java.lang.Deprecated()
     public final void foo(int a) {
-    }
-
-    @java.lang.Deprecated()
-    public static void getProp$annotations() {
-    }
-
-    @java.lang.Deprecated()
-    public final int getProp() {
-        return 0;
     }
 
     @java.lang.Deprecated()
@@ -40,10 +35,15 @@ public final class Foo {
     }
 
     @java.lang.Deprecated()
-    public final void setFoo(int value) {
+    public final int getProp() {
+        return 0;
     }
 
-    public Foo() {
-        super();
+    @java.lang.Deprecated()
+    public static void getProp$annotations() {
+    }
+
+    @java.lang.Deprecated()
+    public final void setFoo(int value) {
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/enumInCompanion.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/enumInCompanion.txt
@@ -2,9 +2,9 @@ import java.lang.System;
 
 @kotlin.Metadata()
 public final class Test {
-    private final Test.Companion.Example foo;
     @org.jetbrains.annotations.NotNull()
     public static final Test.Companion Companion = null;
+    private final Test.Companion.Example foo;
 
     public Test() {
         super();
@@ -34,9 +34,9 @@ import java.lang.System;
 
 @kotlin.Metadata()
 public final class Test2 {
-    private final Test2.Amigo.Example foo;
     @org.jetbrains.annotations.NotNull()
     public static final Test2.Amigo Amigo = null;
+    private final Test2.Amigo.Example foo;
 
     public Test2() {
         super();
@@ -98,9 +98,9 @@ import java.lang.System;
 
 @kotlin.Metadata()
 public final class Test4 {
-    private final int foo = 1;
     @org.jetbrains.annotations.NotNull()
     public static final Test4.Companion Companion = null;
+    private final int foo = 1;
 
     public Test4() {
         super();
@@ -115,9 +115,9 @@ public final class Test4 {
 
         @kotlin.Metadata()
         public static final class Foo {
-            public static final int constProperty = 1;
             @org.jetbrains.annotations.NotNull()
             public static final Test4.Companion.Foo INSTANCE = null;
+            public static final int constProperty = 1;
 
             private Foo() {
                 super();

--- a/plugins/kapt3/kapt3-compiler/testData/converter/enums.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/enums.txt
@@ -34,15 +34,14 @@ public enum Enum2 {
     private final java.lang.String col = null;
     private final int col2 = 0;
 
+    Enum2(@Anno1(value = "first")
+    java.lang.String col, @Anno1(value = "second")
+    int col2) {
+    }
+
     @org.jetbrains.annotations.NotNull()
     public final java.lang.String color() {
         return null;
-    }
-
-    private final void privateEnumFun() {
-    }
-
-    public final void publicEnumFun() {
     }
 
     @org.jetbrains.annotations.NotNull()
@@ -54,9 +53,10 @@ public enum Enum2 {
         return 0;
     }
 
-    Enum2(@Anno1(value = "first")
-    java.lang.String col, @Anno1(value = "second")
-    int col2) {
+    private final void privateEnumFun() {
+    }
+
+    public final void publicEnumFun() {
     }
 }
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/errorLocationMapping.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/errorLocationMapping.txt
@@ -35,6 +35,13 @@ public final class ErrorInConstructorParameter {
     @org.jetbrains.annotations.NotNull()
     private final java.util.List<ABC> c = null;
 
+    public ErrorInConstructorParameter(@org.jetbrains.annotations.NotNull()
+    java.lang.String a, @org.jetbrains.annotations.NotNull()
+    ABC b, @org.jetbrains.annotations.NotNull()
+    java.util.List<? extends ABC> c) {
+        super();
+    }
+
     @org.jetbrains.annotations.NotNull()
     public final java.lang.String getA() {
         return null;
@@ -49,13 +56,6 @@ public final class ErrorInConstructorParameter {
     public final java.util.List<ABC> getC() {
         return null;
     }
-
-    public ErrorInConstructorParameter(@org.jetbrains.annotations.NotNull()
-    java.lang.String a, @org.jetbrains.annotations.NotNull()
-    ABC b, @org.jetbrains.annotations.NotNull()
-    java.util.List<? extends ABC> c) {
-        super();
-    }
 }
 
 ////////////////////
@@ -69,39 +69,8 @@ public final class ErrorInDeclarations {
     public ABC p2;
     public BCD<java.lang.String> p3;
 
-    @org.jetbrains.annotations.NotNull()
-    public final java.lang.String getP1() {
-        return null;
-    }
-
-    public final void setP1(@org.jetbrains.annotations.NotNull()
-    java.lang.String p0) {
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final ABC getP2() {
-        return null;
-    }
-
-    public final void setP2(@org.jetbrains.annotations.NotNull()
-    ABC p0) {
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final BCD<java.lang.String> getP3() {
-        return null;
-    }
-
-    public final void setP3(@org.jetbrains.annotations.NotNull()
-    BCD<java.lang.String> p0) {
-    }
-
-    public final void overloads(@org.jetbrains.annotations.NotNull()
-    java.lang.String a) {
-    }
-
-    public final void overloads(@org.jetbrains.annotations.NotNull()
-    ABC a) {
+    public ErrorInDeclarations() {
+        super();
     }
 
     public final void f1(@org.jetbrains.annotations.NotNull()
@@ -120,8 +89,39 @@ public final class ErrorInDeclarations {
         return null;
     }
 
-    public ErrorInDeclarations() {
-        super();
+    @org.jetbrains.annotations.NotNull()
+    public final java.lang.String getP1() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final ABC getP2() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final BCD<java.lang.String> getP3() {
+        return null;
+    }
+
+    public final void overloads(@org.jetbrains.annotations.NotNull()
+    ABC a) {
+    }
+
+    public final void overloads(@org.jetbrains.annotations.NotNull()
+    java.lang.String a) {
+    }
+
+    public final void setP1(@org.jetbrains.annotations.NotNull()
+    java.lang.String p0) {
+    }
+
+    public final void setP2(@org.jetbrains.annotations.NotNull()
+    ABC p0) {
+    }
+
+    public final void setP3(@org.jetbrains.annotations.NotNull()
+    BCD<java.lang.String> p0) {
     }
 }
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/errorSuperclass.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/errorSuperclass.txt
@@ -23,16 +23,16 @@ public final class ClassWithParent implements java.lang.CharSequence {
     }
 
     @java.lang.Override()
-    public final int length() {
-        return 0;
-    }
-
-    public abstract int getLength();
-
-    @java.lang.Override()
     public final char charAt(int p0) {
         return '\u0000';
     }
 
     public abstract char get(int p0);
+
+    public abstract int getLength();
+
+    @java.lang.Override()
+    public final int length() {
+        return 0;
+    }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/errorSuperclassCorrectErrorTypes.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/errorSuperclassCorrectErrorTypes.txt
@@ -10,18 +10,13 @@ public final class Child extends kotlin.collections.AbstractList<java.lang.Strin
     }
 
     @java.lang.Override()
-    public boolean contains(java.lang.String p0) {
-        return false;
-    }
-
-    @java.lang.Override()
     public final boolean contains(java.lang.Object p0) {
         return false;
     }
 
     @java.lang.Override()
-    public int indexOf(java.lang.String p0) {
-        return 0;
+    public boolean contains(java.lang.String p0) {
+        return false;
     }
 
     @java.lang.Override()
@@ -30,12 +25,17 @@ public final class Child extends kotlin.collections.AbstractList<java.lang.Strin
     }
 
     @java.lang.Override()
-    public int lastIndexOf(java.lang.String p0) {
+    public int indexOf(java.lang.String p0) {
         return 0;
     }
 
     @java.lang.Override()
     public final int lastIndexOf(java.lang.Object p0) {
+        return 0;
+    }
+
+    @java.lang.Override()
+    public int lastIndexOf(java.lang.String p0) {
         return 0;
     }
 }
@@ -115,6 +115,10 @@ import java.lang.System;
 @kotlin.Metadata()
 public final class MappedList<R extends java.lang.Object> extends kotlin.collections.AbstractList<R> implements java.util.List<R> {
 
+    public MappedList() {
+        super();
+    }
+
     @org.jetbrains.annotations.NotNull()
     @java.lang.Override()
     public java.lang.Void get(int index) {
@@ -124,10 +128,6 @@ public final class MappedList<R extends java.lang.Object> extends kotlin.collect
     @java.lang.Override()
     public int getSize() {
         return 0;
-    }
-
-    public MappedList() {
-        super();
     }
 }
 
@@ -180,14 +180,14 @@ public final class TFooBar extends Foo implements test.Intf, Bar {
     @org.jetbrains.annotations.NotNull()
     private final X a = null;
 
-    @org.jetbrains.annotations.NotNull()
-    public final X getA() {
-        return null;
-    }
-
     public TFooBar(@org.jetbrains.annotations.NotNull()
     X a) {
         super();
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final X getA() {
+        return null;
     }
 }
 
@@ -202,14 +202,14 @@ public final class TFooBar2 implements Foo, Bar {
     @org.jetbrains.annotations.NotNull()
     private final X a = null;
 
-    @org.jetbrains.annotations.NotNull()
-    public final X getA() {
-        return null;
-    }
-
     public TFooBar2(@org.jetbrains.annotations.NotNull()
     X a) {
         super();
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final X getA() {
+        return null;
     }
 }
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/functions.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/functions.txt
@@ -3,6 +3,10 @@ import java.lang.System;
 @kotlin.Metadata()
 public final class FunctionsTest {
 
+    public FunctionsTest() {
+        super();
+    }
+
     @org.jetbrains.annotations.NotNull()
     public final kotlin.reflect.KProperty1<java.lang.String, java.lang.Integer> f() {
         return null;
@@ -18,9 +22,5 @@ public final class FunctionsTest {
 
     public final int f4() {
         return 0;
-    }
-
-    public FunctionsTest() {
-        super();
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/genericParameters.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/genericParameters.txt
@@ -2,18 +2,19 @@ import java.lang.System;
 
 @kotlin.Metadata()
 public final class MappedList<T extends java.lang.Object, R extends java.lang.Object> extends kotlin.collections.AbstractList<R> implements java.util.List<R> {
+    private final kotlin.jvm.functions.Function1<T, R> function = null;
     @org.jetbrains.annotations.NotNull()
     private final java.util.List<T> list = null;
-    private final kotlin.jvm.functions.Function1<T, R> function = null;
+
+    public MappedList(@org.jetbrains.annotations.NotNull()
+    java.util.List<? extends T> list, @org.jetbrains.annotations.NotNull()
+    kotlin.jvm.functions.Function1<? super T, ? extends R> function) {
+        super();
+    }
 
     @java.lang.Override()
     public R get(int index) {
         return null;
-    }
-
-    @java.lang.Override()
-    public int getSize() {
-        return 0;
     }
 
     @org.jetbrains.annotations.NotNull()
@@ -21,9 +22,8 @@ public final class MappedList<T extends java.lang.Object, R extends java.lang.Ob
         return null;
     }
 
-    public MappedList(@org.jetbrains.annotations.NotNull()
-    java.util.List<? extends T> list, @org.jetbrains.annotations.NotNull()
-    kotlin.jvm.functions.Function1<? super T, ? extends R> function) {
-        super();
+    @java.lang.Override()
+    public int getSize() {
+        return 0;
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/genericRawSignatures.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/genericRawSignatures.txt
@@ -3,6 +3,10 @@ import java.lang.System;
 @kotlin.Metadata()
 public final class GenericRawSignatures {
 
+    public GenericRawSignatures() {
+        super();
+    }
+
     @org.jetbrains.annotations.Nullable()
     public final <T extends java.lang.Object>T genericFun() {
         return null;
@@ -11,9 +15,5 @@ public final class GenericRawSignatures {
     @org.jetbrains.annotations.Nullable()
     public final java.lang.String nonGenericFun() {
         return null;
-    }
-
-    public GenericRawSignatures() {
-        super();
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/genericSimple.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/genericSimple.txt
@@ -54,13 +54,13 @@ public final class MyClass<M1 extends java.lang.Object, M2 extends java.lang.Obj
     @org.jetbrains.annotations.Nullable()
     private final java.util.List<java.util.Map<java.lang.String, M1>> fld = null;
 
+    public MyClass() {
+        super();
+    }
+
     @org.jetbrains.annotations.Nullable()
     public final java.util.List<java.util.Map<java.lang.String, M1>> getFld() {
         return null;
-    }
-
-    public MyClass() {
-        super();
     }
 }
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/ignoredMembers.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/ignoredMembers.txt
@@ -7,7 +7,8 @@ public final class Test {
     @org.jetbrains.annotations.NotNull()
     private final java.lang.String nonIgnoredProperty = "";
 
-    public final void nonIgnoredFun() {
+    public Test() {
+        super();
     }
 
     @org.jetbrains.annotations.NotNull()
@@ -15,7 +16,6 @@ public final class Test {
         return null;
     }
 
-    public Test() {
-        super();
+    public final void nonIgnoredFun() {
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/implicitReturnTypes.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/implicitReturnTypes.txt
@@ -22,6 +22,11 @@ public final class Cl {
     @org.jetbrains.annotations.NotNull()
     private java.lang.String name;
 
+    public Cl(@org.jetbrains.annotations.NotNull()
+    java.lang.String name) {
+        super();
+    }
+
     @org.jetbrains.annotations.NotNull()
     public final java.lang.String getName() {
         return null;
@@ -29,11 +34,6 @@ public final class Cl {
 
     public final void setName(@org.jetbrains.annotations.NotNull()
     java.lang.String p0) {
-    }
-
-    public Cl(@org.jetbrains.annotations.NotNull()
-    java.lang.String name) {
-        super();
     }
 }
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/inheritanceSimple.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/inheritanceSimple.txt
@@ -3,13 +3,13 @@ import java.lang.System;
 @kotlin.Metadata()
 public abstract class BaseClass {
 
-    @org.jetbrains.annotations.NotNull()
-    public abstract Result doJob();
-
     public BaseClass(@org.jetbrains.annotations.NotNull()
     Context context, int num, boolean bool) {
         super();
     }
+
+    @org.jetbrains.annotations.NotNull()
+    public abstract Result doJob();
 }
 
 ////////////////////
@@ -29,15 +29,15 @@ import java.lang.System;
 @kotlin.Metadata()
 public final class Inheritor extends BaseClass {
 
+    public Inheritor(@org.jetbrains.annotations.NotNull()
+    Context context) {
+        super(null, 0, false);
+    }
+
     @org.jetbrains.annotations.NotNull()
     @java.lang.Override()
     public Result doJob() {
         return null;
-    }
-
-    public Inheritor(@org.jetbrains.annotations.NotNull()
-    Context context) {
-        super(null, 0, false);
     }
 }
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/inlineClasses.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/inlineClasses.txt
@@ -9,13 +9,13 @@ public final class Cl {
     @org.jetbrains.annotations.NotNull()
     private final java.lang.String a = null;
 
-    @org.jetbrains.annotations.NotNull()
-    public final java.lang.String getA() {
-        return null;
+    @java.lang.Override()
+    public boolean equals(java.lang.Object p0) {
+        return false;
     }
 
-    @java.lang.Override()
-    public java.lang.String toString() {
+    @org.jetbrains.annotations.NotNull()
+    public final java.lang.String getA() {
         return null;
     }
 
@@ -25,7 +25,7 @@ public final class Cl {
     }
 
     @java.lang.Override()
-    public boolean equals(java.lang.Object p0) {
-        return false;
+    public java.lang.String toString() {
+        return null;
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/interfaceImplementation.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/interfaceImplementation.txt
@@ -17,6 +17,11 @@ public final class Product2 implements Named {
     @org.jetbrains.annotations.Nullable()
     private java.lang.String name;
 
+    public Product2(@org.jetbrains.annotations.NotNull()
+    java.lang.String otherName) {
+        super();
+    }
+
     @org.jetbrains.annotations.Nullable()
     @java.lang.Override()
     public java.lang.String getName() {
@@ -25,10 +30,5 @@ public final class Product2 implements Named {
 
     public void setName(@org.jetbrains.annotations.Nullable()
     java.lang.String p0) {
-    }
-
-    public Product2(@org.jetbrains.annotations.NotNull()
-    java.lang.String otherName) {
-        super();
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/javadoc.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/javadoc.txt
@@ -57,6 +57,10 @@ public final class B {
     @org.jetbrains.annotations.NotNull()
     private final java.lang.String d = "";
 
+    public B() {
+        super();
+    }
+
     @org.jetbrains.annotations.NotNull()
     public final java.lang.String getA() {
         return null;
@@ -75,9 +79,5 @@ public final class B {
     @org.jetbrains.annotations.NotNull()
     public final java.lang.String getD() {
         return null;
-    }
-
-    public B() {
-        super();
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/jvmDefaultAll.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/jvmDefaultAll.txt
@@ -3,11 +3,11 @@ import java.lang.System;
 @kotlin.Metadata()
 public abstract interface Foo {
 
+    public abstract void bar();
+
     public default void foo() {
     }
 
     public default void foo2(int a) {
     }
-
-    public abstract void bar();
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/jvmDefaultAllCompatibility.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/jvmDefaultAllCompatibility.txt
@@ -3,13 +3,13 @@ import java.lang.System;
 @kotlin.Metadata()
 public abstract interface Foo {
 
+    public abstract void bar();
+
     public default void foo() {
     }
 
     public default void foo2(int a) {
     }
-
-    public abstract void bar();
 
     @kotlin.Metadata()
     public static final class DefaultImpls {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/jvmDefaultDisable.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/jvmDefaultDisable.txt
@@ -3,12 +3,12 @@ import java.lang.System;
 @kotlin.Metadata()
 public abstract interface Foo {
 
+    public abstract void bar();
+
     public abstract void foo();
 
     public default void foo2(int a) {
     }
-
-    public abstract void bar();
 
     @kotlin.Metadata()
     public static final class DefaultImpls {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/jvmDefaultEnable.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/jvmDefaultEnable.txt
@@ -3,12 +3,12 @@ import java.lang.System;
 @kotlin.Metadata()
 public abstract interface Foo {
 
+    public abstract void bar();
+
     public abstract void foo();
 
     public default void foo2(int a) {
     }
-
-    public abstract void bar();
 
     @kotlin.Metadata()
     public static final class DefaultImpls {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/jvmOverloads.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/jvmOverloads.txt
@@ -7,6 +7,15 @@ public final class State {
     @org.jetbrains.annotations.NotNull()
     private final java.lang.String someString = null;
 
+    public State(int someInt, long someLong) {
+        super();
+    }
+
+    public State(int someInt, long someLong, @org.jetbrains.annotations.NotNull()
+    java.lang.String someString) {
+        super();
+    }
+
     public final int getSomeInt() {
         return 0;
     }
@@ -18,15 +27,6 @@ public final class State {
     @org.jetbrains.annotations.NotNull()
     public final java.lang.String getSomeString() {
         return null;
-    }
-
-    public State(int someInt, long someLong, @org.jetbrains.annotations.NotNull()
-    java.lang.String someString) {
-        super();
-    }
-
-    public State(int someInt, long someLong) {
-        super();
     }
 }
 
@@ -42,28 +42,7 @@ public final class State2 {
     @org.jetbrains.annotations.NotNull()
     public final java.lang.String someString = null;
 
-    public final int test(int someInt, long someLong, @org.jetbrains.annotations.NotNull()
-    java.lang.String someString) {
-        return 0;
-    }
-
-    public final int test(int someInt, long someLong) {
-        return 0;
-    }
-
-    public final int test(int someInt) {
-        return 0;
-    }
-
-    public final void someMethod(@org.jetbrains.annotations.NotNull()
-    java.lang.String str) {
-    }
-
-    public final void methodWithoutArgs() {
-    }
-
-    public State2(int someInt, long someLong, @org.jetbrains.annotations.NotNull()
-    java.lang.String someString) {
+    public State2(int someInt) {
         super();
     }
 
@@ -71,7 +50,28 @@ public final class State2 {
         super();
     }
 
-    public State2(int someInt) {
+    public State2(int someInt, long someLong, @org.jetbrains.annotations.NotNull()
+    java.lang.String someString) {
         super();
+    }
+
+    public final void methodWithoutArgs() {
+    }
+
+    public final void someMethod(@org.jetbrains.annotations.NotNull()
+    java.lang.String str) {
+    }
+
+    public final int test(int someInt) {
+        return 0;
+    }
+
+    public final int test(int someInt, long someLong) {
+        return 0;
+    }
+
+    public final int test(int someInt, long someLong, @org.jetbrains.annotations.NotNull()
+    java.lang.String someString) {
+        return 0;
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/jvmStatic.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/jvmStatic.txt
@@ -14,14 +14,14 @@ public abstract interface FooComponent {
     @kotlin.Metadata()
     public static final class Companion {
 
+        private Companion() {
+            super();
+        }
+
         @org.jetbrains.annotations.NotNull()
         public final java.lang.String create(@org.jetbrains.annotations.NotNull()
         java.lang.String context) {
             return null;
-        }
-
-        private Companion() {
-            super();
         }
     }
 }
@@ -33,13 +33,13 @@ import java.lang.System;
 
 @kotlin.Metadata()
 public final class JvmStaticTest {
-    public final byte three = (byte)3;
-    public final char d = 'D';
-    private static final int one = 1;
-    public static final int two = 2;
-    public static final char c = 'C';
     @org.jetbrains.annotations.NotNull()
     public static final JvmStaticTest.Companion Companion = null;
+    public static final char c = 'C';
+    public final char d = 'D';
+    private static final int one = 1;
+    public final byte three = (byte)3;
+    public static final int two = 2;
 
     public JvmStaticTest() {
         super();
@@ -52,16 +52,16 @@ public final class JvmStaticTest {
     @kotlin.Metadata()
     public static final class Companion {
 
-        @java.lang.Deprecated()
-        public static void getOne$annotations() {
+        private Companion() {
+            super();
         }
 
         public final int getOne() {
             return 0;
         }
 
-        private Companion() {
-            super();
+        @java.lang.Deprecated()
+        public static void getOne$annotations() {
         }
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/jvmStaticFieldInParent.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/jvmStaticFieldInParent.txt
@@ -3,9 +3,9 @@ import java.lang.System;
 @kotlin.Metadata()
 public final class Test {
     @org.jetbrains.annotations.NotNull()
-    private static final java.lang.String test = "";
-    @org.jetbrains.annotations.NotNull()
     public static final Test.A A = null;
+    @org.jetbrains.annotations.NotNull()
+    private static final java.lang.String test = "";
 
     public Test() {
         super();
@@ -19,8 +19,8 @@ public final class Test {
     @kotlin.Metadata()
     public static final class A {
 
-        @java.lang.Deprecated()
-        public static void getTest$annotations() {
+        private A() {
+            super();
         }
 
         @org.jetbrains.annotations.NotNull()
@@ -28,8 +28,8 @@ public final class Test {
             return null;
         }
 
-        private A() {
-            super();
+        @java.lang.Deprecated()
+        public static void getTest$annotations() {
         }
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt14996.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt14996.txt
@@ -8,14 +8,14 @@ public final class Kt14996Kt {
     }
 
     @org.jetbrains.annotations.NotNull()
-    public static final java.lang.String crashMe(@org.jetbrains.annotations.NotNull()
-    java.util.List<java.lang.String> values) {
+    public static final java.lang.CharSequence crashMe(@org.jetbrains.annotations.NotNull()
+    java.util.List<? extends java.lang.CharSequence> values) {
         return null;
     }
 
     @org.jetbrains.annotations.NotNull()
-    public static final java.lang.CharSequence crashMe(@org.jetbrains.annotations.NotNull()
-    java.util.List<? extends java.lang.CharSequence> values) {
+    public static final java.lang.String crashMe(@org.jetbrains.annotations.NotNull()
+    java.util.List<java.lang.String> values) {
         return null;
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt14998.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt14998.txt
@@ -3,48 +3,49 @@ import java.lang.System;
 @kotlin.Metadata()
 public final class Outer {
 
-    public final void nonAbstract(@org.jetbrains.annotations.NotNull()
-    java.lang.String s, int i) {
-    }
-
     public Outer() {
         super();
+    }
+
+    public final void nonAbstract(@org.jetbrains.annotations.NotNull()
+    java.lang.String s, int i) {
     }
 
     @kotlin.Metadata()
     final class Inner {
         @org.jetbrains.annotations.NotNull()
-        private final java.lang.String foo = null;
-        @org.jetbrains.annotations.NotNull()
         private final java.lang.String bar = null;
-
         @org.jetbrains.annotations.NotNull()
-        public final java.lang.String getFoo() {
-            return null;
-        }
-
-        @org.jetbrains.annotations.NotNull()
-        public final java.lang.String getBar() {
-            return null;
-        }
+        private final java.lang.String foo = null;
 
         public Inner(@org.jetbrains.annotations.NotNull()
         java.lang.String foo, @org.jetbrains.annotations.NotNull()
         java.lang.String bar) {
             super();
         }
+
+        @org.jetbrains.annotations.NotNull()
+        public final java.lang.String getBar() {
+            return null;
+        }
+
+        @org.jetbrains.annotations.NotNull()
+        public final java.lang.String getFoo() {
+            return null;
+        }
     }
 
     @kotlin.Metadata()
     static final class Nested {
         @org.jetbrains.annotations.NotNull()
-        private final java.lang.String foo = null;
-        @org.jetbrains.annotations.NotNull()
         private final java.lang.String bar = null;
-
         @org.jetbrains.annotations.NotNull()
-        public final java.lang.String getFoo() {
-            return null;
+        private final java.lang.String foo = null;
+
+        public Nested(@org.jetbrains.annotations.NotNull()
+        java.lang.String foo, @org.jetbrains.annotations.NotNull()
+        java.lang.String bar) {
+            super();
         }
 
         @org.jetbrains.annotations.NotNull()
@@ -52,10 +53,9 @@ public final class Outer {
             return null;
         }
 
-        public Nested(@org.jetbrains.annotations.NotNull()
-        java.lang.String foo, @org.jetbrains.annotations.NotNull()
-        java.lang.String bar) {
-            super();
+        @org.jetbrains.annotations.NotNull()
+        public final java.lang.String getFoo() {
+            return null;
         }
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt17567.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt17567.txt
@@ -7,13 +7,13 @@ public final class MutableEntry<K extends java.lang.Object, V extends java.lang.
     private final java.util.Map<K, V> internal = null;
     private final K key = null;
 
-    @java.lang.Override()
-    public K getKey() {
-        return null;
-    }
-
     public MutableEntry(@org.jetbrains.annotations.NotNull()
     java.util.Map<K, V> internal, K key, V value) {
         super();
+    }
+
+    @java.lang.Override()
+    public K getKey() {
+        return null;
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt18791.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt18791.txt
@@ -90,13 +90,12 @@ import java.lang.System;
 @kotlin.Metadata()
 public final class JJ {
     @org.jetbrains.annotations.NotNull()
-    private static final java.lang.String b = null;
-    @org.jetbrains.annotations.NotNull()
     public static final app.JJ INSTANCE = null;
-
     @org.jetbrains.annotations.NotNull()
-    public final java.lang.String getB() {
-        return null;
+    private static final java.lang.String b = null;
+
+    private JJ() {
+        super();
     }
 
     @org.jetbrains.annotations.NotNull()
@@ -104,8 +103,9 @@ public final class JJ {
         return null;
     }
 
-    private JJ() {
-        super();
+    @org.jetbrains.annotations.NotNull()
+    public final java.lang.String getB() {
+        return null;
     }
 }
 
@@ -136,59 +136,8 @@ public final class MyActivity {
     public int propE = app.B.id.textView;
     private final int propF = 0;
 
-    @Bind(id = lib.R.id.textView)
-    @java.lang.Deprecated()
-    public static void getA$annotations() {
-    }
-
-    public final int getA() {
-        return 0;
-    }
-
-    @Bind(id = lib.R.id.textView)
-    @java.lang.Deprecated()
-    public static void getB$annotations() {
-    }
-
-    public final int getB() {
-        return 0;
-    }
-
-    @Bind(id = app.R.layout.mainActivity)
-    @java.lang.Deprecated()
-    public static void getC$annotations() {
-    }
-
-    public final int getC() {
-        return 0;
-    }
-
-    @Bind(id = app.R.layout.mainActivity)
-    @java.lang.Deprecated()
-    public static void getD$annotations() {
-    }
-
-    public final int getD() {
-        return 0;
-    }
-
-    @Anno(a1 = app.B.a1, a2 = app.B.a2, a3 = app.B.a3, a4 = app.B.a4, a5 = app.B.a5, a6 = app.B.a6, a7 = app.B.a7, a8 = app.B.a8, a9 = "A")
-    @Bind(id = app.R2.layout.mainActivity)
-    @java.lang.Deprecated()
-    public static void getE$annotations() {
-    }
-
-    public final int getE() {
-        return 0;
-    }
-
-    @Bind(id = app.B.id.textView)
-    @java.lang.Deprecated()
-    public static void getF$annotations() {
-    }
-
-    public final int getF() {
-        return 0;
+    public MyActivity() {
+        super();
     }
 
     @Bind(id = lib.R.id.textView)
@@ -212,8 +161,59 @@ public final class MyActivity {
     public final void foo5() {
     }
 
+    public final int getA() {
+        return 0;
+    }
+
+    @Bind(id = lib.R.id.textView)
+    @java.lang.Deprecated()
+    public static void getA$annotations() {
+    }
+
+    public final int getB() {
+        return 0;
+    }
+
+    @Bind(id = lib.R.id.textView)
+    @java.lang.Deprecated()
+    public static void getB$annotations() {
+    }
+
+    public final int getC() {
+        return 0;
+    }
+
+    @Bind(id = app.R.layout.mainActivity)
+    @java.lang.Deprecated()
+    public static void getC$annotations() {
+    }
+
+    public final int getD() {
+        return 0;
+    }
+
+    @Bind(id = app.R.layout.mainActivity)
+    @java.lang.Deprecated()
+    public static void getD$annotations() {
+    }
+
+    public final int getE() {
+        return 0;
+    }
+
+    @Anno(a1 = app.B.a1, a2 = app.B.a2, a3 = app.B.a3, a4 = app.B.a4, a5 = app.B.a5, a6 = app.B.a6, a7 = app.B.a7, a8 = app.B.a8, a9 = "A")
+    @Bind(id = app.R2.layout.mainActivity)
+    @java.lang.Deprecated()
+    public static void getE$annotations() {
+    }
+
+    public final int getF() {
+        return 0;
+    }
+
     @Bind(id = app.B.id.textView)
-    public final void plainIntConstant() {
+    @java.lang.Deprecated()
+    public static void getF$annotations() {
     }
 
     public final int getPropB() {
@@ -224,15 +224,15 @@ public final class MyActivity {
         return 0;
     }
 
-    public final void setPropC(int p0) {
-    }
-
     public final int getPropF() {
         return 0;
     }
 
-    public MyActivity() {
-        super();
+    @Bind(id = app.B.id.textView)
+    public final void plainIntConstant() {
+    }
+
+    public final void setPropC(int p0) {
     }
 }
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt24272.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt24272.txt
@@ -6,14 +6,14 @@ public final class Foo {
     private final Foo.Bar bar = null;
     private final java.lang.String string = null;
 
-    @org.jetbrains.annotations.NotNull()
-    public final Foo.Bar getBar() {
-        return null;
-    }
-
     public Foo(@org.jetbrains.annotations.NotNull()
     java.lang.String string) {
         super();
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final Foo.Bar getBar() {
+        return null;
     }
 
     @kotlin.Metadata()
@@ -23,6 +23,11 @@ public final class Foo {
         @org.jetbrains.annotations.NotNull()
         private final java.lang.String string = null;
 
+        public Bar(@org.jetbrains.annotations.NotNull()
+        java.lang.String string) {
+            super();
+        }
+
         @org.jetbrains.annotations.NotNull()
         public final java.util.ArrayList<Foo.Bar.Bar> getBars() {
             return null;
@@ -31,11 +36,6 @@ public final class Foo {
         @org.jetbrains.annotations.NotNull()
         public final java.lang.String getString() {
             return null;
-        }
-
-        public Bar(@org.jetbrains.annotations.NotNull()
-        java.lang.String string) {
-            super();
         }
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt25071.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt25071.txt
@@ -4,13 +4,13 @@ import java.lang.System;
 
 @kotlin.Metadata()
 public final class StaticImport {
-    private final java.util.Collection<java.lang.String> x = null;
     private final kapt.StaticMethod<java.lang.String> l = null;
     private final kapt.StaticMethod<java.lang.String> m = null;
+    private final java.util.Collection<java.lang.String> x = null;
     private final int y = 0;
 
-    public final java.util.Collection<java.lang.String> getX() {
-        return null;
+    public StaticImport() {
+        super();
     }
 
     public final kapt.StaticMethod<java.lang.String> getL() {
@@ -21,12 +21,12 @@ public final class StaticImport {
         return null;
     }
 
-    public final int getY() {
-        return 0;
+    public final java.util.Collection<java.lang.String> getX() {
+        return null;
     }
 
-    public StaticImport() {
-        super();
+    public final int getY() {
+        return 0;
     }
 }
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt27126.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt27126.txt
@@ -5,11 +5,9 @@ import java.lang.System;
 @kotlin.Metadata()
 public abstract class BundleProperty<AA extends java.lang.Object> extends test.NullableBundleProperty<AA> {
 
-    @java.lang.Override()
-    public final void setValue(@org.jetbrains.annotations.NotNull()
-    java.lang.Object thisRef, @org.jetbrains.annotations.NotNull()
-    kotlin.reflect.KProperty<?> property, @org.jetbrains.annotations.Nullable()
-    AA value) {
+    public BundleProperty(@org.jetbrains.annotations.Nullable()
+    java.lang.String key) {
+        super(null);
     }
 
     @java.lang.Override()
@@ -30,9 +28,11 @@ public abstract class BundleProperty<AA extends java.lang.Object> extends test.N
     java.lang.Object bundle, @org.jetbrains.annotations.NotNull()
     java.lang.String key, AA value);
 
-    public BundleProperty(@org.jetbrains.annotations.Nullable()
-    java.lang.String key) {
-        super(null);
+    @java.lang.Override()
+    public final void setValue(@org.jetbrains.annotations.NotNull()
+    java.lang.Object thisRef, @org.jetbrains.annotations.NotNull()
+    kotlin.reflect.KProperty<?> property, @org.jetbrains.annotations.Nullable()
+    AA value) {
     }
 }
 
@@ -67,9 +67,15 @@ import java.lang.System;
 public abstract class NullableBundleProperty<EE extends java.lang.Object> implements kotlin.properties.ReadWriteProperty<java.lang.Object, EE> {
     private final java.lang.String key = null;
 
-    private final java.lang.String toKey(kotlin.reflect.KProperty<?> $this$toKey) {
-        return null;
+    public NullableBundleProperty(@org.jetbrains.annotations.Nullable()
+    java.lang.String key) {
+        super();
     }
+
+    @org.jetbrains.annotations.Nullable()
+    public abstract EE getValue(@org.jetbrains.annotations.NotNull()
+    java.lang.Object bundle, @org.jetbrains.annotations.NotNull()
+    java.lang.String key);
 
     @org.jetbrains.annotations.Nullable()
     @java.lang.Override()
@@ -79,6 +85,11 @@ public abstract class NullableBundleProperty<EE extends java.lang.Object> implem
         return null;
     }
 
+    public abstract void setNullableValue(@org.jetbrains.annotations.NotNull()
+    java.lang.Object bundle, @org.jetbrains.annotations.NotNull()
+    java.lang.String key, @org.jetbrains.annotations.Nullable()
+    EE value);
+
     @java.lang.Override()
     public void setValue(@org.jetbrains.annotations.NotNull()
     java.lang.Object thisRef, @org.jetbrains.annotations.NotNull()
@@ -86,18 +97,7 @@ public abstract class NullableBundleProperty<EE extends java.lang.Object> implem
     EE value) {
     }
 
-    @org.jetbrains.annotations.Nullable()
-    public abstract EE getValue(@org.jetbrains.annotations.NotNull()
-    java.lang.Object bundle, @org.jetbrains.annotations.NotNull()
-    java.lang.String key);
-
-    public abstract void setNullableValue(@org.jetbrains.annotations.NotNull()
-    java.lang.Object bundle, @org.jetbrains.annotations.NotNull()
-    java.lang.String key, @org.jetbrains.annotations.Nullable()
-    EE value);
-
-    public NullableBundleProperty(@org.jetbrains.annotations.Nullable()
-    java.lang.String key) {
-        super();
+    private final java.lang.String toKey(kotlin.reflect.KProperty<?> $this$toKey) {
+        return null;
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt34569.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt34569.txt
@@ -3,11 +3,11 @@ import java.lang.System;
 @kotlin.Metadata()
 public final class T implements java.lang.Runnable {
 
-    @java.lang.Override()
-    public void run() {
-    }
-
     public T() {
         super();
+    }
+
+    @java.lang.Override()
+    public void run() {
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/lazyProperty.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/lazyProperty.txt
@@ -2,13 +2,13 @@ import java.lang.System;
 
 @kotlin.Metadata()
 public final class Foo {
-    private final kotlin.Lazy foo$delegate = null;
     private final kotlin.Lazy bar$delegate = null;
     private final kotlin.Lazy baz$delegate = null;
+    private final kotlin.Lazy foo$delegate = null;
     private final kotlin.Lazy generic1$delegate = null;
 
-    private final java.lang.Runnable getFoo() {
-        return null;
+    public Foo() {
+        super();
     }
 
     private final java.lang.Object getBar() {
@@ -19,12 +19,12 @@ public final class Foo {
         return null;
     }
 
-    private final GenericIntf<java.lang.CharSequence> getGeneric1() {
+    private final java.lang.Runnable getFoo() {
         return null;
     }
 
-    public Foo() {
-        super();
+    private final GenericIntf<java.lang.CharSequence> getGeneric1() {
+        return null;
     }
 }
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/maxErrorCount.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/maxErrorCount.txt
@@ -3,12 +3,12 @@ import kotlin.reflect.KClass;
 @kotlin.Metadata()
 public final class Test {
 
+    public Test() {
+        super();
+    }
+
     public final void a(@org.jetbrains.annotations.NotNull()
     ABC a, @org.jetbrains.annotations.NotNull()
     BCD b) {
-    }
-
-    public Test() {
-        super();
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/methodParameterNames.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/methodParameterNames.txt
@@ -3,17 +3,17 @@ import java.lang.System;
 @kotlin.Metadata()
 public abstract class Cls {
 
-    public abstract void foo(@org.jetbrains.annotations.NotNull()
-    java.lang.String abc);
+    public Cls() {
+        super();
+    }
 
     @org.jetbrains.annotations.NotNull()
     public final java.lang.String bar(int bcd) {
         return null;
     }
 
-    public Cls() {
-        super();
-    }
+    public abstract void foo(@org.jetbrains.annotations.NotNull()
+    java.lang.String abc);
 }
 
 ////////////////////
@@ -24,11 +24,11 @@ import java.lang.System;
 @kotlin.Metadata()
 public abstract interface Intf {
 
-    public abstract void foo(@org.jetbrains.annotations.NotNull()
-    java.lang.String abc);
-
     @org.jetbrains.annotations.NotNull()
     public abstract java.lang.String bar(int bcd);
+
+    public abstract void foo(@org.jetbrains.annotations.NotNull()
+    java.lang.String abc);
 
     @kotlin.Metadata()
     public static final class DefaultImpls {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/methodPropertySignatureClash.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/methodPropertySignatureClash.txt
@@ -4,6 +4,10 @@ import java.lang.System;
 public final class CrashMe {
     private final int resources = 1;
 
+    public CrashMe() {
+        super();
+    }
+
     public final int getResources() {
         return 0;
     }
@@ -11,9 +15,5 @@ public final class CrashMe {
     @org.jetbrains.annotations.NotNull()
     public final java.lang.String getResources() {
         return null;
-    }
-
-    public CrashMe() {
-        super();
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/modifiers.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/modifiers.txt
@@ -33,6 +33,10 @@ public final class Modifiers {
     @org.jetbrains.annotations.NotNull()
     private volatile java.lang.String volatileField = "";
 
+    public Modifiers() {
+        super();
+    }
+
     @org.jetbrains.annotations.NotNull()
     public final java.lang.String getTransientField() {
         return null;
@@ -43,16 +47,8 @@ public final class Modifiers {
         return null;
     }
 
-    public final void setVolatileField(@org.jetbrains.annotations.NotNull()
-    java.lang.String p0) {
-    }
-
-    public final strictfp void strictFp() {
-    }
-
     @org.jetbrains.annotations.NotNull()
-    public final java.lang.String overloads(@org.jetbrains.annotations.NotNull()
-    java.lang.String a, int n) {
+    public final java.lang.String overloads() {
         return null;
     }
 
@@ -63,12 +59,16 @@ public final class Modifiers {
     }
 
     @org.jetbrains.annotations.NotNull()
-    public final java.lang.String overloads() {
+    public final java.lang.String overloads(@org.jetbrains.annotations.NotNull()
+    java.lang.String a, int n) {
         return null;
     }
 
-    public Modifiers() {
-        super();
+    public final void setVolatileField(@org.jetbrains.annotations.NotNull()
+    java.lang.String p0) {
+    }
+
+    public final strictfp void strictFp() {
     }
 }
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/nestedClasses.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/nestedClasses.txt
@@ -5,9 +5,8 @@ public final class A {
     @org.jetbrains.annotations.Nullable()
     private final A x = null;
 
-    @org.jetbrains.annotations.Nullable()
-    public final A getX() {
-        return null;
+    public A() {
+        super();
     }
 
     @org.jetbrains.annotations.Nullable()
@@ -17,8 +16,9 @@ public final class A {
         return null;
     }
 
-    public A() {
-        super();
+    @org.jetbrains.annotations.Nullable()
+    public final A getX() {
+        return null;
     }
 
     @kotlin.Metadata()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/nestedClasses2.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/nestedClasses2.txt
@@ -4,10 +4,10 @@ import java.lang.System;
 public final class A$B {
     public A$B.C c;
     public A$B.D$E de;
-    public J$B.C jc;
-    public J$B.D$E jde;
     public A$B.D$$E dee;
     public A$B.D$$$E deee;
+    public J$B.C jc;
+    public J$B.D$E jde;
     public J$B.D$$E jdee;
     public J$B.D$$$E jdeee;
 
@@ -245,6 +245,11 @@ public final class Test1 extends Foo.Bar implements IFoo.IBar, IFoo.IBar.IZoo {
     @org.jetbrains.annotations.NotNull()
     private final Foo.Bar.Zoo zoo = null;
 
+    public Test1(@org.jetbrains.annotations.NotNull()
+    Foo.Bar.Zoo zoo) {
+        super();
+    }
+
     @org.jetbrains.annotations.NotNull()
     public final java.lang.Thread.State a() {
         return null;
@@ -258,10 +263,5 @@ public final class Test1 extends Foo.Bar implements IFoo.IBar, IFoo.IBar.IZoo {
     @org.jetbrains.annotations.NotNull()
     public final Foo.Bar.Zoo getZoo() {
         return null;
-    }
-
-    public Test1(@org.jetbrains.annotations.NotNull()
-    Foo.Bar.Zoo zoo) {
-        super();
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/nestedClassesNonRootPackage.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/nestedClassesNonRootPackage.txt
@@ -6,10 +6,10 @@ import java.lang.System;
 public final class A$B {
     public test.A$B.C c;
     public test.A$B.D$E de;
-    public test.J$B.C jc;
-    public test.J$B.D$E jde;
     public test.A$B.D$$E dee;
     public test.A$B.D$$$E deee;
+    public test.J$B.C jc;
+    public test.J$B.D$E jde;
     public test.J$B.D$$E jdee;
     public test.J$B.D$$$E jdeee;
 
@@ -253,6 +253,11 @@ public final class Test1 extends test.Foo.Bar implements test.IFoo.IBar, test.IF
     @org.jetbrains.annotations.NotNull()
     private final test.Foo.Bar.Zoo zoo = null;
 
+    public Test1(@org.jetbrains.annotations.NotNull()
+    test.Foo.Bar.Zoo zoo) {
+        super();
+    }
+
     @org.jetbrains.annotations.NotNull()
     public final java.lang.Thread.State a() {
         return null;
@@ -266,10 +271,5 @@ public final class Test1 extends test.Foo.Bar implements test.IFoo.IBar, test.IF
     @org.jetbrains.annotations.NotNull()
     public final test.Foo.Bar.Zoo getZoo() {
         return null;
-    }
-
-    public Test1(@org.jetbrains.annotations.NotNull()
-    test.Foo.Bar.Zoo zoo) {
-        super();
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/nonExistentClass.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/nonExistentClass.txt
@@ -3,6 +3,8 @@ import java.lang.System;
 @kotlin.Suppress(names = {"UNRESOLVED_REFERENCE"})
 @kotlin.Metadata()
 public final class NonExistentType {
+    @org.jetbrains.annotations.NotNull()
+    public static final NonExistentType INSTANCE = null;
     @org.jetbrains.annotations.Nullable()
     private static final ABCDEF a = null;
     @org.jetbrains.annotations.Nullable()
@@ -11,8 +13,23 @@ public final class NonExistentType {
     private static final Function1<ABCDEF, kotlin.Unit> c = null;
     @org.jetbrains.annotations.Nullable()
     private static final ABCDEF<java.lang.String, Function1<java.util.List<ABCDEF>, kotlin.Unit>> d = null;
+
+    private NonExistentType() {
+        super();
+    }
+
     @org.jetbrains.annotations.NotNull()
-    public static final NonExistentType INSTANCE = null;
+    public final ABCDEF a(@org.jetbrains.annotations.NotNull()
+    ABCDEF a, @org.jetbrains.annotations.NotNull()
+    java.lang.String s) {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final ABCDEF b(@org.jetbrains.annotations.NotNull()
+    java.lang.String s) {
+        return null;
+    }
 
     @org.jetbrains.annotations.Nullable()
     public final ABCDEF getA() {
@@ -32,23 +49,6 @@ public final class NonExistentType {
     @org.jetbrains.annotations.Nullable()
     public final ABCDEF<java.lang.String, Function1<java.util.List<ABCDEF>, kotlin.Unit>> getD() {
         return null;
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final ABCDEF a(@org.jetbrains.annotations.NotNull()
-    ABCDEF a, @org.jetbrains.annotations.NotNull()
-    java.lang.String s) {
-        return null;
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final ABCDEF b(@org.jetbrains.annotations.NotNull()
-    java.lang.String s) {
-        return null;
-    }
-
-    private NonExistentType() {
-        super();
     }
 }
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/nonExistentClassTypesConversion.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/nonExistentClassTypesConversion.txt
@@ -53,6 +53,11 @@ public final class Test<G extends java.lang.Object> {
     private final ABC b = null;
     @org.jetbrains.annotations.Nullable()
     private final java.util.List<ABC> c = null;
+    public ABC coocoo;
+    public ABC<java.lang.String> coocoo2;
+    public ABC<ABC> coocoo21;
+    public ABC<java.lang.String, java.lang.String> coocoo3;
+    public ABC<java.lang.String, ABC<ABC>> coocoo31;
     @org.jetbrains.annotations.Nullable()
     private final java.util.List<java.util.Map<BCD, ABC<java.util.List<BCD>>>> d = null;
     public java.util.List<java.util.Map<? extends ABC, BCD>> e;
@@ -63,205 +68,17 @@ public final class Test<G extends java.lang.Object> {
     public Function0<CDE> j;
     public Function2<ABC, java.util.List<BCD>, CDE> k;
     public ABC.BCD.EFG l;
-    public ABC coocoo;
-    public ABC<java.lang.String> coocoo2;
-    public ABC<ABC> coocoo21;
-    public ABC<java.lang.String, java.lang.String> coocoo3;
-    public ABC<java.lang.String, ABC<ABC>> coocoo31;
-    public ABC nested;
     @org.jetbrains.annotations.NotNull()
     private final java.lang.Object m = null;
     @org.jetbrains.annotations.NotNull()
     private final java.lang.String n = "";
-    public java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends error.NonExistentClass>>>>>>>>>> o11;
+    public ABC nested;
     public java.util.List<java.util.List<java.util.List<java.util.List<java.util.List<java.util.List<java.util.List<java.util.List<java.util.List<ABC>>>>>>>>> o10;
+    public java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends error.NonExistentClass>>>>>>>>>> o11;
     public java.util.Calendar.Builder p;
 
-    @org.jetbrains.annotations.NotNull()
-    public final ABC getA() {
-        return null;
-    }
-
-    public final void setA(@org.jetbrains.annotations.NotNull()
-    ABC p0) {
-    }
-
-    @org.jetbrains.annotations.Nullable()
-    public final ABC getB() {
-        return null;
-    }
-
-    @org.jetbrains.annotations.Nullable()
-    public final java.util.List<ABC> getC() {
-        return null;
-    }
-
-    @org.jetbrains.annotations.Nullable()
-    public final java.util.List<java.util.Map<BCD, ABC<java.util.List<BCD>>>> getD() {
-        return null;
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final java.util.List<java.util.Map<? extends ABC, BCD>> getE() {
-        return null;
-    }
-
-    public final void setE(@org.jetbrains.annotations.NotNull()
-    java.util.List<? extends java.util.Map<? extends ABC, ? extends BCD>> p0) {
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final ABC<?> getF() {
-        return null;
-    }
-
-    public final void setF(@org.jetbrains.annotations.NotNull()
-    ABC<?> p0) {
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final java.util.List<?> getG() {
-        return null;
-    }
-
-    public final void setG(@org.jetbrains.annotations.NotNull()
-    java.util.List<?> p0) {
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final ABC<java.lang.Integer, java.lang.String> getH() {
-        return null;
-    }
-
-    public final void setH(@org.jetbrains.annotations.NotNull()
-    ABC<java.lang.Integer, java.lang.String> p0) {
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final Function2<ABC, java.util.List<BCD>, CDE> getI() {
-        return null;
-    }
-
-    public final void setI(@org.jetbrains.annotations.NotNull()
-    Function2<ABC, java.util.List<? extends BCD>, CDE> p0) {
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final Function0<CDE> getJ() {
-        return null;
-    }
-
-    public final void setJ(@org.jetbrains.annotations.NotNull()
-    Function0<CDE> p0) {
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final Function2<ABC, java.util.List<BCD>, CDE> getK() {
-        return null;
-    }
-
-    public final void setK(@org.jetbrains.annotations.NotNull()
-    Function2<ABC, java.util.List<? extends BCD>, CDE> p0) {
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final ABC.BCD.EFG getL() {
-        return null;
-    }
-
-    public final void setL(@org.jetbrains.annotations.NotNull()
-    ABC.BCD.EFG p0) {
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final ABC getCoocoo() {
-        return null;
-    }
-
-    public final void setCoocoo(@org.jetbrains.annotations.NotNull()
-    ABC p0) {
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final ABC<java.lang.String> getCoocoo2() {
-        return null;
-    }
-
-    public final void setCoocoo2(@org.jetbrains.annotations.NotNull()
-    ABC<java.lang.String> p0) {
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final ABC<ABC> getCoocoo21() {
-        return null;
-    }
-
-    public final void setCoocoo21(@org.jetbrains.annotations.NotNull()
-    ABC<ABC> p0) {
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final ABC<java.lang.String, java.lang.String> getCoocoo3() {
-        return null;
-    }
-
-    public final void setCoocoo3(@org.jetbrains.annotations.NotNull()
-    ABC<java.lang.String, java.lang.String> p0) {
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final ABC<java.lang.String, ABC<ABC>> getCoocoo31() {
-        return null;
-    }
-
-    public final void setCoocoo31(@org.jetbrains.annotations.NotNull()
-    ABC<java.lang.String, ABC<ABC>> p0) {
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final ABC getNested() {
-        return null;
-    }
-
-    public final void setNested(@org.jetbrains.annotations.NotNull()
-    ABC p0) {
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final java.lang.Object getM() {
-        return null;
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final java.lang.String getN() {
-        return null;
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final java.util.List<java.util.List<java.util.List<java.util.List<java.util.List<java.util.List<java.util.List<java.util.List<java.util.List<java.util.List<error.NonExistentClass>>>>>>>>>> getO11() {
-        return null;
-    }
-
-    public final void setO11(@org.jetbrains.annotations.NotNull()
-    java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends error.NonExistentClass>>>>>>>>>> p0) {
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final java.util.List<java.util.List<java.util.List<java.util.List<java.util.List<java.util.List<java.util.List<java.util.List<java.util.List<ABC>>>>>>>>> getO10() {
-        return null;
-    }
-
-    public final void setO10(@org.jetbrains.annotations.NotNull()
-    java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends ABC>>>>>>>>> p0) {
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final java.util.Calendar.Builder getP() {
-        return null;
-    }
-
-    public final void setP(@org.jetbrains.annotations.NotNull()
-    java.util.Calendar.Builder p0) {
+    public Test() {
+        super();
     }
 
     @org.jetbrains.annotations.Nullable()
@@ -290,8 +107,191 @@ public final class Test<G extends java.lang.Object> {
         return null;
     }
 
-    public Test() {
-        super();
+    @org.jetbrains.annotations.NotNull()
+    public final ABC getA() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.Nullable()
+    public final ABC getB() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.Nullable()
+    public final java.util.List<ABC> getC() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final ABC getCoocoo() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final ABC<java.lang.String> getCoocoo2() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final ABC<ABC> getCoocoo21() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final ABC<java.lang.String, java.lang.String> getCoocoo3() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final ABC<java.lang.String, ABC<ABC>> getCoocoo31() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.Nullable()
+    public final java.util.List<java.util.Map<BCD, ABC<java.util.List<BCD>>>> getD() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final java.util.List<java.util.Map<? extends ABC, BCD>> getE() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final ABC<?> getF() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final java.util.List<?> getG() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final ABC<java.lang.Integer, java.lang.String> getH() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final Function2<ABC, java.util.List<BCD>, CDE> getI() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final Function0<CDE> getJ() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final Function2<ABC, java.util.List<BCD>, CDE> getK() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final ABC.BCD.EFG getL() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final java.lang.Object getM() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final java.lang.String getN() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final ABC getNested() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final java.util.List<java.util.List<java.util.List<java.util.List<java.util.List<java.util.List<java.util.List<java.util.List<java.util.List<ABC>>>>>>>>> getO10() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final java.util.List<java.util.List<java.util.List<java.util.List<java.util.List<java.util.List<java.util.List<java.util.List<java.util.List<java.util.List<error.NonExistentClass>>>>>>>>>> getO11() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final java.util.Calendar.Builder getP() {
+        return null;
+    }
+
+    public final void setA(@org.jetbrains.annotations.NotNull()
+    ABC p0) {
+    }
+
+    public final void setCoocoo(@org.jetbrains.annotations.NotNull()
+    ABC p0) {
+    }
+
+    public final void setCoocoo2(@org.jetbrains.annotations.NotNull()
+    ABC<java.lang.String> p0) {
+    }
+
+    public final void setCoocoo21(@org.jetbrains.annotations.NotNull()
+    ABC<ABC> p0) {
+    }
+
+    public final void setCoocoo3(@org.jetbrains.annotations.NotNull()
+    ABC<java.lang.String, java.lang.String> p0) {
+    }
+
+    public final void setCoocoo31(@org.jetbrains.annotations.NotNull()
+    ABC<java.lang.String, ABC<ABC>> p0) {
+    }
+
+    public final void setE(@org.jetbrains.annotations.NotNull()
+    java.util.List<? extends java.util.Map<? extends ABC, ? extends BCD>> p0) {
+    }
+
+    public final void setF(@org.jetbrains.annotations.NotNull()
+    ABC<?> p0) {
+    }
+
+    public final void setG(@org.jetbrains.annotations.NotNull()
+    java.util.List<?> p0) {
+    }
+
+    public final void setH(@org.jetbrains.annotations.NotNull()
+    ABC<java.lang.Integer, java.lang.String> p0) {
+    }
+
+    public final void setI(@org.jetbrains.annotations.NotNull()
+    Function2<ABC, java.util.List<? extends BCD>, CDE> p0) {
+    }
+
+    public final void setJ(@org.jetbrains.annotations.NotNull()
+    Function0<CDE> p0) {
+    }
+
+    public final void setK(@org.jetbrains.annotations.NotNull()
+    Function2<ABC, java.util.List<? extends BCD>, CDE> p0) {
+    }
+
+    public final void setL(@org.jetbrains.annotations.NotNull()
+    ABC.BCD.EFG p0) {
+    }
+
+    public final void setNested(@org.jetbrains.annotations.NotNull()
+    ABC p0) {
+    }
+
+    public final void setO10(@org.jetbrains.annotations.NotNull()
+    java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends ABC>>>>>>>>> p0) {
+    }
+
+    public final void setO11(@org.jetbrains.annotations.NotNull()
+    java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends java.util.List<? extends error.NonExistentClass>>>>>>>>>> p0) {
+    }
+
+    public final void setP(@org.jetbrains.annotations.NotNull()
+    java.util.Calendar.Builder p0) {
     }
 }
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/nonExistentClassWIthoutCorrection.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/nonExistentClassWIthoutCorrection.txt
@@ -12,22 +12,39 @@ import java.lang.System;
 
 @kotlin.Metadata()
 public final class NonExistentType {
+    @org.jetbrains.annotations.NotNull()
+    public static final NonExistentType INSTANCE = null;
     @org.jetbrains.annotations.Nullable()
     private static final error.NonExistentClass a = null;
     @org.jetbrains.annotations.Nullable()
     private static final java.util.List<error.NonExistentClass> b = null;
     @org.jetbrains.annotations.NotNull()
     private static final kotlin.jvm.functions.Function1<error.NonExistentClass, kotlin.Unit> c = null;
-    @org.jetbrains.annotations.Nullable()
-    private static final error.NonExistentClass d = null;
-    public static java.lang.String string2;
     public static error.NonExistentClass coocoo;
     public static error.NonExistentClass coocoo2;
     public static error.NonExistentClass coocoo21;
     public static error.NonExistentClass coocoo3;
     public static error.NonExistentClass coocoo31;
+    @org.jetbrains.annotations.Nullable()
+    private static final error.NonExistentClass d = null;
+    public static java.lang.String string2;
+
+    private NonExistentType() {
+        super();
+    }
+
     @org.jetbrains.annotations.NotNull()
-    public static final NonExistentType INSTANCE = null;
+    public final error.NonExistentClass a(@org.jetbrains.annotations.NotNull()
+    error.NonExistentClass a, @org.jetbrains.annotations.NotNull()
+    java.lang.String s) {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final error.NonExistentClass b(@org.jetbrains.annotations.NotNull()
+    java.lang.String s) {
+        return null;
+    }
 
     @org.jetbrains.annotations.Nullable()
     public final error.NonExistentClass getA() {
@@ -44,6 +61,31 @@ public final class NonExistentType {
         return null;
     }
 
+    @org.jetbrains.annotations.NotNull()
+    public final error.NonExistentClass getCoocoo() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final error.NonExistentClass getCoocoo2() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final error.NonExistentClass getCoocoo21() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final error.NonExistentClass getCoocoo3() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final error.NonExistentClass getCoocoo31() {
+        return null;
+    }
+
     @org.jetbrains.annotations.Nullable()
     public final error.NonExistentClass getD() {
         return null;
@@ -54,70 +96,28 @@ public final class NonExistentType {
         return null;
     }
 
-    public final void setString2(@org.jetbrains.annotations.NotNull()
-    java.lang.String p0) {
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final error.NonExistentClass getCoocoo() {
-        return null;
-    }
-
     public final void setCoocoo(@org.jetbrains.annotations.NotNull()
     error.NonExistentClass p0) {
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final error.NonExistentClass getCoocoo2() {
-        return null;
     }
 
     public final void setCoocoo2(@org.jetbrains.annotations.NotNull()
     error.NonExistentClass p0) {
     }
 
-    @org.jetbrains.annotations.NotNull()
-    public final error.NonExistentClass getCoocoo21() {
-        return null;
-    }
-
     public final void setCoocoo21(@org.jetbrains.annotations.NotNull()
     error.NonExistentClass p0) {
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final error.NonExistentClass getCoocoo3() {
-        return null;
     }
 
     public final void setCoocoo3(@org.jetbrains.annotations.NotNull()
     error.NonExistentClass p0) {
     }
 
-    @org.jetbrains.annotations.NotNull()
-    public final error.NonExistentClass getCoocoo31() {
-        return null;
-    }
-
     public final void setCoocoo31(@org.jetbrains.annotations.NotNull()
     error.NonExistentClass p0) {
     }
 
-    @org.jetbrains.annotations.NotNull()
-    public final error.NonExistentClass a(@org.jetbrains.annotations.NotNull()
-    error.NonExistentClass a, @org.jetbrains.annotations.NotNull()
-    java.lang.String s) {
-        return null;
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final error.NonExistentClass b(@org.jetbrains.annotations.NotNull()
-    java.lang.String s) {
-        return null;
-    }
-
-    private NonExistentType() {
-        super();
+    public final void setString2(@org.jetbrains.annotations.NotNull()
+    java.lang.String p0) {
     }
 }
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/primitiveTypes.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/primitiveTypes.txt
@@ -2,57 +2,45 @@ import java.lang.System;
 
 @kotlin.Metadata()
 public final class PrimitiveTypes {
+    @org.jetbrains.annotations.NotNull()
+    public static final PrimitiveTypes INSTANCE = null;
     public static final boolean booleanFalse = false;
     public static final boolean booleanTrue = true;
-    public static final int int0 = 0;
-    public static final int intMinus1000 = -1000;
-    public static final int intMinValue = -2147483648;
-    public static final int intMaxValue = 2147483647;
-    public static final int intHex = -1;
     public static final byte byte0 = (byte)0;
     public static final byte byte50 = (byte)50;
-    public static final short short5 = (short)5;
-    public static final char charC = 'C';
     public static final char char0 = '\u0000';
     public static final char char10 = '\n';
     public static final char char13 = '\r';
-    public static final long long0 = 0L;
-    public static final long longMaxValue = 9223372036854775807L;
-    public static final long longMinValue = -9223372036854775808L;
-    public static final long longHex = 4294967295L;
-    public static final float float54 = 5.4F;
-    private static final float floatMaxValue = 3.4028235E38F;
-    private static final float floatNan = 0.0F / 0.0F;
-    private static final float floatPositiveInfinity = 1.0F / 0.0F;
-    private static final float floatNegativeInfinity = -1.0F / 0.0F;
+    public static final char charC = 'C';
     public static final double double54 = 5.4;
     private static final double doubleMaxValue = 1.7976931348623157E308;
     private static final double doubleNan = 0.0 / 0.0;
-    private static final double doublePositiveInfinity = 1.0 / 0.0;
     private static final double doubleNegativeInfinity = -1.0 / 0.0;
+    private static final double doublePositiveInfinity = 1.0 / 0.0;
+    public static final float float54 = 5.4F;
+    private static final float floatMaxValue = 3.4028235E38F;
+    private static final float floatNan = 0.0F / 0.0F;
+    private static final float floatNegativeInfinity = -1.0F / 0.0F;
+    private static final float floatPositiveInfinity = 1.0F / 0.0F;
+    public static final int int0 = 0;
+    public static final int intHex = -1;
+    public static final int intMaxValue = 2147483647;
+    public static final int intMinValue = -2147483648;
+    public static final int intMinus1000 = -1000;
+    public static final long long0 = 0L;
+    public static final long longHex = 4294967295L;
+    public static final long longMaxValue = 9223372036854775807L;
+    public static final long longMinValue = -9223372036854775808L;
+    public static final short short5 = (short)5;
     @org.jetbrains.annotations.NotNull()
     public static final java.lang.String stringHelloWorld = "Hello, world!";
     @org.jetbrains.annotations.NotNull()
     public static final java.lang.String stringQuotes = "quotes \" \'\'quotes";
     @org.jetbrains.annotations.NotNull()
     public static final java.lang.String stringRN = "\r\n";
-    @org.jetbrains.annotations.NotNull()
-    public static final PrimitiveTypes INSTANCE = null;
 
-    public final float getFloatMaxValue() {
-        return 0.0F;
-    }
-
-    public final float getFloatNan() {
-        return 0.0F;
-    }
-
-    public final float getFloatPositiveInfinity() {
-        return 0.0F;
-    }
-
-    public final float getFloatNegativeInfinity() {
-        return 0.0F;
+    private PrimitiveTypes() {
+        super();
     }
 
     public final double getDoubleMaxValue() {
@@ -63,15 +51,27 @@ public final class PrimitiveTypes {
         return 0.0;
     }
 
-    public final double getDoublePositiveInfinity() {
-        return 0.0;
-    }
-
     public final double getDoubleNegativeInfinity() {
         return 0.0;
     }
 
-    private PrimitiveTypes() {
-        super();
+    public final double getDoublePositiveInfinity() {
+        return 0.0;
+    }
+
+    public final float getFloatMaxValue() {
+        return 0.0F;
+    }
+
+    public final float getFloatNan() {
+        return 0.0F;
+    }
+
+    public final float getFloatNegativeInfinity() {
+        return 0.0F;
+    }
+
+    public final float getFloatPositiveInfinity() {
+        return 0.0F;
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/propertyAnnotations.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/propertyAnnotations.txt
@@ -27,10 +27,8 @@ public final class Test {
     @org.jetbrains.annotations.NotNull()
     private final java.lang.String prop = "A";
 
-    @Anno2()
-    @Anno()
-    @java.lang.Deprecated()
-    public static void getProp$annotations() {
+    public Test() {
+        super();
     }
 
     @org.jetbrains.annotations.NotNull()
@@ -38,7 +36,9 @@ public final class Test {
         return null;
     }
 
-    public Test() {
-        super();
+    @Anno2()
+    @Anno()
+    @java.lang.Deprecated()
+    public static void getProp$annotations() {
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/recentlyNullable.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/recentlyNullable.txt
@@ -28,11 +28,6 @@ public final class KBox implements androidx.annotation.Box {
     @org.jetbrains.annotations.NotNull()
     private final androidx.annotation.Box delegate = null;
 
-    @org.jetbrains.annotations.NotNull()
-    public final androidx.annotation.Box getDelegate() {
-        return null;
-    }
-
     public KBox(@org.jetbrains.annotations.NotNull()
     androidx.annotation.Box delegate) {
         super();
@@ -41,6 +36,11 @@ public final class KBox implements androidx.annotation.Box {
     @androidx.annotation.RecentlyNullable()
     @java.lang.Override()
     public java.lang.String foo() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final androidx.annotation.Box getDelegate() {
         return null;
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/repeatableAnnotations.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/repeatableAnnotations.txt
@@ -4,9 +4,9 @@ import java.lang.System;
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 public abstract @interface AnnoArray {
 
-    public abstract int x();
-
     public abstract java.lang.String[] a();
+
+    public abstract int x();
 }
 
 ////////////////////
@@ -18,9 +18,9 @@ import java.lang.System;
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 public abstract @interface AnnoBoolean {
 
-    public abstract int x();
-
     public abstract boolean bool();
+
+    public abstract int x();
 }
 
 ////////////////////
@@ -32,9 +32,9 @@ import java.lang.System;
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 public abstract @interface AnnoChar {
 
-    public abstract int x();
-
     public abstract char chr();
+
+    public abstract int x();
 }
 
 ////////////////////
@@ -46,9 +46,9 @@ import java.lang.System;
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 public abstract @interface AnnoClass {
 
-    public abstract int x();
-
     public abstract java.lang.Class<Color> c();
+
+    public abstract int x();
 }
 
 ////////////////////
@@ -60,9 +60,9 @@ import java.lang.System;
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 public abstract @interface AnnoDouble {
 
-    public abstract int x();
-
     public abstract double dbl();
+
+    public abstract int x();
 }
 
 ////////////////////
@@ -74,9 +74,9 @@ import java.lang.System;
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 public abstract @interface AnnoEnum {
 
-    public abstract int x();
-
     public abstract Color c();
+
+    public abstract int x();
 }
 
 ////////////////////
@@ -88,9 +88,9 @@ import java.lang.System;
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 public abstract @interface AnnoFloat {
 
-    public abstract int x();
-
     public abstract float flt();
+
+    public abstract int x();
 }
 
 ////////////////////
@@ -102,9 +102,9 @@ import java.lang.System;
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 public abstract @interface AnnoInt {
 
-    public abstract int x();
-
     public abstract int i();
+
+    public abstract int x();
 }
 
 ////////////////////
@@ -116,9 +116,9 @@ import java.lang.System;
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 public abstract @interface AnnoIntArray {
 
-    public abstract int x();
-
     public abstract int[] b();
+
+    public abstract int x();
 }
 
 ////////////////////
@@ -130,9 +130,9 @@ import java.lang.System;
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 public abstract @interface AnnoLong {
 
-    public abstract int x();
-
     public abstract long l();
+
+    public abstract int x();
 }
 
 ////////////////////
@@ -144,9 +144,9 @@ import java.lang.System;
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 public abstract @interface AnnoLongArray {
 
-    public abstract int x();
-
     public abstract long[] b();
+
+    public abstract int x();
 }
 
 ////////////////////
@@ -158,9 +158,9 @@ import java.lang.System;
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 public abstract @interface AnnoString {
 
-    public abstract int x();
-
     public abstract java.lang.String s();
+
+    public abstract int x();
 }
 
 ////////////////////
@@ -186,11 +186,8 @@ public final class Test {
     @org.jetbrains.annotations.NotNull()
     private final java.lang.String value = "";
 
-    @lib.Anno(value = "3", construct = {"C"})
-    @lib.Anno(value = "2", construct = {"A", "B"})
-    @lib.Anno(value = "1")
-    @java.lang.Deprecated()
-    public static void getValue$annotations() {
+    public Test() {
+        super();
     }
 
     @org.jetbrains.annotations.NotNull()
@@ -198,8 +195,11 @@ public final class Test {
         return null;
     }
 
-    public Test() {
-        super();
+    @lib.Anno(value = "3", construct = {"C"})
+    @lib.Anno(value = "2", construct = {"A", "B"})
+    @lib.Anno(value = "1")
+    @java.lang.Deprecated()
+    public static void getValue$annotations() {
     }
 }
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/secondaryConstructor.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/secondaryConstructor.txt
@@ -20,6 +20,11 @@ public final class Product2 implements secondary.Named {
     @org.jetbrains.annotations.Nullable()
     private java.lang.String name;
 
+    public Product2(@org.jetbrains.annotations.NotNull()
+    java.lang.String otherName) {
+        super();
+    }
+
     @org.jetbrains.annotations.Nullable()
     @java.lang.Override()
     public java.lang.String getName() {
@@ -28,10 +33,5 @@ public final class Product2 implements secondary.Named {
 
     public void setName(@org.jetbrains.annotations.Nullable()
     java.lang.String p0) {
-    }
-
-    public Product2(@org.jetbrains.annotations.NotNull()
-    java.lang.String otherName) {
-        super();
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/strangeIdentifiers.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/strangeIdentifiers.txt
@@ -4,9 +4,9 @@ import java.lang.System;
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 public abstract @interface Anno {
 
-    public abstract StrangeEnum size();
-
     public abstract java.lang.String name();
+
+    public abstract StrangeEnum size();
 }
 
 ////////////////////
@@ -20,12 +20,12 @@ public enum StrangeEnum {
     @org.jetbrains.annotations.NotNull()
     private final java.lang.String size = null;
 
+    StrangeEnum(java.lang.String size) {
+    }
+
     @org.jetbrains.annotations.NotNull()
     public final java.lang.String getSize() {
         return null;
-    }
-
-    StrangeEnum(java.lang.String size) {
     }
 }
 
@@ -37,6 +37,10 @@ import java.lang.System;
 @kotlin.Metadata()
 public final class Test {
     public java.lang.String simpleName;
+
+    public Test() {
+        super();
+    }
 
     @org.jetbrains.annotations.NotNull()
     public final java.lang.String getSimpleName() {
@@ -55,9 +59,5 @@ public final class Test {
     public final void strangeFun4(@org.jetbrains.annotations.NotNull()
     java.lang.String a, @org.jetbrains.annotations.NotNull()
     java.lang.String p1_949560896) {
-    }
-
-    public Test() {
-        super();
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/stripMetadata.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/stripMetadata.txt
@@ -2,13 +2,13 @@ import java.lang.System;
 
 public abstract class BaseClass {
 
-    @org.jetbrains.annotations.NotNull()
-    public abstract Result doJob();
-
     public BaseClass(@org.jetbrains.annotations.NotNull()
     Context context, int num, boolean bool) {
         super();
     }
+
+    @org.jetbrains.annotations.NotNull()
+    public abstract Result doJob();
 }
 
 ////////////////////
@@ -26,15 +26,15 @@ import java.lang.System;
 
 public final class Inheritor extends BaseClass {
 
+    public Inheritor(@org.jetbrains.annotations.NotNull()
+    Context context) {
+        super(null, 0, false);
+    }
+
     @org.jetbrains.annotations.NotNull()
     @java.lang.Override()
     public Result doJob() {
         return null;
-    }
-
-    public Inheritor(@org.jetbrains.annotations.NotNull()
-    Context context) {
-        super(null, 0, false);
     }
 }
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/suspendErrorTypes.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/suspendErrorTypes.txt
@@ -3,13 +3,13 @@ import java.lang.System;
 @kotlin.Metadata()
 public final class Foo {
 
+    public Foo() {
+        super();
+    }
+
     @org.jetbrains.annotations.Nullable()
     public final java.lang.Object a(@org.jetbrains.annotations.NotNull()
     kotlin.coroutines.Continuation<ABC> p0) {
         return null;
-    }
-
-    public Foo() {
-        super();
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/topLevel.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/topLevel.txt
@@ -21,17 +21,28 @@ public final class TopLevelKt {
     public TopLevelKt() {
         super();
     }
-    private static final int topLevelProperty = 2;
     public static final int topLevelConstProperty = 2;
+    private static final int topLevelProperty = 2;
 
-    @org.jetbrains.annotations.Nullable()
-    public static final java.lang.String topLevelFunction() {
+    public static final void extensionFunction(@org.jetbrains.annotations.NotNull()
+    @Anno(value = "rec")
+    java.lang.String $this$extensionFunction, @org.jetbrains.annotations.NotNull()
+    @Anno(value = "1")
+    java.lang.String a, @org.jetbrains.annotations.NotNull()
+    @Anno(value = "2")
+    java.lang.String b) {
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public static final <T extends java.lang.Object>java.lang.String getExtensionProperty(@org.jetbrains.annotations.NotNull()
+    @Anno(value = "propRec")
+    T $this$extensionProperty) {
         return null;
     }
 
-    @org.jetbrains.annotations.Nullable()
-    public static final <X extends java.lang.CharSequence, T extends java.util.List<? extends X>>T topLevelGenericFunction() {
-        return null;
+    @Anno(value = "extpr")
+    @java.lang.Deprecated()
+    public static void getExtensionProperty$annotations(java.lang.Object p0) {
     }
 
     public static final int getTopLevelProperty() {
@@ -43,31 +54,20 @@ public final class TopLevelKt {
         return null;
     }
 
-    public static final void extensionFunction(@org.jetbrains.annotations.NotNull()
-    @Anno(value = "rec")
-    java.lang.String $this$extensionFunction, @org.jetbrains.annotations.NotNull()
-    @Anno(value = "1")
-    java.lang.String a, @org.jetbrains.annotations.NotNull()
-    @Anno(value = "2")
-    java.lang.String b) {
-    }
-
-    @Anno(value = "extpr")
-    @java.lang.Deprecated()
-    public static void getExtensionProperty$annotations(java.lang.Object p0) {
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public static final <T extends java.lang.Object>java.lang.String getExtensionProperty(@org.jetbrains.annotations.NotNull()
-    @Anno(value = "propRec")
-    T $this$extensionProperty) {
-        return null;
-    }
-
     public static final <T extends java.lang.Object>void setExtensionProperty(@org.jetbrains.annotations.NotNull()
     @Anno(value = "propRec")
     T $this$extensionProperty, @org.jetbrains.annotations.NotNull()
     @Anno(value = "setparam")
     java.lang.String setParamName) {
+    }
+
+    @org.jetbrains.annotations.Nullable()
+    public static final java.lang.String topLevelFunction() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.Nullable()
+    public static final <X extends java.lang.CharSequence, T extends java.util.List<? extends X>>T topLevelGenericFunction() {
+        return null;
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/unsafePropertyInitializers.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/unsafePropertyInitializers.txt
@@ -3,13 +3,12 @@ import java.lang.System;
 @kotlin.Metadata()
 public final class Boo {
     @org.jetbrains.annotations.NotNull()
-    private static final java.lang.String z = null;
-    @org.jetbrains.annotations.NotNull()
     public static final Boo INSTANCE = null;
-
     @org.jetbrains.annotations.NotNull()
-    public final java.lang.String getZ() {
-        return null;
+    private static final java.lang.String z = null;
+
+    private Boo() {
+        super();
     }
 
     @org.jetbrains.annotations.NotNull()
@@ -17,8 +16,9 @@ public final class Boo {
         return null;
     }
 
-    private Boo() {
-        super();
+    @org.jetbrains.annotations.NotNull()
+    public final java.lang.String getZ() {
+        return null;
     }
 }
 
@@ -30,14 +30,16 @@ import java.lang.System;
 @kotlin.Metadata()
 public final class Foo {
     @org.jetbrains.annotations.NotNull()
-    public static final java.lang.String aString = "foo";
+    public static final Foo INSTANCE = null;
     public static final int aInt = 3;
     @org.jetbrains.annotations.NotNull()
-    private static final java.lang.String bString = "bar";
+    public static final java.lang.String aString = "foo";
     private static final int bInt = 5;
     @org.jetbrains.annotations.NotNull()
-    private static java.lang.String cString = "baz";
+    private static final java.lang.String bString = "bar";
     private static int cInt = 7;
+    @org.jetbrains.annotations.NotNull()
+    private static java.lang.String cString = "baz";
     @org.jetbrains.annotations.NotNull()
     private static final java.lang.String d = null;
     private static final int e = 0;
@@ -50,12 +52,9 @@ public final class Foo {
     private static final java.lang.String j = null;
     @org.jetbrains.annotations.NotNull()
     private static final java.lang.String k = null;
-    @org.jetbrains.annotations.NotNull()
-    public static final Foo INSTANCE = null;
 
-    @org.jetbrains.annotations.NotNull()
-    public final java.lang.String getBString() {
-        return null;
+    private Foo() {
+        super();
     }
 
     public final int getBInt() {
@@ -63,19 +62,17 @@ public final class Foo {
     }
 
     @org.jetbrains.annotations.NotNull()
-    public final java.lang.String getCString() {
+    public final java.lang.String getBString() {
         return null;
-    }
-
-    public final void setCString(@org.jetbrains.annotations.NotNull()
-    java.lang.String p0) {
     }
 
     public final int getCInt() {
         return 0;
     }
 
-    public final void setCInt(int p0) {
+    @org.jetbrains.annotations.NotNull()
+    public final java.lang.String getCString() {
+        return null;
     }
 
     @org.jetbrains.annotations.NotNull()
@@ -114,8 +111,11 @@ public final class Foo {
         return null;
     }
 
-    private Foo() {
-        super();
+    public final void setCInt(int p0) {
+    }
+
+    public final void setCString(@org.jetbrains.annotations.NotNull()
+    java.lang.String p0) {
     }
 }
 
@@ -127,6 +127,18 @@ import java.lang.System;
 @kotlin.Metadata()
 public final class HavingState {
     @org.jetbrains.annotations.NotNull()
+    private final kotlin.reflect.KClass<? extends java.lang.Object> anonymous = null;
+    @org.jetbrains.annotations.NotNull()
+    private final kotlin.reflect.KClass<State> clazz = null;
+    @org.jetbrains.annotations.NotNull()
+    private final float[] floatArray = {-1.0F};
+    @org.jetbrains.annotations.NotNull()
+    private final java.lang.Integer[] intArray = {1};
+    @org.jetbrains.annotations.NotNull()
+    private final java.util.List<java.lang.Integer> intList = null;
+    @org.jetbrains.annotations.NotNull()
+    private final java.lang.Class<State> javaClass = null;
+    @org.jetbrains.annotations.NotNull()
     private final State state = State.START;
     @org.jetbrains.annotations.NotNull()
     private final State[] stateArray = {State.START};
@@ -134,23 +146,45 @@ public final class HavingState {
     private final java.lang.String[] stringArray = {"foo"};
     @org.jetbrains.annotations.NotNull()
     private final java.util.List<java.lang.String> stringList = null;
-    @org.jetbrains.annotations.NotNull()
-    private final java.lang.Integer[] intArray = {1};
-    @org.jetbrains.annotations.NotNull()
-    private final float[] floatArray = {-1.0F};
-    @org.jetbrains.annotations.NotNull()
-    private final java.util.List<java.lang.Integer> intList = null;
     private final int uint = 1;
     @org.jetbrains.annotations.NotNull()
     private final kotlin.UInt[] uintArray = {1};
     @org.jetbrains.annotations.NotNull()
     private final java.util.List<kotlin.UInt> uintList = null;
+
+    public HavingState() {
+        super();
+    }
+
     @org.jetbrains.annotations.NotNull()
-    private final kotlin.reflect.KClass<State> clazz = null;
+    public final kotlin.reflect.KClass<? extends java.lang.Object> getAnonymous() {
+        return null;
+    }
+
     @org.jetbrains.annotations.NotNull()
-    private final java.lang.Class<State> javaClass = null;
+    public final kotlin.reflect.KClass<State> getClazz() {
+        return null;
+    }
+
     @org.jetbrains.annotations.NotNull()
-    private final kotlin.reflect.KClass<? extends java.lang.Object> anonymous = null;
+    public final float[] getFloatArray() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final java.lang.Integer[] getIntArray() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final java.util.List<java.lang.Integer> getIntList() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final java.lang.Class<State> getJavaClass() {
+        return null;
+    }
 
     @org.jetbrains.annotations.NotNull()
     public final State getState() {
@@ -173,21 +207,6 @@ public final class HavingState {
     }
 
     @org.jetbrains.annotations.NotNull()
-    public final java.lang.Integer[] getIntArray() {
-        return null;
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final float[] getFloatArray() {
-        return null;
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final java.util.List<java.lang.Integer> getIntList() {
-        return null;
-    }
-
-    @org.jetbrains.annotations.NotNull()
     public final kotlin.UInt[] getUintArray() {
         return null;
     }
@@ -195,25 +214,6 @@ public final class HavingState {
     @org.jetbrains.annotations.NotNull()
     public final java.util.List<kotlin.UInt> getUintList() {
         return null;
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final kotlin.reflect.KClass<State> getClazz() {
-        return null;
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final java.lang.Class<State> getJavaClass() {
-        return null;
-    }
-
-    @org.jetbrains.annotations.NotNull()
-    public final kotlin.reflect.KClass<? extends java.lang.Object> getAnonymous() {
-        return null;
-    }
-
-    public HavingState() {
-        super();
     }
 }
 

--- a/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/DefaultParameterValues.it.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/DefaultParameterValues.it.txt
@@ -26,9 +26,8 @@ public final class User {
     @org.jetbrains.annotations.NotNull()
     private final java.lang.String name = "John";
 
-    @org.jetbrains.annotations.NotNull()
-    public final java.lang.String getName() {
-        return null;
+    public User() {
+        super();
     }
 
     public User(@org.jetbrains.annotations.NotNull()
@@ -36,7 +35,8 @@ public final class User {
         super();
     }
 
-    public User() {
-        super();
+    @org.jetbrains.annotations.NotNull()
+    public final java.lang.String getName() {
+        return null;
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/NestedClasses.it.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/NestedClasses.it.txt
@@ -25,12 +25,12 @@ public final class Simple {
     @org.jetbrains.annotations.NotNull()
     public static final test.Simple.Companion Companion = null;
 
-    @MyAnnotation()
-    public final void myMethod() {
-    }
-
     public Simple() {
         super();
+    }
+
+    @MyAnnotation()
+    public final void myMethod() {
     }
 
     @kotlin.Metadata()

--- a/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/Overloads.it.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/Overloads.it.txt
@@ -28,6 +28,15 @@ public final class State {
     @org.jetbrains.annotations.NotNull()
     private final java.lang.String someString = null;
 
+    public State(int someInt, long someLong) {
+        super();
+    }
+
+    public State(int someInt, long someLong, @org.jetbrains.annotations.NotNull()
+    java.lang.String someString) {
+        super();
+    }
+
     public final int getSomeInt() {
         return 0;
     }
@@ -39,14 +48,5 @@ public final class State {
     @org.jetbrains.annotations.NotNull()
     public final java.lang.String getSomeString() {
         return null;
-    }
-
-    public State(int someInt, long someLong, @org.jetbrains.annotations.NotNull()
-    java.lang.String someString) {
-        super();
-    }
-
-    public State(int someInt, long someLong) {
-        super();
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/Simple.it.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/Simple.it.txt
@@ -16,16 +16,16 @@ import java.lang.System;
 @kotlin.Metadata()
 public final class Simple {
 
-    @MyAnnotation()
-    public final void myMethod() {
+    public Simple() {
+        super();
     }
 
     public final int heavyMethod() {
         return 0;
     }
 
-    public Simple() {
-        super();
+    @MyAnnotation()
+    public final void myMethod() {
     }
 }
 


### PR DESCRIPTION
In an incremental build, class members are already sorted when they are
deserialized from the serialized data (see
DeserializedMemberScope.addMembers).

However, in a clean build where the class members are read directly from
the source files, the class members are not yet sorted. Therefore, there
can be a difference in the contents of the stubs file between a clean
build and the next incremental build, making the subsequent task run
unnecessarily.

To fix that, this commit ensures that we always sort the class members.

Bug: KT-40882 (there are actually 2 issues in here; this commit fixes
     the first one)
Test: New DeterministicBuildIT