### PR TITLE
Add specific extension all sample for text

### DIFF
--- a/libraries/stdlib/common/src/generated/_Strings.kt
+++ b/libraries/stdlib/common/src/generated/_Strings.kt
@@ -1053,7 +1053,7 @@ public fun CharSequence.withIndex(): Iterable<IndexedValue<Char>> {
 /**
  * Returns `true` if all characters match the given [predicate].
  * 
- * @sample samples.collections.Collections.Aggregates.all
+ * @sample samples.text.Strings.all
  */
 public inline fun CharSequence.all(predicate: (Char) -> Boolean): Boolean {
     for (element in this) if (!predicate(element)) return false

--- a/libraries/stdlib/samples/test/samples/text/strings.kt
+++ b/libraries/stdlib/samples/test/samples/text/strings.kt
@@ -420,6 +420,14 @@ class Strings {
     }
 
     @Sample
+    fun all() {
+        val string = "Kotlin"
+        assertTrue(string.all { it.isLetter() })
+        assertFalse(string.all { it.isLowerCase() })
+        assertFalse(string.all { it.isDigit() })
+    }
+
+    @Sample
     fun indexOf() {
         fun matchDetails(inputString: String, whatToFind: String, startIndex: Int = 0): String {
             val matchIndex = inputString.indexOf(whatToFind, startIndex)

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Aggregates.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Aggregates.kt
@@ -51,6 +51,10 @@ object Aggregates : TemplateGroupBase() {
             return true
             """
         }
+
+        specialFor(CharSequences) {
+            sample("samples.text.Strings.all")
+        }
     }
 
     val f_none_predicate = fn("none(predicate: (T) -> Boolean)") {


### PR DESCRIPTION
Works towards [KT-35867](https://youtrack.jetbrains.com/issue/KT-35867). 
Makes sample for `CharSequences.all()`