### PR TITLE
KT-43686: Make kapt Gradle task cacheable across machines

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BuildCacheRelocationIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BuildCacheRelocationIT.kt
@@ -128,7 +128,8 @@ class BuildCacheRelocationIT : BaseGradleIT() {
                      cacheableTaskNames = listOf(
                          "kaptKotlin", "kaptGenerateStubsKotlin", "compileKotlin", "compileTestKotlin", "compileJava"
                      ),
-                     initProject = { File(projectDir, "build.gradle").appendText("\nkapt.useBuildCache = true") }
+                     initProject = { File(projectDir, "build.gradle").appendText("\nkapt.useBuildCache = true") },
+                     withAnotherGradleHome = true
             ),
             TestCase("kotlin2JsDceProject",
                      taskToExecute = arrayOf("assemble", "runDceKotlinJs"),

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/KaptWithoutKotlincTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/KaptWithoutKotlincTask.kt
@@ -50,7 +50,7 @@ abstract class KaptWithoutKotlincTask @Inject constructor(private val workerExec
     @get:Input
     internal val kotlinAndroidPluginWrapperPluginDoesNotExist = project.plugins.none { it is KotlinAndroidPluginWrapper }
 
-    @get:Input
+    @get:Classpath
     internal val kotlinStdlibClasspath = findKotlinStdlibClasspath(project)
 
     @get:Internal


### PR DESCRIPTION
Use `@Classpath` for kotlin stdlib input property. This is to
allow cache hits when builds are running on different machines
and path to kotlin stdlib differs.

Test: BuildCacheRelocationIT