### PR TITLE
KT-43988 Fix validation warnings for Gradle task types

### DIFF
--- a/buildSrc/src/main/kotlin/plugins/DexMethodCount.kt
+++ b/buildSrc/src/main/kotlin/plugins/DexMethodCount.kt
@@ -41,7 +41,7 @@ open class DexMethodCount : DefaultTask() {
         dependsOn(jar)
     }
 
-    @Internal // plain output properties are not supported, mark as internal to suppress warning from validateTaskProperties
+    @Internal // plain output properties are not supported, mark as internal to suppress warning from validatePlugins
     lateinit var counts: Counts
 
     @get:OutputFile

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/build.gradle.kts
@@ -155,7 +155,7 @@ tasks.withType<KotlinCompile> {
 tasks.withType<Test> {
     onlyIf { !project.hasProperty("noTest") }
 
-    dependsOn(":kotlin-gradle-plugin:validateTaskProperties")
+    dependsOn(":kotlin-gradle-plugin:validatePlugins")
     dependsOnKotlinPluginInstall()
 
     executable = "${rootProject.extra["JDK_18"]!!}/bin/java"

--- a/libraries/tools/kotlin-gradle-plugin/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin/build.gradle.kts
@@ -150,7 +150,7 @@ tasks {
     }
 
     named("install") {
-        dependsOn(named("validateTaskProperties"))
+        dependsOn(named("validatePlugins"))
     }
 
     named<DokkaTask>("dokka") {
@@ -161,7 +161,7 @@ tasks {
 
 projectTest {
     executable = "${rootProject.extra["JDK_18"]!!}/bin/java"
-    dependsOn(tasks.named("validateTaskProperties"))
+    dependsOn(tasks.named("validatePlugins"))
 
     workingDir = rootDir
 }

--- a/libraries/tools/kotlin-gradle-plugin/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin/build.gradle.kts
@@ -144,8 +144,9 @@ tasks {
         callGroovy("manifestAttributes", manifest, project)
     }
 
-    named<ValidateTaskProperties>("validateTaskProperties") {
-        failOnWarning = true
+    withType<ValidatePlugins>().configureEach {
+        failOnWarning.set(true)
+        enableStricterValidation.set(true)
     }
 
     named("install") {

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/nodejs/NodeJsExec.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/nodejs/NodeJsExec.kt
@@ -39,6 +39,7 @@ constructor(
     var sourceMapStackTraces = true
 
     @Optional
+    @PathSensitive(PathSensitivity.ABSOLUTE)
     @InputFile
     val inputFileProperty: RegularFileProperty = project.newFileProperty()
 

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/resolver/KotlinCompilationNpmResolver.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/resolver/KotlinCompilationNpmResolver.kt
@@ -15,6 +15,8 @@ import org.gradle.api.initialization.IncludedBuild
 import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.bundling.Zip
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
@@ -300,9 +302,11 @@ internal class KotlinCompilationNpmResolver(
         @get:Input
         val internalDependencies: Collection<String>,
 
+        @get:PathSensitive(PathSensitivity.ABSOLUTE)
         @get:InputFiles
         val internalCompositeDependencies: Collection<File>,
 
+        @get:PathSensitive(PathSensitivity.ABSOLUTE)
         @get:InputFiles
         val externalGradleDependencies: Collection<File>,
 

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/tasks/KotlinNpmInstallTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/tasks/KotlinNpmInstallTask.kt
@@ -9,6 +9,8 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin
 import org.jetbrains.kotlin.gradle.utils.disableTaskOnConfigurationCacheBuild
@@ -37,11 +39,13 @@ open class KotlinNpmInstallTask : DefaultTask() {
     val args: MutableList<String> = mutableListOf()
 
     @Suppress("unused")
+    @get:PathSensitive(PathSensitivity.ABSOLUTE)
     @get:InputFiles
     val packageJsonFiles: Collection<File> by lazy {
         resolutionManager.packageJsonFiles
     }
 
+    @get:PathSensitive(PathSensitivity.ABSOLUTE)
     @get:InputFiles
     val preparedFiles: Collection<File> by lazy {
         nodeJs.packageManager.preparedFiles(project)

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/KotlinJsTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/KotlinJsTest.kt
@@ -12,6 +12,8 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.process.internal.DefaultProcessForkOptions
 import org.gradle.util.ConfigureUtil
 import org.jetbrains.kotlin.gradle.internal.testing.TCServiceMessagesTestExecutionSpec
@@ -60,6 +62,7 @@ constructor(
     val testFrameworkSettings: String
         @Input get() = testFramework!!.settingsState
 
+    @PathSensitive(PathSensitivity.ABSOLUTE)
     @InputFile
     val inputFileProperty: RegularFileProperty = project.newFileProperty()
 
@@ -68,11 +71,15 @@ constructor(
 
     @Suppress("unused")
     val runtimeClasspath: FileCollection
-        @InputFiles get() = compilation.runtimeDependencyFiles
+        @PathSensitive(PathSensitivity.ABSOLUTE)
+        @InputFiles
+        get() = compilation.runtimeDependencyFiles
 
     @Suppress("unused")
     internal val compilationOutputs: FileCollection
-        @InputFiles get() = compilation.output.allOutputs
+        @PathSensitive(PathSensitivity.ABSOLUTE)
+        @InputFiles
+        get() = compilation.output.allOutputs
 
     @Suppress("unused")
     val compilationId: String

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/webpack/KotlinWebpack.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/webpack/KotlinWebpack.kt
@@ -90,6 +90,7 @@ constructor(
     internal var resolveFromModulesFirst: Boolean = false
 
     @Suppress("unused")
+    @get:PathSensitive(PathSensitivity.ABSOLUTE)
     @get:InputFiles
     val runtimeClasspath: FileCollection by lazy {
         compilation.compileDependencyFiles
@@ -138,7 +139,10 @@ constructor(
         get() = destinationDirectory.resolve(outputFileName)
 
     open val configDirectory: File?
-        @Optional @InputDirectory get() = project.projectDir.resolve("webpack.config.d").takeIf { it.isDirectory }
+        @PathSensitive(PathSensitivity.ABSOLUTE)
+        @Optional
+        @InputDirectory
+        get() = project.projectDir.resolve("webpack.config.d").takeIf { it.isDirectory }
 
     @Input
     var report: Boolean = false

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/native/internal/CommonizerTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/native/internal/CommonizerTask.kt
@@ -37,12 +37,14 @@ internal open class CommonizerTask : DefaultTask() {
     @get:Input
     var targetGroups: Set<KonanTargetGroup> = emptySet()
 
+    @get:PathSensitive(PathSensitivity.ABSOLUTE)
     @get:InputDirectory
     @Suppress("unused") // Only for up-to-date checker. The directory with the original common libs.
     val originalCommonLibrariesDirectory = konanHome
         .resolve(KONAN_DISTRIBUTION_KLIB_DIR)
         .resolve(KONAN_DISTRIBUTION_COMMON_LIBS_DIR)
 
+    @get:PathSensitive(PathSensitivity.ABSOLUTE)
     @get:InputDirectory
     @Suppress("unused") // Only for up-to-date checker. The directory with the original platform libs.
     val originalPlatformLibrariesDirectory = konanHome
@@ -53,6 +55,7 @@ internal open class CommonizerTask : DefaultTask() {
     val commonizerTargetOutputDirectories
         get() = targetGroups.map { targets -> project.nativeDistributionCommonizerOutputDirectory(targets) }
 
+    @get:PathSensitive(PathSensitivity.ABSOLUTE)
     @get:InputFiles
     @Suppress("unused") // Only for up-to-date checker.
     val successMarkers

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/native/tasks/AdvancedCocoapodsTasks.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/native/tasks/AdvancedCocoapodsTasks.kt
@@ -364,6 +364,7 @@ open class PodGenTask : DefaultTask() {
         }
     }
 
+    @get:PathSensitive(PathSensitivity.ABSOLUTE)
     @get:InputFile
     internal lateinit var podspec: Provider<File>
 
@@ -480,12 +481,14 @@ private fun getBuildSettingFileName(pod: CocoapodsDependency, sdk: String): Stri
  */
 open class PodBuildTask : DefaultTask() {
 
+    @get:PathSensitive(PathSensitivity.ABSOLUTE)
     @get:InputFile
     internal lateinit var buildSettingsFile: Provider<File>
 
     @get:Nested
     internal lateinit var pod: Provider<CocoapodsDependency>
 
+    @get:PathSensitive(PathSensitivity.ABSOLUTE)
     @get:InputFiles
     internal val srcDir: FileTree
         get() = project.fileTree(

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/native/tasks/FatFrameworkTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/native/tasks/FatFrameworkTask.kt
@@ -105,11 +105,13 @@ open class FatFrameworkTask: DefaultTask() {
     private val fatDsym: IosDsymFiles
         get() = fatFramework.dSYM
 
+    @get:PathSensitive(PathSensitivity.ABSOLUTE)
     @get:InputFiles
     @get:SkipWhenEmpty
     protected val inputFrameworkFiles: Iterable<FileTree>
         get() = frameworks.map { project.fileTree(it.outputFile) }
 
+    @get:PathSensitive(PathSensitivity.ABSOLUTE)
     @get:InputFiles
     protected val inputDsymFiles: Iterable<FileTree>
         get() = frameworks.mapNotNull { framework ->

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/native/tasks/KotlinNativeTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/native/tasks/KotlinNativeTest.kt
@@ -32,6 +32,7 @@ abstract class KotlinNativeTest : KotlinTest() {
     @get:Internal
     val executableProperty: Property<FileCollection> = project.objects.property(FileCollection::class.java)
 
+    @get:PathSensitive(PathSensitivity.ABSOLUTE)
     @get:InputFiles // use FileCollection & @InputFiles rather than @InputFile to allow for task dependencies built-into this FileCollection
     @get:SkipWhenEmpty
     @Suppress("UNUSED") // Gradle input


### PR DESCRIPTION
Gradle has a validation mode which ensures that all input file properties have a path sensitivity declared. This validation mode will be the default in an upcoming Gradle 7.x release.

In this PR, I
- Enable the stricter validation for the `validatePlugins` task
- Fix the currently existing validation problems.

I only added `PathSensitivity.ABSOLUTE` to all properties, which is what happens now implicitly. If you know that for some of the tasks this can be changed to `RELATIVE` or something else, then please comment on the PR so I'll change it.

Fixes https://youtrack.jetbrains.com/issue/KT-43988