### PR TITLE
JVM_IR: do not deep-copy suspend lambdas in initializers

### DIFF
--- a/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
@@ -27003,6 +27003,11 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
             public void testReflectOnLambdaInSuspendLambda() throws Exception {
                 runTest("compiler/testData/codegen/box/reflection/lambdaClasses/reflectOnLambdaInSuspendLambda.kt");
             }
+
+            @TestMetadata("reflectOnSuspendLambdaInField.kt")
+            public void testReflectOnSuspendLambdaInField() throws Exception {
+                runTest("compiler/testData/codegen/box/reflection/lambdaClasses/reflectOnSuspendLambdaInField.kt");
+            }
         }
 
         @TestMetadata("compiler/testData/codegen/box/reflection/mapping")

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/JsLoweringPhases.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/JsLoweringPhases.kt
@@ -504,7 +504,9 @@ private val initializersLoweringPhase = makeBodyLoweringPhase(
     ::InitializersLowering,
     name = "InitializersLowering",
     description = "Merge init block and field initializers into [primary] constructor",
-    prerequisite = setOf(enumClassConstructorLoweringPhase, primaryConstructorLoweringPhase, annotationConstructorLowering)
+    prerequisite = setOf(
+        enumClassConstructorLoweringPhase, primaryConstructorLoweringPhase, annotationConstructorLowering, localClassExtractionPhase
+    )
 )
 
 private val initializersCleanupLoweringPhase = makeDeclarationTransformerPhase(

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
@@ -102,6 +102,12 @@ internal val propertiesPhase = makeIrFilePhase(
     stickyPostconditions = setOf((PropertiesLowering)::checkNoProperties)
 )
 
+internal val IrClass.isGeneratedLambdaClass: Boolean
+    get() = origin == JvmLoweredDeclarationOrigin.LAMBDA_IMPL ||
+            origin == JvmLoweredDeclarationOrigin.SUSPEND_LAMBDA ||
+            origin == JvmLoweredDeclarationOrigin.FUNCTION_REFERENCE_IMPL ||
+            origin == JvmLoweredDeclarationOrigin.GENERATED_PROPERTY_REFERENCE
+
 internal val localDeclarationsPhase = makeIrFilePhase(
     { context ->
         LocalDeclarationsLowering(
@@ -111,12 +117,10 @@ internal val localDeclarationsPhase = makeIrFilePhase(
                     NameUtils.sanitizeAsJavaIdentifier(super.localName(declaration))
             },
             object : VisibilityPolicy {
+                // Note: any condition that results in non-`LOCAL` visibility here should be duplicated in `JvmLocalClassPopupLowering`,
+                // else it won't detect the class as local.
                 override fun forClass(declaration: IrClass, inInlineFunctionScope: Boolean): DescriptorVisibility =
-                    if (declaration.origin == JvmLoweredDeclarationOrigin.LAMBDA_IMPL ||
-                        declaration.origin == JvmLoweredDeclarationOrigin.SUSPEND_LAMBDA ||
-                        declaration.origin == JvmLoweredDeclarationOrigin.FUNCTION_REFERENCE_IMPL ||
-                        declaration.origin == JvmLoweredDeclarationOrigin.GENERATED_PROPERTY_REFERENCE
-                    ) {
+                    if (declaration.isGeneratedLambdaClass) {
                         scopedVisibility(inInlineFunctionScope)
                     } else {
                         declaration.visibility

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/JvmLocalClassPopupLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/JvmLocalClassPopupLowering.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.backend.common.lower.LocalClassPopupLowering
 import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
 import org.jetbrains.kotlin.backend.jvm.JvmLoweredDeclarationOrigin
 import org.jetbrains.kotlin.backend.jvm.ir.IrInlineReferenceLocator
+import org.jetbrains.kotlin.backend.jvm.isGeneratedLambdaClass
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.expressions.IrFunctionReference
 
@@ -31,15 +32,11 @@ class JvmLocalClassPopupLowering(context: JvmBackendContext) : LocalClassPopupLo
     // On JVM, we only pop up local classes in field initializers and anonymous init blocks, so that InitializersLowering would not copy
     // them to each constructor. (Moving all local classes is not possible because of cases where they use reified type parameters,
     // or capture crossinline lambdas.)
-    // Upon moving such class, we record customEnclosingFunction for it to be the class constructor. This is needed because otherwise
-    // the class will not get any EnclosingMethod in the codegen later, since it won't be local anymore.
+    // Upon moving such class, we record that it used to be in an initializer so that the codegen later sets its EnclosingMethod
+    // to the primary constructor.
     override fun shouldPopUp(klass: IrClass, currentScope: ScopeWithIr?): Boolean {
-        // On JVM, lambdas have package-private visibility after LocalDeclarationsLowering, so we have to check something else.
-        val isLocal = super.shouldPopUp(klass, currentScope) ||
-                klass.origin == JvmLoweredDeclarationOrigin.LAMBDA_IMPL ||
-                klass.origin == JvmLoweredDeclarationOrigin.FUNCTION_REFERENCE_IMPL ||
-                klass.origin == JvmLoweredDeclarationOrigin.GENERATED_PROPERTY_REFERENCE
-        if (!isLocal) return false
+        // On JVM, lambdas have package-private visibility after LocalDeclarationsLowering; see `forClass` in `localDeclarationsPhase`.
+        if (!super.shouldPopUp(klass, currentScope) && !klass.isGeneratedLambdaClass) return false
 
         var parent = currentScope?.irElement
         while (parent is IrFunction) {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/SuspendLambdaLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/SuspendLambdaLowering.kt
@@ -187,6 +187,7 @@ private class SuspendLambdaLowering(context: JvmBackendContext) : SuspendLowerin
                 addInvokeCallingConstructor(constructor, invokeSuspend, invokeToOverride, parametersFields)
             }
 
+            this.metadata = function.metadata
             context.suspendLambdaToOriginalFunctionMap[attributeOwnerId as IrFunctionReference] = function
         }
 

--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/WasmLoweringPhases.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/WasmLoweringPhases.kt
@@ -228,7 +228,7 @@ private val initializersLoweringPhase = makeWasmModulePhase(
     ::InitializersLowering,
     name = "InitializersLowering",
     description = "Merge init block and field initializers into [primary] constructor",
-    prerequisite = setOf(primaryConstructorLoweringPhase)
+    prerequisite = setOf(primaryConstructorLoweringPhase, localClassExtractionPhase)
 )
 
 private val initializersCleanupLoweringPhase = makeWasmModulePhase(

--- a/compiler/testData/codegen/box/reflection/lambdaClasses/reflectOnSuspendLambdaInField.kt
+++ b/compiler/testData/codegen/box/reflection/lambdaClasses/reflectOnSuspendLambdaInField.kt
@@ -1,0 +1,12 @@
+// TARGET_BACKEND: JVM
+// WITH_REFLECT
+
+import kotlin.reflect.jvm.reflect
+
+class C {
+    val x: suspend (String) -> Unit = { OK: String -> }
+}
+
+fun box(): String {
+    return C().x.reflect()?.parameters?.singleOrNull()?.name ?: "null"
+}

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -28769,6 +28769,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             public void testReflectOnLambdaInSuspendLambda() throws Exception {
                 runTest("compiler/testData/codegen/box/reflection/lambdaClasses/reflectOnLambdaInSuspendLambda.kt");
             }
+
+            @TestMetadata("reflectOnSuspendLambdaInField.kt")
+            public void testReflectOnSuspendLambdaInField() throws Exception {
+                runTest("compiler/testData/codegen/box/reflection/lambdaClasses/reflectOnSuspendLambdaInField.kt");
+            }
         }
 
         @TestMetadata("compiler/testData/codegen/box/reflection/mapping")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -26403,6 +26403,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             public void testReflectOnLambdaInSuspendLambda() throws Exception {
                 runTest("compiler/testData/codegen/box/reflection/lambdaClasses/reflectOnLambdaInSuspendLambda.kt");
             }
+
+            @TestMetadata("reflectOnSuspendLambdaInField.kt")
+            public void testReflectOnSuspendLambdaInField() throws Exception {
+                runTest("compiler/testData/codegen/box/reflection/lambdaClasses/reflectOnSuspendLambdaInField.kt");
+            }
         }
 
         @TestMetadata("compiler/testData/codegen/box/reflection/mapping")

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -27003,6 +27003,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             public void testReflectOnLambdaInSuspendLambda() throws Exception {
                 runTest("compiler/testData/codegen/box/reflection/lambdaClasses/reflectOnLambdaInSuspendLambda.kt");
             }
+
+            @TestMetadata("reflectOnSuspendLambdaInField.kt")
+            public void testReflectOnSuspendLambdaInField() throws Exception {
+                runTest("compiler/testData/codegen/box/reflection/lambdaClasses/reflectOnSuspendLambdaInField.kt");
+            }
         }
 
         @TestMetadata("compiler/testData/codegen/box/reflection/mapping")


### PR DESCRIPTION
This loses reflection metadata (and also sometimes fails). Which was missing anyway - this is also fixed now.

 #KT-42554 Fixed