### PR TITLE
JVM_IR: fix primitive comparison optimizations

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -1479,6 +1479,18 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         }
 
         @Test
+        @TestMetadata("eqNullableShortToShort.kt")
+        public void testEqNullableShortToShort() throws Exception {
+            runTest("compiler/testData/codegen/box/binaryOp/eqNullableShortToShort.kt");
+        }
+
+        @Test
+        @TestMetadata("eqNullableToPrimitiveWithSideEffects.kt")
+        public void testEqNullableToPrimitiveWithSideEffects() throws Exception {
+            runTest("compiler/testData/codegen/box/binaryOp/eqNullableToPrimitiveWithSideEffects.kt");
+        }
+
+        @Test
         @TestMetadata("intrinsic.kt")
         public void testIntrinsic() throws Exception {
             runTest("compiler/testData/codegen/box/binaryOp/intrinsic.kt");
@@ -1542,6 +1554,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         @TestMetadata("overflowLong.kt")
         public void testOverflowLong() throws Exception {
             runTest("compiler/testData/codegen/box/binaryOp/overflowLong.kt");
+        }
+
+        @Test
+        @TestMetadata("primitiveEqualsSafeCall.kt")
+        public void testPrimitiveEqualsSafeCall() throws Exception {
+            runTest("compiler/testData/codegen/box/binaryOp/primitiveEqualsSafeCall.kt");
         }
     }
 

--- a/compiler/testData/codegen/box/binaryOp/eqNullableShortToShort.kt
+++ b/compiler/testData/codegen/box/binaryOp/eqNullableShortToShort.kt
@@ -1,0 +1,7 @@
+class C(val x: Short)
+
+fun box(): String {
+    val a: C = C(1)
+    val b: C? = C(1)
+    return if (b?.x == a.x) "OK" else "fail"
+}

--- a/compiler/testData/codegen/box/binaryOp/eqNullableToPrimitiveWithSideEffects.kt
+++ b/compiler/testData/codegen/box/binaryOp/eqNullableToPrimitiveWithSideEffects.kt
@@ -1,0 +1,19 @@
+// IGNORE_BACKEND: JS, JS_IR, WASM, NATIVE
+var result = ""
+
+fun sideEffecting(): Int {
+    result += "OK"
+    return 123
+}
+
+class C(val x: Int)
+
+val a: C? = C(123)
+val b: C? = null
+
+fun box(): String {
+    if (a?.x != sideEffecting()) return "fail cmp 1"
+    // RHS not evaluated because `b` is null, might be a bug:
+    if (b?.x == sideEffecting()) return "fail cmp 2"
+    return result
+}

--- a/compiler/testData/codegen/box/binaryOp/primitiveEqualsSafeCall.kt
+++ b/compiler/testData/codegen/box/binaryOp/primitiveEqualsSafeCall.kt
@@ -1,0 +1,7 @@
+class C(val x: Short)
+
+fun box(): String {
+    val a: Short = 1
+    val b: C? = C(1)
+    return if (a.equals(b?.x)) "OK" else "fail"
+}

--- a/compiler/testData/codegen/bytecodeText/boxingOptimization/safeCallToPrimitiveEquality.kt
+++ b/compiler/testData/codegen/bytecodeText/boxingOptimization/safeCallToPrimitiveEquality.kt
@@ -1,10 +1,25 @@
+// FILE: J.java
+import org.jetbrains.annotations.NotNull;
+
+public interface J {
+    @NotNull
+    public Integer foo();
+}
+
+// FILE: test.kt
 fun Long.id() = this
+
+fun Short.id() = this
 
 fun String.drop2() = if (length >= 2) subSequence(2, length) else null
 
 fun doSimple1(s: String?) = s?.length == 3
 
-fun doLongReceiver1(x: Long) = x?.id() == 3L
+fun doJava1(s: String?, j: J) = s?.length == j.foo()
+
+fun doLongReceiver1(x: Long?) = x?.id() == 3L
+
+fun doShortReceiver1(x: Short?, y: Short) = x?.id() == y
 
 fun doChain1(s: String?) = s?.drop2()?.length == 1
 
@@ -13,11 +28,16 @@ fun doIf1(s: String?) =
 
 fun doSimple2(s: String?) = 3 == s?.length
 
-fun doLongReceiver2(x: Long) = 3L == x?.id()
+fun doJava2(s: String?, j: J) = j.foo() == s?.length
+
+fun doLongReceiver2(x: Long?) = 3L == x?.id()
+
+fun doShortReceiver2(x: Short?, y: Short) = y == x?.id()
 
 fun doChain2(s: String?) = 1 == s?.drop2()?.length
 
 fun doIf2(s: String?) =
         if (1 == s?.length) "A" else "B"
 
-// 0 valueOf
+// `doJava1`/`doJava2` box `s?.length` instead of unboxing `j.foo()`:
+// 2 valueOf

--- a/compiler/testData/codegen/bytecodeText/intrinsicsCompare/byteSmartCast_after.kt
+++ b/compiler/testData/codegen/bytecodeText/intrinsicsCompare/byteSmartCast_after.kt
@@ -1,5 +1,4 @@
 // !LANGUAGE: +ProperIeee754Comparisons
-// IGNORE_BACKEND_FIR: JVM_IR
 fun equals3(a: Byte?, b: Byte?) = a != null && b != null && a == b
 
 fun equals4(a: Byte?, b: Byte?) = if (a is Byte && b is Byte) a == b else null!!
@@ -21,10 +20,9 @@ fun less5(a: Any?, b: Any?) = if (a is Byte && b is Byte) a < b else true
 // 3 IF_ICMPGE
 
 // JVM_IR_TEMPLATES
-// 2 Intrinsics\.areEqual
+// 0 Intrinsics\.areEqual
 // 0 Intrinsics\.compare
-// 4 INVOKEVIRTUAL java/lang/Byte\.byteValue \(\)B
+// 8 INVOKEVIRTUAL java/lang/Byte\.byteValue \(\)B
 // 4 INVOKEVIRTUAL java/lang/Number\.byteValue \(\)B
 // 0 IFGE
 // 3 IF_ICMPGE
-

--- a/compiler/testData/codegen/bytecodeText/intrinsicsCompare/byteSmartCast_before.kt
+++ b/compiler/testData/codegen/bytecodeText/intrinsicsCompare/byteSmartCast_before.kt
@@ -1,6 +1,4 @@
 // !LANGUAGE: -ProperIeee754Comparisons
-// IGNORE_BACKEND_FIR: JVM_IR
-
 fun equals3(a: Byte?, b: Byte?) = a != null && b != null && a == b
 
 fun equals4(a: Byte?, b: Byte?) = if (a is Byte && b is Byte) a == b else null!!
@@ -21,9 +19,9 @@ fun less5(a: Any?, b: Any?) = if (a is Byte && b is Byte) a < b else true
 // 0 IF_ICMPGE
 
 // JVM_IR_TEMPLATES
-// 2 Intrinsics\.areEqual
+// 0 Intrinsics\.areEqual
 // 0 Intrinsics\.compare
-// 4 INVOKEVIRTUAL java/lang/Byte\.byteValue \(\)B
+// 8 INVOKEVIRTUAL java/lang/Byte\.byteValue \(\)B
 // 4 INVOKEVIRTUAL java/lang/Number\.byteValue \(\)B
 // 0 IFGE
 // 3 IF_ICMPGE

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -1479,6 +1479,18 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
         }
 
         @Test
+        @TestMetadata("eqNullableShortToShort.kt")
+        public void testEqNullableShortToShort() throws Exception {
+            runTest("compiler/testData/codegen/box/binaryOp/eqNullableShortToShort.kt");
+        }
+
+        @Test
+        @TestMetadata("eqNullableToPrimitiveWithSideEffects.kt")
+        public void testEqNullableToPrimitiveWithSideEffects() throws Exception {
+            runTest("compiler/testData/codegen/box/binaryOp/eqNullableToPrimitiveWithSideEffects.kt");
+        }
+
+        @Test
         @TestMetadata("intrinsic.kt")
         public void testIntrinsic() throws Exception {
             runTest("compiler/testData/codegen/box/binaryOp/intrinsic.kt");
@@ -1542,6 +1554,12 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
         @TestMetadata("overflowLong.kt")
         public void testOverflowLong() throws Exception {
             runTest("compiler/testData/codegen/box/binaryOp/overflowLong.kt");
+        }
+
+        @Test
+        @TestMetadata("primitiveEqualsSafeCall.kt")
+        public void testPrimitiveEqualsSafeCall() throws Exception {
+            runTest("compiler/testData/codegen/box/binaryOp/primitiveEqualsSafeCall.kt");
         }
     }
 

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -1479,6 +1479,18 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         }
 
         @Test
+        @TestMetadata("eqNullableShortToShort.kt")
+        public void testEqNullableShortToShort() throws Exception {
+            runTest("compiler/testData/codegen/box/binaryOp/eqNullableShortToShort.kt");
+        }
+
+        @Test
+        @TestMetadata("eqNullableToPrimitiveWithSideEffects.kt")
+        public void testEqNullableToPrimitiveWithSideEffects() throws Exception {
+            runTest("compiler/testData/codegen/box/binaryOp/eqNullableToPrimitiveWithSideEffects.kt");
+        }
+
+        @Test
         @TestMetadata("intrinsic.kt")
         public void testIntrinsic() throws Exception {
             runTest("compiler/testData/codegen/box/binaryOp/intrinsic.kt");
@@ -1542,6 +1554,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         @TestMetadata("overflowLong.kt")
         public void testOverflowLong() throws Exception {
             runTest("compiler/testData/codegen/box/binaryOp/overflowLong.kt");
+        }
+
+        @Test
+        @TestMetadata("primitiveEqualsSafeCall.kt")
+        public void testPrimitiveEqualsSafeCall() throws Exception {
+            runTest("compiler/testData/codegen/box/binaryOp/primitiveEqualsSafeCall.kt");
         }
     }
 

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -1306,6 +1306,16 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/binaryOp/eqNullableDoublesWithTP.kt");
         }
 
+        @TestMetadata("eqNullableShortToShort.kt")
+        public void testEqNullableShortToShort() throws Exception {
+            runTest("compiler/testData/codegen/box/binaryOp/eqNullableShortToShort.kt");
+        }
+
+        @TestMetadata("eqNullableToPrimitiveWithSideEffects.kt")
+        public void testEqNullableToPrimitiveWithSideEffects() throws Exception {
+            runTest("compiler/testData/codegen/box/binaryOp/eqNullableToPrimitiveWithSideEffects.kt");
+        }
+
         @TestMetadata("intrinsic.kt")
         public void testIntrinsic() throws Exception {
             runTest("compiler/testData/codegen/box/binaryOp/intrinsic.kt");
@@ -1359,6 +1369,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
         @TestMetadata("overflowLong.kt")
         public void testOverflowLong() throws Exception {
             runTest("compiler/testData/codegen/box/binaryOp/overflowLong.kt");
+        }
+
+        @TestMetadata("primitiveEqualsSafeCall.kt")
+        public void testPrimitiveEqualsSafeCall() throws Exception {
+            runTest("compiler/testData/codegen/box/binaryOp/primitiveEqualsSafeCall.kt");
         }
     }
 

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
@@ -806,6 +806,16 @@ public class IrJsCodegenBoxES6TestGenerated extends AbstractIrJsCodegenBoxES6Tes
             runTest("compiler/testData/codegen/box/binaryOp/eqNullableDoublesWithTP.kt");
         }
 
+        @TestMetadata("eqNullableShortToShort.kt")
+        public void testEqNullableShortToShort() throws Exception {
+            runTest("compiler/testData/codegen/box/binaryOp/eqNullableShortToShort.kt");
+        }
+
+        @TestMetadata("eqNullableToPrimitiveWithSideEffects.kt")
+        public void testEqNullableToPrimitiveWithSideEffects() throws Exception {
+            runTest("compiler/testData/codegen/box/binaryOp/eqNullableToPrimitiveWithSideEffects.kt");
+        }
+
         @TestMetadata("intrinsic.kt")
         public void testIntrinsic() throws Exception {
             runTest("compiler/testData/codegen/box/binaryOp/intrinsic.kt");
@@ -859,6 +869,11 @@ public class IrJsCodegenBoxES6TestGenerated extends AbstractIrJsCodegenBoxES6Tes
         @TestMetadata("overflowLong.kt")
         public void testOverflowLong() throws Exception {
             runTest("compiler/testData/codegen/box/binaryOp/overflowLong.kt");
+        }
+
+        @TestMetadata("primitiveEqualsSafeCall.kt")
+        public void testPrimitiveEqualsSafeCall() throws Exception {
+            runTest("compiler/testData/codegen/box/binaryOp/primitiveEqualsSafeCall.kt");
         }
     }
 

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -806,6 +806,16 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/binaryOp/eqNullableDoublesWithTP.kt");
         }
 
+        @TestMetadata("eqNullableShortToShort.kt")
+        public void testEqNullableShortToShort() throws Exception {
+            runTest("compiler/testData/codegen/box/binaryOp/eqNullableShortToShort.kt");
+        }
+
+        @TestMetadata("eqNullableToPrimitiveWithSideEffects.kt")
+        public void testEqNullableToPrimitiveWithSideEffects() throws Exception {
+            runTest("compiler/testData/codegen/box/binaryOp/eqNullableToPrimitiveWithSideEffects.kt");
+        }
+
         @TestMetadata("intrinsic.kt")
         public void testIntrinsic() throws Exception {
             runTest("compiler/testData/codegen/box/binaryOp/intrinsic.kt");
@@ -859,6 +869,11 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
         @TestMetadata("overflowLong.kt")
         public void testOverflowLong() throws Exception {
             runTest("compiler/testData/codegen/box/binaryOp/overflowLong.kt");
+        }
+
+        @TestMetadata("primitiveEqualsSafeCall.kt")
+        public void testPrimitiveEqualsSafeCall() throws Exception {
+            runTest("compiler/testData/codegen/box/binaryOp/primitiveEqualsSafeCall.kt");
         }
     }
 

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -806,6 +806,16 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/binaryOp/eqNullableDoublesWithTP.kt");
         }
 
+        @TestMetadata("eqNullableShortToShort.kt")
+        public void testEqNullableShortToShort() throws Exception {
+            runTest("compiler/testData/codegen/box/binaryOp/eqNullableShortToShort.kt");
+        }
+
+        @TestMetadata("eqNullableToPrimitiveWithSideEffects.kt")
+        public void testEqNullableToPrimitiveWithSideEffects() throws Exception {
+            runTest("compiler/testData/codegen/box/binaryOp/eqNullableToPrimitiveWithSideEffects.kt");
+        }
+
         @TestMetadata("intrinsic.kt")
         public void testIntrinsic() throws Exception {
             runTest("compiler/testData/codegen/box/binaryOp/intrinsic.kt");
@@ -859,6 +869,11 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
         @TestMetadata("overflowLong.kt")
         public void testOverflowLong() throws Exception {
             runTest("compiler/testData/codegen/box/binaryOp/overflowLong.kt");
+        }
+
+        @TestMetadata("primitiveEqualsSafeCall.kt")
+        public void testPrimitiveEqualsSafeCall() throws Exception {
+            runTest("compiler/testData/codegen/box/binaryOp/primitiveEqualsSafeCall.kt");
         }
     }
 

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/wasm/semantics/IrCodegenBoxWasmTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/wasm/semantics/IrCodegenBoxWasmTestGenerated.java
@@ -696,6 +696,16 @@ public class IrCodegenBoxWasmTestGenerated extends AbstractIrCodegenBoxWasmTest 
             runTest("compiler/testData/codegen/box/binaryOp/eqNullableDoublesWithTP.kt");
         }
 
+        @TestMetadata("eqNullableShortToShort.kt")
+        public void testEqNullableShortToShort() throws Exception {
+            runTest("compiler/testData/codegen/box/binaryOp/eqNullableShortToShort.kt");
+        }
+
+        @TestMetadata("eqNullableToPrimitiveWithSideEffects.kt")
+        public void testEqNullableToPrimitiveWithSideEffects() throws Exception {
+            runTest("compiler/testData/codegen/box/binaryOp/eqNullableToPrimitiveWithSideEffects.kt");
+        }
+
         @TestMetadata("intrinsic.kt")
         public void testIntrinsic() throws Exception {
             runTest("compiler/testData/codegen/box/binaryOp/intrinsic.kt");
@@ -749,6 +759,11 @@ public class IrCodegenBoxWasmTestGenerated extends AbstractIrCodegenBoxWasmTest 
         @TestMetadata("overflowLong.kt")
         public void testOverflowLong() throws Exception {
             runTest("compiler/testData/codegen/box/binaryOp/overflowLong.kt");
+        }
+
+        @TestMetadata("primitiveEqualsSafeCall.kt")
+        public void testPrimitiveEqualsSafeCall() throws Exception {
+            runTest("compiler/testData/codegen/box/binaryOp/primitiveEqualsSafeCall.kt");
         }
     }
 


### PR DESCRIPTION
 1. the `primitive == object?.something` fusion should not apply to `primitive.equals(object?.something)` because it can't;
 2. coercions to Int are there for a reason - don't remove them;
 3. better optimize `primitive == object?.something` -- the result should be subject to if-null fusion, so it needs to have a specific pattern that resembles safe calls.

 #KT-47597 Fixed