### PR TITLE
FIR checker: make unused checker path-sensitive

### DIFF
--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/CfaUtils.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/CfaUtils.kt
@@ -128,15 +128,14 @@ class PropertyInitializationInfoCollector(private val localProperties: Set<FirPr
 }
 
 internal fun <P : PathAwareControlFlowInfo<P, S>, S : ControlFlowInfo<S, K, EventOccurrencesRange>, K : Any> addRange(
-    info: P,
+    pathAwareInfo: P,
     key: K,
     range: EventOccurrencesRange,
     constructor: (PersistentMap<EdgeLabel, S>) -> P
 ): P {
     var resultMap = persistentMapOf<EdgeLabel, S>()
     // before: { |-> { p1 |-> PI1 }, l1 |-> { p2 |-> PI2 } }
-    for (label in info.keys) {
-        val dataPerLabel = info[label]!!
+    for ((label, dataPerLabel) in pathAwareInfo) {
         val existingKind = dataPerLabel[key] ?: EventOccurrencesRange.ZERO
         val kind = existingKind + range
         resultMap = resultMap.put(label, dataPerLabel.put(key, kind))

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/CfaUtils.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/CfaUtils.kt
@@ -112,7 +112,7 @@ class PropertyInitializationInfoCollector(private val localProperties: Set<FirPr
     }
 
     fun getData(graph: ControlFlowGraph) =
-        graph.collectPathAwareDataForNode(
+        graph.collectDataForNode(
             TraverseDirection.Forward,
             PathAwarePropertyInitializationInfo.EMPTY,
             this

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/CfgTraverser.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/CfgTraverser.kt
@@ -31,14 +31,12 @@ fun ControlFlowGraph.traverse(
     traverse(direction, visitor, null)
 }
 
+// ---------------------- Path-sensitive data collection -----------------------
 
-// --------------------- Path-insensitive data collection ----------------------
-
-// TODO: Deprecate and make all existing checkers path-sensitive
 fun <I : ControlFlowInfo<I, K, V>, K : Any, V : Any> ControlFlowGraph.collectDataForNode(
     direction: TraverseDirection,
     initialInfo: I,
-    visitor: ControlFlowGraphVisitor<I, Collection<I>>
+    visitor: ControlFlowGraphVisitor<I, Collection<Pair<EdgeLabel, I>>>
 ): Map<CFGNode<*>, I> {
     val nodeMap = LinkedHashMap<CFGNode<*>, I>()
     val startNode = getEnterNode(direction)
@@ -55,56 +53,6 @@ fun <I : ControlFlowInfo<I, K, V>, K : Any, V : Any> ControlFlowGraph.collectDat
 private fun <I : ControlFlowInfo<I, K, V>, K : Any, V : Any> ControlFlowGraph.collectDataForNodeInternal(
     direction: TraverseDirection,
     initialInfo: I,
-    visitor: ControlFlowGraphVisitor<I, Collection<I>>,
-    nodeMap: MutableMap<CFGNode<*>, I>,
-    changed: MutableMap<CFGNode<*>, Boolean>
-) {
-    val nodes = getNodesInOrder(direction)
-    for (node in nodes) {
-        if (direction == TraverseDirection.Backward && node is CFGNodeWithCfgOwner<*>) {
-            node.subGraphs.forEach { it.collectDataForNodeInternal(direction, initialInfo, visitor, nodeMap, changed) }
-        }
-        val previousNodes = when (direction) {
-            TraverseDirection.Forward -> node.previousCfgNodes
-            TraverseDirection.Backward -> node.followingCfgNodes
-        }
-        val previousData = previousNodes.mapNotNull { nodeMap[it] }
-        val data = nodeMap[node]
-        val newData = node.accept(visitor, previousData)
-        val hasChanged = newData != data
-        changed[node] = hasChanged
-        if (hasChanged) {
-            nodeMap[node] = newData
-        }
-        if (direction == TraverseDirection.Forward && node is CFGNodeWithCfgOwner<*>) {
-            node.subGraphs.forEach { it.collectDataForNodeInternal(direction, initialInfo, visitor, nodeMap, changed) }
-        }
-    }
-}
-
-// ---------------------- Path-sensitive data collection -----------------------
-
-// TODO: Once migration is done, get rid of "PathAware" from util names
-fun <I : ControlFlowInfo<I, K, V>, K : Any, V : Any> ControlFlowGraph.collectPathAwareDataForNode(
-    direction: TraverseDirection,
-    initialInfo: I,
-    visitor: ControlFlowGraphVisitor<I, Collection<Pair<EdgeLabel, I>>>
-): Map<CFGNode<*>, I> {
-    val nodeMap = LinkedHashMap<CFGNode<*>, I>()
-    val startNode = getEnterNode(direction)
-    nodeMap[startNode] = initialInfo
-
-    val changed = mutableMapOf<CFGNode<*>, Boolean>()
-    do {
-        collectPathAwareDataForNodeInternal(direction, initialInfo, visitor, nodeMap, changed)
-    } while (changed.any { it.value })
-
-    return nodeMap
-}
-
-private fun <I : ControlFlowInfo<I, K, V>, K : Any, V : Any> ControlFlowGraph.collectPathAwareDataForNodeInternal(
-    direction: TraverseDirection,
-    initialInfo: I,
     visitor: ControlFlowGraphVisitor<I, Collection<Pair<EdgeLabel, I>>>,
     nodeMap: MutableMap<CFGNode<*>, I>,
     changed: MutableMap<CFGNode<*>, Boolean>
@@ -112,7 +60,7 @@ private fun <I : ControlFlowInfo<I, K, V>, K : Any, V : Any> ControlFlowGraph.co
     val nodes = getNodesInOrder(direction)
     for (node in nodes) {
         if (direction == TraverseDirection.Backward && node is CFGNodeWithCfgOwner<*>) {
-            node.subGraphs.forEach { it.collectPathAwareDataForNodeInternal(direction, initialInfo, visitor, nodeMap, changed) }
+            node.subGraphs.forEach { it.collectDataForNodeInternal(direction, initialInfo, visitor, nodeMap, changed) }
         }
         val previousNodes = when (direction) {
             TraverseDirection.Forward -> node.previousCfgNodes
@@ -136,7 +84,7 @@ private fun <I : ControlFlowInfo<I, K, V>, K : Any, V : Any> ControlFlowGraph.co
             nodeMap[node] = newData
         }
         if (direction == TraverseDirection.Forward && node is CFGNodeWithCfgOwner<*>) {
-            node.subGraphs.forEach { it.collectPathAwareDataForNodeInternal(direction, initialInfo, visitor, nodeMap, changed) }
+            node.subGraphs.forEach { it.collectDataForNodeInternal(direction, initialInfo, visitor, nodeMap, changed) }
         }
     }
 }

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/FirCallsEffectAnalyzer.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/FirCallsEffectAnalyzer.kt
@@ -89,9 +89,9 @@ object FirCallsEffectAnalyzer : FirControlFlowChecker() {
         for ((symbol, effectDeclaration) in functionalTypeEffects) {
             graph.exitNode.previousCfgNodes.forEach { node ->
                 val requiredRange = effectDeclaration.kind
-                val info = invocationData.getValue(node)
-                for (label in info.keys) {
-                    if (investigate(info.getValue(label), symbol, requiredRange, function, reporter)) {
+                val pathAwareInfo = invocationData.getValue(node)
+                for (info in pathAwareInfo.values) {
+                    if (investigate(info, symbol, requiredRange, function, reporter)) {
                         // To avoid duplicate reports, stop investigating remaining paths once reported.
                         break
                     }

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/FirCallsEffectAnalyzer.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/FirCallsEffectAnalyzer.kt
@@ -80,7 +80,7 @@ object FirCallsEffectAnalyzer : FirControlFlowChecker() {
             }
         }
 
-        val invocationData = graph.collectPathAwareDataForNode(
+        val invocationData = graph.collectDataForNode(
             TraverseDirection.Forward,
             PathAwareLambdaInvocationInfo.EMPTY,
             InvocationDataCollector(functionalTypeEffects.keys.filterTo(mutableSetOf()) { it !in leakedSymbols })

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/FirPropertyInitializationAnalyzer.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/FirPropertyInitializationAnalyzer.kt
@@ -49,8 +49,8 @@ object FirPropertyInitializationAnalyzer : AbstractFirPropertyInitializationChec
             if (symbol !in localProperties) return
             if (symbol.fir.isLateInit) return
             val pathAwareInfo = data.getValue(node)
-            for (label in pathAwareInfo.keys) {
-                if (investigate(pathAwareInfo[label]!!, symbol, node)) {
+            for (info in pathAwareInfo.values) {
+                if (investigate(info, symbol, node)) {
                     // To avoid duplicate reports, stop investigating remaining paths if the property is not initialized at any path.
                     break
                 }

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/extended/UnusedChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/extended/UnusedChecker.kt
@@ -151,7 +151,7 @@ object UnusedChecker : FirControlFlowChecker() {
         private val localProperties: Set<FirPropertySymbol>
     ) : ControlFlowGraphVisitor<PathAwareVariableStatusInfo, Collection<Pair<EdgeLabel, PathAwareVariableStatusInfo>>>() {
         fun getData(graph: ControlFlowGraph): Map<CFGNode<*>, PathAwareVariableStatusInfo> {
-            return graph.collectPathAwareDataForNode(TraverseDirection.Backward, PathAwareVariableStatusInfo.EMPTY, this)
+            return graph.collectDataForNode(TraverseDirection.Backward, PathAwareVariableStatusInfo.EMPTY, this)
         }
 
         override fun visitNode(

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/extended/UnusedChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/extended/UnusedChecker.kt
@@ -36,41 +36,52 @@ object UnusedChecker : FirControlFlowChecker() {
     }
 
     class CfaVisitor(
-        val data: Map<CFGNode<*>, VariableStatusInfo>,
+        val data: Map<CFGNode<*>, PathAwareVariableStatusInfo>,
         val reporter: DiagnosticReporter
     ) : ControlFlowGraphVisitorVoid() {
         override fun visitNode(node: CFGNode<*>) {}
 
         override fun visitVariableAssignmentNode(node: VariableAssignmentNode) {
             val variableSymbol = (node.fir.calleeReference as? FirResolvedNamedReference)?.resolvedSymbol ?: return
-            val data = data[node]?.get(variableSymbol) ?: return
-            if (data == VariableStatus.ONLY_WRITTEN_NEVER_READ) {
-                // todo: report case like "a += 1" where `a` `doesn't writes` different way (special for Idea)
-                val source = node.fir.lValue.source
-                reporter.report(source, FirErrors.ASSIGNED_VALUE_IS_NEVER_READ)
+            val dataPerNode = data[node] ?: return
+            for (label in dataPerNode.keys) {
+                val data = dataPerNode[label]!![variableSymbol] ?: continue
+                if (data == VariableStatus.ONLY_WRITTEN_NEVER_READ) {
+                    // todo: report case like "a += 1" where `a` `doesn't writes` different way (special for Idea)
+                    val source = node.fir.lValue.source
+                    reporter.report(source, FirErrors.ASSIGNED_VALUE_IS_NEVER_READ)
+                    // To avoid duplicate reports, stop investigating remaining paths once reported.
+                    break
+                }
             }
         }
 
         override fun visitVariableDeclarationNode(node: VariableDeclarationNode) {
             val variableSymbol = node.fir.symbol
             if (variableSymbol.isLoopIterator) return
-            val data = data[node]?.get(variableSymbol) ?: return
+            val dataPerNode = data[node] ?: return
+            for (label in dataPerNode.keys) {
+                val data = dataPerNode[label]!![variableSymbol] ?: continue
 
-            val variableSource = variableSymbol.fir.source.takeIf { it?.elementType != KtNodeTypes.DESTRUCTURING_DECLARATION }
-            when {
-                data == VariableStatus.UNUSED -> {
-                    if ((node.fir.initializer as? FirFunctionCall)?.isIterator != true) {
-                        reporter.report(variableSource, FirErrors.UNUSED_VARIABLE)
+                val variableSource = variableSymbol.fir.source.takeIf { it?.elementType != KtNodeTypes.DESTRUCTURING_DECLARATION }
+                when {
+                    data == VariableStatus.UNUSED -> {
+                        if ((node.fir.initializer as? FirFunctionCall)?.isIterator != true) {
+                            reporter.report(variableSource, FirErrors.UNUSED_VARIABLE)
+                            break
+                        }
                     }
-                }
-                data.isRedundantInit -> {
-                    val source = variableSymbol.fir.initializer?.source
-                    reporter.report(source, FirErrors.VARIABLE_INITIALIZER_IS_REDUNDANT)
-                }
-                data == VariableStatus.ONLY_WRITTEN_NEVER_READ -> {
-                    reporter.report(variableSource, FirErrors.VARIABLE_NEVER_READ)
-                }
-                else -> {
+                    data.isRedundantInit -> {
+                        val source = variableSymbol.fir.initializer?.source
+                        reporter.report(source, FirErrors.VARIABLE_INITIALIZER_IS_REDUNDANT)
+                        break
+                    }
+                    data == VariableStatus.ONLY_WRITTEN_NEVER_READ -> {
+                        reporter.report(variableSource, FirErrors.VARIABLE_NEVER_READ)
+                        break
+                    }
+                    else -> {
+                    }
                 }
             }
         }
@@ -122,72 +133,102 @@ object UnusedChecker : FirControlFlowChecker() {
 
     }
 
+    class PathAwareVariableStatusInfo(
+        map: PersistentMap<EdgeLabel, VariableStatusInfo> = persistentMapOf()
+    ) : PathAwareControlFlowInfo<PathAwareVariableStatusInfo, VariableStatusInfo>(map) {
+        companion object {
+            val EMPTY = PathAwareVariableStatusInfo(persistentMapOf(NormalPath to VariableStatusInfo.EMPTY))
+        }
+
+        override val constructor: (PersistentMap<EdgeLabel, VariableStatusInfo>) -> PathAwareVariableStatusInfo =
+            ::PathAwareVariableStatusInfo
+
+        override val empty: () -> PathAwareVariableStatusInfo =
+            ::EMPTY
+    }
+
     private class ValueWritesWithoutReading(
         private val localProperties: Set<FirPropertySymbol>
-    ) : ControlFlowGraphVisitor<VariableStatusInfo, Collection<VariableStatusInfo>>() {
-        fun getData(graph: ControlFlowGraph): Map<CFGNode<*>, VariableStatusInfo> {
-            return graph.collectDataForNode(TraverseDirection.Backward, VariableStatusInfo.EMPTY, this)
+    ) : ControlFlowGraphVisitor<PathAwareVariableStatusInfo, Collection<Pair<EdgeLabel, PathAwareVariableStatusInfo>>>() {
+        fun getData(graph: ControlFlowGraph): Map<CFGNode<*>, PathAwareVariableStatusInfo> {
+            return graph.collectPathAwareDataForNode(TraverseDirection.Backward, PathAwareVariableStatusInfo.EMPTY, this)
         }
 
-        override fun visitNode(node: CFGNode<*>, data: Collection<VariableStatusInfo>): VariableStatusInfo {
-            if (data.isEmpty()) return VariableStatusInfo.EMPTY
-            return data.reduce(VariableStatusInfo::merge)
+        override fun visitNode(
+            node: CFGNode<*>,
+            data: Collection<Pair<EdgeLabel, PathAwareVariableStatusInfo>>
+        ): PathAwareVariableStatusInfo {
+            if (data.isEmpty()) return PathAwareVariableStatusInfo.EMPTY
+            return data.map { (label, info) -> info.applyLabel(node, label) }
+                .reduce(PathAwareVariableStatusInfo::merge)
         }
 
-        override fun visitVariableDeclarationNode(node: VariableDeclarationNode, data: Collection<VariableStatusInfo>): VariableStatusInfo {
+        override fun visitVariableDeclarationNode(
+            node: VariableDeclarationNode,
+            data: Collection<Pair<EdgeLabel, PathAwareVariableStatusInfo>>
+        ): PathAwareVariableStatusInfo {
             val dataForNode = visitNode(node, data)
             if (node.fir.source?.kind is FirFakeSourceElementKind) return dataForNode
             val symbol = node.fir.symbol
-            return when (dataForNode[symbol]) {
-                null -> {
-                    dataForNode.put(symbol, VariableStatus.UNUSED)
-                }
-                VariableStatus.ONLY_WRITTEN_NEVER_READ, VariableStatus.WRITTEN_AFTER_READ -> {
-                    if (node.fir.initializer != null && dataForNode[symbol]?.isRead == true) {
-                        val newData = dataForNode[symbol] ?: VariableStatus.UNUSED
-                        newData.isRedundantInit = true
-                        dataForNode.put(symbol, newData)
-                    } else if (node.fir.initializer != null) {
-                        dataForNode.put(symbol, VariableStatus.ONLY_WRITTEN_NEVER_READ)
-                    } else {
-                        dataForNode
+            return update(dataForNode, symbol) { prev ->
+                when (prev) {
+                    null -> {
+                        VariableStatus.UNUSED
                     }
-                }
-                VariableStatus.READ -> {
-                    dataForNode.put(symbol, VariableStatus.READ)
-                }
-                else -> {
-                    dataForNode
+                    VariableStatus.ONLY_WRITTEN_NEVER_READ, VariableStatus.WRITTEN_AFTER_READ -> {
+                        if (node.fir.initializer != null && prev.isRead) {
+                            prev.isRedundantInit = true
+                            prev
+                        } else if (node.fir.initializer != null) {
+                            VariableStatus.ONLY_WRITTEN_NEVER_READ
+                        } else {
+                            null
+                        }
+                    }
+                    VariableStatus.READ -> {
+                        VariableStatus.READ
+                    }
+                    else -> {
+                        null
+                    }
                 }
             }
         }
 
-        override fun visitVariableAssignmentNode(node: VariableAssignmentNode, data: Collection<VariableStatusInfo>): VariableStatusInfo {
+        override fun visitVariableAssignmentNode(
+            node: VariableAssignmentNode,
+            data: Collection<Pair<EdgeLabel, PathAwareVariableStatusInfo>>
+        ): PathAwareVariableStatusInfo {
             val dataForNode = visitNode(node, data)
             val reference = node.fir.lValue as? FirResolvedNamedReference ?: return dataForNode
             val symbol = reference.resolvedSymbol as? FirPropertySymbol ?: return dataForNode
-            val toPut = when {
-                symbol !in localProperties -> {
-                    null
+            return update(dataForNode, symbol) update@{ prev ->
+                val toPut = when {
+                    symbol !in localProperties -> {
+                        null
+                    }
+                    prev == VariableStatus.READ -> {
+                        VariableStatus.WRITTEN_AFTER_READ
+                    }
+                    prev == VariableStatus.WRITTEN_AFTER_READ -> {
+                        VariableStatus.ONLY_WRITTEN_NEVER_READ
+                    }
+                    else -> {
+                        VariableStatus.ONLY_WRITTEN_NEVER_READ.merge(prev ?: VariableStatus.UNUSED)
+                    }
                 }
-                dataForNode[symbol] == VariableStatus.READ -> {
-                    VariableStatus.WRITTEN_AFTER_READ
-                }
-                dataForNode[symbol] == VariableStatus.WRITTEN_AFTER_READ -> {
-                    VariableStatus.ONLY_WRITTEN_NEVER_READ
-                }
-                else -> {
-                    VariableStatus.ONLY_WRITTEN_NEVER_READ.merge(dataForNode[symbol] ?: VariableStatus.UNUSED)
-                }
+
+                toPut ?: return@update null
+
+                toPut.isRead = prev?.isRead ?: false
+                toPut
             }
-
-            toPut ?: return dataForNode
-
-            toPut.isRead = dataForNode[symbol]?.isRead ?: false
-            return dataForNode.put(symbol, toPut)
         }
 
-        override fun visitQualifiedAccessNode(node: QualifiedAccessNode, data: Collection<VariableStatusInfo>): VariableStatusInfo {
+        override fun visitQualifiedAccessNode(
+            node: QualifiedAccessNode,
+            data: Collection<Pair<EdgeLabel, PathAwareVariableStatusInfo>>
+        ): PathAwareVariableStatusInfo {
             val dataForNode = visitNode(node, data)
             if (node.fir.source?.kind is FirFakeSourceElementKind) return dataForNode
             val reference = node.fir.calleeReference as? FirResolvedNamedReference ?: return dataForNode
@@ -197,7 +238,27 @@ object UnusedChecker : FirControlFlowChecker() {
 
             val status = VariableStatus.READ
             status.isRead = true
-            return dataForNode.put(symbol, status)
+            return update(dataForNode, symbol) { status }
+        }
+
+        private fun update(
+            info: PathAwareVariableStatusInfo,
+            symbol: FirPropertySymbol,
+            updater: (VariableStatus?) -> VariableStatus?,
+        ): PathAwareVariableStatusInfo {
+            var resultMap = persistentMapOf<EdgeLabel, VariableStatusInfo>()
+            var changed = false
+            for (label in info.keys) {
+                val dataPerLabel = info[label]!!
+                val v = updater.invoke(dataPerLabel[symbol])
+                if (v != null) {
+                    resultMap = resultMap.put(label, dataPerLabel.put(symbol, v))
+                    changed = true
+                } else {
+                    resultMap = resultMap.put(label, dataPerLabel)
+                }
+            }
+            return if (changed) PathAwareVariableStatusInfo(resultMap) else info
         }
     }
 


### PR DESCRIPTION
This, as another follow-up for #3813, makes `UnusedChecker` path-sensitive. Together with #3889, all existing checkers have been migrated, and thus, the old variant---path-insensitive data collection---is deprecated as well.