### PR TITLE
JVM IR: Optimize equality on class literals

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -5134,6 +5134,18 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         }
 
         @Test
+        @TestMetadata("classEquality.kt")
+        public void testClassEquality() throws Exception {
+            runTest("compiler/testData/codegen/box/classLiteral/classEquality.kt");
+        }
+
+        @Test
+        @TestMetadata("primitiveClassEquality.kt")
+        public void testPrimitiveClassEquality() throws Exception {
+            runTest("compiler/testData/codegen/box/classLiteral/primitiveClassEquality.kt");
+        }
+
+        @Test
         @TestMetadata("primitiveKClassEquality.kt")
         public void testPrimitiveKClassEquality() throws Exception {
             runTest("compiler/testData/codegen/box/classLiteral/primitiveKClassEquality.kt");

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -1397,21 +1397,22 @@ class ExpressionCodegen(
         return MaterialValue(this@ExpressionCodegen, JAVA_STRING_TYPE, context.irBuiltIns.stringType)
     }
 
-    override fun visitGetClass(expression: IrGetClass, data: BlockInfo) =
-        generateClassLiteralReference(expression, true, data)
+    override fun visitGetClass(expression: IrGetClass, data: BlockInfo): PromisedValue =
+        generateClassLiteralReference(expression, wrapIntoKClass = true, wrapPrimitives = false, data = data)
 
-    override fun visitClassReference(expression: IrClassReference, data: BlockInfo) =
-        generateClassLiteralReference(expression, true, data)
+    override fun visitClassReference(expression: IrClassReference, data: BlockInfo): PromisedValue =
+        generateClassLiteralReference(expression, wrapIntoKClass = true, wrapPrimitives = false, data = data)
 
     fun generateClassLiteralReference(
         classReference: IrExpression,
         wrapIntoKClass: Boolean,
+        wrapPrimitives: Boolean,
         data: BlockInfo
-    ): PromisedValue {
+    ): MaterialValue {
         when (classReference) {
             is IrGetClass -> {
                 // TODO transform one sort of access into the other?
-                JavaClassProperty.invokeWith(classReference.argument.accept(this, data))
+                JavaClassProperty.invokeWith(classReference.argument.accept(this, data), wrapPrimitives = wrapPrimitives)
             }
             is IrClassReference -> {
                 val classType = classReference.classType
@@ -1423,7 +1424,7 @@ class ExpressionCodegen(
                     }
                 }
 
-                generateClassInstance(mv, classType, typeMapper)
+                generateClassInstance(mv, classType, typeMapper, wrapPrimitives = wrapPrimitives)
             }
             else -> {
                 throw AssertionError("not an IrGetClass or IrClassReference: ${classReference.dump()}")
@@ -1528,9 +1529,9 @@ class ExpressionCodegen(
         get() = this.classifierOrNull?.safeAs<IrTypeParameterSymbol>()?.owner?.isReified == true
 
     companion object {
-        internal fun generateClassInstance(v: InstructionAdapter, classType: IrType, typeMapper: IrTypeMapper) {
+        internal fun generateClassInstance(v: InstructionAdapter, classType: IrType, typeMapper: IrTypeMapper, wrapPrimitives: Boolean) {
             val asmType = typeMapper.mapType(classType)
-            if (classType.getClass()?.isSingleFieldValueClass == true || !isPrimitive(asmType)) {
+            if (wrapPrimitives || classType.getClass()?.isSingleFieldValueClass == true || !isPrimitive(asmType)) {
                 v.aconst(typeMapper.boxType(classType))
             } else {
                 v.getstatic(boxType(asmType).internalName, "TYPE", "Ljava/lang/Class;")

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/IrInlineIntrinsicsSupport.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/IrInlineIntrinsicsSupport.kt
@@ -44,7 +44,7 @@ class IrInlineIntrinsicsSupport(
         get() = context.state
 
     override fun putClassInstance(v: InstructionAdapter, type: IrType) {
-        ExpressionCodegen.generateClassInstance(v, type, typeMapper)
+        ExpressionCodegen.generateClassInstance(v, type, typeMapper, wrapPrimitives = false)
     }
 
     override fun generateTypeParameterContainer(v: InstructionAdapter, typeParameter: TypeParameterMarker) {

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/intrinsics/KClassJavaProperty.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/intrinsics/KClassJavaProperty.kt
@@ -28,6 +28,6 @@ object KClassJavaProperty : IntrinsicMethod() {
         val extensionReceiver = expression.extensionReceiver
         if (extensionReceiver !is IrClassReference && extensionReceiver !is IrGetClass)
             return null
-        return codegen.generateClassLiteralReference(extensionReceiver, false, data)
+        return codegen.generateClassLiteralReference(extensionReceiver, wrapIntoKClass = false, wrapPrimitives = false, data = data)
     }
 }

--- a/compiler/testData/codegen/box/classLiteral/classEquality.kt
+++ b/compiler/testData/codegen/box/classLiteral/classEquality.kt
@@ -1,0 +1,22 @@
+
+open class A
+class B : A()
+
+fun compareClasses(a: Any, b: Any) = a::class == b::class
+
+fun isA(a: Any) = a::class == A::class
+
+inline fun <reified T> isT(a: Any) = a::class == T::class
+
+fun box(): String {
+    if (!compareClasses("a", "b")) return "Fail 1"
+    if (compareClasses(Any(), "")) return "Fail 2"
+    if (!isA(A())) return "Fail 3"
+    if (isA(B())) return "Fail 4"
+    if (!isT<A>(A())) return "Fail 5"
+    if (isT<A>(B())) return "Fail 6"
+    if (isT<B>(A())) return "Fail 7"
+    if (isT<Any>(B())) return "Fail 8"
+    if (!isT<Int>(10 as Any)) return "Fail 9"
+    return "OK"
+}

--- a/compiler/testData/codegen/box/classLiteral/primitiveClassEquality.kt
+++ b/compiler/testData/codegen/box/classLiteral/primitiveClassEquality.kt
@@ -1,0 +1,39 @@
+// boxed primitive comparisons
+fun isBoolean(a: Any) = a::class == true::class
+fun isChar(a: Any) = a::class == 'c'::class
+fun isByte(a: Any) = Byte::class == a::class
+fun isShort(a: Any) = 1.toShort()::class == a::class
+fun isInt(a: Any) = a::class == (40 + 2)::class
+fun isLong(a: Any) = a::class == 0L::class
+fun isFloat(a: Any) = a::class == 1.4f::class
+fun isDouble(a: Any) = a::class == 0.0::class
+
+// reified primitive comparisons
+inline fun <reified T> isReifiedInt() = 1::class == T::class
+
+fun box(): String {
+    if (!isBoolean(true)) return "Fail 1"
+    if (isBoolean(0)) return "Fail 2"
+    if (!isChar('c')) return "Fail 3"
+    if (isChar(0)) return "Fail 4"
+    if (!isByte(0.toByte())) return "Fail 5"
+    if (isByte(0)) return "Fail 6"
+    if (!isShort(0.toShort())) return "Fail 7"
+    if (isShort(0)) return "Fail 8"
+    if (!isInt(0)) return "Fail 9"
+    if (isInt("")) return "Fail 10"
+    if (!isLong(0L)) return "Fail 11"
+    if (isLong(0.0)) return "Fail 12"
+    if (!isFloat(10.0f)) return "Fail 13"
+    if (isFloat("")) return "Fail 14"
+    if (!isDouble(1.0)) return "Fail 15"
+    if (isDouble(0)) return "Fail 16"
+
+    if (!isReifiedInt<Int>()) return "Fail 17"
+    if (isReifiedInt<Any>()) return "Fail 18"
+
+    if (1::class != Int::class) return "Fail 19"
+    if ('c'::class == ""::class) return "Fail 20"
+
+    return "OK"
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -5020,6 +5020,18 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
         }
 
         @Test
+        @TestMetadata("classEquality.kt")
+        public void testClassEquality() throws Exception {
+            runTest("compiler/testData/codegen/box/classLiteral/classEquality.kt");
+        }
+
+        @Test
+        @TestMetadata("primitiveClassEquality.kt")
+        public void testPrimitiveClassEquality() throws Exception {
+            runTest("compiler/testData/codegen/box/classLiteral/primitiveClassEquality.kt");
+        }
+
+        @Test
         @TestMetadata("primitiveKClassEquality.kt")
         public void testPrimitiveKClassEquality() throws Exception {
             runTest("compiler/testData/codegen/box/classLiteral/primitiveKClassEquality.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -5134,6 +5134,18 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         }
 
         @Test
+        @TestMetadata("classEquality.kt")
+        public void testClassEquality() throws Exception {
+            runTest("compiler/testData/codegen/box/classLiteral/classEquality.kt");
+        }
+
+        @Test
+        @TestMetadata("primitiveClassEquality.kt")
+        public void testPrimitiveClassEquality() throws Exception {
+            runTest("compiler/testData/codegen/box/classLiteral/primitiveClassEquality.kt");
+        }
+
+        @Test
         @TestMetadata("primitiveKClassEquality.kt")
         public void testPrimitiveKClassEquality() throws Exception {
             runTest("compiler/testData/codegen/box/classLiteral/primitiveKClassEquality.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -4397,6 +4397,16 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/classLiteral/bareArray.kt");
         }
 
+        @TestMetadata("classEquality.kt")
+        public void testClassEquality() throws Exception {
+            runTest("compiler/testData/codegen/box/classLiteral/classEquality.kt");
+        }
+
+        @TestMetadata("primitiveClassEquality.kt")
+        public void testPrimitiveClassEquality() throws Exception {
+            runTest("compiler/testData/codegen/box/classLiteral/primitiveClassEquality.kt");
+        }
+
         @TestMetadata("primitiveKClassEquality.kt")
         public void testPrimitiveKClassEquality() throws Exception {
             runTest("compiler/testData/codegen/box/classLiteral/primitiveKClassEquality.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/JsCodegenBoxTestGenerated.java
@@ -3687,6 +3687,18 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/classLiteral/bareArray.kt");
         }
 
+        @Test
+        @TestMetadata("classEquality.kt")
+        public void testClassEquality() throws Exception {
+            runTest("compiler/testData/codegen/box/classLiteral/classEquality.kt");
+        }
+
+        @Test
+        @TestMetadata("primitiveClassEquality.kt")
+        public void testPrimitiveClassEquality() throws Exception {
+            runTest("compiler/testData/codegen/box/classLiteral/primitiveClassEquality.kt");
+        }
+
         @Nested
         @TestMetadata("compiler/testData/codegen/box/classLiteral/bound")
         @TestDataPath("$PROJECT_ROOT")

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/IrJsCodegenBoxTestGenerated.java
@@ -3729,6 +3729,18 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             runTest("compiler/testData/codegen/box/classLiteral/bareArray.kt");
         }
 
+        @Test
+        @TestMetadata("classEquality.kt")
+        public void testClassEquality() throws Exception {
+            runTest("compiler/testData/codegen/box/classLiteral/classEquality.kt");
+        }
+
+        @Test
+        @TestMetadata("primitiveClassEquality.kt")
+        public void testPrimitiveClassEquality() throws Exception {
+            runTest("compiler/testData/codegen/box/classLiteral/primitiveClassEquality.kt");
+        }
+
         @Nested
         @TestMetadata("compiler/testData/codegen/box/classLiteral/bound")
         @TestDataPath("$PROJECT_ROOT")

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/testOld/wasm/semantics/IrCodegenBoxWasmTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/testOld/wasm/semantics/IrCodegenBoxWasmTestGenerated.java
@@ -3312,6 +3312,16 @@ public class IrCodegenBoxWasmTestGenerated extends AbstractIrCodegenBoxWasmTest 
             runTest("compiler/testData/codegen/box/classLiteral/bareArray.kt");
         }
 
+        @TestMetadata("classEquality.kt")
+        public void testClassEquality() throws Exception {
+            runTest("compiler/testData/codegen/box/classLiteral/classEquality.kt");
+        }
+
+        @TestMetadata("primitiveClassEquality.kt")
+        public void testPrimitiveClassEquality() throws Exception {
+            runTest("compiler/testData/codegen/box/classLiteral/primitiveClassEquality.kt");
+        }
+
         @TestMetadata("compiler/testData/codegen/box/classLiteral/bound")
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)

--- a/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/NativeCodegenBoxTestGenerated.java
+++ b/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/NativeCodegenBoxTestGenerated.java
@@ -3841,6 +3841,18 @@ public class NativeCodegenBoxTestGenerated extends AbstractNativeCodegenBoxTest 
                 runTest("compiler/testData/codegen/box/classLiteral/bareArray.kt");
             }
 
+            @Test
+            @TestMetadata("classEquality.kt")
+            public void testClassEquality() throws Exception {
+                runTest("compiler/testData/codegen/box/classLiteral/classEquality.kt");
+            }
+
+            @Test
+            @TestMetadata("primitiveClassEquality.kt")
+            public void testPrimitiveClassEquality() throws Exception {
+                runTest("compiler/testData/codegen/box/classLiteral/primitiveClassEquality.kt");
+            }
+
             @Nested
             @TestMetadata("compiler/testData/codegen/box/classLiteral/bound")
             @TestDataPath("$PROJECT_ROOT")


### PR DESCRIPTION
In common code in a multiplatform project the `KotlinGenerateEqualsAndHashcodeAction` generates `equals` methods containing a check of the form `this::class == other::class`. This is slower than code using `javaClass` on Kotlin/JVM since it contains additional calls to `kotlin.jvm.internal.Reflection.getOrCreateKotlinClass`.

This PR optimizes this check in the JVM IR backend, by replacing `a::class == b::class` with `a.javaClass === b.javaClass`.