### PR TITLE
kotlinc: Include kotlin-reflect to resulting jar when option -include-runtime is specified and option -no-reflect is not

### DIFF
--- a/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/CompileEnvironmentUtil.java
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/CompileEnvironmentUtil.java
@@ -28,6 +28,7 @@ import org.jetbrains.kotlin.cli.common.messages.MessageCollector;
 import org.jetbrains.kotlin.cli.common.modules.ModuleChunk;
 import org.jetbrains.kotlin.cli.common.modules.ModuleXmlParser;
 import org.jetbrains.kotlin.name.FqName;
+import org.jetbrains.kotlin.serialization.deserialization.builtins.BuiltInSerializerProtocol;
 import org.jetbrains.kotlin.utils.ExceptionUtilsKt;
 import org.jetbrains.kotlin.utils.PathUtil;
 
@@ -60,6 +61,7 @@ public class CompileEnvironmentUtil {
             OutputStream fos,
             @Nullable FqName mainClass,
             boolean includeRuntime,
+            boolean noReflect,
             boolean resetJarTimestamps
     ) {
         try {
@@ -89,6 +91,9 @@ public class CompileEnvironmentUtil {
             }
             if (includeRuntime) {
                 writeRuntimeToJar(stream, resetJarTimestamps);
+                if (!noReflect) {
+                    writeReflectToJar(stream, resetJarTimestamps);
+                }
             }
             stream.finish();
         }
@@ -98,12 +103,12 @@ public class CompileEnvironmentUtil {
     }
 
     public static void writeToJar(
-            File jarPath, boolean jarRuntime, boolean resetJarTimestamps, FqName mainClass, OutputFileCollection outputFiles
+            File jarPath, boolean jarRuntime, boolean noReflect, boolean resetJarTimestamps, FqName mainClass, OutputFileCollection outputFiles
     ) {
         FileOutputStream outputStream = null;
         try {
             outputStream = new FileOutputStream(jarPath);
-            doWriteToJar(outputFiles, outputStream, mainClass, jarRuntime, resetJarTimestamps);
+            doWriteToJar(outputFiles, outputStream, mainClass, jarRuntime, noReflect, resetJarTimestamps);
             outputStream.close();
         }
         catch (FileNotFoundException e) {
@@ -125,13 +130,22 @@ public class CompileEnvironmentUtil {
         copyJarImpl(stream, stdlibPath, resetJarTimestamps);
     }
 
+    private static void writeReflectToJar(JarOutputStream stream, boolean resetJarTimestamps) throws IOException {
+        File reflectPath = PathUtil.getKotlinPathsForCompiler().getReflectPath();
+        if (!reflectPath.exists()) {
+            throw new CompileEnvironmentException("Couldn't find kotlin-reflect at " + reflectPath);
+        }
+        copyJarImpl(stream, reflectPath, resetJarTimestamps);
+    }
+
     private static void copyJarImpl(JarOutputStream stream, File jarPath, boolean resetJarTimestamps) throws IOException {
         try (JarInputStream jis = new JarInputStream(new FileInputStream(jarPath))) {
             while (true) {
                 JarEntry e = jis.getNextJarEntry();
                 if (e == null) break;
 
-                if (!FileUtilRt.extensionEquals(e.getName(), "class") ||
+                if ((!FileUtilRt.extensionEquals(e.getName(), "class") &&
+                     !FileUtilRt.extensionEquals(e.getName(), BuiltInSerializerProtocol.BUILTINS_FILE_EXTENSION)) ||
                     StringsKt.substringAfterLast(e.getName(), "/", e.getName()).equals("module-info.class")) {
                     continue;
                 }

--- a/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinToJVMBytecodeCompiler.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinToJVMBytecodeCompiler.kt
@@ -86,8 +86,9 @@ object KotlinToJVMBytecodeCompiler {
         val messageCollector = configuration.get(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
         if (jarPath != null) {
             val includeRuntime = configuration.get(JVMConfigurationKeys.INCLUDE_RUNTIME, false)
+            val noReflect = configuration.get(JVMConfigurationKeys.NO_REFLECT, false)
             val resetJarTimestamps = !configuration.get(JVMConfigurationKeys.NO_RESET_JAR_TIMESTAMPS, false)
-            CompileEnvironmentUtil.writeToJar(jarPath, includeRuntime, resetJarTimestamps, mainClassFqName, outputFiles)
+            CompileEnvironmentUtil.writeToJar(jarPath, includeRuntime, noReflect, resetJarTimestamps, mainClassFqName, outputFiles)
             if (reportOutputFiles) {
                 val message = OutputMessageUtil.formatOutputMessage(outputFiles.asList().flatMap { it.sourceFiles }.distinct(), jarPath)
                 messageCollector.report(OUTPUT, message)

--- a/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/jvmArguments.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/jvmArguments.kt
@@ -21,6 +21,7 @@ import java.io.File
 
 fun CompilerConfiguration.setupJvmSpecificArguments(arguments: K2JVMCompilerArguments) {
     put(JVMConfigurationKeys.INCLUDE_RUNTIME, arguments.includeRuntime)
+    put(JVMConfigurationKeys.NO_REFLECT, arguments.noReflect)
 
     putIfNotNull(JVMConfigurationKeys.FRIEND_PATHS, arguments.friendPaths?.asList())
 

--- a/compiler/config.jvm/src/org/jetbrains/kotlin/config/JVMConfigurationKeys.java
+++ b/compiler/config.jvm/src/org/jetbrains/kotlin/config/JVMConfigurationKeys.java
@@ -146,4 +146,7 @@ public class JVMConfigurationKeys {
 
     public static final CompilerConfigurationKey<Boolean> ENABLE_JVM_PREVIEW =
             CompilerConfigurationKey.create("Enable Java language preview features");
+
+    public static final CompilerConfigurationKey<Boolean> NO_REFLECT =
+            CompilerConfigurationKey.create("Don't automatically include kotlin-reflect.jar into the output if the output is a jar");
 }

--- a/compiler/testData/integration/smoke/noReflect/noReflect.compile.expected
+++ b/compiler/testData/integration/smoke/noReflect/noReflect.compile.expected
@@ -1,0 +1,6 @@
+ERR:
+noReflect.kt:5:23: warning: call uses reflection API which is not found in compilation classpath. Make sure you have kotlin-reflect.jar in the classpath
+        String::class.annotations
+                      ^
+
+Return code: 0

--- a/compiler/testData/integration/smoke/noReflect/noReflect.kt
+++ b/compiler/testData/integration/smoke/noReflect/noReflect.kt
@@ -1,0 +1,9 @@
+package noReflect
+
+fun main() {
+    try {
+        String::class.annotations
+    } catch (e: KotlinReflectionNotSupportedError) {
+        println("KotlinReflectionNotSupportedError has been caught")
+    }
+}

--- a/compiler/testData/integration/smoke/noReflect/noReflect.run.expected
+++ b/compiler/testData/integration/smoke/noReflect/noReflect.run.expected
@@ -1,0 +1,4 @@
+OUT:
+KotlinReflectionNotSupportedError has been caught
+
+Return code: 0

--- a/compiler/testData/integration/smoke/reflect/reflect.compile.expected
+++ b/compiler/testData/integration/smoke/reflect/reflect.compile.expected
@@ -1,0 +1,1 @@
+Return code: 0

--- a/compiler/testData/integration/smoke/reflect/reflect.kt
+++ b/compiler/testData/integration/smoke/reflect/reflect.kt
@@ -1,0 +1,5 @@
+package reflect
+
+fun main() {
+    String::class.annotations
+}

--- a/compiler/testData/integration/smoke/reflect/reflect.run.expected
+++ b/compiler/testData/integration/smoke/reflect/reflect.run.expected
@@ -1,0 +1,1 @@
+Return code: 0

--- a/compiler/tests/org/jetbrains/kotlin/integration/CompilerSmokeTest.java
+++ b/compiler/tests/org/jetbrains/kotlin/integration/CompilerSmokeTest.java
@@ -187,4 +187,18 @@ public class CompilerSmokeTest extends CompilerSmokeTestBase {
         );
         run("buildFile.run", "-cp", tmpdir.getAbsolutePath(), "MainKt");
     }
+
+    public void testReflect() throws Exception {
+        String jar = tmpdir.getAbsolutePath() + File.separator + "reflect.jar";
+        assertEquals("compilation failed", 0,
+                     runCompiler("reflect.compile", "-include-runtime", "reflect.kt", "-d", jar));
+        run("reflect.run", "-cp", jar, "reflect.ReflectKt");
+    }
+
+    public void testNoReflect() throws Exception {
+        String jar = tmpdir.getAbsolutePath() + File.separator + "noReflect.jar";
+        assertEquals("compilation failed", 0,
+                     runCompiler("noReflect.compile", "-include-runtime", "-no-reflect", "noReflect.kt", "-d", jar));
+        run("noReflect.run", "-cp", jar, "noReflect.NoReflectKt");
+    }
 }


### PR DESCRIPTION
We should Include ```kotlin-reflect``` to resulting jar when option ```-include-runtime``` is specified  and option ```-no-reflect``` is not. For more details, please see [KT-17344](https://youtrack.jetbrains.com/issue/KT-17344)  && [KT-43220 ](https://youtrack.jetbrains.com/issue/KT-43220).

