### PR TITLE
FIR IDE: fix symbol lookup for anonymous function and function type parameter

### DIFF
--- a/compiler/psi/src/org/jetbrains/kotlin/psi/KtParameter.java
+++ b/compiler/psi/src/org/jetbrains/kotlin/psi/KtParameter.java
@@ -140,8 +140,39 @@ public class KtParameter extends KtNamedDeclarationStub<KotlinParameterStub> imp
         return getParent() instanceof KtForExpression;
     }
 
+    private <T extends PsiElement> boolean checkParentOfParentType(Class<T> klass) {
+        // `parent` is supposed to be [KtParameterList]
+        PsiElement parent = getParent();
+        if (parent == null) {
+            return false;
+        }
+        return klass.isInstance(parent.getParent());
+    }
+
     public boolean isCatchParameter() {
-        return getParent().getParent() instanceof KtCatchClause;
+        return checkParentOfParentType(KtCatchClause.class);
+    }
+
+    /**
+     * For example,
+     *   lambdaConsumer { lambdaParameter ->
+     *     ...
+     *   }
+     *
+     * @return [true] if this [KtParameter] is a parameter of a lambda.
+     */
+    public boolean isLambdaParameter() {
+        return checkParentOfParentType(KtFunctionLiteral.class);
+    }
+
+    /**
+     * For example,
+     *   fun foo(lambdaArgument: (functionTypeParameter: T, ...) -> R) { ... }
+     *
+     * @return [true] if this [KtParameter] is a parameter of a function type.
+     */
+    public boolean isFunctionTypeParameter() {
+        return checkParentOfParentType(KtFunctionType.class);
     }
 
     @Nullable

--- a/idea/idea-frontend-api/src/org/jetbrains/kotlin/idea/frontend/api/symbols/KtSymbolProvider.kt
+++ b/idea/idea-frontend-api/src/org/jetbrains/kotlin/idea/frontend/api/symbols/KtSymbolProvider.kt
@@ -57,6 +57,12 @@ public interface KtSymbolProviderMixIn : KtAnalysisSessionMixIn {
     public fun KtDeclaration.getSymbol(): KtSymbol =
         analysisSession.symbolProvider.getSymbol(this)
 
+    /**
+     * Creates [KtValueParameterSymbol] by [KtParameter]
+     *
+     * If [KtParameter.isFunctionTypeParameter] is `true`, i.e., if the given [KtParameter] is used as a function type parameter,
+     * it is not possible to create [KtValueParameterSymbol], hence an error will be raised.
+     */
     public fun KtParameter.getParameterSymbol(): KtValueParameterSymbol =
         analysisSession.symbolProvider.getParameterSymbol(this)
 

--- a/idea/idea-frontend-fir/idea-fir-low-level-api/src/org/jetbrains/kotlin/idea/fir/low/level/api/FirModuleResolveStateImpl.kt
+++ b/idea/idea-frontend-fir/idea-fir-low-level-api/src/org/jetbrains/kotlin/idea/fir/low/level/api/FirModuleResolveStateImpl.kt
@@ -119,7 +119,7 @@ internal class FirModuleResolveStateImpl(
         val firDeclaration = FirElementFinder.findElementIn<FirDeclaration>(nonLocalFirForNamedDeclaration) { firDeclaration ->
             when (val realPsi = firDeclaration.realPsi) {
                 is KtObjectLiteralExpression -> realPsi.objectDeclaration == ktDeclaration
-                is KtFunctionLiteral -> realPsi.parent == ktDeclaration
+                is KtLambdaExpression -> realPsi.functionLiteral == ktDeclaration
                 else -> realPsi == ktDeclaration
             }
         }

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/symbols/KtFirSymbolProvider.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/symbols/KtFirSymbolProvider.kt
@@ -35,6 +35,9 @@ internal class KtFirSymbolProvider(
     private val firSymbolProvider by weakRef(firSymbolProvider)
 
     override fun getParameterSymbol(psi: KtParameter): KtValueParameterSymbol = withValidityAssertion {
+        if (psi.isFunctionTypeParameter) {
+            error("Creating KtValueParameterSymbol for function type parameter is not possible. Please see the KDoc of getParameterSymbol")
+        }
         psi.withFirDeclarationOfType<FirValueParameter, KtValueParameterSymbol>(resolveState) {
             firSymbolBuilder.variableLikeBuilder.buildValueParameterSymbol(it)
         }

--- a/idea/idea-frontend-fir/testData/symbols/symbolByPsi/implicitReturnInLambda.kt
+++ b/idea/idea-frontend-fir/testData/symbols/symbolByPsi/implicitReturnInLambda.kt
@@ -1,0 +1,124 @@
+fun foo() {
+    val lam1 = { a: Int ->
+        val b = 1
+        a + b
+    }
+
+    val lam2 = { a: Int ->
+        val c = 1
+        if (a > 0)
+            a + c
+        else
+            a - c
+    }
+}
+
+// RESULT
+/*
+KtFirValueParameterSymbol:
+  annotatedType: [] kotlin/Int
+  annotationClassIds: []
+  annotations: []
+  callableIdIfNonLocal: null
+  hasDefaultValue: false
+  isExtension: false
+  isVararg: false
+  name: a
+  origin: SOURCE
+  receiverType: null
+  symbolKind: LOCAL
+
+KtFirLocalVariableSymbol:
+  annotatedType: [] kotlin/Int
+  callableIdIfNonLocal: null
+  isExtension: false
+  isVal: true
+  name: b
+  origin: SOURCE
+  receiverType: null
+  symbolKind: LOCAL
+
+KtFirAnonymousFunctionSymbol:
+  annotatedType: [] kotlin/Int
+  callableIdIfNonLocal: null
+  isExtension: false
+  origin: SOURCE
+  receiverType: null
+  symbolKind: LOCAL
+  valueParameters: [KtFirValueParameterSymbol(a)]
+
+KtFirLocalVariableSymbol:
+  annotatedType: [] kotlin/Function1<kotlin/Int, kotlin/Int>
+  callableIdIfNonLocal: null
+  isExtension: false
+  isVal: true
+  name: lam1
+  origin: SOURCE
+  receiverType: null
+  symbolKind: LOCAL
+
+KtFirValueParameterSymbol:
+  annotatedType: [] kotlin/Int
+  annotationClassIds: []
+  annotations: []
+  callableIdIfNonLocal: null
+  hasDefaultValue: false
+  isExtension: false
+  isVararg: false
+  name: a
+  origin: SOURCE
+  receiverType: null
+  symbolKind: LOCAL
+
+KtFirLocalVariableSymbol:
+  annotatedType: [] kotlin/Int
+  callableIdIfNonLocal: null
+  isExtension: false
+  isVal: true
+  name: c
+  origin: SOURCE
+  receiverType: null
+  symbolKind: LOCAL
+
+KtFirAnonymousFunctionSymbol:
+  annotatedType: [] kotlin/Int
+  callableIdIfNonLocal: null
+  isExtension: false
+  origin: SOURCE
+  receiverType: null
+  symbolKind: LOCAL
+  valueParameters: [KtFirValueParameterSymbol(a)]
+
+KtFirLocalVariableSymbol:
+  annotatedType: [] kotlin/Function1<kotlin/Int, kotlin/Int>
+  callableIdIfNonLocal: null
+  isExtension: false
+  isVal: true
+  name: lam2
+  origin: SOURCE
+  receiverType: null
+  symbolKind: LOCAL
+
+KtFirFunctionSymbol:
+  annotatedType: [] kotlin/Unit
+  annotationClassIds: []
+  annotations: []
+  callableIdIfNonLocal: /foo
+  dispatchType: null
+  isExtension: false
+  isExternal: false
+  isInfix: false
+  isInline: false
+  isOperator: false
+  isOverride: false
+  isStatic: false
+  isSuspend: false
+  modality: FINAL
+  name: foo
+  origin: SOURCE
+  receiverType: null
+  symbolKind: TOP_LEVEL
+  typeParameters: []
+  valueParameters: []
+  visibility: Public
+ */

--- a/idea/idea-frontend-fir/testData/symbols/symbolByPsi/implicitReturnInLambda.kt
+++ b/idea/idea-frontend-fir/testData/symbols/symbolByPsi/implicitReturnInLambda.kt
@@ -11,6 +11,16 @@ fun foo() {
         else
             a - c
     }
+
+    bar {
+        if (it > 5) return
+        val b = 1
+        it + b
+    }
+}
+
+private inline fun bar(lmbd: (Int) -> Int) {
+    lmbd(1)
 }
 
 // RESULT
@@ -99,6 +109,25 @@ KtFirLocalVariableSymbol:
   receiverType: null
   symbolKind: LOCAL
 
+KtFirLocalVariableSymbol:
+  annotatedType: [] kotlin/Int
+  callableIdIfNonLocal: null
+  isExtension: false
+  isVal: true
+  name: b
+  origin: SOURCE
+  receiverType: null
+  symbolKind: LOCAL
+
+KtFirAnonymousFunctionSymbol:
+  annotatedType: [] kotlin/Int
+  callableIdIfNonLocal: null
+  isExtension: false
+  origin: SOURCE
+  receiverType: null
+  symbolKind: LOCAL
+  valueParameters: [KtFirValueParameterSymbol(it)]
+
 KtFirFunctionSymbol:
   annotatedType: [] kotlin/Unit
   annotationClassIds: []
@@ -121,4 +150,40 @@ KtFirFunctionSymbol:
   typeParameters: []
   valueParameters: []
   visibility: Public
- */
+
+KtFirValueParameterSymbol:
+  annotatedType: [] kotlin/Function1<kotlin/Int, kotlin/Int>
+  annotationClassIds: []
+  annotations: []
+  callableIdIfNonLocal: null
+  hasDefaultValue: false
+  isExtension: false
+  isVararg: false
+  name: lmbd
+  origin: SOURCE
+  receiverType: null
+  symbolKind: LOCAL
+
+KtFirFunctionSymbol:
+  annotatedType: [] kotlin/Unit
+  annotationClassIds: []
+  annotations: []
+  callableIdIfNonLocal: /bar
+  dispatchType: null
+  isExtension: false
+  isExternal: false
+  isInfix: false
+  isInline: true
+  isOperator: false
+  isOverride: false
+  isStatic: false
+  isSuspend: false
+  modality: FINAL
+  name: bar
+  origin: SOURCE
+  receiverType: null
+  symbolKind: TOP_LEVEL
+  typeParameters: []
+  valueParameters: [KtFirValueParameterSymbol(lmbd)]
+  visibility: Private
+*/

--- a/idea/idea-frontend-fir/testData/symbols/symbolByPsi/implicitReturnInLambda.txt
+++ b/idea/idea-frontend-fir/testData/symbols/symbolByPsi/implicitReturnInLambda.txt
@@ -82,6 +82,25 @@ KtFirLocalVariableSymbol:
   receiverType: null
   symbolKind: LOCAL
 
+KtFirLocalVariableSymbol:
+  annotatedType: [] kotlin/Int
+  callableIdIfNonLocal: null
+  isExtension: false
+  isVal: true
+  name: b
+  origin: SOURCE
+  receiverType: null
+  symbolKind: LOCAL
+
+KtFirAnonymousFunctionSymbol:
+  annotatedType: [] kotlin/Int
+  callableIdIfNonLocal: null
+  isExtension: false
+  origin: SOURCE
+  receiverType: null
+  symbolKind: LOCAL
+  valueParameters: [KtFirValueParameterSymbol(it)]
+
 KtFirFunctionSymbol:
   annotatedType: [] kotlin/Unit
   annotationClassIds: []
@@ -104,3 +123,39 @@ KtFirFunctionSymbol:
   typeParameters: []
   valueParameters: []
   visibility: Public
+
+KtFirValueParameterSymbol:
+  annotatedType: [] kotlin/Function1<kotlin/Int, kotlin/Int>
+  annotationClassIds: []
+  annotations: []
+  callableIdIfNonLocal: null
+  hasDefaultValue: false
+  isExtension: false
+  isVararg: false
+  name: lmbd
+  origin: SOURCE
+  receiverType: null
+  symbolKind: LOCAL
+
+KtFirFunctionSymbol:
+  annotatedType: [] kotlin/Unit
+  annotationClassIds: []
+  annotations: []
+  callableIdIfNonLocal: /bar
+  dispatchType: null
+  isExtension: false
+  isExternal: false
+  isInfix: false
+  isInline: true
+  isOperator: false
+  isOverride: false
+  isStatic: false
+  isSuspend: false
+  modality: FINAL
+  name: bar
+  origin: SOURCE
+  receiverType: null
+  symbolKind: TOP_LEVEL
+  typeParameters: []
+  valueParameters: [KtFirValueParameterSymbol(lmbd)]
+  visibility: Private

--- a/idea/idea-frontend-fir/testData/symbols/symbolByPsi/implicitReturnInLambda.txt
+++ b/idea/idea-frontend-fir/testData/symbols/symbolByPsi/implicitReturnInLambda.txt
@@ -1,0 +1,106 @@
+KtFirValueParameterSymbol:
+  annotatedType: [] kotlin/Int
+  annotationClassIds: []
+  annotations: []
+  callableIdIfNonLocal: null
+  hasDefaultValue: false
+  isExtension: false
+  isVararg: false
+  name: a
+  origin: SOURCE
+  receiverType: null
+  symbolKind: LOCAL
+
+KtFirLocalVariableSymbol:
+  annotatedType: [] kotlin/Int
+  callableIdIfNonLocal: null
+  isExtension: false
+  isVal: true
+  name: b
+  origin: SOURCE
+  receiverType: null
+  symbolKind: LOCAL
+
+KtFirAnonymousFunctionSymbol:
+  annotatedType: [] kotlin/Int
+  callableIdIfNonLocal: null
+  isExtension: false
+  origin: SOURCE
+  receiverType: null
+  symbolKind: LOCAL
+  valueParameters: [KtFirValueParameterSymbol(a)]
+
+KtFirLocalVariableSymbol:
+  annotatedType: [] kotlin/Function1<kotlin/Int, kotlin/Int>
+  callableIdIfNonLocal: null
+  isExtension: false
+  isVal: true
+  name: lam1
+  origin: SOURCE
+  receiverType: null
+  symbolKind: LOCAL
+
+KtFirValueParameterSymbol:
+  annotatedType: [] kotlin/Int
+  annotationClassIds: []
+  annotations: []
+  callableIdIfNonLocal: null
+  hasDefaultValue: false
+  isExtension: false
+  isVararg: false
+  name: a
+  origin: SOURCE
+  receiverType: null
+  symbolKind: LOCAL
+
+KtFirLocalVariableSymbol:
+  annotatedType: [] kotlin/Int
+  callableIdIfNonLocal: null
+  isExtension: false
+  isVal: true
+  name: c
+  origin: SOURCE
+  receiverType: null
+  symbolKind: LOCAL
+
+KtFirAnonymousFunctionSymbol:
+  annotatedType: [] kotlin/Int
+  callableIdIfNonLocal: null
+  isExtension: false
+  origin: SOURCE
+  receiverType: null
+  symbolKind: LOCAL
+  valueParameters: [KtFirValueParameterSymbol(a)]
+
+KtFirLocalVariableSymbol:
+  annotatedType: [] kotlin/Function1<kotlin/Int, kotlin/Int>
+  callableIdIfNonLocal: null
+  isExtension: false
+  isVal: true
+  name: lam2
+  origin: SOURCE
+  receiverType: null
+  symbolKind: LOCAL
+
+KtFirFunctionSymbol:
+  annotatedType: [] kotlin/Unit
+  annotationClassIds: []
+  annotations: []
+  callableIdIfNonLocal: /foo
+  dispatchType: null
+  isExtension: false
+  isExternal: false
+  isInfix: false
+  isInline: false
+  isOperator: false
+  isOverride: false
+  isStatic: false
+  isSuspend: false
+  modality: FINAL
+  name: foo
+  origin: SOURCE
+  receiverType: null
+  symbolKind: TOP_LEVEL
+  typeParameters: []
+  valueParameters: []
+  visibility: Public

--- a/idea/idea-frontend-fir/tests/org/jetbrains/kotlin/idea/fir/frontend/api/symbols/AbstractSymbolByPsiTest.kt
+++ b/idea/idea-frontend-fir/tests/org/jetbrains/kotlin/idea/fir/frontend/api/symbols/AbstractSymbolByPsiTest.kt
@@ -9,13 +9,21 @@ import org.jetbrains.kotlin.idea.frontend.api.KtAnalysisSession
 import org.jetbrains.kotlin.idea.frontend.api.symbols.KtSymbol
 import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
 import org.jetbrains.kotlin.test.services.TestServices
 
 abstract class AbstractSymbolByPsiTest : AbstractSymbolTest() {
     override fun KtAnalysisSession.collectSymbols(ktFile: KtFile, testServices: TestServices): List<KtSymbol> {
-        return ktFile.collectDescendantsOfType<KtDeclaration>().map { declaration ->
+        return ktFile.collectDescendantsOfType<KtDeclaration> { it.isValidForSymbolCreation }.map { declaration ->
             declaration.getSymbol()
         }
     }
+
+    private val KtDeclaration.isValidForSymbolCreation
+        get() =
+            when (this) {
+                is KtParameter -> !this.isFunctionTypeParameter
+                else -> true
+            }
 }

--- a/idea/idea-frontend-fir/tests/org/jetbrains/kotlin/idea/fir/frontend/api/symbols/SymbolByPsiTestGenerated.java
+++ b/idea/idea-frontend-fir/tests/org/jetbrains/kotlin/idea/fir/frontend/api/symbols/SymbolByPsiTestGenerated.java
@@ -97,6 +97,12 @@ public class SymbolByPsiTestGenerated extends AbstractSymbolByPsiTest {
     }
 
     @Test
+    @TestMetadata("implicitReturnInLambda.kt")
+    public void testImplicitReturnInLambda() throws Exception {
+        runTest("idea/idea-frontend-fir/testData/symbols/symbolByPsi/implicitReturnInLambda.kt");
+    }
+
+    @Test
     @TestMetadata("localDeclarations.kt")
     public void testLocalDeclarations() throws Exception {
         runTest("idea/idea-frontend-fir/testData/symbols/symbolByPsi/localDeclarations.kt");


### PR DESCRIPTION
To commonize `ULambdaExpression`, we need to retrieve implicit return (if any) and parameters (if no explicit parameters are given). The usage of these additions are found at https://github.com/JetBrains/intellij-kotlin/pull/80.