### PR TITLE
FIR2IR: correct base symbols of fake overrides for delegated member

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/codegen/ir/FirBlackBoxAgainstJavaCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/codegen/ir/FirBlackBoxAgainstJavaCodegenTestGenerated.java
@@ -425,6 +425,11 @@ public class FirBlackBoxAgainstJavaCodegenTestGenerated extends AbstractFirBlack
             KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/boxAgainstJava/interfaces"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
         }
 
+        @TestMetadata("defaultMethod.kt")
+        public void testDefaultMethod() throws Exception {
+            runTest("compiler/testData/codegen/boxAgainstJava/interfaces/defaultMethod.kt");
+        }
+
         @TestMetadata("inheritJavaInterface.kt")
         public void testInheritJavaInterface() throws Exception {
             runTest("compiler/testData/codegen/boxAgainstJava/interfaces/inheritJavaInterface.kt");

--- a/compiler/testData/codegen/boxAgainstJava/interfaces/defaultMethod.kt
+++ b/compiler/testData/codegen/boxAgainstJava/interfaces/defaultMethod.kt
@@ -1,0 +1,22 @@
+// JVM_TARGET: 1.8
+
+// FILE: A.java
+
+public interface A {
+    default String getMessage() {
+        return "OK";
+    }
+}
+
+// FILE: 1.kt
+
+interface I : A
+
+class B : A
+
+open class C(a : A) : I, A by a
+
+fun box(): String {
+    val a = B()
+    return C(a).message
+}

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/BlackBoxAgainstJavaCodegenTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/BlackBoxAgainstJavaCodegenTestGenerated.java
@@ -424,6 +424,11 @@ public class BlackBoxAgainstJavaCodegenTestGenerated extends AbstractBlackBoxAga
             KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/boxAgainstJava/interfaces"), Pattern.compile("^(.+)\\.kt$"), null, true);
         }
 
+        @TestMetadata("defaultMethod.kt")
+        public void testDefaultMethod() throws Exception {
+            runTest("compiler/testData/codegen/boxAgainstJava/interfaces/defaultMethod.kt");
+        }
+
         @TestMetadata("inheritJavaInterface.kt")
         public void testInheritJavaInterface() throws Exception {
             runTest("compiler/testData/codegen/boxAgainstJava/interfaces/inheritJavaInterface.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/IrBlackBoxAgainstJavaCodegenTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/IrBlackBoxAgainstJavaCodegenTestGenerated.java
@@ -425,6 +425,11 @@ public class IrBlackBoxAgainstJavaCodegenTestGenerated extends AbstractIrBlackBo
             KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/boxAgainstJava/interfaces"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
         }
 
+        @TestMetadata("defaultMethod.kt")
+        public void testDefaultMethod() throws Exception {
+            runTest("compiler/testData/codegen/boxAgainstJava/interfaces/defaultMethod.kt");
+        }
+
         @TestMetadata("inheritJavaInterface.kt")
         public void testInheritJavaInterface() throws Exception {
             runTest("compiler/testData/codegen/boxAgainstJava/interfaces/inheritJavaInterface.kt");


### PR DESCRIPTION
Otherwise, i.e., if the delegated member itself is used as the base symbol for a fake override, now we have a fake override whose overridden symbol owner points to itself: a recursion that may cause infinite loop or stack overflow in BE IR ([KT-43985](https://youtrack.jetbrains.com/issue/KT-43985)).