### PR TITLE
FIR IDE: Move AddFunctionBodyFix to fe-independent

### DIFF
--- a/idea/idea-frontend-independent/src/org/jetbrains/kotlin/idea/quickfix/AddFunctionBodyFix.kt
+++ b/idea/idea-frontend-independent/src/org/jetbrains/kotlin/idea/quickfix/AddFunctionBodyFix.kt
@@ -1,17 +1,6 @@
 /*
- * Copyright 2010-2015 JetBrains s.r.o.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
 package org.jetbrains.kotlin.idea.quickfix
@@ -25,7 +14,7 @@ import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtPsiFactory
 import org.jetbrains.kotlin.psi.psiUtil.getNonStrictParentOfType
 
-class AddFunctionBodyFix(element: KtFunction) : KotlinQuickFixAction<KtFunction>(element) {
+class AddFunctionBodyFix(element: KtFunction) : KotlinPsiOnlyQuickFixAction<KtFunction>(element) {
     override fun getFamilyName() = KotlinBundle.message("fix.add.function.body")
     override fun getText() = familyName
 


### PR DESCRIPTION
This is a mechanical change. Only logic change is removing the
apparenly unneeded `allowCachedResolveInDispatchThread` check in
`AddFunctionBodyFix.isAvailableImpl()`.