### PR TITLE
JVM: Add FILE target to the JvmSynthetic annotation (KT-41884)

### DIFF
--- a/compiler/testData/writeFlags/class/accessFlags/syntheticFile.kt
+++ b/compiler/testData/writeFlags/class/accessFlags/syntheticFile.kt
@@ -1,6 +1,5 @@
 // WITH_RUNTIME
 // FILE: test.kt
-@file:Suppress("WRONG_ANNOTATION_TARGET_WITH_USE_SITE_TARGET")
 @file:JvmSynthetic
 
 private val keepme = 1

--- a/libraries/stdlib/common/src/kotlin/JvmAnnotationsH.kt
+++ b/libraries/stdlib/common/src/kotlin/JvmAnnotationsH.kt
@@ -13,7 +13,7 @@ import kotlin.annotation.AnnotationTarget.*
  * If a method has N parameters and M of which have default values, M overloads are generated: the first one
  * takes N-1 parameters (all but the last one that takes a default value), the second takes N-2 parameters, and so on.
  */
-@Target(AnnotationTarget.FUNCTION, AnnotationTarget.CONSTRUCTOR)
+@Target(FUNCTION, CONSTRUCTOR)
 @MustBeDocumented
 @OptionalExpectation
 public expect annotation class JvmOverloads()
@@ -25,7 +25,7 @@ public expect annotation class JvmOverloads()
  * See the [Kotlin language documentation](https://kotlinlang.org/docs/reference/java-to-kotlin-interop.html#static-methods)
  * for more information.
  */
-@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)
+@Target(FUNCTION, PROPERTY, PROPERTY_GETTER, PROPERTY_SETTER)
 @MustBeDocumented
 @OptionalExpectation
 public expect annotation class JvmStatic()
@@ -37,7 +37,7 @@ public expect annotation class JvmStatic()
  * for more information.
  * @property name the name of the element.
  */
-@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER, AnnotationTarget.FILE)
+@Target(FILE, FUNCTION, PROPERTY_GETTER, PROPERTY_SETTER)
 @MustBeDocumented
 @OptionalExpectation
 public expect annotation class JvmName(val name: String)
@@ -46,11 +46,10 @@ public expect annotation class JvmName(val name: String)
  * Instructs the Kotlin compiler to generate a multifile class with top-level functions and properties declared in this file as one of its parts.
  * Name of the corresponding multifile class is provided by the [JvmName] annotation.
  */
-@Target(AnnotationTarget.FILE)
+@Target(FILE)
 @MustBeDocumented
 @OptionalExpectation
 public expect annotation class JvmMultifileClass()
-
 
 
 /**
@@ -59,7 +58,7 @@ public expect annotation class JvmMultifileClass()
  * See the [Kotlin language documentation](https://kotlinlang.org/docs/reference/java-to-kotlin-interop.html#instance-fields)
  * for more information.
  */
-@Target(AnnotationTarget.FIELD)
+@Target(FIELD)
 @MustBeDocumented
 @OptionalExpectation
 public expect annotation class JvmField()
@@ -73,7 +72,7 @@ public expect annotation class JvmField()
  * This annotation is intended for *rare cases* when API designer needs to hide Kotlin-specific target from Java API
  * while keeping it a part of Kotlin API so the resulting API is idiomatic for both languages.
  */
-@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER, AnnotationTarget.FIELD)
+@Target(FILE, FUNCTION, PROPERTY_GETTER, PROPERTY_SETTER, FIELD)
 @OptionalExpectation
 public expect annotation class JvmSynthetic()
 
@@ -86,7 +85,7 @@ public expect annotation class JvmSynthetic()
  *
  * It may be helpful only if declaration seems to be inconvenient to use from Java.
  */
-@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY, AnnotationTarget.TYPE)
+@Target(CLASS, FUNCTION, PROPERTY, TYPE)
 @MustBeDocumented
 @OptionalExpectation
 public expect annotation class JvmSuppressWildcards(val suppress: Boolean = true)
@@ -96,7 +95,7 @@ public expect annotation class JvmSuppressWildcards(val suppress: Boolean = true
  *
  * It may be helpful only if declaration seems to be inconvenient to use from Java without wildcard.
  */
-@Target(AnnotationTarget.TYPE)
+@Target(TYPE)
 @MustBeDocumented
 @OptionalExpectation
 public expect annotation class JvmWildcard()
@@ -118,7 +117,7 @@ public expect annotation class JvmInline()
  * Instructs compiler to mark the class as a record and generate relevant toString/equals/hashCode methods
  */
 @Suppress("NEWER_VERSION_IN_SINCE_KOTLIN")
-@Target(AnnotationTarget.CLASS)
+@Target(CLASS)
 @MustBeDocumented
 @OptionalExpectation
 @SinceKotlin("1.5")
@@ -163,7 +162,7 @@ public expect annotation class Strictfp()
 public expect annotation class Synchronized()
 
 
-@Target(AnnotationTarget.FILE)
+@Target(FILE)
 @Retention(AnnotationRetention.SOURCE)
 @MustBeDocumented
 @SinceKotlin("1.2")

--- a/libraries/stdlib/jvm/runtime/kotlin/jvm/annotations/JvmPlatformAnnotations.kt
+++ b/libraries/stdlib/jvm/runtime/kotlin/jvm/annotations/JvmPlatformAnnotations.kt
@@ -72,7 +72,7 @@ internal actual annotation class JvmPackageName(actual val name: String)
  * This annotation is intended for *rare cases* when API designer needs to hide Kotlin-specific target from Java API
  * while keeping it a part of Kotlin API so the resulting API is idiomatic for both languages.
  */
-@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER, AnnotationTarget.FIELD)
+@Target(AnnotationTarget.FILE, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER, AnnotationTarget.FIELD)
 @Retention(AnnotationRetention.SOURCE)
 public actual annotation class JvmSynthetic
 


### PR DESCRIPTION
This is a follow up to #3818 with the standard library changes for Kotlin 1.5.

One question which was still outstanding in #3818 is whether we should limit the `@JvmSynthetic` annotation to file classes or permit it on arbitrary classes. This is not consistent between the JVM and JVM IR backends right now. Using `@Suppress("WRONG_ANNOTATION_TARGET_WITH_USE_SITE_TARGET")` it's possible to use `@JvmSynthetic` on arbitrary classes with the JVM IR backend, while it can only be used on file classes with the JVM backend. Since the original feature request in [KT-41884](https://youtrack.jetbrains.com/issue/KT-41884) was specific to file classes it might be fine to keep the implementation as is and consider extending it later if it comes up again.