### PR TITLE
JVM IR: Map LOCAL_FUNCTION_FOR_LAMBDA return type of Nothing to `V` instead of `Ljava/lang/Void;`

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBytecodeTextTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBytecodeTextTestGenerated.java
@@ -302,6 +302,12 @@ public class FirBytecodeTextTestGenerated extends AbstractFirBytecodeTextTest {
     }
 
     @Test
+    @TestMetadata("kt47279.kt")
+    public void testKt47279() throws Exception {
+        runTest("compiler/testData/codegen/bytecodeText/kt47279.kt");
+    }
+
+    @Test
     @TestMetadata("kt5016.kt")
     public void testKt5016() throws Exception {
         runTest("compiler/testData/codegen/bytecodeText/kt5016.kt");

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/MethodSignatureMapper.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/MethodSignatureMapper.kt
@@ -27,7 +27,6 @@ import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.lazy.IrLazyClass
-import org.jetbrains.kotlin.ir.declarations.lazy.IrLazyFunction
 import org.jetbrains.kotlin.ir.declarations.lazy.IrLazyFunctionBase
 import org.jetbrains.kotlin.ir.declarations.lazy.IrMaybeDeserializedClass
 import org.jetbrains.kotlin.ir.descriptors.IrBasedSimpleFunctionDescriptor
@@ -195,6 +194,7 @@ class MethodSignatureMapper(private val context: JvmBackendContext) {
 
     private fun hasVoidReturnType(function: IrFunction): Boolean =
         function is IrConstructor || (function.returnType.isUnit() && !function.isGetter)
+                || function.returnType.isNothing() && function.origin == IrDeclarationOrigin.LOCAL_FUNCTION_FOR_LAMBDA
 
     // See also: KotlinTypeMapper.forceBoxedReturnType
     private fun forceBoxedReturnType(function: IrFunction): Boolean =

--- a/compiler/testData/codegen/bytecodeText/kt47279.kt
+++ b/compiler/testData/codegen/bytecodeText/kt47279.kt
@@ -1,0 +1,7 @@
+// TARGET_BACKEND: JVM_IR
+
+fun box() {
+    null?.run { return }
+}
+
+// 1 private final static box\$lambda-0\(Ljava.lang.Void;\)V

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBytecodeTextTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBytecodeTextTestGenerated.java
@@ -302,6 +302,12 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
     }
 
     @Test
+    @TestMetadata("kt47279.kt")
+    public void testKt47279() throws Exception {
+        runTest("compiler/testData/codegen/bytecodeText/kt47279.kt");
+    }
+
+    @Test
     @TestMetadata("kt5016.kt")
     public void testKt5016() throws Exception {
         runTest("compiler/testData/codegen/bytecodeText/kt5016.kt");


### PR DESCRIPTION
issue [KT-47279](https://youtrack.jetbrains.com/issue/KT-47279)