### PR TITLE
KT-18629 Add depth-first search to FileTreeWalk

### DIFF
--- a/libraries/stdlib/jvm/src/kotlin/io/files/FileTreeWalk.kt
+++ b/libraries/stdlib/jvm/src/kotlin/io/files/FileTreeWalk.kt
@@ -21,8 +21,9 @@ public enum class FileWalkDirection {
     /** Depth-first search, directory is visited BEFORE its files */
     TOP_DOWN,
     /** Depth-first search, directory is visited AFTER its files */
-    BOTTOM_UP
-    // Do we want also breadth-first search?
+    BOTTOM_UP,
+    /**Breadth-first search, directory is visited BEFORE its files */
+    BREADTH_FIRST
 }
 
 /**
@@ -89,6 +90,7 @@ public class FileTreeWalk private constructor(
             return when (direction) {
                 FileWalkDirection.TOP_DOWN -> TopDownDirectoryState(root)
                 FileWalkDirection.BOTTOM_UP -> BottomUpDirectoryState(root)
+                FileWalkDirection.BREADTH_FIRST -> BreadthFirstDirectoryState(root)
             }
         }
 
@@ -193,6 +195,12 @@ public class FileTreeWalk private constructor(
             }
         }
 
+        private inner class BreadthFirstDirectoryState(rootDir: File) : DirectoryState(rootDir) {
+            override fun step(): File? {
+                TODO()
+            }
+        }
+
         private inner class SingleFileState(rootFile: File) : WalkState(rootFile) {
             private var visited: Boolean = false
 
@@ -270,3 +278,10 @@ public fun File.walkTopDown(): FileTreeWalk = walk(FileWalkDirection.TOP_DOWN)
  * Depth-first search is used and directories are visited after all their files.
  */
 public fun File.walkBottomUp(): FileTreeWalk = walk(FileWalkDirection.BOTTOM_UP)
+
+/**
+ * Gets a sequence for visiting this directory and all its content, visiting all the files at the same depth before continuing
+ * with the ones at the next depth level.
+ * Breadth-first search is used and directories are visited before all their files.
+ */
+public fun File.walkBreadthFirst(): FileTreeWalk = walk(FileWalkDirection.BREADTH_FIRST)

--- a/libraries/stdlib/jvm/src/kotlin/io/files/FileTreeWalk.kt
+++ b/libraries/stdlib/jvm/src/kotlin/io/files/FileTreeWalk.kt
@@ -64,158 +64,226 @@ public class FileTreeWalk private constructor(
         }
     }
 
-    private inner class FileTreeWalkIterator : AbstractIterator<File>() {
+    private interface FileTreeWalkStrategy {
+        fun gotoNext(): File?
+    }
 
-        // Stack of directory states, beginning from the start directory
-        private val state = ArrayDeque<WalkState>()
+    private inner class SingleFileState(rootFile: File) : WalkState(rootFile) {
+        private var visited: Boolean = false
 
         init {
-            when {
-                start.isDirectory -> state.push(directoryState(start))
-                start.isFile -> state.push(SingleFileState(start))
-                else -> done()
-            }
+            if (_Assertions.ENABLED)
+                assert(rootFile.isFile) { "rootFile must be verified to be file beforehand." }
+        }
+
+        override fun step(): File? {
+            if (visited) return null
+            visited = true
+            return root
+        }
+    }
+
+    private inner class FileTreeWalkIterator : AbstractIterator<File>() {
+
+        private var strategy: FileTreeWalkStrategy = when (direction) {
+            FileWalkDirection.TOP_DOWN, FileWalkDirection.BOTTOM_UP -> DepthFirstFileTreeWalkStrategy()
+            FileWalkDirection.BREADTH_FIRST -> BreadthFirstFileTreeWalkStrategy()
         }
 
         override fun computeNext() {
-            val nextFile = gotoNext()
+            val nextFile = strategy.gotoNext()
             if (nextFile != null)
                 setNext(nextFile)
             else
                 done()
         }
 
+        private inner class DepthFirstFileTreeWalkStrategy : FileTreeWalkStrategy {
+            // Stack of directory states, beginning from the start directory
+            private val state = ArrayDeque<WalkState>()
 
-        private fun directoryState(root: File): DirectoryState {
-            return when (direction) {
-                FileWalkDirection.TOP_DOWN -> TopDownDirectoryState(root)
-                FileWalkDirection.BOTTOM_UP -> BottomUpDirectoryState(root)
-                FileWalkDirection.BREADTH_FIRST -> BreadthFirstDirectoryState(root)
+            init {
+                when {
+                    start.isDirectory -> state.push(directoryState(start))
+                    start.isFile -> state.push(SingleFileState(start))
+                    else -> done()
+                }
             }
-        }
 
-        private tailrec fun gotoNext(): File? {
-            // Take next file from the top of the stack or return if there's nothing left
-            val topState = state.peek() ?: return null
-            val file = topState.step()
-            if (file == null) {
-                // There is nothing more on the top of the stack, go back
-                state.pop()
-                return gotoNext()
-            } else {
-                // Check that file/directory matches the filter
-                if (file == topState.root || !file.isDirectory || state.size >= maxDepth) {
-                    // Proceed to a root directory or a simple file
-                    return file
-                } else {
-                    // Proceed to a sub-directory
-                    state.push(directoryState(file))
+            override tailrec fun gotoNext(): File? {
+                // Take next file from the top of the stack or return if there's nothing left
+                val topState = state.peek() ?: return null
+                val file = topState.step()
+                if (file == null) {
+                    // There is nothing more on the top of the stack, go back
+                    state.pop()
                     return gotoNext()
-                }
-            }
-        }
-
-        /** Visiting in bottom-up order */
-        private inner class BottomUpDirectoryState(rootDir: File) : DirectoryState(rootDir) {
-
-            private var rootVisited = false
-
-            private var fileList: Array<File>? = null
-
-            private var fileIndex = 0
-
-            private var failed = false
-
-            /** First all children, then root directory */
-            override fun step(): File? {
-                if (!failed && fileList == null) {
-                    if (onEnter?.invoke(root) == false) {
-                        return null
-                    }
-
-                    fileList = root.listFiles()
-                    if (fileList == null) {
-                        onFail?.invoke(root, AccessDeniedException(file = root, reason = "Cannot list files in a directory"))
-                        failed = true
-                    }
-                }
-                if (fileList != null && fileIndex < fileList!!.size) {
-                    // First visit all files
-                    return fileList!![fileIndex++]
-                } else if (!rootVisited) {
-                    // Then visit root
-                    rootVisited = true
-                    return root
                 } else {
-                    // That's all
-                    onLeave?.invoke(root)
-                    return null
+                    // Check that file/directory matches the filter
+                    if (file == topState.root || !file.isDirectory || state.size >= maxDepth) {
+                        // Proceed to a root directory or a simple file
+                        return file
+                    } else {
+                        // Proceed to a sub-directory
+                        state.push(directoryState(file))
+                        return gotoNext()
+                    }
                 }
             }
-        }
 
-        /** Visiting in top-down order */
-        private inner class TopDownDirectoryState(rootDir: File) : DirectoryState(rootDir) {
-
-            private var rootVisited = false
-
-            private var fileList: Array<File>? = null
-
-            private var fileIndex = 0
-
-            /** First root directory, then all children */
-            override fun step(): File? {
-                if (!rootVisited) {
-                    // First visit root
-                    if (onEnter?.invoke(root) == false) {
-                        return null
+            private fun directoryState(root: File): DirectoryState {
+                return when (direction) {
+                    FileWalkDirection.TOP_DOWN -> TopDownDirectoryState(root)
+                    FileWalkDirection.BOTTOM_UP -> BottomUpDirectoryState(root)
+                    else -> {
+                        throw IllegalArgumentException("Depth first search just supports ${FileWalkDirection.TOP_DOWN} and ${FileWalkDirection.BOTTOM_UP} directions")
                     }
+                }
+            }
 
-                    rootVisited = true
-                    return root
-                } else if (fileList == null || fileIndex < fileList!!.size) {
-                    if (fileList == null) {
-                        // Then read an array of files, if any
+            /** Visiting in bottom-up order */
+            private inner class BottomUpDirectoryState(rootDir: File) : DirectoryState(rootDir) {
+
+                private var rootVisited = false
+
+                private var fileList: Array<File>? = null
+
+                private var fileIndex = 0
+
+                private var failed = false
+
+                /** First all children, then root directory */
+                override fun step(): File? {
+                    if (!failed && fileList == null) {
+                        if (onEnter?.invoke(root) == false) {
+                            return null
+                        }
+
                         fileList = root.listFiles()
                         if (fileList == null) {
                             onFail?.invoke(root, AccessDeniedException(file = root, reason = "Cannot list files in a directory"))
-                        }
-                        if (fileList == null || fileList!!.size == 0) {
-                            onLeave?.invoke(root)
-                            return null
+                            failed = true
                         }
                     }
-                    // Then visit all files
-                    return fileList!![fileIndex++]
-                } else {
-                    // That's all
-                    onLeave?.invoke(root)
-                    return null
+                    if (fileList != null && fileIndex < fileList!!.size) {
+                        // First visit all files
+                        return fileList!![fileIndex++]
+                    } else if (!rootVisited) {
+                        // Then visit root
+                        rootVisited = true
+                        return root
+                    } else {
+                        // That's all
+                        onLeave?.invoke(root)
+                        return null
+                    }
+                }
+            }
+
+            /** Visiting in top-down order */
+            private inner class TopDownDirectoryState(rootDir: File) : DirectoryState(rootDir) {
+
+                private var rootVisited = false
+
+                private var fileList: Array<File>? = null
+
+                private var fileIndex = 0
+
+                /** First root directory, then all children */
+                override fun step(): File? {
+                    if (!rootVisited) {
+                        // First visit root
+                        if (onEnter?.invoke(root) == false) {
+                            return null
+                        }
+
+                        rootVisited = true
+                        return root
+                    } else if (fileList == null || fileIndex < fileList!!.size) {
+                        if (fileList == null) {
+                            // Then read an array of files, if any
+                            fileList = root.listFiles()
+                            if (fileList == null) {
+                                onFail?.invoke(root, AccessDeniedException(file = root, reason = "Cannot list files in a directory"))
+                            }
+                            if (fileList == null || fileList!!.size == 0) {
+                                onLeave?.invoke(root)
+                                return null
+                            }
+                        }
+                        // Then visit all files
+                        return fileList!![fileIndex++]
+                    } else {
+                        // That's all
+                        onLeave?.invoke(root)
+                        return null
+                    }
                 }
             }
         }
 
-        private inner class BreadthFirstDirectoryState(rootDir: File) : DirectoryState(rootDir) {
-            override fun step(): File? {
-                TODO()
-            }
-        }
+        private inner class BreadthFirstFileTreeWalkStrategy : FileTreeWalkStrategy {
 
-        private inner class SingleFileState(rootFile: File) : WalkState(rootFile) {
-            private var visited: Boolean = false
+            private val state = ArrayDeque<BreadthFirstDirectoryState>()
+            private var justFile: SingleFileState? = null
 
             init {
-                if (_Assertions.ENABLED)
-                    assert(rootFile.isFile) { "rootFile must be verified to be file beforehand." }
+                when {
+                    start.isDirectory -> state.push(BreadthFirstDirectoryState(start, 0))
+                    start.isFile -> justFile = SingleFileState(start)
+                    else -> done()
+                }
             }
 
-            override fun step(): File? {
-                if (visited) return null
-                visited = true
-                return root
+            override tailrec fun gotoNext(): File? {
+                if (justFile != null) {
+                    return justFile!!.step()
+                }
+                val topState = state.peek() ?: return null
+                val file = topState.step()
+                return if (file == null) {
+                    state.pop()
+                    gotoNext()
+                } else {
+                    if (file.isDirectory && file != topState.root && topState.depth < maxDepth) {
+                        state.add(BreadthFirstDirectoryState(file, topState.depth + 1, true))
+                    }
+                    file
+                }
+            }
+
+            private inner class BreadthFirstDirectoryState(rootDir: File, val depth: Int, private var visited: Boolean = false) :
+                DirectoryState(rootDir) {
+                private var fileList: Array<File>? = null
+
+                private var fileIndex = 0
+
+                override fun step(): File? {
+                    if (!visited) {
+                        visited = true
+                        return root
+                    } else if (fileList == null || fileIndex < fileList!!.size) {
+                        if (fileList == null) {
+                            if (onEnter?.invoke(root) == false) {
+                                return null
+                            }
+                            fileList = root.listFiles()
+                            if (fileList == null) {
+                                onFail?.invoke(root, AccessDeniedException(file = root, reason = "Cannot list files in a directory"))
+                            }
+                            if (fileList == null || fileList!!.isEmpty()) {
+                                onLeave?.invoke(root)
+                                return null
+                            }
+                        }
+                        return fileList!![fileIndex++]
+                    } else {
+                        onLeave?.invoke(root)
+                        return null
+                    }
+                }
             }
         }
-
     }
 
     /**

--- a/libraries/stdlib/jvm/src/kotlin/io/files/FileTreeWalk.kt
+++ b/libraries/stdlib/jvm/src/kotlin/io/files/FileTreeWalk.kt
@@ -30,7 +30,7 @@ public enum class FileWalkDirection {
  * This class is intended to implement different file traversal methods.
  * It allows to iterate through all files inside a given directory.
  *
- * Use [File.walk], [File.walkTopDown] or [File.walkBottomUp] extension functions to instantiate a `FileTreeWalk` instance.
+ * Use [File.walk], [File.walkTopDown], [File.walkBottomUp] or [File.walkBreadthFirst] extension functions to instantiate a `FileTreeWalk` instance.
 
  * If the file path given is just a file, walker iterates only it.
  * If the file path given does not exist, walker iterates nothing, i.e. it's equivalent to an empty sequence.

--- a/libraries/stdlib/jvm/test/io/FileTreeWalks.kt
+++ b/libraries/stdlib/jvm/test/io/FileTreeWalks.kt
@@ -53,13 +53,13 @@ class FileTreeWalkTest {
 
     @Test fun singleFile() {
         val testFile = @Suppress("DEPRECATION") createTempFile()
-        val nonExistantFile = testFile.resolve("foo")
+        val nonExistentFile = testFile.resolve("foo")
         try {
             for (walk in listOf(File::walkTopDown, File::walkBottomUp)) {
-                assertEquals(testFile, walk(testFile).single(), "${walk.name}")
+                assertEquals(testFile, walk(testFile).single(), walk.name)
                 assertEquals(testFile, testFile.walk().onEnter { false }.single(), "${walk.name} - enter should not be called for single file")
 
-                assertTrue(walk(nonExistantFile).none(), "${walk.name} - enter should not be called for single file")
+                assertTrue(walk(nonExistentFile).none(), "${walk.name} - enter should not be called for single file")
             }
         }
         finally {
@@ -222,7 +222,7 @@ class FileTreeWalkTest {
         val basedir = createTestFiles()
         try {
             val referenceNames = emptySet<String>()
-            compareWalkResults(referenceNames, basedir, { false })
+            compareWalkResults(referenceNames, basedir) { false }
         } finally {
             basedir.deleteRecursively()
         }
@@ -291,7 +291,7 @@ class FileTreeWalkTest {
                 failed.add(dir.name)
             }
             basedir.walkTopDown().onEnter(::beforeVisitDirectory).onLeave(::afterVisitDirectory).
-                    onFail(::visitDirectoryFailed).forEach { it -> if (!it.isDirectory) visitFile(it) }
+                    onFail(::visitDirectoryFailed).forEach { if (!it.isDirectory) visitFile(it) }
             assertTrue(stack.isEmpty())
             for (fileName in arrayOf("", "1", "1/2", "1/3", "6", "8")) {
                 assertTrue(dirs.contains(File(fileName)), fileName)
@@ -304,11 +304,11 @@ class FileTreeWalkTest {
             files.clear()
             dirs.clear()
             basedir.walkTopDown().onEnter(::beforeVisitDirectory).onLeave(::afterVisitDirectory).maxDepth(1).
-                    forEach { it -> if (it != basedir) visitFile(it) }
+                    forEach { if (it != basedir) visitFile(it) }
             assertTrue(stack.isEmpty())
             assertEquals(setOf(File("")), dirs)
             for (file in arrayOf("1", "6", "7.txt", "8")) {
-                assertTrue(files.contains(File(file)), file.toString())
+                assertTrue(files.contains(File(file)), file)
             }
 
             //restrict access
@@ -317,7 +317,7 @@ class FileTreeWalkTest {
                     files.clear()
                     dirs.clear()
                     basedir.walkTopDown().onEnter(::beforeVisitDirectory).onLeave(::afterVisitDirectory).
-                            onFail(::visitDirectoryFailed).forEach { it -> if (!it.isDirectory) visitFile(it) }
+                            onFail(::visitDirectoryFailed).forEach { if (!it.isDirectory) visitFile(it) }
                     assertTrue(stack.isEmpty())
                     assertEquals(setOf("1"), failed)
                     assertEquals(listOf("", "1", "6", "8").map { File(it) }.toSet(), dirs)
@@ -373,7 +373,7 @@ class FileTreeWalkTest {
         var count = 0
         fun makeBackup(file: File) {
             count++
-            val bakFile = File(file.toString() + ".bak")
+            val bakFile = File("$file.bak")
             file.copyTo(bakFile)
         }
 
@@ -459,5 +459,4 @@ class FileTreeWalkTest {
             dir.delete()
         }
     }
-
 }

--- a/libraries/tools/binary-compatibility-validator/reference-public-api/kotlin-stdlib-runtime-merged.txt
+++ b/libraries/tools/binary-compatibility-validator/reference-public-api/kotlin-stdlib-runtime-merged.txt
@@ -3183,6 +3183,7 @@ public final class kotlin/io/FileTreeWalk : kotlin/sequences/Sequence {
 
 public final class kotlin/io/FileWalkDirection : java/lang/Enum {
 	public static final field BOTTOM_UP Lkotlin/io/FileWalkDirection;
+	public static final field BREADTH_FIRST Lkotlin/io/FileWalkDirection;
 	public static final field TOP_DOWN Lkotlin/io/FileWalkDirection;
 	public static fun valueOf (Ljava/lang/String;)Lkotlin/io/FileWalkDirection;
 	public static fun values ()[Lkotlin/io/FileWalkDirection;
@@ -3232,6 +3233,7 @@ public final class kotlin/io/FilesKt {
 	public static final fun walk (Ljava/io/File;Lkotlin/io/FileWalkDirection;)Lkotlin/io/FileTreeWalk;
 	public static synthetic fun walk$default (Ljava/io/File;Lkotlin/io/FileWalkDirection;ILjava/lang/Object;)Lkotlin/io/FileTreeWalk;
 	public static final fun walkBottomUp (Ljava/io/File;)Lkotlin/io/FileTreeWalk;
+	public static final fun walkBreadthFirst (Ljava/io/File;)Lkotlin/io/FileTreeWalk;
 	public static final fun walkTopDown (Ljava/io/File;)Lkotlin/io/FileTreeWalk;
 	public static final fun writeBytes (Ljava/io/File;[B)V
 	public static final fun writeText (Ljava/io/File;Ljava/lang/String;Ljava/nio/charset/Charset;)V


### PR DESCRIPTION
This pull request adds the feature requested in https://youtrack.jetbrains.com/issue/KT-18629/FileTreeWalk-needs-breadth-first-search