### PR TITLE
JVM_IR: remap calls to protected `@JvmStatic` in companions

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -23339,6 +23339,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         }
 
         @Test
+        @TestMetadata("companionObjectProtected.kt")
+        public void testCompanionObjectProtected() throws Exception {
+            runTest("compiler/testData/codegen/box/jvmStatic/companionObjectProtected.kt");
+        }
+
+        @Test
         @TestMetadata("convention.kt")
         public void testConvention() throws Exception {
             runTest("compiler/testData/codegen/box/jvmStatic/convention.kt");

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmCachedDeclarations.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmCachedDeclarations.kt
@@ -192,8 +192,6 @@ class JvmCachedDeclarations(
             valueParameters = target.valueParameters.map { it.copyTo(this) }
 
             body = context.createIrBuilder(symbol).run {
-                // TODO: if the `@JvmStatic` function is inline, this inlines it into the proxy - not great (?)
-                //   for something that's supposed to be only relevant for Java compatibility.
                 irExprBody(irCall(target).apply {
                     passTypeArgumentsFrom(this@proxy)
                     if (target.dispatchReceiverParameter != null) {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -458,10 +458,7 @@ class ExpressionCodegen(
             addSuspendMarker(mv, isStartNotEnd = true, isSuspensionPoint == SuspensionPointKind.NOT_INLINE)
         }
 
-        val generatorForActualCall =
-            // Do not inline callee to continuation, instead, call it
-            if (irFunction.isInvokeSuspendOfContinuation()) IrCallGenerator.DefaultCallGenerator else callGenerator
-        generatorForActualCall.genCall(callable, this, expression, isInsideCondition)
+        callGenerator.genCall(callable, this, expression, isInsideCondition)
 
         val unboxedInlineClassIrType =
             callee.suspendFunctionOriginal().originalReturnTypeOfSuspendFunctionReturningUnboxedInlineClass()
@@ -1351,6 +1348,7 @@ class ExpressionCodegen(
     ): IrCallGenerator {
         if (!element.symbol.owner.isInlineFunctionCall(context) ||
             classCodegen.irClass.fileParent.fileEntry is MultifileFacadeFileEntry ||
+            irFunction.origin == JvmLoweredDeclarationOrigin.JVM_STATIC_WRAPPER ||
             irFunction.isInvokeSuspendOfContinuation()
         ) {
             return IrCallGenerator.DefaultCallGenerator

--- a/compiler/testData/codegen/box/jvmStatic/companionObjectProtected.kt
+++ b/compiler/testData/codegen/box/jvmStatic/companionObjectProtected.kt
@@ -1,0 +1,21 @@
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND: JVM
+// WITH_RUNTIME
+// FILE: 1.kt
+package a
+
+open class A {
+    companion object {
+        @JvmStatic // Required to be accessible from subclasses of A in other packages.
+        protected fun foo() = "OK"
+    }
+}
+
+// FILE: 2.kt
+import a.*
+
+class B : A() {
+    fun bar() = foo() // calls static A.foo(), not inaccessible A.Companion.foo()
+}
+
+fun box() = B().bar()

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -23339,6 +23339,12 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
         }
 
         @Test
+        @TestMetadata("companionObjectProtected.kt")
+        public void testCompanionObjectProtected() throws Exception {
+            runTest("compiler/testData/codegen/box/jvmStatic/companionObjectProtected.kt");
+        }
+
+        @Test
         @TestMetadata("convention.kt")
         public void testConvention() throws Exception {
             runTest("compiler/testData/codegen/box/jvmStatic/convention.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -23339,6 +23339,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         }
 
         @Test
+        @TestMetadata("companionObjectProtected.kt")
+        public void testCompanionObjectProtected() throws Exception {
+            runTest("compiler/testData/codegen/box/jvmStatic/companionObjectProtected.kt");
+        }
+
+        @Test
         @TestMetadata("convention.kt")
         public void testConvention() throws Exception {
             runTest("compiler/testData/codegen/box/jvmStatic/convention.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -19686,6 +19686,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)
     public static class JvmStatic extends AbstractLightAnalysisModeTest {
+        @TestMetadata("companionObjectProtected.kt")
+        public void ignoreCompanionObjectProtected() throws Exception {
+            runTest("compiler/testData/codegen/box/jvmStatic/companionObjectProtected.kt");
+        }
+
         @TestMetadata("extensionPropertyGetter.kt")
         public void ignoreExtensionPropertyGetter() throws Exception {
             runTest("compiler/testData/codegen/box/jvmStatic/extensionPropertyGetter.kt");


### PR DESCRIPTION
Protected functions on unrelated classes cannot be called from outside the current package, so in general, we can only call the static proxy, not the original companion method.

This has an ABI compatibility implication in that removing `@JvmStatic` from a protected companion method will require recompiling Kotlin use sites (of course, this is already source- and binary-incompatible from Java perspective).

 #KT-12063 Fixed