### PR TITLE
Make init script for KotlinMPP tests compatible with Gradle configura…

### DIFF
--- a/idea/resources/org/jetbrains/kotlin/idea/gradle/testing/addKotlinMppTestListener.groovy
+++ b/idea/resources/org/jetbrains/kotlin/idea/gradle/testing/addKotlinMppTestListener.groovy
@@ -1,18 +1,20 @@
-gradle.taskGraph.beforeTask { task ->
-    def taskSuperClass = task.class
-    while (taskSuperClass != Object.class) {
-        if (taskSuperClass.canonicalName == "org.jetbrains.kotlin.gradle.tasks.KotlinTest") {
-            try {
-                KotlinMppTestLogger.logTestReportLocation(task.reports?.html?.entryPoint?.path)
-                KotlinMppTestLogger.configureTestEventLogging(task)
-                task.testLogging.showStandardStreams = false
+gradle.taskGraph.whenReady { taskGraph ->
+    taskGraph.allTasks.each { task ->
+        def taskSuperClass = task.class
+        while (taskSuperClass != Object.class) {
+            if (taskSuperClass.canonicalName == "org.jetbrains.kotlin.gradle.tasks.KotlinTest") {
+                try {
+                    KotlinMppTestLogger.logTestReportLocation(task.reports?.html?.entryPoint?.path)
+                    KotlinMppTestLogger.configureTestEventLogging(task)
+                    task.testLogging.showStandardStreams = false
+                }
+                catch (all) {
+                    logger.error("", all)
+                }
+                return
+            } else {
+                taskSuperClass = taskSuperClass.superclass
             }
-            catch (all) {
-                logger.error("", all)
-            }
-            return
-        } else {
-            taskSuperClass = taskSuperClass.superclass
         }
     }
 }


### PR DESCRIPTION
…tion cache

Avoid using `beforeTask` API and switch to ones that are
compatible with Gradle configuration cache.