### PR TITLE
FIR DFA: refine type info around null equality checks

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/fir/Fir2IrTextTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/fir/Fir2IrTextTestGenerated.java
@@ -1807,6 +1807,11 @@ public class Fir2IrTextTestGenerated extends AbstractFir2IrTextTest {
             runTest("compiler/testData/ir/irText/firProblems/FirBuilder.kt");
         }
 
+        @TestMetadata("inapplicableCollectionSet.kt")
+        public void testInapplicableCollectionSet() throws Exception {
+            runTest("compiler/testData/ir/irText/firProblems/inapplicableCollectionSet.kt");
+        }
+
         @TestMetadata("InnerClassInAnonymous.kt")
         public void testInnerClassInAnonymous() throws Exception {
             runTest("compiler/testData/ir/irText/firProblems/InnerClassInAnonymous.kt");

--- a/compiler/testData/ir/irText/firProblems/inapplicableCollectionSet.fir.kt.txt
+++ b/compiler/testData/ir/irText/firProblems/inapplicableCollectionSet.fir.kt.txt
@@ -23,10 +23,10 @@ class Flaf {
             result = Flaf(javaName = javaName)
           }
         }
-        error("") /* ErrorCallExpression */javaName; result;
+        <this>.<get-INSTANCES>().set<String, Flaf>(key = javaName, value = result /*as Flaf */)
       }
     }
-    return result
+    return result /*as Flaf */
   }
 
 }

--- a/compiler/testData/ir/irText/firProblems/inapplicableCollectionSet.fir.kt.txt
+++ b/compiler/testData/ir/irText/firProblems/inapplicableCollectionSet.fir.kt.txt
@@ -1,0 +1,32 @@
+class Flaf {
+  constructor(javaName: String) /* primary */ {
+    super/*Any*/()
+    /* <init>() */
+
+  }
+
+  val javaName: String
+    field = javaName
+    get
+
+  private val INSTANCES: MutableMap<String, Flaf>
+    field = mutableMapOf<String, Flaf>()
+    private get
+
+  fun forJavaName(javaName: String): Flaf {
+    var result: Flaf? = <this>.<get-INSTANCES>().get(key = javaName)
+    when {
+      EQEQ(arg0 = result, arg1 = null) -> { // BLOCK
+        result = <this>.<get-INSTANCES>().get(key = javaName.toString() + "_alternative")
+        when {
+          EQEQ(arg0 = result, arg1 = null) -> { // BLOCK
+            result = Flaf(javaName = javaName)
+          }
+        }
+        error("") /* ErrorCallExpression */javaName; result;
+      }
+    }
+    return result
+  }
+
+}

--- a/compiler/testData/ir/irText/firProblems/inapplicableCollectionSet.fir.txt
+++ b/compiler/testData/ir/irText/firProblems/inapplicableCollectionSet.fir.txt
@@ -1,0 +1,82 @@
+FILE fqName:<root> fileName:/inapplicableCollectionSet.kt
+  CLASS CLASS name:Flaf modality:FINAL visibility:public superTypes:[kotlin.Any]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.Flaf
+    CONSTRUCTOR visibility:public <> (javaName:kotlin.String) returnType:<root>.Flaf [primary]
+      VALUE_PARAMETER name:javaName index:0 type:kotlin.String
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Flaf modality:FINAL visibility:public superTypes:[kotlin.Any]'
+    PROPERTY name:javaName visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:javaName type:kotlin.String visibility:private [final]
+        EXPRESSION_BODY
+          GET_VAR 'javaName: kotlin.String declared in <root>.Flaf.<init>' type=kotlin.String origin=INITIALIZE_PROPERTY_FROM_PARAMETER
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-javaName> visibility:public modality:FINAL <> ($this:<root>.Flaf) returnType:kotlin.String
+        correspondingProperty: PROPERTY name:javaName visibility:public modality:FINAL [val]
+        $this: VALUE_PARAMETER name:<this> type:<root>.Flaf
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-javaName> (): kotlin.String declared in <root>.Flaf'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:javaName type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.Flaf declared in <root>.Flaf.<get-javaName>' type=<root>.Flaf origin=null
+    PROPERTY name:INSTANCES visibility:private modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:INSTANCES type:kotlin.collections.MutableMap<kotlin.String, <root>.Flaf> visibility:private [final]
+        EXPRESSION_BODY
+          CALL 'public final fun mutableMapOf <K, V> (): kotlin.collections.MutableMap<K of kotlin.collections.mutableMapOf, V of kotlin.collections.mutableMapOf> [inline] declared in kotlin.collections' type=kotlin.collections.MutableMap<kotlin.String, <root>.Flaf> origin=null
+            <K>: kotlin.String
+            <V>: <root>.Flaf
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-INSTANCES> visibility:private modality:FINAL <> ($this:<root>.Flaf) returnType:kotlin.collections.MutableMap<kotlin.String, <root>.Flaf>
+        correspondingProperty: PROPERTY name:INSTANCES visibility:private modality:FINAL [val]
+        $this: VALUE_PARAMETER name:<this> type:<root>.Flaf
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='private final fun <get-INSTANCES> (): kotlin.collections.MutableMap<kotlin.String, <root>.Flaf> declared in <root>.Flaf'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:INSTANCES type:kotlin.collections.MutableMap<kotlin.String, <root>.Flaf> visibility:private [final]' type=kotlin.collections.MutableMap<kotlin.String, <root>.Flaf> origin=null
+              receiver: GET_VAR '<this>: <root>.Flaf declared in <root>.Flaf.<get-INSTANCES>' type=<root>.Flaf origin=null
+    FUN name:forJavaName visibility:public modality:FINAL <> ($this:<root>.Flaf, javaName:kotlin.String) returnType:<root>.Flaf
+      $this: VALUE_PARAMETER name:<this> type:<root>.Flaf
+      VALUE_PARAMETER name:javaName index:0 type:kotlin.String
+      BLOCK_BODY
+        VAR name:result type:<root>.Flaf? [var]
+          CALL 'public abstract fun get (key: K of kotlin.collections.MutableMap): V of kotlin.collections.MutableMap? [fake_override,operator] declared in kotlin.collections.MutableMap' type=<root>.Flaf? origin=null
+            $this: CALL 'private final fun <get-INSTANCES> (): kotlin.collections.MutableMap<kotlin.String, <root>.Flaf> declared in <root>.Flaf' type=kotlin.collections.MutableMap<kotlin.String, <root>.Flaf> origin=GET_PROPERTY
+              $this: GET_VAR '<this>: <root>.Flaf declared in <root>.Flaf.forJavaName' type=<root>.Flaf origin=null
+            key: GET_VAR 'javaName: kotlin.String declared in <root>.Flaf.forJavaName' type=kotlin.String origin=null
+        WHEN type=kotlin.Unit origin=IF
+          BRANCH
+            if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+              arg0: GET_VAR 'var result: <root>.Flaf? [var] declared in <root>.Flaf.forJavaName' type=<root>.Flaf? origin=null
+              arg1: CONST Null type=kotlin.Nothing? value=null
+            then: BLOCK type=kotlin.Unit origin=null
+              SET_VAR 'var result: <root>.Flaf? [var] declared in <root>.Flaf.forJavaName' type=kotlin.Unit origin=EQ
+                CALL 'public abstract fun get (key: K of kotlin.collections.MutableMap): V of kotlin.collections.MutableMap? [fake_override,operator] declared in kotlin.collections.MutableMap' type=<root>.Flaf? origin=null
+                  $this: CALL 'private final fun <get-INSTANCES> (): kotlin.collections.MutableMap<kotlin.String, <root>.Flaf> declared in <root>.Flaf' type=kotlin.collections.MutableMap<kotlin.String, <root>.Flaf> origin=GET_PROPERTY
+                    $this: GET_VAR '<this>: <root>.Flaf declared in <root>.Flaf.forJavaName' type=<root>.Flaf origin=null
+                  key: STRING_CONCATENATION type=kotlin.String
+                    CALL 'public open fun toString (): kotlin.String [fake_override] declared in kotlin.String' type=kotlin.String origin=null
+                      $this: GET_VAR 'javaName: kotlin.String declared in <root>.Flaf.forJavaName' type=kotlin.String origin=null
+                    CONST String type=kotlin.String value="_alternative"
+              WHEN type=kotlin.Unit origin=IF
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'var result: <root>.Flaf? [var] declared in <root>.Flaf.forJavaName' type=<root>.Flaf? origin=null
+                    arg1: CONST Null type=kotlin.Nothing? value=null
+                  then: BLOCK type=kotlin.Unit origin=null
+                    SET_VAR 'var result: <root>.Flaf? [var] declared in <root>.Flaf.forJavaName' type=kotlin.Unit origin=EQ
+                      CONSTRUCTOR_CALL 'public constructor <init> (javaName: kotlin.String) [primary] declared in <root>.Flaf' type=<root>.Flaf origin=null
+                        javaName: GET_VAR 'javaName: kotlin.String declared in <root>.Flaf.forJavaName' type=kotlin.String origin=null
+              ERROR_CALL 'Unresolved reference: <Inapplicable(INAPPLICABLE): kotlin/collections/set>#' type=kotlin.Unit
+                GET_VAR 'javaName: kotlin.String declared in <root>.Flaf.forJavaName' type=kotlin.String origin=null
+                GET_VAR 'var result: <root>.Flaf? [var] declared in <root>.Flaf.forJavaName' type=<root>.Flaf? origin=null
+        RETURN type=kotlin.Nothing from='public final fun forJavaName (javaName: kotlin.String): <root>.Flaf declared in <root>.Flaf'
+          GET_VAR 'var result: <root>.Flaf? [var] declared in <root>.Flaf.forJavaName' type=<root>.Flaf? origin=null
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean [operator] declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any

--- a/compiler/testData/ir/irText/firProblems/inapplicableCollectionSet.fir.txt
+++ b/compiler/testData/ir/irText/firProblems/inapplicableCollectionSet.fir.txt
@@ -62,11 +62,17 @@ FILE fqName:<root> fileName:/inapplicableCollectionSet.kt
                     SET_VAR 'var result: <root>.Flaf? [var] declared in <root>.Flaf.forJavaName' type=kotlin.Unit origin=EQ
                       CONSTRUCTOR_CALL 'public constructor <init> (javaName: kotlin.String) [primary] declared in <root>.Flaf' type=<root>.Flaf origin=null
                         javaName: GET_VAR 'javaName: kotlin.String declared in <root>.Flaf.forJavaName' type=kotlin.String origin=null
-              ERROR_CALL 'Unresolved reference: <Inapplicable(INAPPLICABLE): kotlin/collections/set>#' type=kotlin.Unit
-                GET_VAR 'javaName: kotlin.String declared in <root>.Flaf.forJavaName' type=kotlin.String origin=null
-                GET_VAR 'var result: <root>.Flaf? [var] declared in <root>.Flaf.forJavaName' type=<root>.Flaf? origin=null
+              CALL 'public final fun set <K, V> (key: K of kotlin.collections.set, value: V of kotlin.collections.set): kotlin.Unit [inline,operator] declared in kotlin.collections' type=kotlin.Unit origin=null
+                <K>: kotlin.String
+                <V>: <root>.Flaf
+                $receiver: CALL 'private final fun <get-INSTANCES> (): kotlin.collections.MutableMap<kotlin.String, <root>.Flaf> declared in <root>.Flaf' type=kotlin.collections.MutableMap<kotlin.String, <root>.Flaf> origin=GET_PROPERTY
+                  $this: GET_VAR '<this>: <root>.Flaf declared in <root>.Flaf.forJavaName' type=<root>.Flaf origin=null
+                key: GET_VAR 'javaName: kotlin.String declared in <root>.Flaf.forJavaName' type=kotlin.String origin=null
+                value: TYPE_OP type=<root>.Flaf origin=IMPLICIT_CAST typeOperand=<root>.Flaf
+                  GET_VAR 'var result: <root>.Flaf? [var] declared in <root>.Flaf.forJavaName' type=<root>.Flaf? origin=null
         RETURN type=kotlin.Nothing from='public final fun forJavaName (javaName: kotlin.String): <root>.Flaf declared in <root>.Flaf'
-          GET_VAR 'var result: <root>.Flaf? [var] declared in <root>.Flaf.forJavaName' type=<root>.Flaf? origin=null
+          TYPE_OP type=<root>.Flaf origin=IMPLICIT_CAST typeOperand=<root>.Flaf
+            GET_VAR 'var result: <root>.Flaf? [var] declared in <root>.Flaf.forJavaName' type=<root>.Flaf? origin=null
     FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
       overridden:
         public open fun equals (other: kotlin.Any?): kotlin.Boolean [operator] declared in kotlin.Any

--- a/compiler/testData/ir/irText/firProblems/inapplicableCollectionSet.kt
+++ b/compiler/testData/ir/irText/firProblems/inapplicableCollectionSet.kt
@@ -1,0 +1,20 @@
+// WITH_RUNTIME
+// FULL_JDK
+
+class Flaf(val javaName: String) {
+
+    private val INSTANCES = mutableMapOf<String, Flaf>()
+
+    fun forJavaName(javaName: String): Flaf {
+        var result: Flaf? = INSTANCES[javaName]
+        if (result == null) {
+            result = INSTANCES["${javaName}_alternative"]
+            if (result == null) {
+                result = Flaf(javaName)
+            }
+            INSTANCES[javaName] = result
+        }
+        return result
+    }
+
+}

--- a/compiler/testData/ir/irText/firProblems/inapplicableCollectionSet.kt.txt
+++ b/compiler/testData/ir/irText/firProblems/inapplicableCollectionSet.kt.txt
@@ -1,0 +1,32 @@
+class Flaf {
+  constructor(javaName: String) /* primary */ {
+    super/*Any*/()
+    /* <init>() */
+
+  }
+
+  val javaName: String
+    field = javaName
+    get
+
+  private val INSTANCES: MutableMap<String, Flaf>
+    field = mutableMapOf<String, Flaf>()
+    private get
+
+  fun forJavaName(javaName: String): Flaf {
+    var result: Flaf? = <this>.<get-INSTANCES>().get(key = javaName)
+    when {
+      EQEQ(arg0 = result, arg1 = null) -> { // BLOCK
+        result = <this>.<get-INSTANCES>().get(key = javaName + "_alternative")
+        when {
+          EQEQ(arg0 = result, arg1 = null) -> { // BLOCK
+            result = Flaf(javaName = javaName)
+          }
+        }
+        <this>.<get-INSTANCES>().set<String, Flaf>(key = javaName, value = result)
+      }
+    }
+    return result
+  }
+
+}

--- a/compiler/testData/ir/irText/firProblems/inapplicableCollectionSet.txt
+++ b/compiler/testData/ir/irText/firProblems/inapplicableCollectionSet.txt
@@ -1,0 +1,85 @@
+FILE fqName:<root> fileName:/inapplicableCollectionSet.kt
+  CLASS CLASS name:Flaf modality:FINAL visibility:public superTypes:[kotlin.Any]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.Flaf
+    CONSTRUCTOR visibility:public <> (javaName:kotlin.String) returnType:<root>.Flaf [primary]
+      VALUE_PARAMETER name:javaName index:0 type:kotlin.String
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Flaf modality:FINAL visibility:public superTypes:[kotlin.Any]'
+    PROPERTY name:javaName visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:javaName type:kotlin.String visibility:private [final]
+        EXPRESSION_BODY
+          GET_VAR 'javaName: kotlin.String declared in <root>.Flaf.<init>' type=kotlin.String origin=INITIALIZE_PROPERTY_FROM_PARAMETER
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-javaName> visibility:public modality:FINAL <> ($this:<root>.Flaf) returnType:kotlin.String
+        correspondingProperty: PROPERTY name:javaName visibility:public modality:FINAL [val]
+        $this: VALUE_PARAMETER name:<this> type:<root>.Flaf
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-javaName> (): kotlin.String declared in <root>.Flaf'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:javaName type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.Flaf declared in <root>.Flaf.<get-javaName>' type=<root>.Flaf origin=null
+    PROPERTY name:INSTANCES visibility:private modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:INSTANCES type:kotlin.collections.MutableMap<kotlin.String, <root>.Flaf> visibility:private [final]
+        EXPRESSION_BODY
+          CALL 'public final fun mutableMapOf <K, V> (): kotlin.collections.MutableMap<K of kotlin.collections.mutableMapOf, V of kotlin.collections.mutableMapOf> [inline] declared in kotlin.collections' type=kotlin.collections.MutableMap<kotlin.String, <root>.Flaf> origin=null
+            <K>: kotlin.String
+            <V>: <root>.Flaf
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-INSTANCES> visibility:private modality:FINAL <> ($this:<root>.Flaf) returnType:kotlin.collections.MutableMap<kotlin.String, <root>.Flaf>
+        correspondingProperty: PROPERTY name:INSTANCES visibility:private modality:FINAL [val]
+        $this: VALUE_PARAMETER name:<this> type:<root>.Flaf
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='private final fun <get-INSTANCES> (): kotlin.collections.MutableMap<kotlin.String, <root>.Flaf> declared in <root>.Flaf'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:INSTANCES type:kotlin.collections.MutableMap<kotlin.String, <root>.Flaf> visibility:private [final]' type=kotlin.collections.MutableMap<kotlin.String, <root>.Flaf> origin=null
+              receiver: GET_VAR '<this>: <root>.Flaf declared in <root>.Flaf.<get-INSTANCES>' type=<root>.Flaf origin=null
+    FUN name:forJavaName visibility:public modality:FINAL <> ($this:<root>.Flaf, javaName:kotlin.String) returnType:<root>.Flaf
+      $this: VALUE_PARAMETER name:<this> type:<root>.Flaf
+      VALUE_PARAMETER name:javaName index:0 type:kotlin.String
+      BLOCK_BODY
+        VAR name:result type:<root>.Flaf? [var]
+          CALL 'public abstract fun get (key: K of kotlin.collections.MutableMap): V of kotlin.collections.MutableMap? [fake_override,operator] declared in kotlin.collections.MutableMap' type=<root>.Flaf? origin=GET_ARRAY_ELEMENT
+            $this: CALL 'private final fun <get-INSTANCES> (): kotlin.collections.MutableMap<kotlin.String, <root>.Flaf> declared in <root>.Flaf' type=kotlin.collections.MutableMap<kotlin.String, <root>.Flaf> origin=GET_PROPERTY
+              $this: GET_VAR '<this>: <root>.Flaf declared in <root>.Flaf.forJavaName' type=<root>.Flaf origin=null
+            key: GET_VAR 'javaName: kotlin.String declared in <root>.Flaf.forJavaName' type=kotlin.String origin=null
+        WHEN type=kotlin.Unit origin=IF
+          BRANCH
+            if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+              arg0: GET_VAR 'var result: <root>.Flaf? [var] declared in <root>.Flaf.forJavaName' type=<root>.Flaf? origin=null
+              arg1: CONST Null type=kotlin.Nothing? value=null
+            then: BLOCK type=kotlin.Unit origin=null
+              SET_VAR 'var result: <root>.Flaf? [var] declared in <root>.Flaf.forJavaName' type=kotlin.Unit origin=EQ
+                CALL 'public abstract fun get (key: K of kotlin.collections.MutableMap): V of kotlin.collections.MutableMap? [fake_override,operator] declared in kotlin.collections.MutableMap' type=<root>.Flaf? origin=GET_ARRAY_ELEMENT
+                  $this: CALL 'private final fun <get-INSTANCES> (): kotlin.collections.MutableMap<kotlin.String, <root>.Flaf> declared in <root>.Flaf' type=kotlin.collections.MutableMap<kotlin.String, <root>.Flaf> origin=GET_PROPERTY
+                    $this: GET_VAR '<this>: <root>.Flaf declared in <root>.Flaf.forJavaName' type=<root>.Flaf origin=null
+                  key: STRING_CONCATENATION type=kotlin.String
+                    GET_VAR 'javaName: kotlin.String declared in <root>.Flaf.forJavaName' type=kotlin.String origin=null
+                    CONST String type=kotlin.String value="_alternative"
+              WHEN type=kotlin.Unit origin=IF
+                BRANCH
+                  if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                    arg0: GET_VAR 'var result: <root>.Flaf? [var] declared in <root>.Flaf.forJavaName' type=<root>.Flaf? origin=null
+                    arg1: CONST Null type=kotlin.Nothing? value=null
+                  then: BLOCK type=kotlin.Unit origin=null
+                    SET_VAR 'var result: <root>.Flaf? [var] declared in <root>.Flaf.forJavaName' type=kotlin.Unit origin=EQ
+                      CONSTRUCTOR_CALL 'public constructor <init> (javaName: kotlin.String) [primary] declared in <root>.Flaf' type=<root>.Flaf origin=null
+                        javaName: GET_VAR 'javaName: kotlin.String declared in <root>.Flaf.forJavaName' type=kotlin.String origin=null
+              CALL 'public final fun set <K, V> (key: K of kotlin.collections.set, value: V of kotlin.collections.set): kotlin.Unit [inline,operator] declared in kotlin.collections' type=kotlin.Unit origin=EQ
+                <K>: kotlin.String
+                <V>: <root>.Flaf
+                $receiver: CALL 'private final fun <get-INSTANCES> (): kotlin.collections.MutableMap<kotlin.String, <root>.Flaf> declared in <root>.Flaf' type=kotlin.collections.MutableMap<kotlin.String, <root>.Flaf> origin=GET_PROPERTY
+                  $this: GET_VAR '<this>: <root>.Flaf declared in <root>.Flaf.forJavaName' type=<root>.Flaf origin=null
+                key: GET_VAR 'javaName: kotlin.String declared in <root>.Flaf.forJavaName' type=kotlin.String origin=null
+                value: GET_VAR 'var result: <root>.Flaf? [var] declared in <root>.Flaf.forJavaName' type=<root>.Flaf? origin=null
+        RETURN type=kotlin.Nothing from='public final fun forJavaName (javaName: kotlin.String): <root>.Flaf declared in <root>.Flaf'
+          GET_VAR 'var result: <root>.Flaf? [var] declared in <root>.Flaf.forJavaName' type=<root>.Flaf? origin=null
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean [operator] declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any

--- a/compiler/tests-gen/org/jetbrains/kotlin/ir/IrTextTestCaseGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/ir/IrTextTestCaseGenerated.java
@@ -1806,6 +1806,11 @@ public class IrTextTestCaseGenerated extends AbstractIrTextTestCase {
             runTest("compiler/testData/ir/irText/firProblems/FirBuilder.kt");
         }
 
+        @TestMetadata("inapplicableCollectionSet.kt")
+        public void testInapplicableCollectionSet() throws Exception {
+            runTest("compiler/testData/ir/irText/firProblems/inapplicableCollectionSet.kt");
+        }
+
         @TestMetadata("InnerClassInAnonymous.kt")
         public void testInnerClassInAnonymous() throws Exception {
             runTest("compiler/testData/ir/irText/firProblems/InnerClassInAnonymous.kt");

--- a/compiler/tests-spec/testData/diagnostics/notLinked/dfa/neg/42.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/dfa/neg/42.fir.kt
@@ -19,8 +19,8 @@ fun case_1(x: Any) {
  */
 fun case_2(x: Any?) {
     if (x is Int || x is Float?) {
-        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & kotlin.Any?")!>x<!>
-        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & kotlin.Any?")!>x<!>.<!UNRESOLVED_REFERENCE!>toByte<!>()
+        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Number? & kotlin.Comparable<kotlin.Int & kotlin.Float>? & kotlin.Any?")!>x<!>
+        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Number? & kotlin.Comparable<kotlin.Int & kotlin.Float>? & kotlin.Any?")!>x<!>.<!INAPPLICABLE_CANDIDATE!>toByte<!>()
     }
 }
 
@@ -30,8 +30,8 @@ fun case_2(x: Any?) {
  */
 fun case_3(x: Any?) {
     if (x is Int? || x is Float) {
-        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & kotlin.Any?")!>x<!>
-        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & kotlin.Any?")!>x<!>.<!UNRESOLVED_REFERENCE!>toByte<!>()
+        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Number? & kotlin.Comparable<kotlin.Int & kotlin.Float>? & kotlin.Any?")!>x<!>
+        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Number? & kotlin.Comparable<kotlin.Int & kotlin.Float>? & kotlin.Any?")!>x<!>.<!INAPPLICABLE_CANDIDATE!>toByte<!>()
     }
 }
 


### PR DESCRIPTION
The motivation is [KT-43569](https://youtrack.jetbrains.com/issue/KT-43569) where variable `result` is updated multiple times in order to be non-null:
```kt
class Flaf(val javaName: String) {
    private val INSTANCES = mutableMapOf<String, Flaf>()
    fun forJavaName(javaName: String): Flaf {
      var result: Flaf? = INSTANCES[javaName]
      if (result == null) {
        result = INSTANCES["${javaName}_alternative"]
        if (result == null) {
          result = Flaf(javaName)
        }
        INSTANCES[javaName] = result
      }
      return result
    }
}
```
However, at the last index operator point, the smartcast type info (or info from FIR DFA) is still nullable, hence the resolution failed, which expected the argument for value `V` is not nullable.

The key point is:
```kt
if (result == null) {
  result = ... // not null anymore
} // synthetic else // result is not null according to the condition
// therefore, at the join of when conditions, result is not null
```

When the synthetic `else` of the inner `when` expression was visited, type info added at that point affected all the above expressions, including the first variable assignment: `result = INSTANCE[...]`. So, `result`, which was of `Flaf?` type, became `it(Any, Flaf?)` all the sudden. The effects of branches inside `when` expression as well as expressions before/after `when` expression should be isolated. The 2nd commit does so, and now the type information for the first variable assignment remains as-is.

But, inspired by that, when a variable is of a nullable class-like type, followed by a null check, we can learn that, for that branch and `else` branch, we can nail down that variable's nullability. For now, after `null` check, implications bound to the variable are `Any`. But, we can use the r-value's (non-null) type. The 3rd commit does so, and is able to deal with collection set, which expected non-null value type, properly.