### PR TITLE
Lower memory consumption in Kotlin js DCE

### DIFF
--- a/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/js/dce/K2JSDce.kt
+++ b/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/js/dce/K2JSDce.kt
@@ -78,6 +78,7 @@ class K2JSDce : CLITool<K2JSDceArguments>() {
 
         val dceResult = DeadCodeElimination.run(
             files, includedDeclarations,
+            printReachabilityInfo = arguments.printReachabilityInfo,
             collectOnlyRootNodes = true,
             logConsumer = logConsumer
         )

--- a/js/js.dce/src/org/jetbrains/kotlin/js/dce/Context.kt
+++ b/js/js.dce/src/org/jetbrains/kotlin/js/dce/Context.kt
@@ -172,13 +172,13 @@ class Context {
             flags = flags xor ((-value.toInt() xor flags) and mask)
         }
 
-        val dependencies: MutableSet<Node> get() = original.dependenciesImpl
+        val dependencies: Set<Node> get() = original._dependenciesImpl ?: emptySet()
 
-        val expressions: MutableSet<JsExpression> get() = original.expressionsImpl
+        val expressions: Set<JsExpression> get() = original._expressionsImpl ?: emptySet()
 
-        val functions: MutableSet<JsFunction> get() = original.functionsImpl
+        val functions: Set<JsFunction> get() = original._functionsImpl ?: emptySet()
 
-        val usedByAstNodes: MutableSet<JsNode> get() = original.usedByAstNodesImpl
+        val usedByAstNodes: Set<JsNode> get() = original._usedByAstNodesImpl ?: emptySet()
 
         var hasSideEffects: Boolean
             get() = original.hasSideEffectsImpl
@@ -203,7 +203,7 @@ class Context {
 
         var tag: Int = -1
 
-        val memberNames: MutableSet<String> get() = original.membersImpl.keys
+        val memberNames: Set<String> get() = original._membersImpl?.keys ?: emptySet()
 
         constructor(localName: JsName? = null) : this(localName, null)
 
@@ -216,7 +216,23 @@ class Context {
             }
             private set
 
-        val members: Map<String, Node> get() = original.membersImpl
+        val members: Map<String, Node> get() = original._membersImpl ?: emptyMap()
+
+        fun addDependency(node: Node) {
+            dependenciesImpl += node
+        }
+
+        fun addFunction(function: JsFunction) {
+            functionsImpl += function
+        }
+
+        fun addExpression(expression: JsExpression) {
+            expressionsImpl += expression
+        }
+
+        fun addUsedByAstNode(node: JsNode) {
+            usedByAstNodesImpl += node
+        }
 
         fun member(name: String): Node = original.membersImpl.getOrPut(name) { Node(null, Qualifier(this, name)) }.original
 

--- a/js/js.dce/src/org/jetbrains/kotlin/js/dce/DeadCodeElimination.kt
+++ b/js/js.dce/src/org/jetbrains/kotlin/js/dce/DeadCodeElimination.kt
@@ -39,6 +39,7 @@ import java.io.File
 import java.io.InputStreamReader
 
 class DeadCodeElimination(
+    private val printReachabilityInfo: Boolean,
     private val collectOnlyRootNodes: Boolean,
     private val logConsumer: (DCELogLevel, String) -> Unit
 ) {
@@ -61,7 +62,7 @@ class DeadCodeElimination(
         analyzer.moduleMapping += moduleMapping
         root.accept(analyzer)
 
-        val usageFinder = ReachabilityTracker(context, analyzer.analysisResult, collectOnlyRootNodes, logConsumer)
+        val usageFinder = ReachabilityTracker(context, analyzer.analysisResult, collectOnlyRootNodes, logConsumer.takeIf { printReachabilityInfo })
         root.accept(usageFinder)
 
         for (reachableName in reachableNames) {
@@ -78,11 +79,12 @@ class DeadCodeElimination(
         fun run(
                 inputFiles: Collection<InputFile>,
                 rootReachableNames: Set<String>,
+                printReachabilityInfo: Boolean,
                 collectOnlyRootNodes: Boolean,
                 logConsumer: (DCELogLevel, String) -> Unit
         ): DeadCodeEliminationResult {
             val program = JsProgram()
-            val dce = DeadCodeElimination(collectOnlyRootNodes, logConsumer)
+            val dce = DeadCodeElimination(printReachabilityInfo, collectOnlyRootNodes, logConsumer)
 
             var hasErrors = false
             val blocks = inputFiles.map { file ->

--- a/js/js.dce/src/org/jetbrains/kotlin/js/dce/ReachabilityTracker.kt
+++ b/js/js.dce/src/org/jetbrains/kotlin/js/dce/ReachabilityTracker.kt
@@ -80,7 +80,7 @@ class ReachabilityTracker(
             if (!node.reachable) {
                 nested {
                     reach(node)
-                    currentNodeWithLocation?.let { node.usedByAstNodes += it }
+                    currentNodeWithLocation?.let { node.addUsedByAstNode(it) }
                 }
             }
             return false
@@ -105,7 +105,7 @@ class ReachabilityTracker(
                 if (node != null && node.qualifier?.memberName in CALL_FUNCTIONS) {
                     val parent = node.qualifier!!.parent
                     reach(parent)
-                    currentNodeWithLocation?.let { parent.usedByAstNodes += it }
+                    currentNodeWithLocation?.let { parent.addUsedByAstNode(it) }
                 }
                 super.visitInvocation(invocation)
             }

--- a/js/js.dce/src/org/jetbrains/kotlin/js/dce/ReachabilityTracker.kt
+++ b/js/js.dce/src/org/jetbrains/kotlin/js/dce/ReachabilityTracker.kt
@@ -19,7 +19,6 @@ package org.jetbrains.kotlin.js.dce
 import org.jetbrains.kotlin.js.backend.ast.*
 import org.jetbrains.kotlin.js.dce.Context.Node
 import org.jetbrains.kotlin.js.inline.util.collectLocalVariables
-import java.util.concurrent.atomic.AtomicInteger
 
 class ReachabilityTracker(
         private val context: Context,

--- a/js/js.dce/src/org/jetbrains/kotlin/js/dce/util.kt
+++ b/js/js.dce/src/org/jetbrains/kotlin/js/dce/util.kt
@@ -73,19 +73,19 @@ fun JsLocation.asString(): String {
     return "$simpleFileName:${startLine + 1}"
 }
 
-fun Sequence<Node>.extractRoots(visitedTag: Int): Set<Node> {
-    return mapNotNull { it.original.extractRoot(visitedTag) }.toSet()
+fun Sequence<Node>.extractRoots(): Set<Node> {
+    return mapNotNull { it.original.extractRoot() }.toSet()
 }
 
-fun Node.extractRoot(visitedTag: Int): Node? {
-    if (original.tag == visitedTag) {
+fun Node.extractRoot(): Node? {
+    if (original.visited) {
         return null
     }
-    original.tag = visitedTag
+    original.visited = true
     val qualifier = original.qualifier
     return if (qualifier == null) {
         original
     } else {
-        qualifier.parent.extractRoot(visitedTag)
+        qualifier.parent.extractRoot()
     }
 }

--- a/js/js.dce/src/org/jetbrains/kotlin/js/dce/util.kt
+++ b/js/js.dce/src/org/jetbrains/kotlin/js/dce/util.kt
@@ -73,20 +73,19 @@ fun JsLocation.asString(): String {
     return "$simpleFileName:${startLine + 1}"
 }
 
-fun Set<Node>.extractRoots(): Set<Node> {
-    val result = mutableSetOf<Node>()
-    val visited = mutableSetOf<Node>()
-    forEach { it.original.extractRootsImpl(result, visited) }
-    return result
+fun Sequence<Node>.extractRoots(visitedTag: Int): Set<Node> {
+    return mapNotNull { it.original.extractRoot(visitedTag) }.toSet()
 }
 
-private fun Node.extractRootsImpl(target: MutableSet<Node>, visited: MutableSet<Node>) {
-    if (!visited.add(original)) return
-    val qualifier = original.qualifier
-    if (qualifier == null) {
-        target += original
+fun Node.extractRoot(visitedTag: Int): Node? {
+    if (original.tag == visitedTag) {
+        return null
     }
-    else {
-        qualifier.parent.extractRootsImpl(target, visited)
+    original.tag = visitedTag
+    val qualifier = original.qualifier
+    return if (qualifier == null) {
+        original
+    } else {
+        qualifier.parent.extractRoot(visitedTag)
     }
 }

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/AbstractDceTest.kt
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/AbstractDceTest.kt
@@ -28,7 +28,10 @@ abstract class AbstractDceTest : TestCase() {
         val fileContents = file.readText()
         val inputFile = InputFile(InputResource.file(filePath), null,
                                   File(pathToOutputDir, file.relativeTo(File(pathToTestDir)).path).path, "main")
-        val dceResult = DeadCodeElimination.run(setOf(inputFile), extractDeclarations(REQUEST_REACHABLE_PATTERN, fileContents),false) { _, _ -> }
+        val dceResult = DeadCodeElimination.run(
+            setOf(inputFile), extractDeclarations(REQUEST_REACHABLE_PATTERN, fileContents),
+            printReachabilityInfo = true, collectOnlyRootNodes = false
+        ) { _, _ -> }
         val reachableNodeStrings = dceResult.reachableNodes.map { it.toString().removePrefix("<unknown>.") }.toSet()
 
         for (assertedDeclaration in extractDeclarations(ASSERT_REACHABLE_PATTERN, fileContents)) {

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/AbstractDceTest.kt
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/AbstractDceTest.kt
@@ -28,7 +28,7 @@ abstract class AbstractDceTest : TestCase() {
         val fileContents = file.readText()
         val inputFile = InputFile(InputResource.file(filePath), null,
                                   File(pathToOutputDir, file.relativeTo(File(pathToTestDir)).path).path, "main")
-        val dceResult = DeadCodeElimination.run(setOf(inputFile), extractDeclarations(REQUEST_REACHABLE_PATTERN, fileContents)) { _, _ -> }
+        val dceResult = DeadCodeElimination.run(setOf(inputFile), extractDeclarations(REQUEST_REACHABLE_PATTERN, fileContents),false) { _, _ -> }
         val reachableNodeStrings = dceResult.reachableNodes.map { it.toString().removePrefix("<unknown>.") }.toSet()
 
         for (assertedDeclaration in extractDeclarations(ASSERT_REACHABLE_PATTERN, fileContents)) {

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/BasicBoxTest.kt
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/BasicBoxTest.kt
@@ -929,7 +929,7 @@ abstract class BasicBoxTest(
             "kotlin-test.kotlin.test.DefaultAsserter"
         )
         val allFilesToMinify = filesToMinify.values + kotlinJsInputFile + kotlinTestJsInputFile
-        val dceResult = DeadCodeElimination.run(allFilesToMinify, additionalReachableNodes) { _, _ -> }
+        val dceResult = DeadCodeElimination.run(allFilesToMinify, additionalReachableNodes, false) { _, _ -> }
 
         val reachableNodes = dceResult.reachableNodes
         minificationThresholdChecker(reachableNodes.count { it.reachable })

--- a/js/js.tests/test/org/jetbrains/kotlin/js/test/BasicBoxTest.kt
+++ b/js/js.tests/test/org/jetbrains/kotlin/js/test/BasicBoxTest.kt
@@ -929,7 +929,10 @@ abstract class BasicBoxTest(
             "kotlin-test.kotlin.test.DefaultAsserter"
         )
         val allFilesToMinify = filesToMinify.values + kotlinJsInputFile + kotlinTestJsInputFile
-        val dceResult = DeadCodeElimination.run(allFilesToMinify, additionalReachableNodes, false) { _, _ -> }
+        val dceResult = DeadCodeElimination.run(
+            allFilesToMinify, additionalReachableNodes,
+            printReachabilityInfo = true, collectOnlyRootNodes = false
+        ) { _, _ -> }
 
         val reachableNodes = dceResult.reachableNodes
         minificationThresholdChecker(reachableNodes.count { it.reachable })


### PR DESCRIPTION
Few points:
- Don't store all reachable Js nodes in ReachabilityTracker while only roots are needed
- Make Context.Node class more lightweight because DCE produces tons of such instances
- Remove debug logging (significantly affects task execution time) 