### PR TITLE
KT-43745 Use UNICODE_CASE in String.replace to enable unicode-aware case check

### DIFF
--- a/libraries/stdlib/jvm/src/kotlin/text/StringsJVM.kt
+++ b/libraries/stdlib/jvm/src/kotlin/text/StringsJVM.kt
@@ -78,7 +78,7 @@ public actual fun String.replace(oldChar: Char, newChar: Char, ignoreCase: Boole
 @Suppress("ACTUAL_FUNCTION_WITH_DEFAULT_ARGUMENTS")
 public actual fun String.replace(oldValue: String, newValue: String, ignoreCase: Boolean = false): String {
     if (ignoreCase) {
-        val matcher = Pattern.compile(oldValue, Pattern.LITERAL or Pattern.CASE_INSENSITIVE).matcher(this)
+        val matcher = Pattern.compile(oldValue, Pattern.LITERAL or Pattern.CASE_INSENSITIVE or Pattern.UNICODE_CASE).matcher(this)
         if (!matcher.find()) return this
         val stringBuilder = StringBuilder()
         var i = 0

--- a/libraries/stdlib/test/text/StringTest.kt
+++ b/libraries/stdlib/test/text/StringTest.kt
@@ -896,6 +896,15 @@ class StringTest {
 
         assertEquals("-a-b-b-A-b-", input.replace("", "-"))
         assertEquals("-a-b-b-A-b-", input.replace("", "-", ignoreCase = true))
+
+        assertEquals("Ü", "üÜ".replace("ü", ""))
+        assertEquals("", "üÜ".replace("ü", "", ignoreCase = true))
+
+        assertEquals("Ö", "öÖ".replace("ö", ""))
+        assertEquals("", "öÖ".replace("ö", "", ignoreCase = true))
+
+        assertEquals("Ä", "äÄ".replace("ä", ""))
+        assertEquals("", "äÄ".replace("ä", "", ignoreCase = true))
     }
 
     @Test fun replaceFirst() {


### PR DESCRIPTION
Fixes KT-43745.

New String.replace implementation only works with `US-ASCII` characters. This is not same behaviour as before 1.4.20. It is also not same behaviour as Java. 

This changes add UNICODE_CASE to pattern check to enable unicode-aware case check.

Performance note.
I couldn't find a test to compare performance of new String.replace and old String.replace implementation and I couldn't verify the performance gain announcement in 1.4.20 release. Using UNICODE_CASE might affect the performance as mentioned it java doc of Pattern.UNICODE_CASE