### PR TITLE
JVM, Psi2Ir: Fix constant folding for unsigned values and use the results in psi2ir

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -7155,6 +7155,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         }
 
         @Test
+        @TestMetadata("foldingBinaryOpsUnsignedConst.kt")
+        public void testFoldingBinaryOpsUnsignedConst() throws Exception {
+            runTest("compiler/testData/codegen/box/constants/foldingBinaryOpsUnsignedConst.kt");
+        }
+
+        @Test
         @TestMetadata("kt9532.kt")
         public void testKt9532() throws Exception {
             runTest("compiler/testData/codegen/box/constants/kt9532.kt");

--- a/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/ArgumentsGenerationUtils.kt
+++ b/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/ArgumentsGenerationUtils.kt
@@ -96,11 +96,6 @@ fun StatementGenerator.generateReceiver(defaultStartOffset: Int, defaultEndOffse
                 generateThisOrSuperReceiver(receiver, receiver.thisType.constructor.declarationDescriptor as ClassDescriptor)
             is ExpressionReceiver ->
                 generateExpression(receiver.expression)
-            is ClassValueReceiver ->
-                IrGetObjectValueImpl(
-                    receiver.expression.startOffsetSkippingComments, receiver.expression.endOffset, irReceiverType,
-                    context.symbolTable.referenceClass(receiver.classQualifier.descriptor as ClassDescriptor)
-                )
             is ExtensionReceiver ->
                 IrGetValueImpl(
                     defaultStartOffset, defaultStartOffset, irReceiverType,

--- a/compiler/testData/codegen/box/constants/foldingBinaryOpsUnsignedConst.kt
+++ b/compiler/testData/codegen/box/constants/foldingBinaryOpsUnsignedConst.kt
@@ -1,17 +1,18 @@
 // WITH_RUNTIME
+// IGNORE_BACKEND_FIR: JVM_IR
 // IGNORE_BACKEND: WASM
 
-val a = "INT " + 0x8fffffffU
-val b = "BYTE " + 0x8ffU
-val c = "LONG " + 0xffff_ffff_ffffU
+const val a = "INT " + 0x8fffffffU
+const val b = "BYTE " + 0x8ffU
+const val c = "LONG " + 0xffff_ffff_ffffU
 
-val uint = 0x8fffffffU
-val ubyte = 0x8ffU
-val ulong = 0xffff_ffff_ffffU
+const val uint = 0x8fffffffU
+const val ubyte = 0x8ffU
+const val ulong = 0xffff_ffff_ffffU
 
-val aa = "INT " + uint
-val bb = "BYTE " + ubyte
-val cc = "LONG " + ulong
+const val aa = "INT " + uint
+const val bb = "BYTE " + ubyte
+const val cc = "LONG " + ulong
 
 
 fun box(): String {

--- a/compiler/testData/ir/irText/declarations/kt29833.kt.txt
+++ b/compiler/testData/ir/irText/declarations/kt29833.kt.txt
@@ -12,7 +12,7 @@ object Definitions {
     get
 
   val ktValue: String
-    field = super.#CONSTANT
+    field = "constant"
     get
 
 }

--- a/compiler/testData/ir/irText/declarations/kt29833.txt
+++ b/compiler/testData/ir/irText/declarations/kt29833.txt
@@ -19,7 +19,7 @@ FILE fqName:interop fileName:/Definitions.kt
     PROPERTY name:ktValue visibility:public modality:FINAL [val]
       FIELD PROPERTY_BACKING_FIELD name:ktValue type:kotlin.String visibility:private [final]
         EXPRESSION_BODY
-          GET_FIELD 'FIELD IR_EXTERNAL_JAVA_DECLARATION_STUB name:CONSTANT type:kotlin.String visibility:public [final,static]' type=kotlin.String origin=GET_PROPERTY
+          CONST String type=kotlin.String value="constant"
       FUN DEFAULT_PROPERTY_ACCESSOR name:<get-ktValue> visibility:public modality:FINAL <> ($this:interop.Definitions) returnType:kotlin.String
         correspondingProperty: PROPERTY name:ktValue visibility:public modality:FINAL [val]
         $this: VALUE_PARAMETER name:<this> type:interop.Definitions

--- a/compiler/testData/ir/irText/expressions/primitivesImplicitConversions.kt.txt
+++ b/compiler/testData/ir/irText/expressions/primitivesImplicitConversions.kt.txt
@@ -11,15 +11,15 @@ val test3: Byte
   get
 
 val test4: Long
-  field = 42.unaryMinus()
+  field = -42L
   get
 
 val test5: Short
-  field = 42.unaryMinus()
+  field = -42S
   get
 
 val test6: Byte
-  field = 42.unaryMinus()
+  field = -42B
   get
 
 fun test() {

--- a/compiler/testData/ir/irText/expressions/primitivesImplicitConversions.txt
+++ b/compiler/testData/ir/irText/expressions/primitivesImplicitConversions.txt
@@ -29,8 +29,7 @@ FILE fqName:<root> fileName:/primitivesImplicitConversions.kt
   PROPERTY name:test4 visibility:public modality:FINAL [val]
     FIELD PROPERTY_BACKING_FIELD name:test4 type:kotlin.Long visibility:private [final,static]
       EXPRESSION_BODY
-        CALL 'public final fun unaryMinus (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
-          $this: CONST Int type=kotlin.Int value=42
+        CONST Long type=kotlin.Long value=-42
     FUN DEFAULT_PROPERTY_ACCESSOR name:<get-test4> visibility:public modality:FINAL <> () returnType:kotlin.Long
       correspondingProperty: PROPERTY name:test4 visibility:public modality:FINAL [val]
       BLOCK_BODY
@@ -39,8 +38,7 @@ FILE fqName:<root> fileName:/primitivesImplicitConversions.kt
   PROPERTY name:test5 visibility:public modality:FINAL [val]
     FIELD PROPERTY_BACKING_FIELD name:test5 type:kotlin.Short visibility:private [final,static]
       EXPRESSION_BODY
-        CALL 'public final fun unaryMinus (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
-          $this: CONST Int type=kotlin.Int value=42
+        CONST Short type=kotlin.Short value=-42
     FUN DEFAULT_PROPERTY_ACCESSOR name:<get-test5> visibility:public modality:FINAL <> () returnType:kotlin.Short
       correspondingProperty: PROPERTY name:test5 visibility:public modality:FINAL [val]
       BLOCK_BODY
@@ -49,8 +47,7 @@ FILE fqName:<root> fileName:/primitivesImplicitConversions.kt
   PROPERTY name:test6 visibility:public modality:FINAL [val]
     FIELD PROPERTY_BACKING_FIELD name:test6 type:kotlin.Byte visibility:private [final,static]
       EXPRESSION_BODY
-        CALL 'public final fun unaryMinus (): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
-          $this: CONST Int type=kotlin.Int value=42
+        CONST Byte type=kotlin.Byte value=-42
     FUN DEFAULT_PROPERTY_ACCESSOR name:<get-test6> visibility:public modality:FINAL <> () returnType:kotlin.Byte
       correspondingProperty: PROPERTY name:test6 visibility:public modality:FINAL [val]
       BLOCK_BODY

--- a/compiler/testData/ir/irText/stubs/constFromBuiltins.fir.kt.txt
+++ b/compiler/testData/ir/irText/stubs/constFromBuiltins.fir.kt.txt
@@ -1,0 +1,4 @@
+val test: Int
+  field = Companion.<get-MIN_VALUE>()
+  get
+

--- a/compiler/testData/ir/irText/stubs/constFromBuiltins.fir.txt
+++ b/compiler/testData/ir/irText/stubs/constFromBuiltins.fir.txt
@@ -1,8 +1,9 @@
-FILE fqName:<root> fileName:/simple.kt
+FILE fqName:<root> fileName:/constFromBuiltins.kt
   PROPERTY name:test visibility:public modality:FINAL [val]
     FIELD PROPERTY_BACKING_FIELD name:test type:kotlin.Int visibility:private [final,static]
       EXPRESSION_BODY
-        CONST Int type=kotlin.Int value=4
+        CALL 'public final fun <get-MIN_VALUE> (): kotlin.Int declared in kotlin.Int.Companion' type=kotlin.Int origin=GET_PROPERTY
+          $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=kotlin.Int.Companion
     FUN DEFAULT_PROPERTY_ACCESSOR name:<get-test> visibility:public modality:FINAL <> () returnType:kotlin.Int
       correspondingProperty: PROPERTY name:test visibility:public modality:FINAL [val]
       BLOCK_BODY

--- a/compiler/testData/ir/irText/stubs/constFromBuiltins.kt
+++ b/compiler/testData/ir/irText/stubs/constFromBuiltins.kt
@@ -1,4 +1,3 @@
-// FIR_IDENTICAL
 // DUMP_EXTERNAL_CLASS: kotlin.Int
 
 val test = Int.MIN_VALUE

--- a/compiler/testData/ir/irText/stubs/constFromBuiltins.kt.txt
+++ b/compiler/testData/ir/irText/stubs/constFromBuiltins.kt.txt
@@ -1,4 +1,4 @@
 val test: Int
-  field = Companion.<get-MIN_VALUE>()
+  field = -2147483648
   get
 

--- a/compiler/testData/ir/irText/stubs/constFromBuiltins.txt
+++ b/compiler/testData/ir/irText/stubs/constFromBuiltins.txt
@@ -2,8 +2,7 @@ FILE fqName:<root> fileName:/constFromBuiltins.kt
   PROPERTY name:test visibility:public modality:FINAL [val]
     FIELD PROPERTY_BACKING_FIELD name:test type:kotlin.Int visibility:private [final,static]
       EXPRESSION_BODY
-        CALL 'public final fun <get-MIN_VALUE> (): kotlin.Int declared in kotlin.Int.Companion' type=kotlin.Int origin=GET_PROPERTY
-          $this: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=kotlin.Int.Companion
+        CONST Int type=kotlin.Int value=-2147483648
     FUN DEFAULT_PROPERTY_ACCESSOR name:<get-test> visibility:public modality:FINAL <> () returnType:kotlin.Int
       correspondingProperty: PROPERTY name:test visibility:public modality:FINAL [val]
       BLOCK_BODY

--- a/compiler/testData/ir/irText/stubs/simple.fir.kt.txt
+++ b/compiler/testData/ir/irText/stubs/simple.fir.kt.txt
@@ -1,0 +1,4 @@
+val test: Int
+  field = 2.plus(other = 2)
+  get
+

--- a/compiler/testData/ir/irText/stubs/simple.fir.txt
+++ b/compiler/testData/ir/irText/stubs/simple.fir.txt
@@ -2,7 +2,9 @@ FILE fqName:<root> fileName:/simple.kt
   PROPERTY name:test visibility:public modality:FINAL [val]
     FIELD PROPERTY_BACKING_FIELD name:test type:kotlin.Int visibility:private [final,static]
       EXPRESSION_BODY
-        CONST Int type=kotlin.Int value=4
+        CALL 'public final fun plus (other: kotlin.Int): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=PLUS
+          $this: CONST Int type=kotlin.Int value=2
+          other: CONST Int type=kotlin.Int value=2
     FUN DEFAULT_PROPERTY_ACCESSOR name:<get-test> visibility:public modality:FINAL <> () returnType:kotlin.Int
       correspondingProperty: PROPERTY name:test visibility:public modality:FINAL [val]
       BLOCK_BODY

--- a/compiler/testData/ir/irText/stubs/simple.kt
+++ b/compiler/testData/ir/irText/stubs/simple.kt
@@ -1,4 +1,3 @@
-// FIR_IDENTICAL
 // !DUMP_DEPENDENCIES
 
 val test = 2 + 2

--- a/compiler/testData/ir/irText/stubs/simple.kt.txt
+++ b/compiler/testData/ir/irText/stubs/simple.kt.txt
@@ -1,4 +1,4 @@
 val test: Int
-  field = 2.plus(other = 2)
+  field = 4
   get
 

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -7155,6 +7155,12 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
         }
 
         @Test
+        @TestMetadata("foldingBinaryOpsUnsignedConst.kt")
+        public void testFoldingBinaryOpsUnsignedConst() throws Exception {
+            runTest("compiler/testData/codegen/box/constants/foldingBinaryOpsUnsignedConst.kt");
+        }
+
+        @Test
         @TestMetadata("kt9532.kt")
         public void testKt9532() throws Exception {
             runTest("compiler/testData/codegen/box/constants/kt9532.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -7155,6 +7155,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         }
 
         @Test
+        @TestMetadata("foldingBinaryOpsUnsignedConst.kt")
+        public void testFoldingBinaryOpsUnsignedConst() throws Exception {
+            runTest("compiler/testData/codegen/box/constants/foldingBinaryOpsUnsignedConst.kt");
+        }
+
+        @Test
         @TestMetadata("kt9532.kt")
         public void testKt9532() throws Exception {
             runTest("compiler/testData/codegen/box/constants/kt9532.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -5382,11 +5382,6 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)
     public static class Constants extends AbstractLightAnalysisModeTest {
-        @TestMetadata("foldingBinaryOpsUnsigned.kt")
-        public void ignoreFoldingBinaryOpsUnsigned() throws Exception {
-            runTest("compiler/testData/codegen/box/constants/foldingBinaryOpsUnsigned.kt");
-        }
-
         private void runTest(String testDataFilePath) throws Exception {
             KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM, testDataFilePath);
         }
@@ -5423,6 +5418,16 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
         @TestMetadata("float.kt")
         public void testFloat() throws Exception {
             runTest("compiler/testData/codegen/box/constants/float.kt");
+        }
+
+        @TestMetadata("foldingBinaryOpsUnsigned.kt")
+        public void testFoldingBinaryOpsUnsigned() throws Exception {
+            runTest("compiler/testData/codegen/box/constants/foldingBinaryOpsUnsigned.kt");
+        }
+
+        @TestMetadata("foldingBinaryOpsUnsignedConst.kt")
+        public void testFoldingBinaryOpsUnsignedConst() throws Exception {
+            runTest("compiler/testData/codegen/box/constants/foldingBinaryOpsUnsignedConst.kt");
         }
 
         @TestMetadata("kt9532.kt")

--- a/core/descriptors/src/org/jetbrains/kotlin/resolve/constants/constantValues.kt
+++ b/core/descriptors/src/org/jetbrains/kotlin/resolve/constants/constantValues.kt
@@ -43,7 +43,7 @@ abstract class ConstantValue<out T>(open val value: T) {
 
     override fun toString(): String = value.toString()
 
-    open fun stringTemplateValue(): String = value.toString()
+    open fun boxedValue(): Any? = value
 }
 
 abstract class IntegerValueConstant<out T> protected constructor(value: T) : ConstantValue<T>(value)
@@ -269,7 +269,7 @@ class UByteValue(byteValue: Byte) : UnsignedValueConstant<Byte>(byteValue) {
 
     override fun toString() = "$value.toUByte()"
 
-    override fun stringTemplateValue(): String = (value.toInt() and 0xFF).toString()
+    override fun boxedValue(): Any = value.toUByte()
 }
 
 class UShortValue(shortValue: Short) : UnsignedValueConstant<Short>(shortValue) {
@@ -282,7 +282,7 @@ class UShortValue(shortValue: Short) : UnsignedValueConstant<Short>(shortValue) 
 
     override fun toString() = "$value.toUShort()"
 
-    override fun stringTemplateValue(): String = (value.toInt() and 0xFFFF).toString()
+    override fun boxedValue(): Any = value.toUShort()
 }
 
 class UIntValue(intValue: Int) : UnsignedValueConstant<Int>(intValue) {
@@ -295,7 +295,7 @@ class UIntValue(intValue: Int) : UnsignedValueConstant<Int>(intValue) {
 
     override fun toString() = "$value.toUInt()"
 
-    override fun stringTemplateValue(): String = (value.toLong() and 0xFFFFFFFFL).toString()
+    override fun boxedValue(): Any = value.toUInt()
 }
 
 class ULongValue(longValue: Long) : UnsignedValueConstant<Long>(longValue) {
@@ -308,12 +308,5 @@ class ULongValue(longValue: Long) : UnsignedValueConstant<Long>(longValue) {
 
     override fun toString() = "$value.toULong()"
 
-    override fun stringTemplateValue(): String {
-        if (value >= 0) return value.toString()
-
-        val div10 = (value ushr 1) / 5
-        val mod10 = value - 10 * div10
-
-        return "$div10$mod10"
-    }
+    override fun boxedValue(): Any = value.toULong()
 }

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
@@ -4824,6 +4824,11 @@ public class IrJsCodegenBoxES6TestGenerated extends AbstractIrJsCodegenBoxES6Tes
             runTest("compiler/testData/codegen/box/constants/foldingBinaryOpsUnsigned.kt");
         }
 
+        @TestMetadata("foldingBinaryOpsUnsignedConst.kt")
+        public void testFoldingBinaryOpsUnsignedConst() throws Exception {
+            runTest("compiler/testData/codegen/box/constants/foldingBinaryOpsUnsignedConst.kt");
+        }
+
         @TestMetadata("kt9532.kt")
         public void testKt9532() throws Exception {
             runTest("compiler/testData/codegen/box/constants/kt9532.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -4245,6 +4245,11 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/constants/foldingBinaryOpsUnsigned.kt");
         }
 
+        @TestMetadata("foldingBinaryOpsUnsignedConst.kt")
+        public void testFoldingBinaryOpsUnsignedConst() throws Exception {
+            runTest("compiler/testData/codegen/box/constants/foldingBinaryOpsUnsignedConst.kt");
+        }
+
         @TestMetadata("kt9532.kt")
         public void testKt9532() throws Exception {
             runTest("compiler/testData/codegen/box/constants/kt9532.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -4245,6 +4245,11 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/constants/foldingBinaryOpsUnsigned.kt");
         }
 
+        @TestMetadata("foldingBinaryOpsUnsignedConst.kt")
+        public void testFoldingBinaryOpsUnsignedConst() throws Exception {
+            runTest("compiler/testData/codegen/box/constants/foldingBinaryOpsUnsignedConst.kt");
+        }
+
         @TestMetadata("kt9532.kt")
         public void testKt9532() throws Exception {
             runTest("compiler/testData/codegen/box/constants/kt9532.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/wasm/semantics/IrCodegenBoxWasmTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/wasm/semantics/IrCodegenBoxWasmTestGenerated.java
@@ -3056,6 +3056,11 @@ public class IrCodegenBoxWasmTestGenerated extends AbstractIrCodegenBoxWasmTest 
             runTest("compiler/testData/codegen/box/constants/foldingBinaryOpsUnsigned.kt");
         }
 
+        @TestMetadata("foldingBinaryOpsUnsignedConst.kt")
+        public void testFoldingBinaryOpsUnsignedConst() throws Exception {
+            runTest("compiler/testData/codegen/box/constants/foldingBinaryOpsUnsignedConst.kt");
+        }
+
         @TestMetadata("long.kt")
         public void testLong() throws Exception {
             runTest("compiler/testData/codegen/box/constants/long.kt");


### PR DESCRIPTION
There's three commits in this PR:
- The first is about fixing constant folding for unsigned constants in the JVM and JVM IR backends (see `testFoldingBinaryOpsUnsigned` for the problem with the JVM backend and `testFoldingBinaryOpsUnsignedConst` for the remaining problem with the JVM IR backend).
- The second is a small refactoring to remove unused code in psi2ir that I noticed while looking at the code (`ClassValueReceiver` implements `ExpressionReceiver`).
- The third is a change to psi2ir to use the results from constant folding when generating IR. We're currently producing stack overflow errors when using the IR backend for large constants ([example](https://gist.github.com/sfs/7b33de39e5e1e8b8bcc3ebcfd91aac1a)). Even with this PR the code in question still fails to compile with FIR. Vexingly, I couldn't add a test for this, since a stack overflow error in a test seems to cause the test runner to hang.