### PR TITLE
JVM IR: generate less bytecode for for-loops if possible(KT-22334)

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -34166,6 +34166,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         }
 
         @Test
+        @TestMetadata("forInRangeWithUpperBoundMinus1.kt")
+        public void testForInRangeWithUpperBoundMinus1() throws Exception {
+            runTest("compiler/testData/codegen/box/ranges/forInRangeWithUpperBoundMinus1.kt");
+        }
+
+        @Test
         @TestMetadata("forInStringVarUpdatedInLoopBody.kt")
         public void testForInStringVarUpdatedInLoopBody() throws Exception {
             runTest("compiler/testData/codegen/box/ranges/forInStringVarUpdatedInLoopBody.kt");

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBytecodeTextTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBytecodeTextTestGenerated.java
@@ -2807,6 +2807,130 @@ public class FirBytecodeTextTestGenerated extends AbstractFirBytecodeTextTest {
         }
 
         @Nested
+        @TestMetadata("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1")
+        @TestDataPath("$PROJECT_ROOT")
+        public class ForInRangeWithUpperBoundMinus1 {
+            @Test
+            public void testAllFilesPresentInForInRangeWithUpperBoundMinus1() throws Exception {
+                KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+            }
+
+            @Test
+            @TestMetadata("booleanArray.kt")
+            public void testBooleanArray() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/booleanArray.kt");
+            }
+
+            @Test
+            @TestMetadata("byteArray.kt")
+            public void testByteArray() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/byteArray.kt");
+            }
+
+            @Test
+            @TestMetadata("charArray.kt")
+            public void testCharArray() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/charArray.kt");
+            }
+
+            @Test
+            @TestMetadata("charSequence.kt")
+            public void testCharSequence() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/charSequence.kt");
+            }
+
+            @Test
+            @TestMetadata("doubleArray.kt")
+            public void testDoubleArray() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/doubleArray.kt");
+            }
+
+            @Test
+            @TestMetadata("emptyList.kt")
+            public void testEmptyList() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/emptyList.kt");
+            }
+
+            @Test
+            @TestMetadata("emptyMap.kt")
+            public void testEmptyMap() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/emptyMap.kt");
+            }
+
+            @Test
+            @TestMetadata("emptySet.kt")
+            public void testEmptySet() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/emptySet.kt");
+            }
+
+            @Test
+            @TestMetadata("floatArray.kt")
+            public void testFloatArray() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/floatArray.kt");
+            }
+
+            @Test
+            @TestMetadata("intArray.kt")
+            public void testIntArray() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/intArray.kt");
+            }
+
+            @Test
+            @TestMetadata("list.kt")
+            public void testList() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/list.kt");
+            }
+
+            @Test
+            @TestMetadata("longArray.kt")
+            public void testLongArray() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/longArray.kt");
+            }
+
+            @Test
+            @TestMetadata("map.kt")
+            public void testMap() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/map.kt");
+            }
+
+            @Test
+            @TestMetadata("mutableList.kt")
+            public void testMutableList() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/mutableList.kt");
+            }
+
+            @Test
+            @TestMetadata("mutableMap.kt")
+            public void testMutableMap() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/mutableMap.kt");
+            }
+
+            @Test
+            @TestMetadata("mutableSet.kt")
+            public void testMutableSet() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/mutableSet.kt");
+            }
+
+            @Test
+            @TestMetadata("set.kt")
+            public void testSet() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/set.kt");
+            }
+
+            @Test
+            @TestMetadata("shortArray.kt")
+            public void testShortArray() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/shortArray.kt");
+            }
+
+            @Test
+            @TestMetadata("string.kt")
+            public void testString() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/string.kt");
+            }
+        }
+
+        @Nested
         @TestMetadata("compiler/testData/codegen/bytecodeText/forLoop/forInReversed")
         @TestDataPath("$PROJECT_ROOT")
         public class ForInReversed {

--- a/compiler/testData/codegen/box/ranges/forInRangeWithUpperBoundMinus1.kt
+++ b/compiler/testData/codegen/box/ranges/forInRangeWithUpperBoundMinus1.kt
@@ -1,0 +1,227 @@
+// TARGET_BACKEND: JVM_IR
+// WITH_STDLIB
+
+fun box(): String {
+    noUnderflow()
+    testByteArray()
+    testCharArray()
+    testShortArray()
+    testIntArray()
+    testLongArray()
+    testFloatArray()
+    testDoubleArray()
+    testBooleanArray()
+    testEmptyList()
+    testList()
+    testMutableList()
+    testCharSequence()
+    testString()
+    testEmptySet()
+    testSet()
+    testMutableSet()
+    testEmptyMap()
+    testMap()
+    testMutableMap()
+    return "OK"
+}
+
+fun noUnderflow() {
+    val M1 = Int.MAX_VALUE - 2
+    val M2 = Int.MIN_VALUE
+    var t = 0
+    for (x in M1..M2 - 1) {
+        ++t
+        assert(t <= 3) { "Failed: too many iterations" }
+    }
+    assert(t == 3) { "Failed: t=$t" }
+}
+
+fun testByteArray() {
+    val array = byteArrayOf(1, 2, 3)
+    val range = array.size - 1
+    var optimized = 0
+    var nonOptimized = 0
+    for (i in 0..array.size - 1) optimized += array[i]
+    for (i in 0..range) nonOptimized += array[i]
+    assert(optimized == nonOptimized) { "optimized($optimized) and nonOptimized($nonOptimized) should be equal" }
+}
+
+fun testCharArray() {
+    val array = charArrayOf('1', '2', '3')
+    val range = array.size - 1
+    var optimized = ""
+    var nonOptimized = ""
+    for (i in 0..array.size - 1) optimized += array[i]
+    for (i in 0..range) nonOptimized += array[i]
+    assert(optimized == nonOptimized) { "optimized($optimized) and nonOptimized($nonOptimized) should be equal" }
+}
+
+fun testShortArray() {
+    val array = shortArrayOf(1, 2, 3)
+    val range = array.size - 1
+    var optimized = 0
+    var nonOptimized = 0
+    for (i in 0..array.size - 1) optimized += array[i]
+    for (i in 0..range) nonOptimized += array[i]
+    assert(optimized == nonOptimized) { "optimized($optimized) and nonOptimized($nonOptimized) should be equal" }
+}
+
+fun testIntArray() {
+    val array = intArrayOf(1, 2, 3)
+    val range = array.size - 1
+    var optimized = 0
+    var nonOptimized = 0
+    for (i in 0..array.size - 1) optimized += array[i]
+    for (i in 0..range) nonOptimized += array[i]
+    assert(optimized == nonOptimized) { "optimized($optimized) and nonOptimized($nonOptimized) should be equal" }
+}
+
+fun testLongArray() {
+    val array = longArrayOf(1, 2, 3)
+    val range = array.size - 1
+    var optimized = 0L
+    var nonOptimized = 0L
+    for (i in 0..array.size - 1) optimized += array[i]
+    for (i in 0..range) nonOptimized += array[i]
+    assert(optimized == nonOptimized) { "optimized($optimized) and nonOptimized($nonOptimized) should be equal" }
+}
+
+fun testFloatArray() {
+    val array = floatArrayOf(1f, 2f, 3f)
+    val range = array.size - 1
+    var optimized = 0f
+    var nonOptimized = 0f
+    for (i in 0..array.size - 1) optimized += array[i]
+    for (i in 0..range) nonOptimized += array[i]
+    assert(optimized == nonOptimized) { "optimized($optimized) and nonOptimized($nonOptimized) should be equal" }
+}
+
+fun testDoubleArray() {
+    val array = doubleArrayOf(1.0, 2.0, 3.0)
+    val range = array.size - 1
+    var optimized = 0.0
+    var nonOptimized = 0.0
+    for (i in 0..array.size - 1) optimized += array[i]
+    for (i in 0..range) nonOptimized += array[i]
+    assert(optimized == nonOptimized) { "optimized($optimized) and nonOptimized($nonOptimized) should be equal" }
+}
+
+fun testBooleanArray() {
+    val array = booleanArrayOf(true, false, true)
+    val range = array.size - 1
+    var optimized = ""
+    var nonOptimized = ""
+    for (i in 0..array.size - 1) optimized += array[i]
+    for (i in 0..range) nonOptimized += array[i]
+    assert(optimized == nonOptimized) { "optimized($optimized) and nonOptimized($nonOptimized) should be equal" }
+}
+
+fun testEmptyList() {
+    val list = emptyList<Int>()
+    val range = list.size - 1
+    var optimized = 0
+    var nonOptimized = 0
+    for (i in 0..list.size - 1) optimized += list[i]
+    for (i in 0..range) nonOptimized += list[i]
+    assert(optimized == nonOptimized) { "optimized($optimized) and nonOptimized($nonOptimized) should be equal" }
+}
+
+fun testList() {
+    val list = listOf(1, 2, 3)
+    val range = list.size - 1
+    var optimized = 0
+    var nonOptimized = 0
+    for (i in 0..list.size - 1) optimized += list[i]
+    for (i in 0..range) nonOptimized += list[i]
+    assert(optimized == nonOptimized) { "optimized($optimized) and nonOptimized($nonOptimized) should be equal" }
+}
+
+fun testMutableList() {
+    val list = mutableListOf(1, 2, 3)
+    val range = list.size - 1
+    var optimized = 0
+    var nonOptimized = 0
+    for (i in 0..list.size - 1) optimized += list[i]
+    for (i in 0..range) nonOptimized += list[i]
+    assert(optimized == nonOptimized) { "optimized($optimized) and nonOptimized($nonOptimized) should be equal" }
+}
+
+fun testCharSequence() {
+    val chars: CharSequence = "123"
+    val range = chars.length - 1
+    var optimized = ""
+    var nonOptimized = ""
+    for (i in 0..chars.length - 1) optimized += chars[i]
+    for (i in 0..range) nonOptimized += chars[i]
+    assert(optimized == nonOptimized) { "optimized($optimized) and nonOptimized($nonOptimized) should be equal" }
+}
+
+fun testString() {
+    val str = "123"
+    val range = str.length - 1
+    var optimized = ""
+    var nonOptimized = ""
+    for (i in 0..str.length - 1) optimized += str[i]
+    for (i in 0..range) nonOptimized += str[i]
+    assert(optimized == nonOptimized) { "optimized($optimized) and nonOptimized($nonOptimized) should be equal" }
+}
+
+fun testEmptySet() {
+    val set = emptySet<Int>()
+    val range = set.size - 1
+    var optimized = ""
+    var nonOptimized = ""
+    for (i in 0..set.size - 1) optimized += set.elementAt(i)
+    for (i in 0..range) nonOptimized += set.elementAt(i)
+    assert(optimized == nonOptimized) { "optimized($optimized) and nonOptimized($nonOptimized) should be equal" }
+}
+
+fun testSet() {
+    val set = setOf(1, 2, 3)
+    val range = set.size - 1
+    var optimized = ""
+    var nonOptimized = ""
+    for (i in 0..set.size - 1) optimized += set.elementAt(i)
+    for (i in 0..range) nonOptimized += set.elementAt(i)
+    assert(optimized == nonOptimized) { "optimized($optimized) and nonOptimized($nonOptimized) should be equal" }
+}
+
+fun testMutableSet() {
+    val set = mutableSetOf(1, 2, 3)
+    val range = set.size - 1
+    var optimized = ""
+    var nonOptimized = ""
+    for (i in 0..set.size - 1) optimized += set.elementAt(i)
+    for (i in 0..range) nonOptimized += set.elementAt(i)
+    assert(optimized == nonOptimized) { "optimized($optimized) and nonOptimized($nonOptimized) should be equal" }
+}
+
+fun testEmptyMap() {
+    val map = emptyMap<Int, Int>()
+    val range = map.size - 1
+    var optimized = ""
+    var nonOptimized = ""
+    for (i in 0..map.size - 1) optimized += map[i]
+    for (i in 0..range) nonOptimized += map[i]
+    assert(optimized == nonOptimized) { "optimized($optimized) and nonOptimized($nonOptimized) should be equal" }
+}
+
+fun testMap() {
+    val map = mapOf(1 to 1, 2 to 2, 3 to 3)
+    val range = map.size - 1
+    var optimized = ""
+    var nonOptimized = ""
+    for (i in 0..map.size - 1) optimized += map[i]
+    for (i in 0..range) nonOptimized += map[i]
+    assert(optimized == nonOptimized) { "optimized($optimized) and nonOptimized($nonOptimized) should be equal" }
+}
+
+fun testMutableMap() {
+    val map = mutableMapOf(1 to 1, 2 to 2, 3 to 3)
+    val range = map.size - 1
+    var optimized = ""
+    var nonOptimized = ""
+    for (i in 0..map.size - 1) optimized += map[i]
+    for (i in 0..range) nonOptimized += map[i]
+    assert(optimized == nonOptimized) { "optimized($optimized) and nonOptimized($nonOptimized) should be equal" }
+}

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeSpecializedToUntil.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeSpecializedToUntil.kt
@@ -22,11 +22,12 @@ fun test(): Int {
 // 1 IF
 
 // JVM_IR_TEMPLATES
-// 1 IF_ICMPGT
-// 1 IF_ICMPEQ
-// 2 IF
-// 7 ILOAD
+// 0 IF_ICMPGT
+// 1 IF_ICMPGE
+// 0 IF_ICMPEQ
+// 1 IF
+// 5 ILOAD
 // 4 ISTORE
 // 1 IINC
 // 1 IADD
-// 1 ISUB
+// 0 ISUB

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/booleanArray.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/booleanArray.kt
@@ -1,0 +1,15 @@
+// TARGET_BACKEND: JVM_IR
+
+fun test() {
+    val array = booleanArrayOf(true, false, true)
+    var optimized = ""
+    for (i in 0..array.size - 1) optimized += array[i]
+}
+
+// 0 IF_ICMPGT
+// 1 IF_ICMPGE
+// 0 IADD
+// 0 ISUB
+// 3 ILOAD
+// 2 ISTORE
+// 1 IINC

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/byteArray.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/byteArray.kt
@@ -1,0 +1,15 @@
+// TARGET_BACKEND: JVM_IR
+
+fun test() {
+    val array = byteArrayOf(1, 2, 3)
+    var optimized = 0
+    for (i in 0..array.size - 1) optimized += array[i]
+}
+
+// 0 IF_ICMPGT
+// 1 IF_ICMPGE
+// 1 IADD
+// 0 ISUB
+// 4 ILOAD
+// 4 ISTORE
+// 1 IINC

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/charArray.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/charArray.kt
@@ -1,0 +1,15 @@
+// TARGET_BACKEND: JVM_IR
+
+fun test() {
+    val array = charArrayOf('1', '2', '3')
+    var optimized = ""
+    for (i in 0..array.size - 1) optimized += array[i]
+}
+
+// 0 IF_ICMPGT
+// 1 IF_ICMPGE
+// 0 IADD
+// 0 ISUB
+// 3 ILOAD
+// 2 ISTORE
+// 1 IINC

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/charSequence.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/charSequence.kt
@@ -1,0 +1,15 @@
+// TARGET_BACKEND: JVM_IR
+
+fun test() {
+    val chars: CharSequence = "123"
+    var optimized = ""
+    for (i in 0..chars.length - 1) optimized += chars[i]
+}
+
+// 0 IF_ICMPGT
+// 1 IF_ICMPGE
+// 0 IADD
+// 0 ISUB
+// 3 ILOAD
+// 2 ISTORE
+// 1 IINC

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/doubleArray.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/doubleArray.kt
@@ -1,0 +1,15 @@
+// TARGET_BACKEND: JVM_IR
+
+fun test() {
+    val array = doubleArrayOf(1.0, 2.0, 3.0)
+    var optimized = 0.0
+    for (i in 0..array.size - 1) optimized += array[i]
+}
+
+// 0 IF_ICMPGT
+// 1 IF_ICMPGE
+// 0 IADD
+// 0 ISUB
+// 3 ILOAD
+// 2 ISTORE
+// 1 IINC

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/emptyList.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/emptyList.kt
@@ -1,0 +1,15 @@
+// TARGET_BACKEND: JVM_IR
+
+fun test() {
+    val list = emptyList<Int>()
+    var optimized = 0
+    for (i in 0..list.size - 1) optimized += list[i]
+}
+
+// 0 IF_ICMPGT
+// 1 IF_ICMPGE
+// 1 IADD
+// 0 ISUB
+// 4 ILOAD
+// 4 ISTORE
+// 1 IINC

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/emptyMap.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/emptyMap.kt
@@ -1,0 +1,15 @@
+// TARGET_BACKEND: JVM_IR
+
+fun test() {
+    val map = emptyMap<Int, Int>()
+    var optimized = ""
+    for (i in 0..map.size - 1) optimized += map[i]
+}
+
+// 0 IF_ICMPGT
+// 1 IF_ICMPGE
+// 0 IADD
+// 0 ISUB
+// 3 ILOAD
+// 2 ISTORE
+// 1 IINC

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/emptySet.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/emptySet.kt
@@ -1,0 +1,15 @@
+// TARGET_BACKEND: JVM_IR
+
+fun test() {
+    val set = emptySet<Int>()
+    var optimized = ""
+    for (i in 0..set.size - 1) optimized += set.elementAt(i)
+}
+
+// 0 IF_ICMPGT
+// 1 IF_ICMPGE
+// 0 IADD
+// 0 ISUB
+// 3 ILOAD
+// 2 ISTORE
+// 1 IINC

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/floatArray.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/floatArray.kt
@@ -1,0 +1,15 @@
+// TARGET_BACKEND: JVM_IR
+
+fun test() {
+    val array = floatArrayOf(1f, 2f, 3f)
+    var optimized = 0f
+    for (i in 0..array.size - 1) optimized += array[i]
+}
+
+// 0 IF_ICMPGT
+// 1 IF_ICMPGE
+// 0 IADD
+// 0 ISUB
+// 3 ILOAD
+// 2 ISTORE
+// 1 IINC

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/intArray.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/intArray.kt
@@ -1,0 +1,15 @@
+// TARGET_BACKEND: JVM_IR
+
+fun test() {
+    val array = intArrayOf(1, 2, 3)
+    var optimized = 0
+    for (i in 0..array.size - 1) optimized += array[i]
+}
+
+// 0 IF_ICMPGT
+// 1 IF_ICMPGE
+// 1 IADD
+// 0 ISUB
+// 4 ILOAD
+// 4 ISTORE
+// 1 IINC

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/list.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/list.kt
@@ -1,0 +1,15 @@
+// TARGET_BACKEND: JVM_IR
+
+fun test() {
+    val list = listOf(1, 2, 3)
+    var optimized = 0
+    for (i in 0..list.size - 1) optimized += list[i]
+}
+
+// 0 IF_ICMPGT
+// 1 IF_ICMPGE
+// 1 IADD
+// 0 ISUB
+// 4 ILOAD
+// 4 ISTORE
+// 1 IINC

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/longArray.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/longArray.kt
@@ -1,0 +1,15 @@
+// TARGET_BACKEND: JVM_IR
+
+fun test() {
+    val array = longArrayOf(1, 2, 3)
+    var optimized = 0L
+    for (i in 0..array.size - 1) optimized += array[i]
+}
+
+// 0 IF_ICMPGT
+// 1 IF_ICMPGE
+// 0 IADD
+// 0 ISUB
+// 3 ILOAD
+// 2 ISTORE
+// 1 IINC

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/map.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/map.kt
@@ -1,0 +1,15 @@
+// TARGET_BACKEND: JVM_IR
+
+fun test() {
+    val map = mapOf(1 to 1, 2 to 2, 3 to 3)
+    var optimized = ""
+    for (i in 0..map.size - 1) optimized += map[i]
+}
+
+// 0 IF_ICMPGT
+// 1 IF_ICMPGE
+// 0 IADD
+// 0 ISUB
+// 3 ILOAD
+// 2 ISTORE
+// 1 IINC

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/mutableList.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/mutableList.kt
@@ -1,0 +1,15 @@
+// TARGET_BACKEND: JVM_IR
+
+fun test() {
+    val list = mutableListOf(1, 2, 3)
+    var optimized = 0
+    for (i in 0..list.size - 1) optimized += list[i]
+}
+
+// 0 IF_ICMPGT
+// 1 IF_ICMPGE
+// 1 IADD
+// 0 ISUB
+// 4 ILOAD
+// 4 ISTORE
+// 1 IINC

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/mutableMap.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/mutableMap.kt
@@ -1,0 +1,15 @@
+// TARGET_BACKEND: JVM_IR
+
+fun test() {
+    val map = mutableMapOf(1 to 1, 2 to 2, 3 to 3)
+    var optimized = ""
+    for (i in 0..map.size - 1) optimized += map[i]
+}
+
+// 0 IF_ICMPGT
+// 1 IF_ICMPGE
+// 0 IADD
+// 0 ISUB
+// 3 ILOAD
+// 2 ISTORE
+// 1 IINC

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/mutableSet.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/mutableSet.kt
@@ -1,0 +1,15 @@
+// TARGET_BACKEND: JVM_IR
+
+fun test() {
+    val set = mutableSetOf(1, 2, 3)
+    var optimized = ""
+    for (i in 0..set.size - 1) optimized += set.elementAt(i)
+}
+
+// 0 IF_ICMPGT
+// 1 IF_ICMPGE
+// 0 IADD
+// 0 ISUB
+// 3 ILOAD
+// 2 ISTORE
+// 1 IINC

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/set.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/set.kt
@@ -1,0 +1,15 @@
+// TARGET_BACKEND: JVM_IR
+
+fun test() {
+    val set = setOf(1, 2, 3)
+    var optimized = ""
+    for (i in 0..set.size - 1) optimized += set.elementAt(i)
+}
+
+// 0 IF_ICMPGT
+// 1 IF_ICMPGE
+// 0 IADD
+// 0 ISUB
+// 3 ILOAD
+// 2 ISTORE
+// 1 IINC

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/shortArray.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/shortArray.kt
@@ -1,0 +1,15 @@
+// TARGET_BACKEND: JVM_IR
+
+fun test() {
+    val array = shortArrayOf(1, 2, 3)
+    var optimized = 0
+    for (i in 0..array.size - 1) optimized += array[i]
+}
+
+// 0 IF_ICMPGT
+// 1 IF_ICMPGE
+// 1 IADD
+// 0 ISUB
+// 4 ILOAD
+// 4 ISTORE
+// 1 IINC

--- a/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/string.kt
+++ b/compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/string.kt
@@ -1,0 +1,15 @@
+// TARGET_BACKEND: JVM_IR
+
+fun test() {
+    val str = "123"
+    var optimized = ""
+    for (i in 0..str.length - 1) optimized += str[i]
+}
+
+// 0 IF_ICMPGT
+// 1 IF_ICMPGE
+// 0 IADD
+// 0 ISUB
+// 3 ILOAD
+// 2 ISTORE
+// 1 IINC

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BytecodeTextTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BytecodeTextTestGenerated.java
@@ -2777,6 +2777,16 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
         }
 
         @Nested
+        @TestMetadata("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1")
+        @TestDataPath("$PROJECT_ROOT")
+        public class ForInRangeWithUpperBoundMinus1 {
+            @Test
+            public void testAllFilesPresentInForInRangeWithUpperBoundMinus1() throws Exception {
+                KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM, true);
+            }
+        }
+
+        @Nested
         @TestMetadata("compiler/testData/codegen/bytecodeText/forLoop/forInReversed")
         @TestDataPath("$PROJECT_ROOT")
         public class ForInReversed {

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -34166,6 +34166,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         }
 
         @Test
+        @TestMetadata("forInRangeWithUpperBoundMinus1.kt")
+        public void testForInRangeWithUpperBoundMinus1() throws Exception {
+            runTest("compiler/testData/codegen/box/ranges/forInRangeWithUpperBoundMinus1.kt");
+        }
+
+        @Test
         @TestMetadata("forInStringVarUpdatedInLoopBody.kt")
         public void testForInStringVarUpdatedInLoopBody() throws Exception {
             runTest("compiler/testData/codegen/box/ranges/forInStringVarUpdatedInLoopBody.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBytecodeTextTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBytecodeTextTestGenerated.java
@@ -2807,6 +2807,130 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
         }
 
         @Nested
+        @TestMetadata("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1")
+        @TestDataPath("$PROJECT_ROOT")
+        public class ForInRangeWithUpperBoundMinus1 {
+            @Test
+            public void testAllFilesPresentInForInRangeWithUpperBoundMinus1() throws Exception {
+                KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+            }
+
+            @Test
+            @TestMetadata("booleanArray.kt")
+            public void testBooleanArray() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/booleanArray.kt");
+            }
+
+            @Test
+            @TestMetadata("byteArray.kt")
+            public void testByteArray() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/byteArray.kt");
+            }
+
+            @Test
+            @TestMetadata("charArray.kt")
+            public void testCharArray() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/charArray.kt");
+            }
+
+            @Test
+            @TestMetadata("charSequence.kt")
+            public void testCharSequence() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/charSequence.kt");
+            }
+
+            @Test
+            @TestMetadata("doubleArray.kt")
+            public void testDoubleArray() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/doubleArray.kt");
+            }
+
+            @Test
+            @TestMetadata("emptyList.kt")
+            public void testEmptyList() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/emptyList.kt");
+            }
+
+            @Test
+            @TestMetadata("emptyMap.kt")
+            public void testEmptyMap() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/emptyMap.kt");
+            }
+
+            @Test
+            @TestMetadata("emptySet.kt")
+            public void testEmptySet() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/emptySet.kt");
+            }
+
+            @Test
+            @TestMetadata("floatArray.kt")
+            public void testFloatArray() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/floatArray.kt");
+            }
+
+            @Test
+            @TestMetadata("intArray.kt")
+            public void testIntArray() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/intArray.kt");
+            }
+
+            @Test
+            @TestMetadata("list.kt")
+            public void testList() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/list.kt");
+            }
+
+            @Test
+            @TestMetadata("longArray.kt")
+            public void testLongArray() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/longArray.kt");
+            }
+
+            @Test
+            @TestMetadata("map.kt")
+            public void testMap() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/map.kt");
+            }
+
+            @Test
+            @TestMetadata("mutableList.kt")
+            public void testMutableList() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/mutableList.kt");
+            }
+
+            @Test
+            @TestMetadata("mutableMap.kt")
+            public void testMutableMap() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/mutableMap.kt");
+            }
+
+            @Test
+            @TestMetadata("mutableSet.kt")
+            public void testMutableSet() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/mutableSet.kt");
+            }
+
+            @Test
+            @TestMetadata("set.kt")
+            public void testSet() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/set.kt");
+            }
+
+            @Test
+            @TestMetadata("shortArray.kt")
+            public void testShortArray() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/shortArray.kt");
+            }
+
+            @Test
+            @TestMetadata("string.kt")
+            public void testString() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeText/forLoop/forInRangeWithUpperBoundMinus1/string.kt");
+            }
+        }
+
+        @Nested
         @TestMetadata("compiler/testData/codegen/bytecodeText/forLoop/forInReversed")
         @TestDataPath("$PROJECT_ROOT")
         public class ForInReversed {


### PR DESCRIPTION
issue: https://youtrack.jetbrains.com/issue/KT-22334

following source code
```kotlin
fun test(): Int {
  val intArray = intArrayOf(1, 2, 3)
  var sum = 0
  for (i in 0..intArray.size - 1) {
	  sum += intArray[i]
  }
  return sum
}
```

bytecode comipiled by `kotlin-compiler-1.7.0-dev-225`
```
public static final int test();
    descriptor: ()I
    flags: ACC_PUBLIC, ACC_STATIC, ACC_FINAL
    Code:
      stack=3, locals=4, args_size=0
         0: iconst_3
         1: newarray       int
         3: astore_1
         4: aload_1
         5: iconst_0
         6: iconst_1
         7: iastore
         8: aload_1
         9: iconst_1
        10: iconst_2
        11: iastore
        12: aload_1
        13: iconst_2
        14: iconst_3
        15: iastore
        16: aload_1
        17: astore_0
        18: iconst_0
        19: istore_1
        20: iconst_0
        21: istore_2
        22: aload_0
        23: arraylength
        24: iconst_1
        25: isub
        26: istore_3
        27: iload_2
        28: iload_3
        29: if_icmpgt     49
        32: iload_1
        33: aload_0
        34: iload_2
        35: iaload
        36: iadd
        37: istore_1
        38: iload_2
        39: iload_3
        40: if_icmpeq     49
        43: iinc          2, 1
        46: goto          32
        49: iload_1
        50: ireturn
      StackMapTable: number_of_entries = 2
        frame_type = 255 /* full_frame */
          offset_delta = 32
          locals = [ class "[I", int, int, int ]
          stack = []
        frame_type = 16 /* same */
      LineNumberTable:
        line 2: 0
        line 3: 18
        line 4: 20
        line 5: 32
        line 4: 38
        line 7: 49
      LocalVariableTable:
        Start  Length  Slot  Name   Signature
           22      27     2     i   I
           18      33     0 intArray   [I
           20      31     1   sum   I
```

after this change:
```
public static final int test();
    descriptor: ()I
    flags: ACC_PUBLIC, ACC_STATIC, ACC_FINAL
    Code:
      stack=3, locals=4, args_size=0
         0: iconst_3
         1: newarray       int
         3: astore_1
         4: aload_1
         5: iconst_0
         6: iconst_1
         7: iastore
         8: aload_1
         9: iconst_1
        10: iconst_2
        11: iastore
        12: aload_1
        13: iconst_2
        14: iconst_3
        15: iastore
        16: aload_1
        17: astore_0
        18: iconst_0
        19: istore_1
        20: iconst_0
        21: istore_2
        22: aload_0
        23: arraylength
        24: istore_3
        25: iload_2
        26: iload_3
        27: if_icmpge     42
        30: iload_1
        31: aload_0
        32: iload_2
        33: iaload
        34: iadd
        35: istore_1
        36: iinc          2, 1
        39: goto          25
        42: iload_1
        43: ireturn
      StackMapTable: number_of_entries = 2
        frame_type = 255 /* full_frame */
          offset_delta = 25
          locals = [ class "[I", int, int, int ]
          stack = []
        frame_type = 16 /* same */
      LineNumberTable:
        line 2: 0
        line 3: 18
        line 4: 20
        line 5: 30
        line 4: 36
        line 7: 42
      LocalVariableTable:
        Start  Length  Slot  Name   Signature
           22      20     2     i   I
           18      26     0 intArray   [I
           20      24     1   sum   I
```