### PR TITLE
[JVM_IR] Fix inline class default method codegen.

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -9817,6 +9817,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         }
 
         @Test
+        @TestMetadata("kt49645.kt")
+        public void testKt49645() throws Exception {
+            runTest("compiler/testData/codegen/box/coroutines/kt49645.kt");
+        }
+
+        @Test
         @TestMetadata("lastExpressionIsLoop.kt")
         public void testLastExpressionIsLoop() throws Exception {
             runTest("compiler/testData/codegen/box/coroutines/lastExpressionIsLoop.kt");

--- a/compiler/testData/codegen/box/coroutines/kt49645.kt
+++ b/compiler/testData/codegen/box/coroutines/kt49645.kt
@@ -1,0 +1,30 @@
+// WITH_STDLIB
+// WITH_COROUTINES
+// TARGET_BACKEND: JVM
+
+import helpers.*
+import kotlin.coroutines.*
+
+interface Cont1 {
+    suspend fun flaf() = "O"
+
+    suspend fun toResult(): Result<String> {
+        val x = flaf()
+        return Result.success(x + "K")
+    }
+}
+
+@JvmInline
+private value class ContImpl(val a: String) : Cont1
+
+fun builder(c: suspend () -> Unit) {
+    c.startCoroutine(EmptyContinuation)
+}
+
+fun box(): String {
+    var result = "FAIL"
+    builder {
+        result = ContImpl("A").toResult().getOrThrow()
+    }
+    return result
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -9739,6 +9739,12 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
         }
 
         @Test
+        @TestMetadata("kt49645.kt")
+        public void testKt49645() throws Exception {
+            runTest("compiler/testData/codegen/box/coroutines/kt49645.kt");
+        }
+
+        @Test
         @TestMetadata("lastExpressionIsLoop.kt")
         public void testLastExpressionIsLoop() throws Exception {
             runTest("compiler/testData/codegen/box/coroutines/lastExpressionIsLoop.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -9817,6 +9817,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         }
 
         @Test
+        @TestMetadata("kt49645.kt")
+        public void testKt49645() throws Exception {
+            runTest("compiler/testData/codegen/box/coroutines/kt49645.kt");
+        }
+
+        @Test
         @TestMetadata("lastExpressionIsLoop.kt")
         public void testLastExpressionIsLoop() throws Exception {
             runTest("compiler/testData/codegen/box/coroutines/lastExpressionIsLoop.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -7633,6 +7633,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/coroutines/kt46813.kt");
         }
 
+        @TestMetadata("kt49645.kt")
+        public void testKt49645() throws Exception {
+            runTest("compiler/testData/codegen/box/coroutines/kt49645.kt");
+        }
+
         @TestMetadata("lastExpressionIsLoop.kt")
         public void testLastExpressionIsLoop() throws Exception {
             runTest("compiler/testData/codegen/box/coroutines/lastExpressionIsLoop.kt");

--- a/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/NativeExtBlackBoxTestGenerated.java
+++ b/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/NativeExtBlackBoxTestGenerated.java
@@ -9920,6 +9920,12 @@ public class NativeExtBlackBoxTestGenerated extends AbstractNativeBlackBoxTest {
             }
 
             @Test
+            @TestMetadata("kt49645.kt")
+            public void testKt49645() throws Exception {
+                runTest("compiler/testData/codegen/box/coroutines/kt49645.kt");
+            }
+
+            @Test
             @TestMetadata("lastExpressionIsLoop.kt")
             public void testLastExpressionIsLoop() throws Exception {
                 runTest("compiler/testData/codegen/box/coroutines/lastExpressionIsLoop.kt");


### PR DESCRIPTION
Do not coroutine transform static inline class replacements that
forward to a default interface suspend method. No boxing has to
take place on return (as the default interface method always
boxes) so we can simply forward the call.

^KT-49645 Fixed