### PR TITLE
Bumped Junit dependency to fix CVE-2020-15250

### DIFF
--- a/libraries/kotlin.test/junit/build.gradle
+++ b/libraries/kotlin.test/junit/build.gradle
@@ -15,7 +15,7 @@ sourceSets {
 dependencies {
     expectedBy project(':kotlin-test:kotlin-test-annotations-common')
     compile project(':kotlin-test:kotlin-test-jvm')
-    compile('junit:junit:4.12')
+    compile('junit:junit:4.13.2')
 }
 
 


### PR DESCRIPTION
Junit >= 4.7 and < 4.13.1 is vulnerable to https://nvd.nist.gov/vuln/detail/CVE-2020-15250   Sorry, I didn't build or test this change.