### PR TITLE
Add FlatteningToIterableSequence

### DIFF
--- a/libraries/stdlib/common/src/generated/_Sequences.kt
+++ b/libraries/stdlib/common/src/generated/_Sequences.kt
@@ -749,6 +749,13 @@ public inline fun <K, V, M : MutableMap<in K, in V>> Sequence<K>.associateWithTo
  * The operation is _terminal_.
  */
 public fun <T, C : MutableCollection<in T>> Sequence<T>.toCollection(destination: C): C {
+    if (this is FlatteningToIterableSequence<*, *, *>) {
+        val iter = (this as FlatteningToIterableSequence<*, *, T>).underlyingIterator()
+        while (iter.hasNext()) {
+            destination.addAll(iter.next())
+        }
+        return destination
+    }
     for (item in this) {
         destination.add(item)
     }
@@ -805,7 +812,7 @@ public fun <T> Sequence<T>.toSet(): Set<T> {
 @OverloadResolutionByLambdaReturnType
 @kotlin.jvm.JvmName("flatMapIterable")
 public fun <T, R> Sequence<T>.flatMap(transform: (T) -> Iterable<R>): Sequence<R> {
-    return FlatteningSequence(this, transform, Iterable<R>::iterator)
+    return FlatteningToIterableSequence(this, transform, { it })
 }
 
 /**

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Mapping.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Mapping.kt
@@ -318,7 +318,7 @@ object Mapping : TemplateGroupBase() {
             doc { "Returns a single sequence of all elements from results of [transform] function being invoked on each element of original sequence." }
             returns("Sequence<R>")
             body {
-                "return FlatteningSequence(this, transform, Iterable<R>::iterator)"
+                "return FlatteningToIterableSequence(this, transform, { it })"
             }
         }
     }

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Snapshots.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Snapshots.kt
@@ -33,6 +33,25 @@ object Snapshots : TemplateGroupBase() {
             return destination
             """
         }
+
+        specialFor(Sequences) {
+            body {
+                """
+                if (this is FlatteningToIterableSequence<*, *, *>) {
+                    val iter = (this as FlatteningToIterableSequence<*, *, T>).underlyingIterator()
+                    while (iter.hasNext()) {
+                        destination.addAll(iter.next())
+                    }
+                    return destination
+                }
+                
+                for (item in this) {
+                    destination.add(item)
+                }
+                return destination
+                """
+            }
+        }
     }
 
     val f_toSet = fn("toSet()") {


### PR DESCRIPTION
Adds a Sequence implementation for flatMap to `Iterable`s in order to gain performance on `toCollection` (used by the implementation of `toList` and `toSet`) by potentially using `Collection.addAll` (if the `Iterable` turns out to be a `Collection`).

This slightly pessimizes Sequence.toCollection for cases where the Sequence is not the result of a `flatMap` or `flatten` call by adding a type check, and it pessmizes some cases where it is a `flat*` for `Iterable`s call but very few of the `Iterable`s are `Collection`s.