### PR TITLE
Locate build history when file is outside of root project dir

### DIFF
--- a/build-common/src/org/jetbrains/kotlin/incremental/IncrementalModuleInfo.kt
+++ b/build-common/src/org/jetbrains/kotlin/incremental/IncrementalModuleInfo.kt
@@ -21,6 +21,7 @@ data class IncrementalModuleEntry(
 
 class IncrementalModuleInfo(
     val projectRoot: File,
+    val rootProjectBuildDir: File,
     val dirToModule: Map<File, IncrementalModuleEntry>,
     val nameToModules: Map<String, Set<IncrementalModuleEntry>>,
     val jarToClassListFile: Map<File, File>,
@@ -28,6 +29,6 @@ class IncrementalModuleInfo(
     val jarToModule: Map<File, IncrementalModuleEntry>
 ) : Serializable {
     companion object {
-        private const val serialVersionUID = 0L
+        private const val serialVersionUID = 1L
     }
 }

--- a/compiler/incremental-compilation-impl/test/org/jetbrains/kotlin/incremental/AbstractIncrementaMultiModulelCompilerRunnerTest.kt
+++ b/compiler/incremental-compilation-impl/test/org/jetbrains/kotlin/incremental/AbstractIncrementaMultiModulelCompilerRunnerTest.kt
@@ -32,7 +32,7 @@ abstract class AbstractIncrementalMultiModuleCompilerRunnerTest<Args : CommonCom
     private val jarToModule = mutableMapOf<File, IncrementalModuleEntry>()
 
     protected val incrementalModuleInfo: IncrementalModuleInfo by lazy {
-        IncrementalModuleInfo(workingDir, dirToModule, nameToModules, jarToClassListFile, jarToModule)
+        IncrementalModuleInfo(workingDir, workingDir, dirToModule, nameToModules, jarToClassListFile, jarToModule)
     }
 
     protected abstract val modulesApiHistory: ApiHistory

--- a/compiler/incremental-compilation-impl/test/org/jetbrains/kotlin/incremental/multiproject/ModulesApiHistoryAndroidTest.kt
+++ b/compiler/incremental-compilation-impl/test/org/jetbrains/kotlin/incremental/multiproject/ModulesApiHistoryAndroidTest.kt
@@ -56,6 +56,7 @@ class ModulesApiHistoryAndroidTest {
 
         val info = IncrementalModuleInfo(
             projectRoot = projectRoot,
+            rootProjectBuildDir = projectRoot.resolve("build"),
             dirToModule = mapOf(appKotlinDestination to appEntry, libKotlinDestination to libEntry),
             nameToModules = mapOf("app" to setOf(appEntry), "lib" to setOf(libEntry)),
             jarToClassListFile = mapOf(),

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/compilerRunner/GradleKotlinCompilerRunner.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/compilerRunner/GradleKotlinCompilerRunner.kt
@@ -257,6 +257,7 @@ internal open class GradleCompilerRunner(protected val taskProvider: GradleCompi
 
             return IncrementalModuleInfo(
                 projectRoot = gradle.rootProject.projectDir,
+                rootProjectBuildDir = gradle.rootProject.buildDir,
                 dirToModule = dirToModule,
                 nameToModules = nameToModules,
                 jarToClassListFile = jarToClassListFile,


### PR DESCRIPTION
Support use-cases when the build dir is outside of root project dir.
Many projects set up output dir as <root_project>/../out/<project_name>/build
to be able to clean build dir more easily. This commit extends support
for build history file detection and it tries to find build history
files for artifacts that are:
- under root project dir (a default structure)
- under root project's build dir parent (to support typical custom setup)

Fixes https://youtrack.jetbrains.com/issue/KT-40875

Test: BaseIncrementalCompilationMultiProjectIT