### PR TITLE
FIR: avoid wrapping an erroneous type as FirResolvedTypeRef

### DIFF
--- a/compiler/fir/analysis-tests/testData/resolve/asImports.fir.txt
+++ b/compiler/fir/analysis-tests/testData/resolve/asImports.fir.txt
@@ -10,7 +10,7 @@ FILE: A.kt
     }
 FILE: main.kt
     public final fun test_1(): R|kotlin/Unit| {
-        lval a: R|ERROR CLASS: Unresolved name: A| = <Unresolved name: A>#()
+        lval a: <ERROR TYPE REF: Unresolved name: A> = <Unresolved name: A>#()
         lval b: R|foo/A| = R|foo/A.A|()
         lval c: R|foo/A| = <Unresolved name: A>#()
     }

--- a/compiler/fir/analysis-tests/testData/resolve/cast.fir.txt
+++ b/compiler/fir/analysis-tests/testData/resolve/cast.fir.txt
@@ -18,7 +18,7 @@ FILE: cast.kt
     }
 
         public get(): R|(kotlin/String) -> kotlin/Boolean|
-    public final val hError: R|(ERROR CLASS: No type for parameter) -> kotlin/Boolean| = fun <anonymous>(_: R|ERROR CLASS: No type for parameter|): R|kotlin/Boolean| <inline=Unknown>  {
+    public final val hError: R|(ERROR CLASS: No type for parameter) -> kotlin/Boolean| = fun <anonymous>(_: <ERROR TYPE REF: No type for parameter>): R|kotlin/Boolean| <inline=Unknown>  {
         ^ Boolean(true)
     }
 

--- a/compiler/fir/analysis-tests/testData/resolve/diagnostics/instanceAccessBeforeSuperCall.fir.txt
+++ b/compiler/fir/analysis-tests/testData/resolve/diagnostics/instanceAccessBeforeSuperCall.fir.txt
@@ -25,7 +25,7 @@ FILE: instanceAccessBeforeSuperCall.kt
         }
 
         public constructor(x: R|kotlin/Int|): R|C| {
-            this<R|C|>(fun <anonymous>(): R|ERROR CLASS: Cannot access ''<this>'' before superclass constructor has been called| <inline=Unknown>  {
+            this<R|C|>(fun <anonymous>(): <ERROR TYPE REF: Cannot access ''<this>'' before superclass constructor has been called> <inline=Unknown>  {
                 lval a: R|kotlin/Int| = Int(10)
                 ^ this@R|/C|
             }
@@ -63,8 +63,8 @@ FILE: instanceAccessBeforeSuperCall.kt
     }
     public final fun test(f: R|F|): R|kotlin/Unit| {
     }
-    public final val a: R|ERROR CLASS: 'this' is not defined in this context| = this#
-        public get(): R|ERROR CLASS: 'this' is not defined in this context|
+    public final val a: <ERROR TYPE REF: 'this' is not defined in this context> = this#
+        public get(): <ERROR TYPE REF: 'this' is not defined in this context>
     public final class F : R|kotlin/Any| {
         public constructor(a: R|kotlin/Int|, b: R|kotlin/Int|, closure: R|() -> kotlin/Unit|, instance: R|F?|): R|F| {
             super<R|kotlin/Any|>()

--- a/compiler/fir/analysis-tests/testData/resolve/diagnostics/superIsNotAnExpression.fir.txt
+++ b/compiler/fir/analysis-tests/testData/resolve/diagnostics/superIsNotAnExpression.fir.txt
@@ -13,7 +13,7 @@ FILE: superIsNotAnExpression.kt
         public final fun act(): R|kotlin/Unit| {
             <Super cannot be a callee>#()
             <Unresolved name: invoke>#()
-            <Super cannot be a callee>#(<L> = <Super cannot be a callee>@fun <anonymous>(): R|ERROR CLASS: Unresolved name: println| <inline=Unknown>  {
+            <Super cannot be a callee>#(<L> = <Super cannot be a callee>@fun <anonymous>(): <ERROR TYPE REF: Unresolved name: println> <inline=Unknown>  {
                 ^ <Unresolved name: println>#(ERROR_EXPR(Incorrect character: 'weird'))
             }
             )

--- a/compiler/fir/analysis-tests/testData/resolve/diagnostics/typeArgumentsNotAllowed.fir.txt
+++ b/compiler/fir/analysis-tests/testData/resolve/diagnostics/typeArgumentsNotAllowed.fir.txt
@@ -22,10 +22,10 @@ FILE: typeArgumentsNotAllowed.kt
         }
 
     }
-    public final val a: R|ERROR CLASS: Unresolved name: MyClass| = Q|rest|.<Unresolved name: MyClass>#
-        public get(): R|ERROR CLASS: Unresolved name: MyClass|
-    public final val b: R|ERROR CLASS: Unresolved name: MyClass| = Q|rest/Best|.<Unresolved name: MyClass>#
-        public get(): R|ERROR CLASS: Unresolved name: MyClass|
+    public final val a: <ERROR TYPE REF: Unresolved name: MyClass> = Q|rest|.<Unresolved name: MyClass>#
+        public get(): <ERROR TYPE REF: Unresolved name: MyClass>
+    public final val b: <ERROR TYPE REF: Unresolved name: MyClass> = Q|rest/Best|.<Unresolved name: MyClass>#
+        public get(): <ERROR TYPE REF: Unresolved name: MyClass>
     public final class B<E> : R|kotlin/Any| {
         public constructor<E>(): R|rest/B<E>| {
             super<R|kotlin/Any|>()

--- a/compiler/fir/analysis-tests/testData/resolve/diagnostics/upperBoundViolated.fir.txt
+++ b/compiler/fir/analysis-tests/testData/resolve/diagnostics/upperBoundViolated.fir.txt
@@ -22,7 +22,7 @@ FILE: upperBoundViolated.kt
         lval b1: R|B<kotlin/Int>| = R|/B.B|<R|kotlin/Int|>()
         lval b2: R|B<C>| = R|/B.B|<R|C|>()
         lval b3: R|B<kotlin/Any?>| = R|/B.B|<R|kotlin/Any?|>()
-        lval b4: R|ERROR CLASS: Unresolved name: NumberPhile| = R|/B.B|<<ERROR TYPE REF: Symbol not found for UnexistingType>>().<Unresolved name: NL>#(ERROR_EXPR(No right operand)).<Unresolved name: Int>#(<Call has no callee>#()).<Unresolved name: NumberPhile>#(ERROR_EXPR(No right operand))
+        lval b4: <ERROR TYPE REF: Unresolved name: NumberPhile> = R|/B.B|<<ERROR TYPE REF: Symbol not found for UnexistingType>>().<Unresolved name: NL>#(ERROR_EXPR(No right operand)).<Unresolved name: Int>#(<Call has no callee>#()).<Unresolved name: NumberPhile>#(ERROR_EXPR(No right operand))
         lval b5: R|B<B<ERROR CLASS: Symbol not found for UnexistingType>>| = R|/B.B|<R|B<ERROR CLASS: Symbol not found for UnexistingType>|>()
         R|/fest|<R|kotlin/Boolean|>()
         R|/fest|<R|C|>()
@@ -58,8 +58,8 @@ FILE: upperBoundViolated.kt
 
     }
     public final typealias NL<K> = R|NumColl<kotlin/collections/List<K>>|
-    public final val test7: R|ERROR CLASS: Unresolved name: NumberPhile| = R|/NumColl.NumColl|<R|kotlin/Int|>().<Unresolved name: NumberPhile>#(ERROR_EXPR(No right operand))
-        public get(): R|ERROR CLASS: Unresolved name: NumberPhile|
+    public final val test7: <ERROR TYPE REF: Unresolved name: NumberPhile> = R|/NumColl.NumColl|<R|kotlin/Int|>().<Unresolved name: NumberPhile>#(ERROR_EXPR(No right operand))
+        public get(): <ERROR TYPE REF: Unresolved name: NumberPhile>
     public final val test8: R|NumColl<kotlin/collections/List<kotlin/String>>| = R|/NumColl.NumColl|<R|kotlin/String|>()
         public get(): R|NumColl<kotlin/collections/List<kotlin/String>>|
     public final class NumberPhile<T : R|kotlin/Number|> : R|kotlin/Any| {

--- a/compiler/fir/analysis-tests/testData/resolve/exhaustiveness/positive/exhaustiveness_enumJava.fir.txt
+++ b/compiler/fir/analysis-tests/testData/resolve/exhaustiveness/positive/exhaustiveness_enumJava.fir.txt
@@ -1,6 +1,6 @@
 FILE: main.kt
     public final fun test_1(e: R|JavaEnum|): R|kotlin/Unit| {
-        lval a: R|ERROR CLASS: Unresolved name: plus| = when (R|<local>/e|) {
+        lval a: <ERROR TYPE REF: Unresolved name: plus> = when (R|<local>/e|) {
             ==($subj$, Q|JavaEnum|.R|/JavaEnum.A|) ->  {
                 Int(1)
             }
@@ -9,7 +9,7 @@ FILE: main.kt
             }
         }
         .<Unresolved name: plus>#(Int(0))
-        lval b: R|ERROR CLASS: Unresolved name: plus| = when (R|<local>/e|) {
+        lval b: <ERROR TYPE REF: Unresolved name: plus> = when (R|<local>/e|) {
             ==($subj$, Q|JavaEnum|.R|/JavaEnum.A|) ->  {
                 Int(1)
             }
@@ -44,7 +44,7 @@ FILE: main.kt
         .R|kotlin/Int.plus|(Int(0))
     }
     public final fun test_2(e: R|JavaEnum?|): R|kotlin/Unit| {
-        lval a: R|ERROR CLASS: Unresolved name: plus| = when (R|<local>/e|) {
+        lval a: <ERROR TYPE REF: Unresolved name: plus> = when (R|<local>/e|) {
             ==($subj$, Q|JavaEnum|.R|/JavaEnum.A|) ->  {
                 Int(1)
             }

--- a/compiler/fir/analysis-tests/testData/resolve/exhaustiveness/positive/exhaustiveness_sealedSubClass.fir.txt
+++ b/compiler/fir/analysis-tests/testData/resolve/exhaustiveness/positive/exhaustiveness_sealedSubClass.fir.txt
@@ -77,7 +77,7 @@ FILE: exhaustiveness_sealedSubClass.kt
         .R|kotlin/Int.plus|(Int(0))
     }
     public final fun test_2(e: R|A|): R|kotlin/Unit| {
-        lval a: R|ERROR CLASS: Unresolved name: plus| = when (R|<local>/e|) {
+        lval a: <ERROR TYPE REF: Unresolved name: plus> = when (R|<local>/e|) {
             ($subj$ is R|D|) ->  {
                 Int(1)
             }
@@ -86,7 +86,7 @@ FILE: exhaustiveness_sealedSubClass.kt
             }
         }
         .<Unresolved name: plus>#(Int(0))
-        lval b: R|ERROR CLASS: Unresolved name: plus| = when (R|<local>/e|) {
+        lval b: <ERROR TYPE REF: Unresolved name: plus> = when (R|<local>/e|) {
             ($subj$ is R|B|) ->  {
                 Int(1)
             }
@@ -98,7 +98,7 @@ FILE: exhaustiveness_sealedSubClass.kt
             }
         }
         .<Unresolved name: plus>#(Int(0))
-        lval c: R|ERROR CLASS: Unresolved name: plus| = when (R|<local>/e|) {
+        lval c: <ERROR TYPE REF: Unresolved name: plus> = when (R|<local>/e|) {
             ($subj$ is R|B|) ->  {
                 Int(1)
             }

--- a/compiler/fir/analysis-tests/testData/resolve/expresssions/CallBasedInExpressionGenerator.fir.txt
+++ b/compiler/fir/analysis-tests/testData/resolve/expresssions/CallBasedInExpressionGenerator.fir.txt
@@ -29,8 +29,8 @@ FILE: CallBasedInExpressionGenerator.kt
         public final val codegen: R|org/jetbrains/kotlin/codegen/range/inExpression/ExpressionCodegen| = R|<local>/codegen|
             public get(): R|org/jetbrains/kotlin/codegen/range/inExpression/ExpressionCodegen|
 
-        private final val resolvedCall: R|ERROR CLASS: Unresolved name: getResolvedCallWithAssert| = R|<local>/operatorReference|.<Unresolved name: getResolvedCallWithAssert>#(this@R|org/jetbrains/kotlin/codegen/range/inExpression/CallBasedInExpressionGenerator|.R|org/jetbrains/kotlin/codegen/range/inExpression/CallBasedInExpressionGenerator.codegen|.<Unresolved name: bindingContext>#)
-            private get(): R|ERROR CLASS: Unresolved name: getResolvedCallWithAssert|
+        private final val resolvedCall: <ERROR TYPE REF: Unresolved name: getResolvedCallWithAssert> = R|<local>/operatorReference|.<Unresolved name: getResolvedCallWithAssert>#(this@R|org/jetbrains/kotlin/codegen/range/inExpression/CallBasedInExpressionGenerator|.R|org/jetbrains/kotlin/codegen/range/inExpression/CallBasedInExpressionGenerator.codegen|.<Unresolved name: bindingContext>#)
+            private get(): <ERROR TYPE REF: Unresolved name: getResolvedCallWithAssert>
 
         private final val isInverted: R|kotlin/Boolean| = ==(R|<local>/operatorReference|.<Unresolved name: getReferencedNameElementType>#(), <Unresolved name: KtTokens>#.<Unresolved name: NOT_IN>#)
             private get(): R|kotlin/Boolean|
@@ -75,7 +75,7 @@ FILE: CallBasedInExpressionGenerator.kt
                 }
 
                 private final fun invokeFunction(v: R|org/jetbrains/kotlin/codegen/range/inExpression/InstructionAdapter|): R|kotlin/Unit| {
-                    lval result: R|ERROR CLASS: Unresolved name: invokeFunction| = this@R|org/jetbrains/kotlin/codegen/range/inExpression/CallBasedInExpressionGenerator|.R|org/jetbrains/kotlin/codegen/range/inExpression/CallBasedInExpressionGenerator.codegen|.<Unresolved name: invokeFunction>#(this@R|org/jetbrains/kotlin/codegen/range/inExpression/CallBasedInExpressionGenerator|.R|org/jetbrains/kotlin/codegen/range/inExpression/CallBasedInExpressionGenerator.resolvedCall|.<Unresolved name: call>#, this@R|org/jetbrains/kotlin/codegen/range/inExpression/CallBasedInExpressionGenerator|.R|org/jetbrains/kotlin/codegen/range/inExpression/CallBasedInExpressionGenerator.resolvedCall|, <Unresolved name: none>#())
+                    lval result: <ERROR TYPE REF: Unresolved name: invokeFunction> = this@R|org/jetbrains/kotlin/codegen/range/inExpression/CallBasedInExpressionGenerator|.R|org/jetbrains/kotlin/codegen/range/inExpression/CallBasedInExpressionGenerator.codegen|.<Unresolved name: invokeFunction>#(this@R|org/jetbrains/kotlin/codegen/range/inExpression/CallBasedInExpressionGenerator|.R|org/jetbrains/kotlin/codegen/range/inExpression/CallBasedInExpressionGenerator.resolvedCall|.<Unresolved name: call>#, this@R|org/jetbrains/kotlin/codegen/range/inExpression/CallBasedInExpressionGenerator|.R|org/jetbrains/kotlin/codegen/range/inExpression/CallBasedInExpressionGenerator.resolvedCall|, <Unresolved name: none>#())
                     R|<local>/result|.<Unresolved name: put>#(R|<local>/result|.<Unresolved name: type>#, R|<local>/result|.<Unresolved name: kotlinType>#, R|<local>/v|)
                 }
 

--- a/compiler/fir/analysis-tests/testData/resolve/expresssions/access.fir.txt
+++ b/compiler/fir/analysis-tests/testData/resolve/expresssions/access.fir.txt
@@ -57,7 +57,7 @@ FILE: access.kt
         lval a: R|kotlin/Int| = Int(10)
         lval b: R|kotlin/Int| = R|<local>/a|
         lval d: R|kotlin/String| = String()
-        lval c: R|ERROR CLASS: Unresolved name: c| = <Unresolved name: c>#
+        lval c: <ERROR TYPE REF: Unresolved name: c> = <Unresolved name: c>#
         <Unresolved name: abc>#()
         local final fun bcd(): R|kotlin/Unit| {
         }

--- a/compiler/fir/analysis-tests/testData/resolve/expresssions/baseQualifier.fir.txt
+++ b/compiler/fir/analysis-tests/testData/resolve/expresssions/baseQualifier.fir.txt
@@ -29,7 +29,7 @@ FILE: Test.kt
         lval bbd: R|BB.D| = Q|BB.D|
         lval aac: R|AA.C| = Q|AA.C|
         Q|JavaClass|.R|/JavaClass.bar|()
-        lval errC: R|ERROR CLASS: Unresolved name: C| = Q|BB|.<Unresolved name: C>#
-        lval errBarViaBB: R|ERROR CLASS: Unresolved name: bar| = Q|BB|.<Unresolved name: bar>#()
-        lval errBarViaAA: R|ERROR CLASS: Unresolved name: bar| = Q|AA|.<Unresolved name: bar>#()
+        lval errC: <ERROR TYPE REF: Unresolved name: C> = Q|BB|.<Unresolved name: C>#
+        lval errBarViaBB: <ERROR TYPE REF: Unresolved name: bar> = Q|BB|.<Unresolved name: bar>#()
+        lval errBarViaAA: <ERROR TYPE REF: Unresolved name: bar> = Q|AA|.<Unresolved name: bar>#()
     }

--- a/compiler/fir/analysis-tests/testData/resolve/expresssions/companion.fir.txt
+++ b/compiler/fir/analysis-tests/testData/resolve/expresssions/companion.fir.txt
@@ -47,5 +47,5 @@ FILE: companion.kt
         Q|B|.R|/B.Companion.baz|()
         lval x: R|kotlin/String| = Q|A|.R|/A.Companion.D|
         lval y: R|kotlin/String| = Q|B|.R|/B.Companion.C|
-        lval z: R|ERROR CLASS: Unresolved name: D| = Q|B|.<Unresolved name: D>#
+        lval z: <ERROR TYPE REF: Unresolved name: D> = Q|B|.<Unresolved name: D>#
     }

--- a/compiler/fir/analysis-tests/testData/resolve/expresssions/errCallable.fir.txt
+++ b/compiler/fir/analysis-tests/testData/resolve/expresssions/errCallable.fir.txt
@@ -18,10 +18,10 @@ FILE: errCallable.kt
         }
 
         public final fun foo(): R|kotlin/Unit| {
-            lval x: R|ERROR CLASS: Unresolved reference: Nested| = ::<Unresolved reference: Nested>#
+            lval x: <ERROR TYPE REF: Unresolved reference: Nested> = ::<Unresolved reference: Nested>#
         }
 
     }
     public final fun R|Your|.foo(): R|kotlin/Unit| {
-        lval x: R|ERROR CLASS: Unresolved reference: Nested| = ::<Unresolved reference: Nested>#
+        lval x: <ERROR TYPE REF: Unresolved reference: Nested> = ::<Unresolved reference: Nested>#
     }

--- a/compiler/fir/analysis-tests/testData/resolve/expresssions/localObjects.fir.txt
+++ b/compiler/fir/analysis-tests/testData/resolve/expresssions/localObjects.fir.txt
@@ -40,5 +40,5 @@ FILE: localObjects.kt
 
         Q|B|.R|/B.foo|()
     }
-    public final val bb: R|ERROR CLASS: Unresolved name: foo| = <Unresolved name: B>#.<Unresolved name: foo>#()
-        public get(): R|ERROR CLASS: Unresolved name: foo|
+    public final val bb: <ERROR TYPE REF: Unresolved name: foo> = <Unresolved name: B>#.<Unresolved name: foo>#()
+        public get(): <ERROR TYPE REF: Unresolved name: foo>

--- a/compiler/fir/analysis-tests/testData/resolve/expresssions/nestedObjects.fir.txt
+++ b/compiler/fir/analysis-tests/testData/resolve/expresssions/nestedObjects.fir.txt
@@ -25,7 +25,7 @@ FILE: nestedObjects.kt
         }
 
     }
-    public final val err: R|ERROR CLASS: Unresolved name: B| = Q|B|.<Unresolved name: A>#.<Unresolved name: B>#
-        public get(): R|ERROR CLASS: Unresolved name: B|
+    public final val err: <ERROR TYPE REF: Unresolved name: B> = Q|B|.<Unresolved name: A>#.<Unresolved name: B>#
+        public get(): <ERROR TYPE REF: Unresolved name: B>
     public final val correct: R|A.B.A| = Q|A.B.A|
         public get(): R|A.B.A|

--- a/compiler/fir/analysis-tests/testData/resolve/expresssions/privateObjectLiteral.fir.txt
+++ b/compiler/fir/analysis-tests/testData/resolve/expresssions/privateObjectLiteral.fir.txt
@@ -33,7 +33,7 @@ FILE: privateObjectLiteral.kt
 
             internal get(): R|kotlin/Any|
 
-        public final val w: R|ERROR CLASS: Unresolved name: foo| = this@R|/C|.R|/C.z|.<Unresolved name: foo>#()
-            public get(): R|ERROR CLASS: Unresolved name: foo|
+        public final val w: <ERROR TYPE REF: Unresolved name: foo> = this@R|/C|.R|/C.z|.<Unresolved name: foo>#()
+            public get(): <ERROR TYPE REF: Unresolved name: foo>
 
     }

--- a/compiler/fir/analysis-tests/testData/resolve/innerClasses/inner.fir.txt
+++ b/compiler/fir/analysis-tests/testData/resolve/innerClasses/inner.fir.txt
@@ -41,7 +41,7 @@ FILE: inner.kt
     public final fun test(): R|kotlin/Unit| {
         lval o: R|Owner| = R|/Owner.Owner|()
         R|<local>/o|.R|/Owner.foo|()
-        lval err: R|ERROR CLASS: Unresolved name: Inner| = Q|Owner|.<Unresolved name: Inner>#()
+        lval err: <ERROR TYPE REF: Unresolved name: Inner> = Q|Owner|.<Unresolved name: Inner>#()
         R|<local>/err|.<Unresolved name: baz>#()
         lval i: R|Owner.Inner| = R|<local>/o|.R|/Owner.Inner.Inner|()
         R|<local>/i|.R|/Owner.Inner.gau|()

--- a/compiler/fir/analysis-tests/testData/resolve/nestedClassContructor.fir.txt
+++ b/compiler/fir/analysis-tests/testData/resolve/nestedClassContructor.fir.txt
@@ -35,7 +35,7 @@ FILE: nestedClassContructor.kt
         public final fun foo(): R|kotlin/Unit| {
             lval a: R|A| = R|/A.A|()
             lval ac: R|A.C| = Q|A|.R|/A.C.C|()
-            lval c: R|ERROR CLASS: Unresolved name: C| = <Unresolved name: C>#()
+            lval c: <ERROR TYPE REF: Unresolved name: C> = <Unresolved name: C>#()
         }
 
     }

--- a/compiler/fir/analysis-tests/testData/resolve/problems/inaccessibleJavaGetter.fir.txt
+++ b/compiler/fir/analysis-tests/testData/resolve/problems/inaccessibleJavaGetter.fir.txt
@@ -26,7 +26,7 @@ FILE: test.kt
     public final fun test(): R|kotlin/Unit| {
         lval descriptor: R|WrappedPropertyDescriptor| = R|/WrappedPropertyDescriptor.WrappedPropertyDescriptor|()
         lval res1: R|kotlin/String| = R|<local>/descriptor|.R|/WrappedPropertyDescriptor.setter|
-        lval res2: R|ERROR CLASS: Unresolved name: getSetter| = R|<local>/descriptor|.<Unresolved name: getSetter>#()
+        lval res2: <ERROR TYPE REF: Unresolved name: getSetter> = R|<local>/descriptor|.<Unresolved name: getSetter>#()
         lval res3: R|kotlin/Boolean| = R|<local>/descriptor|.R|/WrappedPropertyDescriptor.isDelegated|
-        lval res4: R|ERROR CLASS: Unresolved name: isDelegated| = R|<local>/descriptor|.<Unresolved name: isDelegated>#()
+        lval res4: <ERROR TYPE REF: Unresolved name: isDelegated> = R|<local>/descriptor|.<Unresolved name: isDelegated>#()
     }

--- a/compiler/fir/analysis-tests/testData/resolve/problems/multipleJavaClassesInOneFile.fir.txt
+++ b/compiler/fir/analysis-tests/testData/resolve/problems/multipleJavaClassesInOneFile.fir.txt
@@ -1,5 +1,5 @@
 FILE: main.kt
     public final fun test(): R|kotlin/Unit| {
         lval some: R|foo/Some| = R|foo/Some.Some|()
-        lval another: R|ERROR CLASS: Unresolved name: Another| = <Unresolved name: Another>#()
+        lval another: <ERROR TYPE REF: Unresolved name: Another> = <Unresolved name: Another>#()
     }

--- a/compiler/fir/analysis-tests/testData/resolve/properties/javaAccessorConversion.fir.txt
+++ b/compiler/fir/analysis-tests/testData/resolve/properties/javaAccessorConversion.fir.txt
@@ -1,15 +1,15 @@
 FILE: main.kt
     public final fun test_1(x: R|A|): R|kotlin/Unit| {
         lval str1: R|ft<kotlin/String, kotlin/String?>| = R|<local>/x|.R|/A.vmParameters|
-        lval str2: R|ERROR CLASS: Unresolved name: vMParameters| = R|<local>/x|.<Unresolved name: vMParameters>#
+        lval str2: <ERROR TYPE REF: Unresolved name: vMParameters> = R|<local>/x|.<Unresolved name: vMParameters>#
     }
     public final fun test_2(x: R|B|): R|kotlin/Unit| {
         lval int: R|ft<kotlin/Int, kotlin/Int?>| = R|<local>/x|.R|/B.vmParameters|
-        lval error: R|ERROR CLASS: Unresolved name: vMParameters| = R|<local>/x|.<Unresolved name: vMParameters>#
+        lval error: <ERROR TYPE REF: Unresolved name: vMParameters> = R|<local>/x|.<Unresolved name: vMParameters>#
     }
     public final fun test_3(x: R|C|): R|kotlin/Unit| {
-        lval error: R|ERROR CLASS: Ambiguity: vmParameters, [/C.vmParameters, /C.vmParameters]| = R|<local>/x|.<Ambiguity: vmParameters, [/C.vmParameters, /C.vmParameters]>#
-        lval int: R|ERROR CLASS: Unresolved name: vMParameters| = R|<local>/x|.<Unresolved name: vMParameters>#
+        lval error: <ERROR TYPE REF: Ambiguity: vmParameters, [/C.vmParameters, /C.vmParameters]> = R|<local>/x|.<Ambiguity: vmParameters, [/C.vmParameters, /C.vmParameters]>#
+        lval int: <ERROR TYPE REF: Unresolved name: vMParameters> = R|<local>/x|.<Unresolved name: vMParameters>#
     }
     public final class Foo : R|kotlin/Any| {
         public constructor(): R|Foo| {

--- a/compiler/fir/analysis-tests/testData/resolve/references/leakedImplicitType.fir.txt
+++ b/compiler/fir/analysis-tests/testData/resolve/references/leakedImplicitType.fir.txt
@@ -7,7 +7,7 @@ FILE: leakedImplicitType.kt
         public final fun bar(): R|kotlin/Unit| {
         }
 
-        public final fun f(): R|ERROR CLASS: Unresolved reference: bar| {
+        public final fun f(): <ERROR TYPE REF: Unresolved reference: bar> {
             ^f <Unresolved name: Unresolved>#()::<Unresolved reference: bar>#
         }
 

--- a/compiler/fir/analysis-tests/testData/resolve/references/referenceToExtension.fir.txt
+++ b/compiler/fir/analysis-tests/testData/resolve/references/referenceToExtension.fir.txt
@@ -40,8 +40,8 @@ FILE: referenceToExtension.kt
         }
 
         public final fun test_2(): R|kotlin/Unit| {
-            lval extensionValRef: R|ERROR CLASS: Unresolved reference: extensionVal| = Q|GenericTest.B|::<Unresolved reference: extensionVal>#
-            lval extensionFunRef: R|ERROR CLASS: Unresolved reference: extensionFun| = Q|GenericTest.B|::<Unresolved reference: extensionFun>#
+            lval extensionValRef: <ERROR TYPE REF: Unresolved reference: extensionVal> = Q|GenericTest.B|::<Unresolved reference: extensionVal>#
+            lval extensionFunRef: <ERROR TYPE REF: Unresolved reference: extensionFun> = Q|GenericTest.B|::<Unresolved reference: extensionFun>#
         }
 
     }

--- a/compiler/fir/analysis-tests/testData/resolveWithStdlib/callableReferences/beyoundCalls.fir.txt
+++ b/compiler/fir/analysis-tests/testData/resolveWithStdlib/callableReferences/beyoundCalls.fir.txt
@@ -13,7 +13,7 @@ FILE: beyoundCalls.kt
     }
     public final fun foo(): R|kotlin/Unit| {
         lval x: R|(kotlin/String) -> kotlin/Int| = ::R|/bar|
-        lval y: R|ERROR CLASS: Ambiguity: bar, [/bar, /bar]| = ::<Ambiguity: bar, [/bar, /bar]>#
+        lval y: <ERROR TYPE REF: Ambiguity: bar, [/bar, /bar]> = ::<Ambiguity: bar, [/bar, /bar]>#
         lval z: R|kotlin/reflect/KFunction1<kotlin/String, kotlin/Int>| = ::R|/baz|
         lval w: R|(kotlin/String) -> kotlin/Int| = ::R|/foobaz<kotlin/String, kotlin/Int>|
         ::R|/baz|

--- a/compiler/fir/analysis-tests/testData/resolveWithStdlib/callableReferences/fromBasicDiagnosticTests/moreSpecificAmbiguousExtensions.fir.txt
+++ b/compiler/fir/analysis-tests/testData/resolveWithStdlib/callableReferences/fromBasicDiagnosticTests/moreSpecificAmbiguousExtensions.fir.txt
@@ -9,7 +9,7 @@ FILE: moreSpecificAmbiguousExtensions.kt
     }
     public final fun test(): R|kotlin/Unit| {
         lval extFun1: R|@ExtensionFunctionType kotlin/reflect/KFunction2<IA, IB, kotlin/Unit>| = Q|IA|::R|/extFun|
-        lval extFun2: R|ERROR CLASS: Ambiguity: extFun, [/extFun, /extFun]| = Q|IB|::<Ambiguity: extFun, [/extFun, /extFun]>#
+        lval extFun2: <ERROR TYPE REF: Ambiguity: extFun, [/extFun, /extFun]> = Q|IB|::<Ambiguity: extFun, [/extFun, /extFun]>#
     }
     public final fun testWithExpectedType(): R|kotlin/Unit| {
         lval extFun_AB_A: R|IA.(IB) -> kotlin/Unit| = Q|IA|::R|/extFun|

--- a/compiler/fir/analysis-tests/testData/resolveWithStdlib/diagnostics/forLoopChecker.fir.txt
+++ b/compiler/fir/analysis-tests/testData/resolveWithStdlib/diagnostics/forLoopChecker.fir.txt
@@ -172,9 +172,9 @@ FILE: forLoopChecker.kt
     }
     public final fun test(notRange1: R|NotRange1|, notRange2: R|NotRange2|, notRange3: R|NotRange3|, notRange4: R|NotRange4|, notRange5: R|NotRange5|, notRange6: R|NotRange6|, notRange7: R|NotRange7|, notRange8: R|NotRange8|, notRange9: R|NotRange9|, range0: R|Range0|, range1: R|Range1|): R|kotlin/Unit| {
          {
-            lval <iterator>: R|ERROR CLASS: Unresolved name: iterator| = R|<local>/notRange1|.<Unresolved name: iterator>#()
+            lval <iterator>: <ERROR TYPE REF: Unresolved name: iterator> = R|<local>/notRange1|.<Unresolved name: iterator>#()
             while(R|<local>/<iterator>|.<Unresolved name: hasNext>#()) {
-                lval i: R|ERROR CLASS: Unresolved name: next| = R|<local>/<iterator>|.<Unresolved name: next>#()
+                lval i: <ERROR TYPE REF: Unresolved name: next> = R|<local>/<iterator>|.<Unresolved name: next>#()
             }
 
         }
@@ -182,7 +182,7 @@ FILE: forLoopChecker.kt
          {
             lval <iterator>: R|kotlin/Unit| = R|<local>/notRange2|.R|/NotRange2.iterator|()
             while(R|<local>/<iterator>|.<Unresolved name: hasNext>#()) {
-                lval i: R|ERROR CLASS: Unresolved name: next| = R|<local>/<iterator>|.<Unresolved name: next>#()
+                lval i: <ERROR TYPE REF: Unresolved name: next> = R|<local>/<iterator>|.<Unresolved name: next>#()
             }
 
         }
@@ -190,7 +190,7 @@ FILE: forLoopChecker.kt
          {
             lval <iterator>: R|ImproperIterator1| = R|<local>/notRange3|.R|/NotRange3.iterator|()
             while(R|<local>/<iterator>|.R|/ImproperIterator1.hasNext|()) {
-                lval i: R|ERROR CLASS: Unresolved name: next| = R|<local>/<iterator>|.<Unresolved name: next>#()
+                lval i: <ERROR TYPE REF: Unresolved name: next> = R|<local>/<iterator>|.<Unresolved name: next>#()
             }
 
         }

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/collectors/components/ErrorNodeDiagnosticCollectorComponent.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/collectors/components/ErrorNodeDiagnosticCollectorComponent.kt
@@ -58,7 +58,10 @@ class ErrorNodeDiagnosticCollectorComponent(
         ) return
 
         // If the receiver cannot be resolved, we skip reporting any further problems for this call.
-        if (qualifiedAccess?.dispatchReceiver.hasUnresolvedNameError() || qualifiedAccess?.extensionReceiver.hasUnresolvedNameError() || qualifiedAccess?.explicitReceiver.hasUnresolvedNameError()) return
+        if (qualifiedAccess?.dispatchReceiver.hasUnresolvedNameError() ||
+            qualifiedAccess?.extensionReceiver.hasUnresolvedNameError() ||
+            qualifiedAccess?.explicitReceiver.hasUnresolvedNameError()
+        ) return
 
         reportFirDiagnostic(errorNamedReference.diagnostic, source, reporter, data, qualifiedAccess?.source)
     }

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/CopyUtils.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/CopyUtils.kt
@@ -90,14 +90,20 @@ fun FirAnonymousFunction.copy(
     }
 }
 
-
 fun FirTypeRef.resolvedTypeFromPrototype(
     type: ConeKotlinType
 ): FirResolvedTypeRef {
-    return buildResolvedTypeRef {
-        source = this@resolvedTypeFromPrototype.source
-        this.type = type
-        annotations += this@resolvedTypeFromPrototype.annotations
+    return if (type is ConeKotlinErrorType) {
+        buildErrorTypeRef {
+            source = this@resolvedTypeFromPrototype.source
+            diagnostic = type.diagnostic
+        }
+    } else {
+        buildResolvedTypeRef {
+            source = this@resolvedTypeFromPrototype.source
+            this.type = type
+            annotations += this@resolvedTypeFromPrototype.annotations
+        }
     }
 }
 

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirDeclarationsResolveTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirDeclarationsResolveTransformer.kt
@@ -673,10 +673,8 @@ open class FirDeclarationsResolveTransformer(transformer: FirBodyResolveTransfor
                                     if (param.returnTypeRef is FirResolvedTypeRef) {
                                         param
                                     } else {
-                                        val resolvedType = buildResolvedTypeRef {
-                                            source = param.source
-                                            type = resolvedLambdaAtom.parameters[index]
-                                        }
+                                        val resolvedType =
+                                            param.returnTypeRef.resolvedTypeFromPrototype(resolvedLambdaAtom.parameters[index])
                                         param.replaceReturnTypeRef(resolvedType)
                                         param
                                     }
@@ -808,6 +806,12 @@ open class FirDeclarationsResolveTransformer(transformer: FirBodyResolveTransfor
                 val expectedType = when (resultType) {
                     is FirImplicitTypeRef -> buildErrorTypeRef {
                         diagnostic = ConeSimpleDiagnostic("No result type for initializer", DiagnosticKind.InferenceError)
+                    }
+                    is FirErrorTypeRef -> buildErrorTypeRef {
+                        diagnostic = resultType.diagnostic
+                        resultType.source?.fakeElement(FirFakeSourceElementKind.ImplicitTypeRef)?.let {
+                            source = it
+                        }
                     }
                     else -> {
                         buildResolvedTypeRef {

--- a/compiler/testData/diagnostics/tests/SafeCallOnFakePackage.fir.kt
+++ b/compiler/testData/diagnostics/tests/SafeCallOnFakePackage.fir.kt
@@ -12,5 +12,5 @@ val s: String = "test"
 fun ff() {
     val a = Test<!UNEXPECTED_SAFE_CALL!>?.<!><!UNRESOLVED_REFERENCE!>FOO<!>
     val b = foo<!UNEXPECTED_SAFE_CALL!>?.<!><!UNRESOLVED_REFERENCE!>s<!>
-    System<!UNEXPECTED_SAFE_CALL!>?.<!><!UNRESOLVED_REFERENCE!>out<!>.<!UNRESOLVED_REFERENCE!>println<!>(a + b)
+    System<!UNEXPECTED_SAFE_CALL!>?.<!><!UNRESOLVED_REFERENCE!>out<!>.println(a + b)
 }

--- a/compiler/testData/diagnostics/tests/functionAsExpression/WithGenericParameters.fir.kt
+++ b/compiler/testData/diagnostics/tests/functionAsExpression/WithGenericParameters.fir.kt
@@ -13,7 +13,7 @@ fun fun_with_where() = fun <!TYPE_PARAMETERS_NOT_ALLOWED!><T><!> <!UNRESOLVED_RE
 fun outer() {
     devNull(fun <!TYPE_PARAMETERS_NOT_ALLOWED!><T><!>() {})
     devNull(fun <!TYPE_PARAMETERS_NOT_ALLOWED!><T><!> <!UNRESOLVED_REFERENCE!>T<!>.() {})
-    devNull(fun <!TYPE_PARAMETERS_NOT_ALLOWED!><T><!> (): <!UNRESOLVED_REFERENCE, UNRESOLVED_REFERENCE!>T<!> = null!!)
+    devNull(fun <!TYPE_PARAMETERS_NOT_ALLOWED!><T><!> (): <!UNRESOLVED_REFERENCE!>T<!> = null!!)
     devNull(fun <!TYPE_PARAMETERS_NOT_ALLOWED!><T><!> (t: <!UNRESOLVED_REFERENCE!>T<!>) {})
     devNull(fun <!TYPE_PARAMETERS_NOT_ALLOWED!><T><!> () where T:A {})
 }

--- a/compiler/testData/diagnostics/tests/regressions/kt10843.fir.kt
+++ b/compiler/testData/diagnostics/tests/regressions/kt10843.fir.kt
@@ -1,7 +1,7 @@
 // !WITH_NEW_INFERENCE
 // NI_EXPECTED_FILE
 // See EA-76890 / KT-10843: NPE during analysis
-fun lambda(x : Int?) = x?.<!UNRESOLVED_REFERENCE!>let<!> <!UNRESOLVED_REFERENCE!>l<!> {
+fun lambda(x : Int?) = x?.<!UNRESOLVED_REFERENCE!>let<!> l {
     y ->
     if (y <!UNRESOLVED_REFERENCE!>><!> 0) return@l x
     y

--- a/compiler/testData/diagnostics/testsWithStdLib/resolve/javaStaticMembers.fir.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/resolve/javaStaticMembers.fir.kt
@@ -8,5 +8,5 @@ fun ff() {
     val a = Test.FOO
     val b = Test<!UNEXPECTED_SAFE_CALL!>?.<!><!UNRESOLVED_REFERENCE!>FOO<!>
     System.out.println(a + b)
-    System<!UNEXPECTED_SAFE_CALL!>?.<!><!UNRESOLVED_REFERENCE!>out<!>.<!UNRESOLVED_REFERENCE!>println<!>(a + b)
+    System<!UNEXPECTED_SAFE_CALL!>?.<!><!UNRESOLVED_REFERENCE!>out<!>.println(a + b)
 }


### PR DESCRIPTION
The motivation is #4317 where I found retrieving diagnostics from `FirTypeRef` may not work for an unintuitive case: `FirResolvedTypeRef` with `ConeKotlinErrorType`, instead of `FirErrorTypeRef`.

We could consider such cases when retrieving diagnostics from `FirTypeRef`, e.g.,
```kt
val diagnostic = when(typeRef = typeRef) {
  is FirErrorTypeRef -> typeRef.diagnostic
  is FirResolvedTypeRef -> (typeRef.coneType as? ConeKotlinErrorType)?.diagnostic
  else -> null
}
```
but using `FirErrorTypeRef`, a subtype of `FirResolvedTypeRef`, whenever possible seems more explicit.