### PR TITLE
FIR IDE: resolve parts of a fully qualified name

### DIFF
--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/Candidate.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/Candidate.kt
@@ -85,6 +85,7 @@ class Candidate(
     private val baseSystem: ConstraintStorage,
     val callInfo: CallInfo,
     val originScope: FirScope?,
+    val isFromCompanionObjectTypeScope: Boolean = false
 ) {
 
     var systemInitialized: Boolean = false

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/CandidateFactory.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/CandidateFactory.kt
@@ -6,9 +6,11 @@
 package org.jetbrains.kotlin.fir.resolve.calls
 
 import org.jetbrains.kotlin.fir.declarations.FirDeclarationOrigin
+import org.jetbrains.kotlin.fir.declarations.FirRegularClass
 import org.jetbrains.kotlin.fir.declarations.FirResolvePhase
 import org.jetbrains.kotlin.fir.declarations.builder.buildErrorFunction
 import org.jetbrains.kotlin.fir.declarations.builder.buildErrorProperty
+import org.jetbrains.kotlin.fir.declarations.classId
 import org.jetbrains.kotlin.fir.diagnostics.ConeDiagnostic
 import org.jetbrains.kotlin.fir.expressions.*
 import org.jetbrains.kotlin.fir.moduleData
@@ -17,6 +19,7 @@ import org.jetbrains.kotlin.fir.scopes.FirScope
 import org.jetbrains.kotlin.fir.symbols.AbstractFirBasedSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirErrorFunctionSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirErrorPropertySymbol
+import org.jetbrains.kotlin.fir.types.classId
 import org.jetbrains.kotlin.resolve.calls.components.PostponedArgumentsAnalyzerContext
 import org.jetbrains.kotlin.resolve.calls.inference.model.ConstraintStorage
 import org.jetbrains.kotlin.resolve.calls.tasks.ExplicitReceiverKind
@@ -55,7 +58,20 @@ class CandidateFactory private constructor(
                 callInfo.withReceiverAsArgument(it)
             } ?: callInfo,
             scope,
+            isFromCompanionObjectTypeScope = when (explicitReceiverKind) {
+                ExplicitReceiverKind.EXTENSION_RECEIVER -> extensionReceiverValue.isCandidateFromCompanionObjectTypeScope()
+                ExplicitReceiverKind.DISPATCH_RECEIVER -> dispatchReceiverValue.isCandidateFromCompanionObjectTypeScope()
+                // The following cases are not applicable for companion objects.
+                ExplicitReceiverKind.NO_EXPLICIT_RECEIVER, ExplicitReceiverKind.BOTH_RECEIVERS -> false
+            }
         )
+    }
+
+    private fun ReceiverValue?.isCandidateFromCompanionObjectTypeScope(): Boolean {
+        val expressionReceiverValue = this as? ExpressionReceiverValue ?: return false
+        val resolvedQualifier = (expressionReceiverValue.explicitReceiver as? FirResolvedQualifier) ?: return false
+        val originClassOfCandidate = expressionReceiverValue.type.classId ?: return false
+        return (resolvedQualifier.symbol?.fir as? FirRegularClass)?.companionObject?.classId == originClassOfCandidate
     }
 
     fun createErrorCandidate(callInfo: CallInfo, diagnostic: ConeDiagnostic): Candidate {

--- a/compiler/fir/tree/gen/org/jetbrains/kotlin/fir/expressions/FirErrorResolvedQualifier.kt
+++ b/compiler/fir/tree/gen/org/jetbrains/kotlin/fir/expressions/FirErrorResolvedQualifier.kt
@@ -30,6 +30,7 @@ abstract class FirErrorResolvedQualifier : FirResolvedQualifier(), FirDiagnostic
     abstract override val classId: ClassId?
     abstract override val symbol: FirClassLikeSymbol<*>?
     abstract override val isNullableLHSForCallableReference: Boolean
+    abstract override val resolvedToCompanionObject: Boolean
     abstract override val typeArguments: List<FirTypeProjection>
     abstract override val diagnostic: ConeDiagnostic
 
@@ -42,6 +43,8 @@ abstract class FirErrorResolvedQualifier : FirResolvedQualifier(), FirDiagnostic
     abstract override fun replaceTypeRef(newTypeRef: FirTypeRef)
 
     abstract override fun replaceIsNullableLHSForCallableReference(newIsNullableLHSForCallableReference: Boolean)
+
+    abstract override fun replaceResolvedToCompanionObject(newResolvedToCompanionObject: Boolean)
 
     abstract override fun replaceTypeArguments(newTypeArguments: List<FirTypeProjection>)
 

--- a/compiler/fir/tree/gen/org/jetbrains/kotlin/fir/expressions/FirResolvedQualifier.kt
+++ b/compiler/fir/tree/gen/org/jetbrains/kotlin/fir/expressions/FirResolvedQualifier.kt
@@ -28,6 +28,7 @@ abstract class FirResolvedQualifier : FirExpression() {
     abstract val classId: ClassId?
     abstract val symbol: FirClassLikeSymbol<*>?
     abstract val isNullableLHSForCallableReference: Boolean
+    abstract val resolvedToCompanionObject: Boolean
     abstract val typeArguments: List<FirTypeProjection>
 
     override fun <R, D> accept(visitor: FirVisitor<R, D>, data: D): R = visitor.visitResolvedQualifier(this, data)
@@ -39,6 +40,8 @@ abstract class FirResolvedQualifier : FirExpression() {
     abstract override fun replaceTypeRef(newTypeRef: FirTypeRef)
 
     abstract fun replaceIsNullableLHSForCallableReference(newIsNullableLHSForCallableReference: Boolean)
+
+    abstract fun replaceResolvedToCompanionObject(newResolvedToCompanionObject: Boolean)
 
     abstract fun replaceTypeArguments(newTypeArguments: List<FirTypeProjection>)
 

--- a/compiler/fir/tree/gen/org/jetbrains/kotlin/fir/expressions/builder/FirAbstractResolvedQualifierBuilder.kt
+++ b/compiler/fir/tree/gen/org/jetbrains/kotlin/fir/expressions/builder/FirAbstractResolvedQualifierBuilder.kt
@@ -31,6 +31,7 @@ interface FirAbstractResolvedQualifierBuilder {
     abstract var classId: ClassId?
     abstract var symbol: FirClassLikeSymbol<*>?
     abstract var isNullableLHSForCallableReference: Boolean
+    abstract var resolvedToCompanionObject: Boolean
     abstract val typeArguments: MutableList<FirTypeProjection>
 
     fun build(): FirResolvedQualifier

--- a/compiler/fir/tree/gen/org/jetbrains/kotlin/fir/expressions/builder/FirErrorResolvedQualifierBuilder.kt
+++ b/compiler/fir/tree/gen/org/jetbrains/kotlin/fir/expressions/builder/FirErrorResolvedQualifierBuilder.kt
@@ -61,6 +61,13 @@ class FirErrorResolvedQualifierBuilder : FirAbstractResolvedQualifierBuilder, Fi
         set(_) {
             throw IllegalStateException()
         }
+
+    @Deprecated("Modification of 'resolvedToCompanionObject' has no impact for FirErrorResolvedQualifierBuilder", level = DeprecationLevel.HIDDEN)
+    override var resolvedToCompanionObject: Boolean
+        get() = throw IllegalStateException()
+        set(_) {
+            throw IllegalStateException()
+        }
 }
 
 @OptIn(ExperimentalContracts::class)

--- a/compiler/fir/tree/gen/org/jetbrains/kotlin/fir/expressions/builder/FirResolvedQualifierBuilder.kt
+++ b/compiler/fir/tree/gen/org/jetbrains/kotlin/fir/expressions/builder/FirResolvedQualifierBuilder.kt
@@ -9,6 +9,7 @@ import kotlin.contracts.*
 import org.jetbrains.kotlin.fir.FirSourceElement
 import org.jetbrains.kotlin.fir.builder.FirAnnotationContainerBuilder
 import org.jetbrains.kotlin.fir.builder.FirBuilderDsl
+import org.jetbrains.kotlin.fir.declarations.FirRegularClass
 import org.jetbrains.kotlin.fir.expressions.FirAnnotationCall
 import org.jetbrains.kotlin.fir.expressions.FirResolvedQualifier
 import org.jetbrains.kotlin.fir.expressions.builder.FirAbstractResolvedQualifierBuilder
@@ -54,6 +55,13 @@ class FirResolvedQualifierBuilder : FirAbstractResolvedQualifierBuilder, FirAnno
 
     @Deprecated("Modification of 'classId' has no impact for FirResolvedQualifierBuilder", level = DeprecationLevel.HIDDEN)
     override var classId: ClassId?
+        get() = throw IllegalStateException()
+        set(_) {
+            throw IllegalStateException()
+        }
+
+    @Deprecated("Modification of 'resolvedToCompanionObject' has no impact for FirResolvedQualifierBuilder", level = DeprecationLevel.HIDDEN)
+    override var resolvedToCompanionObject: Boolean
         get() = throw IllegalStateException()
         set(_) {
             throw IllegalStateException()

--- a/compiler/fir/tree/gen/org/jetbrains/kotlin/fir/expressions/impl/FirErrorResolvedQualifierImpl.kt
+++ b/compiler/fir/tree/gen/org/jetbrains/kotlin/fir/expressions/impl/FirErrorResolvedQualifierImpl.kt
@@ -34,6 +34,7 @@ internal class FirErrorResolvedQualifierImpl(
     override val diagnostic: ConeDiagnostic,
 ) : FirErrorResolvedQualifier() {
     override var typeRef: FirTypeRef = FirImplicitTypeRefImpl(null)
+    override val resolvedToCompanionObject: Boolean get() = false
 
     override fun <R, D> acceptChildren(visitor: FirVisitor<R, D>, data: D) {
         typeRef.accept(visitor, data)
@@ -65,6 +66,8 @@ internal class FirErrorResolvedQualifierImpl(
     override fun replaceIsNullableLHSForCallableReference(newIsNullableLHSForCallableReference: Boolean) {
         isNullableLHSForCallableReference = newIsNullableLHSForCallableReference
     }
+
+    override fun replaceResolvedToCompanionObject(newResolvedToCompanionObject: Boolean) {}
 
     override fun replaceTypeArguments(newTypeArguments: List<FirTypeProjection>) {
         typeArguments.clear()

--- a/compiler/fir/tree/gen/org/jetbrains/kotlin/fir/expressions/impl/FirResolvedQualifierImpl.kt
+++ b/compiler/fir/tree/gen/org/jetbrains/kotlin/fir/expressions/impl/FirResolvedQualifierImpl.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.fir.expressions.impl
 
 import org.jetbrains.kotlin.fir.FirSourceElement
+import org.jetbrains.kotlin.fir.declarations.FirRegularClass
 import org.jetbrains.kotlin.fir.expressions.FirAnnotationCall
 import org.jetbrains.kotlin.fir.expressions.FirResolvedQualifier
 import org.jetbrains.kotlin.fir.symbols.impl.FirClassLikeSymbol
@@ -33,6 +34,7 @@ internal class FirResolvedQualifierImpl(
     override val classId: ClassId? get() = relativeClassFqName?.let {
     ClassId(packageFqName, it, false)
 }
+    override var resolvedToCompanionObject: Boolean = (symbol?.fir as? FirRegularClass)?.companionObject != null
 
     override fun <R, D> acceptChildren(visitor: FirVisitor<R, D>, data: D) {
         typeRef.accept(visitor, data)
@@ -63,6 +65,10 @@ internal class FirResolvedQualifierImpl(
 
     override fun replaceIsNullableLHSForCallableReference(newIsNullableLHSForCallableReference: Boolean) {
         isNullableLHSForCallableReference = newIsNullableLHSForCallableReference
+    }
+
+    override fun replaceResolvedToCompanionObject(newResolvedToCompanionObject: Boolean) {
+        resolvedToCompanionObject = newResolvedToCompanionObject
     }
 
     override fun replaceTypeArguments(newTypeArguments: List<FirTypeProjection>) {

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/declarations/FirDeclarationUtil.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/declarations/FirDeclarationUtil.kt
@@ -116,6 +116,12 @@ fun FirRegularClassBuilder.addDeclarations(declarations: Collection<FirDeclarati
 
 val FirTypeAlias.expandedConeType: ConeClassLikeType? get() = expandedTypeRef.coneTypeSafe()
 
+val FirClassLikeDeclaration<*>.classId
+    get() = when (this) {
+        is FirClass<*> -> symbol.classId
+        is FirTypeAlias -> symbol.classId
+    }
+
 val FirClass<*>.classId get() = symbol.classId
 
 val FirClassSymbol<*>.superConeTypes

--- a/compiler/fir/tree/tree-generator/src/org/jetbrains/kotlin/fir/tree/generator/ImplementationConfigurator.kt
+++ b/compiler/fir/tree/tree-generator/src/org/jetbrains/kotlin/fir/tree/generator/ImplementationConfigurator.kt
@@ -469,6 +469,27 @@ object ImplementationConfigurator : AbstractFirTreeImplementationConfigurator() 
             useTypes(expressionType)
         }
 
+        impl(resolvedQualifier) {
+            // Initialize the value to true if only the companion object is present. This makes a standalone class reference expression
+            // correctly resolve to the companion object. For example
+            // ```
+            // class A {
+            //   companion object
+            // }
+            //
+            // val companionOfA = A // This standalone class reference `A` here should resolve to the companion object.
+            // ```
+            //
+            // If this `FirResolvedQualifier` is a receiver expression of some other qualified access, the value is updated in
+            // `FirCallResolver` according to the resolution result.
+            default("resolvedToCompanionObject", "(symbol?.fir as? FirRegularClass)?.companionObject != null")
+            useTypes(regularClass)
+        }
+
+        impl(errorResolvedQualifier) {
+            defaultFalse("resolvedToCompanionObject", withGetter = true)
+        }
+
         noImpl(userTypeRef)
     }
 

--- a/compiler/fir/tree/tree-generator/src/org/jetbrains/kotlin/fir/tree/generator/NodeConfigurator.kt
+++ b/compiler/fir/tree/tree-generator/src/org/jetbrains/kotlin/fir/tree/generator/NodeConfigurator.kt
@@ -516,6 +516,7 @@ object NodeConfigurator : AbstractFieldConfigurator<FirTreeBuilder>(FirTreeBuild
             +field("classId", classIdType, nullable = true)
             +field("symbol", classLikeSymbolType, nullable = true)
             +booleanField("isNullableLHSForCallableReference", withReplace = true)
+            +booleanField("resolvedToCompanionObject", withReplace = true)
             +typeArguments.withTransform()
         }
 

--- a/idea/idea-fir/tests/org/jetbrains/kotlin/idea/fir/resolve/AbstractFirReferenceResolveTest.kt
+++ b/idea/idea-fir/tests/org/jetbrains/kotlin/idea/fir/resolve/AbstractFirReferenceResolveTest.kt
@@ -5,13 +5,11 @@
 
 package org.jetbrains.kotlin.idea.fir.resolve
 
-import org.jetbrains.kotlin.idea.completion.test.configureWithExtraFile
 import org.jetbrains.kotlin.idea.fir.invalidateCaches
 import org.jetbrains.kotlin.idea.resolve.AbstractReferenceResolveTest
 import org.jetbrains.kotlin.idea.test.KotlinLightProjectDescriptor
 import org.jetbrains.kotlin.idea.test.KotlinWithJdkAndRuntimeLightProjectDescriptor
 import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.kotlin.test.utils.IgnoreTests
 
 abstract class AbstractFirReferenceResolveTest : AbstractReferenceResolveTest() {
     override fun isFirPlugin(): Boolean = true
@@ -22,14 +20,5 @@ abstract class AbstractFirReferenceResolveTest : AbstractReferenceResolveTest() 
     override fun tearDown() {
         project.invalidateCaches(myFixture.file as? KtFile)
         super.tearDown()
-    }
-
-    override fun doTest(path: String) {
-        assert(path.endsWith(".kt")) { path }
-        myFixture.configureWithExtraFile(path, ".Data")
-
-        IgnoreTests.runTestIfNotDisabledByFileDirective(testDataFile().toPath(), IgnoreTests.DIRECTIVES.IGNORE_FIR) {
-            performChecks()
-        }
     }
 }

--- a/idea/idea-fir/tests/org/jetbrains/kotlin/idea/fir/resolve/FirReferenceResolveTestGenerated.java
+++ b/idea/idea-fir/tests/org/jetbrains/kotlin/idea/fir/resolve/FirReferenceResolveTestGenerated.java
@@ -957,4 +957,52 @@ public class FirReferenceResolveTestGenerated extends AbstractFirReferenceResolv
             runTest("idea/testData/resolve/references/packageReference/kotlinPackageSecondQualifier.kt");
         }
     }
+
+    @TestMetadata("idea/testData/resolve/references/qualifiedAccess")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class QualifiedAccess extends AbstractFirReferenceResolveTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
+        }
+
+        public void testAllFilesPresentInQualifiedAccess() throws Exception {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("idea/testData/resolve/references/qualifiedAccess"), Pattern.compile("^([^.]+)\\.kt$"), null, true);
+        }
+
+        @TestMetadata("callableReference1.kt")
+        public void testCallableReference1() throws Exception {
+            runTest("idea/testData/resolve/references/qualifiedAccess/callableReference1.kt");
+        }
+
+        @TestMetadata("callableReference2.kt")
+        public void testCallableReference2() throws Exception {
+            runTest("idea/testData/resolve/references/qualifiedAccess/callableReference2.kt");
+        }
+
+        @TestMetadata("callableReference3.kt")
+        public void testCallableReference3() throws Exception {
+            runTest("idea/testData/resolve/references/qualifiedAccess/callableReference3.kt");
+        }
+
+        @TestMetadata("ResolveFirstPackageOfFullyQualifiedReference.kt")
+        public void testResolveFirstPackageOfFullyQualifiedReference() throws Exception {
+            runTest("idea/testData/resolve/references/qualifiedAccess/ResolveFirstPackageOfFullyQualifiedReference.kt");
+        }
+
+        @TestMetadata("ResolveFullyQualifiedCompanionObject.kt")
+        public void testResolveFullyQualifiedCompanionObject() throws Exception {
+            runTest("idea/testData/resolve/references/qualifiedAccess/ResolveFullyQualifiedCompanionObject.kt");
+        }
+
+        @TestMetadata("ResolveOuterClassOfFullyQualifiedReference.kt")
+        public void testResolveOuterClassOfFullyQualifiedReference() throws Exception {
+            runTest("idea/testData/resolve/references/qualifiedAccess/ResolveOuterClassOfFullyQualifiedReference.kt");
+        }
+
+        @TestMetadata("ResolvePackageOfFullyQualifiedReference.kt")
+        public void testResolvePackageOfFullyQualifiedReference() throws Exception {
+            runTest("idea/testData/resolve/references/qualifiedAccess/ResolvePackageOfFullyQualifiedReference.kt");
+        }
+    }
 }

--- a/idea/idea-frontend-independent/src/org/jetbrains/kotlin/idea/search/searchUtil.kt
+++ b/idea/idea-frontend-independent/src/org/jetbrains/kotlin/idea/search/searchUtil.kt
@@ -37,13 +37,9 @@ import org.jetbrains.kotlin.idea.search.KotlinSearchUsagesSupport.Companion.scri
 import org.jetbrains.kotlin.idea.util.application.runReadAction
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
-import org.jetbrains.kotlin.psi.KtDeclaration
-import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.kotlin.psi.KtImportDirective
-import org.jetbrains.kotlin.psi.KtNamedDeclaration
+import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.getNonStrictParentOfType
 import org.jetbrains.kotlin.types.expressions.OperatorConventions
-import java.util.*
 
 infix fun SearchScope.and(otherScope: SearchScope): SearchScope = intersectWith(otherScope)
 infix fun SearchScope.or(otherScope: SearchScope): SearchScope = union(otherScope)

--- a/idea/idea-frontend-independent/tests/org/jetbrains/kotlin/test/utils/IgnoreTests.kt
+++ b/idea/idea-frontend-independent/tests/org/jetbrains/kotlin/test/utils/IgnoreTests.kt
@@ -218,6 +218,7 @@ object IgnoreTests {
         const val FIR_IDENTICAL = "// FIR_IDENTICAL"
 
         const val IGNORE_FE10_BINDING_BY_FIR = "// IGNORE_FE10_BINDING_BY_FIR"
+        const val IGNORE_FE10 = "// IGNORE_FE10"
     }
 
     enum class DirectivePosition {

--- a/idea/testData/findUsages/kotlin/companionObject/named.0.kt
+++ b/idea/testData/findUsages/kotlin/companionObject/named.0.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 // PSI_ELEMENT: org.jetbrains.kotlin.psi.KtObjectDeclaration
 // OPTIONS: usages
 class Foo {

--- a/idea/testData/findUsages/kotlin/companionObject/simple.0.kt
+++ b/idea/testData/findUsages/kotlin/companionObject/simple.0.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 // PSI_ELEMENT: org.jetbrains.kotlin.psi.KtObjectDeclaration
 // OPTIONS: usages
 class Foo {

--- a/idea/testData/findUsages/kotlin/findObjectUsages/kotlinLocalObjectUsages1.0.kt
+++ b/idea/testData/findUsages/kotlin/findObjectUsages/kotlinLocalObjectUsages1.0.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 // PSI_ELEMENT: org.jetbrains.kotlin.psi.KtObjectDeclaration
 // OPTIONS: usages
 fun foo(): Any {

--- a/idea/testData/findUsages/kotlin/findObjectUsages/kotlinLocalObjectUsages1.results.txt
+++ b/idea/testData/findUsages/kotlin/findObjectUsages/kotlinLocalObjectUsages1.results.txt
@@ -1,1 +1,1 @@
-Value read 6 return Bar
+Value read 7 return Bar

--- a/idea/testData/findUsages/kotlin/findObjectUsages/kotlinLocalObjectUsages2.0.kt
+++ b/idea/testData/findUsages/kotlin/findObjectUsages/kotlinLocalObjectUsages2.0.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 // PSI_ELEMENT: org.jetbrains.kotlin.psi.KtObjectDeclaration
 // OPTIONS: usages
 fun foo(): Any {

--- a/idea/testData/findUsages/kotlin/findObjectUsages/kotlinLocalObjectUsages2.results.txt
+++ b/idea/testData/findUsages/kotlin/findObjectUsages/kotlinLocalObjectUsages2.results.txt
@@ -1,1 +1,1 @@
-Value read 7 return Bar
+Value read 8 return Bar

--- a/idea/testData/resolve/references/TopLevelClassVsLocalClassQualifier.kt
+++ b/idea/testData/resolve/references/TopLevelClassVsLocalClassQualifier.kt
@@ -1,5 +1,3 @@
-// IGNORE_FIR
-
 package test
 
 class Conflict

--- a/idea/testData/resolve/references/TopLevelObjectVsLocalClassQualifier.kt
+++ b/idea/testData/resolve/references/TopLevelObjectVsLocalClassQualifier.kt
@@ -1,3 +1,4 @@
+// IGNORE_FIR
 package test
 
 object Conflict

--- a/idea/testData/resolve/references/qualifiedAccess/ResolveFirstPackageOfFullyQualifiedReference.kt
+++ b/idea/testData/resolve/references/qualifiedAccess/ResolveFirstPackageOfFullyQualifiedReference.kt
@@ -1,0 +1,13 @@
+package foo.bar.baz
+
+class AA {
+    class BB {
+        companion object
+    }
+}
+
+fun test() {
+    val b = f<caret>oo.bar.baz.AA.BB
+}
+
+// REF: foo

--- a/idea/testData/resolve/references/qualifiedAccess/ResolveFullyQualifiedCompanionObject.kt
+++ b/idea/testData/resolve/references/qualifiedAccess/ResolveFullyQualifiedCompanionObject.kt
@@ -1,0 +1,14 @@
+// IGNORE_FIR
+package foo.bar.baz
+
+class AA {
+    class BB {
+        companion object
+    }
+}
+
+fun test() {
+    val b = foo.bar.baz.AA.B<caret>B
+}
+
+// REF: companion object of (in foo.bar.baz.AA).BB

--- a/idea/testData/resolve/references/qualifiedAccess/ResolveOuterClassOfFullyQualifiedReference.kt
+++ b/idea/testData/resolve/references/qualifiedAccess/ResolveOuterClassOfFullyQualifiedReference.kt
@@ -1,0 +1,13 @@
+package foo.bar.baz
+
+class AA {
+    class BB {
+        companion object
+    }
+}
+
+fun test() {
+    val b = foo.bar.baz.A<caret>A.BB
+}
+
+// REF: (foo.bar.baz).AA

--- a/idea/testData/resolve/references/qualifiedAccess/ResolvePackageOfFullyQualifiedReference.kt
+++ b/idea/testData/resolve/references/qualifiedAccess/ResolvePackageOfFullyQualifiedReference.kt
@@ -1,0 +1,13 @@
+package foo.bar.baz
+
+class AA {
+    class BB {
+        companion object
+    }
+}
+
+fun test() {
+    val b = foo.bar.b<caret>az.AA.BB
+}
+
+// REF: baz

--- a/idea/testData/resolve/references/qualifiedAccess/callableReference1.kt
+++ b/idea/testData/resolve/references/qualifiedAccess/callableReference1.kt
@@ -1,0 +1,11 @@
+package foo.bar.baz
+
+class AA {
+    fun foo() {}
+}
+
+fun test() {
+    A<caret>A::foo
+}
+
+// REF: (foo.bar.baz).AA

--- a/idea/testData/resolve/references/qualifiedAccess/callableReference2.kt
+++ b/idea/testData/resolve/references/qualifiedAccess/callableReference2.kt
@@ -1,0 +1,14 @@
+// IGNORE_FE10
+package foo.bar.baz
+
+class AA {
+    companion object {
+        fun foo() {}
+    }
+}
+
+fun test() {
+    A<caret>A::foo // FE1.0 won't resolve this
+}
+
+// REF: companion object of (foo.bar.baz).AA

--- a/idea/testData/resolve/references/qualifiedAccess/callableReference3.kt
+++ b/idea/testData/resolve/references/qualifiedAccess/callableReference3.kt
@@ -1,0 +1,14 @@
+// IGNORE_FE10
+package foo.bar.baz
+
+class AA {
+    companion object
+}
+
+fun AA.Companion.foo() {}
+
+fun test() {
+    A<caret>A::foo // FE1.0 won't resolve this
+}
+
+// REF: companion object of (foo.bar.baz).AA

--- a/idea/tests/org/jetbrains/kotlin/idea/resolve/AbstractReferenceResolveTest.kt
+++ b/idea/tests/org/jetbrains/kotlin/idea/resolve/AbstractReferenceResolveTest.kt
@@ -20,8 +20,8 @@ import org.jetbrains.kotlin.idea.test.PluginTestCaseBase
 import org.jetbrains.kotlin.idea.util.application.runReadAction
 import org.jetbrains.kotlin.test.InTextDirectivesUtils
 import org.jetbrains.kotlin.test.util.renderAsGotoImplementation
+import org.jetbrains.kotlin.test.utils.IgnoreTests
 import org.junit.Assert
-import java.util.concurrent.Callable
 import kotlin.test.assertTrue
 
 abstract class AbstractReferenceResolveTest : KotlinLightPlatformCodeInsightFixtureTestCase() {
@@ -35,7 +35,14 @@ abstract class AbstractReferenceResolveTest : KotlinLightPlatformCodeInsightFixt
     protected open fun doTest(path: String) {
         assert(path.endsWith(".kt")) { path }
         myFixture.configureWithExtraFile(path, ".Data")
-        performChecks()
+        val controlDirective = if (isFirPlugin()) {
+            IgnoreTests.DIRECTIVES.IGNORE_FIR
+        } else {
+            IgnoreTests.DIRECTIVES.IGNORE_FE10
+        }
+        IgnoreTests.runTestIfNotDisabledByFileDirective(testDataFile().toPath(), controlDirective) {
+            performChecks()
+        }
     }
 
     protected fun performChecks() {

--- a/idea/tests/org/jetbrains/kotlin/idea/resolve/ReferenceResolveTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/resolve/ReferenceResolveTestGenerated.java
@@ -957,4 +957,52 @@ public class ReferenceResolveTestGenerated extends AbstractReferenceResolveTest 
             runTest("idea/testData/resolve/references/packageReference/kotlinPackageSecondQualifier.kt");
         }
     }
+
+    @TestMetadata("idea/testData/resolve/references/qualifiedAccess")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class QualifiedAccess extends AbstractReferenceResolveTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
+        }
+
+        public void testAllFilesPresentInQualifiedAccess() throws Exception {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("idea/testData/resolve/references/qualifiedAccess"), Pattern.compile("^([^.]+)\\.kt$"), null, true);
+        }
+
+        @TestMetadata("callableReference1.kt")
+        public void testCallableReference1() throws Exception {
+            runTest("idea/testData/resolve/references/qualifiedAccess/callableReference1.kt");
+        }
+
+        @TestMetadata("callableReference2.kt")
+        public void testCallableReference2() throws Exception {
+            runTest("idea/testData/resolve/references/qualifiedAccess/callableReference2.kt");
+        }
+
+        @TestMetadata("callableReference3.kt")
+        public void testCallableReference3() throws Exception {
+            runTest("idea/testData/resolve/references/qualifiedAccess/callableReference3.kt");
+        }
+
+        @TestMetadata("ResolveFirstPackageOfFullyQualifiedReference.kt")
+        public void testResolveFirstPackageOfFullyQualifiedReference() throws Exception {
+            runTest("idea/testData/resolve/references/qualifiedAccess/ResolveFirstPackageOfFullyQualifiedReference.kt");
+        }
+
+        @TestMetadata("ResolveFullyQualifiedCompanionObject.kt")
+        public void testResolveFullyQualifiedCompanionObject() throws Exception {
+            runTest("idea/testData/resolve/references/qualifiedAccess/ResolveFullyQualifiedCompanionObject.kt");
+        }
+
+        @TestMetadata("ResolveOuterClassOfFullyQualifiedReference.kt")
+        public void testResolveOuterClassOfFullyQualifiedReference() throws Exception {
+            runTest("idea/testData/resolve/references/qualifiedAccess/ResolveOuterClassOfFullyQualifiedReference.kt");
+        }
+
+        @TestMetadata("ResolvePackageOfFullyQualifiedReference.kt")
+        public void testResolvePackageOfFullyQualifiedReference() throws Exception {
+            runTest("idea/testData/resolve/references/qualifiedAccess/ResolvePackageOfFullyQualifiedReference.kt");
+        }
+    }
 }


### PR DESCRIPTION
Commit#1 adds additional data to disambiguate a reference to the companion
object from the regular object. For example

```
class A {
  fun foo() {}
  companion object {
    fun bar() {}
  }
  class B
}

fun A.Companion.ext() {}

fun test() {
    A
//  ^ resolves to `A.Companion`
    A.B
//  ^ resolves to `A`
    A.bar()
//  ^ resolves to `A.Companion`
    A.unresolvedName
//  ^ resolves to `A`
    A::foo
//  ^ resolves to `A`
    A::bar // only resolvable in FIR. FE1.0 marks `bar` as unresolved.
//  ^ resolves to `A.Companion`
    A.ext()
//  ^ resolves to `A.Companion`
    A::ext  // only resolvable in FIR. FE1.0 marks `ext` as unresolved.
//  ^ resolves to `A.Companion`
}
```

It's implemented by checking which (type) scope a candidate is from.

Commit#2 reimplements reference resolver for parts in a fully qualified name
with this additional piece of information.