### PR TITLE
JVM_IR: assume function reference adapters are tail-call

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/CoroutineCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/CoroutineCodegen.kt
@@ -151,6 +151,8 @@ private val BRIDGE_ORIGINS = setOf(
     JvmLoweredDeclarationOrigin.SUPER_INTERFACE_METHOD_BRIDGE,
     IrDeclarationOrigin.BRIDGE,
     IrDeclarationOrigin.BRIDGE_SPECIAL,
+    IrDeclarationOrigin.ADAPTER_FOR_CALLABLE_REFERENCE,
+    IrDeclarationOrigin.ADAPTER_FOR_SUSPEND_CONVERSION
 )
 
 // These functions contain a single `suspend` tail call, the value of which should be returned as is

--- a/compiler/testData/codegen/box/coroutines/suspendConversion/onInlineArgument_ir.txt
+++ b/compiler/testData/codegen/box/coroutines/suspendConversion/onInlineArgument_ir.txt
@@ -8,7 +8,6 @@ final class OnInlineArgumentKt$box$1 {
     field label: int
     inner (anonymous) class OnInlineArgumentKt$box$1
     method <init>(p0: kotlin.jvm.internal.Ref$ObjectRef, p1: kotlin.jvm.functions.Function1, p2: kotlin.coroutines.Continuation): void
-    public synthetic final static method access$invokeSuspend$suspendConversion0(p0: kotlin.jvm.functions.Function1, p1: java.lang.String, p2: kotlin.coroutines.Continuation): java.lang.Object
     public final @org.jetbrains.annotations.NotNull method create(@org.jetbrains.annotations.NotNull p0: kotlin.coroutines.Continuation): kotlin.coroutines.Continuation
     public final @org.jetbrains.annotations.Nullable method invoke(@org.jetbrains.annotations.Nullable p0: kotlin.coroutines.Continuation): java.lang.Object
     public synthetic bridge method invoke(p0: java.lang.Object): java.lang.Object


### PR DESCRIPTION
Meaning, they never need continuation objects. This shouldn't affect correctness (if the assumption is valid, the continuation object should always have been removed in the end), but the phantom continuation sometimes left behind unused accessors (and in case of inline function references, those accessors would refer to non-existent functions) - see the modified test and Kotlin/kotlinx.coroutines#2769.