### PR TITLE
FIR checker: fix checker registration

### DIFF
--- a/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/CheckersConfiguration.kt
+++ b/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/CheckersConfiguration.kt
@@ -6,7 +6,7 @@
 package org.jetbrains.kotlin.fir.checkers.generator
 
 import kotlin.reflect.KClass
-import kotlin.reflect.full.superclasses
+import kotlin.reflect.full.allSuperclasses
 
 class CheckersConfiguration(
     val aliases: Map<KClass<*>, String>,
@@ -17,19 +17,17 @@ class CheckersConfiguration(
     init {
         val parents: MutableMap<KClass<*>, List<KClass<*>>> = mutableMapOf()
         for (firKClass in aliases.keys) {
-            val directParents = mutableListOf<KClass<*>>()
+            val allParents = mutableListOf<KClass<*>>()
             bfs(
                 firKClass,
-                childrenExtractor = { it.superclasses }
+                childrenExtractor = { it.allSuperclasses }
             ) {
                 if (it in aliases) {
-                    directParents += it
-                    false
-                } else {
-                    true
+                    allParents += it
                 }
+                true
             }
-            parents[firKClass] = directParents
+            parents[firKClass] = allParents
         }
         parentsMap = parents
     }

--- a/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/Generator.kt
+++ b/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/Generator.kt
@@ -5,7 +5,8 @@
 
 package org.jetbrains.kotlin.fir.checkers.generator
 
-import org.jetbrains.kotlin.fir.tree.generator.printer.*
+import org.jetbrains.kotlin.fir.tree.generator.printer.printCopyright
+import org.jetbrains.kotlin.fir.tree.generator.printer.printGeneratedMessage
 import org.jetbrains.kotlin.fir.tree.generator.util.writeToFileUsingSmartPrinterIfFileContentChanged
 import org.jetbrains.kotlin.util.SmartPrinter
 import org.jetbrains.kotlin.util.withIndent
@@ -77,7 +78,7 @@ class Generator(
                     print("$CHECKERS_COMPONENT_INTERNAL_ANNOTATION internal val ${alias.allFieldName}: ${alias.setType} get() = ${alias.fieldName}")
                     for (parent in configuration.parentsMap.getValue(kClass)) {
                         val parentAlias = configuration.aliases.getValue(parent)
-                        print(" + ${parentAlias.allFieldName}")
+                        print(" + ${parentAlias.fieldName}")
                     }
                     println()
                 }
@@ -124,7 +125,7 @@ class Generator(
                 println("internal fun register(checkers: $checkersComponentName) {")
                 withIndent {
                     for (alias in configuration.aliases.values) {
-                        println("_${alias.fieldName} += checkers.${alias.allFieldName}")
+                        println("_${alias.fieldName} += checkers.${alias.fieldName}")
                     }
                     for (fieldName in configuration.additionalCheckers.keys) {
                         println("_$fieldName += checkers.$fieldName")

--- a/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/Main.kt
+++ b/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/Main.kt
@@ -29,6 +29,7 @@ fun main(args: Array<String>) {
         alias<FirDeclaration>("BasicDeclarationChecker")
         alias<FirMemberDeclaration>("MemberDeclarationChecker")
         alias<FirFunction<*>>("FunctionChecker")
+        alias<FirSimpleFunction>("SimpleFunctionChecker")
         alias<FirProperty>("PropertyChecker")
         alias<FirClass<*>>("ClassChecker")
         alias<FirRegularClass>("RegularClassChecker")

--- a/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/diagnostics/FirDiagnosticsList.kt
+++ b/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/diagnostics/FirDiagnosticsList.kt
@@ -242,8 +242,7 @@ object DIAGNOSTICS_LIST : DiagnosticList() {
         val INFERENCE_ERROR by error<FirSourceElement, PsiElement>()
         val PROJECTION_ON_NON_CLASS_TYPE_ARGUMENT by error<FirSourceElement, PsiElement>()
         val UPPER_BOUND_VIOLATED by error<FirSourceElement, PsiElement> {
-            parameter<FirTypeParameterSymbol>("typeParameter")
-            parameter<ConeKotlinType>("violatedType")
+            parameter<ConeKotlinType>("upperBound")
         }
         val TYPE_ARGUMENTS_NOT_ALLOWED by error<FirSourceElement, PsiElement>()
         val WRONG_NUMBER_OF_TYPE_ARGUMENTS by error<FirSourceElement, PsiElement> {

--- a/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/checkers/declaration/ComposedDeclarationCheckers.kt
+++ b/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/checkers/declaration/ComposedDeclarationCheckers.kt
@@ -21,6 +21,8 @@ internal class ComposedDeclarationCheckers : DeclarationCheckers() {
         get() = _memberDeclarationCheckers
     override val functionCheckers: Set<FirFunctionChecker>
         get() = _functionCheckers
+    override val simpleFunctionCheckers: Set<FirSimpleFunctionChecker>
+        get() = _simpleFunctionCheckers
     override val propertyCheckers: Set<FirPropertyChecker>
         get() = _propertyCheckers
     override val classCheckers: Set<FirClassChecker>
@@ -39,6 +41,7 @@ internal class ComposedDeclarationCheckers : DeclarationCheckers() {
     private val _basicDeclarationCheckers: MutableSet<FirBasicDeclarationChecker> = mutableSetOf()
     private val _memberDeclarationCheckers: MutableSet<FirMemberDeclarationChecker> = mutableSetOf()
     private val _functionCheckers: MutableSet<FirFunctionChecker> = mutableSetOf()
+    private val _simpleFunctionCheckers: MutableSet<FirSimpleFunctionChecker> = mutableSetOf()
     private val _propertyCheckers: MutableSet<FirPropertyChecker> = mutableSetOf()
     private val _classCheckers: MutableSet<FirClassChecker> = mutableSetOf()
     private val _regularClassCheckers: MutableSet<FirRegularClassChecker> = mutableSetOf()
@@ -49,14 +52,15 @@ internal class ComposedDeclarationCheckers : DeclarationCheckers() {
 
     @CheckersComponentInternal
     internal fun register(checkers: DeclarationCheckers) {
-        _basicDeclarationCheckers += checkers.allBasicDeclarationCheckers
-        _memberDeclarationCheckers += checkers.allMemberDeclarationCheckers
-        _functionCheckers += checkers.allFunctionCheckers
-        _propertyCheckers += checkers.allPropertyCheckers
-        _classCheckers += checkers.allClassCheckers
-        _regularClassCheckers += checkers.allRegularClassCheckers
-        _constructorCheckers += checkers.allConstructorCheckers
-        _fileCheckers += checkers.allFileCheckers
+        _basicDeclarationCheckers += checkers.basicDeclarationCheckers
+        _memberDeclarationCheckers += checkers.memberDeclarationCheckers
+        _functionCheckers += checkers.functionCheckers
+        _simpleFunctionCheckers += checkers.simpleFunctionCheckers
+        _propertyCheckers += checkers.propertyCheckers
+        _classCheckers += checkers.classCheckers
+        _regularClassCheckers += checkers.regularClassCheckers
+        _constructorCheckers += checkers.constructorCheckers
+        _fileCheckers += checkers.fileCheckers
         _controlFlowAnalyserCheckers += checkers.controlFlowAnalyserCheckers
         _variableAssignmentCfaBasedCheckers += checkers.variableAssignmentCfaBasedCheckers
     }

--- a/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/checkers/declaration/DeclarationCheckers.kt
+++ b/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/checkers/declaration/DeclarationCheckers.kt
@@ -22,6 +22,7 @@ abstract class DeclarationCheckers {
     open val basicDeclarationCheckers: Set<FirBasicDeclarationChecker> = emptySet()
     open val memberDeclarationCheckers: Set<FirMemberDeclarationChecker> = emptySet()
     open val functionCheckers: Set<FirFunctionChecker> = emptySet()
+    open val simpleFunctionCheckers: Set<FirSimpleFunctionChecker> = emptySet()
     open val propertyCheckers: Set<FirPropertyChecker> = emptySet()
     open val classCheckers: Set<FirClassChecker> = emptySet()
     open val regularClassCheckers: Set<FirRegularClassChecker> = emptySet()
@@ -32,11 +33,12 @@ abstract class DeclarationCheckers {
     open val variableAssignmentCfaBasedCheckers: Set<AbstractFirPropertyInitializationChecker> = emptySet()
 
     @CheckersComponentInternal internal val allBasicDeclarationCheckers: Set<FirBasicDeclarationChecker> get() = basicDeclarationCheckers
-    @CheckersComponentInternal internal val allMemberDeclarationCheckers: Set<FirMemberDeclarationChecker> get() = memberDeclarationCheckers + allBasicDeclarationCheckers
-    @CheckersComponentInternal internal val allFunctionCheckers: Set<FirFunctionChecker> get() = functionCheckers + allBasicDeclarationCheckers
-    @CheckersComponentInternal internal val allPropertyCheckers: Set<FirPropertyChecker> get() = propertyCheckers + allMemberDeclarationCheckers
-    @CheckersComponentInternal internal val allClassCheckers: Set<FirClassChecker> get() = classCheckers + allBasicDeclarationCheckers
-    @CheckersComponentInternal internal val allRegularClassCheckers: Set<FirRegularClassChecker> get() = regularClassCheckers + allMemberDeclarationCheckers + allClassCheckers
-    @CheckersComponentInternal internal val allConstructorCheckers: Set<FirConstructorChecker> get() = constructorCheckers + allFunctionCheckers
-    @CheckersComponentInternal internal val allFileCheckers: Set<FirFileChecker> get() = fileCheckers + allBasicDeclarationCheckers
+    @CheckersComponentInternal internal val allMemberDeclarationCheckers: Set<FirMemberDeclarationChecker> get() = memberDeclarationCheckers + basicDeclarationCheckers
+    @CheckersComponentInternal internal val allFunctionCheckers: Set<FirFunctionChecker> get() = functionCheckers + basicDeclarationCheckers
+    @CheckersComponentInternal internal val allSimpleFunctionCheckers: Set<FirSimpleFunctionChecker> get() = simpleFunctionCheckers + functionCheckers + basicDeclarationCheckers + memberDeclarationCheckers
+    @CheckersComponentInternal internal val allPropertyCheckers: Set<FirPropertyChecker> get() = propertyCheckers + basicDeclarationCheckers + memberDeclarationCheckers
+    @CheckersComponentInternal internal val allClassCheckers: Set<FirClassChecker> get() = classCheckers + basicDeclarationCheckers
+    @CheckersComponentInternal internal val allRegularClassCheckers: Set<FirRegularClassChecker> get() = regularClassCheckers + memberDeclarationCheckers + basicDeclarationCheckers + classCheckers
+    @CheckersComponentInternal internal val allConstructorCheckers: Set<FirConstructorChecker> get() = constructorCheckers + functionCheckers + basicDeclarationCheckers + memberDeclarationCheckers
+    @CheckersComponentInternal internal val allFileCheckers: Set<FirFileChecker> get() = fileCheckers + basicDeclarationCheckers
 }

--- a/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirDeclarationCheckerAliases.kt
+++ b/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirDeclarationCheckerAliases.kt
@@ -18,10 +18,12 @@ import org.jetbrains.kotlin.fir.declarations.FirFunction
 import org.jetbrains.kotlin.fir.declarations.FirMemberDeclaration
 import org.jetbrains.kotlin.fir.declarations.FirProperty
 import org.jetbrains.kotlin.fir.declarations.FirRegularClass
+import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
 
 typealias FirBasicDeclarationChecker = FirDeclarationChecker<FirDeclaration>
 typealias FirMemberDeclarationChecker = FirDeclarationChecker<FirMemberDeclaration>
 typealias FirFunctionChecker = FirDeclarationChecker<FirFunction<*>>
+typealias FirSimpleFunctionChecker = FirDeclarationChecker<FirSimpleFunction>
 typealias FirPropertyChecker = FirDeclarationChecker<FirProperty>
 typealias FirClassChecker = FirDeclarationChecker<FirClass<*>>
 typealias FirRegularClassChecker = FirDeclarationChecker<FirRegularClass>

--- a/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/checkers/expression/ComposedExpressionCheckers.kt
+++ b/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/checkers/expression/ComposedExpressionCheckers.kt
@@ -35,11 +35,11 @@ internal class ComposedExpressionCheckers : ExpressionCheckers() {
 
     @CheckersComponentInternal
     internal fun register(checkers: ExpressionCheckers) {
-        _basicExpressionCheckers += checkers.allBasicExpressionCheckers
-        _qualifiedAccessCheckers += checkers.allQualifiedAccessCheckers
-        _functionCallCheckers += checkers.allFunctionCallCheckers
-        _variableAssignmentCheckers += checkers.allVariableAssignmentCheckers
-        _tryExpressionCheckers += checkers.allTryExpressionCheckers
-        _whenExpressionCheckers += checkers.allWhenExpressionCheckers
+        _basicExpressionCheckers += checkers.basicExpressionCheckers
+        _qualifiedAccessCheckers += checkers.qualifiedAccessCheckers
+        _functionCallCheckers += checkers.functionCallCheckers
+        _variableAssignmentCheckers += checkers.variableAssignmentCheckers
+        _tryExpressionCheckers += checkers.tryExpressionCheckers
+        _whenExpressionCheckers += checkers.whenExpressionCheckers
     }
 }

--- a/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/checkers/expression/ExpressionCheckers.kt
+++ b/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/checkers/expression/ExpressionCheckers.kt
@@ -25,9 +25,9 @@ abstract class ExpressionCheckers {
     open val whenExpressionCheckers: Set<FirWhenExpressionChecker> = emptySet()
 
     @CheckersComponentInternal internal val allBasicExpressionCheckers: Set<FirBasicExpressionChecker> get() = basicExpressionCheckers
-    @CheckersComponentInternal internal val allQualifiedAccessCheckers: Set<FirQualifiedAccessChecker> get() = qualifiedAccessCheckers + allBasicExpressionCheckers
-    @CheckersComponentInternal internal val allFunctionCallCheckers: Set<FirFunctionCallChecker> get() = functionCallCheckers + allQualifiedAccessCheckers
-    @CheckersComponentInternal internal val allVariableAssignmentCheckers: Set<FirVariableAssignmentChecker> get() = variableAssignmentCheckers + allBasicExpressionCheckers
-    @CheckersComponentInternal internal val allTryExpressionCheckers: Set<FirTryExpressionChecker> get() = tryExpressionCheckers + allBasicExpressionCheckers
-    @CheckersComponentInternal internal val allWhenExpressionCheckers: Set<FirWhenExpressionChecker> get() = whenExpressionCheckers + allBasicExpressionCheckers
+    @CheckersComponentInternal internal val allQualifiedAccessCheckers: Set<FirQualifiedAccessChecker> get() = qualifiedAccessCheckers + basicExpressionCheckers
+    @CheckersComponentInternal internal val allFunctionCallCheckers: Set<FirFunctionCallChecker> get() = functionCallCheckers + qualifiedAccessCheckers + basicExpressionCheckers
+    @CheckersComponentInternal internal val allVariableAssignmentCheckers: Set<FirVariableAssignmentChecker> get() = variableAssignmentCheckers + basicExpressionCheckers
+    @CheckersComponentInternal internal val allTryExpressionCheckers: Set<FirTryExpressionChecker> get() = tryExpressionCheckers + basicExpressionCheckers
+    @CheckersComponentInternal internal val allWhenExpressionCheckers: Set<FirWhenExpressionChecker> get() = whenExpressionCheckers + basicExpressionCheckers
 }

--- a/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/diagnostics/FirErrors.kt
+++ b/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/diagnostics/FirErrors.kt
@@ -189,7 +189,7 @@ object FirErrors {
     val RECURSION_IN_IMPLICIT_TYPES by error0<FirSourceElement, PsiElement>()
     val INFERENCE_ERROR by error0<FirSourceElement, PsiElement>()
     val PROJECTION_ON_NON_CLASS_TYPE_ARGUMENT by error0<FirSourceElement, PsiElement>()
-    val UPPER_BOUND_VIOLATED by error2<FirSourceElement, PsiElement, FirTypeParameterSymbol, ConeKotlinType>()
+    val UPPER_BOUND_VIOLATED by error1<FirSourceElement, PsiElement, ConeKotlinType>()
     val TYPE_ARGUMENTS_NOT_ALLOWED by error0<FirSourceElement, PsiElement>()
     val WRONG_NUMBER_OF_TYPE_ARGUMENTS by error2<FirSourceElement, PsiElement, Int, FirClassLikeSymbol<*>>()
     val NO_TYPE_ARGUMENTS_ON_RHS by error2<FirSourceElement, PsiElement, Int, FirClassLikeSymbol<*>>()

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirFunctionNameChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirFunctionNameChecker.kt
@@ -12,17 +12,16 @@ import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors
 import org.jetbrains.kotlin.fir.analysis.diagnostics.reportOn
 import org.jetbrains.kotlin.fir.declarations.FirClass
 import org.jetbrains.kotlin.fir.declarations.FirFile
-import org.jetbrains.kotlin.fir.declarations.FirFunction
 import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
 import org.jetbrains.kotlin.name.SpecialNames
 
-object FirFunctionNameChecker : FirFunctionChecker() {
-    override fun check(declaration: FirFunction<*>, context: CheckerContext, reporter: DiagnosticReporter) {
+object FirFunctionNameChecker : FirSimpleFunctionChecker() {
+    override fun check(declaration: FirSimpleFunction, context: CheckerContext, reporter: DiagnosticReporter) {
         val source = declaration.source
         if (source == null || source.kind is FirFakeSourceElementKind) return
         val containingDeclaration = context.containingDeclarations.lastOrNull()
         val isNonLocal = containingDeclaration is FirFile || containingDeclaration is FirClass<*>
-        if (declaration is FirSimpleFunction && declaration.name == SpecialNames.NO_NAME_PROVIDED && isNonLocal) {
+        if (declaration.name == SpecialNames.NO_NAME_PROVIDED && isNonLocal) {
             reporter.reportOn(source, FirErrors.FUNCTION_DECLARATION_WITH_NO_NAME, context)
         }
     }

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/collectors/components/DeclarationCheckersDiagnosticComponent.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/collectors/components/DeclarationCheckersDiagnosticComponent.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.fir.analysis.collectors.components
 
+import org.jetbrains.kotlin.fir.analysis.CheckersComponentInternal
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.DeclarationCheckers
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirDeclarationChecker
@@ -13,65 +14,66 @@ import org.jetbrains.kotlin.fir.analysis.collectors.AbstractDiagnosticCollector
 import org.jetbrains.kotlin.fir.analysis.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.fir.declarations.*
 
+@OptIn(CheckersComponentInternal::class)
 class DeclarationCheckersDiagnosticComponent(
     collector: AbstractDiagnosticCollector,
     private val checkers: DeclarationCheckers = collector.session.checkersComponent.declarationCheckers,
 ) : AbstractDiagnosticCollectorComponent(collector) {
 
     override fun visitFile(file: FirFile, data: CheckerContext) {
-        checkers.fileCheckers.check(file, data, reporter)
+        checkers.allFileCheckers.check(file, data, reporter)
     }
 
     override fun visitProperty(property: FirProperty, data: CheckerContext) {
-        (checkers.memberDeclarationCheckers + checkers.propertyCheckers).check(property, data, reporter)
+        checkers.allPropertyCheckers.check(property, data, reporter)
     }
 
     override fun <F : FirClass<F>> visitClass(klass: FirClass<F>, data: CheckerContext) {
-        checkers.classCheckers.check(klass, data, reporter)
+        checkers.allClassCheckers.check(klass, data, reporter)
     }
 
     override fun visitRegularClass(regularClass: FirRegularClass, data: CheckerContext) {
-        (checkers.memberDeclarationCheckers + checkers.regularClassCheckers).check(regularClass, data, reporter)
+        checkers.allRegularClassCheckers.check(regularClass, data, reporter)
     }
 
     override fun visitSimpleFunction(simpleFunction: FirSimpleFunction, data: CheckerContext) {
-        (checkers.memberDeclarationCheckers + checkers.functionCheckers).check(simpleFunction, data, reporter)
+        checkers.allSimpleFunctionCheckers.check(simpleFunction, data, reporter)
     }
 
     override fun visitTypeAlias(typeAlias: FirTypeAlias, data: CheckerContext) {
-        checkers.memberDeclarationCheckers.check(typeAlias, data, reporter)
+        checkers.allMemberDeclarationCheckers.check(typeAlias, data, reporter)
     }
 
     override fun visitConstructor(constructor: FirConstructor, data: CheckerContext) {
-        (checkers.memberDeclarationCheckers + checkers.constructorCheckers).check(constructor, data, reporter)
+        checkers.allConstructorCheckers.check(constructor, data, reporter)
     }
 
     override fun visitAnonymousFunction(anonymousFunction: FirAnonymousFunction, data: CheckerContext) {
-        checkers.basicDeclarationCheckers.check(anonymousFunction, data, reporter)
+        checkers.allBasicDeclarationCheckers.check(anonymousFunction, data, reporter)
     }
 
     override fun visitPropertyAccessor(propertyAccessor: FirPropertyAccessor, data: CheckerContext) {
-        checkers.basicDeclarationCheckers.check(propertyAccessor, data, reporter)
+        checkers.allBasicDeclarationCheckers.check(propertyAccessor, data, reporter)
     }
 
     override fun visitValueParameter(valueParameter: FirValueParameter, data: CheckerContext) {
-        checkers.basicDeclarationCheckers.check(valueParameter, data, reporter)
+        checkers.allBasicDeclarationCheckers.check(valueParameter, data, reporter)
     }
 
     override fun visitTypeParameter(typeParameter: FirTypeParameter, data: CheckerContext) {
-        checkers.basicDeclarationCheckers.check(typeParameter, data, reporter)
+        checkers.allBasicDeclarationCheckers.check(typeParameter, data, reporter)
     }
 
     override fun visitEnumEntry(enumEntry: FirEnumEntry, data: CheckerContext) {
-        checkers.basicDeclarationCheckers.check(enumEntry, data, reporter)
+        checkers.allBasicDeclarationCheckers.check(enumEntry, data, reporter)
     }
 
     override fun visitAnonymousObject(anonymousObject: FirAnonymousObject, data: CheckerContext) {
-        (checkers.classCheckers + checkers.basicDeclarationCheckers).check(anonymousObject, data, reporter)
+        checkers.allClassCheckers.check(anonymousObject, data, reporter)
     }
 
     override fun visitAnonymousInitializer(anonymousInitializer: FirAnonymousInitializer, data: CheckerContext) {
-        checkers.basicDeclarationCheckers.check(anonymousInitializer, data, reporter)
+        checkers.allBasicDeclarationCheckers.check(anonymousInitializer, data, reporter)
     }
 
     private fun <D : FirDeclaration> Collection<FirDeclarationChecker<D>>.check(

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/collectors/components/ExpressionCheckersDiagnosticComponent.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/collectors/components/ExpressionCheckersDiagnosticComponent.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.fir.analysis.collectors.components
 
+import org.jetbrains.kotlin.fir.analysis.CheckersComponentInternal
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.fir.analysis.checkers.expression.ExpressionCheckers
 import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirExpressionChecker
@@ -14,85 +15,86 @@ import org.jetbrains.kotlin.fir.analysis.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.fir.declarations.FirAnonymousFunction
 import org.jetbrains.kotlin.fir.expressions.*
 
+@OptIn(CheckersComponentInternal::class)
 class ExpressionCheckersDiagnosticComponent(
     collector: AbstractDiagnosticCollector,
     private val checkers: ExpressionCheckers = collector.session.checkersComponent.expressionCheckers,
 ) : AbstractDiagnosticCollectorComponent(collector) {
 
     override fun visitAnonymousFunction(anonymousFunction: FirAnonymousFunction, data: CheckerContext) {
-        checkers.basicExpressionCheckers.check(anonymousFunction, data, reporter)
+        checkers.allBasicExpressionCheckers.check(anonymousFunction, data, reporter)
     }
 
     override fun visitTypeOperatorCall(typeOperatorCall: FirTypeOperatorCall, data: CheckerContext) {
-        checkers.basicExpressionCheckers.check(typeOperatorCall, data, reporter)
+        checkers.allBasicExpressionCheckers.check(typeOperatorCall, data, reporter)
     }
 
     override fun <T> visitConstExpression(constExpression: FirConstExpression<T>, data: CheckerContext) {
-        checkers.basicExpressionCheckers.check(constExpression, data, reporter)
+        checkers.allBasicExpressionCheckers.check(constExpression, data, reporter)
     }
 
     override fun visitAnnotationCall(annotationCall: FirAnnotationCall, data: CheckerContext) {
-        checkers.basicExpressionCheckers.check(annotationCall, data, reporter)
+        checkers.allBasicExpressionCheckers.check(annotationCall, data, reporter)
     }
 
     override fun visitQualifiedAccessExpression(qualifiedAccessExpression: FirQualifiedAccessExpression, data: CheckerContext) {
-        checkers.qualifiedAccessCheckers.check(qualifiedAccessExpression, data, reporter)
+        checkers.allQualifiedAccessCheckers.check(qualifiedAccessExpression, data, reporter)
     }
 
     override fun visitFunctionCall(functionCall: FirFunctionCall, data: CheckerContext) {
-        checkers.functionCallCheckers.check(functionCall, data, reporter)
+        checkers.allFunctionCallCheckers.check(functionCall, data, reporter)
     }
 
     override fun visitCallableReferenceAccess(callableReferenceAccess: FirCallableReferenceAccess, data: CheckerContext) {
-        checkers.qualifiedAccessCheckers.check(callableReferenceAccess, data, reporter)
+        checkers.allQualifiedAccessCheckers.check(callableReferenceAccess, data, reporter)
     }
 
     override fun visitThisReceiverExpression(thisReceiverExpression: FirThisReceiverExpression, data: CheckerContext) {
-        checkers.basicExpressionCheckers.check(thisReceiverExpression, data, reporter)
+        checkers.allBasicExpressionCheckers.check(thisReceiverExpression, data, reporter)
     }
 
     override fun visitResolvedQualifier(resolvedQualifier: FirResolvedQualifier, data: CheckerContext) {
-        checkers.basicExpressionCheckers.check(resolvedQualifier, data, reporter)
+        checkers.allBasicExpressionCheckers.check(resolvedQualifier, data, reporter)
     }
 
     override fun visitWhenExpression(whenExpression: FirWhenExpression, data: CheckerContext) {
-        checkers.whenExpressionCheckers.check(whenExpression, data, reporter)
+        checkers.allWhenExpressionCheckers.check(whenExpression, data, reporter)
     }
 
     override fun visitBinaryLogicExpression(binaryLogicExpression: FirBinaryLogicExpression, data: CheckerContext) {
-        checkers.basicExpressionCheckers.check(binaryLogicExpression, data, reporter)
+        checkers.allBasicExpressionCheckers.check(binaryLogicExpression, data, reporter)
     }
 
     override fun visitArrayOfCall(arrayOfCall: FirArrayOfCall, data: CheckerContext) {
-        checkers.basicExpressionCheckers.check(arrayOfCall, data, reporter)
+        checkers.allBasicExpressionCheckers.check(arrayOfCall, data, reporter)
     }
 
     override fun visitStringConcatenationCall(stringConcatenationCall: FirStringConcatenationCall, data: CheckerContext) {
-        checkers.basicExpressionCheckers.check(stringConcatenationCall, data, reporter)
+        checkers.allBasicExpressionCheckers.check(stringConcatenationCall, data, reporter)
     }
 
     override fun visitCheckNotNullCall(checkNotNullCall: FirCheckNotNullCall, data: CheckerContext) {
-        checkers.basicExpressionCheckers.check(checkNotNullCall, data, reporter)
+        checkers.allBasicExpressionCheckers.check(checkNotNullCall, data, reporter)
     }
 
     override fun visitTryExpression(tryExpression: FirTryExpression, data: CheckerContext) {
-        checkers.tryExpressionCheckers.check(tryExpression, data, reporter)
+        checkers.allTryExpressionCheckers.check(tryExpression, data, reporter)
     }
 
     override fun visitClassReferenceExpression(classReferenceExpression: FirClassReferenceExpression, data: CheckerContext) {
-        checkers.basicExpressionCheckers.check(classReferenceExpression, data, reporter)
+        checkers.allBasicExpressionCheckers.check(classReferenceExpression, data, reporter)
     }
 
     override fun visitGetClassCall(getClassCall: FirGetClassCall, data: CheckerContext) {
-        checkers.basicExpressionCheckers.check(getClassCall, data, reporter)
+        checkers.allBasicExpressionCheckers.check(getClassCall, data, reporter)
     }
 
     override fun visitEqualityOperatorCall(equalityOperatorCall: FirEqualityOperatorCall, data: CheckerContext) {
-        checkers.basicExpressionCheckers.check(equalityOperatorCall, data, reporter)
+        checkers.allBasicExpressionCheckers.check(equalityOperatorCall, data, reporter)
     }
 
     override fun visitVariableAssignment(variableAssignment: FirVariableAssignment, data: CheckerContext) {
-        checkers.variableAssignmentCheckers.check(variableAssignment, data, reporter)
+        checkers.allVariableAssignmentCheckers.check(variableAssignment, data, reporter)
     }
 
     private fun <E : FirStatement> Collection<FirExpressionChecker<E>>.check(

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/FirDefaultErrorMessages.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/FirDefaultErrorMessages.kt
@@ -396,7 +396,7 @@ class FirDefaultErrorMessages : DefaultErrorMessages.Extension {
             map.put(RECURSION_IN_IMPLICIT_TYPES, "Recursion in implicit types")
             map.put(INFERENCE_ERROR, "Inference error")
             map.put(PROJECTION_ON_NON_CLASS_TYPE_ARGUMENT, "Projections are not allowed on type arguments of functions and properties")
-            map.put(UPPER_BOUND_VIOLATED, "Type argument is not within its bounds: should be subtype of ''{0}''", TO_STRING, TO_STRING)
+            map.put(UPPER_BOUND_VIOLATED, "Type argument is not within its bounds: should be subtype of ''{0}''", RENDER_TYPE)
             map.put(TYPE_ARGUMENTS_NOT_ALLOWED, "Type arguments are not allowed for type parameters") // *
             map.put(
                 WRONG_NUMBER_OF_TYPE_ARGUMENTS,

--- a/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/checkers/CommonDeclarationCheckers.kt
+++ b/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/checkers/CommonDeclarationCheckers.kt
@@ -29,8 +29,11 @@ object CommonDeclarationCheckers : DeclarationCheckers() {
 
     override val functionCheckers: Set<FirFunctionChecker> = setOf(
         FirContractChecker,
-        FirFunctionNameChecker,
         FirFunctionParameterChecker,
+    )
+
+    override val simpleFunctionCheckers: Set<FirSimpleFunctionChecker> = setOf(
+        FirFunctionNameChecker
     )
 
     override val propertyCheckers: Set<FirPropertyChecker> = setOf(

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDataClassConverters.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDataClassConverters.kt
@@ -743,8 +743,7 @@ internal val KT_DIAGNOSTIC_CONVERTER = KtDiagnosticConverterBuilder.buildConvert
     }
     add(FirErrors.UPPER_BOUND_VIOLATED) { firDiagnostic ->
         UpperBoundViolatedImpl(
-            firSymbolBuilder.classifierBuilder.buildTypeParameterSymbol(firDiagnostic.a.fir),
-            firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
+            firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firDiagnostic as FirPsiDiagnostic<*>,
             token,
         )

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnostics.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnostics.kt
@@ -532,8 +532,7 @@ sealed class KtFirDiagnostic<PSI: PsiElement> : KtDiagnosticWithPsi<PSI> {
 
     abstract class UpperBoundViolated : KtFirDiagnostic<PsiElement>() {
         override val diagnosticClass get() = UpperBoundViolated::class
-        abstract val typeParameter: KtTypeParameterSymbol
-        abstract val violatedType: KtType
+        abstract val upperBound: KtType
     }
 
     abstract class TypeArgumentsNotAllowed : KtFirDiagnostic<PsiElement>() {

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnosticsImpl.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnosticsImpl.kt
@@ -850,8 +850,7 @@ internal class ProjectionOnNonClassTypeArgumentImpl(
 }
 
 internal class UpperBoundViolatedImpl(
-    override val typeParameter: KtTypeParameterSymbol,
-    override val violatedType: KtType,
+    override val upperBound: KtType,
     firDiagnostic: FirPsiDiagnostic<*>,
     override val token: ValidityToken,
 ) : KtFirDiagnostic.UpperBoundViolated(), KtAbstractFirDiagnostic<PsiElement> {

--- a/idea/testData/checker/Bounds.fir.kt
+++ b/idea/testData/checker/Bounds.fir.kt
@@ -4,7 +4,7 @@
   class Pair<A, B>
 
   abstract class C<T : B<Int>, X : (B<Char>) -> Pair<B<Any>, B<A>>>() : B<Any>() { // 2 errors
-    val a = B<<error descr="[UPPER_BOUND_VIOLATED] Type argument is not within its bounds: should be subtype of 'org.jetbrains.kotlin.fir.symbols.impl.FirTypeParameterSymbol@1f33f4d4'">Char</error>>() // error
+    val a = B<<error descr="[UPPER_BOUND_VIOLATED] Type argument is not within its bounds: should be subtype of 'A'">Char</error>>() // error
 
     abstract val x : (B<Char>) -> B<Any>
   }

--- a/idea/testData/checker/Bounds.fir.kt
+++ b/idea/testData/checker/Bounds.fir.kt
@@ -4,7 +4,7 @@
   class Pair<A, B>
 
   abstract class C<T : B<Int>, X : (B<Char>) -> Pair<B<Any>, B<A>>>() : B<Any>() { // 2 errors
-    val a = B<Char>() // error
+    val a = B<<error descr="[UPPER_BOUND_VIOLATED] Type argument is not within its bounds: should be subtype of 'org.jetbrains.kotlin.fir.symbols.impl.FirTypeParameterSymbol@1f33f4d4'">Char</error>>() // error
 
     abstract val x : (B<Char>) -> B<Any>
   }

--- a/idea/testData/checker/Bounds2.fir.kt
+++ b/idea/testData/checker/Bounds2.fir.kt
@@ -1,10 +1,10 @@
 fun test() {
-    foo<Int?>()
+    foo<<error descr="[UPPER_BOUND_VIOLATED] Type argument is not within its bounds: should be subtype of 'org.jetbrains.kotlin.fir.symbols.impl.FirTypeParameterSymbol@23ae790a'">Int?</error>>()
     foo<Int>()
     bar<Int?>()
     bar<Int>()
-    bar<Double?>()
-    bar<Double>()
+    bar<<error descr="[UPPER_BOUND_VIOLATED] Type argument is not within its bounds: should be subtype of 'org.jetbrains.kotlin.fir.symbols.impl.FirTypeParameterSymbol@ca50b2f'">Double?</error>>()
+    bar<<error descr="[UPPER_BOUND_VIOLATED] Type argument is not within its bounds: should be subtype of 'org.jetbrains.kotlin.fir.symbols.impl.FirTypeParameterSymbol@ca50b2f'">Double</error>>()
     1.<error descr="[INAPPLICABLE_CANDIDATE] Inapplicable candidate(s): /buzz">buzz</error><Double>()
 }
 

--- a/idea/testData/checker/Bounds2.fir.kt
+++ b/idea/testData/checker/Bounds2.fir.kt
@@ -1,10 +1,10 @@
 fun test() {
-    foo<<error descr="[UPPER_BOUND_VIOLATED] Type argument is not within its bounds: should be subtype of 'org.jetbrains.kotlin.fir.symbols.impl.FirTypeParameterSymbol@23ae790a'">Int?</error>>()
+    foo<<error descr="[UPPER_BOUND_VIOLATED] Type argument is not within its bounds: should be subtype of 'kotlin/Any'">Int?</error>>()
     foo<Int>()
     bar<Int?>()
     bar<Int>()
-    bar<<error descr="[UPPER_BOUND_VIOLATED] Type argument is not within its bounds: should be subtype of 'org.jetbrains.kotlin.fir.symbols.impl.FirTypeParameterSymbol@ca50b2f'">Double?</error>>()
-    bar<<error descr="[UPPER_BOUND_VIOLATED] Type argument is not within its bounds: should be subtype of 'org.jetbrains.kotlin.fir.symbols.impl.FirTypeParameterSymbol@ca50b2f'">Double</error>>()
+    bar<<error descr="[UPPER_BOUND_VIOLATED] Type argument is not within its bounds: should be subtype of 'kotlin/Int?'">Double?</error>>()
+    bar<<error descr="[UPPER_BOUND_VIOLATED] Type argument is not within its bounds: should be subtype of 'kotlin/Int?'">Double</error>>()
     1.<error descr="[INAPPLICABLE_CANDIDATE] Inapplicable candidate(s): /buzz">buzz</error><Double>()
 }
 

--- a/idea/testData/checker/BoundsWithSubstitutors.fir.kt
+++ b/idea/testData/checker/BoundsWithSubstitutors.fir.kt
@@ -6,10 +6,10 @@
     class C : A<C>()
 
     val a = B<C>()
-    val a1 = B<Int>()
+    val a1 = B<<error descr="[UPPER_BOUND_VIOLATED] Type argument is not within its bounds: should be subtype of 'org.jetbrains.kotlin.fir.symbols.impl.FirTypeParameterSymbol@29263cc3'">Int</error>>()
 
     class X<A, B : A>()
 
     val b = X<Any, X<A<C>, C>>()
-    val b0 = X<Any, Any?>()
-    val b1 = X<Any, X<A<C>, String>>()
+    val b0 = X<Any, <error descr="[UPPER_BOUND_VIOLATED] Type argument is not within its bounds: should be subtype of 'org.jetbrains.kotlin.fir.symbols.impl.FirTypeParameterSymbol@2826285f'">Any?</error>>()
+    val b1 = X<Any, <error descr="[UPPER_BOUND_VIOLATED] Type argument is not within its bounds: should be subtype of 'org.jetbrains.kotlin.fir.symbols.impl.FirTypeParameterSymbol@2826285f'">X<A<C>, String></error>>()

--- a/idea/testData/checker/BoundsWithSubstitutors.fir.kt
+++ b/idea/testData/checker/BoundsWithSubstitutors.fir.kt
@@ -6,10 +6,10 @@
     class C : A<C>()
 
     val a = B<C>()
-    val a1 = B<<error descr="[UPPER_BOUND_VIOLATED] Type argument is not within its bounds: should be subtype of 'org.jetbrains.kotlin.fir.symbols.impl.FirTypeParameterSymbol@29263cc3'">Int</error>>()
+    val a1 = B<<error descr="[UPPER_BOUND_VIOLATED] Type argument is not within its bounds: should be subtype of 'A<kotlin/Int>'">Int</error>>()
 
     class X<A, B : A>()
 
     val b = X<Any, X<A<C>, C>>()
-    val b0 = X<Any, <error descr="[UPPER_BOUND_VIOLATED] Type argument is not within its bounds: should be subtype of 'org.jetbrains.kotlin.fir.symbols.impl.FirTypeParameterSymbol@2826285f'">Any?</error>>()
-    val b1 = X<Any, <error descr="[UPPER_BOUND_VIOLATED] Type argument is not within its bounds: should be subtype of 'org.jetbrains.kotlin.fir.symbols.impl.FirTypeParameterSymbol@2826285f'">X<A<C>, String></error>>()
+    val b0 = X<Any, <error descr="[UPPER_BOUND_VIOLATED] Type argument is not within its bounds: should be subtype of 'kotlin/Any'">Any?</error>>()
+    val b1 = X<Any, <error descr="[UPPER_BOUND_VIOLATED] Type argument is not within its bounds: should be subtype of 'A<C>'">X<A<C>, String></error>>()

--- a/idea/testData/checker/Builders.fir.kt
+++ b/idea/testData/checker/Builders.fir.kt
@@ -16,7 +16,7 @@ import java.util.*
 
     protected fun <T : Element> initTag(init :  T.() -> Unit) : T
       {
-      val tag = T.<error descr="[UNRESOLVED_REFERENCE] Unresolved reference: create">create</error>()
+      val tag = <error descr="[TYPE_PARAMETER_ON_LHS_OF_DOT] Type parameter 'T' cannot have or inherit a companion object, so it cannot be on the left hand side of dot">T</error>.<error descr="[UNRESOLVED_REFERENCE] Unresolved reference: create">create</error>()
       tag.init()
       children.add(tag)
       return tag

--- a/idea/testData/checker/MultipleBounds.fir.kt
+++ b/idea/testData/checker/MultipleBounds.fir.kt
@@ -30,8 +30,8 @@ class Test1<T>()
 }
 
 fun test() {
-  Test1<<error descr="[UPPER_BOUND_VIOLATED] Type argument is not within its bounds: should be subtype of 'org.jetbrains.kotlin.fir.symbols.impl.FirTypeParameterSymbol@4c663d20'">B</error>>()
-  Test1<<error descr="[UPPER_BOUND_VIOLATED] Type argument is not within its bounds: should be subtype of 'org.jetbrains.kotlin.fir.symbols.impl.FirTypeParameterSymbol@4c663d20'">A</error>>()
+  Test1<<error descr="[UPPER_BOUND_VIOLATED] Type argument is not within its bounds: should be subtype of 'it(Jet87/A & Jet87/B)'">B</error>>()
+  Test1<<error descr="[UPPER_BOUND_VIOLATED] Type argument is not within its bounds: should be subtype of 'it(Jet87/A & Jet87/B)'">A</error>>()
   Test1<C>()
 }
 

--- a/idea/testData/checker/MultipleBounds.fir.kt
+++ b/idea/testData/checker/MultipleBounds.fir.kt
@@ -22,16 +22,16 @@ class Test1<T>()
   {
 
   fun test(t : T) {
-    T.<error descr="[UNRESOLVED_REFERENCE] Unresolved reference: foo">foo</error>()
-    T.<error descr="[UNRESOLVED_REFERENCE] Unresolved reference: bar">bar</error>()
+    <error descr="[TYPE_PARAMETER_ON_LHS_OF_DOT] Type parameter 'T' cannot have or inherit a companion object, so it cannot be on the left hand side of dot">T</error>.<error descr="[UNRESOLVED_REFERENCE] Unresolved reference: foo">foo</error>()
+    <error descr="[TYPE_PARAMETER_ON_LHS_OF_DOT] Type parameter 'T' cannot have or inherit a companion object, so it cannot be on the left hand side of dot">T</error>.<error descr="[UNRESOLVED_REFERENCE] Unresolved reference: bar">bar</error>()
     t.foo()
     t.bar()
   }
 }
 
 fun test() {
-  Test1<B>()
-  Test1<A>()
+  Test1<<error descr="[UPPER_BOUND_VIOLATED] Type argument is not within its bounds: should be subtype of 'org.jetbrains.kotlin.fir.symbols.impl.FirTypeParameterSymbol@4c663d20'">B</error>>()
+  Test1<<error descr="[UPPER_BOUND_VIOLATED] Type argument is not within its bounds: should be subtype of 'org.jetbrains.kotlin.fir.symbols.impl.FirTypeParameterSymbol@4c663d20'">A</error>>()
   Test1<C>()
 }
 
@@ -50,8 +50,8 @@ fun <T> test2(t : T)
     T : B,
     B : T
 {
-  T.<error descr="[UNRESOLVED_REFERENCE] Unresolved reference: foo">foo</error>()
-  T.<error descr="[UNRESOLVED_REFERENCE] Unresolved reference: bar">bar</error>()
+  <error descr="[TYPE_PARAMETER_ON_LHS_OF_DOT] Type parameter 'T' cannot have or inherit a companion object, so it cannot be on the left hand side of dot">T</error>.<error descr="[UNRESOLVED_REFERENCE] Unresolved reference: foo">foo</error>()
+  <error descr="[TYPE_PARAMETER_ON_LHS_OF_DOT] Type parameter 'T' cannot have or inherit a companion object, so it cannot be on the left hand side of dot">T</error>.<error descr="[UNRESOLVED_REFERENCE] Unresolved reference: bar">bar</error>()
   t.foo()
   t.bar()
 }


### PR DESCRIPTION
Previously, composed checker passes the `allXXX` flavor of checkers to
each category of checkrs. This makes the composed checkers
non-transparent: behavior changes after composing. In addition, nested
composing would create redundant checkers.

As a result, some checkers registered in the IDE mode
(org.jetbrains.kotlin.idea.fir.low.level.api.diagnostics.AbstractFirIdeDiagnosticsCollector)
are not invoked with the FIR plugin.

This change does two things:
1. pass on checkers to composed checkers without combining
2. use combined checkers in DeclarationCheckersDiagnosticComponent and
   ExpressionCheckersDiagnosticComponent

Also fixed UPPER_BOUND_VIOLATED diagnostic message to make the IDE diagnostic test pass.