### PR TITLE
Support logging file accessed in Kotlin annotation processing

### DIFF
--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/KaptContext.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/KaptContext.kt
@@ -60,7 +60,7 @@ open class KaptContext(val options: KaptOptions, val withJdk: Boolean, val logge
 
     init {
         preregisterLog(context)
-        KaptJavaFileManager.preRegister(context)
+        KaptJavaFileManager.preRegister(context, options.fileAccessHistoryReportFile != null)
 
         @Suppress("LeakingThis")
         preregisterTreeMaker(context)

--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/KaptOptions.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/KaptOptions.kt
@@ -43,7 +43,8 @@ class KaptOptions(
     val processingClassLoader: ClassLoader?,
     //construct new classloader for these processors instead of using one defined in processingClassLoader
     val separateClassloaderForProcessors: Set<String>,
-    val processorsStatsReportFile: File?
+    val processorsStatsReportFile: File?,
+    val fileAccessHistoryReportFile: File?
 ) : KaptFlags {
     override fun get(flag: KaptFlag) = flags[flag]
 
@@ -74,6 +75,7 @@ class KaptOptions(
         var mode: AptMode = AptMode.WITH_COMPILATION
         var detectMemoryLeaks: DetectMemoryLeaksMode = DetectMemoryLeaksMode.DEFAULT
         var processorsStatsReportFile: File? = null
+        var fileAccessHistoryReportFile: File? = null
 
         fun build(): KaptOptions {
             val sourcesOutputDir = this.sourcesOutputDir ?: error("'sourcesOutputDir' must be set")
@@ -88,7 +90,8 @@ class KaptOptions(
                 mode, detectMemoryLeaks,
                 processingClassLoader = null,
                 separateClassloaderForProcessors = emptySet(),
-                processorsStatsReportFile = processorsStatsReportFile
+                processorsStatsReportFile = processorsStatsReportFile,
+                fileAccessHistoryReportFile = fileAccessHistoryReportFile
             )
         }
     }

--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/annotationProcessing.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/annotationProcessing.kt
@@ -14,6 +14,7 @@ import com.sun.tools.javac.processing.JavacProcessingEnvironment
 import com.sun.tools.javac.tree.JCTree
 import org.jetbrains.kotlin.base.kapt3.KaptFlag
 import org.jetbrains.kotlin.kapt3.base.incremental.*
+import org.jetbrains.kotlin.kapt3.base.javac.KaptJavaFileManager
 import org.jetbrains.kotlin.kapt3.base.util.KaptBaseError
 import org.jetbrains.kotlin.kapt3.base.util.KaptLogger
 import org.jetbrains.kotlin.kapt3.base.util.isJava9OrLater
@@ -25,6 +26,7 @@ import javax.annotation.processing.RoundEnvironment
 import javax.lang.model.SourceVersion
 import javax.lang.model.element.TypeElement
 import javax.tools.JavaFileObject
+import kotlin.collections.List
 import kotlin.system.measureTimeMillis
 import com.sun.tools.javac.util.List as JavacList
 
@@ -124,6 +126,10 @@ fun KaptContext.doAnnotationProcessing(
 
         options.processorsStatsReportFile?.let { dumpProcessorStats(wrappedProcessors, it, logger::info) }
 
+        options.fileAccessHistoryReportFile?.let {
+            dumpFileAccessHistory(fileManager, options.fileAccessHistoryReportFile, logger::info)
+        }
+
         if (logger.isVerbose) {
             filer.displayState()
         }
@@ -161,6 +167,12 @@ private fun dumpProcessorStats(wrappedProcessors: List<ProcessorWrapper>, apRepo
             appendLine(processor.renderGenerations())
         }
     })
+}
+
+private fun dumpFileAccessHistory(fileManager: KaptJavaFileManager, reportFile: File, logger: (String) -> Unit) {
+    logger("Dumping KAPT file access history to ${reportFile.absolutePath}")
+
+    reportFile.writeText(fileManager.renderFileAccessHistory())
 }
 
 private fun reportIfRunningNonIncrementally(

--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/javac/KaptJavaFileManager.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/javac/KaptJavaFileManager.kt
@@ -9,12 +9,15 @@ import com.sun.tools.javac.file.JavacFileManager
 import com.sun.tools.javac.main.Option
 import com.sun.tools.javac.util.Context
 import java.io.File
+import java.io.InputStream
+import java.io.Reader
+import java.net.URI
 import java.util.*
-import javax.tools.JavaFileManager
-import javax.tools.JavaFileObject
-import javax.tools.StandardLocation
+import javax.tools.*
 
-class KaptJavaFileManager(context: Context) : JavacFileManager(context, true, null) {
+class KaptJavaFileManager(context: Context, private val shouldRecordFileAccess: Boolean) : JavacFileManager(context, true, null) {
+    private val fileAccessHistory = mutableSetOf<URI>()
+
     fun handleOptionJavac9(option: Option, value: String) {
         val handleOptionMethod = JavacFileManager::class.java
             .getMethod("handleOption", Option::class.java, String::class.java)
@@ -34,24 +37,70 @@ class KaptJavaFileManager(context: Context) : JavacFileManager(context, true, nu
     ): MutableIterable<JavaFileObject> {
         val originalList = super.list(location, packageName, kinds, recurse)
 
-        if (location == null
-            || location != StandardLocation.CLASS_PATH
-            || rootsToFilter.isEmpty()
-            || typeToIgnore.isEmpty()
-            || !filterThisPath(packageName)
-        ) {
-            return originalList
-        }
+        val shouldPackageBeFiltered =
+            location != null &&
+                    location == StandardLocation.CLASS_PATH &&
+                    rootsToFilter.isNotEmpty() &&
+                    typeToIgnore.isNotEmpty() &&
+                    filterThisPath(packageName)
 
         val filteredList = LinkedList<JavaFileObject>()
         for (file in originalList)
-            if (!shouldBeFiltered(packageName, file)) {
-                filteredList.add(file)
+            if (!shouldPackageBeFiltered || !shouldBeFiltered(packageName, file)) {
+                filteredList.add(getAccessMonitoredFileObject(location, file) as JavaFileObject)
             }
 
         return filteredList
     }
 
+    override fun getJavaFileForInput(location: JavaFileManager.Location?, className: String?, kind: JavaFileObject.Kind?): JavaFileObject? {
+        val file = super.getJavaFileForInput(location, className, kind)
+        return getAccessMonitoredFileObject(location, file) as JavaFileObject?
+    }
+
+    override fun getJavaFileForOutput(
+        location: JavaFileManager.Location?,
+        className: String?,
+        kind: JavaFileObject.Kind?,
+        sibling: FileObject?
+    ): JavaFileObject? {
+        val file = super.getJavaFileForOutput(location, className, kind, sibling)
+        return getAccessMonitoredFileObject(location, file) as JavaFileObject?
+    }
+
+    override fun getFileForInput(location: JavaFileManager.Location?, packageName: String?, relativeName: String?): FileObject? {
+        val file = super.getFileForInput(location, packageName, relativeName)
+        return getAccessMonitoredFileObject(location, file)
+    }
+
+    override fun getFileForOutput(
+        location: JavaFileManager.Location?,
+        packageName: String?,
+        relativeName: String?,
+        sibling: FileObject?
+    ): FileObject? {
+        val file = super.getFileForOutput(location, packageName, relativeName, sibling)
+        return getAccessMonitoredFileObject(location, file)
+    }
+
+    /** javac does not play nice with wrapped file objects in this method; so we unwrap */
+    override fun inferBinaryName(location: JavaFileManager.Location?, file: JavaFileObject): String? =
+        super.inferBinaryName(location, getOriginalFileObject(file) as JavaFileObject)
+
+    /** javac does not play nice with wrapped file objects in this method; so we unwrap */
+    override fun isSameFile(a: FileObject, b: FileObject): Boolean {
+        return super.isSameFile(getOriginalFileObject(a), getOriginalFileObject(b))
+    }
+
+    private fun getAccessMonitoredFileObject(location: JavaFileManager.Location?, file: FileObject?) =
+        if (shouldRecordFileAccess && location != StandardLocation.ANNOTATION_PROCESSOR_PATH && file != null && file is JavaFileObject)
+            AccessMonitoredJavaFileObject(file)
+        else file
+
+    private fun getOriginalFileObject(file: FileObject): FileObject =
+        if (file is AccessMonitoredJavaFileObject) file.getJavaFileObject() else file
+
+    fun renderFileAccessHistory() = fileAccessHistory.sorted().joinToString("\n")
 
     private fun filterThisPath(packageName: String?): Boolean {
         packageName ?: return false
@@ -72,9 +121,32 @@ class KaptJavaFileManager(context: Context) : JavacFileManager(context, true, nu
         }
     }
 
+    inner class AccessMonitoredJavaFileObject(innerFile: JavaFileObject) : ForwardingJavaFileObject<JavaFileObject>(innerFile) {
+        fun getJavaFileObject(): JavaFileObject = fileObject
+        override fun toString(): String = fileObject.name
+        override fun openInputStream(): InputStream {
+            recordFileAccess()
+            return super.openInputStream()
+        }
+
+        override fun openReader(ignoreEncodingErrors: Boolean): Reader {
+            recordFileAccess()
+            return super.openReader(ignoreEncodingErrors)
+        }
+
+        override fun getCharContent(ignoreEncodingErrors: Boolean): CharSequence {
+            recordFileAccess()
+            return super.getCharContent(ignoreEncodingErrors)
+        }
+
+        private fun recordFileAccess() {
+            fileAccessHistory.add(fileObject.toUri())
+        }
+    }
+
     companion object {
-        internal fun preRegister(context: Context) {
-            context.put(JavaFileManager::class.java, Context.Factory<JavaFileManager> { KaptJavaFileManager(it) })
+        internal fun preRegister(context: Context, shouldRecordFileAccess: Boolean) {
+            context.put(JavaFileManager::class.java, Context.Factory { KaptJavaFileManager(it, shouldRecordFileAccess) })
         }
     }
 }

--- a/plugins/kapt3/kapt3-cli/src/KaptCliOption.kt
+++ b/plugins/kapt3/kapt3-cli/src/KaptCliOption.kt
@@ -187,6 +187,13 @@ enum class KaptCliOption(
         cliToolOption = CliToolOption("-Kapt-dump-processor-stats", VALUE)
     ),
 
+    DUMP_FILE_ACCESS_HISTORY(
+        "dumpFileAccessHistory",
+        "<path>",
+        "Dump list of files accessed by processors to the specified file",
+        cliToolOption = CliToolOption("-Kapt-dump-file-access-history", VALUE)
+    ),
+
     STRICT_MODE_OPTION(
         "strict",
         "true | false",

--- a/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/Kapt3Plugin.kt
+++ b/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/Kapt3Plugin.kt
@@ -131,6 +131,7 @@ class Kapt3CommandLineProcessor : CommandLineProcessor {
 
             SHOW_PROCESSOR_STATS -> setFlag(KaptFlag.SHOW_PROCESSOR_STATS, value)
             DUMP_PROCESSOR_STATS -> processorsStatsReportFile = File(value)
+            DUMP_FILE_ACCESS_HISTORY -> fileAccessHistoryReportFile = File(value)
             INCLUDE_COMPILE_CLASSPATH -> setFlag(KaptFlag.INCLUDE_COMPILE_CLASSPATH, value)
 
             DETECT_MEMORY_LEAKS_OPTION -> setSelector(enumValues<DetectMemoryLeaksMode>(), value) { detectMemoryLeaks = it }


### PR DESCRIPTION
# Context:
Youtrack report: https://youtrack.jetbrains.com/issue/KT-52853

This change expanded KAPT to support a new param `fileAccessHistoryReportFile`, which report all the classed used during annotation processing into a file, in the form of a list of URIs. 

This is useful for build speed improvements described in https://engineering.fb.com/2017/11/09/android/rethinking-android-app-compilation-with-buck/ . Essentially, using the list of used classes, we can compile only the dependencies that are really affected by the developer's code changes, and improve kotlin build speed

# Test plan:
Tested in real life CLI based build tool
Tested in unit test ` ./gradlew :kotlin-annotation-processing-base:test --tests "org.jetbrains.kotlin.kapt.base.test.JavaKaptContextTest"`. Test passed.

Use the test as an example, you can see the following line in log:
```
[INFO] Dumping KAPT file access history to /var/folders/x9/f8cztkfn3b9gpdth_4v2nyx00000gn/T/kotlin-annotation-processing-baseProject_test_2971344083190170958/kapt_access_history8753395934352559134.txt
```
Locally print the report file's content, you can see the following text content:
```
file:/private/var/folders/x9/f8cztkfn3b9gpdth_4v2nyx00000gn/T/kotlin-annotation-processing-baseProject_test_2971344083190170958/kaptRunner3607328635994579172/generated/MyMethodMyAnnotation.java
jar:file:/Library/Java/JavaVirtualMachines/jdk1.8.0_181.jdk/Contents/Home/lib/ct.sym!/META-INF/sym/rt.jar/java/io/Serializable.class
jar:file:/Library/Java/JavaVirtualMachines/jdk1.8.0_181.jdk/Contents/Home/lib/ct.sym!/META-INF/sym/rt.jar/java/lang/Comparable.class
jar:file:/Library/Java/JavaVirtualMachines/jdk1.8.0_181.jdk/Contents/Home/lib/ct.sym!/META-INF/sym/rt.jar/java/lang/Enum.class
jar:file:/Library/Java/JavaVirtualMachines/jdk1.8.0_181.jdk/Contents/Home/lib/ct.sym!/META-INF/sym/rt.jar/java/lang/Object.class
jar:file:/Library/Java/JavaVirtualMachines/jdk1.8.0_181.jdk/Contents/Home/lib/ct.sym!/META-INF/sym/rt.jar/java/lang/String.class
jar:file:/Library/Java/JavaVirtualMachines/jdk1.8.0_181.jdk/Contents/Home/lib/ct.sym!/META-INF/sym/rt.jar/java/lang/annotation/Annotation.class
```
