### PR TITLE
[JVM_IR] Copy offsets from the original function to invokeSuspend.

### DIFF
--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/ir/builders/declarations/declarationBuilders.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/ir/builders/declarations/declarationBuilders.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.ir.builders.declarations
 import org.jetbrains.kotlin.backend.common.descriptors.synthesizedName
 import org.jetbrains.kotlin.backend.common.ir.copyTo
 import org.jetbrains.kotlin.descriptors.*
+import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrVariableImpl
 import org.jetbrains.kotlin.ir.declarations.lazy.IrLazyFunction
@@ -168,9 +169,13 @@ fun IrClass.addFunction(
         isStatic: Boolean = false,
         isSuspend: Boolean = false,
         isFakeOverride: Boolean = false,
-        origin: IrDeclarationOrigin = IrDeclarationOrigin.DEFINED
+        origin: IrDeclarationOrigin = IrDeclarationOrigin.DEFINED,
+        startOffset: Int = UNDEFINED_OFFSET,
+        endOffset: Int = UNDEFINED_OFFSET
 ): IrSimpleFunction =
     addFunction {
+        this.startOffset = startOffset
+        this.endOffset = endOffset
         this.name = Name.identifier(name)
         this.returnType = returnType
         this.modality = modality

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/AddContinuationLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/AddContinuationLowering.kt
@@ -155,7 +155,7 @@ private class AddContinuationLowering(context: JvmBackendContext) : SuspendLower
         val backendContext = context
         val invokeSuspend = context.ir.symbols.continuationImplClass.owner.functions
             .single { it.name == Name.identifier(INVOKE_SUSPEND_METHOD_NAME) }
-        addFunctionOverride(invokeSuspend) { function ->
+        addFunctionOverride(invokeSuspend, irFunction.startOffset, irFunction.endOffset) { function ->
             +irSetField(irGet(function.dispatchReceiverParameter!!), resultField, irGet(function.valueParameters[0]))
             // There can be three kinds of suspend function call:
             // 1) direct call from another suspend function/lambda

--- a/idea/jvm-debugger/jvm-debugger-test/testData/stepping/stepOver/coroutines/sequenceNested.out
+++ b/idea/jvm-debugger/jvm-debugger-test/testData/stepping/stepOver/coroutines/sequenceNested.out
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 LineBreakpoint created at sequenceNested.kt:6
 Run Java
 Connected to the target VM

--- a/idea/jvm-debugger/jvm-debugger-test/testData/stepping/stepOver/coroutines/sequenceNested2.ir.out
+++ b/idea/jvm-debugger/jvm-debugger-test/testData/stepping/stepOver/coroutines/sequenceNested2.ir.out
@@ -7,6 +7,7 @@ sequenceNested2.kt:10
 sequenceNested2.kt:11
 sequenceNested2.kt:23
 sequenceNested2.kt:23
+sequenceNested2.kt:23
 sequenceNested2.kt:24
 Disconnected from the target VM
 

--- a/idea/jvm-debugger/jvm-debugger-test/testData/stepping/stepOver/coroutines/sequenceSimple.out
+++ b/idea/jvm-debugger/jvm-debugger-test/testData/stepping/stepOver/coroutines/sequenceSimple.out
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 LineBreakpoint created at sequenceSimple.kt:6
 Run Java
 Connected to the target VM

--- a/idea/jvm-debugger/jvm-debugger-test/testData/stepping/stepOver/soSuspendableCallInEndOfFun.out
+++ b/idea/jvm-debugger/jvm-debugger-test/testData/stepping/stepOver/soSuspendableCallInEndOfFun.out
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 LineBreakpoint created at soSuspendableCallInEndOfFun.kt:29
 Run Java
 Connected to the target VM


### PR DESCRIPTION
Otherwise, implicit returns in void returning suspend functions
will not have the line number of the end brace.

Fixes KT-41962 and KT-40464.