### PR TITLE
kotlinx-metadata: Fix parsing of inlineClassUnderlyingType

### DIFF
--- a/libraries/kotlinx-metadata/jvm/test/kotlinx/metadata/test/MetadataSmokeTest.kt
+++ b/libraries/kotlinx-metadata/jvm/test/kotlinx/metadata/test/MetadataSmokeTest.kt
@@ -9,12 +9,11 @@ import kotlinx.metadata.*
 import kotlinx.metadata.jvm.*
 import org.jetbrains.org.objectweb.asm.ClassWriter
 import org.jetbrains.org.objectweb.asm.Opcodes
-import org.junit.Assert.*
 import org.junit.Test
 import java.net.URLClassLoader
 import kotlin.coroutines.CoroutineContext
 import kotlin.reflect.full.primaryConstructor
-import kotlin.test.assertFailsWith
+import kotlin.test.*
 
 class MetadataSmokeTest {
     private fun Class<*>.readMetadata(): KotlinClassHeader {

--- a/libraries/kotlinx-metadata/src/kotlinx/metadata/impl/readers.kt
+++ b/libraries/kotlinx-metadata/src/kotlinx/metadata/impl/readers.kt
@@ -97,7 +97,7 @@ fun ProtoBuf.Class.accept(
         v.visitInlineClassUnderlyingPropertyName(c[inlineClassUnderlyingPropertyName])
     }
     loadInlineClassUnderlyingType(c)?.let { underlyingType ->
-        v.visitInlineClassUnderlyingType(underlyingType.flags)?.let { underlyingType.accept(it, c) }
+        v.visitInlineClassUnderlyingType(underlyingType.typeFlags)?.let { underlyingType.accept(it, c) }
     }
 
     for (versionRequirement in versionRequirementList) {

--- a/libraries/tools/kotlinp/testData/ValueClass.kt
+++ b/libraries/tools/kotlinp/testData/ValueClass.kt
@@ -1,2 +1,8 @@
 @JvmInline
+value class A(private val i: Int?)
+
+@JvmInline
+value class B(private val f: suspend () -> Unit)
+
+@JvmInline
 value class Z(val s: String)

--- a/libraries/tools/kotlinp/testData/ValueClass.txt
+++ b/libraries/tools/kotlinp/testData/ValueClass.txt
@@ -1,3 +1,61 @@
+// A.class
+// ------------------------------------------
+// requires language version 1.3.0 (level=ERROR)
+public final value class A : kotlin/Any {
+
+  // requires language version 1.3.0 (level=ERROR)
+  // signature: constructor-impl(Ljava/lang/Integer;)Ljava/lang/Integer;
+  public constructor(i: kotlin/Int?)
+
+  // signature: equals-impl(Ljava/lang/Integer;Ljava/lang/Object;)Z
+  public open /* synthesized */ operator fun equals(other: kotlin/Any?): kotlin/Boolean
+
+  // signature: hashCode-impl(Ljava/lang/Integer;)I
+  public open /* synthesized */ fun hashCode(): kotlin/Int
+
+  // signature: toString-impl(Ljava/lang/Integer;)Ljava/lang/String;
+  public open /* synthesized */ fun toString(): kotlin/String
+
+  // field: i:Ljava/lang/Integer;
+  private final val i: kotlin/Int?
+    private final get
+
+  // underlying property: i
+
+  // underlying type: kotlin/Int?
+
+  // module name: test-module
+}
+// B.class
+// ------------------------------------------
+// requires language version 1.3.0 (level=ERROR)
+public final value class B : kotlin/Any {
+
+  // requires language version 1.3.0 (level=ERROR)
+  // requires language version 1.3.0 (level=ERROR)
+  // signature: constructor-impl(Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function1;
+  public constructor(f: suspend kotlin/Function1<kotlin/coroutines/Continuation<kotlin/Unit>, kotlin/Any?>)
+
+  // signature: equals-impl(Lkotlin/jvm/functions/Function1;Ljava/lang/Object;)Z
+  public open /* synthesized */ operator fun equals(other: kotlin/Any?): kotlin/Boolean
+
+  // signature: hashCode-impl(Lkotlin/jvm/functions/Function1;)I
+  public open /* synthesized */ fun hashCode(): kotlin/Int
+
+  // signature: toString-impl(Lkotlin/jvm/functions/Function1;)Ljava/lang/String;
+  public open /* synthesized */ fun toString(): kotlin/String
+
+  // requires language version 1.3.0 (level=ERROR)
+  // field: f:Lkotlin/jvm/functions/Function1;
+  private final val f: suspend kotlin/Function1<kotlin/coroutines/Continuation<kotlin/Unit>, kotlin/Any?>
+    private final get
+
+  // underlying property: f
+
+  // underlying type: suspend kotlin/Function1<kotlin/coroutines/Continuation<kotlin/Unit>, kotlin/Any?>
+
+  // module name: test-module
+}
 // Z.class
 // ------------------------------------------
 // requires language version 1.3.0 (level=ERROR)


### PR DESCRIPTION
There are two problems with how `kotlinx-metadata` handles inline class representations.

First, there is a bug, where the flags of the underlying type are incorrect. The code uses `type.flags` instead of `type.typeFlags`, which seems a bit error prone. :-|

Second, the class reader would always visits the `inlineClassUnderlyingType` field, even if it wasn't present in the metadata. This was clearly intentional, but I think it's problematic, since there is now no way to tell whether the metadata contained this field to begin with. Just copying metadata using `kotlinx-metadata` would quietly add the field to the result.

I can think of two alternatives here if we want to keep the current behavior. First we could visit the underlying type field with an additional `isDefault` flag. That's not binary compatible, but would make it easy to adapt existing code that was written to assume that the underlying type is always available. Alternatively, the class writer could be made to omit the underlying type field if we notice that the underlying property is public, same as what the compiler does.

Honestly, both alternatives seem unnecessarily complicated. It's probably for the best to minimize the differences between the model in `kotlinx-metadata` and the underlying metadata format and just not visit the underlying type field if it's not present. That's what the PR does.