### PR TITLE
Changes the parameter name of `writeToParcel` to `out`

### DIFF
--- a/plugins/parcelize/parcelize-compiler/src/org/jetbrains/kotlin/parcelize/ParcelizeResolveExtension.kt
+++ b/plugins/parcelize/parcelize-compiler/src/org/jetbrains/kotlin/parcelize/ParcelizeResolveExtension.kt
@@ -145,7 +145,7 @@ open class ParcelizeResolveExtension : SyntheticResolveExtension {
             val parcelClassType = resolveParcelClassType(thisDescriptor.module) ?: ErrorUtils.createErrorType(ErrorTypeKind.UNRESOLVED_PARCEL_TYPE)
             result += createMethod(
                 thisDescriptor, WRITE_TO_PARCEL, Modality.OPEN,
-                builtIns.unitType, "parcel" to parcelClassType, "flags" to builtIns.intType
+                builtIns.unitType, "out" to parcelClassType, "flags" to builtIns.intType
             )
         }
     }


### PR DESCRIPTION
The parameter name of `writeToParcel` is changed from `parcel` to `out`. This way the name matches the one specified in `parcelize/ir/ParcelizeIrTransformer.kt`.