### PR TITLE
Gradle 7.0 support update. com.gradle.plugin-publish 0.13.0 -> 0.14.0

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -145,7 +145,7 @@ dependencies {
     implementation(kotlin("stdlib", embeddedKotlinVersion))
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:${project.bootstrapKotlinVersion}")
     implementation("org.jetbrains.kotlin:kotlin-build-gradle-plugin:0.0.26")
-    implementation("com.gradle.publish:plugin-publish-plugin:0.13.0")
+    implementation("com.gradle.publish:plugin-publish-plugin:0.14.0")
 
     implementation("net.rubygrapefruit:native-platform:${property("versions.native-platform")}")
     implementation("net.rubygrapefruit:native-platform-windows-amd64:${property("versions.native-platform")}")


### PR DESCRIPTION
[Gradle 7.0 support update details](https://plugins.gradle.org/plugin/com.gradle.plugin-publish/0.14.0)

cc @Tapchicoma