### PR TITLE
[EE-IR] Support Local Functions

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/state/GenerationState.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/state/GenerationState.kt
@@ -22,9 +22,7 @@ import org.jetbrains.kotlin.codegen.optimization.OptimizationClassBuilderFactory
 import org.jetbrains.kotlin.codegen.serialization.JvmSerializationBindings
 import org.jetbrains.kotlin.config.*
 import org.jetbrains.kotlin.config.LanguageVersion.*
-import org.jetbrains.kotlin.descriptors.ClassDescriptor
-import org.jetbrains.kotlin.descriptors.ModuleDescriptor
-import org.jetbrains.kotlin.descriptors.ScriptDescriptor
+import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.diagnostics.Diagnostic
 import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.diagnostics.DiagnosticReporterFactory
@@ -402,6 +400,11 @@ class GenerationState private constructor(
 
     private fun shouldOnlyCollectSignatures(origin: JvmDeclarationOrigin) =
         classBuilderMode == ClassBuilderMode.LIGHT_CLASSES && origin.originKind in doNotGenerateInLightClassMode
+
+    val newFragmentCaptureParameters: MutableList<Triple<String, KotlinType, DeclarationDescriptor>> = mutableListOf()
+    fun recordNewFragmentCaptureParameter(string: String, type: KotlinType, descriptor: DeclarationDescriptor) {
+        newFragmentCaptureParameters.add(Triple(string, type, descriptor))
+    }
 
     companion object {
         private val LANGUAGE_TO_METADATA_VERSION = EnumMap<LanguageVersion, JvmMetadataVersion>(LanguageVersion::class.java).apply {

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirLocalVariableTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirLocalVariableTestGenerated.java
@@ -188,6 +188,28 @@ public class FirLocalVariableTestGenerated extends AbstractFirLocalVariableTest 
     }
 
     @Nested
+    @TestMetadata("compiler/testData/debug/localVariables/constructors")
+    @TestDataPath("$PROJECT_ROOT")
+    public class Constructors {
+        @Test
+        public void testAllFilesPresentInConstructors() throws Exception {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/debug/localVariables/constructors"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+        }
+
+        @Test
+        @TestMetadata("multipleConstructors.kt")
+        public void testMultipleConstructors() throws Exception {
+            runTest("compiler/testData/debug/localVariables/constructors/multipleConstructors.kt");
+        }
+
+        @Test
+        @TestMetadata("property.kt")
+        public void testProperty() throws Exception {
+            runTest("compiler/testData/debug/localVariables/constructors/property.kt");
+        }
+    }
+
+    @Nested
     @TestMetadata("compiler/testData/debug/localVariables/receiverMangling")
     @TestDataPath("$PROJECT_ROOT")
     public class ReceiverMangling {

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirSteppingTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirSteppingTestGenerated.java
@@ -248,6 +248,18 @@ public class FirSteppingTestGenerated extends AbstractFirSteppingTest {
     }
 
     @Test
+    @TestMetadata("kt15259.kt")
+    public void testKt15259() throws Exception {
+        runTest("compiler/testData/debug/stepping/kt15259.kt");
+    }
+
+    @Test
+    @TestMetadata("kt29179.kt")
+    public void testKt29179() throws Exception {
+        runTest("compiler/testData/debug/stepping/kt29179.kt");
+    }
+
+    @Test
     @TestMetadata("kt42208.kt")
     public void testKt42208() throws Exception {
         runTest("compiler/testData/debug/stepping/kt42208.kt");
@@ -335,6 +347,12 @@ public class FirSteppingTestGenerated extends AbstractFirSteppingTest {
     @TestMetadata("noParametersArgumentCallInExpression.kt")
     public void testNoParametersArgumentCallInExpression() throws Exception {
         runTest("compiler/testData/debug/stepping/noParametersArgumentCallInExpression.kt");
+    }
+
+    @Test
+    @TestMetadata("nullcheck.kt")
+    public void testNullcheck() throws Exception {
+        runTest("compiler/testData/debug/stepping/nullcheck.kt");
     }
 
     @Test

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/LocalDeclarationsLowering.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/LocalDeclarationsLowering.kt
@@ -11,9 +11,9 @@ import org.jetbrains.kotlin.backend.common.descriptors.synthesizedString
 import org.jetbrains.kotlin.backend.common.ir.*
 import org.jetbrains.kotlin.backend.common.lower.inline.isInlineParameter
 import org.jetbrains.kotlin.backend.common.runOnFilePostfix
-import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.descriptors.DescriptorVisibility
+import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.ir.*
 import org.jetbrains.kotlin.ir.builders.declarations.buildConstructor
 import org.jetbrains.kotlin.ir.builders.declarations.buildFun
@@ -80,7 +80,8 @@ class LocalDeclarationsLowering(
     val localNameProvider: LocalNameProvider = LocalNameProvider.DEFAULT,
     val visibilityPolicy: VisibilityPolicy = VisibilityPolicy.DEFAULT,
     val suggestUniqueNames: Boolean = true, // When `true` appends a `-#index` suffix to lifted declaration names
-    val forceFieldsForInlineCaptures: Boolean = false // See `LocalClassContext`
+    val forceFieldsForInlineCaptures: Boolean = false, // See `LocalClassContext`
+    private val postLocalDeclarationLoweringCallback: ((IntermediateDatastructures) -> Unit)? = null
 ) :
     BodyLoweringPass {
 
@@ -118,7 +119,7 @@ class LocalDeclarationsLowering(
             ScopeWithCounter(this)
         }
 
-    private abstract class LocalContext {
+    abstract class LocalContext {
         val capturedTypeParameterToTypeParameter: MutableMap<IrTypeParameter, IrTypeParameter> = mutableMapOf()
 
         // By the time typeRemapper is used, the map will be already filled
@@ -130,7 +131,7 @@ class LocalDeclarationsLowering(
         abstract fun irGet(startOffset: Int, endOffset: Int, valueDeclaration: IrValueDeclaration): IrExpression?
     }
 
-    private abstract class LocalContextWithClosureAsParameters : LocalContext() {
+    abstract class LocalContextWithClosureAsParameters : LocalContext() {
 
         abstract val declaration: IrFunction
         abstract val transformedDeclaration: IrFunction
@@ -144,7 +145,7 @@ class LocalDeclarationsLowering(
         }
     }
 
-    private class LocalFunctionContext(
+    class LocalFunctionContext(
         override val declaration: IrSimpleFunction,
         val index: Int,
         val ownerForLoweredDeclaration: IrDeclarationContainer
@@ -255,6 +256,10 @@ class LocalDeclarationsLowering(
             rewriteDeclarations()
 
             insertLoweredDeclarationForLocalFunctions()
+
+            postLocalDeclarationLoweringCallback?.invoke(
+                IntermediateDatastructures(localFunctions, newParameterToOld, newParameterToCaptured)
+            )
         }
 
         private fun insertLoweredDeclarationForLocalFunctions() {
@@ -975,6 +980,12 @@ class LocalDeclarationsLowering(
             }, Data(null, false))
         }
     }
+
+    data class IntermediateDatastructures(
+        val localFunctions: Map<IrFunction, LocalFunctionContext>,
+        val newParameterToOld: Map<IrValueParameter, IrValueParameter>,
+        val newParameterToCaptured: Map<IrValueParameter, IrValueSymbol>
+    )
 }
 
 // Local inner classes capture anything through outer

--- a/compiler/ir/backend.jvm/entrypoint/src/org/jetbrains/kotlin/backend/jvm/JvmIrCodegenFactory.kt
+++ b/compiler/ir/backend.jvm/entrypoint/src/org/jetbrains/kotlin/backend/jvm/JvmIrCodegenFactory.kt
@@ -52,7 +52,6 @@ open class JvmIrCodegenFactory(
     private val externalMangler: JvmDescriptorMangler? = null,
     private val externalSymbolTable: SymbolTable? = null,
     private val jvmGeneratorExtensions: JvmGeneratorExtensionsImpl = JvmGeneratorExtensionsImpl(configuration),
-    private val prefixPhases: CompilerPhase<JvmBackendContext, IrModuleFragment, IrModuleFragment>? = null,
     private val evaluatorFragmentInfoForPsi2Ir: EvaluatorFragmentInfo? = null,
     private val shouldStubAndNotLinkUnboundSymbols: Boolean = false,
 ) : CodegenFactory {
@@ -254,11 +253,14 @@ open class JvmIrCodegenFactory(
         )
             JvmIrSerializerImpl(state.configuration)
         else null
-        val phases = prefixPhases?.then(jvmLoweringPhases) ?: jvmLoweringPhases
+        val phases = if (evaluatorFragmentInfoForPsi2Ir != null) jvmFragmentLoweringPhases else jvmLoweringPhases
         val phaseConfig = customPhaseConfig ?: PhaseConfig(phases)
         val context = JvmBackendContext(
             state, irModuleFragment.irBuiltins, irModuleFragment, symbolTable, phaseConfig, extensions, backendExtension, irSerializer,
         )
+        if (evaluatorFragmentInfoForPsi2Ir != null) {
+            context.localDeclarationsLoweringData = mutableMapOf()
+        }
         val intrinsics by lazy { IrIntrinsicMethods(irModuleFragment.irBuiltins, context.ir.symbols) }
         context.getIntrinsic = { symbol: IrFunctionSymbol -> intrinsics.getIntrinsic(symbol) }
         /* JvmBackendContext creates new unbound symbols, have to resolve them. */

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/FragmentLocalFunctionPatchLowering.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/FragmentLocalFunctionPatchLowering.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.jvm.lower
+
+import org.jetbrains.kotlin.backend.common.FileLoweringPass
+import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
+import org.jetbrains.kotlin.backend.common.lower.LocalDeclarationsLowering
+import org.jetbrains.kotlin.backend.common.phaser.makeIrFilePhase
+import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
+import org.jetbrains.kotlin.backend.jvm.ir.createJvmIrBuilder
+import org.jetbrains.kotlin.backend.jvm.localDeclarationsPhase
+import org.jetbrains.kotlin.backend.jvm.lower.FragmentSharedVariablesLowering.Companion.GENERATED_FUNCTION_NAME
+import org.jetbrains.kotlin.ir.IrStatement
+import org.jetbrains.kotlin.ir.builders.declarations.addValueParameter
+import org.jetbrains.kotlin.ir.builders.irCall
+import org.jetbrains.kotlin.ir.builders.irGet
+import org.jetbrains.kotlin.ir.declarations.*
+import org.jetbrains.kotlin.ir.descriptors.toIrBasedDescriptor
+import org.jetbrains.kotlin.ir.descriptors.toIrBasedKotlinType
+import org.jetbrains.kotlin.ir.expressions.IrCall
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.copyTypeArgumentsFrom
+import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
+
+
+// Used from CodeFragmentCompiler for IDE Debugger Plug-In
+@Suppress("unused")
+val fragmentLocalFunctionPatchLowering = makeIrFilePhase(
+    ::FragmentLocalFunctionPatchLowering,
+    name = "FragmentLocalFunctionPatching",
+    description = "Rewrite calls to local functions to the appropriate, lifted function created by local declarations lowering.",
+    prerequisite = setOf(localDeclarationsPhase)
+)
+
+// This lowering rewrites local function calls in code fragments to the
+// corresponding lifted declaration. In the process, the lowering determines
+// whether the captures of the local function are a subset of the captures of
+// the fragment, and if not, introduces additional captures to the fragment
+// wrapper. The captures are then supplied to the fragment wrapper as
+// parameters supplied at evaluation time.
+internal class FragmentLocalFunctionPatchLowering(
+    val context: JvmBackendContext
+) : IrElementTransformerVoidWithContext(), FileLoweringPass {
+
+    lateinit var localDeclarationsData: Map<IrFunction, JvmBackendContext.LocalFunctionData>
+
+    override fun lower(irFile: IrFile) {
+        context.localDeclarationsLoweringData?.let {
+            localDeclarationsData = it
+        } ?: return
+        irFile.transformChildrenVoid(this)
+    }
+
+    override fun visitSimpleFunction(declaration: IrSimpleFunction): IrStatement {
+        if (declaration.name.asString() != GENERATED_FUNCTION_NAME) return declaration
+
+        declaration.body!!.transformChildrenVoid(object : IrElementTransformerVoidWithContext() {
+            override fun visitCall(expression: IrCall): IrExpression {
+                expression.transformChildrenVoid(this)
+                val localsData = localDeclarationsData[expression.symbol.owner] ?: return super.visitCall(expression)
+                val remappedTarget: LocalDeclarationsLowering.LocalFunctionContext = localsData.localContext
+
+                val irBuilder = context.createJvmIrBuilder(declaration.symbol)
+                return irBuilder.irCall(remappedTarget.transformedDeclaration).apply {
+                    this.copyTypeArgumentsFrom(expression)
+                    extensionReceiver = expression.extensionReceiver
+                    dispatchReceiver = expression.dispatchReceiver
+
+                    remappedTarget.transformedDeclaration.valueParameters.map { newValueParameterDeclaration ->
+                        val oldParameter = localsData.newParameterToOld[newValueParameterDeclaration]
+
+                        val getValue = if (oldParameter != null) {
+                            // the parameter is an actual parameter to the local
+                            // function, not a parameter corresponding to a
+                            // capture introduced by a lowering: fetch
+                            // the corresponding argument from the existing
+                            // call and place at the appropriate slot in the
+                            // call to the lowered function
+                            expression.getValueArgument(oldParameter.index)!!
+                        } else {
+                            // The parameter is introduced by the lowering to
+                            // private static function, so corresponds to a _capture_ by the local function
+                            val capturedValueSymbol =
+                                localsData.newParameterToCaptured[newValueParameterDeclaration]
+                                    ?: error("Non-mapped parameter $newValueParameterDeclaration")
+
+                            // We introduce a new parameter to the _fragment function_ surrounding the call to the
+                            // lowered local function, and supply _that_ parameter to the corresponding _argument_ slot
+                            // in the call to the lowered function.
+                            val newParameter = declaration.addValueParameter {
+                                type = capturedValueSymbol.owner.type
+                                name = capturedValueSymbol.owner.name
+                            }
+
+                            context.state.recordNewFragmentCaptureParameter(
+                                newParameter.name.asString(),
+                                capturedValueSymbol.owner.type.toIrBasedKotlinType(),
+                                capturedValueSymbol.owner.toIrBasedDescriptor()
+                            )
+
+                            irBuilder.irGet(newParameter)
+                        }
+
+                        putValueArgument(newValueParameterDeclaration.index, getValue)
+                    }
+                }
+            }
+
+        })
+
+        return declaration
+    }
+}

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendContext.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendContext.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.backend.common.CommonBackendContext
 import org.jetbrains.kotlin.backend.common.DefaultMapping
 import org.jetbrains.kotlin.backend.common.Mapping
 import org.jetbrains.kotlin.backend.common.ir.Ir
+import org.jetbrains.kotlin.backend.common.lower.LocalDeclarationsLowering
 import org.jetbrains.kotlin.backend.common.phaser.PhaseConfig
 import org.jetbrains.kotlin.backend.jvm.caches.BridgeLoweringCache
 import org.jetbrains.kotlin.backend.jvm.caches.CollectionStubComputer
@@ -47,6 +48,18 @@ class JvmBackendContext(
     val backendExtension: JvmBackendExtension,
     val irSerializer: JvmIrSerializer?,
 ) : CommonBackendContext {
+
+    data class LocalFunctionData(
+        val localContext: LocalDeclarationsLowering.LocalFunctionContext,
+        val newParameterToOld: Map<IrValueParameter, IrValueParameter>,
+        val newParameterToCaptured: Map<IrValueParameter, IrValueSymbol>
+    )
+
+    // If not-null, this is populated by LocalDeclarationsLowering with the intermediate data
+    // allowing mapping from local function captures to parameters and accurate transformation
+    // of calls to local functions from code fragments (i.e. the expression evaluator).
+    var localDeclarationsLoweringData: MutableMap<IrFunction, LocalFunctionData>? = null
+
     // If the JVM fqname of a class differs from what is implied by its parent, e.g. if it's a file class
     // annotated with @JvmPackageName, the correct name is recorded here.
     val classNameOverride: MutableMap<IrClass, JvmClassName>

--- a/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/GeneratorContext.kt
+++ b/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/GeneratorContext.kt
@@ -36,7 +36,7 @@ class GeneratorContext private constructor(
     val typeTranslator: TypeTranslator,
     override val irBuiltIns: IrBuiltIns,
     internal val callToSubstitutedDescriptorMap: MutableMap<IrDeclarationReference, CallableDescriptor>,
-    internal val fragmentContext: FragmentContext?,
+    internal var fragmentContext: FragmentContext?,
 ) : IrGeneratorContext {
 
     constructor(

--- a/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/fragments/FragmentModuleGenerator.kt
+++ b/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/fragments/FragmentModuleGenerator.kt
@@ -38,11 +38,25 @@ class FragmentModuleGenerator(
                             patchDeclarationParents()
                         }
                     } else {
-                        val fileContext = context.createFileScopeContext(ktFile)
-                        generateSingleFile(DeclarationGenerator(fileContext), ktFile, irModule)
+                        generateInContextWithoutFragmentInfo(ktFile) {
+                            generateSingleFile(DeclarationGenerator(it), ktFile, irModule)
+                        }
                     }
                 )
             }
+        }
+    }
+
+    private fun <T> generateInContextWithoutFragmentInfo(ktFile: KtFile, block: (GeneratorContext) -> T): T {
+        val symbolTableDecorator = context.symbolTable as FragmentCompilerSymbolTableDecorator
+        val fragmentInfo = symbolTableDecorator.fragmentInfo
+        symbolTableDecorator.fragmentInfo = null
+
+        val fileContext = context.createFileScopeContext(ktFile)
+        fileContext.fragmentContext = null
+
+        return block(fileContext).also {
+            symbolTableDecorator.fragmentInfo = fragmentInfo
         }
     }
 

--- a/compiler/testData/debug/localVariables/constructors/multipleConstructors.kt
+++ b/compiler/testData/debug/localVariables/constructors/multipleConstructors.kt
@@ -1,0 +1,38 @@
+
+
+// FILE: test.kt
+open class Base(i: Int)
+
+class Derived(): Base(1) {
+    constructor(p: Int): this() {
+        val a = 2
+    }
+
+    constructor(p1: Int, p2: Int): this()
+}
+
+fun box() {
+    Derived(3)
+    Derived(4, 5)
+}
+
+// EXPECTATIONS
+// test.kt:15 box:
+// test.kt:7 <init>: p:int=3:int
+// test.kt:6 <init>:
+// test.kt:4 <init>: i:int=1:int
+// test.kt:6 <init>:
+// test.kt:8 <init>: p:int=3:int
+// EXPECTATIONS JVM_IR
+// test.kt:9 <init>: p:int=3:int, a:int=2:int
+// EXPECTATIONS
+// test.kt:15 box:
+
+// test.kt:16 box:
+// test.kt:11 <init>: p1:int=4:int, p2:int=5:int
+// test.kt:6 <init>:
+// test.kt:4 <init>: i:int=1:int
+// test.kt:6 <init>:
+// test.kt:11 <init>: p1:int=4:int, p2:int=5:int
+// test.kt:16 box:
+// test.kt:17 box:

--- a/compiler/testData/debug/localVariables/constructors/property.kt
+++ b/compiler/testData/debug/localVariables/constructors/property.kt
@@ -1,0 +1,14 @@
+
+
+// FILE: test.kt
+class F(val a: String)
+
+fun box() {
+    F("foo")
+}
+
+// EXPECTATIONS
+// test.kt:7 box:
+// test.kt:4 <init>: a:java.lang.String="foo":java.lang.String
+// test.kt:7 box:
+// test.kt:8 box:

--- a/compiler/testData/debug/stepping/kt15259.kt
+++ b/compiler/testData/debug/stepping/kt15259.kt
@@ -1,0 +1,24 @@
+// IGNORE_BACKEND: JVM_IR
+// IGNORE_BACKEND_FIR: JVM_IR
+// FILE: test.kt
+interface ObjectFace
+
+private fun makeFace() = object : ObjectFace {
+
+    init { 5 }
+}
+
+fun box() {
+    makeFace()
+}
+
+// IR backend has additional steps on the way _out_ of the init block.
+
+// EXPECTATIONS
+// test.kt:12 box
+// test.kt:6 makeFace
+// test.kt:6 <init>
+// test.kt:8 <init>
+// test.kt:9 makeFace
+// test.kt:12 box
+// test.kt:13 box

--- a/compiler/testData/debug/stepping/kt29179.kt
+++ b/compiler/testData/debug/stepping/kt29179.kt
@@ -1,0 +1,26 @@
+// IGNORE_BACKEND: JVM_IR
+// IGNORE_BACKEND_FIR: JVM_IR
+// FILE: test.kt
+class A {
+    val a = 1
+    fun bar() = 2
+    fun foo() {
+        3
+            //Breakpoint! from the Evaluate Expression test suite.
+            .toString()
+    }
+}
+
+fun box() {
+    A().foo()
+}
+
+// EXPECTATIONS
+// test.kt:15 box
+// test.kt:4 <init>
+// test.kt:5 <init>
+// test.kt:15 box
+// test.kt:8 foo
+// test.kt:10 foo
+// test.kt:11 foo
+// test.kt:16 box

--- a/compiler/testData/debug/stepping/nullcheck.kt
+++ b/compiler/testData/debug/stepping/nullcheck.kt
@@ -1,0 +1,68 @@
+
+
+
+// FILE: test.kt
+fun box() {
+    test("OK")
+    test(null)
+    testExpressionBody("OK")
+    testExpressionBody(null)
+}
+
+fun test(nullable: String?): Boolean {
+    return nullable != null &&
+            // Some comment
+            nullable.length == 2
+}
+
+fun testExpressionBody(nullable: String?) =
+    nullable != null &&
+            // Some comment
+            nullable.length == 2
+
+// EXPECTATIONS
+// EXPECTATIONS JVM
+// test.kt:6 box
+// test.kt:15 test
+// test.kt:13 test
+// test.kt:6 box
+
+// test.kt:7 box
+// test.kt:15 test
+// test.kt:13 test
+// test.kt:7 box
+
+// test.kt:8 box
+// test.kt:21 testExpressionBody
+// test.kt:8 box
+
+// test.kt:9 box
+// test.kt:21 testExpressionBody
+// test.kt:9 box
+
+// test.kt:10 box
+
+// EXPECTATIONS JVM_IR
+// test.kt:6 box
+// test.kt:13 test
+// test.kt:15 test
+// test.kt:13 test
+// test.kt:6 box
+
+// test.kt:7 box
+// test.kt:13 test
+// test.kt:15 test
+// test.kt:13 test
+// test.kt:7 box
+
+// test.kt:8 box
+// test.kt:19 testExpressionBody
+// test.kt:21 testExpressionBody
+// test.kt:8 box
+
+// test.kt:9 box
+// test.kt:19 testExpressionBody
+// test.kt:21 testExpressionBody
+// test.kt:9 box
+
+// test.kt:10 box

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrLocalVariableTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrLocalVariableTestGenerated.java
@@ -188,6 +188,28 @@ public class IrLocalVariableTestGenerated extends AbstractIrLocalVariableTest {
     }
 
     @Nested
+    @TestMetadata("compiler/testData/debug/localVariables/constructors")
+    @TestDataPath("$PROJECT_ROOT")
+    public class Constructors {
+        @Test
+        public void testAllFilesPresentInConstructors() throws Exception {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/debug/localVariables/constructors"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+        }
+
+        @Test
+        @TestMetadata("multipleConstructors.kt")
+        public void testMultipleConstructors() throws Exception {
+            runTest("compiler/testData/debug/localVariables/constructors/multipleConstructors.kt");
+        }
+
+        @Test
+        @TestMetadata("property.kt")
+        public void testProperty() throws Exception {
+            runTest("compiler/testData/debug/localVariables/constructors/property.kt");
+        }
+    }
+
+    @Nested
     @TestMetadata("compiler/testData/debug/localVariables/receiverMangling")
     @TestDataPath("$PROJECT_ROOT")
     public class ReceiverMangling {

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrSteppingTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrSteppingTestGenerated.java
@@ -248,6 +248,18 @@ public class IrSteppingTestGenerated extends AbstractIrSteppingTest {
     }
 
     @Test
+    @TestMetadata("kt15259.kt")
+    public void testKt15259() throws Exception {
+        runTest("compiler/testData/debug/stepping/kt15259.kt");
+    }
+
+    @Test
+    @TestMetadata("kt29179.kt")
+    public void testKt29179() throws Exception {
+        runTest("compiler/testData/debug/stepping/kt29179.kt");
+    }
+
+    @Test
     @TestMetadata("kt42208.kt")
     public void testKt42208() throws Exception {
         runTest("compiler/testData/debug/stepping/kt42208.kt");
@@ -335,6 +347,12 @@ public class IrSteppingTestGenerated extends AbstractIrSteppingTest {
     @TestMetadata("noParametersArgumentCallInExpression.kt")
     public void testNoParametersArgumentCallInExpression() throws Exception {
         runTest("compiler/testData/debug/stepping/noParametersArgumentCallInExpression.kt");
+    }
+
+    @Test
+    @TestMetadata("nullcheck.kt")
+    public void testNullcheck() throws Exception {
+        runTest("compiler/testData/debug/stepping/nullcheck.kt");
     }
 
     @Test

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/LocalVariableTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/LocalVariableTestGenerated.java
@@ -188,6 +188,28 @@ public class LocalVariableTestGenerated extends AbstractLocalVariableTest {
     }
 
     @Nested
+    @TestMetadata("compiler/testData/debug/localVariables/constructors")
+    @TestDataPath("$PROJECT_ROOT")
+    public class Constructors {
+        @Test
+        public void testAllFilesPresentInConstructors() throws Exception {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/debug/localVariables/constructors"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM, true);
+        }
+
+        @Test
+        @TestMetadata("multipleConstructors.kt")
+        public void testMultipleConstructors() throws Exception {
+            runTest("compiler/testData/debug/localVariables/constructors/multipleConstructors.kt");
+        }
+
+        @Test
+        @TestMetadata("property.kt")
+        public void testProperty() throws Exception {
+            runTest("compiler/testData/debug/localVariables/constructors/property.kt");
+        }
+    }
+
+    @Nested
     @TestMetadata("compiler/testData/debug/localVariables/receiverMangling")
     @TestDataPath("$PROJECT_ROOT")
     public class ReceiverMangling {

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/SteppingTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/SteppingTestGenerated.java
@@ -248,6 +248,18 @@ public class SteppingTestGenerated extends AbstractSteppingTest {
     }
 
     @Test
+    @TestMetadata("kt15259.kt")
+    public void testKt15259() throws Exception {
+        runTest("compiler/testData/debug/stepping/kt15259.kt");
+    }
+
+    @Test
+    @TestMetadata("kt29179.kt")
+    public void testKt29179() throws Exception {
+        runTest("compiler/testData/debug/stepping/kt29179.kt");
+    }
+
+    @Test
     @TestMetadata("kt42208.kt")
     public void testKt42208() throws Exception {
         runTest("compiler/testData/debug/stepping/kt42208.kt");
@@ -335,6 +347,12 @@ public class SteppingTestGenerated extends AbstractSteppingTest {
     @TestMetadata("noParametersArgumentCallInExpression.kt")
     public void testNoParametersArgumentCallInExpression() throws Exception {
         runTest("compiler/testData/debug/stepping/noParametersArgumentCallInExpression.kt");
+    }
+
+    @Test
+    @TestMetadata("nullcheck.kt")
+    public void testNullcheck() throws Exception {
+        runTest("compiler/testData/debug/stepping/nullcheck.kt");
     }
 
     @Test


### PR DESCRIPTION
This commit introduces support for calling and referencing local functions and
objects in evaluate expression on the IR backend.

The primary incision is a lowering inserted after Local Declaration Lowering,
that uses the intermediate data structures recorded by LDL to rewrite calls to
local functions to the appropriate function in the binary, instead of predicting
the compilation strategy. The required changes to the rest of the pipeline
facilitate piping the required data around.

The key to this transformation is that _captures by the local function_ must be
introduced as _captures by the fragment function_, such that the evaluator
infrastructure can find the appropriate values at run-time. This is necessary
due to the strategy of compiling local functions to static functions instead of
closures.

Additional test coverage of stepping behavior support the corresponding changes
in the Evaluator, part of the Kotlin Debugger plug-in.