### PR TITLE
Avoid running call checkers when possible

### DIFF
--- a/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/KotlinToResolvedCallTransformer.kt
+++ b/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/tower/KotlinToResolvedCallTransformer.kt
@@ -239,6 +239,8 @@ class KotlinToResolvedCallTransformer(
     }
 
     fun runCallCheckers(resolvedCall: ResolvedCall<*>, callCheckerContext: CallCheckerContext) {
+        if (!callCheckerContext.trace.wantsDiagnostics()) return // Optimization.
+
         val calleeExpression = if (resolvedCall is VariableAsFunctionResolvedCall)
             resolvedCall.variableCall.call.calleeExpression
         else


### PR DESCRIPTION
Commit d8b0c7aaec added an optimization: call checkers
are not invoked if BindingTrace.wantsDiagnostics() returns false.

However, the optimization was never applied to
KotlinToResolvedCallTransformer, which was introduced around the same
time in commit b012681a53 as part of the new type inference.

cc @erokhins; let me know what you think!