### PR TITLE
Remove incorrect override in TypeVariableImpl

### DIFF
--- a/libraries/stdlib/jvm/src/kotlin/reflect/TypesJVM.kt
+++ b/libraries/stdlib/jvm/src/kotlin/reflect/TypesJVM.kt
@@ -136,8 +136,9 @@ private class TypeVariableImpl(private val typeParameter: KTypeParameter) : Type
     @Suppress("VIRTUAL_MEMBER_HIDDEN")
     fun getDeclaredAnnotations(): Array<Annotation> = emptyArray()
 
-    @Suppress("VIRTUAL_MEMBER_HIDDEN")
-    fun getAnnotatedBounds(): Array<Annotation> = emptyArray()
+    // There is also [getAnnotatedBounds] which returns an array of [AnnotatedType]; because [AnnotatedType] is JDK 8+,
+    // we can't declare that method here for compatibility with Android SDK 25 and lower, so we leave it unimplemented
+    // to throw an exception at runtime if called.
 }
 
 @ExperimentalStdlibApi


### PR DESCRIPTION
The correct return type of getAnnotatedBounds is Array\<AnnotatedType\>. This fact causes some problems now that kotlin-stdlib is targeting JDK 1.8:

  * the compiler generates a bridge to the incorrect "override" that attempts to cast an empty Array\<Annotation\> into the correct type, which fails because those two types are unrelated;

  * on Android, touching this method in any way (via reflection) on any API version causes a ClassNotFoundException;

  * tools that validate references in libraries when compiling for Android complain about the bridge because they know the returned type does not exist.

The easiest solution is to simply remove the override and leave getAnnotatedBounds unimplemented, making it throw AbstractMethodError when called. This is the behavior it previously had anyway, as kotlin-stdlib targeting JDK 1.6 lacked a method with the correct signature.