### PR TITLE
Remove redundant MetaSerializable test

### DIFF
--- a/plugins/kotlin-serialization/kotlin-serialization-compiler/test/org/jetbrains/kotlinx/serialization/SerializationPluginDiagnosticTestGenerated.java
+++ b/plugins/kotlin-serialization/kotlin-serialization-compiler/test/org/jetbrains/kotlinx/serialization/SerializationPluginDiagnosticTestGenerated.java
@@ -59,11 +59,6 @@ public class SerializationPluginDiagnosticTestGenerated extends AbstractSerializ
         runTest("plugins/kotlin-serialization/kotlin-serialization-compiler/testData/diagnostics/LocalAndAnonymous.kt");
     }
 
-    @TestMetadata("MetaSerializable.kt")
-    public void testMetaSerializable() throws Exception {
-        runTest("plugins/kotlin-serialization/kotlin-serialization-compiler/testData/diagnostics/MetaSerializable.kt");
-    }
-
     @TestMetadata("NoSuitableCtorInParent.kt")
     public void testNoSuitableCtorInParent() throws Exception {
         runTest("plugins/kotlin-serialization/kotlin-serialization-compiler/testData/diagnostics/NoSuitableCtorInParent.kt");


### PR DESCRIPTION
This test is a leftover from the original implementation of #4583 which was updated. This test is redundant now. 