### PR TITLE
[FIR] fix KT-42825

### DIFF
--- a/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
@@ -16036,6 +16036,11 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
                 runTest("compiler/testData/codegen/box/javaInterop/generics/javaNestedSamInterface.kt");
             }
 
+            @TestMetadata("kt42825.kt")
+            public void testKt42825() throws Exception {
+                runTest("compiler/testData/codegen/box/javaInterop/generics/kt42825.kt");
+            }
+
             @TestMetadata("propertyVarianceConflict.kt")
             public void testPropertyVarianceConflict() throws Exception {
                 runTest("compiler/testData/codegen/box/javaInterop/generics/propertyVarianceConflict.kt");

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/types/IrTypeCheckerContext.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/types/IrTypeCheckerContext.kt
@@ -39,6 +39,13 @@ open class IrTypeCheckerContext(override val irBuiltIns: IrBuiltIns) : IrTypeSys
     ): AbstractTypeCheckerContext = IrTypeCheckerContext(irBuiltIns)
 
     override fun KotlinTypeMarker.isUninferredParameter(): Boolean = false
+    override fun KotlinTypeMarker.withNullability(nullable: Boolean): KotlinTypeMarker {
+        if (this.isSimpleType()) {
+            return this.asSimpleType()!!.withNullability(nullable)
+        } else {
+            error("withNullability for non-simple types is not supported in IR")
+        }
+    }
 
     override fun captureFromExpression(type: KotlinTypeMarker): KotlinTypeMarker? =
         error("Captured type is unsupported in IR")

--- a/compiler/testData/codegen/box/javaInterop/generics/kt42825.kt
+++ b/compiler/testData/codegen/box/javaInterop/generics/kt42825.kt
@@ -1,0 +1,23 @@
+// FILE: Processor.java
+
+public interface Processor<T> {
+    boolean process(T t);
+}
+
+// FILE: test.kt
+
+interface PsiModifierListOwner
+interface KtClassOrObject {
+    fun toLightClass(): PsiModifierListOwner?
+}
+
+fun execute(declaration: Any, consumer: Processor<in PsiModifierListOwner>) {
+    when (declaration) {
+        is KtClassOrObject -> {
+            val lightClass = declaration.toLightClass()
+            consumer.process(lightClass)
+        }
+    }
+}
+
+fun box(): String = "OK"

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -17436,6 +17436,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
                 runTest("compiler/testData/codegen/box/javaInterop/generics/javaNestedSamInterface.kt");
             }
 
+            @TestMetadata("kt42825.kt")
+            public void testKt42825() throws Exception {
+                runTest("compiler/testData/codegen/box/javaInterop/generics/kt42825.kt");
+            }
+
             @TestMetadata("propertyVarianceConflict.kt")
             public void testPropertyVarianceConflict() throws Exception {
                 runTest("compiler/testData/codegen/box/javaInterop/generics/propertyVarianceConflict.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -17436,6 +17436,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
                 runTest("compiler/testData/codegen/box/javaInterop/generics/javaNestedSamInterface.kt");
             }
 
+            @TestMetadata("kt42825.kt")
+            public void testKt42825() throws Exception {
+                runTest("compiler/testData/codegen/box/javaInterop/generics/kt42825.kt");
+            }
+
             @TestMetadata("propertyVarianceConflict.kt")
             public void testPropertyVarianceConflict() throws Exception {
                 runTest("compiler/testData/codegen/box/javaInterop/generics/propertyVarianceConflict.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -16036,6 +16036,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
                 runTest("compiler/testData/codegen/box/javaInterop/generics/javaNestedSamInterface.kt");
             }
 
+            @TestMetadata("kt42825.kt")
+            public void testKt42825() throws Exception {
+                runTest("compiler/testData/codegen/box/javaInterop/generics/kt42825.kt");
+            }
+
             @TestMetadata("propertyVarianceConflict.kt")
             public void testPropertyVarianceConflict() throws Exception {
                 runTest("compiler/testData/codegen/box/javaInterop/generics/propertyVarianceConflict.kt");

--- a/core/compiler.common/src/org/jetbrains/kotlin/types/AbstractTypeChecker.kt
+++ b/core/compiler.common/src/org/jetbrains/kotlin/types/AbstractTypeChecker.kt
@@ -407,9 +407,15 @@ object AbstractTypeChecker {
         val superTypeCaptured = superType.asCapturedType()
         val lowerType = superTypeCaptured?.lowerType()
         if (superTypeCaptured != null && lowerType != null) {
+            // If superType is nullable, e.g., to check if Foo? a subtype of Captured<in Foo>?, we check the LHS, Foo?,
+            // against the nullable version of the lower type of RHS. See KT-42825
+            val nullableLowerType =
+                if (superType.isMarkedNullable())
+                    lowerType.withNullability(true)
+                else lowerType
             when (getLowerCapturedTypePolicy(subType, superTypeCaptured)) {
-                CHECK_ONLY_LOWER -> return isSubtypeOf(this, subType, lowerType)
-                CHECK_SUBTYPE_AND_LOWER -> if (isSubtypeOf(this, subType, lowerType)) return true
+                CHECK_ONLY_LOWER -> return isSubtypeOf(this, subType, nullableLowerType)
+                CHECK_SUBTYPE_AND_LOWER -> if (isSubtypeOf(this, subType, nullableLowerType)) return true
                 SKIP_LOWER -> Unit
             }
         }

--- a/core/compiler.common/src/org/jetbrains/kotlin/types/model/TypeSystemContext.kt
+++ b/core/compiler.common/src/org/jetbrains/kotlin/types/model/TypeSystemContext.kt
@@ -144,9 +144,6 @@ interface TypeSystemInferenceExtensionContext : TypeSystemContext, TypeSystemBui
 
     fun KotlinTypeMarker.isBuiltinFunctionalTypeOrSubtype(): Boolean
 
-    fun KotlinTypeMarker.withNullability(nullable: Boolean): KotlinTypeMarker
-
-
     fun KotlinTypeMarker.makeDefinitelyNotNullOrNotNull(): KotlinTypeMarker
     fun SimpleTypeMarker.makeSimpleTypeDefinitelyNotNullOrNotNull(): SimpleTypeMarker
 
@@ -241,7 +238,6 @@ interface TypeSystemContext : TypeSystemOptimizationContext {
     fun KotlinTypeMarker.isError(): Boolean
     fun TypeConstructorMarker.isError(): Boolean
     fun KotlinTypeMarker.isUninferredParameter(): Boolean
-
     fun FlexibleTypeMarker.asDynamicType(): DynamicTypeMarker?
 
     fun FlexibleTypeMarker.asRawType(): RawTypeMarker?
@@ -259,6 +255,7 @@ interface TypeSystemContext : TypeSystemOptimizationContext {
 
     fun SimpleTypeMarker.withNullability(nullable: Boolean): SimpleTypeMarker
     fun SimpleTypeMarker.typeConstructor(): TypeConstructorMarker
+    fun KotlinTypeMarker.withNullability(nullable: Boolean): KotlinTypeMarker
 
     fun CapturedTypeMarker.typeConstructor(): CapturedTypeConstructorMarker
     fun CapturedTypeMarker.captureStatus(): CaptureStatus

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
@@ -13890,6 +13890,11 @@ public class IrJsCodegenBoxES6TestGenerated extends AbstractIrJsCodegenBoxES6Tes
             public void testAllFilesPresentInGenerics() throws Exception {
                 KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/javaInterop/generics"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR_ES6, true);
             }
+
+            @TestMetadata("kt42825.kt")
+            public void testKt42825() throws Exception {
+                runTest("compiler/testData/codegen/box/javaInterop/generics/kt42825.kt");
+            }
         }
 
         @TestMetadata("compiler/testData/codegen/box/javaInterop/notNullAssertions")

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -13890,6 +13890,11 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             public void testAllFilesPresentInGenerics() throws Exception {
                 KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/javaInterop/generics"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR, true);
             }
+
+            @TestMetadata("kt42825.kt")
+            public void testKt42825() throws Exception {
+                runTest("compiler/testData/codegen/box/javaInterop/generics/kt42825.kt");
+            }
         }
 
         @TestMetadata("compiler/testData/codegen/box/javaInterop/notNullAssertions")

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -13955,6 +13955,11 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             public void testAllFilesPresentInGenerics() throws Exception {
                 KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/javaInterop/generics"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS, true);
             }
+
+            @TestMetadata("kt42825.kt")
+            public void testKt42825() throws Exception {
+                runTest("compiler/testData/codegen/box/javaInterop/generics/kt42825.kt");
+            }
         }
 
         @TestMetadata("compiler/testData/codegen/box/javaInterop/notNullAssertions")


### PR DESCRIPTION
The issue is the type checker doesn't consider P? a subtype of
CapturedType<in P>?, whereas P a subtype of CapturedType<in P>?. In
AbstractTypeCheckerContext::checkSubtypeForSpecialCases, it checks if
P? is a subtype of the lower type of the captured type, which is
CapturedType<in P>, and returns false.

This fix uses non-nullable version of the type to check in the case of
CapturedType.