### PR TITLE
FIR: ensure the absence of FirResolvedTypeRef with erroneous type

### DIFF
--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/collectors/components/ErrorNodeDiagnosticCollectorComponent.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/collectors/components/ErrorNodeDiagnosticCollectorComponent.kt
@@ -10,7 +10,6 @@ import org.jetbrains.kotlin.fir.FirFakeSourceElementKind
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.FirSourceElement
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
-import org.jetbrains.kotlin.fir.analysis.collectors.AbstractDiagnosticCollector
 import org.jetbrains.kotlin.fir.analysis.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.fir.analysis.diagnostics.toFirDiagnostics
 import org.jetbrains.kotlin.fir.declarations.FirErrorFunction
@@ -20,9 +19,10 @@ import org.jetbrains.kotlin.fir.references.FirErrorNamedReference
 import org.jetbrains.kotlin.fir.resolve.diagnostics.ConeAmbiguityError
 import org.jetbrains.kotlin.fir.resolve.diagnostics.ConeInapplicableCandidateError
 import org.jetbrains.kotlin.fir.resolve.diagnostics.ConeUnresolvedNameError
-import org.jetbrains.kotlin.fir.types.ConeClassErrorType
+import org.jetbrains.kotlin.fir.types.ConeKotlinErrorType
 import org.jetbrains.kotlin.fir.types.FirErrorTypeRef
 import org.jetbrains.kotlin.fir.types.FirResolvedTypeRef
+import org.jetbrains.kotlin.fir.types.render
 
 class ErrorNodeDiagnosticCollectorComponent(
     session: FirSession,
@@ -39,9 +39,9 @@ class ErrorNodeDiagnosticCollectorComponent(
     }
 
     override fun visitResolvedTypeRef(resolvedTypeRef: FirResolvedTypeRef, data: CheckerContext) {
-        val errorType = resolvedTypeRef.type as? ConeClassErrorType ?: return
-        val source = resolvedTypeRef.source ?: return
-        reportFirDiagnostic(errorType.diagnostic, source, reporter, data)
+        assert(resolvedTypeRef.type !is ConeKotlinErrorType) {
+            "Instead use FirErrorTypeRef for ${resolvedTypeRef.type.render()}"
+        }
     }
 
     override fun visitErrorNamedReference(errorNamedReference: FirErrorNamedReference, data: CheckerContext) {

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/diagnostics/FirDiagnostics.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/diagnostics/FirDiagnostics.kt
@@ -30,7 +30,7 @@ class ConeUnresolvedSymbolError(val classId: ClassId) : ConeDiagnostic() {
 }
 
 class ConeUnresolvedQualifierError(val qualifier: String) : ConeDiagnostic() {
-    override val reason: String get() = "Symbol not found for ${qualifier}"
+    override val reason: String get() = "Symbol not found for $qualifier"
 }
 
 class ConeUnresolvedNameError(val name: Name) : ConeDiagnostic() {

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/inference/FirCallCompleter.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/inference/FirCallCompleter.kt
@@ -27,6 +27,7 @@ import org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.resultType
 import org.jetbrains.kotlin.fir.resolve.typeFromCallee
 import org.jetbrains.kotlin.fir.symbols.impl.FirVariableSymbol
 import org.jetbrains.kotlin.fir.types.*
+import org.jetbrains.kotlin.fir.types.builder.buildErrorTypeRef
 import org.jetbrains.kotlin.fir.types.builder.buildResolvedTypeRef
 import org.jetbrains.kotlin.fir.types.impl.ConeClassLikeTypeImpl
 import org.jetbrains.kotlin.fir.visitors.transformSingle
@@ -188,7 +189,7 @@ class FirCallCompleter(
                         source = lambdaAtom.atom.source?.fakeElement(FirFakeSourceElementKind.ItLambdaParameter)
                         declarationSiteSession = session
                         origin = FirDeclarationOrigin.Source
-                        returnTypeRef = buildResolvedTypeRef { type = itType.approximateLambdaInputType() }
+                        returnTypeRef = itType.approximateLambdaInputType().toFirResolvedTypeRef()
                         this.name = name
                         symbol = FirVariableSymbol(name)
                         defaultValue = null
@@ -212,10 +213,7 @@ class FirCallCompleter(
             lambdaArgument.valueParameters.forEachIndexed { index, parameter ->
                 val newReturnType = parameters[index].approximateLambdaInputType()
                 val newReturnTypeRef = if (parameter.returnTypeRef is FirImplicitTypeRef) {
-                    buildResolvedTypeRef {
-                        source = parameter.source
-                        type = newReturnType
-                    }
+                    newReturnType.toFirResolvedTypeRef(parameter.source)
                 } else parameter.returnTypeRef.resolvedTypeFromPrototype(newReturnType)
                 parameter.replaceReturnTypeRef(newReturnTypeRef)
                 lookupTracker?.recordTypeResolveAsLookup(newReturnTypeRef, parameter.source, null)

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirDeclarationsResolveTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirDeclarationsResolveTransformer.kt
@@ -255,7 +255,6 @@ open class FirDeclarationsResolveTransformer(transformer: FirBodyResolveTransfor
             return wrappedDelegateExpression.expression
                 .transformSingle(transformer, data)
                 .approximateIfIsIntegerConst()
-                
         } finally {
             dataFlowAnalyzer.exitDelegateExpression()
         }
@@ -658,7 +657,7 @@ open class FirDeclarationsResolveTransformer(transformer: FirBodyResolveTransfor
                                     source = lambda.source?.fakeElement(FirFakeSourceElementKind.ItLambdaParameter)
                                     declarationSiteSession = session
                                     origin = FirDeclarationOrigin.Source
-                                    returnTypeRef = buildResolvedTypeRef { type = singleParameterType }
+                                    returnTypeRef = singleParameterType.toFirResolvedTypeRef()
                                     this.name = name
                                     symbol = FirVariableSymbol(name)
                                     isCrossinline = false

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirExpressionsResolveTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirExpressionsResolveTransformer.kt
@@ -185,10 +185,7 @@ open class FirExpressionsResolveTransformer(transformer: FirBodyResolveTransform
                  *   DiagnosticsTestGenerated$Tests$ThisAndSuper.testQualifiedSuperOverridden
                  */
                 val actualSuperTypeRef = actualSuperType?.let {
-                    buildResolvedTypeRef {
-                        source = superTypeRef.source
-                        type = it
-                    }
+                    it.toFirResolvedTypeRef(superTypeRef.source)
                 } ?: buildErrorTypeRef {
                     source = superTypeRef.source
                     diagnostic = ConeSimpleDiagnostic("Not a super type", DiagnosticKind.Other)

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/types/TypeUtils.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/types/TypeUtils.kt
@@ -177,6 +177,22 @@ fun ConeKotlinType.toSymbol(session: FirSession): AbstractFirBasedSymbol<*>? {
     return (this as? ConeLookupTagBasedType)?.lookupTag?.toSymbol(session)
 }
 
+fun ConeKotlinType.toFirResolvedTypeRef(
+    source: FirSourceElement? = null,
+): FirResolvedTypeRef {
+    return if (this is ConeKotlinErrorType) {
+        buildErrorTypeRef {
+            this.source = source
+            diagnostic = this@toFirResolvedTypeRef.diagnostic
+        }
+    } else {
+        buildResolvedTypeRef {
+            this.source = source
+            type = this@toFirResolvedTypeRef
+        }
+    }
+}
+
 fun FirTypeRef.isUnsafeVarianceType(session: FirSession): Boolean {
     return coneTypeSafe<ConeKotlinType>()?.isUnsafeVarianceType(session) == true
 }


### PR DESCRIPTION
After #4320, there are still remaining use cases of `FirResolvedTypeRef` with `ConeKotlinErrorType`: lambda parameter types and super type refs. With a centralized util that converts cone type to resolved type ref or error type ref if needed, those places can be fixed too. In checker's error node visitor, we can ensure there is no longer a resolved type ref with an erroneous type.