### PR TITLE
Remove unsupported '!' from DIAGNOSTICS directive

### DIFF
--- a/compiler/testData/diagnostics/ReadMe.md
+++ b/compiler/testData/diagnostics/ReadMe.md
@@ -21,19 +21,18 @@ Several directives can be added to the beginning of a test file with the followi
 
 ### 1. DIAGNOSTICS
 
-This directive allows to exclude some irrelevant diagnostics (e.g. unused parameter) from a certain test, or to test only a specific set of diagnostics.
+This directive allows to exclude some irrelevant diagnostics (e.g. unused parameter) from a certain test or to include others.
 
 The syntax is
 
-    '([ + - ! ] DIAGNOSTIC_FACTORY_NAME | ERROR | WARNING | INFO ) +'
+    '([ + - ] DIAGNOSTIC_FACTORY_NAME | ERROR | WARNING | INFO ) +'
 
   where
 
 * `+` means 'include';
-* `-` means 'exclude';
-* `!` means 'exclude everything but this'.
+* `-` means 'exclude'.
 
-  Directives are applied in the order of appearance, i.e. `!FOO +BAR` means include only `FOO` and `BAR`.
+  Directives are applied in the order of appearance, i.e. `+FOO -BAR` means include `FOO` but not `BAR`.
 
 #### Usage:
 


### PR DESCRIPTION
The `testData/diagnostics/ReadMe.md` suggests to use `!` to exclude everything but one diagnostic.

That's actually not supported, and doing so will cause all the diagnostic tests to fail:
https://github.com/JetBrains/kotlin/blob/e7c4121e6785d1ac4cd7633066b4662ea3a23248/compiler/tests-common-new/tests/org/jetbrains/kotlin/test/services/DiagnosticsService.kt#L30-L34

The error messages mentions to use only `+` and `-`:
https://github.com/JetBrains/kotlin/blob/e7c4121e6785d1ac4cd7633066b4662ea3a23248/compiler/tests-common-new/tests/org/jetbrains/kotlin/test/directives/DiagnosticsDirectives.kt#L18-L26