### PR TITLE
 FIR IDE: Enable add initializer quickfix for MUST_BE_INITIALIZED

### DIFF
--- a/idea/idea-fir/src/org/jetbrains/kotlin/idea/core/overrideImplement/KtImplementMembersHandler.kt
+++ b/idea/idea-fir/src/org/jetbrains/kotlin/idea/core/overrideImplement/KtImplementMembersHandler.kt
@@ -120,19 +120,19 @@ internal class KtImplementAsConstructorParameterQuickfix(private val members: Co
 
 object MemberNotImplementedQuickfixFactories {
 
-    val abstractMemberNotImplemented = diagnosticFixFactory<KtFirDiagnostic.AbstractMemberNotImplemented> { diagnostic ->
+    val abstractMemberNotImplemented = diagnosticFixFactory(KtFirDiagnostic.AbstractMemberNotImplemented::class) { diagnostic ->
         getUnimplementedMemberFixes(diagnostic.psi)
     }
 
-    val abstractClassMemberNotImplemented = diagnosticFixFactory<KtFirDiagnostic.AbstractClassMemberNotImplemented> { diagnostic ->
+    val abstractClassMemberNotImplemented = diagnosticFixFactory(KtFirDiagnostic.AbstractClassMemberNotImplemented::class) { diagnostic ->
         getUnimplementedMemberFixes(diagnostic.psi)
     }
 
-    val manyInterfacesMemberNotImplemented = diagnosticFixFactory<KtFirDiagnostic.ManyInterfacesMemberNotImplemented> { diagnostic ->
+    val manyInterfacesMemberNotImplemented = diagnosticFixFactory(KtFirDiagnostic.ManyInterfacesMemberNotImplemented::class) { diagnostic ->
         getUnimplementedMemberFixes(diagnostic.psi)
     }
 
-    val manyImplMemberNotImplemented = diagnosticFixFactory<KtFirDiagnostic.ManyImplMemberNotImplemented> { diagnostic ->
+    val manyImplMemberNotImplemented = diagnosticFixFactory(KtFirDiagnostic.ManyImplMemberNotImplemented::class) { diagnostic ->
         getUnimplementedMemberFixes(diagnostic.psi, false)
     }
 

--- a/idea/idea-fir/src/org/jetbrains/kotlin/idea/fir/api/fixes/KtQuickFixesList.kt
+++ b/idea/idea-fir/src/org/jetbrains/kotlin/idea/fir/api/fixes/KtQuickFixesList.kt
@@ -64,13 +64,6 @@ class KtQuickFixesListBuilder private constructor() {
         }
     }
 
-    @OptIn(PrivateForInline::class)
-    inline fun <reified DIAGNOSTIC : KtDiagnosticWithPsi<*>> registerApplicator(
-        quickFixFactory: HLDiagnosticFixFactory<DIAGNOSTIC>
-    ) {
-        registerApplicator(DIAGNOSTIC::class, quickFixFactory)
-    }
-
     @PrivateForInline
     fun <DIAGNOSTIC_PSI : PsiElement, DIAGNOSTIC : KtDiagnosticWithPsi<DIAGNOSTIC_PSI>> registerPsiQuickFix(
         diagnosticClass: KClass<DIAGNOSTIC>,
@@ -79,13 +72,18 @@ class KtQuickFixesListBuilder private constructor() {
         quickFixes.getOrPut(diagnosticClass) { mutableListOf() }.add(HLQuickFixFactory.HLQuickFixesPsiBasedFactory(quickFixFactory))
     }
 
-
-    @PrivateForInline
-    fun <DIAGNOSTIC : KtDiagnosticWithPsi<*>> registerApplicator(
-        diagnosticClass: KClass<DIAGNOSTIC>,
-        quickFixFactory: HLDiagnosticFixFactory<DIAGNOSTIC>
+    @OptIn(PrivateForInline::class)
+    fun <DIAGNOSTIC : KtDiagnosticWithPsi<*>> registerApplicators(
+        quickFixFactories: Collection<HLDiagnosticFixFactory<out DIAGNOSTIC>>
     ) {
-        quickFixes.getOrPut(diagnosticClass) { mutableListOf() }
+        quickFixFactories.forEach(::registerApplicator)
+    }
+
+    @OptIn(PrivateForInline::class)
+    fun <DIAGNOSTIC : KtDiagnosticWithPsi<*>> registerApplicator(
+        quickFixFactory: HLDiagnosticFixFactory<out DIAGNOSTIC>
+    ) {
+        quickFixes.getOrPut(quickFixFactory.diagnosticClass) { mutableListOf() }
             .add(HLQuickFixFactory.HLApplicatorBasedFactory(quickFixFactory))
     }
 

--- a/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/MainKtQuickFixRegistrar.kt
+++ b/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/MainKtQuickFixRegistrar.kt
@@ -11,7 +11,6 @@ import org.jetbrains.kotlin.idea.fir.api.fixes.KtQuickFixesList
 import org.jetbrains.kotlin.idea.fir.api.fixes.KtQuickFixesListBuilder
 import org.jetbrains.kotlin.idea.frontend.api.fir.diagnostics.KtFirDiagnostic
 import org.jetbrains.kotlin.idea.quickfix.fixes.*
-import org.jetbrains.kotlin.idea.quickfix.fixes.InitializePropertyQuickFixFactory
 
 class MainKtQuickFixRegistrar : KtQuickFixRegistrar() {
     private val keywords = KtQuickFixesListBuilder.registerPsiQuickFix {
@@ -74,7 +73,7 @@ class MainKtQuickFixRegistrar : KtQuickFixRegistrar() {
             KtFirDiagnostic.MustBeInitializedOrBeAbstract::class,
             AddModifierFix.addAbstractModifier,
         )
-        registerApplicator(InitializePropertyQuickFixFactory.initializePropertyFactory)
+        registerApplicators(InitializePropertyQuickFixFactories.initializePropertyFactory)
         registerApplicator(AddLateInitFactory.addLateInitFactory)
         registerApplicator(AddAccessorsFactories.addAccessorsToUninitializedProperty)
     }

--- a/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/fixes/AddAccessorsFactories.kt
+++ b/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/fixes/AddAccessorsFactories.kt
@@ -12,7 +12,7 @@ import org.jetbrains.kotlin.idea.intentions.fir.AddAccessorsIntention
 import org.jetbrains.kotlin.psi.KtProperty
 
 object AddAccessorsFactories {
-    val addAccessorsToUninitializedProperty = diagnosticFixFactory<KtFirDiagnostic.MustBeInitializedOrBeAbstract> { diagnostic ->
+    val addAccessorsToUninitializedProperty = diagnosticFixFactory(KtFirDiagnostic.MustBeInitializedOrBeAbstract::class) { diagnostic ->
         val property: KtProperty = diagnostic.psi
         val addGetter = property.getter == null
         val addSetter = property.isVar && property.setter == null

--- a/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/fixes/AddExclExclCallFixFactories.kt
+++ b/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/fixes/AddExclExclCallFixFactories.kt
@@ -17,15 +17,15 @@ import org.jetbrains.kotlin.psi.psiUtil.unwrapParenthesesLabelsAndAnnotations
 import org.jetbrains.kotlin.util.OperatorNameConventions
 
 object AddExclExclCallFixFactories {
-    val unsafeCallFactory = diagnosticFixFactory<KtFirDiagnostic.UnsafeCall> { diagnostic ->
+    val unsafeCallFactory = diagnosticFixFactory(KtFirDiagnostic.UnsafeCall::class) { diagnostic ->
         getFixForUnsafeCall(diagnostic.psi)
     }
 
-    val unsafeInfixCallFactory = diagnosticFixFactory<KtFirDiagnostic.UnsafeInfixCall> { diagnostic ->
+    val unsafeInfixCallFactory = diagnosticFixFactory(KtFirDiagnostic.UnsafeInfixCall::class) { diagnostic ->
         getFixForUnsafeCall(diagnostic.psi)
     }
 
-    val unsafeOperatorCallFactory = diagnosticFixFactory<KtFirDiagnostic.UnsafeOperatorCall> { diagnostic ->
+    val unsafeOperatorCallFactory = diagnosticFixFactory(KtFirDiagnostic.UnsafeOperatorCall::class) { diagnostic ->
         getFixForUnsafeCall(diagnostic.psi)
     }
 
@@ -82,7 +82,7 @@ object AddExclExclCallFixFactories {
         return listOfNotNull(target.asAddExclExclCallFix(hasImplicitReceiver = hasImplicitReceiver))
     }
 
-    val iteratorOnNullableFactory = diagnosticFixFactory<KtFirDiagnostic.IteratorOnNullable> { diagnostic ->
+    val iteratorOnNullableFactory = diagnosticFixFactory(KtFirDiagnostic.IteratorOnNullable::class) { diagnostic ->
         val expression = diagnostic.psi as? KtExpression ?: return@diagnosticFixFactory emptyList()
         val type = expression.getKtType()
         if (!type.canBeNull) return@diagnosticFixFactory emptyList()

--- a/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/fixes/AddLateInitFactory.kt
+++ b/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/fixes/AddLateInitFactory.kt
@@ -12,7 +12,7 @@ import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtProperty
 
 object AddLateInitFactory {
-    val addLateInitFactory = diagnosticFixFactory<KtFirDiagnostic.MustBeInitializedOrBeAbstract> { diagnostic ->
+    val addLateInitFactory = diagnosticFixFactory(KtFirDiagnostic.MustBeInitializedOrBeAbstract::class) { diagnostic ->
         val property: KtProperty = diagnostic.psi
         if (!property.isVar) return@diagnosticFixFactory emptyList()
 

--- a/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/fixes/ChangeTypeQuickFixFactories.kt
+++ b/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/fixes/ChangeTypeQuickFixFactories.kt
@@ -118,14 +118,14 @@ object ChangeTypeQuickFixFactories {
         }
 
     val returnTypeMismatch =
-        diagnosticFixFactory<KtFirDiagnostic.ReturnTypeMismatch, KtCallableDeclaration, Input>(applicator) { diagnostic ->
+        diagnosticFixFactory(KtFirDiagnostic.ReturnTypeMismatch::class, applicator) { diagnostic ->
             val function = diagnostic.targetFunction.psi as? KtCallableDeclaration ?: return@diagnosticFixFactory emptyList()
             listOf(function withInput Input(TargetType.ENCLOSING_DECLARATION, createTypeInfo(diagnostic.actualType)))
         }
 
     @OptIn(ExperimentalStdlibApi::class)
     val componentFunctionReturnTypeMismatch =
-        diagnosticFixFactory<KtFirDiagnostic.ComponentFunctionReturnTypeMismatch, KtCallableDeclaration, Input>(applicator) { diagnostic ->
+        diagnosticFixFactory(KtFirDiagnostic.ComponentFunctionReturnTypeMismatch::class, applicator) { diagnostic ->
             val entryWithWrongType =
                 getDestructuringDeclarationEntryThatTypeMismatchComponentFunction(
                     diagnostic.componentFunctionName,
@@ -143,9 +143,9 @@ object ChangeTypeQuickFixFactories {
             }
         }
 
-    private inline fun <DIAGNOSTIC : KtDiagnosticWithPsi<KtNamedDeclaration>> changeReturnTypeOnOverride(
+    private inline fun <reified DIAGNOSTIC : KtDiagnosticWithPsi<KtNamedDeclaration>> changeReturnTypeOnOverride(
         crossinline getCallableSymbol: (DIAGNOSTIC) -> KtCallableSymbol?
-    ) = diagnosticFixFactory<DIAGNOSTIC, KtCallableDeclaration, Input>(applicator) { diagnostic ->
+    ) = diagnosticFixFactory(DIAGNOSTIC::class, applicator) { diagnostic ->
         val declaration = diagnostic.psi as? KtCallableDeclaration ?: return@diagnosticFixFactory emptyList()
         val callable = getCallableSymbol(diagnostic) ?: return@diagnosticFixFactory emptyList()
         listOfNotNull(

--- a/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/fixes/ImportQuickFix.kt
+++ b/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/fixes/ImportQuickFix.kt
@@ -134,7 +134,7 @@ internal class ImportQuickFix(
     }
 
     internal companion object {
-        val FACTORY = diagnosticFixFactory<KtFirDiagnostic.UnresolvedReference> { diagnostic ->
+        val FACTORY = diagnosticFixFactory(KtFirDiagnostic.UnresolvedReference::class) { diagnostic ->
             val element = diagnostic.psi
 
             val indexHelper = IndexHelper(element.project, createSearchScope(element))

--- a/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/fixes/InitializePropertyQuickFixFactory.kt
+++ b/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/fixes/InitializePropertyQuickFixFactory.kt
@@ -38,7 +38,7 @@ object InitializePropertyQuickFixFactory {
 
     @OptIn(ExperimentalStdlibApi::class)
     val initializePropertyFactory =
-        diagnosticFixFactory<KtFirDiagnostic.MustBeInitializedOrBeAbstract> { diagnostic ->
+        diagnosticFixFactory(KtFirDiagnostic.MustBeInitializedOrBeAbstract::class) { diagnostic ->
             val property: KtProperty = diagnostic.psi
             buildList {
                 add(

--- a/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/fixes/ReplaceCallFixFactories.kt
+++ b/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/fixes/ReplaceCallFixFactories.kt
@@ -22,7 +22,7 @@ import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 
 object ReplaceCallFixFactories {
     val unsafeCallFactory =
-        diagnosticFixFactory<KtFirDiagnostic.UnsafeCall> { diagnostic ->
+        diagnosticFixFactory(KtFirDiagnostic.UnsafeCall::class) { diagnostic ->
             val psi = diagnostic.psi
             val target = if (psi is KtBinaryExpression && psi.operationToken in KtTokens.ALL_ASSIGNMENTS) {
                 // UNSAFE_CALL for assignments (e.g., `foo.bar = value`) is reported on the entire statement (KtBinaryExpression).
@@ -48,14 +48,14 @@ object ReplaceCallFixFactories {
         }
 
     val unsafeInfixCallFactory =
-        diagnosticFixFactory<KtFirDiagnostic.UnsafeInfixCall> { diagnostic ->
+        diagnosticFixFactory(KtFirDiagnostic.UnsafeInfixCall::class) { diagnostic ->
             val psi = diagnostic.psi
             val target = psi.parent as? KtBinaryExpression ?: return@diagnosticFixFactory emptyList()
             listOf(ReplaceInfixOrOperatorCallFix(target, shouldHaveNotNullType(target), diagnostic.operator))
         }
 
     val unsafeOperatorCallFactory =
-        diagnosticFixFactory<KtFirDiagnostic.UnsafeOperatorCall> { diagnostic ->
+        diagnosticFixFactory(KtFirDiagnostic.UnsafeOperatorCall::class) { diagnostic ->
             val psi = diagnostic.psi
             val operationToken = psi.safeAs<KtOperationReferenceExpression>()?.getReferencedNameElementType()
             if (operationToken == KtTokens.EQ || operationToken in OperatorConventions.COMPARISON_OPERATIONS) {
@@ -68,7 +68,7 @@ object ReplaceCallFixFactories {
         }
 
     val unsafeImplicitInvokeCallFactory =
-        diagnosticFixFactory<KtFirDiagnostic.UnsafeImplicitInvokeCall> { diagnostic ->
+        diagnosticFixFactory(KtFirDiagnostic.UnsafeImplicitInvokeCall::class) { diagnostic ->
             val target = diagnostic.psi as? KtNameReferenceExpression ?: return@diagnosticFixFactory emptyList()
 
             val callExpression = target.parent as? KtCallExpression ?: return@diagnosticFixFactory emptyList()

--- a/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/fixes/TypeMismatchFactories.kt
+++ b/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/fixes/TypeMismatchFactories.kt
@@ -14,11 +14,11 @@ import org.jetbrains.kotlin.idea.frontend.api.types.KtType
 import org.jetbrains.kotlin.idea.frontend.api.types.KtTypeNullability
 
 object TypeMismatchFactories {
-    val argumentTypeMismatchFactory = diagnosticFixFactory<KtFirDiagnostic.ArgumentTypeMismatch> { diagnostic ->
+    val argumentTypeMismatchFactory = diagnosticFixFactory(KtFirDiagnostic.ArgumentTypeMismatch::class) { diagnostic ->
         getFixesForTypeMismatch(diagnostic.psi, diagnostic.expectedType, diagnostic.actualType)
     }
 
-    val returnTypeMismatchFactory = diagnosticFixFactory<KtFirDiagnostic.ReturnTypeMismatch> { diagnostic ->
+    val returnTypeMismatchFactory = diagnosticFixFactory(KtFirDiagnostic.ReturnTypeMismatch::class) { diagnostic ->
         getFixesForTypeMismatch(diagnostic.psi, diagnostic.expectedType, diagnostic.actualType)
     }
 

--- a/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/fixes/WrapWithSafeLetCallFixFactories.kt
+++ b/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/fixes/WrapWithSafeLetCallFixFactories.kt
@@ -140,12 +140,12 @@ object WrapWithSafeLetCallFixFactories {
         }
     }
 
-    val forUnsafeCall = diagnosticFixFactory<KtFirDiagnostic.UnsafeCall> { diagnostic ->
+    val forUnsafeCall = diagnosticFixFactory(KtFirDiagnostic.UnsafeCall::class) { diagnostic ->
         val nullableExpression = diagnostic.receiverExpression
         createWrapWithSafeLetCallInputForNullableExpressionIfMoreThanImmediateParentIsWrapped(nullableExpression)
     }
 
-    val forUnsafeImplicitInvokeCall = diagnosticFixFactory<KtFirDiagnostic.UnsafeImplicitInvokeCall> { diagnostic ->
+    val forUnsafeImplicitInvokeCall = diagnosticFixFactory(KtFirDiagnostic.UnsafeImplicitInvokeCall::class) { diagnostic ->
         val callExpression = diagnostic.psi.parentOfType<KtCallExpression>(withSelf = true) ?: return@diagnosticFixFactory emptyList()
         val callingFunctionalVariableInLocalScope =
             isCallingFunctionalTypeVariableInLocalScope(callExpression) ?: return@diagnosticFixFactory emptyList()
@@ -164,15 +164,15 @@ object WrapWithSafeLetCallFixFactories {
         return localScope.scopes.getCallableSymbols { it.identifierOrNullIfSpecial == calleeName }.any { it == functionalVariableSymbol }
     }
 
-    val forUnsafeInfixCall = diagnosticFixFactory<KtFirDiagnostic.UnsafeInfixCall> { diagnostic ->
+    val forUnsafeInfixCall = diagnosticFixFactory(KtFirDiagnostic.UnsafeInfixCall::class) { diagnostic ->
         createWrapWithSafeLetCallInputForNullableExpressionIfMoreThanImmediateParentIsWrapped(diagnostic.receiverExpression)
     }
 
-    val forUnsafeOperatorCall = diagnosticFixFactory<KtFirDiagnostic.UnsafeOperatorCall> { diagnostic ->
+    val forUnsafeOperatorCall = diagnosticFixFactory(KtFirDiagnostic.UnsafeOperatorCall::class) { diagnostic ->
         createWrapWithSafeLetCallInputForNullableExpressionIfMoreThanImmediateParentIsWrapped(diagnostic.receiverExpression)
     }
 
-    val forArgumentTypeMismatch = diagnosticFixFactory<KtFirDiagnostic.ArgumentTypeMismatch> { diagnostic ->
+    val forArgumentTypeMismatch = diagnosticFixFactory(KtFirDiagnostic.ArgumentTypeMismatch::class) { diagnostic ->
         if (diagnostic.isMismatchDueToNullability) createWrapWithSafeLetCallInputForNullableExpression(diagnostic.psi.wrappingExpressionOrSelf)
         else emptyList()
     }

--- a/idea/testData/quickfix/addInitializer/memberPropertyVarGetterOnly.kt
+++ b/idea/testData/quickfix/addInitializer/memberPropertyVarGetterOnly.kt
@@ -3,4 +3,3 @@ class A {
     <caret>var n: Int
         get() = 1
 }
-/* IGNORE_FIR */

--- a/idea/testData/quickfix/addInitializer/memberPropertyVarGetterOnly.kt.after
+++ b/idea/testData/quickfix/addInitializer/memberPropertyVarGetterOnly.kt.after
@@ -3,4 +3,3 @@ class A {
     var n: Int = <selection>0</selection><caret>
         get() = 1
 }
-/* IGNORE_FIR */

--- a/idea/testData/quickfix/addInitializer/memberPropertyVarSetterOnly.kt
+++ b/idea/testData/quickfix/addInitializer/memberPropertyVarSetterOnly.kt
@@ -3,4 +3,3 @@ class A {
     <caret>var n: Int
         set(value: Int) {}
 }
-/* IGNORE_FIR */

--- a/idea/testData/quickfix/addInitializer/memberPropertyVarSetterOnly.kt.after
+++ b/idea/testData/quickfix/addInitializer/memberPropertyVarSetterOnly.kt.after
@@ -3,4 +3,3 @@ class A {
     var n: Int = <selection>0</selection><caret>
         set(value: Int) {}
 }
-/* IGNORE_FIR */

--- a/idea/testData/quickfix/addInitializer/topLevelProperty.kt
+++ b/idea/testData/quickfix/addInitializer/topLevelProperty.kt
@@ -1,3 +1,2 @@
 // "Add initializer" "true"
 <caret>val n: Int
-/* IGNORE_FIR */

--- a/idea/testData/quickfix/addInitializer/topLevelProperty.kt.after
+++ b/idea/testData/quickfix/addInitializer/topLevelProperty.kt.after
@@ -1,3 +1,2 @@
 // "Add initializer" "true"
 val n: Int = <selection>0</selection><caret>
-/* IGNORE_FIR */

--- a/idea/testData/quickfix/addInitializer/topLevelPropertyVarClass.kt
+++ b/idea/testData/quickfix/addInitializer/topLevelPropertyVarClass.kt
@@ -2,4 +2,3 @@
 // WITH_RUNTIME
 class A
 <caret>var label: A
-/* IGNORE_FIR */

--- a/idea/testData/quickfix/addInitializer/topLevelPropertyVarClass.kt.after
+++ b/idea/testData/quickfix/addInitializer/topLevelPropertyVarClass.kt.after
@@ -2,4 +2,3 @@
 // WITH_RUNTIME
 class A
 var label: A = TODO()
-/* IGNORE_FIR */

--- a/idea/testData/quickfix/addInitializer/topLevelPropertyVarGetterOnly.kt
+++ b/idea/testData/quickfix/addInitializer/topLevelPropertyVarGetterOnly.kt
@@ -1,4 +1,3 @@
 // "Add initializer" "true"
 <caret>var n: Int
     get() = 1
-/* IGNORE_FIR */

--- a/idea/testData/quickfix/addInitializer/topLevelPropertyVarGetterOnly.kt.after
+++ b/idea/testData/quickfix/addInitializer/topLevelPropertyVarGetterOnly.kt.after
@@ -1,4 +1,3 @@
 // "Add initializer" "true"
 var n: Int = <selection>0</selection><caret>
     get() = 1
-/* IGNORE_FIR */

--- a/idea/testData/quickfix/addInitializer/topLevelPropertyVarSetterOnly.kt
+++ b/idea/testData/quickfix/addInitializer/topLevelPropertyVarSetterOnly.kt
@@ -1,4 +1,3 @@
 // "Add initializer" "true"
 <caret>var n: Int
     set(value: Int) {}
-/* IGNORE_FIR */

--- a/idea/testData/quickfix/addInitializer/topLevelPropertyVarSetterOnly.kt.after
+++ b/idea/testData/quickfix/addInitializer/topLevelPropertyVarSetterOnly.kt.after
@@ -1,4 +1,3 @@
 // "Add initializer" "true"
 var n: Int = <selection>0</selection><caret>
     set(value: Int) {}
-/* IGNORE_FIR */


### PR DESCRIPTION
1st commit allows sharing of quickfix creation logic across multiple diagnostics with the same PSI (in this case, `MUST_BE_INITIALIZED` and `MUST_BE_INITIALIZED_OR_BE_ABSTRACT`).