### PR TITLE
Ant: Add support for fork-mode

### DIFF
--- a/ant/src/org/jetbrains/kotlin/ant/Kotlin2JvmTask.kt
+++ b/ant/src/org/jetbrains/kotlin/ant/Kotlin2JvmTask.kt
@@ -16,9 +16,12 @@
 
 package org.jetbrains.kotlin.ant
 
-import org.apache.tools.ant.types.Path
-import org.apache.tools.ant.types.Reference
+import org.apache.tools.ant.BuildException
+import org.apache.tools.ant.taskdefs.Execute
+import org.apache.tools.ant.taskdefs.Redirector
+import org.apache.tools.ant.types.*
 import java.io.File.pathSeparator
+import java.io.File.separator
 
 class Kotlin2JvmTask : KotlinCompilerBaseTask() {
     override val compilerFqName = "org.jetbrains.kotlin.cli.jvm.K2JVMCompiler"
@@ -27,6 +30,9 @@ class Kotlin2JvmTask : KotlinCompilerBaseTask() {
     var moduleName: String? = null
 
     var noReflect: Boolean = false
+
+    private val cmdl = CommandlineJava()
+    var fork: Boolean = false
 
     private var compileClasspath: Path? = null
 
@@ -72,5 +78,48 @@ class Kotlin2JvmTask : KotlinCompilerBaseTask() {
         if (noStdlib) args.add("-no-stdlib")
         if (noReflect) args.add("-no-reflect")
         if (includeRuntime) args.add("-include-runtime")
+    }
+
+    override fun execute() {
+        if (!fork)
+            super.execute()
+        else {
+            exec()
+        }
+    }
+
+    private fun exec() {
+        val javaHome = System.getProperty("java.home")
+        val javaBin = javaHome + separator + "bin" + separator + "java"
+        val redirector = Redirector(this)
+
+        fillArguments()
+
+        val command = ArrayList<String>()
+        command.add(javaBin)
+        command.addAll(cmdl.vmCommand.arguments) // jvm args
+        command.add("-Dorg.jetbrains.kotlin.cliMessageRenderer=FullPath") // same MessageRenderer as non-forking mode
+        command.add("-cp")
+        command.add(KotlinAntTaskUtil.compilerJar.canonicalPath)
+        command.add(compilerFqName)
+        command.addAll(args) // compiler args
+
+        // streamHandler: used to handle the input and output streams of the subprocess.
+        // watchdog: a watchdog for the subprocess or <code>null</code> to disable a timeout for the subprocess.
+        // TODO: support timeout for the subprocess
+        val exe = Execute(redirector.createHandler(), null)
+        exe.setAntRun(getProject())
+        exe.commandline = command.toTypedArray()
+        log("Executing command: ${command.joinToString(" ")}", LogLevel.DEBUG.level)
+        log("Compiling ${src!!.list().toList()} => [${output!!.canonicalPath}]")
+        val exitCode = exe.execute()
+        redirector.complete()
+        if (failOnError && exitCode != 0) {
+            throw BuildException("Compile failed; see the compiler error output for details.")
+        }
+    }
+
+    fun createJvmarg(): Commandline.Argument {
+        return cmdl.createVmArgument()
     }
 }

--- a/ant/src/org/jetbrains/kotlin/ant/KotlinCompilerBaseTask.kt
+++ b/ant/src/org/jetbrains/kotlin/ant/KotlinCompilerBaseTask.kt
@@ -80,7 +80,7 @@ abstract class KotlinCompilerBaseTask : Task() {
         fillSpecificArguments()
     }
 
-    final override fun execute() {
+    override fun execute() {
         fillArguments()
 
         val compilerClass = KotlinAntTaskUtil.getOrCreateClassLoader().loadClass(compilerFqName)

--- a/compiler/testData/integration/ant/jvm/fork/build.log.expected
+++ b/compiler/testData/integration/ant/jvm/fork/build.log.expected
@@ -1,0 +1,16 @@
+OUT:
+Buildfile: [TestData]/build.xml
+
+premain:
+    [javac] Compiling 1 source file to [Temp]
+      [jar] Building jar: [Temp]/premain.jar
+
+build:
+  [kotlinc] Compiling [[TestData]] => [[Temp]/fork.jar]
+  [kotlinc] -Xms64m
+  [kotlinc] -Xmx128m
+
+BUILD SUCCESSFUL
+Total time: [time]
+
+Return code: 0

--- a/compiler/testData/integration/ant/jvm/fork/build.xml
+++ b/compiler/testData/integration/ant/jvm/fork/build.xml
@@ -1,0 +1,25 @@
+<project name="Ant Task Test" default="build">
+    <taskdef resource="org/jetbrains/kotlin/ant/antlib.xml" classpath="${kotlin.lib}/kotlin-ant.jar"/>
+
+    <target name="premain">
+        <sequential>
+            <javac srcdir="${test.data}/premain" destdir="${temp}" includeAntRuntime="false"/>
+            <jar destfile="${temp}/premain.jar"
+                 basedir="${temp}"
+                 excludes="*.java *.jar">
+                <manifest>
+                    <attribute name="Premain-Class" value="Premain"/>
+                </manifest>
+            </jar>
+        </sequential>
+    </target>
+
+    <target name="build" depends="premain">
+        <kotlinc src="${test.data}" output="${temp}/fork.jar" fork="true">
+            <jvmarg value="-Xms64m"/>
+            <jvmarg value="-Xmx128m"/>
+            <jvmarg value="-javaagent:${temp}/premain.jar"/>
+            <compilerarg value="-nowarn"/>
+        </kotlinc>
+    </target>
+</project>

--- a/compiler/testData/integration/ant/jvm/fork/hello.kt
+++ b/compiler/testData/integration/ant/jvm/fork/hello.kt
@@ -1,0 +1,5 @@
+package hello
+
+fun main() {
+    println(0 as String)
+}

--- a/compiler/testData/integration/ant/jvm/fork/premain/Premain.java
+++ b/compiler/testData/integration/ant/jvm/fork/premain/Premain.java
@@ -1,0 +1,14 @@
+import java.lang.instrument.Instrumentation;
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+import java.util.List;
+
+public class Premain {
+    public static void premain(String agentArgs, Instrumentation inst) {
+        RuntimeMXBean bean = ManagementFactory.getRuntimeMXBean();
+        List<String> arguments = bean.getInputArguments();
+        arguments.stream().filter(param ->
+            param.startsWith("-Xmx") || param.startsWith("-Xms")
+        ).sorted().forEach(System.out::println);
+    }
+}

--- a/compiler/testData/integration/ant/jvm/forkOnError/build.log.expected
+++ b/compiler/testData/integration/ant/jvm/forkOnError/build.log.expected
@@ -1,0 +1,24 @@
+OUT:
+Buildfile: [TestData]/build.xml
+
+premain:
+    [javac] Compiling 1 source file to [Temp]
+      [jar] Building jar: [Temp]/premain.jar
+
+build:
+  [kotlinc] Compiling [[TestData]] => [[Temp]/fork.jar]
+  [kotlinc] -Xms64m
+  [kotlinc] -Xmx128m
+  [kotlinc] error: warnings found and -Werror specified
+  [kotlinc] [TestData]/test.kt:4:15: warning: this cast can never succeed
+  [kotlinc]     println(0 as String)
+  [kotlinc]               ^
+
+ERR:
+
+BUILD FAILED
+[TestData]/build.xml:18: Compile failed; see the compiler error output for details.
+
+Total time: [time]
+
+Return code: 1

--- a/compiler/testData/integration/ant/jvm/forkOnError/build.xml
+++ b/compiler/testData/integration/ant/jvm/forkOnError/build.xml
@@ -1,0 +1,25 @@
+<project name="Ant Task Test" default="build">
+    <taskdef resource="org/jetbrains/kotlin/ant/antlib.xml" classpath="${kotlin.lib}/kotlin-ant.jar"/>
+
+    <target name="premain">
+        <sequential>
+            <javac srcdir="${test.data}/premain" destdir="${temp}" includeAntRuntime="false"/>
+            <jar destfile="${temp}/premain.jar"
+                 basedir="${temp}"
+                 excludes="*.java *.jar">
+                <manifest>
+                    <attribute name="Premain-Class" value="Premain"/>
+                </manifest>
+            </jar>
+        </sequential>
+    </target>
+
+    <target name="build" depends="premain">
+        <kotlinc src="${test.data}" output="${temp}/fork.jar" fork="true">
+            <jvmarg value="-Xms64m"/>
+            <jvmarg value="-Xmx128m"/>
+            <jvmarg value="-javaagent:${temp}/premain.jar"/>
+            <compilerarg value="-Werror"/>
+        </kotlinc>
+    </target>
+</project>

--- a/compiler/testData/integration/ant/jvm/forkOnError/premain/Premain.java
+++ b/compiler/testData/integration/ant/jvm/forkOnError/premain/Premain.java
@@ -1,0 +1,14 @@
+import java.lang.instrument.Instrumentation;
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+import java.util.List;
+
+public class Premain {
+    public static void premain(String agentArgs, Instrumentation inst) {
+        RuntimeMXBean bean = ManagementFactory.getRuntimeMXBean();
+        List<String> arguments = bean.getInputArguments();
+        arguments.stream().filter(param ->
+            param.startsWith("-Xmx") || param.startsWith("-Xms")
+        ).sorted().forEach(System.out::println);
+    }
+}

--- a/compiler/testData/integration/ant/jvm/forkOnError/test.kt
+++ b/compiler/testData/integration/ant/jvm/forkOnError/test.kt
@@ -1,0 +1,5 @@
+package hello
+
+fun main() {
+    println(0 as String)
+}

--- a/compiler/tests-gen/org/jetbrains/kotlin/integration/AntTaskTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/integration/AntTaskTestGenerated.java
@@ -44,6 +44,16 @@ public class AntTaskTestGenerated extends AbstractAntTaskTest {
         runTest("compiler/testData/integration/ant/jvm/failOnErrorByDefault/");
     }
 
+    @TestMetadata("fork")
+    public void testFork() throws Exception {
+        runTest("compiler/testData/integration/ant/jvm/fork/");
+    }
+
+    @TestMetadata("forkOnError")
+    public void testForkOnError() throws Exception {
+        runTest("compiler/testData/integration/ant/jvm/forkOnError/");
+    }
+
     @TestMetadata("helloWorld")
     public void testHelloWorld() throws Exception {
         runTest("compiler/testData/integration/ant/jvm/helloWorld/");


### PR DESCRIPTION
Without support for fork-mode, a OOM error can be produced like below.  Since tasks ```java``` and ```javac``` both support fork-mode in Ant, it is better to have a fork-mode supported by the task ```kotlinc``` I think.
```
D:\Github-scaventz\lwjgl3\build.xml:204: java.lang.OutOfMemoryError: Java heap space
	at org.apache.tools.ant.dispatch.DispatchUtils.execute(DispatchUtils.java:109)
	at org.apache.tools.ant.Task.perform(Task.java:350)
	at org.apache.tools.ant.Target.execute(Target.java:449)
	at org.apache.tools.ant.Target.performTasks(Target.java:470)
	at org.apache.tools.ant.Project.executeSortedTargets(Project.java:1388)
	at org.apache.tools.ant.Project.executeTarget(Project.java:1361)
	at org.apache.tools.ant.helper.DefaultExecutor.executeTargets(DefaultExecutor.java:41)
	at org.apache.tools.ant.Project.executeTargets(Project.java:1251)
	at org.apache.tools.ant.Main.runBuild(Main.java:834)
	at org.apache.tools.ant.Main.startAnt(Main.java:223)
	at org.apache.tools.ant.Main.start(Main.java:190)
	at org.apache.tools.ant.Main.main(Main.java:274)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.intellij.rt.ant.execution.AntMain2.main(AntMain2.java:31)
Caused by: java.lang.OutOfMemoryError: Java heap space
	at java.util.Arrays.copyOf(Arrays.java:3236)
	at java.io.ByteArrayOutputStream.toByteArray(ByteArrayOutputStream.java:191)
	at org.jetbrains.kotlin.preloading.ClassPreloadingUtils.loadAllClassesFromJars(ClassPreloadingUtils.java:146)
	at org.jetbrains.kotlin.preloading.ClassPreloadingUtils.preloadClasses(ClassPreloadingUtils.java:49)
	at org.jetbrains.kotlin.preloading.ClassPreloadingUtils.preloadClasses(ClassPreloadingUtils.java:70)
	at org.jetbrains.kotlin.ant.KotlinAntTaskUtil.getOrCreateClassLoader(KotlinAntTaskUtil.kt:60)
	at org.jetbrains.kotlin.ant.KotlinCompilerBaseTask.execute(KotlinCompilerBaseTask.kt:117)
	at org.jetbrains.kotlin.ant.Kotlin2JvmTask.execute(Kotlin2JvmTask.kt:85)
	at org.apache.tools.ant.UnknownElement.execute(UnknownElement.java:292)
	at sun.reflect.GeneratedMethodAccessor4.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.tools.ant.dispatch.DispatchUtils.execute(DispatchUtils.java:99)
	... 16 more
```
