### PR TITLE
Fix build errors with Gradle 6.8

### DIFF
--- a/gradle/jps.gradle.kts
+++ b/gradle/jps.gradle.kts
@@ -480,7 +480,7 @@ fun RecursiveArtifact.jarContentsFromConfiguration(configuration: Configuration)
 
     resolvedArtifacts.filter { it.id.componentIdentifier is ModuleComponentIdentifier }
         .map { it.file }
-        .forEach(::extractedDirectory)
+        .forEach { extractedDirectory(it) }
 
     resolvedArtifacts
         .map { it.id.componentIdentifier }

--- a/prepare/idea-plugin/build.gradle.kts
+++ b/prepare/idea-plugin/build.gradle.kts
@@ -202,7 +202,7 @@ dependencies {
 
     (libraries.dependencies + gradleToolingModel.dependencies)
         .map { if (it is ProjectDependency) it.dependencyProject else it }
-        .forEach(::compile)
+        .forEach { compile(it) }
 }
 
 val jar = runtimeJar {


### PR DESCRIPTION
With Gradle 6.8, the build would fail on this line due to type resolution ambiguity.