### PR TITLE
Kotlin Gradle Plugin - clean caches for in-process compilation

### DIFF
--- a/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment.kt
@@ -573,6 +573,7 @@ class KotlinCoreEnvironment private constructor(
         /**
          * This method is also used in Gradle after configuration phase finished.
          */
+        @JvmStatic
         fun disposeApplicationEnvironment() {
             synchronized(APPLICATION_LOCK) {
                 val environment = ourApplicationEnvironment ?: return

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/compilerRunner/GradleKotlinCompilerWork.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/compilerRunner/GradleKotlinCompilerWork.kt
@@ -366,6 +366,15 @@ internal class GradleKotlinCompilerWork @Inject constructor(
             stream,
             exitCode
         )
+        try {
+            metrics.measure(BuildTime.CLEAR_JAR_CACHE) {
+                val coreEnvironment = Class.forName("org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment", true, classLoader)
+                val dispose = coreEnvironment.getMethod("disposeApplicationEnvironment")
+                dispose.invoke(null)
+            }
+        } catch (e: Throwable) {
+            log.warn("Unable to clear jar cache after in-process compilation: $e")
+        }
         log.logFinish(KotlinCompilerExecutionStrategy.IN_PROCESS)
         return exitCode
     }


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-49772

This is to prevent file handle leaks on Windows. This
commit disposes KotlinCoreEnvironment used during
in-process compilation.