### PR TITLE
Allow parameter annotation for lambda expression

### DIFF
--- a/compiler/psi/src/org/jetbrains/kotlin/parsing/KotlinExpressionParsing.java
+++ b/compiler/psi/src/org/jetbrains/kotlin/parsing/KotlinExpressionParsing.java
@@ -1234,7 +1234,13 @@ public class KotlinExpressionParsing extends AbstractKotlinParsing {
             }
             PsiBuilder.Marker parameter = mark();
 
+            PsiBuilder.Marker modifiers = mark();
             boolean annotationExists = myKotlinParsing.parseAnnotations(DEFAULT);
+            if (annotationExists) {
+                modifiers.done(MODIFIER_LIST);
+            } else {
+                modifiers.drop();
+            }
             if (at(COLON)) {
                 error("Expecting parameter name");
             }

--- a/compiler/psi/src/org/jetbrains/kotlin/parsing/KotlinExpressionParsing.java
+++ b/compiler/psi/src/org/jetbrains/kotlin/parsing/KotlinExpressionParsing.java
@@ -1144,7 +1144,7 @@ public class KotlinExpressionParsing extends AbstractKotlinParsing {
             advance(); // ARROW
             paramsFound = true;
         }
-        else if (at(IDENTIFIER) || at(COLON) || at(LPAR)) {
+        else if (at(IDENTIFIER) || at(COLON) || at(LPAR) || at(AT)) {
             // Try to parse a simple name list followed by an ARROW
             //   {a -> ...}
             //   {a, b -> ...}
@@ -1234,10 +1234,12 @@ public class KotlinExpressionParsing extends AbstractKotlinParsing {
             }
             PsiBuilder.Marker parameter = mark();
 
+            boolean annotationExists = myKotlinParsing.parseAnnotations(DEFAULT);
             if (at(COLON)) {
                 error("Expecting parameter name");
             }
-            else if (at(LPAR)) {
+            // multiVariableDeclaration after annotation is not allowed
+            else if (!annotationExists && at(LPAR)) {
                 PsiBuilder.Marker destructuringDeclaration = mark();
                 myKotlinParsing.parseMultiDeclarationName(TOKEN_SET_TO_FOLLOW_AFTER_DESTRUCTURING_DECLARATION_IN_LAMBDA);
                 destructuringDeclaration.done(DESTRUCTURING_DECLARATION);


### PR DESCRIPTION
fixes KT-17882

Sorry, I couldn't found the best way to implement tests so can you help me or can you add tests for this?

I've tested that
- dumped IR () has annotations
- compiled code with kotlinc has annotations for parameters
with
```
fun main(args: Array<String>) {}

typealias Func = (Pair<String, String>) -> Unit;

fun test(@Ann list: List<Pair<String, String>>): (Pair<String, String>) -> Unit {
    val v0: Func = { @Ann test -> }
    //val v1: Func = { @Ann (test1, test2) -> }
    val v2: Func = { (@Ann test1, test2) -> }
    return if (list.isEmpty()) v0 else v2
}

annotation class Ann()
```