### PR TITLE
FIR IDE: remove redundant/unneeded dependencies

### DIFF
--- a/idea/idea-frontend-api/build.gradle.kts
+++ b/idea/idea-frontend-api/build.gradle.kts
@@ -10,7 +10,6 @@ dependencies {
     compileOnly(project(":compiler:frontend"))
     compileOnly(project(":core:compiler.common"))
     compileOnly(project(":idea:idea-frontend-independent"))
-    compileOnly(project(":compiler:psi"))
     compileOnly(intellijCoreDep())
     compileOnly(intellijDep())
     compileOnly(intellijPluginDep("java")) { includeJars("java-api", "java-impl") }

--- a/idea/idea-frontend-fir/build.gradle.kts
+++ b/idea/idea-frontend-fir/build.gradle.kts
@@ -10,8 +10,6 @@ dependencies {
     compile(project(":idea:idea-frontend-independent"))
     compile(project(":idea:idea-frontend-api"))
     compile(project(":idea:idea-core"))
-    compile(project(":compiler:fir:fir2ir"))
-    compile(project(":compiler:ir.tree"))
     compile(project(":compiler:fir:resolve"))
     compile(project(":compiler:fir:checkers"))
     compile(project(":compiler:fir:java"))


### PR DESCRIPTION
1st commit is obvious: it's simply redundant, i.e., the same dependency is already there a couple line above.

About 2nd commit, it seems there is no place that `idea-frontend-fir` invokes the conversion to backend IR, or I missed something else...?