### PR TITLE
JVM_IR: correctly (?) unbox Result when needed, and don't unbox when not needed

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -20173,6 +20173,52 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         }
 
         @Nested
+        @TestMetadata("compiler/testData/codegen/box/inlineClasses/result")
+        @TestDataPath("$PROJECT_ROOT")
+        public class Result {
+            @Test
+            public void testAllFilesPresentInResult() throws Exception {
+                KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/inlineClasses/result"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+            }
+
+            @Test
+            @TestMetadata("directCall1.kt")
+            public void testDirectCall1() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/directCall1.kt");
+            }
+
+            @Test
+            @TestMetadata("directCall2.kt")
+            public void testDirectCall2() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/directCall2.kt");
+            }
+
+            @Test
+            @TestMetadata("doubleOverride.kt")
+            public void testDoubleOverride() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/doubleOverride.kt");
+            }
+
+            @Test
+            @TestMetadata("extensionOverride.kt")
+            public void testExtensionOverride() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/extensionOverride.kt");
+            }
+
+            @Test
+            @TestMetadata("inlineMethodOnResult.kt")
+            public void testInlineMethodOnResult() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/inlineMethodOnResult.kt");
+            }
+
+            @Test
+            @TestMetadata("lambdaTakesResultThroughBridge.kt")
+            public void testLambdaTakesResultThroughBridge() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/lambdaTakesResultThroughBridge.kt");
+            }
+        }
+
+        @Nested
         @TestMetadata("compiler/testData/codegen/box/inlineClasses/returnResult")
         @TestDataPath("$PROJECT_ROOT")
         public class ReturnResult {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -678,10 +678,6 @@ class ExpressionCodegen(
         return when {
             // Only care about `Result<T>`; `Result<T>?` is boxed in any case.
             type.erasedUpperBound.fqNameWhenAvailable != StandardNames.RESULT_FQ_NAME || type.isNullable() -> null
-            // In `SuspendLambda.invoke`, we take a boxed result and store it in a field of type `Any?` (or pass it
-            // to `create(Any?)`). Normally, we'd unbox here and the box at the store/call, but the boxing is elided
-            // by the hack in `PromisedValue.materializedAt`, and so we remove the unboxing as well. TODO: unhack this.
-            parentAsClass.origin == JvmLoweredDeclarationOrigin.SUSPEND_LAMBDA && name == OperatorNameConventions.INVOKE -> false
             // If there's a bridge, it will unbox `Result` along with transforming all other arguments.
             parentAsClass.declarations.any { function ->
                 function is IrSimpleFunction && function != this &&

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -16,7 +16,6 @@ import org.jetbrains.kotlin.backend.jvm.ir.erasedUpperBound
 import org.jetbrains.kotlin.backend.jvm.ir.isInlineClassType
 import org.jetbrains.kotlin.backend.jvm.lower.MultifileFacadeFileEntry
 import org.jetbrains.kotlin.backend.jvm.lower.constantValue
-import org.jetbrains.kotlin.backend.jvm.lower.inlineclasses.requiresMangling
 import org.jetbrains.kotlin.backend.jvm.lower.inlineclasses.unboxInlineClass
 import org.jetbrains.kotlin.backend.jvm.lower.isMultifileBridge
 import org.jetbrains.kotlin.backend.jvm.lower.suspendFunctionOriginal
@@ -222,13 +221,6 @@ class ExpressionCodegen(
             expression.accept(this, data).materializeAt(type, irType)
         }
         return StackValue.onStack(type, irType.toIrBasedKotlinType())
-    }
-
-    internal fun genOrGetLocal(expression: IrExpression, type: Type, parameterType: IrType, data: BlockInfo): StackValue {
-        return if (expression is IrGetValue)
-            StackValue.local(findLocalIndex(expression.symbol), frameMap.typeOf(expression.symbol), expression.type.toIrBasedKotlinType())
-        else
-            gen(expression, type, parameterType, data)
     }
 
     fun generate() {
@@ -544,6 +536,8 @@ class ExpressionCodegen(
                     MaterialValue(this, unboxedInlineClassIrType.asmType, unboxedInlineClassIrType)
                 }
             }
+            expression.symbol.owner.resultIsActuallyAny(null) == true ->
+                MaterialValue(this, callable.asmMethod.returnType, context.irBuiltIns.anyNType)
             else ->
                 MaterialValue(this, callable.asmMethod.returnType, callable.returnType)
         }
@@ -647,55 +641,57 @@ class ExpressionCodegen(
         expression.markLineNumber(startOffset = true)
         val type = frameMap.typeOf(expression.symbol)
         mv.load(findLocalIndex(expression.symbol), type)
-        unboxResultIfNeeded(expression)
-        return MaterialValue(this, type, expression.type)
+        return MaterialValue(this, type, expression.symbol.owner.realType)
     }
 
-    // We do not mangle functions if Result is the only parameter of the function,
-    // thus, if the function overrides generic parameter, its argument is boxed and there is no
-    // bridge to unbox it. Instead, we unbox it in the non-mangled function manually.
-    private fun unboxResultIfNeeded(arg: IrGetValue) {
-        if (arg.type.erasedUpperBound.fqNameWhenAvailable != StandardNames.RESULT_FQ_NAME) return
-        // Unlike inline callable reference arguments, nullable Result arguments are unboxed during coercion to not-null Result
-        if (arg.type.isNullable()) return
-        // Do not unbox arguments of lambda, but unbox arguments of callable references
-        if (irFunction.origin == IrDeclarationOrigin.LOCAL_FUNCTION_FOR_LAMBDA) return
-        if (!onlyResultInlineClassParameters()) return
-        if (irFunction !is IrSimpleFunction) return
-        // Skip Result's methods
-        if (irFunction.parentAsClass.fqNameWhenAvailable == StandardNames.RESULT_FQ_NAME) return
-        // Do not unbox, if there is a bridge, which unboxes for us
-        if (hasBridge()) return
+    internal fun genOrGetLocal(expression: IrExpression, type: Type, parameterType: IrType, data: BlockInfo): StackValue =
+        if (expression is IrGetValue)
+            StackValue.local(
+                findLocalIndex(expression.symbol), frameMap.typeOf(expression.symbol),
+                expression.symbol.owner.realType.toIrBasedKotlinType()
+            )
+        else
+            gen(expression, type, parameterType, data)
 
-        val index = (arg.symbol as? IrValueParameterSymbol)?.owner?.index ?: return
-        val genericOrAnyOverride = irFunction.overriddenSymbols.any {
-            val overriddenParam = if (index < 0) it.owner.dispatchReceiverParameter!! else it.owner.valueParameters[index]
-            overriddenParam.type.erasedUpperBound.fqNameWhenAvailable != StandardNames.RESULT_FQ_NAME
-        } || irFunction.parentAsClass.let { it.origin == JvmLoweredDeclarationOrigin.LAMBDA_IMPL && !it.isSamAdapter() }
-        if (!genericOrAnyOverride) return
+    // We do not mangle functions if Result is the only parameter of the function. This means that if a function
+    // taking `Result` as a parameter overrides a function taking `Any?`, there is no bridge unless needed for
+    // some other reason, and thus `Result` is actually `Any?`. TODO: do this stuff at IR level?
+    val IrValueDeclaration.realType: IrType
+        get() = parent.let { parent ->
+            val isBoxedResult = this is IrValueParameter && parent is IrSimpleFunction &&
+                    parent.dispatchReceiverParameter != this &&
+                    (parent.parent as? IrClass)?.fqNameWhenAvailable != StandardNames.RESULT_FQ_NAME &&
+                    parent.resultIsActuallyAny(index) == true
+            return if (isBoxedResult) context.irBuiltIns.anyNType else type
+        }
 
-        // Result parameter of SAM-wrapper to Java SAM is already unboxed in visitGetValue, do not unbox it anymore
-        if (irFunction.parentAsClass.superTypes.any { it.getClass()?.isFromJava() == true }) return
-
-        // Do not unbox Results in suspend lambda `invoke` methods. These just forward to `invokeSuspend`,
-        // where the arguments are unboxed.
-        if (
-            irFunction.parentAsClass.origin == JvmLoweredDeclarationOrigin.SUSPEND_LAMBDA &&
-            irFunction.name == OperatorNameConventions.INVOKE
-        ) return
-
-        StackValue.unboxInlineClass(OBJECT_TYPE, arg.type.erasedUpperBound.defaultType, mv, typeMapper)
-    }
-
-    private fun IrClass.isSamAdapter(): Boolean = this.superTypes.any { it.getClass()?.isFun == true }
-
-    private fun onlyResultInlineClassParameters(): Boolean = irFunction.valueParameters.all { !it.type.requiresMangling }
-
-    private fun hasBridge(): Boolean = irFunction.parentAsClass.declarations.any { function ->
-        function is IrFunction && function != irFunction &&
-                context.methodSignatureMapper.mapSignatureSkipGeneric(function).let {
-                    it.asmMethod.name == signature.asmMethod.name && it.valueParameters == signature.valueParameters
-                }
+    // Argument: null for return value, -1 for extension receiver, >= 0 for value parameter.
+    //           (It does not make sense to check the dispatch receiver.)
+    // Return: null if this is not a `Result<T>` type at all, false if this is an unboxed `Result<T>`,
+    //         true if this is a `Result<T>` overriding `Any?` and so it is boxed.
+    private fun IrSimpleFunction.resultIsActuallyAny(index: Int?): Boolean? {
+        val type = when {
+            index == null -> returnType
+            index < 0 -> extensionReceiverParameter!!.type
+            else -> valueParameters[index].type
+        }
+        return when {
+            // Only care about `Result<T>`; `Result<T>?` is boxed in any case.
+            type.erasedUpperBound.fqNameWhenAvailable != StandardNames.RESULT_FQ_NAME || type.isNullable() -> null
+            // In `SuspendLambda.invoke`, we take a boxed result and store it in a field of type `Any?` (or pass it
+            // to `create(Any?)`). Normally, we'd unbox here and the box at the store/call, but the boxing is elided
+            // by the hack in `PromisedValue.materializedAt`, and so we remove the unboxing as well. TODO: unhack this.
+            parentAsClass.origin == JvmLoweredDeclarationOrigin.SUSPEND_LAMBDA && name == OperatorNameConventions.INVOKE -> false
+            // If there's a bridge, it will unbox `Result` along with transforming all other arguments.
+            parentAsClass.declarations.any { function ->
+                function is IrSimpleFunction && function != this &&
+                        function.origin == IrDeclarationOrigin.BRIDGE &&
+                        function.attributeOwnerId == attributeOwnerId
+            } -> false
+            // And if there's no bridge, we only need to unbox if we override another method that either takes
+            // `Any?` or also needs to unbox. (TODO: what if results of `needsResultArgumentUnboxing` are inconsistent?)
+            else -> overriddenSymbols.any { it.owner.resultIsActuallyAny(index) != false }
+        }
     }
 
     override fun visitFieldAccess(expression: IrFieldAccessExpression, data: BlockInfo): PromisedValue {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/IrCallGenerator.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/IrCallGenerator.kt
@@ -44,7 +44,7 @@ interface IrCallGenerator {
         codegen: ExpressionCodegen,
         blockInfo: BlockInfo
     ) {
-        codegen.gen(argumentExpression, parameterType, irValueParameter.type, blockInfo)
+        with(codegen) { gen(argumentExpression, parameterType, irValueParameter.realType, blockInfo) }
     }
 
     object DefaultCallGenerator : IrCallGenerator

--- a/compiler/testData/codegen/box/inlineClasses/result/directCall1.kt
+++ b/compiler/testData/codegen/box/inlineClasses/result/directCall1.kt
@@ -1,0 +1,11 @@
+// WITH_RUNTIME
+// IGNORE_BACKEND: JVM, WASM
+interface I<T> {
+    fun foo(x: T): T
+}
+
+class C : I<Result<Any?>> {
+    override fun foo(x: Result<Any?>) = x
+}
+
+fun box() = C().foo(Result.success("OK")).getOrNull()

--- a/compiler/testData/codegen/box/inlineClasses/result/directCall2.kt
+++ b/compiler/testData/codegen/box/inlineClasses/result/directCall2.kt
@@ -1,0 +1,13 @@
+// WITH_RUNTIME
+// IGNORE_BACKEND: JVM, WASM
+interface I<T> {
+    fun foo(x: T): Any?
+}
+
+class C : I<Result<Any?>> {
+    override fun foo(x: Result<Any?>) = x.getOrNullNoinline()
+}
+
+fun <T> Result<T>.getOrNullNoinline() = getOrNull()
+
+fun box() = C().foo(Result.success("OK"))

--- a/compiler/testData/codegen/box/inlineClasses/result/doubleOverride.kt
+++ b/compiler/testData/codegen/box/inlineClasses/result/doubleOverride.kt
@@ -1,0 +1,19 @@
+// WITH_RUNTIME
+// IGNORE_BACKEND: JVM
+interface C<T> {
+    abstract fun foo(x: T): String
+}
+
+open class D<T> : C<Result<T>> {
+    open override fun foo(x: Result<T>): String = "???"
+}
+
+class E : D<String>() {
+    override fun foo(x: Result<String>): String = x.get()
+}
+
+fun <T> Result<T>.get(): T = getOrNull()!!
+
+fun <T> C<Result<T>>.bar(x: T) = foo(Result.success(x))
+
+fun box() = E().bar("OK")

--- a/compiler/testData/codegen/box/inlineClasses/result/extensionOverride.kt
+++ b/compiler/testData/codegen/box/inlineClasses/result/extensionOverride.kt
@@ -1,0 +1,14 @@
+// WITH_RUNTIME
+fun <T> Result<T>.get(): T = getOrNull()!!
+
+interface C<T> {
+    abstract fun Result<T>.foo(): String
+}
+
+class D : C<String> {
+    override fun Result<String>.foo() = get()
+}
+
+fun <T> C<T>.bar(x: T) = Result.success(x).foo()
+
+fun box() = D().bar("OK")

--- a/compiler/testData/codegen/box/inlineClasses/result/inlineMethodOnResult.kt
+++ b/compiler/testData/codegen/box/inlineClasses/result/inlineMethodOnResult.kt
@@ -1,0 +1,11 @@
+// WITH_RUNTIME
+// IGNORE_BACKEND: WASM
+interface I<T, V> {
+    fun foo(x: T): V
+}
+
+class C : I<Result<Any?>, Any?> {
+    override fun foo(x: Result<Any?>) = x.getOrNull()
+}
+
+fun box() = (C() as I<Result<Any?>, Any?>).foo(Result.success("OK"))

--- a/compiler/testData/codegen/box/inlineClasses/result/lambdaTakesResultThroughBridge.kt
+++ b/compiler/testData/codegen/box/inlineClasses/result/lambdaTakesResultThroughBridge.kt
@@ -1,0 +1,7 @@
+// WITH_RUNTIME
+// IGNORE_BACKEND: WASM
+fun <T> Result<T>.getOrNullNoinline() = getOrNull()
+
+val x = { a: Int, b: Result<String> -> b.getOrNullNoinline() }
+
+fun box() = x(1, Result.success("OK"))

--- a/compiler/testData/codegen/bytecodeListing/annotations/kt9320_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/annotations/kt9320_ir.txt
@@ -1,0 +1,50 @@
+@java.lang.annotation.Retention
+@kotlin.Metadata
+public annotation class Ann {
+    // source: 'kt9320.kt'
+}
+
+@kotlin.annotation.Target
+@kotlin.annotation.Retention
+@java.lang.annotation.Retention
+@java.lang.annotation.Target
+@kotlin.Metadata
+public annotation class AnnExpr {
+    // source: 'kt9320.kt'
+}
+
+@Ann
+@kotlin.Metadata
+public final class Kt9320Kt$foo$v$1 {
+    // source: 'kt9320.kt'
+    enclosing method Kt9320Kt.foo()V
+    inner (anonymous) class Kt9320Kt$foo$v$1
+    method <init>(): void
+}
+
+@kotlin.Metadata
+final class Kt9320Kt$foo$w$1 {
+    // source: 'kt9320.kt'
+    enclosing method Kt9320Kt.foo()V
+    public final static field INSTANCE: Kt9320Kt$foo$w$1
+    inner (anonymous) class Kt9320Kt$foo$w$1
+    static method <clinit>(): void
+    method <init>(): void
+    public final @Ann @org.jetbrains.annotations.NotNull method invoke(@org.jetbrains.annotations.NotNull p0: My): java.lang.Integer
+    public synthetic bridge method invoke(p0: java.lang.Object): java.lang.Object
+}
+
+@kotlin.Metadata
+public final class Kt9320Kt {
+    // source: 'kt9320.kt'
+    inner (anonymous) class Kt9320Kt$foo$v$1
+    inner (anonymous) class Kt9320Kt$foo$w$1
+    public final static method foo(): void
+}
+
+@Ann
+@kotlin.Metadata
+public class My {
+    // source: 'kt9320.kt'
+    public method <init>(): void
+}

--- a/compiler/testData/codegen/bytecodeListing/annotations/literals_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/annotations/literals_ir.txt
@@ -1,0 +1,83 @@
+@kotlin.annotation.Target
+@java.lang.annotation.Retention
+@java.lang.annotation.Target
+@kotlin.Metadata
+public annotation class ClsAnn {
+    // source: 'literals.kt'
+}
+
+@kotlin.annotation.Target
+@kotlin.annotation.Retention
+@java.lang.annotation.Retention
+@java.lang.annotation.Target
+@kotlin.Metadata
+public annotation class ExprAnn {
+    // source: 'literals.kt'
+}
+
+@kotlin.annotation.Target
+@java.lang.annotation.Retention
+@java.lang.annotation.Target
+@kotlin.Metadata
+public annotation class FunAnn {
+    // source: 'literals.kt'
+}
+
+@kotlin.Metadata
+final class LiteralsKt$foo$1 {
+    // source: 'literals.kt'
+    enclosing method LiteralsKt.foo(I)LMy;
+    synthetic final field $arg: int
+    inner (anonymous) class LiteralsKt$foo$1
+    method <init>(p0: int): void
+    public final @FunAnn @org.jetbrains.annotations.NotNull method invoke(): java.lang.Integer
+    public synthetic bridge method invoke(): java.lang.Object
+}
+
+@kotlin.Metadata
+final class LiteralsKt$foo$2 {
+    // source: 'literals.kt'
+    enclosing method LiteralsKt.foo(I)LMy;
+    synthetic final field $arg: int
+    inner (anonymous) class LiteralsKt$foo$2
+    method <init>(p0: int): void
+    public final @org.jetbrains.annotations.NotNull method invoke(): java.lang.Integer
+    public synthetic bridge method invoke(): java.lang.Object
+}
+
+@ClsAnn
+@kotlin.Metadata
+public final class LiteralsKt$foo$3 {
+    // source: 'literals.kt'
+    enclosing method LiteralsKt.foo(I)LMy;
+    inner (anonymous) class LiteralsKt$foo$3
+    method <init>(): void
+}
+
+@kotlin.Metadata
+final class LiteralsKt$foo$x$1 {
+    // source: 'literals.kt'
+    enclosing method LiteralsKt.foo(I)LMy;
+    synthetic final field $arg: int
+    inner (anonymous) class LiteralsKt$foo$x$1
+    method <init>(p0: int): void
+    public final @FunAnn @org.jetbrains.annotations.NotNull method invoke(): java.lang.Integer
+    public synthetic bridge method invoke(): java.lang.Object
+}
+
+@kotlin.Metadata
+public final class LiteralsKt {
+    // source: 'literals.kt'
+    inner (anonymous) class LiteralsKt$foo$1
+    inner (anonymous) class LiteralsKt$foo$2
+    inner (anonymous) class LiteralsKt$foo$3
+    inner (anonymous) class LiteralsKt$foo$x$1
+    public final static method bar(@org.jetbrains.annotations.NotNull p0: kotlin.jvm.functions.Function0): int
+    public final static @org.jetbrains.annotations.NotNull method foo(p0: int): My
+}
+
+@kotlin.Metadata
+public class My {
+    // source: 'literals.kt'
+    public method <init>(): void
+}

--- a/compiler/testData/codegen/bytecodeText/directInvoke/inplaceClosure.kt
+++ b/compiler/testData/codegen/bytecodeText/directInvoke/inplaceClosure.kt
@@ -3,4 +3,4 @@ fun test() {
     1.fn()
 }
 
-// 1 invoke \(I\)I
+// 1 invoke \(Ljava/lang/Object;\)Ljava/lang/Object;

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -20143,6 +20143,52 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
         }
 
         @Nested
+        @TestMetadata("compiler/testData/codegen/box/inlineClasses/result")
+        @TestDataPath("$PROJECT_ROOT")
+        public class Result {
+            @Test
+            public void testAllFilesPresentInResult() throws Exception {
+                KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/inlineClasses/result"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM, true);
+            }
+
+            @Test
+            @TestMetadata("directCall1.kt")
+            public void testDirectCall1() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/directCall1.kt");
+            }
+
+            @Test
+            @TestMetadata("directCall2.kt")
+            public void testDirectCall2() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/directCall2.kt");
+            }
+
+            @Test
+            @TestMetadata("doubleOverride.kt")
+            public void testDoubleOverride() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/doubleOverride.kt");
+            }
+
+            @Test
+            @TestMetadata("extensionOverride.kt")
+            public void testExtensionOverride() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/extensionOverride.kt");
+            }
+
+            @Test
+            @TestMetadata("inlineMethodOnResult.kt")
+            public void testInlineMethodOnResult() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/inlineMethodOnResult.kt");
+            }
+
+            @Test
+            @TestMetadata("lambdaTakesResultThroughBridge.kt")
+            public void testLambdaTakesResultThroughBridge() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/lambdaTakesResultThroughBridge.kt");
+            }
+        }
+
+        @Nested
         @TestMetadata("compiler/testData/codegen/box/inlineClasses/returnResult")
         @TestDataPath("$PROJECT_ROOT")
         public class ReturnResult {

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -20173,6 +20173,52 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         }
 
         @Nested
+        @TestMetadata("compiler/testData/codegen/box/inlineClasses/result")
+        @TestDataPath("$PROJECT_ROOT")
+        public class Result {
+            @Test
+            public void testAllFilesPresentInResult() throws Exception {
+                KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/inlineClasses/result"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+            }
+
+            @Test
+            @TestMetadata("directCall1.kt")
+            public void testDirectCall1() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/directCall1.kt");
+            }
+
+            @Test
+            @TestMetadata("directCall2.kt")
+            public void testDirectCall2() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/directCall2.kt");
+            }
+
+            @Test
+            @TestMetadata("doubleOverride.kt")
+            public void testDoubleOverride() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/doubleOverride.kt");
+            }
+
+            @Test
+            @TestMetadata("extensionOverride.kt")
+            public void testExtensionOverride() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/extensionOverride.kt");
+            }
+
+            @Test
+            @TestMetadata("inlineMethodOnResult.kt")
+            public void testInlineMethodOnResult() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/inlineMethodOnResult.kt");
+            }
+
+            @Test
+            @TestMetadata("lambdaTakesResultThroughBridge.kt")
+            public void testLambdaTakesResultThroughBridge() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/lambdaTakesResultThroughBridge.kt");
+            }
+        }
+
+        @Nested
         @TestMetadata("compiler/testData/codegen/box/inlineClasses/returnResult")
         @TestDataPath("$PROJECT_ROOT")
         public class ReturnResult {

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -16765,6 +16765,49 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             }
         }
 
+        @TestMetadata("compiler/testData/codegen/box/inlineClasses/result")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class Result extends AbstractLightAnalysisModeTest {
+            @TestMetadata("directCall1.kt")
+            public void ignoreDirectCall1() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/directCall1.kt");
+            }
+
+            @TestMetadata("directCall2.kt")
+            public void ignoreDirectCall2() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/directCall2.kt");
+            }
+
+            @TestMetadata("doubleOverride.kt")
+            public void ignoreDoubleOverride() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/doubleOverride.kt");
+            }
+
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInResult() throws Exception {
+                KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/inlineClasses/result"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM, true);
+            }
+
+            @TestMetadata("extensionOverride.kt")
+            public void testExtensionOverride() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/extensionOverride.kt");
+            }
+
+            @TestMetadata("inlineMethodOnResult.kt")
+            public void testInlineMethodOnResult() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/inlineMethodOnResult.kt");
+            }
+
+            @TestMetadata("lambdaTakesResultThroughBridge.kt")
+            public void testLambdaTakesResultThroughBridge() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/lambdaTakesResultThroughBridge.kt");
+            }
+        }
+
         @TestMetadata("compiler/testData/codegen/box/inlineClasses/returnResult")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
@@ -14709,6 +14709,49 @@ public class IrJsCodegenBoxES6TestGenerated extends AbstractIrJsCodegenBoxES6Tes
             }
         }
 
+        @TestMetadata("compiler/testData/codegen/box/inlineClasses/result")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class Result extends AbstractIrJsCodegenBoxES6Test {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest0(this::doTest, TargetBackend.JS_IR_ES6, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInResult() throws Exception {
+                KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/inlineClasses/result"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR_ES6, true);
+            }
+
+            @TestMetadata("directCall1.kt")
+            public void testDirectCall1() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/directCall1.kt");
+            }
+
+            @TestMetadata("directCall2.kt")
+            public void testDirectCall2() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/directCall2.kt");
+            }
+
+            @TestMetadata("doubleOverride.kt")
+            public void testDoubleOverride() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/doubleOverride.kt");
+            }
+
+            @TestMetadata("extensionOverride.kt")
+            public void testExtensionOverride() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/extensionOverride.kt");
+            }
+
+            @TestMetadata("inlineMethodOnResult.kt")
+            public void testInlineMethodOnResult() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/inlineMethodOnResult.kt");
+            }
+
+            @TestMetadata("lambdaTakesResultThroughBridge.kt")
+            public void testLambdaTakesResultThroughBridge() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/lambdaTakesResultThroughBridge.kt");
+            }
+        }
+
         @TestMetadata("compiler/testData/codegen/box/inlineClasses/returnResult")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -14115,6 +14115,49 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             }
         }
 
+        @TestMetadata("compiler/testData/codegen/box/inlineClasses/result")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class Result extends AbstractIrJsCodegenBoxTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest0(this::doTest, TargetBackend.JS_IR, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInResult() throws Exception {
+                KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/inlineClasses/result"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR, true);
+            }
+
+            @TestMetadata("directCall1.kt")
+            public void testDirectCall1() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/directCall1.kt");
+            }
+
+            @TestMetadata("directCall2.kt")
+            public void testDirectCall2() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/directCall2.kt");
+            }
+
+            @TestMetadata("doubleOverride.kt")
+            public void testDoubleOverride() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/doubleOverride.kt");
+            }
+
+            @TestMetadata("extensionOverride.kt")
+            public void testExtensionOverride() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/extensionOverride.kt");
+            }
+
+            @TestMetadata("inlineMethodOnResult.kt")
+            public void testInlineMethodOnResult() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/inlineMethodOnResult.kt");
+            }
+
+            @TestMetadata("lambdaTakesResultThroughBridge.kt")
+            public void testLambdaTakesResultThroughBridge() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/lambdaTakesResultThroughBridge.kt");
+            }
+        }
+
         @TestMetadata("compiler/testData/codegen/box/inlineClasses/returnResult")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -14180,6 +14180,49 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             }
         }
 
+        @TestMetadata("compiler/testData/codegen/box/inlineClasses/result")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class Result extends AbstractJsCodegenBoxTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest0(this::doTest, TargetBackend.JS, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInResult() throws Exception {
+                KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/inlineClasses/result"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS, true);
+            }
+
+            @TestMetadata("directCall1.kt")
+            public void testDirectCall1() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/directCall1.kt");
+            }
+
+            @TestMetadata("directCall2.kt")
+            public void testDirectCall2() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/directCall2.kt");
+            }
+
+            @TestMetadata("doubleOverride.kt")
+            public void testDoubleOverride() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/doubleOverride.kt");
+            }
+
+            @TestMetadata("extensionOverride.kt")
+            public void testExtensionOverride() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/extensionOverride.kt");
+            }
+
+            @TestMetadata("inlineMethodOnResult.kt")
+            public void testInlineMethodOnResult() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/inlineMethodOnResult.kt");
+            }
+
+            @TestMetadata("lambdaTakesResultThroughBridge.kt")
+            public void testLambdaTakesResultThroughBridge() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/lambdaTakesResultThroughBridge.kt");
+            }
+        }
+
         @TestMetadata("compiler/testData/codegen/box/inlineClasses/returnResult")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/wasm/semantics/IrCodegenBoxWasmTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/wasm/semantics/IrCodegenBoxWasmTestGenerated.java
@@ -8045,6 +8045,49 @@ public class IrCodegenBoxWasmTestGenerated extends AbstractIrCodegenBoxWasmTest 
             }
         }
 
+        @TestMetadata("compiler/testData/codegen/box/inlineClasses/result")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class Result extends AbstractIrCodegenBoxWasmTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest0(this::doTest, TargetBackend.WASM, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInResult() throws Exception {
+                KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/inlineClasses/result"), Pattern.compile("^([^_](.+))\\.kt$"), null, TargetBackend.WASM, true);
+            }
+
+            @TestMetadata("directCall1.kt")
+            public void testDirectCall1() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/directCall1.kt");
+            }
+
+            @TestMetadata("directCall2.kt")
+            public void testDirectCall2() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/directCall2.kt");
+            }
+
+            @TestMetadata("doubleOverride.kt")
+            public void testDoubleOverride() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/doubleOverride.kt");
+            }
+
+            @TestMetadata("extensionOverride.kt")
+            public void testExtensionOverride() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/extensionOverride.kt");
+            }
+
+            @TestMetadata("inlineMethodOnResult.kt")
+            public void testInlineMethodOnResult() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/inlineMethodOnResult.kt");
+            }
+
+            @TestMetadata("lambdaTakesResultThroughBridge.kt")
+            public void testLambdaTakesResultThroughBridge() throws Exception {
+                runTest("compiler/testData/codegen/box/inlineClasses/result/lambdaTakesResultThroughBridge.kt");
+            }
+        }
+
         @TestMetadata("compiler/testData/codegen/box/inlineClasses/returnResult")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)


### PR DESCRIPTION
Note some `IGNORE_BACKEND: WASM`, especially in the test for KT-46890.

#KT-46890 Fixed

cc @sfs 