### PR TITLE
JVM IR: Resolve fake overrides during inline class mangling (KT-51672)

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -21358,6 +21358,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         }
 
         @Test
+        @TestMetadata("kt51672.kt")
+        public void testKt51672() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/kt51672.kt");
+        }
+
+        @Test
         @TestMetadata("mangledDefaultParameterFunction.kt")
         public void testMangledDefaultParameterFunction() throws Exception {
             runTest("compiler/testData/codegen/box/inlineClasses/mangledDefaultParameterFunction.kt", TransformersFunctions.getReplaceOptionalJvmInlineAnnotationWithReal());

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/MemoizedInlineClassReplacements.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/MemoizedInlineClassReplacements.kt
@@ -234,12 +234,11 @@ class MemoizedInlineClassReplacements(
         val replacement = buildReplacementInner(function, replacementOrigin, noFakeOverride, useOldManglingScheme, body)
         // When using the new mangling scheme we might run into dependencies using the old scheme
         // for which we will fall back to the old mangling scheme as well.
-        if (
-            !useOldManglingScheme &&
-            replacement.name.asString().contains("-") &&
-            function.parentClassId?.let { classFileContainsMethod(it, replacement, context) } == false
-        ) {
-            return buildReplacementInner(function, replacementOrigin, noFakeOverride, true, body)
+        if (!useOldManglingScheme && replacement.name.asString().contains('-') && function.parentClassId != null) {
+            val resolved = (function as? IrSimpleFunction)?.resolveFakeOverride(true)
+            if (resolved?.parentClassId?.let { classFileContainsMethod(it, replacement, context) } == false) {
+                return buildReplacementInner(function, replacementOrigin, noFakeOverride, true, body)
+            }
         }
         return replacement
     }

--- a/compiler/testData/codegen/box/inlineClasses/kt51672.kt
+++ b/compiler/testData/codegen/box/inlineClasses/kt51672.kt
@@ -1,0 +1,20 @@
+// MODULE: lib
+// WITH_STDLIB
+// TARGET_BACKEND: JVM
+// FILE: lib.kt
+@JvmInline
+value class S(val value: String)
+
+interface A {
+    fun f(s: S): S = s
+}
+
+interface B : A
+
+// MODULE: main(lib)
+// FILE: main.kt
+interface C : B
+
+fun box(): String {
+    return object : C {}.f(S("OK")).value
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -20908,6 +20908,12 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
         }
 
         @Test
+        @TestMetadata("kt51672.kt")
+        public void testKt51672() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/kt51672.kt");
+        }
+
+        @Test
         @TestMetadata("mangledDefaultParameterFunction.kt")
         public void testMangledDefaultParameterFunction() throws Exception {
             runTest("compiler/testData/codegen/box/inlineClasses/mangledDefaultParameterFunction.kt", TransformersFunctions.getReplaceOptionalJvmInlineAnnotationWithReal());

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -21358,6 +21358,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         }
 
         @Test
+        @TestMetadata("kt51672.kt")
+        public void testKt51672() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/kt51672.kt");
+        }
+
+        @Test
         @TestMetadata("mangledDefaultParameterFunction.kt")
         public void testMangledDefaultParameterFunction() throws Exception {
             runTest("compiler/testData/codegen/box/inlineClasses/mangledDefaultParameterFunction.kt", TransformersFunctions.getReplaceOptionalJvmInlineAnnotationWithReal());

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -17451,6 +17451,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/inlineClasses/kt51353.kt");
         }
 
+        @TestMetadata("kt51672.kt")
+        public void testKt51672() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/kt51672.kt");
+        }
+
         @TestMetadata("mangledDefaultParameterFunction.kt")
         public void testMangledDefaultParameterFunction() throws Exception {
             runTest("compiler/testData/codegen/box/inlineClasses/mangledDefaultParameterFunction.kt", TransformersFunctions.getReplaceOptionalJvmInlineAnnotationWithReal());


### PR DESCRIPTION
This is necessary to determine which mangling scheme to use.