### PR TITLE
[JVM IR] Fix constant folding to use basic types always.

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -15549,6 +15549,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         }
 
         @Test
+        @TestMetadata("kt46540.kt")
+        public void testKt46540() throws Exception {
+            runTest("compiler/testData/codegen/box/fullJdk/kt46540.kt");
+        }
+
+        @Test
         @TestMetadata("platformTypeAssertionStackTrace.kt")
         public void testPlatformTypeAssertionStackTrace() throws Exception {
             runTest("compiler/testData/codegen/box/fullJdk/platformTypeAssertionStackTrace.kt");

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/optimizations/FoldConstantLowering.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/optimizations/FoldConstantLowering.kt
@@ -105,18 +105,17 @@ class FoldConstantLowering(
         }
 
     private fun buildIrConstant(startOffset: Int, endOffset: Int, type: IrType, v: Any?): IrConst<*> {
-        val constType = type.makeNotNull()
         return when (type.getPrimitiveType()) {
-            PrimitiveType.BOOLEAN -> IrConstImpl.boolean(startOffset, endOffset, constType, v as Boolean)
-            PrimitiveType.CHAR -> IrConstImpl.char(startOffset, endOffset, constType, v as Char)
-            PrimitiveType.BYTE -> IrConstImpl.byte(startOffset, endOffset, constType, (v as Number).toByte())
-            PrimitiveType.SHORT -> IrConstImpl.short(startOffset, endOffset, constType, (v as Number).toShort())
-            PrimitiveType.INT -> IrConstImpl.int(startOffset, endOffset, constType, (v as Number).toInt())
-            PrimitiveType.FLOAT -> fromFloatConstSafe(startOffset, endOffset, type, v)
-            PrimitiveType.LONG -> IrConstImpl.long(startOffset, endOffset, constType, (v as Number).toLong())
-            PrimitiveType.DOUBLE -> IrConstImpl.double(startOffset, endOffset, constType, (v as Number).toDouble())
+            PrimitiveType.BOOLEAN -> IrConstImpl.boolean(startOffset, endOffset, context.irBuiltIns.booleanType, v as Boolean)
+            PrimitiveType.CHAR -> IrConstImpl.char(startOffset, endOffset, context.irBuiltIns.charType, v as Char)
+            PrimitiveType.BYTE -> IrConstImpl.byte(startOffset, endOffset, context.irBuiltIns.byteType, (v as Number).toByte())
+            PrimitiveType.SHORT -> IrConstImpl.short(startOffset, endOffset, context.irBuiltIns.shortType, (v as Number).toShort())
+            PrimitiveType.INT -> IrConstImpl.int(startOffset, endOffset, context.irBuiltIns.intType, (v as Number).toInt())
+            PrimitiveType.FLOAT -> fromFloatConstSafe(startOffset, endOffset, context.irBuiltIns.floatType, v)
+            PrimitiveType.LONG -> IrConstImpl.long(startOffset, endOffset, context.irBuiltIns.longType, (v as Number).toLong())
+            PrimitiveType.DOUBLE -> IrConstImpl.double(startOffset, endOffset, context.irBuiltIns.doubleType, (v as Number).toDouble())
             else -> when {
-                constType.isString() -> IrConstImpl.string(startOffset, endOffset, constType, v as String)
+                type.isStringClassType() -> IrConstImpl.string(startOffset, endOffset, context.irBuiltIns.stringType, v as String)
                 else -> throw IllegalArgumentException("Unexpected IrCall return type")
             }
         }

--- a/compiler/testData/codegen/box/fullJdk/kt46540.kt
+++ b/compiler/testData/codegen/box/fullJdk/kt46540.kt
@@ -1,0 +1,30 @@
+// TARGET_BACKEND: JVM
+// SKIP_JDK6
+// FULL_JDK
+
+import java.util.function.Supplier
+
+class A {
+    val xLong: Supplier<Long>
+        get() = Supplier { 30 * 30 }
+
+    val xShort: Supplier<Short>
+        get() = Supplier { 30 * 30 }
+
+    val xInt: Supplier<Int>
+        get() = Supplier { 30 * 30 }
+
+    val xByte: Supplier<Byte>
+        get() = Supplier { 3 * 3 }
+}
+
+fun box(): String {
+    val a = A()
+    if (a.xLong.get() != 900L) return "FAIL1"
+    var expectedShort: Short = 900
+    if (a.xShort.get() != expectedShort) return "FAIL2"
+    if (a.xInt.get() != 900) return "FAIL3"
+    val expectedByte: Byte = 9
+    if (a.xByte.get() != expectedByte) return "FAIL4"
+    return "OK"
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -15525,6 +15525,12 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
         }
 
         @Test
+        @TestMetadata("kt46540.kt")
+        public void testKt46540() throws Exception {
+            runTest("compiler/testData/codegen/box/fullJdk/kt46540.kt");
+        }
+
+        @Test
         @TestMetadata("platformTypeAssertionStackTrace.kt")
         public void testPlatformTypeAssertionStackTrace() throws Exception {
             runTest("compiler/testData/codegen/box/fullJdk/platformTypeAssertionStackTrace.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -15549,6 +15549,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         }
 
         @Test
+        @TestMetadata("kt46540.kt")
+        public void testKt46540() throws Exception {
+            runTest("compiler/testData/codegen/box/fullJdk/kt46540.kt");
+        }
+
+        @Test
         @TestMetadata("platformTypeAssertionStackTrace.kt")
         public void testPlatformTypeAssertionStackTrace() throws Exception {
             runTest("compiler/testData/codegen/box/fullJdk/platformTypeAssertionStackTrace.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -12782,6 +12782,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/fullJdk/kt434.kt");
         }
 
+        @TestMetadata("kt46540.kt")
+        public void testKt46540() throws Exception {
+            runTest("compiler/testData/codegen/box/fullJdk/kt46540.kt");
+        }
+
         @TestMetadata("platformTypeAssertionStackTrace.kt")
         public void testPlatformTypeAssertionStackTrace() throws Exception {
             runTest("compiler/testData/codegen/box/fullJdk/platformTypeAssertionStackTrace.kt");


### PR DESCRIPTION
Fixes KT-46540.