### PR TITLE
AsmLikeInstructionListingTest: Handle remaining instructions

### DIFF
--- a/compiler/tests-common/tests/org/jetbrains/kotlin/codegen/AbstractAsmLikeInstructionListingTest.kt
+++ b/compiler/tests-common/tests/org/jetbrains/kotlin/codegen/AbstractAsmLikeInstructionListingTest.kt
@@ -9,7 +9,6 @@ import org.jetbrains.kotlin.ObsoleteTestInfrastructure
 import org.jetbrains.kotlin.test.KotlinTestUtils
 import org.jetbrains.org.objectweb.asm.ClassReader
 import org.jetbrains.org.objectweb.asm.Label
-import org.jetbrains.org.objectweb.asm.Opcodes
 import org.jetbrains.org.objectweb.asm.Opcodes.*
 import org.jetbrains.org.objectweb.asm.Type
 import org.jetbrains.org.objectweb.asm.tree.*
@@ -279,7 +278,7 @@ abstract class AbstractAsmLikeInstructionListingTest : CodegenTestCase() {
         return buildString {
             append("Local variables:")
             for (variable in localVariables) {
-                appendLine().append((variable.index.toString() + " " + variable.name + ": " + variable.desc).withMargin())
+                appendLine().append(("${variable.index} ${variable.name}: ${variable.desc}").withMargin())
             }
         }
     }
@@ -296,12 +295,12 @@ abstract class AbstractAsmLikeInstructionListingTest : CodegenTestCase() {
 
     private fun StringBuilder.renderInstruction(node: AbstractInsnNode, labelMappings: LabelMappings) {
         if (node is LabelNode) {
-            appendLine("LABEL (L" + labelMappings[node.label] + ")")
+            appendLine("LABEL (L${labelMappings[node.label]})")
             return
         }
 
         if (node is LineNumberNode) {
-            appendLine("LINENUMBER (" + node.line + ")")
+            appendLine("LINENUMBER (${node.line})")
             return
         }
 
@@ -310,15 +309,32 @@ abstract class AbstractAsmLikeInstructionListingTest : CodegenTestCase() {
         append("  ").append(Printer.OPCODES[node.opcode] ?: error("Invalid opcode ${node.opcode}"))
 
         when (node) {
-            is FieldInsnNode -> append(" (" + node.owner + ", " + node.name + ", " + node.desc + ")")
-            is JumpInsnNode -> append(" (L" + labelMappings[node.label.label] + ")")
-            is IntInsnNode -> append(" (" + node.operand + ")")
-            is MethodInsnNode -> append(" (" + node.owner + ", "+ node.name + ", " + node.desc + ")")
-            is VarInsnNode -> append(" (" + node.`var` + ")")
-            is LdcInsnNode -> append(" (" + node.cst + ")")
+            is FieldInsnNode -> append(" (${node.owner}, ${node.name}, ${node.desc})")
+            is JumpInsnNode -> append(" (L${labelMappings[node.label.label]})")
+            is IntInsnNode -> append(" (${node.operand})")
+            is MethodInsnNode -> append(" (${node.owner}, ${node.name}, ${node.desc})")
+            is VarInsnNode -> append(" (${node.`var`})")
+            is LdcInsnNode -> append(" (${node.cst})")
+            is TypeInsnNode -> append(" (${node.desc})")
+            is IincInsnNode -> append(" (${node.`var`}, ${node.incr})")
+            is MultiANewArrayInsnNode -> append(" (${node.desc}, ${node.dims})")
+            is InvokeDynamicInsnNode -> append(" (${node.name}, ${node.desc}, ${node.bsm}, ${node.bsmArgs.joinToString()})")
         }
 
         appendLine()
+
+        if (node is TableSwitchInsnNode || node is LookupSwitchInsnNode) {
+            val (cases, default) = if (node is LookupSwitchInsnNode) {
+                node.keys.zip(node.labels) to node.dflt
+            } else {
+                (node as TableSwitchInsnNode).min.rangeTo(node.max).zip(node.labels) to node.dflt
+            }
+
+            for ((key, labelNode) in cases) {
+                appendLine("    $key: L${labelMappings[labelNode.label]}")
+            }
+            appendLine("    default: L${labelMappings[default.label]}")
+        }
     }
 
     private fun String.withMargin(margin: String = "    "): String {

--- a/plugins/kotlin-serialization/kotlin-serialization-compiler/testData/codegen/Basic.ir.txt
+++ b/plugins/kotlin-serialization/kotlin-serialization-compiler/testData/codegen/Basic.ir.txt
@@ -4,17 +4,17 @@ public final class ListOfUsers$$serializer : java/lang/Object, kotlinx/serializa
     public final static kotlinx.serialization.descriptors.SerialDescriptor descriptor
 
     static void <clinit>() {
-          NEW
+          NEW (ListOfUsers$$serializer)
           DUP
           INVOKESPECIAL (ListOfUsers$$serializer, <init>, ()V)
           PUTSTATIC (ListOfUsers$$serializer, INSTANCE, LListOfUsers$$serializer;)
         LABEL (L0)
         LINENUMBER (12)
-          NEW
+          NEW (kotlinx/serialization/internal/PluginGeneratedSerialDescriptor)
           DUP
           LDC (ListOfUsers)
           GETSTATIC (ListOfUsers$$serializer, INSTANCE, LListOfUsers$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/internal/GeneratedSerializer)
           ICONST_1
           INVOKESPECIAL (kotlinx/serialization/internal/PluginGeneratedSerialDescriptor, <init>, (Ljava/lang/String;Lkotlinx/serialization/internal/GeneratedSerializer;I)V)
           ASTORE (0)
@@ -23,7 +23,7 @@ public final class ListOfUsers$$serializer : java/lang/Object, kotlinx/serializa
           ICONST_0
           INVOKEVIRTUAL (kotlinx/serialization/internal/PluginGeneratedSerialDescriptor, addElement, (Ljava/lang/String;Z)V)
           ALOAD (0)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/descriptors/SerialDescriptor)
           PUTSTATIC (ListOfUsers$$serializer, descriptor, Lkotlinx/serialization/descriptors/SerialDescriptor;)
         LABEL (L1)
         LINENUMBER (13)
@@ -43,16 +43,16 @@ public final class ListOfUsers$$serializer : java/lang/Object, kotlinx/serializa
         LABEL (L0)
         LINENUMBER (12)
           ICONST_1
-          ANEWARRAY
+          ANEWARRAY (kotlinx/serialization/KSerializer)
           ASTORE (1)
           ALOAD (1)
           ICONST_0
-          NEW
+          NEW (kotlinx/serialization/internal/ArrayListSerializer)
           DUP
           GETSTATIC (User$$serializer, INSTANCE, LUser$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           INVOKESPECIAL (kotlinx/serialization/internal/ArrayListSerializer, <init>, (Lkotlinx/serialization/KSerializer;)V)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           AASTORE
           ALOAD (1)
           ARETURN
@@ -85,12 +85,12 @@ public final class ListOfUsers$$serializer : java/lang/Object, kotlinx/serializa
           ALOAD (7)
           ALOAD (2)
           ICONST_0
-          NEW
+          NEW (kotlinx/serialization/internal/ArrayListSerializer)
           DUP
           GETSTATIC (User$$serializer, INSTANCE, LUser$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           INVOKESPECIAL (kotlinx/serialization/internal/ArrayListSerializer, <init>, (Lkotlinx/serialization/KSerializer;)V)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/DeserializationStrategy)
           ALOAD (6)
           INVOKEINTERFACE (kotlinx/serialization/encoding/CompositeDecoder, decodeSerializableElement, (Lkotlinx/serialization/descriptors/SerialDescriptor;ILkotlinx/serialization/DeserializationStrategy;Ljava/lang/Object;)Ljava/lang/Object;)
           ASTORE (6)
@@ -108,6 +108,9 @@ public final class ListOfUsers$$serializer : java/lang/Object, kotlinx/serializa
           ISTORE (4)
           ILOAD (4)
           TABLESWITCH
+            -1: L4
+            0: L5
+            default: L6
         LABEL (L4)
           ICONST_0
           ISTORE (3)
@@ -116,12 +119,12 @@ public final class ListOfUsers$$serializer : java/lang/Object, kotlinx/serializa
           ALOAD (7)
           ALOAD (2)
           ICONST_0
-          NEW
+          NEW (kotlinx/serialization/internal/ArrayListSerializer)
           DUP
           GETSTATIC (User$$serializer, INSTANCE, LUser$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           INVOKESPECIAL (kotlinx/serialization/internal/ArrayListSerializer, <init>, (Lkotlinx/serialization/KSerializer;)V)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/DeserializationStrategy)
           ALOAD (6)
           INVOKEINTERFACE (kotlinx/serialization/encoding/CompositeDecoder, decodeSerializableElement, (Lkotlinx/serialization/descriptors/SerialDescriptor;ILkotlinx/serialization/DeserializationStrategy;Ljava/lang/Object;)Ljava/lang/Object;)
           ASTORE (6)
@@ -131,7 +134,7 @@ public final class ListOfUsers$$serializer : java/lang/Object, kotlinx/serializa
           ISTORE (5)
           GOTO (L2)
         LABEL (L6)
-          NEW
+          NEW (kotlinx/serialization/UnknownFieldException)
           DUP
           ILOAD (4)
           INVOKESPECIAL (kotlinx/serialization/UnknownFieldException, <init>, (I)V)
@@ -140,11 +143,11 @@ public final class ListOfUsers$$serializer : java/lang/Object, kotlinx/serializa
           ALOAD (7)
           ALOAD (2)
           INVOKEINTERFACE (kotlinx/serialization/encoding/CompositeDecoder, endStructure, (Lkotlinx/serialization/descriptors/SerialDescriptor;)V)
-          NEW
+          NEW (ListOfUsers)
           DUP
           ILOAD (5)
           ALOAD (6)
-          CHECKCAST
+          CHECKCAST (java/util/List)
           ACONST_NULL
           INVOKESPECIAL (ListOfUsers, <init>, (ILjava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V)
           ARETURN
@@ -197,7 +200,7 @@ public final class ListOfUsers$$serializer : java/lang/Object, kotlinx/serializa
           ALOAD (0)
           ALOAD (1)
           ALOAD (2)
-          CHECKCAST
+          CHECKCAST (ListOfUsers)
           INVOKEVIRTUAL (ListOfUsers$$serializer, serialize, (Lkotlinx/serialization/encoding/Encoder;LListOfUsers;)V)
           RETURN
         LABEL (L1)
@@ -233,7 +236,7 @@ public final class ListOfUsers : java/lang/Object {
     private final java.util.List list
 
     static void <clinit>() {
-          NEW
+          NEW (ListOfUsers$Companion)
           DUP
           ACONST_NULL
           INVOKESPECIAL (ListOfUsers$Companion, <init>, (Lkotlin/jvm/internal/DefaultConstructorMarker;)V)
@@ -300,12 +303,12 @@ public final class ListOfUsers : java/lang/Object {
           ALOAD (1)
           ALOAD (2)
           ICONST_0
-          NEW
+          NEW (kotlinx/serialization/internal/ArrayListSerializer)
           DUP
           GETSTATIC (User$$serializer, INSTANCE, LUser$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           INVOKESPECIAL (kotlinx/serialization/internal/ArrayListSerializer, <init>, (Lkotlinx/serialization/KSerializer;)V)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/SerializationStrategy)
           ALOAD (0)
           GETFIELD (ListOfUsers, list, Ljava/util/List;)
           INVOKEINTERFACE (kotlinx/serialization/encoding/CompositeEncoder, encodeSerializableElement, (Lkotlinx/serialization/descriptors/SerialDescriptor;ILkotlinx/serialization/SerializationStrategy;Ljava/lang/Object;)V)
@@ -320,17 +323,17 @@ public final class OptionalUser$$serializer : java/lang/Object, kotlinx/serializ
     public final static kotlinx.serialization.descriptors.SerialDescriptor descriptor
 
     static void <clinit>() {
-          NEW
+          NEW (OptionalUser$$serializer)
           DUP
           INVOKESPECIAL (OptionalUser$$serializer, <init>, ()V)
           PUTSTATIC (OptionalUser$$serializer, INSTANCE, LOptionalUser$$serializer;)
         LABEL (L0)
         LINENUMBER (9)
-          NEW
+          NEW (kotlinx/serialization/internal/PluginGeneratedSerialDescriptor)
           DUP
           LDC (OptionalUser)
           GETSTATIC (OptionalUser$$serializer, INSTANCE, LOptionalUser$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/internal/GeneratedSerializer)
           ICONST_1
           INVOKESPECIAL (kotlinx/serialization/internal/PluginGeneratedSerialDescriptor, <init>, (Ljava/lang/String;Lkotlinx/serialization/internal/GeneratedSerializer;I)V)
           ASTORE (0)
@@ -339,7 +342,7 @@ public final class OptionalUser$$serializer : java/lang/Object, kotlinx/serializ
           ICONST_1
           INVOKEVIRTUAL (kotlinx/serialization/internal/PluginGeneratedSerialDescriptor, addElement, (Ljava/lang/String;Z)V)
           ALOAD (0)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/descriptors/SerialDescriptor)
           PUTSTATIC (OptionalUser$$serializer, descriptor, Lkotlinx/serialization/descriptors/SerialDescriptor;)
         LABEL (L1)
         LINENUMBER (10)
@@ -359,12 +362,12 @@ public final class OptionalUser$$serializer : java/lang/Object, kotlinx/serializ
         LABEL (L0)
         LINENUMBER (9)
           ICONST_1
-          ANEWARRAY
+          ANEWARRAY (kotlinx/serialization/KSerializer)
           ASTORE (1)
           ALOAD (1)
           ICONST_0
           GETSTATIC (User$$serializer, INSTANCE, LUser$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           AASTORE
           ALOAD (1)
           ARETURN
@@ -398,7 +401,7 @@ public final class OptionalUser$$serializer : java/lang/Object, kotlinx/serializ
           ALOAD (2)
           ICONST_0
           GETSTATIC (User$$serializer, INSTANCE, LUser$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/DeserializationStrategy)
           ALOAD (6)
           INVOKEINTERFACE (kotlinx/serialization/encoding/CompositeDecoder, decodeSerializableElement, (Lkotlinx/serialization/descriptors/SerialDescriptor;ILkotlinx/serialization/DeserializationStrategy;Ljava/lang/Object;)Ljava/lang/Object;)
           ASTORE (6)
@@ -416,6 +419,9 @@ public final class OptionalUser$$serializer : java/lang/Object, kotlinx/serializ
           ISTORE (4)
           ILOAD (4)
           TABLESWITCH
+            -1: L4
+            0: L5
+            default: L6
         LABEL (L4)
           ICONST_0
           ISTORE (3)
@@ -425,7 +431,7 @@ public final class OptionalUser$$serializer : java/lang/Object, kotlinx/serializ
           ALOAD (2)
           ICONST_0
           GETSTATIC (User$$serializer, INSTANCE, LUser$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/DeserializationStrategy)
           ALOAD (6)
           INVOKEINTERFACE (kotlinx/serialization/encoding/CompositeDecoder, decodeSerializableElement, (Lkotlinx/serialization/descriptors/SerialDescriptor;ILkotlinx/serialization/DeserializationStrategy;Ljava/lang/Object;)Ljava/lang/Object;)
           ASTORE (6)
@@ -435,7 +441,7 @@ public final class OptionalUser$$serializer : java/lang/Object, kotlinx/serializ
           ISTORE (5)
           GOTO (L2)
         LABEL (L6)
-          NEW
+          NEW (kotlinx/serialization/UnknownFieldException)
           DUP
           ILOAD (4)
           INVOKESPECIAL (kotlinx/serialization/UnknownFieldException, <init>, (I)V)
@@ -444,11 +450,11 @@ public final class OptionalUser$$serializer : java/lang/Object, kotlinx/serializ
           ALOAD (7)
           ALOAD (2)
           INVOKEINTERFACE (kotlinx/serialization/encoding/CompositeDecoder, endStructure, (Lkotlinx/serialization/descriptors/SerialDescriptor;)V)
-          NEW
+          NEW (OptionalUser)
           DUP
           ILOAD (5)
           ALOAD (6)
-          CHECKCAST
+          CHECKCAST (User)
           ACONST_NULL
           INVOKESPECIAL (OptionalUser, <init>, (ILUser;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V)
           ARETURN
@@ -501,7 +507,7 @@ public final class OptionalUser$$serializer : java/lang/Object, kotlinx/serializ
           ALOAD (0)
           ALOAD (1)
           ALOAD (2)
-          CHECKCAST
+          CHECKCAST (OptionalUser)
           INVOKEVIRTUAL (OptionalUser$$serializer, serialize, (Lkotlinx/serialization/encoding/Encoder;LOptionalUser;)V)
           RETURN
         LABEL (L1)
@@ -537,7 +543,7 @@ public final class OptionalUser : java/lang/Object {
     private final User user
 
     static void <clinit>() {
-          NEW
+          NEW (OptionalUser$Companion)
           DUP
           ACONST_NULL
           INVOKESPECIAL (OptionalUser$Companion, <init>, (Lkotlin/jvm/internal/DefaultConstructorMarker;)V)
@@ -570,7 +576,7 @@ public final class OptionalUser : java/lang/Object {
           ICONST_1
           IAND
           IFEQ (L1)
-          NEW
+          NEW (User)
           DUP
           LDC ()
           LDC ()
@@ -605,7 +611,7 @@ public final class OptionalUser : java/lang/Object {
           ALOAD (0)
         LABEL (L3)
         LINENUMBER (10)
-          NEW
+          NEW (User)
           DUP
           LDC ()
           LDC ()
@@ -661,7 +667,7 @@ public final class OptionalUser : java/lang/Object {
           GETFIELD (OptionalUser, user, LUser;)
         LABEL (L4)
         LINENUMBER (10)
-          NEW
+          NEW (User)
           DUP
           LDC ()
           LDC ()
@@ -680,7 +686,7 @@ public final class OptionalUser : java/lang/Object {
           ALOAD (2)
           ICONST_0
           GETSTATIC (User$$serializer, INSTANCE, LUser$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/SerializationStrategy)
           ALOAD (0)
           GETFIELD (OptionalUser, user, LUser;)
           INVOKEINTERFACE (kotlinx/serialization/encoding/CompositeEncoder, encodeSerializableElement, (Lkotlinx/serialization/descriptors/SerialDescriptor;ILkotlinx/serialization/SerializationStrategy;Ljava/lang/Object;)V)
@@ -696,17 +702,17 @@ public final class User$$serializer : java/lang/Object, kotlinx/serialization/in
     public final static kotlinx.serialization.descriptors.SerialDescriptor descriptor
 
     static void <clinit>() {
-          NEW
+          NEW (User$$serializer)
           DUP
           INVOKESPECIAL (User$$serializer, <init>, ()V)
           PUTSTATIC (User$$serializer, INSTANCE, LUser$$serializer;)
         LABEL (L0)
         LINENUMBER (6)
-          NEW
+          NEW (kotlinx/serialization/internal/PluginGeneratedSerialDescriptor)
           DUP
           LDC (User)
           GETSTATIC (User$$serializer, INSTANCE, LUser$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/internal/GeneratedSerializer)
           ICONST_2
           INVOKESPECIAL (kotlinx/serialization/internal/PluginGeneratedSerialDescriptor, <init>, (Ljava/lang/String;Lkotlinx/serialization/internal/GeneratedSerializer;I)V)
           ASTORE (0)
@@ -719,7 +725,7 @@ public final class User$$serializer : java/lang/Object, kotlinx/serialization/in
           ICONST_0
           INVOKEVIRTUAL (kotlinx/serialization/internal/PluginGeneratedSerialDescriptor, addElement, (Ljava/lang/String;Z)V)
           ALOAD (0)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/descriptors/SerialDescriptor)
           PUTSTATIC (User$$serializer, descriptor, Lkotlinx/serialization/descriptors/SerialDescriptor;)
         LABEL (L1)
         LINENUMBER (7)
@@ -739,17 +745,17 @@ public final class User$$serializer : java/lang/Object, kotlinx/serialization/in
         LABEL (L0)
         LINENUMBER (6)
           ICONST_2
-          ANEWARRAY
+          ANEWARRAY (kotlinx/serialization/KSerializer)
           ASTORE (1)
           ALOAD (1)
           ICONST_0
           GETSTATIC (kotlinx/serialization/internal/StringSerializer, INSTANCE, Lkotlinx/serialization/internal/StringSerializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           AASTORE
           ALOAD (1)
           ICONST_1
           GETSTATIC (kotlinx/serialization/internal/StringSerializer, INSTANCE, Lkotlinx/serialization/internal/StringSerializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           AASTORE
           ALOAD (1)
           ARETURN
@@ -809,6 +815,10 @@ public final class User$$serializer : java/lang/Object, kotlinx/serialization/in
           ISTORE (4)
           ILOAD (4)
           TABLESWITCH
+            -1: L4
+            0: L5
+            1: L6
+            default: L7
         LABEL (L4)
           ICONST_0
           ISTORE (3)
@@ -836,7 +846,7 @@ public final class User$$serializer : java/lang/Object, kotlinx/serialization/in
           ISTORE (5)
           GOTO (L2)
         LABEL (L7)
-          NEW
+          NEW (kotlinx/serialization/UnknownFieldException)
           DUP
           ILOAD (4)
           INVOKESPECIAL (kotlinx/serialization/UnknownFieldException, <init>, (I)V)
@@ -845,7 +855,7 @@ public final class User$$serializer : java/lang/Object, kotlinx/serialization/in
           ALOAD (8)
           ALOAD (2)
           INVOKEINTERFACE (kotlinx/serialization/encoding/CompositeDecoder, endStructure, (Lkotlinx/serialization/descriptors/SerialDescriptor;)V)
-          NEW
+          NEW (User)
           DUP
           ILOAD (5)
           ALOAD (6)
@@ -902,7 +912,7 @@ public final class User$$serializer : java/lang/Object, kotlinx/serialization/in
           ALOAD (0)
           ALOAD (1)
           ALOAD (2)
-          CHECKCAST
+          CHECKCAST (User)
           INVOKEVIRTUAL (User$$serializer, serialize, (Lkotlinx/serialization/encoding/Encoder;LUser;)V)
           RETURN
         LABEL (L1)
@@ -940,7 +950,7 @@ public final class User : java/lang/Object {
     private final java.lang.String lastName
 
     static void <clinit>() {
-          NEW
+          NEW (User$Companion)
           DUP
           ACONST_NULL
           INVOKESPECIAL (User$Companion, <init>, (Lkotlin/jvm/internal/DefaultConstructorMarker;)V)

--- a/plugins/kotlin-serialization/kotlin-serialization-compiler/testData/codegen/Basic.txt
+++ b/plugins/kotlin-serialization/kotlin-serialization-compiler/testData/codegen/Basic.txt
@@ -6,17 +6,17 @@ public final class ListOfUsers$$serializer : java/lang/Object, kotlinx/serializa
     static void <clinit>() {
         LABEL (L0)
         LINENUMBER (13)
-          NEW
+          NEW (ListOfUsers$$serializer)
           DUP
           INVOKESPECIAL (ListOfUsers$$serializer, <init>, ()V)
           ASTORE (0)
           ALOAD (0)
           PUTSTATIC (ListOfUsers$$serializer, INSTANCE, LListOfUsers$$serializer;)
-          NEW
+          NEW (kotlinx/serialization/internal/PluginGeneratedSerialDescriptor)
           DUP
           LDC (ListOfUsers)
           GETSTATIC (ListOfUsers$$serializer, INSTANCE, LListOfUsers$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/internal/GeneratedSerializer)
           LDC (1)
           INVOKESPECIAL (kotlinx/serialization/internal/PluginGeneratedSerialDescriptor, <init>, (Ljava/lang/String;Lkotlinx/serialization/internal/GeneratedSerializer;I)V)
           ASTORE (0)
@@ -41,13 +41,13 @@ public final class ListOfUsers$$serializer : java/lang/Object, kotlinx/serializa
     public kotlinx.serialization.KSerializer[] childSerializers() {
         LABEL (L0)
           ICONST_1
-          ANEWARRAY
+          ANEWARRAY (kotlinx/serialization/KSerializer)
           DUP
           ICONST_0
-          NEW
+          NEW (kotlinx/serialization/internal/ArrayListSerializer)
           DUP
           GETSTATIC (User$$serializer, INSTANCE, LUser$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           INVOKESPECIAL (kotlinx/serialization/internal/ArrayListSerializer, <init>, (Lkotlinx/serialization/KSerializer;)V)
           AASTORE
           ARETURN
@@ -75,14 +75,14 @@ public final class ListOfUsers$$serializer : java/lang/Object, kotlinx/serializa
           ALOAD (1)
           ALOAD (2)
           ICONST_0
-          NEW
+          NEW (kotlinx/serialization/internal/ArrayListSerializer)
           DUP
           GETSTATIC (User$$serializer, INSTANCE, LUser$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           INVOKESPECIAL (kotlinx/serialization/internal/ArrayListSerializer, <init>, (Lkotlinx/serialization/KSerializer;)V)
           ALOAD (5)
           INVOKEINTERFACE (kotlinx/serialization/encoding/CompositeDecoder, decodeSerializableElement, (Lkotlinx/serialization/descriptors/SerialDescriptor;ILkotlinx/serialization/DeserializationStrategy;Ljava/lang/Object;)Ljava/lang/Object;)
-          CHECKCAST
+          CHECKCAST (java/util/List)
           ASTORE (5)
           LDC (2147483647)
           ISTORE (4)
@@ -94,18 +94,21 @@ public final class ListOfUsers$$serializer : java/lang/Object, kotlinx/serializa
           ISTORE (3)
           ILOAD (3)
           TABLESWITCH
+            -1: L2
+            0: L3
+            default: L4
         LABEL (L3)
           ALOAD (1)
           ALOAD (2)
           ICONST_0
-          NEW
+          NEW (kotlinx/serialization/internal/ArrayListSerializer)
           DUP
           GETSTATIC (User$$serializer, INSTANCE, LUser$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           INVOKESPECIAL (kotlinx/serialization/internal/ArrayListSerializer, <init>, (Lkotlinx/serialization/KSerializer;)V)
           ALOAD (5)
           INVOKEINTERFACE (kotlinx/serialization/encoding/CompositeDecoder, decodeSerializableElement, (Lkotlinx/serialization/descriptors/SerialDescriptor;ILkotlinx/serialization/DeserializationStrategy;Ljava/lang/Object;)Ljava/lang/Object;)
-          CHECKCAST
+          CHECKCAST (java/util/List)
           ASTORE (5)
           ILOAD (4)
           ICONST_1
@@ -116,7 +119,7 @@ public final class ListOfUsers$$serializer : java/lang/Object, kotlinx/serializa
           ALOAD (1)
           ALOAD (2)
           INVOKEINTERFACE (kotlinx/serialization/encoding/CompositeDecoder, endStructure, (Lkotlinx/serialization/descriptors/SerialDescriptor;)V)
-          NEW
+          NEW (ListOfUsers)
           DUP
           ILOAD (4)
           ALOAD (5)
@@ -124,11 +127,11 @@ public final class ListOfUsers$$serializer : java/lang/Object, kotlinx/serializa
           INVOKESPECIAL (ListOfUsers, <init>, (ILjava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V)
           ARETURN
         LABEL (L4)
-          NEW
+          NEW (kotlinx/serialization/UnknownFieldException)
           DUP
           ILOAD (3)
           INVOKESPECIAL (kotlinx/serialization/UnknownFieldException, <init>, (I)V)
-          CHECKCAST
+          CHECKCAST (java/lang/Throwable)
           ATHROW
         LABEL (L5)
     }
@@ -175,7 +178,7 @@ public final class ListOfUsers$$serializer : java/lang/Object, kotlinx/serializa
           ALOAD (0)
           ALOAD (1)
           ALOAD (2)
-          CHECKCAST
+          CHECKCAST (ListOfUsers)
           INVOKEVIRTUAL (ListOfUsers$$serializer, serialize, (Lkotlinx/serialization/encoding/Encoder;LListOfUsers;)V)
           RETURN
     }
@@ -211,7 +214,7 @@ public final class ListOfUsers : java/lang/Object {
     private final java.util.List list
 
     static void <clinit>() {
-          NEW
+          NEW (ListOfUsers$Companion)
           DUP
           ACONST_NULL
           INVOKESPECIAL (ListOfUsers$Companion, <init>, (Lkotlin/jvm/internal/DefaultConstructorMarker;)V)
@@ -245,7 +248,7 @@ public final class ListOfUsers : java/lang/Object {
           ILOAD (1)
           ICONST_1
           GETSTATIC (ListOfUsers$$serializer, INSTANCE, LListOfUsers$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           INVOKEINTERFACE (kotlinx/serialization/KSerializer, getDescriptor, ()Lkotlinx/serialization/descriptors/SerialDescriptor;)
           INVOKESTATIC (kotlinx/serialization/internal/PluginExceptionsKt, throwMissingFieldException, (IILkotlinx/serialization/descriptors/SerialDescriptor;)V)
         LABEL (L1)
@@ -274,10 +277,10 @@ public final class ListOfUsers : java/lang/Object {
           ALOAD (1)
           ALOAD (2)
           ICONST_0
-          NEW
+          NEW (kotlinx/serialization/internal/ArrayListSerializer)
           DUP
           GETSTATIC (User$$serializer, INSTANCE, LUser$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           INVOKESPECIAL (kotlinx/serialization/internal/ArrayListSerializer, <init>, (Lkotlinx/serialization/KSerializer;)V)
           ALOAD (0)
           GETFIELD (ListOfUsers, list, Ljava/util/List;)
@@ -295,17 +298,17 @@ public final class OptionalUser$$serializer : java/lang/Object, kotlinx/serializ
     static void <clinit>() {
         LABEL (L0)
         LINENUMBER (10)
-          NEW
+          NEW (OptionalUser$$serializer)
           DUP
           INVOKESPECIAL (OptionalUser$$serializer, <init>, ()V)
           ASTORE (0)
           ALOAD (0)
           PUTSTATIC (OptionalUser$$serializer, INSTANCE, LOptionalUser$$serializer;)
-          NEW
+          NEW (kotlinx/serialization/internal/PluginGeneratedSerialDescriptor)
           DUP
           LDC (OptionalUser)
           GETSTATIC (OptionalUser$$serializer, INSTANCE, LOptionalUser$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/internal/GeneratedSerializer)
           LDC (1)
           INVOKESPECIAL (kotlinx/serialization/internal/PluginGeneratedSerialDescriptor, <init>, (Ljava/lang/String;Lkotlinx/serialization/internal/GeneratedSerializer;I)V)
           ASTORE (0)
@@ -330,11 +333,11 @@ public final class OptionalUser$$serializer : java/lang/Object, kotlinx/serializ
     public kotlinx.serialization.KSerializer[] childSerializers() {
         LABEL (L0)
           ICONST_1
-          ANEWARRAY
+          ANEWARRAY (kotlinx/serialization/KSerializer)
           DUP
           ICONST_0
           GETSTATIC (User$$serializer, INSTANCE, LUser$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           AASTORE
           ARETURN
         LABEL (L1)
@@ -362,10 +365,10 @@ public final class OptionalUser$$serializer : java/lang/Object, kotlinx/serializ
           ALOAD (2)
           ICONST_0
           GETSTATIC (User$$serializer, INSTANCE, LUser$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           ALOAD (5)
           INVOKEINTERFACE (kotlinx/serialization/encoding/CompositeDecoder, decodeSerializableElement, (Lkotlinx/serialization/descriptors/SerialDescriptor;ILkotlinx/serialization/DeserializationStrategy;Ljava/lang/Object;)Ljava/lang/Object;)
-          CHECKCAST
+          CHECKCAST (User)
           ASTORE (5)
           LDC (2147483647)
           ISTORE (4)
@@ -377,15 +380,18 @@ public final class OptionalUser$$serializer : java/lang/Object, kotlinx/serializ
           ISTORE (3)
           ILOAD (3)
           TABLESWITCH
+            -1: L2
+            0: L3
+            default: L4
         LABEL (L3)
           ALOAD (1)
           ALOAD (2)
           ICONST_0
           GETSTATIC (User$$serializer, INSTANCE, LUser$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           ALOAD (5)
           INVOKEINTERFACE (kotlinx/serialization/encoding/CompositeDecoder, decodeSerializableElement, (Lkotlinx/serialization/descriptors/SerialDescriptor;ILkotlinx/serialization/DeserializationStrategy;Ljava/lang/Object;)Ljava/lang/Object;)
-          CHECKCAST
+          CHECKCAST (User)
           ASTORE (5)
           ILOAD (4)
           ICONST_1
@@ -396,7 +402,7 @@ public final class OptionalUser$$serializer : java/lang/Object, kotlinx/serializ
           ALOAD (1)
           ALOAD (2)
           INVOKEINTERFACE (kotlinx/serialization/encoding/CompositeDecoder, endStructure, (Lkotlinx/serialization/descriptors/SerialDescriptor;)V)
-          NEW
+          NEW (OptionalUser)
           DUP
           ILOAD (4)
           ALOAD (5)
@@ -404,11 +410,11 @@ public final class OptionalUser$$serializer : java/lang/Object, kotlinx/serializ
           INVOKESPECIAL (OptionalUser, <init>, (ILUser;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V)
           ARETURN
         LABEL (L4)
-          NEW
+          NEW (kotlinx/serialization/UnknownFieldException)
           DUP
           ILOAD (3)
           INVOKESPECIAL (kotlinx/serialization/UnknownFieldException, <init>, (I)V)
-          CHECKCAST
+          CHECKCAST (java/lang/Throwable)
           ATHROW
         LABEL (L5)
     }
@@ -455,7 +461,7 @@ public final class OptionalUser$$serializer : java/lang/Object, kotlinx/serializ
           ALOAD (0)
           ALOAD (1)
           ALOAD (2)
-          CHECKCAST
+          CHECKCAST (OptionalUser)
           INVOKEVIRTUAL (OptionalUser$$serializer, serialize, (Lkotlinx/serialization/encoding/Encoder;LOptionalUser;)V)
           RETURN
     }
@@ -491,7 +497,7 @@ public final class OptionalUser : java/lang/Object {
     private final User user
 
     static void <clinit>() {
-          NEW
+          NEW (OptionalUser$Companion)
           DUP
           ACONST_NULL
           INVOKESPECIAL (OptionalUser$Companion, <init>, (Lkotlin/jvm/internal/DefaultConstructorMarker;)V)
@@ -522,7 +528,7 @@ public final class OptionalUser : java/lang/Object {
           IFEQ (L0)
         LABEL (L1)
         LINENUMBER (10)
-          NEW
+          NEW (User)
           DUP
           LDC ()
           LDC ()
@@ -554,7 +560,7 @@ public final class OptionalUser : java/lang/Object {
           ILOAD (1)
           ICONST_0
           GETSTATIC (OptionalUser$$serializer, INSTANCE, LOptionalUser$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           INVOKEINTERFACE (kotlinx/serialization/KSerializer, getDescriptor, ()Lkotlinx/serialization/descriptors/SerialDescriptor;)
           INVOKESTATIC (kotlinx/serialization/internal/PluginExceptionsKt, throwMissingFieldException, (IILkotlinx/serialization/descriptors/SerialDescriptor;)V)
         LABEL (L1)
@@ -572,7 +578,7 @@ public final class OptionalUser : java/lang/Object {
           ALOAD (0)
         LABEL (L4)
         LINENUMBER (10)
-          NEW
+          NEW (User)
           DUP
           LDC ()
           LDC ()
@@ -600,7 +606,7 @@ public final class OptionalUser : java/lang/Object {
           GETFIELD (OptionalUser, user, LUser;)
         LABEL (L1)
         LINENUMBER (10)
-          NEW
+          NEW (User)
           DUP
           LDC ()
           LDC ()
@@ -619,7 +625,7 @@ public final class OptionalUser : java/lang/Object {
           ALOAD (2)
           ICONST_0
           GETSTATIC (User$$serializer, INSTANCE, LUser$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           ALOAD (0)
           GETFIELD (OptionalUser, user, LUser;)
           INVOKEINTERFACE (kotlinx/serialization/encoding/CompositeEncoder, encodeSerializableElement, (Lkotlinx/serialization/descriptors/SerialDescriptor;ILkotlinx/serialization/SerializationStrategy;Ljava/lang/Object;)V)
@@ -637,17 +643,17 @@ public final class User$$serializer : java/lang/Object, kotlinx/serialization/in
     static void <clinit>() {
         LABEL (L0)
         LINENUMBER (7)
-          NEW
+          NEW (User$$serializer)
           DUP
           INVOKESPECIAL (User$$serializer, <init>, ()V)
           ASTORE (0)
           ALOAD (0)
           PUTSTATIC (User$$serializer, INSTANCE, LUser$$serializer;)
-          NEW
+          NEW (kotlinx/serialization/internal/PluginGeneratedSerialDescriptor)
           DUP
           LDC (User)
           GETSTATIC (User$$serializer, INSTANCE, LUser$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/internal/GeneratedSerializer)
           LDC (2)
           INVOKESPECIAL (kotlinx/serialization/internal/PluginGeneratedSerialDescriptor, <init>, (Ljava/lang/String;Lkotlinx/serialization/internal/GeneratedSerializer;I)V)
           ASTORE (0)
@@ -676,16 +682,16 @@ public final class User$$serializer : java/lang/Object, kotlinx/serialization/in
     public kotlinx.serialization.KSerializer[] childSerializers() {
         LABEL (L0)
           ICONST_2
-          ANEWARRAY
+          ANEWARRAY (kotlinx/serialization/KSerializer)
           DUP
           ICONST_0
           GETSTATIC (kotlinx/serialization/internal/StringSerializer, INSTANCE, Lkotlinx/serialization/internal/StringSerializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           AASTORE
           DUP
           ICONST_1
           GETSTATIC (kotlinx/serialization/internal/StringSerializer, INSTANCE, Lkotlinx/serialization/internal/StringSerializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           AASTORE
           ARETURN
         LABEL (L1)
@@ -731,6 +737,10 @@ public final class User$$serializer : java/lang/Object, kotlinx/serialization/in
           ISTORE (3)
           ILOAD (3)
           TABLESWITCH
+            -1: L2
+            0: L3
+            1: L4
+            default: L5
         LABEL (L3)
           ALOAD (1)
           ALOAD (2)
@@ -757,7 +767,7 @@ public final class User$$serializer : java/lang/Object, kotlinx/serialization/in
           ALOAD (1)
           ALOAD (2)
           INVOKEINTERFACE (kotlinx/serialization/encoding/CompositeDecoder, endStructure, (Lkotlinx/serialization/descriptors/SerialDescriptor;)V)
-          NEW
+          NEW (User)
           DUP
           ILOAD (4)
           ALOAD (5)
@@ -766,11 +776,11 @@ public final class User$$serializer : java/lang/Object, kotlinx/serialization/in
           INVOKESPECIAL (User, <init>, (ILjava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V)
           ARETURN
         LABEL (L5)
-          NEW
+          NEW (kotlinx/serialization/UnknownFieldException)
           DUP
           ILOAD (3)
           INVOKESPECIAL (kotlinx/serialization/UnknownFieldException, <init>, (I)V)
-          CHECKCAST
+          CHECKCAST (java/lang/Throwable)
           ATHROW
         LABEL (L6)
     }
@@ -817,7 +827,7 @@ public final class User$$serializer : java/lang/Object, kotlinx/serialization/in
           ALOAD (0)
           ALOAD (1)
           ALOAD (2)
-          CHECKCAST
+          CHECKCAST (User)
           INVOKEVIRTUAL (User$$serializer, serialize, (Lkotlinx/serialization/encoding/Encoder;LUser;)V)
           RETURN
     }
@@ -855,7 +865,7 @@ public final class User : java/lang/Object {
     private final java.lang.String lastName
 
     static void <clinit>() {
-          NEW
+          NEW (User$Companion)
           DUP
           ACONST_NULL
           INVOKESPECIAL (User$Companion, <init>, (Lkotlin/jvm/internal/DefaultConstructorMarker;)V)
@@ -895,7 +905,7 @@ public final class User : java/lang/Object {
           ILOAD (1)
           ICONST_3
           GETSTATIC (User$$serializer, INSTANCE, LUser$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           INVOKEINTERFACE (kotlinx/serialization/KSerializer, getDescriptor, ()Lkotlinx/serialization/descriptors/SerialDescriptor;)
           INVOKESTATIC (kotlinx/serialization/internal/PluginExceptionsKt, throwMissingFieldException, (IILkotlinx/serialization/descriptors/SerialDescriptor;)V)
         LABEL (L1)

--- a/plugins/kotlin-serialization/kotlin-serialization-compiler/testData/codegen/Sealed.ir.txt
+++ b/plugins/kotlin-serialization/kotlin-serialization-compiler/testData/codegen/Sealed.ir.txt
@@ -4,17 +4,17 @@ public final class Container$$serializer : java/lang/Object, kotlinx/serializati
     public final static kotlinx.serialization.descriptors.SerialDescriptor descriptor
 
     static void <clinit>() {
-          NEW
+          NEW (Container$$serializer)
           DUP
           INVOKESPECIAL (Container$$serializer, <init>, ()V)
           PUTSTATIC (Container$$serializer, INSTANCE, LContainer$$serializer;)
         LABEL (L0)
         LINENUMBER (13)
-          NEW
+          NEW (kotlinx/serialization/internal/PluginGeneratedSerialDescriptor)
           DUP
           LDC (Container)
           GETSTATIC (Container$$serializer, INSTANCE, LContainer$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/internal/GeneratedSerializer)
           ICONST_1
           INVOKESPECIAL (kotlinx/serialization/internal/PluginGeneratedSerialDescriptor, <init>, (Ljava/lang/String;Lkotlinx/serialization/internal/GeneratedSerializer;I)V)
           ASTORE (0)
@@ -23,7 +23,7 @@ public final class Container$$serializer : java/lang/Object, kotlinx/serializati
           ICONST_0
           INVOKEVIRTUAL (kotlinx/serialization/internal/PluginGeneratedSerialDescriptor, addElement, (Ljava/lang/String;Z)V)
           ALOAD (0)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/descriptors/SerialDescriptor)
           PUTSTATIC (Container$$serializer, descriptor, Lkotlinx/serialization/descriptors/SerialDescriptor;)
         LABEL (L1)
         LINENUMBER (14)
@@ -43,7 +43,7 @@ public final class Container$$serializer : java/lang/Object, kotlinx/serializati
         LABEL (L0)
         LINENUMBER (13)
           ICONST_1
-          ANEWARRAY
+          ANEWARRAY (kotlinx/serialization/KSerializer)
           ASTORE (1)
           ALOAD (1)
           ICONST_0
@@ -83,7 +83,7 @@ public final class Container$$serializer : java/lang/Object, kotlinx/serializati
           ICONST_0
           GETSTATIC (Result, Companion, LResult$Companion;)
           INVOKEVIRTUAL (Result$Companion, serializer, ()Lkotlinx/serialization/KSerializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/DeserializationStrategy)
           ALOAD (6)
           INVOKEINTERFACE (kotlinx/serialization/encoding/CompositeDecoder, decodeSerializableElement, (Lkotlinx/serialization/descriptors/SerialDescriptor;ILkotlinx/serialization/DeserializationStrategy;Ljava/lang/Object;)Ljava/lang/Object;)
           ASTORE (6)
@@ -101,6 +101,9 @@ public final class Container$$serializer : java/lang/Object, kotlinx/serializati
           ISTORE (4)
           ILOAD (4)
           TABLESWITCH
+            -1: L4
+            0: L5
+            default: L6
         LABEL (L4)
           ICONST_0
           ISTORE (3)
@@ -111,7 +114,7 @@ public final class Container$$serializer : java/lang/Object, kotlinx/serializati
           ICONST_0
           GETSTATIC (Result, Companion, LResult$Companion;)
           INVOKEVIRTUAL (Result$Companion, serializer, ()Lkotlinx/serialization/KSerializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/DeserializationStrategy)
           ALOAD (6)
           INVOKEINTERFACE (kotlinx/serialization/encoding/CompositeDecoder, decodeSerializableElement, (Lkotlinx/serialization/descriptors/SerialDescriptor;ILkotlinx/serialization/DeserializationStrategy;Ljava/lang/Object;)Ljava/lang/Object;)
           ASTORE (6)
@@ -121,7 +124,7 @@ public final class Container$$serializer : java/lang/Object, kotlinx/serializati
           ISTORE (5)
           GOTO (L2)
         LABEL (L6)
-          NEW
+          NEW (kotlinx/serialization/UnknownFieldException)
           DUP
           ILOAD (4)
           INVOKESPECIAL (kotlinx/serialization/UnknownFieldException, <init>, (I)V)
@@ -130,11 +133,11 @@ public final class Container$$serializer : java/lang/Object, kotlinx/serializati
           ALOAD (7)
           ALOAD (2)
           INVOKEINTERFACE (kotlinx/serialization/encoding/CompositeDecoder, endStructure, (Lkotlinx/serialization/descriptors/SerialDescriptor;)V)
-          NEW
+          NEW (Container)
           DUP
           ILOAD (5)
           ALOAD (6)
-          CHECKCAST
+          CHECKCAST (Result)
           ACONST_NULL
           INVOKESPECIAL (Container, <init>, (ILResult;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V)
           ARETURN
@@ -182,7 +185,7 @@ public final class Container$Companion : java/lang/Object {
         LABEL (L0)
         LINENUMBER (13)
           GETSTATIC (Container$$serializer, INSTANCE, LContainer$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           ARETURN
         LABEL (L1)
     }
@@ -194,7 +197,7 @@ public final class Container : java/lang/Object {
     private final Result r
 
     static void <clinit>() {
-          NEW
+          NEW (Container$Companion)
           DUP
           ACONST_NULL
           INVOKESPECIAL (Container$Companion, <init>, (Lkotlin/jvm/internal/DefaultConstructorMarker;)V)
@@ -263,7 +266,7 @@ public final class Container : java/lang/Object {
           ICONST_0
           GETSTATIC (Result, Companion, LResult$Companion;)
           INVOKEVIRTUAL (Result$Companion, serializer, ()Lkotlinx/serialization/KSerializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/SerializationStrategy)
           ALOAD (0)
           GETFIELD (Container, r, LResult;)
           INVOKEINTERFACE (kotlinx/serialization/encoding/CompositeEncoder, encodeSerializableElement, (Lkotlinx/serialization/descriptors/SerialDescriptor;ILkotlinx/serialization/SerializationStrategy;Ljava/lang/Object;)V)
@@ -276,7 +279,7 @@ final class Result$Companion$$cachedSerializer$delegate$1 : kotlin/jvm/internal/
     public final static Result$Companion$$cachedSerializer$delegate$1 INSTANCE
 
     static void <clinit>() {
-          NEW
+          NEW (Result$Companion$$cachedSerializer$delegate$1)
           DUP
           INVOKESPECIAL (Result$Companion$$cachedSerializer$delegate$1, <init>, ()V)
           PUTSTATIC (Result$Companion$$cachedSerializer$delegate$1, INSTANCE, LResult$Companion$$cachedSerializer$delegate$1;)
@@ -295,13 +298,13 @@ final class Result$Companion$$cachedSerializer$delegate$1 : kotlin/jvm/internal/
     public final kotlinx.serialization.KSerializer invoke() {
         LABEL (L0)
         LINENUMBER (7)
-          NEW
+          NEW (kotlinx/serialization/SealedClassSerializer)
           DUP
           LDC (Result)
           LDC (LResult;)
           INVOKESTATIC (kotlin/jvm/internal/Reflection, getOrCreateKotlinClass, (Ljava/lang/Class;)Lkotlin/reflect/KClass;)
           ICONST_2
-          ANEWARRAY
+          ANEWARRAY (kotlin/reflect/KClass)
           ASTORE (1)
           ALOAD (1)
           ICONST_0
@@ -315,25 +318,25 @@ final class Result$Companion$$cachedSerializer$delegate$1 : kotlin/jvm/internal/
           AASTORE
           ALOAD (1)
           ICONST_2
-          ANEWARRAY
+          ANEWARRAY (kotlinx/serialization/KSerializer)
           ASTORE (1)
           ALOAD (1)
           ICONST_0
           GETSTATIC (Result$OK$$serializer, INSTANCE, LResult$OK$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           AASTORE
           ALOAD (1)
           ICONST_1
-          NEW
+          NEW (kotlinx/serialization/internal/ObjectSerializer)
           DUP
           LDC (Result.Err)
           GETSTATIC (Result$Err, INSTANCE, LResult$Err;)
           INVOKESPECIAL (kotlinx/serialization/internal/ObjectSerializer, <init>, (Ljava/lang/String;Ljava/lang/Object;)V)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           AASTORE
           ALOAD (1)
           INVOKESPECIAL (kotlinx/serialization/SealedClassSerializer, <init>, (Ljava/lang/String;Lkotlin/reflect/KClass;[Lkotlin/reflect/KClass;[Lkotlinx/serialization/KSerializer;)V)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           ARETURN
         LABEL (L1)
     }
@@ -374,7 +377,7 @@ public final class Result$Companion : java/lang/Object {
           ALOAD (0)
           INVOKESPECIAL (Result$Companion, get$cachedSerializer$delegate, ()Lkotlin/Lazy;)
           INVOKEINTERFACE (kotlin/Lazy, getValue, ()Ljava/lang/Object;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           ARETURN
         LABEL (L1)
     }
@@ -384,7 +387,7 @@ final class Result$Err$$cachedSerializer$delegate$1 : kotlin/jvm/internal/Lambda
     public final static Result$Err$$cachedSerializer$delegate$1 INSTANCE
 
     static void <clinit>() {
-          NEW
+          NEW (Result$Err$$cachedSerializer$delegate$1)
           DUP
           INVOKESPECIAL (Result$Err$$cachedSerializer$delegate$1, <init>, ()V)
           PUTSTATIC (Result$Err$$cachedSerializer$delegate$1, INSTANCE, LResult$Err$$cachedSerializer$delegate$1;)
@@ -403,12 +406,12 @@ final class Result$Err$$cachedSerializer$delegate$1 : kotlin/jvm/internal/Lambda
     public final kotlinx.serialization.KSerializer invoke() {
         LABEL (L0)
         LINENUMBER (10)
-          NEW
+          NEW (kotlinx/serialization/internal/ObjectSerializer)
           DUP
           LDC (Result.Err)
           GETSTATIC (Result$Err, INSTANCE, LResult$Err;)
           INVOKESPECIAL (kotlinx/serialization/internal/ObjectSerializer, <init>, (Ljava/lang/String;Ljava/lang/Object;)V)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           ARETURN
         LABEL (L1)
     }
@@ -429,7 +432,7 @@ public final class Result$Err : Result {
     public final static Result$Err INSTANCE
 
     static void <clinit>() {
-          NEW
+          NEW (Result$Err)
           DUP
           INVOKESPECIAL (Result$Err, <init>, ()V)
           PUTSTATIC (Result$Err, INSTANCE, LResult$Err;)
@@ -437,7 +440,7 @@ public final class Result$Err : Result {
         LINENUMBER (10)
           GETSTATIC (kotlin/LazyThreadSafetyMode, PUBLICATION, Lkotlin/LazyThreadSafetyMode;)
           GETSTATIC (Result$Err$$cachedSerializer$delegate$1, INSTANCE, LResult$Err$$cachedSerializer$delegate$1;)
-          CHECKCAST
+          CHECKCAST (kotlin/jvm/functions/Function0)
           INVOKESTATIC (kotlin/LazyKt, lazy, (Lkotlin/LazyThreadSafetyMode;Lkotlin/jvm/functions/Function0;)Lkotlin/Lazy;)
           PUTSTATIC (Result$Err, $cachedSerializer$delegate, Lkotlin/Lazy;)
           RETURN
@@ -461,7 +464,7 @@ public final class Result$Err : Result {
           ALOAD (0)
           INVOKESPECIAL (Result$Err, get$cachedSerializer$delegate, ()Lkotlin/Lazy;)
           INVOKEINTERFACE (kotlin/Lazy, getValue, ()Ljava/lang/Object;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           ARETURN
         LABEL (L1)
     }
@@ -473,17 +476,17 @@ public final class Result$OK$$serializer : java/lang/Object, kotlinx/serializati
     public final static kotlinx.serialization.descriptors.SerialDescriptor descriptor
 
     static void <clinit>() {
-          NEW
+          NEW (Result$OK$$serializer)
           DUP
           INVOKESPECIAL (Result$OK$$serializer, <init>, ()V)
           PUTSTATIC (Result$OK$$serializer, INSTANCE, LResult$OK$$serializer;)
         LABEL (L0)
         LINENUMBER (9)
-          NEW
+          NEW (kotlinx/serialization/internal/PluginGeneratedSerialDescriptor)
           DUP
           LDC (Result.OK)
           GETSTATIC (Result$OK$$serializer, INSTANCE, LResult$OK$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/internal/GeneratedSerializer)
           ICONST_1
           INVOKESPECIAL (kotlinx/serialization/internal/PluginGeneratedSerialDescriptor, <init>, (Ljava/lang/String;Lkotlinx/serialization/internal/GeneratedSerializer;I)V)
           ASTORE (0)
@@ -492,7 +495,7 @@ public final class Result$OK$$serializer : java/lang/Object, kotlinx/serializati
           ICONST_0
           INVOKEVIRTUAL (kotlinx/serialization/internal/PluginGeneratedSerialDescriptor, addElement, (Ljava/lang/String;Z)V)
           ALOAD (0)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/descriptors/SerialDescriptor)
           PUTSTATIC (Result$OK$$serializer, descriptor, Lkotlinx/serialization/descriptors/SerialDescriptor;)
           RETURN
     }
@@ -510,12 +513,12 @@ public final class Result$OK$$serializer : java/lang/Object, kotlinx/serializati
         LABEL (L0)
         LINENUMBER (9)
           ICONST_1
-          ANEWARRAY
+          ANEWARRAY (kotlinx/serialization/KSerializer)
           ASTORE (1)
           ALOAD (1)
           ICONST_0
           GETSTATIC (kotlinx/serialization/internal/StringSerializer, INSTANCE, Lkotlinx/serialization/internal/StringSerializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           AASTORE
           ALOAD (1)
           ARETURN
@@ -564,6 +567,9 @@ public final class Result$OK$$serializer : java/lang/Object, kotlinx/serializati
           ISTORE (4)
           ILOAD (4)
           TABLESWITCH
+            -1: L4
+            0: L5
+            default: L6
         LABEL (L4)
           ICONST_0
           ISTORE (3)
@@ -580,7 +586,7 @@ public final class Result$OK$$serializer : java/lang/Object, kotlinx/serializati
           ISTORE (5)
           GOTO (L2)
         LABEL (L6)
-          NEW
+          NEW (kotlinx/serialization/UnknownFieldException)
           DUP
           ILOAD (4)
           INVOKESPECIAL (kotlinx/serialization/UnknownFieldException, <init>, (I)V)
@@ -589,7 +595,7 @@ public final class Result$OK$$serializer : java/lang/Object, kotlinx/serializati
           ALOAD (7)
           ALOAD (2)
           INVOKEINTERFACE (kotlinx/serialization/encoding/CompositeDecoder, endStructure, (Lkotlinx/serialization/descriptors/SerialDescriptor;)V)
-          NEW
+          NEW (Result$OK)
           DUP
           ILOAD (5)
           ALOAD (6)
@@ -640,7 +646,7 @@ public final class Result$OK$Companion : java/lang/Object {
         LABEL (L0)
         LINENUMBER (9)
           GETSTATIC (Result$OK$$serializer, INSTANCE, LResult$OK$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           ARETURN
         LABEL (L1)
     }
@@ -652,7 +658,7 @@ public final class Result$OK : Result {
     private final java.lang.String s
 
     static void <clinit>() {
-          NEW
+          NEW (Result$OK$Companion)
           DUP
           ACONST_NULL
           INVOKESPECIAL (Result$OK$Companion, <init>, (Lkotlin/jvm/internal/DefaultConstructorMarker;)V)
@@ -718,7 +724,7 @@ public final class Result$OK : Result {
         LABEL (L1)
         LINENUMBER (9)
           ALOAD (0)
-          CHECKCAST
+          CHECKCAST (Result)
           ALOAD (1)
           ALOAD (2)
           INVOKESTATIC (Result, write$Self, (LResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V)
@@ -739,7 +745,7 @@ public abstract class Result : java/lang/Object {
     public final static Result$Companion Companion
 
     static void <clinit>() {
-          NEW
+          NEW (Result$Companion)
           DUP
           ACONST_NULL
           INVOKESPECIAL (Result$Companion, <init>, (Lkotlin/jvm/internal/DefaultConstructorMarker;)V)
@@ -748,7 +754,7 @@ public abstract class Result : java/lang/Object {
         LINENUMBER (7)
           GETSTATIC (kotlin/LazyThreadSafetyMode, PUBLICATION, Lkotlin/LazyThreadSafetyMode;)
           GETSTATIC (Result$Companion$$cachedSerializer$delegate$1, INSTANCE, LResult$Companion$$cachedSerializer$delegate$1;)
-          CHECKCAST
+          CHECKCAST (kotlin/jvm/functions/Function0)
           INVOKESTATIC (kotlin/LazyKt, lazy, (Lkotlin/LazyThreadSafetyMode;Lkotlin/jvm/functions/Function0;)Lkotlin/Lazy;)
           PUTSTATIC (Result, $cachedSerializer$delegate, Lkotlin/Lazy;)
           RETURN

--- a/plugins/kotlin-serialization/kotlin-serialization-compiler/testData/codegen/Sealed.txt
+++ b/plugins/kotlin-serialization/kotlin-serialization-compiler/testData/codegen/Sealed.txt
@@ -6,17 +6,17 @@ public final class Container$$serializer : java/lang/Object, kotlinx/serializati
     static void <clinit>() {
         LABEL (L0)
         LINENUMBER (14)
-          NEW
+          NEW (Container$$serializer)
           DUP
           INVOKESPECIAL (Container$$serializer, <init>, ()V)
           ASTORE (0)
           ALOAD (0)
           PUTSTATIC (Container$$serializer, INSTANCE, LContainer$$serializer;)
-          NEW
+          NEW (kotlinx/serialization/internal/PluginGeneratedSerialDescriptor)
           DUP
           LDC (Container)
           GETSTATIC (Container$$serializer, INSTANCE, LContainer$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/internal/GeneratedSerializer)
           LDC (1)
           INVOKESPECIAL (kotlinx/serialization/internal/PluginGeneratedSerialDescriptor, <init>, (Ljava/lang/String;Lkotlinx/serialization/internal/GeneratedSerializer;I)V)
           ASTORE (0)
@@ -41,16 +41,16 @@ public final class Container$$serializer : java/lang/Object, kotlinx/serializati
     public kotlinx.serialization.KSerializer[] childSerializers() {
         LABEL (L0)
           ICONST_1
-          ANEWARRAY
+          ANEWARRAY (kotlinx/serialization/KSerializer)
           DUP
           ICONST_0
-          NEW
+          NEW (kotlinx/serialization/SealedClassSerializer)
           DUP
           LDC (Result)
           LDC (LResult;)
           INVOKESTATIC (kotlin/jvm/internal/Reflection, getOrCreateKotlinClass, (Ljava/lang/Class;)Lkotlin/reflect/KClass;)
           ICONST_2
-          ANEWARRAY
+          ANEWARRAY (kotlin/reflect/KClass)
           DUP
           ICONST_0
           LDC (LResult$OK;)
@@ -62,15 +62,15 @@ public final class Container$$serializer : java/lang/Object, kotlinx/serializati
           INVOKESTATIC (kotlin/jvm/internal/Reflection, getOrCreateKotlinClass, (Ljava/lang/Class;)Lkotlin/reflect/KClass;)
           AASTORE
           ICONST_2
-          ANEWARRAY
+          ANEWARRAY (kotlinx/serialization/KSerializer)
           DUP
           ICONST_0
           GETSTATIC (Result$OK$$serializer, INSTANCE, LResult$OK$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           AASTORE
           DUP
           ICONST_1
-          NEW
+          NEW (kotlinx/serialization/internal/ObjectSerializer)
           DUP
           LDC (Result.Err)
           GETSTATIC (Result$Err, INSTANCE, LResult$Err;)
@@ -103,13 +103,13 @@ public final class Container$$serializer : java/lang/Object, kotlinx/serializati
           ALOAD (1)
           ALOAD (2)
           ICONST_0
-          NEW
+          NEW (kotlinx/serialization/SealedClassSerializer)
           DUP
           LDC (Result)
           LDC (LResult;)
           INVOKESTATIC (kotlin/jvm/internal/Reflection, getOrCreateKotlinClass, (Ljava/lang/Class;)Lkotlin/reflect/KClass;)
           ICONST_2
-          ANEWARRAY
+          ANEWARRAY (kotlin/reflect/KClass)
           DUP
           ICONST_0
           LDC (LResult$OK;)
@@ -121,15 +121,15 @@ public final class Container$$serializer : java/lang/Object, kotlinx/serializati
           INVOKESTATIC (kotlin/jvm/internal/Reflection, getOrCreateKotlinClass, (Ljava/lang/Class;)Lkotlin/reflect/KClass;)
           AASTORE
           ICONST_2
-          ANEWARRAY
+          ANEWARRAY (kotlinx/serialization/KSerializer)
           DUP
           ICONST_0
           GETSTATIC (Result$OK$$serializer, INSTANCE, LResult$OK$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           AASTORE
           DUP
           ICONST_1
-          NEW
+          NEW (kotlinx/serialization/internal/ObjectSerializer)
           DUP
           LDC (Result.Err)
           GETSTATIC (Result$Err, INSTANCE, LResult$Err;)
@@ -138,7 +138,7 @@ public final class Container$$serializer : java/lang/Object, kotlinx/serializati
           INVOKESPECIAL (kotlinx/serialization/SealedClassSerializer, <init>, (Ljava/lang/String;Lkotlin/reflect/KClass;[Lkotlin/reflect/KClass;[Lkotlinx/serialization/KSerializer;)V)
           ALOAD (5)
           INVOKEINTERFACE (kotlinx/serialization/encoding/CompositeDecoder, decodeSerializableElement, (Lkotlinx/serialization/descriptors/SerialDescriptor;ILkotlinx/serialization/DeserializationStrategy;Ljava/lang/Object;)Ljava/lang/Object;)
-          CHECKCAST
+          CHECKCAST (Result)
           ASTORE (5)
           LDC (2147483647)
           ISTORE (4)
@@ -150,17 +150,20 @@ public final class Container$$serializer : java/lang/Object, kotlinx/serializati
           ISTORE (3)
           ILOAD (3)
           TABLESWITCH
+            -1: L2
+            0: L3
+            default: L4
         LABEL (L3)
           ALOAD (1)
           ALOAD (2)
           ICONST_0
-          NEW
+          NEW (kotlinx/serialization/SealedClassSerializer)
           DUP
           LDC (Result)
           LDC (LResult;)
           INVOKESTATIC (kotlin/jvm/internal/Reflection, getOrCreateKotlinClass, (Ljava/lang/Class;)Lkotlin/reflect/KClass;)
           ICONST_2
-          ANEWARRAY
+          ANEWARRAY (kotlin/reflect/KClass)
           DUP
           ICONST_0
           LDC (LResult$OK;)
@@ -172,15 +175,15 @@ public final class Container$$serializer : java/lang/Object, kotlinx/serializati
           INVOKESTATIC (kotlin/jvm/internal/Reflection, getOrCreateKotlinClass, (Ljava/lang/Class;)Lkotlin/reflect/KClass;)
           AASTORE
           ICONST_2
-          ANEWARRAY
+          ANEWARRAY (kotlinx/serialization/KSerializer)
           DUP
           ICONST_0
           GETSTATIC (Result$OK$$serializer, INSTANCE, LResult$OK$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           AASTORE
           DUP
           ICONST_1
-          NEW
+          NEW (kotlinx/serialization/internal/ObjectSerializer)
           DUP
           LDC (Result.Err)
           GETSTATIC (Result$Err, INSTANCE, LResult$Err;)
@@ -189,7 +192,7 @@ public final class Container$$serializer : java/lang/Object, kotlinx/serializati
           INVOKESPECIAL (kotlinx/serialization/SealedClassSerializer, <init>, (Ljava/lang/String;Lkotlin/reflect/KClass;[Lkotlin/reflect/KClass;[Lkotlinx/serialization/KSerializer;)V)
           ALOAD (5)
           INVOKEINTERFACE (kotlinx/serialization/encoding/CompositeDecoder, decodeSerializableElement, (Lkotlinx/serialization/descriptors/SerialDescriptor;ILkotlinx/serialization/DeserializationStrategy;Ljava/lang/Object;)Ljava/lang/Object;)
-          CHECKCAST
+          CHECKCAST (Result)
           ASTORE (5)
           ILOAD (4)
           ICONST_1
@@ -200,7 +203,7 @@ public final class Container$$serializer : java/lang/Object, kotlinx/serializati
           ALOAD (1)
           ALOAD (2)
           INVOKEINTERFACE (kotlinx/serialization/encoding/CompositeDecoder, endStructure, (Lkotlinx/serialization/descriptors/SerialDescriptor;)V)
-          NEW
+          NEW (Container)
           DUP
           ILOAD (4)
           ALOAD (5)
@@ -208,11 +211,11 @@ public final class Container$$serializer : java/lang/Object, kotlinx/serializati
           INVOKESPECIAL (Container, <init>, (ILResult;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V)
           ARETURN
         LABEL (L4)
-          NEW
+          NEW (kotlinx/serialization/UnknownFieldException)
           DUP
           ILOAD (3)
           INVOKESPECIAL (kotlinx/serialization/UnknownFieldException, <init>, (I)V)
-          CHECKCAST
+          CHECKCAST (java/lang/Throwable)
           ATHROW
         LABEL (L5)
     }
@@ -257,7 +260,7 @@ public final class Container$Companion : java/lang/Object {
     public final kotlinx.serialization.KSerializer serializer() {
         LABEL (L0)
           GETSTATIC (Container$$serializer, INSTANCE, LContainer$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           ARETURN
         LABEL (L1)
     }
@@ -269,7 +272,7 @@ public final class Container : java/lang/Object {
     private final Result r
 
     static void <clinit>() {
-          NEW
+          NEW (Container$Companion)
           DUP
           ACONST_NULL
           INVOKESPECIAL (Container$Companion, <init>, (Lkotlin/jvm/internal/DefaultConstructorMarker;)V)
@@ -303,7 +306,7 @@ public final class Container : java/lang/Object {
           ILOAD (1)
           ICONST_1
           GETSTATIC (Container$$serializer, INSTANCE, LContainer$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           INVOKEINTERFACE (kotlinx/serialization/KSerializer, getDescriptor, ()Lkotlinx/serialization/descriptors/SerialDescriptor;)
           INVOKESTATIC (kotlinx/serialization/internal/PluginExceptionsKt, throwMissingFieldException, (IILkotlinx/serialization/descriptors/SerialDescriptor;)V)
         LABEL (L1)
@@ -332,13 +335,13 @@ public final class Container : java/lang/Object {
           ALOAD (1)
           ALOAD (2)
           ICONST_0
-          NEW
+          NEW (kotlinx/serialization/SealedClassSerializer)
           DUP
           LDC (Result)
           LDC (LResult;)
           INVOKESTATIC (kotlin/jvm/internal/Reflection, getOrCreateKotlinClass, (Ljava/lang/Class;)Lkotlin/reflect/KClass;)
           ICONST_2
-          ANEWARRAY
+          ANEWARRAY (kotlin/reflect/KClass)
           DUP
           ICONST_0
           LDC (LResult$OK;)
@@ -350,15 +353,15 @@ public final class Container : java/lang/Object {
           INVOKESTATIC (kotlin/jvm/internal/Reflection, getOrCreateKotlinClass, (Ljava/lang/Class;)Lkotlin/reflect/KClass;)
           AASTORE
           ICONST_2
-          ANEWARRAY
+          ANEWARRAY (kotlinx/serialization/KSerializer)
           DUP
           ICONST_0
           GETSTATIC (Result$OK$$serializer, INSTANCE, LResult$OK$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           AASTORE
           DUP
           ICONST_1
-          NEW
+          NEW (kotlinx/serialization/internal/ObjectSerializer)
           DUP
           LDC (Result.Err)
           GETSTATIC (Result$Err, INSTANCE, LResult$Err;)
@@ -377,7 +380,7 @@ final class Result$Companion$serializer$1 : kotlin/jvm/internal/Lambda, kotlin/j
     public final static Result$Companion$serializer$1 INSTANCE
 
     static void <clinit>() {
-          NEW
+          NEW (Result$Companion$serializer$1)
           DUP
           INVOKESPECIAL (Result$Companion$serializer$1, <init>, ()V)
           PUTSTATIC (Result$Companion$serializer$1, INSTANCE, LResult$Companion$serializer$1;)
@@ -395,13 +398,13 @@ final class Result$Companion$serializer$1 : kotlin/jvm/internal/Lambda, kotlin/j
 
     public final kotlinx.serialization.KSerializer invoke() {
         LABEL (L0)
-          NEW
+          NEW (kotlinx/serialization/SealedClassSerializer)
           DUP
           LDC (Result)
           LDC (LResult;)
           INVOKESTATIC (kotlin/jvm/internal/Reflection, getOrCreateKotlinClass, (Ljava/lang/Class;)Lkotlin/reflect/KClass;)
           ICONST_2
-          ANEWARRAY
+          ANEWARRAY (kotlin/reflect/KClass)
           DUP
           ICONST_0
           LDC (LResult$OK;)
@@ -413,15 +416,15 @@ final class Result$Companion$serializer$1 : kotlin/jvm/internal/Lambda, kotlin/j
           INVOKESTATIC (kotlin/jvm/internal/Reflection, getOrCreateKotlinClass, (Ljava/lang/Class;)Lkotlin/reflect/KClass;)
           AASTORE
           ICONST_2
-          ANEWARRAY
+          ANEWARRAY (kotlinx/serialization/KSerializer)
           DUP
           ICONST_0
           GETSTATIC (Result$OK$$serializer, INSTANCE, LResult$OK$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           AASTORE
           DUP
           ICONST_1
-          NEW
+          NEW (kotlinx/serialization/internal/ObjectSerializer)
           DUP
           LDC (Result.Err)
           GETSTATIC (Result$Err, INSTANCE, LResult$Err;)
@@ -447,7 +450,7 @@ public final class Result$Companion : java/lang/Object {
     static void <clinit>() {
           GETSTATIC (kotlin/LazyThreadSafetyMode, PUBLICATION, Lkotlin/LazyThreadSafetyMode;)
           GETSTATIC (Result$Companion$serializer$1, INSTANCE, LResult$Companion$serializer$1;)
-          CHECKCAST
+          CHECKCAST (kotlin/jvm/functions/Function0)
           INVOKESTATIC (kotlin/LazyKt, lazy, (Lkotlin/LazyThreadSafetyMode;Lkotlin/jvm/functions/Function0;)Lkotlin/Lazy;)
           PUTSTATIC (Result$Companion, $cachedSerializer$delegate, Lkotlin/Lazy;)
           RETURN
@@ -475,7 +478,7 @@ public final class Result$Companion : java/lang/Object {
         LABEL (L0)
           GETSTATIC (Result$Companion, $cachedSerializer$delegate, Lkotlin/Lazy;)
           INVOKEINTERFACE (kotlin/Lazy, getValue, ()Ljava/lang/Object;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           ARETURN
         LABEL (L1)
     }
@@ -485,7 +488,7 @@ final class Result$Err$serializer$1 : kotlin/jvm/internal/Lambda, kotlin/jvm/fun
     public final static Result$Err$serializer$1 INSTANCE
 
     static void <clinit>() {
-          NEW
+          NEW (Result$Err$serializer$1)
           DUP
           INVOKESPECIAL (Result$Err$serializer$1, <init>, ()V)
           PUTSTATIC (Result$Err$serializer$1, INSTANCE, LResult$Err$serializer$1;)
@@ -503,7 +506,7 @@ final class Result$Err$serializer$1 : kotlin/jvm/internal/Lambda, kotlin/jvm/fun
 
     public final kotlinx.serialization.KSerializer invoke() {
         LABEL (L0)
-          NEW
+          NEW (kotlinx/serialization/internal/ObjectSerializer)
           DUP
           LDC (Result.Err)
           GETSTATIC (Result$Err, INSTANCE, LResult$Err;)
@@ -529,7 +532,7 @@ public final class Result$Err : Result {
     static void <clinit>() {
         LABEL (L0)
         LINENUMBER (10)
-          NEW
+          NEW (Result$Err)
           DUP
           INVOKESPECIAL (Result$Err, <init>, ()V)
           ASTORE (0)
@@ -537,7 +540,7 @@ public final class Result$Err : Result {
           PUTSTATIC (Result$Err, INSTANCE, LResult$Err;)
           GETSTATIC (kotlin/LazyThreadSafetyMode, PUBLICATION, Lkotlin/LazyThreadSafetyMode;)
           GETSTATIC (Result$Err$serializer$1, INSTANCE, LResult$Err$serializer$1;)
-          CHECKCAST
+          CHECKCAST (kotlin/jvm/functions/Function0)
           INVOKESTATIC (kotlin/LazyKt, lazy, (Lkotlin/LazyThreadSafetyMode;Lkotlin/jvm/functions/Function0;)Lkotlin/Lazy;)
           PUTSTATIC (Result$Err, $cachedSerializer$delegate, Lkotlin/Lazy;)
           RETURN
@@ -559,7 +562,7 @@ public final class Result$Err : Result {
         LABEL (L0)
           GETSTATIC (Result$Err, $cachedSerializer$delegate, Lkotlin/Lazy;)
           INVOKEINTERFACE (kotlin/Lazy, getValue, ()Ljava/lang/Object;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           ARETURN
         LABEL (L1)
     }
@@ -573,17 +576,17 @@ public final class Result$OK$$serializer : java/lang/Object, kotlinx/serializati
     static void <clinit>() {
         LABEL (L0)
         LINENUMBER (9)
-          NEW
+          NEW (Result$OK$$serializer)
           DUP
           INVOKESPECIAL (Result$OK$$serializer, <init>, ()V)
           ASTORE (0)
           ALOAD (0)
           PUTSTATIC (Result$OK$$serializer, INSTANCE, LResult$OK$$serializer;)
-          NEW
+          NEW (kotlinx/serialization/internal/PluginGeneratedSerialDescriptor)
           DUP
           LDC (Result.OK)
           GETSTATIC (Result$OK$$serializer, INSTANCE, LResult$OK$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/internal/GeneratedSerializer)
           LDC (1)
           INVOKESPECIAL (kotlinx/serialization/internal/PluginGeneratedSerialDescriptor, <init>, (Ljava/lang/String;Lkotlinx/serialization/internal/GeneratedSerializer;I)V)
           ASTORE (0)
@@ -608,11 +611,11 @@ public final class Result$OK$$serializer : java/lang/Object, kotlinx/serializati
     public kotlinx.serialization.KSerializer[] childSerializers() {
         LABEL (L0)
           ICONST_1
-          ANEWARRAY
+          ANEWARRAY (kotlinx/serialization/KSerializer)
           DUP
           ICONST_0
           GETSTATIC (kotlinx/serialization/internal/StringSerializer, INSTANCE, Lkotlinx/serialization/internal/StringSerializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           AASTORE
           ARETURN
         LABEL (L1)
@@ -651,6 +654,9 @@ public final class Result$OK$$serializer : java/lang/Object, kotlinx/serializati
           ISTORE (3)
           ILOAD (3)
           TABLESWITCH
+            -1: L2
+            0: L3
+            default: L4
         LABEL (L3)
           ALOAD (1)
           ALOAD (2)
@@ -666,7 +672,7 @@ public final class Result$OK$$serializer : java/lang/Object, kotlinx/serializati
           ALOAD (1)
           ALOAD (2)
           INVOKEINTERFACE (kotlinx/serialization/encoding/CompositeDecoder, endStructure, (Lkotlinx/serialization/descriptors/SerialDescriptor;)V)
-          NEW
+          NEW (Result$OK)
           DUP
           ILOAD (4)
           ALOAD (5)
@@ -674,11 +680,11 @@ public final class Result$OK$$serializer : java/lang/Object, kotlinx/serializati
           INVOKESPECIAL (Result$OK, <init>, (ILjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V)
           ARETURN
         LABEL (L4)
-          NEW
+          NEW (kotlinx/serialization/UnknownFieldException)
           DUP
           ILOAD (3)
           INVOKESPECIAL (kotlinx/serialization/UnknownFieldException, <init>, (I)V)
-          CHECKCAST
+          CHECKCAST (java/lang/Throwable)
           ATHROW
         LABEL (L5)
     }
@@ -723,7 +729,7 @@ public final class Result$OK$Companion : java/lang/Object {
     public final kotlinx.serialization.KSerializer serializer() {
         LABEL (L0)
           GETSTATIC (Result$OK$$serializer, INSTANCE, LResult$OK$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           ARETURN
         LABEL (L1)
     }
@@ -735,7 +741,7 @@ public final class Result$OK : Result {
     private final java.lang.String s
 
     static void <clinit>() {
-          NEW
+          NEW (Result$OK$Companion)
           DUP
           ACONST_NULL
           INVOKESPECIAL (Result$OK$Companion, <init>, (Lkotlin/jvm/internal/DefaultConstructorMarker;)V)
@@ -770,7 +776,7 @@ public final class Result$OK : Result {
           ILOAD (1)
           ICONST_1
           GETSTATIC (Result$OK$$serializer, INSTANCE, LResult$OK$$serializer;)
-          CHECKCAST
+          CHECKCAST (kotlinx/serialization/KSerializer)
           INVOKEINTERFACE (kotlinx/serialization/KSerializer, getDescriptor, ()Lkotlinx/serialization/descriptors/SerialDescriptor;)
           INVOKESTATIC (kotlinx/serialization/internal/PluginExceptionsKt, throwMissingFieldException, (IILkotlinx/serialization/descriptors/SerialDescriptor;)V)
         LABEL (L1)
@@ -817,7 +823,7 @@ public abstract class Result : java/lang/Object {
     public final static Result$Companion Companion
 
     static void <clinit>() {
-          NEW
+          NEW (Result$Companion)
           DUP
           ACONST_NULL
           INVOKESPECIAL (Result$Companion, <init>, (Lkotlin/jvm/internal/DefaultConstructorMarker;)V)

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/IBinderIInterface.asm.ir.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/IBinderIInterface.asm.ir.txt
@@ -6,7 +6,7 @@ public final class User$Creator : java/lang/Object, android/os/Parcelable$Creato
           ALOAD (1)
           LDC (parcel)
           INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
-          NEW
+          NEW (User)
           DUP
           ALOAD (1)
           INVOKEVIRTUAL (android/os/Parcel, readStrongBinder, ()Landroid/os/IBinder;)
@@ -14,7 +14,7 @@ public final class User$Creator : java/lang/Object, android/os/Parcelable$Creato
           INVOKEVIRTUAL (android/os/Parcel, createBinderArray, ()[Landroid/os/IBinder;)
           ALOAD (1)
           INVOKEVIRTUAL (android/os/Parcel, createBinderArrayList, ()Ljava/util/ArrayList;)
-          CHECKCAST
+          CHECKCAST (java/util/List)
           ALOAD (1)
           INVOKEVIRTUAL (android/os/Parcel, createBinderArrayList, ()Ljava/util/ArrayList;)
           INVOKESPECIAL (User, <init>, (Landroid/os/IBinder;[Landroid/os/IBinder;Ljava/util/List;Ljava/util/ArrayList;)V)
@@ -81,7 +81,7 @@ public final class User : java/lang/Object, android/os/Parcelable {
           ALOAD (1)
           ALOAD (0)
           GETFIELD (User, binderArrayList, Ljava/util/ArrayList;)
-          CHECKCAST
+          CHECKCAST (java/util/List)
           INVOKEVIRTUAL (android/os/Parcel, writeBinderList, (Ljava/util/List;)V)
           RETURN
         LABEL (L1)

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/IBinderIInterface.asm.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/IBinderIInterface.asm.txt
@@ -7,7 +7,7 @@ public final class User$Creator : java/lang/Object, android/os/Parcelable$Creato
           LDC (in)
           INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
         LABEL (L1)
-          NEW
+          NEW (User)
           DUP
           ALOAD (1)
           INVOKEVIRTUAL (android/os/Parcel, readStrongBinder, ()Landroid/os/IBinder;)
@@ -15,11 +15,11 @@ public final class User$Creator : java/lang/Object, android/os/Parcelable$Creato
           INVOKEVIRTUAL (android/os/Parcel, createBinderArray, ()[Landroid/os/IBinder;)
           ALOAD (1)
           INVOKEVIRTUAL (android/os/Parcel, createBinderArrayList, ()Ljava/util/ArrayList;)
-          CHECKCAST
+          CHECKCAST (java/util/List)
           ALOAD (1)
           INVOKEVIRTUAL (android/os/Parcel, readInt, ()I)
           ISTORE (2)
-          NEW
+          NEW (java/util/ArrayList)
           DUP
           ILOAD (2)
           INVOKESPECIAL (java/util/ArrayList, <init>, (I)V)
@@ -115,7 +115,7 @@ public final class User : java/lang/Object, android/os/Parcelable {
           ALOAD (1)
           SWAP
           INVOKEINTERFACE (java/util/Iterator, next, ()Ljava/lang/Object;)
-          CHECKCAST
+          CHECKCAST (android/os/IBinder)
           INVOKEVIRTUAL (android/os/Parcel, writeStrongBinder, (Landroid/os/IBinder;)V)
           GOTO (L1)
         LABEL (L2)

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/classLoaderValues.asm.ir.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/classLoaderValues.asm.ir.txt
@@ -6,7 +6,7 @@ public final class A$Creator : java/lang/Object, android/os/Parcelable$Creator {
           ALOAD (1)
           LDC (parcel)
           INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
-          NEW
+          NEW (A)
           DUP
           ALOAD (1)
           LDC (LA;)

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/classLoaderValues.asm.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/classLoaderValues.asm.txt
@@ -6,7 +6,7 @@ public final class A$Creator : java/lang/Object, android/os/Parcelable$Creator {
           ALOAD (1)
           LDC (in)
           INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
-          NEW
+          NEW (A)
           DUP
           ALOAD (1)
           LDC (Ljava/lang/Object;)

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/customParcelablesDifferentModule.asm.ir.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/customParcelablesDifferentModule.asm.ir.txt
@@ -6,13 +6,13 @@ public final class test/Foo$Creator : java/lang/Object, android/os/Parcelable$Cr
           ALOAD (1)
           LDC (parcel)
           INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
-          NEW
+          NEW (test/Foo)
           DUP
           ALOAD (1)
           LDC (Ltest/Foo;)
           INVOKEVIRTUAL (java/lang/Class, getClassLoader, ()Ljava/lang/ClassLoader;)
           INVOKEVIRTUAL (android/os/Parcel, readParcelable, (Ljava/lang/ClassLoader;)Landroid/os/Parcelable;)
-          CHECKCAST
+          CHECKCAST (android/accounts/Account)
           INVOKESPECIAL (test/Foo, <init>, (Landroid/accounts/Account;)V)
           ARETURN
         LABEL (L1)
@@ -38,10 +38,10 @@ public final class test/Foo : java/lang/Object, android/os/Parcelable {
     private final android.accounts.Account kp
 
     static void <clinit>() {
-          NEW
+          NEW (test/Foo$Creator)
           DUP
           INVOKESPECIAL (test/Foo$Creator, <init>, ()V)
-          CHECKCAST
+          CHECKCAST (android/os/Parcelable$Creator)
           PUTSTATIC (test/Foo, CREATOR, Landroid/os/Parcelable$Creator;)
           RETURN
     }
@@ -60,7 +60,7 @@ public final class test/Foo : java/lang/Object, android/os/Parcelable {
           ALOAD (1)
           ALOAD (0)
           GETFIELD (test/Foo, kp, Landroid/accounts/Account;)
-          CHECKCAST
+          CHECKCAST (android/os/Parcelable)
           ILOAD (2)
           INVOKEVIRTUAL (android/os/Parcel, writeParcelable, (Landroid/os/Parcelable;I)V)
           RETURN

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/customParcelablesDifferentModule.asm.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/customParcelablesDifferentModule.asm.txt
@@ -6,13 +6,13 @@ public final class test/Foo$Creator : java/lang/Object, android/os/Parcelable$Cr
           ALOAD (1)
           LDC (in)
           INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
-          NEW
+          NEW (test/Foo)
           DUP
           ALOAD (1)
           LDC (Ltest/Foo;)
           INVOKEVIRTUAL (java/lang/Class, getClassLoader, ()Ljava/lang/ClassLoader;)
           INVOKEVIRTUAL (android/os/Parcel, readParcelable, (Ljava/lang/ClassLoader;)Landroid/os/Parcelable;)
-          CHECKCAST
+          CHECKCAST (android/accounts/Account)
           INVOKESPECIAL (test/Foo, <init>, (Landroid/accounts/Account;)V)
           ARETURN
         LABEL (L1)
@@ -38,7 +38,7 @@ public final class test/Foo : java/lang/Object, android/os/Parcelable {
     private final android.accounts.Account kp
 
     static void <clinit>() {
-          NEW
+          NEW (test/Foo$Creator)
           DUP
           INVOKESPECIAL (test/Foo$Creator, <init>, ()V)
           PUTSTATIC (test/Foo, CREATOR, Landroid/os/Parcelable$Creator;)

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/customParcelablesSameModule.asm.ir.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/customParcelablesSameModule.asm.ir.txt
@@ -19,7 +19,7 @@ public final class k/KotlinParcelable$Creator : java/lang/Object, android/os/Par
           ISTORE (2)
         LABEL (L2)
         LINENUMBER (24)
-          NEW
+          NEW (k/KotlinParcelable)
           DUP
           ILOAD (2)
           INVOKESPECIAL (k/KotlinParcelable, <init>, (I)V)
@@ -50,14 +50,14 @@ public final class k/KotlinParcelable : java/lang/Object, android/os/Parcelable 
     private int data
 
     static void <clinit>() {
-          NEW
+          NEW (k/KotlinParcelable$Companion)
           DUP
           ACONST_NULL
           INVOKESPECIAL (k/KotlinParcelable$Companion, <init>, (Lkotlin/jvm/internal/DefaultConstructorMarker;)V)
           PUTSTATIC (k/KotlinParcelable, Companion, Lk/KotlinParcelable$Companion;)
         LABEL (L0)
         LINENUMBER (18)
-          NEW
+          NEW (k/KotlinParcelable$Creator)
           DUP
           INVOKESPECIAL (k/KotlinParcelable$Creator, <init>, ()V)
           PUTSTATIC (k/KotlinParcelable, CREATOR, Lk/KotlinParcelable$Creator;)
@@ -110,7 +110,7 @@ public final class test/Foo$Creator : java/lang/Object, android/os/Parcelable$Cr
           ALOAD (1)
           LDC (parcel)
           INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
-          NEW
+          NEW (test/Foo)
           DUP
           GETSTATIC (k/KotlinParcelable, CREATOR, Lk/KotlinParcelable$Creator;)
           ALOAD (1)
@@ -140,10 +140,10 @@ public final class test/Foo : java/lang/Object, android/os/Parcelable {
     private final k.KotlinParcelable kp
 
     static void <clinit>() {
-          NEW
+          NEW (test/Foo$Creator)
           DUP
           INVOKESPECIAL (test/Foo$Creator, <init>, ()V)
-          CHECKCAST
+          CHECKCAST (android/os/Parcelable$Creator)
           PUTSTATIC (test/Foo, CREATOR, Landroid/os/Parcelable$Creator;)
           RETURN
     }

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/customParcelablesSameModule.asm.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/customParcelablesSameModule.asm.txt
@@ -19,7 +19,7 @@ public final class k/KotlinParcelable$Creator : java/lang/Object, android/os/Par
           ISTORE (2)
         LABEL (L2)
         LINENUMBER (24)
-          NEW
+          NEW (k/KotlinParcelable)
           DUP
           ILOAD (2)
           INVOKESPECIAL (k/KotlinParcelable, <init>, (I)V)
@@ -49,14 +49,14 @@ public final class k/KotlinParcelable : java/lang/Object, android/os/Parcelable 
     private int data
 
     static void <clinit>() {
-          NEW
+          NEW (k/KotlinParcelable$Companion)
           DUP
           ACONST_NULL
           INVOKESPECIAL (k/KotlinParcelable$Companion, <init>, (Lkotlin/jvm/internal/DefaultConstructorMarker;)V)
           PUTSTATIC (k/KotlinParcelable, Companion, Lk/KotlinParcelable$Companion;)
         LABEL (L0)
         LINENUMBER (18)
-          NEW
+          NEW (k/KotlinParcelable$Creator)
           DUP
           INVOKESPECIAL (k/KotlinParcelable$Creator, <init>, ()V)
           PUTSTATIC (k/KotlinParcelable, CREATOR, Lk/KotlinParcelable$Creator;)
@@ -109,13 +109,13 @@ public final class test/Foo$Creator : java/lang/Object, android/os/Parcelable$Cr
           ALOAD (1)
           LDC (in)
           INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
-          NEW
+          NEW (test/Foo)
           DUP
           ALOAD (1)
           LDC (Ltest/Foo;)
           INVOKEVIRTUAL (java/lang/Class, getClassLoader, ()Ljava/lang/ClassLoader;)
           INVOKEVIRTUAL (android/os/Parcel, readParcelable, (Ljava/lang/ClassLoader;)Landroid/os/Parcelable;)
-          CHECKCAST
+          CHECKCAST (k/KotlinParcelable)
           INVOKESPECIAL (test/Foo, <init>, (Lk/KotlinParcelable;)V)
           ARETURN
         LABEL (L1)
@@ -141,7 +141,7 @@ public final class test/Foo : java/lang/Object, android/os/Parcelable {
     private final k.KotlinParcelable kp
 
     static void <clinit>() {
-          NEW
+          NEW (test/Foo$Creator)
           DUP
           INVOKESPECIAL (test/Foo$Creator, <init>, ()V)
           PUTSTATIC (test/Foo, CREATOR, Landroid/os/Parcelable$Creator;)

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/customSimple.asm.ir.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/customSimple.asm.ir.txt
@@ -11,10 +11,10 @@ final class User$Companion : java/lang/Object, kotlinx/parcelize/Parceler {
         LABEL (L0)
         LINENUMBER (10)
           ALOAD (0)
-          CHECKCAST
+          CHECKCAST (kotlinx/parcelize/Parceler)
           ILOAD (1)
           INVOKESTATIC (kotlinx/parcelize/Parceler$DefaultImpls, newArray, (Lkotlinx/parcelize/Parceler;I)[Ljava/lang/Object;)
-          CHECKCAST
+          CHECKCAST ([LUser;)
           ARETURN
         LABEL (L1)
     }
@@ -61,7 +61,7 @@ public final class User$Creator : java/lang/Object, android/os/Parcelable$Creato
     public final User[] newArray(int size) {
         LABEL (L0)
           ILOAD (1)
-          ANEWARRAY
+          ANEWARRAY (User)
           ARETURN
         LABEL (L1)
     }

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/customSimple.asm.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/customSimple.asm.txt
@@ -13,7 +13,7 @@ final class User$Companion : java/lang/Object, kotlinx/parcelize/Parceler {
           ALOAD (0)
           ILOAD (1)
           INVOKESTATIC (kotlinx/parcelize/Parceler$DefaultImpls, newArray, (Lkotlinx/parcelize/Parceler;I)[Ljava/lang/Object;)
-          CHECKCAST
+          CHECKCAST ([LUser;)
           ARETURN
         LABEL (L1)
     }
@@ -59,7 +59,7 @@ public final class User$Creator : java/lang/Object, android/os/Parcelable$Creato
     public final User[] newArray(int size) {
         LABEL (L0)
           ILOAD (1)
-          ANEWARRAY
+          ANEWARRAY (User)
           ARETURN
         LABEL (L1)
     }

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/customSimpleWithNewArray.asm.ir.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/customSimpleWithNewArray.asm.ir.txt
@@ -11,7 +11,7 @@ final class User$Companion : java/lang/Object, kotlinx/parcelize/Parceler {
         LABEL (L0)
         LINENUMBER (19)
           ILOAD (1)
-          ANEWARRAY
+          ANEWARRAY (User)
           ARETURN
         LABEL (L1)
     }

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/customSimpleWithNewArray.asm.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/customSimpleWithNewArray.asm.txt
@@ -11,7 +11,7 @@ final class User$Companion : java/lang/Object, kotlinx/parcelize/Parceler {
         LABEL (L0)
         LINENUMBER (19)
           ILOAD (1)
-          ANEWARRAY
+          ANEWARRAY (User)
           ARETURN
         LABEL (L1)
     }

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/duplicatingClinit.asm.ir.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/duplicatingClinit.asm.ir.txt
@@ -28,19 +28,19 @@ public final class User : java/lang/Object, android/os/Parcelable {
     private final static java.lang.StringBuilder test
 
     static void <clinit>() {
-          NEW
+          NEW (User$Companion)
           DUP
           ACONST_NULL
           INVOKESPECIAL (User$Companion, <init>, (Lkotlin/jvm/internal/DefaultConstructorMarker;)V)
           PUTSTATIC (User, Companion, LUser$Companion;)
-          NEW
+          NEW (User$Creator)
           DUP
           INVOKESPECIAL (User$Creator, <init>, ()V)
-          CHECKCAST
+          CHECKCAST (android/os/Parcelable$Creator)
           PUTSTATIC (User, CREATOR, Landroid/os/Parcelable$Creator;)
         LABEL (L0)
         LINENUMBER (12)
-          NEW
+          NEW (java/lang/StringBuilder)
           DUP
           INVOKESPECIAL (java/lang/StringBuilder, <init>, ()V)
           PUTSTATIC (User, test, Ljava/lang/StringBuilder;)

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/duplicatingClinit.asm.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/duplicatingClinit.asm.txt
@@ -28,18 +28,18 @@ public final class User : java/lang/Object, android/os/Parcelable {
     private final static java.lang.StringBuilder test
 
     static void <clinit>() {
-          NEW
+          NEW (User$Companion)
           DUP
           ACONST_NULL
           INVOKESPECIAL (User$Companion, <init>, (Lkotlin/jvm/internal/DefaultConstructorMarker;)V)
           PUTSTATIC (User, Companion, LUser$Companion;)
         LABEL (L0)
         LINENUMBER (12)
-          NEW
+          NEW (java/lang/StringBuilder)
           DUP
           INVOKESPECIAL (java/lang/StringBuilder, <init>, ()V)
           PUTSTATIC (User, test, Ljava/lang/StringBuilder;)
-          NEW
+          NEW (User$Creator)
           DUP
           INVOKESPECIAL (User$Creator, <init>, ()V)
           PUTSTATIC (User, CREATOR, Landroid/os/Parcelable$Creator;)

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/efficientParcelable.asm.ir.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/efficientParcelable.asm.ir.txt
@@ -7,7 +7,7 @@ public final class test/Bar$Creator : java/lang/Object, android/os/Parcelable$Cr
           LDC (parcel)
           INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
         LABEL (L1)
-          NEW
+          NEW (test/Bar)
           DUP
           ALOAD (1)
           INVOKEVIRTUAL (android/os/Parcel, readInt, ()I)
@@ -19,7 +19,7 @@ public final class test/Bar$Creator : java/lang/Object, android/os/Parcelable$Cr
           ALOAD (1)
           INVOKEINTERFACE (android/os/Parcelable$Creator, createFromParcel, (Landroid/os/Parcel;)Ljava/lang/Object;)
         LABEL (L3)
-          CHECKCAST
+          CHECKCAST (test/Foo)
           INVOKESPECIAL (test/Bar, <init>, (Ltest/Foo;)V)
           ARETURN
         LABEL (L4)
@@ -45,10 +45,10 @@ public final class test/Bar : java/lang/Object, android/os/Parcelable {
     private final test.Foo foo
 
     static void <clinit>() {
-          NEW
+          NEW (test/Bar$Creator)
           DUP
           INVOKESPECIAL (test/Bar$Creator, <init>, ()V)
-          CHECKCAST
+          CHECKCAST (android/os/Parcelable$Creator)
           PUTSTATIC (test/Bar, CREATOR, Landroid/os/Parcelable$Creator;)
           RETURN
     }
@@ -95,12 +95,12 @@ public final class test/Foo$Creator : java/lang/Object, android/os/Parcelable$Cr
           ALOAD (1)
           LDC (parcel)
           INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
-          NEW
+          NEW (test/Foo)
           DUP
           GETSTATIC (test/Bar, CREATOR, Landroid/os/Parcelable$Creator;)
           ALOAD (1)
           INVOKEINTERFACE (android/os/Parcelable$Creator, createFromParcel, (Landroid/os/Parcel;)Ljava/lang/Object;)
-          CHECKCAST
+          CHECKCAST (test/Bar)
           INVOKESPECIAL (test/Foo, <init>, (Ltest/Bar;)V)
           ARETURN
         LABEL (L1)
@@ -126,10 +126,10 @@ public final class test/Foo : java/lang/Object, android/os/Parcelable {
     private final test.Bar bar
 
     static void <clinit>() {
-          NEW
+          NEW (test/Foo$Creator)
           DUP
           INVOKESPECIAL (test/Foo$Creator, <init>, ()V)
-          CHECKCAST
+          CHECKCAST (android/os/Parcelable$Creator)
           PUTSTATIC (test/Foo, CREATOR, Landroid/os/Parcelable$Creator;)
           RETURN
     }

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/efficientParcelable.asm.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/efficientParcelable.asm.txt
@@ -7,7 +7,7 @@ public final class test/Bar$Creator : java/lang/Object, android/os/Parcelable$Cr
           LDC (in)
           INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
         LABEL (L1)
-          NEW
+          NEW (test/Bar)
           DUP
           ALOAD (1)
           INVOKEVIRTUAL (android/os/Parcel, readInt, ()I)
@@ -16,7 +16,7 @@ public final class test/Bar$Creator : java/lang/Object, android/os/Parcelable$Cr
           GETSTATIC (test/Foo, CREATOR, Landroid/os/Parcelable$Creator;)
           SWAP
           INVOKEINTERFACE (android/os/Parcelable$Creator, createFromParcel, (Landroid/os/Parcel;)Ljava/lang/Object;)
-          CHECKCAST
+          CHECKCAST (test/Foo)
           GOTO (L3)
         LABEL (L2)
           ACONST_NULL
@@ -46,7 +46,7 @@ public final class test/Bar : java/lang/Object, android/os/Parcelable {
     private final test.Foo foo
 
     static void <clinit>() {
-          NEW
+          NEW (test/Bar$Creator)
           DUP
           INVOKESPECIAL (test/Bar$Creator, <init>, ()V)
           PUTSTATIC (test/Bar, CREATOR, Landroid/os/Parcelable$Creator;)
@@ -94,13 +94,13 @@ public final class test/Foo$Creator : java/lang/Object, android/os/Parcelable$Cr
           ALOAD (1)
           LDC (in)
           INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
-          NEW
+          NEW (test/Foo)
           DUP
           ALOAD (1)
           GETSTATIC (test/Bar, CREATOR, Landroid/os/Parcelable$Creator;)
           SWAP
           INVOKEINTERFACE (android/os/Parcelable$Creator, createFromParcel, (Landroid/os/Parcel;)Ljava/lang/Object;)
-          CHECKCAST
+          CHECKCAST (test/Bar)
           INVOKESPECIAL (test/Foo, <init>, (Ltest/Bar;)V)
           ARETURN
         LABEL (L1)
@@ -126,7 +126,7 @@ public final class test/Foo : java/lang/Object, android/os/Parcelable {
     private final test.Bar bar
 
     static void <clinit>() {
-          NEW
+          NEW (test/Foo$Creator)
           DUP
           INVOKESPECIAL (test/Foo$Creator, <init>, ()V)
           PUTSTATIC (test/Foo, CREATOR, Landroid/os/Parcelable$Creator;)

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/generics.asm.ir.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/generics.asm.ir.txt
@@ -10,7 +10,7 @@ public final class Box$Creator : java/lang/Object, android/os/Parcelable$Creator
           ALOAD (1)
           LDC (parcel)
           INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
-          NEW
+          NEW (Box)
           DUP
           ALOAD (1)
           LDC (LBox;)

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/generics.asm.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/generics.asm.txt
@@ -10,7 +10,7 @@ public final class Box$Creator : java/lang/Object, android/os/Parcelable$Creator
           ALOAD (1)
           LDC (in)
           INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
-          NEW
+          NEW (Box)
           DUP
           ALOAD (1)
           LDC (LBox;)

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/kt25839.asm.ir.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/kt25839.asm.ir.txt
@@ -9,7 +9,7 @@ public final class test/SomeClass$Creator : java/lang/Object, android/os/Parcela
           ALOAD (1)
           INVOKEVIRTUAL (android/os/Parcel, readInt, ()I)
           POP
-          NEW
+          NEW (test/SomeClass)
           DUP
           INVOKESPECIAL (test/SomeClass, <init>, ()V)
           ARETURN

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/kt25839.asm.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/kt25839.asm.txt
@@ -7,12 +7,12 @@ public final class test/SomeClass$Creator : java/lang/Object, android/os/Parcela
           LDC (in)
           INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
         LABEL (L1)
-          NEW
+          NEW (test/SomeClass)
           DUP
           ALOAD (1)
           INVOKEVIRTUAL (android/os/Parcel, readInt, ()I)
           IFEQ (L2)
-          NEW
+          NEW (test/SomeClass)
           DUP
           INVOKESPECIAL (test/SomeClass, <init>, ()V)
           GOTO (L3)

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/listInsideList.asm.ir.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/listInsideList.asm.ir.txt
@@ -44,7 +44,7 @@ public final class Test : java/lang/Object, android/os/Parcelable {
           IFEQ (L2)
           ALOAD (4)
           INVOKEINTERFACE (java/util/Iterator, next, ()Ljava/lang/Object;)
-          CHECKCAST
+          CHECKCAST (java/util/List)
           ASTORE (5)
           ALOAD (1)
           ALOAD (5)
@@ -60,7 +60,7 @@ public final class Test : java/lang/Object, android/os/Parcelable {
           ALOAD (1)
           ALOAD (6)
           INVOKEINTERFACE (java/util/Iterator, next, ()Ljava/lang/Object;)
-          CHECKCAST
+          CHECKCAST (java/util/List)
           INVOKEVIRTUAL (android/os/Parcel, writeStringList, (Ljava/util/List;)V)
           GOTO (L3)
         LABEL (L2)

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/listInsideList.asm.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/listInsideList.asm.txt
@@ -43,7 +43,7 @@ public final class Test : java/lang/Object, android/os/Parcelable {
           ALOAD (1)
           SWAP
           INVOKEINTERFACE (java/util/Iterator, next, ()Ljava/lang/Object;)
-          CHECKCAST
+          CHECKCAST (java/util/List)
           DUP_X1
           INVOKEINTERFACE (java/util/Collection, size, ()I)
           INVOKEVIRTUAL (android/os/Parcel, writeInt, (I)V)
@@ -56,7 +56,7 @@ public final class Test : java/lang/Object, android/os/Parcelable {
           ALOAD (1)
           SWAP
           INVOKEINTERFACE (java/util/Iterator, next, ()Ljava/lang/Object;)
-          CHECKCAST
+          CHECKCAST (java/util/ArrayList)
           DUP_X1
           INVOKEINTERFACE (java/util/Collection, size, ()I)
           INVOKEVIRTUAL (android/os/Parcel, writeInt, (I)V)
@@ -69,7 +69,7 @@ public final class Test : java/lang/Object, android/os/Parcelable {
           ALOAD (1)
           SWAP
           INVOKEINTERFACE (java/util/Iterator, next, ()Ljava/lang/Object;)
-          CHECKCAST
+          CHECKCAST (java/lang/String)
           INVOKEVIRTUAL (android/os/Parcel, writeString, (Ljava/lang/String;)V)
           GOTO (L5)
         LABEL (L6)

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/parcelable.asm.ir.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/parcelable.asm.ir.txt
@@ -6,7 +6,7 @@ public final class test/Foo$Creator : java/lang/Object, android/os/Parcelable$Cr
           ALOAD (1)
           LDC (parcel)
           INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
-          NEW
+          NEW (test/Foo)
           DUP
           ALOAD (1)
           LDC (Ltest/Foo;)
@@ -37,10 +37,10 @@ public final class test/Foo : java/lang/Object, android/os/Parcelable {
     private final android.os.Parcelable parcelable
 
     static void <clinit>() {
-          NEW
+          NEW (test/Foo$Creator)
           DUP
           INVOKESPECIAL (test/Foo$Creator, <init>, ()V)
-          CHECKCAST
+          CHECKCAST (android/os/Parcelable$Creator)
           PUTSTATIC (test/Foo, CREATOR, Landroid/os/Parcelable$Creator;)
           RETURN
     }

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/parcelable.asm.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/parcelable.asm.txt
@@ -6,7 +6,7 @@ public final class test/Foo$Creator : java/lang/Object, android/os/Parcelable$Cr
           ALOAD (1)
           LDC (in)
           INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
-          NEW
+          NEW (test/Foo)
           DUP
           ALOAD (1)
           LDC (Ltest/Foo;)
@@ -37,7 +37,7 @@ public final class test/Foo : java/lang/Object, android/os/Parcelable {
     private final android.os.Parcelable parcelable
 
     static void <clinit>() {
-          NEW
+          NEW (test/Foo$Creator)
           DUP
           INVOKESPECIAL (test/Foo$Creator, <init>, ()V)
           PUTSTATIC (test/Foo, CREATOR, Landroid/os/Parcelable$Creator;)

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/parcelableCreator.asm.ir.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/parcelableCreator.asm.ir.txt
@@ -102,32 +102,32 @@ public final class ParcelableCreatorKt : java/lang/Object {
           LDC (T)
           INVOKESTATIC (kotlin/jvm/internal/Intrinsics, reifiedOperationMarker, (ILjava/lang/String;)V)
           LDC (Landroid/os/Parcelable;)
-          CHECKCAST
+          CHECKCAST (java/lang/Class)
           LDC (CREATOR)
           INVOKEVIRTUAL (java/lang/Class, getDeclaredField, (Ljava/lang/String;)Ljava/lang/reflect/Field;)
           ACONST_NULL
           INVOKEVIRTUAL (java/lang/reflect/Field, get, (Ljava/lang/Object;)Ljava/lang/Object;)
           ASTORE (2)
           ALOAD (2)
-          INSTANCEOF
+          INSTANCEOF (android/os/Parcelable$Creator)
           IFEQ (L2)
           ALOAD (2)
-          CHECKCAST
+          CHECKCAST (android/os/Parcelable$Creator)
           GOTO (L3)
         LABEL (L2)
           ACONST_NULL
         LABEL (L3)
           DUP
           IFNULL (L4)
-          CHECKCAST
+          CHECKCAST (android/os/Parcelable$Creator)
           GOTO (L5)
         LABEL (L4)
           POP
         LABEL (L6)
         LINENUMBER (31)
-          NEW
+          NEW (java/lang/IllegalArgumentException)
           DUP
-          NEW
+          NEW (java/lang/StringBuilder)
           DUP
           INVOKESPECIAL (java/lang/StringBuilder, <init>, ()V)
           LDC (Could not access CREATOR field in class )
@@ -168,10 +168,10 @@ public final class ParcelableCreatorKt : java/lang/Object {
           INVOKEVIRTUAL (java/lang/reflect/Field, get, (Ljava/lang/Object;)Ljava/lang/Object;)
           ASTORE (2)
           ALOAD (2)
-          INSTANCEOF
+          INSTANCEOF (android/os/Parcelable$Creator)
           IFEQ (L3)
           ALOAD (2)
-          CHECKCAST
+          CHECKCAST (android/os/Parcelable$Creator)
           GOTO (L4)
         LABEL (L3)
           ACONST_NULL
@@ -181,9 +181,9 @@ public final class ParcelableCreatorKt : java/lang/Object {
           POP
         LABEL (L6)
         LINENUMBER (34)
-          NEW
+          NEW (java/lang/IllegalArgumentException)
           DUP
-          NEW
+          NEW (java/lang/StringBuilder)
           DUP
           INVOKESPECIAL (java/lang/StringBuilder, <init>, ()V)
           LDC (Could not access CREATOR field in class )

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/parcelableCreator.asm.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/parcelableCreator.asm.txt
@@ -91,10 +91,10 @@ public final class ParcelableCreatorKt : java/lang/Object {
           INVOKEVIRTUAL (java/lang/reflect/Field, get, (Ljava/lang/Object;)Ljava/lang/Object;)
           ASTORE (1)
           ALOAD (1)
-          INSTANCEOF
+          INSTANCEOF (android/os/Parcelable$Creator)
           IFEQ (L2)
           ALOAD (1)
-          CHECKCAST
+          CHECKCAST (android/os/Parcelable$Creator)
           GOTO (L3)
         LABEL (L2)
           ACONST_NULL
@@ -104,9 +104,9 @@ public final class ParcelableCreatorKt : java/lang/Object {
           POP
         LABEL (L5)
         LINENUMBER (31)
-          NEW
+          NEW (java/lang/IllegalArgumentException)
           DUP
-          NEW
+          NEW (java/lang/StringBuilder)
           DUP
           INVOKESPECIAL (java/lang/StringBuilder, <init>, ()V)
           LDC (Could not access CREATOR field in class )
@@ -133,10 +133,10 @@ public final class ParcelableCreatorKt : java/lang/Object {
           INVOKEVIRTUAL (java/lang/reflect/Field, get, (Ljava/lang/Object;)Ljava/lang/Object;)
           ASTORE (1)
           ALOAD (1)
-          INSTANCEOF
+          INSTANCEOF (android/os/Parcelable$Creator)
           IFEQ (L8)
           ALOAD (1)
-          CHECKCAST
+          CHECKCAST (android/os/Parcelable$Creator)
           GOTO (L9)
         LABEL (L8)
           ACONST_NULL
@@ -146,9 +146,9 @@ public final class ParcelableCreatorKt : java/lang/Object {
           POP
         LABEL (L11)
         LINENUMBER (33)
-          NEW
+          NEW (java/lang/IllegalArgumentException)
           DUP
-          NEW
+          NEW (java/lang/StringBuilder)
           DUP
           INVOKESPECIAL (java/lang/StringBuilder, <init>, ()V)
           LDC (Could not access CREATOR field in class )
@@ -175,10 +175,10 @@ public final class ParcelableCreatorKt : java/lang/Object {
           INVOKEVIRTUAL (java/lang/reflect/Field, get, (Ljava/lang/Object;)Ljava/lang/Object;)
           ASTORE (1)
           ALOAD (1)
-          INSTANCEOF
+          INSTANCEOF (android/os/Parcelable$Creator)
           IFEQ (L14)
           ALOAD (1)
-          CHECKCAST
+          CHECKCAST (android/os/Parcelable$Creator)
           GOTO (L15)
         LABEL (L14)
           ACONST_NULL
@@ -188,9 +188,9 @@ public final class ParcelableCreatorKt : java/lang/Object {
           POP
         LABEL (L17)
         LINENUMBER (35)
-          NEW
+          NEW (java/lang/IllegalArgumentException)
           DUP
-          NEW
+          NEW (java/lang/StringBuilder)
           DUP
           INVOKESPECIAL (java/lang/StringBuilder, <init>, ()V)
           LDC (Could not access CREATOR field in class )
@@ -222,32 +222,32 @@ public final class ParcelableCreatorKt : java/lang/Object {
           LDC (T)
           INVOKESTATIC (kotlin/jvm/internal/Intrinsics, reifiedOperationMarker, (ILjava/lang/String;)V)
           LDC (Landroid/os/Parcelable;)
-          CHECKCAST
+          CHECKCAST (java/lang/Class)
           LDC (CREATOR)
           INVOKEVIRTUAL (java/lang/Class, getDeclaredField, (Ljava/lang/String;)Ljava/lang/reflect/Field;)
           ACONST_NULL
           INVOKEVIRTUAL (java/lang/reflect/Field, get, (Ljava/lang/Object;)Ljava/lang/Object;)
           ASTORE (2)
           ALOAD (2)
-          INSTANCEOF
+          INSTANCEOF (android/os/Parcelable$Creator)
           IFEQ (L2)
           ALOAD (2)
-          CHECKCAST
+          CHECKCAST (android/os/Parcelable$Creator)
           GOTO (L3)
         LABEL (L2)
           ACONST_NULL
         LABEL (L3)
           DUP
           IFNULL (L4)
-          CHECKCAST
+          CHECKCAST (android/os/Parcelable$Creator)
           GOTO (L5)
         LABEL (L4)
           POP
         LABEL (L6)
         LINENUMBER (37)
-          NEW
+          NEW (java/lang/IllegalArgumentException)
           DUP
-          NEW
+          NEW (java/lang/StringBuilder)
           DUP
           INVOKESPECIAL (java/lang/StringBuilder, <init>, ()V)
           LDC (Could not access CREATOR field in class )
@@ -288,10 +288,10 @@ public final class ParcelableCreatorKt : java/lang/Object {
           INVOKEVIRTUAL (java/lang/reflect/Field, get, (Ljava/lang/Object;)Ljava/lang/Object;)
           ASTORE (2)
           ALOAD (2)
-          INSTANCEOF
+          INSTANCEOF (android/os/Parcelable$Creator)
           IFEQ (L3)
           ALOAD (2)
-          CHECKCAST
+          CHECKCAST (android/os/Parcelable$Creator)
           GOTO (L4)
         LABEL (L3)
           ACONST_NULL
@@ -301,9 +301,9 @@ public final class ParcelableCreatorKt : java/lang/Object {
           POP
         LABEL (L6)
         LINENUMBER (40)
-          NEW
+          NEW (java/lang/IllegalArgumentException)
           DUP
-          NEW
+          NEW (java/lang/StringBuilder)
           DUP
           INVOKESPECIAL (java/lang/StringBuilder, <init>, ()V)
           LDC (Could not access CREATOR field in class )

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/primitiveArrays.asm.ir.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/primitiveArrays.asm.ir.txt
@@ -119,7 +119,7 @@ public final class Test$Creator : java/lang/Object, android/os/Parcelable$Creato
           ASTORE (23)
           ASTORE (24)
           ASTORE (25)
-          NEW
+          NEW (Test)
           DUP
           ALOAD (25)
           ALOAD (24)

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/serializable.asm.ir.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/serializable.asm.ir.txt
@@ -18,14 +18,14 @@ public final class User$Creator : java/lang/Object, android/os/Parcelable$Creato
           ALOAD (1)
           LDC (parcel)
           INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
-          NEW
+          NEW (User)
           DUP
           ALOAD (1)
           INVOKEVIRTUAL (android/os/Parcel, readSerializable, ()Ljava/io/Serializable;)
-          CHECKCAST
+          CHECKCAST (SerializableSimple)
           ALOAD (1)
           INVOKEVIRTUAL (android/os/Parcel, readSerializable, ()Ljava/io/Serializable;)
-          CHECKCAST
+          CHECKCAST (SerializableSimple)
           INVOKESPECIAL (User, <init>, (LSerializableSimple;LSerializableSimple;)V)
           ARETURN
         LABEL (L1)
@@ -53,10 +53,10 @@ public final class User : java/lang/Object, android/os/Parcelable {
     private final SerializableSimple nullable
 
     static void <clinit>() {
-          NEW
+          NEW (User$Creator)
           DUP
           INVOKESPECIAL (User$Creator, <init>, ()V)
-          CHECKCAST
+          CHECKCAST (android/os/Parcelable$Creator)
           PUTSTATIC (User, CREATOR, Landroid/os/Parcelable$Creator;)
           RETURN
     }
@@ -77,12 +77,12 @@ public final class User : java/lang/Object, android/os/Parcelable {
           ALOAD (1)
           ALOAD (0)
           GETFIELD (User, notNull, LSerializableSimple;)
-          CHECKCAST
+          CHECKCAST (java/io/Serializable)
           INVOKEVIRTUAL (android/os/Parcel, writeSerializable, (Ljava/io/Serializable;)V)
           ALOAD (1)
           ALOAD (0)
           GETFIELD (User, nullable, LSerializableSimple;)
-          CHECKCAST
+          CHECKCAST (java/io/Serializable)
           INVOKEVIRTUAL (android/os/Parcel, writeSerializable, (Ljava/io/Serializable;)V)
           RETURN
         LABEL (L1)

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/serializable.asm.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/serializable.asm.txt
@@ -18,14 +18,14 @@ public final class User$Creator : java/lang/Object, android/os/Parcelable$Creato
           ALOAD (1)
           LDC (in)
           INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
-          NEW
+          NEW (User)
           DUP
           ALOAD (1)
           INVOKEVIRTUAL (android/os/Parcel, readSerializable, ()Ljava/io/Serializable;)
-          CHECKCAST
+          CHECKCAST (SerializableSimple)
           ALOAD (1)
           INVOKEVIRTUAL (android/os/Parcel, readSerializable, ()Ljava/io/Serializable;)
-          CHECKCAST
+          CHECKCAST (SerializableSimple)
           INVOKESPECIAL (User, <init>, (LSerializableSimple;LSerializableSimple;)V)
           ARETURN
         LABEL (L1)
@@ -53,7 +53,7 @@ public final class User : java/lang/Object, android/os/Parcelable {
     private final SerializableSimple nullable
 
     static void <clinit>() {
-          NEW
+          NEW (User$Creator)
           DUP
           INVOKESPECIAL (User$Creator, <init>, ()V)
           PUTSTATIC (User, CREATOR, Landroid/os/Parcelable$Creator;)

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/serializeValue.asm.ir.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/serializeValue.asm.ir.txt
@@ -6,13 +6,13 @@ public final class Test$Creator : java/lang/Object, android/os/Parcelable$Creato
           ALOAD (1)
           LDC (parcel)
           INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
-          NEW
+          NEW (Test)
           DUP
           ALOAD (1)
           LDC (LTest;)
           INVOKEVIRTUAL (java/lang/Class, getClassLoader, ()Ljava/lang/ClassLoader;)
           INVOKEVIRTUAL (android/os/Parcel, readValue, (Ljava/lang/ClassLoader;)Ljava/lang/Object;)
-          CHECKCAST
+          CHECKCAST (Value)
           INVOKESPECIAL (Test, <init>, (LValue;)V)
           ARETURN
         LABEL (L1)
@@ -38,10 +38,10 @@ public final class Test : java/lang/Object, android/os/Parcelable {
     private final Value value
 
     static void <clinit>() {
-          NEW
+          NEW (Test$Creator)
           DUP
           INVOKESPECIAL (Test$Creator, <init>, ()V)
-          CHECKCAST
+          CHECKCAST (android/os/Parcelable$Creator)
           PUTSTATIC (Test, CREATOR, Landroid/os/Parcelable$Creator;)
           RETURN
     }

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/serializeValue.asm.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/serializeValue.asm.txt
@@ -6,13 +6,13 @@ public final class Test$Creator : java/lang/Object, android/os/Parcelable$Creato
           ALOAD (1)
           LDC (in)
           INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
-          NEW
+          NEW (Test)
           DUP
           ALOAD (1)
           LDC (LValue;)
           INVOKEVIRTUAL (java/lang/Class, getClassLoader, ()Ljava/lang/ClassLoader;)
           INVOKEVIRTUAL (android/os/Parcel, readValue, (Ljava/lang/ClassLoader;)Ljava/lang/Object;)
-          CHECKCAST
+          CHECKCAST (Value)
           INVOKESPECIAL (Test, <init>, (LValue;)V)
           ARETURN
         LABEL (L1)
@@ -38,7 +38,7 @@ public final class Test : java/lang/Object, android/os/Parcelable {
     private final Value value
 
     static void <clinit>() {
-          NEW
+          NEW (Test$Creator)
           DUP
           INVOKESPECIAL (Test$Creator, <init>, ()V)
           PUTSTATIC (Test, CREATOR, Landroid/os/Parcelable$Creator;)

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/simple.asm.ir.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/simple.asm.ir.txt
@@ -14,7 +14,7 @@ public final class User$Creator : java/lang/Object, android/os/Parcelable$Creato
           LDC (parcel)
           INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
         LABEL (L1)
-          NEW
+          NEW (User)
           DUP
           ALOAD (1)
           INVOKEVIRTUAL (android/os/Parcel, readString, ()Ljava/lang/String;)
@@ -73,10 +73,10 @@ public final class User : java/lang/Object, android/os/Parcelable {
     private final java.lang.String lastName
 
     static void <clinit>() {
-          NEW
+          NEW (User$Creator)
           DUP
           INVOKESPECIAL (User$Creator, <init>, ()V)
-          CHECKCAST
+          CHECKCAST (android/os/Parcelable$Creator)
           PUTSTATIC (User, CREATOR, Landroid/os/Parcelable$Creator;)
           RETURN
     }

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/simple.asm.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/simple.asm.txt
@@ -14,7 +14,7 @@ public final class User$Creator : java/lang/Object, android/os/Parcelable$Creato
           LDC (in)
           INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
         LABEL (L1)
-          NEW
+          NEW (User)
           DUP
           ALOAD (1)
           INVOKEVIRTUAL (android/os/Parcel, readString, ()Ljava/lang/String;)
@@ -65,7 +65,7 @@ public final class User : java/lang/Object, android/os/Parcelable {
     private final java.lang.String lastName
 
     static void <clinit>() {
-          NEW
+          NEW (User$Creator)
           DUP
           INVOKESPECIAL (User$Creator, <init>, ()V)
           PUTSTATIC (User, CREATOR, Landroid/os/Parcelable$Creator;)

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/size.asm.ir.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/size.asm.ir.txt
@@ -7,7 +7,7 @@ public final class Test$Creator : java/lang/Object, android/os/Parcelable$Creato
           LDC (parcel)
           INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
         LABEL (L1)
-          NEW
+          NEW (Test)
           DUP
           ALOAD (1)
           INVOKEVIRTUAL (android/os/Parcel, readSize, ()Landroid/util/Size;)
@@ -110,7 +110,7 @@ public final class TestF$Creator : java/lang/Object, android/os/Parcelable$Creat
           LDC (parcel)
           INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
         LABEL (L1)
-          NEW
+          NEW (TestF)
           DUP
           ALOAD (1)
           INVOKEVIRTUAL (android/os/Parcel, readSizeF, ()Landroid/util/SizeF;)

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/size.asm.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/size.asm.txt
@@ -7,7 +7,7 @@ public final class Test$Creator : java/lang/Object, android/os/Parcelable$Creato
           LDC (in)
           INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
         LABEL (L1)
-          NEW
+          NEW (Test)
           DUP
           ALOAD (1)
           INVOKEVIRTUAL (android/os/Parcel, readSize, ()Landroid/util/Size;)
@@ -108,7 +108,7 @@ public final class TestF$Creator : java/lang/Object, android/os/Parcelable$Creat
           LDC (in)
           INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
         LABEL (L1)
-          NEW
+          NEW (TestF)
           DUP
           ALOAD (1)
           INVOKEVIRTUAL (android/os/Parcel, readSizeF, ()Landroid/util/SizeF;)

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/unsignedPrimitiveArrays.asm.ir.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/unsignedPrimitiveArrays.asm.ir.txt
@@ -97,7 +97,7 @@ public final class Test$Creator : java/lang/Object, android/os/Parcelable$Creato
           ASTORE (16)
           ASTORE (17)
           ASTORE (18)
-          NEW
+          NEW (Test)
           DUP
           ALOAD (18)
           ALOAD (17)


### PR DESCRIPTION
Adds argument printing for `TypeInsnNode`, `IincInsnNode`, `MultiANewArrayInsnNode`, `InvokeDynamicInsnNode`, `TableSwitchInsnNode`, and `LookupSwitchInsnNode`.

---

There's probably a better way of displaying `invokedynamic` instructions, but for now we don't have any instruction listing test with that instruction...