### PR TITLE
Avoid reading /tmp/build.txt in standalone compiler invocations.

### DIFF
--- a/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/compat.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/compat.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.diagnostic.Logger
 
 object IdeaStandaloneExecutionSetup {
     private val LOG: Logger = Logger.getInstance(IdeaStandaloneExecutionSetup::class.java)
+    private const val FALLBACK_IDEA_BUILD_NUMBER = "999.SNAPSHOT"
 
     fun doSetup() {
         checkInHeadlessMode()
@@ -20,7 +21,10 @@ object IdeaStandaloneExecutionSetup {
         System.getProperties().setProperty("ide.hide.excluded.files", "false")
         System.getProperties().setProperty("ast.loading.filter", "false")
         System.getProperties().setProperty("idea.ignore.disabled.plugins", "true")
-        System.getProperties().setProperty("idea.home.path", System.getProperty("java.io.tmpdir"))
+        // Setting the build number explicitly avoids the command-line compiler
+        // reading /tmp/build.txt in an attempt to get a build number from there.
+        // See intellij platform PluginManagerCore.getBuildNumber.
+        System.getProperties().setProperty("idea.plugins.compatible.build", FALLBACK_IDEA_BUILD_NUMBER)
     }
 
     private fun checkInHeadlessMode() {

--- a/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/compat.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/compat.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.diagnostic.Logger
 
 object IdeaStandaloneExecutionSetup {
     private val LOG: Logger = Logger.getInstance(IdeaStandaloneExecutionSetup::class.java)
+    // Copy-pasted from com.intellij.openapi.util.BuildNumber#FALLBACK_VERSION
     private const val FALLBACK_IDEA_BUILD_NUMBER = "999.SNAPSHOT"
 
     fun doSetup() {


### PR DESCRIPTION
kotlinc will currently read /tmp/build.txt in an attempt to
determine an IDEA version number for IDEA plugin compatibility
checking. If that file exists and does not match the expected
format kotlinc will fail.

Since standalone kotlinc is not IDEA, this change explicitly
sets the system property for the build number to a fallback
value. That avoids reading /tmp/build.txt.