### PR TITLE
JvmValueParameterExtensionVisitor superclass

### DIFF
--- a/libraries/kotlinx-metadata/jvm/src/kotlinx/metadata/jvm/jvmExtensionVisitors.kt
+++ b/libraries/kotlinx-metadata/jvm/src/kotlinx/metadata/jvm/jvmExtensionVisitors.kt
@@ -394,7 +394,7 @@ open class JvmTypeAliasExtensionVisitor @JvmOverloads constructor(
  */
 open class JvmValueParameterExtensionVisitor @JvmOverloads constructor(
     private val delegate: JvmValueParameterExtensionVisitor? = null
-) : KmTypeAliasExtensionVisitor {
+) : KmValueParameterExtensionVisitor {
     final override val type: KmExtensionType
         get() = TYPE
 


### PR DESCRIPTION
Its supertype was `KmTypeAliasExtensionVisitor`, but it looks like this was a copy/paste error, and it should be `KmValueParameterExtensionVisitor`.

I'm not certain which tests are relevant, but I've run `frontendApiTests` and they pass.
