### PR TITLE
KT-49910: Fix adding sources for Android projects

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPlugin.kt
@@ -991,7 +991,12 @@ abstract class AbstractAndroidProjectHandler(private val kotlinConfigurationTool
 
         val javaTask = variantData.getJavaTaskProvider()
         val kotlinTask = compilation.compileKotlinTaskProvider
-        compilation.androidVariant.forEachJavaSourceDir { sources -> kotlinTask.configure { it.source(sources.dir) } }
+        compilation.androidVariant.forEachJavaSourceDir { sources ->
+            kotlinTask.configure {
+                it.source(sources.dir)
+                it.dependsOn(sources)
+            }
+        }
         wireKotlinTasks(project, compilation, androidPlugin, androidExt, variantData, javaTask, kotlinTask)
     }
 }

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/android/Android25ProjectHandler.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/android/Android25ProjectHandler.kt
@@ -60,10 +60,6 @@ class Android25ProjectHandler(
 
         val preJavaClasspathKey = variantData.registerPreJavacGeneratedBytecode(preJavaKotlinOutput)
         kotlinTask.configure { kotlinTaskInstance ->
-            kotlinTaskInstance.source(
-                variantData.getSourceFolders(SourceKind.JAVA)
-            )
-
             kotlinTaskInstance.classpath = project.files()
                 .from(variantData.getCompileClasspath(preJavaClasspathKey))
                 .from(Callable { AndroidGradleWrapper.getRuntimeJars(androidPlugin, androidExt) })


### PR DESCRIPTION
Avoid adding ConfigurableFileTrees to sources as that causes
individual *.java files to be evaluated as sources roots. To
pass the dependency info, manual dependsOn is used, but in the
future SourceRoots should be fixed to carry the dependency info.