### PR TITLE
KGP - Create configurations that are not consumable

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinTargetConfigurator.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinTargetConfigurator.kt
@@ -274,6 +274,7 @@ abstract class AbstractKotlinTargetConfigurator<KotlinTargetType : KotlinTarget>
             val compileConfiguration = configurations.maybeCreate(compilation.deprecatedCompileConfigurationName).apply {
                 setupAsLocalTargetSpecificConfigurationIfSupported(target)
                 isVisible = false
+                isCanBeConsumed = false
                 isCanBeResolved = true // Needed for IDE import
                 description = "Dependencies for $compilation (deprecated, use '${compilation.implementationConfigurationName} ' instead)."
             }
@@ -297,6 +298,7 @@ abstract class AbstractKotlinTargetConfigurator<KotlinTargetType : KotlinTarget>
             val compileOnlyConfiguration = configurations.maybeCreate(compilation.compileOnlyConfigurationName).apply {
                 setupAsLocalTargetSpecificConfigurationIfSupported(target)
                 isVisible = false
+                isCanBeConsumed = false
                 isCanBeResolved = true // Needed for IDE import
                 description = "Compile only dependencies for $compilation."
             }
@@ -315,6 +317,7 @@ abstract class AbstractKotlinTargetConfigurator<KotlinTargetType : KotlinTarget>
                     setupAsLocalTargetSpecificConfigurationIfSupported(target)
                     extendsFrom(compileConfiguration)
                     isVisible = false
+                    isCanBeConsumed = false
                     isCanBeResolved = true // Needed for IDE import
                     description =
                         "Runtime dependencies for $compilation (deprecated, use '${compilation.runtimeOnlyConfigurationName} ' instead)."


### PR DESCRIPTION
Make sure to set isCanBeConsumed to false in order to
avoid making configurations consumable from other projects.

This is to tackle: https://issuetracker.google.com/129469650