### PR TITLE
Remove wrapper class constructors

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/intrinsics/TypeIntrinsics.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/intrinsics/TypeIntrinsics.kt
@@ -71,7 +71,7 @@ object TypeIntrinsics {
                 IntInsnNode(Opcodes.SIPUSH, value)
             }
             else {
-                LdcInsnNode(Integer(value))
+                LdcInsnNode(Integer.valueOf(value))
             }
 
     @JvmStatic fun instanceOf(instanceofInsn: TypeInsnNode, instructions: InsnList, jetType: KotlinType, asmType: Type) {

--- a/compiler/tests/org/jetbrains/kotlin/codegen/PackageGenTest.java
+++ b/compiler/tests/org/jetbrains/kotlin/codegen/PackageGenTest.java
@@ -45,14 +45,14 @@ public class PackageGenTest extends CodegenTestCase {
         loadText("fun f() : Int { return 42; }");
         Method main = generateFunction();
         Object returnValue = main.invoke(null);
-        assertEquals(new Integer(42), returnValue);
+        assertEquals(Integer.valueOf(42), returnValue);
     }
 
     public void testReturnA() throws Exception {
         loadText("fun foo(a : Int) = a");
         Method main = generateFunction();
         Object returnValue = main.invoke(null, 50);
-        assertEquals(new Integer(50), returnValue);
+        assertEquals(Integer.valueOf(50), returnValue);
     }
 
     public void testCurrentTime() throws Exception {

--- a/libraries/stdlib/jvm/src/kotlin/coroutines/jvm/internal/boxing.kt
+++ b/libraries/stdlib/jvm/src/kotlin/coroutines/jvm/internal/boxing.kt
@@ -25,24 +25,24 @@ internal fun boxByte(primitive: Byte): java.lang.Byte = java.lang.Byte.valueOf(p
 
 @SinceKotlin("1.3")
 @PublishedApi
-internal fun boxShort(primitive: Short): java.lang.Short = java.lang.Short(primitive)
+internal fun boxShort(primitive: Short): java.lang.Short = java.lang.Short.valueOf(primitive) as java.lang.Short
 
 @SinceKotlin("1.3")
 @PublishedApi
-internal fun boxInt(primitive: Int): java.lang.Integer = java.lang.Integer(primitive)
+internal fun boxInt(primitive: Int): java.lang.Integer = java.lang.Integer.valueOf(primitive) as java.lang.Integer
 
 @SinceKotlin("1.3")
 @PublishedApi
-internal fun boxLong(primitive: Long): java.lang.Long = java.lang.Long(primitive)
+internal fun boxLong(primitive: Long): java.lang.Long = java.lang.Long.valueOf(primitive) as java.lang.Long
 
 @SinceKotlin("1.3")
 @PublishedApi
-internal fun boxFloat(primitive: Float): java.lang.Float = java.lang.Float(primitive)
+internal fun boxFloat(primitive: Float): java.lang.Float = java.lang.Float.valueOf(primitive) as java.lang.Float
 
 @SinceKotlin("1.3")
 @PublishedApi
-internal fun boxDouble(primitive: Double): java.lang.Double = java.lang.Double(primitive)
+internal fun boxDouble(primitive: Double): java.lang.Double = java.lang.Double.valueOf(primitive) as java.lang.Double
 
 @SinceKotlin("1.3")
 @PublishedApi
-internal fun boxChar(primitive: Char): java.lang.Character = java.lang.Character(primitive)
+internal fun boxChar(primitive: Char): java.lang.Character = java.lang.Character.valueOf(primitive) as java.lang.Character


### PR DESCRIPTION
As per [JEP-390](https://openjdk.java.net/jeps/390), wrapper class constructors which have been deprecated since java 9, will now be marked deprecated for removal.

This will be interesting going forward, as this could mean older library might break when being run on a newer jdk.