### PR TITLE
JVM: do not assume presence of default method handle arguments

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/InlineCodegen.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/InlineCodegen.kt
@@ -106,7 +106,7 @@ abstract class InlineCodegen<out T : BaseExpressionCodegen>(
             node, parameters, info, FieldRemapper(null, null, parameters), sourceCompiler.isCallInsideSameModuleAsCallee,
             "Method inlining " + sourceCompiler.callElementText,
             SourceMapCopier(sourceMapper, nodeAndSmap.classSMAP, callSite),
-            info.callSiteInfo, isInlineOnly, !isInlinedToInlineFunInKotlinRuntime(), maskStartIndex, methodHandleInDefaultMethodIndex
+            info.callSiteInfo, isInlineOnly, !isInlinedToInlineFunInKotlinRuntime(), maskStartIndex, maskStartIndex + maskValues.size,
         ) //with captured
 
         val remapper = LocalVarRemapper(parameters, initialFrameSize)


### PR DESCRIPTION
I believe Jetpack Compose is not generating them, and that's what's causing KT-58243. Adding them is obviously an ABI-breaking change.