### PR TITLE
JVM_IR: fix a couple `@JvmStatic external` issues

### DIFF
--- a/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/declarationCheckers.kt
+++ b/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/declarationCheckers.kt
@@ -90,7 +90,7 @@ class JvmStaticChecker(jvmTarget: JvmTarget, languageVersionSettings: LanguageVe
                 supportJvmStaticInInterface &&
                 descriptor is DeclarationDescriptorWithVisibility
             ) {
-                checkVisibility(descriptor, diagnosticHolder, declaration)
+                checkForInterface(descriptor, diagnosticHolder, declaration)
                 if (isLessJVM18) {
                     diagnosticHolder.report(ErrorsJvm.JVM_STATIC_IN_INTERFACE_1_6.on(declaration))
                 }
@@ -116,15 +116,18 @@ class JvmStaticChecker(jvmTarget: JvmTarget, languageVersionSettings: LanguageVe
         }
     }
 
-    private fun checkVisibility(
+    private fun checkForInterface(
         descriptor: DeclarationDescriptorWithVisibility,
         diagnosticHolder: DiagnosticSink,
         declaration: KtDeclaration
     ) {
         if (descriptor.visibility != DescriptorVisibilities.PUBLIC) {
             diagnosticHolder.report(ErrorsJvm.JVM_STATIC_ON_NON_PUBLIC_MEMBER.on(declaration))
+        } else if (descriptor is MemberDescriptor && descriptor.isExternal) {
+            diagnosticHolder.report(ErrorsJvm.JVM_STATIC_ON_EXTERNAL_IN_INTERFACE.on(declaration))
         } else if (descriptor is PropertyDescriptor) {
-            descriptor.setter?.let { checkVisibility(it, diagnosticHolder, declaration) }
+            descriptor.getter?.let { checkForInterface(it, diagnosticHolder, declaration) }
+            descriptor.setter?.let { checkForInterface(it, diagnosticHolder, declaration) }
         }
     }
 }

--- a/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/diagnostics/DefaultErrorMessagesJvm.java
+++ b/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/diagnostics/DefaultErrorMessagesJvm.java
@@ -45,6 +45,7 @@ public class DefaultErrorMessagesJvm implements DefaultErrorMessages.Extension {
         MAP.put(JVM_STATIC_ON_NON_PUBLIC_MEMBER, "Only public members in interface companion objects can be annotated with '@JvmStatic'");
         MAP.put(JVM_STATIC_IN_INTERFACE_1_6, "'@JvmStatic' annotation in interface supported only with JVM target 1.8 and above. Recompile with '-jvm-target 1.8'\"");
         MAP.put(JVM_STATIC_ON_CONST_OR_JVM_FIELD, "'@JvmStatic' annotation is useless for const or '@JvmField' properties");
+        MAP.put(JVM_STATIC_ON_EXTERNAL_IN_INTERFACE, "'@JvmStatic' annotation cannot be used on 'external' members of interface companions");
         MAP.put(OVERRIDE_CANNOT_BE_STATIC, "Override member cannot be '@JvmStatic' in object");
         MAP.put(OVERLOADS_WITHOUT_DEFAULT_ARGUMENTS, "'@JvmOverloads' annotation has no effect for methods without default arguments");
         MAP.put(OVERLOADS_ABSTRACT, "'@JvmOverloads' annotation cannot be used on abstract methods");

--- a/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/diagnostics/ErrorsJvm.java
+++ b/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/diagnostics/ErrorsJvm.java
@@ -34,6 +34,7 @@ public interface ErrorsJvm {
     DiagnosticFactory0<KtDeclaration> JVM_STATIC_ON_NON_PUBLIC_MEMBER = DiagnosticFactory0.create(ERROR, DECLARATION_SIGNATURE);
     DiagnosticFactory0<KtDeclaration> JVM_STATIC_IN_INTERFACE_1_6 = DiagnosticFactory0.create(ERROR, DECLARATION_SIGNATURE);
     DiagnosticFactory0<KtDeclaration> JVM_STATIC_ON_CONST_OR_JVM_FIELD = DiagnosticFactory0.create(ERROR, DECLARATION_SIGNATURE);
+    DiagnosticFactory0<KtDeclaration> JVM_STATIC_ON_EXTERNAL_IN_INTERFACE = DiagnosticFactory0.create(ERROR, DECLARATION_SIGNATURE);
 
     DiagnosticFactory0<PsiElement> INAPPLICABLE_JVM_NAME = DiagnosticFactory0.create(ERROR);
     DiagnosticFactory0<KtAnnotationEntry> ILLEGAL_JVM_NAME = DiagnosticFactory0.create(ERROR);

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmCachedDeclarations.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmCachedDeclarations.kt
@@ -149,18 +149,18 @@ class JvmCachedDeclarations(
             if (jvmStaticFunction.isExternal) {
                 // We move external functions to the enclosing class and potentially add accessors there.
                 // The JVM backend also adds accessors in the companion object, but these are superfluous.
-                // TODO: this should really do the same as `makeProxy`, but without a body; otherwise, external
-                //   functions in interface companions won't work (KT-43696).
                 val staticExternal = context.irFactory.buildFun {
                     updateFrom(jvmStaticFunction)
                     name = jvmStaticFunction.name
                     returnType = jvmStaticFunction.returnType
                 }.apply {
                     parent = companion.parent
-                    copyTypeParametersFrom(jvmStaticFunction)
+                    copyAttributes(jvmStaticFunction)
                     copyAnnotationsFrom(jvmStaticFunction)
-                    extensionReceiverParameter = jvmStaticFunction.extensionReceiverParameter?.copyTo(this)
-                    valueParameters = jvmStaticFunction.valueParameters.map { it.copyTo(this) }
+                    copyCorrespondingPropertyFrom(jvmStaticFunction)
+                    copyParameterDeclarationsFrom(jvmStaticFunction)
+                    dispatchReceiverParameter = null
+                    metadata = jvmStaticFunction.metadata
                 }
                 staticExternal to companion.makeProxy(staticExternal, isStatic = false)
             } else {

--- a/compiler/testData/diagnostics/testsWithStdLib/annotations/jvmStatic/interfaceCompanion_LL12.fir.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/annotations/jvmStatic/interfaceCompanion_LL12.fir.kt
@@ -18,6 +18,8 @@ interface B {
 
         }
 
+        @JvmStatic external fun a5()
+
         @JvmStatic
         var foo = 1
 
@@ -49,6 +51,11 @@ interface B {
 
         public var foo9 = 1
         @JvmStatic private set
+
+        @JvmStatic
+        val foo10: Int external get
+
+        val foo11: Int @JvmStatic external get
     }
 
 }

--- a/compiler/testData/diagnostics/testsWithStdLib/annotations/jvmStatic/interfaceCompanion_LL12.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/annotations/jvmStatic/interfaceCompanion_LL12.kt
@@ -18,6 +18,8 @@ interface B {
 
         }
 
+        <!JVM_STATIC_NOT_IN_OBJECT_OR_CLASS_COMPANION!>@JvmStatic external fun a5()<!>
+
         <!JVM_STATIC_NOT_IN_OBJECT_OR_CLASS_COMPANION!>@JvmStatic
         var foo<!> = 1
 
@@ -49,6 +51,11 @@ interface B {
 
         public var foo9 = 1
         <!JVM_STATIC_NOT_IN_OBJECT_OR_CLASS_COMPANION!>@JvmStatic private set<!>
+
+        <!JVM_STATIC_NOT_IN_OBJECT_OR_CLASS_COMPANION!>@JvmStatic
+        val foo10: Int<!> external get
+
+        val foo11: Int <!JVM_STATIC_NOT_IN_OBJECT_OR_CLASS_COMPANION!>@JvmStatic external get<!>
     }
 
 }

--- a/compiler/testData/diagnostics/testsWithStdLib/annotations/jvmStatic/interfaceCompanion_LL12.txt
+++ b/compiler/testData/diagnostics/testsWithStdLib/annotations/jvmStatic/interfaceCompanion_LL12.txt
@@ -9,6 +9,8 @@ public interface B {
         private constructor Companion()
         @kotlin.jvm.JvmStatic public final var foo: kotlin.Int
         @kotlin.jvm.JvmStatic public final var foo1: kotlin.Int
+        @kotlin.jvm.JvmStatic public final val foo10: kotlin.Int
+        @get:kotlin.jvm.JvmStatic public final val foo11: kotlin.Int
         @kotlin.jvm.JvmStatic public final var foo2: kotlin.Int
         @kotlin.jvm.JvmStatic private final var foo3: kotlin.Int
         @kotlin.jvm.JvmStatic protected final var foo4: kotlin.Int
@@ -21,6 +23,7 @@ public interface B {
         @kotlin.jvm.JvmStatic private final fun a2(): kotlin.Unit
         @kotlin.jvm.JvmStatic protected final fun a3(): kotlin.Unit
         @kotlin.jvm.JvmStatic internal final fun a4(): kotlin.Unit
+        @kotlin.jvm.JvmStatic public final external fun a5(): kotlin.Unit
         public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
         public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
         public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String

--- a/compiler/testData/diagnostics/testsWithStdLib/annotations/jvmStatic/interfaceCompanion_LL13_16.fir.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/annotations/jvmStatic/interfaceCompanion_LL13_16.fir.kt
@@ -20,6 +20,8 @@ interface B {
 
         }
 
+        @JvmStatic external fun a5()
+
         @JvmStatic
         var foo = 1
 
@@ -52,6 +54,10 @@ interface B {
         public var foo9 = 1
         @JvmStatic private set
 
+        @JvmStatic
+        val foo10: Int external get
+
+        val foo11: Int @JvmStatic external get
     }
 
 }

--- a/compiler/testData/diagnostics/testsWithStdLib/annotations/jvmStatic/interfaceCompanion_LL13_16.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/annotations/jvmStatic/interfaceCompanion_LL13_16.kt
@@ -20,6 +20,8 @@ interface B {
 
         }
 
+        <!JVM_STATIC_IN_INTERFACE_1_6, JVM_STATIC_ON_EXTERNAL_IN_INTERFACE!>@JvmStatic external fun a5()<!>
+
         <!JVM_STATIC_IN_INTERFACE_1_6!>@JvmStatic
         var foo<!> = 1
 
@@ -52,6 +54,10 @@ interface B {
         public var foo9 = 1
         <!JVM_STATIC_IN_INTERFACE_1_6, JVM_STATIC_ON_NON_PUBLIC_MEMBER!>@JvmStatic private set<!>
 
+        <!JVM_STATIC_IN_INTERFACE_1_6, JVM_STATIC_ON_EXTERNAL_IN_INTERFACE!>@JvmStatic
+        val foo10: Int<!> external get
+
+        val foo11: Int <!JVM_STATIC_IN_INTERFACE_1_6, JVM_STATIC_ON_EXTERNAL_IN_INTERFACE!>@JvmStatic external get<!>
     }
 
 }

--- a/compiler/testData/diagnostics/testsWithStdLib/annotations/jvmStatic/interfaceCompanion_LL13_16.txt
+++ b/compiler/testData/diagnostics/testsWithStdLib/annotations/jvmStatic/interfaceCompanion_LL13_16.txt
@@ -9,6 +9,8 @@ public interface B {
         private constructor Companion()
         @kotlin.jvm.JvmStatic public final var foo: kotlin.Int
         @kotlin.jvm.JvmStatic public final var foo1: kotlin.Int
+        @kotlin.jvm.JvmStatic public final val foo10: kotlin.Int
+        @get:kotlin.jvm.JvmStatic public final val foo11: kotlin.Int
         @kotlin.jvm.JvmStatic public final var foo2: kotlin.Int
         @kotlin.jvm.JvmStatic private final var foo3: kotlin.Int
         @kotlin.jvm.JvmStatic protected final var foo4: kotlin.Int
@@ -21,6 +23,7 @@ public interface B {
         @kotlin.jvm.JvmStatic private final fun a2(): kotlin.Unit
         @kotlin.jvm.JvmStatic protected final fun a3(): kotlin.Unit
         @kotlin.jvm.JvmStatic internal final fun a4(): kotlin.Unit
+        @kotlin.jvm.JvmStatic public final external fun a5(): kotlin.Unit
         public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
         public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
         public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String

--- a/compiler/testData/diagnostics/testsWithStdLib/annotations/jvmStatic/interfaceCompanion_LL13_18.fir.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/annotations/jvmStatic/interfaceCompanion_LL13_18.fir.kt
@@ -19,6 +19,8 @@ interface B {
 
         }
 
+        @JvmStatic external fun a5()
+
         @JvmStatic
         var foo = 1
 
@@ -51,6 +53,10 @@ interface B {
         public var foo9 = 1
         @JvmStatic private set
 
+        @JvmStatic
+        val foo10: Int external get
+
+        val foo11: Int @JvmStatic external get
     }
 
 }

--- a/compiler/testData/diagnostics/testsWithStdLib/annotations/jvmStatic/interfaceCompanion_LL13_18.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/annotations/jvmStatic/interfaceCompanion_LL13_18.kt
@@ -19,6 +19,8 @@ interface B {
 
         }
 
+        <!JVM_STATIC_ON_EXTERNAL_IN_INTERFACE!>@JvmStatic external fun a5()<!>
+
         @JvmStatic
         var foo = 1
 
@@ -51,6 +53,10 @@ interface B {
         public var foo9 = 1
         <!JVM_STATIC_ON_NON_PUBLIC_MEMBER!>@JvmStatic private set<!>
 
+        <!JVM_STATIC_ON_EXTERNAL_IN_INTERFACE!>@JvmStatic
+        val foo10: Int<!> external get
+
+        val foo11: Int <!JVM_STATIC_ON_EXTERNAL_IN_INTERFACE!>@JvmStatic external get<!>
     }
 
 }

--- a/compiler/testData/diagnostics/testsWithStdLib/annotations/jvmStatic/interfaceCompanion_LL13_18.txt
+++ b/compiler/testData/diagnostics/testsWithStdLib/annotations/jvmStatic/interfaceCompanion_LL13_18.txt
@@ -9,6 +9,8 @@ public interface B {
         private constructor Companion()
         @kotlin.jvm.JvmStatic public final var foo: kotlin.Int
         @kotlin.jvm.JvmStatic public final var foo1: kotlin.Int
+        @kotlin.jvm.JvmStatic public final val foo10: kotlin.Int
+        @get:kotlin.jvm.JvmStatic public final val foo11: kotlin.Int
         @kotlin.jvm.JvmStatic public final var foo2: kotlin.Int
         @kotlin.jvm.JvmStatic private final var foo3: kotlin.Int
         @kotlin.jvm.JvmStatic protected final var foo4: kotlin.Int
@@ -21,6 +23,7 @@ public interface B {
         @kotlin.jvm.JvmStatic private final fun a2(): kotlin.Unit
         @kotlin.jvm.JvmStatic protected final fun a3(): kotlin.Unit
         @kotlin.jvm.JvmStatic internal final fun a4(): kotlin.Unit
+        @kotlin.jvm.JvmStatic public final external fun a5(): kotlin.Unit
         public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
         public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
         public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String


### PR DESCRIPTION
1. `correspondingProperty` should be copied so that `MethodSignatureMapper` computes the name correctly;
2. `static native` is not a permitted combination of flags in interface class files, so the frontend should reject that.

#KT-47715 Fixed
#KT-43696 Fixed