### PR TITLE
FIR IDE: add APIs to retrieve PsiType for FIR UAST

### DIFF
--- a/idea/idea-frontend-api/src/org/jetbrains/kotlin/idea/frontend/api/components/KtExpressionTypeProvider.kt
+++ b/idea/idea-frontend-api/src/org/jetbrains/kotlin/idea/frontend/api/components/KtExpressionTypeProvider.kt
@@ -9,10 +9,13 @@ import com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.idea.frontend.api.types.KtType
 import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtFunction
 
 public abstract class KtExpressionTypeProvider : KtAnalysisSessionComponent() {
-    public abstract fun getReturnTypeForKtDeclaration(declaration: KtDeclaration): KtType
     public abstract fun getKtExpressionType(expression: KtExpression): KtType
+    public abstract fun getReturnTypeForKtDeclaration(declaration: KtDeclaration): KtType
+    public abstract fun getFunctionalTypeForKtFunction(declaration: KtFunction): KtType
+
     public abstract fun getExpectedType(expression: PsiElement): KtType?
     public abstract fun isDefinitelyNull(expression: KtExpression): Boolean
     public abstract fun isDefinitelyNotNull(expression: KtExpression): Boolean
@@ -22,8 +25,24 @@ public interface KtExpressionTypeProviderMixIn : KtAnalysisSessionMixIn {
     public fun KtExpression.getKtType(): KtType =
         analysisSession.expressionTypeProvider.getKtExpressionType(this)
 
+    /**
+     * Returns the return type of the given [KtDeclaration] as [KtType]
+     */
     public fun KtDeclaration.getReturnKtType(): KtType =
         analysisSession.expressionTypeProvider.getReturnTypeForKtDeclaration(this)
+
+    /**
+     * Returns the functional type of the given [KtFunction].
+     *
+     * For a regular function, it would be kotlin.FunctionN<Ps, R> where
+     *   N is the number of value parameters in the function;
+     *   Ps are types of value parameters;
+     *   R is the return type of the function.
+     * Depending on the function's attributes, such as `suspend` or reflective access, different functional type,
+     * such as `SuspendFunction`, `KFunction`, or `KSuspendFunction`, will be constructed.
+     */
+    public fun KtFunction.getFunctionalType(): KtType =
+        analysisSession.expressionTypeProvider.getFunctionalTypeForKtFunction(this)
 
     /**
      * Returns the expected [KtType] of this [PsiElement] if it is an expression. The returned value should not be a

--- a/idea/idea-frontend-api/src/org/jetbrains/kotlin/idea/frontend/api/components/KtPsiTypeProvider.kt
+++ b/idea/idea-frontend-api/src/org/jetbrains/kotlin/idea/frontend/api/components/KtPsiTypeProvider.kt
@@ -5,42 +5,19 @@
 
 package org.jetbrains.kotlin.idea.frontend.api.components
 
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiType
+import org.jetbrains.kotlin.idea.frontend.api.types.KtType
 import org.jetbrains.kotlin.load.kotlin.TypeMappingMode
-import org.jetbrains.kotlin.psi.*
 
 public abstract class KtPsiTypeProvider : KtAnalysisSessionComponent() {
-    public abstract fun commonSuperType(expressions: Collection<KtExpression>, context: KtExpression, mode: TypeMappingMode): PsiType?
-    public abstract fun getPsiTypeForKtExpression(expression: KtExpression, mode: TypeMappingMode): PsiType
-    public abstract fun getPsiTypeForKtDeclaration(ktDeclaration: KtDeclaration, mode: TypeMappingMode): PsiType
-    public abstract fun getPsiTypeForKtFunction(ktFunction: KtFunction, mode: TypeMappingMode): PsiType
-    public abstract fun getPsiTypeForKtTypeReference(ktTypeReference: KtTypeReference, mode: TypeMappingMode): PsiType
-    public abstract fun getPsiTypeForReceiverOfDoubleColonExpression(
-        ktDoubleColonExpression: KtDoubleColonExpression,
-        mode: TypeMappingMode
-    ): PsiType?
+    public abstract fun asPsiType(type: KtType, context: PsiElement, mode: TypeMappingMode): PsiType
 }
 
 public interface KtPsiTypeProviderMixIn : KtAnalysisSessionMixIn {
-    public fun commonSuperType(
-        expressions: Collection<KtExpression>,
-        context: KtExpression,
+    public fun KtType.asPsiType(
+        context: PsiElement,
         mode: TypeMappingMode = TypeMappingMode.DEFAULT
     ): PsiType? =
-        analysisSession.psiTypeProvider.commonSuperType(expressions, context, mode)
-
-    public fun KtExpression.getPsiType(mode: TypeMappingMode = TypeMappingMode.DEFAULT): PsiType =
-        analysisSession.psiTypeProvider.getPsiTypeForKtExpression(this, mode)
-
-    public fun KtDeclaration.getPsiType(mode: TypeMappingMode = TypeMappingMode.DEFAULT): PsiType =
-        analysisSession.psiTypeProvider.getPsiTypeForKtDeclaration(this, mode)
-
-    public fun KtFunction.getPsiType(mode: TypeMappingMode = TypeMappingMode.DEFAULT): PsiType =
-        analysisSession.psiTypeProvider.getPsiTypeForKtFunction(this, mode)
-
-    public fun KtTypeReference.getPsiType(mode: TypeMappingMode = TypeMappingMode.DEFAULT): PsiType =
-        analysisSession.psiTypeProvider.getPsiTypeForKtTypeReference(this, mode)
-
-    public fun KtDoubleColonExpression.getReceiverPsiType(mode: TypeMappingMode = TypeMappingMode.DEFAULT): PsiType? =
-        analysisSession.psiTypeProvider.getPsiTypeForReceiverOfDoubleColonExpression(this, mode)
+        analysisSession.psiTypeProvider.asPsiType(this, context, mode)
 }

--- a/idea/idea-frontend-api/src/org/jetbrains/kotlin/idea/frontend/api/components/KtPsiTypeProvider.kt
+++ b/idea/idea-frontend-api/src/org/jetbrains/kotlin/idea/frontend/api/components/KtPsiTypeProvider.kt
@@ -7,12 +7,14 @@ package org.jetbrains.kotlin.idea.frontend.api.components
 
 import com.intellij.psi.PsiType
 import org.jetbrains.kotlin.load.kotlin.TypeMappingMode
+import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtDoubleColonExpression
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtTypeReference
 
 public abstract class KtPsiTypeProvider : KtAnalysisSessionComponent() {
     public abstract fun getPsiTypeForKtExpression(expression: KtExpression, mode: TypeMappingMode): PsiType
+    public abstract fun getPsiTypeForKtDeclaration(ktDeclaration: KtDeclaration, mode: TypeMappingMode): PsiType
     public abstract fun getPsiTypeForKtTypeReference(ktTypeReference: KtTypeReference, mode: TypeMappingMode): PsiType
     public abstract fun getPsiTypeForReceiverOfDoubleColonExpression(
         ktDoubleColonExpression: KtDoubleColonExpression,
@@ -23,6 +25,9 @@ public abstract class KtPsiTypeProvider : KtAnalysisSessionComponent() {
 public interface KtPsiTypeProviderMixIn : KtAnalysisSessionMixIn {
     public fun KtExpression.getPsiType(mode: TypeMappingMode = TypeMappingMode.DEFAULT): PsiType =
         analysisSession.psiTypeProvider.getPsiTypeForKtExpression(this, mode)
+
+    public fun KtDeclaration.getPsiType(mode: TypeMappingMode = TypeMappingMode.DEFAULT): PsiType =
+        analysisSession.psiTypeProvider.getPsiTypeForKtDeclaration(this, mode)
 
     public fun KtTypeReference.getPsiType(mode: TypeMappingMode = TypeMappingMode.DEFAULT): PsiType =
         analysisSession.psiTypeProvider.getPsiTypeForKtTypeReference(this, mode)

--- a/idea/idea-frontend-api/src/org/jetbrains/kotlin/idea/frontend/api/components/KtPsiTypeProvider.kt
+++ b/idea/idea-frontend-api/src/org/jetbrains/kotlin/idea/frontend/api/components/KtPsiTypeProvider.kt
@@ -7,15 +7,13 @@ package org.jetbrains.kotlin.idea.frontend.api.components
 
 import com.intellij.psi.PsiType
 import org.jetbrains.kotlin.load.kotlin.TypeMappingMode
-import org.jetbrains.kotlin.psi.KtDeclaration
-import org.jetbrains.kotlin.psi.KtDoubleColonExpression
-import org.jetbrains.kotlin.psi.KtExpression
-import org.jetbrains.kotlin.psi.KtTypeReference
+import org.jetbrains.kotlin.psi.*
 
 public abstract class KtPsiTypeProvider : KtAnalysisSessionComponent() {
     public abstract fun commonSuperType(expressions: Collection<KtExpression>, context: KtExpression, mode: TypeMappingMode): PsiType?
     public abstract fun getPsiTypeForKtExpression(expression: KtExpression, mode: TypeMappingMode): PsiType
     public abstract fun getPsiTypeForKtDeclaration(ktDeclaration: KtDeclaration, mode: TypeMappingMode): PsiType
+    public abstract fun getPsiTypeForKtFunction(ktFunction: KtFunction, mode: TypeMappingMode): PsiType
     public abstract fun getPsiTypeForKtTypeReference(ktTypeReference: KtTypeReference, mode: TypeMappingMode): PsiType
     public abstract fun getPsiTypeForReceiverOfDoubleColonExpression(
         ktDoubleColonExpression: KtDoubleColonExpression,
@@ -36,6 +34,9 @@ public interface KtPsiTypeProviderMixIn : KtAnalysisSessionMixIn {
 
     public fun KtDeclaration.getPsiType(mode: TypeMappingMode = TypeMappingMode.DEFAULT): PsiType =
         analysisSession.psiTypeProvider.getPsiTypeForKtDeclaration(this, mode)
+
+    public fun KtFunction.getPsiType(mode: TypeMappingMode = TypeMappingMode.DEFAULT): PsiType =
+        analysisSession.psiTypeProvider.getPsiTypeForKtFunction(this, mode)
 
     public fun KtTypeReference.getPsiType(mode: TypeMappingMode = TypeMappingMode.DEFAULT): PsiType =
         analysisSession.psiTypeProvider.getPsiTypeForKtTypeReference(this, mode)

--- a/idea/idea-frontend-api/src/org/jetbrains/kotlin/idea/frontend/api/components/KtPsiTypeProvider.kt
+++ b/idea/idea-frontend-api/src/org/jetbrains/kotlin/idea/frontend/api/components/KtPsiTypeProvider.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtTypeReference
 
 public abstract class KtPsiTypeProvider : KtAnalysisSessionComponent() {
+    public abstract fun commonSuperType(expressions: Collection<KtExpression>, context: KtExpression, mode: TypeMappingMode): PsiType?
     public abstract fun getPsiTypeForKtExpression(expression: KtExpression, mode: TypeMappingMode): PsiType
     public abstract fun getPsiTypeForKtDeclaration(ktDeclaration: KtDeclaration, mode: TypeMappingMode): PsiType
     public abstract fun getPsiTypeForKtTypeReference(ktTypeReference: KtTypeReference, mode: TypeMappingMode): PsiType
@@ -23,6 +24,13 @@ public abstract class KtPsiTypeProvider : KtAnalysisSessionComponent() {
 }
 
 public interface KtPsiTypeProviderMixIn : KtAnalysisSessionMixIn {
+    public fun commonSuperType(
+        expressions: Collection<KtExpression>,
+        context: KtExpression,
+        mode: TypeMappingMode = TypeMappingMode.DEFAULT
+    ): PsiType? =
+        analysisSession.psiTypeProvider.commonSuperType(expressions, context, mode)
+
     public fun KtExpression.getPsiType(mode: TypeMappingMode = TypeMappingMode.DEFAULT): PsiType =
         analysisSession.psiTypeProvider.getPsiTypeForKtExpression(this, mode)
 

--- a/idea/idea-frontend-api/src/org/jetbrains/kotlin/idea/frontend/api/components/KtTypeProvider.kt
+++ b/idea/idea-frontend-api/src/org/jetbrains/kotlin/idea/frontend/api/components/KtTypeProvider.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlin.idea.frontend.api.ValidityTokenOwner
 import org.jetbrains.kotlin.idea.frontend.api.symbols.KtNamedClassOrObjectSymbol
 import org.jetbrains.kotlin.idea.frontend.api.types.KtType
 import org.jetbrains.kotlin.idea.frontend.api.types.KtTypeNullability
+import org.jetbrains.kotlin.psi.KtDoubleColonExpression
 import org.jetbrains.kotlin.psi.KtTypeReference
 
 public abstract class KtTypeProvider : KtAnalysisSessionComponent() {
@@ -18,7 +19,11 @@ public abstract class KtTypeProvider : KtAnalysisSessionComponent() {
 
     public abstract fun buildSelfClassType(symbol: KtNamedClassOrObjectSymbol): KtType
 
+    public abstract fun commonSuperType(types: Collection<KtType>): KtType?
+
     public abstract fun getKtType(ktTypeReference: KtTypeReference): KtType
+
+    public abstract fun getReceiverTypeForDoubleColonExpression(expression: KtDoubleColonExpression): KtType?
 
     public abstract fun withNullability(type: KtType, newNullability: KtTypeNullability): KtType
 }
@@ -42,12 +47,28 @@ public interface KtTypeProviderMixIn : KtAnalysisSessionMixIn {
         analysisSession.typeProvider.buildSelfClassType(this)
 
     /**
+     * Computes the common super type of the given collection of [KtType].
+     *
+     * If the collection is empty, it returns `null`.
+     */
+    public fun commonSuperType(types: Collection<KtType>): KtType? =
+        analysisSession.typeProvider.commonSuperType(types)
+
+    /**
      * Resolve [KtTypeReference] and return corresponding [KtType] if resolved.
      *
      * This may raise an exception if the resolution ends up with an unexpected kind.
      */
     public fun KtTypeReference.getKtType(): KtType =
         analysisSession.typeProvider.getKtType(this)
+
+    /**
+     * Resolve [KtDoubleColonExpression] and return [KtType] of its receiver.
+     *
+     * Return `null` if the resolution fails or the resolved callable reference is not a reflection type.
+     */
+    public fun KtDoubleColonExpression.getReceiverKtType(): KtType? =
+        analysisSession.typeProvider.getReceiverTypeForDoubleColonExpression(this)
 
     public fun KtType.withNullability(newNullability: KtTypeNullability): KtType =
         analysisSession.typeProvider.withNullability(this, newNullability)

--- a/idea/idea-frontend-api/src/org/jetbrains/kotlin/idea/frontend/api/components/KtTypeProvider.kt
+++ b/idea/idea-frontend-api/src/org/jetbrains/kotlin/idea/frontend/api/components/KtTypeProvider.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlin.idea.frontend.api.ValidityTokenOwner
 import org.jetbrains.kotlin.idea.frontend.api.symbols.KtNamedClassOrObjectSymbol
 import org.jetbrains.kotlin.idea.frontend.api.types.KtType
 import org.jetbrains.kotlin.idea.frontend.api.types.KtTypeNullability
+import org.jetbrains.kotlin.psi.KtTypeReference
 
 public abstract class KtTypeProvider : KtAnalysisSessionComponent() {
     public abstract val builtinTypes: KtBuiltinTypes
@@ -16,6 +17,8 @@ public abstract class KtTypeProvider : KtAnalysisSessionComponent() {
     public abstract fun approximateToSuperPublicDenotableType(type: KtType): KtType?
 
     public abstract fun buildSelfClassType(symbol: KtNamedClassOrObjectSymbol): KtType
+
+    public abstract fun getKtType(ktTypeReference: KtTypeReference): KtType
 
     public abstract fun withNullability(type: KtType, newNullability: KtTypeNullability): KtType
 }
@@ -37,6 +40,14 @@ public interface KtTypeProviderMixIn : KtAnalysisSessionMixIn {
 
     public fun KtNamedClassOrObjectSymbol.buildSelfClassType(): KtType =
         analysisSession.typeProvider.buildSelfClassType(this)
+
+    /**
+     * Resolve [KtTypeReference] and return corresponding [KtType] if resolved.
+     *
+     * This may raise an exception if the resolution ends up with an unexpected kind.
+     */
+    public fun KtTypeReference.getKtType(): KtType =
+        analysisSession.typeProvider.getKtType(this)
 
     public fun KtType.withNullability(newNullability: KtTypeNullability): KtType =
         analysisSession.typeProvider.withNullability(this, newNullability)

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/components/KtFirAnalysisSessionComponent.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/components/KtFirAnalysisSessionComponent.kt
@@ -5,7 +5,6 @@
 
 package org.jetbrains.kotlin.idea.frontend.api.fir.components
 
-import com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.FirSourceElement
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirDiagnostic
@@ -18,11 +17,9 @@ import org.jetbrains.kotlin.idea.frontend.api.KtStarProjectionTypeArgument
 import org.jetbrains.kotlin.idea.frontend.api.KtTypeArgument
 import org.jetbrains.kotlin.idea.frontend.api.KtTypeArgumentWithVariance
 import org.jetbrains.kotlin.fir.types.ConeTypeCheckerContext
-import org.jetbrains.kotlin.idea.asJava.asPsiType
 import org.jetbrains.kotlin.idea.frontend.api.diagnostics.KtDiagnosticWithPsi
 import org.jetbrains.kotlin.idea.frontend.api.fir.KtFirAnalysisSession
 import org.jetbrains.kotlin.idea.frontend.api.fir.diagnostics.KT_DIAGNOSTIC_CONVERTER
-import org.jetbrains.kotlin.load.kotlin.TypeMappingMode
 import org.jetbrains.kotlin.idea.frontend.api.fir.types.KtFirType
 import org.jetbrains.kotlin.idea.frontend.api.types.KtType
 import org.jetbrains.kotlin.types.model.convertVariance
@@ -36,9 +33,6 @@ internal interface KtFirAnalysisSessionComponent {
     val firResolveState get() = analysisSession.firResolveState
 
     fun ConeKotlinType.asKtType() = analysisSession.firSymbolBuilder.typeBuilder.buildKtType(this)
-
-    fun ConeKotlinType.asPsiType(mode: TypeMappingMode, psiContext: PsiElement) =
-        asPsiType(rootModuleSession, analysisSession.firResolveState, mode, psiContext)
 
     fun FirPsiDiagnostic.asKtDiagnostic(): KtDiagnosticWithPsi<*> =
         KT_DIAGNOSTIC_CONVERTER.convert(analysisSession, this as FirDiagnostic)

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/components/KtFirExpressionTypeProvider.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/components/KtFirExpressionTypeProvider.kt
@@ -18,6 +18,7 @@ import org.jetbrains.kotlin.idea.fir.low.level.api.api.getOrBuildFirSafe
 import org.jetbrains.kotlin.idea.frontend.api.components.KtExpressionTypeProvider
 import org.jetbrains.kotlin.idea.frontend.api.fir.KtFirAnalysisSession
 import org.jetbrains.kotlin.idea.frontend.api.fir.utils.getReferencedElementType
+import org.jetbrains.kotlin.idea.frontend.api.fir.utils.unwrap
 import org.jetbrains.kotlin.idea.frontend.api.tokens.ValidityToken
 import org.jetbrains.kotlin.idea.frontend.api.types.KtClassErrorType
 import org.jetbrains.kotlin.idea.frontend.api.types.KtType
@@ -41,15 +42,6 @@ internal class KtFirExpressionTypeProvider(
             is FirStatement -> with(analysisSession) { builtinTypes.UNIT }
             else -> error("Unexpected ${fir?.let { it::class }}")
         }
-    }
-
-    private fun KtExpression.unwrap(): KtExpression {
-        return when (this) {
-            is KtLabeledExpression -> baseExpression?.unwrap()
-            is KtAnnotatedExpression -> baseExpression?.unwrap()
-            is KtObjectLiteralExpression -> objectDeclaration
-            else -> null
-        } ?: this
     }
 
     override fun getExpectedType(expression: PsiElement): KtType? {

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/components/KtFirPsiTypeProvider.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/components/KtFirPsiTypeProvider.kt
@@ -5,111 +5,22 @@
 
 package org.jetbrains.kotlin.idea.frontend.api.fir.components
 
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiType
-import org.jetbrains.kotlin.fir.declarations.FirCallableDeclaration
-import org.jetbrains.kotlin.fir.declarations.FirFunction
-import org.jetbrains.kotlin.fir.declarations.utils.isSuspend
-import org.jetbrains.kotlin.fir.expressions.FirCallableReferenceAccess
-import org.jetbrains.kotlin.fir.expressions.FirExpression
-import org.jetbrains.kotlin.fir.expressions.FirGetClassCall
-import org.jetbrains.kotlin.fir.expressions.FirStatement
-import org.jetbrains.kotlin.fir.references.FirNamedReference
-import org.jetbrains.kotlin.fir.resolve.constructFunctionalType
-import org.jetbrains.kotlin.fir.typeContext
-import org.jetbrains.kotlin.fir.types.*
-import org.jetbrains.kotlin.idea.fir.low.level.api.api.getOrBuildFir
-import org.jetbrains.kotlin.idea.fir.low.level.api.api.getOrBuildFirOfType
-import org.jetbrains.kotlin.idea.fir.low.level.api.api.throwUnexpectedFirElementError
+import org.jetbrains.kotlin.idea.asJava.asPsiType
 import org.jetbrains.kotlin.idea.frontend.api.components.KtPsiTypeProvider
 import org.jetbrains.kotlin.idea.frontend.api.fir.KtFirAnalysisSession
-import org.jetbrains.kotlin.idea.frontend.api.fir.utils.getReferencedElementType
 import org.jetbrains.kotlin.idea.frontend.api.tokens.ValidityToken
+import org.jetbrains.kotlin.idea.frontend.api.types.KtType
 import org.jetbrains.kotlin.idea.frontend.api.withValidityAssertion
 import org.jetbrains.kotlin.load.kotlin.TypeMappingMode
-import org.jetbrains.kotlin.name.StandardClassIds
-import org.jetbrains.kotlin.psi.*
 
 internal class KtFirPsiTypeProvider(
     override val analysisSession: KtFirAnalysisSession,
     override val token: ValidityToken,
 ) : KtPsiTypeProvider(), KtFirAnalysisSessionComponent {
 
-    override fun commonSuperType(
-        expressions: Collection<KtExpression>,
-        context: KtExpression,
-        mode: TypeMappingMode
-    ): PsiType? = withValidityAssertion {
-        val unitType = analysisSession.rootModuleSession.builtinTypes.unitType.type
-        analysisSession.rootModuleSession.typeContext
-            .commonSuperTypeOrNull(expressions.map { e -> e.getConeType(unitType) { it } })
-            ?.asPsiType(mode, context)
-    }
-
-    override fun getPsiTypeForKtExpression(
-        expression: KtExpression,
-        mode: TypeMappingMode,
-    ): PsiType = withValidityAssertion {
-        expression.getConeType(PsiType.VOID) {
-            it.asPsiType(mode, expression)
-        }
-    }
-
-    private inline fun <T> KtExpression.getConeType(
-        defaultType: T,
-        coneTypeConverter: (ConeKotlinType) -> T,
-    ): T = withValidityAssertion {
-        when (val fir = this.getOrBuildFir(firResolveState)) {
-            is FirExpression -> coneTypeConverter(fir.typeRef.coneType)
-            is FirNamedReference -> coneTypeConverter(fir.getReferencedElementType())
-            is FirStatement -> defaultType
-            else -> throwUnexpectedFirElementError(fir, this)
-        }
-    }
-
-    override fun getPsiTypeForKtDeclaration(
-        ktDeclaration: KtDeclaration,
-        mode: TypeMappingMode
-    ): PsiType = withValidityAssertion {
-        val firDeclaration = ktDeclaration.getOrBuildFirOfType<FirCallableDeclaration>(firResolveState)
-        firDeclaration.returnTypeRef.coneType.asPsiType(mode, ktDeclaration)
-    }
-
-    override fun getPsiTypeForKtFunction(
-        ktFunction: KtFunction,
-        mode: TypeMappingMode
-    ): PsiType = withValidityAssertion {
-        val firFunction = ktFunction.getOrBuildFirOfType<FirFunction>(firResolveState)
-        firFunction.constructFunctionalType(firFunction.isSuspend).asPsiType(mode, ktFunction)
-    }
-
-    override fun getPsiTypeForKtTypeReference(
-        ktTypeReference: KtTypeReference,
-        mode: TypeMappingMode
-    ): PsiType = withValidityAssertion {
-        when (val fir = ktTypeReference.getOrBuildFir(firResolveState)) {
-            // NB: [FirErrorTypeRef] is a subtype of [FirResolvedTypeRef], and the error type in it will be properly handled by [asPsiType].
-            is FirResolvedTypeRef -> fir.coneType.asPsiType(mode, ktTypeReference)
-            else -> throwUnexpectedFirElementError(fir, ktTypeReference)
-        }
-    }
-
-    override fun getPsiTypeForReceiverOfDoubleColonExpression(
-        ktDoubleColonExpression: KtDoubleColonExpression,
-        mode: TypeMappingMode
-    ): PsiType? = withValidityAssertion {
-        val receiver = ktDoubleColonExpression.receiverExpression ?: return null
-        when (val fir = ktDoubleColonExpression.getOrBuildFir(firResolveState)) {
-            is FirGetClassCall ->
-                fir.typeRef.coneType.getReceiverOfReflectionType()?.asPsiType(mode, receiver)
-            is FirCallableReferenceAccess ->
-                fir.typeRef.coneType.getReceiverOfReflectionType()?.asPsiType(mode, receiver)
-            else -> throwUnexpectedFirElementError(fir, ktDoubleColonExpression)
-        }
-    }
-
-    private fun ConeKotlinType.getReceiverOfReflectionType(): ConeKotlinType? {
-        if (this !is ConeClassLikeType) return null
-        if (lookupTag.classId.packageFqName != StandardClassIds.BASE_REFLECT_PACKAGE) return null
-        return typeArguments.firstOrNull()?.type
+    override fun asPsiType(type: KtType, context: PsiElement, mode: TypeMappingMode): PsiType = withValidityAssertion {
+        type.coneType.asPsiType(rootModuleSession, analysisSession.firResolveState, mode, context)
     }
 }

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/components/KtFirPsiTypeProvider.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/components/KtFirPsiTypeProvider.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.idea.frontend.api.fir.components
 
 import com.intellij.psi.PsiType
+import org.jetbrains.kotlin.fir.declarations.FirCallableDeclaration
 import org.jetbrains.kotlin.fir.expressions.FirCallableReferenceAccess
 import org.jetbrains.kotlin.fir.expressions.FirExpression
 import org.jetbrains.kotlin.fir.expressions.FirGetClassCall
@@ -13,6 +14,7 @@ import org.jetbrains.kotlin.fir.expressions.FirStatement
 import org.jetbrains.kotlin.fir.references.FirNamedReference
 import org.jetbrains.kotlin.fir.types.*
 import org.jetbrains.kotlin.idea.fir.low.level.api.api.getOrBuildFir
+import org.jetbrains.kotlin.idea.fir.low.level.api.api.getOrBuildFirOfType
 import org.jetbrains.kotlin.idea.fir.low.level.api.api.throwUnexpectedFirElementError
 import org.jetbrains.kotlin.idea.frontend.api.components.KtPsiTypeProvider
 import org.jetbrains.kotlin.idea.frontend.api.fir.KtFirAnalysisSession
@@ -21,6 +23,7 @@ import org.jetbrains.kotlin.idea.frontend.api.tokens.ValidityToken
 import org.jetbrains.kotlin.idea.frontend.api.withValidityAssertion
 import org.jetbrains.kotlin.load.kotlin.TypeMappingMode
 import org.jetbrains.kotlin.name.StandardClassIds
+import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtDoubleColonExpression
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtTypeReference
@@ -39,6 +42,14 @@ internal class KtFirPsiTypeProvider(
             is FirStatement -> PsiType.VOID
             else -> throwUnexpectedFirElementError(fir, expression)
         }
+    }
+
+    override fun getPsiTypeForKtDeclaration(
+        ktDeclaration: KtDeclaration,
+        mode: TypeMappingMode
+    ): PsiType = withValidityAssertion {
+        val firDeclaration = ktDeclaration.getOrBuildFirOfType<FirCallableDeclaration>(firResolveState)
+        firDeclaration.returnTypeRef.coneType.asPsiType(mode, ktDeclaration)
     }
 
     override fun getPsiTypeForKtTypeReference(

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/components/KtFirPsiTypeProvider.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/components/KtFirPsiTypeProvider.kt
@@ -7,11 +7,14 @@ package org.jetbrains.kotlin.idea.frontend.api.fir.components
 
 import com.intellij.psi.PsiType
 import org.jetbrains.kotlin.fir.declarations.FirCallableDeclaration
+import org.jetbrains.kotlin.fir.declarations.FirFunction
+import org.jetbrains.kotlin.fir.declarations.utils.isSuspend
 import org.jetbrains.kotlin.fir.expressions.FirCallableReferenceAccess
 import org.jetbrains.kotlin.fir.expressions.FirExpression
 import org.jetbrains.kotlin.fir.expressions.FirGetClassCall
 import org.jetbrains.kotlin.fir.expressions.FirStatement
 import org.jetbrains.kotlin.fir.references.FirNamedReference
+import org.jetbrains.kotlin.fir.resolve.constructFunctionalType
 import org.jetbrains.kotlin.fir.typeContext
 import org.jetbrains.kotlin.fir.types.*
 import org.jetbrains.kotlin.idea.fir.low.level.api.api.getOrBuildFir
@@ -24,10 +27,7 @@ import org.jetbrains.kotlin.idea.frontend.api.tokens.ValidityToken
 import org.jetbrains.kotlin.idea.frontend.api.withValidityAssertion
 import org.jetbrains.kotlin.load.kotlin.TypeMappingMode
 import org.jetbrains.kotlin.name.StandardClassIds
-import org.jetbrains.kotlin.psi.KtDeclaration
-import org.jetbrains.kotlin.psi.KtDoubleColonExpression
-import org.jetbrains.kotlin.psi.KtExpression
-import org.jetbrains.kotlin.psi.KtTypeReference
+import org.jetbrains.kotlin.psi.*
 
 internal class KtFirPsiTypeProvider(
     override val analysisSession: KtFirAnalysisSession,
@@ -72,6 +72,14 @@ internal class KtFirPsiTypeProvider(
     ): PsiType = withValidityAssertion {
         val firDeclaration = ktDeclaration.getOrBuildFirOfType<FirCallableDeclaration>(firResolveState)
         firDeclaration.returnTypeRef.coneType.asPsiType(mode, ktDeclaration)
+    }
+
+    override fun getPsiTypeForKtFunction(
+        ktFunction: KtFunction,
+        mode: TypeMappingMode
+    ): PsiType = withValidityAssertion {
+        val firFunction = ktFunction.getOrBuildFirOfType<FirFunction>(firResolveState)
+        firFunction.constructFunctionalType(firFunction.isSuspend).asPsiType(mode, ktFunction)
     }
 
     override fun getPsiTypeForKtTypeReference(

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/components/KtFirTypeProvider.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/components/KtFirTypeProvider.kt
@@ -7,9 +7,14 @@ package org.jetbrains.kotlin.idea.frontend.api.fir.components
 
 import org.jetbrains.kotlin.fir.declarations.FirResolvePhase
 import org.jetbrains.kotlin.fir.typeContext
+import org.jetbrains.kotlin.fir.types.FirErrorTypeRef
+import org.jetbrains.kotlin.fir.types.FirResolvedTypeRef
+import org.jetbrains.kotlin.fir.types.coneType
 import org.jetbrains.kotlin.fir.types.impl.ConeClassLikeTypeImpl
 import org.jetbrains.kotlin.fir.types.impl.ConeTypeParameterTypeImpl
 import org.jetbrains.kotlin.fir.types.withNullability
+import org.jetbrains.kotlin.idea.fir.low.level.api.api.getOrBuildFir
+import org.jetbrains.kotlin.idea.fir.low.level.api.api.getOrBuildFirOfType
 import org.jetbrains.kotlin.idea.frontend.api.components.KtBuiltinTypes
 import org.jetbrains.kotlin.idea.frontend.api.components.KtTypeProvider
 import org.jetbrains.kotlin.idea.frontend.api.fir.KtFirAnalysisSession
@@ -21,6 +26,8 @@ import org.jetbrains.kotlin.idea.frontend.api.symbols.KtNamedClassOrObjectSymbol
 import org.jetbrains.kotlin.idea.frontend.api.tokens.ValidityToken
 import org.jetbrains.kotlin.idea.frontend.api.types.KtType
 import org.jetbrains.kotlin.idea.frontend.api.types.KtTypeNullability
+import org.jetbrains.kotlin.idea.frontend.api.withValidityAssertion
+import org.jetbrains.kotlin.psi.KtTypeReference
 
 internal class KtFirTypeProvider(
     override val analysisSession: KtFirAnalysisSession,
@@ -49,6 +56,10 @@ internal class KtFirTypeProvider(
             )
         }
         return type.asKtType()
+    }
+
+    override fun getKtType(ktTypeReference: KtTypeReference): KtType = withValidityAssertion {
+        ktTypeReference.getOrBuildFirOfType<FirResolvedTypeRef>(firResolveState).coneType.asKtType()
     }
 
     override fun withNullability(type: KtType, newNullability: KtTypeNullability): KtType {

--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/utils/firUtils.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/utils/firUtils.kt
@@ -23,6 +23,19 @@ import org.jetbrains.kotlin.idea.frontend.api.symbols.markers.KtSimpleConstantVa
 import org.jetbrains.kotlin.idea.frontend.api.symbols.markers.KtUnsupportedConstantValue
 import org.jetbrains.kotlin.idea.frontend.api.types.KtTypeNullability
 import org.jetbrains.kotlin.idea.references.FirReferenceResolveHelper
+import org.jetbrains.kotlin.psi.KtAnnotatedExpression
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtLabeledExpression
+import org.jetbrains.kotlin.psi.KtObjectLiteralExpression
+
+internal fun KtExpression.unwrap(): KtExpression {
+    return when (this) {
+        is KtLabeledExpression -> baseExpression?.unwrap()
+        is KtAnnotatedExpression -> baseExpression?.unwrap()
+        is KtObjectLiteralExpression -> objectDeclaration
+        else -> null
+    } ?: this
+}
 
 internal fun FirNamedReference.getReferencedElementType(): ConeKotlinType {
     val symbols = when (this) {


### PR DESCRIPTION
This PR adds HL APIs for FIR UAST supports: https://github.com/JetBrains/intellij-kotlin/pull/85.

1st: `KtDeclaration` -> `PsiType`, which is used for local variables.

2nd: common super type as `PsiType` for the given `KtExpression`s. It's used to compute the type of `?:`, hence two inputs: lhs/rhs, but the API can input expressions in a general form, which resembles the underlying util in FIR resolution.

3rd: `KtFunction` -> `PsiType`, which is also used for local variables whose initializers are lambda or function.

4th: `KtTypeReference` -> `KtType`, from which nullability is retrieved to compute literally nullability of `PsiElement`.