### PR TITLE
FIR2IR: correct dispatch receiver inside inner class constructor

### DIFF
--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrConversionScope.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrConversionScope.kt
@@ -111,6 +111,11 @@ class Fir2IrConversionScope {
     fun dispatchReceiverParameter(irClass: IrClass): IrValueParameter? {
         for (function in functionStack.asReversed()) {
             if (function.parentClassOrNull == irClass) {
+                // An inner class's constructor needs an instance of the outer class as a dispatch receiver.
+                // However, if we are converting `this` receiver inside that constructor, now we should point to the inner class instance.
+                if (function is IrConstructor && irClass.isInner) {
+                    irClass.thisReceiver?.let { return it }
+                }
                 function.dispatchReceiverParameter?.let { return it }
             }
         }

--- a/compiler/testData/codegen/box/secondaryConstructors/innerClasses.kt
+++ b/compiler/testData/codegen/box/secondaryConstructors/innerClasses.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 class Outer {
     val outerProp: String
     constructor(x: String) {

--- a/compiler/testData/codegen/box/secondaryConstructors/innerClassesInheritance.kt
+++ b/compiler/testData/codegen/box/secondaryConstructors/innerClassesInheritance.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 class Outer {
     val outerProp: String
     constructor(x: String) {


### PR DESCRIPTION
The motivation is `secondaryConstructors/innerClasses`:
```kt
class Outer {
  inner class A1() {
    var prop: ...
    constructor(x: String): this() {
      prop = x + ...
    }
  }
}
```
The (secondary) constructor of `Outer.A1` needs `Outer` instance as a dispatch receiver. But, when (implicit) `this` receiver inside that constructor is converted, e.g., `<set-prop>`, the same `Outer`'s `<this>` is used, which supposed to be `Outer.A1`'s `<this>`.

In general, the dispatch receiver for the top function in the conversion scope is the one we're looking for as `this` receiver, but the inner class's constructor should be handled differently.