### PR TITLE
IR: fix typo in KotlinIr.proto

### DIFF
--- a/compiler/ir/serialization.common/src/KotlinIr.proto
+++ b/compiler/ir/serialization.common/src/KotlinIr.proto
@@ -361,7 +361,7 @@ message IrDynamicOperatorExpression {
   repeated IrExpression argument = 3;
 }
 
-// TODO: we need an extension mechanism to accomodate new
+// TODO: we need an extension mechanism to accommodate new
 // IR operators in upcoming releases.
 message IrOperation {
   oneof operation {
@@ -530,7 +530,7 @@ message IrAnonymousInit {
   required int32 body = 2;
 }
 
-// TODO: we need an extension mechanism to accomodate new
+// TODO: we need an extension mechanism to accommodate new
 // IR operators in upcoming releases.
 
 message IrDeclaration {


### PR DESCRIPTION
accomodate -> accommodate