### PR TITLE
JVM_IR: consistently use callable reference type to get the receiver type

### DIFF
--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrTypeConverter.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrTypeConverter.kt
@@ -67,6 +67,14 @@ class Fir2IrTypeConverter(
 
     private val typeApproximator = ConeTypeApproximator(session.typeContext, session.languageVersionSettings)
 
+    private val typeApproximatorConfiguration =
+        object : TypeApproximatorConfiguration.AllFlexibleSameValue() {
+            override val allFlexible: Boolean get() = true
+            override val errorType: Boolean get() = true
+            override val integerLiteralType: Boolean get() = true
+            override val intersectionTypesInContravariantPositions: Boolean get() = true
+        }
+
     fun FirTypeRef.toIrType(typeContext: ConversionTypeContext = ConversionTypeContext.DEFAULT): IrType {
         capturedTypeCache.clear()
         return when (this) {
@@ -232,11 +240,9 @@ class Fir2IrTypeConverter(
                 } else null
             }
         }
-        val typeWithSpecifiedIntersectionTypes = substitutor.substituteOrSelf(type)
-        return typeApproximator.approximateToSuperType(
-            typeWithSpecifiedIntersectionTypes,
-            TypeApproximatorConfiguration.PublicDeclaration
-        ) ?: type
+        return substitutor.substituteOrSelf(type).let {
+            typeApproximator.approximateToSuperType(it, typeApproximatorConfiguration) ?: it
+        }
     }
 }
 

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -3148,6 +3148,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
             }
 
             @Test
+            @TestMetadata("argumentTypesNoinline.kt")
+            public void testArgumentTypesNoinline() throws Exception {
+                runTest("compiler/testData/codegen/box/callableReference/function/argumentTypesNoinline.kt");
+            }
+
+            @Test
             @TestMetadata("booleanNotIntrinsic.kt")
             public void testBooleanNotIntrinsic() throws Exception {
                 runTest("compiler/testData/codegen/box/callableReference/function/booleanNotIntrinsic.kt");
@@ -3211,6 +3217,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
             @TestMetadata("constructorFromTopLevelOneStringArg.kt")
             public void testConstructorFromTopLevelOneStringArg() throws Exception {
                 runTest("compiler/testData/codegen/box/callableReference/function/constructorFromTopLevelOneStringArg.kt");
+            }
+
+            @Test
+            @TestMetadata("dispatchReceiverType.kt")
+            public void testDispatchReceiverType() throws Exception {
+                runTest("compiler/testData/codegen/box/callableReference/function/dispatchReceiverType.kt");
             }
 
             @Test

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/InlineCallableReferenceToLambda.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/InlineCallableReferenceToLambda.kt
@@ -112,7 +112,7 @@ private class InlineCallableReferenceToLambdaTransformer(
             +IrFunctionReferenceImpl.fromSymbolOwner(
                 expression.startOffset,
                 expression.endOffset,
-                field.type,
+                expression.type,
                 function.symbol,
                 typeArgumentsCount = 0,
                 reflectionTarget = null,
@@ -184,7 +184,7 @@ private class InlineCallableReferenceToLambdaTransformer(
             +IrFunctionReferenceImpl.fromSymbolOwner(
                 expression.startOffset,
                 expression.endOffset,
-                function.returnType,
+                expression.type,
                 function.symbol,
                 typeArgumentsCount = function.typeParameters.size,
                 reflectionTarget = null,

--- a/compiler/testData/codegen/box/callableReference/function/argumentTypes.kt
+++ b/compiler/testData/codegen/box/callableReference/function/argumentTypes.kt
@@ -1,11 +1,7 @@
-// IGNORE_BACKEND: JVM_IR
-// IGNORE_BACKEND_FIR: JVM_IR
-// DONT_TARGET_EXACT_BACKEND: WASM
-// WASM_MUTE_REASON: CALLABLE_REFERENCES_FAIL
 fun <T> id(x: T): T = x
 fun <T> String.extId(x: T): T = x
 
-fun <T> foo(value: T?): T? = value?.let(::id) // KFunction1<Nothing, T>
+fun <T> foo(value: T?): T? = value?.let(::id) // ::id = KFunction1<T!!, T!!>
 fun <T> bar(value: T?): T? = value?.let(""::extId)
 
-fun box() = foo("O")!! + foo("K")!!
+fun box() = foo("O")!! + bar("K")!!

--- a/compiler/testData/codegen/box/callableReference/function/argumentTypesNoinline.kt
+++ b/compiler/testData/codegen/box/callableReference/function/argumentTypesNoinline.kt
@@ -1,13 +1,11 @@
-// IGNORE_BACKEND: JVM_IR
-// IGNORE_BACKEND_FIR: JVM_IR
 // DONT_TARGET_EXACT_BACKEND: WASM
-// WASM_MUTE_REASON: CALLABLE_REFERENCES_FAIL
+// WASM_MUTE_REASON: BINDING_RECEIVERS
 fun <T> id(x: T): T = x
 fun <T> String.extId(x: T): T = x
 
 fun <T, R> T.myLet(block: (T) -> R): R = block(this)
 
-fun <T> foo(value: T?): T? = value?.myLet(::id) // KFunction1<Nothing, T>
+fun <T> foo(value: T?): T? = value?.myLet(::id) // ::id = KFunction1<T!!, T!!>
 fun <T> bar(value: T?): T? = value?.myLet(""::extId)
 
-fun box() = foo("O")!! + foo("K")!!
+fun box() = foo("O")!! + bar("K")!!

--- a/compiler/testData/codegen/box/callableReference/function/argumentTypesNoinline.kt
+++ b/compiler/testData/codegen/box/callableReference/function/argumentTypesNoinline.kt
@@ -5,7 +5,9 @@
 fun <T> id(x: T): T = x
 fun <T> String.extId(x: T): T = x
 
-fun <T> foo(value: T?): T? = value?.let(::id) // KFunction1<Nothing, T>
-fun <T> bar(value: T?): T? = value?.let(""::extId)
+fun <T, R> T.myLet(block: (T) -> R): R = block(this)
+
+fun <T> foo(value: T?): T? = value?.myLet(::id) // KFunction1<Nothing, T>
+fun <T> bar(value: T?): T? = value?.myLet(""::extId)
 
 fun box() = foo("O")!! + foo("K")!!

--- a/compiler/testData/codegen/box/callableReference/function/dispatchReceiverType.kt
+++ b/compiler/testData/codegen/box/callableReference/function/dispatchReceiverType.kt
@@ -1,0 +1,28 @@
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND_FIR: JVM_IR
+// MODULE: lib
+// FILE: X.java
+package test;
+
+public class X extends PX {
+    public X(String x) { super(x); }
+}
+
+// FILE: PX.java
+package test;
+
+class PX {
+    private final String x;
+
+    PX(String x) { this.x = x; }
+
+    public String foo() { return x; }
+}
+
+// MODULE: main(lib)
+// FILE: box.kt
+import test.X
+
+fun <T, R> T.myLet(block: (T) -> R): R = block(this)
+
+fun box() = X("O").let(X::foo) + X("K").myLet(X::foo)

--- a/compiler/testData/codegen/box/syntheticAccessors/accessorForProtectedPropertyReference.kt
+++ b/compiler/testData/codegen/box/syntheticAccessors/accessorForProtectedPropertyReference.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 // IGNORE_BACKEND: WASM
 // FILE: 1.kt
 package a

--- a/compiler/testData/ir/irText/types/intersectionType1_NI.kt.txt
+++ b/compiler/testData/ir/irText/types/intersectionType1_NI.kt.txt
@@ -12,7 +12,7 @@ fun <S : Any?> select(x: S, y: S): S {
 }
 
 fun <T : Any?> foo(a: Array<In<T>>, b: Array<In<String>>): Boolean {
-  return select<Array<out In<Nothing>>>(x = a, y = b).get(index = 0).ofType<Any?>(y = true)
+  return select<Array<out In<Nothing>>>(x = a, y = b).get(index = 0).ofType<Any>(y = true)
 }
 
 inline fun <reified K : Any?> In<K>.ofType(y: Any?): Boolean {

--- a/compiler/testData/ir/irText/types/intersectionType1_NI.txt
+++ b/compiler/testData/ir/irText/types/intersectionType1_NI.txt
@@ -33,7 +33,7 @@ FILE fqName:<root> fileName:/intersectionType1_NI.kt
     BLOCK_BODY
       RETURN type=kotlin.Nothing from='public final fun foo <T> (a: kotlin.Array<<root>.In<T of <root>.foo>>, b: kotlin.Array<<root>.In<kotlin.String>>): kotlin.Boolean declared in <root>'
         CALL 'public final fun ofType <K> (y: kotlin.Any?): kotlin.Boolean [inline] declared in <root>' type=kotlin.Boolean origin=null
-          <K>: kotlin.Any?
+          <K>: kotlin.Any
           $receiver: CALL 'public final fun get (index: kotlin.Int): T of kotlin.Array [operator] declared in kotlin.Array' type=<root>.In<kotlin.Nothing> origin=GET_ARRAY_ELEMENT
             $this: CALL 'public final fun select <S> (x: S of <root>.select, y: S of <root>.select): S of <root>.select declared in <root>' type=kotlin.Array<out <root>.In<kotlin.Nothing>> origin=null
               <S>: kotlin.Array<out <root>.In<kotlin.Nothing>>

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -3148,6 +3148,12 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             }
 
             @Test
+            @TestMetadata("argumentTypesNoinline.kt")
+            public void testArgumentTypesNoinline() throws Exception {
+                runTest("compiler/testData/codegen/box/callableReference/function/argumentTypesNoinline.kt");
+            }
+
+            @Test
             @TestMetadata("booleanNotIntrinsic.kt")
             public void testBooleanNotIntrinsic() throws Exception {
                 runTest("compiler/testData/codegen/box/callableReference/function/booleanNotIntrinsic.kt");
@@ -3211,6 +3217,12 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             @TestMetadata("constructorFromTopLevelOneStringArg.kt")
             public void testConstructorFromTopLevelOneStringArg() throws Exception {
                 runTest("compiler/testData/codegen/box/callableReference/function/constructorFromTopLevelOneStringArg.kt");
+            }
+
+            @Test
+            @TestMetadata("dispatchReceiverType.kt")
+            public void testDispatchReceiverType() throws Exception {
+                runTest("compiler/testData/codegen/box/callableReference/function/dispatchReceiverType.kt");
             }
 
             @Test

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -3148,6 +3148,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             }
 
             @Test
+            @TestMetadata("argumentTypesNoinline.kt")
+            public void testArgumentTypesNoinline() throws Exception {
+                runTest("compiler/testData/codegen/box/callableReference/function/argumentTypesNoinline.kt");
+            }
+
+            @Test
             @TestMetadata("booleanNotIntrinsic.kt")
             public void testBooleanNotIntrinsic() throws Exception {
                 runTest("compiler/testData/codegen/box/callableReference/function/booleanNotIntrinsic.kt");
@@ -3211,6 +3217,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             @TestMetadata("constructorFromTopLevelOneStringArg.kt")
             public void testConstructorFromTopLevelOneStringArg() throws Exception {
                 runTest("compiler/testData/codegen/box/callableReference/function/constructorFromTopLevelOneStringArg.kt");
+            }
+
+            @Test
+            @TestMetadata("dispatchReceiverType.kt")
+            public void testDispatchReceiverType() throws Exception {
+                runTest("compiler/testData/codegen/box/callableReference/function/dispatchReceiverType.kt");
             }
 
             @Test

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -2762,6 +2762,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
                 runTest("compiler/testData/codegen/box/callableReference/function/argumentTypes.kt");
             }
 
+            @TestMetadata("argumentTypesNoinline.kt")
+            public void testArgumentTypesNoinline() throws Exception {
+                runTest("compiler/testData/codegen/box/callableReference/function/argumentTypesNoinline.kt");
+            }
+
             @TestMetadata("booleanNotIntrinsic.kt")
             public void testBooleanNotIntrinsic() throws Exception {
                 runTest("compiler/testData/codegen/box/callableReference/function/booleanNotIntrinsic.kt");
@@ -2815,6 +2820,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             @TestMetadata("constructorFromTopLevelOneStringArg.kt")
             public void testConstructorFromTopLevelOneStringArg() throws Exception {
                 runTest("compiler/testData/codegen/box/callableReference/function/constructorFromTopLevelOneStringArg.kt");
+            }
+
+            @TestMetadata("dispatchReceiverType.kt")
+            public void testDispatchReceiverType() throws Exception {
+                runTest("compiler/testData/codegen/box/callableReference/function/dispatchReceiverType.kt");
             }
 
             @TestMetadata("enumValueOfMethod.kt")

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
@@ -1982,6 +1982,11 @@ public class IrJsCodegenBoxES6TestGenerated extends AbstractIrJsCodegenBoxES6Tes
                 runTest("compiler/testData/codegen/box/callableReference/function/argumentTypes.kt");
             }
 
+            @TestMetadata("argumentTypesNoinline.kt")
+            public void testArgumentTypesNoinline() throws Exception {
+                runTest("compiler/testData/codegen/box/callableReference/function/argumentTypesNoinline.kt");
+            }
+
             @TestMetadata("booleanNotIntrinsic.kt")
             public void testBooleanNotIntrinsic() throws Exception {
                 runTest("compiler/testData/codegen/box/callableReference/function/booleanNotIntrinsic.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -1982,6 +1982,11 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
                 runTest("compiler/testData/codegen/box/callableReference/function/argumentTypes.kt");
             }
 
+            @TestMetadata("argumentTypesNoinline.kt")
+            public void testArgumentTypesNoinline() throws Exception {
+                runTest("compiler/testData/codegen/box/callableReference/function/argumentTypesNoinline.kt");
+            }
+
             @TestMetadata("booleanNotIntrinsic.kt")
             public void testBooleanNotIntrinsic() throws Exception {
                 runTest("compiler/testData/codegen/box/callableReference/function/booleanNotIntrinsic.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -1982,6 +1982,11 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
                 runTest("compiler/testData/codegen/box/callableReference/function/argumentTypes.kt");
             }
 
+            @TestMetadata("argumentTypesNoinline.kt")
+            public void testArgumentTypesNoinline() throws Exception {
+                runTest("compiler/testData/codegen/box/callableReference/function/argumentTypesNoinline.kt");
+            }
+
             @TestMetadata("booleanNotIntrinsic.kt")
             public void testBooleanNotIntrinsic() throws Exception {
                 runTest("compiler/testData/codegen/box/callableReference/function/booleanNotIntrinsic.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/wasm/semantics/IrCodegenBoxWasmTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/wasm/semantics/IrCodegenBoxWasmTestGenerated.java
@@ -1437,6 +1437,11 @@ public class IrCodegenBoxWasmTestGenerated extends AbstractIrCodegenBoxWasmTest 
                 KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/callableReference/function"), Pattern.compile("^([^_](.+))\\.kt$"), null, TargetBackend.WASM, true);
             }
 
+            @TestMetadata("argumentTypes.kt")
+            public void testArgumentTypes() throws Exception {
+                runTest("compiler/testData/codegen/box/callableReference/function/argumentTypes.kt");
+            }
+
             @TestMetadata("booleanNotIntrinsic.kt")
             public void testBooleanNotIntrinsic() throws Exception {
                 runTest("compiler/testData/codegen/box/callableReference/function/booleanNotIntrinsic.kt");


### PR DESCRIPTION
#KT-46555 Fixed