### PR TITLE
JVM_IR: Add null-checks in SAM wrapper constructors (KT-50108)

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -41225,6 +41225,18 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         }
 
         @Test
+        @TestMetadata("kt50108.kt")
+        public void testKt50108() throws Exception {
+            runTest("compiler/testData/codegen/box/sam/kt50108.kt");
+        }
+
+        @Test
+        @TestMetadata("kt50108_java.kt")
+        public void testKt50108_java() throws Exception {
+            runTest("compiler/testData/codegen/box/sam/kt50108_java.kt");
+        }
+
+        @Test
         @TestMetadata("nonInlinedSamWrapper.kt")
         public void testNonInlinedSamWrapper() throws Exception {
             runTest("compiler/testData/codegen/box/sam/nonInlinedSamWrapper.kt");

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -277,9 +277,7 @@ class ExpressionCodegen(
             irFunction.origin.isSynthetic ||
             // TODO: refine this condition to not generate nullability assertions on parameters
             //       corresponding to captured variables and anonymous object super constructor arguments
-            (irFunction is IrConstructor &&
-                    (irFunction.parentAsClass.isAnonymousObject ||
-                            irFunction.parentAsClass.origin == IrDeclarationOrigin.GENERATED_SAM_IMPLEMENTATION)) ||
+            (irFunction is IrConstructor && irFunction.parentAsClass.isAnonymousObject) ||
             // TODO: Implement this as a lowering, so that we can more easily exclude generated methods.
             irFunction.origin == JvmLoweredDeclarationOrigin.INLINE_CLASS_GENERATED_IMPL_METHOD ||
             // Although these are accessible from Java, the functions they bridge to already have the assertions.

--- a/compiler/testData/codegen/box/sam/kt50108.kt
+++ b/compiler/testData/codegen/box/sam/kt50108.kt
@@ -1,0 +1,32 @@
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND: JVM
+
+fun interface IFoo {
+    fun foo(): String
+}
+
+abstract class Base {
+    abstract val fn: () -> String
+
+    init {
+        // This should throw a NPE, since the constructor of the IFoo
+        // SAM wrapper expects a non-nullable function type.
+        //
+        // In the JVM backend this expression evaluates to `null` instead,
+        // which isn't a valid result according to the type system.
+        IFoo(fn)
+    }
+}
+
+class Derived : Base() {
+    override val fn: () -> String = { "OK" }
+}
+
+fun box(): String {
+    try {
+        Derived()
+    } catch (e: java.lang.NullPointerException) {
+        return "OK"
+    }
+    return "Fail"
+}

--- a/compiler/testData/codegen/box/sam/kt50108_java.kt
+++ b/compiler/testData/codegen/box/sam/kt50108_java.kt
@@ -1,0 +1,23 @@
+// TARGET_BACKEND: JVM
+// FILE: test.kt
+fun interface IFoo {
+    fun foo(s: String)
+}
+
+val foo = IFoo {}
+
+fun box(): String {
+    try {
+        J.callWithNull(foo)
+        return "J.callWithNull(foo) should throw NPE"
+    } catch (e: NullPointerException) {
+        return "OK"
+    }
+}
+
+// FILE: J.java
+public class J {
+    public static void callWithNull(IFoo iFoo) {
+        iFoo.foo(null);
+    }
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -40799,6 +40799,18 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
         }
 
         @Test
+        @TestMetadata("kt50108.kt")
+        public void testKt50108() throws Exception {
+            runTest("compiler/testData/codegen/box/sam/kt50108.kt");
+        }
+
+        @Test
+        @TestMetadata("kt50108_java.kt")
+        public void testKt50108_java() throws Exception {
+            runTest("compiler/testData/codegen/box/sam/kt50108_java.kt");
+        }
+
+        @Test
         @TestMetadata("nonInlinedSamWrapper.kt")
         public void testNonInlinedSamWrapper() throws Exception {
             runTest("compiler/testData/codegen/box/sam/nonInlinedSamWrapper.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -41225,6 +41225,18 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         }
 
         @Test
+        @TestMetadata("kt50108.kt")
+        public void testKt50108() throws Exception {
+            runTest("compiler/testData/codegen/box/sam/kt50108.kt");
+        }
+
+        @Test
+        @TestMetadata("kt50108_java.kt")
+        public void testKt50108_java() throws Exception {
+            runTest("compiler/testData/codegen/box/sam/kt50108_java.kt");
+        }
+
+        @Test
         @TestMetadata("nonInlinedSamWrapper.kt")
         public void testNonInlinedSamWrapper() throws Exception {
             runTest("compiler/testData/codegen/box/sam/nonInlinedSamWrapper.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -32622,6 +32622,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)
     public static class Sam extends AbstractLightAnalysisModeTest {
+        @TestMetadata("kt50108.kt")
+        public void ignoreKt50108() throws Exception {
+            runTest("compiler/testData/codegen/box/sam/kt50108.kt");
+        }
+
         private void runTest(String testDataFilePath) throws Exception {
             KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM, testDataFilePath);
         }
@@ -32753,6 +32758,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
         @TestMetadata("kt49226.kt")
         public void testKt49226() throws Exception {
             runTest("compiler/testData/codegen/box/sam/kt49226.kt");
+        }
+
+        @TestMetadata("kt50108_java.kt")
+        public void testKt50108_java() throws Exception {
+            runTest("compiler/testData/codegen/box/sam/kt50108_java.kt");
         }
 
         @TestMetadata("nonInlinedSamWrapper.kt")


### PR DESCRIPTION
This partially reverts 8574cb4466207a2f7d143556c4b22bdd05d17a2b. The JVM backend doesn't generate null-checks in SAM wrapper constructors, but that's because it does a null check around each call to such a constructor.