### PR TITLE
Have kotlin-compiler-embeddable copy sources and javadocs from kotlin-compiler

### DIFF
--- a/prepare/compiler-embeddable/build.gradle.kts
+++ b/prepare/compiler-embeddable/build.gradle.kts
@@ -92,16 +92,16 @@ val runtimeJar = runtimeJar(embeddableCompiler()) {
     transform(CoreXmlShadingTransformer::class.java)
 }
 
-sourcesJar{
+sourcesJar {
     val compilerTask = project(":kotlin-compiler").tasks.named<Jar>("sourcesJar")
     dependsOn(compilerTask)
-    from(compilerTask.map{ zipTree(it.archiveFile) })
+    from(compilerTask.map { zipTree(it.archiveFile) })
 }
 
-javadocJar{
+javadocJar {
     val compilerTask = project(":kotlin-compiler").tasks.named<Jar>("javadocJar")
     dependsOn(compilerTask)
-    from(compilerTask.map{ zipTree(it.archiveFile) })
+    from(compilerTask.map { zipTree(it.archiveFile) })
 }
 
 projectTest {

--- a/prepare/compiler-embeddable/build.gradle.kts
+++ b/prepare/compiler-embeddable/build.gradle.kts
@@ -93,13 +93,13 @@ val runtimeJar = runtimeJar(embeddableCompiler()) {
 }
 
 sourcesJar{
-    val compilerTask = project(":kotlin-compiler").tasks.named("sourcesJar") as TaskProvider<out Jar>
+    val compilerTask = project(":kotlin-compiler").tasks.named<Jar>("sourcesJar")
     dependsOn(compilerTask)
     from(compilerTask.map{ zipTree(it.archiveFile) })
 }
 
 javadocJar{
-    val compilerTask = project(":kotlin-compiler").tasks.named("javadocJar") as TaskProvider<out Jar>
+    val compilerTask = project(":kotlin-compiler").tasks.named<Jar>("javadocJar")
     dependsOn(compilerTask)
     from(compilerTask.map{ zipTree(it.archiveFile) })
 }
@@ -114,5 +114,4 @@ projectTest {
         systemProperty("compilationClasspath", testCompilationClasspathProvider.get())
     }
 }
-
 

--- a/prepare/compiler-embeddable/build.gradle.kts
+++ b/prepare/compiler-embeddable/build.gradle.kts
@@ -92,8 +92,17 @@ val runtimeJar = runtimeJar(embeddableCompiler()) {
     transform(CoreXmlShadingTransformer::class.java)
 }
 
-sourcesJar()
-javadocJar()
+sourcesJar{
+    val compilerTask = project(":kotlin-compiler").tasks.named("sourcesJar") as TaskProvider<out Jar>
+    dependsOn(compilerTask)
+    from(compilerTask.map{ zipTree(it.archiveFile) })
+}
+
+javadocJar{
+    val compilerTask = project(":kotlin-compiler").tasks.named("javadocJar") as TaskProvider<out Jar>
+    dependsOn(compilerTask)
+    from(compilerTask.map{ zipTree(it.archiveFile) })
+}
 
 projectTest {
     dependsOn(runtimeJar)


### PR DESCRIPTION
Makes the `sourcesJar` and `javadocJar` tasks in `kotlin-compiler-embeddable` copy from `kotlin-compiler`.  Note that `kotlin-compiler` does not generate javadoc, so the javadoc jar will be empty, but it will have sources.

Sources can't be relocated, so there may be a few incorrect source files, but the vast majority of them are the compiler sources which are correct.

YouTrack issue: [KT-42183](https://youtrack.jetbrains.com/issue/KT-42183)