### PR TITLE
Improve error message for pre-release classes accessed by a release c…

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/writeAnnotationUtil.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/writeAnnotationUtil.kt
@@ -18,6 +18,7 @@ package org.jetbrains.kotlin.codegen
 
 import org.jetbrains.kotlin.codegen.state.GenerationState
 import org.jetbrains.kotlin.config.JvmAnalysisFlags
+import org.jetbrains.kotlin.config.KotlinCompilerVersion
 import org.jetbrains.kotlin.load.java.JvmAnnotationNames
 import org.jetbrains.kotlin.load.kotlin.JvmBytecodeBinaryVersion
 import org.jetbrains.kotlin.load.kotlin.header.KotlinClassHeader
@@ -40,6 +41,7 @@ fun writeKotlinMetadata(
     var flags = extraFlags
     if (state.languageVersionSettings.isPreRelease()) {
         flags = flags or JvmAnnotationNames.METADATA_PRE_RELEASE_FLAG
+        av.visit(JvmAnnotationNames.COMPILER_VERSION_FIELD_NAME, KotlinCompilerVersion.VERSION)
     }
     if (state.languageVersionSettings.getFlag(JvmAnalysisFlags.strictMetadataVersionSemantics)) {
         flags = flags or JvmAnnotationNames.METADATA_STRICT_VERSION_SEMANTICS_FLAG

--- a/compiler/cli/src/org/jetbrains/kotlin/cli/common/messages/AnalyzerWithCompilerReport.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/common/messages/AnalyzerWithCompilerReport.kt
@@ -172,7 +172,7 @@ class AnalyzerWithCompilerReport(
                 )
             }
 
-            if (diagnostics.any { it.factory == Errors.PRE_RELEASE_CLASS }) {
+            if (diagnostics.any { it.factory == Errors.PRE_RELEASE_CLASS || it.factory == Errors.PRE_RELEASE_CLASS_WITH_COMPILER_VERSION }) {
                 messageCollector.report(
                     ERROR,
                     "Pre-release classes were found in dependencies. " +

--- a/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/Errors.java
+++ b/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/Errors.java
@@ -129,6 +129,7 @@ public interface Errors {
     DiagnosticFactory1<PsiElement, String> MISSING_IMPORTED_SCRIPT_PSI = DiagnosticFactory1.create(ERROR);
     DiagnosticFactory1<PsiElement, String> MISSING_SCRIPT_PROVIDED_PROPERTY_CLASS = DiagnosticFactory1.create(ERROR);
     DiagnosticFactory1<PsiElement, String> PRE_RELEASE_CLASS = DiagnosticFactory1.create(ERROR);
+    DiagnosticFactory2<PsiElement, String, String> PRE_RELEASE_CLASS_WITH_COMPILER_VERSION = DiagnosticFactory2.create(ERROR);
     DiagnosticFactory1<PsiElement, String> IR_WITH_UNSTABLE_ABI_COMPILED_CLASS = DiagnosticFactory1.create(ERROR);
     DiagnosticFactory1<PsiElement, String> FIR_COMPILED_CLASS = DiagnosticFactory1.create(ERROR);
     DiagnosticFactory2<PsiElement, String, IncompatibleVersionErrorData<?>> INCOMPATIBLE_CLASS = DiagnosticFactory2.create(ERROR);

--- a/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/rendering/DefaultErrorMessages.java
+++ b/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/rendering/DefaultErrorMessages.java
@@ -417,6 +417,7 @@ public class DefaultErrorMessages {
         MAP.put(MISSING_IMPORTED_SCRIPT_PSI, "Imported script file ''{0}'' is not loaded. Check your script imports", TO_STRING);
         MAP.put(MISSING_SCRIPT_PROVIDED_PROPERTY_CLASS, "Cannot access script provided property class ''{0}''. Check your module classpath for missing or conflicting dependencies", TO_STRING);
         MAP.put(PRE_RELEASE_CLASS, "{0} is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler", TO_STRING);
+        MAP.put(PRE_RELEASE_CLASS_WITH_COMPILER_VERSION, "{0} is compiled by a pre-release version of Kotlin {1} and cannot be loaded by this version of the compiler", TO_STRING, TO_STRING);
         MAP.put(IR_WITH_UNSTABLE_ABI_COMPILED_CLASS, "{0} is compiled by an unstable version of the Kotlin compiler and cannot be loaded by this compiler", TO_STRING);
         MAP.put(FIR_COMPILED_CLASS, "{0} is compiled by the new Kotlin compiler frontend and cannot be loaded by the old compiler", TO_STRING);
         MAP.put(INCOMPATIBLE_CLASS,

--- a/compiler/frontend/src/org/jetbrains/kotlin/resolve/checkers/MissingDependencyClassChecker.kt
+++ b/compiler/frontend/src/org/jetbrains/kotlin/resolve/checkers/MissingDependencyClassChecker.kt
@@ -57,7 +57,10 @@ object MissingDependencyClassChecker : CallChecker {
                 return INCOMPATIBLE_CLASS.on(reportOn, source.presentableString, incompatibility)
             }
             if (source.isPreReleaseInvisible) {
-                return PRE_RELEASE_CLASS.on(reportOn, source.presentableString)
+                return if (source.compilerVersion.isNullOrEmpty())
+                    PRE_RELEASE_CLASS.on(reportOn, source.presentableString)
+                else
+                    PRE_RELEASE_CLASS_WITH_COMPILER_VERSION.on(reportOn, source.presentableString, source.compilerVersion!!)
             }
             if (source.abiStability == DeserializedContainerAbiStability.FIR_UNSTABLE) {
                 return FIR_COMPILED_CLASS.on(reportOn, source.presentableString)

--- a/compiler/ir/backend.jvm/entrypoint/src/org/jetbrains/kotlin/backend/jvm/FacadeClassSourceShimForFragmentCompilation.kt
+++ b/compiler/ir/backend.jvm/entrypoint/src/org/jetbrains/kotlin/backend/jvm/FacadeClassSourceShimForFragmentCompilation.kt
@@ -31,6 +31,8 @@ class FacadeClassSourceShimForFragmentCompilation(private val containingFile: Ps
         get() = DeserializedContainerAbiStability.STABLE
     override val presentableString: String
         get() = "Fragment for $containingFile"
+    override val compilerVersion: String?
+        get() = null
 
     override fun getContainingFile(): SourceFile {
         return containingFile

--- a/compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/output.txt
+++ b/compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/output.txt
@@ -1,41 +1,41 @@
 error: pre-release classes were found in dependencies. Remove them from the classpath, recompile with a release compiler or use '-Xskip-prerelease-check' to suppress errors
-compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:5:16: error: class 'a.A' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
+compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:5:16: error: class 'a.A' is compiled by a pre-release version of Kotlin $VERSION$ and cannot be loaded by this version of the compiler
 fun baz(param: A, nested: A.Nested) {
                ^
-compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:5:27: error: class 'a.A' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
+compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:5:27: error: class 'a.A' is compiled by a pre-release version of Kotlin $VERSION$ and cannot be loaded by this version of the compiler
 fun baz(param: A, nested: A.Nested) {
                           ^
-compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:5:29: error: class 'a.A.Nested' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
+compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:5:29: error: class 'a.A.Nested' is compiled by a pre-release version of Kotlin $VERSION$ and cannot be loaded by this version of the compiler
 fun baz(param: A, nested: A.Nested) {
                             ^
-compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:6:23: error: class 'a.A' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
+compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:6:23: error: class 'a.A' is compiled by a pre-release version of Kotlin $VERSION$ and cannot be loaded by this version of the compiler
     val constructor = A()
                       ^
-compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:7:18: error: class 'a.A' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
+compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:7:18: error: class 'a.A' is compiled by a pre-release version of Kotlin $VERSION$ and cannot be loaded by this version of the compiler
     val nested = A.Nested()
                  ^
-compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:7:20: error: class 'a.A.Nested' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
+compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:7:20: error: class 'a.A.Nested' is compiled by a pre-release version of Kotlin $VERSION$ and cannot be loaded by this version of the compiler
     val nested = A.Nested()
                    ^
-compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:8:22: error: class 'a.A' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
+compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:8:22: error: class 'a.A' is compiled by a pre-release version of Kotlin $VERSION$ and cannot be loaded by this version of the compiler
     val methodCall = param.method()
                      ^
 compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:8:28: error: unresolved reference: method
     val methodCall = param.method()
                            ^
-compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:9:30: error: class 'a.A' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
+compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:9:30: error: class 'a.A' is compiled by a pre-release version of Kotlin $VERSION$ and cannot be loaded by this version of the compiler
     val supertype = object : A() {}
                              ^
-compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:11:13: error: class 'a.AKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
+compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:11:13: error: class 'a.AKt' is compiled by a pre-release version of Kotlin $VERSION$ and cannot be loaded by this version of the compiler
     val x = foo()
             ^
-compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:12:13: error: class 'a.AKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
+compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:12:13: error: class 'a.AKt' is compiled by a pre-release version of Kotlin $VERSION$ and cannot be loaded by this version of the compiler
     val y = bar
             ^
-compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:13:5: error: class 'a.AKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
+compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:13:5: error: class 'a.AKt' is compiled by a pre-release version of Kotlin $VERSION$ and cannot be loaded by this version of the compiler
     bar = 239
     ^
-compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:14:12: error: class 'a.AKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
+compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:14:12: error: class 'a.AKt' is compiled by a pre-release version of Kotlin $VERSION$ and cannot be loaded by this version of the compiler
     val z: TA = ""
            ^
 COMPILATION_ERROR

--- a/core/compiler.common.jvm/src/org/jetbrains/kotlin/load/java/JvmAnnotationNames.java
+++ b/core/compiler.common.jvm/src/org/jetbrains/kotlin/load/java/JvmAnnotationNames.java
@@ -28,6 +28,7 @@ public final class JvmAnnotationNames {
     public static final String METADATA_DESC = "L" + JvmClassName.byFqNameWithoutInnerClasses(METADATA_FQ_NAME).getInternalName() + ";";
 
     public static final String METADATA_VERSION_FIELD_NAME = "mv";
+    public static final String COMPILER_VERSION_FIELD_NAME = "cv";
     public static final String KIND_FIELD_NAME = "k";
     public static final String METADATA_DATA_FIELD_NAME = "d1";
     public static final String METADATA_STRINGS_FIELD_NAME = "d2";

--- a/core/compiler.common/src/org/jetbrains/kotlin/serialization/deserialization/descriptors/DeserializedContainerSource.kt
+++ b/core/compiler.common/src/org/jetbrains/kotlin/serialization/deserialization/descriptors/DeserializedContainerSource.kt
@@ -21,6 +21,9 @@ interface DeserializedContainerSource : SourceElement {
 
     // This string should only be used in error messages
     val presentableString: String
+
+    // This string used in error messages
+    val compilerVersion: String?
 }
 
 enum class DeserializedContainerAbiStability {

--- a/core/descriptors.jvm/src/org/jetbrains/kotlin/load/kotlin/header/ReadKotlinClassHeaderAnnotationVisitor.java
+++ b/core/descriptors.jvm/src/org/jetbrains/kotlin/load/kotlin/header/ReadKotlinClassHeaderAnnotationVisitor.java
@@ -51,6 +51,7 @@ public class ReadKotlinClassHeaderAnnotationVisitor implements AnnotationVisitor
     }
 
     private int[] metadataVersionArray = null;
+    private String compilerVersion = null;
     private String extraString = null;
     private int extraInt = 0;
     private String packageName = null;
@@ -87,6 +88,7 @@ public class ReadKotlinClassHeaderAnnotationVisitor implements AnnotationVisitor
         return new KotlinClassHeader(
                 headerKind,
                 metadataVersion,
+                compilerVersion,
                 data,
                 incompatibleData,
                 strings,
@@ -148,6 +150,11 @@ public class ReadKotlinClassHeaderAnnotationVisitor implements AnnotationVisitor
             else if (METADATA_VERSION_FIELD_NAME.equals(string)) {
                 if (value instanceof int[]) {
                     metadataVersionArray = (int[]) value;
+                }
+            }
+            else if (COMPILER_VERSION_FIELD_NAME.equals(string)) {
+                if (value instanceof String) {
+                    compilerVersion = (String) value;
                 }
             }
             else if (METADATA_EXTRA_STRING_FIELD_NAME.equals(string)) {

--- a/core/deserialization.common.jvm/src/org/jetbrains/kotlin/load/kotlin/JvmPackagePartSource.kt
+++ b/core/deserialization.common.jvm/src/org/jetbrains/kotlin/load/kotlin/JvmPackagePartSource.kt
@@ -60,6 +60,9 @@ class JvmPackagePartSource(
 
     val classId: ClassId get() = ClassId(className.packageFqName, simpleName)
 
+    override val compilerVersion: String?
+        get() = knownJvmBinaryClass?.classHeader?.compilerVersion
+
     override fun toString() = "${this::class.java.simpleName}: $className"
 
     override fun getContainingFile(): SourceFile = SourceFile.NO_SOURCE_FILE

--- a/core/deserialization.common.jvm/src/org/jetbrains/kotlin/load/kotlin/KotlinJvmBinarySourceElement.kt
+++ b/core/deserialization.common.jvm/src/org/jetbrains/kotlin/load/kotlin/KotlinJvmBinarySourceElement.kt
@@ -31,6 +31,9 @@ class KotlinJvmBinarySourceElement(
     override val presentableString: String
         get() = "Class '${binaryClass.classId.asSingleFqName().asString()}'"
 
+    override val compilerVersion: String?
+        get() = binaryClass.classHeader.compilerVersion
+
     override fun getContainingFile(): SourceFile = SourceFile.NO_SOURCE_FILE
 
     override fun toString() = "${this::class.java.simpleName}: $binaryClass"

--- a/core/deserialization.common.jvm/src/org/jetbrains/kotlin/load/kotlin/header/KotlinClassHeader.kt
+++ b/core/deserialization.common.jvm/src/org/jetbrains/kotlin/load/kotlin/header/KotlinClassHeader.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.metadata.jvm.deserialization.JvmMetadataVersion
 class KotlinClassHeader(
     val kind: Kind,
     val metadataVersion: JvmMetadataVersion,
+    val compilerVersion: String?,
     val data: Array<String>?,
     val incompatibleData: Array<String>?,
     val strings: Array<String>?,

--- a/js/js.serializer/src/org/jetbrains/kotlin/serialization/js/KotlinJavascriptPackageFragment.kt
+++ b/js/js.serializer/src/org/jetbrains/kotlin/serialization/js/KotlinJavascriptPackageFragment.kt
@@ -100,5 +100,8 @@ class KotlinJavascriptPackageFragment(
 
         override val presentableString: String
             get() = "Package '$fqName'"
+
+        override val compilerVersion: String?
+            get() = null
     }
 }


### PR DESCRIPTION
This PR is related to [KT-16279](https://youtrack.jetbrains.com/issue/KT-16279), but only considered the ```Kotlin/JVM``` compiler. Should we also consider the ```Kotlin/JS``` compiler in this issue?