### PR TITLE
Introduced zipAll() for KT-13017

### DIFF
--- a/kotlin-native/runtime/src/main/kotlin/generated/_ArraysNative.kt
+++ b/kotlin-native/runtime/src/main/kotlin/generated/_ArraysNative.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 

--- a/kotlin-native/runtime/src/main/kotlin/generated/_CollectionsNative.kt
+++ b/kotlin-native/runtime/src/main/kotlin/generated/_CollectionsNative.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 

--- a/kotlin-native/runtime/src/main/kotlin/generated/_ComparisonsNative.kt
+++ b/kotlin-native/runtime/src/main/kotlin/generated/_ComparisonsNative.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 

--- a/kotlin-native/runtime/src/main/kotlin/generated/_StringsNative.kt
+++ b/kotlin-native/runtime/src/main/kotlin/generated/_StringsNative.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 

--- a/kotlin-native/runtime/src/main/kotlin/generated/_UArraysNative.kt
+++ b/kotlin-native/runtime/src/main/kotlin/generated/_UArraysNative.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 

--- a/libraries/stdlib/common/src/generated/_Collections.kt
+++ b/libraries/stdlib/common/src/generated/_Collections.kt
@@ -3297,6 +3297,26 @@ public inline fun <T, R, V> Iterable<T>.zip(other: Iterable<R>, transform: (a: T
 }
 
 /**
+ * Returns a list of values built from the elements of `this` collection and the [other] collection with the same index
+ * using the provided [transform] function applied to each pair of elements. This function can operation collections of differing
+ * sizes using the provide defaults to fill in missing values.
+ * The returned list has length of the longest collection.
+ * 
+ * @sample samples.collections.Iterables.Operations.zipAllIterableWithTransform
+ */
+public inline fun <T, R, V> Iterable<T>.zipAll(other: Iterable<R>, thisDefault: T, otherDefault: R, transform: (a: T, b: R) -> V): List<V> {
+    val first = iterator()
+    val second = other.iterator()
+    val list = ArrayList<V>(maxOf(collectionSizeOrDefault(10), other.collectionSizeOrDefault(10)))
+    while (first.hasNext() || second.hasNext()) {
+        val thisValue = if (first.hasNext()) first.next() else thisDefault
+        val otherValue = if (second.hasNext()) second.next() else otherDefault
+        list.add(transform(thisValue, otherValue))
+    }
+    return list
+}
+
+/**
  * Returns a list of pairs of each two adjacent elements in this collection.
  * 
  * The returned list is empty if this collection contains less than two elements.

--- a/libraries/stdlib/samples/test/samples/collections/iterables.kt
+++ b/libraries/stdlib/samples/test/samples/collections/iterables.kt
@@ -73,6 +73,14 @@ class Iterables {
         }
 
         @Sample
+        fun zipAllIterableWithTransform() {
+            val listA = listOf("a", "b", "c")
+            val listB = listOf(1, 2, 3, 4)
+            val result = listA.zipAll(listB, "?", "0") { a, b -> "$a$b" }
+            assertPrints(result, "[a1, b2, c3, ?4]")
+        }
+
+        @Sample
         fun partition() {
             data class Person(val name: String, val age: Int) {
                 override fun toString(): String {

--- a/libraries/stdlib/test/collections/CollectionTest.kt
+++ b/libraries/stdlib/test/collections/CollectionTest.kt
@@ -292,6 +292,33 @@ class CollectionTest {
         }
     }
 
+    @Test
+    fun zipAllTransform() {
+        expect(listOf("ab", "bc", "cd")) {
+            listOf("a", "b", "c").zipAll(listOf("b", "c", "d"), "X", "Y") { a, b -> a + b }
+        }
+
+        expect(listOf("ab", "bc", "cY")) {
+            listOf("a", "b", "c").zipAll(listOf("b", "c"), "X", "Y") { a, b -> a + b }
+        }
+
+        expect(listOf("ab", "bc", "Xd")) {
+            listOf("a", "b").zipAll(listOf("b", "c", "d"), "X", "Y") { a, b -> a + b }
+        }
+
+        expect(listOf("Xb", "Xc", "Xd")) {
+            listOf<String>().zipAll(listOf("b", "c", "d"), "X", "Y") { a, b -> a + b }
+        }
+
+        expect(listOf("aY", "bY", "cY")) {
+            listOf("a", "b", "c").zipAll(listOf(), "X", "Y") { a, b -> a + b }
+        }
+
+        expect(listOf()) {
+            listOf<String>().zipAll(listOf(), "X", "Y") { a, b -> a + b }
+        }
+    }
+
     @Test fun partition() {
         val data = listOf("foo", "bar", "something", "xyz")
         val pair = data.partition { it.length == 3 }

--- a/libraries/tools/binary-compatibility-validator/reference-public-api/kotlin-stdlib-runtime-merged.txt
+++ b/libraries/tools/binary-compatibility-validator/reference-public-api/kotlin-stdlib-runtime-merged.txt
@@ -2383,6 +2383,7 @@ public final class kotlin/collections/CollectionsKt {
 	public static final fun zip (Ljava/lang/Iterable;Ljava/lang/Iterable;Lkotlin/jvm/functions/Function2;)Ljava/util/List;
 	public static final fun zip (Ljava/lang/Iterable;[Ljava/lang/Object;)Ljava/util/List;
 	public static final fun zip (Ljava/lang/Iterable;[Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/util/List;
+	public static final fun zipAll (Ljava/lang/Iterable;Ljava/lang/Iterable;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/util/List;
 	public static final fun zipWithNext (Ljava/lang/Iterable;)Ljava/util/List;
 	public static final fun zipWithNext (Ljava/lang/Iterable;Lkotlin/jvm/functions/Function2;)Ljava/util/List;
 }

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Generators.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Generators.kt
@@ -1278,6 +1278,38 @@ object Generators : TemplateGroupBase() {
         }
     }
 
+    val f_zipAll_transform = fn("zipAll(other: Iterable<R>, thisDefault: T, otherDefault: R, transform: (a: T, b: R) -> V)") {
+        include(Iterables)
+    } builder {
+        inline()
+        doc {
+            """
+            Returns a list of values built from the elements of `this` ${f.collection} and the [other] collection with the same index
+            using the provided [transform] function applied to each pair of elements. This function can operation collections of differing 
+            sizes using the provide defaults to fill in missing values.
+            The returned list has length of the longest collection.
+            """
+        }
+        sample("samples.collections.Iterables.Operations.zipAllIterableWithTransform")
+        typeParam("T")
+        typeParam("R")
+        typeParam("V")
+        returns("List<V>")
+        body {
+            """
+            val first = iterator()
+            val second = other.iterator()
+            val list = ArrayList<V>(maxOf(collectionSizeOrDefault(10), other.collectionSizeOrDefault(10)))
+            while (first.hasNext() || second.hasNext()) {
+                val thisValue = if (first.hasNext()) first.next() else thisDefault
+                val otherValue = if (second.hasNext()) second.next() else otherDefault
+                list.add(transform(thisValue, otherValue))
+            }
+            return list
+            """
+        }
+    }
+
     // documentation helpers
 
     private val Family.snapshotResult: String


### PR DESCRIPTION
Adding zipAll function to address https://youtrack.jetbrains.com/issue/KT-13017

Code, docs, and samples are written to be constant with existing zip function below. 

https://github.com/JetBrains/kotlin/blob/f62ffeaa0ae46a5c9df248d6ef18ded75840026d/libraries/stdlib/common/src/generated/_Collections.kt#L3254-L3270