### PR TITLE
Fix utf8

### DIFF
--- a/kotlin-native/licenses/third_party/harmony_LICENSE.txt
+++ b/kotlin-native/licenses/third_party/harmony_LICENSE.txt
@@ -805,7 +805,7 @@ PKCS#7, PKCS#8 and PKSC#10. Portions of these standards are included
 in Harmony Javadoc for reference, and in accordance with the licensing terms 
 for PKCS#7, PKCS#8 and PKSC#10, the full copyright statement is here:
 
-Copyrigh © 1991-1993 RSA Laboratories, a division of RSA Data Security, Inc.
+Copyright © 1991-1993 RSA Laboratories, a division of RSA Data Security, Inc.
 License to copy this document is granted provided that it is identified as
 "RSA Data Security, Inc. Public-Key Cryptography Standards (PKCS)" in all
 material mentioning or referencing this document.

--- a/kotlin-native/licenses/third_party/harmony_LICENSE.txt
+++ b/kotlin-native/licenses/third_party/harmony_LICENSE.txt
@@ -805,7 +805,7 @@ PKCS#7, PKCS#8 and PKSC#10. Portions of these standards are included
 in Harmony Javadoc for reference, and in accordance with the licensing terms 
 for PKCS#7, PKCS#8 and PKSC#10, the full copyright statement is here:
 
-Copyright © 1991-1993 RSA Laboratories, a division of RSA Data Security, Inc.
+Copyrigh Â© 1991-1993 RSA Laboratories, a division of RSA Data Security, Inc.
 License to copy this document is granted provided that it is identified as
 "RSA Data Security, Inc. Public-Key Cryptography Standards (PKCS)" in all
 material mentioning or referencing this document.


### PR DESCRIPTION
Reprocess kotlin-native/licenses/third_party/harmony_LICENSE.txt to add the correct character

This can be seen by running the following command:
grep -axv '.*'  kotlin-native/licenses/third_party/harmony_LICENSE.txt | od -c -bxc
Before:
0000000   C   o   p   y   r   i   g   h     251       1   9   9   1   -
        103 157 160 171 162 151 147 150 040 251 040 061 071 071 061 055
           6f43    7970    6972    6867    a920    3120    3939    2d31
          C   o   p   y   r   i   g   h     251       1   9   9   1   -
0000020   1   9   9   3       R   S   A       L   a   b   o   r   a   t
        061 071 071 063 040 122 123 101 040 114 141 142 157 162 141 164
           3931    3339    5220    4153    4c20    6261    726f    7461
          1   9   9   3       R   S   A       L   a   b   o   r   a   t
0000040   o   r   i   e   s   ,       a       d   i   v   i   s   i   o
        157 162 151 145 163 054 040 141 040 144 151 166 151 163 151 157
           726f    6569    2c73    6120    6420    7669    7369    6f69
          o   r   i   e   s   ,       a       d   i   v   i   s   i   o
0000060   n       o   f       R   S   A       D   a   t   a       S   e
        156 040 157 146 040 122 123 101 040 104 141 164 141 040 123 145
           206e    666f    5220    4153    4420    7461    2061    6553
          n       o   f       R   S   A       D   a   t   a       S   e
0000100   c   u   r   i   t   y   ,       I   n   c   .  \n
        143 165 162 151 164 171 054 040 111 156 143 056 012
           7563    6972    7974    202c    6e49    2e63    000a
          c   u   r   i   t   y   ,       I   n   c   .  \n
After:
0000000

Note: The 00000 mean that it didn't find any invalid lines.

Fixes  KT-52150