### PR TITLE
FIR LT: set source for destructured value parameter of lambda

### DIFF
--- a/compiler/fir/analysis-tests/testData/resolve/arguments/destructuring.kt
+++ b/compiler/fir/analysis-tests/testData/resolve/arguments/destructuring.kt
@@ -6,8 +6,8 @@ fun foo2(block: (C, C) -> Unit) = block(C(0, ""), C(0, ""))
 fun test() {
     foo1 { (x, y) -> C(x, y) }
     foo1 { (x: Int, y: String) -> C(x, y) }
-    foo1 { (<!COMPONENT_FUNCTION_RETURN_TYPE_MISMATCH{PSI}!>x: String<!>, <!COMPONENT_FUNCTION_RETURN_TYPE_MISMATCH{PSI}!>y: Int<!>) -> <!INAPPLICABLE_CANDIDATE!>C<!>(x, y) }
+    foo1 { (<!COMPONENT_FUNCTION_RETURN_TYPE_MISMATCH!>x: String<!>, <!COMPONENT_FUNCTION_RETURN_TYPE_MISMATCH!>y: Int<!>) -> <!INAPPLICABLE_CANDIDATE!>C<!>(x, y) }
     foo2 { (x, y), (z, w) -> C(x + z, y + w) }
     foo2 { (x: Int, y: String), (z: Int, w: String) -> C(x + z, y + w) }
-    foo2 { (<!COMPONENT_FUNCTION_RETURN_TYPE_MISMATCH{PSI}!>x: String<!>, <!COMPONENT_FUNCTION_RETURN_TYPE_MISMATCH{PSI}!>y: Int<!>), (<!COMPONENT_FUNCTION_RETURN_TYPE_MISMATCH{PSI}!>z: String<!>, <!COMPONENT_FUNCTION_RETURN_TYPE_MISMATCH{PSI}!>w: Int<!>) -> <!INAPPLICABLE_CANDIDATE!>C<!>(x + z, y + w) }
+    foo2 { (<!COMPONENT_FUNCTION_RETURN_TYPE_MISMATCH!>x: String<!>, <!COMPONENT_FUNCTION_RETURN_TYPE_MISMATCH!>y: Int<!>), (<!COMPONENT_FUNCTION_RETURN_TYPE_MISMATCH!>z: String<!>, <!COMPONENT_FUNCTION_RETURN_TYPE_MISMATCH!>w: Int<!>) -> <!INAPPLICABLE_CANDIDATE!>C<!>(x + z, y + w) }
 }

--- a/compiler/fir/raw-fir/light-tree2fir/src/org/jetbrains/kotlin/fir/lightTree/converter/ExpressionsConverter.kt
+++ b/compiler/fir/raw-fir/light-tree2fir/src/org/jetbrains/kotlin/fir/lightTree/converter/ExpressionsConverter.kt
@@ -153,6 +153,7 @@ class ExpressionsConverter(
                 valueParameters += if (multiDeclaration != null) {
                     val name = Name.special("<destruct>")
                     val multiParameter = buildValueParameter {
+                        source = valueParameter.firValueParameter.source
                         session = baseSession
                         origin = FirDeclarationOrigin.Source
                         returnTypeRef = valueParameter.firValueParameter.returnTypeRef


### PR DESCRIPTION
As mentioned at https://github.com/JetBrains/kotlin/pull/4286#issuecomment-816557426, `COMPONENT_FUNCTION_RETURN_TYPE_MISMATCH` shows different behavior for LT. It turns out `source` for destructured value parameter of lambda is not set in LT.