### PR TITLE
JVM_IR: generate `$suspendImpl` in interfaces as public

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -24820,6 +24820,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
                     runTest("compiler/testData/codegen/box/jvm8/defaults/noDefaultImpls/suspendFunction.kt");
                 }
 
+                @Test
+                @TestMetadata("suspendSuperCall.kt")
+                public void testSuspendSuperCall() throws Exception {
+                    runTest("compiler/testData/codegen/box/jvm8/defaults/noDefaultImpls/suspendSuperCall.kt");
+                }
+
                 @Nested
                 @TestMetadata("compiler/testData/codegen/box/jvm8/defaults/noDefaultImpls/delegationBy")
                 @TestDataPath("$PROJECT_ROOT")

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/AddContinuationLowering.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/AddContinuationLowering.kt
@@ -224,7 +224,10 @@ private class AddContinuationLowering(context: JvmBackendContext) : SuspendLower
             irFunction,
             origin = JvmLoweredDeclarationOrigin.SUSPEND_IMPL_STATIC_FUNCTION,
             modality = Modality.OPEN,
-            visibility = JavaDescriptorVisibilities.PACKAGE_VISIBILITY,
+            visibility = if (irFunction.parentAsClass.isJvmInterface)
+                DescriptorVisibilities.PUBLIC
+            else
+                JavaDescriptorVisibilities.PACKAGE_VISIBILITY,
             isFakeOverride = false,
             copyMetadata = false
         )
@@ -344,7 +347,7 @@ private class AddContinuationLowering(context: JvmBackendContext) : SuspendLower
                     }
                 }
 
-                val newFunction = if (function.isOverridable && !function.parentAsClass.isJvmInterface) {
+                val newFunction = if (function.isOverridable) {
                     // Create static method for the suspend state machine method so that reentering the method
                     // does not lead to virtual dispatch to the wrong method.
                     createStaticSuspendImpl(view).also { result += it }

--- a/compiler/testData/codegen/box/jvm8/defaults/noDefaultImpls/suspendSuperCall.kt
+++ b/compiler/testData/codegen/box/jvm8/defaults/noDefaultImpls/suspendSuperCall.kt
@@ -1,0 +1,34 @@
+// !JVM_DEFAULT_MODE: all
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND: JVM
+// JVM_TARGET: 1.8
+// WITH_COROUTINES
+// WITH_RUNTIME
+import kotlin.coroutines.*
+import kotlin.coroutines.intrinsics.*
+import helpers.*
+
+suspend fun suspendHere() = suspendCoroutineUninterceptedOrReturn<Unit> {
+    it.resume(Unit)
+    COROUTINE_SUSPENDED
+}
+
+interface MyInterface {
+    suspend fun myMethod(myParam: String): String {
+        suspendHere()
+        return myParam
+    }
+}
+
+class MyImplementation : MyInterface {
+    override suspend fun myMethod(myParam: String): String {
+        suspendHere()
+        return super.myMethod(myParam)
+    }
+}
+
+fun box(): String {
+    var result = "fail"
+    suspend { result = MyImplementation().myMethod("OK") }.startCoroutine(EmptyContinuation)
+    return result
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -24688,6 +24688,12 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
                     runTest("compiler/testData/codegen/box/jvm8/defaults/noDefaultImpls/suspendFunction.kt");
                 }
 
+                @Test
+                @TestMetadata("suspendSuperCall.kt")
+                public void testSuspendSuperCall() throws Exception {
+                    runTest("compiler/testData/codegen/box/jvm8/defaults/noDefaultImpls/suspendSuperCall.kt");
+                }
+
                 @Nested
                 @TestMetadata("compiler/testData/codegen/box/jvm8/defaults/noDefaultImpls/delegationBy")
                 @TestDataPath("$PROJECT_ROOT")

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -24820,6 +24820,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
                     runTest("compiler/testData/codegen/box/jvm8/defaults/noDefaultImpls/suspendFunction.kt");
                 }
 
+                @Test
+                @TestMetadata("suspendSuperCall.kt")
+                public void testSuspendSuperCall() throws Exception {
+                    runTest("compiler/testData/codegen/box/jvm8/defaults/noDefaultImpls/suspendSuperCall.kt");
+                }
+
                 @Nested
                 @TestMetadata("compiler/testData/codegen/box/jvm8/defaults/noDefaultImpls/delegationBy")
                 @TestDataPath("$PROJECT_ROOT")

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -20618,6 +20618,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
                     runTest("compiler/testData/codegen/box/jvm8/defaults/noDefaultImpls/kt42967_all.kt");
                 }
 
+                @TestMetadata("suspendSuperCall.kt")
+                public void ignoreSuspendSuperCall() throws Exception {
+                    runTest("compiler/testData/codegen/box/jvm8/defaults/noDefaultImpls/suspendSuperCall.kt");
+                }
+
                 private void runTest(String testDataFilePath) throws Exception {
                     KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM, testDataFilePath);
                 }


### PR DESCRIPTION
The visibility was the cause of KT-44533; not generating `$suspendImpl` at all makes `super` calls impossible.

^KT-49106 Fixed