### PR TITLE
[KAPT] KT-32202 JPMS support

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kapt3IT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kapt3IT.kt
@@ -679,19 +679,22 @@ open class Kapt3IT : Kapt3BaseIT() {
 
     @Test
     fun testJpmsModule() {
+        //jpms is part of java >= 9
+        val javaHome = File(System.getProperty("jdk9Home")!!)
+        Assume.assumeTrue("JDK 9 isn't available", javaHome.isDirectory)
+        val options = defaultBuildOptions().copy(javaHome = javaHome)
+
         val project = Project("jpms-module", directoryPrefix = "kapt2")
 
-        project.build("build") {
+        project.build("build", options = options) {
             assertSuccessful()
             assertKaptSuccessful()
             assertTasksExecuted(":compileKotlin", ":compileJava")
             assertFileExists("build/generated/source/kapt/main/lab/TestClassGenerated.java")
             assertFileExists(kotlinClassesDir() + "lab/TestClass.class")
-
-//            assertContains("Need to discovery annotation processors in the AP classpath")
         }
 
-        project.build("build") {
+        project.build("build", options = options) {
             assertSuccessful()
             assertTasksUpToDate(":compileKotlin", ":compileJava")
         }
@@ -703,7 +706,7 @@ open class Kapt3IT : Kapt3BaseIT() {
             )
         }
 
-        project.build("build") {
+        project.build("build", options = options) {
             assertSuccessful()
             assertKaptSuccessful()
             assertTasksExecuted(":compileKotlin", ":compileJava")

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kapt3IT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kapt3IT.kt
@@ -676,4 +676,24 @@ open class Kapt3IT : Kapt3BaseIT() {
             assertContains("Javac options: {-source=1.8}")
         }
     }
+
+    @Test
+    fun testJpmsModule() {
+        val project = Project("jpms-module", directoryPrefix = "kapt2")
+
+        project.build("build") {
+            assertSuccessful()
+            assertKaptSuccessful()
+            assertTasksExecuted(":compileKotlin", ":compileJava")
+            assertFileExists("build/generated/source/kapt/main/lab/TestClassGenerated.java")
+            assertFileExists(kotlinClassesDir() + "lab/TestClass.class")
+
+//            assertContains("Need to discovery annotation processors in the AP classpath")
+        }
+
+        project.build("build") {
+            assertSuccessful()
+            assertTasksUpToDate(":compileKotlin", ":compileJava")
+        }
+    }
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kapt3IT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kapt3IT.kt
@@ -695,5 +695,19 @@ open class Kapt3IT : Kapt3BaseIT() {
             assertSuccessful()
             assertTasksUpToDate(":compileKotlin", ":compileJava")
         }
+
+        project.projectDir.getFileByName("InjectedClass.kt").modify { text ->
+            text.checkedReplace(
+                "//placeholder",
+                "fun someChange() = null"
+            )
+        }
+
+        project.build("build") {
+            assertSuccessful()
+            assertKaptSuccessful()
+            assertTasksExecuted(":compileKotlin", ":compileJava")
+           
+        }
     }
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/jpms-module/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/jpms-module/build.gradle
@@ -23,17 +23,22 @@ dependencies {
     implementation "org.jetbrains.kotlin:annotation-processor-example:$kotlin_version"
     kapt "org.jetbrains.kotlin:annotation-processor-example:$kotlin_version"
 
+    implementation 'com.google.dagger:dagger:2.33'
+    kapt 'com.google.dagger:dagger-compiler:2.33'
+
     //jpms module provider
     implementation "org.apache.logging.log4j:log4j-api:2.14.0"
 }
 
 compileKotlin.kotlinOptions.allWarningsAsErrors = true
 
-//workaround to make classpath into modules for java compilation
 compileJava {
     doFirst {
         options.compilerArgs += [
-                '--module-path', classpath.asPath
+                //workaround to make classpath into modules for java compilation so auto modules would work
+                '--module-path', classpath.asPath,
+                //provide compiled kotlin classes to javac (needed for java/kotlin mixed sources to work)
+                '--patch-module', "my.module=${sourceSets.main.output.asPath}"
         ]
     }
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/jpms-module/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/jpms-module/build.gradle
@@ -1,0 +1,46 @@
+buildscript {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    }
+}
+
+apply plugin: "java"
+apply plugin: "kotlin"
+apply plugin: "kotlin-kapt"
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:annotation-processor-example:$kotlin_version"
+    kapt "org.jetbrains.kotlin:annotation-processor-example:$kotlin_version"
+
+    //jpms module provider
+    implementation "org.apache.logging.log4j:log4j-api:2.14.0"
+}
+
+compileKotlin.kotlinOptions.allWarningsAsErrors = true
+
+//workaround to make classpath into modules for java compilation
+compileJava {
+    doFirst {
+        options.compilerArgs += [
+                '--module-path', classpath.asPath
+        ]
+    }
+}
+
+//starting from gradle 6.4 it has built in jpms support
+//still as for now it doesn't work with fully legacy jars (with no module's descriptor)
+//so we need workaround above till we get AP packed as module
+//java {
+//    modularity.inferModulePath.set(true)
+//}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/jpms-module/gradle.properties
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/jpms-module/gradle.properties
@@ -1,0 +1,1 @@
+kapt.verbose=true

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/jpms-module/src/main/java/dagger_example/ApplicationComponent.java
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/jpms-module/src/main/java/dagger_example/ApplicationComponent.java
@@ -1,0 +1,8 @@
+package dagger_example;
+
+import dagger.Component;
+
+@Component(modules = {ExampleModule.class})
+public interface ApplicationComponent {
+    void inject(Main main);
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/jpms-module/src/main/java/dagger_example/ExampleModule.java
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/jpms-module/src/main/java/dagger_example/ExampleModule.java
@@ -1,0 +1,13 @@
+package dagger_example;
+
+import dagger.Binds;
+import dagger.Module;
+
+@Module
+public abstract class ExampleModule {
+    @Binds
+    public abstract Injected bindInjected(InjectedImpl impl);
+
+    @Binds
+    public abstract OtherInjected bindOtherInjected(OtherInjectedImpl impl);
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/jpms-module/src/main/java/dagger_example/Main.java
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/jpms-module/src/main/java/dagger_example/Main.java
@@ -1,0 +1,20 @@
+package dagger_example;
+
+import javax.inject.Inject;
+
+public class Main {
+    @Inject
+    Injected injected;
+
+    @Inject
+    OtherInjected otherInjected;
+
+    public static void main(String[] args) {
+        new Main().example();
+    }
+
+    private void example() {
+        DaggerApplicationComponent.create().inject(this);
+        System.out.println(injected.getMessage());
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/jpms-module/src/main/java/dagger_example/OtherInjected.java
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/jpms-module/src/main/java/dagger_example/OtherInjected.java
@@ -1,0 +1,6 @@
+package dagger_example;
+
+public interface OtherInjected {
+
+    public String getMessage();
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/jpms-module/src/main/java/dagger_example/OtherInjectedImpl.java
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/jpms-module/src/main/java/dagger_example/OtherInjectedImpl.java
@@ -1,0 +1,16 @@
+package dagger_example;
+
+import javax.inject.Inject;
+
+public class OtherInjectedImpl implements OtherInjected {
+
+    @Inject
+    public OtherInjectedImpl() {
+
+    }
+
+    @Override
+    public String getMessage() {
+        return "zzzz";
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/jpms-module/src/main/java/module-info.java
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/jpms-module/src/main/java/module-info.java
@@ -1,0 +1,5 @@
+module my.module {
+    requires kotlin.stdlib;
+    requires org.apache.logging.log4j;
+    requires annotation.processor.example;
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/jpms-module/src/main/java/module-info.java
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/jpms-module/src/main/java/module-info.java
@@ -2,4 +2,9 @@ module my.module {
     requires kotlin.stdlib;
     requires org.apache.logging.log4j;
     requires annotation.processor.example;
+
+    requires dagger;
+    requires javax.inject;
+    //because dagger generates classes with @javax.annotation.processing.Generated
+    requires java.compiler;
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/jpms-module/src/main/kotlin/dagger_example/InjectedClass.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/jpms-module/src/main/kotlin/dagger_example/InjectedClass.kt
@@ -1,0 +1,14 @@
+package dagger_example
+
+import javax.inject.Inject
+
+interface Injected {
+
+    val message: String
+}
+
+class InjectedImpl @Inject constructor() : Injected {
+    override val message = "This is injected1: " + SomeOtherClass().callMe()
+
+    //placeholder
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/jpms-module/src/main/kotlin/dagger_example/SomeOtherClass.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/jpms-module/src/main/kotlin/dagger_example/SomeOtherClass.kt
@@ -1,0 +1,7 @@
+package dagger_example
+
+class SomeOtherClass {
+
+    fun callMe() = "hell1o"
+    fun changeMe() = null
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/jpms-module/src/main/kotlin/lab/test.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/jpms-module/src/main/kotlin/lab/test.kt
@@ -1,0 +1,15 @@
+package lab
+
+@example.ExampleAnnotation
+@example.ExampleSourceAnnotation
+@example.ExampleBinaryAnnotation
+@example.ExampleRuntimeAnnotation
+public class TestClass {
+
+    @example.ExampleAnnotation
+    public val testVal: String = "text"
+
+    @example.ExampleAnnotation
+    public fun testFunction(): TestClassGenerated = TestClassGenerated()
+
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/jpms-module/src/main/kotlin/test/ModuleUser.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/jpms-module/src/main/kotlin/test/ModuleUser.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package test
+
+import org.apache.logging.log4j.util.Base64Util
+import org.apache.logging.log4j.*
+
+@example.ExampleAnnotation
+class ModuleUser {
+
+    fun useSomethingFromModule(): String = Base64Util.encode("test")
+
+    fun haveSomeUsageInSignature(): Logger = TODO("I have nothing")
+}

--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/KaptContext.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/KaptContext.kt
@@ -35,17 +35,6 @@ open class KaptContext(val options: KaptOptions, val withJdk: Boolean, val logge
 
     val sourcesToReprocess: SourcesToReprocess
 
-    private val isJava9Module by lazy {
-        if (isJava9OrLater()) {
-            options.javaSourceRoots.any { file ->
-                (file.name == MODULE_INFO_FILE ||
-                        (file.isDirectory && file.listFiles()?.any { it.name == MODULE_INFO_FILE } ?: false))
-            }
-        } else {
-            false
-        }
-    }
-
     protected open fun preregisterTreeMaker(context: Context) {}
 
     private fun preregisterLog(context: Context) {
@@ -131,19 +120,7 @@ open class KaptContext(val options: KaptOptions, val withJdk: Boolean, val logge
                 options.compileClasspath + options.compiledSources + options.classesOutputDir
             }
 
-            if (isJava9Module) {
-                logger.info("11JPMS module discovered. Adding --module-path option to javac")
-                put(Option.valueOf("MODULE_PATH"), compileClasspath.makePathsString())
-                //we provide minimum useful java version to jpms modules discovery work properly
-                //maybe should add option to override it or infer it from current java version.
-                put(Option.valueOf("MULTIRELEASE"), "9")
-                putJavacOption(
-                    "CLASSPATH", "CLASS_PATH",
-                    (options.compiledSources + options.classesOutputDir).makePathsString()
-                )
-            } else {
-                putJavacOption("CLASSPATH", "CLASS_PATH", compileClasspath.makePathsString())
-            }
+            putJavacOption("CLASSPATH", "CLASS_PATH", compileClasspath.makePathsString())
 
             @Suppress("SpellCheckingInspection")
             putJavacOption("PROCESSORPATH", "PROCESSOR_PATH", options.processingClasspath.makePathsString())
@@ -187,7 +164,7 @@ open class KaptContext(val options: KaptOptions, val withJdk: Boolean, val logge
     }
 
     companion object {
-        private const val MODULE_INFO_FILE = "module-info.java"
+        const val MODULE_INFO_FILE = "module-info.java"
 
         private fun Iterable<File>.makePathsString(): String = joinToString(File.pathSeparator) { it.canonicalPath }
     }

--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/KaptContext.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/KaptContext.kt
@@ -35,6 +35,17 @@ open class KaptContext(val options: KaptOptions, val withJdk: Boolean, val logge
 
     val sourcesToReprocess: SourcesToReprocess
 
+    private val isJava9Module by lazy {
+        if (isJava9OrLater()) {
+            options.javaSourceRoots.any { file ->
+                (file.name == MODULE_INFO_FILE ||
+                        (file.isDirectory && file.listFiles()?.any { it.name == MODULE_INFO_FILE } ?: false))
+            }
+        } else {
+            false
+        }
+    }
+
     protected open fun preregisterTreeMaker(context: Context) {}
 
     private fun preregisterLog(context: Context) {
@@ -120,12 +131,22 @@ open class KaptContext(val options: KaptOptions, val withJdk: Boolean, val logge
                 options.compileClasspath + options.compiledSources + options.classesOutputDir
             }
 
-            putJavacOption("CLASSPATH", "CLASS_PATH",
-                           compileClasspath.joinToString(File.pathSeparator) { it.canonicalPath })
+            if (isJava9Module) {
+                logger.info("11JPMS module discovered. Adding --module-path option to javac")
+                put(Option.valueOf("MODULE_PATH"), compileClasspath.makePathsString())
+                //we provide minimum useful java version to jpms modules discovery work properly
+                //maybe should add option to override it or infer it from current java version.
+                put(Option.valueOf("MULTIRELEASE"), "9")
+                putJavacOption(
+                    "CLASSPATH", "CLASS_PATH",
+                    (options.compiledSources + options.classesOutputDir).makePathsString()
+                )
+            } else {
+                putJavacOption("CLASSPATH", "CLASS_PATH", compileClasspath.makePathsString())
+            }
 
             @Suppress("SpellCheckingInspection")
-            putJavacOption("PROCESSORPATH", "PROCESSOR_PATH",
-                           options.processingClasspath.joinToString(File.pathSeparator) { it.canonicalPath })
+            putJavacOption("PROCESSORPATH", "PROCESSOR_PATH", options.processingClasspath.makePathsString())
 
             put(Option.S, options.sourcesOutputDir.canonicalPath)
             put(Option.D, options.classesOutputDir.canonicalPath)
@@ -163,5 +184,11 @@ open class KaptContext(val options: KaptOptions, val withJdk: Boolean, val logge
         cacheManager?.close()
         compiler.close()
         fileManager.close()
+    }
+
+    companion object {
+        private const val MODULE_INFO_FILE = "module-info.java"
+
+        private fun Iterable<File>.makePathsString(): String = joinToString(File.pathSeparator) { it.canonicalPath }
     }
 }


### PR DESCRIPTION
Disable jpms for kapt, because modules will be validated in kotlin compiler and in javac anyway.