### PR TITLE
[KTIJ-11532] Create member function removes selected code in target Java file

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/CallableBuilder.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/CallableBuilder.kt
@@ -888,6 +888,7 @@ class CallableBuilder(val config: CallableBuilderConfiguration) {
 
             val descriptor = OpenFileDescriptor(project, targetClass.containingFile.virtualFile)
             val targetEditor = FileEditorManager.getInstance(project).openTextEditor(descriptor, true)!!
+            targetEditor.selectionModel.removeSelection()
 
             when (newJavaMember) {
                 is PsiMethod -> CreateFromUsageUtils.setupEditor(newJavaMember, targetEditor)


### PR DESCRIPTION
Added selection removal before setting up target editor.

Issue: https://youtrack.jetbrains.com/issue/KTIJ-11532
