### PR TITLE
K2JS: Add ability to use any symbol wrapped in backticks

### DIFF
--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/transformers/irToJs/ModuleWrapperTranslation.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/transformers/irToJs/ModuleWrapperTranslation.kt
@@ -7,13 +7,13 @@ package org.jetbrains.kotlin.ir.backend.js.transformers.irToJs
 
 import org.jetbrains.kotlin.ir.backend.js.utils.RESERVED_IDENTIFIERS
 import org.jetbrains.kotlin.js.backend.ast.*
-import org.jetbrains.kotlin.js.naming.isValidES5Identifier
+import org.jetbrains.kotlin.js.common.IdentifierPolicy
 import org.jetbrains.kotlin.serialization.js.ModuleKind
 
 object ModuleWrapperTranslation {
     object Namer {
         fun requiresEscaping(name: String) =
-            !name.isValidES5Identifier() || name in RESERVED_IDENTIFIERS
+            !IdentifierPolicy.isValidES5Identifier(name) || name in RESERVED_IDENTIFIERS
     }
 
     fun wrap(

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/utils/NameTables.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/utils/NameTables.kt
@@ -19,9 +19,7 @@ import org.jetbrains.kotlin.ir.util.isEffectivelyExternal
 import org.jetbrains.kotlin.ir.util.render
 import org.jetbrains.kotlin.ir.visitors.IrElementVisitorVoid
 import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
-import org.jetbrains.kotlin.js.naming.isES5IdentifierPart
-import org.jetbrains.kotlin.js.naming.isES5IdentifierStart
-import org.jetbrains.kotlin.js.naming.isValidES5Identifier
+import org.jetbrains.kotlin.js.common.IdentifierPolicy
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
 import java.util.*
@@ -368,17 +366,17 @@ class LocalNameGenerator(parentScope: NameScope) : IrElementVisitorVoid {
 
 
 fun sanitizeName(name: String): String {
-    if (name.isValidES5Identifier()) return name
+    if (IdentifierPolicy.isValidES5Identifier(name)) return name
     if (name.isEmpty()) return "_"
 
     val builder = StringBuilder()
 
-    val first = name.first().let { if (it.isES5IdentifierStart()) it else '_' }
+    val first = name.first().let { if (IdentifierPolicy.isES5IdentifierStart(it)) it else '_' }
     builder.append(first)
 
     for (idx in 1..name.lastIndex) {
         val c = name[idx]
-        builder.append(if (c.isES5IdentifierPart()) c else '_')
+        builder.append(if (IdentifierPolicy.isES5IdentifierPart(c)) c else '_')
     }
 
     return builder.toString()

--- a/js/js.ast/src/org/jetbrains/kotlin/js/backend/ast/JsName.java
+++ b/js/js.ast/src/org/jetbrains/kotlin/js/backend/ast/JsName.java
@@ -6,6 +6,7 @@ package org.jetbrains.kotlin.js.backend.ast;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.kotlin.js.backend.ast.metadata.HasMetadata;
+import org.jetbrains.kotlin.js.common.IdentifierPolicy;
 import org.jetbrains.kotlin.js.common.Symbol;
 
 /**
@@ -31,6 +32,10 @@ public class JsName extends HasMetadata implements Symbol {
 
   public boolean isTemporary() {
     return temporary;
+  }
+
+  public boolean containsAnyUnresolvedChar() {
+    return !IdentifierPolicy.isValidES5Identifier(ident);
   }
 
   @NotNull

--- a/js/js.ast/src/org/jetbrains/kotlin/js/common/IdentifierPolicy.java
+++ b/js/js.ast/src/org/jetbrains/kotlin/js/common/IdentifierPolicy.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+package org.jetbrains.kotlin.js.common;
+
+public final class IdentifierPolicy {
+    private IdentifierPolicy() {}
+
+    public static boolean isES5IdentifierStart(char c) {
+        if (isAllowedLatinLetterOrSpecial(c)) return true;
+        if (isNotAllowedSimpleCharacter(c)) return false;
+
+        return isES5IdentifierStartFull(c);
+    }
+
+    public static boolean isES5IdentifierPart(char c) {
+        if (isAllowedLatinLetterOrSpecial(c)) return true;
+        if (isAllowedSimpleDigit(c)) return true;
+        if (isNotAllowedSimpleCharacter(c)) return false;
+
+        int charType = Character.getType(c);
+
+        return isES5IdentifierStartFull(c) ||
+               charType == Character.NON_SPACING_MARK ||
+               charType == Character.COMBINING_SPACING_MARK ||
+               charType == Character.DECIMAL_DIGIT_NUMBER ||
+               charType == Character.CONNECTOR_PUNCTUATION ||
+               c == '\u200C' ||   // Zero-width non-joiner
+               c == '\u200D';      // Zero-width joiner
+    }
+
+    public static boolean isValidES5Identifier(String id) {
+       if (id.isEmpty() || !isES5IdentifierStart(id.charAt(0))) return false;
+
+       for (int i = 1; i < id.length(); i++) {
+           char c = id.charAt(i);
+           if (!isES5IdentifierPart(c)) return false;
+       }
+
+       return true;
+    }
+
+    private static boolean isAllowedLatinLetterOrSpecial(char c) {
+        return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_' || c == '$';
+    }
+
+    private static boolean isAllowedSimpleDigit(char c) {
+        return c >= '0' && c <= '9';
+    }
+
+    private static boolean isNotAllowedSimpleCharacter(char c) {
+        return c == ' ' || c == '<' || c == '>' || c == '-' || c == '?';
+    }
+
+    // See ES 5.1 spec: https://www.ecma-international.org/ecma-262/5.1/#sec-7.6
+    private static boolean isES5IdentifierStartFull(char c) {
+        return Character.isLetter(c) ||   // Lu | Ll | Lt | Lm | Lo
+               // Nl which is missing in Character.isLetter, but present in UnicodeLetter in spec
+               Character.getType(c) == Character.LETTER_NUMBER;
+    }
+}

--- a/js/js.frontend/src/org/jetbrains/kotlin/js/naming/NameSuggestion.kt
+++ b/js/js.frontend/src/org/jetbrains/kotlin/js/naming/NameSuggestion.kt
@@ -19,6 +19,7 @@ package org.jetbrains.kotlin.js.naming
 import org.jetbrains.kotlin.builtins.ReflectionTypes
 import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.descriptors.impl.TypeAliasConstructorDescriptor
+import org.jetbrains.kotlin.js.common.IdentifierPolicy
 import org.jetbrains.kotlin.js.translate.utils.AnnotationsUtils.getNameForAnnotatedObject
 import org.jetbrains.kotlin.js.translate.utils.AnnotationsUtils.isNativeObject
 import org.jetbrains.kotlin.name.Name
@@ -354,59 +355,8 @@ class NameSuggestion {
         @JvmStatic fun sanitizeName(name: String): String {
             if (name.isEmpty()) return "_"
 
-            val first = name.first().let { if (it.isES5IdentifierStart()) it else '_' }
-            return first.toString() + name.drop(1).map { if (it.isES5IdentifierPart()) it else '_' }.joinToString("")
+            val first = name.first().let { if (IdentifierPolicy.isES5IdentifierStart(it)) it else '_' }
+            return first.toString() + name.drop(1).map { if (IdentifierPolicy.isES5IdentifierPart(it)) it else '_' }.joinToString("")
         }
     }
-}
-
-private fun Char.isAllowedLatinLetterOrSpecial(): Boolean {
-    return this in 'a'..'z' || this in 'A'..'Z' || this == '_' || this == '$'
-}
-
-private fun Char.isAllowedSimpleDigit() =
-    this in '0'..'9'
-
-private fun Char.isNotAllowedSimpleCharacter() = when (this) {
-    ' ', '<', '>', '-', '?' -> true
-    else -> false
-}
-
-fun Char.isES5IdentifierStart(): Boolean {
-    if (isAllowedLatinLetterOrSpecial()) return true
-    if (isNotAllowedSimpleCharacter()) return false
-
-    return isES5IdentifierStartFull()
-}
-
-// See ES 5.1 spec: https://www.ecma-international.org/ecma-262/5.1/#sec-7.6
-private fun Char.isES5IdentifierStartFull() =
-    Character.isLetter(this) ||   // Lu | Ll | Lt | Lm | Lo
-            // Nl which is missing in Character.isLetter, but present in UnicodeLetter in spec
-            Character.getType(this).toByte() == Character.LETTER_NUMBER
-
-
-fun Char.isES5IdentifierPart(): Boolean {
-    if (isAllowedLatinLetterOrSpecial()) return true
-    if (isAllowedSimpleDigit()) return true
-    if (isNotAllowedSimpleCharacter()) return false
-
-    return isES5IdentifierStartFull() ||
-            when (Character.getType(this).toByte()) {
-                Character.NON_SPACING_MARK,
-                Character.COMBINING_SPACING_MARK,
-                Character.DECIMAL_DIGIT_NUMBER,
-                Character.CONNECTOR_PUNCTUATION -> true
-                else -> false
-            } ||
-            this == '\u200C' ||   // Zero-width non-joiner
-            this == '\u200D'      // Zero-width joiner
-}
-
-fun String.isValidES5Identifier(): Boolean {
-    if (isEmpty() || !this[0].isES5IdentifierStart()) return false
-    for (idx in 1 ..length-1) {
-        if (!get(idx).isES5IdentifierPart()) return false
-    }
-    return true
 }

--- a/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/diagnostics/JsNameCharsChecker.kt
+++ b/js/js.frontend/src/org/jetbrains/kotlin/js/resolve/diagnostics/JsNameCharsChecker.kt
@@ -5,31 +5,13 @@
 
 package org.jetbrains.kotlin.js.resolve.diagnostics
 
-import org.jetbrains.kotlin.descriptors.ConstructorDescriptor
 import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
-import org.jetbrains.kotlin.descriptors.PropertyAccessorDescriptor
 import org.jetbrains.kotlin.js.naming.NameSuggestion
-import org.jetbrains.kotlin.js.translate.utils.AnnotationsUtils
 import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.resolve.checkers.DeclarationChecker
 import org.jetbrains.kotlin.resolve.checkers.DeclarationCheckerContext
 
 class JsNameCharsChecker(private val suggestion: NameSuggestion) : DeclarationChecker {
-    override fun check(declaration: KtDeclaration, descriptor: DeclarationDescriptor, context: DeclarationCheckerContext) {
-        val bindingContext = context.trace.bindingContext
-
-        if (descriptor is PropertyAccessorDescriptor && AnnotationsUtils.getJsName(descriptor) == null) return
-
-        // This case will be reported as WRONG_EXPORTED_DECLARATION for
-        // secondary constructor with missing JsName. Skipping it here to simplify further logic.
-        if (descriptor is ConstructorDescriptor &&
-            AnnotationsUtils.getJsName(descriptor) == null &&
-            AnnotationsUtils.isExportedObject(descriptor, bindingContext)
-        ) return
-
-        val suggestedName = suggestion.suggest(descriptor, bindingContext) ?: return
-        if (suggestedName.stable && suggestedName.names.any { NameSuggestion.sanitizeName(it) != it }) {
-            context.trace.report(ErrorsJs.NAME_CONTAINS_ILLEGAL_CHARS.on(declaration))
-        }
-    }
+    override fun check(declaration: KtDeclaration, descriptor: DeclarationDescriptor, context: DeclarationCheckerContext) =
+        Unit
 }

--- a/js/js.translator/src/org/jetbrains/kotlin/js/translate/context/StaticContext.java
+++ b/js/js.translator/src/org/jetbrains/kotlin/js/translate/context/StaticContext.java
@@ -31,9 +31,9 @@ import org.jetbrains.kotlin.js.backend.ast.*;
 import org.jetbrains.kotlin.js.backend.ast.metadata.MetadataProperties;
 import org.jetbrains.kotlin.js.backend.ast.metadata.SideEffectKind;
 import org.jetbrains.kotlin.js.backend.ast.metadata.SpecialFunction;
+import org.jetbrains.kotlin.js.common.IdentifierPolicy;
 import org.jetbrains.kotlin.js.config.JsConfig;
 import org.jetbrains.kotlin.js.naming.NameSuggestion;
-import org.jetbrains.kotlin.js.naming.NameSuggestionKt;
 import org.jetbrains.kotlin.js.naming.SuggestedName;
 import org.jetbrains.kotlin.js.resolve.diagnostics.JsBuiltinNameClashChecker;
 import org.jetbrains.kotlin.js.sourceMap.SourceFilePathResolver;
@@ -843,7 +843,7 @@ public final class StaticContext {
             JsExpression currentImports = pureFqn(getNameForImportsForInline(), null);
 
             JsExpression lhsModuleRef;
-            if (NameSuggestionKt.isValidES5Identifier(moduleId)) {
+            if (IdentifierPolicy.isValidES5Identifier(moduleId)) {
                 moduleRef = pureFqn(moduleId, importsRef);
                 lhsModuleRef = pureFqn(moduleId, currentImports);
             }


### PR DESCRIPTION
Those changes provide the ability to use any symbol inside escaped identifiers for Kotlin/JS.
The idea is to mangle all possible identifiers at the backend side and leave them as raw only for exported variables, classes, functions.

cc @bashor 