### PR TITLE
KT-48594: Preserve symlinks during framework copy

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/AppleFrameworkIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/AppleFrameworkIT.kt
@@ -79,6 +79,32 @@ class AppleFrameworkIT : BaseGradleIT() {
     }
 
     @Test
+    fun `check that macOS framework has symlinks`() {
+        with(Project("sharedAppleFramework")) {
+            val options: BuildOptions = defaultBuildOptions().copy(
+                customEnvironmentVariables = mapOf(
+                    "CONFIGURATION" to "debug",
+                    "SDK_NAME" to "macosx",
+                    "ARCHS" to "x86_64",
+                    "EXPANDED_CODE_SIGN_IDENTITY" to "-",
+                    "TARGET_BUILD_DIR" to workingDir.absolutePath,
+                    "FRAMEWORKS_FOLDER_PATH" to "${projectName}/build/xcode-derived"
+                )
+            )
+            build(":shared:embedAndSignAppleFrameworkForXcode", options = options) {
+                assertSuccessful()
+                assertTasksExecuted(":shared:assembleDebugAppleFrameworkForXcodeMacosX64")
+                // Verify symlinks in gradle build folder
+                assertFileExists("/shared/build/xcode-frameworks/debug/macosx/sdk.framework/Headers")
+                assertFileIsSymlink("/shared/build/xcode-frameworks/debug/macosx/sdk.framework/Headers")
+                // Verify symlinks in xcode derived folder
+                assertFileExists("/build/xcode-derived/sdk.framework/Headers")
+                assertFileIsSymlink("/build/xcode-derived/sdk.framework/Headers")
+            }
+        }
+    }
+
+    @Test
     fun `check embedAndSignAppleFrameworkForXcode fail`() {
         with(Project("sharedAppleFramework")) {
             build(":shared:embedAndSignAppleFrameworkForXcode") {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BaseGradleIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BaseGradleIT.kt
@@ -31,6 +31,7 @@ import org.junit.Assert
 import org.junit.Before
 import org.junit.runner.RunWith
 import java.io.File
+import java.nio.file.Files
 import java.util.regex.Pattern
 import kotlin.io.path.isDirectory
 import kotlin.test.*
@@ -556,6 +557,11 @@ abstract class BaseGradleIT {
 
     fun CompiledProject.assertFileExists(path: String = ""): CompiledProject {
         assertTrue(fileInWorkingDir(path).exists(), "The file [$path] does not exist.")
+        return this
+    }
+
+    fun CompiledProject.assertFileIsSymlink(path: String = ""): CompiledProject {
+        assertTrue(Files.isSymbolicLink(fileInWorkingDir(path).toPath()), "The file [$path] isn't a symlink.")
         return this
     }
 

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/sharedAppleFramework/shared/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/sharedAppleFramework/shared/build.gradle.kts
@@ -6,10 +6,11 @@ plugins {
 kotlin {
     android()
 
+    val macosX64 = macosX64()
     val iosX64 = iosX64()
     val iosSimulatorArm64 = iosSimulatorArm64()
     val iosArm64 = iosArm64()
-    configure(listOf(iosX64, iosSimulatorArm64, iosArm64))  {
+    configure(listOf(macosX64, iosX64, iosSimulatorArm64, iosArm64))  {
         binaries {
             framework {
                 baseName = "sdk"

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/sharedAppleFramework/shared/src/macosX64Main/kotlin/com/github/jetbrains/myapplication/Platform.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/sharedAppleFramework/shared/src/macosX64Main/kotlin/com/github/jetbrains/myapplication/Platform.kt
@@ -1,0 +1,5 @@
+package com.github.jetbrains.myapplication
+
+actual class Platform actual constructor() {
+    actual val platform: String = "macOS"
+}


### PR DESCRIPTION
The Gradle `Copy` tasks which are currently used to copy the Xcode frameworks erase the symlinks within those frameworks.
This results in failing macOS app build (see [KT-48594](https://youtrack.jetbrains.com/issue/KT-48594)).

This can be fixed by using the `cp -R` command, which doesn't follow symlinks but copies them instead.
Though `cp` doesn't support copying symlinks that already exists, so `rm -r` is used to make sure the destination files don't exist.