### PR TITLE
[Native] Explicitly use Foundation in ObjC export.

### DIFF
--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExport.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExport.kt
@@ -135,6 +135,8 @@ internal class ObjCExport(val context: Context, symbolTable: SymbolTable) {
             |
             |    export *
             |    module * { export * }
+            |
+            |    use "Foundation"
             |}
         """.trimMargin()
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExport.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExport.kt
@@ -136,7 +136,7 @@ internal class ObjCExport(val context: Context, symbolTable: SymbolTable) {
             |    export *
             |    module * { export * }
             |
-            |    use "Foundation"
+            |    use Foundation
             |}
         """.trimMargin()
 


### PR DESCRIPTION
This enables using exported Frameworks with `-fmodules-decluse`.
One use-case for this is ensuring that distributed builds are
explicitly providing all required modules, which is important for
reproducibility.

For more background on `use` declarations, see:
https://clang.llvm.org/docs/Modules.html#use-declaration

The easiest way to reproduce this locally is by compiling a framework,
and emitting a pcm file with `swiftc`. Note that this requires a
pcm for `Foundation`, which can be found in the clang ModuleCache. e.g.

```
kotlin-native/dist/bin/kotlinc-native ~/test.kt -produce framework -o /tmp/TestFramework.framework
swiftc -emit-pcm -module-name TestFramework -o /tmp/TestFramework.pcm /tmp/TestFramework.framework/Modules/module.modulemap -Xcc -fmodules-decluse -Xcc -fmodule-file=Foundation=$HOME/Library/Developer/Xcode/DerivedData/$PATH_TO_FOUNDATION.pcm
```