### PR TITLE
FIR2IR: distinguish constructor when picking return target

### DIFF
--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrConversionScope.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrConversionScope.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.fir.backend
 
 import org.jetbrains.kotlin.fir.declarations.FirClass
+import org.jetbrains.kotlin.fir.declarations.FirConstructor
 import org.jetbrains.kotlin.fir.declarations.FirFunction
 import org.jetbrains.kotlin.fir.expressions.FirReturnExpression
 import org.jetbrains.kotlin.ir.declarations.*
@@ -97,7 +98,13 @@ class Fir2IrConversionScope {
 
     fun returnTarget(expression: FirReturnExpression, declarationStorage: Fir2IrDeclarationStorage): IrFunction {
         val firTarget = expression.target.labeledElement
-        val irTarget = (firTarget as? FirFunction)?.let { declarationStorage.getCachedIrFunction(it) }
+        val irTarget = (firTarget as? FirFunction)?.let {
+            if (it is FirConstructor) {
+                declarationStorage.getCachedIrConstructor(it)
+            } else {
+                declarationStorage.getCachedIrFunction(it)
+            }
+        }
         for (potentialTarget in functionStack.asReversed()) {
             if (potentialTarget == irTarget) {
                 return potentialTarget

--- a/compiler/testData/codegen/box/secondaryConstructors/withNonLocalReturn.kt
+++ b/compiler/testData/codegen/box/secondaryConstructors/withNonLocalReturn.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 inline fun run2(block: () -> Unit) = block()
 
 class A {


### PR DESCRIPTION
The motivation is `secondaryConstructors/withNonLocalReturn`, which literally has a non-local return in secondary constructor, which reveals that, when retrieving IR target for the return target, constructor and normal functions should be treated differently (since they're stored in different caches). This should have been done at https://github.com/JetBrains/kotlin/pull/3720.