### PR TITLE
FIR checker: report VAL_REASSIGNMENT on value parameter

### DIFF
--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/FirPropertyInitializationAnalyzer.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/FirPropertyInitializationAnalyzer.kt
@@ -80,17 +80,14 @@ object FirPropertyInitializationAnalyzer : AbstractFirPropertyInitializationChec
             }
             val kind = info[symbol] ?: EventOccurrencesRange.ZERO
             if (symbol.fir.isVal && kind.canBeRevisited()) {
-                node.fir.lValue.source?.let {
-                    reporter.report(FirErrors.VAL_REASSIGNMENT.on(it, symbol), context)
-                    return true
-                }
+                reporter.reportOn(node.fir.lValue.source, FirErrors.VAL_REASSIGNMENT, symbol, context)
+                return true
             }
             return false
         }
 
         override fun visitQualifiedAccessNode(node: QualifiedAccessNode) {
-            val reference = node.fir.calleeReference as? FirResolvedNamedReference ?: return
-            val symbol = reference.resolvedSymbol as? FirPropertySymbol ?: return
+            val symbol = getPropertySymbol(node) ?: return
             if (symbol !in localProperties) return
             if (symbol.fir.isLateInit) return
             val pathAwareInfo = data.getValue(node)
@@ -109,10 +106,8 @@ object FirPropertyInitializationAnalyzer : AbstractFirPropertyInitializationChec
         ): Boolean {
             val kind = info[symbol] ?: EventOccurrencesRange.ZERO
             if (!kind.isDefinitelyVisited()) {
-                node.fir.source?.let {
-                    reporter.report(FirErrors.UNINITIALIZED_VARIABLE.on(it, symbol), context)
-                    return true
-                }
+                reporter.reportOn(node.fir.source, FirErrors.UNINITIALIZED_VARIABLE, symbol, context)
+                return true
             }
             return false
         }

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/CommonExpressionCheckers.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/CommonExpressionCheckers.kt
@@ -51,7 +51,7 @@ object CommonExpressionCheckers : ExpressionCheckers() {
 
     override val variableAssignmentCheckers: Set<FirVariableAssignmentChecker>
         get() = setOf(
-            FirValReassignmentViaBackingFieldChecker,
+            FirValReassignmentChecker,
             FirAssignmentTypeMismatchChecker
         )
 

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/expression/FirValReassignmentChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/expression/FirValReassignmentChecker.kt
@@ -16,8 +16,16 @@ import org.jetbrains.kotlin.fir.expressions.FirVariableAssignment
 import org.jetbrains.kotlin.fir.languageVersionSettings
 import org.jetbrains.kotlin.fir.references.FirBackingFieldReference
 
-object FirValReassignmentViaBackingFieldChecker : FirVariableAssignmentChecker() {
+object FirValReassignmentChecker : FirVariableAssignmentChecker() {
     override fun check(expression: FirVariableAssignment, context: CheckerContext, reporter: DiagnosticReporter) {
+        checkValReassignmentViaBackingField(expression, context, reporter)
+    }
+
+    private fun checkValReassignmentViaBackingField(
+        expression: FirVariableAssignment,
+        context: CheckerContext,
+        reporter: DiagnosticReporter
+    ) {
         val backingFieldReference = expression.lValue as? FirBackingFieldReference ?: return
         val property = backingFieldReference.resolvedSymbol.fir
         if (property.isVar) return

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/expression/FirValReassignmentChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/expression/FirValReassignmentChecker.kt
@@ -12,13 +12,16 @@ import org.jetbrains.kotlin.fir.analysis.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors
 import org.jetbrains.kotlin.fir.analysis.diagnostics.reportOn
 import org.jetbrains.kotlin.fir.declarations.FirPropertyAccessor
+import org.jetbrains.kotlin.fir.declarations.FirValueParameter
 import org.jetbrains.kotlin.fir.expressions.FirVariableAssignment
 import org.jetbrains.kotlin.fir.languageVersionSettings
 import org.jetbrains.kotlin.fir.references.FirBackingFieldReference
+import org.jetbrains.kotlin.fir.references.FirResolvedNamedReference
 
 object FirValReassignmentChecker : FirVariableAssignmentChecker() {
     override fun check(expression: FirVariableAssignment, context: CheckerContext, reporter: DiagnosticReporter) {
         checkValReassignmentViaBackingField(expression, context, reporter)
+        checkValReassignmentOnValueParameter(expression, context, reporter)
     }
 
     private fun checkValReassignmentViaBackingField(
@@ -39,5 +42,14 @@ object FirValReassignmentChecker : FirVariableAssignmentChecker() {
                 reporter.reportOn(it, FirErrors.VAL_REASSIGNMENT_VIA_BACKING_FIELD, property.symbol, context)
             }
         }
+    }
+
+    private fun checkValReassignmentOnValueParameter(
+        expression: FirVariableAssignment,
+        context: CheckerContext,
+        reporter: DiagnosticReporter
+    ) {
+        val valueParameter = (expression.lValue as? FirResolvedNamedReference)?.resolvedSymbol?.fir as? FirValueParameter ?: return
+        reporter.reportOn(expression.lValue.source, FirErrors.VAL_REASSIGNMENT, valueParameter.symbol, context)
     }
 }

--- a/compiler/testData/diagnostics/tests/LValueAssignment.fir.kt
+++ b/compiler/testData/diagnostics/tests/LValueAssignment.fir.kt
@@ -59,7 +59,7 @@ fun canBe(i0: Int, j: Int) {
     var i = i0
     (label@ i) = 34
 
-    (label@ j) = 34 //repeat for j
+    (label@ <!VAL_REASSIGNMENT!>j<!>) = 34 //repeat for j
 
     val a = A()
     (l@ a.a) = 3894
@@ -69,7 +69,7 @@ fun canBe(i0: Int, j: Int) {
 }
 
 fun canBe2(j: Int) {
-    (label@ j) = 34
+    (label@ <!VAL_REASSIGNMENT!>j<!>) = 34
 }
 
 class A() {

--- a/compiler/testData/diagnostics/tests/controlFlowAnalysis/UninitializedOrReassignedVariables.fir.kt
+++ b/compiler/testData/diagnostics/tests/controlFlowAnalysis/UninitializedOrReassignedVariables.fir.kt
@@ -54,7 +54,7 @@ fun t2() {
 class A() {}
 
 fun t4(a: A) {
-    a = A()
+    <!VAL_REASSIGNMENT!>a<!> = A()
 }
 
 // ------------------------------------------------
@@ -188,7 +188,7 @@ class AnonymousInitializers(var a: String, val b: String) {
 }
 
 fun reassignFunParams(a: Int) {
-    a = 1
+    <!VAL_REASSIGNMENT!>a<!> = 1
 }
 
 open class Open(a: Int, w: Int) {}

--- a/compiler/testData/diagnostics/tests/controlFlowAnalysis/deadCode/deadCodeInUnaryExpr.fir.kt
+++ b/compiler/testData/diagnostics/tests/controlFlowAnalysis/deadCode/deadCodeInUnaryExpr.fir.kt
@@ -5,7 +5,7 @@ fun testPrefix() {
 
 fun testPostfixWithCall(n: Nothing) {
     operator fun Nothing.inc(): Nothing = this
-    n++
+    <!VAL_REASSIGNMENT!>n<!>++
 }
 
 fun testPostfixSpecial() {

--- a/compiler/testData/diagnostics/tests/suppress/allWarnings/suppressWarningsOnClass.fir.kt
+++ b/compiler/testData/diagnostics/tests/suppress/allWarnings/suppressWarningsOnClass.fir.kt
@@ -1,7 +1,0 @@
-@Suppress("warnings")
-class C {
-    fun foo(p: String??) {
-        // Make sure errors are not suppressed:
-        p = ""
-    }
-}

--- a/compiler/testData/diagnostics/tests/suppress/allWarnings/suppressWarningsOnClass.kt
+++ b/compiler/testData/diagnostics/tests/suppress/allWarnings/suppressWarningsOnClass.kt
@@ -1,3 +1,4 @@
+// FIR_IDENTICAL
 @Suppress("warnings")
 class C {
     fun foo(p: String??) {

--- a/compiler/tests-spec/testData/diagnostics/notLinked/dfa/neg/13.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/dfa/neg/13.fir.kt
@@ -5,7 +5,7 @@
 // TESTCASE NUMBER: 1
 fun case_1(x: Class?) {
     x!!
-    <!DEBUG_INFO_EXPRESSION_TYPE("Class? & Class")!>x<!>[if (true) {x=null;0} else 0] += <!DEBUG_INFO_EXPRESSION_TYPE("Class? & Class")!>x<!>[0]
+    <!DEBUG_INFO_EXPRESSION_TYPE("Class? & Class")!>x<!>[if (true) {<!VAL_REASSIGNMENT!>x<!>=null;0} else 0] += <!DEBUG_INFO_EXPRESSION_TYPE("Class? & Class")!>x<!>[0]
     <!DEBUG_INFO_EXPRESSION_TYPE("Class? & Class")!>x<!>
     <!DEBUG_INFO_EXPRESSION_TYPE("Class? & Class")!>x<!>[0].inv()
 }


### PR DESCRIPTION
E.g.,

```kt
fun reassignFunParams(a: Int) {
    <!VAL_REASSIGNMENT!>a<!> = 1
} 
```

This doesn't require CFA. We can simply visit variable assignment, and check if the lvalue is value parameter.

2nd commit refactors existing `FirValReassignmentViaBackingFieldChecker` to a general form, and 3rd commit adds that new part. 1st commit is a simple cleanup while revisiting CFA.