### PR TITLE
[JVM IR] Limit local variables in do-while conditions.

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirLocalVariableTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirLocalVariableTestGenerated.java
@@ -50,6 +50,12 @@ public class FirLocalVariableTestGenerated extends AbstractFirLocalVariableTest 
     }
 
     @Test
+    @TestMetadata("doWhile.kt")
+    public void testDoWhile() throws Exception {
+        runTest("compiler/testData/debug/localVariables/doWhile.kt");
+    }
+
+    @Test
     @TestMetadata("emptyFun.kt")
     public void testEmptyFun() throws Exception {
         runTest("compiler/testData/debug/localVariables/emptyFun.kt");

--- a/compiler/testData/checkLocalVariablesTable/underscoreNames.kt
+++ b/compiler/testData/checkLocalVariablesTable/underscoreNames.kt
@@ -13,7 +13,7 @@ fun box() {
         val (_, `_`, d) = A()
 
         for ((_, q) in arrayOfA) {
-
+            Unit
         }
 
         ""

--- a/compiler/testData/debug/localVariables/doWhile.kt
+++ b/compiler/testData/debug/localVariables/doWhile.kt
@@ -1,0 +1,33 @@
+// IGNORE_BACKEND: JVM
+// FILE: test.kt
+fun shouldContinue(i: Int) = i < 1
+
+fun box() {
+  var x = 0
+  do {
+      var z = 2
+      if (shouldContinue(x++)) {
+          continue
+      }
+      // Introduce a variable `y` which is not defined on all control-flow
+      // paths to the while condition. Therefore, it should not be in the
+      // local variable table at the condition.
+      var y = 12
+  } while (x < z)
+}
+
+// EXPECTATIONS
+// test.kt:6 box:
+// test.kt:8 box: x:int=0:int
+// test.kt:9 box: x:int=0:int, z:int=2:int
+// test.kt:3 shouldContinue: i:int=0:int
+// test.kt:9 box: x:int=1:int, z:int=2:int
+// test.kt:10 box: x:int=1:int, z:int=2:int
+// test.kt:16 box: x:int=1:int, z:int=2:int
+// test.kt:8 box: x:int=1:int
+// test.kt:9 box: x:int=1:int, z:int=2:int
+// test.kt:3 shouldContinue: i:int=1:int
+// test.kt:9 box: x:int=2:int, z:int=2:int
+// test.kt:15 box: x:int=2:int, z:int=2:int
+// test.kt:16 box: x:int=2:int, z:int=2:int
+// test.kt:17 box: x:int=2:int

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrLocalVariableTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrLocalVariableTestGenerated.java
@@ -50,6 +50,12 @@ public class IrLocalVariableTestGenerated extends AbstractIrLocalVariableTest {
     }
 
     @Test
+    @TestMetadata("doWhile.kt")
+    public void testDoWhile() throws Exception {
+        runTest("compiler/testData/debug/localVariables/doWhile.kt");
+    }
+
+    @Test
     @TestMetadata("emptyFun.kt")
     public void testEmptyFun() throws Exception {
         runTest("compiler/testData/debug/localVariables/emptyFun.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/LocalVariableTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/LocalVariableTestGenerated.java
@@ -50,6 +50,12 @@ public class LocalVariableTestGenerated extends AbstractLocalVariableTest {
     }
 
     @Test
+    @TestMetadata("doWhile.kt")
+    public void testDoWhile() throws Exception {
+        runTest("compiler/testData/debug/localVariables/doWhile.kt");
+    }
+
+    @Test
     @TestMetadata("emptyFun.kt")
     public void testEmptyFun() throws Exception {
         runTest("compiler/testData/debug/localVariables/emptyFun.kt");


### PR DESCRIPTION
Locals introduced in the body of a do-while loop are not
necessarily live at the do-while condition. For example,
if there is a continue in the body before the declaration:

    do {
      if (shouldContinue(x))
        continue
      val y = 32  // not always defined in the condition
      doSomething(y)
    } while (x < 2)

For locals referenced in the condition such code is rejected
by the frontend because a local referenced in the condition
must be always defined when you get there.

However, locals that are not used in the condition were always
put in the local variable table. This leads to invalid locals
information which can trip of debuggers and other build tools
such as the D8 dexer.

This patch only puts in locals information for locals actually
referenced in the local variable table for the condition.

^Fixes KT-51754