### PR TITLE
Strictly parse gradle plugin boolean properties

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinProperties.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinProperties.kt
@@ -423,7 +423,7 @@ internal class PropertiesProvider private constructor(private val project: Proje
     }
 
     private fun booleanProperty(propName: String): Boolean? =
-        property(propName)?.toBoolean()
+        property(propName)?.toBooleanStrict()
 
     private inline fun <reified T : Enum<T>> enumProperty(
         propName: String,


### PR DESCRIPTION
At the moment gradle plugin boolean properties aren't strictly parsed, meaning that invalid values are interpreted as `false`.
Even `true ` is silently ignored and interpreted as `false`.

Using `toBooleanStrict` instead of `toBoolean` will throw an `IllegalArgumentException` if the value isn't exactly `true` or `false` (just like an invalid enum property value would).