### PR TITLE
JVM: write back to tailrec function parameters if possible

### DIFF
--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/ir/builders/IrBuilders.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/ir/builders/IrBuilders.kt
@@ -24,10 +24,7 @@ import org.jetbrains.kotlin.ir.declarations.IrVariable
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrLoop
 import org.jetbrains.kotlin.ir.expressions.IrStatementOrigin
-import org.jetbrains.kotlin.ir.expressions.impl.IrBreakImpl
-import org.jetbrains.kotlin.ir.expressions.impl.IrContinueImpl
-import org.jetbrains.kotlin.ir.expressions.impl.IrGetObjectValueImpl
-import org.jetbrains.kotlin.ir.expressions.impl.IrWhileLoopImpl
+import org.jetbrains.kotlin.ir.expressions.impl.*
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.SimpleTypeNullability
@@ -36,6 +33,9 @@ import org.jetbrains.kotlin.name.Name
 
 fun IrBuilderWithScope.irWhile(origin: IrStatementOrigin? = null) =
     IrWhileLoopImpl(startOffset, endOffset, context.irBuiltIns.unitType, origin)
+
+fun IrBuilderWithScope.irDoWhile(origin: IrStatementOrigin? = null) =
+    IrDoWhileLoopImpl(startOffset, endOffset, context.irBuiltIns.unitType, origin)
 
 fun IrBuilderWithScope.irBreak(loop: IrLoop) =
     IrBreakImpl(startOffset, endOffset, context.irBuiltIns.nothingType, loop)

--- a/compiler/ir/backend.jvm/entrypoint/src/org/jetbrains/kotlin/backend/jvm/JvmGeneratorExtensionsImpl.kt
+++ b/compiler/ir/backend.jvm/entrypoint/src/org/jetbrains/kotlin/backend/jvm/JvmGeneratorExtensionsImpl.kt
@@ -249,4 +249,7 @@ open class JvmGeneratorExtensionsImpl(
         }
         return null
     }
+
+    override val parametersAreAssignable: Boolean
+        get() = true
 }

--- a/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/GeneratorExtensions.kt
+++ b/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/GeneratorExtensions.kt
@@ -45,4 +45,7 @@ open class GeneratorExtensions : StubGeneratorExtensions() {
     open fun unwrapSyntheticJavaProperty(descriptor: PropertyDescriptor): Pair<FunctionDescriptor, FunctionDescriptor?>? = null
 
     open fun remapDebuggerFieldPropertyDescriptor(propertyDescriptor: PropertyDescriptor): PropertyDescriptor = propertyDescriptor
+
+    open val parametersAreAssignable: Boolean
+        get() = false
 }


### PR DESCRIPTION
This makes the debugger update the values when entering a recursive call, and also uses fewer variable slots.

This may also work on the JS backend, but Native would probably require something else.

^KT-47203 Fixed