### PR TITLE
[KT-47876] Populate class realm in plugin descriptor (where it is available) instead of project.

### DIFF
--- a/libraries/tools/kotlin-maven-plugin-test/src/it/test-use-javac/pom.xml
+++ b/libraries/tools/kotlin-maven-plugin-test/src/it/test-use-javac/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.jetbrains.kotlin</groupId>
+    <artifactId>test-use-javac</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>2.3.2</version>
+                    <configuration>
+                        <source>1.6</source>
+                        <target>1.6</target>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>2.1.2</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
+        <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+        <plugins>
+            <plugin>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <version>${kotlin.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <phase>process-test-sources</phase>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <args>
+                        <arg>-Xuse-javac</arg>
+                    </args>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/libraries/tools/kotlin-maven-plugin-test/src/it/test-use-javac/src/main/kotlin/org/jetbrains/HelloWorld.kt
+++ b/libraries/tools/kotlin-maven-plugin-test/src/it/test-use-javac/src/main/kotlin/org/jetbrains/HelloWorld.kt
@@ -1,0 +1,9 @@
+package org.jetbrains
+
+fun main(args : Array<String>) {
+    System.out?.println(getGreeting())
+}
+
+fun getGreeting() : String {
+    return "Hello, Javac World!"
+}

--- a/libraries/tools/kotlin-maven-plugin-test/src/it/test-use-javac/src/test/java/org/jetbrains/HelloWorldJavacTest.java
+++ b/libraries/tools/kotlin-maven-plugin-test/src/it/test-use-javac/src/test/java/org/jetbrains/HelloWorldJavacTest.java
@@ -1,0 +1,13 @@
+package org.jetbrains;
+
+import org.junit.Test;
+
+import static junit.framework.Assert.assertEquals;
+
+public class HelloWorldJavacTest {
+
+    @Test
+    public void greeting() {
+        assertEquals("Hello, Javac World!", org.jetbrains.HelloWorldKt.getGreeting());
+    }
+}

--- a/libraries/tools/kotlin-maven-plugin-test/src/it/test-use-javac/verify.bsh
+++ b/libraries/tools/kotlin-maven-plugin-test/src/it/test-use-javac/verify.bsh
@@ -1,0 +1,6 @@
+import java.io.*;
+
+File file = new File(basedir, "target/test-use-javac-1.0-SNAPSHOT.jar");
+if (!file.exists() || !file.isFile()) {
+    throw new FileNotFoundException("Could not find generated JAR: " + file);
+}

--- a/libraries/tools/kotlin-maven-plugin/src/main/java/org/jetbrains/kotlin/maven/K2JVMCompileMojo.java
+++ b/libraries/tools/kotlin-maven-plugin/src/main/java/org/jetbrains/kotlin/maven/K2JVMCompileMojo.java
@@ -21,6 +21,7 @@ import com.intellij.psi.PsiJavaModule;
 import kotlin.collections.MapsKt;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -89,6 +90,9 @@ public class K2JVMCompileMojo extends KotlinCompileMojoBase<K2JVMCompilerArgumen
 
     @Parameter(property = "kotlin.compiler.javaParameters")
     protected boolean javaParameters;
+
+    @Parameter(defaultValue = "${plugin}", required = true, readonly = true)
+    private PluginDescriptor plugin;
 
     @NotNull
     private File getCachesDir() {
@@ -214,8 +218,9 @@ public class K2JVMCompileMojo extends KotlinCompileMojoBase<K2JVMCompilerArgumen
             try {
                 URL toolsJar = getJdkToolsJarURL();
                 if (toolsJar != null) {
-                    project.getClassRealm().addURL(toolsJar);
+                    plugin.getClassRealm().addURL(toolsJar);
                 }
+
             } catch (IOException ignored) {}
         }
 


### PR DESCRIPTION
The option -Xuse-javac requires the tools-jar classpath to be setup
before the plugin triggers compilation. This was done by adding the
path to the tools Jar to the project realm, but at this point in the
plugin phase, the project doesn't actually have a class realm setup
yet that can be modified (the behavior of MavenProject changed a lot
in 3.2.2 and later it seems). Instead, we populate the plugin class
realm, as that is used when executing the compilation anyway, and it
does actually exist.

Without this fix, the compilation will fail with an NPE:

Caused by: java.lang.NullPointerException
    at org.jetbrains.kotlin.maven.K2JVMCompileMojo.execute (K2JVMCompileMojo.java:217)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)

After this change, compilation with -Xuse-javac works as intended. An
integration test is supplied to test that it works.

Tracking issue: https://youtrack.jetbrains.com/issue/KT-47876