### PR TITLE
KT-52315: Consistently allow modifier keywords as enum entry names

### DIFF
--- a/compiler/psi/src/org/jetbrains/kotlin/parsing/KotlinParsing.java
+++ b/compiler/psi/src/org/jetbrains/kotlin/parsing/KotlinParsing.java
@@ -1126,7 +1126,7 @@ public class KotlinParsing extends AbstractKotlinParsing {
     private ParseEnumEntryResult parseEnumEntry() {
         PsiBuilder.Marker entry = mark();
 
-        parseModifierList(DEFAULT, TokenSet.create(COMMA, SEMICOLON, RBRACE));
+        parseModifierList(DEFAULT, TokenSet.create(LPAR, COMMA, SEMICOLON, RBRACE));
 
         if (!atSet(SOFT_KEYWORDS_AT_MEMBER_START) && at(IDENTIFIER)) {
             advance(); // IDENTIFIER

--- a/compiler/testData/psi/EnumEntryModifierKeywordNames.kt
+++ b/compiler/testData/psi/EnumEntryModifierKeywordNames.kt
@@ -1,0 +1,7 @@
+enum class My {
+    const,
+    data(),
+    header,
+    impl(),
+    ;
+}

--- a/compiler/testData/psi/EnumEntryModifierKeywordNames.txt
+++ b/compiler/testData/psi/EnumEntryModifierKeywordNames.txt
@@ -1,0 +1,56 @@
+KtFile: EnumEntryModifierKeywordNames.kt
+  PACKAGE_DIRECTIVE
+    <empty list>
+  IMPORT_LIST
+    <empty list>
+  CLASS
+    MODIFIER_LIST
+      PsiElement(enum)('enum')
+    PsiWhiteSpace(' ')
+    PsiElement(class)('class')
+    PsiWhiteSpace(' ')
+    PsiElement(IDENTIFIER)('My')
+    PsiWhiteSpace(' ')
+    CLASS_BODY
+      PsiElement(LBRACE)('{')
+      PsiWhiteSpace('\n    ')
+      ENUM_ENTRY
+        PsiElement(IDENTIFIER)('const')
+        PsiElement(COMMA)(',')
+      PsiWhiteSpace('\n    ')
+      ENUM_ENTRY
+        PsiElement(IDENTIFIER)('data')
+        INITIALIZER_LIST
+          SUPER_TYPE_CALL_ENTRY
+            CONSTRUCTOR_CALLEE
+              TYPE_REFERENCE
+                USER_TYPE
+                  ENUM_ENTRY_SUPERCLASS_REFERENCE_EXPRESSION
+                    <empty list>
+            VALUE_ARGUMENT_LIST
+              PsiElement(LPAR)('(')
+              PsiElement(RPAR)(')')
+        PsiElement(COMMA)(',')
+      PsiWhiteSpace('\n    ')
+      ENUM_ENTRY
+        PsiElement(IDENTIFIER)('header')
+        PsiElement(COMMA)(',')
+      PsiWhiteSpace('\n    ')
+      ENUM_ENTRY
+        PsiElement(IDENTIFIER)('impl')
+        INITIALIZER_LIST
+          SUPER_TYPE_CALL_ENTRY
+            CONSTRUCTOR_CALLEE
+              TYPE_REFERENCE
+                USER_TYPE
+                  ENUM_ENTRY_SUPERCLASS_REFERENCE_EXPRESSION
+                    <empty list>
+            VALUE_ARGUMENT_LIST
+              PsiElement(LPAR)('(')
+              PsiElement(RPAR)(')')
+        PsiElement(COMMA)(',')
+        PsiWhiteSpace('\n    ')
+        PsiElement(SEMICOLON)(';')
+      PsiWhiteSpace('\n')
+      PsiElement(RBRACE)('}')
+

--- a/compiler/tests-gen/org/jetbrains/kotlin/parsing/ParsingTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/parsing/ParsingTestGenerated.java
@@ -276,6 +276,11 @@ public class ParsingTestGenerated extends AbstractParsingTest {
             runTest("compiler/testData/psi/EnumEntrySemicolonMember.kt");
         }
 
+        @TestMetadata("EnumEntryModifierKeywordNames.kt")
+        public void testEnumEntrySoftKeywords() throws Exception {
+            runTest("compiler/testData/psi/EnumEntryModifierKeywordNames.kt");
+        }
+
         @TestMetadata("EnumEntrySpaceInlineMember.kt")
         public void testEnumEntrySpaceInlineMember() throws Exception {
             runTest("compiler/testData/psi/EnumEntrySpaceInlineMember.kt");


### PR DESCRIPTION
Before this change, they work without `()` but fail with `()`.
After this change, they work with or without `()`.