### PR TITLE
KT-45032 Don't fail on empty InsnList

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/common/Util.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/common/Util.kt
@@ -61,7 +61,7 @@ class InsnSequence(val from: AbstractInsnNode, val to: AbstractInsnNode?) : Sequ
     }
 }
 
-fun InsnList.asSequence() = InsnSequence(this)
+fun InsnList.asSequence(): Sequence<AbstractInsnNode> = if (size() == 0) emptySequence() else InsnSequence(this)
 
 fun MethodNode.prepareForEmitting() {
     stripOptimizationMarkers()

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KaptIncrementalIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KaptIncrementalIT.kt
@@ -287,6 +287,22 @@ open class KaptIncrementalIT : BaseGradleIT() {
         }
     }
 
+    @Test
+    fun testChangeInlineDelegate() {
+        val project = getProject()
+        project.build("build") {
+            assertSuccessful()
+        }
+
+        val file = project.projectDir.getFileByName("Usage.kt")
+        file.modify { "$it//" }
+
+        project.build("build") {
+            assertSuccessful()
+            assertTasksExecuted(":kaptGenerateStubsKotlin", ":compileKotlin")
+        }
+    }
+
     private fun CompiledProject.assertCompiledKotlinSourcesHandleKapt3(
         sources: Iterable<String>,
         weakTesting: Boolean = false

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kaptIncrementalCompilationProject/src/main/java/delegate/Delegate.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kaptIncrementalCompilationProject/src/main/java/delegate/Delegate.kt
@@ -1,0 +1,13 @@
+package delegate
+
+import kotlin.reflect.KProperty
+
+class Delegate() {
+    inline operator fun getValue(thisRef: Any?, property: KProperty<*>): String {
+        return "I'm your val"
+    }
+
+    inline operator fun setValue(thisRef: Any?, property: KProperty<*>, value: String) {
+        println("$value has been assigned to '${property.name}' in $thisRef.")
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kaptIncrementalCompilationProject/src/main/java/delegate/Usage.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kaptIncrementalCompilationProject/src/main/java/delegate/Usage.kt
@@ -1,0 +1,7 @@
+package delegate
+
+object Usage {
+
+    var delegated: String by Delegate()
+
+}


### PR DESCRIPTION
KAPT uses light classes, where methods don't have bodies. In incremental compilation there is some cases when we get empty instructions list from such methods. It leads to NPE