### PR TITLE
[FIR] fix property accessors from fakeoverriding delegated properties.

### DIFF
--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/generators/FakeOverrideGenerator.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/generators/FakeOverrideGenerator.kt
@@ -234,11 +234,14 @@ class FakeOverrideGenerator(
         for (baseSymbol in baseSymbols) {
             val unwrapped = baseSymbol.unwrapFakeOverrides()
             // Do not create fake overrides for accessors if not allowed to do so, e.g., private lateinit var.
-            if (unwrapped.fir.getter?.allowsToHaveFakeOverride != true) {
+            // For delegated Fir properties with null accessors, DelegatedMemberGenerator creates their IR accessors.
+            // We'd like to keep the accessors of their fakeoverrides. See KT-43342.
+            val isFromDelegated = unwrapped.fir.origin == FirDeclarationOrigin.Delegated
+            if (unwrapped.fir.getter?.allowsToHaveFakeOverride != true && !(isFromDelegated && unwrapped.fir.getter == null)) {
                 getter = null
             }
             // or private setter
-            if (unwrapped.fir.setter?.allowsToHaveFakeOverride != true) {
+            if (unwrapped.fir.setter?.allowsToHaveFakeOverride != true && !(isFromDelegated && unwrapped.fir.setter == null)) {
                 setter = null
             }
         }

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
@@ -10183,6 +10183,11 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
             runTest("compiler/testData/codegen/box/delegatedProperty/kt4138.kt");
         }
 
+        @TestMetadata("kt43342.kt")
+        public void testKt43342() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/kt43342.kt");
+        }
+
         @TestMetadata("kt6722.kt")
         public void testKt6722() throws Exception {
             runTest("compiler/testData/codegen/box/delegatedProperty/kt6722.kt");

--- a/compiler/testData/codegen/box/delegatedProperty/kt43342.kt
+++ b/compiler/testData/codegen/box/delegatedProperty/kt43342.kt
@@ -1,0 +1,15 @@
+// WITH_RUNTIME
+open class ControlFlowInfo<K, V>(val map: Map<K, V>): Map<K, V> by map
+
+
+class StringFlowInfo(map: Map<String, String>): ControlFlowInfo<String, String>(map) {
+    fun foo(info: StringFlowInfo): String {
+        if (keys.size == info.keys.size) return "OK"
+        return "FAIL"
+    }
+}
+
+fun box(): String {
+    val s = StringFlowInfo(mapOf("a" to "b"))
+    return s.foo(s)
+}

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -11583,6 +11583,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             runTest("compiler/testData/codegen/box/delegatedProperty/kt4138.kt");
         }
 
+        @TestMetadata("kt43342.kt")
+        public void testKt43342() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/kt43342.kt");
+        }
+
         @TestMetadata("kt6722.kt")
         public void testKt6722() throws Exception {
             runTest("compiler/testData/codegen/box/delegatedProperty/kt6722.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -11583,6 +11583,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/delegatedProperty/kt4138.kt");
         }
 
+        @TestMetadata("kt43342.kt")
+        public void testKt43342() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/kt43342.kt");
+        }
+
         @TestMetadata("kt6722.kt")
         public void testKt6722() throws Exception {
             runTest("compiler/testData/codegen/box/delegatedProperty/kt6722.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -10183,6 +10183,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             runTest("compiler/testData/codegen/box/delegatedProperty/kt4138.kt");
         }
 
+        @TestMetadata("kt43342.kt")
+        public void testKt43342() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/kt43342.kt");
+        }
+
         @TestMetadata("kt6722.kt")
         public void testKt6722() throws Exception {
             runTest("compiler/testData/codegen/box/delegatedProperty/kt6722.kt");

--- a/js/js.tests/test-gen/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
+++ b/js/js.tests/test-gen/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
@@ -8693,6 +8693,11 @@ public class IrJsCodegenBoxES6TestGenerated extends AbstractIrJsCodegenBoxES6Tes
             runTest("compiler/testData/codegen/box/delegatedProperty/kt4138.kt");
         }
 
+        @TestMetadata("kt43342.kt")
+        public void testKt43342() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/kt43342.kt");
+        }
+
         @TestMetadata("kt6722.kt")
         public void testKt6722() throws Exception {
             runTest("compiler/testData/codegen/box/delegatedProperty/kt6722.kt");

--- a/js/js.tests/test-gen/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test-gen/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -8693,6 +8693,11 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/delegatedProperty/kt4138.kt");
         }
 
+        @TestMetadata("kt43342.kt")
+        public void testKt43342() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/kt43342.kt");
+        }
+
         @TestMetadata("kt6722.kt")
         public void testKt6722() throws Exception {
             runTest("compiler/testData/codegen/box/delegatedProperty/kt6722.kt");

--- a/js/js.tests/test-gen/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/test-gen/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -8693,6 +8693,11 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/delegatedProperty/kt4138.kt");
         }
 
+        @TestMetadata("kt43342.kt")
+        public void testKt43342() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/kt43342.kt");
+        }
+
         @TestMetadata("kt6722.kt")
         public void testKt6722() throws Exception {
             runTest("compiler/testData/codegen/box/delegatedProperty/kt6722.kt");


### PR DESCRIPTION
When a property in a subclass is created from fakeoverriding a delegated property in a super class, the delegated property does not have FIR accessors, and DeleagatedMemberGenerator creates IR accessors. This causes IrProperty.discardAccessorsAccordingToBaseVisibility to discard the subclass property accessors.

This PR adds a check in IrProperty.discardAccessorsAccordingToBaseVisibility for the delegated property case, so that subclass property accessors can be kept.

^Fix KT-43342.