### PR TITLE
HiddenFromObjC and ShouldRefineInSwift annotations

### DIFF
--- a/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendNativeDiagnosticsTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendNativeDiagnosticsTestGenerated.java
@@ -37,6 +37,12 @@ public class FirOldFrontendNativeDiagnosticsTestGenerated extends AbstractFirNat
     }
 
     @Test
+    @TestMetadata("objCRefinement.kt")
+    public void testObjCRefinement() throws Exception {
+        runTest("compiler/testData/diagnostics/nativeTests/objCRefinement.kt");
+    }
+
+    @Test
     @TestMetadata("sharedImmutable.kt")
     public void testSharedImmutable() throws Exception {
         runTest("compiler/testData/diagnostics/nativeTests/sharedImmutable.kt");

--- a/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendNativeDiagnosticsWithLightTreeTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendNativeDiagnosticsWithLightTreeTestGenerated.java
@@ -37,6 +37,12 @@ public class FirOldFrontendNativeDiagnosticsWithLightTreeTestGenerated extends A
     }
 
     @Test
+    @TestMetadata("objCRefinement.kt")
+    public void testObjCRefinement() throws Exception {
+        runTest("compiler/testData/diagnostics/nativeTests/objCRefinement.kt");
+    }
+
+    @Test
     @TestMetadata("sharedImmutable.kt")
     public void testSharedImmutable() throws Exception {
         runTest("compiler/testData/diagnostics/nativeTests/sharedImmutable.kt");

--- a/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/diagnostics/FirNativeDiagnosticsList.kt
+++ b/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/diagnostics/FirNativeDiagnosticsList.kt
@@ -10,6 +10,8 @@ import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.fir.PrivateForInline
 import org.jetbrains.kotlin.fir.checkers.generator.diagnostics.model.DiagnosticList
 import org.jetbrains.kotlin.fir.checkers.generator.diagnostics.model.PositioningStrategy
+import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirCallableSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtDeclaration
@@ -39,5 +41,11 @@ object NATIVE_DIAGNOSTICS_LIST : DiagnosticList("FirNativeErrors") {
         ) {
             parameter<String>("message")
         }
+        val REDUNDANT_SWIFT_REFINEMENT by error<KtElement>()
+        val INCOMPATIBLE_OBJC_REFINEMENT_OVERRIDE by error<KtElement> {
+            parameter<FirBasedSymbol<*>>("declaration")
+            parameter<Collection<FirRegularClassSymbol>>("containingClasses")
+        }
+        val INVALID_OBJC_REFINEMENT_TARGETS by error<KtElement>()
     }
 }

--- a/compiler/fir/checkers/checkers.native/gen/org/jetbrains/kotlin/fir/analysis/diagnostics/native/FirNativeErrors.kt
+++ b/compiler/fir/checkers/checkers.native/gen/org/jetbrains/kotlin/fir/analysis/diagnostics/native/FirNativeErrors.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.diagnostics.*
 import org.jetbrains.kotlin.diagnostics.SourceElementPositioningStrategies
 import org.jetbrains.kotlin.diagnostics.rendering.RootDiagnosticRendererFactory
 import org.jetbrains.kotlin.fir.analysis.diagnostics.*
+import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtDeclaration
@@ -32,6 +33,9 @@ object FirNativeErrors {
     val INAPPLICABLE_THREAD_LOCAL by error0<KtElement>()
     val INAPPLICABLE_THREAD_LOCAL_TOP_LEVEL by error0<KtElement>()
     val INVALID_CHARACTERS_NATIVE by deprecationError1<PsiElement, String>(ProhibitInvalidCharsInNativeIdentifiers, SourceElementPositioningStrategies.NAME_IDENTIFIER)
+    val REDUNDANT_SWIFT_REFINEMENT by error0<KtElement>()
+    val INCOMPATIBLE_OBJC_REFINEMENT_OVERRIDE by error2<KtElement, FirBasedSymbol<*>, Collection<FirRegularClassSymbol>>()
+    val INVALID_OBJC_REFINEMENT_TARGETS by error0<KtElement>()
 
     init {
         RootDiagnosticRendererFactory.registerFactory(FirNativeErrorsDefaultMessages)

--- a/compiler/fir/checkers/checkers.native/src/org/jetbrains/kotlin/fir/analysis/diagnostics/native/FirNativeErrorsDefaultMessages.kt
+++ b/compiler/fir/checkers/checkers.native/src/org/jetbrains/kotlin/fir/analysis/diagnostics/native/FirNativeErrorsDefaultMessages.kt
@@ -15,10 +15,13 @@ import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.INAP
 import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.INAPPLICABLE_SHARED_IMMUTABLE_TOP_LEVEL
 import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.INAPPLICABLE_THREAD_LOCAL
 import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.INAPPLICABLE_THREAD_LOCAL_TOP_LEVEL
+import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.INCOMPATIBLE_OBJC_REFINEMENT_OVERRIDE
 import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.INCOMPATIBLE_THROWS_INHERITED
 import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.INCOMPATIBLE_THROWS_OVERRIDE
 import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.INVALID_CHARACTERS_NATIVE
+import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.INVALID_OBJC_REFINEMENT_TARGETS
 import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.MISSING_EXCEPTION_IN_THROWS_ON_SUSPEND
+import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.REDUNDANT_SWIFT_REFINEMENT
 import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.THROWS_LIST_EMPTY
 
 object FirNativeErrorsDefaultMessages : BaseDiagnosticRendererFactory() {
@@ -41,6 +44,17 @@ object FirNativeErrorsDefaultMessages : BaseDiagnosticRendererFactory() {
         )
         map.put(INAPPLICABLE_THREAD_LOCAL_TOP_LEVEL, "@ThreadLocal is applicable only to top level declarations")
         map.put(INVALID_CHARACTERS_NATIVE, "Name {0}", TO_STRING)
+        map.put(REDUNDANT_SWIFT_REFINEMENT, "An ObjC refined declaration can't also be refined in Swift")
+        map.put(
+            INCOMPATIBLE_OBJC_REFINEMENT_OVERRIDE,
+            "Refined declaration \"{0}\" overrides declarations with different or no refinement from {1}",
+            SYMBOL,
+            SYMBOLS
+        )
+        map.put(
+            INVALID_OBJC_REFINEMENT_TARGETS,
+            "Refines annotations are only applicable to annotations with targets FUNCTION and/or PROPERTY"
+        )
 
         map.checkMissingMessages(FirNativeErrors)
     }

--- a/compiler/fir/checkers/checkers.native/src/org/jetbrains/kotlin/fir/analysis/native/checkers/FirNativeObjCRefinementAnnotationChecker.kt
+++ b/compiler/fir/checkers/checkers.native/src/org/jetbrains/kotlin/fir/analysis/native/checkers/FirNativeObjCRefinementAnnotationChecker.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.fir.analysis.native.checkers
+
+import org.jetbrains.kotlin.descriptors.ClassKind
+import org.jetbrains.kotlin.descriptors.annotations.KotlinTarget
+import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.diagnostics.reportOn
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirRegularClassChecker
+import org.jetbrains.kotlin.fir.analysis.checkers.getAllowedAnnotationTargets
+import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors
+import org.jetbrains.kotlin.fir.analysis.native.checkers.FirNativeObjCRefinementChecker.hidesFromObjCClassId
+import org.jetbrains.kotlin.fir.analysis.native.checkers.FirNativeObjCRefinementChecker.refinesInSwiftClassId
+import org.jetbrains.kotlin.fir.declarations.*
+import org.jetbrains.kotlin.fir.expressions.FirAnnotation
+
+object FirNativeObjCRefinementAnnotationChecker : FirRegularClassChecker() {
+
+    private val supportedTargets = arrayOf(KotlinTarget.FUNCTION, KotlinTarget.PROPERTY)
+
+    override fun check(declaration: FirRegularClass, context: CheckerContext, reporter: DiagnosticReporter) {
+        if (declaration.classKind != ClassKind.ANNOTATION_CLASS) return
+        val (objCAnnotation, swiftAnnotation) = declaration.findMetaAnnotations()
+        if (objCAnnotation == null && swiftAnnotation == null) return
+        if (objCAnnotation != null && swiftAnnotation != null) {
+            reporter.reportOn(
+                swiftAnnotation.source,
+                FirNativeErrors.REDUNDANT_SWIFT_REFINEMENT,
+                context
+            )
+        }
+        val targets = declaration.getAllowedAnnotationTargets()
+        val unsupportedTargets = targets - supportedTargets
+        if (unsupportedTargets.isNotEmpty()) {
+            objCAnnotation?.let { reporter.reportOn(it.source, FirNativeErrors.INVALID_OBJC_REFINEMENT_TARGETS, context) }
+            swiftAnnotation?.let { reporter.reportOn(it.source, FirNativeErrors.INVALID_OBJC_REFINEMENT_TARGETS, context) }
+        }
+    }
+
+    private fun FirRegularClass.findMetaAnnotations(): Pair<FirAnnotation?, FirAnnotation?> {
+        var objCAnnotation: FirAnnotation? = null
+        var swiftAnnotation: FirAnnotation? = null
+        for (annotation in annotations) {
+            when (annotation.toAnnotationClassId()) {
+                hidesFromObjCClassId -> objCAnnotation = annotation
+                refinesInSwiftClassId -> swiftAnnotation = annotation
+            }
+            if (objCAnnotation != null && swiftAnnotation != null) break
+        }
+        return objCAnnotation to swiftAnnotation
+    }
+}

--- a/compiler/fir/checkers/checkers.native/src/org/jetbrains/kotlin/fir/analysis/native/checkers/FirNativeObjCRefinementChecker.kt
+++ b/compiler/fir/checkers/checkers.native/src/org/jetbrains/kotlin/fir/analysis/native/checkers/FirNativeObjCRefinementChecker.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.fir.analysis.native.checkers
+
+import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.diagnostics.reportOn
+import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.analysis.native.checkers.FirNativeObjCRefinementOverridesChecker.check
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirCallableDeclarationChecker
+import org.jetbrains.kotlin.fir.analysis.checkers.unsubstitutedScope
+import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.REDUNDANT_SWIFT_REFINEMENT
+import org.jetbrains.kotlin.fir.declarations.*
+import org.jetbrains.kotlin.fir.expressions.FirAnnotation
+import org.jetbrains.kotlin.fir.expressions.coneClassLikeType
+import org.jetbrains.kotlin.fir.resolve.toSymbol
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+
+object FirNativeObjCRefinementChecker : FirCallableDeclarationChecker() {
+
+    val hidesFromObjCClassId = ClassId.topLevel(FqName("kotlin.native.HidesFromObjC"))
+    val refinesInSwiftClassId = ClassId.topLevel(FqName("kotlin.native.RefinesInSwift"))
+
+    override fun check(declaration: FirCallableDeclaration, context: CheckerContext, reporter: DiagnosticReporter) {
+        if (declaration !is FirSimpleFunction && declaration !is FirProperty) return
+        val (objCAnnotations, swiftAnnotations) = declaration.findRefinedAnnotations(context.session)
+        if (objCAnnotations.isNotEmpty() && swiftAnnotations.isNotEmpty()) {
+            for (swiftAnnotation in swiftAnnotations) {
+                reporter.reportOn(swiftAnnotation.source, REDUNDANT_SWIFT_REFINEMENT, context)
+            }
+        }
+        val containingClass = context.containingDeclarations.lastOrNull() as? FirClass
+        if (containingClass != null) {
+            val firTypeScope = containingClass.unsubstitutedScope(context)
+            check(firTypeScope, declaration.symbol, declaration, context, reporter, objCAnnotations, swiftAnnotations)
+        }
+    }
+
+    private fun FirCallableDeclaration.findRefinedAnnotations(session: FirSession): Pair<List<FirAnnotation>, List<FirAnnotation>> {
+        val objCAnnotations = mutableListOf<FirAnnotation>()
+        val swiftAnnotations = mutableListOf<FirAnnotation>()
+        for (annotation in annotations) {
+            val metaAnnotations = annotation.coneClassLikeType?.lookupTag?.toSymbol(session)?.resolvedAnnotationsWithClassIds.orEmpty()
+            for (metaAnnotation in metaAnnotations) {
+                when (metaAnnotation.toAnnotationClassId()) {
+                    hidesFromObjCClassId -> {
+                        objCAnnotations.add(annotation)
+                        break
+                    }
+
+                    refinesInSwiftClassId -> {
+                        swiftAnnotations.add(annotation)
+                        break
+                    }
+                }
+            }
+        }
+        return objCAnnotations to swiftAnnotations
+    }
+}

--- a/compiler/fir/checkers/checkers.native/src/org/jetbrains/kotlin/fir/analysis/native/checkers/FirNativeObjCRefinementOverridesChecker.kt
+++ b/compiler/fir/checkers/checkers.native/src/org/jetbrains/kotlin/fir/analysis/native/checkers/FirNativeObjCRefinementOverridesChecker.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.fir.analysis.native.checkers
+
+import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.diagnostics.reportOn
+import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirClassChecker
+import org.jetbrains.kotlin.fir.analysis.checkers.unsubstitutedScope
+import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.INCOMPATIBLE_OBJC_REFINEMENT_OVERRIDE
+import org.jetbrains.kotlin.fir.analysis.native.checkers.FirNativeObjCRefinementChecker.hidesFromObjCClassId
+import org.jetbrains.kotlin.fir.analysis.native.checkers.FirNativeObjCRefinementChecker.refinesInSwiftClassId
+import org.jetbrains.kotlin.fir.containingClass
+import org.jetbrains.kotlin.fir.declarations.FirClass
+import org.jetbrains.kotlin.fir.declarations.FirDeclaration
+import org.jetbrains.kotlin.fir.declarations.toAnnotationClassId
+import org.jetbrains.kotlin.fir.expressions.FirAnnotation
+import org.jetbrains.kotlin.fir.expressions.coneClassLikeType
+import org.jetbrains.kotlin.fir.isIntersectionOverride
+import org.jetbrains.kotlin.fir.resolve.toFirRegularClassSymbol
+import org.jetbrains.kotlin.fir.resolve.toSymbol
+import org.jetbrains.kotlin.fir.scopes.*
+import org.jetbrains.kotlin.fir.symbols.impl.FirCallableSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
+
+object FirNativeObjCRefinementOverridesChecker : FirClassChecker() {
+
+    override fun check(declaration: FirClass, context: CheckerContext, reporter: DiagnosticReporter) {
+        // We just need to check intersection overrides, all other declarations are checked by FirNativeObjCRefinementChecker
+        val firTypeScope = declaration.unsubstitutedScope(context)
+        firTypeScope.processAllFunctions { symbol ->
+            if (!symbol.isIntersectionOverride) return@processAllFunctions
+            check(firTypeScope, symbol, declaration, context, reporter, emptyList(), emptyList())
+        }
+        firTypeScope.processAllProperties { symbol ->
+            if (!symbol.isIntersectionOverride) return@processAllProperties
+            check(firTypeScope, symbol, declaration, context, reporter, emptyList(), emptyList())
+        }
+    }
+
+    fun check(
+        firTypeScope: FirTypeScope,
+        memberSymbol: FirCallableSymbol<*>,
+        declarationToReport: FirDeclaration,
+        context: CheckerContext,
+        reporter: DiagnosticReporter,
+        objCAnnotations: List<FirAnnotation>,
+        swiftAnnotations: List<FirAnnotation>
+    ) {
+        val overriddenMemberSymbols = firTypeScope.getDirectOverriddenSymbols(memberSymbol)
+        if (overriddenMemberSymbols.isEmpty()) return
+        var isHiddenFromObjC = objCAnnotations.isNotEmpty()
+        var isRefinedInSwift = swiftAnnotations.isNotEmpty()
+        val supersNotHiddenFromObjC = mutableListOf<FirCallableSymbol<*>>()
+        val supersNotRefinedInSwift = mutableListOf<FirCallableSymbol<*>>()
+        for (symbol in overriddenMemberSymbols) {
+            val (superIsHiddenFromObjC, superIsRefinedInSwift) = symbol.inheritsRefinedAnnotations(context.session, firTypeScope)
+            if (superIsHiddenFromObjC) isHiddenFromObjC = true else supersNotHiddenFromObjC.add(symbol)
+            if (superIsRefinedInSwift) isRefinedInSwift = true else supersNotRefinedInSwift.add(symbol)
+        }
+        if (isHiddenFromObjC && supersNotHiddenFromObjC.isNotEmpty()) {
+            reporter.reportIncompatibleOverride(declarationToReport, objCAnnotations, supersNotHiddenFromObjC, context)
+        }
+        if (isRefinedInSwift && supersNotRefinedInSwift.isNotEmpty()) {
+            reporter.reportIncompatibleOverride(declarationToReport, swiftAnnotations, supersNotRefinedInSwift, context)
+        }
+    }
+
+    private fun FirTypeScope.getDirectOverriddenSymbols(memberSymbol: FirCallableSymbol<*>): List<FirCallableSymbol<*>> {
+        return when (memberSymbol) {
+            is FirNamedFunctionSymbol -> {
+                processFunctionsByName(memberSymbol.name) {}
+                getDirectOverriddenFunctions(memberSymbol)
+            }
+
+            is FirPropertySymbol -> {
+                processPropertiesByName(memberSymbol.name) {}
+                getDirectOverriddenProperties(memberSymbol)
+            }
+
+            else -> error("unexpected member kind $memberSymbol")
+        }
+    }
+
+    private fun FirCallableSymbol<*>.inheritsRefinedAnnotations(session: FirSession, firTypeScope: FirTypeScope): Pair<Boolean, Boolean> {
+        val (hasObjC, hasSwift) = hasRefinedAnnotations(session)
+        if (hasObjC && hasSwift) return true to true
+        // Note: `checkMember` requires all overridden symbols to be either refined or not refined.
+        val overriddenMemberSymbol = firTypeScope.getDirectOverriddenSymbols(this).firstOrNull()
+            ?: return hasObjC to hasSwift
+        val (inheritsObjC, inheritsSwift) = overriddenMemberSymbol.inheritsRefinedAnnotations(session, firTypeScope)
+        return (hasObjC || inheritsObjC) to (hasSwift || inheritsSwift)
+    }
+
+    private fun FirCallableSymbol<*>.hasRefinedAnnotations(session: FirSession): Pair<Boolean, Boolean> {
+        var hasObjC = false
+        var hasSwift = false
+        for (annotation in resolvedAnnotationsWithClassIds) {
+            val metaAnnotations = annotation.coneClassLikeType?.lookupTag?.toSymbol(session)?.resolvedAnnotationsWithClassIds.orEmpty()
+            for (metaAnnotation in metaAnnotations) {
+                when (metaAnnotation.toAnnotationClassId()) {
+                    hidesFromObjCClassId -> {
+                        hasObjC = true
+                        break
+                    }
+
+                    refinesInSwiftClassId -> {
+                        hasSwift = true
+                        break
+                    }
+                }
+            }
+            if (hasObjC && hasSwift) return true to true
+        }
+        return hasObjC to hasSwift
+    }
+
+    private fun DiagnosticReporter.reportIncompatibleOverride(
+        declaration: FirDeclaration,
+        annotations: List<FirAnnotation>,
+        notRefinedSupers: List<FirCallableSymbol<*>>,
+        context: CheckerContext
+    ) {
+        val containingDeclarations = notRefinedSupers.mapNotNull { it.containingClass()?.toFirRegularClassSymbol(context.session) }
+        if (annotations.isEmpty()) {
+            reportOn(declaration.source, INCOMPATIBLE_OBJC_REFINEMENT_OVERRIDE, declaration.symbol, containingDeclarations, context)
+        } else {
+            for (annotation in annotations) {
+                reportOn(annotation.source, INCOMPATIBLE_OBJC_REFINEMENT_OVERRIDE, declaration.symbol, containingDeclarations, context)
+            }
+        }
+    }
+}

--- a/compiler/fir/checkers/checkers.native/src/org/jetbrains/kotlin/fir/analysis/native/checkers/NativeDeclarationCheckers.kt
+++ b/compiler/fir/checkers/checkers.native/src/org/jetbrains/kotlin/fir/analysis/native/checkers/NativeDeclarationCheckers.kt
@@ -5,8 +5,7 @@
 
 package org.jetbrains.kotlin.fir.analysis.native.checkers
 
-import org.jetbrains.kotlin.fir.analysis.checkers.declaration.DeclarationCheckers
-import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirBasicDeclarationChecker
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.*
 
 object NativeDeclarationCheckers : DeclarationCheckers() {
     override val basicDeclarationCheckers: Set<FirBasicDeclarationChecker>
@@ -15,5 +14,20 @@ object NativeDeclarationCheckers : DeclarationCheckers() {
             FirNativeSharedImmutableChecker,
             FirNativeThreadLocalChecker,
             FirNativeIdentifierChecker
+        )
+
+    override val callableDeclarationCheckers: Set<FirCallableDeclarationChecker>
+        get() = setOf(
+            FirNativeObjCRefinementChecker
+        )
+
+    override val classCheckers: Set<FirClassChecker>
+        get() = setOf(
+            FirNativeObjCRefinementOverridesChecker
+        )
+
+    override val regularClassCheckers: Set<FirRegularClassChecker>
+        get() = setOf(
+            FirNativeObjCRefinementAnnotationChecker
         )
 }

--- a/compiler/testData/diagnostics/nativeTests/objCRefinement.kt
+++ b/compiler/testData/diagnostics/nativeTests/objCRefinement.kt
@@ -1,3 +1,4 @@
+// FIR_IDENTICAL
 // FILE: kotlin.kt
 package kotlin.native
 

--- a/compiler/testData/diagnostics/nativeTests/objCRefinement.kt
+++ b/compiler/testData/diagnostics/nativeTests/objCRefinement.kt
@@ -1,0 +1,131 @@
+// FILE: kotlin.kt
+package kotlin.native
+
+@Target(AnnotationTarget.ANNOTATION_CLASS)
+@Retention(AnnotationRetention.BINARY)
+@MustBeDocumented
+annotation class HidesFromObjC
+
+@HidesFromObjC
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
+annotation class HiddenFromObjC
+
+@Target(AnnotationTarget.ANNOTATION_CLASS)
+@Retention(AnnotationRetention.BINARY)
+annotation class RefinesInSwift
+
+@RefinesInSwift
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
+public annotation class ShouldRefineInSwift
+
+// FILE: plugin.kt
+package plugin
+
+@HidesFromObjC
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
+annotation class PluginHiddenFromObjC
+
+@RefinesInSwift
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
+annotation class PluginShouldRefineInSwift
+
+// FILE: test.kt
+import plugin.PluginHiddenFromObjC
+import plugin.PluginShouldRefineInSwift
+
+@HidesFromObjC
+<!REDUNDANT_SWIFT_REFINEMENT!>@RefinesInSwift<!>
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
+annotation class MyRefinedAnnotationA
+
+<!INVALID_OBJC_REFINEMENT_TARGETS!>@HidesFromObjC<!>
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.BINARY)
+annotation class MyRefinedAnnotationB
+
+<!INVALID_OBJC_REFINEMENT_TARGETS!>@RefinesInSwift<!>
+@Retention(AnnotationRetention.BINARY)
+annotation class MyRefinedAnnotationC
+
+@RefinesInSwift
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.BINARY)
+annotation class MyRefinedAnnotationD
+
+@HiddenFromObjC
+<!REDUNDANT_SWIFT_REFINEMENT!>@ShouldRefineInSwift<!>
+var refinedProperty: Int = 0
+
+@PluginHiddenFromObjC
+<!REDUNDANT_SWIFT_REFINEMENT!>@PluginShouldRefineInSwift<!>
+fun pluginRefinedFunction() { }
+
+@HiddenFromObjC
+@PluginHiddenFromObjC
+fun multipleObjCRefinementsFunction() { }
+
+@ShouldRefineInSwift
+@PluginShouldRefineInSwift
+fun multipleSwiftRefinementsFunction() { }
+
+@HiddenFromObjC
+@PluginHiddenFromObjC
+<!REDUNDANT_SWIFT_REFINEMENT!>@ShouldRefineInSwift<!>
+<!REDUNDANT_SWIFT_REFINEMENT!>@PluginShouldRefineInSwift<!>
+fun multipleMixedRefinementsFunction() { }
+
+interface InterfaceA {
+    val barA: Int
+    val barB: Int
+    fun fooA()
+    @HiddenFromObjC
+    fun fooB()
+}
+
+interface InterfaceB {
+    val barA: Int
+    @ShouldRefineInSwift
+    val barB: Int
+    @HiddenFromObjC
+    fun fooA()
+    @HiddenFromObjC
+    fun fooB()
+}
+
+open class ClassA: InterfaceA, InterfaceB {
+    <!INCOMPATIBLE_OBJC_REFINEMENT_OVERRIDE!>@HiddenFromObjC<!>
+    override val barA: Int = 0
+    <!INCOMPATIBLE_OBJC_REFINEMENT_OVERRIDE!>@ShouldRefineInSwift<!>
+    override val barB: Int = 0
+    <!INCOMPATIBLE_OBJC_REFINEMENT_OVERRIDE!>override fun fooA() { }<!>
+    override fun fooB() { }
+    @HiddenFromObjC
+    open fun fooC() { }
+}
+
+class ClassB: ClassA() {
+    @HiddenFromObjC
+    override fun fooB() { }
+    <!INCOMPATIBLE_OBJC_REFINEMENT_OVERRIDE!>@ShouldRefineInSwift<!>
+    override fun fooC() { }
+}
+
+open class Base {
+    @HiddenFromObjC
+    open fun foo() {}
+}
+
+interface I {
+    fun foo()
+}
+
+<!INCOMPATIBLE_OBJC_REFINEMENT_OVERRIDE!>open class Derived : Base(), I<!>
+
+open class Derived2 : Derived() {
+    override fun foo() {}
+}

--- a/compiler/testData/diagnostics/nativeTests/objCRefinement.txt
+++ b/compiler/testData/diagnostics/nativeTests/objCRefinement.txt
@@ -1,0 +1,161 @@
+package
+
+@kotlin.native.HiddenFromObjC @kotlin.native.ShouldRefineInSwift public var refinedProperty: kotlin.Int
+@kotlin.native.HiddenFromObjC @plugin.PluginHiddenFromObjC @kotlin.native.ShouldRefineInSwift @plugin.PluginShouldRefineInSwift public fun multipleMixedRefinementsFunction(): kotlin.Unit
+@kotlin.native.HiddenFromObjC @plugin.PluginHiddenFromObjC public fun multipleObjCRefinementsFunction(): kotlin.Unit
+@kotlin.native.ShouldRefineInSwift @plugin.PluginShouldRefineInSwift public fun multipleSwiftRefinementsFunction(): kotlin.Unit
+@plugin.PluginHiddenFromObjC @plugin.PluginShouldRefineInSwift public fun pluginRefinedFunction(): kotlin.Unit
+
+public open class Base {
+    public constructor Base()
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    @kotlin.native.HiddenFromObjC public open fun foo(): kotlin.Unit
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public open class ClassA : InterfaceA, InterfaceB {
+    public constructor ClassA()
+    @kotlin.native.HiddenFromObjC public open override /*2*/ val barA: kotlin.Int = 0
+    @kotlin.native.ShouldRefineInSwift public open override /*2*/ val barB: kotlin.Int = 0
+    public open override /*2*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*2*/ fun fooA(): kotlin.Unit
+    public open override /*2*/ fun fooB(): kotlin.Unit
+    @kotlin.native.HiddenFromObjC public open fun fooC(): kotlin.Unit
+    public open override /*2*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*2*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public final class ClassB : ClassA {
+    public constructor ClassB()
+    @kotlin.native.HiddenFromObjC public open override /*1*/ /*fake_override*/ val barA: kotlin.Int
+    @kotlin.native.ShouldRefineInSwift public open override /*1*/ /*fake_override*/ val barB: kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun fooA(): kotlin.Unit
+    @kotlin.native.HiddenFromObjC public open override /*1*/ fun fooB(): kotlin.Unit
+    @kotlin.native.ShouldRefineInSwift public open override /*1*/ fun fooC(): kotlin.Unit
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public open class Derived : Base, I {
+    public constructor Derived()
+    public open override /*2*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    @kotlin.native.HiddenFromObjC public open override /*2*/ /*fake_override*/ fun foo(): kotlin.Unit
+    public open override /*2*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*2*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public open class Derived2 : Derived {
+    public constructor Derived2()
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ fun foo(): kotlin.Unit
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public interface I {
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public abstract fun foo(): kotlin.Unit
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public interface InterfaceA {
+    public abstract val barA: kotlin.Int
+    public abstract val barB: kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public abstract fun fooA(): kotlin.Unit
+    @kotlin.native.HiddenFromObjC public abstract fun fooB(): kotlin.Unit
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public interface InterfaceB {
+    public abstract val barA: kotlin.Int
+    @kotlin.native.ShouldRefineInSwift public abstract val barB: kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    @kotlin.native.HiddenFromObjC public abstract fun fooA(): kotlin.Unit
+    @kotlin.native.HiddenFromObjC public abstract fun fooB(): kotlin.Unit
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+@kotlin.native.HidesFromObjC @kotlin.native.RefinesInSwift @kotlin.annotation.Target(allowedTargets = {AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION}) @kotlin.annotation.Retention(value = AnnotationRetention.BINARY) public final annotation class MyRefinedAnnotationA : kotlin.Annotation {
+    public constructor MyRefinedAnnotationA()
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+@kotlin.native.HidesFromObjC @kotlin.annotation.Target(allowedTargets = {AnnotationTarget.PROPERTY, AnnotationTarget.CLASS}) @kotlin.annotation.Retention(value = AnnotationRetention.BINARY) public final annotation class MyRefinedAnnotationB : kotlin.Annotation {
+    public constructor MyRefinedAnnotationB()
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+@kotlin.native.RefinesInSwift @kotlin.annotation.Retention(value = AnnotationRetention.BINARY) public final annotation class MyRefinedAnnotationC : kotlin.Annotation {
+    public constructor MyRefinedAnnotationC()
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+@kotlin.native.RefinesInSwift @kotlin.annotation.Target(allowedTargets = {AnnotationTarget.PROPERTY}) @kotlin.annotation.Retention(value = AnnotationRetention.BINARY) public final annotation class MyRefinedAnnotationD : kotlin.Annotation {
+    public constructor MyRefinedAnnotationD()
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+package kotlin {
+
+    package kotlin.native {
+
+        @kotlin.native.HidesFromObjC @kotlin.annotation.Target(allowedTargets = {AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION}) @kotlin.annotation.Retention(value = AnnotationRetention.BINARY) public final annotation class HiddenFromObjC : kotlin.Annotation {
+            public constructor HiddenFromObjC()
+            public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+            public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+            public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+        }
+
+        @kotlin.annotation.Target(allowedTargets = {AnnotationTarget.ANNOTATION_CLASS}) @kotlin.annotation.Retention(value = AnnotationRetention.BINARY) @kotlin.annotation.MustBeDocumented public final annotation class HidesFromObjC : kotlin.Annotation {
+            public constructor HidesFromObjC()
+            public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+            public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+            public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+        }
+
+        @kotlin.annotation.Target(allowedTargets = {AnnotationTarget.ANNOTATION_CLASS}) @kotlin.annotation.Retention(value = AnnotationRetention.BINARY) public final annotation class RefinesInSwift : kotlin.Annotation {
+            public constructor RefinesInSwift()
+            public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+            public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+            public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+        }
+
+        @kotlin.native.RefinesInSwift @kotlin.annotation.Target(allowedTargets = {AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION}) @kotlin.annotation.Retention(value = AnnotationRetention.BINARY) public final annotation class ShouldRefineInSwift : kotlin.Annotation {
+            public constructor ShouldRefineInSwift()
+            public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+            public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+            public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+        }
+    }
+}
+
+package plugin {
+
+    @kotlin.native.HidesFromObjC @kotlin.annotation.Target(allowedTargets = {AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION}) @kotlin.annotation.Retention(value = AnnotationRetention.BINARY) public final annotation class PluginHiddenFromObjC : kotlin.Annotation {
+        public constructor PluginHiddenFromObjC()
+        public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+        public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+        public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+    }
+
+    @kotlin.native.RefinesInSwift @kotlin.annotation.Target(allowedTargets = {AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION}) @kotlin.annotation.Retention(value = AnnotationRetention.BINARY) public final annotation class PluginShouldRefineInSwift : kotlin.Annotation {
+        public constructor PluginShouldRefineInSwift()
+        public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+        public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+        public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+    }
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/DiagnosticsNativeTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/DiagnosticsNativeTestGenerated.java
@@ -37,6 +37,12 @@ public class DiagnosticsNativeTestGenerated extends AbstractDiagnosticsNativeTes
     }
 
     @Test
+    @TestMetadata("objCRefinement.kt")
+    public void testObjCRefinement() throws Exception {
+        runTest("compiler/testData/diagnostics/nativeTests/objCRefinement.kt");
+    }
+
+    @Test
     @TestMetadata("sharedImmutable.kt")
     public void testSharedImmutable() throws Exception {
         runTest("compiler/testData/diagnostics/nativeTests/sharedImmutable.kt");

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanFqNames.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanFqNames.kt
@@ -38,5 +38,8 @@ object KonanFqNames {
     val eagerInitialization = FqName("kotlin.native.EagerInitialization")
     val noReorderFields = FqName("kotlin.native.internal.NoReorderFields")
     val objCName = FqName("kotlin.native.ObjCName")
+    val hidesFromObjC = FqName("kotlin.native.HidesFromObjC")
+    val refinesInSwift = FqName("kotlin.native.RefinesInSwift")
+    val shouldRefineInSwift = FqName("kotlin.native.ShouldRefineInSwift")
     val reflectionPackageName = FqName("kotlin.native.internal.ReflectionPackageName")
 }

--- a/kotlin-native/backend.native/tests/objcexport/expectedLazy.h
+++ b/kotlin-native/backend.native/tests/objcexport/expectedLazy.h
@@ -1418,6 +1418,40 @@ __attribute__((swift_name("OverrideMethodsOfAnyKt")))
 + (BOOL)testObj:(id)obj other:(id)other swift:(BOOL)swift error:(NSError * _Nullable * _Nullable)error __attribute__((swift_name("test(obj:other:swift:)")));
 @end
 
+__attribute__((swift_name("RefinedClassA")))
+@interface KtRefinedClassA : KtBase
+- (instancetype)init __attribute__((swift_name("init()"))) __attribute__((objc_designated_initializer));
++ (instancetype)new __attribute__((availability(swift, unavailable, message="use object initializers instead")));
+- (NSString *)fooRefined __attribute__((swift_private));
+@end
+
+__attribute__((objc_subclassing_restricted))
+__attribute__((swift_name("RefinedClassB")))
+@interface KtRefinedClassB : KtRefinedClassA
+- (instancetype)init __attribute__((swift_name("init()"))) __attribute__((objc_designated_initializer));
++ (instancetype)new __attribute__((availability(swift, unavailable, message="use object initializers instead")));
+- (NSString *)fooRefined __attribute__((swift_private));
+@end
+
+__attribute__((objc_subclassing_restricted))
+__attribute__((swift_name("RefinedKt")))
+@interface KtRefinedKt : KtBase
++ (NSString *)fooRefined __attribute__((swift_private));
+
+/**
+ * @note annotations
+ *   refined.MyShouldRefineInSwift
+*/
++ (NSString *)myFooRefined __attribute__((swift_private));
+@property (class, readonly) NSString *barRefined __attribute__((swift_private));
+
+/**
+ * @note annotations
+ *   refined.MyShouldRefineInSwift
+*/
+@property (class, readonly) NSString *myBarRefined __attribute__((swift_private));
+@end
+
 __attribute__((swift_name("Person")))
 @interface KtPerson : KtBase
 @end

--- a/kotlin-native/backend.native/tests/objcexport/expectedLazyLegacySuspendUnit.h
+++ b/kotlin-native/backend.native/tests/objcexport/expectedLazyLegacySuspendUnit.h
@@ -1353,6 +1353,40 @@ __attribute__((swift_name("OverrideMethodsOfAnyKt")))
 + (BOOL)testObj:(id)obj other:(id)other swift:(BOOL)swift error:(NSError * _Nullable * _Nullable)error __attribute__((swift_name("test(obj:other:swift:)")));
 @end
 
+__attribute__((swift_name("RefinedClassA")))
+@interface KtRefinedClassA : KtBase
+- (instancetype)init __attribute__((swift_name("init()"))) __attribute__((objc_designated_initializer));
++ (instancetype)new __attribute__((availability(swift, unavailable, message="use object initializers instead")));
+- (NSString *)fooRefined __attribute__((swift_private));
+@end
+
+__attribute__((objc_subclassing_restricted))
+__attribute__((swift_name("RefinedClassB")))
+@interface KtRefinedClassB : KtRefinedClassA
+- (instancetype)init __attribute__((swift_name("init()"))) __attribute__((objc_designated_initializer));
++ (instancetype)new __attribute__((availability(swift, unavailable, message="use object initializers instead")));
+- (NSString *)fooRefined __attribute__((swift_private));
+@end
+
+__attribute__((objc_subclassing_restricted))
+__attribute__((swift_name("RefinedKt")))
+@interface KtRefinedKt : KtBase
++ (NSString *)fooRefined __attribute__((swift_private));
+
+/**
+ * @note annotations
+ *   refined.MyShouldRefineInSwift
+*/
++ (NSString *)myFooRefined __attribute__((swift_private));
+@property (class, readonly) NSString *barRefined __attribute__((swift_private));
+
+/**
+ * @note annotations
+ *   refined.MyShouldRefineInSwift
+*/
+@property (class, readonly) NSString *myBarRefined __attribute__((swift_private));
+@end
+
 __attribute__((swift_name("Person")))
 @interface KtPerson : KtBase
 @end

--- a/kotlin-native/backend.native/tests/objcexport/expectedLazyNoGenerics.h
+++ b/kotlin-native/backend.native/tests/objcexport/expectedLazyNoGenerics.h
@@ -1353,6 +1353,40 @@ __attribute__((swift_name("OverrideMethodsOfAnyKt")))
 + (BOOL)testObj:(id)obj other:(id)other swift:(BOOL)swift error:(NSError * _Nullable * _Nullable)error __attribute__((swift_name("test(obj:other:swift:)")));
 @end
 
+__attribute__((swift_name("RefinedClassA")))
+@interface KtRefinedClassA : KtBase
+- (instancetype)init __attribute__((swift_name("init()"))) __attribute__((objc_designated_initializer));
++ (instancetype)new __attribute__((availability(swift, unavailable, message="use object initializers instead")));
+- (NSString *)fooRefined __attribute__((swift_private));
+@end
+
+__attribute__((objc_subclassing_restricted))
+__attribute__((swift_name("RefinedClassB")))
+@interface KtRefinedClassB : KtRefinedClassA
+- (instancetype)init __attribute__((swift_name("init()"))) __attribute__((objc_designated_initializer));
++ (instancetype)new __attribute__((availability(swift, unavailable, message="use object initializers instead")));
+- (NSString *)fooRefined __attribute__((swift_private));
+@end
+
+__attribute__((objc_subclassing_restricted))
+__attribute__((swift_name("RefinedKt")))
+@interface KtRefinedKt : KtBase
++ (NSString *)fooRefined __attribute__((swift_private));
+
+/**
+ * @note annotations
+ *   refined.MyShouldRefineInSwift
+*/
++ (NSString *)myFooRefined __attribute__((swift_private));
+@property (class, readonly) NSString *barRefined __attribute__((swift_private));
+
+/**
+ * @note annotations
+ *   refined.MyShouldRefineInSwift
+*/
+@property (class, readonly) NSString *myBarRefined __attribute__((swift_private));
+@end
+
 __attribute__((swift_name("Person")))
 @interface KtPerson : KtBase
 @end

--- a/kotlin-native/backend.native/tests/objcexport/refined.kt
+++ b/kotlin-native/backend.native/tests/objcexport/refined.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package refined
+
+import kotlin.experimental.ExperimentalObjCRefinement
+
+@ExperimentalObjCRefinement
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
+@MustBeDocumented
+@HidesFromObjC
+annotation class MyHiddenFromObjC
+
+@ExperimentalObjCRefinement
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
+@MustBeDocumented
+@RefinesInSwift
+annotation class MyShouldRefineInSwift
+
+@OptIn(ExperimentalObjCRefinement::class)
+@HiddenFromObjC
+fun foo(): Int = 1
+
+@OptIn(ExperimentalObjCRefinement::class)
+@ShouldRefineInSwift
+fun fooRefined(): String = foo().toString()
+
+@OptIn(ExperimentalObjCRefinement::class)
+@MyHiddenFromObjC
+fun myFoo(): Int = 2
+
+@OptIn(ExperimentalObjCRefinement::class)
+@MyShouldRefineInSwift
+fun myFooRefined(): String = myFoo().toString()
+
+@OptIn(ExperimentalObjCRefinement::class)
+@HiddenFromObjC
+val bar: Int = 3
+
+@OptIn(ExperimentalObjCRefinement::class)
+@ShouldRefineInSwift
+val barRefined: String get() = bar.toString()
+
+@OptIn(ExperimentalObjCRefinement::class)
+@MyHiddenFromObjC
+val myBar: Int = 4
+
+@OptIn(ExperimentalObjCRefinement::class)
+@MyShouldRefineInSwift
+val myBarRefined: String get() = myBar.toString()
+
+open class RefinedClassA {
+    @OptIn(ExperimentalObjCRefinement::class)
+    @HiddenFromObjC
+    open fun foo(): Int = 1
+    @OptIn(ExperimentalObjCRefinement::class)
+    @ShouldRefineInSwift
+    open fun fooRefined(): String = foo().toString()
+}
+
+class RefinedClassB: RefinedClassA() {
+    override fun foo(): Int = 2
+    override fun fooRefined(): String {
+        val foo = foo()
+        return "$foo$foo"
+    }
+}

--- a/kotlin-native/backend.native/tests/objcexport/refined.swift
+++ b/kotlin-native/backend.native/tests/objcexport/refined.swift
@@ -1,0 +1,50 @@
+import Kt
+
+extension RefinedKt {
+    static func foo() -> Int {
+        return Int(RefinedKt.__fooRefined())! * 2
+    }
+
+    static func myFoo() -> Int {
+        return Int(RefinedKt.__myFooRefined())! * 2
+    }
+
+    static var bar: Int {
+        return Int(RefinedKt.__barRefined)! * 2
+    }
+
+    static var myBar: Int {
+        return Int(RefinedKt.__myBarRefined)! * 2
+    }
+}
+
+extension RefinedClassA {
+    func foo() -> Int {
+        return Int(__fooRefined())! * 2
+    }
+}
+
+private func testSwiftRefinements() throws {
+    try assertEquals(actual: RefinedKt.foo(), expected: 2)
+    try assertEquals(actual: RefinedKt.bar, expected: 6)
+}
+
+private func testMySwiftRefinements() throws {
+    try assertEquals(actual: RefinedKt.myFoo(), expected: 4)
+    try assertEquals(actual: RefinedKt.myBar, expected: 8)
+}
+
+private func testInheritedRefinements() throws {
+    try assertEquals(actual: RefinedClassA().foo(), expected: 2)
+    try assertEquals(actual: RefinedClassB().foo(), expected: 44)
+}
+
+class RefinedTests : SimpleTestProvider {
+    override init() {
+        super.init()
+
+        test("TestSwiftRefinements", testSwiftRefinements)
+        test("TestMySwiftRefinements", testMySwiftRefinements)
+        test("TestInheritedRefinements", testInheritedRefinements)
+    }
+}

--- a/kotlin-native/runtime/src/main/kotlin/kotlin/native/Annotations.kt
+++ b/kotlin-native/runtime/src/main/kotlin/kotlin/native/Annotations.kt
@@ -6,6 +6,7 @@
 package kotlin.native
 
 import kotlin.experimental.ExperimentalObjCName
+import kotlin.experimental.ExperimentalObjCRefinement
 import kotlin.reflect.KClass
 
 /**
@@ -100,3 +101,58 @@ public actual annotation class CName(actual val externName: String = "", actual 
 @MustBeDocumented
 @ExperimentalObjCName
 public actual annotation class ObjCName(actual val name: String = "", actual val swiftName: String = "", actual val exact: Boolean = false)
+
+/**
+ * Meta-annotation that instructs the Kotlin compiler to remove the annotated function or property from the public Objective-C API.
+ *
+ * Annotation processors that refine the public Objective-C API can annotate their annotations with this meta-annotation
+ * to have the original declarations automatically removed from the public API.
+ *
+ * Note: only annotations with [AnnotationTarget.FUNCTION] and/or [AnnotationTarget.PROPERTY] are supported.
+ */
+@Target(AnnotationTarget.ANNOTATION_CLASS)
+@Retention(AnnotationRetention.BINARY)
+@MustBeDocumented
+@ExperimentalObjCRefinement
+public actual annotation class HidesFromObjC
+
+/**
+ * Instructs the Kotlin compiler to remove this function or property from the public Objective-C API.
+ */
+@HidesFromObjC
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
+@MustBeDocumented
+@ExperimentalObjCRefinement
+public actual annotation class HiddenFromObjC
+
+/**
+ * Meta-annotation that instructs the Kotlin compiler to mark the annotated function or property as
+ * `swift_private` in the generated Objective-C API.
+ *
+ * Annotation processors that refine the public API in Swift can annotate their annotations with this meta-annotation
+ * to automatically hide the annotated declarations from Swift.
+ *
+ * See Apple's documentation of the [`NS_REFINED_FOR_SWIFT`](https://developer.apple.com/documentation/swift/objective-c_and_c_code_customization/improving_objective-c_api_declarations_for_swift)
+ * macro for more information on refining Objective-C declarations in Swift.
+ *
+ * Note: only annotations with [AnnotationTarget.FUNCTION] and/or [AnnotationTarget.PROPERTY] are supported.
+ */
+@Target(AnnotationTarget.ANNOTATION_CLASS)
+@Retention(AnnotationRetention.BINARY)
+@MustBeDocumented
+@ExperimentalObjCRefinement
+public actual annotation class RefinesInSwift
+
+/**
+ * Instructs the Kotlin compiler to mark this function or property as `swift_private` in the generated Objective-C API.
+ *
+ * See Apple's documentation of the [`NS_REFINED_FOR_SWIFT`](https://developer.apple.com/documentation/swift/objective-c_and_c_code_customization/improving_objective-c_api_declarations_for_swift)
+ * macro for more information on refining Objective-C declarations in Swift.
+ */
+@RefinesInSwift
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
+@MustBeDocumented
+@ExperimentalObjCRefinement
+public actual annotation class ShouldRefineInSwift

--- a/libraries/stdlib/api/js-v1/kotlin.experimental.kt
+++ b/libraries/stdlib/api/js-v1/kotlin.experimental.kt
@@ -38,6 +38,14 @@ public final annotation class ExperimentalObjCName : kotlin.Annotation {
     public constructor ExperimentalObjCName()
 }
 
+@kotlin.RequiresOptIn
+@kotlin.annotation.Target(allowedTargets = {AnnotationTarget.ANNOTATION_CLASS})
+@kotlin.annotation.Retention(value = AnnotationRetention.BINARY)
+@kotlin.annotation.MustBeDocumented
+public final annotation class ExperimentalObjCRefinement : kotlin.Annotation {
+    public constructor ExperimentalObjCRefinement()
+}
+
 @kotlin.RequiresOptIn(level = Level.ERROR)
 @kotlin.annotation.MustBeDocumented
 @kotlin.annotation.Retention(value = AnnotationRetention.BINARY)

--- a/libraries/stdlib/api/js/kotlin.experimental.kt
+++ b/libraries/stdlib/api/js/kotlin.experimental.kt
@@ -38,6 +38,14 @@ public final annotation class ExperimentalObjCName : kotlin.Annotation {
     public constructor ExperimentalObjCName()
 }
 
+@kotlin.RequiresOptIn
+@kotlin.annotation.Target(allowedTargets = {AnnotationTarget.ANNOTATION_CLASS})
+@kotlin.annotation.Retention(value = AnnotationRetention.BINARY)
+@kotlin.annotation.MustBeDocumented
+public final annotation class ExperimentalObjCRefinement : kotlin.Annotation {
+    public constructor ExperimentalObjCRefinement()
+}
+
 @kotlin.RequiresOptIn(level = Level.ERROR)
 @kotlin.annotation.MustBeDocumented
 @kotlin.annotation.Retention(value = AnnotationRetention.BINARY)

--- a/libraries/stdlib/src/kotlin/annotations/NativeAnnotations.kt
+++ b/libraries/stdlib/src/kotlin/annotations/NativeAnnotations.kt
@@ -6,6 +6,7 @@
 package kotlin.native
 
 import kotlin.experimental.ExperimentalObjCName
+import kotlin.experimental.ExperimentalObjCRefinement
 
 /**
  * Makes top level function available from C/C++ code with the given name.
@@ -65,3 +66,62 @@ expect annotation class FreezingIsDeprecated
 @OptionalExpectation
 @ExperimentalObjCName
 public expect annotation class ObjCName(val name: String = "", val swiftName: String = "", val exact: Boolean = false)
+
+/**
+ * Meta-annotation that instructs the Kotlin compiler to remove the annotated function or property from the public Objective-C API.
+ *
+ * Annotation processors that refine the public Objective-C API can annotate their annotations with this meta-annotation
+ * to have the original declarations automatically removed from the public API.
+ *
+ * Note: only annotations with [AnnotationTarget.FUNCTION] and/or [AnnotationTarget.PROPERTY] are supported.
+ */
+@Target(AnnotationTarget.ANNOTATION_CLASS)
+@Retention(AnnotationRetention.BINARY)
+@MustBeDocumented
+@OptionalExpectation
+@ExperimentalObjCRefinement
+public expect annotation class HidesFromObjC()
+
+/**
+ * Instructs the Kotlin compiler to remove this function or property from the public Objective-C API.
+ */
+@HidesFromObjC
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
+@MustBeDocumented
+@OptionalExpectation
+@ExperimentalObjCRefinement
+public expect annotation class HiddenFromObjC()
+
+/**
+ * Meta-annotation that instructs the Kotlin compiler to mark the annotated function or property as
+ * `swift_private` in the generated Objective-C API.
+ *
+ * Annotation processors that refine the public API in Swift can annotate their annotations with this meta-annotation
+ * to automatically hide the annotated declarations from Swift.
+ *
+ * See Apple's documentation of the [`NS_REFINED_FOR_SWIFT`](https://developer.apple.com/documentation/swift/objective-c_and_c_code_customization/improving_objective-c_api_declarations_for_swift)
+ * macro for more information on refining Objective-C declarations in Swift.
+ *
+ * Note: only annotations with [AnnotationTarget.FUNCTION] and/or [AnnotationTarget.PROPERTY] are supported.
+ */
+@Target(AnnotationTarget.ANNOTATION_CLASS)
+@Retention(AnnotationRetention.BINARY)
+@MustBeDocumented
+@OptionalExpectation
+@ExperimentalObjCRefinement
+public expect annotation class RefinesInSwift()
+
+/**
+ * Instructs the Kotlin compiler to mark this function or property as `swift_private` in the generated Objective-C API.
+ *
+ * See Apple's documentation of the [`NS_REFINED_FOR_SWIFT`](https://developer.apple.com/documentation/swift/objective-c_and_c_code_customization/improving_objective-c_api_declarations_for_swift)
+ * macro for more information on refining Objective-C declarations in Swift.
+ */
+@RefinesInSwift
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
+@MustBeDocumented
+@OptionalExpectation
+@ExperimentalObjCRefinement
+public expect annotation class ShouldRefineInSwift()

--- a/libraries/stdlib/src/kotlin/experimental/ExperimentalObjCRefinement.kt
+++ b/libraries/stdlib/src/kotlin/experimental/ExperimentalObjCRefinement.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package kotlin.experimental
+
+/**
+ * This annotation marks the experimental Objective-C export refinement annotations.
+ */
+@RequiresOptIn
+@Target(AnnotationTarget.ANNOTATION_CLASS)
+@Retention(AnnotationRetention.BINARY)
+@MustBeDocumented
+public annotation class ExperimentalObjCRefinement

--- a/libraries/tools/binary-compatibility-validator/reference-public-api/kotlin-stdlib-runtime-merged.txt
+++ b/libraries/tools/binary-compatibility-validator/reference-public-api/kotlin-stdlib-runtime-merged.txt
@@ -3148,6 +3148,9 @@ public final class kotlin/enums/EnumEntriesKt {
 public abstract interface annotation class kotlin/experimental/ExperimentalObjCName : java/lang/annotation/Annotation {
 }
 
+public abstract interface annotation class kotlin/experimental/ExperimentalObjCRefinement : java/lang/annotation/Annotation {
+}
+
 public abstract interface annotation class kotlin/experimental/ExperimentalTypeInference : java/lang/annotation/Annotation {
 }
 

--- a/native/frontend/src/org/jetbrains/kotlin/resolve/konan/diagnostics/DefaultErrorMessagesNative.kt
+++ b/native/frontend/src/org/jetbrains/kotlin/resolve/konan/diagnostics/DefaultErrorMessagesNative.kt
@@ -54,6 +54,17 @@ private val DIAGNOSTIC_FACTORY_TO_RENDERER by lazy {
         put(ErrorsNative.INAPPLICABLE_EXACT_OBJC_NAME, "Exact @ObjCName is only applicable to classes, objects and interfaces")
         put(ErrorsNative.MISSING_EXACT_OBJC_NAME, "Exact @ObjCName is required to have an ObjC name")
         put(ErrorsNative.NON_LITERAL_OBJC_NAME_ARG, "@ObjCName accepts only literal string and boolean values")
+        put(ErrorsNative.REDUNDANT_SWIFT_REFINEMENT, "An ObjC refined declaration can't also be refined in Swift")
+        put(
+            ErrorsNative.INCOMPATIBLE_OBJC_REFINEMENT_OVERRIDE,
+            "Refined declaration \"{0}\" overrides declarations with different or no refinement from {1}",
+            Renderers.NAME,
+            CommonRenderers.commaSeparated(Renderers.NAME)
+        )
+        put(
+            ErrorsNative.INVALID_OBJC_REFINEMENT_TARGETS,
+            "Refines annotations are only applicable to annotations with targets FUNCTION and/or PROPERTY"
+        )
     }
 }
 

--- a/native/frontend/src/org/jetbrains/kotlin/resolve/konan/diagnostics/ErrorsNative.kt
+++ b/native/frontend/src/org/jetbrains/kotlin/resolve/konan/diagnostics/ErrorsNative.kt
@@ -52,6 +52,12 @@ object ErrorsNative {
     val MISSING_EXACT_OBJC_NAME = DiagnosticFactory0.create<KtElement>(Severity.ERROR)
     @JvmField
     val NON_LITERAL_OBJC_NAME_ARG = DiagnosticFactory0.create<KtElement>(Severity.ERROR)
+    @JvmField
+    val REDUNDANT_SWIFT_REFINEMENT = DiagnosticFactory0.create<KtElement>(Severity.ERROR)
+    @JvmField
+    val INCOMPATIBLE_OBJC_REFINEMENT_OVERRIDE = DiagnosticFactory2.create<KtElement, DeclarationDescriptor, Collection<DeclarationDescriptor>>(Severity.ERROR)
+    @JvmField
+    val INVALID_OBJC_REFINEMENT_TARGETS = DiagnosticFactory0.create<KtElement>(Severity.ERROR)
 
     init {
         Errors.Initializer.initializeFactoryNames(ErrorsNative::class.java)

--- a/native/frontend/src/org/jetbrains/kotlin/resolve/konan/diagnostics/NativeObjCRefinementAnnotationChecker.kt
+++ b/native/frontend/src/org/jetbrains/kotlin/resolve/konan/diagnostics/NativeObjCRefinementAnnotationChecker.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.resolve.konan.diagnostics
+
+import org.jetbrains.kotlin.descriptors.ClassDescriptor
+import org.jetbrains.kotlin.descriptors.ClassKind
+import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
+import org.jetbrains.kotlin.descriptors.annotations.AnnotationDescriptor
+import org.jetbrains.kotlin.descriptors.annotations.KotlinTarget
+import org.jetbrains.kotlin.psi.KtDeclaration
+import org.jetbrains.kotlin.resolve.AnnotationChecker
+import org.jetbrains.kotlin.resolve.BindingTrace
+import org.jetbrains.kotlin.resolve.DescriptorToSourceUtils
+import org.jetbrains.kotlin.resolve.checkers.DeclarationChecker
+import org.jetbrains.kotlin.resolve.checkers.DeclarationCheckerContext
+import org.jetbrains.kotlin.resolve.konan.diagnostics.NativeObjCRefinementChecker.hidesFromObjCFqName
+import org.jetbrains.kotlin.resolve.konan.diagnostics.NativeObjCRefinementChecker.refinesInSwiftFqName
+
+object NativeObjCRefinementAnnotationChecker : DeclarationChecker {
+
+    private val supportedTargets = arrayOf(KotlinTarget.FUNCTION, KotlinTarget.PROPERTY)
+
+    override fun check(declaration: KtDeclaration, descriptor: DeclarationDescriptor, context: DeclarationCheckerContext) {
+        if (descriptor !is ClassDescriptor || descriptor.kind != ClassKind.ANNOTATION_CLASS) return
+        val (objCAnnotation, swiftAnnotation) = descriptor.findRefinesAnnotations()
+        if (objCAnnotation == null && swiftAnnotation == null) return
+        if (objCAnnotation != null && swiftAnnotation != null) {
+            val reportLocation = DescriptorToSourceUtils.getSourceFromAnnotation(swiftAnnotation) ?: declaration
+            context.trace.report(ErrorsNative.REDUNDANT_SWIFT_REFINEMENT.on(reportLocation))
+        }
+        val targets = AnnotationChecker.applicableTargetSet(descriptor)
+        val unsupportedTargets = targets - supportedTargets
+        if (unsupportedTargets.isNotEmpty()) {
+            objCAnnotation?.let { context.trace.reportInvalidAnnotationTargets(declaration, it) }
+            swiftAnnotation?.let { context.trace.reportInvalidAnnotationTargets(declaration, it) }
+        }
+    }
+
+    private fun DeclarationDescriptor.findRefinesAnnotations(): Pair<AnnotationDescriptor?, AnnotationDescriptor?> {
+        var objCAnnotation: AnnotationDescriptor? = null
+        var swiftAnnotation: AnnotationDescriptor? = null
+        for (annotation in annotations) {
+            when (annotation.fqName) {
+                hidesFromObjCFqName -> objCAnnotation = annotation
+                refinesInSwiftFqName -> swiftAnnotation = annotation
+            }
+            if (objCAnnotation != null && swiftAnnotation != null) break
+        }
+        return objCAnnotation to swiftAnnotation
+    }
+
+    private fun BindingTrace.reportInvalidAnnotationTargets(
+        declaration: KtDeclaration,
+        annotation: AnnotationDescriptor
+    ) {
+        val reportLocation = DescriptorToSourceUtils.getSourceFromAnnotation(annotation) ?: declaration
+        report(ErrorsNative.INVALID_OBJC_REFINEMENT_TARGETS.on(reportLocation))
+    }
+}

--- a/native/frontend/src/org/jetbrains/kotlin/resolve/konan/diagnostics/NativeObjCRefinementChecker.kt
+++ b/native/frontend/src/org/jetbrains/kotlin/resolve/konan/diagnostics/NativeObjCRefinementChecker.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.resolve.konan.diagnostics
+
+import org.jetbrains.kotlin.descriptors.*
+import org.jetbrains.kotlin.descriptors.annotations.AnnotationDescriptor
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.KtDeclaration
+import org.jetbrains.kotlin.resolve.DescriptorToSourceUtils
+import org.jetbrains.kotlin.resolve.checkers.DeclarationChecker
+import org.jetbrains.kotlin.resolve.checkers.DeclarationCheckerContext
+import org.jetbrains.kotlin.resolve.descriptorUtil.annotationClass
+import org.jetbrains.kotlin.resolve.konan.diagnostics.NativeObjCRefinementOverridesChecker.check
+
+object NativeObjCRefinementChecker : DeclarationChecker {
+
+    val hidesFromObjCFqName = FqName("kotlin.native.HidesFromObjC")
+    val refinesInSwiftFqName = FqName("kotlin.native.RefinesInSwift")
+
+    override fun check(declaration: KtDeclaration, descriptor: DeclarationDescriptor, context: DeclarationCheckerContext) {
+        if (descriptor !is CallableMemberDescriptor) return
+        if (descriptor !is FunctionDescriptor && descriptor !is PropertyDescriptor) return
+        val (objCAnnotations, swiftAnnotations) = descriptor.findRefinedAnnotations()
+        if (objCAnnotations.isNotEmpty() && swiftAnnotations.isNotEmpty()) {
+            swiftAnnotations.forEach {
+                val reportLocation = DescriptorToSourceUtils.getSourceFromAnnotation(it) ?: declaration
+                context.trace.report(ErrorsNative.REDUNDANT_SWIFT_REFINEMENT.on(reportLocation))
+            }
+        }
+        check(declaration, descriptor, context, objCAnnotations, swiftAnnotations)
+    }
+
+    private fun DeclarationDescriptor.findRefinedAnnotations(): Pair<List<AnnotationDescriptor>, List<AnnotationDescriptor>> {
+        val objCAnnotations = mutableListOf<AnnotationDescriptor>()
+        val swiftAnnotations = mutableListOf<AnnotationDescriptor>()
+        for (annotation in annotations) {
+            val annotations = annotation.annotationClass?.annotations ?: continue
+            for (metaAnnotation in annotations) {
+                when (metaAnnotation.fqName) {
+                    hidesFromObjCFqName -> {
+                        objCAnnotations.add(annotation)
+                        break
+                    }
+
+                    refinesInSwiftFqName -> {
+                        swiftAnnotations.add(annotation)
+                        break
+                    }
+                }
+            }
+        }
+        return objCAnnotations to swiftAnnotations
+    }
+}

--- a/native/frontend/src/org/jetbrains/kotlin/resolve/konan/diagnostics/NativeObjCRefinementOverridesChecker.kt
+++ b/native/frontend/src/org/jetbrains/kotlin/resolve/konan/diagnostics/NativeObjCRefinementOverridesChecker.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.resolve.konan.diagnostics
+
+import org.jetbrains.kotlin.descriptors.CallableMemberDescriptor
+import org.jetbrains.kotlin.descriptors.ClassDescriptor
+import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
+import org.jetbrains.kotlin.descriptors.annotations.AnnotationDescriptor
+import org.jetbrains.kotlin.psi.KtDeclaration
+import org.jetbrains.kotlin.resolve.BindingTrace
+import org.jetbrains.kotlin.resolve.DescriptorToSourceUtils
+import org.jetbrains.kotlin.resolve.checkers.DeclarationChecker
+import org.jetbrains.kotlin.resolve.checkers.DeclarationCheckerContext
+import org.jetbrains.kotlin.resolve.descriptorUtil.annotationClass
+import org.jetbrains.kotlin.resolve.konan.diagnostics.NativeObjCRefinementChecker.hidesFromObjCFqName
+import org.jetbrains.kotlin.resolve.konan.diagnostics.NativeObjCRefinementChecker.refinesInSwiftFqName
+import org.jetbrains.kotlin.resolve.scopes.DescriptorKindFilter
+import org.jetbrains.kotlin.resolve.scopes.MemberScope
+
+object NativeObjCRefinementOverridesChecker : DeclarationChecker {
+
+    override fun check(declaration: KtDeclaration, descriptor: DeclarationDescriptor, context: DeclarationCheckerContext) {
+        if (descriptor !is ClassDescriptor) return
+        descriptor.defaultType.memberScope
+            .getContributedDescriptors(DescriptorKindFilter.ALL, MemberScope.Companion.ALL_NAME_FILTER)
+            .forEach {
+                if (it !is CallableMemberDescriptor || it.kind.isReal) return@forEach
+                check(declaration, it, context, emptyList(), emptyList())
+            }
+    }
+
+    fun check(
+        declarationToReport: KtDeclaration,
+        descriptor: CallableMemberDescriptor,
+        context: DeclarationCheckerContext,
+        objCAnnotations: List<AnnotationDescriptor>,
+        swiftAnnotations: List<AnnotationDescriptor>
+    ) {
+        if (descriptor.overriddenDescriptors.isEmpty()) return
+        var isHiddenFromObjC = objCAnnotations.isNotEmpty()
+        var isRefinedInSwift = swiftAnnotations.isNotEmpty()
+        val supersNotHiddenFromObjC = mutableListOf<CallableMemberDescriptor>()
+        val supersNotRefinedInSwift = mutableListOf<CallableMemberDescriptor>()
+        for (overriddenDescriptor in descriptor.overriddenDescriptors) {
+            val (superIsHiddenFromObjC, superIsRefinedInSwift) = overriddenDescriptor.inheritsRefinedAnnotations()
+            if (superIsHiddenFromObjC) isHiddenFromObjC = true else supersNotHiddenFromObjC.add(overriddenDescriptor)
+            if (superIsRefinedInSwift) isRefinedInSwift = true else supersNotRefinedInSwift.add(overriddenDescriptor)
+        }
+        if (isHiddenFromObjC && supersNotHiddenFromObjC.isNotEmpty()) {
+            context.trace.reportIncompatibleOverride(declarationToReport, descriptor, objCAnnotations, supersNotHiddenFromObjC)
+        }
+        if (isRefinedInSwift && supersNotRefinedInSwift.isNotEmpty()) {
+            context.trace.reportIncompatibleOverride(declarationToReport, descriptor, swiftAnnotations, supersNotRefinedInSwift)
+        }
+    }
+
+    private fun CallableMemberDescriptor.inheritsRefinedAnnotations(): Pair<Boolean, Boolean> {
+        val (hasObjC, hasSwift) = hasRefinedAnnotations()
+        if (hasObjC && hasSwift) return true to true
+        if (overriddenDescriptors.isEmpty()) return hasObjC to hasSwift
+        // Note: `checkOverrides` requires all overridden descriptors to be either refined or not refined.
+        val (inheritsObjC, inheritsSwift) = overriddenDescriptors.first().inheritsRefinedAnnotations()
+        return (hasObjC || inheritsObjC) to (hasSwift || inheritsSwift)
+    }
+
+    private fun CallableMemberDescriptor.hasRefinedAnnotations(): Pair<Boolean, Boolean> {
+        var hasObjC = false
+        var hasSwift = false
+        for (annotation in annotations) {
+            val annotations = annotation.annotationClass?.annotations ?: continue
+            for (metaAnnotation in annotations) {
+                when (metaAnnotation.fqName) {
+                    hidesFromObjCFqName -> {
+                        hasObjC = true
+                        break
+                    }
+
+                    refinesInSwiftFqName -> {
+                        hasSwift = true
+                        break
+                    }
+                }
+            }
+            if (hasObjC && hasSwift) return true to true
+        }
+        return hasObjC to hasSwift
+    }
+
+    private fun BindingTrace.reportIncompatibleOverride(
+        declaration: KtDeclaration,
+        descriptor: CallableMemberDescriptor,
+        annotations: List<AnnotationDescriptor>,
+        notRefinedSupers: List<CallableMemberDescriptor>
+    ) {
+        val containingDeclarations = notRefinedSupers.map { it.containingDeclaration }
+        if (annotations.isEmpty()) {
+            report(ErrorsNative.INCOMPATIBLE_OBJC_REFINEMENT_OVERRIDE.on(declaration, descriptor, containingDeclarations))
+        } else {
+            annotations.forEach {
+                val reportLocation = DescriptorToSourceUtils.getSourceFromAnnotation(it) ?: declaration
+                report(ErrorsNative.INCOMPATIBLE_OBJC_REFINEMENT_OVERRIDE.on(reportLocation, descriptor, containingDeclarations))
+            }
+        }
+    }
+}

--- a/native/frontend/src/org/jetbrains/kotlin/resolve/konan/platform/NativePlatformConfigurator.kt
+++ b/native/frontend/src/org/jetbrains/kotlin/resolve/konan/platform/NativePlatformConfigurator.kt
@@ -5,7 +5,6 @@
 
 package org.jetbrains.kotlin.resolve.konan.platform
 
-import org.jetbrains.kotlin.config.LanguageVersionSettings
 import org.jetbrains.kotlin.container.StorageComponentContainer
 import org.jetbrains.kotlin.container.useImpl
 import org.jetbrains.kotlin.container.useInstance
@@ -13,7 +12,6 @@ import org.jetbrains.kotlin.descriptors.CallableMemberDescriptor
 import org.jetbrains.kotlin.psi.KtCallableDeclaration
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.PlatformConfiguratorBase
-import org.jetbrains.kotlin.resolve.calls.checkers.TypeOfChecker
 import org.jetbrains.kotlin.resolve.checkers.ExpectedActualDeclarationChecker
 import org.jetbrains.kotlin.resolve.inline.ReasonableInlineRule
 import org.jetbrains.kotlin.resolve.jvm.checkers.SuperCallWithDefaultArgumentsChecker
@@ -26,7 +24,8 @@ object NativePlatformConfigurator : PlatformConfiguratorBase(
     additionalDeclarationCheckers = listOf(
         NativeThrowsChecker, NativeSharedImmutableChecker,
         NativeTopLevelSingletonChecker, NativeThreadLocalChecker,
-        NativeObjCNameChecker
+        NativeObjCNameChecker, NativeObjCRefinementChecker,
+        NativeObjCRefinementAnnotationChecker, NativeObjCRefinementOverridesChecker
     )
 ) {
     override fun configureModuleComponents(container: StorageComponentContainer) {


### PR DESCRIPTION
Relates to [KT-42297](https://youtrack.jetbrains.com/issue/KT-42297).

The Kotlin ObjC/Swift is pretty great, but at the moment there are also some gaps (especially with the Swift interop) like suspend functions and enum classes.
With some boilerplate code the interop for such code can be improved, which can even be automated with a compiler plugin/annotation processor.
However one limitation of such boilerplate code is that it adds unnecessary declarations to your public API.

With the `HiddenFromObjC` and `ShouldRefineInSwift` annotations we can hide these unnecessary declarations from the public API.
We also have the meta-annotations `HidesFromObjC` and `RefinesInSwift` such that annotation processors can generate ObjC/Swift friendly APIs while automatically hiding the original declaration.

### HiddenFromObjC
Functions and properties annotated with the `HiddenFromObjC` annotation won't be exported to ObjC.
This allows you to create a more ObjC friendly version in your Kotlin code.

> With the `ObjCName` annotation from #4815 you could even use the original name of the function/property for your ObjC friendly version.

### ShouldRefineInSwift
The `ShouldRefineInSwift` annotation adds the [`swift_private`](https://developer.apple.com/documentation/swift/objective-c_and_c_code_customization/improving_objective-c_api_declarations_for_swift) attribute to the declaration.
This results in the declarations being prefixed with `__`, which make them "invisible" from Swift.
These declarations can still be used in your Swift code to create your Swift friendly API, but won't be shown in e.g. the Xcode autocomplete.
