### PR TITLE
FIR: ensure type refs at checkers stage are resolved

### DIFF
--- a/compiler/fir/analysis-tests/testData/resolve/diagnostics/superIsNotAnExpression.fir.txt
+++ b/compiler/fir/analysis-tests/testData/resolve/diagnostics/superIsNotAnExpression.fir.txt
@@ -13,8 +13,8 @@ FILE: superIsNotAnExpression.kt
         public final fun act(): R|kotlin/Unit| {
             <Super cannot be a callee>#()
             <Unresolved name: invoke>#()
-            <Super cannot be a callee>#(<L> = <Super cannot be a callee>@fun <implicit>.<anonymous>(): <implicit> {
-                println#(ERROR_EXPR(Incorrect character: 'weird'))
+            <Super cannot be a callee>#(<L> = <Super cannot be a callee>@fun <anonymous>(): R|ERROR CLASS: Unresolved name: println| {
+                ^ <Unresolved name: println>#(ERROR_EXPR(Incorrect character: 'weird'))
             }
             )
         }

--- a/compiler/fir/analysis-tests/testData/resolve/diagnostics/superIsNotAnExpression.kt
+++ b/compiler/fir/analysis-tests/testData/resolve/diagnostics/superIsNotAnExpression.kt
@@ -7,7 +7,7 @@ class B: A() {
         <!UNRESOLVED_REFERENCE{LT}!><!UNRESOLVED_REFERENCE{PSI}!>invoke<!>()<!>
 
         <!SUPER_IS_NOT_AN_EXPRESSION!>super<!> {
-            println(<!ILLEGAL_CONST_EXPRESSION!>'weird'<!>)
+            <!UNRESOLVED_REFERENCE{LT}!><!UNRESOLVED_REFERENCE{PSI}!>println<!>(<!ILLEGAL_CONST_EXPRESSION!>'weird'<!>)<!>
         }
     }
 }

--- a/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsTestGenerated.java
@@ -34694,6 +34694,12 @@ public class FirOldFrontendDiagnosticsTestGenerated extends AbstractFirDiagnosti
             }
 
             @Test
+            @TestMetadata("lambdaArgumentOfInapplicableCall.kt")
+            public void testLambdaArgumentOfInapplicableCall() throws Exception {
+                runTest("compiler/testData/diagnostics/testsWithStdLib/resolve/lambdaArgumentOfInapplicableCall.kt");
+            }
+
+            @Test
             @TestMetadata("samAgainstFunctionalType.kt")
             public void testSamAgainstFunctionalType() throws Exception {
                 runTest("compiler/testData/diagnostics/testsWithStdLib/resolve/samAgainstFunctionalType.kt");

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirConflictingProjectionChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirConflictingProjectionChecker.kt
@@ -23,6 +23,10 @@ object FirConflictingProjectionChecker : FirBasicDeclarationChecker() {
         }
 
         if (declaration is FirTypedDeclaration) {
+            // The body of function contract is not fully resolved.
+            if (declaration.resolvePhase == FirResolvePhase.CONTRACTS) {
+                return
+            }
             checkTypeRef(declaration.returnTypeRef, context, reporter)
         }
 
@@ -44,10 +48,7 @@ object FirConflictingProjectionChecker : FirBasicDeclarationChecker() {
     }
 
     private fun checkTypeRef(typeRef: FirTypeRef, context: CheckerContext, reporter: DiagnosticReporter) {
-        // TODO: remaining implicit types should be resolved as an error type, along with proper error kind,
-        //  e.g., type mismatch, can't infer parameter type, syntax error, etc.
-        val declaration = typeRef.safeAs<FirResolvedTypeRef>()
-            ?.coneTypeSafe<ConeClassLikeType>()
+        val declaration = typeRef.coneTypeSafe<ConeClassLikeType>()
             ?.lookupTag
             ?.toSymbol(context.session)
             ?.fir.safeAs<FirRegularClass>()

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/expression/FirCatchParameterChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/expression/FirCatchParameterChecker.kt
@@ -13,7 +13,7 @@ import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors
 import org.jetbrains.kotlin.fir.analysis.diagnostics.reportOn
 import org.jetbrains.kotlin.fir.expressions.FirTryExpression
 import org.jetbrains.kotlin.fir.types.ConeTypeParameterType
-import org.jetbrains.kotlin.fir.types.FirResolvedTypeRef
+import org.jetbrains.kotlin.fir.types.coneType
 
 object FirCatchParameterChecker : FirTryExpressionChecker() {
     override fun check(expression: FirTryExpression, context: CheckerContext, reporter: DiagnosticReporter) {
@@ -24,11 +24,7 @@ object FirCatchParameterChecker : FirTryExpressionChecker() {
                 reporter.reportOn(catchParameter.source, FirErrors.CATCH_PARAMETER_WITH_DEFAULT_VALUE, context)
             }
 
-            val typeRef = catchParameter.returnTypeRef
-            // TODO: remaining implicit types should be resolved as an error type, along with proper error kind, most likely syntax error.
-            if (typeRef !is FirResolvedTypeRef) return
-
-            val coneType = typeRef.type
+            val coneType = catchParameter.returnTypeRef.coneType
             if (coneType is ConeTypeParameterType) {
                 val isReified = coneType.lookupTag.typeParameterSymbol.fir.isReified
 

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirCallCompletionResultsWriterTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirCallCompletionResultsWriterTransformer.kt
@@ -536,6 +536,7 @@ class FirCallCompletionResultsWriterTransformer(
         // NB: if we transform simply all children, there would be too many type error reports.
         anonymousFunction.transformReturnTypeRef(implicitTypeTransformer, null)
         anonymousFunction.transformValueParameters(implicitTypeTransformer, null)
+        anonymousFunction.transformBody(implicitTypeTransformer, null)
         return anonymousFunction.compose()
     }
 

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirCallCompletionResultsWriterTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirCallCompletionResultsWriterTransformer.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.fir.*
 import org.jetbrains.kotlin.fir.declarations.*
 import org.jetbrains.kotlin.fir.diagnostics.ConeSimpleDiagnostic
+import org.jetbrains.kotlin.fir.diagnostics.DiagnosticKind
 import org.jetbrains.kotlin.fir.expressions.*
 import org.jetbrains.kotlin.fir.references.builder.buildErrorNamedReference
 import org.jetbrains.kotlin.fir.references.builder.buildResolvedCallableReference
@@ -436,7 +437,10 @@ class FirCallCompletionResultsWriterTransformer(
         // Control flow info is necessary prerequisite because we collect return expressions in that function
         //
         // Example: second lambda in the call like list.filter({}, {})
-        if (!dataFlowAnalyzer.isThereControlFlowInfoForAnonymousFunction(anonymousFunction)) return anonymousFunction.compose()
+        if (!dataFlowAnalyzer.isThereControlFlowInfoForAnonymousFunction(anonymousFunction)) {
+            // But, don't leave implicit type refs behind
+            return transformImplicitTypeRefInAnonymousFunction(anonymousFunction)
+        }
 
         val expectedType = data?.getExpectedType(anonymousFunction)?.let { expectedArgumentType ->
             // From the argument mapping, the expected type of this anonymous function would be:
@@ -507,6 +511,32 @@ class FirCallCompletionResultsWriterTransformer(
         }
 
         return result
+    }
+
+    private fun transformImplicitTypeRefInAnonymousFunction(
+        anonymousFunction: FirAnonymousFunction
+    ): CompositeTransformResult<FirStatement> {
+        val implicitTypeTransformer = object : FirDefaultTransformer<Nothing?>() {
+            override fun <E : FirElement> transformElement(element: E, data: Nothing?): CompositeTransformResult<E> {
+                @Suppress("UNCHECKED_CAST")
+                return (element.transformChildren(this, data) as E).compose()
+            }
+
+            override fun transformImplicitTypeRef(
+                implicitTypeRef: FirImplicitTypeRef,
+                data: Nothing?
+            ): CompositeTransformResult<FirTypeRef> =
+                buildErrorTypeRef {
+                    source = implicitTypeRef.source
+                    // NB: this error message assumes that it is used only if CFG for the anonymous function is not available
+                    diagnostic = ConeSimpleDiagnostic("Cannot infer type w/o CFG", DiagnosticKind.InferenceError)
+                }.compose()
+
+        }
+        // NB: if we transform simply all children, there would be too many type error reports.
+        anonymousFunction.transformReturnTypeRef(implicitTypeTransformer, null)
+        anonymousFunction.transformValueParameters(implicitTypeTransformer, null)
+        return anonymousFunction.compose()
     }
 
     override fun transformReturnExpression(

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirSpecificTypeResolverTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirSpecificTypeResolverTransformer.kt
@@ -38,12 +38,15 @@ class FirSpecificTypeResolverTransformer(
         }
     }
 
-    override fun transformTypeRef(typeRef: FirTypeRef, data: FirScope): CompositeTransformResult<FirTypeRef> {
+    override fun transformTypeRef(typeRef: FirTypeRef, data: FirScope): CompositeTransformResult<FirResolvedTypeRef> {
         typeRef.transformChildren(this, data)
         return transformType(typeRef, typeResolver.resolveType(typeRef, data, areBareTypesAllowed))
     }
 
-    override fun transformFunctionTypeRef(functionTypeRef: FirFunctionTypeRef, data: FirScope): CompositeTransformResult<FirTypeRef> {
+    override fun transformFunctionTypeRef(
+        functionTypeRef: FirFunctionTypeRef,
+        data: FirScope
+    ): CompositeTransformResult<FirResolvedTypeRef> {
         functionTypeRef.transformChildren(this, data)
         val resolvedType = typeResolver.resolveType(functionTypeRef, data, areBareTypesAllowed).takeIfAcceptable()
         return if (resolvedType != null && resolvedType !is ConeClassErrorType) {
@@ -62,11 +65,11 @@ class FirSpecificTypeResolverTransformer(
         }.compose()
     }
 
-    private fun transformType(typeRef: FirTypeRef, resolvedType: ConeKotlinType): CompositeTransformResult<FirTypeRef> {
+    private fun transformType(typeRef: FirTypeRef, resolvedType: ConeKotlinType): CompositeTransformResult<FirResolvedTypeRef> {
         return if (resolvedType !is ConeClassErrorType) {
             buildResolvedTypeRef {
                 source = typeRef.source
-                type = resolvedType.takeIfAcceptable() ?: return typeRef.compose()
+                type = resolvedType
                 annotations += typeRef.annotations
                 delegatedTypeRef = typeRef
             }

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirSupertypesResolution.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirSupertypesResolution.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlin.fir.expressions.FirStatement
 import org.jetbrains.kotlin.fir.extensions.extensionService
 import org.jetbrains.kotlin.fir.extensions.predicateBasedProvider
 import org.jetbrains.kotlin.fir.extensions.supertypeGenerators
+import org.jetbrains.kotlin.fir.render
 import org.jetbrains.kotlin.fir.resolve.*
 import org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.LocalClassesNavigationInfo
 import org.jetbrains.kotlin.fir.scopes.FirCompositeScope
@@ -112,7 +113,7 @@ private class FirApplySupertypesTransformer(
         return super.transformAnonymousObject(anonymousObject, data)
     }
 
-    private fun getResolvedSupertypeRefs(classLikeDeclaration: FirClassLikeDeclaration<*>): List<FirTypeRef> {
+    private fun getResolvedSupertypeRefs(classLikeDeclaration: FirClassLikeDeclaration<*>): List<FirResolvedTypeRef> {
         val status = supertypeComputationSession.getSupertypesComputationStatus(classLikeDeclaration)
         require(status is SupertypeComputationStatus.Computed) {
             "Unexpected status at FirApplySupertypesTransformer: $status for ${classLikeDeclaration.symbol.classId}"
@@ -248,7 +249,7 @@ private class FirSupertypeResolverVisitor(
 
     private fun resolveSpecificClassLikeSupertypes(
         classLikeDeclaration: FirClassLikeDeclaration<*>,
-        resolveSuperTypeRefs: (FirTransformer<FirScope>, FirScope) -> List<FirTypeRef>
+        resolveSuperTypeRefs: (FirTransformer<FirScope>, FirScope) -> List<FirResolvedTypeRef>
     ): List<FirTypeRef> {
         when (val status = supertypeComputationSession.getSupertypesComputationStatus(classLikeDeclaration)) {
             is SupertypeComputationStatus.Computed -> return status.supertypeRefs
@@ -282,23 +283,26 @@ private class FirSupertypeResolverVisitor(
         supertypeRefs: List<FirTypeRef>
     ): List<FirTypeRef> {
         return resolveSpecificClassLikeSupertypes(classLikeDeclaration) { transformer, scope ->
-            ArrayList(supertypeRefs).mapTo(mutableListOf()) {
+            supertypeRefs.mapTo(mutableListOf()) {
                 val superTypeRef = transformer.transformTypeRef(it, scope).single
-
-                if (superTypeRef.coneTypeSafe<ConeTypeParameterType>() != null)
-                    createErrorTypeRef(
-                        superTypeRef,
-                        "Type parameter cannot be a super-type: ${superTypeRef.coneTypeUnsafe<ConeTypeParameterType>().render()}"
-                    )
-                else
-                    superTypeRef
+                when {
+                    superTypeRef.coneTypeSafe<ConeTypeParameterType>() != null ->
+                        createErrorTypeRef(
+                            superTypeRef,
+                            "Type parameter cannot be a super-type: ${superTypeRef.coneTypeUnsafe<ConeTypeParameterType>().render()}"
+                        )
+                    superTypeRef !is FirResolvedTypeRef ->
+                        createErrorTypeRef(superTypeRef, "Unresolved super-type: ${superTypeRef.render()}")
+                    else ->
+                        superTypeRef
+                }
             }.also {
                 addSupertypesFromExtensions(classLikeDeclaration, it)
             }
         }
     }
 
-    private fun addSupertypesFromExtensions(klass: FirClassLikeDeclaration<*>, supertypeRefs: MutableList<FirTypeRef>) {
+    private fun addSupertypesFromExtensions(klass: FirClassLikeDeclaration<*>, supertypeRefs: MutableList<FirResolvedTypeRef>) {
         if (supertypeGenerationExtensions.isEmpty()) return
         val provider = session.predicateBasedProvider
         for (extension in supertypeGenerationExtensions) {
@@ -384,7 +388,7 @@ private class SupertypeComputationSession {
         supertypeStatusMap[classLikeDeclaration] = SupertypeComputationStatus.Computing
     }
 
-    fun storeSupertypes(classLikeDeclaration: FirClassLikeDeclaration<*>, resolvedTypesRefs: List<FirTypeRef>) {
+    fun storeSupertypes(classLikeDeclaration: FirClassLikeDeclaration<*>, resolvedTypesRefs: List<FirResolvedTypeRef>) {
         require(supertypeStatusMap[classLikeDeclaration] is SupertypeComputationStatus.Computing) {
             "Unexpected in storeSupertypes supertype status for $classLikeDeclaration: ${supertypeStatusMap[classLikeDeclaration]}"
         }
@@ -411,7 +415,7 @@ private class SupertypeComputationSession {
             }
 
             val typeRefs = supertypeComputationStatus.supertypeRefs
-            val resultingTypeRefs = mutableListOf<FirTypeRef>()
+            val resultingTypeRefs = mutableListOf<FirResolvedTypeRef>()
             var wereChanges = false
 
             for (typeRef in typeRefs) {
@@ -453,7 +457,7 @@ sealed class SupertypeComputationStatus {
     object NotComputed : SupertypeComputationStatus()
     object Computing : SupertypeComputationStatus()
 
-    class Computed(val supertypeRefs: List<FirTypeRef>) : SupertypeComputationStatus()
+    class Computed(val supertypeRefs: List<FirResolvedTypeRef>) : SupertypeComputationStatus()
 }
 
 private typealias ScopePersistentList = PersistentList<FirScope>

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirTypeResolveTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirTypeResolveTransformer.kt
@@ -168,7 +168,7 @@ class FirTypeResolveTransformer(
         return implicitTypeRef.compose()
     }
 
-    override fun transformTypeRef(typeRef: FirTypeRef, data: Nothing?): CompositeTransformResult<FirTypeRef> {
+    override fun transformTypeRef(typeRef: FirTypeRef, data: Nothing?): CompositeTransformResult<FirResolvedTypeRef> {
         return typeRef.transform(typeResolverTransformer, towerScope)
     }
 

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirBodyResolveTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirBodyResolveTransformer.kt
@@ -74,7 +74,7 @@ open class FirBodyResolveTransformer(
         return (element.transformChildren(this, data) as E).compose()
     }
 
-    override fun transformTypeRef(typeRef: FirTypeRef, data: ResolutionMode): CompositeTransformResult<FirTypeRef> {
+    override fun transformTypeRef(typeRef: FirTypeRef, data: ResolutionMode): CompositeTransformResult<FirResolvedTypeRef> {
         if (typeRef is FirResolvedTypeRef) {
             return typeRef.compose()
         }

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirDeclarationsResolveTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirDeclarationsResolveTransformer.kt
@@ -704,6 +704,9 @@ open class FirDeclarationsResolveTransformer(transformer: FirBodyResolveTransfor
         context.storeVariable(valueParameter)
         if (valueParameter.returnTypeRef is FirImplicitTypeRef) {
             transformer.replaceDeclarationResolvePhaseIfNeeded(valueParameter, transformerPhase)
+            valueParameter.replaceReturnTypeRef(
+                valueParameter.returnTypeRef.errorTypeFromPrototype(ConeSimpleDiagnostic("Unresolved value parameter type"))
+            )
             return valueParameter.compose()
         }
 

--- a/compiler/testData/diagnostics/tests/AutoCreatedIt.fir.kt
+++ b/compiler/testData/diagnostics/tests/AutoCreatedIt.fir.kt
@@ -10,7 +10,7 @@ fun text() {
     bar1 {1}
     bar1 {it + 1}
 
-    bar2 {}
+    <!INAPPLICABLE_CANDIDATE!>bar2<!> {}
     bar2 {1}
     bar2 {<!UNRESOLVED_REFERENCE!>it<!>}
     <!INAPPLICABLE_CANDIDATE!>bar2<!> {it -> it}

--- a/compiler/testData/diagnostics/tests/generics/kt34729.fir.kt
+++ b/compiler/testData/diagnostics/tests/generics/kt34729.fir.kt
@@ -14,6 +14,6 @@ fun <T : ILength> bar(a: (Int) -> T) {
 }
 
 fun test() {
-    foo<String> { }
-    bar<Impl> { }
+    <!INAPPLICABLE_CANDIDATE!>foo<!><String> { }
+    <!INAPPLICABLE_CANDIDATE!>bar<!><Impl> { }
 }

--- a/compiler/testData/diagnostics/testsWithStdLib/regression/kt9820_javaFunctionTypeInheritor.fir.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/regression/kt9820_javaFunctionTypeInheritor.fir.kt
@@ -14,5 +14,5 @@ fun useJ(j: J) {
 }
 
 fun jj() {
-    useJ({})
+    <!INAPPLICABLE_CANDIDATE!>useJ<!>({})
 }

--- a/compiler/testData/diagnostics/testsWithStdLib/resolve/lambdaArgumentOfInapplicableCall.fir.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/resolve/lambdaArgumentOfInapplicableCall.fir.kt
@@ -1,0 +1,6 @@
+// KT-45010
+fun foo(map: MutableMap<Int, String>) {
+    map.<!INAPPLICABLE_CANDIDATE!>getOrPut<!>("Not an Int") {
+        "Hello" + " world"
+    }
+}

--- a/compiler/testData/diagnostics/testsWithStdLib/resolve/lambdaArgumentOfInapplicableCall.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/resolve/lambdaArgumentOfInapplicableCall.kt
@@ -1,0 +1,6 @@
+// KT-45010
+fun foo(map: MutableMap<Int, String>) {
+    map.getOrPut(<!TYPE_MISMATCH!>"Not an Int"<!>) {
+        "Hello" + " world"
+    }
+}

--- a/compiler/testData/diagnostics/testsWithStdLib/resolve/lambdaArgumentOfInapplicableCall.txt
+++ b/compiler/testData/diagnostics/testsWithStdLib/resolve/lambdaArgumentOfInapplicableCall.txt
@@ -1,0 +1,3 @@
+package
+
+public fun foo(/*0*/ map: kotlin.collections.MutableMap<kotlin.Int, kotlin.String>): kotlin.Unit

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/DiagnosticTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/DiagnosticTestGenerated.java
@@ -34790,6 +34790,12 @@ public class DiagnosticTestGenerated extends AbstractDiagnosticTest {
             }
 
             @Test
+            @TestMetadata("lambdaArgumentOfInapplicableCall.kt")
+            public void testLambdaArgumentOfInapplicableCall() throws Exception {
+                runTest("compiler/testData/diagnostics/testsWithStdLib/resolve/lambdaArgumentOfInapplicableCall.kt");
+            }
+
+            @Test
             @TestMetadata("samAgainstFunctionalType.kt")
             public void testSamAgainstFunctionalType() throws Exception {
                 runTest("compiler/testData/diagnostics/testsWithStdLib/resolve/samAgainstFunctionalType.kt");

--- a/idea/idea-completion/testData/basic/common/annotations/ParameterAnnotationArgs.kt
+++ b/idea/idea-completion/testData/basic/common/annotations/ParameterAnnotationArgs.kt
@@ -12,3 +12,4 @@ fun foo(@inlineOptions(<caret>) { }
 // EXIST: InlineOption
 // EXIST: String
 // EXIST: v
+// FIR_COMPARISON


### PR DESCRIPTION
This starts from https://github.com/JetBrains/kotlin/pull/4086#discussion_r571410664

> safe casting is redundant on checkers stage because it's guaranteed that all type refs are resolved (and if it's not then it's a bug which we should find AFAP)

It isn't at the moment:
* https://github.com/JetBrains/kotlin/commit/a9322a01ce5a05827215b977903d8ca74b6d6717#diff-c9ee748339a0c52370774866e0e788a137c98b9a4dd8129be44abb6ce98b7be0
* https://github.com/JetBrains/kotlin/commit/a9322a01ce5a05827215b977903d8ca74b6d6717#diff-dfb1b963c3ebdbf6a27673dc35da848b614a1f3178666a6c065124368ab45d45

As per the suggestions (https://github.com/JetBrains/kotlin/pull/4086#discussion_r571815938):
> Types are converted in three phases, so there are three phases for fixing implicits:
> * supertype resolve transformer
> * type resolve transformer (for types of members, value parameters)
> * body resolve transformers (for every type in local scope of functions/property body)

1st commit revisits super type resolve transformers, and once transformed, ensures type refs are indeed resolved ones.

2nd commit revisits type resolve transformer and its users, and does the same thing.

The place where implicit type refs can be addressed in body resolve transformers are scattered. For catch parameter checker, 3rd commit resolves remaining implicit type ref of value parameter at declaration resolve stage.

4 to 6th commit deal with implicit type refs left in various scenarios with anonymous functions.

At last, 7th commit removes the last TODO in checkers. Now, except for `contract` body, all typed declarations' return types are guaranteed to be resolved. All other (redundant) castings to resolved type refs have gone at https://github.com/JetBrains/kotlin/commit/a9322a01ce5a05827215b977903d8ca74b6d6717