### PR TITLE
KotlinCompile: Add `kotlin.incremental.useClasspathSnapshot` flag

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinProperties.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinProperties.kt
@@ -21,6 +21,7 @@ import org.jetbrains.kotlin.gradle.tasks.AbstractKotlinCompile
 import org.jetbrains.kotlin.gradle.tasks.Kotlin2JsCompile
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jetbrains.kotlin.gradle.utils.SingleWarningPerBuild
+import org.jetbrains.kotlin.gradle.utils.getSystemProperty
 import org.jetbrains.kotlin.konan.target.KonanTarget
 import org.jetbrains.kotlin.konan.target.presetName
 import org.jetbrains.kotlin.statistics.metrics.StringMetrics
@@ -35,6 +36,7 @@ internal fun PropertiesProvider.mapKotlinTaskProperties(task: AbstractKotlinComp
         usePreciseJavaTracking?.let {
             task.usePreciseJavaTracking = it
         }
+        task.useClasspathSnapshot.value(useClasspathSnapshot).disallowChanges()
         useFir?.let {
             if (it == true) {
                 task.kotlinOptions.useFir = true
@@ -95,6 +97,16 @@ internal class PropertiesProvider private constructor(private val project: Proje
 
     val usePreciseJavaTracking: Boolean?
         get() = booleanProperty("kotlin.incremental.usePreciseJavaTracking")
+
+    val useClasspathSnapshot: Boolean
+        get() {
+            // The feature should be controlled by a Gradle property.
+            // Currently, we also allow it to be controlled by a system property to make it easier to test the feature during development.
+            // TODO: Remove the system property later.
+            val gradleProperty = booleanProperty("kotlin.incremental.useClasspathSnapshot") ?: false
+            val systemProperty = project.getSystemProperty("kotlin.incremental.useClasspathSnapshot")?.toBoolean() ?: false
+            return gradleProperty || systemProperty
+        }
 
     val useFir: Boolean?
         get() = booleanProperty("kotlin.useFir")

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/Tasks.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/Tasks.kt
@@ -421,6 +421,9 @@ abstract class KotlinCompile @Inject constructor(
             logger.kotlinDebug { "Set $this.usePreciseJavaTracking=$value" }
         }
 
+    @get:Input
+    abstract val useClasspathSnapshot: Property<Boolean>
+
     init {
         incremental = true
     }


### PR DESCRIPTION
We are planning to improve incremental Kotlin compile with a new
approach using classpath snapshot (see
https://youtrack.jetbrains.com/issue/KT-45777 for more details).

The estimated steps will be as follows:
  [x] Add a flag for the new approach, disabled by default
  [ ] Add tests for the new approach, and update them as we go
  [ ] Add computation of classpath snapshot using artifact transforms
  [ ] Add computation of classpath snapshot changes
  [ ] Ensure incremental compile is fully functional with the new approach
  [ ] Measure performance + optimize: Repeat until we see evidence that
      the new approach is clearly better than the current approach
  [ ] Advertise the flag, and later on enable it by default

This commit is the first step. Although it's simple, it allows further
changes to be made safely without impacting the current approach.

Bug: KT-45777
Test: N/A (will be added in a subsequent change)