### PR TITLE
FIR checker: Enable ReplaceWithDotCallFix for UNNECESSARY_SAFE_CALL

### DIFF
--- a/generators/tests/org/jetbrains/kotlin/generators/tests/GenerateTests.kt
+++ b/generators/tests/org/jetbrains/kotlin/generators/tests/GenerateTests.kt
@@ -1136,6 +1136,7 @@ fun main(args: Array<String>) {
                 model("quickfix/lateinit", pattern = pattern, filenameStartsLowerCase = true)
                 model("quickfix/modifiers", pattern = pattern, filenameStartsLowerCase = true, recursive = false)
                 model("quickfix/override/typeMismatchOnOverride", pattern = pattern, filenameStartsLowerCase = true, recursive = false)
+                model("quickfix/replaceWithDotCall", pattern = pattern, filenameStartsLowerCase = true)
                 model("quickfix/replaceWithSafeCall", pattern = pattern, filenameStartsLowerCase = true)
                 model("quickfix/variables/changeMutability", pattern = pattern, filenameStartsLowerCase = true)
                 model("quickfix/addInitializer", pattern = pattern, filenameStartsLowerCase = true)

--- a/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/MainKtQuickFixRegistrar.kt
+++ b/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/MainKtQuickFixRegistrar.kt
@@ -81,6 +81,7 @@ class MainKtQuickFixRegistrar : KtQuickFixRegistrar() {
     }
 
     private val expressions = KtQuickFixesListBuilder.registerPsiQuickFix {
+        registerPsiQuickFixes(KtFirDiagnostic.UnnecessarySafeCall::class, ReplaceWithDotCallFix)
         registerApplicator(ReplaceCallFixFactories.unsafeCallFactory)
     }
 

--- a/idea/idea-fir/tests/org/jetbrains/kotlin/idea/quickfix/HighLevelQuickFixTestGenerated.java
+++ b/idea/idea-fir/tests/org/jetbrains/kotlin/idea/quickfix/HighLevelQuickFixTestGenerated.java
@@ -344,6 +344,11 @@ public class HighLevelQuickFixTestGenerated extends AbstractHighLevelQuickFixTes
             runTest("idea/testData/quickfix/expressions/unnecessarySafeCall1.kt");
         }
 
+        @TestMetadata("unnecessarySafeCall2.kt")
+        public void testUnnecessarySafeCall2() throws Exception {
+            runTest("idea/testData/quickfix/expressions/unnecessarySafeCall2.kt");
+        }
+
         @TestMetadata("unsafeCall1.kt")
         public void testUnsafeCall1() throws Exception {
             runTest("idea/testData/quickfix/expressions/unsafeCall1.kt");
@@ -871,6 +876,39 @@ public class HighLevelQuickFixTestGenerated extends AbstractHighLevelQuickFixTes
         @TestMetadata("returnTypeMismatchOnOverrideUnitInt.kt")
         public void testReturnTypeMismatchOnOverrideUnitInt() throws Exception {
             runTest("idea/testData/quickfix/override/typeMismatchOnOverride/returnTypeMismatchOnOverrideUnitInt.kt");
+        }
+    }
+
+    @TestMetadata("idea/testData/quickfix/replaceWithDotCall")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class ReplaceWithDotCall extends AbstractHighLevelQuickFixTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
+        }
+
+        public void testAllFilesPresentInReplaceWithDotCall() throws Exception {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("idea/testData/quickfix/replaceWithDotCall"), Pattern.compile("^([\\w\\-_]+)\\.kt$"), null, true);
+        }
+
+        @TestMetadata("comment.kt")
+        public void testComment() throws Exception {
+            runTest("idea/testData/quickfix/replaceWithDotCall/comment.kt");
+        }
+
+        @TestMetadata("functionCall.kt")
+        public void testFunctionCall() throws Exception {
+            runTest("idea/testData/quickfix/replaceWithDotCall/functionCall.kt");
+        }
+
+        @TestMetadata("lineBreak.kt")
+        public void testLineBreak() throws Exception {
+            runTest("idea/testData/quickfix/replaceWithDotCall/lineBreak.kt");
+        }
+
+        @TestMetadata("normal.kt")
+        public void testNormal() throws Exception {
+            runTest("idea/testData/quickfix/replaceWithDotCall/normal.kt");
         }
     }
 

--- a/idea/idea-frontend-independent/src/org/jetbrains/kotlin/idea/quickfix/ReplaceCallFix.kt
+++ b/idea/idea-frontend-independent/src/org/jetbrains/kotlin/idea/quickfix/ReplaceCallFix.kt
@@ -11,7 +11,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
-import org.jetbrains.kotlin.diagnostics.Diagnostic
 import org.jetbrains.kotlin.idea.KotlinBundle
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.*
@@ -92,10 +91,10 @@ class ReplaceWithSafeCallForScopeFunctionFix(
 class ReplaceWithDotCallFix(expression: KtSafeQualifiedExpression) : ReplaceCallFix(expression, "."), CleanupFix {
     override fun getText() = KotlinBundle.message("replace.with.dot.call")
 
-    companion object : KotlinSingleIntentionActionFactory() {
-        override fun createAction(diagnostic: Diagnostic): IntentionAction? {
-            val qualifiedExpression = diagnostic.psiElement.getParentOfType<KtSafeQualifiedExpression>(strict = false) ?: return null
-            return ReplaceWithDotCallFix(qualifiedExpression)
+    companion object : QuickFixesPsiBasedFactory<PsiElement>(PsiElement::class, PsiElementSuitabilityCheckers.ALWAYS_SUITABLE) {
+        override fun doCreateQuickFix(psiElement: PsiElement): List<IntentionAction> {
+            val qualifiedExpression = psiElement.getParentOfType<KtSafeQualifiedExpression>(strict = false) ?: return emptyList()
+            return listOfNotNull(ReplaceWithDotCallFix(qualifiedExpression))
         }
     }
 }

--- a/idea/testData/quickfix/expressions/unnecessarySafeCall1.kt
+++ b/idea/testData/quickfix/expressions/unnecessarySafeCall1.kt
@@ -2,5 +2,3 @@
 fun foo(a: Any) {
     a<caret>?.equals(0)
 }
-
-/* IGNORE_FIR */

--- a/idea/testData/quickfix/expressions/unnecessarySafeCall1.kt.after
+++ b/idea/testData/quickfix/expressions/unnecessarySafeCall1.kt.after
@@ -2,5 +2,3 @@
 fun foo(a: Any) {
     a<caret>.equals(0)
 }
-
-/* IGNORE_FIR */

--- a/idea/testData/quickfix/expressions/unnecessarySafeCall2.kt
+++ b/idea/testData/quickfix/expressions/unnecessarySafeCall2.kt
@@ -1,4 +1,4 @@
 // "Replace with dot call" "true"
 fun Any.foo() {
-    this.equals(0)
+    this<caret>?.equals(0)
 }

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -7757,6 +7757,11 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
             runTest("idea/testData/quickfix/expressions/unnecessarySafeCall1.kt");
         }
 
+        @TestMetadata("unnecessarySafeCall2.kt")
+        public void testUnnecessarySafeCall2() throws Exception {
+            runTest("idea/testData/quickfix/expressions/unnecessarySafeCall2.kt");
+        }
+
         @TestMetadata("unsafeCall1.kt")
         public void testUnsafeCall1() throws Exception {
             runTest("idea/testData/quickfix/expressions/unsafeCall1.kt");


### PR DESCRIPTION
`unnecessarySafeCall2.kt` was removed in https://github.com/JetBrains/kotlin/commit/0c758902efb64137fe658617967e5e887fc24fa8#diff-1e769b5e958acf313fdbcc14e29b3f2443ac596595e132f2d4ce5ccd98269049 and is no longer applicable (didn't know Kotlin allowed this kind of pattern matching before!) so I replaced it with some other test.