### PR TITLE
Fix 45590 - New J2K: in string literals, convert \f to \u000c.

### DIFF
--- a/nj2k/src/org/jetbrains/kotlin/nj2k/conversions/LiteralConversion.kt
+++ b/nj2k/src/org/jetbrains/kotlin/nj2k/conversions/LiteralConversion.kt
@@ -70,6 +70,8 @@ class LiteralConversion(context: NewJ2kConverterContext) : RecursiveApplicableCo
             val leadingBackslashes = matchResult.groupValues[1]
             if (leadingBackslashes.length % 2 == 0)
                 String.format("%s\\u%04x", leadingBackslashes, Integer.parseInt(matchResult.groupValues[2], 8))
+            else if (matchResult.value == "\\f")
+                "\\u000c"
             else matchResult.value
         }.replace("""(?<!\\)\$([A-Za-z]+|\{)""".toRegex(), "\\\\$0")
 

--- a/nj2k/testData/newJ2k/literalExpression/stringEscaping.java
+++ b/nj2k/testData/newJ2k/literalExpression/stringEscaping.java
@@ -1,0 +1,4 @@
+public class A {
+    public String a = "\t\b\n\r\'\"\\";
+    public String b = "\f";
+}

--- a/nj2k/testData/newJ2k/literalExpression/stringEscaping.kt
+++ b/nj2k/testData/newJ2k/literalExpression/stringEscaping.kt
@@ -1,0 +1,4 @@
+class A {
+    var a = "\t\b\n\r\'\"\\"
+    var b = "\u000c"
+}

--- a/nj2k/tests/org/jetbrains/kotlin/nj2k/NewJavaToKotlinConverterSingleFileTestGenerated.java
+++ b/nj2k/tests/org/jetbrains/kotlin/nj2k/NewJavaToKotlinConverterSingleFileTestGenerated.java
@@ -3587,6 +3587,11 @@ public class NewJavaToKotlinConverterSingleFileTestGenerated extends AbstractNew
             runTest("nj2k/testData/newJ2k/literalExpression/octal.java");
         }
 
+        @TestMetadata("stringEscaping.java")
+        public void testStringEscaping() throws Exception {
+            runTest("nj2k/testData/newJ2k/literalExpression/stringEscaping.java");
+        }
+
         @TestMetadata("stringOctalChars.java")
         public void testStringOctalChars() throws Exception {
             runTest("nj2k/testData/newJ2k/literalExpression/stringOctalChars.java");


### PR DESCRIPTION
Both Java and Kotlin accept almost the same set of escaped characters
in string literals. However, in Java string literals, \f can be used to
represent a "form feed" in ASCII code, while in Kotlin it can't.

This should fix https://youtrack.jetbrains.com/issue/KT-45590

----

I didn't really confirm this fix locally (I don't have all `JVM_*`s at hand).
I'm expecting any CI tasks to detect any problems.