### PR TITLE
implement KtSymbolWithTypeParameters interface for KtPropertySymbol

### DIFF
--- a/analysis/analysis-api-fe10/src/org/jetbrains/kotlin/analysis/api/descriptors/symbols/descriptorBased/KtFe10DescKotlinPropertySymbol.kt
+++ b/analysis/analysis-api-fe10/src/org/jetbrains/kotlin/analysis/api/descriptors/symbols/descriptorBased/KtFe10DescKotlinPropertySymbol.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.analysis.api.descriptors.symbols.pointers.KtFe10Neve
 import org.jetbrains.kotlin.analysis.api.symbols.KtKotlinPropertySymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KtPropertyGetterSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KtPropertySetterSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KtTypeParameterSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.markers.KtConstantValue
 import org.jetbrains.kotlin.analysis.api.symbols.markers.KtSymbolKind
 import org.jetbrains.kotlin.analysis.api.symbols.markers.KtTypeAndAnnotations
@@ -89,6 +90,9 @@ internal class KtFe10DescKotlinPropertySymbol(
 
     override val receiverType: KtTypeAndAnnotations?
         get() = withValidityAssertion { descriptor.extensionReceiverParameter?.type?.toKtTypeAndAnnotations(analysisContext) }
+
+    override val typeParameters: List<KtTypeParameterSymbol>
+        get() = withValidityAssertion { descriptor.typeParameters.map { it.toKtTypeParameter(analysisContext) } }
 
     override val hasBackingField: Boolean
         get() = withValidityAssertion {

--- a/analysis/analysis-api-fe10/src/org/jetbrains/kotlin/analysis/api/descriptors/symbols/descriptorBased/KtFe10DescSyntheticJavaPropertySymbol.kt
+++ b/analysis/analysis-api-fe10/src/org/jetbrains/kotlin/analysis/api/descriptors/symbols/descriptorBased/KtFe10DescSyntheticJavaPropertySymbol.kt
@@ -8,10 +8,7 @@ package org.jetbrains.kotlin.analysis.api.descriptors.symbols.descriptorBased
 import org.jetbrains.kotlin.analysis.api.descriptors.Fe10AnalysisContext
 import org.jetbrains.kotlin.analysis.api.descriptors.symbols.descriptorBased.base.*
 import org.jetbrains.kotlin.analysis.api.descriptors.symbols.pointers.KtFe10NeverRestoringSymbolPointer
-import org.jetbrains.kotlin.analysis.api.symbols.KtFunctionSymbol
-import org.jetbrains.kotlin.analysis.api.symbols.KtPropertyGetterSymbol
-import org.jetbrains.kotlin.analysis.api.symbols.KtPropertySetterSymbol
-import org.jetbrains.kotlin.analysis.api.symbols.KtSyntheticJavaPropertySymbol
+import org.jetbrains.kotlin.analysis.api.symbols.*
 import org.jetbrains.kotlin.analysis.api.symbols.markers.KtConstantValue
 import org.jetbrains.kotlin.analysis.api.symbols.markers.KtTypeAndAnnotations
 import org.jetbrains.kotlin.analysis.api.symbols.pointers.KtPsiBasedSymbolPointer
@@ -86,6 +83,9 @@ internal class KtFe10DescSyntheticJavaPropertySymbol(
     override val receiverType: KtTypeAndAnnotations?
         get() = withValidityAssertion { descriptor.extensionReceiverParameter?.type?.toKtTypeAndAnnotations(analysisContext) }
 
+
+    override val typeParameters: List<KtTypeParameterSymbol>
+        get() = withValidityAssertion { descriptor.typeParameters.map { it.toKtTypeParameter(analysisContext) } }
 
     override fun createPointer(): KtSymbolPointer<KtSyntheticJavaPropertySymbol> = withValidityAssertion {
         return KtPsiBasedSymbolPointer.createForSymbolFromSource(this) ?: KtFe10NeverRestoringSymbolPointer()

--- a/analysis/analysis-api-fe10/src/org/jetbrains/kotlin/analysis/api/descriptors/symbols/descriptorBased/KtFe10DescSyntheticJavaPropertySymbolForOverride.kt
+++ b/analysis/analysis-api-fe10/src/org/jetbrains/kotlin/analysis/api/descriptors/symbols/descriptorBased/KtFe10DescSyntheticJavaPropertySymbolForOverride.kt
@@ -8,10 +8,7 @@ package org.jetbrains.kotlin.analysis.api.descriptors.symbols.descriptorBased
 import org.jetbrains.kotlin.analysis.api.descriptors.Fe10AnalysisContext
 import org.jetbrains.kotlin.analysis.api.descriptors.symbols.descriptorBased.base.*
 import org.jetbrains.kotlin.analysis.api.descriptors.symbols.pointers.KtFe10NeverRestoringSymbolPointer
-import org.jetbrains.kotlin.analysis.api.symbols.KtFunctionSymbol
-import org.jetbrains.kotlin.analysis.api.symbols.KtPropertyGetterSymbol
-import org.jetbrains.kotlin.analysis.api.symbols.KtPropertySetterSymbol
-import org.jetbrains.kotlin.analysis.api.symbols.KtSyntheticJavaPropertySymbol
+import org.jetbrains.kotlin.analysis.api.symbols.*
 import org.jetbrains.kotlin.analysis.api.symbols.markers.KtConstantValue
 import org.jetbrains.kotlin.analysis.api.symbols.markers.KtTypeAndAnnotations
 import org.jetbrains.kotlin.analysis.api.symbols.pointers.KtPsiBasedSymbolPointer
@@ -85,6 +82,9 @@ internal class KtFe10DescSyntheticJavaPropertySymbolForOverride(
 
     override val receiverType: KtTypeAndAnnotations?
         get() = withValidityAssertion { descriptor.extensionReceiverParameter?.type?.toKtTypeAndAnnotations(analysisContext) }
+
+    override val typeParameters: List<KtTypeParameterSymbol>
+        get() = withValidityAssertion { descriptor.typeParameters.map { it.toKtTypeParameter(analysisContext) } }
 
     override fun createPointer(): KtSymbolPointer<KtSyntheticJavaPropertySymbol> = withValidityAssertion {
         return KtPsiBasedSymbolPointer.createForSymbolFromSource(this) ?: KtFe10NeverRestoringSymbolPointer()

--- a/analysis/analysis-api-fe10/src/org/jetbrains/kotlin/analysis/api/descriptors/symbols/descriptorBased/base/Kt1DescUtils.kt
+++ b/analysis/analysis-api-fe10/src/org/jetbrains/kotlin/analysis/api/descriptors/symbols/descriptorBased/base/Kt1DescUtils.kt
@@ -196,6 +196,10 @@ internal fun TypeProjection.toKtTypeArgument(analysisContext: Fe10AnalysisContex
     }
 }
 
+internal fun TypeParameterDescriptor.toKtTypeParameter(analysisContext: Fe10AnalysisContext): KtTypeParameterSymbol {
+    return KtFe10DescTypeParameterSymbol(this, analysisContext)
+}
+
 internal fun DeclarationDescriptor.getSymbolOrigin(analysisContext: Fe10AnalysisContext): KtSymbolOrigin {
     when (this) {
         is SyntheticJavaPropertyDescriptor -> return KtSymbolOrigin.JAVA_SYNTHETIC_PROPERTY

--- a/analysis/analysis-api-fe10/src/org/jetbrains/kotlin/analysis/api/descriptors/symbols/psiBased/KtFe10PsiKotlinPropertySymbol.kt
+++ b/analysis/analysis-api-fe10/src/org/jetbrains/kotlin/analysis/api/descriptors/symbols/psiBased/KtFe10PsiKotlinPropertySymbol.kt
@@ -17,6 +17,7 @@ import org.jetbrains.kotlin.analysis.api.descriptors.utils.cached
 import org.jetbrains.kotlin.analysis.api.symbols.KtKotlinPropertySymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KtPropertyGetterSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KtPropertySetterSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KtTypeParameterSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.markers.KtConstantValue
 import org.jetbrains.kotlin.analysis.api.symbols.markers.KtSymbolKind
 import org.jetbrains.kotlin.analysis.api.symbols.markers.KtTypeAndAnnotations
@@ -138,6 +139,11 @@ internal class KtFe10PsiKotlinPropertySymbol(
 
     override val name: Name
         get() = withValidityAssertion { psi.nameAsSafeName }
+
+    override val typeParameters: List<KtTypeParameterSymbol>
+        get() = withValidityAssertion {
+            psi.typeParameters.map { KtFe10PsiTypeParameterSymbol(it, analysisContext) }
+        }
 
     override val modality: Modality
         get() = withValidityAssertion { psi.ktModality ?: descriptor?.ktModality ?: Modality.FINAL }

--- a/analysis/analysis-api-fir/src/org/jetbrains/kotlin/analysis/api/fir/symbols/KtFirKotlinPropertySymbol.kt
+++ b/analysis/analysis-api-fir/src/org/jetbrains/kotlin/analysis/api/fir/symbols/KtFirKotlinPropertySymbol.kt
@@ -20,6 +20,7 @@ import org.jetbrains.kotlin.analysis.api.fir.utils.firRef
 import org.jetbrains.kotlin.analysis.api.symbols.KtKotlinPropertySymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KtPropertyGetterSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KtPropertySetterSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KtTypeParameterSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.markers.KtAnnotationCall
 import org.jetbrains.kotlin.analysis.api.symbols.markers.KtConstantValue
 import org.jetbrains.kotlin.analysis.api.symbols.markers.KtSymbolKind
@@ -60,6 +61,10 @@ internal class KtFirKotlinPropertySymbol(
 
     override val annotatedType: KtTypeAndAnnotations by cached {
         firRef.returnTypeAndAnnotations(FirResolvePhase.IMPLICIT_TYPES_BODY_RESOLVE, builder)
+    }
+
+    override val typeParameters: List<KtTypeParameterSymbol> by cached {
+        fir.typeParameters.map { builder.classifierBuilder.buildTypeParameterSymbol(it) }
     }
 
     override val receiverType: KtTypeAndAnnotations? by cached {

--- a/analysis/analysis-api-fir/src/org/jetbrains/kotlin/analysis/api/fir/symbols/KtFirSyntheticJavaPropertySymbol.kt
+++ b/analysis/analysis-api-fir/src/org/jetbrains/kotlin/analysis/api/fir/symbols/KtFirSyntheticJavaPropertySymbol.kt
@@ -49,6 +49,10 @@ internal class KtFirSyntheticJavaPropertySymbol(
         firRef.returnTypeAndAnnotations(FirResolvePhase.IMPLICIT_TYPES_BODY_RESOLVE, builder)
     }
 
+    override val typeParameters: List<KtTypeParameterSymbol> by cached {
+        fir.typeParameters.map { builder.classifierBuilder.buildTypeParameterSymbol(it) }
+    }
+
     override val receiverType: KtTypeAndAnnotations? by cached {
         firRef.receiverTypeAndAnnotations(builder)
     }

--- a/analysis/analysis-api/src/org/jetbrains/kotlin/analysis/api/symbols/KtVariableLikeSymbol.kt
+++ b/analysis/analysis-api/src/org/jetbrains/kotlin/analysis/api/symbols/KtVariableLikeSymbol.kt
@@ -77,6 +77,7 @@ public abstract class KtJavaFieldSymbol :
 
 public sealed class KtPropertySymbol : KtVariableSymbol(),
     KtPossibleMemberSymbol,
+    KtSymbolWithTypeParameters,
     KtSymbolWithModality,
     KtSymbolWithVisibility,
     KtAnnotatedSymbol,

--- a/analysis/analysis-api/testData/scopes/fileScopeTest/simpleFileScope.txt
+++ b/analysis/analysis-api/testData/scopes/fileScopeTest/simpleFileScope.txt
@@ -57,6 +57,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: null
   symbolKind: TOP_LEVEL
+  typeParameters: []
   visibility: Public
   deprecationStatus: null
   getterDeprecationStatus: null

--- a/analysis/analysis-api/testData/scopes/memberScopeByFqName/MutableList.txt
+++ b/analysis/analysis-api/testData/scopes/memberScopeByFqName/MutableList.txt
@@ -558,6 +558,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: null
   symbolKind: CLASS_MEMBER
+  typeParameters: []
   visibility: Public
   getDispatchReceiver(): kotlin/collections/MutableList<E>
   deprecationStatus: null

--- a/analysis/analysis-api/testData/scopes/memberScopeByFqName/java.lang.String.txt
+++ b/analysis/analysis-api/testData/scopes/memberScopeByFqName/java.lang.String.txt
@@ -89,6 +89,7 @@ KtSyntheticJavaPropertySymbol:
   receiverType: null
   setter: null
   symbolKind: CLASS_MEMBER
+  typeParameters: []
   visibility: Public
   getDispatchReceiver(): java/lang/String
   deprecationStatus: null

--- a/analysis/analysis-api/testData/scopes/memberScopeByFqName/overridenFunctionWithGenericBound.txt
+++ b/analysis/analysis-api/testData/scopes/memberScopeByFqName/overridenFunctionWithGenericBound.txt
@@ -53,6 +53,10 @@ KtKotlinPropertySymbol:
   receiverType: [] test/TwoParams<TT1, TT2>
   setter: null
   symbolKind: CLASS_MEMBER
+  typeParameters: [
+    KtTypeParameterSymbol(TT1)
+    KtTypeParameterSymbol(TT2)
+  ]
   visibility: Public
   getDispatchReceiver(): test/MyClass
   deprecationStatus: null

--- a/analysis/analysis-api/testData/symbols/symbolByPsi/anonymousObject.descriptors.txt
+++ b/analysis/analysis-api/testData/symbols/symbolByPsi/anonymousObject.descriptors.txt
@@ -47,6 +47,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: null
   symbolKind: CLASS_MEMBER
+  typeParameters: []
   visibility: Public
   getDispatchReceiver(): <no name provided>
   deprecationStatus: null
@@ -92,6 +93,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: null
   symbolKind: CLASS_MEMBER
+  typeParameters: []
   visibility: Public
   getDispatchReceiver(): AnonymousContainer
   deprecationStatus: null

--- a/analysis/analysis-api/testData/symbols/symbolByPsi/anonymousObject.txt
+++ b/analysis/analysis-api/testData/symbols/symbolByPsi/anonymousObject.txt
@@ -47,6 +47,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: null
   symbolKind: CLASS_MEMBER
+  typeParameters: []
   visibility: Public
   getDispatchReceiver(): <anonymous>
   deprecationStatus: null
@@ -92,6 +93,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: null
   symbolKind: CLASS_MEMBER
+  typeParameters: []
   visibility: Public
   getDispatchReceiver(): AnonymousContainer
   deprecationStatus: null

--- a/analysis/analysis-api/testData/symbols/symbolByPsi/backingField.txt
+++ b/analysis/analysis-api/testData/symbols/symbolByPsi/backingField.txt
@@ -77,6 +77,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: KtPropertySetterSymbol(<setter>)
   symbolKind: TOP_LEVEL
+  typeParameters: []
   visibility: Public
   deprecationStatus: null
   getterDeprecationStatus: null

--- a/analysis/analysis-api/testData/symbols/symbolByPsi/classInitializer.txt
+++ b/analysis/analysis-api/testData/symbols/symbolByPsi/classInitializer.txt
@@ -22,6 +22,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: null
   symbolKind: CLASS_MEMBER
+  typeParameters: []
   visibility: Public
   getDispatchReceiver(): A
   deprecationStatus: null

--- a/analysis/analysis-api/testData/symbols/symbolByPsi/classMembes.txt
+++ b/analysis/analysis-api/testData/symbols/symbolByPsi/classMembes.txt
@@ -22,6 +22,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: null
   symbolKind: CLASS_MEMBER
+  typeParameters: []
   visibility: Public
   getDispatchReceiver(): A
   deprecationStatus: null

--- a/analysis/analysis-api/testData/symbols/symbolByPsi/delegateField.descriptors.txt
+++ b/analysis/analysis-api/testData/symbols/symbolByPsi/delegateField.descriptors.txt
@@ -118,6 +118,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: null
   symbolKind: CLASS_MEMBER
+  typeParameters: []
   visibility: Public
   getDispatchReceiver(): Some
   deprecationStatus: null
@@ -161,6 +162,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: null
   symbolKind: CLASS_MEMBER
+  typeParameters: []
   visibility: Public
   getDispatchReceiver(): Some
   deprecationStatus: null
@@ -193,6 +195,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: null
   symbolKind: CLASS_MEMBER
+  typeParameters: []
   visibility: Public
   getDispatchReceiver(): Some
   deprecationStatus: null

--- a/analysis/analysis-api/testData/symbols/symbolByPsi/delegateField.txt
+++ b/analysis/analysis-api/testData/symbols/symbolByPsi/delegateField.txt
@@ -118,6 +118,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: null
   symbolKind: CLASS_MEMBER
+  typeParameters: []
   visibility: Public
   getDispatchReceiver(): Some
   deprecationStatus: null
@@ -161,6 +162,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: null
   symbolKind: CLASS_MEMBER
+  typeParameters: []
   visibility: Public
   getDispatchReceiver(): Some
   deprecationStatus: null
@@ -193,6 +195,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: null
   symbolKind: CLASS_MEMBER
+  typeParameters: []
   visibility: Public
   getDispatchReceiver(): Some
   deprecationStatus: null

--- a/analysis/analysis-api/testData/symbols/symbolByPsi/deprecated.descriptors.txt
+++ b/analysis/analysis-api/testData/symbols/symbolByPsi/deprecated.descriptors.txt
@@ -27,6 +27,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: null
   symbolKind: TOP_LEVEL
+  typeParameters: []
   visibility: Public
   deprecationStatus: DeprecationInfo(deprecationLevel=WARNING, propagatesToOverrides=true, message=don't use i)
   getterDeprecationStatus: DeprecationInfo(deprecationLevel=WARNING, propagatesToOverrides=true, message=don't use i)
@@ -58,6 +59,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: null
   symbolKind: TOP_LEVEL
+  typeParameters: []
   visibility: Public
   deprecationStatus: null
   getterDeprecationStatus: DeprecationInfo(deprecationLevel=WARNING, propagatesToOverrides=true, message=don't use getter of i2)
@@ -89,6 +91,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: KtPropertySetterSymbol(<setter>)
   symbolKind: TOP_LEVEL
+  typeParameters: []
   visibility: Public
   deprecationStatus: null
   getterDeprecationStatus: null
@@ -120,6 +123,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: KtPropertySetterSymbol(<setter>)
   symbolKind: TOP_LEVEL
+  typeParameters: []
   visibility: Public
   deprecationStatus: null
   getterDeprecationStatus: DeprecationInfo(deprecationLevel=WARNING, propagatesToOverrides=true, message=don't use getter of i4)
@@ -212,6 +216,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: null
   symbolKind: CLASS_MEMBER
+  typeParameters: []
   visibility: Public
   getDispatchReceiver(): Foo
   deprecationStatus: DeprecationInfo(deprecationLevel=WARNING, propagatesToOverrides=true, message=don't use i2)
@@ -301,6 +306,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: null
   symbolKind: TOP_LEVEL
+  typeParameters: []
   visibility: Public
   deprecationStatus: DeprecationInfo(deprecationLevel=ERROR, propagatesToOverrides=true, message=don't use j)
   getterDeprecationStatus: DeprecationInfo(deprecationLevel=ERROR, propagatesToOverrides=true, message=don't use j)
@@ -337,6 +343,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: null
   symbolKind: TOP_LEVEL
+  typeParameters: []
   visibility: Public
   deprecationStatus: DeprecationInfo(deprecationLevel=HIDDEN, propagatesToOverrides=true, message=don't use j2)
   getterDeprecationStatus: DeprecationInfo(deprecationLevel=HIDDEN, propagatesToOverrides=true, message=don't use j2)
@@ -368,6 +375,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: null
   symbolKind: TOP_LEVEL
+  typeParameters: []
   visibility: Public
   deprecationStatus: DeprecationInfo(deprecationLevel=WARNING, propagatesToOverrides=false, message=null)
   getterDeprecationStatus: DeprecationInfo(deprecationLevel=WARNING, propagatesToOverrides=false, message=null)

--- a/analysis/analysis-api/testData/symbols/symbolByPsi/deprecated.txt
+++ b/analysis/analysis-api/testData/symbols/symbolByPsi/deprecated.txt
@@ -27,6 +27,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: null
   symbolKind: TOP_LEVEL
+  typeParameters: []
   visibility: Public
   deprecationStatus: DeprecationInfo(deprecationLevel=WARNING, propagatesToOverrides=true, message=don't use i)
   getterDeprecationStatus: DeprecationInfo(deprecationLevel=WARNING, propagatesToOverrides=true, message=don't use i)
@@ -58,6 +59,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: null
   symbolKind: TOP_LEVEL
+  typeParameters: []
   visibility: Public
   deprecationStatus: null
   getterDeprecationStatus: DeprecationInfo(deprecationLevel=WARNING, propagatesToOverrides=true, message=don't use getter of i2)
@@ -89,6 +91,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: KtPropertySetterSymbol(<setter>)
   symbolKind: TOP_LEVEL
+  typeParameters: []
   visibility: Public
   deprecationStatus: null
   getterDeprecationStatus: null
@@ -120,6 +123,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: KtPropertySetterSymbol(<setter>)
   symbolKind: TOP_LEVEL
+  typeParameters: []
   visibility: Public
   deprecationStatus: null
   getterDeprecationStatus: DeprecationInfo(deprecationLevel=WARNING, propagatesToOverrides=true, message=don't use getter of i4)
@@ -212,6 +216,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: null
   symbolKind: CLASS_MEMBER
+  typeParameters: []
   visibility: Public
   getDispatchReceiver(): Foo
   deprecationStatus: DeprecationInfo(deprecationLevel=WARNING, propagatesToOverrides=true, message=don't use i2)
@@ -301,6 +306,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: null
   symbolKind: TOP_LEVEL
+  typeParameters: []
   visibility: Public
   deprecationStatus: DeprecationInfo(deprecationLevel=ERROR, propagatesToOverrides=true, message=null)
   getterDeprecationStatus: DeprecationInfo(deprecationLevel=ERROR, propagatesToOverrides=true, message=null)
@@ -337,6 +343,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: null
   symbolKind: TOP_LEVEL
+  typeParameters: []
   visibility: Public
   deprecationStatus: DeprecationInfo(deprecationLevel=HIDDEN, propagatesToOverrides=true, message=null)
   getterDeprecationStatus: DeprecationInfo(deprecationLevel=HIDDEN, propagatesToOverrides=true, message=null)
@@ -373,6 +380,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: null
   symbolKind: TOP_LEVEL
+  typeParameters: []
   visibility: Public
   deprecationStatus: DeprecationInfo(deprecationLevel=WARNING, propagatesToOverrides=false, message=null)
   getterDeprecationStatus: DeprecationInfo(deprecationLevel=WARNING, propagatesToOverrides=false, message=null)

--- a/analysis/analysis-api/testData/symbols/symbolByPsi/enumValueMember.descriptors.txt
+++ b/analysis/analysis-api/testData/symbols/symbolByPsi/enumValueMember.descriptors.txt
@@ -75,6 +75,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: null
   symbolKind: CLASS_MEMBER
+  typeParameters: []
   visibility: Public
   getDispatchReceiver(): Style.SHEET
   deprecationStatus: null
@@ -118,6 +119,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: null
   symbolKind: CLASS_MEMBER
+  typeParameters: []
   visibility: Public
   getDispatchReceiver(): Style
   deprecationStatus: null

--- a/analysis/analysis-api/testData/symbols/symbolByPsi/enumValueMember.txt
+++ b/analysis/analysis-api/testData/symbols/symbolByPsi/enumValueMember.txt
@@ -74,6 +74,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: null
   symbolKind: CLASS_MEMBER
+  typeParameters: []
   visibility: Public
   getDispatchReceiver(): <anonymous>
   deprecationStatus: null
@@ -117,6 +118,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: null
   symbolKind: CLASS_MEMBER
+  typeParameters: []
   visibility: Public
   getDispatchReceiver(): Style
   deprecationStatus: null

--- a/analysis/analysis-api/testData/symbols/symbolByPsi/jvmName.descriptors.txt
+++ b/analysis/analysis-api/testData/symbols/symbolByPsi/jvmName.descriptors.txt
@@ -22,6 +22,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: KtPropertySetterSymbol(<setter>)
   symbolKind: CLASS_MEMBER
+  typeParameters: []
   visibility: Public
   getDispatchReceiver(): Foo
   deprecationStatus: null
@@ -121,6 +122,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: KtPropertySetterSymbol(<setter>)
   symbolKind: CLASS_MEMBER
+  typeParameters: []
   visibility: Public
   getDispatchReceiver(): Foo
   deprecationStatus: null

--- a/analysis/analysis-api/testData/symbols/symbolByPsi/jvmName.txt
+++ b/analysis/analysis-api/testData/symbols/symbolByPsi/jvmName.txt
@@ -22,6 +22,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: KtPropertySetterSymbol(<setter>)
   symbolKind: CLASS_MEMBER
+  typeParameters: []
   visibility: Public
   getDispatchReceiver(): Foo
   deprecationStatus: null
@@ -119,6 +120,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: KtPropertySetterSymbol(<setter>)
   symbolKind: CLASS_MEMBER
+  typeParameters: []
   visibility: Public
   getDispatchReceiver(): Foo
   deprecationStatus: null

--- a/analysis/analysis-api/testData/symbols/symbolByPsi/memberProperties.descriptors.txt
+++ b/analysis/analysis-api/testData/symbols/symbolByPsi/memberProperties.descriptors.txt
@@ -22,6 +22,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: null
   symbolKind: CLASS_MEMBER
+  typeParameters: []
   visibility: Public
   getDispatchReceiver(): A
   deprecationStatus: null
@@ -74,6 +75,7 @@ KtKotlinPropertySymbol:
   receiverType: [] kotlin/Int
   setter: null
   symbolKind: CLASS_MEMBER
+  typeParameters: []
   visibility: Public
   getDispatchReceiver(): A
   deprecationStatus: null

--- a/analysis/analysis-api/testData/symbols/symbolByPsi/memberProperties.txt
+++ b/analysis/analysis-api/testData/symbols/symbolByPsi/memberProperties.txt
@@ -22,6 +22,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: null
   symbolKind: CLASS_MEMBER
+  typeParameters: []
   visibility: Public
   getDispatchReceiver(): A
   deprecationStatus: null
@@ -73,6 +74,7 @@ KtKotlinPropertySymbol:
   receiverType: [] kotlin/Int
   setter: null
   symbolKind: CLASS_MEMBER
+  typeParameters: []
   visibility: Public
   getDispatchReceiver(): A
   deprecationStatus: null

--- a/analysis/analysis-api/testData/symbols/symbolByPsi/topLevelProperties.descriptors.txt
+++ b/analysis/analysis-api/testData/symbols/symbolByPsi/topLevelProperties.descriptors.txt
@@ -22,6 +22,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: null
   symbolKind: TOP_LEVEL
+  typeParameters: []
   visibility: Public
   deprecationStatus: null
   getterDeprecationStatus: null
@@ -72,6 +73,7 @@ KtKotlinPropertySymbol:
   receiverType: [] kotlin/Int
   setter: null
   symbolKind: TOP_LEVEL
+  typeParameters: []
   visibility: Public
   deprecationStatus: null
   getterDeprecationStatus: null

--- a/analysis/analysis-api/testData/symbols/symbolByPsi/topLevelProperties.txt
+++ b/analysis/analysis-api/testData/symbols/symbolByPsi/topLevelProperties.txt
@@ -22,6 +22,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: null
   symbolKind: TOP_LEVEL
+  typeParameters: []
   visibility: Public
   deprecationStatus: null
   getterDeprecationStatus: null
@@ -72,6 +73,7 @@ KtKotlinPropertySymbol:
   receiverType: [] kotlin/Int
   setter: null
   symbolKind: TOP_LEVEL
+  typeParameters: []
   visibility: Public
   deprecationStatus: null
   getterDeprecationStatus: null

--- a/analysis/analysis-api/testData/symbols/symbolByPsi/typeAnnotations.descriptors.txt
+++ b/analysis/analysis-api/testData/symbols/symbolByPsi/typeAnnotations.descriptors.txt
@@ -202,6 +202,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: null
   symbolKind: CLASS_MEMBER
+  typeParameters: []
   visibility: Public
   getDispatchReceiver(): X
   deprecationStatus: null

--- a/analysis/analysis-api/testData/symbols/symbolByPsi/typeAnnotations.txt
+++ b/analysis/analysis-api/testData/symbols/symbolByPsi/typeAnnotations.txt
@@ -202,6 +202,7 @@ KtKotlinPropertySymbol:
   receiverType: null
   setter: null
   symbolKind: CLASS_MEMBER
+  typeParameters: []
   visibility: Public
   getDispatchReceiver(): X
   deprecationStatus: null


### PR DESCRIPTION
was trying to figure out how to add a test case for this change, but noticed that there is a test case covering a property with multiple type parameters, will that be sufficient or should I add more test cases?