### PR TITLE
[Gradle] Add CompilerPluginConfig to API

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-api/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinGradleSubplugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin-api/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinGradleSubplugin.kt
@@ -19,7 +19,6 @@ package org.jetbrains.kotlin.gradle.plugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
-import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.compile.AbstractCompile
 import org.jetbrains.kotlin.gradle.dsl.KotlinCommonOptions
 import java.io.File
@@ -64,6 +63,17 @@ enum class FilesOptionKind {
 
 /** Defines a subplugin option that should be excluded from Gradle input/output checks */
 open class InternalSubpluginOption(key: String, value: String) : SubpluginOption(key, value)
+
+/** Keeps one or more compiler options for one of more compiler plugins. */
+open class CompilerPluginConfig {
+    protected val optionsByPluginId = mutableMapOf<String, MutableList<SubpluginOption>>()
+
+    fun allOptions(): Map<String, List<SubpluginOption>> = optionsByPluginId
+
+    fun addPluginArgument(pluginId: String, option: SubpluginOption) {
+        optionsByPluginId.getOrPut(pluginId) { mutableListOf() }.add(option)
+    }
+}
 
 // Deprecated because most calls require the tasks to be instantiated, which is not compatible with Gradle task configuration avoidance.
 @Deprecated(

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/CompilerPluginOptions.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/CompilerPluginOptions.kt
@@ -16,29 +16,35 @@
 
 package org.jetbrains.kotlin.gradle.tasks
 
-import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
+import org.jetbrains.kotlin.gradle.plugin.CompilerPluginConfig
 
-class CompilerPluginOptions {
-    internal val subpluginOptionsByPluginId =
-        mutableMapOf<String, MutableList<SubpluginOption>>()
+class CompilerPluginOptions() : CompilerPluginConfig() {
+
+    constructor(options: CompilerPluginConfig) : this() {
+        copyOptionsFrom(options)
+    }
+
+    val subpluginOptionsByPluginId = optionsByPluginId
 
     val arguments: List<String>
-        get() = subpluginOptionsByPluginId.flatMap { (pluginId, subplubinOptions) ->
+        get() = optionsByPluginId.flatMap { (pluginId, subplubinOptions) ->
             subplubinOptions.map { option ->
                 "plugin:$pluginId:${option.key}=${option.value}"
             }
         }
 
-    fun addPluginArgument(pluginId: String, option: SubpluginOption) {
-        subpluginOptionsByPluginId.getOrPut(pluginId) { mutableListOf() }.add(option)
-    }
-
-    operator fun plus(options: CompilerPluginOptions?): CompilerPluginOptions {
+    operator fun plus(options: CompilerPluginConfig?): CompilerPluginOptions {
         if (options == null) return this
         val newOptions = CompilerPluginOptions()
-        newOptions.subpluginOptionsByPluginId += subpluginOptionsByPluginId
-        newOptions.subpluginOptionsByPluginId += options.subpluginOptionsByPluginId
+        newOptions.optionsByPluginId += subpluginOptionsByPluginId
+        newOptions.copyOptionsFrom(options)
 
         return newOptions
+    }
+
+    private fun copyOptionsFrom(options: CompilerPluginConfig) {
+        options.allOptions().forEach { entry ->
+            optionsByPluginId[entry.key] = entry.value.toMutableList()
+        }
     }
 }


### PR DESCRIPTION
Add a convenient way to specify Kotlin compiler
plugin options with the CompilePluginConfig,
which is added to the -api subproject.

This PR is addressing https://youtrack.jetbrains.com/issue/KT-50869.