### PR TITLE
MPP plugin: add expectedBy deps to "api" configuration

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BaseGradleIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BaseGradleIT.kt
@@ -153,13 +153,15 @@ abstract class BaseGradleIT {
             return wrapper
         }
 
-        fun mightUpdateSettingsScript(wrapperVersion: String, settingsScript: File) {
+        fun maybeUpdateSettingsScript(wrapperVersion: String, settingsScript: File) {
             // enableFeaturePreview("GRADLE_METADATA") is no longer needed when building with Gradle 5.4 or above
-            if (GradleVersion.version(wrapperVersion) > GradleVersion.version("5.3")) {
+            if (GradleVersion.version(wrapperVersion) >= GradleVersion.version("5.4")) {
                 settingsScript.apply {
                     if(exists()) {
                         modify {
                             it.replace("enableFeaturePreview('GRADLE_METADATA')", "//")
+                        }
+                        modify {
                             it.replace("enableFeaturePreview(\"GRADLE_METADATA\")", "//")
                         }
                     }
@@ -336,8 +338,6 @@ abstract class BaseGradleIT {
         val env = createEnvironmentVariablesMap(options)
         val wrapperDir = prepareWrapper(wrapperVersion, env)
 
-        mightUpdateSettingsScript(wrapperVersion, gradleSettingsScript())
-
         val cmd = createBuildCommand(wrapperDir, params, options)
 
         println("<=== Test build: ${this.projectName} $cmd ===>")
@@ -345,6 +345,8 @@ abstract class BaseGradleIT {
         if (!projectDir.exists()) {
             setupWorkingDir()
         }
+
+        maybeUpdateSettingsScript(wrapperVersion, gradleSettingsScript())
 
         val result = runProcess(cmd, projectDir, env, options)
         try {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BuildCacheRelocationIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BuildCacheRelocationIT.kt
@@ -36,7 +36,6 @@ class BuildCacheRelocationIT : BaseGradleIT() {
     override fun defaultBuildOptions(): BuildOptions =
         super.defaultBuildOptions().copy(
             withBuildCache = true,
-            androidGradlePluginVersion = AGPVersion.v3_6_0,
             androidHome = KotlinTestUtils.findAndroidSdk()
         )
 
@@ -64,7 +63,10 @@ class BuildCacheRelocationIT : BaseGradleIT() {
             lateinit var firstOutputHashes: List<Pair<File, Int>>
 
             workingDir = workingDirs[0]
-            firstProject.build(*testCase.taskToExecute) {
+            firstProject.build(
+                *testCase.taskToExecute,
+                options = defaultBuildOptions().copy(androidGradlePluginVersion = testCase.androidGradlePluginVersion)
+            ) {
                 assertSuccessful()
                 firstOutputHashes = hashOutputFiles(outputRoots)
                 cacheableTaskNames.forEach { assertTaskPackedToCache(":$it") }
@@ -73,9 +75,10 @@ class BuildCacheRelocationIT : BaseGradleIT() {
             workingDir = workingDirs[1]
             val alternateBuildEnvOptions = if (withAnotherGradleHome) {
                 val alternateGradleHome = File(firstProject.projectDir.parentFile, "gradleUserHome")
-                defaultBuildOptions().copy(gradleUserHome = alternateGradleHome)
+                defaultBuildOptions().copy(
+                    gradleUserHome = alternateGradleHome, androidGradlePluginVersion = testCase.androidGradlePluginVersion)
             } else {
-                defaultBuildOptions()
+                defaultBuildOptions().copy(androidGradlePluginVersion = testCase.androidGradlePluginVersion)
             }
             secondProject.build(*testCase.taskToExecute, options = alternateBuildEnvOptions) {
                 assertSuccessful()
@@ -97,7 +100,8 @@ class BuildCacheRelocationIT : BaseGradleIT() {
         val initProject: Project.() -> Unit = {},
         val taskToExecute: Array<String>,
         val withAnotherGradleHome: Boolean = false,
-        val gradleVersionRequired: GradleVersionRequired = DEFAULT_GRADLE_VERSION
+        val gradleVersionRequired: GradleVersionRequired = DEFAULT_GRADLE_VERSION,
+        val androidGradlePluginVersion: AGPVersion? = null
     ) {
 
         override fun toString(): String = (projectDirectoryPrefix?.plus("/") ?: "") + projectName
@@ -156,7 +160,8 @@ class BuildCacheRelocationIT : BaseGradleIT() {
                              }
                          }
                      },
-                     outputRootPaths = listOf("Lib", "Android", "Test").map { "$it/build" }
+                     outputRootPaths = listOf("Lib", "Android", "Test").map { "$it/build" },
+                     androidGradlePluginVersion = AGPVersion.v3_6_0
             ),
             TestCase("android-dagger",
                      taskToExecute = arrayOf("assembleDebug"),
@@ -167,7 +172,8 @@ class BuildCacheRelocationIT : BaseGradleIT() {
                          }
                      },
                      outputRootPaths = listOf("app/build"),
-                     initProject = { File(projectDir, "app/build.gradle").appendText("\nkapt.useBuildCache = true") }
+                     initProject = { File(projectDir, "app/build.gradle").appendText("\nkapt.useBuildCache = true") },
+                     androidGradlePluginVersion = AGPVersion.v3_6_0
             ),
             TestCase("native-build-cache",
                      taskToExecute = arrayOf("build-cache-lib:publish", "build-cache-app:assemble"),

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/ConfigurationCacheForAndroidIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/ConfigurationCacheForAndroidIT.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.gradle
 
+import org.gradle.api.logging.configuration.WarningMode
 import org.jetbrains.kotlin.gradle.util.AGPVersion
 import org.jetbrains.kotlin.test.KotlinTestUtils
 import org.junit.Test
@@ -18,7 +19,8 @@ class ConfigurationCacheForAndroidIT : AbstractConfigurationCacheIT() {
             androidHome = KotlinTestUtils.findAndroidSdk(),
             androidGradlePluginVersion = androidGradlePluginVersion,
             configurationCache = true,
-            configurationCacheProblems = ConfigurationCacheProblems.FAIL
+            configurationCacheProblems = ConfigurationCacheProblems.FAIL,
+            warningMode = WarningMode.Summary
         )
 
     @Test

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/ConfigurationCacheForAndroidIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/ConfigurationCacheForAndroidIT.kt
@@ -19,8 +19,7 @@ class ConfigurationCacheForAndroidIT : AbstractConfigurationCacheIT() {
             androidHome = KotlinTestUtils.findAndroidSdk(),
             androidGradlePluginVersion = androidGradlePluginVersion,
             configurationCache = true,
-            configurationCacheProblems = ConfigurationCacheProblems.FAIL,
-            warningMode = WarningMode.Summary
+            configurationCacheProblems = ConfigurationCacheProblems.FAIL
         )
 
     @Test
@@ -39,7 +38,10 @@ class ConfigurationCacheForAndroidIT : AbstractConfigurationCacheIT() {
     @Test
     fun testKotlinAndroidProjectTests() = with(Project("AndroidIncrementalMultiModule")) {
         applyAndroid40Alpha4KotlinVersionWorkaround()
-        testConfigurationCacheOf(":app:compileDebugAndroidTestKotlin", ":app:compileDebugUnitTestKotlin")
+        testConfigurationCacheOf(
+            ":app:compileDebugAndroidTestKotlin", ":app:compileDebugUnitTestKotlin",
+            buildOptions = defaultBuildOptions().copy(warningMode = WarningMode.Summary)
+        )
     }
 
     /**

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/ConfigurationCacheIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/ConfigurationCacheIT.kt
@@ -92,7 +92,7 @@ abstract class AbstractConfigurationCacheIT : BaseGradleIT() {
             checkInstantExecutionSucceeded()
         }
 
-        build("clean") {
+        build("clean", options = buildOptions) {
             assertSuccessful()
         }
 

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/DukatIntegrationIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/DukatIntegrationIT.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.gradle
 
+import org.gradle.api.logging.configuration.WarningMode
 import org.jetbrains.kotlin.gradle.targets.js.dukat.ExternalsOutputFormat
 import org.jetbrains.kotlin.gradle.util.modify
 import org.junit.Test
@@ -330,7 +331,7 @@ class DukatIntegrationIT : BaseGradleIT() {
         project.setupWorkingDir()
         project.gradleBuildScript().modify(::transformBuildScriptWithPluginsDsl)
 
-        project.build("assemble") {
+        project.build("assemble", options = defaultBuildOptions().copy(warningMode = WarningMode.Summary)) {
             assertSuccessful()
         }
     }
@@ -381,7 +382,7 @@ class DukatIntegrationIT : BaseGradleIT() {
         }
 
         val externalSrcs = "build/externals/both-jsIr/src"
-        project.build("assemble") {
+        project.build("assemble", options = defaultBuildOptions().copy(warningMode = WarningMode.Summary)) {
             assertSuccessful()
 
             assertTasksExecuted(":irGenerateExternalsIntegrated")

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/IncrementalCompilationMultiProjectIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/IncrementalCompilationMultiProjectIT.kt
@@ -71,8 +71,8 @@ class IncrementalCompilationJvmMultiProjectIT : BaseIncrementalCompilationMultiP
             apply plugin: 'kotlin'
 
             dependencies {
-                compile "org.jetbrains.kotlin:kotlin-stdlib:${"$"}kotlin_version"
-                compile 'org.codehaus.groovy:groovy-all:2.4.8'
+                implementation "org.jetbrains.kotlin:kotlin-stdlib:${"$"}kotlin_version"
+                implementation 'org.codehaus.groovy:groovy-all:2.4.8'
             }
             """.trimIndent()
         }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kapt3IT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kapt3IT.kt
@@ -16,6 +16,7 @@
 
 package org.jetbrains.kotlin.gradle
 
+import org.gradle.api.logging.configuration.WarningMode
 import org.jetbrains.kotlin.gradle.tasks.USING_JVM_INCREMENTAL_COMPILATION_MESSAGE
 import org.jetbrains.kotlin.gradle.util.*
 import org.junit.Assert
@@ -30,7 +31,7 @@ abstract class Kapt3BaseIT : BaseGradleIT() {
     }
 
     override fun defaultBuildOptions(): BuildOptions =
-        super.defaultBuildOptions().copy(kaptOptions = kaptOptions())
+        super.defaultBuildOptions().copy(kaptOptions = kaptOptions(), warningMode = WarningMode.Summary)
 
     protected open fun kaptOptions(): KaptOptions =
         KaptOptions(verbose = true, useWorkers = false)

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kotlin2JsGradlePluginIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kotlin2JsGradlePluginIT.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.gradle
 
 import com.google.gson.Gson
 import org.gradle.api.logging.LogLevel
+import org.gradle.api.logging.configuration.WarningMode
 import org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType
 import org.jetbrains.kotlin.gradle.targets.js.ir.KLIB_TYPE
 import org.jetbrains.kotlin.gradle.targets.js.npm.*
@@ -22,6 +23,11 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class Kotlin2JsIrGradlePluginIT : AbstractKotlin2JsGradlePluginIT(true) {
+
+    override fun defaultBuildOptions(): BuildOptions {
+        return super.defaultBuildOptions().copy(warningMode = WarningMode.Summary)
+    }
+
     @Test
     fun generateDts() {
         val project = Project("kotlin2JsIrDtsGeneration")
@@ -116,6 +122,11 @@ class Kotlin2JsIrGradlePluginIT : AbstractKotlin2JsGradlePluginIT(true) {
 }
 
 class Kotlin2JsGradlePluginIT : AbstractKotlin2JsGradlePluginIT(false) {
+
+    override fun defaultBuildOptions(): BuildOptions {
+        return super.defaultBuildOptions().copy(warningMode = WarningMode.Summary)
+    }
+
     @Test
     fun testKotlinJsBuiltins() {
         val project = Project("kotlinBuiltins")

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinGradlePluginIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinGradlePluginIT.kt
@@ -17,6 +17,7 @@
 package org.jetbrains.kotlin.gradle
 
 import org.gradle.api.logging.LogLevel
+import org.gradle.api.logging.configuration.WarningMode
 import org.jetbrains.kotlin.gradle.plugin.MULTIPLE_KOTLIN_PLUGINS_LOADED_WARNING
 import org.jetbrains.kotlin.gradle.plugin.MULTIPLE_KOTLIN_PLUGINS_SPECIFIC_PROJECTS_WARNING
 import org.jetbrains.kotlin.gradle.scripting.internal.ScriptingGradleSubplugin
@@ -34,6 +35,10 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class KotlinGradleIT : BaseGradleIT() {
+
+    override fun defaultBuildOptions(): BuildOptions {
+        return super.defaultBuildOptions().copy(warningMode = WarningMode.Summary)
+    }
 
     @Test
     fun testCrossCompile() {
@@ -774,12 +779,12 @@ class KotlinGradleIT : BaseGradleIT() {
         with(Project("simpleProject")) {
             setupWorkingDir()
             // Add a dependency with an explicit lower Kotlin version that has a kotlin-stdlib transitive dependency:
-            gradleBuildScript().appendText("\ndependencies { compile 'org.jetbrains.kotlin:kotlin-reflect:1.2.71' }")
+            gradleBuildScript().appendText("\ndependencies { implementation 'org.jetbrains.kotlin:kotlin-reflect:1.2.71' }")
             testResolveAllConfigurations {
                 assertSuccessful()
-                assertContains(">> :compile --> kotlin-reflect-1.2.71.jar")
+                assertContains(">> :compileClasspath --> kotlin-reflect-1.2.71.jar")
                 // Check that the default newer Kotlin version still wins for 'kotlin-stdlib':
-                assertContains(">> :compile --> kotlin-stdlib-${defaultBuildOptions().kotlinVersion}.jar")
+                assertContains(">> :compileClasspath --> kotlin-stdlib-${defaultBuildOptions().kotlinVersion}.jar")
             }
         }
 

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinGradlePluginIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinGradlePluginIT.kt
@@ -776,7 +776,7 @@ class KotlinGradleIT : BaseGradleIT() {
             setupWorkingDir()
             // Add a dependency with an explicit lower Kotlin version that has a kotlin-stdlib transitive dependency:
             gradleBuildScript().appendText("\ndependencies { implementation 'org.jetbrains.kotlin:kotlin-reflect:1.2.71' }")
-            testResolveAllConfigurations {
+            testResolveAllConfigurations(options = defaultBuildOptions().copy(warningMode = WarningMode.Summary)) {
                 assertSuccessful()
                 assertContains(">> :compileClasspath --> kotlin-reflect-1.2.71.jar")
                 // Check that the default newer Kotlin version still wins for 'kotlin-stdlib':

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinGradlePluginIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinGradlePluginIT.kt
@@ -36,10 +36,6 @@ import kotlin.test.assertTrue
 
 class KotlinGradleIT : BaseGradleIT() {
 
-    override fun defaultBuildOptions(): BuildOptions {
-        return super.defaultBuildOptions().copy(warningMode = WarningMode.Summary)
-    }
-
     @Test
     fun testCrossCompile() {
         val project = Project("kotlinJavaProject")
@@ -395,7 +391,7 @@ class KotlinGradleIT : BaseGradleIT() {
             """.trimIndent()
         }
 
-        project.build("build", "install") {
+        project.build("build", "install", options = defaultBuildOptions().copy(warningMode = WarningMode.Summary)) {
             assertSuccessful()
             assertTasksExecuted(":compileKotlin", ":compileTestKotlin")
             val pomLines = File(project.projectDir, "build/poms/pom-default.xml").readLines()
@@ -934,7 +930,7 @@ class KotlinGradleIT : BaseGradleIT() {
         setupWorkingDir()
         gradleBuildScript().modify(::transformBuildScriptWithPluginsDsl)
 
-        build("publish", "check", "runBenchmark") {
+        build("publish", "check", "runBenchmark", options = defaultBuildOptions().copy(warningMode = WarningMode.Summary)) {
             assertSuccessful()
             assertTasksExecuted(":compileKotlin", ":compileTestKotlin", ":compileBenchmarkKotlin", ":test", ":runBenchmark")
 

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/MultiplatformGradleIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/MultiplatformGradleIT.kt
@@ -226,7 +226,7 @@ class MultiplatformGradleIT : BaseGradleIT() {
             ${'\n'}
             task printCompileConfiguration(type: DefaultTask) {
                 doFirst {
-                    configurations.compile.resolvedConfiguration.resolvedArtifacts.each {
+                    configurations.getByName("api").dependencies.each {
                         println("Dependency: '" + it.name + "'")
                     }
                 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/MultiplatformGradleIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/MultiplatformGradleIT.kt
@@ -17,6 +17,7 @@
 package org.jetbrains.kotlin.gradle
 
 import com.intellij.testFramework.TestDataPath
+import org.gradle.api.logging.configuration.WarningMode
 import org.jetbrains.kotlin.gradle.internals.KOTLIN_12X_MPP_DEPRECATION_WARNING
 import org.jetbrains.kotlin.gradle.plugin.EXPECTED_BY_CONFIG_NAME
 import org.jetbrains.kotlin.gradle.plugin.IMPLEMENT_CONFIG_NAME
@@ -175,7 +176,7 @@ class MultiplatformGradleIT : BaseGradleIT() {
 
     @Test
     fun testMultipleCommonModules(): Unit = with(Project("multiplatformMultipleCommonModules")) {
-        build("build") {
+        build("build", options = defaultBuildOptions().copy(warningMode = WarningMode.Summary)) {
             assertSuccessful()
 
             val sourceSets = listOf("", "Test")
@@ -305,7 +306,7 @@ class MultiplatformGradleIT : BaseGradleIT() {
         val customSourceSetCompileTasks = listOf(":lib" to "Common", ":libJs" to "2Js", ":libJvm" to "")
             .map { (module, platform) -> "$module:compile${sourceSetName.capitalize()}Kotlin$platform" }
 
-        build(*customSourceSetCompileTasks.toTypedArray()) {
+        build(*customSourceSetCompileTasks.toTypedArray(), options = defaultBuildOptions().copy(warningMode = WarningMode.Summary)) {
             assertSuccessful()
             assertTasksExecuted(customSourceSetCompileTasks)
         }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/NewMultiplatformIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/NewMultiplatformIT.kt
@@ -6,6 +6,7 @@ package org.jetbrains.kotlin.gradle
 
 import org.jetbrains.kotlin.gradle.native.GeneralNativeIT.Companion.checkNativeCommandLineArguments
 import org.jetbrains.kotlin.gradle.native.GeneralNativeIT.Companion.containsSequentially
+import org.gradle.api.logging.configuration.WarningMode
 import org.jetbrains.kotlin.gradle.native.MPPNativeTargets
 import org.jetbrains.kotlin.gradle.native.configureMemoryInGradleProperties
 import org.jetbrains.kotlin.gradle.native.transformNativeTestProject
@@ -42,6 +43,10 @@ class NewMultiplatformIT : BaseGradleIT() {
 
     private fun Project.targetClassesDir(targetName: String, sourceSetName: String = "main") =
         classesDir(sourceSet = "$targetName/$sourceSetName")
+
+    override fun defaultBuildOptions(): BuildOptions {
+        return super.defaultBuildOptions().copy(warningMode = WarningMode.Summary)
+    }
 
     @Test
     fun testLibAndApp() = doTestLibAndApp(

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/NewMultiplatformIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/NewMultiplatformIT.kt
@@ -44,10 +44,6 @@ class NewMultiplatformIT : BaseGradleIT() {
     private fun Project.targetClassesDir(targetName: String, sourceSetName: String = "main") =
         classesDir(sourceSet = "$targetName/$sourceSetName")
 
-    override fun defaultBuildOptions(): BuildOptions {
-        return super.defaultBuildOptions().copy(warningMode = WarningMode.Summary)
-    }
-
     @Test
     fun testLibAndApp() = doTestLibAndApp(
         "sample-lib",
@@ -1280,7 +1276,7 @@ class NewMultiplatformIT : BaseGradleIT() {
 
     @Test
     fun testJsDceInMpp() = with(Project("new-mpp-js-dce", gradleVersion)) {
-        build("runRhino") {
+        build("runRhino", options = defaultBuildOptions().copy(warningMode = WarningMode.Summary)) {
             assertSuccessful()
             assertTasksExecuted(":mainProject:runDceNodeJsKotlin")
 
@@ -1365,7 +1361,7 @@ class NewMultiplatformIT : BaseGradleIT() {
     fun testDependenciesDsl() = with(transformProjectWithPluginsDsl("newMppDependenciesDsl")) {
         val originalBuildscriptContent = gradleBuildScript("app").readText()
 
-        fun testDependencies() = testResolveAllConfigurations("app") {
+        fun testDependencies() = testResolveAllConfigurations("app", options = defaultBuildOptions().copy(warningMode = WarningMode.Summary)) {
             assertContains(">> :app:testNonTransitiveStringNotationApiDependenciesMetadata --> junit-4.12.jar")
             assertEquals(
                 1,
@@ -1399,7 +1395,7 @@ class NewMultiplatformIT : BaseGradleIT() {
 
     @Test
     fun testMultipleTargetsSamePlatform() = with(Project("newMppMultipleTargetsSamePlatform", gradleVersion)) {
-        testResolveAllConfigurations("app") {
+        testResolveAllConfigurations("app", options = defaultBuildOptions().copy(warningMode = WarningMode.Summary)) {
             assertContains(">> :app:junitCompileClasspath --> lib-junit.jar")
             assertContains(">> :app:junitCompileClasspath --> junit-4.12.jar")
 
@@ -1489,7 +1485,7 @@ class NewMultiplatformIT : BaseGradleIT() {
 
         val groupDir = "build/repo/com/example/"
 
-        build(":mpp-lib:publish") {
+        build(":mpp-lib:publish", options = defaultBuildOptions().copy(warningMode = WarningMode.Summary)) {
             assertSuccessful()
             assertFileExists(groupDir + "mpp-lib")
             assertFileExists(groupDir + "mpp-lib-myjvm")
@@ -1506,7 +1502,7 @@ class NewMultiplatformIT : BaseGradleIT() {
                     add("-Pkotlin.mpp.keepMppDependenciesIntactInPoms=true")
             }.toTypedArray()
 
-            build(*params) {
+            build(*params, options = defaultBuildOptions().copy(warningMode = WarningMode.Summary)) {
                 assertSuccessful()
                 if (legacyPublishing) {
                     assertTasksExecuted(":jvm-app:uploadArchives")

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/SimpleKotlinGradleIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/SimpleKotlinGradleIT.kt
@@ -1,11 +1,16 @@
 package org.jetbrains.kotlin.gradle
 
+import org.gradle.api.logging.configuration.WarningMode
 import org.jetbrains.kotlin.gradle.util.modify
 import org.junit.Test
 import java.io.File
 import kotlin.test.assertTrue
 
 class SimpleKotlinGradleIT : BaseGradleIT() {
+
+    override fun defaultBuildOptions(): BuildOptions {
+        return super.defaultBuildOptions().copy(warningMode = WarningMode.Summary)
+    }
 
     @Test
     fun testSimpleCompile() {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/SubpluginsIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/SubpluginsIT.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.gradle
 
+import org.gradle.api.logging.configuration.WarningMode
 import org.jetbrains.kotlin.gradle.util.AGPVersion
 import org.jetbrains.kotlin.gradle.util.checkBytecodeContains
 import org.jetbrains.kotlin.gradle.util.modify
@@ -14,6 +15,11 @@ import java.io.File
 import kotlin.test.assertTrue
 
 class SubpluginsIT : BaseGradleIT() {
+
+    override fun defaultBuildOptions(): BuildOptions {
+        return super.defaultBuildOptions().copy(warningMode = WarningMode.Summary)
+    }
+
     @Test
     fun testGradleSubplugin() {
         val project = Project("kotlinGradleSubplugin")

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/VariantAwareDependenciesIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/VariantAwareDependenciesIT.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.gradle
 
+import org.gradle.api.logging.configuration.WarningMode
 import org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType
 import org.jetbrains.kotlin.gradle.util.*
 import org.junit.Test
@@ -12,6 +13,10 @@ import kotlin.test.assertTrue
 
 class VariantAwareDependenciesIT : BaseGradleIT() {
     private val gradleVersion = GradleVersionRequired.FOR_MPP_SUPPORT
+
+    override fun defaultBuildOptions(): BuildOptions {
+        return super.defaultBuildOptions().copy(warningMode = WarningMode.Summary)
+    }
 
     @Test
     fun testJvmKtAppResolvesMppLib() {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/GeneralNativeIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/GeneralNativeIT.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.gradle.native
 
 import com.intellij.testFramework.TestDataFile
+import org.gradle.api.logging.configuration.WarningMode
 import org.jdom.input.SAXBuilder
 import org.jetbrains.kotlin.gradle.BaseGradleIT
 import org.jetbrains.kotlin.gradle.GradleVersionRequired
@@ -92,6 +93,10 @@ class GeneralNativeIT : BaseGradleIT() {
 
     override val defaultGradleVersion: GradleVersionRequired
         get() = GradleVersionRequired.FOR_MPP_SUPPORT
+
+    override fun defaultBuildOptions(): BuildOptions {
+        return super.defaultBuildOptions().copy(warningMode = WarningMode.Summary)
+    }
 
     @Test
     fun testParallelExecutionSmoke(): Unit = with(transformNativeTestProjectWithPluginDsl("native-parallel")) {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/GeneralNativeIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/GeneralNativeIT.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlin.gradle.native
 
 import com.intellij.testFramework.TestDataFile
-import org.gradle.api.logging.configuration.WarningMode
 import org.jdom.input.SAXBuilder
 import org.jetbrains.kotlin.gradle.BaseGradleIT
 import org.jetbrains.kotlin.gradle.GradleVersionRequired
@@ -93,10 +92,6 @@ class GeneralNativeIT : BaseGradleIT() {
 
     override val defaultGradleVersion: GradleVersionRequired
         get() = GradleVersionRequired.FOR_MPP_SUPPORT
-
-    override fun defaultBuildOptions(): BuildOptions {
-        return super.defaultBuildOptions().copy(warningMode = WarningMode.Summary)
-    }
 
     @Test
     fun testParallelExecutionSmoke(): Unit = with(transformNativeTestProjectWithPluginDsl("native-parallel")) {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/util/testResolveAllConfigurations.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/util/testResolveAllConfigurations.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.gradle.util
 
+import org.gradle.api.logging.configuration.WarningMode
 import org.jetbrains.kotlin.gradle.BaseGradleIT
 import kotlin.test.assertTrue
 
@@ -31,7 +32,7 @@ fun BaseGradleIT.Project.testResolveAllConfigurations(
         }
     }
 
-    build(RESOLVE_ALL_CONFIGURATIONS_TASK_NAME) {
+    build(RESOLVE_ALL_CONFIGURATIONS_TASK_NAME, options = defaultBuildOptions().copy(warningMode = WarningMode.Summary)) {
         assertSuccessful()
         assertTasksExecuted(":${subproject?.let { "$it:" }.orEmpty()}$RESOLVE_ALL_CONFIGURATIONS_TASK_NAME")
         val unresolvedConfigurations = unresolvedConfigurationRegex.findAll(output).map { it.groupValues[1] }.toList()

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/util/testResolveAllConfigurations.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/util/testResolveAllConfigurations.kt
@@ -17,6 +17,7 @@ fun BaseGradleIT.Project.testResolveAllConfigurations(
     subproject: String? = null,
     skipSetup: Boolean = false,
     excludePredicate: String = "false",
+    options: BaseGradleIT.BuildOptions = testCase.defaultBuildOptions(),
     withUnresolvedConfigurationNames: BaseGradleIT.CompiledProject.(List<String>) -> Unit = { assertTrue("Unresolved configurations: $it") { it.isEmpty() } }
 ) = with(testCase) {
 
@@ -32,7 +33,7 @@ fun BaseGradleIT.Project.testResolveAllConfigurations(
         }
     }
 
-    build(RESOLVE_ALL_CONFIGURATIONS_TASK_NAME, options = defaultBuildOptions().copy(warningMode = WarningMode.Summary)) {
+    build(RESOLVE_ALL_CONFIGURATIONS_TASK_NAME, options = options) {
         assertSuccessful()
         assertTasksExecuted(":${subproject?.let { "$it:" }.orEmpty()}$RESOLVE_ALL_CONFIGURATIONS_TASK_NAME")
         val unresolvedConfigurations = unresolvedConfigurationRegex.findAll(output).map { it.groupValues[1] }.toList()

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/Project Path With Spaces/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/Project Path With Spaces/build.gradle
@@ -16,9 +16,9 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.guava:guava:12.0'
-    testCompile 'org.testng:testng:6.8'
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation 'com.google.guava:guava:12.0'
+    testImplementation 'org.testng:testng:6.8'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
 
 test {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/buildCacheSimple/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/buildCacheSimple/build.gradle
@@ -17,5 +17,5 @@ repositories {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/classpathTest/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/classpathTest/build.gradle
@@ -16,9 +16,9 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.guava:guava:12.0'
-    testCompile 'org.testng:testng:6.8'
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation 'com.google.guava:guava:12.0'
+    testImplementation 'org.testng:testng:6.8'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
 
 test {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/convertBetweenJavaAndKotlin/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/convertBetweenJavaAndKotlin/build.gradle
@@ -17,7 +17,7 @@ repositories {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
 
 compileJava {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/customCompilerFile/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/customCompilerFile/build.gradle
@@ -16,8 +16,8 @@ repositories {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    testImplementation 'junit:junit:4.12'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
 
 compileKotlin.compilerJarFile = project.file("compiler.jar")

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/duplicatedClass/app/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/duplicatedClass/app/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'kotlin'
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    compile project(':lib')
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation project(':lib')
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/duplicatedClass/lib/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/duplicatedClass/lib/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'kotlin'
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/gradleDaemonMemory/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/gradleDaemonMemory/build.gradle
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
 
 task('exit') {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/instantExecution/lib-project/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/instantExecution/lib-project/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'kotlin'
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/instantExecution/main-project/src/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/instantExecution/main-project/src/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'kotlin'
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    compile project(':lib-project')
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation project(':lib-project')
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/instantExecutionToJs/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/instantExecutionToJs/build.gradle
@@ -16,8 +16,8 @@ repositories {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-js:$kotlin_version"
-    testCompile "org.jetbrains.kotlin:kotlin-test-js:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-js:$kotlin_version"
+    testImplementation "org.jetbrains.kotlin:kotlin-test-js:$kotlin_version"
 }
 
 task jarSources(type: Jar) {
@@ -25,7 +25,7 @@ task jarSources(type: Jar) {
             classifier = 'source'
 }
 artifacts {
-    compile jarSources
+    implementation jarSources
 }
 
 compileKotlin2Js.kotlinOptions.outputFile = "${buildDir}/kotlin2js/main/module.js"

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/internalTest/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/internalTest/build.gradle
@@ -17,8 +17,8 @@ repositories {
 }
 
 dependencies {
-    testCompile 'org.testng:testng:6.8'
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    testImplementation 'org.testng:testng:6.8'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
 
 test {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/javaLibraryProject/app/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/javaLibraryProject/app/build.gradle
@@ -2,6 +2,6 @@ apply plugin: 'java'
 apply plugin: 'kotlin'
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    compile project(':libB')
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation project(':libB')
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/javaPackagePrefix/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/javaPackagePrefix/build.gradle
@@ -17,7 +17,7 @@ repositories {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
 
 compileKotlin.javaPackagePrefix = "my.pack.name"

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/javaUpToDate/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/javaUpToDate/build.gradle
@@ -17,5 +17,5 @@ repositories {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/jvmTarget/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/jvmTarget/build.gradle
@@ -24,7 +24,7 @@ repositories {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
 
 compileKotlin {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/kaptAvoidance/app/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/kaptAvoidance/app/build.gradle
@@ -2,10 +2,10 @@ apply plugin: "kotlin"
 apply plugin: "kotlin-kapt"
 
 dependencies {
-    compile project(":lib")
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation project(":lib")
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
-    compile "org.jetbrains.kotlin:annotation-processor-example:$kotlin_version"
+    implementation "org.jetbrains.kotlin:annotation-processor-example:$kotlin_version"
     kapt "org.jetbrains.kotlin:annotation-processor-example:$kotlin_version"
 
     // actually unused, but kapt skips AP when annotation processing classpath is empty (see checkOptions)

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/kaptAvoidance/lib/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/kaptAvoidance/lib/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: "kotlin"
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/simple/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/simple/build.gradle
@@ -18,10 +18,10 @@ repositories {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    compile "org.jetbrains.kotlin:annotation-processor-example:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:annotation-processor-example:$kotlin_version"
     kapt "org.jetbrains.kotlin:annotation-processor-example:$kotlin_version"
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
 }
 
 compileKotlin.kotlinOptions.allWarningsAsErrors = true

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsDceProject/libraryProject/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsDceProject/libraryProject/build.gradle
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-js:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-js:$kotlin_version"
 }
 
 compileKotlin2Js.kotlinOptions.outputFile = "${buildDir}/examplelib.js"

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsDceProject/mainProject/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsDceProject/mainProject/build.gradle
@@ -17,9 +17,9 @@ repositories {
 }
 
 dependencies {
-    compile project(":libraryProject")
-    compile "org.jetbrains.kotlin:kotlin-stdlib-js:$kotlin_version"
-    compile "org.mozilla:rhino:1.7.7.1"
+    implementation project(":libraryProject")
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-js:$kotlin_version"
+    implementation "org.mozilla:rhino:1.7.7.1"
 }
 
 compileKotlin2Js.kotlinOptions.sourceMap = true

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsNoOutputFileProject/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsNoOutputFileProject/build.gradle
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-js:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-js:$kotlin_version"
 }
 
 if (project.findProperty("kotlin.js.useIrBackend")?.toBoolean() == true) {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinBuiltins/app/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinBuiltins/app/build.gradle
@@ -6,5 +6,5 @@ repositories {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinInJavaRoot/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinInJavaRoot/build.gradle
@@ -21,9 +21,9 @@ sourceSets {
 }
 
 dependencies {
-    compile 'com.google.guava:guava:12.0'
-    testCompile 'org.testng:testng:6.8'
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation 'com.google.guava:guava:12.0'
+    testImplementation 'org.testng:testng:6.8'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
 
 test {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinJavaProject/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinJavaProject/build.gradle
@@ -21,11 +21,11 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.guava:guava:12.0'
-    deployCompile 'com.google.guava:guava:12.0'
-    testCompile 'org.testng:testng:6.8'
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    deployCompile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation 'com.google.guava:guava:12.0'
+    deployImplementation 'com.google.guava:guava:12.0'
+    testImplementation 'org.testng:testng:6.8'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    deployImplementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
 
 test {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinProject/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinProject/build.gradle
@@ -16,9 +16,9 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.guava:guava:12.0'
-    testCompile 'org.testng:testng:6.8'
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation 'com.google.guava:guava:12.0'
+    testImplementation 'org.testng:testng:6.8'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
 
 test {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinProjectWithBuildSrc/buildSrc/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinProjectWithBuildSrc/buildSrc/build.gradle
@@ -6,5 +6,5 @@ repositories {
 apply plugin: 'java'
 
 dependencies {
-    runtime "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    runtimeOnly "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kt-29971/jvm-app/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kt-29971/jvm-app/build.gradle
@@ -6,5 +6,5 @@ group = "com.example.jvm"
 version = "1.0"
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/manyClasses/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/manyClasses/build.gradle
@@ -16,5 +16,5 @@ repositories {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/moveClassToOtherModule/app/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/moveClassToOtherModule/app/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'kotlin'
 
 dependencies {
-    compile project(':lib')
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation project(':lib')
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/moveClassToOtherModule/lib/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/moveClassToOtherModule/lib/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'kotlin'
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformProject/libJvm/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformProject/libJvm/build.gradle
@@ -2,6 +2,6 @@ apply plugin: 'kotlin-platform-jvm'
 
 dependencies {
     expectedBy project(":lib")
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    compile 'com.google.guava:guava:20.0'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation 'com.google.guava:guava:20.0'
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiprojectClassPathTest/subproject/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiprojectClassPathTest/subproject/build.gradle
@@ -1,9 +1,9 @@
 apply plugin: "kotlin"
 
 dependencies {
-    compile 'com.google.guava:guava:12.0'
-    testCompile 'org.testng:testng:6.8'
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation 'com.google.guava:guava:12.0'
+    testImplementation 'org.testng:testng:6.8'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
 
 test {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiprojectWithDependency/projA/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiprojectWithDependency/projA/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: "kotlin"
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiprojectWithDependency/projB/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiprojectWithDependency/projB/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: "kotlin"
 
 dependencies {
-    compile project(':projA')
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation project(':projA')
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/new-mpp-lib-and-app/sample-old-style-app/app-common/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/new-mpp-lib-and-app/sample-old-style-app/app-common/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'kotlin-platform-common'
 
 dependencies {
-	compile 'com.example:sample-lib:1.0'
+	implementation 'com.example:sample-lib:1.0'
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/new-mpp-lib-and-app/sample-old-style-app/app-js/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/new-mpp-lib-and-app/sample-old-style-app/app-js/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'kotlin2js'
 
 dependencies {
-	compile 'com.example:sample-lib:1.0'
+	implementation 'com.example:sample-lib:1.0'
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/new-mpp-lib-and-app/sample-old-style-app/app-jvm/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/new-mpp-lib-and-app/sample-old-style-app/app-jvm/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'kotlin'
 apply plugin: 'application'
 
 dependencies {
-	compile 'com.example:sample-lib:1.0'
+	implementation 'com.example:sample-lib:1.0'
 }
 
 mainClassName = 'com.example.app.JvmAppKt'

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/pluginsDsl/allopenPluginsDsl/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/pluginsDsl/allopenPluginsDsl/build.gradle
@@ -13,6 +13,6 @@ allOpen {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
-    testCompile "junit:junit:4.12"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+    testImplementation "junit:junit:4.12"
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/pluginsDsl/applyAllPlugins/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/pluginsDsl/applyAllPlugins/build.gradle
@@ -13,8 +13,8 @@ repositories {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
-    testCompile "junit:junit:4.12"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+    testImplementation "junit:junit:4.12"
 }
 
 afterEvaluate {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/pluginsDsl/applyToSubprojects/subproject/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/pluginsDsl/applyToSubprojects/subproject/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
-    compile 'com.google.guava:guava:12.0'
-    testCompile 'org.testng:testng:6.8'
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation 'com.google.guava:guava:12.0'
+    testImplementation 'org.testng:testng:6.8'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
 
 test {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/simpleProject/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/simpleProject/build.gradle
@@ -21,11 +21,11 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.guava:guava:12.0'
-    deployCompile 'com.google.guava:guava:12.0'
-    testCompile 'org.testng:testng:6.8'
-    compile "org.jetbrains.kotlin:kotlin-stdlib"
-    deployCompile "org.jetbrains.kotlin:kotlin-stdlib"
+    implementation 'com.google.guava:guava:12.0'
+    deployImplementation 'com.google.guava:guava:12.0'
+    testImplementation 'org.testng:testng:6.8'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib"
+    deployImplementation "org.jetbrains.kotlin:kotlin-stdlib"
 }
 
 test {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/typeAlias/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/typeAlias/build.gradle
@@ -16,5 +16,5 @@ repositories {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinMultiplatformPlugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinMultiplatformPlugin.kt
@@ -56,7 +56,7 @@ open class KotlinPlatformImplementationPluginBase(platformName: String) : Kotlin
     private val commonProjects = arrayListOf<Project>()
 
     protected open fun configurationsForCommonModuleDependency(project: Project): List<Configuration> =
-        listOf(project.configurations.getByName("compile"))
+        listOf(project.configurations.getByName("api"))
 
     override fun apply(project: Project) {
         warnAboutKotlin12xMppDeprecation(project)
@@ -238,10 +238,6 @@ open class KotlinPlatformAndroidPlugin : KotlinPlatformImplementationPluginBase(
         project.applyPlugin<KotlinAndroidPluginWrapper>()
         super.apply(project)
     }
-
-    override fun configurationsForCommonModuleDependency(project: Project): List<Configuration> =
-        (project.configurations.findByName("api"))?.let(::listOf)
-            ?: super.configurationsForCommonModuleDependency(project) // older Android plugins don't have api/implementation configs
 
     override fun namedSourceSetsContainer(project: Project): NamedDomainObjectContainer<*> =
         (project.extensions.getByName("android") as BaseExtension).sourceSets

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinMultiplatformPlugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinMultiplatformPlugin.kt
@@ -55,7 +55,7 @@ const val IMPLEMENT_DEPRECATION_WARNING = "The '$IMPLEMENT_CONFIG_NAME' configur
 open class KotlinPlatformImplementationPluginBase(platformName: String) : KotlinPlatformPluginBase(platformName) {
     private val commonProjects = arrayListOf<Project>()
 
-    protected open fun configurationsForCommonModuleDependency(project: Project): List<Configuration> =
+    private fun configurationsForCommonModuleDependency(project: Project): List<Configuration> =
         listOf(project.configurations.getByName("api"))
 
     override fun apply(project: Project) {


### PR DESCRIPTION
Currently, KotlinPlatformJvmPlugin and KotlinPlatformJsPlugin are
adding expectedBy deps to "compile" configuration which is deprecated
by Gradle. This PR fixes that by replacing "compile" with "api" which
is what we are doing in KotlinPlatformAndroidPlugin.

This PR also makes integration tests running with warning-mode=fail by
default and fixes most of the integration tests. For the remaining tests
to be fixed, we make them run with warning-mode=summary and will fix
them incrementally in following PRs.