### PR TITLE
[FIR] Fix lookup order for statics in super chains.

### DIFF
--- a/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -35555,6 +35555,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         }
 
         @Test
+        @TestMetadata("simpleStaticInJavaSuperChain.kt")
+        public void testSimpleStaticInJavaSuperChain() throws Exception {
+            runTest("compiler/testData/codegen/box/statics/simpleStaticInJavaSuperChain.kt");
+        }
+
+        @Test
         @TestMetadata("syntheticAccessor.kt")
         public void testSyntheticAccessor() throws Exception {
             runTest("compiler/testData/codegen/box/statics/syntheticAccessor.kt");

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/BodyResolveComponents.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/BodyResolveComponents.kt
@@ -180,7 +180,7 @@ fun SessionHolder.collectImplicitReceivers(
             throw IllegalArgumentException("Incorrect label & receiver owner: ${owner.javaClass}")
         }
     }
-    return ImplicitReceivers(implicitReceiverValue, implicitCompanionValues.asReversed())
+    return ImplicitReceivers(implicitReceiverValue, implicitCompanionValues)
 }
 
 fun SessionHolder.collectTowerDataElementsForClass(owner: FirClass<*>, defaultType: ConeKotlinType): TowerElementsForClass {
@@ -221,8 +221,8 @@ fun SessionHolder.collectTowerDataElementsForClass(owner: FirClass<*>, defaultTy
         owner.staticScope(this),
         companionReceiver,
         companionObject?.staticScope(this),
-        superClassesStaticsAndCompanionReceivers,
-        allImplicitCompanionValues
+        superClassesStaticsAndCompanionReceivers.asReversed(),
+        allImplicitCompanionValues.asReversed()
     )
 }
 
@@ -234,6 +234,8 @@ class TowerElementsForClass(
     val staticScope: FirScope?,
     val companionReceiver: ImplicitReceiverValue<*>?,
     val companionStaticScope: FirScope?,
+    // Ordered from inner scopes to outer scopes.
     val superClassesStaticsAndCompanionReceivers: List<FirTowerDataElement>,
+    // Ordered from inner scopes to outer scopes.
     val implicitCompanionValues: List<ImplicitReceiverValue<*>>
 )

--- a/compiler/testData/codegen/box/statics/protectedStatic2.kt
+++ b/compiler/testData/codegen/box/statics/protectedStatic2.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 // TARGET_BACKEND: JVM
 
 // FILE: Base.java

--- a/compiler/testData/codegen/box/statics/simpleStaticInJavaSuperChain.kt
+++ b/compiler/testData/codegen/box/statics/simpleStaticInJavaSuperChain.kt
@@ -1,0 +1,31 @@
+// TARGET_BACKEND: JVM
+
+// FILE: A.java
+
+public class A {
+    public static String s = "A.s: NOT OK";
+    public static String f() {
+        return "A.f: NOT OK";
+    }
+
+    public static class B extends A {
+        public static String s = "OK";
+        public static String f() {
+            return "OK";
+        }
+    }
+}
+
+
+// FILE: Kotlin.kt
+
+class Kotlin: A.B() {
+    fun getS() = s
+    fun callF() = f()
+}
+
+fun box(): String {
+    val kotlin = Kotlin()
+    if (kotlin.getS() != "OK") return "fail1"
+    return kotlin.callF()
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -35755,6 +35755,12 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
         }
 
         @Test
+        @TestMetadata("simpleStaticInJavaSuperChain.kt")
+        public void testSimpleStaticInJavaSuperChain() throws Exception {
+            runTest("compiler/testData/codegen/box/statics/simpleStaticInJavaSuperChain.kt");
+        }
+
+        @Test
         @TestMetadata("syntheticAccessor.kt")
         public void testSyntheticAccessor() throws Exception {
             runTest("compiler/testData/codegen/box/statics/syntheticAccessor.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -35555,6 +35555,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         }
 
         @Test
+        @TestMetadata("simpleStaticInJavaSuperChain.kt")
+        public void testSimpleStaticInJavaSuperChain() throws Exception {
+            runTest("compiler/testData/codegen/box/statics/simpleStaticInJavaSuperChain.kt");
+        }
+
+        @Test
         @TestMetadata("syntheticAccessor.kt")
         public void testSyntheticAccessor() throws Exception {
             runTest("compiler/testData/codegen/box/statics/syntheticAccessor.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -29244,6 +29244,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/statics/protectedStaticAndInline.kt");
         }
 
+        @TestMetadata("simpleStaticInJavaSuperChain.kt")
+        public void testSimpleStaticInJavaSuperChain() throws Exception {
+            runTest("compiler/testData/codegen/box/statics/simpleStaticInJavaSuperChain.kt");
+        }
+
         @TestMetadata("syntheticAccessor.kt")
         public void testSyntheticAccessor() throws Exception {
             runTest("compiler/testData/codegen/box/statics/syntheticAccessor.kt");


### PR DESCRIPTION
The order was reversed and the static in the top-most class
in the inheritance hierarchy would be found instead of the
lowest one.