### PR TITLE
Build report: Print task name instead of TaskRecord@hashCode

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/report/PlainTextBuildReportWriter.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/report/PlainTextBuildReportWriter.kt
@@ -148,13 +148,13 @@ internal class PlainTextBuildReportWriter(
     private fun printTaskLog(task: TaskExecutionData) {
         val skipMessage = task.resultState.skipMessage
         if (skipMessage != null) {
-            p.println("$task was skipped: $skipMessage")
+            p.println("Task '${task.task.path}' was skipped: $skipMessage")
         } else {
-            p.println("$task finished in ${formatTime(task.totalTimeNs)}")
+            p.println("Task '${task.task.path}' finished in ${formatTime(task.totalTimeNs)}")
         }
 
         if (task.icLogLines.isNotEmpty()) {
-            p.withIndent("Compilation log for $task:") {
+            p.withIndent("Compilation log for task '${task.task.path}':") {
                 task.icLogLines.forEach { p.println(it) }
             }
         }


### PR DESCRIPTION
Previously when kotlin.build.report.enable=true, the build report
contained lines such as:
  org.jetbrains.kotlin.gradle.report.TaskRecord@2db49688 was skipped

This commit prints the task name instead of TaskRecord@hashCode so that
it is more readable, like this:
  Task ':app:compileDebugKotlin' was skipped

Bug: N/A (Clean up)
Test: Existing tests + manually checked the build report output