### PR TITLE
KT-16228: Support markdown tables in KDoc quickdoc renderer

### DIFF
--- a/idea/testData/editor/quickDoc/OnFunctionDeclarationWithGFMTable.kt
+++ b/idea/testData/editor/quickDoc/OnFunctionDeclarationWithGFMTable.kt
@@ -1,0 +1,19 @@
+package test
+
+/**
+ * Test function
+ *
+ * | foo  | bar   | qux |
+ * | ---: | :---: | --- |
+ * | baz  | bim   | box |
+ *
+ * @param first Some
+ * @param second Other
+ */
+fun <caret>testFun(first: String, second: Int) = 12
+
+//INFO: <div class='definition'><pre><a href="psi_element://test"><code>test</code></a> <font color="808080"><i>OnFunctionDeclarationWithGFMTable.kt</i></font><br>public fun <b>testFun</b>(
+//INFO:     first: String,
+//INFO:     second: Int
+//INFO: ): Int</pre></div><div class='content'><p>Test function</p>
+//INFO:   <table><thead><tr><th align="right"> foo</th><th align="center"> bar</th><th align="left"> qux</th></tr></thead><tbody><tr><td align="right"> baz</td><td align="center"> bim</td><td align="left"> box</td></tr></tbody></table></div><table class='sections'><tr><td valign='top' class='section'><p>Params:</td><td valign='top'><p><code>first</code> - Some<p><code>second</code> - Other</td></table>

--- a/idea/tests/org/jetbrains/kotlin/idea/editor/quickDoc/QuickDocProviderTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/editor/quickDoc/QuickDocProviderTestGenerated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -196,6 +196,11 @@ public class QuickDocProviderTestGenerated extends AbstractQuickDocProviderTest 
     @TestMetadata("OnEnumValuesFunction.kt")
     public void testOnEnumValuesFunction() throws Exception {
         runTest("idea/testData/editor/quickDoc/OnEnumValuesFunction.kt");
+    }
+
+    @TestMetadata("OnFunctionDeclarationWithGFMTable.kt")
+    public void testOnFunctionDeclarationWithGFMTable() throws Exception {
+        runTest("idea/testData/editor/quickDoc/OnFunctionDeclarationWithGFMTable.kt");
     }
 
     @TestMetadata("OnFunctionDeclarationWithPackage.kt")


### PR DESCRIPTION
This commit changes the markdown flavor used parsing for KDocs from CommonMark to GFM. Dokka itself uses GFM, so this change aligns dokka and quickdocs. The KDoc renderer is updated to render the new GFM node types.