### PR TITLE
FIR: Do not load `inline` flag when deserializing properties

### DIFF
--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/class/FunInterface.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/class/FunInterface.txt
@@ -1,4 +1,4 @@
-public abstract interface F : R|kotlin/Any| {
+public abstract fun interface F : R|kotlin/Any| {
     public abstract fun R|kotlin/String|.f(x: R|kotlin/Int|): R|kotlin/Unit|
 
 }

--- a/compiler/fir/analysis-tests/testData/resolve/samConstructors/funInterfaceConstructorReference.fir.txt
+++ b/compiler/fir/analysis-tests/testData/resolve/samConstructors/funInterfaceConstructorReference.fir.txt
@@ -1,5 +1,5 @@
 FILE: funInterfaceConstructorReference.kt
-    public abstract interface Test : R|kotlin/Any| {
+    public abstract fun interface Test : R|kotlin/Any| {
         public abstract fun foo(): R|kotlin/Unit|
 
     }

--- a/compiler/fir/analysis-tests/testData/resolve/samConstructors/kotlinSam.fir.txt
+++ b/compiler/fir/analysis-tests/testData/resolve/samConstructors/kotlinSam.fir.txt
@@ -1,11 +1,11 @@
 FILE: kotlinSam.kt
-    public abstract interface MyRunnable : R|kotlin/Any| {
+    public abstract fun interface MyRunnable : R|kotlin/Any| {
         public abstract fun foo(x: R|kotlin/Int|): R|kotlin/Boolean|
 
     }
     public final fun foo(m: R|MyRunnable|): R|kotlin/Unit| {
     }
-    private abstract interface PrivateRunnable : R|kotlin/Any| {
+    private abstract fun interface PrivateRunnable : R|kotlin/Any| {
         public abstract fun bar(x: R|kotlin/String|): R|kotlin/Boolean|
 
     }

--- a/compiler/fir/analysis-tests/testData/resolve/samConversions/kotlinSam.fir.txt
+++ b/compiler/fir/analysis-tests/testData/resolve/samConversions/kotlinSam.fir.txt
@@ -1,22 +1,22 @@
 FILE: kotlinSam.kt
-    public abstract interface MyRunnable : R|kotlin/Any| {
+    public abstract fun interface MyRunnable : R|kotlin/Any| {
         public abstract fun foo(x: R|kotlin/Int|): R|kotlin/Boolean|
 
     }
-    public abstract interface WithProperty : R|kotlin/Any| {
+    public abstract fun interface WithProperty : R|kotlin/Any| {
         public abstract val x: R|kotlin/Int|
             public get(): R|kotlin/Int|
 
     }
-    public abstract interface TwoAbstract : R|MyRunnable| {
+    public abstract fun interface TwoAbstract : R|MyRunnable| {
         public abstract fun bar(): R|kotlin/Unit|
 
     }
-    public abstract interface Super : R|kotlin/Any| {
+    public abstract fun interface Super : R|kotlin/Any| {
         public abstract fun foo(x: R|kotlin/Int|): R|kotlin/Any|
 
     }
-    public abstract interface Derived : R|Super| {
+    public abstract fun interface Derived : R|Super| {
         public abstract override fun foo(x: R|kotlin/Int|): R|kotlin/Boolean|
 
     }

--- a/compiler/fir/analysis-tests/testData/resolveWithStdlib/callableReferences/sam.fir.txt
+++ b/compiler/fir/analysis-tests/testData/resolveWithStdlib/callableReferences/sam.fir.txt
@@ -1,5 +1,5 @@
 FILE: sam.kt
-    public abstract interface MySam : R|kotlin/Any| {
+    public abstract fun interface MySam : R|kotlin/Any| {
         public abstract fun run(x: R|kotlin/String|): R|kotlin/Int|
 
     }

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirDeclarationCheckerUtils.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirDeclarationCheckerUtils.kt
@@ -57,8 +57,18 @@ internal fun FirMemberDeclaration.isEffectivelyExternal(
 ): Boolean {
     if (this.isExternal) return true
 
-    // NB: [MemberDescriptor.isEffectivelyExternal] checks property accessors for property and vice versa.
-    // But, raw FIR creation already did such upward/downward propagation of modifiers.
+    if (this is FirPropertyAccessor) {
+        // Check containing property
+        val property = context.containingDeclarations.last() as FirProperty
+        return property.isEffectivelyExternal(containingClass, context)
+    }
+
+    if (this is FirProperty) {
+        // Property is effectively external if all accessors are external
+        if (getter?.isExternal == true && (!isVar || setter?.isExternal == true)) {
+            return true
+        }
+    }
 
     return containingClass != null && isInsideExternalClass(containingClass, context)
 }

--- a/compiler/fir/fir-deserialization/src/org/jetbrains/kotlin/fir/deserialization/FirMemberDeserializer.kt
+++ b/compiler/fir/fir-deserialization/src/org/jetbrains/kotlin/fir/deserialization/FirMemberDeserializer.kt
@@ -337,7 +337,6 @@ class FirMemberDeserializer(private val c: FirDeserializationContext) {
                 isOverride = false
                 isConst = Flags.IS_CONST.get(flags)
                 isLateInit = Flags.IS_LATEINIT.get(flags)
-                isInline = Flags.IS_INLINE.get(flags)
                 isExternal = Flags.IS_EXTERNAL_PROPERTY.get(flags)
             }
 

--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/ConversionUtils.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/ConversionUtils.kt
@@ -462,7 +462,7 @@ internal fun IrDeclarationParent.declareThisReceiverParameter(
 
 fun FirClass<*>.irOrigin(firProvider: FirProvider): IrDeclarationOrigin = when {
     firProvider.getFirClassifierContainerFileIfAny(symbol) != null -> IrDeclarationOrigin.DEFINED
-    origin == FirDeclarationOrigin.Java -> IrDeclarationOrigin.IR_EXTERNAL_JAVA_DECLARATION_STUB
+    isJava -> IrDeclarationOrigin.IR_EXTERNAL_JAVA_DECLARATION_STUB
     else -> IrDeclarationOrigin.IR_EXTERNAL_DECLARATION_STUB
 }
 

--- a/compiler/fir/java/src/org/jetbrains/kotlin/fir/java/JavaScopeProvider.kt
+++ b/compiler/fir/java/src/org/jetbrains/kotlin/fir/java/JavaScopeProvider.kt
@@ -155,7 +155,7 @@ class JavaScopeProvider(
             }
         } ?: return null
 
-        if (superClass.origin is FirDeclarationOrigin.Java) return superClass
+        if (superClass.isJava) return superClass
 
         return superClass.findJavaSuperClass(useSiteSession)
     }

--- a/compiler/fir/raw-fir/light-tree2fir/src/org/jetbrains/kotlin/fir/lightTree/converter/DeclarationsConverter.kt
+++ b/compiler/fir/raw-fir/light-tree2fir/src/org/jetbrains/kotlin/fir/lightTree/converter/DeclarationsConverter.kt
@@ -1098,17 +1098,13 @@ class DeclarationsConverter(
                             }
                         } else null
 
-                    // Upward propagation of `inline` and `external` modifiers (from accessors to property)
-                    // Note that, depending on `var` or `val`, checking setter's modifiers should be careful: for `val`, setter doesn't
-                    // exist (null); for `var`, the retrieval of the specific modifier is supposed to be `true`
                     status = FirDeclarationStatusImpl(propertyVisibility, modifiers.getModality(isClassOrObject = false)).apply {
                         isExpect = modifiers.hasExpect() || classWrapper?.hasExpect() == true
                         isActual = modifiers.hasActual()
                         isOverride = modifiers.hasOverride()
                         isConst = modifiers.isConst()
                         isLateInit = modifiers.hasLateinit()
-                        isInline = modifiers.hasInline() || (getter!!.isInline && setter?.isInline != false)
-                        isExternal = modifiers.hasExternal() || (getter!!.isExternal && setter?.isExternal != false)
+                        isExternal = modifiers.hasExternal()
                     }
 
                     val receiver = delegateExpression?.let {

--- a/compiler/fir/raw-fir/psi2fir/src/org/jetbrains/kotlin/fir/builder/RawFirBuilder.kt
+++ b/compiler/fir/raw-fir/psi2fir/src/org/jetbrains/kotlin/fir/builder/RawFirBuilder.kt
@@ -1331,17 +1331,13 @@ open class RawFirBuilder(
                         getter = this@toFirProperty.getter.toFirPropertyAccessor(this@toFirProperty, propertyType, isGetter = true)
                         setter = this@toFirProperty.setter.toFirPropertyAccessor(this@toFirProperty, propertyType, isGetter = false)
 
-                        // Upward propagation of `inline` and `external` modifiers (from accessors to property)
-                        // Note that, depending on `var` or `val`, checking setter's modifiers should be careful: for `val`, setter doesn't
-                        // exist (null); for `var`, the retrieval of the specific modifier is supposed to be `true`
                         status = FirDeclarationStatusImpl(visibility, modality).apply {
                             isExpect = hasExpectModifier() || containingClassOrObject?.hasExpectModifier() == true
                             isActual = hasActualModifier()
                             isOverride = hasModifier(OVERRIDE_KEYWORD)
                             isConst = hasModifier(CONST_KEYWORD)
                             isLateInit = hasModifier(LATEINIT_KEYWORD)
-                            isInline = hasModifier(INLINE_KEYWORD) || (getter!!.isInline && setter?.isInline != false)
-                            isExternal = hasModifier(EXTERNAL_KEYWORD) || (getter!!.isExternal && setter?.isExternal != false)
+                            isExternal = hasModifier(EXTERNAL_KEYWORD)
                         }
 
                         val receiver = delegateExpression?.toFirExpression("Should have delegate")

--- a/compiler/fir/raw-fir/psi2fir/testData/rawBuilder/declarations/external.lazyBodies.txt
+++ b/compiler/fir/raw-fir/psi2fir/testData/rawBuilder/declarations/external.lazyBodies.txt
@@ -20,6 +20,6 @@ FILE: external.kt
             public? set(value: Int): R|kotlin/Unit| { LAZY_BLOCK }
 
     }
-    public? final? external var z: Int
+    public? final? var z: Int
         public? external get(): Int
         public? external set(value: Int): R|kotlin/Unit|

--- a/compiler/fir/raw-fir/psi2fir/testData/rawBuilder/declarations/external.txt
+++ b/compiler/fir/raw-fir/psi2fir/testData/rawBuilder/declarations/external.txt
@@ -21,6 +21,6 @@ FILE: external.kt
             }
 
     }
-    public? final? external var z: Int
+    public? final? var z: Int
         public? external get(): Int
         public? external set(value: Int): R|kotlin/Unit|

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/FirRenderer.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/FirRenderer.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.fir
 
+import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.EffectiveVisibility
 import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.descriptors.Visibility
@@ -325,13 +326,20 @@ class FirRenderer(builder: StringBuilder, private val mode: RenderMode = RenderM
             print("inner ")
         }
 
-        // `companion/data` modifiers are only valid for FirRegularClass, but we render them to make sure they are not
+        // `companion/data/fun` modifiers are only valid for FirRegularClass, but we render them to make sure they are not
         // incorrectly loaded for other declarations during deserialization.
         if (memberDeclaration.status.isCompanion) {
             print("companion ")
         }
         if (memberDeclaration.status.isData) {
             print("data ")
+        }
+        // All Java interfaces are considered `fun` (functional interfaces) for resolution purposes
+        // (see JavaSymbolProvider.createFirJavaClass). Don't render `fun` for Java interfaces; it's not a modifier in Java.
+        val isJavaInterface =
+            memberDeclaration is FirRegularClass && memberDeclaration.classKind == ClassKind.INTERFACE && memberDeclaration.isJava
+        if (memberDeclaration.status.isFun && !isJavaInterface) {
+            print("fun ")
         }
 
         if (memberDeclaration.isInline) {

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/FirRenderer.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/FirRenderer.kt
@@ -315,50 +315,45 @@ class FirRenderer(builder: StringBuilder, private val mode: RenderMode = RenderM
         if (memberDeclaration.isExternal) {
             print("external ")
         }
-        if (memberDeclaration is FirCallableMemberDeclaration<*>) {
-            if (memberDeclaration.isOverride) {
-                print("override ")
-            }
-            if (memberDeclaration.isStatic) {
-                print("static ")
-            }
+        if (memberDeclaration.isOverride) {
+            print("override ")
         }
-        if (memberDeclaration is FirRegularClass) {
-            if (memberDeclaration.isInner) {
-                print("inner ")
-            }
-            if (memberDeclaration.isCompanion) {
-                print("companion ")
-            }
-            if (memberDeclaration.isData) {
-                print("data ")
-            }
-            if (memberDeclaration.isInline) {
-                print("inline ")
-            }
-        } else if (memberDeclaration is FirSimpleFunction) {
-            if (memberDeclaration.isOperator) {
-                print("operator ")
-            }
-            if (memberDeclaration.isInfix) {
-                print("infix ")
-            }
-            if (memberDeclaration.isInline) {
-                print("inline ")
-            }
-            if (memberDeclaration.isTailRec) {
-                print("tailrec ")
-            }
-            if (memberDeclaration.isSuspend) {
-                print("suspend ")
-            }
-        } else if (memberDeclaration is FirProperty) {
-            if (memberDeclaration.isConst) {
-                print("const ")
-            }
-            if (memberDeclaration.isLateInit) {
-                print("lateinit ")
-            }
+        if (memberDeclaration.isStatic) {
+            print("static ")
+        }
+        if (memberDeclaration.isInner) {
+            print("inner ")
+        }
+
+        // `companion/data` modifiers are only valid for FirRegularClass, but we render them to make sure they are not
+        // incorrectly loaded for other declarations during deserialization.
+        if (memberDeclaration.status.isCompanion) {
+            print("companion ")
+        }
+        if (memberDeclaration.status.isData) {
+            print("data ")
+        }
+
+        if (memberDeclaration.isInline) {
+            print("inline ")
+        }
+        if (memberDeclaration.isOperator) {
+            print("operator ")
+        }
+        if (memberDeclaration.isInfix) {
+            print("infix ")
+        }
+        if (memberDeclaration.isTailRec) {
+            print("tailrec ")
+        }
+        if (memberDeclaration.isSuspend) {
+            print("suspend ")
+        }
+        if (memberDeclaration.isConst) {
+            print("const ")
+        }
+        if (memberDeclaration.isLateInit) {
+            print("lateinit ")
         }
 
         visitDeclaration(memberDeclaration)

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/declarations/FirDeclarationUtil.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/declarations/FirDeclarationUtil.kt
@@ -12,7 +12,6 @@ import org.jetbrains.kotlin.fir.declarations.builder.FirTypeParameterBuilder
 import org.jetbrains.kotlin.fir.declarations.impl.FirFileImpl
 import org.jetbrains.kotlin.fir.declarations.impl.FirRegularClassImpl
 import org.jetbrains.kotlin.fir.expressions.FirQualifiedAccess
-import org.jetbrains.kotlin.fir.expressions.FirVariableAssignment
 import org.jetbrains.kotlin.fir.references.FirResolvedNamedReference
 import org.jetbrains.kotlin.fir.render
 import org.jetbrains.kotlin.fir.symbols.impl.FirAnonymousObjectSymbol
@@ -23,8 +22,6 @@ import org.jetbrains.kotlin.fir.types.ConeClassLikeType
 import org.jetbrains.kotlin.fir.types.ConeFlexibleType
 import org.jetbrains.kotlin.fir.types.builder.buildResolvedTypeRef
 import org.jetbrains.kotlin.fir.types.coneTypeSafe
-import org.jetbrains.kotlin.metadata.ProtoBuf
-import org.jetbrains.kotlin.metadata.deserialization.NameResolver
 
 fun FirTypeParameterBuilder.addDefaultBoundIfNecessary(isFlexible: Boolean = false) {
     if (bounds.isEmpty()) {
@@ -227,6 +224,8 @@ val FirQualifiedAccess.referredPropertySymbol: FirPropertySymbol?
         return reference.resolvedSymbol as? FirPropertySymbol
     }
 
+inline val FirDeclaration.isJava: Boolean
+    get() = origin == FirDeclarationOrigin.Java
 inline val FirDeclaration.isFromLibrary: Boolean
     get() = origin == FirDeclarationOrigin.Library
 inline val FirDeclaration.isSynthetic: Boolean

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/declarations/FirDeclarationUtil.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/declarations/FirDeclarationUtil.kt
@@ -49,15 +49,12 @@ inline val FirClass<*>.isEnumClass: Boolean
 inline val FirRegularClass.modality get() = status.modality
 inline val FirRegularClass.isSealed get() = status.modality == Modality.SEALED
 inline val FirRegularClass.isAbstract get() = status.modality == Modality.ABSTRACT
+inline val FirRegularClass.isFun get() = status.isFun
+inline val FirRegularClass.isCompanion get() = status.isCompanion
+inline val FirRegularClass.isData get() = status.isData
 
 inline val FirRegularClass.canHaveAbstractDeclaration: Boolean
     get() = isAbstract || isSealed || isEnumClass
-
-inline val FirRegularClass.isInner get() = status.isInner
-inline val FirRegularClass.isCompanion get() = status.isCompanion
-inline val FirRegularClass.isData get() = status.isData
-inline val FirRegularClass.isInline get() = status.isInline
-inline val FirRegularClass.isFun get() = status.isFun
 
 inline val FirMemberDeclaration.modality get() = status.modality
 inline val FirMemberDeclaration.isAbstract get() = status.modality == Modality.ABSTRACT
@@ -92,7 +89,6 @@ inline val FirMemberDeclaration.isConst: Boolean get() = status.isConst
 inline val FirMemberDeclaration.isLateInit: Boolean get() = status.isLateInit
 inline val FirMemberDeclaration.isFromSealedClass: Boolean get() = status.isFromSealedClass
 inline val FirMemberDeclaration.isFromEnumClass: Boolean get() = status.isFromEnumClass
-inline val FirMemberDeclaration.isFun: Boolean get() = status.isFun
 
 inline val FirFunction<*>.hasBody get() = body != null
 


### PR DESCRIPTION
...there is no `inline` flag for serialized properties.

In order to test this, I added the changes to FirRenderer to make sure the flag is not loaded. However, this revealed that the `inline` status was propagated upward to the `FirProperty` during raw FIR building, causing test failures.

I removed the upward propagation for `inline`. I also removed it for `external` because it is incorrect: `external` on properties (used in JS) should be separate from `external` on accessors (used in JNI interop for JVM).  The `external` flags are also serialized separately for properties and accessors.