### PR TITLE
Organize integration tests for incremental Kotlin compile

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/IncrementalCompilationBaseIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/IncrementalCompilationBaseIT.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle
+
+import org.jetbrains.kotlin.gradle.util.getFileByName
+import org.jetbrains.kotlin.gradle.util.getFilesByNames
+import org.jetbrains.kotlin.gradle.util.modify
+
+abstract class IncrementalCompilationBaseIT : BaseGradleIT() {
+
+    protected abstract fun defaultProject(): Project
+
+    protected fun doTest(
+        fileToModify: String,
+        modifyFileContents: (String) -> String,
+        expectedAffectedFileNames: Collection<String>,
+    ) {
+        doTest(
+            { it.projectDir.getFileByName(fileToModify).modify(modifyFileContents) },
+            expectedAffectedFileNames
+        )
+    }
+
+    protected fun doTest(
+        modifyProject: (Project) -> Unit,
+        expectedAffectedFileNames: Collection<String>,
+    ) {
+        val project = defaultProject()
+        project.build("build") {
+            assertSuccessful()
+        }
+
+        modifyProject(project)
+
+        project.build("build") {
+            assertSuccessful()
+            val expectedAffectedFiles = project.projectDir.getFilesByNames(*expectedAffectedFileNames.toTypedArray())
+            val expectedAffectedFileRelativePaths = project.relativize(expectedAffectedFiles)
+            assertCompiledKotlinSources(expectedAffectedFileRelativePaths)
+        }
+    }
+}


### PR DESCRIPTION
Refactor common code into new abstract class
IncrementalCompilationBaseIT to make the code cleaner and easier to
evolve.

Also add a few missing key scenarios for ABI and non-ABI changes in
Kotlin files, and make it consistent with the test for changes in Java
files.

Bug: KT-45777
Test: Updating them