### PR TITLE
JVM: restore call site line number after inlining lambdas

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/AnonymousObjectTransformer.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/AnonymousObjectTransformer.kt
@@ -335,8 +335,7 @@ class AnonymousObjectTransformer(
                 inliningContext.callSiteInfo.inlineScopeVisibility,
                 inliningContext.callSiteInfo.file,
                 inliningContext.callSiteInfo.lineNumber
-            ),
-            null
+            )
         ).doInline(deferringVisitor, LocalVarRemapper(parameters, 0), false, mapOf())
         reifiedTypeParametersUsages?.let(result.reifiedTypeParametersUsages::mergeAll)
         deferringVisitor.visitMaxs(-1, -1)

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/InlineCodegen.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/InlineCodegen.kt
@@ -106,7 +106,7 @@ abstract class InlineCodegen<out T : BaseExpressionCodegen>(
             node, parameters, info, FieldRemapper(null, null, parameters), sourceCompiler.isCallInsideSameModuleAsCallee,
             "Method inlining " + sourceCompiler.callElementText,
             SourceMapCopier(sourceMapper, nodeAndSmap.classSMAP, callSite),
-            info.callSiteInfo, if (isInlineOnly) InlineOnlySmapSkipper(codegen) else null,
+            info.callSiteInfo, isInlineOnly,
             !isInlinedToInlineFunInKotlinRuntime()
         ) //with captured
 

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/SMAP.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/SMAP.kt
@@ -87,6 +87,7 @@ class SourceMapper(val sourceInfo: SourceInfo?) {
     companion object {
         const val FAKE_FILE_NAME = "fake.kt"
         const val FAKE_PATH = "kotlin/jvm/internal/FakeKt"
+        const val LOCAL_VARIABLE_INLINE_ARGUMENT_SYNTHETIC_LINE_NUMBER = 1
     }
 
     init {

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/inlineCodegenUtils.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/inlineCodegenUtils.kt
@@ -9,7 +9,6 @@ import com.intellij.openapi.vfs.VirtualFile
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.codegen.ASSERTIONS_DISABLED_FIELD_NAME
 import org.jetbrains.kotlin.codegen.AsmUtil
-import org.jetbrains.kotlin.codegen.BaseExpressionCodegen
 import org.jetbrains.kotlin.codegen.SamWrapperCodegen.SAM_WRAPPER_SUFFIX
 import org.jetbrains.kotlin.codegen.StackValue
 import org.jetbrains.kotlin.codegen.`when`.WhenByEnumsMapping
@@ -694,37 +693,6 @@ fun isFakeLocalVariableForInline(name: String): Boolean {
 }
 
 internal fun isThis0(name: String): Boolean = AsmUtil.CAPTURED_THIS_FIELD == name
-
-class InlineOnlySmapSkipper(codegen: BaseExpressionCodegen) {
-    private val callLineNumber = codegen.lastLineNumber
-
-    companion object {
-        const val LOCAL_VARIABLE_INLINE_ARGUMENT_SYNTHETIC_LINE_NUMBER = 1
-    }
-
-    fun onInlineLambdaStart(mv: MethodVisitor, lambda: MethodNode, smap: SourceMapper) {
-        val firstLine = lambda.instructions.asSequence().mapNotNull { it as? LineNumberNode }.firstOrNull()?.line ?: -1
-        if (callLineNumber >= 0 && firstLine == callLineNumber) {
-            // We want the debugger to be able to break both on the inline call itself, plus on each
-            // invocation of the inline lambda passed to it. For that to happen there needs to be at least
-            // one different line number in between those breakpoints for the VM to emit a locatable event.
-            // @InlineOnly functions, however, contain no line numbers, so if the lambda is single-line,
-            // the entire call will "meld" into a single region. To break it up, we insert a different line
-            // number that is remapped by the SMAP to a line that does not exist.
-            val label = Label()
-            mv.visitLabel(label)
-            mv.visitLineNumber(smap.mapSyntheticLineNumber(LOCAL_VARIABLE_INLINE_ARGUMENT_SYNTHETIC_LINE_NUMBER), label)
-        }
-    }
-
-    fun onInlineLambdaEnd(mv: MethodVisitor) {
-        if (callLineNumber >= 0) {
-            val label = Label()
-            mv.visitLabel(label)
-            mv.visitLineNumber(callLineNumber, label)
-        }
-    }
-}
 
 fun MethodNode.preprocessSuspendMarkers(forInline: Boolean, keepFakeContinuation: Boolean = true) {
     if (instructions.first == null) return

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/boxing/StackPeepholeOptimizationsTransformer.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/boxing/StackPeepholeOptimizationsTransformer.kt
@@ -16,6 +16,7 @@
 
 package org.jetbrains.kotlin.codegen.optimization.boxing
 
+import org.jetbrains.kotlin.codegen.optimization.common.FastMethodAnalyzer
 import org.jetbrains.kotlin.codegen.optimization.common.findPreviousOrNull
 import org.jetbrains.kotlin.codegen.optimization.transformer.MethodTransformer
 import org.jetbrains.org.objectweb.asm.Opcodes
@@ -29,83 +30,83 @@ class StackPeepholeOptimizationsTransformer : MethodTransformer() {
     }
 
     private fun transformOnce(methodNode: MethodNode): Boolean {
-        val actions = ArrayList<(InsnList) -> Unit>()
+        val instructions = methodNode.instructions
+        var changed = false
 
-        val insns = methodNode.instructions.toArray()
+        val isMergeNode = FastMethodAnalyzer.findMergeNodes(methodNode)
 
-        for (i in 1 until insns.size) {
-            val insn = insns[i]
-            val prev = insn.previous
-            val prevNonNop = insn.findPreviousOrNull { it.opcode != Opcodes.NOP } ?: continue
+        fun AbstractInsnNode.previousMeaningful() =
+            findPreviousOrNull {
+                it.opcode != Opcodes.NOP && it.type != AbstractInsnNode.LINE &&
+                        (it.type != AbstractInsnNode.LABEL || isMergeNode[instructions.indexOf(it)])
+            }
 
+        var insn: AbstractInsnNode?
+        var next = instructions.first
+        while (next != null) {
+            insn = next
+            next = insn.next
+
+            val prev = insn.previousMeaningful() ?: continue
             when (insn.opcode) {
                 Opcodes.POP -> {
                     when {
-                        prevNonNop.isEliminatedByPop() -> actions.add {
-                            it.set(insn, InsnNode(Opcodes.NOP))
-                            it.remove(prevNonNop)
+                        prev.isEliminatedByPop() -> {
+                            instructions.set(insn, InsnNode(Opcodes.NOP))
+                            instructions.set(prev, InsnNode(Opcodes.NOP))
+                            changed = true
                         }
-                        prevNonNop.opcode == Opcodes.DUP_X1 -> actions.add {
-                            it.remove(insn)
-                            it.set(prevNonNop, InsnNode(Opcodes.SWAP))
+                        prev.opcode == Opcodes.DUP_X1 -> {
+                            instructions.set(insn, InsnNode(Opcodes.NOP))
+                            instructions.set(prev, InsnNode(Opcodes.SWAP))
+                            changed = true
                         }
                     }
                 }
 
                 Opcodes.SWAP -> {
-                    val prevNonNop2 = prevNonNop.findPreviousOrNull { it.opcode != Opcodes.NOP } ?: continue
-                    if (prevNonNop.isPurePushOfSize1() && prevNonNop2.isPurePushOfSize1()) {
-                        actions.add {
-                            it.remove(insn)
-                            it.set(prevNonNop, prevNonNop2.clone(emptyMap()))
-                            it.set(prevNonNop2, prevNonNop.clone(emptyMap()))
-                        }
+                    val prev2 = prev.previousMeaningful() ?: continue
+                    if (prev.isPurePushOfSize1() && prev2.isPurePushOfSize1()) {
+                        instructions.set(insn, InsnNode(Opcodes.NOP))
+                        instructions.set(prev, prev2.clone(emptyMap()))
+                        instructions.set(prev2, prev.clone(emptyMap()))
+                        changed = true
                     }
                 }
 
                 Opcodes.I2L -> {
-                    when (prevNonNop.opcode) {
-                        Opcodes.ICONST_0 -> actions.add {
-                            it.remove(insn)
-                            it.set(prevNonNop, InsnNode(Opcodes.LCONST_0))
+                    when (prev.opcode) {
+                        Opcodes.ICONST_0 -> {
+                            instructions.set(insn, InsnNode(Opcodes.NOP))
+                            instructions.set(prev, InsnNode(Opcodes.LCONST_0))
+                            changed = true
                         }
-                        Opcodes.ICONST_1 -> actions.add {
-                            it.remove(insn)
-                            it.set(prevNonNop, InsnNode(Opcodes.LCONST_1))
+                        Opcodes.ICONST_1 -> {
+                            instructions.set(insn, InsnNode(Opcodes.NOP))
+                            instructions.set(prev, InsnNode(Opcodes.LCONST_1))
+                            changed = true
                         }
                     }
                 }
 
                 Opcodes.POP2 -> {
-                    if (prevNonNop.isEliminatedByPop2()) {
-                        actions.add {
-                            it.set(insn, InsnNode(Opcodes.NOP))
-                            it.remove(prevNonNop)
-                        }
-                    } else if (i > 1) {
-                        val prevNonNop2 = prevNonNop.findPreviousOrNull { it.opcode != Opcodes.NOP } ?: continue
-                        if (prevNonNop.isEliminatedByPop() && prevNonNop2.isEliminatedByPop()) {
-                            actions.add {
-                                it.set(insn, InsnNode(Opcodes.NOP))
-                                it.remove(prevNonNop)
-                                it.remove(prevNonNop2)
-                            }
+                    if (prev.isEliminatedByPop2()) {
+                        instructions.set(insn, InsnNode(Opcodes.NOP))
+                        instructions.set(prev, InsnNode(Opcodes.NOP))
+                        changed = true
+                    } else {
+                        val prev2 = prev.previousMeaningful() ?: continue
+                        if (prev.isEliminatedByPop() && prev2.isEliminatedByPop()) {
+                            instructions.set(insn, InsnNode(Opcodes.NOP))
+                            instructions.set(prev, InsnNode(Opcodes.NOP))
+                            instructions.set(prev2, InsnNode(Opcodes.NOP))
+                            changed = true
                         }
                     }
                 }
-
-                Opcodes.NOP ->
-                    if (prev.opcode == Opcodes.NOP) {
-                        actions.add {
-                            it.remove(prev)
-                        }
-                    }
             }
         }
-
-        actions.forEach { it(methodNode.instructions) }
-
-        return actions.isNotEmpty()
+        return changed
     }
 
     private fun AbstractInsnNode.isEliminatedByPop() =

--- a/compiler/testData/codegen/bytecodeText/coercionToUnitOptimization/nopInlineFuns.kt
+++ b/compiler/testData/codegen/bytecodeText/coercionToUnitOptimization/nopInlineFuns.kt
@@ -12,7 +12,7 @@ inline fun inlineFunInt(f: () -> Int): Int {
 
 inline fun inlineFunVoid(f: () -> Unit): Unit {
     val a = 1
-    return f()
+    return f() // return replaced with nop to stop here *after* calling f
 }
 
 fun simpleFunInt(f: () -> Int): Int {
@@ -20,7 +20,7 @@ fun simpleFunInt(f: () -> Int): Int {
 }
 
 fun simpleFunVoid(f: () -> Unit): Unit {
-    return f()
+    return f() // return replaced with nop to stop here *after* calling f
 }
 
-// 0 NOP
+// 2 NOP

--- a/compiler/testData/codegen/bytecodeText/inline/linenumberForOneParametersArgumentCall.kt
+++ b/compiler/testData/codegen/bytecodeText/inline/linenumberForOneParametersArgumentCall.kt
@@ -1,13 +1,13 @@
 
 fun box() {
-    lookAtMe {
-        val c = "c"
-    }
+    lookAtMe { // 1
+        val c = "c" // 4
+    } // 5 (nop)
 }
 
 inline fun lookAtMe(f: (String) -> Unit) {
-    val a = "a"
-    f(a) // Should be no unneeded nops on this line, that might be generated for zero-parameters lambda
-}
+    val a = "a" // 2
+    f(a) // 3 before call, 6 after call (nop)
+} // 7 (nop)
 
-// 2 NOP
+// 3 NOP

--- a/compiler/testData/debug/stepping/functionCallWithInlinedLambdaParam.kt
+++ b/compiler/testData/debug/stepping/functionCallWithInlinedLambdaParam.kt
@@ -21,11 +21,13 @@ inline fun foo(f: () -> Unit) {
 // test.kt:15 box
 // test.kt:5 box
 // test.kt:6 box
+// test.kt:15 box
 // test.kt:16 box
 // test.kt:8 box
 // test.kt:14 box
 // test.kt:15 box
 // test.kt:9 box
 // test.kt:10 box
+// test.kt:15 box
 // test.kt:16 box
 // test.kt:11 box

--- a/compiler/testData/debug/stepping/inTheEndOfLambdaArgumentOfInlineCall.kt
+++ b/compiler/testData/debug/stepping/inTheEndOfLambdaArgumentOfInlineCall.kt
@@ -30,5 +30,6 @@ fun nop() {}
 // test.kt:19 nop
 // test.kt:17 box
 // test.kt:7 box
+// test.kt:12 box
 // test.kt:13 box
 // test.kt:8 box

--- a/compiler/testData/debug/stepping/inlineCallableReference.kt
+++ b/compiler/testData/debug/stepping/inlineCallableReference.kt
@@ -21,6 +21,7 @@ inline fun f(block: () -> Unit) {
 // test.kt:15 box
 // test.kt:5 box
 // test.kt:6 box
+// test.kt:15 box
 // test.kt:16 box
 // test.kt:7 box
 // test.kt:8 box
@@ -29,5 +30,6 @@ inline fun f(block: () -> Unit) {
 // test.kt:15 box
 // test.kt:10 box
 // test.kt:11 box
+// test.kt:15 box
 // test.kt:16 box
 // test.kt:12 box

--- a/compiler/testData/debug/stepping/inlineNamedCallableReference.kt
+++ b/compiler/testData/debug/stepping/inlineNamedCallableReference.kt
@@ -16,5 +16,6 @@ fun g() {}
 // test.kt:8 box
 // test.kt:4 box
 // test.kt:11 g
+// test.kt:8 box
 // test.kt:9 box
 // test.kt:5 box

--- a/compiler/testData/debug/stepping/inlineSimpleCall.kt
+++ b/compiler/testData/debug/stepping/inlineSimpleCall.kt
@@ -27,11 +27,13 @@ fun box() {
 // test.kt:4 box
 // test.kt:9 box
 // test.kt:10 box
+// test.kt:4 box
 // test.kt:5 box
 // test.kt:12 box
 // test.kt:4 box
 // test.kt:13 box
 // test.kt:14 box
+// test.kt:4 box
 // test.kt:5 box
 // test.kt:16 box
 // test.kt:4 box
@@ -40,7 +42,9 @@ fun box() {
 // test.kt:4 box
 // test.kt:20 box
 // test.kt:21 box
+// test.kt:4 box
 // test.kt:5 box
 // test.kt:22 box
+// test.kt:4 box
 // test.kt:5 box
 // test.kt:23 box

--- a/compiler/testData/debug/stepping/lambdaStepInline.kt
+++ b/compiler/testData/debug/stepping/lambdaStepInline.kt
@@ -17,7 +17,9 @@ fun box(): String {
 // test.kt:8 box
 // test.kt:4 box
 // test.kt:8 box
+// test.kt:4 box
 // test.kt:9 box
 // test.kt:4 box
 // test.kt:10 box
+// test.kt:4 box
 // test.kt:13 box

--- a/compiler/testData/debug/stepping/lambdaStepInlineWithDefaults.kt
+++ b/compiler/testData/debug/stepping/lambdaStepInlineWithDefaults.kt
@@ -22,8 +22,10 @@ fun box(): String {
 // test.kt:3 box
 // test.kt:4 box
 // test.kt:3 box
+// test.kt:4 box
 // test.kt:16 box
 // test.kt:7 box
 // test.kt:11 box
 // test.kt:8 box
+// test.kt:11 box
 // test.kt:17 box

--- a/compiler/testData/debug/stepping/linenumberForOneParametersArgumentCall.kt
+++ b/compiler/testData/debug/stepping/linenumberForOneParametersArgumentCall.kt
@@ -17,5 +17,6 @@ inline fun lookAtMe(f: (String) -> Unit) {
 // test.kt:11 box
 // test.kt:5 box
 // test.kt:6 box
+// test.kt:11 box
 // test.kt:12 box
 // test.kt:7 box

--- a/compiler/testData/debug/stepping/nestedInline.kt
+++ b/compiler/testData/debug/stepping/nestedInline.kt
@@ -53,9 +53,11 @@ inline fun html(init: () -> Unit) {
 // 1.kt:34 box
 // test.kt:11 box
 // test.kt:12 box
+// 1.kt:34 box
 // 1.kt:35 box
 // 1.kt:37 box
 // test.kt:13 box
+// 1.kt:29 box
 // 1.kt:30 box
 // 1.kt:41 box
 // test.kt:15 box

--- a/compiler/testData/debug/stepping/noParametersArgumentCallInExpression.kt
+++ b/compiler/testData/debug/stepping/noParametersArgumentCallInExpression.kt
@@ -16,5 +16,6 @@ inline fun lookAtMe(f: () -> Int) {
 // test.kt:10 box
 // test.kt:11 box
 // test.kt:5 box
+// test.kt:11 box
 // test.kt:12 box
 // test.kt:7 box

--- a/compiler/testData/debug/stepping/simpleSmap.kt
+++ b/compiler/testData/debug/stepping/simpleSmap.kt
@@ -15,5 +15,6 @@ fun box() {
 // test.kt:4 box
 // test.kt:9 box
 // test.kt:10 box
+// test.kt:4 box
 // test.kt:5 box
 // test.kt:11 box


### PR DESCRIPTION
E.g. in `x + f()` where `f` is an inline lambda, the instructions for `+` should have the line number of that expression (while previously they instead had the line number of the last line of the lambda).

Since this generates many more line numbers, nops, and corresponding labels, this PR also includes a memory optimization in FastMethodAnalyzer to avoid constructing Frame objects for such instructions.

The changes in stepping tests are consistent with how non-inline lambdas behave, i.e. "force step into" at the end of a lambda brings you back to the call even if the result is discarded.

Note that although this change adds fake line numbers to single-line inline functions with default lambda arguments, this does not fix KTIJ-21440; apparently, extra support from IntelliJ is required.

^KT-51738 Fixed