### PR TITLE
JVM_IR: produce collection stubs in a stable order

### DIFF
--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/types/IrTypeUtils.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/types/IrTypeUtils.kt
@@ -21,15 +21,14 @@ fun IrClassifierSymbol.superTypes(): List<IrType> = when (this) {
     else -> emptyList()
 }
 
-fun IrClassifierSymbol.isSubtypeOfClass(superClass: IrClassSymbol): Boolean {
-    if (FqNameEqualityChecker.areEqual(this, superClass)) return true
-    return superTypes().any { it.isSubtypeOfClass(superClass) }
-}
+fun IrClassifierSymbol.isSubtypeOfClass(superClass: IrClassSymbol): Boolean =
+    FqNameEqualityChecker.areEqual(this, superClass) || isStrictSubtypeOfClass(superClass)
 
-fun IrType.isSubtypeOfClass(superClass: IrClassSymbol): Boolean {
-    if (this !is IrSimpleType) return false
-    return classifier.isSubtypeOfClass(superClass)
-}
+fun IrClassifierSymbol.isStrictSubtypeOfClass(superClass: IrClassSymbol): Boolean =
+    superTypes().any { it.isSubtypeOfClass(superClass) }
+
+fun IrType.isSubtypeOfClass(superClass: IrClassSymbol): Boolean =
+    this is IrSimpleType && classifier.isSubtypeOfClass(superClass)
 
 fun IrType.isSubtypeOf(superType: IrType, irBuiltIns: IrBuiltIns): Boolean {
     return AbstractTypeChecker.isSubtypeOf(


### PR DESCRIPTION
This means not storing intermediate results in any HashSets.

 #KT-47411 Fixed