### PR TITLE
expose original message collector in CLIConfiguration

### DIFF
--- a/compiler/cli/src/org/jetbrains/kotlin/cli/common/CLICompiler.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/common/CLICompiler.kt
@@ -65,6 +65,8 @@ abstract class CLICompiler<A : CommonCompilerArguments> : CLITool<A>() {
 
         val configuration = CompilerConfiguration()
 
+        configuration.put(CLIConfigurationKeys.ORIGINAL_MESSAGE_COLLECTOR_KEY, messageCollector)
+
         val collector = GroupingMessageCollector(messageCollector, arguments.allWarningsAsErrors).also {
             configuration.put(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, it)
         }

--- a/compiler/cli/src/org/jetbrains/kotlin/cli/common/CLIConfigurationKeys.java
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/common/CLIConfigurationKeys.java
@@ -31,6 +31,11 @@ public class CLIConfigurationKeys {
 
     public static final CompilerConfigurationKey<MessageCollector> MESSAGE_COLLECTOR_KEY =
             CompilerConfigurationKey.create("message collector");
+
+    // Used by compiler plugins to access delegated message collector in GroupingMessageCollector
+    public static final CompilerConfigurationKey<MessageCollector> ORIGINAL_MESSAGE_COLLECTOR_KEY =
+            CompilerConfigurationKey.create("original message collector");
+
     public static final CompilerConfigurationKey<Boolean> ALLOW_KOTLIN_PACKAGE =
             CompilerConfigurationKey.create("allow kotlin package");
     public static final CompilerConfigurationKey<CommonCompilerPerformanceManager> PERF_MANAGER =


### PR DESCRIPTION
This will allow compiler plugins to have access to the unwrapped MessageCollector during plugin registration phase.