### PR TITLE
[JVM_IR] Reduce the amount of `super` suffixes on accesibility bridges.

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/SyntheticAccessorLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/SyntheticAccessorLowering.kt
@@ -531,9 +531,10 @@ internal class SyntheticAccessorLowering(val context: JvmBackendContext) : IrEle
             // Accessor for _s_uper-qualified call
             superQualifier != null -> "\$s" + superQualifier.owner.syntheticAccessorToSuperSuffix()
 
-            // Access to static members that need an accessor must be because they are inherited,
-            // hence accessed on a _s_upertype.
-            isStatic -> "\$s" + parentAsClass.syntheticAccessorToSuperSuffix()
+            // Access to protected members that need an accessor must be because they are inherited,
+            // hence accessed on a _s_upertype. If what is accessed is static, we can point to different
+            // parts of the inheritance hierarchy and need to distinguish with a suffix.
+            isStatic && visibility.isProtected -> "\$s" + parentAsClass.syntheticAccessorToSuperSuffix()
 
             else -> ""
         }
@@ -556,9 +557,10 @@ internal class SyntheticAccessorLowering(val context: JvmBackendContext) : IrEle
             return "cp"
         }
 
-        // Static accesses that need an accessor must be due to being inherited, hence accessed on a
-        // _s_upertype
-        return "p" + if (isStatic) "\$s" + parentAsClass.syntheticAccessorToSuperSuffix() else ""
+        // Accesses to static protected fields that need an accessor must be due to being inherited, hence accessed on a
+        // _s_upertype. If the field is static, the super class the access is on can be different and therefore
+        // we generate a suffix to distinguish access to field with different receiver types in the super hierarchy.
+        return "p" + if (isStatic && visibility.isProtected) "\$s" + parentAsClass.syntheticAccessorToSuperSuffix() else ""
     }
 
     private val DescriptorVisibility.isPrivate

--- a/compiler/testData/codegen/bytecodeListing/accessorForTopLevelMembers.kt
+++ b/compiler/testData/codegen/bytecodeListing/accessorForTopLevelMembers.kt
@@ -1,0 +1,6 @@
+private val x: String = "OK"
+private fun f(y: String) = y
+
+class A {
+    fun g() = f(x)
+}

--- a/compiler/testData/codegen/bytecodeListing/accessorForTopLevelMembers.txt
+++ b/compiler/testData/codegen/bytecodeListing/accessorForTopLevelMembers.txt
@@ -1,0 +1,16 @@
+@kotlin.Metadata
+public final class A {
+    // source: 'accessorForTopLevelMembers.kt'
+    public method <init>(): void
+    public final @org.jetbrains.annotations.NotNull method g(): java.lang.String
+}
+
+@kotlin.Metadata
+public final class AccessorForTopLevelMembersKt {
+    // source: 'accessorForTopLevelMembers.kt'
+    private final static field x: java.lang.String
+    static method <clinit>(): void
+    public synthetic final static method access$f(p0: java.lang.String): java.lang.String
+    public synthetic final static method access$getX$p(): java.lang.String
+    private final static method f(p0: java.lang.String): java.lang.String
+}

--- a/compiler/testData/codegen/bytecodeListing/accessorForTopLevelMembers_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/accessorForTopLevelMembers_ir.txt
@@ -1,0 +1,16 @@
+@kotlin.Metadata
+public final class A {
+    // source: 'accessorForTopLevelMembers.kt'
+    public method <init>(): void
+    public final @org.jetbrains.annotations.NotNull method g(): java.lang.String
+}
+
+@kotlin.Metadata
+public final class AccessorForTopLevelMembersKt {
+    // source: 'accessorForTopLevelMembers.kt'
+    private final static @org.jetbrains.annotations.NotNull field x: java.lang.String
+    static method <clinit>(): void
+    public synthetic final static method access$f(p0: java.lang.String): java.lang.String
+    public synthetic final static method access$getX$p(): java.lang.String
+    private final static method f(p0: java.lang.String): java.lang.String
+}

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/BytecodeListingTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/BytecodeListingTestGenerated.java
@@ -35,6 +35,11 @@ public class BytecodeListingTestGenerated extends AbstractBytecodeListingTest {
         runTest("compiler/testData/codegen/bytecodeListing/accessorForProtectedPropertyWithPrivateSetterInObjectLiteral.kt");
     }
 
+    @TestMetadata("accessorForTopLevelMembers.kt")
+    public void testAccessorForTopLevelMembers() throws Exception {
+        runTest("compiler/testData/codegen/bytecodeListing/accessorForTopLevelMembers.kt");
+    }
+
     public void testAllFilesPresentInBytecodeListing() throws Exception {
         KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/bytecodeListing"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM, true);
     }

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/IrBytecodeListingTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/IrBytecodeListingTestGenerated.java
@@ -35,6 +35,11 @@ public class IrBytecodeListingTestGenerated extends AbstractIrBytecodeListingTes
         runTest("compiler/testData/codegen/bytecodeListing/accessorForProtectedPropertyWithPrivateSetterInObjectLiteral.kt");
     }
 
+    @TestMetadata("accessorForTopLevelMembers.kt")
+    public void testAccessorForTopLevelMembers() throws Exception {
+        runTest("compiler/testData/codegen/bytecodeListing/accessorForTopLevelMembers.kt");
+    }
+
     public void testAllFilesPresentInBytecodeListing() throws Exception {
         KotlinTestUtils.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/bytecodeListing"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
     }

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/customSimple.ir.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/customSimple.ir.txt
@@ -41,7 +41,7 @@ public final class User$Creator : java/lang/Object, android/os/Parcelable$Creato
           ALOAD (1)
           LDC (parcel)
           INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
-          INVOKESTATIC (User, access$getCompanion$p$s2645995, ()LUser$Companion;)
+          INVOKESTATIC (User, access$getCompanion$p, ()LUser$Companion;)
           ALOAD (1)
           INVOKEVIRTUAL (User$Companion, create, (Landroid/os/Parcel;)LUser;)
           ARETURN
@@ -90,7 +90,7 @@ public final class User : java/lang/Object, android/os/Parcelable {
 
     public void <init>(java.lang.String firstName, java.lang.String lastName, int age)
 
-    public final static User$Companion access$getCompanion$p$s2645995()
+    public final static User$Companion access$getCompanion$p()
 
     public int describeContents()
 

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/customSimpleWithNewArray.ir.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/customSimpleWithNewArray.ir.txt
@@ -40,7 +40,7 @@ public final class User$Creator : java/lang/Object, android/os/Parcelable$Creato
 
     public final User[] newArray(int size) {
         LABEL (L0)
-          INVOKESTATIC (User, access$getCompanion$p$s2645995, ()LUser$Companion;)
+          INVOKESTATIC (User, access$getCompanion$p, ()LUser$Companion;)
           ILOAD (1)
           INVOKEVIRTUAL (User$Companion, newArray, (I)[LUser;)
           ARETURN
@@ -72,7 +72,7 @@ public final class User : java/lang/Object, android/os/Parcelable {
 
     public void <init>(java.lang.String firstName, java.lang.String lastName, int age)
 
-    public final static User$Companion access$getCompanion$p$s2645995()
+    public final static User$Companion access$getCompanion$p()
 
     public int describeContents()
 


### PR DESCRIPTION
The super suffix was used for any static field/method that needed
an accessor. We should only use it when that field or method is
inherited.

(cherry picked from commit ef36b81c6764119941a39ee1ea0f58178f380a8c)