### PR TITLE
FIR CFG: revise edge kind between local func node and fun enter node

### DIFF
--- a/compiler/fir/analysis-tests/testData/resolveWithStdlib/contracts/fromSource/bad/callsInPlace/inLocalFunction.dot
+++ b/compiler/fir/analysis-tests/testData/resolveWithStdlib/contracts/fromSource/bad/callsInPlace/inLocalFunction.dot
@@ -31,8 +31,7 @@ digraph inLocalFunction_kt {
     }
     0 -> {1};
     1 -> {2};
-    2 -> {3};
-    2 -> {7} [color=red];
+    2 -> {7 3};
     2 -> {7} [style=dashed];
     3 -> {4};
     4 -> {5};

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/dfa/cfg/ControlFlowGraphBuilder.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/dfa/cfg/ControlFlowGraphBuilder.kt
@@ -192,7 +192,11 @@ class ControlFlowGraphBuilder {
         }
 
         if (previousNode != null) {
-            addEdge(previousNode, enterNode, preferredKind = EdgeKind.DfgForward)
+            if (localFunctionNode == previousNode) {
+                addEdge(localFunctionNode, enterNode, preferredKind = EdgeKind.Forward)
+            } else {
+                addEdge(previousNode, enterNode, preferredKind = EdgeKind.DfgForward)
+            }
         }
 
         createFunctionExitNode(function).also {

--- a/compiler/testData/diagnostics/tests/controlFlowAnalysis/assignedInIfElse.kt
+++ b/compiler/testData/diagnostics/tests/controlFlowAnalysis/assignedInIfElse.kt
@@ -14,4 +14,8 @@ fun foo(arg: Boolean) {
             x.hashCode()
         }
     }
+
+    fun local(): Int {
+        return x.hashCode()
+    }
 }


### PR DESCRIPTION
so that local function enter node can be visited by FIR CFA

The motivation is https://youtrack.jetbrains.com/issue/KT-42814:
```kt
fun foo(arg: Boolean) {
    val callToUse: Int
    if (arg) {
        callToUse = 1
    } else {
        callToUse = 2
    }

    fun local(): Int {
        return <!UNINITIALIZED_VARIABLE!>callToUse<!>
    }
}
```

which is quite similar to https://youtrack.jetbrains.com/issue/KT-42348

The only difference is, the function inside a local class has an incoming edge from the end of the previous expression, along with `CfgForward` kind, whereas the local function has an incoming edge with `DfgForward` kind, which prevents CFA from picking up that edge and legitimate incoming flow.

Similar to the local class exit node, which acts like a `CfgForward` entrance towards function enter, the local function declaration node should act like that. The caveat is, it could be already connected as `DfgForward` if that's the last node on the stack. Instead, we can use `Forward` kind so that it can be used at both of DFA and CFA.