### PR TITLE
Add readable toString for JvmTarget

### DIFF
--- a/compiler/config.jvm/src/org/jetbrains/kotlin/config/JvmTarget.kt
+++ b/compiler/config.jvm/src/org/jetbrains/kotlin/config/JvmTarget.kt
@@ -36,6 +36,8 @@ enum class JvmTarget(
     JVM_17("17", Opcodes.V12 + 5),
     ;
 
+    override fun toString() = description
+
     companion object {
         @JvmField
         val DEFAULT = JVM_1_8


### PR DESCRIPTION
In the detekt project we show valid values for various Kotlin compiler flags on the detekt CLI. The CLI library we're using uses `toString` to enumerate values for enums and display when run with the `--help` flag.

There's a `toString` override on `LanguageVersion` which allows us to display all values that can be parsed successfully with `LanguageVersion.fromVersionString(...)`, so it would be great to have the same for `JvmTarget`, which would allow us to show all valid values that can be parsed by `JvmTarget.fromString(...)`.