### PR TITLE
JVM_IR: optimize delegation by property references

### DIFF
--- a/build-common/src/org/jetbrains/kotlin/incremental/ProtoCompareGenerated.kt
+++ b/build-common/src/org/jetbrains/kotlin/incremental/ProtoCompareGenerated.kt
@@ -1104,6 +1104,11 @@ open class ProtoCompareGenerated(
             if (!checkEquals(old.setter, new.setter)) return false
         }
 
+        if (old.hasDelegateMethod() != new.hasDelegateMethod()) return false
+        if (old.hasDelegateMethod()) {
+            if (!checkEquals(old.delegateMethod, new.delegateMethod)) return false
+        }
+
         return true
     }
 
@@ -2351,6 +2356,10 @@ fun JvmProtoBuf.JvmPropertySignature.hashCode(stringIndexes: (Int) -> Int, fqNam
 
     if (hasSetter()) {
         hashCode = 31 * hashCode + setter.hashCode(stringIndexes, fqNameIndexes, typeById)
+    }
+
+    if (hasDelegateMethod()) {
+        hashCode = 31 * hashCode + delegateMethod.hashCode(stringIndexes, fqNameIndexes, typeById)
     }
 
     return hashCode

--- a/build-common/test/org/jetbrains/kotlin/metadata/jvm/DebugJvmProtoBuf.java
+++ b/build-common/test/org/jetbrains/kotlin/metadata/jvm/DebugJvmProtoBuf.java
@@ -3443,6 +3443,34 @@ public final class DebugJvmProtoBuf {
      * <code>optional .org.jetbrains.kotlin.metadata.jvm.JvmMethodSignature setter = 4;</code>
      */
     org.jetbrains.kotlin.metadata.jvm.DebugJvmProtoBuf.JvmMethodSignatureOrBuilder getSetterOrBuilder();
+
+    /**
+     * <code>optional .org.jetbrains.kotlin.metadata.jvm.JvmMethodSignature delegate_method = 5;</code>
+     *
+     * <pre>
+     * The delegate field of delegated properties may be optimized out; `getDelegate` should
+     * then call this method instead
+     * </pre>
+     */
+    boolean hasDelegateMethod();
+    /**
+     * <code>optional .org.jetbrains.kotlin.metadata.jvm.JvmMethodSignature delegate_method = 5;</code>
+     *
+     * <pre>
+     * The delegate field of delegated properties may be optimized out; `getDelegate` should
+     * then call this method instead
+     * </pre>
+     */
+    org.jetbrains.kotlin.metadata.jvm.DebugJvmProtoBuf.JvmMethodSignature getDelegateMethod();
+    /**
+     * <code>optional .org.jetbrains.kotlin.metadata.jvm.JvmMethodSignature delegate_method = 5;</code>
+     *
+     * <pre>
+     * The delegate field of delegated properties may be optimized out; `getDelegate` should
+     * then call this method instead
+     * </pre>
+     */
+    org.jetbrains.kotlin.metadata.jvm.DebugJvmProtoBuf.JvmMethodSignatureOrBuilder getDelegateMethodOrBuilder();
   }
   /**
    * Protobuf type {@code org.jetbrains.kotlin.metadata.jvm.JvmPropertySignature}
@@ -3546,6 +3574,19 @@ public final class DebugJvmProtoBuf {
                 setter_ = subBuilder.buildPartial();
               }
               bitField0_ |= 0x00000008;
+              break;
+            }
+            case 42: {
+              org.jetbrains.kotlin.metadata.jvm.DebugJvmProtoBuf.JvmMethodSignature.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000010) == 0x00000010)) {
+                subBuilder = delegateMethod_.toBuilder();
+              }
+              delegateMethod_ = input.readMessage(org.jetbrains.kotlin.metadata.jvm.DebugJvmProtoBuf.JvmMethodSignature.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(delegateMethod_);
+                delegateMethod_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000010;
               break;
             }
           }
@@ -3684,11 +3725,48 @@ public final class DebugJvmProtoBuf {
       return setter_;
     }
 
+    public static final int DELEGATE_METHOD_FIELD_NUMBER = 5;
+    private org.jetbrains.kotlin.metadata.jvm.DebugJvmProtoBuf.JvmMethodSignature delegateMethod_;
+    /**
+     * <code>optional .org.jetbrains.kotlin.metadata.jvm.JvmMethodSignature delegate_method = 5;</code>
+     *
+     * <pre>
+     * The delegate field of delegated properties may be optimized out; `getDelegate` should
+     * then call this method instead
+     * </pre>
+     */
+    public boolean hasDelegateMethod() {
+      return ((bitField0_ & 0x00000010) == 0x00000010);
+    }
+    /**
+     * <code>optional .org.jetbrains.kotlin.metadata.jvm.JvmMethodSignature delegate_method = 5;</code>
+     *
+     * <pre>
+     * The delegate field of delegated properties may be optimized out; `getDelegate` should
+     * then call this method instead
+     * </pre>
+     */
+    public org.jetbrains.kotlin.metadata.jvm.DebugJvmProtoBuf.JvmMethodSignature getDelegateMethod() {
+      return delegateMethod_;
+    }
+    /**
+     * <code>optional .org.jetbrains.kotlin.metadata.jvm.JvmMethodSignature delegate_method = 5;</code>
+     *
+     * <pre>
+     * The delegate field of delegated properties may be optimized out; `getDelegate` should
+     * then call this method instead
+     * </pre>
+     */
+    public org.jetbrains.kotlin.metadata.jvm.DebugJvmProtoBuf.JvmMethodSignatureOrBuilder getDelegateMethodOrBuilder() {
+      return delegateMethod_;
+    }
+
     private void initFields() {
       field_ = org.jetbrains.kotlin.metadata.jvm.DebugJvmProtoBuf.JvmFieldSignature.getDefaultInstance();
       syntheticMethod_ = org.jetbrains.kotlin.metadata.jvm.DebugJvmProtoBuf.JvmMethodSignature.getDefaultInstance();
       getter_ = org.jetbrains.kotlin.metadata.jvm.DebugJvmProtoBuf.JvmMethodSignature.getDefaultInstance();
       setter_ = org.jetbrains.kotlin.metadata.jvm.DebugJvmProtoBuf.JvmMethodSignature.getDefaultInstance();
+      delegateMethod_ = org.jetbrains.kotlin.metadata.jvm.DebugJvmProtoBuf.JvmMethodSignature.getDefaultInstance();
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -3715,6 +3793,9 @@ public final class DebugJvmProtoBuf {
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         output.writeMessage(4, setter_);
       }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        output.writeMessage(5, delegateMethod_);
+      }
       getUnknownFields().writeTo(output);
     }
 
@@ -3739,6 +3820,10 @@ public final class DebugJvmProtoBuf {
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         size += org.jetbrains.kotlin.protobuf.CodedOutputStream
           .computeMessageSize(4, setter_);
+      }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        size += org.jetbrains.kotlin.protobuf.CodedOutputStream
+          .computeMessageSize(5, delegateMethod_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -3853,6 +3938,7 @@ public final class DebugJvmProtoBuf {
           getSyntheticMethodFieldBuilder();
           getGetterFieldBuilder();
           getSetterFieldBuilder();
+          getDelegateMethodFieldBuilder();
         }
       }
       private static Builder create() {
@@ -3885,6 +3971,12 @@ public final class DebugJvmProtoBuf {
           setterBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000008);
+        if (delegateMethodBuilder_ == null) {
+          delegateMethod_ = org.jetbrains.kotlin.metadata.jvm.DebugJvmProtoBuf.JvmMethodSignature.getDefaultInstance();
+        } else {
+          delegateMethodBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000010);
         return this;
       }
 
@@ -3945,6 +4037,14 @@ public final class DebugJvmProtoBuf {
         } else {
           result.setter_ = setterBuilder_.build();
         }
+        if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
+          to_bitField0_ |= 0x00000010;
+        }
+        if (delegateMethodBuilder_ == null) {
+          result.delegateMethod_ = delegateMethod_;
+        } else {
+          result.delegateMethod_ = delegateMethodBuilder_.build();
+        }
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -3972,6 +4072,9 @@ public final class DebugJvmProtoBuf {
         }
         if (other.hasSetter()) {
           mergeSetter(other.getSetter());
+        }
+        if (other.hasDelegateMethod()) {
+          mergeDelegateMethod(other.getDelegateMethod());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -4500,6 +4603,167 @@ public final class DebugJvmProtoBuf {
         return setterBuilder_;
       }
 
+      private org.jetbrains.kotlin.metadata.jvm.DebugJvmProtoBuf.JvmMethodSignature delegateMethod_ = org.jetbrains.kotlin.metadata.jvm.DebugJvmProtoBuf.JvmMethodSignature.getDefaultInstance();
+      private org.jetbrains.kotlin.protobuf.SingleFieldBuilder<
+          org.jetbrains.kotlin.metadata.jvm.DebugJvmProtoBuf.JvmMethodSignature, org.jetbrains.kotlin.metadata.jvm.DebugJvmProtoBuf.JvmMethodSignature.Builder, org.jetbrains.kotlin.metadata.jvm.DebugJvmProtoBuf.JvmMethodSignatureOrBuilder> delegateMethodBuilder_;
+      /**
+       * <code>optional .org.jetbrains.kotlin.metadata.jvm.JvmMethodSignature delegate_method = 5;</code>
+       *
+       * <pre>
+       * The delegate field of delegated properties may be optimized out; `getDelegate` should
+       * then call this method instead
+       * </pre>
+       */
+      public boolean hasDelegateMethod() {
+        return ((bitField0_ & 0x00000010) == 0x00000010);
+      }
+      /**
+       * <code>optional .org.jetbrains.kotlin.metadata.jvm.JvmMethodSignature delegate_method = 5;</code>
+       *
+       * <pre>
+       * The delegate field of delegated properties may be optimized out; `getDelegate` should
+       * then call this method instead
+       * </pre>
+       */
+      public org.jetbrains.kotlin.metadata.jvm.DebugJvmProtoBuf.JvmMethodSignature getDelegateMethod() {
+        if (delegateMethodBuilder_ == null) {
+          return delegateMethod_;
+        } else {
+          return delegateMethodBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>optional .org.jetbrains.kotlin.metadata.jvm.JvmMethodSignature delegate_method = 5;</code>
+       *
+       * <pre>
+       * The delegate field of delegated properties may be optimized out; `getDelegate` should
+       * then call this method instead
+       * </pre>
+       */
+      public Builder setDelegateMethod(org.jetbrains.kotlin.metadata.jvm.DebugJvmProtoBuf.JvmMethodSignature value) {
+        if (delegateMethodBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          delegateMethod_ = value;
+          onChanged();
+        } else {
+          delegateMethodBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000010;
+        return this;
+      }
+      /**
+       * <code>optional .org.jetbrains.kotlin.metadata.jvm.JvmMethodSignature delegate_method = 5;</code>
+       *
+       * <pre>
+       * The delegate field of delegated properties may be optimized out; `getDelegate` should
+       * then call this method instead
+       * </pre>
+       */
+      public Builder setDelegateMethod(
+          org.jetbrains.kotlin.metadata.jvm.DebugJvmProtoBuf.JvmMethodSignature.Builder builderForValue) {
+        if (delegateMethodBuilder_ == null) {
+          delegateMethod_ = builderForValue.build();
+          onChanged();
+        } else {
+          delegateMethodBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000010;
+        return this;
+      }
+      /**
+       * <code>optional .org.jetbrains.kotlin.metadata.jvm.JvmMethodSignature delegate_method = 5;</code>
+       *
+       * <pre>
+       * The delegate field of delegated properties may be optimized out; `getDelegate` should
+       * then call this method instead
+       * </pre>
+       */
+      public Builder mergeDelegateMethod(org.jetbrains.kotlin.metadata.jvm.DebugJvmProtoBuf.JvmMethodSignature value) {
+        if (delegateMethodBuilder_ == null) {
+          if (((bitField0_ & 0x00000010) == 0x00000010) &&
+              delegateMethod_ != org.jetbrains.kotlin.metadata.jvm.DebugJvmProtoBuf.JvmMethodSignature.getDefaultInstance()) {
+            delegateMethod_ =
+              org.jetbrains.kotlin.metadata.jvm.DebugJvmProtoBuf.JvmMethodSignature.newBuilder(delegateMethod_).mergeFrom(value).buildPartial();
+          } else {
+            delegateMethod_ = value;
+          }
+          onChanged();
+        } else {
+          delegateMethodBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00000010;
+        return this;
+      }
+      /**
+       * <code>optional .org.jetbrains.kotlin.metadata.jvm.JvmMethodSignature delegate_method = 5;</code>
+       *
+       * <pre>
+       * The delegate field of delegated properties may be optimized out; `getDelegate` should
+       * then call this method instead
+       * </pre>
+       */
+      public Builder clearDelegateMethod() {
+        if (delegateMethodBuilder_ == null) {
+          delegateMethod_ = org.jetbrains.kotlin.metadata.jvm.DebugJvmProtoBuf.JvmMethodSignature.getDefaultInstance();
+          onChanged();
+        } else {
+          delegateMethodBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000010);
+        return this;
+      }
+      /**
+       * <code>optional .org.jetbrains.kotlin.metadata.jvm.JvmMethodSignature delegate_method = 5;</code>
+       *
+       * <pre>
+       * The delegate field of delegated properties may be optimized out; `getDelegate` should
+       * then call this method instead
+       * </pre>
+       */
+      public org.jetbrains.kotlin.metadata.jvm.DebugJvmProtoBuf.JvmMethodSignature.Builder getDelegateMethodBuilder() {
+        bitField0_ |= 0x00000010;
+        onChanged();
+        return getDelegateMethodFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>optional .org.jetbrains.kotlin.metadata.jvm.JvmMethodSignature delegate_method = 5;</code>
+       *
+       * <pre>
+       * The delegate field of delegated properties may be optimized out; `getDelegate` should
+       * then call this method instead
+       * </pre>
+       */
+      public org.jetbrains.kotlin.metadata.jvm.DebugJvmProtoBuf.JvmMethodSignatureOrBuilder getDelegateMethodOrBuilder() {
+        if (delegateMethodBuilder_ != null) {
+          return delegateMethodBuilder_.getMessageOrBuilder();
+        } else {
+          return delegateMethod_;
+        }
+      }
+      /**
+       * <code>optional .org.jetbrains.kotlin.metadata.jvm.JvmMethodSignature delegate_method = 5;</code>
+       *
+       * <pre>
+       * The delegate field of delegated properties may be optimized out; `getDelegate` should
+       * then call this method instead
+       * </pre>
+       */
+      private org.jetbrains.kotlin.protobuf.SingleFieldBuilder<
+          org.jetbrains.kotlin.metadata.jvm.DebugJvmProtoBuf.JvmMethodSignature, org.jetbrains.kotlin.metadata.jvm.DebugJvmProtoBuf.JvmMethodSignature.Builder, org.jetbrains.kotlin.metadata.jvm.DebugJvmProtoBuf.JvmMethodSignatureOrBuilder> 
+          getDelegateMethodFieldBuilder() {
+        if (delegateMethodBuilder_ == null) {
+          delegateMethodBuilder_ = new org.jetbrains.kotlin.protobuf.SingleFieldBuilder<
+              org.jetbrains.kotlin.metadata.jvm.DebugJvmProtoBuf.JvmMethodSignature, org.jetbrains.kotlin.metadata.jvm.DebugJvmProtoBuf.JvmMethodSignature.Builder, org.jetbrains.kotlin.metadata.jvm.DebugJvmProtoBuf.JvmMethodSignatureOrBuilder>(
+                  getDelegateMethod(),
+                  getParentForChildren(),
+                  isClean());
+          delegateMethod_ = null;
+        }
+        return delegateMethodBuilder_;
+      }
+
       // @@protoc_insertion_point(builder_scope:org.jetbrains.kotlin.metadata.jvm.JvmPropertySignature)
     }
 
@@ -4740,7 +5004,7 @@ public final class DebugJvmProtoBuf {
       "\020DESC_TO_CLASS_ID\020\002\"<\n\022JvmMethodSignatur" +
       "e\022\022\n\004name\030\001 \001(\005B\004\230\265\030\001\022\022\n\004desc\030\002 \001(\005B\004\230\265\030" +
       "\001\";\n\021JvmFieldSignature\022\022\n\004name\030\001 \001(\005B\004\230\265" +
-      "\030\001\022\022\n\004desc\030\002 \001(\005B\004\230\265\030\001\"\272\002\n\024JvmPropertySi" +
+      "\030\001\022\022\n\004desc\030\002 \001(\005B\004\230\265\030\001\"\212\003\n\024JvmPropertySi" +
       "gnature\022C\n\005field\030\001 \001(\01324.org.jetbrains.k" +
       "otlin.metadata.jvm.JvmFieldSignature\022O\n\020",
       "synthetic_method\030\002 \001(\01325.org.jetbrains.k" +
@@ -4748,11 +5012,13 @@ public final class DebugJvmProtoBuf {
       "\006getter\030\003 \001(\01325.org.jetbrains.kotlin.met" +
       "adata.jvm.JvmMethodSignature\022E\n\006setter\030\004" +
       " \001(\01325.org.jetbrains.kotlin.metadata.jvm" +
+      ".JvmMethodSignature\022N\n\017delegate_method\030\005" +
+      " \001(\01325.org.jetbrains.kotlin.metadata.jvm" +
       ".JvmMethodSignature:\200\001\n\025constructor_sign" +
       "ature\022*.org.jetbrains.kotlin.metadata.Co" +
-      "nstructor\030d \001(\01325.org.jetbrains.kotlin.m" +
+      "nstructor\030d \001(\01325.org.jetbrains.kotlin.m",
       "etadata.jvm.JvmMethodSignature:x\n\020method" +
-      "_signature\022\'.org.jetbrains.kotlin.metada",
+      "_signature\022\'.org.jetbrains.kotlin.metada" +
       "ta.Function\030d \001(\01325.org.jetbrains.kotlin" +
       ".metadata.jvm.JvmMethodSignature:O\n\030lamb" +
       "da_class_origin_name\022\'.org.jetbrains.kot" +
@@ -4760,9 +5026,9 @@ public final class DebugJvmProtoBuf {
       "perty_signature\022\'.org.jetbrains.kotlin.m" +
       "etadata.Property\030d \001(\01327.org.jetbrains.k" +
       "otlin.metadata.jvm.JvmPropertySignature:" +
-      "9\n\005flags\022\'.org.jetbrains.kotlin.metadata" +
+      "9\n\005flags\022\'.org.jetbrains.kotlin.metadata",
       ".Property\030e \001(\005:\0010:g\n\017type_annotation\022#." +
-      "org.jetbrains.kotlin.metadata.Type\030d \003(\013",
+      "org.jetbrains.kotlin.metadata.Type\030d \003(\013" +
       "2).org.jetbrains.kotlin.metadata.Annotat" +
       "ion:3\n\006is_raw\022#.org.jetbrains.kotlin.met" +
       "adata.Type\030e \001(\010:z\n\031type_parameter_annot" +
@@ -4770,9 +5036,9 @@ public final class DebugJvmProtoBuf {
       "peParameter\030d \003(\0132).org.jetbrains.kotlin" +
       ".metadata.Annotation:E\n\021class_module_nam" +
       "e\022$.org.jetbrains.kotlin.metadata.Class\030" +
-      "e \001(\005B\004\230\265\030\001:k\n\024class_local_variable\022$.or" +
+      "e \001(\005B\004\230\265\030\001:k\n\024class_local_variable\022$.or",
       "g.jetbrains.kotlin.metadata.Class\030f \003(\0132" +
-      "\'.org.jetbrains.kotlin.metadata.Property",
+      "\'.org.jetbrains.kotlin.metadata.Property" +
       ":P\n\034anonymous_object_origin_name\022$.org.j" +
       "etbrains.kotlin.metadata.Class\030g \001(\005B\004\230\265" +
       "\030\001:@\n\017jvm_class_flags\022$.org.jetbrains.ko" +
@@ -4780,7 +5046,7 @@ public final class DebugJvmProtoBuf {
       "module_name\022&.org.jetbrains.kotlin.metad" +
       "ata.Package\030e \001(\005B\004\230\265\030\001:o\n\026package_local" +
       "_variable\022&.org.jetbrains.kotlin.metadat" +
-      "a.Package\030f \003(\0132\'.org.jetbrains.kotlin.m" +
+      "a.Package\030f \003(\0132\'.org.jetbrains.kotlin.m",
       "etadata.PropertyB\022B\020DebugJvmProtoBuf"
     };
     org.jetbrains.kotlin.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
@@ -4826,7 +5092,7 @@ public final class DebugJvmProtoBuf {
     internal_static_org_jetbrains_kotlin_metadata_jvm_JvmPropertySignature_fieldAccessorTable = new
       org.jetbrains.kotlin.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_org_jetbrains_kotlin_metadata_jvm_JvmPropertySignature_descriptor,
-        new java.lang.String[] { "Field", "SyntheticMethod", "Getter", "Setter", });
+        new java.lang.String[] { "Field", "SyntheticMethod", "Getter", "Setter", "DelegateMethod", });
     constructorSignature.internalInit(descriptor.getExtensions().get(0));
     methodSignature.internalInit(descriptor.getExtensions().get(1));
     lambdaClassOriginName.internalInit(descriptor.getExtensions().get(2));

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/serialization/JvmSerializationBindings.java
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/serialization/JvmSerializationBindings.java
@@ -35,6 +35,8 @@ public final class JvmSerializationBindings {
             SerializationMappingSlice.create();
     public static final SerializationMappingSlice<PropertyDescriptor, Method> SYNTHETIC_METHOD_FOR_PROPERTY =
             SerializationMappingSlice.create();
+    public static final SerializationMappingSlice<PropertyDescriptor, Method> DELEGATE_METHOD_FOR_PROPERTY =
+            SerializationMappingSlice.create();
 
     public static final class SerializationMappingSlice<K, V> extends BasicWritableSlice<K, V> {
         public SerializationMappingSlice() {

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/serialization/JvmSerializerExtension.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/serialization/JvmSerializerExtension.kt
@@ -255,12 +255,15 @@ class JvmSerializerExtension @JvmOverloads constructor(
 
         val field = getBinding(FIELD_FOR_PROPERTY, descriptor)
         val syntheticMethod = getBinding(SYNTHETIC_METHOD_FOR_PROPERTY, descriptor)
+        val delegateMethod = getBinding(DELEGATE_METHOD_FOR_PROPERTY, descriptor)
+        assert(descriptor.isDelegated || delegateMethod == null) { "non-delegated property $descriptor has delegate method" }
 
         val signature = signatureSerializer.propertySignature(
             descriptor,
             field?.second,
             field?.first?.descriptor,
             if (syntheticMethod != null) signatureSerializer.methodSignature(null, syntheticMethod) else null,
+            if (delegateMethod != null) signatureSerializer.methodSignature(null, delegateMethod) else null,
             if (getterMethod != null) signatureSerializer.methodSignature(null, getterMethod) else null,
             if (setterMethod != null) signatureSerializer.methodSignature(null, setterMethod) else null
         )
@@ -359,6 +362,7 @@ class JvmSerializerExtension @JvmOverloads constructor(
             fieldName: String?,
             fieldDesc: String?,
             syntheticMethod: JvmProtoBuf.JvmMethodSignature?,
+            delegateMethod: JvmProtoBuf.JvmMethodSignature?,
             getter: JvmProtoBuf.JvmMethodSignature?,
             setter: JvmProtoBuf.JvmMethodSignature?
         ): JvmProtoBuf.JvmPropertySignature? {
@@ -371,6 +375,10 @@ class JvmSerializerExtension @JvmOverloads constructor(
 
             if (syntheticMethod != null) {
                 signature.syntheticMethod = syntheticMethod
+            }
+
+            if (delegateMethod != null) {
+                signature.delegateMethod = delegateMethod
             }
 
             if (getter != null) {

--- a/compiler/fir/fir2ir/jvm-backend/src/org/jetbrains/kotlin/fir/backend/jvm/FirMetadataSerializer.kt
+++ b/compiler/fir/fir2ir/jvm-backend/src/org/jetbrains/kotlin/fir/backend/jvm/FirMetadataSerializer.kt
@@ -183,8 +183,13 @@ class FirMetadataSerializer(
                 serializer!!.packagePartProto(irClass.getPackageFragment()!!.fqName, metadata.fir).apply {
                     serializerExtension.serializeJvmPackage(this)
                 }.build()
-            is FirMetadataSource.Function ->
-                serializer!!.functionProto(metadata.fir.copyToFreeAnonymousFunction())?.build()
+            is FirMetadataSource.Function -> {
+                val withTypeParameters = metadata.fir.copyToFreeAnonymousFunction()
+                serializationBindings.get(FirJvmSerializerExtension.METHOD_FOR_FIR_FUNCTION, metadata.fir)?.let {
+                    serializationBindings.put(FirJvmSerializerExtension.METHOD_FOR_FIR_FUNCTION, withTypeParameters, it)
+                }
+                serializer!!.functionProto(withTypeParameters)?.build()
+            }
             else -> null
         } ?: return null
         return message to serializer!!.stringTable as JvmStringTable

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -13211,9 +13211,21 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         }
 
         @Test
+        @TestMetadata("delegateToAnotherWithSideEffects.kt")
+        public void testDelegateToAnotherWithSideEffects() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnotherWithSideEffects.kt");
+        }
+
+        @Test
         @TestMetadata("delegateToGenericJavaProperty.kt")
         public void testDelegateToGenericJavaProperty() throws Exception {
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateToGenericJavaProperty.kt");
+        }
+
+        @Test
+        @TestMetadata("delegateToOpenProperty.kt")
+        public void testDelegateToOpenProperty() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToOpenProperty.kt");
         }
 
         @Test

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -13193,9 +13193,21 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         }
 
         @Test
+        @TestMetadata("delegateToAnotherCustom.kt")
+        public void testDelegateToAnotherCustom() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnotherCustom.kt");
+        }
+
+        @Test
         @TestMetadata("delegateToAnotherMutable.kt")
         public void testDelegateToAnotherMutable() throws Exception {
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnotherMutable.kt");
+        }
+
+        @Test
+        @TestMetadata("delegateToAnotherReflection.kt")
+        public void testDelegateToAnotherReflection() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnotherReflection.kt");
         }
 
         @Test

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -13193,6 +13193,18 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         }
 
         @Test
+        @TestMetadata("delegateToAnotherMutable.kt")
+        public void testDelegateToAnotherMutable() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnotherMutable.kt");
+        }
+
+        @Test
+        @TestMetadata("delegateToGenericJavaProperty.kt")
+        public void testDelegateToGenericJavaProperty() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToGenericJavaProperty.kt");
+        }
+
+        @Test
         @TestMetadata("delegateWithPrivateSet.kt")
         public void testDelegateWithPrivateSet() throws Exception {
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateWithPrivateSet.kt");

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -18823,6 +18823,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         }
 
         @Test
+        @TestMetadata("kt47609.kt")
+        public void testKt47609() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/kt47609.kt");
+        }
+
+        @Test
         @TestMetadata("mangledDefaultParameterFunction.kt")
         public void testMangledDefaultParameterFunction() throws Exception {
             runTest("compiler/testData/codegen/box/inlineClasses/mangledDefaultParameterFunction.kt");

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBytecodeTextTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBytecodeTextTestGenerated.java
@@ -4703,6 +4703,12 @@ public class FirBytecodeTextTestGenerated extends AbstractFirBytecodeTextTest {
         }
 
         @Test
+        @TestMetadata("delegateToAnother.kt")
+        public void testDelegateToAnother() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/optimizedDelegatedProperties/delegateToAnother.kt");
+        }
+
+        @Test
         @TestMetadata("inSeparateModule.kt")
         public void testInSeparateModule() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/optimizedDelegatedProperties/inSeparateModule.kt");

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
@@ -334,6 +334,7 @@ private val jvmFilePhases = listOf(
     inlineCallableReferenceToLambdaPhase,
     functionReferencePhase,
     suspendLambdaPhase,
+    propertyReferenceDelegationPhase,
     propertyReferencePhase,
     arrayConstructorPhase,
     constPhase1,

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ClassCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ClassCodegen.kt
@@ -57,7 +57,7 @@ import java.util.concurrent.ConcurrentHashMap
 
 interface MetadataSerializer {
     fun serialize(metadata: MetadataSource): Pair<MessageLite, JvmStringTable>?
-    fun bindMethodMetadata(metadata: MetadataSource.Property, signature: Method)
+    fun bindPropertyMetadata(metadata: MetadataSource.Property, signature: Method, origin: IrDeclarationOrigin)
     fun bindMethodMetadata(metadata: MetadataSource.Function, signature: Method)
     fun bindFieldMetadata(metadata: MetadataSource.Property, signature: Pair<Type, String>)
 }
@@ -393,12 +393,7 @@ class ClassCodegen private constructor(
         jvmSignatureClashDetector.trackMethod(method, RawSignature(node.name, node.desc, MemberKind.METHOD))
 
         when (val metadata = method.metadata) {
-            is MetadataSource.Property -> {
-                assert(method.origin == JvmLoweredDeclarationOrigin.SYNTHETIC_METHOD_FOR_PROPERTY_OR_TYPEALIAS_ANNOTATIONS) {
-                    "MetadataSource.Property on IrFunction should only be used for synthetic \$annotations methods: ${method.render()}"
-                }
-                metadataSerializer.bindMethodMetadata(metadata, Method(node.name, node.desc))
-            }
+            is MetadataSource.Property -> metadataSerializer.bindPropertyMetadata(metadata, Method(node.name, node.desc), method.origin)
             is MetadataSource.Function -> metadataSerializer.bindMethodMetadata(metadata, Method(node.name, node.desc))
             null -> Unit
             else -> error("Incorrect metadata source $metadata for:\n${method.dump()}")

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/DescriptorMetadataSerializer.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/DescriptorMetadataSerializer.kt
@@ -65,8 +65,13 @@ class DescriptorMetadataSerializer(
                 serializer!!.packagePartProto(irClass.getPackageFragment()!!.fqName, metadata.descriptors).apply {
                     serializerExtension.serializeJvmPackage(this, type)
                 }.build()
-            is DescriptorMetadataSource.Function ->
-                serializer!!.functionProto(createFreeFakeLambdaDescriptor(metadata.descriptor, context.state.typeApproximator))?.build()
+            is DescriptorMetadataSource.Function -> {
+                val withTypeParameters = createFreeFakeLambdaDescriptor(metadata.descriptor, context.state.typeApproximator)
+                serializationBindings.get(JvmSerializationBindings.METHOD_FOR_FUNCTION, metadata.descriptor)?.let {
+                    serializationBindings.put(JvmSerializationBindings.METHOD_FOR_FUNCTION, withTypeParameters, it)
+                }
+                serializer!!.functionProto(withTypeParameters)?.build()
+            }
             else -> null
         } ?: return null
         return message to serializer!!.stringTable as JvmStringTable

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/FunctionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/FunctionCodegen.kt
@@ -135,8 +135,6 @@ class FunctionCodegen(private val irFunction: IrFunction, private val classCodeg
             irFunction.origin == JvmLoweredDeclarationOrigin.SYNTHETIC_METHOD_FOR_PROPERTY_OR_TYPEALIAS_ANNOTATIONS ->
                 false
             irFunction is IrConstructor && irFunction.parentAsClass.shouldNotGenerateConstructorParameterAnnotations() ->
-                // Not generating parameter annotations for default stubs fixes KT-7892, though
-                // this certainly looks like a workaround for a javac bug.
                 false
             else ->
                 true
@@ -310,6 +308,8 @@ class FunctionCodegen(private val irFunction: IrFunction, private val classCodeg
     companion object {
         internal val methodOriginsWithoutAnnotations =
             setOf(
+                // Not generating parameter annotations for default stubs fixes KT-7892, though
+                // this certainly looks like a workaround for a javac bug.
                 IrDeclarationOrigin.FUNCTION_FOR_DEFAULT_PARAMETER,
                 JvmLoweredDeclarationOrigin.SYNTHETIC_ACCESSOR,
                 IrDeclarationOrigin.ENUM_CLASS_SPECIAL_MEMBER,
@@ -319,6 +319,7 @@ class FunctionCodegen(private val irFunction: IrFunction, private val classCodeg
                 JvmLoweredDeclarationOrigin.ABSTRACT_BRIDGE_STUB,
                 JvmLoweredDeclarationOrigin.TO_ARRAY,
                 IrDeclarationOrigin.IR_BUILTINS_STUB,
+                IrDeclarationOrigin.PROPERTY_DELEGATE,
             )
     }
 }

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/MethodSignatureMapper.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/MethodSignatureMapper.kt
@@ -132,6 +132,7 @@ class MethodSignatureMapper(private val context: JvmBackendContext) {
         if (visibility == DescriptorVisibilities.INTERNAL &&
             origin != JvmLoweredDeclarationOrigin.STATIC_INLINE_CLASS_CONSTRUCTOR &&
             origin != JvmLoweredDeclarationOrigin.SYNTHETIC_METHOD_FOR_PROPERTY_OR_TYPEALIAS_ANNOTATIONS &&
+            origin != IrDeclarationOrigin.PROPERTY_DELEGATE &&
             !isPublishedApi()
         ) {
             return originalFunction.takeIf { it != this }

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/AssertionLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/AssertionLowering.kt
@@ -120,11 +120,6 @@ private class AssertionLowering(private val context: JvmBackendContext) :
         get() = name.asString() == "assert" && getPackageFragment()?.fqName == StandardNames.BUILT_INS_PACKAGE_FQ_NAME
 }
 
-private fun IrBuilderWithScope.getJavaClass(backendContext: JvmBackendContext, irClass: IrClass) =
-    with(FunctionReferenceLowering) {
-        javaClassReference(irClass.defaultType, backendContext)
-    }
-
 fun IrClass.buildAssertionsDisabledField(backendContext: JvmBackendContext, topLevelClass: IrClass) =
     factory.buildField {
         name = Name.identifier(ASSERTIONS_DISABLED_FIELD_NAME)
@@ -138,7 +133,9 @@ fun IrClass.buildAssertionsDisabledField(backendContext: JvmBackendContext, topL
         field.initializer = backendContext.createJvmIrBuilder(this.symbol).run {
             at(field)
             irExprBody(irNot(irCall(irSymbols.desiredAssertionStatus).apply {
-                dispatchReceiver = getJavaClass(backendContext, topLevelClass)
+                dispatchReceiver = with(FunctionReferenceLowering) {
+                    javaClassReference(topLevelClass.defaultType)
+                }
             }))
         }
     }

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/EnumClassLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/EnumClassLowering.kt
@@ -162,7 +162,7 @@ private class EnumClassLowering(val context: JvmBackendContext) : ClassLoweringP
                             IrSyntheticBodyKind.ENUM_VALUEOF ->
                                 irCall(backendContext.ir.symbols.enumValueOfFunction).apply {
                                     putValueArgument(0, with(FunctionReferenceLowering) {
-                                        javaClassReference(irClass.defaultType, backendContext)
+                                        javaClassReference(irClass.defaultType)
                                     })
                                     putValueArgument(1, irGet(declaration.valueParameters[0]))
                                 }

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/FunctionReferenceLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/FunctionReferenceLowering.kt
@@ -514,7 +514,7 @@ internal class FunctionReferenceLowering(private val context: JvmBackendContext)
                         irString(callee.originalName.asString())
                     }
                     createLegacyMethodOverride(irSymbols.functionReferenceGetOwner.owner) {
-                        calculateOwner(callee.parent, backendContext)
+                        calculateOwner(callee.parent)
                     }
                 }
 
@@ -627,8 +627,8 @@ internal class FunctionReferenceLowering(private val context: JvmBackendContext)
             }
             if (!isLambda && useOptimizedSuperClass) {
                 val callableReferenceTarget = adaptedReferenceOriginalTarget ?: callee
-                val owner = calculateOwnerKClass(callableReferenceTarget.parent, backendContext)
-                call.putValueArgument(index++, kClassToJavaClass(owner, backendContext))
+                val owner = calculateOwnerKClass(callableReferenceTarget.parent)
+                call.putValueArgument(index++, kClassToJavaClass(owner))
                 call.putValueArgument(index++, irString(callableReferenceTarget.originalName.asString()))
                 call.putValueArgument(index++, generateSignature(callableReferenceTarget.symbol))
                 call.putValueArgument(index, irInt(getFunctionReferenceFlags(callableReferenceTarget)))
@@ -803,31 +803,31 @@ internal class FunctionReferenceLowering(private val context: JvmBackendContext)
                 startOffset, endOffset, context.irBuiltIns.kClassClass.starProjectedType, context.irBuiltIns.kClassClass, classType
             )
 
-        internal fun IrBuilderWithScope.kClassToJavaClass(kClassReference: IrExpression, context: JvmBackendContext) =
-            irGet(context.ir.symbols.javaLangClass.starProjectedType, null, context.ir.symbols.kClassJava.owner.getter!!.symbol).apply {
+        internal fun JvmIrBuilder.kClassToJavaClass(kClassReference: IrExpression) =
+            irGet(irSymbols.javaLangClass.starProjectedType, null, irSymbols.kClassJava.owner.getter!!.symbol).apply {
                 extensionReceiver = kClassReference
             }
 
-        internal fun IrBuilderWithScope.javaClassReference(classType: IrType, context: JvmBackendContext) =
-            kClassToJavaClass(kClassReference(classType), context)
+        internal fun JvmIrBuilder.javaClassReference(classType: IrType) =
+            kClassToJavaClass(kClassReference(classType))
 
-        internal fun IrBuilderWithScope.calculateOwner(irContainer: IrDeclarationParent, context: JvmBackendContext): IrExpression {
-            val kClass = calculateOwnerKClass(irContainer, context)
+        internal fun JvmIrBuilder.calculateOwner(irContainer: IrDeclarationParent): IrExpression {
+            val kClass = calculateOwnerKClass(irContainer)
 
             if ((irContainer as? IrClass)?.isFileClass != true && irContainer !is IrPackageFragment)
                 return kClass
 
-            return irCall(context.ir.symbols.getOrCreateKotlinPackage).apply {
-                putValueArgument(0, kClassToJavaClass(kClass, context))
+            return irCall(irSymbols.getOrCreateKotlinPackage).apply {
+                putValueArgument(0, kClassToJavaClass(kClass))
                 // Note that this name is not used in reflection. There should be the name of the referenced declaration's
                 // module instead, but there's no nice API to obtain that name here yet
                 // TODO: write the referenced declaration's module name and use it in reflection
-                putValueArgument(1, irString(context.state.moduleName))
+                putValueArgument(1, irString(backendContext.state.moduleName))
             }
         }
 
-        internal fun IrBuilderWithScope.calculateOwnerKClass(irContainer: IrDeclarationParent, context: JvmBackendContext): IrExpression =
-            kClassReference(getOwnerKClassType(irContainer, context))
+        internal fun JvmIrBuilder.calculateOwnerKClass(irContainer: IrDeclarationParent): IrExpression =
+            kClassReference(getOwnerKClassType(irContainer, backendContext))
 
         internal fun getOwnerKClassType(irContainer: IrDeclarationParent, context: JvmBackendContext): IrType =
             if (irContainer is IrClass) irContainer.defaultType

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/FunctionReferenceLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/FunctionReferenceLowering.kt
@@ -672,6 +672,7 @@ internal class FunctionReferenceLowering(private val context: JvmBackendContext)
                 returnType = referenceReturnType
                 isSuspend = callee.isSuspend
             }.apply {
+                metadata = functionReferenceClass.metadata
                 overriddenSymbols += superMethod.symbol
                 dispatchReceiverParameter = buildReceiverParameter(
                     this,

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/GenerateMultifileFacades.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/GenerateMultifileFacades.kt
@@ -239,6 +239,7 @@ private fun IrSimpleFunction.createMultifileDelegateIfNeeded(
         name == StaticInitializersLowering.clinitName ||
         origin == JvmLoweredDeclarationOrigin.SYNTHETIC_ACCESSOR ||
         origin == IrDeclarationOrigin.LOCAL_FUNCTION_FOR_LAMBDA ||
+        origin == IrDeclarationOrigin.PROPERTY_DELEGATE ||
         // $annotations methods in the facade are only needed for const properties.
         (origin == JvmLoweredDeclarationOrigin.SYNTHETIC_METHOD_FOR_PROPERTY_OR_TYPEALIAS_ANNOTATIONS &&
                 (metadata as? MetadataSource.Property)?.isConst != true)

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/PropertyReferenceDelegationLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/PropertyReferenceDelegationLowering.kt
@@ -9,20 +9,20 @@ import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.common.phaser.makeIrFilePhase
 import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
+import org.jetbrains.kotlin.backend.jvm.codegen.fileParent
 import org.jetbrains.kotlin.backend.jvm.ir.createJvmIrBuilder
 import org.jetbrains.kotlin.backend.jvm.lower.JvmPropertiesLowering.Companion.createSyntheticMethodForPropertyDelegate
 import org.jetbrains.kotlin.builtins.StandardNames
+import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.builders.declarations.buildField
 import org.jetbrains.kotlin.ir.builders.declarations.buildVariable
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.expressions.*
-import org.jetbrains.kotlin.ir.expressions.impl.IrCompositeImpl
-import org.jetbrains.kotlin.ir.expressions.impl.IrPropertyReferenceImpl
-import org.jetbrains.kotlin.ir.util.getPackageFragment
-import org.jetbrains.kotlin.ir.util.render
-import org.jetbrains.kotlin.ir.util.transformDeclarationsFlat
+import org.jetbrains.kotlin.ir.expressions.impl.*
+import org.jetbrains.kotlin.ir.symbols.impl.IrAnonymousInitializerSymbolImpl
+import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 import org.jetbrains.kotlin.name.Name
 
@@ -39,14 +39,15 @@ private class PropertyReferenceDelegationLowering(val context: JvmBackendContext
 }
 
 private class PropertyReferenceDelegationTransformer(val context: JvmBackendContext) : IrElementTransformerVoid() {
-    private fun IrSimpleFunction.accessorBody(delegate: IrPropertyReference, receiverField: IrDeclaration?) =
+    private fun IrSimpleFunction.accessorBody(delegate: IrPropertyReference, receiverFieldOrExpression: IrStatement?) =
         context.createIrBuilder(symbol, startOffset, endOffset).run {
             val value = valueParameters.singleOrNull()?.let(::irGet)
-            var boundReceiver = when (receiverField) {
+            var boundReceiver = when (receiverFieldOrExpression) {
                 null -> null
-                is IrField -> irGetField(dispatchReceiverParameter?.let(::irGet), receiverField)
-                is IrValueDeclaration -> irGet(receiverField)
-                else -> throw AssertionError("not a field/variable: ${receiverField.render()}")
+                is IrField -> irGetField(dispatchReceiverParameter?.let(::irGet), receiverFieldOrExpression)
+                is IrValueDeclaration -> irGet(receiverFieldOrExpression)
+                is IrExpression -> receiverFieldOrExpression
+                else -> throw AssertionError("not a field/variable/expression: ${receiverFieldOrExpression.render()}")
             }
             val unboundReceiver = extensionReceiverParameter ?: dispatchReceiverParameter
             val field = delegate.field?.owner
@@ -84,6 +85,35 @@ private class PropertyReferenceDelegationTransformer(val context: JvmBackendCont
     private val IrStatement.isStdlibCall: Boolean
         get() = this is IrCall && symbol.owner.getPackageFragment()?.fqName == StandardNames.BUILT_INS_PACKAGE_FQ_NAME
 
+    // Constants, object accesses, reads of immutable variables, and reads of immutable properties in the same file
+    // don't need to be cached in a field; reads of mutable properties have to be as we should ignore further assignments
+    // to those, and immutable properties in other files might become mutable without breaking ABI.
+    private fun IrExpression.canInline(currentFile: IrFile): Boolean = when (this) {
+        is IrGetValue -> !symbol.owner.let { it is IrVariable && it.isVar }
+        is IrGetField -> symbol.owner.let { it.isFinal && it.fileParent == currentFile } && receiver?.canInline(currentFile) != false
+        is IrCall -> symbol.owner.let { it.isFinalDefaultValGetter && it.fileParent == currentFile } &&
+                dispatchReceiver?.canInline(currentFile) != false && extensionReceiver?.canInline(currentFile) != false
+        else -> isTrivial()
+    }
+
+    private val IrSimpleFunction.isFinalDefaultValGetter: Boolean
+        get() = origin == IrDeclarationOrigin.DEFAULT_PROPERTY_ACCESSOR &&
+                correspondingPropertySymbol?.let { it.owner.getter == this && it.owner.setter == null } == true &&
+                modality == Modality.FINAL
+
+    private fun IrExpression.inline(oldReceiver: IrValueParameter?, newReceiver: IrValueParameter?): IrExpression = when (this) {
+        is IrGetField ->
+            IrGetFieldImpl(startOffset, endOffset, symbol, type, receiver?.inline(oldReceiver, newReceiver), origin, superQualifierSymbol)
+        is IrGetValue ->
+            IrGetValueImpl(startOffset, endOffset, type, newReceiver?.symbol.takeIf { symbol == oldReceiver?.symbol } ?: symbol, origin)
+        is IrCall ->
+            IrCallImpl(startOffset, endOffset, type, symbol, typeArgumentsCount, valueArgumentsCount, origin, superQualifierSymbol).apply {
+                dispatchReceiver = this@inline.dispatchReceiver?.inline(oldReceiver, newReceiver)
+                extensionReceiver = this@inline.extensionReceiver?.inline(oldReceiver, newReceiver)
+            }
+        else -> shallowCopy()
+    }
+
     override fun visitClass(declaration: IrClass): IrStatement {
         declaration.transformChildren(this, null)
         declaration.transformDeclarationsFlat {
@@ -102,23 +132,27 @@ private class PropertyReferenceDelegationTransformer(val context: JvmBackendCont
             setter?.returnsResultOfStdlibCall == false
         ) return null
 
-        backingField = (delegate.dispatchReceiver ?: delegate.extensionReceiver)?.let { receiver ->
+        val receiver = (delegate.dispatchReceiver ?: delegate.extensionReceiver)
+            ?.transform(this@PropertyReferenceDelegationTransformer, null)
+        backingField = receiver?.takeIf { !it.canInline(fileParent) }?.let {
             context.irFactory.buildField {
                 updateFrom(oldField)
                 name = Name.identifier("${this@transform.name}\$receiver")
                 type = receiver.type
             }.apply {
                 parent = oldField.parent
-                initializer = context.irFactory.createExpressionBody(receiver.transform(this@PropertyReferenceDelegationTransformer, null))
+                initializer = context.irFactory.createExpressionBody(it)
             }
         }
-        getter?.apply { body = accessorBody(delegate, backingField) }
-        setter?.apply { body = accessorBody(delegate, backingField) }
+        val originalThis = parentAsClass.thisReceiver
+        getter?.apply { body = accessorBody(delegate, backingField ?: receiver?.inline(originalThis, dispatchReceiverParameter)) }
+        setter?.apply { body = accessorBody(delegate, backingField ?: receiver?.inline(originalThis, dispatchReceiverParameter)) }
 
         val delegateMethod = context.createSyntheticMethodForPropertyDelegate(this).apply {
             body = context.createJvmIrBuilder(symbol).run {
-                val propertyOwner = if (getter?.dispatchReceiverParameter != null) irGet(valueParameters[0]) else null
-                val boundReceiver = backingField?.let { irGetField(propertyOwner, it) }
+                val propertyOwner = if (getter?.dispatchReceiverParameter != null) valueParameters[0] else null
+                val boundReceiver = backingField?.let { irGetField(propertyOwner?.let(::irGet), it) }
+                    ?: receiver?.inline(originalThis, propertyOwner)
                 irExprBody(with(delegate) {
                     val origin = PropertyReferenceLowering.REFLECTED_PROPERTY_REFERENCE
                     IrPropertyReferenceImpl(startOffset, endOffset, type, symbol, typeArgumentsCount, field, getter, setter, origin)
@@ -130,7 +164,14 @@ private class PropertyReferenceDelegationTransformer(val context: JvmBackendCont
                 })
             }
         }
-        return listOf(this, delegateMethod)
+        // When the receiver is inlined, it can have side effects in form of class initialization, so it should be evaluated here.
+        val receiverBlock = receiver.takeIf { backingField == null }?.let {
+            val symbol = IrAnonymousInitializerSymbolImpl(parentAsClass.symbol)
+            context.irFactory.createAnonymousInitializer(it.startOffset, it.endOffset, IrDeclarationOrigin.DEFINED, symbol).apply {
+                body = context.irFactory.createBlockBody(startOffset, endOffset, listOf(it.inline(null, null)))
+            }
+        }
+        return listOfNotNull(this, delegateMethod, receiverBlock)
     }
 
     override fun visitLocalDelegatedProperty(declaration: IrLocalDelegatedProperty): IrStatement {
@@ -140,6 +181,7 @@ private class PropertyReferenceDelegationTransformer(val context: JvmBackendCont
             declaration.setter?.returnsResultOfStdlibCall == false
         ) return super.visitLocalDelegatedProperty(declaration)
 
+        // Variables are cheap, so optimizing them out is not really necessary.
         val receiver = (delegate.dispatchReceiver ?: delegate.extensionReceiver)?.let { receiver ->
             with(declaration.delegate) { buildVariable(parent, startOffset, endOffset, origin, name, receiver.type) }.apply {
                 initializer = receiver.transform(this@PropertyReferenceDelegationTransformer, null)

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/PropertyReferenceDelegationLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/PropertyReferenceDelegationLowering.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.jvm.lower
+
+import org.jetbrains.kotlin.backend.common.FileLoweringPass
+import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
+import org.jetbrains.kotlin.backend.common.phaser.makeIrFilePhase
+import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
+import org.jetbrains.kotlin.builtins.StandardNames
+import org.jetbrains.kotlin.ir.IrStatement
+import org.jetbrains.kotlin.ir.builders.*
+import org.jetbrains.kotlin.ir.builders.declarations.buildField
+import org.jetbrains.kotlin.ir.builders.declarations.buildVariable
+import org.jetbrains.kotlin.ir.declarations.*
+import org.jetbrains.kotlin.ir.expressions.*
+import org.jetbrains.kotlin.ir.expressions.impl.IrCompositeImpl
+import org.jetbrains.kotlin.ir.util.getPackageFragment
+import org.jetbrains.kotlin.ir.util.render
+import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
+import org.jetbrains.kotlin.name.Name
+
+internal val propertyReferenceDelegationPhase = makeIrFilePhase(
+    ::PropertyReferenceDelegationLowering,
+    name = "PropertyReferenceDelegation",
+    description = "Optimize `val x by ::y`: there is no need to construct a KProperty instance"
+)
+
+private class PropertyReferenceDelegationLowering(val context: JvmBackendContext) : FileLoweringPass {
+    override fun lower(irFile: IrFile) {
+        irFile.transform(PropertyReferenceDelegationTransformer(context), null)
+    }
+}
+
+private class PropertyReferenceDelegationTransformer(val context: JvmBackendContext) : IrElementTransformerVoid() {
+    private fun IrSimpleFunction.accessorBody(delegate: IrPropertyReference, receiverField: IrDeclaration?) =
+        context.createIrBuilder(symbol, startOffset, endOffset).run {
+            val value = valueParameters.singleOrNull()?.let(::irGet)
+            var boundReceiver = when (receiverField) {
+                null -> null
+                is IrField -> irGetField(dispatchReceiverParameter?.let(::irGet), receiverField)
+                is IrValueDeclaration -> irGet(receiverField)
+                else -> throw AssertionError("not a field/variable: ${receiverField.render()}")
+            }
+            val unboundReceiver = extensionReceiverParameter ?: dispatchReceiverParameter
+            val field = delegate.field?.owner
+            val access = if (field == null) {
+                val accessor = if (value == null) delegate.getter!! else delegate.setter!!
+                irCall(accessor).apply {
+                    // This has the same assumptions about receivers as `PropertyReferenceLowering.propertyReferenceKindFor`:
+                    // only one receiver can be bound, and if the property has both, the extension receiver cannot be bound.
+                    // The frontend must also ensure the receiver of the delegated property (extension if present, dispatch
+                    // otherwise) is a subtype of the unbound receiver (if there is one; and there can *only* be one).
+                    if (accessor.owner.dispatchReceiverParameter != null) {
+                        dispatchReceiver = boundReceiver.also { boundReceiver = null } ?: irGet(unboundReceiver!!)
+                    }
+                    if (accessor.owner.extensionReceiverParameter != null) {
+                        extensionReceiver = boundReceiver.also { boundReceiver = null } ?: irGet(unboundReceiver!!)
+                    }
+                    if (value != null) {
+                        putValueArgument(0, value)
+                    }
+                }
+            } else {
+                val receiver = if (field.isStatic) null else boundReceiver ?: irGet(unboundReceiver!!)
+                if (value == null) irGetField(receiver, field) else irSetField(receiver, field, value)
+            }
+            irExprBody(access)
+        }
+
+    private val IrSimpleFunction.returnsResultOfStdlibCall: Boolean
+        get() = when (val body = body) {
+            is IrExpressionBody -> body.expression.isStdlibCall
+            is IrBlockBody -> body.statements.singleOrNull()?.let { it.isStdlibCall || (it is IrReturn && it.value.isStdlibCall) } == true
+            else -> false
+        }
+
+    private val IrStatement.isStdlibCall: Boolean
+        get() = this is IrCall && symbol.owner.getPackageFragment()?.fqName == StandardNames.BUILT_INS_PACKAGE_FQ_NAME
+
+    override fun visitProperty(declaration: IrProperty): IrStatement {
+        if (!declaration.isDelegated || declaration.isFakeOverride) return super.visitProperty(declaration)
+
+        val oldField = declaration.backingField
+        val delegate = oldField?.initializer?.expression
+        if (delegate !is IrPropertyReference ||
+            declaration.getter?.returnsResultOfStdlibCall == false ||
+            declaration.setter?.returnsResultOfStdlibCall == false
+        ) return super.visitProperty(declaration)
+
+        declaration.backingField = (delegate.dispatchReceiver ?: delegate.extensionReceiver)?.let { receiver ->
+            context.irFactory.buildField {
+                updateFrom(oldField)
+                name = Name.identifier("${declaration.name}\$receiver")
+                type = receiver.type
+            }.apply {
+                parent = oldField.parent
+                initializer = context.irFactory.createExpressionBody(receiver.transform(this@PropertyReferenceDelegationTransformer, null))
+            }
+        }
+        declaration.getter?.apply { body = accessorBody(delegate, declaration.backingField) }
+        declaration.setter?.apply { body = accessorBody(delegate, declaration.backingField) }
+        return declaration
+    }
+
+    override fun visitLocalDelegatedProperty(declaration: IrLocalDelegatedProperty): IrStatement {
+        val delegate = declaration.delegate.initializer
+        if (delegate !is IrPropertyReference ||
+            !declaration.getter.returnsResultOfStdlibCall ||
+            declaration.setter?.returnsResultOfStdlibCall == false
+        ) return super.visitLocalDelegatedProperty(declaration)
+
+        val receiver = (delegate.dispatchReceiver ?: delegate.extensionReceiver)?.let { receiver ->
+            with(declaration.delegate) { buildVariable(parent, startOffset, endOffset, origin, name, receiver.type) }.apply {
+                initializer = receiver.transform(this@PropertyReferenceDelegationTransformer, null)
+            }
+        }
+        // TODO: just like in `PropertyReferenceLowering`, probably better to inline the getter/setter rather than
+        //       generate them as local functions.
+        val getter = declaration.getter.apply { body = accessorBody(delegate, receiver) }
+        val setter = declaration.setter?.apply { body = accessorBody(delegate, receiver) }
+        val statements = listOfNotNull(receiver, getter, setter)
+        return statements.singleOrNull()
+            ?: IrCompositeImpl(declaration.startOffset, declaration.endOffset, context.irBuiltIns.unitType, null, statements)
+    }
+}

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/PropertyReferenceLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/PropertyReferenceLowering.kt
@@ -60,7 +60,7 @@ internal val propertyReferencePhase = makeIrFilePhase(
     description = "Construct KProperty instances returned by expressions such as A::x and A()::x",
     // This must be done after contents of functions are extracted into separate classes, or else the `$$delegatedProperties`
     // field will end up in the wrong class (not the one that declares the delegated property).
-    prerequisite = setOf(functionReferencePhase, suspendLambdaPhase)
+    prerequisite = setOf(functionReferencePhase, suspendLambdaPhase, propertyReferenceDelegationPhase)
 )
 
 private class PropertyReferenceLowering(val context: JvmBackendContext) : IrElementTransformerVoidWithContext(), FileLoweringPass {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/PropertyReferenceLowering.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/lower/PropertyReferenceLowering.kt
@@ -121,8 +121,12 @@ private class PropertyReferenceLowering(val context: JvmBackendContext) : IrElem
                 // Internal underlying vals of inline classes have no getter method
                 getter.owner.isInlineClassFieldGetter && getter.owner.visibility == DescriptorVisibilities.INTERNAL
         val origin = if (needsDummySignature) InlineClassAbi.UNMANGLED_FUNCTION_REFERENCE else null
-        val reference =
-            IrFunctionReferenceImpl.fromSymbolOwner(UNDEFINED_OFFSET, UNDEFINED_OFFSET, expression.type, getter, 0, getter, origin)
+        val reference = IrFunctionReferenceImpl.fromSymbolOwner(
+            startOffset, endOffset, expression.type, getter, getter.owner.typeParameters.size, getter, origin
+        )
+        for ((index, parameter) in getter.owner.typeParameters.withIndex()) {
+            reference.putTypeArgument(index, parameter.erasedUpperBound.defaultType)
+        }
         return irCall(signatureStringIntrinsic).apply { putValueArgument(0, reference) }
     }
 

--- a/compiler/testData/codegen/box/delegatedProperty/delegateToAnother.kt
+++ b/compiler/testData/codegen/box/delegatedProperty/delegateToAnother.kt
@@ -1,4 +1,3 @@
-// WITH_REFLECT
 // WITH_RUNTIME
 class C(val x: String)
 

--- a/compiler/testData/codegen/box/delegatedProperty/delegateToAnotherCustom.kt
+++ b/compiler/testData/codegen/box/delegatedProperty/delegateToAnotherCustom.kt
@@ -1,0 +1,14 @@
+// WITH_RUNTIME
+var x: String
+    get() = throw Exception("x's getter shouldn't be called")
+    set(_) { throw Exception("x's setter shouldn't be called") }
+var y: String by ::x
+
+var storage = "Fail"
+operator fun Any.getValue(thiz: Any?, property: Any?): String = storage
+operator fun Any.setValue(thiz: Any?, property: Any?, value: String) { storage = value }
+
+fun box(): String {
+    y = "OK"
+    return y
+}

--- a/compiler/testData/codegen/box/delegatedProperty/delegateToAnotherMutable.kt
+++ b/compiler/testData/codegen/box/delegatedProperty/delegateToAnotherMutable.kt
@@ -1,0 +1,13 @@
+// WITH_RUNTIME
+// IGNORE_BACKEND: JS
+class C(var x: String)
+
+var x = "fail"
+var y by ::x
+var z by C("fail")::x
+
+fun box(): String {
+    y = "O"
+    z = "K"
+    return y + z
+}

--- a/compiler/testData/codegen/box/delegatedProperty/delegateToAnotherReflection.kt
+++ b/compiler/testData/codegen/box/delegatedProperty/delegateToAnotherReflection.kt
@@ -1,0 +1,51 @@
+// WITH_REFLECT
+// TARGET_BACKEND: JVM
+import kotlin.reflect.*
+import kotlin.reflect.jvm.isAccessible
+import kotlin.reflect.full.getExtensionDelegate
+
+class C(var x: Int) {
+    var y by C::x
+    var z by ::x
+}
+
+class D(val c: C) {
+    var y by c::x
+}
+
+var x = 1
+var y by ::x
+var z by C(1)::x
+
+var _x = -99
+var Int.x
+    get() = this + _x
+    set(v: Int) { _x = v - this }
+var Int.y by Int::x
+
+inline fun <P : KProperty<*>, R> P.test(delegate: P.() -> R, get: R.() -> Int, set: R.(Int) -> Unit) {
+    val ref = apply { isAccessible = true }.delegate()
+    require(ref.get() == 1) { "$ref initial value is ${ref.get()}, not 1" }
+    ref.set(2)
+    require(ref.get() == 2) { "$ref after set(2) is ${ref.get()}, not 2" }
+    ref.set(1)
+}
+
+fun KMutableProperty0<Int>.test() =
+    test({ getDelegate() as KMutableProperty0<Int> }, { get() }, { set(it) })
+
+fun <T> KMutableProperty1<T, Int>.test(receiver: T) =
+    test({ getDelegate(receiver) as KMutableProperty0<Int> }, { get() }, { set(it) })
+
+fun <T> KMutableProperty1<T, Int>.test(receiver: T, receiver2: T) =
+    test({ getDelegate(receiver) as KMutableProperty1<T, Int> }, { get(receiver2) }, { set(receiver2, it) })
+
+fun box(): String {
+    C::y.test(C(100), C(1))
+    C::z.test(C(1))
+    D::y.test(D(C(1)))
+    ::y.test()
+    ::z.test()
+    Int::y.test({ getExtensionDelegate() as KMutableProperty1<Int, Int> }, { get(100) }, { set(100, it) })
+    return "OK"
+}

--- a/compiler/testData/codegen/box/delegatedProperty/delegateToAnotherWithSideEffects.kt
+++ b/compiler/testData/codegen/box/delegatedProperty/delegateToAnotherWithSideEffects.kt
@@ -1,0 +1,16 @@
+// WITH_RUNTIME
+var result = "Fail"
+
+object O {
+    val z = 42
+    init { result = "OK" }
+}
+
+class A {
+    val x by O::z
+}
+
+fun box(): String {
+    A()
+    return result
+}

--- a/compiler/testData/codegen/box/delegatedProperty/delegateToGenericJavaProperty.kt
+++ b/compiler/testData/codegen/box/delegatedProperty/delegateToGenericJavaProperty.kt
@@ -1,0 +1,26 @@
+// TARGET_BACKEND: JVM
+// v-- fir2ir produces an IrFunctionReference of type KProperty0 instead of an IrPropertyReference
+// IGNORE_BACKEND_FIR: JVM_IR
+// WITH_REFLECT
+// WITH_RUNTIME
+// FILE: J.java
+public interface J<T> {
+    public T getValue();
+}
+
+// FILE: box.kt
+class Impl(val x: String) : J<String> {
+    override fun getValue() = x
+}
+
+val j1: J<String> = Impl("O")
+// Note that taking a reference to `J<T>::value` is not permitted by the frontend
+// in any context except as a direct argument to `by`; e.g. `val x by run { j1::value }`
+// would produce an error.
+val x by j1::value
+
+fun box(): String {
+    val j2: J<String> = Impl("K")
+    val y by j2::value
+    return x + y
+}

--- a/compiler/testData/codegen/box/delegatedProperty/delegateToOpenProperty.kt
+++ b/compiler/testData/codegen/box/delegatedProperty/delegateToOpenProperty.kt
@@ -1,0 +1,23 @@
+// WITH_RUNTIME
+val String.foo: String
+    get() = this
+
+abstract class A {
+    abstract val x: String
+
+    val y by x::foo
+}
+
+var storage = "OK"
+
+class B : A() {
+    override var x: String
+        get() = storage
+        set(value) { storage = value }
+}
+
+fun box(): String {
+    val b = B()
+    b.x = "fail"
+    return b.y
+}

--- a/compiler/testData/codegen/box/inlineClasses/kt47609.kt
+++ b/compiler/testData/codegen/box/inlineClasses/kt47609.kt
@@ -1,0 +1,11 @@
+// WITH_REFLECT
+// TARGET_BACKEND: JVM
+annotation class Ann(val value: String)
+
+inline class C<T>(val x: String)
+
+@Ann("OK")
+val <T> C<T>.value: String
+    get() = x
+
+fun box() = (C<Any?>::value.annotations.singleOrNull() as? Ann)?.value ?: "null"

--- a/compiler/testData/codegen/bytecodeText/optimizedDelegatedProperties/delegateToAnother.kt
+++ b/compiler/testData/codegen/bytecodeText/optimizedDelegatedProperties/delegateToAnother.kt
@@ -33,6 +33,7 @@ fun local() {
 // Optimized all to direct accesses, with `$delegate` methods generating reflected references on demand:
 // 0 extends kotlin/jvm/internal/MutablePropertyReference[0-2]Impl
 // 0 private final( static)? Lkotlin/reflect/KMutableProperty[0-2]; [xyz]m?\$delegate
+// 2 private final( static)? LC; [xyz]m?\$receiver
 // 0 LOCALVARIABLE [xyz]m? Lkotlin/reflect/KMutableProperty[0-2];
 // 12 static get[XYZ]m?\$delegate
 

--- a/compiler/testData/codegen/bytecodeText/optimizedDelegatedProperties/delegateToAnother.kt
+++ b/compiler/testData/codegen/bytecodeText/optimizedDelegatedProperties/delegateToAnother.kt
@@ -1,0 +1,38 @@
+// WITH_RUNTIME
+class C(var x: Int) {
+    val y by C::x
+    var ym by C::x
+    val z by ::x
+    var zm by ::x
+}
+
+class D(val c: C) {
+    val y by c::x
+    var ym by c::x
+    val C.z by C::x
+    var C.zm by C::x
+}
+
+var x = 1
+val y by ::x
+var ym by ::x
+val z by C(1)::x
+var zm by C(1)::x
+
+fun local() {
+    val y by ::x
+    var ym by ::x
+    val z by C(1)::x
+    var zm by C(1)::x
+}
+
+// 0 \$\$delegatedProperties
+// 0 kotlin/jvm/internal/PropertyReference[0-2]Impl\.\<init\>
+
+// JVM_IR_TEMPLATES
+// Optimized all to direct accesses:
+// 0 kotlin/jvm/internal/MutablePropertyReference[0-2]Impl\.\<init\>
+
+// JVM_TEMPLATES
+// Not optimized:
+// 16 kotlin/jvm/internal/MutablePropertyReference[0-2]Impl\.\<init\>

--- a/compiler/testData/codegen/bytecodeText/optimizedDelegatedProperties/delegateToAnother.kt
+++ b/compiler/testData/codegen/bytecodeText/optimizedDelegatedProperties/delegateToAnother.kt
@@ -30,9 +30,15 @@ fun local() {
 // 0 kotlin/jvm/internal/PropertyReference[0-2]Impl\.\<init\>
 
 // JVM_IR_TEMPLATES
-// Optimized all to direct accesses:
-// 0 kotlin/jvm/internal/MutablePropertyReference[0-2]Impl\.\<init\>
+// Optimized all to direct accesses, with `$delegate` methods generating reflected references on demand:
+// 0 extends kotlin/jvm/internal/MutablePropertyReference[0-2]Impl
+// 0 private final( static)? Lkotlin/reflect/KMutableProperty[0-2]; [xyz]m?\$delegate
+// 0 LOCALVARIABLE [xyz]m? Lkotlin/reflect/KMutableProperty[0-2];
+// 12 static get[XYZ]m?\$delegate
 
 // JVM_TEMPLATES
-// Not optimized:
-// 16 kotlin/jvm/internal/MutablePropertyReference[0-2]Impl\.\<init\>
+// Not optimized, references created as classes and stored in fields:
+// 16 extends kotlin/jvm/internal/MutablePropertyReference[0-2]Impl
+// 12 private final( static)? Lkotlin/reflect/KMutableProperty[0-2]; [xyz]m?\$delegate
+// 4 LOCALVARIABLE [xyz]m? Lkotlin/reflect/KMutableProperty[0-2];
+// 0 static get[XYZ]m?\$delegate

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -13193,9 +13193,21 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
         }
 
         @Test
+        @TestMetadata("delegateToAnotherCustom.kt")
+        public void testDelegateToAnotherCustom() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnotherCustom.kt");
+        }
+
+        @Test
         @TestMetadata("delegateToAnotherMutable.kt")
         public void testDelegateToAnotherMutable() throws Exception {
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnotherMutable.kt");
+        }
+
+        @Test
+        @TestMetadata("delegateToAnotherReflection.kt")
+        public void testDelegateToAnotherReflection() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnotherReflection.kt");
         }
 
         @Test

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -13211,9 +13211,21 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
         }
 
         @Test
+        @TestMetadata("delegateToAnotherWithSideEffects.kt")
+        public void testDelegateToAnotherWithSideEffects() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnotherWithSideEffects.kt");
+        }
+
+        @Test
         @TestMetadata("delegateToGenericJavaProperty.kt")
         public void testDelegateToGenericJavaProperty() throws Exception {
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateToGenericJavaProperty.kt");
+        }
+
+        @Test
+        @TestMetadata("delegateToOpenProperty.kt")
+        public void testDelegateToOpenProperty() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToOpenProperty.kt");
         }
 
         @Test

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -13193,6 +13193,18 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
         }
 
         @Test
+        @TestMetadata("delegateToAnotherMutable.kt")
+        public void testDelegateToAnotherMutable() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnotherMutable.kt");
+        }
+
+        @Test
+        @TestMetadata("delegateToGenericJavaProperty.kt")
+        public void testDelegateToGenericJavaProperty() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToGenericJavaProperty.kt");
+        }
+
+        @Test
         @TestMetadata("delegateWithPrivateSet.kt")
         public void testDelegateWithPrivateSet() throws Exception {
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateWithPrivateSet.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -18781,6 +18781,12 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
         }
 
         @Test
+        @TestMetadata("kt47609.kt")
+        public void testKt47609() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/kt47609.kt");
+        }
+
+        @Test
         @TestMetadata("mangledDefaultParameterFunction.kt")
         public void testMangledDefaultParameterFunction() throws Exception {
             runTest("compiler/testData/codegen/box/inlineClasses/mangledDefaultParameterFunction.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BytecodeTextTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BytecodeTextTestGenerated.java
@@ -4571,6 +4571,12 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
         }
 
         @Test
+        @TestMetadata("delegateToAnother.kt")
+        public void testDelegateToAnother() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/optimizedDelegatedProperties/delegateToAnother.kt");
+        }
+
+        @Test
         @TestMetadata("inSeparateModule.kt")
         public void testInSeparateModule() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/optimizedDelegatedProperties/inSeparateModule.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -13211,9 +13211,21 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         }
 
         @Test
+        @TestMetadata("delegateToAnotherWithSideEffects.kt")
+        public void testDelegateToAnotherWithSideEffects() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnotherWithSideEffects.kt");
+        }
+
+        @Test
         @TestMetadata("delegateToGenericJavaProperty.kt")
         public void testDelegateToGenericJavaProperty() throws Exception {
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateToGenericJavaProperty.kt");
+        }
+
+        @Test
+        @TestMetadata("delegateToOpenProperty.kt")
+        public void testDelegateToOpenProperty() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToOpenProperty.kt");
         }
 
         @Test

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -13193,6 +13193,18 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         }
 
         @Test
+        @TestMetadata("delegateToAnotherMutable.kt")
+        public void testDelegateToAnotherMutable() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnotherMutable.kt");
+        }
+
+        @Test
+        @TestMetadata("delegateToGenericJavaProperty.kt")
+        public void testDelegateToGenericJavaProperty() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToGenericJavaProperty.kt");
+        }
+
+        @Test
         @TestMetadata("delegateWithPrivateSet.kt")
         public void testDelegateWithPrivateSet() throws Exception {
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateWithPrivateSet.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -13193,9 +13193,21 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         }
 
         @Test
+        @TestMetadata("delegateToAnotherCustom.kt")
+        public void testDelegateToAnotherCustom() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnotherCustom.kt");
+        }
+
+        @Test
         @TestMetadata("delegateToAnotherMutable.kt")
         public void testDelegateToAnotherMutable() throws Exception {
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnotherMutable.kt");
+        }
+
+        @Test
+        @TestMetadata("delegateToAnotherReflection.kt")
+        public void testDelegateToAnotherReflection() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnotherReflection.kt");
         }
 
         @Test

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -18823,6 +18823,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         }
 
         @Test
+        @TestMetadata("kt47609.kt")
+        public void testKt47609() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/kt47609.kt");
+        }
+
+        @Test
         @TestMetadata("mangledDefaultParameterFunction.kt")
         public void testMangledDefaultParameterFunction() throws Exception {
             runTest("compiler/testData/codegen/box/inlineClasses/mangledDefaultParameterFunction.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBytecodeTextTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBytecodeTextTestGenerated.java
@@ -4703,6 +4703,12 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
         }
 
         @Test
+        @TestMetadata("delegateToAnother.kt")
+        public void testDelegateToAnother() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/optimizedDelegatedProperties/delegateToAnother.kt");
+        }
+
+        @Test
         @TestMetadata("inSeparateModule.kt")
         public void testInSeparateModule() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/optimizedDelegatedProperties/inSeparateModule.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -10717,9 +10717,19 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnother.kt");
         }
 
+        @TestMetadata("delegateToAnotherCustom.kt")
+        public void testDelegateToAnotherCustom() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnotherCustom.kt");
+        }
+
         @TestMetadata("delegateToAnotherMutable.kt")
         public void testDelegateToAnotherMutable() throws Exception {
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnotherMutable.kt");
+        }
+
+        @TestMetadata("delegateToAnotherReflection.kt")
+        public void testDelegateToAnotherReflection() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnotherReflection.kt");
         }
 
         @TestMetadata("delegateToGenericJavaProperty.kt")

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -10717,6 +10717,16 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnother.kt");
         }
 
+        @TestMetadata("delegateToAnotherMutable.kt")
+        public void testDelegateToAnotherMutable() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnotherMutable.kt");
+        }
+
+        @TestMetadata("delegateToGenericJavaProperty.kt")
+        public void testDelegateToGenericJavaProperty() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToGenericJavaProperty.kt");
+        }
+
         @TestMetadata("delegateWithPrivateSet.kt")
         public void testDelegateWithPrivateSet() throws Exception {
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateWithPrivateSet.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -10732,9 +10732,19 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnotherReflection.kt");
         }
 
+        @TestMetadata("delegateToAnotherWithSideEffects.kt")
+        public void testDelegateToAnotherWithSideEffects() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnotherWithSideEffects.kt");
+        }
+
         @TestMetadata("delegateToGenericJavaProperty.kt")
         public void testDelegateToGenericJavaProperty() throws Exception {
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateToGenericJavaProperty.kt");
+        }
+
+        @TestMetadata("delegateToOpenProperty.kt")
+        public void testDelegateToOpenProperty() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToOpenProperty.kt");
         }
 
         @TestMetadata("delegateWithPrivateSet.kt")

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -15570,6 +15570,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/inlineClasses/kt46554.kt");
         }
 
+        @TestMetadata("kt47609.kt")
+        public void testKt47609() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/kt47609.kt");
+        }
+
         @TestMetadata("mangledDefaultParameterFunction.kt")
         public void testMangledDefaultParameterFunction() throws Exception {
             runTest("compiler/testData/codegen/box/inlineClasses/mangledDefaultParameterFunction.kt");

--- a/core/metadata.jvm/src/jvm_metadata.proto
+++ b/core/metadata.jvm/src/jvm_metadata.proto
@@ -86,6 +86,10 @@ message JvmPropertySignature {
 
   optional JvmMethodSignature getter = 3;
   optional JvmMethodSignature setter = 4;
+
+  // The delegate field of delegated properties may be optimized out; `getDelegate` should
+  // then call this method instead
+  optional JvmMethodSignature delegate_method = 5;
 }
 
 extend Constructor {

--- a/core/metadata.jvm/src/org/jetbrains/kotlin/metadata/jvm/JvmProtoBuf.java
+++ b/core/metadata.jvm/src/org/jetbrains/kotlin/metadata/jvm/JvmProtoBuf.java
@@ -3068,6 +3068,25 @@ public final class JvmProtoBuf {
      * <code>optional .org.jetbrains.kotlin.metadata.jvm.JvmMethodSignature setter = 4;</code>
      */
     org.jetbrains.kotlin.metadata.jvm.JvmProtoBuf.JvmMethodSignature getSetter();
+
+    /**
+     * <code>optional .org.jetbrains.kotlin.metadata.jvm.JvmMethodSignature delegate_method = 5;</code>
+     *
+     * <pre>
+     * The delegate field of delegated properties may be optimized out; `getDelegate` should
+     * then call this method instead
+     * </pre>
+     */
+    boolean hasDelegateMethod();
+    /**
+     * <code>optional .org.jetbrains.kotlin.metadata.jvm.JvmMethodSignature delegate_method = 5;</code>
+     *
+     * <pre>
+     * The delegate field of delegated properties may be optimized out; `getDelegate` should
+     * then call this method instead
+     * </pre>
+     */
+    org.jetbrains.kotlin.metadata.jvm.JvmProtoBuf.JvmMethodSignature getDelegateMethod();
   }
   /**
    * Protobuf type {@code org.jetbrains.kotlin.metadata.jvm.JvmPropertySignature}
@@ -3169,6 +3188,19 @@ public final class JvmProtoBuf {
                 setter_ = subBuilder.buildPartial();
               }
               bitField0_ |= 0x00000008;
+              break;
+            }
+            case 42: {
+              org.jetbrains.kotlin.metadata.jvm.JvmProtoBuf.JvmMethodSignature.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000010) == 0x00000010)) {
+                subBuilder = delegateMethod_.toBuilder();
+              }
+              delegateMethod_ = input.readMessage(org.jetbrains.kotlin.metadata.jvm.JvmProtoBuf.JvmMethodSignature.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(delegateMethod_);
+                delegateMethod_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000010;
               break;
             }
           }
@@ -3273,11 +3305,37 @@ public final class JvmProtoBuf {
       return setter_;
     }
 
+    public static final int DELEGATE_METHOD_FIELD_NUMBER = 5;
+    private org.jetbrains.kotlin.metadata.jvm.JvmProtoBuf.JvmMethodSignature delegateMethod_;
+    /**
+     * <code>optional .org.jetbrains.kotlin.metadata.jvm.JvmMethodSignature delegate_method = 5;</code>
+     *
+     * <pre>
+     * The delegate field of delegated properties may be optimized out; `getDelegate` should
+     * then call this method instead
+     * </pre>
+     */
+    public boolean hasDelegateMethod() {
+      return ((bitField0_ & 0x00000010) == 0x00000010);
+    }
+    /**
+     * <code>optional .org.jetbrains.kotlin.metadata.jvm.JvmMethodSignature delegate_method = 5;</code>
+     *
+     * <pre>
+     * The delegate field of delegated properties may be optimized out; `getDelegate` should
+     * then call this method instead
+     * </pre>
+     */
+    public org.jetbrains.kotlin.metadata.jvm.JvmProtoBuf.JvmMethodSignature getDelegateMethod() {
+      return delegateMethod_;
+    }
+
     private void initFields() {
       field_ = org.jetbrains.kotlin.metadata.jvm.JvmProtoBuf.JvmFieldSignature.getDefaultInstance();
       syntheticMethod_ = org.jetbrains.kotlin.metadata.jvm.JvmProtoBuf.JvmMethodSignature.getDefaultInstance();
       getter_ = org.jetbrains.kotlin.metadata.jvm.JvmProtoBuf.JvmMethodSignature.getDefaultInstance();
       setter_ = org.jetbrains.kotlin.metadata.jvm.JvmProtoBuf.JvmMethodSignature.getDefaultInstance();
+      delegateMethod_ = org.jetbrains.kotlin.metadata.jvm.JvmProtoBuf.JvmMethodSignature.getDefaultInstance();
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -3304,6 +3362,9 @@ public final class JvmProtoBuf {
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         output.writeMessage(4, setter_);
       }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        output.writeMessage(5, delegateMethod_);
+      }
       output.writeRawBytes(unknownFields);
     }
 
@@ -3328,6 +3389,10 @@ public final class JvmProtoBuf {
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         size += org.jetbrains.kotlin.protobuf.CodedOutputStream
           .computeMessageSize(4, setter_);
+      }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        size += org.jetbrains.kotlin.protobuf.CodedOutputStream
+          .computeMessageSize(5, delegateMethod_);
       }
       size += unknownFields.size();
       memoizedSerializedSize = size;
@@ -3431,6 +3496,8 @@ public final class JvmProtoBuf {
         bitField0_ = (bitField0_ & ~0x00000004);
         setter_ = org.jetbrains.kotlin.metadata.jvm.JvmProtoBuf.JvmMethodSignature.getDefaultInstance();
         bitField0_ = (bitField0_ & ~0x00000008);
+        delegateMethod_ = org.jetbrains.kotlin.metadata.jvm.JvmProtoBuf.JvmMethodSignature.getDefaultInstance();
+        bitField0_ = (bitField0_ & ~0x00000010);
         return this;
       }
 
@@ -3470,6 +3537,10 @@ public final class JvmProtoBuf {
           to_bitField0_ |= 0x00000008;
         }
         result.setter_ = setter_;
+        if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
+          to_bitField0_ |= 0x00000010;
+        }
+        result.delegateMethod_ = delegateMethod_;
         result.bitField0_ = to_bitField0_;
         return result;
       }
@@ -3487,6 +3558,9 @@ public final class JvmProtoBuf {
         }
         if (other.hasSetter()) {
           mergeSetter(other.getSetter());
+        }
+        if (other.hasDelegateMethod()) {
+          mergeDelegateMethod(other.getDelegateMethod());
         }
         setUnknownFields(
             getUnknownFields().concat(other.unknownFields));
@@ -3777,6 +3851,96 @@ public final class JvmProtoBuf {
         setter_ = org.jetbrains.kotlin.metadata.jvm.JvmProtoBuf.JvmMethodSignature.getDefaultInstance();
 
         bitField0_ = (bitField0_ & ~0x00000008);
+        return this;
+      }
+
+      private org.jetbrains.kotlin.metadata.jvm.JvmProtoBuf.JvmMethodSignature delegateMethod_ = org.jetbrains.kotlin.metadata.jvm.JvmProtoBuf.JvmMethodSignature.getDefaultInstance();
+      /**
+       * <code>optional .org.jetbrains.kotlin.metadata.jvm.JvmMethodSignature delegate_method = 5;</code>
+       *
+       * <pre>
+       * The delegate field of delegated properties may be optimized out; `getDelegate` should
+       * then call this method instead
+       * </pre>
+       */
+      public boolean hasDelegateMethod() {
+        return ((bitField0_ & 0x00000010) == 0x00000010);
+      }
+      /**
+       * <code>optional .org.jetbrains.kotlin.metadata.jvm.JvmMethodSignature delegate_method = 5;</code>
+       *
+       * <pre>
+       * The delegate field of delegated properties may be optimized out; `getDelegate` should
+       * then call this method instead
+       * </pre>
+       */
+      public org.jetbrains.kotlin.metadata.jvm.JvmProtoBuf.JvmMethodSignature getDelegateMethod() {
+        return delegateMethod_;
+      }
+      /**
+       * <code>optional .org.jetbrains.kotlin.metadata.jvm.JvmMethodSignature delegate_method = 5;</code>
+       *
+       * <pre>
+       * The delegate field of delegated properties may be optimized out; `getDelegate` should
+       * then call this method instead
+       * </pre>
+       */
+      public Builder setDelegateMethod(org.jetbrains.kotlin.metadata.jvm.JvmProtoBuf.JvmMethodSignature value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        delegateMethod_ = value;
+
+        bitField0_ |= 0x00000010;
+        return this;
+      }
+      /**
+       * <code>optional .org.jetbrains.kotlin.metadata.jvm.JvmMethodSignature delegate_method = 5;</code>
+       *
+       * <pre>
+       * The delegate field of delegated properties may be optimized out; `getDelegate` should
+       * then call this method instead
+       * </pre>
+       */
+      public Builder setDelegateMethod(
+          org.jetbrains.kotlin.metadata.jvm.JvmProtoBuf.JvmMethodSignature.Builder builderForValue) {
+        delegateMethod_ = builderForValue.build();
+
+        bitField0_ |= 0x00000010;
+        return this;
+      }
+      /**
+       * <code>optional .org.jetbrains.kotlin.metadata.jvm.JvmMethodSignature delegate_method = 5;</code>
+       *
+       * <pre>
+       * The delegate field of delegated properties may be optimized out; `getDelegate` should
+       * then call this method instead
+       * </pre>
+       */
+      public Builder mergeDelegateMethod(org.jetbrains.kotlin.metadata.jvm.JvmProtoBuf.JvmMethodSignature value) {
+        if (((bitField0_ & 0x00000010) == 0x00000010) &&
+            delegateMethod_ != org.jetbrains.kotlin.metadata.jvm.JvmProtoBuf.JvmMethodSignature.getDefaultInstance()) {
+          delegateMethod_ =
+            org.jetbrains.kotlin.metadata.jvm.JvmProtoBuf.JvmMethodSignature.newBuilder(delegateMethod_).mergeFrom(value).buildPartial();
+        } else {
+          delegateMethod_ = value;
+        }
+
+        bitField0_ |= 0x00000010;
+        return this;
+      }
+      /**
+       * <code>optional .org.jetbrains.kotlin.metadata.jvm.JvmMethodSignature delegate_method = 5;</code>
+       *
+       * <pre>
+       * The delegate field of delegated properties may be optimized out; `getDelegate` should
+       * then call this method instead
+       * </pre>
+       */
+      public Builder clearDelegateMethod() {
+        delegateMethod_ = org.jetbrains.kotlin.metadata.jvm.JvmProtoBuf.JvmMethodSignature.getDefaultInstance();
+
+        bitField0_ = (bitField0_ & ~0x00000010);
         return this;
       }
 

--- a/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KProperty0Impl.kt
+++ b/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KProperty0Impl.kt
@@ -34,9 +34,9 @@ internal open class KProperty0Impl<out V> : KProperty0<V>, KPropertyImpl<V> {
 
     override fun get(): V = getter.call()
 
-    private val delegateFieldValue = lazy(PUBLICATION) { getDelegate(computeDelegateField(), boundReceiver) }
+    private val delegateValue = lazy(PUBLICATION) { getDelegateImpl(computeDelegateSource(), null, null) }
 
-    override fun getDelegate(): Any? = delegateFieldValue.value
+    override fun getDelegate(): Any? = delegateValue.value
 
     override fun invoke(): V = get()
 

--- a/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KProperty1Impl.kt
+++ b/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KProperty1Impl.kt
@@ -34,9 +34,9 @@ internal open class KProperty1Impl<T, out V> : KProperty1<T, V>, KPropertyImpl<V
 
     override fun get(receiver: T): V = getter.call(receiver)
 
-    private val delegateField = lazy(PUBLICATION) { computeDelegateField() }
+    private val delegateSource = lazy(PUBLICATION) { computeDelegateSource() }
 
-    override fun getDelegate(receiver: T): Any? = getDelegate(delegateField.value, receiver)
+    override fun getDelegate(receiver: T): Any? = getDelegateImpl(delegateSource.value, receiver, null)
 
     override fun invoke(receiver: T): V = get(receiver)
 

--- a/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KProperty2Impl.kt
+++ b/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KProperty2Impl.kt
@@ -35,9 +35,9 @@ internal open class KProperty2Impl<D, E, out V> : KProperty2<D, E, V>, KProperty
 
     override fun get(receiver1: D, receiver2: E): V = getter.call(receiver1, receiver2)
 
-    private val delegateField = lazy(PUBLICATION) { computeDelegateField() }
+    private val delegateSource = lazy(PUBLICATION) { computeDelegateSource() }
 
-    override fun getDelegate(receiver1: D, receiver2: E): Any? = getDelegate(delegateField.value, receiver1)
+    override fun getDelegate(receiver1: D, receiver2: E): Any? = getDelegateImpl(delegateSource.value, receiver1, receiver2)
 
     override fun invoke(receiver1: D, receiver2: E): V = get(receiver1, receiver2)
 

--- a/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KPropertyImpl.kt
+++ b/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KPropertyImpl.kt
@@ -15,6 +15,8 @@ import org.jetbrains.kotlin.resolve.isUnderlyingPropertyOfInlineClass
 import org.jetbrains.kotlin.serialization.deserialization.descriptors.DeserializedPropertyDescriptor
 import org.jetbrains.kotlin.types.TypeUtils
 import java.lang.reflect.Field
+import java.lang.reflect.Member
+import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 import kotlin.jvm.internal.CallableReference
 import kotlin.reflect.KFunction
@@ -77,12 +79,22 @@ internal abstract class KPropertyImpl<out V> private constructor(
 
     val javaField: Field? get() = _javaField()
 
-    protected fun computeDelegateField(): Field? =
-        if (descriptor.isDelegated) javaField else null
+    protected fun computeDelegateSource(): Member? {
+        if (!descriptor.isDelegated) return null
+        val jvmSignature = RuntimeTypeMapper.mapPropertySignature(descriptor)
+        if (jvmSignature is KotlinProperty && jvmSignature.signature.hasDelegateMethod()) {
+            val method = jvmSignature.signature.delegateMethod
+            if (!method.hasName() || !method.hasDesc()) return null
+            val name = jvmSignature.nameResolver.getString(method.name)
+            val desc = jvmSignature.nameResolver.getString(method.desc)
+            return container.findMethodBySignature(name, desc)
+        }
+        return javaField
+    }
 
-    protected fun getDelegate(field: Field?, receiver: Any?): Any? =
+    protected fun getDelegateImpl(fieldOrMethod: Member?, receiver1: Any?, receiver2: Any?): Any? =
         try {
-            if (receiver === EXTENSION_PROPERTY_DELEGATE) {
+            if (receiver1 === EXTENSION_PROPERTY_DELEGATE || receiver2 === EXTENSION_PROPERTY_DELEGATE) {
                 if (descriptor.extensionReceiverParameter == null) {
                     throw RuntimeException(
                         "'$this' is not an extension property and thus getExtensionDelegate() " +
@@ -90,7 +102,20 @@ internal abstract class KPropertyImpl<out V> private constructor(
                     )
                 }
             }
-            field?.get(receiver)
+
+            val realReceiver1 = (if (isBound) boundReceiver else receiver1).takeIf { it !== EXTENSION_PROPERTY_DELEGATE }
+            val realReceiver2 = (if (isBound) receiver1 else receiver2).takeIf { it !== EXTENSION_PROPERTY_DELEGATE }
+            when (fieldOrMethod) {
+                null -> null
+                is Field -> fieldOrMethod.get(realReceiver1)
+                is Method -> when (fieldOrMethod.parameterTypes.size) {
+                    0 -> fieldOrMethod.invoke(null)
+                    1 -> fieldOrMethod.invoke(null, realReceiver1 ?: defaultPrimitiveValue(fieldOrMethod.parameterTypes[0]))
+                    2 -> fieldOrMethod.invoke(null, realReceiver1, realReceiver2 ?: defaultPrimitiveValue(fieldOrMethod.parameterTypes[1]))
+                    else -> throw AssertionError("delegate method $fieldOrMethod should take 0, 1, or 2 parameters")
+                }
+                else -> throw AssertionError("delegate field/method $fieldOrMethod neither field nor method")
+            }
         } catch (e: IllegalAccessException) {
             throw IllegalPropertyDelegateAccessException(e)
         }

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
@@ -9536,6 +9536,11 @@ public class IrJsCodegenBoxES6TestGenerated extends AbstractIrJsCodegenBoxES6Tes
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnother.kt");
         }
 
+        @TestMetadata("delegateToAnotherMutable.kt")
+        public void testDelegateToAnotherMutable() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnotherMutable.kt");
+        }
+
         @TestMetadata("delegateWithPrivateSet.kt")
         public void testDelegateWithPrivateSet() throws Exception {
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateWithPrivateSet.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
@@ -9536,6 +9536,11 @@ public class IrJsCodegenBoxES6TestGenerated extends AbstractIrJsCodegenBoxES6Tes
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnother.kt");
         }
 
+        @TestMetadata("delegateToAnotherCustom.kt")
+        public void testDelegateToAnotherCustom() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnotherCustom.kt");
+        }
+
         @TestMetadata("delegateToAnotherMutable.kt")
         public void testDelegateToAnotherMutable() throws Exception {
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnotherMutable.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
@@ -9546,6 +9546,16 @@ public class IrJsCodegenBoxES6TestGenerated extends AbstractIrJsCodegenBoxES6Tes
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnotherMutable.kt");
         }
 
+        @TestMetadata("delegateToAnotherWithSideEffects.kt")
+        public void testDelegateToAnotherWithSideEffects() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnotherWithSideEffects.kt");
+        }
+
+        @TestMetadata("delegateToOpenProperty.kt")
+        public void testDelegateToOpenProperty() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToOpenProperty.kt");
+        }
+
         @TestMetadata("delegateWithPrivateSet.kt")
         public void testDelegateWithPrivateSet() throws Exception {
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateWithPrivateSet.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -8942,6 +8942,11 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnother.kt");
         }
 
+        @TestMetadata("delegateToAnotherMutable.kt")
+        public void testDelegateToAnotherMutable() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnotherMutable.kt");
+        }
+
         @TestMetadata("delegateWithPrivateSet.kt")
         public void testDelegateWithPrivateSet() throws Exception {
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateWithPrivateSet.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -8952,6 +8952,16 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnotherMutable.kt");
         }
 
+        @TestMetadata("delegateToAnotherWithSideEffects.kt")
+        public void testDelegateToAnotherWithSideEffects() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnotherWithSideEffects.kt");
+        }
+
+        @TestMetadata("delegateToOpenProperty.kt")
+        public void testDelegateToOpenProperty() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToOpenProperty.kt");
+        }
+
         @TestMetadata("delegateWithPrivateSet.kt")
         public void testDelegateWithPrivateSet() throws Exception {
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateWithPrivateSet.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -8942,6 +8942,11 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnother.kt");
         }
 
+        @TestMetadata("delegateToAnotherCustom.kt")
+        public void testDelegateToAnotherCustom() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnotherCustom.kt");
+        }
+
         @TestMetadata("delegateToAnotherMutable.kt")
         public void testDelegateToAnotherMutable() throws Exception {
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnotherMutable.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -8942,6 +8942,11 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnother.kt");
         }
 
+        @TestMetadata("delegateToAnotherMutable.kt")
+        public void testDelegateToAnotherMutable() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnotherMutable.kt");
+        }
+
         @TestMetadata("delegateWithPrivateSet.kt")
         public void testDelegateWithPrivateSet() throws Exception {
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateWithPrivateSet.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -8942,6 +8942,11 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnother.kt");
         }
 
+        @TestMetadata("delegateToAnotherCustom.kt")
+        public void testDelegateToAnotherCustom() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnotherCustom.kt");
+        }
+
         @TestMetadata("delegateToAnotherMutable.kt")
         public void testDelegateToAnotherMutable() throws Exception {
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnotherMutable.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -8952,6 +8952,16 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnotherMutable.kt");
         }
 
+        @TestMetadata("delegateToAnotherWithSideEffects.kt")
+        public void testDelegateToAnotherWithSideEffects() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToAnotherWithSideEffects.kt");
+        }
+
+        @TestMetadata("delegateToOpenProperty.kt")
+        public void testDelegateToOpenProperty() throws Exception {
+            runTest("compiler/testData/codegen/box/delegatedProperty/delegateToOpenProperty.kt");
+        }
+
         @TestMetadata("delegateWithPrivateSet.kt")
         public void testDelegateWithPrivateSet() throws Exception {
             runTest("compiler/testData/codegen/box/delegatedProperty/delegateWithPrivateSet.kt");

--- a/libraries/kotlinx-metadata/jvm/src/kotlinx/metadata/jvm/impl/jvmExtensionNodes.kt
+++ b/libraries/kotlinx-metadata/jvm/src/kotlinx/metadata/jvm/impl/jvmExtensionNodes.kt
@@ -105,6 +105,7 @@ internal class JvmPropertyExtension : JvmPropertyExtensionVisitor(), KmPropertyE
     var getterSignature: JvmMethodSignature? = null
     var setterSignature: JvmMethodSignature? = null
     var syntheticMethodForAnnotations: JvmMethodSignature? = null
+    var syntheticMethodForDelegate: JvmMethodSignature? = null
 
     override fun visit(
         jvmFlags: Flags,
@@ -122,10 +123,15 @@ internal class JvmPropertyExtension : JvmPropertyExtensionVisitor(), KmPropertyE
         this.syntheticMethodForAnnotations = signature
     }
 
+    override fun visitSyntheticMethodForDelegate(signature: JvmMethodSignature?) {
+        this.syntheticMethodForDelegate = signature
+    }
+
     override fun accept(visitor: KmPropertyExtensionVisitor) {
         require(visitor is JvmPropertyExtensionVisitor)
         visitor.visit(jvmFlags, fieldSignature, getterSignature, setterSignature)
         visitor.visitSyntheticMethodForAnnotations(syntheticMethodForAnnotations)
+        visitor.visitSyntheticMethodForDelegate(syntheticMethodForDelegate)
         visitor.visitEnd()
     }
 }

--- a/libraries/kotlinx-metadata/jvm/src/kotlinx/metadata/jvm/jvmExtensionVisitors.kt
+++ b/libraries/kotlinx-metadata/jvm/src/kotlinx/metadata/jvm/jvmExtensionVisitors.kt
@@ -213,6 +213,19 @@ open class JvmPropertyExtensionVisitor @JvmOverloads constructor(
     }
 
     /**
+     * Visits the JVM signature of a synthetic method which is generated when a delegated property's delegate object is
+     * optimized out, e.g. because it is constant; in that case, a copy of that object can be obtained on demand by calling
+     * this method. It takes up to two arguments - the property's receivers.
+     *
+     * Example: `JvmMethodSignature("getX$delegate", "(LMyClass;)LMyDelegate;")`
+     *
+     * @param signature the signature of the synthetic method
+     */
+    open fun visitSyntheticMethodForDelegate(signature: JvmMethodSignature?) {
+        delegate?.visitSyntheticMethodForDelegate(signature)
+    }
+
+    /**
      * Visits the end of JVM extensions for the property.
      */
     open fun visitEnd() {

--- a/libraries/tools/kotlinp/src/org/jetbrains/kotlin/kotlinp/printers.kt
+++ b/libraries/tools/kotlinp/src/org/jetbrains/kotlin/kotlinp/printers.kt
@@ -103,6 +103,7 @@ private fun visitProperty(
         var jvmGetterSignature: JvmMemberSignature? = null
         var jvmSetterSignature: JvmMemberSignature? = null
         var jvmSyntheticMethodForAnnotationsSignature: JvmMemberSignature? = null
+        var jvmSyntheticMethodForDelegateSignature: JvmMemberSignature? = null
         var isMovedFromInterfaceCompanion: Boolean = false
 
         override fun visitReceiverParameterType(flags: Flags): KmTypeVisitor? =
@@ -138,6 +139,10 @@ private fun visitProperty(
                 override fun visitSyntheticMethodForAnnotations(signature: JvmMethodSignature?) {
                     jvmSyntheticMethodForAnnotationsSignature = signature
                 }
+
+                override fun visitSyntheticMethodForDelegate(signature: JvmMethodSignature?) {
+                    jvmSyntheticMethodForDelegateSignature = signature
+                }
             }
         }
 
@@ -157,6 +162,9 @@ private fun visitProperty(
             }
             if (jvmSyntheticMethodForAnnotationsSignature != null) {
                 sb.appendLine("  // synthetic method for annotations: $jvmSyntheticMethodForAnnotationsSignature")
+            }
+            if (jvmSyntheticMethodForDelegateSignature != null) {
+                sb.appendLine("  // synthetic method for delegate: $jvmSyntheticMethodForDelegateSignature")
             }
             if (isMovedFromInterfaceCompanion) {
                 sb.appendLine("  // is moved from interface companion")

--- a/libraries/tools/kotlinp/test/org/jetbrains/kotlin/kotlinp/test/KotlinpTestUtils.kt
+++ b/libraries/tools/kotlinp/test/org/jetbrains/kotlin/kotlinp/test/KotlinpTestUtils.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.checkers.setupLanguageVersionSettingsForCompilerTest
 import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.codegen.GenerationUtils
+import org.jetbrains.kotlin.config.JVMConfigurationKeys
 import org.jetbrains.kotlin.jvm.compiler.AbstractLoadJavaTest
 import org.jetbrains.kotlin.kotlinp.Kotlinp
 import org.jetbrains.kotlin.kotlinp.KotlinpSettings
@@ -74,6 +75,7 @@ fun compileAndPrintAllFiles(file: File, disposable: Disposable, tmpdir: File, co
 private fun compile(file: File, disposable: Disposable, tmpdir: File, forEachOutputFile: (File) -> Unit) {
     val content = file.readText()
     val configuration = KotlinTestUtils.newConfiguration(ConfigurationKind.ALL, TestJdkKind.MOCK_JDK)
+    configuration.put(JVMConfigurationKeys.IR, true)
     AbstractLoadJavaTest.updateConfigurationWithDirectives(content, configuration)
     val environment = KotlinCoreEnvironment.createForTests(disposable, configuration, EnvironmentConfigFiles.JVM_CONFIG_FILES)
     setupLanguageVersionSettingsForCompilerTests(content, environment)

--- a/libraries/tools/kotlinp/testData/LocalDelegatedProperties.txt
+++ b/libraries/tools/kotlinp/testData/LocalDelegatedProperties.txt
@@ -22,13 +22,6 @@ public final class Class : kotlin/Any {
 
   // module name: test-module
 }
-// Class$f$1.class
-// ------------------------------------------
-lambda {
-
-  // signature: invoke()V
-  local final fun g(): kotlin/Unit
-}
 // Delegate.class
 // ------------------------------------------
 public final class Delegate<T#0 /* T */> : kotlin/Any {

--- a/libraries/tools/kotlinp/testData/Properties.kt
+++ b/libraries/tools/kotlinp/testData/Properties.kt
@@ -8,5 +8,7 @@ class C(val constructorParam: String = "") {
 
     val <T : Number> T.delegated: List<Nothing> by null
 
+    val withOptimizedDelegate by C::getterOnlyVal
+
     operator fun Nothing?.getValue(x: Any?, y: Any?) = emptyList<Nothing>()
 }

--- a/libraries/tools/kotlinp/testData/Properties.txt
+++ b/libraries/tools/kotlinp/testData/Properties.txt
@@ -30,6 +30,11 @@ public final class C : kotlin/Any {
     public final get
     public final set
 
+  // getter: getWithOptimizedDelegate()D
+  // synthetic method for delegate: getWithOptimizedDelegate$delegate(LC;)Ljava/lang/Object;
+  public final /* delegated */ val withOptimizedDelegate: kotlin/Double
+    public final /* non-default */ get
+
   // field: delegated$delegate:Ljava/lang/Void;
   // getter: getDelegated(Ljava/lang/Number;)Ljava/util/List;
   public final /* delegated */ val <T#0 /* T */ : kotlin/Number> T#0.delegated: kotlin/collections/List<kotlin/Nothing>


### PR DESCRIPTION
E.g. a statement like

    var x by ::y

is semantically equivalent to

    var x
      get() = y
      set(value) { y = value }

and thus does not need a full property reference object, or even a field if the receiver is not bound. To support `getDelegate` for these properties, a synthetic `getX$delegate` method is generated that creates `::y` on demand.

 #KT-39054 Fixed
 #KT-39055 Fixed
 #KT-47102 Fixed