### PR TITLE
FIR IDE: Add quickfix for VAR_ANNOTATION_PARAMETER.

### DIFF
--- a/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/MainKtQuickFixRegistrar.kt
+++ b/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/MainKtQuickFixRegistrar.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.idea.frontend.api.fir.diagnostics.KtFirDiagnostic
 import org.jetbrains.kotlin.idea.quickfix.fixes.ChangeTypeQuickFix
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtModifierListOwner
+import org.jetbrains.kotlin.psi.KtParameter
 
 class MainKtQuickFixRegistrar : KtQuickFixRegistrar() {
     private val modifiers = KtQuickFixesListBuilder.registerPsiQuickFix {
@@ -37,6 +38,7 @@ class MainKtQuickFixRegistrar : KtQuickFixRegistrar() {
 
     private val mutability = KtQuickFixesListBuilder.registerPsiQuickFix {
         registerPsiQuickFix<PsiElement, KtFirDiagnostic.VarOverriddenByVal>(ChangeVariableMutabilityFix.VAR_OVERRIDDEN_BY_VAL_FACTORY)
+        registerPsiQuickFix<KtParameter, KtFirDiagnostic.VarAnnotationParameter>(ChangeVariableMutabilityFix.VAR_ANNOTATION_PARAMETER_FACTORY)
     }
 
     override val list: KtQuickFixesList = KtQuickFixesList.createCombined(

--- a/idea/idea-fir/tests/org/jetbrains/kotlin/idea/quickfix/HighLevelQuickFixTestGenerated.java
+++ b/idea/idea-fir/tests/org/jetbrains/kotlin/idea/quickfix/HighLevelQuickFixTestGenerated.java
@@ -521,5 +521,10 @@ public class HighLevelQuickFixTestGenerated extends AbstractHighLevelQuickFixTes
         public void testValWithSetter() throws Exception {
             runTest("idea/testData/quickfix/variables/changeMutability/valWithSetter.kt");
         }
+
+        @TestMetadata("varAnnotationParameter.kt")
+        public void testVarAnnotationParameter() throws Exception {
+            runTest("idea/testData/quickfix/variables/changeMutability/varAnnotationParameter.kt");
+        }
     }
 }

--- a/idea/testData/quickfix/variables/changeMutability/varAnnotationParameter.kt
+++ b/idea/testData/quickfix/variables/changeMutability/varAnnotationParameter.kt
@@ -1,0 +1,6 @@
+// "Change to val" "true"
+annotation class Ann(
+    val a: Int,
+    var<caret> b: Int
+)
+/* FIR_COMPARISON */

--- a/idea/testData/quickfix/variables/changeMutability/varAnnotationParameter.kt.after
+++ b/idea/testData/quickfix/variables/changeMutability/varAnnotationParameter.kt.after
@@ -1,0 +1,6 @@
+// "Change to val" "true"
+annotation class Ann(
+    val a: Int,
+    val b: Int
+)
+/* FIR_COMPARISON */

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -15167,6 +15167,11 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
                 runTest("idea/testData/quickfix/variables/changeMutability/valWithSetter.kt");
             }
 
+            @TestMetadata("varAnnotationParameter.kt")
+            public void testVarAnnotationParameter() throws Exception {
+                runTest("idea/testData/quickfix/variables/changeMutability/varAnnotationParameter.kt");
+            }
+
             @TestMetadata("idea/testData/quickfix/variables/changeMutability/canBeVal")
             @TestDataPath("$PROJECT_ROOT")
             @RunWith(JUnit3RunnerWithInners.class)


### PR DESCRIPTION
No quickfix test added when error was originally added (https://github.com/JetBrains/kotlin/commit/cffdce908e17022e9feb61c3a86cdca66b956361) so I added one.