### PR TITLE
[EE-IR] Minor: run local function patching on all fragment code

### DIFF
--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/FragmentLocalFunctionPatchLowering.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/FragmentLocalFunctionPatchLowering.kt
@@ -55,8 +55,6 @@ internal class FragmentLocalFunctionPatchLowering(
     }
 
     override fun visitSimpleFunction(declaration: IrSimpleFunction): IrStatement {
-        if (declaration.name.asString() != GENERATED_FUNCTION_NAME) return declaration
-
         declaration.body!!.transformChildrenVoid(object : IrElementTransformerVoidWithContext() {
             override fun visitCall(expression: IrCall): IrExpression {
                 expression.transformChildrenVoid(this)


### PR DESCRIPTION
Sequence Debugger test suite revealed the need for rewriting calls to local functions in _lambdas_ occuring in the fragment.