### PR TITLE
JVM_IR: Optimize frame calculation for checkcast from IntRange to IntProgression

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBytecodeTextTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBytecodeTextTestGenerated.java
@@ -368,6 +368,12 @@ public class FirBytecodeTextTestGenerated extends AbstractFirBytecodeTextTest {
     }
 
     @Test
+    @TestMetadata("mergedProgression.kt")
+    public void testMergedProgression() throws Exception {
+        runTest("compiler/testData/codegen/bytecodeText/mergedProgression.kt");
+    }
+
+    @Test
     @TestMetadata("noAccessorForProtectedInSamePackageCrossinline.kt")
     public void testNoAccessorForProtectedInSamePackageCrossinline() throws Exception {
         runTest("compiler/testData/codegen/bytecodeText/noAccessorForProtectedInSamePackageCrossinline.kt");

--- a/compiler/testData/codegen/bytecodeText/mergedProgression.kt
+++ b/compiler/testData/codegen/bytecodeText/mergedProgression.kt
@@ -1,0 +1,7 @@
+// TARGET_BACKEND: JVM_IR
+
+fun test(a: Int, b: Int, flag: Boolean) =
+    (if (flag) a..b else a downTo b).map { it + 1 }
+
+// 0 java/util/Iterator.next \(\)Ljava/lang/Object;
+// 1 kotlin/collections/IntIterator.nextInt \(\)I

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBytecodeTextTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBytecodeTextTestGenerated.java
@@ -368,6 +368,12 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
     }
 
     @Test
+    @TestMetadata("mergedProgression.kt")
+    public void testMergedProgression() throws Exception {
+        runTest("compiler/testData/codegen/bytecodeText/mergedProgression.kt");
+    }
+
+    @Test
     @TestMetadata("noAccessorForProtectedInSamePackageCrossinline.kt")
     public void testNoAccessorForProtectedInSamePackageCrossinline() throws Exception {
         runTest("compiler/testData/codegen/bytecodeText/noAccessorForProtectedInSamePackageCrossinline.kt");


### PR DESCRIPTION
issue: https://youtrack.jetbrains.com/issue/KT-29199

```kotlin
fun test(a: Int, b: Int, flag: Boolean) =
    (if (flag) a..b else a downTo b).map { it + 1 }
```

above code is compiled to something like this:

```java
public final static test(IIZ)Ljava/util/List;
  @Lorg/jetbrains/annotations/NotNull;() // invisible
    // annotable parameter count: 3 (visible)
    // annotable parameter count: 3 (invisible)
   L0
    LINENUMBER 2 L0
    ILOAD 2
    IFEQ L1
    NEW kotlin/ranges/IntRange
    DUP
    ILOAD 0
    ILOAD 1
    INVOKESPECIAL kotlin/ranges/IntRange.<init> (II)V
    CHECKCAST kotlin/ranges/IntProgression
    GOTO L2
   L1
    ILOAD 0
    ILOAD 1
    INVOKESTATIC kotlin/ranges/RangesKt.downTo (II)Lkotlin/ranges/IntProgression;
   L2
    CHECKCAST java/lang/Iterable
    ASTORE 3
   L3
    ICONST_0
    ISTORE 4
   L4
   ...
    ALOAD 5
    INVOKEINTERFACE java/lang/Iterable.iterator ()Ljava/util/Iterator; (itf)
    ASTORE 8
   L7
    ALOAD 8
    INVOKEINTERFACE java/util/Iterator.hasNext ()Z (itf)
    IFEQ L8
    ALOAD 8
    INVOKEINTERFACE java/util/Iterator.next ()Ljava/lang/Object; (itf)
   ...
```

When I debug `BoxingInterpreter` , I noticed that after `CHECKCAST kotlin/ranges/IntProgression` is executed, the frame pushed onto stack is `IntRange` instead of `IntProgression`, which leads us to merge `IntProgression` and `IntRange` at the `L2` label, and the result of merging is `Object` .This in turn caused `INVOKEINTERFACE java/lang/Iterable.iterator ()Ljava/util/Iterator; (itf)` to be parsed twice, and the original `progressionIterator` in `valuesToOptimize` is marked as `tainted`. 

We need it to stay not tainted in order to generate a `CHECKCAST kotlin/collections/IntIterator` for us in a later optimization (`RedundantBoxingMethodTransformer`).