### PR TITLE
[JVM_IR] Fix range of locals in connection with finally blocks.

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/InlineCodegen.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/InlineCodegen.kt
@@ -320,8 +320,7 @@ abstract class InlineCodegen<out T : BaseExpressionCodegen>(
 
                 val splitBy = SimpleInterval(start.info as LabelNode, extension.finallyIntervalEnd)
                 processor.tryBlocksMetaInfo.splitAndRemoveCurrentIntervals(splitBy, true)
-
-                //processor.getLocalVarsMetaInfo().splitAndRemoveIntervalsFromCurrents(splitBy);
+                processor.localVarsMetaInfo.splitAndRemoveCurrentIntervals(splitBy, true);
 
                 mark.dropTo()
             }
@@ -330,8 +329,7 @@ abstract class InlineCodegen<out T : BaseExpressionCodegen>(
         }
 
         processor.substituteTryBlockNodes(intoNode)
-
-        //processor.substituteLocalVarTable(intoNode);
+        processor.substituteLocalVarTable(intoNode);
     }
 
     protected abstract fun generateAssertFieldIfNeeded(info: RootInliningContext)

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -8660,6 +8660,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
             }
 
             @Test
+            @TestMetadata("nonLocalReturnInTryFinally.kt")
+            public void testNonLocalReturnInTryFinally() throws Exception {
+                runTest("compiler/testData/codegen/box/controlStructures/tryCatchInExpressions/nonLocalReturnInTryFinally.kt");
+            }
+
+            @Test
             @TestMetadata("splitTry.kt")
             public void testSplitTry() throws Exception {
                 runTest("compiler/testData/codegen/box/controlStructures/tryCatchInExpressions/splitTry.kt");

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -423,7 +423,7 @@ class ExpressionCodegen(
         }
     }
 
-    private fun addLocalVariableGapsForFinallyBlocks(
+    private fun splitLocalVariableRangesByFinallyBlocks(
         info: BlockInfo,
         tryWithFinallyInfo: TryWithFinallyInfo,
         gapStart: Label,
@@ -1276,7 +1276,7 @@ class ExpressionCodegen(
         // Split the local variables for the blocks on the way to the finally. Variables introduced in these blocks do not
         // cover the finally block code.
         val endOfFinallyCode = markNewLinkedLabel()
-        addLocalVariableGapsForFinallyBlocks(data, tryWithFinallyInfo, gapStart, endOfFinallyCode)
+        splitLocalVariableRangesByFinallyBlocks(data, tryWithFinallyInfo, gapStart, endOfFinallyCode)
 
         val gapEnd = afterJumpLabel ?: endOfFinallyCode
         tryWithFinallyInfo.gaps.add(gapStart to gapEnd)

--- a/compiler/testData/codegen/box/controlStructures/tryCatchInExpressions/nonLocalReturnInTryFinally.kt
+++ b/compiler/testData/codegen/box/controlStructures/tryCatchInExpressions/nonLocalReturnInTryFinally.kt
@@ -1,0 +1,14 @@
+inline fun g(block: () -> Unit): Unit = block()
+
+fun box(): String {
+    try {
+        for (c in emptyArray<String>()) {
+            g {
+                for (d in emptyArray<Int>()) {
+                    return "Fail"
+                }
+            }
+        }
+    } finally {}
+    return "OK"
+}

--- a/compiler/testData/debug/localVariables/tryFinally.kt
+++ b/compiler/testData/debug/localVariables/tryFinally.kt
@@ -1,0 +1,28 @@
+// FILE: test.kt
+fun box() {
+    var result = ""
+    for (x in listOf("A", "B")) {
+        try {
+            val y = "y"
+            result += y
+            break
+        }
+        finally {
+            val z = "z"
+            result += z
+        }
+    }
+}
+
+// The old backend has the local y covering the finally block as well.
+// IGNORE_BACKEND: JVM
+
+// LOCAL VARIABLES
+// test.kt:3 box:
+// test.kt:4 box: result:java.lang.String="":java.lang.String
+// test.kt:5 box: result:java.lang.String="":java.lang.String, x:java.lang.String="A":java.lang.String
+// test.kt:6 box: result:java.lang.String="":java.lang.String, x:java.lang.String="A":java.lang.String
+// test.kt:7 box: result:java.lang.String="":java.lang.String, x:java.lang.String="A":java.lang.String, y:java.lang.String="y":java.lang.String
+// test.kt:11 box: result:java.lang.String="y":java.lang.String, x:java.lang.String="A":java.lang.String
+// test.kt:12 box: result:java.lang.String="y":java.lang.String, x:java.lang.String="A":java.lang.String, z:java.lang.String="z":java.lang.String
+// test.kt:15 box: result:java.lang.String="yz":java.lang.String

--- a/compiler/testData/debug/localVariables/tryFinally10.kt
+++ b/compiler/testData/debug/localVariables/tryFinally10.kt
@@ -1,0 +1,55 @@
+// FILE: test.kt
+
+inline fun f(block: () -> Unit) {
+    try {
+        val z = 32
+        for (j in 0 until 1) {
+            return
+        }
+    } finally {
+        block()
+    }
+}
+
+var x: String = ""
+
+fun compute(): String {
+    try {
+        val y = 42
+        for (i in 0 until 1) {
+            f {
+                return "NON_LOCAL_RETURN"
+            }
+        }
+    } finally {
+        val s2 = "OK"
+        x = s2  // TODO: Why is `s2` not visible here?
+    }
+    return "FAIL"
+}
+
+fun box() {
+    val result = compute()
+    val localX = x
+}
+
+// The local variables `y` and `i` are visible in the finally block with old backend.
+// IGNORE_BACKEND: JVM
+
+// LOCAL VARIABLES
+// test.kt:32 box:
+// test.kt:17 compute:
+// test.kt:18 compute:
+// test.kt:19 compute: y:int=42:int
+// test.kt:20 compute: y:int=42:int, i:int=0:int
+// test.kt:4 compute: y:int=42:int, i:int=0:int, $i$f$f:int=0:int
+// test.kt:5 compute: y:int=42:int, i:int=0:int, $i$f$f:int=0:int
+// test.kt:6 compute: y:int=42:int, i:int=0:int, $i$f$f:int=0:int, z$iv:int=32:int
+// test.kt:7 compute: y:int=42:int, i:int=0:int, $i$f$f:int=0:int, z$iv:int=32:int, j$iv:int=0:int
+// test.kt:10 compute: y:int=42:int, i:int=0:int, $i$f$f:int=0:int
+// test.kt:21 compute: y:int=42:int, i:int=0:int, $i$f$f:int=0:int, $i$a$-f-TestKt$compute$1:int=0:int
+// test.kt:25 compute:
+// test.kt:26 compute:
+// test.kt:32 box:
+// test.kt:33 box: result:java.lang.String="NON_LOCAL_RETURN":java.lang.String
+// test.kt:34 box: result:java.lang.String="NON_LOCAL_RETURN":java.lang.String, localX:java.lang.String="OK":java.lang.String

--- a/compiler/testData/debug/localVariables/tryFinally11.kt
+++ b/compiler/testData/debug/localVariables/tryFinally11.kt
@@ -1,0 +1,37 @@
+// FILE: test.kt
+
+fun box(): String {
+    try {
+        for (i in 0 until 1) {
+            try {
+                val x = "x"
+                throw RuntimeException(x)
+            } catch (e: Exception) {
+                val y = "y"
+                val z = "z"
+                break  // TODO: why does the break not have a line number so we can stop on it?
+            } finally {
+                throw RuntimeException("$i")  // TODO: `e` should not be visible here
+            }
+        }
+    } finally {
+        return "OK"
+    }  // TODO: why do we go to this line before going to the line above for the finally block.
+    return "FAIL"
+}
+
+// The local variables `z` and `y` are visible in the finally block with old backend.
+// IGNORE_BACKEND: JVM
+
+// LOCAL VARIABLES
+// test.kt:4 box:
+// test.kt:5 box:
+// test.kt:6 box: i:int=0:int
+// test.kt:7 box: i:int=0:int
+// test.kt:8 box: i:int=0:int, x:java.lang.String="x":java.lang.String
+// test.kt:9 box: i:int=0:int
+// test.kt:10 box: i:int=0:int, e:java.lang.Exception=java.lang.RuntimeException
+// test.kt:11 box: i:int=0:int, e:java.lang.Exception=java.lang.RuntimeException, y:java.lang.String="y":java.lang.String
+// test.kt:14 box: i:int=0:int, e:java.lang.Exception=java.lang.RuntimeException
+// test.kt:19 box:
+// test.kt:18 box:

--- a/compiler/testData/debug/localVariables/tryFinally12.kt
+++ b/compiler/testData/debug/localVariables/tryFinally12.kt
@@ -1,0 +1,38 @@
+// FILE: test.kt
+
+fun box(): String {
+    try {
+        for (i in 0 until 1) {
+            try {
+                val x = "x"
+                throw RuntimeException(x)
+            } catch (e: Exception) {
+                val y = "y"
+                val z = "z"
+                continue  // TODO: why does the continue not have a line number so we stop here?
+            } finally {
+                throw RuntimeException("$i")  // TODO: `e` should not be visible here
+            }
+        }
+    } finally {
+        return "OK"
+    }  // TODO: why stop here before the line above for the finally block?
+    return "FAIL"
+}
+
+// The local variables `z` and `y` are visible in the finally block with old backend.
+// IGNORE_BACKEND: JVM
+
+// LOCAL VARIABLES
+// test.kt:4 box:
+// test.kt:5 box:
+// test.kt:6 box: i:int=0:int
+// test.kt:7 box: i:int=0:int
+// test.kt:8 box: i:int=0:int, x:java.lang.String="x":java.lang.String
+// test.kt:9 box: i:int=0:int
+// test.kt:10 box: i:int=0:int, e:java.lang.Exception=java.lang.RuntimeException
+// test.kt:11 box: i:int=0:int, e:java.lang.Exception=java.lang.RuntimeException, y:java.lang.String="y":java.lang.String
+// test.kt:14 box: i:int=0:int, e:java.lang.Exception=java.lang.RuntimeException
+// test.kt:19 box:
+// test.kt:18 box:
+

--- a/compiler/testData/debug/localVariables/tryFinally13.kt
+++ b/compiler/testData/debug/localVariables/tryFinally13.kt
@@ -1,0 +1,36 @@
+// FILE: test.kt
+
+fun box(): String {
+    try {
+        for (i in 0 until 1) {
+            try {
+                val x = "x"
+                throw RuntimeException(x)
+            } catch (e: Exception) {
+                val y = "y"
+                return "FAIL1"
+            } finally {
+                return "FAIL2"  // TODO: `e` should not be visible here.
+            }
+        }
+    } finally {
+        return "OK"  // TODO: `e` should not be visible here.
+    }
+    return "FAIL3"
+}
+
+// The local variables `y` and `i` are visible in finally blocks with old backend.
+// IGNORE_BACKEND: JVM
+
+// LOCAL VARIABLES
+// test.kt:4 box:
+// test.kt:5 box:
+// test.kt:6 box: i:int=0:int
+// test.kt:7 box: i:int=0:int
+// test.kt:8 box: i:int=0:int, x:java.lang.String="x":java.lang.String
+// test.kt:9 box: i:int=0:int
+// test.kt:10 box: i:int=0:int, e:java.lang.Exception=java.lang.RuntimeException
+// test.kt:11 box: i:int=0:int, e:java.lang.Exception=java.lang.RuntimeException, y:java.lang.String="y":java.lang.String
+// test.kt:13 box: i:int=0:int, e:java.lang.Exception=java.lang.RuntimeException
+// test.kt:17 box: e:java.lang.Exception=java.lang.RuntimeException
+

--- a/compiler/testData/debug/localVariables/tryFinally14.kt
+++ b/compiler/testData/debug/localVariables/tryFinally14.kt
@@ -1,0 +1,26 @@
+// FILE: test.kt
+
+fun box(): String {
+    try {
+        for (i in 0 until 1) {
+            try {
+                val x = "x"
+                var y = "y"
+            } finally {
+                break
+            }
+        }
+    } finally {
+        return "OK"
+    }
+    return "FAIL"
+}
+
+// LOCAL VARIABLES
+// test.kt:4 box:
+// test.kt:5 box:
+// test.kt:6 box: i:int=0:int
+// test.kt:7 box: i:int=0:int
+// test.kt:8 box: i:int=0:int, x:java.lang.String="x":java.lang.String
+// test.kt:10 box: i:int=0:int
+// test.kt:14 box:

--- a/compiler/testData/debug/localVariables/tryFinally15.kt
+++ b/compiler/testData/debug/localVariables/tryFinally15.kt
@@ -1,0 +1,27 @@
+// FILE: test.kt
+
+fun box(): String {
+    try {
+        for (i in 0 until 1) {
+            try {
+                val x = "x"
+                val y = "y"
+            } finally {
+                continue
+            }
+        }
+    } finally {
+        return "OK"
+    }
+    return "FAIL"
+}
+
+// LOCAL VARIABLES
+// test.kt:4 box:
+// test.kt:5 box:
+// test.kt:6 box: i:int=0:int
+// test.kt:7 box: i:int=0:int
+// test.kt:8 box: i:int=0:int, x:java.lang.String="x":java.lang.String
+// test.kt:10 box: i:int=0:int
+// test.kt:5 box: i:int=0:int
+// test.kt:14 box:

--- a/compiler/testData/debug/localVariables/tryFinally16.kt
+++ b/compiler/testData/debug/localVariables/tryFinally16.kt
@@ -1,0 +1,29 @@
+// FILE: test.kt
+
+fun box(): String {
+    try {
+        for (i in 0 until 1) {
+            try {
+                val x = "x"
+                val y = "y"
+            } finally {
+                return "FAIL1"
+            }
+        }
+    } finally {
+        return "OK"
+    }
+    return "FAIL2"
+}
+
+// The local `i` is visible in the finally block with old backend.
+// IGNORE_BACKEND: JVM
+
+// LOCAL VARIABLES
+// test.kt:4 box:
+// test.kt:5 box:
+// test.kt:6 box: i:int=0:int
+// test.kt:7 box: i:int=0:int
+// test.kt:8 box: i:int=0:int, x:java.lang.String="x":java.lang.String
+// test.kt:10 box: i:int=0:int
+// test.kt:14 box:

--- a/compiler/testData/debug/localVariables/tryFinally2.kt
+++ b/compiler/testData/debug/localVariables/tryFinally2.kt
@@ -1,0 +1,35 @@
+// FILE: test.kt
+fun box() {
+    var result = ""
+    for (x in listOf("A", "B")) {
+        try {
+            val y = "y"
+            result += y
+            continue
+        }
+        finally {
+            val z = "z"
+            result += z
+        }
+    }
+}
+
+// The old backend has the local y covering the finally block as well.
+// IGNORE_BACKEND: JVM
+
+// LOCAL VARIABLES
+// test.kt:3 box:
+// test.kt:4 box: result:java.lang.String="":java.lang.String
+// test.kt:5 box: result:java.lang.String="":java.lang.String, x:java.lang.String="A":java.lang.String
+// test.kt:6 box: result:java.lang.String="":java.lang.String, x:java.lang.String="A":java.lang.String
+// test.kt:7 box: result:java.lang.String="":java.lang.String, x:java.lang.String="A":java.lang.String, y:java.lang.String="y":java.lang.String
+// test.kt:11 box: result:java.lang.String="y":java.lang.String, x:java.lang.String="A":java.lang.String
+// test.kt:12 box: result:java.lang.String="y":java.lang.String, x:java.lang.String="A":java.lang.String, z:java.lang.String="z":java.lang.String
+// test.kt:4 box: result:java.lang.String="yz":java.lang.String
+// test.kt:5 box: result:java.lang.String="yz":java.lang.String, x:java.lang.String="B":java.lang.String
+// test.kt:6 box: result:java.lang.String="yz":java.lang.String, x:java.lang.String="B":java.lang.String
+// test.kt:7 box: result:java.lang.String="yz":java.lang.String, x:java.lang.String="B":java.lang.String, y:java.lang.String="y":java.lang.String
+// test.kt:11 box: result:java.lang.String="yzy":java.lang.String, x:java.lang.String="B":java.lang.String
+// test.kt:12 box: result:java.lang.String="yzy":java.lang.String, x:java.lang.String="B":java.lang.String, z:java.lang.String="z":java.lang.String
+// test.kt:4 box: result:java.lang.String="yzyz":java.lang.String
+// test.kt:15 box: result:java.lang.String="yzyz":java.lang.String

--- a/compiler/testData/debug/localVariables/tryFinally3.kt
+++ b/compiler/testData/debug/localVariables/tryFinally3.kt
@@ -1,0 +1,38 @@
+// FILE: test.kt
+
+fun compute(): String {
+    var result = ""
+    for (x in listOf("A", "B")) {
+        try {
+            val y = "y"
+            result += y
+            return result
+        }
+        finally {
+            val z = "z"
+            result += z
+        }
+    }
+    return result
+}
+
+fun box() {
+    compute()
+}
+
+// The old backend has the local y covering the finally block as well.
+// IGNORE_BACKEND: JVM
+
+// LOCAL VARIABLES
+// test.kt:20 box:
+// test.kt:4 compute:
+// test.kt:5 compute: result:java.lang.String="":java.lang.String
+// test.kt:6 compute: result:java.lang.String="":java.lang.String, x:java.lang.String="A":java.lang.String
+// test.kt:7 compute: result:java.lang.String="":java.lang.String, x:java.lang.String="A":java.lang.String
+// test.kt:8 compute: result:java.lang.String="":java.lang.String, x:java.lang.String="A":java.lang.String, y:java.lang.String="y":java.lang.String
+// test.kt:9 compute: result:java.lang.String="y":java.lang.String, x:java.lang.String="A":java.lang.String, y:java.lang.String="y":java.lang.String
+// test.kt:12 compute: result:java.lang.String="y":java.lang.String, x:java.lang.String="A":java.lang.String
+// test.kt:13 compute: result:java.lang.String="y":java.lang.String, x:java.lang.String="A":java.lang.String, z:java.lang.String="z":java.lang.String
+// test.kt:9 compute: result:java.lang.String="yz":java.lang.String, x:java.lang.String="A":java.lang.String, y:java.lang.String="y":java.lang.String
+// test.kt:20 box:
+// test.kt:21 box:

--- a/compiler/testData/debug/localVariables/tryFinally4.kt
+++ b/compiler/testData/debug/localVariables/tryFinally4.kt
@@ -1,0 +1,49 @@
+// FILE: test.kt
+
+fun compute(): String {
+    var result = ""
+    try {
+        val a = "a"
+        try {
+            val b = "b"
+            for (i in 0 until 1) {
+                val e = "e"
+                result += b
+                return result
+            }
+        } finally {
+            val c = "c"
+            result += c
+        }
+    } finally {
+        val d = "d"
+        result += d
+    }
+    return result
+}
+
+fun box() {
+    compute()
+}
+
+// The old backend gets the local variables for finally blocks wrong.
+// IGNORE_BACKEND: JVM
+
+// LOCAL VARIABLES
+// test.kt:26 box:
+// test.kt:4 compute:
+// test.kt:5 compute: result:java.lang.String="":java.lang.String
+// test.kt:6 compute: result:java.lang.String="":java.lang.String
+// test.kt:7 compute: result:java.lang.String="":java.lang.String, a:java.lang.String="a":java.lang.String
+// test.kt:8 compute: result:java.lang.String="":java.lang.String, a:java.lang.String="a":java.lang.String
+// test.kt:9 compute: result:java.lang.String="":java.lang.String, a:java.lang.String="a":java.lang.String, b:java.lang.String="b":java.lang.String
+// test.kt:10 compute: result:java.lang.String="":java.lang.String, a:java.lang.String="a":java.lang.String, b:java.lang.String="b":java.lang.String, i:int=0:int
+// test.kt:11 compute: result:java.lang.String="":java.lang.String, a:java.lang.String="a":java.lang.String, b:java.lang.String="b":java.lang.String, i:int=0:int, e:java.lang.String="e":java.lang.String
+// test.kt:12 compute: result:java.lang.String="b":java.lang.String, a:java.lang.String="a":java.lang.String, b:java.lang.String="b":java.lang.String, i:int=0:int, e:java.lang.String="e":java.lang.String
+// test.kt:15 compute: result:java.lang.String="b":java.lang.String, a:java.lang.String="a":java.lang.String
+// test.kt:16 compute: result:java.lang.String="b":java.lang.String, a:java.lang.String="a":java.lang.String, c:java.lang.String="c":java.lang.String
+// test.kt:19 compute: result:java.lang.String="bc":java.lang.String
+// test.kt:20 compute: result:java.lang.String="bc":java.lang.String, d:java.lang.String="d":java.lang.String
+// test.kt:12 compute: result:java.lang.String="bcd":java.lang.String, a:java.lang.String="a":java.lang.String, b:java.lang.String="b":java.lang.String, i:int=0:int, e:java.lang.String="e":java.lang.String
+// test.kt:26 box:
+// test.kt:27 box:

--- a/compiler/testData/debug/localVariables/tryFinally5.kt
+++ b/compiler/testData/debug/localVariables/tryFinally5.kt
@@ -1,0 +1,48 @@
+// FILE: test.kt
+
+inline fun g(block: () -> Unit) {
+    block()
+}
+
+var x: String? = null
+
+fun compute(): String {
+    try {
+        for (a in listOf("a")) {
+            g {
+                for (b in listOf("b")) {
+                    return b
+                }
+            }
+        }
+    } finally {
+        x = "OK"
+    }
+    return "FAIL"
+}
+
+fun box() {
+    val result = compute()
+    val localX = x
+}
+
+// JVM_IR backend correctly gets rid of the `a` local in the finally, but the inliner
+// does not get rid of `b` or the inlining locals.
+
+// JVM backend does not get rid of `a` and also the inliner does not get rid of `b`
+// or the inlining locals.
+
+// IGNORE_BACKEND: JVM_IR, JVM
+
+// LOCAL VARIABLES
+// test.kt:25 box:
+// test.kt:10 compute:
+// test.kt:11 compute:
+// test.kt:12 compute: a:java.lang.String="a":java.lang.String
+// test.kt:4 compute: a:java.lang.String="a":java.lang.String, $i$f$g:int=0:int
+// test.kt:13 compute: a:java.lang.String="a":java.lang.String, $i$f$g:int=0:int, $i$a$-g-TestKt$compute$1:int=0:int
+// test.kt:14 compute: a:java.lang.String="a":java.lang.String, $i$f$g:int=0:int, $i$a$-g-TestKt$compute$1:int=0:int, b:java.lang.String="b":java.lang.String
+// test.kt:19 compute:
+// test.kt:25 box:
+// test.kt:26 box: result:java.lang.String="b":java.lang.String
+// test.kt:27 box: result:java.lang.String="b":java.lang.String, localX:java.lang.String="OK":java.lang.String

--- a/compiler/testData/debug/localVariables/tryFinally5.kt
+++ b/compiler/testData/debug/localVariables/tryFinally5.kt
@@ -26,13 +26,9 @@ fun box() {
     val localX = x
 }
 
-// JVM_IR backend correctly gets rid of the `a` local in the finally, but the inliner
-// does not get rid of `b` or the inlining locals.
+// JVM backend has the `a` local covering the finally block. It shouldn't.
 
-// JVM backend does not get rid of `a` and also the inliner does not get rid of `b`
-// or the inlining locals.
-
-// IGNORE_BACKEND: JVM_IR, JVM
+// IGNORE_BACKEND: JVM
 
 // LOCAL VARIABLES
 // test.kt:25 box:

--- a/compiler/testData/debug/localVariables/tryFinally6.kt
+++ b/compiler/testData/debug/localVariables/tryFinally6.kt
@@ -1,0 +1,64 @@
+// FILE: test.kt
+
+inline fun h(block: () -> Unit) {
+    try {
+        val hLocal = "hLocal"
+        block()
+    } finally {
+        val h = "h"
+    }
+}
+
+inline fun g(block: () -> Unit) {
+    try {
+        val gLocal = "gLocal"
+        h(block)
+    } finally {
+        val g = "g"
+    }
+}
+
+var x: String? = null
+
+fun compute(): String {
+    try {
+        for (a in listOf("a")) {
+            g {
+                for (b in listOf("b")) {
+                    return b
+                }
+            }
+        }
+    } finally {
+        x = "OK"
+    }
+    return "FAIL"
+}
+
+fun box() {
+    val result = compute()
+    val localX = x
+}
+
+// JVM backend has `a` visible in the `compute` finally block. It shouldn't be.
+// IGNORE_BACKEND: JVM
+
+// LOCAL VARIABLES
+// test.kt:39 box:
+// test.kt:24 compute:
+// test.kt:25 compute:
+// test.kt:26 compute: a:java.lang.String="a":java.lang.String
+// test.kt:13 compute: a:java.lang.String="a":java.lang.String, $i$f$g:int=0:int
+// test.kt:14 compute: a:java.lang.String="a":java.lang.String, $i$f$g:int=0:int
+// test.kt:15 compute: a:java.lang.String="a":java.lang.String, $i$f$g:int=0:int, gLocal$iv:java.lang.String="gLocal":java.lang.String
+// test.kt:4 compute: a:java.lang.String="a":java.lang.String, $i$f$g:int=0:int, gLocal$iv:java.lang.String="gLocal":java.lang.String, $i$f$h:int=0:int
+// test.kt:5 compute: a:java.lang.String="a":java.lang.String, $i$f$g:int=0:int, gLocal$iv:java.lang.String="gLocal":java.lang.String, $i$f$h:int=0:int
+// test.kt:6 compute: a:java.lang.String="a":java.lang.String, $i$f$g:int=0:int, gLocal$iv:java.lang.String="gLocal":java.lang.String, $i$f$h:int=0:int, hLocal$iv$iv:java.lang.String="hLocal":java.lang.String
+// test.kt:27 compute: a:java.lang.String="a":java.lang.String, $i$f$g:int=0:int, gLocal$iv:java.lang.String="gLocal":java.lang.String, $i$f$h:int=0:int, hLocal$iv$iv:java.lang.String="hLocal":java.lang.String, $i$a$-g-TestKt$compute$1:int=0:int
+// test.kt:28 compute: a:java.lang.String="a":java.lang.String, $i$f$g:int=0:int, gLocal$iv:java.lang.String="gLocal":java.lang.String, $i$f$h:int=0:int, hLocal$iv$iv:java.lang.String="hLocal":java.lang.String, $i$a$-g-TestKt$compute$1:int=0:int, b:java.lang.String="b":java.lang.String
+// test.kt:8 compute: a:java.lang.String="a":java.lang.String
+// test.kt:17 compute: a:java.lang.String="a":java.lang.String
+// test.kt:33 compute:
+// test.kt:39 box:
+// test.kt:40 box: result:java.lang.String="b":java.lang.String
+// test.kt:41 box: result:java.lang.String="b":java.lang.String, localX:java.lang.String="OK":java.lang.String

--- a/compiler/testData/debug/localVariables/tryFinally7.kt
+++ b/compiler/testData/debug/localVariables/tryFinally7.kt
@@ -1,0 +1,51 @@
+// FILE: test.kt
+
+inline fun f(block: () -> Unit) {
+    block()
+}
+
+var x: String = ""
+
+fun compute(): String {
+    try {
+        val y = 42
+        for (i in 0 until 1) {
+            throw RuntimeException("$y $i")
+        }
+    } catch (e: Exception) {
+        val y = 32
+        for (j in 0 until 1) {
+            f {
+                return "NON_LOCAL_RETURN"
+            }
+        }
+    } finally {
+        x = "OK"
+    }
+    return "FAIL"
+}
+
+fun box() {
+    val result = compute()
+    val localX = x
+}
+
+// The old backend has `y` and `j` visible on the finally block.
+// IGNORE_BACKEND: JVM
+
+// LOCAL VARIABLES
+// test.kt:29 box:
+// test.kt:10 compute:
+// test.kt:11 compute:
+// test.kt:12 compute: y:int=42:int
+// test.kt:13 compute: y:int=42:int, i:int=0:int
+// test.kt:15 compute:
+// test.kt:16 compute: e:java.lang.Exception=java.lang.RuntimeException
+// test.kt:17 compute: e:java.lang.Exception=java.lang.RuntimeException, y:int=32:int
+// test.kt:18 compute: e:java.lang.Exception=java.lang.RuntimeException, y:int=32:int, j:int=0:int
+// test.kt:4 compute: e:java.lang.Exception=java.lang.RuntimeException, y:int=32:int, j:int=0:int, $i$f$f:int=0:int
+// test.kt:19 compute: e:java.lang.Exception=java.lang.RuntimeException, y:int=32:int, j:int=0:int, $i$f$f:int=0:int, $i$a$-f-TestKt$compute$1:int=0:int
+// test.kt:23 compute: e:java.lang.Exception=java.lang.RuntimeException
+// test.kt:29 box:
+// test.kt:30 box: result:java.lang.String="NON_LOCAL_RETURN":java.lang.String
+// test.kt:31 box: result:java.lang.String="NON_LOCAL_RETURN":java.lang.String, localX:java.lang.String="OK":java.lang.String

--- a/compiler/testData/debug/localVariables/tryFinally7.kt
+++ b/compiler/testData/debug/localVariables/tryFinally7.kt
@@ -20,7 +20,7 @@ fun compute(): String {
             }
         }
     } finally {
-        x = "OK"
+        x = "OK"  // TODO: `e` should not be visible here.
     }
     return "FAIL"
 }

--- a/compiler/testData/debug/localVariables/tryFinally8.kt
+++ b/compiler/testData/debug/localVariables/tryFinally8.kt
@@ -1,0 +1,54 @@
+// FILE: test.kt
+
+inline fun f(block: () -> Unit) {
+    try {
+        val z = 32
+        for (j in 0 until 1) {
+            throw RuntimeException("$z $j")
+        }
+    } catch (e: Exception) {
+        block()
+    }
+}
+
+var x: String = ""
+
+fun compute(): String {
+    try {
+        val y = 42
+        for (i in 0 until 1) {
+            f {
+                return "NON_LOCAL_RETURN"
+            }
+        }
+    } finally {
+        x = "OK"
+    }
+    return "FAIL"
+}
+
+fun box() {
+    val result = compute()
+    val localX = x
+}
+
+// The old backend has `y` and `i` visible on the finally block.
+// IGNORE_BACKEND: JVM
+
+// LOCAL VARIABLES
+// test.kt:31 box:
+// test.kt:17 compute:
+// test.kt:18 compute:
+// test.kt:19 compute: y:int=42:int
+// test.kt:20 compute: y:int=42:int, i:int=0:int
+// test.kt:4 compute: y:int=42:int, i:int=0:int, $i$f$f:int=0:int
+// test.kt:5 compute: y:int=42:int, i:int=0:int, $i$f$f:int=0:int
+// test.kt:6 compute: y:int=42:int, i:int=0:int, $i$f$f:int=0:int, z$iv:int=32:int
+// test.kt:7 compute: y:int=42:int, i:int=0:int, $i$f$f:int=0:int, z$iv:int=32:int, j$iv:int=0:int
+// test.kt:9 compute: y:int=42:int, i:int=0:int, $i$f$f:int=0:int
+// test.kt:10 compute: y:int=42:int, i:int=0:int, $i$f$f:int=0:int, e$iv:java.lang.Exception=java.lang.RuntimeException
+// test.kt:21 compute: y:int=42:int, i:int=0:int, $i$f$f:int=0:int, e$iv:java.lang.Exception=java.lang.RuntimeException, $i$a$-f-TestKt$compute$1:int=0:int
+// test.kt:25 compute:
+// test.kt:31 box:
+// test.kt:32 box: result:java.lang.String="NON_LOCAL_RETURN":java.lang.String
+// test.kt:33 box: result:java.lang.String="NON_LOCAL_RETURN":java.lang.String, localX:java.lang.String="OK":java.lang.String

--- a/compiler/testData/debug/localVariables/tryFinally9.kt
+++ b/compiler/testData/debug/localVariables/tryFinally9.kt
@@ -1,0 +1,54 @@
+// FILE: test.kt
+
+inline fun f(block: () -> Unit) {
+    block()
+}
+
+var x: String = ""
+
+fun compute(): String {
+    try {
+        try {
+            val y = 42
+            for (i in 0 until 1) {
+                return "NORMAL_RETURN"
+            }
+        } finally {
+            var s = "NOPE"
+            x = s
+            f {
+                return "NON_LOCAL_RETURN"
+            }
+        }
+    } finally {
+        val s2 = "OK"
+        x = s2  // TODO: Why is `s2` not visible here?
+    }
+    return "FAIL"
+}
+
+fun box() {
+    val result = compute()
+    val localX = x
+}
+
+// The local variables in the try and finally blocks are not removed for the finally block with the old backend.
+// IGNORE_BACKEND: JVM
+
+// LOCAL VARIABLES
+// test.kt:31 box:
+// test.kt:10 compute:
+// test.kt:11 compute:
+// test.kt:12 compute:
+// test.kt:13 compute: y:int=42:int
+// test.kt:14 compute: y:int=42:int, i:int=0:int
+// test.kt:17 compute:
+// test.kt:18 compute: s:java.lang.String="NOPE":java.lang.String
+// test.kt:19 compute: s:java.lang.String="NOPE":java.lang.String
+// test.kt:4 compute: s:java.lang.String="NOPE":java.lang.String, $i$f$f:int=0:int
+// test.kt:20 compute: s:java.lang.String="NOPE":java.lang.String, $i$f$f:int=0:int, $i$a$-f-TestKt$compute$1:int=0:int
+// test.kt:24 compute:
+// test.kt:25 compute:
+// test.kt:31 box:
+// test.kt:32 box: result:java.lang.String="NON_LOCAL_RETURN":java.lang.String
+// test.kt:33 box: result:java.lang.String="NON_LOCAL_RETURN":java.lang.String, localX:java.lang.String="OK":java.lang.String

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -8660,6 +8660,12 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             }
 
             @Test
+            @TestMetadata("nonLocalReturnInTryFinally.kt")
+            public void testNonLocalReturnInTryFinally() throws Exception {
+                runTest("compiler/testData/codegen/box/controlStructures/tryCatchInExpressions/nonLocalReturnInTryFinally.kt");
+            }
+
+            @Test
             @TestMetadata("splitTry.kt")
             public void testSplitTry() throws Exception {
                 runTest("compiler/testData/codegen/box/controlStructures/tryCatchInExpressions/splitTry.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -8660,6 +8660,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             }
 
             @Test
+            @TestMetadata("nonLocalReturnInTryFinally.kt")
+            public void testNonLocalReturnInTryFinally() throws Exception {
+                runTest("compiler/testData/codegen/box/controlStructures/tryCatchInExpressions/nonLocalReturnInTryFinally.kt");
+            }
+
+            @Test
             @TestMetadata("splitTry.kt")
             public void testSplitTry() throws Exception {
                 runTest("compiler/testData/codegen/box/controlStructures/tryCatchInExpressions/splitTry.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -6725,6 +6725,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
                 runTest("compiler/testData/codegen/box/controlStructures/tryCatchInExpressions/multipleCatchBlocks.kt");
             }
 
+            @TestMetadata("nonLocalReturnInTryFinally.kt")
+            public void testNonLocalReturnInTryFinally() throws Exception {
+                runTest("compiler/testData/codegen/box/controlStructures/tryCatchInExpressions/nonLocalReturnInTryFinally.kt");
+            }
+
             @TestMetadata("splitTry.kt")
             public void testSplitTry() throws Exception {
                 runTest("compiler/testData/codegen/box/controlStructures/tryCatchInExpressions/splitTry.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/debugInformation/IrLocalVariableTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/debugInformation/IrLocalVariableTestGenerated.java
@@ -93,6 +93,12 @@ public class IrLocalVariableTestGenerated extends AbstractIrLocalVariableTest {
     }
 
     @Test
+    @TestMetadata("tryFinally10.kt")
+    public void testTryFinally10() throws Exception {
+        runTest("compiler/testData/debug/localVariables/tryFinally10.kt");
+    }
+
+    @Test
     @TestMetadata("tryFinally2.kt")
     public void testTryFinally2() throws Exception {
         runTest("compiler/testData/debug/localVariables/tryFinally2.kt");
@@ -114,6 +120,30 @@ public class IrLocalVariableTestGenerated extends AbstractIrLocalVariableTest {
     @TestMetadata("tryFinally5.kt")
     public void testTryFinally5() throws Exception {
         runTest("compiler/testData/debug/localVariables/tryFinally5.kt");
+    }
+
+    @Test
+    @TestMetadata("tryFinally6.kt")
+    public void testTryFinally6() throws Exception {
+        runTest("compiler/testData/debug/localVariables/tryFinally6.kt");
+    }
+
+    @Test
+    @TestMetadata("tryFinally7.kt")
+    public void testTryFinally7() throws Exception {
+        runTest("compiler/testData/debug/localVariables/tryFinally7.kt");
+    }
+
+    @Test
+    @TestMetadata("tryFinally8.kt")
+    public void testTryFinally8() throws Exception {
+        runTest("compiler/testData/debug/localVariables/tryFinally8.kt");
+    }
+
+    @Test
+    @TestMetadata("tryFinally9.kt")
+    public void testTryFinally9() throws Exception {
+        runTest("compiler/testData/debug/localVariables/tryFinally9.kt");
     }
 
     @Test

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/debugInformation/IrLocalVariableTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/debugInformation/IrLocalVariableTestGenerated.java
@@ -87,6 +87,36 @@ public class IrLocalVariableTestGenerated extends AbstractIrLocalVariableTest {
     }
 
     @Test
+    @TestMetadata("tryFinally.kt")
+    public void testTryFinally() throws Exception {
+        runTest("compiler/testData/debug/localVariables/tryFinally.kt");
+    }
+
+    @Test
+    @TestMetadata("tryFinally2.kt")
+    public void testTryFinally2() throws Exception {
+        runTest("compiler/testData/debug/localVariables/tryFinally2.kt");
+    }
+
+    @Test
+    @TestMetadata("tryFinally3.kt")
+    public void testTryFinally3() throws Exception {
+        runTest("compiler/testData/debug/localVariables/tryFinally3.kt");
+    }
+
+    @Test
+    @TestMetadata("tryFinally4.kt")
+    public void testTryFinally4() throws Exception {
+        runTest("compiler/testData/debug/localVariables/tryFinally4.kt");
+    }
+
+    @Test
+    @TestMetadata("tryFinally5.kt")
+    public void testTryFinally5() throws Exception {
+        runTest("compiler/testData/debug/localVariables/tryFinally5.kt");
+    }
+
+    @Test
     @TestMetadata("underscoreNames.kt")
     public void testUnderscoreNames() throws Exception {
         runTest("compiler/testData/debug/localVariables/underscoreNames.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/debugInformation/IrLocalVariableTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/debugInformation/IrLocalVariableTestGenerated.java
@@ -99,6 +99,42 @@ public class IrLocalVariableTestGenerated extends AbstractIrLocalVariableTest {
     }
 
     @Test
+    @TestMetadata("tryFinally11.kt")
+    public void testTryFinally11() throws Exception {
+        runTest("compiler/testData/debug/localVariables/tryFinally11.kt");
+    }
+
+    @Test
+    @TestMetadata("tryFinally12.kt")
+    public void testTryFinally12() throws Exception {
+        runTest("compiler/testData/debug/localVariables/tryFinally12.kt");
+    }
+
+    @Test
+    @TestMetadata("tryFinally13.kt")
+    public void testTryFinally13() throws Exception {
+        runTest("compiler/testData/debug/localVariables/tryFinally13.kt");
+    }
+
+    @Test
+    @TestMetadata("tryFinally14.kt")
+    public void testTryFinally14() throws Exception {
+        runTest("compiler/testData/debug/localVariables/tryFinally14.kt");
+    }
+
+    @Test
+    @TestMetadata("tryFinally15.kt")
+    public void testTryFinally15() throws Exception {
+        runTest("compiler/testData/debug/localVariables/tryFinally15.kt");
+    }
+
+    @Test
+    @TestMetadata("tryFinally16.kt")
+    public void testTryFinally16() throws Exception {
+        runTest("compiler/testData/debug/localVariables/tryFinally16.kt");
+    }
+
+    @Test
     @TestMetadata("tryFinally2.kt")
     public void testTryFinally2() throws Exception {
         runTest("compiler/testData/debug/localVariables/tryFinally2.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/debugInformation/LocalVariableTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/debugInformation/LocalVariableTestGenerated.java
@@ -87,6 +87,36 @@ public class LocalVariableTestGenerated extends AbstractLocalVariableTest {
     }
 
     @Test
+    @TestMetadata("tryFinally.kt")
+    public void testTryFinally() throws Exception {
+        runTest("compiler/testData/debug/localVariables/tryFinally.kt");
+    }
+
+    @Test
+    @TestMetadata("tryFinally2.kt")
+    public void testTryFinally2() throws Exception {
+        runTest("compiler/testData/debug/localVariables/tryFinally2.kt");
+    }
+
+    @Test
+    @TestMetadata("tryFinally3.kt")
+    public void testTryFinally3() throws Exception {
+        runTest("compiler/testData/debug/localVariables/tryFinally3.kt");
+    }
+
+    @Test
+    @TestMetadata("tryFinally4.kt")
+    public void testTryFinally4() throws Exception {
+        runTest("compiler/testData/debug/localVariables/tryFinally4.kt");
+    }
+
+    @Test
+    @TestMetadata("tryFinally5.kt")
+    public void testTryFinally5() throws Exception {
+        runTest("compiler/testData/debug/localVariables/tryFinally5.kt");
+    }
+
+    @Test
     @TestMetadata("underscoreNames.kt")
     public void testUnderscoreNames() throws Exception {
         runTest("compiler/testData/debug/localVariables/underscoreNames.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/debugInformation/LocalVariableTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/debugInformation/LocalVariableTestGenerated.java
@@ -93,6 +93,12 @@ public class LocalVariableTestGenerated extends AbstractLocalVariableTest {
     }
 
     @Test
+    @TestMetadata("tryFinally10.kt")
+    public void testTryFinally10() throws Exception {
+        runTest("compiler/testData/debug/localVariables/tryFinally10.kt");
+    }
+
+    @Test
     @TestMetadata("tryFinally2.kt")
     public void testTryFinally2() throws Exception {
         runTest("compiler/testData/debug/localVariables/tryFinally2.kt");
@@ -114,6 +120,30 @@ public class LocalVariableTestGenerated extends AbstractLocalVariableTest {
     @TestMetadata("tryFinally5.kt")
     public void testTryFinally5() throws Exception {
         runTest("compiler/testData/debug/localVariables/tryFinally5.kt");
+    }
+
+    @Test
+    @TestMetadata("tryFinally6.kt")
+    public void testTryFinally6() throws Exception {
+        runTest("compiler/testData/debug/localVariables/tryFinally6.kt");
+    }
+
+    @Test
+    @TestMetadata("tryFinally7.kt")
+    public void testTryFinally7() throws Exception {
+        runTest("compiler/testData/debug/localVariables/tryFinally7.kt");
+    }
+
+    @Test
+    @TestMetadata("tryFinally8.kt")
+    public void testTryFinally8() throws Exception {
+        runTest("compiler/testData/debug/localVariables/tryFinally8.kt");
+    }
+
+    @Test
+    @TestMetadata("tryFinally9.kt")
+    public void testTryFinally9() throws Exception {
+        runTest("compiler/testData/debug/localVariables/tryFinally9.kt");
     }
 
     @Test

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/debugInformation/LocalVariableTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/debugInformation/LocalVariableTestGenerated.java
@@ -99,6 +99,42 @@ public class LocalVariableTestGenerated extends AbstractLocalVariableTest {
     }
 
     @Test
+    @TestMetadata("tryFinally11.kt")
+    public void testTryFinally11() throws Exception {
+        runTest("compiler/testData/debug/localVariables/tryFinally11.kt");
+    }
+
+    @Test
+    @TestMetadata("tryFinally12.kt")
+    public void testTryFinally12() throws Exception {
+        runTest("compiler/testData/debug/localVariables/tryFinally12.kt");
+    }
+
+    @Test
+    @TestMetadata("tryFinally13.kt")
+    public void testTryFinally13() throws Exception {
+        runTest("compiler/testData/debug/localVariables/tryFinally13.kt");
+    }
+
+    @Test
+    @TestMetadata("tryFinally14.kt")
+    public void testTryFinally14() throws Exception {
+        runTest("compiler/testData/debug/localVariables/tryFinally14.kt");
+    }
+
+    @Test
+    @TestMetadata("tryFinally15.kt")
+    public void testTryFinally15() throws Exception {
+        runTest("compiler/testData/debug/localVariables/tryFinally15.kt");
+    }
+
+    @Test
+    @TestMetadata("tryFinally16.kt")
+    public void testTryFinally16() throws Exception {
+        runTest("compiler/testData/debug/localVariables/tryFinally16.kt");
+    }
+
+    @Test
     @TestMetadata("tryFinally2.kt")
     public void testTryFinally2() throws Exception {
         runTest("compiler/testData/debug/localVariables/tryFinally2.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
@@ -6014,6 +6014,11 @@ public class IrJsCodegenBoxES6TestGenerated extends AbstractIrJsCodegenBoxES6Tes
                 runTest("compiler/testData/codegen/box/controlStructures/tryCatchInExpressions/multipleCatchBlocks.kt");
             }
 
+            @TestMetadata("nonLocalReturnInTryFinally.kt")
+            public void testNonLocalReturnInTryFinally() throws Exception {
+                runTest("compiler/testData/codegen/box/controlStructures/tryCatchInExpressions/nonLocalReturnInTryFinally.kt");
+            }
+
             @TestMetadata("splitTry.kt")
             public void testSplitTry() throws Exception {
                 runTest("compiler/testData/codegen/box/controlStructures/tryCatchInExpressions/splitTry.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -5425,6 +5425,11 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
                 runTest("compiler/testData/codegen/box/controlStructures/tryCatchInExpressions/multipleCatchBlocks.kt");
             }
 
+            @TestMetadata("nonLocalReturnInTryFinally.kt")
+            public void testNonLocalReturnInTryFinally() throws Exception {
+                runTest("compiler/testData/codegen/box/controlStructures/tryCatchInExpressions/nonLocalReturnInTryFinally.kt");
+            }
+
             @TestMetadata("splitTry.kt")
             public void testSplitTry() throws Exception {
                 runTest("compiler/testData/codegen/box/controlStructures/tryCatchInExpressions/splitTry.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -5425,6 +5425,11 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
                 runTest("compiler/testData/codegen/box/controlStructures/tryCatchInExpressions/multipleCatchBlocks.kt");
             }
 
+            @TestMetadata("nonLocalReturnInTryFinally.kt")
+            public void testNonLocalReturnInTryFinally() throws Exception {
+                runTest("compiler/testData/codegen/box/controlStructures/tryCatchInExpressions/nonLocalReturnInTryFinally.kt");
+            }
+
             @TestMetadata("splitTry.kt")
             public void testSplitTry() throws Exception {
                 runTest("compiler/testData/codegen/box/controlStructures/tryCatchInExpressions/splitTry.kt");


### PR DESCRIPTION
For code such as:

```
try {
  var y = "y"
  for (i in 0 until 1) {
    return y
  }
} finally {
  println("finally")
}
```

The local variables `y` and `i` ended up covering the finally block as
well in the debugger.

This change splits the range of the locals so that they do
not cover the finally block.