### PR TITLE
[IR] Generalize fragment generation logic for wider use

### DIFF
--- a/compiler/ir/backend.jvm/entrypoint/src/org/jetbrains/kotlin/backend/jvm/JvmIrCodegenFactory.kt
+++ b/compiler/ir/backend.jvm/entrypoint/src/org/jetbrains/kotlin/backend/jvm/JvmIrCodegenFactory.kt
@@ -55,6 +55,7 @@ open class JvmIrCodegenFactory(
     private val jvmGeneratorExtensions: JvmGeneratorExtensionsImpl = JvmGeneratorExtensionsImpl(configuration),
     private val prefixPhases: CompilerPhase<JvmBackendContext, IrModuleFragment, IrModuleFragment>? = null,
     private val evaluatorFragmentInfoForPsi2Ir: EvaluatorFragmentInfo? = null,
+    private val shouldStubAndNotLinkUnboundSymbols: Boolean = false,
 ) : CodegenFactory {
     data class JvmIrBackendInput(
         val irModuleFragment: IrModuleFragment,
@@ -159,10 +160,11 @@ open class JvmIrCodegenFactory(
             irLinker.deserializeIrModuleHeader(it, kotlinLibrary, _moduleName = it.name.asString())
         }
 
-        val stubGeneratorForMissingClasses = DeclarationStubGeneratorForNotFoundClasses(stubGenerator)
-        val irProviders = if (evaluatorFragmentInfoForPsi2Ir != null) {
-            listOf(stubGenerator, irLinker, stubGeneratorForMissingClasses)
+
+        val irProviders = if (shouldStubAndNotLinkUnboundSymbols) {
+            listOf(stubGenerator)
         } else {
+            val stubGeneratorForMissingClasses = DeclarationStubGeneratorForNotFoundClasses(stubGenerator)
             listOf(irLinker, stubGeneratorForMissingClasses)
         }
 


### PR DESCRIPTION
Generalize the config specific to evaluator fragment compilation for wider
applicability.

---

I am getting the strangest runtime exception which I have been unable to create a useful repro for: intellij-community/kt-212-master (879c6d432b4ce0051eb3204e674bd0cc86ff5661) _builds_ against this change, but I get a `RuntimeException` reporting that the new constructor does not exist for any code that relies on the presence of the default value for the new constructor parameter:

```
Caused by: java.lang.NoSuchMethodError: 'void org.jetbrains.kotlin.backend.jvm.JvmIrCodegenFactory.<init>(org.jetbrains.kotlin.config.CompilerConfiguration, org.jetbrains.kotlin.backend.common.phaser.PhaseConfig, org.jetbrains.kotlin.ir.backend.jvm.serialization.JvmDescriptorMangler, org.jetbrains.kotlin.ir.util.SymbolTable, org.jetbrains.kotlin.backend.jvm.JvmGeneratorExtensionsImpl, org.jetbrains.kotlin.backend.common.phaser.CompilerPhase, org.jetbrains.kotlin.psi2ir.generators.fragments.EvaluatorFragmentInfo, int, kotlin.jvm.internal.DefaultConstructorMarker)'
	at org.jetbrains.kotlin.idea.codegen.GenerationUtils.generateFiles(GenerationUtils.kt:101)
...
```
I am not familiar enough with the build setup of either project to confirm I am not somehow hitting stale artifacts, but I have not had any indication in the past of that happening.

Could this be a kotlinc error?
