### PR TITLE
FIR: join KotlinDeserializedJvmSymbolsProvider and JavaSymbolProvider

### DIFF
--- a/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/PsiBasedProjectEnvironment.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/PsiBasedProjectEnvironment.kt
@@ -14,14 +14,13 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.ProjectScope
 import org.jetbrains.kotlin.asJava.finder.JavaElementFinder
-import org.jetbrains.kotlin.fir.FirModuleData
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.java.FirJavaElementFinder
-import org.jetbrains.kotlin.fir.java.JavaSymbolProvider
 import org.jetbrains.kotlin.fir.session.environment.AbstractProjectEnvironment
 import org.jetbrains.kotlin.fir.session.environment.AbstractProjectFileSearchScope
 import org.jetbrains.kotlin.load.java.JavaClassFinder
 import org.jetbrains.kotlin.load.java.JavaClassFinderImpl
+import org.jetbrains.kotlin.load.java.createJavaClassFinder
 import org.jetbrains.kotlin.load.kotlin.KotlinClassFinder
 import org.jetbrains.kotlin.load.kotlin.PackagePartProvider
 import org.jetbrains.kotlin.load.kotlin.VirtualFileFinderFactory
@@ -48,22 +47,11 @@ class PsiBasedProjectEnvironment(
     val localFileSystem: VirtualFileSystem,
     val getPackagePartProviderFn: (GlobalSearchScope) -> PackagePartProvider
 ) : AbstractProjectEnvironment {
-
     override fun getKotlinClassFinder(fileSearchScope: AbstractProjectFileSearchScope): KotlinClassFinder =
         VirtualFileFinderFactory.getInstance(project).create(fileSearchScope.asPsiSearchScope())
 
     override fun getJavaClassFinder(fileSearchScope: AbstractProjectFileSearchScope): JavaClassFinder =
-        JavaClassFinderImpl().apply {
-            this.setProjectInstance(project)
-            this.setScope(fileSearchScope.asPsiSearchScope())
-        }
-
-    override fun getJavaSymbolProvider(
-        firSession: FirSession,
-        baseModuleData: FirModuleData,
-        fileSearchScope: AbstractProjectFileSearchScope
-    ): JavaSymbolProvider =
-        JavaSymbolProvider(firSession, baseModuleData, project, fileSearchScope.asPsiSearchScope())
+        project.createJavaClassFinder(fileSearchScope.asPsiSearchScope())
 
     override fun getJavaModuleResolver(): JavaModuleResolver =
         JavaModuleResolver.getInstance(project)

--- a/compiler/fir/analysis-tests/legacy-fir-tests/tests/org/jetbrains/kotlin/fir/java/AbstractFirTypeEnhancementTest.kt
+++ b/compiler/fir/analysis-tests/legacy-fir-tests/tests/org/jetbrains/kotlin/fir/java/AbstractFirTypeEnhancementTest.kt
@@ -23,7 +23,6 @@ import org.jetbrains.kotlin.codegen.forTestCompile.ForTestCompileRuntime
 import org.jetbrains.kotlin.fir.FirRenderer
 import org.jetbrains.kotlin.fir.createSessionForTests
 import org.jetbrains.kotlin.fir.java.declarations.FirJavaClass
-import org.jetbrains.kotlin.fir.resolve.providers.impl.FirCompositeSymbolProvider
 import org.jetbrains.kotlin.fir.resolve.symbolProvider
 import org.jetbrains.kotlin.fir.symbols.SymbolInternals
 import org.jetbrains.kotlin.name.ClassId
@@ -142,13 +141,10 @@ abstract class AbstractFirTypeEnhancementTest : KtUsefulTestCase() {
 
         val javaFirDump = StringBuilder().also { builder ->
             val renderer = FirRenderer(builder)
-            val symbolProvider = session.symbolProvider as FirCompositeSymbolProvider
-            val javaProvider = symbolProvider.providers.filterIsInstance<JavaSymbolProvider>().first()
-
             val processedJavaClasses = mutableSetOf<FirJavaClass>()
             fun processClassWithChildren(psiClass: PsiClass, parentFqName: FqName) {
                 val classId = psiClass.classId(parentFqName)
-                val javaClass = javaProvider.getClassLikeSymbolByClassId(classId)?.fir
+                val javaClass = session.symbolProvider.getClassLikeSymbolByClassId(classId)?.fir
                     ?: throw AssertionError(classId.asString())
                 if (javaClass !is FirJavaClass || javaClass in processedJavaClasses) {
                     return

--- a/compiler/fir/checkers/checkers.jvm/src/org/jetbrains/kotlin/fir/analysis/jvm/checkers/declaration/FirRepeatableAnnotationChecker.kt
+++ b/compiler/fir/checkers/checkers.jvm/src/org/jetbrains/kotlin/fir/analysis/jvm/checkers/declaration/FirRepeatableAnnotationChecker.kt
@@ -21,7 +21,7 @@ import org.jetbrains.kotlin.fir.analysis.jvm.checkers.isJvm6
 import org.jetbrains.kotlin.fir.declarations.*
 import org.jetbrains.kotlin.fir.declarations.utils.classId
 import org.jetbrains.kotlin.fir.expressions.*
-import org.jetbrains.kotlin.fir.java.JavaSymbolProvider
+import org.jetbrains.kotlin.fir.java.JavaClassConverter
 import org.jetbrains.kotlin.fir.languageVersionSettings
 import org.jetbrains.kotlin.fir.resolve.defaultType
 import org.jetbrains.kotlin.fir.resolve.symbolProvider
@@ -166,7 +166,7 @@ object FirRepeatableAnnotationChecker : FirAnnotatedDeclarationChecker() {
                 ?: return
 
         val valueParameterSymbols = containerCtor.valueParameterSymbols
-        val parameterName = JavaSymbolProvider.VALUE_METHOD_NAME
+        val parameterName = JavaClassConverter.VALUE_METHOD_NAME
         val value = valueParameterSymbols.find { it.name == parameterName }
         if (value == null || !value.resolvedReturnTypeRef.isArrayType ||
             value.resolvedReturnTypeRef.type.typeArguments.single().type != annotationClass.defaultType()

--- a/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/FirSessionFactory.kt
+++ b/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/FirSessionFactory.kt
@@ -153,8 +153,7 @@ object FirSessionFactory {
                     kotlinScopeProvider,
                     it.packagePartProvider,
                     projectEnvironment.getKotlinClassFinder(it.scope),
-                    projectEnvironment.getJavaClassFinder(it.scope),
-                    projectEnvironment.getJavaSymbolProvider(this, moduleData, it.scope)
+                    projectEnvironment.getJavaClassFinder(it.scope)
                 )
             }
 
@@ -166,7 +165,7 @@ object FirSessionFactory {
                     listOfNotNull(
                         firProvider.symbolProvider,
                         symbolProviderForBinariesFromIncrementalCompilation,
-                        JavaSymbolProviderWrapper(this, projectEnvironment.getJavaSymbolProvider(this, moduleData, scope)),
+                        JavaSymbolProviderWrapper(this, moduleData, projectEnvironment.getJavaClassFinder(scope)),
                         dependenciesSymbolProvider,
                     )
                 )
@@ -214,8 +213,7 @@ object FirSessionFactory {
                 kotlinScopeProvider,
                 packagePartProvider,
                 projectEnvironment.getKotlinClassFinder(scope),
-                projectEnvironment.getJavaClassFinder(scope),
-                projectEnvironment.getJavaSymbolProvider(this, moduleDataProvider.allModuleData.last(), scope)
+                projectEnvironment.getJavaClassFinder(scope)
             )
 
             val builtinsModuleData = createModuleDataForBuiltins(

--- a/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/FirSessionFactory.kt
+++ b/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/FirSessionFactory.kt
@@ -24,7 +24,7 @@ import org.jetbrains.kotlin.fir.extensions.extensionService
 import org.jetbrains.kotlin.fir.extensions.registerExtensions
 import org.jetbrains.kotlin.fir.java.FirCliSession
 import org.jetbrains.kotlin.fir.java.FirProjectSessionProvider
-import org.jetbrains.kotlin.fir.java.JavaSymbolProviderWrapper
+import org.jetbrains.kotlin.fir.java.JavaSymbolProvider
 import org.jetbrains.kotlin.fir.java.deserialization.KotlinDeserializedJvmSymbolsProvider
 import org.jetbrains.kotlin.fir.resolve.providers.FirDependenciesSymbolProvider
 import org.jetbrains.kotlin.fir.resolve.providers.FirProvider
@@ -165,7 +165,7 @@ object FirSessionFactory {
                     listOfNotNull(
                         firProvider.symbolProvider,
                         symbolProviderForBinariesFromIncrementalCompilation,
-                        JavaSymbolProviderWrapper(this, moduleData, projectEnvironment.getJavaClassFinder(scope)),
+                        JavaSymbolProvider(this, moduleData, projectEnvironment.getJavaClassFinder(scope)),
                         dependenciesSymbolProvider,
                     )
                 )

--- a/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/environment/AbstractProjectEnvironment.kt
+++ b/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/environment/AbstractProjectEnvironment.kt
@@ -5,9 +5,7 @@
 
 package org.jetbrains.kotlin.fir.session.environment
 
-import org.jetbrains.kotlin.fir.FirModuleData
 import org.jetbrains.kotlin.fir.FirSession
-import org.jetbrains.kotlin.fir.java.JavaSymbolProvider
 import org.jetbrains.kotlin.load.java.JavaClassFinder
 import org.jetbrains.kotlin.load.kotlin.KotlinClassFinder
 import org.jetbrains.kotlin.load.kotlin.PackagePartProvider
@@ -40,16 +38,9 @@ interface AbstractProjectFileSearchScope {
 }
 
 interface AbstractProjectEnvironment {
-
     fun getKotlinClassFinder(fileSearchScope: AbstractProjectFileSearchScope): KotlinClassFinder
 
     fun getJavaClassFinder(fileSearchScope: AbstractProjectFileSearchScope): JavaClassFinder
-
-    fun getJavaSymbolProvider(
-        firSession: FirSession,
-        baseModuleData: FirModuleData,
-        fileSearchScope: AbstractProjectFileSearchScope
-    ): JavaSymbolProvider
 
     fun getJavaModuleResolver(): JavaModuleResolver
 

--- a/compiler/fir/fir-deserialization/src/org/jetbrains/kotlin/fir/deserialization/AbstractFirDeserializedSymbolsProvider.kt
+++ b/compiler/fir/fir-deserialization/src/org/jetbrains/kotlin/fir/deserialization/AbstractFirDeserializedSymbolsProvider.kt
@@ -187,7 +187,7 @@ abstract class AbstractFirDeserializedSymbolsProvider(
 
     protected open fun shouldLoadParentsFirst(classId: ClassId): Boolean = false
 
-    protected open fun getClass(
+    protected fun getClass(
         classId: ClassId,
         parentContext: FirDeserializationContext? = null
     ): FirRegularClassSymbol? {

--- a/compiler/fir/fir-deserialization/src/org/jetbrains/kotlin/fir/deserialization/AbstractFirDeserializedSymbolsProvider.kt
+++ b/compiler/fir/fir-deserialization/src/org/jetbrains/kotlin/fir/deserialization/AbstractFirDeserializedSymbolsProvider.kt
@@ -91,6 +91,10 @@ abstract class AbstractFirDeserializedSymbolsProvider(
     // ------------------------ Deserialization methods ------------------------
 
     sealed class ClassMetadataFindResult {
+        data class NoMetadata(
+            val classPostProcessor: DeserializedClassPostProcessor
+        ) : ClassMetadataFindResult()
+
         data class Metadata(
             val nameResolver: NameResolver,
             val classProto: ProtoBuf.Class,
@@ -125,6 +129,7 @@ abstract class AbstractFirDeserializedSymbolsProvider(
         parentContext: FirDeserializationContext? = null
     ): Pair<FirRegularClassSymbol?, DeserializedClassPostProcessor?> {
         return when (val result = extractClassMetadata(classId, parentContext)) {
+            is ClassMetadataFindResult.NoMetadata -> FirRegularClassSymbol(classId) to result.classPostProcessor
             is ClassMetadataFindResult.Metadata -> {
                 val (nameResolver, classProto, annotationDeserializer, containingLibrary, sourceElement, postProcessor) = result
                 val moduleData = moduleDataProvider.getModuleData(containingLibrary) ?: return null to null

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -22947,6 +22947,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         }
 
         @Test
+        @TestMetadata("javaOuterClassDependsOnInner.kt")
+        public void testJavaOuterClassDependsOnInner() throws Exception {
+            runTest("compiler/testData/codegen/box/javaInterop/javaOuterClassDependsOnInner.kt");
+        }
+
+        @Test
         @TestMetadata("kt43217.kt")
         public void testKt43217() throws Exception {
             runTest("compiler/testData/codegen/box/javaInterop/kt43217.kt");

--- a/compiler/fir/java/src/org/jetbrains/kotlin/fir/java/JavaScopeProvider.kt
+++ b/compiler/fir/java/src/org/jetbrains/kotlin/fir/java/JavaScopeProvider.kt
@@ -25,9 +25,7 @@ import org.jetbrains.kotlin.fir.types.constructClassLikeType
 import org.jetbrains.kotlin.name.StandardClassIds
 import org.jetbrains.kotlin.utils.DFS
 
-class JavaScopeProvider(
-    val symbolProvider: JavaSymbolProvider
-) : FirScopeProvider() {
+object JavaScopeProvider : FirScopeProvider() {
     override fun getUseSiteMemberScope(
         klass: FirClass,
         useSiteSession: FirSession,
@@ -74,7 +72,7 @@ class JavaScopeProvider(
         return if (regularClass is FirJavaClass) useSiteSession.declaredMemberScopeWithLazyNestedScope(
             regularClass,
             existingNames = regularClass.existingNestedClassifierNames,
-            symbolProvider = symbolProvider
+            symbolProvider = useSiteSession.symbolProvider
         ) else useSiteSession.declaredMemberScope(regularClass)
     }
 

--- a/compiler/fir/java/src/org/jetbrains/kotlin/fir/java/JavaSymbolProvider.kt
+++ b/compiler/fir/java/src/org/jetbrains/kotlin/fir/java/JavaSymbolProvider.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.fir.java
+
+import com.intellij.openapi.progress.ProcessCanceledException
+import org.jetbrains.kotlin.fir.FirModuleData
+import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.caches.firCachesFactory
+import org.jetbrains.kotlin.fir.resolve.providers.FirSymbolProvider
+import org.jetbrains.kotlin.fir.resolve.providers.FirSymbolProviderInternals
+import org.jetbrains.kotlin.fir.symbols.impl.FirCallableSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
+import org.jetbrains.kotlin.load.java.JavaClassFinder
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
+
+// This symbol provider only loads JVM classes *not* annotated with Kotlin `@Metadata` annotation.
+// Use it in application sessions for loading classes from Java files listed on the command line.
+// For library and incremental compilation sessions use `KotlinDeserializedJvmSymbolsProvider`
+// in order to load Kotlin classes as well.
+class JavaSymbolProvider(session: FirSession, baseModuleData: FirModuleData, facade: JavaClassFinder) : FirSymbolProvider(session) {
+    private val javaClassConverter = JavaClassConverter(session, baseModuleData, facade)
+
+    private val classCache =
+        session.firCachesFactory.createCacheWithPostCompute(
+            createValue = { classId: ClassId, parentClassSymbol: FirRegularClassSymbol? ->
+                javaClassConverter.findClass(classId)?.let { FirRegularClassSymbol(classId) to (it to parentClassSymbol) }
+                    ?: null to (null to null)
+            },
+            postCompute = { _, classSymbol, (javaClass, parentClassSymbol) ->
+                if (classSymbol != null && javaClass != null) {
+                    javaClassConverter.convertJavaClassToFir(classSymbol, parentClassSymbol, javaClass)
+                }
+            }
+        )
+
+    override fun getPackage(fqName: FqName): FqName? =
+        javaClassConverter.getPackage(fqName)
+
+    override fun getClassLikeSymbolByClassId(classId: ClassId): FirRegularClassSymbol? =
+        try {
+            if (javaClassConverter.hasTopLevelClassOf(classId)) getFirJavaClass(classId) else null
+        } catch (e: ProcessCanceledException) {
+            null
+        }
+
+    private fun getFirJavaClass(classId: ClassId): FirRegularClassSymbol? =
+        classCache.getValue(classId, classId.outerClassId?.let { getFirJavaClass(it) })
+
+    @OptIn(FirSymbolProviderInternals::class)
+    override fun getTopLevelCallableSymbolsTo(destination: MutableList<FirCallableSymbol<*>>, packageFqName: FqName, name: Name) {}
+
+    @OptIn(FirSymbolProviderInternals::class)
+    override fun getTopLevelFunctionSymbolsTo(destination: MutableList<FirNamedFunctionSymbol>, packageFqName: FqName, name: Name) {}
+
+    @OptIn(FirSymbolProviderInternals::class)
+    override fun getTopLevelPropertySymbolsTo(destination: MutableList<FirPropertySymbol>, packageFqName: FqName, name: Name) {}
+}

--- a/compiler/fir/java/src/org/jetbrains/kotlin/fir/java/JavaUtils.kt
+++ b/compiler/fir/java/src/org/jetbrains/kotlin/fir/java/JavaUtils.kt
@@ -152,7 +152,7 @@ private fun fillAnnotationArgumentMapping(
         ?.declarations
         ?.firstIsInstanceOrNull<FirConstructor>()
     annotationArguments.associateTo(destination) { argument ->
-        val name = argument.name ?: JavaSymbolProvider.VALUE_METHOD_NAME
+        val name = argument.name ?: JavaClassConverter.VALUE_METHOD_NAME
         val parameter = annotationConstructor?.valueParameters?.find { it.name == name }
         name to argument.toFirExpression(session, javaTypeParameterStack, parameter?.returnTypeRef)
     }

--- a/compiler/fir/java/src/org/jetbrains/kotlin/fir/java/deserialization/KotlinDeserializedJvmSymbolsProvider.kt
+++ b/compiler/fir/java/src/org/jetbrains/kotlin/fir/java/deserialization/KotlinDeserializedJvmSymbolsProvider.kt
@@ -33,7 +33,7 @@ import java.nio.file.Paths
 
 // This symbol provider loads JVM classes, reading extra info from Kotlin `@Metadata` annotations
 // if present. Use it for library and incremental compilation sessions. For source sessions use
-// `JavaSymbolProviderWrapper`, as Kotlin classes should be parsed first.
+// `JavaSymbolProvider`, as Kotlin classes should be parsed first.
 @ThreadSafeMutableState
 class KotlinDeserializedJvmSymbolsProvider(
     session: FirSession,

--- a/compiler/fir/java/src/org/jetbrains/kotlin/fir/java/deserialization/KotlinDeserializedJvmSymbolsProvider.kt
+++ b/compiler/fir/java/src/org/jetbrains/kotlin/fir/java/deserialization/KotlinDeserializedJvmSymbolsProvider.kt
@@ -93,6 +93,9 @@ open class KotlinDeserializedJvmSymbolsProvider(
     private val KotlinJvmBinaryClass.isPreReleaseInvisible: Boolean
         get() = classHeader.isPreRelease
 
+    override fun shouldLoadParentsFirst(classId: ClassId): Boolean =
+        javaSymbolProvider.hasTopLevelClassOf(classId)
+
     override fun extractClassMetadata(classId: ClassId, parentContext: FirDeserializationContext?): ClassMetadataFindResult? {
         if (knownNameInPackageCache.hasNoTopLevelClassOf(classId)) return null
         val result = try {

--- a/compiler/frontend.java/src/org/jetbrains/kotlin/load/java/JavaClassFinderImpl.kt
+++ b/compiler/frontend.java/src/org/jetbrains/kotlin/load/java/JavaClassFinderImpl.kt
@@ -17,6 +17,7 @@
 package org.jetbrains.kotlin.load.java
 
 import com.intellij.openapi.project.Project
+import com.intellij.psi.search.GlobalSearchScope
 import org.jetbrains.kotlin.load.java.structure.JavaClass
 import org.jetbrains.kotlin.load.java.structure.JavaPackage
 import org.jetbrains.kotlin.load.java.structure.impl.JavaPackageImpl
@@ -24,8 +25,13 @@ import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.resolve.jvm.KotlinJavaPsiFacade
 import javax.inject.Inject
 
-class JavaClassFinderImpl : AbstractJavaClassFinder() {
+fun Project.createJavaClassFinder(scope: GlobalSearchScope): JavaClassFinder =
+    JavaClassFinderImpl().apply {
+        setProjectInstance(this@createJavaClassFinder)
+        setScope(scope)
+    }
 
+class JavaClassFinderImpl : AbstractJavaClassFinder() {
     private lateinit var javaFacade: KotlinJavaPsiFacade
 
     @Inject

--- a/compiler/testData/codegen/box/javaInterop/javaOuterClassDependsOnInner.kt
+++ b/compiler/testData/codegen/box/javaInterop/javaOuterClassDependsOnInner.kt
@@ -1,0 +1,21 @@
+// TARGET_BACKEND: JVM
+// This is really a frontend test that checks loading of compiled Java classes.
+// MODULE: lib
+// FILE: I.java
+public interface I<T> {}
+
+// FILE: J.java
+public class J implements I<J.X> {
+    public static class X {}
+}
+
+// FILE: Z.java
+public class Z<T> {
+    public T foo(J.X x) { return null; }
+}
+
+// MODULE: main(lib)
+// FILE: main.kt
+class C : Z<Int>()
+
+fun box() = C().foo(null) ?: "OK"

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -22815,6 +22815,12 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
         }
 
         @Test
+        @TestMetadata("javaOuterClassDependsOnInner.kt")
+        public void testJavaOuterClassDependsOnInner() throws Exception {
+            runTest("compiler/testData/codegen/box/javaInterop/javaOuterClassDependsOnInner.kt");
+        }
+
+        @Test
         @TestMetadata("kt43217.kt")
         public void testKt43217() throws Exception {
             runTest("compiler/testData/codegen/box/javaInterop/kt43217.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -22947,6 +22947,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         }
 
         @Test
+        @TestMetadata("javaOuterClassDependsOnInner.kt")
+        public void testJavaOuterClassDependsOnInner() throws Exception {
+            runTest("compiler/testData/codegen/box/javaInterop/javaOuterClassDependsOnInner.kt");
+        }
+
+        @Test
         @TestMetadata("kt43217.kt")
         public void testKt43217() throws Exception {
             runTest("compiler/testData/codegen/box/javaInterop/kt43217.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -19136,6 +19136,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/javaInterop/genericSamSmartcast.kt");
         }
 
+        @TestMetadata("javaOuterClassDependsOnInner.kt")
+        public void testJavaOuterClassDependsOnInner() throws Exception {
+            runTest("compiler/testData/codegen/box/javaInterop/javaOuterClassDependsOnInner.kt");
+        }
+
         @TestMetadata("kt43217.kt")
         public void testKt43217() throws Exception {
             runTest("compiler/testData/codegen/box/javaInterop/kt43217.kt");

--- a/idea/idea-frontend-fir/idea-fir-low-level-api/src/org/jetbrains/kotlin/idea/fir/low/level/api/sessions/FirIdeSessionFactory.kt
+++ b/idea/idea-frontend-fir/idea-fir-low-level-api/src/org/jetbrains/kotlin/idea/fir/low/level/api/sessions/FirIdeSessionFactory.kt
@@ -19,6 +19,7 @@ import org.jetbrains.kotlin.fir.declarations.SealedClassInheritorsProvider
 import org.jetbrains.kotlin.fir.deserialization.FirDeserializationContext
 import org.jetbrains.kotlin.fir.deserialization.ModuleDataProvider
 import org.jetbrains.kotlin.fir.java.JavaSymbolProvider
+import org.jetbrains.kotlin.fir.java.JavaSymbolProviderWrapper
 import org.jetbrains.kotlin.fir.java.deserialization.KotlinDeserializedJvmSymbolsProvider
 import org.jetbrains.kotlin.fir.resolve.providers.FirDependenciesSymbolProvider
 import org.jetbrains.kotlin.fir.resolve.providers.FirProvider
@@ -150,7 +151,7 @@ internal object FirIdeSessionFactory {
                     this,
                     providers = listOf(
                         provider.symbolProvider,
-                        JavaSymbolProvider(this@session, moduleData, project, searchScope),
+                        JavaSymbolProviderWrapper(this@session, JavaSymbolProvider(this@session, moduleData, project, searchScope)),
                     ),
                     dependencyProvider
                 )
@@ -214,10 +215,10 @@ internal object FirIdeSessionFactory {
                             kotlinScopeProvider,
                             packagePartProvider,
                             kotlinClassFinder,
-                            javaClassFinder
+                            javaClassFinder,
+                            JavaSymbolProvider(this@session, mainModuleData, project, searchScope)
                         )
                     )
-                    add(JavaSymbolProvider(this@session, mainModuleData, project, searchScope))
                     addAll((builtinsAndCloneableSession.symbolProvider as FirCompositeSymbolProvider).providers)
                 }
             )
@@ -239,10 +240,11 @@ internal object FirIdeSessionFactory {
         kotlinScopeProvider: FirKotlinScopeProvider,
         packagePartProvider: PackagePartProvider,
         kotlinClassFinder: KotlinClassFinder,
-        javaClassFinder: JavaClassFinder
+        javaClassFinder: JavaClassFinder,
+        javaSymbolProvider: JavaSymbolProvider
     ) : KotlinDeserializedJvmSymbolsProvider(
         session, moduleDataProvider, kotlinScopeProvider, packagePartProvider, kotlinClassFinder,
-        javaClassFinder
+        javaClassFinder, javaSymbolProvider
     ) {
         override fun getClass(
             classId: ClassId,

--- a/idea/idea-frontend-fir/idea-fir-low-level-api/src/org/jetbrains/kotlin/idea/fir/low/level/api/sessions/FirIdeSessionFactory.kt
+++ b/idea/idea-frontend-fir/idea-fir-low-level-api/src/org/jetbrains/kotlin/idea/fir/low/level/api/sessions/FirIdeSessionFactory.kt
@@ -16,7 +16,7 @@ import org.jetbrains.kotlin.fir.backend.jvm.FirJvmTypeMapper
 import org.jetbrains.kotlin.fir.caches.FirCachesFactory
 import org.jetbrains.kotlin.fir.checkers.registerExtendedCommonCheckers
 import org.jetbrains.kotlin.fir.declarations.SealedClassInheritorsProvider
-import org.jetbrains.kotlin.fir.java.JavaSymbolProviderWrapper
+import org.jetbrains.kotlin.fir.java.JavaSymbolProvider
 import org.jetbrains.kotlin.fir.java.deserialization.KotlinDeserializedJvmSymbolsProvider
 import org.jetbrains.kotlin.fir.resolve.providers.FirDependenciesSymbolProvider
 import org.jetbrains.kotlin.fir.resolve.providers.FirProvider
@@ -44,7 +44,6 @@ import org.jetbrains.kotlin.idea.fir.low.level.api.providers.FirIdeLibrariesSess
 import org.jetbrains.kotlin.idea.fir.low.level.api.providers.FirIdeProvider
 import org.jetbrains.kotlin.idea.fir.low.level.api.providers.FirModuleWithDependenciesSymbolProvider
 import org.jetbrains.kotlin.idea.fir.low.level.api.util.checkCanceled
-import org.jetbrains.kotlin.load.java.JavaClassFinderImpl
 import org.jetbrains.kotlin.load.java.createJavaClassFinder
 import org.jetbrains.kotlin.load.kotlin.VirtualFileFinderFactory
 import org.jetbrains.kotlin.name.Name
@@ -144,7 +143,7 @@ internal object FirIdeSessionFactory {
                     this,
                     providers = listOf(
                         provider.symbolProvider,
-                        JavaSymbolProviderWrapper(this, moduleData, project.createJavaClassFinder(searchScope)),
+                        JavaSymbolProvider(this, moduleData, project.createJavaClassFinder(searchScope)),
                     ),
                     dependencyProvider
                 )


### PR DESCRIPTION
I'm told that removal of redundant cache layers in ba1fc81b96618f32e3e14cb5441a40acdc04afb5 hurt performance due to unnecessary repeated file reads, so this is an attempt to fix that: when a Java class is loaded through a KotlinDeserializedJvmSymbolsProvider, it goes into KotlinDeserializedJvmSymbolsProvider's cache, and JavaSymbolProvider no longer has a cache of its own. This keeps the "at most one cache, and it must be postprocessing-aware" property required for not breaking IDE mode while reverting to the old "read the class file once" behavior.

cc @dzharkov