### PR TITLE
Change pronoun in execption from "his" to "its"

### DIFF
--- a/core/descriptors/src/org/jetbrains/kotlin/descriptors/impl/ModuleDescriptorImpl.kt
+++ b/core/descriptors/src/org/jetbrains/kotlin/descriptors/impl/ModuleDescriptorImpl.kt
@@ -93,7 +93,7 @@ class ModuleDescriptorImpl @JvmOverloads constructor(
     private val packageFragmentProviderForWholeModuleWithDependencies by lazy {
         val moduleDependencies = dependencies.sure { "Dependencies of module $id were not set before querying module content" }
         val dependenciesDescriptors = moduleDependencies.allDependencies
-        assert(this in dependenciesDescriptors) { "Module $id is not contained in his own dependencies, this is probably a misconfiguration" }
+        assert(this in dependenciesDescriptors) { "Module $id is not contained in its own dependencies, this is probably a misconfiguration" }
         dependenciesDescriptors.forEach { dependency ->
             assert(dependency.isInitialized) {
                 "Dependency module ${dependency.id} was not initialized by the time contents of dependent module ${this.id} were queried"


### PR DESCRIPTION
Besides favoring gender neutral language where you can, I think it reads like a strange anthropomorphization to refer to code with pronouns of any gender. It seemed so strange to me, that I did a double take, thinking maybe it was an acronym at first.