### PR TITLE
FIR: don't use `this` as extension receiver in a primary constructor

### DIFF
--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/tower/TowerLevelHandler.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/tower/TowerLevelHandler.kt
@@ -66,7 +66,7 @@ internal class TowerLevelHandler {
 }
 
 private class TowerScopeLevelProcessor(
-    val callInfo: CallInfo,
+    override val callInfo: CallInfo,
     val explicitReceiverKind: ExplicitReceiverKind,
     val resultCollector: CandidateCollector,
     val candidateFactory: CandidateFactory,

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/declarations/FirDeclarationUtil.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/declarations/FirDeclarationUtil.kt
@@ -108,8 +108,11 @@ val FirClassSymbol<*>.superConeTypes
 
 val FirClass<*>.superConeTypes get() = superTypeRefs.mapNotNull { it.coneTypeSafe<ConeClassLikeType>() }
 
+inline val FirDeclaration.isPrimaryConstructor: Boolean
+    get() = this is FirConstructor && this.isPrimary
+
 fun FirClass<*>.getPrimaryConstructorIfAny(): FirConstructor? =
-    declarations.filterIsInstance<FirConstructor>().firstOrNull()?.takeIf { it.isPrimary }
+    declarations.firstOrNull { it.isPrimaryConstructor } as? FirConstructor
 
 fun FirRegularClass.collectEnumEntries(): Collection<FirEnumEntry> {
     assert(classKind == ClassKind.ENUM_CLASS)

--- a/compiler/testData/codegen/box/enum/kt20651_inlineLambda.kt
+++ b/compiler/testData/codegen/box/enum/kt20651_inlineLambda.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 enum class Test(val x: String, val closure1: () -> String) {
     FOO("O", run { { FOO.x } }) {
         override val y: String = "K"

--- a/compiler/testData/codegen/box/objects/selfReferenceToCompanionObjectInInlineLambdaInSuperConstructorCall.kt
+++ b/compiler/testData/codegen/box/objects/selfReferenceToCompanionObjectInInlineLambdaInSuperConstructorCall.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 abstract class Base(val fn: () -> String)
 
 class Host {

--- a/compiler/testData/codegen/box/objects/selfReferenceToInterfaceCompanionObjectInInlineLambdaInSuperConstructorCall.kt
+++ b/compiler/testData/codegen/box/objects/selfReferenceToInterfaceCompanionObjectInInlineLambdaInSuperConstructorCall.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 abstract class Base(val fn: () -> String)
 
 interface Host {


### PR DESCRIPTION
The motivation is bb test `objects/selfReferenceToCompanionObjectInInlineLambdaInSuperConstructorCall.kt`:
```kt
abstract class Base(val fn: () -> String)

class Host {
    companion object : Base(run { { Host.ok() } }) {
        fun ok() = "OK"
    }
}
```
where `run` as the argument for `fn` is resolved as
```kt
fun <T, R> T.run(block: T.() -> R): R
```
instead of
```kt
fun <R> run(block: () -> R): R
```
`FirAbstractImportingScope` loaded two `run` symbols correctly, but then an implicit dispatch receiver that was bound to `ScopeTowerLevel` made the resolution choose the extension one. Using that extension variant means something like: `Base(this.run { ... })`, but `this` is not available at that point---in a primary constructor. Massaging the use of bound extension receiver for `ScopeTowerLevel` can make the resolution pick the right one.