### PR TITLE
[Native] Escape the module name in the C adapter.

### DIFF
--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CAdapterGenerator.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CAdapterGenerator.kt
@@ -521,7 +521,7 @@ private fun ModuleDescriptor.getPackageFragments(): List<PackageFragmentDescript
 internal class CAdapterGenerator(val context: Context) : DeclarationDescriptorVisitor<Boolean, Void?> {
 
     private val scopes = mutableListOf<ExportedElementScope>()
-    internal val prefix = context.config.fullExportedNamePrefix
+    internal val prefix = context.config.fullExportedNamePrefix.replace("-|\\.".toRegex(), "_")
     private lateinit var outputStreamWriter: PrintWriter
     private val paramNamesRecorded = mutableMapOf<String, Int>()
 


### PR DESCRIPTION
This previously failed if the module name contaned dots or dashes, e.g.

```
kotlinc-native ~/test.kt -produce static -module-name="foo-bar.baz"
```

This change espaces `-` and `.` similar to `ObjCExportNamer`'s `abbreviate`.