### PR TITLE
[JVM_IR] Do not generate property reference setter if inaccessible.

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -26816,6 +26816,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         }
 
         @Test
+        @TestMetadata("accessorForPropertyWithPrivateSetter.kt")
+        public void testAccessorForPropertyWithPrivateSetter() throws Exception {
+            runTest("compiler/testData/codegen/box/properties/accessorForPropertyWithPrivateSetter.kt");
+        }
+
+        @Test
         @TestMetadata("accessorForProtectedPropertyWithPrivateSetter.kt")
         public void testAccessorForProtectedPropertyWithPrivateSetter() throws Exception {
             runTest("compiler/testData/codegen/box/properties/accessorForProtectedPropertyWithPrivateSetter.kt");

--- a/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/ReflectionReferencesGenerator.kt
+++ b/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/ReflectionReferencesGenerator.kt
@@ -16,10 +16,7 @@
 
 package org.jetbrains.kotlin.psi2ir.generators
 
-import org.jetbrains.kotlin.builtins.KotlinBuiltIns
-import org.jetbrains.kotlin.builtins.createFunctionType
-import org.jetbrains.kotlin.builtins.isKFunctionType
-import org.jetbrains.kotlin.builtins.isKSuspendFunctionType
+import org.jetbrains.kotlin.builtins.*
 import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.ir.declarations.DescriptorMetadataSource
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
@@ -382,7 +379,7 @@ class ReflectionReferencesGenerator(statementGenerator: StatementGenerator) : St
                 generateFunctionReference(startOffset, endOffset, type, symbol, callableDescriptor, typeArguments, origin)
             }
             is PropertyDescriptor -> {
-                val mutable = get(BindingContext.VARIABLE, ktElement)?.isVar ?: true
+                val mutable = ReflectionTypes.isNumberedKMutablePropertyType(type)
                 generatePropertyReference(startOffset, endOffset, type, callableDescriptor, typeArguments, origin, mutable)
             }
             else ->

--- a/compiler/testData/codegen/box/properties/accessorForPropertyWithPrivateSetter.kt
+++ b/compiler/testData/codegen/box/properties/accessorForPropertyWithPrivateSetter.kt
@@ -1,0 +1,19 @@
+// IGNORE_BACKEND: WASM
+
+// WITH_RUNTIME
+// FILE: b.kt
+import a.A
+
+class B {
+    fun getValue() = sequenceOf(A()).map(A::value).first()
+}
+
+fun box() = B().getValue()
+
+// FILE: a.kt
+package a
+
+class A {
+    var value: String = "OK"
+        private set
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -26816,6 +26816,12 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
         }
 
         @Test
+        @TestMetadata("accessorForPropertyWithPrivateSetter.kt")
+        public void testAccessorForPropertyWithPrivateSetter() throws Exception {
+            runTest("compiler/testData/codegen/box/properties/accessorForPropertyWithPrivateSetter.kt");
+        }
+
+        @Test
         @TestMetadata("accessorForProtectedPropertyWithPrivateSetter.kt")
         public void testAccessorForProtectedPropertyWithPrivateSetter() throws Exception {
             runTest("compiler/testData/codegen/box/properties/accessorForProtectedPropertyWithPrivateSetter.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -26816,6 +26816,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         }
 
         @Test
+        @TestMetadata("accessorForPropertyWithPrivateSetter.kt")
+        public void testAccessorForPropertyWithPrivateSetter() throws Exception {
+            runTest("compiler/testData/codegen/box/properties/accessorForPropertyWithPrivateSetter.kt");
+        }
+
+        @Test
         @TestMetadata("accessorForProtectedPropertyWithPrivateSetter.kt")
         public void testAccessorForProtectedPropertyWithPrivateSetter() throws Exception {
             runTest("compiler/testData/codegen/box/properties/accessorForProtectedPropertyWithPrivateSetter.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -22855,6 +22855,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/properties/accessToPrivateSetter.kt");
         }
 
+        @TestMetadata("accessorForPropertyWithPrivateSetter.kt")
+        public void testAccessorForPropertyWithPrivateSetter() throws Exception {
+            runTest("compiler/testData/codegen/box/properties/accessorForPropertyWithPrivateSetter.kt");
+        }
+
         @TestMetadata("accessorForProtectedPropertyWithPrivateSetter.kt")
         public void testAccessorForProtectedPropertyWithPrivateSetter() throws Exception {
             runTest("compiler/testData/codegen/box/properties/accessorForProtectedPropertyWithPrivateSetter.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
@@ -18195,6 +18195,11 @@ public class IrJsCodegenBoxES6TestGenerated extends AbstractIrJsCodegenBoxES6Tes
             runTest("compiler/testData/codegen/box/properties/accessToPrivateSetter.kt");
         }
 
+        @TestMetadata("accessorForPropertyWithPrivateSetter.kt")
+        public void testAccessorForPropertyWithPrivateSetter() throws Exception {
+            runTest("compiler/testData/codegen/box/properties/accessorForPropertyWithPrivateSetter.kt");
+        }
+
         @TestMetadata("accessorForProtectedPropertyWithPrivateSetter.kt")
         public void testAccessorForProtectedPropertyWithPrivateSetter() throws Exception {
             runTest("compiler/testData/codegen/box/properties/accessorForProtectedPropertyWithPrivateSetter.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -17680,6 +17680,11 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/properties/accessToPrivateSetter.kt");
         }
 
+        @TestMetadata("accessorForPropertyWithPrivateSetter.kt")
+        public void testAccessorForPropertyWithPrivateSetter() throws Exception {
+            runTest("compiler/testData/codegen/box/properties/accessorForPropertyWithPrivateSetter.kt");
+        }
+
         @TestMetadata("accessorForProtectedPropertyWithPrivateSetter.kt")
         public void testAccessorForProtectedPropertyWithPrivateSetter() throws Exception {
             runTest("compiler/testData/codegen/box/properties/accessorForProtectedPropertyWithPrivateSetter.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -17745,6 +17745,11 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/properties/accessToPrivateSetter.kt");
         }
 
+        @TestMetadata("accessorForPropertyWithPrivateSetter.kt")
+        public void testAccessorForPropertyWithPrivateSetter() throws Exception {
+            runTest("compiler/testData/codegen/box/properties/accessorForPropertyWithPrivateSetter.kt");
+        }
+
         @TestMetadata("accessorForProtectedPropertyWithPrivateSetter.kt")
         public void testAccessorForProtectedPropertyWithPrivateSetter() throws Exception {
             runTest("compiler/testData/codegen/box/properties/accessorForProtectedPropertyWithPrivateSetter.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/wasm/semantics/IrCodegenBoxWasmTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/wasm/semantics/IrCodegenBoxWasmTestGenerated.java
@@ -11292,6 +11292,11 @@ public class IrCodegenBoxWasmTestGenerated extends AbstractIrCodegenBoxWasmTest 
             runTest("compiler/testData/codegen/box/properties/accessToPrivateProperty.kt");
         }
 
+        @TestMetadata("accessorForPropertyWithPrivateSetter.kt")
+        public void testAccessorForPropertyWithPrivateSetter() throws Exception {
+            runTest("compiler/testData/codegen/box/properties/accessorForPropertyWithPrivateSetter.kt");
+        }
+
         @TestMetadata("accessorForProtectedPropertyWithPrivateSetter.kt")
         public void testAccessorForProtectedPropertyWithPrivateSetter() throws Exception {
             runTest("compiler/testData/codegen/box/properties/accessorForProtectedPropertyWithPrivateSetter.kt");


### PR DESCRIPTION
Fixes KT-45064.