### PR TITLE
JVM IR: Start fake variables for default lambdas after initialization

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/LambdaInfo.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/LambdaInfo.kt
@@ -140,12 +140,11 @@ class DefaultLambda(info: ExtractedDefaultLambda, sourceCompiler: SourceCompiler
         val withFakeVariable =
             MethodNode(originNode.access, originNode.name, originNode.desc, originNode.signature, originNode.exceptions?.toTypedArray())
         val fakeVarIndex = originNode.maxLocals
+        withFakeVariable.instructions.add(LdcInsnNode(0))
+        withFakeVariable.instructions.add(VarInsnNode(Opcodes.ISTORE, fakeVarIndex))
+        val startLabel = LabelNode().also { withFakeVariable.instructions.add(it) }
         originNode.accept(withFakeVariable)
-        val startLabel =
-            withFakeVariable.instructions.first as? LabelNode ?: LabelNode().apply { withFakeVariable.instructions.insert(this) }
         val endLabel = withFakeVariable.instructions.last as? LabelNode ?: LabelNode().apply { withFakeVariable.instructions.add(this) }
-        withFakeVariable.instructions.insert(startLabel, VarInsnNode(Opcodes.ISTORE, fakeVarIndex))
-        withFakeVariable.instructions.insert(startLabel, LdcInsnNode(0))
 
         withFakeVariable.localVariables.add(
             LocalVariableNode(

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -13736,6 +13736,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         }
 
         @Test
+        @TestMetadata("kt52702.kt")
+        public void testKt52702() throws Exception {
+            runTest("compiler/testData/codegen/box/defaultArguments/kt52702.kt");
+        }
+
+        @Test
         @TestMetadata("kt6382.kt")
         public void testKt6382() throws Exception {
             runTest("compiler/testData/codegen/box/defaultArguments/kt6382.kt");

--- a/compiler/testData/codegen/box/defaultArguments/kt52702.kt
+++ b/compiler/testData/codegen/box/defaultArguments/kt52702.kt
@@ -1,0 +1,24 @@
+// IGNORE_BACKEND: JS
+// Check that local variables for inline functions and inline default lambdas start
+// after they are initialized.
+
+inline fun spray() {
+    val a = Any()
+    val b = Any()
+    val c = Any()
+    val d = Any()
+    val e = Any()
+}
+
+inline fun f(block: () -> String = { "OK" }): String = block()
+
+fun box(): String {
+    // On the JVM, this call adds some locals with reference types to the LVT
+    // which end after the call returns.
+    spray()
+    // When inlining `f` we'll reuse the same slots that previously contained
+    // locals with reference types for the $i$f$f and $i$a$-f-... variables.
+    // Since these locals have integer types D8 would produce a warning if they
+    // started before being initialized, which would cause the test to fail.
+    return f()
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -13616,6 +13616,12 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
         }
 
         @Test
+        @TestMetadata("kt52702.kt")
+        public void testKt52702() throws Exception {
+            runTest("compiler/testData/codegen/box/defaultArguments/kt52702.kt");
+        }
+
+        @Test
         @TestMetadata("kt6382.kt")
         public void testKt6382() throws Exception {
             runTest("compiler/testData/codegen/box/defaultArguments/kt6382.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -13736,6 +13736,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         }
 
         @Test
+        @TestMetadata("kt52702.kt")
+        public void testKt52702() throws Exception {
+            runTest("compiler/testData/codegen/box/defaultArguments/kt52702.kt");
+        }
+
+        @Test
         @TestMetadata("kt6382.kt")
         public void testKt6382() throws Exception {
             runTest("compiler/testData/codegen/box/defaultArguments/kt6382.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -11063,6 +11063,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/defaultArguments/kt48391.kt");
         }
 
+        @TestMetadata("kt52702.kt")
+        public void testKt52702() throws Exception {
+            runTest("compiler/testData/codegen/box/defaultArguments/kt52702.kt");
+        }
+
         @TestMetadata("kt6382.kt")
         public void testKt6382() throws Exception {
             runTest("compiler/testData/codegen/box/defaultArguments/kt6382.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/JsCodegenBoxTestGenerated.java
@@ -10240,6 +10240,12 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
         }
 
         @Test
+        @TestMetadata("kt52702.kt")
+        public void testKt52702() throws Exception {
+            runTest("compiler/testData/codegen/box/defaultArguments/kt52702.kt");
+        }
+
+        @Test
         @TestMetadata("kt6382.kt")
         public void testKt6382() throws Exception {
             runTest("compiler/testData/codegen/box/defaultArguments/kt6382.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/IrJsCodegenBoxTestGenerated.java
@@ -10282,6 +10282,12 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
         }
 
         @Test
+        @TestMetadata("kt52702.kt")
+        public void testKt52702() throws Exception {
+            runTest("compiler/testData/codegen/box/defaultArguments/kt52702.kt");
+        }
+
+        @Test
         @TestMetadata("kt6382.kt")
         public void testKt6382() throws Exception {
             runTest("compiler/testData/codegen/box/defaultArguments/kt6382.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/testOld/wasm/semantics/IrCodegenBoxWasmTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/testOld/wasm/semantics/IrCodegenBoxWasmTestGenerated.java
@@ -9103,6 +9103,11 @@ public class IrCodegenBoxWasmTestGenerated extends AbstractIrCodegenBoxWasmTest 
             runTest("compiler/testData/codegen/box/defaultArguments/kt48391.kt");
         }
 
+        @TestMetadata("kt52702.kt")
+        public void testKt52702() throws Exception {
+            runTest("compiler/testData/codegen/box/defaultArguments/kt52702.kt");
+        }
+
         @TestMetadata("kt6382.kt")
         public void testKt6382() throws Exception {
             runTest("compiler/testData/codegen/box/defaultArguments/kt6382.kt");

--- a/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/NativeCodegenBoxTestGenerated.java
+++ b/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/NativeCodegenBoxTestGenerated.java
@@ -11228,6 +11228,12 @@ public class NativeCodegenBoxTestGenerated extends AbstractNativeCodegenBoxTest 
             }
 
             @Test
+            @TestMetadata("kt52702.kt")
+            public void testKt52702() throws Exception {
+                runTest("compiler/testData/codegen/box/defaultArguments/kt52702.kt");
+            }
+
+            @Test
             @TestMetadata("kt6382.kt")
             public void testKt6382() throws Exception {
                 runTest("compiler/testData/codegen/box/defaultArguments/kt6382.kt");


### PR DESCRIPTION
KT-52702