### PR TITLE
Add keep rules to ensure the name is kept for defined kotlin primitive types

### DIFF
--- a/core/reflection.jvm/resources/META-INF/com.android.tools/r8-from-1.6.0/kotlin-reflect.pro
+++ b/core/reflection.jvm/resources/META-INF/com.android.tools/r8-from-1.6.0/kotlin-reflect.pro
@@ -5,6 +5,18 @@
 # Keep Metadata annotations so they can be parsed at runtime.
 -keep class kotlin.Metadata { *; }
 
+# Ensure that known types to reflect and kotlinc are not rewritten to object in the metadata if pruned
+-keep,allowshrinking,allowoptimization kotlin.Unit
+-keep,allowshrinking,allowoptimization kotlin.UByte
+-keep,allowshrinking,allowoptimization kotlin.UByteArray
+-keep,allowshrinking,allowoptimization kotlin.UShort
+-keep,allowshrinking,allowoptimization kotlin.UShortArray
+-keep,allowshrinking,allowoptimization kotlin.UInt
+-keep,allowshrinking,allowoptimization kotlin.UIntArray
+-keep,allowshrinking,allowoptimization kotlin.ULong
+-keep,allowshrinking,allowoptimization kotlin.ULongArray
+-keep,allowshrinking,allowoptimization kotlin.Function
+
 # Keep generic signatures and annotations at runtime.
 # R8 requires InnerClasses and EnclosingMethod if you keepattributes Signature.
 -keepattributes InnerClasses,Signature,RuntimeVisible*Annotations,EnclosingMethod
@@ -14,3 +26,4 @@
 
 # Don't note on internal APIs, as there is some class relocating that shrinkers may unnecessarily find suspicious.
 -dontwarn kotlin.reflect.jvm.internal.**
+

--- a/core/reflection.jvm/resources/META-INF/com.android.tools/r8-from-1.6.0/kotlin-reflect.pro
+++ b/core/reflection.jvm/resources/META-INF/com.android.tools/r8-from-1.6.0/kotlin-reflect.pro
@@ -26,4 +26,3 @@
 
 # Don't note on internal APIs, as there is some class relocating that shrinkers may unnecessarily find suspicious.
 -dontwarn kotlin.reflect.jvm.internal.**
-


### PR DESCRIPTION
When looking up java methods from kotlin metadata, the reflection library goes through `src/kotlin/reflect/jvm/internal/RuntimeTypeMapper.kt` to find a concrete java method. To bridge kotlin specific types it uses a hard coded map (I believe it is this one: `https://github.com/JetBrains/kotlin/blob/master/core/metadata.jvm/src/org/jetbrains/kotlin/metadata/jvm/deserialization/ClassMapperLite.kt`) to map void to `kotlin.Unit` to void etc.

kotlin-stdlib defines kotlin.Unit, UByte, ..., ULong as classes in the kotlin standard library. Since these types can be present in the output after an R8 compilation, and they have no defined keep rules, their names can move freely. R8 will therefore rename `kotlin.Unit` to fx. `a.a` and rewrite `kotlin/Unit` to `a/a` in the metadata. The result is that looking up java methods fails.

A bug reported on this issue can be found here: https://issuetracker.google.com/issues/196179629

Note that R8 from version 3.1.24 handles pruning of these specific types. Before version 3.1.24, if we were able to prune `kotlin.Unit` we would rewrite the type in the Metadata to kotlin/Any since `kotlin.Unit` is a reference type - it is defined as a class in the library. From version 3.1.24 we now have special handling for the list of types in this CL such that their name stays the same.

There is no need to update the other PG files since it is unknown how proguard rewrites metadata and earlier version than R8 1.6.0 do not support metadata.