### PR TITLE
JVM_IR: generate shorter names for classes in delegate initializers

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/InventNamesForLocalClasses.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/InventNamesForLocalClasses.kt
@@ -87,15 +87,13 @@ class InventNamesForLocalClasses(private val context: JvmBackendContext) : FileL
         }
 
         override fun visitDeclaration(declaration: IrDeclarationBase, data: Data) {
-            if (declaration !is IrDeclarationWithName) {
-                declaration.acceptChildren(this, data)
-                return
-            }
-
-            // We explicitly skip temporary variables (such as a for loop iterator, or a temporary value for an elvis operator)
-            // because they are not present in the original source code and their names should not affect names of local entities.
-            if (declaration.origin == IrDeclarationOrigin.FOR_LOOP_ITERATOR ||
-                declaration.origin == IrDeclarationOrigin.IR_TEMPORARY_VARIABLE
+            if (declaration !is IrDeclarationWithName ||
+                // Skip temporary variables because they are not present in source code, and their names are not particularly
+                // meaningful (e.g. `tmp$1`) in any case.
+                declaration.origin == IrDeclarationOrigin.FOR_LOOP_ITERATOR ||
+                declaration.origin == IrDeclarationOrigin.IR_TEMPORARY_VARIABLE ||
+                // Skip variables storing delegates for local properties because we already have the name of the property itself.
+                declaration.origin == IrDeclarationOrigin.PROPERTY_DELEGATE
             ) {
                 declaration.acceptChildren(this, data)
                 return
@@ -117,7 +115,7 @@ class InventNamesForLocalClasses(private val context: JvmBackendContext) : FileL
             }
 
             val newData = data.withName(internalName).makeLocal()
-            if (declaration is IrProperty && declaration.isDelegated) {
+            if ((declaration is IrProperty && declaration.isDelegated) || declaration is IrLocalDelegatedProperty) {
                 // Old backend currently reserves a name here, in case a property reference-like anonymous object will need
                 // to be generated in the codegen later, which is now happening for local delegated properties in inline functions.
                 // See CodegenAnnotatingVisitor.visitProperty and ExpressionCodegen.initializePropertyMetadata.

--- a/compiler/testData/checkLocalVariablesTable/objectInLocalPropertyDelegate.kt
+++ b/compiler/testData/checkLocalVariablesTable/objectInLocalPropertyDelegate.kt
@@ -1,0 +1,8 @@
+operator fun (() -> String).getValue(thisRef: Any?, property: Any?) = this()
+
+fun foo() {
+    val prop by { "OK" }
+}
+
+// METHOD : ObjectInLocalPropertyDelegateKt$foo$prop$2.invoke()Ljava/lang/String;
+// VARIABLE : NAME=this TYPE=LObjectInLocalPropertyDelegateKt$foo$prop$2; INDEX=0

--- a/compiler/tests/org/jetbrains/kotlin/codegen/CheckLocalVariablesTableTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/CheckLocalVariablesTableTestGenerated.java
@@ -109,6 +109,11 @@ public class CheckLocalVariablesTableTestGenerated extends AbstractCheckLocalVar
         runTest("compiler/testData/checkLocalVariablesTable/localFun.kt");
     }
 
+    @TestMetadata("objectInLocalPropertyDelegate.kt")
+    public void testObjectInLocalPropertyDelegate() throws Exception {
+        runTest("compiler/testData/checkLocalVariablesTable/objectInLocalPropertyDelegate.kt");
+    }
+
     @TestMetadata("receiverParameter.kt")
     public void testReceiverParameter() throws Exception {
         runTest("compiler/testData/checkLocalVariablesTable/receiverParameter.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrCheckLocalVariablesTableTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrCheckLocalVariablesTableTestGenerated.java
@@ -109,6 +109,11 @@ public class IrCheckLocalVariablesTableTestGenerated extends AbstractIrCheckLoca
         runTest("compiler/testData/checkLocalVariablesTable/localFun.kt");
     }
 
+    @TestMetadata("objectInLocalPropertyDelegate.kt")
+    public void testObjectInLocalPropertyDelegate() throws Exception {
+        runTest("compiler/testData/checkLocalVariablesTable/objectInLocalPropertyDelegate.kt");
+    }
+
     @TestMetadata("receiverParameter.kt")
     public void testReceiverParameter() throws Exception {
         runTest("compiler/testData/checkLocalVariablesTable/receiverParameter.kt");


### PR DESCRIPTION
 #KT-41493 Fixed