### PR TITLE
FIR: Take targeted annotations into account for metadata.

### DIFF
--- a/compiler/testData/codegen/box/annotations/annotationsOnLateinitAccessors.kt
+++ b/compiler/testData/codegen/box/annotations/annotationsOnLateinitAccessors.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 // WITH_REFLECT
 // TARGET_BACKEND: JVM
 
@@ -29,3 +28,4 @@ fun box(): String {
     LateinitProperties().test()
     return "OK"
 }
+


### PR DESCRIPTION
Getter/setter targeted annotions were not correctly reflected
in the kotlin metadata which made them not work with
kotlin-reflect.