### PR TITLE
KGP - Fix flaky tests invoking javac through JDK APIs

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/incremental/ClasspathAnalyzer.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/incremental/ClasspathAnalyzer.kt
@@ -54,7 +54,7 @@ abstract class StructureTransformLegacyAction : TransformAction<TransformParamet
     }
 }
 
-private fun transform(input: File, outputs: TransformOutputs) {
+internal fun transform(input: File, outputs: TransformOutputs) {
     val data = if (input.isDirectory) {
         visitDirectory(input)
     } else {


### PR DESCRIPTION
Tests invoking javac APIs were flaky because ClasspathAnalyzerTest
was using Gradle's ProjectBuilder, which appends tools.jar to
the system class loader. Other tests do not do that, and they
invoke javac APIs directly.

In some executions, this causes some javac classes to be loaded
from the system class loader (the one patched by Gradle), while
some of them will be loaded by UrlClassLoader which points to tools.jar
in java.home. Having javac classes from different class loaders causes
java.lang.IllegalAccessError as package private access across class loaders
is not allowed. https://bugs.openjdk.java.net/browse/JDK-8068152 has more
information on this issue.

This change fixes the issue by fully removing usage of ProjectBuilder.

Test: ClasspathAnalyzerTest