### PR TITLE
KT-52243: Fix cacheability of CInteropProcess

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/CommonizerIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/CommonizerIT.kt
@@ -675,6 +675,29 @@ class CommonizerIT : BaseGradleIT() {
         }
     }
 
+    @Test
+    fun `test cinterop caching`() {
+        with(preparedProject("commonizeCurlInterop")) {
+            val localBuildCacheDir = projectDir.resolve("local-build-cache-dir").also { assertTrue(it.mkdirs()) }
+            gradleSettingsScript().appendText("""
+                
+                buildCache {
+                    local {
+                        directory = "$localBuildCacheDir"
+                    }
+                }
+            """.trimIndent()
+            )
+            build(":commonize", options = defaultBuildOptions().copy(withBuildCache = true)) {
+                assertTasksExecuted(":cinteropCurlTargetA", ":cinteropCurlTargetB")
+            }
+            build(":clean") {}
+            build(":commonize", options = defaultBuildOptions().copy(withBuildCache = true)) {
+                assertTasksRetrievedFromCache(":cinteropCurlTargetA", ":cinteropCurlTargetB")
+            }
+        }
+    }
+
     private fun preparedProject(name: String): Project {
         return Project(name).apply {
             setupWorkingDir()

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/tasks/KotlinNativeTasks.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/tasks/KotlinNativeTasks.kt
@@ -1094,10 +1094,6 @@ open class CInteropProcess @Inject constructor(@get:Internal val settings: Defau
     val outputFile: File
         get() = outputFileProvider.get()
 
-    init {
-        outputs.upToDateWhen { outputFile.exists() }
-    }
-
     // Inputs and outputs.
 
     @OutputFile


### PR DESCRIPTION
Remove manual up-to-date checks that were preventing task
from being retrieved from the build cache. When outputs are
not present, task would always run because of
https://github.com/gradle/gradle/issues/9095.

Test: CommonizerIT