### PR TITLE
FE: small cleanup of enhancement-wrapped types

### DIFF
--- a/compiler/testData/diagnostics/foreignAnnotationsTests/java8Tests/jspecify/strictMode/Captured.fir.kt
+++ b/compiler/testData/diagnostics/foreignAnnotationsTests/java8Tests/jspecify/strictMode/Captured.fir.kt
@@ -1,0 +1,17 @@
+// JSPECIFY_STATE: strict
+// !LANGUAGE: +TypeEnhancementImprovementsInStrictMode
+// FILE: J1.java
+import org.jetbrains.annotations.Nullable;
+
+public interface J1<T> {
+    @Nullable
+    public static <T> T foo(J1<T> x) { return null; }
+}
+
+// FILE: J2.java
+import org.jspecify.nullness.Nullable;
+
+public interface J2<V extends @Nullable Object> extends J1<V> { }
+
+// FILE: kotlin.kt
+private fun J2<*>.bar() = J1.foo(this)

--- a/compiler/testData/diagnostics/foreignAnnotationsTests/java8Tests/jspecify/strictMode/Captured.fir.txt
+++ b/compiler/testData/diagnostics/foreignAnnotationsTests/java8Tests/jspecify/strictMode/Captured.fir.txt
@@ -1,0 +1,18 @@
+package
+
+private fun J2<*>.bar(): @org.jspecify.nullness.Nullable kotlin.Any?
+
+public interface J1</*0*/ T : kotlin.Any!> {
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+
+    // Static members
+    @org.jetbrains.annotations.Nullable public open fun </*0*/ T : kotlin.Any!> foo(/*0*/ x: J1<T!>!): @org.jetbrains.annotations.Nullable T?
+}
+
+public interface J2</*0*/ V> : J1<V> {
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}

--- a/compiler/testData/diagnostics/foreignAnnotationsTests/java8Tests/jspecify/strictMode/Captured.kt
+++ b/compiler/testData/diagnostics/foreignAnnotationsTests/java8Tests/jspecify/strictMode/Captured.kt
@@ -1,0 +1,17 @@
+// JSPECIFY_STATE: strict
+// !LANGUAGE: +TypeEnhancementImprovementsInStrictMode
+// FILE: J1.java
+import org.jetbrains.annotations.Nullable;
+
+public interface J1<T> {
+    @Nullable
+    public static <T> T foo(J1<T> x) { return null; }
+}
+
+// FILE: J2.java
+import org.jspecify.nullness.Nullable;
+
+public interface J2<V extends @Nullable Object> extends J1<V> { }
+
+// FILE: kotlin.kt
+private fun J2<*>.bar() = J1.foo(this)

--- a/compiler/testData/diagnostics/foreignAnnotationsTests/java8Tests/jspecify/strictMode/Captured.txt
+++ b/compiler/testData/diagnostics/foreignAnnotationsTests/java8Tests/jspecify/strictMode/Captured.txt
@@ -1,0 +1,18 @@
+package
+
+private fun J2<*>.bar(): @org.jspecify.nullness.Nullable kotlin.Any?
+
+public interface J1</*0*/ T : kotlin.Any!> {
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+
+    // Static members
+    @org.jetbrains.annotations.Nullable public open fun </*0*/ T : kotlin.Any!> foo(/*0*/ x: J1<T!>!): @org.jetbrains.annotations.Nullable T?
+}
+
+public interface J2</*0*/ V> : J1<V> {
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}

--- a/compiler/testData/diagnostics/foreignAnnotationsTests/java8Tests/jspecify/warnMode/Captured.fir.kt
+++ b/compiler/testData/diagnostics/foreignAnnotationsTests/java8Tests/jspecify/warnMode/Captured.fir.kt
@@ -1,0 +1,16 @@
+// JSPECIFY_STATE: warn
+// FILE: J1.java
+import org.jetbrains.annotations.Nullable;
+
+public interface J1<T> {
+    @Nullable
+    public static <T> T foo(J1<T> x) { return null; }
+}
+
+// FILE: J2.java
+import org.jspecify.nullness.Nullable;
+
+public interface J2<V extends @Nullable Object> extends J1<V> { }
+
+// FILE: kotlin.kt
+private fun J2<*>.bar() = J1.foo(this)

--- a/compiler/testData/diagnostics/foreignAnnotationsTests/java8Tests/jspecify/warnMode/Captured.fir.txt
+++ b/compiler/testData/diagnostics/foreignAnnotationsTests/java8Tests/jspecify/warnMode/Captured.fir.txt
@@ -1,0 +1,18 @@
+package
+
+private fun J2<*>.bar(): @org.jspecify.nullness.Nullable kotlin.Any?
+
+public interface J1</*0*/ T : kotlin.Any!> {
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+
+    // Static members
+    @org.jetbrains.annotations.Nullable public open fun </*0*/ T : kotlin.Any!> foo(/*0*/ x: J1<T!>!): @org.jetbrains.annotations.Nullable T?
+}
+
+public interface J2</*0*/ V : @org.jspecify.nullness.Nullable kotlin.Any!> : J1<V!> {
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}

--- a/compiler/testData/diagnostics/foreignAnnotationsTests/java8Tests/jspecify/warnMode/Captured.kt
+++ b/compiler/testData/diagnostics/foreignAnnotationsTests/java8Tests/jspecify/warnMode/Captured.kt
@@ -1,0 +1,16 @@
+// JSPECIFY_STATE: warn
+// FILE: J1.java
+import org.jetbrains.annotations.Nullable;
+
+public interface J1<T> {
+    @Nullable
+    public static <T> T foo(J1<T> x) { return null; }
+}
+
+// FILE: J2.java
+import org.jspecify.nullness.Nullable;
+
+public interface J2<V extends @Nullable Object> extends J1<V> { }
+
+// FILE: kotlin.kt
+private fun J2<*>.bar() = J1.foo(this)

--- a/compiler/testData/diagnostics/foreignAnnotationsTests/java8Tests/jspecify/warnMode/Captured.txt
+++ b/compiler/testData/diagnostics/foreignAnnotationsTests/java8Tests/jspecify/warnMode/Captured.txt
@@ -1,0 +1,18 @@
+package
+
+private fun J2<*>.bar(): @org.jspecify.nullness.Nullable kotlin.Any?
+
+public interface J1</*0*/ T : kotlin.Any!> {
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+
+    // Static members
+    @org.jetbrains.annotations.Nullable public open fun </*0*/ T : kotlin.Any!> foo(/*0*/ x: J1<T!>!): @org.jetbrains.annotations.Nullable T?
+}
+
+public interface J2</*0*/ V : @org.jspecify.nullness.Nullable kotlin.Any!> : J1<V!> {
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/ForeignAnnotationsCompiledJavaTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/ForeignAnnotationsCompiledJavaTestGenerated.java
@@ -631,6 +631,18 @@ public class ForeignAnnotationsCompiledJavaTestGenerated extends AbstractForeign
                 }
 
                 @Test
+                @TestMetadata("Captured.kt")
+                public void testCaptured() throws Exception {
+                    runTest("compiler/testData/diagnostics/foreignAnnotationsTests/java8Tests/jspecify/strictMode/Captured.kt");
+                }
+
+                @Test
+                @TestMetadata("Captured.fir.kt")
+                public void testCaptured_fir() throws Exception {
+                    runTest("compiler/testData/diagnostics/foreignAnnotationsTests/java8Tests/jspecify/strictMode/Captured.fir.kt");
+                }
+
+                @Test
                 @TestMetadata("Defaults.kt")
                 public void testDefaults() throws Exception {
                     runTest("compiler/testData/diagnostics/foreignAnnotationsTests/java8Tests/jspecify/strictMode/Defaults.kt");
@@ -758,6 +770,18 @@ public class ForeignAnnotationsCompiledJavaTestGenerated extends AbstractForeign
                 @TestMetadata("AnnotatedBoundsOfWildcard.fir.kt")
                 public void testAnnotatedBoundsOfWildcard_fir() throws Exception {
                     runTest("compiler/testData/diagnostics/foreignAnnotationsTests/java8Tests/jspecify/warnMode/AnnotatedBoundsOfWildcard.fir.kt");
+                }
+
+                @Test
+                @TestMetadata("Captured.kt")
+                public void testCaptured() throws Exception {
+                    runTest("compiler/testData/diagnostics/foreignAnnotationsTests/java8Tests/jspecify/warnMode/Captured.kt");
+                }
+
+                @Test
+                @TestMetadata("Captured.fir.kt")
+                public void testCaptured_fir() throws Exception {
+                    runTest("compiler/testData/diagnostics/foreignAnnotationsTests/java8Tests/jspecify/warnMode/Captured.fir.kt");
                 }
 
                 @Test

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/ForeignAnnotationsCompiledJavaWithPsiClassReadingTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/ForeignAnnotationsCompiledJavaWithPsiClassReadingTestGenerated.java
@@ -631,6 +631,18 @@ public class ForeignAnnotationsCompiledJavaWithPsiClassReadingTestGenerated exte
                 }
 
                 @Test
+                @TestMetadata("Captured.kt")
+                public void testCaptured() throws Exception {
+                    runTest("compiler/testData/diagnostics/foreignAnnotationsTests/java8Tests/jspecify/strictMode/Captured.kt");
+                }
+
+                @Test
+                @TestMetadata("Captured.fir.kt")
+                public void testCaptured_fir() throws Exception {
+                    runTest("compiler/testData/diagnostics/foreignAnnotationsTests/java8Tests/jspecify/strictMode/Captured.fir.kt");
+                }
+
+                @Test
                 @TestMetadata("Defaults.kt")
                 public void testDefaults() throws Exception {
                     runTest("compiler/testData/diagnostics/foreignAnnotationsTests/java8Tests/jspecify/strictMode/Defaults.kt");
@@ -758,6 +770,18 @@ public class ForeignAnnotationsCompiledJavaWithPsiClassReadingTestGenerated exte
                 @TestMetadata("AnnotatedBoundsOfWildcard.fir.kt")
                 public void testAnnotatedBoundsOfWildcard_fir() throws Exception {
                     runTest("compiler/testData/diagnostics/foreignAnnotationsTests/java8Tests/jspecify/warnMode/AnnotatedBoundsOfWildcard.fir.kt");
+                }
+
+                @Test
+                @TestMetadata("Captured.kt")
+                public void testCaptured() throws Exception {
+                    runTest("compiler/testData/diagnostics/foreignAnnotationsTests/java8Tests/jspecify/warnMode/Captured.kt");
+                }
+
+                @Test
+                @TestMetadata("Captured.fir.kt")
+                public void testCaptured_fir() throws Exception {
+                    runTest("compiler/testData/diagnostics/foreignAnnotationsTests/java8Tests/jspecify/warnMode/Captured.fir.kt");
                 }
 
                 @Test

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/ForeignAnnotationsSourceJavaTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/ForeignAnnotationsSourceJavaTestGenerated.java
@@ -631,6 +631,18 @@ public class ForeignAnnotationsSourceJavaTestGenerated extends AbstractForeignAn
                 }
 
                 @Test
+                @TestMetadata("Captured.kt")
+                public void testCaptured() throws Exception {
+                    runTest("compiler/testData/diagnostics/foreignAnnotationsTests/java8Tests/jspecify/strictMode/Captured.kt");
+                }
+
+                @Test
+                @TestMetadata("Captured.fir.kt")
+                public void testCaptured_fir() throws Exception {
+                    runTest("compiler/testData/diagnostics/foreignAnnotationsTests/java8Tests/jspecify/strictMode/Captured.fir.kt");
+                }
+
+                @Test
                 @TestMetadata("Defaults.kt")
                 public void testDefaults() throws Exception {
                     runTest("compiler/testData/diagnostics/foreignAnnotationsTests/java8Tests/jspecify/strictMode/Defaults.kt");
@@ -758,6 +770,18 @@ public class ForeignAnnotationsSourceJavaTestGenerated extends AbstractForeignAn
                 @TestMetadata("AnnotatedBoundsOfWildcard.fir.kt")
                 public void testAnnotatedBoundsOfWildcard_fir() throws Exception {
                     runTest("compiler/testData/diagnostics/foreignAnnotationsTests/java8Tests/jspecify/warnMode/AnnotatedBoundsOfWildcard.fir.kt");
+                }
+
+                @Test
+                @TestMetadata("Captured.kt")
+                public void testCaptured() throws Exception {
+                    runTest("compiler/testData/diagnostics/foreignAnnotationsTests/java8Tests/jspecify/warnMode/Captured.kt");
+                }
+
+                @Test
+                @TestMetadata("Captured.fir.kt")
+                public void testCaptured_fir() throws Exception {
+                    runTest("compiler/testData/diagnostics/foreignAnnotationsTests/java8Tests/jspecify/warnMode/Captured.fir.kt");
                 }
 
                 @Test

--- a/core/descriptors/src/org/jetbrains/kotlin/types/TypeWithEnhancement.kt
+++ b/core/descriptors/src/org/jetbrains/kotlin/types/TypeWithEnhancement.kt
@@ -156,7 +156,7 @@ fun UnwrappedType.wrapEnhancement(enhancement: KotlinType?): UnwrappedType {
     if (this is TypeWithEnhancement) {
         return origin.wrapEnhancement(enhancement)
     }
-    if (enhancement == null) {
+    if (enhancement == null || enhancement == this) {
         return this
     }
     return when (this) {

--- a/core/descriptors/src/org/jetbrains/kotlin/types/TypeWithEnhancement.kt
+++ b/core/descriptors/src/org/jetbrains/kotlin/types/TypeWithEnhancement.kt
@@ -51,6 +51,9 @@ class SimpleTypeWithEnhancement(
             kotlinTypeRefiner.refineType(delegate) as SimpleType,
             kotlinTypeRefiner.refineType(enhancement)
         )
+
+    override fun toString(): String =
+        "[@EnhancedForWarnings($enhancement)] $origin"
 }
 
 class FlexibleTypeWithEnhancement(
@@ -81,6 +84,9 @@ class FlexibleTypeWithEnhancement(
             kotlinTypeRefiner.refineType(origin) as FlexibleType,
             kotlinTypeRefiner.refineType(enhancement)
         )
+
+    override fun toString(): String =
+        "[@EnhancedForWarnings($enhancement)] $origin"
 }
 
 fun KotlinType.getEnhancement(): KotlinType? = when (this) {
@@ -147,10 +153,12 @@ fun KotlinType.unwrapEnhancement(): KotlinType = getEnhancement() ?: this
 fun UnwrappedType.inheritEnhancement(origin: KotlinType): UnwrappedType = wrapEnhancement(origin.getEnhancement())
 
 fun UnwrappedType.wrapEnhancement(enhancement: KotlinType?): UnwrappedType {
+    if (this is TypeWithEnhancement) {
+        return origin.wrapEnhancement(enhancement)
+    }
     if (enhancement == null) {
         return this
     }
-
     return when (this) {
         is SimpleType -> SimpleTypeWithEnhancement(this, enhancement)
         is FlexibleType -> FlexibleTypeWithEnhancement(this, enhancement)


### PR DESCRIPTION
Fixes KT-47854, but I'm not sure the root cause is addressed. If it was possible to create a `CapturedType(*)?` (not `CapturedType(*)..CapturedType(*)?`) with an enhancement of `CapturedType(*)`, the type approximator would still break.