### PR TITLE
inlineClassUtils: Fix handling of inline classes without constructors (KT-50992)

### DIFF
--- a/core/descriptors/src/org/jetbrains/kotlin/resolve/inlineClassesUtils.kt
+++ b/core/descriptors/src/org/jetbrains/kotlin/resolve/inlineClassesUtils.kt
@@ -22,7 +22,7 @@ val JVM_INLINE_ANNOTATION_CLASS_ID = ClassId.topLevel(JVM_INLINE_ANNOTATION_FQ_N
 fun DeclarationDescriptor.isInlineClass(): Boolean = when {
     this !is ClassDescriptor -> false
     isInline -> true
-    else -> isValue && unsubstitutedPrimaryConstructor?.valueParameters?.size == 1
+    else -> isValue && unsubstitutedPrimaryConstructor?.valueParameters?.size?.let { it == 1 } ?: true
 }
 
 fun DeclarationDescriptor.isValueClass(): Boolean =

--- a/core/deserialization/src/org/jetbrains/kotlin/serialization/deserialization/descriptors/DeserializedClassDescriptor.kt
+++ b/core/deserialization/src/org/jetbrains/kotlin/serialization/deserialization/descriptors/DeserializedClassDescriptor.kt
@@ -177,7 +177,7 @@ class DeserializedClassDescriptor(
     override fun getInlineClassRepresentation(): InlineClassRepresentation<SimpleType>? = inlineClassRepresentation()
 
     private fun computeInlineClassRepresentation(): InlineClassRepresentation<SimpleType>? {
-        if (!isInlineClass()) return null
+        if (!isInlineOrValueClass()) return null
 
         val propertyName = when {
             classProto.hasInlineClassUnderlyingPropertyName() ->

--- a/plugins/jvm-abi-gen/test/org/jetbrains/kotlin/jvm/abi/CompileAgainstJvmAbiTestGenerated.java
+++ b/plugins/jvm-abi-gen/test/org/jetbrains/kotlin/jvm/abi/CompileAgainstJvmAbiTestGenerated.java
@@ -115,6 +115,11 @@ public class CompileAgainstJvmAbiTestGenerated extends AbstractCompileAgainstJvm
         runTest("plugins/jvm-abi-gen/testData/compile/privateOnlyConstructors/");
     }
 
+    @TestMetadata("privateValueClassConstructor")
+    public void testPrivateValueClassConstructor() throws Exception {
+        runTest("plugins/jvm-abi-gen/testData/compile/privateValueClassConstructor/");
+    }
+
     @TestMetadata("topLevel")
     public void testTopLevel() throws Exception {
         runTest("plugins/jvm-abi-gen/testData/compile/topLevel/");

--- a/plugins/jvm-abi-gen/test/org/jetbrains/kotlin/jvm/abi/IrCompileAgainstJvmAbiTestGenerated.java
+++ b/plugins/jvm-abi-gen/test/org/jetbrains/kotlin/jvm/abi/IrCompileAgainstJvmAbiTestGenerated.java
@@ -115,6 +115,11 @@ public class IrCompileAgainstJvmAbiTestGenerated extends AbstractIrCompileAgains
         runTest("plugins/jvm-abi-gen/testData/compile/privateOnlyConstructors/");
     }
 
+    @TestMetadata("privateValueClassConstructor")
+    public void testPrivateValueClassConstructor() throws Exception {
+        runTest("plugins/jvm-abi-gen/testData/compile/privateValueClassConstructor/");
+    }
+
     @TestMetadata("topLevel")
     public void testTopLevel() throws Exception {
         runTest("plugins/jvm-abi-gen/testData/compile/topLevel/");

--- a/plugins/jvm-abi-gen/test/org/jetbrains/kotlin/jvm/abi/LegacyCompileAgainstJvmAbiTestGenerated.java
+++ b/plugins/jvm-abi-gen/test/org/jetbrains/kotlin/jvm/abi/LegacyCompileAgainstJvmAbiTestGenerated.java
@@ -115,6 +115,11 @@ public class LegacyCompileAgainstJvmAbiTestGenerated extends AbstractLegacyCompi
         runTest("plugins/jvm-abi-gen/testData/compile/privateOnlyConstructors/");
     }
 
+    @TestMetadata("privateValueClassConstructor")
+    public void testPrivateValueClassConstructor() throws Exception {
+        runTest("plugins/jvm-abi-gen/testData/compile/privateValueClassConstructor/");
+    }
+
     @TestMetadata("topLevel")
     public void testTopLevel() throws Exception {
         runTest("plugins/jvm-abi-gen/testData/compile/topLevel/");

--- a/plugins/jvm-abi-gen/testData/compile/privateValueClassConstructor/app/app.kt
+++ b/plugins/jvm-abi-gen/testData/compile/privateValueClassConstructor/app/app.kt
@@ -1,0 +1,7 @@
+package app
+
+import lib.*
+
+fun runAppAndReturnOk(): String {
+    return A.a().b()
+}

--- a/plugins/jvm-abi-gen/testData/compile/privateValueClassConstructor/lib/lib.kt
+++ b/plugins/jvm-abi-gen/testData/compile/privateValueClassConstructor/lib/lib.kt
@@ -1,0 +1,7 @@
+package lib
+
+@JvmInline
+value class A private constructor(val value: String) {
+    companion object { fun a() = A("OK") }
+    inline fun b() = value
+}


### PR DESCRIPTION
`DeclarationDescriptor.isInlineClass` misidentifies inline classes without constructors. This can happen for the ABI of inline classes with private constructors.

---

Additionally, we should probably try to deserialize the `inlineClassUnderlyingRepresentation` for both inline and value classes. Just doing this would fix the issue for the JVM IR backend, but the JVM backend still relies on the behavior of `isInlineClass`.

The behavior was changed in e69a973b07c4a990f992e0e568248cb4de1a18ff.