### PR TITLE
Kapt: Don't create KDocCommentKeeper when not needed

### DIFF
--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/KaptContext.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/KaptContext.kt
@@ -150,7 +150,9 @@ open class KaptContext(val options: KaptOptions, val withJdk: Boolean, val logge
         }
 
         compiler = JavaCompiler.instance(context) as KaptJavaCompiler
-        compiler.keepComments = true
+        if (options.flags[KaptFlag.KEEP_KDOC_COMMENTS_IN_STUBS]) {
+            compiler.keepComments = true
+        }
 
         ClassReader.instance(context).saveParameterNames = true
 


### PR DESCRIPTION
Previously, even if `keepKdocComments=false`, we would still create the
KDocCommentKeeper object unnecessarily.

This commit makes sure we create the object only if
`keepKdocComments=true`.

Bug: Clean-up after commit e252171 for KT-43593
Test: Existing tests