### PR TITLE
CLI: Report a readable diagnostic on empty -J argument in CLI.

### DIFF
--- a/compiler/cli/bin/kotlinc
+++ b/compiler/cli/bin/kotlinc
@@ -52,6 +52,10 @@ while [ $# -gt 0 ]; do
       ;;
     -J*)
       java_args=("${java_args[@]}" "${1:2}")
+      if [ "x${1:2}" = "x" ]; then
+        echo "error: empty -J argument"
+        exit 1
+      fi
       shift
       ;;
     *)

--- a/compiler/cli/bin/kotlinc.bat
+++ b/compiler/cli/bin/kotlinc.bat
@@ -28,6 +28,10 @@ set _arg=%~1
 if "%_arg%" == "" goto loopend
 
 if "%_arg:~0,2%"=="-J" (
+  if "%_arg:~2%"=="" (
+    echo error: empty -J argument
+    goto error
+  )
   set JAVA_OPTS=%JAVA_OPTS% "%_arg:~2%"
 ) else (
   if "%_arg:~0,2%"=="-D" (
@@ -67,7 +71,6 @@ if "!_KOTLIN_RUNNER!"=="1" (
     %_KOTLIN_COMPILER% %KOTLIN_OPTS%
 )
 
-exit /b %ERRORLEVEL%
 goto end
 
 rem ##########################################################################
@@ -103,5 +106,8 @@ rem Needs to be executed in the EnableDelayedExpansion mode.
   )
 goto :eof
 
+:error
+set ERRORLEVEL=1
+
 :end
-endlocal
+exit /b %ERRORLEVEL%

--- a/compiler/tests/org/jetbrains/kotlin/cli/LauncherScriptTest.kt
+++ b/compiler/tests/org/jetbrains/kotlin/cli/LauncherScriptTest.kt
@@ -349,4 +349,14 @@ fun f() : Result<Int> = Result.success(42)
             expectedStdout = "[OK]\n", environment = jdk15,
         )
     }
+
+    fun testEmptyJArgument() {
+        runProcess(
+            "kotlinc",
+            "$testDataDirectory/helloWorld.kt",
+            "-d", tmpdir.path,
+            "-J", expectedStdout = "error: empty -J argument\n",
+            expectedExitCode = 1
+        )
+    }
 }


### PR DESCRIPTION
Related to [KT-40977](https://youtrack.jetbrains.com/issue/KT-40977)