### PR TITLE
FIR: fix type comparator

### DIFF
--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/types/ConeKotlinTypeComparator.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/types/ConeKotlinTypeComparator.kt
@@ -136,7 +136,7 @@ object ConeKotlinTypeComparator : Comparator<ConeKotlinType> {
                 }
                 val sizeDiff = a.intersectedTypes.size - b.intersectedTypes.size
                 if (sizeDiff != 0) {
-                    return 0
+                    return sizeDiff
                 }
                 // Can't compare individual types from each side, since their orders are not guaranteed.
                 return a.hashCode() - b.hashCode()


### PR DESCRIPTION
As many other places did, this one is supposed to return the diff value if the given two intersection types' sizes are different.

Found by @ebukreev 