### PR TITLE
Raw FIR: correct loop target for break/continue in do-while loop condition

### DIFF
--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrVisitor.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrVisitor.kt
@@ -727,7 +727,7 @@ class Fir2IrVisitor(
     private val loopMap = mutableMapOf<FirLoop, IrLoop>()
 
     override fun visitDoWhileLoop(doWhileLoop: FirDoWhileLoop, data: Any?): IrElement {
-        return doWhileLoop.convertWithOffsets { startOffset, endOffset ->
+        val irLoop = doWhileLoop.convertWithOffsets { startOffset, endOffset ->
             IrDoWhileLoopImpl(
                 startOffset, endOffset, irBuiltIns.unitType,
                 IrStatementOrigin.DO_WHILE_LOOP
@@ -740,6 +740,9 @@ class Fir2IrVisitor(
             }
         }.also {
             doWhileLoop.accept(implicitCastInserter, it)
+        }
+        return IrBlockImpl(irLoop.startOffset, irLoop.endOffset, irBuiltIns.unitType).apply {
+            statements.add(irLoop)
         }
     }
 

--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrVisitor.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrVisitor.kt
@@ -542,6 +542,11 @@ class Fir2IrVisitor(
         }
     }
 
+    private val IrStatementOrigin.isLoop: Boolean
+        get() {
+            return this == IrStatementOrigin.DO_WHILE_LOOP || this == IrStatementOrigin.WHILE_LOOP || this == IrStatementOrigin.FOR_LOOP
+        }
+
     private fun FirBlock.convertToIrExpressionOrBlock(origin: IrStatementOrigin? = null): IrExpression {
         if (statements.size == 1) {
             val firStatement = statements.single()
@@ -549,8 +554,8 @@ class Fir2IrVisitor(
                 return convertToIrExpression(firStatement)
             }
         }
-        val type =
-            (statements.lastOrNull() as? FirExpression)?.typeRef?.toIrType() ?: irBuiltIns.unitType
+        val type = if (origin?.isLoop == true) irBuiltIns.unitType
+        else (statements.lastOrNull() as? FirExpression)?.typeRef?.toIrType() ?: irBuiltIns.unitType
         return convertWithOffsets { startOffset, endOffset ->
             if (origin == IrStatementOrigin.DO_WHILE_LOOP) {
                 IrCompositeImpl(

--- a/compiler/fir/raw-fir/psi2fir/src/org/jetbrains/kotlin/fir/builder/RawFirBuilder.kt
+++ b/compiler/fir/raw-fir/psi2fir/src/org/jetbrains/kotlin/fir/builder/RawFirBuilder.kt
@@ -1632,28 +1632,31 @@ open class RawFirBuilder(
             }
 
         override fun visitDoWhileExpression(expression: KtDoWhileExpression, data: Unit): FirElement {
+            val target: FirLoopTarget
             return FirDoWhileLoopBuilder().apply {
                 source = expression.toFirSourceElement()
                 // For break/continue in the do-while loop condition, prepare the loop target first so that it can refer to the same loop.
-                prepareTarget()
+                target = prepareTarget()
                 condition = expression.condition.toFirExpression("No condition in do-while loop")
-            }.configure { expression.body.toFirBlock() }
+            }.configure(target) { expression.body.toFirBlock() }
         }
 
         override fun visitWhileExpression(expression: KtWhileExpression, data: Unit): FirElement {
+            val target: FirLoopTarget
             return FirWhileLoopBuilder().apply {
                 source = expression.toFirSourceElement()
                 condition = expression.condition.toFirExpression("No condition in while loop")
                 // break/continue in the while loop condition will refer to an outer loop if any.
                 // So, prepare the loop target after building the condition.
-                prepareTarget()
-            }.configure { expression.body.toFirBlock() }
+                target = prepareTarget()
+            }.configure(target) { expression.body.toFirBlock() }
         }
 
         override fun visitForExpression(expression: KtForExpression, data: Unit?): FirElement {
             val rangeExpression = expression.loopRange.toFirExpression("No range in for loop")
             val ktParameter = expression.loopParameter
             val fakeSource = expression.toFirPsiSourceElement(FirFakeSourceElementKind.DesugaredForLoop)
+            val target: FirLoopTarget
             return buildBlock {
                 source = fakeSource
                 val rangeSource = expression.loopRange?.toFirSourceElement(FirFakeSourceElementKind.DesugaredForLoop)
@@ -1681,8 +1684,8 @@ open class RawFirBuilder(
                     }
                     // break/continue in the for loop condition will refer to an outer loop if any.
                     // So, prepare the loop target after building the condition.
-                    prepareTarget()
-                }.configure {
+                    target = prepareTarget()
+                }.configure(target) {
                     // NB: just body.toFirBlock() isn't acceptable here because we need to add some statements
                     val blockBuilder = when (val body = expression.body) {
                         is KtBlockExpression -> configureBlockWithoutBuilding(body)

--- a/compiler/fir/raw-fir/psi2fir/src/org/jetbrains/kotlin/fir/builder/RawFirBuilder.kt
+++ b/compiler/fir/raw-fir/psi2fir/src/org/jetbrains/kotlin/fir/builder/RawFirBuilder.kt
@@ -1634,6 +1634,8 @@ open class RawFirBuilder(
         override fun visitDoWhileExpression(expression: KtDoWhileExpression, data: Unit): FirElement {
             return FirDoWhileLoopBuilder().apply {
                 source = expression.toFirSourceElement()
+                // For break/continue in the do-while loop condition, prepare the loop target first so that it can refer to the same loop.
+                prepareTarget()
                 condition = expression.condition.toFirExpression("No condition in do-while loop")
             }.configure { expression.body.toFirBlock() }
         }
@@ -1642,6 +1644,9 @@ open class RawFirBuilder(
             return FirWhileLoopBuilder().apply {
                 source = expression.toFirSourceElement()
                 condition = expression.condition.toFirExpression("No condition in while loop")
+                // break/continue in the while loop condition will refer to an outer loop if any.
+                // So, prepare the loop target after building the condition.
+                prepareTarget()
             }.configure { expression.body.toFirBlock() }
         }
 
@@ -1674,6 +1679,9 @@ open class RawFirBuilder(
                         }
                         explicitReceiver = generateResolvedAccessExpression(fakeSource, iteratorVal)
                     }
+                    // break/continue in the for loop condition will refer to an outer loop if any.
+                    // So, prepare the loop target after building the condition.
+                    prepareTarget()
                 }.configure {
                     // NB: just body.toFirBlock() isn't acceptable here because we need to add some statements
                     val blockBuilder = when (val body = expression.body) {

--- a/compiler/fir/raw-fir/raw-fir.common/src/org/jetbrains/kotlin/fir/builder/BaseFirBuilder.kt
+++ b/compiler/fir/raw-fir/raw-fir.common/src/org/jetbrains/kotlin/fir/builder/BaseFirBuilder.kt
@@ -135,8 +135,8 @@ abstract class BaseFirBuilder<T>(val baseSession: FirSession, val context: Conte
 
 
     /**** Function utils ****/
-    fun <T> MutableList<T>.removeLast() {
-        removeAt(size - 1)
+    fun <T> MutableList<T>.removeLast(): T {
+        return removeAt(size - 1)
     }
 
     fun <T> MutableList<T>.pop(): T? {
@@ -216,13 +216,16 @@ abstract class BaseFirBuilder<T>(val baseSession: FirSession, val context: Conte
         }
     }
 
-    fun FirLoopBuilder.configure(generateBlock: () -> FirBlock): FirLoop {
+    fun FirLoopBuilder.prepareTarget() {
         label = context.firLabels.pop()
         val target = FirLoopTarget(label?.name)
         context.firLoopTargets += target
+    }
+
+    fun FirLoopBuilder.configure(generateBlock: () -> FirBlock): FirLoop {
         block = generateBlock()
         val loop = build()
-        context.firLoopTargets.removeLast()
+        val target = context.firLoopTargets.removeLast()
         target.bind(loop)
         return loop
     }

--- a/compiler/fir/raw-fir/raw-fir.common/src/org/jetbrains/kotlin/fir/builder/BaseFirBuilder.kt
+++ b/compiler/fir/raw-fir/raw-fir.common/src/org/jetbrains/kotlin/fir/builder/BaseFirBuilder.kt
@@ -216,16 +216,20 @@ abstract class BaseFirBuilder<T>(val baseSession: FirSession, val context: Conte
         }
     }
 
-    fun FirLoopBuilder.prepareTarget() {
+    fun FirLoopBuilder.prepareTarget(): FirLoopTarget {
         label = context.firLabels.pop()
         val target = FirLoopTarget(label?.name)
         context.firLoopTargets += target
+        return target
     }
 
-    fun FirLoopBuilder.configure(generateBlock: () -> FirBlock): FirLoop {
+    fun FirLoopBuilder.configure(target: FirLoopTarget, generateBlock: () -> FirBlock): FirLoop {
         block = generateBlock()
         val loop = build()
-        val target = context.firLoopTargets.removeLast()
+        val stackTopTarget = context.firLoopTargets.removeLast()
+        assert(target == stackTopTarget) {
+            "Loop target preparation and loop configuration mismatch"
+        }
         target.bind(loop)
         return loop
     }

--- a/compiler/testData/codegen/box/controlStructures/breakContinueInExpressions/breakInLoopConditions.kt
+++ b/compiler/testData/codegen/box/controlStructures/breakContinueInExpressions/breakInLoopConditions.kt
@@ -1,6 +1,5 @@
 // See: https://youtrack.jetbrains.com/issue/KT-45319
 // IGNORE_BACKEND: JVM
-// IGNORE_BACKEND_FIR: JVM_IR
 // IGNORE_BACKEND: JS
 
 fun breakInDoWhileCondition(): String {

--- a/compiler/testData/diagnostics/tests/BreakContinueInWhen_after.fir.kt
+++ b/compiler/testData/diagnostics/tests/BreakContinueInWhen_after.fir.kt
@@ -75,8 +75,8 @@ fun testBreakContinueInWhenInDoWhileCondition() {
         ++i
     } while (
         when (i) {
-            1 -> <!BREAK_OR_CONTINUE_OUTSIDE_A_LOOP!>break<!>
-            2 -> <!BREAK_OR_CONTINUE_OUTSIDE_A_LOOP!>continue<!>
+            1 -> break
+            2 -> continue
             else -> true
         }
     )

--- a/compiler/testData/diagnostics/tests/controlFlowAnalysis/breakOrContinueInLoopCondition.fir.kt
+++ b/compiler/testData/diagnostics/tests/controlFlowAnalysis/breakOrContinueInLoopCondition.fir.kt
@@ -6,8 +6,8 @@ fun test() {
     while (<!BREAK_OR_CONTINUE_OUTSIDE_A_LOOP!>break<!>) {}
     l@ while (<!BREAK_OR_CONTINUE_OUTSIDE_A_LOOP!>break@l<!>) {}
 
-    do {} while (<!BREAK_OR_CONTINUE_OUTSIDE_A_LOOP!>continue<!>)
-    l@ do {} while (<!BREAK_OR_CONTINUE_OUTSIDE_A_LOOP!>continue@l<!>)
+    do {} while (continue)
+    l@ do {} while (continue@l)
 
     //KT-5704
     var i = 0

--- a/compiler/testData/ir/irText/declarations/localVarInDoWhile.fir.kt.txt
+++ b/compiler/testData/ir/irText/declarations/localVarInDoWhile.fir.kt.txt
@@ -1,5 +1,7 @@
 fun foo() {
-  do// COMPOSITE {
-  val x: Int = 42
-  // }  while (EQEQ(arg0 = x, arg1 = 42).not())
+  { // BLOCK
+    do// COMPOSITE {
+    val x: Int = 42
+    // }    while (EQEQ(arg0 = x, arg1 = 42).not())
+  }
 }

--- a/compiler/testData/ir/irText/declarations/localVarInDoWhile.fir.txt
+++ b/compiler/testData/ir/irText/declarations/localVarInDoWhile.fir.txt
@@ -1,11 +1,12 @@
 FILE fqName:<root> fileName:/localVarInDoWhile.kt
   FUN name:foo visibility:public modality:FINAL <> () returnType:kotlin.Unit
     BLOCK_BODY
-      DO_WHILE label=null origin=DO_WHILE_LOOP
-        body: COMPOSITE type=kotlin.Unit origin=DO_WHILE_LOOP
-          VAR name:x type:kotlin.Int [val]
-            CONST Int type=kotlin.Int value=42
-        condition: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-          $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-            arg0: GET_VAR 'val x: kotlin.Int [val] declared in <root>.foo' type=kotlin.Int origin=null
-            arg1: CONST Int type=kotlin.Int value=42
+      BLOCK type=kotlin.Unit origin=null
+        DO_WHILE label=null origin=DO_WHILE_LOOP
+          body: COMPOSITE type=kotlin.Unit origin=DO_WHILE_LOOP
+            VAR name:x type:kotlin.Int [val]
+              CONST Int type=kotlin.Int value=42
+          condition: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+            $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+              arg0: GET_VAR 'val x: kotlin.Int [val] declared in <root>.foo' type=kotlin.Int origin=null
+              arg1: CONST Int type=kotlin.Int value=42

--- a/compiler/testData/ir/irText/expressions/breakContinue.fir.kt.txt
+++ b/compiler/testData/ir/irText/expressions/breakContinue.fir.kt.txt
@@ -1,8 +1,12 @@
 fun test1() {
   while (true) break
-  dobreak  while (true)
+  { // BLOCK
+    dobreak    while (true)
+  }
   while (true) continue
-  docontinue  while (true)
+  { // BLOCK
+    docontinue    while (true)
+  }
 }
 
 fun test2() {

--- a/compiler/testData/ir/irText/expressions/breakContinue.fir.txt
+++ b/compiler/testData/ir/irText/expressions/breakContinue.fir.txt
@@ -4,15 +4,17 @@ FILE fqName:<root> fileName:/breakContinue.kt
       WHILE label=null origin=WHILE_LOOP
         condition: CONST Boolean type=kotlin.Boolean value=true
         body: BREAK label=null loop.label=null
-      DO_WHILE label=null origin=DO_WHILE_LOOP
-        body: BREAK label=null loop.label=null
-        condition: CONST Boolean type=kotlin.Boolean value=true
+      BLOCK type=kotlin.Unit origin=null
+        DO_WHILE label=null origin=DO_WHILE_LOOP
+          body: BREAK label=null loop.label=null
+          condition: CONST Boolean type=kotlin.Boolean value=true
       WHILE label=null origin=WHILE_LOOP
         condition: CONST Boolean type=kotlin.Boolean value=true
         body: CONTINUE label=null loop.label=null
-      DO_WHILE label=null origin=DO_WHILE_LOOP
-        body: CONTINUE label=null loop.label=null
-        condition: CONST Boolean type=kotlin.Boolean value=true
+      BLOCK type=kotlin.Unit origin=null
+        DO_WHILE label=null origin=DO_WHILE_LOOP
+          body: CONTINUE label=null loop.label=null
+          condition: CONST Boolean type=kotlin.Boolean value=true
   FUN name:test2 visibility:public modality:FINAL <> () returnType:kotlin.Unit
     BLOCK_BODY
       WHILE label=OUTER origin=WHILE_LOOP

--- a/compiler/testData/ir/irText/expressions/breakContinueInLoopHeader.fir.kt.txt
+++ b/compiler/testData/ir/irText/expressions/breakContinueInLoopHeader.fir.kt.txt
@@ -64,13 +64,15 @@ fun test5() {
     i = i.inc()
     i /*~> Unit */
     var j: Int = 0
-    Inner@ do// COMPOSITE {
-    j = j.inc()
-    j
-    // }    while (when {
-      greaterOrEqual(arg0 = j, arg1 = 3) -> false
-      else -> break@Outer
-    })
+    { // BLOCK
+      Inner@ do// COMPOSITE {
+      j = j.inc()
+      j
+      // }      while (when {
+        greaterOrEqual(arg0 = j, arg1 = 3) -> false
+        else -> break@Outer
+      })
+    }
     when {
       EQEQ(arg0 = i, arg1 = 3) -> break@Outer
     }

--- a/compiler/testData/ir/irText/expressions/breakContinueInLoopHeader.fir.kt.txt
+++ b/compiler/testData/ir/irText/expressions/breakContinueInLoopHeader.fir.kt.txt
@@ -70,7 +70,7 @@ fun test5() {
       j
       // }      while (when {
         greaterOrEqual(arg0 = j, arg1 = 3) -> false
-        else -> break@Outer
+        else -> break@Inner
       })
     }
     when {

--- a/compiler/testData/ir/irText/expressions/breakContinueInLoopHeader.fir.txt
+++ b/compiler/testData/ir/irText/expressions/breakContinueInLoopHeader.fir.txt
@@ -109,21 +109,22 @@ FILE fqName:<root> fileName:/breakContinueInLoopHeader.kt
             GET_VAR 'var i: kotlin.Int [var] declared in <root>.test5' type=kotlin.Int origin=null
           VAR name:j type:kotlin.Int [var]
             CONST Int type=kotlin.Int value=0
-          DO_WHILE label=Inner origin=DO_WHILE_LOOP
-            body: COMPOSITE type=kotlin.Int origin=DO_WHILE_LOOP
-              SET_VAR 'var j: kotlin.Int [var] declared in <root>.test5' type=kotlin.Unit origin=EQ
-                CALL 'public final fun inc (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
-                  $this: GET_VAR 'var j: kotlin.Int [var] declared in <root>.test5' type=kotlin.Int origin=null
-              GET_VAR 'var j: kotlin.Int [var] declared in <root>.test5' type=kotlin.Int origin=null
-            condition: WHEN type=kotlin.Boolean origin=IF
-              BRANCH
-                if: CALL 'public final fun greaterOrEqual (arg0: kotlin.Int, arg1: kotlin.Int): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=GTEQ
-                  arg0: GET_VAR 'var j: kotlin.Int [var] declared in <root>.test5' type=kotlin.Int origin=null
-                  arg1: CONST Int type=kotlin.Int value=3
-                then: CONST Boolean type=kotlin.Boolean value=false
-              BRANCH
-                if: CONST Boolean type=kotlin.Boolean value=true
-                then: BREAK label=Outer loop.label=Outer
+          BLOCK type=kotlin.Unit origin=null
+            DO_WHILE label=Inner origin=DO_WHILE_LOOP
+              body: COMPOSITE type=kotlin.Int origin=DO_WHILE_LOOP
+                SET_VAR 'var j: kotlin.Int [var] declared in <root>.test5' type=kotlin.Unit origin=EQ
+                  CALL 'public final fun inc (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
+                    $this: GET_VAR 'var j: kotlin.Int [var] declared in <root>.test5' type=kotlin.Int origin=null
+                GET_VAR 'var j: kotlin.Int [var] declared in <root>.test5' type=kotlin.Int origin=null
+              condition: WHEN type=kotlin.Boolean origin=IF
+                BRANCH
+                  if: CALL 'public final fun greaterOrEqual (arg0: kotlin.Int, arg1: kotlin.Int): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=GTEQ
+                    arg0: GET_VAR 'var j: kotlin.Int [var] declared in <root>.test5' type=kotlin.Int origin=null
+                    arg1: CONST Int type=kotlin.Int value=3
+                  then: CONST Boolean type=kotlin.Boolean value=false
+                BRANCH
+                  if: CONST Boolean type=kotlin.Boolean value=true
+                  then: BREAK label=Outer loop.label=Outer
           WHEN type=kotlin.Unit origin=IF
             BRANCH
               if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ

--- a/compiler/testData/ir/irText/expressions/breakContinueInLoopHeader.fir.txt
+++ b/compiler/testData/ir/irText/expressions/breakContinueInLoopHeader.fir.txt
@@ -124,7 +124,7 @@ FILE fqName:<root> fileName:/breakContinueInLoopHeader.kt
                   then: CONST Boolean type=kotlin.Boolean value=false
                 BRANCH
                   if: CONST Boolean type=kotlin.Boolean value=true
-                  then: BREAK label=Outer loop.label=Outer
+                  then: BREAK label=Inner loop.label=Inner
           WHEN type=kotlin.Unit origin=IF
             BRANCH
               if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ

--- a/compiler/testData/ir/irText/expressions/breakContinueInLoopHeader.fir.txt
+++ b/compiler/testData/ir/irText/expressions/breakContinueInLoopHeader.fir.txt
@@ -111,7 +111,7 @@ FILE fqName:<root> fileName:/breakContinueInLoopHeader.kt
             CONST Int type=kotlin.Int value=0
           BLOCK type=kotlin.Unit origin=null
             DO_WHILE label=Inner origin=DO_WHILE_LOOP
-              body: COMPOSITE type=kotlin.Int origin=DO_WHILE_LOOP
+              body: COMPOSITE type=kotlin.Unit origin=DO_WHILE_LOOP
                 SET_VAR 'var j: kotlin.Int [var] declared in <root>.test5' type=kotlin.Unit origin=EQ
                   CALL 'public final fun inc (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
                     $this: GET_VAR 'var j: kotlin.Int [var] declared in <root>.test5' type=kotlin.Int origin=null

--- a/compiler/testData/ir/irText/expressions/breakContinueInWhen.fir.kt.txt
+++ b/compiler/testData/ir/irText/expressions/breakContinueInWhen.fir.kt.txt
@@ -24,9 +24,11 @@ fun testBreakWhile() {
 
 fun testBreakDoWhile() {
   var k: Int = 0
-  dowhen {
-    greater(arg0 = k, arg1 = 2) -> break
-  }  while (less(arg0 = k, arg1 = 10))
+  { // BLOCK
+    dowhen {
+      greater(arg0 = k, arg1 = 2) -> break
+    }    while (less(arg0 = k, arg1 = 10))
+  }
 }
 
 fun testContinueFor() {
@@ -56,14 +58,16 @@ fun testContinueWhile() {
 fun testContinueDoWhile() {
   var k: Int = 0
   var s: String = ""
-  do// COMPOSITE {
-  k = k.inc()
-  k /*~> Unit */
-  when {
-    greater(arg0 = k, arg1 = 2) -> continue
+  { // BLOCK
+    do// COMPOSITE {
+    k = k.inc()
+    k /*~> Unit */
+    when {
+      greater(arg0 = k, arg1 = 2) -> continue
+    }
+    s = s.plus(other = k.toString() + ";")
+    // }    while (less(arg0 = k, arg1 = 10))
   }
-  s = s.plus(other = k.toString() + ";")
-  // }  while (less(arg0 = k, arg1 = 10))
   when {
     EQEQ(arg0 = s, arg1 = "1;2;").not() -> throw AssertionError(p0 = s)
   }

--- a/compiler/testData/ir/irText/expressions/breakContinueInWhen.fir.txt
+++ b/compiler/testData/ir/irText/expressions/breakContinueInWhen.fir.txt
@@ -47,16 +47,17 @@ FILE fqName:<root> fileName:/breakContinueInWhen.kt
     BLOCK_BODY
       VAR name:k type:kotlin.Int [var]
         CONST Int type=kotlin.Int value=0
-      DO_WHILE label=null origin=DO_WHILE_LOOP
-        body: WHEN type=kotlin.Unit origin=WHEN
-          BRANCH
-            if: CALL 'public final fun greater (arg0: kotlin.Int, arg1: kotlin.Int): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=GT
-              arg0: GET_VAR 'var k: kotlin.Int [var] declared in <root>.testBreakDoWhile' type=kotlin.Int origin=null
-              arg1: CONST Int type=kotlin.Int value=2
-            then: BREAK label=null loop.label=null
-        condition: CALL 'public final fun less (arg0: kotlin.Int, arg1: kotlin.Int): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=LT
-          arg0: GET_VAR 'var k: kotlin.Int [var] declared in <root>.testBreakDoWhile' type=kotlin.Int origin=null
-          arg1: CONST Int type=kotlin.Int value=10
+      BLOCK type=kotlin.Unit origin=null
+        DO_WHILE label=null origin=DO_WHILE_LOOP
+          body: WHEN type=kotlin.Unit origin=WHEN
+            BRANCH
+              if: CALL 'public final fun greater (arg0: kotlin.Int, arg1: kotlin.Int): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=GT
+                arg0: GET_VAR 'var k: kotlin.Int [var] declared in <root>.testBreakDoWhile' type=kotlin.Int origin=null
+                arg1: CONST Int type=kotlin.Int value=2
+              then: BREAK label=null loop.label=null
+          condition: CALL 'public final fun less (arg0: kotlin.Int, arg1: kotlin.Int): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=LT
+            arg0: GET_VAR 'var k: kotlin.Int [var] declared in <root>.testBreakDoWhile' type=kotlin.Int origin=null
+            arg1: CONST Int type=kotlin.Int value=10
   FUN name:testContinueFor visibility:public modality:FINAL <> () returnType:kotlin.Unit
     BLOCK_BODY
       VAR name:xs type:kotlin.IntArray [val]
@@ -107,29 +108,30 @@ FILE fqName:<root> fileName:/breakContinueInWhen.kt
         CONST Int type=kotlin.Int value=0
       VAR name:s type:kotlin.String [var]
         CONST String type=kotlin.String value=""
-      DO_WHILE label=null origin=DO_WHILE_LOOP
-        body: COMPOSITE type=kotlin.Unit origin=DO_WHILE_LOOP
-          SET_VAR 'var k: kotlin.Int [var] declared in <root>.testContinueDoWhile' type=kotlin.Unit origin=EQ
-            CALL 'public final fun inc (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
-              $this: GET_VAR 'var k: kotlin.Int [var] declared in <root>.testContinueDoWhile' type=kotlin.Int origin=null
-          TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
-            GET_VAR 'var k: kotlin.Int [var] declared in <root>.testContinueDoWhile' type=kotlin.Int origin=null
-          WHEN type=kotlin.Unit origin=WHEN
-            BRANCH
-              if: CALL 'public final fun greater (arg0: kotlin.Int, arg1: kotlin.Int): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=GT
-                arg0: GET_VAR 'var k: kotlin.Int [var] declared in <root>.testContinueDoWhile' type=kotlin.Int origin=null
-                arg1: CONST Int type=kotlin.Int value=2
-              then: CONTINUE label=null loop.label=null
-          SET_VAR 'var s: kotlin.String [var] declared in <root>.testContinueDoWhile' type=kotlin.Unit origin=EQ
-            CALL 'public final fun plus (other: kotlin.Any?): kotlin.String [operator] declared in kotlin.String' type=kotlin.String origin=null
-              $this: GET_VAR 'var s: kotlin.String [var] declared in <root>.testContinueDoWhile' type=kotlin.String origin=null
-              other: STRING_CONCATENATION type=kotlin.String
-                CALL 'public open fun toString (): kotlin.String declared in kotlin.Any' type=kotlin.String origin=null
-                  $this: GET_VAR 'var k: kotlin.Int [var] declared in <root>.testContinueDoWhile' type=kotlin.Int origin=null
-                CONST String type=kotlin.String value=";"
-        condition: CALL 'public final fun less (arg0: kotlin.Int, arg1: kotlin.Int): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=LT
-          arg0: GET_VAR 'var k: kotlin.Int [var] declared in <root>.testContinueDoWhile' type=kotlin.Int origin=null
-          arg1: CONST Int type=kotlin.Int value=10
+      BLOCK type=kotlin.Unit origin=null
+        DO_WHILE label=null origin=DO_WHILE_LOOP
+          body: COMPOSITE type=kotlin.Unit origin=DO_WHILE_LOOP
+            SET_VAR 'var k: kotlin.Int [var] declared in <root>.testContinueDoWhile' type=kotlin.Unit origin=EQ
+              CALL 'public final fun inc (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
+                $this: GET_VAR 'var k: kotlin.Int [var] declared in <root>.testContinueDoWhile' type=kotlin.Int origin=null
+            TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+              GET_VAR 'var k: kotlin.Int [var] declared in <root>.testContinueDoWhile' type=kotlin.Int origin=null
+            WHEN type=kotlin.Unit origin=WHEN
+              BRANCH
+                if: CALL 'public final fun greater (arg0: kotlin.Int, arg1: kotlin.Int): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=GT
+                  arg0: GET_VAR 'var k: kotlin.Int [var] declared in <root>.testContinueDoWhile' type=kotlin.Int origin=null
+                  arg1: CONST Int type=kotlin.Int value=2
+                then: CONTINUE label=null loop.label=null
+            SET_VAR 'var s: kotlin.String [var] declared in <root>.testContinueDoWhile' type=kotlin.Unit origin=EQ
+              CALL 'public final fun plus (other: kotlin.Any?): kotlin.String [operator] declared in kotlin.String' type=kotlin.String origin=null
+                $this: GET_VAR 'var s: kotlin.String [var] declared in <root>.testContinueDoWhile' type=kotlin.String origin=null
+                other: STRING_CONCATENATION type=kotlin.String
+                  CALL 'public open fun toString (): kotlin.String declared in kotlin.Any' type=kotlin.String origin=null
+                    $this: GET_VAR 'var k: kotlin.Int [var] declared in <root>.testContinueDoWhile' type=kotlin.Int origin=null
+                  CONST String type=kotlin.String value=";"
+          condition: CALL 'public final fun less (arg0: kotlin.Int, arg1: kotlin.Int): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=LT
+            arg0: GET_VAR 'var k: kotlin.Int [var] declared in <root>.testContinueDoWhile' type=kotlin.Int origin=null
+            arg1: CONST Int type=kotlin.Int value=10
       WHEN type=kotlin.Unit origin=IF
         BRANCH
           if: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ

--- a/compiler/testData/ir/irText/expressions/whileDoWhile.fir.kt.txt
+++ b/compiler/testData/ir/irText/expressions/whileDoWhile.fir.kt.txt
@@ -12,18 +12,24 @@ fun test() {
     x = <unary>.inc()
     <unary>
   }
-  do// COMPOSITE {
-  // }  while (less(arg0 = x, arg1 = 0))
-  do{ // BLOCK
+  { // BLOCK
+    do// COMPOSITE {
+    // }    while (less(arg0 = x, arg1 = 0))
+  }
+  { // BLOCK
+    do{ // BLOCK
+      val <unary>: Int = x
+      x = <unary>.inc()
+      <unary>
+    }    while (less(arg0 = x, arg1 = 15))
+  }
+  { // BLOCK
+    do// COMPOSITE {
     val <unary>: Int = x
     x = <unary>.inc()
     <unary>
-  }  while (less(arg0 = x, arg1 = 15))
-  do// COMPOSITE {
-  val <unary>: Int = x
-  x = <unary>.inc()
-  <unary>
-  // }  while (less(arg0 = x, arg1 = 20))
+    // }    while (less(arg0 = x, arg1 = 20))
+  }
 }
 
 fun testSmartcastInCondition() {
@@ -32,8 +38,10 @@ fun testSmartcastInCondition() {
     a is Boolean -> { // BLOCK
       while (a /*as Boolean */) { // BLOCK
       }
-      do// COMPOSITE {
-      // }      while (a /*as Boolean */)
+      { // BLOCK
+        do// COMPOSITE {
+        // }        while (a /*as Boolean */)
+      }
     }
   }
 }

--- a/compiler/testData/ir/irText/expressions/whileDoWhile.fir.txt
+++ b/compiler/testData/ir/irText/expressions/whileDoWhile.fir.txt
@@ -30,33 +30,36 @@ FILE fqName:<root> fileName:/whileDoWhile.kt
             CALL 'public final fun inc (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
               $this: GET_VAR 'val tmp_1: kotlin.Int [val] declared in <root>.test' type=kotlin.Int origin=null
           GET_VAR 'val tmp_1: kotlin.Int [val] declared in <root>.test' type=kotlin.Int origin=null
-      DO_WHILE label=null origin=DO_WHILE_LOOP
-        body: COMPOSITE type=kotlin.Unit origin=DO_WHILE_LOOP
-        condition: CALL 'public final fun less (arg0: kotlin.Int, arg1: kotlin.Int): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=LT
-          arg0: GET_VAR 'var x: kotlin.Int [var] declared in <root>.test' type=kotlin.Int origin=null
-          arg1: CONST Int type=kotlin.Int value=0
-      DO_WHILE label=null origin=DO_WHILE_LOOP
-        body: BLOCK type=kotlin.Int origin=null
-          VAR IR_TEMPORARY_VARIABLE name:tmp_2 type:kotlin.Int [val]
-            GET_VAR 'var x: kotlin.Int [var] declared in <root>.test' type=kotlin.Int origin=null
-          SET_VAR 'var x: kotlin.Int [var] declared in <root>.test' type=kotlin.Unit origin=EQ
-            CALL 'public final fun inc (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
-              $this: GET_VAR 'val tmp_2: kotlin.Int [val] declared in <root>.test' type=kotlin.Int origin=null
-          GET_VAR 'val tmp_2: kotlin.Int [val] declared in <root>.test' type=kotlin.Int origin=null
-        condition: CALL 'public final fun less (arg0: kotlin.Int, arg1: kotlin.Int): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=LT
-          arg0: GET_VAR 'var x: kotlin.Int [var] declared in <root>.test' type=kotlin.Int origin=null
-          arg1: CONST Int type=kotlin.Int value=15
-      DO_WHILE label=null origin=DO_WHILE_LOOP
-        body: COMPOSITE type=kotlin.Int origin=DO_WHILE_LOOP
-          VAR IR_TEMPORARY_VARIABLE name:tmp_3 type:kotlin.Int [val]
-            GET_VAR 'var x: kotlin.Int [var] declared in <root>.test' type=kotlin.Int origin=null
-          SET_VAR 'var x: kotlin.Int [var] declared in <root>.test' type=kotlin.Unit origin=EQ
-            CALL 'public final fun inc (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
-              $this: GET_VAR 'val tmp_3: kotlin.Int [val] declared in <root>.test' type=kotlin.Int origin=null
-          GET_VAR 'val tmp_3: kotlin.Int [val] declared in <root>.test' type=kotlin.Int origin=null
-        condition: CALL 'public final fun less (arg0: kotlin.Int, arg1: kotlin.Int): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=LT
-          arg0: GET_VAR 'var x: kotlin.Int [var] declared in <root>.test' type=kotlin.Int origin=null
-          arg1: CONST Int type=kotlin.Int value=20
+      BLOCK type=kotlin.Unit origin=null
+        DO_WHILE label=null origin=DO_WHILE_LOOP
+          body: COMPOSITE type=kotlin.Unit origin=DO_WHILE_LOOP
+          condition: CALL 'public final fun less (arg0: kotlin.Int, arg1: kotlin.Int): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=LT
+            arg0: GET_VAR 'var x: kotlin.Int [var] declared in <root>.test' type=kotlin.Int origin=null
+            arg1: CONST Int type=kotlin.Int value=0
+      BLOCK type=kotlin.Unit origin=null
+        DO_WHILE label=null origin=DO_WHILE_LOOP
+          body: BLOCK type=kotlin.Int origin=null
+            VAR IR_TEMPORARY_VARIABLE name:tmp_2 type:kotlin.Int [val]
+              GET_VAR 'var x: kotlin.Int [var] declared in <root>.test' type=kotlin.Int origin=null
+            SET_VAR 'var x: kotlin.Int [var] declared in <root>.test' type=kotlin.Unit origin=EQ
+              CALL 'public final fun inc (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
+                $this: GET_VAR 'val tmp_2: kotlin.Int [val] declared in <root>.test' type=kotlin.Int origin=null
+            GET_VAR 'val tmp_2: kotlin.Int [val] declared in <root>.test' type=kotlin.Int origin=null
+          condition: CALL 'public final fun less (arg0: kotlin.Int, arg1: kotlin.Int): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=LT
+            arg0: GET_VAR 'var x: kotlin.Int [var] declared in <root>.test' type=kotlin.Int origin=null
+            arg1: CONST Int type=kotlin.Int value=15
+      BLOCK type=kotlin.Unit origin=null
+        DO_WHILE label=null origin=DO_WHILE_LOOP
+          body: COMPOSITE type=kotlin.Int origin=DO_WHILE_LOOP
+            VAR IR_TEMPORARY_VARIABLE name:tmp_3 type:kotlin.Int [val]
+              GET_VAR 'var x: kotlin.Int [var] declared in <root>.test' type=kotlin.Int origin=null
+            SET_VAR 'var x: kotlin.Int [var] declared in <root>.test' type=kotlin.Unit origin=EQ
+              CALL 'public final fun inc (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
+                $this: GET_VAR 'val tmp_3: kotlin.Int [val] declared in <root>.test' type=kotlin.Int origin=null
+            GET_VAR 'val tmp_3: kotlin.Int [val] declared in <root>.test' type=kotlin.Int origin=null
+          condition: CALL 'public final fun less (arg0: kotlin.Int, arg1: kotlin.Int): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=LT
+            arg0: GET_VAR 'var x: kotlin.Int [var] declared in <root>.test' type=kotlin.Int origin=null
+            arg1: CONST Int type=kotlin.Int value=20
   FUN name:testSmartcastInCondition visibility:public modality:FINAL <> () returnType:kotlin.Unit
     BLOCK_BODY
       VAR name:a type:kotlin.Any? [val]
@@ -70,7 +73,8 @@ FILE fqName:<root> fileName:/whileDoWhile.kt
               condition: TYPE_OP type=kotlin.Boolean origin=IMPLICIT_CAST typeOperand=kotlin.Boolean
                 GET_VAR 'val a: kotlin.Any? [val] declared in <root>.testSmartcastInCondition' type=kotlin.Any? origin=null
               body: BLOCK type=kotlin.Unit origin=null
-            DO_WHILE label=null origin=DO_WHILE_LOOP
-              body: COMPOSITE type=kotlin.Unit origin=DO_WHILE_LOOP
-              condition: TYPE_OP type=kotlin.Boolean origin=IMPLICIT_CAST typeOperand=kotlin.Boolean
-                GET_VAR 'val a: kotlin.Any? [val] declared in <root>.testSmartcastInCondition' type=kotlin.Any? origin=null
+            BLOCK type=kotlin.Unit origin=null
+              DO_WHILE label=null origin=DO_WHILE_LOOP
+                body: COMPOSITE type=kotlin.Unit origin=DO_WHILE_LOOP
+                condition: TYPE_OP type=kotlin.Boolean origin=IMPLICIT_CAST typeOperand=kotlin.Boolean
+                  GET_VAR 'val a: kotlin.Any? [val] declared in <root>.testSmartcastInCondition' type=kotlin.Any? origin=null

--- a/compiler/testData/ir/irText/expressions/whileDoWhile.fir.txt
+++ b/compiler/testData/ir/irText/expressions/whileDoWhile.fir.txt
@@ -50,7 +50,7 @@ FILE fqName:<root> fileName:/whileDoWhile.kt
             arg1: CONST Int type=kotlin.Int value=15
       BLOCK type=kotlin.Unit origin=null
         DO_WHILE label=null origin=DO_WHILE_LOOP
-          body: COMPOSITE type=kotlin.Int origin=DO_WHILE_LOOP
+          body: COMPOSITE type=kotlin.Unit origin=DO_WHILE_LOOP
             VAR IR_TEMPORARY_VARIABLE name:tmp_3 type:kotlin.Int [val]
               GET_VAR 'var x: kotlin.Int [var] declared in <root>.test' type=kotlin.Int origin=null
             SET_VAR 'var x: kotlin.Int [var] declared in <root>.test' type=kotlin.Unit origin=EQ

--- a/compiler/testData/ir/irText/firProblems/ArrayMap.fir.kt.txt
+++ b/compiler/testData/ir/irText/firProblems/ArrayMap.fir.kt.txt
@@ -223,14 +223,16 @@ internal class ArrayMapImpl<T : Any> : ArrayMap<T> {
           private set
 
         protected override fun computeNext() {
-          do// COMPOSITE {
-          val <unary>: Int = <this>.<get-index>()
-          <this>.<set-index>(<set-?> = <unary>.inc())
-          <unary>
-          // }          while (when {
-            less(arg0 = <this>.<get-index>(), arg1 = <this>.<get-data>().<get-size>()) -> EQEQ(arg0 = <this>.<get-data>().get(index = <this>.<get-index>()), arg1 = null)
-            else -> false
-          })
+          { // BLOCK
+            do// COMPOSITE {
+            val <unary>: Int = <this>.<get-index>()
+            <this>.<set-index>(<set-?> = <unary>.inc())
+            <unary>
+            // }            while (when {
+              less(arg0 = <this>.<get-index>(), arg1 = <this>.<get-data>().<get-size>()) -> EQEQ(arg0 = <this>.<get-data>().get(index = <this>.<get-index>()), arg1 = null)
+              else -> false
+            })
+          }
           when {
             greaterOrEqual(arg0 = <this>.<get-index>(), arg1 = <this>.<get-data>().<get-size>()) -> <this>.done()
             else -> <this>.setNext(value = <this>.<get-data>().get(index = <this>.<get-index>()) as T)

--- a/compiler/testData/ir/irText/firProblems/ArrayMap.fir.txt
+++ b/compiler/testData/ir/irText/firProblems/ArrayMap.fir.txt
@@ -537,7 +537,7 @@ FILE fqName:<root> fileName:/ArrayMap.kt
                 BLOCK_BODY
                   BLOCK type=kotlin.Unit origin=null
                     DO_WHILE label=null origin=DO_WHILE_LOOP
-                      body: COMPOSITE type=kotlin.Int origin=DO_WHILE_LOOP
+                      body: COMPOSITE type=kotlin.Unit origin=DO_WHILE_LOOP
                         VAR IR_TEMPORARY_VARIABLE name:tmp_1 type:kotlin.Int [val]
                           CALL 'private final fun <get-index> (): kotlin.Int declared in <root>.ArrayMapImpl.iterator.<no name provided>' type=kotlin.Int origin=GET_PROPERTY
                             $this: GET_VAR '<this>: <root>.ArrayMapImpl.iterator.<no name provided><T of <root>.ArrayMapImpl> declared in <root>.ArrayMapImpl.iterator.<no name provided>.computeNext' type=<root>.ArrayMapImpl.iterator.<no name provided><T of <root>.ArrayMapImpl> origin=null

--- a/compiler/testData/ir/irText/firProblems/ArrayMap.fir.txt
+++ b/compiler/testData/ir/irText/firProblems/ArrayMap.fir.txt
@@ -535,34 +535,35 @@ FILE fqName:<root> fileName:/ArrayMap.kt
                   protected abstract fun computeNext (): kotlin.Unit declared in kotlin.collections.AbstractIterator
                 $this: VALUE_PARAMETER name:<this> type:<root>.ArrayMapImpl.iterator.<no name provided><T of <root>.ArrayMapImpl>
                 BLOCK_BODY
-                  DO_WHILE label=null origin=DO_WHILE_LOOP
-                    body: COMPOSITE type=kotlin.Int origin=DO_WHILE_LOOP
-                      VAR IR_TEMPORARY_VARIABLE name:tmp_1 type:kotlin.Int [val]
-                        CALL 'private final fun <get-index> (): kotlin.Int declared in <root>.ArrayMapImpl.iterator.<no name provided>' type=kotlin.Int origin=GET_PROPERTY
-                          $this: GET_VAR '<this>: <root>.ArrayMapImpl.iterator.<no name provided><T of <root>.ArrayMapImpl> declared in <root>.ArrayMapImpl.iterator.<no name provided>.computeNext' type=<root>.ArrayMapImpl.iterator.<no name provided><T of <root>.ArrayMapImpl> origin=null
-                      CALL 'private final fun <set-index> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>.ArrayMapImpl.iterator.<no name provided>' type=kotlin.Unit origin=EQ
-                        $this: GET_VAR '<this>: <root>.ArrayMapImpl.iterator.<no name provided><T of <root>.ArrayMapImpl> declared in <root>.ArrayMapImpl.iterator.<no name provided>.computeNext' type=<root>.ArrayMapImpl.iterator.<no name provided><T of <root>.ArrayMapImpl> origin=null
-                        <set-?>: CALL 'public final fun inc (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
-                          $this: GET_VAR 'val tmp_1: kotlin.Int [val] declared in <root>.ArrayMapImpl.iterator.<no name provided>.computeNext' type=kotlin.Int origin=null
-                      GET_VAR 'val tmp_1: kotlin.Int [val] declared in <root>.ArrayMapImpl.iterator.<no name provided>.computeNext' type=kotlin.Int origin=null
-                    condition: WHEN type=kotlin.Boolean origin=ANDAND
-                      BRANCH
-                        if: CALL 'public final fun less (arg0: kotlin.Int, arg1: kotlin.Int): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=LT
-                          arg0: CALL 'private final fun <get-index> (): kotlin.Int declared in <root>.ArrayMapImpl.iterator.<no name provided>' type=kotlin.Int origin=GET_PROPERTY
+                  BLOCK type=kotlin.Unit origin=null
+                    DO_WHILE label=null origin=DO_WHILE_LOOP
+                      body: COMPOSITE type=kotlin.Int origin=DO_WHILE_LOOP
+                        VAR IR_TEMPORARY_VARIABLE name:tmp_1 type:kotlin.Int [val]
+                          CALL 'private final fun <get-index> (): kotlin.Int declared in <root>.ArrayMapImpl.iterator.<no name provided>' type=kotlin.Int origin=GET_PROPERTY
                             $this: GET_VAR '<this>: <root>.ArrayMapImpl.iterator.<no name provided><T of <root>.ArrayMapImpl> declared in <root>.ArrayMapImpl.iterator.<no name provided>.computeNext' type=<root>.ArrayMapImpl.iterator.<no name provided><T of <root>.ArrayMapImpl> origin=null
-                          arg1: CALL 'public final fun <get-size> (): kotlin.Int declared in kotlin.Array' type=kotlin.Int origin=GET_PROPERTY
-                            $this: CALL 'private final fun <get-data> (): kotlin.Array<kotlin.Any?> declared in <root>.ArrayMapImpl' type=kotlin.Array<kotlin.Any?> origin=GET_PROPERTY
-                              $this: GET_VAR '<this>: <root>.ArrayMapImpl<T of <root>.ArrayMapImpl> declared in <root>.ArrayMapImpl.iterator' type=<root>.ArrayMapImpl<T of <root>.ArrayMapImpl> origin=null
-                        then: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                          arg0: CALL 'public final fun get (index: kotlin.Int): T of kotlin.Array [operator] declared in kotlin.Array' type=kotlin.Any? origin=null
-                            $this: CALL 'private final fun <get-data> (): kotlin.Array<kotlin.Any?> declared in <root>.ArrayMapImpl' type=kotlin.Array<kotlin.Any?> origin=GET_PROPERTY
-                              $this: GET_VAR '<this>: <root>.ArrayMapImpl<T of <root>.ArrayMapImpl> declared in <root>.ArrayMapImpl.iterator' type=<root>.ArrayMapImpl<T of <root>.ArrayMapImpl> origin=null
-                            index: CALL 'private final fun <get-index> (): kotlin.Int declared in <root>.ArrayMapImpl.iterator.<no name provided>' type=kotlin.Int origin=GET_PROPERTY
+                        CALL 'private final fun <set-index> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>.ArrayMapImpl.iterator.<no name provided>' type=kotlin.Unit origin=EQ
+                          $this: GET_VAR '<this>: <root>.ArrayMapImpl.iterator.<no name provided><T of <root>.ArrayMapImpl> declared in <root>.ArrayMapImpl.iterator.<no name provided>.computeNext' type=<root>.ArrayMapImpl.iterator.<no name provided><T of <root>.ArrayMapImpl> origin=null
+                          <set-?>: CALL 'public final fun inc (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
+                            $this: GET_VAR 'val tmp_1: kotlin.Int [val] declared in <root>.ArrayMapImpl.iterator.<no name provided>.computeNext' type=kotlin.Int origin=null
+                        GET_VAR 'val tmp_1: kotlin.Int [val] declared in <root>.ArrayMapImpl.iterator.<no name provided>.computeNext' type=kotlin.Int origin=null
+                      condition: WHEN type=kotlin.Boolean origin=ANDAND
+                        BRANCH
+                          if: CALL 'public final fun less (arg0: kotlin.Int, arg1: kotlin.Int): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=LT
+                            arg0: CALL 'private final fun <get-index> (): kotlin.Int declared in <root>.ArrayMapImpl.iterator.<no name provided>' type=kotlin.Int origin=GET_PROPERTY
                               $this: GET_VAR '<this>: <root>.ArrayMapImpl.iterator.<no name provided><T of <root>.ArrayMapImpl> declared in <root>.ArrayMapImpl.iterator.<no name provided>.computeNext' type=<root>.ArrayMapImpl.iterator.<no name provided><T of <root>.ArrayMapImpl> origin=null
-                          arg1: CONST Null type=kotlin.Nothing? value=null
-                      BRANCH
-                        if: CONST Boolean type=kotlin.Boolean value=true
-                        then: CONST Boolean type=kotlin.Boolean value=false
+                            arg1: CALL 'public final fun <get-size> (): kotlin.Int declared in kotlin.Array' type=kotlin.Int origin=GET_PROPERTY
+                              $this: CALL 'private final fun <get-data> (): kotlin.Array<kotlin.Any?> declared in <root>.ArrayMapImpl' type=kotlin.Array<kotlin.Any?> origin=GET_PROPERTY
+                                $this: GET_VAR '<this>: <root>.ArrayMapImpl<T of <root>.ArrayMapImpl> declared in <root>.ArrayMapImpl.iterator' type=<root>.ArrayMapImpl<T of <root>.ArrayMapImpl> origin=null
+                          then: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                            arg0: CALL 'public final fun get (index: kotlin.Int): T of kotlin.Array [operator] declared in kotlin.Array' type=kotlin.Any? origin=null
+                              $this: CALL 'private final fun <get-data> (): kotlin.Array<kotlin.Any?> declared in <root>.ArrayMapImpl' type=kotlin.Array<kotlin.Any?> origin=GET_PROPERTY
+                                $this: GET_VAR '<this>: <root>.ArrayMapImpl<T of <root>.ArrayMapImpl> declared in <root>.ArrayMapImpl.iterator' type=<root>.ArrayMapImpl<T of <root>.ArrayMapImpl> origin=null
+                              index: CALL 'private final fun <get-index> (): kotlin.Int declared in <root>.ArrayMapImpl.iterator.<no name provided>' type=kotlin.Int origin=GET_PROPERTY
+                                $this: GET_VAR '<this>: <root>.ArrayMapImpl.iterator.<no name provided><T of <root>.ArrayMapImpl> declared in <root>.ArrayMapImpl.iterator.<no name provided>.computeNext' type=<root>.ArrayMapImpl.iterator.<no name provided><T of <root>.ArrayMapImpl> origin=null
+                            arg1: CONST Null type=kotlin.Nothing? value=null
+                        BRANCH
+                          if: CONST Boolean type=kotlin.Boolean value=true
+                          then: CONST Boolean type=kotlin.Boolean value=false
                   WHEN type=kotlin.Unit origin=IF
                     BRANCH
                       if: CALL 'public final fun greaterOrEqual (arg0: kotlin.Int, arg1: kotlin.Int): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=GTEQ


### PR DESCRIPTION
The motivation is #4180 that fixed [KT-44412](https://youtrack.jetbrains.com/issue/KT-44412), while FIR is disabled. Digging it further led to the following:
```kt
fun main(args: Array<String>) {
    var i = 0
    Outer@while (true) {
        ++i
        println("Outer: $i")
        var j = 0
        Inner@do {
            ++j
            println("Inner: $j")
        } while (if (j >= 3) false else break) // break@Inner
        if (i == 3) break
    }
}
```
from [KT-17728](https://youtrack.jetbrains.com/issue/KT-17728), which said
```
either the FE is wrong with diagnostics for break/continue in do-while condition,
or JVM and JS BEs are wrong and should generate break/continue from the corresponding outer loop.
```

In the internal chat, Mikhail Belyaev said:
"The condition in do-while exists in the scope of the loop itself, while the condition in while exists in the outer scope."

Therefore, that `break` in the do-while loop is supposed to break from that loop, so the former is the case: FE 1.0 / FIR is wrong to report such `break` as `BREAK_OR_CONTINUE_OUTSIDE_A_LOOP`. (Note that the aforementioned #4180 fixed mismatching behavior in JVM IR BE.)

------

FIR currently picks the outer loop as `break` target, and that's why the test in #4180 is broken. The root cause is, in raw FIR building, we prepare the loop target _after_ parsing condition expression. That is, when visiting `break` as the condition expression, the current do-while loop is not ready/stacked as loop target. 3rd commit splits the way raw FIR builder configures loop builder so that the loop target for do-while loop can be configured ahead of condition parsing. Note that diagnostics mismatch between FE 1.0 and FIR are expected.

To make such do-while loop with break in its condition, two more changes are necessary, though. 1st commit wraps do-while loop in `IrBlock`, similar to commit d096f1d ("so that variables declared in loop body are not visible outside of the
loop"). 2nd commit forces the return type of loop body block as `Unit`. Otherwise, i.e., if the block type is set as the last expression's type, bytecode stackmap is corrupted. Finally, FIR renderer needs to keep track of visited jump expression to avoid stack overflow while rendering the example like above.