### PR TITLE
KT-52724 add timeout flag to dry-run and allow dry-run to be skipped altogether

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -18,6 +18,9 @@
     <MarkdownNavigatorCodeStyleSettings>
       <option name="RIGHT_MARGIN" value="72" />
     </MarkdownNavigatorCodeStyleSettings>
+    <ScalaCodeStyleSettings>
+      <option name="MULTILINE_STRING_CLOSING_QUOTES_ON_NEW_LINE" value="true" />
+    </ScalaCodeStyleSettings>
     <codeStyleSettings language="HTML">
       <indentOptions>
         <option name="INDENT_SIZE" value="2" />

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/mocha/KotlinMocha.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/mocha/KotlinMocha.kt
@@ -46,6 +46,8 @@ class KotlinMocha(@Transient override val compilation: KotlinJsCompilation, priv
     // https://mochajs.org/#-timeout-ms-t-ms
     var timeout: String = DEFAULT_TIMEOUT
 
+    var skipDryRun: Boolean = false
+
     private val platformType = compilation.platformType
 
     override fun createTestExecutionSpec(
@@ -94,7 +96,7 @@ class KotlinMocha(@Transient override val compilation: KotlinJsCompilation, priv
             }
         }
 
-        val dryRunArgs = if (platformType == KotlinPlatformType.wasm)
+        val dryRunArgs = if (skipDryRun || platformType == KotlinPlatformType.wasm)
             null
         else {
             mutableListOf(
@@ -104,6 +106,11 @@ class KotlinMocha(@Transient override val compilation: KotlinJsCompilation, priv
                 add(mocha)
                 add(createAdapterJs(file, "kotlin-test-nodejs-empty-runner", ADAPTER_EMPTY_NODEJS).canonicalPath)
                 addAll(cliArgs.toList())
+                if (debug) {
+                    add(NO_TIMEOUT_ARG)
+                } else {
+                    addAll(cliArg(TIMEOUT_ARG, timeout))
+                }
 
                 addAll(cliArg("-n", "experimental-wasm-typed-funcref,experimental-wasm-gc,experimental-wasm-eh"))
             }


### PR DESCRIPTION
Issue: https://youtrack.jetbrains.com/issue/KT-52724

* The `--timeout` flag is missing in the dry-run of the underlying mocha command
* Since dry-run actually runs all the tests (just without the reporter) it might be feasible to skip it altogether.