### PR TITLE
FIR/UAST: clarify what module we should not depend on

### DIFF
--- a/plugins/uast-kotlin-fir/build.gradle.kts
+++ b/plugins/uast-kotlin-fir/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
     implementation(project(":compiler:light-classes"))
     implementation(project(":plugins:uast-kotlin-base"))
 
-    // BEWARE: Uast should not depend on IDEA.
+    // BEWARE: UAST should not depend on IJ platform so that it can work in Android Lint CLI mode (where IDE is not available)
     compileOnly(intellijCoreDep()) { includeJars("intellij-core", "asm-all", rootProject = rootProject) }
     compileOnly(intellijPluginDep("java")) { includeJars("java-api", "java-impl") }
 

--- a/plugins/uast-kotlin/build.gradle.kts
+++ b/plugins/uast-kotlin/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
     compile(project(":compiler:light-classes"))
     compile(project(":plugins:uast-kotlin-base"))
 
-    // BEWARE: Uast should not depend on IDEA.
+    // BEWARE: UAST should not depend on IJ platform so that it can work in Android Lint CLI mode (where IDE is not available)
     compileOnly(intellijCoreDep()) { includeJars("intellij-core", "asm-all", rootProject = rootProject) }
 
     testCompileOnly(intellijDep())


### PR DESCRIPTION
As per https://github.com/JetBrains/kotlin/pull/4312#discussion_r628215916, "IDEA" sounds like IntelliJ, while FIR UAST depends on some of `idea-frontend*` modules. According to the origin of this comment (https://github.com/JetBrains/kotlin/commit/06af2a88f0f5860bebc45f0b366c0a7665912a03), the clearer target to mention in the comment is `:idea:idea-core`