### PR TITLE
KT-47347: Kapt processors should not be input files for stub generation

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/Kapt3KotlinGradleSubplugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/Kapt3KotlinGradleSubplugin.kt
@@ -292,8 +292,6 @@ class Kapt3GradleSubplugin @Inject internal constructor(private val registry: To
         val kaptTaskProvider: TaskProvider<out KaptTask> = context.createKaptKotlinTask(useWorkerApi = project.isUseWorkerApi())
 
         kaptGenerateStubsTaskProvider.configure { kaptGenerateStubsTask ->
-            kaptGenerateStubsTask.source(*kaptConfigurations.toTypedArray())
-
             kaptGenerateStubsTask.dependsOn(*buildDependencies.toTypedArray())
             kaptGenerateStubsTask.dependsOn(
                 project.provider {

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/KaptGenerateStubsTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/KaptGenerateStubsTask.kt
@@ -76,9 +76,12 @@ abstract class KaptGenerateStubsTask : KotlinCompile(KotlinJvmOptionsImpl()) {
     @get:Internal
     lateinit var generatedSourcesDirs: List<File>
 
-    @get:Classpath
-    @get:InputFiles
+    @get:Internal("Not an input, just passed as kapt args. ")
     abstract val kaptClasspath: ConfigurableFileCollection
+
+    /* Used as input as empty kapt classpath should not trigger stub generation, but a non-empty one should. */
+    @Input
+    fun getIfKaptClasspathIsPresent() = !kaptClasspath.isEmpty
 
     @get:Classpath
     @get:InputFiles


### PR DESCRIPTION
This commit avoids passing kapt processors as sources for stub generation
task, and it also avoid using them as input files for stub generation.
Instead, it adds a new property that simply records if processors are
present (as going from empty to 1+ processors should re-run stubs).

Fixes #KT-47347

Test: Kapt3IT.kt