### PR TITLE
KT-44442 Don't report "Control flow with empty body" when 'if' not empty and 'else' has comment

### DIFF
--- a/idea/testData/inspectionsLocal/controlFlowWithEmptyBody/if/blockHasBothComments.kt
+++ b/idea/testData/inspectionsLocal/controlFlowWithEmptyBody/if/blockHasBothComments.kt
@@ -1,0 +1,10 @@
+// PROBLEM: 'if' has empty body
+// FIX: none
+
+fun test(i: Int) {
+    <caret>if (i == 1) {
+        // comment
+    } else {
+        // comment
+    }
+}

--- a/idea/testData/inspectionsLocal/controlFlowWithEmptyBody/ifElse/blockHasBothComments.kt
+++ b/idea/testData/inspectionsLocal/controlFlowWithEmptyBody/ifElse/blockHasBothComments.kt
@@ -1,0 +1,10 @@
+// PROBLEM: 'else' has empty body
+// FIX: none
+
+fun test(i: Int) {
+    if (i == 1) {
+        // comment
+    } <caret>else {
+        // comment
+    }
+}

--- a/idea/testData/inspectionsLocal/controlFlowWithEmptyBody/ifElse/blockHasCommentWithIf.kt
+++ b/idea/testData/inspectionsLocal/controlFlowWithEmptyBody/ifElse/blockHasCommentWithIf.kt
@@ -1,0 +1,12 @@
+// PROBLEM: none
+// FIX: none
+
+fun test(i: Int) {
+    if (i == 1) {
+        foo()
+    } <caret>else {
+        // comment
+    }
+}
+
+fun foo() {}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -2973,6 +2973,11 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
                 runTest("idea/testData/inspectionsLocal/controlFlowWithEmptyBody/if/block.kt");
             }
 
+            @TestMetadata("blockHasBothComments.kt")
+            public void testBlockHasBothComments() throws Exception {
+                runTest("idea/testData/inspectionsLocal/controlFlowWithEmptyBody/if/blockHasBothComments.kt");
+            }
+
             @TestMetadata("blockHasComment.kt")
             public void testBlockHasComment() throws Exception {
                 runTest("idea/testData/inspectionsLocal/controlFlowWithEmptyBody/if/blockHasComment.kt");
@@ -3026,9 +3031,19 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
                 runTest("idea/testData/inspectionsLocal/controlFlowWithEmptyBody/ifElse/block.kt");
             }
 
+            @TestMetadata("blockHasBothComments.kt")
+            public void testBlockHasBothComments() throws Exception {
+                runTest("idea/testData/inspectionsLocal/controlFlowWithEmptyBody/ifElse/blockHasBothComments.kt");
+            }
+
             @TestMetadata("blockHasComment.kt")
             public void testBlockHasComment() throws Exception {
                 runTest("idea/testData/inspectionsLocal/controlFlowWithEmptyBody/ifElse/blockHasComment.kt");
+            }
+
+            @TestMetadata("blockHasCommentWithIf.kt")
+            public void testBlockHasCommentWithIf() throws Exception {
+                runTest("idea/testData/inspectionsLocal/controlFlowWithEmptyBody/ifElse/blockHasCommentWithIf.kt");
             }
 
             @TestMetadata("blockHasStatement.kt")


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-44442

If you decided not to implement this behavior, please feel free to close this PR.