### PR TITLE
JVM_IR: Handle methods descriptor clash in data class

### DIFF
--- a/compiler/backend-common/src/org/jetbrains/kotlin/backend/common/CodegenUtil.kt
+++ b/compiler/backend-common/src/org/jetbrains/kotlin/backend/common/CodegenUtil.kt
@@ -141,7 +141,8 @@ object CodegenUtil {
                         function.modality != Modality.FINAL &&
                         areParametersOk(function.valueParameters) &&
                         function.returnType != null &&
-                        isReturnTypeOk(function.returnType!!)
+                        isReturnTypeOk(function.returnType!!) &&
+                        function.extensionReceiverParameter == null
                     }
 
 

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -13138,6 +13138,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         }
 
         @Test
+        @TestMetadata("kt49715.kt")
+        public void testKt49715() throws Exception {
+            runTest("compiler/testData/codegen/box/dataClasses/kt49715.kt");
+        }
+
+        @Test
         @TestMetadata("kt5002.kt")
         public void testKt5002() throws Exception {
             runTest("compiler/testData/codegen/box/dataClasses/kt5002.kt");

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -13144,6 +13144,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         }
 
         @Test
+        @TestMetadata("kt49715_behaviorChange.kt")
+        public void testKt49715_behaviorChange() throws Exception {
+            runTest("compiler/testData/codegen/box/dataClasses/kt49715_behaviorChange.kt");
+        }
+
+        @Test
         @TestMetadata("kt5002.kt")
         public void testKt5002() throws Exception {
             runTest("compiler/testData/codegen/box/dataClasses/kt5002.kt");

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/utils/misc.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/utils/misc.kt
@@ -23,6 +23,7 @@ import org.jetbrains.kotlin.ir.types.isNullableAny
 import org.jetbrains.kotlin.ir.util.isEffectivelyExternal
 import org.jetbrains.kotlin.ir.util.isTopLevelDeclaration
 import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.util.OperatorNameConventions
 
 fun TODO(element: IrElement): Nothing = TODO(element::class.java.simpleName + " is not supported yet here")
 
@@ -58,9 +59,10 @@ fun IrFunction.hasStableJsName(context: JsIrBackendContext): Boolean {
     return (isEffectivelyExternal() || getJsName() != null || isExported(context)) && namedOrMissingGetter
 }
 
-fun IrFunction.isEqualsInheritedFromAny() =
-    name == Name.identifier("equals") &&
+fun IrFunction.isEqualsInheritedFromAny(): Boolean =
+    name == OperatorNameConventions.EQUALS &&
             dispatchReceiverParameter != null &&
+            extensionReceiverParameter == null &&
             valueParameters.size == 1 &&
             valueParameters[0].type.isNullableAny()
 

--- a/compiler/testData/codegen/box/dataClasses/kt49715.kt
+++ b/compiler/testData/codegen/box/dataClasses/kt49715.kt
@@ -1,0 +1,22 @@
+// IGNORE_BACKEND_FIR: JVM_IR
+// FIR status: [IR VALIDATION] Duplicate IR node: FUN GENERATED_DATA_CLASS_MEMBER name:toString
+// CHECK_BYTECODE_LISTING
+// WITH_STDLIB
+
+import kotlin.test.*
+
+interface A {
+    fun Any.toString(): String = "hello"
+}
+
+data class B(val x: Int) : A {
+    fun Any.hi() = "hi"
+}
+
+fun box(): String {
+    val b = B(1)
+    assertEquals("B(x=1)", b.toString())
+    assertTrue(b == B(1))
+    assertTrue(1.hashCode() == b.hashCode())
+    return "OK"
+}

--- a/compiler/testData/codegen/box/dataClasses/kt49715.txt
+++ b/compiler/testData/codegen/box/dataClasses/kt49715.txt
@@ -1,0 +1,35 @@
+@kotlin.Metadata
+public final class A$DefaultImpls {
+    // source: 'kt49715.kt'
+    public static @org.jetbrains.annotations.NotNull method toString(@org.jetbrains.annotations.NotNull p0: A, @org.jetbrains.annotations.NotNull p1: java.lang.Object): java.lang.String
+    public final inner class A$DefaultImpls
+}
+
+@kotlin.Metadata
+public interface A {
+    // source: 'kt49715.kt'
+    public abstract @org.jetbrains.annotations.NotNull method toString(@org.jetbrains.annotations.NotNull p0: java.lang.Object): java.lang.String
+    public final inner class A$DefaultImpls
+}
+
+@kotlin.Metadata
+public final class B {
+    // source: 'kt49715.kt'
+    private final field x: int
+    public method <init>(p0: int): void
+    public final method component1(): int
+    public synthetic static method copy$default(p0: B, p1: int, p2: int, p3: java.lang.Object): B
+    public final @org.jetbrains.annotations.NotNull method copy(p0: int): B
+    public method equals(@org.jetbrains.annotations.Nullable p0: java.lang.Object): boolean
+    public final method getX(): int
+    public method hashCode(): int
+    public final @org.jetbrains.annotations.NotNull method hi(@org.jetbrains.annotations.NotNull p0: java.lang.Object): java.lang.String
+    public @org.jetbrains.annotations.NotNull method toString(): java.lang.String
+    public @org.jetbrains.annotations.NotNull method toString(@org.jetbrains.annotations.NotNull p0: java.lang.Object): java.lang.String
+}
+
+@kotlin.Metadata
+public final class Kt49715Kt {
+    // source: 'kt49715.kt'
+    public final static @org.jetbrains.annotations.NotNull method box(): java.lang.String
+}

--- a/compiler/testData/codegen/box/dataClasses/kt49715_behaviorChange.kt
+++ b/compiler/testData/codegen/box/dataClasses/kt49715_behaviorChange.kt
@@ -1,0 +1,17 @@
+// IGNORE_BACKEND_FIR: JVM_IR
+// FIR status: [IR VALIDATION] Duplicate IR node: FUN GENERATED_DATA_CLASS_MEMBER name:equals
+
+interface A {
+    fun Any.equals(other: Any?): Boolean = false
+    fun Any.hashCode(): Int = 0
+    fun Any.toString(): String = ""
+}
+
+data class B(val x: Int) : A
+
+fun box(): String {
+    if (B(42) != B(42)) return "Fail equals"
+    if (B(42).hashCode() != B(42).hashCode()) return "Fail hashCode"
+    if (B(42).toString() != B(42).toString()) return "Fail toString"
+    return "OK"
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -13012,6 +13012,12 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
         }
 
         @Test
+        @TestMetadata("kt49715.kt")
+        public void testKt49715() throws Exception {
+            runTest("compiler/testData/codegen/box/dataClasses/kt49715.kt");
+        }
+
+        @Test
         @TestMetadata("kt5002.kt")
         public void testKt5002() throws Exception {
             runTest("compiler/testData/codegen/box/dataClasses/kt5002.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -13018,6 +13018,12 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
         }
 
         @Test
+        @TestMetadata("kt49715_behaviorChange.kt")
+        public void testKt49715_behaviorChange() throws Exception {
+            runTest("compiler/testData/codegen/box/dataClasses/kt49715_behaviorChange.kt");
+        }
+
+        @Test
         @TestMetadata("kt5002.kt")
         public void testKt5002() throws Exception {
             runTest("compiler/testData/codegen/box/dataClasses/kt5002.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -13144,6 +13144,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         }
 
         @Test
+        @TestMetadata("kt49715_behaviorChange.kt")
+        public void testKt49715_behaviorChange() throws Exception {
+            runTest("compiler/testData/codegen/box/dataClasses/kt49715_behaviorChange.kt");
+        }
+
+        @Test
         @TestMetadata("kt5002.kt")
         public void testKt5002() throws Exception {
             runTest("compiler/testData/codegen/box/dataClasses/kt5002.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -13138,6 +13138,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         }
 
         @Test
+        @TestMetadata("kt49715.kt")
+        public void testKt49715() throws Exception {
+            runTest("compiler/testData/codegen/box/dataClasses/kt49715.kt");
+        }
+
+        @Test
         @TestMetadata("kt5002.kt")
         public void testKt5002() throws Exception {
             runTest("compiler/testData/codegen/box/dataClasses/kt5002.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -10542,6 +10542,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/dataClasses/kt49715.kt");
         }
 
+        @TestMetadata("kt49715_behaviorChange.kt")
+        public void testKt49715_behaviorChange() throws Exception {
+            runTest("compiler/testData/codegen/box/dataClasses/kt49715_behaviorChange.kt");
+        }
+
         @TestMetadata("kt5002.kt")
         public void testKt5002() throws Exception {
             runTest("compiler/testData/codegen/box/dataClasses/kt5002.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -10537,6 +10537,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/dataClasses/genericParam.kt");
         }
 
+        @TestMetadata("kt49715.kt")
+        public void testKt49715() throws Exception {
+            runTest("compiler/testData/codegen/box/dataClasses/kt49715.kt");
+        }
+
         @TestMetadata("kt5002.kt")
         public void testKt5002() throws Exception {
             runTest("compiler/testData/codegen/box/dataClasses/kt5002.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/JsCodegenBoxTestGenerated.java
@@ -9726,6 +9726,12 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
         }
 
         @Test
+        @TestMetadata("kt49715.kt")
+        public void testKt49715() throws Exception {
+            runTest("compiler/testData/codegen/box/dataClasses/kt49715.kt");
+        }
+
+        @Test
         @TestMetadata("mixedParams.kt")
         public void testMixedParams() throws Exception {
             runTest("compiler/testData/codegen/box/dataClasses/mixedParams.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/JsCodegenBoxTestGenerated.java
@@ -9732,6 +9732,12 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
         }
 
         @Test
+        @TestMetadata("kt49715_behaviorChange.kt")
+        public void testKt49715_behaviorChange() throws Exception {
+            runTest("compiler/testData/codegen/box/dataClasses/kt49715_behaviorChange.kt");
+        }
+
+        @Test
         @TestMetadata("mixedParams.kt")
         public void testMixedParams() throws Exception {
             runTest("compiler/testData/codegen/box/dataClasses/mixedParams.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/IrJsCodegenBoxTestGenerated.java
@@ -9768,6 +9768,12 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
         }
 
         @Test
+        @TestMetadata("kt49715.kt")
+        public void testKt49715() throws Exception {
+            runTest("compiler/testData/codegen/box/dataClasses/kt49715.kt");
+        }
+
+        @Test
         @TestMetadata("mixedParams.kt")
         public void testMixedParams() throws Exception {
             runTest("compiler/testData/codegen/box/dataClasses/mixedParams.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/IrJsCodegenBoxTestGenerated.java
@@ -9774,6 +9774,12 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
         }
 
         @Test
+        @TestMetadata("kt49715_behaviorChange.kt")
+        public void testKt49715_behaviorChange() throws Exception {
+            runTest("compiler/testData/codegen/box/dataClasses/kt49715_behaviorChange.kt");
+        }
+
+        @Test
         @TestMetadata("mixedParams.kt")
         public void testMixedParams() throws Exception {
             runTest("compiler/testData/codegen/box/dataClasses/mixedParams.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/testOld/wasm/semantics/IrCodegenBoxWasmTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/testOld/wasm/semantics/IrCodegenBoxWasmTestGenerated.java
@@ -8549,6 +8549,11 @@ public class IrCodegenBoxWasmTestGenerated extends AbstractIrCodegenBoxWasmTest 
             runTest("compiler/testData/codegen/box/dataClasses/genericParam.kt");
         }
 
+        @TestMetadata("kt49715.kt")
+        public void testKt49715() throws Exception {
+            runTest("compiler/testData/codegen/box/dataClasses/kt49715.kt");
+        }
+
         @TestMetadata("mixedParams.kt")
         public void testMixedParams() throws Exception {
             runTest("compiler/testData/codegen/box/dataClasses/mixedParams.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/testOld/wasm/semantics/IrCodegenBoxWasmTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/testOld/wasm/semantics/IrCodegenBoxWasmTestGenerated.java
@@ -8554,6 +8554,11 @@ public class IrCodegenBoxWasmTestGenerated extends AbstractIrCodegenBoxWasmTest 
             runTest("compiler/testData/codegen/box/dataClasses/kt49715.kt");
         }
 
+        @TestMetadata("kt49715_behaviorChange.kt")
+        public void testKt49715_behaviorChange() throws Exception {
+            runTest("compiler/testData/codegen/box/dataClasses/kt49715_behaviorChange.kt");
+        }
+
         @TestMetadata("mixedParams.kt")
         public void testMixedParams() throws Exception {
             runTest("compiler/testData/codegen/box/dataClasses/mixedParams.kt");

--- a/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/NativeCodegenBoxTestGenerated.java
+++ b/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/NativeCodegenBoxTestGenerated.java
@@ -10688,6 +10688,12 @@ public class NativeCodegenBoxTestGenerated extends AbstractNativeCodegenBoxTest 
             }
 
             @Test
+            @TestMetadata("kt49715_behaviorChange.kt")
+            public void testKt49715_behaviorChange() throws Exception {
+                runTest("compiler/testData/codegen/box/dataClasses/kt49715_behaviorChange.kt");
+            }
+
+            @Test
             @TestMetadata("mixedParams.kt")
             public void testMixedParams() throws Exception {
                 runTest("compiler/testData/codegen/box/dataClasses/mixedParams.kt");

--- a/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/NativeCodegenBoxTestGenerated.java
+++ b/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/NativeCodegenBoxTestGenerated.java
@@ -10682,6 +10682,12 @@ public class NativeCodegenBoxTestGenerated extends AbstractNativeCodegenBoxTest 
             }
 
             @Test
+            @TestMetadata("kt49715.kt")
+            public void testKt49715() throws Exception {
+                runTest("compiler/testData/codegen/box/dataClasses/kt49715.kt");
+            }
+
+            @Test
             @TestMetadata("mixedParams.kt")
             public void testMixedParams() throws Exception {
                 runTest("compiler/testData/codegen/box/dataClasses/mixedParams.kt");


### PR DESCRIPTION
issue: https://youtrack.jetbrains.com/issue/KT-49715

----
As far as I know, the method `getMemberToGenerate` is used to: 
1. generate `toString`, `hashCode`, `equals` methods for data class
2. generate `serialize`, `deserialize`, `childSerializers`, `typeParametersSerializers` methods  in `serialization-compiler-plugin`

Not pretty sure if this change breaks semantics/purpose of  method `getMemberToGenerate`, but it is safe for now because all those methods above are not extension methods.

#KT-49715 Fixed

----
It passed `jvmCompilerTest` but I haven't run many tests for `jsBackend` or `nativeBackend`