### PR TITLE
Kotlin Gradle plugin - Remove assertions from integration tests

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidDaggerProject/gradle.properties
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidDaggerProject/gradle.properties
@@ -1,2 +1,2 @@
-org.gradle.jvmargs=-ea -XX:MaxPermSize=512m
+org.gradle.jvmargs=-XX:MaxPermSize=512m
 kapt.info.as.warnings=true

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidExtensionsProject/gradle.properties
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidExtensionsProject/gradle.properties
@@ -1,1 +1,1 @@
-org.gradle.jvmargs=-ea -XX:MaxPermSize=512m
+org.gradle.jvmargs=-XX:MaxPermSize=512m

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidExtensionsSpecificFeatures/gradle.properties
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidExtensionsSpecificFeatures/gradle.properties
@@ -1,1 +1,1 @@
-org.gradle.jvmargs=-ea -XX:MaxPermSize=512m
+org.gradle.jvmargs=-XX:MaxPermSize=512m

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidKaptChangingDependencies/gradle.properties
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidKaptChangingDependencies/gradle.properties
@@ -1,1 +1,1 @@
-org.gradle.jvmargs=-ea -XX:MaxPermSize=512m
+org.gradle.jvmargs=-XX:MaxPermSize=512m

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidParcelizeProject/gradle.properties
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidParcelizeProject/gradle.properties
@@ -1,1 +1,1 @@
-org.gradle.jvmargs=-ea -XX:MaxPermSize=512m
+org.gradle.jvmargs=-XX:MaxPermSize=512m


### PR DESCRIPTION
This is because AGP 3.4 and 3.6 have version of R8 that is unable
to handle kotlin-stdlib 1.6+. Issue https://issuetracker.google.com/148661132
has more details on this.

Instead of adding logic to remove assertions based on the AGP version,
this change fully removes them to keep things simple. Also, running with
assertions enabled may be too much for the integration tests.