### PR TITLE
[Test] Ignore test helpers in debugging tests

### DIFF
--- a/compiler/testData/debug/localVariables/suspend/completion/nonStaticStateMachine.kt
+++ b/compiler/testData/debug/localVariables/suspend/completion/nonStaticStateMachine.kt
@@ -21,7 +21,6 @@ suspend fun box() {
 // test.kt:4 <init>:
 // test.kt:14 box: $completion:kotlin.coroutines.Continuation=helpers.ResultContinuation
 // test.kt:6 foo1:
-// CoroutineUtil.kt:28 getContext:
 
 // LOCAL VARIABLES JVM
 // test.kt:-1 <init>:

--- a/compiler/testData/debug/localVariables/suspend/completion/staticStateMachine.kt
+++ b/compiler/testData/debug/localVariables/suspend/completion/staticStateMachine.kt
@@ -17,7 +17,6 @@ suspend fun box() {
 // LOCAL VARIABLES
 // test.kt:12 box: $completion:kotlin.coroutines.Continuation=helpers.ResultContinuation
 // test.kt:5 foo1:
-// CoroutineUtil.kt:28 getContext:
 
 // LOCAL VARIABLES JVM
 // test.kt:-1 <init>:

--- a/compiler/testData/debug/localVariables/suspend/completion/staticStateMachineReceiver.kt
+++ b/compiler/testData/debug/localVariables/suspend/completion/staticStateMachineReceiver.kt
@@ -21,7 +21,6 @@ suspend fun box() {
 // test.kt:4 <init>:
 // test.kt:14 box: $completion:kotlin.coroutines.Continuation=helpers.ResultContinuation
 // test.kt:7 foo1:
-// CoroutineUtil.kt:28 getContext:
 
 // LOCAL VARIABLES JVM
 // test.kt:-1 <init>:

--- a/compiler/testData/debug/localVariables/suspend/inlineLocalsStateMachineTransform.kt
+++ b/compiler/testData/debug/localVariables/suspend/inlineLocalsStateMachineTransform.kt
@@ -20,7 +20,6 @@ suspend fun box() {
 
 // LOCAL VARIABLES
 // test.kt:10 box:
-// CoroutineUtil.kt:28 getContext:
 
 // LOCAL VARIABLES JVM_IR
 // test.kt:-1 <init>: $completion:kotlin.coroutines.Continuation=helpers.ResultContinuation

--- a/compiler/testData/debug/localVariables/suspend/localsStateMachineTransform.kt
+++ b/compiler/testData/debug/localVariables/suspend/localsStateMachineTransform.kt
@@ -22,7 +22,6 @@ suspend fun box() {
 
 // LOCAL VARIABLES
 // test.kt:7 box:
-// CoroutineUtil.kt:28 getContext:
 // test.kt:-1 <init>: $completion:kotlin.coroutines.Continuation=helpers.ResultContinuation
 // test.kt:7 box:
 // test.kt:9 box: $continuation:kotlin.coroutines.Continuation=TestKt$box$1, $result:java.lang.Object=null

--- a/compiler/testData/debug/localVariables/suspend/underscoreNames.kt
+++ b/compiler/testData/debug/localVariables/suspend/underscoreNames.kt
@@ -21,7 +21,6 @@ suspend fun box() = foo(A()) { (x_param, _, y_param) ->
 // test.kt:4 <init>:
 // test.kt:12 box: $completion:kotlin.coroutines.Continuation=helpers.ResultContinuation
 // test.kt:10 foo: a:A=A, block:kotlin.jvm.functions.Function2=TestKt$box$2, $completion:kotlin.coroutines.Continuation=helpers.ResultContinuation
-// CoroutineUtil.kt:28 getContext:
 
 // LOCAL VARIABLES JVM
 // test.kt:-1 <init>:

--- a/compiler/testData/debug/stepping/suspendFunWithSuspendLambdaParameter.kt
+++ b/compiler/testData/debug/stepping/suspendFunWithSuspendLambdaParameter.kt
@@ -13,7 +13,6 @@ suspend fun box() {
 // LINENUMBERS
 // test.kt:8 box
 // test.kt:4 foo
-// CoroutineUtil.kt:28 getContext
 // test.kt:-1 <init>
 // test.kt:-1 create
 // test.kt:-1 invoke

--- a/compiler/tests-common/tests/org/jetbrains/kotlin/codegen/debugInformation/AbstractDebugTest.kt
+++ b/compiler/tests-common/tests/org/jetbrains/kotlin/codegen/debugInformation/AbstractDebugTest.kt
@@ -110,6 +110,10 @@ abstract class AbstractDebugTest : CodegenTestCase() {
                 ?: File(javaBin, "java").also { assert(it.exists()) }
         }
 
+        val Location.isInDebugTestInfrastructure: Boolean
+            get() {
+                return this.sourcePath().startsWith("helpers" + File.separatorChar)
+            }
     }
 
     @Before

--- a/compiler/tests-common/tests/org/jetbrains/kotlin/codegen/debugInformation/AbstractLocalVariableTest.kt
+++ b/compiler/tests-common/tests/org/jetbrains/kotlin/codegen/debugInformation/AbstractLocalVariableTest.kt
@@ -81,7 +81,9 @@ abstract class AbstractLocalVariableTest : AbstractDebugTest() {
         val locatableEvent = event as LocatableEvent
         waitUntil { locatableEvent.thread().isSuspended }
         val location = locatableEvent.location()
+        if (location.isInDebugTestInfrastructure) return
         if (location.method().isSynthetic) return
+
         val frame = locatableEvent.thread().frame(0)
         val visibleVars = try {
             frame.visibleVariables().map { variable -> toRecord(frame, variable) }

--- a/compiler/tests-common/tests/org/jetbrains/kotlin/codegen/debugInformation/AbstractSteppingTest.kt
+++ b/compiler/tests-common/tests/org/jetbrains/kotlin/codegen/debugInformation/AbstractSteppingTest.kt
@@ -60,9 +60,11 @@ abstract class AbstractSteppingTest : AbstractDebugTest() {
         val actualLineNumbers = compressRunsWithoutLinenumber(loggedItems as List<LocatableEvent>, LocatableEvent::location)
             .filter {
                 val location = it.location()
-                // Ignore synthetic code with no line number information
-                // unless force step into behavior is requested.
-                forceStepInto || !location.method().isSynthetic
+                // Ignore:
+                //   - synthetic code with no line number information
+                //     unless force step into behavior is requested.
+                //   - helper code from the test infrastructure
+                (forceStepInto || !location.method().isSynthetic) && !location.isInDebugTestInfrastructure
             }
             .map { "// ${it.location().formatAsExpectation()}" }
         val actualLineNumbersIterator = actualLineNumbers.iterator()


### PR DESCRIPTION
This solves no immediate deficiency, but is a to-do that arose as part
of an ongoing effort to port the old, slightly too restrictive
checkLocalVariableTable tests to the more "functional" debugger
infrastructure.

This just shaves a little bit of overhead off the test expectations
and couples them less tightly to the specifics of the test
infrastructure.