### PR TITLE
FIR unused checker: handle invoke properly

### DIFF
--- a/compiler/fir/analysis-tests/testData/extendedCheckers/unused/invoke.kt
+++ b/compiler/fir/analysis-tests/testData/extendedCheckers/unused/invoke.kt
@@ -1,0 +1,5 @@
+fun foo(): Int {
+    val <!UNUSED_VARIABLE!>x<!> = fun() = 4
+    val <!UNUSED_VARIABLE!>y<!> = fun() = 2
+    return 10 * x() + y()
+}

--- a/compiler/fir/analysis-tests/testData/extendedCheckers/unused/invoke.kt
+++ b/compiler/fir/analysis-tests/testData/extendedCheckers/unused/invoke.kt
@@ -1,5 +1,5 @@
 fun foo(): Int {
-    val <!UNUSED_VARIABLE!>x<!> = fun() = 4
-    val <!UNUSED_VARIABLE!>y<!> = fun() = 2
+    val x = fun() = 4
+    val y = fun() = 2
     return 10 * x() + y()
 }

--- a/compiler/fir/analysis-tests/testData/extendedCheckers/unused/invoke.txt
+++ b/compiler/fir/analysis-tests/testData/extendedCheckers/unused/invoke.txt
@@ -1,0 +1,12 @@
+FILE: invoke.kt
+    public final fun foo(): R|kotlin/Int| {
+        lval x: R|() -> kotlin/Int| = fun <anonymous>(): R|kotlin/Int| {
+            ^ Int(4)
+        }
+
+        lval y: R|() -> kotlin/Int| = fun <anonymous>(): R|kotlin/Int| {
+            ^ Int(2)
+        }
+
+        ^foo Int(10).R|kotlin/Int.times|(R|<local>/x|.R|SubstitutionOverride<kotlin/Function0.invoke: R|kotlin/Int|>|()).R|kotlin/Int.plus|(R|<local>/y|.R|SubstitutionOverride<kotlin/Function0.invoke: R|kotlin/Int|>|())
+    }

--- a/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/fir/ExtendedFirDiagnosticsTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/fir/ExtendedFirDiagnosticsTestGenerated.java
@@ -329,6 +329,11 @@ public class ExtendedFirDiagnosticsTestGenerated extends AbstractExtendedFirDiag
             runTest("compiler/fir/analysis-tests/testData/extendedCheckers/unused/classProperty.kt");
         }
 
+        @TestMetadata("invoke.kt")
+        public void testInvoke() throws Exception {
+            runTest("compiler/fir/analysis-tests/testData/extendedCheckers/unused/invoke.kt");
+        }
+
         @TestMetadata("lambda.kt")
         public void testLambda() throws Exception {
             runTest("compiler/fir/analysis-tests/testData/extendedCheckers/unused/lambda.kt");

--- a/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/fir/ExtendedFirWithLightTreeDiagnosticsTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/fir/ExtendedFirWithLightTreeDiagnosticsTestGenerated.java
@@ -329,6 +329,11 @@ public class ExtendedFirWithLightTreeDiagnosticsTestGenerated extends AbstractEx
             runTest("compiler/fir/analysis-tests/testData/extendedCheckers/unused/classProperty.kt");
         }
 
+        @TestMetadata("invoke.kt")
+        public void testInvoke() throws Exception {
+            runTest("compiler/fir/analysis-tests/testData/extendedCheckers/unused/invoke.kt");
+        }
+
         @TestMetadata("lambda.kt")
         public void testLambda() throws Exception {
             runTest("compiler/fir/analysis-tests/testData/extendedCheckers/unused/lambda.kt");


### PR DESCRIPTION
The motivation is [KT-43688](https://youtrack.jetbrains.com/issue/KT-43688) where local properties that are used via `invoke` are determined as unused variable. It's simply because unused checker has not handled `invoke` properly.