### PR TITLE
KT-40140: Task configuration avoidance for Android projects

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/ConfigurationAvoidanceIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/ConfigurationAvoidanceIT.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.gradle
 
+import org.jetbrains.kotlin.gradle.util.AGPVersion
 import org.junit.Test
 
 class ConfigurationAvoidanceIT : BaseGradleIT() {
@@ -28,4 +29,46 @@ class ConfigurationAvoidanceIT : BaseGradleIT() {
         }
     }
 
+    @Test
+    fun testAndroidUnrelatedTaskNotConfigured() = with(
+        Project(
+            "AndroidProject",
+            gradleVersionRequirement = GradleVersionRequired.AtLeast("6.6.1")
+        )
+    ) {
+        setupWorkingDir()
+
+        listOf("Android", "Test").forEach { subproject ->
+            gradleBuildScript(subproject).appendText("\n" + """
+                android {
+                    applicationVariants.all {
+                        it.getAidlCompileProvider().configure {
+                            throw new RuntimeException("Task should not be configured.")
+                        }
+                    }
+                }
+                """.trimIndent()
+            )
+        }
+
+        gradleBuildScript("Lib").appendText(
+            "\n" + """
+            android {
+                libraryVariants.all {
+                    it.getAidlCompileProvider().configure {
+                        throw new RuntimeException("Task should not be configured.")
+                    }
+                }
+            }
+        """.trimIndent()
+        )
+
+        build(
+            "help", options = defaultBuildOptions().copy(
+                androidGradlePluginVersion = AGPVersion.v4_2_0
+            )
+        ) {
+            assertSuccessful()
+        }
+    }
 }

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt
@@ -13,6 +13,7 @@ import org.gradle.api.*
 import org.gradle.api.artifacts.maven.Conf2ScopeMappingContainer
 import org.gradle.api.artifacts.maven.MavenResolver
 import org.gradle.api.attributes.Usage
+import org.gradle.api.file.ConfigurableFileTree
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.logging.Logging
@@ -990,7 +991,7 @@ abstract class AbstractAndroidProjectHandler(private val kotlinConfigurationTool
 
         val javaTask = variantData.getJavaTaskProvider()
         val kotlinTask = compilation.compileKotlinTaskProvider
-        compilation.androidVariant.forEachJavaSourceDir { sources -> kotlinTask.configure { it.source(sources) } }
+        compilation.androidVariant.forEachJavaSourceDir { sources -> kotlinTask.configure { it.source(sources.dir) } }
         wireKotlinTasks(project, compilation, androidPlugin, androidExt, variantData, javaTask, kotlinTask)
     }
 }
@@ -1001,8 +1002,8 @@ internal inline fun BaseVariant.forEachKotlinSourceSet(action: (KotlinSourceSet)
         .forEach(action)
 }
 
-internal inline fun BaseVariant.forEachJavaSourceDir(action: (File) -> Unit) {
-    getSourceFolders(SourceKind.JAVA).map { it.dir }.forEach(action)
+internal inline fun BaseVariant.forEachJavaSourceDir(action: (ConfigurableFileTree) -> Unit) {
+    getSourceFolders(SourceKind.JAVA).forEach(action)
 }
 
 

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/SubpluginEnvironment.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/SubpluginEnvironment.kt
@@ -115,7 +115,7 @@ class SubpluginEnvironment(
 internal fun addCompilationSourcesToExternalCompileTask(compilation: KotlinCompilation<*>, task: TaskProvider<out AbstractCompile>) {
     if (compilation is KotlinJvmAndroidCompilation) {
         compilation.androidVariant.forEachKotlinSourceSet { sourceSet -> task.configure { it.source(sourceSet.kotlin) } }
-        compilation.androidVariant.forEachJavaSourceDir { sources -> task.configure { it.source(sources) } }
+        compilation.androidVariant.forEachJavaSourceDir { sources -> task.configure { it.source(sources.dir) } }
     } else {
         task.configure { taskInstance ->
             compilation.allKotlinSourceSets.forEach { sourceSet -> taskInstance.source(sourceSet.kotlin) }


### PR DESCRIPTION
When adding Java sources to Kotlin task, avoid
force-configuring source-generating tasks in AGP.

Fixes https://youtrack.jetbrains.com/issue/KT-40140.

Test: ConfigurationAvoidanceIT.testAndroidUnrelatedTaskNotConfigured