### PR TITLE
[JVM CLI] Prefer source over classpath.

### DIFF
--- a/compiler/tests/org/jetbrains/kotlin/cli/JavaSourceClassInClassPathTest.kt
+++ b/compiler/tests/org/jetbrains/kotlin/cli/JavaSourceClassInClassPathTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.cli
+
+import org.jetbrains.kotlin.cli.common.ExitCode
+import org.jetbrains.kotlin.cli.jvm.K2JVMCompiler
+import org.jetbrains.kotlin.test.TestCaseWithTmpdir
+
+class JavaSourceClassInClassPathTest : TestCaseWithTmpdir() {
+
+    // Test that a java source file for a class is taken before a class file for the same
+    // class on the class path.
+    fun testDeterministicOutput() {
+        val aKt = tmpdir.resolve("A.kt").also {
+            it.writeText("class A")
+        }
+        val bKt = tmpdir.resolve("B.kt").also {
+            it.writeText("fun main() { A() }")
+        }
+        val aJava = tmpdir.resolve("A.java").also {
+            it.writeText("public class A { public int i = 32; }")
+        }
+        val bNewKt = tmpdir.resolve("Bnew.kt").also {
+            it.writeText("fun main() { A().i }")
+        }
+        val firstJar = tmpdir.resolve("first.jar")
+        val (_, exit) = AbstractCliTest.executeCompilerGrabOutput(
+            K2JVMCompiler(),
+            listOf(aKt.path, bKt.path, "-d", firstJar.path, "-include-runtime")
+        )
+        assert(exit == ExitCode.OK)
+        val (_, exit2) = AbstractCliTest.executeCompilerGrabOutput(
+            K2JVMCompiler(),
+            listOf("-cp", firstJar.path, aJava.path, bNewKt.path, "-d", firstJar.path, "-include-runtime")
+        )
+        assert(exit2 == ExitCode.OK)
+    }
+}


### PR DESCRIPTION
If the class `A` is in a jar `previous.jar`, the following CLI
invocation will take that class instead of the `A` class
defined in `A.java`:

kotlinc -cp previous.jar A.java B.kt

This is problematic for build tools that put the jar for a
previous build on the classpath when recompiling some of the
files.

^KT-51025 Fixed.