### PR TITLE
plugin.serialization: Provide @EncodeDefault annotation for fields

### DIFF
--- a/plugins/kotlin-serialization/kotlin-serialization-compiler/src/org/jetbrains/kotlinx/serialization/compiler/backend/js/SerializerJsTranslator.kt
+++ b/plugins/kotlin-serialization/kotlin-serialization-compiler/src/org/jetbrains/kotlinx/serialization/compiler/backend/js/SerializerJsTranslator.kt
@@ -208,7 +208,7 @@ open class SerializerJsTranslator(
                 ).makeStmt()
             }
 
-            if (!property.optional) {
+            if (!property.optional || property.encodeDefaultMode == EncodeDefaultMode.ALWAYS) {
                 +invocation
             } else {
                 val shouldEncodeFunc = ctx.referenceMethod(kOutputClass, CallingConventions.shouldEncodeDefault)
@@ -218,7 +218,11 @@ open class SerializerJsTranslator(
                 val partA = JsAstUtils.not(KOTLIN_EQUALS.apply(property.jsNameRef(), listOf(defaultValue), ctx))
                 val partB =
                     JsInvocation(JsNameRef(shouldEncodeFunc, localOutputRef), serialClassDescRef, JsIntLiteral(index))
-                val cond = JsBinaryOperation(JsBinaryOperator.OR, partA, partB)
+                val cond =
+                    if (property.encodeDefaultMode == EncodeDefaultMode.NEVER)
+                        partA
+                    else
+                        JsBinaryOperation(JsBinaryOperator.OR, partA, partB)
                 +JsIf(cond, invocation)
             }
         }

--- a/plugins/kotlin-serialization/kotlin-serialization-compiler/src/org/jetbrains/kotlinx/serialization/compiler/resolve/KSerializationUtil.kt
+++ b/plugins/kotlin-serialization/kotlin-serialization-compiler/src/org/jetbrains/kotlinx/serialization/compiler/resolve/KSerializationUtil.kt
@@ -95,6 +95,15 @@ internal val Annotations.serialRequired: Boolean
 internal val Annotations.serialTransient: Boolean
     get() = hasAnnotation(SerializationAnnotations.serialTransientFqName)
 
+enum class EncodeDefaultMode {
+    DEFAULT,
+    ALWAYS,
+    NEVER
+}
+
+internal val Annotations.encodeDefaultMode: EncodeDefaultMode
+    get() = findAnnotationEnumValue<EncodeDefaultMode>(SerializationAnnotations.encodeDefaultModeAnnotationFqName, "mode")
+        ?: EncodeDefaultMode.DEFAULT
 // ----------------------------------------
 
 val KotlinType?.toClassDescriptor: ClassDescriptor?

--- a/plugins/kotlin-serialization/kotlin-serialization-compiler/src/org/jetbrains/kotlinx/serialization/compiler/resolve/NamingConventions.kt
+++ b/plugins/kotlin-serialization/kotlin-serialization-compiler/src/org/jetbrains/kotlinx/serialization/compiler/resolve/NamingConventions.kt
@@ -27,6 +27,7 @@ object SerializationAnnotations {
     val serializerAnnotationFqName = FqName("kotlinx.serialization.Serializer")
     internal val serialNameAnnotationFqName = FqName("kotlinx.serialization.SerialName")
     internal val requiredAnnotationFqName = FqName("kotlinx.serialization.Required")
+    internal val encodeDefaultModeAnnotationFqName = FqName("kotlinx.serialization.EncodeDefault")
     val serialTransientFqName = FqName("kotlinx.serialization.Transient")
     internal val serialInfoFqName = FqName("kotlinx.serialization.SerialInfo")
 

--- a/plugins/kotlin-serialization/kotlin-serialization-compiler/src/org/jetbrains/kotlinx/serialization/compiler/resolve/SearchUtils.kt
+++ b/plugins/kotlin-serialization/kotlin-serialization-compiler/src/org/jetbrains/kotlinx/serialization/compiler/resolve/SearchUtils.kt
@@ -51,6 +51,11 @@ inline fun <reified R> Annotations.findAnnotationConstantValue(annotationFqName:
         annotation.allValueArguments.entries.singleOrNull { it.key.asString() == property }?.value?.value
     } as? R
 
+inline fun <reified R : Enum<R>> Annotations.findAnnotationEnumValue(annotationFqName: FqName, property: String): R? =
+    this.findAnnotationConstantValue<Pair<ClassId, Name>>(annotationFqName, property)?.second?.asString()?.let {
+        enumValueOf<R>(it)
+    }
+
 internal fun Annotations.findAnnotationKotlinTypeValue(
     annotationFqName: FqName,
     moduleForResolve: ModuleDescriptor,

--- a/plugins/kotlin-serialization/kotlin-serialization-compiler/src/org/jetbrains/kotlinx/serialization/compiler/resolve/SerializableProperty.kt
+++ b/plugins/kotlin-serialization/kotlin-serialization-compiler/src/org/jetbrains/kotlinx/serialization/compiler/resolve/SerializableProperty.kt
@@ -37,6 +37,7 @@ class SerializableProperty(
     val module = descriptor.module
     val serializableWith = descriptor.serializableWith ?: analyzeSpecialSerializers(module, descriptor.annotations)?.defaultType
     val optional = !descriptor.annotations.serialRequired && descriptor.declaresDefaultValue
+    val encodeDefaultMode = descriptor.annotations.encodeDefaultMode
     val transient = descriptor.annotations.serialTransient || !hasBackingField
     val annotationsWithArguments: List<Triple<ClassDescriptor, List<ValueArgument>, List<ValueParameterDescriptor>>> =
         descriptor.annotationsWithArguments()


### PR DESCRIPTION
More details are described in Kotlin/kotlinx.serialization#1091.
Tests are included but CI will fail since it needs the new version of the compiler plugin.
See also Kotlin/kotlinx.serialization#1190