### PR TITLE
[JVM_IR] Determine correct type of empty varargs array.

### DIFF
--- a/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxAgainstJavaCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxAgainstJavaCodegenTestGenerated.java
@@ -1066,6 +1066,34 @@ public class FirBlackBoxAgainstJavaCodegenTestGenerated extends AbstractFirBlack
         }
     }
 
+    @TestMetadata("compiler/testData/codegen/boxAgainstJava/varargs")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class Varargs extends AbstractFirBlackBoxAgainstJavaCodegenTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTestWithCustomIgnoreDirective(this::doTest, TargetBackend.JVM_IR, testDataFilePath, "// IGNORE_BACKEND_FIR: ");
+        }
+
+        public void testAllFilesPresentInVarargs() throws Exception {
+            KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/boxAgainstJava/varargs"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+        }
+
+        @TestMetadata("varargsOverride.kt")
+        public void testVarargsOverride() throws Exception {
+            runTest("compiler/testData/codegen/boxAgainstJava/varargs/varargsOverride.kt");
+        }
+
+        @TestMetadata("varargsOverride2.kt")
+        public void testVarargsOverride2() throws Exception {
+            runTest("compiler/testData/codegen/boxAgainstJava/varargs/varargsOverride2.kt");
+        }
+
+        @TestMetadata("varargsOverride3.kt")
+        public void testVarargsOverride3() throws Exception {
+            runTest("compiler/testData/codegen/boxAgainstJava/varargs/varargsOverride3.kt");
+        }
+    }
+
     @TestMetadata("compiler/testData/codegen/boxAgainstJava/visibility")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/FunctionReferenceLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/FunctionReferenceLowering.kt
@@ -401,8 +401,8 @@ internal class FunctionReferenceLowering(private val context: JvmBackendContext)
             body = context.createJvmIrBuilder(symbol, startOffset, endOffset).run {
                 var unboundIndex = 0
                 irExprBody(irCall(callee).apply {
-                    for ((typeParameter, typeArgument) in typeArgumentsMap) {
-                        putTypeArgument(typeParameter.owner.index, typeArgument)
+                    for (typeParameter in irFunctionReference.symbol.owner.allTypeParameters) {
+                        putTypeArgument(typeParameter.index, typeArgumentsMap[typeParameter.symbol])
                     }
 
                     for (parameter in callee.explicitParameters) {

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/types/IrTypeSystemContext.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/types/IrTypeSystemContext.kt
@@ -389,7 +389,6 @@ fun extractTypeParameters(klass: IrDeclarationParent): List<IrTypeParameter> {
     val result = mutableListOf<IrTypeParameter>()
     var current: IrDeclarationParent? = klass
     while (current != null) {
-//        result += current.typeParameters
         (current as? IrTypeParametersContainer)?.let { result += it.typeParameters }
         current =
             when (current) {

--- a/compiler/testData/codegen/boxAgainstJava/varargs/varargsOverride.kt
+++ b/compiler/testData/codegen/boxAgainstJava/varargs/varargsOverride.kt
@@ -1,0 +1,18 @@
+// FILE: A.java
+
+public abstract class A<T> {
+    protected abstract String doIt(T... args);
+
+    public String test(T... args) {
+        return doIt(args);
+    }
+}
+
+// FILE: 1.kt
+
+val a: A<Void> =
+    object : A<Void>() {
+        override fun doIt(vararg parameters: Void): String = "OK"
+    }
+
+fun box(): String = a.test()

--- a/compiler/testData/codegen/boxAgainstJava/varargs/varargsOverride2.kt
+++ b/compiler/testData/codegen/boxAgainstJava/varargs/varargsOverride2.kt
@@ -1,0 +1,21 @@
+// FILE: A.java
+
+public abstract class A<T> {
+    protected abstract String doIt(T... args);
+
+    public <S extends T> String test(S... args) {
+        return doIt(args);
+    }
+}
+
+// FILE: 1.kt
+
+open class Super
+class Sub: Super()
+
+val a: A<Super> =
+    object : A<Super>() {
+        override fun doIt(vararg parameters: Super): String = "OK"
+    }
+
+fun box(): String = a.test<Sub>()

--- a/compiler/testData/codegen/boxAgainstJava/varargs/varargsOverride3.kt
+++ b/compiler/testData/codegen/boxAgainstJava/varargs/varargsOverride3.kt
@@ -1,0 +1,37 @@
+// FILE: A.java
+
+public abstract class A<T> {
+    protected abstract String doIt(T... args);
+
+    class B<S extends T, U extends S> {
+        public String test(T... args) {
+            return doIt(args);
+        }
+
+        public String test2(S... args) {
+            return doIt(args);
+        }
+
+        public String test3(U... args) {
+            return doIt(args);
+        }
+    }
+}
+
+// FILE: 1.kt
+
+open class Super
+open class Sub: Super()
+class Sub2: Sub()
+
+val a: A<Super> =
+    object : A<Super>() {
+        override fun doIt(vararg parameters: Super): String = "OK"
+    }
+
+fun box(): String {
+    val b = a.B<Sub, Sub2>()
+    if (b.test() != "OK") return "FAIL1"
+    if (b.test2() != "OK") return "FAIL2"
+    return b.test3()
+}

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxAgainstJavaCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxAgainstJavaCodegenTestGenerated.java
@@ -1096,6 +1096,34 @@ public class BlackBoxAgainstJavaCodegenTestGenerated extends AbstractBlackBoxAga
         }
     }
 
+    @TestMetadata("compiler/testData/codegen/boxAgainstJava/varargs")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class Varargs extends AbstractBlackBoxAgainstJavaCodegenTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
+        }
+
+        public void testAllFilesPresentInVarargs() throws Exception {
+            KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/boxAgainstJava/varargs"), Pattern.compile("^(.+)\\.kt$"), null, true);
+        }
+
+        @TestMetadata("varargsOverride.kt")
+        public void testVarargsOverride() throws Exception {
+            runTest("compiler/testData/codegen/boxAgainstJava/varargs/varargsOverride.kt");
+        }
+
+        @TestMetadata("varargsOverride2.kt")
+        public void testVarargsOverride2() throws Exception {
+            runTest("compiler/testData/codegen/boxAgainstJava/varargs/varargsOverride2.kt");
+        }
+
+        @TestMetadata("varargsOverride3.kt")
+        public void testVarargsOverride3() throws Exception {
+            runTest("compiler/testData/codegen/boxAgainstJava/varargs/varargsOverride3.kt");
+        }
+    }
+
     @TestMetadata("compiler/testData/codegen/boxAgainstJava/visibility")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxAgainstJavaCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxAgainstJavaCodegenTestGenerated.java
@@ -1066,6 +1066,34 @@ public class IrBlackBoxAgainstJavaCodegenTestGenerated extends AbstractIrBlackBo
         }
     }
 
+    @TestMetadata("compiler/testData/codegen/boxAgainstJava/varargs")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class Varargs extends AbstractIrBlackBoxAgainstJavaCodegenTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM_IR, testDataFilePath);
+        }
+
+        public void testAllFilesPresentInVarargs() throws Exception {
+            KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/boxAgainstJava/varargs"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+        }
+
+        @TestMetadata("varargsOverride.kt")
+        public void testVarargsOverride() throws Exception {
+            runTest("compiler/testData/codegen/boxAgainstJava/varargs/varargsOverride.kt");
+        }
+
+        @TestMetadata("varargsOverride2.kt")
+        public void testVarargsOverride2() throws Exception {
+            runTest("compiler/testData/codegen/boxAgainstJava/varargs/varargsOverride2.kt");
+        }
+
+        @TestMetadata("varargsOverride3.kt")
+        public void testVarargsOverride3() throws Exception {
+            runTest("compiler/testData/codegen/boxAgainstJava/varargs/varargsOverride3.kt");
+        }
+    }
+
     @TestMetadata("compiler/testData/codegen/boxAgainstJava/visibility")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)


### PR DESCRIPTION
When calling vararg methods with a generic vararg type without
passing explicit parameters, we have to allocate an empty array
of the right type. We failed to do so previously, as we did
not take the type arguments for the dispatch receiver into
account.