### PR TITLE
FIR CLI: initialize module and dependencies

### DIFF
--- a/compiler/testData/codegen/box/ranges/forInIndices/forInArrayListIndices.kt
+++ b/compiler/testData/codegen/box/ranges/forInIndices/forInArrayListIndices.kt
@@ -1,11 +1,31 @@
 // WITH_RUNTIME
 // KJS_WITH_FULL_RUNTIME
 
-fun box(): String {
+fun foo(): String {
     val a = ArrayList<String>()
     a.add("OK")
     for (i in a.indices) {
         return a[i]
     }
     return "Fail"
+}
+
+// KT-42642
+fun bar(): String {
+    val a = ArrayList<String>()
+    a.add("O")
+    a.add("K")
+    val map = mutableMapOf<String, String>().apply {
+        for (i in a.indices step 2) {
+            put(a[i].toLowerCase(), a[i])
+            put(a[i + 1].toLowerCase(), a[i + 1])
+        }
+    }
+    return map.values.joinToString(separator = "")
+}
+
+fun box(): String {
+    val r = foo()
+    if (r != "OK") return r
+    return bar()
 }


### PR DESCRIPTION
Otherwise, `getProgressionLastElement` from built-ins is not found.

Note that https://github.com/JetBrains/kotlin/pull/3228 did for test set up, and we should have added the same set up for CLI.

Running full pipeline tests with the filter `.*metadata.*` shows:
```
SUCCESSFUL MODULES
------------------

metadata.main: main-java-production, 12 files (589 lines)
metadata.jvm.main: main-java-production, 11 files (893 lines)

...

SUCCESSFUL MODULES
------------------

metadata.main: main-java-production, 12 files (589 lines)
metadata.jvm.main: main-java-production, 11 files (893 lines)
```