### PR TITLE
Provide quickfix for wrong `external` modifier on declarations

### DIFF
--- a/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/ExternalFunChecker.kt
+++ b/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/ExternalFunChecker.kt
@@ -23,8 +23,8 @@ import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtDeclarationWithBody
 import org.jetbrains.kotlin.psi.KtPropertyAccessor
 import org.jetbrains.kotlin.resolve.DescriptorUtils
-import org.jetbrains.kotlin.resolve.checkers.DeclarationCheckerContext
 import org.jetbrains.kotlin.resolve.checkers.DeclarationChecker
+import org.jetbrains.kotlin.resolve.checkers.DeclarationCheckerContext
 import org.jetbrains.kotlin.resolve.inline.InlineUtil
 import org.jetbrains.kotlin.resolve.jvm.diagnostics.ErrorsJvm
 
@@ -39,7 +39,9 @@ class ExternalFunChecker : DeclarationChecker {
                 is ClassDescriptor -> "class"
                 else -> "non-function declaration"
             }
-            trace.report(Errors.WRONG_MODIFIER_TARGET.on(declaration, KtTokens.EXTERNAL_KEYWORD, target))
+            declaration.modifierList?.getModifier(KtTokens.EXTERNAL_KEYWORD)?.let {
+                trace.report(Errors.WRONG_MODIFIER_TARGET.on(it, KtTokens.EXTERNAL_KEYWORD, target))
+            }
             return
         }
 

--- a/compiler/testData/diagnostics/testsWithStdLib/native/nonFunction.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/native/nonFunction.kt
@@ -1,9 +1,9 @@
-<!WRONG_MODIFIER_TARGET!>external class A<!>
+<!WRONG_MODIFIER_TARGET!>external<!> class A
 
-<!WRONG_MODIFIER_TARGET!>external val foo: Int = 23<!>
+<!WRONG_MODIFIER_TARGET!>external<!> val foo: Int = 23
 
 class B {
-    <!WRONG_MODIFIER_TARGET!>external class A<!>
+    <!WRONG_MODIFIER_TARGET!>external<!> class A
 
-    <!WRONG_MODIFIER_TARGET!>external val foo: Int = 23<!>
+    <!WRONG_MODIFIER_TARGET!>external<!> val foo: Int = 23
 }

--- a/idea/idea-fir/tests/org/jetbrains/kotlin/idea/quickfix/HighLevelQuickFixTestGenerated.java
+++ b/idea/idea-fir/tests/org/jetbrains/kotlin/idea/quickfix/HighLevelQuickFixTestGenerated.java
@@ -274,6 +274,11 @@ public class HighLevelQuickFixTestGenerated extends AbstractHighLevelQuickFixTes
             runTest("idea/testData/quickfix/modifiers/removeConst.kt");
         }
 
+        @TestMetadata("removeExternalModifier.kt")
+        public void testRemoveExternalModifier() throws Exception {
+            runTest("idea/testData/quickfix/modifiers/removeExternalModifier.kt");
+        }
+
         @TestMetadata("removeIncompatibleModifier.kt")
         public void testRemoveIncompatibleModifier() throws Exception {
             runTest("idea/testData/quickfix/modifiers/removeIncompatibleModifier.kt");

--- a/idea/testData/quickfix/modifiers/removeExternalModifier.kt
+++ b/idea/testData/quickfix/modifiers/removeExternalModifier.kt
@@ -1,0 +1,5 @@
+// "Remove 'external' modifier" "true"
+
+class B {
+    <caret>external val foo: Int = 23
+}

--- a/idea/testData/quickfix/modifiers/removeExternalModifier.kt.after
+++ b/idea/testData/quickfix/modifiers/removeExternalModifier.kt.after
@@ -1,0 +1,5 @@
+// "Remove 'external' modifier" "true"
+
+class B {
+    val foo: Int = 23
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -9412,6 +9412,11 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
             runTest("idea/testData/quickfix/modifiers/removeConst.kt");
         }
 
+        @TestMetadata("removeExternalModifier.kt")
+        public void testRemoveExternalModifier() throws Exception {
+            runTest("idea/testData/quickfix/modifiers/removeExternalModifier.kt");
+        }
+
         @TestMetadata("removeIncompatibleModifier.kt")
         public void testRemoveIncompatibleModifier() throws Exception {
             runTest("idea/testData/quickfix/modifiers/removeIncompatibleModifier.kt");


### PR DESCRIPTION
Report `WRONG_MODIFIER_TARGET` on the modifier instead of the declaration in `ExternalFunChecker`. This allows `RemoveModifierFix` to provide a quickfix to remove it.