### PR TITLE
Downgrades warnings about missing source

### DIFF
--- a/libraries/tools/kotlin-maven-plugin/src/main/java/org/jetbrains/kotlin/maven/KotlinCompileMojoBase.java
+++ b/libraries/tools/kotlin-maven-plugin/src/main/java/org/jetbrains/kotlin/maven/KotlinCompileMojoBase.java
@@ -192,7 +192,7 @@ public abstract class KotlinCompileMojoBase<A extends CommonCompilerArguments> e
                 " (JRE " + System.getProperty("java.runtime.version") + ")");
 
         if (!hasKotlinFilesInSources()) {
-            getLog().warn("No sources found skipping Kotlin compile");
+            getLog().info("No sources found skipping Kotlin compile");
             return;
         }
 
@@ -421,7 +421,7 @@ public abstract class KotlinCompileMojoBase<A extends CommonCompilerArguments> e
             }
             // unfortunately there is no good way to detect generated sources directory so we simply keep hardcoded value
             else if (!sourceDir.getPath().contains("generated-sources")) {
-                getLog().warn("Source root doesn't exist: " + sourceDir);
+                getLog().info("Source root doesn't exist: " + sourceDir);
             }
         }
         if (sourceRoots.isEmpty()) {


### PR DESCRIPTION
Except for pure kotlin projects, not having kotlin source files in a module or not having all the source roots available is actually a common occurrence, this leads to lots of unnecessary warnings. Unnecessary warnings in general are bad since they decrease developer's attention to all warnings which usually leads to important warnings being ignored.

An alternative solution to downgrading would be reviewing each pom, module by module, to set the exact set of source roots to consider to fix the warning. This has the immediate downside that it makes incremental migration from java to kotlin more painful since we then have to change the pom again when we want to add kotlin in a project which doesn't use it. 

It is also especially painful in very large maven reactors (reviewing our 354 pom files to determine which set of source roots to use is tedious at best)
Another alternative would be to add an option to alternate between info and warn but I didn't think it was worth the additional complexity in the mojo.