### PR TITLE
JVM_IR: skip SAM lambdas when computing enclosing method of objects

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -44706,6 +44706,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         }
 
         @Test
+        @TestMetadata("kt52417.kt")
+        public void testKt52417() throws Exception {
+            runTest("compiler/testData/codegen/box/sam/kt52417.kt");
+        }
+
+        @Test
         @TestMetadata("nonInlinedSamWrapper.kt")
         public void testNonInlinedSamWrapper() throws Exception {
             runTest("compiler/testData/codegen/box/sam/nonInlinedSamWrapper.kt");

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxInlineCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxInlineCodegenTestGenerated.java
@@ -2231,6 +2231,12 @@ public class FirBlackBoxInlineCodegenTestGenerated extends AbstractFirBlackBoxIn
         }
 
         @Test
+        @TestMetadata("kt52417.kt")
+        public void testKt52417() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/enclosingInfo/kt52417.kt");
+        }
+
+        @Test
         @TestMetadata("objectInInlineFun.kt")
         public void testObjectInInlineFun() throws Exception {
             runTest("compiler/testData/codegen/boxInline/enclosingInfo/objectInInlineFun.kt");

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirLightTreeBlackBoxInlineCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirLightTreeBlackBoxInlineCodegenTestGenerated.java
@@ -2231,6 +2231,12 @@ public class FirLightTreeBlackBoxInlineCodegenTestGenerated extends AbstractFirL
         }
 
         @Test
+        @TestMetadata("kt52417.kt")
+        public void testKt52417() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/enclosingInfo/kt52417.kt");
+        }
+
+        @Test
         @TestMetadata("objectInInlineFun.kt")
         public void testObjectInInlineFun() throws Exception {
             runTest("compiler/testData/codegen/boxInline/enclosingInfo/objectInInlineFun.kt");

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirSerializeCompileKotlinAgainstInlineKotlinTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirSerializeCompileKotlinAgainstInlineKotlinTestGenerated.java
@@ -2231,6 +2231,12 @@ public class FirSerializeCompileKotlinAgainstInlineKotlinTestGenerated extends A
         }
 
         @Test
+        @TestMetadata("kt52417.kt")
+        public void testKt52417() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/enclosingInfo/kt52417.kt");
+        }
+
+        @Test
         @TestMetadata("objectInInlineFun.kt")
         public void testObjectInInlineFun() throws Exception {
             runTest("compiler/testData/codegen/boxInline/enclosingInfo/objectInInlineFun.kt");

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -139,7 +139,6 @@ class ExpressionCodegen(
     override val frameMap: IrFrameMap,
     val mv: InstructionAdapter,
     val classCodegen: ClassCodegen,
-    val inlinedInto: ExpressionCodegen?,
     val smap: SourceMapper,
     val reifiedTypeParametersUsages: ReifiedTypeParametersUsages,
 ) : IrElementVisitor<PromisedValue, BlockInfo>, BaseExpressionCodegen {
@@ -148,11 +147,8 @@ class ExpressionCodegen(
 
     var finallyDepth = 0
 
-    val inlineRoot: ExpressionCodegen
-        get() = inlinedInto ?: this
-
     val enclosingFunctionForLocalObjects: IrFunction
-        get() = generateSequence(inlineRoot.irFunction) { context.enclosingMethodOverride[it] }.last()
+        get() = generateSequence(irFunction) { context.enclosingMethodOverride[it] }.last()
 
     val context = classCodegen.context
     val typeMapper = context.typeMapper
@@ -292,9 +288,9 @@ class ExpressionCodegen(
         if (state.isParamAssertionsDisabled)
             return
 
-        if (inlinedInto != null ||
-            (DescriptorVisibilities.isPrivate(irFunction.visibility) && !shouldGenerateNonNullAssertionsForPrivateFun(irFunction)) ||
+        if ((DescriptorVisibilities.isPrivate(irFunction.visibility) && !shouldGenerateNonNullAssertionsForPrivateFun(irFunction)) ||
             irFunction.origin.isSynthetic ||
+            irFunction.origin == JvmLoweredDeclarationOrigin.INLINE_LAMBDA ||
             // TODO: refine this condition to not generate nullability assertions on parameters
             //       corresponding to captured variables and anonymous object super constructor arguments
             (irFunction is IrConstructor && irFunction.parentAsClass.isAnonymousObject) ||
@@ -1526,7 +1522,7 @@ class ExpressionCodegen(
     }
 
     val isFinallyMarkerRequired: Boolean
-        get() = irFunction.isInline || inlinedInto != null
+        get() = irFunction.isInline || irFunction.origin == JvmLoweredDeclarationOrigin.INLINE_LAMBDA
 
     val IrType.isReifiedTypeParameter: Boolean
         get() = this.classifierOrNull?.safeAs<IrTypeParameterSymbol>()?.owner?.isReified == true

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/FunctionCodegen.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/FunctionCodegen.kt
@@ -39,16 +39,15 @@ class FunctionCodegen(private val irFunction: IrFunction, private val classCodeg
     private val context = classCodegen.context
 
     fun generate(
-        inlinedInto: ExpressionCodegen? = null,
         reifiedTypeParameters: ReifiedTypeParametersUsages = classCodegen.reifiedTypeParametersUsages
     ): SMAPAndMethodNode =
         try {
-            doGenerate(inlinedInto, reifiedTypeParameters)
+            doGenerate(reifiedTypeParameters)
         } catch (e: Throwable) {
             throw RuntimeException("Exception while generating code for:\n${irFunction.dump()}", e)
         }
 
-    private fun doGenerate(inlinedInto: ExpressionCodegen?, reifiedTypeParameters: ReifiedTypeParametersUsages): SMAPAndMethodNode {
+    private fun doGenerate(reifiedTypeParameters: ReifiedTypeParametersUsages): SMAPAndMethodNode {
         val signature = context.methodSignatureMapper.mapSignatureWithGeneric(irFunction)
         val flags = irFunction.calculateMethodFlags()
         val isSynthetic = flags.and(Opcodes.ACC_SYNTHETIC) != 0
@@ -115,9 +114,7 @@ class FunctionCodegen(private val irFunction: IrFunction, private val classCodeg
             context.state.globalInlineContext.enterDeclaration(irFunction.suspendFunctionOriginal().toIrBasedDescriptor())
             try {
                 val adapter = InstructionAdapter(methodVisitor)
-                ExpressionCodegen(
-                    irFunction, signature, frameMap, adapter, classCodegen, inlinedInto, sourceMapper, reifiedTypeParameters
-                ).generate()
+                ExpressionCodegen(irFunction, signature, frameMap, adapter, classCodegen, sourceMapper, reifiedTypeParameters).generate()
             } finally {
                 context.state.globalInlineContext.exitDeclaration()
             }

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/IrSourceCompilerForInline.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/IrSourceCompilerForInline.kt
@@ -42,12 +42,11 @@ class IrSourceCompilerForInline(
 
     override val inlineCallSiteInfo: InlineCallSiteInfo
         get() {
-            val root = codegen.inlineRoot
-            val rootFunction = root.enclosingFunctionForLocalObjects
+            val rootFunction = codegen.enclosingFunctionForLocalObjects
             return InlineCallSiteInfo(
-                root.classCodegen.type.internalName,
-                if (rootFunction === root.irFunction)
-                    root.signature.asmMethod
+                codegen.classCodegen.type.internalName,
+                if (rootFunction === codegen.irFunction)
+                    codegen.signature.asmMethod
                 else
                     codegen.methodSignatureMapper.mapAsmMethod(rootFunction),
                 rootFunction.inlineScopeVisibility,
@@ -66,7 +65,7 @@ class IrSourceCompilerForInline(
                 reifiedTypeParameters.addUsedReifiedParameter(typeParameter.name.asString())
             }
         }
-        return FunctionCodegen(lambdaInfo.function, codegen.classCodegen).generate(codegen.inlineRoot, reifiedTypeParameters)
+        return FunctionCodegen(lambdaInfo.function, codegen.classCodegen).generate(reifiedTypeParameters)
     }
 
     override fun compileInlineFunction(jvmSignature: JvmMethodSignature): SMAPAndMethodNode {
@@ -100,7 +99,7 @@ class IrSourceCompilerForInline(
     override fun generateFinallyBlocks(finallyNode: MethodNode, curFinallyDepth: Int, returnType: Type, afterReturnLabel: Label, target: Label?) {
         ExpressionCodegen(
             codegen.irFunction, codegen.signature, codegen.frameMap, InstructionAdapter(finallyNode), codegen.classCodegen,
-            codegen.inlinedInto, codegen.smap, codegen.reifiedTypeParametersUsages
+            codegen.smap, codegen.reifiedTypeParametersUsages
         ).also {
             it.finallyDepth = curFinallyDepth
         }.generateFinallyBlocksIfNeeded(returnType, afterReturnLabel, data, target)

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
@@ -366,6 +366,7 @@ private val jvmFilePhases = listOf(
     jvmSafeCallFoldingPhase,
     jvmOptimizationLoweringPhase,
     additionalClassAnnotationPhase,
+    recordEnclosingMethodsPhase,
     typeOperatorLowering,
     replaceKFunctionInvokeWithFunctionInvokePhase,
     kotlinNothingValueExceptionPhase,

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/RecordEnclosingMethodsLowering.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/RecordEnclosingMethodsLowering.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.jvm.lower
+
+import org.jetbrains.kotlin.backend.common.FileLoweringPass
+import org.jetbrains.kotlin.backend.common.phaser.makeIrFilePhase
+import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
+import org.jetbrains.kotlin.backend.jvm.ir.isInlineFunctionCall
+import org.jetbrains.kotlin.backend.jvm.ir.unwrapInlineLambda
+import org.jetbrains.kotlin.ir.IrElement
+import org.jetbrains.kotlin.ir.declarations.IrConstructor
+import org.jetbrains.kotlin.ir.declarations.IrFile
+import org.jetbrains.kotlin.ir.declarations.IrFunction
+import org.jetbrains.kotlin.ir.expressions.IrFunctionAccessExpression
+import org.jetbrains.kotlin.ir.expressions.IrFunctionReference
+import org.jetbrains.kotlin.ir.util.isLambda
+import org.jetbrains.kotlin.ir.util.parentAsClass
+import org.jetbrains.kotlin.ir.util.primaryConstructor
+import org.jetbrains.kotlin.ir.util.render
+import org.jetbrains.kotlin.ir.visitors.IrElementVisitor
+
+internal val recordEnclosingMethodsPhase = makeIrFilePhase(
+    ::RecordEnclosingMethodsLowering,
+    name = "RecordEnclosingMethods",
+    description = "Find enclosing methods for objects inside inline and dynamic lambdas"
+)
+
+private class RecordEnclosingMethodsLowering(val context: JvmBackendContext) : FileLoweringPass {
+    override fun lower(irFile: IrFile) =
+        irFile.accept(object : IrElementVisitor<Unit, IrFunction?> {
+            override fun visitElement(element: IrElement, data: IrFunction?) =
+                element.acceptChildren(this, element as? IrFunction ?: data)
+
+            override fun visitFunctionAccess(expression: IrFunctionAccessExpression, data: IrFunction?) {
+                require(data != null) { "function call not in a method: ${expression.render()}" }
+                when {
+                    expression.symbol == context.ir.symbols.indyLambdaMetafactoryIntrinsic -> {
+                        val reference = expression.getValueArgument(1)
+                        if (reference is IrFunctionReference && reference.origin.isLambda) {
+                            recordEnclosingMethodOverride(reference.symbol.owner, data)
+                        }
+                    }
+                    expression.symbol.owner.isInlineFunctionCall(context) -> {
+                        for (parameter in expression.symbol.owner.valueParameters) {
+                            val lambda = expression.getValueArgument(parameter.index)?.unwrapInlineLambda() ?: continue
+                            recordEnclosingMethodOverride(lambda.symbol.owner, data)
+                        }
+                    }
+                }
+                return super.visitFunctionAccess(expression, data)
+            }
+
+            private fun recordEnclosingMethodOverride(from: IrFunction, to: IrFunction) =
+                context.enclosingMethodOverride.merge(from, to) { old, new ->
+                    // A single lambda can be referenced multiple times if it is in a field initializer
+                    // or an anonymous initializer block and there are multiple non-delegating constructors.
+                    assert(old.parentAsClass == new.parentAsClass && old is IrConstructor && new is IrConstructor)
+                    old.parentAsClass.primaryConstructor ?: old
+                }
+        }, null)
+}

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendContext.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendContext.kt
@@ -99,6 +99,7 @@ class JvmBackendContext(
     }
 
     val isEnclosedInConstructor = ConcurrentHashMap.newKeySet<IrAttributeContainer>()
+    val enclosingMethodOverride = ConcurrentHashMap<IrFunction, IrFunction>()
 
     private val classCodegens = ConcurrentHashMap<IrClass, Any>()
 

--- a/compiler/testData/codegen/box/sam/kt52417.kt
+++ b/compiler/testData/codegen/box/sam/kt52417.kt
@@ -1,0 +1,18 @@
+// TARGET_BACKEND: JVM
+// WITH_RUNTIME
+// WITH_STDLIB
+package test
+
+abstract class TypeToken<T>
+
+fun interface I {
+    fun foo(): String
+}
+
+fun <T> foo() =
+    I {
+        (object : TypeToken<T>() {})::class.java.genericSuperclass.toString()
+    }.foo()
+
+fun box(): String =
+    foo<String>().let { if (it == "test.TypeToken<T>") "OK" else it }

--- a/compiler/testData/codegen/boxInline/enclosingInfo/kt52417.kt
+++ b/compiler/testData/codegen/boxInline/enclosingInfo/kt52417.kt
@@ -1,0 +1,28 @@
+// TARGET_BACKEND: JVM
+// WITH_RUNTIME
+// WITH_STDLIB
+// FILE: 1.kt
+package test
+
+abstract class TypeToken<U>
+
+// Although V is not reified, if the object happens to be regenerated, V will be replaced with its value in signatures
+inline fun <V> typeTokenOf(crossinline forceRegeneration: () -> Unit = {}) =
+    object : TypeToken<V>() {
+        fun unused() = forceRegeneration()
+    }
+
+// FILE: 2.kt
+import test.*
+
+fun interface I {
+    fun foo(): String
+}
+
+fun <T> foo() =
+    I {
+        typeTokenOf<T>()::class.java.genericSuperclass.toString()
+    }.foo()
+
+fun box(): String =
+    foo<String>().let { if (it == "test.TypeToken<T>") "OK" else it }

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -44148,6 +44148,12 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
         }
 
         @Test
+        @TestMetadata("kt52417.kt")
+        public void testKt52417() throws Exception {
+            runTest("compiler/testData/codegen/box/sam/kt52417.kt");
+        }
+
+        @Test
         @TestMetadata("nonInlinedSamWrapper.kt")
         public void testNonInlinedSamWrapper() throws Exception {
             runTest("compiler/testData/codegen/box/sam/nonInlinedSamWrapper.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxInlineCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxInlineCodegenTestGenerated.java
@@ -2231,6 +2231,12 @@ public class BlackBoxInlineCodegenTestGenerated extends AbstractBlackBoxInlineCo
         }
 
         @Test
+        @TestMetadata("kt52417.kt")
+        public void testKt52417() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/enclosingInfo/kt52417.kt");
+        }
+
+        @Test
         @TestMetadata("objectInInlineFun.kt")
         public void testObjectInInlineFun() throws Exception {
             runTest("compiler/testData/codegen/boxInline/enclosingInfo/objectInInlineFun.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/CompileKotlinAgainstInlineKotlinTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/CompileKotlinAgainstInlineKotlinTestGenerated.java
@@ -2231,6 +2231,12 @@ public class CompileKotlinAgainstInlineKotlinTestGenerated extends AbstractCompi
         }
 
         @Test
+        @TestMetadata("kt52417.kt")
+        public void testKt52417() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/enclosingInfo/kt52417.kt");
+        }
+
+        @Test
         @TestMetadata("objectInInlineFun.kt")
         public void testObjectInInlineFun() throws Exception {
             runTest("compiler/testData/codegen/boxInline/enclosingInfo/objectInInlineFun.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -44706,6 +44706,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         }
 
         @Test
+        @TestMetadata("kt52417.kt")
+        public void testKt52417() throws Exception {
+            runTest("compiler/testData/codegen/box/sam/kt52417.kt");
+        }
+
+        @Test
         @TestMetadata("nonInlinedSamWrapper.kt")
         public void testNonInlinedSamWrapper() throws Exception {
             runTest("compiler/testData/codegen/box/sam/nonInlinedSamWrapper.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxInlineCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxInlineCodegenTestGenerated.java
@@ -2231,6 +2231,12 @@ public class IrBlackBoxInlineCodegenTestGenerated extends AbstractIrBlackBoxInli
         }
 
         @Test
+        @TestMetadata("kt52417.kt")
+        public void testKt52417() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/enclosingInfo/kt52417.kt");
+        }
+
+        @Test
         @TestMetadata("objectInInlineFun.kt")
         public void testObjectInInlineFun() throws Exception {
             runTest("compiler/testData/codegen/boxInline/enclosingInfo/objectInInlineFun.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrCompileKotlinAgainstInlineKotlinTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrCompileKotlinAgainstInlineKotlinTestGenerated.java
@@ -2231,6 +2231,12 @@ public class IrCompileKotlinAgainstInlineKotlinTestGenerated extends AbstractIrC
         }
 
         @Test
+        @TestMetadata("kt52417.kt")
+        public void testKt52417() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/enclosingInfo/kt52417.kt");
+        }
+
+        @Test
         @TestMetadata("objectInInlineFun.kt")
         public void testObjectInInlineFun() throws Exception {
             runTest("compiler/testData/codegen/boxInline/enclosingInfo/objectInInlineFun.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrSerializeCompileKotlinAgainstInlineKotlinTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrSerializeCompileKotlinAgainstInlineKotlinTestGenerated.java
@@ -2231,6 +2231,12 @@ public class IrSerializeCompileKotlinAgainstInlineKotlinTestGenerated extends Ab
         }
 
         @Test
+        @TestMetadata("kt52417.kt")
+        public void testKt52417() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/enclosingInfo/kt52417.kt");
+        }
+
+        @Test
         @TestMetadata("objectInInlineFun.kt")
         public void testObjectInInlineFun() throws Exception {
             runTest("compiler/testData/codegen/boxInline/enclosingInfo/objectInInlineFun.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/JvmIrAgainstOldBoxInlineTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/JvmIrAgainstOldBoxInlineTestGenerated.java
@@ -2231,6 +2231,12 @@ public class JvmIrAgainstOldBoxInlineTestGenerated extends AbstractJvmIrAgainstO
         }
 
         @Test
+        @TestMetadata("kt52417.kt")
+        public void testKt52417() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/enclosingInfo/kt52417.kt");
+        }
+
+        @Test
         @TestMetadata("objectInInlineFun.kt")
         public void testObjectInInlineFun() throws Exception {
             runTest("compiler/testData/codegen/boxInline/enclosingInfo/objectInInlineFun.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/JvmOldAgainstIrBoxInlineTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/JvmOldAgainstIrBoxInlineTestGenerated.java
@@ -2231,6 +2231,12 @@ public class JvmOldAgainstIrBoxInlineTestGenerated extends AbstractJvmOldAgainst
         }
 
         @Test
+        @TestMetadata("kt52417.kt")
+        public void testKt52417() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/enclosingInfo/kt52417.kt");
+        }
+
+        @Test
         @TestMetadata("objectInInlineFun.kt")
         public void testObjectInInlineFun() throws Exception {
             runTest("compiler/testData/codegen/boxInline/enclosingInfo/objectInInlineFun.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -35648,6 +35648,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/sam/kt50171.kt");
         }
 
+        @TestMetadata("kt52417.kt")
+        public void testKt52417() throws Exception {
+            runTest("compiler/testData/codegen/box/sam/kt52417.kt");
+        }
+
         @TestMetadata("nonInlinedSamWrapper.kt")
         public void testNonInlinedSamWrapper() throws Exception {
             runTest("compiler/testData/codegen/box/sam/nonInlinedSamWrapper.kt");


### PR DESCRIPTION
This is what Java 15+ does, and it permits accessing captured type parameters via reflection. The alternative is to emit generic signatures on the lambda methods, but that was disabled and I have no clue why.

^KT-52417 Fixed