### PR TITLE
Fix for KT-51765

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/utils/androidPluginIds.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/utils/androidPluginIds.kt
@@ -11,7 +11,6 @@ internal val androidPluginIds = listOf(
     "com.android.dynamic-feature",
     "com.android.asset-pack",
     "com.android.asset-pack-bundle",
-    "com.android.lint",
     "com.android.test",
     // Deprecated android plugins
     "com.android.instantapp",


### PR DESCRIPTION
Kotlin Gradle plugin was incorrectly assuming that com.android.lint implies an Android project.
com.android.lint works for any JVM project and is used that way in various projects.