### PR TITLE
FIR CFG: route to exit of try main for throw in try main

### DIFF
--- a/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsTestGenerated.java
@@ -25746,6 +25746,12 @@ public class FirOldFrontendDiagnosticsTestGenerated extends AbstractFirDiagnosti
             }
 
             @Test
+            @TestMetadata("throwInTry.kt")
+            public void testThrowInTry() throws Exception {
+                runTest("compiler/testData/diagnostics/tests/smartCasts/throwInTry.kt");
+            }
+
+            @Test
             @TestMetadata("twoImplicitReceivers.kt")
             public void testTwoImplicitReceivers() throws Exception {
                 runTest("compiler/testData/diagnostics/tests/smartCasts/twoImplicitReceivers.kt");

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/dfa/FirDataFlowAnalyzer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/dfa/FirDataFlowAnalyzer.kt
@@ -718,8 +718,8 @@ abstract class FirDataFlowAnalyzer<FLOW : Flow>(
         tryMainBlockEnterNode.mergeIncomingFlow(shouldForkFlow = true)
     }
 
-    fun exitTryMainBlock(tryExpression: FirTryExpression) {
-        graphBuilder.exitTryMainBlock(tryExpression).mergeIncomingFlow()
+    fun exitTryMainBlock() {
+        graphBuilder.exitTryMainBlock().mergeIncomingFlow()
     }
 
     fun enterCatchClause(catch: FirCatch) {

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/dfa/cfg/ControlFlowGraphBuilder.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/dfa/cfg/ControlFlowGraphBuilder.kt
@@ -1272,10 +1272,10 @@ class ControlFlowGraphBuilder {
                     // (4)... in catch, i.e., re-throw.
                     exitTargetsForTry.top()
                 } else {
-                    // (4)... in try-main. We already have:
-                    // edges from try-main enter node to each catch clause enter node and
-                    // edges from catch clause enter node to exit target (w/ UncaughtExceptionPath)
-                    return
+                    // (4)... in try-main. Route to exit of try main block.
+                    // We already have edges from the exit of try main block to each catch clause.
+                    // This edge makes the remaining part of try main block, e.g., following `when` branches, marked as dead.
+                    tryMainExitNodes.top()
                 }
             }
             // (3)... within finally.

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirControlFlowStatementsResolveTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirControlFlowStatementsResolveTransformer.kt
@@ -144,7 +144,7 @@ class FirControlFlowStatementsResolveTransformer(transformer: FirBodyResolveTran
         tryExpression.transformAnnotations(transformer, ResolutionMode.ContextIndependent)
         dataFlowAnalyzer.enterTryExpression(tryExpression)
         tryExpression.transformTryBlock(transformer, ResolutionMode.ContextDependent)
-        dataFlowAnalyzer.exitTryMainBlock(tryExpression)
+        dataFlowAnalyzer.exitTryMainBlock()
         tryExpression.transformCatches(this, ResolutionMode.ContextDependent)
 
         var callCompleted = false

--- a/compiler/testData/codegen/boxInline/complexStack/spillConstructorArgumentsAndInlineLambdaParameter.kt
+++ b/compiler/testData/codegen/boxInline/complexStack/spillConstructorArgumentsAndInlineLambdaParameter.kt
@@ -1,3 +1,4 @@
+// IGNORE_FIR_DIAGNOSTICS
 // FILE: 1.kt
 class A(val s: String)
 

--- a/compiler/testData/diagnostics/tests/initializedAfterRethrow.fir.kt
+++ b/compiler/testData/diagnostics/tests/initializedAfterRethrow.fir.kt
@@ -67,7 +67,7 @@ object RethrowInCatchWithFinally {
 }
 
 object InnerTryWithCatch {
-    private val p: String
+    <!MUST_BE_INITIALIZED_OR_BE_ABSTRACT!>private val p: String<!>
 
     init {
         try {

--- a/compiler/testData/diagnostics/tests/smartCasts/throwInTry.fir.kt
+++ b/compiler/testData/diagnostics/tests/smartCasts/throwInTry.fir.kt
@@ -1,0 +1,88 @@
+// !DIAGNOSTICS: -UNUSED_PARAMETER, -UNUSED_EXPRESSION
+
+fun throwInTry_valueInCatch_smartcastAfterTryCatch() {
+    val s = try {
+        throw AssertionError()
+    } catch(e: Throwable) {
+        "OK"
+    }
+    s.length
+}
+
+fun throwInTry_valueInFinally_noSmartcastAfterTryCatchFinally() {
+    val s = try {
+        throw AssertionError()
+    } catch(e: Throwable) {
+    } finally {
+        "not enough"
+    }
+    s.<!UNRESOLVED_REFERENCE!>length<!>
+}
+
+fun throwInTry_valueInCatchAndFinally_smartcastAfterTryCatchFinally() {
+    val s = try {
+        throw AssertionError()
+    } catch(e: Throwable) {
+        "OK"
+    } finally {
+        "really"
+    }
+    s.length
+}
+
+interface A
+interface B : A
+
+fun takeB(b: B) {}
+
+fun conditionalThrowInTry_smartcastInTry(a: A) {
+    try {
+        if (a !is B) {
+            throw AssertionError()
+        }
+        <!INAPPLICABLE_CANDIDATE!>takeB<!>(a)
+    } catch (e: Throwable) {}
+}
+
+fun conditionalThrowInTry_noSmartcastAfterTryCatch(a: A) {
+    try {
+        if (a !is B) {
+            throw AssertionError()
+        }
+    } catch (e: Throwable) {}
+    <!INAPPLICABLE_CANDIDATE!>takeB<!>(a)
+}
+
+fun conditionalThrowInTry_rethrow_smartcastAfterTryCatch(a: A) {
+    try {
+        if (a !is B) {
+            throw AssertionError()
+        }
+    } catch (e: Throwable) {
+        throw e
+    }
+    <!INAPPLICABLE_CANDIDATE!>takeB<!>(a)
+}
+
+fun conditionalThrowInTry_rethrow_smartcastAfterTryCatchFinally(a: A) {
+    try {
+        if (a !is B) {
+            throw AssertionError()
+        }
+    } catch (e: Throwable) {
+        throw e
+    } finally {}
+    <!INAPPLICABLE_CANDIDATE!>takeB<!>(a)
+}
+
+fun conditionalThrowInTry_rethrow_noSmartcastInFinally(a: A) {
+    try {
+        if (a !is B) {
+            throw AssertionError()
+        }
+    } catch (e: Throwable) {
+        throw e
+    } finally {
+        <!INAPPLICABLE_CANDIDATE!>takeB<!>(a)
+    }
+}

--- a/compiler/testData/diagnostics/tests/smartCasts/throwInTry.fir.kt
+++ b/compiler/testData/diagnostics/tests/smartCasts/throwInTry.fir.kt
@@ -40,7 +40,7 @@ fun conditionalThrowInTry_smartcastInTry(a: A) {
         if (a !is B) {
             throw AssertionError()
         }
-        <!INAPPLICABLE_CANDIDATE!>takeB<!>(a)
+        takeB(a)
     } catch (e: Throwable) {}
 }
 

--- a/compiler/testData/diagnostics/tests/smartCasts/throwInTry.kt
+++ b/compiler/testData/diagnostics/tests/smartCasts/throwInTry.kt
@@ -1,0 +1,88 @@
+// !DIAGNOSTICS: -UNUSED_PARAMETER, -UNUSED_EXPRESSION
+
+fun throwInTry_valueInCatch_smartcastAfterTryCatch() {
+    val s = try {
+        throw AssertionError()
+    } catch(e: Throwable) {
+        "OK"
+    }
+    s.length
+}
+
+fun throwInTry_valueInFinally_noSmartcastAfterTryCatchFinally() {
+    val s = try {
+        throw AssertionError()
+    } catch(e: Throwable) {
+    } finally {
+        "not enough"
+    }
+    s.<!UNRESOLVED_REFERENCE!>length<!>
+}
+
+fun throwInTry_valueInCatchAndFinally_smartcastAfterTryCatchFinally() {
+    val s = try {
+        throw AssertionError()
+    } catch(e: Throwable) {
+        "OK"
+    } finally {
+        "really"
+    }
+    s.length
+}
+
+interface A
+interface B : A
+
+fun takeB(b: B) {}
+
+fun conditionalThrowInTry_smartcastInTry(a: A) {
+    try {
+        if (a !is B) {
+            throw AssertionError()
+        }
+        takeB(<!DEBUG_INFO_SMARTCAST!>a<!>)
+    } catch (e: Throwable) {}
+}
+
+fun conditionalThrowInTry_noSmartcastAfterTryCatch(a: A) {
+    try {
+        if (a !is B) {
+            throw AssertionError()
+        }
+    } catch (e: Throwable) {}
+    takeB(<!TYPE_MISMATCH!>a<!>)
+}
+
+fun conditionalThrowInTry_rethrow_smartcastAfterTryCatch(a: A) {
+    try {
+        if (a !is B) {
+            throw AssertionError()
+        }
+    } catch (e: Throwable) {
+        throw e
+    }
+    takeB(<!DEBUG_INFO_SMARTCAST!>a<!>)
+}
+
+fun conditionalThrowInTry_rethrow_smartcastAfterTryCatchFinally(a: A) {
+    try {
+        if (a !is B) {
+            throw AssertionError()
+        }
+    } catch (e: Throwable) {
+        throw e
+    } finally {}
+    takeB(<!TYPE_MISMATCH!>a<!>)
+}
+
+fun conditionalThrowInTry_rethrow_noSmartcastInFinally(a: A) {
+    try {
+        if (a !is B) {
+            throw AssertionError()
+        }
+    } catch (e: Throwable) {
+        throw e
+    } finally {
+        takeB(<!TYPE_MISMATCH!>a<!>)
+    }
+}

--- a/compiler/testData/diagnostics/tests/smartCasts/throwInTry.txt
+++ b/compiler/testData/diagnostics/tests/smartCasts/throwInTry.txt
@@ -1,0 +1,23 @@
+package
+
+public fun conditionalThrowInTry_noSmartcastAfterTryCatch(/*0*/ a: A): kotlin.Unit
+public fun conditionalThrowInTry_rethrow_noSmartcastInFinally(/*0*/ a: A): kotlin.Unit
+public fun conditionalThrowInTry_rethrow_smartcastAfterTryCatch(/*0*/ a: A): kotlin.Unit
+public fun conditionalThrowInTry_rethrow_smartcastAfterTryCatchFinally(/*0*/ a: A): kotlin.Unit
+public fun conditionalThrowInTry_smartcastInTry(/*0*/ a: A): kotlin.Unit
+public fun takeB(/*0*/ b: B): kotlin.Unit
+public fun throwInTry_valueInCatchAndFinally_smartcastAfterTryCatchFinally(): kotlin.Unit
+public fun throwInTry_valueInCatch_smartcastAfterTryCatch(): kotlin.Unit
+public fun throwInTry_valueInFinally_noSmartcastAfterTryCatchFinally(): kotlin.Unit
+
+public interface A {
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public interface B : A {
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/DiagnosticTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/DiagnosticTestGenerated.java
@@ -25836,6 +25836,12 @@ public class DiagnosticTestGenerated extends AbstractDiagnosticTest {
             }
 
             @Test
+            @TestMetadata("throwInTry.kt")
+            public void testThrowInTry() throws Exception {
+                runTest("compiler/testData/diagnostics/tests/smartCasts/throwInTry.kt");
+            }
+
+            @Test
             @TestMetadata("twoImplicitReceivers.kt")
             public void testTwoImplicitReceivers() throws Exception {
                 runTest("compiler/testData/diagnostics/tests/smartCasts/twoImplicitReceivers.kt");


### PR DESCRIPTION
#4198 broke bootstrap/full pipeline as shown in [KT-45475](https://youtrack.jetbrains.com/issue/KT-45475):
```kt
interface A
interface B : A

fun takeB(b: B) {}

fun test(a: A) {
    try {
        if (a !is B) {
            throw AssertionError()
        }
        <!INAPPLICABLE_CANDIDATE!>takeB<!>(a)
    } catch (e: Throwable) {}
}
```
In #4198, while (re)routing `throw` in various positions inside `try` expression, the case like above---`throw` in try main---was intentionally skipped, considering all other edges around enter/exit of try main block cover necessary paths. Maybe true for CFA, but I missed the use of node's deadness in DFA (smartcast).

1st commit adds some more variants of [KT-45475](https://youtrack.jetbrains.com/issue/KT-45475). As a prerequisite, 2nd commit creates `TryMainBlockExitNode` before visiting try main block. Previously, that node was created when we literally visit the exit of try main, which means any nodes inside try main block cannot be routed to the exit of try main block. Confirmed no behaviors changes. 3rd commit adds an edge from `throw` in try main to the exit of try main block. Note that, we already have edges from the exit of try main block to enter of `catch` clauses as well as edges from exit of `catch` clauses to function exit (or `finally`). This edge addition resolves the original issue, but adds a couple regressions (will be pointed out as comments).

Note that, before #4198, all `throw`s were routed to the exit target for `try`, most likely function exit. Adding an edge from `throw` in try main to function exit (as it was before) resolved the original issue (as well as some more variants added in 1st commit). However, that will break more variants of property initialization situations with (re)throw in (nested) try expressions.