### PR TITLE
Fix typo in KFunctionProxy.kt

### DIFF
--- a/compiler/ir/ir.interpreter/src/org/jetbrains/kotlin/ir/interpreter/proxy/reflection/KFunctionProxy.kt
+++ b/compiler/ir/ir.interpreter/src/org/jetbrains/kotlin/ir/interpreter/proxy/reflection/KFunctionProxy.kt
@@ -85,7 +85,7 @@ internal class KFunctionProxy(
         if (!state.hasTheSameFieldsWith(other.state)) return false
 
         return when {
-            state.irFunction.isAdapter() && other.state.irFunction.isAdapter() -> state.irFunction.eqaulsByAdapteeCall(other.state.irFunction)
+            state.irFunction.isAdapter() && other.state.irFunction.isAdapter() -> state.irFunction.equalsByAdapteeCall(other.state.irFunction)
             else -> state.irFunction == other.state.irFunction
         }
     }
@@ -114,7 +114,7 @@ internal class KFunctionProxy(
         return (call as? IrFunctionAccessExpression)?.symbol
     }
 
-    private fun IrFunction.eqaulsByAdapteeCall(other: IrFunction): Boolean {
+    private fun IrFunction.equalsByAdapteeCall(other: IrFunction): Boolean {
         if (!this.isAdapter() || !other.isAdapter()) return false
 
         val statement = this.body!!.statements.single()


### PR DESCRIPTION
Replace `eqaulsByAdapteeCall` with `equalsByAdapteeCall`