### PR TITLE
[Stblib, JS] Add adapter for Map from EcmaScript 6

### DIFF
--- a/libraries/stdlib/api/js-v1/kotlin.collections.kt
+++ b/libraries/stdlib/api/js-v1/kotlin.collections.kt
@@ -11080,6 +11080,42 @@ public interface MutableSet<E> : kotlin.collections.Set<E>, kotlin.collections.M
 /*∆*/     public abstract override fun retainAll(elements: kotlin.collections.Collection<E>): kotlin.Boolean
 /*∆*/ }
 /*∆*/ 
+public final class NativeMap<K, V> : kotlin.collections.AbstractMutableMap<K, V>, kotlin.collections.MutableMap<K, V> {
+    public constructor NativeMap<K, V>()
+
+    public constructor NativeMap<K, V>(original: kotlin.collections.Map<out K, V>)
+
+    public open override val entries: kotlin.collections.MutableSet<kotlin.collections.MutableMap.MutableEntry<K, V>> { get; }
+
+    public open override val keys: kotlin.collections.MutableSet<K> { get; }
+
+    public open override val size: kotlin.Int { get; }
+
+    public open override val values: kotlin.collections.MutableCollection<V> { get; }
+
+    public open override fun clear(): kotlin.Unit
+
+    public open override fun containsKey(key: K): kotlin.Boolean
+
+    public open override operator fun get(key: K): V?
+
+    public open override fun put(key: K, value: V): V?
+
+    public final fun putAll(pairs: kotlin.Array<out kotlin.Pair<K, V>>): kotlin.Unit
+
+    public final fun putAll(pairs: kotlin.collections.Iterable<kotlin.Pair<K, V>>): kotlin.Unit
+
+    public open override fun putAll(from: kotlin.collections.Map<out K, V>): kotlin.Unit
+
+    public final fun putAll(pairs: kotlin.sequences.Sequence<kotlin.Pair<K, V>>): kotlin.Unit
+
+    public final fun putFast(key: K, value: V): kotlin.Unit
+
+    public open override fun remove(key: K): V?
+
+    public final fun removeFast(key: K): kotlin.Unit
+}
+
 public interface RandomAccess {
 }
 

--- a/libraries/stdlib/api/js/kotlin.collections.kt
+++ b/libraries/stdlib/api/js/kotlin.collections.kt
@@ -10804,6 +10804,42 @@ public interface MutableSet<E> : kotlin.collections.Set<E>, kotlin.collections.M
     public abstract override fun retainAll(elements: kotlin.collections.Collection<E>): kotlin.Boolean
 }
 
+public final class NativeMap<K, V> : kotlin.collections.AbstractMutableMap<K, V>, kotlin.collections.MutableMap<K, V> {
+    public constructor NativeMap<K, V>()
+
+    public constructor NativeMap<K, V>(original: kotlin.collections.Map<out K, V>)
+
+    public open override val entries: kotlin.collections.MutableSet<kotlin.collections.MutableMap.MutableEntry<K, V>> { get; }
+
+    public open override val keys: kotlin.collections.MutableSet<K> { get; }
+
+    public open override val size: kotlin.Int { get; }
+
+    public open override val values: kotlin.collections.MutableCollection<V> { get; }
+
+    public open override fun clear(): kotlin.Unit
+
+    public open override fun containsKey(key: K): kotlin.Boolean
+
+    public open override operator fun get(key: K): V?
+
+    public open override fun put(key: K, value: V): V?
+
+    public final fun putAll(pairs: kotlin.Array<out kotlin.Pair<K, V>>): kotlin.Unit
+
+    public final fun putAll(pairs: kotlin.collections.Iterable<kotlin.Pair<K, V>>): kotlin.Unit
+
+    public open override fun putAll(from: kotlin.collections.Map<out K, V>): kotlin.Unit
+
+    public final fun putAll(pairs: kotlin.sequences.Sequence<kotlin.Pair<K, V>>): kotlin.Unit
+
+    public final fun putFast(key: K, value: V): kotlin.Unit
+
+    public open override fun remove(key: K): V?
+
+    public final fun removeFast(key: K): kotlin.Unit
+}
+
 public interface RandomAccess {
 }
 

--- a/libraries/stdlib/js/src/kotlin/collections/Es6Iterator.kt
+++ b/libraries/stdlib/js/src/kotlin/collections/Es6Iterator.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package kotlin.collections
+
+internal external interface Es6Iterator<E> {
+    fun next(): NextResult<E>
+
+    interface NextResult<E> {
+        val done: Boolean // | undefined
+        val value: E
+    }
+}
+
+internal open class Es6IteratorAdapter<T>(
+    private val iter: Es6Iterator<T>
+) : Iterator<T> {
+    protected var current = iter.next()
+        private set
+
+    override fun hasNext(): Boolean {
+        return current.done != true
+    }
+
+    override fun next(): T {
+        if (!hasNext()) throw NoSuchElementException()
+        val value = current.value
+        current = iter.next()
+        return value
+    }
+}
+
+internal open class Es6IteratorAdapterWithLast<T>(iter: Es6Iterator<T>) : Es6IteratorAdapter<T>(iter) {
+    protected var lastValue: T? = null
+        private set
+
+    override fun next(): T {
+        return super.next().also {
+            lastValue = it
+        }
+    }
+}

--- a/libraries/stdlib/js/src/kotlin/collections/Es6Map.kt
+++ b/libraries/stdlib/js/src/kotlin/collections/Es6Map.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package kotlin.collections
+
+@JsName("Map")
+internal external class Es6Map<K, V> {
+    constructor()
+    constructor(entries: dynamic /*Es6Iterable<[K, V]>*/)
+
+    val size: Int
+
+    fun clear()
+    fun delete(key: K): Boolean
+    fun get(key: K): V // | undefined
+    fun has(key: K): Boolean
+    fun set(key: K, value: V): Es6Map<K, V>
+
+    fun keys(): Es6Iterator<K>
+    fun values(): Es6Iterator<V>
+    fun entries(): Es6Iterator<dynamic /*[K, V]*/>
+
+    fun forEach(callbackFn: () -> Unit, thisArg: Any? = definedExternally)
+    fun forEach(callbackFn: (value: V) -> Unit, thisArg: Any? = definedExternally)
+    fun forEach(callbackFn: (value: V, key: K) -> Unit, thisArg: Any? = definedExternally)
+    fun forEach(callbackFn: (value: V, key: K, map: Es6Map<K, V>) -> Unit, thisArg: Any? = definedExternally)
+}

--- a/libraries/stdlib/js/src/kotlin/collections/NativeMap.kt
+++ b/libraries/stdlib/js/src/kotlin/collections/NativeMap.kt
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package kotlin.collections
+
+/**
+ * Implementation of the [MutableMap] interface using the JavaScript built-in [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) defined in ECMAScript 6.
+ *
+ * Important: Unlike most other implementations, it compares keys by identity, not equality (i.e. not with [Any.equals]). See [documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#key_equality) for details of key equality.
+ *
+ * It keeps the insertion order when enumerating with [keys], [values] and [entries].
+ * */
+class NativeMap<K, V> : AbstractMutableMap<K, V>, MutableMap<K, V> {
+    private val map: Es6Map<K, V>
+    private var isReadOnly = false
+
+    /**
+     * Constructs an empty [NativeMap] instance.
+     */
+    constructor() : super() {
+        map = Es6Map()
+    }
+
+    /**
+     * Constructs an instance of [NativeMap] filled with the contents of the specified [original] map.
+     */
+    constructor(original: Map<out K, V>) : super() {
+        if (original is NativeMap<*, *>) {
+            map = Es6Map(original.map)
+        } else {
+            map = Es6Map()
+            putAll(original)
+        }
+    }
+
+    override val size get() = map.size
+
+    private var _entries: EntrySet? = null
+    override val entries: MutableSet<MutableMap.MutableEntry<K, V>>
+        get() = _entries ?: EntrySet().also { _entries = it }
+    private var _keys: KeySet? = null
+    override val keys: MutableSet<K>
+        get() = _keys ?: KeySet().also { _keys = it }
+    private var _values: ValueCollection? = null
+    override val values: MutableCollection<V>
+        get() = _values ?: ValueCollection().also { _values = it }
+
+    override fun containsKey(key: K) = map.has(key)
+
+    override operator fun get(key: K): V? = map.get(key).takeUnless { it == undefined }
+
+    /**
+     * Associates the specified [value] with the specified [key] in the map.
+     *
+     * @return the previous value associated with the key, or `null` if the key was not present in the map.
+     *
+     * Note: Because of the [MutableMap] interface specification, this function must first lookup the present
+     * value for the key before setting new one. To avoid this overhead, you may use [putFast] instead.
+     */
+    override fun put(key: K, value: V): V? {
+        checkIsMutable()
+        val prev = this[key]
+        map.set(key, value)
+        return prev
+    }
+
+    /**
+     * Associates the specified [value] with the specified [key] in the map.
+     * Same as [put] but does not lookup and return the previous value.
+     */
+    fun putFast(key: K, value: V) {
+        checkIsMutable()
+        map.set(key, value)
+    }
+
+    // To avoid using long-path [put]
+    @kotlin.internal.InlineOnly
+    inline operator fun set(key: K, value: V) {
+        putFast(key, value)
+    }
+
+    /**
+     * Updates this map with key/value pairs from the specified map [from].
+     */
+    override fun putAll(from: Map<out K, V>) {
+        checkIsMutable()
+        for ((key, value) in from.entries) {
+            putFast(key, value)
+        }
+    }
+
+    /**
+     * Puts all the given [pairs] into this [NativeMap] with the first component in the pair being the key and the second the value.
+     */
+    fun putAll(pairs: Array<out Pair<K, V>>) {
+        checkIsMutable()
+        for ((key, value) in pairs) {
+            putFast(key, value)
+        }
+    }
+
+    /**
+     * Puts all the elements of the given collection into this [NativeMap] with the first component in the pair being the key and the second the value.
+     */
+    fun putAll(pairs: Iterable<Pair<K, V>>) {
+        checkIsMutable()
+        for ((key, value) in pairs) {
+            putFast(key, value)
+        }
+    }
+
+    /**
+     * Puts all the elements of the given sequence into this [NativeMap] with the first component in the pair being the key and the second the value.
+     */
+    fun putAll(pairs: Sequence<Pair<K, V>>) {
+        checkIsMutable()
+        for ((key, value) in pairs) {
+            putFast(key, value)
+        }
+    }
+
+    /**
+     * Removes the specified key and its corresponding value from this map.
+     *
+     * @return the previous value associated with the key, or `null` if the key was not present in the map.
+     *
+     * Note: Because of the [MutableMap] interface specification, this function must first lookup the present
+     * value for the key before removing it. To avoid this overhead, you may use [removeFast] instead.
+     */
+    override fun remove(key: K): V? {
+        checkIsMutable()
+        val prev = map.get(key)
+        if (prev != undefined) {
+            map.delete(key)
+            return prev
+        }
+        return null
+    }
+
+    /**
+     * Removes the specified key and its corresponding value from this map.
+     * Same as [remove] but does not lookup and return the previous value.
+     *
+     * @return true if an element existed and has been removed, or false if the element does not exist.
+     */
+    fun removeFast(key: K): Boolean {
+        checkIsMutable()
+        return map.delete(key)
+    }
+
+    override fun clear() {
+        checkIsMutable()
+        map.clear()
+    }
+
+    @PublishedApi
+    internal fun build(): Map<K, V> {
+        checkIsMutable()
+        isReadOnly = true
+        return this
+    }
+
+    override fun checkIsMutable() {
+        if (isReadOnly) throw UnsupportedOperationException()
+    }
+
+    // Note this implementation is quite heavy-weighted as it holds reference to the map and queries the value each time.
+    // Thus there is also [ReadonlyEntry] is case we can be sure no more modifications will be made.
+    private inner class MutableEntry(override val key: K, value: V) : MutableMap.MutableEntry<K, V> {
+        private var lastValue = value
+        override val value: V
+            get() = this@NativeMap[key]?.also { lastValue = it } ?: lastValue
+
+        override fun setValue(newValue: V): V {
+            val oldValue = this.value
+            this@NativeMap[key] = newValue
+            return oldValue
+        }
+
+        override fun hashCode(): Int = entryHashCode(this)
+        override fun toString(): String = entryToString(this)
+        override fun equals(other: Any?): Boolean = entryEquals(this, other)
+    }
+
+    private class ReadonlyEntry<K, V>(override val key: K, override val value: V) : MutableMap.MutableEntry<K, V> {
+        override fun setValue(newValue: V): V = throw UnsupportedOperationException("The map is readonly")
+
+        override fun hashCode(): Int = entryHashCode(this)
+        override fun toString(): String = entryToString(this)
+        override fun equals(other: Any?): Boolean = entryEquals(this, other)
+    }
+
+    private inner class EntrySet : AbstractMutableMap.AbstractEntrySet<MutableMap.MutableEntry<K, V>, K, V>() {
+        override val size get() = this@NativeMap.size
+
+        override fun add(element: MutableMap.MutableEntry<K, V>): Boolean =
+            throw UnsupportedOperationException("Add is not supported on entries")
+
+        override fun containsEntry(element: Map.Entry<K, V>): Boolean = this@NativeMap.containsEntry(element)
+
+        override fun removeEntry(element: Map.Entry<K, V>): Boolean {
+            if (contains(element)) {
+                this@NativeMap.removeFast(element.key)
+                return true
+            }
+            return false
+        }
+
+        override fun iterator(): MutableIterator<MutableMap.MutableEntry<K, V>> = IteratorImpl()
+
+        private inner class IteratorImpl() : Es6IteratorAdapterWithLast<dynamic>(map.entries().unsafeCast<Es6Iterator<dynamic>>()),
+            MutableIterator<MutableMap.MutableEntry<K, V>> {
+            override fun next(): MutableMap.MutableEntry<K, V> {
+                val entry = super.next()
+                val key = entry[0].unsafeCast<K>()
+                val value = entry[1].unsafeCast<V>()
+                // When we know that the map won't change anymore, return the lightweight entry impl
+                // which does not have to keep track of nor allow mutations.
+                return if (isReadOnly) ReadonlyEntry(key, value) else MutableEntry(key, value)
+            }
+
+            override fun remove() {
+                this@NativeMap.removeFast(lastValue!![0].unsafeCast<K>())
+            }
+        }
+    }
+
+    private inner class KeySet : AbstractMutableSet<K>() {
+        override val size get() = this@NativeMap.size
+
+        override fun add(element: K): Boolean = throw UnsupportedOperationException("Add is not supported on keys")
+
+        override fun contains(element: K) = containsKey(element)
+
+        override fun remove(element: K): Boolean {
+            return this@NativeMap.removeFast(element)
+        }
+
+        override fun removeAll(elements: Collection<K>): Boolean {
+            var removed = false
+            for (element in elements) {
+                if (this@NativeMap.removeFast(element)) {
+                    removed = true
+                }
+            }
+            return removed
+        }
+
+        override fun clear() {
+            this@NativeMap.clear()
+        }
+
+        override fun iterator(): MutableIterator<K> = IteratorImpl()
+
+        private inner class IteratorImpl() : Es6IteratorAdapterWithLast<K>(map.keys()), MutableIterator<K> {
+            override fun remove() {
+                this@NativeMap.removeFast(lastValue!!)
+            }
+        }
+    }
+
+    private inner class ValueCollection : AbstractMutableCollection<V>(), MutableCollection<V> {
+        override val size get() = this@NativeMap.size
+
+        override fun add(element: V): Boolean = throw UnsupportedOperationException("Add is not supported on values")
+
+        override fun contains(element: V) = containsValue(element)
+
+        override fun clear() {
+            this@NativeMap.clear()
+        }
+
+        override fun iterator(): MutableIterator<V> = IteratorImpl()
+
+        private inner class IteratorImpl() : Es6IteratorAdapterWithLast<dynamic>(map.entries().unsafeCast<Es6Iterator<dynamic>>()),
+            MutableIterator<V> {
+            override fun next(): V {
+                return super.next()[1].unsafeCast<V>()
+            }
+
+            override fun remove() {
+                this@NativeMap.removeFast(lastValue!![0].unsafeCast<K>())
+            }
+        }
+    }
+}
+
+/**
+ * Returns an empty new [NativeMap].
+ */
+@kotlin.internal.InlineOnly
+inline fun <K, V> nativeMapOf() = NativeMap<K, V>()
+
+/**
+ * Returns a new [NativeMap] with the specified contents, given as a list of pairs
+ * where the first component is the key and the second is the value.
+ */
+fun <K, V> nativeMapOf(vararg pairs: Pair<K, V>) = NativeMap<K, V>().apply { putAll(pairs) }

--- a/libraries/stdlib/js/test/collections/NativeMapTest.kt
+++ b/libraries/stdlib/js/test/collections/NativeMapTest.kt
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package test.collections.js
+
+import kotlin.test.*
+
+class NativeMapTest {
+    @Test
+    fun sizeAndEmpty() {
+        val data = nativeMapOf<String, Int>()
+        assertTrue { data.none() }
+        assertEquals(data.size, 0)
+        assertFalse(data.entries.iterator().hasNext())
+        assertFalse(data.values.iterator().hasNext())
+        assertFalse(data.keys.iterator().hasNext())
+    }
+
+    @Test
+    fun createFromNativeMap() {
+        val src = nativeMapOf("beverage" to "beer", "location" to "Mells", "name" to "James")
+        val clone = NativeMap(src)
+        src.remove("location")
+        assertEquals(clone, mapOf("beverage" to "beer", "location" to "Mells", "name" to "James"))
+    }
+
+    @Test
+    fun createFromMap() {
+        val src = mutableMapOf("beverage" to "beer", "location" to "Mells", "name" to "James")
+        val clone = NativeMap(src)
+        src.remove("location")
+        assertEquals(clone, mapOf("beverage" to "beer", "location" to "Mells", "name" to "James"))
+    }
+
+    @Test
+    fun iterate() {
+        val src = arrayOf("beverage" to "beer", "location" to "Mells", "name" to "James")
+        val map = nativeMapOf(*src)
+
+        val srcIter = src.iterator()
+        val keysIter = map.keys.iterator()
+        val valuesIter = map.values.iterator()
+        val entryIter = map.entries.iterator()
+
+        while (true) {
+            assertEquals(keysIter.hasNext(), srcIter.hasNext())
+            assertEquals(valuesIter.hasNext(), srcIter.hasNext())
+            assertEquals(entryIter.hasNext(), srcIter.hasNext())
+
+            if (!srcIter.hasNext()) {
+                break
+            }
+
+            val (key, value) = srcIter.next()
+            assertEquals(key, keysIter.next())
+            assertEquals(value, valuesIter.next())
+            entryIter.next().let {
+                assertEquals(key, it.key)
+                assertEquals(value, it.value)
+            }
+        }
+    }
+
+    @Test
+    fun iterateAndMutateEntries() {
+        val map = nativeMapOf("beverage" to "beer", "location" to "Mells", "name" to "James")
+        val e1 = map.entries.elementAt(0)
+        val e2 = map.entries.elementAt(1)
+
+        val it = map.iterator()
+        for (e in it) {
+            when (e.key) {
+                "beverage" -> e.setValue("juice")
+                "location" -> it.remove()
+            }
+        }
+
+        assertEquals(mapOf("beverage" to "juice", "name" to "James"), map)
+        assertEquals(e1.value, "juice")
+        assertEquals(e2.value, "Mells")
+    }
+
+    @Test
+    fun iterateAndMutateKeys() {
+        val map = nativeMapOf("beverage" to "beer", "location" to "Mells", "name" to "James")
+        val it = map.keys.iterator()
+        for (key in it) {
+            when (key) {
+                "beverage" -> map["beverage"] = "juice"
+                "location" -> it.remove()
+            }
+        }
+
+        assertEquals(mapOf("beverage" to "juice", "name" to "James"), map)
+    }
+
+    @Test
+    fun iterateAndMutateValues() {
+        val map = nativeMapOf("beverage" to "beer", "location" to "Mells", "name" to "James")
+        val it = map.values.iterator()
+        for (value in it) {
+            when (value) {
+                "beer" -> map["beverage"] = "juice"
+                "Mells" -> it.remove()
+            }
+        }
+
+        assertEquals(mapOf("beverage" to "juice", "name" to "James"), map)
+    }
+
+    @Test
+    fun containsKey() {
+        val map = nativeMapOf("a" to 1, "b" to 2)
+        assertTrue("a" in map)
+        assertTrue("a" in map.keys)
+        assertTrue("c" !in map)
+        assertTrue("c" !in map.keys)
+    }
+
+    @Test
+    fun containsValue() {
+        val map = nativeMapOf("a" to 1, "b" to 2)
+        assertTrue(map.containsValue(1))
+        assertFalse(map.containsValue(3))
+        assertTrue(1 in map.values)
+        assertTrue(3 !in map.values)
+    }
+
+    @Test
+    fun keyIdentity() {
+        val k1 = Pair(0, 1)
+        val k2 = Pair(0, 1)
+        val map = nativeMapOf(k1 to 10)
+        assertFalse(k2 in map)
+    }
+
+    private value class ValueKey(val value: Int)
+
+    @Test
+    fun boxedValueKeyIdentity() {
+        val k1 = ValueKey(0)
+        val k2 = ValueKey(0)
+        val k1Boxed: Any? = k1
+        val k2Boxed: Any? = k2
+        val map = nativeMapOf(k1 to 10, k2Boxed to 20)
+        assertTrue(k1 in map)
+        assertTrue(k2 in map)
+        assertTrue(k1Boxed in map)
+        assertTrue(k2Boxed in map)
+        assertEquals(map[k1], 10)
+        assertEquals(map[k2], 20)
+        assertEquals(map[k1Boxed], 10)
+        assertEquals(map[k2Boxed], 20)
+    }
+
+    @Test
+    fun entriesCovariantContains() {
+        // Based on https://youtrack.jetbrains.com/issue/KT-42428.
+        fun doTest(implName: String, map: Map<String, Int>, key: String, value: Int) {
+            class SimpleEntry<out K, out V>(override val key: K, override val value: V) : Map.Entry<K, V> {
+                override fun toString(): String = "$key=$value"
+                override fun hashCode(): Int = key.hashCode() xor value.hashCode()
+                override fun equals(other: Any?): Boolean =
+                    other is Map.Entry<*, *> && key == other.key && value == other.value
+            }
+
+            val mapDescription = "$implName: ${map::class}"
+
+            assertTrue(map.keys.contains(key), mapDescription)
+            assertEquals(value, map[key], mapDescription)
+            // This one requires special efforts to make it work this way.
+            // map.entries can in fact be `MutableSet<MutableMap.MutableEntry>`,
+            // which [contains] method takes [MutableEntry], so the compiler may generate special bridge
+            // returning false for values that aren't [MutableEntry] (including [SimpleEntry]).
+            assertTrue(map.entries.contains(SimpleEntry(key, value)), mapDescription)
+            assertTrue(map.entries.toSet().contains(SimpleEntry(key, value)), "$mapDescription: reference")
+
+            assertFalse(map.entries.contains(null as Any?), "$mapDescription: contains null")
+            assertFalse(map.entries.contains("not an entry" as Any?), "$mapDescription: contains not an entry")
+        }
+
+        val mapLetterToIndex = ('a'..'z').mapIndexed { i, c -> "$c" to i }.toMap()
+        doTest("NativeMap", mapLetterToIndex.toMap(NativeMap()), "c", 2)
+    }
+
+    @Test
+    fun entriesCovariantRemove() {
+        fun doTest(implName: String, map: MutableMap<String, Int>, key: String, value: Int) {
+            class SimpleEntry<out K, out V>(override val key: K, override val value: V) : Map.Entry<K, V> {
+                override fun toString(): String = "$key=$value"
+                override fun hashCode(): Int = key.hashCode() xor value.hashCode()
+                override fun equals(other: Any?): Boolean =
+                    other is Map.Entry<*, *> && key == other.key && value == other.value
+            }
+
+            val mapDescription = "$implName: ${map::class}"
+
+            assertTrue(map.entries.toMutableSet().remove(SimpleEntry(key, value) as Map.Entry<*, *>), "$mapDescription: reference")
+            assertTrue(map.entries.remove(SimpleEntry(key, value) as Map.Entry<*, *>), mapDescription)
+
+            assertFalse(map.entries.remove(null as Any?), "$mapDescription: remove null")
+            assertFalse(map.entries.remove("not an entry" as Any?), "$mapDescription: remove not an entry")
+        }
+
+        val mapLetterToIndex = ('a'..'z').mapIndexed { i, c -> "$c" to i }.toMap()
+        doTest("NativeMap", mapLetterToIndex.toMap(NativeMap()), "c", 2)
+    }
+
+    @Test
+    fun put() {
+        val map = nativeMapOf("a" to 1)
+        assertEquals(map.put("b", 2), null)
+        assertEquals(map["b"], 2)
+        assertEquals(map.put("b", 3), 2)
+        assertEquals(map["b"], 3)
+    }
+
+    @Test
+    fun putFast() {
+        val map = nativeMapOf("a" to 1)
+        map.putFast("b", 2)
+        assertEquals(map["b"], 2)
+        map.putFast("b", 3)
+        assertEquals(map["b"], 3)
+    }
+
+    @Test
+    fun putAll() {
+        val map = nativeMapOf('a' to 1)
+        map.putAll(mapOf('b' to 2, 'c' to 3))
+        map.putAll(listOf('d' to 4, 'e' to 5))
+        map.putAll(sequenceOf('f' to 6, 'g' to 7))
+        map.putAll(arrayOf('h' to 8, 'j' to 9))
+        assertContentEquals(map.entries.map { it.key to it.value }, (1..9).map { i -> 'a' + i to i })
+    }
+
+    @Test
+    fun remove() {
+        val map = nativeMapOf("a" to 1)
+        assertEquals(map.remove("b"), null)
+        assertEquals(map.remove("a"), 1)
+        assertEquals(map.remove("a"), null)
+    }
+
+    @Test
+    fun removeFast() {
+        val map = nativeMapOf("a" to 1)
+        assertFalse(map.removeFast("b"))
+        assertTrue(map.removeFast("a"))
+        assertFalse(map.removeFast("a"))
+    }
+
+    @Test
+    fun clear() {
+        val map = nativeMapOf("a" to 1, "b" to 2)
+        map.clear()
+        assertEquals(map.size, 0)
+    }
+
+    @Test
+    fun build(){
+        val src = arrayOf("a" to 1, "b" to 2)
+        val map = nativeMapOf(*src)
+        val built = map.build()
+        assertFailsWith<UnsupportedOperationException>() {
+            map["c"] = 3
+        }
+
+        assertContentEquals(map.entries.map { it.key to it.value }.toTypedArray(), src)
+    }
+}


### PR DESCRIPTION
Implements a `MutableMap` on top of [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map), providing a fast, general purpose implementation with identity based keys.

Relates: https://youtrack.jetbrains.com/issue/KT-8435, I think few other which I don't have opened right now.

To consider:
- Instead of `NativeMap`: `PlatformMap`, `JsMap`,  `Es6Map` (but conflicts with external declaration), `BuiltinMap`, `IdentityMap` (though I to stay low level)?
- Make some of the introduced `internal` declarations public, experimental?