### PR TITLE
JVM IR: Don't generate nullability annotations on private fields

### DIFF
--- a/compiler/testData/codegen/bytecodeListing/annotations/delegatedPropertiesNullabilityAnnotations.kt
+++ b/compiler/testData/codegen/bytecodeListing/annotations/delegatedPropertiesNullabilityAnnotations.kt
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+
+val map: Map<String, String> = hashMapOf("a" to "all", "b" to "bar", "c" to "code")
+val d: String? by map

--- a/compiler/testData/codegen/bytecodeListing/annotations/delegatedPropertiesNullabilityAnnotations.txt
+++ b/compiler/testData/codegen/bytecodeListing/annotations/delegatedPropertiesNullabilityAnnotations.txt
@@ -1,0 +1,10 @@
+@kotlin.Metadata
+public final class DelegatedPropertiesNullabilityAnnotationsKt {
+    // source: 'delegatedPropertiesNullabilityAnnotations.kt'
+    synthetic final static field $$delegatedProperties: kotlin.reflect.KProperty[]
+    private final static @org.jetbrains.annotations.Nullable field d$delegate: java.util.Map
+    private final static @org.jetbrains.annotations.NotNull field map: java.util.Map
+    static method <clinit>(): void
+    public final static @org.jetbrains.annotations.Nullable method getD(): java.lang.String
+    public final static @org.jetbrains.annotations.NotNull method getMap(): java.util.Map
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BytecodeListingTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BytecodeListingTestGenerated.java
@@ -329,6 +329,12 @@ public class BytecodeListingTestGenerated extends AbstractBytecodeListingTest {
         }
 
         @Test
+        @TestMetadata("delegatedPropertiesNullabilityAnnotations.kt")
+        public void testDelegatedPropertiesNullabilityAnnotations() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeListing/annotations/delegatedPropertiesNullabilityAnnotations.kt");
+        }
+
+        @Test
         @TestMetadata("deprecatedJvmOverloads.kt")
         public void testDeprecatedJvmOverloads() throws Exception {
             runTest("compiler/testData/codegen/bytecodeListing/annotations/deprecatedJvmOverloads.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBytecodeListingTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBytecodeListingTestGenerated.java
@@ -329,6 +329,12 @@ public class IrBytecodeListingTestGenerated extends AbstractIrBytecodeListingTes
         }
 
         @Test
+        @TestMetadata("delegatedPropertiesNullabilityAnnotations.kt")
+        public void testDelegatedPropertiesNullabilityAnnotations() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeListing/annotations/delegatedPropertiesNullabilityAnnotations.kt");
+        }
+
+        @Test
         @TestMetadata("deprecatedJvmOverloads.kt")
         public void testDeprecatedJvmOverloads() throws Exception {
             runTest("compiler/testData/codegen/bytecodeListing/annotations/deprecatedJvmOverloads.kt");


### PR DESCRIPTION
issue: [KT-43049](https://youtrack.jetbrains.com/issue/KT-43049)
Looking at the issue's description, and [document ](https://www.jetbrains.com/help/idea/nullable-and-notnull-annotations.html)of these nullability annotations, it seems that we should not generate nullability annotations on private fields.