### PR TITLE
FIR/UAST: make a fat jar with the base module

### DIFF
--- a/plugins/uast-kotlin/build.gradle.kts
+++ b/plugins/uast-kotlin/build.gradle.kts
@@ -1,8 +1,15 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
     kotlin("jvm")
     id("jps-compatible")
 }
+
+val shadows by configurations.creating {
+    isTransitive = false
+}
+configurations.getByName("compileOnly").extendsFrom(shadows)
+configurations.getByName("testCompile").extendsFrom(shadows)
 
 dependencies {
     compile(kotlinStdlib())
@@ -11,7 +18,7 @@ dependencies {
     compile(project(":compiler:frontend"))
     compile(project(":compiler:frontend.java"))
     compile(project(":compiler:light-classes"))
-    compile(project(":plugins:uast-kotlin-base"))
+    shadows(project(":plugins:uast-kotlin-base"))
 
     // BEWARE: Uast should not depend on IDEA.
     compileOnly(intellijCoreDep()) { includeJars("intellij-core", "asm-all", rootProject = rootProject) }
@@ -62,6 +69,13 @@ dependencies {
 sourceSets {
     "main" { projectDefault() }
     "test" { projectDefault() }
+}
+
+noDefaultJar()
+
+runtimeJar(tasks.register<ShadowJar>("shadowJar")) {
+    from(mainSourceSet.output)
+    configurations = listOf(shadows)
 }
 
 testsJar {}


### PR DESCRIPTION
When running IDEA > IDEA (No ProcessCanceledException), we'll see:
```
java.lang.NoClassDefFoundError: org/jetbrains/uast/kotlin/ConverterUtilsKt
        at org.jetbrains.uast.kotlin.KotlinUastLanguagePlugin.convertElementWithParent(KotlinUastLanguagePlugin.kt:92)
        at org.jetbrains.uast.UastFacade.convertElementWithParent(UastContext.kt:64)
        at org.jetbrains.uast.UastContextKt.toUElement(UastContext.kt:111)
        at com.intellij.codeInsight.daemon.impl.IconLineMarkerProvider.getLineMarkerInfo(IconLineMarkerProvider.java:40)
        at com.intellij.codeInsight.daemon.impl.LineMarkersPass.queryProviders(LineMarkersPass.java:163)
        at com.intellij.codeInsight.daemon.impl.LineMarkersPass.lambda$doCollectInformation$3(LineMarkersPass.java:88)
        at com.intellij.codeInsight.daemon.impl.Divider.divideInsideAndOutsideInOneRoot(Divider.java:81)
        at com.intellij.codeInsight.daemon.impl.LineMarkersPass.doCollectInformation(LineMarkersPass.java:83)
        at com.intellij.codeHighlighting.TextEditorHighlightingPass.collectInformation(TextEditorHighlightingPass.java:54)
        at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$1(PassExecutorService.java:399)
        at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1110)
        at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$2(PassExecutorService.java:392)
        at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:629)
        at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:581)
        at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:60)
        at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.doRun(PassExecutorService.java:391)
        at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$run$0(PassExecutorService.java:367)
        at com.intellij.openapi.application.impl.ReadMostlyRWLock.executeByImpatientReader(ReadMostlyRWLock.java:170)
        at com.intellij.openapi.application.impl.ApplicationImpl.executeByImpatientReader(ApplicationImpl.java:182)
        at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.run(PassExecutorService.java:365)
        at com.intellij.concurrency.JobLauncherImpl$VoidForkJoinTask$1.exec(JobLauncherImpl.java:181)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
```
because `:plugins:uast-kotlin-base` is available at compile time, but not included in `uast-kotlin.jar`. When publishing UAST Kotlin (and FIR UAST in the future), such common module should be included to the jar as well. Thus, we need a _fat_ jar that includes dependencies in the published jar. (Note that, to avoid namespace conflict, we sometimes need name relocation, see kotlinx metadata, and in that case, we call that _shadow_ jar. In our case, we don't need relocation.)

Gradle tweak is borrowed from kotlinx metadata (w/o relocation, since utils in the base module _should_ be in the same package). And, here is the diff:
```
tmp $ ls -al
-rw-r-----  1 jsjeon ... 1959997 May  6 22:23  uast-kotlin-1.5.255-SNAPSHOT.after.jar
-rw-r-----  1 jsjeon ... 1929264 May  6 22:19  uast-kotlin-1.5.255-SNAPSHOT.before.jar
tmp $ jar tvf uast-kotlin-1.5.255-SNAPSHOT.after.jar > after.txt
tmp $ jar tvf uast-kotlin-1.5.255-SNAPSHOT.before.jar > before.txt
tmp $ diff before.txt after.txt 
2c2
<     25 Fri Feb 01 00:00:00 PST 1980 META-INF/MANIFEST.MF
---
>    136 Fri Feb 01 00:00:00 PST 1980 META-INF/MANIFEST.MF
427a428,436
>    102 Fri Feb 01 00:00:00 PST 1980 META-INF/uast-kotlin-base.kotlin_module
>   4166 Fri Feb 01 00:00:00 PST 1980 org/jetbrains/uast/kotlin/BaseKotlinInternalUastUtilsKt.class
>   2084 Fri Feb 01 00:00:00 PST 1980 org/jetbrains/uast/kotlin/ConverterUtilsKt$accommodate$1$1.class
>   2467 Fri Feb 01 00:00:00 PST 1980 org/jetbrains/uast/kotlin/ConverterUtilsKt$accommodate$1.class
>   2057 Fri Feb 01 00:00:00 PST 1980 org/jetbrains/uast/kotlin/ConverterUtilsKt$accommodate$2.class
>   6400 Fri Feb 01 00:00:00 PST 1980 org/jetbrains/uast/kotlin/ConverterUtilsKt.class
>   1756 Fri Feb 01 00:00:00 PST 1980 org/jetbrains/uast/kotlin/UElementAlternative.class
>   8482 Fri Feb 01 00:00:00 PST 1980 org/jetbrains/uast/kotlin/internal/KotlinUElementWithComments$DefaultImpls.class
>   1356 Fri Feb 01 00:00:00 PST 1980 org/jetbrains/uast/kotlin/internal/KotlinUElementWithComments.class
```
That is, `.class` files from the base module are included to lib jar, and IDEA run works well now.