### PR TITLE
Make kotlin.jvm.internal.DefaultConstructorMarker public

### DIFF
--- a/libraries/stdlib/jvm/runtime/kotlin/jvm/internal/DefaultConstructorMarker.java
+++ b/libraries/stdlib/jvm/runtime/kotlin/jvm/internal/DefaultConstructorMarker.java
@@ -5,6 +5,6 @@
 
 package kotlin.jvm.internal;
 
-final class DefaultConstructorMarker {
+public final class DefaultConstructorMarker {
     private DefaultConstructorMarker() {}
 }

--- a/libraries/tools/binary-compatibility-validator/reference-public-api/kotlin-stdlib-runtime-merged.txt
+++ b/libraries/tools/binary-compatibility-validator/reference-public-api/kotlin-stdlib-runtime-merged.txt
@@ -3536,6 +3536,9 @@ public final class kotlin/jvm/internal/CollectionToArray {
 	public static final fun toArray (Ljava/util/Collection;[Ljava/lang/Object;)[Ljava/lang/Object;
 }
 
+public final class kotlin/jvm/internal/DefaultConstructorMarker {
+}
+
 public final class kotlin/jvm/internal/DoubleCompanionObject {
 	public static final field INSTANCE Lkotlin/jvm/internal/DoubleCompanionObject;
 	public static final field MAX_VALUE D


### PR DESCRIPTION
DefaultConstructorMarker is used as a marker to ensure that a
constructor is unique for companion objects. Prior to this change,
DefaultConstructorMarker was package private.

Being package private worked when calling the
DefaultConstructorMarker-marked constsructor using `invokespecial`,
likely because the JVM may not perform strict access checks in this
situation.

However, when access checks are performed, trying to call a
DefaultConstructorMarker-marked constructor will fail. This could happen
if the constructor was called using reflection or the MethodHandle API.
These APIs may be used by tools that perform bytecode instrumentation
on Kotlin JVM bytecode, such as Robolectric. It also caused problems
when using ByteBuddy validation.

Fixes https://youtrack.jetbrains.com/issue/KT-20869