### PR TITLE
KT-48822: Fixes ConcurrentModificationException in AsmTypes

### DIFF
--- a/compiler/backend.common.jvm/src/org/jetbrains/kotlin/resolve/jvm/AsmTypes.java
+++ b/compiler/backend.common.jvm/src/org/jetbrains/kotlin/resolve/jvm/AsmTypes.java
@@ -14,9 +14,10 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class AsmTypes {
-    private static final Map<Class<?>, Type> TYPES_MAP = new HashMap<>();
+    private static final Map<Class<?>, Type> TYPES_MAP = new ConcurrentHashMap<>();
 
     public static final Type OBJECT_TYPE = getType(Object.class);
     public static final Type JAVA_STRING_TYPE = getType(String.class);


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-48822

We catch a flaky build crash with the following stacktrace:
```
 Caused by: java.util.ConcurrentModificationException
 	at java.base/java.util.HashMap.computeIfAbsent(HashMap.java:1134)
 	at org.jetbrains.kotlin.resolve.jvm.AsmTypes.getType(AsmTypes.java:133)
 	at org.jetbrains.kotlin.codegen.AsmUtil.wrapJavaClassesIntoKClasses(AsmUtil.java:443)
```

Presumably, AsmTypes#getType() could be called from multiple threads during build process, which causes CME sometimes.
Can't reproduce steps to get a crash, that might be a hint to concurrent nature of problem as well.

Solution: make TYPES_MAP modification safe.