### PR TITLE
Allow to inline anonymous objects from `init` block to several constructors

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/codegen/ir/FirBlackBoxInlineCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/codegen/ir/FirBlackBoxInlineCodegenTestGenerated.java
@@ -246,6 +246,16 @@ public class FirBlackBoxInlineCodegenTestGenerated extends AbstractFirBlackBoxIn
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt38197.kt");
         }
 
+        @TestMetadata("kt42815.kt")
+        public void testKt42815() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt42815.kt");
+        }
+
+        @TestMetadata("kt42815_delegated.kt")
+        public void testKt42815_delegated() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt42815_delegated.kt");
+        }
+
         @TestMetadata("kt6552.kt")
         public void testKt6552() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt6552.kt");

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/ir/IrInlineReferenceLocator.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/ir/IrInlineReferenceLocator.kt
@@ -9,10 +9,7 @@ import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
 import org.jetbrains.kotlin.backend.jvm.codegen.isInlineFunctionCall
 import org.jetbrains.kotlin.backend.jvm.codegen.isInlineIrExpression
 import org.jetbrains.kotlin.ir.IrElement
-import org.jetbrains.kotlin.ir.declarations.IrDeclaration
-import org.jetbrains.kotlin.ir.declarations.IrDeclarationBase
-import org.jetbrains.kotlin.ir.declarations.IrFunction
-import org.jetbrains.kotlin.ir.declarations.IrValueParameter
+import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.expressions.IrBlock
 import org.jetbrains.kotlin.ir.expressions.IrCallableReference
 import org.jetbrains.kotlin.ir.expressions.IrFunctionAccessExpression
@@ -25,7 +22,8 @@ internal open class IrInlineReferenceLocator(private val context: JvmBackendCont
     }
 
     override fun visitDeclaration(declaration: IrDeclarationBase, data: IrDeclaration?) {
-        declaration.acceptChildren(this, declaration)
+        val scope = if (declaration is IrVariable) data else declaration
+        declaration.acceptChildren(this, scope)
     }
 
     override fun visitFunctionAccess(expression: IrFunctionAccessExpression, data: IrDeclaration?) {

--- a/compiler/testData/codegen/boxInline/anonymousObject/kt42815.kt
+++ b/compiler/testData/codegen/boxInline/anonymousObject/kt42815.kt
@@ -1,0 +1,21 @@
+// FILE: 1.kt
+package test
+
+inline fun myRun(x: () -> String) = x()
+
+// FILE: 2.kt
+// NO_CHECK_LAMBDA_INLINING
+import test.*
+
+class C {
+    val x: String
+    init {
+        val y = myRun { { "OK" }() }
+        x = y
+    }
+
+    constructor(y: Int)
+    constructor(y: String)
+}
+
+fun box(): String = C("").x

--- a/compiler/testData/codegen/boxInline/anonymousObject/kt42815_delegated.kt
+++ b/compiler/testData/codegen/boxInline/anonymousObject/kt42815_delegated.kt
@@ -1,0 +1,30 @@
+// WITH_RUNTIME
+// FILE: 1.kt
+package test
+
+inline fun myRun( x: () -> String): Lazy<String> {
+    val value2 = x()
+    return object : Lazy<String> {
+        override val value: String
+            get() = value2
+
+        override fun isInitialized(): Boolean = true
+    }
+}
+
+// FILE: 2.kt
+
+import test.*
+
+class C {
+    val x: String
+    init {
+        val y by myRun { { "OK" }() }
+        x = y
+    }
+
+    constructor(y: Int)
+    constructor(y: String)
+}
+
+fun box(): String = C("").x

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/BlackBoxInlineCodegenTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/BlackBoxInlineCodegenTestGenerated.java
@@ -246,6 +246,16 @@ public class BlackBoxInlineCodegenTestGenerated extends AbstractBlackBoxInlineCo
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt38197.kt");
         }
 
+        @TestMetadata("kt42815.kt")
+        public void testKt42815() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt42815.kt");
+        }
+
+        @TestMetadata("kt42815_delegated.kt")
+        public void testKt42815_delegated() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt42815_delegated.kt");
+        }
+
         @TestMetadata("kt6552.kt")
         public void testKt6552() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt6552.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/CompileKotlinAgainstInlineKotlinTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/CompileKotlinAgainstInlineKotlinTestGenerated.java
@@ -246,6 +246,16 @@ public class CompileKotlinAgainstInlineKotlinTestGenerated extends AbstractCompi
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt38197.kt");
         }
 
+        @TestMetadata("kt42815.kt")
+        public void testKt42815() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt42815.kt");
+        }
+
+        @TestMetadata("kt42815_delegated.kt")
+        public void testKt42815_delegated() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt42815_delegated.kt");
+        }
+
         @TestMetadata("kt6552.kt")
         public void testKt6552() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt6552.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/IrBlackBoxInlineCodegenTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/IrBlackBoxInlineCodegenTestGenerated.java
@@ -246,6 +246,16 @@ public class IrBlackBoxInlineCodegenTestGenerated extends AbstractIrBlackBoxInli
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt38197.kt");
         }
 
+        @TestMetadata("kt42815.kt")
+        public void testKt42815() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt42815.kt");
+        }
+
+        @TestMetadata("kt42815_delegated.kt")
+        public void testKt42815_delegated() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt42815_delegated.kt");
+        }
+
         @TestMetadata("kt6552.kt")
         public void testKt6552() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt6552.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/IrCompileKotlinAgainstInlineKotlinTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/IrCompileKotlinAgainstInlineKotlinTestGenerated.java
@@ -246,6 +246,16 @@ public class IrCompileKotlinAgainstInlineKotlinTestGenerated extends AbstractIrC
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt38197.kt");
         }
 
+        @TestMetadata("kt42815.kt")
+        public void testKt42815() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt42815.kt");
+        }
+
+        @TestMetadata("kt42815_delegated.kt")
+        public void testKt42815_delegated() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt42815_delegated.kt");
+        }
+
         @TestMetadata("kt6552.kt")
         public void testKt6552() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt6552.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/JvmIrAgainstOldBoxInlineTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/JvmIrAgainstOldBoxInlineTestGenerated.java
@@ -246,6 +246,16 @@ public class JvmIrAgainstOldBoxInlineTestGenerated extends AbstractJvmIrAgainstO
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt38197.kt");
         }
 
+        @TestMetadata("kt42815.kt")
+        public void testKt42815() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt42815.kt");
+        }
+
+        @TestMetadata("kt42815_delegated.kt")
+        public void testKt42815_delegated() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt42815_delegated.kt");
+        }
+
         @TestMetadata("kt6552.kt")
         public void testKt6552() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt6552.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/JvmOldAgainstIrBoxInlineTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/JvmOldAgainstIrBoxInlineTestGenerated.java
@@ -246,6 +246,16 @@ public class JvmOldAgainstIrBoxInlineTestGenerated extends AbstractJvmOldAgainst
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt38197.kt");
         }
 
+        @TestMetadata("kt42815.kt")
+        public void testKt42815() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt42815.kt");
+        }
+
+        @TestMetadata("kt42815_delegated.kt")
+        public void testKt42815_delegated() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt42815_delegated.kt");
+        }
+
         @TestMetadata("kt6552.kt")
         public void testKt6552() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt6552.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenInlineES6TestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenInlineES6TestGenerated.java
@@ -226,6 +226,16 @@ public class IrJsCodegenInlineES6TestGenerated extends AbstractIrJsCodegenInline
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt38197.kt");
         }
 
+        @TestMetadata("kt42815.kt")
+        public void testKt42815() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt42815.kt");
+        }
+
+        @TestMetadata("kt42815_delegated.kt")
+        public void testKt42815_delegated() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt42815_delegated.kt");
+        }
+
         @TestMetadata("kt6552.kt")
         public void testKt6552() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt6552.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenInlineTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenInlineTestGenerated.java
@@ -226,6 +226,16 @@ public class IrJsCodegenInlineTestGenerated extends AbstractIrJsCodegenInlineTes
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt38197.kt");
         }
 
+        @TestMetadata("kt42815.kt")
+        public void testKt42815() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt42815.kt");
+        }
+
+        @TestMetadata("kt42815_delegated.kt")
+        public void testKt42815_delegated() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt42815_delegated.kt");
+        }
+
         @TestMetadata("kt6552.kt")
         public void testKt6552() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt6552.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/semantics/JsCodegenInlineTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/semantics/JsCodegenInlineTestGenerated.java
@@ -226,6 +226,16 @@ public class JsCodegenInlineTestGenerated extends AbstractJsCodegenInlineTest {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt38197.kt");
         }
 
+        @TestMetadata("kt42815.kt")
+        public void testKt42815() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt42815.kt");
+        }
+
+        @TestMetadata("kt42815_delegated.kt")
+        public void testKt42815_delegated() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt42815_delegated.kt");
+        }
+
         @TestMetadata("kt6552.kt")
         public void testKt6552() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt6552.kt");


### PR DESCRIPTION
Allow to inline anonymous objects from `init` block to several constructors

Mostly it's a workaround to avoid assertion on generating `init` block in several constructors

#KT-42815 Fixed