### PR TITLE
KT-20357: Add samples for Result

### DIFF
--- a/libraries/stdlib/samples/test/samples/misc/result.kt
+++ b/libraries/stdlib/samples/test/samples/misc/result.kt
@@ -1,0 +1,240 @@
+package samples.misc
+
+import samples.*
+import kotlin.test.*
+
+class Result {
+
+    @Sample
+    fun runCatching() {
+        // Failure
+        val resultLong = runCatching { "N".toLong() }
+        assertTrue(resultLong.isFailure)
+
+        // Success
+        val resultChar = runCatching { "11".first() }
+        assertTrue(resultChar.isSuccess)
+    }
+
+    @Sample
+    fun runCatchingWithReceiver() {
+        // Failure
+        val resultLong = "N".runCatching { toLong() }
+        assertTrue(resultLong.isFailure)
+
+        // Success
+        val resultChar = "11".runCatching { first() }
+        assertTrue(resultChar.isSuccess)
+    }
+
+    @Sample
+    fun getOrThrow() {
+        // Failure
+        val resultLong = runCatching { "N".toLong() }
+        assertFailsWith<NumberFormatException> { resultLong.getOrThrow() }
+
+        // Success
+        val resultChar = runCatching { "11".first() }
+        assertPrints(resultChar.getOrThrow(), "1")
+    }
+
+    @Sample
+    fun getOrElse() {
+        // Failure
+        val resultLong = runCatching { "N".toLong() }
+        val resultLongOrZero = resultLong.getOrElse { exception ->
+            println(exception.message)
+            0
+        }
+
+        assertPrints(resultLongOrZero, "0")
+
+        // IllegalArgumentException thrown by onFailure function is rethrown
+        val resultInt = runCatching { "N".toInt() }
+        assertFailsWith<IllegalArgumentException> {
+            resultInt.getOrElse { throw IllegalArgumentException() }
+        }
+
+        // Success
+        val resultChar = runCatching { "11".first() }
+        assertPrints(resultChar.getOrElse { throw IllegalArgumentException() }, "1")
+    }
+
+    @Sample
+    fun getOrDefault() {
+        // Failure
+        val resultLong = runCatching { "N".toLong() }
+        assertPrints(resultLong.getOrDefault(0), "0")
+
+        // Success
+        val resultChar = runCatching { "11".first() }
+        assertPrints(resultChar.getOrDefault('0'), "1")
+    }
+
+    @Sample
+    fun fold() {
+        // Failure
+        val resultLong = runCatching { "N".toLong() }
+        val foldLong = resultLong.fold(
+            { value ->
+                println(value)
+                value
+            },
+            { exception ->
+                println(exception.message)
+                0
+            }
+        )
+
+        assertPrints(foldLong, 0)
+
+        // Success
+        val resultChar = runCatching { "11".first() }
+        val foldChar = resultChar.fold(
+            { value ->
+                assertPrints(value, "1")
+                value
+            },
+            { exception ->
+                println(exception)
+                '0'
+            }
+        )
+
+        assertPrints(foldChar, "1")
+    }
+
+    @Sample
+    fun map() {
+        // Failure
+        val resultLong = runCatching { "N".toLong() }
+        val mapLong = resultLong.map { it.inc() }
+        assertPrints(mapLong.getOrNull(), "null")
+
+        // Success
+        val resultChar = runCatching { "11".first() }
+        val mapChar = resultChar.map { it.inc() }
+        assertPrints(mapChar.getOrNull(), "2")
+
+        // IllegalArgumentException thrown by transform function is rethrown
+        val resultThrowable = runCatching { "11".first() }
+        assertFailsWith<IllegalArgumentException> {
+            resultThrowable.map { throw IllegalArgumentException() }
+        }
+    }
+
+    @Sample
+    fun mapCatching() {
+        // Failure
+        val resultLong = runCatching { "N".toLong() }
+        val mapLong = resultLong.mapCatching { it.inc() }
+        assertPrints(mapLong.getOrNull(), "null")
+
+        // Success
+        val resultChar = runCatching { "11".first() }
+        val mapChar = resultChar.mapCatching { it.inc() }
+        assertPrints(mapChar.getOrNull(), "2")
+
+        // IllegalArgumentException thrown by transform function is catched
+        val resultThrowable = runCatching { "11".first() }
+        val mapThrowable = resultThrowable.mapCatching {
+            throw IllegalArgumentException()
+        }
+
+        assertPrints(mapThrowable.getOrNull(), "null")
+    }
+
+    @Sample
+    fun recover() {
+        // Failure
+        val resultLong = runCatching { "N".toLong() }
+        val recoverLong = resultLong.recover { exception ->
+            println(exception.message)
+            0
+        }
+
+        assertPrints(recoverLong.getOrNull(), "0")
+
+        // Success
+        val resultChar = runCatching { "11".first() }
+        val recoverChar = resultChar.recover { exception ->
+            println(exception.message)
+            '0'
+        }
+
+        assertPrints(recoverChar.getOrNull(), "1")
+
+        // IllegalArgumentException thrown by transform function is rethrown
+        val resultThrowable = runCatching { "N".toLong() }
+        assertFailsWith<IllegalArgumentException> {
+            resultThrowable.recover { throw IllegalArgumentException() }
+        }
+    }
+
+    @Sample
+    fun recoverCatching() {
+        // Failure
+        val resultLong = runCatching { "N".toLong() }
+        val recoverLong = resultLong.recoverCatching { exception ->
+            println(exception.message)
+            0
+        }
+
+        assertPrints(recoverLong.getOrNull(), "0")
+
+        // Success
+        val resultChar = runCatching { "11".first() }
+        val recoverChar = resultChar.recoverCatching { exception ->
+            println(exception.message)
+            '0'
+        }
+
+        assertPrints(recoverChar.getOrNull(), "1")
+
+        // IllegalArgumentException thrown by transform function is catched
+        val resultThrowable = runCatching { "N".toLong() }
+        val recoverThrowable = resultThrowable.recoverCatching {
+            throw IllegalArgumentException()
+        }
+
+        assertTrue(resultThrowable.isFailure)
+    }
+
+    @Sample
+    fun onFailure() {
+        // Failure
+        val resultLong = runCatching { "N".toLong() }
+        val originalResultLong = resultLong.onFailure {
+            assertPrints(it, "java.lang.NumberFormatException: For input string: \"N\"")
+        }
+
+        assertTrue(originalResultLong.isFailure)
+
+        // Success
+        val resultChar = runCatching { "11".first() }
+        val originalResultChar = resultChar.onFailure {
+            println(it.message)
+        }
+
+        assertTrue(originalResultChar.isSuccess)
+    }
+
+    @Sample
+    fun onSuccess() {
+        // Failure
+        val resultLong = runCatching { "N".toLong() }
+        val originalResultLong = resultLong.onSuccess {
+            println(it.inc())
+        }
+
+        assertTrue(originalResultLong.isFailure)
+
+        // Success
+        val resultChar = runCatching { "11".first() }
+        val originalResultChar = resultChar.onSuccess {
+            assertPrints(it.inc(), "2")
+        }
+
+        assertTrue(originalResultChar.isSuccess)
+    }
+}

--- a/libraries/stdlib/src/kotlin/util/Result.kt
+++ b/libraries/stdlib/src/kotlin/util/Result.kt
@@ -135,6 +135,8 @@ internal fun Result<*>.throwOnFailure() {
 /**
  * Calls the specified function [block] and returns its encapsulated result if invocation was successful,
  * catching any [Throwable] exception that was thrown from the [block] function execution and encapsulating it as a failure.
+ *
+ * @sample samples.misc.result.Result.runCatching
  */
 @InlineOnly
 @SinceKotlin("1.3")
@@ -149,6 +151,8 @@ public inline fun <R> runCatching(block: () -> R): Result<R> {
 /**
  * Calls the specified function [block] with `this` value as its receiver and returns its encapsulated result if invocation was successful,
  * catching any [Throwable] exception that was thrown from the [block] function execution and encapsulating it as a failure.
+ *
+ * @sample samples.misc.result.Result.runCatchingWithReceiver
  */
 @InlineOnly
 @SinceKotlin("1.3")
@@ -167,6 +171,8 @@ public inline fun <T, R> T.runCatching(block: T.() -> R): Result<R> {
  * if it is [failure][Result.isFailure].
  *
  * This function is a shorthand for `getOrElse { throw it }` (see [getOrElse]).
+ *
+ * @sample samples.misc.result.Result.getOrThrow
  */
 @InlineOnly
 @SinceKotlin("1.3")
@@ -182,6 +188,8 @@ public inline fun <T> Result<T>.getOrThrow(): T {
  * Note, that this function rethrows any [Throwable] exception thrown by [onFailure] function.
  *
  * This function is a shorthand for `fold(onSuccess = { it }, onFailure = onFailure)` (see [fold]).
+ *
+ * @sample samples.misc.result.Result.getOrElse
  */
 @InlineOnly
 @SinceKotlin("1.3")
@@ -200,6 +208,8 @@ public inline fun <R, T : R> Result<T>.getOrElse(onFailure: (exception: Throwabl
  * [defaultValue] if it is [failure][Result.isFailure].
  *
  * This function is a shorthand for `getOrElse { defaultValue }` (see [getOrElse]).
+ *
+ * @sample samples.misc.result.Result.getOrDefault
  */
 @InlineOnly
 @SinceKotlin("1.3")
@@ -213,6 +223,8 @@ public inline fun <R, T : R> Result<T>.getOrDefault(defaultValue: R): R {
  * or the result of [onFailure] function for the encapsulated [Throwable] exception if it is [failure][Result.isFailure].
  *
  * Note, that this function rethrows any [Throwable] exception thrown by [onSuccess] or by [onFailure] function.
+ *
+ * @sample samples.misc.result.Result.fold
  */
 @InlineOnly
 @SinceKotlin("1.3")
@@ -239,6 +251,8 @@ public inline fun <R, T> Result<T>.fold(
  *
  * Note, that this function rethrows any [Throwable] exception thrown by [transform] function.
  * See [mapCatching] for an alternative that encapsulates exceptions.
+ *
+ * @sample samples.misc.result.Result.map
  */
 @InlineOnly
 @SinceKotlin("1.3")
@@ -259,6 +273,8 @@ public inline fun <R, T> Result<T>.map(transform: (value: T) -> R): Result<R> {
  *
  * This function catches any [Throwable] exception thrown by [transform] function and encapsulates it as a failure.
  * See [map] for an alternative that rethrows exceptions from `transform` function.
+ *
+ * @sample samples.misc.result.Result.mapCatching
  */
 @InlineOnly
 @SinceKotlin("1.3")
@@ -276,6 +292,8 @@ public inline fun <R, T> Result<T>.mapCatching(transform: (value: T) -> R): Resu
  *
  * Note, that this function rethrows any [Throwable] exception thrown by [transform] function.
  * See [recoverCatching] for an alternative that encapsulates exceptions.
+ *
+ * @sample samples.misc.result.Result.recover
  */
 @InlineOnly
 @SinceKotlin("1.3")
@@ -296,6 +314,8 @@ public inline fun <R, T : R> Result<T>.recover(transform: (exception: Throwable)
  *
  * This function catches any [Throwable] exception thrown by [transform] function and encapsulates it as a failure.
  * See [recover] for an alternative that rethrows exceptions.
+ *
+ * @sample samples.misc.result.Result.recoverCatching
  */
 @InlineOnly
 @SinceKotlin("1.3")
@@ -311,6 +331,8 @@ public inline fun <R, T : R> Result<T>.recoverCatching(transform: (exception: Th
 /**
  * Performs the given [action] on the encapsulated [Throwable] exception if this instance represents [failure][Result.isFailure].
  * Returns the original `Result` unchanged.
+ *
+ * @sample samples.misc.result.Result.onFailure
  */
 @InlineOnly
 @SinceKotlin("1.3")
@@ -325,6 +347,8 @@ public inline fun <T> Result<T>.onFailure(action: (exception: Throwable) -> Unit
 /**
  * Performs the given [action] on the encapsulated value if this instance represents [success][Result.isSuccess].
  * Returns the original `Result` unchanged.
+ *
+ * @sample samples.misc.result.Result.onSuccess
  */
 @InlineOnly
 @SinceKotlin("1.3")


### PR DESCRIPTION
This PR adds samples for the `Result` functions.
Issue: https://youtrack.jetbrains.com/issue/KT-20357