### PR TITLE
FIR IDE: check generated primary constructor

### DIFF
--- a/idea/idea-frontend-fir/idea-fir-low-level-api/src/org/jetbrains/kotlin/idea/fir/low/level/api/file/structure/FileStructureElement.kt
+++ b/idea/idea-frontend-fir/idea-fir-low-level-api/src/org/jetbrains/kotlin/idea/fir/low/level/api/file/structure/FileStructureElement.kt
@@ -173,10 +173,15 @@ internal class NonReanalyzableDeclarationStructureElement(
                 firFile,
                 onDeclarationEnter = { firDeclaration ->
                     when {
-                        // Some generated declaration contains structures that we need to check. For example the FIR representation of an
-                        // enum entry initializer, when present, is a generated anonymous object of kind `ENUM_ENTRY`.
-                        firDeclaration.isGeneratedDeclaration ->
-                            DiagnosticCollectorDeclarationAction.DO_NOT_CHECK_IN_CURRENT_DECLARATION_AND_LOOKUP_FOR_NESTED
+                        firDeclaration.isGeneratedDeclaration -> when {
+                            // a generated primary constructor need to be checked. For example it may have a delegated super constructor
+                            // call or some annotations
+                            firDeclaration is FirConstructor && firDeclaration.isPrimary ->
+                                DiagnosticCollectorDeclarationAction.CHECK_IN_CURRENT_DECLARATION_AND_LOOKUP_FOR_NESTED
+                            // Some generated declaration contains structures that we need to check. For example the FIR representation of an
+                            // enum entry initializer, when present, is a generated anonymous object of kind `ENUM_ENTRY`.
+                            else -> DiagnosticCollectorDeclarationAction.DO_NOT_CHECK_IN_CURRENT_DECLARATION_AND_LOOKUP_FOR_NESTED
+                        }
                         firDeclaration is FirFile -> DiagnosticCollectorDeclarationAction.DO_NOT_CHECK_IN_CURRENT_DECLARATION_AND_LOOKUP_FOR_NESTED
                         firDeclaration == fir -> {
                             inCurrentDeclaration = true


### PR DESCRIPTION
Currently the IDE skips checking the delegated constructor call because
the primary constructor is generated if it's declared with the class.