### PR TITLE
Add a key to enable spilling of all variables in a suspending context

### DIFF
--- a/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/arguments/K2JVMCompilerArguments.kt
+++ b/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/arguments/K2JVMCompilerArguments.kt
@@ -511,6 +511,13 @@ Also sets `-jvm-target` value equal to the selected JDK version"""
     )
     var linkViaSignatures: Boolean by FreezableVar(false)
 
+    @Argument(
+        value = "-Xdebug",
+        description = "Enable debug mode for compilation.\n" +
+                "Currently this includes spilling all variables in a suspending context regardless their liveness."
+    )
+    var enableDebugMode: Boolean by FreezableVar(false)
+
     override fun configureAnalysisFlags(collector: MessageCollector, languageVersion: LanguageVersion): MutableMap<AnalysisFlag<*>, Any> {
         val result = super.configureAnalysisFlags(collector, languageVersion)
         result[JvmAnalysisFlags.strictMetadataVersionSemantics] = strictMetadataVersionSemantics

--- a/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/jvmArguments.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/jvmArguments.kt
@@ -294,6 +294,8 @@ fun CompilerConfiguration.configureAdvancedJvmOptions(arguments: K2JVMCompilerAr
 
     put(JVMConfigurationKeys.LINK_VIA_SIGNATURES, arguments.linkViaSignatures)
 
+    put(JVMConfigurationKeys.ENABLE_DEBUG_MODE, arguments.enableDebugMode)
+
     val assertionsMode =
         JVMAssertionsMode.fromStringOrNull(arguments.assertionsMode)
     if (assertionsMode == null) {

--- a/compiler/config.jvm/src/org/jetbrains/kotlin/config/JVMConfigurationKeys.java
+++ b/compiler/config.jvm/src/org/jetbrains/kotlin/config/JVMConfigurationKeys.java
@@ -156,4 +156,7 @@ public class JVMConfigurationKeys {
 
     public static final CompilerConfigurationKey<Boolean> LINK_VIA_SIGNATURES =
             CompilerConfigurationKey.create("Link JVM IR symbols via signatures, instead of by descriptors");
+
+    public static final CompilerConfigurationKey<Boolean> ENABLE_DEBUG_MODE =
+            CompilerConfigurationKey.create("Enable debug mode");
 }

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -13221,6 +13221,64 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
                     runTest("compiler/testData/codegen/box/coroutines/varSpilling/cleanup/when.kt");
                 }
             }
+
+            @Nested
+            @TestMetadata("compiler/testData/codegen/box/coroutines/varSpilling/debugMode")
+            @TestDataPath("$PROJECT_ROOT")
+            public class DebugMode {
+                @Test
+                public void testAllFilesPresentInDebugMode() throws Exception {
+                    KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/coroutines/varSpilling/debugMode"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+                }
+
+                @Test
+                @TestMetadata("backEdge.kt")
+                public void testBackEdge() throws Exception {
+                    runTest("compiler/testData/codegen/box/coroutines/varSpilling/debugMode/backEdge.kt");
+                }
+
+                @Test
+                @TestMetadata("if.kt")
+                public void testIf() throws Exception {
+                    runTest("compiler/testData/codegen/box/coroutines/varSpilling/debugMode/if.kt");
+                }
+
+                @Test
+                @TestMetadata("nullCleanup.kt")
+                public void testNullCleanup() throws Exception {
+                    runTest("compiler/testData/codegen/box/coroutines/varSpilling/debugMode/nullCleanup.kt");
+                }
+
+                @Test
+                @TestMetadata("nullNotSpill.kt")
+                public void testNullNotSpill() throws Exception {
+                    runTest("compiler/testData/codegen/box/coroutines/varSpilling/debugMode/nullNotSpill.kt");
+                }
+
+                @Test
+                @TestMetadata("simple.kt")
+                public void testSimple() throws Exception {
+                    runTest("compiler/testData/codegen/box/coroutines/varSpilling/debugMode/simple.kt");
+                }
+
+                @Test
+                @TestMetadata("twoRefs.kt")
+                public void testTwoRefs() throws Exception {
+                    runTest("compiler/testData/codegen/box/coroutines/varSpilling/debugMode/twoRefs.kt");
+                }
+
+                @Test
+                @TestMetadata("unusedParamNotSpill.kt")
+                public void testUnusedParamNotSpill() throws Exception {
+                    runTest("compiler/testData/codegen/box/coroutines/varSpilling/debugMode/unusedParamNotSpill.kt");
+                }
+
+                @Test
+                @TestMetadata("when.kt")
+                public void testWhen() throws Exception {
+                    runTest("compiler/testData/codegen/box/coroutines/varSpilling/debugMode/when.kt");
+                }
+            }
         }
     }
 

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/CoroutineCodegen.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/CoroutineCodegen.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.backend.jvm.unboxInlineClass
 import org.jetbrains.kotlin.codegen.ClassBuilder
 import org.jetbrains.kotlin.codegen.coroutines.CoroutineTransformerMethodVisitor
 import org.jetbrains.kotlin.codegen.coroutines.reportSuspensionPointInsideMonitor
+import org.jetbrains.kotlin.config.JVMConfigurationKeys
 import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.expressions.IrBlockBody
@@ -36,13 +37,14 @@ internal fun MethodNode.acceptWithStateMachine(
     varsCountByType: Map<Type, Int>,
     obtainContinuationClassBuilder: () -> ClassBuilder,
 ) {
-    val state = classCodegen.context.state
+    val context = classCodegen.context
+    val state = context.state
     val languageVersionSettings = state.languageVersionSettings
     assert(languageVersionSettings.supportsFeature(LanguageFeature.ReleaseCoroutines)) { "Experimental coroutines are unsupported in JVM_IR backend" }
     val element = if (irFunction.isSuspend)
         irFunction.psiElement ?: classCodegen.irClass.psiElement
     else
-        classCodegen.context.suspendLambdaToOriginalFunctionMap[classCodegen.irClass.attributeOwnerId]!!.psiElement
+        context.suspendLambdaToOriginalFunctionMap[classCodegen.irClass.attributeOwnerId]!!.psiElement
 
     val lineNumber = if (irFunction.isSuspend) {
         val irFile = irFunction.file
@@ -74,6 +76,7 @@ internal fun MethodNode.acceptWithStateMachine(
         internalNameForDispatchReceiver = classCodegen.type.internalName,
         putContinuationParameterToLvt = false,
         initialVarsCountByType = varsCountByType,
+        shouldOptimiseUnusedVariables = !context.configuration.getBoolean(JVMConfigurationKeys.ENABLE_DEBUG_MODE)
     )
     accept(visitor)
 }

--- a/compiler/testData/cli/jvm/extraHelp.out
+++ b/compiler/testData/cli/jvm/extraHelp.out
@@ -28,6 +28,8 @@ where advanced options include:
   -Xir-do-not-clear-binding-context
                              When using the IR backend, do not clear BindingContext between psi2ir and lowerings
   -Xemit-jvm-type-annotations Emit JVM type annotations in bytecode
+  -Xdebug                    Enable debug mode for compilation.
+                             Currently this includes spilling all variables in a suspending context regardless their liveness.
   -Xjvm-enable-preview       Allow using features from Java language that are in preview phase.
                              Works as `--enable-preview` in Java. All class files are marked as preview-generated thus it won't be possible to use them in release environment
   -Xenhance-type-parameter-types-to-def-not-null

--- a/compiler/testData/codegen/box/coroutines/varSpilling/debugMode/backEdge.kt
+++ b/compiler/testData/codegen/box/coroutines/varSpilling/debugMode/backEdge.kt
@@ -1,0 +1,57 @@
+// WITH_STDLIB
+// FULL_JDK
+// TARGET_BACKEND: JVM_IR
+// IGNORE_BACKEND: JVM
+import kotlin.coroutines.*
+import kotlin.coroutines.intrinsics.*
+
+fun blackhole(vararg a: Any?) {}
+
+val spilledVariables = mutableSetOf<Pair<String, String>>()
+
+var c: Continuation<Unit>? = null
+
+suspend fun saveSpilledVariables() = suspendCoroutineUninterceptedOrReturn<Unit> { continuation ->
+    spilledVariables.clear()
+    for (field in continuation.javaClass.declaredFields) {
+        if (field.name != "label" && (field.name.length != 3 || field.name[1] != '$')) continue
+        field.isAccessible = true
+        spilledVariables += field.name to "${field.get(continuation)}"
+    }
+    c = continuation
+    COROUTINE_SUSPENDED
+}
+
+suspend fun test() {
+    for (i in 0..1) {
+        saveSpilledVariables()
+        val a = "a"
+        saveSpilledVariables()
+        blackhole(a)
+    }
+}
+
+fun builder(c: suspend () -> Unit) {
+    c.startCoroutine(Continuation(EmptyCoroutineContext) {
+        it.getOrThrow()
+    })
+}
+
+fun box(): String {
+    builder {
+        test()
+    }
+
+    val continuationName = "Continuation at BackEdgeKt\$box\$1.invokeSuspend(backEdge.kt:42)"
+    if (spilledVariables != setOf("label" to "1", "I$0" to "0", "L$0" to continuationName, "L$1" to "null")) return "FAIL 1: $spilledVariables"
+    c?.resume(Unit)
+    if (spilledVariables != setOf("label" to "2", "I$0" to "0", "L$0" to continuationName, "L$1" to "a")) return "FAIL 2: $spilledVariables"
+    c?.resume(Unit)
+    if (spilledVariables != setOf("label" to "1", "I$0" to "1", "L$0" to continuationName, "L$1" to "a")) return "FAIL 3: $spilledVariables"
+    c?.resume(Unit)
+    if (spilledVariables != setOf("label" to "2", "I$0" to "1", "L$0" to continuationName, "L$1" to "a")) return "FAIL 4: $spilledVariables"
+    c?.resume(Unit)
+    if (spilledVariables != setOf("label" to "2", "I$0" to "1", "L$0" to continuationName, "L$1" to "a")) return "FAIL 5: $spilledVariables"
+
+    return "OK"
+}

--- a/compiler/testData/codegen/box/coroutines/varSpilling/debugMode/if.kt
+++ b/compiler/testData/codegen/box/coroutines/varSpilling/debugMode/if.kt
@@ -1,0 +1,76 @@
+// WITH_STDLIB
+// FULL_JDK
+// TARGET_BACKEND: JVM_IR
+// IGNORE_BACKEND: JVM
+import kotlin.coroutines.*
+import kotlin.coroutines.intrinsics.*
+
+fun blackhole(vararg a: Any?) {}
+
+val spilledVariables = mutableSetOf<Pair<String, String>>()
+
+var c: Continuation<Unit>? = null
+
+suspend fun saveSpilledVariables() = suspendCoroutineUninterceptedOrReturn<Unit> { continuation ->
+    spilledVariables.clear()
+    for (field in continuation.javaClass.declaredFields) {
+        if (field.name != "label" && (field.name.length != 3 || field.name[1] != '$')) continue
+        field.isAccessible = true
+        val fieldValue = when (val obj = field.get(continuation)) {
+            is Array<*> -> obj.joinToString(prefix = "[", postfix = "]")
+            else -> obj
+        }
+        spilledVariables += field.name to "$fieldValue"
+    }
+    c = continuation
+    COROUTINE_SUSPENDED
+}
+
+suspend fun test(check: Boolean) {
+    if (check) {
+        val a = "a1"
+        saveSpilledVariables()
+        blackhole(a)
+    } else {
+        val a = "a2"
+        val b = "b2"
+        saveSpilledVariables()
+        blackhole(a, b)
+    }
+    saveSpilledVariables()
+}
+
+fun builder(c: suspend () -> Unit) {
+    c.startCoroutine(Continuation(EmptyCoroutineContext) {
+        it.getOrThrow()
+    })
+}
+
+fun box(): String {
+    builder {
+        test(true)
+    }
+
+    var continuationName = "Continuation at IfKt\$box\$1.invokeSuspend(if.kt:51)"
+    if (spilledVariables != setOf("label" to "1", "Z$0" to "true", "L$0" to continuationName, "L$1" to "a1", "L$2" to "null"))
+        return "FAIL 1: $spilledVariables"
+    c?.resume(Unit)
+    if (spilledVariables != setOf("label" to "3", "Z$0" to "true", "L$0" to continuationName, "L$1" to "a1", "L$2" to "[a1]"))
+        return "FAIL 2: $spilledVariables"
+    c?.resume(Unit)
+    if (spilledVariables != setOf("label" to "3", "Z$0" to "true", "L$0" to continuationName, "L$1" to "a1", "L$2" to "[a1]"))
+        return "FAIL 3: $spilledVariables"
+
+    builder {
+        test(false)
+    }
+
+    continuationName = "Continuation at IfKt\$box\$2.invokeSuspend(if.kt:65)"
+    if (spilledVariables != setOf("label" to "2", "Z$0" to "false", "L$0" to continuationName, "L$1" to "a2", "L$2" to "b2")) return "FAIL 4: $spilledVariables"
+    c?.resume(Unit)
+    if (spilledVariables != setOf("label" to "3", "Z$0" to "false", "L$0" to continuationName, "L$1" to "a2", "L$2" to "b2")) return "FAIL 5: $spilledVariables"
+    c?.resume(Unit)
+    if (spilledVariables != setOf("label" to "3", "Z$0" to "false", "L$0" to continuationName, "L$1" to "a2", "L$2" to "b2")) return "FAIL 6: $spilledVariables"
+
+    return "OK"
+}

--- a/compiler/testData/codegen/box/coroutines/varSpilling/debugMode/nullCleanup.kt
+++ b/compiler/testData/codegen/box/coroutines/varSpilling/debugMode/nullCleanup.kt
@@ -1,0 +1,57 @@
+// WITH_STDLIB
+// FULL_JDK
+// TARGET_BACKEND: JVM_IR
+// IGNORE_BACKEND: JVM
+import kotlin.coroutines.*
+import kotlin.coroutines.intrinsics.*
+
+fun blackhole(vararg a: Any?) {}
+
+val spilledVariables = mutableSetOf<Pair<String, String>>()
+
+var c: Continuation<Unit>? = null
+
+suspend fun saveSpilledVariables() = suspendCoroutineUninterceptedOrReturn<Unit> { continuation ->
+    spilledVariables.clear()
+    for (field in continuation.javaClass.declaredFields) {
+        if (field.name != "label" && (field.name.length != 3 || field.name[1] != '$')) continue
+        field.isAccessible = true
+        val fieldValue = when (val obj = field.get(continuation)) {
+            is Array<*> -> obj.joinToString(prefix = "[", postfix = "]")
+            else -> obj
+        }
+        spilledVariables += field.name to "$fieldValue"
+    }
+    c = continuation
+    COROUTINE_SUSPENDED
+}
+
+suspend fun test() {
+    var a: String? = "a"
+    saveSpilledVariables()
+    blackhole(a)
+    a = null
+    saveSpilledVariables()
+    blackhole(a)
+}
+
+fun builder(c: suspend () -> Unit) {
+    c.startCoroutine(Continuation(EmptyCoroutineContext) {
+        it.getOrThrow()
+    })
+}
+
+fun box(): String {
+    builder {
+        test()
+    }
+
+    val continuationName = "Continuation at NullCleanupKt\$box\$1.invokeSuspend(nullCleanup.kt:46)"
+    if (spilledVariables != setOf("label" to "1", "L$0" to continuationName, "L$1" to "a")) return "FAIL 1: $spilledVariables"
+    c?.resume(Unit)
+    if (spilledVariables != setOf("label" to "2", "L$0" to continuationName, "L$1" to "[a]")) return "FAIL 2: $spilledVariables"
+    c?.resume(Unit)
+    if (spilledVariables != setOf("label" to "2", "L$0" to continuationName, "L$1" to "[a]")) return "FAIL 3: $spilledVariables"
+
+    return "OK"
+}

--- a/compiler/testData/codegen/box/coroutines/varSpilling/debugMode/nullNotSpill.kt
+++ b/compiler/testData/codegen/box/coroutines/varSpilling/debugMode/nullNotSpill.kt
@@ -1,0 +1,55 @@
+// WITH_STDLIB
+// FULL_JDK
+// TARGET_BACKEND: JVM_IR
+// IGNORE_BACKEND: JVM
+import kotlin.coroutines.*
+import kotlin.coroutines.intrinsics.*
+
+fun blackhole(vararg a: Any?) {}
+
+val spilledVariables = mutableSetOf<Pair<String, String>>()
+
+var c: Continuation<Unit>? = null
+
+suspend fun saveSpilledVariables() = suspendCoroutineUninterceptedOrReturn<Unit> { continuation ->
+    spilledVariables.clear()
+    for (field in continuation.javaClass.declaredFields) {
+        if (field.name != "label" && (field.name.length != 3 || field.name[1] != '$')) continue
+        field.isAccessible = true
+        val fieldValue = when (val obj = field.get(continuation)) {
+            is Array<*> -> obj.joinToString(prefix = "[", postfix = "]")
+            else -> obj
+        }
+        spilledVariables += field.name to "$fieldValue"
+    }
+    c = continuation
+    COROUTINE_SUSPENDED
+}
+
+suspend fun test() {
+    val a = null
+    saveSpilledVariables()
+    blackhole(a)
+    saveSpilledVariables()
+}
+
+fun builder(c: suspend () -> Unit) {
+    c.startCoroutine(Continuation(EmptyCoroutineContext) {
+        it.getOrThrow()
+    })
+}
+
+fun box(): String {
+    builder {
+        test()
+    }
+
+    val continuationName = "Continuation at NullNotSpillKt\$box\$1.invokeSuspend(nullNotSpill.kt:44)"
+    if (spilledVariables != setOf("label" to "1", "L$0" to continuationName, "L$1" to "null")) return "FAIL 1: $spilledVariables"
+    c?.resume(Unit)
+    if (spilledVariables != setOf("label" to "2", "L$0" to continuationName, "L$1" to "[null]")) return "FAIL 2: $spilledVariables"
+    c?.resume(Unit)
+    if (spilledVariables != setOf("label" to "2", "L$0" to continuationName, "L$1" to "[null]")) return "FAIL 3: $spilledVariables"
+
+    return "OK"
+}

--- a/compiler/testData/codegen/box/coroutines/varSpilling/debugMode/simple.kt
+++ b/compiler/testData/codegen/box/coroutines/varSpilling/debugMode/simple.kt
@@ -1,0 +1,59 @@
+// WITH_STDLIB
+// FULL_JDK
+// TARGET_BACKEND: JVM_IR
+// IGNORE_BACKEND: JVM
+import kotlin.coroutines.*
+import kotlin.coroutines.intrinsics.*
+
+fun blackhole(vararg a: Any?) {}
+
+val spilledVariables = mutableSetOf<Pair<String, String>>()
+
+var c: Continuation<Unit>? = null
+
+suspend fun saveSpilledVariables() = suspendCoroutineUninterceptedOrReturn<Unit> { continuation ->
+    spilledVariables.clear()
+    for (field in continuation.javaClass.declaredFields) {
+        if (field.name != "label" && (field.name.length != 3 || field.name[1] != '$')) continue
+        field.isAccessible = true
+        val fieldValue = when (val obj = field.get(continuation)) {
+            is Array<*> -> obj.joinToString(prefix = "[", postfix = "]")
+            else -> obj
+        }
+        spilledVariables += field.name to "$fieldValue"
+    }
+    c = continuation
+    COROUTINE_SUSPENDED
+}
+
+suspend fun test() {
+    val a = "a"
+    saveSpilledVariables()
+    blackhole(a)
+    saveSpilledVariables()
+}
+
+fun builder(c: suspend () -> Unit) {
+    c.startCoroutine(Continuation(EmptyCoroutineContext) {
+        it.getOrThrow()
+    })
+}
+
+fun box(): String {
+    builder {
+        test()
+    }
+
+    val continuationName = "Continuation at SimpleKt\$box\$1.invokeSuspend(simple.kt:44)"
+    if (spilledVariables != setOf("label" to "1", "L$0" to continuationName, "L$1" to "a", "L$2" to "null")) return "FAIL 1: $spilledVariables"
+    c?.resume(Unit)
+    if (spilledVariables != setOf("label" to "2", "L$0" to continuationName, "L$1" to "a", "L$2" to "[a]")) return "FAIL 2: $spilledVariables"
+    c?.resume(Unit)
+    if (spilledVariables != setOf("label" to "2", "L$0" to continuationName, "L$1" to "a", "L$2" to "[a]")) return "FAIL 3: $spilledVariables"
+
+    return "OK"
+}
+
+fun main() {
+    println(box())
+}

--- a/compiler/testData/codegen/box/coroutines/varSpilling/debugMode/twoRefs.kt
+++ b/compiler/testData/codegen/box/coroutines/varSpilling/debugMode/twoRefs.kt
@@ -1,0 +1,62 @@
+// WITH_STDLIB
+// FULL_JDK
+// TARGET_BACKEND: JVM_IR
+// IGNORE_BACKEND: JVM
+import kotlin.coroutines.*
+import kotlin.coroutines.intrinsics.*
+
+fun blackhole(vararg a: Any?) {}
+
+val spilledVariables = mutableSetOf<Pair<String, String>>()
+
+var c: Continuation<Unit>? = null
+
+suspend fun saveSpilledVariables() = suspendCoroutineUninterceptedOrReturn<Unit> { continuation ->
+    spilledVariables.clear()
+    for (field in continuation.javaClass.declaredFields) {
+        if (field.name != "label" && (field.name.length != 3 || field.name[1] != '$')) continue
+        field.isAccessible = true
+        val fieldValue = when (val obj = field.get(continuation)) {
+            is Array<*> -> obj.joinToString(prefix = "[", postfix = "]")
+            else -> obj
+        }
+        spilledVariables += field.name to "$fieldValue"
+    }
+    c = continuation
+    COROUTINE_SUSPENDED
+}
+
+suspend fun test(a: String, b: String) {
+    saveSpilledVariables()
+    blackhole(a)
+    saveSpilledVariables()
+    blackhole(b)
+    saveSpilledVariables()
+}
+
+fun builder(c: suspend () -> Unit) {
+    c.startCoroutine(Continuation(EmptyCoroutineContext) {
+        it.getOrThrow()
+    })
+}
+
+fun box(): String {
+    builder {
+        test("a", "b")
+    }
+
+    val continuationName = "Continuation at TwoRefsKt\$box\$1.invokeSuspend(twoRefs.kt:45)"
+    if (spilledVariables != setOf("label" to "1", "L$0" to "a", "L$1" to "b", "L$2" to continuationName, "L$3" to "null")) return "FAIL 1: $spilledVariables"
+    c?.resume(Unit)
+    if (spilledVariables != setOf("label" to "2", "L$0" to "a", "L$1" to "b", "L$2" to continuationName, "L$3" to "[a]")) return "FAIL 2: $spilledVariables"
+    c?.resume(Unit)
+    if (spilledVariables != setOf("label" to "3", "L$0" to "a", "L$1" to "b", "L$2" to continuationName, "L$3" to "[b]")) return "FAIL 3: $spilledVariables"
+    c?.resume(Unit)
+    if (spilledVariables != setOf("label" to "3", "L$0" to "a", "L$1" to "b", "L$2" to continuationName, "L$3" to "[b]")) return "FAIL 4: $spilledVariables"
+
+    return "OK"
+}
+
+fun main() {
+    println(box())
+}

--- a/compiler/testData/codegen/box/coroutines/varSpilling/debugMode/unusedParamNotSpill.kt
+++ b/compiler/testData/codegen/box/coroutines/varSpilling/debugMode/unusedParamNotSpill.kt
@@ -1,0 +1,44 @@
+// WITH_STDLIB
+// FULL_JDK
+// TARGET_BACKEND: JVM_IR
+import kotlin.coroutines.*
+import kotlin.coroutines.intrinsics.*
+
+fun blackhole(vararg a: Any?) {}
+
+val spilledVariables = mutableSetOf<Pair<String, String>>()
+
+var c: Continuation<Unit>? = null
+
+suspend fun saveSpilledVariables() = suspendCoroutineUninterceptedOrReturn<Unit> { continuation ->
+    spilledVariables.clear()
+    for (field in continuation.javaClass.declaredFields) {
+        if (field.name != "label" && (field.name.length != 3 || field.name[1] != '$')) continue
+        field.isAccessible = true
+        spilledVariables += field.name to "${field.get(continuation)}"
+    }
+    c = continuation
+    COROUTINE_SUSPENDED
+}
+
+val test: suspend (Int) -> Unit = { unused ->
+    saveSpilledVariables()
+}
+
+fun builder(c: suspend () -> Unit) {
+    c.startCoroutine(Continuation(EmptyCoroutineContext) {
+        it.getOrThrow()
+    })
+}
+
+fun box(): String {
+    builder {
+        test(1)
+    }
+
+    if (spilledVariables != setOf("label" to "1")) return "FAIL 1: $spilledVariables"
+    c?.resume(Unit)
+    if (spilledVariables != setOf("label" to "1")) return "FAIL 2: $spilledVariables"
+
+    return "OK"
+}

--- a/compiler/testData/codegen/box/coroutines/varSpilling/debugMode/when.kt
+++ b/compiler/testData/codegen/box/coroutines/varSpilling/debugMode/when.kt
@@ -1,0 +1,103 @@
+// WITH_STDLIB
+// FULL_JDK
+// TARGET_BACKEND: JVM_IR
+// IGNORE_BACKEND: JVM
+import kotlin.coroutines.*
+import kotlin.coroutines.intrinsics.*
+
+fun blackhole(vararg a: Any?) {}
+
+val spilledVariables = mutableSetOf<Pair<String, String>>()
+
+var c: Continuation<Unit>? = null
+
+suspend fun saveSpilledVariables() = suspendCoroutineUninterceptedOrReturn<Unit> { continuation ->
+    spilledVariables.clear()
+    for (field in continuation.javaClass.declaredFields) {
+        if (field.name != "label" && (field.name.length != 3 || field.name[1] != '$')) continue
+        field.isAccessible = true
+        val fieldValue = when (val obj = field.get(continuation)) {
+            is Array<*> -> obj.joinToString(prefix = "[", postfix = "]")
+            else -> obj
+        }
+        spilledVariables += field.name to "$fieldValue"
+    }
+    c = continuation
+    COROUTINE_SUSPENDED
+}
+
+suspend fun test(check: Int) {
+    when (check) {
+        0 -> {
+            val a = "a0"
+            saveSpilledVariables()
+            blackhole(a)
+        }
+        1 -> {
+            val a = "a1"
+            val b = "b1"
+            saveSpilledVariables()
+            blackhole(a, b)
+        }
+        else -> {
+            val a = "a2"
+            val b = "b2"
+            val c = 1
+            saveSpilledVariables()
+            blackhole(a, b, c)
+        }
+    }
+    saveSpilledVariables()
+}
+
+fun builder(c: suspend () -> Unit) {
+    c.startCoroutine(Continuation(EmptyCoroutineContext) {
+        it.getOrThrow()
+    })
+}
+
+fun box(): String {
+    builder {
+        test(0)
+    }
+
+    var continuationName = "Continuation at WhenKt\$box\$1.invokeSuspend(when.kt:61)"
+    if (spilledVariables != setOf("label" to "1", "I$0" to "0", "I$1" to "0", "I$2" to "0", "L$0" to continuationName, "L$1" to "a0", "L$2" to "null"))
+        return "FAIL 1: $spilledVariables"
+    c?.resume(Unit)
+    if (spilledVariables != setOf("label" to "4", "I$0" to "0", "I$1" to "0", "I$2" to "0", "L$0" to continuationName, "L$1" to "a0", "L$2" to "[a0]"))
+        return "FAIL 2: $spilledVariables"
+    c?.resume(Unit)
+    if (spilledVariables != setOf("label" to "4", "I$0" to "0", "I$1" to "0", "I$2" to "0", "L$0" to continuationName, "L$1" to "a0", "L$2" to "[a0]"))
+        return "FAIL 3: $spilledVariables"
+
+    builder {
+        test(1)
+    }
+
+    continuationName = "Continuation at WhenKt\$box\$2.invokeSuspend(when.kt:75)"
+    if (spilledVariables != setOf("label" to "2", "I$0" to "1", "I$1" to "1", "I$2" to "0", "L$0" to continuationName, "L$1" to "a1", "L$2" to "b1"))
+        return "FAIL 4: $spilledVariables"
+    c?.resume(Unit)
+    if (spilledVariables != setOf("label" to "4", "I$0" to "1", "I$1" to "1", "I$2" to "0", "L$0" to continuationName, "L$1" to "a1", "L$2" to "b1"))
+        return "FAIL 5: $spilledVariables"
+    c?.resume(Unit)
+    if (spilledVariables != setOf("label" to "4", "I$0" to "1", "I$1" to "1", "I$2" to "0", "L$0" to continuationName, "L$1" to "a1", "L$2" to "b1"))
+        return "FAIL 6: $spilledVariables"
+
+    builder {
+        test(2)
+    }
+
+    continuationName = "Continuation at WhenKt\$box\$3.invokeSuspend(when.kt:89)"
+    if (spilledVariables != setOf("label" to "3", "I$0" to "2", "I$1" to "2", "I$2" to "1", "L$0" to continuationName, "L$1" to "a2", "L$2" to "b2"))
+        return "FAIL 7: $spilledVariables"
+    c?.resume(Unit)
+    if (spilledVariables != setOf("label" to "4", "I$0" to "2", "I$1" to "2", "I$2" to "1", "L$0" to continuationName, "L$1" to "a2", "L$2" to "b2"))
+        return "FAIL 8: $spilledVariables"
+    c?.resume(Unit)
+    if (spilledVariables != setOf("label" to "4", "I$0" to "2", "I$1" to "2", "I$2" to "1", "L$0" to continuationName, "L$1" to "a2", "L$2" to "b2"))
+        return "FAIL 9: $spilledVariables"
+
+    return "OK"
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -13101,6 +13101,16 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
                     runTest("compiler/testData/codegen/box/coroutines/varSpilling/cleanup/when.kt");
                 }
             }
+
+            @Nested
+            @TestMetadata("compiler/testData/codegen/box/coroutines/varSpilling/debugMode")
+            @TestDataPath("$PROJECT_ROOT")
+            public class DebugMode {
+                @Test
+                public void testAllFilesPresentInDebugMode() throws Exception {
+                    KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/coroutines/varSpilling/debugMode"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM, true);
+                }
+            }
         }
     }
 

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -13221,6 +13221,64 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
                     runTest("compiler/testData/codegen/box/coroutines/varSpilling/cleanup/when.kt");
                 }
             }
+
+            @Nested
+            @TestMetadata("compiler/testData/codegen/box/coroutines/varSpilling/debugMode")
+            @TestDataPath("$PROJECT_ROOT")
+            public class DebugMode {
+                @Test
+                public void testAllFilesPresentInDebugMode() throws Exception {
+                    KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/coroutines/varSpilling/debugMode"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+                }
+
+                @Test
+                @TestMetadata("backEdge.kt")
+                public void testBackEdge() throws Exception {
+                    runTest("compiler/testData/codegen/box/coroutines/varSpilling/debugMode/backEdge.kt");
+                }
+
+                @Test
+                @TestMetadata("if.kt")
+                public void testIf() throws Exception {
+                    runTest("compiler/testData/codegen/box/coroutines/varSpilling/debugMode/if.kt");
+                }
+
+                @Test
+                @TestMetadata("nullCleanup.kt")
+                public void testNullCleanup() throws Exception {
+                    runTest("compiler/testData/codegen/box/coroutines/varSpilling/debugMode/nullCleanup.kt");
+                }
+
+                @Test
+                @TestMetadata("nullNotSpill.kt")
+                public void testNullNotSpill() throws Exception {
+                    runTest("compiler/testData/codegen/box/coroutines/varSpilling/debugMode/nullNotSpill.kt");
+                }
+
+                @Test
+                @TestMetadata("simple.kt")
+                public void testSimple() throws Exception {
+                    runTest("compiler/testData/codegen/box/coroutines/varSpilling/debugMode/simple.kt");
+                }
+
+                @Test
+                @TestMetadata("twoRefs.kt")
+                public void testTwoRefs() throws Exception {
+                    runTest("compiler/testData/codegen/box/coroutines/varSpilling/debugMode/twoRefs.kt");
+                }
+
+                @Test
+                @TestMetadata("unusedParamNotSpill.kt")
+                public void testUnusedParamNotSpill() throws Exception {
+                    runTest("compiler/testData/codegen/box/coroutines/varSpilling/debugMode/unusedParamNotSpill.kt");
+                }
+
+                @Test
+                @TestMetadata("when.kt")
+                public void testWhen() throws Exception {
+                    runTest("compiler/testData/codegen/box/coroutines/varSpilling/debugMode/when.kt");
+                }
+            }
         }
     }
 

--- a/compiler/tests-common-new/tests/org/jetbrains/kotlin/test/directives/JvmEnvironmentConfigurationDirectives.kt
+++ b/compiler/tests-common-new/tests/org/jetbrains/kotlin/test/directives/JvmEnvironmentConfigurationDirectives.kt
@@ -77,4 +77,6 @@ object JvmEnvironmentConfigurationDirectives : SimpleDirectivesContainer() {
         description = "Enable serialization of JVM IR",
         additionalParser = JvmSerializeIrMode.Companion::fromString
     )
+
+    val ENABLE_DEBUG_MODE by directive("Enable debug mode for compilation")
 }

--- a/compiler/tests-common-new/tests/org/jetbrains/kotlin/test/runners/codegen/AbstractJvmBlackBoxCodegenTestBase.kt
+++ b/compiler/tests-common-new/tests/org/jetbrains/kotlin/test/runners/codegen/AbstractJvmBlackBoxCodegenTestBase.kt
@@ -24,6 +24,7 @@ import org.jetbrains.kotlin.test.directives.CodegenTestDirectives.USE_JAVAC_BASE
 import org.jetbrains.kotlin.test.directives.JvmEnvironmentConfigurationDirectives.JDK_KIND
 import org.jetbrains.kotlin.test.directives.JvmEnvironmentConfigurationDirectives.JVM_TARGET
 import org.jetbrains.kotlin.test.directives.ConfigurationDirectives.WITH_STDLIB
+import org.jetbrains.kotlin.test.directives.JvmEnvironmentConfigurationDirectives.ENABLE_DEBUG_MODE
 import org.jetbrains.kotlin.test.frontend.classic.handlers.ClassicDiagnosticsHandler
 import org.jetbrains.kotlin.test.frontend.fir.handlers.FirDiagnosticsHandler
 import org.jetbrains.kotlin.test.model.*
@@ -79,6 +80,12 @@ abstract class AbstractJvmBlackBoxCodegenTestBase<R : ResultingArtifact.Frontend
 
         forTestsMatching("compiler/testData/codegen/boxModernJdk/testsWithJava17/*") {
             configureModernJavaTest(TestJdkKind.FULL_JDK_17, JvmTarget.JVM_17)
+        }
+
+        forTestsMatching("compiler/testData/codegen/box/coroutines/varSpilling/debugMode/*") {
+            defaultDirectives {
+                +ENABLE_DEBUG_MODE
+            }
         }
 
         enableMetaInfoHandler()

--- a/compiler/tests-common-new/tests/org/jetbrains/kotlin/test/services/configuration/JvmEnvironmentConfigurator.kt
+++ b/compiler/tests-common-new/tests/org/jetbrains/kotlin/test/services/configuration/JvmEnvironmentConfigurator.kt
@@ -39,6 +39,7 @@ import org.jetbrains.kotlin.test.directives.JvmEnvironmentConfigurationDirective
 import org.jetbrains.kotlin.test.directives.JvmEnvironmentConfigurationDirectives.SERIALIZE_IR
 import org.jetbrains.kotlin.test.directives.JvmEnvironmentConfigurationDirectives.STRING_CONCAT
 import org.jetbrains.kotlin.test.directives.JvmEnvironmentConfigurationDirectives.USE_OLD_INLINE_CLASSES_MANGLING_SCHEME
+import org.jetbrains.kotlin.test.directives.JvmEnvironmentConfigurationDirectives.ENABLE_DEBUG_MODE
 import org.jetbrains.kotlin.test.directives.LanguageSettingsDirectives
 import org.jetbrains.kotlin.test.directives.LanguageSettingsDirectives.DISABLE_CALL_ASSERTIONS
 import org.jetbrains.kotlin.test.directives.LanguageSettingsDirectives.DISABLE_PARAM_ASSERTIONS
@@ -174,6 +175,7 @@ class JvmEnvironmentConfigurator(testServices: TestServices) : EnvironmentConfig
         register(SERIALIZE_IR, JVMConfigurationKeys.SERIALIZE_IR)
         register(JDK_RELEASE, JVMConfigurationKeys.JDK_RELEASE)
         register(USE_TYPE_TABLE, JVMConfigurationKeys.USE_TYPE_TABLE)
+        register(ENABLE_DEBUG_MODE, JVMConfigurationKeys.ENABLE_DEBUG_MODE)
     }
 
     @OptIn(ExperimentalPathApi::class, ExperimentalStdlibApi::class)

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -10592,6 +10592,19 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
                     runTest("compiler/testData/codegen/box/coroutines/varSpilling/cleanup/when.kt");
                 }
             }
+
+            @TestMetadata("compiler/testData/codegen/box/coroutines/varSpilling/debugMode")
+            @TestDataPath("$PROJECT_ROOT")
+            @RunWith(JUnit3RunnerWithInners.class)
+            public static class DebugMode extends AbstractLightAnalysisModeTest {
+                private void runTest(String testDataFilePath) throws Exception {
+                    KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM, testDataFilePath);
+                }
+
+                public void testAllFilesPresentInDebugMode() throws Exception {
+                    KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/coroutines/varSpilling/debugMode"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM, true);
+                }
+            }
         }
     }
 

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/JsCodegenBoxTestGenerated.java
@@ -9725,6 +9725,16 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
                     KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/coroutines/varSpilling/cleanup"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS, true);
                 }
             }
+
+            @Nested
+            @TestMetadata("compiler/testData/codegen/box/coroutines/varSpilling/debugMode")
+            @TestDataPath("$PROJECT_ROOT")
+            public class DebugMode {
+                @Test
+                public void testAllFilesPresentInDebugMode() throws Exception {
+                    KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/coroutines/varSpilling/debugMode"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS, true);
+                }
+            }
         }
     }
 

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/IrJsCodegenBoxTestGenerated.java
@@ -9767,6 +9767,16 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
                     KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/coroutines/varSpilling/cleanup"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR, true);
                 }
             }
+
+            @Nested
+            @TestMetadata("compiler/testData/codegen/box/coroutines/varSpilling/debugMode")
+            @TestDataPath("$PROJECT_ROOT")
+            public class DebugMode {
+                @Test
+                public void testAllFilesPresentInDebugMode() throws Exception {
+                    KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/coroutines/varSpilling/debugMode"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR, true);
+                }
+            }
         }
     }
 

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/testOld/wasm/semantics/IrCodegenBoxWasmTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/testOld/wasm/semantics/IrCodegenBoxWasmTestGenerated.java
@@ -8637,6 +8637,19 @@ public class IrCodegenBoxWasmTestGenerated extends AbstractIrCodegenBoxWasmTest 
                     KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/coroutines/varSpilling/cleanup"), Pattern.compile("^([^_](.+))\\.kt$"), null, TargetBackend.WASM, true);
                 }
             }
+
+            @TestMetadata("compiler/testData/codegen/box/coroutines/varSpilling/debugMode")
+            @TestDataPath("$PROJECT_ROOT")
+            @RunWith(JUnit3RunnerWithInners.class)
+            public static class DebugMode extends AbstractIrCodegenBoxWasmTest {
+                private void runTest(String testDataFilePath) throws Exception {
+                    KotlinTestUtils.runTest0(this::doTest, TargetBackend.WASM, testDataFilePath);
+                }
+
+                public void testAllFilesPresentInDebugMode() throws Exception {
+                    KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/coroutines/varSpilling/debugMode"), Pattern.compile("^([^_](.+))\\.kt$"), null, TargetBackend.WASM, true);
+                }
+            }
         }
     }
 

--- a/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/NativeCodegenBoxTestGenerated.java
+++ b/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/NativeCodegenBoxTestGenerated.java
@@ -10697,6 +10697,18 @@ public class NativeCodegenBoxTestGenerated extends AbstractNativeCodegenBoxTest 
                         KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/coroutines/varSpilling/cleanup"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.NATIVE, true);
                     }
                 }
+
+                @Nested
+                @TestMetadata("compiler/testData/codegen/box/coroutines/varSpilling/debugMode")
+                @TestDataPath("$PROJECT_ROOT")
+                @Tag("codegen")
+                @UseExtTestCaseGroupProvider()
+                public class DebugMode {
+                    @Test
+                    public void testAllFilesPresentInDebugMode() throws Exception {
+                        KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/coroutines/varSpilling/debugMode"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.NATIVE, true);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
This commit adds a new key that will allow users to enhance their
debugging experience in suspending contexts when using the IR backend.
After the key is enabled, the following things are changed:
1. All variables in a suspending context are spilled regardless their
liveness.
2. Their LVT records are not shrunk.
3. ACONST_NULL is not spilled to dead variables.

I would be very thankful if you told me how it would be best to cover this key with tests.

The drawback of the current implementation is that `shouldOptimiseUnusedVariables` affects three different places in `CoroutineTransformerMethodVisitor` as described above. They may seem random at a first glance, however I thought that it is better than if I refactored a large amount of a very important code.

I also consciously named the key `-Xenable-debug-mode`, since I believe that in future we may add some other changes that enhance the debugging experience under the same key. 