### PR TITLE
JVM_IR: generate tableswitch for literal string subject of when expression

### DIFF
--- a/compiler/testData/codegen/box/unit/nullableUnitInWhen3.kt
+++ b/compiler/testData/codegen/box/unit/nullableUnitInWhen3.kt
@@ -10,3 +10,8 @@ fun box(): String {
     
     return if (x == null) "OK" else "Fail"
 }
+
+// CHECK_BYTECODE_TEXT
+// JVM_IR_TEMPLATES
+// 0 Intrinsics.areEqual
+// 1 TABLESWITCH


### PR DESCRIPTION
issue: https://youtrack.jetbrains.com/issue/KT-50074

on my notebook, compile the code posted in the issue page, 
with `1.6.20-RC-17` and JVM_IR
```
box         :   28068700
```
with `1.6.20-RC-17` and old-backend
```
box         :    6935500
```

after this change, compile it with JVM_IR
```
box         :    7021800
```

It seems to me that the problem has nothing to do with how many branches there are, so I don't limit the number of branches in this optimization