### PR TITLE
Kotlin Gradle Plugin integration tests - ensure Android sdk...

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinGradlePluginIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinGradlePluginIT.kt
@@ -1172,7 +1172,7 @@ class KotlinGradleIT : BaseGradleIT() {
             ":lib1:compileDebugUnitTestKotlin",
             options = defaultBuildOptions().copy(
                 androidGradlePluginVersion = AGPVersion.v4_2_0,
-                androidHome = KtTestUtil.findAndroidSdk(),
+                androidHome = KtTestUtil.findAndroidSdk().also { acceptAndroidSdkLicenses(it) },
             ),
         ) {
             assertSuccessful()


### PR DESCRIPTION
... licenses are accepted before running the test build.