### PR TITLE
Atomicfu: Fix test environment setup

### DIFF
--- a/plugins/atomicfu/atomicfu-compiler/build.gradle.kts
+++ b/plugins/atomicfu/atomicfu-compiler/build.gradle.kts
@@ -1,6 +1,7 @@
 import org.jetbrains.kotlin.gradle.targets.js.KotlinJsCompilerAttribute
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinUsages
+import org.jetbrains.kotlin.gradle.targets.js.d8.D8RootPlugin
 
 description = "Atomicfu Compiler Plugin"
 
@@ -118,11 +119,13 @@ projectTest(jUnitMode = JUnitMode.JUnit5) {
     setUpJsIrBoxTests()
 }
 
+val d8Plugin = D8RootPlugin.apply(rootProject)
+d8Plugin.version = v8Version
+
 fun Test.setupV8() {
-    dependsOn(":js:js.tests:unzipV8")
+    dependsOn(d8Plugin.setupTaskProvider)
     doFirst {
-        val unzipV8Task = project.tasks.getByPath(":js:js.tests:unzipV8")
-        systemProperty("javascript.engine.path.V8", File(unzipV8Task.outputs.files.single().path, "d8"))
+        systemProperty("javascript.engine.path.V8", d8Plugin.requireConfigured().executablePath.absolutePath)
     }
 }
 


### PR DESCRIPTION
Currently, tests for the atomicfu plugin give the following error when run:

```
FAILURE: Build failed with an exception.
* What went wrong:
Could not determine the dependencies of task ':kotlinx-atomicfu-compiler-plugin:test'.
> Task with path ':js:js.tests:unzipV8' not found in project ':kotlinx-atomicfu-compiler-plugin'.
```

As you can see, this problem occurred because the build script refers to a non-existent task `unzipV8` in the `:js:js.tests` module. Judging by the commit history, the cause of the problem is a change in the way to download V8 made by dab1ec7affd261a42165fded8a29b52ca620a6da. 

This fix simply adapts the build script to the changes in the V8 setup.