### PR TITLE
FIR CFG: correct target and label for rethrow in try expression

### DIFF
--- a/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsTestGenerated.java
@@ -363,6 +363,12 @@ public class FirOldFrontendDiagnosticsTestGenerated extends AbstractFirDiagnosti
         }
 
         @Test
+        @TestMetadata("initializedAfterRethrow.kt")
+        public void testInitializedAfterRethrow() throws Exception {
+            runTest("compiler/testData/diagnostics/tests/initializedAfterRethrow.kt");
+        }
+
+        @Test
         @TestMetadata("InvokeAndRecursiveResolve.kt")
         public void testInvokeAndRecursiveResolve() throws Exception {
             runTest("compiler/testData/diagnostics/tests/InvokeAndRecursiveResolve.kt");

--- a/compiler/testData/codegen/boxInline/complexStack/spillConstructorArgumentsAndInlineLambdaParameter.kt
+++ b/compiler/testData/codegen/boxInline/complexStack/spillConstructorArgumentsAndInlineLambdaParameter.kt
@@ -1,4 +1,3 @@
-// IGNORE_FIR_DIAGNOSTICS
 // FILE: 1.kt
 class A(val s: String)
 

--- a/compiler/testData/diagnostics/tests/initializedAfterRethrow.fir.kt
+++ b/compiler/testData/diagnostics/tests/initializedAfterRethrow.fir.kt
@@ -1,0 +1,222 @@
+fun foo(): Int = 42
+
+object ThrowInTryWithCatch {
+    <!MUST_BE_INITIALIZED_OR_BE_ABSTRACT!>private val p: String<!>
+
+    init {
+        try {
+            throw Exception()
+        } catch (e: Exception) {
+        }
+        p = "OK"
+    }
+}
+
+object ThrowInTryWithCatchAndFinally {
+    <!MUST_BE_INITIALIZED_OR_BE_ABSTRACT!>private val p: String<!>
+
+    init {
+        try {
+            throw Exception()
+        } catch (e: Exception) {
+        } finally {
+        }
+        p = "OK"
+    }
+}
+
+object ThrowInFinally {
+    <!MUST_BE_INITIALIZED_OR_BE_ABSTRACT!>private val p: String<!>
+
+    init {
+        try {
+            foo()
+        } catch (e: Exception) {
+        } finally {
+            throw Exception()
+        }
+        p = "OK"
+    }
+}
+
+object RethrowInCatch {
+    <!MUST_BE_INITIALIZED_OR_BE_ABSTRACT!>private val p: String<!>
+
+    init {
+        try {
+            foo()
+        } catch (e: Exception) {
+            throw e
+        }
+        p = "OK"
+    }
+}
+
+object RethrowInCatchWithFinally {
+    <!MUST_BE_INITIALIZED_OR_BE_ABSTRACT!>private val p: String<!>
+
+    init {
+        try {
+            foo()
+        } catch (e: Exception) {
+            throw e
+        } finally {
+        }
+        p = "OK"
+    }
+}
+
+object InnerTryWithCatch {
+    <!MUST_BE_INITIALIZED_OR_BE_ABSTRACT!>private val p: String<!>
+
+    init {
+        try {
+            foo()
+        } catch (e: Exception) {
+            try {
+                throw e
+            } catch (ee: Exception) {
+            }
+        }
+        p = "OK"
+    }
+}
+
+object InnerTryWithFinally {
+    <!MUST_BE_INITIALIZED_OR_BE_ABSTRACT!>private val p: String<!>
+
+    init {
+        try {
+            foo()
+        } catch (e: Exception) {
+            try {
+                throw e
+            } finally {
+            }
+        }
+        p = "OK"
+    }
+}
+
+
+object InnerTryWithCatchAndFinally {
+    <!MUST_BE_INITIALIZED_OR_BE_ABSTRACT!>private val p: String<!>
+
+    init {
+        try {
+            foo()
+        } catch (e: Exception) {
+            try {
+                throw e
+            } catch (ee: Exception) {
+            } finally {
+            }
+        }
+        p = "OK"
+    }
+}
+
+object InnerCatch {
+    <!MUST_BE_INITIALIZED_OR_BE_ABSTRACT!>private val p: String<!>
+
+    init {
+        try {
+            foo()
+        } catch (e: Exception) {
+            try {
+                foo()
+            } catch (ee: Exception) {
+                throw ee
+            }
+        }
+        p = "OK"
+    }
+}
+
+object InnerCatchWithFinally {
+    <!MUST_BE_INITIALIZED_OR_BE_ABSTRACT!>private val p: String<!>
+
+    init {
+        try {
+            foo()
+        } catch (e: Exception) {
+            try {
+                foo()
+            } catch (ee: Exception) {
+                throw ee
+            } finally {
+            }
+        }
+        p = "OK"
+    }
+}
+
+object InnerCatchOuterRethrow {
+    <!MUST_BE_INITIALIZED_OR_BE_ABSTRACT!>private val p: String<!>
+
+    init {
+        try {
+            foo()
+        } catch (e: Exception) {
+            try {
+                foo()
+            } catch (ee: Exception) {
+                throw e
+            }
+        }
+        p = "OK"
+    }
+}
+
+object InnerCatchOuterRethrowWithFinally {
+    <!MUST_BE_INITIALIZED_OR_BE_ABSTRACT!>private val p: String<!>
+
+    init {
+        try {
+            foo()
+        } catch (e: Exception) {
+            try {
+                foo()
+            } catch (ee: Exception) {
+                throw e
+            } finally {
+            }
+        }
+        p = "OK"
+    }
+}
+
+object InnerFinally {
+    <!MUST_BE_INITIALIZED_OR_BE_ABSTRACT!>private val p: String<!>
+
+    init {
+        try {
+            foo()
+        } catch (e: Exception) {
+            try {
+                foo()
+            } finally {
+                throw e
+            }
+        }
+        p = "OK"
+    }
+}
+
+object InnerFinallyWithCatch {
+    <!MUST_BE_INITIALIZED_OR_BE_ABSTRACT!>private val p: String<!>
+
+    init {
+        try {
+            foo()
+        } catch (e: Exception) {
+            try {
+                foo()
+            } catch (ee: Exception) {
+            } finally {
+                throw e
+            }
+        }
+        p = "OK"
+    }
+}

--- a/compiler/testData/diagnostics/tests/initializedAfterRethrow.fir.kt
+++ b/compiler/testData/diagnostics/tests/initializedAfterRethrow.fir.kt
@@ -1,7 +1,7 @@
 fun foo(): Int = 42
 
 object ThrowInTryWithCatch {
-    <!MUST_BE_INITIALIZED_OR_BE_ABSTRACT!>private val p: String<!>
+    private val p: String
 
     init {
         try {
@@ -40,7 +40,7 @@ object ThrowInFinally {
 }
 
 object RethrowInCatch {
-    <!MUST_BE_INITIALIZED_OR_BE_ABSTRACT!>private val p: String<!>
+    private val p: String
 
     init {
         try {
@@ -67,7 +67,7 @@ object RethrowInCatchWithFinally {
 }
 
 object InnerTryWithCatch {
-    <!MUST_BE_INITIALIZED_OR_BE_ABSTRACT!>private val p: String<!>
+    private val p: String
 
     init {
         try {
@@ -117,7 +117,7 @@ object InnerTryWithCatchAndFinally {
 }
 
 object InnerCatch {
-    <!MUST_BE_INITIALIZED_OR_BE_ABSTRACT!>private val p: String<!>
+    private val p: String
 
     init {
         try {
@@ -152,7 +152,7 @@ object InnerCatchWithFinally {
 }
 
 object InnerCatchOuterRethrow {
-    <!MUST_BE_INITIALIZED_OR_BE_ABSTRACT!>private val p: String<!>
+    private val p: String
 
     init {
         try {

--- a/compiler/testData/diagnostics/tests/initializedAfterRethrow.kt
+++ b/compiler/testData/diagnostics/tests/initializedAfterRethrow.kt
@@ -1,0 +1,222 @@
+fun foo(): Int = 42
+
+object ThrowInTryWithCatch {
+    private val p: String
+
+    init {
+        try {
+            throw Exception()
+        } catch (e: Exception) {
+        }
+        p = "OK"
+    }
+}
+
+object ThrowInTryWithCatchAndFinally {
+    private val p: String
+
+    init {
+        try {
+            throw Exception()
+        } catch (e: Exception) {
+        } finally {
+        }
+        p = "OK"
+    }
+}
+
+object ThrowInFinally {
+    <!MUST_BE_INITIALIZED_OR_BE_ABSTRACT!>private val p: String<!>
+
+    init {
+        try {
+            foo()
+        } catch (e: Exception) {
+        } finally {
+            throw Exception()
+        }
+        p = "OK"
+    }
+}
+
+object RethrowInCatch {
+    private val p: String
+
+    init {
+        try {
+            foo()
+        } catch (e: Exception) {
+            throw e
+        }
+        p = "OK"
+    }
+}
+
+object RethrowInCatchWithFinally {
+    private val p: String
+
+    init {
+        try {
+            foo()
+        } catch (e: Exception) {
+            throw e
+        } finally {
+        }
+        p = "OK"
+    }
+}
+
+object InnerTryWithCatch {
+    private val p: String
+
+    init {
+        try {
+            foo()
+        } catch (e: Exception) {
+            try {
+                throw e
+            } catch (ee: Exception) {
+            }
+        }
+        p = "OK"
+    }
+}
+
+object InnerTryWithFinally {
+    private val p: String
+
+    init {
+        try {
+            foo()
+        } catch (e: Exception) {
+            try {
+                throw e
+            } finally {
+            }
+        }
+        p = "OK"
+    }
+}
+
+
+object InnerTryWithCatchAndFinally {
+    private val p: String
+
+    init {
+        try {
+            foo()
+        } catch (e: Exception) {
+            try {
+                throw e
+            } catch (ee: Exception) {
+            } finally {
+            }
+        }
+        p = "OK"
+    }
+}
+
+object InnerCatch {
+    private val p: String
+
+    init {
+        try {
+            foo()
+        } catch (e: Exception) {
+            try {
+                foo()
+            } catch (ee: Exception) {
+                throw ee
+            }
+        }
+        p = "OK"
+    }
+}
+
+object InnerCatchWithFinally {
+    private val p: String
+
+    init {
+        try {
+            foo()
+        } catch (e: Exception) {
+            try {
+                foo()
+            } catch (ee: Exception) {
+                throw ee
+            } finally {
+            }
+        }
+        p = "OK"
+    }
+}
+
+object InnerCatchOuterRethrow {
+    private val p: String
+
+    init {
+        try {
+            foo()
+        } catch (e: Exception) {
+            try {
+                foo()
+            } catch (ee: Exception) {
+                throw e
+            }
+        }
+        p = "OK"
+    }
+}
+
+object InnerCatchOuterRethrowWithFinally {
+    private val p: String
+
+    init {
+        try {
+            foo()
+        } catch (e: Exception) {
+            try {
+                foo()
+            } catch (ee: Exception) {
+                throw e
+            } finally {
+            }
+        }
+        p = "OK"
+    }
+}
+
+object InnerFinally {
+    private val p: String
+
+    init {
+        try {
+            foo()
+        } catch (e: Exception) {
+            try {
+                foo()
+            } finally {
+                throw e
+            }
+        }
+        p = "OK"
+    }
+}
+
+object InnerFinallyWithCatch {
+    private val p: String
+
+    init {
+        try {
+            foo()
+        } catch (e: Exception) {
+            try {
+                foo()
+            } catch (ee: Exception) {
+            } finally {
+                throw e
+            }
+        }
+        p = "OK"
+    }
+}

--- a/compiler/testData/diagnostics/tests/initializedAfterRethrow.txt
+++ b/compiler/testData/diagnostics/tests/initializedAfterRethrow.txt
@@ -1,0 +1,116 @@
+package
+
+public fun foo(): kotlin.Int
+
+public object InnerCatch {
+    private constructor InnerCatch()
+    private final val p: kotlin.String
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public object InnerCatchOuterRethrow {
+    private constructor InnerCatchOuterRethrow()
+    private final val p: kotlin.String
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public object InnerCatchOuterRethrowWithFinally {
+    private constructor InnerCatchOuterRethrowWithFinally()
+    private final val p: kotlin.String
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public object InnerCatchWithFinally {
+    private constructor InnerCatchWithFinally()
+    private final val p: kotlin.String
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public object InnerFinally {
+    private constructor InnerFinally()
+    private final val p: kotlin.String
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public object InnerFinallyWithCatch {
+    private constructor InnerFinallyWithCatch()
+    private final val p: kotlin.String
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public object InnerTryWithCatch {
+    private constructor InnerTryWithCatch()
+    private final val p: kotlin.String
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public object InnerTryWithCatchAndFinally {
+    private constructor InnerTryWithCatchAndFinally()
+    private final val p: kotlin.String
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public object InnerTryWithFinally {
+    private constructor InnerTryWithFinally()
+    private final val p: kotlin.String
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public object RethrowInCatch {
+    private constructor RethrowInCatch()
+    private final val p: kotlin.String
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public object RethrowInCatchWithFinally {
+    private constructor RethrowInCatchWithFinally()
+    private final val p: kotlin.String
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public object ThrowInFinally {
+    private constructor ThrowInFinally()
+    private final val p: kotlin.String
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public object ThrowInTryWithCatch {
+    private constructor ThrowInTryWithCatch()
+    private final val p: kotlin.String
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public object ThrowInTryWithCatchAndFinally {
+    private constructor ThrowInTryWithCatchAndFinally()
+    private final val p: kotlin.String
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/DiagnosticTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/DiagnosticTestGenerated.java
@@ -363,6 +363,12 @@ public class DiagnosticTestGenerated extends AbstractDiagnosticTest {
         }
 
         @Test
+        @TestMetadata("initializedAfterRethrow.kt")
+        public void testInitializedAfterRethrow() throws Exception {
+            runTest("compiler/testData/diagnostics/tests/initializedAfterRethrow.kt");
+        }
+
+        @Test
         @TestMetadata("InvokeAndRecursiveResolve.kt")
         public void testInvokeAndRecursiveResolve() throws Exception {
             runTest("compiler/testData/diagnostics/tests/InvokeAndRecursiveResolve.kt");


### PR DESCRIPTION
The main motivation is [KT-45385](https://youtrack.jetbrains.com/issue/KT-45385):
```kt
fun foo(): Int = 42

object O {
  private val p: String // initialized

  init {
    try {
      foo()
    } catch (e: Exception) {
      throw e
    }
    p = "OK"
  }
}
```
For a node that returns `Nothing`, such as `throw`, #4184 labeled an edge with a special `UncaughtExceptionPath`, only if it's not caught by `try` expression. However, as shown at the above example, "re"-throwing expression still needs the same `UncaughtExceptionPath`.

1st commit adds several variations to cover many different `throw` with `try` expression. 2nd commit revisits how FIR CFG adds an edge for a node that returns `Nothing`. At a high-level, the main changes are two-fold:
1) route to `finally` if such node is either in `try` main or in `catch` clause _with_ `finally`.
2) except for `throw` in `try` main, everything else needs an uncaught exception path. In details:
  2-1) `throw` not in `try`
  2-2) in `try` with `finally` (but not in `finally`) -> route to `finally`
  2-3) in `try` without `finally`, but only `catch` case. For `try` main case, we already have necessary edges
  2-4) in `finally`

The original issue is resolved, and many examples added at the 1st commit match with FE 1.0. However, all the examples with `finally` still have false positives, which needs more investigations (but I guess it's the time to add label-based path differentiation at the exit of `finally` indeed).