### PR TITLE
FIR checker: attempt to reproduce KT-42352

### DIFF
--- a/compiler/fir/analysis-tests/testData/resolve/diagnostics/abstractSuperCall.kt
+++ b/compiler/fir/analysis-tests/testData/resolve/diagnostics/abstractSuperCall.kt
@@ -39,3 +39,24 @@ abstract class J : A() {
         super.<!ABSTRACT_SUPER_CALL!>y<!>
     }
 }
+
+// KT-42352
+
+interface PsiVariable {
+    fun getInitializer(): Any?
+}
+
+interface UVariable : PsiVariable {
+    override fun getInitializer(): Any? {
+        return null
+    }
+}
+
+abstract class AbstractKotlinUVariable : PsiVariable, UVariable {
+}
+
+class KotlinUVariable : AbstractKotlinUVariable(), UVariable, PsiVariable {
+    override fun getInitializer(): Any? {
+        return super<AbstractKotlinUVariable>.getInitializer()
+    }
+}

--- a/compiler/fir/analysis-tests/testData/resolve/diagnostics/abstractSuperCall.txt
+++ b/compiler/fir/analysis-tests/testData/resolve/diagnostics/abstractSuperCall.txt
@@ -59,3 +59,29 @@ FILE: abstractSuperCall.kt
         }
 
     }
+    public abstract interface PsiVariable : R|kotlin/Any| {
+        public abstract fun getInitializer(): R|kotlin/Any?|
+
+    }
+    public abstract interface UVariable : R|PsiVariable| {
+        public open override fun getInitializer(): R|kotlin/Any?| {
+            ^getInitializer Null(null)
+        }
+
+    }
+    public abstract class AbstractKotlinUVariable : R|PsiVariable|, R|UVariable| {
+        public constructor(): R|AbstractKotlinUVariable| {
+            super<R|kotlin/Any|>()
+        }
+
+    }
+    public final class KotlinUVariable : R|AbstractKotlinUVariable|, R|UVariable|, R|PsiVariable| {
+        public constructor(): R|KotlinUVariable| {
+            super<R|AbstractKotlinUVariable|>()
+        }
+
+        public final override fun getInitializer(): R|kotlin/Any?| {
+            ^getInitializer this@R|/KotlinUVariable|.super<R|AbstractKotlinUVariable|>.R|/PsiVariable.getInitializer|()
+        }
+
+    }

--- a/compiler/testData/diagnostics/tests/defaultArguments/superCall.fir.kt
+++ b/compiler/testData/diagnostics/tests/defaultArguments/superCall.fir.kt
@@ -1,6 +1,16 @@
 // !DIAGNOSTICS: -UNUSED_PARAMETER -ABSTRACT_SUPER_CALL
 
-abstract class A {
+interface I {
+    fun bar(): Any?
+}
+
+interface EI : I {
+    override fun bar(): Any? {
+        throw UnsupportedOperationException()
+    }
+}
+
+abstract class A : I, EI {
     open fun foo(a: String = "default") {
     }
 
@@ -10,7 +20,7 @@ abstract class A {
     abstract fun foo3(a: String = "default")
 }
 
-open class B : A() {
+class B(i : I) : A(), EI, I by i {
     fun test() {
         super.foo("123")
         super.foo()
@@ -24,5 +34,9 @@ open class B : A() {
 
     override fun foo3(a: String) {
         throw UnsupportedOperationException()
+    }
+
+    override fun bar(): Any? {
+        return super<A>.bar()
     }
 }

--- a/compiler/testData/diagnostics/tests/defaultArguments/superCall.kt
+++ b/compiler/testData/diagnostics/tests/defaultArguments/superCall.kt
@@ -1,6 +1,16 @@
 // !DIAGNOSTICS: -UNUSED_PARAMETER -ABSTRACT_SUPER_CALL
 
-abstract class A {
+interface I {
+    fun bar(): Any?
+}
+
+interface EI : I {
+    override fun bar(): Any? {
+        throw UnsupportedOperationException()
+    }
+}
+
+abstract class A : I, EI {
     open fun foo(a: String = "default") {
     }
 
@@ -10,7 +20,7 @@ abstract class A {
     abstract fun foo3(a: String = "default")
 }
 
-open class B : A() {
+class B(i: I) : A(), EI, I by i {
     fun test() {
         super.foo("123")
         super.<!SUPER_CALL_WITH_DEFAULT_PARAMETERS!>foo<!>()
@@ -24,5 +34,9 @@ open class B : A() {
 
     override fun foo3(a: String) {
         throw UnsupportedOperationException()
+    }
+
+    override fun bar(): Any? {
+        return super<A>.bar()
     }
 }

--- a/compiler/testData/diagnostics/tests/defaultArguments/superCall.txt
+++ b/compiler/testData/diagnostics/tests/defaultArguments/superCall.txt
@@ -1,22 +1,38 @@
 package
 
-public abstract class A {
+public abstract class A : I, EI {
     public constructor A()
-    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*2*/ /*fake_override*/ fun bar(): kotlin.Any?
+    public open override /*2*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
     public open fun foo(/*0*/ a: kotlin.String = ...): kotlin.Unit
     public final fun foo2(/*0*/ a: kotlin.String = ...): kotlin.Unit
     public abstract fun foo3(/*0*/ a: kotlin.String = ...): kotlin.Unit
-    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
-    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+    public open override /*2*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*2*/ /*fake_override*/ fun toString(): kotlin.String
 }
 
 public open class B : A {
     public constructor B()
+    public open override /*1*/ /*fake_override*/ fun bar(): kotlin.Any?
     public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
     public open override /*1*/ /*fake_override*/ fun foo(/*0*/ a: kotlin.String = ...): kotlin.Unit
     public final override /*1*/ /*fake_override*/ fun foo2(/*0*/ a: kotlin.String = ...): kotlin.Unit
     public open override /*1*/ fun foo3(/*0*/ a: kotlin.String = ...): kotlin.Unit
     public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
     public final fun test(): kotlin.Unit
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public interface EI : I {
+    public open override /*1*/ fun bar(): kotlin.Any?
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public interface I {
+    public abstract fun bar(): kotlin.Any?
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
     public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
 }


### PR DESCRIPTION
i.e., not reproducible.

`FirAbstractSuperCallChecker` is quite simple in the sense that it visits `super` reference and checks if the corresponding resolved callable member declaration is `abstract` or not: https://github.com/JetBrains/kotlin/blob/master/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/expression/FirAbstractSuperCallChecker.kt#L35

For the case mentioned in https://youtrack.jetbrains.com/issue/KT-42352, `super<AbstractKotlinUVariable>.getInitializer()` is resolved as `AbstractKotlinUVariable.getInitializer`, an `open` fake override, hence no report.