### PR TITLE
Make KotlinJvmTest Cacheable, fixes KT-51454

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/jvm/tasks/KotlinJvmTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/jvm/tasks/KotlinJvmTest.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.gradle.targets.jvm.tasks
 
 import org.gradle.api.internal.tasks.testing.*
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.testing.Test
@@ -13,6 +14,7 @@ import org.gradle.api.tasks.testing.TestFilter
 import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
 import org.jetbrains.kotlin.gradle.plugin.KotlinTestRun
 
+@CacheableTask
 open class KotlinJvmTest : Test() {
     @Input
     @Optional


### PR DESCRIPTION
In Gradle tasks need to be explicitly marked as cacheable. `org.gradle.api.tasks.testing.Test`
is marked with @CacheableTask but this annotation is inherited by subclasses. See:
https://docs.gradle.org/current/userguide/build_cache.html#sec:task_output_caching_details