### PR TITLE
KT-49066: Use correct moduleName in the incremental compilation

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/Tasks.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/Tasks.kt
@@ -553,6 +553,9 @@ abstract class KotlinCompile @Inject constructor(
                     compileJavaTaskProvider.map { it.name }
                 )
             }
+            task.moduleName.set(task.project.provider {
+                task.kotlinOptions.moduleName ?: task.parentKotlinOptionsImpl.orNull?.moduleName ?: compilation.moduleName
+            })
 
             if (properties.useClasspathSnapshot) {
                 val classpathSnapshot = task.project.configurations.getByName(classpathSnapshotConfigurationName(task.name))


### PR DESCRIPTION
When storing mapping from moduleName to module information, ensure
that values from kotlinOptions DSL objects are taken into
consideration.

Fixes #KT-49066
Test: KotlinAndroid70GradleIT.testCustomModuleName