### PR TITLE
JVM IR: Fix generic signatures for special bridge methods (KT-52929)

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -2316,6 +2316,18 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         }
 
         @Test
+        @TestMetadata("kt52929.kt")
+        public void testKt52929() throws Exception {
+            runTest("compiler/testData/codegen/box/bridges/kt52929.kt");
+        }
+
+        @Test
+        @TestMetadata("kt52929_platformDependent.kt")
+        public void testKt52929_platformDependent() throws Exception {
+            runTest("compiler/testData/codegen/box/bridges/kt52929_platformDependent.kt");
+        }
+
+        @Test
         @TestMetadata("longChainOneBridge.kt")
         public void testLongChainOneBridge() throws Exception {
             runTest("compiler/testData/codegen/box/bridges/longChainOneBridge.kt");
@@ -2433,6 +2445,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         @TestMetadata("simpleUpperBound.kt")
         public void testSimpleUpperBound() throws Exception {
             runTest("compiler/testData/codegen/box/bridges/simpleUpperBound.kt");
+        }
+
+        @Test
+        @TestMetadata("specialBridgeTypesJava.kt")
+        public void testSpecialBridgeTypesJava() throws Exception {
+            runTest("compiler/testData/codegen/box/bridges/specialBridgeTypesJava.kt");
         }
 
         @Test

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/BridgeLowering.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/BridgeLowering.kt
@@ -166,14 +166,7 @@ internal class BridgeLowering(val context: JvmBackendContext) : FileLoweringPass
 
         // We don't produce bridges for abstract functions in interfaces.
         if (isJvmAbstract(context.state.jvmDefaultMode)) {
-            if (parentAsClass.isJvmInterface) {
-                // If function requires a special bridge, we should record it for generic signatures generation.
-                if (specialBridgeOrNull != null) {
-                    context.functionsWithSpecialBridges.add(this)
-                }
-                return false
-            }
-            return true
+            return !parentAsClass.isJvmInterface
         }
 
         // Finally, the JVM backend also ignores concrete fake overrides whose implementation is directly inherited from an interface.
@@ -481,8 +474,6 @@ internal class BridgeLowering(val context: JvmBackendContext) : FileLoweringPass
             returnType = specialBridge.substitutedReturnType?.eraseToScope(target.parentAsClass)
                 ?: specialBridge.overridden.returnType.eraseTypeParameters()
         }.apply {
-            context.functionsWithSpecialBridges.add(target)
-
             copyParametersWithErasure(this@addSpecialBridge, specialBridge.overridden, specialBridge.substitutedParameterTypes)
 
             body = context.createIrBuilder(symbol, startOffset, endOffset).irBlockBody {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendContext.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendContext.kt
@@ -128,7 +128,6 @@ class JvmBackendContext(
         overridesWithoutStubs.getOrElse(function) { function.overriddenSymbols }
 
     val bridgeLoweringCache = BridgeLoweringCache(this)
-    val functionsWithSpecialBridges: MutableSet<IrFunction> = ConcurrentHashMap.newKeySet()
 
     override var inVerbosePhase: Boolean = false // TODO: needs parallelizing
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/mapping/GenericSignatureMapper.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/mapping/GenericSignatureMapper.kt
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.jvm.mapping
+
+import org.jetbrains.kotlin.builtins.StandardNames
+import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
+import org.jetbrains.kotlin.ir.util.allOverridden
+import org.jetbrains.kotlin.ir.util.fqNameWhenAvailable
+import org.jetbrains.kotlin.ir.util.parentClassOrNull
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.resolve.jvm.jvmSignature.JvmMethodGenericSignature
+import org.jetbrains.org.objectweb.asm.commons.Method
+
+object GenericSignatureMapper {
+    private enum class SignatureKind {
+        NON_GENERIC, FIXED_COLLECTION_PARAMETER, FIRST_PARAMETER_ERASED
+    }
+
+    private class SignatureProcessor(
+        private val builtinFqName: FqName,
+        private val descriptorPrefix: String,
+        private val kind: SignatureKind,
+        private val checker: ((Method) -> Boolean)? = null
+    ) {
+        fun match(irFunction: IrSimpleFunction, method: Method): Boolean =
+            method.descriptor.startsWith(descriptorPrefix) &&
+                    checker?.invoke(method) != false &&
+                    irFunction.allOverridden(false).any {
+                        it.parentClassOrNull?.fqNameWhenAvailable == builtinFqName
+                    }
+
+        fun process(signature: String): String? = when (kind) {
+            SignatureKind.NON_GENERIC -> null
+            SignatureKind.FIXED_COLLECTION_PARAMETER -> "(Ljava/util/Collection<+Ljava/lang/Object;>;)Z"
+            SignatureKind.FIRST_PARAMETER_ERASED -> "(Ljava/lang/Object;${signature.substringAfter(';')}"
+        }
+    }
+
+    // Change generic signatures of remapped Kotlin builtins for Java interoperability.
+    //
+    // There are a few Kotlin builtins which are mapped to methods with different generic signatures in Java.
+    // For example, `MutableMap<K, V>` contains the following method.
+    //
+    //   remove(key: K): V
+    //
+    // This is mapped to a method with the same name in `java.util.Map` but with the following signature.
+    //
+    //   V remove(Object key)
+    //
+    // If we instantiate `K` with some type that erases to `Object` then the Java compiler will see the
+    // `remove` method as an override of the corresponding method in `java.util.Map`. This leads to a check
+    // that it is a valid override according to the Java language rules, i.e., that the parameter types
+    // are the same and the return type of the override is a subtype of the return type of the declaration.
+    //
+    // This check will fail if we generate a generic signature for the Kotlin declaration, since `K` is not
+    // the same type as `Object`. Similarly, we cannot just omit the generic signature, since otherwise the
+    // check would fail as `Object` is not a subtype of `V`.
+    //
+    // Instead, we have to produce a generic signature matching what Java expects. This is not a problem for
+    // Kotlin code, since we record the correct types in the Kotlin metadata.
+    fun mapSignature(irFunction: IrSimpleFunction, genericSignature: JvmMethodGenericSignature): JvmMethodGenericSignature {
+        val signature = genericSignature.genericsSignature
+            ?: return genericSignature
+
+        val method = genericSignature.asmMethod
+        val processors = methodNameToProcessors[method.name]
+            ?: return genericSignature
+
+        for (processor in processors) {
+            if (processor.match(irFunction, method)) {
+                return JvmMethodGenericSignature(
+                    method,
+                    genericSignature.valueParameters,
+                    processor.process(signature)
+                )
+            }
+        }
+
+        return genericSignature
+    }
+
+    private val methodNameToProcessors = mapOf(
+        "contains" to listOf(
+            // boolean contains(Object o)
+            SignatureProcessor(
+                StandardNames.FqNames.collection,
+                "(Ljava/lang/Object;)Z",
+                SignatureKind.NON_GENERIC
+            )
+        ),
+        "containsAll" to listOf(
+            // boolean containsAll(Collection<?> c)
+            SignatureProcessor(
+                StandardNames.FqNames.collection,
+                "(Ljava/util/Collection;)Z",
+                SignatureKind.FIXED_COLLECTION_PARAMETER
+            ),
+        ),
+        "containsKey" to listOf(
+            // boolean containsKey(Object key)
+            SignatureProcessor(
+                StandardNames.FqNames.map,
+                "(Ljava/lang/Object;)Z",
+                SignatureKind.NON_GENERIC
+            ),
+        ),
+        "containsValue" to listOf(
+            // boolean containsValue(Object value)
+            SignatureProcessor(
+                StandardNames.FqNames.map,
+                "(Ljava/lang/Object;)Z",
+                SignatureKind.NON_GENERIC
+            ),
+        ),
+        "get" to listOf(
+            // V get(Object key)
+            // Match the first parameter and ensure that there is only a single parameter.
+            // The return type is generic in both Kotlin and Java.
+            SignatureProcessor(
+                StandardNames.FqNames.map,
+                "(Ljava/lang/Object;)",
+                SignatureKind.FIRST_PARAMETER_ERASED
+            )
+        ),
+        "getOrDefault" to listOf(
+            // V getOrDefault(Object key, V defaultValue)
+            // Match the first parameter and ensure that there are two parameters. This check
+            // could be more precise, but it's unnecessary since we will check afterwards that
+            // any matching function overrides a `getOrDefault` method in `Map`.
+            // Note that this check is required anyway, since `getOrDefault` is platform specific
+            // and only present when compiling against JDK 1.8+.
+            SignatureProcessor(
+                StandardNames.FqNames.map,
+                "(Ljava/lang/Object;",
+                SignatureKind.FIRST_PARAMETER_ERASED
+            ) { method ->
+                method.argumentTypes.size == 2
+            },
+        ),
+        "indexOf" to listOf(
+            // int indexOf(Object o)
+            SignatureProcessor(
+                StandardNames.FqNames.list,
+                "(Ljava/lang/Object;)I",
+                SignatureKind.NON_GENERIC
+            ),
+        ),
+        "lastIndexOf" to listOf(
+            // int lastIndexOf(Object o)
+            SignatureProcessor(
+                StandardNames.FqNames.list,
+                "(Ljava/lang/Object;)I",
+                SignatureKind.NON_GENERIC
+            ),
+        ),
+        "remove" to listOf(
+            // boolean remove(Object o)
+            SignatureProcessor(
+                StandardNames.FqNames.mutableCollection,
+                "(Ljava/lang/Object;)Z",
+                SignatureKind.NON_GENERIC
+            ),
+            // V remove(Object key)
+            // Match the first parameter and ensure that there is only a single parameter.
+            // The return type is generic in both Kotlin and Java.
+            SignatureProcessor(
+                StandardNames.FqNames.mutableMap,
+                "(Ljava/lang/Object;)",
+                SignatureKind.FIRST_PARAMETER_ERASED
+            ),
+            // boolean remove(Object key, Object value)
+            // This declaration is platform specific and only present on JDK 1.8+.
+            // We check that the function overrides `remove` in `MutableMap` to avoid
+            // erasing generic signatures when compiling against older JDK versions.
+            SignatureProcessor(
+                StandardNames.FqNames.mutableMap,
+                "(Ljava/lang/Object;Ljava/lang/Object;)Z",
+                SignatureKind.NON_GENERIC
+            ),
+        ),
+        "removeAll" to listOf(
+            // boolean removeAll(Collection<?> c)
+            SignatureProcessor(
+                StandardNames.FqNames.mutableCollection,
+                "(Ljava/util/Collection;)Z",
+                SignatureKind.FIXED_COLLECTION_PARAMETER
+            ),
+        ),
+        "retainAll" to listOf(
+            // boolean retainAll(Collection<?> c)
+            SignatureProcessor(
+                StandardNames.FqNames.mutableCollection,
+                "(Ljava/util/Collection;)Z",
+                SignatureKind.FIXED_COLLECTION_PARAMETER
+            ),
+        ),
+    )
+}

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/mapping/GenericSignatureMapper.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/mapping/GenericSignatureMapper.kt
@@ -34,7 +34,7 @@ object GenericSignatureMapper {
 
         fun process(signature: String): String? = when (kind) {
             SignatureKind.NON_GENERIC -> null
-            SignatureKind.FIXED_COLLECTION_PARAMETER -> "(Ljava/util/Collection<+Ljava/lang/Object;>;)Z"
+            SignatureKind.FIXED_COLLECTION_PARAMETER -> "(Ljava/util/Collection<*>;)Z"
             SignatureKind.FIRST_PARAMETER_ERASED -> "(Ljava/lang/Object;${signature.substringAfter(';')}"
         }
     }

--- a/compiler/testData/codegen/box/bridges/kt52929.kt
+++ b/compiler/testData/codegen/box/bridges/kt52929.kt
@@ -1,0 +1,16 @@
+// TARGET_BACKEND: JVM
+// WITH_STDLIB
+// FILE: lib.kt
+
+open class KotlinCollection<T> : Collection<T> by emptyList<T>()
+class BreakGenericSignatures : KotlinCollection<String>()
+
+// FILE: JavaCollection.java
+
+public class JavaCollection extends KotlinCollection<String> {
+    public String result() { return "OK"; }
+}
+
+// FILE: main.kt
+
+fun box(): String = JavaCollection().result()

--- a/compiler/testData/codegen/box/bridges/kt52929_platformDependent.kt
+++ b/compiler/testData/codegen/box/bridges/kt52929_platformDependent.kt
@@ -1,0 +1,31 @@
+// TARGET_BACKEND: JVM
+// WITH_STDLIB
+// FULL_JDK
+// JVM_TARGET: 1.8
+// IGNORE_BACKEND: JVM
+// FILE: lib.kt
+
+open class KotlinMap<K> : MutableMap<K, String> by mutableMapOf() {
+    override fun getOrDefault(key: K, value: String): String = value
+    override fun remove(key: K, value: String): Boolean = false
+}
+
+class BreakGenericSignatures : KotlinMap<String>()
+
+// FILE: JavaMap.java
+
+public class JavaMap extends KotlinMap<Integer> {
+    public String result() { return "OK"; }
+
+    public String getOrDefault(Object key, String value) {
+        return null;
+    }
+
+    public boolean remove(Integer key, String value) {
+        return false;
+    }
+}
+
+// FILE: main.kt
+
+fun box(): String = JavaMap().result()

--- a/compiler/testData/codegen/box/bridges/specialBridgeTypesJava.kt
+++ b/compiler/testData/codegen/box/bridges/specialBridgeTypesJava.kt
@@ -1,0 +1,23 @@
+// TARGET_BACKEND: JVM
+// WITH_STDLIB
+// IGNORE_BACKEND: JVM
+// FILE: lib.kt
+
+abstract class AbstractStringMap<K> : Map<K, String>
+class KotlinMap<K> : AbstractStringMap<K>(), MutableMap<K, String> by mutableMapOf()
+
+// FILE: UseMap.java
+
+public class UseMap {
+    public static <K> String first(AbstractStringMap<K> map) {
+        return map.getEntries().iterator().next().getValue();
+    }
+}
+
+// FILE: main.kt
+
+fun box(): String {
+    val map = KotlinMap<Int>()
+    map[0] = "OK"
+    return UseMap.first(map)
+}

--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/abstractStubSignatures/byteShortMap_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/abstractStubSignatures/byteShortMap_ir.txt
@@ -1,9 +1,12 @@
 @kotlin.Metadata
 public abstract class<Ljava/lang/Object;Ljava/util/Map<Ljava/lang/Byte;Ljava/lang/Short;>;Lkotlin/jvm/internal/markers/KMappedMarker;>  ByteShortMap {
     // source: 'byteShortMap.kt'
+    public abstract <()Ljava/util/Collection<Ljava/lang/Short;>;> method getValues(): java.util.Collection
     public bridge final <()Ljava/util/Collection<Ljava/lang/Short;>;> method values(): java.util.Collection
+    public abstract <()Ljava/util/Set<Ljava/lang/Byte;>;> method getKeys(): java.util.Set
     public bridge final <()Ljava/util/Set<Ljava/lang/Byte;>;> method keySet(): java.util.Set
     public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/Byte;Ljava/lang/Short;>;>;> method entrySet(): java.util.Set
+    public abstract <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/Byte;Ljava/lang/Short;>;>;> method getEntries(): java.util.Set
     public <(Ljava/util/Map<+Ljava/lang/Byte;+Ljava/lang/Short;>;)V> method putAll(p0: java.util.Map): void
     public <null> method <init>(): void
     public <null> method clear(): void
@@ -14,10 +17,7 @@ public abstract class<Ljava/lang/Object;Ljava/util/Map<Ljava/lang/Byte;Ljava/lan
     public abstract <null> method get(p0: byte): java.lang.Short
     public synthetic bridge final <null> method get(p0: java.lang.Object): java.lang.Object
     public bridge final <null> method get(p0: java.lang.Object): java.lang.Short
-    public abstract <null> method getEntries(): java.util.Set
-    public abstract <null> method getKeys(): java.util.Set
     public abstract <null> method getSize(): int
-    public abstract <null> method getValues(): java.util.Collection
     public <null> method put(p0: byte, p1: short): java.lang.Short
     public synthetic bridge <null> method put(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
     public synthetic bridge <null> method remove(p0: java.lang.Object): java.lang.Object

--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/abstractStubSignatures/byteShortMutableMap_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/abstractStubSignatures/byteShortMutableMap_ir.txt
@@ -1,9 +1,12 @@
 @kotlin.Metadata
 public abstract class<Ljava/lang/Object;Ljava/util/Map<Ljava/lang/Byte;Ljava/lang/Short;>;Lkotlin/jvm/internal/markers/KMutableMap;>  ByteShortMutableMap {
     // source: 'byteShortMutableMap.kt'
+    public abstract <()Ljava/util/Collection<Ljava/lang/Short;>;> method getValues(): java.util.Collection
     public bridge final <()Ljava/util/Collection<Ljava/lang/Short;>;> method values(): java.util.Collection
+    public abstract <()Ljava/util/Set<Ljava/lang/Byte;>;> method getKeys(): java.util.Set
     public bridge final <()Ljava/util/Set<Ljava/lang/Byte;>;> method keySet(): java.util.Set
     public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/Byte;Ljava/lang/Short;>;>;> method entrySet(): java.util.Set
+    public abstract <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/Byte;Ljava/lang/Short;>;>;> method getEntries(): java.util.Set
     public <null> method <init>(): void
     public abstract <null> method containsKey(p0: byte): boolean
     public bridge final <null> method containsKey(p0: java.lang.Object): boolean
@@ -12,10 +15,7 @@ public abstract class<Ljava/lang/Object;Ljava/util/Map<Ljava/lang/Byte;Ljava/lan
     public abstract <null> method get(p0: byte): java.lang.Short
     public synthetic bridge final <null> method get(p0: java.lang.Object): java.lang.Object
     public bridge final <null> method get(p0: java.lang.Object): java.lang.Short
-    public abstract <null> method getEntries(): java.util.Set
-    public abstract <null> method getKeys(): java.util.Set
     public abstract <null> method getSize(): int
-    public abstract <null> method getValues(): java.util.Collection
     public abstract <null> method remove(p0: byte): java.lang.Short
     public synthetic bridge final <null> method remove(p0: java.lang.Object): java.lang.Object
     public bridge final <null> method remove(p0: java.lang.Object): java.lang.Short

--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/abstractStubSignatures/collection_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/abstractStubSignatures/collection_ir.txt
@@ -2,9 +2,9 @@
 public abstract class<Ljava/lang/Object;Ljava/util/Collection<Ljava/lang/Double;>;Lkotlin/jvm/internal/markers/KMappedMarker;>  DoubleCollection {
     // source: 'collection.kt'
     public <()Ljava/util/Iterator<Ljava/lang/Double;>;> method iterator(): java.util.Iterator
+    public <(Ljava/util/Collection<*>;)Z> method removeAll(p0: java.util.Collection): boolean
+    public <(Ljava/util/Collection<*>;)Z> method retainAll(p0: java.util.Collection): boolean
     public <(Ljava/util/Collection<+Ljava/lang/Double;>;)Z> method addAll(p0: java.util.Collection): boolean
-    public <(Ljava/util/Collection<+Ljava/lang/Object;>;)Z> method removeAll(p0: java.util.Collection): boolean
-    public <(Ljava/util/Collection<+Ljava/lang/Object;>;)Z> method retainAll(p0: java.util.Collection): boolean
     public <<T:Ljava/lang/Object;>([TT;)[TT;> method toArray(p0: java.lang.Object[]): java.lang.Object[]
     public <null> method <init>(): void
     public <null> method add(p0: double): boolean
@@ -22,8 +22,8 @@ public abstract class<Ljava/lang/Object;Ljava/util/Collection<Ljava/lang/Double;
 public abstract class<Ljava/lang/Object;Ljava/util/Collection<Ljava/lang/String;>;Lkotlin/jvm/internal/markers/KMappedMarker;>  StringCollection {
     // source: 'collection.kt'
     public <()Ljava/util/Iterator<Ljava/lang/String;>;> method iterator(): java.util.Iterator
-    public <(Ljava/util/Collection<+Ljava/lang/Object;>;)Z> method removeAll(p0: java.util.Collection): boolean
-    public <(Ljava/util/Collection<+Ljava/lang/Object;>;)Z> method retainAll(p0: java.util.Collection): boolean
+    public <(Ljava/util/Collection<*>;)Z> method removeAll(p0: java.util.Collection): boolean
+    public <(Ljava/util/Collection<*>;)Z> method retainAll(p0: java.util.Collection): boolean
     public <(Ljava/util/Collection<+Ljava/lang/String;>;)Z> method addAll(p0: java.util.Collection): boolean
     public <<T:Ljava/lang/Object;>([TT;)[TT;> method toArray(p0: java.lang.Object[]): java.lang.Object[]
     public <null> method <init>(): void

--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/abstractStubSignatures/genericCollection_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/abstractStubSignatures/genericCollection_ir.txt
@@ -2,8 +2,8 @@
 public abstract class<<T:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/Collection<TT;>;Lkotlin/jvm/internal/markers/KMappedMarker;>  GenericCollection {
     // source: 'genericCollection.kt'
     public <()Ljava/util/Iterator<TT;>;> method iterator(): java.util.Iterator
-    public <(Ljava/util/Collection<+Ljava/lang/Object;>;)Z> method removeAll(p0: java.util.Collection): boolean
-    public <(Ljava/util/Collection<+Ljava/lang/Object;>;)Z> method retainAll(p0: java.util.Collection): boolean
+    public <(Ljava/util/Collection<*>;)Z> method removeAll(p0: java.util.Collection): boolean
+    public <(Ljava/util/Collection<*>;)Z> method retainAll(p0: java.util.Collection): boolean
     public <(Ljava/util/Collection<+TT;>;)Z> method addAll(p0: java.util.Collection): boolean
     public <(TT;)Z> method add(p0: java.lang.Object): boolean
     public <<T:Ljava/lang/Object;>([TT;)[TT;> method toArray(p0: java.lang.Object[]): java.lang.Object[]

--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/abstractStubSignatures/genericMap_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/abstractStubSignatures/genericMap_ir.txt
@@ -1,17 +1,17 @@
 @kotlin.Metadata
 public abstract class<<K:Ljava/lang/Object;V:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/Map<TK;TV;>;Lkotlin/jvm/internal/markers/KMappedMarker;>  GenericMap {
     // source: 'genericMap.kt'
+    public abstract <()Ljava/util/Collection<TV;>;> method getValues(): java.util.Collection
     public bridge final <()Ljava/util/Collection<TV;>;> method values(): java.util.Collection
     public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<TK;TV;>;>;> method entrySet(): java.util.Set
+    public abstract <()Ljava/util/Set<Ljava/util/Map$Entry<TK;TV;>;>;> method getEntries(): java.util.Set
+    public abstract <()Ljava/util/Set<TK;>;> method getKeys(): java.util.Set
     public bridge final <()Ljava/util/Set<TK;>;> method keySet(): java.util.Set
     public <(Ljava/lang/Object;)TV;> method remove(p0: java.lang.Object): java.lang.Object
     public <(Ljava/util/Map<+TK;+TV;>;)V> method putAll(p0: java.util.Map): void
     public <(TK;TV;)TV;> method put(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
     public <null> method <init>(): void
     public <null> method clear(): void
-    public abstract <null> method getEntries(): java.util.Set
-    public abstract <null> method getKeys(): java.util.Set
     public abstract <null> method getSize(): int
-    public abstract <null> method getValues(): java.util.Collection
     public bridge final <null> method size(): int
 }

--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/abstractStubSignatures/genericMutableList_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/abstractStubSignatures/genericMutableList_ir.txt
@@ -2,10 +2,10 @@
 public abstract class<<T:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/List<TT;>;Lkotlin/jvm/internal/markers/KMutableList;>  GenericMutableList {
     // source: 'genericMutableList.kt'
     public bridge final <(I)TT;> method remove(p0: int): java.lang.Object
+    public abstract <(I)TT;> method removeAt(p0: int): java.lang.Object
     public <<T:Ljava/lang/Object;>([TT;)[TT;> method toArray(p0: java.lang.Object[]): java.lang.Object[]
     public <null> method <init>(): void
     public abstract <null> method getSize(): int
-    public abstract <null> method removeAt(p0: int): java.lang.Object
     public bridge final <null> method size(): int
     public <null> method toArray(): java.lang.Object[]
 }

--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/abstractStubSignatures/genericMutableMap_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/abstractStubSignatures/genericMutableMap_ir.txt
@@ -1,13 +1,13 @@
 @kotlin.Metadata
 public abstract class<<K:Ljava/lang/Object;V:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/Map<TK;TV;>;Lkotlin/jvm/internal/markers/KMutableMap;>  GenericMutableMap {
     // source: 'genericMutableMap.kt'
+    public abstract <()Ljava/util/Collection<TV;>;> method getValues(): java.util.Collection
     public bridge final <()Ljava/util/Collection<TV;>;> method values(): java.util.Collection
     public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<TK;TV;>;>;> method entrySet(): java.util.Set
+    public abstract <()Ljava/util/Set<Ljava/util/Map$Entry<TK;TV;>;>;> method getEntries(): java.util.Set
+    public abstract <()Ljava/util/Set<TK;>;> method getKeys(): java.util.Set
     public bridge final <()Ljava/util/Set<TK;>;> method keySet(): java.util.Set
     public <null> method <init>(): void
-    public abstract <null> method getEntries(): java.util.Set
-    public abstract <null> method getKeys(): java.util.Set
     public abstract <null> method getSize(): int
-    public abstract <null> method getValues(): java.util.Collection
     public bridge final <null> method size(): int
 }

--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/abstractStubSignatures/genericStringMap_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/abstractStubSignatures/genericStringMap_ir.txt
@@ -1,8 +1,11 @@
 @kotlin.Metadata
 public abstract class<<K:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/Map<TK;Ljava/lang/String;>;Lkotlin/jvm/internal/markers/KMappedMarker;>  GenericStringMap {
     // source: 'genericStringMap.kt'
+    public abstract <()Ljava/util/Collection<Ljava/lang/String;>;> method getValues(): java.util.Collection
     public bridge final <()Ljava/util/Collection<Ljava/lang/String;>;> method values(): java.util.Collection
     public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<TK;Ljava/lang/String;>;>;> method entrySet(): java.util.Set
+    public abstract <()Ljava/util/Set<Ljava/util/Map$Entry<TK;Ljava/lang/String;>;>;> method getEntries(): java.util.Set
+    public abstract <()Ljava/util/Set<TK;>;> method getKeys(): java.util.Set
     public bridge final <()Ljava/util/Set<TK;>;> method keySet(): java.util.Set
     public <(Ljava/util/Map<+TK;+Ljava/lang/String;>;)V> method putAll(p0: java.util.Map): void
     public <(TK;Ljava/lang/String;)Ljava/lang/String;> method put(p0: java.lang.Object, p1: java.lang.String): java.lang.String
@@ -11,10 +14,7 @@ public abstract class<<K:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/Map<TK;
     public bridge final <null> method containsValue(p0: java.lang.Object): boolean
     public abstract <null> method containsValue(p0: java.lang.String): boolean
     public synthetic bridge <null> method get(p0: java.lang.Object): java.lang.Object
-    public abstract <null> method getEntries(): java.util.Set
-    public abstract <null> method getKeys(): java.util.Set
     public abstract <null> method getSize(): int
-    public abstract <null> method getValues(): java.util.Collection
     public synthetic bridge <null> method put(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
     public synthetic bridge <null> method remove(p0: java.lang.Object): java.lang.Object
     public <null> method remove(p0: java.lang.Object): java.lang.String

--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/abstractStubSignatures/genericStringMutableMap_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/abstractStubSignatures/genericStringMutableMap_ir.txt
@@ -1,17 +1,17 @@
 @kotlin.Metadata
 public abstract class<<K:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/Map<TK;Ljava/lang/String;>;Lkotlin/jvm/internal/markers/KMutableMap;>  GenericStringMutableMap {
     // source: 'genericStringMutableMap.kt'
+    public abstract <()Ljava/util/Collection<Ljava/lang/String;>;> method getValues(): java.util.Collection
     public bridge final <()Ljava/util/Collection<Ljava/lang/String;>;> method values(): java.util.Collection
     public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<TK;Ljava/lang/String;>;>;> method entrySet(): java.util.Set
+    public abstract <()Ljava/util/Set<Ljava/util/Map$Entry<TK;Ljava/lang/String;>;>;> method getEntries(): java.util.Set
+    public abstract <()Ljava/util/Set<TK;>;> method getKeys(): java.util.Set
     public bridge final <()Ljava/util/Set<TK;>;> method keySet(): java.util.Set
     public <null> method <init>(): void
     public bridge final <null> method containsValue(p0: java.lang.Object): boolean
     public abstract <null> method containsValue(p0: java.lang.String): boolean
     public synthetic bridge <null> method get(p0: java.lang.Object): java.lang.Object
-    public abstract <null> method getEntries(): java.util.Set
-    public abstract <null> method getKeys(): java.util.Set
     public abstract <null> method getSize(): int
-    public abstract <null> method getValues(): java.util.Collection
     public synthetic bridge <null> method remove(p0: java.lang.Object): java.lang.Object
     public bridge final <null> method size(): int
 }

--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/abstractStubSignatures/list_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/abstractStubSignatures/list_ir.txt
@@ -5,9 +5,9 @@ public abstract class<Ljava/lang/Object;Ljava/util/List<Ljava/lang/Double;>;Lkot
     public <(I)Ljava/util/ListIterator<Ljava/lang/Double;>;> method listIterator(p0: int): java.util.ListIterator
     public <(II)Ljava/util/List<Ljava/lang/Double;>;> method subList(p0: int, p1: int): java.util.List
     public <(ILjava/util/Collection<+Ljava/lang/Double;>;)Z> method addAll(p0: int, p1: java.util.Collection): boolean
+    public <(Ljava/util/Collection<*>;)Z> method removeAll(p0: java.util.Collection): boolean
+    public <(Ljava/util/Collection<*>;)Z> method retainAll(p0: java.util.Collection): boolean
     public <(Ljava/util/Collection<+Ljava/lang/Double;>;)Z> method addAll(p0: java.util.Collection): boolean
-    public <(Ljava/util/Collection<+Ljava/lang/Object;>;)Z> method removeAll(p0: java.util.Collection): boolean
-    public <(Ljava/util/Collection<+Ljava/lang/Object;>;)Z> method retainAll(p0: java.util.Collection): boolean
     public <<T:Ljava/lang/Object;>([TT;)[TT;> method toArray(p0: java.lang.Object[]): java.lang.Object[]
     public <null> method <init>(): void
     public <null> method add(p0: double): boolean
@@ -41,8 +41,8 @@ public abstract class<<T:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/List<TT
     public <(ILjava/util/Collection<+TT;>;)Z> method addAll(p0: int, p1: java.util.Collection): boolean
     public <(ITT;)TT;> method set(p0: int, p1: java.lang.Object): java.lang.Object
     public <(ITT;)V> method add(p0: int, p1: java.lang.Object): void
-    public <(Ljava/util/Collection<+Ljava/lang/Object;>;)Z> method removeAll(p0: java.util.Collection): boolean
-    public <(Ljava/util/Collection<+Ljava/lang/Object;>;)Z> method retainAll(p0: java.util.Collection): boolean
+    public <(Ljava/util/Collection<*>;)Z> method removeAll(p0: java.util.Collection): boolean
+    public <(Ljava/util/Collection<*>;)Z> method retainAll(p0: java.util.Collection): boolean
     public <(Ljava/util/Collection<+TT;>;)Z> method addAll(p0: java.util.Collection): boolean
     public <(TT;)Z> method add(p0: java.lang.Object): boolean
     public <<T:Ljava/lang/Object;>([TT;)[TT;> method toArray(p0: java.lang.Object[]): java.lang.Object[]
@@ -61,8 +61,8 @@ public abstract class<Ljava/lang/Object;Ljava/util/List<Ljava/lang/String;>;Lkot
     public <(I)Ljava/util/ListIterator<Ljava/lang/String;>;> method listIterator(p0: int): java.util.ListIterator
     public <(II)Ljava/util/List<Ljava/lang/String;>;> method subList(p0: int, p1: int): java.util.List
     public <(ILjava/util/Collection<+Ljava/lang/String;>;)Z> method addAll(p0: int, p1: java.util.Collection): boolean
-    public <(Ljava/util/Collection<+Ljava/lang/Object;>;)Z> method removeAll(p0: java.util.Collection): boolean
-    public <(Ljava/util/Collection<+Ljava/lang/Object;>;)Z> method retainAll(p0: java.util.Collection): boolean
+    public <(Ljava/util/Collection<*>;)Z> method removeAll(p0: java.util.Collection): boolean
+    public <(Ljava/util/Collection<*>;)Z> method retainAll(p0: java.util.Collection): boolean
     public <(Ljava/util/Collection<+Ljava/lang/String;>;)Z> method addAll(p0: java.util.Collection): boolean
     public <<T:Ljava/lang/Object;>([TT;)[TT;> method toArray(p0: java.lang.Object[]): java.lang.Object[]
     public <null> method <init>(): void

--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/abstractStubSignatures/numberStringMap_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/abstractStubSignatures/numberStringMap_ir.txt
@@ -1,9 +1,12 @@
 @kotlin.Metadata
 public abstract class<Ljava/lang/Object;Ljava/util/Map<Ljava/lang/Number;Ljava/lang/String;>;Lkotlin/jvm/internal/markers/KMappedMarker;>  NumberStringMap {
     // source: 'numberStringMap.kt'
+    public abstract <()Ljava/util/Collection<Ljava/lang/String;>;> method getValues(): java.util.Collection
     public bridge final <()Ljava/util/Collection<Ljava/lang/String;>;> method values(): java.util.Collection
+    public abstract <()Ljava/util/Set<Ljava/lang/Number;>;> method getKeys(): java.util.Set
     public bridge final <()Ljava/util/Set<Ljava/lang/Number;>;> method keySet(): java.util.Set
     public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/Number;Ljava/lang/String;>;>;> method entrySet(): java.util.Set
+    public abstract <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/Number;Ljava/lang/String;>;>;> method getEntries(): java.util.Set
     public <(Ljava/util/Map<+Ljava/lang/Number;+Ljava/lang/String;>;)V> method putAll(p0: java.util.Map): void
     public <null> method <init>(): void
     public <null> method clear(): void
@@ -14,10 +17,7 @@ public abstract class<Ljava/lang/Object;Ljava/util/Map<Ljava/lang/Number;Ljava/l
     public abstract <null> method get(p0: java.lang.Number): java.lang.String
     public synthetic bridge final <null> method get(p0: java.lang.Object): java.lang.Object
     public bridge final <null> method get(p0: java.lang.Object): java.lang.String
-    public abstract <null> method getEntries(): java.util.Set
-    public abstract <null> method getKeys(): java.util.Set
     public abstract <null> method getSize(): int
-    public abstract <null> method getValues(): java.util.Collection
     public <null> method put(p0: java.lang.Number, p1: java.lang.String): java.lang.String
     public synthetic bridge <null> method put(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
     public synthetic bridge <null> method remove(p0: java.lang.Object): java.lang.Object

--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/abstractStubSignatures/numberStringMutableMap_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/abstractStubSignatures/numberStringMutableMap_ir.txt
@@ -1,9 +1,12 @@
 @kotlin.Metadata
 public abstract class<Ljava/lang/Object;Ljava/util/Map<Ljava/lang/Number;Ljava/lang/String;>;Lkotlin/jvm/internal/markers/KMutableMap;>  NumberStringMutableMap {
     // source: 'numberStringMutableMap.kt'
+    public abstract <()Ljava/util/Collection<Ljava/lang/String;>;> method getValues(): java.util.Collection
     public bridge final <()Ljava/util/Collection<Ljava/lang/String;>;> method values(): java.util.Collection
+    public abstract <()Ljava/util/Set<Ljava/lang/Number;>;> method getKeys(): java.util.Set
     public bridge final <()Ljava/util/Set<Ljava/lang/Number;>;> method keySet(): java.util.Set
     public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/Number;Ljava/lang/String;>;>;> method entrySet(): java.util.Set
+    public abstract <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/Number;Ljava/lang/String;>;>;> method getEntries(): java.util.Set
     public <null> method <init>(): void
     public abstract <null> method containsKey(p0: java.lang.Number): boolean
     public bridge final <null> method containsKey(p0: java.lang.Object): boolean
@@ -12,10 +15,7 @@ public abstract class<Ljava/lang/Object;Ljava/util/Map<Ljava/lang/Number;Ljava/l
     public abstract <null> method get(p0: java.lang.Number): java.lang.String
     public synthetic bridge final <null> method get(p0: java.lang.Object): java.lang.Object
     public bridge final <null> method get(p0: java.lang.Object): java.lang.String
-    public abstract <null> method getEntries(): java.util.Set
-    public abstract <null> method getKeys(): java.util.Set
     public abstract <null> method getSize(): int
-    public abstract <null> method getValues(): java.util.Collection
     public abstract <null> method remove(p0: java.lang.Number): java.lang.String
     public synthetic bridge final <null> method remove(p0: java.lang.Object): java.lang.Object
     public bridge final <null> method remove(p0: java.lang.Object): java.lang.String

--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/abstractStubSignatures/set_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/abstractStubSignatures/set_ir.txt
@@ -2,8 +2,8 @@
 public abstract class<<T:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/Set<TT;>;Lkotlin/jvm/internal/markers/KMappedMarker;>  GenericSet {
     // source: 'set.kt'
     public <()Ljava/util/Iterator<TT;>;> method iterator(): java.util.Iterator
-    public <(Ljava/util/Collection<+Ljava/lang/Object;>;)Z> method removeAll(p0: java.util.Collection): boolean
-    public <(Ljava/util/Collection<+Ljava/lang/Object;>;)Z> method retainAll(p0: java.util.Collection): boolean
+    public <(Ljava/util/Collection<*>;)Z> method removeAll(p0: java.util.Collection): boolean
+    public <(Ljava/util/Collection<*>;)Z> method retainAll(p0: java.util.Collection): boolean
     public <(Ljava/util/Collection<+TT;>;)Z> method addAll(p0: java.util.Collection): boolean
     public <(TT;)Z> method add(p0: java.lang.Object): boolean
     public <<T:Ljava/lang/Object;>([TT;)[TT;> method toArray(p0: java.lang.Object[]): java.lang.Object[]
@@ -19,9 +19,9 @@ public abstract class<<T:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/Set<TT;
 public abstract class<Ljava/lang/Object;Ljava/util/Set<Ljava/lang/Integer;>;Lkotlin/jvm/internal/markers/KMappedMarker;>  IntSet {
     // source: 'set.kt'
     public <()Ljava/util/Iterator<Ljava/lang/Integer;>;> method iterator(): java.util.Iterator
+    public <(Ljava/util/Collection<*>;)Z> method removeAll(p0: java.util.Collection): boolean
+    public <(Ljava/util/Collection<*>;)Z> method retainAll(p0: java.util.Collection): boolean
     public <(Ljava/util/Collection<+Ljava/lang/Integer;>;)Z> method addAll(p0: java.util.Collection): boolean
-    public <(Ljava/util/Collection<+Ljava/lang/Object;>;)Z> method removeAll(p0: java.util.Collection): boolean
-    public <(Ljava/util/Collection<+Ljava/lang/Object;>;)Z> method retainAll(p0: java.util.Collection): boolean
     public <<T:Ljava/lang/Object;>([TT;)[TT;> method toArray(p0: java.lang.Object[]): java.lang.Object[]
     public <null> method <init>(): void
     public <null> method add(p0: int): boolean
@@ -39,8 +39,8 @@ public abstract class<Ljava/lang/Object;Ljava/util/Set<Ljava/lang/Integer;>;Lkot
 public abstract class<Ljava/lang/Object;Ljava/util/Set<Ljava/lang/String;>;Lkotlin/jvm/internal/markers/KMappedMarker;>  StringSet {
     // source: 'set.kt'
     public <()Ljava/util/Iterator<Ljava/lang/String;>;> method iterator(): java.util.Iterator
-    public <(Ljava/util/Collection<+Ljava/lang/Object;>;)Z> method removeAll(p0: java.util.Collection): boolean
-    public <(Ljava/util/Collection<+Ljava/lang/Object;>;)Z> method retainAll(p0: java.util.Collection): boolean
+    public <(Ljava/util/Collection<*>;)Z> method removeAll(p0: java.util.Collection): boolean
+    public <(Ljava/util/Collection<*>;)Z> method retainAll(p0: java.util.Collection): boolean
     public <(Ljava/util/Collection<+Ljava/lang/String;>;)Z> method addAll(p0: java.util.Collection): boolean
     public <<T:Ljava/lang/Object;>([TT;)[TT;> method toArray(p0: java.lang.Object[]): java.lang.Object[]
     public <null> method <init>(): void

--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/abstractStubSignatures/specializedGenericMap_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/abstractStubSignatures/specializedGenericMap_ir.txt
@@ -1,18 +1,18 @@
 @kotlin.Metadata
 public abstract class<<K:Ljava/lang/Object;V:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/Map<TK;TV;>;Lkotlin/jvm/internal/markers/KMappedMarker;>  GenericMap {
     // source: 'specializedGenericMap.kt'
+    public abstract <()Ljava/util/Collection<TV;>;> method getValues(): java.util.Collection
     public bridge final <()Ljava/util/Collection<TV;>;> method values(): java.util.Collection
     public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<TK;TV;>;>;> method entrySet(): java.util.Set
+    public abstract <()Ljava/util/Set<Ljava/util/Map$Entry<TK;TV;>;>;> method getEntries(): java.util.Set
+    public abstract <()Ljava/util/Set<TK;>;> method getKeys(): java.util.Set
     public bridge final <()Ljava/util/Set<TK;>;> method keySet(): java.util.Set
     public <(Ljava/lang/Object;)TV;> method remove(p0: java.lang.Object): java.lang.Object
     public <(Ljava/util/Map<+TK;+TV;>;)V> method putAll(p0: java.util.Map): void
     public <(TK;TV;)TV;> method put(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
     public <null> method <init>(): void
     public <null> method clear(): void
-    public abstract <null> method getEntries(): java.util.Set
-    public abstract <null> method getKeys(): java.util.Set
     public abstract <null> method getSize(): int
-    public abstract <null> method getValues(): java.util.Collection
     public bridge final <null> method size(): int
 }
 

--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/abstractStubSignatures/stringGenericMap_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/abstractStubSignatures/stringGenericMap_ir.txt
@@ -1,22 +1,22 @@
 @kotlin.Metadata
 public abstract class<<V:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/Map<Ljava/lang/String;TV;>;Lkotlin/jvm/internal/markers/KMappedMarker;>  StringGenericMap {
     // source: 'stringGenericMap.kt'
+    public abstract <()Ljava/util/Collection<TV;>;> method getValues(): java.util.Collection
     public bridge final <()Ljava/util/Collection<TV;>;> method values(): java.util.Collection
+    public abstract <()Ljava/util/Set<Ljava/lang/String;>;> method getKeys(): java.util.Set
     public bridge final <()Ljava/util/Set<Ljava/lang/String;>;> method keySet(): java.util.Set
     public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/String;TV;>;>;> method entrySet(): java.util.Set
+    public abstract <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/String;TV;>;>;> method getEntries(): java.util.Set
     public bridge final <(Ljava/lang/Object;)TV;> method get(p0: java.lang.Object): java.lang.Object
     public <(Ljava/lang/Object;)TV;> method remove(p0: java.lang.Object): java.lang.Object
+    public abstract <(Ljava/lang/String;)TV;> method get(p0: java.lang.String): java.lang.Object
     public <(Ljava/lang/String;TV;)TV;> method put(p0: java.lang.String, p1: java.lang.Object): java.lang.Object
     public <(Ljava/util/Map<+Ljava/lang/String;+TV;>;)V> method putAll(p0: java.util.Map): void
     public <null> method <init>(): void
     public <null> method clear(): void
     public bridge final <null> method containsKey(p0: java.lang.Object): boolean
     public abstract <null> method containsKey(p0: java.lang.String): boolean
-    public abstract <null> method get(p0: java.lang.String): java.lang.Object
-    public abstract <null> method getEntries(): java.util.Set
-    public abstract <null> method getKeys(): java.util.Set
     public abstract <null> method getSize(): int
-    public abstract <null> method getValues(): java.util.Collection
     public synthetic bridge <null> method put(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
     public bridge final <null> method size(): int
 }

--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/abstractStubSignatures/stringGenericMutableMap_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/abstractStubSignatures/stringGenericMutableMap_ir.txt
@@ -1,19 +1,19 @@
 @kotlin.Metadata
 public abstract class<<V:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/Map<Ljava/lang/String;TV;>;Lkotlin/jvm/internal/markers/KMutableMap;>  StringGenericMutableMap {
     // source: 'stringGenericMutableMap.kt'
+    public abstract <()Ljava/util/Collection<TV;>;> method getValues(): java.util.Collection
     public bridge final <()Ljava/util/Collection<TV;>;> method values(): java.util.Collection
+    public abstract <()Ljava/util/Set<Ljava/lang/String;>;> method getKeys(): java.util.Set
     public bridge final <()Ljava/util/Set<Ljava/lang/String;>;> method keySet(): java.util.Set
     public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/String;TV;>;>;> method entrySet(): java.util.Set
+    public abstract <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/String;TV;>;>;> method getEntries(): java.util.Set
     public bridge final <(Ljava/lang/Object;)TV;> method get(p0: java.lang.Object): java.lang.Object
     public bridge final <(Ljava/lang/Object;)TV;> method remove(p0: java.lang.Object): java.lang.Object
+    public abstract <(Ljava/lang/String;)TV;> method get(p0: java.lang.String): java.lang.Object
+    public abstract <(Ljava/lang/String;)TV;> method remove(p0: java.lang.String): java.lang.Object
     public <null> method <init>(): void
     public bridge final <null> method containsKey(p0: java.lang.Object): boolean
     public abstract <null> method containsKey(p0: java.lang.String): boolean
-    public abstract <null> method get(p0: java.lang.String): java.lang.Object
-    public abstract <null> method getEntries(): java.util.Set
-    public abstract <null> method getKeys(): java.util.Set
     public abstract <null> method getSize(): int
-    public abstract <null> method getValues(): java.util.Collection
-    public abstract <null> method remove(p0: java.lang.String): java.lang.Object
     public bridge final <null> method size(): int
 }

--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/stubLikeMethodSignatures.kt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/stubLikeMethodSignatures.kt
@@ -16,7 +16,7 @@ class MyList<T>(val v: T): List<T> {
     override fun equals(other: Any?): Boolean = false
 
     public fun add(e: T): Boolean = true
-    public fun remove(o: T): Boolean = true
+    public fun remove(o: T): Boolean = true // So apparently there was a bug here, the compiled form contained a generic type which would have tripped up Java subclasses
     public fun addAll(c: Collection<T>): Boolean = true
     public fun addAll(index: Int, c: Collection<T>): Boolean = true
     public fun removeAll(c: Collection<T>): Boolean = true

--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/stubLikeMethodSignatures_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/stubLikeMethodSignatures_ir.txt
@@ -12,9 +12,9 @@ public final class<<T:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/List<TT;>;
     public final <(ILjava/util/Collection<+TT;>;)Z> method addAll(p0: int, @org.jetbrains.annotations.NotNull p1: java.util.Collection): boolean
     public final <(ITT;)TT;> method set(p0: int, p1: java.lang.Object): java.lang.Object
     public final <(ITT;)V> method add(p0: int, p1: java.lang.Object): void
-    public <(Ljava/util/Collection<+Ljava/lang/Object;>;)Z> method containsAll(@org.jetbrains.annotations.NotNull p0: java.util.Collection): boolean
-    public final <(Ljava/util/Collection<+Ljava/lang/Object;>;)Z> method removeAll(@org.jetbrains.annotations.NotNull p0: java.util.Collection): boolean
-    public final <(Ljava/util/Collection<+Ljava/lang/Object;>;)Z> method retainAll(@org.jetbrains.annotations.NotNull p0: java.util.Collection): boolean
+    public <(Ljava/util/Collection<*>;)Z> method containsAll(@org.jetbrains.annotations.NotNull p0: java.util.Collection): boolean
+    public final <(Ljava/util/Collection<*>;)Z> method removeAll(@org.jetbrains.annotations.NotNull p0: java.util.Collection): boolean
+    public final <(Ljava/util/Collection<*>;)Z> method retainAll(@org.jetbrains.annotations.NotNull p0: java.util.Collection): boolean
     public final <(Ljava/util/Collection<+TT;>;)Z> method addAll(@org.jetbrains.annotations.NotNull p0: java.util.Collection): boolean
     public <(TT;)V> method <init>(p0: java.lang.Object): void
     public final <(TT;)Z> method add(p0: java.lang.Object): boolean

--- a/compiler/testData/codegen/bytecodeListing/collectionStubs/stubLikeMethodSignatures_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/collectionStubs/stubLikeMethodSignatures_ir.txt
@@ -1,0 +1,34 @@
+@kotlin.Metadata
+public final class<<T:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/List<TT;>;Lkotlin/jvm/internal/markers/KMappedMarker;>  MyList {
+    // source: 'stubLikeMethodSignatures.kt'
+    public @org.jetbrains.annotations.NotNull <()Ljava/util/Iterator<TT;>;> method iterator(): java.util.Iterator
+    public @org.jetbrains.annotations.NotNull <()Ljava/util/ListIterator<TT;>;> method listIterator(): java.util.ListIterator
+    public final <()TT;> method getV(): java.lang.Object
+    public @org.jetbrains.annotations.NotNull <(I)Ljava/util/ListIterator<TT;>;> method listIterator(p0: int): java.util.ListIterator
+    public <(I)TT;> method get(p0: int): java.lang.Object
+    public bridge final <(I)TT;> method remove(p0: int): java.lang.Object
+    public final <(I)TT;> method removeAt(p0: int): java.lang.Object
+    public @org.jetbrains.annotations.NotNull <(II)Ljava/util/List<TT;>;> method subList(p0: int, p1: int): java.util.List
+    public final <(ILjava/util/Collection<+TT;>;)Z> method addAll(p0: int, @org.jetbrains.annotations.NotNull p1: java.util.Collection): boolean
+    public final <(ITT;)TT;> method set(p0: int, p1: java.lang.Object): java.lang.Object
+    public final <(ITT;)V> method add(p0: int, p1: java.lang.Object): void
+    public <(Ljava/util/Collection<+Ljava/lang/Object;>;)Z> method containsAll(@org.jetbrains.annotations.NotNull p0: java.util.Collection): boolean
+    public final <(Ljava/util/Collection<+Ljava/lang/Object;>;)Z> method removeAll(@org.jetbrains.annotations.NotNull p0: java.util.Collection): boolean
+    public final <(Ljava/util/Collection<+Ljava/lang/Object;>;)Z> method retainAll(@org.jetbrains.annotations.NotNull p0: java.util.Collection): boolean
+    public final <(Ljava/util/Collection<+TT;>;)Z> method addAll(@org.jetbrains.annotations.NotNull p0: java.util.Collection): boolean
+    public <(TT;)V> method <init>(p0: java.lang.Object): void
+    public final <(TT;)Z> method add(p0: java.lang.Object): boolean
+    public <<T:Ljava/lang/Object;>([TT;)[TT;> method toArray(p0: java.lang.Object[]): java.lang.Object[]
+    public final <null> method clear(): void
+    public <null> method contains(p0: java.lang.Object): boolean
+    public <null> method equals(@org.jetbrains.annotations.Nullable p0: java.lang.Object): boolean
+    public <null> method getSize(): int
+    public <null> method hashCode(): int
+    public <null> method indexOf(p0: java.lang.Object): int
+    public <null> method isEmpty(): boolean
+    public <null> method lastIndexOf(p0: java.lang.Object): int
+    public final <null> method remove(p0: java.lang.Object): boolean
+    public bridge final <null> method size(): int
+    public <null> method toArray(): java.lang.Object[]
+    private final field <TT;> v: java.lang.Object
+}

--- a/compiler/testData/codegen/bytecodeListing/specialBridges/signatures/implementsJavaMap_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/specialBridges/signatures/implementsJavaMap_ir.txt
@@ -1,34 +1,34 @@
 @kotlin.Metadata
 public abstract class<<A:Ljava/lang/Object;B:Ljava/lang/Object;>Ljava/lang/Object;LJMap<TA;TB;>;>  JMapImpl {
     // source: 'implementsJavaMap.kt'
+    public abstract <()Ljava/util/Collection<TB;>;> method getValues(): java.util.Collection
     public bridge final <()Ljava/util/Collection<TB;>;> method values(): java.util.Collection
     public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<TA;TB;>;>;> method entrySet(): java.util.Set
+    public abstract <()Ljava/util/Set<Ljava/util/Map$Entry<TA;TB;>;>;> method getEntries(): java.util.Set
+    public abstract <()Ljava/util/Set<TA;>;> method getKeys(): java.util.Set
     public bridge final <()Ljava/util/Set<TA;>;> method keySet(): java.util.Set
     public <null> method <init>(): void
     public <null> method containsKey(p0: java.lang.Object): boolean
-    public abstract <null> method getEntries(): java.util.Set
-    public abstract <null> method getKeys(): java.util.Set
     public abstract <null> method getSize(): int
-    public abstract <null> method getValues(): java.util.Collection
     public bridge final <null> method size(): int
 }
 
 @kotlin.Metadata
 public abstract class<<A:Ljava/lang/Number;B:Ljava/lang/Object;>Ljava/lang/Object;LJMapN<TA;TB;>;>  JMapNImpl {
     // source: 'implementsJavaMap.kt'
+    public abstract <()Ljava/util/Collection<TB;>;> method getValues(): java.util.Collection
     public bridge final <()Ljava/util/Collection<TB;>;> method values(): java.util.Collection
     public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<TA;TB;>;>;> method entrySet(): java.util.Set
+    public abstract <()Ljava/util/Set<Ljava/util/Map$Entry<TA;TB;>;>;> method getEntries(): java.util.Set
+    public abstract <()Ljava/util/Set<TA;>;> method getKeys(): java.util.Set
     public bridge final <()Ljava/util/Set<TA;>;> method keySet(): java.util.Set
     public bridge final <(Ljava/lang/Object;)TB;> method get(p0: java.lang.Object): java.lang.Object
     public bridge final <(Ljava/lang/Object;)TB;> method remove(p0: java.lang.Object): java.lang.Object
+    public abstract <(TA;)TB;> method get(p0: java.lang.Number): java.lang.Object
+    public abstract <(TA;)TB;> method remove(p0: java.lang.Number): java.lang.Object
     public <(TA;)Z> method containsKey(@org.jetbrains.annotations.NotNull p0: java.lang.Number): boolean
     public <null> method <init>(): void
     public bridge final <null> method containsKey(p0: java.lang.Object): boolean
-    public abstract <null> method get(p0: java.lang.Number): java.lang.Object
-    public abstract <null> method getEntries(): java.util.Set
-    public abstract <null> method getKeys(): java.util.Set
     public abstract <null> method getSize(): int
-    public abstract <null> method getValues(): java.util.Collection
-    public abstract <null> method remove(p0: java.lang.Number): java.lang.Object
     public bridge final <null> method size(): int
 }

--- a/compiler/testData/codegen/bytecodeListing/specialBridges/signatures/implementsMap_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/specialBridges/signatures/implementsMap_ir.txt
@@ -1,8 +1,11 @@
 @kotlin.Metadata
 public abstract class<<A:Ljava/lang/Object;B:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/Map<TA;TB;>;Lkotlin/jvm/internal/markers/KMappedMarker;>  MapImpl {
     // source: 'implementsMap.kt'
+    public abstract <()Ljava/util/Collection<TB;>;> method getValues(): java.util.Collection
     public bridge final <()Ljava/util/Collection<TB;>;> method values(): java.util.Collection
     public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<TA;TB;>;>;> method entrySet(): java.util.Set
+    public abstract <()Ljava/util/Set<Ljava/util/Map$Entry<TA;TB;>;>;> method getEntries(): java.util.Set
+    public abstract <()Ljava/util/Set<TA;>;> method getKeys(): java.util.Set
     public bridge final <()Ljava/util/Set<TA;>;> method keySet(): java.util.Set
     public <(Ljava/lang/Object;)TB;> method remove(p0: java.lang.Object): java.lang.Object
     public <(Ljava/util/Map<+TA;+TB;>;)V> method putAll(p0: java.util.Map): void
@@ -10,10 +13,7 @@ public abstract class<<A:Ljava/lang/Object;B:Ljava/lang/Object;>Ljava/lang/Objec
     public <null> method <init>(): void
     public <null> method clear(): void
     public <null> method containsKey(p0: java.lang.Object): boolean
-    public abstract <null> method getEntries(): java.util.Set
-    public abstract <null> method getKeys(): java.util.Set
     public abstract <null> method getSize(): int
-    public abstract <null> method getValues(): java.util.Collection
     public bridge final <null> method size(): int
 }
 
@@ -25,22 +25,22 @@ public interface<<K:Ljava/lang/Number;V:Ljava/lang/Object;>Ljava/lang/Object;Lja
 @kotlin.Metadata
 public abstract class<<A:Ljava/lang/Number;B:Ljava/lang/Object;>Ljava/lang/Object;LMapN<TA;TB;>;>  MapNImpl {
     // source: 'implementsMap.kt'
+    public abstract <()Ljava/util/Collection<TB;>;> method getValues(): java.util.Collection
     public bridge final <()Ljava/util/Collection<TB;>;> method values(): java.util.Collection
     public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<TA;TB;>;>;> method entrySet(): java.util.Set
+    public abstract <()Ljava/util/Set<Ljava/util/Map$Entry<TA;TB;>;>;> method getEntries(): java.util.Set
+    public abstract <()Ljava/util/Set<TA;>;> method getKeys(): java.util.Set
     public bridge final <()Ljava/util/Set<TA;>;> method keySet(): java.util.Set
     public bridge final <(Ljava/lang/Object;)TB;> method get(p0: java.lang.Object): java.lang.Object
     public <(Ljava/lang/Object;)TB;> method remove(p0: java.lang.Object): java.lang.Object
     public <(Ljava/util/Map<+TA;+TB;>;)V> method putAll(p0: java.util.Map): void
+    public abstract <(TA;)TB;> method get(p0: java.lang.Number): java.lang.Object
     public <(TA;)Z> method containsKey(@org.jetbrains.annotations.NotNull p0: java.lang.Number): boolean
     public <(TA;TB;)TB;> method put(p0: java.lang.Number, p1: java.lang.Object): java.lang.Object
     public <null> method <init>(): void
     public <null> method clear(): void
     public bridge final <null> method containsKey(p0: java.lang.Object): boolean
-    public abstract <null> method get(p0: java.lang.Number): java.lang.Object
-    public abstract <null> method getEntries(): java.util.Set
-    public abstract <null> method getKeys(): java.util.Set
     public abstract <null> method getSize(): int
-    public abstract <null> method getValues(): java.util.Collection
     public synthetic bridge <null> method put(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
     public bridge final <null> method size(): int
 }
@@ -48,22 +48,22 @@ public abstract class<<A:Ljava/lang/Number;B:Ljava/lang/Object;>Ljava/lang/Objec
 @kotlin.Metadata
 public abstract class<<B:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/Map<Ljava/lang/String;TB;>;Lkotlin/jvm/internal/markers/KMappedMarker;>  MapSImpl {
     // source: 'implementsMap.kt'
+    public abstract <()Ljava/util/Collection<TB;>;> method getValues(): java.util.Collection
     public bridge final <()Ljava/util/Collection<TB;>;> method values(): java.util.Collection
+    public abstract <()Ljava/util/Set<Ljava/lang/String;>;> method getKeys(): java.util.Set
     public bridge final <()Ljava/util/Set<Ljava/lang/String;>;> method keySet(): java.util.Set
     public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/String;TB;>;>;> method entrySet(): java.util.Set
+    public abstract <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/String;TB;>;>;> method getEntries(): java.util.Set
     public bridge final <(Ljava/lang/Object;)TB;> method get(p0: java.lang.Object): java.lang.Object
     public <(Ljava/lang/Object;)TB;> method remove(p0: java.lang.Object): java.lang.Object
+    public abstract <(Ljava/lang/String;)TB;> method get(p0: java.lang.String): java.lang.Object
     public <(Ljava/lang/String;TB;)TB;> method put(p0: java.lang.String, p1: java.lang.Object): java.lang.Object
     public <(Ljava/util/Map<+Ljava/lang/String;+TB;>;)V> method putAll(p0: java.util.Map): void
     public <null> method <init>(): void
     public <null> method clear(): void
     public <null> method containsKey(@org.jetbrains.annotations.NotNull p0: java.lang.String): boolean
     public bridge final <null> method containsKey(p0: java.lang.Object): boolean
-    public abstract <null> method get(p0: java.lang.String): java.lang.Object
-    public abstract <null> method getEntries(): java.util.Set
-    public abstract <null> method getKeys(): java.util.Set
     public abstract <null> method getSize(): int
-    public abstract <null> method getValues(): java.util.Collection
     public synthetic bridge <null> method put(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
     public bridge final <null> method size(): int
 }

--- a/compiler/testData/codegen/bytecodeListing/specialBridges/signatures/withPlatformDependentDeclarations.kt
+++ b/compiler/testData/codegen/bytecodeListing/specialBridges/signatures/withPlatformDependentDeclarations.kt
@@ -1,0 +1,100 @@
+// FULL_JDK
+// JVM_TARGET: 1.8
+// WITH_SIGNATURES
+interface I
+
+abstract class T1<K, V> : MutableMap<K, V> {
+    // This declaration should have a generic signature (Ljava/lang/Object;TV;)TV; to match the declaration
+    // in java.util.Map
+    override fun getOrDefault(key: K, value: V): V = value
+
+    // This declaration does not override the getOrDefault method in java.util.Map and should have a
+    // normal generic signature of (TK;I)I
+    fun getOrDefault(key: K, value: Int): Int = value + 1
+
+    // This declaration overrides a non-generic method in java.util.Map and should not have a generic signature
+    override fun remove(key: K, value: V): Boolean = false
+
+    // This declaration does not override the remove method in java.util.Map and should have a normal
+    // generic signature of (TK;I)Z
+    fun remove(key: K, value: Int): Boolean = true
+}
+
+abstract class T2<V> : MutableMap<String, V> {
+    // This declaration does not override the corresponding method in java.util.Map and should
+    // have a normal generic signature of
+    //
+    //   (Ljava/lang/String;TV;)TV;
+    //
+    // However, we also generate an additional bridge method with signature
+    //
+    //   (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+    //
+    // to override the corresponding method in java.util.Map. If we generate a generic signature at
+    // all - it's not really checked for bridge methods - it should be
+    //
+    //   (Ljava/lang/Object;TV;)TV;
+    //
+    override fun getOrDefault(key: String, value: V): V = value
+
+    // This does not override the getOrDefault method in java.util.Map and should have a
+    // normal generic signature of (Ljava/lang/Integer;TV;)TV;
+    fun getOrDefault(key: Int?, value: V): V = value
+
+    // This declaration does not override the corresponding method in java.util.Map and should
+    // have a normal generic signature of
+    //
+    //   (Ljava/lang/String;TV;)Z
+    //
+    // However, we also generate an additional non-generic bridge method
+    override fun remove(key: String, value: V): Boolean = false
+
+    // This declaration does not override the remove method in java.util.Map and should have a normal
+    // generic signature of (Ljava/lang/Integer;TV;)Z
+    fun remove(key: Int?, value: V): Boolean = true
+}
+
+abstract class T3<K, V : I> : MutableMap<K, V> {
+    // This declaration overrides the corresponding declaration in java.util.Map and should have
+    // the following modified generic signature.
+    //
+    //   (Ljava/lang/Object;TV;)TV;
+    //
+    // The additional bridge method should have no generic signature or the same one.
+    override fun getOrDefault(key: K, value: V): V = value
+
+    // This declaration overrides nothing and should have the following generic signature.
+    //
+    //   (TK;I)LI;
+    //
+    fun getOrDefault(key: K, value: Int): I? = null
+
+    // This declaration does not override the corresponding declaration in java.util.Map
+    // and should have the following generic signature.
+    //
+    //   (TK;TV;)Z
+    //
+    // The corresponding bridge overrides a non-generic method in java.util.Map and should
+    // not have a generic signature.
+    override fun remove(key: K, value: V): Boolean = false
+
+    // This declaration overrides nothing and should have the following generic signature.
+    //
+    //   (TK;I)Z
+    //
+    fun remove(key: K, value: Int): Boolean = true
+}
+
+abstract class T4<K, V> : Map<K, V> {
+    // This declaration implicitly overrides a non-generic method in java.util.Map and
+    // should not have a generic signature.
+    fun remove(key: K, value: V): Boolean = false
+
+    // The behavior for the remaining declarations is the same as in T1
+    // (Ljava/lang/Object;TV;)TV;
+    override fun getOrDefault(key: K, value: V): V = value
+    // (TK;I)I
+    fun getOrDefault(key: K, value: Int): Int = value + 1
+    // (TK;I)Z
+    fun remove(key: K, value: Int): Boolean = true
+}

--- a/compiler/testData/codegen/bytecodeListing/specialBridges/signatures/withPlatformDependentDeclarations.txt
+++ b/compiler/testData/codegen/bytecodeListing/specialBridges/signatures/withPlatformDependentDeclarations.txt
@@ -1,0 +1,113 @@
+@kotlin.Metadata
+public interface<null>  I {
+    // source: 'withPlatformDependentDeclarations.kt'
+}
+
+@kotlin.Metadata
+public abstract class<<K:Ljava/lang/Object;V:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/Map<TK;TV;>;Lkotlin/jvm/internal/markers/KMutableMap;>  T1 {
+    // source: 'withPlatformDependentDeclarations.kt'
+    public bridge final <()Ljava/util/Collection<TV;>;> method values(): java.util.Collection
+    public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<TK;TV;>;>;> method entrySet(): java.util.Set
+    public bridge final <()Ljava/util/Set<TK;>;> method keySet(): java.util.Set
+    public final <(TK;I)I> method getOrDefault(p0: java.lang.Object, p1: int): int
+    public final <(TK;I)Z> method remove(p0: java.lang.Object, p1: int): boolean
+    public <null> method <init>(): void
+    public abstract <null> method containsKey(p0: java.lang.Object): boolean
+    public abstract <null> method containsValue(p0: java.lang.Object): boolean
+    public abstract <null> method get(p0: java.lang.Object): java.lang.Object
+    public abstract <null> method getEntries(): java.util.Set
+    public abstract <null> method getKeys(): java.util.Set
+    public <null> method getOrDefault(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
+    public abstract <null> method getSize(): int
+    public abstract <null> method getValues(): java.util.Collection
+    public abstract <null> method remove(p0: java.lang.Object): java.lang.Object
+    public <null> method remove(p0: java.lang.Object, p1: java.lang.Object): boolean
+    public bridge final <null> method size(): int
+}
+
+@kotlin.Metadata
+public abstract class<<V:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/Map<Ljava/lang/String;TV;>;Lkotlin/jvm/internal/markers/KMutableMap;>  T2 {
+    // source: 'withPlatformDependentDeclarations.kt'
+    public bridge final <()Ljava/util/Collection<TV;>;> method values(): java.util.Collection
+    public bridge final <()Ljava/util/Set<Ljava/lang/String;>;> method keySet(): java.util.Set
+    public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/String;TV;>;>;> method entrySet(): java.util.Set
+    public final <(Ljava/lang/Integer;TV;)TV;> method getOrDefault(@org.jetbrains.annotations.Nullable p0: java.lang.Integer, p1: java.lang.Object): java.lang.Object
+    public final <(Ljava/lang/Integer;TV;)Z> method remove(@org.jetbrains.annotations.Nullable p0: java.lang.Integer, p1: java.lang.Object): boolean
+    public bridge final <(Ljava/lang/Object;)TV;> method get(p0: java.lang.Object): java.lang.Object
+    public bridge final <(Ljava/lang/Object;)TV;> method remove(p0: java.lang.Object): java.lang.Object
+    public <(Ljava/lang/String;TV;)TV;> method getOrDefault(@org.jetbrains.annotations.NotNull p0: java.lang.String, p1: java.lang.Object): java.lang.Object
+    public <(Ljava/lang/String;TV;)Z> method remove(@org.jetbrains.annotations.NotNull p0: java.lang.String, p1: java.lang.Object): boolean
+    public <null> method <init>(): void
+    public bridge final <null> method containsKey(p0: java.lang.Object): boolean
+    public abstract <null> method containsKey(p0: java.lang.String): boolean
+    public abstract <null> method containsValue(p0: java.lang.Object): boolean
+    public abstract <null> method get(p0: java.lang.String): java.lang.Object
+    public abstract <null> method getEntries(): java.util.Set
+    public abstract <null> method getKeys(): java.util.Set
+    public bridge final <null> method getOrDefault(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
+    public abstract <null> method getSize(): int
+    public abstract <null> method getValues(): java.util.Collection
+    public bridge final <null> method remove(p0: java.lang.Object, p1: java.lang.Object): boolean
+    public abstract <null> method remove(p0: java.lang.String): java.lang.Object
+    public bridge final <null> method size(): int
+}
+
+@kotlin.Metadata
+public abstract class<<K:Ljava/lang/Object;V::LI;>Ljava/lang/Object;Ljava/util/Map<TK;TV;>;Lkotlin/jvm/internal/markers/KMutableMap;>  T3 {
+    // source: 'withPlatformDependentDeclarations.kt'
+    public bridge final <()Ljava/util/Collection<TV;>;> method values(): java.util.Collection
+    public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<TK;TV;>;>;> method entrySet(): java.util.Set
+    public bridge final <()Ljava/util/Set<TK;>;> method keySet(): java.util.Set
+    public bridge final <(Ljava/lang/Object;)TV;> method get(p0: java.lang.Object): java.lang.Object
+    public bridge final <(Ljava/lang/Object;)TV;> method remove(p0: java.lang.Object): java.lang.Object
+    public final @org.jetbrains.annotations.Nullable <(TK;I)LI;> method getOrDefault(p0: java.lang.Object, p1: int): I
+    public final <(TK;I)Z> method remove(p0: java.lang.Object, p1: int): boolean
+    public @org.jetbrains.annotations.NotNull <(TK;TV;)TV;> method getOrDefault(p0: java.lang.Object, @org.jetbrains.annotations.NotNull p1: I): I
+    public <(TK;TV;)Z> method remove(p0: java.lang.Object, @org.jetbrains.annotations.NotNull p1: I): boolean
+    public <null> method <init>(): void
+    public abstract <null> method containsKey(p0: java.lang.Object): boolean
+    public abstract <null> method containsValue(p0: I): boolean
+    public bridge final <null> method containsValue(p0: java.lang.Object): boolean
+    public abstract <null> method get(p0: java.lang.Object): I
+    public abstract <null> method getEntries(): java.util.Set
+    public abstract <null> method getKeys(): java.util.Set
+    public bridge final <null> method getOrDefault(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
+    public abstract <null> method getSize(): int
+    public abstract <null> method getValues(): java.util.Collection
+    public abstract <null> method remove(p0: java.lang.Object): I
+    public bridge final <null> method remove(p0: java.lang.Object, p1: java.lang.Object): boolean
+    public bridge final <null> method size(): int
+}
+
+@kotlin.Metadata
+public abstract class<<K:Ljava/lang/Object;V:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/Map<TK;TV;>;Lkotlin/jvm/internal/markers/KMappedMarker;>  T4 {
+    // source: 'withPlatformDependentDeclarations.kt'
+    public bridge final <()Ljava/util/Collection<TV;>;> method values(): java.util.Collection
+    public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<TK;TV;>;>;> method entrySet(): java.util.Set
+    public bridge final <()Ljava/util/Set<TK;>;> method keySet(): java.util.Set
+    public <(Ljava/lang/Object;)TV;> method remove(p0: java.lang.Object): java.lang.Object
+    public <(Ljava/util/Map<+TK;+TV;>;)V> method putAll(p0: java.util.Map): void
+    public <(Ljava/util/function/BiFunction<-TK;-TV;+TV;>;)V> method replaceAll(p0: java.util.function.BiFunction): void
+    public final <(TK;I)I> method getOrDefault(p0: java.lang.Object, p1: int): int
+    public final <(TK;I)Z> method remove(p0: java.lang.Object, p1: int): boolean
+    public <(TK;Ljava/util/function/BiFunction<-TK;-TV;+TV;>;)TV;> method compute(p0: java.lang.Object, p1: java.util.function.BiFunction): java.lang.Object
+    public <(TK;Ljava/util/function/BiFunction<-TK;-TV;+TV;>;)TV;> method computeIfPresent(p0: java.lang.Object, p1: java.util.function.BiFunction): java.lang.Object
+    public <(TK;Ljava/util/function/Function<-TK;+TV;>;)TV;> method computeIfAbsent(p0: java.lang.Object, p1: java.util.function.Function): java.lang.Object
+    public <(TK;TV;)TV;> method put(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
+    public <(TK;TV;)TV;> method putIfAbsent(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
+    public <(TK;TV;)TV;> method replace(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
+    public final <(TK;TV;)Z> method remove(p0: java.lang.Object, p1: java.lang.Object): boolean
+    public <(TK;TV;Ljava/util/function/BiFunction<-TV;-TV;+TV;>;)TV;> method merge(p0: java.lang.Object, p1: java.lang.Object, p2: java.util.function.BiFunction): java.lang.Object
+    public <(TK;TV;TV;)Z> method replace(p0: java.lang.Object, p1: java.lang.Object, p2: java.lang.Object): boolean
+    public <null> method <init>(): void
+    public <null> method clear(): void
+    public abstract <null> method containsKey(p0: java.lang.Object): boolean
+    public abstract <null> method containsValue(p0: java.lang.Object): boolean
+    public abstract <null> method get(p0: java.lang.Object): java.lang.Object
+    public abstract <null> method getEntries(): java.util.Set
+    public abstract <null> method getKeys(): java.util.Set
+    public <null> method getOrDefault(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
+    public abstract <null> method getSize(): int
+    public abstract <null> method getValues(): java.util.Collection
+    public bridge final <null> method size(): int
+}

--- a/compiler/testData/codegen/bytecodeListing/specialBridges/signatures/withPlatformDependentDeclarations_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/specialBridges/signatures/withPlatformDependentDeclarations_ir.txt
@@ -1,0 +1,102 @@
+@kotlin.Metadata
+public interface<null>  I {
+    // source: 'withPlatformDependentDeclarations.kt'
+}
+
+@kotlin.Metadata
+public abstract class<<K:Ljava/lang/Object;V:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/Map<TK;TV;>;Lkotlin/jvm/internal/markers/KMutableMap;>  T1 {
+    // source: 'withPlatformDependentDeclarations.kt'
+    public abstract <()Ljava/util/Collection<TV;>;> method getValues(): java.util.Collection
+    public bridge final <()Ljava/util/Collection<TV;>;> method values(): java.util.Collection
+    public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<TK;TV;>;>;> method entrySet(): java.util.Set
+    public abstract <()Ljava/util/Set<Ljava/util/Map$Entry<TK;TV;>;>;> method getEntries(): java.util.Set
+    public abstract <()Ljava/util/Set<TK;>;> method getKeys(): java.util.Set
+    public bridge final <()Ljava/util/Set<TK;>;> method keySet(): java.util.Set
+    public <(Ljava/lang/Object;TV;)TV;> method getOrDefault(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
+    public final <(TK;I)I> method getOrDefault(p0: java.lang.Object, p1: int): int
+    public final <(TK;I)Z> method remove(p0: java.lang.Object, p1: int): boolean
+    public <null> method <init>(): void
+    public abstract <null> method getSize(): int
+    public <null> method remove(p0: java.lang.Object, p1: java.lang.Object): boolean
+    public bridge final <null> method size(): int
+}
+
+@kotlin.Metadata
+public abstract class<<V:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/Map<Ljava/lang/String;TV;>;Lkotlin/jvm/internal/markers/KMutableMap;>  T2 {
+    // source: 'withPlatformDependentDeclarations.kt'
+    public abstract <()Ljava/util/Collection<TV;>;> method getValues(): java.util.Collection
+    public bridge final <()Ljava/util/Collection<TV;>;> method values(): java.util.Collection
+    public abstract <()Ljava/util/Set<Ljava/lang/String;>;> method getKeys(): java.util.Set
+    public bridge final <()Ljava/util/Set<Ljava/lang/String;>;> method keySet(): java.util.Set
+    public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/String;TV;>;>;> method entrySet(): java.util.Set
+    public abstract <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/String;TV;>;>;> method getEntries(): java.util.Set
+    public final <(Ljava/lang/Integer;TV;)TV;> method getOrDefault(@org.jetbrains.annotations.Nullable p0: java.lang.Integer, p1: java.lang.Object): java.lang.Object
+    public final <(Ljava/lang/Integer;TV;)Z> method remove(@org.jetbrains.annotations.Nullable p0: java.lang.Integer, p1: java.lang.Object): boolean
+    public bridge final <(Ljava/lang/Object;)TV;> method get(p0: java.lang.Object): java.lang.Object
+    public bridge final <(Ljava/lang/Object;)TV;> method remove(p0: java.lang.Object): java.lang.Object
+    public bridge final <(Ljava/lang/Object;TV;)TV;> method getOrDefault(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
+    public abstract <(Ljava/lang/String;)TV;> method get(p0: java.lang.String): java.lang.Object
+    public abstract <(Ljava/lang/String;)TV;> method remove(p0: java.lang.String): java.lang.Object
+    public <(Ljava/lang/String;TV;)TV;> method getOrDefault(@org.jetbrains.annotations.NotNull p0: java.lang.String, p1: java.lang.Object): java.lang.Object
+    public <(Ljava/lang/String;TV;)Z> method remove(@org.jetbrains.annotations.NotNull p0: java.lang.String, p1: java.lang.Object): boolean
+    public <null> method <init>(): void
+    public bridge final <null> method containsKey(p0: java.lang.Object): boolean
+    public abstract <null> method containsKey(p0: java.lang.String): boolean
+    public abstract <null> method getSize(): int
+    public bridge final <null> method remove(p0: java.lang.Object, p1: java.lang.Object): boolean
+    public bridge final <null> method size(): int
+}
+
+@kotlin.Metadata
+public abstract class<<K:Ljava/lang/Object;V::LI;>Ljava/lang/Object;Ljava/util/Map<TK;TV;>;Lkotlin/jvm/internal/markers/KMutableMap;>  T3 {
+    // source: 'withPlatformDependentDeclarations.kt'
+    public abstract <()Ljava/util/Collection<TV;>;> method getValues(): java.util.Collection
+    public bridge final <()Ljava/util/Collection<TV;>;> method values(): java.util.Collection
+    public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<TK;TV;>;>;> method entrySet(): java.util.Set
+    public abstract <()Ljava/util/Set<Ljava/util/Map$Entry<TK;TV;>;>;> method getEntries(): java.util.Set
+    public abstract <()Ljava/util/Set<TK;>;> method getKeys(): java.util.Set
+    public bridge final <()Ljava/util/Set<TK;>;> method keySet(): java.util.Set
+    public @org.jetbrains.annotations.NotNull <(Ljava/lang/Object;TV;)TV;> method getOrDefault(p0: java.lang.Object, @org.jetbrains.annotations.NotNull p1: I): I
+    public final @org.jetbrains.annotations.Nullable <(TK;I)LI;> method getOrDefault(p0: java.lang.Object, p1: int): I
+    public final <(TK;I)Z> method remove(p0: java.lang.Object, p1: int): boolean
+    public <(TK;TV;)Z> method remove(p0: java.lang.Object, @org.jetbrains.annotations.NotNull p1: I): boolean
+    public abstract <(TV;)Z> method containsValue(p0: I): boolean
+    public <null> method <init>(): void
+    public bridge final <null> method containsValue(p0: java.lang.Object): boolean
+    public synthetic bridge <null> method get(p0: java.lang.Object): java.lang.Object
+    public synthetic bridge <null> method getOrDefault(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
+    public abstract <null> method getSize(): int
+    public synthetic bridge <null> method remove(p0: java.lang.Object): java.lang.Object
+    public bridge final <null> method remove(p0: java.lang.Object, p1: java.lang.Object): boolean
+    public bridge final <null> method size(): int
+}
+
+@kotlin.Metadata
+public abstract class<<K:Ljava/lang/Object;V:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/Map<TK;TV;>;Lkotlin/jvm/internal/markers/KMappedMarker;>  T4 {
+    // source: 'withPlatformDependentDeclarations.kt'
+    public abstract <()Ljava/util/Collection<TV;>;> method getValues(): java.util.Collection
+    public bridge final <()Ljava/util/Collection<TV;>;> method values(): java.util.Collection
+    public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<TK;TV;>;>;> method entrySet(): java.util.Set
+    public abstract <()Ljava/util/Set<Ljava/util/Map$Entry<TK;TV;>;>;> method getEntries(): java.util.Set
+    public abstract <()Ljava/util/Set<TK;>;> method getKeys(): java.util.Set
+    public bridge final <()Ljava/util/Set<TK;>;> method keySet(): java.util.Set
+    public <(Ljava/lang/Object;)TV;> method remove(p0: java.lang.Object): java.lang.Object
+    public <(Ljava/lang/Object;TV;)TV;> method getOrDefault(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
+    public <(Ljava/util/Map<+TK;+TV;>;)V> method putAll(p0: java.util.Map): void
+    public <(Ljava/util/function/BiFunction<-TK;-TV;+TV;>;)V> method replaceAll(p0: java.util.function.BiFunction): void
+    public final <(TK;I)I> method getOrDefault(p0: java.lang.Object, p1: int): int
+    public final <(TK;I)Z> method remove(p0: java.lang.Object, p1: int): boolean
+    public <(TK;Ljava/util/function/BiFunction<-TK;-TV;+TV;>;)TV;> method compute(p0: java.lang.Object, p1: java.util.function.BiFunction): java.lang.Object
+    public <(TK;Ljava/util/function/BiFunction<-TK;-TV;+TV;>;)TV;> method computeIfPresent(p0: java.lang.Object, p1: java.util.function.BiFunction): java.lang.Object
+    public <(TK;Ljava/util/function/Function<-TK;+TV;>;)TV;> method computeIfAbsent(p0: java.lang.Object, p1: java.util.function.Function): java.lang.Object
+    public <(TK;TV;)TV;> method put(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
+    public <(TK;TV;)TV;> method putIfAbsent(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
+    public <(TK;TV;)TV;> method replace(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
+    public <(TK;TV;Ljava/util/function/BiFunction<-TV;-TV;+TV;>;)TV;> method merge(p0: java.lang.Object, p1: java.lang.Object, p2: java.util.function.BiFunction): java.lang.Object
+    public <(TK;TV;TV;)Z> method replace(p0: java.lang.Object, p1: java.lang.Object, p2: java.lang.Object): boolean
+    public <null> method <init>(): void
+    public <null> method clear(): void
+    public abstract <null> method getSize(): int
+    public final <null> method remove(p0: java.lang.Object, p1: java.lang.Object): boolean
+    public bridge final <null> method size(): int
+}

--- a/compiler/testData/codegen/bytecodeListing/specialBridges/signatures/withoutPlatformDependentDeclarations.kt
+++ b/compiler/testData/codegen/bytecodeListing/specialBridges/signatures/withoutPlatformDependentDeclarations.kt
@@ -1,0 +1,31 @@
+// Without platform dependent declarations we should see ordinary generic signatures everywhere.
+// WITH_SIGNATURES
+interface I
+
+abstract class T1<K, V> : MutableMap<K, V> {
+    fun getOrDefault(key: K, value: V): V = value
+    fun getOrDefault(key: K, value: Int): Int = value + 1
+    fun remove(key: K, value: V): Boolean = false
+    fun remove(key: K, value: Int): Boolean = true
+}
+
+abstract class T2<V> : MutableMap<String, V> {
+    fun getOrDefault(key: String, value: V): V = value
+    fun getOrDefault(key: Int?, value: V): V = value
+    fun remove(key: String, value: V): Boolean = false
+    fun remove(key: Int?, value: V): Boolean = true
+}
+
+abstract class T3<K, V : I> : MutableMap<K, V> {
+    fun getOrDefault(key: K, value: V): V = value
+    fun getOrDefault(key: K, value: Int): I? = null
+    fun remove(key: K, value: V): Boolean = false
+    fun remove(key: K, value: Int): Boolean = true
+}
+
+abstract class T4<K, V> : Map<K, V> {
+    fun remove(key: K, value: V): Boolean = false
+    fun getOrDefault(key: K, value: V): V = value
+    fun getOrDefault(key: K, value: Int): Int = value + 1
+    fun remove(key: K, value: Int): Boolean = true
+}

--- a/compiler/testData/codegen/bytecodeListing/specialBridges/signatures/withoutPlatformDependentDeclarations.txt
+++ b/compiler/testData/codegen/bytecodeListing/specialBridges/signatures/withoutPlatformDependentDeclarations.txt
@@ -1,0 +1,101 @@
+@kotlin.Metadata
+public interface<null>  I {
+    // source: 'withoutPlatformDependentDeclarations.kt'
+}
+
+@kotlin.Metadata
+public abstract class<<K:Ljava/lang/Object;V:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/Map<TK;TV;>;Lkotlin/jvm/internal/markers/KMutableMap;>  T1 {
+    // source: 'withoutPlatformDependentDeclarations.kt'
+    public bridge final <()Ljava/util/Collection<TV;>;> method values(): java.util.Collection
+    public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<TK;TV;>;>;> method entrySet(): java.util.Set
+    public bridge final <()Ljava/util/Set<TK;>;> method keySet(): java.util.Set
+    public final <(TK;I)I> method getOrDefault(p0: java.lang.Object, p1: int): int
+    public final <(TK;I)Z> method remove(p0: java.lang.Object, p1: int): boolean
+    public final <(TK;TV;)TV;> method getOrDefault(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
+    public final <(TK;TV;)Z> method remove(p0: java.lang.Object, p1: java.lang.Object): boolean
+    public <null> method <init>(): void
+    public abstract <null> method containsKey(p0: java.lang.Object): boolean
+    public abstract <null> method containsValue(p0: java.lang.Object): boolean
+    public abstract <null> method get(p0: java.lang.Object): java.lang.Object
+    public abstract <null> method getEntries(): java.util.Set
+    public abstract <null> method getKeys(): java.util.Set
+    public abstract <null> method getSize(): int
+    public abstract <null> method getValues(): java.util.Collection
+    public abstract <null> method remove(p0: java.lang.Object): java.lang.Object
+    public bridge final <null> method size(): int
+}
+
+@kotlin.Metadata
+public abstract class<<V:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/Map<Ljava/lang/String;TV;>;Lkotlin/jvm/internal/markers/KMutableMap;>  T2 {
+    // source: 'withoutPlatformDependentDeclarations.kt'
+    public bridge final <()Ljava/util/Collection<TV;>;> method values(): java.util.Collection
+    public bridge final <()Ljava/util/Set<Ljava/lang/String;>;> method keySet(): java.util.Set
+    public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/String;TV;>;>;> method entrySet(): java.util.Set
+    public final <(Ljava/lang/Integer;TV;)TV;> method getOrDefault(@org.jetbrains.annotations.Nullable p0: java.lang.Integer, p1: java.lang.Object): java.lang.Object
+    public final <(Ljava/lang/Integer;TV;)Z> method remove(@org.jetbrains.annotations.Nullable p0: java.lang.Integer, p1: java.lang.Object): boolean
+    public bridge final <(Ljava/lang/Object;)TV;> method get(p0: java.lang.Object): java.lang.Object
+    public bridge final <(Ljava/lang/Object;)TV;> method remove(p0: java.lang.Object): java.lang.Object
+    public final <(Ljava/lang/String;TV;)TV;> method getOrDefault(@org.jetbrains.annotations.NotNull p0: java.lang.String, p1: java.lang.Object): java.lang.Object
+    public final <(Ljava/lang/String;TV;)Z> method remove(@org.jetbrains.annotations.NotNull p0: java.lang.String, p1: java.lang.Object): boolean
+    public <null> method <init>(): void
+    public bridge final <null> method containsKey(p0: java.lang.Object): boolean
+    public abstract <null> method containsKey(p0: java.lang.String): boolean
+    public abstract <null> method containsValue(p0: java.lang.Object): boolean
+    public abstract <null> method get(p0: java.lang.String): java.lang.Object
+    public abstract <null> method getEntries(): java.util.Set
+    public abstract <null> method getKeys(): java.util.Set
+    public abstract <null> method getSize(): int
+    public abstract <null> method getValues(): java.util.Collection
+    public abstract <null> method remove(p0: java.lang.String): java.lang.Object
+    public bridge final <null> method size(): int
+}
+
+@kotlin.Metadata
+public abstract class<<K:Ljava/lang/Object;V::LI;>Ljava/lang/Object;Ljava/util/Map<TK;TV;>;Lkotlin/jvm/internal/markers/KMutableMap;>  T3 {
+    // source: 'withoutPlatformDependentDeclarations.kt'
+    public bridge final <()Ljava/util/Collection<TV;>;> method values(): java.util.Collection
+    public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<TK;TV;>;>;> method entrySet(): java.util.Set
+    public bridge final <()Ljava/util/Set<TK;>;> method keySet(): java.util.Set
+    public bridge final <(Ljava/lang/Object;)TV;> method get(p0: java.lang.Object): java.lang.Object
+    public bridge final <(Ljava/lang/Object;)TV;> method remove(p0: java.lang.Object): java.lang.Object
+    public final @org.jetbrains.annotations.Nullable <(TK;I)LI;> method getOrDefault(p0: java.lang.Object, p1: int): I
+    public final <(TK;I)Z> method remove(p0: java.lang.Object, p1: int): boolean
+    public final @org.jetbrains.annotations.NotNull <(TK;TV;)TV;> method getOrDefault(p0: java.lang.Object, @org.jetbrains.annotations.NotNull p1: I): I
+    public final <(TK;TV;)Z> method remove(p0: java.lang.Object, @org.jetbrains.annotations.NotNull p1: I): boolean
+    public <null> method <init>(): void
+    public abstract <null> method containsKey(p0: java.lang.Object): boolean
+    public abstract <null> method containsValue(p0: I): boolean
+    public bridge final <null> method containsValue(p0: java.lang.Object): boolean
+    public abstract <null> method get(p0: java.lang.Object): I
+    public abstract <null> method getEntries(): java.util.Set
+    public abstract <null> method getKeys(): java.util.Set
+    public abstract <null> method getSize(): int
+    public abstract <null> method getValues(): java.util.Collection
+    public abstract <null> method remove(p0: java.lang.Object): I
+    public bridge final <null> method size(): int
+}
+
+@kotlin.Metadata
+public abstract class<<K:Ljava/lang/Object;V:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/Map<TK;TV;>;Lkotlin/jvm/internal/markers/KMappedMarker;>  T4 {
+    // source: 'withoutPlatformDependentDeclarations.kt'
+    public bridge final <()Ljava/util/Collection<TV;>;> method values(): java.util.Collection
+    public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<TK;TV;>;>;> method entrySet(): java.util.Set
+    public bridge final <()Ljava/util/Set<TK;>;> method keySet(): java.util.Set
+    public <(Ljava/lang/Object;)TV;> method remove(p0: java.lang.Object): java.lang.Object
+    public <(Ljava/util/Map<+TK;+TV;>;)V> method putAll(p0: java.util.Map): void
+    public final <(TK;I)I> method getOrDefault(p0: java.lang.Object, p1: int): int
+    public final <(TK;I)Z> method remove(p0: java.lang.Object, p1: int): boolean
+    public final <(TK;TV;)TV;> method getOrDefault(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
+    public <(TK;TV;)TV;> method put(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
+    public final <(TK;TV;)Z> method remove(p0: java.lang.Object, p1: java.lang.Object): boolean
+    public <null> method <init>(): void
+    public <null> method clear(): void
+    public abstract <null> method containsKey(p0: java.lang.Object): boolean
+    public abstract <null> method containsValue(p0: java.lang.Object): boolean
+    public abstract <null> method get(p0: java.lang.Object): java.lang.Object
+    public abstract <null> method getEntries(): java.util.Set
+    public abstract <null> method getKeys(): java.util.Set
+    public abstract <null> method getSize(): int
+    public abstract <null> method getValues(): java.util.Collection
+    public bridge final <null> method size(): int
+}

--- a/compiler/testData/codegen/bytecodeListing/specialBridges/signatures/withoutPlatformDependentDeclarations_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/specialBridges/signatures/withoutPlatformDependentDeclarations_ir.txt
@@ -1,0 +1,90 @@
+@kotlin.Metadata
+public interface<null>  I {
+    // source: 'withoutPlatformDependentDeclarations.kt'
+}
+
+@kotlin.Metadata
+public abstract class<<K:Ljava/lang/Object;V:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/Map<TK;TV;>;Lkotlin/jvm/internal/markers/KMutableMap;>  T1 {
+    // source: 'withoutPlatformDependentDeclarations.kt'
+    public abstract <()Ljava/util/Collection<TV;>;> method getValues(): java.util.Collection
+    public bridge final <()Ljava/util/Collection<TV;>;> method values(): java.util.Collection
+    public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<TK;TV;>;>;> method entrySet(): java.util.Set
+    public abstract <()Ljava/util/Set<Ljava/util/Map$Entry<TK;TV;>;>;> method getEntries(): java.util.Set
+    public abstract <()Ljava/util/Set<TK;>;> method getKeys(): java.util.Set
+    public bridge final <()Ljava/util/Set<TK;>;> method keySet(): java.util.Set
+    public final <(TK;I)I> method getOrDefault(p0: java.lang.Object, p1: int): int
+    public final <(TK;I)Z> method remove(p0: java.lang.Object, p1: int): boolean
+    public final <(TK;TV;)TV;> method getOrDefault(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
+    public final <(TK;TV;)Z> method remove(p0: java.lang.Object, p1: java.lang.Object): boolean
+    public <null> method <init>(): void
+    public abstract <null> method getSize(): int
+    public bridge final <null> method size(): int
+}
+
+@kotlin.Metadata
+public abstract class<<V:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/Map<Ljava/lang/String;TV;>;Lkotlin/jvm/internal/markers/KMutableMap;>  T2 {
+    // source: 'withoutPlatformDependentDeclarations.kt'
+    public abstract <()Ljava/util/Collection<TV;>;> method getValues(): java.util.Collection
+    public bridge final <()Ljava/util/Collection<TV;>;> method values(): java.util.Collection
+    public abstract <()Ljava/util/Set<Ljava/lang/String;>;> method getKeys(): java.util.Set
+    public bridge final <()Ljava/util/Set<Ljava/lang/String;>;> method keySet(): java.util.Set
+    public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/String;TV;>;>;> method entrySet(): java.util.Set
+    public abstract <()Ljava/util/Set<Ljava/util/Map$Entry<Ljava/lang/String;TV;>;>;> method getEntries(): java.util.Set
+    public final <(Ljava/lang/Integer;TV;)TV;> method getOrDefault(@org.jetbrains.annotations.Nullable p0: java.lang.Integer, p1: java.lang.Object): java.lang.Object
+    public final <(Ljava/lang/Integer;TV;)Z> method remove(@org.jetbrains.annotations.Nullable p0: java.lang.Integer, p1: java.lang.Object): boolean
+    public bridge final <(Ljava/lang/Object;)TV;> method get(p0: java.lang.Object): java.lang.Object
+    public bridge final <(Ljava/lang/Object;)TV;> method remove(p0: java.lang.Object): java.lang.Object
+    public abstract <(Ljava/lang/String;)TV;> method get(p0: java.lang.String): java.lang.Object
+    public abstract <(Ljava/lang/String;)TV;> method remove(p0: java.lang.String): java.lang.Object
+    public final <(Ljava/lang/String;TV;)TV;> method getOrDefault(@org.jetbrains.annotations.NotNull p0: java.lang.String, p1: java.lang.Object): java.lang.Object
+    public final <(Ljava/lang/String;TV;)Z> method remove(@org.jetbrains.annotations.NotNull p0: java.lang.String, p1: java.lang.Object): boolean
+    public <null> method <init>(): void
+    public bridge final <null> method containsKey(p0: java.lang.Object): boolean
+    public abstract <null> method containsKey(p0: java.lang.String): boolean
+    public abstract <null> method getSize(): int
+    public bridge final <null> method size(): int
+}
+
+@kotlin.Metadata
+public abstract class<<K:Ljava/lang/Object;V::LI;>Ljava/lang/Object;Ljava/util/Map<TK;TV;>;Lkotlin/jvm/internal/markers/KMutableMap;>  T3 {
+    // source: 'withoutPlatformDependentDeclarations.kt'
+    public abstract <()Ljava/util/Collection<TV;>;> method getValues(): java.util.Collection
+    public bridge final <()Ljava/util/Collection<TV;>;> method values(): java.util.Collection
+    public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<TK;TV;>;>;> method entrySet(): java.util.Set
+    public abstract <()Ljava/util/Set<Ljava/util/Map$Entry<TK;TV;>;>;> method getEntries(): java.util.Set
+    public abstract <()Ljava/util/Set<TK;>;> method getKeys(): java.util.Set
+    public bridge final <()Ljava/util/Set<TK;>;> method keySet(): java.util.Set
+    public final @org.jetbrains.annotations.Nullable <(TK;I)LI;> method getOrDefault(p0: java.lang.Object, p1: int): I
+    public final <(TK;I)Z> method remove(p0: java.lang.Object, p1: int): boolean
+    public final @org.jetbrains.annotations.NotNull <(TK;TV;)TV;> method getOrDefault(p0: java.lang.Object, @org.jetbrains.annotations.NotNull p1: I): I
+    public final <(TK;TV;)Z> method remove(p0: java.lang.Object, @org.jetbrains.annotations.NotNull p1: I): boolean
+    public abstract <(TV;)Z> method containsValue(p0: I): boolean
+    public <null> method <init>(): void
+    public bridge final <null> method containsValue(p0: java.lang.Object): boolean
+    public synthetic bridge <null> method get(p0: java.lang.Object): java.lang.Object
+    public abstract <null> method getSize(): int
+    public synthetic bridge <null> method remove(p0: java.lang.Object): java.lang.Object
+    public bridge final <null> method size(): int
+}
+
+@kotlin.Metadata
+public abstract class<<K:Ljava/lang/Object;V:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/Map<TK;TV;>;Lkotlin/jvm/internal/markers/KMappedMarker;>  T4 {
+    // source: 'withoutPlatformDependentDeclarations.kt'
+    public abstract <()Ljava/util/Collection<TV;>;> method getValues(): java.util.Collection
+    public bridge final <()Ljava/util/Collection<TV;>;> method values(): java.util.Collection
+    public bridge final <()Ljava/util/Set<Ljava/util/Map$Entry<TK;TV;>;>;> method entrySet(): java.util.Set
+    public abstract <()Ljava/util/Set<Ljava/util/Map$Entry<TK;TV;>;>;> method getEntries(): java.util.Set
+    public abstract <()Ljava/util/Set<TK;>;> method getKeys(): java.util.Set
+    public bridge final <()Ljava/util/Set<TK;>;> method keySet(): java.util.Set
+    public <(Ljava/lang/Object;)TV;> method remove(p0: java.lang.Object): java.lang.Object
+    public <(Ljava/util/Map<+TK;+TV;>;)V> method putAll(p0: java.util.Map): void
+    public final <(TK;I)I> method getOrDefault(p0: java.lang.Object, p1: int): int
+    public final <(TK;I)Z> method remove(p0: java.lang.Object, p1: int): boolean
+    public final <(TK;TV;)TV;> method getOrDefault(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
+    public <(TK;TV;)TV;> method put(p0: java.lang.Object, p1: java.lang.Object): java.lang.Object
+    public final <(TK;TV;)Z> method remove(p0: java.lang.Object, p1: java.lang.Object): boolean
+    public <null> method <init>(): void
+    public <null> method clear(): void
+    public abstract <null> method getSize(): int
+    public bridge final <null> method size(): int
+}

--- a/compiler/testData/codegen/bytecodeText/builtinFunctions/genericParameterBridge/abstractList.kt
+++ b/compiler/testData/codegen/bytecodeText/builtinFunctions/genericParameterBridge/abstractList.kt
@@ -21,10 +21,14 @@ abstract class A6 : java.util.AbstractList<String>() {
 }
 
 // 0 signature \(TW;\)Z
-// 2 signature \(Ljava/util/Collection<\+Ljava/lang/Object;>;\)Z
 // 2 public final bridge contains\(Ljava/lang/Object;\)Z
 // 2 public final bridge remove\(Ljava/lang/Object;\)Z
 // 2 public final bridge indexOf\(Ljava/lang/Object;\)I
 // 2 public final bridge lastIndexOf\(Ljava/lang/Object;\)I
 /* 2 INSTANCEOF for each class: one for 'remove', one for 'contains' type-safe bridges */
 // 8 INSTANCEOF java/lang/String
+// JVM_TEMPLATES:
+// 2 signature \(Ljava/util/Collection<\+Ljava/lang/Object;>;\)Z
+// JVM_IR_TEMPLATES:
+// 0 signature \(Ljava/util/Collection<\+Ljava/lang/Object;>;\)Z
+// 2 signature \(Ljava/util/Collection<\*>;\)Z

--- a/compiler/testData/codegen/bytecodeText/builtinFunctions/genericParameterBridge/mutableCollection.kt
+++ b/compiler/testData/codegen/bytecodeText/builtinFunctions/genericParameterBridge/mutableCollection.kt
@@ -19,9 +19,13 @@ abstract class A2 : MutableCollection<String> {
 }
 
 // 0 signature \(TQ;\)Z
-// 2 signature \(Ljava/util/Collection<\+Ljava/lang/Object;>;\)Z
 // 1 public final bridge contains\(Ljava/lang/Object;\)Z
 // 1 public final bridge remove\(Ljava/lang/Object;\)Z
 // 1 INVOKEVIRTUAL A[0-9]\.contains \(Ljava/lang/String;\)Z
 /* 2 INSTANCEOF: one for 'remove', one for 'contains' type-safe bridges */
 // 2 INSTANCEOF
+// JVM_TEMPLATES:
+// 2 signature \(Ljava/util/Collection<\+Ljava/lang/Object;>;\)Z
+// JVM_IR_TEMPLATES:
+// 0 signature \(Ljava/util/Collection<\+Ljava/lang/Object;>;\)Z
+// 2 signature \(Ljava/util/Collection<\*>;\)Z

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -2220,6 +2220,18 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
         }
 
         @Test
+        @TestMetadata("kt52929.kt")
+        public void testKt52929() throws Exception {
+            runTest("compiler/testData/codegen/box/bridges/kt52929.kt");
+        }
+
+        @Test
+        @TestMetadata("kt52929_platformDependent.kt")
+        public void testKt52929_platformDependent() throws Exception {
+            runTest("compiler/testData/codegen/box/bridges/kt52929_platformDependent.kt");
+        }
+
+        @Test
         @TestMetadata("longChainOneBridge.kt")
         public void testLongChainOneBridge() throws Exception {
             runTest("compiler/testData/codegen/box/bridges/longChainOneBridge.kt");
@@ -2337,6 +2349,12 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
         @TestMetadata("simpleUpperBound.kt")
         public void testSimpleUpperBound() throws Exception {
             runTest("compiler/testData/codegen/box/bridges/simpleUpperBound.kt");
+        }
+
+        @Test
+        @TestMetadata("specialBridgeTypesJava.kt")
+        public void testSpecialBridgeTypesJava() throws Exception {
+            runTest("compiler/testData/codegen/box/bridges/specialBridgeTypesJava.kt");
         }
 
         @Test

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BytecodeListingTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BytecodeListingTestGenerated.java
@@ -2396,6 +2396,18 @@ public class BytecodeListingTestGenerated extends AbstractBytecodeListingTest {
             public void testPartiallySpecializedClass() throws Exception {
                 runTest("compiler/testData/codegen/bytecodeListing/specialBridges/signatures/partiallySpecializedClass.kt");
             }
+
+            @Test
+            @TestMetadata("withPlatformDependentDeclarations.kt")
+            public void testWithPlatformDependentDeclarations() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeListing/specialBridges/signatures/withPlatformDependentDeclarations.kt");
+            }
+
+            @Test
+            @TestMetadata("withoutPlatformDependentDeclarations.kt")
+            public void testWithoutPlatformDependentDeclarations() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeListing/specialBridges/signatures/withoutPlatformDependentDeclarations.kt");
+            }
         }
     }
 }

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -2316,6 +2316,18 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         }
 
         @Test
+        @TestMetadata("kt52929.kt")
+        public void testKt52929() throws Exception {
+            runTest("compiler/testData/codegen/box/bridges/kt52929.kt");
+        }
+
+        @Test
+        @TestMetadata("kt52929_platformDependent.kt")
+        public void testKt52929_platformDependent() throws Exception {
+            runTest("compiler/testData/codegen/box/bridges/kt52929_platformDependent.kt");
+        }
+
+        @Test
         @TestMetadata("longChainOneBridge.kt")
         public void testLongChainOneBridge() throws Exception {
             runTest("compiler/testData/codegen/box/bridges/longChainOneBridge.kt");
@@ -2433,6 +2445,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         @TestMetadata("simpleUpperBound.kt")
         public void testSimpleUpperBound() throws Exception {
             runTest("compiler/testData/codegen/box/bridges/simpleUpperBound.kt");
+        }
+
+        @Test
+        @TestMetadata("specialBridgeTypesJava.kt")
+        public void testSpecialBridgeTypesJava() throws Exception {
+            runTest("compiler/testData/codegen/box/bridges/specialBridgeTypesJava.kt");
         }
 
         @Test

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBytecodeListingTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBytecodeListingTestGenerated.java
@@ -2492,6 +2492,18 @@ public class IrBytecodeListingTestGenerated extends AbstractIrBytecodeListingTes
             public void testPartiallySpecializedClass() throws Exception {
                 runTest("compiler/testData/codegen/bytecodeListing/specialBridges/signatures/partiallySpecializedClass.kt");
             }
+
+            @Test
+            @TestMetadata("withPlatformDependentDeclarations.kt")
+            public void testWithPlatformDependentDeclarations() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeListing/specialBridges/signatures/withPlatformDependentDeclarations.kt");
+            }
+
+            @Test
+            @TestMetadata("withoutPlatformDependentDeclarations.kt")
+            public void testWithoutPlatformDependentDeclarations() throws Exception {
+                runTest("compiler/testData/codegen/bytecodeListing/specialBridges/signatures/withoutPlatformDependentDeclarations.kt");
+            }
         }
     }
 }

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -1774,6 +1774,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/bridges/kt24193.kt");
         }
 
+        @TestMetadata("kt52929_platformDependent.kt")
+        public void ignoreKt52929_platformDependent() throws Exception {
+            runTest("compiler/testData/codegen/box/bridges/kt52929_platformDependent.kt");
+        }
+
         private void runTest(String testDataFilePath) throws Exception {
             KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM, testDataFilePath);
         }
@@ -1947,6 +1952,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/bridges/kt46389_jvmDefault.kt");
         }
 
+        @TestMetadata("kt52929.kt")
+        public void testKt52929() throws Exception {
+            runTest("compiler/testData/codegen/box/bridges/kt52929.kt");
+        }
+
         @TestMetadata("longChainOneBridge.kt")
         public void testLongChainOneBridge() throws Exception {
             runTest("compiler/testData/codegen/box/bridges/longChainOneBridge.kt");
@@ -2045,6 +2055,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
         @TestMetadata("simpleUpperBound.kt")
         public void testSimpleUpperBound() throws Exception {
             runTest("compiler/testData/codegen/box/bridges/simpleUpperBound.kt");
+        }
+
+        @TestMetadata("specialBridgeTypesJava.kt")
+        public void testSpecialBridgeTypesJava() throws Exception {
+            runTest("compiler/testData/codegen/box/bridges/specialBridgeTypesJava.kt");
         }
 
         @TestMetadata("strListContains.kt")


### PR DESCRIPTION
- Only modify generic signatures for declarations that *erase* to an override of a Java declaration with a different generic signature, instead of modifying all special bridges. This fixes KT-52929.
- Fix generic signatures for methods with generic types in Java. For example, `getOrDefault` is generic in its second argument and `Map.remove` has a generic return type. The code in `GenericSignatureMapper` contains a comment explaining what goes wrong with `remove` if we generate the wrong or no generic signature.
- Produce generic signatures on abstract bridge methods so as to avoid raw types in Java. See `testSpecialBridgeTypesJava`.
- Match the behavior of the Java compiler for special bridges with collection parameters. We currently produce a signature with a parameter like `Collection<out Any?>`, while the Java compiler generates `Collection<*>`. The two types are equivalent, but the latter is shorter. This is technically not breaking anything though, so I've put it into a separate commit.

---

For the implementation I started out using the existing tables in `SpecialGenericSignatures`, but they don't quite contain all the relevant information. For example, which methods are generic in their return values and which Kotlin class we should check for overrides (i.e., `java.util.Map` could be `MutableMap` or `Map`). Writing out these additional special cases is basically as much code as writing out all cases so I ended up with a new table in `GenericSignatureMapper`. After some more cleanup we should probably look into unifying all the different implementations again, but for now I think this is the cleanest solution without touching code in the old backend.

As a nice side effect this gets rid of another use of `IrBasedDescriptors` in `MethodSignatureMapper`.