### PR TITLE
[FIR]: fix KT-42351

### DIFF
--- a/compiler/fir/raw-fir/light-tree2fir/src/org/jetbrains/kotlin/fir/lightTree/converter/DeclarationsConverter.kt
+++ b/compiler/fir/raw-fir/light-tree2fir/src/org/jetbrains/kotlin/fir/lightTree/converter/DeclarationsConverter.kt
@@ -643,7 +643,12 @@ class DeclarationsConverter(
                     )
                     superTypeRefs += enumClassWrapper.delegatedSuperTypeRef
                     convertPrimaryConstructor(null, null, enumClassWrapper, null)?.let { declarations += it.firConstructor }
-                    classBodyNode?.also { declarations += convertClassBody(it, enumClassWrapper) }
+                    classBodyNode?.also {
+                        // Use ANONYMOUS_OBJECT_NAME for the owner class id of enum entry declarations
+                        this@DeclarationsConverter.context.className =
+                            this@DeclarationsConverter.context.className.parent().child(ANONYMOUS_OBJECT_NAME)
+                        declarations += convertClassBody(it, enumClassWrapper)
+                    }
                 }
             }
         }

--- a/compiler/fir/raw-fir/psi2fir/src/org/jetbrains/kotlin/fir/builder/RawFirBuilder.kt
+++ b/compiler/fir/raw-fir/psi2fir/src/org/jetbrains/kotlin/fir/builder/RawFirBuilder.kt
@@ -742,6 +742,8 @@ class RawFirBuilder(
                             owner = ktEnumEntry,
                             typeParameters
                         )
+                        // Use ANONYMOUS_OBJECT_NAME for the owner class id for enum entry declarations (see KT-42351)
+                        this@RawFirBuilder.context.className = this@RawFirBuilder.context.className.parent().child(ANONYMOUS_OBJECT_NAME)
                         for (declaration in ktEnumEntry.declarations) {
                             declarations += declaration.toFirDeclaration(
                                 correctedEnumSelfTypeRef,

--- a/compiler/testData/codegen/box/enum/enumEntryMembers.kt
+++ b/compiler/testData/codegen/box/enum/enumEntryMembers.kt
@@ -3,6 +3,10 @@
 // FILE: lib.kt
 enum class Foo {
     FOO() {
+        // Test for KT-42351
+        private fun privateBar() = "bar"
+        override fun bar(): String = privateBar()
+
         override fun foo() = "foo"
        
         override var xxx: String
@@ -12,6 +16,7 @@ enum class Foo {
     };
 
     abstract fun foo(): String
+    abstract fun bar(): String
     abstract var xxx: String
 }
 
@@ -25,6 +30,7 @@ fun box(): String {
     assertEquals(Foo.FOO.xxx, "xxx")
     assertEquals(Foo.FOO.toString(), "FOO")
     assertEquals(Foo.valueOf("FOO").toString(), "FOO")
+    assertEquals(Foo.FOO.bar(), "bar")
     return "OK"
 }
 


### PR DESCRIPTION
FirVisibilityChecker::isVisible checked if a private declaration can be
accessed at a use site by matching class ids of the private
declaration's owner with the use site's containing class
declarations. When the private declaration is defined in an enum
entry and used in the same entry, its owner class id has the enum
entry name, but the use site is in an FirAnonymousObject, which has
"anonymous" as the class id. This causes visibility check to fail.

This PR adds handling of enum entries in isVisible: it checks if any
containing FirAnonymousObject of the use site contains the private
declaration.