### PR TITLE
FIR: fix incorrect handling of suspend function typealiases again

### DIFF
--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/types/InferenceUtils.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/types/InferenceUtils.kt
@@ -112,16 +112,16 @@ fun ConeKotlinType.suspendFunctionTypeToFunctionTypeWithContinuation(session: Fi
     val kind =
         if (isKFunctionType(session)) FunctionClassKind.KFunction
         else FunctionClassKind.Function
-    val functionalTypeId = ClassId(kind.packageFqName, kind.numberedClassName(typeArguments.size))
     val fullyExpandedType = type.fullyExpandedType(session)
     val typeArguments = fullyExpandedType.typeArguments
+    val functionalTypeId = ClassId(kind.packageFqName, kind.numberedClassName(typeArguments.size))
     val lastTypeArgument = typeArguments.last()
     return ConeClassLikeTypeImpl(
         ConeClassLikeLookupTagImpl(functionalTypeId),
         typeArguments = (typeArguments.dropLast(1) + ConeClassLikeLookupTagImpl(continuationClassId).constructClassType(
             arrayOf(lastTypeArgument),
             isNullable = false
-        ) + lastTypeArgument).toTypedArray(),
+        ) + session.builtinTypes.nullableAnyType.type).toTypedArray(),
         isNullable = false,
         attributes = attributes
     )

--- a/compiler/testData/codegen/box/typealias/incorrectTypeOfTypealiasForSuspendFunctionalType.kt
+++ b/compiler/testData/codegen/box/typealias/incorrectTypeOfTypealiasForSuspendFunctionalType.kt
@@ -1,5 +1,13 @@
+// WITH_STDLIB
 // ISSUE: KT-50997
+// MODULE: lib
+// FILE: lib.kt
+typealias MySuspendFunction = suspend (String, String) -> Unit
 
-typealias MySuspendFunction = suspend (String) -> Unit
 fun foo(function: MySuspendFunction) {}
+
+// MODULE: main(lib)
+// FILE: main.kt
+fun bar() = foo { a, b -> a + b }
+
 fun box() = "OK"


### PR DESCRIPTION
The previous attempt stopped this code from throwing an exception during serialization, but the arity is still wrong so an exception is now throw when reading the serialized type.

^KT-50997 Fixed