### PR TITLE
FIR: strengthen resolution success check for augmented array set call

### DIFF
--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirExpressionsResolveTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirExpressionsResolveTransformer.kt
@@ -867,8 +867,11 @@ open class FirExpressionsResolveTransformer(transformer: FirBodyResolveTransform
         }
         val secondResult = augmentedArraySetCall.assignCall.transformSingle(transformer, ResolutionMode.ContextIndependent)
 
-        val firstSucceed = firstCalls.all { it.typeRef !is FirErrorTypeRef }
-        val secondSucceed = secondCalls.all { it.typeRef !is FirErrorTypeRef }
+        fun isSuccessful(functionCall: FirFunctionCall): Boolean =
+            functionCall.typeRef !is FirErrorTypeRef && functionCall.calleeReference is FirResolvedNamedReference
+
+        val firstSucceed = firstCalls.all(::isSuccessful)
+        val secondSucceed = secondCalls.all(::isSuccessful)
 
         val result: FirStatement = when {
             firstSucceed && secondSucceed -> {

--- a/compiler/testData/ir/irText/expressions/callableReferences/caoWithAdaptationForSam.fir.kt.txt
+++ b/compiler/testData/ir/irText/expressions/callableReferences/caoWithAdaptationForSam.fir.kt.txt
@@ -44,19 +44,11 @@ fun withVararg(vararg xs: Int): Int {
 }
 
 fun test1() {
-  { // BLOCK
-    val <<array>>: A = A
-    val <<index_0>>: KFunction1<IntArray, Int> = ::withVararg
-    error("") /* ErrorCallExpression */<<index_0>>; error("") /* ErrorCallExpression */<<index_0>>; .plus(other = 1);
-  }
+  error("") /* ErrorCallExpression */
 }
 
 fun test2() {
-  { // BLOCK
-    val <<array>>: B = B
-    val <<index_0>>: KFunction1<IntArray, Int> = ::withVararg
-    error("") /* ErrorCallExpression */<<index_0>>; error("") /* ErrorCallExpression */<<index_0>>; .plus(other = 1);
-  }
+  error("") /* ErrorCallExpression */
 }
 
 fun test3(fn: Function1<Int, Unit>) {

--- a/compiler/testData/ir/irText/expressions/callableReferences/caoWithAdaptationForSam.fir.txt
+++ b/compiler/testData/ir/irText/expressions/callableReferences/caoWithAdaptationForSam.fir.txt
@@ -104,47 +104,27 @@ FILE fqName:<root> fileName:/caoWithAdaptationForSam.kt
         CONST Int type=kotlin.Int value=42
   FUN name:test1 visibility:public modality:FINAL <> () returnType:kotlin.Unit
     BLOCK_BODY
-      BLOCK type=kotlin.Unit origin=null
-        VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:<root>.A [val]
-          GET_OBJECT 'CLASS OBJECT name:A modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.A
-        VAR IR_TEMPORARY_VARIABLE name:tmp_1 type:kotlin.reflect.KFunction1<kotlin.IntArray, kotlin.Int> [val]
-          FUNCTION_REFERENCE 'public final fun withVararg (vararg xs: kotlin.Int): kotlin.Int declared in <root>' type=kotlin.reflect.KFunction1<kotlin.IntArray, kotlin.Int> origin=null reflectionTarget=<same>
-        ERROR_CALL 'Unresolved reference: <Inapplicable(INAPPLICABLE): /set>#' type=kotlin.Unit
-          GET_VAR 'val tmp_1: kotlin.reflect.KFunction1<kotlin.IntArray, kotlin.Int> [val] declared in <root>.test1' type=kotlin.reflect.KFunction1<kotlin.IntArray, kotlin.Int> origin=null
-          CALL 'public final fun plus (other: kotlin.Int): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
-            $this: ERROR_CALL 'Unresolved reference: <Inapplicable(INAPPLICABLE): /get>#' type=kotlin.Int
-              GET_VAR 'val tmp_1: kotlin.reflect.KFunction1<kotlin.IntArray, kotlin.Int> [val] declared in <root>.test1' type=kotlin.reflect.KFunction1<kotlin.IntArray, kotlin.Int> origin=null
-            other: CONST Int type=kotlin.Int value=1
+      ERROR_CALL 'FirArraySetCall (resolve isn't supported yet)' type=kotlin.Unit
   FUN name:test2 visibility:public modality:FINAL <> () returnType:kotlin.Unit
     BLOCK_BODY
-      BLOCK type=kotlin.Unit origin=null
-        VAR IR_TEMPORARY_VARIABLE name:tmp_2 type:<root>.B [val]
-          GET_OBJECT 'CLASS OBJECT name:B modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.B
-        VAR IR_TEMPORARY_VARIABLE name:tmp_3 type:kotlin.reflect.KFunction1<kotlin.IntArray, kotlin.Int> [val]
-          FUNCTION_REFERENCE 'public final fun withVararg (vararg xs: kotlin.Int): kotlin.Int declared in <root>' type=kotlin.reflect.KFunction1<kotlin.IntArray, kotlin.Int> origin=null reflectionTarget=<same>
-        ERROR_CALL 'Unresolved reference: <Inapplicable(INAPPLICABLE): /set>#' type=kotlin.Unit
-          GET_VAR 'val tmp_3: kotlin.reflect.KFunction1<kotlin.IntArray, kotlin.Int> [val] declared in <root>.test2' type=kotlin.reflect.KFunction1<kotlin.IntArray, kotlin.Int> origin=null
-          CALL 'public final fun plus (other: kotlin.Int): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
-            $this: ERROR_CALL 'Unresolved reference: <Inapplicable(INAPPLICABLE): /get>#' type=kotlin.Int
-              GET_VAR 'val tmp_3: kotlin.reflect.KFunction1<kotlin.IntArray, kotlin.Int> [val] declared in <root>.test2' type=kotlin.reflect.KFunction1<kotlin.IntArray, kotlin.Int> origin=null
-            other: CONST Int type=kotlin.Int value=1
+      ERROR_CALL 'FirArraySetCall (resolve isn't supported yet)' type=kotlin.Unit
   FUN name:test3 visibility:public modality:FINAL <> (fn:kotlin.Function1<kotlin.Int, kotlin.Unit>) returnType:kotlin.Unit
     VALUE_PARAMETER name:fn index:0 type:kotlin.Function1<kotlin.Int, kotlin.Unit>
     BLOCK_BODY
       BLOCK type=kotlin.Unit origin=null
-        VAR IR_TEMPORARY_VARIABLE name:tmp_4 type:<root>.A [val]
+        VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:<root>.A [val]
           GET_OBJECT 'CLASS OBJECT name:A modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.A
-        VAR IR_TEMPORARY_VARIABLE name:tmp_5 type:kotlin.Function1<kotlin.Int, kotlin.Unit> [val]
+        VAR IR_TEMPORARY_VARIABLE name:tmp_1 type:kotlin.Function1<kotlin.Int, kotlin.Unit> [val]
           GET_VAR 'fn: kotlin.Function1<kotlin.Int, kotlin.Unit> declared in <root>.test3' type=kotlin.Function1<kotlin.Int, kotlin.Unit> origin=null
         CALL 'public final fun set (i: <root>.IFoo, newValue: kotlin.Int): kotlin.Unit [operator] declared in <root>' type=kotlin.Unit origin=null
-          $receiver: GET_VAR 'val tmp_4: <root>.A [val] declared in <root>.test3' type=<root>.A origin=null
+          $receiver: GET_VAR 'val tmp_0: <root>.A [val] declared in <root>.test3' type=<root>.A origin=null
           i: TYPE_OP type=<root>.IFoo origin=SAM_CONVERSION typeOperand=<root>.IFoo
-            GET_VAR 'val tmp_5: kotlin.Function1<kotlin.Int, kotlin.Unit> [val] declared in <root>.test3' type=kotlin.Function1<kotlin.Int, kotlin.Unit> origin=null
+            GET_VAR 'val tmp_1: kotlin.Function1<kotlin.Int, kotlin.Unit> [val] declared in <root>.test3' type=kotlin.Function1<kotlin.Int, kotlin.Unit> origin=null
           newValue: CALL 'public final fun plus (other: kotlin.Int): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
             $this: CALL 'public final fun get (i: <root>.IFoo): kotlin.Int [operator] declared in <root>' type=kotlin.Int origin=null
-              $receiver: GET_VAR 'val tmp_4: <root>.A [val] declared in <root>.test3' type=<root>.A origin=null
+              $receiver: GET_VAR 'val tmp_0: <root>.A [val] declared in <root>.test3' type=<root>.A origin=null
               i: TYPE_OP type=<root>.IFoo origin=SAM_CONVERSION typeOperand=<root>.IFoo
-                GET_VAR 'val tmp_5: kotlin.Function1<kotlin.Int, kotlin.Unit> [val] declared in <root>.test3' type=kotlin.Function1<kotlin.Int, kotlin.Unit> origin=null
+                GET_VAR 'val tmp_1: kotlin.Function1<kotlin.Int, kotlin.Unit> [val] declared in <root>.test3' type=kotlin.Function1<kotlin.Int, kotlin.Unit> origin=null
             other: CONST Int type=kotlin.Int value=1
   FUN name:test4 visibility:public modality:FINAL <> (fn:kotlin.Function1<kotlin.Int, kotlin.Unit>) returnType:kotlin.Unit
     VALUE_PARAMETER name:fn index:0 type:kotlin.Function1<kotlin.Int, kotlin.Unit>
@@ -154,18 +134,18 @@ FILE fqName:<root> fileName:/caoWithAdaptationForSam.kt
           if: TYPE_OP type=kotlin.Boolean origin=INSTANCEOF typeOperand=<root>.IFoo
             GET_VAR 'fn: kotlin.Function1<kotlin.Int, kotlin.Unit> declared in <root>.test4' type=kotlin.Function1<kotlin.Int, kotlin.Unit> origin=null
           then: BLOCK type=kotlin.Unit origin=null
-            VAR IR_TEMPORARY_VARIABLE name:tmp_6 type:<root>.A [val]
+            VAR IR_TEMPORARY_VARIABLE name:tmp_2 type:<root>.A [val]
               GET_OBJECT 'CLASS OBJECT name:A modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.A
-            VAR IR_TEMPORARY_VARIABLE name:tmp_7 type:<root>.IFoo [val]
+            VAR IR_TEMPORARY_VARIABLE name:tmp_3 type:<root>.IFoo [val]
               TYPE_OP type=<root>.IFoo origin=IMPLICIT_CAST typeOperand=<root>.IFoo
                 GET_VAR 'fn: kotlin.Function1<kotlin.Int, kotlin.Unit> declared in <root>.test4' type=kotlin.Function1<kotlin.Int, kotlin.Unit> origin=null
             CALL 'public final fun set (i: <root>.IFoo, newValue: kotlin.Int): kotlin.Unit [operator] declared in <root>' type=kotlin.Unit origin=null
-              $receiver: GET_VAR 'val tmp_6: <root>.A [val] declared in <root>.test4' type=<root>.A origin=null
-              i: GET_VAR 'val tmp_7: <root>.IFoo [val] declared in <root>.test4' type=<root>.IFoo origin=null
+              $receiver: GET_VAR 'val tmp_2: <root>.A [val] declared in <root>.test4' type=<root>.A origin=null
+              i: GET_VAR 'val tmp_3: <root>.IFoo [val] declared in <root>.test4' type=<root>.IFoo origin=null
               newValue: CALL 'public final fun plus (other: kotlin.Int): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
                 $this: CALL 'public final fun get (i: <root>.IFoo): kotlin.Int [operator] declared in <root>' type=kotlin.Int origin=null
-                  $receiver: GET_VAR 'val tmp_6: <root>.A [val] declared in <root>.test4' type=<root>.A origin=null
-                  i: GET_VAR 'val tmp_7: <root>.IFoo [val] declared in <root>.test4' type=<root>.IFoo origin=null
+                  $receiver: GET_VAR 'val tmp_2: <root>.A [val] declared in <root>.test4' type=<root>.A origin=null
+                  i: GET_VAR 'val tmp_3: <root>.IFoo [val] declared in <root>.test4' type=<root>.IFoo origin=null
                 other: CONST Int type=kotlin.Int value=1
   FUN name:test5 visibility:public modality:FINAL <> (a:kotlin.Any) returnType:kotlin.Unit
     VALUE_PARAMETER name:a index:0 type:kotlin.Any
@@ -174,20 +154,20 @@ FILE fqName:<root> fileName:/caoWithAdaptationForSam.kt
         TYPE_OP type=kotlin.Function1<kotlin.Int, kotlin.Unit> origin=CAST typeOperand=kotlin.Function1<kotlin.Int, kotlin.Unit>
           GET_VAR 'a: kotlin.Any declared in <root>.test5' type=kotlin.Any origin=null
       BLOCK type=kotlin.Unit origin=null
-        VAR IR_TEMPORARY_VARIABLE name:tmp_8 type:<root>.A [val]
+        VAR IR_TEMPORARY_VARIABLE name:tmp_4 type:<root>.A [val]
           GET_OBJECT 'CLASS OBJECT name:A modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.A
-        VAR IR_TEMPORARY_VARIABLE name:tmp_9 type:kotlin.Function1<kotlin.Int, kotlin.Unit> [val]
+        VAR IR_TEMPORARY_VARIABLE name:tmp_5 type:kotlin.Function1<kotlin.Int, kotlin.Unit> [val]
           TYPE_OP type=kotlin.Function1<kotlin.Int, kotlin.Unit> origin=IMPLICIT_CAST typeOperand=kotlin.Function1<kotlin.Int, kotlin.Unit>
             GET_VAR 'a: kotlin.Any declared in <root>.test5' type=kotlin.Any origin=null
         CALL 'public final fun set (i: <root>.IFoo, newValue: kotlin.Int): kotlin.Unit [operator] declared in <root>' type=kotlin.Unit origin=null
-          $receiver: GET_VAR 'val tmp_8: <root>.A [val] declared in <root>.test5' type=<root>.A origin=null
+          $receiver: GET_VAR 'val tmp_4: <root>.A [val] declared in <root>.test5' type=<root>.A origin=null
           i: TYPE_OP type=<root>.IFoo origin=SAM_CONVERSION typeOperand=<root>.IFoo
-            GET_VAR 'val tmp_9: kotlin.Function1<kotlin.Int, kotlin.Unit> [val] declared in <root>.test5' type=kotlin.Function1<kotlin.Int, kotlin.Unit> origin=null
+            GET_VAR 'val tmp_5: kotlin.Function1<kotlin.Int, kotlin.Unit> [val] declared in <root>.test5' type=kotlin.Function1<kotlin.Int, kotlin.Unit> origin=null
           newValue: CALL 'public final fun plus (other: kotlin.Int): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
             $this: CALL 'public final fun get (i: <root>.IFoo): kotlin.Int [operator] declared in <root>' type=kotlin.Int origin=null
-              $receiver: GET_VAR 'val tmp_8: <root>.A [val] declared in <root>.test5' type=<root>.A origin=null
+              $receiver: GET_VAR 'val tmp_4: <root>.A [val] declared in <root>.test5' type=<root>.A origin=null
               i: TYPE_OP type=<root>.IFoo origin=SAM_CONVERSION typeOperand=<root>.IFoo
-                GET_VAR 'val tmp_9: kotlin.Function1<kotlin.Int, kotlin.Unit> [val] declared in <root>.test5' type=kotlin.Function1<kotlin.Int, kotlin.Unit> origin=null
+                GET_VAR 'val tmp_5: kotlin.Function1<kotlin.Int, kotlin.Unit> [val] declared in <root>.test5' type=kotlin.Function1<kotlin.Int, kotlin.Unit> origin=null
             other: CONST Int type=kotlin.Int value=1
   FUN name:test6 visibility:public modality:FINAL <> (a:kotlin.Any) returnType:kotlin.Unit
     VALUE_PARAMETER name:a index:0 type:kotlin.Any
@@ -200,16 +180,16 @@ FILE fqName:<root> fileName:/caoWithAdaptationForSam.kt
           TYPE_OP type=kotlin.Function1<kotlin.Int, kotlin.Unit> origin=IMPLICIT_CAST typeOperand=kotlin.Function1<kotlin.Int, kotlin.Unit>
             GET_VAR 'a: kotlin.Any declared in <root>.test6' type=kotlin.Any origin=null
       BLOCK type=kotlin.Unit origin=null
-        VAR IR_TEMPORARY_VARIABLE name:tmp_10 type:<root>.A [val]
+        VAR IR_TEMPORARY_VARIABLE name:tmp_6 type:<root>.A [val]
           GET_OBJECT 'CLASS OBJECT name:A modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.A
-        VAR IR_TEMPORARY_VARIABLE name:tmp_11 type:kotlin.Function1<kotlin.Int, kotlin.Unit> [val]
+        VAR IR_TEMPORARY_VARIABLE name:tmp_7 type:kotlin.Function1<kotlin.Int, kotlin.Unit> [val]
           TYPE_OP type=kotlin.Function1<kotlin.Int, kotlin.Unit> origin=IMPLICIT_CAST typeOperand=kotlin.Function1<kotlin.Int, kotlin.Unit>
             GET_VAR 'a: kotlin.Any declared in <root>.test6' type=kotlin.Any origin=null
         CALL 'public final fun set (i: <root>.IFoo, newValue: kotlin.Int): kotlin.Unit [operator] declared in <root>' type=kotlin.Unit origin=null
-          $receiver: GET_VAR 'val tmp_10: <root>.A [val] declared in <root>.test6' type=<root>.A origin=null
-          i: GET_VAR 'val tmp_11: kotlin.Function1<kotlin.Int, kotlin.Unit> [val] declared in <root>.test6' type=kotlin.Function1<kotlin.Int, kotlin.Unit> origin=null
+          $receiver: GET_VAR 'val tmp_6: <root>.A [val] declared in <root>.test6' type=<root>.A origin=null
+          i: GET_VAR 'val tmp_7: kotlin.Function1<kotlin.Int, kotlin.Unit> [val] declared in <root>.test6' type=kotlin.Function1<kotlin.Int, kotlin.Unit> origin=null
           newValue: CALL 'public final fun plus (other: kotlin.Int): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
             $this: CALL 'public final fun get (i: <root>.IFoo): kotlin.Int [operator] declared in <root>' type=kotlin.Int origin=null
-              $receiver: GET_VAR 'val tmp_10: <root>.A [val] declared in <root>.test6' type=<root>.A origin=null
-              i: GET_VAR 'val tmp_11: kotlin.Function1<kotlin.Int, kotlin.Unit> [val] declared in <root>.test6' type=kotlin.Function1<kotlin.Int, kotlin.Unit> origin=null
+              $receiver: GET_VAR 'val tmp_6: <root>.A [val] declared in <root>.test6' type=<root>.A origin=null
+              i: GET_VAR 'val tmp_7: kotlin.Function1<kotlin.Int, kotlin.Unit> [val] declared in <root>.test6' type=kotlin.Function1<kotlin.Int, kotlin.Unit> origin=null
             other: CONST Int type=kotlin.Int value=1

--- a/compiler/testData/ir/irText/expressions/lambdaInCAO.fir.kt.txt
+++ b/compiler/testData/ir/irText/expressions/lambdaInCAO.fir.kt.txt
@@ -16,7 +16,14 @@ fun test1(a: Any) {
 }
 
 fun test2(a: Any) {
-  error("") /* ErrorCallExpression */
+  { // BLOCK
+    val <<array>>: Any = a
+    val <<index_0>>: Function0<Unit> = local fun <anonymous>() {
+      return Unit
+    }
+
+    <<array>>.set(index = <<index_0>>, value = <<array>>.get(index = <<index_0>>).plus(other = 42))
+  }
 }
 
 fun test3(a: Any) {

--- a/compiler/testData/ir/irText/expressions/lambdaInCAO.fir.txt
+++ b/compiler/testData/ir/irText/expressions/lambdaInCAO.fir.txt
@@ -27,26 +27,42 @@ FILE fqName:<root> fileName:/lambdaInCAO.kt
   FUN name:test2 visibility:public modality:FINAL <> (a:kotlin.Any) returnType:kotlin.Unit
     VALUE_PARAMETER name:a index:0 type:kotlin.Any
     BLOCK_BODY
-      ERROR_CALL 'FirArraySetCall (resolve isn't supported yet)' type=kotlin.Unit
+      BLOCK type=kotlin.Unit origin=null
+        VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:kotlin.Any [val]
+          GET_VAR 'a: kotlin.Any declared in <root>.test2' type=kotlin.Any origin=null
+        VAR IR_TEMPORARY_VARIABLE name:tmp_1 type:kotlin.Function0<kotlin.Unit> [val]
+          FUN_EXPR type=kotlin.Function0<kotlin.Unit> origin=LAMBDA
+            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> () returnType:kotlin.Unit
+              BLOCK_BODY
+                RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.Unit declared in <root>.test2'
+                  GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Unit modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+        CALL 'public final fun set (index: kotlin.Function0<kotlin.Unit>, value: kotlin.Int): kotlin.Unit [operator] declared in <root>' type=kotlin.Unit origin=null
+          $receiver: GET_VAR 'val tmp_0: kotlin.Any [val] declared in <root>.test2' type=kotlin.Any origin=null
+          index: GET_VAR 'val tmp_1: kotlin.Function0<kotlin.Unit> [val] declared in <root>.test2' type=kotlin.Function0<kotlin.Unit> origin=null
+          value: CALL 'public final fun plus (other: kotlin.Int): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
+            $this: CALL 'public final fun get (index: kotlin.Function0<kotlin.Unit>): kotlin.Int [operator] declared in <root>' type=kotlin.Int origin=null
+              $receiver: GET_VAR 'val tmp_0: kotlin.Any [val] declared in <root>.test2' type=kotlin.Any origin=null
+              index: GET_VAR 'val tmp_1: kotlin.Function0<kotlin.Unit> [val] declared in <root>.test2' type=kotlin.Function0<kotlin.Unit> origin=null
+            other: CONST Int type=kotlin.Int value=42
   FUN name:test3 visibility:public modality:FINAL <> (a:kotlin.Any) returnType:kotlin.Unit
     VALUE_PARAMETER name:a index:0 type:kotlin.Any
     BLOCK_BODY
-      VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:kotlin.Any [val]
+      VAR IR_TEMPORARY_VARIABLE name:tmp_2 type:kotlin.Any [val]
         GET_VAR 'a: kotlin.Any declared in <root>.test3' type=kotlin.Any origin=null
-      VAR IR_TEMPORARY_VARIABLE name:tmp_1 type:kotlin.Function0<kotlin.Unit> [val]
+      VAR IR_TEMPORARY_VARIABLE name:tmp_3 type:kotlin.Function0<kotlin.Unit> [val]
         FUN_EXPR type=kotlin.Function0<kotlin.Unit> origin=LAMBDA
           FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> () returnType:kotlin.Unit
             BLOCK_BODY
               RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.Unit declared in <root>.test3'
                 GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Unit modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
-      VAR IR_TEMPORARY_VARIABLE name:tmp_2 type:kotlin.Int [val]
+      VAR IR_TEMPORARY_VARIABLE name:tmp_4 type:kotlin.Int [val]
         CALL 'public final fun get (index: kotlin.Function0<kotlin.Unit>): kotlin.Int [operator] declared in <root>' type=kotlin.Int origin=null
-          $receiver: GET_VAR 'val tmp_0: kotlin.Any [val] declared in <root>.test3' type=kotlin.Any origin=null
-          index: GET_VAR 'val tmp_1: kotlin.Function0<kotlin.Unit> [val] declared in <root>.test3' type=kotlin.Function0<kotlin.Unit> origin=null
+          $receiver: GET_VAR 'val tmp_2: kotlin.Any [val] declared in <root>.test3' type=kotlin.Any origin=null
+          index: GET_VAR 'val tmp_3: kotlin.Function0<kotlin.Unit> [val] declared in <root>.test3' type=kotlin.Function0<kotlin.Unit> origin=null
       CALL 'public final fun set (index: kotlin.Function0<kotlin.Unit>, value: kotlin.Int): kotlin.Unit [operator] declared in <root>' type=kotlin.Unit origin=null
-        $receiver: GET_VAR 'val tmp_0: kotlin.Any [val] declared in <root>.test3' type=kotlin.Any origin=null
-        index: GET_VAR 'val tmp_1: kotlin.Function0<kotlin.Unit> [val] declared in <root>.test3' type=kotlin.Function0<kotlin.Unit> origin=null
+        $receiver: GET_VAR 'val tmp_2: kotlin.Any [val] declared in <root>.test3' type=kotlin.Any origin=null
+        index: GET_VAR 'val tmp_3: kotlin.Function0<kotlin.Unit> [val] declared in <root>.test3' type=kotlin.Function0<kotlin.Unit> origin=null
         value: CALL 'public final fun inc (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
-          $this: GET_VAR 'val tmp_2: kotlin.Int [val] declared in <root>.test3' type=kotlin.Int origin=null
+          $this: GET_VAR 'val tmp_4: kotlin.Int [val] declared in <root>.test3' type=kotlin.Int origin=null
       TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
-        GET_VAR 'val tmp_2: kotlin.Int [val] declared in <root>.test3' type=kotlin.Int origin=null
+        GET_VAR 'val tmp_4: kotlin.Int [val] declared in <root>.test3' type=kotlin.Int origin=null


### PR DESCRIPTION
Otherwise, one trial with an unresolved reference (yet non error type) made the overall resolution ambiguous, while that candidate should have been discarded. This will resolve an issue on the full pipeline test for `tree-generator` module.