### PR TITLE
[FE1.0] Fix CFG for inline function calls in finally blocks.

### DIFF
--- a/analysis/low-level-api-fir/tests/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/compiler/based/DiagnosisCompilerTestFE10TestdataTestGenerated.java
+++ b/analysis/low-level-api-fir/tests/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/compiler/based/DiagnosisCompilerTestFE10TestdataTestGenerated.java
@@ -5717,6 +5717,12 @@ public class DiagnosisCompilerTestFE10TestdataTestGenerated extends AbstractDiag
             }
 
             @Test
+            @TestMetadata("kt52131.kt")
+            public void testKt52131() throws Exception {
+                runTest("compiler/testData/diagnostics/tests/controlFlowAnalysis/kt52131.kt");
+            }
+
+            @Test
             @TestMetadata("kt607.kt")
             public void testKt607() throws Exception {
                 runTest("compiler/testData/diagnostics/tests/controlFlowAnalysis/kt607.kt");

--- a/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsTestGenerated.java
@@ -5717,6 +5717,12 @@ public class FirOldFrontendDiagnosticsTestGenerated extends AbstractFirDiagnosti
             }
 
             @Test
+            @TestMetadata("kt52131.kt")
+            public void testKt52131() throws Exception {
+                runTest("compiler/testData/diagnostics/tests/controlFlowAnalysis/kt52131.kt");
+            }
+
+            @Test
             @TestMetadata("kt607.kt")
             public void testKt607() throws Exception {
                 runTest("compiler/testData/diagnostics/tests/controlFlowAnalysis/kt607.kt");

--- a/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsWithLightTreeTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsWithLightTreeTestGenerated.java
@@ -5717,6 +5717,12 @@ public class FirOldFrontendDiagnosticsWithLightTreeTestGenerated extends Abstrac
             }
 
             @Test
+            @TestMetadata("kt52131.kt")
+            public void testKt52131() throws Exception {
+                runTest("compiler/testData/diagnostics/tests/controlFlowAnalysis/kt52131.kt");
+            }
+
+            @Test
             @TestMetadata("kt607.kt")
             public void testKt607() throws Exception {
                 runTest("compiler/testData/diagnostics/tests/controlFlowAnalysis/kt607.kt");

--- a/compiler/frontend/cfg/src/org/jetbrains/kotlin/cfg/pseudocode/instructions/special/InlinedLocalFunctionDeclarationInstruction.kt
+++ b/compiler/frontend/cfg/src/org/jetbrains/kotlin/cfg/pseudocode/instructions/special/InlinedLocalFunctionDeclarationInstruction.kt
@@ -30,7 +30,7 @@ class InlinedLocalFunctionDeclarationInstruction(
     blockScope: BlockScope,
     val kind: EventOccurrencesRange
 ) : LocalFunctionDeclarationInstruction(element, body, blockScope) {
-    override fun createCopy(): InstructionImpl = InlinedLocalFunctionDeclarationInstruction(element, body, blockScope, kind)
+    override fun createCopy(): InstructionImpl = InlinedLocalFunctionDeclarationInstruction(element, body.copy(), blockScope, kind)
 
     override fun accept(visitor: InstructionVisitor) = visitor.visitInlinedLocalFunctionDeclarationInstruction(this)
 

--- a/compiler/testData/diagnostics/tests/controlFlowAnalysis/kt52131.kt
+++ b/compiler/testData/diagnostics/tests/controlFlowAnalysis/kt52131.kt
@@ -1,0 +1,10 @@
+// FIR_IDENTICAL
+
+fun foo(): Int {
+    var result = 0
+    try {
+    } finally {
+        42.let { }
+    }
+    return result
+}

--- a/compiler/testData/diagnostics/tests/controlFlowAnalysis/kt52131.txt
+++ b/compiler/testData/diagnostics/tests/controlFlowAnalysis/kt52131.txt
@@ -1,0 +1,3 @@
+package
+
+public fun foo(): kotlin.Int

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/DiagnosticTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/DiagnosticTestGenerated.java
@@ -5723,6 +5723,12 @@ public class DiagnosticTestGenerated extends AbstractDiagnosticTest {
             }
 
             @Test
+            @TestMetadata("kt52131.kt")
+            public void testKt52131() throws Exception {
+                runTest("compiler/testData/diagnostics/tests/controlFlowAnalysis/kt52131.kt");
+            }
+
+            @Test
             @TestMetadata("kt607.kt")
             public void testKt607() throws Exception {
                 runTest("compiler/testData/diagnostics/tests/controlFlowAnalysis/kt607.kt");


### PR DESCRIPTION
The body of the InlinedLocalFunctionDeclarationInstruction was
not copied. That confuses the information on the exceptional edge
with the information on the normal edge.

^KT-52131 Fixed