### PR TITLE
KT-50907 Update no-arg plugin to for jakarta persistence api namespace

### DIFF
--- a/plugins/noarg/noarg.common/src/org/jetbrains/kotlin/noarg/NoArgPluginNames.kt
+++ b/plugins/noarg/noarg.common/src/org/jetbrains/kotlin/noarg/NoArgPluginNames.kt
@@ -7,7 +7,8 @@ package org.jetbrains.kotlin.noarg
 
 object NoArgPluginNames {
     val SUPPORTED_PRESETS = mapOf(
-        "jpa" to listOf("javax.persistence.Entity", "javax.persistence.Embeddable", "javax.persistence.MappedSuperclass")
+        "jpa" to listOf("javax.persistence.Entity", "javax.persistence.Embeddable", "javax.persistence.MappedSuperclass",
+                        "jakarta.persistence.Entity", "jakarta.persistence.Embeddable", "jakarta.persistence.MappedSuperclass")
     )
 
     const val PLUGIN_ID = "org.jetbrains.kotlin.noarg"


### PR DESCRIPTION
This addresses https://youtrack.jetbrains.com/issue/KT-50907 issue

kotlin-jpa is wrapped on top of no-arg. The plugin specifies [@Entity](https://docs.oracle.com/javaee/7/api/javax/persistence/Entity.html), [@Embeddable](https://docs.oracle.com/javaee/7/api/javax/persistence/Embeddable.html), and [@MappedSuperclass](https://docs.oracle.com/javaee/7/api/javax/persistence/MappedSuperclass.html) no-arg annotations automatically.

But these annotations supported only for javax.persistence namespace. the plugin also needs to support jakarta.persistence namespace. It is preventing using kotlin for entity classes in JEE 9 environment