### PR TITLE
[JVM] Fix the nop removal optimization.

### DIFF
--- a/compiler/testData/codegen/bytecodeText/coercionToUnitOptimization/nopInlineFuns.kt
+++ b/compiler/testData/codegen/bytecodeText/coercionToUnitOptimization/nopInlineFuns.kt
@@ -23,4 +23,4 @@ fun simpleFunVoid(f: () -> Unit): Unit {
     return f()
 }
 
-// 3 NOP
+// 0 NOP

--- a/idea/jvm-debugger/jvm-debugger-test/testData/stepping/stepOut/fwBackingField.out
+++ b/idea/jvm-debugger/jvm-debugger-test/testData/stepping/stepOut/fwBackingField.out
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 KotlinFieldBreakpoint created at fwBackingField.kt:5
 KotlinFieldBreakpoint created at fwBackingField.kt:8
 KotlinFieldBreakpoint created at fwBackingField.kt:18

--- a/idea/jvm-debugger/jvm-debugger-test/testData/stepping/stepOver/stepOverInlinedLambdaStdlib.out
+++ b/idea/jvm-debugger/jvm-debugger-test/testData/stepping/stepOver/stepOverInlinedLambdaStdlib.out
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_IR
 LineBreakpoint created at stepOverInlinedLambdaStdlib.kt:5
 Run Java
 Connected to the target VM

--- a/tests/mute-common.csv
+++ b/tests/mute-common.csv
@@ -48,7 +48,6 @@ org.jetbrains.kotlin.util.KotlinVersionsTest.testVersionsAreConsistent, KT-35567
 org.jetbrains.kotlin.jvm.compiler.CompileKotlinAgainstJavaTestGenerated.WithAPT.testClassWithTypeParameter, KT-36448,,
 org.jetbrains.kotlin.jvm.compiler.CompileKotlinAgainstJavaTestGenerated.WithoutAPT.testClassWithTypeParameter, KT-36448,,
 org.jetbrains.kotlin.idea.debugger.test.AsyncStackTraceTestGenerated.testAsyncLambdas, redesign test AsyncStackTraces,,
-org.jetbrains.kotlin.idea.debugger.test.KotlinSteppingTestGenerated.StepOver.testStepOverInlinedLambdaStdlib, fails after advancing bootstrap KT-37879,,
 org.jetbrains.kotlin.incremental.IncrementalJsKlibCompilerRunnerTestGenerated.ClassHierarchyAffected.testMethodRemoved, full fledged FO in klib required,,
 org.jetbrains.kotlin.idea.quickfix.QuickFixTestGenerated.ConvertToAnonymousObject.testHasConcreateMember2, Unprocessed,,
 org.jetbrains.uast.test.kotlin.KotlinUastTypesTest.testEa101715, Unprocessed,,


### PR DESCRIPTION
Never remove a nop if that would cause a line number to move
across a local lifetime boundary.

This fixes KT-42725.