### PR TITLE
Fix 64bit atomics on arm32

### DIFF
--- a/kotlin-native/konan/konan.properties
+++ b/kotlin-native/konan/konan.properties
@@ -770,7 +770,7 @@ clangNooptFlags.android_arm32 = -O1
 targetSysRoot.android_arm32 = target-sysroot-1-android_ndk
 linkerKonanFlags.android_arm32 = -lm -lc++_static -lc++abi -landroid -llog -latomic
 runtimeDefinitions.android_arm32 = __ANDROID__ USE_GCC_UNWIND=1 USE_ELF_SYMBOLS=1 ELFSIZE=32 \
-  KONAN_ANDROID=1 KONAN_ARM32=1 KONAN_NO_UNALIGNED_ACCESS=1
+  KONAN_ANDROID=1 KONAN_ARM32=1 KONAN_NO_UNALIGNED_ACCESS=1 KONAN_NO_64BIT_ATOMIC=1
 
 # Android ARM64, based on NDK.
 targetToolchain.macos_x64-android_arm64 = target-toolchain-2-osx-android_ndk


### PR DESCRIPTION
- Fixes https://youtrack.jetbrains.com/issue/KT-49348 : one of the ops in Atomic.cpp (Kotlin_AtomicLong_addAndGet) was not guarded by the `KONAN_NO_64BIT_ATOMIC` flag, causing issues when using atomic long on 32bit cpu
- Fixes https://youtrack.jetbrains.com/issue/KT-49347 : the `KONAN_NO_64BIT_ATOMIC` flag was added to all arm devices in https://github.com/JetBrains/kotlin-native/pull/2647/files but not android_arm32. 