### PR TITLE
FIR checker: enable diagnostic CANNOT_CHANGE_ACCESS_PRIVILEGE

### DIFF
--- a/compiler/testData/diagnostics/tests/scopes/VisibilityInheritModifier.fir.kt
+++ b/compiler/testData/diagnostics/tests/scopes/VisibilityInheritModifier.fir.kt
@@ -5,7 +5,7 @@ open class A {
 }
 
 class B : A() {
-    protected override fun foo() {}
+    <!CANNOT_CHANGE_ACCESS_PRIVILEGE!>protected<!> override fun foo() {}
 }
 
 class C : A() {
@@ -48,7 +48,7 @@ class I : H() {
 }
 
 class J : H() {
-    internal override fun pi_fun() {}
+    <!CANNOT_CHANGE_ACCESS_PRIVILEGE!>internal<!> override fun pi_fun() {}
 }
 
 class K : H() {

--- a/compiler/testData/diagnostics/tests/scopes/kt151.fir.kt
+++ b/compiler/testData/diagnostics/tests/scopes/kt151.fir.kt
@@ -24,7 +24,7 @@ interface T {
 }
 
 class D : C(), T {
-    protected override fun foo() {}
+    <!CANNOT_CHANGE_ACCESS_PRIVILEGE!>protected<!> override fun foo() {}
 }
 
 class E : C(), T {


### PR DESCRIPTION
All necessary pieces, such as error declaration, message, etc., were added together with another visibility diagnostic: CANNOT_WEAKEN_ACCESS_PRIVILEGE at PR #4060. Just didn't pay attention to details of false alarms, and disabled it temporarily. It turns out that, due to visibility from Java code, we need bi-directional comparisons.