### PR TITLE
KAPT: Avoid evaluating apOptions from AGP too early

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/KaptWithoutKotlincTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/KaptWithoutKotlincTask.kt
@@ -11,6 +11,7 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs
+import org.gradle.process.CommandLineArgumentProvider
 import org.gradle.workers.IsolationMode
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
@@ -74,6 +75,14 @@ abstract class KaptWithoutKotlincTask @Inject constructor(
         for (option in options) {
             result[option.key] = option.value
         }
+        annotationProcessorOptionProviders.forEach {
+            (it as List<Any>).forEach {
+                (it as CommandLineArgumentProvider).asArguments().forEach {
+                    result[it.removePrefix("-A")] = ""
+                }
+            }
+        }
+
         return result
     }
 


### PR DESCRIPTION
This is causing issues such as https://issuetracker.google.com/183423660.
Annotation processor options that are provided by the Android Gradle plugin
may contain references to files and file collections that are safe to
evaluate only at execution time. This change avoids eagerly creating
compiler plugin options for these options, as they are already a task input.

Test: AbstractKotlinAndroidGradleTests.testAgpNestedArgsNotEvaluatedDuringConfiguration