### PR TITLE
Fix clean outputs may lead to javac error

### DIFF
--- a/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/IncrementalCompilerRunner.kt
+++ b/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/IncrementalCompilerRunner.kt
@@ -190,7 +190,10 @@ abstract class IncrementalCompilerRunner<
         } catch (e: Exception) { // todo: catch only cache corruption
             // todo: warn?
             reporter.report { "Rebuilding because of possible caches corruption: $e" }
-            rebuild(BuildAttribute.CACHE_CORRUPTION)
+            val exitCode = rebuild(BuildAttribute.CACHE_CORRUPTION)
+            if (exitCode == ExitCode.OK) {
+                cachesMayBeCorrupted = false
+            }
         } finally {
             if (cachesMayBeCorrupted) {
                 cleanOutputsAndLocalStateOnRebuild(args)


### PR DESCRIPTION
When kotlin compile failed at first:
Caused by: org.jetbrains.kotlin.com.intellij.util.io.PersistentEnumeratorBase$CorruptedException: PersistentEnumerator storage corrupted xxxx/build/kotlin/compileDebugKotlin/caches-jvm/jvm/kotlin/class-fq-name-to-source.tab.values

Then, compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/IncrementalCompilerRunner.kt:101  will be delete outputs;

And In the finally function, it's deleted outputs again. Finally may lead to javaTask compile error.
