### PR TITLE
[FIR] Give external package fragments different module descriptors.

### DIFF
--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrDeclarationStorage.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrDeclarationStorage.kt
@@ -225,7 +225,10 @@ class Fir2IrDeclarationStorage(
 
     fun getIrExternalPackageFragment(fqName: FqName): IrExternalPackageFragment {
         return fragmentCache.getOrPut(fqName) {
-            return symbolTable.declareExternalPackageFragment(FirPackageFragmentDescriptor(fqName, moduleDescriptor))
+            // Make sure that external package fragments have a different module descriptor. The module descriptors are compared
+            // to determine if objects need regeneration because they are from different modules.
+            val externalFragmentModuleDescriptor = FirModuleDescriptor(session)
+            return symbolTable.declareExternalPackageFragment(FirPackageFragmentDescriptor(fqName, externalFragmentModuleDescriptor))
         }
     }
 

--- a/compiler/testData/codegen/box/annotations/instances/multimoduleInlining.kt
+++ b/compiler/testData/codegen/box/annotations/instances/multimoduleInlining.kt
@@ -1,8 +1,3 @@
-// With FIR the annotation implementation class is not regenerated as it
-// is seen as coming from the same module.
-// See IrSourceCompilerForInline.kt:isCallInsideSameModuleAsCallee.
-// IGNORE_BACKEND_FIR: JVM_IR
-// FIR status: assertion failed: assert(one.javaClass.getEnclosingClass().getName() == "test.C")
 // TARGET_BACKEND: JVM_IR
 // IGNORE_DEXING
 // WITH_STDLIB

--- a/compiler/testData/codegen/box/compileKotlinAgainstKotlin/copySamOnInline.kt
+++ b/compiler/testData/codegen/box/compileKotlinAgainstKotlin/copySamOnInline.kt
@@ -1,5 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
-// FIR status: class should be regenerated, but test.AKt$sam$i$java_util_concurrent_Callable$0
 // FULL_JDK
 // WITH_STDLIB
 

--- a/compiler/testData/codegen/box/compileKotlinAgainstKotlin/copySamOnInline2.kt
+++ b/compiler/testData/codegen/box/compileKotlinAgainstKotlin/copySamOnInline2.kt
@@ -1,5 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
-// FIR status: class should be regenerated, but test.AKt$sam$i$java_util_concurrent_Callable$0
 // FULL_JDK
 // WITH_STDLIB
 

--- a/compiler/testData/codegen/box/compileKotlinAgainstKotlin/defaultLambdaRegeneration.kt
+++ b/compiler/testData/codegen/box/compileKotlinAgainstKotlin/defaultLambdaRegeneration.kt
@@ -1,5 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
-// FIR status: fail 1 : class test.AKt$test$1$1 ==  class test.AKt$test$1$1
 // TARGET_BACKEND: JVM
 // WITH_STDLIB
 

--- a/compiler/testData/codegen/box/compileKotlinAgainstKotlin/defaultLambdaRegeneration2.kt
+++ b/compiler/testData/codegen/box/compileKotlinAgainstKotlin/defaultLambdaRegeneration2.kt
@@ -1,5 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
-// FIR status: fail 1 : class test.AKt$test$1$1 ==  class test.AKt$test$1$1
 // TARGET_BACKEND: JVM
 // WITH_STDLIB
 


### PR DESCRIPTION
The inliner uses module descriptors to figure out if it needs to
regenerate objects.

We should avoid the use of descriptors in the inliner, but this
works as a first quick fix.