### PR TITLE
Fix `File` as input of an artifact transform

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/scripting/internal/ScriptingGradleSubplugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/scripting/internal/ScriptingGradleSubplugin.kt
@@ -15,6 +15,7 @@ import org.gradle.api.artifacts.transform.TransformAction
 import org.gradle.api.artifacts.transform.TransformOutputs
 import org.gradle.api.artifacts.transform.TransformParameters
 import org.gradle.api.attributes.Attribute
+import org.gradle.api.file.FileSystemLocation
 import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.compile.AbstractCompile
@@ -153,10 +154,10 @@ private fun configureDiscoveryTransformation(
 
 internal abstract class DiscoverScriptExtensionsTransformAction : TransformAction<TransformParameters.None> {
     @get:InputArtifact
-    abstract val inputArtifact: File
+    abstract val inputArtifact: Provider<FileSystemLocation>
 
     override fun transform(outputs: TransformOutputs) {
-        val input = inputArtifact
+        val input = inputArtifact.get().asFile
 
         val definitions =
             ScriptDefinitionsFromClasspathDiscoverySource(


### PR DESCRIPTION
Using `File` as input of an artifact transform was deprecated.

With Gradle 7, this becomes an error. This commit fixes the problem by using the proper replacement (`Provider<FileSystemLocation>`).