### PR TITLE
FIR checker/IDE: Add checker and quickfix for VAL_WITH_SETTER

### DIFF
--- a/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/diagnostics/FirDiagnosticsList.kt
+++ b/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/diagnostics/FirDiagnosticsList.kt
@@ -322,6 +322,7 @@ object DIAGNOSTICS_LIST : DiagnosticList() {
         val PRIVATE_SETTER_FOR_ABSTRACT_PROPERTY by error<FirSourceElement, KtModifierListOwner>(PositioningStrategy.PRIVATE_MODIFIER)
         val PRIVATE_SETTER_FOR_OPEN_PROPERTY by error<FirSourceElement, KtModifierListOwner>(PositioningStrategy.PRIVATE_MODIFIER)
         val EXPECTED_PRIVATE_DECLARATION by error<FirSourceElement, KtModifierListOwner>(PositioningStrategy.VISIBILITY_MODIFIER)
+        val VAL_WITH_SETTER by error<FirSourceElement, KtPropertyAccessor>()
     }
 
     val MPP_PROJECTS by object : DiagnosticGroup("Multi-platform projects") {

--- a/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/diagnostics/FirErrors.kt
+++ b/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/diagnostics/FirErrors.kt
@@ -217,6 +217,7 @@ object FirErrors {
     val PRIVATE_SETTER_FOR_ABSTRACT_PROPERTY by error0<FirSourceElement, KtModifierListOwner>(SourceElementPositioningStrategies.PRIVATE_MODIFIER)
     val PRIVATE_SETTER_FOR_OPEN_PROPERTY by error0<FirSourceElement, KtModifierListOwner>(SourceElementPositioningStrategies.PRIVATE_MODIFIER)
     val EXPECTED_PRIVATE_DECLARATION by error0<FirSourceElement, KtModifierListOwner>(SourceElementPositioningStrategies.VISIBILITY_MODIFIER)
+    val VAL_WITH_SETTER by error0<FirSourceElement, KtPropertyAccessor>()
 
     // Multi-platform projects
     val EXPECTED_DECLARATION_WITH_BODY by error0<FirSourceElement, KtDeclaration>(SourceElementPositioningStrategies.DECLARATION_SIGNATURE)

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirDeclarationCheckerUtils.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirDeclarationCheckerUtils.kt
@@ -48,6 +48,17 @@ internal fun checkProperty(
     reporter: DiagnosticReporter,
     context: CheckerContext
 ) {
+    checkPropertyInitializer(containingClass, modifierList, property, reporter, context)
+    checkPropertyAccessors(property, reporter, context)
+}
+
+private fun checkPropertyInitializer(
+    containingClass: FirRegularClass?,
+    modifierList: FirModifierList?,
+    property: FirProperty,
+    reporter: DiagnosticReporter,
+    context: CheckerContext
+) {
     val inInterface = containingClass?.isInterface == true
     val hasAbstractModifier = modifierList?.modifiers?.any { it.token == KtTokens.ABSTRACT_KEYWORD } == true
     val isAbstract = property.isAbstract || hasAbstractModifier
@@ -64,12 +75,6 @@ internal fun checkProperty(
     if (inInterface && backingFieldRequired && property.hasAccessorImplementation) {
         property.source?.let {
             reporter.reportOn(it, FirErrors.BACKING_FIELD_IN_INTERFACE, context)
-        }
-    }
-
-    property.setter?.source?.let {
-        if (property.isVal) {
-            reporter.reportOn(it, FirErrors.VAL_WITH_SETTER, context)
         }
     }
 
@@ -123,6 +128,18 @@ internal fun checkProperty(
                     }
                 }
             }
+        }
+    }
+}
+
+private fun checkPropertyAccessors(
+    property: FirProperty,
+    reporter: DiagnosticReporter,
+    context: CheckerContext
+) {
+    property.setter?.source?.let {
+        if (property.isVal) {
+            reporter.reportOn(it, FirErrors.VAL_WITH_SETTER, context)
         }
     }
 }

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirMemberPropertyChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirMemberPropertyChecker.kt
@@ -39,6 +39,10 @@ object FirMemberPropertyChecker : FirRegularClassChecker() {
         // If multiple (potentially conflicting) modality modifiers are specified, not all modifiers are recorded at `status`.
         // So, our source of truth should be the full modifier list retrieved from the source.
         val modifierList = with(FirModifierList) { property.source.getModifierList() }
+
+        checkProperty(containingDeclaration, property, modifierList, reporter, context)
+        checkExpectDeclarationVisibilityAndBody(property, source, modifierList, reporter, context)
+
         val hasAbstractModifier = modifierList?.modifiers?.any { it.token == KtTokens.ABSTRACT_KEYWORD } == true
         val isAbstract = property.isAbstract || hasAbstractModifier
         if (containingDeclaration.isInterface &&
@@ -83,8 +87,6 @@ object FirMemberPropertyChecker : FirRegularClassChecker() {
             }
         }
 
-        checkPropertyInitializer(containingDeclaration, property, reporter, context)
-
         val hasOpenModifier = modifierList?.modifiers?.any { it.token == KtTokens.OPEN_KEYWORD } == true
         if (hasOpenModifier &&
             containingDeclaration.isInterface &&
@@ -104,8 +106,6 @@ object FirMemberPropertyChecker : FirRegularClassChecker() {
                 }
             }
         }
-
-        checkExpectDeclarationVisibilityAndBody(property, source, modifierList, reporter, context)
     }
 
     private fun checkAccessor(

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirTopLevelPropertyChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirTopLevelPropertyChecker.kt
@@ -24,9 +24,11 @@ object FirTopLevelPropertyChecker : FirFileChecker() {
     private fun checkProperty(property: FirProperty, reporter: DiagnosticReporter, context: CheckerContext) {
         val source = property.source ?: return
         if (source.kind is FirFakeSourceElementKind) return
+        // If multiple (potentially conflicting) modality modifiers are specified, not all modifiers are recorded at `status`.
+        // So, our source of truth should be the full modifier list retrieved from the source.
         val modifierList = with(FirModifierList) { source.getModifierList() }
 
-        checkPropertyInitializer(null, property, reporter, context)
+        checkProperty(null, property, modifierList, reporter, context)
         checkExpectDeclarationVisibilityAndBody(property, source, modifierList, reporter, context)
     }
 }

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/FirDefaultErrorMessages.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/FirDefaultErrorMessages.kt
@@ -170,6 +170,7 @@ import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.UNSAFE_OPERATOR_C
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.UNUSED_VARIABLE
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.UPPER_BOUND_VIOLATED
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.USELESS_VARARG_ON_PARAMETER
+import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.VAL_WITH_SETTER
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.VARIABLE_EXPECTED
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.VARIABLE_INITIALIZER_IS_REDUNDANT
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.VARIABLE_NEVER_READ
@@ -477,6 +478,7 @@ class FirDefaultErrorMessages : DefaultErrorMessages.Extension {
             map.put(ABSTRACT_PROPERTY_WITH_SETTER, "Property with setter implementation cannot be abstract")
             map.put(PRIVATE_SETTER_FOR_ABSTRACT_PROPERTY, "Private setters are not allowed for abstract properties")
             map.put(PRIVATE_SETTER_FOR_OPEN_PROPERTY, "Private setters are not allowed for open properties")
+            map.put(VAL_WITH_SETTER, "A 'val'-property cannot have a setter")
 
             // Multi-platform projects
             map.put(EXPECTED_DECLARATION_WITH_BODY, "Expected declaration must not have a body")

--- a/compiler/fir/raw-fir/light-tree2fir/src/org/jetbrains/kotlin/fir/lightTree/converter/DeclarationsConverter.kt
+++ b/compiler/fir/raw-fir/light-tree2fir/src/org/jetbrains/kotlin/fir/lightTree/converter/DeclarationsConverter.kt
@@ -1017,16 +1017,16 @@ class DeclarationsConverter(
                                 it.containingClassAttr = lookupTag
                             }
                         }
-                    this.setter =
-                        if (isVar) {
-                            convertedAccessors.find { it.isSetter }
-                                ?: FirDefaultPropertySetter(
-                                    null, session, FirDeclarationOrigin.Source, returnType, propertyVisibility
-                                ).also {
-                                    currentDispatchReceiverType()?.lookupTag?.let { lookupTag ->
-                                        it.containingClassAttr = lookupTag
-                                    }
+                    // NOTE: We still need the setter even for a val property so we can report errors (e.g., VAL_WITH_SETTER).
+                    this.setter = convertedAccessors.find { it.isSetter }
+                        ?: if (isVar) {
+                            FirDefaultPropertySetter(
+                                null, session, FirDeclarationOrigin.Source, returnType, propertyVisibility
+                            ).also {
+                                currentDispatchReceiverType()?.lookupTag?.let { lookupTag ->
+                                    it.containingClassAttr = lookupTag
                                 }
+                            }
                         } else null
 
                     // Upward propagation of `inline` and `external` modifiers (from accessors to property)

--- a/compiler/fir/raw-fir/light-tree2fir/tests/org/jetbrains/kotlin/fir/lightTree/TotalKotlinTest.kt
+++ b/compiler/fir/raw-fir/light-tree2fir/tests/org/jetbrains/kotlin/fir/lightTree/TotalKotlinTest.kt
@@ -80,7 +80,7 @@ class TotalKotlinTest : AbstractRawFirBuilderTestCase() {
         println("BASE PATH: $path")
         for (file in root.walkTopDown()) {
             if (file.isDirectory) continue
-            if (file.path.contains("testData") || file.path.contains("resources")) continue
+            if (file.path.toLowerCase().contains("testdata") || file.path.contains("resources")) continue
             if (file.extension != "kt") continue
 
             val text = FileUtil.loadFile(file, CharsetToolkit.UTF8, true).trim()

--- a/compiler/fir/raw-fir/psi2fir/tests/org/jetbrains/kotlin/fir/builder/RawFirBuilderTotalKotlinTestCase.kt
+++ b/compiler/fir/raw-fir/psi2fir/tests/org/jetbrains/kotlin/fir/builder/RawFirBuilderTotalKotlinTestCase.kt
@@ -52,8 +52,8 @@ class RawFirBuilderTotalKotlinTestCase : AbstractRawFirBuilderTestCase() {
         println("BASE PATH: $testDataPath")
         for (file in root.walkTopDown()) {
             if (file.isDirectory) continue
-            val path = file.path
-            if ("testData" in path || "resources" in path || "api/js" in path.replace('\\', '/')) continue
+            val path = file.path.toLowerCase()
+            if ("testdata" in path || "resources" in path || "api/js" in path.replace('\\', '/')) continue
             if (file.extension != "kt") continue
             try {
                 val ktFile = createKtFile(file.toRelativeString(root))
@@ -157,11 +157,11 @@ class RawFirBuilderTotalKotlinTestCase : AbstractRawFirBuilderTestCase() {
         println("KT DECLARATIONS: $ktDeclarations")
         println("KT REFERENCES: $ktReferences")
         if (!stubMode) {
-            assertEquals(0, expressionStubs)
+            assertEquals("# of expression stubs", 0, expressionStubs)
         }
-        assertEquals(0, errorExpressions)
-        assertEquals(0, errorDeclarations)
-        assertEquals(0, errorReferences)
+        assertEquals("# of error expressions", 0, errorExpressions)
+        assertEquals("# of error declarations", 0, errorDeclarations)
+        assertEquals("# of error references", 0, errorReferences)
     }
 
     fun testTotalKotlinWithExpressionTrees() {
@@ -176,8 +176,8 @@ class RawFirBuilderTotalKotlinTestCase : AbstractRawFirBuilderTestCase() {
         val root = File(testDataPath)
         for (file in root.walkTopDown()) {
             if (file.isDirectory) continue
-            val path = file.path
-            if ("testData" in path || "resources" in path || "api/js" in path.replace('\\', '/')) continue
+            val path = file.path.toLowerCase()
+            if ("testdata" in path || "resources" in path || "api/js" in path.replace('\\', '/')) continue
             if (file.extension != "kt") continue
             val ktFile = createKtFile(file.toRelativeString(root))
             val firFile = ktFile.toFirFile()
@@ -203,8 +203,8 @@ class RawFirBuilderTotalKotlinTestCase : AbstractRawFirBuilderTestCase() {
         var counter = 0
         for (file in root.walkTopDown()) {
             if (file.isDirectory) continue
-            val path = file.path
-            if ("testData" in path || "testdata" in path || "resources" in path || "api/js" in path.replace('\\', '/')) continue
+            val path = file.path.toLowerCase()
+            if ("testdata" in path || "resources" in path || "api/js" in path.replace('\\', '/')) continue
             if (file.extension != "kt") continue
             val ktFile = createKtFile(file.toRelativeString(root))
             val firFile: FirFile = ktFile.toFirFile()

--- a/compiler/testData/diagnostics/tests/Properties.fir.kt
+++ b/compiler/testData/diagnostics/tests/Properties.fir.kt
@@ -7,7 +7,7 @@ var x : Int = 1 + x
 
  val xx : Int = <!PROPERTY_INITIALIZER_NO_BACKING_FIELD!>1 + x<!>
    get() : Int = 1
-   set(value : Long) {}
+   <!VAL_WITH_SETTER!>set(value : Long) {}<!>
 
   val p : Int = <!PROPERTY_INITIALIZER_NO_BACKING_FIELD!>1<!>
     get() = 1

--- a/idea/idea-completion/testData/basic/common/CompletionInSetter.kt
+++ b/idea/idea-completion/testData/basic/common/CompletionInSetter.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 val a: Int = 1
     get() {
       return field

--- a/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/MainKtQuickFixRegistrar.kt
+++ b/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/MainKtQuickFixRegistrar.kt
@@ -48,6 +48,7 @@ class MainKtQuickFixRegistrar : KtQuickFixRegistrar() {
         registerPsiQuickFixes(KtFirDiagnostic.VarOverriddenByVal::class, ChangeVariableMutabilityFix.VAR_OVERRIDDEN_BY_VAL_FACTORY)
         registerPsiQuickFixes(KtFirDiagnostic.VarAnnotationParameter::class, ChangeVariableMutabilityFix.VAR_ANNOTATION_PARAMETER_FACTORY)
         registerPsiQuickFixes(KtFirDiagnostic.InapplicableLateinitModifier::class, ChangeVariableMutabilityFix.LATEINIT_VAL_FACTORY)
+        registerPsiQuickFixes(KtFirDiagnostic.ValWithSetter::class, ChangeVariableMutabilityFix.VAL_WITH_SETTER_FACTORY)
     }
 
     override val list: KtQuickFixesList = KtQuickFixesList.createCombined(

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDataClassConverters.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDataClassConverters.kt
@@ -945,6 +945,12 @@ internal val KT_DIAGNOSTIC_CONVERTER = KtDiagnosticConverterBuilder.buildConvert
             token,
         )
     }
+    add(FirErrors.VAL_WITH_SETTER) { firDiagnostic ->
+        ValWithSetterImpl(
+            firDiagnostic as FirPsiDiagnostic<*>,
+            token,
+        )
+    }
     add(FirErrors.EXPECTED_DECLARATION_WITH_BODY) { firDiagnostic ->
         ExpectedDeclarationWithBodyImpl(
             firDiagnostic as FirPsiDiagnostic<*>,

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnostics.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnostics.kt
@@ -665,6 +665,10 @@ sealed class KtFirDiagnostic<PSI: PsiElement> : KtDiagnosticWithPsi<PSI> {
         override val diagnosticClass get() = ExpectedPrivateDeclaration::class
     }
 
+    abstract class ValWithSetter : KtFirDiagnostic<KtPropertyAccessor>() {
+        override val diagnosticClass get() = ValWithSetter::class
+    }
+
     abstract class ExpectedDeclarationWithBody : KtFirDiagnostic<KtDeclaration>() {
         override val diagnosticClass get() = ExpectedDeclarationWithBody::class
     }

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnosticsImpl.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnosticsImpl.kt
@@ -1074,6 +1074,13 @@ internal class ExpectedPrivateDeclarationImpl(
     override val firDiagnostic: FirPsiDiagnostic<*> by weakRef(firDiagnostic)
 }
 
+internal class ValWithSetterImpl(
+    firDiagnostic: FirPsiDiagnostic<*>,
+    override val token: ValidityToken,
+) : KtFirDiagnostic.ValWithSetter(), KtAbstractFirDiagnostic<KtPropertyAccessor> {
+    override val firDiagnostic: FirPsiDiagnostic<*> by weakRef(firDiagnostic)
+}
+
 internal class ExpectedDeclarationWithBodyImpl(
     firDiagnostic: FirPsiDiagnostic<*>,
     override val token: ValidityToken,

--- a/idea/testData/quickfix/variables/changeMutability/valWithSetter.kt
+++ b/idea/testData/quickfix/variables/changeMutability/valWithSetter.kt
@@ -3,3 +3,4 @@ class A() {
     val a: Int = 0
         <caret>set(v: Int) {}
 }
+/* FIR_COMPARISON */

--- a/idea/testData/quickfix/variables/changeMutability/valWithSetter.kt.after
+++ b/idea/testData/quickfix/variables/changeMutability/valWithSetter.kt.after
@@ -3,3 +3,4 @@ class A() {
     var a: Int = 0
         set(v: Int) {}
 }
+/* FIR_COMPARISON */


### PR DESCRIPTION
The changes to FIR building were necessary as no `FirPropertyAccessor` was created for a setter inside a `val` property.