### PR TITLE
KT-44615 Update Java Annotation dependency to 20.1.0

### DIFF
--- a/libraries/stdlib/jvm/build.gradle
+++ b/libraries/stdlib/jvm/build.gradle
@@ -54,7 +54,7 @@ dependencies {
 
     commonSources project(path: ":kotlin-stdlib-common", configuration: "sources")
 
-    compile group: 'org.jetbrains', name: 'annotations', version:'13.0'
+    compile group: 'org.jetbrains', name: 'annotations', version:'20.1.0'
 
     testCompile project(':kotlin-test:kotlin-test-junit')
 


### PR DESCRIPTION
The JVM standard lib refers to an old version of Java annotations. The newest annotations supports generics via TYPE_USE and additional annotations, see https://github.com/JetBrains/java-annotations/blob/master/CHANGELOG.md.

Current workaround to use the newest annotation: Update to the version manually
````kotlin
// build.gradle.kts
dependencies {
   implementation("org.jetbrains:annotations:20.1.0")
}
````
https://youtrack.jetbrains.com/issue/KT-44615

https://youtrack.jetbrains.com/issue/IDEA-260651