### PR TITLE
Specify type explicitly in KotlinCoreProjectEnvironment.createCoreFil…

### DIFF
--- a/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreProjectEnvironment.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreProjectEnvironment.kt
@@ -19,10 +19,11 @@ package org.jetbrains.kotlin.cli.jvm.compiler
 import com.intellij.core.JavaCoreProjectEnvironment
 import com.intellij.openapi.Disposable
 import com.intellij.psi.PsiManager
+import org.jetbrains.kotlin.resolve.jvm.KotlinCliJavaFileManager
 
 open class KotlinCoreProjectEnvironment(
     disposable: Disposable,
     applicationEnvironment: KotlinCoreApplicationEnvironment
 ) : JavaCoreProjectEnvironment(disposable, applicationEnvironment) {
-    override fun createCoreFileManager() = KotlinCliJavaFileManagerImpl(PsiManager.getInstance(project))
+    override fun createCoreFileManager(): KotlinCliJavaFileManager = KotlinCliJavaFileManagerImpl(PsiManager.getInstance(project))
 }


### PR DESCRIPTION
…eManager to allow overriding this method with different implementation

Right now the type is `KotlinCliJavaFileManagerImpl` which defeats the point of inheritance since no one is able to substitute the result with own implementation. 