### PR TITLE
FIR2IR: convert recursive captured type

### DIFF
--- a/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/fir/Fir2IrTextTestGenerated.java
+++ b/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/fir/Fir2IrTextTestGenerated.java
@@ -1807,6 +1807,11 @@ public class Fir2IrTextTestGenerated extends AbstractFir2IrTextTest {
             runTest("compiler/testData/ir/irText/firProblems/putIfAbsent.kt");
         }
 
+        @TestMetadata("recursiveCapturedTypeInPropertyReference.kt")
+        public void testRecursiveCapturedTypeInPropertyReference() throws Exception {
+            runTest("compiler/testData/ir/irText/firProblems/recursiveCapturedTypeInPropertyReference.kt");
+        }
+
         @TestMetadata("SameJavaFieldReferences.kt")
         public void testSameJavaFieldReferences() throws Exception {
             runTest("compiler/testData/ir/irText/firProblems/SameJavaFieldReferences.kt");

--- a/compiler/testData/ir/irText/firProblems/recursiveCapturedTypeInPropertyReference.fir.txt
+++ b/compiler/testData/ir/irText/firProblems/recursiveCapturedTypeInPropertyReference.fir.txt
@@ -1,0 +1,68 @@
+FILE fqName:<root> fileName:/recursiveCapturedTypeInPropertyReference.kt
+  CLASS INTERFACE name:Something modality:ABSTRACT visibility:public superTypes:[kotlin.Any]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.Something
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean [operator] declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+  CLASS INTERFACE name:Recursive modality:ABSTRACT visibility:public superTypes:[kotlin.Any]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.Recursive<R of <root>.Recursive>
+    TYPE_PARAMETER name:R index:0 variance: superTypes:[<root>.Recursive<R of <root>.Recursive>; <root>.Something]
+    PROPERTY name:symbol visibility:public modality:ABSTRACT [val]
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-symbol> visibility:public modality:ABSTRACT <> ($this:<root>.Recursive<R of <root>.Recursive>) returnType:<root>.AbstractSymbol<R of <root>.Recursive>
+        correspondingProperty: PROPERTY name:symbol visibility:public modality:ABSTRACT [val]
+        $this: VALUE_PARAMETER name:<this> type:<root>.Recursive<R of <root>.Recursive>
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean [operator] declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+  CLASS CLASS name:AbstractSymbol modality:ABSTRACT visibility:public superTypes:[kotlin.Any]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.AbstractSymbol<E of <root>.AbstractSymbol>
+    TYPE_PARAMETER name:E index:0 variance: superTypes:[<root>.Recursive<E of <root>.AbstractSymbol>; <root>.Something]
+    CONSTRUCTOR visibility:public <> () returnType:<root>.AbstractSymbol<E of <root>.AbstractSymbol> [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:AbstractSymbol modality:ABSTRACT visibility:public superTypes:[kotlin.Any]'
+    FUN name:foo visibility:public modality:FINAL <> ($this:<root>.AbstractSymbol<E of <root>.AbstractSymbol>, list:kotlin.collections.List<kotlin.Any>) returnType:kotlin.Unit
+      $this: VALUE_PARAMETER name:<this> type:<root>.AbstractSymbol<E of <root>.AbstractSymbol>
+      VALUE_PARAMETER name:list index:0 type:kotlin.collections.List<kotlin.Any>
+      BLOCK_BODY
+        VAR name:result type:kotlin.collections.List<<root>.AbstractSymbol<out <root>.Recursive<*>>> [val]
+          CALL 'public final fun map <T, R> (transform: kotlin.Function1<T of kotlin.collections.map, R of kotlin.collections.map>): kotlin.collections.List<R of kotlin.collections.map> [inline] declared in kotlin.collections' type=kotlin.collections.List<<root>.AbstractSymbol<out <root>.Recursive<*>>> origin=null
+            <T>: <root>.Recursive<*>
+            <R>: <root>.AbstractSymbol<out <root>.Recursive<*>>
+            $receiver: CALL 'public final fun filterIsInstance <R> (): kotlin.collections.List<R of kotlin.collections.filterIsInstance> [inline] declared in kotlin.collections' type=kotlin.collections.List<<root>.Recursive<*>> origin=null
+              <R>: <root>.Recursive<*>
+              $receiver: GET_VAR 'list: kotlin.collections.List<kotlin.Any> declared in <root>.AbstractSymbol.foo' type=kotlin.collections.List<kotlin.Any> origin=null
+            transform: PROPERTY_REFERENCE 'public abstract symbol: <root>.AbstractSymbol<R of <root>.Recursive> [val]' field=null getter='public abstract fun <get-symbol> (): <root>.AbstractSymbol<R of <root>.Recursive> declared in <root>.Recursive' setter=null type=kotlin.reflect.KProperty1<<root>.Recursive<*>, <root>.AbstractSymbol<<root>.Recursive<*>>> origin=null
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean [operator] declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any

--- a/compiler/testData/ir/irText/firProblems/recursiveCapturedTypeInPropertyReference.kt
+++ b/compiler/testData/ir/irText/firProblems/recursiveCapturedTypeInPropertyReference.kt
@@ -1,0 +1,14 @@
+// WITH_RUNTIME
+// FULL_JDK
+
+interface Something
+
+interface Recursive<R> where R : Recursive<R>, R : Something {
+    val symbol: AbstractSymbol<R>
+}
+
+abstract class AbstractSymbol<E> where E : Recursive<E>, E : Something {
+    fun foo(list: List<Any>) {
+        val result = list.filterIsInstance<Recursive<*>>().map(Recursive<*>::symbol)
+    }
+}

--- a/compiler/testData/ir/irText/firProblems/recursiveCapturedTypeInPropertyReference.txt
+++ b/compiler/testData/ir/irText/firProblems/recursiveCapturedTypeInPropertyReference.txt
@@ -1,0 +1,68 @@
+FILE fqName:<root> fileName:/recursiveCapturedTypeInPropertyReference.kt
+  CLASS INTERFACE name:Something modality:ABSTRACT visibility:public superTypes:[kotlin.Any]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.Something
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean [operator] declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+  CLASS INTERFACE name:Recursive modality:ABSTRACT visibility:public superTypes:[kotlin.Any]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.Recursive<R of <root>.Recursive>
+    TYPE_PARAMETER name:R index:0 variance: superTypes:[<root>.Recursive<R of <root>.Recursive>; <root>.Something]
+    PROPERTY name:symbol visibility:public modality:ABSTRACT [val]
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-symbol> visibility:public modality:ABSTRACT <> ($this:<root>.Recursive<R of <root>.Recursive>) returnType:<root>.AbstractSymbol<R of <root>.Recursive>
+        correspondingProperty: PROPERTY name:symbol visibility:public modality:ABSTRACT [val]
+        $this: VALUE_PARAMETER name:<this> type:<root>.Recursive<R of <root>.Recursive>
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean [operator] declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+  CLASS CLASS name:AbstractSymbol modality:ABSTRACT visibility:public superTypes:[kotlin.Any]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.AbstractSymbol<E of <root>.AbstractSymbol>
+    TYPE_PARAMETER name:E index:0 variance: superTypes:[<root>.Recursive<E of <root>.AbstractSymbol>; <root>.Something]
+    CONSTRUCTOR visibility:public <> () returnType:<root>.AbstractSymbol<E of <root>.AbstractSymbol> [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:AbstractSymbol modality:ABSTRACT visibility:public superTypes:[kotlin.Any]'
+    FUN name:foo visibility:public modality:FINAL <> ($this:<root>.AbstractSymbol<E of <root>.AbstractSymbol>, list:kotlin.collections.List<kotlin.Any>) returnType:kotlin.Unit
+      $this: VALUE_PARAMETER name:<this> type:<root>.AbstractSymbol<E of <root>.AbstractSymbol>
+      VALUE_PARAMETER name:list index:0 type:kotlin.collections.List<kotlin.Any>
+      BLOCK_BODY
+        VAR name:result type:kotlin.collections.List<<root>.AbstractSymbol<out <root>.Recursive<*>>> [val]
+          CALL 'public final fun map <T, R> (transform: kotlin.Function1<T of kotlin.collections.map, R of kotlin.collections.map>): kotlin.collections.List<R of kotlin.collections.map> [inline] declared in kotlin.collections' type=kotlin.collections.List<<root>.AbstractSymbol<out <root>.Recursive<*>>> origin=null
+            <T>: <root>.Recursive<*>
+            <R>: <root>.AbstractSymbol<out <root>.Recursive<*>>
+            $receiver: CALL 'public final fun filterIsInstance <R> (): kotlin.collections.List<@[NoInfer] R of kotlin.collections.filterIsInstance> [inline] declared in kotlin.collections' type=kotlin.collections.List<@[NoInfer] <root>.Recursive<*>> origin=null
+              <R>: <root>.Recursive<*>
+              $receiver: GET_VAR 'list: kotlin.collections.List<kotlin.Any> declared in <root>.AbstractSymbol.foo' type=kotlin.collections.List<kotlin.Any> origin=null
+            transform: PROPERTY_REFERENCE 'public abstract symbol: <root>.AbstractSymbol<R of <root>.Recursive> [val]' field=null getter='public abstract fun <get-symbol> (): <root>.AbstractSymbol<R of <root>.Recursive> declared in <root>.Recursive' setter=null type=kotlin.reflect.KProperty1<<root>.Recursive<*>, <root>.AbstractSymbol<out <root>.Recursive<*>>> origin=null
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean [operator] declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any

--- a/compiler/tests/org/jetbrains/kotlin/ir/IrTextTestCaseGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/ir/IrTextTestCaseGenerated.java
@@ -1806,6 +1806,11 @@ public class IrTextTestCaseGenerated extends AbstractIrTextTestCase {
             runTest("compiler/testData/ir/irText/firProblems/putIfAbsent.kt");
         }
 
+        @TestMetadata("recursiveCapturedTypeInPropertyReference.kt")
+        public void testRecursiveCapturedTypeInPropertyReference() throws Exception {
+            runTest("compiler/testData/ir/irText/firProblems/recursiveCapturedTypeInPropertyReference.kt");
+        }
+
         @TestMetadata("SameJavaFieldReferences.kt")
         public void testSameJavaFieldReferences() throws Exception {
             runTest("compiler/testData/ir/irText/firProblems/SameJavaFieldReferences.kt");


### PR DESCRIPTION
The motivation is [KT-43346](https://youtrack.jetbrains.com/issue/KT-43346) where type converter raises stack overflow while converting recursive captured type, e.g., `Recursive<R> where R : Recursive<R>, ...`. According to `psi2ir` result, it's okay to convert type parameter `R` in this case. So, we can keep track of what captured types are visited during the conversion, and when we detect the recursion, we can rather switch to convert type parameter, in lieu of super type chain.