### PR TITLE
Lower memory consumption in Kotlin js DCE

### DIFF
--- a/js/js.dce/src/org/jetbrains/kotlin/js/dce/util.kt
+++ b/js/js.dce/src/org/jetbrains/kotlin/js/dce/util.kt
@@ -72,20 +72,19 @@ fun JsLocation.asString(): String {
     return "$simpleFileName:${startLine + 1}"
 }
 
-fun Set<Node>.extractRoots(): Set<Node> {
-    val result = mutableSetOf<Node>()
-    val visited = mutableSetOf<Node>()
-    forEach { it.original.extractRootsImpl(result, visited) }
-    return result
+fun Sequence<Node>.extractRoots(visitedTag: Int): Set<Node> {
+    return mapNotNull { it.original.extractRoot(visitedTag) }.toSet()
 }
 
-private fun Node.extractRootsImpl(target: MutableSet<Node>, visited: MutableSet<Node>) {
-    if (!visited.add(original)) return
-    val qualifier = original.qualifier
-    if (qualifier == null) {
-        target += original
+fun Node.extractRoot(visitedTag: Int): Node? {
+    if (original.tag == visitedTag) {
+        return null
     }
-    else {
-        qualifier.parent.extractRootsImpl(target, visited)
+    original.tag = visitedTag
+    val qualifier = original.qualifier
+    return if (qualifier == null) {
+        original
+    } else {
+        qualifier.parent.extractRoot(visitedTag)
     }
 }

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/AbstractDceTest.kt
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/AbstractDceTest.kt
@@ -28,7 +28,7 @@ abstract class AbstractDceTest : TestCase() {
         val fileContents = file.readText()
         val inputFile = InputFile(InputResource.file(filePath), null,
                                   File(pathToOutputDir, file.relativeTo(File(pathToTestDir)).path).path, "main")
-        val dceResult = DeadCodeElimination.run(setOf(inputFile), extractDeclarations(REQUEST_REACHABLE_PATTERN, fileContents)) { _, _ -> }
+        val dceResult = DeadCodeElimination.run(setOf(inputFile), extractDeclarations(REQUEST_REACHABLE_PATTERN, fileContents),false) { _, _ -> }
         val reachableNodeStrings = dceResult.reachableNodes.map { it.toString().removePrefix("<unknown>.") }.toSet()
 
         for (assertedDeclaration in extractDeclarations(ASSERT_REACHABLE_PATTERN, fileContents)) {

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/BasicBoxTest.kt
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/BasicBoxTest.kt
@@ -773,7 +773,7 @@ abstract class BasicBoxTest(
                 "kotlin-test.kotlin.test.DefaultAsserter"
         )
         val allFilesToMinify = filesToMinify.values + kotlinJsInputFile + kotlinTestJsInputFile
-        val dceResult = DeadCodeElimination.run(allFilesToMinify, additionalReachableNodes) { _, _ -> }
+        val dceResult = DeadCodeElimination.run(allFilesToMinify, additionalReachableNodes, false) { _, _ -> }
 
         val reachableNodes = dceResult.reachableNodes
         minificationThresholdChecker(reachableNodes.count { it.reachable })


### PR DESCRIPTION
Few points:
- Don't store all reachable Js nodes in ReachabilityTracker while only roots are needed
- Make Context.Node class more lightweight because DCE produces tons of such instances
- Remove debug logging (significantly affects task execution time) 