### PR TITLE
FIR ObjCName checkers

### DIFF
--- a/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/diagnostics/FirNativeDiagnosticsList.kt
+++ b/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/diagnostics/FirNativeDiagnosticsList.kt
@@ -47,5 +47,20 @@ object NATIVE_DIAGNOSTICS_LIST : DiagnosticList("FirNativeErrors") {
             parameter<Collection<FirRegularClassSymbol>>("containingClasses")
         }
         val INVALID_OBJC_REFINEMENT_TARGETS by error<KtElement>()
+        val INAPPLICABLE_OBJC_NAME by error<KtElement>()
+        val INVALID_OBJC_NAME by error<KtElement>()
+        val INVALID_OBJC_NAME_CHARS by error<KtElement> {
+            parameter<String>("characters")
+        }
+        val INVALID_OBJC_NAME_FIRST_CHAR by error<KtElement> {
+            parameter<String>("characters")
+        }
+        val INCOMPATIBLE_OBJC_NAME_OVERRIDE by error<KtElement> {
+            parameter<FirBasedSymbol<*>>("declaration")
+            parameter<Collection<FirRegularClassSymbol>>("containingClasses")
+        }
+        val INAPPLICABLE_EXACT_OBJC_NAME by error<KtElement>()
+        val MISSING_EXACT_OBJC_NAME by error<KtElement>()
+        val NON_LITERAL_OBJC_NAME_ARG by error<KtElement>()
     }
 }

--- a/compiler/fir/checkers/checkers.native/gen/org/jetbrains/kotlin/fir/analysis/diagnostics/native/FirNativeErrors.kt
+++ b/compiler/fir/checkers/checkers.native/gen/org/jetbrains/kotlin/fir/analysis/diagnostics/native/FirNativeErrors.kt
@@ -36,6 +36,14 @@ object FirNativeErrors {
     val REDUNDANT_SWIFT_REFINEMENT by error0<KtElement>()
     val INCOMPATIBLE_OBJC_REFINEMENT_OVERRIDE by error2<KtElement, FirBasedSymbol<*>, Collection<FirRegularClassSymbol>>()
     val INVALID_OBJC_REFINEMENT_TARGETS by error0<KtElement>()
+    val INAPPLICABLE_OBJC_NAME by error0<KtElement>()
+    val INVALID_OBJC_NAME by error0<KtElement>()
+    val INVALID_OBJC_NAME_CHARS by error1<KtElement, String>()
+    val INVALID_OBJC_NAME_FIRST_CHAR by error1<KtElement, String>()
+    val INCOMPATIBLE_OBJC_NAME_OVERRIDE by error2<KtElement, FirBasedSymbol<*>, Collection<FirRegularClassSymbol>>()
+    val INAPPLICABLE_EXACT_OBJC_NAME by error0<KtElement>()
+    val MISSING_EXACT_OBJC_NAME by error0<KtElement>()
+    val NON_LITERAL_OBJC_NAME_ARG by error0<KtElement>()
 
     init {
         RootDiagnosticRendererFactory.registerFactory(FirNativeErrorsDefaultMessages)

--- a/compiler/fir/checkers/checkers.native/src/org/jetbrains/kotlin/fir/analysis/diagnostics/native/FirNativeErrorsDefaultMessages.kt
+++ b/compiler/fir/checkers/checkers.native/src/org/jetbrains/kotlin/fir/analysis/diagnostics/native/FirNativeErrorsDefaultMessages.kt
@@ -11,17 +11,25 @@ import org.jetbrains.kotlin.diagnostics.rendering.BaseDiagnosticRendererFactory
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirDiagnosticRenderers.SYMBOL
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirDiagnosticRenderers.SYMBOLS
 import org.jetbrains.kotlin.fir.analysis.diagnostics.checkMissingMessages
+import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.INAPPLICABLE_EXACT_OBJC_NAME
+import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.INAPPLICABLE_OBJC_NAME
 import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.INAPPLICABLE_SHARED_IMMUTABLE_PROPERTY
 import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.INAPPLICABLE_SHARED_IMMUTABLE_TOP_LEVEL
 import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.INAPPLICABLE_THREAD_LOCAL
 import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.INAPPLICABLE_THREAD_LOCAL_TOP_LEVEL
+import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.INCOMPATIBLE_OBJC_NAME_OVERRIDE
 import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.INCOMPATIBLE_OBJC_REFINEMENT_OVERRIDE
 import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.INCOMPATIBLE_THROWS_INHERITED
 import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.INCOMPATIBLE_THROWS_OVERRIDE
 import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.INVALID_CHARACTERS_NATIVE
+import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.INVALID_OBJC_NAME
+import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.INVALID_OBJC_NAME_CHARS
+import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.INVALID_OBJC_NAME_FIRST_CHAR
 import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.INVALID_OBJC_REFINEMENT_TARGETS
+import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.MISSING_EXACT_OBJC_NAME
 import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.MISSING_EXCEPTION_IN_THROWS_ON_SUSPEND
 import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.REDUNDANT_SWIFT_REFINEMENT
+import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.NON_LITERAL_OBJC_NAME_ARG
 import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.THROWS_LIST_EMPTY
 
 object FirNativeErrorsDefaultMessages : BaseDiagnosticRendererFactory() {
@@ -55,6 +63,14 @@ object FirNativeErrorsDefaultMessages : BaseDiagnosticRendererFactory() {
             INVALID_OBJC_REFINEMENT_TARGETS,
             "Refines annotations are only applicable to annotations with targets FUNCTION and/or PROPERTY"
         )
+        map.put(INAPPLICABLE_OBJC_NAME, "@ObjCName is not applicable on overrides")
+        map.put(INVALID_OBJC_NAME, "@ObjCName should have a name and/or swiftName")
+        map.put(INVALID_OBJC_NAME_CHARS, "@ObjCName contains illegal characters: {0}", TO_STRING)
+        map.put(INVALID_OBJC_NAME_FIRST_CHAR, "@ObjCName contains illegal first characters: {0}", TO_STRING)
+        map.put(INCOMPATIBLE_OBJC_NAME_OVERRIDE, "Member \"{0}\" inherits inconsistent @ObjCName from {1}", SYMBOL, SYMBOLS)
+        map.put(INAPPLICABLE_EXACT_OBJC_NAME, "Exact @ObjCName is only applicable to classes, objects and interfaces")
+        map.put(MISSING_EXACT_OBJC_NAME, "Exact @ObjCName is required to have an ObjC name")
+        map.put(NON_LITERAL_OBJC_NAME_ARG, "@ObjCName accepts only literal string and boolean values")
 
         map.checkMissingMessages(FirNativeErrors)
     }

--- a/compiler/fir/checkers/checkers.native/src/org/jetbrains/kotlin/fir/analysis/native/checkers/FirNativeObjCNameChecker.kt
+++ b/compiler/fir/checkers/checkers.native/src/org/jetbrains/kotlin/fir/analysis/native/checkers/FirNativeObjCNameChecker.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.fir.analysis.native.checkers
+
+import org.jetbrains.kotlin.descriptors.ClassKind
+import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.diagnostics.reportOn
+import org.jetbrains.kotlin.fir.FirAnnotationContainer
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirBasicDeclarationChecker
+import org.jetbrains.kotlin.fir.analysis.checkers.unsubstitutedScope
+import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.INAPPLICABLE_EXACT_OBJC_NAME
+import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.INAPPLICABLE_OBJC_NAME
+import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.INVALID_OBJC_NAME
+import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.INVALID_OBJC_NAME_CHARS
+import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.INVALID_OBJC_NAME_FIRST_CHAR
+import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.MISSING_EXACT_OBJC_NAME
+import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.NON_LITERAL_OBJC_NAME_ARG
+import org.jetbrains.kotlin.fir.analysis.native.checkers.FirNativeObjCNameOverridesChecker.check
+import org.jetbrains.kotlin.fir.declarations.*
+import org.jetbrains.kotlin.fir.declarations.utils.isOverride
+import org.jetbrains.kotlin.fir.expressions.FirAnnotation
+import org.jetbrains.kotlin.fir.expressions.FirConstExpression
+import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirFunctionSymbol
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
+
+object FirNativeObjCNameChecker : FirBasicDeclarationChecker() {
+
+    private val objCNameClassId = ClassId.topLevel(FqName("kotlin.native.ObjCName"))
+    private val nameName = Name.identifier("name")
+    private val swiftNameName = Name.identifier("swiftName")
+    private val exactName = Name.identifier("exact")
+
+    override fun check(declaration: FirDeclaration, context: CheckerContext, reporter: DiagnosticReporter) {
+        checkDeclaration(declaration, context, reporter)
+        if (declaration is FirCallableDeclaration && (declaration is FirSimpleFunction || declaration is FirProperty)) {
+            val containingClass = context.containingDeclarations.lastOrNull() as? FirClass
+            if (containingClass != null) {
+                val firTypeScope = containingClass.unsubstitutedScope(context)
+                check(firTypeScope, declaration.symbol, declaration, context, reporter)
+            }
+        }
+    }
+
+    private fun checkDeclaration(declaration: FirDeclaration, context: CheckerContext, reporter: DiagnosticReporter) {
+        if (declaration is FirValueParameter) return // those are checked with the FirFunction
+        val objCNames = declaration.symbol.getObjCNames().filterNotNull()
+        if (objCNames.isEmpty()) return
+        if (declaration is FirCallableDeclaration && declaration.isOverride) {
+            for (objCName in objCNames) {
+                reporter.reportOn(objCName.annotation.source, INAPPLICABLE_OBJC_NAME, context)
+            }
+        }
+        objCNames.forEach { checkObjCName(it, declaration, context, reporter) }
+    }
+
+    // We only allow valid ObjC identifiers (even for Swift names)
+    private val validFirstChars = ('A'..'Z').toSet() + ('a'..'z').toSet() + '_'
+    private val validChars = validFirstChars + ('0'..'9').toSet()
+
+    private fun checkObjCName(objCName: ObjCName, declaration: FirDeclaration, context: CheckerContext, reporter: DiagnosticReporter) {
+        val annotationSource = objCName.annotation.source
+        for ((_, argument) in objCName.annotation.argumentMapping.mapping) {
+            if (argument is FirConstExpression<*>) continue
+            reporter.reportOn(argument.source, NON_LITERAL_OBJC_NAME_ARG, context)
+        }
+        if (objCName.name == null && objCName.swiftName == null) {
+            reporter.reportOn(annotationSource, INVALID_OBJC_NAME, context)
+        }
+        val invalidNameFirstChar = objCName.name?.firstOrNull()?.takeUnless(validFirstChars::contains)
+        val invalidSwiftNameFirstChar = objCName.swiftName?.firstOrNull()?.takeUnless(validFirstChars::contains)
+        val invalidFirstChars = setOfNotNull(invalidNameFirstChar, invalidSwiftNameFirstChar)
+        if (invalidFirstChars.isNotEmpty()) {
+            reporter.reportOn(annotationSource, INVALID_OBJC_NAME_FIRST_CHAR, invalidFirstChars.joinToString(""), context)
+        }
+        val invalidNameChars = objCName.name?.toSet()?.subtract(validChars) ?: emptySet()
+        val invalidSwiftNameChars = objCName.swiftName?.toSet()?.subtract(validChars) ?: emptySet()
+        val invalidChars = invalidNameChars + invalidSwiftNameChars
+        if (invalidChars.isNotEmpty()) {
+            reporter.reportOn(annotationSource, INVALID_OBJC_NAME_CHARS, invalidFirstChars.joinToString(""), context)
+        }
+        if (objCName.exact && (declaration !is FirClass || declaration.classKind == ClassKind.ENUM_ENTRY)) {
+            reporter.reportOn(annotationSource, INAPPLICABLE_EXACT_OBJC_NAME, context)
+        }
+        if (objCName.exact && objCName.name == null) {
+            reporter.reportOn(annotationSource, MISSING_EXACT_OBJC_NAME, context)
+        }
+    }
+
+    class ObjCName(
+        val annotation: FirAnnotation
+    ) {
+        val name: String? = annotation.getStringArgument(nameName)?.takeIf { it.isNotBlank() }
+        val swiftName: String? = annotation.getStringArgument(swiftNameName)?.takeIf { it.isNotBlank() }
+        val exact: Boolean = annotation.getBooleanArgument(exactName) ?: false
+
+        override fun equals(other: Any?): Boolean =
+            other is ObjCName && name == other.name && swiftName == other.swiftName && exact == other.exact
+
+        override fun hashCode(): Int {
+            var result = name.hashCode()
+            result = 31 * result + swiftName.hashCode()
+            result = 31 * result + exact.hashCode()
+            return result
+        }
+    }
+
+    private fun FirAnnotationContainer.getObjCName(): ObjCName? =
+        getAnnotationByClassId(objCNameClassId)?.let(::ObjCName)
+
+    private fun FirBasedSymbol<*>.getObjCName(): ObjCName? =
+        getAnnotationByClassId(objCNameClassId)?.let(::ObjCName)
+
+    fun FirBasedSymbol<*>.getObjCNames(): List<ObjCName?> = when (this) {
+        is FirFunctionSymbol<*> -> buildList {
+            add((this@getObjCNames as FirBasedSymbol<*>).getObjCName())
+            add(resolvedReceiverTypeRef?.getObjCName())
+            valueParameterSymbols.forEach { add(it.getObjCName()) }
+        }
+
+        else -> listOf(getObjCName())
+    }
+}

--- a/compiler/fir/checkers/checkers.native/src/org/jetbrains/kotlin/fir/analysis/native/checkers/FirNativeObjCNameOverridesChecker.kt
+++ b/compiler/fir/checkers/checkers.native/src/org/jetbrains/kotlin/fir/analysis/native/checkers/FirNativeObjCNameOverridesChecker.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.fir.analysis.native.checkers
+
+import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.diagnostics.reportOn
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirClassChecker
+import org.jetbrains.kotlin.fir.analysis.checkers.unsubstitutedScope
+import org.jetbrains.kotlin.fir.analysis.diagnostics.native.FirNativeErrors.INCOMPATIBLE_OBJC_NAME_OVERRIDE
+import org.jetbrains.kotlin.fir.analysis.native.checkers.FirNativeObjCNameChecker.getObjCNames
+import org.jetbrains.kotlin.fir.containingClass
+import org.jetbrains.kotlin.fir.declarations.FirClass
+import org.jetbrains.kotlin.fir.declarations.FirDeclaration
+import org.jetbrains.kotlin.fir.isIntersectionOverride
+import org.jetbrains.kotlin.fir.resolve.toFirRegularClassSymbol
+import org.jetbrains.kotlin.fir.scopes.*
+import org.jetbrains.kotlin.fir.symbols.impl.FirCallableSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
+
+object FirNativeObjCNameOverridesChecker : FirClassChecker() {
+
+    override fun check(declaration: FirClass, context: CheckerContext, reporter: DiagnosticReporter) {
+        // We just need to check intersection overrides, all other declarations are checked by FirNativeObjCNameChecker
+        val firTypeScope = declaration.unsubstitutedScope(context)
+        firTypeScope.processAllFunctions { symbol ->
+            if (!symbol.isIntersectionOverride) return@processAllFunctions
+            check(firTypeScope, symbol, declaration, context, reporter)
+        }
+        firTypeScope.processAllProperties { symbol ->
+            if (!symbol.isIntersectionOverride) return@processAllProperties
+            check(firTypeScope, symbol, declaration, context, reporter)
+        }
+    }
+
+    fun check(
+        firTypeScope: FirTypeScope,
+        memberSymbol: FirCallableSymbol<*>,
+        declarationToReport: FirDeclaration,
+        context: CheckerContext,
+        reporter: DiagnosticReporter
+    ) {
+        val overriddenSymbols = firTypeScope.getDirectOverriddenSymbols(memberSymbol)
+        if (overriddenSymbols.isEmpty()) return
+        val objCNames = overriddenSymbols.map { it.getFirstBaseSymbol(firTypeScope).getObjCNames() }
+        if (!objCNames.allNamesEquals()) {
+            val containingDeclarations = overriddenSymbols.mapNotNull { it.containingClass()?.toFirRegularClassSymbol(context.session) }
+            reporter.reportOn(
+                declarationToReport.source,
+                INCOMPATIBLE_OBJC_NAME_OVERRIDE,
+                declarationToReport.symbol,
+                containingDeclarations,
+                context
+            )
+        }
+    }
+
+    private fun FirTypeScope.getDirectOverriddenSymbols(memberSymbol: FirCallableSymbol<*>): List<FirCallableSymbol<*>> {
+        return when (memberSymbol) {
+            is FirNamedFunctionSymbol -> {
+                processFunctionsByName(memberSymbol.name) {}
+                getDirectOverriddenFunctions(memberSymbol)
+            }
+
+            is FirPropertySymbol -> {
+                processPropertiesByName(memberSymbol.name) {}
+                getDirectOverriddenProperties(memberSymbol)
+            }
+
+            else -> error("unexpected member kind $memberSymbol")
+        }
+    }
+
+    private fun FirCallableSymbol<*>.getFirstBaseSymbol(firTypeScope: FirTypeScope): FirCallableSymbol<*> {
+        val overriddenMemberSymbols = firTypeScope.getDirectOverriddenSymbols(this)
+        return if (overriddenMemberSymbols.isEmpty()) this else overriddenMemberSymbols.first().getFirstBaseSymbol(firTypeScope)
+    }
+
+    private fun List<List<FirNativeObjCNameChecker.ObjCName?>>.allNamesEquals(): Boolean {
+        val first = this[0]
+        for (i in 1 until size) {
+            if (first != this[i]) return false
+        }
+        return true
+    }
+}

--- a/compiler/fir/checkers/checkers.native/src/org/jetbrains/kotlin/fir/analysis/native/checkers/NativeDeclarationCheckers.kt
+++ b/compiler/fir/checkers/checkers.native/src/org/jetbrains/kotlin/fir/analysis/native/checkers/NativeDeclarationCheckers.kt
@@ -13,7 +13,8 @@ object NativeDeclarationCheckers : DeclarationCheckers() {
             FirNativeThrowsChecker,
             FirNativeSharedImmutableChecker,
             FirNativeThreadLocalChecker,
-            FirNativeIdentifierChecker
+            FirNativeIdentifierChecker,
+            FirNativeObjCNameChecker
         )
 
     override val callableDeclarationCheckers: Set<FirCallableDeclarationChecker>
@@ -23,7 +24,8 @@ object NativeDeclarationCheckers : DeclarationCheckers() {
 
     override val classCheckers: Set<FirClassChecker>
         get() = setOf(
-            FirNativeObjCRefinementOverridesChecker
+            FirNativeObjCRefinementOverridesChecker,
+            FirNativeObjCNameOverridesChecker
         )
 
     override val regularClassCheckers: Set<FirRegularClassChecker>

--- a/compiler/testData/diagnostics/nativeTests/objCName.fir.kt
+++ b/compiler/testData/diagnostics/nativeTests/objCName.fir.kt
@@ -24,30 +24,39 @@ open class KotlinClass {
 
 @ObjCName("ObjCSubClass", "SwiftSubClass")
 class KotlinSubClass: KotlinClass() {
-    @ObjCName("objCProperty")
+    <!INAPPLICABLE_OBJC_NAME!>@ObjCName("objCProperty")<!>
     override var kotlinProperty: Int = 1
-    @ObjCName(swiftName = "swiftFunction")
-    override fun @receiver:ObjCName("objCReceiver") Int.kotlinFunction(
-        @ObjCName("objCParam") kotlinParam: Int
+    <!INAPPLICABLE_OBJC_NAME!>@ObjCName(swiftName = "swiftFunction")<!>
+    override fun <!INAPPLICABLE_OBJC_NAME!>@receiver:ObjCName("objCReceiver")<!> Int.kotlinFunction(
+        <!INAPPLICABLE_OBJC_NAME!>@ObjCName("objCParam")<!> kotlinParam: Int
     ): Int = this + kotlinParam * 2
 }
 
-@ObjCName()
-val invalidObjCName: Int = 0
+<!INVALID_OBJC_NAME!>@ObjCName()<!>
+val invalidObjCNameA: Int = 0
 
-@ObjCName("validName", "invalid.name")
+<!INVALID_OBJC_NAME!>@ObjCName("", "")<!>
+val invalidObjCNameB: Int = 0
+
+@ObjCName("validName", "")
+val validBlankObjCNameA: Int = 0
+
+@ObjCName("", "validName")
+val validBlankObjCNameB: Int = 0
+
+<!INVALID_OBJC_NAME_CHARS!>@ObjCName("validName", "invalid.name")<!>
 val invalidCharactersObjCNameA: Int = 0
 
-@ObjCName("invalid.name", "validName")
+<!INVALID_OBJC_NAME_CHARS!>@ObjCName("invalid.name", "validName")<!>
 val invalidCharactersObjCNameB: Int = 0
 
-@ObjCName("validName1", "1validName")
+<!INVALID_OBJC_NAME_FIRST_CHAR!>@ObjCName("validName1", "1validName")<!>
 val invalidFirstCharacterObjCNameA: Int = 0
 
-@ObjCName("1validName", "validName1")
+<!INVALID_OBJC_NAME_FIRST_CHAR!>@ObjCName("1validName", "validName1")<!>
 val invalidFirstCharacterObjCNameB: Int = 0
 
-@ObjCName(swiftName = "SwiftMissingExactName", exact = true)
+<!MISSING_EXACT_OBJC_NAME!>@ObjCName(swiftName = "SwiftMissingExactName", exact = true)<!>
 class MissingExactName
 
 interface KotlinInterfaceA {
@@ -118,32 +127,32 @@ interface KotlinInterfaceB {
 
 class KotlinOverrideClass: KotlinInterfaceA, KotlinInterfaceB {
     override var kotlinPropertyA: Int = 0
-    override var kotlinPropertyB: Int = 0
-    override var kotlinPropertyC: Int = 0
-    override var kotlinPropertyD: Int = 0
-    override var kotlinPropertyE: Int = 0
+    <!INCOMPATIBLE_OBJC_NAME_OVERRIDE!>override var kotlinPropertyB: Int = 0<!>
+    <!INCOMPATIBLE_OBJC_NAME_OVERRIDE!>override var kotlinPropertyC: Int = 0<!>
+    <!INCOMPATIBLE_OBJC_NAME_OVERRIDE!>override var kotlinPropertyD: Int = 0<!>
+    <!INCOMPATIBLE_OBJC_NAME_OVERRIDE!>override var kotlinPropertyE: Int = 0<!>
     override var kotlinPropertyF: Int = 0
 
     override fun Int.kotlinFunctionA(kotlinParam: Int): Int = this + kotlinParam
-    override fun Int.kotlinFunctionB(kotlinParam: Int): Int = this + kotlinParam
-    override fun Int.kotlinFunctionC(kotlinParam: Int): Int = this + kotlinParam
-    override fun Int.kotlinFunctionD(kotlinParam: Int): Int = this + kotlinParam
-    override fun Int.kotlinFunctionE(kotlinParam: Int): Int = this + kotlinParam
+    <!INCOMPATIBLE_OBJC_NAME_OVERRIDE!>override fun Int.kotlinFunctionB(kotlinParam: Int): Int = this + kotlinParam<!>
+    <!INCOMPATIBLE_OBJC_NAME_OVERRIDE!>override fun Int.kotlinFunctionC(kotlinParam: Int): Int = this + kotlinParam<!>
+    <!INCOMPATIBLE_OBJC_NAME_OVERRIDE!>override fun Int.kotlinFunctionD(kotlinParam: Int): Int = this + kotlinParam<!>
+    <!INCOMPATIBLE_OBJC_NAME_OVERRIDE!>override fun Int.kotlinFunctionE(kotlinParam: Int): Int = this + kotlinParam<!>
 }
 
 @ObjCName("ObjCExactChecks", exact = true)
 class ExactChecks {
-    @ObjCName("objCProperty", exact = true)
+    <!INAPPLICABLE_EXACT_OBJC_NAME!>@ObjCName("objCProperty", exact = true)<!>
     var property: Int = 0
-    @ObjCName("objCFunction", exact = true)
-    fun @receiver:ObjCName("objCReceiver", exact = true) Int.function(
-        @ObjCName("objCParam", exact = true) param: Int
+    <!INAPPLICABLE_EXACT_OBJC_NAME!>@ObjCName("objCFunction", exact = true)<!>
+    fun <!INAPPLICABLE_EXACT_OBJC_NAME!>@receiver:ObjCName("objCReceiver", exact = true)<!> Int.function(
+        <!INAPPLICABLE_EXACT_OBJC_NAME!>@ObjCName("objCParam", exact = true)<!> param: Int
     ): Int = this * param
 }
 
 @ObjCName("ObjCEnumExactChecks", exact = true)
 enum class EnumExactChecks {
-    @ObjCName("objCEntryOne", exact = true)
+    <!INAPPLICABLE_EXACT_OBJC_NAME!>@ObjCName("objCEntryOne", exact = true)<!>
     ENTRY_ONE,
     @ObjCName("objCEntryTwo")
     ENTRY_TWO
@@ -159,7 +168,7 @@ interface I {
     fun foo()
 }
 
-open class Derived : Base(), I
+<!INCOMPATIBLE_OBJC_NAME_OVERRIDE!>open class Derived : Base(), I<!>
 
 open class Derived2 : Derived() {
     override fun foo() {}
@@ -168,11 +177,11 @@ open class Derived2 : Derived() {
 private const val exact = false
 private const val objcName = "nonLiteralArgsObjC"
 
-@ObjCName(
-    objcName,
-    "nonLiteralArgs" + "Swift",
-    exact
-)
+<!INVALID_OBJC_NAME!>@ObjCName(
+    <!NON_LITERAL_OBJC_NAME_ARG!>objcName<!>,
+    <!NON_LITERAL_OBJC_NAME_ARG!>"nonLiteralArgs" + "Swift"<!>,
+    <!NON_LITERAL_OBJC_NAME_ARG!>exact<!>
+)<!>
 val nonLiteralArgs: Int = 0
 
 @ObjCName("invalidArgsObjC", <!ARGUMENT_TYPE_MISMATCH!>false<!>, <!ARGUMENT_TYPE_MISMATCH!>"not a boolean"<!>)

--- a/native/frontend/src/org/jetbrains/kotlin/resolve/konan/diagnostics/NativeObjCNameChecker.kt
+++ b/native/frontend/src/org/jetbrains/kotlin/resolve/konan/diagnostics/NativeObjCNameChecker.kt
@@ -16,17 +16,17 @@ import org.jetbrains.kotlin.resolve.DescriptorToSourceUtils
 import org.jetbrains.kotlin.resolve.annotations.argumentValue
 import org.jetbrains.kotlin.resolve.checkers.DeclarationChecker
 import org.jetbrains.kotlin.resolve.checkers.DeclarationCheckerContext
-import org.jetbrains.kotlin.resolve.scopes.DescriptorKindFilter
-import org.jetbrains.kotlin.resolve.scopes.MemberScope
 import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 
 object NativeObjCNameChecker : DeclarationChecker {
+
     private val objCNameFqName = FqName("kotlin.native.ObjCName")
 
     override fun check(declaration: KtDeclaration, descriptor: DeclarationDescriptor, context: DeclarationCheckerContext) {
         checkDeclaration(declaration, descriptor, context)
-        checkOverrides(declaration, descriptor, context)
-        checkFakeOverrides(declaration, descriptor, context)
+        if (descriptor is CallableMemberDescriptor) {
+            NativeObjCNameOverridesChecker.check(declaration, descriptor, context)
+        }
     }
 
     private fun checkDeclaration(declaration: KtDeclaration, descriptor: DeclarationDescriptor, context: DeclarationCheckerContext) {
@@ -84,29 +84,7 @@ object NativeObjCNameChecker : DeclarationChecker {
         }
     }
 
-    private fun checkOverrides(declaration: KtDeclaration, descriptor: DeclarationDescriptor, context: DeclarationCheckerContext) {
-        if (descriptor !is CallableMemberDescriptor || descriptor.overriddenDescriptors.isEmpty()) return
-        val objCNames = descriptor.overriddenDescriptors.map { it.getFirstBaseDescriptor().getObjCNames() }
-        if (!objCNames.allNamesEquals()) {
-            val containingDeclarations = descriptor.overriddenDescriptors.map { it.containingDeclaration }
-            context.trace.report(ErrorsNative.INCOMPATIBLE_OBJC_NAME_OVERRIDE.on(declaration, descriptor, containingDeclarations))
-        }
-    }
-
-    private fun checkFakeOverrides(declaration: KtDeclaration, descriptor: DeclarationDescriptor, context: DeclarationCheckerContext) {
-        if (descriptor !is ClassDescriptor) return
-        descriptor.defaultType.memberScope
-            .getContributedDescriptors(DescriptorKindFilter.ALL, MemberScope.Companion.ALL_NAME_FILTER)
-            .forEach {
-                if (it !is CallableMemberDescriptor || it.kind.isReal) return@forEach
-                checkOverrides(declaration, it, context)
-            }
-    }
-
-    private fun CallableMemberDescriptor.getFirstBaseDescriptor(): CallableMemberDescriptor =
-        if (overriddenDescriptors.isEmpty()) this else overriddenDescriptors.first().getFirstBaseDescriptor()
-
-    private class ObjCName(
+    class ObjCName(
         val annotation: AnnotationDescriptor
     ) {
         val name: String? = annotation.argumentValue("name")?.value?.safeAs<String>()?.takeIf { it.isNotBlank() }
@@ -126,20 +104,13 @@ object NativeObjCNameChecker : DeclarationChecker {
 
     private fun DeclarationDescriptor.getObjCName(): ObjCName? = annotations.findAnnotation(objCNameFqName)?.let(::ObjCName)
 
-    private fun DeclarationDescriptor.getObjCNames(): List<ObjCName?> = when (this) {
+    fun DeclarationDescriptor.getObjCNames(): List<ObjCName?> = when (this) {
         is FunctionDescriptor -> buildList {
             add(getObjCName())
             add(extensionReceiverParameter?.getObjCName())
             valueParameters.forEach { add(it.getObjCName()) }
         }
-        else -> listOf(getObjCName())
-    }
 
-    private fun List<List<ObjCName?>>.allNamesEquals(): Boolean {
-        val first = this[0]
-        for (i in 1 until size) {
-            if (first != this[i]) return false
-        }
-        return true
+        else -> listOf(getObjCName())
     }
 }

--- a/native/frontend/src/org/jetbrains/kotlin/resolve/konan/diagnostics/NativeObjCNameOverridesChecker.kt
+++ b/native/frontend/src/org/jetbrains/kotlin/resolve/konan/diagnostics/NativeObjCNameOverridesChecker.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.resolve.konan.diagnostics
+
+import org.jetbrains.kotlin.descriptors.CallableMemberDescriptor
+import org.jetbrains.kotlin.descriptors.ClassDescriptor
+import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
+import org.jetbrains.kotlin.psi.KtDeclaration
+import org.jetbrains.kotlin.resolve.checkers.DeclarationChecker
+import org.jetbrains.kotlin.resolve.checkers.DeclarationCheckerContext
+import org.jetbrains.kotlin.resolve.konan.diagnostics.NativeObjCNameChecker.getObjCNames
+import org.jetbrains.kotlin.resolve.scopes.DescriptorKindFilter
+import org.jetbrains.kotlin.resolve.scopes.MemberScope
+
+object NativeObjCNameOverridesChecker : DeclarationChecker {
+
+    override fun check(declaration: KtDeclaration, descriptor: DeclarationDescriptor, context: DeclarationCheckerContext) {
+        if (descriptor !is ClassDescriptor) return
+        descriptor.defaultType.memberScope
+            .getContributedDescriptors(DescriptorKindFilter.ALL, MemberScope.Companion.ALL_NAME_FILTER)
+            .forEach {
+                if (it !is CallableMemberDescriptor || it.kind.isReal) return@forEach
+                check(declaration, it, context)
+            }
+    }
+
+    fun check(declaration: KtDeclaration, descriptor: CallableMemberDescriptor, context: DeclarationCheckerContext) {
+        if (descriptor.overriddenDescriptors.isEmpty()) return
+        val objCNames = descriptor.overriddenDescriptors.map { it.getFirstBaseDescriptor().getObjCNames() }
+        if (!objCNames.allNamesEquals()) {
+            val containingDeclarations = descriptor.overriddenDescriptors.map { it.containingDeclaration }
+            context.trace.report(ErrorsNative.INCOMPATIBLE_OBJC_NAME_OVERRIDE.on(declaration, descriptor, containingDeclarations))
+        }
+    }
+
+    private fun CallableMemberDescriptor.getFirstBaseDescriptor(): CallableMemberDescriptor =
+        if (overriddenDescriptors.isEmpty()) this else overriddenDescriptors.first().getFirstBaseDescriptor()
+
+    private fun List<List<NativeObjCNameChecker.ObjCName?>>.allNamesEquals(): Boolean {
+        val first = this[0]
+        for (i in 1 until size) {
+            if (first != this[i]) return false
+        }
+        return true
+    }
+}

--- a/native/frontend/src/org/jetbrains/kotlin/resolve/konan/platform/NativePlatformConfigurator.kt
+++ b/native/frontend/src/org/jetbrains/kotlin/resolve/konan/platform/NativePlatformConfigurator.kt
@@ -24,8 +24,9 @@ object NativePlatformConfigurator : PlatformConfiguratorBase(
     additionalDeclarationCheckers = listOf(
         NativeThrowsChecker, NativeSharedImmutableChecker,
         NativeTopLevelSingletonChecker, NativeThreadLocalChecker,
-        NativeObjCNameChecker, NativeObjCRefinementChecker,
-        NativeObjCRefinementAnnotationChecker, NativeObjCRefinementOverridesChecker
+        NativeObjCNameChecker, NativeObjCNameOverridesChecker,
+        NativeObjCRefinementChecker, NativeObjCRefinementAnnotationChecker,
+        NativeObjCRefinementOverridesChecker
     )
 ) {
     override fun configureModuleComponents(container: StorageComponentContainer) {


### PR DESCRIPTION
Implements the FIR checkers for the `@ObjCName` annotation.
Also splits the FE 1.0 checker into two seperate checkers like in https://github.com/JetBrains/kotlin/pull/4818#discussion_r948766522.