### PR TITLE
[KTIJ-21963] Move reflective access after default args lowerings

### DIFF
--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
@@ -167,7 +167,7 @@ private val defaultArgumentStubPhase = makeIrFilePhase(
     prerequisite = setOf(localDeclarationsPhase)
 )
 
-private val defaultArgumentCleanerPhase = makeIrFilePhase(
+val defaultArgumentCleanerPhase = makeIrFilePhase(
     { context: JvmBackendContext -> DefaultParameterCleaner(context, replaceDefaultValuesWithStubs = true) },
     name = "DefaultParameterCleaner",
     description = "Replace default values arguments with stubs",
@@ -423,13 +423,13 @@ private fun buildLoweringsPhase(
 
 
 val jvmFragmentLoweringPhases = run {
-    val localDeclarationsIndex = jvmFilePhases.indexOf(localDeclarationsPhase)
-    val loweringsUpToLocalDeclarations = jvmFilePhases.subList(0, localDeclarationsIndex + 1)
-    val remainingLowerings = jvmFilePhases.subList(localDeclarationsIndex + 1, jvmFilePhases.size)
+    val defaultArgsPhase = jvmFilePhases.indexOf(defaultArgumentCleanerPhase)
+    val loweringsUpToAndIncludingDefaultArgsPhase = jvmFilePhases.subList(0, defaultArgsPhase + 1)
+    val remainingLowerings = jvmFilePhases.subList(defaultArgsPhase + 1, jvmFilePhases.size)
     buildJvmLoweringPhases(
         "IrFragmentLowering",
         listOf(
-            "PrefixOfIRPhases" to loweringsUpToLocalDeclarations,
+            "PrefixOfIRPhases" to loweringsUpToAndIncludingDefaultArgsPhase,
             "FragmentLowerings" to listOf(
                 fragmentLocalFunctionPatchLowering,
                 reflectiveAccessLowering,

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/ReflectiveAccess.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/ReflectiveAccess.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
 import org.jetbrains.kotlin.backend.common.phaser.makeIrFilePhase
 import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
+import org.jetbrains.kotlin.backend.jvm.defaultArgumentCleanerPhase
 import org.jetbrains.kotlin.backend.jvm.ir.*
 import org.jetbrains.kotlin.backend.jvm.lower.SyntheticAccessorLowering.Companion.isAccessible
 import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
@@ -30,7 +31,7 @@ val reflectiveAccessLowering = makeIrFilePhase(
     ::ReflectiveAccessLowering,
     name = "ReflectiveCalls",
     description = "Avoid the need for accessors by replacing direct access to inaccessible members with accesses via reflection",
-    prerequisite = setOf()
+    prerequisite = setOf(defaultArgumentCleanerPhase)
 )
 
 // This lowering replaces member accesses that are illegal according to JVM


### PR DESCRIPTION
Title says it all.

ReflectAccessLowering was making incorrect assumptions on the shape of the IR due to running _before_ lowering of calls with "unsaturated" default arguments.

Moving the lowerings later in the sequence resolves this.

Resolves KTIJ-21963. Tests in [intellij-community#2046](https://github.com/JetBrains/intellij-community/pull/2046)