### PR TITLE
FIR checker: report setter parameter with default value

### DIFF
--- a/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsTestGenerated.java
@@ -21383,6 +21383,12 @@ public class FirOldFrontendDiagnosticsTestGenerated extends AbstractFirDiagnosti
                 runTest("compiler/testData/diagnostics/tests/properties/lateinitOnTopLevel.kt");
             }
 
+            @Test
+            @TestMetadata("setterWithDefaultValue.kt")
+            public void testSetterWithDefaultValue() throws Exception {
+                runTest("compiler/testData/diagnostics/tests/properties/setterWithDefaultValue.kt");
+            }
+
             @Nested
             @TestMetadata("compiler/testData/diagnostics/tests/properties/inferenceFromGetters")
             @TestDataPath("$PROJECT_ROOT")

--- a/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsWithLightTreeTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsWithLightTreeTestGenerated.java
@@ -21383,6 +21383,12 @@ public class FirOldFrontendDiagnosticsWithLightTreeTestGenerated extends Abstrac
                 runTest("compiler/testData/diagnostics/tests/properties/lateinitOnTopLevel.kt");
             }
 
+            @Test
+            @TestMetadata("setterWithDefaultValue.kt")
+            public void testSetterWithDefaultValue() throws Exception {
+                runTest("compiler/testData/diagnostics/tests/properties/setterWithDefaultValue.kt");
+            }
+
             @Nested
             @TestMetadata("compiler/testData/diagnostics/tests/properties/inferenceFromGetters")
             @TestDataPath("$PROJECT_ROOT")

--- a/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/diagnostics/FirDiagnosticsList.kt
+++ b/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/diagnostics/FirDiagnosticsList.kt
@@ -552,6 +552,7 @@ object DIAGNOSTICS_LIST : DiagnosticList() {
         val PRIVATE_SETTER_FOR_OPEN_PROPERTY by error<KtModifierListOwner>(PositioningStrategy.PRIVATE_MODIFIER)
         val EXPECTED_PRIVATE_DECLARATION by error<KtModifierListOwner>(PositioningStrategy.VISIBILITY_MODIFIER)
         val VAL_WITH_SETTER by error<KtPropertyAccessor>()
+        val SETTER_PARAMETER_WITH_DEFAULT_VALUE by error<KtExpression>()
         val CONST_VAL_NOT_TOP_LEVEL_OR_OBJECT by error<KtProperty>(PositioningStrategy.CONST_MODIFIER)
         val CONST_VAL_WITH_GETTER by error<KtProperty>()
         val CONST_VAL_WITH_DELEGATE by error<KtPropertyDelegate>()

--- a/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/diagnostics/FirErrors.kt
+++ b/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/diagnostics/FirErrors.kt
@@ -344,6 +344,7 @@ object FirErrors {
     val PRIVATE_SETTER_FOR_OPEN_PROPERTY by error0<KtModifierListOwner>(SourceElementPositioningStrategies.PRIVATE_MODIFIER)
     val EXPECTED_PRIVATE_DECLARATION by error0<KtModifierListOwner>(SourceElementPositioningStrategies.VISIBILITY_MODIFIER)
     val VAL_WITH_SETTER by error0<KtPropertyAccessor>()
+    val SETTER_PARAMETER_WITH_DEFAULT_VALUE by error0<KtExpression>()
     val CONST_VAL_NOT_TOP_LEVEL_OR_OBJECT by error0<KtProperty>(SourceElementPositioningStrategies.CONST_MODIFIER)
     val CONST_VAL_WITH_GETTER by error0<KtProperty>()
     val CONST_VAL_WITH_DELEGATE by error0<KtPropertyDelegate>()

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirPropertyAccessorChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirPropertyAccessorChecker.kt
@@ -33,13 +33,16 @@ object FirPropertyAccessorChecker : FirPropertyChecker() {
 
     private fun checkSetter(property: FirProperty, context: CheckerContext, reporter: DiagnosticReporter) {
         val setter = property.setter ?: return
-
         withSuppressedDiagnostics(setter, context) {
             if (property.isVal) {
                 reporter.reportOn(setter.source, FirErrors.VAL_WITH_SETTER, context)
             }
 
             val valueSetterParameter = setter.valueParameters.first()
+            // This check is redundant: the parser does not allow a default value, but we'll keep it just in case
+            if (valueSetterParameter.defaultValue != null) {
+                reporter.reportOn(valueSetterParameter.defaultValue!!.source, FirErrors.SETTER_PARAMETER_WITH_DEFAULT_VALUE, context)
+            }
             if (valueSetterParameter.isVararg) {
                 return
             }

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/FirDefaultErrorMessages.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/FirDefaultErrorMessages.kt
@@ -245,6 +245,7 @@ import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.SEALED_CLASS_CONS
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.SEALED_SUPERTYPE
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.SEALED_SUPERTYPE_IN_LOCAL_CLASS
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.SECONDARY_CONSTRUCTOR_WITH_BODY_INSIDE_INLINE_CLASS
+import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.SETTER_PARAMETER_WITH_DEFAULT_VALUE
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.SUPERCLASS_NOT_ACCESSIBLE_FROM_INTERFACE
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.SUPERTYPES_FOR_ANNOTATION_CLASS
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.SUPERTYPE_INITIALIZED_IN_INTERFACE
@@ -778,6 +779,7 @@ class FirDefaultErrorMessages : DefaultErrorMessages.Extension {
             map.put(PRIVATE_SETTER_FOR_ABSTRACT_PROPERTY, "Private setters are not allowed for abstract properties")
             map.put(PRIVATE_SETTER_FOR_OPEN_PROPERTY, "Private setters are not allowed for open properties")
             map.put(VAL_WITH_SETTER, "A 'val'-property cannot have a setter")
+            map.put(SETTER_PARAMETER_WITH_DEFAULT_VALUE, "Setter parameters cannot have default values")
             map.put(
                 WRONG_SETTER_PARAMETER_TYPE,
                 "Setter parameter type must be equal to the type of the property, i.e. ''{0}''",

--- a/compiler/testData/diagnostics/tests/properties/setterWithDefaultValue.fir.kt
+++ b/compiler/testData/diagnostics/tests/properties/setterWithDefaultValue.fir.kt
@@ -1,0 +1,4 @@
+var err: Int
+    set(value<!SYNTAX, SYNTAX!><!> = 42<!SYNTAX!>)<!> <!FUNCTION_DECLARATION_WITH_NO_NAME!><!SYNTAX!><!>{
+        <!UNRESOLVED_REFERENCE!>field<!> = <!UNRESOLVED_REFERENCE!>value<!>
+    }<!>

--- a/compiler/testData/diagnostics/tests/properties/setterWithDefaultValue.kt
+++ b/compiler/testData/diagnostics/tests/properties/setterWithDefaultValue.kt
@@ -1,0 +1,4 @@
+var err: Int
+    set(<!WRONG_MODIFIER_TARGET!>value<!><!SYNTAX, SYNTAX!><!> = <!CONSTANT_EXPECTED_TYPE_MISMATCH!>42<!><!SYNTAX!>)<!> <!FUNCTION_DECLARATION_WITH_NO_NAME!><!SYNTAX!><!>{
+        <!UNRESOLVED_REFERENCE!>field<!> = <!UNRESOLVED_REFERENCE!>value<!>
+    }<!>

--- a/compiler/testData/diagnostics/tests/properties/setterWithDefaultValue.txt
+++ b/compiler/testData/diagnostics/tests/properties/setterWithDefaultValue.txt
@@ -1,0 +1,4 @@
+package
+
+public var err: kotlin.Int
+public fun <no name provided>(): kotlin.Unit

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/DiagnosticTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/DiagnosticTestGenerated.java
@@ -21389,6 +21389,12 @@ public class DiagnosticTestGenerated extends AbstractDiagnosticTest {
                 runTest("compiler/testData/diagnostics/tests/properties/lateinitOnTopLevel.kt");
             }
 
+            @Test
+            @TestMetadata("setterWithDefaultValue.kt")
+            public void testSetterWithDefaultValue() throws Exception {
+                runTest("compiler/testData/diagnostics/tests/properties/setterWithDefaultValue.kt");
+            }
+
             @Nested
             @TestMetadata("compiler/testData/diagnostics/tests/properties/inferenceFromGetters")
             @TestDataPath("$PROJECT_ROOT")

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDataClassConverters.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDataClassConverters.kt
@@ -1594,6 +1594,12 @@ internal val KT_DIAGNOSTIC_CONVERTER = KtDiagnosticConverterBuilder.buildConvert
             token,
         )
     }
+    add(FirErrors.SETTER_PARAMETER_WITH_DEFAULT_VALUE) { firDiagnostic ->
+        SetterParameterWithDefaultValueImpl(
+            firDiagnostic as FirPsiDiagnostic<*>,
+            token,
+        )
+    }
     add(FirErrors.CONST_VAL_NOT_TOP_LEVEL_OR_OBJECT) { firDiagnostic ->
         ConstValNotTopLevelOrObjectImpl(
             firDiagnostic as FirPsiDiagnostic<*>,

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnostics.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnostics.kt
@@ -1121,6 +1121,10 @@ sealed class KtFirDiagnostic<PSI: PsiElement> : KtDiagnosticWithPsi<PSI> {
         override val diagnosticClass get() = ValWithSetter::class
     }
 
+    abstract class SetterParameterWithDefaultValue : KtFirDiagnostic<KtExpression>() {
+        override val diagnosticClass get() = SetterParameterWithDefaultValue::class
+    }
+
     abstract class ConstValNotTopLevelOrObject : KtFirDiagnostic<KtProperty>() {
         override val diagnosticClass get() = ConstValNotTopLevelOrObject::class
     }

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnosticsImpl.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnosticsImpl.kt
@@ -1818,6 +1818,13 @@ internal class ValWithSetterImpl(
     override val firDiagnostic: FirPsiDiagnostic<*> by weakRef(firDiagnostic)
 }
 
+internal class SetterParameterWithDefaultValueImpl(
+    firDiagnostic: FirPsiDiagnostic<*>,
+    override val token: ValidityToken,
+) : KtFirDiagnostic.SetterParameterWithDefaultValue(), KtAbstractFirDiagnostic<KtExpression> {
+    override val firDiagnostic: FirPsiDiagnostic<*> by weakRef(firDiagnostic)
+}
+
 internal class ConstValNotTopLevelOrObjectImpl(
     firDiagnostic: FirPsiDiagnostic<*>,
     override val token: ValidityToken,


### PR DESCRIPTION
It is a syntax error at the parser level, though. We keep this redundant diagnostic just in case.