### PR TITLE
KTIJ-21986 Don't log non-kotlin code fragment context when it's null

### DIFF
--- a/compiler/psi/src/org/jetbrains/kotlin/psi/KtCodeFragment.kt
+++ b/compiler/psi/src/org/jetbrains/kotlin/psi/KtCodeFragment.kt
@@ -83,8 +83,8 @@ abstract class KtCodeFragment(
 
     override fun getContext(): PsiElement? {
         if (fakeContextForJavaFile != null) return fakeContextForJavaFile
-        if (context !is KtElement) {
-            val logInfoForContextElement = (context as? PsiFile)?.virtualFile?.path ?: context?.getElementTextWithContext()
+        if (context != null && context !is KtElement) {
+            val logInfoForContextElement = (context as? PsiFile)?.virtualFile?.path ?: context.getElementTextWithContext()
             LOG.warn("CodeFragment with non-kotlin context should have fakeContextForJavaFile set: \noriginalContext = $logInfoForContextElement")
             return null
         }


### PR DESCRIPTION
This warning shouldn't be logged when the context is null.