### PR TITLE
FIR IDE: AddExclExclCallFix follow-up

### DIFF
--- a/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/diagnostics/FirDiagnosticsList.kt
+++ b/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/diagnostics/FirDiagnosticsList.kt
@@ -331,13 +331,13 @@ object DIAGNOSTICS_LIST : DiagnosticList("FirErrors") {
         }
 
         val ASSIGNMENT_TYPE_MISMATCH by error<KtExpression> {
-            parameter<ConeKotlinType>("expected")
-            parameter<ConeKotlinType>("actual")
+            parameter<ConeKotlinType>("expectedType")
+            parameter<ConeKotlinType>("actualType")
         }
 
         val RESULT_TYPE_MISMATCH by error<KtExpression> {
-            parameter<ConeKotlinType>("expected")
-            parameter<ConeKotlinType>("actual")
+            parameter<ConeKotlinType>("expectedType")
+            parameter<ConeKotlinType>("actualType")
         }
 
         val MANY_LAMBDA_EXPRESSION_ARGUMENTS by error<KtValueArgument>()

--- a/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/MainKtQuickFixRegistrar.kt
+++ b/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/MainKtQuickFixRegistrar.kt
@@ -118,6 +118,8 @@ class MainKtQuickFixRegistrar : KtQuickFixRegistrar() {
         registerApplicator(AddExclExclCallFixFactories.iteratorOnNullableFactory)
         registerApplicator(TypeMismatchFactories.argumentTypeMismatchFactory)
         registerApplicator(TypeMismatchFactories.returnTypeMismatchFactory)
+        registerApplicator(TypeMismatchFactories.assignmentTypeMismatch)
+        registerApplicator(TypeMismatchFactories.initializerTypeMismatch)
 
         // TODO: NON_EXHAUSTIVE_WHEN[_ON_SEALED_CLASS] will be replaced in future. We need to register the fix for those diagnostics as well
         registerPsiQuickFixes(KtFirDiagnostic.NoElseInWhen::class, AddWhenElseBranchFix)

--- a/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/fixes/TypeMismatchFactories.kt
+++ b/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/fixes/TypeMismatchFactories.kt
@@ -22,6 +22,14 @@ object TypeMismatchFactories {
         getFixesForTypeMismatch(diagnostic.psi, diagnostic.expectedType, diagnostic.actualType)
     }
 
+    val assignmentTypeMismatch = diagnosticFixFactory<KtFirDiagnostic.AssignmentTypeMismatch> { diagnostic ->
+        getFixesForTypeMismatch(diagnostic.psi, diagnostic.expectedType, diagnostic.actualType)
+    }
+
+    val initializerTypeMismatch = diagnosticFixFactory<KtFirDiagnostic.InitializerTypeMismatch> { diagnostic ->
+        diagnostic.psi.initializer?.let { getFixesForTypeMismatch(it, diagnostic.expectedType, diagnostic.actualType) } ?: emptyList()
+    }
+
     private fun KtAnalysisSession.getFixesForTypeMismatch(
         psi: PsiElement,
         expectedType: KtType,

--- a/idea/idea-fir/tests/org/jetbrains/kotlin/idea/fir/quickfix/HighLevelQuickFixTestGenerated.java
+++ b/idea/idea-fir/tests/org/jetbrains/kotlin/idea/fir/quickfix/HighLevelQuickFixTestGenerated.java
@@ -361,6 +361,11 @@ public class HighLevelQuickFixTestGenerated extends AbstractHighLevelQuickFixTes
                 runTest("idea/testData/quickfix/addExclExclCall/typeMismatch/assignmentRValue.kt");
             }
 
+            @TestMetadata("initializer.kt")
+            public void testInitializer() throws Exception {
+                runTest("idea/testData/quickfix/addExclExclCall/typeMismatch/initializer.kt");
+            }
+
             @TestMetadata("memberAccessInExtension.kt")
             public void testMemberAccessInExtension() throws Exception {
                 runTest("idea/testData/quickfix/addExclExclCall/typeMismatch/memberAccessInExtension.kt");
@@ -369,6 +374,11 @@ public class HighLevelQuickFixTestGenerated extends AbstractHighLevelQuickFixTes
             @TestMetadata("memberAccessInExtensionAsAssignmentRValue.kt")
             public void testMemberAccessInExtensionAsAssignmentRValue() throws Exception {
                 runTest("idea/testData/quickfix/addExclExclCall/typeMismatch/memberAccessInExtensionAsAssignmentRValue.kt");
+            }
+
+            @TestMetadata("memberAccessInExtensionAsInitializer.kt")
+            public void testMemberAccessInExtensionAsInitializer() throws Exception {
+                runTest("idea/testData/quickfix/addExclExclCall/typeMismatch/memberAccessInExtensionAsInitializer.kt");
             }
 
             @TestMetadata("nullArgument.kt")

--- a/idea/idea-fir/tests/org/jetbrains/kotlin/idea/fir/quickfix/HighLevelQuickFixTestGenerated.java
+++ b/idea/idea-fir/tests/org/jetbrains/kotlin/idea/fir/quickfix/HighLevelQuickFixTestGenerated.java
@@ -324,6 +324,11 @@ public class HighLevelQuickFixTestGenerated extends AbstractHighLevelQuickFixTes
             runTest("idea/testData/quickfix/addExclExclCall/nullExpression.kt");
         }
 
+        @TestMetadata("nullReceiver.kt")
+        public void testNullReceiver() throws Exception {
+            runTest("idea/testData/quickfix/addExclExclCall/nullReceiver.kt");
+        }
+
         @TestMetadata("operationBinary.kt")
         public void testOperationBinary() throws Exception {
             runTest("idea/testData/quickfix/addExclExclCall/operationBinary.kt");

--- a/idea/idea-frontend-api/src/org/jetbrains/kotlin/idea/frontend/api/components/KtExpressionTypeProvider.kt
+++ b/idea/idea-frontend-api/src/org/jetbrains/kotlin/idea/frontend/api/components/KtExpressionTypeProvider.kt
@@ -13,8 +13,9 @@ import org.jetbrains.kotlin.psi.KtExpression
 abstract class KtExpressionTypeProvider : KtAnalysisSessionComponent() {
     abstract fun getReturnTypeForKtDeclaration(declaration: KtDeclaration): KtType
     abstract fun getKtExpressionType(expression: KtExpression): KtType
-
     abstract fun getExpectedType(expression: PsiElement): KtType?
+    abstract fun isDefinitelyNull(expression: KtExpression): Boolean
+    abstract fun isDefinitelyNotNull(expression: KtExpression): Boolean
 }
 
 interface KtExpressionTypeProviderMixIn : KtAnalysisSessionMixIn {
@@ -30,4 +31,35 @@ interface KtExpressionTypeProviderMixIn : KtAnalysisSessionMixIn {
      */
     fun PsiElement.getExpectedType(): KtType? =
         analysisSession.expressionTypeProvider.getExpectedType(this)
+
+    /**
+     * Returns `true` if this expression is definitely null, based on declared nullability and smart cast types derived from
+     * data-flow analysis facts. Examples:
+     * ```
+     *   fun <T : Any> foo(t: T, nt: T?, s: String, ns: String?) {
+     *     t     // t.isDefinitelyNull()  == false && t.isDefinitelyNotNull()  == true
+     *     nt    // nt.isDefinitelyNull() == false && nt.isDefinitelyNotNull() == false
+     *     s     // s.isDefinitelyNull()  == false && s.isDefinitelyNotNull()  == true
+     *     ns    // ns.isDefinitelyNull() == false && ns.isDefinitelyNotNull() == false
+     *
+     *     if (ns != null) {
+     *       ns  // ns.isDefinitelyNull() == false && ns.isDefinitelyNotNull() == true
+     *     } else {
+     *       ns  // ns.isDefinitelyNull() == true  && ns.isDefinitelyNotNull() == false
+     *     }
+     *
+     *     ns!!  // From this point on: ns.isDefinitelyNull() == false && ns.isDefinitelyNotNull() == true
+     *   }
+     * ```
+     * Note that only nullability from "stable" smart cast types is considered. The
+     * [spec](https://kotlinlang.org/spec/type-inference.html#smart-cast-sink-stability) provides an explanation on smart cast stability.
+     */
+    fun KtExpression.isDefinitelyNull(): Boolean =
+        analysisSession.expressionTypeProvider.isDefinitelyNull(this)
+
+    /**
+     * Returns `true` if this expression is definitely not null. See [isDefinitelyNull] for examples.
+     */
+    fun KtExpression.isDefinitelyNotNull(): Boolean =
+        analysisSession.expressionTypeProvider.isDefinitelyNotNull(this)
 }

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnostics.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnostics.kt
@@ -760,14 +760,14 @@ sealed class KtFirDiagnostic<PSI: PsiElement> : KtDiagnosticWithPsi<PSI> {
 
     abstract class AssignmentTypeMismatch : KtFirDiagnostic<KtExpression>() {
         override val diagnosticClass get() = AssignmentTypeMismatch::class
-        abstract val expected: KtType
-        abstract val actual: KtType
+        abstract val expectedType: KtType
+        abstract val actualType: KtType
     }
 
     abstract class ResultTypeMismatch : KtFirDiagnostic<KtExpression>() {
         override val diagnosticClass get() = ResultTypeMismatch::class
-        abstract val expected: KtType
-        abstract val actual: KtType
+        abstract val expectedType: KtType
+        abstract val actualType: KtType
     }
 
     abstract class ManyLambdaExpressionArguments : KtFirDiagnostic<KtValueArgument>() {

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnosticsImpl.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnosticsImpl.kt
@@ -1222,8 +1222,8 @@ internal class NamedParameterNotFoundImpl(
 }
 
 internal class AssignmentTypeMismatchImpl(
-    override val expected: KtType,
-    override val actual: KtType,
+    override val expectedType: KtType,
+    override val actualType: KtType,
     firDiagnostic: FirPsiDiagnostic<*>,
     override val token: ValidityToken,
 ) : KtFirDiagnostic.AssignmentTypeMismatch(), KtAbstractFirDiagnostic<KtExpression> {
@@ -1231,8 +1231,8 @@ internal class AssignmentTypeMismatchImpl(
 }
 
 internal class ResultTypeMismatchImpl(
-    override val expected: KtType,
-    override val actual: KtType,
+    override val expectedType: KtType,
+    override val actualType: KtType,
     firDiagnostic: FirPsiDiagnostic<*>,
     override val token: ValidityToken,
 ) : KtFirDiagnostic.ResultTypeMismatch(), KtAbstractFirDiagnostic<KtExpression> {

--- a/idea/testData/quickfix/addExclExclCall/nullExpression.kt
+++ b/idea/testData/quickfix/addExclExclCall/nullExpression.kt
@@ -9,6 +9,3 @@ fun foo(arg: String?) {
         val x: String = arg<caret>
     }
 }
-
-// TODO: Need data flow info from null check
-/* IGNORE_FIR */

--- a/idea/testData/quickfix/addExclExclCall/nullExpression.kt
+++ b/idea/testData/quickfix/addExclExclCall/nullExpression.kt
@@ -9,3 +9,6 @@ fun foo(arg: String?) {
         val x: String = arg<caret>
     }
 }
+
+// TODO: Need data flow info from null check
+/* IGNORE_FIR */

--- a/idea/testData/quickfix/addExclExclCall/nullReceiver.fir.kt
+++ b/idea/testData/quickfix/addExclExclCall/nullReceiver.fir.kt
@@ -1,0 +1,7 @@
+// "Add non-null asserted (!!) call" "false"
+
+fun foo(arg: String?) {
+    if (arg == null) {
+        arg<caret>.length
+    }
+}

--- a/idea/testData/quickfix/addExclExclCall/nullReceiver.kt
+++ b/idea/testData/quickfix/addExclExclCall/nullReceiver.kt
@@ -1,0 +1,8 @@
+// "Add non-null asserted (!!) call" "true"
+// DISABLE-ERRORS
+
+fun foo(arg: String?) {
+    if (arg == null) {
+        arg<caret>.length
+    }
+}

--- a/idea/testData/quickfix/addExclExclCall/nullReceiver.kt.after
+++ b/idea/testData/quickfix/addExclExclCall/nullReceiver.kt.after
@@ -1,0 +1,8 @@
+// "Add non-null asserted (!!) call" "true"
+// DISABLE-ERRORS
+
+fun foo(arg: String?) {
+    if (arg == null) {
+        arg!!.length
+    }
+}

--- a/idea/testData/quickfix/addExclExclCall/typeMismatch/argumentAfterNullCheck.kt
+++ b/idea/testData/quickfix/addExclExclCall/typeMismatch/argumentAfterNullCheck.kt
@@ -13,6 +13,3 @@ fun test(i: Int?) {
 }
 
 fun other(i: Int) {}
-
-// TODO: Need data flow info from null check
-/* IGNORE_FIR */

--- a/idea/testData/quickfix/addExclExclCall/typeMismatch/assignmentRValue.kt.after
+++ b/idea/testData/quickfix/addExclExclCall/typeMismatch/assignmentRValue.kt.after
@@ -1,7 +1,5 @@
 // "Add non-null asserted (!!) call" "true"
-fun test() {
-    val s: String? = null
-    val z: String = s!!
+fun test(s: String?) {
+    var z: String = ""
+    z = s!!
 }
-// TODO: Enable when FIR reports TYPE_MISMATCH for assignments
-/* IGNORE_FIR */

--- a/idea/testData/quickfix/addExclExclCall/typeMismatch/initializer.kt
+++ b/idea/testData/quickfix/addExclExclCall/typeMismatch/initializer.kt
@@ -1,5 +1,4 @@
 // "Add non-null asserted (!!) call" "true"
 fun test(s: String?) {
-    var z: String = ""
-    z = <caret>s
+    val z: String = <caret>s
 }

--- a/idea/testData/quickfix/addExclExclCall/typeMismatch/initializer.kt.after
+++ b/idea/testData/quickfix/addExclExclCall/typeMismatch/initializer.kt.after
@@ -1,5 +1,4 @@
 // "Add non-null asserted (!!) call" "true"
 fun test(s: String?) {
-    var z: String = ""
-    z = <caret>s
+    val z: String = s!!
 }

--- a/idea/testData/quickfix/addExclExclCall/typeMismatch/memberAccessInExtensionAsAssignmentRValue.kt.after
+++ b/idea/testData/quickfix/addExclExclCall/typeMismatch/memberAccessInExtensionAsAssignmentRValue.kt.after
@@ -5,7 +5,6 @@ class C {
 
 // Test for KTIJ-10052
 fun C.test() {
-    val z: String = s!!
+    var z: String = ""
+    z = s!!
 }
-// TODO: Enable when FIR reports TYPE_MISMATCH for assignments
-/* IGNORE_FIR */

--- a/idea/testData/quickfix/addExclExclCall/typeMismatch/memberAccessInExtensionAsInitializer.kt
+++ b/idea/testData/quickfix/addExclExclCall/typeMismatch/memberAccessInExtensionAsInitializer.kt
@@ -5,6 +5,5 @@ class C {
 
 // Test for KTIJ-10052
 fun C.test() {
-    var z: String = ""
-    z = <caret>s
+    var z: String = <caret>s
 }

--- a/idea/testData/quickfix/addExclExclCall/typeMismatch/memberAccessInExtensionAsInitializer.kt.after
+++ b/idea/testData/quickfix/addExclExclCall/typeMismatch/memberAccessInExtensionAsInitializer.kt.after
@@ -5,6 +5,5 @@ class C {
 
 // Test for KTIJ-10052
 fun C.test() {
-    var z: String = ""
-    z = <caret>s
+    var z: String = s!!
 }

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -774,6 +774,11 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
                 runTest("idea/testData/quickfix/addExclExclCall/typeMismatch/assignmentRValue.kt");
             }
 
+            @TestMetadata("initializer.kt")
+            public void testInitializer() throws Exception {
+                runTest("idea/testData/quickfix/addExclExclCall/typeMismatch/initializer.kt");
+            }
+
             @TestMetadata("memberAccessInExtension.kt")
             public void testMemberAccessInExtension() throws Exception {
                 runTest("idea/testData/quickfix/addExclExclCall/typeMismatch/memberAccessInExtension.kt");
@@ -782,6 +787,11 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
             @TestMetadata("memberAccessInExtensionAsAssignmentRValue.kt")
             public void testMemberAccessInExtensionAsAssignmentRValue() throws Exception {
                 runTest("idea/testData/quickfix/addExclExclCall/typeMismatch/memberAccessInExtensionAsAssignmentRValue.kt");
+            }
+
+            @TestMetadata("memberAccessInExtensionAsInitializer.kt")
+            public void testMemberAccessInExtensionAsInitializer() throws Exception {
+                runTest("idea/testData/quickfix/addExclExclCall/typeMismatch/memberAccessInExtensionAsInitializer.kt");
             }
 
             @TestMetadata("nullArgument.kt")

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -737,6 +737,11 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
             runTest("idea/testData/quickfix/addExclExclCall/nullExpression.kt");
         }
 
+        @TestMetadata("nullReceiver.kt")
+        public void testNullReceiver() throws Exception {
+            runTest("idea/testData/quickfix/addExclExclCall/nullReceiver.kt");
+        }
+
         @TestMetadata("operationBinary.kt")
         public void testOperationBinary() throws Exception {
             runTest("idea/testData/quickfix/addExclExclCall/operationBinary.kt");


### PR DESCRIPTION
This addresses some TODOs from https://github.com/JetBrains/kotlin/pull/4331:
- Enable `AddExclExclCallFix` for `ASSIGNMENT_TYPE_MISMATCH` and `INITIALIZER_TYPE_MISMATCH`.
- Don't offer `AddExclExclCallFix` when expression is definitely null. We do this by checking if it is a `FirExpressionWithSmartcastToNull`.