### PR TITLE
Improve error parsing

### DIFF
--- a/compiler/psi/src/org/jetbrains/kotlin/parsing/KotlinExpressionParsing.java
+++ b/compiler/psi/src/org/jetbrains/kotlin/parsing/KotlinExpressionParsing.java
@@ -1841,8 +1841,17 @@ public class KotlinExpressionParsing extends AbstractKotlinParsing {
                 while (true) {
                     while (at(COMMA)) errorAndAdvance("Expecting an argument");
                     parseValueArgument();
-                    if (at(COLON) && lookahead(1) == IDENTIFIER) {
-                        errorAndAdvance("Unexpected type specification", 2);
+                    if (at(COLON) && (lookahead(1) == IDENTIFIER || lookahead(1) == LPAR)) {
+                        PsiBuilder.Marker type = mark();
+                        advance(); // COLON
+                        myKotlinParsing.parseTypeRef();
+                        int end = myBuilder.rawTokenIndex();
+                        type.rollbackTo();
+                        PsiBuilder.Marker err = mark();
+                        while (myBuilder.rawTokenIndex() < end) {
+                            advance();
+                        }
+                        err.error("Unexpected type specification");
                     }
                     if (!at(COMMA)) {
                         if (atSet(EXPRESSION_FIRST)) {

--- a/compiler/psi/src/org/jetbrains/kotlin/parsing/KotlinExpressionParsing.java
+++ b/compiler/psi/src/org/jetbrains/kotlin/parsing/KotlinExpressionParsing.java
@@ -1493,6 +1493,11 @@ public class KotlinExpressionParsing extends AbstractKotlinParsing {
                 error("Expecting a variable name");
             }
 
+            TokenSet recoverySet = TokenSet.create(RPAR, LBRACE, RBRACE, EOL_OR_SEMICOLON, EOF);
+            if (!atSet(recoverySet)) {
+                errorUntil("Unexpected tokens in loop", recoverySet);
+            }
+
             expectNoAdvance(RPAR, "Expecting ')'");
             myBuilder.restoreNewlinesState();
         }

--- a/compiler/testData/diagnostics/tests/incompleteCode/checkNothingIsSubtype.fir.kt
+++ b/compiler/testData/diagnostics/tests/incompleteCode/checkNothingIsSubtype.fir.kt
@@ -11,6 +11,6 @@ fun test(nothing: Nothing?) {
 }
 
 fun sum(a : IntArray) : Int {
-<!UNRESOLVED_REFERENCE, UNRESOLVED_REFERENCE, UNRESOLVED_REFERENCE!>for (n
-<!SYNTAX!>return<!><!SYNTAX!><!> "?"<!>
-}
+for (n
+<!SYNTAX!>return<!> <!SYNTAX!>"?"<!><!SYNTAX!><!>
+<!SYNTAX!><!>}

--- a/compiler/testData/diagnostics/tests/incompleteCode/checkNothingIsSubtype.kt
+++ b/compiler/testData/diagnostics/tests/incompleteCode/checkNothingIsSubtype.kt
@@ -12,5 +12,5 @@ fun test(nothing: Nothing?) {
 
 fun sum(<!UNUSED_PARAMETER!>a<!> : IntArray) : Int {
 for (n
-<!SYNTAX!>return<!><!SYNTAX!><!> "?"
-<!NO_RETURN_IN_FUNCTION_WITH_BLOCK_BODY!>}<!>
+<!SYNTAX!>return<!><!OI;SYNTAX!><!> <!NI;SYNTAX!>"?"<!><!NI;SYNTAX!><!>
+<!OI;NO_RETURN_IN_FUNCTION_WITH_BLOCK_BODY!><!NI;SYNTAX!><!>}<!>

--- a/compiler/testData/psi/TripleDot.txt
+++ b/compiler/testData/psi/TripleDot.txt
@@ -29,22 +29,16 @@ KtFile: TripleDot.kt
         LOOP_RANGE
           INTEGER_CONSTANT
             PsiElement(INTEGER_LITERAL)('1')
-        PsiErrorElement:Expecting ')'
-          <empty list>
-        BODY
-          <empty list>
-      PsiErrorElement:Unexpected tokens (use ';' to separate expressions on the same line)
-        PsiElement(RESERVED)('...')
-        PsiElement(INTEGER_LITERAL)('2')
+        PsiErrorElement:Unexpected tokens in loop
+          PsiElement(RESERVED)('...')
+          PsiElement(INTEGER_LITERAL)('2')
         PsiElement(RPAR)(')')
-      PsiWhiteSpace(' ')
-      LAMBDA_EXPRESSION
-        FUNCTION_LITERAL
-          PsiElement(LBRACE)('{')
-          PsiWhiteSpace('\n\n    ')
+        PsiWhiteSpace(' ')
+        BODY
           BLOCK
-            <empty list>
-          PsiElement(RBRACE)('}')
+            PsiElement(LBRACE)('{')
+            PsiWhiteSpace('\n\n    ')
+            PsiElement(RBRACE)('}')
       PsiWhiteSpace('\n\n    ')
       FOR
         PsiElement(for)('for')

--- a/compiler/testData/psi/annotation/functionalTypes/regressionForSimilarSyntax/forDestructuring.txt
+++ b/compiler/testData/psi/annotation/functionalTypes/regressionForSimilarSyntax/forDestructuring.txt
@@ -53,48 +53,51 @@ KtFile: forDestructuring.kt
             PsiElement(LBRACE)('{')
             PsiElement(RBRACE)('}')
       PsiWhiteSpace('\n    ')
-      FOR
-        PsiElement(for)('for')
-        PsiWhiteSpace(' ')
-        PsiElement(LPAR)('(')
-        VALUE_PARAMETER
-          MODIFIER_LIST
-            ANNOTATION_ENTRY
-              PsiElement(AT)('@')
-              CONSTRUCTOR_CALLEE
-                TYPE_REFERENCE
-                  USER_TYPE
-                    REFERENCE_EXPRESSION
-                      PsiElement(IDENTIFIER)('Foo')
-              PsiWhiteSpace(' ')
-              VALUE_ARGUMENT_LIST
-                PsiElement(LPAR)('(')
-                VALUE_ARGUMENT
-                  REFERENCE_EXPRESSION
-                    PsiElement(IDENTIFIER)('i')
-                PsiErrorElement:Expecting ')'
-                  PsiElement(COLON)(':')
+      BINARY_EXPRESSION
+        FOR
+          PsiElement(for)('for')
           PsiWhiteSpace(' ')
-          DESTRUCTURING_DECLARATION
-            PsiElement(LPAR)('(')
-            PsiErrorElement:Expecting a name
-              <empty list>
-            PsiElement(RPAR)(')')
-        PsiWhiteSpace(' ')
-        PsiErrorElement:Expecting 'in'
-          PsiElement(ARROW)('->')
-        PsiErrorElement:Expecting ')'
-          <empty list>
-        PsiWhiteSpace(' ')
-        BODY
-          REFERENCE_EXPRESSION
+          PsiElement(LPAR)('(')
+          VALUE_PARAMETER
+            MODIFIER_LIST
+              ANNOTATION_ENTRY
+                PsiElement(AT)('@')
+                CONSTRUCTOR_CALLEE
+                  TYPE_REFERENCE
+                    USER_TYPE
+                      REFERENCE_EXPRESSION
+                        PsiElement(IDENTIFIER)('Foo')
+                PsiWhiteSpace(' ')
+                VALUE_ARGUMENT_LIST
+                  PsiElement(LPAR)('(')
+                  VALUE_ARGUMENT
+                    REFERENCE_EXPRESSION
+                      PsiElement(IDENTIFIER)('i')
+                  PsiErrorElement:Expecting ')'
+                    PsiElement(COLON)(':')
+            PsiWhiteSpace(' ')
+            DESTRUCTURING_DECLARATION
+              PsiElement(LPAR)('(')
+              PsiErrorElement:Expecting a name
+                <empty list>
+              PsiElement(RPAR)(')')
+          PsiWhiteSpace(' ')
+          PsiErrorElement:Expecting 'in'
+            PsiElement(ARROW)('->')
+          PsiWhiteSpace(' ')
+          PsiErrorElement:Unexpected tokens in loop
             PsiElement(IDENTIFIER)('Unit')
+          PsiElement(RPAR)(')')
+          PsiWhiteSpace(' ')
+          BODY
+            PsiErrorElement:Expecting an expression
+              <empty list>
+        OPERATION_REFERENCE
+          PsiElement(in)('in')
+        PsiWhiteSpace(' ')
+        REFERENCE_EXPRESSION
+          PsiElement(IDENTIFIER)('y')
       PsiErrorElement:Unexpected tokens (use ';' to separate expressions on the same line)
-        PsiElement(RPAR)(')')
-        PsiWhiteSpace(' ')
-        PsiElement(in)('in')
-        PsiWhiteSpace(' ')
-        PsiElement(IDENTIFIER)('y')
         PsiElement(RPAR)(')')
       PsiWhiteSpace(' ')
       LAMBDA_EXPRESSION

--- a/compiler/testData/psi/annotation/functionalTypes/regressionForSimilarSyntax/forDestructuring.txt
+++ b/compiler/testData/psi/annotation/functionalTypes/regressionForSimilarSyntax/forDestructuring.txt
@@ -53,59 +53,47 @@ KtFile: forDestructuring.kt
             PsiElement(LBRACE)('{')
             PsiElement(RBRACE)('}')
       PsiWhiteSpace('\n    ')
-      BINARY_EXPRESSION
-        FOR
-          PsiElement(for)('for')
-          PsiWhiteSpace(' ')
-          PsiElement(LPAR)('(')
-          VALUE_PARAMETER
-            MODIFIER_LIST
-              ANNOTATION_ENTRY
-                PsiElement(AT)('@')
-                CONSTRUCTOR_CALLEE
-                  TYPE_REFERENCE
-                    USER_TYPE
-                      REFERENCE_EXPRESSION
-                        PsiElement(IDENTIFIER)('Foo')
-                PsiWhiteSpace(' ')
-                VALUE_ARGUMENT_LIST
-                  PsiElement(LPAR)('(')
-                  VALUE_ARGUMENT
-                    REFERENCE_EXPRESSION
-                      PsiElement(IDENTIFIER)('i')
-                  PsiErrorElement:Expecting ')'
-                    PsiElement(COLON)(':')
-            PsiWhiteSpace(' ')
-            DESTRUCTURING_DECLARATION
-              PsiElement(LPAR)('(')
-              PsiErrorElement:Expecting a name
-                <empty list>
-              PsiElement(RPAR)(')')
-          PsiWhiteSpace(' ')
-          PsiErrorElement:Expecting 'in'
-            PsiElement(ARROW)('->')
-          PsiWhiteSpace(' ')
-          PsiErrorElement:Unexpected tokens in loop
-            PsiElement(IDENTIFIER)('Unit')
-          PsiElement(RPAR)(')')
-          PsiWhiteSpace(' ')
-          BODY
-            PsiErrorElement:Expecting an expression
-              <empty list>
-        OPERATION_REFERENCE
-          PsiElement(in)('in')
+      FOR
+        PsiElement(for)('for')
         PsiWhiteSpace(' ')
-        REFERENCE_EXPRESSION
+        PsiElement(LPAR)('(')
+        VALUE_PARAMETER
+          MODIFIER_LIST
+            ANNOTATION_ENTRY
+              PsiElement(AT)('@')
+              CONSTRUCTOR_CALLEE
+                TYPE_REFERENCE
+                  USER_TYPE
+                    REFERENCE_EXPRESSION
+                      PsiElement(IDENTIFIER)('Foo')
+              PsiWhiteSpace(' ')
+              VALUE_ARGUMENT_LIST
+                PsiElement(LPAR)('(')
+                VALUE_ARGUMENT
+                  REFERENCE_EXPRESSION
+                    PsiElement(IDENTIFIER)('i')
+                PsiErrorElement:Unexpected type specification
+                  PsiElement(COLON)(':')
+                  PsiWhiteSpace(' ')
+                  PsiElement(LPAR)('(')
+                  PsiElement(RPAR)(')')
+                  PsiWhiteSpace(' ')
+                  PsiElement(ARROW)('->')
+                  PsiWhiteSpace(' ')
+                  PsiElement(IDENTIFIER)('Unit')
+                PsiElement(RPAR)(')')
+            PsiWhiteSpace(' ')
+            PsiElement(in)('in')
+          PsiWhiteSpace(' ')
           PsiElement(IDENTIFIER)('y')
-      PsiErrorElement:Unexpected tokens (use ';' to separate expressions on the same line)
+        PsiErrorElement:Expecting 'in'
+          <empty list>
         PsiElement(RPAR)(')')
-      PsiWhiteSpace(' ')
-      LAMBDA_EXPRESSION
-        FUNCTION_LITERAL
-          PsiElement(LBRACE)('{')
+        PsiWhiteSpace(' ')
+        BODY
           BLOCK
-            <empty list>
-          PsiElement(RBRACE)('}')
+            PsiElement(LBRACE)('{')
+            PsiElement(RBRACE)('}')
       PsiWhiteSpace('\n    ')
       FOR
         PsiElement(for)('for')

--- a/compiler/testData/psi/annotation/functionalTypes/regressionForSimilarSyntax/lambdaParameterDeclaration.txt
+++ b/compiler/testData/psi/annotation/functionalTypes/regressionForSimilarSyntax/lambdaParameterDeclaration.txt
@@ -86,16 +86,18 @@ KtFile: lambdaParameterDeclaration.kt
                       PsiElement(COLON)(':')
                       PsiWhiteSpace(' ')
                       PsiElement(IDENTIFIER)('kotlin')
-                    PsiErrorElement:Expecting ')'
                       PsiElement(DOT)('.')
-                REFERENCE_EXPRESSION
-                  PsiElement(IDENTIFIER)('Any')
+                      PsiElement(IDENTIFIER)('Any')
+                    PsiElement(COMMA)(',')
+                    PsiWhiteSpace(' ')
+                    VALUE_ARGUMENT
+                      REFERENCE_EXPRESSION
+                        PsiElement(IDENTIFIER)('bar')
+                    PsiElement(RPAR)(')')
+                PsiErrorElement:Expecting an element
+                  <empty list>
+              PsiWhiteSpace(' ')
               PsiErrorElement:Unexpected tokens (use ';' to separate expressions on the same line)
-                PsiElement(COMMA)(',')
-                PsiWhiteSpace(' ')
-                PsiElement(IDENTIFIER)('bar')
-                PsiElement(RPAR)(')')
-                PsiWhiteSpace(' ')
                 PsiElement(ARROW)('->')
             PsiWhiteSpace(' ')
             PsiElement(RBRACE)('}')

--- a/compiler/testData/psi/annotation/functionalTypes/regressionForSimilarSyntax/variableDestructuring.txt
+++ b/compiler/testData/psi/annotation/functionalTypes/regressionForSimilarSyntax/variableDestructuring.txt
@@ -54,7 +54,7 @@ KtFile: variableDestructuring.kt
                 PsiElement(INTEGER_LITERAL)('2')
             PsiElement(RPAR)(')')
       PsiWhiteSpace('\n    ')
-      DESTRUCTURING_DECLARATION
+      PROPERTY
         PsiElement(var)('var')
         PsiWhiteSpace(' ')
         PsiErrorElement:Annotations are not allowed in this position
@@ -71,29 +71,35 @@ KtFile: variableDestructuring.kt
               VALUE_ARGUMENT
                 REFERENCE_EXPRESSION
                   PsiElement(IDENTIFIER)('i')
-              PsiErrorElement:Expecting ')'
+              PsiErrorElement:Unexpected type specification
                 PsiElement(COLON)(':')
-        PsiWhiteSpace(' ')
-        PsiElement(LPAR)('(')
-        PsiErrorElement:Expecting a name
+                PsiWhiteSpace(' ')
+                PsiElement(LPAR)('(')
+                PsiElement(RPAR)(')')
+                PsiWhiteSpace(' ')
+                PsiElement(ARROW)('->')
+                PsiWhiteSpace(' ')
+                PsiElement(IDENTIFIER)('Unit')
+              PsiElement(RPAR)(')')
+        PsiErrorElement:Expecting property name or receiver type
           <empty list>
-        PsiElement(RPAR)(')')
-      PsiWhiteSpace(' ')
-      PsiErrorElement:Unexpected tokens (use ';' to separate expressions on the same line)
-        PsiElement(ARROW)('->')
-        PsiWhiteSpace(' ')
-        PsiElement(IDENTIFIER)('Unit')
-        PsiElement(RPAR)(')')
         PsiWhiteSpace(' ')
         PsiElement(EQ)('=')
         PsiWhiteSpace(' ')
-        PsiElement(IDENTIFIER)('Pair')
-        PsiElement(LPAR)('(')
-        PsiElement(INTEGER_LITERAL)('1')
-        PsiElement(COMMA)(',')
-        PsiWhiteSpace(' ')
-        PsiElement(INTEGER_LITERAL)('2')
-        PsiElement(RPAR)(')')
+        CALL_EXPRESSION
+          REFERENCE_EXPRESSION
+            PsiElement(IDENTIFIER)('Pair')
+          VALUE_ARGUMENT_LIST
+            PsiElement(LPAR)('(')
+            VALUE_ARGUMENT
+              INTEGER_CONSTANT
+                PsiElement(INTEGER_LITERAL)('1')
+            PsiElement(COMMA)(',')
+            PsiWhiteSpace(' ')
+            VALUE_ARGUMENT
+              INTEGER_CONSTANT
+                PsiElement(INTEGER_LITERAL)('2')
+            PsiElement(RPAR)(')')
       PsiWhiteSpace('\n    ')
       PROPERTY
         PsiElement(var)('var')


### PR DESCRIPTION
Motivation to create this pull request was fact that syntax errors can lead to weird semantic errors. I made some changes in parser to make this situations less frequent.

1. **Change for-expression parsing**
In the case when error occurred in "for" declaration it starts to parse loop body right after error token although usually next tokens are also error and they are not body. As a result there can be messages about non-existent semantic errors. E.g.:
`for (i in 1...3) {break;}`
Here among messages we can see _"'break' and 'continue' are only allowed inside a loop"_ despite of "break" being in loop body. 
Or if "in" is absent:
`for (i 1..3){}`
We get a message _"For is not an expression, and only expressions are allowed here"_ that is pretty unexpected and not very clear.
So i made some changes and now, if there is some error in "for" declaration, body will not be parsed until right parenthesis or braces appears. It allows to avoid messages like above.

2. **Type parsing in value argument list**
In value argument parsing there is already a case when the type for it is specified but only if it's simply type consisted from one token. E.g. 
`foo(a:Int) // error: Unexpected type specification`
But if the type is more complex:
`foo(a:kotlin.Any)`
we get much more error messages and there is _"Unresolved reference: Any"_ among them. Besides it makes parsing worse when value argument list is inside more complex constructions, e.g. annotations.
So i also added parsing for more complex types in this case.