### PR TITLE
[REPL] Fix caching of unresolved imports

### DIFF
--- a/compiler/frontend/src/org/jetbrains/kotlin/context/context.kt
+++ b/compiler/frontend/src/org/jetbrains/kotlin/context/context.kt
@@ -20,6 +20,7 @@ import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
+import org.jetbrains.kotlin.descriptors.ModuleCapability
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.descriptors.PackageFragmentProvider
 import org.jetbrains.kotlin.descriptors.impl.ModuleDescriptorImpl
@@ -103,8 +104,9 @@ fun ContextForNewModule(
     projectContext: ProjectContext,
     moduleName: Name,
     builtIns: KotlinBuiltIns,
-    platform: TargetPlatform?
+    platform: TargetPlatform?,
+    capabilities: Map<ModuleCapability<*>, Any?> = emptyMap(),
 ): MutableModuleContext {
-    val module = ModuleDescriptorImpl(moduleName, projectContext.storageManager, builtIns, platform)
+    val module = ModuleDescriptorImpl(moduleName, projectContext.storageManager, builtIns, platform, capabilities)
     return MutableModuleContextImpl(module, projectContext)
 }

--- a/compiler/resolution.common.jvm/src/org/jetbrains/kotlin/resolve/jvm/NotFoundPackagesCachingStrategy.kt
+++ b/compiler/resolution.common.jvm/src/org/jetbrains/kotlin/resolve/jvm/NotFoundPackagesCachingStrategy.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.resolve.jvm
+
+interface NotFoundPackagesCachingStrategy {
+
+    fun chooseStrategy(isLibrarySearchScope: Boolean, qualifiedName: String): CacheType
+
+    enum class CacheType {
+        LIB_SCOPE, SCOPE, NO_CACHING
+    }
+
+    object Default : NotFoundPackagesCachingStrategy {
+        override fun chooseStrategy(isLibrarySearchScope: Boolean, qualifiedName: String): CacheType {
+            // qualifiedName could be like a proper package name, e.g `org.jetbrains.kotlin`
+            // but it could be as well part of typed text like `fooba`
+            //
+            // all those temporary names and those don't even look like a package name should be stored in a short term cache
+            // while names those are potentially proper package name could be stored for a long time
+            // (till PROJECT_ROOTS or specific VFS changes)
+            val packageLikeQName = qualifiedName.indexOf('.') > 0
+
+            return if (isLibrarySearchScope && packageLikeQName) CacheType.LIB_SCOPE
+            else CacheType.SCOPE
+        }
+    }
+}

--- a/core/descriptors/src/org/jetbrains/kotlin/descriptors/impl/LazyPackageViewDescriptorImpl.kt
+++ b/core/descriptors/src/org/jetbrains/kotlin/descriptors/impl/LazyPackageViewDescriptorImpl.kt
@@ -28,7 +28,7 @@ import org.jetbrains.kotlin.resolve.scopes.MemberScope
 import org.jetbrains.kotlin.storage.StorageManager
 import org.jetbrains.kotlin.storage.getValue
 
-class LazyPackageViewDescriptorImpl(
+open class LazyPackageViewDescriptorImpl(
     override val module: ModuleDescriptorImpl,
     override val fqName: FqName,
     storageManager: StorageManager

--- a/core/descriptors/src/org/jetbrains/kotlin/descriptors/impl/PackageViewDescriptorFactory.kt
+++ b/core/descriptors/src/org/jetbrains/kotlin/descriptors/impl/PackageViewDescriptorFactory.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.descriptors.impl
+
+import org.jetbrains.kotlin.descriptors.ModuleCapability
+import org.jetbrains.kotlin.descriptors.PackageViewDescriptor
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.storage.StorageManager
+
+interface PackageViewDescriptorFactory {
+    fun compute(
+        module: ModuleDescriptorImpl,
+        fqName: FqName,
+        storageManager: StorageManager
+    ): PackageViewDescriptor
+
+    object Default: PackageViewDescriptorFactory {
+        override fun compute(module: ModuleDescriptorImpl, fqName: FqName, storageManager: StorageManager): PackageViewDescriptor {
+            return LazyPackageViewDescriptorImpl(module, fqName, storageManager)
+        }
+    }
+
+    companion object {
+        val CAPABILITY = ModuleCapability<PackageViewDescriptorFactory>("PackageViewDescriptorFactory")
+    }
+}

--- a/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/impl/KJvmReplCompilerBase.kt
+++ b/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/impl/KJvmReplCompilerBase.kt
@@ -29,6 +29,7 @@ import org.jetbrains.kotlin.ir.declarations.impl.IrFactoryImpl
 import org.jetbrains.kotlin.ir.util.SymbolTable
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.calls.tower.ImplicitsExtensionsResolutionFilter
+import org.jetbrains.kotlin.resolve.jvm.KotlinJavaPsiFacade
 import org.jetbrains.kotlin.scripting.compiler.plugin.repl.*
 import org.jetbrains.kotlin.scripting.definitions.ScriptDependenciesProvider
 import org.jetbrains.kotlin.scripting.resolve.skipExtensionsResolutionForImplicits
@@ -333,8 +334,10 @@ class ReplCompilationState<AnalyzerT : ReplCodeAnalyzerBase>(
     override val baseScriptCompilationConfiguration: ScriptCompilationConfiguration get() = context.baseScriptCompilationConfiguration
     override val environment: KotlinCoreEnvironment get() = context.environment
     override val analyzerEngine: AnalyzerT by lazy {
-        // ReplCodeAnalyzer1(context.environment)
-        analyzerInit(context, implicitsResolutionFilter)
+        val analyzer = analyzerInit(context, implicitsResolutionFilter)
+        val psiFacade = KotlinJavaPsiFacade.getInstance(environment.project)
+        psiFacade.setNotFoundPackagesCachingStrategy(ReplNotFoundPackagesCachingStrategy)
+        analyzer
     }
 
     private val manglerAndSymbolTable by lazy {

--- a/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/impl/KJvmReplCompilerBase.kt
+++ b/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/impl/KJvmReplCompilerBase.kt
@@ -310,12 +310,8 @@ open class KJvmReplCompilerBase<AnalyzerT : ReplCodeAnalyzerBase> protected cons
             else allPreviousLines.subList(1, allPreviousLines.size)
 
         return ScriptCompilationConfiguration(configuration) {
-            skipExtensionsResolutionForImplicits.update {
-                it?.also { it.toMutableList().addAll(skipAlways) } ?: skipAlways
-            }
-            skipExtensionsResolutionForImplicitsExceptInnermost.update {
-                it?.also { it.toMutableList().addAll(skipFirstTime) } ?: skipFirstTime
-            }
+            skipExtensionsResolutionForImplicits(*skipAlways.toTypedArray())
+            skipExtensionsResolutionForImplicitsExceptInnermost(*skipFirstTime.toTypedArray())
         }
     }
 

--- a/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/impl/ReplNotFoundPackagesCachingStrategy.kt
+++ b/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/impl/ReplNotFoundPackagesCachingStrategy.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.scripting.compiler.plugin.impl
+
+import org.jetbrains.kotlin.resolve.jvm.NotFoundPackagesCachingStrategy
+
+object ReplNotFoundPackagesCachingStrategy : NotFoundPackagesCachingStrategy {
+    override fun chooseStrategy(isLibrarySearchScope: Boolean, qualifiedName: String): NotFoundPackagesCachingStrategy.CacheType {
+        return NotFoundPackagesCachingStrategy.CacheType.NO_CACHING
+    }
+}

--- a/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/impl/ReplPackageViewDescriptorFactory.kt
+++ b/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/impl/ReplPackageViewDescriptorFactory.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.scripting.compiler.plugin.impl
+
+import org.jetbrains.kotlin.descriptors.PackageFragmentDescriptor
+import org.jetbrains.kotlin.descriptors.PackageViewDescriptor
+import org.jetbrains.kotlin.descriptors.impl.LazyPackageViewDescriptorImpl
+import org.jetbrains.kotlin.descriptors.impl.ModuleDescriptorImpl
+import org.jetbrains.kotlin.descriptors.impl.PackageViewDescriptorFactory
+import org.jetbrains.kotlin.descriptors.packageFragments
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.storage.StorageManager
+
+object ReplPackageViewDescriptorFactory : PackageViewDescriptorFactory {
+    override fun compute(module: ModuleDescriptorImpl, fqName: FqName, storageManager: StorageManager): PackageViewDescriptor {
+        return ReplPackageViewDescriptor(module, fqName, storageManager)
+    }
+}
+
+class ReplPackageViewDescriptor(
+    module: ModuleDescriptorImpl,
+    fqName: FqName,
+    storageManager: StorageManager
+) : LazyPackageViewDescriptorImpl(module, fqName, storageManager) {
+    private var cachedFragments: List<PackageFragmentDescriptor>? = null
+
+    override val fragments: List<PackageFragmentDescriptor>
+        get() {
+            cachedFragments?.let { return it }
+            val calculatedFragments = module.packageFragmentProvider.packageFragments(fqName)
+            if (calculatedFragments.isNotEmpty()) cachedFragments = calculatedFragments
+            return calculatedFragments
+        }
+}

--- a/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/repl/ReplCodeAnalyzer.kt
+++ b/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/repl/ReplCodeAnalyzer.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlin.container.ComponentProvider
 import org.jetbrains.kotlin.container.get
 import org.jetbrains.kotlin.descriptors.ClassDescriptorWithResolutionScopes
 import org.jetbrains.kotlin.descriptors.impl.ModuleDescriptorImpl
+import org.jetbrains.kotlin.descriptors.impl.PackageViewDescriptorFactory
 import org.jetbrains.kotlin.diagnostics.Severity
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtFile
@@ -33,6 +34,7 @@ import org.jetbrains.kotlin.resolve.lazy.declarations.*
 import org.jetbrains.kotlin.resolve.scopes.ImportingScope
 import org.jetbrains.kotlin.resolve.scopes.utils.parentsWithSelf
 import org.jetbrains.kotlin.resolve.scopes.utils.replaceImportingScopes
+import org.jetbrains.kotlin.scripting.compiler.plugin.impl.ReplPackageViewDescriptorFactory
 import org.jetbrains.kotlin.scripting.definitions.ScriptPriorities
 import kotlin.script.experimental.api.SourceCode
 import kotlin.script.experimental.jvm.util.CompiledHistoryItem
@@ -65,7 +67,8 @@ open class ReplCodeAnalyzerBase(
             environment.configuration,
             environment::createPackagePartProvider,
             { _, _ -> ScriptMutableDeclarationProviderFactory() },
-            implicitsResolutionFilter = implicitsResolutionFilter
+            implicitsResolutionFilter = implicitsResolutionFilter,
+            moduleCapabilities = mapOf(PackageViewDescriptorFactory.CAPABILITY to ReplPackageViewDescriptorFactory)
         )
 
         this.module = container.get()

--- a/plugins/scripting/scripting-ide-services-test/test/org/jetbrains/kotlin/scripting/ide_services/JvmReplTest.kt
+++ b/plugins/scripting/scripting-ide-services-test/test/org/jetbrains/kotlin/scripting/ide_services/JvmReplTest.kt
@@ -296,6 +296,12 @@ class JvmIdeServicesTest : TestCase() {
                 val (exitCode, outputJarPath) = compileFile("stringTo.kt", outputJarName)
                 assertEquals(ExitCode.OK, exitCode)
 
+                assertCompileFails(
+                    repl, """
+                        import example.dependency.*
+                    """.trimIndent()
+                )
+
                 assertEvalUnit(
                     repl, """
                         @file:DependsOn("$outputJarPath")
@@ -410,6 +416,17 @@ private fun JvmTestRepl.compileAndEval(codeLine: SourceCode): Pair<ResultWithDia
         eval(it)
     }
     return compRes to evalRes?.valueOrNull().get()
+}
+
+private fun assertCompileFails(
+    repl: JvmTestRepl,
+    @Suppress("SameParameterValue")
+    line: String
+) {
+    val compiledSnippet =
+        checkCompile(repl, line)
+
+    TestCase.assertNull(compiledSnippet)
 }
 
 private fun assertEvalUnit(


### PR DESCRIPTION
Before this fix, if some imports were not resolved during compilation, this result had been saved in caches, and this import couldn't been resolved during following compilations even if it was added to the module dependencies. This PR adds special handling of packages resolution caches for the REPL compiler.

Also this PR fixes performance problem with updating of configuration for implicit receivers.