### PR TITLE
Allow running Chrome headless with '--no-sandbox' flag

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/karma/KotlinKarma.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/karma/KotlinKarma.kt
@@ -148,6 +148,16 @@ class KotlinKarma(
 
     fun useChromeHeadless() = useChromeLike("ChromeHeadless")
 
+    fun useChromeHeadlessNoSandbox() {
+        val chromeHeadlessNoSandbox = "ChromeHeadlessNoSandbox"
+
+        config.customLaunchers[chromeHeadlessNoSandbox] = CustomLauncher("ChromeHeadless").apply {
+            flags.add("--no-sandbox")
+        }
+
+        useChromeLike(chromeHeadlessNoSandbox)
+    }
+
     fun useChromium() = useChromeLike("Chromium")
 
     fun useChromiumHeadless() = useChromeLike("ChromiumHeadless")


### PR DESCRIPTION
Without this, one has to define a file like `karma.config.d/karma.conf.js`
with contents:

```js
config.set({
    browsers: ['ChromeHeadlessNoSandbox'],

    customLaunchers: {
        ChromeHeadlessNoSandbox: {
            base: 'ChromeHeadless',
            // Needed to work on Jenkins. Otherwise, there's an error:
            // 'Running as root without --no-sandbox is not supported. See https://crbug.com/638180.'
            flags: ['--no-sandbox'],
        }
    }
});
```

This change allows staying 100% in Gradle config for such configuration.
With growing usage of Kubernetes, this flag becomes more and more
popular.

Ideally the Karma config API in Gradle could be more flexible, so that
e.g. someone that uses Chromium could also use `--no-sandbox` flag.
However, it's some bigger change that influnces the API, so I want this
change to be simple.

Related Slack thread: https://kotlinlang.slack.com/archives/C0B8L3U69/p1639133380172400