### PR TITLE
Use AGP support for Kotlin sources when it is available

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/Kapt3KotlinGradleSubplugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/Kapt3KotlinGradleSubplugin.kt
@@ -26,6 +26,7 @@ import org.gradle.process.CommandLineArgumentProvider
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
 import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.gradle.dsl.KotlinCommonOptions
+import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
 import org.jetbrains.kotlin.gradle.internal.kapt.incremental.CLASS_STRUCTURE_ARTIFACT_TYPE
 import org.jetbrains.kotlin.gradle.internal.kapt.incremental.StructureTransformAction
 import org.jetbrains.kotlin.gradle.internal.kapt.incremental.StructureTransformLegacyAction
@@ -571,7 +572,7 @@ class Kapt3GradleSubplugin @Inject internal constructor(private val registry: To
         }
 
         project.whenEvaluated {
-            addCompilationSourcesToExternalCompileTask(kotlinCompilation, kaptTaskProvider)
+            addCompilationSourcesToExternalCompileTask(kotlinCompilation, kaptTaskProvider, project.kotlinExtension.sourceSets)
         }
 
         val subpluginOptions = buildOptions("stubs", project.provider { kaptExtension.getJavacOptions() })

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt
@@ -987,7 +987,7 @@ abstract class AbstractAndroidProjectHandler(private val kotlinConfigurationTool
         // Register the source only after the task is created, because the task is required for that:
         compilation.source(defaultSourceSet)
 
-        compilation.androidVariant.forEachKotlinSourceSet { kotlinSourceSet -> compilation.source(kotlinSourceSet) }
+        compilation.forEachKotlinSourceSet(project.kotlinExtension.sourceSets) { kotlinSourceSet -> compilation.source(kotlinSourceSet) }
     }
 
     private fun postprocessVariant(
@@ -1011,10 +1011,16 @@ abstract class AbstractAndroidProjectHandler(private val kotlinConfigurationTool
     }
 }
 
-internal inline fun BaseVariant.forEachKotlinSourceSet(action: (KotlinSourceSet) -> Unit) {
-    sourceSets
-        .mapNotNull { provider -> provider.getConvention(KOTLIN_DSL_NAME) as? KotlinSourceSet }
-        .forEach(action)
+internal inline fun KotlinJvmAndroidCompilation.forEachKotlinSourceSet(
+    kotlinSourceSets: NamedDomainObjectContainer<KotlinSourceSet>,
+    action: (KotlinSourceSet) -> Unit
+) {
+    androidVariant.sourceSets.mapNotNull { provider ->
+        val kotlinSourceSetName = AbstractAndroidProjectHandler.kotlinSourceSetNameForAndroidSourceSet(
+            this.target as KotlinAndroidTarget, provider.name
+        )
+        kotlinSourceSets.findByName(kotlinSourceSetName)
+    }.forEach { action(it) }
 }
 
 internal inline fun BaseVariant.forEachJavaSourceDir(action: (ConfigurableFileTree) -> Unit) {

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/SubpluginEnvironment.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/SubpluginEnvironment.kt
@@ -1,11 +1,13 @@
 package org.jetbrains.kotlin.gradle.plugin
 
+import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.compile.AbstractCompile
 import org.gradle.api.tasks.compile.JavaCompile
 import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
+import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
 import org.jetbrains.kotlin.gradle.logging.kotlinDebug
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinAndroidTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinJvmAndroidCompilation
@@ -90,7 +92,7 @@ class SubpluginEnvironment(
 
             if (subplugin is LegacyKotlinCompilerPluginSupportPlugin) {
                 subplugin.getPluginKotlinTasks(kotlinCompilation).forEach { task ->
-                    addCompilationSourcesToExternalCompileTask(kotlinCompilation, task.thisTaskProvider)
+                    addCompilationSourcesToExternalCompileTask(kotlinCompilation, task.thisTaskProvider, project.kotlinExtension.sourceSets)
                 }
             }
         }
@@ -112,9 +114,13 @@ class SubpluginEnvironment(
     }
 }
 
-internal fun addCompilationSourcesToExternalCompileTask(compilation: KotlinCompilation<*>, task: TaskProvider<out AbstractCompile>) {
+internal fun addCompilationSourcesToExternalCompileTask(
+    compilation: KotlinCompilation<*>,
+    task: TaskProvider<out AbstractCompile>,
+    kotlinSourceSets: NamedDomainObjectContainer<KotlinSourceSet>
+) {
     if (compilation is KotlinJvmAndroidCompilation) {
-        compilation.androidVariant.forEachKotlinSourceSet { sourceSet -> task.configure { it.source(sourceSet.kotlin) } }
+        compilation.forEachKotlinSourceSet(kotlinSourceSets) { sourceSet -> task.configure { it.source(sourceSet.kotlin) } }
         compilation.androidVariant.forEachJavaSourceDir { sources -> task.configure { it.source(sources.dir) } }
     } else {
         task.configure { taskInstance ->


### PR DESCRIPTION
This change introduces support for Kotlin source directories
when they specified in AGP. Please note this this feature is
not yet available in the released AGP, but adding suport in
the KGP is the first step. If the support is not available,
old behavior is preserved.

The location of Kotlin sources is (as known by KGP) is passed
to AGP, in order to sync the two models.