### PR TITLE
JVM: regenerate objects if they have been regenerated in parent contexts

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/codegen/ir/FirBlackBoxInlineCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/codegen/ir/FirBlackBoxInlineCodegenTestGenerated.java
@@ -102,6 +102,11 @@ public class FirBlackBoxInlineCodegenTestGenerated extends AbstractFirBlackBoxIn
             runTest("compiler/testData/codegen/boxInline/anonymousObject/changingReturnType.kt");
         }
 
+        @TestMetadata("constructOriginalInRegenerated.kt")
+        public void testConstructOriginalInRegenerated() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/constructOriginalInRegenerated.kt");
+        }
+
         @TestMetadata("constructorVisibility.kt")
         public void testConstructorVisibility() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/constructorVisibility.kt");

--- a/compiler/testData/codegen/boxInline/anonymousObject/constructOriginalInRegenerated.kt
+++ b/compiler/testData/codegen/boxInline/anonymousObject/constructOriginalInRegenerated.kt
@@ -1,0 +1,15 @@
+// FILE: 1.kt
+// Intentionally in the same package, as objects in other packages are always regenerated.
+
+fun f(x: () -> String) = x()
+
+inline fun g(crossinline x: () -> String) = f { x() }
+
+// FILE: 2.kt
+//   _1Kt$g$1 not regenerated because the original already does the same thing (invoking a functional object)
+//                         \-v
+fun h(x: () -> String) = g { g(x) }
+//                     /-^
+//   _1Kt$g$1 regenerated to inline the lambda
+
+fun box() = h { "OK" }

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/BlackBoxInlineCodegenTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/BlackBoxInlineCodegenTestGenerated.java
@@ -102,6 +102,11 @@ public class BlackBoxInlineCodegenTestGenerated extends AbstractBlackBoxInlineCo
             runTest("compiler/testData/codegen/boxInline/anonymousObject/changingReturnType.kt");
         }
 
+        @TestMetadata("constructOriginalInRegenerated.kt")
+        public void testConstructOriginalInRegenerated() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/constructOriginalInRegenerated.kt");
+        }
+
         @TestMetadata("constructorVisibility.kt")
         public void testConstructorVisibility() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/constructorVisibility.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/CompileKotlinAgainstInlineKotlinTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/CompileKotlinAgainstInlineKotlinTestGenerated.java
@@ -102,6 +102,11 @@ public class CompileKotlinAgainstInlineKotlinTestGenerated extends AbstractCompi
             runTest("compiler/testData/codegen/boxInline/anonymousObject/changingReturnType.kt");
         }
 
+        @TestMetadata("constructOriginalInRegenerated.kt")
+        public void testConstructOriginalInRegenerated() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/constructOriginalInRegenerated.kt");
+        }
+
         @TestMetadata("constructorVisibility.kt")
         public void testConstructorVisibility() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/constructorVisibility.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/IrBlackBoxInlineCodegenTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/IrBlackBoxInlineCodegenTestGenerated.java
@@ -102,6 +102,11 @@ public class IrBlackBoxInlineCodegenTestGenerated extends AbstractIrBlackBoxInli
             runTest("compiler/testData/codegen/boxInline/anonymousObject/changingReturnType.kt");
         }
 
+        @TestMetadata("constructOriginalInRegenerated.kt")
+        public void testConstructOriginalInRegenerated() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/constructOriginalInRegenerated.kt");
+        }
+
         @TestMetadata("constructorVisibility.kt")
         public void testConstructorVisibility() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/constructorVisibility.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/IrCompileKotlinAgainstInlineKotlinTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/IrCompileKotlinAgainstInlineKotlinTestGenerated.java
@@ -102,6 +102,11 @@ public class IrCompileKotlinAgainstInlineKotlinTestGenerated extends AbstractIrC
             runTest("compiler/testData/codegen/boxInline/anonymousObject/changingReturnType.kt");
         }
 
+        @TestMetadata("constructOriginalInRegenerated.kt")
+        public void testConstructOriginalInRegenerated() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/constructOriginalInRegenerated.kt");
+        }
+
         @TestMetadata("constructorVisibility.kt")
         public void testConstructorVisibility() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/constructorVisibility.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/JvmIrAgainstOldBoxInlineTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/JvmIrAgainstOldBoxInlineTestGenerated.java
@@ -102,6 +102,11 @@ public class JvmIrAgainstOldBoxInlineTestGenerated extends AbstractJvmIrAgainstO
             runTest("compiler/testData/codegen/boxInline/anonymousObject/changingReturnType.kt");
         }
 
+        @TestMetadata("constructOriginalInRegenerated.kt")
+        public void testConstructOriginalInRegenerated() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/constructOriginalInRegenerated.kt");
+        }
+
         @TestMetadata("constructorVisibility.kt")
         public void testConstructorVisibility() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/constructorVisibility.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/JvmOldAgainstIrBoxInlineTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/JvmOldAgainstIrBoxInlineTestGenerated.java
@@ -102,6 +102,11 @@ public class JvmOldAgainstIrBoxInlineTestGenerated extends AbstractJvmOldAgainst
             runTest("compiler/testData/codegen/boxInline/anonymousObject/changingReturnType.kt");
         }
 
+        @TestMetadata("constructOriginalInRegenerated.kt")
+        public void testConstructOriginalInRegenerated() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/constructOriginalInRegenerated.kt");
+        }
+
         @TestMetadata("constructorVisibility.kt")
         public void testConstructorVisibility() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/constructorVisibility.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenInlineES6TestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenInlineES6TestGenerated.java
@@ -102,6 +102,11 @@ public class IrJsCodegenInlineES6TestGenerated extends AbstractIrJsCodegenInline
             runTest("compiler/testData/codegen/boxInline/anonymousObject/changingReturnType.kt");
         }
 
+        @TestMetadata("constructOriginalInRegenerated.kt")
+        public void testConstructOriginalInRegenerated() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/constructOriginalInRegenerated.kt");
+        }
+
         @TestMetadata("constructorVisibility.kt")
         public void testConstructorVisibility() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/constructorVisibility.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenInlineTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenInlineTestGenerated.java
@@ -102,6 +102,11 @@ public class IrJsCodegenInlineTestGenerated extends AbstractIrJsCodegenInlineTes
             runTest("compiler/testData/codegen/boxInline/anonymousObject/changingReturnType.kt");
         }
 
+        @TestMetadata("constructOriginalInRegenerated.kt")
+        public void testConstructOriginalInRegenerated() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/constructOriginalInRegenerated.kt");
+        }
+
         @TestMetadata("constructorVisibility.kt")
         public void testConstructorVisibility() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/constructorVisibility.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/semantics/JsCodegenInlineTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/semantics/JsCodegenInlineTestGenerated.java
@@ -102,6 +102,11 @@ public class JsCodegenInlineTestGenerated extends AbstractJsCodegenInlineTest {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/changingReturnType.kt");
         }
 
+        @TestMetadata("constructOriginalInRegenerated.kt")
+        public void testConstructOriginalInRegenerated() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/constructOriginalInRegenerated.kt");
+        }
+
         @TestMetadata("constructorVisibility.kt")
         public void testConstructorVisibility() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/constructorVisibility.kt");


### PR DESCRIPTION
This is a hack to work around the fact that type mappings should not be inherited by inlining contexts for lambdas called from anonymous objects. As the lambda can call the inline function again, this could produce a reference to the original object, which is remapped to a new type in the parent context. Unfortunately, there are many redundant `MethodRemapper`s between the lambda and the class file, so simply editing `TypeRemapper` does not work. Hence, this hack. For now.

(Issue found by compiling IntelliJ IDEA BTW.)