### PR TITLE
KT-44020: Rename KAPT configuration used as task property

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kapt3AndroidIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kapt3AndroidIT.kt
@@ -90,6 +90,25 @@ class Kapt3Android34IT : Kapt3AndroidIT() {
         get() = GradleVersionRequired.Until("5.4.1")
 }
 
+class Kapt3Android42IT : Kapt3BaseIT() {
+    override val defaultGradleVersion: GradleVersionRequired
+        get() = GradleVersionRequired.AtLeast("6.7")
+
+    override fun defaultBuildOptions(): BuildOptions =
+        super.defaultBuildOptions().copy(androidGradlePluginVersion = AGPVersion.v4_2_0)
+
+    /** Regression test for https://youtrack.jetbrains.com/issue/KT-44020. */
+    @Test
+    fun testDatabindingWithAndroidX() {
+        val project = Project("android-databinding-androidX", directoryPrefix = "kapt2")
+
+        project.build("kaptDebugKotlin") {
+            assertSuccessful()
+            assertKaptSuccessful()
+        }
+    }
+}
+
 abstract class Kapt3AndroidIT : Kapt3BaseIT() {
     protected abstract val androidGradlePluginVersion: AGPVersion
 

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-databinding-androidX/app/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-databinding-androidX/app/build.gradle
@@ -1,0 +1,30 @@
+apply plugin: 'com.android.application'
+apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-kapt'
+
+android {
+    compileSdkVersion 24
+    buildToolsVersion "25.0.2"
+    defaultConfig {
+        applicationId "com.example.databinding"
+        minSdkVersion 21
+        targetSdkVersion 24
+        versionCode 1
+        versionName "1.0"
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+    }
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+    dataBinding {
+        enabled = true
+    }
+}
+
+dependencies {
+    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    compile 'com.android.support.constraint:constraint-layout:1.0.2'
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-databinding-androidX/app/src/main/AndroidManifest.xml
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-databinding-androidX/app/src/main/AndroidManifest.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.example.databinding">
+
+   <application />
+
+</manifest>

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-databinding-androidX/app/src/main/java/com/example/databinding/MyBindingMethods.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-databinding-androidX/app/src/main/java/com/example/databinding/MyBindingMethods.kt
@@ -1,0 +1,15 @@
+package com.example.databinding
+
+import androidx.databinding.BindingMethod
+import androidx.databinding.BindingMethods
+import android.widget.ImageView
+
+
+@BindingMethods(
+    BindingMethod(
+        type = ImageView::class,
+        attribute = "app:srcCompat",
+        method = "setImageResource"
+    )
+)
+class MyBindingMethods

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-databinding-androidX/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-databinding-androidX/build.gradle
@@ -1,0 +1,26 @@
+import org.gradle.util.VersionNumber
+
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
+
+buildscript {
+    repositories {
+        mavenLocal()
+        maven { url 'https://maven.google.com' }
+        jcenter()
+    }
+    dependencies {
+        classpath "com.android.tools.build:gradle:$android_tools_version"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+
+        // NOTE: Do not place your application dependencies here; they belong
+        // in the individual module build.gradle files
+    }
+}
+
+allprojects {
+    repositories {
+        mavenLocal()
+        maven { url 'https://maven.google.com' }
+        jcenter()
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-databinding-androidX/gradle.properties
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-databinding-androidX/gradle.properties
@@ -1,0 +1,2 @@
+android.enableJetifier=true
+android.useAndroidX=true

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-databinding-androidX/settings.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-databinding-androidX/settings.gradle
@@ -1,0 +1,1 @@
+include ':app'

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/Kapt3KotlinGradleSubplugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/Kapt3KotlinGradleSubplugin.kt
@@ -451,7 +451,7 @@ class Kapt3GradleSubplugin @Inject internal constructor(private val registry: To
             }
 
             val kaptClasspathConfiguration =
-                project.configurations.create("_kaptClasspath_" + kaptTask.name).setExtendsFrom(kaptClasspathConfigurations).also {
+                project.configurations.create("kaptClasspath_" + kaptTask.name).setExtendsFrom(kaptClasspathConfigurations).also {
                     it.isVisible = false
                     it.isCanBeConsumed = false
                 }


### PR DESCRIPTION
This is so AGP does not try to apply AndroidX substitution
to dependencies found in the annotation processor classpath.
AGP does this by checking if the configuration name starts
with "kapt".

Test: Kapt3Android42IT