### PR TITLE
KT-47511: Incremental build compatibility with gradle composing builds

### DIFF
--- a/build-common/src/org/jetbrains/kotlin/incremental/IncrementalModuleInfo.kt
+++ b/build-common/src/org/jetbrains/kotlin/incremental/IncrementalModuleInfo.kt
@@ -35,3 +35,35 @@ class IncrementalModuleInfo(
         private const val serialVersionUID = 1L
     }
 }
+
+private fun mergeNameToModules(
+    main: Map<String, Set<IncrementalModuleEntry>>,
+    child: Map<String, Set<IncrementalModuleEntry>>
+): Map<String, Set<IncrementalModuleEntry>> {
+    val merged = mutableMapOf<String, Set<IncrementalModuleEntry>>()
+    merged.putAll(main)
+
+    child.forEach { key, value ->
+        merged.put(key, mutableSetOf<IncrementalModuleEntry>().apply {
+            addAll(merged.get(key) ?: mutableSetOf())
+            addAll(value)
+        })
+    }
+
+    return merged
+}
+
+fun mergeIncrementalModuleInfo(
+    mainModuleInfo: IncrementalModuleInfo,
+    includedBuildModuleInfo: IncrementalModuleInfo
+): IncrementalModuleInfo {
+    return IncrementalModuleInfo(
+        projectRoot = mainModuleInfo.projectRoot,
+        rootProjectBuildDir = mainModuleInfo.rootProjectBuildDir,
+        dirToModule = mainModuleInfo.dirToModule.toMutableMap().apply { putAll(includedBuildModuleInfo.dirToModule) },
+        nameToModules = mergeNameToModules(mainModuleInfo.nameToModules, includedBuildModuleInfo.nameToModules),
+        jarToClassListFile = mainModuleInfo.jarToClassListFile.toMutableMap().apply { putAll(includedBuildModuleInfo.jarToClassListFile) },
+        jarToModule = mainModuleInfo.jarToModule.toMutableMap().apply { putAll(includedBuildModuleInfo.jarToModule) },
+        jarToAbiSnapshot = mainModuleInfo.jarToAbiSnapshot.toMutableMap().apply { putAll(includedBuildModuleInfo.jarToAbiSnapshot) }
+    )
+}

--- a/build-common/test/org/jetbrains/kotlin/incremental/storage/IncrementalModuleInfoTest.kt
+++ b/build-common/test/org/jetbrains/kotlin/incremental/storage/IncrementalModuleInfoTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.incremental.storage
+
+import org.jetbrains.kotlin.TestWithWorkingDir
+import org.jetbrains.kotlin.incremental.IncrementalModuleEntry
+import org.jetbrains.kotlin.incremental.IncrementalModuleInfo
+import org.jetbrains.kotlin.incremental.mergeIncrementalModuleInfo
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class IncrementalModuleInfoTest: TestWithWorkingDir()  {
+    private lateinit var mainInfo: IncrementalModuleInfo
+    private lateinit var includedBuildInfo: IncrementalModuleInfo
+
+    @Before
+    override fun setUp() {
+        super.setUp()
+
+        val projectRoot = workingDir.resolve("root")
+        // Faked module entry
+        val appEntry = IncrementalModuleEntry(":app", "app", projectRoot, projectRoot, projectRoot)
+        val libEntry = IncrementalModuleEntry(":lib", "lib", projectRoot, projectRoot, projectRoot)
+
+        mainInfo = IncrementalModuleInfo(
+            projectRoot = projectRoot,
+            rootProjectBuildDir = projectRoot.resolve("build"),
+            dirToModule = mapOf(projectRoot.resolve("file-1") to appEntry,
+                                projectRoot.resolve("file-2") to libEntry),
+            nameToModules = mapOf("app" to setOf(appEntry),
+                                  "lib" to setOf(libEntry)),
+            jarToClassListFile = mapOf(),
+            jarToModule = mapOf(),
+            jarToAbiSnapshot = mapOf()
+        )
+
+        includedBuildInfo = IncrementalModuleInfo(
+            projectRoot = projectRoot.resolve("included"),
+            rootProjectBuildDir = projectRoot.resolve("build").resolve("included"),
+            dirToModule = mapOf(projectRoot.resolve("file-1") to appEntry,
+                                projectRoot.resolve("file-2") to libEntry),
+            nameToModules = mapOf("app" to setOf(appEntry.copy(projectPath = ":included-build", name = ":included-build")),
+                                  "lib" to setOf(libEntry.copy())),
+            jarToClassListFile = mapOf(),
+            jarToModule = mapOf(),
+            jarToAbiSnapshot = mapOf()
+        )
+    }
+
+    @Test
+    fun testKeepMainInfo() {
+        val merged = mergeIncrementalModuleInfo(mainInfo, includedBuildInfo)
+        assertEquals(merged.projectRoot, mainInfo.projectRoot)
+        assertEquals(merged.rootProjectBuildDir, mainInfo.rootProjectBuildDir)
+    }
+
+    @Test
+    fun testMergeNameToModules() {
+        val merged = mergeIncrementalModuleInfo(mainInfo, includedBuildInfo)
+        assertEquals(merged.nameToModules.get("lib")?.size ?: -1, 1)
+        assertEquals(merged.nameToModules.get("app")?.size ?: -1, 2)
+    }
+
+
+    @After
+    override fun tearDown() {
+        super.tearDown()
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/compilerRunner/GradleKotlinCompilerRunner.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/compilerRunner/GradleKotlinCompilerRunner.kt
@@ -307,6 +307,7 @@ internal open class GradleCompilerRunner(
 
             var mergedIncrementalModuleInfo = incrementalModuleInfo
 
+            // compat with gradle composing build. See https://youtrack.jetbrains.com/issue/KT-47511 for more details.
             if (gradle.rootProject.gradle.includedBuilds.isNotEmpty()) {
                 val includedBuilds = gradle.rootProject.gradle.includedBuilds
                     .filter { it is IncludedBuildState }


### PR DESCRIPTION
Kotlin-gradle-plugin maintains the dependency relationship between modules from gradle taskGraph, and it is used in incremental compilation.

Assume there are two modules called moduleA and moduleB. If modulesA depends on moduleB, during once compilation, moduleB changed, moduleA will find out the 'build' directory of moduleB to determine if moduleA should be re-compiled. 

But when moduleB is a **[composing build](https://docs.gradle.org/current/userguide/composite_builds.html)**, incremental compilation will fail because moduleA have no idea about what moduleB is. when moduleB changes, moduleA will **always perform full compilation.**

It's a bug in kotlin-gradle-plugin, kotlin didn't take this situation into account

To briefly illustrate this case, here is a demo-application project attached.

1. run `./gradlew assembleDebug`
2. modify `included/lib/src/main/java/me/fengguang/lib/KTClassInIncludedLib.kt`, for example: Append strings at line 8.
3. run `./gradlew assembleDebug --debug | grep -e ".*\[KOTLIN\] \[IC\] Non-incremental compilation will be performed.*"`

You will see, there is a debug message printed at the console.
`2021-06-29T14:26:00.714+0800 [DEBUG] [o
[KotlinDemoApplication.zip](https://github.com/JetBrains/kotlin/files/6731224/KotlinDemoApplication.zip)
rg.gradle.api.Task] [KOTLIN] [IC] Non-incremental compilation will be performed: DEP_CHANGE_HISTORY_IS_NOT_FOUND`

This log indicated that moduleA(:app in demoapplication) performs re-compile because `classes.jar` in moduleB(:lib in demo-application) changed, and moduleA cannot analyze what's going on with this jar file because moduleB didn't show up at moduleA's dependency graph.