### PR TITLE
KT-52959 stop using project.rootProject in KotlinProperties.kt

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinProperties.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinProperties.kt
@@ -39,7 +39,7 @@ import java.util.*
 internal class PropertiesProvider private constructor(private val project: Project) {
     private val localProperties: Properties by lazy {
         Properties().apply {
-            val localPropertiesFile = project.rootProject.file("local.properties")
+            val localPropertiesFile = File(project.rootDir, "local.properties")
             if (localPropertiesFile.isFile) {
                 localPropertiesFile.inputStream().use {
                     load(it)


### PR DESCRIPTION
project.rootProject breaks project isolation. The access is not needed here as we can
simply use project.getRootDir https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html#getRootDir--