### PR TITLE
JVM: Allow JvmName annotations on builtins with different jvm names (KT-52897)

### DIFF
--- a/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsTestGenerated.java
@@ -34638,6 +34638,12 @@ public class FirOldFrontendDiagnosticsTestGenerated extends AbstractFirDiagnosti
                 }
 
                 @Test
+                @TestMetadata("jvmNameOnSpecialBridges.kt")
+                public void testJvmNameOnSpecialBridges() throws Exception {
+                    runTest("compiler/testData/diagnostics/testsWithStdLib/annotations/annotationApplicability/jvmNameOnSpecialBridges.kt");
+                }
+
+                @Test
                 @TestMetadata("multifileClassPart.kt")
                 public void testMultifileClassPart() throws Exception {
                     runTest("compiler/testData/diagnostics/testsWithStdLib/annotations/annotationApplicability/multifileClassPart.kt");

--- a/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsWithLightTreeTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsWithLightTreeTestGenerated.java
@@ -34638,6 +34638,12 @@ public class FirOldFrontendDiagnosticsWithLightTreeTestGenerated extends Abstrac
                 }
 
                 @Test
+                @TestMetadata("jvmNameOnSpecialBridges.kt")
+                public void testJvmNameOnSpecialBridges() throws Exception {
+                    runTest("compiler/testData/diagnostics/testsWithStdLib/annotations/annotationApplicability/jvmNameOnSpecialBridges.kt");
+                }
+
+                @Test
                 @TestMetadata("multifileClassPart.kt")
                 public void testMultifileClassPart() throws Exception {
                     runTest("compiler/testData/diagnostics/testsWithStdLib/annotations/annotationApplicability/multifileClassPart.kt");

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -29815,6 +29815,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
             runTest("compiler/testData/codegen/box/jvmName/renamedFileClass.kt");
         }
 
+        @Test
+        @TestMetadata("specialBridges.kt")
+        public void testSpecialBridges() throws Exception {
+            runTest("compiler/testData/codegen/box/jvmName/specialBridges.kt");
+        }
+
         @Nested
         @TestMetadata("compiler/testData/codegen/box/jvmName/fileFacades")
         @TestDataPath("$PROJECT_ROOT")

--- a/compiler/testData/codegen/box/jvmName/specialBridges.kt
+++ b/compiler/testData/codegen/box/jvmName/specialBridges.kt
@@ -1,0 +1,211 @@
+// TARGET_BACKEND: JVM
+// CHECK_BYTECODE_LISTING
+// WITH_STDLIB
+// FILE: lib.kt
+package lib
+
+open class JvmNumber : Number() {
+    @JvmName("byteValue")
+    override fun toByte(): Byte = 1.toByte()
+
+    @JvmName("shortValue")
+    override fun toShort(): Short = 2.toShort()
+
+    @JvmName("intValue")
+    override fun toInt(): Int = 3
+
+    @JvmName("longValue")
+    override fun toLong(): Long = 4L
+
+    @JvmName("floatValue")
+    override fun toFloat(): Float = 5f
+
+    @JvmName("doubleValue")
+    override fun toDouble(): Double = 6.0
+
+    // Doesn't exist on java.lang.Number
+    override fun toChar(): Char = 'a'
+}
+
+class KotlinNumber : JvmNumber() {
+    override fun toInt(): Int = 10
+}
+
+open class JvmCharSequence : CharSequence {
+    @get:JvmName("length")
+    override val length: Int
+        get() = 0
+
+    @JvmName("charAt")
+    override fun get(index: Int): Char = 'a'
+
+    override fun subSequence(startIndex: Int, endIndex: Int): CharSequence = this
+}
+
+class KotlinCharSequence : JvmCharSequence() {
+    override val length: Int
+        get() = 1
+
+    override fun get(index: Int): Char = super.get(index) + 1
+}
+
+open class JvmCollection<T> : Collection<T> {
+    @get:JvmName("size")
+    override val size: Int
+        get() = 0
+
+    override fun isEmpty(): Boolean = true
+    override fun contains(element: T): Boolean = false
+    override fun containsAll(elements: Collection<T>): Boolean = elements.isEmpty()
+    override fun iterator(): Iterator<T> = TODO()
+}
+
+class KotlinCollection : JvmCollection<String>() {
+    override val size: Int
+        get() = 1
+}
+
+open class JvmMap<K,V> : Map<K,V> {
+    @get:JvmName("size")
+    override val size: Int
+        get() = 0
+
+    @get:JvmName("entrySet")
+    override val entries: Set<Map.Entry<K, V>>
+        get() = emptySet()
+
+    @get:JvmName("values")
+    override val values: Collection<V>
+        get() = emptySet()
+
+    @get:JvmName("keySet")
+    override val keys: Set<K>
+        get() = emptySet()
+
+    override fun containsKey(key: K): Boolean = false
+    override fun containsValue(value: V): Boolean = false
+    override fun get(key: K): V? = null
+    override fun isEmpty(): Boolean = true
+}
+
+class KotlinMap<K, V> : JvmMap<K, V>() {
+    override val size: Int
+        get() = super.size + 1
+
+    override val entries: Set<Map.Entry<K, V>>
+        get() = setOf()
+
+    override val values: Collection<V>
+        get() = listOf()
+
+    override val keys: Set<K>
+        get() = super.keys
+}
+
+// FILE: JavaNumber.java
+package lib;
+
+public class JavaNumber extends JvmNumber {
+    public int intValue() { return 10; }
+
+    public static long useKotlinNumber(KotlinNumber number) {
+        return number.longValue();
+    }
+}
+
+// FILE: JavaCharSequence.java
+package lib;
+
+public class JavaCharSequence extends JvmCharSequence {
+    public int length() { return -1; }
+    public char charAt(int index) { return (char) (super.charAt(index) + 2); }
+
+    public static int useKotlinCharSequence(KotlinCharSequence s) {
+        return s.length();
+    }
+}
+
+// FILE: JavaCollection.java
+package lib;
+
+public class JavaCollection<T> extends JvmCollection<T> {
+    public int size() { return -1; }
+
+    public static int useKotlinCollection(KotlinCollection c) {
+        return c.size() + 1;
+    }
+}
+
+// FILE: JavaMap.java
+package lib;
+
+public class JavaMap extends JvmMap<String, String> {
+    public int size() { return 2; }
+
+    public static int useKotlinMap(KotlinMap<Integer, String> c) {
+        return c.size() + 1;
+    }
+}
+
+// FILE: test.kt
+import lib.*
+
+fun box(): String {
+    val number = JvmNumber()
+    if (number.toByte() != 1.toByte()) return "Fail 1"
+    if (number.toShort() != 2.toShort()) return "Fail 2"
+    if (number.toInt() != 3) return "Fail 3"
+    if (number.toLong() != 4L) return "Fail 4"
+    if (number.toFloat() != 5f) return "Fail 5"
+    if (number.toDouble() != 6.0) return "Fail 6"
+
+    val kotlinNumber = KotlinNumber()
+    if (kotlinNumber.toInt() != 10) return "Fail 7"
+    if (kotlinNumber.toByte() != 1.toByte()) return "Fail 8"
+
+    val charSequence = JvmCharSequence()
+    if (charSequence.length != 0) return "Fail 9"
+    if (charSequence[0] != 'a') return "Fail 10"
+
+    val kotlinCharSequence = KotlinCharSequence()
+    if (kotlinCharSequence.length != 1) return "Fail 11"
+    if (kotlinCharSequence[0] != 'b') return "Fail 12"
+
+    val collection = JvmCollection<String>()
+    if (collection.size != 0) return "Fail 13"
+
+    val kotlinCollection = KotlinCollection()
+    if (kotlinCollection.size != 1) return "Fail 14"
+
+    val map = JvmMap<Int, String>()
+    if (map.size != 0) return "Fail 15"
+    if (!map.entries.isEmpty()) return "Fail 16"
+    if (!map.keys.isEmpty()) return "Fail 17"
+    if (!map.values.isEmpty()) return "Fail 18"
+
+    val kotlinMap = KotlinMap<Int, String>()
+    if (kotlinMap.size != 1) return "Fail 19"
+    if (!kotlinMap.entries.isEmpty()) return "Fail 20"
+    if (!kotlinMap.values.isEmpty()) return "Fail 21"
+    if (!kotlinMap.keys.isEmpty()) return "Fail 22"
+
+    // Java tests
+    val javaNumber = JavaNumber()
+    if (javaNumber.toInt() != 10) return "Fail 23"
+    if (JavaNumber.useKotlinNumber(kotlinNumber) != 4L) return "Fail 24"
+
+    val javaCharSequence = JavaCharSequence()
+    if (javaCharSequence.length != -1) return "Fail 25"
+    if (javaCharSequence[0] != 'c') return "Fail 26"
+    if (JavaCharSequence.useKotlinCharSequence(kotlinCharSequence) != 1) return "Fail 27"
+
+    val javaCollection = JavaCollection<String>()
+    if (javaCollection.size != -1) return "Fail 28"
+    if (JavaCollection.useKotlinCollection(kotlinCollection) != 2) return "Fail 29"
+
+    val javaMap = JavaMap()
+    if (javaMap.size != 2) return "Fail 30"
+    if (JavaMap.useKotlinMap(kotlinMap) != 2) return "Fail 31"
+
+    return "OK"
+}

--- a/compiler/testData/codegen/box/jvmName/specialBridges.txt
+++ b/compiler/testData/codegen/box/jvmName/specialBridges.txt
@@ -1,0 +1,106 @@
+@kotlin.Metadata
+public final class TestKt {
+    // source: 'test.kt'
+    public final static @org.jetbrains.annotations.NotNull method box(): java.lang.String
+}
+
+@kotlin.Metadata
+public class lib/JvmCharSequence {
+    // source: 'lib.kt'
+    public method <init>(): void
+    public @kotlin.jvm.JvmName(name="charAt") method charAt(p0: int): char
+    public @kotlin.jvm.JvmName(name="length") method length(): int
+    public @org.jetbrains.annotations.NotNull method subSequence(p0: int, p1: int): java.lang.CharSequence
+}
+
+@kotlin.Metadata
+public class lib/JvmCollection {
+    // source: 'lib.kt'
+    public method <init>(): void
+    public method add(p0: java.lang.Object): boolean
+    public method addAll(p0: java.util.Collection): boolean
+    public method clear(): void
+    public method contains(p0: java.lang.Object): boolean
+    public method containsAll(@org.jetbrains.annotations.NotNull p0: java.util.Collection): boolean
+    public method isEmpty(): boolean
+    public @org.jetbrains.annotations.NotNull method iterator(): java.util.Iterator
+    public method remove(p0: java.lang.Object): boolean
+    public method removeAll(p0: java.util.Collection): boolean
+    public method retainAll(p0: java.util.Collection): boolean
+    public @kotlin.jvm.JvmName(name="size") method size(): int
+    public method toArray(): java.lang.Object[]
+    public method toArray(p0: java.lang.Object[]): java.lang.Object[]
+}
+
+@kotlin.Metadata
+public class lib/JvmMap {
+    // source: 'lib.kt'
+    public method <init>(): void
+    public method clear(): void
+    public method containsKey(p0: java.lang.Object): boolean
+    public method containsValue(p0: java.lang.Object): boolean
+    public @kotlin.jvm.JvmName(name="entrySet") @org.jetbrains.annotations.NotNull method entrySet(): java.util.Set
+    public @org.jetbrains.annotations.Nullable method get(p0: java.lang.Object): java.lang.Object
+    public method isEmpty(): boolean
+    public @kotlin.jvm.JvmName(name="keySet") @org.jetbrains.annotations.NotNull method keySet(): java.util.Set
+    public method put(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
+    public method putAll(p0: java.util.Map): void
+    public method remove(p0: java.lang.Object): java.lang.Object
+    public @kotlin.jvm.JvmName(name="size") method size(): int
+    public @kotlin.jvm.JvmName(name="values") @org.jetbrains.annotations.NotNull method values(): java.util.Collection
+}
+
+@kotlin.Metadata
+public class lib/JvmNumber {
+    // source: 'lib.kt'
+    public method <init>(): void
+    public @kotlin.jvm.JvmName(name="byteValue") method byteValue(): byte
+    public @kotlin.jvm.JvmName(name="doubleValue") method doubleValue(): double
+    public @kotlin.jvm.JvmName(name="floatValue") method floatValue(): float
+    public @kotlin.jvm.JvmName(name="intValue") method intValue(): int
+    public @kotlin.jvm.JvmName(name="longValue") method longValue(): long
+    public @kotlin.jvm.JvmName(name="shortValue") method shortValue(): short
+    public method toChar(): char
+}
+
+@kotlin.Metadata
+public final class lib/KotlinCharSequence {
+    // source: 'lib.kt'
+    public method <init>(): void
+    public bridge final method charAt(p0: int): char
+    public method get(p0: int): char
+    public method getLength(): int
+    public bridge final method length(): int
+}
+
+@kotlin.Metadata
+public final class lib/KotlinCollection {
+    // source: 'lib.kt'
+    public method <init>(): void
+    public bridge final method contains(p0: java.lang.Object): boolean
+    public bridge method contains(p0: java.lang.String): boolean
+    public method getSize(): int
+    public bridge final method size(): int
+}
+
+@kotlin.Metadata
+public final class lib/KotlinMap {
+    // source: 'lib.kt'
+    public method <init>(): void
+    public bridge final method entrySet(): java.util.Set
+    public @org.jetbrains.annotations.NotNull method getEntries(): java.util.Set
+    public @org.jetbrains.annotations.NotNull method getKeys(): java.util.Set
+    public method getSize(): int
+    public @org.jetbrains.annotations.NotNull method getValues(): java.util.Collection
+    public bridge final method keySet(): java.util.Set
+    public bridge final method size(): int
+    public bridge final method values(): java.util.Collection
+}
+
+@kotlin.Metadata
+public final class lib/KotlinNumber {
+    // source: 'lib.kt'
+    public method <init>(): void
+    public bridge final method intValue(): int
+    public method toInt(): int
+}

--- a/compiler/testData/diagnostics/testsWithStdLib/annotations/annotationApplicability/jvmNameOnSpecialBridges.fir.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/annotations/annotationApplicability/jvmNameOnSpecialBridges.fir.kt
@@ -1,0 +1,28 @@
+interface I {
+    fun toInt(): Int
+}
+
+interface J : I
+
+abstract class KotlinNumber : Number() {
+    <!INAPPLICABLE_JVM_NAME!>@JvmName("intValue")<!>
+    override fun toInt(): Int = 0
+
+    <!INAPPLICABLE_JVM_NAME!>@JvmName("wrongName")<!>
+    override fun toByte(): Byte = 0.toByte()
+}
+
+abstract class KotlinNumberSpecialBridge : Number(), J {
+    <!INAPPLICABLE_JVM_NAME!>@JvmName("longValue")<!>
+    override fun toLong(): Long = 0L
+}
+
+abstract class KotlinNumberDirectError : Number(), I {
+    <!INAPPLICABLE_JVM_NAME!>@JvmName("intValue")<!>
+    override fun toInt(): Int = 0
+}
+
+abstract class KotlinNumberIndirectError : Number(), J {
+    <!INAPPLICABLE_JVM_NAME!>@JvmName("intValue")<!>
+    override fun toInt(): Int = 0
+}

--- a/compiler/testData/diagnostics/testsWithStdLib/annotations/annotationApplicability/jvmNameOnSpecialBridges.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/annotations/annotationApplicability/jvmNameOnSpecialBridges.kt
@@ -1,0 +1,28 @@
+interface I {
+    fun toInt(): Int
+}
+
+interface J : I
+
+abstract class KotlinNumber : Number() {
+    @JvmName("intValue")
+    override fun toInt(): Int = 0
+
+    <!INAPPLICABLE_JVM_NAME!>@JvmName("wrongName")<!>
+    override fun toByte(): Byte = 0.toByte()
+}
+
+abstract class KotlinNumberSpecialBridge : Number(), J {
+    @JvmName("longValue")
+    override fun toLong(): Long = 0L
+}
+
+abstract class KotlinNumberDirectError : Number(), I {
+    <!INAPPLICABLE_JVM_NAME!>@JvmName("intValue")<!>
+    override fun toInt(): Int = 0
+}
+
+abstract class KotlinNumberIndirectError : Number(), J {
+    <!INAPPLICABLE_JVM_NAME!>@JvmName("intValue")<!>
+    override fun toInt(): Int = 0
+}

--- a/compiler/testData/diagnostics/testsWithStdLib/annotations/annotationApplicability/jvmNameOnSpecialBridges.txt
+++ b/compiler/testData/diagnostics/testsWithStdLib/annotations/annotationApplicability/jvmNameOnSpecialBridges.txt
@@ -1,0 +1,72 @@
+package
+
+public interface I {
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public abstract fun toInt(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public interface J : I {
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public abstract override /*1*/ /*fake_override*/ fun toInt(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public abstract class KotlinNumber : kotlin.Number {
+    public constructor KotlinNumber()
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    @kotlin.jvm.JvmName(name = "wrongName") public open override /*1*/ fun toByte(): kotlin.Byte
+    public abstract override /*1*/ /*fake_override*/ fun toChar(): kotlin.Char
+    public abstract override /*1*/ /*fake_override*/ fun toDouble(): kotlin.Double
+    public abstract override /*1*/ /*fake_override*/ fun toFloat(): kotlin.Float
+    @kotlin.jvm.JvmName(name = "intValue") public open override /*1*/ fun toInt(): kotlin.Int
+    public abstract override /*1*/ /*fake_override*/ fun toLong(): kotlin.Long
+    public abstract override /*1*/ /*fake_override*/ fun toShort(): kotlin.Short
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public abstract class KotlinNumberDirectError : kotlin.Number, I {
+    public constructor KotlinNumberDirectError()
+    public open override /*2*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*2*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public abstract override /*1*/ /*fake_override*/ fun toByte(): kotlin.Byte
+    public abstract override /*1*/ /*fake_override*/ fun toChar(): kotlin.Char
+    public abstract override /*1*/ /*fake_override*/ fun toDouble(): kotlin.Double
+    public abstract override /*1*/ /*fake_override*/ fun toFloat(): kotlin.Float
+    @kotlin.jvm.JvmName(name = "intValue") public open override /*2*/ fun toInt(): kotlin.Int
+    public abstract override /*1*/ /*fake_override*/ fun toLong(): kotlin.Long
+    public abstract override /*1*/ /*fake_override*/ fun toShort(): kotlin.Short
+    public open override /*2*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public abstract class KotlinNumberIndirectError : kotlin.Number, J {
+    public constructor KotlinNumberIndirectError()
+    public open override /*2*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*2*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public abstract override /*1*/ /*fake_override*/ fun toByte(): kotlin.Byte
+    public abstract override /*1*/ /*fake_override*/ fun toChar(): kotlin.Char
+    public abstract override /*1*/ /*fake_override*/ fun toDouble(): kotlin.Double
+    public abstract override /*1*/ /*fake_override*/ fun toFloat(): kotlin.Float
+    @kotlin.jvm.JvmName(name = "intValue") public open override /*2*/ fun toInt(): kotlin.Int
+    public abstract override /*1*/ /*fake_override*/ fun toLong(): kotlin.Long
+    public abstract override /*1*/ /*fake_override*/ fun toShort(): kotlin.Short
+    public open override /*2*/ /*fake_override*/ fun toString(): kotlin.String
+}
+
+public abstract class KotlinNumberSpecialBridge : kotlin.Number, J {
+    public constructor KotlinNumberSpecialBridge()
+    public open override /*2*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*2*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public abstract override /*1*/ /*fake_override*/ fun toByte(): kotlin.Byte
+    public abstract override /*1*/ /*fake_override*/ fun toChar(): kotlin.Char
+    public abstract override /*1*/ /*fake_override*/ fun toDouble(): kotlin.Double
+    public abstract override /*1*/ /*fake_override*/ fun toFloat(): kotlin.Float
+    public abstract override /*2*/ /*fake_override*/ fun toInt(): kotlin.Int
+    @kotlin.jvm.JvmName(name = "longValue") public open override /*1*/ fun toLong(): kotlin.Long
+    public abstract override /*1*/ /*fake_override*/ fun toShort(): kotlin.Short
+    public open override /*2*/ /*fake_override*/ fun toString(): kotlin.String
+}
+

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/DiagnosticTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/DiagnosticTestGenerated.java
@@ -34728,6 +34728,12 @@ public class DiagnosticTestGenerated extends AbstractDiagnosticTest {
                 }
 
                 @Test
+                @TestMetadata("jvmNameOnSpecialBridges.kt")
+                public void testJvmNameOnSpecialBridges() throws Exception {
+                    runTest("compiler/testData/diagnostics/testsWithStdLib/annotations/annotationApplicability/jvmNameOnSpecialBridges.kt");
+                }
+
+                @Test
                 @TestMetadata("multifileClassPart.kt")
                 public void testMultifileClassPart() throws Exception {
                     runTest("compiler/testData/diagnostics/testsWithStdLib/annotations/annotationApplicability/multifileClassPart.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -29311,6 +29311,12 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             runTest("compiler/testData/codegen/box/jvmName/renamedFileClass.kt");
         }
 
+        @Test
+        @TestMetadata("specialBridges.kt")
+        public void testSpecialBridges() throws Exception {
+            runTest("compiler/testData/codegen/box/jvmName/specialBridges.kt");
+        }
+
         @Nested
         @TestMetadata("compiler/testData/codegen/box/jvmName/fileFacades")
         @TestDataPath("$PROJECT_ROOT")

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -29815,6 +29815,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             runTest("compiler/testData/codegen/box/jvmName/renamedFileClass.kt");
         }
 
+        @Test
+        @TestMetadata("specialBridges.kt")
+        public void testSpecialBridges() throws Exception {
+            runTest("compiler/testData/codegen/box/jvmName/specialBridges.kt");
+        }
+
         @Nested
         @TestMetadata("compiler/testData/codegen/box/jvmName/fileFacades")
         @TestDataPath("$PROJECT_ROOT")

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -24834,6 +24834,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/jvmName/renamedFileClass.kt");
         }
 
+        @TestMetadata("specialBridges.kt")
+        public void testSpecialBridges() throws Exception {
+            runTest("compiler/testData/codegen/box/jvmName/specialBridges.kt");
+        }
+
         @TestMetadata("compiler/testData/codegen/box/jvmName/fileFacades")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)


### PR DESCRIPTION
This is an implementation for the feature request in [KT-52897](https://youtrack.jetbrains.com/issue/KT-52897). Briefly, the issue is that there is currently no way of converting a Java collection into a Kotlin collection while maintaining binary compatibility with existing Java clients. The proposed workaround (for the case where we don't need to instantiate any type parameters!) is to allow `JvmName` to specify the binary name of the underlying Java declaration.

---

There is no FIR implementation for this yet, since we still need to convert the code in `specialBuiltinMembers.kt`, `SpecialGenericSignatures.kt`, and `BuiltinSpecialProperties.kt` to avoid using descriptors. This is necessary anyway if we ever want to remove `IrBasedDescriptors` from the IR backend, which currently relies on the same functions in the method signature mapper.