### PR TITLE
JVM Inline: Fix operand stack type verify error

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -21234,6 +21234,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         }
 
         @Test
+        @TestMetadata("implicitCastToNonValueClassType.kt")
+        public void testImplicitCastToNonValueClassType() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/implicitCastToNonValueClassType.kt");
+        }
+
+        @Test
         @TestMetadata("initBlock.kt")
         public void testInitBlock() throws Exception {
             runTest("compiler/testData/codegen/box/inlineClasses/initBlock.kt", TransformersFunctions.getReplaceOptionalJvmInlineAnnotationWithReal());

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/PromisedValue.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/PromisedValue.kt
@@ -38,6 +38,13 @@ abstract class PromisedValue(val codegen: ExpressionCodegen, val type: Type, val
         if (isFromTypeUnboxed && !isToTypeUnboxed) {
             val boxed = typeMapper.mapType(erasedSourceType, TypeMappingMode.CLASS_DECLARATION)
             StackValue.boxInlineClass(type, boxed, erasedSourceType.isNullable(), mv)
+
+            if (typeMapper.mapType(erasedTargetType) == target) {
+                if (!erasedSourceType.isSubtypeOf(erasedTargetType, codegen.context.typeSystem)) {
+                    StackValue.coerce(boxed, target, mv, false)
+                }
+            }
+
             return
         }
         if (!isFromTypeUnboxed && isToTypeUnboxed) {

--- a/compiler/testData/codegen/box/inlineClasses/implicitCastToNonValueClassType.kt
+++ b/compiler/testData/codegen/box/inlineClasses/implicitCastToNonValueClassType.kt
@@ -1,0 +1,19 @@
+// TARGET_BACKEND: JVM_IR
+// WITH_STDLIB
+
+fun box(): String {
+    try {
+        val a:ULong = 1u
+        a as Int
+        func(a)
+    } catch (e: ClassCastException) {
+        return "OK"
+    }
+    return "FAIL"
+}
+
+fun func(para: Int) {}
+
+// CHECK_BYTECODE_TEXT
+// 1 CHECKCAST java/lang/Integer
+// 1 L2I

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -21234,6 +21234,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         }
 
         @Test
+        @TestMetadata("implicitCastToNonValueClassType.kt")
+        public void testImplicitCastToNonValueClassType() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/implicitCastToNonValueClassType.kt");
+        }
+
+        @Test
         @TestMetadata("initBlock.kt")
         public void testInitBlock() throws Exception {
             runTest("compiler/testData/codegen/box/inlineClasses/initBlock.kt", TransformersFunctions.getReplaceOptionalJvmInlineAnnotationWithReal());


### PR DESCRIPTION
This is a proposal to fix [KT-49364](https://youtrack.jetbrains.com/issue/KT-49364/VerifyError-Bad-type-on-operand-stack-on-cast-which-can-never-succeed-from-ULong-to-Int).

Operand stack type verification happens before `checkcast`
is executed. When we implicitly cast an inline class
to a non-inline type, if type of stack value is not subtype
of the target, then coercing/checkcast is necessary.