### PR TITLE
DRAFT2: FIR2IR: avoid implicit NOT_NULL cast if expected type accepts null

### DIFF
--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrImplicitCastInserter.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrImplicitCastInserter.kt
@@ -207,7 +207,7 @@ class Fir2IrImplicitCastInserter(
                 coerceToUnitIfNeeded(type, irBuiltIns)
             }
             // TODO: Not exactly matched with psi2ir yet...
-            valueType.hasEnhancedNullability() -> {
+            valueType.hasEnhancedNullability() && !expectedType.acceptsNullValues() -> {
                 insertImplicitNotNullCastIfNeeded(expression)
             }
             // TODO: coerceIntToAnotherIntegerType
@@ -215,6 +215,10 @@ class Fir2IrImplicitCastInserter(
             else -> this
         }
     }
+
+    private fun FirTypeRef.acceptsNullValues(): Boolean =
+        (this is FirResolvedTypeRef && this.delegatedTypeRef !is FirImplicitTypeRef) &&
+                (isMarkedNullable == true || hasEnhancedNullability())
 
     private fun IrExpression.insertImplicitNotNullCastIfNeeded(expression: FirExpression): IrExpression {
         // [TypeOperatorLowering] will retrieve the source (from start offset to end offset) as an assertion message.

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/dfa/cfg/CFGNodeRenderer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/dfa/cfg/CFGNodeRenderer.kt
@@ -122,7 +122,10 @@ fun CFGNode<*>.render(): String =
     }
 
 private object CfgRenderMode : FirRenderer.RenderMode(
-    renderLambdaBodies = false, renderCallArguments = false, renderCallableFqNames = false, renderDeclatationResovlePhase = false
+    renderLambdaBodies = false,
+    renderCallArguments = false,
+    renderCallableFqNames = false,
+    renderDeclarationResolvePhase = false
 )
 
 private fun FirFunction<*>.name(): String = when (this) {

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirSpecificTypeResolverTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirSpecificTypeResolverTransformer.kt
@@ -51,6 +51,7 @@ class FirSpecificTypeResolverTransformer(
                 source = functionTypeRef.source
                 type = resolvedType
                 annotations += functionTypeRef.annotations
+                delegatedTypeRef = functionTypeRef
             }
         } else {
             buildErrorTypeRef {

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirDeclarationsResolveTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirDeclarationsResolveTransformer.kt
@@ -498,7 +498,7 @@ open class FirDeclarationsResolveTransformer(transformer: FirBodyResolveTransfor
                     withExpectedType(
                         body.resultType.approximatedIfNeededOrSelf(
                             inferenceComponents.approximator, simpleFunction?.visibility, simpleFunction?.isInline == true
-                        )
+                        ).withReplacedDelegation(result.returnTypeRef)
                     )
                 )
             } else {
@@ -926,7 +926,9 @@ open class FirDeclarationsResolveTransformer(transformer: FirBodyResolveTransfor
                     variable.transformReturnTypeRef(
                         transformer,
                         withExpectedType(
-                            expectedType.approximatedIfNeededOrSelf(inferenceComponents.approximator, (variable as? FirProperty)?.visibility)
+                            expectedType.approximatedIfNeededOrSelf(
+                                inferenceComponents.approximator, (variable as? FirProperty)?.visibility
+                            ).withReplacedDelegation(variable.returnTypeRef)
                         )
                     )
                 }
@@ -950,7 +952,9 @@ open class FirDeclarationsResolveTransformer(transformer: FirBodyResolveTransfor
                     variable.transformReturnTypeRef(
                         transformer,
                         withExpectedType(
-                            expectedType?.approximatedIfNeededOrSelf(inferenceComponents.approximator, (variable as? FirProperty)?.visibility)
+                            expectedType?.approximatedIfNeededOrSelf(
+                                inferenceComponents.approximator, (variable as? FirProperty)?.visibility
+                            )?.withReplacedDelegation(variable.returnTypeRef)
                         )
                     )
                 }

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/FirRenderer.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/FirRenderer.kt
@@ -51,27 +51,27 @@ class FirRenderer(builder: StringBuilder, private val mode: RenderMode = RenderM
         val renderLambdaBodies: Boolean,
         val renderCallArguments: Boolean,
         val renderCallableFqNames: Boolean,
-        val renderDeclatationResovlePhase: Boolean
+        val renderDeclarationResolvePhase: Boolean
     ) {
         object Normal : RenderMode(
             renderLambdaBodies = true,
             renderCallArguments = true,
             renderCallableFqNames = false,
-            renderDeclatationResovlePhase = false
+            renderDeclarationResolvePhase = false
         )
 
         object WithFqNames : RenderMode(
             renderLambdaBodies = true,
             renderCallArguments = true,
             renderCallableFqNames = true,
-            renderDeclatationResovlePhase = false
+            renderDeclarationResolvePhase = false
         )
 
         object WithResolvePhases : RenderMode(
             renderLambdaBodies = true,
             renderCallArguments = true,
             renderCallableFqNames = false,
-            renderDeclatationResovlePhase = true
+            renderDeclarationResolvePhase = true
         )
     }
 
@@ -340,7 +340,7 @@ class FirRenderer(builder: StringBuilder, private val mode: RenderMode = RenderM
     }
 
     override fun visitDeclaration(declaration: FirDeclaration) {
-        if (mode.renderDeclatationResovlePhase) {
+        if (mode.renderDeclarationResolvePhase) {
             print("[${declaration.resolvePhase}] ")
         }
         print(

--- a/compiler/testData/codegen/box/javaInterop/notNullAssertions/enhancedNullability/inLambdaReturnWithExpectedType.kt
+++ b/compiler/testData/codegen/box/javaInterop/notNullAssertions/enhancedNullability/inLambdaReturnWithExpectedType.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: +StrictJavaNullabilityAssertions
-// IGNORE_BACKEND_FIR: JVM_IR
 // TARGET_BACKEND: JVM
 
 // FILE: inLambdaReturnWithExpectedType.kt

--- a/compiler/testData/codegen/box/javaInterop/notNullAssertions/nullCheckOnLambdaReturnValue/nnStringVsT.kt
+++ b/compiler/testData/codegen/box/javaInterop/notNullAssertions/nullCheckOnLambdaReturnValue/nnStringVsT.kt
@@ -1,5 +1,4 @@
 // TARGET_BACKEND: JVM
-// IGNORE_BACKEND_FIR: JVM_IR
 // FILE: nnStringVsT.kt
 fun <T> useT(fn: () -> T) = fn()
 

--- a/compiler/testData/codegen/box/javaInterop/notNullAssertions/nullCheckOnLambdaReturnValue/nnStringVsTAny.kt
+++ b/compiler/testData/codegen/box/javaInterop/notNullAssertions/nullCheckOnLambdaReturnValue/nnStringVsTAny.kt
@@ -1,5 +1,4 @@
 // TARGET_BACKEND: JVM
-// IGNORE_BACKEND_FIR: JVM_IR
 // FILE: nnStringVsTAny.kt
 fun <T : Any> useTAny(fn: () -> T) = fn()
 

--- a/compiler/testData/diagnostics/tests/incompleteCode/diagnosticWithSyntaxError/typeReferenceError.fir.kt
+++ b/compiler/testData/diagnostics/tests/incompleteCode/diagnosticWithSyntaxError/typeReferenceError.fir.kt
@@ -1,3 +1,3 @@
 package typeReferenceError
 
-class Pair<<!SYNTAX!><!>:<!UNRESOLVED_REFERENCE!>(val c: <!SYNTAX!><!SYNTAX!><!>fun<!><!SYNTAX!><!> main<!>()
+class Pair<<!SYNTAX!><!>:<!UNRESOLVED_REFERENCE!>(val c: <!SYNTAX!><!SYNTAX!><!>fun<!><!SYNTAX!><!> <!UNRESOLVED_REFERENCE!>main<!><!>()

--- a/compiler/testData/ir/irText/expressions/nullCheckOnGenericLambdaReturn.fir.txt
+++ b/compiler/testData/ir/irText/expressions/nullCheckOnGenericLambdaReturn.fir.txt
@@ -51,8 +51,7 @@ FILE fqName:<root> fileName:/nullCheckOnGenericLambdaReturn.kt
               FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> () returnType:kotlin.String
                 BLOCK_BODY
                   RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.String declared in <root>.test2'
-                    TYPE_OP type=kotlin.String origin=IMPLICIT_NOTNULL typeOperand=kotlin.String
-                      CALL 'public open fun nnFoo (): kotlin.String declared in <root>.J' type=kotlin.String origin=null
+                    CALL 'public open fun nnFoo (): kotlin.String declared in <root>.J' type=kotlin.String origin=null
   FUN name:test3 visibility:public modality:FINAL <> () returnType:kotlin.String?
     BLOCK_BODY
       RETURN type=kotlin.Nothing from='public final fun test3 (): kotlin.String? declared in <root>'
@@ -73,5 +72,4 @@ FILE fqName:<root> fileName:/nullCheckOnGenericLambdaReturn.kt
               FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> () returnType:kotlin.String
                 BLOCK_BODY
                   RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.String declared in <root>.test4'
-                    TYPE_OP type=kotlin.String origin=IMPLICIT_NOTNULL typeOperand=kotlin.String
-                      CALL 'public open fun nnFoo (): kotlin.String declared in <root>.J' type=kotlin.String origin=null
+                    CALL 'public open fun nnFoo (): kotlin.String declared in <root>.J' type=kotlin.String origin=null

--- a/compiler/testData/ir/irText/expressions/nullCheckOnLambdaReturn.fir.txt
+++ b/compiler/testData/ir/irText/expressions/nullCheckOnLambdaReturn.fir.txt
@@ -85,5 +85,4 @@ FILE fqName:<root> fileName:/nullCheckOnLambdaReturn.kt
             FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> () returnType:kotlin.Any?
               BLOCK_BODY
                 RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.Any? declared in <root>.test6'
-                  TYPE_OP type=kotlin.String origin=IMPLICIT_NOTNULL typeOperand=kotlin.String
-                    CALL 'public open fun nnFoo (): kotlin.String declared in <root>.J' type=kotlin.String origin=null
+                  CALL 'public open fun nnFoo (): kotlin.String declared in <root>.J' type=kotlin.String origin=null

--- a/compiler/testData/ir/irText/types/nullChecks/enhancedNullability.fir.txt
+++ b/compiler/testData/ir/irText/types/nullChecks/enhancedNullability.fir.txt
@@ -39,8 +39,7 @@ FILE fqName:<root> fileName:/enhancedNullability.kt
       CALL 'public open fun use (s: kotlin.String): kotlin.Unit declared in <root>.J' type=kotlin.Unit origin=null
         s: CALL 'public open fun nullString (): kotlin.String? declared in <root>.J' type=kotlin.String? origin=null
       CALL 'public open fun use (s: kotlin.String): kotlin.Unit declared in <root>.J' type=kotlin.Unit origin=null
-        s: TYPE_OP type=kotlin.String origin=IMPLICIT_NOTNULL typeOperand=kotlin.String
-          CALL 'public open fun notNullString (): kotlin.String declared in <root>.J' type=kotlin.String origin=null
+        s: CALL 'public open fun notNullString (): kotlin.String declared in <root>.J' type=kotlin.String origin=null
   FUN name:testLocalVarUse visibility:public modality:FINAL <> () returnType:kotlin.Unit
     BLOCK_BODY
       VAR name:ns type:kotlin.String? [val]
@@ -51,5 +50,4 @@ FILE fqName:<root> fileName:/enhancedNullability.kt
         TYPE_OP type=kotlin.String origin=IMPLICIT_NOTNULL typeOperand=kotlin.String
           CALL 'public open fun notNullString (): kotlin.String declared in <root>.J' type=kotlin.String origin=null
       CALL 'public open fun use (s: kotlin.String): kotlin.Unit declared in <root>.J' type=kotlin.Unit origin=null
-        s: TYPE_OP type=kotlin.String origin=IMPLICIT_NOTNULL typeOperand=kotlin.String
-          GET_VAR 'val nns: kotlin.String [val] declared in <root>.testLocalVarUse' type=kotlin.String origin=null
+        s: GET_VAR 'val nns: kotlin.String [val] declared in <root>.testLocalVarUse' type=kotlin.String origin=null

--- a/compiler/testData/ir/irText/types/nullChecks/nullCheckOnLambdaResult/nnStringVsT.fir.txt
+++ b/compiler/testData/ir/irText/types/nullChecks/nullCheckOnLambdaResult/nnStringVsT.fir.txt
@@ -15,5 +15,4 @@ FILE fqName:<root> fileName:/nnStringVsT.kt
             FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> () returnType:kotlin.String
               BLOCK_BODY
                 RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.String declared in <root>.testNoNullCheck'
-                  TYPE_OP type=kotlin.String origin=IMPLICIT_NOTNULL typeOperand=kotlin.String
-                    CALL 'public open fun notNullString (): kotlin.String declared in <root>.J' type=kotlin.String origin=null
+                  CALL 'public open fun notNullString (): kotlin.String declared in <root>.J' type=kotlin.String origin=null

--- a/compiler/testData/ir/irText/types/nullChecks/nullCheckOnLambdaResult/nnStringVsTAny.fir.txt
+++ b/compiler/testData/ir/irText/types/nullChecks/nullCheckOnLambdaResult/nnStringVsTAny.fir.txt
@@ -15,5 +15,4 @@ FILE fqName:<root> fileName:/nnStringVsTAny.kt
             FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> () returnType:kotlin.String
               BLOCK_BODY
                 RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.String declared in <root>.testNoNullCheck'
-                  TYPE_OP type=kotlin.String origin=IMPLICIT_NOTNULL typeOperand=kotlin.String
-                    CALL 'public open fun notNullString (): kotlin.String declared in <root>.J' type=kotlin.String origin=null
+                  CALL 'public open fun notNullString (): kotlin.String declared in <root>.J' type=kotlin.String origin=null


### PR DESCRIPTION
This is the second attempt to resolve regressions added at #3857 where implicit `NOT_NULL` cast was added whenever the expression's return type has `@EnhancedNullability`. Such implicit cast is not necessary if the expected type accepts `null`.

After #3868, we're ready to compare the value type and the expected type in a similar way `psi2ir` does. Then, checking if the expected type accepts `null` or not isn't a big deal. Rather, the caveat is, we should distinguish whether such expected type is inferred type or user-contributed type.

To that end, the first approach (#3881) attempts to utilize `FirFakeSourceElementKind.ImplicitTypeRef`. That fake kind needs to be recorded even though there is no type reference (like `var x = nonNullString()`), and then propagated during declaration resolution. It might over-populate `source`; and I need to fine-tune error reports in some checkers.

The last part of the first approach doesn't seem good, so this PR attempts to utilize `FirResolvedTypeRef.delegatedType` as a source to indicate whether the given type is inferred or not, since that property is used to store the reference to original, unresolved type ref.

During the course of implementing it, found two minor fixes; see first two commits. Core parts are also intuitive, and much simpler than the first approach.