### PR TITLE
JVM: be more careful when removing unused constants 

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/boxing/PopBackwardPropagationTransformer.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/boxing/PopBackwardPropagationTransformer.kt
@@ -19,10 +19,8 @@ package org.jetbrains.kotlin.codegen.optimization.boxing
 import org.jetbrains.kotlin.codegen.optimization.OptimizationMethodVisitor
 import org.jetbrains.kotlin.codegen.optimization.common.debugText
 import org.jetbrains.kotlin.codegen.optimization.common.isLoadOperation
-import org.jetbrains.kotlin.codegen.optimization.common.isMeaningful
 import org.jetbrains.kotlin.codegen.optimization.fixStack.peekWords
 import org.jetbrains.kotlin.codegen.optimization.fixStack.top
-import org.jetbrains.kotlin.codegen.optimization.removeNodeGetNext
 import org.jetbrains.kotlin.codegen.optimization.transformer.MethodTransformer
 import org.jetbrains.org.objectweb.asm.Opcodes
 import org.jetbrains.org.objectweb.asm.tree.*
@@ -32,59 +30,49 @@ import org.jetbrains.org.objectweb.asm.tree.analysis.SourceInterpreter
 import org.jetbrains.org.objectweb.asm.tree.analysis.SourceValue
 import java.util.*
 
+private typealias Transformation = (AbstractInsnNode) -> Unit
+
 class PopBackwardPropagationTransformer : MethodTransformer() {
     override fun transform(internalClassName: String, methodNode: MethodNode) {
         if (!OptimizationMethodVisitor.canBeOptimizedUsingSourceInterpreter(methodNode)) return
-        Transformer(methodNode).transform()
+        if (methodNode.instructions.any { it.isPop() || it.isPurePush() }) {
+            Transformer(methodNode).transform()
+        }
     }
 
     private class Transformer(val methodNode: MethodNode) {
-        private interface Transformation {
-            fun apply(insn: AbstractInsnNode)
-        }
-
-        private inline fun Transformation(crossinline body: (AbstractInsnNode) -> Unit): Transformation =
-            object : Transformation {
-                override fun apply(insn: AbstractInsnNode) {
-                    body(insn)
-                }
-            }
-
-        private val REPLACE_WITH_NOP = Transformation { insnList.set(it, createRemovableNopInsn()) }
-        private val REPLACE_WITH_POP1 = Transformation { insnList.set(it, InsnNode(Opcodes.POP)) }
-        private val REPLACE_WITH_POP2 = Transformation { insnList.set(it, InsnNode(Opcodes.POP2)) }
-        private val INSERT_POP1_AFTER = Transformation { insnList.insert(it, InsnNode(Opcodes.POP)) }
-        private val INSERT_POP2_AFTER = Transformation { insnList.insert(it, InsnNode(Opcodes.POP2)) }
+        private val REPLACE_WITH_NOP: Transformation = { insnList.set(it, InsnNode(Opcodes.NOP)) }
+        private val REPLACE_WITH_POP1: Transformation = { insnList.set(it, InsnNode(Opcodes.POP)) }
+        private val REPLACE_WITH_POP2: Transformation = { insnList.set(it, InsnNode(Opcodes.POP2)) }
+        private val INSERT_POP1_AFTER: Transformation = { insnList.insert(it, InsnNode(Opcodes.POP)) }
+        private val INSERT_POP2_AFTER: Transformation = { insnList.insert(it, InsnNode(Opcodes.POP2)) }
 
         private val insnList = methodNode.instructions
-
         private val insns = insnList.toArray()
 
         private val dontTouchInsnIndices = BitSet(insns.size)
-        private val transformations = hashMapOf<AbstractInsnNode, Transformation>()
-        private val removableNops = hashSetOf<InsnNode>()
 
-        private val frames by lazy { analyzeMethodBody() }
+        private val transformations = hashMapOf<AbstractInsnNode, Transformation>()
+        private val frames = analyzeMethodBody()
 
         fun transform() {
-            if (insns.none { it.isPop() || it.isPurePush() }) return
-
-            computeTransformations()
-            for ((insn, transformation) in transformations.entries) {
-                transformation.apply(insn)
+            for ((i, insn) in insns.withIndex()) {
+                if (insn.opcode == Opcodes.POP && frames[i] != null) {
+                    val inputTop = getInputTop(insn)
+                    val sources = inputTop.insns
+                    if (sources.all { !isDontTouch(it) } && sources.any { isTransformablePopOperand(it) }) {
+                        transformations[insn] = REPLACE_WITH_NOP
+                        sources.forEach { propagatePopBackwards(it, inputTop.size) }
+                    }
+                }
             }
-            postprocessNops()
+            for ((insn, transformation) in transformations.entries) {
+                transformation(insn)
+            }
         }
 
         private fun analyzeMethodBody(): Array<out Frame<SourceValue>?> {
-            val frames = Analyzer<SourceValue>(HazardsTrackingInterpreter()).analyze("fake", methodNode)
-
-            postprocessStackHazards(frames)
-
-            return frames
-        }
-
-        private fun postprocessStackHazards(frames: Array<out Frame<SourceValue>?>) {
+            val frames = Analyzer(HazardsTrackingInterpreter()).analyze("fake", methodNode)
             val insns = methodNode.instructions.toArray()
             for (i in frames.indices) {
                 val frame = frames[i] ?: continue
@@ -113,6 +101,7 @@ class PopBackwardPropagationTransformer : MethodTransformer() {
                     }
                 }
             }
+            return frames
         }
 
         private fun throwIncorrectBytecode(insn: AbstractInsnNode?, frame: Frame<SourceValue>): Nothing {
@@ -164,39 +153,16 @@ class PopBackwardPropagationTransformer : MethodTransformer() {
             }
         }
 
-
-        private fun computeTransformations() {
-            transformations.clear()
-
-            for (i in insns.indices) {
-                if (frames[i] == null) continue
-                val insn = insns[i]
-
-                if (insn.opcode == Opcodes.POP) {
-                    propagatePopBackwards(insn, 0)
-                }
-            }
-        }
-
         private fun propagatePopBackwards(insn: AbstractInsnNode, poppedValueSize: Int) {
             if (transformations.containsKey(insn)) return
 
             when {
-                insn.opcode == Opcodes.POP -> {
-                    val inputTop = getInputTop(insn)
-                    val sources = inputTop.insns
-                    if (sources.all { !isDontTouch(it) } && sources.any { isTransformablePopOperand(it) }) {
-                        transformations[insn] = replaceWithNopTransformation()
-                        sources.forEach { propagatePopBackwards(it, inputTop.size) }
-                    }
-                }
-
                 insn.opcode == Opcodes.CHECKCAST -> {
                     val inputTop = getInputTop(insn)
                     val sources = inputTop.insns
                     val resultType = (insn as TypeInsnNode).desc
                     if (sources.all { !isDontTouch(it) } && sources.any { isTransformableCheckcastOperand(it, resultType) }) {
-                        transformations[insn] = replaceWithNopTransformation()
+                        transformations[insn] = REPLACE_WITH_NOP
                         sources.forEach { propagatePopBackwards(it, inputTop.size) }
                     } else {
                         transformations[insn] = insertPopAfterTransformation(poppedValueSize)
@@ -204,60 +170,26 @@ class PopBackwardPropagationTransformer : MethodTransformer() {
                 }
 
                 insn.isPrimitiveBoxing() -> {
-                    val boxedValueSize = getInputTop(insn).size
-                    transformations[insn] = replaceWithPopTransformation(boxedValueSize)
+                    transformations[insn] = replaceWithPopTransformation(getInputTop(insn).size)
                 }
 
                 insn.isPurePush() -> {
-                    transformations[insn] = replaceWithNopTransformation()
+                    transformations[insn] = REPLACE_WITH_NOP
                 }
 
                 insn.isPrimitiveTypeConversion() -> {
                     val inputTop = getInputTop(insn)
                     val sources = inputTop.insns
                     if (sources.all { !isDontTouch(it) }) {
-                        transformations[insn] = replaceWithNopTransformation()
+                        transformations[insn] = REPLACE_WITH_NOP
                         sources.forEach { propagatePopBackwards(it, inputTop.size) }
                     } else {
-                        transformations[insn] = replaceWithPopTransformation(poppedValueSize)
+                        transformations[insn] = replaceWithPopTransformation(inputTop.size)
                     }
                 }
 
                 else -> {
                     transformations[insn] = insertPopAfterTransformation(poppedValueSize)
-                }
-            }
-        }
-
-        private fun postprocessNops() {
-            var node: AbstractInsnNode? = insnList.first
-            var hasRemovableNops = false
-            while (node != null) {
-                node = node.next
-                val begin = node ?: break
-                while (node != null && node !is LabelNode) {
-                    if (node in removableNops) {
-                        hasRemovableNops = true
-                    }
-                    node = node.next
-                }
-                val end = node
-                if (hasRemovableNops) {
-                    removeUnneededNopsInRange(begin, end)
-                }
-                hasRemovableNops = false
-            }
-        }
-
-        private fun removeUnneededNopsInRange(begin: AbstractInsnNode, end: AbstractInsnNode?) {
-            var node: AbstractInsnNode? = begin
-            var keepNop = true
-            while (node != null && node != end) {
-                if (node in removableNops && !keepNop) {
-                    node = insnList.removeNodeGetNext(node)
-                } else {
-                    if (node.isMeaningful) keepNop = false
-                    node = node.next
                 }
             }
         }
@@ -275,12 +207,6 @@ class PopBackwardPropagationTransformer : MethodTransformer() {
                 2 -> INSERT_POP2_AFTER
                 else -> throw AssertionError("Unexpected pop value size: $size")
             }
-
-        private fun replaceWithNopTransformation(): Transformation =
-            REPLACE_WITH_NOP
-
-        private fun createRemovableNopInsn() =
-            InsnNode(Opcodes.NOP).apply { removableNops.add(this) }
 
         private fun getInputTop(insn: AbstractInsnNode): SourceValue {
             val i = insnList.indexOf(insn)
@@ -301,16 +227,13 @@ class PopBackwardPropagationTransformer : MethodTransformer() {
 }
 
 fun AbstractInsnNode.isPurePush() =
-    isLoadOperation() ||
-            opcode in Opcodes.ACONST_NULL..Opcodes.LDC + 2 ||
-            isUnitInstance()
+    isLoadOperation() || opcode in Opcodes.ACONST_NULL..Opcodes.LDC + 2 || isUnitInstance()
 
 fun AbstractInsnNode.isPop() =
     opcode == Opcodes.POP || opcode == Opcodes.POP2
 
 fun AbstractInsnNode.isUnitInstance() =
-    opcode == Opcodes.GETSTATIC &&
-            this is FieldInsnNode && owner == "kotlin/Unit" && name == "INSTANCE"
+    opcode == Opcodes.GETSTATIC && this is FieldInsnNode && owner == "kotlin/Unit" && name == "INSTANCE"
 
 fun AbstractInsnNode.isPrimitiveTypeConversion() =
     opcode in Opcodes.I2L..Opcodes.I2S

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -27259,6 +27259,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         public void testKt20844() throws Exception {
             runTest("compiler/testData/codegen/box/optimizations/kt20844.kt");
         }
+
+        @Test
+        @TestMetadata("kt46921.kt")
+        public void testKt46921() throws Exception {
+            runTest("compiler/testData/codegen/box/optimizations/kt46921.kt");
+        }
     }
 
     @Nested

--- a/compiler/testData/codegen/box/optimizations/kt46921.kt
+++ b/compiler/testData/codegen/box/optimizations/kt46921.kt
@@ -1,0 +1,12 @@
+// TARGET_BACKEND: JVM
+// FILE: I.java
+public interface I<T> {
+    public T create();
+}
+
+// FILE: box.kt
+// A specific bytecode pattern here may confuse POP propagation.
+inline fun <reified T, V : Any> I<V>.bar(default: T, crossinline baz: V.(T) -> T) =
+    u@{ it: Any? -> create().baz(it as? T ?: return@u default) }
+
+fun box() = I<String> { "O" }.bar("fail") { this + it }("K")

--- a/compiler/testData/codegen/bytecodeText/boxedNotNumberTypeOnUnboxing.kt
+++ b/compiler/testData/codegen/bytecodeText/boxedNotNumberTypeOnUnboxing.kt
@@ -1,34 +1,34 @@
 fun test(p: Int?) {
     if (p != null) {
-        p.toByte() //intValue & I2B
-        p.toShort() //intValue & I2S
-        p.toInt() //intValue
-        p.toLong() //intValue & I2L
-        p.toFloat() //intValue & I2F
-        p.toDouble() //intValue & I2D
+        val a = p.toByte() //intValue & I2B
+        val b = p.toShort() //intValue & I2S
+        val c = p.toInt() //intValue
+        val d = p.toLong() //intValue & I2L
+        val e = p.toFloat() //intValue & I2F
+        val f = p.toDouble() //intValue & I2D
     }
 }
 
 fun test(p: Byte?) {
     if (p != null) {
-        p.toByte() //byteValue
-        p.toShort() //byteValue & I2S
-        p.toInt() //byteValue
-        p.toLong() //byteValue & I2L
-        p.toFloat() //byteValue & I2F
-        p.toDouble() //byteValue & I2D
+        val a = p.toByte() //byteValue
+        val b = p.toShort() //byteValue & I2S
+        val c = p.toInt() //byteValue
+        val d = p.toLong() //byteValue & I2L
+        val e = p.toFloat() //byteValue & I2F
+        val f = p.toDouble() //byteValue & I2D
     }
 }
 
 
 fun test(p: Char?) {
     if (p != null) {
-        p.toByte() //charValue & I2B
-        p.toShort() //charValue & I2S
-        p.toInt() //charValue
-        p.toLong() //charValue & I2L
-        p.toFloat() //charValue & I2F
-        p.toDouble() //charValue & I2D
+        val a = p.toByte() //charValue & I2B
+        val b = p.toShort() //charValue & I2S
+        val c = p.toInt() //charValue
+        val d = p.toLong() //charValue & I2L
+        val e = p.toFloat() //charValue & I2F
+        val f = p.toDouble() //charValue & I2D
     }
 }
 

--- a/compiler/testData/codegen/bytecodeText/boxingOptimization/casts.kt
+++ b/compiler/testData/codegen/bytecodeText/boxingOptimization/casts.kt
@@ -4,12 +4,12 @@ inline fun <R, T> foo(x : R?, block : (R?) -> T) : T {
 }
 
 fun bar() {
-    foo(1) { x -> x!!.toLong() }
-    foo(1) { x -> x!!.toShort() }
-    foo(1L) { x -> x!!.toByte() }
-    foo(1L) { x -> x!!.toShort() }
-    foo('a') { x -> x!!.toDouble() }
-    foo(1.0) { x -> x!!.toInt() }
+    val a = foo(1) { x -> x!!.toLong() }
+    val b = foo(1) { x -> x!!.toShort() }
+    val c = foo(1L) { x -> x!!.toByte() }
+    val d = foo(1L) { x -> x!!.toShort() }
+    val e = foo('a') { x -> x!!.toDouble() }
+    val f = foo(1.0) { x -> x!!.toInt() }
 }
 
 // 0 valueOf

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -27229,6 +27229,12 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
         public void testKt20844() throws Exception {
             runTest("compiler/testData/codegen/box/optimizations/kt20844.kt");
         }
+
+        @Test
+        @TestMetadata("kt46921.kt")
+        public void testKt46921() throws Exception {
+            runTest("compiler/testData/codegen/box/optimizations/kt46921.kt");
+        }
     }
 
     @Nested

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -27259,6 +27259,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         public void testKt20844() throws Exception {
             runTest("compiler/testData/codegen/box/optimizations/kt20844.kt");
         }
+
+        @Test
+        @TestMetadata("kt46921.kt")
+        public void testKt46921() throws Exception {
+            runTest("compiler/testData/codegen/box/optimizations/kt46921.kt");
+        }
     }
 
     @Nested

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -23100,6 +23100,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
         public void testKt20844() throws Exception {
             runTest("compiler/testData/codegen/box/optimizations/kt20844.kt");
         }
+
+        @TestMetadata("kt46921.kt")
+        public void testKt46921() throws Exception {
+            runTest("compiler/testData/codegen/box/optimizations/kt46921.kt");
+        }
     }
 
     @TestMetadata("compiler/testData/codegen/box/package")


### PR DESCRIPTION
1. if an argument of a `pop` cannot be removed, then all other potential arguments of that `pop` can't be removed either, and the same applies to other `pop`s that touch them;
2. the same is true for primitive conversions, but this is even trickier to implement correctly, so I simply did the same thing as with boxing operators: replace the conversion itself with a `pop` and keep the argument as-is.

Somehow this actually removes *more* redundant primitive type conversions than the old code in a couple bytecode text tests, so I've patched them to kind of use the value, forcing the instructions to stay.

 #KT-46921 Fixed