### PR TITLE
Fix incorrect kapt classpath error message

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/Kapt3KotlinGradleSubplugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/Kapt3KotlinGradleSubplugin.kt
@@ -621,7 +621,7 @@ class Kapt3GradleSubplugin @Inject internal constructor(private val registry: To
                 if (includeCompileClasspath && project.classLoadersCacheSize() > 0) {
                     project.logger.warn(
                         "ClassLoaders cache can't be enabled together with AP discovery in compilation classpath."
-                                + "\nSet 'kapt.includeCompileClasspath = false' to disable discovery"
+                                + "\nSet 'kapt.include.compile.classpath=false' to disable discovery"
                     )
                 } else {
                     it.classLoadersCacheSize = project.classLoadersCacheSize()

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/KaptTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/KaptTask.kt
@@ -226,7 +226,7 @@ abstract class KaptTask @Inject constructor(
             if (logger.isInfoEnabled) {
                 logger.warn(
                     "Annotation processors discovery from compile classpath is deprecated."
-                            + "\nSet 'kapt.includeCompileClasspath = false' to disable discovery."
+                            + "\nSet 'kapt.include.compile.classpath=false' to disable discovery."
                             + "\nThe following files, containing annotation processors, are not present in KAPT classpath:\n"
                             + processorsAbsentInKaptClasspath.joinToString("\n") { "  '$it'" }
                             + "\nAdd corresponding dependencies to any of the following configurations:\n"
@@ -235,7 +235,7 @@ abstract class KaptTask @Inject constructor(
             } else {
                 logger.warn(
                     "Annotation processors discovery from compile classpath is deprecated."
-                            + "\nSet 'kapt.includeCompileClasspath = false' to disable discovery."
+                            + "\nSet 'kapt.include.compile.classpath=false' to disable discovery."
                             + "\nRun the build with '--info' for more details."
                 )
             }


### PR DESCRIPTION
The correct name is `kapt.include.compile.classpath`