### PR TITLE
FIR unused checker: visit qualified accesses in annotations

### DIFF
--- a/compiler/fir/analysis-tests/testData/extendedCheckers/unused/usedInAnnotationArguments.kt
+++ b/compiler/fir/analysis-tests/testData/extendedCheckers/unused/usedInAnnotationArguments.kt
@@ -1,7 +1,7 @@
 annotation class Ann(val value: Int)
 
 fun foo(): Int {
-    val <!UNUSED_VARIABLE!>x<!> = 3
+    val x = 3
     @Ann(<!ANNOTATION_ARGUMENT_MUST_BE_CONST!>x<!>) val y = 5
     return y
 }

--- a/compiler/fir/analysis-tests/testData/extendedCheckers/unused/usedInAnnotationArguments.kt
+++ b/compiler/fir/analysis-tests/testData/extendedCheckers/unused/usedInAnnotationArguments.kt
@@ -1,0 +1,7 @@
+annotation class Ann(val value: Int)
+
+fun foo(): Int {
+    val <!UNUSED_VARIABLE!>x<!> = 3
+    @Ann(<!ANNOTATION_ARGUMENT_MUST_BE_CONST!>x<!>) val y = 5
+    return y
+}

--- a/compiler/fir/analysis-tests/testData/extendedCheckers/unused/usedInAnnotationArguments.txt
+++ b/compiler/fir/analysis-tests/testData/extendedCheckers/unused/usedInAnnotationArguments.txt
@@ -1,0 +1,15 @@
+FILE: usedInAnnotationArguments.kt
+    public final annotation class Ann : R|kotlin/Annotation| {
+        public constructor(value: R|kotlin/Int|): R|Ann| {
+            super<R|kotlin/Any|>()
+        }
+
+        public final val value: R|kotlin/Int| = R|<local>/value|
+            public get(): R|kotlin/Int|
+
+    }
+    public final fun foo(): R|kotlin/Int| {
+        lval x: R|kotlin/Int| = Int(3)
+        @R|Ann|(R|<local>/x|) lval y: R|kotlin/Int| = Int(5)
+        ^foo R|<local>/y|
+    }

--- a/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/fir/ExtendedFirDiagnosticsTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/fir/ExtendedFirDiagnosticsTestGenerated.java
@@ -344,6 +344,11 @@ public class ExtendedFirDiagnosticsTestGenerated extends AbstractExtendedFirDiag
             runTest("compiler/fir/analysis-tests/testData/extendedCheckers/unused/manyLocalVariables.kt");
         }
 
+        @TestMetadata("usedInAnnotationArguments.kt")
+        public void testUsedInAnnotationArguments() throws Exception {
+            runTest("compiler/fir/analysis-tests/testData/extendedCheckers/unused/usedInAnnotationArguments.kt");
+        }
+
         @TestMetadata("valueIsNeverRead.kt")
         public void testValueIsNeverRead() throws Exception {
             runTest("compiler/fir/analysis-tests/testData/extendedCheckers/unused/valueIsNeverRead.kt");

--- a/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/fir/ExtendedFirWithLightTreeDiagnosticsTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/fir/ExtendedFirWithLightTreeDiagnosticsTestGenerated.java
@@ -344,6 +344,11 @@ public class ExtendedFirWithLightTreeDiagnosticsTestGenerated extends AbstractEx
             runTest("compiler/fir/analysis-tests/testData/extendedCheckers/unused/manyLocalVariables.kt");
         }
 
+        @TestMetadata("usedInAnnotationArguments.kt")
+        public void testUsedInAnnotationArguments() throws Exception {
+            runTest("compiler/fir/analysis-tests/testData/extendedCheckers/unused/usedInAnnotationArguments.kt");
+        }
+
         @TestMetadata("valueIsNeverRead.kt")
         public void testValueIsNeverRead() throws Exception {
             runTest("compiler/fir/analysis-tests/testData/extendedCheckers/unused/valueIsNeverRead.kt");


### PR DESCRIPTION
The motivation is [KT-43687](https://youtrack.jetbrains.com/issue/KT-43687) where a variable used as annotation arguments is determined as unused variable. It's simply because unused checker has not considered annotations.