### PR TITLE
[JVM_IR] Keep track of catch variable gaps.

### DIFF
--- a/compiler/testData/debug/localVariables/tryFinally11.kt
+++ b/compiler/testData/debug/localVariables/tryFinally11.kt
@@ -11,7 +11,7 @@ fun box(): String {
                 val z = "z"
                 break  // TODO: why does the break not have a line number so we can stop on it?
             } finally {
-                throw RuntimeException("$i")  // TODO: `e` should not be visible here
+                throw RuntimeException("$i")
             }
         }
     } finally {
@@ -32,5 +32,5 @@ fun box(): String {
 // test.kt:9 box: i:int=0:int
 // test.kt:10 box: i:int=0:int, e:java.lang.Exception=java.lang.RuntimeException
 // test.kt:11 box: i:int=0:int, e:java.lang.Exception=java.lang.RuntimeException, y:java.lang.String="y":java.lang.String
-// test.kt:14 box: i:int=0:int, e:java.lang.Exception=java.lang.RuntimeException
+// test.kt:14 box: i:int=0:int
 // test.kt:18 box:

--- a/compiler/testData/debug/localVariables/tryFinally12.kt
+++ b/compiler/testData/debug/localVariables/tryFinally12.kt
@@ -11,7 +11,7 @@ fun box(): String {
                 val z = "z"
                 continue  // TODO: why does the continue not have a line number so we stop here?
             } finally {
-                throw RuntimeException("$i")  // TODO: `e` should not be visible here
+                throw RuntimeException("$i")
             }
         }
     } finally {
@@ -32,6 +32,5 @@ fun box(): String {
 // test.kt:9 box: i:int=0:int
 // test.kt:10 box: i:int=0:int, e:java.lang.Exception=java.lang.RuntimeException
 // test.kt:11 box: i:int=0:int, e:java.lang.Exception=java.lang.RuntimeException, y:java.lang.String="y":java.lang.String
-// test.kt:14 box: i:int=0:int, e:java.lang.Exception=java.lang.RuntimeException
+// test.kt:14 box: i:int=0:int
 // test.kt:18 box:
-

--- a/compiler/testData/debug/localVariables/tryFinally13.kt
+++ b/compiler/testData/debug/localVariables/tryFinally13.kt
@@ -10,11 +10,11 @@ fun box(): String {
                 val y = "y"
                 return "FAIL1"
             } finally {
-                return "FAIL2"  // TODO: `e` should not be visible here.
+                return "FAIL2"
             }
         }
     } finally {
-        return "OK"  // TODO: `e` should not be visible here.
+        return "OK"
     }
     return "FAIL3"
 }
@@ -31,6 +31,5 @@ fun box(): String {
 // test.kt:9 box: i:int=0:int
 // test.kt:10 box: i:int=0:int, e:java.lang.Exception=java.lang.RuntimeException
 // test.kt:11 box: i:int=0:int, e:java.lang.Exception=java.lang.RuntimeException, y:java.lang.String="y":java.lang.String
-// test.kt:13 box: i:int=0:int, e:java.lang.Exception=java.lang.RuntimeException
-// test.kt:17 box: e:java.lang.Exception=java.lang.RuntimeException
-
+// test.kt:13 box: i:int=0:int
+// test.kt:17 box:

--- a/compiler/testData/debug/localVariables/tryFinally7.kt
+++ b/compiler/testData/debug/localVariables/tryFinally7.kt
@@ -20,7 +20,7 @@ fun compute(): String {
             }
         }
     } finally {
-        x = "OK"  // TODO: `e` should not be visible here.
+        x = "OK"
     }
     return "FAIL"
 }
@@ -45,7 +45,7 @@ fun box() {
 // test.kt:18 compute: e:java.lang.Exception=java.lang.RuntimeException, y:int=32:int, j:int=0:int
 // test.kt:4 compute: e:java.lang.Exception=java.lang.RuntimeException, y:int=32:int, j:int=0:int, $i$f$f:int=0:int
 // test.kt:19 compute: e:java.lang.Exception=java.lang.RuntimeException, y:int=32:int, j:int=0:int, $i$f$f:int=0:int, $i$a$-f-TestKt$compute$1:int=0:int
-// test.kt:23 compute: e:java.lang.Exception=java.lang.RuntimeException
+// test.kt:23 compute:
 // test.kt:29 box:
 // test.kt:30 box: result:java.lang.String="NON_LOCAL_RETURN":java.lang.String
 // test.kt:31 box: result:java.lang.String="NON_LOCAL_RETURN":java.lang.String, localX:java.lang.String="OK":java.lang.String


### PR DESCRIPTION
This ensures that catch variables are not visible in duplicated
finally blocks generated at an exit within the catch variable
scope.

^KT-46449 Fixed