### PR TITLE
[JVM_IR] Fix off-by-one line number error in CoroutineCodegen.

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/CoroutineCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/CoroutineCodegen.kt
@@ -55,12 +55,12 @@ internal fun MethodNode.acceptWithStateMachine(
         val irFile = irFunction.file
         if (irFunction.startOffset >= 0) {
             // if it suspend function like `suspend fun foo(...)`
-            irFile.fileEntry.getLineNumber(irFunction.startOffset)
+            irFile.fileEntry.getLineNumber(irFunction.startOffset) + 1
         } else {
             val klass = classCodegen.irClass
             if (klass.startOffset >= 0) {
                 // if it suspend lambda transformed into class `runSuspend { .... }`
-                irFile.fileEntry.getLineNumber(klass.startOffset)
+                irFile.fileEntry.getLineNumber(klass.startOffset) + 1
             } else 0
         }
     } else element?.let { CodegenUtil.getLineNumberForElement(it, false) } ?: 0

--- a/idea/jvm-debugger/jvm-debugger-test/testData/stepping/stepInto/stepIntoSuspendFunctionSimple.out
+++ b/idea/jvm-debugger/jvm-debugger-test/testData/stepping/stepInto/stepIntoSuspendFunctionSimple.out
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 LineBreakpoint created at stepIntoSuspendFunctionSimple.kt:20
 Run Java
 Connected to the target VM


### PR DESCRIPTION
Fixes KT-41957.