### PR TITLE
FIR: remap Java meta-annotations to Kotlin equivalents

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
@@ -121,6 +121,11 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
             runTest("compiler/testData/codegen/box/annotations/fileClassWithFileAnnotation.kt");
         }
 
+        @TestMetadata("javaAnnotationOnProperty.kt")
+        public void testJavaAnnotationOnProperty() throws Exception {
+            runTest("compiler/testData/codegen/box/annotations/javaAnnotationOnProperty.kt");
+        }
+
         @TestMetadata("jvmAnnotationFlags.kt")
         public void testJvmAnnotationFlags() throws Exception {
             runTest("compiler/testData/codegen/box/annotations/jvmAnnotationFlags.kt");

--- a/compiler/testData/codegen/box/annotations/javaAnnotationOnProperty.kt
+++ b/compiler/testData/codegen/box/annotations/javaAnnotationOnProperty.kt
@@ -1,0 +1,25 @@
+// WITH_REFLECT
+// TARGET_BACKEND: JVM
+// FILE: Ann1.java
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Ann1 {}
+
+// FILE: Ann2.java
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Ann2 {}
+
+// FILE: box.kt
+class C {
+    @Ann1 @Ann2 val x = 1
+}
+
+fun box(): String {
+    require(C::class.java.getDeclaredField("x")?.getAnnotation(Ann1::class.java) != null) { "no Ann1 on field x" }
+    require(C::class.java.getDeclaredMethod("getX\$annotations")?.getAnnotation(Ann2::class.java) != null) { "no Ann2 on property x" }
+    return "OK"
+}

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -121,6 +121,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             runTest("compiler/testData/codegen/box/annotations/fileClassWithFileAnnotation.kt");
         }
 
+        @TestMetadata("javaAnnotationOnProperty.kt")
+        public void testJavaAnnotationOnProperty() throws Exception {
+            runTest("compiler/testData/codegen/box/annotations/javaAnnotationOnProperty.kt");
+        }
+
         @TestMetadata("jvmAnnotationFlags.kt")
         public void testJvmAnnotationFlags() throws Exception {
             runTest("compiler/testData/codegen/box/annotations/jvmAnnotationFlags.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -121,6 +121,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/annotations/fileClassWithFileAnnotation.kt");
         }
 
+        @TestMetadata("javaAnnotationOnProperty.kt")
+        public void testJavaAnnotationOnProperty() throws Exception {
+            runTest("compiler/testData/codegen/box/annotations/javaAnnotationOnProperty.kt");
+        }
+
         @TestMetadata("jvmAnnotationFlags.kt")
         public void testJvmAnnotationFlags() throws Exception {
             runTest("compiler/testData/codegen/box/annotations/jvmAnnotationFlags.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -121,6 +121,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             runTest("compiler/testData/codegen/box/annotations/fileClassWithFileAnnotation.kt");
         }
 
+        @TestMetadata("javaAnnotationOnProperty.kt")
+        public void testJavaAnnotationOnProperty() throws Exception {
+            runTest("compiler/testData/codegen/box/annotations/javaAnnotationOnProperty.kt");
+        }
+
         @TestMetadata("jvmAnnotationFlags.kt")
         public void testJvmAnnotationFlags() throws Exception {
             runTest("compiler/testData/codegen/box/annotations/jvmAnnotationFlags.kt");


### PR DESCRIPTION
This is a direct port of JavaAnnotationMapper from the old frontend.