### PR TITLE
JVM_IR: handle star projection arguments in smart casts (KT-48987)

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -4590,6 +4590,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         }
 
         @Test
+        @TestMetadata("kt48987.kt")
+        public void testKt48987() throws Exception {
+            runTest("compiler/testData/codegen/box/casts/kt48987.kt");
+        }
+
+        @Test
         @TestMetadata("lambdaToUnitCast.kt")
         public void testLambdaToUnitCast() throws Exception {
             runTest("compiler/testData/codegen/box/casts/lambdaToUnitCast.kt");

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/FunctionReferenceLowering.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/FunctionReferenceLowering.kt
@@ -532,7 +532,12 @@ internal class FunctionReferenceLowering(private val context: JvmBackendContext)
             else irFunctionReference.getArgumentsWithIr().singleOrNull()
 
         // The type of the reference is KFunction<in A1, ..., in An, out R>
-        private val parameterTypes = (irFunctionReference.type as IrSimpleType).arguments.map { (it as IrTypeProjection).type }
+        private val parameterTypes = (irFunctionReference.type as IrSimpleType).arguments.map {
+            when (it) {
+                is IrTypeProjection -> it.type
+                else -> context.irBuiltIns.anyNType
+            }
+        }
         private val argumentTypes = parameterTypes.dropLast(1)
         private val referenceReturnType = parameterTypes.last()
 

--- a/compiler/testData/codegen/box/casts/kt48987.kt
+++ b/compiler/testData/codegen/box/casts/kt48987.kt
@@ -1,0 +1,12 @@
+// TARGET_BACKEND: JVM_IR
+// WITH_STDLIB
+
+fun box(): String {
+    return try {
+        val range1 = 0..1
+        range1 as List<Double>
+        range1.joinToString { "" }
+    } catch (e: java.lang.ClassCastException) {
+        "OK"
+    }
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -4590,6 +4590,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         }
 
         @Test
+        @TestMetadata("kt48987.kt")
+        public void testKt48987() throws Exception {
+            runTest("compiler/testData/codegen/box/casts/kt48987.kt");
+        }
+
+        @Test
         @TestMetadata("lambdaToUnitCast.kt")
         public void testLambdaToUnitCast() throws Exception {
             runTest("compiler/testData/codegen/box/casts/lambdaToUnitCast.kt");


### PR DESCRIPTION
Fixes [KT-48987](https://youtrack.jetbrains.com/issue/KT-48987), which looks similar to [KT-47449 ](https://youtrack.jetbrains.com/issue/KT-47449)