### PR TITLE
FIR: more correct functional argument type resolution

### DIFF
--- a/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/diagnostics/FirDiagnosticsList.kt
+++ b/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/diagnostics/FirDiagnosticsList.kt
@@ -477,6 +477,7 @@ object DIAGNOSTICS_LIST : DiagnosticList() {
             parameter<ConeKotlinType>("varargParameterType")
         }
         val VALUE_PARAMETER_WITH_NO_TYPE_ANNOTATION by error<FirSourceElement, KtParameter>()
+        val CANNOT_INFER_PARAMETER_TYPE by error<FirSourceElement, KtParameter>()
     }
 
     val FUN_INTERFACES by object : DiagnosticGroup("Fun interfaces") {

--- a/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/diagnostics/FirErrors.kt
+++ b/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/diagnostics/FirErrors.kt
@@ -295,6 +295,7 @@ object FirErrors {
     val MULTIPLE_VARARG_PARAMETERS by error0<FirSourceElement, KtParameter>(SourceElementPositioningStrategies.PARAMETER_VARARG_MODIFIER)
     val FORBIDDEN_VARARG_PARAMETER_TYPE by error1<FirSourceElement, KtParameter, ConeKotlinType>(SourceElementPositioningStrategies.PARAMETER_VARARG_MODIFIER)
     val VALUE_PARAMETER_WITH_NO_TYPE_ANNOTATION by error0<FirSourceElement, KtParameter>()
+    val CANNOT_INFER_PARAMETER_TYPE by error0<FirSourceElement, KtParameter>()
 
     // Fun interfaces
     val FUN_INTERFACE_CONSTRUCTOR_REFERENCE by error0<FirSourceElement, KtExpression>(SourceElementPositioningStrategies.REFERENCE_BY_QUALIFIED)

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/collectors/components/ErrorNodeDiagnosticCollectorComponent.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/collectors/components/ErrorNodeDiagnosticCollectorComponent.kt
@@ -19,7 +19,9 @@ import org.jetbrains.kotlin.fir.references.FirErrorNamedReference
 import org.jetbrains.kotlin.fir.resolve.diagnostics.ConeAmbiguityError
 import org.jetbrains.kotlin.fir.resolve.diagnostics.ConeInapplicableCandidateError
 import org.jetbrains.kotlin.fir.resolve.diagnostics.ConeUnresolvedNameError
+import org.jetbrains.kotlin.fir.types.ConeClassErrorType
 import org.jetbrains.kotlin.fir.types.FirErrorTypeRef
+import org.jetbrains.kotlin.fir.types.FirResolvedTypeRef
 
 class ErrorNodeDiagnosticCollectorComponent(collector: AbstractDiagnosticCollector) : AbstractDiagnosticCollectorComponent(collector) {
     override fun visitErrorLoop(errorLoop: FirErrorLoop, data: CheckerContext) {
@@ -30,6 +32,12 @@ class ErrorNodeDiagnosticCollectorComponent(collector: AbstractDiagnosticCollect
     override fun visitErrorTypeRef(errorTypeRef: FirErrorTypeRef, data: CheckerContext) {
         val source = errorTypeRef.source ?: return
         reportFirDiagnostic(errorTypeRef.diagnostic, source, reporter, data)
+    }
+
+    override fun visitResolvedTypeRef(resolvedTypeRef: FirResolvedTypeRef, data: CheckerContext) {
+        val errorType = resolvedTypeRef.type as? ConeClassErrorType ?: return
+        val source = resolvedTypeRef.source ?: return
+        reportFirDiagnostic(errorType.diagnostic, source, reporter, data)
     }
 
     override fun visitErrorNamedReference(errorNamedReference: FirErrorNamedReference, data: CheckerContext) {

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/FirDefaultErrorMessages.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/FirDefaultErrorMessages.kt
@@ -49,6 +49,7 @@ import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.BREAK_OR_CONTINUE
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.CALLABLE_REFERENCE_LHS_NOT_A_CLASS
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.CALLABLE_REFERENCE_TO_ANNOTATION_CONSTRUCTOR
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.CANNOT_CHANGE_ACCESS_PRIVILEGE
+import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.CANNOT_INFER_PARAMETER_TYPE
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.CANNOT_WEAKEN_ACCESS_PRIVILEGE
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.CAN_BE_REPLACED_WITH_OPERATOR_ASSIGNMENT
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.CAN_BE_VAL
@@ -685,6 +686,7 @@ class FirDefaultErrorMessages : DefaultErrorMessages.Extension {
             map.put(MULTIPLE_VARARG_PARAMETERS, "Multiple vararg-parameters are prohibited")
             map.put(FORBIDDEN_VARARG_PARAMETER_TYPE, "Forbidden vararg parameter type: {0}", RENDER_TYPE)
             map.put(VALUE_PARAMETER_WITH_NO_TYPE_ANNOTATION, "A type annotation is required on a value parameter")
+            map.put(CANNOT_INFER_PARAMETER_TYPE, "cannot infer a type for this parameter. Please specify it explicitly.")
 
             // Fun interfaces
             map.put(FUN_INTERFACE_CONSTRUCTOR_REFERENCE, "Functional interface constructor references are prohibited")

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/coneDiagnosticToFirDiagnostic.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/coneDiagnosticToFirDiagnostic.kt
@@ -176,6 +176,7 @@ private fun ConeSimpleDiagnostic.getFactory(): FirDiagnosticFactory0<FirSourceEl
         DiagnosticKind.NotLoopLabel -> FirErrors.NOT_A_LOOP_LABEL
         DiagnosticKind.VariableExpected -> FirErrors.VARIABLE_EXPECTED
         DiagnosticKind.ValueParameterWithNoTypeAnnotation -> FirErrors.VALUE_PARAMETER_WITH_NO_TYPE_ANNOTATION
+        DiagnosticKind.CannotInferParameterType -> FirErrors.CANNOT_INFER_PARAMETER_TYPE
         DiagnosticKind.UnknownCallableKind -> FirErrors.UNKNOWN_CALLABLE_KIND
         DiagnosticKind.IllegalProjectionUsage -> FirErrors.ILLEGAL_PROJECTION_USAGE
         DiagnosticKind.MissingStdlibClass -> FirErrors.MISSING_STDLIB_CLASS

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -16979,6 +16979,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         }
 
         @Test
+        @TestMetadata("lambdaWithStarReturn.kt")
+        public void testLambdaWithStarReturn() throws Exception {
+            runTest("compiler/testData/codegen/box/inference/lambdaWithStarReturn.kt");
+        }
+
+        @Test
         @TestMetadata("lambdasWithExtensionFunctionType.kt")
         public void testLambdasWithExtensionFunctionType() throws Exception {
             runTest("compiler/testData/codegen/box/inference/lambdasWithExtensionFunctionType.kt");

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/Arguments.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/Arguments.kt
@@ -508,7 +508,7 @@ fun FirExpression.isFunctional(
                     session, scopeSession, classLikeExpectedFunctionType, shouldCalculateReturnTypesOfFakeOverrides = false
                 ) ?: return false
             // Make sure the contributed `invoke` is indeed a wanted functional type by checking if types are compatible.
-            val expectedReturnType = classLikeExpectedFunctionType.returnType(session)!!.lowerBoundIfFlexible()
+            val expectedReturnType = classLikeExpectedFunctionType.returnType(session).lowerBoundIfFlexible()
             val returnTypeCompatible =
                 expectedReturnType is ConeTypeParameterType ||
                         AbstractTypeChecker.isSubtypeOf(
@@ -529,7 +529,7 @@ fun FirExpression.isFunctional(
             val parameterPairs =
                 invokeSymbol.fir.valueParameters.zip(classLikeExpectedFunctionType.valueParameterTypesIncludingReceiver(session))
             return parameterPairs.all { (invokeParameter, expectedParameter) ->
-                val expectedParameterType = expectedParameter!!.lowerBoundIfFlexible()
+                val expectedParameterType = expectedParameter.lowerBoundIfFlexible()
                 expectedParameterType is ConeTypeParameterType ||
                         AbstractTypeChecker.isSubtypeOf(
                             session.inferenceComponents.ctx.newBaseTypeCheckerContext(

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/inference/FirCallCompleter.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/inference/FirCallCompleter.kt
@@ -210,7 +210,13 @@ class FirCallCompleter(
 
             val lookupTracker = session.lookupTracker
             lambdaArgument.valueParameters.forEachIndexed { index, parameter ->
-                val newReturnTypeRef = parameter.returnTypeRef.resolvedTypeFromPrototype(parameters[index].approximateLambdaInputType())
+                val newReturnType = parameters[index].approximateLambdaInputType()
+                val newReturnTypeRef = if (parameter.returnTypeRef is FirImplicitTypeRef) {
+                    buildResolvedTypeRef {
+                        source = parameter.source
+                        type = newReturnType
+                    }
+                } else parameter.returnTypeRef.resolvedTypeFromPrototype(newReturnType)
                 parameter.replaceReturnTypeRef(newReturnTypeRef)
                 lookupTracker?.recordTypeResolveAsLookup(newReturnTypeRef, parameter.source, null)
             }

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/inference/PostponedAtoms.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/inference/PostponedAtoms.kt
@@ -165,7 +165,7 @@ internal fun extractInputOutputTypesFromCallableReferenceExpectedType(
 
     return when {
         expectedType.isBuiltinFunctionalType(session) ->
-            extractInputOutputTypesFromFunctionType(expectedType, session)
+            InputOutputTypes(expectedType.valueParameterTypesIncludingReceiver(session), expectedType.returnType(session))
 
 //        ReflectionTypes.isBaseTypeForNumberedReferenceTypes(expectedType) ->
 //            InputOutputTypes(emptyList(), expectedType.arguments.single().type.unwrap())
@@ -187,23 +187,4 @@ internal fun extractInputOutputTypesFromCallableReferenceExpectedType(
 
         else -> null
     }
-}
-
-private fun extractInputOutputTypesFromFunctionType(
-    functionType: ConeKotlinType,
-    session: FirSession
-): InputOutputTypes {
-    val parameters = functionType.valueParameterTypesIncludingReceiver(session).map {
-        it ?: ConeClassLikeTypeImpl(
-            ConeClassLikeLookupTagImpl(StandardClassIds.Nothing), emptyArray(),
-            isNullable = false
-        )
-    }
-
-    val outputType = functionType.returnType(session) ?: ConeClassLikeTypeImpl(
-        ConeClassLikeLookupTagImpl(StandardClassIds.Any), emptyArray(),
-        isNullable = true
-    )
-
-    return InputOutputTypes(parameters, outputType)
 }

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirDeclarationsResolveTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirDeclarationsResolveTransformer.kt
@@ -669,12 +669,11 @@ open class FirDeclarationsResolveTransformer(transformer: FirBodyResolveTransfor
                                     if (param.returnTypeRef is FirResolvedTypeRef) {
                                         param
                                     } else {
-                                        param.transformReturnTypeRef(
-                                            StoreType,
-                                            param.returnTypeRef.resolvedTypeFromPrototype(
-                                                resolvedLambdaAtom.parameters[index]
-                                            )
-                                        )
+                                        val resolvedType = buildResolvedTypeRef {
+                                            source = param.source
+                                            type = resolvedLambdaAtom.parameters[index]
+                                        }
+                                        param.replaceReturnTypeRef(resolvedType)
                                         param
                                     }
                                 }

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/diagnostics/ConeSimpleDiagnostic.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/diagnostics/ConeSimpleDiagnostic.kt
@@ -27,6 +27,7 @@ enum class DiagnosticKind {
     Java,
     SuperNotAllowed,
     ValueParameterWithNoTypeAnnotation,
+    CannotInferParameterType,
     UnknownCallableKind,
     IllegalProjectionUsage,
     MissingStdlibClass,

--- a/compiler/testData/codegen/box/inference/lambdaWithStarReturn.kt
+++ b/compiler/testData/codegen/box/inference/lambdaWithStarReturn.kt
@@ -1,0 +1,3 @@
+fun invoke(f: Function1<Any?, *>) = f("OK")
+
+fun box() = invoke { it } as String

--- a/compiler/testData/diagnostics/tests/AutoCreatedIt.fir.kt
+++ b/compiler/testData/diagnostics/tests/AutoCreatedIt.fir.kt
@@ -3,8 +3,8 @@ fun text() {
     "direct:a" to "mock:a"
     "direct:a" on {it.body == "<hello/>"} to "mock:a"
     "direct:a" on {it -> it.body == "<hello/>"} to "mock:a"
-    bar {1}
-    bar {<!UNRESOLVED_REFERENCE!>it<!> + 1}
+    bar {<!ARGUMENT_TYPE_MISMATCH!>1<!>}
+    bar {<!ARGUMENT_TYPE_MISMATCH!><!UNRESOLVED_REFERENCE!>it<!> + 1<!>}
     bar {it, it1 -> it}
 
     bar1 {1}

--- a/compiler/testData/diagnostics/tests/AutoCreatedIt.fir.kt
+++ b/compiler/testData/diagnostics/tests/AutoCreatedIt.fir.kt
@@ -13,7 +13,7 @@ fun text() {
     <!INAPPLICABLE_CANDIDATE!>bar2<!> {}
     bar2 {1}
     bar2 {<!UNRESOLVED_REFERENCE!>it<!>}
-    bar2 {it -> <!ARGUMENT_TYPE_MISMATCH!>it<!>}
+    bar2 {<!CANNOT_INFER_PARAMETER_TYPE!>it<!> -> <!ARGUMENT_TYPE_MISMATCH!>it<!>}
 }
 
 fun bar(f :  (Int, Int) -> Int) {}

--- a/compiler/testData/diagnostics/tests/EnumEntryAsType.fir.kt
+++ b/compiler/testData/diagnostics/tests/EnumEntryAsType.fir.kt
@@ -18,7 +18,7 @@ class MyColor(val x: <!UNRESOLVED_REFERENCE!>Color.RED<!>, y: <!UNRESOLVED_REFER
         class Local : <!UNRESOLVED_REFERENCE!>Color.RED<!>
         fun local(arg: <!UNRESOLVED_REFERENCE!>Color.RED<!>): <!UNRESOLVED_REFERENCE!>Color.RED<!> = arg
         val temp: <!UNRESOLVED_REFERENCE!>Color.RED<!> = Color.RED
-        temp as? <!UNRESOLVED_REFERENCE!>Color.RED<!>
+        temp as? <!UNRESOLVED_REFERENCE, UNRESOLVED_REFERENCE!>Color.RED<!>
         if (temp is <!UNRESOLVED_REFERENCE!>Color.RED<!>) {
         return temp as <!UNRESOLVED_REFERENCE!>Color.RED<!>
     }

--- a/compiler/testData/diagnostics/tests/FunctionCalleeExpressions.fir.kt
+++ b/compiler/testData/diagnostics/tests/FunctionCalleeExpressions.fir.kt
@@ -40,8 +40,8 @@ fun main(args : Array<String>) {
     foo2()({})
     foo2()<!TOO_MANY_ARGUMENTS!>{}<!>
     (foo2()){}
-    <!INAPPLICABLE_CANDIDATE!>(foo2())<!>{x -> }
-    <!INAPPLICABLE_CANDIDATE!>foo2()<!>({x -> })
+    <!INAPPLICABLE_CANDIDATE!>(foo2())<!>{<!CANNOT_INFER_PARAMETER_TYPE!>x<!> -> }
+    <!INAPPLICABLE_CANDIDATE!>foo2()<!>({<!CANNOT_INFER_PARAMETER_TYPE!>x<!> -> })
 
     val a = fooT1(1)()
     checkSubtype<Int>(a)

--- a/compiler/testData/diagnostics/tests/functionAsExpression/ReceiverByExpectedType.fir.kt
+++ b/compiler/testData/diagnostics/tests/functionAsExpression/ReceiverByExpectedType.fir.kt
@@ -1,3 +1,3 @@
 // !WITH_NEW_INFERENCE
 fun foo(f: String.() -> Int) {}
-val test = foo(fun () = <!UNRESOLVED_REFERENCE!>length<!>)
+val test = foo(fun () = <!ARGUMENT_TYPE_MISMATCH, UNRESOLVED_REFERENCE!>length<!>)

--- a/compiler/testData/diagnostics/tests/functionAsExpression/WithGenericParameters.fir.kt
+++ b/compiler/testData/diagnostics/tests/functionAsExpression/WithGenericParameters.fir.kt
@@ -12,8 +12,8 @@ fun fun_with_where() = fun <!TYPE_PARAMETERS_NOT_ALLOWED!><T><!> <!UNRESOLVED_RE
 
 fun outer() {
     devNull(fun <!TYPE_PARAMETERS_NOT_ALLOWED!><T><!>() {})
-    devNull(fun <!TYPE_PARAMETERS_NOT_ALLOWED!><T><!> T.() {})
-    devNull(fun <!TYPE_PARAMETERS_NOT_ALLOWED!><T><!> (): T = null!!)
-    devNull(fun <!TYPE_PARAMETERS_NOT_ALLOWED!><T><!> (t: T) {})
+    devNull(fun <!TYPE_PARAMETERS_NOT_ALLOWED!><T><!> <!UNRESOLVED_REFERENCE!>T<!>.() {})
+    devNull(fun <!TYPE_PARAMETERS_NOT_ALLOWED!><T><!> (): <!UNRESOLVED_REFERENCE, UNRESOLVED_REFERENCE!>T<!> = null!!)
+    devNull(fun <!TYPE_PARAMETERS_NOT_ALLOWED!><T><!> (t: <!UNRESOLVED_REFERENCE!>T<!>) {})
     devNull(fun <!TYPE_PARAMETERS_NOT_ALLOWED!><T><!> () where T:A {})
 }

--- a/compiler/testData/diagnostics/tests/functionLiterals/ExpectedParametersTypesMismatch.fir.kt
+++ b/compiler/testData/diagnostics/tests/functionLiterals/ExpectedParametersTypesMismatch.fir.kt
@@ -13,7 +13,7 @@ fun test1() {
         s: String-> <!ARGUMENT_TYPE_MISMATCH!>""<!>
     }
     foo0 {
-        x, y -> <!ARGUMENT_TYPE_MISMATCH!>""<!>
+        <!CANNOT_INFER_PARAMETER_TYPE!>x<!>, <!CANNOT_INFER_PARAMETER_TYPE!>y<!> -> <!ARGUMENT_TYPE_MISMATCH!>""<!>
     }
 
     foo1 {
@@ -23,7 +23,7 @@ fun test1() {
         s: String -> <!ARGUMENT_TYPE_MISMATCH!>""<!>
     }
     foo1 {
-        x, y -> <!ARGUMENT_TYPE_MISMATCH!>""<!>
+        x, <!CANNOT_INFER_PARAMETER_TYPE!>y<!> -> <!ARGUMENT_TYPE_MISMATCH!>""<!>
     }
     foo1 {
         -> 42

--- a/compiler/testData/diagnostics/tests/functionLiterals/ExpectedParametersTypesMismatch.fir.kt
+++ b/compiler/testData/diagnostics/tests/functionLiterals/ExpectedParametersTypesMismatch.fir.kt
@@ -31,7 +31,7 @@ fun test1() {
 
 
     foo2 {
-        ""
+        <!ARGUMENT_TYPE_MISMATCH!>""<!>
     }
     foo2 {
         s: String -> <!ARGUMENT_TYPE_MISMATCH!>""<!>
@@ -40,6 +40,6 @@ fun test1() {
         x -> <!ARGUMENT_TYPE_MISMATCH!>""<!>
     }
     foo2 {
-         -> 42
+         -> <!ARGUMENT_TYPE_MISMATCH!>42<!>
     }
 }

--- a/compiler/testData/diagnostics/tests/inference/completion/anonymousFunction.fir.kt
+++ b/compiler/testData/diagnostics/tests/inference/completion/anonymousFunction.fir.kt
@@ -20,5 +20,5 @@ fun testFunctions() {
 fun testNestedCalls() {
     id<String>(inferFromLambda { materialize() })
     id<String>(inferFromLambda(fun() = materialize()))
-    id<String>(inferFromLambda2(fun() = materialize()))
+    id<String>(<!ARGUMENT_TYPE_MISMATCH!>inferFromLambda2(fun() = <!ARGUMENT_TYPE_MISMATCH!>materialize()<!>)<!>)
 }

--- a/compiler/testData/diagnostics/tests/inference/completion/postponedArgumentsAnalysis/basic.fir.kt
+++ b/compiler/testData/diagnostics/tests/inference/completion/postponedArgumentsAnalysis/basic.fir.kt
@@ -228,7 +228,7 @@ fun main() {
     val x70: (Int) -> Unit = selectNumber(id(fun (it) { }), id {}, id {})
     val x71: String.() -> Unit = select(<!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Function1<kotlin.String, kotlin.Unit>")!>id(fun String.() { })<!>, <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Function1<kotlin.String, kotlin.Unit>")!>id(fun(x: String) {})<!>)
     val x72: String.() -> Unit = select(fun String.() { }, fun(x: String) {}) // must be error
-    select(id(fun String.(x: String) {}), id(fun(x: String, y: String) { }), fun (x, y) { <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.String")!>x<!>;<!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any?")!>y<!> })
+    select(id(fun String.(x: String) {}), id(fun(x: String, y: String) { }), fun (x, y) { <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.String")!>x<!>;<!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Nothing")!>y<!> })
     select(id<Int.(String) -> Unit>(fun (x, y) {}), { x: Int, y: String -> x }) // receiver of anonymous function must be specified explicitly
     select(id<Int.(String) -> Unit>(fun Int.(y) {}), { x: Int, y: String -> x })
     <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Function1<kotlin.Number, java.io.Serializable>")!>select(A3(), fun (x) = "", { a -> <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Number")!>a<!> })<!>

--- a/compiler/testData/diagnostics/tests/inference/completion/postponedArgumentsAnalysis/basic.fir.kt
+++ b/compiler/testData/diagnostics/tests/inference/completion/postponedArgumentsAnalysis/basic.fir.kt
@@ -228,7 +228,7 @@ fun main() {
     val x70: (Int) -> Unit = selectNumber(id(fun (it) { }), id {}, id {})
     val x71: String.() -> Unit = select(<!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Function1<kotlin.String, kotlin.Unit>")!>id(fun String.() { })<!>, <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Function1<kotlin.String, kotlin.Unit>")!>id(fun(x: String) {})<!>)
     val x72: String.() -> Unit = select(fun String.() { }, fun(x: String) {}) // must be error
-    select(id(fun String.(x: String) {}), id(fun(x: String, y: String) { }), fun (x, y) { <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.String")!>x<!>;<!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Nothing")!>y<!> })
+    select(id(fun String.(x: String) {}), id(fun(x: String, y: String) { }), fun (x, y) { <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.String")!>x<!>;<!DEBUG_INFO_EXPRESSION_TYPE("kotlin.String")!>y<!> })
     select(id<Int.(String) -> Unit>(fun (x, y) {}), { x: Int, y: String -> x }) // receiver of anonymous function must be specified explicitly
     select(id<Int.(String) -> Unit>(fun Int.(y) {}), { x: Int, y: String -> x })
     <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Function1<kotlin.Number, java.io.Serializable>")!>select(A3(), fun (x) = "", { a -> <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Number")!>a<!> })<!>

--- a/compiler/testData/diagnostics/tests/inference/completion/postponedArgumentsAnalysis/basic.fir.kt
+++ b/compiler/testData/diagnostics/tests/inference/completion/postponedArgumentsAnalysis/basic.fir.kt
@@ -151,7 +151,7 @@ fun main() {
     select(id(fun String.(x: String) {}), id(fun(x: String, y: String) { }), { x -> <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.String")!>this<!> })
     select(id(fun String.(x: String) {}), id(fun(x: String, y: String) { }), { x: String, y: String -> x })
     // Convert to extension lambda is impossible because the lambda parameter types aren't specified explicitly
-    select(id(fun String.(x: String) {}), id(fun(x: String, y: String) { }), { x, y -> x })
+    select(id(fun String.(x: String) {}), id(fun(x: String, y: String) { }), { x, <!CANNOT_INFER_PARAMETER_TYPE!>y<!> -> x })
     select(id(id(fun(x: String, y: String) { }), <!TOO_MANY_ARGUMENTS!>fun String.(x: String) {}<!>), { x, y -> x })
     val x26: Int.(String) -> Int = fun (x: String) = 10 // it must be error, see KT-38439
     // Receiver must be specified in anonymous function declaration

--- a/compiler/testData/diagnostics/tests/inference/extensionLambdasAndArrow.fir.kt
+++ b/compiler/testData/diagnostics/tests/inference/extensionLambdasAndArrow.fir.kt
@@ -8,9 +8,9 @@ fun main() {
     val x3: () -> String = if (true) {{ -> "this" }} else {{ -> "this" }}
     val x4: String.() -> String = if (true) {{ str: String -> "this" }} else {{ str: String -> "this" }}
     val x41: String.(String) -> String = if (true) {{ str: String, str2: String -> "this" }} else {{ str: String, str2: String -> "this" }}
-    val x42: String.(String) -> String = if (true) {{ str, str2 -> "this" }} else {{ str, str2 -> "this" }}
-    val x5: String.() -> String = if (true) {{ str -> "this" }} else {{ str -> "this" }}
-    val x6: String.() -> String = if (true) {{ str -> "this" }} else {{ "this" }}
+    val x42: String.(String) -> String = if (true) {{ str, <!CANNOT_INFER_PARAMETER_TYPE!>str2<!> -> "this" }} else {{ str, <!CANNOT_INFER_PARAMETER_TYPE!>str2<!> -> "this" }}
+    val x5: String.() -> String = if (true) {{ <!CANNOT_INFER_PARAMETER_TYPE!>str<!> -> "this" }} else {{ <!CANNOT_INFER_PARAMETER_TYPE!>str<!> -> "this" }}
+    val x6: String.() -> String = if (true) {{ <!CANNOT_INFER_PARAMETER_TYPE!>str<!> -> "this" }} else {{ "this" }}
     val x7: String.() -> String = select({ -> this }, { -> this })
     val x8: String.() -> String = select({ this }, { this })
 }

--- a/compiler/testData/diagnostics/tests/inference/reportingImprovements/cannotInferParameterTypeWithInference.fir.kt
+++ b/compiler/testData/diagnostics/tests/inference/reportingImprovements/cannotInferParameterTypeWithInference.fir.kt
@@ -13,5 +13,5 @@ fun test1() {
 fun bar(f: (<!UNRESOLVED_REFERENCE!>A<!>)->Unit) {}
 
 fun test2() {
-    bar { a -> } // here we don't have 'cannot infer parameter type' error
+    bar { <!UNRESOLVED_REFERENCE!>a<!> -> } // here we don't have 'cannot infer parameter type' error
 }

--- a/compiler/testData/diagnostics/tests/labels/labeledFunctionLiteral.fir.kt
+++ b/compiler/testData/diagnostics/tests/labels/labeledFunctionLiteral.fir.kt
@@ -5,13 +5,13 @@ val funLit = lambda@ fun String.() {
 }
 
 fun test() {
-    val funLit = lambda@ fun String.(): String {
+    val funLit = lambda@ fun String.(): <!UNRESOLVED_LABEL!>String<!> {
         return <!UNRESOLVED_LABEL!>this@lambda<!>
     }
 }
 
 fun lambda() {
-    val funLit = lambda@ fun String.(): String {
+    val funLit = lambda@ fun String.(): <!UNRESOLVED_LABEL!>String<!> {
         return <!UNRESOLVED_LABEL!>this@lambda<!>
     }
 }

--- a/compiler/testData/diagnostics/tests/regressions/kt30245.fir.kt
+++ b/compiler/testData/diagnostics/tests/regressions/kt30245.fir.kt
@@ -46,9 +46,9 @@ fun test1() { // to extension lambda 0
 
     val w11 = W1 { i: Int -> <!ARGUMENT_TYPE_MISMATCH!>i<!> } // oi- ni-
     val i11: E0 = id { i: Int -> i } // o1+ ni+
-    val w12 = W1 { i -> <!ARGUMENT_TYPE_MISMATCH!>i<!> } // oi- ni-
-    val i12: E0 = id { i -> i } // oi- ni-
-    val j12 = id<E0> { i -> i } // oi- ni-
+    val w12 = W1 { <!CANNOT_INFER_PARAMETER_TYPE!>i<!> -> <!ARGUMENT_TYPE_MISMATCH!>i<!> } // oi- ni-
+    val i12: E0 = id { <!CANNOT_INFER_PARAMETER_TYPE!>i<!> -> i } // oi- ni-
+    val j12 = id<E0> { <!CANNOT_INFER_PARAMETER_TYPE!>i<!> -> i } // oi- ni-
 
     // yet unsupported cases - considering lambdas as extension ones unconditionally
 //    val w13 = W1 { it } // this or it: oi- ni-
@@ -83,8 +83,8 @@ fun test2() { // to extension lambda 1
     val i27: E1 = <!INITIALIZER_TYPE_MISMATCH!>when (e) { E.VALUE ->  { s: String -> <!NO_THIS!>this<!> + s.length } }<!> // oi+ ni+
     val i27a: E1 = <!INITIALIZER_TYPE_MISMATCH!>when (e) { E.VALUE ->  { s -> <!NO_THIS!>this<!> + s.<!UNRESOLVED_REFERENCE!>length<!> } }<!> // oi+ ni+
 
-    val w28 = W2 { i: Int, s -> <!ARGUMENT_TYPE_MISMATCH!>i <!OVERLOAD_RESOLUTION_AMBIGUITY!>+<!> s.<!UNRESOLVED_REFERENCE!>length<!><!> } // oi- ni-
-    val i28: E1 = id { i: Int, s -> i <!OVERLOAD_RESOLUTION_AMBIGUITY!>+<!> s.<!UNRESOLVED_REFERENCE!>length<!> } // oi- ni-
+    val w28 = W2 { i: Int, <!CANNOT_INFER_PARAMETER_TYPE!>s<!> -> <!ARGUMENT_TYPE_MISMATCH!>i <!OVERLOAD_RESOLUTION_AMBIGUITY!>+<!> s.<!UNRESOLVED_REFERENCE!>length<!><!> } // oi- ni-
+    val i28: E1 = id { i: Int, <!CANNOT_INFER_PARAMETER_TYPE!>s<!> -> i <!OVERLOAD_RESOLUTION_AMBIGUITY!>+<!> s.<!UNRESOLVED_REFERENCE!>length<!> } // oi- ni-
     val w29 = W2 { i: Int, s: String -> <!ARGUMENT_TYPE_MISMATCH!>i + s.length<!> } // oi- ni-
     val i29: E1 = id { i: Int, s: String -> i + s.length } // oi+ ni+
 

--- a/compiler/testData/diagnostics/tests/regressions/kt30245.fir.kt
+++ b/compiler/testData/diagnostics/tests/regressions/kt30245.fir.kt
@@ -111,7 +111,7 @@ fun test3() { // to non-extension lambda 1
 //    val i32: L1 = id { this } // this or it: oi- ni-
 //    val j32 = id<L1> { this } // this or it: oi- ni-
 
-    val w33 = W3(fun Int.(): Int = <!ARGUMENT_TYPE_MISMATCH!>this<!>) // oi- ni+
+    val w33 = W3(fun Int.(): Int = this) // oi- ni+
     val i33: L1 = id(fun Int.(): Int = this) // oi+ ni+
 
     // yet unsupported cases with ambiguity for the lambda conversion (commented constructors in wrappers above)

--- a/compiler/testData/diagnostics/tests/typealias/typeAliasAsSuperQualifier.fir.kt
+++ b/compiler/testData/diagnostics/tests/typealias/typeAliasAsSuperQualifier.fir.kt
@@ -22,7 +22,7 @@ class TestSuperForBase : B() {
     override fun foo() {
         super<Base>.foo()
         super<B>.foo()
-        super<MyBase>.<!UNRESOLVED_REFERENCE!>foo<!>()
+        super<<!UNRESOLVED_REFERENCE, UNRESOLVED_REFERENCE!>MyBase<!>>.<!UNRESOLVED_REFERENCE!>foo<!>()
         <!NOT_A_SUPERTYPE!>super<U><!>.foo()
     }
 }
@@ -34,8 +34,8 @@ class TestSuperForGenericBase<T> : GB<T>() {
     override fun foo() {
         super<GenericBase>.foo()
         super<GB>.foo()
-        super<MyBase>.<!UNRESOLVED_REFERENCE!>foo<!>()
-        super<MyBaseInt>.<!UNRESOLVED_REFERENCE!>foo<!>() // Type arguments don't matter here
+        super<<!UNRESOLVED_REFERENCE, UNRESOLVED_REFERENCE!>MyBase<!>>.<!UNRESOLVED_REFERENCE!>foo<!>()
+        super<<!UNRESOLVED_REFERENCE, UNRESOLVED_REFERENCE!>MyBaseInt<!>>.<!UNRESOLVED_REFERENCE!>foo<!>() // Type arguments don't matter here
         <!NOT_A_SUPERTYPE!>super<U><!>.foo()
     }
 }

--- a/compiler/testData/diagnostics/tests/when/whenAndLambdaWithExpectedType.fir.kt
+++ b/compiler/testData/diagnostics/tests/when/whenAndLambdaWithExpectedType.fir.kt
@@ -30,7 +30,7 @@ val test3: (String) -> Boolean =
 
 val test4: (String) -> Boolean =
         when {
-            true -> { s1, s2 -> true }
+            true -> { s1, <!CANNOT_INFER_PARAMETER_TYPE!>s2<!> -> true }
             else -> null!!
         }
 

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -16961,6 +16961,12 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
         }
 
         @Test
+        @TestMetadata("lambdaWithStarReturn.kt")
+        public void testLambdaWithStarReturn() throws Exception {
+            runTest("compiler/testData/codegen/box/inference/lambdaWithStarReturn.kt");
+        }
+
+        @Test
         @TestMetadata("lambdasWithExtensionFunctionType.kt")
         public void testLambdasWithExtensionFunctionType() throws Exception {
             runTest("compiler/testData/codegen/box/inference/lambdasWithExtensionFunctionType.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -16979,6 +16979,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         }
 
         @Test
+        @TestMetadata("lambdaWithStarReturn.kt")
+        public void testLambdaWithStarReturn() throws Exception {
+            runTest("compiler/testData/codegen/box/inference/lambdaWithStarReturn.kt");
+        }
+
+        @Test
         @TestMetadata("lambdasWithExtensionFunctionType.kt")
         public void testLambdasWithExtensionFunctionType() throws Exception {
             runTest("compiler/testData/codegen/box/inference/lambdasWithExtensionFunctionType.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -14040,6 +14040,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/inference/kt42130.kt");
         }
 
+        @TestMetadata("lambdaWithStarReturn.kt")
+        public void testLambdaWithStarReturn() throws Exception {
+            runTest("compiler/testData/codegen/box/inference/lambdaWithStarReturn.kt");
+        }
+
         @TestMetadata("lambdasWithExtensionFunctionType.kt")
         public void testLambdasWithExtensionFunctionType() throws Exception {
             runTest("compiler/testData/codegen/box/inference/lambdasWithExtensionFunctionType.kt");

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDataClassConverters.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDataClassConverters.kt
@@ -1338,6 +1338,12 @@ internal val KT_DIAGNOSTIC_CONVERTER = KtDiagnosticConverterBuilder.buildConvert
             token,
         )
     }
+    add(FirErrors.CANNOT_INFER_PARAMETER_TYPE) { firDiagnostic ->
+        CannotInferParameterTypeImpl(
+            firDiagnostic as FirPsiDiagnostic<*>,
+            token,
+        )
+    }
     add(FirErrors.FUN_INTERFACE_CONSTRUCTOR_REFERENCE) { firDiagnostic ->
         FunInterfaceConstructorReferenceImpl(
             firDiagnostic as FirPsiDiagnostic<*>,

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnostics.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnostics.kt
@@ -949,6 +949,10 @@ sealed class KtFirDiagnostic<PSI: PsiElement> : KtDiagnosticWithPsi<PSI> {
         override val diagnosticClass get() = ValueParameterWithNoTypeAnnotation::class
     }
 
+    abstract class CannotInferParameterType : KtFirDiagnostic<KtParameter>() {
+        override val diagnosticClass get() = CannotInferParameterType::class
+    }
+
     abstract class FunInterfaceConstructorReference : KtFirDiagnostic<KtExpression>() {
         override val diagnosticClass get() = FunInterfaceConstructorReference::class
     }

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnosticsImpl.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnosticsImpl.kt
@@ -1529,6 +1529,13 @@ internal class ValueParameterWithNoTypeAnnotationImpl(
     override val firDiagnostic: FirPsiDiagnostic<*> by weakRef(firDiagnostic)
 }
 
+internal class CannotInferParameterTypeImpl(
+    firDiagnostic: FirPsiDiagnostic<*>,
+    override val token: ValidityToken,
+) : KtFirDiagnostic.CannotInferParameterType(), KtAbstractFirDiagnostic<KtParameter> {
+    override val firDiagnostic: FirPsiDiagnostic<*> by weakRef(firDiagnostic)
+}
+
 internal class FunInterfaceConstructorReferenceImpl(
     firDiagnostic: FirPsiDiagnostic<*>,
     override val token: ValidityToken,

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
@@ -12344,6 +12344,11 @@ public class IrJsCodegenBoxES6TestGenerated extends AbstractIrJsCodegenBoxES6Tes
             runTest("compiler/testData/codegen/box/inference/kt42130.kt");
         }
 
+        @TestMetadata("lambdaWithStarReturn.kt")
+        public void testLambdaWithStarReturn() throws Exception {
+            runTest("compiler/testData/codegen/box/inference/lambdaWithStarReturn.kt");
+        }
+
         @TestMetadata("lambdasWithExtensionFunctionType.kt")
         public void testLambdasWithExtensionFunctionType() throws Exception {
             runTest("compiler/testData/codegen/box/inference/lambdasWithExtensionFunctionType.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -11765,6 +11765,11 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/inference/kt42130.kt");
         }
 
+        @TestMetadata("lambdaWithStarReturn.kt")
+        public void testLambdaWithStarReturn() throws Exception {
+            runTest("compiler/testData/codegen/box/inference/lambdaWithStarReturn.kt");
+        }
+
         @TestMetadata("lambdasWithExtensionFunctionType.kt")
         public void testLambdasWithExtensionFunctionType() throws Exception {
             runTest("compiler/testData/codegen/box/inference/lambdasWithExtensionFunctionType.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -11830,6 +11830,11 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/inference/kt42130.kt");
         }
 
+        @TestMetadata("lambdaWithStarReturn.kt")
+        public void testLambdaWithStarReturn() throws Exception {
+            runTest("compiler/testData/codegen/box/inference/lambdaWithStarReturn.kt");
+        }
+
         @TestMetadata("lambdasWithExtensionFunctionType.kt")
         public void testLambdasWithExtensionFunctionType() throws Exception {
             runTest("compiler/testData/codegen/box/inference/lambdasWithExtensionFunctionType.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/wasm/semantics/IrCodegenBoxWasmTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/wasm/semantics/IrCodegenBoxWasmTestGenerated.java
@@ -6256,6 +6256,11 @@ public class IrCodegenBoxWasmTestGenerated extends AbstractIrCodegenBoxWasmTest 
             runTest("compiler/testData/codegen/box/inference/kt42130.kt");
         }
 
+        @TestMetadata("lambdaWithStarReturn.kt")
+        public void testLambdaWithStarReturn() throws Exception {
+            runTest("compiler/testData/codegen/box/inference/lambdaWithStarReturn.kt");
+        }
+
         @TestMetadata("lambdasWithExtensionFunctionType.kt")
         public void testLambdasWithExtensionFunctionType() throws Exception {
             runTest("compiler/testData/codegen/box/inference/lambdasWithExtensionFunctionType.kt");


### PR DESCRIPTION
1. Allow star projections as type arguments of `Function{N}`: `() -> *` is not valid, but things like `F<*>` where `typealias F<T> = () -> T` are.
2. Disallow lambdas with inferred parameters when there are more than 1.
3. Allow using an anonymous function (not a lambda) with N+1 arguments and no receiver as a functional object with N arguments and a receiver, and the other way around.