### PR TITLE
FIR checker: report errors in contract description

### DIFF
--- a/compiler/fir/analysis-tests/testData/resolveWithStdlib/contracts/fromSource/good/returnsImplies/conditionLogic.fir.txt
+++ b/compiler/fir/analysis-tests/testData/resolveWithStdlib/contracts/fromSource/good/returnsImplies/conditionLogic.fir.txt
@@ -11,6 +11,7 @@ FILE: conditionLogic.kt
     @R|kotlin/OptIn|(vararg(<getClass>(Q|kotlin/contracts/ExperimentalContracts|))) public final fun test2(x: R|kotlin/String?|): R|kotlin/Any?|
         [R|Contract description]
          <
+            Returns(NOT_NULL) -> x is kotlin/String && x != null
         >
      {
         [StubStatement]
@@ -46,6 +47,7 @@ FILE: conditionLogic.kt
     @R|kotlin/OptIn|(vararg(<getClass>(Q|kotlin/contracts/ExperimentalContracts|))) public final fun test6(x: R|kotlin/Any?|): R|kotlin/Any?|
         [R|Contract description]
          <
+            Returns(TRUE) -> x is kotlin/String? && x != null
         >
      {
         [StubStatement]
@@ -54,6 +56,7 @@ FILE: conditionLogic.kt
     @R|kotlin/OptIn|(vararg(<getClass>(Q|kotlin/contracts/ExperimentalContracts|))) public final fun test7(x: R|kotlin/Any?|): R|kotlin/Any?|
         [R|Contract description]
          <
+            Returns(TRUE) -> x is kotlin/String? && x != null || x is kotlin/Int
         >
      {
         [StubStatement]
@@ -95,6 +98,7 @@ FILE: conditionLogic.kt
     @R|kotlin/OptIn|(vararg(<getClass>(Q|kotlin/contracts/ExperimentalContracts|))) public final fun test11(x: R|kotlin/Any?|): R|kotlin/Any?|
         [R|Contract description]
          <
+            Returns(TRUE) -> x is kotlin/Comparable<*> && x is kotlin/CharSequence
         >
      {
         [StubStatement]
@@ -103,6 +107,7 @@ FILE: conditionLogic.kt
     @R|kotlin/OptIn|(vararg(<getClass>(Q|kotlin/contracts/ExperimentalContracts|))) public final fun test12(x: R|kotlin/Any?|): R|kotlin/Any?|
         [R|Contract description]
          <
+            Returns(TRUE) -> x is kotlin/Comparable<*> && x is kotlin/CharSequence || x is kotlin/Number
         >
      {
         [StubStatement]
@@ -111,6 +116,7 @@ FILE: conditionLogic.kt
     @R|kotlin/OptIn|(vararg(<getClass>(Q|kotlin/contracts/ExperimentalContracts|))) public final fun test13(x: R|kotlin/Any?|): R|kotlin/Any?|
         [R|Contract description]
          <
+            Returns(TRUE) -> (!)x !is kotlin/Comparable<*> || x !is kotlin/CharSequence && (!x is kotlin/Number)
         >
      {
         [StubStatement]

--- a/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/diagnostics/FirDiagnosticsList.kt
+++ b/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/diagnostics/FirDiagnosticsList.kt
@@ -381,6 +381,12 @@ val DIAGNOSTICS_LIST = DiagnosticListBuilder.buildDiagnosticList {
         val INVALID_IF_AS_EXPRESSION by error<FirSourceElement, KtIfExpression>(PositioningStrategy.IF_EXPRESSION)
     }
 
+    group("Function contracts") {
+        val ERROR_IN_CONTRACT_DESCRIPTION by error<FirSourceElement, KtElement> {
+            parameter<String>("reason")
+        }
+    }
+
     group("Extended checkers") {
         val REDUNDANT_VISIBILITY_MODIFIER by warning<FirSourceElement, KtModifierListOwner>(PositioningStrategy.VISIBILITY_MODIFIER)
         val REDUNDANT_MODALITY_MODIFIER by warning<FirSourceElement, KtModifierListOwner>(PositioningStrategy.MODALITY_MODIFIER)

--- a/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/diagnostics/FirErrors.kt
+++ b/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/diagnostics/FirErrors.kt
@@ -27,6 +27,7 @@ import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtDestructuringDeclaration
+import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtIfExpression
@@ -238,6 +239,9 @@ object FirErrors {
     // When expressions
     val NO_ELSE_IN_WHEN by error1<FirSourceElement, KtWhenExpression, List<WhenMissingCase>>(SourceElementPositioningStrategies.WHEN_EXPRESSION)
     val INVALID_IF_AS_EXPRESSION by error0<FirSourceElement, KtIfExpression>(SourceElementPositioningStrategies.IF_EXPRESSION)
+
+    // Function contracts
+    val ERROR_IN_CONTRACT_DESCRIPTION by error1<FirSourceElement, KtElement, String>()
 
     // Extended checkers
     val REDUNDANT_VISIBILITY_MODIFIER by warning0<FirSourceElement, KtModifierListOwner>(SourceElementPositioningStrategies.VISIBILITY_MODIFIER)

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirContractChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirContractChecker.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.fir.analysis.checkers.declaration
+
+import org.jetbrains.kotlin.fir.FirFakeSourceElementKind
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.analysis.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors
+import org.jetbrains.kotlin.fir.contracts.FirResolvedContractDescription
+import org.jetbrains.kotlin.fir.declarations.FirContractDescriptionOwner
+import org.jetbrains.kotlin.fir.declarations.FirFunction
+
+object FirContractChecker : FirFunctionChecker() {
+    // TODO: The message should vary. Migrate this to [ConeEffectExtractor] when creating fine-grained errors.
+    private const val UNEXPECTED_CONSTRUCTION = "unexpected construction in contract description"
+
+    override fun check(declaration: FirFunction<*>, context: CheckerContext, reporter: DiagnosticReporter) {
+        if (declaration !is FirContractDescriptionOwner ||
+            declaration.contractDescription !is FirResolvedContractDescription
+        ) {
+            return
+        }
+
+        // Any statements that [ConeEffectExtractor] cannot extract effects will be in `unresolvedEffects`.
+        for (statement in (declaration.contractDescription as FirResolvedContractDescription).unresolvedEffects) {
+            if (statement.source == null || statement.source!!.kind is FirFakeSourceElementKind) continue
+
+            // TODO: report on fine-grained locations, e.g., ... implies unresolved => report on unresolved, not the entire statement.
+            //  but, sometimes, it's just reported on `contract`...
+            reporter.report(FirErrors.ERROR_IN_CONTRACT_DESCRIPTION.on(statement.source!!, UNEXPECTED_CONSTRUCTION), context)
+        }
+    }
+}

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/FirDefaultErrorMessages.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/FirDefaultErrorMessages.kt
@@ -60,6 +60,7 @@ import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.DESERIALIZATION_E
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.EMPTY_RANGE
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.ENUM_AS_SUPERTYPE
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.ERROR_FROM_JAVA_RESOLUTION
+import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.ERROR_IN_CONTRACT_DESCRIPTION
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.EXPECTED_DECLARATION_WITH_BODY
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.EXPECTED_DELEGATED_PROPERTY
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.EXPECTED_PRIVATE_DECLARATION
@@ -534,6 +535,9 @@ class FirDefaultErrorMessages : DefaultErrorMessages.Extension {
             // When expressions
             map.put(NO_ELSE_IN_WHEN, "''when'' expression must be exhaustive, add necessary {0}", WHEN_MISSING_CASES)
             map.put(INVALID_IF_AS_EXPRESSION, "'if' must have both main and 'else' branches if used as an expression")
+
+            // Function contracts
+            map.put(ERROR_IN_CONTRACT_DESCRIPTION, "Error in contract description", TO_STRING)
 
             // Extended checkers group
             map.put(REDUNDANT_VISIBILITY_MODIFIER, "Redundant visibility modifier")

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/coneDiagnosticToFirDiagnostic.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/coneDiagnosticToFirDiagnostic.kt
@@ -46,6 +46,7 @@ fun ConeDiagnostic.toFirDiagnostic(source: FirSourceElement): FirDiagnostic<FirS
     is ConeInstanceAccessBeforeSuperCall -> FirErrors.INSTANCE_ACCESS_BEFORE_SUPER_CALL.on(source, this.target)
     is ConeStubDiagnostic -> null
     is ConeIntermediateDiagnostic -> null
+    is ConeContractDescriptionError -> FirErrors.ERROR_IN_CONTRACT_DESCRIPTION.on(source, this.reason)
     else -> throw IllegalArgumentException("Unsupported diagnostic type: ${this.javaClass}")
 }
 

--- a/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/checkers/CommonDeclarationCheckers.kt
+++ b/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/checkers/CommonDeclarationCheckers.kt
@@ -27,6 +27,7 @@ object CommonDeclarationCheckers : DeclarationCheckers() {
     )
 
     override val functionCheckers: Set<FirFunctionChecker> = setOf(
+        FirContractChecker,
         FirFunctionNameChecker,
     )
 

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/providers/impl/FirTypeResolverImpl.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/providers/impl/FirTypeResolverImpl.kt
@@ -181,7 +181,7 @@ class FirTypeResolverImpl(private val session: FirSession) : FirTypeResolver() {
             }
             is FirFunctionTypeRef -> createFunctionalType(typeRef)
             is FirDynamicTypeRef -> ConeKotlinErrorType(ConeIntermediateDiagnostic("Not supported: ${typeRef::class.simpleName}"))
-            else -> error("!")
+            else -> error(typeRef.render())
         }
     }
 }

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/contracts/ConeEffectExtractor.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/contracts/ConeEffectExtractor.kt
@@ -109,6 +109,13 @@ class ConeEffectExtractor(
         return ConeIsNullPredicate(arg, isNegated)
     }
 
+    override fun visitExpressionWithSmartcast(
+        expressionWithSmartcast: FirExpressionWithSmartcast,
+        data: Nothing?
+    ): ConeContractDescriptionElement? {
+        return expressionWithSmartcast.originalExpression.accept(this, data)
+    }
+
     override fun visitQualifiedAccessExpression(
         qualifiedAccessExpression: FirQualifiedAccessExpression,
         data: Nothing?

--- a/compiler/testData/diagnostics/testsWithStdLib/contracts/dsl/errors/accessToOuterThis.fir.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/contracts/dsl/errors/accessToOuterThis.fir.kt
@@ -10,19 +10,19 @@ class Foo {
     inner class Bar {
         fun good() {
             contract {
-                returns() implies (<!UNRESOLVED_LABEL!>this@Bar<!> != null)
+                <!ERROR_IN_CONTRACT_DESCRIPTION!>returns() implies (<!UNRESOLVED_LABEL!>this@Bar<!> != null)<!>
             }
         }
 
         fun badOuter() {
             contract {
-                returns() implies (<!UNRESOLVED_LABEL!>this@Foo<!> != null)
+                <!ERROR_IN_CONTRACT_DESCRIPTION!>returns() implies (<!UNRESOLVED_LABEL!>this@Foo<!> != null)<!>
             }
         }
 
         fun badInner() {
             contract {
-                returns() implies (this != null)
+                <!ERROR_IN_CONTRACT_DESCRIPTION!>returns() implies (this != null)<!>
             }
         }
 
@@ -34,7 +34,7 @@ class Foo {
 
         fun A?.badWithReceiver() {
             contract {
-                returns() implies (<!UNRESOLVED_LABEL!>this@Bar<!> != null)
+                <!ERROR_IN_CONTRACT_DESCRIPTION!>returns() implies (<!UNRESOLVED_LABEL!>this@Bar<!> != null)<!>
             }
         }
     }

--- a/compiler/testData/diagnostics/testsWithStdLib/contracts/dsl/errors/booleanComparisons.fir.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/contracts/dsl/errors/booleanComparisons.fir.kt
@@ -7,7 +7,7 @@ import kotlin.contracts.*
 fun foo(b: Boolean): Boolean {
     contract {
         // pointless, can be reduced to just "b"
-        returns(true) implies (b == true)
+        <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(true) implies (b == true)<!>
     }
 
     return b
@@ -16,7 +16,7 @@ fun foo(b: Boolean): Boolean {
 fun bar(b: Boolean?): Boolean {
     contract {
         // not pointless, but not supported yet
-        returns(true) implies (b == true)
+        <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(true) implies (b == true)<!>
     }
     if (b == null) throw java.lang.IllegalArgumentException("")
     return b

--- a/compiler/testData/diagnostics/testsWithStdLib/contracts/dsl/errors/callInContractDescription.fir.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/contracts/dsl/errors/callInContractDescription.fir.kt
@@ -8,7 +8,7 @@ fun bar(x: Int): Boolean = x == 0
 
 fun foo(x: Int): Boolean {
     contract {
-        returns(true) implies (bar(x))
+        <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(true) implies (bar(x))<!>
     }
     return x == 0
 }

--- a/compiler/testData/diagnostics/testsWithStdLib/contracts/dsl/errors/illegalConstructionInContractBlock.fir.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/contracts/dsl/errors/illegalConstructionInContractBlock.fir.kt
@@ -6,26 +6,26 @@ import kotlin.contracts.*
 
 fun ifInContract(x: Any?, boolean: Boolean) {
     contract {
-        if (boolean) {
+        <!ERROR_IN_CONTRACT_DESCRIPTION!>if (boolean) {
             returns() implies (x is String)
         } else {
             returns() implies (x is Int)
-        }
+        }<!>
     }
 }
 
 fun whenInContract(x: Any?, boolean: Boolean) {
     contract {
-        when (boolean) {
+        <!ERROR_IN_CONTRACT_DESCRIPTION!>when (boolean) {
             true -> returns() implies (x is String)
             else -> returns() implies (x is Int)
-        }
+        }<!>
     }
 }
 
 fun forInContract(x: Any?) {
     contract {
-        <!UNRESOLVED_REFERENCE!>for (i in 0..1) {
+        <!ERROR_IN_CONTRACT_DESCRIPTION, UNRESOLVED_REFERENCE!>for (i in 0..1) {
             returns() implies (x is String)
         }<!>
     }
@@ -33,23 +33,23 @@ fun forInContract(x: Any?) {
 
 fun whileInContract(x: Any?) {
     contract {
-        while (false) {
+        <!ERROR_IN_CONTRACT_DESCRIPTION!>while (false) {
             returns() implies (x is String)
-        }
+        }<!>
     }
 }
 
 fun doWhileInContract(x: Any?) {
     contract {
-        do {
+        <!ERROR_IN_CONTRACT_DESCRIPTION!>do {
             returns() implies (x is String)
-        } while (false)
+        } while (false)<!>
     }
 }
 
 fun localValInContract(x: Any?) {
     <!WRONG_IMPLIES_CONDITION!>contract {
-        val y: Int = 42
+        <!ERROR_IN_CONTRACT_DESCRIPTION!>val y: Int = 42<!>
         returns() implies (x is String)
     }<!>
 }

--- a/compiler/testData/diagnostics/testsWithStdLib/contracts/dsl/errors/illegalEqualsCondition.fir.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/contracts/dsl/errors/illegalEqualsCondition.fir.kt
@@ -6,25 +6,25 @@ import kotlin.contracts.*
 
 fun equalsWithVariables(x: Any?, y: Any?) {
     contract {
-        returns() implies (x == y)
+        <!ERROR_IN_CONTRACT_DESCRIPTION!>returns() implies (x == y)<!>
     }
 }
 
 fun identityEqualsWithVariables(x: Any?, y: Any?) {
     contract {
-        returns() implies (x === y)
+        <!ERROR_IN_CONTRACT_DESCRIPTION!>returns() implies (x === y)<!>
     }
 }
 
 fun equalConstants() {
     contract {
-        returns() implies (null == null)
+        <!ERROR_IN_CONTRACT_DESCRIPTION!>returns() implies (null == null)<!>
     }
 }
 
 fun get(): Int? = null
 fun equalNullWithCall() {
     contract {
-        returns() implies (get() == null)
+        <!ERROR_IN_CONTRACT_DESCRIPTION!>returns() implies (get() == null)<!>
     }
 }

--- a/compiler/testData/diagnostics/testsWithStdLib/contracts/dsl/errors/nestedConditionalEffects.fir.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/contracts/dsl/errors/nestedConditionalEffects.fir.kt
@@ -6,6 +6,6 @@ import kotlin.contracts.*
 
 fun foo(boolean: Boolean) {
     contract {
-        (returns() implies (boolean)) <!UNRESOLVED_REFERENCE!>implies<!> (!boolean)
+        <!ERROR_IN_CONTRACT_DESCRIPTION!>(returns() implies (boolean)) <!UNRESOLVED_REFERENCE!>implies<!> (!boolean)<!>
     }
 }

--- a/compiler/testData/diagnostics/testsWithStdLib/contracts/dsl/errors/recursiveContract.fir.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/contracts/dsl/errors/recursiveContract.fir.kt
@@ -5,21 +5,21 @@
 import kotlin.contracts.*
 
 fun case_1(): Boolean {
-    contract { returns(null) implies case_1() }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(null) implies case_1()<!> }
     return true
 }
 
 fun case_2(): Boolean {
-    contract { returns(null) implies case_3() }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(null) implies case_3()<!> }
     return true
 }
 
 fun case_3(): Boolean {
-    contract { returns(null) implies case_2() }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(null) implies case_2()<!> }
     return true
 }
 
 fun case_4(): Boolean {
-    kotlin.contracts.contract { returns(null) implies case_1() }
+    kotlin.contracts.contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(null) implies case_1()<!> }
     return true
 }

--- a/compiler/testData/diagnostics/testsWithStdLib/contracts/dsl/errors/referenceToProperty.1.3.fir.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/contracts/dsl/errors/referenceToProperty.1.3.fir.kt
@@ -7,7 +7,7 @@ import kotlin.contracts.*
 class Foo(val x: Int?) {
     fun isXNull(): Boolean {
         contract {
-            returns(false) implies (<!UNRESOLVED_REFERENCE!>x<!> != null)
+            <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(false) implies (<!UNRESOLVED_REFERENCE!>x<!> != null)<!>
         }
         return x != null
     }

--- a/compiler/testData/diagnostics/testsWithStdLib/contracts/dsl/errors/referenceToProperty.1.4.fir.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/contracts/dsl/errors/referenceToProperty.1.4.fir.kt
@@ -7,7 +7,7 @@ import kotlin.contracts.*
 class Foo(val x: Int?) {
     fun isXNull(): Boolean {
         contract {
-            returns(false) implies (<!UNRESOLVED_REFERENCE!>x<!> != null)
+            <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(false) implies (<!UNRESOLVED_REFERENCE!>x<!> != null)<!>
         }
         return x != null
     }

--- a/compiler/testData/diagnostics/testsWithStdLib/contracts/dsl/errors/unlabeledReceiver.fir.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/contracts/dsl/errors/unlabeledReceiver.fir.kt
@@ -6,7 +6,7 @@ import kotlin.contracts.*
 
 fun Any?.foo(): Boolean {
     contract {
-        returns(true) implies (this != null)
+        <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(true) implies (this != null)<!>
     }
     return this != null
 }

--- a/compiler/tests-spec/testData/diagnostics/notLinked/contracts/analysis/smartcasts/neg/12.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/contracts/analysis/smartcasts/neg/12.fir.kt
@@ -31,5 +31,5 @@ fun case_1(value_1: Any?) {
 // TESTCASE NUMBER: 2
 fun case_2(value_1: Any?, value_2: Number, value_3: Any?, value_4: String?) {
     value_1.case_2(value_2, value_3, value_4)
-    <!AMBIGUITY!>println<!>(value_1.<!UNRESOLVED_REFERENCE!>toByte<!>())
+    println(value_1.toByte())
 }

--- a/compiler/tests-spec/testData/diagnostics/notLinked/contracts/analysis/smartcasts/pos/11.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/contracts/analysis/smartcasts/pos/11.fir.kt
@@ -51,8 +51,8 @@ class case_3 {
     fun case_3(value_1: Any?, value_2: Number?) {
         val o = case_3()
         contracts.case_3(value_1, value_2, o.prop_1, this.prop_1)
-        <!AMBIGUITY!>println<!>(o.prop_1.<!NONE_APPLICABLE!>plus<!>(3))
-        <!AMBIGUITY!>println<!>(this.prop_1.<!NONE_APPLICABLE!>plus<!>(3))
+        println(o.prop_1.plus(3))
+        println(this.prop_1.plus(3))
     }
 }
 
@@ -62,8 +62,8 @@ class case_4 {
     fun case_4(value_1: Any?, value_2: Number?) {
         val o = case_4()
         if (contracts.case_4(value_1, value_2, o.prop_1, this.prop_1)) {
-            <!AMBIGUITY!>println<!>(o.prop_1.<!NONE_APPLICABLE!>plus<!>(3))
-            <!AMBIGUITY!>println<!>(this.prop_1.<!NONE_APPLICABLE!>plus<!>(3))
+            println(o.prop_1.plus(3))
+            println(this.prop_1.plus(3))
         }
     }
 }

--- a/compiler/tests-spec/testData/diagnostics/notLinked/contracts/analysis/smartcasts/pos/13.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/contracts/analysis/smartcasts/pos/13.fir.kt
@@ -31,5 +31,5 @@ fun case_1(value_1: Any?) {
 // TESTCASE NUMBER: 2
 fun case_2(value_1: Any?, value_2: Number, value_3: Any?, value_4: String?) {
     value_1.case_2(value_2, value_3, value_4)
-    <!AMBIGUITY!>println<!>(value_1.<!UNRESOLVED_REFERENCE!>toByte<!>())
+    println(value_1.toByte())
 }

--- a/compiler/tests-spec/testData/diagnostics/notLinked/contracts/analysis/smartcasts/pos/3.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/contracts/analysis/smartcasts/pos/3.fir.kt
@@ -102,9 +102,9 @@ class case_3_class {
     fun case_3(value_1: Any?, value_2: Number?) {
         val o = case_3_class()
         contracts.case_3(value_1, value_2, o.prop_1, this.prop_1)
-        println(value_1.<!INAPPLICABLE_CANDIDATE!>dec<!>())
+        println(value_1.dec())
         println(value_2?.toByte())
-        <!AMBIGUITY!>println<!>(o.prop_1.<!NONE_APPLICABLE!>plus<!>(3))
+        println(o.prop_1.plus(3))
     }
 }
 
@@ -154,24 +154,24 @@ class case_6_class {
     fun case_6(value_1: Any?, value_2: Number?) {
         val o = case_6_class()
         if (contracts.case_6_1(value_1, value_2, o.prop_1, this.prop_1)) {
-            println(value_1.<!INAPPLICABLE_CANDIDATE!>dec<!>())
+            println(value_1.dec())
             println(value_2?.toByte())
-            <!AMBIGUITY!>println<!>(o.prop_1.<!NONE_APPLICABLE!>plus<!>(3))
+            println(o.prop_1.plus(3))
         }
         if (!contracts.case_6_2(value_1, value_2, o.prop_1, this.prop_1)) {
-            println(value_1.<!INAPPLICABLE_CANDIDATE!>dec<!>())
+            println(value_1.dec())
             println(value_2?.toByte())
-            <!AMBIGUITY!>println<!>(o.prop_1.<!NONE_APPLICABLE!>plus<!>(3))
+            println(o.prop_1.plus(3))
         }
         if (contracts.case_6_3(value_1, value_2, o.prop_1, this.prop_1) != null) {
-            println(value_1.<!INAPPLICABLE_CANDIDATE!>dec<!>())
+            println(value_1.dec())
             println(value_2?.toByte())
-            <!AMBIGUITY!>println<!>(o.prop_1.<!NONE_APPLICABLE!>plus<!>(3))
+            println(o.prop_1.plus(3))
         }
         if (contracts.case_6_4(value_1, value_2, o.prop_1, this.prop_1) == null) {
-            println(value_1.<!INAPPLICABLE_CANDIDATE!>dec<!>())
+            println(value_1.dec())
             println(value_2?.toByte())
-            <!AMBIGUITY!>println<!>(o.prop_1.<!NONE_APPLICABLE!>plus<!>(3))
+            println(o.prop_1.plus(3))
         }
     }
 }

--- a/compiler/tests-spec/testData/diagnostics/notLinked/contracts/analysis/smartcasts/pos/5.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/contracts/analysis/smartcasts/pos/5.fir.kt
@@ -85,41 +85,41 @@ import contracts.*
 // TESTCASE NUMBER: 1
 fun case_1(value_1: Any?) {
     value_1.case_1()
-    <!AMBIGUITY!>println<!>(value_1.<!UNRESOLVED_REFERENCE!>length<!>)
+    println(value_1.length)
 }
 
 // TESTCASE NUMBER: 2
 fun case_2(value_1: Number?) {
     value_1.case_2()
-    <!AMBIGUITY!>println<!>(value_1.<!UNRESOLVED_REFERENCE!>inv<!>())
+    println(value_1.inv())
 }
 
 // TESTCASE NUMBER: 3
 fun case_3(value_1: Any?) {
     value_1.case_3()
-    <!AMBIGUITY!>println<!>(value_1.<!UNRESOLVED_REFERENCE!>inv<!>())
+    println(value_1.inv())
 }
 
 // TESTCASE NUMBER: 4
 fun case_4(value_1: Any?, value_2: Any?, value_3: Any?) {
-    when { value_1.case_4_1() -> <!AMBIGUITY!>println<!>(value_1.<!UNRESOLVED_REFERENCE!>length<!>) }
-    when { !value_2.case_4_2() -> <!AMBIGUITY!>println<!>(value_2.<!UNRESOLVED_REFERENCE!>length<!>) }
-    when { value_3.case_4_3() != null -> <!AMBIGUITY!>println<!>(value_3.<!UNRESOLVED_REFERENCE!>length<!>) }
-    when { value_3.case_4_4() == null -> <!AMBIGUITY!>println<!>(value_3.<!UNRESOLVED_REFERENCE!>length<!>) }
+    when { value_1.case_4_1() -> println(value_1.length) }
+    when { !value_2.case_4_2() -> println(value_2.length) }
+    when { value_3.case_4_3() != null -> println(value_3.length) }
+    when { value_3.case_4_4() == null -> println(value_3.length) }
 }
 
 // TESTCASE NUMBER: 5
 fun case_5(value_1: Number?, value_2: Number?, value_3: Number?) {
-    if (value_1.case_5_1()) <!AMBIGUITY!>println<!>(value_1.<!UNRESOLVED_REFERENCE!>inv<!>())
-    if (!value_2.case_5_2()) <!AMBIGUITY!>println<!>(value_2.<!UNRESOLVED_REFERENCE!>inv<!>())
-    if (value_3.case_5_3() != null) <!AMBIGUITY!>println<!>(value_3.<!UNRESOLVED_REFERENCE!>inv<!>())
-    if (value_3.case_5_4() == null) <!AMBIGUITY!>println<!>(value_3.<!UNRESOLVED_REFERENCE!>inv<!>())
+    if (value_1.case_5_1()) println(value_1.inv())
+    if (!value_2.case_5_2()) println(value_2.inv())
+    if (value_3.case_5_3() != null) println(value_3.inv())
+    if (value_3.case_5_4() == null) println(value_3.inv())
 }
 
 // TESTCASE NUMBER: 6
 fun case_6(value_1: Any?, value_2: Any?, value_3: Any?) {
-    if (value_1.case_6_1()) <!AMBIGUITY!>println<!>(value_1.<!UNRESOLVED_REFERENCE!>inv<!>())
-    if (!value_2.case_6_2()) <!AMBIGUITY!>println<!>(value_2.<!UNRESOLVED_REFERENCE!>inv<!>())
-    if (value_3.case_6_3() != null) <!AMBIGUITY!>println<!>(value_3.<!UNRESOLVED_REFERENCE!>inv<!>())
-    if (value_3.case_6_4() == null) <!AMBIGUITY!>println<!>(value_3.<!UNRESOLVED_REFERENCE!>inv<!>())
+    if (value_1.case_6_1()) println(value_1.inv())
+    if (!value_2.case_6_2()) println(value_2.inv())
+    if (value_3.case_6_3() != null) println(value_3.inv())
+    if (value_3.case_6_4() == null) println(value_3.inv())
 }

--- a/compiler/tests-spec/testData/diagnostics/notLinked/contracts/analysis/smartcasts/pos/6.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/contracts/analysis/smartcasts/pos/6.fir.kt
@@ -109,56 +109,56 @@ import contracts.*
 // TESTCASE NUMBER: 1
 fun case_1(value_1: Any?, value_2: Int?) {
     value_1.case_1(value_2)
-    <!AMBIGUITY!>println<!>(value_1.<!UNRESOLVED_REFERENCE!>length<!>)
-    println(value_2<!UNSAFE_CALL!>.<!>inv())
+    println(value_1.length)
+    println(value_2.inv())
 }
 
 // TESTCASE NUMBER: 2
 fun case_2(value_1: Number?, value_2: Any?) {
     value_1.case_2(value_2)
-    <!AMBIGUITY!>println<!>(value_1.<!UNRESOLVED_REFERENCE!>inv<!>())
-    <!AMBIGUITY!>println<!>(value_2.<!UNRESOLVED_REFERENCE!>toByte<!>())
+    println(value_1.inv())
+    println(value_2.toByte())
 }
 
 // TESTCASE NUMBER: 3
 fun case_3(value_1: Any?, value_2: String?) {
     value_1.case_3(value_2)
-    <!AMBIGUITY!>println<!>(value_1.<!UNRESOLVED_REFERENCE!>inv<!>())
-    println(value_2<!UNSAFE_CALL!>.<!>length)
+    println(value_1.inv())
+    println(value_2.length)
 }
 
 // TESTCASE NUMBER: 4
 fun case_4(value_1: Any?, value_2: Number, value_3: Any?, value_4: String?) {
     value_1.case_4(value_2, value_3, value_4)
-    <!AMBIGUITY!>println<!>(value_2.<!UNRESOLVED_REFERENCE!>inv<!>())
-    <!AMBIGUITY!>println<!>(value_3.<!UNRESOLVED_REFERENCE!>toByte<!>())
-    println(value_4<!UNSAFE_CALL!>.<!>length)
+    println(value_2.inv())
+    println(value_3.toByte())
+    println(value_4.length)
 }
 
 // TESTCASE NUMBER: 5
 fun case_5(value_1: Any?, value_2: Int?, value_3: Any?, value_4: Int?, value_5: Any?, value_6: Int?) {
     when {
         value_1.case_5_1(value_2) -> {
-            <!AMBIGUITY!>println<!>(value_1.<!UNRESOLVED_REFERENCE!>length<!>)
-            println(value_2<!UNSAFE_CALL!>.<!>inv())
+            println(value_1.length)
+            println(value_2.inv())
         }
     }
     when {
         !value_3.case_5_2(value_4) -> {
-            <!AMBIGUITY!>println<!>(value_3.<!UNRESOLVED_REFERENCE!>length<!>)
-            println(value_4<!UNSAFE_CALL!>.<!>inv())
+            println(value_3.length)
+            println(value_4.inv())
         }
     }
     when {
         value_5.case_5_3(value_6) != null -> {
-            <!AMBIGUITY!>println<!>(value_5.<!UNRESOLVED_REFERENCE!>length<!>)
-            println(value_6<!UNSAFE_CALL!>.<!>inv())
+            println(value_5.length)
+            println(value_6.inv())
         }
     }
     when {
         value_5.case_5_4(value_6) == null -> {
-            <!AMBIGUITY!>println<!>(value_5.<!UNRESOLVED_REFERENCE!>length<!>)
-            println(value_6<!UNSAFE_CALL!>.<!>inv())
+            println(value_5.length)
+            println(value_6.inv())
         }
     }
 }
@@ -166,55 +166,55 @@ fun case_5(value_1: Any?, value_2: Int?, value_3: Any?, value_4: Int?, value_5: 
 // TESTCASE NUMBER: 6
 fun case_6(value_1: Number?, value_2: Any?, value_3: Number?, value_4: Any?, value_5: Number?, value_6: Any?) {
     if (value_1.case_6_1(value_2)) {
-        <!AMBIGUITY!>println<!>(value_1.<!UNRESOLVED_REFERENCE!>inv<!>())
-        <!AMBIGUITY!>println<!>(value_2.<!UNRESOLVED_REFERENCE!>toByte<!>())
+        println(value_1.inv())
+        println(value_2.toByte())
     }
     if (!value_3.case_6_2(value_4)) {
-        <!AMBIGUITY!>println<!>(value_3.<!UNRESOLVED_REFERENCE!>inv<!>())
-        <!AMBIGUITY!>println<!>(value_4.<!UNRESOLVED_REFERENCE!>toByte<!>())
+        println(value_3.inv())
+        println(value_4.toByte())
     }
     if (value_5.case_6_3(value_6) != null) {
-        <!AMBIGUITY!>println<!>(value_5.<!UNRESOLVED_REFERENCE!>inv<!>())
-        <!AMBIGUITY!>println<!>(value_6.<!UNRESOLVED_REFERENCE!>toByte<!>())
+        println(value_5.inv())
+        println(value_6.toByte())
     }
     if (value_5.case_6_4(value_6) == null) {
-        <!AMBIGUITY!>println<!>(value_5.<!UNRESOLVED_REFERENCE!>inv<!>())
-        <!AMBIGUITY!>println<!>(value_6.<!UNRESOLVED_REFERENCE!>toByte<!>())
+        println(value_5.inv())
+        println(value_6.toByte())
     }
 }
 
 // TESTCASE NUMBER: 7
 fun case_7(value_1: Any?, value_2: String?, value_3: Any?, value_4: String?, value_5: Any?, value_6: String?) {
     if (value_1.case_7_1(value_2)) {
-        <!AMBIGUITY!>println<!>(value_1.<!UNRESOLVED_REFERENCE!>inv<!>())
-        println(value_2<!UNSAFE_CALL!>.<!>length)
+        println(value_1.inv())
+        println(value_2.length)
     }
     if (value_3.case_7_2(value_4)) {
-        <!AMBIGUITY!>println<!>(value_3.<!UNRESOLVED_REFERENCE!>inv<!>())
-        println(value_4<!UNSAFE_CALL!>.<!>length)
+        println(value_3.inv())
+        println(value_4.length)
     }
     if (value_5.case_7_3(value_6) != null) {
-        <!AMBIGUITY!>println<!>(value_5.<!UNRESOLVED_REFERENCE!>inv<!>())
-        println(value_6<!UNSAFE_CALL!>.<!>length)
+        println(value_5.inv())
+        println(value_6.length)
     }
     if (value_5.case_7_4(value_6) == null) {
-        <!AMBIGUITY!>println<!>(value_5.<!UNRESOLVED_REFERENCE!>inv<!>())
-        println(value_6<!UNSAFE_CALL!>.<!>length)
+        println(value_5.inv())
+        println(value_6.length)
     }
 }
 
 // TESTCASE NUMBER: 8
 fun case_8(value_1: Any?, value_2: Number, value_3: Any?, value_4: String?, value_5: Any?, value_6: Number, value_7: Any?, value_8: String?) {
-    when { value_1.case_8_1(value_2, value_3, value_4) -> <!AMBIGUITY!>println<!>(value_2.<!UNRESOLVED_REFERENCE!>inv<!>()) }
-    when { value_1.case_8_1(value_2, value_3, value_4) -> <!AMBIGUITY!>println<!>(value_3.<!UNRESOLVED_REFERENCE!>toByte<!>()) }
-    when { value_1.case_8_1(value_2, value_3, value_4) -> println(value_4<!UNSAFE_CALL!>.<!>length) }
-    when { !value_5.case_8_2(value_6, value_7, value_8) -> <!AMBIGUITY!>println<!>(value_6.<!UNRESOLVED_REFERENCE!>inv<!>()) }
-    when { !value_5.case_8_2(value_6, value_7, value_8) -> <!AMBIGUITY!>println<!>(value_7.<!UNRESOLVED_REFERENCE!>toByte<!>()) }
-    when { !value_5.case_8_2(value_6, value_7, value_8) -> println(value_8<!UNSAFE_CALL!>.<!>length) }
-    when { value_5.case_8_3(value_6, value_7, value_8) != null -> <!AMBIGUITY!>println<!>(value_6.<!UNRESOLVED_REFERENCE!>inv<!>()) }
-    when { value_5.case_8_3(value_6, value_7, value_8) != null -> <!AMBIGUITY!>println<!>(value_7.<!UNRESOLVED_REFERENCE!>toByte<!>()) }
-    when { value_5.case_8_3(value_6, value_7, value_8) != null -> println(value_8<!UNSAFE_CALL!>.<!>length) }
-    when { value_5.case_8_4(value_6, value_7, value_8) == null -> <!AMBIGUITY!>println<!>(value_6.<!UNRESOLVED_REFERENCE!>inv<!>()) }
-    when { value_5.case_8_4(value_6, value_7, value_8) == null -> <!AMBIGUITY!>println<!>(value_7.<!UNRESOLVED_REFERENCE!>toByte<!>()) }
-    when { value_5.case_8_4(value_6, value_7, value_8) == null -> println(value_8<!UNSAFE_CALL!>.<!>length) }
+    when { value_1.case_8_1(value_2, value_3, value_4) -> println(value_2.inv()) }
+    when { value_1.case_8_1(value_2, value_3, value_4) -> println(value_3.toByte()) }
+    when { value_1.case_8_1(value_2, value_3, value_4) -> println(value_4.length) }
+    when { !value_5.case_8_2(value_6, value_7, value_8) -> println(value_6.inv()) }
+    when { !value_5.case_8_2(value_6, value_7, value_8) -> println(value_7.toByte()) }
+    when { !value_5.case_8_2(value_6, value_7, value_8) -> println(value_8.length) }
+    when { value_5.case_8_3(value_6, value_7, value_8) != null -> println(value_6.inv()) }
+    when { value_5.case_8_3(value_6, value_7, value_8) != null -> println(value_7.toByte()) }
+    when { value_5.case_8_3(value_6, value_7, value_8) != null -> println(value_8.length) }
+    when { value_5.case_8_4(value_6, value_7, value_8) == null -> println(value_6.inv()) }
+    when { value_5.case_8_4(value_6, value_7, value_8) == null -> println(value_7.toByte()) }
+    when { value_5.case_8_4(value_6, value_7, value_8) == null -> println(value_8.length) }
 }

--- a/compiler/tests-spec/testData/diagnostics/notLinked/contracts/declarations/contractBuilder/common/neg/12.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/contracts/declarations/contractBuilder/common/neg/12.fir.kt
@@ -26,7 +26,7 @@ inline fun case_1(block: () -> Unit) {
 
 // TESTCASE NUMBER: 2
 inline fun case_2(block: () -> Unit) {
-    contract { callsInPlaceEffectBuilder(block) }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>callsInPlaceEffectBuilder(block)<!> }
     return block()
 }
 

--- a/compiler/tests-spec/testData/diagnostics/notLinked/contracts/declarations/contractBuilder/common/neg/13.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/contracts/declarations/contractBuilder/common/neg/13.fir.kt
@@ -5,6 +5,6 @@ import kotlin.contracts.*
 
 // TESTCASE NUMBER: 1
 fun case_1(value_1: Any?, block: () -> Unit) {
-    contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) <!UNRESOLVED_REFERENCE!>implies<!> (value_1 != null) }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>callsInPlace(block, InvocationKind.EXACTLY_ONCE) <!UNRESOLVED_REFERENCE!>implies<!> (value_1 != null)<!> }
     if (value_1 != null) block()
 }

--- a/compiler/tests-spec/testData/diagnostics/notLinked/contracts/declarations/contractBuilder/common/neg/17.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/contracts/declarations/contractBuilder/common/neg/17.fir.kt
@@ -5,7 +5,7 @@ import kotlin.contracts.*
 
 // TESTCASE NUMBER: 1
 fun case_1(): Boolean {
-    contract { returns(null) implies throw Exception() }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(null) implies throw Exception()<!> }
     return true
 }
 
@@ -17,6 +17,6 @@ fun case_2(): Boolean {
 
 // TESTCASE NUMBER: 3
 fun case_3(): Boolean {
-    contract { returns(null) implies return return return false && throw throw throw throw Exception() }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(null) implies return return return false && throw throw throw throw Exception()<!> }
     return true
 }

--- a/compiler/tests-spec/testData/diagnostics/notLinked/contracts/declarations/contractBuilder/common/neg/2.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/contracts/declarations/contractBuilder/common/neg/2.fir.kt
@@ -5,24 +5,24 @@ import kotlin.contracts.*
 
 // TESTCASE NUMBER: 1
 fun case_1(value_1: Boolean): Boolean {
-    contract { returns(true) implies (value_1 == true) }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(true) implies (value_1 == true)<!> }
     return value_1 == true
 }
 
 // TESTCASE NUMBER: 2
 fun case_2(value_1: Boolean): Boolean? {
-    contract { returnsNotNull() implies (value_1 != false) }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returnsNotNull() implies (value_1 != false)<!> }
     return if (value_1 != false) true else null
 }
 
 // TESTCASE NUMBER: 3
 fun case_3(value_1: String): Boolean {
-    contract { returns(false) implies (value_1 != "") }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(false) implies (value_1 != "")<!> }
     return !(value_1 != "")
 }
 
 // TESTCASE NUMBER: 4
 fun case_4(value_1: Int): Boolean? {
-    contract { returns(null) implies (value_1 == 0) }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(null) implies (value_1 == 0)<!> }
     return if (value_1 == 0) null else true
 }

--- a/compiler/tests-spec/testData/diagnostics/notLinked/contracts/declarations/contractBuilder/common/neg/3.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/contracts/declarations/contractBuilder/common/neg/3.fir.kt
@@ -5,36 +5,36 @@ import kotlin.contracts.*
 
 // TESTCASE NUMBER: 1
 fun case_1(value_1: Boolean?): Boolean {
-    contract { returns(true) implies (value_1 != null && value_1 == false) }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(true) implies (value_1 != null && value_1 == false)<!> }
     return value_1 != null && value_1 == false
 }
 
 // TESTCASE NUMBER: 2
 fun case_2(value_1: Boolean, value_2: Boolean): Boolean? {
-    contract { returnsNotNull() implies (value_1 != false || value_2) }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returnsNotNull() implies (value_1 != false || value_2)<!> }
     return if (value_1 != false || value_2) true else null
 }
 
 // TESTCASE NUMBER: 3
 fun case_3(value_1: String?, value_2: Boolean): Boolean {
-    contract { returns(false) implies (value_1 != null && value_2 != true) }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(false) implies (value_1 != null && value_2 != true)<!> }
     return !(value_1 != null && value_2 != true)
 }
 
 // TESTCASE NUMBER: 4
 fun case_4(value_1: Nothing?, value_2: Boolean?): Boolean? {
-    contract { returns(null) implies (value_1 == null || value_2 != null || value_2 == false) }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(null) implies (value_1 == null || value_2 != null || value_2 == false)<!> }
     return if (value_1 == null || value_2 != null || value_2 == false) null else true
 }
 
 // TESTCASE NUMBER: 5
 fun case_5(value_1: Any?, value_2: String?): Boolean? {
-    contract { returns(null) implies (value_1 != null && value_2 != null || value_2 == ".") }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(null) implies (value_1 != null && value_2 != null || value_2 == ".")<!> }
     return if (value_1 != null && value_2 != null || value_2 == ".") null else true
 }
 
 // TESTCASE NUMBER: 6
 fun case_6(value_1: Boolean, value_2: Int?): Boolean? {
-    contract { returns(null) implies (value_2 == null && value_1 || value_2 == 0) }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(null) implies (value_2 == null && value_1 || value_2 == 0)<!> }
     return if (value_2 == null && value_1 || value_2 == 0) null else true
 }

--- a/compiler/tests-spec/testData/diagnostics/notLinked/contracts/declarations/contractBuilder/common/neg/4.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/contracts/declarations/contractBuilder/common/neg/4.fir.kt
@@ -6,18 +6,18 @@ import kotlin.contracts.*
 
 // TESTCASE NUMBER: 1
 fun case_1(): Boolean? {
-    contract { returnsNotNull() <!INAPPLICABLE_CANDIDATE!>implies<!> (null) }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returnsNotNull() <!INAPPLICABLE_CANDIDATE!>implies<!> (null)<!> }
     return true
 }
 
 // TESTCASE NUMBER: 2
 fun case_2(): Boolean {
-    contract { returns(false) <!INAPPLICABLE_CANDIDATE!>implies<!> 0.000001 }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(false) <!INAPPLICABLE_CANDIDATE!>implies<!> 0.000001<!> }
     return true
 }
 
 // TESTCASE NUMBER: 3
 fun case_3(): Boolean? {
-    contract { returns(null) <!INAPPLICABLE_CANDIDATE!>implies<!> "" }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(null) <!INAPPLICABLE_CANDIDATE!>implies<!> ""<!> }
     return null
 }

--- a/compiler/tests-spec/testData/diagnostics/notLinked/contracts/declarations/contractBuilder/common/neg/5.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/contracts/declarations/contractBuilder/common/neg/5.fir.kt
@@ -6,7 +6,7 @@ import kotlin.contracts.*
 
 // TESTCASE NUMBER: 1
 fun case_1(): Boolean {
-    contract { returns(true) <!INAPPLICABLE_CANDIDATE!>implies<!> (-10) }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(true) <!INAPPLICABLE_CANDIDATE!>implies<!> (-10)<!> }
     return true
 }
 
@@ -18,7 +18,7 @@ fun case_2(): Boolean {
 
 // TESTCASE NUMBER: 3
 fun case_3(): Boolean {
-    contract { returns(false) <!INAPPLICABLE_CANDIDATE!>implies<!> ("..." + "$<!UNRESOLVED_REFERENCE!>value_1<!>") }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(false) <!INAPPLICABLE_CANDIDATE!>implies<!> ("..." + "$<!UNRESOLVED_REFERENCE!>value_1<!>")<!> }
     return true
 }
 
@@ -27,26 +27,26 @@ fun case_3(): Boolean {
  * ISSUES: KT-26386
  */
 fun case_4(): Boolean? {
-    contract { returns(null) <!INAPPLICABLE_CANDIDATE!>implies<!> case_4() }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(null) <!INAPPLICABLE_CANDIDATE!>implies<!> case_4()<!> }
     return null
 }
 
 // TESTCASE NUMBER: 5
 fun case_5(): Boolean? {
-    contract { returns(null) <!INAPPLICABLE_CANDIDATE!>implies<!> listOf(0) }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(null) <!INAPPLICABLE_CANDIDATE!>implies<!> listOf(0)<!> }
     return null
 }
 
 // TESTCASE NUMBER: 6
 fun case_6(value_1: Boolean): Boolean? {
-    contract { returns(null) <!INAPPLICABLE_CANDIDATE!>implies<!> contract { returns(null) implies (!value_1) } }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(null) <!INAPPLICABLE_CANDIDATE!>implies<!> contract { returns(null) implies (!value_1) }<!> }
     return null
 }
 
 // TESTCASE NUMBER: 7
 fun case_7(): Int {
     contract {
-        callsInPlace(::case_7, InvocationKind.EXACTLY_ONCE)
+        <!ERROR_IN_CONTRACT_DESCRIPTION!>callsInPlace(::case_7, InvocationKind.EXACTLY_ONCE)<!>
     }
     return 1
 }
@@ -57,7 +57,7 @@ fun case_7(): Int {
  */
 fun case_8(): () -> Unit {
     contract {
-        callsInPlace(case_8(), InvocationKind.EXACTLY_ONCE)
+        <!ERROR_IN_CONTRACT_DESCRIPTION!>callsInPlace(case_8(), InvocationKind.EXACTLY_ONCE)<!>
     }
     return {}
 }

--- a/compiler/tests-spec/testData/diagnostics/notLinked/contracts/declarations/contractBuilder/common/neg/6.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/contracts/declarations/contractBuilder/common/neg/6.fir.kt
@@ -11,16 +11,16 @@ object case_1 {
     private const val value_3 = false
 
     fun case_1_1(): Boolean? {
-        contract { returnsNotNull() implies (<!UNRESOLVED_REFERENCE!>value_1<!>) }
+        contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returnsNotNull() implies (<!UNRESOLVED_REFERENCE!>value_1<!>)<!> }
         return if (value_1) true else null
     }
     fun case_1_2(): Boolean? {
-        contract { returns(null) implies (<!UNRESOLVED_REFERENCE!>value_2<!>) }
+        contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(null) implies (<!UNRESOLVED_REFERENCE!>value_2<!>)<!> }
         return if (value_2) null else true
     }
 
     fun case_1_3(): Boolean {
-        contract { returns(true) implies (<!UNRESOLVED_REFERENCE!>value_3<!>) }
+        contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(true) implies (<!UNRESOLVED_REFERENCE!>value_3<!>)<!> }
         return value_3
     }
 }
@@ -42,22 +42,22 @@ class case_2(value_5: Boolean, val value_1: Boolean) {
     }
 
     fun case_2_2(): Boolean? {
-        contract { returns(null) implies (<!UNRESOLVED_REFERENCE!>value_1<!>) }
+        contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(null) implies (<!UNRESOLVED_REFERENCE!>value_1<!>)<!> }
         return if (value_1) null else true
     }
 
     fun case_2_3(): Boolean {
-        contract { returns(true) implies (<!UNRESOLVED_REFERENCE!>value_2<!>) }
+        contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(true) implies (<!UNRESOLVED_REFERENCE!>value_2<!>)<!> }
         return value_2
     }
 
     fun case_2_4(): Boolean {
-        contract { returns(false) implies (<!UNRESOLVED_REFERENCE!>value_3<!>) }
+        contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(false) implies (<!UNRESOLVED_REFERENCE!>value_3<!>)<!> }
         return !(value_3)
     }
 
     inline fun <reified K : Number> K.case_2_5(): Boolean? {
-        contract { returnsNotNull() implies (<!UNRESOLVED_REFERENCE!>value_4<!>) }
+        contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returnsNotNull() implies (<!UNRESOLVED_REFERENCE!>value_4<!>)<!> }
         return if (value_4) true else null
     }
 }

--- a/compiler/tests-spec/testData/diagnostics/notLinked/contracts/declarations/contractBuilder/effects/common/neg/1.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/contracts/declarations/contractBuilder/effects/common/neg/1.fir.kt
@@ -6,7 +6,7 @@ import kotlin.contracts.*
 // TESTCASE NUMBER: 1
 inline fun case_1(block: () -> Unit) {
     contract {
-        { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }()
+        <!ERROR_IN_CONTRACT_DESCRIPTION!>{ callsInPlace(block, InvocationKind.EXACTLY_ONCE) }()<!>
     }
     return block()
 }
@@ -14,7 +14,7 @@ inline fun case_1(block: () -> Unit) {
 // TESTCASE NUMBER: 2
 fun case_2(x: Any?): Boolean {
     contract {
-         returns(true).apply { implies (x is Number) } // 'Returns' as result
+         returns(true).<!ERROR_IN_CONTRACT_DESCRIPTION!>apply { implies (x is Number) }<!> // 'Returns' as result
     }
     return x is Number
 }
@@ -22,7 +22,7 @@ fun case_2(x: Any?): Boolean {
 // TESTCASE NUMBER: 3
 fun case_3(x: Any?): Boolean {
     contract {
-         returns(true).also { it implies (x is Number) } // 'Returns' as result
+         returns(true).<!ERROR_IN_CONTRACT_DESCRIPTION!>also { it implies (x is Number) }<!> // 'Returns' as result
     }
     return x is Number
 }
@@ -30,7 +30,7 @@ fun case_3(x: Any?): Boolean {
 // TESTCASE NUMBER: 4
 fun case_4(x: Any?): Boolean {
     contract {
-         returns(true).let { it implies (x is Number) } // 'ConditionalEffect' as result
+         returns(true).<!ERROR_IN_CONTRACT_DESCRIPTION!>let { it implies (x is Number) }<!> // 'ConditionalEffect' as result
     }
     return x is Number
 }
@@ -38,7 +38,7 @@ fun case_4(x: Any?): Boolean {
 // TESTCASE NUMBER: 5
 fun case_5(x: Any?): Boolean {
     contract {
-        returns(true).run { implies (x is Number) } // 'ConditionalEffect' as result
+        returns(true).<!ERROR_IN_CONTRACT_DESCRIPTION!>run { implies (x is Number) }<!> // 'ConditionalEffect' as result
     }
     return x is Number
 }
@@ -46,7 +46,7 @@ fun case_5(x: Any?): Boolean {
 // TESTCASE NUMBER: 6
 fun case_6(x: Any?): Boolean {
     contract {
-         returns(true).takeIf { it implies (x is Number); false } // null, must be unrecognized effect
+         returns(true).<!ERROR_IN_CONTRACT_DESCRIPTION!>takeIf { it implies (x is Number); false }<!> // null, must be unrecognized effect
     }
     return x is Number
 }

--- a/compiler/tests-spec/testData/diagnostics/notLinked/contracts/declarations/contractBuilder/effects/returns/neg/1.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/contracts/declarations/contractBuilder/effects/returns/neg/1.fir.kt
@@ -4,24 +4,24 @@ import kotlin.contracts.*
 
 // TESTCASE NUMBER: 1
 fun case_1(x: Any?): Boolean {
-    contract { returns(true) implies (x == -.15f) }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(true) implies (x == -.15f)<!> }
     return x !is Number
 }
 
 // TESTCASE NUMBER: 2
 fun case_2(x: Any?): Boolean {
-    contract { returns(true) implies (x == "..." + ".") }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(true) implies (x == "..." + ".")<!> }
     return x !is Number
 }
 
 // TESTCASE NUMBER: 3
 fun case_3(x: Int, y: Int): Boolean {
-    contract { returns(true) implies (x > y) }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(true) implies (x > y)<!> }
     return x > y
 }
 
 // TESTCASE NUMBER: 4
 fun case_4(x: Any?, y: Any?): Boolean {
-    contract { returns(true) implies (x == y.toString()) }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(true) implies (x == y.toString())<!> }
     return x !is Number
 }

--- a/compiler/tests-spec/testData/diagnostics/notLinked/contracts/declarations/contractBuilder/effects/returns/neg/2.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/contracts/declarations/contractBuilder/effects/returns/neg/2.fir.kt
@@ -5,7 +5,7 @@ import kotlin.contracts.*
 // TESTCASE NUMBER: 1
 fun Any?.case_1(): Boolean {
     contract {
-        returns(true) implies (this != null)
+        <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(true) implies (this != null)<!>
     }
     return this != null
 }
@@ -13,7 +13,7 @@ fun Any?.case_1(): Boolean {
 // TESTCASE NUMBER: 2
 fun Any?.case_2(): Boolean {
     contract {
-        returnsNotNull() implies (this is Number?)
+        <!ERROR_IN_CONTRACT_DESCRIPTION!>returnsNotNull() implies (this is Number?)<!>
     }
     return this is Number?
 }
@@ -21,7 +21,7 @@ fun Any?.case_2(): Boolean {
 // TESTCASE NUMBER: 3
 fun <T> T?.case_3(): Boolean {
     contract {
-        returnsNotNull() implies (this != null)
+        <!ERROR_IN_CONTRACT_DESCRIPTION!>returnsNotNull() implies (this != null)<!>
     }
     return this != null
 }
@@ -29,7 +29,7 @@ fun <T> T?.case_3(): Boolean {
 // TESTCASE NUMBER: 4
 inline fun <reified T : Number> T.case_4(): Boolean {
     contract {
-        returns(null) implies (this is Int)
+        <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(null) implies (this is Int)<!>
     }
     return this is Int
 }

--- a/compiler/tests-spec/testData/diagnostics/notLinked/contracts/declarations/contractBuilder/effects/returns/neg/3.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/contracts/declarations/contractBuilder/effects/returns/neg/3.fir.kt
@@ -5,7 +5,7 @@ import kotlin.contracts.*
 // TESTCASE NUMBER: 1
 fun case_1(x: Any?): Boolean {
     contract {
-        returns(true) implies (x === EmptyObject) // should be not allowed
+        <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(true) implies (x === EmptyObject)<!> // should be not allowed
     }
     return x === EmptyObject
 }

--- a/compiler/tests-spec/testData/diagnostics/notLinked/contracts/declarations/contractBuilder/effects/returns/neg/4.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/contracts/declarations/contractBuilder/effects/returns/neg/4.fir.kt
@@ -4,18 +4,18 @@ import kotlin.contracts.*
 
 // TESTCASE NUMBER: 1
 fun case_1(x: Any?): Boolean {
-    contract { returns(true) implies (x == .15f) }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(true) implies (x == .15f)<!> }
     return x == .15f
 }
 
 // TESTCASE NUMBER: 2
 fun case_2(x: Any?) {
-    contract { returns() implies (x == "...") }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns() implies (x == "...")<!> }
     if (x != "...") throw Exception()
 }
 
 // TESTCASE NUMBER: 3
 fun case_3(x: Any?): Boolean {
-    contract { returns(true) implies (x == '-') }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(true) implies (x == '-')<!> }
     return x == '-'
 }

--- a/compiler/tests-spec/testData/diagnostics/notLinked/contracts/declarations/contractBuilder/effects/returns/neg/5.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/contracts/declarations/contractBuilder/effects/returns/neg/5.fir.kt
@@ -4,6 +4,6 @@ import kotlin.contracts.*
 
 // TESTCASE NUMBER: 1
 fun <T : Boolean>T.case_1(): Boolean? {
-    contract { returns(null) implies (!this@case_1) }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(null) implies (!this@case_1)<!> }
     return if (!this) null else true
 }

--- a/compiler/tests-spec/testData/diagnostics/notLinked/contracts/declarations/contractBuilder/effects/returns/neg/6.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/contracts/declarations/contractBuilder/effects/returns/neg/6.fir.kt
@@ -4,42 +4,42 @@ import kotlin.contracts.*
 
 // TESTCASE NUMBER: 1
 fun Boolean?.case_1(): Boolean {
-    contract { returns(true) implies (this@case_1 != null && this@case_1) }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(true) implies (this@case_1 != null && this@case_1)<!> }
     return this != null && this
 }
 
 // TESTCASE NUMBER: 2
 fun <T : Boolean>T?.case_2(): Boolean {
-    contract { returns(true) implies (this@case_2 != null && this@case_2 !is Nothing && this@case_2) }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(true) implies (this@case_2 != null && this@case_2 !is Nothing && this@case_2)<!> }
     return this != null && this !is Nothing && this
 }
 
 // TESTCASE NUMBER: 3
 fun <T>T?.case_3() {
-    contract { returns() implies (this@case_3 == null || this@case_3 is Boolean? && !this@case_3) }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns() implies (this@case_3 == null || this@case_3 is Boolean? && !this@case_3)<!> }
     if (!(this == null || this is Boolean? && !this)) throw Exception()
 }
 
 // TESTCASE NUMBER: 4
 fun case_4(value_1: Boolean?): Boolean {
-    contract { returns(true) implies (value_1 != null && !value_1) }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(true) implies (value_1 != null && !value_1)<!> }
     return value_1 != null && !value_1
 }
 
 // TESTCASE NUMBER: 5
 fun Boolean.case_5(value_1: Any?): Boolean? {
-    contract { returnsNotNull() implies (value_1 is Boolean? && value_1 != null && value_1) }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returnsNotNull() implies (value_1 is Boolean? && value_1 != null && value_1)<!> }
     return if (value_1 is Boolean? && value_1 != null && value_1) true else null
 }
 
 // TESTCASE NUMBER: 6
 fun Boolean?.case_6(): Boolean? {
-    contract { returnsNotNull() implies (this@case_6 != null && this@case_6) }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returnsNotNull() implies (this@case_6 != null && this@case_6)<!> }
     return if (this@case_6 != null && this@case_6) true else null
 }
 
 // TESTCASE NUMBER: 7
 fun <T : Boolean?> T.case_7(value_1: Any?): Boolean? {
-    contract { returnsNotNull() implies (value_1 is Boolean? && value_1 != null && value_1 && this@case_7 != null && this@case_7) }
+    contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returnsNotNull() implies (value_1 is Boolean? && value_1 != null && value_1 && this@case_7 != null && this@case_7)<!> }
     return if (value_1 is Boolean? && value_1 != null && value_1 && this@case_7 != null && this@case_7) true else null
 }

--- a/compiler/tests-spec/testData/diagnostics/notLinked/contracts/declarations/contractFunction/neg/2.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/contracts/declarations/contractFunction/neg/2.fir.kt
@@ -32,12 +32,12 @@ fun case_2() {
 class case_4 : ClassLevel3() {
 
     fun <T : Number?>T.case_4_1(): Boolean {
-        contract { returns(false) implies (<!UNRESOLVED_LABEL!>this@case_4<!> !is ClassLevel1) }
+        contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns(false) implies (<!UNRESOLVED_LABEL!>this@case_4<!> !is ClassLevel1)<!> }
         return this == null
     }
 
     fun <T : Boolean>T.case_4_2() {
-        contract { returns() implies (!this@case_4_2) }
+        contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns() implies (!this@case_4_2)<!> }
         if (this) throw Exception()
     }
 
@@ -60,12 +60,12 @@ class case_4 : ClassLevel3() {
 class case_5<T> : ClassLevel5() {
     inner class case_5_1 {
         fun <K : Number?>K.case_5_1_1() {
-            contract { returns() implies (<!UNRESOLVED_LABEL!>this@case_5_1<!> !is ClassLevel1 && <!UNRESOLVED_LABEL!>this@case_5_1<!> != null || <!UNRESOLVED_LABEL!>this@case_5<!> is ClassLevel1 && this@case_5_1_1 is Float) }
+            contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns() implies (<!UNRESOLVED_LABEL!>this@case_5_1<!> !is ClassLevel1 && <!UNRESOLVED_LABEL!>this@case_5_1<!> != null || <!UNRESOLVED_LABEL!>this@case_5<!> is ClassLevel1 && this@case_5_1_1 is Float)<!> }
             if (!(this@case_5_1 !is ClassLevel1 && this@case_5_1 != null || this@case_5 is ClassLevel1 && this is Float)) throw Exception()
         }
 
         fun case_5_1_2() {
-            contract { returns() implies (<!UNRESOLVED_LABEL!>this@case_5_1<!> !is ClassLevel1 || <!UNRESOLVED_LABEL!>this@case_5<!> is ClassLevel1 || <!UNRESOLVED_LABEL!>this@case_5_1<!> == null) }
+            contract { <!ERROR_IN_CONTRACT_DESCRIPTION!>returns() implies (<!UNRESOLVED_LABEL!>this@case_5_1<!> !is ClassLevel1 || <!UNRESOLVED_LABEL!>this@case_5<!> is ClassLevel1 || <!UNRESOLVED_LABEL!>this@case_5_1<!> == null)<!> }
             if (!(this@case_5_1 !is ClassLevel1 || this@case_5 is ClassLevel1 || this@case_5_1 == null)) throw Exception()
         }
     }

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDataClassConverters.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDataClassConverters.kt
@@ -19,6 +19,7 @@ import org.jetbrains.kotlin.fir.psi
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtDestructuringDeclaration
+import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtIfExpression
@@ -1029,6 +1030,13 @@ internal val KT_DIAGNOSTIC_CONVERTER = KtDiagnosticConverterBuilder.buildConvert
     }
     add(FirErrors.INVALID_IF_AS_EXPRESSION) { firDiagnostic ->
         InvalidIfAsExpressionImpl(
+            firDiagnostic as FirPsiDiagnostic<*>,
+            token,
+        )
+    }
+    add(FirErrors.ERROR_IN_CONTRACT_DESCRIPTION) { firDiagnostic ->
+        ErrorInContractDescriptionImpl(
+            firDiagnostic.a,
             firDiagnostic as FirPsiDiagnostic<*>,
             token,
         )

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDataClassConverters.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDataClassConverters.kt
@@ -848,6 +848,24 @@ internal val KT_DIAGNOSTIC_CONVERTER = KtDiagnosticConverterBuilder.buildConvert
             token,
         )
     }
+    add(FirErrors.BACKING_FIELD_IN_INTERFACE) { firDiagnostic ->
+        BackingFieldInInterfaceImpl(
+            firDiagnostic as FirPsiDiagnostic<*>,
+            token,
+        )
+    }
+    add(FirErrors.EXTENSION_PROPERTY_WITH_BACKING_FIELD) { firDiagnostic ->
+        ExtensionPropertyWithBackingFieldImpl(
+            firDiagnostic as FirPsiDiagnostic<*>,
+            token,
+        )
+    }
+    add(FirErrors.PROPERTY_INITIALIZER_NO_BACKING_FIELD) { firDiagnostic ->
+        PropertyInitializerNoBackingFieldImpl(
+            firDiagnostic as FirPsiDiagnostic<*>,
+            token,
+        )
+    }
     add(FirErrors.ABSTRACT_DELEGATED_PROPERTY) { firDiagnostic ->
         AbstractDelegatedPropertyImpl(
             firDiagnostic as FirPsiDiagnostic<*>,

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnostics.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnostics.kt
@@ -21,6 +21,7 @@ import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtDestructuringDeclaration
+import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtIfExpression
@@ -727,6 +728,11 @@ sealed class KtFirDiagnostic<PSI: PsiElement> : KtDiagnosticWithPsi<PSI> {
 
     abstract class InvalidIfAsExpression : KtFirDiagnostic<KtIfExpression>() {
         override val diagnosticClass get() = InvalidIfAsExpression::class
+    }
+
+    abstract class ErrorInContractDescription : KtFirDiagnostic<KtElement>() {
+        override val diagnosticClass get() = ErrorInContractDescription::class
+        abstract val reason: String
     }
 
     abstract class RedundantVisibilityModifier : KtFirDiagnostic<KtModifierListOwner>() {

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnostics.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnostics.kt
@@ -602,6 +602,18 @@ sealed class KtFirDiagnostic<PSI: PsiElement> : KtDiagnosticWithPsi<PSI> {
         override val diagnosticClass get() = PropertyWithNoTypeNoInitializer::class
     }
 
+    abstract class BackingFieldInInterface : KtFirDiagnostic<KtProperty>() {
+        override val diagnosticClass get() = BackingFieldInInterface::class
+    }
+
+    abstract class ExtensionPropertyWithBackingField : KtFirDiagnostic<KtExpression>() {
+        override val diagnosticClass get() = ExtensionPropertyWithBackingField::class
+    }
+
+    abstract class PropertyInitializerNoBackingField : KtFirDiagnostic<KtExpression>() {
+        override val diagnosticClass get() = PropertyInitializerNoBackingField::class
+    }
+
     abstract class AbstractDelegatedProperty : KtFirDiagnostic<KtPropertyDelegate>() {
         override val diagnosticClass get() = AbstractDelegatedProperty::class
     }

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnosticsImpl.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnosticsImpl.kt
@@ -966,6 +966,27 @@ internal class PropertyWithNoTypeNoInitializerImpl(
     override val firDiagnostic: FirPsiDiagnostic<*> by weakRef(firDiagnostic)
 }
 
+internal class BackingFieldInInterfaceImpl(
+    firDiagnostic: FirPsiDiagnostic<*>,
+    override val token: ValidityToken,
+) : KtFirDiagnostic.BackingFieldInInterface(), KtAbstractFirDiagnostic<KtProperty> {
+    override val firDiagnostic: FirPsiDiagnostic<*> by weakRef(firDiagnostic)
+}
+
+internal class ExtensionPropertyWithBackingFieldImpl(
+    firDiagnostic: FirPsiDiagnostic<*>,
+    override val token: ValidityToken,
+) : KtFirDiagnostic.ExtensionPropertyWithBackingField(), KtAbstractFirDiagnostic<KtExpression> {
+    override val firDiagnostic: FirPsiDiagnostic<*> by weakRef(firDiagnostic)
+}
+
+internal class PropertyInitializerNoBackingFieldImpl(
+    firDiagnostic: FirPsiDiagnostic<*>,
+    override val token: ValidityToken,
+) : KtFirDiagnostic.PropertyInitializerNoBackingField(), KtAbstractFirDiagnostic<KtExpression> {
+    override val firDiagnostic: FirPsiDiagnostic<*> by weakRef(firDiagnostic)
+}
+
 internal class AbstractDelegatedPropertyImpl(
     firDiagnostic: FirPsiDiagnostic<*>,
     override val token: ValidityToken,

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnosticsImpl.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnosticsImpl.kt
@@ -23,6 +23,7 @@ import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtDestructuringDeclaration
+import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtIfExpression
@@ -1171,6 +1172,14 @@ internal class InvalidIfAsExpressionImpl(
     firDiagnostic: FirPsiDiagnostic<*>,
     override val token: ValidityToken,
 ) : KtFirDiagnostic.InvalidIfAsExpression(), KtAbstractFirDiagnostic<KtIfExpression> {
+    override val firDiagnostic: FirPsiDiagnostic<*> by weakRef(firDiagnostic)
+}
+
+internal class ErrorInContractDescriptionImpl(
+    override val reason: String,
+    firDiagnostic: FirPsiDiagnostic<*>,
+    override val token: ValidityToken,
+) : KtFirDiagnostic.ErrorInContractDescription(), KtAbstractFirDiagnostic<KtElement> {
     override val firDiagnostic: FirPsiDiagnostic<*> by weakRef(firDiagnostic)
 }
 


### PR DESCRIPTION
The actual motivation was to trace the remaining implicit type ref after resolution, and one of them was local property in `contract`, then I found the prohibited statements in contract block: https://github.com/JetBrains/kotlin/blob/master/compiler/testData/diagnostics/testsWithStdLib/contracts/dsl/errors/illegalConstructionInContractBlock.kt

The new checker simply visits resolved `contract` that is bound to a function, and then checks if some of unresolved effects are due to such prohibition.