### PR TITLE
Copy typeParameters from original declaration to the exportedDefaultS…

### DIFF
--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/ExportedDefaultParameterStub.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/ExportedDefaultParameterStub.kt
@@ -107,9 +107,9 @@ class ExportedDefaultParameterStub(val context: JsIrBackendContext) : Declaratio
 
         context.additionalExportedDeclarations.add(exportedDefaultStubFun)
 
-        exportedDefaultStubFun.returnType = declaration.returnType.remapTypeParameters(declaration, exportedDefaultStubFun)
         exportedDefaultStubFun.parent = declaration.parent
         exportedDefaultStubFun.copyParameterDeclarationsFrom(declaration)
+        exportedDefaultStubFun.returnType = declaration.returnType.remapTypeParameters(declaration, exportedDefaultStubFun)
         exportedDefaultStubFun.valueParameters.forEach { it.defaultValue = null }
 
         declaration.origin = JsLoweredDeclarationOrigin.JS_SHADOWED_EXPORT


### PR DESCRIPTION
Seems, that there was a bug: we should copy `typeParameters` from the original declaration to the `exportedDefaultStubFun` before substitution of type parameters in `exportedDefaultStubFun.returnType`, otherwise this causes failure at  

```
e: java.lang.IndexOutOfBoundsException: Empty list doesn't contain element at index 0.
15:51:45
      at kotlin.collections.EmptyList.get(Collections.kt:36)
15:51:45
      at kotlin.collections.EmptyList.get(Collections.kt:24)
15:51:45
      at org.jetbrains.kotlin.backend.common.ir.IrUtilsKt.remapTypeParameters(IrUtils.kt:328)
```