### PR TITLE
Update supported Ktor version in MM migration guide

### DIFF
--- a/kotlin-native/NEW_MM.md
+++ b/kotlin-native/NEW_MM.md
@@ -66,7 +66,7 @@ To take full advantage of the new MM, we released new versions of the following 
     * `newFixedThreadPoolContext` to create a coroutine dispatcher backed by a pool of `N` `Worker`s.
     * `Dispatchers.Main` is backed by the main queue on Darwin and by a standalone `Worker` on other platforms.
       _In unit tests, nothing processes the main thread queue, so do not use `Dispatchers.Main` in unit tests unless it was mocked, which can be done by calling `Dispatchers.setMain` from `kotlinx-coroutines-test`._
-* `ktor`: `1.6.2-native-mm-eap-196` at https://maven.pkg.jetbrains.space/public/p/ktor/eap
+* `ktor`: `1.6.6` at mavenCentral
 
 ### Using previous versions of the libraries
 


### PR DESCRIPTION
Since Ktor `1.6.6`, the new experimental MM is supported.

cc @e5l 

https://github.com/JetBrains/kotlin/pull/4687#issuecomment-1003712844