### PR TITLE
FIR checker: consolidate property accessor checks

### DIFF
--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirDeclarationCheckerUtils.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirDeclarationCheckerUtils.kt
@@ -163,18 +163,6 @@ internal fun checkPropertyInitializer(
     }
 }
 
-internal fun checkPropertyAccessors(
-    property: FirProperty,
-    reporter: DiagnosticReporter,
-    context: CheckerContext
-) {
-    if (property.isVal) {
-        property.setter?.source?.let {
-            reporter.reportOn(it, FirErrors.VAL_WITH_SETTER, context)
-        }
-    }
-}
-
 private val FirProperty.hasAccessorImplementation: Boolean
     get() = (getter !is FirDefaultPropertyAccessor && getter?.hasBody == true) ||
             (setter !is FirDefaultPropertyAccessor && setter?.hasBody == true)

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirMemberPropertiesChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirMemberPropertiesChecker.kt
@@ -156,7 +156,6 @@ object FirMemberPropertiesChecker : FirRegularClassChecker() {
             reporter,
             context
         )
-        checkPropertyAccessors(property, reporter, context)
         checkExpectDeclarationVisibilityAndBody(property, source, reporter, context)
 
         val hasAbstractModifier = KtTokens.ABSTRACT_KEYWORD in modifierList

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirPropertyAccessorChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirPropertyAccessorChecker.kt
@@ -7,17 +7,21 @@ package org.jetbrains.kotlin.fir.analysis.checkers.declaration
 
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.fir.analysis.diagnostics.DiagnosticReporter
-import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.WRONG_SETTER_PARAMETER_TYPE
+import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors
 import org.jetbrains.kotlin.fir.analysis.diagnostics.reportOn
 import org.jetbrains.kotlin.fir.analysis.diagnostics.withSuppressedDiagnostics
 import org.jetbrains.kotlin.fir.declarations.FirProperty
 import org.jetbrains.kotlin.fir.types.ConeClassErrorType
 import org.jetbrains.kotlin.fir.types.coneType
 
-
 object FirPropertyAccessorChecker : FirPropertyChecker() {
     override fun check(declaration: FirProperty, context: CheckerContext, reporter: DiagnosticReporter) {
         val setter = declaration.setter ?: return
+
+        if (declaration.isVal) {
+            reporter.reportOn(setter.source, FirErrors.VAL_WITH_SETTER, context)
+        }
+
         val valueSetterParameter = setter.valueParameters.first()
         if (valueSetterParameter.isVararg) {
             return
@@ -32,7 +36,7 @@ object FirPropertyAccessorChecker : FirPropertyChecker() {
         if (valueSetterType != propertyType) {
             withSuppressedDiagnostics(setter, context) {
                 withSuppressedDiagnostics(valueSetterParameter, context) {
-                    reporter.reportOn(valueSetterTypeSource, WRONG_SETTER_PARAMETER_TYPE, propertyType, valueSetterType, context)
+                    reporter.reportOn(valueSetterTypeSource, FirErrors.WRONG_SETTER_PARAMETER_TYPE, propertyType, valueSetterType, context)
                 }
             }
         }

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirTopLevelPropertiesChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirTopLevelPropertiesChecker.kt
@@ -36,7 +36,6 @@ object FirTopLevelPropertiesChecker : FirFileChecker() {
             reporter,
             context
         )
-        checkPropertyAccessors(property, reporter, context)
         checkExpectDeclarationVisibilityAndBody(property, source, reporter, context)
     }
 }


### PR DESCRIPTION
As of #4093, property accessor checker is introduced, which will report a couple more diagnostics as per https://github.com/JetBrains/kotlin/pull/4093#discussion_r598615446. It'd be better to consolidate property accessor related checks here.