### PR TITLE
Add quotes to Windows paths

### DIFF
--- a/compiler/cli/bin/kotlin.bat
+++ b/compiler/cli/bin/kotlin.bat
@@ -6,4 +6,4 @@ rem Use of this source code is governed by the Apache 2.0 license that can be fo
 setlocal
 set _KOTLIN_RUNNER=1
 
-call %~dps0kotlinc.bat %*
+call "%~dps0"kotlinc.bat %*

--- a/compiler/cli/bin/kotlinc.bat
+++ b/compiler/cli/bin/kotlinc.bat
@@ -78,7 +78,7 @@ rem # subroutines
 
 :set_home
   set _BIN_DIR=
-  for %%i in (%~sf0) do set _BIN_DIR=%_BIN_DIR%%%~dpsi
+  for %%i in ("%~sf0") do set _BIN_DIR=%_BIN_DIR%%%~dpsi
   set _KOTLIN_HOME=%_BIN_DIR%..
 goto :eof
 


### PR DESCRIPTION
Resolves errors that occur when the %_KOTLIN_HOME% path has a space in it, e.g. (C:\Program Files\kotlinc\bin)
See errors:
![image](https://user-images.githubusercontent.com/55121683/174528206-349bfddc-ddc1-4e39-9f9e-f6e877d5383c.png)

![image](https://user-images.githubusercontent.com/55121683/174528160-0b6f4194-9c9d-48c0-8c96-ac2386b5f01f.png)

Adding quotes around these two path variables handles the spaces.