### PR TITLE
Add always-do-smart-step setting to debugger

### DIFF
--- a/idea/jvm-debugger/jvm-debugger-core/resources/messages/KotlinDebuggerCoreBundle.properties
+++ b/idea/jvm-debugger/jvm-debugger-core/resources/messages/KotlinDebuggerCoreBundle.properties
@@ -13,6 +13,7 @@ line.breakpoint=Line breakpoint
 line.and.lambda.breakpoint=Line and {0,choice,1#Lambda|2#Lambdas} Breakpoints
 
 filter.ignore.internal.classes=Do not step into Kotlin runtime library implementation classes
+always.do.smart.step.into=Always do smart step into
 variables.calculate.delegated.property.values=Calculate values of delegated properties (may affect program execution)
 variables.disable.coroutine.agent.values=Disable coroutine agent
 variables.disable.coroutine.agent.tooltip=Disables coroutine agent for Gradle and Java run configurations

--- a/idea/jvm-debugger/jvm-debugger-core/src/org/jetbrains/kotlin/idea/debugger/KotlinDebuggerSettings.kt
+++ b/idea/jvm-debugger/jvm-debugger-core/src/org/jetbrains/kotlin/idea/debugger/KotlinDebuggerSettings.kt
@@ -21,6 +21,7 @@ import org.jetbrains.kotlin.idea.debugger.stepping.KotlinSteppingConfigurableUi
 class KotlinDebuggerSettings : XDebuggerSettings<KotlinDebuggerSettings>("kotlin_debugger"), Getter<KotlinDebuggerSettings> {
     var renderDelegatedProperties: Boolean = false
     var disableKotlinInternalClasses: Boolean = true
+    var alwaysDoSmartStep: Boolean = true
     var debugDisableCoroutineAgent: Boolean = false
 
     companion object {

--- a/idea/jvm-debugger/jvm-debugger-core/src/org/jetbrains/kotlin/idea/debugger/stepping/KotlinSteppingConfigurableUi.form
+++ b/idea/jvm-debugger/jvm-debugger-core/src/org/jetbrains/kotlin/idea/debugger/stepping/KotlinSteppingConfigurableUi.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="org.jetbrains.kotlin.idea.debugger.stepping.KotlinSteppingConfigurableUi">
-  <grid id="27dc6" binding="myPanel" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="myPanel" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="662" height="400"/>
@@ -17,9 +17,17 @@
           <text resource-bundle="messages/KotlinDebuggerCoreBundle" key="filter.ignore.internal.classes"/>
         </properties>
       </component>
+      <component id="bf57" class="javax.swing.JCheckBox" binding="alwaysDoSmartStep">
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text resource-bundle="messages/KotlinDebuggerCoreBundle" key="always.do.smart.step.into"/>
+        </properties>
+      </component>
       <vspacer id="c37da">
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
     </children>

--- a/idea/jvm-debugger/jvm-debugger-core/src/org/jetbrains/kotlin/idea/debugger/stepping/KotlinSteppingConfigurableUi.java
+++ b/idea/jvm-debugger/jvm-debugger-core/src/org/jetbrains/kotlin/idea/debugger/stepping/KotlinSteppingConfigurableUi.java
@@ -25,22 +25,25 @@ import javax.swing.*;
 
 public class KotlinSteppingConfigurableUi implements ConfigurableUi<KotlinDebuggerSettings> {
     private JCheckBox ignoreKotlinMethods;
+    private JCheckBox alwaysDoSmartStep;
     private JPanel myPanel;
 
     @Override
     public void reset(@NotNull KotlinDebuggerSettings settings) {
-        boolean flag = settings.getDisableKotlinInternalClasses();
-        ignoreKotlinMethods.setSelected(flag);
+        ignoreKotlinMethods.setSelected(settings.getDisableKotlinInternalClasses());
+        alwaysDoSmartStep.setSelected(settings.getAlwaysDoSmartStep());
     }
 
     @Override
     public boolean isModified(@NotNull KotlinDebuggerSettings settings) {
-        return settings.getDisableKotlinInternalClasses() != ignoreKotlinMethods.isSelected();
+        return settings.getDisableKotlinInternalClasses() != ignoreKotlinMethods.isSelected() ||
+               settings.getAlwaysDoSmartStep() != alwaysDoSmartStep.isSelected();
     }
 
     @Override
     public void apply(@NotNull KotlinDebuggerSettings settings) {
         settings.setDisableKotlinInternalClasses(ignoreKotlinMethods.isSelected());
+        settings.setAlwaysDoSmartStep(alwaysDoSmartStep.isSelected());
     }
 
     @NotNull

--- a/idea/jvm-debugger/jvm-debugger-core/src/org/jetbrains/kotlin/idea/debugger/stepping/smartStepInto/KotlinSmartStepIntoHandler.kt
+++ b/idea/jvm-debugger/jvm-debugger-core/src/org/jetbrains/kotlin/idea/debugger/stepping/smartStepInto/KotlinSmartStepIntoHandler.kt
@@ -9,10 +9,13 @@ import com.intellij.debugger.SourcePosition
 import com.intellij.debugger.actions.JvmSmartStepIntoHandler
 import com.intellij.debugger.actions.SmartStepTarget
 import com.intellij.debugger.engine.MethodFilter
+import com.intellij.debugger.impl.DebuggerSession
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.util.Range
 import com.intellij.util.containers.OrderedSet
+import org.jetbrains.concurrency.Promise
 import org.jetbrains.kotlin.idea.core.util.CodeInsightUtils.getTopmostElementAtOffset
+import org.jetbrains.kotlin.idea.debugger.KotlinDebuggerSettings
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.idea.util.application.runReadAction
 
@@ -33,6 +36,13 @@ class KotlinSmartStepIntoHandler : JvmSmartStepIntoHandler() {
             ktElement.accept(visitor, null)
             return@runReadAction consumer
         }
+    }
+
+    override fun findStepIntoTargets(position: SourcePosition?, session: DebuggerSession?): Promise<MutableList<SmartStepTarget>> {
+        return if (KotlinDebuggerSettings.getInstance().alwaysDoSmartStep) super.findSmartStepTargetsAsync(
+            position,
+            session
+        ) else super.findStepIntoTargets(position, session)
     }
 
     override fun createMethodFilter(stepTarget: SmartStepTarget?): MethodFilter? {


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-31558

This feature already exists in Java debugger and should also exist
in Kotlin debugger in order to provide a consistent experience.

The core of the feature is documented below:
https://www.jetbrains.com/help/idea/stepping-through-the-program.html#step-into