### PR TITLE
Introduce missing compareByDescending with varargs selectors

### DIFF
--- a/libraries/stdlib/samples/test/samples/comparisons/comparisons.kt
+++ b/libraries/stdlib/samples/test/samples/comparisons/comparisons.kt
@@ -85,6 +85,18 @@ class Comparisons {
     }
 
     @Sample
+    fun compareByDescendingWithSelectors() {
+        val list = listOf("aa", "b", "bb", "a")
+
+        val sorted = list.sortedWith(compareByDescending(
+            { it.length },
+            { it }
+        ))
+
+        assertPrints(sorted, "[bb, aa, b, a]")
+    }
+
+    @Sample
     fun compareByWithComparator() {
         val list = listOf('B', 'a', 'A', 'b')
 

--- a/libraries/stdlib/src/kotlin/comparisons/Comparisons.kt
+++ b/libraries/stdlib/src/kotlin/comparisons/Comparisons.kt
@@ -91,6 +91,18 @@ public fun <T> compareBy(vararg selectors: (T) -> Comparable<*>?): Comparator<T>
     return Comparator { a, b -> compareValuesByImpl(a, b, selectors) }
 }
 
+/**
+ * Creates a descending comparator using the sequence of functions to calculate a result of comparison.
+ * The functions are called sequentially, receive the given values `a` and `b` and return [Comparable]
+ * objects. As soon as the [Comparable] instances returned by a function for `a` and `b` values do not
+ * compare as equal, the result of that comparison is returned from the [Comparator].
+ *
+ * @sample samples.comparisons.Comparisons.compareByWithSelectors
+ */
+public fun <T> compareByDescending(vararg selectors: (T) -> Comparable<*>?): Comparator<T> {
+    require(selectors.size > 0)
+    return Comparator { a, b -> compareValuesByImpl(b, a, selectors) }
+}
 
 /**
  * Creates a comparator using the function to transform value to a [Comparable] instance for comparison.

--- a/libraries/stdlib/test/comparisons/OrderingTest.kt
+++ b/libraries/stdlib/test/comparisons/OrderingTest.kt
@@ -138,6 +138,16 @@ class OrderingTest {
     }
 
     @Test
+    fun sortUsingFunctionalDescendingComparator() {
+        val comparator = compareByDescending<Item>({ it.name }, { it.rating })
+        val diff = comparator.compare(v1, v2)
+        assertTrue(diff < 0)
+        val items = arrayListOf(v1, v2).sortedWith(comparator)
+        assertEquals(v2, items[1])
+        assertEquals(v1, items[0])
+    }
+
+    @Test
     fun sortUsingCustomComparator() {
         val comparator = object : Comparator<Item> {
             override fun compare(a: Item, b: Item): Int {


### PR DESCRIPTION
This is a shorter version of sorting elements in descending order.
It is a pretty common task to sort elements in descending order by multiple fields.
For example: building a top list.

```kotlin
fun main() {
    data class User(val achievements: Int, val stars: Int)
    val topUsers = listOf<User>()
    topUsers.sortedWith(compareBy(User::achievements, User::stars)) // exists for ascending sort
    topUsers.sortedWith(compareByDescending(User::achievements, User::stars)) // but missing for descending one
    topUsers.sortedWith(compareByDescending(User::achievements).thenByDescending(User::stars)) // the only option
}
```