### PR TITLE
JVM IR: Minor changes to Enum codegen to align with the JVM backend

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmSymbols.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmSymbols.kt
@@ -850,6 +850,14 @@ class JvmSymbols(
     val enumValueOfFunction: IrSimpleFunctionSymbol =
         javaLangEnum.functionByName("valueOf")
 
+    private val javaLangObject: IrClassSymbol =
+        createClass(FqName("java.lang.Object")) { klass ->
+            klass.addFunction("clone", irBuiltIns.anyType)
+        }
+
+    val objectCloneFunction: IrSimpleFunctionSymbol =
+        javaLangObject.functionByName("clone")
+
     private val kotlinCoroutinesJvmInternalRunSuspendKt =
         createClass(FqName("kotlin.coroutines.jvm.internal.RunSuspendKt")) { klass ->
             klass.addFunction("runSuspend", irBuiltIns.unitType, isStatic = true).apply {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -288,6 +288,7 @@ class ExpressionCodegen(
             irFunction.origin == JvmLoweredDeclarationOrigin.SUPER_INTERFACE_METHOD_BRIDGE ||
             irFunction.origin == JvmLoweredDeclarationOrigin.JVM_STATIC_WRAPPER ||
             irFunction.origin == IrDeclarationOrigin.IR_BUILTINS_STUB ||
+            irFunction.origin == IrDeclarationOrigin.ENUM_CLASS_SPECIAL_MEMBER ||
             irFunction.parentAsClass.origin == JvmLoweredDeclarationOrigin.CONTINUATION_CLASS ||
             irFunction.parentAsClass.origin == JvmLoweredDeclarationOrigin.SUSPEND_LAMBDA ||
             irFunction.isMultifileBridge()

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/EnumClassLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/EnumClassLowering.kt
@@ -154,10 +154,7 @@ private class EnumClassLowering(val context: JvmBackendContext) : ClassLoweringP
                     irExprBody(
                         when (body.kind) {
                             IrSyntheticBodyKind.ENUM_VALUES -> {
-                                val cloneFun = context.irBuiltIns.arrayClass.functions.single {
-                                    it.owner.name.asString() == "clone"
-                                }
-                                irCall(cloneFun, declaration.returnType).apply {
+                                irCall(this@EnumClassLowering.context.ir.symbols.objectCloneFunction, declaration.returnType).apply {
                                     dispatchReceiver = irGetField(null, valuesField)
                                 }
                             }

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/EnumClassLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/EnumClassLowering.kt
@@ -32,10 +32,7 @@ import org.jetbrains.kotlin.ir.expressions.impl.IrSetValueImpl
 import org.jetbrains.kotlin.ir.symbols.IrConstructorSymbol
 import org.jetbrains.kotlin.ir.symbols.IrValueParameterSymbol
 import org.jetbrains.kotlin.ir.types.typeWith
-import org.jetbrains.kotlin.ir.util.defaultType
-import org.jetbrains.kotlin.ir.util.isEnumClass
-import org.jetbrains.kotlin.ir.util.isEnumEntry
-import org.jetbrains.kotlin.ir.util.patchDeclarationParents
+import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
 import org.jetbrains.kotlin.name.Name
@@ -156,8 +153,14 @@ private class EnumClassLowering(val context: JvmBackendContext) : ClassLoweringP
                 declaration.body = context.createJvmIrBuilder(declaration.symbol).run {
                     irExprBody(
                         when (body.kind) {
-                            IrSyntheticBodyKind.ENUM_VALUES ->
-                                irArray(valuesField.type) { addSpread(irGetField(null, valuesField)) }
+                            IrSyntheticBodyKind.ENUM_VALUES -> {
+                                val cloneFun = context.irBuiltIns.arrayClass.functions.single {
+                                    it.owner.name.asString() == "clone"
+                                }
+                                irCall(cloneFun, declaration.returnType).apply {
+                                    dispatchReceiver = irGetField(null, valuesField)
+                                }
+                            }
 
                             IrSyntheticBodyKind.ENUM_VALUEOF ->
                                 irCall(backendContext.ir.symbols.enumValueOfFunction).apply {

--- a/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/EnumClassMembersGenerator.kt
+++ b/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/EnumClassMembersGenerator.kt
@@ -21,6 +21,7 @@ import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
 import org.jetbrains.kotlin.ir.declarations.addMember
 import org.jetbrains.kotlin.ir.expressions.IrSyntheticBodyKind
 import org.jetbrains.kotlin.ir.expressions.impl.IrSyntheticBodyImpl
+import org.jetbrains.kotlin.ir.util.SYNTHETIC_OFFSET
 import org.jetbrains.kotlin.ir.util.declareSimpleFunctionWithOverrides
 import org.jetbrains.kotlin.ir.util.findFirstFunction
 
@@ -39,12 +40,12 @@ class EnumClassMembersGenerator(declarationGenerator: DeclarationGenerator) : De
 
         irClass.addMember(
             context.symbolTable.declareSimpleFunctionWithOverrides(
-                irClass.startOffset, irClass.endOffset,
+                SYNTHETIC_OFFSET, SYNTHETIC_OFFSET,
                 IrDeclarationOrigin.ENUM_CLASS_SPECIAL_MEMBER,
                 valuesFunction
             ).also { irFunction ->
                 FunctionGenerator(declarationGenerator).generateFunctionParameterDeclarationsAndReturnType(irFunction, null, null)
-                irFunction.body = IrSyntheticBodyImpl(irClass.startOffset, irClass.endOffset, IrSyntheticBodyKind.ENUM_VALUES)
+                irFunction.body = IrSyntheticBodyImpl(SYNTHETIC_OFFSET, SYNTHETIC_OFFSET, IrSyntheticBodyKind.ENUM_VALUES)
             }
         )
     }
@@ -58,12 +59,12 @@ class EnumClassMembersGenerator(declarationGenerator: DeclarationGenerator) : De
 
         irClass.addMember(
             context.symbolTable.declareSimpleFunctionWithOverrides(
-                irClass.startOffset, irClass.endOffset,
+                SYNTHETIC_OFFSET, SYNTHETIC_OFFSET,
                 IrDeclarationOrigin.ENUM_CLASS_SPECIAL_MEMBER,
                 valueOfFunction
             ).also { irFunction ->
                 FunctionGenerator(declarationGenerator).generateFunctionParameterDeclarationsAndReturnType(irFunction, null, null)
-                irFunction.body = IrSyntheticBodyImpl(irClass.startOffset, irClass.endOffset, IrSyntheticBodyKind.ENUM_VALUEOF)
+                irFunction.body = IrSyntheticBodyImpl(SYNTHETIC_OFFSET, SYNTHETIC_OFFSET, IrSyntheticBodyKind.ENUM_VALUEOF)
             }
         )
     }

--- a/compiler/testData/codegen/bytecodeText/enum/enumCheckcasts.kt
+++ b/compiler/testData/codegen/bytecodeText/enum/enumCheckcasts.kt
@@ -3,10 +3,5 @@ enum class Foo {
     open fun result() = "Fail"
 }
 
-// JVM_TEMPLATES:
 // There are two CHECKCASTs, one in Foo.valueOf and one in Foo.values
 // 2 CHECKCAST
-
-// JVM_IR_TEMPLATES:
-// There should be only one CHECKCAST in Foo.valueOf
-// 1 CHECKCAST

--- a/compiler/testData/ir/sourceRanges/declarations/classes.txt
+++ b/compiler/testData/ir/sourceRanges/declarations/classes.txt
@@ -79,11 +79,11 @@
         @17:0..18:11 VALUE_PARAMETER name:<this> type:kotlin.Enum<<root>.Test5>
     @18:0..11 FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Enum<<root>.Test5>) returnType:kotlin.String [fake_override]
       @17:0..18:11 VALUE_PARAMETER name:<this> type:kotlin.Enum<<root>.Test5>
-    @17:0..18:11 FUN ENUM_CLASS_SPECIAL_MEMBER name:values visibility:public modality:FINAL <> () returnType:kotlin.Array<<root>.Test5>
-      @17:0..18:11 SYNTHETIC_BODY kind=ENUM_VALUES
-    @17:0..18:11 FUN ENUM_CLASS_SPECIAL_MEMBER name:valueOf visibility:public modality:FINAL <> (value:kotlin.String) returnType:<root>.Test5
-      @17:0..18:11 VALUE_PARAMETER name:value index:0 type:kotlin.String
-      @17:0..18:11 SYNTHETIC_BODY kind=ENUM_VALUEOF
+    @-1:-1..-1 FUN ENUM_CLASS_SPECIAL_MEMBER name:values visibility:public modality:FINAL <> () returnType:kotlin.Array<<root>.Test5>
+      @-1:-1..-1 SYNTHETIC_BODY kind=ENUM_VALUES
+    @-1:-1..-1 FUN ENUM_CLASS_SPECIAL_MEMBER name:valueOf visibility:public modality:FINAL <> (value:kotlin.String) returnType:<root>.Test5
+      @-1:-1..-1 VALUE_PARAMETER name:value index:0 type:kotlin.String
+      @-1:-1..-1 SYNTHETIC_BODY kind=ENUM_VALUEOF
   @21:0..22:11 CLASS ANNOTATION_CLASS name:Test6 modality:FINAL visibility:public superTypes:[kotlin.Annotation]
     @21:0..22:11 VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.Test6
     @22:0..11 CONSTRUCTOR visibility:public <> () returnType:<root>.Test6 [primary]


### PR DESCRIPTION
These are all minor, but there are tools out there which seem to be very sensitive to the code in enum classes:

- Use `Object.clone` in the `Enum.values` function rather than arraycopy.
- Don't produce a null check in `Enum.valueOf`. The JVM backend doesn't and it's superfluous since `java.lang.Enum.valueOf` includes a null check.
- Don't produce line numbers in `Enum.values` and `Enum.valueOf`.