### PR TITLE
KT-52071 Fallback if Security Manager blocks reading system properties

### DIFF
--- a/core/descriptors.jvm/src/org/jetbrains/kotlin/load/kotlin/header/ReadKotlinClassHeaderAnnotationVisitor.java
+++ b/core/descriptors.jvm/src/org/jetbrains/kotlin/load/kotlin/header/ReadKotlinClassHeaderAnnotationVisitor.java
@@ -27,6 +27,7 @@ import org.jetbrains.kotlin.name.FqName;
 import org.jetbrains.kotlin.name.Name;
 import org.jetbrains.kotlin.resolve.constants.ClassLiteralValue;
 
+import java.security.AccessControlException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -37,7 +38,16 @@ import static org.jetbrains.kotlin.load.kotlin.KotlinJvmBinaryClass.*;
 import static org.jetbrains.kotlin.load.kotlin.header.KotlinClassHeader.Kind.*;
 
 public class ReadKotlinClassHeaderAnnotationVisitor implements AnnotationVisitor {
-    private static final boolean IGNORE_OLD_METADATA = "true".equals(System.getProperty("kotlin.ignore.old.metadata"));
+
+    private static boolean IGNORE_OLD_METADATA;
+    static {
+        try {
+            IGNORE_OLD_METADATA = "true".equals(System.getProperty("kotlin.ignore.old.metadata"));
+        } catch (AccessControlException e) {
+            // Use default value if the Security Manager blocks reading system variables
+            IGNORE_OLD_METADATA = false;
+        }
+    }
 
     private static final Map<ClassId, KotlinClassHeader.Kind> HEADER_KINDS = new HashMap<ClassId, KotlinClassHeader.Kind>();
 


### PR DESCRIPTION
This solves an issue I reported myself: https://youtrack.jetbrains.com/issue/KT-52071

Some environments still use the Java Security Manager (despite its impending deprecation). They're also likely to block reading unknown system variables.

If Kotlin isn't widely used in an organization, then reading `kotlin.ignore.old.metadata` will trigger an `AccessControlException`. In that case, the code should continue as if the variable is unset, not crash.

I've tested this change manually in my own environment, which has a Security Manager that blocks reading system variables.