### PR TITLE
FIR: resolve Throwable.stackTrace synthetic property

### DIFF
--- a/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/fir/Fir2IrTextTestGenerated.java
+++ b/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/fir/Fir2IrTextTestGenerated.java
@@ -1822,6 +1822,11 @@ public class Fir2IrTextTestGenerated extends AbstractFir2IrTextTest {
             runTest("compiler/testData/ir/irText/firProblems/SignatureClash.kt");
         }
 
+        @TestMetadata("throwableStackTrace.kt")
+        public void testThrowableStackTrace() throws Exception {
+            runTest("compiler/testData/ir/irText/firProblems/throwableStackTrace.kt");
+        }
+
         @TestMetadata("V8ArrayToList.kt")
         public void testV8ArrayToList() throws Exception {
             runTest("compiler/testData/ir/irText/firProblems/V8ArrayToList.kt");

--- a/compiler/fir/jvm/src/org/jetbrains/kotlin/fir/scopes/jvm/DescriptorUtils.kt
+++ b/compiler/fir/jvm/src/org/jetbrains/kotlin/fir/scopes/jvm/DescriptorUtils.kt
@@ -50,6 +50,7 @@ private fun StringBuilder.appendErasedType(typeRef: FirTypeRef) {
         klass.fqName?.let {
             append("L")
             append(it.asString().replace(".", "/"))
+            append(";")
         }
     }
 
@@ -63,14 +64,13 @@ private fun StringBuilder.appendErasedType(typeRef: FirTypeRef) {
                         is JavaTypeParameter -> {
                             val representative = classifier.upperBounds.firstOrNull { it.classifier is JavaClass }
                             if (representative == null) {
-                                append("Ljava/lang/Object")
+                                append("Ljava/lang/Object;")
                             } else {
                                 appendClass(representative.classifier as JavaClass)
                             }
                         }
                         else -> return
                     }
-                    append(";")
                 }
             }
         }
@@ -92,19 +92,31 @@ private fun StringBuilder.appendConeType(coneType: ConeKotlinType) {
     (coneType as? ConeClassLikeType)?.let {
         val classId = it.lookupTag.classId
         if (classId.packageFqName.toString() == "kotlin") {
-            PRIMITIVE_TYPE_SIGNATURE[classId.shortClassName.identifier]?.let {
-                append(it)
+            PRIMITIVE_TYPE_SIGNATURE[classId.shortClassName.identifier]?.let { signature ->
+                append(signature)
                 return
             }
         }
     }
 
     fun appendClassLikeType(type: ConeClassLikeType) {
-        append("L")
         val classId = type.lookupTag.classId
-        append(classId.packageFqName.asString().replace(".", "/"))
-        append("/")
-        append(classId.relativeClassName)
+        if (classId.shortClassName.isSpecial) return
+        if (classId.shortClassName.identifier == "Array") {
+            append("[")
+            type.typeArguments.forEach { typeArg ->
+                when (typeArg) {
+                    ConeStarProjection -> append("*")
+                    is ConeKotlinTypeProjection -> appendConeType(typeArg.type)
+                }
+            }
+        } else {
+            append("L")
+            append(classId.packageFqName.asString().replace(".", "/"))
+            append("/")
+            append(classId.relativeClassName)
+            append(";")
+        }
     }
 
     if (coneType is ConeClassErrorType) return
@@ -117,21 +129,18 @@ private fun StringBuilder.appendConeType(coneType: ConeKotlinType) {
                 it.coneType is ConeClassLikeType
             }
             if (representative == null || representative is FirImplicitNullableAnyTypeRef || representative is FirImplicitAnyTypeRef) {
-                append("Ljava/lang/Object")
+                append("Ljava/lang/Object;")
             } else {
                 appendClassLikeType(representative.coneTypeUnsafe())
             }
         }
         is ConeDefinitelyNotNullType -> {
             appendConeType(coneType.original)
-            return
         }
         is ConeFlexibleType -> {
             appendConeType(coneType.lowerBound)
-            return
         }
     }
-    append(";")
 }
 
 private val unitClassId = ClassId.topLevel(FqName("kotlin.Unit"))

--- a/compiler/testData/diagnostics/tests/resolve/underscoreInCatchBlock.fir.kt
+++ b/compiler/testData/diagnostics/tests/resolve/underscoreInCatchBlock.fir.kt
@@ -1,11 +1,12 @@
 // !LANGUAGE: -ForbidReferencingToUnderscoreNamedParameterOfCatchBlock
 // !DIAGNOSTICS: -UNUSED_PARAMETER -UNUSED_VARIABLE -UNUSED_ANONYMOUS_PARAMETER -UNUSED_EXPRESSION
+// FULL_JDK
 
 fun foo() {
     try {
         TODO()
     } catch (_: Exception) {
-        `_`.<!UNRESOLVED_REFERENCE!>stackTrace<!>
+        `_`.stackTrace
     }
     try {
         TODO()
@@ -27,7 +28,7 @@ fun foo() {
             }
         }
     } catch (_: Exception) {
-        `_`.<!UNRESOLVED_REFERENCE!>stackTrace<!>
+        `_`.stackTrace
         val y1 = _
         val y2 = (`_`)
     }
@@ -37,21 +38,21 @@ fun foo() {
         try {
             TODO()
         } catch (x: Exception) {
-            `_`.<!UNRESOLVED_REFERENCE!>stackTrace<!>
+            `_`.stackTrace
         }
     }
     val boo1 = { `_`: Exception ->
         try {
             TODO()
         } catch (x: Exception) {
-            `_`.<!UNRESOLVED_REFERENCE!>stackTrace<!>
+            `_`.stackTrace
         }
     }
     val boo2 = { _: Exception ->
         try {
             TODO()
         } catch (x: Exception) {
-            `_`.<!UNRESOLVED_REFERENCE!>stackTrace<!>
+            `_`.stackTrace
         }
     }
 }

--- a/compiler/testData/diagnostics/tests/resolve/underscoreInCatchBlockWithEnabledFeature.fir.kt
+++ b/compiler/testData/diagnostics/tests/resolve/underscoreInCatchBlockWithEnabledFeature.fir.kt
@@ -1,11 +1,12 @@
 // !LANGUAGE: +ForbidReferencingToUnderscoreNamedParameterOfCatchBlock
 // !DIAGNOSTICS: -UNUSED_PARAMETER -UNUSED_VARIABLE -UNUSED_ANONYMOUS_PARAMETER -UNUSED_EXPRESSION
+// FULL_JDK
 
 fun foo() {
     try {
         TODO()
     } catch (_: Exception) {
-        `_`.<!UNRESOLVED_REFERENCE!>stackTrace<!>
+        `_`.stackTrace
     }
     try {
         TODO()
@@ -27,7 +28,7 @@ fun foo() {
             }
         }
     } catch (_: Exception) {
-        `_`.<!UNRESOLVED_REFERENCE!>stackTrace<!>
+        `_`.stackTrace
         val y1 = _
         val y2 = (`_`)
     }
@@ -37,21 +38,21 @@ fun foo() {
         try {
             TODO()
         } catch (x: Exception) {
-            `_`.<!UNRESOLVED_REFERENCE!>stackTrace<!>
+            `_`.stackTrace
         }
     }
     val boo1 = { `_`: Exception ->
         try {
             TODO()
         } catch (x: Exception) {
-            `_`.<!UNRESOLVED_REFERENCE!>stackTrace<!>
+            `_`.stackTrace
         }
     }
     val boo2 = { _: Exception ->
         try {
             TODO()
         } catch (x: Exception) {
-            `_`.<!UNRESOLVED_REFERENCE!>stackTrace<!>
+            `_`.stackTrace
         }
     }
 }

--- a/compiler/testData/ir/irText/firProblems/throwableStackTrace.fir.txt
+++ b/compiler/testData/ir/irText/firProblems/throwableStackTrace.fir.txt
@@ -2,4 +2,7 @@ FILE fqName:<root> fileName:/throwableStackTrace.kt
   FUN name:foo visibility:public modality:FINAL <> (t:kotlin.Throwable) returnType:kotlin.Unit
     VALUE_PARAMETER name:t index:0 type:kotlin.Throwable
     BLOCK_BODY
-      ERROR_CALL 'Unresolved reference: R|kotlin/stackTrace|' type=IrErrorType
+      CALL 'public open fun setStackTrace (p0: kotlin.Array<out java.lang.StackTraceElement?>?): kotlin.Unit declared in java.lang.Throwable' type=kotlin.Unit origin=EQ
+        $this: GET_VAR 't: kotlin.Throwable declared in <root>.foo' type=kotlin.Throwable origin=null
+        p0: CALL 'public open fun getStackTrace (): kotlin.Array<out java.lang.StackTraceElement?>? declared in java.lang.Throwable' type=kotlin.Array<out java.lang.StackTraceElement?>? origin=GET_PROPERTY
+          $this: GET_VAR 't: kotlin.Throwable declared in <root>.foo' type=kotlin.Throwable origin=null

--- a/compiler/testData/ir/irText/firProblems/throwableStackTrace.fir.txt
+++ b/compiler/testData/ir/irText/firProblems/throwableStackTrace.fir.txt
@@ -1,0 +1,5 @@
+FILE fqName:<root> fileName:/throwableStackTrace.kt
+  FUN name:foo visibility:public modality:FINAL <> (t:kotlin.Throwable) returnType:kotlin.Unit
+    VALUE_PARAMETER name:t index:0 type:kotlin.Throwable
+    BLOCK_BODY
+      ERROR_CALL 'Unresolved reference: R|kotlin/stackTrace|' type=IrErrorType

--- a/compiler/testData/ir/irText/firProblems/throwableStackTrace.kt
+++ b/compiler/testData/ir/irText/firProblems/throwableStackTrace.kt
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+// FULL_JDK
+
+fun foo(t: Throwable) {
+    t.stackTrace = t.stackTrace
+}

--- a/compiler/testData/ir/irText/firProblems/throwableStackTrace.txt
+++ b/compiler/testData/ir/irText/firProblems/throwableStackTrace.txt
@@ -1,0 +1,8 @@
+FILE fqName:<root> fileName:/throwableStackTrace.kt
+  FUN name:foo visibility:public modality:FINAL <> (t:kotlin.Throwable) returnType:kotlin.Unit
+    VALUE_PARAMETER name:t index:0 type:kotlin.Throwable
+    BLOCK_BODY
+      CALL 'public open fun setStackTrace (p0: @[FlexibleNullability] kotlin.Array<out @[FlexibleNullability] java.lang.StackTraceElement?>?): kotlin.Unit declared in kotlin.Throwable' type=kotlin.Unit origin=EQ
+        $this: GET_VAR 't: kotlin.Throwable declared in <root>.foo' type=kotlin.Throwable origin=null
+        p0: CALL 'public open fun getStackTrace (): @[FlexibleNullability] kotlin.Array<out @[FlexibleNullability] java.lang.StackTraceElement?>? declared in kotlin.Throwable' type=@[FlexibleNullability] kotlin.Array<out @[FlexibleNullability] java.lang.StackTraceElement?>? origin=GET_PROPERTY
+          $this: GET_VAR 't: kotlin.Throwable declared in <root>.foo' type=kotlin.Throwable origin=null

--- a/compiler/tests/org/jetbrains/kotlin/ir/IrTextTestCaseGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/ir/IrTextTestCaseGenerated.java
@@ -1821,6 +1821,11 @@ public class IrTextTestCaseGenerated extends AbstractIrTextTestCase {
             runTest("compiler/testData/ir/irText/firProblems/SignatureClash.kt");
         }
 
+        @TestMetadata("throwableStackTrace.kt")
+        public void testThrowableStackTrace() throws Exception {
+            runTest("compiler/testData/ir/irText/firProblems/throwableStackTrace.kt");
+        }
+
         @TestMetadata("V8ArrayToList.kt")
         public void testV8ArrayToList() throws Exception {
             runTest("compiler/testData/ir/irText/firProblems/V8ArrayToList.kt");


### PR DESCRIPTION
The motivation is [KT-43339](https://youtrack.jetbrains.com/issue/KT-43339), where `java/lang/Throwable.(get|set)StackTrace` is not property processed by `JvmMappedScope`. The main reason is that return type (or parameter type) of `getStackTrace` (or `setStackTrace`) is `Array<java/lang/StackTraceElement>`, and JVM descriptor util didn't convert array appropriately, returning just `Array`, which should have been `[Ljava/lang/StackTraceElement;`.