### PR TITLE
[JVM_IR] Follow old backend in bridge visibility and varargs marking.

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/FunctionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/FunctionCodegen.kt
@@ -149,8 +149,7 @@ class FunctionCodegen(
             }
         }
 
-        val isVararg = valueParameters.lastOrNull()?.varargElementType != null
-        val isBridge = origin == IrDeclarationOrigin.BRIDGE || origin == IrDeclarationOrigin.BRIDGE_SPECIAL
+        val isVararg = valueParameters.lastOrNull()?.varargElementType != null && !isBridge()
         val modalityFlag = when ((this as? IrSimpleFunction)?.modality) {
             Modality.FINAL -> when {
                 origin == JvmLoweredDeclarationOrigin.CLASS_STATIC_INITIALIZER -> 0
@@ -172,7 +171,7 @@ class FunctionCodegen(
                 (if (isStatic) Opcodes.ACC_STATIC else 0) or
                 (if (isVararg) Opcodes.ACC_VARARGS else 0) or
                 (if (isExternal) Opcodes.ACC_NATIVE else 0) or
-                (if (isBridge) Opcodes.ACC_BRIDGE else 0) or
+                (if (isBridge()) Opcodes.ACC_BRIDGE else 0) or
                 (if (isSynthetic) Opcodes.ACC_SYNTHETIC else 0) or
                 (if (isStrict) Opcodes.ACC_STRICT else 0) or
                 (if (isSynchronized) Opcodes.ACC_SYNCHRONIZED else 0)

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/MethodSignatureMapper.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/MethodSignatureMapper.kt
@@ -362,7 +362,7 @@ class MethodSignatureMapper(private val context: JvmBackendContext) {
     private fun mapOverriddenSpecialBuiltinIfNeeded(caller: IrFunction, callee: IrFunction, superCall: Boolean): JvmMethodSignature? {
         // Do not remap special builtin methods when called from a bridge. The bridges are there to provide the
         // remapped name or signature and forward to the actually declared method.
-        if (caller.origin == IrDeclarationOrigin.BRIDGE || caller.origin == IrDeclarationOrigin.BRIDGE_SPECIAL) return null
+        if (caller.isBridge()) return null
         // Do not remap calls to static replacements of inline class methods, since they have completely different signatures.
         if (callee.isStaticInlineClassReplacement) return null
         val overriddenSpecialBuiltinFunction =

--- a/compiler/testData/codegen/bytecodeListing/varargsBridge.kt
+++ b/compiler/testData/codegen/bytecodeListing/varargsBridge.kt
@@ -1,0 +1,8 @@
+abstract class A<T> {
+    protected abstract fun doIt(vararg args: T): String
+    fun test() = doIt()
+}
+
+class B : A<Void>() {
+    override fun doIt(vararg args: Void): String = "OK"
+}

--- a/compiler/testData/codegen/bytecodeListing/varargsBridge.txt
+++ b/compiler/testData/codegen/bytecodeListing/varargsBridge.txt
@@ -1,0 +1,15 @@
+@kotlin.Metadata
+public abstract class A {
+    // source: 'varargsBridge.kt'
+    public method <init>(): void
+    protected varargs abstract @org.jetbrains.annotations.NotNull method doIt(@org.jetbrains.annotations.NotNull p0: java.lang.Object[]): java.lang.String
+    public final @org.jetbrains.annotations.NotNull method test(): java.lang.String
+}
+
+@kotlin.Metadata
+public final class B {
+    // source: 'varargsBridge.kt'
+    public method <init>(): void
+    protected varargs @org.jetbrains.annotations.NotNull method doIt(@org.jetbrains.annotations.NotNull p0: java.lang.Void[]): java.lang.String
+    public synthetic bridge method doIt(p0: java.lang.Object[]): java.lang.String
+}

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeListingTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BytecodeListingTestGenerated.java
@@ -179,6 +179,11 @@ public class BytecodeListingTestGenerated extends AbstractBytecodeListingTest {
         runTest("compiler/testData/codegen/bytecodeListing/samAdapterAndInlinedOne.kt");
     }
 
+    @TestMetadata("varargsBridge.kt")
+    public void testVarargsBridge() throws Exception {
+        runTest("compiler/testData/codegen/bytecodeListing/varargsBridge.kt");
+    }
+
     @TestMetadata("compiler/testData/codegen/bytecodeListing/annotations")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeListingTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBytecodeListingTestGenerated.java
@@ -179,6 +179,11 @@ public class IrBytecodeListingTestGenerated extends AbstractIrBytecodeListingTes
         runTest("compiler/testData/codegen/bytecodeListing/samAdapterAndInlinedOne.kt");
     }
 
+    @TestMetadata("varargsBridge.kt")
+    public void testVarargsBridge() throws Exception {
+        runTest("compiler/testData/codegen/bytecodeListing/varargsBridge.kt");
+    }
+
     @TestMetadata("compiler/testData/codegen/bytecodeListing/annotations")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)


### PR DESCRIPTION
The old backend makes bridges for protected and package-private
methods public. Also, for bridges for vararg methods, the vararg
marker is not on the bridge.

These differences seem minor but are visible via reflection, so
we might as well follow the old backend.