### PR TITLE
FIR: import parents of companion objects first

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/codegen/FirCompileKotlinAgainstKotlinTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/codegen/FirCompileKotlinAgainstKotlinTestGenerated.java
@@ -148,6 +148,11 @@ public class FirCompileKotlinAgainstKotlinTestGenerated extends AbstractFirCompi
         runTest("compiler/testData/compileKotlinAgainstKotlin/expectClassActualTypeAlias.kt");
     }
 
+    @TestMetadata("importCompanion.kt")
+    public void testImportCompanion() throws Exception {
+        runTest("compiler/testData/compileKotlinAgainstKotlin/importCompanion.kt");
+    }
+
     @TestMetadata("inlineClassFromBinaryDependencies.kt")
     public void testInlineClassFromBinaryDependencies() throws Exception {
         runTest("compiler/testData/compileKotlinAgainstKotlin/inlineClassFromBinaryDependencies.kt");

--- a/compiler/testData/compileKotlinAgainstKotlin/importCompanion.kt
+++ b/compiler/testData/compileKotlinAgainstKotlin/importCompanion.kt
@@ -1,0 +1,16 @@
+// WITH_RUNTIME
+// TARGET_BACKEND: JVM
+// FILE: 1.kt
+package test
+
+class C(val x: String) {
+    companion object {
+        @JvmField
+        val instance: C = C("OK")
+    }
+}
+
+// FILE: 2.kt
+import test.C.Companion.instance
+
+fun box() = instance.x

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/CompileKotlinAgainstKotlinTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/CompileKotlinAgainstKotlinTestGenerated.java
@@ -153,6 +153,11 @@ public class CompileKotlinAgainstKotlinTestGenerated extends AbstractCompileKotl
         runTest("compiler/testData/compileKotlinAgainstKotlin/expectClassActualTypeAlias.kt");
     }
 
+    @TestMetadata("importCompanion.kt")
+    public void testImportCompanion() throws Exception {
+        runTest("compiler/testData/compileKotlinAgainstKotlin/importCompanion.kt");
+    }
+
     @TestMetadata("inlineClassFromBinaryDependencies.kt")
     public void testInlineClassFromBinaryDependencies() throws Exception {
         runTest("compiler/testData/compileKotlinAgainstKotlin/inlineClassFromBinaryDependencies.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/IrCompileKotlinAgainstKotlinTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/IrCompileKotlinAgainstKotlinTestGenerated.java
@@ -148,6 +148,11 @@ public class IrCompileKotlinAgainstKotlinTestGenerated extends AbstractIrCompile
         runTest("compiler/testData/compileKotlinAgainstKotlin/expectClassActualTypeAlias.kt");
     }
 
+    @TestMetadata("importCompanion.kt")
+    public void testImportCompanion() throws Exception {
+        runTest("compiler/testData/compileKotlinAgainstKotlin/importCompanion.kt");
+    }
+
     @TestMetadata("inlineClassFromBinaryDependencies.kt")
     public void testInlineClassFromBinaryDependencies() throws Exception {
         runTest("compiler/testData/compileKotlinAgainstKotlin/inlineClassFromBinaryDependencies.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/JvmIrAgainstOldBoxTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/JvmIrAgainstOldBoxTestGenerated.java
@@ -148,6 +148,11 @@ public class JvmIrAgainstOldBoxTestGenerated extends AbstractJvmIrAgainstOldBoxT
         runTest("compiler/testData/compileKotlinAgainstKotlin/expectClassActualTypeAlias.kt");
     }
 
+    @TestMetadata("importCompanion.kt")
+    public void testImportCompanion() throws Exception {
+        runTest("compiler/testData/compileKotlinAgainstKotlin/importCompanion.kt");
+    }
+
     @TestMetadata("inlineClassFromBinaryDependencies.kt")
     public void testInlineClassFromBinaryDependencies() throws Exception {
         runTest("compiler/testData/compileKotlinAgainstKotlin/inlineClassFromBinaryDependencies.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/JvmOldAgainstIrBoxTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/JvmOldAgainstIrBoxTestGenerated.java
@@ -148,6 +148,11 @@ public class JvmOldAgainstIrBoxTestGenerated extends AbstractJvmOldAgainstIrBoxT
         runTest("compiler/testData/compileKotlinAgainstKotlin/expectClassActualTypeAlias.kt");
     }
 
+    @TestMetadata("importCompanion.kt")
+    public void testImportCompanion() throws Exception {
+        runTest("compiler/testData/compileKotlinAgainstKotlin/importCompanion.kt");
+    }
+
     @TestMetadata("inlineClassFromBinaryDependencies.kt")
     public void testInlineClassFromBinaryDependencies() throws Exception {
         runTest("compiler/testData/compileKotlinAgainstKotlin/inlineClassFromBinaryDependencies.kt");


### PR DESCRIPTION
Otherwise, information about members moved from companion objects to the parent class (e.g. on JVM, companion object fields -> static fields in parent class) will be incorrect.