### PR TITLE
KT-32753: JvmFieldApplicabilityChecker: add check for KtParameter

### DIFF
--- a/compiler/testData/diagnostics/testsWithStdLib/annotations/jvmField/jvmFieldApplicability.fir.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/annotations/jvmField/jvmFieldApplicability.fir.kt
@@ -114,6 +114,11 @@ open class KKK : K {
     override final val j: Int = 0
 }
 
+class JK(
+    override val i: Int,
+    @JvmField override val j: Int,
+) : K
+
 annotation class L {
     companion object {
         @JvmField

--- a/compiler/testData/diagnostics/testsWithStdLib/annotations/jvmField/jvmFieldApplicability.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/annotations/jvmField/jvmFieldApplicability.kt
@@ -114,6 +114,11 @@ open class KKK : K {
     override final val j: Int = 0
 }
 
+class JK(
+    override val i: Int,
+    <!INAPPLICABLE_JVM_FIELD!>@JvmField<!> override val j: Int,
+) : K
+
 annotation class L {
     companion object {
         <!INAPPLICABLE_JVM_FIELD!>@JvmField<!>

--- a/compiler/testData/diagnostics/testsWithStdLib/annotations/jvmField/jvmFieldApplicability.txt
+++ b/compiler/testData/diagnostics/testsWithStdLib/annotations/jvmField/jvmFieldApplicability.txt
@@ -83,6 +83,15 @@ public object IObject {
     public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
 }
 
+public final class JK : K {
+    public constructor JK(/*0*/ i: kotlin.Int, /*1*/ j: kotlin.Int)
+    public open override /*1*/ val i: kotlin.Int
+    @field:kotlin.jvm.JvmField public open override /*1*/ val j: kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
 public interface K {
     public abstract val i: kotlin.Int
     public abstract val j: kotlin.Int


### PR DESCRIPTION
[KT-32753](https://youtrack.jetbrains.com/issue/KT-32753) fixed.

See <https://youtrack.jetbrains.com/issue/KT-32753#focus=Comments-27-4801047.0-0> for details.