### PR TITLE
FIR IDE: Add quickfix to change function return type

### DIFF
--- a/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/diagnostics/FirDiagnosticsList.kt
+++ b/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/diagnostics/FirDiagnosticsList.kt
@@ -418,6 +418,7 @@ object DIAGNOSTICS_LIST : DiagnosticList("FirErrors") {
         val RETURN_TYPE_MISMATCH by error<KtExpression>(PositioningStrategy.WHOLE_ELEMENT) {
             parameter<ConeKotlinType>("expectedType")
             parameter<ConeKotlinType>("actualType")
+            parameter<FirSimpleFunction>("targetFunction")
         }
 
         val CYCLIC_GENERIC_UPPER_BOUND by error<PsiElement>()

--- a/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/diagnostics/FirErrors.kt
+++ b/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/diagnostics/FirErrors.kt
@@ -20,6 +20,7 @@ import org.jetbrains.kotlin.fir.declarations.FirClass
 import org.jetbrains.kotlin.fir.declarations.FirDeclaration
 import org.jetbrains.kotlin.fir.declarations.FirEnumEntry
 import org.jetbrains.kotlin.fir.declarations.FirMemberDeclaration
+import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
 import org.jetbrains.kotlin.fir.declarations.FirValueParameter
 import org.jetbrains.kotlin.fir.expressions.FirExpression
 import org.jetbrains.kotlin.fir.symbols.AbstractFirBasedSymbol
@@ -288,7 +289,7 @@ object FirErrors {
     val REIFIED_TYPE_PARAMETER_NO_INLINE by error0<KtTypeParameter>(SourceElementPositioningStrategies.REIFIED_MODIFIER)
     val TYPE_PARAMETERS_NOT_ALLOWED by error0<KtDeclaration>(SourceElementPositioningStrategies.TYPE_PARAMETERS_LIST)
     val TYPE_PARAMETER_OF_PROPERTY_NOT_USED_IN_RECEIVER by error0<KtTypeParameter>()
-    val RETURN_TYPE_MISMATCH by error2<KtExpression, ConeKotlinType, ConeKotlinType>(SourceElementPositioningStrategies.WHOLE_ELEMENT)
+    val RETURN_TYPE_MISMATCH by error3<KtExpression, ConeKotlinType, ConeKotlinType, FirSimpleFunction>(SourceElementPositioningStrategies.WHOLE_ELEMENT)
     val CYCLIC_GENERIC_UPPER_BOUND by error0<PsiElement>()
     val DEPRECATED_TYPE_PARAMETER_SYNTAX by error0<KtDeclaration>(SourceElementPositioningStrategies.TYPE_PARAMETERS_LIST)
     val MISPLACED_TYPE_PARAMETER_CONSTRAINTS by warning0<KtTypeParameter>()

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/expression/FirFunctionReturnTypeMismatchChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/expression/FirFunctionReturnTypeMismatchChecker.kt
@@ -36,7 +36,10 @@ object FirFunctionReturnTypeMismatchChecker : FirReturnExpressionChecker() {
             if (resultExpression.isNullLiteral && functionReturnType.nullability == ConeNullability.NOT_NULL) {
                 reporter.reportOn(resultExpression.source, NULL_FOR_NONNULL_TYPE, context)
             } else {
-                reporter.report(RETURN_TYPE_MISMATCH.on(returnExpressionSource, functionReturnType, returnExpressionType), context)
+                reporter.report(
+                    RETURN_TYPE_MISMATCH.on(returnExpressionSource, functionReturnType, returnExpressionType, targetElement),
+                    context
+                )
             }
         }
     }

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/FirDefaultErrorMessages.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/FirDefaultErrorMessages.kt
@@ -667,7 +667,7 @@ class FirDefaultErrorMessages : DefaultErrorMessages.Extension {
 
             map.put(TYPE_PARAMETER_OF_PROPERTY_NOT_USED_IN_RECEIVER, "Type parameter of a property must be used in its receiver type")
 
-            map.put(RETURN_TYPE_MISMATCH, "Return type mismatch: expected {0}, actual {1}", RENDER_TYPE, RENDER_TYPE)
+            map.put(RETURN_TYPE_MISMATCH, "Return type mismatch: expected {0}, actual {1}", RENDER_TYPE, RENDER_TYPE, NOT_RENDERED)
 
             map.put(CYCLIC_GENERIC_UPPER_BOUND, "Type parameter has cyclic upper bounds")
 

--- a/generators/idea-generator/tests/org/jetbrains/kotlin/generators/tests/idea/GenerateTests.kt
+++ b/generators/idea-generator/tests/org/jetbrains/kotlin/generators/tests/idea/GenerateTests.kt
@@ -1148,6 +1148,8 @@ fun main(args: Array<String>) {
                 model("quickfix/variables/changeMutability", pattern = pattern, filenameStartsLowerCase = true)
                 model("quickfix/when", pattern = pattern, filenameStartsLowerCase = true)
                 model("quickfix/wrapWithSafeLetCall", pattern = pattern, filenameStartsLowerCase = true)
+                model("quickfix/typeMismatch/componentFunctionReturnTypeMismatch", pattern = pattern, filenameStartsLowerCase = true)
+                model("quickfix/typeMismatch/typeMismatchOnReturnedExpression", pattern = pattern, filenameStartsLowerCase = true)
             }
 
             testClass<AbstractHighLevelQuickFixMultiFileTest> {

--- a/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/MainKtQuickFixRegistrar.kt
+++ b/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/MainKtQuickFixRegistrar.kt
@@ -12,8 +12,6 @@ import org.jetbrains.kotlin.idea.fir.api.fixes.KtQuickFixesListBuilder
 import org.jetbrains.kotlin.idea.frontend.api.fir.diagnostics.KtFirDiagnostic
 import org.jetbrains.kotlin.idea.quickfix.fixes.*
 import org.jetbrains.kotlin.idea.quickfix.fixes.InitializePropertyQuickFixFactory
-import org.jetbrains.kotlin.idea.quickfix.fixes.ChangeTypeQuickFix
-import org.jetbrains.kotlin.idea.quickfix.fixes.ReplaceCallFixFactories
 
 class MainKtQuickFixRegistrar : KtQuickFixRegistrar() {
     private val modifiers = KtQuickFixesListBuilder.registerPsiQuickFix {
@@ -78,9 +76,9 @@ class MainKtQuickFixRegistrar : KtQuickFixRegistrar() {
     }
 
     private val overrides = KtQuickFixesListBuilder.registerPsiQuickFix {
-        registerApplicator(ChangeTypeQuickFix.changeFunctionReturnTypeOnOverride)
-        registerApplicator(ChangeTypeQuickFix.changePropertyReturnTypeOnOverride)
-        registerApplicator(ChangeTypeQuickFix.changeVariableReturnTypeOnOverride)
+        registerApplicator(ChangeTypeQuickFixFactories.changeFunctionReturnTypeOnOverride)
+        registerApplicator(ChangeTypeQuickFixFactories.changePropertyReturnTypeOnOverride)
+        registerApplicator(ChangeTypeQuickFixFactories.changeVariableReturnTypeOnOverride)
         registerApplicator(MemberNotImplementedQuickfixFactories.abstractMemberNotImplemented)
         registerApplicator(MemberNotImplementedQuickfixFactories.abstractClassMemberNotImplemented)
         registerApplicator(MemberNotImplementedQuickfixFactories.manyInterfacesMemberNotImplemented)
@@ -120,6 +118,11 @@ class MainKtQuickFixRegistrar : KtQuickFixRegistrar() {
         registerApplicator(WrapWithSafeLetCallFixFactories.forArgumentTypeMismatch)
     }
 
+    private val returnTypes = KtQuickFixesListBuilder.registerPsiQuickFix {
+        registerApplicator(ChangeTypeQuickFixFactories.componentFunctionReturnTypeMismatch)
+        registerApplicator(ChangeTypeQuickFixFactories.returnTypeMismatch)
+    }
+
     override val list: KtQuickFixesList = KtQuickFixesList.createCombined(
         modifiers,
         propertyInitialization,
@@ -127,5 +130,6 @@ class MainKtQuickFixRegistrar : KtQuickFixRegistrar() {
         imports,
         mutability,
         expressions,
+        returnTypes
     )
 }

--- a/idea/idea-fir/tests/org/jetbrains/kotlin/idea/quickfix/HighLevelQuickFixTestGenerated.java
+++ b/idea/idea-fir/tests/org/jetbrains/kotlin/idea/quickfix/HighLevelQuickFixTestGenerated.java
@@ -1813,4 +1813,140 @@ public class HighLevelQuickFixTestGenerated extends AbstractHighLevelQuickFixTes
             runTest("idea/testData/quickfix/wrapWithSafeLetCall/wrapAllNonNullablePositions6.kt");
         }
     }
+
+    @TestMetadata("idea/testData/quickfix/typeMismatch/componentFunctionReturnTypeMismatch")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class ComponentFunctionReturnTypeMismatch extends AbstractHighLevelQuickFixTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
+        }
+
+        public void testAllFilesPresentInComponentFunctionReturnTypeMismatch() throws Exception {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("idea/testData/quickfix/typeMismatch/componentFunctionReturnTypeMismatch"), Pattern.compile("^([\\w\\-_]+)\\.kt$"), null, true);
+        }
+
+        @TestMetadata("componentFunctionReturnTypeMismatch1.kt")
+        public void testComponentFunctionReturnTypeMismatch1() throws Exception {
+            runTest("idea/testData/quickfix/typeMismatch/componentFunctionReturnTypeMismatch/componentFunctionReturnTypeMismatch1.kt");
+        }
+
+        @TestMetadata("componentFunctionReturnTypeMismatch2.kt")
+        public void testComponentFunctionReturnTypeMismatch2() throws Exception {
+            runTest("idea/testData/quickfix/typeMismatch/componentFunctionReturnTypeMismatch/componentFunctionReturnTypeMismatch2.kt");
+        }
+
+        @TestMetadata("componentFunctionReturnTypeMismatch3.kt")
+        public void testComponentFunctionReturnTypeMismatch3() throws Exception {
+            runTest("idea/testData/quickfix/typeMismatch/componentFunctionReturnTypeMismatch/componentFunctionReturnTypeMismatch3.kt");
+        }
+
+        @TestMetadata("componentFunctionReturnTypeMismatch4.kt")
+        public void testComponentFunctionReturnTypeMismatch4() throws Exception {
+            runTest("idea/testData/quickfix/typeMismatch/componentFunctionReturnTypeMismatch/componentFunctionReturnTypeMismatch4.kt");
+        }
+
+        @TestMetadata("componentFunctionReturnTypeMismatch5.kt")
+        public void testComponentFunctionReturnTypeMismatch5() throws Exception {
+            runTest("idea/testData/quickfix/typeMismatch/componentFunctionReturnTypeMismatch/componentFunctionReturnTypeMismatch5.kt");
+        }
+
+        @TestMetadata("dataClass.kt")
+        public void testDataClass() throws Exception {
+            runTest("idea/testData/quickfix/typeMismatch/componentFunctionReturnTypeMismatch/dataClass.kt");
+        }
+    }
+
+    @TestMetadata("idea/testData/quickfix/typeMismatch/typeMismatchOnReturnedExpression")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class TypeMismatchOnReturnedExpression extends AbstractHighLevelQuickFixTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
+        }
+
+        public void testAllFilesPresentInTypeMismatchOnReturnedExpression() throws Exception {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("idea/testData/quickfix/typeMismatch/typeMismatchOnReturnedExpression"), Pattern.compile("^([\\w\\-_]+)\\.kt$"), null, true);
+        }
+
+        @TestMetadata("assignmentTypeMismatch.kt")
+        public void testAssignmentTypeMismatch() throws Exception {
+            runTest("idea/testData/quickfix/typeMismatch/typeMismatchOnReturnedExpression/assignmentTypeMismatch.kt");
+        }
+
+        @TestMetadata("changeFunctionReturnTypeToFunctionType.kt")
+        public void testChangeFunctionReturnTypeToFunctionType() throws Exception {
+            runTest("idea/testData/quickfix/typeMismatch/typeMismatchOnReturnedExpression/changeFunctionReturnTypeToFunctionType.kt");
+        }
+
+        @TestMetadata("changeFunctionReturnTypeToMatchReturnTypeOfReturnedLiteral.kt")
+        public void testChangeFunctionReturnTypeToMatchReturnTypeOfReturnedLiteral() throws Exception {
+            runTest("idea/testData/quickfix/typeMismatch/typeMismatchOnReturnedExpression/changeFunctionReturnTypeToMatchReturnTypeOfReturnedLiteral.kt");
+        }
+
+        @TestMetadata("dontChangeFunctionReturnTypeToErrorType.kt")
+        public void testDontChangeFunctionReturnTypeToErrorType() throws Exception {
+            runTest("idea/testData/quickfix/typeMismatch/typeMismatchOnReturnedExpression/dontChangeFunctionReturnTypeToErrorType.kt");
+        }
+
+        @TestMetadata("literalPropertyWithGetter.kt")
+        public void testLiteralPropertyWithGetter() throws Exception {
+            runTest("idea/testData/quickfix/typeMismatch/typeMismatchOnReturnedExpression/literalPropertyWithGetter.kt");
+        }
+
+        @TestMetadata("multiFakeOverride.kt")
+        public void testMultiFakeOverride() throws Exception {
+            runTest("idea/testData/quickfix/typeMismatch/typeMismatchOnReturnedExpression/multiFakeOverride.kt");
+        }
+
+        @TestMetadata("multiFakeOverrideForOperatorConvention.kt")
+        public void testMultiFakeOverrideForOperatorConvention() throws Exception {
+            runTest("idea/testData/quickfix/typeMismatch/typeMismatchOnReturnedExpression/multiFakeOverrideForOperatorConvention.kt");
+        }
+
+        @TestMetadata("nonLocalReturnRuntime.kt")
+        public void testNonLocalReturnRuntime() throws Exception {
+            runTest("idea/testData/quickfix/typeMismatch/typeMismatchOnReturnedExpression/nonLocalReturnRuntime.kt");
+        }
+
+        @TestMetadata("nonLocalReturnWithLabelRuntime.kt")
+        public void testNonLocalReturnWithLabelRuntime() throws Exception {
+            runTest("idea/testData/quickfix/typeMismatch/typeMismatchOnReturnedExpression/nonLocalReturnWithLabelRuntime.kt");
+        }
+
+        @TestMetadata("notApplicableToConstructor.kt")
+        public void testNotApplicableToConstructor() throws Exception {
+            runTest("idea/testData/quickfix/typeMismatch/typeMismatchOnReturnedExpression/notApplicableToConstructor.kt");
+        }
+
+        @TestMetadata("propertyGetterInitializerTypeMismatch.kt")
+        public void testPropertyGetterInitializerTypeMismatch() throws Exception {
+            runTest("idea/testData/quickfix/typeMismatch/typeMismatchOnReturnedExpression/propertyGetterInitializerTypeMismatch.kt");
+        }
+
+        @TestMetadata("returnedExpressionTypeMismatchFunctionParameterType.kt")
+        public void testReturnedExpressionTypeMismatchFunctionParameterType() throws Exception {
+            runTest("idea/testData/quickfix/typeMismatch/typeMismatchOnReturnedExpression/returnedExpressionTypeMismatchFunctionParameterType.kt");
+        }
+
+        @TestMetadata("typeMismatchInIfStatementReturnedByFunction.kt")
+        public void testTypeMismatchInIfStatementReturnedByFunction() throws Exception {
+            runTest("idea/testData/quickfix/typeMismatch/typeMismatchOnReturnedExpression/typeMismatchInIfStatementReturnedByFunction.kt");
+        }
+
+        @TestMetadata("typeMismatchInIfStatementReturnedByLiteral.kt")
+        public void testTypeMismatchInIfStatementReturnedByLiteral() throws Exception {
+            runTest("idea/testData/quickfix/typeMismatch/typeMismatchOnReturnedExpression/typeMismatchInIfStatementReturnedByLiteral.kt");
+        }
+
+        @TestMetadata("typeMismatchInInitializer.kt")
+        public void testTypeMismatchInInitializer() throws Exception {
+            runTest("idea/testData/quickfix/typeMismatch/typeMismatchOnReturnedExpression/typeMismatchInInitializer.kt");
+        }
+
+        @TestMetadata("typeMismatchInReturnStatement.kt")
+        public void testTypeMismatchInReturnStatement() throws Exception {
+            runTest("idea/testData/quickfix/typeMismatch/typeMismatchOnReturnedExpression/typeMismatchInReturnStatement.kt");
+        }
+    }
 }

--- a/idea/idea-frontend-fir/idea-frontend-fir-generator/src/org/jetbrains/kotlin/idea/frontend/api/fir/generator/HLDiagnosticConverter.kt
+++ b/idea/idea-frontend-fir/idea-frontend-fir-generator/src/org/jetbrains/kotlin/idea/frontend/api/fir/generator/HLDiagnosticConverter.kt
@@ -217,6 +217,11 @@ private object FirToKtConversionCreator {
             KtSymbol::class.createType(),
             importsToAdd = listOf("org.jetbrains.kotlin.fir.declarations.FirDeclaration")
         ),
+        FirSimpleFunction::class to HLFunctionCallConversion(
+            "firSymbolBuilder.buildSymbol({0})",
+            KtSymbol::class.createType(),
+            importsToAdd = listOf("org.jetbrains.kotlin.fir.declarations.FirSimpleFunction")
+        ),
         FirNamedFunctionSymbol::class to HLFunctionCallConversion(
             "firSymbolBuilder.functionLikeBuilder.buildFunctionSymbol({0}.fir)",
             KtFunctionLikeSymbol::class.createType(),

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/fir/FirIdeDeserializedDeclarationSourceProvider.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/fir/FirIdeDeserializedDeclarationSourceProvider.kt
@@ -137,7 +137,11 @@ object FirIdeDeserializedDeclarationSourceProvider {
 
 private fun KtElement.isCompiled(): Boolean = containingKtFile.isCompiled
 
-private val allowedFakeElementKinds = setOf(FirFakeSourceElementKind.PropertyFromParameter, FirFakeSourceElementKind.ItLambdaParameter)
+private val allowedFakeElementKinds = setOf(
+    FirFakeSourceElementKind.PropertyFromParameter,
+    FirFakeSourceElementKind.ItLambdaParameter,
+    FirFakeSourceElementKind.DataClassGeneratedMembers
+)
 
 private fun FirElement.getAllowedPsi() = when (val source = source) {
     null -> null

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDataClassConverters.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDataClassConverters.kt
@@ -1289,6 +1289,7 @@ internal val KT_DIAGNOSTIC_CONVERTER = KtDiagnosticConverterBuilder.buildConvert
         ReturnTypeMismatchImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
+            firSymbolBuilder.buildSymbol(firDiagnostic.c),
             firDiagnostic as FirPsiDiagnostic<*>,
             token,
         )

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnostics.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnostics.kt
@@ -910,6 +910,7 @@ sealed class KtFirDiagnostic<PSI: PsiElement> : KtDiagnosticWithPsi<PSI> {
         override val diagnosticClass get() = ReturnTypeMismatch::class
         abstract val expectedType: KtType
         abstract val actualType: KtType
+        abstract val targetFunction: KtSymbol
     }
 
     abstract class CyclicGenericUpperBound : KtFirDiagnostic<PsiElement>() {

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnosticsImpl.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnosticsImpl.kt
@@ -1471,6 +1471,7 @@ internal class TypeParameterOfPropertyNotUsedInReceiverImpl(
 internal class ReturnTypeMismatchImpl(
     override val expectedType: KtType,
     override val actualType: KtType,
+    override val targetFunction: KtSymbol,
     firDiagnostic: FirPsiDiagnostic<*>,
     override val token: ValidityToken,
 ) : KtFirDiagnostic.ReturnTypeMismatch(), KtAbstractFirDiagnostic<KtExpression> {

--- a/idea/idea-frontend-independent/src/org/jetbrains/kotlin/idea/quickfix/ChangeTypeFixUtils.kt
+++ b/idea/idea-frontend-independent/src/org/jetbrains/kotlin/idea/quickfix/ChangeTypeFixUtils.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.idea.quickfix
+
+import org.jetbrains.kotlin.idea.KotlinBundle
+import org.jetbrains.kotlin.psi.KtCallableDeclaration
+import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.KtParameter
+import org.jetbrains.kotlin.psi.KtProperty
+
+object ChangeTypeFixUtils {
+    fun familyName(): String = KotlinBundle.message("fix.change.return.type.family")
+
+    fun functionOrConstructorParameterPresentation(element: KtCallableDeclaration, containerName: String?): String? {
+        val name = element.name
+        return if (name != null) {
+            val fullName = if (containerName != null) "'${containerName}.$name'" else "'$name'"
+            when (element) {
+                is KtParameter -> KotlinBundle.message("fix.change.return.type.presentation.property", fullName)
+                is KtProperty -> KotlinBundle.message("fix.change.return.type.presentation.property", fullName)
+                else -> KotlinBundle.message("fix.change.return.type.presentation.function", fullName)
+            }
+        } else null
+    }
+
+
+    fun baseFunctionOrConstructorParameterPresentation(presentation: String): String =
+        KotlinBundle.message("fix.change.return.type.presentation.base", presentation)
+
+    fun baseFunctionOrConstructorParameterPresentation(element: KtCallableDeclaration, containerName: String?): String? {
+        val presentation = functionOrConstructorParameterPresentation(element, containerName) ?: return null
+        return baseFunctionOrConstructorParameterPresentation(presentation)
+    }
+
+    fun getTextForQuickFix(
+        element: KtCallableDeclaration,
+        presentation: String?,
+        isUnitType: Boolean,
+        typePresentation: String
+    ): String {
+        if (isUnitType && element is KtFunction && element.hasBlockBody()) {
+            return if (presentation == null)
+                KotlinBundle.message("fix.change.return.type.remove.explicit.return.type")
+            else
+                KotlinBundle.message("fix.change.return.type.remove.explicit.return.type.of", presentation)
+        }
+
+        return when (element) {
+            is KtFunction -> {
+                if (presentation != null)
+                    KotlinBundle.message("fix.change.return.type.return.type.text.of", presentation, typePresentation)
+                else
+                    KotlinBundle.message("fix.change.return.type.return.type.text", typePresentation)
+            }
+            else -> {
+                if (presentation != null)
+                    KotlinBundle.message("fix.change.return.type.type.text.of", presentation, typePresentation)
+                else
+                    KotlinBundle.message("fix.change.return.type.type.text", typePresentation)
+            }
+        }
+    }
+}

--- a/idea/testData/quickfix/typeMismatch/typeMismatchOnReturnedExpression/assignmentTypeMismatch.kt
+++ b/idea/testData/quickfix/typeMismatch/typeMismatchOnReturnedExpression/assignmentTypeMismatch.kt
@@ -5,3 +5,4 @@ fun foo() {
         x += 21<caret>
     }
 }
+/* IGNORE_FIR */

--- a/idea/testData/quickfix/typeMismatch/typeMismatchOnReturnedExpression/assignmentTypeMismatch.kt.after
+++ b/idea/testData/quickfix/typeMismatch/typeMismatchOnReturnedExpression/assignmentTypeMismatch.kt.after
@@ -5,3 +5,4 @@ fun foo() {
         x += 21<caret>
     }
 }
+/* IGNORE_FIR */

--- a/idea/testData/quickfix/typeMismatch/typeMismatchOnReturnedExpression/literalPropertyWithGetter.kt
+++ b/idea/testData/quickfix/typeMismatch/typeMismatchOnReturnedExpression/literalPropertyWithGetter.kt
@@ -2,3 +2,4 @@
 
 val complex: (Int) -> String
     get() = { it.toLong()<caret> }
+/* IGNORE_FIR */

--- a/idea/testData/quickfix/typeMismatch/typeMismatchOnReturnedExpression/literalPropertyWithGetter.kt.after
+++ b/idea/testData/quickfix/typeMismatch/typeMismatchOnReturnedExpression/literalPropertyWithGetter.kt.after
@@ -2,3 +2,4 @@
 
 val complex: (Int) -> Long
     get() = { it.toLong() }
+/* IGNORE_FIR */

--- a/idea/testData/quickfix/typeMismatch/typeMismatchOnReturnedExpression/propertyGetterInitializerTypeMismatch.kt
+++ b/idea/testData/quickfix/typeMismatch/typeMismatchOnReturnedExpression/propertyGetterInitializerTypeMismatch.kt
@@ -5,3 +5,4 @@ class A {
         get(): Int = if (true) { {42}<caret> } else { {24} }
         set(i: Int) {}
 }
+/* IGNORE_FIR */

--- a/idea/testData/quickfix/typeMismatch/typeMismatchOnReturnedExpression/returnedExpressionTypeMismatchFunctionParameterType.kt
+++ b/idea/testData/quickfix/typeMismatch/typeMismatchOnReturnedExpression/returnedExpressionTypeMismatchFunctionParameterType.kt
@@ -4,3 +4,4 @@ fun foo(f: () -> Int) {
         ""<caret>
     }
 }
+/* IGNORE_FIR */

--- a/idea/testData/quickfix/typeMismatch/typeMismatchOnReturnedExpression/typeMismatchInIfStatementReturnedByLiteral.kt
+++ b/idea/testData/quickfix/typeMismatch/typeMismatchOnReturnedExpression/typeMismatchInIfStatementReturnedByLiteral.kt
@@ -10,3 +10,4 @@ fun foo() {
         }
     }
 }
+/* IGNORE_FIR */


### PR DESCRIPTION
Add quickfix to change type for the following diagnostics
* RETURN_TYPE_MISMATCH
* COMPONENT_FUNCTION_RETURN_TYPE_MISMATCH