### PR TITLE
FIR checker: make calls effect analyzer path-sensitive

### DIFF
--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/CfaUtils.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/CfaUtils.kt
@@ -11,7 +11,6 @@ import org.jetbrains.kotlin.contracts.description.EventOccurrencesRange
 import org.jetbrains.kotlin.fir.references.FirResolvedNamedReference
 import org.jetbrains.kotlin.fir.resolve.dfa.cfg.*
 import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
-import java.lang.IllegalStateException
 
 abstract class EventOccurrencesRangeInfo<E : EventOccurrencesRangeInfo<E, K>, K : Any>(
     map: PersistentMap<K, EventOccurrencesRange> = persistentMapOf()
@@ -39,6 +38,8 @@ class PropertyInitializationInfo(
     override val constructor: (PersistentMap<FirPropertySymbol, EventOccurrencesRange>) -> PropertyInitializationInfo =
         ::PropertyInitializationInfo
 
+    override val empty: () -> PropertyInitializationInfo =
+        ::EMPTY
 }
 
 class LocalPropertyCollector private constructor() : ControlFlowGraphVisitorVoid() {
@@ -61,7 +62,7 @@ class LocalPropertyCollector private constructor() : ControlFlowGraphVisitorVoid
 
 class PathAwarePropertyInitializationInfo(
     map: PersistentMap<EdgeLabel, PropertyInitializationInfo> = persistentMapOf()
-) : ControlFlowInfo<PathAwarePropertyInitializationInfo, EdgeLabel, PropertyInitializationInfo>(map) {
+) : PathAwareControlFlowInfo<PathAwarePropertyInitializationInfo, PropertyInitializationInfo>(map) {
     companion object {
         val EMPTY = PathAwarePropertyInitializationInfo(persistentMapOf(NormalPath to PropertyInitializationInfo.EMPTY))
     }
@@ -69,70 +70,8 @@ class PathAwarePropertyInitializationInfo(
     override val constructor: (PersistentMap<EdgeLabel, PropertyInitializationInfo>) -> PathAwarePropertyInitializationInfo =
         ::PathAwarePropertyInitializationInfo
 
-    val infoAtNormalPath: PropertyInitializationInfo
-        get() = map[NormalPath] ?: PropertyInitializationInfo.EMPTY
-
-    val hasNormalPath: Boolean
-        get() = map.containsKey(NormalPath)
-
-    fun applyLabel(node: CFGNode<*>, label: EdgeLabel): PathAwarePropertyInitializationInfo {
-        if (label.isNormal) {
-            // Special case: when we exit the try expression, null label means a normal path.
-            // Filter out any info bound to non-null label
-            // One day, if we allow multiple edges between nodes with different labels, e.g., labeling all paths in try/catch/finally,
-            // instead of this kind of special handling, proxy enter/exit nodes per label are preferred.
-            if (node is TryExpressionExitNode) {
-                return if (hasNormalPath) {
-                    constructor(persistentMapOf(NormalPath to infoAtNormalPath))
-                } else {
-                    /* This means no info for normal path. */
-                    EMPTY
-                }
-            }
-            // In general, null label means no additional path info, hence return `this` as-is.
-            return this
-        }
-
-        val hasAbnormalLabels = map.keys.any { !it.isNormal }
-        return if (hasAbnormalLabels) {
-            // { |-> ... l1 |-> I1, l2 |-> I2, ... }
-            //   | l1         // path exit: if the given info has non-null labels, this acts like a filtering
-            // { |-> I1 }     // NB: remove the path info
-            if (map.keys.contains(label)) {
-                constructor(persistentMapOf(NormalPath to map[label]!!))
-            } else {
-                /* This means no info for the specific label. */
-                EMPTY
-            }
-        } else {
-            // { |-> ... }    // empty path info
-            //   | l1         // path entry
-            // { l1 -> ... }  // now, every info bound to the label
-            constructor(persistentMapOf(label to infoAtNormalPath))
-        }
-    }
-
-    override fun merge(other: PathAwarePropertyInitializationInfo): PathAwarePropertyInitializationInfo {
-        var resultMap = persistentMapOf<EdgeLabel, PropertyInitializationInfo>()
-        for (label in keys.union(other.keys)) {
-            // disjoint merging to preserve paths. i.e., merge the property initialization info if and only if both have the key.
-            // merge({ |-> I1 }, { |-> I2, l1 |-> I3 }
-            //   == { |-> merge(I1, I2), l1 |-> I3 }
-            val i1 = this[label]
-            val i2 = other[label]
-            resultMap = when {
-                i1 != null && i2 != null ->
-                    resultMap.put(label, i1.merge(i2))
-                i1 != null ->
-                    resultMap.put(label, i1)
-                i2 != null ->
-                    resultMap.put(label, i2)
-                else ->
-                    throw IllegalStateException()
-            }
-        }
-        return constructor(resultMap)
-    }
+    override val empty: () -> PathAwarePropertyInitializationInfo =
+        ::EMPTY
 }
 
 class PropertyInitializationInfoCollector(private val localProperties: Set<FirPropertySymbol>) :

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/ControlFlowInfo.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/ControlFlowInfo.kt
@@ -13,6 +13,8 @@ abstract class ControlFlowInfo<S : ControlFlowInfo<S, K, V>, K : Any, V : Any> p
 
     protected abstract val constructor: (PersistentMap<K, V>) -> S
 
+    protected abstract val empty: () -> S
+
     override fun equals(other: Any?): Boolean {
         return map == (other as? ControlFlowInfo<*, *, *>)?.map
     }

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/ControlFlowInfo.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/ControlFlowInfo.kt
@@ -28,4 +28,6 @@ abstract class ControlFlowInfo<S : ControlFlowInfo<S, K, V>, K : Any, V : Any> p
     override fun put(key: K, value: V): S {
         return constructor(map.put(key, value))
     }
+
+    abstract fun merge(other: S): S
 }

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/FirCallsEffectAnalyzer.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/FirCallsEffectAnalyzer.kt
@@ -38,7 +38,6 @@ import org.jetbrains.kotlin.fir.types.ConeKotlinType
 import org.jetbrains.kotlin.fir.types.FirTypeRef
 import org.jetbrains.kotlin.fir.types.coneTypeSafe
 import org.jetbrains.kotlin.utils.addIfNotNull
-import java.lang.IllegalStateException
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 
@@ -213,11 +212,13 @@ object FirCallsEffectAnalyzer : FirControlFlowChecker() {
         override val constructor: (PersistentMap<FirBasedSymbol<*>, EventOccurrencesRange>) -> LambdaInvocationInfo =
             ::LambdaInvocationInfo
 
+        override val empty: () -> LambdaInvocationInfo =
+            ::EMPTY
     }
 
     class PathAwareLambdaInvocationInfo(
         map: PersistentMap<EdgeLabel, LambdaInvocationInfo> = persistentMapOf()
-    ) : ControlFlowInfo<PathAwareLambdaInvocationInfo, EdgeLabel, LambdaInvocationInfo>(map) {
+    ) : PathAwareControlFlowInfo<PathAwareLambdaInvocationInfo, LambdaInvocationInfo>(map) {
         companion object {
             val EMPTY = PathAwareLambdaInvocationInfo(persistentMapOf(NormalPath to LambdaInvocationInfo.EMPTY))
         }
@@ -225,70 +226,8 @@ object FirCallsEffectAnalyzer : FirControlFlowChecker() {
         override val constructor: (PersistentMap<EdgeLabel, LambdaInvocationInfo>) -> PathAwareLambdaInvocationInfo =
             ::PathAwareLambdaInvocationInfo
 
-        val infoAtNormalPath: LambdaInvocationInfo
-            get() = map[NormalPath] ?: LambdaInvocationInfo.EMPTY
-
-        val hasNormalPath: Boolean
-            get() = map.containsKey(NormalPath)
-
-        fun applyLabel(node: CFGNode<*>, label: EdgeLabel): PathAwareLambdaInvocationInfo {
-            if (label.isNormal) {
-                // Special case: when we exit the try expression, null label means a normal path.
-                // Filter out any info bound to non-null label
-                // One day, if we allow multiple edges between nodes with different labels, e.g., labeling all paths in try/catch/finally,
-                // instead of this kind of special handling, proxy enter/exit nodes per label are preferred.
-                if (node is TryExpressionExitNode) {
-                    return if (hasNormalPath) {
-                        constructor(persistentMapOf(NormalPath to infoAtNormalPath))
-                    } else {
-                        /* This means no info for normal path. */
-                        EMPTY
-                    }
-                }
-                // In general, null label means no additional path info, hence return `this` as-is.
-                return this
-            }
-
-            val hasAbnormalLabels = map.keys.any { !it.isNormal }
-            return if (hasAbnormalLabels) {
-                // { |-> ... l1 |-> I1, l2 |-> I2, ... }
-                //   | l1         // path exit: if the given info has non-null labels, this acts like a filtering
-                // { |-> I1 }     // NB: remove the path info
-                if (map.keys.contains(label)) {
-                    constructor(persistentMapOf(NormalPath to map[label]!!))
-                } else {
-                    /* This means no info for the specific label. */
-                    EMPTY
-                }
-            } else {
-                // { |-> ... }    // empty path info
-                //   | l1         // path entry
-                // { l1 -> ... }  // now, every info bound to the label
-                constructor(persistentMapOf(label to infoAtNormalPath))
-            }
-        }
-
-        override fun merge(other: PathAwareLambdaInvocationInfo): PathAwareLambdaInvocationInfo {
-            var resultMap = persistentMapOf<EdgeLabel, LambdaInvocationInfo>()
-            for (label in keys.union(other.keys)) {
-                // disjoint merging to preserve paths. i.e., merge the property initialization info if and only if both have the key.
-                // merge({ |-> I1 }, { |-> I2, l1 |-> I3 }
-                //   == { |-> merge(I1, I2), l1 |-> I3 }
-                val i1 = this[label]
-                val i2 = other[label]
-                resultMap = when {
-                    i1 != null && i2 != null ->
-                        resultMap.put(label, i1.merge(i2))
-                    i1 != null ->
-                        resultMap.put(label, i1)
-                    i2 != null ->
-                        resultMap.put(label, i2)
-                    else ->
-                        throw IllegalStateException()
-                }
-            }
-            return constructor(resultMap)
-        }
+        override val empty: () -> PathAwareLambdaInvocationInfo =
+            ::EMPTY
     }
 
     private class InvocationDataCollector(

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/FirCallsEffectAnalyzer.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/FirCallsEffectAnalyzer.kt
@@ -205,8 +205,7 @@ object FirCallsEffectAnalyzer : FirControlFlowChecker() {
 
     class LambdaInvocationInfo(
         map: PersistentMap<FirBasedSymbol<*>, EventOccurrencesRange> = persistentMapOf(),
-    ) : ControlFlowInfo<LambdaInvocationInfo, FirBasedSymbol<*>, EventOccurrencesRange>(map) {
-
+    ) : EventOccurrencesRangeInfo<LambdaInvocationInfo, FirBasedSymbol<*>>(map) {
         companion object {
             val EMPTY = LambdaInvocationInfo()
         }
@@ -214,15 +213,6 @@ object FirCallsEffectAnalyzer : FirControlFlowChecker() {
         override val constructor: (PersistentMap<FirBasedSymbol<*>, EventOccurrencesRange>) -> LambdaInvocationInfo =
             ::LambdaInvocationInfo
 
-        fun merge(other: LambdaInvocationInfo): LambdaInvocationInfo {
-            var result = this
-            for (symbol in keys.union(other.keys)) {
-                val kind1 = this[symbol] ?: EventOccurrencesRange.ZERO
-                val kind2 = other[symbol] ?: EventOccurrencesRange.ZERO
-                result = result.put(symbol, kind1 or kind2)
-            }
-            return result
-        }
     }
 
     class PathAwareLambdaInvocationInfo(
@@ -278,7 +268,7 @@ object FirCallsEffectAnalyzer : FirControlFlowChecker() {
             }
         }
 
-        fun merge(other: PathAwareLambdaInvocationInfo): PathAwareLambdaInvocationInfo {
+        override fun merge(other: PathAwareLambdaInvocationInfo): PathAwareLambdaInvocationInfo {
             var resultMap = persistentMapOf<EdgeLabel, LambdaInvocationInfo>()
             for (label in keys.union(other.keys)) {
                 // disjoint merging to preserve paths. i.e., merge the property initialization info if and only if both have the key.

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/FirCallsEffectAnalyzer.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/FirCallsEffectAnalyzer.kt
@@ -289,17 +289,7 @@ object FirCallsEffectAnalyzer : FirControlFlowChecker() {
         ): PathAwareLambdaInvocationInfo {
             val symbol = referenceToSymbol(reference)
             return if (symbol != null) {
-                var resultMap = persistentMapOf<EdgeLabel, LambdaInvocationInfo>()
-                // before: { |-> { p1 |-> PI1 }, l1 |-> { p2 |-> PI2 }
-                for (label in this.keys) {
-                    val dataPerLabel = this[label]!!
-                    val existingKind = dataPerLabel[symbol] ?: EventOccurrencesRange.ZERO
-                    val kind = existingKind + range
-                    resultMap = resultMap.put(label, dataPerLabel.put(symbol, kind))
-                }
-                // after (if symbol is p1):
-                //   { |-> { p1 |-> PI1 + r }, l1 |-> { p1 |-> r, p2 |-> PI2 }
-                PathAwareLambdaInvocationInfo(resultMap)
+                addRange(this, symbol, range, ::PathAwareLambdaInvocationInfo)
             } else this
         }
     }

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/PathAwareControlFlowInfo.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/PathAwareControlFlowInfo.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.fir.analysis.cfa
+
+import kotlinx.collections.immutable.PersistentMap
+import kotlinx.collections.immutable.persistentMapOf
+import org.jetbrains.kotlin.fir.resolve.dfa.cfg.CFGNode
+import org.jetbrains.kotlin.fir.resolve.dfa.cfg.EdgeLabel
+import org.jetbrains.kotlin.fir.resolve.dfa.cfg.NormalPath
+import org.jetbrains.kotlin.fir.resolve.dfa.cfg.TryExpressionExitNode
+
+abstract class PathAwareControlFlowInfo<P : PathAwareControlFlowInfo<P, S>, S : ControlFlowInfo<S, *, *>>(
+    map: PersistentMap<EdgeLabel, S>,
+) : ControlFlowInfo<P, EdgeLabel, S>(map) {
+
+    internal val infoAtNormalPath: S
+        get() = map.getValue(NormalPath)
+
+    private val hasNormalPath: Boolean
+        get() = map.containsKey(NormalPath)
+
+    fun applyLabel(node: CFGNode<*>, label: EdgeLabel): P {
+        if (label.isNormal) {
+            // Special case: when we exit the try expression, null label means a normal path.
+            // Filter out any info bound to non-null label
+            // One day, if we allow multiple edges between nodes with different labels, e.g., labeling all paths in try/catch/finally,
+            // instead of this kind of special handling, proxy enter/exit nodes per label are preferred.
+            if (node is TryExpressionExitNode) {
+                return if (hasNormalPath) {
+                    constructor(persistentMapOf(NormalPath to infoAtNormalPath))
+                } else {
+                    /* This means no info for normal path. */
+                    empty()
+                }
+            }
+            // In general, null label means no additional path info, hence return `this` as-is.
+            @Suppress("UNCHECKED_CAST")
+            return this as P
+        }
+
+        val hasAbnormalLabels = map.keys.any { !it.isNormal }
+        return if (hasAbnormalLabels) {
+            // { |-> ... l1 |-> I1, l2 |-> I2, ... }
+            //   | l1         // path exit: if the given info has non-null labels, this acts like a filtering
+            // { |-> I1 }     // NB: remove the path info
+            if (map.keys.contains(label)) {
+                constructor(persistentMapOf(NormalPath to map[label]!!))
+            } else {
+                /* This means no info for the specific label. */
+                empty()
+            }
+        } else {
+            // { |-> ... }    // empty path info
+            //   | l1         // path entry
+            // { l1 -> ... }  // now, every info bound to the label
+            constructor(persistentMapOf(label to infoAtNormalPath))
+        }
+    }
+
+    override fun merge(other: P): P {
+        var resultMap = persistentMapOf<EdgeLabel, S>()
+        for (label in keys.union(other.keys)) {
+            // disjoint merging to preserve paths. i.e., merge the property initialization info if and only if both have the key.
+            // merge({ |-> I1 }, { |-> I2, l1 |-> I3 })
+            //   == { |-> merge(I1, I2), l1 |-> I3 }
+            val i1 = this[label]
+            val i2 = other[label]
+            resultMap = when {
+                i1 != null && i2 != null ->
+                    resultMap.put(label, i1.merge(i2))
+                i1 != null ->
+                    resultMap.put(label, i1)
+                i2 != null ->
+                    resultMap.put(label, i2)
+                else ->
+                    throw IllegalStateException()
+            }
+        }
+        return constructor(resultMap)
+    }
+}

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/extended/UnusedChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/extended/UnusedChecker.kt
@@ -106,6 +106,9 @@ object UnusedChecker : FirControlFlowChecker() {
         override val constructor: (PersistentMap<FirPropertySymbol, VariableStatus>) -> VariableStatusInfo =
             ::VariableStatusInfo
 
+        override val empty: () -> VariableStatusInfo =
+            ::EMPTY
+
         override fun merge(other: VariableStatusInfo): VariableStatusInfo {
             var result = this
             for (symbol in keys.union(other.keys)) {

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/extended/UnusedChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/extended/UnusedChecker.kt
@@ -106,7 +106,7 @@ object UnusedChecker : FirControlFlowChecker() {
         override val constructor: (PersistentMap<FirPropertySymbol, VariableStatus>) -> VariableStatusInfo =
             ::VariableStatusInfo
 
-        fun merge(other: VariableStatusInfo): VariableStatusInfo {
+        override fun merge(other: VariableStatusInfo): VariableStatusInfo {
             var result = this
             for (symbol in keys.union(other.keys)) {
                 val kind1 = this[symbol] ?: VariableStatus.UNUSED


### PR DESCRIPTION
One of TODOs left after https://github.com/JetBrains/kotlin/pull/3813 is to migrate all existing checkers to use path-sensitive CFG traversals (and then deprecate/remove old, path-insensitive traversals; and then restore names of traversing utils). This PR revises calls effect analyzer to use path-sensitive version.

The underlying info for the calls effect analyzer is event occurrence range. This PR includes some refactoring regarding CFA info whose key and value are `EdgeLabel` and `EventOccurrencesRange`.