### PR TITLE
FIR IDE: fix findSourceFirDeclarationByExpression

### DIFF
--- a/idea/idea-frontend-fir/idea-fir-low-level-api/src/org/jetbrains/kotlin/idea/fir/low/level/api/FirModuleResolveStateImpl.kt
+++ b/idea/idea-frontend-fir/idea-fir-low-level-api/src/org/jetbrains/kotlin/idea/fir/low/level/api/FirModuleResolveStateImpl.kt
@@ -126,7 +126,6 @@ internal class FirModuleResolveStateImpl(
         }
         val firDeclaration = FirElementFinder.findElementIn<FirDeclaration>(container) { firDeclaration ->
             when (val realPsi = firDeclaration.realPsi) {
-                is KtObjectLiteralExpression -> realPsi.objectDeclaration == ktDeclaration
                 is KtFunctionLiteral -> realPsi.parent == ktDeclaration
                 else -> realPsi == ktDeclaration
             }


### PR DESCRIPTION
Consider the following code

```
interface A
class B : A by object : A {}
```

When finding the FirDeclaration for the anonymous object `A`, the
current logic would return an `FirFieldImpl` that corresponds to the
delegate field for `A`. This is because while traversing the children
of `B`, the logic first traverses the delegate field (realPsi is an
KtObjectLiteralExpression) and then the initializer (realPsi is the
KtObjectDeclaration). As a result, I am getting the following exception

```
org.jetbrains.kotlin.idea.fir.low.level.api.api.InvalidFirElementTypeException: For OBJECT_DECLARATION with text `object : A3 {}` the class org.jetbrains.kotlin.fir.declarations.FirAnonymousObject expected, but class org.jetbrains.kotlin.fir.declarations.impl.FirFieldImpl found
	at org.jetbrains.kotlin.idea.frontend.api.fir.symbols.KtFirSymbolProvider.getAnonymousObjectSymbol(KtFirSymbolProvider.kt:397)
	at org.jetbrains.kotlin.idea.frontend.api.symbols.KtSymbolProviderMixIn$DefaultImpls.getAnonymousObjectSymbol(KtSymbolProvider.kt:96)
	at org.jetbrains.kotlin.idea.frontend.api.KtAnalysisSession.getAnonymousObjectSymbol(KtAnalysisSession.kt:26)
	at org.jetbrains.kotlin.idea.asJava.classes.FirLightClassUtilsKt.createFirLightClassNoCache(firLightClassUtils.kt:62)
	at org.jetbrains.kotlin.idea.asJava.classes.FirLightClassUtilsKt.getOrCreateFirLightClass$lambda-0(firLightClassUtils.kt:39)
	at com.intellij.psi.util.CachedValuesManager$1.compute(CachedValuesManager.java:153)
	at com.intellij.psi.impl.PsiCachedValueImpl.doCompute(PsiCachedValueImpl.java:54)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$1(CachedValueBase.java:235)
	at com.intellij.openapi.util.RecursionManager$1.doPreventingRecursion(RecursionManager.java:112)
	at com.intellij.openapi.util.RecursionManager.doPreventingRecursion(RecursionManager.java:71)
	at com.intellij.util.CachedValueBase.getValueWithLock(CachedValueBase.java:236)
	at com.intellij.psi.impl.PsiCachedValueImpl.getValue(PsiCachedValueImpl.java:43)
	at com.intellij.util.CachedValuesManagerImpl.getCachedValue(CachedValuesManagerImpl.java:76)
	at com.intellij.psi.util.CachedValuesManager.getCachedValue(CachedValuesManager.java:150)
	at com.intellij.psi.util.CachedValuesManager.getCachedValue(CachedValuesManager.java:120)
	at org.jetbrains.kotlin.idea.asJava.classes.FirLightClassUtilsKt.getOrCreateFirLightClass(firLightClassUtils.kt:36)
	at org.jetbrains.kotlin.idea.caches.resolve.IDEKotlinAsJavaFirSupport.createLightClassForSourceDeclaration(IDEKotlinAsJavaSupport.kt:34)
	at org.jetbrains.kotlin.idea.caches.resolve.IDEKotlinAsJavaSupport.getLightClass(IDEKotlinAsJavaSupport.kt:157)
	at org.jetbrains.kotlin.asJava.LightClassUtilsKt.toLightClass(lightClassUtils.kt:43)
	at org.jetbrains.kotlin.idea.findUsages.handlers.KotlinFindClassUsagesHandler$MySearcher.buildTaskList(KotlinFindClassUsagesHandler.kt:101)
	at org.jetbrains.kotlin.idea.findUsages.handlers.KotlinFindUsagesHandler$searchReferences$2.invoke(KotlinFindUsagesHandler.kt:93)
	at org.jetbrains.kotlin.idea.findUsages.handlers.KotlinFindUsagesHandler$searchReferences$2.invoke(KotlinFindUsagesHandler.kt:93)
	at org.jetbrains.kotlin.idea.util.application.ApplicationUtilsKt.runReadActionInSmartMode(ApplicationUtils.kt:67)
	at org.jetbrains.kotlin.idea.findUsages.handlers.KotlinFindUsagesHandler.searchReferences(KotlinFindUsagesHandler.kt:93)
	at org.jetbrains.kotlin.idea.findUsages.handlers.KotlinFindUsagesHandler.findReferencesToHighlight(KotlinFindUsagesHandler.kt:107)
	at com.intellij.codeInsight.daemon.impl.IdentifierHighlighterPass.getReferences(IdentifierHighlighterPass.java:302)
	at com.intellij.codeInsight.daemon.impl.IdentifierHighlighterPass.getUsages(IdentifierHighlighterPass.java:272)
	at com.intellij.codeInsight.daemon.impl.IdentifierHighlighterPass.lambda$highlightTargetUsages$2(IdentifierHighlighterPass.java:252)
	at com.intellij.util.AstLoadingFilter.disallowTreeLoading(AstLoadingFilter.java:126)
	at com.intellij.codeInsight.daemon.impl.IdentifierHighlighterPass.highlightTargetUsages(IdentifierHighlighterPass.java:251)
	at com.intellij.codeInsight.daemon.impl.IdentifierHighlighterPass.highlightReferencesAndDeclarations(IdentifierHighlighterPass.java:227)
	at com.intellij.codeInsight.daemon.impl.IdentifierHighlighterPass.doCollectInformation(IdentifierHighlighterPass.java:90)
	at com.intellij.codeHighlighting.TextEditorHighlightingPass.collectInformation(TextEditorHighlightingPass.java:54)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$1(PassExecutorService.java:399)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1110)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$2(PassExecutorService.java:392)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:629)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:581)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:60)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.doRun(PassExecutorService.java:391)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$run$0(PassExecutorService.java:367)
	at com.intellij.openapi.application.impl.ReadMostlyRWLock.executeByImpatientReader(ReadMostlyRWLock.java:170)
	at com.intellij.openapi.application.impl.ApplicationImpl.executeByImpatientReader(ApplicationImpl.java:182)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.run(PassExecutorService.java:365)
	at com.intellij.concurrency.JobLauncherImpl$VoidForkJoinTask$1.exec(JobLauncherImpl.java:181)
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
	at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)
```

Simply deleting one line seems to fix the issue and does not seem to
cause any problems.