### PR TITLE
FIR: check NAMED_ARGUMENTS_NOT_ALLOWED

### DIFF
--- a/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/diagnostics/FirDiagnosticsList.kt
+++ b/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/diagnostics/FirDiagnosticsList.kt
@@ -10,6 +10,7 @@ import com.intellij.psi.PsiTypeElement
 import org.jetbrains.kotlin.contracts.description.EventOccurrencesRange
 import org.jetbrains.kotlin.descriptors.Visibility
 import org.jetbrains.kotlin.diagnostics.WhenMissingCase
+import org.jetbrains.kotlin.resolve.BadNamedArgumentsTarget
 import org.jetbrains.kotlin.fir.FirEffectiveVisibility
 import org.jetbrains.kotlin.fir.FirSourceElement
 import org.jetbrains.kotlin.fir.PrivateForInline
@@ -197,6 +198,11 @@ object DIAGNOSTICS_LIST : DiagnosticList() {
         }
 
         val VARARG_OUTSIDE_PARENTHESES by error<FirSourceElement, KtExpression>()
+
+        // TODO: implement a position strategy that highlights the argument name instead of the whole named argument
+        val NAMED_ARGUMENTS_NOT_ALLOWED by error<FirSourceElement, PsiElement> {
+            parameter<BadNamedArgumentsTarget>("badNamedArgumentTarget")
+        }
     }
 
     val AMBIGUITY by object : DiagnosticGroup("Ambiguity") {

--- a/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/diagnostics/FirErrors.kt
+++ b/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/diagnostics/FirErrors.kt
@@ -44,6 +44,7 @@ import org.jetbrains.kotlin.psi.KtTypeParameter
 import org.jetbrains.kotlin.psi.KtTypeParameterList
 import org.jetbrains.kotlin.psi.KtTypeReference
 import org.jetbrains.kotlin.psi.KtWhenExpression
+import org.jetbrains.kotlin.resolve.BadNamedArgumentsTarget
 
 /*
  * This file was generated automatically
@@ -167,6 +168,7 @@ object FirErrors {
     val INAPPLICABLE_CANDIDATE by error1<FirSourceElement, PsiElement, AbstractFirBasedSymbol<*>>(SourceElementPositioningStrategies.REFERENCE_BY_QUALIFIED)
     val INAPPLICABLE_LATEINIT_MODIFIER by error1<FirSourceElement, KtModifierListOwner, String>(SourceElementPositioningStrategies.LATEINIT_MODIFIER)
     val VARARG_OUTSIDE_PARENTHESES by error0<FirSourceElement, KtExpression>()
+    val NAMED_ARGUMENTS_NOT_ALLOWED by error1<FirSourceElement, PsiElement, BadNamedArgumentsTarget>()
 
     // Ambiguity
     val AMBIGUITY by error1<FirSourceElement, PsiElement, Collection<AbstractFirBasedSymbol<*>>>(SourceElementPositioningStrategies.REFERENCE_BY_QUALIFIED)

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/collectors/components/ErrorNodeDiagnosticCollectorComponent.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/collectors/components/ErrorNodeDiagnosticCollectorComponent.kt
@@ -11,7 +11,7 @@ import org.jetbrains.kotlin.fir.FirSourceElement
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.fir.analysis.collectors.AbstractDiagnosticCollector
 import org.jetbrains.kotlin.fir.analysis.diagnostics.DiagnosticReporter
-import org.jetbrains.kotlin.fir.analysis.diagnostics.toFirDiagnostic
+import org.jetbrains.kotlin.fir.analysis.diagnostics.toFirDiagnostics
 import org.jetbrains.kotlin.fir.declarations.FirErrorFunction
 import org.jetbrains.kotlin.fir.diagnostics.ConeDiagnostic
 import org.jetbrains.kotlin.fir.expressions.FirErrorExpression
@@ -77,7 +77,8 @@ class ErrorNodeDiagnosticCollectorComponent(collector: AbstractDiagnosticCollect
         if (source.kind == FirFakeSourceElementKind.ImplicitConstructor) {
             return
         }
-        val coneDiagnostic = diagnostic.toFirDiagnostic(source)
-        reporter.report(coneDiagnostic, context)
+        for (coneDiagnostic in diagnostic.toFirDiagnostics(source)) {
+            reporter.report(coneDiagnostic, context)
+        }
     }
 }

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/FirDefaultErrorMessages.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/FirDefaultErrorMessages.kt
@@ -119,6 +119,7 @@ import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.NESTED_CLASS_NOT_
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.MULTIPLE_VARARG_PARAMETERS
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.MUST_BE_INITIALIZED
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.MUST_BE_INITIALIZED_OR_BE_ABSTRACT
+import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.NAMED_ARGUMENTS_NOT_ALLOWED
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.NONE_APPLICABLE
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.NON_ABSTRACT_FUNCTION_WITH_NO_BODY
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.NON_FINAL_MEMBER_IN_FINAL_CLASS
@@ -353,6 +354,7 @@ class FirDefaultErrorMessages : DefaultErrorMessages.Extension {
             map.put(INAPPLICABLE_CANDIDATE, "Inapplicable candidate(s): {0}", SYMBOL)
             map.put(INAPPLICABLE_LATEINIT_MODIFIER, "''lateinit'' modifier {0}", TO_STRING)
             map.put(VARARG_OUTSIDE_PARENTHESES, "Passing value as a vararg is only allowed inside a parenthesized argument list")
+            map.put(NAMED_ARGUMENTS_NOT_ALLOWED, "Named arguments are not allowed for {0}", TO_STRING)
 
             // Ambiguity
             map.put(AMBIGUITY, "Ambiguity between candidates: {0}", SYMBOLS)

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/coneDiagnosticToFirDiagnostic.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/coneDiagnosticToFirDiagnostic.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.fir.declarations.isInfix
 import org.jetbrains.kotlin.fir.declarations.isOperator
 import org.jetbrains.kotlin.fir.diagnostics.*
 import org.jetbrains.kotlin.fir.resolve.calls.InapplicableWrongReceiver
+import org.jetbrains.kotlin.fir.resolve.calls.NamedArgumentNotAllowed
 import org.jetbrains.kotlin.fir.resolve.calls.VarargArgumentOutsideParentheses
 import org.jetbrains.kotlin.fir.resolve.diagnostics.*
 import org.jetbrains.kotlin.fir.types.*
@@ -101,6 +102,10 @@ private fun mapInapplicableCandidateError(
 
         when (rootCause) {
             is VarargArgumentOutsideParentheses -> FirErrors.VARARG_OUTSIDE_PARENTHESES.on(rootCause.argument.source ?: source)
+            is NamedArgumentNotAllowed -> FirErrors.NAMED_ARGUMENTS_NOT_ALLOWED.on(
+                rootCause.argument.source ?: source,
+                rootCause.badNamedArgumentsTarget
+            )
             else -> null
         }
     }.ifEmpty { listOf(FirErrors.INAPPLICABLE_CANDIDATE.on(source, diagnostic.candidate.symbol)) }

--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/generators/CallAndReferenceGenerator.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/generators/CallAndReferenceGenerator.kt
@@ -465,7 +465,7 @@ class CallAndReferenceGenerator(
                             ((calleeReference as? FirResolvedNamedReference)?.resolvedSymbol as? FirFunctionSymbol<*>)?.fir
                         }
                         val valueParameters = function?.valueParameters
-                        val argumentMapping = call.argumentMapping
+                        val argumentMapping = call.resolvedArgumentMapping
                         val substitutor = (call as? FirFunctionCall)?.buildSubstitutorByCalledFunction(function) ?: ConeSubstitutor.Empty
                         if (argumentMapping != null && (annotationMode || argumentMapping.isNotEmpty())) {
                             if (valueParameters != null) {

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/FirArgumentsToParametersMapper.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/FirArgumentsToParametersMapper.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.fir.resolve.calls
 
+import org.jetbrains.kotlin.resolve.BadNamedArgumentsTarget
 import org.jetbrains.kotlin.fir.declarations.FirFunction
 import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
 import org.jetbrains.kotlin.fir.declarations.FirValueParameter
@@ -15,11 +16,10 @@ import org.jetbrains.kotlin.fir.expressions.FirNamedArgumentExpression
 import org.jetbrains.kotlin.fir.expressions.FirSpreadArgumentExpression
 import org.jetbrains.kotlin.fir.expressions.builder.buildNamedArgumentExpression
 import org.jetbrains.kotlin.fir.resolve.BodyResolveComponents
+import org.jetbrains.kotlin.fir.resolve.asBadForNamedArgumentTarget
 import org.jetbrains.kotlin.fir.resolve.defaultParameterResolver
 import org.jetbrains.kotlin.fir.scopes.FirScope
 import org.jetbrains.kotlin.name.Name
-import kotlin.collections.ArrayList
-import kotlin.collections.LinkedHashMap
 import kotlin.collections.component1
 import kotlin.collections.component2
 import kotlin.collections.set
@@ -108,6 +108,10 @@ private class FirCallArgumentsProcessor(
         private set
     val result: LinkedHashMap<FirValueParameter, ResolvedCallArgument> = LinkedHashMap(function.valueParameters.size)
 
+    val badForNamedArgumentTarget: BadNamedArgumentsTarget? by lazy {
+        function.asBadForNamedArgumentTarget
+    }
+
     private enum class State {
         POSITION_ARGUMENTS,
         VARARG_POSITION,
@@ -165,8 +169,8 @@ private class FirCallArgumentsProcessor(
     }
 
     private fun processNamedArgument(argument: FirExpression, name: Name) {
-        if (!function.hasStableParameterNames) {
-            addDiagnostic(NamedArgumentNotAllowed(argument, function))
+        badForNamedArgumentTarget?.let {
+            addDiagnostic(NamedArgumentNotAllowed(argument, function, it))
         }
 
         val stateAllowsMixedNamedAndPositionArguments = state != State.NAMED_ONLY_ARGUMENTS
@@ -296,10 +300,4 @@ private class FirCallArgumentsProcessor(
 
     private val FirExpression.argumentName: Name?
         get() = (this as? FirNamedArgumentExpression)?.name
-
-    // TODO: handle functions with non-stable parameter names, see also
-    //  org.jetbrains.kotlin.fir.serialization.FirElementSerializer.functionProto
-    //  org.jetbrains.kotlin.fir.serialization.FirElementSerializer.constructorProto
-    private val FirFunction<*>.hasStableParameterNames: Boolean
-        get() = true
 }

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/ResolutionDiagnostic.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/ResolutionDiagnostic.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.fir.resolve.calls
 
+import org.jetbrains.kotlin.resolve.BadNamedArgumentsTarget
 import org.jetbrains.kotlin.fir.declarations.FirFunction
 import org.jetbrains.kotlin.fir.declarations.FirValueParameter
 import org.jetbrains.kotlin.fir.expressions.FirExpression
@@ -26,7 +27,8 @@ class TooManyArguments(
 
 class NamedArgumentNotAllowed(
     override val argument: FirExpression,
-    val function: FirFunction<*>
+    val function: FirFunction<*>,
+    val badNamedArgumentsTarget: BadNamedArgumentsTarget
 ) : InapplicableArgumentDiagnostic()
 
 class ArgumentPassedTwice(

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirCallCompletionResultsWriterTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirCallCompletionResultsWriterTransformer.kt
@@ -16,7 +16,6 @@ import org.jetbrains.kotlin.fir.references.builder.buildResolvedCallableReferenc
 import org.jetbrains.kotlin.fir.references.builder.buildResolvedNamedReference
 import org.jetbrains.kotlin.fir.resolve.*
 import org.jetbrains.kotlin.fir.resolve.calls.*
-import org.jetbrains.kotlin.fir.resolve.calls.CallableReferenceAdaptation
 import org.jetbrains.kotlin.fir.resolve.dfa.FirDataFlowAnalyzer
 import org.jetbrains.kotlin.fir.resolve.inference.*
 import org.jetbrains.kotlin.fir.resolve.substitution.ConeSubstitutor
@@ -161,7 +160,11 @@ class FirCallCompletionResultsWriterTransformer(
                 resultType = typeRef.substituteTypeRef(subCandidate)
                 val expectedArgumentsTypeMapping = runIf(!calleeReference.isError) { subCandidate.createArgumentsMapping() }
                 result.argumentList.transformArguments(this, expectedArgumentsTypeMapping)
-                if (!calleeReference.isError) {
+                if (calleeReference.isError) {
+                    subCandidate.argumentMapping?.let {
+                        result.replaceArgumentList(buildPartiallyResolvedArgumentList(result.argumentList, it))
+                    }
+                } else {
                     subCandidate.handleVarargs()
                     subCandidate.argumentMapping?.let {
                         result.replaceArgumentList(buildResolvedArgumentList(it))
@@ -212,7 +215,11 @@ class FirCallCompletionResultsWriterTransformer(
                 }
             }
         }
-        if (!calleeReference.isError) {
+        if (calleeReference.isError) {
+            subCandidate.argumentMapping?.let {
+                annotationCall.replaceArgumentList(buildPartiallyResolvedArgumentList(annotationCall.argumentList, it))
+            }
+        } else {
             subCandidate.handleVarargs()
             subCandidate.argumentMapping?.let {
                 annotationCall.replaceArgumentList(buildResolvedArgumentList(it))
@@ -367,7 +374,11 @@ class FirCallCompletionResultsWriterTransformer(
 
         val argumentsMapping = runIf(!calleeReference.isError) { calleeReference.candidate.createArgumentsMapping() }
         delegatedConstructorCall.argumentList.transformArguments(this, argumentsMapping)
-        if (!calleeReference.isError) {
+        if (calleeReference.isError) {
+            subCandidate.argumentMapping?.let {
+                delegatedConstructorCall.replaceArgumentList(buildPartiallyResolvedArgumentList(delegatedConstructorCall.argumentList, it))
+            }
+        } else {
             subCandidate.handleVarargs()
             subCandidate.argumentMapping?.let {
                 delegatedConstructorCall.replaceArgumentList(buildResolvedArgumentList(it))

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/expressions/FirArgumentUtil.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/expressions/FirArgumentUtil.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlin.fir.FirSourceElement
 import org.jetbrains.kotlin.fir.declarations.FirValueParameter
 import org.jetbrains.kotlin.fir.expressions.builder.buildArgumentList
 import org.jetbrains.kotlin.fir.expressions.impl.FirArraySetArgumentList
+import org.jetbrains.kotlin.fir.expressions.impl.FirPartiallyResolvedArgumentList
 import org.jetbrains.kotlin.fir.expressions.impl.FirResolvedArgumentList
 
 fun buildUnaryArgumentList(argument: FirExpression): FirArgumentList = buildArgumentList {
@@ -25,6 +26,16 @@ fun buildArraySetArgumentList(rValue: FirExpression, indexes: List<FirExpression
 
 fun buildResolvedArgumentList(mapping: LinkedHashMap<FirExpression, FirValueParameter>): FirArgumentList =
     FirResolvedArgumentList(mapping)
+
+fun buildPartiallyResolvedArgumentList(
+    original: FirArgumentList,
+    mapping: LinkedHashMap<FirExpression, FirValueParameter>
+): FirArgumentList {
+    return FirPartiallyResolvedArgumentList(
+        original.source,
+        original.arguments.map { key -> key to mapping[key] }.toMap(LinkedHashMap())
+    )
+}
 
 object FirEmptyArgumentList : FirAbstractArgumentList() {
     override val arguments: List<FirExpression>

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/expressions/FirExpressionUtil.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/expressions/FirExpressionUtil.kt
@@ -11,8 +11,10 @@ import org.jetbrains.kotlin.fir.diagnostics.ConeDiagnostic
 import org.jetbrains.kotlin.fir.expressions.builder.buildConstExpression
 import org.jetbrains.kotlin.fir.expressions.builder.buildErrorExpression
 import org.jetbrains.kotlin.fir.expressions.builder.buildErrorLoop
-import org.jetbrains.kotlin.fir.expressions.impl.*
 import org.jetbrains.kotlin.fir.expressions.impl.FirBlockImpl
+import org.jetbrains.kotlin.fir.expressions.impl.FirPartiallyResolvedArgumentList
+import org.jetbrains.kotlin.fir.expressions.impl.FirResolvedArgumentList
+import org.jetbrains.kotlin.fir.expressions.impl.FirSingleExpressionBlock
 import org.jetbrains.kotlin.fir.references.FirResolvedNamedReference
 import org.jetbrains.kotlin.fir.symbols.impl.FirCallableSymbol
 import org.jetbrains.kotlin.fir.types.ConeClassLikeType
@@ -41,8 +43,18 @@ inline val FirCall.arguments: List<FirExpression> get() = argumentList.arguments
 
 inline val FirCall.argument: FirExpression get() = argumentList.arguments.first()
 
+inline val FirCall.resolvedArgumentMapping: LinkedHashMap<FirExpression, FirValueParameter>?
+    get() = when (val argumentList = argumentList) {
+        is FirResolvedArgumentList -> argumentList.mapping
+        else -> null
+    }
+
 inline val FirCall.argumentMapping: LinkedHashMap<FirExpression, FirValueParameter>?
-    get() = (argumentList as? FirResolvedArgumentList)?.mapping
+    get() = when (val argumentList = argumentList) {
+        is FirResolvedArgumentList -> argumentList.mapping
+        is FirPartiallyResolvedArgumentList -> argumentList.mapping
+        else -> null
+    }
 
 fun FirExpression.toResolvedCallableReference(): FirResolvedNamedReference? {
     if (this is FirWrappedArgumentExpression) return expression.toResolvedCallableReference()

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/expressions/impl/FirPartiallyResolvedArgumentList.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/expressions/impl/FirPartiallyResolvedArgumentList.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.fir.expressions.impl
+
+import org.jetbrains.kotlin.fir.FirSourceElement
+import org.jetbrains.kotlin.fir.declarations.FirValueParameter
+import org.jetbrains.kotlin.fir.expressions.FirArgumentList
+import org.jetbrains.kotlin.fir.expressions.FirExpression
+import org.jetbrains.kotlin.fir.visitors.FirTransformer
+import org.jetbrains.kotlin.fir.visitors.FirVisitor
+import org.jetbrains.kotlin.fir.visitors.transformSingle
+
+class FirPartiallyResolvedArgumentList internal constructor(
+    override var source: FirSourceElement?,
+    private var _mapping: LinkedHashMap<FirExpression, FirValueParameter?>
+) : FirArgumentList() {
+
+    @Suppress("UNCHECKED_CAST")
+    val mapping: LinkedHashMap<FirExpression, FirValueParameter> =
+        _mapping.filterValues { it != null } as LinkedHashMap<FirExpression, FirValueParameter>
+
+
+    override val arguments: List<FirExpression>
+        get() = _mapping.keys.toList()
+
+    override fun <R, D> acceptChildren(visitor: FirVisitor<R, D>, data: D) {
+        _mapping.forEach { (k, _) -> k.accept(visitor, data) }
+    }
+
+    override fun <D> transformChildren(transformer: FirTransformer<D>, data: D): FirPartiallyResolvedArgumentList {
+        transformArguments(transformer, data)
+        return this
+    }
+
+    override fun <D> transformArguments(transformer: FirTransformer<D>, data: D): FirPartiallyResolvedArgumentList {
+        _mapping = _mapping.mapKeys { (k, _) -> k.transformSingle(transformer, data) } as LinkedHashMap<FirExpression, FirValueParameter?>
+        return this
+    }
+
+    override fun replaceSource(newSource: FirSourceElement?) {
+        source = newSource
+    }
+}

--- a/compiler/frontend.common/src/org/jetbrains/kotlin/resolve/BadNamedArgumentsTarget.kt
+++ b/compiler/frontend.common/src/org/jetbrains/kotlin/resolve/BadNamedArgumentsTarget.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.resolve
+
+enum class BadNamedArgumentsTarget(private val description:String) {
+    NON_KOTLIN_FUNCTION("non-Kotlin functions"),  // a function provided by non-Kotlin artifact, ex: Java function
+    INVOKE_ON_FUNCTION_TYPE("function types"),
+    EXPECTED_CLASS_MEMBER("members of expected classes"),
+    // TODO: add the following when MPP support is available
+//     INTEROP_FUNCTION("interop functions with ambiguous parameter names"),  // deserialized Kotlin function that serves as a bridge to a function written in another language, ex: Obj-C
+    ;
+
+    override fun toString(): String = description
+}

--- a/compiler/testData/diagnostics/tests/annotations/annotationParameterMustBeConstant/enumConst_after.fir.kt
+++ b/compiler/testData/diagnostics/tests/annotations/annotationParameterMustBeConstant/enumConst_after.fir.kt
@@ -11,5 +11,5 @@ enum class MyEnum {
     A
 }
 
-<!INAPPLICABLE_CANDIDATE!>@AnnE(Test())<!>
+<!INAPPLICABLE_CANDIDATE!>@AnnE(<!ANNOTATION_ARGUMENT_MUST_BE_CONST!>Test()<!>)<!>
 class Test2

--- a/compiler/testData/diagnostics/tests/annotations/annotationParameterMustBeConstant/enumConst_before.fir.kt
+++ b/compiler/testData/diagnostics/tests/annotations/annotationParameterMustBeConstant/enumConst_before.fir.kt
@@ -11,5 +11,5 @@ enum class MyEnum {
     A
 }
 
-<!INAPPLICABLE_CANDIDATE!>@AnnE(Test())<!>
+<!INAPPLICABLE_CANDIDATE!>@AnnE(<!ANNOTATION_ARGUMENT_MUST_BE_CONST!>Test()<!>)<!>
 class Test2

--- a/compiler/testData/diagnostics/tests/annotations/dontReportWarningAboutChangingExecutionOrderForVararg.fir.kt
+++ b/compiler/testData/diagnostics/tests/annotations/dontReportWarningAboutChangingExecutionOrderForVararg.fir.kt
@@ -7,7 +7,7 @@ fun foo1() {}
 @Anno(x = ["a", "b"], y = "a")
 fun foo2() {}
 
-<!INAPPLICABLE_CANDIDATE!>@Anno(x = arrayOf(arrayOf("a"), arrayOf("b")), y = "a")<!>
+<!INAPPLICABLE_CANDIDATE!>@Anno(x = <!NON_CONST_VAL_USED_IN_CONSTANT_EXPRESSION!>arrayOf(<!ANNOTATION_ARGUMENT_MUST_BE_CONST!>arrayOf("a")<!>, <!ANNOTATION_ARGUMENT_MUST_BE_CONST!>arrayOf("b")<!>)<!>, y = "a")<!>
 fun foo3() {}
 
 @Anno(x = arrayOf("a", "b"), y = "a")

--- a/compiler/testData/diagnostics/tests/extensions/variableInvoke.fir.kt
+++ b/compiler/testData/diagnostics/tests/extensions/variableInvoke.fir.kt
@@ -7,5 +7,5 @@ class A(foo: Int.() -> Unit) {
 fun test(foo: Int.(String) -> Unit) {
     4.foo("")
     4.<!INAPPLICABLE_CANDIDATE!>foo<!>(p1 = "")
-    4.foo(p2 = "")
+    4.foo(<!NAMED_ARGUMENTS_NOT_ALLOWED!>p2 = ""<!>)
 }

--- a/compiler/testData/diagnostics/tests/multiplatform/namedArguments.fir.kt
+++ b/compiler/testData/diagnostics/tests/multiplatform/namedArguments.fir.kt
@@ -12,10 +12,10 @@ expect class Foo(zzz: Int) {
 expect fun f2(xxx: Int)
 
 fun testCommon() {
-    Foo(zzz = 0)
-    val f = Foo(aaa = true)
-    f.f1(xxx = "")
-    f2(xxx = 42)
+    Foo(<!NAMED_ARGUMENTS_NOT_ALLOWED!>zzz = 0<!>)
+    val f = Foo(<!NAMED_ARGUMENTS_NOT_ALLOWED!>aaa = true<!>)
+    f.f1(<!NAMED_ARGUMENTS_NOT_ALLOWED!>xxx = ""<!>)
+    f2(<!NAMED_ARGUMENTS_NOT_ALLOWED!>xxx = 42<!>)
 }
 
 // MODULE: m2-jvm(m1-common)

--- a/compiler/testData/diagnostics/tests/namedArguments/disallowForJavaConstructor.fir.kt
+++ b/compiler/testData/diagnostics/tests/namedArguments/disallowForJavaConstructor.fir.kt
@@ -6,4 +6,4 @@ public class A {
 
 // FILE: 1.kt
 
-val test = A(x = 1, y = "2")
+val test = A(<!NAMED_ARGUMENTS_NOT_ALLOWED!>x = 1<!>, <!NAMED_ARGUMENTS_NOT_ALLOWED!>y = "2"<!>)

--- a/compiler/testData/diagnostics/tests/namedArguments/disallowForJavaMethods.fir.kt
+++ b/compiler/testData/diagnostics/tests/namedArguments/disallowForJavaMethods.fir.kt
@@ -8,11 +8,11 @@ public class JavaSuperClass {
 
 // FILE: 1.kt
 
-fun directInvocation() = JavaSuperClass().foo(javaName = 1)
+fun directInvocation() = JavaSuperClass().foo(<!NAMED_ARGUMENTS_NOT_ALLOWED!>javaName = 1<!>)
 
 open class KotlinSubClass : JavaSuperClass()
 
-fun viaFakeOverride() = KotlinSubClass().foo(javaName = 2)
+fun viaFakeOverride() = KotlinSubClass().foo(<!NAMED_ARGUMENTS_NOT_ALLOWED!>javaName = 2<!>)
 
 class KotlinSubSubClass : KotlinSubClass() {
     override fun foo(kotlinName: Int) {}
@@ -24,4 +24,4 @@ fun viaRealOverride() = KotlinSubSubClass().foo(kotlinName = 3)
 fun unresolvedParameter() = JavaSuperClass().<!INAPPLICABLE_CANDIDATE!>foo<!>(nonexistentName = 4)
 
 
-fun multipleParameters() = JavaSuperClass().multipleParameters(first = 1, second = 2L, third = "3")
+fun multipleParameters() = JavaSuperClass().multipleParameters(<!NAMED_ARGUMENTS_NOT_ALLOWED!>first = 1<!>, <!NAMED_ARGUMENTS_NOT_ALLOWED!>second = 2L<!>, <!NAMED_ARGUMENTS_NOT_ALLOWED!>third = "3"<!>)

--- a/compiler/testData/diagnostics/tests/namedArguments/disallowForSamAdapterConstructor.fir.kt
+++ b/compiler/testData/diagnostics/tests/namedArguments/disallowForSamAdapterConstructor.fir.kt
@@ -13,5 +13,5 @@ public class J {
 package test
 
 fun test() {
-    J("", r = { }, z = false)
+    J("", <!NAMED_ARGUMENTS_NOT_ALLOWED!>r = { }<!>, <!NAMED_ARGUMENTS_NOT_ALLOWED!>z = false<!>)
 }

--- a/compiler/testData/diagnostics/tests/namedArguments/disallowForSamAdapterFunction.fir.kt
+++ b/compiler/testData/diagnostics/tests/namedArguments/disallowForSamAdapterFunction.fir.kt
@@ -13,5 +13,5 @@ public class J {
 package test
 
 fun test() {
-    J.foo("", r = { }, z = false)
+    J.foo("", <!NAMED_ARGUMENTS_NOT_ALLOWED!>r = { }<!>, <!NAMED_ARGUMENTS_NOT_ALLOWED!>z = false<!>)
 }

--- a/compiler/testData/diagnostics/tests/syntheticExtensions/samAdapters/NoNamedArgsAllowed.fir.kt
+++ b/compiler/testData/diagnostics/tests/syntheticExtensions/samAdapters/NoNamedArgsAllowed.fir.kt
@@ -1,7 +1,7 @@
 // !WITH_NEW_INFERENCE
 // FILE: KotlinFile.kt
 fun foo(javaClass: JavaClass) {
-    javaClass.doSomething(p = 1) {
+    javaClass.doSomething(<!NAMED_ARGUMENTS_NOT_ALLOWED!>p = 1<!>) {
         bar()
     }
 }

--- a/idea/idea-frontend-fir/idea-frontend-fir-generator/src/org/jetbrains/kotlin/idea/frontend/api/fir/generator/HLDiagnosticConverter.kt
+++ b/idea/idea-frontend-fir/idea-frontend-fir-generator/src/org/jetbrains/kotlin/idea/frontend/api/fir/generator/HLDiagnosticConverter.kt
@@ -9,6 +9,7 @@ import com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.contracts.description.EventOccurrencesRange
 import org.jetbrains.kotlin.descriptors.Visibility
 import org.jetbrains.kotlin.diagnostics.WhenMissingCase
+import org.jetbrains.kotlin.resolve.BadNamedArgumentsTarget
 import org.jetbrains.kotlin.fir.FirEffectiveVisibility
 import org.jetbrains.kotlin.fir.checkers.generator.diagnostics.DiagnosticData
 import org.jetbrains.kotlin.fir.checkers.generator.diagnostics.DiagnosticList
@@ -173,6 +174,7 @@ private object FirToKtConversionCreator {
         KtModifierKeywordToken::class,
         Visibility::class,
         WhenMissingCase::class,
+        BadNamedArgumentsTarget::class,
     )
 
     private val KType.kClass: KClass<*>

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/components/KtFirAnalysisSessionComponent.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/components/KtFirAnalysisSessionComponent.kt
@@ -9,14 +9,11 @@ import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.FirSourceElement
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirDiagnostic
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirPsiDiagnostic
-import org.jetbrains.kotlin.fir.analysis.diagnostics.toFirDiagnostic
+import org.jetbrains.kotlin.fir.analysis.diagnostics.toFirDiagnostics
 import org.jetbrains.kotlin.fir.diagnostics.ConeDiagnostic
 import org.jetbrains.kotlin.fir.typeContext
 import org.jetbrains.kotlin.fir.types.ConeKotlinType
 import org.jetbrains.kotlin.fir.types.ConeTypeCheckerContext
-import org.jetbrains.kotlin.idea.frontend.api.ValidityTokenOwner
-import org.jetbrains.kotlin.idea.frontend.api.components.KtAnalysisSessionComponent
-import org.jetbrains.kotlin.idea.frontend.api.diagnostics.KtDiagnostic
 import org.jetbrains.kotlin.idea.frontend.api.diagnostics.KtDiagnosticWithPsi
 import org.jetbrains.kotlin.idea.frontend.api.fir.KtFirAnalysisSession
 import org.jetbrains.kotlin.idea.frontend.api.fir.diagnostics.KT_DIAGNOSTIC_CONVERTER
@@ -34,7 +31,7 @@ internal interface KtFirAnalysisSessionComponent {
         KT_DIAGNOSTIC_CONVERTER.convert(analysisSession, this as FirDiagnostic<*>)
 
     fun ConeDiagnostic.asKtDiagnostic(source: FirSourceElement): KtDiagnosticWithPsi<*>? {
-        val firDiagnostic = toFirDiagnostic(source) ?: return null
+        val firDiagnostic = toFirDiagnostics(source).firstOrNull() ?: return null
         check(firDiagnostic is FirPsiDiagnostic<*>)
         return firDiagnostic.asKtDiagnostic()
     }

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDataClassConverters.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDataClassConverters.kt
@@ -657,6 +657,13 @@ internal val KT_DIAGNOSTIC_CONVERTER = KtDiagnosticConverterBuilder.buildConvert
             token,
         )
     }
+    add(FirErrors.NAMED_ARGUMENTS_NOT_ALLOWED) { firDiagnostic ->
+        NamedArgumentsNotAllowedImpl(
+            firDiagnostic.a,
+            firDiagnostic as FirPsiDiagnostic<*>,
+            token,
+        )
+    }
     add(FirErrors.AMBIGUITY) { firDiagnostic ->
         AmbiguityImpl(
             firDiagnostic.a.map { abstractFirBasedSymbol ->

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnostics.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnostics.kt
@@ -39,6 +39,7 @@ import org.jetbrains.kotlin.psi.KtTypeParameter
 import org.jetbrains.kotlin.psi.KtTypeParameterList
 import org.jetbrains.kotlin.psi.KtTypeReference
 import org.jetbrains.kotlin.psi.KtWhenExpression
+import org.jetbrains.kotlin.resolve.BadNamedArgumentsTarget
 
 /*
  * This file was generated automatically
@@ -467,6 +468,11 @@ sealed class KtFirDiagnostic<PSI: PsiElement> : KtDiagnosticWithPsi<PSI> {
 
     abstract class VarargOutsideParentheses : KtFirDiagnostic<KtExpression>() {
         override val diagnosticClass get() = VarargOutsideParentheses::class
+    }
+
+    abstract class NamedArgumentsNotAllowed : KtFirDiagnostic<PsiElement>() {
+        override val diagnosticClass get() = NamedArgumentsNotAllowed::class
+        abstract val badNamedArgumentTarget: BadNamedArgumentsTarget
     }
 
     abstract class Ambiguity : KtFirDiagnostic<PsiElement>() {

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnosticsImpl.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnosticsImpl.kt
@@ -41,6 +41,7 @@ import org.jetbrains.kotlin.psi.KtTypeParameter
 import org.jetbrains.kotlin.psi.KtTypeParameterList
 import org.jetbrains.kotlin.psi.KtTypeReference
 import org.jetbrains.kotlin.psi.KtWhenExpression
+import org.jetbrains.kotlin.resolve.BadNamedArgumentsTarget
 
 /*
  * This file was generated automatically
@@ -752,6 +753,14 @@ internal class VarargOutsideParenthesesImpl(
     firDiagnostic: FirPsiDiagnostic<*>,
     override val token: ValidityToken,
 ) : KtFirDiagnostic.VarargOutsideParentheses(), KtAbstractFirDiagnostic<KtExpression> {
+    override val firDiagnostic: FirPsiDiagnostic<*> by weakRef(firDiagnostic)
+}
+
+internal class NamedArgumentsNotAllowedImpl(
+    override val badNamedArgumentTarget: BadNamedArgumentsTarget,
+    firDiagnostic: FirPsiDiagnostic<*>,
+    override val token: ValidityToken,
+) : KtFirDiagnostic.NamedArgumentsNotAllowed(), KtAbstractFirDiagnostic<PsiElement> {
     override val firDiagnostic: FirPsiDiagnostic<*> by weakRef(firDiagnostic)
 }
 


### PR DESCRIPTION
The check has already been partially implemented in
org.jetbrains.kotlin.fir.resolve.calls.FirCallArgumentsProcessor. This
change completes the missing piece that determines if a `FirFunction`
has stable parameter names.

In addition, this change now makes `org.jetbrains.kotlin.fir.analysis.diagnostics.ConeDiagnosticToFirDiagnosticKt#toFirDiagnostic` converter allow mapping one `ConeDiagnostics` to multiple `FirDiagnostics`.