### PR TITLE
FIR DFA: add back edge to local function and contractless lambda

### DIFF
--- a/compiler/fir/analysis-tests/testData/resolve/cfg/flowFromInplaceLambda.dot
+++ b/compiler/fir/analysis-tests/testData/resolve/cfg/flowFromInplaceLambda.dot
@@ -447,6 +447,7 @@ digraph flowFromInplaceLambda_kt {
     156 -> {157};
     157 -> {158};
     158 -> {159};
+    159 -> {152} [color=green style=dashed];
     160 -> {161};
     161 -> {162};
     162 -> {163};
@@ -455,6 +456,7 @@ digraph flowFromInplaceLambda_kt {
     165 -> {166};
     166 -> {167};
     167 -> {168};
+    168 -> {160} [color=green style=dashed];
 
     subgraph cluster_32 {
         color=red
@@ -586,6 +588,7 @@ digraph flowFromInplaceLambda_kt {
     206 -> {207};
     207 -> {208};
     208 -> {209};
+    209 -> {203} [color=green style=dashed];
     210 -> {211};
     211 -> {212};
     212 -> {213};

--- a/compiler/fir/analysis-tests/testData/resolve/cfg/lambdaAsReturnOfLambda.dot
+++ b/compiler/fir/analysis-tests/testData/resolve/cfg/lambdaAsReturnOfLambda.dot
@@ -54,11 +54,13 @@ digraph lambdaAsReturnOfLambda_kt {
     4 -> {5} [style=dotted];
     5 -> {6} [style=dotted];
     6 -> {7} [style=dotted];
+    7 -> {0} [color=green style=dashed];
     8 -> {9};
     9 -> {10};
     10 -> {11};
     11 -> {12};
     12 -> {13};
+    13 -> {8} [color=green style=dashed];
 
     subgraph cluster_5 {
         color=red

--- a/compiler/fir/analysis-tests/testData/resolve/cfg/lambdaReturningObject.dot
+++ b/compiler/fir/analysis-tests/testData/resolve/cfg/lambdaReturningObject.dot
@@ -107,5 +107,6 @@ digraph lambdaReturningObject_kt {
     30 -> {31};
     31 -> {32};
     32 -> {33};
+    33 -> {29} [color=green style=dashed];
 
 }

--- a/compiler/fir/analysis-tests/testData/resolve/cfg/lambdas.dot
+++ b/compiler/fir/analysis-tests/testData/resolve/cfg/lambdas.dot
@@ -159,6 +159,7 @@ digraph lambdas_kt {
     49 -> {50};
     50 -> {51};
     51 -> {52};
+    52 -> {47} [color=green style=dashed];
 
     subgraph cluster_16 {
         color=red

--- a/compiler/fir/analysis-tests/testData/resolve/cfg/postponedLambdaInConstructor.dot
+++ b/compiler/fir/analysis-tests/testData/resolve/cfg/postponedLambdaInConstructor.dot
@@ -85,6 +85,7 @@ digraph postponedLambdaInConstructor_kt {
     23 -> {24};
     24 -> {25};
     25 -> {26};
+    26 -> {22} [color=green style=dashed];
 
     subgraph cluster_8 {
         color=red

--- a/compiler/fir/analysis-tests/testData/resolve/extendedCheckers/CanBeValChecker.kt
+++ b/compiler/fir/analysis-tests/testData/resolve/extendedCheckers/CanBeValChecker.kt
@@ -153,7 +153,7 @@ fun lambda() {
 }
 
 fun lambdaInitialization() {
-    <!CAN_BE_VAL!>var<!> <!VARIABLE_NEVER_READ!>a<!>: Int
+    var <!VARIABLE_NEVER_READ!>a<!>: Int
 
     run {
         <!ASSIGNED_VALUE_IS_NEVER_READ!>a<!> = 20

--- a/compiler/fir/analysis-tests/testData/resolve/smartcasts/controlStructures/returns.dot
+++ b/compiler/fir/analysis-tests/testData/resolve/smartcasts/controlStructures/returns.dot
@@ -491,5 +491,6 @@ digraph returns_kt {
     172 -> {173};
     173 -> {174};
     174 -> {175};
+    175 -> {170} [color=green style=dashed];
 
 }

--- a/compiler/fir/analysis-tests/testData/resolve/smartcasts/safeCalls/safeCalls.dot
+++ b/compiler/fir/analysis-tests/testData/resolve/smartcasts/safeCalls/safeCalls.dot
@@ -193,6 +193,7 @@ digraph safeCalls_kt {
     67 -> {68};
     68 -> {69};
     69 -> {70};
+    70 -> {65} [color=green style=dashed];
 
     subgraph cluster_16 {
         color=red

--- a/compiler/fir/analysis-tests/testData/resolveWithStdlib/contracts/fromLibrary/callsInPlace.dot
+++ b/compiler/fir/analysis-tests/testData/resolveWithStdlib/contracts/fromLibrary/callsInPlace.dot
@@ -429,5 +429,6 @@ digraph callsInPlace_kt {
     136 -> {137};
     137 -> {138};
     138 -> {139};
+    139 -> {135} [color=green style=dashed];
 
 }

--- a/compiler/fir/analysis-tests/testData/resolveWithStdlib/delegates/delegateWithAnonymousObject.dot
+++ b/compiler/fir/analysis-tests/testData/resolveWithStdlib/delegates/delegateWithAnonymousObject.dot
@@ -242,6 +242,7 @@ digraph delegateWithAnonymousObject_kt {
     30 -> {35 38 45 33} [color=green];
     30 -> {35 38 45 33} [style=dashed];
     31 -> {32};
+    32 -> {28} [color=green style=dashed];
     33 -> {34} [color=green];
 
 }

--- a/compiler/fir/analysis-tests/testData/resolveWithStdlib/inference/plusAssignWithLambdaInRhs.dot
+++ b/compiler/fir/analysis-tests/testData/resolveWithStdlib/inference/plusAssignWithLambdaInRhs.dot
@@ -150,6 +150,7 @@ digraph plusAssignWithLambdaInRhs_kt {
     40 -> {41};
     41 -> {42};
     42 -> {43};
+    43 -> {36} [color=green style=dashed];
     44 -> {49 45};
     45 -> {46};
     46 -> {47};

--- a/compiler/fir/analysis-tests/testData/resolveWithStdlib/smartcasts/tryWithLambdaInside.dot
+++ b/compiler/fir/analysis-tests/testData/resolveWithStdlib/smartcasts/tryWithLambdaInside.dot
@@ -216,5 +216,6 @@ finally {
     57 -> {58};
     58 -> {59};
     59 -> {60};
+    60 -> {56} [color=green style=dashed];
 
 }

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/dfa/cfg/ControlFlowGraphBuilder.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/dfa/cfg/ControlFlowGraphBuilder.kt
@@ -302,6 +302,8 @@ class ControlFlowGraphBuilder {
 
     private val EventOccurrencesRange?.hasBackEdge: Boolean
         get() = when (this) {
+            // no contract, hence the function may be called multiple times.
+            null -> true
             EventOccurrencesRange.AT_LEAST_ONCE, EventOccurrencesRange.UNKNOWN -> true
             else -> false
         }

--- a/compiler/testData/diagnostics/tests/controlFlowAnalysis/initializationInLambda.fir.kt
+++ b/compiler/testData/diagnostics/tests/controlFlowAnalysis/initializationInLambda.fir.kt
@@ -17,7 +17,7 @@ fun foo() {
 fun bar() {
     val x: Int
     exec {
-        x = 13
+        <!VAL_REASSIGNMENT!>x<!> = 13
     }
 }
 
@@ -60,7 +60,7 @@ class Your {
     val y = if (true) {
         val xx: Int
         exec {
-            xx = 42
+            <!VAL_REASSIGNMENT!>xx<!> = 42
         }
         24
     }
@@ -70,7 +70,7 @@ class Your {
 val z = if (true) {
     val xx: Int
     exec {
-        xx = 24
+        <!VAL_REASSIGNMENT!>xx<!> = 24
     }
     42
 }

--- a/compiler/testData/diagnostics/testsWithStdLib/contracts/controlflow/initialization/exactlyOnce/valIndefiniteInitialization.fir.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/contracts/controlflow/initialization/exactlyOnce/valIndefiniteInitialization.fir.kt
@@ -36,7 +36,7 @@ fun branchingIndetermineFlow(a: Any?) {
 
 fun nonAnonymousLambdas() {
     val x: Int
-    val initializer = { x = 42 }
+    val initializer = { <!VAL_REASSIGNMENT!>x<!> = 42 }
     myRun(initializer)
     <!UNINITIALIZED_VARIABLE!>x<!>.inc()
 }
@@ -55,7 +55,7 @@ fun funWithUnknownInvocations(block: () -> Unit) = block()
 fun nestedIndefiniteAssignment() {
     val x: Int
     // Captured val initialization reported, because we don't know anything about funWithUnknownInvocations
-    funWithUnknownInvocations { myRun { x = 42 } }
+    funWithUnknownInvocations { myRun { <!VAL_REASSIGNMENT!>x<!> = 42 } }
     <!UNINITIALIZED_VARIABLE!>x<!>.inc()
 }
 

--- a/compiler/testData/diagnostics/testsWithStdLib/contracts/controlflow/initialization/exactlyOnce/varIndefiniteInitialization.fir.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/contracts/controlflow/initialization/exactlyOnce/varIndefiniteInitialization.fir.kt
@@ -46,6 +46,6 @@ fun funWithUnknownInvocations(block: () -> Unit) = block()
 
 fun nestedIndefiniteAssignment() {
     val x: Int
-    funWithUnknownInvocations { myRun { x = 42 } }
+    funWithUnknownInvocations { myRun { <!VAL_REASSIGNMENT!>x<!> = 42 } }
     <!UNINITIALIZED_VARIABLE!>x<!>.inc()
 }


### PR DESCRIPTION
A contractless lambda may be invoked repeatedly. Hence, it makes sense
to add a back edge to account for this.

Similarly for local functions.