### PR TITLE
FIR: no constraint for coerced-to-Unit expression in lambda

### DIFF
--- a/compiler/fir/analysis-tests/testData/extendedCheckers/RedundantReturnUnitTypeChecker.txt
+++ b/compiler/fir/analysis-tests/testData/extendedCheckers/RedundantReturnUnitTypeChecker.txt
@@ -59,7 +59,7 @@ FILE: RedundantReturnUnitTypeChecker.kt
         }
 
         public final fun foo(): R|kotlin/Unit| {
-            ^foo this@R|/B|.R|/B.run|<R|kotlin/Int|>(<L> = run@fun <anonymous>(): R|kotlin/Int| {
+            ^foo this@R|/B|.R|/B.run|<R|kotlin/Unit|>(<L> = run@fun <anonymous>(): R|kotlin/Unit| {
                 this@R|/B|.R|/B.bar|()
             }
             )
@@ -88,7 +88,7 @@ FILE: RedundantReturnUnitTypeChecker.kt
         }
 
         public final fun goo(): R|kotlin/Unit| {
-            ^goo (this@R|/B|, Int(1)).R|/B.let|<R|kotlin/Int|, R|kotlin/Int|>(<L> = let@fun <anonymous>(it: R|kotlin/Int|): R|kotlin/Int| {
+            ^goo (this@R|/B|, Int(1)).R|/B.let|<R|kotlin/Int|, R|kotlin/Unit|>(<L> = let@fun <anonymous>(it: R|kotlin/Int|): R|kotlin/Unit| {
                 this@R|/B|.R|/B.bar|()
             }
             )

--- a/compiler/fir/analysis-tests/testData/resolveWithStdlib/complexPostponedCfg.dot
+++ b/compiler/fir/analysis-tests/testData/resolveWithStdlib/complexPostponedCfg.dot
@@ -63,7 +63,7 @@ digraph complexPostponedCfg_kt {
                             }
                             34 [label="Call arguments union" style="filled" fillcolor=yellow];
                             35 [label="Postponed exit from lambda"];
-                            36 [label="Function call: R|kotlin/with|<R|FirFunctionCall|, R|kotlin/Boolean|>(...)"];
+                            36 [label="Function call: R|kotlin/with|<R|FirFunctionCall|, R|kotlin/Unit|>(...)"];
                             37 [label="Exit block"];
                         }
                         38 [label="Exit function anonymousFunction" style="filled" fillcolor=red];

--- a/compiler/fir/analysis-tests/testData/resolveWithStdlib/complexPostponedCfg.txt
+++ b/compiler/fir/analysis-tests/testData/resolveWithStdlib/complexPostponedCfg.txt
@@ -7,7 +7,7 @@ FILE: complexPostponedCfg.kt
         lval firstCalls: R|kotlin/collections/List<FirFunctionCall>| = R|kotlin/with|<R|FirFunctionCall|, R|kotlin/collections/List<FirFunctionCall>|>((R|<local>/statements|.R|kotlin/collections/last|<R|FirBase|>() as R|FirFunctionCall|), <L> = setCall@fun R|FirFunctionCall|.<anonymous>(): R|kotlin/collections/List<FirFunctionCall>| <kind=EXACTLY_ONCE>  {
             ^ R|kotlin/collections/buildList|<R|FirFunctionCall|>(<L> = buildList@fun R|kotlin/collections/MutableList<FirFunctionCall>|.<anonymous>(): R|kotlin/Unit| <kind=EXACTLY_ONCE>  {
                 this@R|special/anonymous|.R|SubstitutionOverride<kotlin/collections/MutableList.add: R|kotlin/Boolean|>|(this@R|special/anonymous|)
-                R|kotlin/with|<R|FirFunctionCall|, R|kotlin/Boolean|>((R|<local>/arguments|.R|kotlin/collections/last|<R|FirBase|>() as R|FirFunctionCall|), <L> = plusCall@fun R|FirFunctionCall|.<anonymous>(): R|kotlin/Boolean| <kind=EXACTLY_ONCE>  {
+                R|kotlin/with|<R|FirFunctionCall|, R|kotlin/Unit|>((R|<local>/arguments|.R|kotlin/collections/last|<R|FirBase|>() as R|FirFunctionCall|), <L> = plusCall@fun R|FirFunctionCall|.<anonymous>(): R|kotlin/Unit| <kind=EXACTLY_ONCE>  {
                     this@R|special/anonymous|.R|SubstitutionOverride<kotlin/collections/MutableList.add: R|kotlin/Boolean|>|(this@R|special/anonymous|)
                     this@R|special/anonymous|.R|SubstitutionOverride<kotlin/collections/MutableList.add: R|kotlin/Boolean|>|((R|<local>/explicitReceiver| as R|FirFunctionCall|))
                 }

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/inference/PostponedArgumentsAnalyzer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/inference/PostponedArgumentsAnalyzer.kt
@@ -130,7 +130,7 @@ class PostponedArgumentsAnalyzer(
             rawReturnType,
             stubsForPostponedVariables
         )
-        applyResultsOfAnalyzedLambdaToCandidateSystem(c, lambda, candidate, results, ::substitute)
+        applyResultsOfAnalyzedLambdaToCandidateSystem(c, lambda, candidate, results, expectedTypeForReturnArguments, ::substitute)
         return results
     }
 
@@ -139,6 +139,7 @@ class PostponedArgumentsAnalyzer(
         lambda: ResolvedLambdaAtom,
         candidate: Candidate,
         results: ReturnArgumentsAnalysisResult,
+        expectedReturnType: ConeKotlinType? = null,
         substitute: (ConeKotlinType) -> ConeKotlinType = c.createSubstituteFunctorForLambdaAnalysis()
     ) {
         val (returnArguments, inferenceSession) = results
@@ -164,21 +165,30 @@ class PostponedArgumentsAnalyzer(
 
         val checkerSink: CheckerSink = CheckerSinkImpl(candidate)
 
+        val lastExpression = lambda.atom.body?.statements?.lastOrNull() as? FirExpression
         var hasExpressionInReturnArguments = false
+        // No constraint for return expressions of lambda if it has Unit return type.
         val lambdaReturnType = lambda.returnType.let(substitute).takeUnless { it.isUnit }
         returnArguments.forEach {
             if (it !is FirExpression) return@forEach
             hasExpressionInReturnArguments = true
-            candidate.resolveArgumentExpression(
-                c.getBuilder(),
-                it,
-                lambdaReturnType,
-                lambda.atom.returnTypeRef, // TODO: proper ref
-                checkerSink,
-                context = resolutionContext,
-                isReceiver = false,
-                isDispatch = false
-            )
+            // If it is the last expression, and the expected type is Unit, that expression will be coerced to Unit.
+            // If the last expression is of Unit type, of course it's not coercion-to-Unit case.
+            val lastExpressionCoercedToUnit =
+                it == lastExpression && expectedReturnType?.isUnit == true && !it.typeRef.coneType.isUnit
+            // No constraint for the last expression of lambda if it will be coerced to Unit.
+            if (!lastExpressionCoercedToUnit) {
+                candidate.resolveArgumentExpression(
+                    c.getBuilder(),
+                    it,
+                    lambdaReturnType,
+                    lambda.atom.returnTypeRef, // TODO: proper ref
+                    checkerSink,
+                    context = resolutionContext,
+                    isReceiver = false,
+                    isDispatch = false
+                )
+            }
         }
 
         if (!hasExpressionInReturnArguments && lambdaReturnType != null) {

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/inference/PostponedArgumentsAnalyzer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/inference/PostponedArgumentsAnalyzer.kt
@@ -116,8 +116,7 @@ class PostponedArgumentsAnalyzer(
             c.canBeProper(rawReturnType) -> substitute(rawReturnType)
 
             // For Unit-coercion
-            c.hasUpperOrEqualUnitConstraint(rawReturnType) ->
-                if (rawReturnType.isMarkedNullable) unitType.withNullability(ConeNullability.NULLABLE) else unitType
+            !rawReturnType.isMarkedNullable && c.hasUpperOrEqualUnitConstraint(rawReturnType) -> unitType
 
             else -> null
         }

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirExpressionsResolveTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirExpressionsResolveTransformer.kt
@@ -309,7 +309,13 @@ open class FirExpressionsResolveTransformer(transformer: FirBodyResolveTransform
             TransformData.Data(value)
         }
         block.transformOtherChildren(transformer, data)
-        block.writeResultType(session)
+        if (data is ResolutionMode.WithExpectedType && data.expectedTypeRef is FirResolvedTypeRef) {
+            // Top-down propagation: from the explicit type of the enclosing declaration to the block type
+            block.resultType = data.expectedTypeRef
+        } else {
+            // Bottom-up propagation: from the return type of the last expression in the block to the block type
+            block.writeResultType(session)
+        }
 
         dataFlowAnalyzer.exitBlock(block)
     }

--- a/compiler/resolution.common/src/org/jetbrains/kotlin/resolve/calls/inference/model/NewConstraintSystemImpl.kt
+++ b/compiler/resolution.common/src/org/jetbrains/kotlin/resolve/calls/inference/model/NewConstraintSystemImpl.kt
@@ -437,6 +437,9 @@ class NewConstraintSystemImpl(
     override fun hasUpperOrEqualUnitConstraint(type: KotlinTypeMarker): Boolean {
         checkState(State.BUILDING, State.COMPLETION, State.FREEZED)
         val constraints = storage.notFixedTypeVariables[type.typeConstructor()]?.constraints ?: return false
-        return constraints.any { (it.kind == ConstraintKind.UPPER || it.kind == ConstraintKind.EQUALITY) && it.type.isUnit() }
+        return constraints.any {
+            (it.kind == ConstraintKind.UPPER || it.kind == ConstraintKind.EQUALITY) &&
+                    it.type.lowerBoundIfFlexible().isUnit()
+        }
     }
 }

--- a/compiler/testData/codegen/box/inference/coercionToUnitForLambdaReturnTypeWithFlexibleConstraint.kt
+++ b/compiler/testData/codegen/box/inference/coercionToUnitForLambdaReturnTypeWithFlexibleConstraint.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 // TARGET_BACKEND: JVM
 
 // FILE: TestJ.java

--- a/compiler/testData/diagnostics/tests/inference/completion/postponedArgumentsAnalysis/basic.fir.kt
+++ b/compiler/testData/diagnostics/tests/inference/completion/postponedArgumentsAnalysis/basic.fir.kt
@@ -142,8 +142,8 @@ fun main() {
     val x18: (C) -> Unit = select(id { <!DEBUG_INFO_EXPRESSION_TYPE("C")!>it<!> }, { <!DEBUG_INFO_EXPRESSION_TYPE("C")!>it<!> }, id<(B) -> Unit> { x -> x })
 
     // Resolution of extension/non-extension functions combination
-    val x19: String.() -> Unit = select(<!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Function1<kotlin.String, kotlin.String>")!>id { <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.String")!>this<!> }<!>, <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Function1<kotlin.String, kotlin.Unit>")!>id(fun(x: String) {})<!>)
-    val x20: String.() -> Unit = select(<!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Function1<kotlin.String, kotlin.String>")!>{ <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.String")!>this<!> }<!>, (fun(x: String) {}))
+    val x19: String.() -> Unit = select(<!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Function1<kotlin.String, kotlin.Unit>")!>id { <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.String")!>this<!> }<!>, <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Function1<kotlin.String, kotlin.Unit>")!>id(fun(x: String) {})<!>)
+    val x20: String.() -> Unit = select(<!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Function1<kotlin.String, kotlin.Unit>")!>{ <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.String")!>this<!> }<!>, (fun(x: String) {}))
     val x21: String.() -> Unit = select(<!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Function1<kotlin.String, kotlin.Unit>")!>id(fun(x: String) {})<!>, <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Function1<kotlin.String, kotlin.Unit>")!>id(fun(x: String) {})<!>)
     select(id<String.() -> Unit>(fun(x: String) {}), <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Function1<kotlin.String, kotlin.Unit>")!>id(fun(x: String) {})<!>)
     select(<!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Function2<kotlin.String, kotlin.String, kotlin.Unit>")!>id(fun String.(x: String) {})<!>, <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Function2<kotlin.String, kotlin.String, kotlin.Unit>")!>id(fun(x: String, y: String) {})<!>)

--- a/compiler/testData/diagnostics/testsWithStdLib/inference/completion/postponedArgumentsAnalysis/suspendFunctions.fir.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/inference/completion/postponedArgumentsAnalysis/suspendFunctions.fir.kt
@@ -14,12 +14,12 @@ fun main() {
     select(<!DEBUG_INFO_EXPRESSION_TYPE("kotlin.coroutines.SuspendFunction0<kotlin.Unit>")!>id {}<!>, id(suspend {}))
     select(<!DEBUG_INFO_EXPRESSION_TYPE("kotlin.coroutines.SuspendFunction0<kotlin.Unit>")!>id {}<!>, id<suspend () -> Unit> {})
 
-    takeSuspend(<!DEBUG_INFO_EXPRESSION_TYPE("kotlin.coroutines.SuspendFunction1<kotlin.Int, kotlin.Int>")!>id { it }<!>, <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.coroutines.SuspendFunction1<kotlin.Int, kotlin.Int>")!>{ x -> x }<!>)
+    takeSuspend(<!DEBUG_INFO_EXPRESSION_TYPE("kotlin.coroutines.SuspendFunction1<kotlin.Int, kotlin.Unit>")!>id { it }<!>, <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.coroutines.SuspendFunction1<kotlin.Int, kotlin.Unit>")!>{ x -> x }<!>)
 
-    val x1: suspend (Int) -> Unit = takeSuspend(<!DEBUG_INFO_EXPRESSION_TYPE("kotlin.coroutines.SuspendFunction1<kotlin.Int, kotlin.Int>")!>id { it }<!>, <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.coroutines.SuspendFunction1<kotlin.Int, kotlin.Int>")!>{ x -> x }<!>)
+    val x1: suspend (Int) -> Unit = takeSuspend(<!DEBUG_INFO_EXPRESSION_TYPE("kotlin.coroutines.SuspendFunction1<kotlin.Int, kotlin.Unit>")!>id { it }<!>, <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.coroutines.SuspendFunction1<kotlin.Int, kotlin.Unit>")!>{ x -> x }<!>)
 
     // Here, the error should be
-    val x2: (Int) -> Unit = takeSuspend(<!DEBUG_INFO_EXPRESSION_TYPE("kotlin.coroutines.SuspendFunction1<kotlin.Int, kotlin.Int>")!>id { it }<!>, <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.coroutines.SuspendFunction1<kotlin.Int, kotlin.Int>")!>{ x -> x }<!>)
-    val x3: suspend (Int) -> Unit = takeSimpleFunction(<!DEBUG_INFO_EXPRESSION_TYPE("kotlin.coroutines.SuspendFunction1<kotlin.Int, kotlin.Int>")!>id { it }<!>, <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.coroutines.SuspendFunction1<kotlin.Int, kotlin.Int>")!>{ x -> x }<!>)
+    val x2: (Int) -> Unit = takeSuspend(<!DEBUG_INFO_EXPRESSION_TYPE("kotlin.coroutines.SuspendFunction1<kotlin.Int, kotlin.Unit>")!>id { it }<!>, <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.coroutines.SuspendFunction1<kotlin.Int, kotlin.Unit>")!>{ x -> x }<!>)
+    val x3: suspend (Int) -> Unit = takeSimpleFunction(<!DEBUG_INFO_EXPRESSION_TYPE("kotlin.coroutines.SuspendFunction1<kotlin.Int, kotlin.Unit>")!>id { it }<!>, <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.coroutines.SuspendFunction1<kotlin.Int, kotlin.Unit>")!>{ x -> x }<!>)
     val x4: (Int) -> Unit = <!INAPPLICABLE_CANDIDATE!>takeSimpleFunction<!>(id<suspend (Int) -> Unit> {}, <!DEBUG_INFO_EXPRESSION_TYPE("Type is unknown")!>{}<!>)
 }

--- a/compiler/testData/ir/irText/expressions/coercionToUnit.fir.kt.txt
+++ b/compiler/testData/ir/irText/expressions/coercionToUnit.fir.kt.txt
@@ -1,6 +1,6 @@
 val test1: Function0<Unit>
   field = local fun <anonymous>(): Int {
-    return 42
+    42 /*~> Unit */
   }
 
   get

--- a/compiler/testData/ir/irText/expressions/coercionToUnit.fir.txt
+++ b/compiler/testData/ir/irText/expressions/coercionToUnit.fir.txt
@@ -5,7 +5,7 @@ FILE fqName:<root> fileName:/coercionToUnit.kt
         FUN_EXPR type=kotlin.Function0<kotlin.Int> origin=LAMBDA
           FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> () returnType:kotlin.Int
             BLOCK_BODY
-              RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.Int declared in <root>.test1'
+              TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
                 CONST Int type=kotlin.Int value=42
     FUN DEFAULT_PROPERTY_ACCESSOR name:<get-test1> visibility:public modality:FINAL <> () returnType:kotlin.Function0<kotlin.Unit>
       correspondingProperty: PROPERTY name:test1 visibility:public modality:FINAL [val]

--- a/compiler/testData/ir/irText/firProblems/typeVariableAfterBuildMap.fir.kt.txt
+++ b/compiler/testData/ir/irText/firProblems/typeVariableAfterBuildMap.fir.kt.txt
@@ -167,7 +167,7 @@ object Visibilities {
       <this>.put(key = Private, value = 0) /*~> Unit */
       <this>.put(key = Internal, value = 1) /*~> Unit */
       <this>.put(key = Protected, value = 1) /*~> Unit */
-      return <this>.put(key = Public, value = 2) /*~> Unit */
+      <this>.put(key = Public, value = 2) /*~> Unit */
     }
 )
     private get

--- a/compiler/testData/ir/irText/firProblems/typeVariableAfterBuildMap.fir.txt
+++ b/compiler/testData/ir/irText/firProblems/typeVariableAfterBuildMap.fir.txt
@@ -572,12 +572,11 @@ FILE fqName:<root> fileName:/typeVariableAfterBuildMap.kt
                       $this: GET_VAR '<this>: kotlin.collections.MutableMap<<root>.Visibility, kotlin.Int> declared in <root>.Visibilities.ORDERED_VISIBILITIES.<anonymous>' type=kotlin.collections.MutableMap<<root>.Visibility, kotlin.Int> origin=null
                       key: GET_OBJECT 'CLASS OBJECT name:Protected modality:FINAL visibility:public superTypes:[<root>.Visibility]' type=<root>.Visibilities.Protected
                       value: CONST Int type=kotlin.Int value=1
-                  RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.Unit declared in <root>.Visibilities.ORDERED_VISIBILITIES'
-                    TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
-                      CALL 'public abstract fun put (key: K of kotlin.collections.MutableMap, value: V of kotlin.collections.MutableMap): V of kotlin.collections.MutableMap? declared in kotlin.collections.MutableMap' type=kotlin.Int? origin=null
-                        $this: GET_VAR '<this>: kotlin.collections.MutableMap<<root>.Visibility, kotlin.Int> declared in <root>.Visibilities.ORDERED_VISIBILITIES.<anonymous>' type=kotlin.collections.MutableMap<<root>.Visibility, kotlin.Int> origin=null
-                        key: GET_OBJECT 'CLASS OBJECT name:Public modality:FINAL visibility:public superTypes:[<root>.Visibility]' type=<root>.Visibilities.Public
-                        value: CONST Int type=kotlin.Int value=2
+                  TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+                    CALL 'public abstract fun put (key: K of kotlin.collections.MutableMap, value: V of kotlin.collections.MutableMap): V of kotlin.collections.MutableMap? declared in kotlin.collections.MutableMap' type=kotlin.Int? origin=null
+                      $this: GET_VAR '<this>: kotlin.collections.MutableMap<<root>.Visibility, kotlin.Int> declared in <root>.Visibilities.ORDERED_VISIBILITIES.<anonymous>' type=kotlin.collections.MutableMap<<root>.Visibility, kotlin.Int> origin=null
+                      key: GET_OBJECT 'CLASS OBJECT name:Public modality:FINAL visibility:public superTypes:[<root>.Visibility]' type=<root>.Visibilities.Public
+                      value: CONST Int type=kotlin.Int value=2
       FUN DEFAULT_PROPERTY_ACCESSOR name:<get-ORDERED_VISIBILITIES> visibility:private modality:FINAL <> ($this:<root>.Visibilities) returnType:kotlin.collections.Map<<root>.Visibility, kotlin.Int>
         correspondingProperty: PROPERTY name:ORDERED_VISIBILITIES visibility:private modality:FINAL [val]
         $this: VALUE_PARAMETER name:<this> type:<root>.Visibilities

--- a/compiler/testData/ir/irText/stubs/builtinMap.fir.kt.txt
+++ b/compiler/testData/ir/irText/stubs/builtinMap.fir.kt.txt
@@ -2,7 +2,7 @@ fun <K1 : Any?, V1 : Any?> Map<out K1, V1>.plus(pair: Pair<K1, V1>): Map<K1, V1>
   return when {
     <this>.isEmpty() -> mapOf<K1, V1>(pair = pair)
     else -> LinkedHashMap<K1?, V1?>(p0 = <this>).apply<LinkedHashMap<K1?, V1?>>(block = local fun LinkedHashMap<K1?, V1?>.<anonymous>() {
-      return <this>.put(p0 = pair.<get-first>(), p1 = pair.<get-second>()) /*~> Unit */
+      <this>.put(p0 = pair.<get-first>(), p1 = pair.<get-second>()) /*~> Unit */
     }
 )
   }

--- a/compiler/testData/ir/irText/stubs/builtinMap.fir.txt
+++ b/compiler/testData/ir/irText/stubs/builtinMap.fir.txt
@@ -26,11 +26,10 @@ FILE fqName:<root> fileName:/builtinMap.kt
                 FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> ($receiver:java.util.LinkedHashMap<K1 of <root>.plus?, V1 of <root>.plus?>) returnType:kotlin.Unit
                   $receiver: VALUE_PARAMETER name:<this> type:java.util.LinkedHashMap<K1 of <root>.plus?, V1 of <root>.plus?>
                   BLOCK_BODY
-                    RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.Unit declared in <root>.plus'
-                      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
-                        CALL 'public open fun put (p0: @[FlexibleNullability] K of java.util.LinkedHashMap?, p1: @[FlexibleNullability] V of java.util.LinkedHashMap?): @[FlexibleNullability] V of java.util.LinkedHashMap? declared in java.util.LinkedHashMap' type=V1 of <root>.plus? origin=null
-                          $this: GET_VAR '<this>: java.util.LinkedHashMap<K1 of <root>.plus?, V1 of <root>.plus?> declared in <root>.plus.<anonymous>' type=java.util.LinkedHashMap<K1 of <root>.plus?, V1 of <root>.plus?> origin=null
-                          p0: CALL 'public final fun <get-first> (): A of kotlin.Pair declared in kotlin.Pair' type=K1 of <root>.plus origin=GET_PROPERTY
-                            $this: GET_VAR 'pair: kotlin.Pair<K1 of <root>.plus, V1 of <root>.plus> declared in <root>.plus' type=kotlin.Pair<K1 of <root>.plus, V1 of <root>.plus> origin=null
-                          p1: CALL 'public final fun <get-second> (): B of kotlin.Pair declared in kotlin.Pair' type=V1 of <root>.plus origin=GET_PROPERTY
-                            $this: GET_VAR 'pair: kotlin.Pair<K1 of <root>.plus, V1 of <root>.plus> declared in <root>.plus' type=kotlin.Pair<K1 of <root>.plus, V1 of <root>.plus> origin=null
+                    TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+                      CALL 'public open fun put (p0: @[FlexibleNullability] K of java.util.LinkedHashMap?, p1: @[FlexibleNullability] V of java.util.LinkedHashMap?): @[FlexibleNullability] V of java.util.LinkedHashMap? declared in java.util.LinkedHashMap' type=V1 of <root>.plus? origin=null
+                        $this: GET_VAR '<this>: java.util.LinkedHashMap<K1 of <root>.plus?, V1 of <root>.plus?> declared in <root>.plus.<anonymous>' type=java.util.LinkedHashMap<K1 of <root>.plus?, V1 of <root>.plus?> origin=null
+                        p0: CALL 'public final fun <get-first> (): A of kotlin.Pair declared in kotlin.Pair' type=K1 of <root>.plus origin=GET_PROPERTY
+                          $this: GET_VAR 'pair: kotlin.Pair<K1 of <root>.plus, V1 of <root>.plus> declared in <root>.plus' type=kotlin.Pair<K1 of <root>.plus, V1 of <root>.plus> origin=null
+                        p1: CALL 'public final fun <get-second> (): B of kotlin.Pair declared in kotlin.Pair' type=V1 of <root>.plus origin=GET_PROPERTY
+                          $this: GET_VAR 'pair: kotlin.Pair<K1 of <root>.plus, V1 of <root>.plus> declared in <root>.plus' type=kotlin.Pair<K1 of <root>.plus, V1 of <root>.plus> origin=null


### PR DESCRIPTION
The motivation is bb test `inference/coercionToUnitForLambdaReturnTypeWithFlexibleConstraint`:
```java
// FILE: TestJ.java

public class TestJ {
    public static <T> In<T> materialize() {
        return null;
    }
}
```
```kt
// FILE: test.kt

class In<in T>

fun <T> inferred(e: In<T>?, l: () -> T): T = l()

fun box(): String {
    // coercion to Unit for T!
    val inferred = (inferred(TestJ.materialize<Unit>(), { null })).toString()
    return if (inferred == "kotlin.Unit") "OK" else "fail : $inferred"
}
```
which currently fails with `"fail: null"` because the lambda `{ null }`, whose only expression (`null`) is supposed to be wrapped with coercion-to-Unit, still returns `null`. The lambda's return type and its block type should be `Unit` too, instead of `Nothing?`. To do so, we need a chain of changes as follows.

First, to change the lambda's return type as `Unit`, when analyzing the postponed lambda, we should be able to conclude that the expected return type of that lambda is `Unit`. In the collected type constraints, we were close but not quite yet: `ft<Unit?, Unit> <: T` is the constraint for the not fixed type. NI allows only simple type marker, like `Unit <: T`. The first commit extends it to flexible type. See the detailed message of the first commit.

Second, to change the block type, during expression resolution, we need top-down propagation---from the explicit type of the enclosing declaration to the block type---as well. Currently, only bottom-up propagation---from the type of the last expression of the block to the block type---is implemented. This also helps avoid adding redundant `return` expression with `Unit` type.

The last thing that bothers coercion-to-Unit insertion is the unnecessary type constraint from the argument resolution. After analyzing the postponed lambda, we visit return arguments to add more type constraints. However, `null`, which is of `Nothing?`, will be coerced to `Unit` (if no more type constraints are added), should have not visited. Otherwise, a constraint like `Nothing? <: T` will be added and change the block type and lambda return type again. In a similar manner, we don't constraint for the return expression of lambda if it is of `Unit` type. We should do so for the last expression which would be coerced to `Unit` without any constraints.