### PR TITLE
KT-43804 [kapt] take argument names from original descriptor

### DIFF
--- a/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/ClassFileToSourceStubConverter.kt
+++ b/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/ClassFileToSourceStubConverter.kt
@@ -882,7 +882,7 @@ class ClassFileToSourceStubConverter(val kaptContext: KaptContextForStubGenerati
         val asmReturnType = Type.getReturnType(method.desc)
         val jcReturnType = if (isConstructor) null else treeMaker.Type(asmReturnType)
 
-        val parametersInfo = method.getParametersInfo(containingClass, isInner)
+        val parametersInfo = method.getParametersInfo(containingClass, isInner, descriptor)
 
         if (!checkIfValidTypeName(containingClass, asmReturnType)
             || parametersInfo.any { !checkIfValidTypeName(containingClass, it.type) }

--- a/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/parseParameters.kt
+++ b/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/parseParameters.kt
@@ -17,6 +17,7 @@
 package org.jetbrains.kotlin.kapt3.stubs
 
 import org.jetbrains.kotlin.codegen.AsmUtil
+import org.jetbrains.kotlin.descriptors.CallableDescriptor
 import org.jetbrains.kotlin.kapt3.util.isAbstract
 import org.jetbrains.kotlin.kapt3.util.isEnum
 import org.jetbrains.kotlin.kapt3.util.isJvmOverloadsGenerated
@@ -35,7 +36,11 @@ internal class ParameterInfo(
     val invisibleAnnotations: List<AnnotationNode>?
 )
 
-internal fun MethodNode.getParametersInfo(containingClass: ClassNode, isInnerClassMember: Boolean): List<ParameterInfo> {
+internal fun MethodNode.getParametersInfo(
+    containingClass: ClassNode,
+    isInnerClassMember: Boolean,
+    originalDescriptor: CallableDescriptor
+): List<ParameterInfo> {
     val localVariables = this.localVariables ?: emptyList()
     val parameters = this.parameters ?: emptyList()
     val isStatic = isStatic(access)
@@ -67,6 +72,8 @@ internal fun MethodNode.getParametersInfo(containingClass: ClassNode, isInnerCla
 
         // @JvmOverloads constructors and ordinary methods don't have "this" local variable
         name = name ?: localVariables.getOrNull(index + localVariableIndexOffset)?.name
+
+        name = name ?: originalDescriptor.valueParameters.getOrNull(index)?.name?.identifier
                 ?: "p${index - startParameterIndex}"
 
         // Property setters has bad parameter names

--- a/plugins/kapt3/kapt3-compiler/test/org/jetbrains/kotlin/kapt3/test/ClassFileToSourceStubConverterTestGenerated.java
+++ b/plugins/kapt3/kapt3-compiler/test/org/jetbrains/kotlin/kapt3/test/ClassFileToSourceStubConverterTestGenerated.java
@@ -449,6 +449,11 @@ public class ClassFileToSourceStubConverterTestGenerated extends AbstractClassFi
         runTest("plugins/kapt3/kapt3-compiler/testData/converter/stripMetadata.kt");
     }
 
+    @TestMetadata("suspendArgName.kt")
+    public void testSuspendArgName() throws Exception {
+        runTest("plugins/kapt3/kapt3-compiler/testData/converter/suspendArgName.kt");
+    }
+
     @TestMetadata("suspendErrorTypes.kt")
     public void testSuspendErrorTypes() throws Exception {
         runTest("plugins/kapt3/kapt3-compiler/testData/converter/suspendErrorTypes.kt");

--- a/plugins/kapt3/kapt3-compiler/test/org/jetbrains/kotlin/kapt3/test/IrClassFileToSourceStubConverterTestGenerated.java
+++ b/plugins/kapt3/kapt3-compiler/test/org/jetbrains/kotlin/kapt3/test/IrClassFileToSourceStubConverterTestGenerated.java
@@ -450,6 +450,11 @@ public class IrClassFileToSourceStubConverterTestGenerated extends AbstractIrCla
         runTest("plugins/kapt3/kapt3-compiler/testData/converter/stripMetadata.kt");
     }
 
+    @TestMetadata("suspendArgName.kt")
+    public void testSuspendArgName() throws Exception {
+        runTest("plugins/kapt3/kapt3-compiler/testData/converter/suspendArgName.kt");
+    }
+
     @TestMetadata("suspendErrorTypes.kt")
     public void testSuspendErrorTypes() throws Exception {
         runTest("plugins/kapt3/kapt3-compiler/testData/converter/suspendErrorTypes.kt");

--- a/plugins/kapt3/kapt3-compiler/testData/converter/dataClass.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/dataClass.txt
@@ -17,7 +17,7 @@ public final class User {
 
     @java.lang.Override()
     public boolean equals(@org.jetbrains.annotations.Nullable()
-    java.lang.Object p0) {
+    java.lang.Object other) {
         return false;
     }
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/errorSuperclass.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/errorSuperclass.txt
@@ -23,11 +23,11 @@ public final class ClassWithParent implements java.lang.CharSequence {
     }
 
     @java.lang.Override()
-    public final char charAt(int p0) {
+    public final char charAt(int index) {
         return '\u0000';
     }
 
-    public abstract char get(int p0);
+    public abstract char get(int index);
 
     public abstract int getLength();
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/errorSuperclassCorrectErrorTypes.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/errorSuperclassCorrectErrorTypes.txt
@@ -10,32 +10,32 @@ public final class Child extends kotlin.collections.AbstractList<java.lang.Strin
     }
 
     @java.lang.Override()
-    public final boolean contains(java.lang.Object p0) {
+    public final boolean contains(java.lang.Object element) {
         return false;
     }
 
     @java.lang.Override()
-    public boolean contains(java.lang.String p0) {
+    public boolean contains(java.lang.String element) {
         return false;
     }
 
     @java.lang.Override()
-    public final int indexOf(java.lang.Object p0) {
+    public final int indexOf(java.lang.Object element) {
         return 0;
     }
 
     @java.lang.Override()
-    public int indexOf(java.lang.String p0) {
+    public int indexOf(java.lang.String element) {
         return 0;
     }
 
     @java.lang.Override()
-    public final int lastIndexOf(java.lang.Object p0) {
+    public final int lastIndexOf(java.lang.Object element) {
         return 0;
     }
 
     @java.lang.Override()
-    public int lastIndexOf(java.lang.String p0) {
+    public int lastIndexOf(java.lang.String element) {
         return 0;
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/inlineClasses.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/inlineClasses.txt
@@ -10,7 +10,7 @@ public final class Cl {
     private final java.lang.String a = null;
 
     @java.lang.Override()
-    public boolean equals(java.lang.Object p0) {
+    public boolean equals(java.lang.Object other) {
         return false;
     }
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/suspendArgName.kt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/suspendArgName.kt
@@ -1,0 +1,10 @@
+open class Test {
+
+    open fun getTestNoSuspend(text: String): String {
+        return text
+    }
+
+    open suspend fun getTest(text: String): String {
+        return text
+    }
+}

--- a/plugins/kapt3/kapt3-compiler/testData/converter/suspendArgName.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/suspendArgName.txt
@@ -1,0 +1,22 @@
+import java.lang.System;
+
+@kotlin.Metadata()
+public class Test {
+
+    public Test() {
+        super();
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public java.lang.String getTestNoSuspend(@org.jetbrains.annotations.NotNull()
+    java.lang.String text) {
+        return null;
+    }
+
+    @org.jetbrains.annotations.Nullable()
+    public java.lang.Object getTest(@org.jetbrains.annotations.NotNull()
+    java.lang.String text, @org.jetbrains.annotations.NotNull()
+    kotlin.coroutines.Continuation<? super java.lang.String> continuation) {
+        return null;
+    }
+}

--- a/plugins/kapt3/kapt3-compiler/testData/converter/suspendErrorTypes.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/suspendErrorTypes.txt
@@ -9,7 +9,7 @@ public final class Foo {
 
     @org.jetbrains.annotations.Nullable()
     public final java.lang.Object a(@org.jetbrains.annotations.NotNull()
-    kotlin.coroutines.Continuation<ABC> p0) {
+    kotlin.coroutines.Continuation<ABC> continuation) {
         return null;
     }
 }


### PR DESCRIPTION
Suspend functions doesn't have local variables with names (it seems so). Try to fallback to parameters from original descriptor.