### PR TITLE
Added `TYPE_USE` to `Mutable` and `ReadOnly`

### DIFF
--- a/libraries/tools/kotlin-annotations-jvm/src/kotlin/annotations/jvm/Mutable.java
+++ b/libraries/tools/kotlin-annotations-jvm/src/kotlin/annotations/jvm/Mutable.java
@@ -24,6 +24,6 @@ import java.lang.annotation.*;
  */
 @Documented
 @Retention(RetentionPolicy.CLASS)
-@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE})
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE})
 public @interface Mutable {
 }

--- a/libraries/tools/kotlin-annotations-jvm/src/kotlin/annotations/jvm/ReadOnly.java
+++ b/libraries/tools/kotlin-annotations-jvm/src/kotlin/annotations/jvm/ReadOnly.java
@@ -24,6 +24,6 @@ import java.lang.annotation.*;
  */
 @Documented
 @Retention(RetentionPolicy.CLASS)
-@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE})
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE})
 public @interface ReadOnly {
 }

--- a/libraries/tools/mutability-annotations-compat/src/org/jetbrains/annotations/Mutable.java
+++ b/libraries/tools/mutability-annotations-compat/src/org/jetbrains/annotations/Mutable.java
@@ -24,6 +24,6 @@ import java.lang.annotation.*;
  */
 @Documented
 @Retention(RetentionPolicy.CLASS)
-@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE})
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE})
 public @interface Mutable {
 }

--- a/libraries/tools/mutability-annotations-compat/src/org/jetbrains/annotations/ReadOnly.java
+++ b/libraries/tools/mutability-annotations-compat/src/org/jetbrains/annotations/ReadOnly.java
@@ -24,6 +24,6 @@ import java.lang.annotation.*;
  */
 @Documented
 @Retention(RetentionPolicy.CLASS)
-@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE})
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE})
 public @interface ReadOnly {
 }


### PR DESCRIPTION
The `Mutable` and `ReadOnly` annotations are currently unusable on generics because they are missing the `TYPE_USE` target. This is a problem in many situations, most notable in lambda parameters, e.g.:

```java
public final class Example {
    public static void example(Consumer<@Mutable Map<String, String>> builder) {}
}
```
