### PR TITLE
JVM: generate delegate for toString method of SAM wrapper

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -16333,6 +16333,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         }
 
         @Test
+        @TestMetadata("kt46908.kt")
+        public void testKt46908() throws Exception {
+            runTest("compiler/testData/codegen/box/funInterface/kt46908.kt");
+        }
+
+        @Test
         @TestMetadata("multimodule.kt")
         public void testMultimodule() throws Exception {
             runTest("compiler/testData/codegen/box/funInterface/multimodule.kt");

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/FunctionReferenceLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/FunctionReferenceLowering.kt
@@ -8,7 +8,7 @@ package org.jetbrains.kotlin.backend.jvm.lower
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
 import org.jetbrains.kotlin.backend.common.ir.*
-import org.jetbrains.kotlin.backend.common.lower.SamEqualsHashCodeMethodsGenerator
+import org.jetbrains.kotlin.backend.common.lower.SamEqualsHashCodeToStringMethodsGenerator
 import org.jetbrains.kotlin.backend.common.lower.parents
 import org.jetbrains.kotlin.backend.common.phaser.makeIrFilePhase
 import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
@@ -559,7 +559,7 @@ internal class FunctionReferenceLowering(private val context: JvmBackendContext)
                 return
             }
 
-            SamEqualsHashCodeMethodsGenerator(backendContext, functionReferenceClass, samSuperType) {
+            SamEqualsHashCodeToStringMethodsGenerator(backendContext, functionReferenceClass, samSuperType) {
                 val internalClass = when {
                     isAdaptedReference -> backendContext.ir.symbols.adaptedFunctionReference
                     else -> backendContext.ir.symbols.functionReferenceImpl
@@ -571,7 +571,7 @@ internal class FunctionReferenceLowering(private val context: JvmBackendContext)
                 irCallConstructor(constructor.symbol, emptyList()).apply {
                     generateConstructorCallArguments(this) { irGet(boundReceiverVar!!) }
                 }
-            }.generate()
+            }.generateEqualsHashCode()
         }
 
         private fun isEqualsFromAny(f: IrSimpleFunction): Boolean =

--- a/compiler/testData/codegen/box/funInterface/kt46908.kt
+++ b/compiler/testData/codegen/box/funInterface/kt46908.kt
@@ -1,0 +1,18 @@
+// TARGET_BACKEND: JVM_IR
+
+fun interface Foo1 : () -> String
+fun interface Foo2 : Foo1
+
+fun test2(foo: Foo2, expected: String) {
+    if (foo.toString() != expected) throw AssertionError("expected $expected but found $foo")
+}
+
+fun box(): String {
+    val foo1 = object : Foo1 {
+        override fun invoke() = "123"
+        override fun toString() = "foo1"
+    }
+
+    test2(foo1, "foo1")
+    return "OK"
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -16333,6 +16333,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         }
 
         @Test
+        @TestMetadata("kt46908.kt")
+        public void testKt46908() throws Exception {
+            runTest("compiler/testData/codegen/box/funInterface/kt46908.kt");
+        }
+
+        @Test
         @TestMetadata("multimodule.kt")
         public void testMultimodule() throws Exception {
             runTest("compiler/testData/codegen/box/funInterface/multimodule.kt");


### PR DESCRIPTION
issue link:  [KT-46908](https://youtrack.jetbrains.com/issue/KT-46908)

This is my first PR relate to JVM IR, so please feel free to close it if it is not the right way to fix the issue.

It seems that the easiest way to fix this issue is to override the `toString` method of the wrapper.

Let me explain why I didn't chose to drop the wrapper, consider the following situation

```kotlin
fun interface Foo1 : () -> String
fun interface Foo2 : Foo1

fun test2(foo: Foo2, expected: String) {
    if (foo.toString() != expected) throw AssertionError("expected $expected but found $foo")
}

fun box(): String {
    val foo1 = object : Foo1 {
        override fun invoke() = "123"
        override fun toString() = "foo1"
    }

    test2(foo1, "foo1")
    return "OK"
}
```

after compilation, the following classes will be generated
```kotlin
public final class MainKt$box$foo1$1 implements Foo1
```

```kotlin
final class MainKt$sam$Foo2$0 implements Foo2,kotlin.jvm.internal.FunctionAdapter
```

In this case, if we don't wrap the implementation(`MainKt$box$foo1$1`) into SAM adapter(`MainKt$sam$Foo2$0`), a `ClassCastException` will be produced when the method `test2` is called. 