### PR TITLE
JS parser: fix typo in LineBuffer.java

### DIFF
--- a/js/js.parser/src/com/google/gwt/dev/js/rhino/LineBuffer.java
+++ b/js/js.parser/src/com/google/gwt/dev/js/rhino/LineBuffer.java
@@ -258,7 +258,7 @@ final class LineBuffer {
         if (lineStart >= 0) {
             otherStart = lineStart;
         } else {
-            // discard beging of the old line
+            // discard beginning of the old line
             otherStart = 0;
         }
 


### PR DESCRIPTION
beging -> beginning