### PR TITLE
FIR IDE: Split and AddModifierFix to fe-independent

### DIFF
--- a/idea/idea-frontend-independent/src/org/jetbrains/kotlin/idea/quickfix/AddModifierFix.kt
+++ b/idea/idea-frontend-independent/src/org/jetbrains/kotlin/idea/quickfix/AddModifierFix.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.idea.quickfix
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.PsiTreeUtil
+import org.jetbrains.kotlin.idea.KotlinBundle
+import org.jetbrains.kotlin.idea.inspections.KotlinUniversalQuickFix
+import org.jetbrains.kotlin.lexer.KtModifierKeywordToken
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.psiUtil.containingClass
+import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
+
+open class AddModifierFix(
+    element: KtModifierListOwner,
+    protected val modifier: KtModifierKeywordToken
+) : KotlinCrossLanguageQuickFixAction<KtModifierListOwner>(element), KotlinUniversalQuickFix {
+    override fun getText(): String {
+        val element = element ?: return ""
+        if (modifier in modalityModifiers || modifier in KtTokens.VISIBILITY_MODIFIERS || modifier == KtTokens.CONST_KEYWORD) {
+            return KotlinBundle.message("fix.add.modifier.text", RemoveModifierFix.getElementName(element), modifier.value)
+        }
+        return KotlinBundle.message("fix.add.modifier.text.generic", modifier.value)
+    }
+
+    override fun getFamilyName() = KotlinBundle.message("fix.add.modifier.family")
+
+    protected fun invokeOnElement(element: KtModifierListOwner?) {
+        element?.addModifier(modifier)
+
+        if (modifier == KtTokens.ABSTRACT_KEYWORD && (element is KtProperty || element is KtNamedFunction)) {
+            element.containingClass()?.run {
+                if (!hasModifier(KtTokens.ABSTRACT_KEYWORD) && !hasModifier(KtTokens.SEALED_KEYWORD)) {
+                    addModifier(KtTokens.ABSTRACT_KEYWORD)
+                }
+            }
+        }
+    }
+
+    override fun invokeImpl(project: Project, editor: Editor?, file: PsiFile) {
+        val originalElement = element
+        invokeOnElement(originalElement)
+    }
+
+    // TODO: consider checking if this fix is available by testing if the [element] can be refactored by calling
+    //  FIR version of [org.jetbrains.kotlin.idea.refactoring.KotlinRefactoringUtilKt#canRefactor]
+    override fun isAvailableImpl(project: Project, editor: Editor?, file: PsiFile): Boolean = element != null
+
+    interface Factory<T> {
+        fun createFactory(modifier: KtModifierKeywordToken): QuickFixesPsiBasedFactory<PsiElement> {
+            return createFactory(modifier, KtModifierListOwner::class.java)
+        }
+
+        fun <T : KtModifierListOwner> createFactory(
+            modifier: KtModifierKeywordToken,
+            modifierOwnerClass: Class<T>
+        ): QuickFixesPsiBasedFactory<PsiElement> {
+            return quickFixesPsiBasedFactory { e ->
+                val modifierListOwner =
+                    PsiTreeUtil.getParentOfType(e, modifierOwnerClass, false) ?: return@quickFixesPsiBasedFactory emptyList()
+                listOfNotNull(createIfApplicable(modifierListOwner, modifier))
+            }
+        }
+
+        fun createIfApplicable(modifierListOwner: KtModifierListOwner, modifier: KtModifierKeywordToken): AddModifierFix? {
+            when (modifier) {
+                KtTokens.ABSTRACT_KEYWORD, KtTokens.OPEN_KEYWORD -> {
+                    if (modifierListOwner is KtObjectDeclaration) return null
+                    if (modifierListOwner is KtEnumEntry) return null
+                    if (modifierListOwner is KtDeclaration && modifierListOwner !is KtClass) {
+                        val parentClassOrObject = modifierListOwner.containingClassOrObject ?: return null
+                        if (parentClassOrObject is KtObjectDeclaration) return null
+                        if (parentClassOrObject is KtEnumEntry) return null
+                    }
+                    if (modifier == KtTokens.ABSTRACT_KEYWORD
+                        && modifierListOwner is KtClass
+                        && modifierListOwner.hasModifier(KtTokens.INLINE_KEYWORD)
+                    ) return null
+                }
+                KtTokens.INNER_KEYWORD -> {
+                    if (modifierListOwner is KtObjectDeclaration) return null
+                    if (modifierListOwner is KtClass) {
+                        if (modifierListOwner.isInterface() ||
+                            modifierListOwner.isSealed() ||
+                            modifierListOwner.isEnum() ||
+                            modifierListOwner.isData() ||
+                            modifierListOwner.isAnnotation()
+                        ) return null
+                    }
+                }
+            }
+            return AddModifierFix(modifierListOwner, modifier)
+        }
+
+        fun createModifierFix(
+            element: KtModifierListOwner,
+            modifier: KtModifierKeywordToken
+        ): T
+    }
+
+    companion object : Factory<AddModifierFix> {
+        private val modalityModifiers = setOf(KtTokens.ABSTRACT_KEYWORD, KtTokens.OPEN_KEYWORD, KtTokens.FINAL_KEYWORD)
+        override fun createModifierFix(element: KtModifierListOwner, modifier: KtModifierKeywordToken): AddModifierFix =
+            AddModifierFix(element, modifier)
+
+    }
+}

--- a/idea/src/org/jetbrains/kotlin/idea/inspections/AddModifierFixFactory.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/AddModifierFixFactory.kt
@@ -21,7 +21,7 @@ import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.diagnostics.Diagnostic
 import org.jetbrains.kotlin.diagnostics.DiagnosticWithParameters2
 import org.jetbrains.kotlin.idea.codeInsight.DescriptorToSourceUtilsIde
-import org.jetbrains.kotlin.idea.quickfix.AddModifierFix
+import org.jetbrains.kotlin.idea.quickfix.AddModifierFixMpp
 import org.jetbrains.kotlin.idea.quickfix.CleanupFix
 import org.jetbrains.kotlin.idea.quickfix.KotlinSingleIntentionActionFactory
 import org.jetbrains.kotlin.idea.refactoring.canRefactor
@@ -34,7 +34,7 @@ class AddModifierFixFactory(val token: KtModifierKeywordToken) : KotlinSingleInt
         val target = DescriptorToSourceUtilsIde.getAnyDeclaration(diagnostic.psiFile.project, functionDescriptor)
                 as? KtModifierListOwner ?: return null
         if (target.canRefactor()) {
-            return object : AddModifierFix(target, token), CleanupFix {}
+            return object : AddModifierFixMpp(target, token), CleanupFix {}
         }
         return null
     }

--- a/idea/src/org/jetbrains/kotlin/idea/inspections/LeakingThisInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/LeakingThisInspection.kt
@@ -16,7 +16,7 @@ import org.jetbrains.kotlin.cfg.LeakingThisDescriptor.*
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.idea.KotlinBundle
 import org.jetbrains.kotlin.idea.caches.resolve.analyzeWithContent
-import org.jetbrains.kotlin.idea.quickfix.AddModifierFix
+import org.jetbrains.kotlin.idea.quickfix.AddModifierFixMpp
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
@@ -100,7 +100,7 @@ class LeakingThisInspection : AbstractKotlinInspection() {
             val useScope = declaration.useScope
             if (DefinitionsScopedSearch.search(declaration, useScope).findFirst() != null) return null
             if ((declaration.containingClassOrObject as? KtClass)?.isInterface() == true) return null
-            return IntentionWrapper(AddModifierFix(declaration, KtTokens.FINAL_KEYWORD), declaration.containingFile)
+            return IntentionWrapper(AddModifierFixMpp(declaration, KtTokens.FINAL_KEYWORD), declaration.containingFile)
         }
     }
 }

--- a/idea/src/org/jetbrains/kotlin/idea/inspections/MemberVisibilityCanBePrivateInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/MemberVisibilityCanBePrivateInspection.kt
@@ -38,7 +38,7 @@ import org.jetbrains.kotlin.idea.core.canBePrivate
 import org.jetbrains.kotlin.idea.core.isInheritable
 import org.jetbrains.kotlin.idea.core.isOverridable
 import org.jetbrains.kotlin.idea.core.toDescriptor
-import org.jetbrains.kotlin.idea.quickfix.AddModifierFix
+import org.jetbrains.kotlin.idea.quickfix.AddModifierFixMpp
 import org.jetbrains.kotlin.idea.refactoring.isConstructorDeclaredProperty
 import org.jetbrains.kotlin.idea.search.isCheapEnoughToSearchConsideringOperators
 import org.jetbrains.kotlin.idea.search.usagesSearch.dataClassComponentFunction
@@ -159,7 +159,7 @@ class MemberVisibilityCanBePrivateInspection : AbstractKotlinInspection() {
             declaration.visibilityModifier() ?: nameElement,
             KotlinBundle.message("0.1.could.be.private", member, declaration.getName().toString()),
             ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
-            IntentionWrapper(AddModifierFix(modifierListOwner, KtTokens.PRIVATE_KEYWORD), declaration.containingKtFile)
+            IntentionWrapper(AddModifierFixMpp(modifierListOwner, KtTokens.PRIVATE_KEYWORD), declaration.containingKtFile)
         )
     }
 }

--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/AddConstModifierFix.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/AddConstModifierFix.kt
@@ -35,7 +35,7 @@ import org.jetbrains.kotlin.psi.psiUtil.hasActualModifier
 import org.jetbrains.kotlin.resolve.checkers.ConstModifierChecker
 import org.jetbrains.kotlin.resolve.source.PsiSourceElement
 
-class AddConstModifierFix(property: KtProperty) : AddModifierFix(property, KtTokens.CONST_KEYWORD), CleanupFix {
+class AddConstModifierFix(property: KtProperty) : AddModifierFixMpp(property, KtTokens.CONST_KEYWORD), CleanupFix {
     private val pointer = property.createSmartPointer()
 
     override fun invokeImpl(project: Project, editor: Editor?, file: PsiFile) {

--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/AddDataModifierFix.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/AddDataModifierFix.kt
@@ -22,7 +22,7 @@ import org.jetbrains.kotlin.resolve.DescriptorToSourceUtils
 import org.jetbrains.kotlin.resolve.DescriptorUtils
 import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
 
-class AddDataModifierFix(element: KtClass, private val fqName: String) : AddModifierFix(element, KtTokens.DATA_KEYWORD) {
+class AddDataModifierFix(element: KtClass, private val fqName: String) : AddModifierFixMpp(element, KtTokens.DATA_KEYWORD) {
 
     override fun getText() = KotlinBundle.message("fix.make.data.class", fqName)
 

--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/AddInlineModifierFix.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/AddInlineModifierFix.kt
@@ -20,7 +20,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 class AddInlineModifierFix(
     parameter: KtParameter,
     modifier: KtModifierKeywordToken
-) : AddModifierFix(parameter, modifier) {
+) : AddModifierFixMpp(parameter, modifier) {
 
     override fun getText(): String {
         val element = this.element

--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/AddInlineToFunctionWithReifiedFix.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/AddInlineToFunctionWithReifiedFix.kt
@@ -23,7 +23,7 @@ import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 
-class AddInlineToFunctionWithReifiedFix(function: KtNamedFunction) : AddModifierFix(function, KtTokens.INLINE_KEYWORD) {
+class AddInlineToFunctionWithReifiedFix(function: KtNamedFunction) : AddModifierFixMpp(function, KtTokens.INLINE_KEYWORD) {
     companion object Factory : KotlinSingleIntentionActionFactory() {
         override fun createAction(diagnostic: Diagnostic): IntentionAction? {
             val element = Errors.REIFIED_TYPE_PARAMETER_NO_INLINE.cast(diagnostic)

--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/AddModifierFixMpp.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/AddModifierFixMpp.kt
@@ -42,7 +42,7 @@ import org.jetbrains.kotlin.resolve.DescriptorToSourceUtils
 import org.jetbrains.kotlin.resolve.lazy.BodyResolveMode
 import org.jetbrains.kotlin.types.TypeUtils
 
-open class AddModifierFix(
+open class AddModifierFixMpp(
     element: KtModifierListOwner,
     protected val modifier: KtModifierKeywordToken
 ) : KotlinCrossLanguageQuickFixAction<KtModifierListOwner>(element), KotlinUniversalQuickFix {
@@ -105,7 +105,7 @@ open class AddModifierFix(
             }
         }
 
-        fun createIfApplicable(modifierListOwner: KtModifierListOwner, modifier: KtModifierKeywordToken): AddModifierFix? {
+        fun createIfApplicable(modifierListOwner: KtModifierListOwner, modifier: KtModifierKeywordToken): AddModifierFixMpp? {
             when (modifier) {
                 ABSTRACT_KEYWORD, OPEN_KEYWORD -> {
                     if (modifierListOwner is KtObjectDeclaration) return null
@@ -132,7 +132,7 @@ open class AddModifierFix(
                     }
                 }
             }
-            return AddModifierFix(modifierListOwner, modifier)
+            return AddModifierFixMpp(modifierListOwner, modifier)
         }
 
     }
@@ -142,7 +142,7 @@ open class AddModifierFix(
             val typeReference = diagnostic.psiElement as KtTypeReference
             val declaration = typeReference.classForRefactor() ?: return null
             if (declaration.isEnum() || declaration.isData()) return null
-            return AddModifierFix(declaration, OPEN_KEYWORD)
+            return AddModifierFixMpp(declaration, OPEN_KEYWORD)
         }
     }
 
@@ -157,7 +157,7 @@ open class AddModifierFix(
             if (TypeUtils.isNullableType(type)) return null
             if (KotlinBuiltIns.isPrimitiveType(type)) return null
 
-            return AddModifierFix(property, LATEINIT_KEYWORD)
+            return AddModifierFixMpp(property, LATEINIT_KEYWORD)
         }
     }
 }

--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/AddReifiedToTypeParameterOfFunctionFix.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/AddReifiedToTypeParameterOfFunctionFix.kt
@@ -47,7 +47,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 class AddReifiedToTypeParameterOfFunctionFix(
     typeParameter: KtTypeParameter,
     function: KtNamedFunction
-) : AddModifierFix(typeParameter, KtTokens.REIFIED_KEYWORD) {
+) : AddModifierFixMpp(typeParameter, KtTokens.REIFIED_KEYWORD) {
 
     private val inlineFix = AddInlineToFunctionWithReifiedFix(function)
     private val elementName = RemoveModifierFix.getElementName(function)

--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/AddSuspendModifierFix.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/AddSuspendModifierFix.kt
@@ -21,7 +21,7 @@ import org.jetbrains.kotlin.resolve.DescriptorToSourceUtils
 class AddSuspendModifierFix(
     element: KtModifierListOwner,
     private val declarationName: String?
-) : AddModifierFix(element, KtTokens.SUSPEND_KEYWORD) {
+) : AddModifierFixMpp(element, KtTokens.SUSPEND_KEYWORD) {
 
     override fun getText() = when (element) {
         is KtNamedFunction -> {

--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/MakeTypeParameterReifiedAndFunctionInlineFix.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/MakeTypeParameterReifiedAndFunctionInlineFix.kt
@@ -32,7 +32,7 @@ class MakeTypeParameterReifiedAndFunctionInlineFix(
 
     override fun invoke(project: Project, editor: Editor?, file: KtFile) {
         inlineFix.invoke(project, editor, file)
-        AddModifierFix(typeParameter, KtTokens.REIFIED_KEYWORD).invoke(project, editor, file)
+        AddModifierFixMpp(typeParameter, KtTokens.REIFIED_KEYWORD).invoke(project, editor, file)
     }
 
     companion object : KotlinSingleIntentionActionFactory() {

--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixRegistrar.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixRegistrar.kt
@@ -66,7 +66,7 @@ class QuickFixRegistrar : QuickFixContributor {
         }
 
         val removeAbstractModifierFactory = createRemoveModifierFromListOwnerPsiBasedFactory(ABSTRACT_KEYWORD )
-        val addAbstractModifierFactory = AddModifierFix.createFactory(ABSTRACT_KEYWORD)
+        val addAbstractModifierFactory = AddModifierFixMpp.createFactory(ABSTRACT_KEYWORD)
 
         ABSTRACT_PROPERTY_IN_PRIMARY_CONSTRUCTOR_PARAMETERS.registerFactory(removeAbstractModifierFactory)
 
@@ -83,7 +83,7 @@ class QuickFixRegistrar : QuickFixContributor {
         MUST_BE_INITIALIZED_OR_BE_ABSTRACT.registerFactory(InitializePropertyQuickFixFactory)
         MUST_BE_INITIALIZED.registerFactory(InitializePropertyQuickFixFactory)
 
-        val addAbstractToClassFactory = AddModifierFix.createFactory(ABSTRACT_KEYWORD, KtClassOrObject::class.java)
+        val addAbstractToClassFactory = AddModifierFixMpp.createFactory(ABSTRACT_KEYWORD, KtClassOrObject::class.java)
         ABSTRACT_PROPERTY_IN_NON_ABSTRACT_CLASS.registerFactory(removeAbstractModifierFactory, addAbstractToClassFactory)
 
         ABSTRACT_FUNCTION_IN_NON_ABSTRACT_CLASS.registerFactory(removeAbstractModifierFactory, addAbstractToClassFactory)
@@ -104,7 +104,7 @@ class QuickFixRegistrar : QuickFixContributor {
             AddFunctionToSupertypeFix,
             AddPropertyToSupertypeFix
         )
-        VIRTUAL_MEMBER_HIDDEN.registerFactory(AddModifierFix.createFactory(OVERRIDE_KEYWORD))
+        VIRTUAL_MEMBER_HIDDEN.registerFactory(AddModifierFixMpp.createFactory(OVERRIDE_KEYWORD))
 
         USELESS_CAST.registerFactory(RemoveUselessCastFix)
 
@@ -128,7 +128,7 @@ class QuickFixRegistrar : QuickFixContributor {
 
         val removeOpenModifierFactory = RemoveModifierFix.createRemoveModifierFromListOwnerPsiBasedFactory(OPEN_KEYWORD)
         NON_FINAL_MEMBER_IN_FINAL_CLASS.registerFactory(
-            AddModifierFix.createFactory(OPEN_KEYWORD, KtClass::class.java),
+            AddModifierFixMpp.createFactory(OPEN_KEYWORD, KtClass::class.java),
             removeOpenModifierFactory
         )
         NON_FINAL_MEMBER_IN_OBJECT.registerFactory(removeOpenModifierFactory)
@@ -138,7 +138,7 @@ class QuickFixRegistrar : QuickFixContributor {
         SETTER_VISIBILITY_INCONSISTENT_WITH_PROPERTY_VISIBILITY.registerFactory(removeModifierFactory)
         PRIVATE_SETTER_FOR_ABSTRACT_PROPERTY.registerFactory(removeModifierFactory)
         PRIVATE_SETTER_FOR_OPEN_PROPERTY.registerFactory(
-            AddModifierFix.createFactory(FINAL_KEYWORD, KtProperty::class.java),
+            AddModifierFixMpp.createFactory(FINAL_KEYWORD, KtProperty::class.java),
             removeModifierFactory
         )
         REDUNDANT_MODIFIER_IN_GETTER.registerFactory(removeRedundantModifierFactory)
@@ -296,16 +296,16 @@ class QuickFixRegistrar : QuickFixContributor {
         UNCHECKED_CAST.registerFactory(ChangeToStarProjectionFix)
         CANNOT_CHECK_FOR_ERASED.registerFactory(ChangeToStarProjectionFix)
 
-        INACCESSIBLE_OUTER_CLASS_EXPRESSION.registerFactory(AddModifierFix.createFactory(INNER_KEYWORD, KtClass::class.java))
+        INACCESSIBLE_OUTER_CLASS_EXPRESSION.registerFactory(AddModifierFixMpp.createFactory(INNER_KEYWORD, KtClass::class.java))
 
-        FINAL_SUPERTYPE.registerFactory(AddModifierFix.MakeClassOpenFactory)
-        FINAL_UPPER_BOUND.registerFactory(AddModifierFix.MakeClassOpenFactory)
+        FINAL_SUPERTYPE.registerFactory(AddModifierFixMpp.MakeClassOpenFactory)
+        FINAL_UPPER_BOUND.registerFactory(AddModifierFixMpp.MakeClassOpenFactory)
 
         OVERRIDING_FINAL_MEMBER.registerFactory(MakeOverriddenMemberOpenFix)
 
         PARAMETER_NAME_CHANGED_ON_OVERRIDE.registerFactory(RenameParameterToMatchOverriddenMethodFix)
 
-        NESTED_CLASS_NOT_ALLOWED.registerFactory(AddModifierFix.createFactory(INNER_KEYWORD))
+        NESTED_CLASS_NOT_ALLOWED.registerFactory(AddModifierFixMpp.createFactory(INNER_KEYWORD))
 
         CONFLICTING_PROJECTION.registerFactory(RemoveModifierFix.createRemoveProjectionFactory(false))
         PROJECTION_ON_NON_CLASS_TYPE_ARGUMENT.registerFactory(RemoveModifierFix.createRemoveProjectionFactory(false))
@@ -546,7 +546,7 @@ class QuickFixRegistrar : QuickFixContributor {
         NO_ACTUAL_FOR_EXPECT.registerFactory(CreateActualFix)
         NO_ACTUAL_CLASS_MEMBER_FOR_EXPECTED_CLASS.registerFactory(AddActualFix)
 
-        ACTUAL_MISSING.registerFactory(AddModifierFix.createFactory(ACTUAL_KEYWORD))
+        ACTUAL_MISSING.registerFactory(AddModifierFixMpp.createFactory(ACTUAL_KEYWORD))
 
         CAST_NEVER_SUCCEEDS.registerFactory(ReplacePrimitiveCastWithNumberConversionFix)
 
@@ -569,7 +569,7 @@ class QuickFixRegistrar : QuickFixContributor {
 
         CONFLICTING_OVERLOADS.registerFactory(ChangeSuspendInHierarchyFix)
 
-        MUST_BE_INITIALIZED_OR_BE_ABSTRACT.registerFactory(AddModifierFix.AddLateinitFactory)
+        MUST_BE_INITIALIZED_OR_BE_ABSTRACT.registerFactory(AddModifierFixMpp.AddLateinitFactory)
 
         RETURN_NOT_ALLOWED.registerFactory(ChangeToLabeledReturnFix)
 

--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/crossLanguage/KotlinElementActionsFactory.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/crossLanguage/KotlinElementActionsFactory.kt
@@ -34,7 +34,7 @@ import org.jetbrains.kotlin.idea.caches.resolve.getResolutionFacade
 import org.jetbrains.kotlin.idea.caches.resolve.resolveToDescriptorIfAny
 import org.jetbrains.kotlin.idea.core.ShortenReferences
 import org.jetbrains.kotlin.idea.core.appendModifier
-import org.jetbrains.kotlin.idea.quickfix.AddModifierFix
+import org.jetbrains.kotlin.idea.quickfix.AddModifierFixMpp
 import org.jetbrains.kotlin.idea.quickfix.RemoveModifierFix
 import org.jetbrains.kotlin.idea.quickfix.createFromUsage.callableBuilder.*
 import org.jetbrains.kotlin.idea.quickfix.createFromUsage.createCallable.CreateCallableFromUsageFix
@@ -198,7 +198,7 @@ class KotlinElementActionsFactory : JvmElementActionsFactory() {
         if (kToken == null) return emptyList()
 
         val action = if (shouldPresentMapped)
-            AddModifierFix.createIfApplicable(kModifierOwner, kToken)
+            AddModifierFixMpp.createIfApplicable(kModifierOwner, kToken)
         else
             RemoveModifierFix(kModifierOwner, kToken, false)
         return listOfNotNull(action)

--- a/nj2k/nj2k-services/src/org/jetbrains/kotlin/nj2k/postProcessing/J2kPostProcessor.kt
+++ b/nj2k/nj2k-services/src/org/jetbrains/kotlin/nj2k/postProcessing/J2kPostProcessor.kt
@@ -129,7 +129,7 @@ private val errorsFixingDiagnosticBasedPostProcessingGroup =
             Errors.REDUNDANT_PROJECTION
         ),
         diagnosticBasedProcessing(
-            AddModifierFix.createFactory(KtTokens.OVERRIDE_KEYWORD),
+            AddModifierFixMpp.createFactory(KtTokens.OVERRIDE_KEYWORD),
             Errors.VIRTUAL_MEMBER_HIDDEN
         ),
         diagnosticBasedProcessing(


### PR DESCRIPTION
This change strips the MPP part off AddModifierFix and create a new fix
AddModifierFixMpp that behaves exactly as the original fix in FE1.0.

In addition, the original fix checks if the element belongs to project source
and report it's availability accordingly. Part of this check requires FE1.0
logic to determine if the source is in a Kotlin script. It looks like porting
this check to FIR is infeasible at the moment. Hence the availability check in
the FIR version of AddModifierFix is simplified. AFAIK, this should be fine
since in the other cases, this check won't be reported in the first place for
library code.