### PR TITLE
KT-43489: KGP - Avoid storing build history mapping in a property

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/IncrementalCompilationMultiProjectIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/IncrementalCompilationMultiProjectIT.kt
@@ -99,6 +99,44 @@ class IncrementalCompilationJvmMultiProjectIT : BaseIncrementalCompilationMultiP
             assertCompiledKotlinSources(relativePaths)
         }
     }
+
+    /** Regression test for KT-43489. Make sure build history mapping is not initialized too early. */
+    @Test
+    fun testBuildHistoryMappingLazilyComputedWithWorkers() {
+        val project = defaultProject()
+        project.setupWorkingDir()
+        project.projectDir.resolve("app/build.gradle").appendText(
+            """
+                // added to force eager configuration
+                tasks.withType(JavaCompile) {
+                    options.encoding = 'UTF-8'
+                }
+            """.trimIndent()
+        )
+        val options = defaultBuildOptions().copy(parallelTasksInProject = true)
+        project.build(options = options, params = arrayOf("build")) {
+            assertSuccessful()
+        }
+
+        val aKt = project.projectDir.getFileByName("A.kt")
+        aKt.writeText(
+            """
+package bar
+
+open class A {
+    fun a() {}
+    fun newA() {}
+}
+"""
+        )
+
+        project.build(options = options, params = arrayOf("build")) {
+            assertSuccessful()
+            val affectedSources = project.projectDir.getFilesByNames("A.kt", "B.kt", "AA.kt", "AAA.kt", "BB.kt")
+            val relativePaths = project.relativize(affectedSources)
+            assertCompiledKotlinSources(relativePaths)
+        }
+    }
 }
 
 abstract class BaseIncrementalCompilationMultiProjectIT : BaseGradleIT() {

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/Tasks.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/Tasks.kt
@@ -323,6 +323,7 @@ abstract class AbstractKotlinCompile<T : CommonCompilerArguments>() : AbstractKo
 
     private val kotlinLogger by lazy { GradleKotlinLogger(logger) }
 
+    /** Keep lazy to avoid computing before all projects are evaluated. */
     @get:Internal
     internal val compilerRunner by lazy { compilerRunner() }
 
@@ -593,10 +594,7 @@ internal open class KotlinCompileWithWorkers @Inject constructor(
     private val workerExecutor: WorkerExecutor
 ) : KotlinCompile() {
 
-    @get:Internal
-    val compilerRunnerValue = GradleCompilerRunnerWithWorkers(GradleCompileTaskProvider(this), workerExecutor)
-
-    override fun compilerRunner() = compilerRunnerValue
+    override fun compilerRunner() = GradleCompilerRunnerWithWorkers(GradleCompileTaskProvider(this), workerExecutor)
 }
 
 @CacheableTask


### PR DESCRIPTION
If tasks are created eagerly, it is possible for this
mapping to be initalized too early. This causes incremental
compilation to fail, as it will contain mappings only for
projects that have been evaluated thus far.

Fixes KT-43489