### PR TITLE
JVM_IR: make `primitive == object` slightly less lazy.

### DIFF
--- a/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBytecodeTextTestGenerated.java
+++ b/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBytecodeTextTestGenerated.java
@@ -1765,6 +1765,11 @@ public class FirBytecodeTextTestGenerated extends AbstractFirBytecodeTextTest {
         public void testSimpleConstructorNotRedundantNotOptimizable() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/deadCodeElimination/simpleConstructorNotRedundantNotOptimizable.kt");
         }
+
+        @TestMetadata("unusedPrimitiveAndObjectEquals.kt")
+        public void testUnusedPrimitiveAndObjectEquals() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/deadCodeElimination/unusedPrimitiveAndObjectEquals.kt");
+        }
     }
 
     @TestMetadata("compiler/testData/codegen/bytecodeText/defaultArguments")

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/Equals.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/intrinsics/Equals.kt
@@ -16,7 +16,6 @@ import org.jetbrains.kotlin.codegen.StackValue
 import org.jetbrains.kotlin.codegen.intrinsics.IntrinsicMethods
 import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.ir.descriptors.toIrBasedKotlinType
-import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrFunctionAccessExpression
 import org.jetbrains.kotlin.ir.expressions.IrStatementOrigin
 import org.jetbrains.kotlin.ir.types.classOrNull
@@ -26,7 +25,6 @@ import org.jetbrains.kotlin.ir.util.isEnumEntry
 import org.jetbrains.kotlin.ir.util.isIntegerConst
 import org.jetbrains.kotlin.ir.util.isNullConst
 import org.jetbrains.kotlin.lexer.KtTokens
-import org.jetbrains.kotlin.psi2ir.generators.hasNoSideEffects
 import org.jetbrains.kotlin.resolve.jvm.AsmTypes
 import org.jetbrains.kotlin.resolve.jvm.jvmSignature.JvmMethodSignature
 import org.jetbrains.kotlin.types.isNullable
@@ -83,21 +81,6 @@ class Equals(val operator: IElementType) : IntrinsicMethod() {
         val rightType = with(codegen) { b.asmType }
         val opToken = expression.origin
 
-        fun loadOther(expression: IrExpression, type: Type): () -> MaterialValue {
-            return if (expression.hasNoSideEffects()) {
-                { expression.accept(codegen, data).materializedAt(type, expression.type) }
-            } else {
-                val aValue = expression.accept(codegen, data).materializedAt(type, expression.type)
-                val local = codegen.frameMap.enterTemp(type)
-                codegen.mv.store(local, type)
-                ({
-                    codegen.mv.load(local, type)
-                    codegen.frameMap.leaveTemp(type)
-                    aValue
-                })
-            }
-        }
-
         // Avoid boxing for `primitive == object` and `boxed primitive == primitive` where we know
         // what comparison means. The optimization does not apply to `object == primitive` as equals
         // could be overridden for the object.
@@ -105,19 +88,9 @@ class Equals(val operator: IElementType) : IntrinsicMethod() {
             ((AsmUtil.isIntOrLongPrimitive(leftType) && !AsmUtil.isPrimitive(rightType)) ||
                     (AsmUtil.isIntOrLongPrimitive(rightType) && AsmUtil.isBoxedPrimitiveType(leftType)))
         ) {
-            val leftIsPrimitive = AsmUtil.isIntOrLongPrimitive(leftType)
-            val primitiveType = if (leftIsPrimitive) leftType else rightType
-            val nonPrimitiveType = if (leftIsPrimitive) rightType else leftType
-            val useNullCheck = AsmUtil.isBoxedPrimitiveType(nonPrimitiveType)
-            return if (leftIsPrimitive) {
-                val loadOther = loadOther(a, leftType)
-                val boxedValue = b.accept(codegen, data).materializedAt(rightType, b.type)
-                PrimitiveToObjectComparison(operator, boxedValue, useNullCheck, primitiveType, loadOther)
-            } else {
-                val boxedValue = a.accept(codegen, data).materializedAt(leftType, a.type)
-                val loadOther = loadOther(b, rightType)
-                PrimitiveToObjectComparison(operator, boxedValue, useNullCheck, primitiveType, loadOther)
-            }
+            val aValue = a.accept(codegen, data).materializedAt(leftType, a.type)
+            val bValue = b.accept(codegen, data).materializedAt(rightType, b.type)
+            return PrimitiveToObjectComparison(operator, AsmUtil.isIntOrLongPrimitive(leftType), aValue, bValue)
         }
 
         val aIsEnum = a.type.classOrNull?.owner?.run { isEnumClass || isEnumEntry } == true

--- a/compiler/testData/codegen/bytecodeText/deadCodeElimination/unusedPrimitiveAndObjectEquals.kt
+++ b/compiler/testData/codegen/bytecodeText/deadCodeElimination/unusedPrimitiveAndObjectEquals.kt
@@ -1,0 +1,12 @@
+var x = 1
+
+fun box() {
+    val y: Number = 1
+    x == y
+}
+
+// 0 equals
+// JVM_TEMPLATES
+// 1 ICMP
+// JVM_IR_TEMPLATES
+// 0 ICMP

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeTextTestGenerated.java
@@ -1810,6 +1810,11 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
         public void testSimpleConstructorNotRedundantNotOptimizable() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/deadCodeElimination/simpleConstructorNotRedundantNotOptimizable.kt");
         }
+
+        @TestMetadata("unusedPrimitiveAndObjectEquals.kt")
+        public void testUnusedPrimitiveAndObjectEquals() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/deadCodeElimination/unusedPrimitiveAndObjectEquals.kt");
+        }
     }
 
     @TestMetadata("compiler/testData/codegen/bytecodeText/defaultArguments")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeTextTestGenerated.java
@@ -1765,6 +1765,11 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
         public void testSimpleConstructorNotRedundantNotOptimizable() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/deadCodeElimination/simpleConstructorNotRedundantNotOptimizable.kt");
         }
+
+        @TestMetadata("unusedPrimitiveAndObjectEquals.kt")
+        public void testUnusedPrimitiveAndObjectEquals() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/deadCodeElimination/unusedPrimitiveAndObjectEquals.kt");
+        }
     }
 
     @TestMetadata("compiler/testData/codegen/bytecodeText/defaultArguments")


### PR DESCRIPTION
Discarding the value used to leave an unused-but-never-destroyed temporary variable. It's best to not separate calls to `enterTemp` and `leaveTemp`.

Not sure what kind of test to add though, since this is minor -- if the result of the comparison is discarded, then the entire statement is more or less pointless.

 #KT-42251 Fixed