### PR TITLE
FIR IDE: Fix PSI element type for NO_COMPANION_OBJECT and EXPRESSION_EXPECTED_PACKAGE_FOUND

### DIFF
--- a/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/diagnostics/FirDiagnosticsList.kt
+++ b/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/diagnostics/FirDiagnosticsList.kt
@@ -811,10 +811,10 @@ object DIAGNOSTICS_LIST : DiagnosticList("FirErrors") {
         val TYPE_PARAMETER_ON_LHS_OF_DOT by error<KtSimpleNameExpression> {
             parameter<FirTypeParameterSymbol>("typeParameter")
         }
-        val NO_COMPANION_OBJECT by error<KtSimpleNameExpression>(PositioningStrategy.SELECTOR_BY_QUALIFIED) {
+        val NO_COMPANION_OBJECT by error<KtExpression>(PositioningStrategy.SELECTOR_BY_QUALIFIED) {
             parameter<FirRegularClassSymbol>("klass")
         }
-        val EXPRESSION_EXPECTED_PACKAGE_FOUND by error<KtSimpleNameExpression>(PositioningStrategy.SELECTOR_BY_QUALIFIED)
+        val EXPRESSION_EXPECTED_PACKAGE_FOUND by error<KtExpression>(PositioningStrategy.SELECTOR_BY_QUALIFIED)
     }
 
     val FUNCTION_CONTRACTS by object : DiagnosticGroup("Function contracts") {

--- a/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/diagnostics/FirErrors.kt
+++ b/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/diagnostics/FirErrors.kt
@@ -460,8 +460,8 @@ object FirErrors {
     // Context tracking
     val TYPE_PARAMETER_IS_NOT_AN_EXPRESSION by error1<KtSimpleNameExpression, FirTypeParameterSymbol>()
     val TYPE_PARAMETER_ON_LHS_OF_DOT by error1<KtSimpleNameExpression, FirTypeParameterSymbol>()
-    val NO_COMPANION_OBJECT by error1<KtSimpleNameExpression, FirRegularClassSymbol>(SourceElementPositioningStrategies.SELECTOR_BY_QUALIFIED)
-    val EXPRESSION_EXPECTED_PACKAGE_FOUND by error0<KtSimpleNameExpression>(SourceElementPositioningStrategies.SELECTOR_BY_QUALIFIED)
+    val NO_COMPANION_OBJECT by error1<KtExpression, FirRegularClassSymbol>(SourceElementPositioningStrategies.SELECTOR_BY_QUALIFIED)
+    val EXPRESSION_EXPECTED_PACKAGE_FOUND by error0<KtExpression>(SourceElementPositioningStrategies.SELECTOR_BY_QUALIFIED)
 
     // Function contracts
     val ERROR_IN_CONTRACT_DESCRIPTION by error1<KtElement, String>(SourceElementPositioningStrategies.SELECTOR_BY_QUALIFIED)

--- a/idea/idea-fir/tests/org/jetbrains/kotlin/idea/fir/checkers/FirKotlinHighlightingPassTestGenerated.java
+++ b/idea/idea-fir/tests/org/jetbrains/kotlin/idea/fir/checkers/FirKotlinHighlightingPassTestGenerated.java
@@ -231,6 +231,11 @@ public class FirKotlinHighlightingPassTestGenerated extends AbstractFirKotlinHig
             runTest("idea/testData/checker/OverridesAndGenerics.kt");
         }
 
+        @TestMetadata("PackageInExpressionPosition.kt")
+        public void testPackageInExpressionPosition() throws Exception {
+            runTest("idea/testData/checker/PackageInExpressionPosition.kt");
+        }
+
         @TestMetadata("PackageQualified.kt")
         public void testPackageQualified() throws Exception {
             runTest("idea/testData/checker/PackageQualified.kt");

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnostics.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnostics.kt
@@ -1585,12 +1585,12 @@ sealed class KtFirDiagnostic<PSI: PsiElement> : KtDiagnosticWithPsi<PSI> {
         abstract val typeParameter: KtTypeParameterSymbol
     }
 
-    abstract class NoCompanionObject : KtFirDiagnostic<KtSimpleNameExpression>() {
+    abstract class NoCompanionObject : KtFirDiagnostic<KtExpression>() {
         override val diagnosticClass get() = NoCompanionObject::class
         abstract val klass: KtClassLikeSymbol
     }
 
-    abstract class ExpressionExpectedPackageFound : KtFirDiagnostic<KtSimpleNameExpression>() {
+    abstract class ExpressionExpectedPackageFound : KtFirDiagnostic<KtExpression>() {
         override val diagnosticClass get() = ExpressionExpectedPackageFound::class
     }
 

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnosticsImpl.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/diagnostics/KtFirDiagnosticsImpl.kt
@@ -2571,14 +2571,14 @@ internal class NoCompanionObjectImpl(
     override val klass: KtClassLikeSymbol,
     firDiagnostic: FirPsiDiagnostic<*>,
     override val token: ValidityToken,
-) : KtFirDiagnostic.NoCompanionObject(), KtAbstractFirDiagnostic<KtSimpleNameExpression> {
+) : KtFirDiagnostic.NoCompanionObject(), KtAbstractFirDiagnostic<KtExpression> {
     override val firDiagnostic: FirPsiDiagnostic<*> by weakRef(firDiagnostic)
 }
 
 internal class ExpressionExpectedPackageFoundImpl(
     firDiagnostic: FirPsiDiagnostic<*>,
     override val token: ValidityToken,
-) : KtFirDiagnostic.ExpressionExpectedPackageFound(), KtAbstractFirDiagnostic<KtSimpleNameExpression> {
+) : KtFirDiagnostic.ExpressionExpectedPackageFound(), KtAbstractFirDiagnostic<KtExpression> {
     override val firDiagnostic: FirPsiDiagnostic<*> by weakRef(firDiagnostic)
 }
 

--- a/idea/idea-frontend-independent/tests/org/jetbrains/kotlin/test/utils/IgnoreTests.kt
+++ b/idea/idea-frontend-independent/tests/org/jetbrains/kotlin/test/utils/IgnoreTests.kt
@@ -14,7 +14,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 
 object IgnoreTests {
-    private const val INSERT_DIRECTIVE_AUTOMATICALLY = true // TODO use environment variable instead
+    private const val INSERT_DIRECTIVE_AUTOMATICALLY = false // TODO use environment variable instead
     private const val ALWAYS_CONSIDER_TEST_AS_PASSING = false // TODO use environment variable instead
 
     fun runTestIfEnabledByFileDirective(

--- a/idea/testData/checker/PackageInExpressionPosition.fir.kt
+++ b/idea/testData/checker/PackageInExpressionPosition.fir.kt
@@ -1,0 +1,26 @@
+package foo
+
+class X {}
+
+val s = <error descr="[EXPRESSION_EXPECTED_PACKAGE_FOUND] Expression expected, but a package name found">java</error>
+val ss = <error descr="[NO_COMPANION_OBJECT] Classifier 'java/lang/System' does not have a companion object, and thus must be initialized here">System</error>
+val sss = <error descr="[NO_COMPANION_OBJECT] Classifier 'foo/X' does not have a companion object, and thus must be initialized here">X</error>
+val x = "${<error descr="[NO_COMPANION_OBJECT] Classifier 'java/lang/System' does not have a companion object, and thus must be initialized here">System</error>}"
+val xs = java.<error descr="[EXPRESSION_EXPECTED_PACKAGE_FOUND] Expression expected, but a package name found">lang</error>
+val xss = java.lang.<error descr="[NO_COMPANION_OBJECT] Classifier 'java/lang/System' does not have a companion object, and thus must be initialized here">System</error>
+val xsss = foo.<error descr="[NO_COMPANION_OBJECT] Classifier 'foo/X' does not have a companion object, and thus must be initialized here">X</error>
+val xssss = <error descr="[EXPRESSION_EXPECTED_PACKAGE_FOUND] Expression expected, but a package name found">foo</error>
+val f = { <error descr="[NO_COMPANION_OBJECT] Classifier 'java/lang/System' does not have a companion object, and thus must be initialized here">System</error> }
+
+fun main() {
+    <error descr="[EXPRESSION_EXPECTED_PACKAGE_FOUND] Expression expected, but a package name found">java</error> = null
+    <error descr="[NO_COMPANION_OBJECT] Classifier 'java/lang/System' does not have a companion object, and thus must be initialized here">System</error> = null
+    <error descr="[NO_COMPANION_OBJECT] Classifier 'java/lang/System' does not have a companion object, and thus must be initialized here">System</error>!!
+    java.lang.<error descr="[NO_COMPANION_OBJECT] Classifier 'java/lang/System' does not have a companion object, and thus must be initialized here">System</error> = null
+    java.lang.<error descr="[NO_COMPANION_OBJECT] Classifier 'java/lang/System' does not have a companion object, and thus must be initialized here">System</error>!!
+    <error descr="[NO_COMPANION_OBJECT] Classifier 'java/lang/System' does not have a companion object, and thus must be initialized here">System</error> is Int
+    <error descr="[INVISIBLE_REFERENCE] Symbol java/lang/System.System is invisible">System</error>()
+    (<error descr="[NO_COMPANION_OBJECT] Classifier 'java/lang/System' does not have a companion object, and thus must be initialized here">System</error>)
+    foo@ <error descr="[NO_COMPANION_OBJECT] Classifier 'java/lang/System' does not have a companion object, and thus must be initialized here">System</error>
+    null <error descr="[UNRESOLVED_REFERENCE] Unresolved reference: contains">in</error> System
+}

--- a/idea/testData/checker/PackageInExpressionPosition.kt
+++ b/idea/testData/checker/PackageInExpressionPosition.kt
@@ -1,0 +1,26 @@
+package foo
+
+class X {}
+
+val s = <error descr="[EXPRESSION_EXPECTED_PACKAGE_FOUND] Expression expected, but a package name found">java</error>
+val ss = <error descr="[NO_COMPANION_OBJECT] Classifier 'System' does not have a companion object, and thus must be initialized here">System</error>
+val sss = <error descr="[NO_COMPANION_OBJECT] Classifier 'X' does not have a companion object, and thus must be initialized here">X</error>
+val x = "${<error descr="[NO_COMPANION_OBJECT] Classifier 'System' does not have a companion object, and thus must be initialized here">System</error>}"
+val xs = java.<error descr="[EXPRESSION_EXPECTED_PACKAGE_FOUND] Expression expected, but a package name found">lang</error>
+val xss = java.lang.<error descr="[NO_COMPANION_OBJECT] Classifier 'System' does not have a companion object, and thus must be initialized here">System</error>
+val xsss = foo.<error descr="[NO_COMPANION_OBJECT] Classifier 'X' does not have a companion object, and thus must be initialized here">X</error>
+val xssss = <error descr="[EXPRESSION_EXPECTED_PACKAGE_FOUND] Expression expected, but a package name found">foo</error>
+val f = { <error descr="[NO_COMPANION_OBJECT] Classifier 'System' does not have a companion object, and thus must be initialized here">System</error> }
+
+fun main() {
+    <error descr="[EXPRESSION_EXPECTED_PACKAGE_FOUND] Expression expected, but a package name found">java</error> = null
+    <error descr="[NO_COMPANION_OBJECT] Classifier 'System' does not have a companion object, and thus must be initialized here">System</error> = null
+    <error descr="[NO_COMPANION_OBJECT] Classifier 'System' does not have a companion object, and thus must be initialized here">System</error>!!
+    java.lang.<error descr="[NO_COMPANION_OBJECT] Classifier 'System' does not have a companion object, and thus must be initialized here">System</error> = null
+    java.lang.<error descr="[NO_COMPANION_OBJECT] Classifier 'System' does not have a companion object, and thus must be initialized here">System</error>!!
+    <error descr="[NO_COMPANION_OBJECT] Classifier 'System' does not have a companion object, and thus must be initialized here">System</error> is Int
+    <error descr="[INVISIBLE_MEMBER] Cannot access '<init>': it is private in 'System'">System</error>()
+    (<error descr="[NO_COMPANION_OBJECT] Classifier 'System' does not have a companion object, and thus must be initialized here">System</error>)
+    <warning descr="[REDUNDANT_LABEL_WARNING] Label is redundant, because it can not be referenced in either ''break'', ''continue'', or ''return'' expression">foo@</warning> <error descr="[NO_COMPANION_OBJECT] Classifier 'System' does not have a companion object, and thus must be initialized here">System</error>
+    null in <error descr="[NO_COMPANION_OBJECT] Classifier 'System' does not have a companion object, and thus must be initialized here">System</error>
+}

--- a/idea/tests/org/jetbrains/kotlin/checkers/KotlinHighlightingPassTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/checkers/KotlinHighlightingPassTestGenerated.java
@@ -231,6 +231,11 @@ public class KotlinHighlightingPassTestGenerated extends AbstractKotlinHighlight
             runTest("idea/testData/checker/OverridesAndGenerics.kt");
         }
 
+        @TestMetadata("PackageInExpressionPosition.kt")
+        public void testPackageInExpressionPosition() throws Exception {
+            runTest("idea/testData/checker/PackageInExpressionPosition.kt");
+        }
+
         @TestMetadata("PackageQualified.kt")
         public void testPackageQualified() throws Exception {
             runTest("idea/testData/checker/PackageQualified.kt");


### PR DESCRIPTION
Changed from `KtSimpleNameExpression` to `KtExpression`; the source can be `KtDotQualifiedExpression`.