### PR TITLE
[JVM] Do not put the name of default lambda parameter in LVT.

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/defaultMethodUtil.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/defaultMethodUtil.kt
@@ -130,7 +130,9 @@ fun <T, R : DefaultLambda> expandMaskConditionsAndUpdateVariableNodes(
         node.instructions.insert(position, newInsn)
     }
 
-    node.localVariables.removeIf { it.start in toDelete && it.end in toDelete }
+    node.localVariables.removeIf {
+        (it.start in toDelete && it.end in toDelete) || defaultLambdas.contains(it.index)
+    }
 
     node.remove(toDelete)
 

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/codegen/ir/FirBlackBoxCodegenTestGenerated.java
@@ -9838,6 +9838,11 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
                 runTest("compiler/testData/codegen/box/defaultArguments/function/covariantOverrideGeneric.kt");
             }
 
+            @TestMetadata("defaultLambdaInline.kt")
+            public void testDefaultLambdaInline() throws Exception {
+                runTest("compiler/testData/codegen/box/defaultArguments/function/defaultLambdaInline.kt");
+            }
+
             @TestMetadata("extensionFunctionManyArgs.kt")
             public void testExtensionFunctionManyArgs() throws Exception {
                 runTest("compiler/testData/codegen/box/defaultArguments/function/extensionFunctionManyArgs.kt");

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/IrTypeMapper.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/IrTypeMapper.kt
@@ -53,6 +53,10 @@ class IrTypeMapper(private val context: JvmBackendContext) : KotlinTypeMapperBas
         }
 
     private fun computeClassInternalName(irClass: IrClass): StringBuilder {
+        context.getLocalClassType(irClass)?.internalName?.let {
+            return StringBuilder(it)
+        }
+
         val shortName = SpecialNames.safeIdentifier(irClass.name).identifier
 
         when (val parent = irClass.parent) {
@@ -71,11 +75,6 @@ class IrTypeMapper(private val context: JvmBackendContext) : KotlinTypeMapperBas
                     return computeClassInternalName(parent.parentAsClass.parentAsClass)
                         .append("$").append(parent.name.asString())
                 }
-        }
-
-        val localClassType = context.getLocalClassType(irClass)
-        if (localClassType != null) {
-            return StringBuilder(localClassType.internalName)
         }
 
         error(

--- a/compiler/testData/codegen/box/coroutines/kt42554.kt
+++ b/compiler/testData/codegen/box/coroutines/kt42554.kt
@@ -1,5 +1,14 @@
 // WITH_RUNTIME
 
+// Need to ignore dexing for now. This generates invalid inner-class attributes on the IR backend.
+//
+// java.lang.AssertionError: D8 dexing error: D8 dexing info: Malformed inner-class attribute:
+//	outerTypeInternal: C$result$1
+//	innerTypeInternal: C$no_name_in_PSI_3d19d79d_1ba9_4cd0_b7f5_b46aa3cd5d40$WhenMappings
+//	innerName: WhenMappings
+//
+// IGNORE_DEXING
+
 import kotlin.coroutines.*
 
 fun launch(block: suspend () -> String): String {

--- a/compiler/testData/codegen/box/coroutines/kt42554.kt
+++ b/compiler/testData/codegen/box/coroutines/kt42554.kt
@@ -1,14 +1,5 @@
 // WITH_RUNTIME
 
-// Need to ignore dexing for now. This generates invalid inner-class attributes on the IR backend.
-//
-// java.lang.AssertionError: D8 dexing error: D8 dexing info: Malformed inner-class attribute:
-//	outerTypeInternal: C$result$1
-//	innerTypeInternal: C$no_name_in_PSI_3d19d79d_1ba9_4cd0_b7f5_b46aa3cd5d40$WhenMappings
-//	innerName: WhenMappings
-//
-// IGNORE_DEXING
-
 import kotlin.coroutines.*
 
 fun launch(block: suspend () -> String): String {

--- a/compiler/testData/codegen/box/defaultArguments/function/defaultLambdaInline.kt
+++ b/compiler/testData/codegen/box/defaultArguments/function/defaultLambdaInline.kt
@@ -1,0 +1,7 @@
+inline fun f(getString: () -> String = { "OK" }) = getString()
+inline fun g() { }
+
+fun box(): String {
+    g()
+    return f()
+}

--- a/compiler/testData/codegen/boxInline/defaultValues/lambdaInlining/genericLambda.kt
+++ b/compiler/testData/codegen/boxInline/defaultValues/lambdaInlining/genericLambda.kt
@@ -1,6 +1,3 @@
-// Enable for dexing once we have a D8 version with a fix for
-// https://issuetracker.google.com/148661132
-// IGNORE_DEXING
 // NO_CHECK_LAMBDA_INLINING
 // FILE: 1.kt
 package test

--- a/compiler/testData/codegen/boxInline/defaultValues/lambdaInlining/simpleGeneric.kt
+++ b/compiler/testData/codegen/boxInline/defaultValues/lambdaInlining/simpleGeneric.kt
@@ -1,6 +1,3 @@
-// Enable for dexing once we have a D8 version with a fix for
-// https://issuetracker.google.com/148661132
-// IGNORE_DEXING
 // FILE: 1.kt
 // SKIP_INLINE_CHECK_IN: inlineFun$default
 package test

--- a/compiler/tests-common/tests/org/jetbrains/kotlin/codegen/D8Checker.java
+++ b/compiler/tests-common/tests/org/jetbrains/kotlin/codegen/D8Checker.java
@@ -40,9 +40,27 @@ public class D8Checker {
         });
     }
 
+    // Compilation with D8 should proceed with no output. There should be no info, warnings, or errors.
+    static class TestDiagnosticsHandler implements DiagnosticsHandler {
+        @Override
+        public void error(Diagnostic diagnostic) {
+            Assert.fail("D8 dexing error: " + diagnostic.getDiagnosticMessage());
+        }
+
+        @Override
+        public void warning(Diagnostic diagnostic) {
+            Assert.fail("D8 dexing warning: " + diagnostic.getDiagnosticMessage());
+        }
+
+        @Override
+        public void info(Diagnostic diagnostic) {
+            Assert.fail("D8 dexing info: " + diagnostic.getDiagnosticMessage());
+        }
+    }
+
     private static void runD8(Consumer<D8Command.Builder> addInput) {
         ProgramConsumer ignoreOutputConsumer = new DexIndexedConsumer.ForwardingConsumer(null);
-        D8Command.Builder builder = D8Command.builder()
+        D8Command.Builder builder = D8Command.builder(new TestDiagnosticsHandler())
                 .setMinApiLevel(28)
                 .setMode(CompilationMode.DEBUG)
                 .setProgramConsumer(ignoreOutputConsumer);

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/BlackBoxCodegenTestGenerated.java
@@ -11238,6 +11238,11 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
                 runTest("compiler/testData/codegen/box/defaultArguments/function/covariantOverrideGeneric.kt");
             }
 
+            @TestMetadata("defaultLambdaInline.kt")
+            public void testDefaultLambdaInline() throws Exception {
+                runTest("compiler/testData/codegen/box/defaultArguments/function/defaultLambdaInline.kt");
+            }
+
             @TestMetadata("extensionFunctionManyArgs.kt")
             public void testExtensionFunctionManyArgs() throws Exception {
                 runTest("compiler/testData/codegen/box/defaultArguments/function/extensionFunctionManyArgs.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -11238,6 +11238,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
                 runTest("compiler/testData/codegen/box/defaultArguments/function/covariantOverrideGeneric.kt");
             }
 
+            @TestMetadata("defaultLambdaInline.kt")
+            public void testDefaultLambdaInline() throws Exception {
+                runTest("compiler/testData/codegen/box/defaultArguments/function/defaultLambdaInline.kt");
+            }
+
             @TestMetadata("extensionFunctionManyArgs.kt")
             public void testExtensionFunctionManyArgs() throws Exception {
                 runTest("compiler/testData/codegen/box/defaultArguments/function/extensionFunctionManyArgs.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/IrBlackBoxCodegenTestGenerated.java
@@ -9838,6 +9838,11 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
                 runTest("compiler/testData/codegen/box/defaultArguments/function/covariantOverrideGeneric.kt");
             }
 
+            @TestMetadata("defaultLambdaInline.kt")
+            public void testDefaultLambdaInline() throws Exception {
+                runTest("compiler/testData/codegen/box/defaultArguments/function/defaultLambdaInline.kt");
+            }
+
             @TestMetadata("extensionFunctionManyArgs.kt")
             public void testExtensionFunctionManyArgs() throws Exception {
                 runTest("compiler/testData/codegen/box/defaultArguments/function/extensionFunctionManyArgs.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
@@ -8348,6 +8348,11 @@ public class IrJsCodegenBoxES6TestGenerated extends AbstractIrJsCodegenBoxES6Tes
                 runTest("compiler/testData/codegen/box/defaultArguments/function/covariantOverrideGeneric.kt");
             }
 
+            @TestMetadata("defaultLambdaInline.kt")
+            public void testDefaultLambdaInline() throws Exception {
+                runTest("compiler/testData/codegen/box/defaultArguments/function/defaultLambdaInline.kt");
+            }
+
             @TestMetadata("extensionFunctionManyArgs.kt")
             public void testExtensionFunctionManyArgs() throws Exception {
                 runTest("compiler/testData/codegen/box/defaultArguments/function/extensionFunctionManyArgs.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -8348,6 +8348,11 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
                 runTest("compiler/testData/codegen/box/defaultArguments/function/covariantOverrideGeneric.kt");
             }
 
+            @TestMetadata("defaultLambdaInline.kt")
+            public void testDefaultLambdaInline() throws Exception {
+                runTest("compiler/testData/codegen/box/defaultArguments/function/defaultLambdaInline.kt");
+            }
+
             @TestMetadata("extensionFunctionManyArgs.kt")
             public void testExtensionFunctionManyArgs() throws Exception {
                 runTest("compiler/testData/codegen/box/defaultArguments/function/extensionFunctionManyArgs.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -8348,6 +8348,11 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
                 runTest("compiler/testData/codegen/box/defaultArguments/function/covariantOverrideGeneric.kt");
             }
 
+            @TestMetadata("defaultLambdaInline.kt")
+            public void testDefaultLambdaInline() throws Exception {
+                runTest("compiler/testData/codegen/box/defaultArguments/function/defaultLambdaInline.kt");
+            }
+
             @TestMetadata("extensionFunctionManyArgs.kt")
             public void testExtensionFunctionManyArgs() throws Exception {
                 runTest("compiler/testData/codegen/box/defaultArguments/function/extensionFunctionManyArgs.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/wasm/semantics/IrCodegenBoxWasmTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/wasm/semantics/IrCodegenBoxWasmTestGenerated.java
@@ -4033,6 +4033,11 @@ public class IrCodegenBoxWasmTestGenerated extends AbstractIrCodegenBoxWasmTest 
                 runTest("compiler/testData/codegen/box/defaultArguments/function/covariantOverrideGeneric.kt");
             }
 
+            @TestMetadata("defaultLambdaInline.kt")
+            public void testDefaultLambdaInline() throws Exception {
+                runTest("compiler/testData/codegen/box/defaultArguments/function/defaultLambdaInline.kt");
+            }
+
             @TestMetadata("extensionFunctionManyArgs.kt")
             public void testExtensionFunctionManyArgs() throws Exception {
                 runTest("compiler/testData/codegen/box/defaultArguments/function/extensionFunctionManyArgs.kt");


### PR DESCRIPTION
If we do, the local variable table will not make sense. As as
example:

```
inline fun foo(getString: () -> String = { "OK" }) {
  println(getString())
}

inline fun bar() {
}

fun main() {
    bar()
    foo()
}
```

leads to the following bytecode:

```
  public static final void main();
    descriptor: ()V
    flags: ACC_PUBLIC, ACC_STATIC, ACC_FINAL
    Code:
      stack=2, locals=4, args_size=0
         0: iconst_0
         1: istore_0
         2: nop
         3: nop
         4: iconst_0
         5: istore_1
         6: nop
         7: ldc           #53                 // String OK
         9: astore_2
        10: iconst_0
        11: istore_3
        12: getstatic     #30                 // Field java/lang/System.out:Ljava/io/PrintStream;
        15: aload_2
        16: invokevirtual #36                 // Method java/io/PrintStream.println:(Ljava/lang/Object;)V
        19: nop
        20: return
      LineNumberTable:
        line 9: 0
        line 13: 2
        line 10: 3
        line 14: 4
        line 15: 6
        line 16: 7
        line 17: 19
        line 11: 20
      LocalVariableTable:
        Start  Length  Slot  Name   Signature
            2       1     0 $i$f$bar   I
            6      14     1 $i$f$foo   I
            4      16     0 getString$iv   Lkotlin/jvm/functions/Function0;
```

The `getString$iv` local should not be there. It has been inlined away.
Leaving it in the local variable table leads to inconsistent locals
info. Local 0 contains an int but we declare a local of type
Function0.

Strengthen the checking that is done with D8 so that we catch issues
like these. Also, mute a test that generates invalid inner class attributes.