### PR TITLE
[chore] use template literal instead of '+' operator

### DIFF
--- a/libraries/examples/annotation-processor-example/src/main/kotlin/example/ExampleAnnotationProcessor.kt
+++ b/libraries/examples/annotation-processor-example/src/main/kotlin/example/ExampleAnnotationProcessor.kt
@@ -54,7 +54,7 @@ class ExampleAnnotationProcessor : AbstractProcessor() {
                         simpleName.replaceFirstChar(Char::uppercaseChar) +
                         generatedFileSuffix
 
-            filer.createSourceFile(packageName + '.' + generatedJavaClassName).openWriter().use {
+            filer.createSourceFile("$packageName.$generatedJavaClassName").openWriter().use {
                 with(it) {
                     appendLine("package $packageName;")
                     appendLine("public final class $generatedJavaClassName {}")


### PR DESCRIPTION
fix compiler warning of "'String' concatenation can be converted to a template".