### PR TITLE
KT-52647 remove "Projects must be configuring" check

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/resolver/KotlinRootNpmResolver.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/resolver/KotlinRootNpmResolver.kt
@@ -246,9 +246,6 @@ internal class KotlinRootNpmResolver internal constructor(
      */
     internal fun prepareInstallation(logger: Logger): Installation {
         synchronized(projectResolvers) {
-            check(state == State.CONFIGURING) {
-                "Projects must be configuring"
-            }
             state = State.PROJECTS_CLOSED
 
             val projectResolutions = projectResolvers.values


### PR DESCRIPTION
This bug is incredibly annoying. I don't see a reason why the "Projects must be configuring" check is here. I propose removing it. So what if `prepareInstalation(...)` runs twice?

https://youtrack.jetbrains.com/issue/KT-52647