### PR TITLE
KT-50889: Kotlin/Metadata multiple round fix

### DIFF
--- a/compiler/cli/src/org/jetbrains/kotlin/cli/metadata/K2MetadataKlibSerializer.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/metadata/K2MetadataKlibSerializer.kt
@@ -231,6 +231,9 @@ private class KlibMetadataDependencyContainer(
         val languageVersionSettings = configuration.languageVersionSettings
 
         val libraryModuleDescriptor = moduleDescriptorsForKotlinLibraries.getValue(library)
+        if (libraryModuleDescriptor.isInitialized) {
+            return libraryModuleDescriptor.packageFragmentProviderForModuleContentWithoutDependencies
+        }
         val packageFragmentNames = parseModuleHeader(library.moduleHeaderData).packageFragmentNameList
 
         return klibMetadataModuleDescriptorFactory.createPackageFragmentProvider(

--- a/compiler/tests/org/jetbrains/kotlin/cli/AnalysisHandlerExtensionTest.kt
+++ b/compiler/tests/org/jetbrains/kotlin/cli/AnalysisHandlerExtensionTest.kt
@@ -34,6 +34,7 @@ private data class TestKtFile(
 
 private val classNotFound = TestKtFile("C.kt", "class C : ClassNotFound")
 private val repeatedAnalysis = TestKtFile("D.kt", "class D : Generated")
+private val library = TestKtFile("L.kt", "class L")
 
 class AnalysisHandlerExtensionTest : TestCaseWithTmpdir() {
 
@@ -78,7 +79,12 @@ class AnalysisHandlerExtensionTest : TestCaseWithTmpdir() {
     }
 
     fun testRepeatedAnalysisMetadata() {
-        runTest(K2MetadataCompiler(), repeatedAnalysis, listOf("-d", tmpdir.resolve("out").absolutePath))
+        val libKt = tmpdir.resolve(library.name).apply {
+            writeText(library.content)
+        }
+        val compiler = K2MetadataCompiler()
+        CompilerTestUtil.executeCompilerAssertSuccessful(compiler, listOf("-Xexpect-actual-linker=true", "-d", tmpdir.resolve("libOut").absolutePath, libKt.absolutePath))
+        runTest(K2MetadataCompiler(), repeatedAnalysis, listOf("-cp", tmpdir.resolve("libOut").absolutePath, "-Xexpect-actual-linker=true", "-d", tmpdir.resolve("out").absolutePath))
     }
 }
 

--- a/core/descriptors/src/org/jetbrains/kotlin/descriptors/impl/ModuleDescriptorImpl.kt
+++ b/core/descriptors/src/org/jetbrains/kotlin/descriptors/impl/ModuleDescriptorImpl.kt
@@ -105,7 +105,7 @@ class ModuleDescriptorImpl @JvmOverloads constructor(
         )
     }
 
-    private val isInitialized: Boolean
+    val isInitialized: Boolean
         get() = packageFragmentProviderForModuleContent != null
 
     fun setDependencies(dependencies: ModuleDependencies) {


### PR DESCRIPTION
* expose ModuleDescriptorImpl.isInitialized property
* in Kotlin/Metadata compiler, in multi round mode, avoid re-initialization for ModuleDescriptorImpl.

related youtrack issue: [KT-50889](https://youtrack.jetbrains.com/issue/KT-50889)