### PR TITLE
Add support for RxJava 3 nullability annotations

### DIFF
--- a/compiler/testData/foreignAnnotations/tests/rxjava3.kt
+++ b/compiler/testData/foreignAnnotations/tests/rxjava3.kt
@@ -1,0 +1,42 @@
+// !DIAGNOSTICS: -UNUSED_VARIABLE -UNUSED_PARAMETER
+// FILE: A.java
+
+import io.reactivex.rxjava3.annotations.*;
+
+public class A<T> {
+    @Nullable public String field = null;
+
+    @Nullable
+    public String foo(@NonNull String x, @Nullable CharSequence y) {
+        return "";
+    }
+
+    @NonNull
+    public String bar() {
+        return "";
+    }
+
+    @Nullable
+    public T baz(@NonNull T x) { return x; }
+}
+
+// FILE: main.kt
+
+fun main(a: A<String>, a1: A<String?>) {
+    a.foo("", null)?.length
+    a.foo("", null)<!UNSAFE_CALL!>.<!>length
+    a.foo(<!NULL_FOR_NONNULL_TYPE!>null<!>, "")<!UNSAFE_CALL!>.<!>length
+
+    a.bar().length
+    a.bar()<!UNNECESSARY_NOT_NULL_ASSERTION!>!!<!>.length
+
+    a.field?.length
+    a.field<!UNSAFE_CALL!>.<!>length
+
+    a.baz("")<!UNSAFE_CALL!>.<!>length
+    a.baz("")?.length
+    a.baz(<!NULL_FOR_NONNULL_TYPE!>null<!>)<!UNSAFE_CALL!>.<!>length
+
+    a1.baz("")!!.length
+    a1.baz(<!NULL_FOR_NONNULL_TYPE!>null<!>)!!.length
+}

--- a/compiler/testData/foreignAnnotations/tests/rxjava3.txt
+++ b/compiler/testData/foreignAnnotations/tests/rxjava3.txt
@@ -1,0 +1,14 @@
+package
+
+public fun main(/*0*/ a: A<kotlin.String>, /*1*/ a1: A<kotlin.String?>): kotlin.Unit
+
+public open class A</*0*/ T : kotlin.Any!> {
+    public constructor A</*0*/ T : kotlin.Any!>()
+    @io.reactivex.rxjava3.annotations.Nullable public final var field: @io.reactivex.rxjava3.annotations.Nullable kotlin.String?
+    @io.reactivex.rxjava3.annotations.NonNull public open fun bar(): @io.reactivex.rxjava3.annotations.NonNull kotlin.String
+    @io.reactivex.rxjava3.annotations.Nullable public open fun baz(/*0*/ @io.reactivex.rxjava3.annotations.NonNull x: @io.reactivex.rxjava3.annotations.NonNull T): @io.reactivex.rxjava3.annotations.Nullable T?
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    @io.reactivex.rxjava3.annotations.Nullable public open fun foo(/*0*/ @io.reactivex.rxjava3.annotations.NonNull x: @io.reactivex.rxjava3.annotations.NonNull kotlin.String, /*1*/ @io.reactivex.rxjava3.annotations.Nullable y: @io.reactivex.rxjava3.annotations.Nullable kotlin.CharSequence?): @io.reactivex.rxjava3.annotations.Nullable kotlin.String?
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/ForeignAnnotationsNoAnnotationInClasspathTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/ForeignAnnotationsNoAnnotationInClasspathTestGenerated.java
@@ -92,6 +92,12 @@ public class ForeignAnnotationsNoAnnotationInClasspathTestGenerated extends Abst
             runTest("compiler/testData/foreignAnnotations/tests/rxjava.kt");
         }
 
+        @Test
+        @TestMetadata("rxjava3.kt")
+        public void testRxjava3() throws Exception {
+            runTest("compiler/testData/foreignAnnotations/tests/rxjava3.kt");
+        }
+
         @Nested
         @TestMetadata("compiler/testData/foreignAnnotations/tests/jsr305")
         @TestDataPath("$PROJECT_ROOT")

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/ForeignAnnotationsNoAnnotationInClasspathWithPsiClassReadingTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/ForeignAnnotationsNoAnnotationInClasspathWithPsiClassReadingTestGenerated.java
@@ -92,6 +92,12 @@ public class ForeignAnnotationsNoAnnotationInClasspathWithPsiClassReadingTestGen
             runTest("compiler/testData/foreignAnnotations/tests/rxjava.kt");
         }
 
+        @Test
+        @TestMetadata("rxjava3.kt")
+        public void testRxjava3() throws Exception {
+            runTest("compiler/testData/foreignAnnotations/tests/rxjava3.kt");
+        }
+
         @Nested
         @TestMetadata("compiler/testData/foreignAnnotations/tests/jsr305")
         @TestDataPath("$PROJECT_ROOT")

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/ForeignAnnotationsTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/ForeignAnnotationsTestGenerated.java
@@ -92,6 +92,12 @@ public class ForeignAnnotationsTestGenerated extends AbstractForeignAnnotationsT
             runTest("compiler/testData/foreignAnnotations/tests/rxjava.kt");
         }
 
+        @Test
+        @TestMetadata("rxjava3.kt")
+        public void testRxjava3() throws Exception {
+            runTest("compiler/testData/foreignAnnotations/tests/rxjava3.kt");
+        }
+
         @Nested
         @TestMetadata("compiler/testData/foreignAnnotations/tests/jsr305")
         @TestDataPath("$PROJECT_ROOT")

--- a/core/compiler.common.jvm/src/org/jetbrains/kotlin/load/java/JvmAnnotationNames.kt
+++ b/core/compiler.common.jvm/src/org/jetbrains/kotlin/load/java/JvmAnnotationNames.kt
@@ -36,7 +36,8 @@ val NULLABLE_ANNOTATIONS = listOf(
     FqName("edu.umd.cs.findbugs.annotations.CheckForNull"),
     FqName("edu.umd.cs.findbugs.annotations.Nullable"),
     FqName("edu.umd.cs.findbugs.annotations.PossiblyNull"),
-    FqName("io.reactivex.annotations.Nullable")
+    FqName("io.reactivex.annotations.Nullable"),
+    FqName("io.reactivex.rxjava3.annotations.Nullable")
 )
 
 val JAVAX_NONNULL_ANNOTATION = FqName("javax.annotation.Nonnull")
@@ -52,7 +53,8 @@ val NOT_NULL_ANNOTATIONS = listOf(
     FqName("org.eclipse.jdt.annotation.NonNull"),
     FqName("org.checkerframework.checker.nullness.qual.NonNull"),
     FqName("lombok.NonNull"),
-    FqName("io.reactivex.annotations.NonNull")
+    FqName("io.reactivex.annotations.NonNull"),
+    FqName("io.reactivex.rxjava3.annotations.NonNull")
 )
 
 val COMPATQUAL_NULLABLE_ANNOTATION = FqName("org.checkerframework.checker.nullness.compatqual.NullableDecl")

--- a/third-party/annotations/io/reactivex/rxjava3/annotations/NonNull.java
+++ b/third-party/annotations/io/reactivex/rxjava3/annotations/NonNull.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.annotations;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+import java.lang.annotation.*;
+
+/**
+ * Indicates that a field/parameter/variable/type parameter/return type is never null.
+ */
+@Documented
+@Target(value = {FIELD, METHOD, PARAMETER, LOCAL_VARIABLE, TYPE_PARAMETER, TYPE_USE})
+@Retention(value = CLASS)
+public @interface NonNull { }
+

--- a/third-party/annotations/io/reactivex/rxjava3/annotations/Nullable.java
+++ b/third-party/annotations/io/reactivex/rxjava3/annotations/Nullable.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava3.annotations;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+import java.lang.annotation.*;
+
+/**
+ * Indicates that a field/parameter/variable/type parameter/return type may be null.
+ */
+@Documented
+@Target(value = {FIELD, METHOD, PARAMETER, LOCAL_VARIABLE, TYPE_PARAMETER, TYPE_USE})
+@Retention(value = CLASS)
+public @interface Nullable { }
+


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-44261

Mostly a copy of the RxJava 1 & 2 support. Just in `rxjava3.txt` a few more annotations get retained in the bytecode(?), so the file was adjusted to pass the tests.