### PR TITLE
[JVM_IR] Fix mangling of default argument stubs for internal methods.

### DIFF
--- a/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/FirCompileKotlinAgainstKotlinTestGenerated.java
+++ b/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/FirCompileKotlinAgainstKotlinTestGenerated.java
@@ -173,6 +173,11 @@ public class FirCompileKotlinAgainstKotlinTestGenerated extends AbstractFirCompi
         runTest("compiler/testData/compileKotlinAgainstKotlin/internalSetterOverridden.kt");
     }
 
+    @TestMetadata("internalWithDefaultArgs.kt")
+    public void testInternalWithDefaultArgs() throws Exception {
+        runTest("compiler/testData/compileKotlinAgainstKotlin/internalWithDefaultArgs.kt");
+    }
+
     @TestMetadata("internalWithOtherModuleName.kt")
     public void testInternalWithOtherModuleName() throws Exception {
         runTest("compiler/testData/compileKotlinAgainstKotlin/internalWithOtherModuleName.kt");

--- a/compiler/testData/compileKotlinAgainstKotlin/internalWithDefaultArgs.kt
+++ b/compiler/testData/compileKotlinAgainstKotlin/internalWithDefaultArgs.kt
@@ -1,0 +1,15 @@
+// IGNORE_BACKEND_FIR: JVM_IR
+// IGNORE_BACKEND: NATIVE
+// FILE: A.kt
+
+package a
+
+class Box() {
+    internal fun result(value: String = "OK"): String = value
+}
+
+// FILE: B.kt
+
+fun box(): String {
+    return a.Box().result()
+}

--- a/compiler/tests/org/jetbrains/kotlin/codegen/CompileKotlinAgainstKotlinTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/CompileKotlinAgainstKotlinTestGenerated.java
@@ -178,6 +178,11 @@ public class CompileKotlinAgainstKotlinTestGenerated extends AbstractCompileKotl
         runTest("compiler/testData/compileKotlinAgainstKotlin/internalSetterOverridden.kt");
     }
 
+    @TestMetadata("internalWithDefaultArgs.kt")
+    public void testInternalWithDefaultArgs() throws Exception {
+        runTest("compiler/testData/compileKotlinAgainstKotlin/internalWithDefaultArgs.kt");
+    }
+
     @TestMetadata("internalWithOtherModuleName.kt")
     public void testInternalWithOtherModuleName() throws Exception {
         runTest("compiler/testData/compileKotlinAgainstKotlin/internalWithOtherModuleName.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrCompileKotlinAgainstKotlinTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrCompileKotlinAgainstKotlinTestGenerated.java
@@ -173,6 +173,11 @@ public class IrCompileKotlinAgainstKotlinTestGenerated extends AbstractIrCompile
         runTest("compiler/testData/compileKotlinAgainstKotlin/internalSetterOverridden.kt");
     }
 
+    @TestMetadata("internalWithDefaultArgs.kt")
+    public void testInternalWithDefaultArgs() throws Exception {
+        runTest("compiler/testData/compileKotlinAgainstKotlin/internalWithDefaultArgs.kt");
+    }
+
     @TestMetadata("internalWithOtherModuleName.kt")
     public void testInternalWithOtherModuleName() throws Exception {
         runTest("compiler/testData/compileKotlinAgainstKotlin/internalWithOtherModuleName.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/JvmIrAgainstOldBoxTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/JvmIrAgainstOldBoxTestGenerated.java
@@ -173,6 +173,11 @@ public class JvmIrAgainstOldBoxTestGenerated extends AbstractJvmIrAgainstOldBoxT
         runTest("compiler/testData/compileKotlinAgainstKotlin/internalSetterOverridden.kt");
     }
 
+    @TestMetadata("internalWithDefaultArgs.kt")
+    public void testInternalWithDefaultArgs() throws Exception {
+        runTest("compiler/testData/compileKotlinAgainstKotlin/internalWithDefaultArgs.kt");
+    }
+
     @TestMetadata("internalWithOtherModuleName.kt")
     public void testInternalWithOtherModuleName() throws Exception {
         runTest("compiler/testData/compileKotlinAgainstKotlin/internalWithOtherModuleName.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/JvmOldAgainstIrBoxTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/JvmOldAgainstIrBoxTestGenerated.java
@@ -173,6 +173,11 @@ public class JvmOldAgainstIrBoxTestGenerated extends AbstractJvmOldAgainstIrBoxT
         runTest("compiler/testData/compileKotlinAgainstKotlin/internalSetterOverridden.kt");
     }
 
+    @TestMetadata("internalWithDefaultArgs.kt")
+    public void testInternalWithDefaultArgs() throws Exception {
+        runTest("compiler/testData/compileKotlinAgainstKotlin/internalWithDefaultArgs.kt");
+    }
+
     @TestMetadata("internalWithOtherModuleName.kt")
     public void testInternalWithOtherModuleName() throws Exception {
         runTest("compiler/testData/compileKotlinAgainstKotlin/internalWithOtherModuleName.kt");


### PR DESCRIPTION
The MethodSignatureMapper expected to be able to look at the body
of the default argument stub. That is of course not possible when
it is from an external dependency.

Instead, we go through the attribute owner to get to the method
the stub is a default argument adapter for.