### PR TITLE
FIR2IR: cache type parameters in delegated property

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/fir/Fir2IrTextTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/fir/Fir2IrTextTestGenerated.java
@@ -1848,6 +1848,11 @@ public class Fir2IrTextTestGenerated extends AbstractFir2IrTextTest {
             runTest("compiler/testData/ir/irText/firProblems/putIfAbsent.kt");
         }
 
+        @TestMetadata("readWriteProperty.kt")
+        public void testReadWriteProperty() throws Exception {
+            runTest("compiler/testData/ir/irText/firProblems/readWriteProperty.kt");
+        }
+
         @TestMetadata("recursiveCapturedTypeInPropertyReference.kt")
         public void testRecursiveCapturedTypeInPropertyReference() throws Exception {
             runTest("compiler/testData/ir/irText/firProblems/recursiveCapturedTypeInPropertyReference.kt");

--- a/compiler/testData/ir/irText/firProblems/readWriteProperty.fir.kt.txt
+++ b/compiler/testData/ir/irText/firProblems/readWriteProperty.fir.kt.txt
@@ -1,0 +1,76 @@
+class SettingType<out V : Any> {
+  constructor(type: KClass<out V>) /* primary */ {
+    super/*Any*/()
+    /* <init>() */
+
+  }
+
+  val type: KClass<out V>
+    field = type
+    get
+
+}
+
+class SettingReference<V : Any, T : SettingType<V>> {
+  constructor(t: T, v: V) /* primary */ {
+    super/*Any*/()
+    /* <init>() */
+
+  }
+
+  var t: T
+    field = t
+    get
+    set
+
+  var v: V
+    field = v
+    get
+    set
+
+}
+
+class IdeWizard {
+  constructor() /* primary */ {
+    super/*Any*/()
+    /* <init>() */
+
+  }
+
+  var projectTemplate: Int? /* by */
+    field = <this>.setting<Int, SettingType<Int>>(reference = SettingReference<Int, SettingType<Int>>(t = SettingType<Int>(type = 42::class), v = 42))
+    get(): Int? {
+      return <this>.#projectTemplate$delegate.getValue(thisRef = <this>, property = IdeWizard::projectTemplate)
+    }
+    set(<set-?>: Int?) {
+      <this>.#projectTemplate$delegate.setValue(thisRef = <this>, property = IdeWizard::projectTemplate, value = <set-?>)
+    }
+
+  private fun <V : Any, T : SettingType<V>> setting(reference: SettingReference<V, T>): <no name provided><V, T> {
+    return { // BLOCK
+      local class <no name provided> : ReadWriteProperty<Any?, V?> {
+        private constructor() /* primary */ {
+          super/*Any*/()
+          /* <init>() */
+
+        }
+
+        override operator fun setValue(thisRef: Any?, property: KProperty<*>, value: V?) {
+          when {
+            EQEQ(arg0 = value, arg1 = null) -> return Unit
+          }
+          reference.<set-t>(<set-?> = SettingType<V>(type = value /*as V */::class) as T)
+          reference.<set-v>(<set-?> = value /*as V */)
+        }
+
+        override operator fun getValue(thisRef: Any?, property: KProperty<*>): V? {
+          return reference.<get-v>()
+        }
+
+      }
+
+      <no name provided>()
+    }
+  }
+
+}

--- a/compiler/testData/ir/irText/firProblems/readWriteProperty.fir.txt
+++ b/compiler/testData/ir/irText/firProblems/readWriteProperty.fir.txt
@@ -1,0 +1,214 @@
+FILE fqName:<root> fileName:/readWriteProperty.kt
+  CLASS CLASS name:SettingType modality:FINAL visibility:public superTypes:[kotlin.Any]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.SettingType<V of <root>.SettingType>
+    TYPE_PARAMETER name:V index:0 variance:out superTypes:[kotlin.Any]
+    CONSTRUCTOR visibility:public <> (type:kotlin.reflect.KClass<out V of <root>.SettingType>) returnType:<root>.SettingType<V of <root>.SettingType> [primary]
+      VALUE_PARAMETER name:type index:0 type:kotlin.reflect.KClass<out V of <root>.SettingType>
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:SettingType modality:FINAL visibility:public superTypes:[kotlin.Any]'
+    PROPERTY name:type visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:type type:kotlin.reflect.KClass<out V of <root>.SettingType> visibility:private [final]
+        EXPRESSION_BODY
+          GET_VAR 'type: kotlin.reflect.KClass<out V of <root>.SettingType> declared in <root>.SettingType.<init>' type=kotlin.reflect.KClass<out V of <root>.SettingType> origin=INITIALIZE_PROPERTY_FROM_PARAMETER
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-type> visibility:public modality:FINAL <> ($this:<root>.SettingType<V of <root>.SettingType>) returnType:kotlin.reflect.KClass<out V of <root>.SettingType>
+        correspondingProperty: PROPERTY name:type visibility:public modality:FINAL [val]
+        $this: VALUE_PARAMETER name:<this> type:<root>.SettingType<V of <root>.SettingType>
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-type> (): kotlin.reflect.KClass<out V of <root>.SettingType> declared in <root>.SettingType'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:type type:kotlin.reflect.KClass<out V of <root>.SettingType> visibility:private [final]' type=kotlin.reflect.KClass<out V of <root>.SettingType> origin=null
+              receiver: GET_VAR '<this>: <root>.SettingType<V of <root>.SettingType> declared in <root>.SettingType.<get-type>' type=<root>.SettingType<V of <root>.SettingType> origin=null
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean [operator] declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+  CLASS CLASS name:SettingReference modality:FINAL visibility:public superTypes:[kotlin.Any]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.SettingReference<V of <root>.SettingReference, T of <root>.SettingReference>
+    TYPE_PARAMETER name:V index:0 variance: superTypes:[kotlin.Any]
+    TYPE_PARAMETER name:T index:1 variance: superTypes:[<root>.SettingType<V of <root>.SettingReference>]
+    CONSTRUCTOR visibility:public <> (t:T of <root>.SettingReference, v:V of <root>.SettingReference) returnType:<root>.SettingReference<V of <root>.SettingReference, T of <root>.SettingReference> [primary]
+      VALUE_PARAMETER name:t index:0 type:T of <root>.SettingReference
+      VALUE_PARAMETER name:v index:1 type:V of <root>.SettingReference
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:SettingReference modality:FINAL visibility:public superTypes:[kotlin.Any]'
+    PROPERTY name:t visibility:public modality:FINAL [var]
+      FIELD PROPERTY_BACKING_FIELD name:t type:T of <root>.SettingReference visibility:private
+        EXPRESSION_BODY
+          GET_VAR 't: T of <root>.SettingReference declared in <root>.SettingReference.<init>' type=T of <root>.SettingReference origin=INITIALIZE_PROPERTY_FROM_PARAMETER
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-t> visibility:public modality:FINAL <> ($this:<root>.SettingReference<V of <root>.SettingReference, T of <root>.SettingReference>) returnType:T of <root>.SettingReference
+        correspondingProperty: PROPERTY name:t visibility:public modality:FINAL [var]
+        $this: VALUE_PARAMETER name:<this> type:<root>.SettingReference<V of <root>.SettingReference, T of <root>.SettingReference>
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-t> (): T of <root>.SettingReference declared in <root>.SettingReference'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:t type:T of <root>.SettingReference visibility:private' type=T of <root>.SettingReference origin=null
+              receiver: GET_VAR '<this>: <root>.SettingReference<V of <root>.SettingReference, T of <root>.SettingReference> declared in <root>.SettingReference.<get-t>' type=<root>.SettingReference<V of <root>.SettingReference, T of <root>.SettingReference> origin=null
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<set-t> visibility:public modality:FINAL <> ($this:<root>.SettingReference<V of <root>.SettingReference, T of <root>.SettingReference>, <set-?>:T of <root>.SettingReference) returnType:kotlin.Unit
+        correspondingProperty: PROPERTY name:t visibility:public modality:FINAL [var]
+        $this: VALUE_PARAMETER name:<this> type:<root>.SettingReference<V of <root>.SettingReference, T of <root>.SettingReference>
+        VALUE_PARAMETER name:<set-?> index:0 type:T of <root>.SettingReference
+        BLOCK_BODY
+          SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:t type:T of <root>.SettingReference visibility:private' type=kotlin.Unit origin=null
+            receiver: GET_VAR '<this>: <root>.SettingReference<V of <root>.SettingReference, T of <root>.SettingReference> declared in <root>.SettingReference.<set-t>' type=<root>.SettingReference<V of <root>.SettingReference, T of <root>.SettingReference> origin=null
+            value: GET_VAR '<set-?>: T of <root>.SettingReference declared in <root>.SettingReference.<set-t>' type=T of <root>.SettingReference origin=null
+    PROPERTY name:v visibility:public modality:FINAL [var]
+      FIELD PROPERTY_BACKING_FIELD name:v type:V of <root>.SettingReference visibility:private
+        EXPRESSION_BODY
+          GET_VAR 'v: V of <root>.SettingReference declared in <root>.SettingReference.<init>' type=V of <root>.SettingReference origin=INITIALIZE_PROPERTY_FROM_PARAMETER
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-v> visibility:public modality:FINAL <> ($this:<root>.SettingReference<V of <root>.SettingReference, T of <root>.SettingReference>) returnType:V of <root>.SettingReference
+        correspondingProperty: PROPERTY name:v visibility:public modality:FINAL [var]
+        $this: VALUE_PARAMETER name:<this> type:<root>.SettingReference<V of <root>.SettingReference, T of <root>.SettingReference>
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-v> (): V of <root>.SettingReference declared in <root>.SettingReference'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:v type:V of <root>.SettingReference visibility:private' type=V of <root>.SettingReference origin=null
+              receiver: GET_VAR '<this>: <root>.SettingReference<V of <root>.SettingReference, T of <root>.SettingReference> declared in <root>.SettingReference.<get-v>' type=<root>.SettingReference<V of <root>.SettingReference, T of <root>.SettingReference> origin=null
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<set-v> visibility:public modality:FINAL <> ($this:<root>.SettingReference<V of <root>.SettingReference, T of <root>.SettingReference>, <set-?>:V of <root>.SettingReference) returnType:kotlin.Unit
+        correspondingProperty: PROPERTY name:v visibility:public modality:FINAL [var]
+        $this: VALUE_PARAMETER name:<this> type:<root>.SettingReference<V of <root>.SettingReference, T of <root>.SettingReference>
+        VALUE_PARAMETER name:<set-?> index:0 type:V of <root>.SettingReference
+        BLOCK_BODY
+          SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:v type:V of <root>.SettingReference visibility:private' type=kotlin.Unit origin=null
+            receiver: GET_VAR '<this>: <root>.SettingReference<V of <root>.SettingReference, T of <root>.SettingReference> declared in <root>.SettingReference.<set-v>' type=<root>.SettingReference<V of <root>.SettingReference, T of <root>.SettingReference> origin=null
+            value: GET_VAR '<set-?>: V of <root>.SettingReference declared in <root>.SettingReference.<set-v>' type=V of <root>.SettingReference origin=null
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean [operator] declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+  CLASS CLASS name:IdeWizard modality:FINAL visibility:public superTypes:[kotlin.Any]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.IdeWizard
+    CONSTRUCTOR visibility:public <> () returnType:<root>.IdeWizard [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:IdeWizard modality:FINAL visibility:public superTypes:[kotlin.Any]'
+    PROPERTY name:projectTemplate visibility:public modality:FINAL [delegated,var]
+      FIELD PROPERTY_DELEGATE name:projectTemplate$delegate type:<root>.IdeWizard.setting.<no name provided><kotlin.Int, <root>.SettingType<kotlin.Int>> visibility:private [final]
+        EXPRESSION_BODY
+          CALL 'private final fun setting <V, T> (reference: <root>.SettingReference<V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting>): <root>.IdeWizard.setting.<no name provided><V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting> declared in <root>.IdeWizard' type=<root>.IdeWizard.setting.<no name provided><kotlin.Int, <root>.SettingType<kotlin.Int>> origin=null
+            <V>: kotlin.Int
+            <T>: <root>.SettingType<kotlin.Int>
+            $this: GET_VAR '<this>: <root>.IdeWizard declared in <root>.IdeWizard' type=<root>.IdeWizard origin=null
+            reference: CONSTRUCTOR_CALL 'public constructor <init> (t: T of <root>.SettingReference, v: V of <root>.SettingReference) [primary] declared in <root>.SettingReference' type=<root>.SettingReference<kotlin.Int, <root>.SettingType<kotlin.Int>> origin=null
+              <class: V>: kotlin.Int
+              <class: T>: <root>.SettingType<kotlin.Int>
+              t: CONSTRUCTOR_CALL 'public constructor <init> (type: kotlin.reflect.KClass<out V of <root>.SettingType>) [primary] declared in <root>.SettingType' type=<root>.SettingType<kotlin.Int> origin=null
+                <class: V>: kotlin.Int
+                type: GET_CLASS type=kotlin.reflect.KClass<kotlin.Int>
+                  CONST Int type=kotlin.Int value=42
+              v: CONST Int type=kotlin.Int value=42
+      FUN DELEGATED_PROPERTY_ACCESSOR name:<get-projectTemplate> visibility:public modality:FINAL <> ($this:<root>.IdeWizard) returnType:kotlin.Int?
+        correspondingProperty: PROPERTY name:projectTemplate visibility:public modality:FINAL [delegated,var]
+        $this: VALUE_PARAMETER name:<this> type:<root>.IdeWizard
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-projectTemplate> (): kotlin.Int? declared in <root>.IdeWizard'
+            CALL 'public final fun getValue (thisRef: kotlin.Any?, property: kotlin.reflect.KProperty<*>): V of <root>.IdeWizard.setting? [operator] declared in <root>.IdeWizard.setting.<no name provided>' type=kotlin.Int? origin=null
+              $this: GET_FIELD 'FIELD PROPERTY_DELEGATE name:projectTemplate$delegate type:<root>.IdeWizard.setting.<no name provided><kotlin.Int, <root>.SettingType<kotlin.Int>> visibility:private [final]' type=<root>.IdeWizard.setting.<no name provided><kotlin.Int, <root>.SettingType<kotlin.Int>> origin=null
+                receiver: GET_VAR '<this>: <root>.IdeWizard declared in <root>.IdeWizard.<get-projectTemplate>' type=<root>.IdeWizard origin=null
+              thisRef: GET_VAR '<this>: <root>.IdeWizard declared in <root>.IdeWizard.<get-projectTemplate>' type=<root>.IdeWizard origin=null
+              property: PROPERTY_REFERENCE 'public final projectTemplate: kotlin.Int? [delegated,var]' field=null getter='public final fun <get-projectTemplate> (): kotlin.Int? declared in <root>.IdeWizard' setter='public final fun <set-projectTemplate> (<set-?>: kotlin.Int?): kotlin.Unit declared in <root>.IdeWizard' type=kotlin.reflect.KMutableProperty1<<root>.IdeWizard, kotlin.Int?> origin=PROPERTY_REFERENCE_FOR_DELEGATE
+      FUN DELEGATED_PROPERTY_ACCESSOR name:<set-projectTemplate> visibility:public modality:FINAL <> ($this:<root>.IdeWizard, <set-?>:kotlin.Int?) returnType:kotlin.Unit
+        correspondingProperty: PROPERTY name:projectTemplate visibility:public modality:FINAL [delegated,var]
+        $this: VALUE_PARAMETER name:<this> type:<root>.IdeWizard
+        VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Int?
+        BLOCK_BODY
+          CALL 'public final fun setValue (thisRef: kotlin.Any?, property: kotlin.reflect.KProperty<*>, value: V of <root>.IdeWizard.setting?): kotlin.Unit [operator] declared in <root>.IdeWizard.setting.<no name provided>' type=kotlin.Unit origin=null
+            $this: GET_FIELD 'FIELD PROPERTY_DELEGATE name:projectTemplate$delegate type:<root>.IdeWizard.setting.<no name provided><kotlin.Int, <root>.SettingType<kotlin.Int>> visibility:private [final]' type=<root>.IdeWizard.setting.<no name provided><kotlin.Int, <root>.SettingType<kotlin.Int>> origin=null
+              receiver: GET_VAR '<this>: <root>.IdeWizard declared in <root>.IdeWizard.<set-projectTemplate>' type=<root>.IdeWizard origin=null
+            thisRef: GET_VAR '<this>: <root>.IdeWizard declared in <root>.IdeWizard.<set-projectTemplate>' type=<root>.IdeWizard origin=null
+            property: PROPERTY_REFERENCE 'public final projectTemplate: kotlin.Int? [delegated,var]' field=null getter='public final fun <get-projectTemplate> (): kotlin.Int? declared in <root>.IdeWizard' setter='public final fun <set-projectTemplate> (<set-?>: kotlin.Int?): kotlin.Unit declared in <root>.IdeWizard' type=kotlin.reflect.KMutableProperty1<<root>.IdeWizard, kotlin.Int?> origin=PROPERTY_REFERENCE_FOR_DELEGATE
+            value: GET_VAR '<set-?>: kotlin.Int? declared in <root>.IdeWizard.<set-projectTemplate>' type=kotlin.Int? origin=null
+    FUN name:setting visibility:private modality:FINAL <V, T> ($this:<root>.IdeWizard, reference:<root>.SettingReference<V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting>) returnType:<root>.IdeWizard.setting.<no name provided><V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting>
+      TYPE_PARAMETER name:V index:0 variance: superTypes:[kotlin.Any]
+      TYPE_PARAMETER name:T index:1 variance: superTypes:[<root>.SettingType<V of <root>.IdeWizard.setting>]
+      $this: VALUE_PARAMETER name:<this> type:<root>.IdeWizard
+      VALUE_PARAMETER name:reference index:0 type:<root>.SettingReference<V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting>
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='private final fun setting <V, T> (reference: <root>.SettingReference<V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting>): <root>.IdeWizard.setting.<no name provided><V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting> declared in <root>.IdeWizard'
+          BLOCK type=<root>.IdeWizard.setting.<no name provided><V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting> origin=OBJECT_LITERAL
+            CLASS CLASS name:<no name provided> modality:FINAL visibility:local superTypes:[kotlin.properties.ReadWriteProperty<kotlin.Any?, V of <root>.IdeWizard.setting?>]
+              $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.IdeWizard.setting.<no name provided><V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting>
+              CONSTRUCTOR visibility:private <> () returnType:<root>.IdeWizard.setting.<no name provided><V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting> [primary]
+                BLOCK_BODY
+                  DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in kotlin.Any'
+                  INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:<no name provided> modality:FINAL visibility:local superTypes:[kotlin.properties.ReadWriteProperty<kotlin.Any?, V of <root>.IdeWizard.setting?>]'
+              FUN name:setValue visibility:public modality:FINAL <> ($this:<root>.IdeWizard.setting.<no name provided><V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting>, thisRef:kotlin.Any?, property:kotlin.reflect.KProperty<*>, value:V of <root>.IdeWizard.setting?) returnType:kotlin.Unit [operator]
+                overridden:
+                  public abstract fun setValue (thisRef: T of kotlin.properties.ReadWriteProperty, property: kotlin.reflect.KProperty<*>, value: V of kotlin.properties.ReadWriteProperty): kotlin.Unit [operator] declared in kotlin.properties.ReadWriteProperty
+                $this: VALUE_PARAMETER name:<this> type:<root>.IdeWizard.setting.<no name provided><V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting>
+                VALUE_PARAMETER name:thisRef index:0 type:kotlin.Any?
+                VALUE_PARAMETER name:property index:1 type:kotlin.reflect.KProperty<*>
+                VALUE_PARAMETER name:value index:2 type:V of <root>.IdeWizard.setting?
+                BLOCK_BODY
+                  WHEN type=kotlin.Unit origin=IF
+                    BRANCH
+                      if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: GET_VAR 'value: V of <root>.IdeWizard.setting? declared in <root>.IdeWizard.setting.<no name provided>.setValue' type=V of <root>.IdeWizard.setting? origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
+                      then: RETURN type=kotlin.Nothing from='public final fun setValue (thisRef: kotlin.Any?, property: kotlin.reflect.KProperty<*>, value: V of <root>.IdeWizard.setting?): kotlin.Unit [operator] declared in <root>.IdeWizard.setting.<no name provided>'
+                        GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Unit modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+                  CALL 'public final fun <set-t> (<set-?>: T of <root>.SettingReference): kotlin.Unit declared in <root>.SettingReference' type=kotlin.Unit origin=EQ
+                    $this: GET_VAR 'reference: <root>.SettingReference<V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting> declared in <root>.IdeWizard.setting' type=<root>.SettingReference<V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting> origin=null
+                    <set-?>: TYPE_OP type=T of <root>.IdeWizard.setting origin=CAST typeOperand=T of <root>.IdeWizard.setting
+                      CONSTRUCTOR_CALL 'public constructor <init> (type: kotlin.reflect.KClass<out V of <root>.SettingType>) [primary] declared in <root>.SettingType' type=<root>.SettingType<V of <root>.IdeWizard.setting> origin=null
+                        <class: V>: V of <root>.IdeWizard.setting
+                        type: GET_CLASS type=kotlin.reflect.KClass<V of <root>.IdeWizard.setting>
+                          TYPE_OP type=V of <root>.IdeWizard.setting origin=IMPLICIT_CAST typeOperand=V of <root>.IdeWizard.setting
+                            GET_VAR 'value: V of <root>.IdeWizard.setting? declared in <root>.IdeWizard.setting.<no name provided>.setValue' type=V of <root>.IdeWizard.setting? origin=null
+                  CALL 'public final fun <set-v> (<set-?>: V of <root>.SettingReference): kotlin.Unit declared in <root>.SettingReference' type=kotlin.Unit origin=EQ
+                    $this: GET_VAR 'reference: <root>.SettingReference<V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting> declared in <root>.IdeWizard.setting' type=<root>.SettingReference<V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting> origin=null
+                    <set-?>: TYPE_OP type=V of <root>.IdeWizard.setting origin=IMPLICIT_CAST typeOperand=V of <root>.IdeWizard.setting
+                      GET_VAR 'value: V of <root>.IdeWizard.setting? declared in <root>.IdeWizard.setting.<no name provided>.setValue' type=V of <root>.IdeWizard.setting? origin=null
+              FUN name:getValue visibility:public modality:FINAL <> ($this:<root>.IdeWizard.setting.<no name provided><V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting>, thisRef:kotlin.Any?, property:kotlin.reflect.KProperty<*>) returnType:V of <root>.IdeWizard.setting? [operator]
+                overridden:
+                  public abstract fun getValue (thisRef: T of kotlin.properties.ReadWriteProperty, property: kotlin.reflect.KProperty<*>): V of kotlin.properties.ReadWriteProperty [operator] declared in kotlin.properties.ReadWriteProperty
+                $this: VALUE_PARAMETER name:<this> type:<root>.IdeWizard.setting.<no name provided><V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting>
+                VALUE_PARAMETER name:thisRef index:0 type:kotlin.Any?
+                VALUE_PARAMETER name:property index:1 type:kotlin.reflect.KProperty<*>
+                BLOCK_BODY
+                  RETURN type=kotlin.Nothing from='public final fun getValue (thisRef: kotlin.Any?, property: kotlin.reflect.KProperty<*>): V of <root>.IdeWizard.setting? [operator] declared in <root>.IdeWizard.setting.<no name provided>'
+                    CALL 'public final fun <get-v> (): V of <root>.SettingReference declared in <root>.SettingReference' type=V of <root>.IdeWizard.setting origin=GET_PROPERTY
+                      $this: GET_VAR 'reference: <root>.SettingReference<V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting> declared in <root>.IdeWizard.setting' type=<root>.SettingReference<V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting> origin=null
+              FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+                overridden:
+                  public open fun equals (other: kotlin.Any?): kotlin.Boolean [operator] declared in kotlin.Any
+                $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+                VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+              FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+                overridden:
+                  public open fun hashCode (): kotlin.Int declared in kotlin.Any
+                $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+              FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+                overridden:
+                  public open fun toString (): kotlin.String declared in kotlin.Any
+                $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+            CONSTRUCTOR_CALL 'private constructor <init> () [primary] declared in <root>.IdeWizard.setting.<no name provided>' type=<root>.IdeWizard.setting.<no name provided><V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting> origin=OBJECT_LITERAL
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean [operator] declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any

--- a/compiler/testData/ir/irText/firProblems/readWriteProperty.kt
+++ b/compiler/testData/ir/irText/firProblems/readWriteProperty.kt
@@ -1,0 +1,32 @@
+// WITH_RUNTIME
+// WITH_REFLECT
+
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KClass
+import kotlin.reflect.KProperty
+
+class SettingType<out V : Any>(
+    val type : KClass<out V>
+)
+
+class SettingReference<V : Any, T : SettingType<V>>(
+    var t : T
+    var v : V
+)
+
+class IdeWizard {
+    var projectTemplate by setting(SettingReference(SettingType(42::class), 42))
+
+    private fun <V : Any, T : SettingType<V>> setting(reference: SettingReference<V, T>) =
+        object : ReadWriteProperty<Any?, V?> {
+            override fun setValue(thisRef: Any?, property: KProperty<*>, value: V?) {
+                if (value == null) return
+                reference.t = SettingType(value::class) as T
+                reference.v = value
+            }
+
+            override fun getValue(thisRef: Any?, property: KProperty<*>): V? {
+                return reference.v
+            }
+        }
+}

--- a/compiler/testData/ir/irText/firProblems/readWriteProperty.kt.txt
+++ b/compiler/testData/ir/irText/firProblems/readWriteProperty.kt.txt
@@ -1,0 +1,76 @@
+class SettingType<out V : Any> {
+  constructor(type: KClass<out V>) /* primary */ {
+    super/*Any*/()
+    /* <init>() */
+
+  }
+
+  val type: KClass<out V>
+    field = type
+    get
+
+}
+
+class SettingReference<V : Any, T : SettingType<V>> {
+  constructor(t: T, v: V) /* primary */ {
+    super/*Any*/()
+    /* <init>() */
+
+  }
+
+  var t: T
+    field = t
+    get
+    set
+
+  var v: V
+    field = v
+    get
+    set
+
+}
+
+class IdeWizard {
+  constructor() /* primary */ {
+    super/*Any*/()
+    /* <init>() */
+
+  }
+
+  var projectTemplate: Int? /* by */
+    field = <this>.setting<Int, SettingType<Int>>(reference = SettingReference<Int, SettingType<Int>>(t = SettingType<Int>(type = 42::class), v = 42))
+    get(): Int? {
+      return <this>.#projectTemplate$delegate.getValue(thisRef = <this>, property = IdeWizard::projectTemplate)
+    }
+    set(<set-?>: Int?) {
+      return <this>.#projectTemplate$delegate.setValue(thisRef = <this>, property = IdeWizard::projectTemplate, value = <set-?>)
+    }
+
+  private fun <V : Any, T : SettingType<V>> setting(reference: SettingReference<V, T>): <no name provided><V, T> {
+    return { // BLOCK
+      local class <no name provided> : ReadWriteProperty<Any?, V?> {
+        constructor() /* primary */ {
+          super/*Any*/()
+          /* <init>() */
+
+        }
+
+        override operator fun setValue(thisRef: Any?, property: KProperty<*>, value: V?) {
+          when {
+            EQEQ(arg0 = value, arg1 = null) -> return Unit
+          }
+          reference.<set-t>(<set-?> = SettingType<V>(type = value::class) as T)
+          reference.<set-v>(<set-?> = value)
+        }
+
+        override operator fun getValue(thisRef: Any?, property: KProperty<*>): V? {
+          return reference.<get-v>()
+        }
+
+      }
+
+      <no name provided>()
+    }
+  }
+
+}

--- a/compiler/testData/ir/irText/firProblems/readWriteProperty.txt
+++ b/compiler/testData/ir/irText/firProblems/readWriteProperty.txt
@@ -1,0 +1,213 @@
+FILE fqName:<root> fileName:/readWriteProperty.kt
+  CLASS CLASS name:SettingType modality:FINAL visibility:public superTypes:[kotlin.Any]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.SettingType<V of <root>.SettingType>
+    TYPE_PARAMETER name:V index:0 variance:out superTypes:[kotlin.Any]
+    CONSTRUCTOR visibility:public <> (type:kotlin.reflect.KClass<out V of <root>.SettingType>) returnType:<root>.SettingType<V of <root>.SettingType> [primary]
+      VALUE_PARAMETER name:type index:0 type:kotlin.reflect.KClass<out V of <root>.SettingType>
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:SettingType modality:FINAL visibility:public superTypes:[kotlin.Any]'
+    PROPERTY name:type visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:type type:kotlin.reflect.KClass<out V of <root>.SettingType> visibility:private [final]
+        EXPRESSION_BODY
+          GET_VAR 'type: kotlin.reflect.KClass<out V of <root>.SettingType> declared in <root>.SettingType.<init>' type=kotlin.reflect.KClass<out V of <root>.SettingType> origin=INITIALIZE_PROPERTY_FROM_PARAMETER
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-type> visibility:public modality:FINAL <> ($this:<root>.SettingType<V of <root>.SettingType>) returnType:kotlin.reflect.KClass<out V of <root>.SettingType>
+        correspondingProperty: PROPERTY name:type visibility:public modality:FINAL [val]
+        $this: VALUE_PARAMETER name:<this> type:<root>.SettingType<V of <root>.SettingType>
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-type> (): kotlin.reflect.KClass<out V of <root>.SettingType> declared in <root>.SettingType'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:type type:kotlin.reflect.KClass<out V of <root>.SettingType> visibility:private [final]' type=kotlin.reflect.KClass<out V of <root>.SettingType> origin=null
+              receiver: GET_VAR '<this>: <root>.SettingType<V of <root>.SettingType> declared in <root>.SettingType.<get-type>' type=<root>.SettingType<V of <root>.SettingType> origin=null
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean [operator] declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+  CLASS CLASS name:SettingReference modality:FINAL visibility:public superTypes:[kotlin.Any]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.SettingReference<V of <root>.SettingReference, T of <root>.SettingReference>
+    TYPE_PARAMETER name:V index:0 variance: superTypes:[kotlin.Any]
+    TYPE_PARAMETER name:T index:1 variance: superTypes:[<root>.SettingType<V of <root>.SettingReference>]
+    CONSTRUCTOR visibility:public <> (t:T of <root>.SettingReference, v:V of <root>.SettingReference) returnType:<root>.SettingReference<V of <root>.SettingReference, T of <root>.SettingReference> [primary]
+      VALUE_PARAMETER name:t index:0 type:T of <root>.SettingReference
+      VALUE_PARAMETER name:v index:1 type:V of <root>.SettingReference
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:SettingReference modality:FINAL visibility:public superTypes:[kotlin.Any]'
+    PROPERTY name:t visibility:public modality:FINAL [var]
+      FIELD PROPERTY_BACKING_FIELD name:t type:T of <root>.SettingReference visibility:private
+        EXPRESSION_BODY
+          GET_VAR 't: T of <root>.SettingReference declared in <root>.SettingReference.<init>' type=T of <root>.SettingReference origin=INITIALIZE_PROPERTY_FROM_PARAMETER
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-t> visibility:public modality:FINAL <> ($this:<root>.SettingReference<V of <root>.SettingReference, T of <root>.SettingReference>) returnType:T of <root>.SettingReference
+        correspondingProperty: PROPERTY name:t visibility:public modality:FINAL [var]
+        $this: VALUE_PARAMETER name:<this> type:<root>.SettingReference<V of <root>.SettingReference, T of <root>.SettingReference>
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-t> (): T of <root>.SettingReference declared in <root>.SettingReference'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:t type:T of <root>.SettingReference visibility:private' type=T of <root>.SettingReference origin=null
+              receiver: GET_VAR '<this>: <root>.SettingReference<V of <root>.SettingReference, T of <root>.SettingReference> declared in <root>.SettingReference.<get-t>' type=<root>.SettingReference<V of <root>.SettingReference, T of <root>.SettingReference> origin=null
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<set-t> visibility:public modality:FINAL <> ($this:<root>.SettingReference<V of <root>.SettingReference, T of <root>.SettingReference>, <set-?>:T of <root>.SettingReference) returnType:kotlin.Unit
+        correspondingProperty: PROPERTY name:t visibility:public modality:FINAL [var]
+        $this: VALUE_PARAMETER name:<this> type:<root>.SettingReference<V of <root>.SettingReference, T of <root>.SettingReference>
+        VALUE_PARAMETER name:<set-?> index:0 type:T of <root>.SettingReference
+        BLOCK_BODY
+          SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:t type:T of <root>.SettingReference visibility:private' type=kotlin.Unit origin=null
+            receiver: GET_VAR '<this>: <root>.SettingReference<V of <root>.SettingReference, T of <root>.SettingReference> declared in <root>.SettingReference.<set-t>' type=<root>.SettingReference<V of <root>.SettingReference, T of <root>.SettingReference> origin=null
+            value: GET_VAR '<set-?>: T of <root>.SettingReference declared in <root>.SettingReference.<set-t>' type=T of <root>.SettingReference origin=null
+    PROPERTY name:v visibility:public modality:FINAL [var]
+      FIELD PROPERTY_BACKING_FIELD name:v type:V of <root>.SettingReference visibility:private
+        EXPRESSION_BODY
+          GET_VAR 'v: V of <root>.SettingReference declared in <root>.SettingReference.<init>' type=V of <root>.SettingReference origin=INITIALIZE_PROPERTY_FROM_PARAMETER
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-v> visibility:public modality:FINAL <> ($this:<root>.SettingReference<V of <root>.SettingReference, T of <root>.SettingReference>) returnType:V of <root>.SettingReference
+        correspondingProperty: PROPERTY name:v visibility:public modality:FINAL [var]
+        $this: VALUE_PARAMETER name:<this> type:<root>.SettingReference<V of <root>.SettingReference, T of <root>.SettingReference>
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-v> (): V of <root>.SettingReference declared in <root>.SettingReference'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:v type:V of <root>.SettingReference visibility:private' type=V of <root>.SettingReference origin=null
+              receiver: GET_VAR '<this>: <root>.SettingReference<V of <root>.SettingReference, T of <root>.SettingReference> declared in <root>.SettingReference.<get-v>' type=<root>.SettingReference<V of <root>.SettingReference, T of <root>.SettingReference> origin=null
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<set-v> visibility:public modality:FINAL <> ($this:<root>.SettingReference<V of <root>.SettingReference, T of <root>.SettingReference>, <set-?>:V of <root>.SettingReference) returnType:kotlin.Unit
+        correspondingProperty: PROPERTY name:v visibility:public modality:FINAL [var]
+        $this: VALUE_PARAMETER name:<this> type:<root>.SettingReference<V of <root>.SettingReference, T of <root>.SettingReference>
+        VALUE_PARAMETER name:<set-?> index:0 type:V of <root>.SettingReference
+        BLOCK_BODY
+          SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:v type:V of <root>.SettingReference visibility:private' type=kotlin.Unit origin=null
+            receiver: GET_VAR '<this>: <root>.SettingReference<V of <root>.SettingReference, T of <root>.SettingReference> declared in <root>.SettingReference.<set-v>' type=<root>.SettingReference<V of <root>.SettingReference, T of <root>.SettingReference> origin=null
+            value: GET_VAR '<set-?>: V of <root>.SettingReference declared in <root>.SettingReference.<set-v>' type=V of <root>.SettingReference origin=null
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean [operator] declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+  CLASS CLASS name:IdeWizard modality:FINAL visibility:public superTypes:[kotlin.Any]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.IdeWizard
+    CONSTRUCTOR visibility:public <> () returnType:<root>.IdeWizard [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:IdeWizard modality:FINAL visibility:public superTypes:[kotlin.Any]'
+    PROPERTY name:projectTemplate visibility:public modality:FINAL [delegated,var]
+      FIELD PROPERTY_DELEGATE name:projectTemplate$delegate type:<root>.IdeWizard.setting.<no name provided><kotlin.Int, <root>.SettingType<kotlin.Int>> visibility:private [final]
+        EXPRESSION_BODY
+          CALL 'private final fun setting <V, T> (reference: <root>.SettingReference<V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting>): <root>.IdeWizard.setting.<no name provided><V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting> declared in <root>.IdeWizard' type=<root>.IdeWizard.setting.<no name provided><kotlin.Int, <root>.SettingType<kotlin.Int>> origin=null
+            <V>: kotlin.Int
+            <T>: <root>.SettingType<kotlin.Int>
+            $this: GET_VAR '<this>: <root>.IdeWizard declared in <root>.IdeWizard' type=<root>.IdeWizard origin=null
+            reference: CONSTRUCTOR_CALL 'public constructor <init> (t: T of <root>.SettingReference, v: V of <root>.SettingReference) [primary] declared in <root>.SettingReference' type=<root>.SettingReference<kotlin.Int, <root>.SettingType<kotlin.Int>> origin=null
+              <class: V>: kotlin.Int
+              <class: T>: <root>.SettingType<kotlin.Int>
+              t: CONSTRUCTOR_CALL 'public constructor <init> (type: kotlin.reflect.KClass<out V of <root>.SettingType>) [primary] declared in <root>.SettingType' type=<root>.SettingType<kotlin.Int> origin=null
+                <class: V>: kotlin.Int
+                type: GET_CLASS type=kotlin.reflect.KClass<out kotlin.Int>
+                  CONST Int type=kotlin.Int value=42
+              v: CONST Int type=kotlin.Int value=42
+      FUN DELEGATED_PROPERTY_ACCESSOR name:<get-projectTemplate> visibility:public modality:FINAL <> ($this:<root>.IdeWizard) returnType:kotlin.Int?
+        correspondingProperty: PROPERTY name:projectTemplate visibility:public modality:FINAL [delegated,var]
+        $this: VALUE_PARAMETER name:<this> type:<root>.IdeWizard
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-projectTemplate> (): kotlin.Int? declared in <root>.IdeWizard'
+            CALL 'public open fun getValue (thisRef: kotlin.Any?, property: kotlin.reflect.KProperty<*>): V of <root>.IdeWizard.setting? [operator] declared in <root>.IdeWizard.setting.<no name provided>' type=kotlin.Int? origin=null
+              $this: GET_FIELD 'FIELD PROPERTY_DELEGATE name:projectTemplate$delegate type:<root>.IdeWizard.setting.<no name provided><kotlin.Int, <root>.SettingType<kotlin.Int>> visibility:private [final]' type=<root>.IdeWizard.setting.<no name provided><kotlin.Int, <root>.SettingType<kotlin.Int>> origin=null
+                receiver: GET_VAR '<this>: <root>.IdeWizard declared in <root>.IdeWizard.<get-projectTemplate>' type=<root>.IdeWizard origin=null
+              thisRef: GET_VAR '<this>: <root>.IdeWizard declared in <root>.IdeWizard.<get-projectTemplate>' type=<root>.IdeWizard origin=null
+              property: PROPERTY_REFERENCE 'public final projectTemplate: kotlin.Int? [delegated,var]' field=null getter='public final fun <get-projectTemplate> (): kotlin.Int? declared in <root>.IdeWizard' setter='public final fun <set-projectTemplate> (<set-?>: kotlin.Int?): kotlin.Unit declared in <root>.IdeWizard' type=kotlin.reflect.KMutableProperty1<<root>.IdeWizard, kotlin.Int?> origin=PROPERTY_REFERENCE_FOR_DELEGATE
+      FUN DELEGATED_PROPERTY_ACCESSOR name:<set-projectTemplate> visibility:public modality:FINAL <> ($this:<root>.IdeWizard, <set-?>:kotlin.Int?) returnType:kotlin.Unit
+        correspondingProperty: PROPERTY name:projectTemplate visibility:public modality:FINAL [delegated,var]
+        $this: VALUE_PARAMETER name:<this> type:<root>.IdeWizard
+        VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Int?
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <set-projectTemplate> (<set-?>: kotlin.Int?): kotlin.Unit declared in <root>.IdeWizard'
+            CALL 'public open fun setValue (thisRef: kotlin.Any?, property: kotlin.reflect.KProperty<*>, value: V of <root>.IdeWizard.setting?): kotlin.Unit [operator] declared in <root>.IdeWizard.setting.<no name provided>' type=kotlin.Unit origin=null
+              $this: GET_FIELD 'FIELD PROPERTY_DELEGATE name:projectTemplate$delegate type:<root>.IdeWizard.setting.<no name provided><kotlin.Int, <root>.SettingType<kotlin.Int>> visibility:private [final]' type=<root>.IdeWizard.setting.<no name provided><kotlin.Int, <root>.SettingType<kotlin.Int>> origin=null
+                receiver: GET_VAR '<this>: <root>.IdeWizard declared in <root>.IdeWizard.<set-projectTemplate>' type=<root>.IdeWizard origin=null
+              thisRef: GET_VAR '<this>: <root>.IdeWizard declared in <root>.IdeWizard.<set-projectTemplate>' type=<root>.IdeWizard origin=null
+              property: PROPERTY_REFERENCE 'public final projectTemplate: kotlin.Int? [delegated,var]' field=null getter='public final fun <get-projectTemplate> (): kotlin.Int? declared in <root>.IdeWizard' setter='public final fun <set-projectTemplate> (<set-?>: kotlin.Int?): kotlin.Unit declared in <root>.IdeWizard' type=kotlin.reflect.KMutableProperty1<<root>.IdeWizard, kotlin.Int?> origin=PROPERTY_REFERENCE_FOR_DELEGATE
+              value: GET_VAR '<set-?>: kotlin.Int? declared in <root>.IdeWizard.<set-projectTemplate>' type=kotlin.Int? origin=null
+    FUN name:setting visibility:private modality:FINAL <V, T> ($this:<root>.IdeWizard, reference:<root>.SettingReference<V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting>) returnType:<root>.IdeWizard.setting.<no name provided><V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting>
+      TYPE_PARAMETER name:V index:0 variance: superTypes:[kotlin.Any]
+      TYPE_PARAMETER name:T index:1 variance: superTypes:[<root>.SettingType<V of <root>.IdeWizard.setting>]
+      $this: VALUE_PARAMETER name:<this> type:<root>.IdeWizard
+      VALUE_PARAMETER name:reference index:0 type:<root>.SettingReference<V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting>
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='private final fun setting <V, T> (reference: <root>.SettingReference<V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting>): <root>.IdeWizard.setting.<no name provided><V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting> declared in <root>.IdeWizard'
+          BLOCK type=<root>.IdeWizard.setting.<no name provided><V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting> origin=OBJECT_LITERAL
+            CLASS CLASS name:<no name provided> modality:FINAL visibility:local superTypes:[kotlin.properties.ReadWriteProperty<kotlin.Any?, V of <root>.IdeWizard.setting?>]
+              $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.IdeWizard.setting.<no name provided><V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting>
+              CONSTRUCTOR visibility:public <> () returnType:<root>.IdeWizard.setting.<no name provided><V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting> [primary]
+                BLOCK_BODY
+                  DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in kotlin.Any'
+                  INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:<no name provided> modality:FINAL visibility:local superTypes:[kotlin.properties.ReadWriteProperty<kotlin.Any?, V of <root>.IdeWizard.setting?>]'
+              FUN name:setValue visibility:public modality:OPEN <> ($this:<root>.IdeWizard.setting.<no name provided><V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting>, thisRef:kotlin.Any?, property:kotlin.reflect.KProperty<*>, value:V of <root>.IdeWizard.setting?) returnType:kotlin.Unit [operator]
+                overridden:
+                  public abstract fun setValue (thisRef: T of kotlin.properties.ReadWriteProperty, property: kotlin.reflect.KProperty<*>, value: V of kotlin.properties.ReadWriteProperty): kotlin.Unit [operator] declared in kotlin.properties.ReadWriteProperty
+                $this: VALUE_PARAMETER name:<this> type:<root>.IdeWizard.setting.<no name provided><V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting>
+                VALUE_PARAMETER name:thisRef index:0 type:kotlin.Any?
+                VALUE_PARAMETER name:property index:1 type:kotlin.reflect.KProperty<*>
+                VALUE_PARAMETER name:value index:2 type:V of <root>.IdeWizard.setting?
+                BLOCK_BODY
+                  WHEN type=kotlin.Unit origin=IF
+                    BRANCH
+                      if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        arg0: GET_VAR 'value: V of <root>.IdeWizard.setting? declared in <root>.IdeWizard.setting.<no name provided>.setValue' type=V of <root>.IdeWizard.setting? origin=null
+                        arg1: CONST Null type=kotlin.Nothing? value=null
+                      then: RETURN type=kotlin.Nothing from='public open fun setValue (thisRef: kotlin.Any?, property: kotlin.reflect.KProperty<*>, value: V of <root>.IdeWizard.setting?): kotlin.Unit [operator] declared in <root>.IdeWizard.setting.<no name provided>'
+                        GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Unit modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+                  CALL 'public final fun <set-t> (<set-?>: T of <root>.SettingReference): kotlin.Unit declared in <root>.SettingReference' type=kotlin.Unit origin=EQ
+                    $this: GET_VAR 'reference: <root>.SettingReference<V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting> declared in <root>.IdeWizard.setting' type=<root>.SettingReference<V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting> origin=null
+                    <set-?>: TYPE_OP type=T of <root>.IdeWizard.setting origin=CAST typeOperand=T of <root>.IdeWizard.setting
+                      CONSTRUCTOR_CALL 'public constructor <init> (type: kotlin.reflect.KClass<out V of <root>.SettingType>) [primary] declared in <root>.SettingType' type=<root>.SettingType<V of <root>.IdeWizard.setting> origin=null
+                        <class: V>: V of <root>.IdeWizard.setting
+                        type: GET_CLASS type=kotlin.reflect.KClass<out V of <root>.IdeWizard.setting>
+                          GET_VAR 'value: V of <root>.IdeWizard.setting? declared in <root>.IdeWizard.setting.<no name provided>.setValue' type=V of <root>.IdeWizard.setting? origin=null
+                  CALL 'public final fun <set-v> (<set-?>: V of <root>.SettingReference): kotlin.Unit declared in <root>.SettingReference' type=kotlin.Unit origin=EQ
+                    $this: GET_VAR 'reference: <root>.SettingReference<V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting> declared in <root>.IdeWizard.setting' type=<root>.SettingReference<V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting> origin=null
+                    <set-?>: GET_VAR 'value: V of <root>.IdeWizard.setting? declared in <root>.IdeWizard.setting.<no name provided>.setValue' type=V of <root>.IdeWizard.setting? origin=null
+              FUN name:getValue visibility:public modality:OPEN <> ($this:<root>.IdeWizard.setting.<no name provided><V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting>, thisRef:kotlin.Any?, property:kotlin.reflect.KProperty<*>) returnType:V of <root>.IdeWizard.setting? [operator]
+                overridden:
+                  public abstract fun getValue (thisRef: T of kotlin.properties.ReadWriteProperty, property: kotlin.reflect.KProperty<*>): V of kotlin.properties.ReadWriteProperty [operator] declared in kotlin.properties.ReadWriteProperty
+                $this: VALUE_PARAMETER name:<this> type:<root>.IdeWizard.setting.<no name provided><V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting>
+                VALUE_PARAMETER name:thisRef index:0 type:kotlin.Any?
+                VALUE_PARAMETER name:property index:1 type:kotlin.reflect.KProperty<*>
+                BLOCK_BODY
+                  RETURN type=kotlin.Nothing from='public open fun getValue (thisRef: kotlin.Any?, property: kotlin.reflect.KProperty<*>): V of <root>.IdeWizard.setting? [operator] declared in <root>.IdeWizard.setting.<no name provided>'
+                    CALL 'public final fun <get-v> (): V of <root>.SettingReference declared in <root>.SettingReference' type=V of <root>.IdeWizard.setting origin=GET_PROPERTY
+                      $this: GET_VAR 'reference: <root>.SettingReference<V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting> declared in <root>.IdeWizard.setting' type=<root>.SettingReference<V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting> origin=null
+              FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+                overridden:
+                  public open fun equals (other: kotlin.Any?): kotlin.Boolean [fake_override,operator] declared in kotlin.properties.ReadWriteProperty
+                $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+                VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+              FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+                overridden:
+                  public open fun hashCode (): kotlin.Int [fake_override] declared in kotlin.properties.ReadWriteProperty
+                $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+              FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+                overridden:
+                  public open fun toString (): kotlin.String [fake_override] declared in kotlin.properties.ReadWriteProperty
+                $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+            CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in <root>.IdeWizard.setting.<no name provided>' type=<root>.IdeWizard.setting.<no name provided><V of <root>.IdeWizard.setting, T of <root>.IdeWizard.setting> origin=OBJECT_LITERAL
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean [operator] declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any

--- a/compiler/tests-gen/org/jetbrains/kotlin/ir/IrTextTestCaseGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/ir/IrTextTestCaseGenerated.java
@@ -1847,6 +1847,11 @@ public class IrTextTestCaseGenerated extends AbstractIrTextTestCase {
             runTest("compiler/testData/ir/irText/firProblems/putIfAbsent.kt");
         }
 
+        @TestMetadata("readWriteProperty.kt")
+        public void testReadWriteProperty() throws Exception {
+            runTest("compiler/testData/ir/irText/firProblems/readWriteProperty.kt");
+        }
+
         @TestMetadata("recursiveCapturedTypeInPropertyReference.kt")
         public void testRecursiveCapturedTypeInPropertyReference() throws Exception {
             runTest("compiler/testData/ir/irText/firProblems/recursiveCapturedTypeInPropertyReference.kt");


### PR DESCRIPTION
Otherwise, cache lookup for type parameters will fail like this: [KT-44030](https://youtrack.jetbrains.com/issue/KT-44030)

Together with #3987, full pipeline test with module `idea-new-project-wizard` will work properly.