### PR TITLE
kotlinc: Add a test to for the situation where pathname of destination does not name a parent

### DIFF
--- a/compiler/testData/integration/smoke/destinationDirNoPermission/test.notWindows.compile.expected
+++ b/compiler/testData/integration/smoke/destinationDirNoPermission/test.notWindows.compile.expected
@@ -1,0 +1,5 @@
+ERR:
+error: error while writing [Temp]/noPermissionDir/Test.class (Permission denied)
+error: error while writing [Temp]/noPermissionDir/META-INF/main.kotlin_module (Permission denied)
+
+Return code: 1

--- a/compiler/testData/integration/smoke/destinationJarNoPermission/test.notWindows.compile.expected
+++ b/compiler/testData/integration/smoke/destinationJarNoPermission/test.notWindows.compile.expected
@@ -1,0 +1,4 @@
+ERR:
+error: invalid jar path: [Temp]/noPermissionDir/test.jar
+
+Return code: 1


### PR DESCRIPTION
This PR contains the following:

- Add a test to for the situation where pathname of destination does not name a parent, it is related to #4183 ;
- Make sure we test the original issue at least on Linux, this is related to https://github.com/JetBrains/kotlin/pull/4080#discussion_r587750927 ;
- Minor: suppress the warning "ignored method call result" .