### PR TITLE
Changing Number class to interface

### DIFF
--- a/core/builtins/native/kotlin/Number.kt
+++ b/core/builtins/native/kotlin/Number.kt
@@ -17,42 +17,41 @@
 package kotlin
 
 /**
- * Superclass for all platform classes representing numeric values.
+ * High level interface for all platform classes representing numeric values.
  */
-public abstract class Number {
+public interface Number {
     /**
      * Returns the value of this number as a [Double], which may involve rounding.
      */
-    public abstract fun toDouble(): Double
+    public fun toDouble(): Double
 
     /**
      * Returns the value of this number as a [Float], which may involve rounding.
      */
-    public abstract fun toFloat(): Float
+    public fun toFloat(): Float
 
     /**
      * Returns the value of this number as a [Long], which may involve rounding or truncation.
      */
-    public abstract fun toLong(): Long
+    public fun toLong(): Long
 
     /**
      * Returns the value of this number as an [Int], which may involve rounding or truncation.
      */
-    public abstract fun toInt(): Int
+    public fun toInt(): Int
 
     /**
      * Returns the [Char] with the numeric value equal to this number, truncated to 16 bits if appropriate.
      */
-    public abstract fun toChar(): Char
+    public fun toChar(): Char
 
     /**
      * Returns the value of this number as a [Short], which may involve rounding or truncation.
      */
-    public abstract fun toShort(): Short
+    public fun toShort(): Short
 
     /**
      * Returns the value of this number as a [Byte], which may involve rounding or truncation.
      */
-    public abstract fun toByte(): Byte
+    public fun toByte(): Byte
 }
-


### PR DESCRIPTION
Actually [Number](https://github.com/JetBrains/kotlin/blob/8f675fe757ff6d5aeff74f4aedfc3d0135795382/core/builtins/native/kotlin/Number.kt#L22) is an abstract class with only abstract methods. I think it would be better to change it to an interface that can be simply implemented with specific code for `toDouble()`, `toFloat()`...

A usefull use case : a class that extends `Number` and another class would be possible if `Number` is an interface.