### PR TITLE
FIR IDE: fix override/implement action

### DIFF
--- a/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/symbols/KtFirOverrideInfoProvider.kt
+++ b/idea/idea-frontend-fir/src/org/jetbrains/kotlin/idea/frontend/api/fir/symbols/KtFirOverrideInfoProvider.kt
@@ -50,8 +50,11 @@ class KtFirOverrideInfoProvider(
         return memberSymbol.firRef.withFir { memberFir ->
             if (memberFir !is FirCallableDeclaration) return@withFir null
             parentClassSymbol.firRef.withFir inner@{ parentClassFir ->
-                if (parentClassSymbol !is FirClassSymbol<*>) return@inner null
-                memberFir.symbol.getImplementationStatus(SessionHolderImpl(firAnalysisSession.rootModuleSession, ScopeSession()), parentClassSymbol)
+                val parentClassFirSymbol = parentClassFir.symbol as? FirClassSymbol<*> ?: return@inner null
+                memberFir.symbol.getImplementationStatus(
+                    SessionHolderImpl(firAnalysisSession.rootModuleSession, ScopeSession()),
+                    parentClassFirSymbol
+                )
             }
         }
     }


### PR DESCRIPTION
A previous refactoring checks if a KtSymbol is a FirSymbol, which can
never succeed. This change fixes that. Unfortunately, the related IDE
tests are not running to catch this.