### PR TITLE
Register KAPT incremental apt cache as local state

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/KaptTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/KaptTask.kt
@@ -30,7 +30,7 @@ abstract class KaptTask : ConventionTask(), TaskWithLocalState {
         outputs.cacheIf(reason) { useBuildCache }
     }
 
-    override fun localStateDirectories(): FileCollection = objects.fileCollection()
+    override fun localStateDirectories(): FileCollection = objects.fileCollection().from(incAptCache)
 
     @get:Internal
     @field:Transient


### PR DESCRIPTION
This is so that incremental caches are removed on
non-incremental task run.