### PR TITLE
add commonMain resources to Android AAR

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/syncKotlinAndAndroidSourceSets.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/syncKotlinAndAndroidSourceSets.kt
@@ -28,7 +28,9 @@ internal fun syncKotlinAndAndroidSourceSets(target: KotlinAndroidTarget) {
 
         createDefaultDependsOnEdges(target, kotlinSourceSet, androidSourceSet)
         syncKotlinAndAndroidSourceDirs(target, kotlinSourceSet, androidSourceSet)
-        syncKotlinAndAndroidResources(target, kotlinSourceSet, androidSourceSet)
+        (setOf(kotlinSourceSet) + kotlinSourceSet.dependsOn).forEach {
+            syncKotlinAndAndroidResources(target, it, androidSourceSet)
+        }
 
         ifKaptEnabled(project) {
             Kapt3GradleSubplugin.createAptConfigurationIfNeeded(project, androidSourceSet.name)


### PR DESCRIPTION
the Kotlin plugin only add the `androidMain` resources to AAR, if I add the resources to `commonMain`, the resources is not added to AAR.