### PR TITLE
KT-50306: Make extra plugin dependencies available to scripts

### DIFF
--- a/libraries/tools/kotlin-maven-plugin-test/src/it/test-executeKotlinScriptWithDependencies/pom.xml
+++ b/libraries/tools/kotlin-maven-plugin-test/src/it/test-executeKotlinScriptWithDependencies/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.jetbrains.kotlin</groupId>
+    <artifactId>test-executeKotlinScriptWithDependencies</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+        <plugins>
+            <plugin>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <version>${kotlin.version}</version>
+                <executions>
+                    <execution>
+                        <id>execute-kotlin-script</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>script</goal>
+                        </goals>
+                        <configuration>
+                            <scriptFile>script.kts</scriptFile>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <!-- This is an arbitrary artifact that's not otherwise in the script's classpath -->
+                    <dependency>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                        <version>4.13.1</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/libraries/tools/kotlin-maven-plugin-test/src/it/test-executeKotlinScriptWithDependencies/script.kts
+++ b/libraries/tools/kotlin-maven-plugin-test/src/it/test-executeKotlinScriptWithDependencies/script.kts
@@ -1,0 +1,3 @@
+import org.junit.Assert
+
+println("Dependency jar is: ${Assert::class.java.getProtectionDomain().getCodeSource().getLocation().getPath().replace(Regex(".*/"), "")}")

--- a/libraries/tools/kotlin-maven-plugin-test/src/it/test-executeKotlinScriptWithDependencies/verify.bsh
+++ b/libraries/tools/kotlin-maven-plugin-test/src/it/test-executeKotlinScriptWithDependencies/verify.bsh
@@ -1,0 +1,3 @@
+source(new File(basedir, "../../../verify-common.bsh").getAbsolutePath());
+
+assertBuildLogHasLine("Dependency jar is: junit-4.13.1.jar");

--- a/libraries/tools/kotlin-maven-plugin/src/main/java/org/jetbrains/kotlin/maven/ExecuteKotlinScriptMojo.java
+++ b/libraries/tools/kotlin-maven-plugin/src/main/java/org/jetbrains/kotlin/maven/ExecuteKotlinScriptMojo.java
@@ -247,7 +247,7 @@ public class ExecuteKotlinScriptMojo extends AbstractMojo {
     }
 
     private List<File> getThisPluginDependencies() {
-        return plugin.getDependencies().stream().map(this::getDependencyFile).collect(Collectors.toList());
+        return plugin.getArtifacts().stream().map(this::getArtifactFile).collect(Collectors.toList());
     }
 
     private File getThisPluginAsDependency() {


### PR DESCRIPTION
I'd expect to be able to add dependencies to a script using the `kotlin-maven-plugin`'s classpath. This PR includes a test for that behaviour, and a change to make it pass.
