### PR TITLE
Fix links to Kotlin online docs

### DIFF
--- a/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/GradleKotlinFrameworkSupportProvider.kt
+++ b/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/GradleKotlinFrameworkSupportProvider.kt
@@ -311,7 +311,7 @@ open class GradleKotlinMPPSourceSetsFrameworkSupportProvider : GradleKotlinMPPFr
             """kotlin {
     /* Targets configuration omitted. 
     *  To find out how to configure the targets, please follow the link:
-    *  https://kotlinlang.org/docs/reference/building-mpp-with-gradle.html#setting-up-targets */
+    *  https://kotlinlang.org/docs/reference/mpp-set-up-targets.html */
 
     sourceSets {
         commonMain {

--- a/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/KotlinDslGradleKotlinFrameworkSupportProvider.kt
+++ b/idea/idea-gradle/src/org/jetbrains/kotlin/idea/configuration/KotlinDslGradleKotlinFrameworkSupportProvider.kt
@@ -275,7 +275,7 @@ class KotlinDslGradleKotlinMPPFrameworkSupportProvider :
             """kotlin {
     /* Targets configuration omitted. 
     *  To find out how to configure the targets, please follow the link:
-    *  https://kotlinlang.org/docs/reference/building-mpp-with-gradle.html#setting-up-targets */
+    *  https://kotlinlang.org/docs/reference/mpp-set-up-targets.html */
 
     sourceSets {
         val commonMain by getting {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/NewMultiplatformIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/NewMultiplatformIT.kt
@@ -1422,7 +1422,7 @@ class NewMultiplatformIT : BaseGradleIT() {
                             * Compilation: 'test', arguments: [-g]
 
                 Please move them into final binary declarations. E.g. binaries.executable { freeCompilerArgs += "..." }
-                See more about final binaries: https://kotlinlang.org/docs/reference/building-mpp-with-gradle.html#building-final-native-binaries.
+                See more about final binaries: https://kotlinlang.org/docs/reference/mpp-build-native-binaries.html.
                 """.trimIndent()
             )
         }

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinMultiplatformPlugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinMultiplatformPlugin.kt
@@ -254,7 +254,7 @@ open class KotlinPlatformJsPlugin : KotlinPlatformImplementationPluginBase("js")
 internal val KOTLIN_12X_MPP_DEPRECATION_WARNING = "\n" + """
     The 'org.jetbrains.kotlin.platform.*' plugins are deprecated and will no longer be available in Kotlin 1.4.
     Please migrate the project to the 'org.jetbrains.kotlin.multiplatform' plugin.
-    See: https://kotlinlang.org/docs/reference/building-mpp-with-gradle.html
+    See: https://kotlinlang.org/docs/reference/mpp-discover-project.html#multiplatform-plugin
     """.trimIndent()
 
 private const val KOTLIN_12X_MPP_DEPRECATION_SUPPRESS_FLAG = "kotlin.internal.mpp12x.deprecation.suppress"

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPluginWrapper.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPluginWrapper.kt
@@ -225,7 +225,7 @@ open class KotlinMultiplatformPluginWrapper @Inject constructor(
             throw GradleException(
                 """
                 Please initialize at least one Kotlin target in '${project.name} (${project.path})'.
-                Read more https://kotlinlang.org/docs/reference/building-mpp-with-gradle.html#setting-up-targets
+                Read more https://kotlinlang.org/docs/reference/mpp-set-up-targets.html
                 """.trimIndent()
             )
         }

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/UnusedSourceSetsChecker.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/UnusedSourceSetsChecker.kt
@@ -20,7 +20,7 @@ object UnusedSourceSetsChecker {
 
     const val WARNING_BOTTOM_LINE =
         "You can add a source set to a target's compilation by connecting it with the compilation's default source set using 'dependsOn'.\n" +
-                "See https://kotlinlang.org/docs/reference/building-mpp-with-gradle.html#connecting-source-sets"
+                "See https://kotlinlang.org/docs/reference/mpp-share-on-platforms.html#configure-the-hierarchical-structure-manually"
 
     private fun reportUnusedSourceSets(project: Project, sourceSets: Set<KotlinSourceSet>) {
         require(sourceSets.isNotEmpty())

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/native/CompilationFreeArgsValidator.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/native/CompilationFreeArgsValidator.kt
@@ -86,7 +86,7 @@ internal object CompilationFreeArgsValidator : AggregateReporter() {
             appendln(
                 """
                 Please move them into final binary declarations. E.g. binaries.executable { freeCompilerArgs += "..." }
-                See more about final binaries: https://kotlinlang.org/docs/reference/building-mpp-with-gradle.html#building-final-native-binaries.
+                See more about final binaries: https://kotlinlang.org/docs/reference/mpp-build-native-binaries.html.
                 """.trimIndent()
             )
         }


### PR DESCRIPTION
After recent update of Kotlin website (after [this commit](https://github.com/JetBrains/kotlin-web-site/commit/2716350c2d773a338e179fb6955996cf12dee661) to be particular), some of URLs (related to MPP) in warnings of kotlin-gradle-plugin and in comments of buildscripts generated by IntelliJ IDEA Project Wizard become invalid.
Currently they all are redirected to the [intro of MPP section](https://kotlinlang.org/docs/reference/mpp-intro.html). This PR restores links to relevant parts of new MPP documentation. 