### PR TITLE
Fix KAPT cli tests on windows

### DIFF
--- a/compiler/cli/bin/kotlinc.bat
+++ b/compiler/cli/bin/kotlinc.bat
@@ -49,6 +49,7 @@ if "%_KOTLIN_RUNNER%"=="1" (
   "%_JAVACMD%" %JAVA_OPTS% "-Dkotlin.home=%_KOTLIN_HOME%" -cp "%_KOTLIN_HOME%\lib\kotlin-runner.jar" ^
     org.jetbrains.kotlin.runner.Main %KOTLIN_OPTS%
 ) else (
+  setlocal EnableDelayedExpansion
   SET _ADDITIONAL_CLASSPATH=
 
   if not "%_KOTLIN_TOOL%"=="" (
@@ -56,7 +57,7 @@ if "%_KOTLIN_RUNNER%"=="1" (
   )
 
   "%_JAVACMD%" %JAVA_OPTS% -noverify -cp "%_KOTLIN_HOME%\lib\kotlin-preloader.jar" ^
-    org.jetbrains.kotlin.preloading.Preloader -cp "%_KOTLIN_HOME%\lib\kotlin-compiler.jar%_ADDITIONAL_CLASSPATH%" ^
+    org.jetbrains.kotlin.preloading.Preloader -cp "%_KOTLIN_HOME%\lib\kotlin-compiler.jar!_ADDITIONAL_CLASSPATH!" ^
     %_KOTLIN_COMPILER% %KOTLIN_OPTS%
 )
 

--- a/plugins/kapt3/kapt3-cli/test/org/jetbrains/kotlin/kapt/cli/test/AbstractArgumentParsingTest.kt
+++ b/plugins/kapt3/kapt3-cli/test/org/jetbrains/kotlin/kapt/cli/test/AbstractArgumentParsingTest.kt
@@ -25,7 +25,7 @@ abstract class AbstractArgumentParsingTest : TestCase() {
         val before = sections.single { it.name == "before" }
 
         val messageCollector = TestMessageCollector()
-        val transformedArgs = transformArgs(before.content.split(LINE_SEPARATOR), messageCollector, isTest = true)
+        val transformedArgs = transformArgs(before.content.lines(), messageCollector, isTest = true)
         val actualAfter = if (messageCollector.hasErrors()) messageCollector.toString() else transformedArgs.joinToString(LINE_SEPARATOR)
         val actual = sections.replacingSection("after", actualAfter).render()
 

--- a/plugins/kapt3/kapt3-cli/test/org/jetbrains/kotlin/kapt/cli/test/AbstractKaptToolIntegrationTest.kt
+++ b/plugins/kapt3/kapt3-cli/test/org/jetbrains/kotlin/kapt/cli/test/AbstractKaptToolIntegrationTest.kt
@@ -103,7 +103,14 @@ abstract class AbstractKaptToolIntegrationTest : TestCaseWithTmpdir() {
     }
 
     private fun transformArguments(args: List<String>): List<String> {
-        return args.map { it.replace("%KOTLIN_STDLIB%", File("dist/kotlinc/lib/kotlin-stdlib.jar").absolutePath) }
+        return args.map {
+            val arg = it.replace("%KOTLIN_STDLIB%", File("dist/kotlinc/lib/kotlin-stdlib.jar").absolutePath)
+            if (SystemInfo.isWindows && (arg.contains("=") || arg.contains(":"))) {
+                "\"" + arg + "\""
+            } else {
+                arg
+            }
+        }
     }
 
     private fun getJdk8Home(): File {

--- a/plugins/kapt3/kapt3-cli/testData/integration/argfile/kaptArgs.txt
+++ b/plugins/kapt3/kapt3-cli/testData/integration/argfile/kaptArgs.txt
@@ -4,5 +4,5 @@
 -Kapt-classpath=output/ap
 -Kapt-processors=apt.SampleApt
 -d output/classes
--cp output/ap:%KOTLIN_STDLIB%
+-cp output/ap
 Test.kt


### PR DESCRIPTION
- Fix line separator issue
- Always quote args with delimiters (=, :)
- fix one of args files by removing obsolete stdlib reference
- Fix kotlinc.bat to ensure lazy evaluation of additional classpath