### PR TITLE
Don't generate redundant CHECKCAST when type is subtype of target(KT-11700)

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/StackValue.java
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/StackValue.java
@@ -640,10 +640,16 @@ public abstract class StackValue {
     }
 
     public static void coerce(@NotNull Type fromType, @NotNull Type toType, @NotNull InstructionAdapter v) {
-        coerce(fromType, toType, v, false);
+        coerce(fromType, toType, v, false, false);
     }
 
-    public static void coerce(@NotNull Type fromType, @NotNull Type toType, @NotNull InstructionAdapter v, boolean forceSelfCast) {
+    public static void coerce(
+            @NotNull Type fromType,
+            @NotNull Type toType,
+            @NotNull InstructionAdapter v,
+            boolean forceSelfCast,
+            boolean fromIsSubtypeOfTo
+    ) {
         if (toType.equals(fromType) && !forceSelfCast) return;
 
         if (toType.getSort() == Type.VOID) {
@@ -679,7 +685,7 @@ public abstract class StackValue {
         }
         else if (toType.getSort() == Type.OBJECT) {
             if (fromType.getSort() == Type.OBJECT || fromType.getSort() == Type.ARRAY) {
-                if (!toType.equals(OBJECT_TYPE)) {
+                if (!toType.equals(OBJECT_TYPE) && !fromIsSubtypeOfTo) {
                     v.checkcast(toType);
                 }
             }

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBytecodeTextTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBytecodeTextTestGenerated.java
@@ -1015,6 +1015,12 @@ public class FirBytecodeTextTestGenerated extends AbstractFirBytecodeTextTest {
         }
 
         @Test
+        @TestMetadata("kt11700.kt")
+        public void testKt11700() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/checkcast/kt11700.kt");
+        }
+
+        @Test
         @TestMetadata("kt14811.kt")
         public void testKt14811() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/checkcast/kt14811.kt");

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/PromisedValue.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/PromisedValue.kt
@@ -59,7 +59,7 @@ abstract class PromisedValue(val codegen: ExpressionCodegen, val type: Type, val
         }
 
         if (type != target || (castForReified && irType.anyTypeArgument { it.isReified })) {
-            StackValue.coerce(type, target, mv, type == target)
+            StackValue.coerce(type, target, mv, type == target, irType.isSubtypeOf(irTarget))
         }
     }
 
@@ -70,6 +70,9 @@ abstract class PromisedValue(val codegen: ExpressionCodegen, val type: Type, val
 
     val typeMapper: IrTypeMapper
         get() = codegen.typeMapper
+
+    private fun IrType.isSubtypeOf(irTarget: IrType): Boolean =
+        irTarget.classOrNull != null && this.isSubtypeOfClass(irTarget.classOrNull!!)
 }
 
 

--- a/compiler/testData/codegen/bytecodeText/checkcast/kt11700.kt
+++ b/compiler/testData/codegen/bytecodeText/checkcast/kt11700.kt
@@ -1,0 +1,55 @@
+// TARGET_BACKEND: JVM_IR
+
+// FILE: j/JBase.java
+package j;
+interface JBase {
+    void foo();
+}
+
+// FILE: j/JSub.java
+package j;
+public interface JSub extends JBase{}
+
+// FILE: j/JBaseImpl.java
+package j;
+public class JBaseImpl implements JBase {
+    @Override
+    public void foo() {}
+}
+
+// FILE: j/JSubImpl.java
+package j;
+public class JSubImpl implements JSub {
+    @Override
+    public void foo() {}
+}
+
+// FILE: j/JOperation.java
+package j;
+public class JOperation {
+    public void forJBase(JBase jb) {
+        jb.foo();
+    }
+}
+
+// FILE: main.kt
+package k
+
+import j.JBaseImpl
+import j.JOperation
+import j.JSub
+import j.JSubImpl
+
+fun test() {
+    JOperation().forJBase(JBaseImpl())
+}
+
+fun <T : JBaseImpl> testGeneric(t: T) {
+    JOperation().forJBase(t)
+}
+
+fun <T> testMultipleBounds(t: T) where T : Any, T : JSub {
+    JOperation().forJBase(t)
+}
+
+// 0 CHECKCAST j/JBase

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBytecodeTextTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBytecodeTextTestGenerated.java
@@ -1015,6 +1015,12 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
         }
 
         @Test
+        @TestMetadata("kt11700.kt")
+        public void testKt11700() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/checkcast/kt11700.kt");
+        }
+
+        @Test
         @TestMetadata("kt14811.kt")
         public void testKt14811() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/checkcast/kt14811.kt");


### PR DESCRIPTION
[KT-11700](https://youtrack.jetbrains.com/issue/KT-11700)