### PR TITLE
FIR Java: Fix Java override ambiguity with vararg value type

### DIFF
--- a/compiler/fir/java/src/org/jetbrains/kotlin/fir/java/scopes/JavaOverrideChecker.kt
+++ b/compiler/fir/java/src/org/jetbrains/kotlin/fir/java/scopes/JavaOverrideChecker.kt
@@ -39,7 +39,7 @@ class JavaOverrideChecker internal constructor(
             val candidateTypeClassId = candidateType.fullyExpandedType(session).lookupTag.classId.let { it.readOnlyToMutable() ?: it }
             val baseTypeClassId = baseType.fullyExpandedType(session).lookupTag.classId.let { it.readOnlyToMutable() ?: it }
             if (candidateTypeClassId != baseTypeClassId) return false
-            if (!candidateTypeClassId.shortClassName.isSpecial && candidateTypeClassId.shortClassName.identifier == "Array") {
+            if (candidateTypeClassId == StandardClassIds.Array) {
                 assert(candidateType.typeArguments.size == 1) {
                     "Array type with unexpected number of type arguments: $candidateType"
                 }

--- a/compiler/fir/jvm/src/org/jetbrains/kotlin/fir/scopes/jvm/DescriptorUtils.kt
+++ b/compiler/fir/jvm/src/org/jetbrains/kotlin/fir/scopes/jvm/DescriptorUtils.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.fir.scopes.jvm
 
 import org.jetbrains.kotlin.fir.declarations.FirFunction
 import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
+import org.jetbrains.kotlin.fir.symbols.StandardClassIds
 import org.jetbrains.kotlin.fir.types.*
 import org.jetbrains.kotlin.fir.types.impl.FirImplicitAnyTypeRef
 import org.jetbrains.kotlin.fir.types.impl.FirImplicitNullableAnyTypeRef
@@ -101,8 +102,7 @@ private fun StringBuilder.appendConeType(coneType: ConeKotlinType) {
 
     fun appendClassLikeType(type: ConeClassLikeType) {
         val classId = type.lookupTag.classId
-        if (classId.shortClassName.isSpecial) return
-        if (classId.shortClassName.identifier == "Array") {
+        if (classId == StandardClassIds.Array) {
             append("[")
             type.typeArguments.forEach { typeArg ->
                 when (typeArg) {


### PR DESCRIPTION
Otherwise, as shown at [KT-44066](https://youtrack.jetbrains.com/issue/KT-44066), overrides from Java class with similar `vararg` value types, e.g., `...(File... p0)` v.s. `...(String... p0)` become ambiguous, resulting in signature clash during code gen.

[KT-44066](https://youtrack.jetbrains.com/issue/KT-44066) (and module `kotlin-annotation-processing-base`) fixed.