### PR TITLE
Add a `String.sarcastic()` easter egg. 

### DIFF
--- a/libraries/stdlib/jvm/src/kotlin/text/StringsJVM.kt
+++ b/libraries/stdlib/jvm/src/kotlin/text/StringsJVM.kt
@@ -15,6 +15,7 @@ import java.nio.charset.Charset
 import java.nio.charset.CodingErrorAction
 import java.util.Locale
 import java.util.regex.Pattern
+import kotlin.random.Random
 
 
 /**
@@ -722,3 +723,14 @@ public actual fun CharSequence.repeat(n: Int): String {
  */
 public actual val String.Companion.CASE_INSENSITIVE_ORDER: Comparator<String>
     get() = java.lang.String.CASE_INSENSITIVE_ORDER
+
+/**
+ * Returns the string with the case of each character randomized, to emphasize sarcasm in the resulting text.
+ */
+public fun String.sarcastic(random: Random = Random): String = buildString {
+    this@sarcastic.forEach {
+        val mocking = if (random.nextBoolean()) Char::toLowerCase else Char::toUpperCase
+
+        append(mocking(it))
+    }
+}

--- a/libraries/stdlib/samples/test/samples/text/strings.kt
+++ b/libraries/stdlib/samples/test/samples/text/strings.kt
@@ -2,6 +2,7 @@ package samples.text
 
 import samples.*
 import kotlin.test.*
+import kotlin.random.Random
 
 class Strings {
 

--- a/libraries/stdlib/samples/test/samples/text/strings.kt
+++ b/libraries/stdlib/samples/test/samples/text/strings.kt
@@ -421,4 +421,11 @@ class Strings {
         assertPrints(emptyString.lastOrNull(), "null")
         assertFails { emptyString.last() }
     }
+
+    @Sample
+    fun sarcastic() {
+        val string = "Programmers should remain professional."
+        val seededRandom = Random(2)
+        assertPrints(string.sarcastic(seededRandom), "pROgRamMERS ShOuLD rEMAin ProFEssioNAL.")
+    }
 }


### PR DESCRIPTION
Easter eggs in programming languages can be a quick way to brighten a developers day. This has precedence in the Android ecosystem with things like [Log.wtf](https://developer.android.com/reference/android/util/Log#wtf(java.lang.String,%20java.lang.String)) or [isUserAGoat](https://developer.android.com/reference/android/os/UserManager#isUserAGoat()).

One way we could bring this simple humor to the Kotlin language is with an extension function that randomizes the case of each character, playing off of the [mocking SpongeBob](https://knowyourmeme.com/memes/mocking-spongebob) meme.  

Let me know what you think! 