### PR TITLE
FIR: rewrite inference for bare type parameters again

### DIFF
--- a/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsTestGenerated.java
@@ -4321,6 +4321,12 @@ public class FirOldFrontendDiagnosticsTestGenerated extends AbstractFirDiagnosti
                 }
 
                 @Test
+                @TestMetadata("IntermediateSubstitution.kt")
+                public void testIntermediateSubstitution() throws Exception {
+                    runTest("compiler/testData/diagnostics/tests/cast/bare/IntermediateSubstitution.kt");
+                }
+
+                @Test
                 @TestMetadata("NullableAs.kt")
                 public void testNullableAs() throws Exception {
                     runTest("compiler/testData/diagnostics/tests/cast/bare/NullableAs.kt");
@@ -4372,6 +4378,12 @@ public class FirOldFrontendDiagnosticsTestGenerated extends AbstractFirDiagnosti
                 @TestMetadata("UnrelatedIs.kt")
                 public void testUnrelatedIs() throws Exception {
                     runTest("compiler/testData/diagnostics/tests/cast/bare/UnrelatedIs.kt");
+                }
+
+                @Test
+                @TestMetadata("UnusedIntermediate.kt")
+                public void testUnusedIntermediate() throws Exception {
+                    runTest("compiler/testData/diagnostics/tests/cast/bare/UnusedIntermediate.kt");
                 }
             }
 

--- a/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsWithLightTreeTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsWithLightTreeTestGenerated.java
@@ -4321,6 +4321,12 @@ public class FirOldFrontendDiagnosticsWithLightTreeTestGenerated extends Abstrac
                 }
 
                 @Test
+                @TestMetadata("IntermediateSubstitution.kt")
+                public void testIntermediateSubstitution() throws Exception {
+                    runTest("compiler/testData/diagnostics/tests/cast/bare/IntermediateSubstitution.kt");
+                }
+
+                @Test
                 @TestMetadata("NullableAs.kt")
                 public void testNullableAs() throws Exception {
                     runTest("compiler/testData/diagnostics/tests/cast/bare/NullableAs.kt");
@@ -4372,6 +4378,12 @@ public class FirOldFrontendDiagnosticsWithLightTreeTestGenerated extends Abstrac
                 @TestMetadata("UnrelatedIs.kt")
                 public void testUnrelatedIs() throws Exception {
                     runTest("compiler/testData/diagnostics/tests/cast/bare/UnrelatedIs.kt");
+                }
+
+                @Test
+                @TestMetadata("UnusedIntermediate.kt")
+                public void testUnusedIntermediate() throws Exception {
+                    runTest("compiler/testData/diagnostics/tests/cast/bare/UnusedIntermediate.kt");
                 }
             }
 

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/FirDefaultErrorMessages.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/FirDefaultErrorMessages.kt
@@ -21,6 +21,7 @@ import org.jetbrains.kotlin.fir.analysis.diagnostics.FirDiagnosticRenderers.NULL
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirDiagnosticRenderers.RENDER_CLASS_OR_OBJECT
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirDiagnosticRenderers.RENDER_CLASS_OR_OBJECT_NAME
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirDiagnosticRenderers.RENDER_COLLECTION_OF_TYPES
+import org.jetbrains.kotlin.fir.analysis.diagnostics.FirDiagnosticRenderers.RENDER_STAR_PROJECTED_TYPE
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirDiagnosticRenderers.RENDER_TYPE
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirDiagnosticRenderers.SYMBOL
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirDiagnosticRenderers.SYMBOLS
@@ -305,6 +306,7 @@ import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.NO_RECEIVER_ALLOW
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.NO_RETURN_IN_FUNCTION_WITH_BLOCK_BODY
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.NO_SET_METHOD
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.NO_THIS
+import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.NO_TYPE_ARGUMENTS_ON_RHS
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.NO_VALUE_FOR_PARAMETER
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.NULLABLE_INLINE_PARAMETER
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.NULLABLE_SUPERTYPE
@@ -812,12 +814,15 @@ class FirDefaultErrorMessages {
                 RENDER_TYPE
             )
 
+            val wrongNumberOfTypeArguments =
+                "{0,choice,0#No type arguments|1#One type argument|1<{0,number,integer} type arguments} expected"
             map.put(TYPE_ARGUMENTS_NOT_ALLOWED, "Type arguments are not allowed for type parameters") // *
+            map.put(WRONG_NUMBER_OF_TYPE_ARGUMENTS, "$wrongNumberOfTypeArguments for {1}", null, RENDER_CLASS_OR_OBJECT_NAME)
             map.put(
-                WRONG_NUMBER_OF_TYPE_ARGUMENTS,
-                "{0,choice,0#No type arguments|1#One type argument|1<{0,number,integer} type arguments} expected for {1}",
+                NO_TYPE_ARGUMENTS_ON_RHS,
+                "$wrongNumberOfTypeArguments. Use ''{1}'' if you don''t want to pass type arguments",
                 null,
-                RENDER_CLASS_OR_OBJECT_NAME
+                RENDER_STAR_PROJECTED_TYPE
             )
             map.put(
                 OUTER_CLASS_ARGUMENTS_REQUIRED,

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/FirDiagnosticRenderers.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/FirDiagnosticRenderers.kt
@@ -5,7 +5,6 @@
 
 package org.jetbrains.kotlin.fir.analysis.diagnostics
 
-import com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.Visibility
 import org.jetbrains.kotlin.diagnostics.WhenMissingCase
@@ -14,11 +13,9 @@ import org.jetbrains.kotlin.diagnostics.rendering.Renderer
 import org.jetbrains.kotlin.fir.FirElement
 import org.jetbrains.kotlin.fir.FirModuleData
 import org.jetbrains.kotlin.fir.FirRenderer
-import org.jetbrains.kotlin.fir.declarations.*
+import org.jetbrains.kotlin.fir.analysis.checkers.typeParameterSymbols
 import org.jetbrains.kotlin.fir.declarations.utils.*
 import org.jetbrains.kotlin.fir.render
-import org.jetbrains.kotlin.fir.resolve.dfa.cfg.isLocalClassOrAnonymousObject
-import org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.firUnsafe
 import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
 import org.jetbrains.kotlin.fir.symbols.SymbolInternals
 import org.jetbrains.kotlin.fir.symbols.impl.*
@@ -97,6 +94,18 @@ object FirDiagnosticRenderers {
             else -> AssertionError("Unexpected class: $firClassLike")
         }
         "$prefix '$name'"
+    }
+
+    val RENDER_STAR_PROJECTED_TYPE = Renderer { firClassLike: FirClassLikeSymbol<*> ->
+        val name = firClassLike.classId.relativeClassName.shortName().asString()
+        val typeParameterCount = firClassLike.typeParameterSymbols?.size ?: 0
+        if (typeParameterCount == 0) return@Renderer name
+        StringBuilder().apply {
+            append(name)
+            append('<')
+            repeat(typeParameterCount - 1) { append("*, ") }
+            append("*>")
+        }.toString()
     }
 
     val RENDER_TYPE = Renderer { t: ConeKotlinType ->

--- a/compiler/testData/diagnostics/tests/cast/bare/IntermediateSubstitution.fir.kt
+++ b/compiler/testData/diagnostics/tests/cast/bare/IntermediateSubstitution.fir.kt
@@ -1,0 +1,8 @@
+interface A<T, V, U>
+interface B<U, T, W> : A<T, Int, U>
+typealias C<X> = B<X, X, Any?>
+
+fun a(x: A<String, Int, String>) = x as C
+fun b(x: A<String, Int, Any?>) = x as <!NO_TYPE_ARGUMENTS_ON_RHS!>C<!>
+fun c(x: A<String, Any?, String>) = x as C
+fun d(x: A<String, Int, Any?>) = x as <!NO_TYPE_ARGUMENTS_ON_RHS!>B<!>

--- a/compiler/testData/diagnostics/tests/cast/bare/IntermediateSubstitution.kt
+++ b/compiler/testData/diagnostics/tests/cast/bare/IntermediateSubstitution.kt
@@ -1,0 +1,8 @@
+interface A<T, V, U>
+interface B<U, T, W> : A<T, Int, U>
+typealias C<X> = B<X, X, Any?>
+
+fun a(x: A<String, Int, String>) = x as <!WRONG_NUMBER_OF_TYPE_ARGUMENTS!>C<!>
+fun b(x: A<String, Int, Any?>) = x as <!WRONG_NUMBER_OF_TYPE_ARGUMENTS!>C<!>
+fun c(x: A<String, Any?, String>) = x as <!WRONG_NUMBER_OF_TYPE_ARGUMENTS!>C<!>
+fun d(x: A<String, Int, Any?>) = x as <!NO_TYPE_ARGUMENTS_ON_RHS!>B<!>

--- a/compiler/testData/diagnostics/tests/cast/bare/IntermediateSubstitution.txt
+++ b/compiler/testData/diagnostics/tests/cast/bare/IntermediateSubstitution.txt
@@ -1,0 +1,19 @@
+package
+
+public fun a(/*0*/ x: A<kotlin.String, kotlin.Int, kotlin.String>): [ERROR : C]
+public fun b(/*0*/ x: A<kotlin.String, kotlin.Int, kotlin.Any?>): [ERROR : C]
+public fun c(/*0*/ x: A<kotlin.String, kotlin.Any?, kotlin.String>): [ERROR : C]
+public fun d(/*0*/ x: A<kotlin.String, kotlin.Int, kotlin.Any?>): B<kotlin.Any?, kotlin.String, *>
+
+public interface A</*0*/ T, /*1*/ V, /*2*/ U> {
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public interface B</*0*/ U, /*1*/ T, /*2*/ W> : A<T, kotlin.Int, U> {
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+public typealias C</*0*/ X> = B<X, X, kotlin.Any?>

--- a/compiler/testData/diagnostics/tests/cast/bare/UnusedIntermediate.kt
+++ b/compiler/testData/diagnostics/tests/cast/bare/UnusedIntermediate.kt
@@ -1,0 +1,7 @@
+// FIR_IDENTICAL
+interface A<T>
+interface B<T, V> : A<T>
+interface C<T> : B<T, Any?>
+
+fun foo(x: A<Int>) = x as C
+fun bar(x: A<Int>) = x as <!NO_TYPE_ARGUMENTS_ON_RHS!>B<!>

--- a/compiler/testData/diagnostics/tests/cast/bare/UnusedIntermediate.txt
+++ b/compiler/testData/diagnostics/tests/cast/bare/UnusedIntermediate.txt
@@ -1,0 +1,22 @@
+package
+
+public fun bar(/*0*/ x: A<kotlin.Int>): B<kotlin.Int, *>
+public fun foo(/*0*/ x: A<kotlin.Int>): C<kotlin.Int>
+
+public interface A</*0*/ T> {
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public interface B</*0*/ T, /*1*/ V> : A<T> {
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public interface C</*0*/ T> : B<T, kotlin.Any?> {
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/DiagnosticTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/DiagnosticTestGenerated.java
@@ -4327,6 +4327,12 @@ public class DiagnosticTestGenerated extends AbstractDiagnosticTest {
                 }
 
                 @Test
+                @TestMetadata("IntermediateSubstitution.kt")
+                public void testIntermediateSubstitution() throws Exception {
+                    runTest("compiler/testData/diagnostics/tests/cast/bare/IntermediateSubstitution.kt");
+                }
+
+                @Test
                 @TestMetadata("NullableAs.kt")
                 public void testNullableAs() throws Exception {
                     runTest("compiler/testData/diagnostics/tests/cast/bare/NullableAs.kt");
@@ -4378,6 +4384,12 @@ public class DiagnosticTestGenerated extends AbstractDiagnosticTest {
                 @TestMetadata("UnrelatedIs.kt")
                 public void testUnrelatedIs() throws Exception {
                     runTest("compiler/testData/diagnostics/tests/cast/bare/UnrelatedIs.kt");
+                }
+
+                @Test
+                @TestMetadata("UnusedIntermediate.kt")
+                public void testUnusedIntermediate() throws Exception {
+                    runTest("compiler/testData/diagnostics/tests/cast/bare/UnusedIntermediate.kt");
                 }
             }
 


### PR DESCRIPTION
Intermediate results can contain uninferred values, so long as they are not used for the final result.

Also, the new code is hopefully clearer - that was some horrendous use of extension receivers. Wonder who wrote that? Not me, right?

 #KT-48305 Fixed