### PR TITLE
FIR checker: Report UNSAFE_CALL on calls with receivers of generic type

### DIFF
--- a/compiler/fir/cones/src/org/jetbrains/kotlin/fir/types/ConeTypes.kt
+++ b/compiler/fir/cones/src/org/jetbrains/kotlin/fir/types/ConeTypes.kt
@@ -217,7 +217,7 @@ data class ConeCapturedType(
 
 data class ConeTypeVariableType(
     override val nullability: ConeNullability,
-    override val lookupTag: ConeClassifierLookupTag
+    override val lookupTag: ConeTypeVariableTypeConstructor
 ) : ConeLookupTagBasedType() {
     override val typeArguments: Array<out ConeTypeProjection> get() = emptyArray()
 

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -21503,6 +21503,24 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
                 runTest("compiler/testData/codegen/box/javaInterop/notNullAssertions/staticCallErrorMessage.kt");
             }
 
+            @Test
+            @TestMetadata("typeParameterWithMixedNullableAndNotNullableBounds.kt")
+            public void testTypeParameterWithMixedNullableAndNotNullableBounds() throws Exception {
+                runTest("compiler/testData/codegen/box/javaInterop/notNullAssertions/typeParameterWithMixedNullableAndNotNullableBounds.kt");
+            }
+
+            @Test
+            @TestMetadata("typeParameterWithMultipleNotNullableBounds.kt")
+            public void testTypeParameterWithMultipleNotNullableBounds() throws Exception {
+                runTest("compiler/testData/codegen/box/javaInterop/notNullAssertions/typeParameterWithMultipleNotNullableBounds.kt");
+            }
+
+            @Test
+            @TestMetadata("typeParameterWithMultipleNullableBounds.kt")
+            public void testTypeParameterWithMultipleNullableBounds() throws Exception {
+                runTest("compiler/testData/codegen/box/javaInterop/notNullAssertions/typeParameterWithMultipleNullableBounds.kt");
+            }
+
             @Nested
             @TestMetadata("compiler/testData/codegen/box/javaInterop/notNullAssertions/enhancedNullability")
             @TestDataPath("$PROJECT_ROOT")

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/ir/Fir2IrTextTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/ir/Fir2IrTextTestGenerated.java
@@ -2731,6 +2731,24 @@ public class Fir2IrTextTestGenerated extends AbstractFir2IrTextTest {
                 runTest("compiler/testData/ir/irText/types/nullChecks/platformTypeReceiver.kt");
             }
 
+            @Test
+            @TestMetadata("typeParameterWithMixedNullableAndNotNullableBounds.kt")
+            public void testTypeParameterWithMixedNullableAndNotNullableBounds() throws Exception {
+                runTest("compiler/testData/ir/irText/types/nullChecks/typeParameterWithMixedNullableAndNotNullableBounds.kt");
+            }
+
+            @Test
+            @TestMetadata("typeParameterWithMultipleNotNullableBounds.kt")
+            public void testTypeParameterWithMultipleNotNullableBounds() throws Exception {
+                runTest("compiler/testData/ir/irText/types/nullChecks/typeParameterWithMultipleNotNullableBounds.kt");
+            }
+
+            @Test
+            @TestMetadata("typeParameterWithMultipleNullableBounds.kt")
+            public void testTypeParameterWithMultipleNullableBounds() throws Exception {
+                runTest("compiler/testData/ir/irText/types/nullChecks/typeParameterWithMultipleNullableBounds.kt");
+            }
+
             @Nested
             @TestMetadata("compiler/testData/ir/irText/types/nullChecks/nullCheckOnLambdaResult")
             @TestDataPath("$PROJECT_ROOT")

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/types/FirTypeUtils.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/types/FirTypeUtils.kt
@@ -168,8 +168,8 @@ val ConeKotlinType.canBeNull: Boolean
         return when (this) {
             is ConeFlexibleType -> upperBound.canBeNull
             is ConeDefinitelyNotNullType -> false
-            is ConeTypeParameterType -> this.lookupTag.typeParameterSymbol.fir.bounds.any { it.canBeNull }
-            is ConeIntersectionType -> intersectedTypes.any { it.canBeNull }
+            is ConeTypeParameterType -> this.lookupTag.typeParameterSymbol.allBoundsAreNullable()
+            is ConeIntersectionType -> intersectedTypes.all { it.canBeNull }
             is ConeTypeVariableType -> lookupTag.originalTypeParameter?.safeAs<ConeTypeParameterLookupTag>()?.typeParameterSymbol?.allBoundsAreNullable()
                 ?: isNullable
             else -> isNullable

--- a/compiler/testData/codegen/box/javaInterop/notNullAssertions/typeParameterWithMixedNullableAndNotNullableBounds.kt
+++ b/compiler/testData/codegen/box/javaInterop/notNullAssertions/typeParameterWithMixedNullableAndNotNullableBounds.kt
@@ -1,0 +1,26 @@
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND: JVM, JVM_IR
+
+// Note: This fails on non-FIR because of KT-45903 (missing not-null assertion on argument).
+
+// FILE: typeParameterWithMixedNullableAndNotNullableBounds.kt
+fun <T> f(x: T): Int where T : CharSequence?, T : Comparable<T> {
+    try {
+        return x.compareTo(x)
+    } catch (e: NullPointerException) {
+        return 42
+    }
+}
+
+fun box() = try {
+    val r = f(J.s())
+    if (r == 42) "FAIL" else "Unexpected, x.compareTo(x) should have NPE'd"
+} catch (e: NullPointerException) {
+    "OK"
+}
+
+
+// FILE: J.java
+public class J {
+    public static String s() { return null; }
+}

--- a/compiler/testData/codegen/box/javaInterop/notNullAssertions/typeParameterWithMultipleNotNullableBounds.kt
+++ b/compiler/testData/codegen/box/javaInterop/notNullAssertions/typeParameterWithMultipleNotNullableBounds.kt
@@ -1,0 +1,22 @@
+// TARGET_BACKEND: JVM
+// FILE: typeParameterWithMultipleNotNullableBounds.kt
+fun <T> f(x: T): Int where T : CharSequence, T : Comparable<T> {
+    try {
+        return x.compareTo(x)
+    } catch (e: NullPointerException) {
+        return 42
+    }
+}
+
+fun box() = try {
+    val r = f(J.s())
+    if (r == 42) "FAIL" else "Unexpected, x.compareTo(x) should have NPE'd"
+} catch (e: NullPointerException) {
+    "OK"
+}
+
+
+// FILE: J.java
+public class J {
+    public static String s() { return null; }
+}

--- a/compiler/testData/codegen/box/javaInterop/notNullAssertions/typeParameterWithMultipleNullableBounds.kt
+++ b/compiler/testData/codegen/box/javaInterop/notNullAssertions/typeParameterWithMultipleNullableBounds.kt
@@ -1,0 +1,12 @@
+// TARGET_BACKEND: JVM
+// FILE: typeParameterWithMultipleNullableBounds.kt
+fun <T> f(x: T): Int? where T : CharSequence?, T : Comparable<T>? {
+    return x?.compareTo(x)
+}
+
+fun box() = f(J.s()) ?: "OK"
+
+// FILE: J.java
+public class J {
+    public static String s() { return null; }
+}

--- a/compiler/testData/diagnostics/tests/generics/nullability/expressionsBoundsViolation.fir.kt
+++ b/compiler/testData/diagnostics/tests/generics/nullability/expressionsBoundsViolation.fir.kt
@@ -13,7 +13,7 @@ fun <F : String?> bar(x: F) {
     <!INAPPLICABLE_CANDIDATE!>foo1<!>(x)
     <!INAPPLICABLE_CANDIDATE!>foo1<!><F>(x)
 
-    x.<!INAPPLICABLE_CANDIDATE!>foo2<!>()
-    x.<!INAPPLICABLE_CANDIDATE!>foo2<!><F>()
+    x<!UNSAFE_CALL!>.<!>foo2()
+    x<!UNSAFE_CALL!>.<!>foo2<F>()
 }
 

--- a/compiler/testData/diagnostics/tests/generics/nullability/functionalBound.fir.kt
+++ b/compiler/testData/diagnostics/tests/generics/nullability/functionalBound.fir.kt
@@ -1,6 +1,6 @@
 fun <E : String?, T : ((CharSequence) -> Unit)?> foo(x: E, y: T) {
     if (x != null) {
-        <!INAPPLICABLE_CANDIDATE!>y<!>(x)
+        <!UNSAFE_IMPLICIT_INVOKE_CALL!>y<!>(x)
     }
 
     if (y != null) {

--- a/compiler/testData/diagnostics/tests/generics/nullability/smartCastRefinedClass.fir.kt
+++ b/compiler/testData/diagnostics/tests/generics/nullability/smartCastRefinedClass.fir.kt
@@ -1,6 +1,6 @@
 fun <T : Any?> foo(x: T) {
     if (x is String?) {
-        x.<!INAPPLICABLE_CANDIDATE!>length<!>
+        x<!UNSAFE_CALL!>.<!>length
 
         if (x != null) {
             x.length

--- a/compiler/testData/diagnostics/tests/generics/nullability/smartCasts.fir.kt
+++ b/compiler/testData/diagnostics/tests/generics/nullability/smartCasts.fir.kt
@@ -24,7 +24,7 @@ fun <T : CharSequence?> foo(x: T) {
         x?.bar1()
     }
 
-    x.<!INAPPLICABLE_CANDIDATE!>length<!>
+    x<!UNSAFE_CALL!>.<!>length
 
     if (x is String) {
         x.length

--- a/compiler/testData/diagnostics/tests/generics/nullability/smartCastsOnThis.fir.kt
+++ b/compiler/testData/diagnostics/tests/generics/nullability/smartCastsOnThis.fir.kt
@@ -23,7 +23,7 @@ fun <T : String?> T.foo() {
         this?.bar1()
     }
 
-    <!INAPPLICABLE_CANDIDATE!>length<!>
+    <!UNSAFE_CALL!>length<!>
 
     if (this is String) {
         length

--- a/compiler/testData/diagnostics/tests/generics/nullability/useAsReceiver.fir.kt
+++ b/compiler/testData/diagnostics/tests/generics/nullability/useAsReceiver.fir.kt
@@ -7,7 +7,7 @@ fun CharSequence?.bar2() {}
 fun <T : CharSequence> T.bar3() {}
 
 fun <T : String?> foo(x: T) {
-    x.<!INAPPLICABLE_CANDIDATE!>length<!>
+    x<!UNSAFE_CALL!>.<!>length
     x?.length
 
     if (1 == 1) {
@@ -21,7 +21,7 @@ fun <T : String?> foo(x: T) {
     x?.bar1()
     x?.bar2()
 
-    x.<!INAPPLICABLE_CANDIDATE!>bar3<!>()
+    x<!UNSAFE_CALL!>.<!>bar3()
 
     x?.let { it.length }
 }

--- a/compiler/testData/diagnostics/tests/inference/regressions/kt742.fir.kt
+++ b/compiler/testData/diagnostics/tests/inference/regressions/kt742.fir.kt
@@ -10,4 +10,4 @@ fun <T, Q> List<T>.map1(f: (T)-> Q): List<T>? = tail!!.map1(f)
 
 fun <T, Q> List<T>.map2(f: (T)-> Q): List<T>? = tail.sure().map2(f)
 
-fun <T, Q> List<T>.map3(f: (T)-> Q): List<T>? = tail.<!INAPPLICABLE_CANDIDATE!>sure<!><T>().<!INAPPLICABLE_CANDIDATE!>map3<!>(f)
+fun <T, Q> List<T>.map3(f: (T)-> Q): List<T>? = tail.<!INAPPLICABLE_CANDIDATE!>sure<!><T>()<!UNSAFE_CALL!>.<!>map3(f)

--- a/compiler/testData/ir/irText/types/nullChecks/typeParameterWithMixedNullableAndNotNullableBounds.fir.kt.txt
+++ b/compiler/testData/ir/irText/types/nullChecks/typeParameterWithMixedNullableAndNotNullableBounds.fir.kt.txt
@@ -1,0 +1,8 @@
+fun <T> f(x: T): Int where T : CharSequence?, T : Comparable<T> {
+  return x.compareTo(other = x)
+}
+
+fun test() {
+  f<@FlexibleNullability String?>(x = s() /*!! @FlexibleNullability String */) /*~> Unit */
+  f<@FlexibleNullability String?>(x = #STRING /*!! @FlexibleNullability String */) /*~> Unit */
+}

--- a/compiler/testData/ir/irText/types/nullChecks/typeParameterWithMixedNullableAndNotNullableBounds.fir.txt
+++ b/compiler/testData/ir/irText/types/nullChecks/typeParameterWithMixedNullableAndNotNullableBounds.fir.txt
@@ -1,0 +1,21 @@
+FILE fqName:<root> fileName:/typeParameterWithMixedNullableAndNotNullableBounds.kt
+  FUN name:f visibility:public modality:FINAL <T> (x:T of <root>.f) returnType:kotlin.Int
+    TYPE_PARAMETER name:T index:0 variance: superTypes:[kotlin.CharSequence?; kotlin.Comparable<T of <root>.f>]
+    VALUE_PARAMETER name:x index:0 type:T of <root>.f
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='public final fun f <T> (x: T of <root>.f): kotlin.Int declared in <root>'
+        CALL 'public abstract fun compareTo (other: T of kotlin.Comparable): kotlin.Int [operator] declared in kotlin.Comparable' type=kotlin.Int origin=null
+          $this: GET_VAR 'x: T of <root>.f declared in <root>.f' type=T of <root>.f origin=null
+          other: GET_VAR 'x: T of <root>.f declared in <root>.f' type=T of <root>.f origin=null
+  FUN name:test visibility:public modality:FINAL <> () returnType:kotlin.Unit
+    BLOCK_BODY
+      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+        CALL 'public final fun f <T> (x: T of <root>.f): kotlin.Int declared in <root>' type=kotlin.Int origin=null
+          <T>: @[FlexibleNullability] kotlin.String?
+          x: TYPE_OP type=@[FlexibleNullability] kotlin.String origin=IMPLICIT_NOTNULL typeOperand=@[FlexibleNullability] kotlin.String
+            CALL 'public open fun s (): @[FlexibleNullability] kotlin.String? declared in <root>.J' type=@[FlexibleNullability] kotlin.String? origin=null
+      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+        CALL 'public final fun f <T> (x: T of <root>.f): kotlin.Int declared in <root>' type=kotlin.Int origin=null
+          <T>: @[FlexibleNullability] kotlin.String?
+          x: TYPE_OP type=@[FlexibleNullability] kotlin.String origin=IMPLICIT_NOTNULL typeOperand=@[FlexibleNullability] kotlin.String
+            GET_FIELD 'FIELD IR_EXTERNAL_JAVA_DECLARATION_STUB name:STRING type:@[FlexibleNullability] kotlin.String? visibility:public [static]' type=@[FlexibleNullability] kotlin.String? origin=GET_PROPERTY

--- a/compiler/testData/ir/irText/types/nullChecks/typeParameterWithMixedNullableAndNotNullableBounds.kt
+++ b/compiler/testData/ir/irText/types/nullChecks/typeParameterWithMixedNullableAndNotNullableBounds.kt
@@ -1,0 +1,16 @@
+// FILE: typeParameterWithMixedNullableAndNotNullableBounds.kt
+fun <T> f(x: T): Int where T : CharSequence?, T : Comparable<T> {
+    return x.compareTo(x)
+}
+
+fun test() {
+    f(J.s())
+    f(J.STRING)
+}
+
+
+// FILE: J.java
+public class J {
+    public static String STRING = s()
+    public static String s() { return null; }
+}

--- a/compiler/testData/ir/irText/types/nullChecks/typeParameterWithMixedNullableAndNotNullableBounds.kt.txt
+++ b/compiler/testData/ir/irText/types/nullChecks/typeParameterWithMixedNullableAndNotNullableBounds.kt.txt
@@ -1,0 +1,8 @@
+fun <T> f(x: T): Int where T : CharSequence?, T : Comparable<T> {
+  return x.compareTo(other = x)
+}
+
+fun test() {
+  f<@FlexibleNullability String?>(x = s()) /*~> Unit */
+  f<@FlexibleNullability String?>(x = super.#STRING) /*~> Unit */
+}

--- a/compiler/testData/ir/irText/types/nullChecks/typeParameterWithMixedNullableAndNotNullableBounds.txt
+++ b/compiler/testData/ir/irText/types/nullChecks/typeParameterWithMixedNullableAndNotNullableBounds.txt
@@ -1,0 +1,19 @@
+FILE fqName:<root> fileName:/typeParameterWithMixedNullableAndNotNullableBounds.kt
+  FUN name:f visibility:public modality:FINAL <T> (x:T of <root>.f) returnType:kotlin.Int
+    TYPE_PARAMETER name:T index:0 variance: superTypes:[kotlin.CharSequence?; kotlin.Comparable<T of <root>.f>]
+    VALUE_PARAMETER name:x index:0 type:T of <root>.f
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='public final fun f <T> (x: T of <root>.f): kotlin.Int declared in <root>'
+        CALL 'public abstract fun compareTo (other: T of kotlin.Comparable): kotlin.Int [operator] declared in kotlin.Comparable' type=kotlin.Int origin=null
+          $this: GET_VAR 'x: T of <root>.f declared in <root>.f' type=T of <root>.f origin=null
+          other: GET_VAR 'x: T of <root>.f declared in <root>.f' type=T of <root>.f origin=null
+  FUN name:test visibility:public modality:FINAL <> () returnType:kotlin.Unit
+    BLOCK_BODY
+      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+        CALL 'public final fun f <T> (x: T of <root>.f): kotlin.Int declared in <root>' type=kotlin.Int origin=null
+          <T>: @[FlexibleNullability] kotlin.String?
+          x: CALL 'public open fun s (): @[FlexibleNullability] kotlin.String? declared in <root>.J' type=@[FlexibleNullability] kotlin.String? origin=null
+      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+        CALL 'public final fun f <T> (x: T of <root>.f): kotlin.Int declared in <root>' type=kotlin.Int origin=null
+          <T>: @[FlexibleNullability] kotlin.String?
+          x: GET_FIELD 'FIELD IR_EXTERNAL_JAVA_DECLARATION_STUB name:STRING type:@[FlexibleNullability] kotlin.String? visibility:public [static]' type=@[FlexibleNullability] kotlin.String? origin=GET_PROPERTY

--- a/compiler/testData/ir/irText/types/nullChecks/typeParameterWithMultipleNotNullableBounds.fir.kt.txt
+++ b/compiler/testData/ir/irText/types/nullChecks/typeParameterWithMultipleNotNullableBounds.fir.kt.txt
@@ -1,0 +1,8 @@
+fun <T> f(x: T): Int where T : CharSequence, T : Comparable<T> {
+  return x.compareTo(other = x)
+}
+
+fun test() {
+  f<@FlexibleNullability String?>(x = s() /*!! @FlexibleNullability String */) /*~> Unit */
+  f<@FlexibleNullability String?>(x = #STRING /*!! @FlexibleNullability String */) /*~> Unit */
+}

--- a/compiler/testData/ir/irText/types/nullChecks/typeParameterWithMultipleNotNullableBounds.fir.txt
+++ b/compiler/testData/ir/irText/types/nullChecks/typeParameterWithMultipleNotNullableBounds.fir.txt
@@ -1,0 +1,21 @@
+FILE fqName:<root> fileName:/typeParameterWithMultipleNotNullableBounds.kt
+  FUN name:f visibility:public modality:FINAL <T> (x:T of <root>.f) returnType:kotlin.Int
+    TYPE_PARAMETER name:T index:0 variance: superTypes:[kotlin.CharSequence; kotlin.Comparable<T of <root>.f>]
+    VALUE_PARAMETER name:x index:0 type:T of <root>.f
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='public final fun f <T> (x: T of <root>.f): kotlin.Int declared in <root>'
+        CALL 'public abstract fun compareTo (other: T of kotlin.Comparable): kotlin.Int [operator] declared in kotlin.Comparable' type=kotlin.Int origin=null
+          $this: GET_VAR 'x: T of <root>.f declared in <root>.f' type=T of <root>.f origin=null
+          other: GET_VAR 'x: T of <root>.f declared in <root>.f' type=T of <root>.f origin=null
+  FUN name:test visibility:public modality:FINAL <> () returnType:kotlin.Unit
+    BLOCK_BODY
+      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+        CALL 'public final fun f <T> (x: T of <root>.f): kotlin.Int declared in <root>' type=kotlin.Int origin=null
+          <T>: @[FlexibleNullability] kotlin.String?
+          x: TYPE_OP type=@[FlexibleNullability] kotlin.String origin=IMPLICIT_NOTNULL typeOperand=@[FlexibleNullability] kotlin.String
+            CALL 'public open fun s (): @[FlexibleNullability] kotlin.String? declared in <root>.J' type=@[FlexibleNullability] kotlin.String? origin=null
+      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+        CALL 'public final fun f <T> (x: T of <root>.f): kotlin.Int declared in <root>' type=kotlin.Int origin=null
+          <T>: @[FlexibleNullability] kotlin.String?
+          x: TYPE_OP type=@[FlexibleNullability] kotlin.String origin=IMPLICIT_NOTNULL typeOperand=@[FlexibleNullability] kotlin.String
+            GET_FIELD 'FIELD IR_EXTERNAL_JAVA_DECLARATION_STUB name:STRING type:@[FlexibleNullability] kotlin.String? visibility:public [static]' type=@[FlexibleNullability] kotlin.String? origin=GET_PROPERTY

--- a/compiler/testData/ir/irText/types/nullChecks/typeParameterWithMultipleNotNullableBounds.kt
+++ b/compiler/testData/ir/irText/types/nullChecks/typeParameterWithMultipleNotNullableBounds.kt
@@ -1,0 +1,16 @@
+// FILE: typeParameterWithMultipleNotNullableBounds.kt
+fun <T> f(x: T): Int where T : CharSequence, T : Comparable<T> {
+    return x.compareTo(x)
+}
+
+fun test() {
+    f(J.s())
+    f(J.STRING)
+}
+
+
+// FILE: J.java
+public class J {
+    public static String STRING = s()
+    public static String s() { return null; }
+}

--- a/compiler/testData/ir/irText/types/nullChecks/typeParameterWithMultipleNotNullableBounds.kt.txt
+++ b/compiler/testData/ir/irText/types/nullChecks/typeParameterWithMultipleNotNullableBounds.kt.txt
@@ -1,0 +1,8 @@
+fun <T> f(x: T): Int where T : CharSequence, T : Comparable<T> {
+  return x.compareTo(other = x)
+}
+
+fun test() {
+  f<@FlexibleNullability String?>(x = s()) /*~> Unit */
+  f<@FlexibleNullability String?>(x = super.#STRING) /*~> Unit */
+}

--- a/compiler/testData/ir/irText/types/nullChecks/typeParameterWithMultipleNotNullableBounds.txt
+++ b/compiler/testData/ir/irText/types/nullChecks/typeParameterWithMultipleNotNullableBounds.txt
@@ -1,0 +1,19 @@
+FILE fqName:<root> fileName:/typeParameterWithMultipleNotNullableBounds.kt
+  FUN name:f visibility:public modality:FINAL <T> (x:T of <root>.f) returnType:kotlin.Int
+    TYPE_PARAMETER name:T index:0 variance: superTypes:[kotlin.CharSequence; kotlin.Comparable<T of <root>.f>]
+    VALUE_PARAMETER name:x index:0 type:T of <root>.f
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='public final fun f <T> (x: T of <root>.f): kotlin.Int declared in <root>'
+        CALL 'public abstract fun compareTo (other: T of kotlin.Comparable): kotlin.Int [operator] declared in kotlin.Comparable' type=kotlin.Int origin=null
+          $this: GET_VAR 'x: T of <root>.f declared in <root>.f' type=T of <root>.f origin=null
+          other: GET_VAR 'x: T of <root>.f declared in <root>.f' type=T of <root>.f origin=null
+  FUN name:test visibility:public modality:FINAL <> () returnType:kotlin.Unit
+    BLOCK_BODY
+      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+        CALL 'public final fun f <T> (x: T of <root>.f): kotlin.Int declared in <root>' type=kotlin.Int origin=null
+          <T>: @[FlexibleNullability] kotlin.String?
+          x: CALL 'public open fun s (): @[FlexibleNullability] kotlin.String? declared in <root>.J' type=@[FlexibleNullability] kotlin.String? origin=null
+      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+        CALL 'public final fun f <T> (x: T of <root>.f): kotlin.Int declared in <root>' type=kotlin.Int origin=null
+          <T>: @[FlexibleNullability] kotlin.String?
+          x: GET_FIELD 'FIELD IR_EXTERNAL_JAVA_DECLARATION_STUB name:STRING type:@[FlexibleNullability] kotlin.String? visibility:public [static]' type=@[FlexibleNullability] kotlin.String? origin=GET_PROPERTY

--- a/compiler/testData/ir/irText/types/nullChecks/typeParameterWithMultipleNullableBounds.fir.kt.txt
+++ b/compiler/testData/ir/irText/types/nullChecks/typeParameterWithMultipleNullableBounds.fir.kt.txt
@@ -1,0 +1,14 @@
+fun <T> f(x: T): Int? where T : CharSequence?, T : Comparable<T>? {
+  return { // BLOCK
+    val tmp0_safe_receiver: T = x
+    when {
+      EQEQ(arg0 = tmp0_safe_receiver, arg1 = null) -> null
+      else -> tmp0_safe_receiver.compareTo(other = x)
+    }
+  }
+}
+
+fun test() {
+  f<@FlexibleNullability String?>(x = s()) /*~> Unit */
+  f<@FlexibleNullability String?>(x = #STRING) /*~> Unit */
+}

--- a/compiler/testData/ir/irText/types/nullChecks/typeParameterWithMultipleNullableBounds.fir.txt
+++ b/compiler/testData/ir/irText/types/nullChecks/typeParameterWithMultipleNullableBounds.fir.txt
@@ -1,0 +1,30 @@
+FILE fqName:<root> fileName:/typeParameterWithMultipleNullableBounds.kt
+  FUN name:f visibility:public modality:FINAL <T> (x:T of <root>.f) returnType:kotlin.Int?
+    TYPE_PARAMETER name:T index:0 variance: superTypes:[kotlin.CharSequence?; kotlin.Comparable<T of <root>.f>?]
+    VALUE_PARAMETER name:x index:0 type:T of <root>.f
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='public final fun f <T> (x: T of <root>.f): kotlin.Int? declared in <root>'
+        BLOCK type=kotlin.Int? origin=SAFE_CALL
+          VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:T of <root>.f [val]
+            GET_VAR 'x: T of <root>.f declared in <root>.f' type=T of <root>.f origin=null
+          WHEN type=kotlin.Int? origin=null
+            BRANCH
+              if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                arg0: GET_VAR 'val tmp_0: T of <root>.f [val] declared in <root>.f' type=T of <root>.f origin=null
+                arg1: CONST Null type=kotlin.Nothing? value=null
+              then: CONST Null type=kotlin.Nothing? value=null
+            BRANCH
+              if: CONST Boolean type=kotlin.Boolean value=true
+              then: CALL 'public abstract fun compareTo (other: T of kotlin.Comparable): kotlin.Int [operator] declared in kotlin.Comparable' type=kotlin.Int origin=null
+                $this: GET_VAR 'val tmp_0: T of <root>.f [val] declared in <root>.f' type=T of <root>.f origin=null
+                other: GET_VAR 'x: T of <root>.f declared in <root>.f' type=T of <root>.f origin=null
+  FUN name:test visibility:public modality:FINAL <> () returnType:kotlin.Unit
+    BLOCK_BODY
+      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+        CALL 'public final fun f <T> (x: T of <root>.f): kotlin.Int? declared in <root>' type=kotlin.Int? origin=null
+          <T>: @[FlexibleNullability] kotlin.String?
+          x: CALL 'public open fun s (): @[FlexibleNullability] kotlin.String? declared in <root>.J' type=@[FlexibleNullability] kotlin.String? origin=null
+      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+        CALL 'public final fun f <T> (x: T of <root>.f): kotlin.Int? declared in <root>' type=kotlin.Int? origin=null
+          <T>: @[FlexibleNullability] kotlin.String?
+          x: GET_FIELD 'FIELD IR_EXTERNAL_JAVA_DECLARATION_STUB name:STRING type:@[FlexibleNullability] kotlin.String? visibility:public [static]' type=@[FlexibleNullability] kotlin.String? origin=GET_PROPERTY

--- a/compiler/testData/ir/irText/types/nullChecks/typeParameterWithMultipleNullableBounds.kt
+++ b/compiler/testData/ir/irText/types/nullChecks/typeParameterWithMultipleNullableBounds.kt
@@ -1,0 +1,16 @@
+// FILE: typeParameterWithMultipleNullableBounds.kt
+fun <T> f(x: T): Int? where T : CharSequence?, T : Comparable<T>? {
+    return x?.compareTo(x)
+}
+
+fun test() {
+    f(J.s())
+    f(J.STRING)
+}
+
+
+// FILE: J.java
+public class J {
+    public static String STRING = s()
+    public static String s() { return null; }
+}

--- a/compiler/testData/ir/irText/types/nullChecks/typeParameterWithMultipleNullableBounds.kt.txt
+++ b/compiler/testData/ir/irText/types/nullChecks/typeParameterWithMultipleNullableBounds.kt.txt
@@ -1,0 +1,14 @@
+fun <T> f(x: T): Int? where T : CharSequence?, T : Comparable<T>? {
+  return { // BLOCK
+    val tmp0_safe_receiver: T = x
+    when {
+      EQEQ(arg0 = tmp0_safe_receiver, arg1 = null) -> null
+      else -> tmp0_safe_receiver.compareTo(other = x)
+    }
+  }
+}
+
+fun test() {
+  f<@FlexibleNullability String?>(x = s()) /*~> Unit */
+  f<@FlexibleNullability String?>(x = super.#STRING) /*~> Unit */
+}

--- a/compiler/testData/ir/irText/types/nullChecks/typeParameterWithMultipleNullableBounds.txt
+++ b/compiler/testData/ir/irText/types/nullChecks/typeParameterWithMultipleNullableBounds.txt
@@ -1,0 +1,30 @@
+FILE fqName:<root> fileName:/typeParameterWithMultipleNullableBounds.kt
+  FUN name:f visibility:public modality:FINAL <T> (x:T of <root>.f) returnType:kotlin.Int?
+    TYPE_PARAMETER name:T index:0 variance: superTypes:[kotlin.CharSequence?; kotlin.Comparable<T of <root>.f>?]
+    VALUE_PARAMETER name:x index:0 type:T of <root>.f
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='public final fun f <T> (x: T of <root>.f): kotlin.Int? declared in <root>'
+        BLOCK type=kotlin.Int? origin=SAFE_CALL
+          VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:T of <root>.f [val]
+            GET_VAR 'x: T of <root>.f declared in <root>.f' type=T of <root>.f origin=null
+          WHEN type=kotlin.Int? origin=null
+            BRANCH
+              if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                arg0: GET_VAR 'val tmp_0: T of <root>.f [val] declared in <root>.f' type=T of <root>.f origin=null
+                arg1: CONST Null type=kotlin.Nothing? value=null
+              then: CONST Null type=kotlin.Nothing? value=null
+            BRANCH
+              if: CONST Boolean type=kotlin.Boolean value=true
+              then: CALL 'public abstract fun compareTo (other: T of kotlin.Comparable): kotlin.Int [operator] declared in kotlin.Comparable' type=kotlin.Int origin=null
+                $this: GET_VAR 'val tmp_0: T of <root>.f [val] declared in <root>.f' type=T of <root>.f origin=null
+                other: GET_VAR 'x: T of <root>.f declared in <root>.f' type=T of <root>.f origin=null
+  FUN name:test visibility:public modality:FINAL <> () returnType:kotlin.Unit
+    BLOCK_BODY
+      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+        CALL 'public final fun f <T> (x: T of <root>.f): kotlin.Int? declared in <root>' type=kotlin.Int? origin=null
+          <T>: @[FlexibleNullability] kotlin.String?
+          x: CALL 'public open fun s (): @[FlexibleNullability] kotlin.String? declared in <root>.J' type=@[FlexibleNullability] kotlin.String? origin=null
+      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+        CALL 'public final fun f <T> (x: T of <root>.f): kotlin.Int? declared in <root>' type=kotlin.Int? origin=null
+          <T>: @[FlexibleNullability] kotlin.String?
+          x: GET_FIELD 'FIELD IR_EXTERNAL_JAVA_DECLARATION_STUB name:STRING type:@[FlexibleNullability] kotlin.String? visibility:public [static]' type=@[FlexibleNullability] kotlin.String? origin=GET_PROPERTY

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -21485,6 +21485,24 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
                 runTest("compiler/testData/codegen/box/javaInterop/notNullAssertions/staticCallErrorMessage.kt");
             }
 
+            @Test
+            @TestMetadata("typeParameterWithMixedNullableAndNotNullableBounds.kt")
+            public void testTypeParameterWithMixedNullableAndNotNullableBounds() throws Exception {
+                runTest("compiler/testData/codegen/box/javaInterop/notNullAssertions/typeParameterWithMixedNullableAndNotNullableBounds.kt");
+            }
+
+            @Test
+            @TestMetadata("typeParameterWithMultipleNotNullableBounds.kt")
+            public void testTypeParameterWithMultipleNotNullableBounds() throws Exception {
+                runTest("compiler/testData/codegen/box/javaInterop/notNullAssertions/typeParameterWithMultipleNotNullableBounds.kt");
+            }
+
+            @Test
+            @TestMetadata("typeParameterWithMultipleNullableBounds.kt")
+            public void testTypeParameterWithMultipleNullableBounds() throws Exception {
+                runTest("compiler/testData/codegen/box/javaInterop/notNullAssertions/typeParameterWithMultipleNullableBounds.kt");
+            }
+
             @Nested
             @TestMetadata("compiler/testData/codegen/box/javaInterop/notNullAssertions/enhancedNullability")
             @TestDataPath("$PROJECT_ROOT")

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -21503,6 +21503,24 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
                 runTest("compiler/testData/codegen/box/javaInterop/notNullAssertions/staticCallErrorMessage.kt");
             }
 
+            @Test
+            @TestMetadata("typeParameterWithMixedNullableAndNotNullableBounds.kt")
+            public void testTypeParameterWithMixedNullableAndNotNullableBounds() throws Exception {
+                runTest("compiler/testData/codegen/box/javaInterop/notNullAssertions/typeParameterWithMixedNullableAndNotNullableBounds.kt");
+            }
+
+            @Test
+            @TestMetadata("typeParameterWithMultipleNotNullableBounds.kt")
+            public void testTypeParameterWithMultipleNotNullableBounds() throws Exception {
+                runTest("compiler/testData/codegen/box/javaInterop/notNullAssertions/typeParameterWithMultipleNotNullableBounds.kt");
+            }
+
+            @Test
+            @TestMetadata("typeParameterWithMultipleNullableBounds.kt")
+            public void testTypeParameterWithMultipleNullableBounds() throws Exception {
+                runTest("compiler/testData/codegen/box/javaInterop/notNullAssertions/typeParameterWithMultipleNullableBounds.kt");
+            }
+
             @Nested
             @TestMetadata("compiler/testData/codegen/box/javaInterop/notNullAssertions/enhancedNullability")
             @TestDataPath("$PROJECT_ROOT")

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/ir/IrTextTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/ir/IrTextTestGenerated.java
@@ -2731,6 +2731,24 @@ public class IrTextTestGenerated extends AbstractIrTextTest {
                 runTest("compiler/testData/ir/irText/types/nullChecks/platformTypeReceiver.kt");
             }
 
+            @Test
+            @TestMetadata("typeParameterWithMixedNullableAndNotNullableBounds.kt")
+            public void testTypeParameterWithMixedNullableAndNotNullableBounds() throws Exception {
+                runTest("compiler/testData/ir/irText/types/nullChecks/typeParameterWithMixedNullableAndNotNullableBounds.kt");
+            }
+
+            @Test
+            @TestMetadata("typeParameterWithMultipleNotNullableBounds.kt")
+            public void testTypeParameterWithMultipleNotNullableBounds() throws Exception {
+                runTest("compiler/testData/ir/irText/types/nullChecks/typeParameterWithMultipleNotNullableBounds.kt");
+            }
+
+            @Test
+            @TestMetadata("typeParameterWithMultipleNullableBounds.kt")
+            public void testTypeParameterWithMultipleNullableBounds() throws Exception {
+                runTest("compiler/testData/ir/irText/types/nullChecks/typeParameterWithMultipleNullableBounds.kt");
+            }
+
             @Nested
             @TestMetadata("compiler/testData/ir/irText/types/nullChecks/nullCheckOnLambdaResult")
             @TestDataPath("$PROJECT_ROOT")

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -8125,11 +8125,6 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             @TestDataPath("$PROJECT_ROOT")
             @RunWith(JUnit3RunnerWithInners.class)
             public static class Resume extends AbstractLightAnalysisModeTest {
-                @TestMetadata("boxTypeParameterOfSuperTypeResult.kt")
-                public void ignoreBoxTypeParameterOfSuperTypeResult() throws Exception {
-                    runTest("compiler/testData/codegen/box/coroutines/inlineClasses/resume/boxTypeParameterOfSuperTypeResult.kt");
-                }
-
                 private void runTest(String testDataFilePath) throws Exception {
                     KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM, testDataFilePath);
                 }
@@ -8151,6 +8146,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
                 @TestMetadata("boxTypeParameterOfSuperType.kt")
                 public void testBoxTypeParameterOfSuperType() throws Exception {
                     runTest("compiler/testData/codegen/box/coroutines/inlineClasses/resume/boxTypeParameterOfSuperType.kt");
+                }
+
+                @TestMetadata("boxTypeParameterOfSuperTypeResult.kt")
+                public void testBoxTypeParameterOfSuperTypeResult() throws Exception {
+                    runTest("compiler/testData/codegen/box/coroutines/inlineClasses/resume/boxTypeParameterOfSuperTypeResult.kt");
                 }
 
                 @TestMetadata("boxUnboxInsideCoroutine.kt")
@@ -8363,11 +8363,6 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             @TestDataPath("$PROJECT_ROOT")
             @RunWith(JUnit3RunnerWithInners.class)
             public static class ResumeWithException extends AbstractLightAnalysisModeTest {
-                @TestMetadata("boxTypeParameterOfSuperTypeResult.kt")
-                public void ignoreBoxTypeParameterOfSuperTypeResult() throws Exception {
-                    runTest("compiler/testData/codegen/box/coroutines/inlineClasses/resumeWithException/boxTypeParameterOfSuperTypeResult.kt");
-                }
-
                 private void runTest(String testDataFilePath) throws Exception {
                     KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM, testDataFilePath);
                 }
@@ -8389,6 +8384,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
                 @TestMetadata("boxTypeParameterOfSuperType.kt")
                 public void testBoxTypeParameterOfSuperType() throws Exception {
                     runTest("compiler/testData/codegen/box/coroutines/inlineClasses/resumeWithException/boxTypeParameterOfSuperType.kt");
+                }
+
+                @TestMetadata("boxTypeParameterOfSuperTypeResult.kt")
+                public void testBoxTypeParameterOfSuperTypeResult() throws Exception {
+                    runTest("compiler/testData/codegen/box/coroutines/inlineClasses/resumeWithException/boxTypeParameterOfSuperTypeResult.kt");
                 }
 
                 @TestMetadata("boxUnboxInsideCoroutine.kt")
@@ -17894,6 +17894,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
                 runTest("compiler/testData/codegen/box/javaInterop/notNullAssertions/kt24258.kt");
             }
 
+            @TestMetadata("typeParameterWithMixedNullableAndNotNullableBounds.kt")
+            public void ignoreTypeParameterWithMixedNullableAndNotNullableBounds() throws Exception {
+                runTest("compiler/testData/codegen/box/javaInterop/notNullAssertions/typeParameterWithMixedNullableAndNotNullableBounds.kt");
+            }
+
             private void runTest(String testDataFilePath) throws Exception {
                 KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM, testDataFilePath);
             }
@@ -18000,6 +18005,16 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             @TestMetadata("staticCallErrorMessage.kt")
             public void testStaticCallErrorMessage() throws Exception {
                 runTest("compiler/testData/codegen/box/javaInterop/notNullAssertions/staticCallErrorMessage.kt");
+            }
+
+            @TestMetadata("typeParameterWithMultipleNotNullableBounds.kt")
+            public void testTypeParameterWithMultipleNotNullableBounds() throws Exception {
+                runTest("compiler/testData/codegen/box/javaInterop/notNullAssertions/typeParameterWithMultipleNotNullableBounds.kt");
+            }
+
+            @TestMetadata("typeParameterWithMultipleNullableBounds.kt")
+            public void testTypeParameterWithMultipleNullableBounds() throws Exception {
+                runTest("compiler/testData/codegen/box/javaInterop/notNullAssertions/typeParameterWithMultipleNullableBounds.kt");
             }
 
             @TestMetadata("compiler/testData/codegen/box/javaInterop/notNullAssertions/enhancedNullability")

--- a/compiler/tests-spec/testData/diagnostics/notLinked/dfa/neg/23.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/dfa/neg/23.fir.kt
@@ -20,7 +20,7 @@ inline fun <reified T, reified K> case_1(x: T) {
 inline fun <reified T, reified K> case_2(x: T) {
     x as K
     <!DEBUG_INFO_EXPRESSION_TYPE("T & K & T")!>x<!>
-    <!DEBUG_INFO_EXPRESSION_TYPE("T & K & T")!>x<!>.<!INAPPLICABLE_CANDIDATE!>equals<!>(x)
+    <!DEBUG_INFO_EXPRESSION_TYPE("T & K & T")!>x<!><!UNSAFE_CALL!>.<!>equals(x)
 }
 
 /*
@@ -49,7 +49,7 @@ inline fun <reified T, reified K> case_4(x: T?) {
 inline fun <reified T, reified K> case_5(x: T) {
     if (x is K?) {
         <!DEBUG_INFO_EXPRESSION_TYPE("T & K? & T")!>x<!>
-        <!DEBUG_INFO_EXPRESSION_TYPE("T & K? & T")!>x<!>.<!INAPPLICABLE_CANDIDATE!>equals<!>(x)
+        <!DEBUG_INFO_EXPRESSION_TYPE("T & K? & T")!>x<!><!UNSAFE_CALL!>.<!>equals(x)
     }
 }
 

--- a/compiler/tests-spec/testData/diagnostics/notLinked/dfa/neg/9.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/dfa/neg/9.fir.kt
@@ -8,7 +8,7 @@ fun <T, K> case_1(x: T?, y: K?) {
     y as K
     val z = <!DEBUG_INFO_EXPRESSION_TYPE("T? & T")!>x<!> ?: <!DEBUG_INFO_EXPRESSION_TYPE("K? & K")!>y<!>
 
-    <!DEBUG_INFO_EXPRESSION_TYPE("T? & T")!>x<!>.<!INAPPLICABLE_CANDIDATE!>equals<!>(10)
+    <!DEBUG_INFO_EXPRESSION_TYPE("T? & T")!>x<!><!UNSAFE_CALL!>.<!>equals(10)
     <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any?")!>z<!>
     <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any?")!>z<!><!UNSAFE_CALL!>.<!>equals(10)
 }
@@ -18,5 +18,5 @@ inline fun <reified T: Any, reified K: T?> case_2(y: K?) {
     y as K
 
     <!DEBUG_INFO_EXPRESSION_TYPE("K? & K")!>y<!>
-    <!DEBUG_INFO_EXPRESSION_TYPE("K? & K")!>y<!>.<!INAPPLICABLE_CANDIDATE!>equals<!>(10)
+    <!DEBUG_INFO_EXPRESSION_TYPE("K? & K")!>y<!><!UNSAFE_CALL!>.<!>equals(10)
 }

--- a/compiler/tests-spec/testData/diagnostics/notLinked/dfa/pos/13.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/dfa/pos/13.fir.kt
@@ -8,31 +8,31 @@ fun <T> case_1(x: T) {
 
     if (y != x) {
         <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>
-        <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.<!INAPPLICABLE_CANDIDATE!>equals<!>(null)
+        <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!><!UNSAFE_CALL!>.<!>equals(null)
         <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.propT
-        <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.<!INAPPLICABLE_CANDIDATE!>propAny<!>
+        <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!><!UNSAFE_CALL!>.<!>propAny
         <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.propNullableT
         <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.propNullableAny
         <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.funT()
-        <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.<!INAPPLICABLE_CANDIDATE!>funAny<!>()
+        <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!><!UNSAFE_CALL!>.<!>funAny()
         <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.funNullableT()
         <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.funNullableAny()
-        <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.apply { <!INAPPLICABLE_CANDIDATE!>equals<!>(null) }
+        <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.apply { <!UNSAFE_CALL!>equals<!>(null) }
         <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.apply { propT }
-        <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.apply { <!INAPPLICABLE_CANDIDATE!>propAny<!> }
+        <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.apply { <!UNSAFE_CALL!>propAny<!> }
         <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.apply { propNullableT }
         <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.apply { propNullableAny }
         <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.apply { funT() }
-        <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.apply { <!INAPPLICABLE_CANDIDATE!>funAny<!>() }
+        <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.apply { <!UNSAFE_CALL!>funAny<!>() }
         <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.apply { funNullableT() }
-        <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.apply { funNullableAny(); <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.<!INAPPLICABLE_CANDIDATE!>equals<!>(null) }
-        <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.also { <!DEBUG_INFO_EXPRESSION_TYPE("T")!>it<!>.<!INAPPLICABLE_CANDIDATE!>equals<!>(null) }
+        <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.apply { funNullableAny(); <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!><!UNSAFE_CALL!>.<!>equals(null) }
+        <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.also { <!DEBUG_INFO_EXPRESSION_TYPE("T")!>it<!><!UNSAFE_CALL!>.<!>equals(null) }
         <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.also { <!DEBUG_INFO_EXPRESSION_TYPE("T")!>it<!>.propT }
-        <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.also { <!DEBUG_INFO_EXPRESSION_TYPE("T")!>it<!>.<!INAPPLICABLE_CANDIDATE!>propAny<!> }
+        <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.also { <!DEBUG_INFO_EXPRESSION_TYPE("T")!>it<!><!UNSAFE_CALL!>.<!>propAny }
         <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.also { <!DEBUG_INFO_EXPRESSION_TYPE("T")!>it<!>.propNullableT }
         <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.also { <!DEBUG_INFO_EXPRESSION_TYPE("T")!>it<!>.propNullableAny }
         <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.also { <!DEBUG_INFO_EXPRESSION_TYPE("T")!>it<!>.funT() }
-        <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.also { <!DEBUG_INFO_EXPRESSION_TYPE("T")!>it<!>.<!INAPPLICABLE_CANDIDATE!>funAny<!>() }
+        <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.also { <!DEBUG_INFO_EXPRESSION_TYPE("T")!>it<!><!UNSAFE_CALL!>.<!>funAny() }
         <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.also { <!DEBUG_INFO_EXPRESSION_TYPE("T")!>it<!>.funNullableT() }
         <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.also { <!DEBUG_INFO_EXPRESSION_TYPE("T")!>it<!>.funNullableAny() }
     }

--- a/compiler/tests-spec/testData/diagnostics/notLinked/dfa/pos/18.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/dfa/pos/18.fir.kt
@@ -244,13 +244,13 @@ fun <T>case_18(x: T, f: Boolean) {
     while (f) {
         if (false || false || false || x == nullableNothingProperty) break
         <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>
-        <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.<!INAPPLICABLE_CANDIDATE!>equals<!>(null)
+        <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!><!UNSAFE_CALL!>.<!>equals(null)
         <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.propT
-        <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.<!INAPPLICABLE_CANDIDATE!>propAny<!>
+        <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!><!UNSAFE_CALL!>.<!>propAny
         <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.propNullableT
         <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.propNullableAny
         <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.funT()
-        <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.<!INAPPLICABLE_CANDIDATE!>funAny<!>()
+        <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!><!UNSAFE_CALL!>.<!>funAny()
         <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.funNullableT()
         <!DEBUG_INFO_EXPRESSION_TYPE("T")!>x<!>.funNullableAny()
     }
@@ -261,23 +261,23 @@ fun <K, V>case_19(map: MutableMap<K, V>, y: Nothing?) {
     for ((k, v) in map) {
         if (k !== implicitNullableNothingProperty && true && v != y) else { break }
         <!DEBUG_INFO_EXPRESSION_TYPE("K")!>k<!>
-        <!DEBUG_INFO_EXPRESSION_TYPE("K")!>k<!>.<!INAPPLICABLE_CANDIDATE!>equals<!>(null)
+        <!DEBUG_INFO_EXPRESSION_TYPE("K")!>k<!><!UNSAFE_CALL!>.<!>equals(null)
         <!DEBUG_INFO_EXPRESSION_TYPE("K")!>k<!>.propT
-        <!DEBUG_INFO_EXPRESSION_TYPE("K")!>k<!>.<!INAPPLICABLE_CANDIDATE!>propAny<!>
+        <!DEBUG_INFO_EXPRESSION_TYPE("K")!>k<!><!UNSAFE_CALL!>.<!>propAny
         <!DEBUG_INFO_EXPRESSION_TYPE("K")!>k<!>.propNullableT
         <!DEBUG_INFO_EXPRESSION_TYPE("K")!>k<!>.propNullableAny
         <!DEBUG_INFO_EXPRESSION_TYPE("K")!>k<!>.funT()
-        <!DEBUG_INFO_EXPRESSION_TYPE("K")!>k<!>.<!INAPPLICABLE_CANDIDATE!>funAny<!>()
+        <!DEBUG_INFO_EXPRESSION_TYPE("K")!>k<!><!UNSAFE_CALL!>.<!>funAny()
         <!DEBUG_INFO_EXPRESSION_TYPE("K")!>k<!>.funNullableT()
         <!DEBUG_INFO_EXPRESSION_TYPE("K")!>k<!>.funNullableAny()
         <!DEBUG_INFO_EXPRESSION_TYPE("V")!>v<!>
-        <!DEBUG_INFO_EXPRESSION_TYPE("V")!>v<!>.<!INAPPLICABLE_CANDIDATE!>equals<!>(null)
+        <!DEBUG_INFO_EXPRESSION_TYPE("V")!>v<!><!UNSAFE_CALL!>.<!>equals(null)
         <!DEBUG_INFO_EXPRESSION_TYPE("V")!>v<!>.propT
-        <!DEBUG_INFO_EXPRESSION_TYPE("V")!>v<!>.<!INAPPLICABLE_CANDIDATE!>propAny<!>
+        <!DEBUG_INFO_EXPRESSION_TYPE("V")!>v<!><!UNSAFE_CALL!>.<!>propAny
         <!DEBUG_INFO_EXPRESSION_TYPE("V")!>v<!>.propNullableT
         <!DEBUG_INFO_EXPRESSION_TYPE("V")!>v<!>.propNullableAny
         <!DEBUG_INFO_EXPRESSION_TYPE("V")!>v<!>.funT()
-        <!DEBUG_INFO_EXPRESSION_TYPE("V")!>v<!>.<!INAPPLICABLE_CANDIDATE!>funAny<!>()
+        <!DEBUG_INFO_EXPRESSION_TYPE("V")!>v<!><!UNSAFE_CALL!>.<!>funAny()
         <!DEBUG_INFO_EXPRESSION_TYPE("V")!>v<!>.funNullableT()
         <!DEBUG_INFO_EXPRESSION_TYPE("V")!>v<!>.funNullableAny()
     }

--- a/compiler/tests-spec/testData/diagnostics/notLinked/dfa/pos/6.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/dfa/pos/6.fir.kt
@@ -1296,11 +1296,11 @@ fun case_71(t: Any?) {
         if (t is Interface2?) {
             if (t != z2) {
                 <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface1? & Interface2?")!>t<!>
-                <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface1? & Interface2?")!>t<!>.<!INAPPLICABLE_CANDIDATE!>itest1<!>()
-                <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface1? & Interface2?")!>t<!>.<!INAPPLICABLE_CANDIDATE!>itest2<!>()
-                <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface1? & Interface2?")!>t<!>.<!INAPPLICABLE_CANDIDATE!>itest<!>()
+                <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface1? & Interface2?")!>t<!><!UNSAFE_CALL!>.<!>itest1()
+                <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface1? & Interface2?")!>t<!><!UNSAFE_CALL!>.<!>itest2()
+                <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface1? & Interface2?")!>t<!><!UNSAFE_CALL!>.<!>itest()
 
-                <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface1? & Interface2?")!>t<!>.let { <!DEBUG_INFO_EXPRESSION_TYPE("Interface1? & Interface2?")!>it<!>.<!INAPPLICABLE_CANDIDATE!>itest1<!>(); <!DEBUG_INFO_EXPRESSION_TYPE("Interface1? & Interface2?")!>it<!>.<!INAPPLICABLE_CANDIDATE!>itest2<!>() }
+                <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface1? & Interface2?")!>t<!>.let { <!DEBUG_INFO_EXPRESSION_TYPE("Interface1? & Interface2?")!>it<!><!UNSAFE_CALL!>.<!>itest1(); <!DEBUG_INFO_EXPRESSION_TYPE("Interface1? & Interface2?")!>it<!><!UNSAFE_CALL!>.<!>itest2() }
             }
         }
     }
@@ -1318,11 +1318,11 @@ fun case_72(t: Any?, z1: Nothing?) {
 
     if (t is Interface1? && t != z1 ?: z2 && t is Interface2?) {
         <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface1? & Interface2?")!>t<!>
-        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface1? & Interface2?")!>t<!>.<!INAPPLICABLE_CANDIDATE!>itest1<!>()
-        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface1? & Interface2?")!>t<!>.<!INAPPLICABLE_CANDIDATE!>itest2<!>()
-        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface1? & Interface2?")!>t<!>.<!INAPPLICABLE_CANDIDATE!>itest<!>()
+        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface1? & Interface2?")!>t<!><!UNSAFE_CALL!>.<!>itest1()
+        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface1? & Interface2?")!>t<!><!UNSAFE_CALL!>.<!>itest2()
+        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface1? & Interface2?")!>t<!><!UNSAFE_CALL!>.<!>itest()
 
-        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface1? & Interface2?")!>t<!>.let { <!DEBUG_INFO_EXPRESSION_TYPE("Interface1? & Interface2?")!>it<!>.<!INAPPLICABLE_CANDIDATE!>itest1<!>(); <!DEBUG_INFO_EXPRESSION_TYPE("Interface1? & Interface2?")!>it<!>.<!INAPPLICABLE_CANDIDATE!>itest2<!>() }
+        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface1? & Interface2?")!>t<!>.let { <!DEBUG_INFO_EXPRESSION_TYPE("Interface1? & Interface2?")!>it<!><!UNSAFE_CALL!>.<!>itest1(); <!DEBUG_INFO_EXPRESSION_TYPE("Interface1? & Interface2?")!>it<!><!UNSAFE_CALL!>.<!>itest2() }
     }
 }
 
@@ -1341,11 +1341,11 @@ fun case_73(t: Any?) {
             if (t is ClassLevel2? && t is Interface1?) {
                 if (t !is Interface3?) {} else if (false) {
                     if (t != `null`) {
-                        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface2? & ClassLevel2? & Interface1? & Interface3?")!>t<!>.<!INAPPLICABLE_CANDIDATE!>itest2<!>()
-                        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface2? & ClassLevel2? & Interface1? & Interface3?")!>t<!>.<!INAPPLICABLE_CANDIDATE!>itest1<!>()
-                        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface2? & ClassLevel2? & Interface1? & Interface3?")!>t<!>.<!INAPPLICABLE_CANDIDATE!>itest<!>()
-                        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface2? & ClassLevel2? & Interface1? & Interface3?")!>t<!>.<!INAPPLICABLE_CANDIDATE!>test1<!>()
-                        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface2? & ClassLevel2? & Interface1? & Interface3?")!>t<!>.<!INAPPLICABLE_CANDIDATE!>test2<!>()
+                        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface2? & ClassLevel2? & Interface1? & Interface3?")!>t<!><!UNSAFE_CALL!>.<!>itest2()
+                        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface2? & ClassLevel2? & Interface1? & Interface3?")!>t<!><!UNSAFE_CALL!>.<!>itest1()
+                        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface2? & ClassLevel2? & Interface1? & Interface3?")!>t<!><!UNSAFE_CALL!>.<!>itest()
+                        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface2? & ClassLevel2? & Interface1? & Interface3?")!>t<!><!UNSAFE_CALL!>.<!>test1()
+                        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface2? & ClassLevel2? & Interface1? & Interface3?")!>t<!><!UNSAFE_CALL!>.<!>test2()
                         <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface2? & ClassLevel2? & Interface1? & Interface3?")!>t<!>
                     }
                 }
@@ -1366,11 +1366,11 @@ fun case_74(t: Any?) {
             if (t == implicitNullableNothingProperty || t === implicitNullableNothingProperty || t !is Interface1?) else {
                 if (t is ClassLevel2?) {
                     if (t is Interface3?) {
-                        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface2? & Interface1? & ClassLevel2? & Interface3?")!>t<!>.<!INAPPLICABLE_CANDIDATE!>itest2<!>()
-                        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface2? & Interface1? & ClassLevel2? & Interface3?")!>t<!>.<!INAPPLICABLE_CANDIDATE!>itest1<!>()
-                        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface2? & Interface1? & ClassLevel2? & Interface3?")!>t<!>.<!INAPPLICABLE_CANDIDATE!>itest<!>()
-                        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface2? & Interface1? & ClassLevel2? & Interface3?")!>t<!>.<!INAPPLICABLE_CANDIDATE!>test1<!>()
-                        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface2? & Interface1? & ClassLevel2? & Interface3?")!>t<!>.<!INAPPLICABLE_CANDIDATE!>test2<!>()
+                        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface2? & Interface1? & ClassLevel2? & Interface3?")!>t<!><!UNSAFE_CALL!>.<!>itest2()
+                        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface2? & Interface1? & ClassLevel2? & Interface3?")!>t<!><!UNSAFE_CALL!>.<!>itest1()
+                        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface2? & Interface1? & ClassLevel2? & Interface3?")!>t<!><!UNSAFE_CALL!>.<!>itest()
+                        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface2? & Interface1? & ClassLevel2? & Interface3?")!>t<!><!UNSAFE_CALL!>.<!>test1()
+                        <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface2? & Interface1? & ClassLevel2? & Interface3?")!>t<!><!UNSAFE_CALL!>.<!>test2()
                         <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & Interface2? & Interface1? & ClassLevel2? & Interface3?")!>t<!>
                     }
                 }
@@ -1389,11 +1389,11 @@ fun case_75(t: Any?, z: Nothing?) {
     if (t !is ClassLevel2? || t !is ClassLevel1?) else {
         if (t === ((((((z)))))) || t !is Interface1?) else {
             if (t !is Interface2? || t !is Interface3?) {} else {
-                <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & ClassLevel2? & Interface1? & Interface2? & Interface3?")!>t<!>.<!INAPPLICABLE_CANDIDATE!>itest2<!>()
-                <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & ClassLevel2? & Interface1? & Interface2? & Interface3?")!>t<!>.<!INAPPLICABLE_CANDIDATE!>itest1<!>()
-                <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & ClassLevel2? & Interface1? & Interface2? & Interface3?")!>t<!>.<!INAPPLICABLE_CANDIDATE!>itest<!>()
-                <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & ClassLevel2? & Interface1? & Interface2? & Interface3?")!>t<!>.<!INAPPLICABLE_CANDIDATE!>test1<!>()
-                <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & ClassLevel2? & Interface1? & Interface2? & Interface3?")!>t<!>.<!INAPPLICABLE_CANDIDATE!>test2<!>()
+                <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & ClassLevel2? & Interface1? & Interface2? & Interface3?")!>t<!><!UNSAFE_CALL!>.<!>itest2()
+                <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & ClassLevel2? & Interface1? & Interface2? & Interface3?")!>t<!><!UNSAFE_CALL!>.<!>itest1()
+                <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & ClassLevel2? & Interface1? & Interface2? & Interface3?")!>t<!><!UNSAFE_CALL!>.<!>itest()
+                <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & ClassLevel2? & Interface1? & Interface2? & Interface3?")!>t<!><!UNSAFE_CALL!>.<!>test1()
+                <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & ClassLevel2? & Interface1? & Interface2? & Interface3?")!>t<!><!UNSAFE_CALL!>.<!>test2()
                 <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any? & ClassLevel2? & Interface1? & Interface2? & Interface3?")!>t<!>
             }
         }


### PR DESCRIPTION
The motivation was `compiler/testData/diagnostics/tests/generics/nullability/smartCastsOnThis.fir.kt`, where the implicit receiver was of a generic type which can be null, hence the change to use `ConeKotlinType.canBeNull` instead of `ConeKotlinType.isNullable`.

I noticed that this missed the 2nd unsafe call in `compiler/testData/diagnostics/tests/generics/nullability/useAsReceiver.fir.kt`, where the expected type of the receiver was a `ConeTypeVariableType`, hence the change in `ConeKotlinType.isEffectivelyNotNull()`.

I did not look deeply into the cause of the unsafe calls to `checkType` in the tests, but nevertheless `UNSAFE_INFIX_CALL` is better than `INAPPLICABLE_CANDIDATE`.