### PR TITLE
Speed up checkStatisticsEnabled check

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/statistics/KotlinBuildStatsService.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/statistics/KotlinBuildStatsService.kt
@@ -149,7 +149,7 @@ internal abstract class KotlinBuildStatsService internal constructor() : BuildAd
             return if (File(gradle.gradleUserHomeDir, DISABLE_STATISTICS_FILE_NAME).exists()) {
                 false
             } else {
-                gradle.rootProject.properties[ENABLE_STATISTICS_PROPERTY_NAME]?.toString()?.toBoolean() ?: DEFAULT_STATISTICS_STATE
+                gradle.rootProject.findProperty(ENABLE_STATISTICS_PROPERTY_NAME)?.toString()?.toBoolean() ?: DEFAULT_STATISTICS_STATE
             }
         }
     }


### PR DESCRIPTION
Project.getProperties() can be very expensive on large projects, it is much better to call Project.findProperty(String) as that only retrieves that single property as opposed to returning all in a synchronized way.