### PR TITLE
IR: Add vararg builder method

### DIFF
--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/builders/ExpressionHelpers.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/builders/ExpressionHelpers.kt
@@ -326,6 +326,8 @@ fun IrBuilderWithScope.irString(value: String) =
 fun IrBuilderWithScope.irConcat() =
     IrStringConcatenationImpl(startOffset, endOffset, context.irBuiltIns.stringType)
 
+fun IrBuilderWithScope.irVararg(type: IrType, varargElementType: IrType, elements: List<IrExpression> = emptyList()) =
+    IrVarargImpl(startOffset, endOffset, type, varargElementType, elements)
 
 inline fun IrBuilderWithScope.irBlock(
     startOffset: Int = this.startOffset,


### PR DESCRIPTION
Very simple PR, fixes [KT-44252](https://youtrack.jetbrains.com/issue/KT-44252).

Thoughts on adding an overload that builds the vararg type from `varargElementType` using `irBuiltIns.arrayClass` or the primitive array where appropriate?