### PR TITLE
Always add a local variable for its live ranges.

### DIFF
--- a/compiler/testData/codegen/bytecodeText/coroutines/debug/thisAndResultInLvt.kt
+++ b/compiler/testData/codegen/bytecodeText/coroutines/debug/thisAndResultInLvt.kt
@@ -21,7 +21,7 @@ class A {
 // BEs generate continuation classes differently, JVM_IR generates more correctly
 
 // foo, c's lambda and foo's continuation
-// 3 LOCALVARIABLE \$result Ljava/lang/Object;
+// 8 LOCALVARIABLE \$result Ljava/lang/Object;
 
 // foo x 3 since we split the local over restore code for the two calls to block(), and <init>
 // 4 LOCALVARIABLE this LA;

--- a/compiler/testData/codegen/bytecodeText/coroutines/mergeLvt.kt
+++ b/compiler/testData/codegen/bytecodeText/coroutines/mergeLvt.kt
@@ -22,4 +22,4 @@ class MyBlockingAdapter() {
     }
 }
 
-// 1 LOCALVARIABLE \$this\$extensionFun\$iv\$iv LAtomicInt;
+// 2 LOCALVARIABLE \$this\$extensionFun\$iv\$iv LAtomicInt;

--- a/compiler/testData/codegen/bytecodeText/coroutines/varValueConflictsWithTableSameSort.kt
+++ b/compiler/testData/codegen/bytecodeText/coroutines/varValueConflictsWithTableSameSort.kt
@@ -43,7 +43,7 @@ fun box(): String {
 
 // 1 LOCALVARIABLE i Ljava/lang/String; L.* 3
 // We merge LVT records for two consequent branches, but we split the local over the restore code.
-// 2 LOCALVARIABLE s Ljava/lang/String; L.* 3
+// 3 LOCALVARIABLE s Ljava/lang/String; L.* 3
 // 1 PUTFIELD VarValueConflictsWithTableSameSortKt\$box\$1.L\$0 : Ljava/lang/Object;
 /* 1 load in the catch (e: Throwable) { throw e } block which is implicitly wrapped around try/finally */
 // 1 ALOAD 3\s+ATHROW


### PR DESCRIPTION
There used to be code that extended a previous range instead.
However, that does not work as that extension could have the
local cover code where it does not exists. Since we no longer
extend the range of locals, we should always introduce a new
one even if there was another one for a previous range.