### PR TITLE
DRAFT1: FIR2IR: avoid implicit NOT_NULL cast if expected type accepts null

### DIFF
--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirTypeMismatchOnOverrideChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirTypeMismatchOnOverrideChecker.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.fir.analysis.checkers.declaration
 
+import org.jetbrains.kotlin.fir.FirFakeSourceElementKind
 import org.jetbrains.kotlin.fir.FirSourceElement
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.fir.analysis.diagnostics.DiagnosticReporter
@@ -179,14 +180,26 @@ object FirTypeMismatchOnOverrideChecker : FirRegularClassChecker() {
     }
 
     private fun DiagnosticReporter.reportMismatchOnFunction(source: FirSourceElement?, type: String, declaration: FirMemberDeclaration) {
-        source?.let { report(FirErrors.RETURN_TYPE_MISMATCH_ON_OVERRIDE.on(it, type, declaration)) }
+        source?.let {
+            if (it.kind !is FirFakeSourceElementKind) {
+                report(FirErrors.RETURN_TYPE_MISMATCH_ON_OVERRIDE.on(it, type, declaration))
+            }
+        }
     }
 
     private fun DiagnosticReporter.reportMismatchOnProperty(source: FirSourceElement?, type: String, declaration: FirMemberDeclaration) {
-        source?.let { report(FirErrors.PROPERTY_TYPE_MISMATCH_ON_OVERRIDE.on(it, type, declaration)) }
+        source?.let {
+            if (it.kind !is FirFakeSourceElementKind) {
+                report(FirErrors.PROPERTY_TYPE_MISMATCH_ON_OVERRIDE.on(it, type, declaration))
+            }
+        }
     }
 
     private fun DiagnosticReporter.reportMismatchOnVariable(source: FirSourceElement?, type: String, declaration: FirMemberDeclaration) {
-        source?.let { report(FirErrors.VAR_TYPE_MISMATCH_ON_OVERRIDE.on(it, type, declaration)) }
+        source?.let {
+            if (it.kind !is FirFakeSourceElementKind) {
+                report(FirErrors.VAR_TYPE_MISMATCH_ON_OVERRIDE.on(it, type, declaration))
+            }
+        }
     }
 }

--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrImplicitCastInserter.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrImplicitCastInserter.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.fir.backend
 
 import org.jetbrains.kotlin.fir.FirElement
+import org.jetbrains.kotlin.fir.FirFakeSourceElementKind
 import org.jetbrains.kotlin.fir.baseForIntersectionOverride
 import org.jetbrains.kotlin.fir.declarations.FirAnonymousFunction
 import org.jetbrains.kotlin.fir.declarations.FirAnonymousObject
@@ -207,7 +208,7 @@ class Fir2IrImplicitCastInserter(
                 coerceToUnitIfNeeded(type, irBuiltIns)
             }
             // TODO: Not exactly matched with psi2ir yet...
-            valueType.hasEnhancedNullability() -> {
+            valueType.hasEnhancedNullability() && !expectedType.acceptsNullValues() -> {
                 insertImplicitNotNullCastIfNeeded(expression)
             }
             // TODO: coerceIntToAnotherIntegerType
@@ -215,6 +216,10 @@ class Fir2IrImplicitCastInserter(
             else -> this
         }
     }
+
+    private fun FirTypeRef.acceptsNullValues(): Boolean =
+        source?.kind != FirFakeSourceElementKind.ImplicitTypeRef &&
+                (isMarkedNullable == true || hasEnhancedNullability())
 
     private fun IrExpression.insertImplicitNotNullCastIfNeeded(expression: FirExpression): IrExpression {
         // [TypeOperatorLowering] will retrieve the source (from start offset to end offset) as an assertion message.

--- a/compiler/fir/raw-fir/light-tree2fir/src/org/jetbrains/kotlin/fir/lightTree/converter/BaseConverter.kt
+++ b/compiler/fir/raw-fir/light-tree2fir/src/org/jetbrains/kotlin/fir/lightTree/converter/BaseConverter.kt
@@ -15,6 +15,7 @@ import org.jetbrains.kotlin.fir.*
 import org.jetbrains.kotlin.fir.builder.BaseFirBuilder
 import org.jetbrains.kotlin.fir.builder.Context
 import org.jetbrains.kotlin.fir.builder.escapedStringToCharacter
+import org.jetbrains.kotlin.fir.types.FirImplicitTypeRef
 import org.jetbrains.kotlin.fir.types.builder.buildImplicitTypeRef
 import org.jetbrains.kotlin.lexer.KtToken
 import org.jetbrains.kotlin.lexer.KtTokens.*
@@ -27,7 +28,10 @@ open class BaseConverter(
     val offset: Int,
     context: Context<LighterASTNode> = Context()
 ) : BaseFirBuilder<LighterASTNode>(baseSession, context) {
-    protected val implicitType = buildImplicitTypeRef()
+    protected fun LighterASTNode.toFirImplicitType(): FirImplicitTypeRef =
+        buildImplicitTypeRef {
+            source = toFirSourceElement(FirFakeSourceElementKind.ImplicitTypeRef)
+        }
 
     override fun LighterASTNode.toFirSourceElement(kind: FirFakeSourceElementKind?): FirLightSourceElement {
         val startOffset = offset + tree.getStartOffset(this)

--- a/compiler/fir/raw-fir/light-tree2fir/src/org/jetbrains/kotlin/fir/lightTree/converter/DeclarationsConverter.kt
+++ b/compiler/fir/raw-fir/light-tree2fir/src/org/jetbrains/kotlin/fir/lightTree/converter/DeclarationsConverter.kt
@@ -916,7 +916,7 @@ class DeclarationsConverter(
         var delegateExpression: LighterASTNode? = null
         var isVar = false
         var receiverType: FirTypeRef? = null
-        var returnType: FirTypeRef = implicitType
+        var returnType: FirTypeRef = property.toFirImplicitType()
         val typeConstraints = mutableListOf<TypeConstraint>()
         val accessors = mutableListOf<LighterASTNode>()
         var propertyInitializer: FirExpression? = null
@@ -1077,7 +1077,7 @@ class DeclarationsConverter(
             source = entry.toFirSourceElement()
             session = baseSession
             origin = FirDeclarationOrigin.Source
-            returnTypeRef = firType ?: implicitType
+            returnTypeRef = firType ?: entry.toFirImplicitType()
             this.name = name
             isVar = false
             symbol = FirPropertySymbol(name)
@@ -1221,7 +1221,7 @@ class DeclarationsConverter(
             source = setterParameter.toFirSourceElement()
             session = baseSession
             origin = FirDeclarationOrigin.Source
-            returnTypeRef = if (firValueParameter.returnTypeRef == implicitType) propertyTypeRef else firValueParameter.returnTypeRef
+            returnTypeRef = if (firValueParameter.returnTypeRef is FirImplicitTypeRef) propertyTypeRef else firValueParameter.returnTypeRef
             name = firValueParameter.name
             symbol = FirVariableSymbol(firValueParameter.name)
             defaultValue = firValueParameter.defaultValue
@@ -1269,7 +1269,7 @@ class DeclarationsConverter(
         if (returnType == null) {
             returnType =
                 if (block != null || !hasEqToken) implicitUnitType
-                else implicitType
+                else functionDeclaration.toFirImplicitType()
         }
 
         val parentNode = functionDeclaration.getParent()
@@ -1466,7 +1466,7 @@ class DeclarationsConverter(
      *   ;
      */
     private fun convertConstructorInvocation(constructorInvocation: LighterASTNode): Pair<FirTypeRef, List<FirExpression>> {
-        var firTypeRef: FirTypeRef = implicitType
+        var firTypeRef: FirTypeRef = constructorInvocation.toFirImplicitType()
         val firValueArguments = mutableListOf<FirExpression>()
         constructorInvocation.forEachChildren {
             when (it.tokenType) {
@@ -1815,7 +1815,7 @@ class DeclarationsConverter(
             source = valueParameter.toFirSourceElement()
             session = baseSession
             origin = FirDeclarationOrigin.Source
-            returnTypeRef = firType ?: implicitType
+            returnTypeRef = firType ?: valueParameter.toFirImplicitType()
             this.name = name
             symbol = FirVariableSymbol(name)
             defaultValue = firExpression

--- a/compiler/fir/raw-fir/light-tree2fir/src/org/jetbrains/kotlin/fir/lightTree/converter/ExpressionsConverter.kt
+++ b/compiler/fir/raw-fir/light-tree2fir/src/org/jetbrains/kotlin/fir/lightTree/converter/ExpressionsConverter.kt
@@ -130,6 +130,7 @@ class ExpressionsConverter(
 
         val expressionSource = lambdaExpression.toFirSourceElement()
         val target: FirFunctionTarget
+        val implicitType = lambdaExpression.toFirImplicitType()
         return buildAnonymousFunction {
             source = expressionSource
             session = baseSession
@@ -1167,7 +1168,7 @@ class ExpressionsConverter(
      */
     private fun convertSuperExpression(superExpression: LighterASTNode): FirQualifiedAccessExpression {
         val label: String? = superExpression.getLabelName()
-        var superTypeRef: FirTypeRef = implicitType
+        var superTypeRef: FirTypeRef = superExpression.toFirImplicitType()
         superExpression.forEachChildren {
             when (it.tokenType) {
                 TYPE_REFERENCE -> superTypeRef = declarationsConverter.convertType(it)

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/types/TypeUtils.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/types/TypeUtils.kt
@@ -7,12 +7,9 @@ package org.jetbrains.kotlin.fir.types
 
 import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.descriptors.Visibility
-import org.jetbrains.kotlin.fir.FirFakeSourceElementKind
-import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.*
 import org.jetbrains.kotlin.fir.declarations.classId
 import org.jetbrains.kotlin.fir.diagnostics.ConeSimpleDiagnostic
-import org.jetbrains.kotlin.fir.fakeElement
-import org.jetbrains.kotlin.fir.render
 import org.jetbrains.kotlin.fir.resolve.fullyExpandedType
 import org.jetbrains.kotlin.fir.symbols.impl.ConeClassLookupTagWithFixedSymbol
 import org.jetbrains.kotlin.fir.types.builder.buildErrorTypeRef
@@ -185,6 +182,18 @@ fun FirTypeRef.isUnsafeVarianceType(session: FirSession): Boolean {
 
 fun FirTypeRef.hasEnhancedNullability(): Boolean =
     coneTypeSafe<ConeKotlinType>()?.hasEnhancedNullability == true
+
+fun FirTypeRef.withReplacedSource(
+    knownSource: FirSourceElement
+): FirResolvedTypeRef {
+    require(this is FirResolvedTypeRef)
+
+    return buildResolvedTypeRef {
+        source = knownSource
+        type = coneType
+        annotations += this@withReplacedSource.annotations
+    }
+}
 
 // Unlike other cases, return types may be implicit, i.e. unresolved
 // But in that cases newType should also be `null`

--- a/compiler/testData/codegen/box/javaInterop/notNullAssertions/enhancedNullability/inLambdaReturnWithExpectedType.kt
+++ b/compiler/testData/codegen/box/javaInterop/notNullAssertions/enhancedNullability/inLambdaReturnWithExpectedType.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: +StrictJavaNullabilityAssertions
-// IGNORE_BACKEND_FIR: JVM_IR
 // TARGET_BACKEND: JVM
 
 // FILE: inLambdaReturnWithExpectedType.kt

--- a/compiler/testData/codegen/box/javaInterop/notNullAssertions/nullCheckOnLambdaReturnValue/nnStringVsT.kt
+++ b/compiler/testData/codegen/box/javaInterop/notNullAssertions/nullCheckOnLambdaReturnValue/nnStringVsT.kt
@@ -1,5 +1,4 @@
 // TARGET_BACKEND: JVM
-// IGNORE_BACKEND_FIR: JVM_IR
 // FILE: nnStringVsT.kt
 fun <T> useT(fn: () -> T) = fn()
 

--- a/compiler/testData/codegen/box/javaInterop/notNullAssertions/nullCheckOnLambdaReturnValue/nnStringVsTAny.kt
+++ b/compiler/testData/codegen/box/javaInterop/notNullAssertions/nullCheckOnLambdaReturnValue/nnStringVsTAny.kt
@@ -1,5 +1,4 @@
 // TARGET_BACKEND: JVM
-// IGNORE_BACKEND_FIR: JVM_IR
 // FILE: nnStringVsTAny.kt
 fun <T : Any> useTAny(fn: () -> T) = fn()
 

--- a/compiler/testData/diagnostics/tests/delegatedProperty/delegatedPropertyOverridedInTraitTypeMismatch.fir.kt
+++ b/compiler/testData/diagnostics/tests/delegatedProperty/delegatedPropertyOverridedInTraitTypeMismatch.fir.kt
@@ -15,7 +15,7 @@ fun foo() {
 }
 
 class Delegate {
-    operator fun getValue(t: Any?, p: KProperty<*>): <!PROPERTY_TYPE_MISMATCH_ON_OVERRIDE!>String<!> {
+    operator fun getValue(t: Any?, p: KProperty<*>): String {
         return ""
     }
 }

--- a/compiler/testData/diagnostics/testsWithStdLib/coroutines/suspendFunctionType/lambdaInOverriddenValInitializer.fir.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/coroutines/suspendFunctionType/lambdaInOverriddenValInitializer.fir.kt
@@ -7,7 +7,7 @@ interface Bar<T> {
 }
 
 class Test1 : Foo {
-    override val foo = <!PROPERTY_TYPE_MISMATCH_ON_OVERRIDE!>{}<!>
+    override val foo = {}
 }
 
 class Test2 : Foo {
@@ -15,7 +15,7 @@ class Test2 : Foo {
 }
 
 class Test3 : Bar<suspend () -> Unit> {
-    override val bar = <!PROPERTY_TYPE_MISMATCH_ON_OVERRIDE!>{}<!>
+    override val bar = {}
 }
 
 class Test4 : Bar<suspend () -> Unit> {

--- a/compiler/testData/ir/irText/expressions/nullCheckOnGenericLambdaReturn.fir.txt
+++ b/compiler/testData/ir/irText/expressions/nullCheckOnGenericLambdaReturn.fir.txt
@@ -51,8 +51,7 @@ FILE fqName:<root> fileName:/nullCheckOnGenericLambdaReturn.kt
               FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> () returnType:kotlin.String
                 BLOCK_BODY
                   RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.String declared in <root>.test2'
-                    TYPE_OP type=kotlin.String origin=IMPLICIT_NOTNULL typeOperand=kotlin.String
-                      CALL 'public open fun nnFoo (): kotlin.String declared in <root>.J' type=kotlin.String origin=null
+                    CALL 'public open fun nnFoo (): kotlin.String declared in <root>.J' type=kotlin.String origin=null
   FUN name:test3 visibility:public modality:FINAL <> () returnType:kotlin.String?
     BLOCK_BODY
       RETURN type=kotlin.Nothing from='public final fun test3 (): kotlin.String? declared in <root>'
@@ -73,5 +72,4 @@ FILE fqName:<root> fileName:/nullCheckOnGenericLambdaReturn.kt
               FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> () returnType:kotlin.String
                 BLOCK_BODY
                   RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.String declared in <root>.test4'
-                    TYPE_OP type=kotlin.String origin=IMPLICIT_NOTNULL typeOperand=kotlin.String
-                      CALL 'public open fun nnFoo (): kotlin.String declared in <root>.J' type=kotlin.String origin=null
+                    CALL 'public open fun nnFoo (): kotlin.String declared in <root>.J' type=kotlin.String origin=null

--- a/compiler/testData/ir/irText/types/nullChecks/enhancedNullability.fir.txt
+++ b/compiler/testData/ir/irText/types/nullChecks/enhancedNullability.fir.txt
@@ -39,8 +39,7 @@ FILE fqName:<root> fileName:/enhancedNullability.kt
       CALL 'public open fun use (s: kotlin.String): kotlin.Unit declared in <root>.J' type=kotlin.Unit origin=null
         s: CALL 'public open fun nullString (): kotlin.String? declared in <root>.J' type=kotlin.String? origin=null
       CALL 'public open fun use (s: kotlin.String): kotlin.Unit declared in <root>.J' type=kotlin.Unit origin=null
-        s: TYPE_OP type=kotlin.String origin=IMPLICIT_NOTNULL typeOperand=kotlin.String
-          CALL 'public open fun notNullString (): kotlin.String declared in <root>.J' type=kotlin.String origin=null
+        s: CALL 'public open fun notNullString (): kotlin.String declared in <root>.J' type=kotlin.String origin=null
   FUN name:testLocalVarUse visibility:public modality:FINAL <> () returnType:kotlin.Unit
     BLOCK_BODY
       VAR name:ns type:kotlin.String? [val]
@@ -51,5 +50,4 @@ FILE fqName:<root> fileName:/enhancedNullability.kt
         TYPE_OP type=kotlin.String origin=IMPLICIT_NOTNULL typeOperand=kotlin.String
           CALL 'public open fun notNullString (): kotlin.String declared in <root>.J' type=kotlin.String origin=null
       CALL 'public open fun use (s: kotlin.String): kotlin.Unit declared in <root>.J' type=kotlin.Unit origin=null
-        s: TYPE_OP type=kotlin.String origin=IMPLICIT_NOTNULL typeOperand=kotlin.String
-          GET_VAR 'val nns: kotlin.String [val] declared in <root>.testLocalVarUse' type=kotlin.String origin=null
+        s: GET_VAR 'val nns: kotlin.String [val] declared in <root>.testLocalVarUse' type=kotlin.String origin=null

--- a/compiler/testData/ir/irText/types/nullChecks/enhancedNullabilityInDestructuringAssignment.fir.txt
+++ b/compiler/testData/ir/irText/types/nullChecks/enhancedNullabilityInDestructuringAssignment.fir.txt
@@ -118,8 +118,7 @@ FILE fqName:<root> fileName:/enhancedNullabilityInDestructuringAssignment.kt
   FUN name:test1 visibility:public modality:FINAL <> () returnType:kotlin.Unit
     BLOCK_BODY
       VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:<root>.P [val]
-        TYPE_OP type=<root>.P origin=IMPLICIT_NOTNULL typeOperand=<root>.P
-          CALL 'public open fun notNullP (): <root>.P declared in <root>.J' type=<root>.P origin=null
+        CALL 'public open fun notNullP (): <root>.P declared in <root>.J' type=<root>.P origin=null
       VAR name:x type:kotlin.Int [val]
         CALL 'public final fun component1 (): kotlin.Int [operator] declared in <root>.P' type=kotlin.Int origin=null
           $this: GET_VAR 'val tmp_0: <root>.P [val] declared in <root>.test1' type=<root>.P origin=null

--- a/compiler/testData/ir/irText/types/nullChecks/nullCheckOnLambdaResult/nnStringVsT.fir.txt
+++ b/compiler/testData/ir/irText/types/nullChecks/nullCheckOnLambdaResult/nnStringVsT.fir.txt
@@ -15,5 +15,4 @@ FILE fqName:<root> fileName:/nnStringVsT.kt
             FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> () returnType:kotlin.String
               BLOCK_BODY
                 RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.String declared in <root>.testNoNullCheck'
-                  TYPE_OP type=kotlin.String origin=IMPLICIT_NOTNULL typeOperand=kotlin.String
-                    CALL 'public open fun notNullString (): kotlin.String declared in <root>.J' type=kotlin.String origin=null
+                  CALL 'public open fun notNullString (): kotlin.String declared in <root>.J' type=kotlin.String origin=null

--- a/compiler/testData/ir/irText/types/nullChecks/nullCheckOnLambdaResult/nnStringVsTAny.fir.txt
+++ b/compiler/testData/ir/irText/types/nullChecks/nullCheckOnLambdaResult/nnStringVsTAny.fir.txt
@@ -15,5 +15,4 @@ FILE fqName:<root> fileName:/nnStringVsTAny.kt
             FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> () returnType:kotlin.String
               BLOCK_BODY
                 RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.String declared in <root>.testNoNullCheck'
-                  TYPE_OP type=kotlin.String origin=IMPLICIT_NOTNULL typeOperand=kotlin.String
-                    CALL 'public open fun notNullString (): kotlin.String declared in <root>.J' type=kotlin.String origin=null
+                  CALL 'public open fun notNullString (): kotlin.String declared in <root>.J' type=kotlin.String origin=null


### PR DESCRIPTION
This is the first attempt to resolve regressions added at https://github.com/JetBrains/kotlin/pull/3857 where implicit `NOT_NULL` cast was added whenever the expression's return type has `@EnhancedNullability`. Such implicit cast is not necessary if the expected type accepts `null`.

After https://github.com/JetBrains/kotlin/pull/3868, we're ready to compare the value type and the expected type in a similar way `psi2ir` does. Then, checking if the expected type accepts `null` or not isn't a big deal. Rather, the caveat is, we should distinguish whether such expected type is inferred type or user-contributed type.

To that end, this PR attempts to utilize `FirFakeSourceElementKind.ImplicitTypeRef`. That fake kind needs to be recorded even though there is no type reference (like `var x = nonNullString()`), and then propagated during declaration resolution. It might over-populate `source`; and I need to fine-tune error reports in some checkers.