### PR TITLE
FIR: handle reference to property with invisible setter

### DIFF
--- a/compiler/fir/cones/src/org/jetbrains/kotlin/fir/symbols/StandardClassIds.kt
+++ b/compiler/fir/cones/src/org/jetbrains/kotlin/fir/symbols/StandardClassIds.kt
@@ -13,7 +13,7 @@ import org.jetbrains.kotlin.name.Name
 object StandardClassIds {
 
     private val BASE_KOTLIN_PACKAGE = FqName("kotlin")
-    private val BASE_REFLECT_PACKAGE = BASE_KOTLIN_PACKAGE.child(Name.identifier("reflect"))
+    val BASE_REFLECT_PACKAGE = BASE_KOTLIN_PACKAGE.child(Name.identifier("reflect"))
     private fun String.baseId() = ClassId(BASE_KOTLIN_PACKAGE, Name.identifier(this))
     private fun ClassId.unsignedId() = ClassId(BASE_KOTLIN_PACKAGE, Name.identifier("U" + shortClassName.identifier))
     private fun String.reflectId() = ClassId(BASE_REFLECT_PACKAGE, Name.identifier(this))

--- a/compiler/fir/raw-fir/light-tree2fir/src/org/jetbrains/kotlin/fir/lightTree/converter/DeclarationsConverter.kt
+++ b/compiler/fir/raw-fir/light-tree2fir/src/org/jetbrains/kotlin/fir/lightTree/converter/DeclarationsConverter.kt
@@ -999,11 +999,23 @@ class DeclarationsConverter(
 
                     val convertedAccessors = accessors.map { convertGetterOrSetter(it, returnType, propertyVisibility, modifiers) }
                     this.getter = convertedAccessors.find { it.isGetter }
-                        ?: FirDefaultPropertyGetter(null, session, FirDeclarationOrigin.Source, returnType, propertyVisibility)
+                        ?: FirDefaultPropertyGetter(
+                            null, session, FirDeclarationOrigin.Source, returnType, propertyVisibility
+                        ).also {
+                            currentDispatchReceiverType()?.lookupTag?.let { lookupTag ->
+                                it.containingClassAttr = lookupTag
+                            }
+                        }
                     this.setter =
                         if (isVar) {
                             convertedAccessors.find { it.isSetter }
-                                ?: FirDefaultPropertySetter(null, session, FirDeclarationOrigin.Source, returnType, propertyVisibility)
+                                ?: FirDefaultPropertySetter(
+                                    null, session, FirDeclarationOrigin.Source, returnType, propertyVisibility
+                                ).also {
+                                    currentDispatchReceiverType()?.lookupTag?.let { lookupTag ->
+                                        it.containingClassAttr = lookupTag
+                                    }
+                                }
                         } else null
 
                     // Upward propagation of `inline` and `external` modifiers (from accessors to property)
@@ -1173,6 +1185,9 @@ class DeclarationsConverter(
             context.firFunctionTargets.removeLast()
         }.also {
             target.bind(it)
+            currentDispatchReceiverType()?.lookupTag?.let { lookupTag ->
+                it.containingClassAttr = lookupTag
+            }
         }
     }
 

--- a/compiler/fir/raw-fir/psi2fir/src/org/jetbrains/kotlin/fir/builder/RawFirBuilder.kt
+++ b/compiler/fir/raw-fir/psi2fir/src/org/jetbrains/kotlin/fir/builder/RawFirBuilder.kt
@@ -350,6 +350,9 @@ class RawFirBuilder(
                             it.extractAnnotationsFrom(this)
                         }
                         it.status = status
+                        currentDispatchReceiverType()?.lookupTag?.let { lookupTag ->
+                            it.containingClassAttr = lookupTag
+                        }
                     }
             }
             val source = this.toFirSourceElement()
@@ -386,6 +389,9 @@ class RawFirBuilder(
                     this.contractDescription = it
                 }
             }.also {
+                currentDispatchReceiverType()?.lookupTag?.let { lookupTag ->
+                    it.containingClassAttr = lookupTag
+                }
                 accessorTarget.bind(it)
                 this@RawFirBuilder.context.firFunctionTargets.removeLast()
             }

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/inference/InferenceUtils.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/inference/InferenceUtils.kt
@@ -29,12 +29,22 @@ import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 
 @OptIn(ExperimentalContracts::class)
-private fun ConeKotlinType.functionClassKind(session: FirSession): FunctionClassKind? {
+private fun ConeKotlinType.classId(session: FirSession): ClassId? {
     contract {
-        returns(true) implies (this@functionClassKind is ConeClassLikeType)
+        returns(true) implies (this@classId is ConeClassLikeType)
     }
     if (this !is ConeClassLikeType) return null
-    val classId = fullyExpandedType(session).lookupTag.classId
+    return fullyExpandedType(session).lookupTag.classId
+}
+
+fun ConeKotlinType.isKMutableProperty(session: FirSession): Boolean {
+    val classId = classId(session) ?: return false
+    return classId.packageFqName == StandardClassIds.BASE_REFLECT_PACKAGE &&
+            classId.shortClassName.identifier.startsWith("KMutableProperty")
+}
+
+private fun ConeKotlinType.functionClassKind(session: FirSession): FunctionClassKind? {
+    val classId = classId(session) ?: return null
     return FunctionClassKind.byClassNamePrefix(classId.packageFqName, classId.relativeClassName.asString())
 }
 

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/providers/impl/FirProviderImpl.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/providers/impl/FirProviderImpl.kt
@@ -121,7 +121,10 @@ class FirProviderImpl(val session: FirSession, val kotlinScopeProvider: KotlinSc
             state.classifierContainerFileMap[classId] = file
         }
 
-        override fun <F : FirCallableDeclaration<F>> visitCallableDeclaration(callableDeclaration: FirCallableDeclaration<F>, data: Pair<State, FirFile>) {
+        override fun <F : FirCallableDeclaration<F>> visitCallableDeclaration(
+            callableDeclaration: FirCallableDeclaration<F>,
+            data: Pair<State, FirFile>
+        ) {
             val symbol = callableDeclaration.symbol
             val callableId = symbol.callableId
             val (state, file) = data
@@ -139,6 +142,8 @@ class FirProviderImpl(val session: FirSession, val kotlinScopeProvider: KotlinSc
 
         override fun visitProperty(property: FirProperty, data: Pair<State, FirFile>) {
             visitCallableDeclaration(property, data)
+            property.getter?.let { visitCallableDeclaration(it, data) }
+            property.setter?.let { visitCallableDeclaration(it, data) }
         }
 
         override fun visitEnumEntry(enumEntry: FirEnumEntry, data: Pair<State, FirFile>) {

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/declarations/FirDeclarationUtil.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/declarations/FirDeclarationUtil.kt
@@ -20,7 +20,6 @@ import org.jetbrains.kotlin.fir.types.ConeClassLikeType
 import org.jetbrains.kotlin.fir.types.ConeFlexibleType
 import org.jetbrains.kotlin.fir.types.builder.buildResolvedTypeRef
 import org.jetbrains.kotlin.fir.types.coneTypeSafe
-import org.jetbrains.kotlin.name.ClassId
 
 fun FirTypeParameterBuilder.addDefaultBoundIfNecessary(isFlexible: Boolean = false) {
     if (bounds.isEmpty()) {
@@ -85,9 +84,6 @@ fun FirRegularClassBuilder.addDeclarations(declarations: Collection<FirDeclarati
 val FirTypeAlias.expandedConeType: ConeClassLikeType? get() = expandedTypeRef.coneTypeSafe()
 
 val FirClass<*>.classId get() = symbol.classId
-
-inline val FirDeclaration.ownerClassId: ClassId?
-    get() = (this as? FirCallableMemberDeclaration<*>)?.symbol?.callableId?.classId
 
 val FirClassSymbol<*>.superConeTypes
     get() = when (this) {

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/declarations/FirDeclarationUtil.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/declarations/FirDeclarationUtil.kt
@@ -20,6 +20,7 @@ import org.jetbrains.kotlin.fir.types.ConeClassLikeType
 import org.jetbrains.kotlin.fir.types.ConeFlexibleType
 import org.jetbrains.kotlin.fir.types.builder.buildResolvedTypeRef
 import org.jetbrains.kotlin.fir.types.coneTypeSafe
+import org.jetbrains.kotlin.name.ClassId
 
 fun FirTypeParameterBuilder.addDefaultBoundIfNecessary(isFlexible: Boolean = false) {
     if (bounds.isEmpty()) {
@@ -84,6 +85,9 @@ fun FirRegularClassBuilder.addDeclarations(declarations: Collection<FirDeclarati
 val FirTypeAlias.expandedConeType: ConeClassLikeType? get() = expandedTypeRef.coneTypeSafe()
 
 val FirClass<*>.classId get() = symbol.classId
+
+inline val FirDeclaration.ownerClassId: ClassId?
+    get() = (this as? FirCallableMemberDeclaration<*>)?.symbol?.callableId?.classId
 
 val FirClassSymbol<*>.superConeTypes
     get() = when (this) {

--- a/compiler/testData/codegen/box/callableReference/property/privateSetterOutsideClass.kt
+++ b/compiler/testData/codegen/box/callableReference/property/privateSetterOutsideClass.kt
@@ -1,6 +1,5 @@
 // DONT_TARGET_EXACT_BACKEND: WASM
 // WASM_MUTE_REASON: PROPERTY_REFERENCES
-// IGNORE_BACKEND_FIR: JVM_IR
 // See KT-12337 Reference to property with invisible setter should not be a KMutableProperty
 
 import kotlin.reflect.KProperty1

--- a/compiler/testData/ir/irText/expressions/propertyReferences.fir.txt
+++ b/compiler/testData/ir/irText/expressions/propertyReferences.fir.txt
@@ -278,20 +278,20 @@ FILE fqName:<root> fileName:/propertyReferences.kt
         RETURN type=kotlin.Nothing from='public final fun <get-test_J_nonConst> (): kotlin.reflect.KMutableProperty0<kotlin.Int> declared in <root>'
           GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:test_J_nonConst type:kotlin.reflect.KMutableProperty0<kotlin.Int> visibility:private [final,static]' type=kotlin.reflect.KMutableProperty0<kotlin.Int> origin=null
   PROPERTY name:test_varWithPrivateSet visibility:public modality:FINAL [val]
-    FIELD PROPERTY_BACKING_FIELD name:test_varWithPrivateSet type:kotlin.reflect.KMutableProperty1<<root>.C, kotlin.Int> visibility:private [final,static]
+    FIELD PROPERTY_BACKING_FIELD name:test_varWithPrivateSet type:kotlin.reflect.KProperty1<<root>.C, kotlin.Int> visibility:private [final,static]
       EXPRESSION_BODY
-        PROPERTY_REFERENCE 'public final varWithPrivateSet: kotlin.Int [var]' field=null getter='public final fun <get-varWithPrivateSet> (): kotlin.Int declared in <root>.C' setter='private final fun <set-varWithPrivateSet> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>.C' type=kotlin.reflect.KMutableProperty1<<root>.C, kotlin.Int> origin=null
-    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-test_varWithPrivateSet> visibility:public modality:FINAL <> () returnType:kotlin.reflect.KMutableProperty1<<root>.C, kotlin.Int>
+        PROPERTY_REFERENCE 'public final varWithPrivateSet: kotlin.Int [var]' field=null getter='public final fun <get-varWithPrivateSet> (): kotlin.Int declared in <root>.C' setter=null type=kotlin.reflect.KProperty1<<root>.C, kotlin.Int> origin=null
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-test_varWithPrivateSet> visibility:public modality:FINAL <> () returnType:kotlin.reflect.KProperty1<<root>.C, kotlin.Int>
       correspondingProperty: PROPERTY name:test_varWithPrivateSet visibility:public modality:FINAL [val]
       BLOCK_BODY
-        RETURN type=kotlin.Nothing from='public final fun <get-test_varWithPrivateSet> (): kotlin.reflect.KMutableProperty1<<root>.C, kotlin.Int> declared in <root>'
-          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:test_varWithPrivateSet type:kotlin.reflect.KMutableProperty1<<root>.C, kotlin.Int> visibility:private [final,static]' type=kotlin.reflect.KMutableProperty1<<root>.C, kotlin.Int> origin=null
+        RETURN type=kotlin.Nothing from='public final fun <get-test_varWithPrivateSet> (): kotlin.reflect.KProperty1<<root>.C, kotlin.Int> declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:test_varWithPrivateSet type:kotlin.reflect.KProperty1<<root>.C, kotlin.Int> visibility:private [final,static]' type=kotlin.reflect.KProperty1<<root>.C, kotlin.Int> origin=null
   PROPERTY name:test_varWithProtectedSet visibility:public modality:FINAL [val]
-    FIELD PROPERTY_BACKING_FIELD name:test_varWithProtectedSet type:kotlin.reflect.KMutableProperty1<<root>.C, kotlin.Int> visibility:private [final,static]
+    FIELD PROPERTY_BACKING_FIELD name:test_varWithProtectedSet type:kotlin.reflect.KProperty1<<root>.C, kotlin.Int> visibility:private [final,static]
       EXPRESSION_BODY
-        PROPERTY_REFERENCE 'public final varWithProtectedSet: kotlin.Int [var]' field=null getter='public final fun <get-varWithProtectedSet> (): kotlin.Int declared in <root>.C' setter='protected final fun <set-varWithProtectedSet> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>.C' type=kotlin.reflect.KMutableProperty1<<root>.C, kotlin.Int> origin=null
-    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-test_varWithProtectedSet> visibility:public modality:FINAL <> () returnType:kotlin.reflect.KMutableProperty1<<root>.C, kotlin.Int>
+        PROPERTY_REFERENCE 'public final varWithProtectedSet: kotlin.Int [var]' field=null getter='public final fun <get-varWithProtectedSet> (): kotlin.Int declared in <root>.C' setter=null type=kotlin.reflect.KProperty1<<root>.C, kotlin.Int> origin=null
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-test_varWithProtectedSet> visibility:public modality:FINAL <> () returnType:kotlin.reflect.KProperty1<<root>.C, kotlin.Int>
       correspondingProperty: PROPERTY name:test_varWithProtectedSet visibility:public modality:FINAL [val]
       BLOCK_BODY
-        RETURN type=kotlin.Nothing from='public final fun <get-test_varWithProtectedSet> (): kotlin.reflect.KMutableProperty1<<root>.C, kotlin.Int> declared in <root>'
-          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:test_varWithProtectedSet type:kotlin.reflect.KMutableProperty1<<root>.C, kotlin.Int> visibility:private [final,static]' type=kotlin.reflect.KMutableProperty1<<root>.C, kotlin.Int> origin=null
+        RETURN type=kotlin.Nothing from='public final fun <get-test_varWithProtectedSet> (): kotlin.reflect.KProperty1<<root>.C, kotlin.Int> declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:test_varWithProtectedSet type:kotlin.reflect.KProperty1<<root>.C, kotlin.Int> visibility:private [final,static]' type=kotlin.reflect.KProperty1<<root>.C, kotlin.Int> origin=null


### PR DESCRIPTION
The motivation is bb test `callableReference/property/privateSetterOutsideClass.kt`, which is originated from [KT-12337](https://youtrack.jetbrains.com/issue/KT-12337):
```kt
open class Bar(name: String) {
    var foo: String = name
        private set
}

fun box(): String {
    val p1: KProperty1<Bar, String> = Bar::foo
    if (p1 is KMutableProperty<*>) return "Fail: p1 is a KMutableProperty"
    ...
}
```
For `Bar::foo`, its type shouldn't be `KMutableProperty`. Also, `setter` for `IrPropertyReference` shouldn't be set if the target property reference is not mutable.

Checking mutability of a property needs more sophisticated logic than expected: we should consider _where_ the reference is used. E.g., even though a property has a `private` setter, it's still mutable if it's referenced in the same class's members or inner/local classes' members.