### PR TITLE
box the Kotlin primary type with NSNumber instead of Kotlin${Type}

### DIFF
--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objcexport/ObjCExportCodeGenerator.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objcexport/ObjCExportCodeGenerator.kt
@@ -626,8 +626,8 @@ private fun ObjCExportCodeGenerator.emitBoxConverter(
 
         val value = kotlinToObjC(kotlinValue, objCValueType)
 
-        val nsNumberSubclass = genGetLinkedClass(namer.numberBoxName(boxClass.classId!!).binaryName)
-        ret(genSendMessage(int8TypePtr, nsNumberSubclass, nsNumberFactorySelector, value))
+        val nsNumberClass = genGetLinkedClass("NSNumber")
+        ret(genSendMessage(int8TypePtr, nsNumberClass, nsNumberFactorySelector, value))
     }
 
     LLVMSetLinkage(converter, LLVMLinkage.LLVMPrivateLinkage)

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/CustomTypeMapper.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/CustomTypeMapper.kt
@@ -47,7 +47,7 @@ internal object CustomTypeMappers {
             // TODO: NSNumber seem to have different equality semantics.
             val classId = it.mappedKotlinClassId
             if (classId != null) {
-                result += Simple(classId, { namer.numberBoxName(classId).objCName })
+                result += Simple(classId, { "NSNumber" })
             }
 
         }


### PR DESCRIPTION
now Kotlin Native﻿ use runtime, the [https://kotlinlang.org/docs/native-objc-interop.html#nsnumber](https://kotlinlang.org/docs/native-objc-interop.html#nsnumber) is no longer applicable.


# in iOS

if I use `NSJSONSerialization` to serialize the `NSDictionary` which contains a `BOOL` value, the `BOOL` value is convert to `true` or `false` in JSON text, for example:

```objective-c
// add a BOOL value with [NSNumber numberWithBool:YES]
NSDictionary* dict = @{@"a": [NSNumber numberWithBool:YES]};
```

the result is:

```json
{
  "a" : true
}
```

if I add a `BOOL` value with `[NSNumber numberWithInteger:YES]`:

```objective-c
// add a BOOL value with [NSNumber numberWithInteger:YES]
NSDictionary* dict = @{@"a": [NSNumber numberWithInteger:YES]};
```

the result is:

```JSON
{
  "a" : 1
}
```

# in Kotlin

if I declare a Kotlin `map` in Kotlin code, like:

```Kotlin
class Greeting {
    val map = mapOf("a" to true)
}
```

return the Kotlin `map` to iOS, and use `NSJSONSerialization` to serialize the map, the result is:

```JSON
{
  "a" : 1 // expect is true
}
```

# the reason

## in iOS

if I box the `BOOL` with `NSNumber* result = [NSNumber numberWithBool:YES]`, the type of `result` is `__NSCFBoolean`.

if I box the `BOOL` with `NSNumber* result = [NSNumber numberWithInteger:YES]`, the type of `result` is `__NSCFNumber `.

so `NSJSONSerialization` can know `BOOL` is `BOOL`.

## in Kotlin

the type of `BOOL` in map is `KotlinBoolean` which is not the `__NSCFBoolean`, so `NSJSONSerialization` doesn't know the `BOOL` is `BOOL`

# the solution

## 1. box the Kotlin primary type with `[NSNumber numberWith${Type}:value]` instead of `[Kotlin${Type} numberWith${Type}:value]` for example:

1. box `Boolean?` with `[NSNumber numberWithBool:YES]` not `[KotlinBoolean numberWithBool:YES]`
2. box `Int?` with `[NSNumber numberWithInt:YES]` not `[KotlinInt numberWithInt:YES]`
3. ...

## 2. generate header: map the box type into `"NSNumber"`

Kotlin

```Kotlin
fun greeting(int: Int?) {
    println("Hello,  ${int!!::class.simpleName}!")
}

fun greeting(int: Boolean?) {
    println("Hello,  ${int!!::class.simpleName}!")
}
```

generate

```objective-c
- (void)greetingInt:(NSNumber * _Nullable)int_ __attribute__((swift_name("greeting(int:)")));
- (void)greetingInt_:(NSNumber * _Nullable)int_ __attribute__((swift_name("greeting(int_:)")));
```

instead of

```objective-c
- (void)greetingInt:(ShareInt * _Nullable)int_ __attribute__((swift_name("greeting(int:)")));
- (void)greetingInt_:(ShareBoolean * _Nullable)int_ __attribute__((swift_name("greeting(int_:)")));
```

## 3. test: pass the `NSNumber` argument to Kotlin, and print the type of the argument

Kotlin

```Kotlin
fun greeting(int: Int?) {
    println("Hello,  ${int!!::class.simpleName}!")
}
```

iOS

```objective-c
[greeting greetingInt:[NSNumber numberWithInt:10]];
[greeting greetingInt:[NSNumber numberWithBool:10]];
[greeting greetingInt:[NSNumber numberWithChar:10]];
[greeting greetingInt:[NSNumber numberWithShort:10]];
[greeting greetingInt:[NSNumber numberWithLong:10]];
[greeting greetingInt:[NSNumber numberWithFloat:10]];
[greeting greetingInt:[NSNumber numberWithDouble:10]];
```

the result is OK：

```Kotlin
Hello,  Int!
Hello,  Boolean!
Hello,  Byte!
Hello,  Short!
Hello,  Long!
Hello,  Float!
Hello,  Double!
```