### PR TITLE
FIR2IR: check non-parameter Unit type for adapted callable references

### DIFF
--- a/compiler/testData/codegen/box/coroutines/suspendFunctionMethodReference.kt
+++ b/compiler/testData/codegen/box/coroutines/suspendFunctionMethodReference.kt
@@ -1,6 +1,5 @@
 // WITH_RUNTIME
 // WITH_COROUTINES
-// IGNORE_BACKEND_FIR: JVM_IR
 
 import kotlin.coroutines.*
 import helpers.*


### PR DESCRIPTION
The motivation is bb test `coroutines/suspendFunctionMethodReference`:
```kt
fun f(a: suspend () -> Unit) {
  val f = a::invoke
  ...
}
```
That `invoke` from external stub has a type parameter `R` as a return type, and is determined as a candidate for generating coercion-to-Unit adapter, which shouldn't be the case.