### PR TITLE
Parcelize: Fix diagnostics for parcelable value classes

### DIFF
--- a/plugins/parcelize/parcelize-compiler/src/org/jetbrains/kotlin/parcelize/ParcelizeDeclarationChecker.kt
+++ b/plugins/parcelize/parcelize-compiler/src/org/jetbrains/kotlin/parcelize/ParcelizeDeclarationChecker.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlin.descriptors.SimpleFunctionDescriptor
 import org.jetbrains.kotlin.descriptors.annotations.Annotations
 import org.jetbrains.kotlin.diagnostics.DiagnosticSink
 import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.load.kotlin.TypeMappingMode
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.parcelize.diagnostic.ErrorsParcelize
 import org.jetbrains.kotlin.parcelize.serializers.ParcelSerializer
@@ -234,13 +235,13 @@ open class ParcelizeDeclarationChecker : DeclarationChecker {
         val type = descriptor.type
 
         if (!type.isError && !containerClass.hasCustomParceler()) {
-            val asmType = typeMapper.mapType(type)
+            val asmType = typeMapper.mapType(type, mode = TypeMappingMode.CLASS_DECLARATION)
 
             try {
                 val parcelers = getTypeParcelers(descriptor.annotations) + getTypeParcelers(containerClass.annotations)
                 val context = ParcelSerializer.ParcelSerializerContext(
                     typeMapper,
-                    typeMapper.mapType(containerClass.defaultType),
+                    typeMapper.mapClass(containerClass),
                     parcelers,
                     FrameMap()
                 )

--- a/plugins/parcelize/parcelize-compiler/testData/box/valueClassWrapper.kt
+++ b/plugins/parcelize/parcelize-compiler/testData/box/valueClassWrapper.kt
@@ -1,0 +1,37 @@
+// WITH_RUNTIME
+// See: https://issuetracker.google.com/197890119
+// IGNORE_BACKEND: JVM
+
+@file:JvmName("TestKt")
+package test
+
+import kotlinx.parcelize.*
+import android.os.Parcel
+import android.os.Parcelable
+
+@Parcelize
+@JvmInline
+value class ListWrapper(val list: List<String>) : Parcelable
+
+@Parcelize
+data class Wrapper(val listWrapper: ListWrapper) : Parcelable
+
+@Parcelize
+data class NullableWrapper(val listWrapper: ListWrapper?) : Parcelable
+
+fun box() = parcelTest { parcel ->
+    val data = Wrapper(ListWrapper(listOf("O", "K")))
+    val none = NullableWrapper(null)
+    data.writeToParcel(parcel, 0)
+    none.writeToParcel(parcel, 0)
+
+    val bytes = parcel.marshall()
+    parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
+
+    val data2 = readFromParcel<Wrapper>(parcel)
+    assert(data2 == data)
+
+    val none2 = readFromParcel<NullableWrapper>(parcel)
+    assert(none2 == none)
+}

--- a/plugins/parcelize/parcelize-compiler/tests/org/jetbrains/kotlin/parcelize/test/ParcelizeBoxTestGenerated.java
+++ b/plugins/parcelize/parcelize-compiler/tests/org/jetbrains/kotlin/parcelize/test/ParcelizeBoxTestGenerated.java
@@ -370,6 +370,11 @@ public class ParcelizeBoxTestGenerated extends AbstractParcelizeBoxTest {
         runTest("plugins/parcelize/parcelize-compiler/testData/box/typeParameters.kt");
     }
 
+    @TestMetadata("valueClassWrapper.kt")
+    public void testValueClassWrapper() throws Exception {
+        runTest("plugins/parcelize/parcelize-compiler/testData/box/valueClassWrapper.kt");
+    }
+
     @TestMetadata("valueClasses.kt")
     public void testValueClasses() throws Exception {
         runTest("plugins/parcelize/parcelize-compiler/testData/box/valueClasses.kt");

--- a/plugins/parcelize/parcelize-compiler/tests/org/jetbrains/kotlin/parcelize/test/ParcelizeIrBoxTestGenerated.java
+++ b/plugins/parcelize/parcelize-compiler/tests/org/jetbrains/kotlin/parcelize/test/ParcelizeIrBoxTestGenerated.java
@@ -370,6 +370,11 @@ public class ParcelizeIrBoxTestGenerated extends AbstractParcelizeIrBoxTest {
         runTest("plugins/parcelize/parcelize-compiler/testData/box/typeParameters.kt");
     }
 
+    @TestMetadata("valueClassWrapper.kt")
+    public void testValueClassWrapper() throws Exception {
+        runTest("plugins/parcelize/parcelize-compiler/testData/box/valueClassWrapper.kt");
+    }
+
     @TestMetadata("valueClasses.kt")
     public void testValueClasses() throws Exception {
         runTest("plugins/parcelize/parcelize-compiler/testData/box/valueClasses.kt");


### PR DESCRIPTION
While Parcelize supports value classes in the backend, there was still an issue with frontend diagnostics, reported [here](https://issuetracker.google.com/197890119). This PR addresses the frontend diagnostics by not unfolding inline classes before checking whether they are parcelable.