### PR TITLE
Kotlinc: Exclude module-info.class from resulting jar when "-include-…

### DIFF
--- a/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/CompileEnvironmentUtil.java
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/CompileEnvironmentUtil.java
@@ -19,6 +19,7 @@ package org.jetbrains.kotlin.cli.jvm.compiler;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.io.FileUtilRt;
 import kotlin.io.FilesKt;
+import kotlin.text.StringsKt;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.kotlin.backend.common.output.OutputFile;
@@ -130,6 +131,9 @@ public class CompileEnvironmentUtil {
                 JarEntry e = jis.getNextJarEntry();
                 if (e == null) {
                     break;
+                }
+                if (StringsKt.substringAfterLast(e.getName(), "/", e.getName()).equals("module-info.class")) {
+                    continue;
                 }
                 if (resetJarTimestamps) {
                     e.setTime(DOS_EPOCH);

--- a/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/CompileEnvironmentUtil.java
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/CompileEnvironmentUtil.java
@@ -129,19 +129,17 @@ public class CompileEnvironmentUtil {
         try (JarInputStream jis = new JarInputStream(new FileInputStream(jarPath))) {
             while (true) {
                 JarEntry e = jis.getNextJarEntry();
-                if (e == null) {
-                    break;
-                }
-                if (StringsKt.substringAfterLast(e.getName(), "/", e.getName()).equals("module-info.class")) {
+                if (e == null) break;
+
+                if (!FileUtilRt.extensionEquals(e.getName(), "class") ||
+                    StringsKt.substringAfterLast(e.getName(), "/", e.getName()).equals("module-info.class")) {
                     continue;
                 }
                 if (resetJarTimestamps) {
                     e.setTime(DOS_EPOCH);
                 }
-                if (FileUtilRt.extensionEquals(e.getName(), "class")) {
-                    stream.putNextEntry(e);
-                    FileUtil.copy(jis, stream);
-                }
+                stream.putNextEntry(e);
+                FileUtil.copy(jis, stream);
             }
         }
     }

--- a/compiler/tests/org/jetbrains/kotlin/cli/JarOutputTest.kt
+++ b/compiler/tests/org/jetbrains/kotlin/cli/JarOutputTest.kt
@@ -17,16 +17,14 @@
 package org.jetbrains.kotlin.cli
 
 import java.io.File
-import java.io.FileInputStream
-import java.util.jar.JarInputStream
-import java.util.zip.ZipEntry
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 import org.jetbrains.kotlin.cli.jvm.K2JVMCompiler
 import org.jetbrains.kotlin.cli.jvm.compiler.CompileEnvironmentUtil.DOS_EPOCH
 import org.jetbrains.kotlin.test.TestCaseWithTmpdir
+import java.util.jar.JarFile
 
-class DeterministicOutputTest : TestCaseWithTmpdir() {
+class JarOutputTest : TestCaseWithTmpdir() {
 
     fun testDeterministicOutput() {
         val fooKt = tmpdir.resolve("foo.kt").also {
@@ -63,21 +61,40 @@ class DeterministicOutputTest : TestCaseWithTmpdir() {
         assertNoTimestampsAreReset(jar)
     }
 
+    /**
+     *  KT-44078
+     */
+    fun testNoModuleInfoClass() {
+        val fooKt = tmpdir.resolve("foo.kt").also {
+            it.writeText("class Foo")
+        }
+        val jar = tmpdir.resolve("jarWithoutModuleInfoClass.jar")
+        AbstractCliTest.executeCompilerGrabOutput(
+            K2JVMCompiler(),
+            listOf(fooKt.path, "-d", jar.path, "-include-runtime")
+        )
+
+        assertNoModuleInfoClass(jar)
+    }
+
     private fun assertAllTimestampsAreReset(jar: File) {
-        val zis = JarInputStream(FileInputStream(jar))
-        var entry: ZipEntry? = zis.nextEntry
-        while (entry != null) {
+        for (entry in JarFile(jar).entries()) {
             assertEquals(entry.time, DOS_EPOCH, "$entry timestamp should be reset")
-            entry = zis.nextEntry
         }
     }
 
     private fun assertNoTimestampsAreReset(jar: File) {
-        val zis = JarInputStream(FileInputStream(jar))
-        var entry: ZipEntry? = zis.nextEntry
-        while (entry != null) {
+        for (entry in JarFile(jar).entries()) {
             assertNotEquals(entry.time, DOS_EPOCH, "$entry timestamp should not be reset")
-            entry = zis.nextEntry
+        }
+    }
+
+    private fun assertNoModuleInfoClass(jar: File) {
+        for (entry in JarFile(jar).entries()) {
+            assertNotEquals(
+                "module-info.class", entry.name.substringAfterLast("/"),
+                "$entry is expected to be excluded from the resulting jar"
+            )
         }
     }
 }


### PR DESCRIPTION
[KT-44078](https://youtrack.jetbrains.com/issue/KT-44078)
Exclude module-info.class from resulting jar when "-include-runtime" is specified
