### PR TITLE
[JVM_IR] Use line number 1 for multifile bridge methods.

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/SMAP.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/SMAP.kt
@@ -84,15 +84,20 @@ class SourceMapper(val sourceInfo: SourceInfo?) {
     val resultMappings: List<FileMapping>
         get() = fileMappings.values.toList()
 
+    companion object {
+        const val FAKE_FILE_NAME = "fake.kt"
+        const val FAKE_PATH = "kotlin/jvm/internal/FakeKt"
+    }
+
     init {
         sourceInfo?.let { sourceInfo ->
-            // If 'sourceFileName' is null, this class doesn't have debug information
-            // (e.g., multi-file class facade with multiple parts).
-            sourceInfo.sourceFileName?.let { sourceFileName ->
-                // Explicitly map the file to itself -- we'll probably need a lot of lines from it, so this will produce fewer ranges.
-                getOrRegisterNewSource(sourceFileName, sourceInfo.pathOrCleanFQN)
-                    .mapNewInterval(1, 1, sourceInfo.linesInFile)
-            }
+            // If 'sourceFileName' is null we are dealing with a synthesized class
+            // (e.g., multi-file class facade with multiple parts). Such classes
+            // only have synthetic debug information and we use a fake file name.
+            val sourceFileName = sourceInfo.sourceFileName ?: FAKE_FILE_NAME
+            // Explicitly map the file to itself -- we'll probably need a lot of lines from it, so this will produce fewer ranges.
+            getOrRegisterNewSource(sourceFileName, sourceInfo.pathOrCleanFQN)
+                .mapNewInterval(1, 1, sourceInfo.linesInFile)
         }
     }
 
@@ -110,7 +115,7 @@ class SourceMapper(val sourceInfo: SourceInfo?) {
     }
 
     fun mapSyntheticLineNumber(id: Int): Int {
-        return mapLineNumber(SourcePosition(id, "fake.kt", "kotlin/jvm/internal/FakeKt"), null)
+        return mapLineNumber(SourcePosition(id, FAKE_FILE_NAME, FAKE_PATH), null)
     }
 }
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -213,6 +213,10 @@ class ExpressionCodegen(
     fun generate() {
         mv.visitCode()
         val startLabel = markNewLabel()
+        if (irFunction.origin == JvmLoweredDeclarationOrigin.MULTIFILE_BRIDGE) {
+            // Multifile bridges need to have line number 1 to be filtered out by the intellij debugging filters.
+            mv.visitLineNumber(1, startLabel)
+        }
         val info = BlockInfo()
         val body = irFunction.body!!
         generateNonNullAssertions()

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/irCodegenUtils.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/irCodegenUtils.kt
@@ -89,7 +89,6 @@ fun JvmBackendContext.getSourceMapper(declaration: IrClass): SourceMapper {
     val fileEntry = sourceManager.getFileEntry(declaration.fileParent)
     // NOTE: apparently inliner requires the source range to cover the
     //       whole file the class is declared in rather than the class only.
-    // TODO: revise
     val endLineNumber = when (fileEntry) {
         is MultifileFacadeFileEntry -> 0
         else -> fileEntry?.getSourceRangeInfo(0, fileEntry.maxOffset)?.endLineNumber ?: 0

--- a/idea/jvm-debugger/jvm-debugger-test/testData/stepping/filters/stepIntoMultiFileFacade.out
+++ b/idea/jvm-debugger/jvm-debugger-test/testData/stepping/filters/stepIntoMultiFileFacade.out
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 LineBreakpoint created at stepIntoMultiFileFacade.kt:6
 Run Java
 Connected to the target VM


### PR DESCRIPTION
This is necessary for the intellij debugger filters to hide
these bridges.

Fixes KT-41961.