### PR TITLE
FIR: fix nullability computation of intersection of flexible types

### DIFF
--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/types/ConeTypeIntersector.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/types/ConeTypeIntersector.kt
@@ -145,6 +145,11 @@ object ConeTypeIntersector {
         protected fun ConeKotlinType.resultNullability(context: ConeTypeContext): ResultNullability =
             when {
                 isMarkedNullable -> ACCEPT_NULL
+                // Technically, upper bound's nullability is more accurate, e.g., a type from Java with @NotNull.
+                // However, it requires one more recursive call here. In contrast, UNKNOWN here is a safe approximation: for even such
+                // flexible type case, as long as the upper bound is still used in the intersection computation (and it indeed is),
+                // we will still get the same nullability from the resulting intersected type.
+                this is ConeFlexibleType -> UNKNOWN
                 ConeNullabilityChecker.isSubtypeOfAny(context, this) -> NOT_NULL
                 else -> UNKNOWN
             }

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/types/ConeTypeIntersector.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/types/ConeTypeIntersector.kt
@@ -145,11 +145,7 @@ object ConeTypeIntersector {
         protected fun ConeKotlinType.resultNullability(context: ConeTypeContext): ResultNullability =
             when {
                 isMarkedNullable -> ACCEPT_NULL
-                // Technically, upper bound's nullability is more accurate, e.g., a type from Java with @NotNull.
-                // However, it requires one more recursive call here. In contrast, UNKNOWN here is a safe approximation: for even such
-                // flexible type case, as long as the upper bound is still used in the intersection computation (and it indeed is),
-                // we will still get the same nullability from the resulting intersected type.
-                this is ConeFlexibleType -> UNKNOWN
+                this is ConeFlexibleType -> upperBound.resultNullability(context)
                 ConeNullabilityChecker.isSubtypeOfAny(context, this) -> NOT_NULL
                 else -> UNKNOWN
             }

--- a/compiler/testData/diagnostics/tests/smartCasts/smartcastToNothingAfterCheckingForNull.fir.kt
+++ b/compiler/testData/diagnostics/tests/smartCasts/smartcastToNothingAfterCheckingForNull.fir.kt
@@ -23,7 +23,7 @@ fun g(x: B<Int>) {
     }
 
     if (y is Nothing?) {
-        <!OVERLOAD_RESOLUTION_AMBIGUITY!>f<!>(y)
-        <!OVERLOAD_RESOLUTION_AMBIGUITY!>g<!>(y)
+        f(y)
+        <!NONE_APPLICABLE!>g<!>(y)
     }
 }

--- a/compiler/testData/diagnostics/tests/smartCasts/varnotnull/toFlexibleType.fir.kt
+++ b/compiler/testData/diagnostics/tests/smartCasts/varnotnull/toFlexibleType.fir.kt
@@ -9,8 +9,8 @@ class J {
 fun bar() {
     var v: String?
     v = J.foo()
-    v.length
-    gav(v)
+    v<!UNSAFE_CALL!>.<!>length
+    <!INAPPLICABLE_CANDIDATE!>gav<!>(v)
 }
 
 fun gav(v: String) = v

--- a/compiler/testData/diagnostics/tests/smartCasts/varnotnull/toFlexibleType.fir.kt
+++ b/compiler/testData/diagnostics/tests/smartCasts/varnotnull/toFlexibleType.fir.kt
@@ -1,7 +1,12 @@
 // FILE: J.java
+import org.jetbrains.annotations.*;
+import java.util.List;
 
 class J {
     static String foo() { return "abc"; }
+
+    @NotNull
+    static List<String> bar() { return new List<String>(); }
 }
 
 // FILE: test.kt
@@ -11,6 +16,10 @@ fun bar() {
     v = J.foo()
     v<!UNSAFE_CALL!>.<!>length
     <!INAPPLICABLE_CANDIDATE!>gav<!>(v)
+
+    var l: List<String>?
+    l = J.bar()
+    l.isEmpty()
 }
 
 fun gav(v: String) = v

--- a/compiler/testData/diagnostics/tests/smartCasts/varnotnull/toFlexibleType.fir.kt
+++ b/compiler/testData/diagnostics/tests/smartCasts/varnotnull/toFlexibleType.fir.kt
@@ -14,8 +14,8 @@ class J {
 fun bar() {
     var v: String?
     v = J.foo()
-    v<!UNSAFE_CALL!>.<!>length
-    <!INAPPLICABLE_CANDIDATE!>gav<!>(v)
+    v.length
+    gav(v)
 
     var l: List<String>?
     l = J.bar()

--- a/compiler/testData/diagnostics/tests/smartCasts/varnotnull/toFlexibleType.kt
+++ b/compiler/testData/diagnostics/tests/smartCasts/varnotnull/toFlexibleType.kt
@@ -1,7 +1,12 @@
 // FILE: J.java
+import org.jetbrains.annotations.*;
+import java.util.List;
 
 class J {
     static String foo() { return "abc"; }
+
+    @NotNull
+    static List<String> bar() { return new List<String>(); }
 }
 
 // FILE: test.kt
@@ -11,6 +16,10 @@ fun bar() {
     v = J.foo()
     <!DEBUG_INFO_SMARTCAST!>v<!>.length
     gav(<!DEBUG_INFO_SMARTCAST!>v<!>)
+
+    var l: List<String>?
+    l = J.bar()
+    <!DEBUG_INFO_SMARTCAST!>l<!>.isEmpty()
 }
 
 fun gav(v: String) = v

--- a/compiler/testData/diagnostics/tests/smartCasts/varnotnull/toFlexibleType.txt
+++ b/compiler/testData/diagnostics/tests/smartCasts/varnotnull/toFlexibleType.txt
@@ -10,5 +10,6 @@ public/*package*/ open class J {
     public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
 
     // Static members
+    @org.jetbrains.annotations.NotNull public/*package*/ open fun bar(): kotlin.collections.(Mutable)List<kotlin.String!>
     public/*package*/ open fun foo(): kotlin.String!
 }

--- a/compiler/tests-spec/testData/diagnostics/linked/expressions/logical-conjunction-expression/p-2/neg/1.1.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/linked/expressions/logical-conjunction-expression/p-2/neg/1.1.fir.kt
@@ -41,7 +41,7 @@ fun case2() {
 fun case3() {
     val a1 = false
     val a2 = JavaClass.VALUE
-    <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any..kotlin.Any?! & kotlin.Any")!>a2<!>
+    <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any..kotlin.Any?!")!>a2<!>
 
     val x3 = a1 && a2
     <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Boolean")!>x3<!>

--- a/compiler/tests-spec/testData/diagnostics/linked/expressions/logical-disjunction-expression/p-2/neg/1.1.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/linked/expressions/logical-disjunction-expression/p-2/neg/1.1.fir.kt
@@ -41,7 +41,7 @@ fun case2() {
 fun case3() {
     val a1 = false
     val a2 = JavaClass.VALUE
-    <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any..kotlin.Any?! & kotlin.Any")!>a2<!>
+    <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any..kotlin.Any?!")!>a2<!>
 
     val x3 = a1 || a2
     <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Boolean")!>x3<!>

--- a/compiler/tests-spec/testData/diagnostics/linked/expressions/not-null-assertion-expression/p-3/pos/1.1.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/linked/expressions/not-null-assertion-expression/p-3/pos/1.1.fir.kt
@@ -22,7 +22,7 @@ import checkSubtype
 // TESTCASE NUMBER: 1
 fun case1() {
     val a = JavaClass.STR
-    <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.String..kotlin.String?! & kotlin.String")!>a<!>
+    <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.String..kotlin.String?!")!>a<!>
     val res = a!!
     <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.String")!>res<!>
 }
@@ -30,7 +30,7 @@ fun case1() {
 // TESTCASE NUMBER: 2
 fun case2() {
     val a = JavaClass.obj
-    <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any..kotlin.Any?! & kotlin.Any")!>a<!>
+    <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any..kotlin.Any?!")!>a<!>
     val x = a!!
     <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.Any")!>x<!>
 }


### PR DESCRIPTION
Without this, currently,
```
  it(ft(J..J?), ft(J..J?) => J
```
which should be `ft(J..J?)` instead.