### PR TITLE
Generalize getLightClassMethods name filtering

### DIFF
--- a/compiler/light-classes/src/org/jetbrains/kotlin/asJava/LightClassUtil.kt
+++ b/compiler/light-classes/src/org/jetbrains/kotlin/asJava/LightClassUtil.kt
@@ -26,6 +26,7 @@ import org.jetbrains.kotlin.asJava.classes.KtLightClass
 import org.jetbrains.kotlin.asJava.elements.*
 import org.jetbrains.kotlin.asJava.finder.JavaElementFinder
 import org.jetbrains.kotlin.fileClasses.javaFileFacadeFqName
+import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.load.java.JvmAbi
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.getNonStrictParentOfType
@@ -131,7 +132,7 @@ object LightClassUtil {
     private fun getPsiMethodWrappers(declaration: KtDeclaration, name: String? = null): Sequence<KtLightMethod> =
         getWrappingClasses(declaration).flatMap { it.methods.asSequence() }
             .filterIsInstance<KtLightMethod>()
-            .filter { name == null || name == it.name }
+            .filter { name == null || declaration.hasModifier(KtTokens.INTERNAL_KEYWORD) || name == it.name }
             .filter { it.kotlinOrigin === declaration || it.navigationElement === declaration }
 
     private fun getWrappingClass(declaration: KtDeclaration): PsiClass? {

--- a/compiler/light-classes/src/org/jetbrains/kotlin/asJava/LightClassUtil.kt
+++ b/compiler/light-classes/src/org/jetbrains/kotlin/asJava/LightClassUtil.kt
@@ -110,7 +110,7 @@ object LightClassUtil {
     }
 
     fun getLightClassMethod(function: KtFunction): PsiMethod? {
-        return getPsiMethodWrapper(function)
+        return getPsiMethodWrapper(function, function.name)
     }
 
     /**
@@ -121,15 +121,11 @@ object LightClassUtil {
     }
 
     fun getLightClassMethods(function: KtFunction): List<PsiMethod> {
-        return getPsiMethodWrappers(function).toList()
+        return getPsiMethodWrappers(function, function.name).toList()
     }
 
-    fun getLightClassMethodsByName(function: KtFunction, name: String): Sequence<KtLightMethod> {
-        return getPsiMethodWrappers(function, name)
-    }
-
-    private fun getPsiMethodWrapper(declaration: KtDeclaration): PsiMethod? {
-        return getPsiMethodWrappers(declaration).firstOrNull()
+    private fun getPsiMethodWrapper(declaration: KtDeclaration, name: String? = null): PsiMethod? {
+        return getPsiMethodWrappers(declaration, name).firstOrNull()
     }
 
     private fun getPsiMethodWrappers(declaration: KtDeclaration, name: String? = null): Sequence<KtLightMethod> =

--- a/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/KotlinShortNamesCache.kt
+++ b/idea/idea-analysis/src/org/jetbrains/kotlin/idea/caches/KotlinShortNamesCache.kt
@@ -192,7 +192,7 @@ class KotlinShortNamesCache(private val project: Project) : PsiShortNamesCache()
             filter,
             KtNamedFunction::class.java
         ) { ktNamedFunction ->
-            val methods = LightClassUtil.getLightClassMethodsByName(ktNamedFunction, name)
+            val methods = LightClassUtil.getLightClassMethods(ktNamedFunction)
             return@processElements methods.all { method ->
                 processor.process(method)
             }

--- a/plugins/uast-kotlin/testData/InternalFunction.kt
+++ b/plugins/uast-kotlin/testData/InternalFunction.kt
@@ -1,0 +1,3 @@
+class Test {
+    internal fun method(param: String) = Unit
+}

--- a/plugins/uast-kotlin/testData/InternalFunction.log.txt
+++ b/plugins/uast-kotlin/testData/InternalFunction.log.txt
@@ -1,0 +1,9 @@
+UFile (package = )
+    UClass (name = Test)
+        UMethod (name = method$test_module)
+            UParameter (name = param)
+                UAnnotation (fqName = org.jetbrains.annotations.NotNull)
+            UBlockExpression
+                UReturnExpression
+                    USimpleNameReferenceExpression (identifier = Unit)
+        UMethod (name = Test)

--- a/plugins/uast-kotlin/testData/InternalFunction.render.txt
+++ b/plugins/uast-kotlin/testData/InternalFunction.render.txt
@@ -1,0 +1,6 @@
+public final class Test {
+    public final fun method$test_module(@org.jetbrains.annotations.NotNull param: java.lang.String) : void {
+        return Unit
+    }
+    public fun Test() = UastEmptyExpression
+}

--- a/plugins/uast-kotlin/tests/SimpleKotlinRenderLogTest.kt
+++ b/plugins/uast-kotlin/tests/SimpleKotlinRenderLogTest.kt
@@ -153,6 +153,9 @@ class SimpleKotlinRenderLogTest : AbstractKotlinUastTest(), AbstractKotlinRender
 
     @Test
     fun testTypeAliasExpansionWithOtherAliasInArgument() = doTest("TypeAliasExpansionWithOtherAliasInArgument")
+
+    @Test
+    fun testInternalFunction() = doTest("InternalFunction")
 }
 
 fun withForceUInjectionHostValue(call: () -> Unit) {


### PR DESCRIPTION
These changes are related to KT-44727. While original issues has been fixed by https://github.com/JetBrains/kotlin/commit/6331a135c8c7a966d2688326bf203b1873734dc5 I've noticed that similar scenario might happen in other places like https://github.com/JetBrains/kotlin/blob/29b23e79f32791e456a5b4a453277f0f0b3e984d/plugins/uast-kotlin/src/org/jetbrains/uast/kotlin/KotlinUastLanguagePlugin.kt#L659
Since `getLightClassMethod` and `getLightClassMethods` are taking `KtFunction` as a parameter we should be able to get name from it without introducing `getLightClassMethodsByName` function so all call sites could leverage it by default. 