### PR TITLE
JVM IR: Fix inline class mangling for calls to internal functions in a different module

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/codegen/FirCompileKotlinAgainstKotlinTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/codegen/FirCompileKotlinAgainstKotlinTestGenerated.java
@@ -245,6 +245,11 @@ public class FirCompileKotlinAgainstKotlinTestGenerated extends AbstractFirCompi
         runTest("compiler/testData/compileKotlinAgainstKotlin/internalWithDefaultArgs.kt");
     }
 
+    @TestMetadata("internalWithInlineClass.kt")
+    public void testInternalWithInlineClass() throws Exception {
+        runTest("compiler/testData/compileKotlinAgainstKotlin/internalWithInlineClass.kt");
+    }
+
     @TestMetadata("internalWithOtherModuleName.kt")
     public void testInternalWithOtherModuleName() throws Exception {
         runTest("compiler/testData/compileKotlinAgainstKotlin/internalWithOtherModuleName.kt");

--- a/compiler/incremental-compilation-impl/test/org/jetbrains/kotlin/incremental/IncrementalMultiModuleJsCompilerRunnerTestGenerated.java
+++ b/compiler/incremental-compilation-impl/test/org/jetbrains/kotlin/incremental/IncrementalMultiModuleJsCompilerRunnerTestGenerated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 

--- a/compiler/incremental-compilation-impl/test/org/jetbrains/kotlin/incremental/IncrementalMultiModuleJsKlibCompilerRunnerTestGenerated.java
+++ b/compiler/incremental-compilation-impl/test/org/jetbrains/kotlin/incremental/IncrementalMultiModuleJsKlibCompilerRunnerTestGenerated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/MethodSignatureMapper.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/MethodSignatureMapper.kt
@@ -134,7 +134,10 @@ class MethodSignatureMapper(private val context: JvmBackendContext) {
             origin != JvmLoweredDeclarationOrigin.SYNTHETIC_METHOD_FOR_PROPERTY_OR_TYPEALIAS_ANNOTATIONS &&
             !isPublishedApi()
         ) {
-            return this
+            return originalFunction.takeIf { it != this }
+                ?.safeAs<IrSimpleFunction>()
+                ?.getInternalFunctionForManglingIfNeeded()
+                ?: this
         }
         originalForDefaultAdapter?.getInternalFunctionForManglingIfNeeded()?.let { return it }
         return null

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/irCodegenUtils.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/irCodegenUtils.kt
@@ -383,12 +383,13 @@ fun IrSimpleType.isRawType(): Boolean =
     hasAnnotation(JvmGeneratorExtensions.RAW_TYPE_ANNOTATION_FQ_NAME)
 
 internal fun classFileContainsMethod(classId: ClassId, function: IrFunction, context: JvmBackendContext): Boolean? {
-    val originalDescriptor = context.methodSignatureMapper.mapSignatureWithGeneric(function).asmMethod.descriptor
+    val originalSignature = context.methodSignatureMapper.mapSignatureWithGeneric(function).asmMethod
+    val originalDescriptor = originalSignature.descriptor
     val descriptor = if (function.isSuspend)
         listOf(*Type.getArgumentTypes(originalDescriptor), Type.getObjectType("kotlin/coroutines/Continuation"))
             .joinToString(prefix = "(", postfix = ")", separator = "") + AsmTypes.OBJECT_TYPE
     else originalDescriptor
-    return classFileContainsMethod(classId, context.state, Method(function.name.asString(), descriptor))
+    return classFileContainsMethod(classId, context.state, Method(originalSignature.name, descriptor))
 }
 
 val IrMemberWithContainerSource.parentClassId: ClassId?

--- a/compiler/testData/compileKotlinAgainstKotlin/internalWithInlineClass.kt
+++ b/compiler/testData/compileKotlinAgainstKotlin/internalWithInlineClass.kt
@@ -1,0 +1,16 @@
+// IGNORE_BACKEND_FIR: JVM_IR
+// FILE: A.kt
+
+package a
+
+inline class Message(val value: String)
+
+class Box {
+    internal fun result(msg: Message): String = msg.value
+}
+
+// FILE: B.kt
+
+fun box(): String {
+    return a.Box().result(a.Message("OK"))
+}

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/CompileKotlinAgainstKotlinTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/CompileKotlinAgainstKotlinTestGenerated.java
@@ -244,6 +244,11 @@ public class CompileKotlinAgainstKotlinTestGenerated extends AbstractCompileKotl
         runTest("compiler/testData/compileKotlinAgainstKotlin/internalWithDefaultArgs.kt");
     }
 
+    @TestMetadata("internalWithInlineClass.kt")
+    public void testInternalWithInlineClass() throws Exception {
+        runTest("compiler/testData/compileKotlinAgainstKotlin/internalWithInlineClass.kt");
+    }
+
     @TestMetadata("internalWithOtherModuleName.kt")
     public void testInternalWithOtherModuleName() throws Exception {
         runTest("compiler/testData/compileKotlinAgainstKotlin/internalWithOtherModuleName.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/IrCompileKotlinAgainstKotlinTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/IrCompileKotlinAgainstKotlinTestGenerated.java
@@ -245,6 +245,11 @@ public class IrCompileKotlinAgainstKotlinTestGenerated extends AbstractIrCompile
         runTest("compiler/testData/compileKotlinAgainstKotlin/internalWithDefaultArgs.kt");
     }
 
+    @TestMetadata("internalWithInlineClass.kt")
+    public void testInternalWithInlineClass() throws Exception {
+        runTest("compiler/testData/compileKotlinAgainstKotlin/internalWithInlineClass.kt");
+    }
+
     @TestMetadata("internalWithOtherModuleName.kt")
     public void testInternalWithOtherModuleName() throws Exception {
         runTest("compiler/testData/compileKotlinAgainstKotlin/internalWithOtherModuleName.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/JvmIrAgainstOldBoxTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/JvmIrAgainstOldBoxTestGenerated.java
@@ -245,6 +245,11 @@ public class JvmIrAgainstOldBoxTestGenerated extends AbstractJvmIrAgainstOldBoxT
         runTest("compiler/testData/compileKotlinAgainstKotlin/internalWithDefaultArgs.kt");
     }
 
+    @TestMetadata("internalWithInlineClass.kt")
+    public void testInternalWithInlineClass() throws Exception {
+        runTest("compiler/testData/compileKotlinAgainstKotlin/internalWithInlineClass.kt");
+    }
+
     @TestMetadata("internalWithOtherModuleName.kt")
     public void testInternalWithOtherModuleName() throws Exception {
         runTest("compiler/testData/compileKotlinAgainstKotlin/internalWithOtherModuleName.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/JvmOldAgainstIrBoxTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/JvmOldAgainstIrBoxTestGenerated.java
@@ -245,6 +245,11 @@ public class JvmOldAgainstIrBoxTestGenerated extends AbstractJvmOldAgainstIrBoxT
         runTest("compiler/testData/compileKotlinAgainstKotlin/internalWithDefaultArgs.kt");
     }
 
+    @TestMetadata("internalWithInlineClass.kt")
+    public void testInternalWithInlineClass() throws Exception {
+        runTest("compiler/testData/compileKotlinAgainstKotlin/internalWithInlineClass.kt");
+    }
+
     @TestMetadata("internalWithOtherModuleName.kt")
     public void testInternalWithOtherModuleName() throws Exception {
         runTest("compiler/testData/compileKotlinAgainstKotlin/internalWithOtherModuleName.kt");


### PR DESCRIPTION
This can happen when using `-Xfriend-paths`.