### PR TITLE
Fix configuration cache issue in AbstractKotlinTarget

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/kotlinTargets.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/kotlinTargets.kt
@@ -125,14 +125,19 @@ abstract class AbstractKotlinTarget(
 
             adhocVariant as SoftwareComponent
 
+            // Resolve the values early here instead of passing `adhocVariant` to the SoftwareComponent object below (which would break
+            // configuration caching---see KT-43054). Passing `kotlinVariant` to the object did not break configuration caching, but we also
+            // avoid doing that just to be safe.
+            val coordinates = (kotlinVariant as? ComponentWithCoordinates)?.coordinates
+            val variants = (kotlinVariant as? KotlinVariantWithMetadataVariant)?.variants.orEmpty()
+            val name = adhocVariant.name
+            val usages = (adhocVariant as SoftwareComponentInternal).usages
+
             object : ComponentWithVariants, ComponentWithCoordinates, SoftwareComponentInternal {
-                override fun getCoordinates() = (kotlinVariant as? ComponentWithCoordinates)?.coordinates
-
-                override fun getVariants(): Set<out SoftwareComponent> =
-                    (kotlinVariant as? KotlinVariantWithMetadataVariant)?.variants.orEmpty()
-
-                override fun getName(): String = adhocVariant.name
-                override fun getUsages(): MutableSet<out UsageContext> = (adhocVariant as SoftwareComponentInternal).usages
+                override fun getCoordinates() = coordinates
+                override fun getVariants(): Set<out SoftwareComponent> = variants
+                override fun getName(): String = name
+                override fun getUsages(): MutableSet<out UsageContext> = usages
             }
         }.toSet()
     }


### PR DESCRIPTION
AbstractKotlinTarget#buildAdhocComponentsFromKotlinVariants passes a
non-serializable local object to a lambda, which will fail during
serialization when configuration caching is enabled.

To fix that, this commit passes only the relevant parts of the object
to the lambda.

Bug: KT-43054
Test: Manually verified on
      https://android.googlesource.com/platform/tools/metalava/+/refs/heads/master/
      where the issue was detected (I haven't been able to create a mininal
      reproducible project)