### PR TITLE
Merge js library resources into distribution resources

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/KotlinJsTargetConfigurator.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/KotlinJsTargetConfigurator.kt
@@ -8,6 +8,10 @@ package org.jetbrains.kotlin.gradle.targets.js
 import org.gradle.api.DefaultTask
 import org.gradle.api.Task
 import org.gradle.api.attributes.Usage
+import org.gradle.api.plugins.BasePlugin
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.api.tasks.bundling.Jar
+import org.gradle.api.tasks.bundling.Zip
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
 import org.jetbrains.kotlin.gradle.plugin.*
@@ -69,6 +73,18 @@ open class KotlinJsTargetConfigurator :
             configureResourceProcessing(compilation, project.files(Callable { compilation.allKotlinSourceSets.map { it.resources } }))
 
             createLifecycleTaskInternal(compilation)
+        }
+    }
+
+    override fun createArchiveTasks(target: KotlinJsTarget): TaskProvider<out Zip> {
+        return target.project.registerTask<Jar>(target.artifactsTaskName) {
+            it.description = "Assembles an archive containing the main classes."
+            it.group = BasePlugin.BUILD_GROUP
+            val output = target.compilations.getByName(KotlinCompilation.MAIN_COMPILATION_NAME).output
+            it.from(output.classesDirs)
+            it.from(Callable { output.resourcesDir }) { spec ->
+                spec.into("resources")
+            }
         }
     }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/Tasks.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/Tasks.kt
@@ -691,6 +691,12 @@ abstract class Kotlin2JsCompile @Inject constructor(
             "-Xir-produce-klib-file"
         ).any(freeCompilerArgs::contains)
 
+    @get:Internal
+    val dependencies
+        get() = classpath
+            .filter { it.exists() && libraryFilter(it) }
+            .map { it.canonicalPath }
+
     // Kotlin/JS can operate in 3 modes:
     //  1) purely pre-IR backend
     //  2) purely IR backend
@@ -719,10 +725,6 @@ abstract class Kotlin2JsCompile @Inject constructor(
         if (kotlinOptions.isIrBackendEnabled()) {
             logger.info(USING_JS_IR_BACKEND_MESSAGE)
         }
-
-        val dependencies = classpath
-            .filter { it.exists() && libraryFilter(it) }
-            .map { it.canonicalPath }
 
         args.libraries = dependencies.distinct().let {
             if (it.isNotEmpty())


### PR DESCRIPTION
### example

We have a `js` library project contains resources files:

![image](https://user-images.githubusercontent.com/1407040/118305692-e6bf3580-b51a-11eb-8d05-46ce59cda95c.png)

and a `js` browser project depends on `js` library:

build.gradle

```javascript
val jsMain by getting {
    dependencies {
        implementation("org.example:-lib-js:0.0.1")
    }
}
```

### problem

If I run gradle task `jsBrowserDistribution`, the resources in library does not copy to distribution directory.

### reason

`jsBrowserDistribution` only copy current project resources files into distribution directory.

### solution

1. copy resources files into a specific directory in jar. 

normal js jar: "resources" directory in root.
![image](https://user-images.githubusercontent.com/1407040/118306316-d9ef1180-b51b-11eb-8d00-b7140b621b7e.png)
note: if do not copy into specific directory, we don't known what files are resources files. I have tried exclude `.js`, `.meta.js`..., it's not work with complicated library.

klib(js with IR): `default/resources` directory.
![image](https://user-images.githubusercontent.com/1407040/118342523-425ae480-b556-11eb-93ae-23dcedaede95.png)

Kotlin Native has the same problem. I have mentioned this: https://github.com/JetBrains/kotlin/pull/4336

2. merge library's resources directory into distribution directory.
![image](https://user-images.githubusercontent.com/1407040/118306260-c0e66080-b51b-11eb-824d-b7085fa6ef6a.png)


### test

js
1. library with not resources. OK
2. library with resources. OK
3. browser project with not resources is OK.
4. browser project with resources is OK.

js[IR]
1. library with not resources. OK
2. library with resources. OK
3. browser project with not resources is OK.
4. browser project with resources is OK.
