### PR TITLE
Parcelize: More permissive constructor diagnostics

### DIFF
--- a/plugins/parcelize/parcelize-compiler/src/org/jetbrains/kotlin/parcelize/ParcelizeAnnotationChecker.kt
+++ b/plugins/parcelize/parcelize-compiler/src/org/jetbrains/kotlin/parcelize/ParcelizeAnnotationChecker.kt
@@ -86,7 +86,9 @@ open class ParcelizeAnnotationChecker : CallChecker {
 
     private fun checkIgnoredOnParcelUsage(annotationEntry: KtAnnotationEntry, context: CallCheckerContext, element: KtModifierListOwner) {
         if (element is KtParameter && PsiTreeUtil.getParentOfType(element, KtDeclaration::class.java) is KtPrimaryConstructor) {
-            context.trace.report(ErrorsParcelize.INAPPLICABLE_IGNORED_ON_PARCEL_CONSTRUCTOR_PROPERTY.on(annotationEntry))
+            if (!element.hasDefaultValue()) {
+                context.trace.report(ErrorsParcelize.INAPPLICABLE_IGNORED_ON_PARCEL_CONSTRUCTOR_PROPERTY.on(annotationEntry))
+            }
         } else if (element !is KtProperty || PsiTreeUtil.getParentOfType(element, KtDeclaration::class.java) !is KtClassOrObject) {
             context.trace.report(ErrorsParcelize.INAPPLICABLE_IGNORED_ON_PARCEL.on(annotationEntry))
         }

--- a/plugins/parcelize/parcelize-compiler/src/org/jetbrains/kotlin/parcelize/ParcelizeDeclarationChecker.kt
+++ b/plugins/parcelize/parcelize-compiler/src/org/jetbrains/kotlin/parcelize/ParcelizeDeclarationChecker.kt
@@ -99,6 +99,7 @@ open class ParcelizeDeclarationChecker : DeclarationChecker {
         if (containingClass.isParcelize
             && (declaration.hasDelegate() || bindingContext[BindingContext.BACKING_FIELD_REQUIRED, property] == true)
             && !hasIgnoredOnParcel()
+            && !containingClass.hasCustomParceler()
         ) {
             val reportElement = declaration.nameIdentifier ?: declaration
             diagnosticHolder.report(ErrorsParcelize.PROPERTY_WONT_BE_SERIALIZED.on(reportElement))
@@ -192,6 +193,11 @@ open class ParcelizeDeclarationChecker : DeclarationChecker {
             }
         }
 
+        // The constructor checks are irrelevant for custom parcelers
+        if (descriptor.hasCustomParceler()) {
+            return
+        }
+
         val primaryConstructor = declaration.primaryConstructor
         if (primaryConstructor == null && declaration.secondaryConstructors.isNotEmpty()) {
             val reportElement = declaration.nameIdentifier ?: declaration
@@ -234,7 +240,7 @@ open class ParcelizeDeclarationChecker : DeclarationChecker {
 
         val type = descriptor.type
 
-        if (!type.isError && !containerClass.hasCustomParceler()) {
+        if (!type.isError) {
             val asmType = typeMapper.mapType(type, mode = TypeMappingMode.CLASS_DECLARATION)
 
             try {

--- a/plugins/parcelize/parcelize-compiler/src/org/jetbrains/kotlin/parcelize/ParcelizeDeclarationChecker.kt
+++ b/plugins/parcelize/parcelize-compiler/src/org/jetbrains/kotlin/parcelize/ParcelizeDeclarationChecker.kt
@@ -226,6 +226,12 @@ open class ParcelizeDeclarationChecker : DeclarationChecker {
         }
 
         val descriptor = typeMapper.bindingContext[BindingContext.PRIMARY_CONSTRUCTOR_PARAMETER, parameter] ?: return
+
+        // Don't check parameters which won't be serialized
+        if (descriptor.annotations.any { it.fqName in IGNORED_ON_PARCEL_FQ_NAMES }) {
+            return
+        }
+
         val type = descriptor.type
 
         if (!type.isError && !containerClass.hasCustomParceler()) {

--- a/plugins/parcelize/parcelize-compiler/src/org/jetbrains/kotlin/parcelize/ParcelizeNames.kt
+++ b/plugins/parcelize/parcelize-compiler/src/org/jetbrains/kotlin/parcelize/ParcelizeNames.kt
@@ -32,6 +32,7 @@ object ParcelizeNames {
     val TYPE_PARCELER_CLASS_IDS = createClassIds("TypeParceler")
     val WRITE_WITH_CLASS_IDS = createClassIds("WriteWith")
     val IGNORED_ON_PARCEL_CLASS_IDS = createClassIds("IgnoredOnParcel")
+    val PARCELER_CLASS_IDS = createClassIds("Parceler")
     val PARCELIZE_CLASS_CLASS_IDS = createClassIds("Parcelize")
     val RAW_VALUE_ANNOTATION_CLASS_IDS = createClassIds("RawValue")
 

--- a/plugins/parcelize/parcelize-compiler/src/org/jetbrains/kotlin/parcelize/diagnostic/DefaultErrorMessagesParcelize.kt
+++ b/plugins/parcelize/parcelize-compiler/src/org/jetbrains/kotlin/parcelize/diagnostic/DefaultErrorMessagesParcelize.kt
@@ -132,7 +132,7 @@ object DefaultErrorMessagesParcelize : DefaultErrorMessages.Extension {
 
         MAP.put(
             ErrorsParcelize.INAPPLICABLE_IGNORED_ON_PARCEL_CONSTRUCTOR_PROPERTY,
-            "'@IgnoredOnParcel' is inapplicable to properties declared in the primary constructor"
+            "'@IgnoredOnParcel' is inapplicable to properties without default value declared in the primary constructor"
         )
 
         MAP.put(

--- a/plugins/parcelize/parcelize-compiler/src/org/jetbrains/kotlin/parcelize/fir/diagnostics/FirParcelizeClassChecker.kt
+++ b/plugins/parcelize/parcelize-compiler/src/org/jetbrains/kotlin/parcelize/fir/diagnostics/FirParcelizeClassChecker.kt
@@ -32,6 +32,7 @@ import org.jetbrains.kotlin.name.SpecialNames
 import org.jetbrains.kotlin.parcelize.ParcelizeNames.CREATOR_NAME
 import org.jetbrains.kotlin.parcelize.ParcelizeNames.OLD_PARCELER_ID
 import org.jetbrains.kotlin.parcelize.ParcelizeNames.PARCELABLE_ID
+import org.jetbrains.kotlin.parcelize.ParcelizeNames.PARCELER_CLASS_IDS
 import org.jetbrains.kotlin.parcelize.ParcelizeNames.PARCELIZE_CLASS_CLASS_IDS
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
@@ -129,5 +130,12 @@ fun FirClassSymbol<*>?.isParcelize(session: FirSession): Boolean {
     return resolvedSuperTypeRefs.any {
         val symbol = it.type.fullyExpandedType(session).toRegularClassSymbol(session) ?: return@any false
         symbol.annotations.any { it.classId in PARCELIZE_CLASS_CLASS_IDS }
+    }
+}
+
+fun FirRegularClass.hasCustomParceler(session: FirSession): Boolean {
+    val companion = companionObjectSymbol ?: return false
+    return lookupSuperTypes(companion, lookupInterfaces = true, deep = true, useSiteSession = session).any {
+        it.classId in PARCELER_CLASS_IDS
     }
 }

--- a/plugins/parcelize/parcelize-compiler/src/org/jetbrains/kotlin/parcelize/fir/diagnostics/FirParcelizeConstructorChecker.kt
+++ b/plugins/parcelize/parcelize-compiler/src/org/jetbrains/kotlin/parcelize/fir/diagnostics/FirParcelizeConstructorChecker.kt
@@ -13,7 +13,8 @@ import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirConstructorChecker
 import org.jetbrains.kotlin.fir.declarations.FirConstructor
 import org.jetbrains.kotlin.fir.declarations.FirRegularClass
-import org.jetbrains.kotlin.parcelize.fir.diagnostics.KtErrorsParcelize.PARCELABLE_CONSTRUCTOR_PARAMETER_SHOULD_BE_VAL_OR_VAR
+import org.jetbrains.kotlin.fir.expressions.classId
+import org.jetbrains.kotlin.parcelize.ParcelizeNames
 
 object FirParcelizeConstructorChecker : FirConstructorChecker() {
     override fun check(declaration: FirConstructor, context: CheckerContext, reporter: DiagnosticReporter) {
@@ -29,7 +30,23 @@ object FirParcelizeConstructorChecker : FirConstructorChecker() {
         } else {
             for (valueParameter in declaration.valueParameters) {
                 if (valueParameter.source?.hasValOrVar() != true) {
-                    reporter.reportOn(valueParameter.source, PARCELABLE_CONSTRUCTOR_PARAMETER_SHOULD_BE_VAL_OR_VAR, context)
+                    reporter.reportOn(
+                        valueParameter.source,
+                        KtErrorsParcelize.PARCELABLE_CONSTRUCTOR_PARAMETER_SHOULD_BE_VAL_OR_VAR,
+                        context
+                    )
+                }
+                if (valueParameter.defaultValue == null) {
+                    val illegalAnnotation = valueParameter.annotations.firstOrNull {
+                        it.classId in ParcelizeNames.IGNORED_ON_PARCEL_CLASS_IDS
+                    }
+                    if (illegalAnnotation != null) {
+                        reporter.reportOn(
+                            illegalAnnotation.source,
+                            KtErrorsParcelize.INAPPLICABLE_IGNORED_ON_PARCEL_CONSTRUCTOR_PROPERTY,
+                            context
+                        )
+                    }
                 }
             }
         }

--- a/plugins/parcelize/parcelize-compiler/src/org/jetbrains/kotlin/parcelize/fir/diagnostics/FirParcelizeConstructorChecker.kt
+++ b/plugins/parcelize/parcelize-compiler/src/org/jetbrains/kotlin/parcelize/fir/diagnostics/FirParcelizeConstructorChecker.kt
@@ -23,7 +23,7 @@ object FirParcelizeConstructorChecker : FirConstructorChecker() {
         if (source.kind == KtFakeSourceElementKind.ImplicitConstructor) return
         val containingClass = context.containingDeclarations.last() as? FirRegularClass ?: return
         val containingClassSymbol = containingClass.symbol
-        if (!containingClassSymbol.isParcelize(context.session)) return
+        if (!containingClassSymbol.isParcelize(context.session) || containingClass.hasCustomParceler(context.session)) return
 
         if (declaration.valueParameters.isEmpty()) {
             reporter.reportOn(containingClass.source, KtErrorsParcelize.PARCELABLE_PRIMARY_CONSTRUCTOR_IS_EMPTY, context)

--- a/plugins/parcelize/parcelize-compiler/src/org/jetbrains/kotlin/parcelize/fir/diagnostics/FirParcelizePropertyChecker.kt
+++ b/plugins/parcelize/parcelize-compiler/src/org/jetbrains/kotlin/parcelize/fir/diagnostics/FirParcelizePropertyChecker.kt
@@ -38,7 +38,8 @@ object FirParcelizePropertyChecker : FirPropertyChecker() {
             if (
                 !fromPrimaryConstructor &&
                 (declaration.hasBackingField || declaration.delegate != null) &&
-                !declaration.hasIgnoredOnParcel()
+                !declaration.hasIgnoredOnParcel() &&
+                !containingClassSymbol.hasCustomParceler(context.session)
             ) {
                 reporter.reportOn(declaration.source, KtErrorsParcelize.PROPERTY_WONT_BE_SERIALIZED, context)
             }

--- a/plugins/parcelize/parcelize-compiler/src/org/jetbrains/kotlin/parcelize/fir/diagnostics/FirParcelizePropertyChecker.kt
+++ b/plugins/parcelize/parcelize-compiler/src/org/jetbrains/kotlin/parcelize/fir/diagnostics/FirParcelizePropertyChecker.kt
@@ -44,7 +44,6 @@ object FirParcelizePropertyChecker : FirPropertyChecker() {
             }
             if (fromPrimaryConstructor) {
                 checkParcelableClassProperty(declaration, containingClassSymbol, context, reporter)
-                checkIgnoredOnParcelUsage(declaration, context, reporter)
             }
         }
 
@@ -54,11 +53,6 @@ object FirParcelizePropertyChecker : FirPropertyChecker() {
                 reporter.reportOn(declaration.source, KtErrorsParcelize.CREATOR_DEFINITION_IS_NOT_ALLOWED, context)
             }
         }
-    }
-
-    private fun checkIgnoredOnParcelUsage(property: FirProperty, context: CheckerContext, reporter: DiagnosticReporter) {
-        val illegalAnnotation = property.annotations.firstOrNull { it.classId in IGNORED_ON_PARCEL_CLASS_IDS } ?: return
-        reporter.reportOn(illegalAnnotation.source, KtErrorsParcelize.INAPPLICABLE_IGNORED_ON_PARCEL_CONSTRUCTOR_PROPERTY, context)
     }
 
     @Suppress("UNUSED_PARAMETER")

--- a/plugins/parcelize/parcelize-compiler/src/org/jetbrains/kotlin/parcelize/fir/diagnostics/KtDefaultErrorMessagesParcelize.kt
+++ b/plugins/parcelize/parcelize-compiler/src/org/jetbrains/kotlin/parcelize/fir/diagnostics/KtDefaultErrorMessagesParcelize.kt
@@ -159,7 +159,7 @@ object KtDefaultErrorMessagesParcelize {
 
         map.put(
             INAPPLICABLE_IGNORED_ON_PARCEL_CONSTRUCTOR_PROPERTY,
-            "'@IgnoredOnParcel' is inapplicable to properties declared in the primary constructor"
+            "'@IgnoredOnParcel' is inapplicable to properties without default value declared in the primary constructor"
         )
 
         map.put(

--- a/plugins/parcelize/parcelize-compiler/src/org/jetbrains/kotlin/parcelize/ir/ParcelizeIrTransformerBase.kt
+++ b/plugins/parcelize/parcelize-compiler/src/org/jetbrains/kotlin/parcelize/ir/ParcelizeIrTransformerBase.kt
@@ -184,8 +184,8 @@ abstract class ParcelizeIrTransformerBase(
             val topLevelScope = getParcelerScope()
 
             return constructor.valueParameters.map { parameter ->
-                val property = properties.first { it.name == parameter.name }
-                if (property.hasAnyAnnotation(IGNORED_ON_PARCEL_FQ_NAMES)) {
+                val property = properties.firstOrNull { it.name == parameter.name }
+                if (property == null || property.hasAnyAnnotation(IGNORED_ON_PARCEL_FQ_NAMES)) {
                     null
                 } else {
                     val localScope = property.getParcelerScope(topLevelScope)

--- a/plugins/parcelize/parcelize-compiler/testData/box/constructorWithoutValOrVar.kt
+++ b/plugins/parcelize/parcelize-compiler/testData/box/constructorWithoutValOrVar.kt
@@ -1,0 +1,35 @@
+// WITH_STDLIB
+
+@file:JvmName("TestKt")
+package test
+
+import kotlinx.parcelize.*
+import android.os.Parcel
+import android.os.Parcelable
+
+@Parcelize
+class A(_a: String) : Parcelable {
+    var a: String = _a
+        private set
+
+    companion object : Parceler<A> {
+        override fun A.write(parcel: Parcel, flags: Int) {
+            parcel.writeString(a)
+        }
+
+        override fun create(parcel: Parcel) = A(parcel.readString())
+    }
+}
+
+fun box() = parcelTest { parcel ->
+    val test = A("OK")
+    test.writeToParcel(parcel, 0)
+
+    val bytes = parcel.marshall()
+    parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
+
+    val test2 = parcelableCreator<A>().createFromParcel(parcel)
+
+    assert(test.a == test2.a)
+}

--- a/plugins/parcelize/parcelize-compiler/testData/box/customParcelerChecks.kt
+++ b/plugins/parcelize/parcelize-compiler/testData/box/customParcelerChecks.kt
@@ -1,0 +1,42 @@
+// WITH_STDLIB
+
+@file:JvmName("TestKt")
+package test
+
+import kotlinx.parcelize.*
+import android.os.Parcel
+import android.os.Parcelable
+
+class T(val value: String)
+
+// There's no warnings on empty constructors, secondary constructors, or
+// non-parcelable types if there is a custom parceler.
+@Parcelize
+class A() : Parcelable {
+    var a: T = T("Fail")
+
+    constructor(value: String) : this() {
+        a = T(value)
+    }
+
+    companion object : Parceler<A> {
+        override fun A.write(parcel: Parcel, flags: Int) {
+            parcel.writeString(a.value)
+        }
+
+        override fun create(parcel: Parcel) = A(parcel.readString())
+    }
+}
+
+fun box() = parcelTest { parcel ->
+    val test = A("OK")
+    test.writeToParcel(parcel, 0)
+
+    val bytes = parcel.marshall()
+    parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
+
+    val test2 = parcelableCreator<A>().createFromParcel(parcel)
+
+    assert(test.a.value == test2.a.value)
+}

--- a/plugins/parcelize/parcelize-compiler/testData/box/ignoredOnParcel.kt
+++ b/plugins/parcelize/parcelize-compiler/testData/box/ignoredOnParcel.kt
@@ -1,0 +1,51 @@
+// WITH_STDLIB
+// IGNORE_BACKEND: JVM
+
+@file:JvmName("TestKt")
+package test
+
+import kotlinx.parcelize.*
+import android.os.Parcel
+import android.os.Parcelable
+
+class T(val value: Int)
+
+@Parcelize
+class A(
+    val x: String,
+    @IgnoredOnParcel
+    val i1: String = "default",
+    @IgnoredOnParcel
+    val i2: T = T(10),
+    val d: String = "default",
+) : Parcelable {
+    @IgnoredOnParcel
+    val a: String = x
+}
+
+@Parcelize
+object B : Parcelable {
+    @IgnoredOnParcel
+    val x: T = T(2)
+}
+
+fun box() = parcelTest { parcel ->
+    val a1 = A("X", "i1", T(0), "d")
+
+    a1.writeToParcel(parcel, 0)
+    B.writeToParcel(parcel, 0)
+
+    val bytes = parcel.marshall()
+    parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
+
+    val a2 = parcelableCreator<A>().createFromParcel(parcel)
+    val b = parcelableCreator<B>().createFromParcel(parcel)
+
+    assert(a1.x == a2.x)
+    assert(a2.i1 == "default")
+    assert(a2.i2.value == 10)
+    assert(a1.d == a2.d)
+    assert(a1.a == a2.a)
+    assert(b == B)
+}

--- a/plugins/parcelize/parcelize-compiler/testData/diagnostics/ignoredOnParcelDefaultValues.kt
+++ b/plugins/parcelize/parcelize-compiler/testData/diagnostics/ignoredOnParcelDefaultValues.kt
@@ -1,0 +1,9 @@
+// FIR_IDENTICAL
+package test
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.IgnoredOnParcel
+
+@Parcelize
+class A(@IgnoredOnParcel val x: String = "OK") : Parcelable

--- a/plugins/parcelize/parcelize-compiler/testData/diagnostics/ignoredOnParcelUnsupportedType.kt
+++ b/plugins/parcelize/parcelize-compiler/testData/diagnostics/ignoredOnParcelUnsupportedType.kt
@@ -1,0 +1,16 @@
+// FIR_IDENTICAL
+package test
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.IgnoredOnParcel
+
+class T(val x: Int)
+
+@Parcelize
+class A(
+    // T is not parcelable, but we don't need it to be since it is not being serialized.
+    @IgnoredOnParcel val x: T = T(0)
+) : Parcelable {
+    @IgnoredOnParcel val y: T = x
+}

--- a/plugins/parcelize/parcelize-compiler/tests-gen/org/jetbrains/kotlin/parcelize/test/runners/FirParcelizeDiagnosticTestGenerated.java
+++ b/plugins/parcelize/parcelize-compiler/tests-gen/org/jetbrains/kotlin/parcelize/test/runners/FirParcelizeDiagnosticTestGenerated.java
@@ -67,6 +67,18 @@ public class FirParcelizeDiagnosticTestGenerated extends AbstractFirParcelizeDia
     }
 
     @Test
+    @TestMetadata("ignoredOnParcelDefaultValues.kt")
+    public void testIgnoredOnParcelDefaultValues() throws Exception {
+        runTest("plugins/parcelize/parcelize-compiler/testData/diagnostics/ignoredOnParcelDefaultValues.kt");
+    }
+
+    @Test
+    @TestMetadata("ignoredOnParcelUnsupportedType.kt")
+    public void testIgnoredOnParcelUnsupportedType() throws Exception {
+        runTest("plugins/parcelize/parcelize-compiler/testData/diagnostics/ignoredOnParcelUnsupportedType.kt");
+    }
+
+    @Test
     @TestMetadata("kt20062.kt")
     public void testKt20062() throws Exception {
         runTest("plugins/parcelize/parcelize-compiler/testData/diagnostics/kt20062.kt");

--- a/plugins/parcelize/parcelize-compiler/tests-gen/org/jetbrains/kotlin/parcelize/test/runners/ParcelizeBoxTestGenerated.java
+++ b/plugins/parcelize/parcelize-compiler/tests-gen/org/jetbrains/kotlin/parcelize/test/runners/ParcelizeBoxTestGenerated.java
@@ -74,6 +74,12 @@ public class ParcelizeBoxTestGenerated extends AbstractParcelizeBoxTest {
     }
 
     @Test
+    @TestMetadata("constructorWithoutValOrVar.kt")
+    public void testConstructorWithoutValOrVar() throws Exception {
+        runTest("plugins/parcelize/parcelize-compiler/testData/box/constructorWithoutValOrVar.kt");
+    }
+
+    @Test
     @TestMetadata("customNewArray.kt")
     public void testCustomNewArray() throws Exception {
         runTest("plugins/parcelize/parcelize-compiler/testData/box/customNewArray.kt");
@@ -83,6 +89,12 @@ public class ParcelizeBoxTestGenerated extends AbstractParcelizeBoxTest {
     @TestMetadata("customParcelable.kt")
     public void testCustomParcelable() throws Exception {
         runTest("plugins/parcelize/parcelize-compiler/testData/box/customParcelable.kt");
+    }
+
+    @Test
+    @TestMetadata("customParcelerChecks.kt")
+    public void testCustomParcelerChecks() throws Exception {
+        runTest("plugins/parcelize/parcelize-compiler/testData/box/customParcelerChecks.kt");
     }
 
     @Test

--- a/plugins/parcelize/parcelize-compiler/tests-gen/org/jetbrains/kotlin/parcelize/test/runners/ParcelizeBoxTestGenerated.java
+++ b/plugins/parcelize/parcelize-compiler/tests-gen/org/jetbrains/kotlin/parcelize/test/runners/ParcelizeBoxTestGenerated.java
@@ -152,6 +152,12 @@ public class ParcelizeBoxTestGenerated extends AbstractParcelizeBoxTest {
     }
 
     @Test
+    @TestMetadata("ignoredOnParcel.kt")
+    public void testIgnoredOnParcel() throws Exception {
+        runTest("plugins/parcelize/parcelize-compiler/testData/box/ignoredOnParcel.kt");
+    }
+
+    @Test
     @TestMetadata("intArray.kt")
     public void testIntArray() throws Exception {
         runTest("plugins/parcelize/parcelize-compiler/testData/box/intArray.kt");

--- a/plugins/parcelize/parcelize-compiler/tests-gen/org/jetbrains/kotlin/parcelize/test/runners/ParcelizeDiagnosticTestGenerated.java
+++ b/plugins/parcelize/parcelize-compiler/tests-gen/org/jetbrains/kotlin/parcelize/test/runners/ParcelizeDiagnosticTestGenerated.java
@@ -67,6 +67,18 @@ public class ParcelizeDiagnosticTestGenerated extends AbstractParcelizeDiagnosti
     }
 
     @Test
+    @TestMetadata("ignoredOnParcelDefaultValues.kt")
+    public void testIgnoredOnParcelDefaultValues() throws Exception {
+        runTest("plugins/parcelize/parcelize-compiler/testData/diagnostics/ignoredOnParcelDefaultValues.kt");
+    }
+
+    @Test
+    @TestMetadata("ignoredOnParcelUnsupportedType.kt")
+    public void testIgnoredOnParcelUnsupportedType() throws Exception {
+        runTest("plugins/parcelize/parcelize-compiler/testData/diagnostics/ignoredOnParcelUnsupportedType.kt");
+    }
+
+    @Test
     @TestMetadata("kt20062.kt")
     public void testKt20062() throws Exception {
         runTest("plugins/parcelize/parcelize-compiler/testData/diagnostics/kt20062.kt");

--- a/plugins/parcelize/parcelize-compiler/tests-gen/org/jetbrains/kotlin/parcelize/test/runners/ParcelizeFirBoxTestGenerated.java
+++ b/plugins/parcelize/parcelize-compiler/tests-gen/org/jetbrains/kotlin/parcelize/test/runners/ParcelizeFirBoxTestGenerated.java
@@ -152,6 +152,12 @@ public class ParcelizeFirBoxTestGenerated extends AbstractParcelizeFirBoxTest {
     }
 
     @Test
+    @TestMetadata("ignoredOnParcel.kt")
+    public void testIgnoredOnParcel() throws Exception {
+        runTest("plugins/parcelize/parcelize-compiler/testData/box/ignoredOnParcel.kt");
+    }
+
+    @Test
     @TestMetadata("intArray.kt")
     public void testIntArray() throws Exception {
         runTest("plugins/parcelize/parcelize-compiler/testData/box/intArray.kt");

--- a/plugins/parcelize/parcelize-compiler/tests-gen/org/jetbrains/kotlin/parcelize/test/runners/ParcelizeFirBoxTestGenerated.java
+++ b/plugins/parcelize/parcelize-compiler/tests-gen/org/jetbrains/kotlin/parcelize/test/runners/ParcelizeFirBoxTestGenerated.java
@@ -74,6 +74,12 @@ public class ParcelizeFirBoxTestGenerated extends AbstractParcelizeFirBoxTest {
     }
 
     @Test
+    @TestMetadata("constructorWithoutValOrVar.kt")
+    public void testConstructorWithoutValOrVar() throws Exception {
+        runTest("plugins/parcelize/parcelize-compiler/testData/box/constructorWithoutValOrVar.kt");
+    }
+
+    @Test
     @TestMetadata("customNewArray.kt")
     public void testCustomNewArray() throws Exception {
         runTest("plugins/parcelize/parcelize-compiler/testData/box/customNewArray.kt");
@@ -83,6 +89,12 @@ public class ParcelizeFirBoxTestGenerated extends AbstractParcelizeFirBoxTest {
     @TestMetadata("customParcelable.kt")
     public void testCustomParcelable() throws Exception {
         runTest("plugins/parcelize/parcelize-compiler/testData/box/customParcelable.kt");
+    }
+
+    @Test
+    @TestMetadata("customParcelerChecks.kt")
+    public void testCustomParcelerChecks() throws Exception {
+        runTest("plugins/parcelize/parcelize-compiler/testData/box/customParcelerChecks.kt");
     }
 
     @Test

--- a/plugins/parcelize/parcelize-compiler/tests-gen/org/jetbrains/kotlin/parcelize/test/runners/ParcelizeIrBoxTestGenerated.java
+++ b/plugins/parcelize/parcelize-compiler/tests-gen/org/jetbrains/kotlin/parcelize/test/runners/ParcelizeIrBoxTestGenerated.java
@@ -152,6 +152,12 @@ public class ParcelizeIrBoxTestGenerated extends AbstractParcelizeIrBoxTest {
     }
 
     @Test
+    @TestMetadata("ignoredOnParcel.kt")
+    public void testIgnoredOnParcel() throws Exception {
+        runTest("plugins/parcelize/parcelize-compiler/testData/box/ignoredOnParcel.kt");
+    }
+
+    @Test
     @TestMetadata("intArray.kt")
     public void testIntArray() throws Exception {
         runTest("plugins/parcelize/parcelize-compiler/testData/box/intArray.kt");

--- a/plugins/parcelize/parcelize-compiler/tests-gen/org/jetbrains/kotlin/parcelize/test/runners/ParcelizeIrBoxTestGenerated.java
+++ b/plugins/parcelize/parcelize-compiler/tests-gen/org/jetbrains/kotlin/parcelize/test/runners/ParcelizeIrBoxTestGenerated.java
@@ -74,6 +74,12 @@ public class ParcelizeIrBoxTestGenerated extends AbstractParcelizeIrBoxTest {
     }
 
     @Test
+    @TestMetadata("constructorWithoutValOrVar.kt")
+    public void testConstructorWithoutValOrVar() throws Exception {
+        runTest("plugins/parcelize/parcelize-compiler/testData/box/constructorWithoutValOrVar.kt");
+    }
+
+    @Test
     @TestMetadata("customNewArray.kt")
     public void testCustomNewArray() throws Exception {
         runTest("plugins/parcelize/parcelize-compiler/testData/box/customNewArray.kt");
@@ -83,6 +89,12 @@ public class ParcelizeIrBoxTestGenerated extends AbstractParcelizeIrBoxTest {
     @TestMetadata("customParcelable.kt")
     public void testCustomParcelable() throws Exception {
         runTest("plugins/parcelize/parcelize-compiler/testData/box/customParcelable.kt");
+    }
+
+    @Test
+    @TestMetadata("customParcelerChecks.kt")
+    public void testCustomParcelerChecks() throws Exception {
+        runTest("plugins/parcelize/parcelize-compiler/testData/box/customParcelerChecks.kt");
     }
 
     @Test


### PR DESCRIPTION
- Allow `@IgnoredOnParcel` annotations on constructor parameters with default values. See https://issuetracker.google.com/177850560
- Don't check constructors if there is a custom `Parceler` - the checks are there to ensure that we can generate correct code, but with a custom Parceler that's not really necessary. See https://issuetracker.google.com/177850558