### PR TITLE
JVM_IR don't use Intrinsics.stringPlus for 2-argument concatenation

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -41537,6 +41537,24 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         public void testSurrogatePair() throws Exception {
             runTest("compiler/testData/codegen/box/strings/surrogatePair.kt");
         }
+
+        @Test
+        @TestMetadata("twoArgumentNullableStringOperatorPlus.kt")
+        public void testTwoArgumentNullableStringOperatorPlus() throws Exception {
+            runTest("compiler/testData/codegen/box/strings/twoArgumentNullableStringOperatorPlus.kt");
+        }
+
+        @Test
+        @TestMetadata("twoArgumentNullableStringPlus.kt")
+        public void testTwoArgumentNullableStringPlus() throws Exception {
+            runTest("compiler/testData/codegen/box/strings/twoArgumentNullableStringPlus.kt");
+        }
+
+        @Test
+        @TestMetadata("twoArgumentStringTemplate.kt")
+        public void testTwoArgumentStringTemplate() throws Exception {
+            runTest("compiler/testData/codegen/box/strings/twoArgumentStringTemplate.kt");
+        }
     }
 
     @Nested

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/JvmStringConcatenationLowering.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/JvmStringConcatenationLowering.kt
@@ -147,13 +147,6 @@ private class JvmStringConcatenationLowering(val context: JvmBackendContext) : F
                 arguments.size == 1 ->
                     lowerInlineClassArgument(arguments[0]) ?: callToString(arguments[0].unwrapImplicitNotNull())
 
-                arguments.size == 2 && arguments[0].type.isStringClassType() ->
-                    irCall(backendContext.ir.symbols.intrinsicStringPlus).apply {
-                        putValueArgument(0, lowerInlineClassArgument(arguments[0]) ?: arguments[0].unwrapImplicitNotNull())
-                        // Unwrapping IMPLICIT_NOTNULL is not strictly necessary on 2nd argument (parameter type is `Any?`)
-                        putValueArgument(1, lowerInlineClassArgument(arguments[1]) ?: arguments[1])
-                    }
-
                 arguments.size < MAX_STRING_CONCAT_DEPTH -> {
                     irCall(toStringFunction).apply {
                         dispatchReceiver = appendWindow(arguments, irCall(constructor))

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmSymbols.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmSymbols.kt
@@ -177,9 +177,6 @@ class JvmSymbols(
     override val throwKotlinNothingValueException: IrSimpleFunctionSymbol =
         intrinsicsClass.functions.single { it.owner.name.asString() == "throwKotlinNothingValueException" }
 
-    val intrinsicStringPlus: IrFunctionSymbol =
-        intrinsicsClass.functions.single { it.owner.name.asString() == "stringPlus" }
-
     val intrinsicsKotlinClass: IrClassSymbol =
         (intrinsicsClass.owner.declarations.single { it is IrClass && it.name.asString() == "Kotlin" } as IrClass).symbol
 

--- a/compiler/testData/codegen/box/strings/twoArgumentNullableStringOperatorPlus.kt
+++ b/compiler/testData/codegen/box/strings/twoArgumentNullableStringOperatorPlus.kt
@@ -1,0 +1,17 @@
+fun stringPlus(x: String?, y: Any?) = x + y
+
+fun box(): String {
+    val t1 = stringPlus("a", "b")
+    if (t1 != "ab") return "Failed: t1=$t1"
+
+    val t2 = stringPlus("a", null)
+    if (t2 != "anull") return "Failed: t2=$t2"
+
+    val t3 = stringPlus(null, "b")
+    if (t3 != "nullb") return "Failed: t3=$t3"
+
+    val t4 = stringPlus(null, null)
+    if (t4 != "nullnull") return "Failed: t4=$t4"
+
+    return "OK"
+}

--- a/compiler/testData/codegen/box/strings/twoArgumentNullableStringPlus.kt
+++ b/compiler/testData/codegen/box/strings/twoArgumentNullableStringPlus.kt
@@ -1,0 +1,17 @@
+fun stringPlus(x: String?, y: Any?) = x.plus(y)
+
+fun box(): String {
+    val t1 = stringPlus("a", "b")
+    if (t1 != "ab") return "Failed: t1=$t1"
+
+    val t2 = stringPlus("a", null)
+    if (t2 != "anull") return "Failed: t2=$t2"
+
+    val t3 = stringPlus(null, "b")
+    if (t3 != "nullb") return "Failed: t3=$t3"
+
+    val t4 = stringPlus(null, null)
+    if (t4 != "nullnull") return "Failed: t4=$t4"
+
+    return "OK"
+}

--- a/compiler/testData/codegen/box/strings/twoArgumentStringTemplate.kt
+++ b/compiler/testData/codegen/box/strings/twoArgumentStringTemplate.kt
@@ -1,0 +1,17 @@
+fun stringPlus(x: String?, y: Any?) = "$x$y"
+
+fun box(): String {
+    val t1 = stringPlus("a", "b")
+    if (t1 != "ab") return "Failed: t1=$t1"
+
+    val t2 = stringPlus("a", null)
+    if (t2 != "anull") return "Failed: t2=$t2"
+
+    val t3 = stringPlus(null, "b")
+    if (t3 != "nullb") return "Failed: t3=$t3"
+
+    val t4 = stringPlus(null, null)
+    if (t4 != "nullnull") return "Failed: t4=$t4"
+
+    return "OK"
+}

--- a/compiler/testData/codegen/bytecodeText/boxingOptimization/maxMinByOrNull.kt
+++ b/compiler/testData/codegen/bytecodeText/boxingOptimization/maxMinByOrNull.kt
@@ -33,19 +33,8 @@ fun box(): String {
 // 1 IFGE
 // 1 IFLE
 
-// JVM_TEMPLATES
-// -- no boxing but lots of StringBuilder calls
 // 0 valueOf
 // 0 Intrinsics.stringPlus
 // 4 StringBuilder.<init>
 // 8 StringBuilder.append
 // 4 StringBuilder.toString
-
-// JVM_IR_TEMPLATES
-// -- perform boxing and call Intrinsics.stringPlus instead
-// -- of having inlined string builder allocation, appends, and toString
-// 4 valueOf
-// 4 Intrinsics.stringPlus
-// 0 StringBuilder.<init>
-// 0 StringBuilder.append
-// 0 StringBuilder.toString

--- a/compiler/testData/codegen/bytecodeText/stringOperations/nullableStringPlus.kt
+++ b/compiler/testData/codegen/bytecodeText/stringOperations/nullableStringPlus.kt
@@ -1,3 +1,9 @@
 fun foo(x: String?, y: Any?) = x + y
 
+// JVM_TEMPLATES
 // 1 stringPlus
+
+// JVM_IR_TEMPLATES
+// 1 NEW java/lang/StringBuilder
+// 2 INVOKEVIRTUAL java/lang/StringBuilder\.append \(Ljava/lang/Object;\)Ljava/lang/StringBuilder;
+// 1 INVOKEVIRTUAL java/lang/StringBuilder\.toString \(\)Ljava/lang/String;

--- a/compiler/testData/codegen/bytecodeText/stringOperations/stringPlus.kt
+++ b/compiler/testData/codegen/bytecodeText/stringOperations/stringPlus.kt
@@ -1,5 +1,3 @@
-// IGNORE_BACKEND: JVM
-
 fun f(s: String?, t: String): String {
     return s.plus(t)
 }
@@ -12,6 +10,9 @@ fun h(s: String, t: Any?): String {
     return s + t
 }
 
-// 0 valueOf
-// 0 NEW java/lang/StringBuilder
-// 3 INVOKESTATIC kotlin/jvm/internal/Intrinsics.stringPlus
+// JVM_TEMPLATES
+// 1 INVOKESTATIC kotlin/jvm/internal/Intrinsics.stringPlus
+// - used in 's.plus(t)'
+
+// JVM_IR_TEMPLATES
+// 0 INVOKESTATIC kotlin/jvm/internal/Intrinsics.stringPlus

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -41381,6 +41381,24 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
         public void testSurrogatePair() throws Exception {
             runTest("compiler/testData/codegen/box/strings/surrogatePair.kt");
         }
+
+        @Test
+        @TestMetadata("twoArgumentNullableStringOperatorPlus.kt")
+        public void testTwoArgumentNullableStringOperatorPlus() throws Exception {
+            runTest("compiler/testData/codegen/box/strings/twoArgumentNullableStringOperatorPlus.kt");
+        }
+
+        @Test
+        @TestMetadata("twoArgumentNullableStringPlus.kt")
+        public void testTwoArgumentNullableStringPlus() throws Exception {
+            runTest("compiler/testData/codegen/box/strings/twoArgumentNullableStringPlus.kt");
+        }
+
+        @Test
+        @TestMetadata("twoArgumentStringTemplate.kt")
+        public void testTwoArgumentStringTemplate() throws Exception {
+            runTest("compiler/testData/codegen/box/strings/twoArgumentStringTemplate.kt");
+        }
     }
 
     @Nested

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -41537,6 +41537,24 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         public void testSurrogatePair() throws Exception {
             runTest("compiler/testData/codegen/box/strings/surrogatePair.kt");
         }
+
+        @Test
+        @TestMetadata("twoArgumentNullableStringOperatorPlus.kt")
+        public void testTwoArgumentNullableStringOperatorPlus() throws Exception {
+            runTest("compiler/testData/codegen/box/strings/twoArgumentNullableStringOperatorPlus.kt");
+        }
+
+        @Test
+        @TestMetadata("twoArgumentNullableStringPlus.kt")
+        public void testTwoArgumentNullableStringPlus() throws Exception {
+            runTest("compiler/testData/codegen/box/strings/twoArgumentNullableStringPlus.kt");
+        }
+
+        @Test
+        @TestMetadata("twoArgumentStringTemplate.kt")
+        public void testTwoArgumentStringTemplate() throws Exception {
+            runTest("compiler/testData/codegen/box/strings/twoArgumentStringTemplate.kt");
+        }
     }
 
     @Nested

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -33255,6 +33255,21 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
         public void testSurrogatePair() throws Exception {
             runTest("compiler/testData/codegen/box/strings/surrogatePair.kt");
         }
+
+        @TestMetadata("twoArgumentNullableStringOperatorPlus.kt")
+        public void testTwoArgumentNullableStringOperatorPlus() throws Exception {
+            runTest("compiler/testData/codegen/box/strings/twoArgumentNullableStringOperatorPlus.kt");
+        }
+
+        @TestMetadata("twoArgumentNullableStringPlus.kt")
+        public void testTwoArgumentNullableStringPlus() throws Exception {
+            runTest("compiler/testData/codegen/box/strings/twoArgumentNullableStringPlus.kt");
+        }
+
+        @TestMetadata("twoArgumentStringTemplate.kt")
+        public void testTwoArgumentStringTemplate() throws Exception {
+            runTest("compiler/testData/codegen/box/strings/twoArgumentStringTemplate.kt");
+        }
     }
 
     @TestMetadata("compiler/testData/codegen/box/super")

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/es6/semantics/IrJsCodegenBoxES6TestGenerated.java
@@ -27780,6 +27780,21 @@ public class IrJsCodegenBoxES6TestGenerated extends AbstractIrJsCodegenBoxES6Tes
         public void testSurrogatePair() throws Exception {
             runTest("compiler/testData/codegen/box/strings/surrogatePair.kt");
         }
+
+        @TestMetadata("twoArgumentNullableStringOperatorPlus.kt")
+        public void testTwoArgumentNullableStringOperatorPlus() throws Exception {
+            runTest("compiler/testData/codegen/box/strings/twoArgumentNullableStringOperatorPlus.kt");
+        }
+
+        @TestMetadata("twoArgumentNullableStringPlus.kt")
+        public void testTwoArgumentNullableStringPlus() throws Exception {
+            runTest("compiler/testData/codegen/box/strings/twoArgumentNullableStringPlus.kt");
+        }
+
+        @TestMetadata("twoArgumentStringTemplate.kt")
+        public void testTwoArgumentStringTemplate() throws Exception {
+            runTest("compiler/testData/codegen/box/strings/twoArgumentStringTemplate.kt");
+        }
     }
 
     @TestMetadata("compiler/testData/codegen/box/super")

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/semantics/IrJsCodegenBoxTestGenerated.java
@@ -27186,6 +27186,21 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
         public void testSurrogatePair() throws Exception {
             runTest("compiler/testData/codegen/box/strings/surrogatePair.kt");
         }
+
+        @TestMetadata("twoArgumentNullableStringOperatorPlus.kt")
+        public void testTwoArgumentNullableStringOperatorPlus() throws Exception {
+            runTest("compiler/testData/codegen/box/strings/twoArgumentNullableStringOperatorPlus.kt");
+        }
+
+        @TestMetadata("twoArgumentNullableStringPlus.kt")
+        public void testTwoArgumentNullableStringPlus() throws Exception {
+            runTest("compiler/testData/codegen/box/strings/twoArgumentNullableStringPlus.kt");
+        }
+
+        @TestMetadata("twoArgumentStringTemplate.kt")
+        public void testTwoArgumentStringTemplate() throws Exception {
+            runTest("compiler/testData/codegen/box/strings/twoArgumentStringTemplate.kt");
+        }
     }
 
     @TestMetadata("compiler/testData/codegen/box/super")

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/semantics/JsCodegenBoxTestGenerated.java
@@ -27111,6 +27111,21 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
         public void testSurrogatePair() throws Exception {
             runTest("compiler/testData/codegen/box/strings/surrogatePair.kt");
         }
+
+        @TestMetadata("twoArgumentNullableStringOperatorPlus.kt")
+        public void testTwoArgumentNullableStringOperatorPlus() throws Exception {
+            runTest("compiler/testData/codegen/box/strings/twoArgumentNullableStringOperatorPlus.kt");
+        }
+
+        @TestMetadata("twoArgumentNullableStringPlus.kt")
+        public void testTwoArgumentNullableStringPlus() throws Exception {
+            runTest("compiler/testData/codegen/box/strings/twoArgumentNullableStringPlus.kt");
+        }
+
+        @TestMetadata("twoArgumentStringTemplate.kt")
+        public void testTwoArgumentStringTemplate() throws Exception {
+            runTest("compiler/testData/codegen/box/strings/twoArgumentStringTemplate.kt");
+        }
     }
 
     @TestMetadata("compiler/testData/codegen/box/super")

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/wasm/semantics/IrCodegenBoxWasmTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/wasm/semantics/IrCodegenBoxWasmTestGenerated.java
@@ -16395,6 +16395,21 @@ public class IrCodegenBoxWasmTestGenerated extends AbstractIrCodegenBoxWasmTest 
         public void testSurrogatePair() throws Exception {
             runTest("compiler/testData/codegen/box/strings/surrogatePair.kt");
         }
+
+        @TestMetadata("twoArgumentNullableStringOperatorPlus.kt")
+        public void testTwoArgumentNullableStringOperatorPlus() throws Exception {
+            runTest("compiler/testData/codegen/box/strings/twoArgumentNullableStringOperatorPlus.kt");
+        }
+
+        @TestMetadata("twoArgumentNullableStringPlus.kt")
+        public void testTwoArgumentNullableStringPlus() throws Exception {
+            runTest("compiler/testData/codegen/box/strings/twoArgumentNullableStringPlus.kt");
+        }
+
+        @TestMetadata("twoArgumentStringTemplate.kt")
+        public void testTwoArgumentStringTemplate() throws Exception {
+            runTest("compiler/testData/codegen/box/strings/twoArgumentStringTemplate.kt");
+        }
     }
 
     @TestMetadata("compiler/testData/codegen/box/super")


### PR DESCRIPTION
Using `Intrinsics.stringPlus` for string concatenation causes performance regressions in HotSpot.
1. It requires boxing for primitive types.
2. It affects string concatenation optimizations in HotSpot.

In fact, it's questionable whether we should use `Intrinsics.stringPlus` at all.