### PR TITLE
JVM: Show language version in pre-release error

### DIFF
--- a/compiler/cli/src/org/jetbrains/kotlin/cli/common/messages/AnalyzerWithCompilerReport.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/common/messages/AnalyzerWithCompilerReport.kt
@@ -29,6 +29,8 @@ import org.jetbrains.kotlin.config.LanguageVersionSettings
 import org.jetbrains.kotlin.config.languageVersionSettings
 import org.jetbrains.kotlin.diagnostics.*
 import org.jetbrains.kotlin.diagnostics.DiagnosticUtils.sortedDiagnostics
+import org.jetbrains.kotlin.diagnostics.Errors.PRE_RELEASE_CLASS
+import org.jetbrains.kotlin.diagnostics.Errors.PRE_RELEASE_CLASS_WITH_VERSION_INFO
 import org.jetbrains.kotlin.diagnostics.rendering.DefaultErrorMessages
 import org.jetbrains.kotlin.load.java.components.TraceBasedErrorReporter
 import org.jetbrains.kotlin.psi.KtFile
@@ -190,7 +192,7 @@ class AnalyzerWithCompilerReport(
                 )
             }
 
-            if (diagnostics.any { it.factory == Errors.PRE_RELEASE_CLASS }) {
+            if (diagnostics.any { it.factory == PRE_RELEASE_CLASS || it.factory == PRE_RELEASE_CLASS_WITH_VERSION_INFO }) {
                 messageCollector.report(
                     ERROR,
                     "Pre-release classes were found in dependencies. " +

--- a/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/KlibBasedSymbolProvider.kt
+++ b/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/KlibBasedSymbolProvider.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.fir.scopes.FirKotlinScopeProvider
 import org.jetbrains.kotlin.library.metadata.KlibMetadataClassDataFinder
 import org.jetbrains.kotlin.library.resolver.KotlinResolvedLibrary
 import org.jetbrains.kotlin.metadata.ProtoBuf
+import org.jetbrains.kotlin.metadata.deserialization.BinaryVersion
 import org.jetbrains.kotlin.metadata.deserialization.NameResolverImpl
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
@@ -105,7 +106,8 @@ class KlibBasedSymbolProvider(
                     deserializationConfiguration.reportErrorsOnPreReleaseDependencies && (moduleHeader.flags and 1) != 0
                 override val abiStability = DeserializedContainerAbiStability.STABLE
                 override val presentableString = "Package '${classId.packageFqName}'"
-
+                override val metadataVersion: BinaryVersion?
+                    get() = null
                 override fun getContainingFile() = SourceFile.NO_SOURCE_FILE
             }
 

--- a/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/Errors.java
+++ b/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/Errors.java
@@ -133,6 +133,7 @@ public interface Errors {
     DiagnosticFactory1<PsiElement, String> MISSING_IMPORTED_SCRIPT_PSI = DiagnosticFactory1.create(ERROR);
     DiagnosticFactory1<PsiElement, String> MISSING_SCRIPT_PROVIDED_PROPERTY_CLASS = DiagnosticFactory1.create(ERROR);
     DiagnosticFactory1<PsiElement, String> PRE_RELEASE_CLASS = DiagnosticFactory1.create(ERROR);
+    DiagnosticFactory2<PsiElement, String, String> PRE_RELEASE_CLASS_WITH_VERSION_INFO = DiagnosticFactory2.create(ERROR);
     DiagnosticFactory1<PsiElement, String> IR_WITH_UNSTABLE_ABI_COMPILED_CLASS = DiagnosticFactory1.create(ERROR);
     DiagnosticFactory1<PsiElement, String> FIR_COMPILED_CLASS = DiagnosticFactory1.create(ERROR);
     DiagnosticFactory2<PsiElement, String, IncompatibleVersionErrorData<?>> INCOMPATIBLE_CLASS = DiagnosticFactory2.create(ERROR);

--- a/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/rendering/DefaultErrorMessages.java
+++ b/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/rendering/DefaultErrorMessages.java
@@ -422,6 +422,7 @@ public class DefaultErrorMessages {
         MAP.put(MISSING_IMPORTED_SCRIPT_PSI, "Imported script file ''{0}'' is not loaded. Check your script imports", TO_STRING);
         MAP.put(MISSING_SCRIPT_PROVIDED_PROPERTY_CLASS, "Cannot access script provided property class ''{0}''. Check your module classpath for missing or conflicting dependencies", TO_STRING);
         MAP.put(PRE_RELEASE_CLASS, "{0} is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler", TO_STRING);
+        MAP.put(PRE_RELEASE_CLASS_WITH_VERSION_INFO, "{0} is compiled by a pre-release version of Kotlin {1} and cannot be loaded by this version of the compiler", TO_STRING, TO_STRING);
         MAP.put(IR_WITH_UNSTABLE_ABI_COMPILED_CLASS, "{0} is compiled by an unstable version of the Kotlin compiler and cannot be loaded by this compiler", TO_STRING);
         MAP.put(FIR_COMPILED_CLASS, "{0} is compiled by the new Kotlin compiler frontend and cannot be loaded by the old compiler", TO_STRING);
         MAP.put(INCOMPATIBLE_CLASS,

--- a/compiler/frontend/src/org/jetbrains/kotlin/resolve/checkers/MissingDependencyClassChecker.kt
+++ b/compiler/frontend/src/org/jetbrains/kotlin/resolve/checkers/MissingDependencyClassChecker.kt
@@ -57,7 +57,10 @@ object MissingDependencyClassChecker : CallChecker {
                 return INCOMPATIBLE_CLASS.on(reportOn, source.presentableString, incompatibility)
             }
             if (source.isPreReleaseInvisible) {
-                return PRE_RELEASE_CLASS.on(reportOn, source.presentableString)
+                return if (source.metadataVersion != null)
+                    PRE_RELEASE_CLASS_WITH_VERSION_INFO.on(reportOn, source.presentableString, source.metadataVersion.toString())
+                else
+                    PRE_RELEASE_CLASS.on(reportOn, source.presentableString)
             }
             if (source.abiStability == DeserializedContainerAbiStability.FIR_UNSTABLE) {
                 return FIR_COMPILED_CLASS.on(reportOn, source.presentableString)

--- a/compiler/ir/backend.jvm/entrypoint/src/org/jetbrains/kotlin/backend/jvm/FacadeClassSourceShimForFragmentCompilation.kt
+++ b/compiler/ir/backend.jvm/entrypoint/src/org/jetbrains/kotlin/backend/jvm/FacadeClassSourceShimForFragmentCompilation.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlin.descriptors.SourceFile
 import org.jetbrains.kotlin.fileClasses.JvmFileClassInfo
 import org.jetbrains.kotlin.fileClasses.JvmFileClassUtil.getFileClassInfoNoResolve
 import org.jetbrains.kotlin.load.kotlin.FacadeClassSource
+import org.jetbrains.kotlin.metadata.deserialization.BinaryVersion
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.jvm.JvmClassName
 import org.jetbrains.kotlin.resolve.source.PsiSourceFile
@@ -31,6 +32,8 @@ class FacadeClassSourceShimForFragmentCompilation(private val containingFile: Ps
         get() = DeserializedContainerAbiStability.STABLE
     override val presentableString: String
         get() = "Fragment for $containingFile"
+    override val metadataVersion: BinaryVersion?
+        get() = null
 
     override fun getContainingFile(): SourceFile {
         return containingFile

--- a/compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/output.txt
+++ b/compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/output.txt
@@ -1,41 +1,41 @@
 error: pre-release classes were found in dependencies. Remove them from the classpath, recompile with a release compiler or use '-Xskip-prerelease-check' to suppress errors
-compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:5:16: error: class 'a.A' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
+compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:5:16: error: class 'a.A' is compiled by a pre-release version of Kotlin $FIRST_NON_STABLE$ and cannot be loaded by this version of the compiler
 fun baz(param: A, nested: A.Nested) {
                ^
-compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:5:27: error: class 'a.A' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
+compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:5:27: error: class 'a.A' is compiled by a pre-release version of Kotlin $FIRST_NON_STABLE$ and cannot be loaded by this version of the compiler
 fun baz(param: A, nested: A.Nested) {
                           ^
-compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:5:29: error: class 'a.A.Nested' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
+compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:5:29: error: class 'a.A.Nested' is compiled by a pre-release version of Kotlin $FIRST_NON_STABLE$ and cannot be loaded by this version of the compiler
 fun baz(param: A, nested: A.Nested) {
                             ^
-compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:6:23: error: class 'a.A' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
+compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:6:23: error: class 'a.A' is compiled by a pre-release version of Kotlin $FIRST_NON_STABLE$ and cannot be loaded by this version of the compiler
     val constructor = A()
                       ^
-compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:7:18: error: class 'a.A' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
+compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:7:18: error: class 'a.A' is compiled by a pre-release version of Kotlin $FIRST_NON_STABLE$ and cannot be loaded by this version of the compiler
     val nested = A.Nested()
                  ^
-compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:7:20: error: class 'a.A.Nested' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
+compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:7:20: error: class 'a.A.Nested' is compiled by a pre-release version of Kotlin $FIRST_NON_STABLE$ and cannot be loaded by this version of the compiler
     val nested = A.Nested()
                    ^
-compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:8:22: error: class 'a.A' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
+compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:8:22: error: class 'a.A' is compiled by a pre-release version of Kotlin $FIRST_NON_STABLE$ and cannot be loaded by this version of the compiler
     val methodCall = param.method()
                      ^
 compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:8:28: error: unresolved reference: method
     val methodCall = param.method()
                            ^
-compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:9:30: error: class 'a.A' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
+compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:9:30: error: class 'a.A' is compiled by a pre-release version of Kotlin $FIRST_NON_STABLE$ and cannot be loaded by this version of the compiler
     val supertype = object : A() {}
                              ^
-compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:11:13: error: class 'a.AKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
+compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:11:13: error: class 'a.AKt' is compiled by a pre-release version of Kotlin $FIRST_NON_STABLE$ and cannot be loaded by this version of the compiler
     val x = foo()
             ^
-compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:12:13: error: class 'a.AKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
+compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:12:13: error: class 'a.AKt' is compiled by a pre-release version of Kotlin $FIRST_NON_STABLE$ and cannot be loaded by this version of the compiler
     val y = bar
             ^
-compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:13:5: error: class 'a.AKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
+compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:13:5: error: class 'a.AKt' is compiled by a pre-release version of Kotlin $FIRST_NON_STABLE$ and cannot be loaded by this version of the compiler
     bar = 239
     ^
-compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:14:12: error: class 'a.AKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
+compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:14:12: error: class 'a.AKt' is compiled by a pre-release version of Kotlin $FIRST_NON_STABLE$ and cannot be loaded by this version of the compiler
     val z: TA = ""
            ^
 COMPILATION_ERROR

--- a/compiler/testData/compileKotlinAgainstCustomBinaries/strictMetadataVersionSemanticsOldVersion/output.txt
+++ b/compiler/testData/compileKotlinAgainstCustomBinaries/strictMetadataVersionSemanticsOldVersion/output.txt
@@ -1,6 +1,6 @@
 error: incompatible classes were found in dependencies. Remove them from the classpath or use '-Xskip-metadata-version-check' to suppress errors
-$TMP_DIR$/library.jar!/META-INF/main.kotlin_module: error: module was compiled with an incompatible version of Kotlin. The binary version of its metadata is 1.9.0, expected version is $ABI_VERSION$.
-compiler/testData/compileKotlinAgainstCustomBinaries/strictMetadataVersionSemanticsOldVersion/source.kt:3:13: error: class 'a.C' was compiled with an incompatible version of Kotlin. The binary version of its metadata is 1.9.0, expected version is $ABI_VERSION$.
+$TMP_DIR$/library.jar!/META-INF/main.kotlin_module: error: module was compiled with an incompatible version of Kotlin. The binary version of its metadata is $FIRST_NON_STABLE$, expected version is $ABI_VERSION$.
+compiler/testData/compileKotlinAgainstCustomBinaries/strictMetadataVersionSemanticsOldVersion/source.kt:3:13: error: class 'a.C' was compiled with an incompatible version of Kotlin. The binary version of its metadata is $FIRST_NON_STABLE$, expected version is $ABI_VERSION$.
 The class is loaded from $TMP_DIR$/library.jar!/a/C.class
 fun test(c: C) {
             ^
@@ -10,15 +10,15 @@ compiler/testData/compileKotlinAgainstCustomBinaries/strictMetadataVersionSemant
 compiler/testData/compileKotlinAgainstCustomBinaries/strictMetadataVersionSemanticsOldVersion/source.kt:5:5: error: unresolved reference: v
     v
     ^
-compiler/testData/compileKotlinAgainstCustomBinaries/strictMetadataVersionSemanticsOldVersion/source.kt:6:5: error: class 'a.C' was compiled with an incompatible version of Kotlin. The binary version of its metadata is 1.9.0, expected version is $ABI_VERSION$.
+compiler/testData/compileKotlinAgainstCustomBinaries/strictMetadataVersionSemanticsOldVersion/source.kt:6:5: error: class 'a.C' was compiled with an incompatible version of Kotlin. The binary version of its metadata is $FIRST_NON_STABLE$, expected version is $ABI_VERSION$.
 The class is loaded from $TMP_DIR$/library.jar!/a/C.class
     c.let { C() }
     ^
-compiler/testData/compileKotlinAgainstCustomBinaries/strictMetadataVersionSemanticsOldVersion/source.kt:6:7: error: class 'a.C' was compiled with an incompatible version of Kotlin. The binary version of its metadata is 1.9.0, expected version is $ABI_VERSION$.
+compiler/testData/compileKotlinAgainstCustomBinaries/strictMetadataVersionSemanticsOldVersion/source.kt:6:7: error: class 'a.C' was compiled with an incompatible version of Kotlin. The binary version of its metadata is $FIRST_NON_STABLE$, expected version is $ABI_VERSION$.
 The class is loaded from $TMP_DIR$/library.jar!/a/C.class
     c.let { C() }
       ^
-compiler/testData/compileKotlinAgainstCustomBinaries/strictMetadataVersionSemanticsOldVersion/source.kt:6:13: error: class 'a.C' was compiled with an incompatible version of Kotlin. The binary version of its metadata is 1.9.0, expected version is $ABI_VERSION$.
+compiler/testData/compileKotlinAgainstCustomBinaries/strictMetadataVersionSemanticsOldVersion/source.kt:6:13: error: class 'a.C' was compiled with an incompatible version of Kotlin. The binary version of its metadata is $FIRST_NON_STABLE$, expected version is $ABI_VERSION$.
 The class is loaded from $TMP_DIR$/library.jar!/a/C.class
     c.let { C() }
             ^

--- a/compiler/tests-common/tests/org/jetbrains/kotlin/cli/AbstractCliTest.java
+++ b/compiler/tests-common/tests/org/jetbrains/kotlin/cli/AbstractCliTest.java
@@ -34,7 +34,9 @@ import org.jetbrains.kotlin.cli.js.K2JSCompiler;
 import org.jetbrains.kotlin.cli.js.dce.K2JSDce;
 import org.jetbrains.kotlin.cli.jvm.K2JVMCompiler;
 import org.jetbrains.kotlin.cli.metadata.K2MetadataCompiler;
+import org.jetbrains.kotlin.codegen.state.GenerationState;
 import org.jetbrains.kotlin.config.KotlinCompilerVersion;
+import org.jetbrains.kotlin.config.LanguageVersion;
 import org.jetbrains.kotlin.metadata.jvm.deserialization.JvmMetadataVersion;
 import org.jetbrains.kotlin.test.CompilerTestUtil;
 import org.jetbrains.kotlin.test.InTextDirectivesUtils;
@@ -98,7 +100,19 @@ public abstract class AbstractCliTest extends TestCaseWithTmpdir {
                 .replace("\n" + Usage.BAT_DELIMITER_CHARACTERS_NOTE + "\n", "")
                 .replaceAll("log4j:WARN.*\n", "");
 
+        normalizedOutputWithoutExitCode = replaceFirstNonStable(normalizedOutputWithoutExitCode);
+
         return exitCode == null ? normalizedOutputWithoutExitCode : (normalizedOutputWithoutExitCode + exitCode + "\n");
+    }
+
+    @NotNull
+    private static String replaceFirstNonStable(@NotNull String compilerOutput) {
+        if (compilerOutput.isEmpty() || LanguageVersion.FIRST_NON_STABLE == null) {
+            return compilerOutput;
+        }
+
+        JvmMetadataVersion mv = GenerationState.Companion.getLANGUAGE_TO_METADATA_VERSION().get(LanguageVersion.FIRST_NON_STABLE);
+        return compilerOutput.replace(mv.toString(), "$FIRST_NON_STABLE$");
     }
 
     private void doTest(@NotNull String fileName, @NotNull CLITool<?> compiler) {

--- a/compiler/tests/org/jetbrains/kotlin/jvm/compiler/CompileKotlinAgainstCustomBinariesTest.kt
+++ b/compiler/tests/org/jetbrains/kotlin/jvm/compiler/CompileKotlinAgainstCustomBinariesTest.kt
@@ -112,7 +112,7 @@ class CompileKotlinAgainstCustomBinariesTest : AbstractKotlinCompilerIntegration
     ) {
         // Compiles the library with some non-stable language version, then compiles a usage of this library with stable LV.
         // If there's no non-stable language version yet, the test does nothing.
-        val someNonStableVersion = LanguageVersion.values().firstOrNull { it > LanguageVersion.LATEST_STABLE } ?: return
+        val someNonStableVersion = LanguageVersion.FIRST_NON_STABLE ?: return
 
         val libraryOptions = listOf(
             "-language-version", someNonStableVersion.versionString,

--- a/compiler/util/src/org/jetbrains/kotlin/config/LanguageVersionSettings.kt
+++ b/compiler/util/src/org/jetbrains/kotlin/config/LanguageVersionSettings.kt
@@ -431,6 +431,9 @@ enum class LanguageVersion(val major: Int, val minor: Int) : DescriptionAware, L
 
         @JvmField
         val LATEST_STABLE = KOTLIN_1_8
+
+        @JvmField
+        val FIRST_NON_STABLE = LanguageVersion.values().firstOrNull { it > LATEST_STABLE }
     }
 }
 

--- a/core/compiler.common/build.gradle.kts
+++ b/core/compiler.common/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
     api(project(":core:util.runtime"))
     api(kotlinStdlib())
     api(project(":kotlin-annotations-jvm"))
+    implementation(project(":core:metadata"))
 }
 
 sourceSets {

--- a/core/compiler.common/src/org/jetbrains/kotlin/serialization/deserialization/descriptors/DeserializedContainerSource.kt
+++ b/core/compiler.common/src/org/jetbrains/kotlin/serialization/deserialization/descriptors/DeserializedContainerSource.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.serialization.deserialization.descriptors
 
 import org.jetbrains.kotlin.descriptors.SourceElement
+import org.jetbrains.kotlin.metadata.deserialization.BinaryVersion
 import org.jetbrains.kotlin.serialization.deserialization.IncompatibleVersionErrorData
 
 interface DeserializedContainerSource : SourceElement {
@@ -21,6 +22,8 @@ interface DeserializedContainerSource : SourceElement {
 
     // This string should only be used in error messages
     val presentableString: String
+
+    val metadataVersion: BinaryVersion?
 }
 
 enum class DeserializedContainerAbiStability {

--- a/core/deserialization.common.jvm/src/org/jetbrains/kotlin/load/kotlin/JvmPackagePartSource.kt
+++ b/core/deserialization.common.jvm/src/org/jetbrains/kotlin/load/kotlin/JvmPackagePartSource.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.load.kotlin
 
 import org.jetbrains.kotlin.descriptors.SourceFile
 import org.jetbrains.kotlin.metadata.ProtoBuf
+import org.jetbrains.kotlin.metadata.deserialization.BinaryVersion
 import org.jetbrains.kotlin.metadata.deserialization.NameResolver
 import org.jetbrains.kotlin.metadata.deserialization.getExtensionOrNull
 import org.jetbrains.kotlin.metadata.jvm.JvmProtoBuf
@@ -63,4 +64,7 @@ class JvmPackagePartSource(
     override fun toString() = "${this::class.java.simpleName}: $className"
 
     override fun getContainingFile(): SourceFile = SourceFile.NO_SOURCE_FILE
+
+    override val metadataVersion: BinaryVersion?
+        get() = knownJvmBinaryClass?.classHeader?.metadataVersion
 }

--- a/core/deserialization.common.jvm/src/org/jetbrains/kotlin/load/kotlin/KotlinJvmBinarySourceElement.kt
+++ b/core/deserialization.common.jvm/src/org/jetbrains/kotlin/load/kotlin/KotlinJvmBinarySourceElement.kt
@@ -17,6 +17,7 @@
 package org.jetbrains.kotlin.load.kotlin
 
 import org.jetbrains.kotlin.descriptors.SourceFile
+import org.jetbrains.kotlin.metadata.deserialization.BinaryVersion
 import org.jetbrains.kotlin.metadata.jvm.deserialization.JvmMetadataVersion
 import org.jetbrains.kotlin.serialization.deserialization.IncompatibleVersionErrorData
 import org.jetbrains.kotlin.serialization.deserialization.descriptors.DeserializedContainerAbiStability
@@ -30,6 +31,8 @@ class KotlinJvmBinarySourceElement(
 ) : DeserializedContainerSource {
     override val presentableString: String
         get() = "Class '${binaryClass.classId.asSingleFqName().asString()}'"
+
+    override val metadataVersion: BinaryVersion = binaryClass.classHeader.metadataVersion
 
     override fun getContainingFile(): SourceFile = SourceFile.NO_SOURCE_FILE
 

--- a/js/js.serializer/src/org/jetbrains/kotlin/serialization/js/KotlinJavascriptPackageFragment.kt
+++ b/js/js.serializer/src/org/jetbrains/kotlin/serialization/js/KotlinJavascriptPackageFragment.kt
@@ -22,6 +22,7 @@ import org.jetbrains.kotlin.descriptors.PackageFragmentDescriptor
 import org.jetbrains.kotlin.descriptors.SourceFile
 import org.jetbrains.kotlin.descriptors.annotations.AnnotationDescriptor
 import org.jetbrains.kotlin.metadata.ProtoBuf
+import org.jetbrains.kotlin.metadata.deserialization.BinaryVersion
 import org.jetbrains.kotlin.metadata.deserialization.NameResolverImpl
 import org.jetbrains.kotlin.metadata.js.JsProtoBuf
 import org.jetbrains.kotlin.name.ClassId
@@ -100,5 +101,8 @@ class KotlinJavascriptPackageFragment(
 
         override val presentableString: String
             get() = "Package '$fqName'"
+
+        override val metadataVersion: BinaryVersion?
+            get() = null
     }
 }


### PR DESCRIPTION
Partially fix [KT-16279](https://youtrack.jetbrains.com/issue/KT-16279). 

It seems that JVM-backend and JS-backend adopt different approaches of writing metadata, so I think it's better to keep JS-backend untouched, and take care of it later.

--- 

This is how JVM backend writes metadata:
https://github.com/JetBrains/kotlin/blob/fc6c2c9631cc152f5ec22cf3285706ece86d043e/compiler/backend/src/org/jetbrains/kotlin/codegen/writeAnnotationUtil.kt#L35

This is how JS-backend writes metadata (not pretty sure) :
https://github.com/JetBrains/kotlin/blob/92d200e093c693b3c06e53a39e0b0973b84c7ec5/js/js.translator/src/org/jetbrains/kotlin/js/facade/K2JSTranslator.kt#L220-L226

