### PR TITLE
Kotlinc: Fix the NullPointerException when pathname does not name a parent.

### DIFF
--- a/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/CompileEnvironmentUtil.java
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/CompileEnvironmentUtil.java
@@ -116,7 +116,9 @@ public class CompileEnvironmentUtil {
         FileOutputStream outputStream = null;
         try {
             // we should try to create the output dir first
-            jarPath.getParentFile().mkdirs();
+            if (jarPath.getParentFile() != null) {
+                jarPath.getParentFile().mkdirs();
+            }
             outputStream = new FileOutputStream(jarPath);
             doWriteToJar(outputFiles, outputStream, mainClass, jarRuntime, noReflect, resetJarTimestamps);
             outputStream.close();


### PR DESCRIPTION
This bug was introduced by #4080

https://github.com/JetBrains/kotlin/pull/4080#issuecomment-791598992

