### PR TITLE
Add AnalysisHandlerExtension extension points to various platforms

### DIFF
--- a/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/js/K2JSCompiler.java
+++ b/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/js/K2JSCompiler.java
@@ -252,17 +252,28 @@ public class K2JSCompiler extends CLICompiler<K2JSCompilerArguments> {
             return COMPILATION_ERROR;
         }
 
-        AnalyzerWithCompilerReport analyzerWithCompilerReport = new AnalyzerWithCompilerReport(
-                messageCollector, CommonConfigurationKeysKt.getLanguageVersionSettings(configuration)
-        );
-        analyzerWithCompilerReport.analyzeAndReport(sourcesFiles, () -> TopDownAnalyzerFacadeForJS.analyzeFiles(sourcesFiles, config));
-        if (analyzerWithCompilerReport.hasErrors()) {
-            return COMPILATION_ERROR;
-        }
+        AnalysisResult analysisResult;
+        do {
+            AnalyzerWithCompilerReport analyzerWithCompilerReport = new AnalyzerWithCompilerReport(
+                    messageCollector, CommonConfigurationKeysKt.getLanguageVersionSettings(configuration)
+            );
+            List<KtFile> sources = environmentForJS.getSourceFiles();
+            analyzerWithCompilerReport.analyzeAndReport(sourcesFiles, () -> TopDownAnalyzerFacadeForJS.analyzeFiles(sources, config));
+            if (analyzerWithCompilerReport.hasErrors()) {
+                return COMPILATION_ERROR;
+            }
 
-        ProgressIndicatorAndCompilationCanceledStatus.checkCanceled();
+            ProgressIndicatorAndCompilationCanceledStatus.checkCanceled();
+            analysisResult = analyzerWithCompilerReport.getAnalysisResult();
 
-        AnalysisResult analysisResult = analyzerWithCompilerReport.getAnalysisResult();
+            if (analysisResult instanceof JsAnalysisResult.RetryWithAdditionalRoots) {
+                environmentForJS.addKotlinSourceRoots(((JsAnalysisResult.RetryWithAdditionalRoots) analysisResult).getAdditionalKotlinRoots());
+            }
+        } while(analysisResult instanceof JsAnalysisResult.RetryWithAdditionalRoots);
+
+        if (!analysisResult.getShouldGenerateCode())
+            return OK;
+
         assert analysisResult instanceof JsAnalysisResult : "analysisResult should be instance of JsAnalysisResult, but " + analysisResult;
         JsAnalysisResult jsAnalysisResult = (JsAnalysisResult) analysisResult;
 

--- a/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/extensions/AnalysisHandlerExtension.kt
+++ b/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/extensions/AnalysisHandlerExtension.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2015 JetBrains s.r.o.
+ * Copyright 2010-2021 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,34 +16,11 @@
 
 package org.jetbrains.kotlin.resolve.jvm.extensions
 
-import com.intellij.openapi.project.Project
-import org.jetbrains.kotlin.analyzer.AnalysisResult
-import org.jetbrains.kotlin.container.ComponentProvider
-import org.jetbrains.kotlin.context.ProjectContext
-import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.extensions.ProjectExtensionDescriptor
-import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.kotlin.resolve.BindingTrace
 
-interface AnalysisHandlerExtension {
-    companion object : ProjectExtensionDescriptor<AnalysisHandlerExtension>(
+interface AnalysisHandlerExtension : org.jetbrains.kotlin.resolve.extensions.AnalysisHandlerExtension {
+    companion object : ProjectExtensionDescriptor<org.jetbrains.kotlin.resolve.extensions.AnalysisHandlerExtension>(
             "org.jetbrains.kotlin.analyzeCompleteHandlerExtension",
-            AnalysisHandlerExtension::class.java
+            org.jetbrains.kotlin.resolve.extensions.AnalysisHandlerExtension::class.java
     )
-
-    fun doAnalysis(
-            project: Project,
-            module: ModuleDescriptor,
-            projectContext: ProjectContext,
-            files: Collection<KtFile>,
-            bindingTrace: BindingTrace,
-            componentProvider: ComponentProvider
-    ): AnalysisResult? = null
-
-    fun analysisCompleted(
-            project: Project,
-            module: ModuleDescriptor,
-            bindingTrace: BindingTrace,
-            files: Collection<KtFile>
-    ): AnalysisResult? = null
 }

--- a/compiler/frontend/src/org/jetbrains/kotlin/analyzer/common/CommonResolverForModuleFactory.kt
+++ b/compiler/frontend/src/org/jetbrains/kotlin/analyzer/common/CommonResolverForModuleFactory.kt
@@ -40,11 +40,13 @@ import org.jetbrains.kotlin.platform.TargetPlatform
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.*
 import org.jetbrains.kotlin.resolve.checkers.ExpectedActualDeclarationChecker
+import org.jetbrains.kotlin.resolve.extensions.AnalysisHandlerExtension
 import org.jetbrains.kotlin.resolve.lazy.ResolveSession
 import org.jetbrains.kotlin.resolve.lazy.declarations.DeclarationProviderFactory
 import org.jetbrains.kotlin.resolve.lazy.declarations.DeclarationProviderFactoryService
 import org.jetbrains.kotlin.serialization.deserialization.MetadataPackageFragmentProvider
 import org.jetbrains.kotlin.serialization.deserialization.MetadataPartProvider
+import org.jetbrains.kotlin.utils.addToStdlib.firstNotNullResult
 
 class CommonAnalysisParameters(
     val metadataPartProviderFactory: (ModuleContent<*>) -> MetadataPartProvider
@@ -148,10 +150,11 @@ class CommonResolverForModuleFactory(
                 dependenciesContainer
             )
 
+            val projectContext = ProjectContext(project, "metadata serializer")
             @Suppress("NAME_SHADOWING")
             val resolver = ResolverForSingleModuleProject<ModuleInfo>(
                 "sources for metadata serializer",
-                ProjectContext(project, "metadata serializer"),
+                projectContext,
                 moduleInfo,
                 resolverForModuleFactory,
                 GlobalSearchScope.allScope(project),
@@ -167,9 +170,24 @@ class CommonResolverForModuleFactory(
 
             val container = resolver.resolverForModule(moduleInfo).componentProvider
 
-            container.get<LazyTopDownAnalyzer>().analyzeDeclarations(TopDownAnalysisMode.TopLevelDeclarations, files)
+            val analysisHandlerExtensions = AnalysisHandlerExtension.getInstances(project)
+            val trace = container.get<BindingTrace>()
 
-            return AnalysisResult.success(container.get<BindingTrace>().bindingContext, moduleDescriptor)
+            // Mimic the behavior in the jvm frontend. The extensions have 2 chances to override the normal analysis:
+            // * If any of the extensions returns a non-null result, it. Otherwise do the normal analysis.
+            // * `analysisCompleted` can be used to override the result, too.
+            var result = analysisHandlerExtensions.firstNotNullResult { extension ->
+                extension.doAnalysis(project, moduleDescriptor, projectContext, files, trace, container)
+            } ?: run {
+                container.get<LazyTopDownAnalyzer>().analyzeDeclarations(TopDownAnalysisMode.TopLevelDeclarations, files)
+                AnalysisResult.success(trace.bindingContext, moduleDescriptor)
+            }
+
+            result = analysisHandlerExtensions.firstNotNullResult { extension ->
+                extension.analysisCompleted(project, moduleDescriptor, trace, files)
+            } ?: result
+
+            return result
         }
     }
 }

--- a/compiler/frontend/src/org/jetbrains/kotlin/resolve/extensions/AnalysisHandlerExtension.kt
+++ b/compiler/frontend/src/org/jetbrains/kotlin/resolve/extensions/AnalysisHandlerExtension.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2010-2021 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.kotlin.resolve.extensions
+
+import com.intellij.openapi.project.Project
+import org.jetbrains.kotlin.analyzer.AnalysisResult
+import org.jetbrains.kotlin.container.ComponentProvider
+import org.jetbrains.kotlin.context.ProjectContext
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.extensions.ProjectExtensionDescriptor
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.resolve.BindingTrace
+
+interface AnalysisHandlerExtension {
+    companion object : ProjectExtensionDescriptor<AnalysisHandlerExtension>(
+        "org.jetbrains.kotlin.analyzeCompleteHandlerExtension",
+        AnalysisHandlerExtension::class.java
+    )
+
+    fun doAnalysis(
+        project: Project,
+        module: ModuleDescriptor,
+        projectContext: ProjectContext,
+        files: Collection<KtFile>,
+        bindingTrace: BindingTrace,
+        componentProvider: ComponentProvider
+    ): AnalysisResult? = null
+
+    fun analysisCompleted(
+        project: Project,
+        module: ModuleDescriptor,
+        bindingTrace: BindingTrace,
+        files: Collection<KtFile>
+    ): AnalysisResult? = null
+}

--- a/compiler/tests-common/tests/org/jetbrains/kotlin/checkers/AbstractDiagnosticsTestWithJsStdLib.kt
+++ b/compiler/tests-common/tests/org/jetbrains/kotlin/checkers/AbstractDiagnosticsTestWithJsStdLib.kt
@@ -60,7 +60,7 @@ abstract class AbstractDiagnosticsTestWithJsStdLib : AbstractDiagnosticsTest() {
         moduleTrace.record<ModuleDescriptor, ModuleKind>(MODULE_KIND, moduleContext.module, getModuleKind(files))
         config.configuration.languageVersionSettings = languageVersionSettings
         return TopDownAnalyzerFacadeForJS.analyzeFilesWithGivenTrace(
-            files, moduleTrace, moduleContext, config.configuration, CompilerEnvironment,
+            files, moduleTrace, moduleContext, config.configuration, CompilerEnvironment, config.project
         )
     }
 

--- a/compiler/tests/org/jetbrains/kotlin/cli/AnalysisHandlerExtensionTest.kt
+++ b/compiler/tests/org/jetbrains/kotlin/cli/AnalysisHandlerExtensionTest.kt
@@ -58,7 +58,7 @@ class AnalysisHandlerExtensionTest : TestCaseWithTmpdir() {
     }
 
     fun testShouldNotGenerateCodeJVM() {
-        runTest(K2JVMCompiler(), classNotFound)
+        runTest(K2JVMCompiler(), classNotFound, listOf("-d", tmpdir.resolve("out").absolutePath))
     }
 
     fun testShouldNotGenerateCodeJS() {
@@ -70,7 +70,7 @@ class AnalysisHandlerExtensionTest : TestCaseWithTmpdir() {
     }
 
     fun testRepeatedAnalysisJVM() {
-        runTest(K2JVMCompiler(), repeatedAnalysis)
+        runTest(K2JVMCompiler(), repeatedAnalysis, listOf("-d", tmpdir.resolve("out").absolutePath))
     }
 
     fun testRepeatedAnalysisJS() {

--- a/compiler/tests/org/jetbrains/kotlin/cli/AnalysisHandlerExtensionTest.kt
+++ b/compiler/tests/org/jetbrains/kotlin/cli/AnalysisHandlerExtensionTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2010-2018 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.cli
+
+import com.intellij.mock.MockProject
+import com.intellij.openapi.project.Project
+import org.jetbrains.kotlin.analyzer.AnalysisResult
+import org.jetbrains.kotlin.cli.common.CLITool
+import org.jetbrains.kotlin.cli.js.K2JSCompiler
+import org.jetbrains.kotlin.cli.jvm.K2JVMCompiler
+import org.jetbrains.kotlin.cli.metadata.K2MetadataCompiler
+import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.container.ComponentProvider
+import org.jetbrains.kotlin.context.ProjectContext
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.BindingTrace
+import org.jetbrains.kotlin.resolve.extensions.AnalysisHandlerExtension
+import org.jetbrains.kotlin.test.CompilerTestUtil
+import org.jetbrains.kotlin.test.TestCaseWithTmpdir
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+private data class TestKtFile(
+    val name: String,
+    val content: String
+)
+
+private val classNotFound = TestKtFile("C.kt", "class C : ClassNotFound")
+private val repeatedAnalysis = TestKtFile("D.kt", "class D : Generated")
+
+class AnalysisHandlerExtensionTest : TestCaseWithTmpdir() {
+
+    // Writes the service file only; CustomComponentRegistrar is already in classpath.
+    private fun writePlugin(): String {
+        val jarFile = tmpdir.resolve("plugin.jar")
+        ZipOutputStream(jarFile.outputStream()).use {
+            val entry = ZipEntry("META-INF/services/org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar")
+            it.putNextEntry(entry)
+            it.write(CustomComponentRegistrar::class.java.name.toByteArray())
+        }
+        return jarFile.absolutePath
+    }
+
+    private fun runTest(compiler: CLITool<*>, src: TestKtFile, extras: List<String> = emptyList()) {
+        val mainKt = tmpdir.resolve(src.name).apply {
+            writeText(src.content)
+        }
+        val plugin = writePlugin()
+        val args = listOf("-Xplugin=$plugin", mainKt.absolutePath)
+        CompilerTestUtil.executeCompilerAssertSuccessful(compiler, args + extras)
+    }
+
+    fun testShouldNotGenerateCodeJVM() {
+        runTest(K2JVMCompiler(), classNotFound)
+    }
+
+    fun testShouldNotGenerateCodeJS() {
+        runTest(K2JSCompiler(), classNotFound, listOf("-output", tmpdir.resolve("out.js").absolutePath))
+    }
+
+    fun testShouldNotGenerateCodeMetadata() {
+        runTest(K2MetadataCompiler(), classNotFound, listOf("-d", tmpdir.resolve("out").absolutePath))
+    }
+
+    fun testRepeatedAnalysisJVM() {
+        runTest(K2JVMCompiler(), repeatedAnalysis)
+    }
+
+    fun testRepeatedAnalysisJS() {
+        runTest(K2JSCompiler(), repeatedAnalysis, listOf("-output", tmpdir.resolve("out.js").absolutePath))
+    }
+
+    fun testRepeatedAnalysisMetadata() {
+        runTest(K2MetadataCompiler(), repeatedAnalysis, listOf("-d", tmpdir.resolve("out").absolutePath))
+    }
+}
+
+class CustomComponentRegistrar : ComponentRegistrar {
+    override fun registerProjectComponents(project: MockProject, configuration: CompilerConfiguration) {
+        AnalysisHandlerExtension.registerExtension(project, CustomAnalysisHandler())
+    }
+}
+
+// Assume that the directory of input files is writeable!
+private class CustomAnalysisHandler : AnalysisHandlerExtension {
+    override fun doAnalysis(
+        project: Project,
+        module: ModuleDescriptor,
+        projectContext: ProjectContext,
+        files: Collection<KtFile>,
+        bindingTrace: BindingTrace,
+        componentProvider: ComponentProvider
+    ): AnalysisResult? {
+        val filenames = files.map { it.name }
+        if (repeatedAnalysis.name in filenames) {
+            if ("Generated.kt" in filenames) {
+                return null
+            } else {
+                val outDir = File(files.single { it.name == repeatedAnalysis.name }.virtualFilePath).parentFile
+                outDir.resolve("Generated.kt").apply {
+                    writeText("interface Generated")
+                }
+                return AnalysisResult.RetryWithAdditionalRoots(BindingContext.EMPTY, module, emptyList(), listOf(outDir))
+            }
+        }
+        return AnalysisResult.success(BindingContext.EMPTY, module, false)
+    }
+}

--- a/compiler/tests/org/jetbrains/kotlin/serialization/js/JsVersionRequirementTest.kt
+++ b/compiler/tests/org/jetbrains/kotlin/serialization/js/JsVersionRequirementTest.kt
@@ -48,7 +48,7 @@ class JsVersionRequirementTest : AbstractVersionRequirementTest() {
         }
         val trace = BindingTraceContext()
         val analysisResult = TopDownAnalyzerFacadeForJS.analyzeFilesWithGivenTrace(
-            ktFiles, trace, createModule(environment), environment.configuration, CompilerEnvironment,
+            ktFiles, trace, createModule(environment), environment.configuration, CompilerEnvironment, environment.project
         )
 
         // There are INVISIBLE_REFERENCE errors on RequireKotlin and K2JSTranslator refuses to translate the code otherwise
@@ -63,7 +63,7 @@ class JsVersionRequirementTest : AbstractVersionRequirementTest() {
     override fun loadModule(directory: File): ModuleDescriptor {
         val environment = createEnvironment(extraDependencies = listOf(File(directory, "lib.meta.js")))
         return TopDownAnalyzerFacadeForJS.analyzeFilesWithGivenTrace(
-            emptyList(), BindingTraceContext(), createModule(environment), environment.configuration, CompilerEnvironment,
+            emptyList(), BindingTraceContext(), createModule(environment), environment.configuration, CompilerEnvironment, environment.project
         ).moduleDescriptor
     }
 

--- a/js/js.frontend/src/org/jetbrains/kotlin/frontend/js/di/injection.kt
+++ b/js/js.frontend/src/org/jetbrains/kotlin/frontend/js/di/injection.kt
@@ -17,6 +17,7 @@
 package org.jetbrains.kotlin.frontend.js.di
 
 import org.jetbrains.kotlin.config.LanguageVersionSettings
+import org.jetbrains.kotlin.container.StorageComponentContainer
 import org.jetbrains.kotlin.container.get
 import org.jetbrains.kotlin.container.useInstance
 import org.jetbrains.kotlin.context.ModuleContext
@@ -37,7 +38,7 @@ import org.jetbrains.kotlin.resolve.createContainer
 import org.jetbrains.kotlin.resolve.lazy.KotlinCodeAnalyzer
 import org.jetbrains.kotlin.resolve.lazy.declarations.DeclarationProviderFactory
 
-fun createTopDownAnalyzerForJs(
+fun createContainerForJS(
     moduleContext: ModuleContext,
     bindingTrace: BindingTrace,
     declarationProviderFactory: DeclarationProviderFactory,
@@ -46,7 +47,7 @@ fun createTopDownAnalyzerForJs(
     expectActualTracker: ExpectActualTracker,
     additionalPackages: List<PackageFragmentProvider>,
     targetEnvironment: TargetEnvironment,
-): LazyTopDownAnalyzer {
+): StorageComponentContainer {
     val storageComponentContainer = createContainer("TopDownAnalyzerForJs", JsPlatformAnalyzerServices) {
         configureModule(
             moduleContext,
@@ -67,5 +68,21 @@ fun createTopDownAnalyzerForJs(
         packagePartProviders += additionalPackages
         moduleDescriptor.initialize(CompositePackageFragmentProvider(packagePartProviders))
     }
-    return storageComponentContainer.get<LazyTopDownAnalyzer>()
+    return storageComponentContainer
+}
+
+fun createTopDownAnalyzerForJs(
+    moduleContext: ModuleContext,
+    bindingTrace: BindingTrace,
+    declarationProviderFactory: DeclarationProviderFactory,
+    languageVersionSettings: LanguageVersionSettings,
+    lookupTracker: LookupTracker,
+    expectActualTracker: ExpectActualTracker,
+    additionalPackages: List<PackageFragmentProvider>,
+    targetEnvironment: TargetEnvironment,
+): LazyTopDownAnalyzer {
+    return createContainerForJS(
+        moduleContext, bindingTrace, declarationProviderFactory, languageVersionSettings,
+        lookupTracker, expectActualTracker, additionalPackages, targetEnvironment
+    ).get<LazyTopDownAnalyzer>()
 }

--- a/js/js.frontend/src/org/jetbrains/kotlin/js/analyzer/JsAnalysisResult.kt
+++ b/js/js.frontend/src/org/jetbrains/kotlin/js/analyzer/JsAnalysisResult.kt
@@ -21,15 +21,27 @@ import org.jetbrains.kotlin.resolve.BindingTrace
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.types.ErrorUtils
+import java.io.File
 
-class JsAnalysisResult(
+open class JsAnalysisResult(
         val bindingTrace: BindingTrace,
-        moduleDescriptor: ModuleDescriptor
-) : AnalysisResult(bindingTrace.bindingContext, moduleDescriptor) {
+        moduleDescriptor: ModuleDescriptor,
+        shouldGenerateCode: Boolean
+) : AnalysisResult(bindingTrace.bindingContext, moduleDescriptor, shouldGenerateCode) {
 
     companion object {
         @JvmStatic fun success(trace: BindingTrace, module: ModuleDescriptor): JsAnalysisResult {
-            return JsAnalysisResult(trace, module)
+            return JsAnalysisResult(trace, module, true)
+        }
+
+        @JvmStatic fun success(trace: BindingTrace, module: ModuleDescriptor, shouldGenerateCode: Boolean): JsAnalysisResult {
+            return JsAnalysisResult(trace, module, shouldGenerateCode)
         }
     }
+
+    class RetryWithAdditionalRoots(
+        bindingTrace: BindingTrace,
+        moduleDescriptor: ModuleDescriptor,
+        val additionalKotlinRoots: List<File>,
+    ) : JsAnalysisResult(bindingTrace, moduleDescriptor,false)
 }

--- a/kotlin-native/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2Native.kt
+++ b/kotlin-native/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2Native.kt
@@ -180,6 +180,7 @@ class K2Native : CLICompiler<K2NativeCompilerArguments>() {
                 put(PRINT_DESCRIPTORS, arguments.printDescriptors)
                 put(PRINT_LOCATIONS, arguments.printLocations)
                 put(PRINT_BITCODE, arguments.printBitCode)
+                put(PRINT_FILES, arguments.printFiles)
 
                 put(PURGE_USER_LIBS, arguments.purgeUserLibs)
 

--- a/kotlin-native/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2NativeCompilerArguments.kt
+++ b/kotlin-native/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2NativeCompilerArguments.kt
@@ -199,6 +199,9 @@ class K2NativeCompilerArguments : CommonCompilerArguments() {
     @Argument(value = "-Xprint-locations", deprecatedName = "--print_locations", description = "Print locations")
     var printLocations: Boolean = false
 
+    @Argument(value = "-Xprint-files", description = "Print files")
+    var printFiles: Boolean = false
+
     @Argument(value="-Xpurge-user-libs", deprecatedName = "--purge_user_libs", description = "Don't link unused libraries even explicitly specified")
     var purgeUserLibs: Boolean = false
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Context.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Context.kt
@@ -410,6 +410,8 @@ internal class Context(config: KonanConfig) : KonanBackendContext(config) {
 
     fun shouldPrintLocations() = config.configuration.getBoolean(KonanConfigKeys.PRINT_LOCATIONS)
 
+    fun shouldPrintFiles() = config.configuration.getBoolean(KonanConfigKeys.PRINT_FILES)
+
     fun shouldProfilePhases() = config.phaseConfig.needProfiling
 
     fun shouldContainDebugInfo() = config.debug

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanConfigurationKeys.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanConfigurationKeys.kt
@@ -106,6 +106,8 @@ class KonanConfigKeys {
                 = CompilerConfigurationKey.create("print ir with descriptors")
         val PRINT_LOCATIONS: CompilerConfigurationKey<Boolean>
                 = CompilerConfigurationKey.create("print locations")
+        val PRINT_FILES: CompilerConfigurationKey<Boolean>
+                = CompilerConfigurationKey.create("print files")
         val PRODUCE: CompilerConfigurationKey<CompilerOutputKind>
                 = CompilerConfigurationKey.create("compiler output kind")
         val PURGE_USER_LIBS: CompilerConfigurationKey<Boolean>

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
@@ -75,26 +75,6 @@ internal fun konanUnitPhase(
         op: Context.() -> Unit
 ) = namedOpUnitPhase(name, description, prerequisite, op)
 
-internal val frontendPhase = konanUnitPhase(
-        op = {
-            val environment = environment
-            val analyzerWithCompilerReport = AnalyzerWithCompilerReport(messageCollector,
-                    environment.configuration.languageVersionSettings)
-
-            // Build AST and binding info.
-            analyzerWithCompilerReport.analyzeAndReport(environment.getSourceFiles()) {
-                TopDownAnalyzerFacadeForKonan.analyzeFiles(environment.getSourceFiles(), this)
-            }
-            if (analyzerWithCompilerReport.hasErrors()) {
-                throw KonanCompilationException()
-            }
-            moduleDescriptor = analyzerWithCompilerReport.analysisResult.moduleDescriptor
-            bindingContext = analyzerWithCompilerReport.analysisResult.bindingContext
-        },
-        name = "Frontend",
-        description = "Frontend builds AST"
-)
-
 /**
  * Valid from [createSymbolTablePhase] until [destroySymbolTablePhase].
  */
@@ -425,8 +405,7 @@ private val backendCodegen = namedUnitPhase(
 val toplevelPhase: CompilerPhase<*, Unit, Unit> = namedUnitPhase(
         name = "Compiler",
         description = "The whole compilation process",
-        lower = frontendPhase then
-                createSymbolTablePhase then
+        lower = createSymbolTablePhase then
                 objCExportPhase then
                 buildCExportsPhase then
                 psiToIrPhase then


### PR DESCRIPTION
This PR adds `AnalysisHandlerExtension` extension point to `K2MetadataCompiler`, `K2JsCompiler` and `K2Native`.

## Background
The extension point `AnalysisHandlerExtension` is currently only available in `K2JVMCompiler`. It allows compiler plugins to
* intercept and override the default analysis, and
* utilize the compiler infrastructure to do custom analysis.

A well known compiler plugin using this extension point is KAPT. Another example is [KSP](https://goo.gle/ksp), which is an alternative to KAPT and designed to be more Kotlin friendly.

As Kotlin MPP is getting more and more popular, people are trying to do annotation processing on K/JS and K/N. Because each platform has its own frontend that resolves source sets, built-ins and libraries differently, the JVM-only `AnalysisHandlerExtension` cannot be reused. Therefore, this PR tries to add `AnalysisHandlerExtension` extension point to `K2MetadataCompiler`, `K2JsCompiler` and `K2Native`.

### Behavior of the extension point
The behavior on each platform is exactly the same as JVM.
* The analysis is repeatable with new source roots from previous rounds.
* Extensions can override the standard `LazyTopDownAnalyzer`. `AnalysisHandlerExtension.doAnalysis` is called first. If the return value is non-null, `LazyTopDownAnalyzer.analyzeDeclarations` will be skipped.
* `AnalysisHandlerExtension.analysisCompleted` can override the result from `LazyTopDownAnalyzer`.
* If `AnalysisResult.shouldGenerateCode` is false, the compiler will finish early and do not generate code.

#### Compatibility
`org.jetbrains.kotlin.resolve.extensions.AnalysisHandlerExtension` is introduced in this PR. Therefore
* The compiler behaviors are unchanged for existing use cases.
* No existing plugins can be broken.

## Commits
The commit for each platform is comprised of two parts:
1. The analysis is made to be repeatable. It checks whether the `AnalysisResult` is `AnalysisResult.RetryWithAdditionalRoots` and if so, repeat with new source roots.
2. Right before calling `LazyTopDownAnalyzer.analyzeDeclarations`, it tries to load the extensions and run them. If any of the extension returns a non-null result, that result is used and `LazyTopDownAnalyzer` is skipped. After the analysis, the extensions has a chance to override the analysis result, which can be from themselves or `LazyTopDownAnalyzer`.

13119e7 **Move AnalysisHandlerExtension out of frontend.java**
This commit moves the extension interface from
`org.jetbrains.kotlin.resolve.jvm.extensions`
into
`org.jetbrains.kotlin.resolve.extensions`

To be backward compatible, the old interface is preserved and made to extend the new interface.

d011fc7 **Add AnalysisHandlerExtension extension point for K2MetadataCompiler** 
(nothing special)

7fe07c4 **Add AnalysisHandlerExtension extension point for K2JsCompiler**
Because `JsAnalysisResult` requires `BindingTrace` rather than `BindingContext` like `AnalysisResult`, `DelegatingBindingTrace(analysisResult.bindingContext, ...)` is used to return from `AbstractTopDownAnalyzerFacadeForJS`.

2ea3faf **Add AnalysisHandlerExtension extension point for K2Native**
To support `shouldNotGenerateCode` and return early, `frontendPhase` is moved out of `topLevelPhases`.

`-Xprint-files` is added to print the source files, since `-XverbosePhases=Frontend` can no longer be used.

879ad2f **Tests for AnalysisHandlerExtension**
Tests are added in this commit. There are two common use cases of `AnalysisHandlerExtension`:
    1. repeated analysis with new source roots.
    2. `shouldNotGenerateCode` / frontend only mode
