### PR TITLE
KT-45875: Add Sequence.randomOrNull and Sequence.random

### DIFF
--- a/libraries/stdlib/src/kotlin/collections/Sequences.kt
+++ b/libraries/stdlib/src/kotlin/collections/Sequences.kt
@@ -677,3 +677,35 @@ public fun <T : Any> generateSequence(seed: T?, nextFunction: (T) -> T?): Sequen
 public fun <T : Any> generateSequence(seedFunction: () -> T?, nextFunction: (T) -> T?): Sequence<T> =
     GeneratorSequence(seedFunction, nextFunction)
 
+
+
+/**
+ * Picks a random element from the sequence. Will return `null` in the case, the sequence is empty.
+ *
+ * This function works differently in comparison to, for example, [List.randomOrNull].
+ * It does not allocate a list of all elements in the sequence, however, it does consume
+ * much more randomness (roughly 1 "randomly generated integer" per element in the sequence).
+ *
+ * @param random the source of randomness to use
+ * @return a randomly picked element, or `null` if the sequence is empty
+ */
+public fun <T> Sequence<T>.randomOrNull(random: Random = Random): T? {
+    return foldIndexed<T, T?>(null) { index, acc, value ->
+        if (random.nextInt(index + 1) == 0) value else acc
+    }
+}
+
+/**
+ * Picks a random element from the sequence.
+ *
+ * This function works differently in comparison to, for example, [List.randomOrNull].
+ * It does not allocate a list of all elements in the sequence, however, it does consume
+ * much more randomness (roughly 1 "randomly generated integer" per element in the sequence).
+ *
+ * @param random the source of randomness to use
+ * @return a randomly picked element
+ * @throws NoSuchElementException if the sequence is empty
+ */
+public fun <T> Sequence<T>.random(random: Random = Random): T {
+    return randomOrNull(random) ?: throw NoSuchElementException("Sequence is empty.")
+}

--- a/libraries/stdlib/src/kotlin/collections/Sequences.kt
+++ b/libraries/stdlib/src/kotlin/collections/Sequences.kt
@@ -698,7 +698,7 @@ public fun <T> Sequence<T>.randomOrNull(random: Random = Random): T? {
 /**
  * Picks a random element from the sequence.
  *
- * This function works differently in comparison to, for example, [List.randomOrNull].
+ * This function works differently in comparison to, for example, [List.random].
  * It does not allocate a list of all elements in the sequence, however, it does consume
  * much more randomness (roughly 1 "randomly generated integer" per element in the sequence).
  *

--- a/libraries/stdlib/test/collections/SequenceTest.kt
+++ b/libraries/stdlib/test/collections/SequenceTest.kt
@@ -759,6 +759,12 @@ public class SequenceTest {
     }
 
     @Test
+    fun randomOrNullNonEmptySequence() {
+        val sequence = sequenceOf("Hello World")
+        assertEquals("Hello World", sequence.randomOrNull())
+    }
+
+    @Test
     fun randomOrNullConsistency() {
         val sequence1 = fibonacci().take(32)
         val sequence2 = fibonacci().take(32)
@@ -772,6 +778,8 @@ public class SequenceTest {
 
         assertNotNull(pick1)
         assertEquals(pick1, pick2)
+        assertContains(sequence1, pick1)
+        assertContains(sequence2, pick2)
     }
 
     @Test
@@ -780,6 +788,12 @@ public class SequenceTest {
         assertFailsWith<NoSuchElementException> {
             sequence.random()
         }
+    }
+
+    @Test
+    fun randomNonEmptySequence() {
+        val sequence = sequenceOf("Hello World")
+        assertEquals("Hello World", sequence.random())
     }
 
     @Test
@@ -795,6 +809,8 @@ public class SequenceTest {
         val pick2 = sequence2.random(random2)
 
         assertEquals(pick1, pick2)
+        assertContains(sequence1, pick1)
+        assertContains(sequence2, pick2)
     }
 
 }

--- a/libraries/stdlib/test/collections/SequenceTest.kt
+++ b/libraries/stdlib/test/collections/SequenceTest.kt
@@ -752,4 +752,49 @@ public class SequenceTest {
     }
 */
 
+    @Test
+    fun randomOrNullEmptySequence() {
+        val sequence = emptySequence<Unit>()
+        assertNull(sequence.randomOrNull())
+    }
+
+    @Test
+    fun randomOrNullConsistency() {
+        val sequence1 = fibonacci().take(32)
+        val sequence2 = fibonacci().take(32)
+
+        val seed = Random.nextInt()
+        val random1 = Random(seed)
+        val random2 = Random(seed)
+
+        val pick1 = sequence1.randomOrNull(random1)
+        val pick2 = sequence2.randomOrNull(random2)
+
+        assertNotNull(pick1)
+        assertEquals(pick1, pick2)
+    }
+
+    @Test
+    fun randomEmptySequence() {
+        val sequence = emptySequence<Unit>()
+        assertFailsWith<NoSuchElementException> {
+            sequence.random()
+        }
+    }
+
+    @Test
+    fun randomConsistency() {
+        val sequence1 = fibonacci().take(32)
+        val sequence2 = fibonacci().take(32)
+
+        val seed = Random.nextInt()
+        val random1 = Random(seed)
+        val random2 = Random(seed)
+
+        val pick1 = sequence1.random(random1)
+        val pick2 = sequence2.random(random2)
+
+        assertEquals(pick1, pick2)
+    }
+
 }


### PR DESCRIPTION
This resolves [KT-45875](https://youtrack.jetbrains.com/issue/KT-45875), by adding `Sequence.randomOrNull` and `Sequence.random` functions. Both allow for a custom random-source to be provided.

The `randomOrNull` function picks a random element out of the sequence and returns `null` if the sequence is empty. This function also works for sequences with nullable elements, I thought it should be up to the end-user to deal with this, as it introduces a conflicting meaning of `null`.

The `random` function picks a random element and throws a `NoSuchElementExcepetion` in case the sequence is empty.

The implementation works as described by Roman Elizarov in the issue, consuming a lot of randomness, but not requiring the sequence to be completely allocated in memory.



## [Checklist](https://github.com/JetBrains/kotlin/blob/master/docs/contributing.md#checklist)

> Before submitting the pull request, make sure that you can say "YES" to each point in this short checklist:

- [x] You provided the link to the related issue(s) from YouTrack
- [x] You made a reasonable amount of changes related only to the provided issues
- [x] You can explain changes made in the pull request
- [x] You ran the build locally and verified new functionality
- [x] You ran related tests locally and they passed
- [x] You do not have merge commits in the pull request



## Proof of correctness

It might be of interest, whether the algorithm actually provides the same probability for all elements in the sequence, and does not prefer, for example, the first or the last elements.

For this, we need to show that given `n ∈ ℕ` elements, each element has a probability of `1 / n`. We can ignore the case of `n = 0`, as we just return `null` or throw an exception in that case.

### Assumption

We assume we have a good random function `random(n)`, which returns any integer in `[1, n]` with equal probability of `1 / n`, for every `n ∈ ℕ`.

**Note:** In the implementation, we use a slightly different function, that returns an integer in `[0, n[`, however, assuming the numbers are still evenly distributed, this does not affect the proof, as we only need to replace `random(n) = 1` with `random(n) = 0` in the implementation.

### Induction Base

The first element, so `n = 1`, should have a probability of `1 / 1 = 100%`. This can be done, by picking the element if `random(n) = random(1) = 1`, which, by definition of the random function, is always the case.

### Induction Step

Given a sequence of `n` elements, for every new element `n + 1`, we need to prove things:

1. The new element has a probability of `1 / (n+1)` to be picked.
2. All previous elements, had a probability of `1 / n`, and now have a probability of `1 / (n+1)`.

#### Proof of the first

We simply pick the new element, if `random(n + 1) = 1`, and thus with a probability of `1 / (n+1)`.

#### Proof of the latter

We can assume, that every previous element, up to this point, has an even probability of `1 / n`. The probability for these elements to be picked now, is that *they have been picked earlier, **and** the new element has **not** been picked*. Expressed mathematically, the probability is `(1 / n) * (1 - (1 / (n+1)))`. We want all these elements to now have a probability of `1 / (n+1)`.

We now need to prove that:
1. `1 / (n+1) = (1 / n) * (1 - (1 / (n+1)))`
2. `1 = (1 / n) * (1 - (1 / (n+1))) * (n+1)`
3. `1 = (1 / n) * ((n+1) - ((n+1) / (n+1)))`
4. `1 = (1 / n) * (n + 1 - 1)`
5. `1 = (1 / n) * n`
6. `1 = 1`
7. This adds up. ✔️ 

#### Conclusion

All elements now have a probability of `1 / (n+1)`, which is exactly what we want.

This small proof might be absolutely not needed, but I found it rather not entirely obvious, that all elements have an equal probability, so I guess it's better to be safe than sorry.