### PR TITLE
Reporting number of generated sources per annotation processor

### DIFF
--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/KaptOptions.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/KaptOptions.kt
@@ -43,7 +43,7 @@ class KaptOptions(
     val processingClassLoader: ClassLoader?,
     //construct new classloader for these processors instead of using one defined in processingClassLoader
     val separateClassloaderForProcessors: Set<String>,
-    val processorsPerfReportFile: File?
+    val processorsStatsReportFile: File?
 ) : KaptFlags {
     override fun get(flag: KaptFlag) = flags[flag]
 
@@ -73,7 +73,7 @@ class KaptOptions(
 
         var mode: AptMode = AptMode.WITH_COMPILATION
         var detectMemoryLeaks: DetectMemoryLeaksMode = DetectMemoryLeaksMode.DEFAULT
-        var processorsPerfReportFile: File? = null
+        var processorsStatsReportFile: File? = null
 
         fun build(): KaptOptions {
             val sourcesOutputDir = this.sourcesOutputDir ?: error("'sourcesOutputDir' must be set")
@@ -88,7 +88,7 @@ class KaptOptions(
                 mode, detectMemoryLeaks,
                 processingClassLoader = null,
                 separateClassloaderForProcessors = emptySet(),
-                processorsPerfReportFile = processorsPerfReportFile
+                processorsStatsReportFile = processorsStatsReportFile
             )
         }
     }
@@ -114,7 +114,7 @@ interface KaptFlags {
 }
 
 enum class KaptFlag(val description: String, val defaultValue: Boolean = false) {
-    SHOW_PROCESSOR_TIMINGS("Show processor time"),
+    SHOW_PROCESSOR_STATS("Show processor stats"),
     VERBOSE("Verbose mode"),
     INFO_AS_WARNINGS("Info as warnings"),
     USE_LIGHT_ANALYSIS("Use light analysis", defaultValue = true),

--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/annotationProcessing.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/annotationProcessing.kt
@@ -116,13 +116,13 @@ fun KaptContext.doAnnotationProcessing(
             logger.info("Annotation processing complete, errors: $errorCount, warnings: $warningCount")
         }
 
-        val showProcessorTimings = options[KaptFlag.SHOW_PROCESSOR_TIMINGS]
+        val showProcessorTimings = options[KaptFlag.SHOW_PROCESSOR_STATS]
         if (logger.isVerbose || showProcessorTimings) {
             val loggerFun = if (showProcessorTimings) logger::warn else logger::info
-            showProcessorTimings(wrappedProcessors, loggerFun)
+            showProcessorStats(wrappedProcessors, loggerFun)
         }
 
-        options.processorsPerfReportFile?.let { dumpProcessorTiming(wrappedProcessors, options.processorsPerfReportFile, logger::info) }
+        options.processorsStatsReportFile?.let { dumpProcessorStats(wrappedProcessors, options.processorsStatsReportFile, logger::info) }
 
         if (logger.isVerbose) {
             filer.displayState()
@@ -137,14 +137,14 @@ fun KaptContext.doAnnotationProcessing(
     }
 }
 
-private fun showProcessorTimings(wrappedProcessors: List<ProcessorWrapper>, logger: (String) -> Unit) {
+private fun showProcessorStats(wrappedProcessors: List<ProcessorWrapper>, logger: (String) -> Unit) {
     logger("Annotation processor stats:")
     wrappedProcessors.forEach { processor ->
         logger(processor.renderSpentTime())
     }
 }
 
-private fun dumpProcessorTiming(wrappedProcessors: List<ProcessorWrapper>, apReportFile: File, logger: (String) -> Unit) {
+private fun dumpProcessorStats(wrappedProcessors: List<ProcessorWrapper>, apReportFile: File, logger: (String) -> Unit) {
     logger("Dumping Kapt Annotation Processing performance report to ${apReportFile.absolutePath}")
 
     apReportFile.writeText(buildString {

--- a/plugins/kapt3/kapt3-cli/src/KaptCliOption.kt
+++ b/plugins/kapt3/kapt3-cli/src/KaptCliOption.kt
@@ -7,7 +7,6 @@ package org.jetbrains.kotlin.kapt.cli
 
 import org.jetbrains.kotlin.compiler.plugin.AbstractCliOption
 import org.jetbrains.kotlin.kapt.cli.CliToolOption.Format.*
-import java.io.File
 
 class CliToolOption(val name: String, val format: Format) {
     enum class Format {
@@ -174,18 +173,18 @@ enum class KaptCliOption(
         cliToolOption = CliToolOption("-Kapt-verbose", FLAG)
     ),
 
-    SHOW_PROCESSOR_TIMINGS(
-        "showProcessorTimings",
+    SHOW_PROCESSOR_STATS(
+        "showProcessorStats",
         "true | false",
         "Show processor timings",
-        cliToolOption = CliToolOption("-Kapt-show-processor-timings", FLAG)
+        cliToolOption = CliToolOption("-Kapt-show-processor-stats", FLAG)
     ),
 
-    DUMP_PROCESSOR_TIMINGS(
-        "dumpProcessorTimings",
+    DUMP_PROCESSOR_STATS(
+        "dumpProcessorStats",
         "<path>",
-        "Dump processor performance statistics to the specified file",
-        cliToolOption = CliToolOption("-Kapt-dump-processor-timings", VALUE)
+        "Dump processor statistics (performance and generations) to the specified file",
+        cliToolOption = CliToolOption("-Kapt-dump-processor-stats", VALUE)
     ),
 
     STRICT_MODE_OPTION(

--- a/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/Kapt3Plugin.kt
+++ b/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/Kapt3Plugin.kt
@@ -120,8 +120,8 @@ class Kapt3CommandLineProcessor : CommandLineProcessor {
             STRICT_MODE_OPTION -> setFlag(KaptFlag.STRICT, value)
             STRIP_METADATA_OPTION -> setFlag(KaptFlag.STRIP_METADATA, value)
             KEEP_KDOC_COMMENTS_IN_STUBS -> setFlag(KaptFlag.KEEP_KDOC_COMMENTS_IN_STUBS, value)
-            SHOW_PROCESSOR_TIMINGS -> setFlag(KaptFlag.SHOW_PROCESSOR_TIMINGS, value)
-            DUMP_PROCESSOR_TIMINGS -> processorsPerfReportFile = File(value)
+            SHOW_PROCESSOR_STATS -> setFlag(KaptFlag.SHOW_PROCESSOR_STATS, value)
+            DUMP_PROCESSOR_STATS -> processorsStatsReportFile = File(value)
             INCLUDE_COMPILE_CLASSPATH -> setFlag(KaptFlag.INCLUDE_COMPILE_CLASSPATH, value)
 
             DETECT_MEMORY_LEAKS_OPTION -> setSelector(enumValues<DetectMemoryLeaksMode>(), value) { detectMemoryLeaks = it }


### PR DESCRIPTION
We already report performance stats for each processor (see #4280 ), this change also adds stats for the number of generated files for each annotation processor. Here's an example for a stats report with the new generation stats:

Kapt Annotation Processing performance report:
com.udinic.aptplayground.processor.TestingProcessor: total: 133 ms, init: 36 ms, 2 round(s): 97 ms, 0 ms
com.udinic.aptplayground.processor.AnotherProcessor: total: 100 ms, init: 6 ms, 1 round(s): 93 ms
**Generated files report:
com.udinic.aptplayground.processor.TestingProcessor: total sources: 3, sources per round: 3, 0
com.udinic.aptplayground.processor.AnotherProcessor: total sources: 5, sources per round: 3, 2**

This is useful to track whether there are unused annotation processors as part of the build. Since KAPT has a large overhead (creating stubs, resolving symbols etc.), executing it for no reason can have an aggregated impact on build times, even when it's a no-op. The generated report can be used to find modules that trigger unnecessary annotation processors and update the module to prevent that.

I also renamed the arguments that generates this report to log/file, since it no longer includes just performance stats:
showProcessorTimings -> showProcessorStats
-Kapt-show-processor-timings -> -Kapt-show-processor-stats
dumpProcessorTimings -> dumpProcessorStats
-Kapt-dump-processor-timings -> -Kapt-dump-processor-stats

An automated script can use the following regexp to parse the report and get the name of the processor with the number of sources it generated:
([\w.$]+)\: total sources: ([-\d]+), sources per round: ([-\d ,]*)


To test this, I created a new jar and used this command to generate a stats report:

kotlinc -cp $MY_CLASSPATH \
-Xplugin=kotlin-annotation-processing-SNAPSHOT.jar -P \
plugin:org.jetbrains.kotlin.kapt3:aptMode=stubsAndApt,\
plugin:org.jetbrains.kotlin.kapt3:apclasspath=processor/build/libs/processor.jar,\
plugin:org.jetbrains.kotlin.kapt3:dumpProcessorStats=cli-tests/ap-perf-report.file \
-Xplugin=$JAVA_HOME/lib/tools.jar \
-d cli-tests/out \
-no-jdk -no-reflect -no-stdlib -verbose \
sample/src/main/