### PR TITLE
Fix ExplicitApiMode.Disabled

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinProjectExtension.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinProjectExtension.kt
@@ -316,7 +316,7 @@ enum class NativeCacheKind(val produce: String?, val outputKind: CompilerOutputK
 enum class ExplicitApiMode(private val cliOption: String) {
     Strict("strict"),
     Warning("warning"),
-    Disabled("disabled");
+    Disabled("disable");
 
     fun toCompilerArg() = "-Xexplicit-api=$cliOption"
 }


### PR DESCRIPTION
Fixes this error: `Unknown value for parameter -Xexplicit-api: 'disabled'. Value should be one of {disable, strict, warning}
when using

```kotlin
kotlin {
    explicitApi = ExplicitApiMode.Disabled
}
```