### PR TITLE
FIR2IR: calculate IR parent for Java field ahead

### DIFF
--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrDeclarationStorage.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrDeclarationStorage.kt
@@ -1168,8 +1168,12 @@ class Fir2IrDeclarationStorage(
 
     fun getIrFieldSymbol(firFieldSymbol: FirFieldSymbol): IrSymbol {
         val fir = firFieldSymbol.fir
-        val irProperty = fieldCache[fir] ?: createIrField(fir).apply {
-            setAndModifyParent(findIrParent(fir))
+        val irProperty = fieldCache[fir] ?: run {
+            // In case of type parameters from the parent as the field's return type, find the parent ahead to cache type parameters.
+            val irParent = findIrParent(fir)
+            createIrField(fir).apply {
+                setAndModifyParent(irParent)
+            }
         }
         return irProperty.symbol
     }

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/fir/Fir2IrTextTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/fir/Fir2IrTextTestGenerated.java
@@ -1873,6 +1873,11 @@ public class Fir2IrTextTestGenerated extends AbstractFir2IrTextTest {
             runTest("compiler/testData/ir/irText/firProblems/throwableStackTrace.kt");
         }
 
+        @TestMetadata("typeParameterFromJavaClass.kt")
+        public void testTypeParameterFromJavaClass() throws Exception {
+            runTest("compiler/testData/ir/irText/firProblems/typeParameterFromJavaClass.kt");
+        }
+
         @TestMetadata("typeVariableAfterBuildMap.kt")
         public void testTypeVariableAfterBuildMap() throws Exception {
             runTest("compiler/testData/ir/irText/firProblems/typeVariableAfterBuildMap.kt");

--- a/compiler/testData/ir/irText/firProblems/typeParameterFromJavaClass.fir.kt.txt
+++ b/compiler/testData/ir/irText/firProblems/typeParameterFromJavaClass.fir.kt.txt
@@ -1,0 +1,6 @@
+fun foo(movedPaths: MutableList<Couple<FilePath>>) {
+  movedPaths.forEach<Couple<FilePath>>(action = local fun <anonymous>(it: Couple<FilePath>) {
+    it.#second.getName() /*~> Unit */
+  }
+)
+}

--- a/compiler/testData/ir/irText/firProblems/typeParameterFromJavaClass.fir.txt
+++ b/compiler/testData/ir/irText/firProblems/typeParameterFromJavaClass.fir.txt
@@ -1,0 +1,15 @@
+FILE fqName:<root> fileName:/typeParameterFromJavaClass.kt
+  FUN name:foo visibility:public modality:FINAL <> (movedPaths:kotlin.collections.MutableList<<root>.Couple<<root>.FilePath>>) returnType:kotlin.Unit
+    VALUE_PARAMETER name:movedPaths index:0 type:kotlin.collections.MutableList<<root>.Couple<<root>.FilePath>>
+    BLOCK_BODY
+      CALL 'public final fun forEach <T> (action: kotlin.Function1<T of kotlin.collections.forEach, kotlin.Unit>): kotlin.Unit [inline] declared in kotlin.collections' type=kotlin.Unit origin=null
+        <T>: <root>.Couple<<root>.FilePath>
+        $receiver: GET_VAR 'movedPaths: kotlin.collections.MutableList<<root>.Couple<<root>.FilePath>> declared in <root>.foo' type=kotlin.collections.MutableList<<root>.Couple<<root>.FilePath>> origin=null
+        action: FUN_EXPR type=kotlin.Function1<<root>.Couple<<root>.FilePath>, kotlin.Unit> origin=LAMBDA
+          FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> (it:<root>.Couple<<root>.FilePath>) returnType:kotlin.Unit
+            VALUE_PARAMETER name:it index:0 type:<root>.Couple<<root>.FilePath>
+            BLOCK_BODY
+              TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+                CALL 'public abstract fun getName (): kotlin.String? declared in <root>.FilePath' type=kotlin.String? origin=GET_PROPERTY
+                  $this: GET_FIELD 'FIELD IR_EXTERNAL_JAVA_DECLARATION_STUB name:second type:B of <root>.Pair? visibility:public [final]' type=<root>.FilePath? origin=GET_PROPERTY
+                    receiver: GET_VAR 'it: <root>.Couple<<root>.FilePath> declared in <root>.foo.<anonymous>' type=<root>.Couple<<root>.FilePath> origin=null

--- a/compiler/testData/ir/irText/firProblems/typeParameterFromJavaClass.kt
+++ b/compiler/testData/ir/irText/firProblems/typeParameterFromJavaClass.kt
@@ -1,0 +1,33 @@
+// FILE: Pair.java
+
+public class Pair<A, B> {
+    public final A first;
+    public final B second;
+
+    public Pair(A first, B second) {
+        this.first = first;
+        this.second = second;
+    }
+}
+
+// FILE: Couple.java
+
+public class Couple<T> extends Pair<T, T> {
+    public Couple(T first, T second) {
+        super(first, second);
+    }
+}
+
+// FILE: FilePath.java
+
+public interface FilePath {
+    String getName();
+}
+
+// FILE: typeParameterFromJavaClass.kt
+
+// WITH_RUNTIME
+
+fun foo(movedPaths: MutableList<Couple<FilePath>>) {
+    movedPaths.forEach { it.second.name }
+}

--- a/compiler/testData/ir/irText/firProblems/typeParameterFromJavaClass.kt.txt
+++ b/compiler/testData/ir/irText/firProblems/typeParameterFromJavaClass.kt.txt
@@ -1,0 +1,6 @@
+fun foo(movedPaths: MutableList<Couple<FilePath>>) {
+  movedPaths.forEach<Couple<FilePath>>(action = local fun <anonymous>(it: Couple<FilePath>) {
+    itsuper.#second /*!! FilePath */.getName() /*~> Unit */
+  }
+)
+}

--- a/compiler/testData/ir/irText/firProblems/typeParameterFromJavaClass.txt
+++ b/compiler/testData/ir/irText/firProblems/typeParameterFromJavaClass.txt
@@ -1,0 +1,16 @@
+FILE fqName:<root> fileName:/typeParameterFromJavaClass.kt
+  FUN name:foo visibility:public modality:FINAL <> (movedPaths:kotlin.collections.MutableList<<root>.Couple<<root>.FilePath>>) returnType:kotlin.Unit
+    VALUE_PARAMETER name:movedPaths index:0 type:kotlin.collections.MutableList<<root>.Couple<<root>.FilePath>>
+    BLOCK_BODY
+      CALL 'public final fun forEach <T> (action: kotlin.Function1<T of kotlin.collections.forEach, kotlin.Unit>): kotlin.Unit [inline] declared in kotlin.collections' type=kotlin.Unit origin=null
+        <T>: <root>.Couple<<root>.FilePath>
+        $receiver: GET_VAR 'movedPaths: kotlin.collections.MutableList<<root>.Couple<<root>.FilePath>> declared in <root>.foo' type=kotlin.collections.MutableList<<root>.Couple<<root>.FilePath>> origin=null
+        action: FUN_EXPR type=kotlin.Function1<<root>.Couple<<root>.FilePath>, kotlin.Unit> origin=LAMBDA
+          FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> (it:<root>.Couple<<root>.FilePath>) returnType:kotlin.Unit
+            VALUE_PARAMETER name:it index:0 type:<root>.Couple<<root>.FilePath>
+            BLOCK_BODY
+              TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+                CALL 'public abstract fun getName (): @[FlexibleNullability] kotlin.String? declared in <root>.FilePath' type=@[FlexibleNullability] kotlin.String? origin=GET_PROPERTY
+                  $this: TYPE_OP type=<root>.FilePath origin=IMPLICIT_NOTNULL typeOperand=<root>.FilePath
+                    GET_FIELD 'FIELD IR_EXTERNAL_JAVA_DECLARATION_STUB name:second type:@[FlexibleNullability] B of <root>.Pair? visibility:public [final]' type=@[FlexibleNullability] <root>.FilePath? origin=GET_PROPERTY
+                      receiver: GET_VAR 'it: <root>.Couple<<root>.FilePath> declared in <root>.foo.<anonymous>' type=<root>.Couple<<root>.FilePath> origin=null

--- a/compiler/tests-gen/org/jetbrains/kotlin/ir/IrTextTestCaseGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/ir/IrTextTestCaseGenerated.java
@@ -1872,6 +1872,11 @@ public class IrTextTestCaseGenerated extends AbstractIrTextTestCase {
             runTest("compiler/testData/ir/irText/firProblems/throwableStackTrace.kt");
         }
 
+        @TestMetadata("typeParameterFromJavaClass.kt")
+        public void testTypeParameterFromJavaClass() throws Exception {
+            runTest("compiler/testData/ir/irText/firProblems/typeParameterFromJavaClass.kt");
+        }
+
         @TestMetadata("typeVariableAfterBuildMap.kt")
         public void testTypeVariableAfterBuildMap() throws Exception {
             runTest("compiler/testData/ir/irText/firProblems/typeVariableAfterBuildMap.kt");


### PR DESCRIPTION
so as to cache type parameters from the parent if the field's return type is one of type parameters.

[KT-44032](https://youtrack.jetbrains.com/issue/KT-44032) (and module `idea-git`) fixed.