### PR TITLE
JVM_IR: use substituted return type when lowering inline references

### DIFF
--- a/compiler/testData/codegen/box/callableReference/arrayConstructor.kt
+++ b/compiler/testData/codegen/box/callableReference/arrayConstructor.kt
@@ -1,6 +1,9 @@
 // WITH_RUNTIME
 
 fun g(b: (Int, (Int) -> String) -> Array<String>): Array<String> =
-    b(1) { "OK" }
+    b(1) { "O" }
 
-fun box(): String = g(::Array)[0]
+inline fun h(b: (Int, (Int) -> String) -> Array<String>): Array<String> =
+    b(1) { "K" }
+
+fun box(): String = g(::Array)[0] + h(::Array)[0]


### PR DESCRIPTION
Basically the same thing as #4418.

#KT-48267 Fixed