### PR TITLE
FIR checker: introduce property init info cache to checker context

### DIFF
--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/CfaUtils.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/CfaUtils.kt
@@ -130,7 +130,7 @@ class PathAwarePropertyInitializationInfo(
 }
 
 class PropertyInitializationInfoCollector(
-    private val localProperties: Set<FirPropertySymbol>,
+    private val properties: Set<FirPropertySymbol>,
     private val declaredVariableCollector: DeclaredVariableCollector = DeclaredVariableCollector(),
 ) : ControlFlowGraphVisitor<PathAwarePropertyInitializationInfo, Collection<Pair<EdgeLabel, PathAwarePropertyInitializationInfo>>>() {
     override fun visitNode(
@@ -148,7 +148,7 @@ class PropertyInitializationInfoCollector(
     ): PathAwarePropertyInitializationInfo {
         val dataForNode = visitNode(node, data)
         val symbol = node.fir.referredPropertySymbol ?: return dataForNode
-        return if (symbol !in localProperties) {
+        return if (symbol !in properties) {
             dataForNode
         } else {
             processVariableWithAssignment(dataForNode, symbol)

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/FirControlFlowAnalyzer.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/FirControlFlowAnalyzer.kt
@@ -63,7 +63,7 @@ class FirControlFlowAnalyzer(
     private fun runAssignmentCfaCheckers(graph: ControlFlowGraph, reporter: DiagnosticReporter, context: CheckerContext) {
         val (properties, capturedWrites) = LocalPropertyAndCapturedWriteCollector.collect(graph)
         if (properties.isEmpty()) return
-        val data = PropertyInitializationInfoCollector(properties).getData(graph)
+        val data = context.propertyInitializationInfoCache.getOrCollectPropertyInitializationInfo(graph, properties)
         variableAssignmentCheckers.forEach { it.analyze(graph, reporter, data, properties, capturedWrites, context) }
     }
 }

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/PropertyInitializationInfoCache.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/cfa/PropertyInitializationInfoCache.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.fir.analysis.cfa
+
+import org.jetbrains.kotlin.fir.resolve.dfa.cfg.CFGNode
+import org.jetbrains.kotlin.fir.resolve.dfa.cfg.ControlFlowGraph
+import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
+
+/**
+ * A Cache that maintains mapping from CFG to collected property initialization info.
+ * [FirMemberPropertiesChekcer] will analyze constructors, anonymous initializers, and property initializers to determine if member
+ * properties are initialized. To avoid redundant control-flow analysis, that checker will collect information for member properties
+ * as well as local properties. Then, when [FirControlFlowAnalyzer] wants to analyze those functions again, the cache will be used.
+ *
+ * But, if we cache everything, the mappings may grow too much. For regular uses (from [FirControlFlowAnalyzer]), we don't need caching.
+ * We will do so only for constructors, anonymous initializers, and property initializers visited ahead by [FirMemberPropertiesChecker].
+ */
+class PropertyInitializationInfoCache private constructor() {
+    private val propertyInitializationInfoCache: MutableMap<ControlFlowGraph, Map<CFGNode<*>, PathAwarePropertyInitializationInfo>> =
+        mutableMapOf()
+
+    fun getOrCollectPropertyInitializationInfo(
+        graph: ControlFlowGraph,
+        properties: Set<FirPropertySymbol>,
+        caching: Boolean = false,
+    ): Map<CFGNode<*>, PathAwarePropertyInitializationInfo> {
+        return if (caching) {
+            propertyInitializationInfoCache.computeIfAbsent(graph) {
+                PropertyInitializationInfoCollector(properties).getData(graph)
+            }
+        } else {
+            if (graph in this) {
+                propertyInitializationInfoCache[graph]!!
+            } else {
+                PropertyInitializationInfoCollector(properties).getData(graph)
+            }
+        }
+    }
+
+    /**
+     * Invalidate cache for the given [graph]. Return `true` if there was a cached data.
+     *
+     * It is likely that the stale cache would be not used anyway, e.g., if the containing declaration is edited in IDE, FIR tree is
+     * re-computed from scratch, hence a different control-flow graph. However, if we let the cache grow only, it may degrade performance.
+     * It's still up to cache users (checker components or IDE) to invalidate cache for (soon-to-be-rebuilt) graph.
+     */
+    fun invalidateCache(graph: ControlFlowGraph): Boolean {
+        return propertyInitializationInfoCache.remove(graph) != null
+    }
+
+    private operator fun contains(graph: ControlFlowGraph): Boolean {
+        return graph in propertyInitializationInfoCache.keys
+    }
+
+    companion object {
+        fun create(): PropertyInitializationInfoCache {
+            return PropertyInitializationInfoCache()
+        }
+    }
+}

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/context/CheckerContext.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/context/CheckerContext.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.fir.analysis.checkers.context
 import org.jetbrains.kotlin.diagnostics.Severity
 import org.jetbrains.kotlin.fir.FirElement
 import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.analysis.cfa.PropertyInitializationInfoCache
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirDiagnostic
 import org.jetbrains.kotlin.fir.declarations.FirDeclaration
 import org.jetbrains.kotlin.fir.expressions.FirGetClassCall
@@ -20,6 +21,7 @@ abstract class CheckerContext {
     // Services
     abstract val sessionHolder: SessionHolder
     abstract val returnTypeCalculator: ReturnTypeCalculator
+    abstract val propertyInitializationInfoCache: PropertyInitializationInfoCache
 
     // Context
     abstract val implicitReceiverStack: ImplicitReceiverStack

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/context/PersistentCheckerContext.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/context/PersistentCheckerContext.kt
@@ -9,6 +9,7 @@ import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.PersistentSet
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentSetOf
+import org.jetbrains.kotlin.fir.analysis.cfa.PropertyInitializationInfoCache
 import org.jetbrains.kotlin.fir.declarations.FirDeclaration
 import org.jetbrains.kotlin.fir.expressions.FirGetClassCall
 import org.jetbrains.kotlin.fir.expressions.FirStatement
@@ -25,18 +26,24 @@ class PersistentCheckerContext private constructor(
     override val getClassCalls: PersistentList<FirGetClassCall>,
     override val sessionHolder: SessionHolder,
     override val returnTypeCalculator: ReturnTypeCalculator,
+    override val propertyInitializationInfoCache: PropertyInitializationInfoCache,
     override val suppressedDiagnostics: PersistentSet<String>,
     override val allInfosSuppressed: Boolean,
     override val allWarningsSuppressed: Boolean,
     override val allErrorsSuppressed: Boolean
 ) : CheckerContext() {
-    constructor(sessionHolder: SessionHolder, returnTypeCalculator: ReturnTypeCalculator) : this(
+    constructor(
+        sessionHolder: SessionHolder,
+        returnTypeCalculator: ReturnTypeCalculator,
+        propertyInitializationInfoCache: PropertyInitializationInfoCache
+    ) : this(
         PersistentImplicitReceiverStack(),
         persistentListOf(),
         persistentListOf(),
         persistentListOf(),
         sessionHolder,
         returnTypeCalculator,
+        propertyInitializationInfoCache,
         persistentSetOf(),
         allInfosSuppressed = false,
         allWarningsSuppressed = false,
@@ -51,6 +58,7 @@ class PersistentCheckerContext private constructor(
             getClassCalls,
             sessionHolder,
             returnTypeCalculator,
+            propertyInitializationInfoCache,
             suppressedDiagnostics,
             allInfosSuppressed,
             allWarningsSuppressed,
@@ -66,6 +74,7 @@ class PersistentCheckerContext private constructor(
             getClassCalls,
             sessionHolder,
             returnTypeCalculator,
+            propertyInitializationInfoCache,
             suppressedDiagnostics,
             allInfosSuppressed,
             allWarningsSuppressed,
@@ -81,6 +90,7 @@ class PersistentCheckerContext private constructor(
             getClassCalls,
             sessionHolder,
             returnTypeCalculator,
+            propertyInitializationInfoCache,
             suppressedDiagnostics,
             allInfosSuppressed,
             allWarningsSuppressed,
@@ -96,6 +106,7 @@ class PersistentCheckerContext private constructor(
             getClassCalls.add(getClassCall),
             sessionHolder,
             returnTypeCalculator,
+            propertyInitializationInfoCache,
             suppressedDiagnostics,
             allInfosSuppressed,
             allWarningsSuppressed,
@@ -117,6 +128,7 @@ class PersistentCheckerContext private constructor(
             getClassCalls,
             sessionHolder,
             returnTypeCalculator,
+            propertyInitializationInfoCache,
             suppressedDiagnostics.addAll(diagnosticNames),
             this.allInfosSuppressed || allInfosSuppressed,
             this.allWarningsSuppressed || allWarningsSuppressed,

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/collectors/FirDiagnosticsCollector.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/collectors/FirDiagnosticsCollector.kt
@@ -7,10 +7,6 @@ package org.jetbrains.kotlin.fir.analysis.collectors
 
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.analysis.collectors.components.DiagnosticComponentsFactory
-import org.jetbrains.kotlin.fir.analysis.diagnostics.FirDiagnostic
-import org.jetbrains.kotlin.fir.analysis.diagnostics.impl.DiagnosticReporterWithSuppress
-import org.jetbrains.kotlin.fir.analysis.diagnostics.impl.SimpleDiagnosticReporter
-import org.jetbrains.kotlin.fir.declarations.FirFile
 import org.jetbrains.kotlin.fir.resolve.ScopeSession
 
 object FirDiagnosticsCollector {

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/collectors/SimpleDiagnosticsCollector.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/collectors/SimpleDiagnosticsCollector.kt
@@ -6,15 +6,11 @@
 package org.jetbrains.kotlin.fir.analysis.collectors
 
 import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.analysis.cfa.PropertyInitializationInfoCache
 import org.jetbrains.kotlin.fir.analysis.checkers.context.PersistentCheckerContext
 import org.jetbrains.kotlin.fir.analysis.collectors.components.AbstractDiagnosticCollectorComponent
 import org.jetbrains.kotlin.fir.analysis.diagnostics.DiagnosticReporter
-import org.jetbrains.kotlin.fir.analysis.diagnostics.FirDiagnostic
-import org.jetbrains.kotlin.fir.analysis.diagnostics.impl.BaseDiagnosticReporter
-import org.jetbrains.kotlin.fir.analysis.diagnostics.impl.DiagnosticReporterWithSuppress
-import org.jetbrains.kotlin.fir.analysis.diagnostics.impl.SimpleDiagnosticReporter
 import org.jetbrains.kotlin.fir.resolve.ScopeSession
-import org.jetbrains.kotlin.fir.resolve.SessionHolder
 import org.jetbrains.kotlin.fir.resolve.transformers.ReturnTypeCalculatorForFullBodyResolve
 
 class SimpleDiagnosticsCollector(
@@ -26,7 +22,8 @@ class SimpleDiagnosticsCollector(
         return CheckerRunningDiagnosticCollectorVisitor(
             PersistentCheckerContext(
                 this,
-                ReturnTypeCalculatorForFullBodyResolve()
+                ReturnTypeCalculatorForFullBodyResolve(),
+                PropertyInitializationInfoCache.create()
             ),
             components
         )

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/collectors/components/ControlFlowAnalysisDiagnosticComponent.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/collectors/components/ControlFlowAnalysisDiagnosticComponent.kt
@@ -51,7 +51,6 @@ class ControlFlowAnalysisDiagnosticComponent(
 
     override fun visitFunction(function: FirFunction, data: CheckerContext) {
         val graph = function.controlFlowGraphReference?.controlFlowGraph ?: return
-
         controlFlowAnalyzer.analyzeFunction(function, graph, data, reporter)
     }
 
@@ -61,7 +60,6 @@ class ControlFlowAnalysisDiagnosticComponent(
 
     override fun visitPropertyAccessor(propertyAccessor: FirPropertyAccessor, data: CheckerContext) {
         val graph = propertyAccessor.controlFlowGraphReference?.controlFlowGraph ?: return
-
         controlFlowAnalyzer.analyzePropertyAccessor(propertyAccessor, graph, data, reporter)
     }
 

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/collectors/components/DiagnosticComponentsFactory.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/collectors/components/DiagnosticComponentsFactory.kt
@@ -11,6 +11,8 @@ import org.jetbrains.kotlin.fir.analysis.diagnostics.DiagnosticReporter
 object DiagnosticComponentsFactory {
     fun createAllDiagnosticComponents(session: FirSession, reporter: DiagnosticReporter): List<AbstractDiagnosticCollectorComponent> {
         return listOf(
+            // NB: the component for declaration checkers should precede the CFA component.
+            // See comments in [PropertyInitializationInfoCache] for more details.
             DeclarationCheckersDiagnosticComponent(session, reporter),
             ExpressionCheckersDiagnosticComponent(session, reporter),
             TypeCheckersDiagnosticComponent(session, reporter),
@@ -18,5 +20,4 @@ object DiagnosticComponentsFactory {
             ControlFlowAnalysisDiagnosticComponent(session, reporter),
         )
     }
-
 }

--- a/idea/idea-frontend-fir/idea-fir-low-level-api/src/org/jetbrains/kotlin/idea/fir/low/level/api/diagnostics/AbstractFirIdeDiagnosticsCollector.kt
+++ b/idea/idea-frontend-fir/idea-fir-low-level-api/src/org/jetbrains/kotlin/idea/fir/low/level/api/diagnostics/AbstractFirIdeDiagnosticsCollector.kt
@@ -16,7 +16,6 @@ import org.jetbrains.kotlin.fir.analysis.collectors.AbstractDiagnosticCollector
 import org.jetbrains.kotlin.fir.analysis.collectors.components.*
 import org.jetbrains.kotlin.fir.analysis.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.fir.analysis.jvm.checkers.JvmDeclarationCheckers
-import org.jetbrains.kotlin.fir.checkers.*
 import org.jetbrains.kotlin.fir.moduleData
 import org.jetbrains.kotlin.idea.fir.low.level.api.sessions.moduleSourceInfo
 import org.jetbrains.kotlin.platform.SimplePlatform
@@ -50,13 +49,14 @@ private object CheckersFactory {
             if (!useExtendedCheckers) {
                 add(ErrorNodeDiagnosticCollectorComponent(session, reporter))
             }
+            // NB: the component for declaration checkers should precede the CFA component.
+            // See comments in [PropertyInitializationInfoCache] for more details.
             add(DeclarationCheckersDiagnosticComponent(session, reporter, declarationCheckers))
             add(ExpressionCheckersDiagnosticComponent(session, reporter, expressionCheckers))
             typeCheckers?.let { add(TypeCheckersDiagnosticComponent(session, reporter, it)) }
             add(ControlFlowAnalysisDiagnosticComponent(session, reporter, declarationCheckers))
         }
     }
-
 
     private fun createDeclarationCheckers(useExtendedCheckers: Boolean, platform: SimplePlatform): DeclarationCheckers {
         return if (useExtendedCheckers) {
@@ -83,7 +83,6 @@ private object CheckersFactory {
         createDeclarationCheckers: MutableList<DeclarationCheckers>.() -> Unit
     ): DeclarationCheckers =
         createDeclarationCheckers(buildList(createDeclarationCheckers))
-
 
     @OptIn(CheckersComponentInternal::class)
     private fun createDeclarationCheckers(declarationCheckers: List<DeclarationCheckers>): DeclarationCheckers {

--- a/idea/idea-frontend-fir/idea-fir-low-level-api/src/org/jetbrains/kotlin/idea/fir/low/level/api/diagnostics/fir/PersistentCheckerContextFactory.kt
+++ b/idea/idea-frontend-fir/idea-fir-low-level-api/src/org/jetbrains/kotlin/idea/fir/low/level/api/diagnostics/fir/PersistentCheckerContextFactory.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.idea.fir.low.level.api.diagnostics.fir
 
+import org.jetbrains.kotlin.fir.analysis.cfa.PropertyInitializationInfoCache
 import org.jetbrains.kotlin.fir.analysis.checkers.context.PersistentCheckerContext
 import org.jetbrains.kotlin.fir.resolve.ScopeSession
 import org.jetbrains.kotlin.fir.resolve.SessionHolder
@@ -20,6 +21,6 @@ internal object PersistentCheckerContextFactory {
             ImplicitBodyResolveComputationSession(),
             ::FirIdeDesignatedBodyResolveTransformerForReturnTypeCalculator
         )
-        return PersistentCheckerContext(sessionHolder, returnTypeCalculator)
+        return PersistentCheckerContext(sessionHolder, returnTypeCalculator, PropertyInitializationInfoCache.create())
     }
 }


### PR DESCRIPTION
Currently, constructors, anonymous initializers, and property initializers are visited twice by `FirMemberPropertiesChecker` and `FirControlFlowAnalyzer`. Note that the former collects init info for member properties only, whereas the latter collects init info for local properties only. Control-flow analysis is one of the expensive analyses in FIR checkers, so it'd be better to avoid such redundant visit.

Another issue is, variable assignment checkers in `FirControlFlowAnalyzer` are not applied if given functions or property initializers don't have local properties. Therefore, diagnostics for member properties are hidden for now.

To mitigate those issues, as a first step, this commit introduces a cache for property init info to checker context so that different checkers across different checker components can share the analyzed (hence cached) info.

Note that the order of components (that determines the order of checkers) matters. Member property initialization info needs info accumulation among constructors, anonymous initializers, and property initializers. Also, it needs topological sorting of constructors. Therefore, declaration checker component (that encompasses member property checker) should precede CFA component (that encompasses variable assignment checkers).

Caching everything would hurt performance potentially. So, we limit caching only for declarations visited by member properties checker.

------

After this, we can extend existing property init analyzer to access/write to member properties in regular functions as well as constructors, anonymous initializers, and property initializers. Doing so, though, found another issue, which will be dealt separately.