### PR TITLE
JVM_IR: Generate counter loop for reversed array (KT-22429)

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -1235,6 +1235,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
             }
 
             @Test
+            @TestMetadata("reversedArray.kt")
+            public void testReversedArray() throws Exception {
+                runTest("compiler/testData/codegen/box/arrays/forInReversed/reversedArray.kt");
+            }
+
+            @Test
             @TestMetadata("reversedArrayOriginalUpdatedInLoopBody.kt")
             public void testReversedArrayOriginalUpdatedInLoopBody() throws Exception {
                 runTest("compiler/testData/codegen/box/arrays/forInReversed/reversedArrayOriginalUpdatedInLoopBody.kt");

--- a/compiler/testData/codegen/box/arrays/forInReversed/reversedArray.kt
+++ b/compiler/testData/codegen/box/arrays/forInReversed/reversedArray.kt
@@ -1,0 +1,33 @@
+// TARGET_BACKEND: JVM_IR
+// WITH_STDLIB
+import kotlin.test.*
+
+fun box(): String {
+    testReversed()
+    testReversedArray()
+    return "OK"
+}
+
+fun testReversed() {
+    val arr = intArrayOf(6, 7, 8, 9)
+    var result = ""
+    for (i in arr.reversed()) {
+        arr[0] = 0
+        result += i
+    }
+    assertEquals("9876", result)
+}
+
+fun testReversedArray() {
+    val arr = intArrayOf(6, 7, 8, 9)
+    var result = ""
+    for (i in arr.reversedArray()) {
+        arr[0] = 0
+        result += i
+    }
+    assertEquals("9876", result)
+}
+
+// CHECK_BYTECODE_TEXT
+// 0 java/util/List.iterator
+// 2 IINC

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -1235,6 +1235,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             }
 
             @Test
+            @TestMetadata("reversedArray.kt")
+            public void testReversedArray() throws Exception {
+                runTest("compiler/testData/codegen/box/arrays/forInReversed/reversedArray.kt");
+            }
+
+            @Test
             @TestMetadata("reversedArrayOriginalUpdatedInLoopBody.kt")
             public void testReversedArrayOriginalUpdatedInLoopBody() throws Exception {
                 runTest("compiler/testData/codegen/box/arrays/forInReversed/reversedArrayOriginalUpdatedInLoopBody.kt");


### PR DESCRIPTION
**The change might looks strange becasue:**

1. Current design seems indicates that I should implement this in `ReversedHandler` by adding a new callee with some restrictions.

**But I chosed a different way in this PR because:**

1. I don't see how to proper implement `IndexedGetHeaderInfo.asReverse`
2. It seems follow the same way that how `reversedArray` was optimized to a counter loop. (This PR doesn't do any optimization about `reversedArray`, it seems already optimized by some prevoius commits)

----
**An example to show the difference in bytecode**

source code:
``` kotlin
fun testReversed() {
    val arr = intArrayOf(6, 7, 8, 9)
    var result = ""
    for (i in arr.reversed()) {
        arr[0] = 0
        result += i
    }
}

fun testReversedArray() {
    val arr = intArrayOf(6, 7, 8, 9)
    var result = ""
    for (i in arr.reversedArray()) {
        arr[0] = 0
        result += i
    }
}
```

compiled by `1.6.20-RC-17` :
```java
...
public static final void testReversed();
    descriptor: ()V
    flags: ACC_PUBLIC, ACC_STATIC, ACC_FINAL
    Code:
      stack=3, locals=4, args_size=0
         0: iconst_4
         1: newarray       int
         3: astore_1
         4: aload_1
         5: iconst_0
         6: bipush        6
         8: iastore
         9: aload_1
        10: iconst_1
        11: bipush        7
        13: iastore
        14: aload_1
        15: iconst_2
        16: bipush        8
        18: iastore
        19: aload_1
        20: iconst_3
        21: bipush        9
        23: iastore
        24: aload_1
        25: astore_0
        26: ldc           #8                  // String
        28: astore_1
        29: aload_0
        30: invokestatic  #14                 // Method kotlin/collections/ArraysKt.reversed:([I)Ljava/util/List;
        33: invokeinterface #20,  1           // InterfaceMethod java/util/List.iterator:()Ljava/util/Iterator;
        38: astore_2
        39: aload_2
        40: invokeinterface #26,  1           // InterfaceMethod java/util/Iterator.hasNext:()Z
        45: ifeq          87
        48: aload_2
        49: invokeinterface #30,  1           // InterfaceMethod java/util/Iterator.next:()Ljava/lang/Object;
        54: checkcast     #32                 // class java/lang/Number
        57: invokevirtual #36                 // Method java/lang/Number.intValue:()I
        60: istore_3
        61: aload_0
        62: iconst_0
        63: iconst_0
        64: iastore
        65: new           #38                 // class java/lang/StringBuilder
        68: dup
        69: invokespecial #41                 // Method java/lang/StringBuilder."<init>":()V
        72: aload_1
        73: invokevirtual #45                 // Method java/lang/StringBuilder.append:(Ljava/lang/String;)Ljava/lang/StringBuilder;
        76: iload_3
        77: invokevirtual #48                 // Method java/lang/StringBuilder.append:(I)Ljava/lang/StringBuilder;
        80: invokevirtual #52                 // Method java/lang/StringBuilder.toString:()Ljava/lang/String;
        83: astore_1
        84: goto          39
        87: return
...
...
...
public static final void testReversedArray();
    descriptor: ()V
    flags: ACC_PUBLIC, ACC_STATIC, ACC_FINAL
    Code:
      stack=3, locals=6, args_size=0
         0: iconst_4
         1: newarray       int
         3: astore_1
         4: aload_1
         5: iconst_0
         6: bipush        6
         8: iastore
         9: aload_1
        10: iconst_1
        11: bipush        7
        13: iastore
        14: aload_1
        15: iconst_2
        16: bipush        8
        18: iastore
        19: aload_1
        20: iconst_3
        21: bipush        9
        23: iastore
        24: aload_1
        25: astore_0
        26: ldc           #8                  // String
        28: astore_1
        29: aload_0
        30: invokestatic  #66                 // Method kotlin/collections/ArraysKt.reversedArray:([I)[I
        33: astore_2
        34: iconst_0
        35: istore_3
        36: aload_2
        37: arraylength
        38: istore        4
        40: iload_3
        41: iload         4
        43: if_icmpge     81
        46: aload_2
        47: iload_3
        48: iaload
        49: istore        5
        51: aload_0
        52: iconst_0
        53: iconst_0
        54: iastore
        55: new           #38                 // class java/lang/StringBuilder
        58: dup
        59: invokespecial #41                 // Method java/lang/StringBuilder."<init>":()V
        62: aload_1
        63: invokevirtual #45                 // Method java/lang/StringBuilder.append:(Ljava/lang/String;)Ljava/lang/StringBuilder;
        66: iload         5
        68: invokevirtual #48                 // Method java/lang/StringBuilder.append:(I)Ljava/lang/StringBuilder;
        71: invokevirtual #52                 // Method java/lang/StringBuilder.toString:()Ljava/lang/String;
        74: astore_1
        75: iinc          3, 1
        78: goto          40
        81: return
```

after this change:
```java
public static final void testReversed();
    descriptor: ()V
    flags: ACC_PUBLIC, ACC_STATIC, ACC_FINAL
    Code:
      stack=3, locals=6, args_size=0
         0: iconst_4
         1: newarray       int
         3: astore_1
         4: aload_1
         5: iconst_0
         6: bipush        6
         8: iastore
         9: aload_1
        10: iconst_1
        11: bipush        7
        13: iastore
        14: aload_1
        15: iconst_2
        16: bipush        8
        18: iastore
        19: aload_1
        20: iconst_3
        21: bipush        9
        23: iastore
        24: aload_1
        25: astore_0
        26: ldc           #8                  // String
        28: astore_1
        29: aload_0
        30: invokestatic  #14                 // Method kotlin/collections/ArraysKt.reversed:([I)Ljava/util/List;
        33: astore_2
        34: iconst_0
        35: istore_3
        36: aload_2
        37: invokeinterface #20,  1           // InterfaceMethod java/util/List.size:()I
        42: istore        4
        44: iload_3
        45: iload         4
        47: if_icmpge     95
        50: aload_2
        51: iload_3
        52: invokeinterface #24,  2           // InterfaceMethod java/util/List.get:(I)Ljava/lang/Object;
        57: checkcast     #26                 // class java/lang/Number
        60: invokevirtual #29                 // Method java/lang/Number.intValue:()I
        63: istore        5
        65: aload_0
        66: iconst_0
        67: iconst_0
        68: iastore
        69: new           #31                 // class java/lang/StringBuilder
        72: dup
        73: invokespecial #34                 // Method java/lang/StringBuilder."<init>":()V
        76: aload_1
        77: invokevirtual #38                 // Method java/lang/StringBuilder.append:(Ljava/lang/String;)Ljava/lang/StringBuilder;
        80: iload         5
        82: invokevirtual #41                 // Method java/lang/StringBuilder.append:(I)Ljava/lang/StringBuilder;
        85: invokevirtual #45                 // Method java/lang/StringBuilder.toString:()Ljava/lang/String;
        88: astore_1
        89: iinc          3, 1
        92: goto          44
        95: return
...
...
...
public static final void testReversedArray();
    descriptor: ()V
    flags: ACC_PUBLIC, ACC_STATIC, ACC_FINAL
    Code:
      stack=3, locals=6, args_size=0
         0: iconst_4
         1: newarray       int
         3: astore_1
         4: aload_1
         5: iconst_0
         6: bipush        6
         8: iastore
         9: aload_1
        10: iconst_1
        11: bipush        7
        13: iastore
        14: aload_1
        15: iconst_2
        16: bipush        8
        18: iastore
        19: aload_1
        20: iconst_3
        21: bipush        9
        23: iastore
        24: aload_1
        25: astore_0
        26: ldc           #8                  // String
        28: astore_1
        29: aload_0
        30: invokestatic  #59                 // Method kotlin/collections/ArraysKt.reversedArray:([I)[I
        33: astore_2
        34: iconst_0
        35: istore_3
        36: aload_2
        37: arraylength
        38: istore        4
        40: iload_3
        41: iload         4
        43: if_icmpge     81
        46: aload_2
        47: iload_3
        48: iaload
        49: istore        5
        51: aload_0
        52: iconst_0
        53: iconst_0
        54: iastore
        55: new           #31                 // class java/lang/StringBuilder
        58: dup
        59: invokespecial #34                 // Method java/lang/StringBuilder."<init>":()V
        62: aload_1
        63: invokevirtual #38                 // Method java/lang/StringBuilder.append:(Ljava/lang/String;)Ljava/lang/StringBuilder;
        66: iload         5
        68: invokevirtual #41                 // Method java/lang/StringBuilder.append:(I)Ljava/lang/StringBuilder;
        71: invokevirtual #45                 // Method java/lang/StringBuilder.toString:()Ljava/lang/String;
        74: astore_1
        75: iinc          3, 1
        78: goto          40
        81: return
```

I've manually checked bytecode of `forInReversedArray.kt`, every `iinc` followed by a `goto`, it seems exactly what a counter-loop shoud be look like.