### PR TITLE
FIR: do not read a Java nested class if the outer class is Kotlin

### DIFF
--- a/core/compiler.common/src/org/jetbrains/kotlin/name/ClassId.java
+++ b/core/compiler.common/src/org/jetbrains/kotlin/name/ClassId.java
@@ -89,6 +89,13 @@ public final class ClassId {
         return parent.isRoot() ? null : new ClassId(getPackageFqName(), parent, local);
     }
 
+    @NotNull
+    public ClassId getOutermostClassId() {
+        FqName name = relativeClassName;
+        while (!name.parent().isRoot()) name = name.parent();
+        return new ClassId(packageFqName, name, false);
+    }
+
     public boolean isNestedClass() {
         return !relativeClassName.parent().isRoot();
     }


### PR DESCRIPTION
Example: if C is a Kotlin class and there is an import of C.Companion.f, a call to f will need to check if it is a constructor, for which it will attempt to load C.Companion.f as a Java class. This involves loading all outer classes, including C itself, as BinaryJavaClass - see KotlinCliJavaFileManagerImpl - despite the fact that C and C.Companion have both already been loaded from their Metadata annotations as Kotlin classes, wasting cycles and polluting caches.

Thus the theoretical motivation for this change is to marginally speed up FIR.

The real motivation is that with the -Xemit-jvm-type-annotations option, kotlinc sometimes generates invalid annotations, and reading them with BinaryJavaClass throws an exception (the Kotlin metadata however is valid):

    // MODULE: lib
    // FILE: C.kt
    // The constructor has an argument of type
    //   List<? extends Function1<? super String, Integer>>
    // and a ParameterName type annotation with path
    //   TYPE_ARGUMENT(0), TYPE_ARGUMENT(0)
    // which is missing a WILDCARD between the two TYPE_ARGUMENTs
    class C(val x: List<(name: String) -> Int>) {
      companion object {
        fun foo() {}
      }
    }
    // MODULE: main(lib)
    // FILE: main.kt
    import C.Companion.f

    fun bar() = foo() // crashes FIR

The parameter annotation should obviously be fixed too, but invalid bytecode may already exist in the wild. Also, did I mention that this change marginally speeds up FIR?