### PR TITLE
[FE] Do not repeatedly load inner classes from class files.

### DIFF
--- a/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinCliJavaFileManagerImpl.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinCliJavaFileManagerImpl.kt
@@ -100,7 +100,7 @@ class KotlinCliJavaFileManagerImpl(private val myPsiManager: PsiManager) : CoreJ
                 classId.outerClassId?.let { outerClassId ->
                     val outerClass = outerClassFromRequest ?: findClass(outerClassId, searchScope)
 
-                    return if (outerClass is BinaryJavaClass)
+                    return@getOrPut if (outerClass is BinaryJavaClass)
                         outerClass.findInnerClass(classId.shortClassName, classFileContentFromRequest)
                     else
                         outerClass?.findInnerClass(classId.shortClassName)


### PR DESCRIPTION
Java protobufs generate a lot of inner classes and when compiling
Kotlin wrappers for those Java protobufs the inner classes can
be loaded hundreds of times leading to out of memory. This change
avoids reloading.