### PR TITLE
IDE FIR: fix resolving vararg parameter type

### DIFF
--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/types/impl/FirUserTypeRefImpl.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/types/impl/FirUserTypeRefImpl.kt
@@ -16,7 +16,7 @@ import org.jetbrains.kotlin.fir.visitors.FirVisitor
 import org.jetbrains.kotlin.fir.visitors.transformInplace
 
 class FirUserTypeRefImpl(
-    override val source: FirSourceElement?,
+    override var source: FirSourceElement?,
     override val isMarkedNullable: Boolean,
     override val qualifier: MutableList<FirQualifierPart>,
     override val annotations: MutableList<FirAnnotationCall>
@@ -43,5 +43,6 @@ class FirUserTypeRefImpl(
     }
 
     override fun replaceSource(newSource: FirSourceElement?) {
+        source = newSource
     }
 }

--- a/idea/idea-fir/tests/org/jetbrains/kotlin/idea/resolve/FirReferenceResolveTestGenerated.java
+++ b/idea/idea-fir/tests/org/jetbrains/kotlin/idea/resolve/FirReferenceResolveTestGenerated.java
@@ -219,6 +219,11 @@ public class FirReferenceResolveTestGenerated extends AbstractFirReferenceResolv
         runTest("idea/testData/resolve/references/InMethodParameter.kt");
     }
 
+    @TestMetadata("InMethodVarargParameter.kt")
+    public void testInMethodVarargParameter() throws Exception {
+        runTest("idea/testData/resolve/references/InMethodVarargParameter.kt");
+    }
+
     @TestMetadata("InObjectClassObject.kt")
     public void testInObjectClassObject() throws Exception {
         runTest("idea/testData/resolve/references/InObjectClassObject.kt");
@@ -227,6 +232,16 @@ public class FirReferenceResolveTestGenerated extends AbstractFirReferenceResolv
     @TestMetadata("InSecondClassObject.kt")
     public void testInSecondClassObject() throws Exception {
         runTest("idea/testData/resolve/references/InSecondClassObject.kt");
+    }
+
+    @TestMetadata("InVaragReferenceInFunctionBody.kt")
+    public void testInVaragReferenceInFunctionBody() throws Exception {
+        runTest("idea/testData/resolve/references/InVaragReferenceInFunctionBody.kt");
+    }
+
+    @TestMetadata("InVaragReferenceInNamedParameter.kt")
+    public void testInVaragReferenceInNamedParameter() throws Exception {
+        runTest("idea/testData/resolve/references/InVaragReferenceInNamedParameter.kt");
     }
 
     @TestMetadata("JavaAnnotationParameter.kt")

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDataClassConverters.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDataClassConverters.kt
@@ -24,6 +24,7 @@ import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtIfExpression
 import org.jetbrains.kotlin.psi.KtModifierListOwner
 import org.jetbrains.kotlin.psi.KtNamedDeclaration
+import org.jetbrains.kotlin.psi.KtObjectDeclaration
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtPropertyAccessor

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnostics.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnostics.kt
@@ -28,6 +28,7 @@ import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtIfExpression
 import org.jetbrains.kotlin.psi.KtModifierListOwner
 import org.jetbrains.kotlin.psi.KtNamedDeclaration
+import org.jetbrains.kotlin.psi.KtObjectDeclaration
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtPropertyAccessor
@@ -534,7 +535,7 @@ sealed class KtFirDiagnostic<PSI: PsiElement> : KtDiagnosticWithPsi<PSI> {
         override val diagnosticClass get() = NonFinalMemberInObject::class
     }
 
-    abstract class ManyCompanionObjects : KtFirDiagnostic<PsiElement>() {
+    abstract class ManyCompanionObjects : KtFirDiagnostic<KtObjectDeclaration>() {
         override val diagnosticClass get() = ManyCompanionObjects::class
     }
 

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnosticsImpl.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnosticsImpl.kt
@@ -30,6 +30,7 @@ import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtIfExpression
 import org.jetbrains.kotlin.psi.KtModifierListOwner
 import org.jetbrains.kotlin.psi.KtNamedDeclaration
+import org.jetbrains.kotlin.psi.KtObjectDeclaration
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtPropertyAccessor
@@ -856,7 +857,7 @@ internal class NonFinalMemberInObjectImpl(
 internal class ManyCompanionObjectsImpl(
     firDiagnostic: FirPsiDiagnostic<*>,
     override val token: ValidityToken,
-) : KtFirDiagnostic.ManyCompanionObjects(), KtAbstractFirDiagnostic<PsiElement> {
+) : KtFirDiagnostic.ManyCompanionObjects(), KtAbstractFirDiagnostic<KtObjectDeclaration> {
     override val firDiagnostic: FirPsiDiagnostic<*> by weakRef(firDiagnostic)
 }
 

--- a/idea/testData/resolve/references/InMethodVarargParameter.kt
+++ b/idea/testData/resolve/references/InMethodVarargParameter.kt
@@ -1,0 +1,9 @@
+package test
+
+class A
+
+class Test {
+    fun some(vararg a: <caret>A) = 12
+}
+
+// REF: (test).A

--- a/idea/testData/resolve/references/InVaragReferenceInFunctionBody.kt
+++ b/idea/testData/resolve/references/InVaragReferenceInFunctionBody.kt
@@ -1,0 +1,9 @@
+package test
+
+class A
+
+class Test {
+    fun some(vararg a: A) = <caret>a
+}
+
+// REF: a

--- a/idea/testData/resolve/references/InVaragReferenceInNamedParameter.kt
+++ b/idea/testData/resolve/references/InVaragReferenceInNamedParameter.kt
@@ -1,0 +1,10 @@
+package test
+
+class A
+
+class Test {
+    fun some(vararg a: A) {}
+    fun call() = some(<caret>a = arrayOf(A()))
+}
+
+// REF: a

--- a/idea/tests/org/jetbrains/kotlin/idea/resolve/ReferenceResolveTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/resolve/ReferenceResolveTestGenerated.java
@@ -219,6 +219,11 @@ public class ReferenceResolveTestGenerated extends AbstractReferenceResolveTest 
         runTest("idea/testData/resolve/references/InMethodParameter.kt");
     }
 
+    @TestMetadata("InMethodVarargParameter.kt")
+    public void testInMethodVarargParameter() throws Exception {
+        runTest("idea/testData/resolve/references/InMethodVarargParameter.kt");
+    }
+
     @TestMetadata("InObjectClassObject.kt")
     public void testInObjectClassObject() throws Exception {
         runTest("idea/testData/resolve/references/InObjectClassObject.kt");
@@ -227,6 +232,16 @@ public class ReferenceResolveTestGenerated extends AbstractReferenceResolveTest 
     @TestMetadata("InSecondClassObject.kt")
     public void testInSecondClassObject() throws Exception {
         runTest("idea/testData/resolve/references/InSecondClassObject.kt");
+    }
+
+    @TestMetadata("InVaragReferenceInFunctionBody.kt")
+    public void testInVaragReferenceInFunctionBody() throws Exception {
+        runTest("idea/testData/resolve/references/InVaragReferenceInFunctionBody.kt");
+    }
+
+    @TestMetadata("InVaragReferenceInNamedParameter.kt")
+    public void testInVaragReferenceInNamedParameter() throws Exception {
+        runTest("idea/testData/resolve/references/InVaragReferenceInNamedParameter.kt");
     }
 
     @TestMetadata("JavaAnnotationParameter.kt")


### PR DESCRIPTION
For a vararg parameter type, there corresponding FIR element has a fake
source of kind ArrayTypeFromVarargParameter. As a result,
`getOrBuildFir` returns the whole `FirValueParameter` for the parameter
type reference. Therefore, we need some special handling for this case
in order to resolve the proper `KtSymbol`.