### PR TITLE
Check analysis error before checking compiler args

### DIFF
--- a/compiler/cli/src/org/jetbrains/kotlin/cli/common/messages/AnalyzerWithCompilerReport.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/common/messages/AnalyzerWithCompilerReport.kt
@@ -113,11 +113,13 @@ class AnalyzerWithCompilerReport(
 
     override fun analyzeAndReport(files: Collection<KtFile>, analyze: () -> AnalysisResult) {
         analysisResult = analyze()
-        ExperimentalUsageChecker.checkCompilerArguments(
-            analysisResult.moduleDescriptor, languageVersionSettings,
-            reportError = { message -> messageCollector.report(ERROR, message) },
-            reportWarning = { message -> messageCollector.report(WARNING, message) }
-        )
+        if (!analysisResult.isError()) {
+            ExperimentalUsageChecker.checkCompilerArguments(
+                analysisResult.moduleDescriptor, languageVersionSettings,
+                reportError = { message -> messageCollector.report(ERROR, message) },
+                reportWarning = { message -> messageCollector.report(WARNING, message) }
+            )
+        }
         reportSyntaxErrors(files)
         reportDiagnostics(analysisResult.bindingContext.diagnostics, messageCollector, renderDiagnosticName)
         reportIncompleteHierarchies()


### PR DESCRIPTION
ExperimentalUsageChecker.checkCompilerArguments() will crash if there was an error running analyze().
This checks for the error first so it can be properly reported.