### PR TITLE
[EE-IR] Add "different classloader" check to synthetic accessor lowering

### DIFF
--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/ReflectiveAccess.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/ReflectiveAccess.kt
@@ -74,7 +74,7 @@ internal class ReflectiveAccessLowering(
 
     // Wrapper for the logic from SyntheticAccessorLowering
     private fun IrSymbol.isAccessible(withSuper: Boolean = false): Boolean {
-        return isAccessible(context, currentScope, inlineScopeResolver, withSuper, null)
+        return isAccessible(context, currentScope, inlineScopeResolver, withSuper, null, fromOtherClassLoader = true)
     }
 
     // Fragments are transformed in a post-order traversal: children first,


### PR DESCRIPTION
An evaluator fragment is considered a member of the `root` package.

When evaluating fragments that call `protected` members at a breakpoint in a file that is also in the `root` package, the logic from synthetic accessor lowering declares the access for legal: the JVM allows protected access within the same package...

... unless the call and the callee live on different class loaders, as may be the case when the evaluator uses the "compiling evaluator" mechanism, where the code for the fragment is loaded and run on the JVM being debugged, rather than interpret the code using eval4j.

This PR lets the fragment lowering tell the logic from synthetic accessor lowering to consider the access as across class loader boundaries.

This will unmute a test (superMembers.kt) in the evaluator suite in the plug-in.