### PR TITLE
[Gradle] Avoid using dependsOn and add output provider to the file collection

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/kotlinCompilations.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/kotlinCompilations.kt
@@ -233,7 +233,7 @@ abstract class AbstractKotlinCompilation<T : KotlinCommonOptions>(
                 // that depends on this module's production part, include the main artifact in the friend artifacts, lazily:
                 files(
                     Callable {
-                        friendArtifactsTaskProvider.get().archivePathCompatible
+                        friendArtifactsTaskProvider.flatMap { it.archiveFile }
                     }
                 )
             } else files()

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/Tasks.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/Tasks.kt
@@ -304,15 +304,6 @@ abstract class AbstractKotlinCompile<T : CommonCompilerArguments>() : AbstractKo
         taskData.compilation.moduleName
     }
 
-    init {
-        if (taskData.compilation is AbstractKotlinCompilation<*> &&
-            (taskData.compilation as AbstractKotlinCompilation<*>).friendArtifactsTask != null) {
-            this@AbstractKotlinCompile.dependsOn(
-                (taskData.compilation as AbstractKotlinCompilation<*>).friendArtifactsTask
-            )
-        }
-    }
-
     @get:Internal // takes part in the compiler arguments
     val friendPaths: FileCollection = project.files(
         project.provider {


### PR DESCRIPTION
Avoid using dependsOn and add output provider to the file collection. This helps to remove duplicate logic, as task outputs should already automatically add dependency info and the task graph should be correct.