### PR TITLE
IR: do not create unused capture fields

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBytecodeTextTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBytecodeTextTestGenerated.java
@@ -2279,6 +2279,12 @@ public class FirBytecodeTextTestGenerated extends AbstractFirBytecodeTextTest {
         }
 
         @Test
+        @TestMetadata("constructorOnly.kt")
+        public void testConstructorOnly() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/fieldsForCapturedValues/constructorOnly.kt");
+        }
+
+        @Test
         @TestMetadata("extensionLambdaExtensionReceiver.kt")
         public void testExtensionLambdaExtensionReceiver() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/fieldsForCapturedValues/extensionLambdaExtensionReceiver.kt");

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
@@ -141,7 +141,8 @@ internal val localDeclarationsPhase = makeIrFilePhase(
 
                 private fun scopedVisibility(inInlineFunctionScope: Boolean): DescriptorVisibility =
                     if (inInlineFunctionScope) DescriptorVisibilities.PUBLIC else JavaDescriptorVisibilities.PACKAGE_VISIBILITY
-            }
+            },
+            forceFieldsForInlineCaptures = true
         )
     },
     name = "JvmLocalDeclarations",

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/SuspendLambdaLowering.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/SuspendLambdaLowering.kt
@@ -348,6 +348,7 @@ private class SuspendLambdaLowering(context: JvmBackendContext) : SuspendLowerin
                     it.putValueArgument(0, irInt(arity + 1))
                     it.putValueArgument(1, irGet(completionParameterSymbol))
                 }
+                +IrInstanceInitializerCallImpl(startOffset, endOffset, symbol, context.irBuiltIns.unitType)
             }
         }
 }

--- a/compiler/testData/codegen/bytecodeListing/annotations/localClassWithCapturedParams_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/annotations/localClassWithCapturedParams_ir.txt
@@ -1,0 +1,25 @@
+@kotlin.Metadata
+public final class LocalClassWithCapturedParamsKt$localCaptured$A {
+    // source: 'localClassWithCapturedParams.kt'
+    enclosing method LocalClassWithCapturedParamsKt.localCaptured()Ljava/lang/Object;
+    private final field x: int
+    private final @org.jetbrains.annotations.NotNull field z: java.lang.String
+    inner (local) class LocalClassWithCapturedParamsKt$localCaptured$A A
+    public method <init>(p0: int, @Simple(value="K") @org.jetbrains.annotations.NotNull p1: java.lang.String): void
+    public final method getX(): int
+    public final @org.jetbrains.annotations.NotNull method getZ(): java.lang.String
+}
+
+@kotlin.Metadata
+public final class LocalClassWithCapturedParamsKt {
+    // source: 'localClassWithCapturedParams.kt'
+    inner (local) class LocalClassWithCapturedParamsKt$localCaptured$A A
+    public final static @org.jetbrains.annotations.NotNull method localCaptured(): java.lang.Object
+}
+
+@java.lang.annotation.Retention(value=RUNTIME)
+@kotlin.Metadata
+public annotation class Simple {
+    // source: 'localClassWithCapturedParams.kt'
+    public abstract method value(): java.lang.String
+}

--- a/compiler/testData/codegen/bytecodeText/fieldsForCapturedValues/constructorOnly.kt
+++ b/compiler/testData/codegen/bytecodeText/fieldsForCapturedValues/constructorOnly.kt
@@ -2,8 +2,8 @@ open class Base(parameter: String)
 
 fun foo(captured: String) {
     object : Base(captured) {
-        // val x = captured
-        // init { println(captured) }
+        val x = captured
+        init { println(captured) }
     }
 }
 

--- a/compiler/testData/codegen/bytecodeText/fieldsForCapturedValues/constructorOnly.kt
+++ b/compiler/testData/codegen/bytecodeText/fieldsForCapturedValues/constructorOnly.kt
@@ -1,0 +1,14 @@
+open class Base(parameter: String)
+
+fun foo(captured: String) {
+    object : Base(captured) {
+        // val x = captured
+        // init { println(captured) }
+    }
+}
+
+// JVM_TEMPLATES
+// 1 final synthetic Ljava/lang/String; \$captured
+
+// JVM_IR_TEMPLATES
+// 0 final synthetic Ljava/lang/String; \$captured

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BytecodeTextTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BytecodeTextTestGenerated.java
@@ -2255,6 +2255,12 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
         }
 
         @Test
+        @TestMetadata("constructorOnly.kt")
+        public void testConstructorOnly() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/fieldsForCapturedValues/constructorOnly.kt");
+        }
+
+        @Test
         @TestMetadata("extensionLambdaExtensionReceiver.kt")
         public void testExtensionLambdaExtensionReceiver() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/fieldsForCapturedValues/extensionLambdaExtensionReceiver.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBytecodeTextTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBytecodeTextTestGenerated.java
@@ -2279,6 +2279,12 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
         }
 
         @Test
+        @TestMetadata("constructorOnly.kt")
+        public void testConstructorOnly() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/fieldsForCapturedValues/constructorOnly.kt");
+        }
+
+        @Test
         @TestMetadata("extensionLambdaExtensionReceiver.kt")
         public void testExtensionLambdaExtensionReceiver() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/fieldsForCapturedValues/extensionLambdaExtensionReceiver.kt");


### PR DESCRIPTION
I.e. those only used in constructors, where parameters with the same values are also present.

One exception is captured inline parameters on the JVM backend, as the bytecode inliner uses field assignment instructions (setfield) to locate them; removing the field is thus not possible:

```
inline fun baz(crossinline f: () -> String) =
    object {
        init { println(f()) } // *has* to create a field called `$f`...
    }

fun main() {
    val ok = "OK"
    println(baz { ok }) // ...otherwise the inliner won't create a field for `ok`.
}
```

TODO: fix the inliner? Even so, removing the field would be a backwards-incompatible change.

^KT-48784 Fixed