### PR TITLE
[KT-28982] Removed `@Target` from `@Mutable` and `@ReadOnly`

### DIFF
--- a/libraries/tools/kotlin-annotations-jvm/src/kotlin/annotations/jvm/Mutable.java
+++ b/libraries/tools/kotlin-annotations-jvm/src/kotlin/annotations/jvm/Mutable.java
@@ -24,6 +24,5 @@ import java.lang.annotation.*;
  */
 @Documented
 @Retention(RetentionPolicy.CLASS)
-@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE})
 public @interface Mutable {
 }

--- a/libraries/tools/kotlin-annotations-jvm/src/kotlin/annotations/jvm/ReadOnly.java
+++ b/libraries/tools/kotlin-annotations-jvm/src/kotlin/annotations/jvm/ReadOnly.java
@@ -24,6 +24,5 @@ import java.lang.annotation.*;
  */
 @Documented
 @Retention(RetentionPolicy.CLASS)
-@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE})
 public @interface ReadOnly {
 }

--- a/libraries/tools/mutability-annotations-compat/src/org/jetbrains/annotations/Mutable.java
+++ b/libraries/tools/mutability-annotations-compat/src/org/jetbrains/annotations/Mutable.java
@@ -24,6 +24,5 @@ import java.lang.annotation.*;
  */
 @Documented
 @Retention(RetentionPolicy.CLASS)
-@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE})
 public @interface Mutable {
 }

--- a/libraries/tools/mutability-annotations-compat/src/org/jetbrains/annotations/ReadOnly.java
+++ b/libraries/tools/mutability-annotations-compat/src/org/jetbrains/annotations/ReadOnly.java
@@ -24,6 +24,5 @@ import java.lang.annotation.*;
  */
 @Documented
 @Retention(RetentionPolicy.CLASS)
-@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE})
 public @interface ReadOnly {
 }


### PR DESCRIPTION
Closes #4918 as it is a Java 6 compatible alternative to adding `TYPE_USE` to the targets that works in Java versions older than 8 as well. The idea for this comes directly from https://youtrack.jetbrains.com/issue/KT-28982.
