### PR TITLE
JVM_IR: move MoveOrCopyCompanionObjectFields down a bit

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
@@ -288,12 +288,14 @@ private val jvmFilePhases = listOf(
     lateinitDeclarationLoweringPhase,
     lateinitUsageLoweringPhase,
 
-    moveOrCopyCompanionObjectFieldsPhase,
     inlineCallableReferenceToLambdaPhase,
     functionReferencePhase,
     suspendLambdaPhase,
     propertyReferencePhase,
     constPhase,
+    // TODO: merge the next three phases together, as visitors behave incorrectly between them
+    //  (backing fields moved out of companion objects are reachable by two paths):
+    moveOrCopyCompanionObjectFieldsPhase,
     propertiesPhase,
     remapObjectFieldAccesses,
     anonymousObjectSuperConstructorPhase,


### PR DESCRIPTION
More specifically, it should be done *just before* JvmPropertiesLowering, as walking the IR tree between them will result in visiting the moved backing fields twice (once via the companion's parent, once via the IrProperty).

Ideally, this group of 3 lowerings should be merged into 1 as they are completely inseparable, but this is slightly harder to do properly.

 #KT-42527 Fixed