### PR TITLE
KT-51714: Parsing fails for context receivers with incomplete label

### DIFF
--- a/compiler/psi/src/org/jetbrains/kotlin/parsing/KotlinExpressionParsing.java
+++ b/compiler/psi/src/org/jetbrains/kotlin/parsing/KotlinExpressionParsing.java
@@ -1691,10 +1691,17 @@ public class KotlinExpressionParsing extends AbstractKotlinParsing {
      * IDENTIFIER "@"
      */
     void parseLabelDefinition() {
+        assert isAtLabelDefinitionOrMissingIdentifier() : "Callers must check that current token is IDENTIFIER followed with '@'";
+
         PsiBuilder.Marker labelWrap = mark();
         PsiBuilder.Marker mark = mark();
 
-        assert _at(IDENTIFIER) && myBuilder.rawLookup(1) == AT : "Callers must check that current token is IDENTIFIER followed with '@'";
+        if (at(AT)) {
+            errorAndAdvance("Expecting identifier before '@' in label definition");
+            labelWrap.drop();
+            mark.drop();
+            return;
+        }
 
         advance(); // IDENTIFIER
         advance(); // AT

--- a/compiler/testData/psi/ContextReceiversWithLabel_ERR.kt
+++ b/compiler/testData/psi/ContextReceiversWithLabel_ERR.kt
@@ -1,0 +1,2 @@
+context(@)
+fun a() {}

--- a/compiler/testData/psi/ContextReceiversWithLabel_ERR.txt
+++ b/compiler/testData/psi/ContextReceiversWithLabel_ERR.txt
@@ -1,0 +1,27 @@
+KtFile: ContextReceiversWithLabel_ERR.kt
+  PACKAGE_DIRECTIVE
+    <empty list>
+  IMPORT_LIST
+    <empty list>
+  FUN
+    CONTEXT_RECEIVER_LIST
+      PsiElement(context)('context')
+      PsiElement(LPAR)('(')
+      CONTEXT_RECEIVER
+        PsiErrorElement:Expecting identifier before '@' in label definition
+          PsiElement(AT)('@')
+        TYPE_REFERENCE
+          PsiErrorElement:Type expected
+            <empty list>
+      PsiElement(RPAR)(')')
+    PsiWhiteSpace('\n')
+    PsiElement(fun)('fun')
+    PsiWhiteSpace(' ')
+    PsiElement(IDENTIFIER)('a')
+    VALUE_PARAMETER_LIST
+      PsiElement(LPAR)('(')
+      PsiElement(RPAR)(')')
+    PsiWhiteSpace(' ')
+    BLOCK
+      PsiElement(LBRACE)('{')
+      PsiElement(RBRACE)('}')

--- a/compiler/tests-gen/org/jetbrains/kotlin/parsing/ParsingTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/parsing/ParsingTestGenerated.java
@@ -136,6 +136,11 @@ public class ParsingTestGenerated extends AbstractParsingTest {
             runTest("compiler/testData/psi/Constructors.kt");
         }
 
+        @TestMetadata("ContextReceiversWithLabel_ERR.kt")
+        public void testContextReceiversWithLabel_ERR() throws Exception {
+            runTest("compiler/testData/psi/ContextReceiversWithLabel_ERR.kt");
+        }
+
         @TestMetadata("ControlStructures.kt")
         public void testControlStructures() throws Exception {
             runTest("compiler/testData/psi/ControlStructures.kt");


### PR DESCRIPTION
When parsing the following or similar code an AssertionException is raised:

```kotlin
context(@)
fun a() {}
```

Inside the parser `parseLabelDefinition()` assumes, that it is currently at an `IDENTIFIER`. The corresponding condition `isAtLabelDefinitionOrMissingIdentifier()`, however, also accepts when parser is at an `@` Symbol. This trips the assert.

With this change, a proper parse error will now be shown. The message might be a bit too descriptive, though.