### PR TITLE
convert KotlinCompilationNpmResolver already closed to a log error

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/resolver/KotlinCompilationNpmResolver.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/resolver/KotlinCompilationNpmResolver.kt
@@ -155,7 +155,10 @@ internal class KotlinCompilationNpmResolver(
 
     @Synchronized
     fun close(): KotlinCompilationNpmResolution? {
-        check(!closed) { "$this already closed" }
+        if (closed) { 
+            logger.error("$this already closed") 
+            return null
+        }
         val resolution = getResolutionOrResolveIfForced()
         closed = true
         return resolution


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-52646