### PR TITLE
[JVM_IR] Trim the expression test string for null assertions.

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -26403,6 +26403,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         }
 
         @Test
+        @TestMetadata("messageLength.kt")
+        public void testMessageLength() throws Exception {
+            runTest("compiler/testData/codegen/box/notNullAssertions/messageLength.kt");
+        }
+
+        @Test
         @TestMetadata("noCallAssertions.kt")
         public void testNoCallAssertions() throws Exception {
             runTest("compiler/testData/codegen/box/notNullAssertions/noCallAssertions.kt");

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/TypeOperatorLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/TypeOperatorLowering.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.backend.jvm.lower
 
+import com.intellij.openapi.util.text.StringUtil
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.lower.IrBuildingTransformer
 import org.jetbrains.kotlin.backend.common.lower.at
@@ -422,7 +423,7 @@ private class TypeOperatorLowering(private val context: JvmBackendContext) : Fil
                     irComposite(resultType = expression.type) {
                         +irCall(checkExpressionValueIsNotNull).apply {
                             putValueArgument(0, irGet(valueSymbol.owner))
-                            putValueArgument(1, irString(source))
+                            putValueArgument(1, irString(source.trimForRuntimeAssertion()))
                         }
                         +irGet(valueSymbol.owner)
                     }
@@ -435,6 +436,8 @@ private class TypeOperatorLowering(private val context: JvmBackendContext) : Fil
             }
         }
     }
+
+    private fun String.trimForRuntimeAssertion() = StringUtil.trimMiddle(this, 50)
 
     private fun IrFunction.isDelegated() =
         origin == IrDeclarationOrigin.DELEGATED_PROPERTY_ACCESSOR ||

--- a/compiler/testData/codegen/box/notNullAssertions/messageLength.kt
+++ b/compiler/testData/codegen/box/notNullAssertions/messageLength.kt
@@ -1,0 +1,31 @@
+// TARGET_BACKEND: JVM
+// FILE: test.kt
+
+fun test(): String {
+    return A()
+        // Large comment that would cause the message for
+        // the non-null assertion to be very large if
+        // it is included verbatim in the message.
+        .foo()
+}
+
+fun box(): String {
+    try {
+        test()
+    } catch(e: Throwable) {
+        return if (e.message!!.length <= " must not be null".length + 50) {
+            "OK"
+        } else {
+            "FAIL1"
+        }
+    }
+    return "FAIL2"
+}
+
+// FILE: A.java
+
+public class A {
+    public String foo() {
+        return null;
+    }
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -26367,6 +26367,12 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
         }
 
         @Test
+        @TestMetadata("messageLength.kt")
+        public void testMessageLength() throws Exception {
+            runTest("compiler/testData/codegen/box/notNullAssertions/messageLength.kt");
+        }
+
+        @Test
         @TestMetadata("noCallAssertions.kt")
         public void testNoCallAssertions() throws Exception {
             runTest("compiler/testData/codegen/box/notNullAssertions/noCallAssertions.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -26403,6 +26403,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         }
 
         @Test
+        @TestMetadata("messageLength.kt")
+        public void testMessageLength() throws Exception {
+            runTest("compiler/testData/codegen/box/notNullAssertions/messageLength.kt");
+        }
+
+        @Test
         @TestMetadata("noCallAssertions.kt")
         public void testNoCallAssertions() throws Exception {
             runTest("compiler/testData/codegen/box/notNullAssertions/noCallAssertions.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -22339,6 +22339,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/notNullAssertions/doGenerateParamAssertions.kt");
         }
 
+        @TestMetadata("messageLength.kt")
+        public void testMessageLength() throws Exception {
+            runTest("compiler/testData/codegen/box/notNullAssertions/messageLength.kt");
+        }
+
         @TestMetadata("noCallAssertions.kt")
         public void testNoCallAssertions() throws Exception {
             runTest("compiler/testData/codegen/box/notNullAssertions/noCallAssertions.kt");


### PR DESCRIPTION
^KT-47166 Fixed.