### PR TITLE
Parcelize: Allow Parcelize annotation on sealed classes

### DIFF
--- a/plugins/parcelize/parcelize-compiler/src/org/jetbrains/kotlin/parcelize/diagnostic/DefaultErrorMessagesParcelize.kt
+++ b/plugins/parcelize/parcelize-compiler/src/org/jetbrains/kotlin/parcelize/diagnostic/DefaultErrorMessagesParcelize.kt
@@ -43,7 +43,7 @@ object DefaultErrorMessagesParcelize : DefaultErrorMessages.Extension {
 
         MAP.put(
             ErrorsParcelize.PARCELABLE_SHOULD_BE_INSTANTIABLE,
-            "'Parcelable' should not be a 'sealed' or 'abstract' class"
+            "'Parcelable' should not be an 'abstract' class"
         )
 
         MAP.put(

--- a/plugins/parcelize/parcelize-compiler/src/org/jetbrains/kotlin/parcelize/ir/ParcelizeIrTransformer.kt
+++ b/plugins/parcelize/parcelize-compiler/src/org/jetbrains/kotlin/parcelize/ir/ParcelizeIrTransformer.kt
@@ -122,7 +122,10 @@ class ParcelizeIrTransformer(private val context: IrPluginContext, private val a
 
     override fun visitClass(declaration: IrClass) {
         declaration.acceptChildren(this, null)
-        if (!declaration.isParcelize)
+
+        // Sealed classes can be annotated with `@Parcelize`, but that only implies that we
+        // should process their immediate subclasses.
+        if (!declaration.isParcelize || declaration.modality == Modality.SEALED)
             return
 
         val parcelableProperties = declaration.parcelableProperties

--- a/plugins/parcelize/parcelize-compiler/src/org/jetbrains/kotlin/parcelize/ir/irUtils.kt
+++ b/plugins/parcelize/parcelize-compiler/src/org/jetbrains/kotlin/parcelize/ir/irUtils.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.parcelize.ir
 import org.jetbrains.kotlin.backend.common.ir.allOverridden
 import org.jetbrains.kotlin.backend.jvm.ir.erasedUpperBound
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
+import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.ir.IrBuiltIns
 import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
 import org.jetbrains.kotlin.ir.builders.*
@@ -34,7 +35,12 @@ import org.jetbrains.kotlin.types.Variance
 
 // true if the class should be processed by the parcelize plugin
 val IrClass.isParcelize: Boolean
-    get() = kind in ParcelizeExtensionBase.ALLOWED_CLASS_KINDS && hasAnyAnnotation(PARCELIZE_CLASS_FQ_NAMES)
+    get() = kind in ParcelizeExtensionBase.ALLOWED_CLASS_KINDS &&
+            (hasAnyAnnotation(PARCELIZE_CLASS_FQ_NAMES) || superTypes.any { superType ->
+                superType.classOrNull?.owner?.let {
+                    it.modality == Modality.SEALED && it.hasAnyAnnotation(PARCELIZE_CLASS_FQ_NAMES)
+                } == true
+            })
 
 // Finds the getter for a pre-existing CREATOR field on the class companion, which is used for manual Parcelable implementations in Kotlin.
 val IrClass.creatorGetter: IrSimpleFunctionSymbol?

--- a/plugins/parcelize/parcelize-compiler/testData/box/sealedClass2.kt
+++ b/plugins/parcelize/parcelize-compiler/testData/box/sealedClass2.kt
@@ -1,0 +1,33 @@
+// WITH_RUNTIME
+
+@file:JvmName("TestKt")
+package test
+
+import kotlinx.parcelize.*
+import android.os.Parcel
+import android.os.Parcelable
+
+@Parcelize
+sealed class Foo : Parcelable {
+    data class A(val x: Int) : Foo()
+    object B : Foo()
+}
+
+data class C(val x: String) : Foo()
+
+@Parcelize
+data class Bar(val a: Foo.A, val b: Foo.B, val c: C, val foo: Foo) : Parcelable
+
+fun box() = parcelTest { parcel ->
+    val first = Bar(Foo.A(1024), Foo.B, C("OK"), Foo.A(1))
+
+    first.writeToParcel(parcel, 0)
+
+    val bytes = parcel.marshall()
+    parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
+
+    val second = parcelableCreator<Bar>().createFromParcel(parcel)
+
+    assert(first == second)
+}

--- a/plugins/parcelize/parcelize-compiler/testData/box/sealedInterface.kt
+++ b/plugins/parcelize/parcelize-compiler/testData/box/sealedInterface.kt
@@ -1,0 +1,74 @@
+// WITH_RUNTIME
+
+@file:JvmName("TestKt")
+package test
+
+import kotlinx.parcelize.*
+import android.os.Parcel
+import android.os.Parcelable
+
+@Parcelize
+sealed interface I : Parcelable
+
+@Parcelize
+sealed class A : Parcelable
+
+abstract class B
+interface J
+
+data class AI(val x: String) : A(), I
+class I1 : J, I {
+    override fun equals(other: Any?): Boolean {
+        return other is I1
+    }
+}
+data class I2(val x: Float) : B(), I
+
+object A1 : A()
+open class A2(val x: Int) : A() {
+    override fun equals(other: Any?): Boolean {
+        return other is A2 && other::class == A2::class && x == other.x
+    }
+}
+
+@Parcelize
+class A3 : A2(3) {
+    override fun equals(other: Any?): Boolean {
+        return other is A3 && x == other.x
+    }
+}
+
+@Parcelize
+data class C(
+    val a: A,
+    val i: I,
+    val a1: A1,
+    val a2: A2,
+    val a3: A3,
+    val ai: AI,
+    val i1: I1,
+    val i2: I2,
+) : Parcelable
+
+fun box() = parcelTest { parcel ->
+    val first = C(
+        AI("0"),
+        AI("1"),
+        A1,
+        A2(2),
+        A3(),
+        AI("4"),
+        I1(),
+        I2(5.0f),
+    )
+
+    first.writeToParcel(parcel, 0)
+
+    val bytes = parcel.marshall()
+    parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
+
+    val second = parcelableCreator<C>().createFromParcel(parcel)
+
+    assert(first == second)
+}

--- a/plugins/parcelize/parcelize-compiler/tests/org/jetbrains/kotlin/parcelize/test/ParcelizeBoxTestGenerated.java
+++ b/plugins/parcelize/parcelize-compiler/tests/org/jetbrains/kotlin/parcelize/test/ParcelizeBoxTestGenerated.java
@@ -350,6 +350,16 @@ public class ParcelizeBoxTestGenerated extends AbstractParcelizeBoxTest {
         runTest("plugins/parcelize/parcelize-compiler/testData/box/sealedClass.kt");
     }
 
+    @TestMetadata("sealedClass2.kt")
+    public void testSealedClass2() throws Exception {
+        runTest("plugins/parcelize/parcelize-compiler/testData/box/sealedClass2.kt");
+    }
+
+    @TestMetadata("sealedInterface.kt")
+    public void testSealedInterface() throws Exception {
+        runTest("plugins/parcelize/parcelize-compiler/testData/box/sealedInterface.kt");
+    }
+
     @TestMetadata("shortArray.kt")
     public void testShortArray() throws Exception {
         runTest("plugins/parcelize/parcelize-compiler/testData/box/shortArray.kt");

--- a/plugins/parcelize/parcelize-compiler/tests/org/jetbrains/kotlin/parcelize/test/ParcelizeIrBoxTestGenerated.java
+++ b/plugins/parcelize/parcelize-compiler/tests/org/jetbrains/kotlin/parcelize/test/ParcelizeIrBoxTestGenerated.java
@@ -350,6 +350,16 @@ public class ParcelizeIrBoxTestGenerated extends AbstractParcelizeIrBoxTest {
         runTest("plugins/parcelize/parcelize-compiler/testData/box/sealedClass.kt");
     }
 
+    @TestMetadata("sealedClass2.kt")
+    public void testSealedClass2() throws Exception {
+        runTest("plugins/parcelize/parcelize-compiler/testData/box/sealedClass2.kt");
+    }
+
+    @TestMetadata("sealedInterface.kt")
+    public void testSealedInterface() throws Exception {
+        runTest("plugins/parcelize/parcelize-compiler/testData/box/sealedInterface.kt");
+    }
+
     @TestMetadata("shortArray.kt")
     public void testShortArray() throws Exception {
         runTest("plugins/parcelize/parcelize-compiler/testData/box/shortArray.kt");


### PR DESCRIPTION
See https://issuetracker.google.com/177856520

This is essentially syntactic sugar. A `@Parcelize` annotation on a `sealed class` just propagates this annotation to all direct subclasses.