### PR TITLE
[Native] Add -Xoverride-konan-properties to cinterop.

### DIFF
--- a/kotlin-native/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/CommandLine.kt
+++ b/kotlin-native/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/CommandLine.kt
@@ -65,6 +65,10 @@ open class CommonInteropArguments(val argParser: ArgParser) {
             description = "save temporary files to the given directory")
     val kotlincOption by argParser.option(ArgType.String, "Xkotlinc-option",
             description = "additional kotlinc compiler option").multiple()
+    val overrideKonanProperties by argParser.option(ArgType.String,
+            fullName = "Xoverride-konan-properties",
+            description = "Override konan.properties.values"
+        ).multiple().delimiter(";")
 
     companion object {
         val DEFAULT_MODE = GenerationMode.METADATA

--- a/kotlin-native/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/ToolConfig.kt
+++ b/kotlin-native/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/ToolConfig.kt
@@ -22,10 +22,10 @@ import org.jetbrains.kotlin.konan.util.defaultTargetSubstitutions
 import org.jetbrains.kotlin.native.interop.gen.jvm.KotlinPlatform
 import org.jetbrains.kotlin.native.interop.indexer.Language
 
-class ToolConfig(userProvidedTargetName: String?, private val flavor: KotlinPlatform) {
+class ToolConfig(userProvidedTargetName: String?, private val flavor: KotlinPlatform, private val propertyOverrides: Map<String, String>) {
 
     private val konanHome = KonanHomeProvider.determineKonanHome()
-    private val distribution = customerDistribution(konanHome)
+    private val distribution = Distribution(konanHome, propertyOverrides = propertyOverrides)
     private val platformManager = PlatformManager(distribution)
     private val targetManager = platformManager.targetManager(userProvidedTargetName)
     private val host = HostManager.host


### PR DESCRIPTION
This aligns with the flag added to kotlinc in:
https://youtrack.jetbrains.com/issue/KT-40670

Hermetic builds would benefit from being able to override dependency paths or airplaneMode using this mechanism:

```
$ bin/cinterop -Xoverride-konan-properties "apple-llvm-20200714-macos-x64-essentials.default=/tmp/llvm;airplaneMode=true" -def foo.def
```