### PR TITLE
FIR IDE: simplify HLDiagnosticFixFactory

### DIFF
--- a/idea/idea-fir/src/org/jetbrains/kotlin/idea/fir/api/fixes/HLDiagnosticFixFactory.kt
+++ b/idea/idea-fir/src/org/jetbrains/kotlin/idea/fir/api/fixes/HLDiagnosticFixFactory.kt
@@ -13,7 +13,7 @@ import org.jetbrains.kotlin.idea.frontend.api.KtAnalysisSession
 import org.jetbrains.kotlin.idea.frontend.api.diagnostics.KtDiagnosticWithPsi
 
 sealed class HLDiagnosticFixFactory<in DIAGNOSTIC : KtDiagnosticWithPsi<*>> {
-    abstract fun KtAnalysisSession.createQuickFixes(diagnostic: DIAGNOSTIC): List<HLQuickFix<*, *>>
+    abstract fun KtAnalysisSession.createQuickFixes(diagnostic: DIAGNOSTIC): List<IntentionAction>
 }
 
 private class HLDiagnosticFixFactoryWithFixedApplicator<DIAGNOSTIC : KtDiagnosticWithPsi<*>, TARGET_PSI : PsiElement, INPUT : HLApplicatorInput>(
@@ -25,9 +25,9 @@ private class HLDiagnosticFixFactoryWithFixedApplicator<DIAGNOSTIC : KtDiagnosti
 }
 
 private class HLDiagnosticFixFactoryWithVariableApplicator<DIAGNOSTIC : KtDiagnosticWithPsi<*>>(
-    private val createQuickFixes: KtAnalysisSession.(DIAGNOSTIC) -> List<HLQuickFix<*, *>>
+    private val createQuickFixes: KtAnalysisSession.(DIAGNOSTIC) -> List<IntentionAction>
 ) : HLDiagnosticFixFactory<DIAGNOSTIC>() {
-    override fun KtAnalysisSession.createQuickFixes(diagnostic: DIAGNOSTIC): List<HLQuickFix<*, *>> =
+    override fun KtAnalysisSession.createQuickFixes(diagnostic: DIAGNOSTIC): List<IntentionAction> =
         createQuickFixes.invoke(this, diagnostic)
 }
 
@@ -50,6 +50,6 @@ fun <DIAGNOSTIC : KtDiagnosticWithPsi<*>, TARGET_PSI : PsiElement, INPUT : HLApp
  * Returns a [HLDiagnosticFixFactory] that creates [HLQuickFix]es from a diagnostic.
  */
 fun <DIAGNOSTIC : KtDiagnosticWithPsi<*>> diagnosticFixFactory(
-    createQuickFixes: KtAnalysisSession.(DIAGNOSTIC) -> List<HLQuickFix<*, *>>
+    createQuickFixes: KtAnalysisSession.(DIAGNOSTIC) -> List<IntentionAction>
 ): HLDiagnosticFixFactory<DIAGNOSTIC> =
     HLDiagnosticFixFactoryWithVariableApplicator(createQuickFixes)

--- a/idea/idea-fir/src/org/jetbrains/kotlin/idea/fir/api/fixes/KtQuickFixesList.kt
+++ b/idea/idea-fir/src/org/jetbrains/kotlin/idea/fir/api/fixes/KtQuickFixesList.kt
@@ -30,7 +30,7 @@ class KtQuickFixesList @ForKtQuickFixesListBuilder @OptIn(PrivateForInline::clas
         is HLQuickFixFactory.HLApplicatorBasedFactory -> {
             @Suppress("UNCHECKED_CAST")
             val factory = quickFixFactory.applicatorFactory
-                    as HLDiagnosticFixFactory<PsiElement, KtDiagnosticWithPsi<PsiElement>, PsiElement, HLApplicatorInput>
+                    as HLDiagnosticFixFactory<PsiElement, KtDiagnosticWithPsi<PsiElement>>
             createPlatformQuickFixes(diagnostic, factory)
         }
         is HLQuickFixFactory.HLQuickFixesPsiBasedFactory -> quickFixFactory.psiFactory.createQuickFix(diagnostic.psi)
@@ -66,8 +66,8 @@ class KtQuickFixesListBuilder private constructor() {
     }
 
     @OptIn(PrivateForInline::class)
-    inline fun <DIAGNOSTIC_PSI : PsiElement, reified DIAGNOSTIC : KtDiagnosticWithPsi<DIAGNOSTIC_PSI>, TARGET_PSI : PsiElement, INPUT : HLApplicatorInput> registerApplicator(
-        quickFixFactory: HLDiagnosticFixFactory<DIAGNOSTIC_PSI, DIAGNOSTIC, TARGET_PSI, INPUT>
+    inline fun <DIAGNOSTIC_PSI : PsiElement, reified DIAGNOSTIC : KtDiagnosticWithPsi<DIAGNOSTIC_PSI>> registerApplicator(
+        quickFixFactory: HLDiagnosticFixFactory<DIAGNOSTIC_PSI, DIAGNOSTIC>
     ) {
         registerApplicator(DIAGNOSTIC::class, quickFixFactory)
     }
@@ -82,9 +82,9 @@ class KtQuickFixesListBuilder private constructor() {
 
 
     @PrivateForInline
-    fun <DIAGNOSTIC_PSI : PsiElement, DIAGNOSTIC : KtDiagnosticWithPsi<DIAGNOSTIC_PSI>, TARGET_PSI : PsiElement, INPUT : HLApplicatorInput> registerApplicator(
+    fun <DIAGNOSTIC_PSI : PsiElement, DIAGNOSTIC : KtDiagnosticWithPsi<DIAGNOSTIC_PSI>> registerApplicator(
         diagnosticClass: KClass<DIAGNOSTIC>,
-        quickFixFactory: HLDiagnosticFixFactory<DIAGNOSTIC_PSI, DIAGNOSTIC, TARGET_PSI, INPUT>
+        quickFixFactory: HLDiagnosticFixFactory<DIAGNOSTIC_PSI, DIAGNOSTIC>
     ) {
         quickFixes.getOrPut(diagnosticClass) { mutableListOf() }
             .add(HLQuickFixFactory.HLApplicatorBasedFactory(quickFixFactory))
@@ -105,7 +105,7 @@ sealed class HLQuickFixFactory {
     ) : HLQuickFixFactory()
 
     class HLApplicatorBasedFactory(
-        val applicatorFactory: HLDiagnosticFixFactory<*, *, *, *>
+        val applicatorFactory: HLDiagnosticFixFactory<*, *>
     ) : HLQuickFixFactory()
 }
 
@@ -121,4 +121,4 @@ private fun <K, V> List<Map<K, List<V>>>.merge(): Map<K, List<V>> {
 }
 
 @RequiresOptIn
-annotation class ForKtQuickFixesListBuilder()
+annotation class ForKtQuickFixesListBuilder

--- a/idea/idea-fir/src/org/jetbrains/kotlin/idea/fir/api/fixes/KtQuickFixesList.kt
+++ b/idea/idea-fir/src/org/jetbrains/kotlin/idea/fir/api/fixes/KtQuickFixesList.kt
@@ -7,7 +7,6 @@ package org.jetbrains.kotlin.idea.fir.api.fixes
 
 import com.intellij.codeInsight.intention.IntentionAction
 import com.intellij.psi.PsiElement
-import org.jetbrains.kotlin.idea.fir.api.applicator.HLApplicatorInput
 import org.jetbrains.kotlin.idea.fir.low.level.api.annotations.PrivateForInline
 import org.jetbrains.kotlin.idea.frontend.api.KtAnalysisSession
 import org.jetbrains.kotlin.idea.frontend.api.diagnostics.KtDiagnosticWithPsi
@@ -30,7 +29,7 @@ class KtQuickFixesList @ForKtQuickFixesListBuilder @OptIn(PrivateForInline::clas
         is HLQuickFixFactory.HLApplicatorBasedFactory -> {
             @Suppress("UNCHECKED_CAST")
             val factory = quickFixFactory.applicatorFactory
-                    as HLDiagnosticFixFactory<PsiElement, KtDiagnosticWithPsi<PsiElement>>
+                    as HLDiagnosticFixFactory<KtDiagnosticWithPsi<PsiElement>>
             createPlatformQuickFixes(diagnostic, factory)
         }
         is HLQuickFixFactory.HLQuickFixesPsiBasedFactory -> quickFixFactory.psiFactory.createQuickFix(diagnostic.psi)
@@ -66,8 +65,8 @@ class KtQuickFixesListBuilder private constructor() {
     }
 
     @OptIn(PrivateForInline::class)
-    inline fun <DIAGNOSTIC_PSI : PsiElement, reified DIAGNOSTIC : KtDiagnosticWithPsi<DIAGNOSTIC_PSI>> registerApplicator(
-        quickFixFactory: HLDiagnosticFixFactory<DIAGNOSTIC_PSI, DIAGNOSTIC>
+    inline fun <reified DIAGNOSTIC : KtDiagnosticWithPsi<*>> registerApplicator(
+        quickFixFactory: HLDiagnosticFixFactory<DIAGNOSTIC>
     ) {
         registerApplicator(DIAGNOSTIC::class, quickFixFactory)
     }
@@ -82,9 +81,9 @@ class KtQuickFixesListBuilder private constructor() {
 
 
     @PrivateForInline
-    fun <DIAGNOSTIC_PSI : PsiElement, DIAGNOSTIC : KtDiagnosticWithPsi<DIAGNOSTIC_PSI>> registerApplicator(
+    fun <DIAGNOSTIC : KtDiagnosticWithPsi<*>> registerApplicator(
         diagnosticClass: KClass<DIAGNOSTIC>,
-        quickFixFactory: HLDiagnosticFixFactory<DIAGNOSTIC_PSI, DIAGNOSTIC>
+        quickFixFactory: HLDiagnosticFixFactory<DIAGNOSTIC>
     ) {
         quickFixes.getOrPut(diagnosticClass) { mutableListOf() }
             .add(HLQuickFixFactory.HLApplicatorBasedFactory(quickFixFactory))
@@ -105,7 +104,7 @@ sealed class HLQuickFixFactory {
     ) : HLQuickFixFactory()
 
     class HLApplicatorBasedFactory(
-        val applicatorFactory: HLDiagnosticFixFactory<*, *>
+        val applicatorFactory: HLDiagnosticFixFactory<*>
     ) : HLQuickFixFactory()
 }
 

--- a/idea/idea-fir/src/org/jetbrains/kotlin/idea/fir/applicators/CallableReturnTypeUpdaterApplicator.kt
+++ b/idea/idea-fir/src/org/jetbrains/kotlin/idea/fir/applicators/CallableReturnTypeUpdaterApplicator.kt
@@ -25,7 +25,7 @@ object CallableReturnTypeUpdaterApplicator {
         applyTo { declaration, type, project ->
             val newTypeRef = if (!declaration.isProcedure(type)) {
                 // TODO use longTypeRepresentation and then shorten
-                KtPsiFactory(project ?: declaration.project).createType(type.shortTypeRepresentation)
+                KtPsiFactory(project).createType(type.shortTypeRepresentation)
             } else null
             runWriteAction {
                 declaration.typeReference = newTypeRef

--- a/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/fixes/ChangeReturnTypeOnOverrideQuickFix.kt
+++ b/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/fixes/ChangeReturnTypeOnOverrideQuickFix.kt
@@ -86,7 +86,7 @@ object ChangeTypeQuickFix {
 
     private inline fun <DIAGNOSTIC : KtDiagnosticWithPsi<KtNamedDeclaration>> changeReturnTypeOnOverride(
         crossinline getCallableSymbol: (DIAGNOSTIC) -> KtCallableSymbol?
-    ) = diagnosticFixFactory<KtNamedDeclaration, DIAGNOSTIC, KtCallableDeclaration, Input>(applicator) { diagnostic ->
+    ) = diagnosticFixFactory<DIAGNOSTIC, KtCallableDeclaration, Input>(applicator) { diagnostic ->
         val declaration = diagnostic.psi as? KtCallableDeclaration ?: return@diagnosticFixFactory emptyList()
         val callable = getCallableSymbol(diagnostic) ?: return@diagnosticFixFactory emptyList()
         listOfNotNull(

--- a/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/fixes/ReplaceCallFixFactories.kt
+++ b/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/fixes/ReplaceCallFixFactories.kt
@@ -5,7 +5,6 @@
 
 package org.jetbrains.kotlin.idea.quickfix.fixes
 
-import com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.idea.KotlinBundle
 import org.jetbrains.kotlin.idea.fir.api.applicator.HLApplicatorInput
 import org.jetbrains.kotlin.idea.fir.api.applicator.applicatorByQuickFix
@@ -40,7 +39,7 @@ object ReplaceCallFixFactories {
     class Input(val notNullNeeded: Boolean) : HLApplicatorInput
 
     val unsafeCallFactory =
-        diagnosticFixFactory<PsiElement, KtFirDiagnostic.UnsafeCall> { diagnostic ->
+        diagnosticFixFactory<KtFirDiagnostic.UnsafeCall> { diagnostic ->
             fun KtExpression.shouldHaveNotNullType(): Boolean {
                 // This function is used to determine if we may need to add an elvis operator after the safe call. For example, to replace
                 // `s.length` in `val x: Int = s.length` with a safe call, it should be replaced with `s.length ?: <caret>`.

--- a/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/fixes/ReplaceCallFixFactories.kt
+++ b/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/fixes/ReplaceCallFixFactories.kt
@@ -40,7 +40,7 @@ object ReplaceCallFixFactories {
     class Input(val notNullNeeded: Boolean) : HLApplicatorInput
 
     val unsafeCallFactory =
-        diagnosticFixFactory<PsiElement, KtFirDiagnostic.UnsafeCall, KtExpression, Input> { diagnostic ->
+        diagnosticFixFactory<PsiElement, KtFirDiagnostic.UnsafeCall> { diagnostic ->
             fun KtExpression.shouldHaveNotNullType(): Boolean {
                 // This function is used to determine if we may need to add an elvis operator after the safe call. For example, to replace
                 // `s.length` in `val x: Int = s.length` with a safe call, it should be replaced with `s.length ?: <caret>`.


### PR DESCRIPTION
This PR has the following commits

FIR IDE: remove type parameter `TARGET_PSI` and `INPUT`
====

The factory does not need to care about what target PSI and input a quick
fix should need. We only need to ensure these two types match when an
`HLQuickfix` is created. With this constraint loosened, now one factory can
register multiple quickfixes applied on different targets and different
input. This makes it much more flexible when implementing quickfixes.

FIR IDE: remove type parameter `DIAGNOSTIC_PSI`
====

This information is already determined by `DIAGNOSTIC` so there is no need
to repeat it.

FIR IDE: tweak nullability of applyTo
====

It looks like `project` can never be null

# FIR IDE: allow HLDiagnosticFixFactory creating any intention

It seems unnecessary to force all quickfixes to fit the `HLQuickfix`
API, especially for those existing trivial fixes that simply modifies
PSI tree. This change further loosen the API of `HLDiagnosticFixFactory`
to allow it to create arbitrary `IntentionAction` objects. This also
avoids code duplication (for example, specify the family name again in
`ReplaceCallFixFactories`).

`HLQuickfix` and the input/target paradighm can still be used where
applicable.
