### PR TITLE
FIR checker: report UNINITIALIZED_PARAMETER (based on existing unresolved errors)

### DIFF
--- a/compiler/fir/analysis-tests/testData/resolve/diagnostics/instanceAccessBeforeSuperCall.fir.txt
+++ b/compiler/fir/analysis-tests/testData/resolve/diagnostics/instanceAccessBeforeSuperCall.fir.txt
@@ -25,7 +25,7 @@ FILE: instanceAccessBeforeSuperCall.kt
         }
 
         public constructor(x: R|kotlin/Int|): R|C| {
-            this<R|C|>(fun <anonymous>(): R|ERROR CLASS: Cannot access ''<this>'' before superclass constructor has been called| <inline=Unknown>  {
+            this<R|C|>(fun <anonymous>(): <ERROR TYPE REF: Cannot access ''<this>'' before superclass constructor has been called> <inline=Unknown>  {
                 lval a: R|kotlin/Int| = Int(10)
                 ^ this@R|/C|
             }

--- a/compiler/fir/analysis-tests/testData/resolve/diagnostics/superIsNotAnExpression.fir.txt
+++ b/compiler/fir/analysis-tests/testData/resolve/diagnostics/superIsNotAnExpression.fir.txt
@@ -13,7 +13,7 @@ FILE: superIsNotAnExpression.kt
         public final fun act(): R|kotlin/Unit| {
             <Super cannot be a callee>#()
             <Unresolved name: invoke>#()
-            <Super cannot be a callee>#(<L> = <Super cannot be a callee>@fun <anonymous>(): R|ERROR CLASS: Unresolved name: println| <inline=Unknown>  {
+            <Super cannot be a callee>#(<L> = <Super cannot be a callee>@fun <anonymous>(): <ERROR TYPE REF: Unresolved name: println> <inline=Unknown>  {
                 ^ <Unresolved name: println>#(ERROR_EXPR(Incorrect character: 'weird'))
             }
             )

--- a/compiler/fir/analysis-tests/testData/resolve/references/leakedImplicitType.fir.txt
+++ b/compiler/fir/analysis-tests/testData/resolve/references/leakedImplicitType.fir.txt
@@ -7,7 +7,7 @@ FILE: leakedImplicitType.kt
         public final fun bar(): R|kotlin/Unit| {
         }
 
-        public final fun f(): R|ERROR CLASS: Unresolved reference: bar| {
+        public final fun f(): <ERROR TYPE REF: Unresolved reference: bar> {
             ^f <Unresolved name: Unresolved>#()::<Unresolved reference: bar>#
         }
 

--- a/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/diagnostics/FirDiagnosticsList.kt
+++ b/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/diagnostics/FirDiagnosticsList.kt
@@ -584,6 +584,9 @@ object DIAGNOSTICS_LIST : DiagnosticList() {
         val UNINITIALIZED_VARIABLE by error<KtSimpleNameExpression> {
             parameter<FirPropertySymbol>("variable")
         }
+        val UNINITIALIZED_PARAMETER by error<KtSimpleNameExpression> {
+            parameter<FirVariableSymbol<FirValueParameter>>("parameter")
+        }
         val UNINITIALIZED_ENUM_ENTRY by error<KtSimpleNameExpression> {
             parameter<FirVariableSymbol<FirEnumEntry>>("enumEntry")
         }

--- a/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/diagnostics/FirErrors.kt
+++ b/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/diagnostics/FirErrors.kt
@@ -356,6 +356,7 @@ object FirErrors {
 
     // Control flow diagnostics
     val UNINITIALIZED_VARIABLE by error1<KtSimpleNameExpression, FirPropertySymbol>()
+    val UNINITIALIZED_PARAMETER by error1<KtSimpleNameExpression, FirVariableSymbol<FirValueParameter>>()
     val UNINITIALIZED_ENUM_ENTRY by error1<KtSimpleNameExpression, FirVariableSymbol<FirEnumEntry>>()
     val UNINITIALIZED_ENUM_COMPANION by error1<KtSimpleNameExpression, FirRegularClassSymbol>(SourceElementPositioningStrategies.REFERENCE_BY_QUALIFIED)
     val VAL_REASSIGNMENT by error1<KtExpression, FirVariableSymbol<*>>()

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/FirHelpers.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/FirHelpers.kt
@@ -22,6 +22,7 @@ import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
 import org.jetbrains.kotlin.fir.expressions.FirQualifiedAccessExpression
 import org.jetbrains.kotlin.fir.expressions.impl.FirEmptyExpressionBlock
 import org.jetbrains.kotlin.fir.references.FirResolvedNamedReference
+import org.jetbrains.kotlin.fir.resolve.diagnostics.ConeUnresolvedNameError
 import org.jetbrains.kotlin.fir.resolve.fullyExpandedType
 import org.jetbrains.kotlin.fir.resolve.inference.isBuiltinFunctionalType
 import org.jetbrains.kotlin.fir.resolve.symbolProvider
@@ -451,3 +452,13 @@ fun isSubtypeOfForFunctionalTypeReturningUnit(context: ConeInferenceContext, sub
     }
     return false
 }
+
+internal fun FirExpression?.hasUnresolvedNameError(): Boolean {
+    return this?.unresolvedNameError != null
+}
+
+internal val FirExpression.unresolvedNameError: ConeUnresolvedNameError?
+    get() {
+        val typeRef = if (this is FirAnonymousFunction) this.returnTypeRef else this.typeRef
+        return (typeRef as? FirErrorTypeRef)?.diagnostic as? ConeUnresolvedNameError
+    }

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/collectors/components/ErrorNodeDiagnosticCollectorComponent.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/collectors/components/ErrorNodeDiagnosticCollectorComponent.kt
@@ -9,12 +9,13 @@ import org.jetbrains.kotlin.KtNodeTypes
 import org.jetbrains.kotlin.fir.FirFakeSourceElementKind
 import org.jetbrains.kotlin.fir.FirSourceElement
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.analysis.checkers.hasUnresolvedNameError
+import org.jetbrains.kotlin.fir.analysis.checkers.unresolvedNameError
 import org.jetbrains.kotlin.fir.analysis.collectors.AbstractDiagnosticCollector
 import org.jetbrains.kotlin.fir.analysis.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors
 import org.jetbrains.kotlin.fir.analysis.diagnostics.reportOn
 import org.jetbrains.kotlin.fir.analysis.diagnostics.toFirDiagnostics
-import org.jetbrains.kotlin.fir.declarations.FirAnonymousFunction
 import org.jetbrains.kotlin.fir.declarations.FirErrorFunction
 import org.jetbrains.kotlin.fir.declarations.FirFunction
 import org.jetbrains.kotlin.fir.declarations.FirValueParameter
@@ -68,16 +69,6 @@ class ErrorNodeDiagnosticCollectorComponent(collector: AbstractDiagnosticCollect
 
         reportFirDiagnostic(errorNamedReference.diagnostic, source, reporter, data, qualifiedAccess?.source)
     }
-
-    private fun FirExpression?.hasUnresolvedNameError(): Boolean {
-        return this?.unresolvedNameError != null
-    }
-
-    private val FirExpression.unresolvedNameError: ConeUnresolvedNameError?
-        get() {
-            val typeRef = if (this is FirAnonymousFunction) this.returnTypeRef else this.typeRef
-            return (typeRef as? FirErrorTypeRef)?.diagnostic as? ConeUnresolvedNameError
-        }
 
     private fun reportUninitializedParameter(qualifiedAccess: FirQualifiedAccessExpression?, context: CheckerContext): Boolean {
         if (qualifiedAccess == null) return false

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/FirDefaultErrorMessages.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/FirDefaultErrorMessages.kt
@@ -246,6 +246,7 @@ import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.TYPE_PARAMETER_ON
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.UNEXPECTED_SAFE_CALL
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.UNINITIALIZED_ENUM_COMPANION
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.UNINITIALIZED_ENUM_ENTRY
+import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.UNINITIALIZED_PARAMETER
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.UNINITIALIZED_VARIABLE
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.UNNECESSARY_LATEINIT
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.UNNECESSARY_NOT_NULL_ASSERTION
@@ -783,7 +784,8 @@ class FirDefaultErrorMessages : DefaultErrorMessages.Extension {
             )
 
             // Control flow diagnostics
-            map.put(UNINITIALIZED_VARIABLE, "{0} must be initialized before access", VARIABLE_NAME)
+            map.put(UNINITIALIZED_VARIABLE, "Variable ''{0}'' must be initialized", VARIABLE_NAME)
+            map.put(UNINITIALIZED_PARAMETER, "Parameter ''{0}'' is uninitialized here", VARIABLE_NAME)
             map.put(UNINITIALIZED_ENUM_ENTRY, "Enum entry ''{0}'' is uninitialized here", VARIABLE_NAME)
             map.put(UNINITIALIZED_ENUM_COMPANION, "Companion object of enum class ''{0}'' is uninitialized here", SYMBOL)
             map.put(VAL_REASSIGNMENT, "Val cannot be reassigned", VARIABLE_NAME)

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirDeclarationsResolveTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirDeclarationsResolveTransformer.kt
@@ -727,8 +727,12 @@ open class FirDeclarationsResolveTransformer(transformer: FirBodyResolveTransfor
                             returnStatements.mapNotNull { (it as? FirExpression)?.resultType?.coneType }
                         ) ?: session.builtinTypes.unitType.type
                     }
+                val returnTypeRef = if (returnType is ConeKotlinErrorType)
+                    lambda.returnTypeRef.errorTypeFromPrototype(returnType.diagnostic)
+                else
+                    lambda.returnTypeRef.resolvedTypeFromPrototype(returnType)
                 lambda.replaceReturnTypeRef(
-                    lambda.returnTypeRef.resolvedTypeFromPrototype(returnType).also {
+                    returnTypeRef.also {
                         session.lookupTracker?.recordTypeResolveAsLookup(it, lambda.source, null)
                     }
                 )

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/types/TypeUtils.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/types/TypeUtils.kt
@@ -204,10 +204,17 @@ fun FirTypeRef.withReplacedReturnType(newType: ConeKotlinType?): FirTypeRef {
     require(this is FirResolvedTypeRef || newType == null)
     if (newType == null) return this
 
-    return buildResolvedTypeRef {
-        source = this@withReplacedReturnType.source
-        type = newType
-        annotations += this@withReplacedReturnType.annotations
+    return if (newType is ConeKotlinErrorType) {
+        buildErrorTypeRef {
+            source = this@withReplacedReturnType.source
+            diagnostic = newType.diagnostic
+        }
+    } else {
+        buildResolvedTypeRef {
+            source = this@withReplacedReturnType.source
+            type = newType
+            annotations += this@withReplacedReturnType.annotations
+        }
     }
 }
 
@@ -218,14 +225,24 @@ fun FirTypeRef.withReplacedConeType(
     require(this is FirResolvedTypeRef)
     if (newType == null) return this
 
-    return buildResolvedTypeRef {
-        source = if (firFakeSourceElementKind != null)
-            this@withReplacedConeType.source?.fakeElement(firFakeSourceElementKind)
+    val newSource =
+        if (firFakeSourceElementKind != null)
+            this.source?.fakeElement(firFakeSourceElementKind)
         else
-            this@withReplacedConeType.source
-        type = newType
-        annotations += this@withReplacedConeType.annotations
-        delegatedTypeRef = this@withReplacedConeType.delegatedTypeRef
+            this.source
+
+    return if (newType is ConeKotlinErrorType) {
+        buildErrorTypeRef {
+            source = newSource
+            diagnostic = newType.diagnostic
+        }
+    } else {
+        buildResolvedTypeRef {
+            source = newSource
+            type = newType
+            annotations += this@withReplacedConeType.annotations
+            delegatedTypeRef = this@withReplacedConeType.delegatedTypeRef
+        }
     }
 }
 

--- a/compiler/testData/diagnostics/tests/DefaultValuesCheckWithoutBody.fir.kt
+++ b/compiler/testData/diagnostics/tests/DefaultValuesCheckWithoutBody.fir.kt
@@ -1,9 +1,0 @@
-interface Inter {
-    fun foo(x: Int = <!UNRESOLVED_REFERENCE!>y<!>, y: Int = x)
-}
-
-abstract class Abst {
-    abstract fun foo(x: Int = <!UNRESOLVED_REFERENCE!>y<!>, y: Int = x)
-}
-
-<!NON_MEMBER_FUNCTION_NO_BODY!>fun extraDiagnostics(x: Int = <!UNRESOLVED_REFERENCE!>y<!>, y: Int)<!>

--- a/compiler/testData/diagnostics/tests/DefaultValuesCheckWithoutBody.kt
+++ b/compiler/testData/diagnostics/tests/DefaultValuesCheckWithoutBody.kt
@@ -1,3 +1,4 @@
+// FIR_IDENTICAL
 interface Inter {
     fun foo(x: Int = <!UNINITIALIZED_PARAMETER!>y<!>, y: Int = x)
 }

--- a/compiler/testData/diagnostics/tests/DefaultValuesTypechecking.fir.kt
+++ b/compiler/testData/diagnostics/tests/DefaultValuesTypechecking.fir.kt
@@ -7,10 +7,12 @@ fun bar(x : Int = "", y : Int = x, z : String = y) {
 
 // KT-371 Resolve default parameters for constructors
 
-class A(x : Int = <!UNRESOLVED_REFERENCE!>y<!>, y : Int = x) { // None of the references is resolved, no types checked
-    fun foo(bool: Boolean, a: Int = <!UNRESOLVED_REFERENCE!>b<!>, b: String = a) {}
+class A(x : Int = <!UNINITIALIZED_PARAMETER!>y<!>, y : Int = x) { // None of the references is resolved, no types checked
+    fun foo(bool: Boolean, a: Int = <!UNINITIALIZED_PARAMETER!>b<!>, b: String = a) {}
 }
 
 val z = 3
 
-fun foo(x: Int = <!UNRESOLVED_REFERENCE!>y<!>, y: Int = x, i : Int = z): Int = x + y
+fun foo(x: Int = <!UNINITIALIZED_PARAMETER!>y<!>, y: Int = x, i : Int = z): Int = x + y
+
+fun foo(x: () -> Int = { <!UNRESOLVED_REFERENCE!>y<!> }, y: Int = x(), i : Int = z): Int = x() + y

--- a/compiler/testData/diagnostics/tests/DefaultValuesTypechecking.fir.kt
+++ b/compiler/testData/diagnostics/tests/DefaultValuesTypechecking.fir.kt
@@ -15,4 +15,4 @@ val z = 3
 
 fun foo(x: Int = <!UNINITIALIZED_PARAMETER!>y<!>, y: Int = x, i : Int = z): Int = x + y
 
-fun foo(x: () -> Int = { <!UNRESOLVED_REFERENCE!>y<!> }, y: Int = x(), i : Int = z): Int = x() + y
+fun foo(x: () -> Int = { <!UNINITIALIZED_PARAMETER!>y<!> }, y: Int = x(), i : Int = z): Int = x() + y

--- a/compiler/testData/diagnostics/tests/DefaultValuesTypechecking.kt
+++ b/compiler/testData/diagnostics/tests/DefaultValuesTypechecking.kt
@@ -14,3 +14,5 @@ class A(x : Int = <!UNINITIALIZED_PARAMETER!>y<!>, y : Int = x) { // None of the
 val z = 3
 
 fun foo(x: Int = <!UNINITIALIZED_PARAMETER!>y<!>, y: Int = x, i : Int = z): Int = x + y
+
+fun foo(x: () -> Int = { <!UNINITIALIZED_PARAMETER{OI}!>y<!> }, y: Int = x(), i : Int = z): Int = x() + y

--- a/compiler/testData/diagnostics/tests/DefaultValuesTypechecking.txt
+++ b/compiler/testData/diagnostics/tests/DefaultValuesTypechecking.txt
@@ -3,6 +3,7 @@ package
 public val x: kotlin.String = ""
 public val z: kotlin.Int = 3
 public fun bar(/*0*/ x: kotlin.Int = ..., /*1*/ y: kotlin.Int = ..., /*2*/ z: kotlin.String = ...): kotlin.Unit
+public fun foo(/*0*/ x: () -> kotlin.Int = ..., /*1*/ y: kotlin.Int = ..., /*2*/ i: kotlin.Int = ...): kotlin.Int
 public fun foo(/*0*/ x: kotlin.Int = ..., /*1*/ y: kotlin.Int = ..., /*2*/ i: kotlin.Int = ...): kotlin.Int
 
 public final class A {

--- a/compiler/testData/diagnostics/tests/resolve/parameterAsDefaultValueInLocalFunction.fir.kt
+++ b/compiler/testData/diagnostics/tests/resolve/parameterAsDefaultValueInLocalFunction.fir.kt
@@ -1,6 +1,0 @@
-// !DIAGNOSTICS: -UNUSED_PARAMETER
-
-fun foo() {
-    fun bar(x: String, y: String = x) {}
-    fun baz(x: Int = <!UNRESOLVED_REFERENCE!>y<!>, y: Int) {}
-}

--- a/compiler/testData/diagnostics/tests/resolve/parameterAsDefaultValueInLocalFunction.kt
+++ b/compiler/testData/diagnostics/tests/resolve/parameterAsDefaultValueInLocalFunction.kt
@@ -1,3 +1,4 @@
+// FIR_IDENTICAL
 // !DIAGNOSTICS: -UNUSED_PARAMETER
 
 fun foo() {

--- a/compiler/testData/diagnostics/tests/resolve/underscoreInCatchBlock.fir.kt
+++ b/compiler/testData/diagnostics/tests/resolve/underscoreInCatchBlock.fir.kt
@@ -23,8 +23,9 @@ fun foo() {
                 10
             }
             fun bar(x: Exception = `_`) {}
-            class Bar(`_`: Exception = `_`) {
+            class Bar(`_`: Exception = <!UNINITIALIZED_PARAMETER!>`_`<!>) {
                 inner class Bar2(x: Exception = `_`) { }
+                inner class Bar3(x: Exception = <!UNINITIALIZED_PARAMETER!>`_`<!>, `_`: Exception) { }
             }
         }
     } catch (_: Exception) {

--- a/compiler/testData/diagnostics/tests/resolve/underscoreInCatchBlock.kt
+++ b/compiler/testData/diagnostics/tests/resolve/underscoreInCatchBlock.kt
@@ -25,6 +25,7 @@ fun foo() {
             fun bar(x: Exception = <!RESOLVED_TO_UNDERSCORE_NAMED_CATCH_PARAMETER!>`_`<!>) {}
             class Bar(`_`: Exception = <!UNINITIALIZED_PARAMETER!>`_`<!>) {
                 inner class Bar2(x: Exception = <!RESOLVED_TO_UNDERSCORE_NAMED_CATCH_PARAMETER!>`_`<!>) { }
+                inner class Bar3(x: Exception = <!UNINITIALIZED_PARAMETER!>`_`<!>, `_`: Exception) { }
             }
         }
     } catch (_: Exception) {

--- a/compiler/testData/diagnostics/tests/resolve/underscoreInCatchBlockWithEnabledFeature.fir.kt
+++ b/compiler/testData/diagnostics/tests/resolve/underscoreInCatchBlockWithEnabledFeature.fir.kt
@@ -23,7 +23,7 @@ fun foo() {
                 10
             }
             fun bar(x: Exception = `_`) {}
-            class Bar(`_`: Exception = `_`) {
+            class Bar(`_`: Exception = <!UNINITIALIZED_PARAMETER!>`_`<!>) {
                 inner class Bar2(x: Exception = `_`) { }
             }
         }

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDataClassConverters.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDataClassConverters.kt
@@ -1664,6 +1664,13 @@ internal val KT_DIAGNOSTIC_CONVERTER = KtDiagnosticConverterBuilder.buildConvert
             token,
         )
     }
+    add(FirErrors.UNINITIALIZED_PARAMETER) { firDiagnostic ->
+        UninitializedParameterImpl(
+            firSymbolBuilder.variableLikeBuilder.buildVariableLikeSymbol(firDiagnostic.a.fir),
+            firDiagnostic as FirPsiDiagnostic<*>,
+            token,
+        )
+    }
     add(FirErrors.UNINITIALIZED_ENUM_ENTRY) { firDiagnostic ->
         UninitializedEnumEntryImpl(
             firSymbolBuilder.variableLikeBuilder.buildVariableLikeSymbol(firDiagnostic.a.fir),

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnostics.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnostics.kt
@@ -1169,6 +1169,11 @@ sealed class KtFirDiagnostic<PSI: PsiElement> : KtDiagnosticWithPsi<PSI> {
         abstract val variable: KtVariableSymbol
     }
 
+    abstract class UninitializedParameter : KtFirDiagnostic<KtSimpleNameExpression>() {
+        override val diagnosticClass get() = UninitializedParameter::class
+        abstract val parameter: KtVariableLikeSymbol
+    }
+
     abstract class UninitializedEnumEntry : KtFirDiagnostic<KtSimpleNameExpression>() {
         override val diagnosticClass get() = UninitializedEnumEntry::class
         abstract val enumEntry: KtVariableLikeSymbol

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnosticsImpl.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnosticsImpl.kt
@@ -1896,6 +1896,14 @@ internal class UninitializedVariableImpl(
     override val firDiagnostic: FirPsiDiagnostic<*> by weakRef(firDiagnostic)
 }
 
+internal class UninitializedParameterImpl(
+    override val parameter: KtVariableLikeSymbol,
+    firDiagnostic: FirPsiDiagnostic<*>,
+    override val token: ValidityToken,
+) : KtFirDiagnostic.UninitializedParameter(), KtAbstractFirDiagnostic<KtSimpleNameExpression> {
+    override val firDiagnostic: FirPsiDiagnostic<*> by weakRef(firDiagnostic)
+}
+
 internal class UninitializedEnumEntryImpl(
     override val enumEntry: KtVariableLikeSymbol,
     firDiagnostic: FirPsiDiagnostic<*>,


### PR DESCRIPTION
If a value parameter's default value refers to another parameter that appears later, e.g.,

```kt
fun foo(x : Int = <!>y<!>, y : Int, ...) { ... }
```

we need to report `UNINITIALIZED_PARAMETER` on that access. It's currently unresolved named error in FIR, so while visiting those errors, we can differentiate uninitialized parameter cases by using context, such as containing declarations. (I've tried differentiating it in FIR resolution, but resolving qualified access doesn't have such context.) 1st commit did that.

------

Searching for containing declarations of certain types (in this case, value parameter and its containing function) needs to be careful, as per https://github.com/JetBrains/kotlin/pull/4244#discussion_r603010409, e.g.,

```kt
fun foo(x : () -> Int = { <!>y<!> }, y : Int, ...) { ... }
```

But adding such case revealed that 1) retrieving unnamed error from a FIR expression should have taken into account lambda return type (which is done in 1st commit) and that 2) retrieving diagnostics from `FirTypeRef` may not work for an unintuitive case: `FirResolvedTypeRef` with `ConeKotlinErrorType`, instead of `FirErrorTypeRef`. Note that `FirErrorTypeRef` is a subtype of `FirResolvedTypeRef`, i.e., resolved to an error. :p

We could consider such cases when retrieving diagnostics from `FirTypeRef`, e.g.,
```kt
val diagnostic = when(typeRef = typeRef) {
  is FirErrorTypeRef -> typeRef.diagnostic
  is FirResolvedTypeRef -> (typeRef.coneType as? ConeKotlinErrorType)?.diagnostic
  else -> null
}
```
but why not explicitly using `FirErrorTypeRef` when possible? 2nd commit found and corrected lambda return type wrapping, and 3rd commit extended that to general utils I know of.

------

However, this doesn't cover all missing diagnostics, in particular, [escaped underscore](https://punzki.github.io/Kotlin-DiagnosticTestsDiff/2021-04-13/viewDiff.html?expected=tests%2Fresolve%2FunderscoreInCatchBlock.kt&actual=tests%2Fresolve%2FunderscoreInCatchBlock.fir.kt):
```kt
try {
   ...
} catch (_ : Exception) {
  class Local(`_` : Exception = <!>`_`<!>)
}
```
and now we need  a declaration checker: `FirFunctionParameterChecker`.

I first tried to move all logics to there, but finding corresponding qualified access in a declaration checker isn't trivial. Rather, I decided to bail out for unresolved name error case from a declaration checker, and made it specific to escaped underscore case.