### PR TITLE
FIR: add a resolution mode for property delegates

### DIFF
--- a/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
@@ -10023,6 +10023,11 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateForExtPropertyInClass.kt");
         }
 
+        @TestMetadata("delegateToAnother.kt")
+        public void testDelegateToAnother() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnother.kt");
+        }
+
         @TestMetadata("delegateWithPrivateSet.kt")
         public void testDelegateWithPrivateSet() throws Exception {
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateWithPrivateSet.kt");

--- a/compiler/fir/raw-fir/raw-fir.common/src/org/jetbrains/kotlin/fir/builder/ConversionUtils.kt
+++ b/compiler/fir/raw-fir/raw-fir.common/src/org/jetbrains/kotlin/fir/builder/ConversionUtils.kt
@@ -292,6 +292,7 @@ fun FirPropertyBuilder.generateAccessorsByDelegate(
         else -> null
     }
     val isMember = ownerSymbol != null
+    val fakeSource = delegateBuilder.source?.fakeElement(FirFakeSourceElementKind.DefaultAccessor)
 
     /*
      * If we have delegation with provide delegate then we generate call like
@@ -310,7 +311,7 @@ fun FirPropertyBuilder.generateAccessorsByDelegate(
     fun thisRef(isForDelegateProviderCall: Boolean = false): FirExpression =
         when {
             ownerSymbol != null -> buildThisReceiverExpression {
-                source = delegateBuilder.source
+                source = fakeSource
                 calleeReference = buildImplicitThisReference {
                     boundSymbol = ownerSymbol
                 }
@@ -320,7 +321,7 @@ fun FirPropertyBuilder.generateAccessorsByDelegate(
                 }
             }
             isExtension && !isForDelegateProviderCall -> buildThisReceiverExpression {
-                source = delegateBuilder.source
+                source = fakeSource
                 calleeReference = buildImplicitThisReference {
                     boundSymbol = this@generateAccessorsByDelegate.symbol
                 }
@@ -329,7 +330,7 @@ fun FirPropertyBuilder.generateAccessorsByDelegate(
         }
 
     fun delegateAccess() = buildQualifiedAccessExpression {
-        source = delegateBuilder.source
+        source = fakeSource
         calleeReference = buildDelegateFieldReference {
             resolvedSymbol = delegateFieldSymbol
         }
@@ -340,9 +341,9 @@ fun FirPropertyBuilder.generateAccessorsByDelegate(
 
     val isVar = this@generateAccessorsByDelegate.isVar
     fun propertyRef() = buildCallableReferenceAccess {
-        source = delegateBuilder.source
+        source = fakeSource
         calleeReference = buildResolvedNamedReference {
-            source = delegateBuilder.source
+            source = fakeSource
             name = this@generateAccessorsByDelegate.name
             resolvedSymbol = this@generateAccessorsByDelegate.symbol
         }
@@ -368,7 +369,7 @@ fun FirPropertyBuilder.generateAccessorsByDelegate(
     delegateBuilder.delegateProvider = if (stubMode) buildExpressionStub() else buildFunctionCall {
         explicitReceiver = receiver
         calleeReference = buildSimpleNamedReference {
-            source = delegateBuilder.source
+            source = fakeSource
             name = PROVIDE_DELEGATE
         }
         argumentList = buildBinaryArgumentList(thisRef(isForDelegateProviderCall = true), propertyRef())
@@ -379,7 +380,7 @@ fun FirPropertyBuilder.generateAccessorsByDelegate(
         val annotations = getter?.annotations
         val returnTarget = FirFunctionTarget(null, isLambda = false)
         getter = buildPropertyAccessor {
-            this.source = delegateBuilder.source
+            this.source = fakeSource
             this.session = session
             origin = FirDeclarationOrigin.Source
             returnTypeRef = buildImplicitTypeRef()
@@ -390,10 +391,10 @@ fun FirPropertyBuilder.generateAccessorsByDelegate(
             body = FirSingleExpressionBlock(
                 buildReturnExpression {
                     result = buildFunctionCall {
-                        source = delegateBuilder.source
+                        source = fakeSource
                         explicitReceiver = delegateAccess()
                         calleeReference = buildSimpleNamedReference {
-                            source = delegateBuilder.source
+                            source = fakeSource
                             name = GET_VALUE
                         }
                         argumentList = buildBinaryArgumentList(thisRef(), propertyRef())
@@ -411,14 +412,14 @@ fun FirPropertyBuilder.generateAccessorsByDelegate(
     if (isVar && (setter == null || setter is FirDefaultPropertyAccessor)) {
         val annotations = setter?.annotations
         setter = buildPropertyAccessor {
-            this.source = delegateBuilder.source
+            this.source = fakeSource
             this.session = session
             origin = FirDeclarationOrigin.Source
             returnTypeRef = session.builtinTypes.unitType
             isGetter = false
             status = FirDeclarationStatusImpl(Visibilities.Unknown, Modality.FINAL)
             val parameter = buildValueParameter {
-                source = delegateBuilder.source
+                source = fakeSource
                 this.session = session
                 origin = FirDeclarationOrigin.Source
                 returnTypeRef = buildImplicitTypeRef()
@@ -432,7 +433,7 @@ fun FirPropertyBuilder.generateAccessorsByDelegate(
             symbol = FirPropertyAccessorSymbol()
             body = FirSingleExpressionBlock(
                 buildFunctionCall {
-                    source = delegateBuilder.source
+                    source = fakeSource
                     explicitReceiver = delegateAccess()
                     calleeReference = buildSimpleNamedReference {
                         name = SET_VALUE
@@ -442,7 +443,7 @@ fun FirPropertyBuilder.generateAccessorsByDelegate(
                         arguments += propertyRef()
                         arguments += buildQualifiedAccessExpression {
                             calleeReference = buildResolvedNamedReference {
-                                source = delegateBuilder.source
+                                source = fakeSource
                                 name = DELEGATED_SETTER_PARAM
                                 resolvedSymbol = parameter.symbol
                             }

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/ResolutionMode.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/ResolutionMode.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.fir.types.builder.buildResolvedTypeRef
 
 sealed class ResolutionMode {
     object ContextDependent : ResolutionMode()
+    object ContextDependentDelegate : ResolutionMode()
     object ContextIndependent : ResolutionMode()
     // TODO: it's better not to use WithExpectedType(FirImplicitTypeRef)
     class WithExpectedType(val expectedTypeRef: FirTypeRef) : ResolutionMode()

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirDeclarationsResolveTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirDeclarationsResolveTransformer.kt
@@ -192,7 +192,7 @@ open class FirDeclarationsResolveTransformer(transformer: FirBodyResolveTransfor
     }
 
     private fun transformPropertyWithDelegate(property: FirProperty) {
-        property.transformDelegate(transformer, ResolutionMode.ContextDependent)
+        property.transformDelegate(transformer, ResolutionMode.ContextDependentDelegate)
 
         val delegateExpression = property.delegate!!
 
@@ -230,7 +230,7 @@ open class FirDeclarationsResolveTransformer(transformer: FirBodyResolveTransfor
     ): CompositeTransformResult<FirStatement> {
         dataFlowAnalyzer.enterDelegateExpression()
         try {
-            val delegateProvider = wrappedDelegateExpression.delegateProvider.transformSingle(transformer, ResolutionMode.ContextDependent)
+            val delegateProvider = wrappedDelegateExpression.delegateProvider.transformSingle(transformer, data)
             when (val calleeReference = (delegateProvider as FirResolvable).calleeReference) {
                 is FirResolvedNamedReference -> return delegateProvider.compose()
                 is FirNamedReferenceWithCandidate -> {
@@ -243,7 +243,7 @@ open class FirDeclarationsResolveTransformer(transformer: FirBodyResolveTransfor
 
             (delegateProvider as? FirFunctionCall)?.let { dataFlowAnalyzer.dropSubgraphFromCall(it) }
             return wrappedDelegateExpression.expression
-                .transformSingle(transformer, ResolutionMode.ContextDependent)
+                .transformSingle(transformer, data)
                 .approximateIfIsIntegerConst()
                 .compose()
         } finally {
@@ -669,7 +669,7 @@ open class FirDeclarationsResolveTransformer(transformer: FirBodyResolveTransfor
             context.saveContextForAnonymousFunction(anonymousFunction)
         }
         return when (data) {
-            ResolutionMode.ContextDependent -> {
+            is ResolutionMode.ContextDependent, is ResolutionMode.ContextDependentDelegate -> {
                 dataFlowAnalyzer.visitPostponedAnonymousFunction(anonymousFunction)
                 anonymousFunction.addReturn().compose()
             }

--- a/compiler/testData/codegen/box/delegatedProperty/delegateToAnother.kt
+++ b/compiler/testData/codegen/box/delegatedProperty/delegateToAnother.kt
@@ -1,0 +1,9 @@
+// WITH_REFLECT
+// WITH_RUNTIME
+class C(val x: String)
+
+val x = "O"
+val y by ::x
+val z by C("K")::x
+
+fun box(): String = y + z

--- a/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -11423,6 +11423,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateForExtPropertyInClass.kt");
         }
 
+        @TestMetadata("delegateToAnother.kt")
+        public void testDelegateToAnother() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnother.kt");
+        }
+
         @TestMetadata("delegateWithPrivateSet.kt")
         public void testDelegateWithPrivateSet() throws Exception {
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateWithPrivateSet.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -11428,6 +11428,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateForExtPropertyInClass.kt");
         }
 
+        @TestMetadata("delegateToAnother.kt")
+        public void testDelegateToAnother() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnother.kt");
+        }
+
         @TestMetadata("delegateWithPrivateSet.kt")
         public void testDelegateWithPrivateSet() throws Exception {
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateWithPrivateSet.kt");

--- a/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -10023,6 +10023,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateForExtPropertyInClass.kt");
         }
 
+        @TestMetadata("delegateToAnother.kt")
+        public void testDelegateToAnother() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnother.kt");
+        }
+
         @TestMetadata("delegateWithPrivateSet.kt")
         public void testDelegateWithPrivateSet() throws Exception {
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateWithPrivateSet.kt");

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
@@ -8538,6 +8538,11 @@ public class IrJsCodegenBoxES6TestGenerated extends AbstractIrJsCodegenBoxES6Tes
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateForExtPropertyInClass.kt");
         }
 
+        @TestMetadata("delegateToAnother.kt")
+        public void testDelegateToAnother() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnother.kt");
+        }
+
         @TestMetadata("delegateWithPrivateSet.kt")
         public void testDelegateWithPrivateSet() throws Exception {
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateWithPrivateSet.kt");

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -8538,6 +8538,11 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateForExtPropertyInClass.kt");
         }
 
+        @TestMetadata("delegateToAnother.kt")
+        public void testDelegateToAnother() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnother.kt");
+        }
+
         @TestMetadata("delegateWithPrivateSet.kt")
         public void testDelegateWithPrivateSet() throws Exception {
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateWithPrivateSet.kt");

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -8538,6 +8538,11 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateForExtPropertyInClass.kt");
         }
 
+        @TestMetadata("delegateToAnother.kt")
+        public void testDelegateToAnother() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnother.kt");
+        }
+
         @TestMetadata("delegateWithPrivateSet.kt")
         public void testDelegateWithPrivateSet() throws Exception {
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateWithPrivateSet.kt");


### PR DESCRIPTION
Like function arguments, they are context-dependent, but unlike function arguments, callable references should be resolved eagerly as if they are explicit receivers.

Also, using PSI to determine the IR origin for callable references does not work if the delegate is a callable reference.