### PR TITLE
Add getter for syntheticMethodForDelegate in JvmExtentions

### DIFF
--- a/libraries/kotlinx-metadata/jvm/src/kotlinx/metadata/jvm/jvmExtensions.kt
+++ b/libraries/kotlinx-metadata/jvm/src/kotlinx/metadata/jvm/jvmExtensions.kt
@@ -146,7 +146,11 @@ var KmProperty.syntheticMethodForAnnotations: JvmMethodSignature?
     }
 
 /**
- * TODO: WHAT IS AN EXAMPLE OF THIS?
+ * JVM signature of a synthetic method for properties which delegate to another property,
+ * which constructs and returns a property reference object.
+ * See https://kotlinlang.org/docs/delegated-properties.html#delegating-to-another-property.
+ *
+ * Example: `JvmMethodSignature("getX$delegate", "()Ljava/lang/Object;")`.
  */
 var KmProperty.syntheticMethodForDelegate: JvmMethodSignature?
     get() = jvm.syntheticMethodForDelegate

--- a/libraries/kotlinx-metadata/jvm/src/kotlinx/metadata/jvm/jvmExtensions.kt
+++ b/libraries/kotlinx-metadata/jvm/src/kotlinx/metadata/jvm/jvmExtensions.kt
@@ -146,6 +146,15 @@ var KmProperty.syntheticMethodForAnnotations: JvmMethodSignature?
     }
 
 /**
+ * TODO: WHAT IS AN EXAMPLE OF THIS?
+ */
+var KmProperty.syntheticMethodForDelegate: JvmMethodSignature?
+    get() = jvm.syntheticMethodForDelegate
+    set(value) {
+        jvm.syntheticMethodForDelegate = value
+    }
+
+/**
  * JVM signature of the constructor, or null if the JVM signature of this constructor is unknown.
  *
  * Example: `JvmMethodSignature("<init>", "(Ljava/lang/Object;)V")`.


### PR DESCRIPTION
Please add a getter for syntheticMethodDelegate. I am a bit unsure what the comment should be.