### PR TITLE
add resources to klib

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/pm20/KotlinMetadataCompilationData.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/pm20/KotlinMetadataCompilationData.kt
@@ -147,6 +147,9 @@ internal open class KotlinNativeFragmentMetadataCompilationDataImpl(
     override val compileKotlinTaskName: String
         get() = lowerCamelCaseName("compile", fragment.disambiguateName(""), "KotlinNativeMetadata")
 
+    override val artifactsTaskName: String
+        get() = lowerCamelCaseName("compile", fragment.disambiguateName(""), "klib")
+
     override val isActive: Boolean
         get() = fragment.isNativeShared()
 

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/pm20/KotlinNativeVariant.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/pm20/KotlinNativeVariant.kt
@@ -58,6 +58,8 @@ open class KotlinIosArm64Variant @Inject constructor(containingModule: KotlinGra
     KotlinNativeVariantInternal(containingModule, fragmentName, KonanTarget.IOS_ARM64)
 
 interface KotlinNativeCompilationData<T : KotlinCommonOptions> : KotlinCompilationData<T> {
+    val artifactsTaskName: String
+
     val konanTarget: KonanTarget
     val enableEndorsedLibs: Boolean
 }
@@ -65,6 +67,9 @@ interface KotlinNativeCompilationData<T : KotlinCommonOptions> : KotlinCompilati
 internal class KotlinNativeVariantCompilationData(
     val variant: KotlinNativeVariantInternal
 ) : KotlinVariantCompilationDataInternal<KotlinCommonOptions>, KotlinNativeCompilationData<KotlinCommonOptions> {
+    override val artifactsTaskName: String
+        get() = owner.disambiguateName("klib")
+
     override val konanTarget: KonanTarget
         get() = variant.konanTarget
 

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/native/KotlinNativeCompilation.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/native/KotlinNativeCompilation.kt
@@ -59,6 +59,9 @@ abstract class AbstractKotlinNativeCompilation(
     compilationName: String
 ) : AbstractKotlinCompilation<KotlinCommonOptions>(target, compilationName), KotlinNativeCompilationData<KotlinCommonOptions> {
 
+    override val artifactsTaskName: String
+        get() = lowerCamelCaseName(target.disambiguationClassifier, compilationPurpose, "klib")
+
     override val kotlinOptions: KotlinCommonOptions = NativeCompileOptions { defaultSourceSet.languageSettings }
 
     override val compileKotlinTask: KotlinNativeCompile

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/native/KotlinNativeTargetConfigurator.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/native/KotlinNativeTargetConfigurator.kt
@@ -24,6 +24,7 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.Exec
 import org.gradle.api.tasks.TaskProvider
+import org.gradle.api.tasks.bundling.Zip
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation.Companion.MAIN_COMPILATION_NAME
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation.Companion.TEST_COMPILATION_NAME
@@ -44,7 +45,9 @@ import org.jetbrains.kotlin.gradle.testing.testTaskName
 import org.jetbrains.kotlin.gradle.utils.lowerCamelCaseName
 import org.jetbrains.kotlin.konan.target.HostManager
 import org.jetbrains.kotlin.konan.target.KonanTarget
+import org.jetbrains.kotlin.library.impl.KLIB_DEFAULT_COMPONENT_NAME
 import java.io.File
+import java.util.concurrent.Callable
 
 open class KotlinNativeTargetConfigurator<T : KotlinNativeTarget> : AbstractKotlinTargetConfigurator<T>(
     createDefaultSourceSets = true,
@@ -461,20 +464,31 @@ open class KotlinNativeTargetConfigurator<T : KotlinNativeTarget> : AbstractKotl
 
             project.project.tasks.getByName(compilation.compileAllTaskName).dependsOn(compileTaskProvider)
 
+            val artifactsTaskProvider = project.registerTask<Zip>(compilation.artifactsTaskName) {
+                it.description = "Assembles an archive containing the main classes."
+                it.group = BasePlugin.BUILD_GROUP
+                it.archiveExtension.set("klib")
+                it.archiveAppendix.set(compilation.compilationPurpose)
+                val output = compilation.output
+                it.from(project.zipTree(project.provider { output.classesDirs.singleFile }))
+                it.from(Callable { output.resourcesDir }) { spec -> spec.into("$KLIB_DEFAULT_COMPONENT_NAME/resources") }
+                it.dependsOn(compilation.compileAllTaskName)
+            }
+
             if (compilation.isMainCompilationData()) {
                 if (compilation is KotlinNativeCompilation) {
                     project.project.tasks.getByName(compilation.target.artifactsTaskName).apply {
-                        dependsOn(compileTaskProvider)
+                        dependsOn(artifactsTaskProvider)
                     }
                 }
 
                 project.project.tasks.getByName(LifecycleBasePlugin.ASSEMBLE_TASK_NAME).apply {
-                    dependsOn(compileTaskProvider)
+                    dependsOn(artifactsTaskProvider)
                 }
             }
             val shouldAddCompileOutputsToElements = compilation.owner is KotlinGradleVariant || compilation.isMainCompilationData()
             if (shouldAddCompileOutputsToElements) {
-                createRegularKlibArtifact(compilation, compileTaskProvider)
+                createRegularKlibArtifact(compilation, artifactsTaskProvider)
             }
 
             if (compilation is AbstractKotlinNativeCompilation) {
@@ -510,8 +524,8 @@ open class KotlinNativeTargetConfigurator<T : KotlinNativeTarget> : AbstractKotl
 
         internal fun createRegularKlibArtifact(
             compilation: KotlinNativeCompilationData<*>,
-            compileTask: TaskProvider<out KotlinNativeCompile>
-        ) = createKlibArtifact(compilation, compileTask.map { it.outputFile.get() }, null, compileTask)
+            artifactsTask: TaskProvider<Zip>
+        ) = createKlibArtifact(compilation, artifactsTask.map { it.archiveFile.get().asFile }, null, artifactsTask)
 
         private fun createKlibArtifact(
             compilation: KotlinNativeCompilationData<*>,


### PR DESCRIPTION
# problem

If we publish a Kotlin Native﻿ library. It will take the `klib` file outputed by `compileKotlinNative` task.

the `klib` file's layout like this:

![image](https://user-images.githubusercontent.com/1407040/116670454-54734980-a9d2-11eb-8be2-5412039768bb.png)

It has a `resources` directory which is **empty**, **even** I put some file in `common` resources directory.

![image](https://user-images.githubusercontent.com/1407040/116670554-6f45be00-a9d2-11eb-92f3-c14f0a5a47fe.png)

# reason

the `${target}ProcessResources` task will merge `common` resources directory and `target` resources directory into `build/processedResources/native/main` directory.

![image](https://user-images.githubusercontent.com/1407040/116671522-9b157380-a9d3-11eb-99d3-39f8264c3f56.png)

And Kotlin gradle plugin create a `${target}Jar` task for some target, like `js` and `jvm` target. for example:

1. `js` target's jar task is `jsJar`.
2. `jvm` target's jar task is `jvmJar`.

and `${target}Jar` task will archive:

1. Kotlin compile output directory
2. Kotlin resources directory

so `${target}Jar` task depends on these two output. for example:

1. `jsJar` depends on:
    1. `compileKotlinJs`
    2. `jsMainClasses` which depends on `jsProcessResources`

1. `jvmJar` depends on:
    1. `compileKotlinJvm`
    2. `jvmMainClasses` which depends on `jvmProcessResources`

`compileKotlinJvm` and `jvmMainClasses` are two separate task. they don't depends on each other.

## `js` target or `jvm` target will publish the jar outputed by `${target}Jar` task.

## Kotlin Native﻿ problem

Kotlin Native﻿ publishes the `klib` file outputed by `compileKotlinNative` task, which does not depend on `nativeProcessResources` task, and `compileKotlinNative` task has not resources input property.

# the solution

1. make `compileKotlinNative` task depends on `nativeProcessResources` task.
2. pass the resources directory to `compileKotlinNative` task, and copy the resources directory to `klib` resources directory.

# result

![image](https://user-images.githubusercontent.com/1407040/116673097-889c3980-a9d5-11eb-8e64-f5badccc0a95.png)

# TODO

when create a binary contains resources(like iOS framework), merge all dependencies `klib` resources directory into framework.
