### PR TITLE
Remove internal members from ABI

### DIFF
--- a/plugins/jvm-abi-gen/src/org/jetbrains/kotlin/jvm/abi/JvmAbiClassBuilderInterceptor.kt
+++ b/plugins/jvm-abi-gen/src/org/jetbrains/kotlin/jvm/abi/JvmAbiClassBuilderInterceptor.kt
@@ -60,7 +60,7 @@ sealed class AbiClassInfo {
  * be stripped. However, if `f` is not callable directly, we only generate a
  * single inline method `f` which should be kept.
  */
-class JvmAbiClassBuilderInterceptor : ClassBuilderInterceptorExtension {
+class JvmAbiClassBuilderInterceptor(private val deleteNonPublicFromAbi: Boolean) : ClassBuilderInterceptorExtension {
     val abiClassInfo: MutableMap<String, AbiClassInfo> = mutableMapOf()
 
     override fun interceptClassBuilderFactory(

--- a/plugins/jvm-abi-gen/src/org/jetbrains/kotlin/jvm/abi/JvmAbiCommandLineProcessor.kt
+++ b/plugins/jvm-abi-gen/src/org/jetbrains/kotlin/jvm/abi/JvmAbiCommandLineProcessor.kt
@@ -30,18 +30,27 @@ class JvmAbiCommandLineProcessor : CommandLineProcessor {
                 "Use the legacy two pass implementation of jvm-abi-gen.",
                 false
             )
+
+        val DELETE_ALL_NON_PUBLIC_ABI_OPTION: CliOption =
+            CliOption(
+                "deleteAllNonPublicAbi",
+                "true|false",
+                "Delete everything with private and internal visibility from abi where possible.",
+                false
+            )
     }
 
     override val pluginId: String
         get() = COMPILER_PLUGIN_ID
 
     override val pluginOptions: Collection<CliOption>
-        get() = listOf(OUTPUT_PATH_OPTION, LEGACY_ABI_GEN_OPTION)
+        get() = listOf(OUTPUT_PATH_OPTION, LEGACY_ABI_GEN_OPTION, DELETE_ALL_NON_PUBLIC_ABI_OPTION)
 
     override fun processOption(option: AbstractCliOption, value: String, configuration: CompilerConfiguration) {
         when (option) {
             OUTPUT_PATH_OPTION -> configuration.put(JvmAbiConfigurationKeys.OUTPUT_PATH, value)
             LEGACY_ABI_GEN_OPTION -> configuration.put(JvmAbiConfigurationKeys.LEGACY_ABI_GEN, value == "true")
+            DELETE_ALL_NON_PUBLIC_ABI_OPTION -> configuration.put(JvmAbiConfigurationKeys.DELETE_ALL_NON_PUBLIC_ABI, value == "true")
             else -> throw CliOptionProcessingException("Unknown option: ${option.optionName}")
         }
     }

--- a/plugins/jvm-abi-gen/src/org/jetbrains/kotlin/jvm/abi/JvmAbiComponentRegistrar.kt
+++ b/plugins/jvm-abi-gen/src/org/jetbrains/kotlin/jvm/abi/JvmAbiComponentRegistrar.kt
@@ -31,10 +31,10 @@ class JvmAbiComponentRegistrar : ComponentRegistrar {
         } else {
             // Use the single-pass implementation, using the new ABI flag in the metadata.
             configuration.put(JVMConfigurationKeys.RETAIN_OUTPUT_IN_MEMORY, true)
-            val deleteNonPublicFromAbi = configuration.get(JvmAbiConfigurationKeys.DELETE_ALL_NON_PUBLIC_ABI, false)
-            val builderExtension = JvmAbiClassBuilderInterceptor(deleteNonPublicFromAbi)
+            val deleteNonPublicAbi = configuration.get(JvmAbiConfigurationKeys.DELETE_ALL_NON_PUBLIC_ABI, false)
+            val builderExtension = JvmAbiClassBuilderInterceptor(deleteNonPublicAbi)
             val messageCollector = configuration.get(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
-            val outputExtension = JvmAbiOutputExtension(File(outputPath), builderExtension.abiClassInfo, messageCollector, deleteNonPublicFromAbi)
+            val outputExtension = JvmAbiOutputExtension(File(outputPath), builderExtension.abiClassInfo, messageCollector, deleteNonPublicAbi)
             ClassBuilderInterceptorExtension.registerExtension(project, builderExtension)
             ClassFileFactoryFinalizerExtension.registerExtension(project, outputExtension)
         }

--- a/plugins/jvm-abi-gen/src/org/jetbrains/kotlin/jvm/abi/JvmAbiComponentRegistrar.kt
+++ b/plugins/jvm-abi-gen/src/org/jetbrains/kotlin/jvm/abi/JvmAbiComponentRegistrar.kt
@@ -31,9 +31,10 @@ class JvmAbiComponentRegistrar : ComponentRegistrar {
         } else {
             // Use the single-pass implementation, using the new ABI flag in the metadata.
             configuration.put(JVMConfigurationKeys.RETAIN_OUTPUT_IN_MEMORY, true)
-            val builderExtension = JvmAbiClassBuilderInterceptor()
+            val deleteNonPublicFromAbi = configuration.get(JvmAbiConfigurationKeys.DELETE_ALL_NON_PUBLIC_ABI, false)
+            val builderExtension = JvmAbiClassBuilderInterceptor(deleteNonPublicFromAbi)
             val messageCollector = configuration.get(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
-            val outputExtension = JvmAbiOutputExtension(File(outputPath), builderExtension.abiClassInfo, messageCollector)
+            val outputExtension = JvmAbiOutputExtension(File(outputPath), builderExtension.abiClassInfo, messageCollector, deleteNonPublicFromAbi)
             ClassBuilderInterceptorExtension.registerExtension(project, builderExtension)
             ClassFileFactoryFinalizerExtension.registerExtension(project, outputExtension)
         }

--- a/plugins/jvm-abi-gen/src/org/jetbrains/kotlin/jvm/abi/JvmAbiConfigurationKeys.kt
+++ b/plugins/jvm-abi-gen/src/org/jetbrains/kotlin/jvm/abi/JvmAbiConfigurationKeys.kt
@@ -13,4 +13,7 @@ object JvmAbiConfigurationKeys {
 
     val LEGACY_ABI_GEN: CompilerConfigurationKey<Boolean> =
         CompilerConfigurationKey.create<Boolean>(JvmAbiCommandLineProcessor.LEGACY_ABI_GEN_OPTION.description)
+
+    val DELETE_ALL_NON_PUBLIC_ABI: CompilerConfigurationKey<Boolean> =
+        CompilerConfigurationKey.create<Boolean>(JvmAbiCommandLineProcessor.DELETE_ALL_NON_PUBLIC_ABI_OPTION.description)
 }

--- a/plugins/jvm-abi-gen/src/org/jetbrains/kotlin/jvm/abi/JvmAbiOutputExtension.kt
+++ b/plugins/jvm-abi-gen/src/org/jetbrains/kotlin/jvm/abi/JvmAbiOutputExtension.kt
@@ -22,6 +22,7 @@ class JvmAbiOutputExtension(
     private val outputPath: File,
     private val abiClassInfos: Map<String, AbiClassInfo>,
     private val messageCollector: MessageCollector,
+    private val deleteNonPublicFromAbi: Boolean,
 ) : ClassFileFactoryFinalizerExtension {
     override fun finalizeClassFactory(factory: ClassFileFactory) {
         // We need to wait until the end to produce any output in order to strip classes

--- a/plugins/jvm-abi-gen/test/org/jetbrains/kotlin/jvm/abi/CompareJvmAbiTestGenerated.java
+++ b/plugins/jvm-abi-gen/test/org/jetbrains/kotlin/jvm/abi/CompareJvmAbiTestGenerated.java
@@ -8,9 +8,9 @@ package org.jetbrains.kotlin.jvm.abi;
 import com.intellij.testFramework.TestDataPath;
 import org.jetbrains.kotlin.test.JUnit3RunnerWithInners;
 import org.jetbrains.kotlin.test.KotlinTestUtils;
-import org.jetbrains.kotlin.test.util.KtTestUtil;
 import org.jetbrains.kotlin.test.TargetBackend;
 import org.jetbrains.kotlin.test.TestMetadata;
+import org.jetbrains.kotlin.test.util.KtTestUtil;
 import org.junit.runner.RunWith;
 
 import java.io.File;
@@ -83,6 +83,11 @@ public class CompareJvmAbiTestGenerated extends AbstractCompareJvmAbiTest {
     @TestMetadata("inlineFunInPrivateNestedClass")
     public void testInlineFunInPrivateNestedClass() throws Exception {
         runTest("plugins/jvm-abi-gen/testData/compare/inlineFunInPrivateNestedClass/");
+    }
+
+    @TestMetadata("inlineFunctionAnonymousObject")
+    public void testInlineFunctionAnonymousObject() throws Exception {
+        runTest("plugins/jvm-abi-gen/testData/compare/inlineFunctionAnonymousObject/");
     }
 
     @TestMetadata("inlineFunctionBody")

--- a/plugins/jvm-abi-gen/test/org/jetbrains/kotlin/jvm/abi/IrCompareJvmAbiTestGenerated.java
+++ b/plugins/jvm-abi-gen/test/org/jetbrains/kotlin/jvm/abi/IrCompareJvmAbiTestGenerated.java
@@ -8,9 +8,9 @@ package org.jetbrains.kotlin.jvm.abi;
 import com.intellij.testFramework.TestDataPath;
 import org.jetbrains.kotlin.test.JUnit3RunnerWithInners;
 import org.jetbrains.kotlin.test.KotlinTestUtils;
-import org.jetbrains.kotlin.test.util.KtTestUtil;
 import org.jetbrains.kotlin.test.TargetBackend;
 import org.jetbrains.kotlin.test.TestMetadata;
+import org.jetbrains.kotlin.test.util.KtTestUtil;
 import org.junit.runner.RunWith;
 
 import java.io.File;
@@ -83,6 +83,11 @@ public class IrCompareJvmAbiTestGenerated extends AbstractIrCompareJvmAbiTest {
     @TestMetadata("inlineFunInPrivateNestedClass")
     public void testInlineFunInPrivateNestedClass() throws Exception {
         runTest("plugins/jvm-abi-gen/testData/compare/inlineFunInPrivateNestedClass/");
+    }
+
+    @TestMetadata("inlineFunctionAnonymousObject")
+    public void testInlineFunctionAnonymousObject() throws Exception {
+        runTest("plugins/jvm-abi-gen/testData/compare/inlineFunctionAnonymousObject/");
     }
 
     @TestMetadata("inlineFunctionBody")

--- a/plugins/jvm-abi-gen/test/org/jetbrains/kotlin/jvm/abi/LegacyCompareJvmAbiTestGenerated.java
+++ b/plugins/jvm-abi-gen/test/org/jetbrains/kotlin/jvm/abi/LegacyCompareJvmAbiTestGenerated.java
@@ -8,9 +8,9 @@ package org.jetbrains.kotlin.jvm.abi;
 import com.intellij.testFramework.TestDataPath;
 import org.jetbrains.kotlin.test.JUnit3RunnerWithInners;
 import org.jetbrains.kotlin.test.KotlinTestUtils;
-import org.jetbrains.kotlin.test.util.KtTestUtil;
 import org.jetbrains.kotlin.test.TargetBackend;
 import org.jetbrains.kotlin.test.TestMetadata;
+import org.jetbrains.kotlin.test.util.KtTestUtil;
 import org.junit.runner.RunWith;
 
 import java.io.File;
@@ -83,6 +83,11 @@ public class LegacyCompareJvmAbiTestGenerated extends AbstractLegacyCompareJvmAb
     @TestMetadata("inlineFunInPrivateNestedClass")
     public void testInlineFunInPrivateNestedClass() throws Exception {
         runTest("plugins/jvm-abi-gen/testData/compare/inlineFunInPrivateNestedClass/");
+    }
+
+    @TestMetadata("inlineFunctionAnonymousObject")
+    public void testInlineFunctionAnonymousObject() throws Exception {
+        runTest("plugins/jvm-abi-gen/testData/compare/inlineFunctionAnonymousObject/");
     }
 
     @TestMetadata("inlineFunctionBody")

--- a/plugins/jvm-abi-gen/testData/compare/inlineFunctionAnonymousObject/base/function.kt
+++ b/plugins/jvm-abi-gen/testData/compare/inlineFunctionAnonymousObject/base/function.kt
@@ -1,0 +1,8 @@
+package test
+
+inline fun sum(x: Int, y: Int): Int {
+    val o = object {
+        val x = 42
+    }
+    return o.x
+}

--- a/plugins/jvm-abi-gen/testData/compare/inlineFunctionAnonymousObject/differentAbi/function.kt
+++ b/plugins/jvm-abi-gen/testData/compare/inlineFunctionAnonymousObject/differentAbi/function.kt
@@ -1,0 +1,8 @@
+package test
+
+inline fun sum(x: Int, y: Int): Int {
+    val o2 = object {
+        val x = 42
+    }
+    return o2.x
+}


### PR DESCRIPTION
Feature is hidden behind the `deleteAllNonPublicAbi` option. Without it set to `true` behavior doesn't change.

[KT-28705](https://youtrack.jetbrains.com/issue/KT-28705)

The original issue suggests generating two different ABI jars:
1) friend abi
2) non-friend abi

Currently it is not supported by the PR. At the first glance, in case of tests it is not very beneficial to compile them against friend abi versus the whole jar. But it could be easily added if needed.