### PR TITLE
KT-45629: ULC field has null nameIdentifier

### DIFF
--- a/compiler/light-classes/src/org/jetbrains/kotlin/asJava/classes/ultraLightField.kt
+++ b/compiler/light-classes/src/org/jetbrains/kotlin/asJava/classes/ultraLightField.kt
@@ -67,6 +67,9 @@ internal class KtUltraLightFieldForSourceDeclaration(
 ) : KtUltraLightFieldImpl(declaration, name, containingClass, support, modifiers),
     KtLightFieldForSourceDeclarationSupport {
 
+    private val lightIdentifier = KtLightIdentifier(this, declaration)
+
+    override fun getNameIdentifier(): PsiIdentifier = lightIdentifier
     override fun getText(): String? = kotlinOrigin.text
     override fun getTextRange(): TextRange = kotlinOrigin.textRange
     override fun getTextOffset(): Int = kotlinOrigin.textOffset


### PR DESCRIPTION
KtUltraLightFieldForSourceDeclaration implements PsiField, for which
getNameIdentifier() is marked `@NonNull`, so some clients expect a
non-null return value.

Issue: https://youtrack.jetbrains.com/issue/KT-45629