### PR TITLE
KT-43818：NPM Dependencies already resolved and installed in Android Studio

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/KotlinNpmResolutionManager.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/KotlinNpmResolutionManager.kt
@@ -80,11 +80,11 @@ class KotlinNpmResolutionManager(private val nodeJsSettings: NodeJsRootExtension
     private val forceFullResolve: Boolean
         get() = isInIdeaSync
 
+    internal val resolver = KotlinRootNpmResolver(nodeJsSettings, forceFullResolve)
+
     @Volatile
     private var state: ResolutionState =
-        ResolutionState.Configuring(
-            KotlinRootNpmResolver(nodeJsSettings, forceFullResolve)
-        )
+        ResolutionState.Configuring(resolver)
 
     internal sealed class ResolutionState {
         abstract val npmProjects: List<NpmProject>
@@ -120,6 +120,9 @@ class KotlinNpmResolutionManager(private val nodeJsSettings: NodeJsRootExtension
 
     internal fun requireConfiguringState(): KotlinRootNpmResolver =
         (this.state as? ResolutionState.Configuring ?: error("NPM Dependencies already resolved and installed")).resolver
+
+    internal fun isConfiguringState(): Boolean =
+        this.state is ResolutionState.Configuring
 
     internal fun prepare() = prepareIfNeeded(requireNotPrepared = true)
 

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/tasks/KotlinPackageJsonTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/tasks/KotlinPackageJsonTask.kt
@@ -21,13 +21,20 @@ import org.jetbrains.kotlin.gradle.tasks.registerTask
 import java.io.File
 
 open class KotlinPackageJsonTask : DefaultTask() {
+
+    init {
+        onlyIf {
+            nodeJs.npmResolutionManager.isConfiguringState()
+        }
+    }
+
     private lateinit var nodeJs: NodeJsRootExtension
 
     @Transient
     private lateinit var compilation: KotlinJsCompilation
 
     private val compilationResolver
-        get() = nodeJs.npmResolutionManager.requireConfiguringState()[project][compilation]
+        get() = nodeJs.npmResolutionManager.resolver[project][compilation]
 
     private val producer: KotlinCompilationNpmResolver.PackageJsonProducer
         get() = compilationResolver.packageJsonProducer

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/tasks/RootPackageJsonTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/tasks/RootPackageJsonTask.kt
@@ -20,6 +20,10 @@ open class RootPackageJsonTask : DefaultTask() {
         outputs.upToDateWhen {
             false
         }
+
+        onlyIf {
+            resolutionManager.isConfiguringState()
+        }
     }
 
     private val nodeJs = NodeJsRootPlugin.apply(project.rootProject)


### PR DESCRIPTION
## https://youtrack.jetbrains.com/issue/KT-43818
in Android Studio, before run a gradle task, AS will configure the project, this will download all dependencies which call `KotlinCompilationNpmResolver.resolve()` function, and in `RootPackageJsonTask` and `KotlinPackageJsonTask`, `KotlinCompilationNpmResolver.resolve()` function will be called twice, and it errors.

this first call stack is:
```
at org.jetbrains.kotlin.gradle.targets.js.npm.resolver.KotlinCompilationNpmResolver.resolve(KotlinCompilationNpmResolver.kt:100)
at org.jetbrains.kotlin.gradle.targets.js.npm.resolver.KotlinCompilationNpmResolver.resolve$default(KotlinCompilationNpmResolver.kt:99)
at org.jetbrains.kotlin.gradle.targets.js.npm.resolver.KotlinCompilationNpmResolver.getResolutionOrResolveIfForced(KotlinCompilationNpmResolver.kt:116)
at org.jetbrains.kotlin.gradle.targets.js.npm.resolver.KotlinCompilationNpmResolver.close(KotlinCompilationNpmResolver.kt:124)
at org.jetbrains.kotlin.gradle.targets.js.npm.resolver.KotlinProjectNpmResolver.close(KotlinProjectNpmResolver.kt:116)
at org.jetbrains.kotlin.gradle.targets.js.npm.resolver.KotlinRootNpmResolver.prepareInstallation$kotlin_gradle_plugin(KotlinRootNpmResolver.kt:107)
at org.jetbrains.kotlin.gradle.targets.js.npm.KotlinNpmResolutionManager.prepareIfNeeded(KotlinNpmResolutionManager.kt:186)
at org.jetbrains.kotlin.gradle.targets.js.npm.KotlinNpmResolutionManager.prepareIfNeeded$default(KotlinNpmResolutionManager.kt:163)
at org.jetbrains.kotlin.gradle.targets.js.npm.KotlinNpmResolutionManager.installIfNeeded$kotlin_gradle_plugin(KotlinNpmResolutionManager.kt:141)
at org.jetbrains.kotlin.gradle.targets.js.npm.KotlinNpmResolutionManager.installIfNeeded$kotlin_gradle_plugin$default(KotlinNpmResolutionManager.kt:129)
at org.jetbrains.kotlin.gradle.targets.js.npm.KotlinNpmResolutionManager.getNpmDependencyResolvedCompilation$kotlin_gradle_plugin(KotlinNpmResolutionManager.kt:203)
at org.jetbrains.kotlin.gradle.targets.js.npm.NpmDependency.resolveProject(NpmDependency.kt:86)
at org.jetbrains.kotlin.gradle.targets.js.npm.NpmDependency.resolve(NpmDependency.kt:50)
at org.jetbrains.kotlin.gradle.targets.js.npm.NpmDependency.getFiles(NpmDependency.kt:93)
at org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.DefaultLocalConfigurationMetadataBuilder$DefaultLocalFileDependencyMetadata.getFiles(DefaultLocalConfigurationMetadataBuilder.java:100)
at org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.LocalFileDependencyBackedArtifactSet.visitDependencies(LocalFileDependencyBackedArtifactSet.java:119)
at org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.CompositeResolvedArtifactSet.visitDependencies(CompositeResolvedArtifactSet.java:69)
at org.gradle.api.internal.tasks.FailureCollectingTaskDependencyResolveContext.add(FailureCollectingTaskDependencyResolveContext.java:45)
at org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.BuildDependenciesOnlyVisitedArtifactSet$BuildDependenciesOnlySelectedArtifactSet.visitDependencies(BuildDependenciesOnlyVisitedArtifactSet.java:65)
at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration$ConfigurationFileCollection.visitDependencies(DefaultConfiguration.java:1214)
at org.gradle.api.internal.tasks.CachingTaskDependencyResolveContext$TaskGraphImpl.getNodeValues(CachingTaskDependencyResolveContext.java:112)
at org.gradle.internal.graph.CachingDirectedGraphWalker$GraphWithEmptyEdges.getNodeValues(CachingDirectedGraphWalker.java:213)
at org.gradle.internal.graph.CachingDirectedGraphWalker.doSearch(CachingDirectedGraphWalker.java:121)
at org.gradle.internal.graph.CachingDirectedGraphWalker.findValues(CachingDirectedGraphWalker.java:73)
at org.gradle.api.internal.tasks.CachingTaskDependencyResolveContext.getDependencies(CachingTaskDependencyResolveContext.java:67)
at org.gradle.execution.plan.TaskDependencyResolver.resolveDependenciesFor(TaskDependencyResolver.java:46)
at org.gradle.execution.plan.LocalTaskNode.getDependencies(LocalTaskNode.java:161)
at org.gradle.execution.plan.LocalTaskNode.resolveDependencies(LocalTaskNode.java:129)
at org.gradle.execution.plan.DefaultExecutionPlan.doAddNodes(DefaultExecutionPlan.java:165)
at org.gradle.execution.plan.DefaultExecutionPlan.addEntryTasks(DefaultExecutionPlan.java:135)
at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph.addEntryTasks(DefaultTaskExecutionGraph.java:144)
at org.gradle.execution.TaskNameResolvingBuildConfigurationAction.configure(TaskNameResolvingBuildConfigurationAction.java:49)
at org.gradle.execution.DefaultBuildConfigurationActionExecuter.configure(DefaultBuildConfigurationActionExecuter.java:58)
……
```