### PR TITLE
[JVM] Fix uninitialized locals after coroutine transformation.

### DIFF
--- a/compiler/testData/codegen/bytecodeText/coroutines/debug/thisAndResultInLvt.kt
+++ b/compiler/testData/codegen/bytecodeText/coroutines/debug/thisAndResultInLvt.kt
@@ -23,11 +23,11 @@ class A {
 // foo, c's lambda and foo's continuation
 // 3 LOCALVARIABLE \$result Ljava/lang/Object;
 
-// foo and <init>
-// 2 LOCALVARIABLE this LA;
-// 1 LOCALVARIABLE a LA;
-// 1 LOCALVARIABLE s Ljava/lang/String;
-// 1 LOCALVARIABLE block Lkotlin/jvm/functions/Function2;
+// foo x 3 since we split the local over restore code for the two calls to block(), and <init>
+// 4 LOCALVARIABLE this LA;
+// 3 LOCALVARIABLE a LA;
+// 3 LOCALVARIABLE s Ljava/lang/String;
+// 3 LOCALVARIABLE block Lkotlin/jvm/functions/Function2;
 // 1 LOCALVARIABLE \$continuation Lkotlin/coroutines/Continuation;
 
 // JVM_TEMPLATES

--- a/compiler/testData/codegen/bytecodeText/coroutines/varValueConflictsWithTableSameSort.kt
+++ b/compiler/testData/codegen/bytecodeText/coroutines/varValueConflictsWithTableSameSort.kt
@@ -42,8 +42,8 @@ fun box(): String {
 }
 
 // 1 LOCALVARIABLE i Ljava/lang/String; L.* 3
-// We merge LVT records for two consequent branches.
-// 1 LOCALVARIABLE s Ljava/lang/String; L.* 3
+// We merge LVT records for two consequent branches, but we split the local over the restore code.
+// 2 LOCALVARIABLE s Ljava/lang/String; L.* 3
 // 1 PUTFIELD VarValueConflictsWithTableSameSortKt\$box\$1.L\$0 : Ljava/lang/Object;
 /* 1 load in the catch (e: Throwable) { throw e } block which is implicitly wrapped around try/finally */
 // 1 ALOAD 3\s+ATHROW

--- a/compiler/testData/debug/localVariables/suspend/completion/staticStateMachineReceiver.kt
+++ b/compiler/testData/debug/localVariables/suspend/completion/staticStateMachineReceiver.kt
@@ -32,7 +32,7 @@ suspend fun box() {
 // test.kt:8 foo1: $continuation:kotlin.coroutines.Continuation=TestKt$foo1$1, $result:java.lang.Object=null, $this$foo1:A=A, l:long=42:long
 // test.kt:6 foo: $this$foo:A=A, $completion:kotlin.coroutines.Continuation=TestKt$foo1$1
 // test.kt:8 foo1: $continuation:kotlin.coroutines.Continuation=TestKt$foo1$1, $result:java.lang.Object=null, $this$foo1:A=A, l:long=42:long
-// test.kt:9 foo1: $continuation:kotlin.coroutines.Continuation=TestKt$foo1$1, $result:java.lang.Object=null, $this$foo1:A=A, l:long=42:long
+// test.kt:9 foo1: $continuation:kotlin.coroutines.Continuation=TestKt$foo1$1, $result:java.lang.Object=null, l:long=42:long, $this$foo1:A=A
 // test.kt:6 foo: $this$foo:A=A, $completion:kotlin.coroutines.Continuation=TestKt$foo1$1
 // test.kt:9 foo1: $continuation:kotlin.coroutines.Continuation=TestKt$foo1$1, $result:java.lang.Object=null, l:long=42:long
 // test.kt:10 foo1: $continuation:kotlin.coroutines.Continuation=TestKt$foo1$1, $result:java.lang.Object=null, l:long=42:long


### PR DESCRIPTION
The coroutine transformation would leave locals in the local
variable table across the code that reloads local variables from
the continuation on reentry. However, when reentering the function
the local has no value until after the reloads from the
continuation.

This change splits the locals in the local variable table to
avoid such uninitialized locals. A local alive across a
suspension point has its range split in two. One that goes
from the original start to the state label for the restart
after the suspension. The other goes from after the local
has been reloaded from the continuation until the previous
end of the local.