### PR TITLE
Partial fix for KT-31141

### DIFF
--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/inlineClassConstructor.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/inlineClassConstructor.kt
@@ -53,9 +53,7 @@ fun box(): String {
     assertEquals(A("abc"), (ctorA2 as KCallable<A>).call("a", "bc"))
 
     assertEquals(Z2(Z(42)), ::Z2.call(Z(42)))
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(Z3(Z(42)), ::Z3.call(Z(42)))
-    }
+    assertEquals(Z3(Z(42)), ::Z3.call(Z(42)))
 
     return "OK"
 }

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/constructorWithInlineClassParameters.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/constructorWithInlineClassParameters.kt
@@ -32,32 +32,20 @@ fun box(): String {
     val z3 = S("3")
     val z4 = S("4")
 
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        val outer = ::Outer.call(z1, z2)
-        assertEquals(z1, outer.z1)
-        assertEquals(z2, outer.z2)
+    val outer = ::Outer.call(z1, z2)
+    assertEquals(z1, outer.z1)
+    assertEquals(z2, outer.z2)
 
-        assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-            assertEquals("S(x=1) S(x=2) S(x=3) S(x=4)", Outer::Inner.call(outer, z3, z4).test)
-            assertEquals("S(x=1) S(x=2) S(x=2) S(x=4)", outer::Inner.call(z2, z4).test)
-        }
-    }
+    assertEquals("S(x=1) S(x=2) S(x=3) S(x=4)", Outer::Inner.call(outer, z3, z4).test)
+    assertEquals("S(x=1) S(x=2) S(x=2) S(x=4)", outer::Inner.call(z2, z4).test)
 
     val inlineNonNullOuter = InlineNonNullOuter(z1)
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals("S(x=1) S(x=2) S(x=3)", InlineNonNullOuter::Inner.call(inlineNonNullOuter, z2, z3).test)
-    }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals("S(x=1) S(x=2) S(x=2)", inlineNonNullOuter::Inner.call(z2, z2).test)
-    }
+    assertEquals("S(x=1) S(x=2) S(x=3)", InlineNonNullOuter::Inner.call(inlineNonNullOuter, z2, z3).test)
+    assertEquals("S(x=1) S(x=2) S(x=2)", inlineNonNullOuter::Inner.call(z2, z2).test)
 
     val inlineNullableOuter = InlineNullableOuter(z1)
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals("S(x=1) S(x=2) S(x=3)", InlineNullableOuter::Inner.call(inlineNullableOuter, z2, z3).test)
-    }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals("S(x=1) S(x=2) S(x=2)", inlineNullableOuter::Inner.call(z2, z2).test)
-    }
+    assertEquals("S(x=1) S(x=2) S(x=3)", InlineNullableOuter::Inner.call(inlineNullableOuter, z2, z3).test)
+    assertEquals("S(x=1) S(x=2) S(x=2)", inlineNullableOuter::Inner.call(z2, z2).test)
 
     return "OK"
 }

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/functionsWithInlineClassParameters.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/functionsWithInlineClassParameters.kt
@@ -23,26 +23,14 @@ fun S.extension3(): String = value!!
 fun S?.extension4(): String = this!!.value!!
 
 fun box(): String {
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(S("abc"), C::member.call(C(), S("a"), "b", S("c")))
-    }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(S("def"), ::topLevel.call("d", S("e"), S("f")))
-    }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(S("ghi"), S::extension1.call(S("g"), S("h"), S("i")))
-    }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(S("jkl"), S::extension2.call(S("j"), S("k"), S("l")))
-    }
+    assertEquals(S("abc"), C::member.call(C(), S("a"), "b", S("c")))
+    assertEquals(S("def"), ::topLevel.call("d", S("e"), S("f")))
+    assertEquals(S("ghi"), S::extension1.call(S("g"), S("h"), S("i")))
+    assertEquals(S("jkl"), S::extension2.call(S("j"), S("k"), S("l")))
     assertEquals("_", S::extension3.call(S("_")))
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals("_", S?::extension4.call(S("_")))
-    }
+    assertEquals("_", S?::extension4.call(S("_")))
 
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(S("mno"), C()::member.call(S("m"), "n", S("o")))
-    }
+    assertEquals(S("mno"), C()::member.call(S("m"), "n", S("o")))
     assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
         assertEquals(S("pqr"), S("p")::extension1.call(S("q"), "r"))
     }

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/jvmStaticFunction.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/jvmStaticFunction.kt
@@ -23,22 +23,14 @@ interface I {
 }
 
 fun box(): String {
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(S("abc"), C::foo.call(S("a"), "b", S("c")))
-    }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(S("def"), (I)::bar.call("d", S("e"), S("f")))
-    }
+    assertEquals(S("abc"), C::foo.call(S("a"), "b", S("c")))
+    assertEquals(S("def"), (I)::bar.call("d", S("e"), S("f")))
 
     val unboundFoo = C::class.members.single { it.name == "foo" } as KFunction<*>
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(S("ghi"), unboundFoo.call(C, S("g"), "h", S("i")))
-    }
+    assertEquals(S("ghi"), unboundFoo.call(C, S("g"), "h", S("i")))
 
     val unboundBar = I.Companion::class.members.single { it.name == "bar" } as KFunction<*>
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(S("jkl"), unboundBar.call(I, "j", S("k"), S("l")))
-    }
+    assertEquals(S("jkl"), unboundBar.call(I, "j", S("k"), S("l")))
 
     return "OK"
 }

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/nonOverridingFunOfInlineClass.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/nonOverridingFunOfInlineClass.kt
@@ -20,26 +20,14 @@ fun box(): String {
     val plus = S("+")
     val aster = S("*")
 
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals("42-+*", S::test.call(S("42"), "-", plus, aster))
-    }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals("42-+*", S("42")::test.call("-", plus, aster))
-    }
+    assertEquals("42-+*", S::test.call(S("42"), "-", plus, aster))
+    assertEquals("42-+*", S("42")::test.call("-", plus, aster))
 
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals("42-+*", Z::test.call(Z(42), "-", plus, aster))
-    }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals("42-+*", Z(42)::test.call("-", plus, aster))
-    }
+    assertEquals("42-+*", Z::test.call(Z(42), "-", plus, aster))
+    assertEquals("42-+*", Z(42)::test.call("-", plus, aster))
 
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals("42-+*", A::test.call(A("42"), "-", plus, aster))
-    }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals("42-+*", A("42")::test.call("-", plus, aster))
-    }
+    assertEquals("42-+*", A::test.call(A("42"), "-", plus, aster))
+    assertEquals("42-+*", A("42")::test.call("-", plus, aster))
 
     return "OK"
 }

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/nonOverridingVarOfInlineClass.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/nonOverridingVarOfInlineClass.kt
@@ -72,14 +72,10 @@ fun box(): String {
     assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
         assertEquals(S("42"), S("42")::nullableTest.getter.call())
     }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        S::nullableTest.setter.call(S("42"), S("S-"))
-        assertEquals(S("S-42"), global)
-    }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        S("42")::nullableTest.setter.call(S("S+"))
-        assertEquals(S("S+42"), global)
-    }
+    S::nullableTest.setter.call(S("42"), S("S-"))
+    assertEquals(S("S-42"), global)
+    S("42")::nullableTest.setter.call(S("S+"))
+    assertEquals(S("S+42"), global)
 
     global = S("")
     assertEquals(S("42"), Z::nonNullTest.call(Z(42)))
@@ -104,14 +100,10 @@ fun box(): String {
     assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
         assertEquals(S("42"), Z(42)::nullableTest.getter.call())
     }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        Z::nullableTest.setter.call(Z(42), S("Z-"))
-        assertEquals(S("Z-42"), global)
-    }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        Z(42)::nullableTest.setter.call(S("Z+"))
-        assertEquals(S("Z+42"), global)
-    }
+    Z::nullableTest.setter.call(Z(42), S("Z-"))
+    assertEquals(S("Z-42"), global)
+    Z(42)::nullableTest.setter.call(S("Z+"))
+    assertEquals(S("Z+42"), global)
 
     global = S("")
     assertEquals(S("42"), A::nonNullTest.call(A(42)))
@@ -136,14 +128,10 @@ fun box(): String {
     assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
         assertEquals(S("42"), A(42)::nullableTest.getter.call())
     }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        A::nullableTest.setter.call(A(42), S("A-"))
-        assertEquals(S("A-42"), global)
-    }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        A(42)::nullableTest.setter.call(S("A+"))
-        assertEquals(S("A+42"), global)
-    }
+    A::nullableTest.setter.call(A(42), S("A-"))
+    assertEquals(S("A-42"), global)
+    A(42)::nullableTest.setter.call(S("A+"))
+    assertEquals(S("A+42"), global)
 
     return "OK"
 }

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/overridingFunOfInlineClass.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/overridingFunOfInlineClass.kt
@@ -24,26 +24,14 @@ fun box(): String {
     val plus = S("+")
     val aster = S("*")
 
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals("42-+*", S::test.call(S("42"), "-", plus, aster))
-    }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals("42-+*", S("42")::test.call("-", plus, aster))
-    }
+    assertEquals("42-+*", S::test.call(S("42"), "-", plus, aster))
+    assertEquals("42-+*", S("42")::test.call("-", plus, aster))
 
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals("42-+*", Z::test.call(Z(42), "-", plus, aster))
-    }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals("42-+*", Z(42)::test.call("-", plus, aster))
-    }
+    assertEquals("42-+*", Z::test.call(Z(42), "-", plus, aster))
+    assertEquals("42-+*", Z(42)::test.call("-", plus, aster))
 
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals("42-+*", A::test.call(A("42"), "-", plus, aster))
-    }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals("42-+*", A("42")::test.call("-", plus, aster))
-    }
+    assertEquals("42-+*", A::test.call(A("42"), "-", plus, aster))
+    assertEquals("42-+*", A("42")::test.call("-", plus, aster))
 
     return "OK"
 }

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/overridingVarOfInlineClass.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/overridingVarOfInlineClass.kt
@@ -77,14 +77,10 @@ fun box(): String {
     assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
         assertEquals(S("42"), S("42")::nullableTest.getter.call())
     }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        S::nullableTest.setter.call(S("42"), S("S-"))
-        assertEquals(S("S-42"), global)
-    }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        S("42")::nullableTest.setter.call(S("S+"))
-        assertEquals(S("S+42"), global)
-    }
+    S::nullableTest.setter.call(S("42"), S("S-"))
+    assertEquals(S("S-42"), global)
+    S("42")::nullableTest.setter.call(S("S+"))
+    assertEquals(S("S+42"), global)
 
     global = S("")
     assertEquals(S("42"), Z::nonNullTest.call(Z(42)))
@@ -109,14 +105,10 @@ fun box(): String {
     assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
         assertEquals(S("42"), Z(42)::nullableTest.getter.call())
     }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        Z::nullableTest.setter.call(Z(42), S("Z-"))
-        assertEquals(S("Z-42"), global)
-    }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        Z(42)::nullableTest.setter.call(S("Z+"))
-        assertEquals(S("Z+42"), global)
-    }
+    Z::nullableTest.setter.call(Z(42), S("Z-"))
+    assertEquals(S("Z-42"), global)
+    Z(42)::nullableTest.setter.call(S("Z+"))
+    assertEquals(S("Z+42"), global)
 
     global = S("")
     assertEquals(S("42"), A::nonNullTest.call(A(42)))
@@ -141,14 +133,10 @@ fun box(): String {
     assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
         assertEquals(S("42"), A(42)::nullableTest.getter.call())
     }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        A::nullableTest.setter.call(A(42), S("A-"))
-        assertEquals(S("A-42"), global)
-    }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        A(42)::nullableTest.setter.call(S("A+"))
-        assertEquals(S("A+42"), global)
-    }
+    A::nullableTest.setter.call(A(42), S("A-"))
+    assertEquals(S("A-42"), global)
+    A(42)::nullableTest.setter.call(S("A+"))
+    assertEquals(S("A+42"), global)
 
     return "OK"
 }

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/properties.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/properties.kt
@@ -86,11 +86,9 @@ fun box(): String {
     }
 
     val nullable_nonNullMemExt = C::class.members.single { it.name == "nullable_nonNullMemExt" } as KMutableProperty2<C, S?, S>
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(Unit, nullable_nonNullMemExt.setter.call(c, S(""), S("f")))
-        assertEquals(S("ef"), nullable_nonNullMemExt.call(c, S("e")))
-        assertEquals(S("ef"), nullable_nonNullMemExt.getter.call(c, S("e")))
-    }
+    assertEquals(Unit, nullable_nonNullMemExt.setter.call(c, S(""), S("f")))
+    assertEquals(S("ef"), nullable_nonNullMemExt.call(c, S("e")))
+    assertEquals(S("ef"), nullable_nonNullMemExt.getter.call(c, S("e")))
 
     val nullable_nullableMemExt = C::class.members.single { it.name == "nullable_nullableMemExt" } as KMutableProperty2<C, S?, S?>
     assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
@@ -119,11 +117,9 @@ fun box(): String {
         assertEquals(S("ij"), S::nonNull_nullableExt.getter.call(S("i")))
     }
 
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(Unit, S?::nullable_nonNullExt.setter.call(S(""), S("j")))
-        assertEquals(S("ij"), S?::nullable_nonNullExt.call(S("i")))
-        assertEquals(S("ij"), S?::nullable_nonNullExt.getter.call(S("i")))
-    }
+    assertEquals(Unit, S?::nullable_nonNullExt.setter.call(S(""), S("j")))
+    assertEquals(S("ij"), S?::nullable_nonNullExt.call(S("i")))
+    assertEquals(S("ij"), S?::nullable_nonNullExt.getter.call(S("i")))
 
     assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
         assertEquals(Unit, S?::nullable_nullableExt.setter.call(S(""), S("j")))

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/suspendFunction.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/suspendFunction.kt
@@ -54,11 +54,9 @@ fun box(): String {
         }.let { assertEquals("nonNull_nullable", it) }
     }
 
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        run0 {
-            C::nullable_nonNullConsumeAndProduce.callSuspend(c, S("nullable_nonNull")).value!!
-        }.let { assertEquals("nullable_nonNull", it) }
-    }
+    run0 {
+        C::nullable_nonNullConsumeAndProduce.callSuspend(c, S("nullable_nonNull")).value!!
+    }.let { assertEquals("nullable_nonNull", it) }
 
     assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
         run0 {

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/primitive/constructorWithInlineClassParameters.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/primitive/constructorWithInlineClassParameters.kt
@@ -32,28 +32,20 @@ fun box(): String {
     val z3 = Z(3)
     val z4 = Z(4)
 
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        val outer = ::Outer.call(z1, z2)
-        assertEquals(z1, outer.z1)
-        assertEquals(z2, outer.z2)
+    val outer = ::Outer.call(z1, z2)
+    assertEquals(z1, outer.z1)
+    assertEquals(z2, outer.z2)
 
-        assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-            assertEquals("Z(x=1) Z(x=2) Z(x=3) Z(x=4)", Outer::Inner.call(outer, z3, z4).test)
-            assertEquals("Z(x=1) Z(x=2) Z(x=2) Z(x=4)", outer::Inner.call(z2, z4).test)
-        }
-    }
+    assertEquals("Z(x=1) Z(x=2) Z(x=3) Z(x=4)", Outer::Inner.call(outer, z3, z4).test)
+    assertEquals("Z(x=1) Z(x=2) Z(x=2) Z(x=4)", outer::Inner.call(z2, z4).test)
 
     val inlineNonNullOuter = InlineNonNullOuter(z1)
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals("Z(x=1) Z(x=2) Z(x=3)", InlineNonNullOuter::Inner.call(inlineNonNullOuter, z2, z3).test)
-        assertEquals("Z(x=1) Z(x=2) Z(x=2)", inlineNonNullOuter::Inner.call(z2, z2).test)
-    }
+    assertEquals("Z(x=1) Z(x=2) Z(x=3)", InlineNonNullOuter::Inner.call(inlineNonNullOuter, z2, z3).test)
+    assertEquals("Z(x=1) Z(x=2) Z(x=2)", inlineNonNullOuter::Inner.call(z2, z2).test)
 
     val inlineNullableOuter = InlineNullableOuter(z1)
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals("Z(x=1) Z(x=2) Z(x=3)", InlineNullableOuter::Inner.call(inlineNullableOuter, z2, z3).test)
-        assertEquals("Z(x=1) Z(x=2) Z(x=2)", inlineNullableOuter::Inner.call(z2, z2).test)
-    }
+    assertEquals("Z(x=1) Z(x=2) Z(x=3)", InlineNullableOuter::Inner.call(inlineNullableOuter, z2, z3).test)
+    assertEquals("Z(x=1) Z(x=2) Z(x=2)", inlineNullableOuter::Inner.call(z2, z2).test)
 
     return "OK"
 }

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/primitive/functionsWithInlineClassParameters.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/primitive/functionsWithInlineClassParameters.kt
@@ -29,29 +29,15 @@ fun box(): String {
     val four = S(4)
     val seven = S(7)
 
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(seven, C::member.call(C(), one, 2, four))
-    }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(seven, ::topLevel.call(1, two, four))
-    }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(seven, S::extension1.call(one, two, four))
-    }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(seven, S::extension2.call(one, two, four))
-    }
+    assertEquals(seven, C::member.call(C(), one, 2, four))
+    assertEquals(seven, ::topLevel.call(1, two, four))
+    assertEquals(seven, S::extension1.call(one, two, four))
+    assertEquals(seven, S::extension2.call(one, two, four))
     assertEquals(0, S::extension3.call(zero))
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(0, S?::extension4.call(zero))
-    }
+    assertEquals(0, S?::extension4.call(zero))
 
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(seven, C()::member.call(one, 2, four))
-    }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(seven, one::extension1.call(two, four))
-    }
+    assertEquals(seven, C()::member.call(one, 2, four))
+    assertEquals(seven, one::extension1.call(two, four))
     assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
         assertEquals(seven, one::extension2.call(two, four))
     }

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/primitive/jvmStaticFunction.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/primitive/jvmStaticFunction.kt
@@ -28,22 +28,14 @@ fun box(): String {
     val four = Z(4)
     val seven = Z(7)
 
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(seven, C::foo.call(one, 2, four))
-    }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(seven, (I)::bar.call(1, two, four))
-    }
+    assertEquals(seven, C::foo.call(one, 2, four))
+    assertEquals(seven, (I)::bar.call(1, two, four))
 
     val unboundFoo = C::class.members.single { it.name == "foo" } as KFunction<*>
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(seven, unboundFoo.call(C, one, 2, four))
-    }
+    assertEquals(seven, unboundFoo.call(C, one, 2, four))
 
     val unboundBar = I.Companion::class.members.single { it.name == "bar" } as KFunction<*>
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(seven, unboundBar.call(I, 1, two, four))
-    }
+    assertEquals(seven, unboundBar.call(I, 1, two, four))
 
     return "OK"
 }

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/primitive/nonOverridingFunOfInlineClass.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/primitive/nonOverridingFunOfInlineClass.kt
@@ -20,26 +20,14 @@ fun box(): String {
     val two = Z(2)
     val four = Z(4)
 
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals("0124", Z::test.call(Z(0), 1, two, four))
-    }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals("0124", Z(0)::test.call(1, two, four))
-    }
+    assertEquals("0124", Z::test.call(Z(0), 1, two, four))
+    assertEquals("0124", Z(0)::test.call(1, two, four))
 
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals("0124", S::test.call(S("0"), 1, two, four))
-    }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals("0124", S("0")::test.call(1, two, four))
-    }
+    assertEquals("0124", S::test.call(S("0"), 1, two, four))
+    assertEquals("0124", S("0")::test.call(1, two, four))
 
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals("0124", A::test.call(A(0), 1, two, four))
-    }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals("0124", A(0)::test.call(1, two, four))
-    }
+    assertEquals("0124", A::test.call(A(0), 1, two, four))
+    assertEquals("0124", A(0)::test.call(1, two, four))
 
     return "OK"
 }

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/primitive/nonOverridingVarOfInlineClass.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/primitive/nonOverridingVarOfInlineClass.kt
@@ -83,14 +83,10 @@ fun box(): String {
     assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
         assertEquals(zOne, zOne::nullableTest.getter.call())
     }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        Z::nullableTest.setter.call(zOne, zTwo)
-        assertEquals(zThree, global)
-    }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        zOne::nullableTest.setter.call(zThree)
-        assertEquals(zFour, global)
-    }
+    Z::nullableTest.setter.call(zOne, zTwo)
+    assertEquals(zThree, global)
+    zOne::nullableTest.setter.call(zThree)
+    assertEquals(zFour, global)
 
     global = zZero
     assertEquals(zOne, S::nonNullTest.call(sOne))
@@ -115,14 +111,10 @@ fun box(): String {
     assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
         assertEquals(zOne, sOne::nullableTest.getter.call())
     }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        S::nullableTest.setter.call(sOne, zTwo)
-        assertEquals(zThree, global)
-    }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        sOne::nullableTest.setter.call(zThree)
-        assertEquals(zFour, global)
-    }
+    S::nullableTest.setter.call(sOne, zTwo)
+    assertEquals(zThree, global)
+    sOne::nullableTest.setter.call(zThree)
+    assertEquals(zFour, global)
 
     global = zZero
     assertEquals(zOne, A::nonNullTest.call(aOne))
@@ -147,14 +139,10 @@ fun box(): String {
     assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
         assertEquals(zOne, aOne::nullableTest.getter.call())
     }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        A::nullableTest.setter.call(aOne, zTwo)
-        assertEquals(zThree, global)
-    }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        aOne::nullableTest.setter.call(zThree)
-        assertEquals(zFour, global)
-    }
+    A::nullableTest.setter.call(aOne, zTwo)
+    assertEquals(zThree, global)
+    aOne::nullableTest.setter.call(zThree)
+    assertEquals(zFour, global)
 
     return "OK"
 }

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/primitive/overridingFunOfInlineClass.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/primitive/overridingFunOfInlineClass.kt
@@ -24,26 +24,14 @@ fun box(): String {
     val two = Z(2)
     val four = Z(4)
 
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals("0124", Z::test.call(Z(0), 1, two, four))
-    }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals("0124", Z(0)::test.call(1, two, four))
-    }
+    assertEquals("0124", Z::test.call(Z(0), 1, two, four))
+    assertEquals("0124", Z(0)::test.call(1, two, four))
 
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals("0124", S::test.call(S("0"), 1, two, four))
-    }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals("0124", S("0")::test.call(1, two, four))
-    }
+    assertEquals("0124", S::test.call(S("0"), 1, two, four))
+    assertEquals("0124", S("0")::test.call(1, two, four))
 
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals("0124", A::test.call(A(0), 1, two, four))
-    }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals("0124", A(0)::test.call(1, two, four))
-    }
+    assertEquals("0124", A::test.call(A(0), 1, two, four))
+    assertEquals("0124", A(0)::test.call(1, two, four))
 
     return "OK"
 }

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/primitive/overridingVarOfInlineClass.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/primitive/overridingVarOfInlineClass.kt
@@ -88,14 +88,10 @@ fun box(): String {
     assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
         assertEquals(zOne, zOne::nullableTest.getter.call())
     }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        Z::nullableTest.setter.call(zOne, zTwo)
-        assertEquals(zThree, global)
-    }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        zOne::nullableTest.setter.call(zThree)
-        assertEquals(zFour, global)
-    }
+    Z::nullableTest.setter.call(zOne, zTwo)
+    assertEquals(zThree, global)
+    zOne::nullableTest.setter.call(zThree)
+    assertEquals(zFour, global)
 
     global = zZero
     assertEquals(zOne, S::nonNullTest.call(sOne))
@@ -120,14 +116,10 @@ fun box(): String {
     assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
         assertEquals(zOne, sOne::nullableTest.getter.call())
     }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        S::nullableTest.setter.call(sOne, zTwo)
-        assertEquals(zThree, global)
-    }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        sOne::nullableTest.setter.call(zThree)
-        assertEquals(zFour, global)
-    }
+    S::nullableTest.setter.call(sOne, zTwo)
+    assertEquals(zThree, global)
+    sOne::nullableTest.setter.call(zThree)
+    assertEquals(zFour, global)
 
     global = zZero
     assertEquals(zOne, A::nonNullTest.call(aOne))
@@ -152,14 +144,10 @@ fun box(): String {
     assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
         assertEquals(zOne, aOne::nullableTest.getter.call())
     }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        A::nullableTest.setter.call(aOne, zTwo)
-        assertEquals(zThree, global)
-    }
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        aOne::nullableTest.setter.call(zThree)
-        assertEquals(zFour, global)
-    }
+    A::nullableTest.setter.call(aOne, zTwo)
+    assertEquals(zThree, global)
+    aOne::nullableTest.setter.call(zThree)
+    assertEquals(zFour, global)
 
     return "OK"
 }

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/primitive/properties.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/primitive/properties.kt
@@ -90,11 +90,9 @@ fun box(): String {
     }
 
     val nullable_nonNullMemExt = C::class.members.single { it.name == "nullable_nonNullMemExt" } as KMutableProperty2<C, Z?, Z>
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(Unit, nullable_nonNullMemExt.setter.call(c, Z(0), two))
-        assertEquals(three, nullable_nonNullMemExt.call(c, one))
-        assertEquals(three, nullable_nonNullMemExt.getter.call(c, one))
-    }
+    assertEquals(Unit, nullable_nonNullMemExt.setter.call(c, Z(0), two))
+    assertEquals(three, nullable_nonNullMemExt.call(c, one))
+    assertEquals(three, nullable_nonNullMemExt.getter.call(c, one))
 
     val nullable_nullableMemExt = C::class.members.single { it.name == "nullable_nullableMemExt" } as KMutableProperty2<C, Z?, Z?>
     assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
@@ -123,11 +121,9 @@ fun box(): String {
         assertEquals(three, Z::nonNull_nullableExt.getter.call(one))
     }
 
-    assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(Unit, Z?::nullable_nonNullExt.setter.call(Z(0), two))
-        assertEquals(three, Z?::nullable_nonNullExt.call(one))
-        assertEquals(three, Z?::nullable_nonNullExt.getter.call(one))
-    }
+    assertEquals(Unit, Z?::nullable_nonNullExt.setter.call(Z(0), two))
+    assertEquals(three, Z?::nullable_nonNullExt.call(one))
+    assertEquals(three, Z?::nullable_nonNullExt.getter.call(one))
 
     assertFailsWith<IllegalArgumentException>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
         assertEquals(Unit, Z?::nullable_nullableExt.setter.call(Z(0), two))


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-31141

In the current code, `IllegalArgumentException: argument type mismatch` was occurring because `unbox` is always execed if the parameter definition in `Kotlin` is `inline class`.
So, I modified the code to exec `unbox` only when the argument in `Kotlin` is `inline class` and the argument in `Java` is different from the argument in `Kotlin`.
In this `PR`, I have also fixed some of the `failing test` that I implemented earlier in #4743, which now succeeds.

## About the remaining failures.
[As I pointed out in a previous comment](https://youtrack.jetbrains.com/issue/KT-31141#focus=Comments-27-5744299.0-0), not all tests are yet in a state of success because of remaining unfixed problems.