### PR TITLE
Handle encoding long plugin option values

### DIFF
--- a/compiler/util/src/org/jetbrains/kotlin/utils/pluginUtils.kt
+++ b/compiler/util/src/org/jetbrains/kotlin/utils/pluginUtils.kt
@@ -18,6 +18,7 @@ package org.jetbrains.kotlin.utils
 
 import java.io.ByteArrayInputStream
 import java.io.ObjectInputStream
+import java.nio.charset.StandardCharsets
 import java.util.*
 
 fun decodePluginOptions(options: String): Map<String, List<String>> {
@@ -36,7 +37,9 @@ fun decodePluginOptions(options: String): Map<String, List<String>> {
         val values = mutableListOf<String>()
 
         repeat(valueCount) {
-            values += ois.readUTF()
+            val size = ois.readInt()
+            val byteArray = ByteArray(size)
+            values += String(byteArray, StandardCharsets.UTF_8)
         }
 
         map[key] = values

--- a/compiler/util/src/org/jetbrains/kotlin/utils/pluginUtils.kt
+++ b/compiler/util/src/org/jetbrains/kotlin/utils/pluginUtils.kt
@@ -39,7 +39,8 @@ fun decodePluginOptions(options: String): Map<String, List<String>> {
         repeat(valueCount) {
             val size = ois.readInt()
             val byteArray = ByteArray(size)
-            values += String(byteArray, StandardCharsets.UTF_8)
+            val valueBytes = ois.readFully(byteArray)
+            values += String(valueBytes, StandardCharsets.UTF_8)
         }
 
         map[key] = values

--- a/compiler/util/src/org/jetbrains/kotlin/utils/pluginUtils.kt
+++ b/compiler/util/src/org/jetbrains/kotlin/utils/pluginUtils.kt
@@ -39,8 +39,8 @@ fun decodePluginOptions(options: String): Map<String, List<String>> {
         repeat(valueCount) {
             val size = ois.readInt()
             val byteArray = ByteArray(size)
-            val valueBytes = ois.readFully(byteArray)
-            values += String(valueBytes, StandardCharsets.UTF_8)
+            ois.readFully(byteArray)
+            values += String(byteArray, StandardCharsets.UTF_8)
         }
 
         map[key] = values

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/subpluginUtils.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/subpluginUtils.kt
@@ -23,6 +23,7 @@ import org.jetbrains.kotlin.gradle.tasks.CompilerPluginOptions
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.ObjectOutputStream
+import java.nio.charset.StandardCharsets
 import java.util.*
 
 fun encodePluginOptions(options: Map<String, List<String>>): String {
@@ -35,7 +36,9 @@ fun encodePluginOptions(options: Map<String, List<String>>): String {
 
         oos.writeInt(values.size)
         for (value in values) {
-            oos.writeUTF(value)
+            val valueBytes = value.toByteArray(StandardCharsets.UTF_8)
+            oos.writeInt(valueBytes.size)
+            oos.write(valueBytes)
         }
     }
 


### PR DESCRIPTION
###  KT-45202: Kapt crashes with java.io.UTFDataFormatException

In multi module project kapt can receive options which exceeds max value for writing UTF string. These changes replace `oos.writeUtf` to `oos.write(bytes)` to allow long option strings serialization.