### PR TITLE
FIR checker: report CAPTURED_VAL_INITIALIZATION

### DIFF
--- a/compiler/fir/analysis-tests/testData/resolveWithStdlib/initialization/fromLocalMembers.kt
+++ b/compiler/fir/analysis-tests/testData/resolveWithStdlib/initialization/fromLocalMembers.kt
@@ -2,7 +2,7 @@ fun test1() {
     val x: Int
 
     fun func() {
-        x = 0
+        <!CAPTURED_VAL_INITIALIZATION!>x<!> = 0
     }
 
     println(<!UNINITIALIZED_VARIABLE!>x<!>)

--- a/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/diagnostics/FirDiagnosticsList.kt
+++ b/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/diagnostics/FirDiagnosticsList.kt
@@ -655,6 +655,12 @@ object DIAGNOSTICS_LIST : DiagnosticList() {
         val VAL_REASSIGNMENT_VIA_BACKING_FIELD_ERROR by error<KtExpression> {
             parameter<FirPropertySymbol>("property")
         }
+        val CAPTURED_VAL_INITIALIZATION by error<KtExpression> {
+            parameter<FirPropertySymbol>("property")
+        }
+        val CAPTURED_MEMBER_VAL_INITIALIZATION by error<KtExpression> {
+            parameter<FirPropertySymbol>("property")
+        }
         val WRONG_INVOCATION_KIND by warning<PsiElement> {
             parameter<Symbol>("declaration")
             parameter<EventOccurrencesRange>("requiredRange")

--- a/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/diagnostics/FirErrors.kt
+++ b/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/diagnostics/FirErrors.kt
@@ -394,6 +394,8 @@ object FirErrors {
     val VAL_REASSIGNMENT by error1<KtExpression, FirVariableSymbol<*>>()
     val VAL_REASSIGNMENT_VIA_BACKING_FIELD by warning1<KtExpression, FirPropertySymbol>()
     val VAL_REASSIGNMENT_VIA_BACKING_FIELD_ERROR by error1<KtExpression, FirPropertySymbol>()
+    val CAPTURED_VAL_INITIALIZATION by error1<KtExpression, FirPropertySymbol>()
+    val CAPTURED_MEMBER_VAL_INITIALIZATION by error1<KtExpression, FirPropertySymbol>()
     val WRONG_INVOCATION_KIND by warning3<PsiElement, AbstractFirBasedSymbol<*>, EventOccurrencesRange, EventOccurrencesRange>()
     val LEAKED_IN_PLACE_LAMBDA by error1<PsiElement, AbstractFirBasedSymbol<*>>()
     val WRONG_IMPLIES_CONDITION by warning0<PsiElement>()

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/AbstractFirPropertyInitializationChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/AbstractFirPropertyInitializationChecker.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.fir.analysis.cfa
 
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.fir.analysis.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.fir.expressions.FirVariableAssignment
 import org.jetbrains.kotlin.fir.resolve.dfa.cfg.CFGNode
 import org.jetbrains.kotlin.fir.resolve.dfa.cfg.ControlFlowGraph
 import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
@@ -17,6 +18,7 @@ abstract class AbstractFirPropertyInitializationChecker {
         reporter: DiagnosticReporter,
         data: Map<CFGNode<*>, PathAwarePropertyInitializationInfo>,
         properties: Set<FirPropertySymbol>,
+        capturedWrites: Set<FirVariableAssignment>,
         context: CheckerContext
     )
 }

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/FirControlFlowAnalyzer.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/FirControlFlowAnalyzer.kt
@@ -61,9 +61,9 @@ class FirControlFlowAnalyzer(
     }
 
     private fun runAssignmentCfaCheckers(graph: ControlFlowGraph, reporter: DiagnosticReporter, context: CheckerContext) {
-        val properties = LocalPropertyCollector.collect(graph)
+        val (properties, capturedWrites) = LocalPropertyAndCapturedWriteCollector.collect(graph)
         if (properties.isEmpty()) return
         val data = PropertyInitializationInfoCollector(properties).getData(graph)
-        variableAssignmentCheckers.forEach { it.analyze(graph, reporter, data, properties, context) }
+        variableAssignmentCheckers.forEach { it.analyze(graph, reporter, data, properties, capturedWrites, context) }
     }
 }

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/extended/CanBeValChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/extended/CanBeValChecker.kt
@@ -18,6 +18,7 @@ import org.jetbrains.kotlin.fir.analysis.checkers.getChildren
 import org.jetbrains.kotlin.fir.analysis.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors
 import org.jetbrains.kotlin.fir.analysis.diagnostics.reportOn
+import org.jetbrains.kotlin.fir.expressions.FirVariableAssignment
 import org.jetbrains.kotlin.fir.references.FirResolvedNamedReference
 import org.jetbrains.kotlin.fir.resolve.dfa.cfg.*
 import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
@@ -28,6 +29,7 @@ object CanBeValChecker : AbstractFirPropertyInitializationChecker() {
         reporter: DiagnosticReporter,
         data: Map<CFGNode<*>, PathAwarePropertyInitializationInfo>,
         properties: Set<FirPropertySymbol>,
+        capturedWrites: Set<FirVariableAssignment>,
         context: CheckerContext
     ) {
         val unprocessedProperties = mutableSetOf<FirPropertySymbol>()

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/extended/UnusedChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/extended/UnusedChecker.kt
@@ -36,7 +36,7 @@ object UnusedChecker : FirControlFlowChecker() {
                 !it.symbol.classId.isLocal
             } != null
         ) return
-        val properties = LocalPropertyCollector.collect(graph)
+        val (properties, _) = LocalPropertyAndCapturedWriteCollector.collect(graph)
         if (properties.isEmpty()) return
 
         val data = ValueWritesWithoutReading(context.session, properties).getData(graph)

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/FirDefaultErrorMessages.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/FirDefaultErrorMessages.kt
@@ -56,6 +56,8 @@ import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.CANNOT_INFER_PARA
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.CANNOT_WEAKEN_ACCESS_PRIVILEGE
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.CAN_BE_REPLACED_WITH_OPERATOR_ASSIGNMENT
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.CAN_BE_VAL
+import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.CAPTURED_MEMBER_VAL_INITIALIZATION
+import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.CAPTURED_VAL_INITIALIZATION
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.CATCH_PARAMETER_WITH_DEFAULT_VALUE
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.CLASS_IN_SUPERTYPE_FOR_ENUM
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.CLASS_LITERAL_LHS_NOT_A_CLASS
@@ -905,6 +907,16 @@ class FirDefaultErrorMessages : DefaultErrorMessages.Extension {
             map.put(VAL_REASSIGNMENT, "Val cannot be reassigned", VARIABLE_NAME)
             map.put(VAL_REASSIGNMENT_VIA_BACKING_FIELD, "Reassignment of read-only property via backing field is deprecated", VARIABLE_NAME)
             map.put(VAL_REASSIGNMENT_VIA_BACKING_FIELD_ERROR, "Reassignment of read-only property via backing field", VARIABLE_NAME)
+            map.put(
+                CAPTURED_VAL_INITIALIZATION,
+                "Captured values initialization is forbidden due to possible reassignment",
+                VARIABLE_NAME
+            )
+            map.put(
+                CAPTURED_MEMBER_VAL_INITIALIZATION,
+                "Captured member values initialization is forbidden due to possible reassignment",
+                VARIABLE_NAME
+            )
             map.put(
                 WRONG_INVOCATION_KIND,
                 "{2} wrong invocation kind: given {3} case, but {4} case is possible",

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/dfa/cfg/CfgUtils.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/dfa/cfg/CfgUtils.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.fir.resolve.dfa.cfg
+
+import org.jetbrains.kotlin.contracts.description.EventOccurrencesRange
+
+val EventOccurrencesRange?.isInPlace: Boolean
+    get() = this != null

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/dfa/cfg/ControlFlowGraphBuilder.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/dfa/cfg/ControlFlowGraphBuilder.kt
@@ -306,9 +306,6 @@ class ControlFlowGraphBuilder {
             else -> false
         }
 
-    private val EventOccurrencesRange?.isInPlace: Boolean
-        get() = this != null
-
     fun exitAnonymousFunction(anonymousFunction: FirAnonymousFunction): Triple<FunctionExitNode, PostponedLambdaExitNode?, ControlFlowGraph> {
         val symbol = anonymousFunction.symbol
         val exitNode = exitsOfAnonymousFunctions.remove(symbol)!!.also {

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/declarations/FirDeclarationUtil.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/declarations/FirDeclarationUtil.kt
@@ -11,10 +11,13 @@ import org.jetbrains.kotlin.fir.declarations.builder.FirRegularClassBuilder
 import org.jetbrains.kotlin.fir.declarations.builder.FirTypeParameterBuilder
 import org.jetbrains.kotlin.fir.declarations.impl.FirFileImpl
 import org.jetbrains.kotlin.fir.declarations.impl.FirRegularClassImpl
+import org.jetbrains.kotlin.fir.expressions.FirQualifiedAccess
+import org.jetbrains.kotlin.fir.expressions.FirVariableAssignment
 import org.jetbrains.kotlin.fir.references.FirResolvedNamedReference
 import org.jetbrains.kotlin.fir.render
 import org.jetbrains.kotlin.fir.symbols.impl.FirAnonymousObjectSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirClassSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
 import org.jetbrains.kotlin.fir.types.ConeClassLikeType
 import org.jetbrains.kotlin.fir.types.ConeFlexibleType
@@ -214,6 +217,12 @@ val FirProperty.hasBackingField: Boolean
                 return isReferredViaField == true
             }
         }
+    }
+
+val FirQualifiedAccess.referredPropertySymbol: FirPropertySymbol?
+    get() {
+        val reference = calleeReference as? FirResolvedNamedReference ?: return null
+        return reference.resolvedSymbol as? FirPropertySymbol
     }
 
 inline val FirDeclaration.isFromLibrary: Boolean

--- a/compiler/testData/diagnostics/tests/controlFlowAnalysis/initializationInLambda.fir.kt
+++ b/compiler/testData/diagnostics/tests/controlFlowAnalysis/initializationInLambda.fir.kt
@@ -17,14 +17,14 @@ fun foo() {
 fun bar() {
     val x: Int
     exec {
-        x = 13
+        <!CAPTURED_VAL_INITIALIZATION!>x<!> = 13
     }
 }
 
 fun bar2() {
     val x: Int
     fun foo() {
-        x = 3
+        <!CAPTURED_VAL_INITIALIZATION!>x<!> = 3
     }
     foo()
 }
@@ -60,7 +60,7 @@ class Your {
     val y = if (true) {
         val xx: Int
         exec {
-            xx = 42
+            <!CAPTURED_VAL_INITIALIZATION!>xx<!> = 42
         }
         24
     }
@@ -70,7 +70,7 @@ class Your {
 val z = if (true) {
     val xx: Int
     exec {
-        xx = 24
+        <!CAPTURED_VAL_INITIALIZATION!>xx<!> = 24
     }
     42
 }

--- a/compiler/testData/diagnostics/tests/controlFlowAnalysis/initializationInLocalClass.fir.kt
+++ b/compiler/testData/diagnostics/tests/controlFlowAnalysis/initializationInLocalClass.fir.kt
@@ -59,7 +59,7 @@ fun gau() {
         object: Any() {
             init {
                 // Error!
-                y = ""
+                <!CAPTURED_VAL_INITIALIZATION!>y<!> = ""
             }
         }
     }

--- a/compiler/testData/diagnostics/testsWithStdLib/contracts/controlflow/initialization/exactlyOnce/valIndefiniteInitialization.fir.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/contracts/controlflow/initialization/exactlyOnce/valIndefiniteInitialization.fir.kt
@@ -36,7 +36,7 @@ fun branchingIndetermineFlow(a: Any?) {
 
 fun nonAnonymousLambdas() {
     val x: Int
-    val initializer = { x = 42 }
+    val initializer = { <!CAPTURED_VAL_INITIALIZATION!>x<!> = 42 }
     myRun(initializer)
     <!UNINITIALIZED_VARIABLE!>x<!>.inc()
 }
@@ -55,7 +55,7 @@ fun funWithUnknownInvocations(block: () -> Unit) = block()
 fun nestedIndefiniteAssignment() {
     val x: Int
     // Captured val initialization reported, because we don't know anything about funWithUnknownInvocations
-    funWithUnknownInvocations { myRun { x = 42 } }
+    funWithUnknownInvocations { myRun { <!CAPTURED_VAL_INITIALIZATION!>x<!> = 42 } }
     <!UNINITIALIZED_VARIABLE!>x<!>.inc()
 }
 

--- a/compiler/testData/diagnostics/testsWithStdLib/contracts/controlflow/initialization/exactlyOnce/varIndefiniteInitialization.fir.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/contracts/controlflow/initialization/exactlyOnce/varIndefiniteInitialization.fir.kt
@@ -46,6 +46,6 @@ fun funWithUnknownInvocations(block: () -> Unit) = block()
 
 fun nestedIndefiniteAssignment() {
     val x: Int
-    funWithUnknownInvocations { myRun { x = 42 } }
+    funWithUnknownInvocations { myRun { <!CAPTURED_VAL_INITIALIZATION!>x<!> = 42 } }
     <!UNINITIALIZED_VARIABLE!>x<!>.inc()
 }

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDataClassConverters.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDataClassConverters.kt
@@ -1887,6 +1887,20 @@ internal val KT_DIAGNOSTIC_CONVERTER = KtDiagnosticConverterBuilder.buildConvert
             token,
         )
     }
+    add(FirErrors.CAPTURED_VAL_INITIALIZATION) { firDiagnostic ->
+        CapturedValInitializationImpl(
+            firSymbolBuilder.variableLikeBuilder.buildVariableSymbol(firDiagnostic.a.fir),
+            firDiagnostic as FirPsiDiagnostic<*>,
+            token,
+        )
+    }
+    add(FirErrors.CAPTURED_MEMBER_VAL_INITIALIZATION) { firDiagnostic ->
+        CapturedMemberValInitializationImpl(
+            firSymbolBuilder.variableLikeBuilder.buildVariableSymbol(firDiagnostic.a.fir),
+            firDiagnostic as FirPsiDiagnostic<*>,
+            token,
+        )
+    }
     add(FirErrors.WRONG_INVOCATION_KIND) { firDiagnostic ->
         WrongInvocationKindImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a.fir as FirDeclaration),

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnostics.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnostics.kt
@@ -1324,6 +1324,16 @@ sealed class KtFirDiagnostic<PSI: PsiElement> : KtDiagnosticWithPsi<PSI> {
         abstract val property: KtVariableSymbol
     }
 
+    abstract class CapturedValInitialization : KtFirDiagnostic<KtExpression>() {
+        override val diagnosticClass get() = CapturedValInitialization::class
+        abstract val property: KtVariableSymbol
+    }
+
+    abstract class CapturedMemberValInitialization : KtFirDiagnostic<KtExpression>() {
+        override val diagnosticClass get() = CapturedMemberValInitialization::class
+        abstract val property: KtVariableSymbol
+    }
+
     abstract class WrongInvocationKind : KtFirDiagnostic<PsiElement>() {
         override val diagnosticClass get() = WrongInvocationKind::class
         abstract val declaration: KtSymbol

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnosticsImpl.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnosticsImpl.kt
@@ -2153,6 +2153,22 @@ internal class ValReassignmentViaBackingFieldErrorImpl(
     override val firDiagnostic: FirPsiDiagnostic<*> by weakRef(firDiagnostic)
 }
 
+internal class CapturedValInitializationImpl(
+    override val property: KtVariableSymbol,
+    firDiagnostic: FirPsiDiagnostic<*>,
+    override val token: ValidityToken,
+) : KtFirDiagnostic.CapturedValInitialization(), KtAbstractFirDiagnostic<KtExpression> {
+    override val firDiagnostic: FirPsiDiagnostic<*> by weakRef(firDiagnostic)
+}
+
+internal class CapturedMemberValInitializationImpl(
+    override val property: KtVariableSymbol,
+    firDiagnostic: FirPsiDiagnostic<*>,
+    override val token: ValidityToken,
+) : KtFirDiagnostic.CapturedMemberValInitialization(), KtAbstractFirDiagnostic<KtExpression> {
+    override val firDiagnostic: FirPsiDiagnostic<*> by weakRef(firDiagnostic)
+}
+
 internal class WrongInvocationKindImpl(
     override val declaration: KtSymbol,
     override val requiredRange: EventOccurrencesRange,


### PR DESCRIPTION
Assignments to local variables that are captured by a lambda or local function are not allowed, since they can be updated outside. From checker's viewpoint, CFG is fully available; resolution is done; hence it is safe to traverse CFG and collect captured write, while maintaining a stack of lambda or local function.

An exception is: a lambda that is `inline`d or invoked in-place (described in the caller function's contract about lambda argument) does not capture a variable. But, a lambda inside another lambda that doesn't have such property still captures a variable. Hence, we should check if _all_ enclosing declarations are lambdas with either `inline` status or in-place invocation kind.