### PR TITLE
Make GenerateProjectStructureMetadata configuration cache compatible

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/GenerateProjectStructureMetadata.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/GenerateProjectStructureMetadata.kt
@@ -6,14 +6,19 @@
 package org.jetbrains.kotlin.gradle.plugin.mpp
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.ProjectLayout
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.jetbrains.kotlin.gradle.utils.notCompatibleWithConfigurationCache
 import java.io.File
+import javax.inject.Inject
 
-open class GenerateProjectStructureMetadata : DefaultTask() {
+abstract class GenerateProjectStructureMetadata : DefaultTask() {
+
+    @get:Inject
+    abstract internal val projectLayout: ProjectLayout
 
     @get:Internal
     internal lateinit var lazyKotlinProjectStructureMetadata: Lazy<KotlinProjectStructureMetadata>
@@ -23,7 +28,10 @@ open class GenerateProjectStructureMetadata : DefaultTask() {
         get() = lazyKotlinProjectStructureMetadata.value
 
     @get:OutputFile
-    val resultFile: File = project.buildDir.resolve("kotlinProjectStructureMetadata/$MULTIPLATFORM_PROJECT_METADATA_JSON_FILE_NAME")
+    val resultFile: File
+        get() = projectLayout.buildDirectory.file(
+            "kotlinProjectStructureMetadata/$MULTIPLATFORM_PROJECT_METADATA_JSON_FILE_NAME"
+        ).get().asFile
 
     @TaskAction
     fun generateMetadataXml() {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/GenerateProjectStructureMetadata.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/GenerateProjectStructureMetadata.kt
@@ -15,10 +15,6 @@ import java.io.File
 
 open class GenerateProjectStructureMetadata : DefaultTask() {
 
-    init {
-        notCompatibleWithConfigurationCache("Task $name does not support Gradle Configuration Cache. Check KT-49933 for more info")
-    }
-
     @get:Internal
     internal lateinit var lazyKotlinProjectStructureMetadata: Lazy<KotlinProjectStructureMetadata>
 
@@ -27,8 +23,7 @@ open class GenerateProjectStructureMetadata : DefaultTask() {
         get() = lazyKotlinProjectStructureMetadata.value
 
     @get:OutputFile
-    val resultFile: File
-        get() = project.buildDir.resolve("kotlinProjectStructureMetadata/$MULTIPLATFORM_PROJECT_METADATA_JSON_FILE_NAME")
+    val resultFile: File = project.buildDir.resolve("kotlinProjectStructureMetadata/$MULTIPLATFORM_PROJECT_METADATA_JSON_FILE_NAME")
 
     @TaskAction
     fun generateMetadataXml() {


### PR DESCRIPTION
GenerateProjectStructureMetadata was accessing project  object through a lazy getter of resultFile.
Since calculating this value is not expensive, do it without it being lazy, which makes it configuration
cache compatible.