### PR TITLE
[JVM_IR] Extend when to switch translation to deal with nested ors.

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBytecodeTextTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBytecodeTextTestGenerated.java
@@ -5575,6 +5575,12 @@ public class FirBytecodeTextTestGenerated extends AbstractFirBytecodeTextTest {
         }
 
         @Test
+        @TestMetadata("whenOr.kt")
+        public void testWhenOr() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/whenEnumOptimization/whenOr.kt");
+        }
+
+        @Test
         @TestMetadata("withoutElse.kt")
         public void testWithoutElse() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/whenEnumOptimization/withoutElse.kt");

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/SwitchGenerator.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/SwitchGenerator.kt
@@ -237,11 +237,13 @@ class SwitchGenerator(private val expression: IrWhen, private val data: BlockInf
     //     action
     // }
     //
+    // fir2ir lowers the same to an or sequence:
+    //
+    // if (((subject == a) || (subject == b)) || (subject = c)) action
+    //
     // @return true if the conditions are equality checks of constants.
     private fun matchConditions(condition: IrExpression): ArrayList<IrCall>? {
-        if (condition is IrCall) {
-            return arrayListOf(condition)
-        } else if (condition is IrWhen && condition.origin == IrStatementOrigin.WHEN_COMMA) {
+        if (condition is IrWhen && condition.origin == IrStatementOrigin.WHEN_COMMA) {
             assert(condition.type.isBoolean()) { "WHEN_COMMA should always be a Boolean: ${condition.dump()}" }
 
             val candidates = ArrayList<IrCall>()
@@ -268,6 +270,15 @@ class SwitchGenerator(private val expression: IrWhen, private val data: BlockInf
             }
 
             return if (candidates.isNotEmpty()) candidates else return null
+        } else if (condition is IrCall && condition.symbol == codegen.context.irBuiltIns.ororSymbol) {
+            val candidates = ArrayList<IrCall>()
+            for (i in 0 until condition.valueArgumentsCount) {
+                val argument = condition.getValueArgument(i)!!
+                candidates += matchConditions(argument) ?: return null
+            }
+            return if (candidates.isNotEmpty()) candidates else return null
+        } else if (condition is IrCall) {
+            return arrayListOf(condition)
         }
 
         return null

--- a/compiler/testData/codegen/bytecodeText/when/switchOptimizationDuplicates.kt
+++ b/compiler/testData/codegen/bytecodeText/when/switchOptimizationDuplicates.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 fun foo(x: Int): Int {
     return when (x) {
         1, 1, 2 -> 1001

--- a/compiler/testData/codegen/bytecodeText/whenEnumOptimization/bigEnum.kt
+++ b/compiler/testData/codegen/bytecodeText/whenEnumOptimization/bigEnum.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 import kotlin.test.assertEquals
 
 enum class BigEnum {

--- a/compiler/testData/codegen/bytecodeText/whenEnumOptimization/duplicatingItems.kt
+++ b/compiler/testData/codegen/bytecodeText/whenEnumOptimization/duplicatingItems.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 import kotlin.test.assertEquals
 
 enum class Season {

--- a/compiler/testData/codegen/bytecodeText/whenEnumOptimization/expression.kt
+++ b/compiler/testData/codegen/bytecodeText/whenEnumOptimization/expression.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 import kotlin.test.assertEquals
 
 enum class Season {

--- a/compiler/testData/codegen/bytecodeText/whenEnumOptimization/manyWhensWithinClass.kt
+++ b/compiler/testData/codegen/bytecodeText/whenEnumOptimization/manyWhensWithinClass.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 package abc.foo
 
 enum class Season {

--- a/compiler/testData/codegen/bytecodeText/whenEnumOptimization/nullability.kt
+++ b/compiler/testData/codegen/bytecodeText/whenEnumOptimization/nullability.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 enum class Season {
     WINTER,
     SPRING,

--- a/compiler/testData/codegen/bytecodeText/whenEnumOptimization/whenOr.kt
+++ b/compiler/testData/codegen/bytecodeText/whenEnumOptimization/whenOr.kt
@@ -1,0 +1,11 @@
+// IGNORE_BACKEND: JVM
+
+fun test(x: Int): String {
+    when {
+        x == 1 || x == 3 || x == 5 -> "135"
+        x == 2 || x == 4 || x == 6 -> "246"
+        else -> "other"
+    }
+}
+
+// 1 TABLESWITCH

--- a/compiler/testData/codegen/bytecodeText/whenEnumOptimization/withoutElse.kt
+++ b/compiler/testData/codegen/bytecodeText/whenEnumOptimization/withoutElse.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 import kotlin.test.assertEquals
 
 enum class Season {

--- a/compiler/testData/codegen/bytecodeText/whenStringOptimization/duplicatingItems.kt
+++ b/compiler/testData/codegen/bytecodeText/whenStringOptimization/duplicatingItems.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 import kotlin.test.assertEquals
 
 fun foo(x : String) : String {

--- a/compiler/testData/codegen/bytecodeText/whenStringOptimization/expression.kt
+++ b/compiler/testData/codegen/bytecodeText/whenStringOptimization/expression.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 fun foo(x : String) : String {
     return when (x) {
         "abc", "cde" -> "abc_cde"

--- a/compiler/testData/codegen/bytecodeText/whenStringOptimization/inlineStringConstInsideWhen.kt
+++ b/compiler/testData/codegen/bytecodeText/whenStringOptimization/inlineStringConstInsideWhen.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 const val y = "cde"
 
 fun foo(x : String) : String {

--- a/compiler/testData/codegen/bytecodeText/whenStringOptimization/nullability.kt
+++ b/compiler/testData/codegen/bytecodeText/whenStringOptimization/nullability.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 fun foo1(x : String?) : String {
     when (x) {
         "abc", "cde" -> return "abc_cde"

--- a/compiler/testData/codegen/bytecodeText/whenStringOptimization/sameHashCode.kt
+++ b/compiler/testData/codegen/bytecodeText/whenStringOptimization/sameHashCode.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 fun foo(x : String) : String {
     assert("abz]".hashCode() == "aby|".hashCode())
 

--- a/compiler/testData/codegen/bytecodeText/whenStringOptimization/statement.kt
+++ b/compiler/testData/codegen/bytecodeText/whenStringOptimization/statement.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 fun foo1(x : String) : String {
     when (x) {
         "abc", "cde" -> return "abc_cde"

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BytecodeTextTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BytecodeTextTestGenerated.java
@@ -5443,6 +5443,12 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
         }
 
         @Test
+        @TestMetadata("whenOr.kt")
+        public void testWhenOr() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/whenEnumOptimization/whenOr.kt");
+        }
+
+        @Test
         @TestMetadata("withoutElse.kt")
         public void testWithoutElse() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/whenEnumOptimization/withoutElse.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBytecodeTextTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBytecodeTextTestGenerated.java
@@ -5575,6 +5575,12 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
         }
 
         @Test
+        @TestMetadata("whenOr.kt")
+        public void testWhenOr() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/whenEnumOptimization/whenOr.kt");
+        }
+
+        @Test
         @TestMetadata("withoutElse.kt")
         public void testWithoutElse() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/whenEnumOptimization/withoutElse.kt");


### PR DESCRIPTION
FIR translates:

```
when (x) {
  1, 2, 3 -> action
  else -> other_action
}
```

to an IR structure with nested ors:

```
if ((x == 1 || x == 2) || (x == 3)) action
else other_action
```

This change allows that to turn into switch instructions in the
JVM backend.