### PR TITLE
Parcelize: Enable warnings in tests

### DIFF
--- a/plugins/parcelize/parcelize-compiler/testData/box/allPrimitiveTypes.kt
+++ b/plugins/parcelize/parcelize-compiler/testData/box/allPrimitiveTypes.kt
@@ -1,6 +1,7 @@
 // WITH_RUNTIME
 
 @file:JvmName("TestKt")
+@file:Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
 package test
 
 import kotlinx.parcelize.*

--- a/plugins/parcelize/parcelize-compiler/testData/box/binder.kt
+++ b/plugins/parcelize/parcelize-compiler/testData/box/binder.kt
@@ -37,5 +37,5 @@ fun box() = parcelTest { parcel ->
     parcel.unmarshall(bytes, 0, bytes.size)
     parcel.setDataPosition(0)
 
-    val test2 = parcelableCreator<ServiceContainer>().createFromParcel(parcel)
+    parcelableCreator<ServiceContainer>().createFromParcel(parcel)
 }

--- a/plugins/parcelize/parcelize-compiler/testData/box/boxedTypes.kt
+++ b/plugins/parcelize/parcelize-compiler/testData/box/boxedTypes.kt
@@ -1,6 +1,7 @@
 // WITH_RUNTIME
 
 @file:JvmName("TestKt")
+@file:Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
 package test
 
 import kotlinx.parcelize.*

--- a/plugins/parcelize/parcelize-compiler/testData/box/customNewArray.kt
+++ b/plugins/parcelize/parcelize-compiler/testData/box/customNewArray.kt
@@ -17,6 +17,7 @@ data class User(val firstName: String, val secondName: String, val age: Int) : P
 
         override fun create(parcel: Parcel) = User(parcel.readString(), parcel.readString(), 0)
 
+        @Suppress("UNCHECKED_CAST")
         override fun newArray(size: Int) = arrayOfNulls<User>(size) as Array<User>
     }
 }

--- a/plugins/parcelize/parcelize-compiler/testData/box/customSerializerSimple.kt
+++ b/plugins/parcelize/parcelize-compiler/testData/box/customSerializerSimple.kt
@@ -18,7 +18,7 @@ object Parceler1 : Parceler<String> {
 typealias Parceler2 = Parceler1
 
 object Parceler3 : Parceler<String> {
-    override fun create(parcel: Parcel) = parcel.readString().toUpperCase()
+    override fun create(parcel: Parcel) = parcel.readString().uppercase()
 
     override fun String.write(parcel: Parcel, flags: Int) {
         parcel.writeString(this)
@@ -29,7 +29,7 @@ object Parceler3 : Parceler<String> {
 @TypeParceler<String, Parceler2>
 data class Test(
         val a: String,
-        @TypeParceler<String, Parceler1> val b: String,
+        @<!REDUNDANT_TYPE_PARCELER!>TypeParceler<!><String, Parceler1> val b: String,
         @TypeParceler<String, Parceler3> val c: CharSequence,
         val d: @WriteWith<Parceler3> String
 ) : Parcelable

--- a/plugins/parcelize/parcelize-compiler/testData/box/exceptions.kt
+++ b/plugins/parcelize/parcelize-compiler/testData/box/exceptions.kt
@@ -21,5 +21,5 @@ fun box() = parcelTest { parcel ->
     parcel.unmarshall(bytes, 0, bytes.size)
     parcel.setDataPosition(0)
 
-    val test2 = parcelableCreator<ExceptionContainer>().createFromParcel(parcel)
+    parcelableCreator<ExceptionContainer>().createFromParcel(parcel)
 }

--- a/plugins/parcelize/parcelize-compiler/testData/box/functions.kt
+++ b/plugins/parcelize/parcelize-compiler/testData/box/functions.kt
@@ -18,7 +18,7 @@ fun box() = parcelTest { parcel ->
     parcel.unmarshall(bytes, 0, bytes.size)
     parcel.setDataPosition(0)
 
-    val test2 = parcelableCreator<Test>().createFromParcel(parcel)
+    parcelableCreator<Test>().createFromParcel(parcel)
 
     assert(test.callback() == 1)
 }

--- a/plugins/parcelize/parcelize-compiler/testData/box/kt19747Deprecated.kt
+++ b/plugins/parcelize/parcelize-compiler/testData/box/kt19747Deprecated.kt
@@ -12,6 +12,7 @@ class JHelp(var j1: String) {
     val j2 = 9
 }
 
+@Suppress("DEPRECATED_ANNOTATION")
 @Parcelize
 class J(val j: @RawValue JHelp) : Parcelable
 

--- a/plugins/parcelize/parcelize-compiler/testData/box/kt20717.kt
+++ b/plugins/parcelize/parcelize-compiler/testData/box/kt20717.kt
@@ -16,6 +16,7 @@ fun doTest(work: (Parcelable.Creator<DummyParcelable>) -> Unit): String {
 
     val clazz = dummy.javaClass
     val field = clazz.getDeclaredField("CREATOR")
+    @Suppress("UNCHECKED_CAST")
     val creator = field.get(dummy) as Parcelable.Creator<DummyParcelable>
 
     val parcel = Parcel.obtain()

--- a/plugins/parcelize/parcelize-compiler/testData/box/kt25839.kt
+++ b/plugins/parcelize/parcelize-compiler/testData/box/kt25839.kt
@@ -11,7 +11,7 @@ import android.os.Parcelable
 class User : Parcelable
 
 @Parcelize
-class User2() : Parcelable
+class <!PARCELABLE_PRIMARY_CONSTRUCTOR_IS_EMPTY!>User2<!>() : Parcelable
 
 fun box() = parcelTest { parcel ->
     val user = User()

--- a/plugins/parcelize/parcelize-compiler/testData/box/kt39981.kt
+++ b/plugins/parcelize/parcelize-compiler/testData/box/kt39981.kt
@@ -16,6 +16,6 @@ import android.os.Parcelable
     }
 }
 
-fun box() = parcelTest { parcel ->
+fun box() = parcelTest {
     TestParcel()
 }

--- a/plugins/parcelize/parcelize-compiler/testData/box/listKinds.kt
+++ b/plugins/parcelize/parcelize-compiler/testData/box/listKinds.kt
@@ -50,6 +50,4 @@ fun box() = parcelTest { parcel ->
     assert(first == first2)
     assert((first.d as LinkedList<*>).size == 1)
     assert((first2.h as HashSet<*>).size == 1)
-    assert(first2.j is NavigableSet<*>)
-    assert(first2.k is SortedSet<*>)
 }

--- a/plugins/parcelize/parcelize-compiler/testData/box/mapKinds.kt
+++ b/plugins/parcelize/parcelize-compiler/testData/box/mapKinds.kt
@@ -42,6 +42,4 @@ fun box() = parcelTest { parcel ->
     assert(first == first2)
     assert((first.c as HashMap<*, *>).size == 1)
     assert((first2.e as TreeMap<*, *>).size == 1)
-    assert(first2.f is SortedMap<*, *>)
-    assert(first2.g is NavigableMap<*, *>)
 }

--- a/plugins/parcelize/parcelize-compiler/testData/box/simpleDeprecated.kt
+++ b/plugins/parcelize/parcelize-compiler/testData/box/simpleDeprecated.kt
@@ -9,6 +9,7 @@ import android.os.Parcelable
 
 annotation class SerializableLike
 
+@Suppress("DEPRECATED_ANNOTATION")
 @Parcelize @SerializableLike
 data class User(val firstName: String, val secondName: String, val age: Int) : Parcelable
 
@@ -20,6 +21,7 @@ fun box() = parcelTest { parcel ->
     parcel.unmarshall(bytes, 0, bytes.size)
     parcel.setDataPosition(0)
 
+    @Suppress("UNCHECKED_CAST")
     val creator = User::class.java.getDeclaredField("CREATOR").get(null) as Parcelable.Creator<User>
     val user2 = creator.createFromParcel(parcel)
     assert(user == user2)

--- a/plugins/parcelize/parcelize-compiler/testData/box/unsignedArrays.kt
+++ b/plugins/parcelize/parcelize-compiler/testData/box/unsignedArrays.kt
@@ -1,3 +1,4 @@
+// !OPT_IN: kotlin.ExperimentalUnsignedTypes
 // WITH_RUNTIME
 // IGNORE_BACKEND: JVM
 

--- a/plugins/parcelize/parcelize-compiler/tests/org/jetbrains/kotlin/parcelize/test/runners/AbstractParcelizeBoxTest.kt
+++ b/plugins/parcelize/parcelize-compiler/tests/org/jetbrains/kotlin/parcelize/test/runners/AbstractParcelizeBoxTest.kt
@@ -46,7 +46,6 @@ abstract class AbstractParcelizeBoxTestBase<R : ResultingArtifact.FrontendOutput
 
     override fun TestConfigurationBuilder.configuration() {
         defaultDirectives {
-            DIAGNOSTICS with "-warnings"
             +REQUIRES_SEPARATE_PROCESS
             +REPORT_ONLY_EXPLICITLY_DEFINED_DEBUG_INFO
         }


### PR DESCRIPTION
This is useful, since the Parcelize diagnostics are currently only tested in the [intellij-community repository](https://github.com/JetBrains/intellij-community/tree/master/plugins/kotlin/compiler-plugins/parcelize/tests). In the long run we may also want to migrate the Parcelize checker tests to the Kotlin repository.