### PR TITLE
Exclude kotlinx.atomicfu compiler plugin modules

### DIFF
--- a/generators/build.gradle.kts
+++ b/generators/build.gradle.kts
@@ -70,7 +70,6 @@ dependencies {
     testCompile(projectTests(":kotlin-sam-with-receiver-compiler-plugin"))
     testCompile(projectTests(":kotlinx-serialization-compiler-plugin"))
     testCompile(projectTests(":plugins:fir:fir-plugin-prototype"))
-    testCompile(projectTests(":kotlinx-atomicfu-compiler-plugin"))
     testCompile(projectTests(":idea:jvm-debugger:jvm-debugger-test"))
     testCompile(projectTests(":generators:test-generator"))
     testCompile(projectTests(":idea"))

--- a/generators/tests/org/jetbrains/kotlin/generators/tests/GenerateTests.kt
+++ b/generators/tests/org/jetbrains/kotlin/generators/tests/GenerateTests.kt
@@ -183,9 +183,6 @@ import org.jetbrains.kotlin.search.AbstractAnnotatedMembersSearchTest
 import org.jetbrains.kotlin.search.AbstractInheritorsSearchTest
 import org.jetbrains.kotlin.shortenRefs.AbstractShortenRefsTest
 import org.jetbrains.kotlin.test.TargetBackend
-import org.jetbrains.kotlin.tools.projectWizard.cli.AbstractBuildFileGenerationTest
-import org.jetbrains.kotlinx.atomicfu.AbstractBasicAtomicfuTest
-import org.jetbrains.kotlinx.atomicfu.AbstractLocksAtomicfuTest
 import org.jetbrains.kotlin.tools.projectWizard.cli.AbstractProjectTemplateBuildFileGenerationTest
 import org.jetbrains.kotlin.tools.projectWizard.cli.AbstractYamlBuildFileGenerationTest
 import org.jetbrains.kotlin.tools.projectWizard.wizard.AbstractProjectTemplateNewWizardProjectImportTest
@@ -1739,18 +1736,6 @@ fun main(args: Array<String>) {
 
             testClass<AbstractSerializationIrBytecodeListingTest> {
                 model("codegen")
-            }
-        }
-
-        testGroup(
-            "plugins/atomicfu/atomicfu-compiler/test",
-            "plugins/atomicfu/atomicfu-compiler/testData"
-        ) {
-            testClass<AbstractBasicAtomicfuTest> {
-                model("basic")
-            }
-            testClass<AbstractLocksAtomicfuTest> {
-                model("locks")
             }
         }
 

--- a/libraries/configureGradleTools.gradle
+++ b/libraries/configureGradleTools.gradle
@@ -1,5 +1,5 @@
 
-configure([project(':kotlin-gradle-plugin'), project(':kotlin-allopen'), project(':kotlin-noarg'), project(':kotlin-serialization'), project(':atomicfu')]) { project ->
+configure([project(':kotlin-gradle-plugin'), project(':kotlin-allopen'), project(':kotlin-noarg'), project(':kotlin-serialization')]) { project ->
     apply plugin: 'com.gradle.plugin-publish'
 
     afterEvaluate {

--- a/settings.gradle
+++ b/settings.gradle
@@ -306,10 +306,6 @@ include ":benchmarks",
         ":kotlin-serialization-unshaded",
         ":wasm:wasm.ir"
 
-include ":kotlinx-atomicfu-compiler-plugin",
-        ":kotlinx-atomicfu-runtime",
-        ":atomicfu"
-
 include ":compiler:fir:cones",
         ":compiler:fir:tree",
         ":compiler:fir:tree:tree-generator",
@@ -576,10 +572,6 @@ project(':kotlinx-serialization-compiler-plugin').projectDir = file("$rootDir/pl
 project(':kotlinx-serialization-ide-plugin').projectDir = file("$rootDir/plugins/kotlin-serialization/kotlin-serialization-ide")
 project(':kotlin-serialization').projectDir = file("$rootDir/libraries/tools/kotlin-serialization")
 project(':kotlin-serialization-unshaded').projectDir = file("$rootDir/libraries/tools/kotlin-serialization-unshaded")
-
-project(':kotlinx-atomicfu-compiler-plugin').projectDir = file("$rootDir/plugins/atomicfu/atomicfu-compiler")
-project(':kotlinx-atomicfu-runtime').projectDir = file("$rootDir/plugins/atomicfu/atomicfu-runtime")
-project(':atomicfu').projectDir = file("$rootDir/libraries/tools/atomicfu")
 
 // Uncomment to use locally built protobuf-relocated
 // includeBuild("dependencies/protobuf")


### PR DESCRIPTION
This commit excludes `kotlinx-atomicfu-compiler-plugin` and `atomicfu` modules from the Kotlin build. 