### PR TITLE
kotlin.native.cocoapods.targets can be a custom list of architectures

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/CocoaPodsIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/CocoaPodsIT.kt
@@ -1259,7 +1259,7 @@ class CocoaPodsIT : BaseGradleIT() {
                                 set -ev
                                 REPO_ROOT="${'$'}PODS_TARGET_SRCROOT"
                                 "${'$'}REPO_ROOT/../gradlew" -p "${'$'}REPO_ROOT" :kotlin-library:syncFramework \
-                                    -Pkotlin.native.cocoapods.targets=${'$'}KOTLIN_TARGET \
+                                    -Pkotlin.native.cocoapods.target=${'$'}KOTLIN_TARGET \
                                     -Pkotlin.native.cocoapods.configuration=${'$'}CONFIGURATION \
                                     -Pkotlin.native.cocoapods.cflags="${'$'}OTHER_CFLAGS" \
                                     -Pkotlin.native.cocoapods.paths.headers="${'$'}HEADER_SEARCH_PATHS" \
@@ -1301,7 +1301,7 @@ class CocoaPodsIT : BaseGradleIT() {
                                 set -ev
                                 REPO_ROOT="${'$'}PODS_TARGET_SRCROOT"
                                 "${'$'}REPO_ROOT/../gradlew" -p "${'$'}REPO_ROOT" :second-library:syncFramework \
-                                    -Pkotlin.native.cocoapods.targets=${'$'}KOTLIN_TARGET \
+                                    -Pkotlin.native.cocoapods.target=${'$'}KOTLIN_TARGET \
                                     -Pkotlin.native.cocoapods.configuration=${'$'}CONFIGURATION \
                                     -Pkotlin.native.cocoapods.cflags="${'$'}OTHER_CFLAGS" \
                                     -Pkotlin.native.cocoapods.paths.headers="${'$'}HEADER_SEARCH_PATHS" \

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/CocoaPodsIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/CocoaPodsIT.kt
@@ -1259,7 +1259,7 @@ class CocoaPodsIT : BaseGradleIT() {
                                 set -ev
                                 REPO_ROOT="${'$'}PODS_TARGET_SRCROOT"
                                 "${'$'}REPO_ROOT/../gradlew" -p "${'$'}REPO_ROOT" :kotlin-library:syncFramework \
-                                    -Pkotlin.native.cocoapods.target=${'$'}KOTLIN_TARGET \
+                                    -Pkotlin.native.cocoapods.targets=${'$'}KOTLIN_TARGET \
                                     -Pkotlin.native.cocoapods.configuration=${'$'}CONFIGURATION \
                                     -Pkotlin.native.cocoapods.cflags="${'$'}OTHER_CFLAGS" \
                                     -Pkotlin.native.cocoapods.paths.headers="${'$'}HEADER_SEARCH_PATHS" \
@@ -1301,7 +1301,7 @@ class CocoaPodsIT : BaseGradleIT() {
                                 set -ev
                                 REPO_ROOT="${'$'}PODS_TARGET_SRCROOT"
                                 "${'$'}REPO_ROOT/../gradlew" -p "${'$'}REPO_ROOT" :second-library:syncFramework \
-                                    -Pkotlin.native.cocoapods.target=${'$'}KOTLIN_TARGET \
+                                    -Pkotlin.native.cocoapods.targets=${'$'}KOTLIN_TARGET \
                                     -Pkotlin.native.cocoapods.configuration=${'$'}CONFIGURATION \
                                     -Pkotlin.native.cocoapods.cflags="${'$'}OTHER_CFLAGS" \
                                     -Pkotlin.native.cocoapods.paths.headers="${'$'}HEADER_SEARCH_PATHS" \

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/native/cocoapods/KotlinCocoapodsPlugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/native/cocoapods/KotlinCocoapodsPlugin.kt
@@ -189,15 +189,16 @@ open class KotlinCocoapodsPlugin : Plugin<Project> {
         project: Project,
         kotlinExtension: KotlinMultiplatformExtension
     ) = project.whenEvaluated {
-        val requestedTargetName = project.findProperty(TARGET_PROPERTY)?.toString() ?: return@whenEvaluated
+        val requestedTargetNames = project.findProperty(TARGET_PROPERTY)?.toString() ?: return@whenEvaluated
         val requestedBuildType = project.findProperty(CONFIGURATION_PROPERTY)?.toString()?.toUpperCase() ?: return@whenEvaluated
 
         // We create a fat framework only for device platforms which have several
         // device architectures: iosArm64, iosArm32, watchosArm32 and watchosArm64.
-        val frameworkPlatforms: List<KonanTarget> = when (requestedTargetName) {
+        val frameworkPlatforms: List<KonanTarget> = when (requestedTargetNames) {
             KOTLIN_TARGET_FOR_IOS_DEVICE -> listOf(IOS_ARM64, IOS_ARM32)
             KOTLIN_TARGET_FOR_WATCHOS_DEVICE -> listOf(WATCHOS_ARM32, WATCHOS_ARM64)
-            else -> listOf(HostManager().targetByName(requestedTargetName)) // A requested target doesn't require building a fat framework.
+            // A request parameter can be comma separated list of targets.
+            else -> requestedTargetNames.split(",").map { HostManager().targetByName(it) }.toList()
         }
 
         val frameworkTargets = frameworkPlatforms.flatMap { kotlinExtension.targetsForPlatform(it) }
@@ -565,7 +566,7 @@ open class KotlinCocoapodsPlugin : Plugin<Project> {
 
         // We don't move these properties in PropertiesProvider because
         // they are not intended to be overridden in local.properties.
-        const val TARGET_PROPERTY = "kotlin.native.cocoapods.target"
+        const val TARGET_PROPERTY = "kotlin.native.cocoapods.targets"
         const val CONFIGURATION_PROPERTY = "kotlin.native.cocoapods.configuration"
 
         const val CFLAGS_PROPERTY = "kotlin.native.cocoapods.cflags"

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/native/cocoapods/KotlinCocoapodsPlugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/native/cocoapods/KotlinCocoapodsPlugin.kt
@@ -189,16 +189,16 @@ open class KotlinCocoapodsPlugin : Plugin<Project> {
         project: Project,
         kotlinExtension: KotlinMultiplatformExtension
     ) = project.whenEvaluated {
-        val requestedTargetNames = project.findProperty(TARGET_PROPERTY)?.toString() ?: return@whenEvaluated
+        val requestedTargetName = project.findProperty(TARGET_PROPERTY)?.toString() ?: return@whenEvaluated
         val requestedBuildType = project.findProperty(CONFIGURATION_PROPERTY)?.toString()?.toUpperCase() ?: return@whenEvaluated
 
         // We create a fat framework only for device platforms which have several
         // device architectures: iosArm64, iosArm32, watchosArm32 and watchosArm64.
-        val frameworkPlatforms: List<KonanTarget> = when (requestedTargetNames) {
+        val frameworkPlatforms: List<KonanTarget> = when (requestedTargetName) {
             KOTLIN_TARGET_FOR_IOS_DEVICE -> listOf(IOS_ARM64, IOS_ARM32)
             KOTLIN_TARGET_FOR_WATCHOS_DEVICE -> listOf(WATCHOS_ARM32, WATCHOS_ARM64)
             // A request parameter can be comma separated list of targets.
-            else -> requestedTargetNames.split(",").map { HostManager().targetByName(it) }.toList()
+            else -> requestedTargetName.split(",").map { HostManager().targetByName(it) }.toList()
         }
 
         val frameworkTargets = frameworkPlatforms.flatMap { kotlinExtension.targetsForPlatform(it) }
@@ -566,7 +566,7 @@ open class KotlinCocoapodsPlugin : Plugin<Project> {
 
         // We don't move these properties in PropertiesProvider because
         // they are not intended to be overridden in local.properties.
-        const val TARGET_PROPERTY = "kotlin.native.cocoapods.targets"
+        const val TARGET_PROPERTY = "kotlin.native.cocoapods.target"
         const val CONFIGURATION_PROPERTY = "kotlin.native.cocoapods.configuration"
 
         const val CFLAGS_PROPERTY = "kotlin.native.cocoapods.cflags"


### PR DESCRIPTION
As sdk developers we would like to have possibility to specify a concrete list of architectures to build as fat framework. When clients of ours would like to use the framework they need to be able to run it on both iPhone and Simulator.

Therefore in this PR I am proposing a change that allows to dynamically specify a list of architectures with comma separated manner. Rest of the functionality stays untouched, meaning user still can provide just one target if they wish.