### PR TITLE
add sample for text version of elementAt

### DIFF
--- a/libraries/stdlib/common/src/generated/_Strings.kt
+++ b/libraries/stdlib/common/src/generated/_Strings.kt
@@ -18,7 +18,7 @@ import kotlin.random.*
 /**
  * Returns a character at the given [index] or throws an [IndexOutOfBoundsException] if the [index] is out of bounds of this char sequence.
  * 
- * @sample samples.collections.Collections.Elements.elementAt
+ * @sample samples.text.Strings.elementAt
  */
 public expect fun CharSequence.elementAt(index: Int): Char
 

--- a/libraries/stdlib/samples/test/samples/text/strings.kt
+++ b/libraries/stdlib/samples/test/samples/text/strings.kt
@@ -98,8 +98,8 @@ class Strings {
         assertPrints(string.elementAt(5), "n")
         assertFailsWith<StringIndexOutOfBoundsException> { string.elementAt(6) }
 
-        val emptyString = ""
-        assertFailsWith<StringIndexOutOfBoundsException> { emptyString.elementAt(0) }
+        val empty = ""
+        assertFailsWith<StringIndexOutOfBoundsException> { empty.elementAt(0) }
     }
 
     @Sample

--- a/libraries/stdlib/samples/test/samples/text/strings.kt
+++ b/libraries/stdlib/samples/test/samples/text/strings.kt
@@ -92,6 +92,17 @@ class Strings {
     }
 
     @Sample
+    fun elementAt() {
+        val string = "kotlin"
+        assertPrints(string.elementAt(0), "k")
+        assertPrints(string.elementAt(5), "n")
+        assertFailsWith<StringIndexOutOfBoundsException> { string.elementAt(6) }
+
+        val emptyString = ""
+        assertFailsWith<StringIndexOutOfBoundsException> { emptyString.elementAt(0) }
+    }
+
+    @Sample
     fun filter() {
         val text = "a1b2c3d4e5"
 

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Elements.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Elements.kt
@@ -302,6 +302,12 @@ object Elements : TemplateGroupBase() {
             """
         }
 
+        specialFor(CharSequences) {
+            on(Platform.Common) {
+                sample("samples.text.Strings.elementAt")
+            }
+        }
+
         specialFor(CharSequences, Lists, ArraysOfObjects, ArraysOfPrimitives, ArraysOfUnsigned) {
             inlineOnly()
             body { "return get(index)" }


### PR DESCRIPTION
Addresses [KT-35867](https://youtrack.jetbrains.com/issue/KT-35867) for the `elementAt()` function.