### PR TITLE
JVM: do not optimize unreachable `Ref`s

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/CapturedVarsOptimizationMethodTransformer.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/CapturedVarsOptimizationMethodTransformer.kt
@@ -72,7 +72,7 @@ class CapturedVarsOptimizationMethodTransformer : MethodTransformer() {
             assignLocalVars(frames)
 
             for (refValue in refValues) {
-                if (!refValue.hazard) {
+                if (!refValue.hazard && refValue.initCallInsn != null) {
                     rewriteRefValue(refValue)
                 }
             }


### PR DESCRIPTION
They'll be removed later anyway.

 #KT-45446 Fixed