### PR TITLE
FIR IDE: AddWhenRemainingBranchFix

### DIFF
--- a/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsTestGenerated.java
@@ -5662,6 +5662,12 @@ public class FirOldFrontendDiagnosticsTestGenerated extends AbstractFirDiagnosti
             }
 
             @Test
+            @TestMetadata("whenWithNothingTypedSubject.kt")
+            public void testWhenWithNothingTypedSubject() throws Exception {
+                runTest("compiler/testData/diagnostics/tests/controlStructures/whenWithNothingTypedSubject.kt");
+            }
+
+            @Test
             @TestMetadata("when.kt234.kt973.kt")
             public void testWhen_kt234_kt973() throws Exception {
                 runTest("compiler/testData/diagnostics/tests/controlStructures/when.kt234.kt973.kt");

--- a/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsWithLightTreeTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsWithLightTreeTestGenerated.java
@@ -5662,6 +5662,12 @@ public class FirOldFrontendDiagnosticsWithLightTreeTestGenerated extends Abstrac
             }
 
             @Test
+            @TestMetadata("whenWithNothingTypedSubject.kt")
+            public void testWhenWithNothingTypedSubject() throws Exception {
+                runTest("compiler/testData/diagnostics/tests/controlStructures/whenWithNothingTypedSubject.kt");
+            }
+
+            @Test
             @TestMetadata("when.kt234.kt973.kt")
             public void testWhen_kt234_kt973() throws Exception {
                 runTest("compiler/testData/diagnostics/tests/controlStructures/when.kt234.kt973.kt");

--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrVisitor.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrVisitor.kt
@@ -646,7 +646,7 @@ class Fir2IrVisitor(
                         it.condition !is FirElseIfTrueCondition || it.result.statements.isNotEmpty()
                     }?.toIrWhenBranch(whenExpression.typeRef)
                 }
-                if (whenExpression.isExhaustive && whenExpression.branches.none { it.condition is FirElseIfTrueCondition }) {
+                if (whenExpression.isProperlyExhaustive && whenExpression.branches.none { it.condition is FirElseIfTrueCondition }) {
                     val irResult = IrCallImpl(
                         startOffset, endOffset, irBuiltIns.nothingType,
                         irBuiltIns.noWhenBranchMatchedExceptionSymbol,
@@ -660,7 +660,7 @@ class Fir2IrVisitor(
                 generateWhen(
                     startOffset, endOffset, origin,
                     subjectVariable, irBranches,
-                    if (whenExpression.isExhaustive && whenExpression.branches.none {
+                    if (whenExpression.isProperlyExhaustive && whenExpression.branches.none {
                             it.condition is FirElseIfTrueCondition && it.result.statements.isEmpty()
                         }
                     ) whenExpression.typeRef.toIrType() else irBuiltIns.unitType

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/dfa/cfg/CFGNode.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/dfa/cfg/CFGNode.kt
@@ -369,7 +369,7 @@ class WhenBranchResultExitNode(owner: ControlFlowGraph, override val fir: FirWhe
 }
 class WhenSyntheticElseBranchNode(owner: ControlFlowGraph, override val fir: FirWhenExpression, level: Int, id: Int) : CFGNode<FirWhenExpression>(owner, level, id) {
     init {
-        assert(!fir.isExhaustive)
+        assert(!fir.isProperlyExhaustive)
     }
 
     override fun <R, D> accept(visitor: ControlFlowGraphVisitor<R, D>, data: D): R {

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/dfa/cfg/ControlFlowGraphBuilder.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/dfa/cfg/ControlFlowGraphBuilder.kt
@@ -631,7 +631,7 @@ class ControlFlowGraphBuilder {
         // exit from last condition node still on stack
         // we should remove it
         val lastWhenConditionExit = lastNodes.pop()
-        val syntheticElseBranchNode = if (!whenExpression.isExhaustive) {
+        val syntheticElseBranchNode = if (!whenExpression.isProperlyExhaustive) {
             createWhenSyntheticElseBranchNode(whenExpression).apply {
                 addEdge(lastWhenConditionExit, this)
                 addEdge(this, whenExitNode)

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirWhenExhaustivenessTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirWhenExhaustivenessTransformer.kt
@@ -33,6 +33,59 @@ class FirWhenExhaustivenessTransformer(private val bodyResolveComponents: BodyRe
             WhenOnEnumExhaustivenessChecker,
             WhenOnSealedClassExhaustivenessChecker
         )
+
+        @OptIn(ExperimentalStdlibApi::class)
+        fun computeAllMissingCases(session: FirSession, whenExpression: FirWhenExpression): List<WhenMissingCase> {
+            val subjectType = getSubjectType(session, whenExpression) ?: return emptyList()
+            return buildList {
+                for (type in subjectType.unwrapIntersectionType()) {
+                    val checkers = getCheckers(type, session)
+                    collectMissingCases(checkers, whenExpression, type, session)
+                }
+            }
+        }
+
+        private fun getSubjectType(session: FirSession, whenExpression: FirWhenExpression): ConeKotlinType? {
+            val subjectType = whenExpression.subjectVariable?.returnTypeRef?.coneType
+                ?: whenExpression.subject?.typeRef?.coneType
+                ?: return null
+
+            return subjectType.fullyExpandedType(session).lowerBoundIfFlexible()
+        }
+
+        private fun ConeKotlinType.unwrapIntersectionType(): Collection<ConeKotlinType> {
+            return (this as? ConeIntersectionType)?.intersectedTypes ?: listOf(this)
+        }
+
+
+        @OptIn(ExperimentalStdlibApi::class)
+        private fun getCheckers(
+            subjectType: ConeKotlinType,
+            session: FirSession
+        ): List<WhenExhaustivenessChecker> {
+            return buildList {
+                exhaustivenessCheckers.filterTo<WhenExhaustivenessChecker, MutableCollection<in WhenExhaustivenessChecker>>(this) {
+                    it.isApplicable(subjectType, session)
+                }
+                if (isNotEmpty() && subjectType.isMarkedNullable) {
+                    this.add(WhenOnNullableExhaustivenessChecker)
+                }
+            }
+        }
+
+        private fun MutableList<WhenMissingCase>.collectMissingCases(
+            checkers: List<WhenExhaustivenessChecker>,
+            whenExpression: FirWhenExpression,
+            subjectType: ConeKotlinType,
+            session: FirSession
+        ) {
+            for (checker in checkers) {
+                checker.computeMissingCases(whenExpression, subjectType, session, this)
+            }
+            if (isEmpty() && whenExpression.branches.isEmpty()) {
+                add(WhenMissingCase.Unknown)
+            }
+        }
     }
 
     override fun <E : FirElement> transformElement(element: E, data: Any?): E {
@@ -52,21 +105,17 @@ class FirWhenExhaustivenessTransformer(private val bodyResolveComponents: BodyRe
         }
 
         val session = bodyResolveComponents.session
-        val subjectType = (whenExpression.subjectVariable?.returnTypeRef?.coneType
-            ?: whenExpression.subject?.typeRef?.coneType)
-            ?.fullyExpandedType(session)?.lowerBoundIfFlexible()
-            ?: run {
-                whenExpression.replaceExhaustivenessStatus(ExhaustivenessStatus.NotExhaustive.NO_ELSE_BRANCH)
-                return
-            }
+        val subjectType = getSubjectType(session, whenExpression) ?: run {
+            whenExpression.replaceExhaustivenessStatus(ExhaustivenessStatus.NotExhaustive.NO_ELSE_BRANCH)
+            return
+        }
 
         if (whenExpression.branches.isEmpty() && subjectType.isNothing) {
             whenExpression.replaceExhaustivenessStatus(ExhaustivenessStatus.ExhaustiveAsNothing)
             return
         }
 
-        val unwrappedIntersectionTypes = (subjectType as? ConeIntersectionType)?.intersectedTypes ?: listOf(subjectType)
-
+        val unwrappedIntersectionTypes = subjectType.unwrapIntersectionType()
 
         var status: ExhaustivenessStatus = ExhaustivenessStatus.NotExhaustive.NO_ELSE_BRANCH
 
@@ -86,30 +135,18 @@ class FirWhenExhaustivenessTransformer(private val bodyResolveComponents: BodyRe
         whenExpression.replaceExhaustivenessStatus(status)
     }
 
-    @OptIn(ExperimentalStdlibApi::class)
     private fun computeStatusForNonIntersectionType(
         unwrappedSubjectType: ConeKotlinType,
         session: FirSession,
         whenExpression: FirWhenExpression,
     ): ExhaustivenessStatus {
-        val checkers = buildList {
-            exhaustivenessCheckers.filterTo(this) { it.isApplicable(unwrappedSubjectType, session) }
-            if (isNotEmpty() && unwrappedSubjectType.isMarkedNullable) {
-                add(WhenOnNullableExhaustivenessChecker)
-            }
-        }
-
+        val checkers = getCheckers(unwrappedSubjectType, session)
         if (checkers.isEmpty()) {
             return ExhaustivenessStatus.NotExhaustive.NO_ELSE_BRANCH
         }
 
         val whenMissingCases = mutableListOf<WhenMissingCase>()
-        for (checker in checkers) {
-            checker.computeMissingCases(whenExpression, unwrappedSubjectType, session, whenMissingCases)
-        }
-        if (whenMissingCases.isEmpty() && whenExpression.branches.isEmpty()) {
-            whenMissingCases.add(WhenMissingCase.Unknown)
-        }
+        whenMissingCases.collectMissingCases(checkers, whenExpression, unwrappedSubjectType, session)
 
         return if (whenMissingCases.isEmpty()) {
             ExhaustivenessStatus.ProperlyExhaustive

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirControlFlowStatementsResolveTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirControlFlowStatementsResolveTransformer.kt
@@ -96,7 +96,7 @@ class FirControlFlowStatementsResolveTransformer(transformer: FirBodyResolveTran
     }
 
     private fun FirWhenExpression.replaceReturnTypeIfNotExhaustive(): FirWhenExpression {
-        if (!isExhaustive) {
+        if (!isProperlyExhaustive) {
             resultType = resultType.resolvedTypeFromPrototype(session.builtinTypes.unitType.type)
         }
         return this

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/expressions/ExhaustivenessStatus.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/expressions/ExhaustivenessStatus.kt
@@ -8,7 +8,19 @@ package org.jetbrains.kotlin.fir.expressions
 import org.jetbrains.kotlin.diagnostics.WhenMissingCase
 
 sealed class ExhaustivenessStatus {
-    object Exhaustive : ExhaustivenessStatus()
+
+    /**
+     * This value is used if the subject has type other than `Nothing`, in which case it's literally exhaustive only if type's possible
+     * cases are properly covered.
+     */
+    object ProperlyExhaustive : ExhaustivenessStatus()
+
+    /**
+     *  This value is used if the subject has type `Nothing`, in which case even an empty `when` is considered exhaustive. Also, in this
+     *  case, a synthetic else branch is created.
+     */
+    object ExhaustiveAsNothing : ExhaustivenessStatus()
+
     class NotExhaustive(val reasons: List<WhenMissingCase>) : ExhaustivenessStatus() {
         companion object {
             val NO_ELSE_BRANCH = NotExhaustive(listOf(WhenMissingCase.Unknown))
@@ -18,4 +30,7 @@ sealed class ExhaustivenessStatus {
 
 
 val FirWhenExpression.isExhaustive: Boolean
-    get() = exhaustivenessStatus == ExhaustivenessStatus.Exhaustive
+    get() = exhaustivenessStatus == ExhaustivenessStatus.ProperlyExhaustive || exhaustivenessStatus == ExhaustivenessStatus.ExhaustiveAsNothing
+
+val FirWhenExpression.isProperlyExhaustive: Boolean
+    get() = exhaustivenessStatus == ExhaustivenessStatus.ProperlyExhaustive

--- a/compiler/testData/diagnostics/tests/controlStructures/whenWithNothingTypedSubject.kt
+++ b/compiler/testData/diagnostics/tests/controlStructures/whenWithNothingTypedSubject.kt
@@ -1,0 +1,9 @@
+// FIR_IDENTICAL
+// !DIAGNOSTICS: -UNREACHABLE_CODE
+
+typealias MyNothing = Nothing
+
+fun foo(n: Nothing, n2: MyNothing) {
+    val a: Unit = when(n) {}
+    val b: Unit = when(n2) {}
+}

--- a/compiler/testData/diagnostics/tests/controlStructures/whenWithNothingTypedSubject.txt
+++ b/compiler/testData/diagnostics/tests/controlStructures/whenWithNothingTypedSubject.txt
@@ -1,0 +1,4 @@
+package
+
+public fun foo(/*0*/ n: kotlin.Nothing, /*1*/ n2: MyNothing /* = kotlin.Nothing */): kotlin.Unit
+public typealias MyNothing = kotlin.Nothing

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/DiagnosticTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/DiagnosticTestGenerated.java
@@ -5668,6 +5668,12 @@ public class DiagnosticTestGenerated extends AbstractDiagnosticTest {
             }
 
             @Test
+            @TestMetadata("whenWithNothingTypedSubject.kt")
+            public void testWhenWithNothingTypedSubject() throws Exception {
+                runTest("compiler/testData/diagnostics/tests/controlStructures/whenWithNothingTypedSubject.kt");
+            }
+
+            @Test
             @TestMetadata("when.kt234.kt973.kt")
             public void testWhen_kt234_kt973() throws Exception {
                 runTest("compiler/testData/diagnostics/tests/controlStructures/when.kt234.kt973.kt");

--- a/generators/idea-generator/tests/org/jetbrains/kotlin/generators/tests/idea/GenerateTests.kt
+++ b/generators/idea-generator/tests/org/jetbrains/kotlin/generators/tests/idea/GenerateTests.kt
@@ -1092,6 +1092,7 @@ fun main(args: Array<String>) {
                 model("intentions/importAllMembers", pattern = pattern)
                 model("intentions/importMember", pattern = pattern)
                 model("intentions/convertToBlockBody", pattern = pattern)
+                model("intentions/addWhenRemainingBranches", pattern = pattern)
             }
 
             testClass<AbstractFirShortenRefsTest> {

--- a/idea/idea-fir/src/org/jetbrains/kotlin/idea/fir/intentions/HLAddWhenRemainingBranchesIntention.kt
+++ b/idea/idea-fir/src/org/jetbrains/kotlin/idea/fir/intentions/HLAddWhenRemainingBranchesIntention.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.idea.fir.intentions
+
+import org.jetbrains.kotlin.diagnostics.WhenMissingCase
+import org.jetbrains.kotlin.idea.fir.api.AbstractHLIntention
+import org.jetbrains.kotlin.idea.fir.api.applicator.HLApplicabilityRange
+import org.jetbrains.kotlin.idea.fir.api.applicator.HLApplicatorInputProvider
+import org.jetbrains.kotlin.idea.fir.api.applicator.inputProvider
+import org.jetbrains.kotlin.idea.fir.applicators.ApplicabilityRanges
+import org.jetbrains.kotlin.idea.quickfix.fixes.AddWhenRemainingBranchFixFactories
+import org.jetbrains.kotlin.psi.KtWhenExpression
+
+class HLAddWhenRemainingBranchesIntention : AbstractHLIntention<KtWhenExpression, AddWhenRemainingBranchFixFactories.Input>(
+    KtWhenExpression::class,
+    AddWhenRemainingBranchFixFactories.applicator
+) {
+    override val applicabilityRange: HLApplicabilityRange<KtWhenExpression> get() = ApplicabilityRanges.SELF
+
+    override val inputProvider: HLApplicatorInputProvider<KtWhenExpression, AddWhenRemainingBranchFixFactories.Input>
+        get() = inputProvider { element ->
+            // TODO: consider removing the condition below so that this intention also works if there is no else. Currently we only offer
+            //  this intention if there is an `else` branch so that it behaves identically with FE1.0 (because FE1.0 reports warnings for
+            //  non-exhaustive when, which then results in a quickfix).
+            if (element.entries.none { it.isElse }) return@inputProvider null
+            val whenMissingCases = element.getMissingCases().takeIf {
+                it.isNotEmpty() && it.singleOrNull() != WhenMissingCase.Unknown
+            } ?: return@inputProvider null
+            AddWhenRemainingBranchFixFactories.Input(whenMissingCases, null)
+        }
+}

--- a/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/MainKtQuickFixRegistrar.kt
+++ b/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/MainKtQuickFixRegistrar.kt
@@ -124,9 +124,6 @@ class MainKtQuickFixRegistrar : KtQuickFixRegistrar() {
         registerApplicator(TypeMismatchFactories.assignmentTypeMismatch)
         registerApplicator(TypeMismatchFactories.initializerTypeMismatch)
 
-        // TODO: NON_EXHAUSTIVE_WHEN[_ON_SEALED_CLASS] will be replaced in future. We need to register the fix for those diagnostics as well
-        registerPsiQuickFixes(KtFirDiagnostic.NoElseInWhen::class, AddWhenElseBranchFix)
-
         registerApplicator(WrapWithSafeLetCallFixFactories.forUnsafeCall)
         registerApplicator(WrapWithSafeLetCallFixFactories.forUnsafeImplicitInvokeCall)
         registerApplicator(WrapWithSafeLetCallFixFactories.forUnsafeInfixCall)
@@ -135,6 +132,12 @@ class MainKtQuickFixRegistrar : KtQuickFixRegistrar() {
 
         registerPsiQuickFixes(KtFirDiagnostic.NullableSupertype::class, RemoveNullableFix.removeForSuperType)
         registerPsiQuickFixes(KtFirDiagnostic.InapplicableLateinitModifier::class, RemoveNullableFix.removeForLateInitProperty)
+    }
+
+    private val whenStatements = KtQuickFixesListBuilder.registerPsiQuickFix {
+        // TODO: NON_EXHAUSTIVE_WHEN[_ON_SEALED_CLASS] will be replaced in future. We need to register the fix for those diagnostics as well
+        registerPsiQuickFixes(KtFirDiagnostic.NoElseInWhen::class, AddWhenElseBranchFix)
+        registerApplicator(AddWhenRemainingBranchFixFactories.noElseInWhen)
     }
 
     private val typeMismatch = KtQuickFixesListBuilder.registerPsiQuickFix {
@@ -156,6 +159,7 @@ class MainKtQuickFixRegistrar : KtQuickFixRegistrar() {
         imports,
         mutability,
         expressions,
+        whenStatements,
         typeMismatch
     )
 }

--- a/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/fixes/AddWhenRemainingBranchFixFactories.kt
+++ b/idea/idea-fir/src/org/jetbrains/kotlin/idea/quickfix/fixes/AddWhenRemainingBranchFixFactories.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.idea.quickfix.fixes
+
+import org.jetbrains.kotlin.diagnostics.WhenMissingCase
+import org.jetbrains.kotlin.idea.KotlinBundle
+import org.jetbrains.kotlin.idea.api.applicator.HLApplicator
+import org.jetbrains.kotlin.idea.api.applicator.HLApplicatorInput
+import org.jetbrains.kotlin.idea.api.applicator.applicator
+import org.jetbrains.kotlin.idea.fir.api.fixes.HLQuickFix
+import org.jetbrains.kotlin.idea.fir.api.fixes.diagnosticFixFactory
+import org.jetbrains.kotlin.idea.frontend.api.analyse
+import org.jetbrains.kotlin.idea.frontend.api.components.ShortenOption
+import org.jetbrains.kotlin.idea.frontend.api.fir.diagnostics.KtFirDiagnostic
+import org.jetbrains.kotlin.idea.frontend.api.symbols.KtClassKind
+import org.jetbrains.kotlin.idea.frontend.api.tokens.HackToForceAllowRunningAnalyzeOnEDT
+import org.jetbrains.kotlin.idea.frontend.api.tokens.hackyAllowRunningOnEdt
+import org.jetbrains.kotlin.idea.util.generateWhenBranches
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.psi.KtWhenExpression
+
+object AddWhenRemainingBranchFixFactories {
+    class Input(val whenMissingCases: List<WhenMissingCase>, val enumToStarImport: ClassId?) : HLApplicatorInput
+
+    val applicator: HLApplicator<KtWhenExpression, Input> = getApplicator(false)
+    val applicatorUsingStarImport: HLApplicator<KtWhenExpression, Input> = getApplicator(true)
+
+    @OptIn(HackToForceAllowRunningAnalyzeOnEDT::class)
+    private fun getApplicator(useStarImport: Boolean = false) = applicator<KtWhenExpression, Input> {
+        familyAndActionName(
+            if (useStarImport) KotlinBundle.lazyMessage("fix.add.remaining.branches.with.star.import")
+            else KotlinBundle.lazyMessage("fix.add.remaining.branches")
+        )
+        applyTo { whenExpression, input ->
+            if (useStarImport) assert(input.enumToStarImport != null)
+            generateWhenBranches(whenExpression, input.whenMissingCases)
+            val shortenCommand = hackyAllowRunningOnEdt {
+                analyse(whenExpression) {
+                    collectPossibleReferenceShorteningsInElement(
+                        whenExpression,
+                        callableShortenOption = {
+                            if (useStarImport && it.callableIdIfNonLocal?.classId == input.enumToStarImport) {
+                                ShortenOption.SHORTEN_AND_STAR_IMPORT
+                            } else {
+                                ShortenOption.DO_NOT_SHORTEN
+                            }
+                        })
+
+                }
+            }
+            shortenCommand.invokeShortening()
+        }
+    }
+
+    @OptIn(ExperimentalStdlibApi::class)
+    val noElseInWhen = diagnosticFixFactory(KtFirDiagnostic.NoElseInWhen::class) { diagnostic ->
+        val whenExpression = diagnostic.psi
+        val subjectExpression = whenExpression.subjectExpression ?: return@diagnosticFixFactory emptyList()
+
+        buildList {
+            val missingCases = diagnostic.missingWhenCases.takeIf {
+                it.isNotEmpty() && it.singleOrNull() != WhenMissingCase.Unknown
+            } ?: return@buildList
+
+            add(HLQuickFix(whenExpression, Input(missingCases, null), applicator))
+            val baseClassSymbol = subjectExpression.getKtType().expandedClassSymbol ?: return@buildList
+            val enumToStarImport = baseClassSymbol.classIdIfNonLocal
+            if (baseClassSymbol.classKind == KtClassKind.ENUM_CLASS && enumToStarImport != null) {
+                add(HLQuickFix(whenExpression, Input(missingCases, enumToStarImport), applicatorUsingStarImport))
+            }
+        }
+    }
+}

--- a/idea/idea-fir/tests/org/jetbrains/kotlin/idea/fir/quickfix/HighLevelQuickFixTestGenerated.java
+++ b/idea/idea-fir/tests/org/jetbrains/kotlin/idea/fir/quickfix/HighLevelQuickFixTestGenerated.java
@@ -1946,6 +1946,21 @@ public class HighLevelQuickFixTestGenerated extends AbstractHighLevelQuickFixTes
             runTest("idea/testData/quickfix/when/addRemainingBranchesInNonDefaultPackage.kt");
         }
 
+        @TestMetadata("addRemainingBranchesMissingLeftBracket.kt")
+        public void testAddRemainingBranchesMissingLeftBracket() throws Exception {
+            runTest("idea/testData/quickfix/when/addRemainingBranchesMissingLeftBracket.kt");
+        }
+
+        @TestMetadata("addRemainingBranchesMissingRightBracket.kt")
+        public void testAddRemainingBranchesMissingRightBracket() throws Exception {
+            runTest("idea/testData/quickfix/when/addRemainingBranchesMissingRightBracket.kt");
+        }
+
+        @TestMetadata("addRemainingBranchesMissingRightParenthesis.kt")
+        public void testAddRemainingBranchesMissingRightParenthesis() throws Exception {
+            runTest("idea/testData/quickfix/when/addRemainingBranchesMissingRightParenthesis.kt");
+        }
+
         @TestMetadata("addRemainingBranchesSealed.kt")
         public void testAddRemainingBranchesSealed() throws Exception {
             runTest("idea/testData/quickfix/when/addRemainingBranchesSealed.kt");

--- a/idea/idea-frontend-api/src/org/jetbrains/kotlin/idea/frontend/api/components/KtExpressionInfoProvider.kt
+++ b/idea/idea-frontend-api/src/org/jetbrains/kotlin/idea/frontend/api/components/KtExpressionInfoProvider.kt
@@ -5,14 +5,19 @@
 
 package org.jetbrains.kotlin.idea.frontend.api.components
 
+import org.jetbrains.kotlin.diagnostics.WhenMissingCase
 import org.jetbrains.kotlin.idea.frontend.api.symbols.KtCallableSymbol
 import org.jetbrains.kotlin.psi.KtReturnExpression
+import org.jetbrains.kotlin.psi.KtWhenExpression
 
 abstract class KtExpressionInfoProvider : KtAnalysisSessionComponent() {
     abstract fun getReturnExpressionTargetSymbol(returnExpression: KtReturnExpression): KtCallableSymbol?
+    abstract fun getWhenMissingCases(whenExpression: KtWhenExpression): List<WhenMissingCase>
 }
 
 interface KtExpressionInfoProviderMixIn : KtAnalysisSessionMixIn {
     fun KtReturnExpression.getReturnTargetSymbol(): KtCallableSymbol? =
         analysisSession.expressionInfoProvider.getReturnExpressionTargetSymbol(this)
+
+    fun KtWhenExpression.getMissingCases(): List<WhenMissingCase> = analysisSession.expressionInfoProvider.getWhenMissingCases(this)
 }

--- a/idea/idea-frontend-fir/idea-fir-low-level-api/tests/org/jetbrains/kotlin/idea/fir/low/level/api/diagnostic/compiler/based/DiagnosisCompilerTestFE10TestdataTestGenerated.java
+++ b/idea/idea-frontend-fir/idea-fir-low-level-api/tests/org/jetbrains/kotlin/idea/fir/low/level/api/diagnostic/compiler/based/DiagnosisCompilerTestFE10TestdataTestGenerated.java
@@ -5662,6 +5662,12 @@ public class DiagnosisCompilerTestFE10TestdataTestGenerated extends AbstractDiag
             }
 
             @Test
+            @TestMetadata("whenWithNothingTypedSubject.kt")
+            public void testWhenWithNothingTypedSubject() throws Exception {
+                runTest("compiler/testData/diagnostics/tests/controlStructures/whenWithNothingTypedSubject.kt");
+            }
+
+            @Test
             @TestMetadata("when.kt234.kt973.kt")
             public void testWhen_kt234_kt973() throws Exception {
                 runTest("compiler/testData/diagnostics/tests/controlStructures/when.kt234.kt973.kt");

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/components/KtFirExpressionInfoProvider.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/components/KtFirExpressionInfoProvider.kt
@@ -5,13 +5,17 @@
 
 package org.jetbrains.kotlin.idea.frontend.api.fir.components
 
+import org.jetbrains.kotlin.diagnostics.WhenMissingCase
 import org.jetbrains.kotlin.fir.expressions.FirReturnExpression
+import org.jetbrains.kotlin.fir.expressions.FirWhenExpression
+import org.jetbrains.kotlin.fir.resolve.transformers.FirWhenExhaustivenessTransformer
 import org.jetbrains.kotlin.idea.fir.low.level.api.api.getOrBuildFirSafe
-import org.jetbrains.kotlin.idea.frontend.api.tokens.ValidityToken
 import org.jetbrains.kotlin.idea.frontend.api.components.KtExpressionInfoProvider
 import org.jetbrains.kotlin.idea.frontend.api.fir.KtFirAnalysisSession
 import org.jetbrains.kotlin.idea.frontend.api.symbols.KtCallableSymbol
+import org.jetbrains.kotlin.idea.frontend.api.tokens.ValidityToken
 import org.jetbrains.kotlin.psi.KtReturnExpression
+import org.jetbrains.kotlin.psi.KtWhenExpression
 
 internal class KtFirExpressionInfoProvider(
     override val analysisSession: KtFirAnalysisSession,
@@ -21,5 +25,10 @@ internal class KtFirExpressionInfoProvider(
         val fir = returnExpression.getOrBuildFirSafe<FirReturnExpression>(firResolveState) ?: return null
         val firTargetSymbol = fir.target.labeledElement
         return firSymbolBuilder.callableBuilder.buildCallableSymbol(firTargetSymbol)
+    }
+
+    override fun getWhenMissingCases(whenExpression: KtWhenExpression): List<WhenMissingCase> {
+        val firWhenExpression = whenExpression.getOrBuildFirSafe<FirWhenExpression>(analysisSession.firResolveState) ?: return emptyList()
+        return FirWhenExhaustivenessTransformer.computeAllMissingCases(analysisSession.firResolveState.rootModuleSession, firWhenExpression)
     }
 }

--- a/idea/resources-en/intentionDescriptions/HLAddWhenRemainingBranchesIntention/after.kt.template
+++ b/idea/resources-en/intentionDescriptions/HLAddWhenRemainingBranchesIntention/after.kt.template
@@ -1,0 +1,12 @@
+enum class Entry {
+    FOO, BAR, BAZ
+}
+
+fun test(e: Entry): Int {
+    return when (e) {
+        <spot>Entry.FOO -> 1
+        Entry.BAR -> TODO()
+        Entry.BAZ -> TODO()
+        else -> 0</spot>
+    }
+}

--- a/idea/resources-en/intentionDescriptions/HLAddWhenRemainingBranchesIntention/before.kt.template
+++ b/idea/resources-en/intentionDescriptions/HLAddWhenRemainingBranchesIntention/before.kt.template
@@ -1,0 +1,10 @@
+enum class Entry {
+    FOO, BAR, BAZ
+}
+
+fun test(e: Entry): Int {
+    return when (e) {
+        <spot>Entry.FOO -> 1
+        else -> 0</spot>
+    }
+}

--- a/idea/resources-en/intentionDescriptions/HLAddWhenRemainingBranchesIntention/description.html
+++ b/idea/resources-en/intentionDescriptions/HLAddWhenRemainingBranchesIntention/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This intention adds remaining branches on a <b>when</b> expression.
+</body>
+</html>

--- a/idea/resources-fir/META-INF/firIntentions.xml
+++ b/idea/resources-fir/META-INF/firIntentions.xml
@@ -35,5 +35,10 @@
       <className>org.jetbrains.kotlin.idea.fir.intentions.HLConvertToBlockBodyIntention</className>
       <category>Kotlin</category>
     </intentionAction>
+
+    <intentionAction>
+      <className>org.jetbrains.kotlin.idea.fir.intentions.HLAddWhenRemainingBranchesIntention</className>
+      <category>Kotlin</category>
+    </intentionAction>
   </extensions>
 </idea-plugin>

--- a/idea/testData/intentions/addWhenRemainingBranches/.firIntention
+++ b/idea/testData/intentions/addWhenRemainingBranches/.firIntention
@@ -1,0 +1,1 @@
+org.jetbrains.kotlin.idea.fir.intentions.HLAddWhenRemainingBranchesIntention

--- a/idea/testData/quickfix/when/addRemainingBranchesBlankLine.kt
+++ b/idea/testData/quickfix/when/addRemainingBranchesBlankLine.kt
@@ -9,4 +9,3 @@ fun test(a: A) {
 
     }
 }
-/* IGNORE_FIR */

--- a/idea/testData/quickfix/when/addRemainingBranchesBlankLine.kt.after
+++ b/idea/testData/quickfix/when/addRemainingBranchesBlankLine.kt.after
@@ -9,4 +9,3 @@ fun test(a: A) {
         is B -> TODO()
     }
 }
-/* IGNORE_FIR */

--- a/idea/testData/quickfix/when/addRemainingBranchesBlankLineWithComment.kt.after
+++ b/idea/testData/quickfix/when/addRemainingBranchesBlankLineWithComment.kt.after
@@ -11,4 +11,3 @@ fun test(a: A) {
         is B -> TODO()
     }
 }
-/* IGNORE_FIR */

--- a/idea/testData/quickfix/when/addRemainingBranchesBoolean.kt
+++ b/idea/testData/quickfix/when/addRemainingBranchesBoolean.kt
@@ -3,4 +3,3 @@
 fun test(b: Boolean) = wh<caret>en(b) {
     false -> 0
 }
-/* IGNORE_FIR */

--- a/idea/testData/quickfix/when/addRemainingBranchesBoolean.kt.after
+++ b/idea/testData/quickfix/when/addRemainingBranchesBoolean.kt.after
@@ -4,4 +4,3 @@ fun test(b: Boolean) = when(b) {
     false -> 0
     true -> TODO()
 }
-/* IGNORE_FIR */

--- a/idea/testData/quickfix/when/addRemainingBranchesEnum.kt
+++ b/idea/testData/quickfix/when/addRemainingBranchesEnum.kt
@@ -5,4 +5,3 @@ enum class Color { R, G, B }
 fun test(c: Color) = wh<caret>en(c) {
     Color.B -> 0xff
 }
-/* IGNORE_FIR */

--- a/idea/testData/quickfix/when/addRemainingBranchesEnum.kt.after
+++ b/idea/testData/quickfix/when/addRemainingBranchesEnum.kt.after
@@ -7,4 +7,3 @@ fun test(c: Color) = when(c) {
     Color.R -> TODO()
     Color.G -> TODO()
 }
-/* IGNORE_FIR */

--- a/idea/testData/quickfix/when/addRemainingBranchesEnumBackTicks.kt
+++ b/idea/testData/quickfix/when/addRemainingBranchesEnumBackTicks.kt
@@ -8,4 +8,3 @@ enum class FooEnum {
 fun test(foo: FooEnum?) = <caret>when (foo) {
     FooEnum.A -> "A"
 }
-/* IGNORE_FIR */

--- a/idea/testData/quickfix/when/addRemainingBranchesEnumBackTicks.kt.after
+++ b/idea/testData/quickfix/when/addRemainingBranchesEnumBackTicks.kt.after
@@ -14,4 +14,3 @@ fun test(foo: FooEnum?) = <caret>when (foo) {
     FooEnum.`null` -> TODO()
     null -> TODO()
 }
-/* IGNORE_FIR */

--- a/idea/testData/quickfix/when/addRemainingBranchesInNonDefaultPackage.kt
+++ b/idea/testData/quickfix/when/addRemainingBranchesInNonDefaultPackage.kt
@@ -6,4 +6,3 @@ enum class Color { R, G, B }
 fun test(c: Color) = wh<caret>en(c) {
     Color.B -> 0xff
 }
-/* IGNORE_FIR */

--- a/idea/testData/quickfix/when/addRemainingBranchesInNonDefaultPackage.kt.after
+++ b/idea/testData/quickfix/when/addRemainingBranchesInNonDefaultPackage.kt.after
@@ -8,4 +8,3 @@ fun test(c: Color) = when(c) {
     Color.R -> TODO()
     Color.G -> TODO()
 }
-/* IGNORE_FIR */

--- a/idea/testData/quickfix/when/addRemainingBranchesMissingLeftBracket.fir.kt
+++ b/idea/testData/quickfix/when/addRemainingBranchesMissingLeftBracket.fir.kt
@@ -5,9 +5,4 @@ sealed class A
 class B : A()
 
 fun test(a: A) {
-    val r = <caret>when (a) {
-
-        // comment
-
-    }
-}
+  val i = w<caret>hen (a)

--- a/idea/testData/quickfix/when/addRemainingBranchesMissingLeftBracket.fir.kt.after
+++ b/idea/testData/quickfix/when/addRemainingBranchesMissingLeftBracket.fir.kt.after
@@ -5,9 +5,6 @@ sealed class A
 class B : A()
 
 fun test(a: A) {
-    val r = <caret>when (a) {
-
-        // comment
-
-    }
-}
+  val i = w<caret>hen (a) {
+      is B -> TODO()
+  }

--- a/idea/testData/quickfix/when/addRemainingBranchesMissingLeftBracket.kt
+++ b/idea/testData/quickfix/when/addRemainingBranchesMissingLeftBracket.kt
@@ -1,0 +1,8 @@
+// "Add remaining branches" "false"
+// WITH_RUNTIME
+
+sealed class A
+class B : A()
+
+fun test(a: A) {
+  val i = w<caret>hen (a)

--- a/idea/testData/quickfix/when/addRemainingBranchesMissingRightBracket.fir.kt
+++ b/idea/testData/quickfix/when/addRemainingBranchesMissingRightBracket.fir.kt
@@ -5,9 +5,4 @@ sealed class A
 class B : A()
 
 fun test(a: A) {
-    val r = <caret>when (a) {
-
-        // comment
-
-    }
-}
+  val i = w<caret>hen (a) {

--- a/idea/testData/quickfix/when/addRemainingBranchesMissingRightBracket.fir.kt.after
+++ b/idea/testData/quickfix/when/addRemainingBranchesMissingRightBracket.fir.kt.after
@@ -5,9 +5,6 @@ sealed class A
 class B : A()
 
 fun test(a: A) {
-    val r = <caret>when (a) {
-
-        // comment
-
-    }
-}
+  val i = w<caret>hen (a) {
+      is B -> TODO()
+  }

--- a/idea/testData/quickfix/when/addRemainingBranchesMissingRightBracket.kt
+++ b/idea/testData/quickfix/when/addRemainingBranchesMissingRightBracket.kt
@@ -1,0 +1,9 @@
+// "Add remaining branches" "false"
+// ACTION: Eliminate argument of 'when'
+// WITH_RUNTIME
+
+sealed class A
+class B : A()
+
+fun test(a: A) {
+  val i = w<caret>hen (a) {

--- a/idea/testData/quickfix/when/addRemainingBranchesMissingRightParenthesis.fir.kt
+++ b/idea/testData/quickfix/when/addRemainingBranchesMissingRightParenthesis.fir.kt
@@ -5,9 +5,4 @@ sealed class A
 class B : A()
 
 fun test(a: A) {
-    val r = <caret>when (a) {
-
-        // comment
-
-    }
-}
+  val i = w<caret>hen (a

--- a/idea/testData/quickfix/when/addRemainingBranchesMissingRightParenthesis.fir.kt.after
+++ b/idea/testData/quickfix/when/addRemainingBranchesMissingRightParenthesis.fir.kt.after
@@ -5,9 +5,6 @@ sealed class A
 class B : A()
 
 fun test(a: A) {
-    val r = <caret>when (a) {
-
-        // comment
-
-    }
-}
+  val i = w<caret>hen (a) {
+      is B -> TODO()
+  }

--- a/idea/testData/quickfix/when/addRemainingBranchesMissingRightParenthesis.kt
+++ b/idea/testData/quickfix/when/addRemainingBranchesMissingRightParenthesis.kt
@@ -1,0 +1,8 @@
+// "Add remaining branches" "false"
+// WITH_RUNTIME
+
+sealed class A
+class B : A()
+
+fun test(a: A) {
+  <caret>when (a

--- a/idea/testData/quickfix/when/addRemainingBranchesSealed.kt
+++ b/idea/testData/quickfix/when/addRemainingBranchesSealed.kt
@@ -12,4 +12,3 @@ sealed class Variant {
 fun test(v: Variant?) = wh<caret>en(v) {
     Variant.Singleton -> "s"
 }
-/* IGNORE_FIR */

--- a/idea/testData/quickfix/when/addRemainingBranchesSealed.kt.after
+++ b/idea/testData/quickfix/when/addRemainingBranchesSealed.kt.after
@@ -15,4 +15,3 @@ fun test(v: Variant?) = when(v) {
     is Variant.Something -> TODO()
     null -> TODO()
 }
-/* IGNORE_FIR */

--- a/idea/testData/quickfix/when/addRemainingBranchesSealedBackTicks.kt
+++ b/idea/testData/quickfix/when/addRemainingBranchesSealedBackTicks.kt
@@ -13,4 +13,3 @@ object `null`: FooSealed()
 fun test(foo: FooSealed?) = <caret>when (foo) {
     A -> "A"
 }
-/* IGNORE_FIR */

--- a/idea/testData/quickfix/when/addRemainingBranchesSealedBackTicks.kt.after
+++ b/idea/testData/quickfix/when/addRemainingBranchesSealedBackTicks.kt.after
@@ -20,4 +20,3 @@ fun test(foo: FooSealed?) = <caret>when (foo) {
     is `true` -> TODO()
     null -> TODO()
 }
-/* IGNORE_FIR */

--- a/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -15518,6 +15518,21 @@ public class QuickFixTestGenerated extends AbstractQuickFixTest {
             runTest("idea/testData/quickfix/when/addRemainingBranchesInNonDefaultPackage.kt");
         }
 
+        @TestMetadata("addRemainingBranchesMissingLeftBracket.kt")
+        public void testAddRemainingBranchesMissingLeftBracket() throws Exception {
+            runTest("idea/testData/quickfix/when/addRemainingBranchesMissingLeftBracket.kt");
+        }
+
+        @TestMetadata("addRemainingBranchesMissingRightBracket.kt")
+        public void testAddRemainingBranchesMissingRightBracket() throws Exception {
+            runTest("idea/testData/quickfix/when/addRemainingBranchesMissingRightBracket.kt");
+        }
+
+        @TestMetadata("addRemainingBranchesMissingRightParenthesis.kt")
+        public void testAddRemainingBranchesMissingRightParenthesis() throws Exception {
+            runTest("idea/testData/quickfix/when/addRemainingBranchesMissingRightParenthesis.kt");
+        }
+
         @TestMetadata("addRemainingBranchesSealed.kt")
         public void testAddRemainingBranchesSealed() throws Exception {
             runTest("idea/testData/quickfix/when/addRemainingBranchesSealed.kt");


### PR DESCRIPTION
The first 5 commits are identical with those in \#4427

The fix reuses logic that is already available from
FirWhenExhaustivenessTransformer to collect missing when branches. The
current logic unfortunately uses hackyAllowRunningOnEdt to shorten the
generated code.

In addition, commit#4 makes FIR accept `when(nothing){}` by introducing
`TRIVIALLY_EXHAUSTIVE` status.