### PR TITLE
KT-47416: Pass Android annotationProcessorOptions to kapt

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kapt3AndroidIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kapt3AndroidIT.kt
@@ -323,6 +323,33 @@ abstract class Kapt3AndroidIT : Kapt3BaseIT() {
         }
     }
 
+    @Test
+    fun testStaticDslOptionsPassedToKapt() = with(Project("android-dagger", directoryPrefix = "kapt2")) {
+        setupWorkingDir()
+
+        gradleBuildScript(subproject = "app").appendText(
+            """
+
+            apply plugin: 'kotlin-kapt'
+
+            android {
+                defaultConfig {
+                    javaCompileOptions {
+                        annotationProcessorOptions {
+                            arguments += ["enable.some.test.option": "true"]
+                        }
+                    }
+                }
+            }
+            """.trimIndent()
+        )
+
+        build(":app:kaptDebugKotlin") {
+            assertSuccessful()
+            assertContainsRegex(Regex("AP options.*enable\\.some\\.test\\.option=true"))
+        }
+    }
+
     private fun setupDataBinding(project: Project) {
         project.setupWorkingDir()
 

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/Kapt3KotlinGradleSubplugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/Kapt3KotlinGradleSubplugin.kt
@@ -365,7 +365,6 @@ class Kapt3GradleSubplugin @Inject internal constructor(private val registry: To
     private fun Kapt3SubpluginContext.getAPOptions(): Provider<CompositeSubpluginOption> = project.provider {
         val androidVariantData = KaptWithAndroid.androidVariantData(this)
 
-        val androidOptions = androidVariantData?.annotationProcessorOptions ?: emptyMap()
         val annotationProcessorProviders = androidVariantData?.annotationProcessorOptionProviders
 
         val subluginOptionsFromProvidedApOptions = lazy {
@@ -383,23 +382,25 @@ class Kapt3GradleSubplugin @Inject internal constructor(private val registry: To
             }
         }
 
-        val nonAndroidOptions = androidOptions.toList().map { SubpluginOption(it.first, it.second) } + getKaptApOptions().get()
-
         CompositeSubpluginOption(
             "apoptions",
-            lazy { encodeList((nonAndroidOptions + subluginOptionsFromProvidedApOptions.value).associate { it.key to it.value }) },
-            nonAndroidOptions
+            lazy { encodeList((getDslKaptApOptions().get() + subluginOptionsFromProvidedApOptions.value).associate { it.key to it.value }) },
+            getDslKaptApOptions().get()
         )
     }
 
-    private fun Kapt3SubpluginContext.getKaptApOptions(): Provider<List<SubpluginOption>> = project.provider {
+    /* Returns AP options from static DSL. */
+    private fun Kapt3SubpluginContext.getDslKaptApOptions(): Provider<List<SubpluginOption>> = project.provider {
         val androidVariantData = KaptWithAndroid.androidVariantData(this)
 
         val androidExtension = androidVariantData?.let {
             project.extensions.findByName("android") as? BaseExtension
         }
 
-        kaptExtension.getAdditionalArguments(project, androidVariantData, androidExtension).toList()
+        val androidOptions = androidVariantData?.annotationProcessorOptions ?: emptyMap()
+        val androidSubpluginOptions = androidOptions.toList().map { SubpluginOption(it.first, it.second) }
+
+        androidSubpluginOptions + kaptExtension.getAdditionalArguments(project, androidVariantData, androidExtension).toList()
             .map { SubpluginOption(it.first, it.second) } +
                 FilesSubpluginOption(KAPT_KOTLIN_GENERATED, listOf(kotlinSourcesOutputDir))
     }
@@ -609,7 +610,7 @@ class Kapt3GradleSubplugin @Inject internal constructor(private val registry: To
                 it.disableClassloaderCacheForProcessors = project.disableClassloaderCacheForProcessors()
             }
 
-            val subpluginOptions = getKaptApOptions()
+            val subpluginOptions = getDslKaptApOptions()
             registerSubpluginOptions(kaptTaskProvider, subpluginOptions)
         }
 


### PR DESCRIPTION
This commits makes sure that "static" DSL options from
`android.javaCompileOptions.annotationProcessorOptions`
are passed to KAPT when running w/o kotlinc.

A regression was introduced in 19708cfa8708bc36da17601f13fe9921d7a380ef.

Fixes #KT-47416
Test: Kapt3AndroidIT.testStaticDslOptionsPassedToKapt