### PR TITLE
[KAPT] KT-46176 Don't fail on illegal delegate

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/JvmRuntimeTypes.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/JvmRuntimeTypes.kt
@@ -25,6 +25,7 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.builtIns
 import org.jetbrains.kotlin.storage.LockBasedStorageManager
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.utils.KotlinExceptionWithAttachments
+import kotlin.math.max
 
 
 class JvmRuntimeTypes(
@@ -188,6 +189,6 @@ class JvmRuntimeTypes(
             else -> if (isMutable) mutablePropertyReferences else propertyReferences
         }
 
-        return classes[arity].defaultType
+        return classes[max(arity, 0)].defaultType
     }
 }

--- a/plugins/kapt3/kapt3-compiler/test/org/jetbrains/kotlin/kapt3/test/ClassFileToSourceStubConverterTestGenerated.java
+++ b/plugins/kapt3/kapt3-compiler/test/org/jetbrains/kotlin/kapt3/test/ClassFileToSourceStubConverterTestGenerated.java
@@ -209,6 +209,11 @@ public class ClassFileToSourceStubConverterTestGenerated extends AbstractClassFi
         runTest("plugins/kapt3/kapt3-compiler/testData/converter/importsKt22083.kt");
     }
 
+    @TestMetadata("incorrectDelegate.kt")
+    public void testIncorrectDelegate() throws Exception {
+        runTest("plugins/kapt3/kapt3-compiler/testData/converter/incorrectDelegate.kt");
+    }
+
     @TestMetadata("inheritanceSimple.kt")
     public void testInheritanceSimple() throws Exception {
         runTest("plugins/kapt3/kapt3-compiler/testData/converter/inheritanceSimple.kt");

--- a/plugins/kapt3/kapt3-compiler/test/org/jetbrains/kotlin/kapt3/test/IrClassFileToSourceStubConverterTestGenerated.java
+++ b/plugins/kapt3/kapt3-compiler/test/org/jetbrains/kotlin/kapt3/test/IrClassFileToSourceStubConverterTestGenerated.java
@@ -210,6 +210,11 @@ public class IrClassFileToSourceStubConverterTestGenerated extends AbstractIrCla
         runTest("plugins/kapt3/kapt3-compiler/testData/converter/importsKt22083.kt");
     }
 
+    @TestMetadata("incorrectDelegate.kt")
+    public void testIncorrectDelegate() throws Exception {
+        runTest("plugins/kapt3/kapt3-compiler/testData/converter/incorrectDelegate.kt");
+    }
+
     @TestMetadata("inheritanceSimple.kt")
     public void testInheritanceSimple() throws Exception {
         runTest("plugins/kapt3/kapt3-compiler/testData/converter/inheritanceSimple.kt");

--- a/plugins/kapt3/kapt3-compiler/testData/converter/incorrectDelegate.kt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/incorrectDelegate.kt
@@ -1,0 +1,19 @@
+class HomeFragment {
+    @Suppress("TOO_MANY_ARGUMENTS", "DELEGATE_SPECIAL_FUNCTION_MISSING")
+    private val categoryNewsListPresenter by moxyPresenter {
+
+    }
+
+    private val groupedNewsListAdapter: GroupedNewsListDelegateAdapter by lazy {
+        GroupedNewsListDelegateAdapter(
+            categoryNewsListPresenter::onWiFiClick
+        )
+    }
+}
+
+class GroupedNewsListDelegateAdapter(onWiFiClickListener: () -> Unit)
+
+
+fun moxyPresenter() {
+
+}

--- a/plugins/kapt3/kapt3-compiler/testData/converter/incorrectDelegate.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/incorrectDelegate.txt
@@ -1,0 +1,54 @@
+import java.lang.System;
+
+@kotlin.Metadata()
+public final class GroupedNewsListDelegateAdapter {
+
+    public GroupedNewsListDelegateAdapter(@org.jetbrains.annotations.NotNull()
+    kotlin.jvm.functions.Function0<kotlin.Unit> onWiFiClickListener) {
+        super();
+    }
+}
+
+////////////////////
+
+
+import java.lang.System;
+
+@kotlin.Metadata()
+public final class HomeFragment {
+    private final kotlin.Unit categoryNewsListPresenter$delegate = null;
+    private final kotlin.Lazy groupedNewsListAdapter$delegate = null;
+
+    public HomeFragment() {
+        super();
+    }
+
+    private final error.NonExistentClass getCategoryNewsListPresenter() {
+        return null;
+    }
+
+    @kotlin.Suppress(names = {"TOO_MANY_ARGUMENTS", "DELEGATE_SPECIAL_FUNCTION_MISSING"})
+    @java.lang.Deprecated()
+    private static void getCategoryNewsListPresenter$annotations() {
+    }
+
+    private final GroupedNewsListDelegateAdapter getGroupedNewsListAdapter() {
+        return null;
+    }
+}
+
+////////////////////
+
+
+import java.lang.System;
+
+@kotlin.Metadata()
+public final class IncorrectDelegateKt {
+
+    public IncorrectDelegateKt() {
+        super();
+    }
+
+    public static final void moxyPresenter() {
+    }
+}


### PR DESCRIPTION
Kapt ignores error diagnostics, but backend can't compile such code at all. This is workaround so backend won't fail.
