### PR TITLE
JVM IR: Avoid double mangling of function reference invoke methods

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -19194,6 +19194,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
             }
 
             @Test
+            @TestMetadata("mangledSamWrappers.kt")
+            public void testMangledSamWrappers() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/funInterface/mangledSamWrappers.kt");
+            }
+
+            @Test
             @TestMetadata("returnIC.kt")
             public void testReturnIC() throws Exception {
                 runTest("compiler/testData/codegen/box/inlineClasses/funInterface/returnIC.kt");

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBytecodeTextTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBytecodeTextTestGenerated.java
@@ -3573,6 +3573,24 @@ public class FirBytecodeTextTestGenerated extends AbstractFirBytecodeTextTest {
         }
 
         @Test
+        @TestMetadata("mangledSamWrappers.kt")
+        public void testMangledSamWrappers() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/inlineClasses/mangledSamWrappers.kt");
+        }
+
+        @Test
+        @TestMetadata("mangledSamWrappersIndy.kt")
+        public void testMangledSamWrappersIndy() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/inlineClasses/mangledSamWrappersIndy.kt");
+        }
+
+        @Test
+        @TestMetadata("mangledSamWrappersOld.kt")
+        public void testMangledSamWrappersOld() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/inlineClasses/mangledSamWrappersOld.kt");
+        }
+
+        @Test
         @TestMetadata("noActualCallsOfInlineFunctionsOfInlineClass.kt")
         public void testNoActualCallsOfInlineFunctionsOfInlineClass() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/inlineClasses/noActualCallsOfInlineFunctionsOfInlineClass.kt");

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/FunctionReferenceLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/FunctionReferenceLowering.kt
@@ -574,15 +574,7 @@ internal class FunctionReferenceLowering(private val context: JvmBackendContext)
         private fun createInvokeMethod(receiverVar: IrValueDeclaration?): IrSimpleFunction =
             functionReferenceClass.addFunction {
                 setSourceRange(if (isLambda) callee else irFunctionReference)
-                name =
-                    if (samSuperType == null && callee.returnType.isInlineClassType() &&
-                        context.state.functionsWithInlineClassReturnTypesMangled
-                    ) {
-                        // For functions with inline class return type we need to mangle the invoke method.
-                        // Otherwise, bridge lowering may fail to generate bridges for inline class types erasing to Any.
-                        val suffix = InlineClassAbi.hashReturnSuffix(callee)
-                        Name.identifier("${superMethod.name.asString()}-${suffix}")
-                    } else superMethod.name
+                name = superMethod.name
                 returnType = callee.returnType
                 isSuspend = callee.isSuspend
             }.apply {

--- a/compiler/testData/codegen/box/inlineClasses/funInterface/mangledSamWrappers.kt
+++ b/compiler/testData/codegen/box/inlineClasses/funInterface/mangledSamWrappers.kt
@@ -1,0 +1,17 @@
+// IGNORE_BACKEND: JVM
+// IGNORE_BACKEND: WASM
+// !LANGUAGE: +InlineClasses
+inline class A(val value: String)
+
+fun interface B {
+    fun f(x: A): A
+}
+
+inline fun g(unit: Unit = Unit, b: B): A {
+    return b.f(A("Fail"))
+}
+
+fun box(): String {
+    val b = { _ : A -> A("O") }
+    return g(b = b).value + g { A("K") }.value
+}

--- a/compiler/testData/codegen/bytecodeText/inlineClasses/mangledSamWrappers.kt
+++ b/compiler/testData/codegen/bytecodeText/inlineClasses/mangledSamWrappers.kt
@@ -1,0 +1,32 @@
+// !LANGUAGE: +InlineClasses
+inline class A(val value: String)
+
+fun interface B {
+    fun f(x: A): A
+}
+
+inline fun g(unit: Unit = Unit, b: B): A {
+    return b.f(A("Fail"))
+}
+
+fun box(): String {
+    val b = { _ : A -> A("OK") }
+    return g(b = b).value
+}
+
+// @B.class:
+// 1 public abstract f-ZsE1S_E\(Ljava/lang/String;\)Ljava/lang/String;
+// @MangledSamWrappersKt.class:
+// 3 INVOKEINTERFACE B.f-ZsE1S_E \(Ljava/lang/String;\)Ljava/lang/String;
+// @MangledSamWrappersKt$sam$B$0.class:
+// public final synthetic f-ZsE1S_E\(Ljava/lang/String;\)Ljava/lang/String;
+
+// JVM_TEMPLATES:
+// @MangledSamWrappersKt$box$b$1.class:
+// 1 public final invoke\(Ljava/lang/String;\)LA;
+
+// JVM_IR_TEMPLATES:
+// @MangledSamWrappersKt$box$b$1.class:
+// 0 public final invoke-ZsE1S_E-ZsE1S_E\(Ljava/lang/String;\)Ljava/lang/String;
+// 1 public final invoke-ZsE1S_E\(Ljava/lang/String;\)Ljava/lang/String;
+// 1 public synthetic bridge invoke\(Ljava/lang/Object;\)Ljava/lang/Object;

--- a/compiler/testData/codegen/bytecodeText/inlineClasses/mangledSamWrappersIndy.kt
+++ b/compiler/testData/codegen/bytecodeText/inlineClasses/mangledSamWrappersIndy.kt
@@ -1,0 +1,30 @@
+// IGNORE_BACKEND: JVM
+// !LANGUAGE: +InlineClasses
+// LAMBDAS: INDY
+
+inline class A(val value: String?)
+
+fun interface B {
+    fun f(x: A): A
+}
+
+inline fun g(unit: Unit = Unit, b: B): A {
+    return b.f(A("Fail"))
+}
+
+fun box(): String {
+    val b = { _ : A -> A("OK") }
+    return g(b = b).value!!
+}
+
+// 0 public final invoke-ZsE1S_E-ZsE1S_E\(Ljava/lang/String;\)Ljava/lang/String;
+// 0 public final invoke-ZsE1S_E\(Ljava/lang/String;\)Ljava/lang/String;
+// 0 public synthetic bridge invoke\(Ljava/lang/Object;\)Ljava/lang/Object;
+
+// @B.class:
+// 1 public abstract f-ZsE1S_E\(Ljava/lang/String;\)Ljava/lang/String;
+// @MangledSamWrappersKt.class:
+// 3 INVOKEINTERFACE B.f-ZsE1S_E \(Ljava/lang/String;\)Ljava/lang/String;
+// 1 private final static box\$lambda-0\(LA;\)LA;
+// @MangledSamWrappersKt$sam$B$0.class:
+// public final synthetic f-ZsE1S_E\(Ljava/lang/String;\)Ljava/lang/String;

--- a/compiler/testData/codegen/bytecodeText/inlineClasses/mangledSamWrappersOld.kt
+++ b/compiler/testData/codegen/bytecodeText/inlineClasses/mangledSamWrappersOld.kt
@@ -1,0 +1,33 @@
+// !LANGUAGE: +InlineClasses
+// USE_OLD_INLINE_CLASSES_MANGLING_SCHEME
+inline class A(val value: String)
+
+fun interface B {
+    fun f(x: A): A
+}
+
+inline fun g(unit: Unit = Unit, b: B): A {
+    return b.f(A("Fail"))
+}
+
+fun box(): String {
+    val b = { _ : A -> A("OK") }
+    return g(b = b).value
+}
+
+// @B.class:
+// 1 public abstract f-iUtXLc0\(Ljava/lang/String;\)Ljava/lang/String;
+// @MangledSamWrappersKt.class:
+// 3 INVOKEINTERFACE B.f-iUtXLc0 \(Ljava/lang/String;\)Ljava/lang/String;
+// @MangledSamWrappersKt$sam$B$0.class:
+// public final synthetic f-iUtXLc0\(Ljava/lang/String;\)Ljava/lang/String;
+
+// JVM_TEMPLATES:
+// @MangledSamWrappersKt$box$b$1.class:
+// 1 public final invoke\(Ljava/lang/String;\)LA;
+
+// JVM_IR_TEMPLATES:
+// @MangledSamWrappersKt$box$b$1.class:
+// 0 public final invoke-iUtXLc0-iUtXLc0\(Ljava/lang/String;\)Ljava/lang/String;
+// 1 public final invoke-iUtXLc0\(Ljava/lang/String;\)Ljava/lang/String;
+// 1 public synthetic bridge invoke\(Ljava/lang/Object;\)Ljava/lang/Object;

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -19170,6 +19170,12 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             }
 
             @Test
+            @TestMetadata("mangledSamWrappers.kt")
+            public void testMangledSamWrappers() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/funInterface/mangledSamWrappers.kt");
+            }
+
+            @Test
             @TestMetadata("returnIC.kt")
             public void testReturnIC() throws Exception {
                 runTest("compiler/testData/codegen/box/inlineClasses/funInterface/returnIC.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BytecodeTextTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BytecodeTextTestGenerated.java
@@ -3441,6 +3441,24 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
         }
 
         @Test
+        @TestMetadata("mangledSamWrappers.kt")
+        public void testMangledSamWrappers() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/inlineClasses/mangledSamWrappers.kt");
+        }
+
+        @Test
+        @TestMetadata("mangledSamWrappersIndy.kt")
+        public void testMangledSamWrappersIndy() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/inlineClasses/mangledSamWrappersIndy.kt");
+        }
+
+        @Test
+        @TestMetadata("mangledSamWrappersOld.kt")
+        public void testMangledSamWrappersOld() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/inlineClasses/mangledSamWrappersOld.kt");
+        }
+
+        @Test
         @TestMetadata("noActualCallsOfInlineFunctionsOfInlineClass.kt")
         public void testNoActualCallsOfInlineFunctionsOfInlineClass() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/inlineClasses/noActualCallsOfInlineFunctionsOfInlineClass.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -19194,6 +19194,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             }
 
             @Test
+            @TestMetadata("mangledSamWrappers.kt")
+            public void testMangledSamWrappers() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/funInterface/mangledSamWrappers.kt");
+            }
+
+            @Test
             @TestMetadata("returnIC.kt")
             public void testReturnIC() throws Exception {
                 runTest("compiler/testData/codegen/box/inlineClasses/funInterface/returnIC.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBytecodeTextTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBytecodeTextTestGenerated.java
@@ -3573,6 +3573,24 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
         }
 
         @Test
+        @TestMetadata("mangledSamWrappers.kt")
+        public void testMangledSamWrappers() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/inlineClasses/mangledSamWrappers.kt");
+        }
+
+        @Test
+        @TestMetadata("mangledSamWrappersIndy.kt")
+        public void testMangledSamWrappersIndy() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/inlineClasses/mangledSamWrappersIndy.kt");
+        }
+
+        @Test
+        @TestMetadata("mangledSamWrappersOld.kt")
+        public void testMangledSamWrappersOld() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/inlineClasses/mangledSamWrappersOld.kt");
+        }
+
+        @Test
         @TestMetadata("noActualCallsOfInlineFunctionsOfInlineClass.kt")
         public void testNoActualCallsOfInlineFunctionsOfInlineClass() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/inlineClasses/noActualCallsOfInlineFunctionsOfInlineClass.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -15899,6 +15899,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
                 runTest("compiler/testData/codegen/box/inlineClasses/funInterface/argumentResult.kt");
             }
 
+            @TestMetadata("mangledSamWrappers.kt")
+            public void ignoreMangledSamWrappers() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/funInterface/mangledSamWrappers.kt");
+            }
+
             @TestMetadata("returnIC.kt")
             public void ignoreReturnIC() throws Exception {
                 runTest("compiler/testData/codegen/box/inlineClasses/funInterface/returnIC.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
@@ -14056,6 +14056,11 @@ public class IrJsCodegenBoxES6TestGenerated extends AbstractIrJsCodegenBoxES6Tes
                 runTest("compiler/testData/codegen/box/inlineClasses/funInterface/argumentResult.kt");
             }
 
+            @TestMetadata("mangledSamWrappers.kt")
+            public void testMangledSamWrappers() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/funInterface/mangledSamWrappers.kt");
+            }
+
             @TestMetadata("returnIC.kt")
             public void testReturnIC() throws Exception {
                 runTest("compiler/testData/codegen/box/inlineClasses/funInterface/returnIC.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -13467,6 +13467,11 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
                 runTest("compiler/testData/codegen/box/inlineClasses/funInterface/argumentResult.kt");
             }
 
+            @TestMetadata("mangledSamWrappers.kt")
+            public void testMangledSamWrappers() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/funInterface/mangledSamWrappers.kt");
+            }
+
             @TestMetadata("returnIC.kt")
             public void testReturnIC() throws Exception {
                 runTest("compiler/testData/codegen/box/inlineClasses/funInterface/returnIC.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -13532,6 +13532,11 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
                 runTest("compiler/testData/codegen/box/inlineClasses/funInterface/argumentResult.kt");
             }
 
+            @TestMetadata("mangledSamWrappers.kt")
+            public void testMangledSamWrappers() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/funInterface/mangledSamWrappers.kt");
+            }
+
             @TestMetadata("returnIC.kt")
             public void testReturnIC() throws Exception {
                 runTest("compiler/testData/codegen/box/inlineClasses/funInterface/returnIC.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/wasm/semantics/IrCodegenBoxWasmTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/wasm/semantics/IrCodegenBoxWasmTestGenerated.java
@@ -7542,6 +7542,11 @@ public class IrCodegenBoxWasmTestGenerated extends AbstractIrCodegenBoxWasmTest 
                 runTest("compiler/testData/codegen/box/inlineClasses/funInterface/argumentResult.kt");
             }
 
+            @TestMetadata("mangledSamWrappers.kt")
+            public void testMangledSamWrappers() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/funInterface/mangledSamWrappers.kt");
+            }
+
             @TestMetadata("returnIC.kt")
             public void testReturnIC() throws Exception {
                 runTest("compiler/testData/codegen/box/inlineClasses/funInterface/returnIC.kt");


### PR DESCRIPTION
This PR removes an outdated workaround for inline class mangling in `FunctionReferenceLowering`. Before 4f171a9eb511823f5f3507d335dc3cb0d2d913c5 this lowering ran after inline class lowering and had to produce mangled function names for `invoke`. After the commit in question we were mangling the same function twice. This never caused any problems since these functions were only called through bridge methods.