### PR TITLE
JVM: fix inline cycle detection

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/InlineCodegen.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/InlineCodegen.kt
@@ -108,11 +108,9 @@ abstract class InlineCodegen<out T : BaseExpressionCodegen>(
         )
     }
 
-    protected fun generateStub(resolvedCall: ResolvedCall<*>?, codegen: BaseExpressionCodegen) {
+    protected fun generateStub(text: String, codegen: BaseExpressionCodegen) {
         leaveTemps()
-        assert(resolvedCall != null)
-        val message = "Call is part of inline cycle: " + resolvedCall!!.call.callElement.text
-        AsmUtil.genThrow(codegen.v, "java/lang/UnsupportedOperationException", message)
+        AsmUtil.genThrow(codegen.v, "java/lang/UnsupportedOperationException", "Call is part of inline cycle: $text")
     }
 
     protected fun endCall(result: InlineResult, registerLineNumberAfterwards: Boolean) {

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/PsiInlineCodegen.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/PsiInlineCodegen.kt
@@ -60,8 +60,8 @@ class PsiInlineCodegen(
         callDefault: Boolean,
         codegen: ExpressionCodegen
     ) {
-        if (!state.globalInlineContext.enterIntoInlining(resolvedCall?.resultingDescriptor, resolvedCall?.call?.callElement)) {
-            generateStub(resolvedCall, codegen)
+        if (!state.globalInlineContext.enterIntoInlining(functionDescriptor, resolvedCall?.call?.callElement)) {
+            generateStub(resolvedCall?.call?.callElement?.text ?: "<no source>", codegen)
             return
         }
         try {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/IrInlineCallGenerator.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/IrInlineCallGenerator.kt
@@ -10,7 +10,6 @@ import org.jetbrains.kotlin.backend.jvm.lower.suspendFunctionOriginal
 import org.jetbrains.kotlin.codegen.AsmUtil
 import org.jetbrains.kotlin.ir.descriptors.toIrBasedDescriptor
 import org.jetbrains.kotlin.ir.expressions.IrFunctionAccessExpression
-import org.jetbrains.kotlin.ir.util.render
 
 interface IrInlineCallGenerator : IrCallGenerator {
     override fun genCall(
@@ -21,11 +20,9 @@ interface IrInlineCallGenerator : IrCallGenerator {
     ) {
         val element = PsiSourceManager.findPsiElement(expression, codegen.irFunction)
             ?: PsiSourceManager.findPsiElement(codegen.irFunction)
-        if (!codegen.state.globalInlineContext.enterIntoInlining(
-                expression.symbol.owner.suspendFunctionOriginal().toIrBasedDescriptor(), element)
-        ) {
-            val message = "Call is a part of inline call cycle: ${expression.render()}"
-            AsmUtil.genThrow(codegen.visitor, "java/lang/UnsupportedOperationException", message)
+        val descriptor = expression.symbol.owner.suspendFunctionOriginal().toIrBasedDescriptor()
+        if (!codegen.state.globalInlineContext.enterIntoInlining(descriptor, element)) {
+            genCycleStub(expression.psiElement?.text ?: "<no source>", codegen)
             return
         }
         try {
@@ -41,4 +38,8 @@ interface IrInlineCallGenerator : IrCallGenerator {
         expression: IrFunctionAccessExpression,
         isInsideIfCondition: Boolean,
     )
+
+    fun genCycleStub(text: String, codegen: ExpressionCodegen) {
+        AsmUtil.genThrow(codegen.visitor, "java/lang/UnsupportedOperationException", "Call is a part of inline call cycle: $text")
+    }
 }

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/IrInlineCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/IrInlineCodegen.kt
@@ -153,6 +153,10 @@ class IrInlineCodegen(
         )
     }
 
+    override fun genCycleStub(text: String, codegen: ExpressionCodegen) {
+        generateStub(text, codegen)
+    }
+
     override fun extractDefaultLambdas(node: MethodNode): List<DefaultLambda> {
         if (maskStartIndex == -1) return listOf()
         return expandMaskConditionsAndUpdateVariableNodes(

--- a/compiler/testData/diagnostics/testsWithJvmBackend/propertyInlineCycle.kt
+++ b/compiler/testData/diagnostics/testsWithJvmBackend/propertyInlineCycle.kt
@@ -1,0 +1,3 @@
+// TARGET_BACKEND: JVM
+inline val String.foo: String
+    get() = <!INLINE_CALL_CYCLE!>foo<!>

--- a/compiler/testData/diagnostics/testsWithJvmBackend/propertyInlineCycle.txt
+++ b/compiler/testData/diagnostics/testsWithJvmBackend/propertyInlineCycle.txt
@@ -1,0 +1,3 @@
+package
+
+public val kotlin.String.foo: kotlin.String

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/DiagnosticsTestWithJvmIrBackendGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/DiagnosticsTestWithJvmIrBackendGenerated.java
@@ -50,6 +50,12 @@ public class DiagnosticsTestWithJvmIrBackendGenerated extends AbstractDiagnostic
     }
 
     @Test
+    @TestMetadata("propertyInlineCycle.kt")
+    public void testPropertyInlineCycle() throws Exception {
+        runTest("compiler/testData/diagnostics/testsWithJvmBackend/propertyInlineCycle.kt");
+    }
+
+    @Test
     @TestMetadata("suspendInlineCycle_ir.kt")
     public void testSuspendInlineCycle_ir() throws Exception {
         runTest("compiler/testData/diagnostics/testsWithJvmBackend/suspendInlineCycle_ir.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/DiagnosticsTestWithOldJvmBackendGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/DiagnosticsTestWithOldJvmBackendGenerated.java
@@ -50,6 +50,12 @@ public class DiagnosticsTestWithOldJvmBackendGenerated extends AbstractDiagnosti
     }
 
     @Test
+    @TestMetadata("propertyInlineCycle.kt")
+    public void testPropertyInlineCycle() throws Exception {
+        runTest("compiler/testData/diagnostics/testsWithJvmBackend/propertyInlineCycle.kt");
+    }
+
+    @Test
     @TestMetadata("suspendInlineCycle.kt")
     public void testSuspendInlineCycle() throws Exception {
         runTest("compiler/testData/diagnostics/testsWithJvmBackend/suspendInlineCycle.kt");


### PR DESCRIPTION
 1. use the correct descriptor in the old backend;
 2. clear the temporary variables for arguments in the IR backend.

 #KT-45292 Fixed