### PR TITLE
Do not report `UNNECESSARY_SAFE_CALL` on `ErrorType`

### DIFF
--- a/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsTestGenerated.java
@@ -687,6 +687,12 @@ public class FirOldFrontendDiagnosticsTestGenerated extends AbstractFirDiagnosti
         }
 
         @Test
+        @TestMetadata("SafeCallUnknownType.kt")
+        public void testSafeCallUnknownType() throws Exception {
+            runTest("compiler/testData/diagnostics/tests/SafeCallUnknownType.kt");
+        }
+
+        @Test
         @TestMetadata("Serializable.kt")
         public void testSerializable() throws Exception {
             runTest("compiler/testData/diagnostics/tests/Serializable.kt");

--- a/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/CallExpressionResolver.kt
+++ b/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/CallExpressionResolver.kt
@@ -67,6 +67,7 @@ import org.jetbrains.kotlin.types.expressions.ExpressionTypingServices
 import org.jetbrains.kotlin.types.expressions.KotlinTypeInfo
 import org.jetbrains.kotlin.types.expressions.typeInfoFactory.createTypeInfo
 import org.jetbrains.kotlin.types.expressions.typeInfoFactory.noTypeInfo
+import org.jetbrains.kotlin.types.isError
 import org.jetbrains.kotlin.types.refinement.TypeRefinement
 import javax.inject.Inject
 
@@ -534,15 +535,17 @@ class CallExpressionResolver(
             } ?: false
 
         fun reportUnnecessarySafeCall(
-            trace: BindingTrace, type: KotlinType,
-            callOperationNode: ASTNode, explicitReceiver: Receiver?
-        ) = trace.report(
+            trace: BindingTrace,
+            type: KotlinType,
+            callOperationNode: ASTNode,
+            explicitReceiver: Receiver?
+        ) {
             if (explicitReceiver is ExpressionReceiver && explicitReceiver.expression is KtSuperExpression) {
-                UNEXPECTED_SAFE_CALL.on(callOperationNode.psi)
-            } else {
-                UNNECESSARY_SAFE_CALL.on(callOperationNode.psi, type)
+                trace.report(UNEXPECTED_SAFE_CALL.on(callOperationNode.psi))
+            } else if (!type.isError) {
+                trace.report(UNNECESSARY_SAFE_CALL.on(callOperationNode.psi, type))
             }
-        )
+        }
 
         private fun checkNestedClassAccess(
             expression: KtQualifiedExpression,

--- a/compiler/testData/diagnostics/tests/SafeCallUnknownType.fir.kt
+++ b/compiler/testData/diagnostics/tests/SafeCallUnknownType.fir.kt
@@ -1,0 +1,7 @@
+// !WITH_NEW_INFERENCE
+import com.unknown
+
+fun ff() {
+    val a = <!UNRESOLVED_REFERENCE!>unknown<!>()
+    val b = a?.plus(42)
+}

--- a/compiler/testData/diagnostics/tests/SafeCallUnknownType.kt
+++ b/compiler/testData/diagnostics/tests/SafeCallUnknownType.kt
@@ -1,0 +1,7 @@
+// !WITH_NEW_INFERENCE
+import <!UNRESOLVED_REFERENCE!>com<!>.<!DEBUG_INFO_MISSING_UNRESOLVED!>unknown<!>
+
+fun ff() {
+    val a = <!UNRESOLVED_REFERENCE!>unknown<!>()
+    val <!UNUSED_VARIABLE!>b<!> = <!TYPE_MISMATCH{OI}!><!DEBUG_INFO_ELEMENT_WITH_ERROR_TYPE!>a<!>?.<!DEBUG_INFO_MISSING_UNRESOLVED!>plus<!>(42)<!>
+}

--- a/compiler/testData/diagnostics/tests/SafeCallUnknownType.txt
+++ b/compiler/testData/diagnostics/tests/SafeCallUnknownType.txt
@@ -1,0 +1,3 @@
+package
+
+public fun ff(): kotlin.Unit

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/DiagnosticTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/DiagnosticTestGenerated.java
@@ -687,6 +687,12 @@ public class DiagnosticTestGenerated extends AbstractDiagnosticTest {
         }
 
         @Test
+        @TestMetadata("SafeCallUnknownType.kt")
+        public void testSafeCallUnknownType() throws Exception {
+            runTest("compiler/testData/diagnostics/tests/SafeCallUnknownType.kt");
+        }
+
+        @Test
         @TestMetadata("Serializable.kt")
         public void testSerializable() throws Exception {
             runTest("compiler/testData/diagnostics/tests/Serializable.kt");


### PR DESCRIPTION
I noticed that the Kotlin compiler is reporting an `UNNECESSARY_SAFE_CALL` diagnostic if the receiver type has an unknown type:

```kotlin
import com.sample.function.from.outside

fun test() {
    val a = outside()
    val b = a?.plus(42)
}
```

This happens apparently as the type of `a` is `org.jetbrains.kotlin.types.ErrorType`, that is marked as non-nullable. Ideally the compiler should not report this diagnostic if the type is not known.

This is affecting Detekt as we're using the `compiler-embeddable` and we had to patch it on our end to overcome this situation: https://github.com/detekt/detekt/pull/3419. 

Originally discussed on https://kotlinlang.slack.com/archives/C7L3JB43G/p1611942049032400