### PR TITLE
Parcelize: Handle class hierarchies of Parcelers (KT-46567)

### DIFF
--- a/plugins/android-extensions/android-extensions-compiler/test/org/jetbrains/kotlin/android/parcel/ParcelBoxTestGenerated.java
+++ b/plugins/android-extensions/android-extensions-compiler/test/org/jetbrains/kotlin/android/parcel/ParcelBoxTestGenerated.java
@@ -180,6 +180,11 @@ public class ParcelBoxTestGenerated extends AbstractParcelBoxTest {
         runTest("plugins/android-extensions/android-extensions-compiler/testData/parcel/box/kt39981.kt");
     }
 
+    @TestMetadata("kt46567.kt")
+    public void testKt46567() throws Exception {
+        runTest("plugins/android-extensions/android-extensions-compiler/testData/parcel/box/kt46567.kt");
+    }
+
     @TestMetadata("listKinds.kt")
     public void testListKinds() throws Exception {
         runTest("plugins/android-extensions/android-extensions-compiler/testData/parcel/box/listKinds.kt");
@@ -238,6 +243,11 @@ public class ParcelBoxTestGenerated extends AbstractParcelBoxTest {
     @TestMetadata("newArray.kt")
     public void testNewArray() throws Exception {
         runTest("plugins/android-extensions/android-extensions-compiler/testData/parcel/box/newArray.kt");
+    }
+
+    @TestMetadata("newArrayParceler.kt")
+    public void testNewArrayParceler() throws Exception {
+        runTest("plugins/android-extensions/android-extensions-compiler/testData/parcel/box/newArrayParceler.kt");
     }
 
     @TestMetadata("nullableTypes.kt")

--- a/plugins/android-extensions/android-extensions-compiler/test/org/jetbrains/kotlin/android/parcel/ParcelIrBoxTestGenerated.java
+++ b/plugins/android-extensions/android-extensions-compiler/test/org/jetbrains/kotlin/android/parcel/ParcelIrBoxTestGenerated.java
@@ -180,6 +180,11 @@ public class ParcelIrBoxTestGenerated extends AbstractParcelIrBoxTest {
         runTest("plugins/android-extensions/android-extensions-compiler/testData/parcel/box/kt39981.kt");
     }
 
+    @TestMetadata("kt46567.kt")
+    public void testKt46567() throws Exception {
+        runTest("plugins/android-extensions/android-extensions-compiler/testData/parcel/box/kt46567.kt");
+    }
+
     @TestMetadata("listKinds.kt")
     public void testListKinds() throws Exception {
         runTest("plugins/android-extensions/android-extensions-compiler/testData/parcel/box/listKinds.kt");
@@ -238,6 +243,11 @@ public class ParcelIrBoxTestGenerated extends AbstractParcelIrBoxTest {
     @TestMetadata("newArray.kt")
     public void testNewArray() throws Exception {
         runTest("plugins/android-extensions/android-extensions-compiler/testData/parcel/box/newArray.kt");
+    }
+
+    @TestMetadata("newArrayParceler.kt")
+    public void testNewArrayParceler() throws Exception {
+        runTest("plugins/android-extensions/android-extensions-compiler/testData/parcel/box/newArrayParceler.kt");
     }
 
     @TestMetadata("nullableTypes.kt")

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/kt46567.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/kt46567.kt
@@ -1,0 +1,64 @@
+// WITH_RUNTIME
+
+@file:JvmName("TestKt")
+package test
+
+import kotlinx.android.parcel.*
+import android.os.Parcel
+import android.os.Parcelable
+import java.util.Arrays
+
+/**
+ * Generic pair parceler
+ * Create concrete object to use (see below)
+ */
+open class PairParceler<F: Any, S: Any>(private val firstParceler: Parceler<F>, private val secondParceler: Parceler<S>): Parceler<Pair<F, S>> {
+    /**
+     * Reads the [T] instance state from the [parcel], constructs the new [T] instance and returns it.
+     */
+    override fun create(parcel: Parcel): Pair<F, S> =
+        firstParceler.create(parcel) to secondParceler.create(parcel)
+
+    /**
+     * Writes the [T] instance state to the [parcel].
+     */
+    override fun Pair<F, S>.write(parcel: Parcel, flags: Int) {
+        with(firstParceler) { this@write.first.write(parcel, 0) }
+        with(secondParceler) { this@write.second.write(parcel, 0) }
+    }
+}
+
+object IntParceler: Parceler<Int> {
+    /**
+     * Reads the [T] instance state from the [parcel], constructs the new [T] instance and returns it.
+     */
+    override fun create(parcel: Parcel): Int = parcel.readInt()
+
+    /**
+     * Writes the [T] instance state to the [parcel].
+     */
+    override fun Int.write(parcel: Parcel, flags: Int) {
+        parcel.writeInt(this)
+    }
+}
+
+/**
+ * [Int] to [Int] pair parceler
+ */
+object IntToIntParceler: PairParceler<Int, Int>(IntParceler, IntParceler)
+
+@Parcelize
+@TypeParceler<Pair<Int, Int>, IntToIntParceler>
+class A(val pair: Pair<Int, Int>): Parcelable
+
+fun box() = parcelTest { parcel ->
+    val a1 = A(1 to 2)
+    a1.writeToParcel(parcel, 0)
+
+    val bytes = parcel.marshall()
+    parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
+
+    val a2 = readFromParcel<A>(parcel)
+    assert(a1.pair == a2.pair)
+}

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/newArrayParceler.kt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/box/newArrayParceler.kt
@@ -1,0 +1,45 @@
+// WITH_RUNTIME
+// IGNORE_BACKEND: JVM
+
+@file:JvmName("TestKt")
+package test
+
+import kotlinx.android.parcel.*
+import android.os.Parcel
+import android.os.Parcelable
+
+abstract class UserParceler : Parceler<User> {
+    override fun User.write(parcel: Parcel, flags: Int) {
+        parcel.writeString(name)
+    }
+
+    override fun newArray(size: Int): Array<User> {
+        return Array(size + 1) { User(null) }
+    }
+}
+
+@Parcelize
+class User(val name: String?) : Parcelable {
+    companion object : UserParceler() {
+        override fun create(parcel: Parcel) = User(parcel.readString())
+    }
+}
+
+fun box() = parcelTest { parcel ->
+    val user = User("John")
+    val user2 = User("Joe")
+    val array = arrayOf(user, user2)
+    parcel.writeTypedArray(array, 0)
+
+    val bytes = parcel.marshall()
+    parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
+
+    val creator = User::class.java.getDeclaredField("CREATOR").get(null) as Parcelable.Creator<User>
+    val result = parcel.createTypedArray(creator)
+
+    assert(result.size == 3)
+    assert(result[0].name == user.name)
+    assert(result[1].name == user2.name)
+    assert(result[2].name == null)
+}

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/customParcelablesSameModule.ir.txt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/customParcelablesSameModule.ir.txt
@@ -29,6 +29,7 @@ public final class k/KotlinParcelable$Creator : java/lang/Object, android/os/Par
 
     public java.lang.Object createFromParcel(android.os.Parcel p0) {
         LABEL (L0)
+        LINENUMBER (21)
           ALOAD (0)
           ALOAD (1)
           INVOKEVIRTUAL (k/KotlinParcelable$Creator, createFromParcel, (Landroid/os/Parcel;)Lk/KotlinParcelable;)

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/customSimple.ir.txt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/customSimple.ir.txt
@@ -20,6 +20,7 @@ final class User$Companion : java/lang/Object, kotlinx/android/parcel/Parceler {
 
     public java.lang.Object[] newArray(int size) {
         LABEL (L0)
+        LINENUMBER (10)
           ALOAD (0)
           ILOAD (1)
           INVOKEVIRTUAL (User$Companion, newArray, (I)[LUser;)
@@ -40,7 +41,7 @@ public final class User$Creator : java/lang/Object, android/os/Parcelable$Creato
           ALOAD (1)
           LDC (parcel)
           INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
-          INVOKESTATIC (User, access$getCompanion$p$s2645995, ()LUser$Companion;)
+          INVOKESTATIC (User, access$getCompanion$p, ()LUser$Companion;)
           ALOAD (1)
           INVOKEVIRTUAL (User$Companion, create, (Landroid/os/Parcel;)LUser;)
           ARETURN
@@ -89,7 +90,7 @@ public final class User : java/lang/Object, android/os/Parcelable {
 
     public void <init>(java.lang.String firstName, java.lang.String lastName, int age)
 
-    public final static User$Companion access$getCompanion$p$s2645995()
+    public final static User$Companion access$getCompanion$p()
 
     public int describeContents()
 

--- a/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/customSimpleWithNewArray.ir.txt
+++ b/plugins/android-extensions/android-extensions-compiler/testData/parcel/codegen/customSimpleWithNewArray.ir.txt
@@ -18,6 +18,7 @@ final class User$Companion : java/lang/Object, kotlinx/android/parcel/Parceler {
 
     public java.lang.Object[] newArray(int size) {
         LABEL (L0)
+        LINENUMBER (10)
           ALOAD (0)
           ILOAD (1)
           INVOKEVIRTUAL (User$Companion, newArray, (I)[LUser;)
@@ -39,7 +40,7 @@ public final class User$Creator : java/lang/Object, android/os/Parcelable$Creato
 
     public final User[] newArray(int size) {
         LABEL (L0)
-          INVOKESTATIC (User, access$getCompanion$p$s2645995, ()LUser$Companion;)
+          INVOKESTATIC (User, access$getCompanion$p, ()LUser$Companion;)
           ILOAD (1)
           INVOKEVIRTUAL (User$Companion, newArray, (I)[LUser;)
           ARETURN
@@ -71,7 +72,7 @@ public final class User : java/lang/Object, android/os/Parcelable {
 
     public void <init>(java.lang.String firstName, java.lang.String lastName, int age)
 
-    public final static User$Companion access$getCompanion$p$s2645995()
+    public final static User$Companion access$getCompanion$p()
 
     public int describeContents()
 

--- a/plugins/parcelize/parcelize-compiler/src/org/jetbrains/kotlin/parcelize/ir/irUtils.kt
+++ b/plugins/parcelize/parcelize-compiler/src/org/jetbrains/kotlin/parcelize/ir/irUtils.kt
@@ -42,34 +42,36 @@ val IrClass.hasCreatorField: Boolean
 
 // object P : Parceler<T> { fun T.write(parcel: Parcel, flags: Int) ...}
 fun IrBuilderWithScope.parcelerWrite(
-    parceler: IrClass, parcel: IrValueDeclaration,
-    flags: IrValueDeclaration, value: IrExpression
-): IrCall {
-    return irCall(parceler.parcelerSymbolByName("write")!!).apply {
-        dispatchReceiver = irGetObject(parceler.symbol)
-        extensionReceiver = value
-        putValueArgument(0, irGet(parcel))
-        putValueArgument(1, irGet(flags))
-    }
+    parceler: IrClass,
+    parcel: IrValueDeclaration,
+    flags: IrValueDeclaration,
+    value: IrExpression,
+) = irCall(parceler.parcelerSymbolByName("write")!!).apply {
+    dispatchReceiver = irGetObject(parceler.symbol)
+    extensionReceiver = value
+    putValueArgument(0, irGet(parcel))
+    putValueArgument(1, irGet(flags))
 }
 
 // object P : Parceler<T> { fun create(parcel: Parcel): T }
-fun IrBuilderWithScope.parcelerCreate(parceler: IrClass, parcel: IrValueDeclaration): IrExpression {
-    return irCall(parceler.parcelerSymbolByName("create")!!).apply {
+fun IrBuilderWithScope.parcelerCreate(parceler: IrClass, parcel: IrValueDeclaration): IrExpression =
+    irCall(parceler.parcelerSymbolByName("create")!!).apply {
         dispatchReceiver = irGetObject(parceler.symbol)
         putValueArgument(0, irGet(parcel))
     }
-}
 
 // object P: Parceler<T> { fun newArray(size: Int): Array<T> }
-fun IrBuilderWithScope.parcelerNewArray(parceler: IrClass?, size: IrValueDeclaration): IrExpression? {
-    return parceler?.parcelerSymbolByName("newArray")?.let { newArraySymbol ->
+fun IrBuilderWithScope.parcelerNewArray(parceler: IrClass?, size: IrValueDeclaration): IrExpression? =
+    parceler?.parcelerSymbolByName("newArray")?.takeIf {
+        // The `newArray` method in `kotlinx.parcelize.Parceler` is stubbed out and we
+        // have to produce a new implementation, unless the user overrides it.
+        !it.owner.isFakeOverride || it.owner.resolveFakeOverride()?.parentClassOrNull?.fqNameWhenAvailable != PARCELER_FQNAME
+    }?.let { newArraySymbol ->
         irCall(newArraySymbol).apply {
             dispatchReceiver = irGetObject(parceler.symbol)
             putValueArgument(0, irGet(size))
         }
     }
-}
 
 // class Parcelable { fun writeToParcel(parcel: Parcel, flags: Int) ...}
 fun IrBuilderWithScope.parcelableWriteToParcel(
@@ -104,34 +106,29 @@ fun IrBuilderWithScope.parcelableCreatorCreateFromParcel(creator: IrExpression, 
 // Find a named function declaration which overrides the corresponding function in [Parceler].
 // This is more reliable than trying to match the functions signature ourselves, since the frontend
 // has already done the work.
-private fun IrClass.parcelerSymbolByName(name: String): IrSimpleFunctionSymbol? {
-    return functions.firstOrNull { function ->
-        !function.isFakeOverride && function.name.asString() == name && function.overridesFunctionIn(PARCELER_FQNAME)
+private fun IrClass.parcelerSymbolByName(name: String): IrSimpleFunctionSymbol? =
+    functions.firstOrNull { function ->
+        function.name.asString() == name && function.overridesFunctionIn(PARCELER_FQNAME)
     }?.symbol
-}
 
-fun IrSimpleFunction.overridesFunctionIn(fqName: FqName): Boolean {
-    return parentClassOrNull?.fqNameWhenAvailable == fqName || allOverridden().any { it.parentClassOrNull?.fqNameWhenAvailable == fqName }
-}
+fun IrSimpleFunction.overridesFunctionIn(fqName: FqName): Boolean =
+    parentClassOrNull?.fqNameWhenAvailable == fqName || allOverridden().any { it.parentClassOrNull?.fqNameWhenAvailable == fqName }
 
-private fun IrBuilderWithScope.kClassReference(classType: IrType): IrClassReferenceImpl {
-    return IrClassReferenceImpl(
+private fun IrBuilderWithScope.kClassReference(classType: IrType): IrClassReferenceImpl =
+    IrClassReferenceImpl(
         startOffset, endOffset, context.irBuiltIns.kClassClass.starProjectedType, context.irBuiltIns.kClassClass, classType
     )
-}
 
-private fun AndroidIrBuilder.kClassToJavaClass(kClassReference: IrExpression): IrCall {
-    return irGet(androidSymbols.javaLangClass.starProjectedType, null, androidSymbols.kotlinKClassJava.owner.getter!!.symbol).apply {
+private fun AndroidIrBuilder.kClassToJavaClass(kClassReference: IrExpression): IrCall =
+    irGet(androidSymbols.javaLangClass.starProjectedType, null, androidSymbols.kotlinKClassJava.owner.getter!!.symbol).apply {
         extensionReceiver = kClassReference
     }
-}
 
 // Produce a static reference to the java class of the given type.
 fun AndroidIrBuilder.javaClassReference(classType: IrType): IrCall = kClassToJavaClass(kClassReference(classType))
 
-fun IrClass.isSubclassOfFqName(fqName: String): Boolean {
-    return fqNameWhenAvailable?.asString() == fqName || superTypes.any { it.erasedUpperBound.isSubclassOfFqName(fqName) }
-}
+fun IrClass.isSubclassOfFqName(fqName: String): Boolean =
+    fqNameWhenAvailable?.asString() == fqName || superTypes.any { it.erasedUpperBound.isSubclassOfFqName(fqName) }
 
 inline fun IrBlockBuilder.forUntil(upperBound: IrExpression, loopBody: IrBlockBuilder.(IrValueDeclaration) -> Unit) {
     val indexTemporary = irTemporary(irInt(0), isMutable = true)

--- a/plugins/parcelize/parcelize-compiler/testData/box/kt46567.kt
+++ b/plugins/parcelize/parcelize-compiler/testData/box/kt46567.kt
@@ -1,0 +1,64 @@
+// WITH_RUNTIME
+
+@file:JvmName("TestKt")
+package test
+
+import kotlinx.parcelize.*
+import android.os.Parcel
+import android.os.Parcelable
+import java.util.Arrays
+
+/**
+ * Generic pair parceler
+ * Create concrete object to use (see below)
+ */
+open class PairParceler<F: Any, S: Any>(private val firstParceler: Parceler<F>, private val secondParceler: Parceler<S>): Parceler<Pair<F, S>> {
+    /**
+     * Reads the [T] instance state from the [parcel], constructs the new [T] instance and returns it.
+     */
+    override fun create(parcel: Parcel): Pair<F, S> =
+        firstParceler.create(parcel) to secondParceler.create(parcel)
+
+    /**
+     * Writes the [T] instance state to the [parcel].
+     */
+    override fun Pair<F, S>.write(parcel: Parcel, flags: Int) {
+        with(firstParceler) { this@write.first.write(parcel, 0) }
+        with(secondParceler) { this@write.second.write(parcel, 0) }
+    }
+}
+
+object IntParceler: Parceler<Int> {
+    /**
+     * Reads the [T] instance state from the [parcel], constructs the new [T] instance and returns it.
+     */
+    override fun create(parcel: Parcel): Int = parcel.readInt()
+
+    /**
+     * Writes the [T] instance state to the [parcel].
+     */
+    override fun Int.write(parcel: Parcel, flags: Int) {
+        parcel.writeInt(this)
+    }
+}
+
+/**
+ * [Int] to [Int] pair parceler
+ */
+object IntToIntParceler: PairParceler<Int, Int>(IntParceler, IntParceler)
+
+@Parcelize
+@TypeParceler<Pair<Int, Int>, IntToIntParceler>
+class A(val pair: Pair<Int, Int>): Parcelable
+
+fun box() = parcelTest { parcel ->
+    val a1 = A(1 to 2)
+    a1.writeToParcel(parcel, 0)
+
+    val bytes = parcel.marshall()
+    parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
+
+    val a2 = readFromParcel<A>(parcel)
+    assert(a1.pair == a2.pair)
+}

--- a/plugins/parcelize/parcelize-compiler/testData/box/newArrayParceler.kt
+++ b/plugins/parcelize/parcelize-compiler/testData/box/newArrayParceler.kt
@@ -1,0 +1,45 @@
+// WITH_RUNTIME
+// IGNORE_BACKEND: JVM
+
+@file:JvmName("TestKt")
+package test
+
+import kotlinx.parcelize.*
+import android.os.Parcel
+import android.os.Parcelable
+
+abstract class UserParceler : Parceler<User> {
+    override fun User.write(parcel: Parcel, flags: Int) {
+        parcel.writeString(name)
+    }
+
+    override fun newArray(size: Int): Array<User> {
+        return Array(size + 1) { User(null) }
+    }
+}
+
+@Parcelize
+class User(val name: String?) : Parcelable {
+    companion object : UserParceler() {
+        override fun create(parcel: Parcel) = User(parcel.readString())
+    }
+}
+
+fun box() = parcelTest { parcel ->
+    val user = User("John")
+    val user2 = User("Joe")
+    val array = arrayOf(user, user2)
+    parcel.writeTypedArray(array, 0)
+
+    val bytes = parcel.marshall()
+    parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
+
+    val creator = User::class.java.getDeclaredField("CREATOR").get(null) as Parcelable.Creator<User>
+    val result = parcel.createTypedArray(creator)
+
+    assert(result.size == 3)
+    assert(result[0].name == user.name)
+    assert(result[1].name == user2.name)
+    assert(result[2].name == null)
+}

--- a/plugins/parcelize/parcelize-compiler/tests/org/jetbrains/kotlin/parcelize/test/ParcelizeBoxTestGenerated.java
+++ b/plugins/parcelize/parcelize-compiler/tests/org/jetbrains/kotlin/parcelize/test/ParcelizeBoxTestGenerated.java
@@ -200,6 +200,11 @@ public class ParcelizeBoxTestGenerated extends AbstractParcelizeBoxTest {
         runTest("plugins/parcelize/parcelize-compiler/testData/box/kt41553_2.kt");
     }
 
+    @TestMetadata("kt46567.kt")
+    public void testKt46567() throws Exception {
+        runTest("plugins/parcelize/parcelize-compiler/testData/box/kt46567.kt");
+    }
+
     @TestMetadata("listKinds.kt")
     public void testListKinds() throws Exception {
         runTest("plugins/parcelize/parcelize-compiler/testData/box/listKinds.kt");
@@ -258,6 +263,11 @@ public class ParcelizeBoxTestGenerated extends AbstractParcelizeBoxTest {
     @TestMetadata("newArray.kt")
     public void testNewArray() throws Exception {
         runTest("plugins/parcelize/parcelize-compiler/testData/box/newArray.kt");
+    }
+
+    @TestMetadata("newArrayParceler.kt")
+    public void testNewArrayParceler() throws Exception {
+        runTest("plugins/parcelize/parcelize-compiler/testData/box/newArrayParceler.kt");
     }
 
     @TestMetadata("nullableTypes.kt")

--- a/plugins/parcelize/parcelize-compiler/tests/org/jetbrains/kotlin/parcelize/test/ParcelizeIrBoxTestGenerated.java
+++ b/plugins/parcelize/parcelize-compiler/tests/org/jetbrains/kotlin/parcelize/test/ParcelizeIrBoxTestGenerated.java
@@ -200,6 +200,11 @@ public class ParcelizeIrBoxTestGenerated extends AbstractParcelizeIrBoxTest {
         runTest("plugins/parcelize/parcelize-compiler/testData/box/kt41553_2.kt");
     }
 
+    @TestMetadata("kt46567.kt")
+    public void testKt46567() throws Exception {
+        runTest("plugins/parcelize/parcelize-compiler/testData/box/kt46567.kt");
+    }
+
     @TestMetadata("listKinds.kt")
     public void testListKinds() throws Exception {
         runTest("plugins/parcelize/parcelize-compiler/testData/box/listKinds.kt");
@@ -258,6 +263,11 @@ public class ParcelizeIrBoxTestGenerated extends AbstractParcelizeIrBoxTest {
     @TestMetadata("newArray.kt")
     public void testNewArray() throws Exception {
         runTest("plugins/parcelize/parcelize-compiler/testData/box/newArray.kt");
+    }
+
+    @TestMetadata("newArrayParceler.kt")
+    public void testNewArrayParceler() throws Exception {
+        runTest("plugins/parcelize/parcelize-compiler/testData/box/newArrayParceler.kt");
     }
 
     @TestMetadata("nullableTypes.kt")


### PR DESCRIPTION
The underlying issue with KT-46567 is that the code in `org/jetbrains/kotlin/android/parcel/ir/irUtils.kt` does not handle fake overrides correctly.

This turned out to be a bit more subtle in the case of `Parceler.newArray` which is what `testNewArrayParceler` is supposed to check for. This case is still broken on the old backend, but it's sufficiently obscure that I really don't think we need to backport a fix.

The PR also includes the same fix for kotlin-android-extensions.