### PR TITLE
KT-51326: fix kotlin-gradle-plugin performance issue with mass java SourceRoots

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/SourceRoots.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/SourceRoots.kt
@@ -50,12 +50,6 @@ internal sealed class SourceRoots(val kotlinSourceFiles: FileCollection) {
             ): Set<File> = filter { sourceRoot ->
                 sourceDirs.map { it.parentFile }.any { sourceRoot.isParentOf(it) }
             }.toSet()
-
-            private fun FileCollection.filterJavaRoots(
-                sourceDirs: FileCollection
-            ): FileCollection = filter { sourceRoot ->
-                sourceDirs.asSequence().map { it.parentFile }.any { sourceRoot.isParentOf(it) }
-            }
         }
 
         override fun log(taskName: String, logger: Logger) {

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/Tasks.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/Tasks.kt
@@ -623,7 +623,9 @@ abstract class KotlinCompile @Inject constructor(
 
     private val jvmSourceRoots by project.provider {
         // serialize in the task state for configuration caching; avoid building anew in task execution, as it may access the project model
-        SourceRoots.ForJvm.create(source, sourceRootsContainer, sourceFilesExtensions.get())
+        SourceRoots.ForJvm.create(source, sourceRootsContainer, sourceFilesExtensions.get(), { files ->
+            project.files(files)
+        })
     }
 
     /** A package prefix that is used for locating Java sources in a directory structure with non-full-depth packages.


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-51326

Hi. we got performance issues when there are mass java sourceRoots.

For example, if we have 100 extra java source roots, kotlin will waste about 8s on calculating sourceRoot directories. (i5-10400 & 64G-ram)

![image](https://user-images.githubusercontent.com/9380897/154037080-cb6eb11d-eee5-47ac-9fe2-59e48d772d60.png)

This caculating happens before real-compilation stage.

Here is the code: https://github.com/JetBrains/kotlin/blob/master/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/tasks/SourceRoots.kt

It there are 100 javaSourceRoots, `FileCollection.filterJavaRoots` will be executed for 100+ times.

And `sourceDirs(taskSource.filter {it.jsJavaFile()} )` will be executed for `100 * javaFileSize` times, which will query gradle api, it take a long time.

![image](https://user-images.githubusercontent.com/9380897/154037109-c8b117e0-0da4-47c8-b028-c51af41b79e7.png)

## How to reproduce it?

Download the dummy project attached ([KotlinDemo.zip](https://github.com/JetBrains/kotlin/files/8067919/KotlinDemo.zip)) 

run `./gradlew clean assembleDebug --no-build-cache --scan`

you will see compileKotlin task cost 10s+

## Solution

It takes so long because `FileCollection.getFiles()` is expensive in gradle.

Kotlin should not call it for too many times, it should be caculated only once and save it to memory cache.

Using kotlin `Collection.filter` instead of gradle `Filecollection.filter`