### PR TITLE
JVM: fix some issues caused by use of RATs where not appropriate

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/codegenUtil.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/codegenUtil.kt
@@ -17,6 +17,7 @@ import org.jetbrains.kotlin.codegen.coroutines.CONTINUATION_ASM_TYPE
 import org.jetbrains.kotlin.codegen.coroutines.unwrapInitialDescriptorForSuspendFunction
 import org.jetbrains.kotlin.codegen.inline.NUMBERED_FUNCTION_PREFIX
 import org.jetbrains.kotlin.codegen.inline.ReificationArgument
+import org.jetbrains.kotlin.codegen.inline.ReifiedTypeParametersUsages
 import org.jetbrains.kotlin.codegen.intrinsics.TypeIntrinsics
 import org.jetbrains.kotlin.codegen.state.GenerationState
 import org.jetbrains.kotlin.codegen.state.KotlinTypeMapper
@@ -386,6 +387,7 @@ fun TypeSystemCommonBackendContext.extractReificationArgument(initialType: Kotli
     val isNullable = type.isMarkedNullable()
     while (type.isArrayOrNullableArray()) {
         arrayDepth++
+        // TODO: warn that nullability info on argument will be lost?
         val argument = type.getArgument(0)
         if (argument.isStarProjection()) return null
         type = argument.getType()
@@ -395,6 +397,24 @@ fun TypeSystemCommonBackendContext.extractReificationArgument(initialType: Kotli
     if (!typeParameter.isReified()) return null
     return Pair(typeParameter, ReificationArgument(typeParameter.getName().asString(), isNullable, arrayDepth))
 }
+
+fun TypeSystemCommonBackendContext.extractUsedReifiedParameters(type: KotlinTypeMarker): ReifiedTypeParametersUsages =
+    ReifiedTypeParametersUsages().apply {
+        fun KotlinTypeMarker.visit() {
+            val typeParameter = typeConstructor().getTypeParameterClassifier()
+            if (typeParameter == null) {
+                for (argument in getArguments()) {
+                    if (!argument.isStarProjection()) {
+                        argument.getType().visit()
+                    }
+                }
+            } else if (typeParameter.isReified()) {
+                addUsedReifiedParameter(typeParameter.getName().asString())
+            }
+        }
+
+        type.visit()
+    }
 
 fun unwrapInitialSignatureDescriptor(function: FunctionDescriptor): FunctionDescriptor =
     function.initialSignatureDescriptor ?: function

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/AsmTypeRemapper.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/AsmTypeRemapper.kt
@@ -30,16 +30,16 @@ class AsmTypeRemapper(val typeRemapper: TypeRemapper, val result: InlineResult) 
         return object : SignatureRemapper(v, this) {
             override fun visitTypeVariable(name: String) {
                 /*TODO try to erase absent type variable*/
-                val mapping = typeRemapper.mapTypeParameter(name) ?: return super.visitTypeVariable(name)
-
-                if (mapping.newName != null) {
+                val mapping = typeRemapper.mapTypeParameter(name)
+                if (mapping != null) {
+                    // TODO: what is this condition
                     if (mapping.isReified) {
-                        result.reifiedTypeParametersUsages.addUsedReifiedParameter(mapping.newName)
+                        result.reifiedTypeParametersUsages.mergeAll(mapping.reifiedTypeParametersUsages)
                     }
-                    return super.visitTypeVariable(mapping.newName)
+                    SignatureReader(mapping.signature).accept(v)
+                    return
                 }
-                // else TypeVariable is replaced by concrete type
-                SignatureReader(mapping.signature).accept(v)
+                return super.visitTypeVariable(name)
             }
 
             override fun visitFormalTypeParameter(name: String) {

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/TypeRemapper.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/TypeRemapper.kt
@@ -18,8 +18,6 @@ package org.jetbrains.kotlin.codegen.inline
 
 import java.util.*
 
-class TypeParameter(val oldName: String, val newName: String?, val isReified: Boolean, val signature: String?)
-
 //typeMapping data could be changed outside through method processing
 class TypeRemapper private constructor(
     private val typeMapping: MutableMap<String, String?>,
@@ -27,7 +25,7 @@ class TypeRemapper private constructor(
     private val isRootInlineLambda: Boolean = false
 ) {
     private val additionalMappings = hashMapOf<String, String>()
-    private val typeParametersMapping = hashMapOf<String, TypeParameter>()
+    private val typeParametersMapping = hashMapOf<String, TypeParameterMapping<*>?>()
 
     fun addMapping(type: String, newType: String) {
         typeMapping[type] = newType
@@ -50,26 +48,24 @@ class TypeRemapper private constructor(
 //        assert(typeParametersMapping[name] == null) {
 //            "Type parameter already registered $name"
 //        }
-        typeParametersMapping[name] = TypeParameter(name, name, false, null)
+        typeParametersMapping[name] = null
     }
 
-    fun registerTypeParameter(mapping: TypeParameterMapping<*>) {
-        typeParametersMapping[mapping.name] = TypeParameter(
-            mapping.name, mapping.reificationArgument?.parameterName, mapping.isReified, mapping.signature
-        )
+    fun registerTypeParameter(name: String, mapping: TypeParameterMapping<*>) {
+        typeParametersMapping[name] = mapping
     }
 
-    fun mapTypeParameter(name: String): TypeParameter? {
-        return typeParametersMapping[name] ?: if (!isRootInlineLambda) parent?.mapTypeParameter(name) else null
+    fun mapTypeParameter(name: String): TypeParameterMapping<*>? = when {
+        name in typeParametersMapping -> typeParametersMapping[name]
+        !isRootInlineLambda -> parent?.mapTypeParameter(name)
+        else -> null
     }
 
     companion object {
         @JvmStatic
-        fun createRoot(formalTypeParameters: TypeParameterMappings<*>?): TypeRemapper {
+        fun createRoot(formalTypeParameters: TypeParameterMappings<*>): TypeRemapper {
             return TypeRemapper(HashMap()).apply {
-                formalTypeParameters?.forEach {
-                    registerTypeParameter(it)
-                }
+                formalTypeParameters.forEach(::registerTypeParameter)
             }
         }
 

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/typeOf.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/typeOf.kt
@@ -22,73 +22,62 @@ import kotlin.reflect.KVariance
 internal fun TypeSystemCommonBackendContext.createTypeOfMethodBody(typeParameter: TypeParameterMarker): MethodNode {
     val node = MethodNode(Opcodes.API_VERSION, Opcodes.ACC_STATIC, "fake", Type.getMethodDescriptor(K_TYPE), null, null)
     val v = InstructionAdapter(node)
-
-    putTypeOfReifiedTypeParameter(v, typeParameter, false)
+    val argument = ReificationArgument(typeParameter.getName().asString(), false, 0)
+    ReifiedTypeInliner.putReifiedOperationMarker(ReifiedTypeInliner.OperationKind.TYPE_OF, argument, v)
+    v.aconst(null)
     v.areturn(K_TYPE)
-
     v.visitMaxs(2, 0)
-
     return node
 }
 
-private fun TypeSystemCommonBackendContext.putTypeOfReifiedTypeParameter(
-    v: InstructionAdapter, typeParameter: TypeParameterMarker, isNullable: Boolean
-) {
-    ReifiedTypeInliner.putReifiedOperationMarkerIfNeeded(typeParameter, isNullable, ReifiedTypeInliner.OperationKind.TYPE_OF, v, this)
-    v.aconst(null)
+private inline fun InstructionAdapter.unrollArrayIfFewerThan(n: Int, limit: Int, type: Type, element: (Int) -> Unit): Array<Type> {
+    if (n < limit) {
+        return Array(n) { i ->
+            element(i)
+            type
+        }
+    }
+    iconst(n)
+    newarray(type)
+    for (i in 0 until n) {
+        dup()
+        iconst(i)
+        element(i)
+        astore(type)
+    }
+    return arrayOf(AsmUtil.getArrayType(type))
 }
 
 fun <KT : KotlinTypeMarker> TypeSystemCommonBackendContext.generateTypeOf(
     v: InstructionAdapter, type: KT, intrinsicsSupport: ReifiedTypeInliner.IntrinsicsSupport<KT>
+) = generateTypeOf(v, type, intrinsicsSupport, isTypeParameterBound = false)
+
+private fun <KT : KotlinTypeMarker> TypeSystemCommonBackendContext.generateTypeOf(
+    v: InstructionAdapter, type: KT, intrinsicsSupport: ReifiedTypeInliner.IntrinsicsSupport<KT>, isTypeParameterBound: Boolean
 ) {
     val typeParameter = type.typeConstructor().getTypeParameterClassifier()
-    if (typeParameter != null) {
-        if (!doesTypeContainTypeParametersWithRecursiveBounds(type)) {
-            intrinsicsSupport.reportNonReifiedTypeParameterWithRecursiveBoundUnsupported(typeParameter.getName())
-            v.aconst(null)
-            return
-        }
-
-        generateNonReifiedTypeParameter(v, typeParameter, intrinsicsSupport)
-    } else {
+    val methodArguments = if (typeParameter == null) {
         intrinsicsSupport.putClassInstance(v, type)
-    }
-
-    val argumentsSize = type.argumentsCount()
-    val useArray = argumentsSize >= 3
-
-    if (useArray) {
-        v.iconst(argumentsSize)
-        v.newarray(K_TYPE_PROJECTION)
-    }
-
-    for (i in 0 until argumentsSize) {
-        if (useArray) {
-            v.dup()
-            v.iconst(i)
+        val arguments = v.unrollArrayIfFewerThan(type.argumentsCount(), 3, K_TYPE_PROJECTION) { i ->
+            generateTypeOfArgument(v, type.getArgument(i), intrinsicsSupport, isTypeParameterBound)
         }
-
-        doGenerateTypeProjection(v, type.getArgument(i), intrinsicsSupport)
-
-        if (useArray) {
-            v.astore(K_TYPE_PROJECTION)
-        }
+        arrayOf(JAVA_CLASS_TYPE, *arguments)
+    } else if (!isTypeParameterBound && typeParameter.isReified()) {
+        val argument = ReificationArgument(typeParameter.getName().asString(), type.isMarkedNullable(), 0)
+        ReifiedTypeInliner.putReifiedOperationMarker(ReifiedTypeInliner.OperationKind.TYPE_OF, argument, v)
+        v.aconst(null)
+        return
+    } else if (typeReferencesParameterWithRecursiveBound(type)) {
+        intrinsicsSupport.reportNonReifiedTypeParameterWithRecursiveBoundUnsupported(typeParameter.getName())
+        v.aconst(null)
+        return
+    } else {
+        generateNonReifiedTypeParameter(v, typeParameter, intrinsicsSupport)
+        arrayOf(K_CLASSIFIER_TYPE)
     }
 
     val methodName = if (type.isMarkedNullable()) "nullableTypeOf" else "typeOf"
-
-    val signature = if (typeParameter != null) {
-        Type.getMethodDescriptor(K_TYPE, K_CLASSIFIER_TYPE)
-    } else {
-        val projections = when (argumentsSize) {
-            0 -> emptyArray()
-            1 -> arrayOf(K_TYPE_PROJECTION)
-            2 -> arrayOf(K_TYPE_PROJECTION, K_TYPE_PROJECTION)
-            else -> arrayOf(AsmUtil.getArrayType(K_TYPE_PROJECTION))
-        }
-        Type.getMethodDescriptor(K_TYPE, JAVA_CLASS_TYPE, *projections)
-    }
-
+    val signature = Type.getMethodDescriptor(K_TYPE, *methodArguments)
     v.invokestatic(REFLECTION, methodName, signature, false)
 
     if (intrinsicsSupport.toKotlinType(type).isSuspendFunctionType) {
@@ -106,7 +95,7 @@ fun <KT : KotlinTypeMarker> TypeSystemCommonBackendContext.generateTypeOf(
             // If this is a flexible type, we've just generated its lower bound and have it on the stack.
             // Let's generate the upper bound now and call the method that takes lower and upper bound and constructs a flexible KType.
             @Suppress("UNCHECKED_CAST")
-            generateTypeOf(v, type.upperBoundIfFlexible() as KT, intrinsicsSupport)
+            generateTypeOf(v, type.upperBoundIfFlexible() as KT, intrinsicsSupport, isTypeParameterBound)
 
             v.invokestatic(REFLECTION, "platformType", Type.getMethodDescriptor(K_TYPE, K_TYPE, K_TYPE), false)
         }
@@ -132,76 +121,54 @@ private fun <KT : KotlinTypeMarker> TypeSystemCommonBackendContext.generateNonRe
         false,
     )
 
-    @Suppress("UNCHECKED_CAST")
-    val bounds = (0 until typeParameter.upperBoundCount()).map { typeParameter.getUpperBound(it) as KT }
-    if (bounds.isEmpty()) return
+    if (typeParameter.upperBoundCount() == 0) return
 
     v.dup()
-
-    if (bounds.size == 1) {
-        generateTypeOf(v, bounds.single(), intrinsicsSupport)
-    } else {
-        v.iconst(bounds.size)
-        v.newarray(K_TYPE)
-        for ((i, bound) in bounds.withIndex()) {
-            v.dup()
-            v.iconst(i)
-            generateTypeOf(v, bound, intrinsicsSupport)
-            v.astore(K_TYPE)
-        }
+    val argumentsForBounds = v.unrollArrayIfFewerThan(typeParameter.upperBoundCount(), 2, K_TYPE) { i ->
+        @Suppress("UNCHECKED_CAST")
+        generateTypeOf(v, typeParameter.getUpperBound(i) as KT, intrinsicsSupport, isTypeParameterBound = true)
     }
-
     v.invokestatic(
-        REFLECTION, "setUpperBounds", Type.getMethodDescriptor(
-            Type.VOID_TYPE, K_TYPE_PARAMETER,
-            if (bounds.size == 1) K_TYPE else AsmUtil.getArrayType(K_TYPE)
-        ),
+        REFLECTION, "setUpperBounds", Type.getMethodDescriptor(Type.VOID_TYPE, K_TYPE_PARAMETER, *argumentsForBounds),
         false
     )
 }
 
-private fun TypeSystemCommonBackendContext.doesTypeContainTypeParametersWithRecursiveBounds(
+private fun TypeSystemCommonBackendContext.typeReferencesParameterWithRecursiveBound(
     type: KotlinTypeMarker,
     used: MutableSet<TypeParameterMarker> = linkedSetOf()
 ): Boolean {
     val typeParameter = type.typeConstructor().getTypeParameterClassifier()
     if (typeParameter != null) {
-        if (!used.add(typeParameter)) return false
+        if (!used.add(typeParameter)) return true
         for (i in 0 until typeParameter.upperBoundCount()) {
-            if (!doesTypeContainTypeParametersWithRecursiveBounds(typeParameter.getUpperBound(i), used)) return false
+            if (typeReferencesParameterWithRecursiveBound(typeParameter.getUpperBound(i), used)) return true
         }
         used.remove(typeParameter)
     } else {
         for (i in 0 until type.argumentsCount()) {
             val argument = type.getArgument(i)
-            if (!argument.isStarProjection() && !doesTypeContainTypeParametersWithRecursiveBounds(argument.getType(), used)) return false
+            if (!argument.isStarProjection() && typeReferencesParameterWithRecursiveBound(argument.getType(), used)) return true
         }
     }
-    return true
+    return false
 }
 
-private fun <KT : KotlinTypeMarker> TypeSystemCommonBackendContext.doGenerateTypeProjection(
+private fun <KT : KotlinTypeMarker> TypeSystemCommonBackendContext.generateTypeOfArgument(
     v: InstructionAdapter,
     projection: TypeArgumentMarker,
-    intrinsicsSupport: ReifiedTypeInliner.IntrinsicsSupport<KT>
+    intrinsicsSupport: ReifiedTypeInliner.IntrinsicsSupport<KT>,
+    isTypeParameterBound: Boolean,
 ) {
-    // KTypeProjection members could be static, see KT-30083 and KT-30084
+    // KTypeProjection companion members could be made `@JvmStatic`, see KT-30083 and KT-30084
     v.getstatic(K_TYPE_PROJECTION.internalName, "Companion", K_TYPE_PROJECTION_COMPANION.descriptor)
-
     if (projection.isStarProjection()) {
         v.invokevirtual(K_TYPE_PROJECTION_COMPANION.internalName, "getSTAR", Type.getMethodDescriptor(K_TYPE_PROJECTION), false)
         return
     }
 
     @Suppress("UNCHECKED_CAST")
-    val type = projection.getType() as KT
-    val typeParameterClassifier = type.typeConstructor().getTypeParameterClassifier()
-    if (typeParameterClassifier != null && typeParameterClassifier.isReified()) {
-        putTypeOfReifiedTypeParameter(v, typeParameterClassifier, type.isMarkedNullable())
-    } else {
-        generateTypeOf(v, type, intrinsicsSupport)
-    }
-
+    generateTypeOf(v, projection.getType() as KT, intrinsicsSupport, isTypeParameterBound)
     val methodName = when (projection.getVariance()) {
         TypeVariance.INV -> "invariant"
         TypeVariance.IN -> "contravariant"

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -44545,6 +44545,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
             }
 
             @Test
+            @TestMetadata("arrayOfNullableReified.kt")
+            public void testArrayOfNullableReified() throws Exception {
+                runTest("compiler/testData/codegen/box/reflection/typeOf/arrayOfNullableReified.kt");
+            }
+
+            @Test
             @TestMetadata("caching.kt")
             public void testCaching() throws Exception {
                 runTest("compiler/testData/codegen/box/reflection/typeOf/caching.kt");
@@ -44632,6 +44638,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
             @TestMetadata("rawTypes_before.kt")
             public void testRawTypes_before() throws Exception {
                 runTest("compiler/testData/codegen/box/reflection/typeOf/rawTypes_before.kt");
+            }
+
+            @Test
+            @TestMetadata("reifiedAsNestedArgument.kt")
+            public void testReifiedAsNestedArgument() throws Exception {
+                runTest("compiler/testData/codegen/box/reflection/typeOf/reifiedAsNestedArgument.kt");
             }
 
             @Test
@@ -45945,6 +45957,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         @TestMetadata("spreads.kt")
         public void testSpreads() throws Exception {
             runTest("compiler/testData/codegen/box/reified/spreads.kt");
+        }
+
+        @Test
+        @TestMetadata("typeTokenWrapper.kt")
+        public void testTypeTokenWrapper() throws Exception {
+            runTest("compiler/testData/codegen/box/reified/typeTokenWrapper.kt");
         }
 
         @Test

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -57,7 +57,6 @@ import org.jetbrains.kotlin.types.computeExpandedTypeForInlineClass
 import org.jetbrains.kotlin.types.model.TypeParameterMarker
 import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstanceOrNull
 import org.jetbrains.kotlin.utils.addToStdlib.safeAs
-import org.jetbrains.kotlin.utils.keysToMap
 import org.jetbrains.org.objectweb.asm.Label
 import org.jetbrains.org.objectweb.asm.Opcodes
 import org.jetbrains.org.objectweb.asm.Type
@@ -1453,30 +1452,12 @@ class ExpressionCodegen(
             if (element.typeArgumentsCount == 0) {
                 //avoid ambiguity with type constructor type parameters
                 emptyMap()
-            } else typeArgumentContainer.typeParameters.keysToMap {
-                element.getTypeArgumentOrDefault(it)
+            } else typeArgumentContainer.typeParameters.associate {
+                it.symbol to element.getTypeArgumentOrDefault(it)
             }
 
-        val mappings = TypeParameterMappings<IrType>()
-        for ((key, type) in typeArguments.entries) {
-            val reificationArgument = typeMapper.typeSystem.extractReificationArgument(type)
-            if (reificationArgument == null) {
-                // type is not generic
-                val signatureWriter = BothSignatureWriter(BothSignatureWriter.Mode.TYPE)
-                val asmType = typeMapper.mapTypeParameter(type, signatureWriter)
-
-                mappings.addParameterMappingToType(
-                    key.name.identifier, type, asmType, signatureWriter.toString(), key.isReified
-                )
-            } else {
-                mappings.addParameterMappingForFurtherReification(
-                    key.name.identifier, type, reificationArgument.second, key.isReified
-                )
-            }
-        }
-
+        val mappings = TypeParameterMappings(typeMapper.typeSystem, typeArguments, allReified = false, typeMapper::mapTypeParameter)
         val sourceCompiler = IrSourceCompilerForInline(state, element, callee, this, data)
-
         val reifiedTypeInliner = ReifiedTypeInliner(
             mappings,
             IrInlineIntrinsicsSupport(classCodegen, element, irFunction.fileParent),

--- a/compiler/testData/codegen/box/reflection/typeOf/arrayOfNullableReified.kt
+++ b/compiler/testData/codegen/box/reflection/typeOf/arrayOfNullableReified.kt
@@ -1,0 +1,21 @@
+// IGNORE_BACKEND: JS_IR, JS_IR_ES6
+// WITH_REFLECT
+
+import kotlin.reflect.typeOf
+import kotlin.test.assertEquals
+
+inline fun <reified T> typeOfArrayOfNArrayOf() =
+    typeOf<Array<Array<T>?>>()
+
+inline fun <reified T> myTypeOf() =
+    typeOf<T>()
+
+inline fun <reified T> myTypeOfArrayOfNArrayOf() =
+    typeOf<Array<Array<T>?>>()
+
+fun box(): String {
+    assertEquals(typeOf<Array<Array<String>?>>(), typeOfArrayOfNArrayOf<String>())
+    assertEquals(typeOf<Array<Array<String>?>>(), myTypeOf<Array<Array<String>?>>())
+    assertEquals(typeOf<Array<Array<String>?>>(), myTypeOfArrayOfNArrayOf<String>())
+    return "OK"
+}

--- a/compiler/testData/codegen/box/reflection/typeOf/reifiedAsNestedArgument.kt
+++ b/compiler/testData/codegen/box/reflection/typeOf/reifiedAsNestedArgument.kt
@@ -1,0 +1,20 @@
+// IGNORE_BACKEND: JS, JS_IR, JS_IR_ES6
+// WITH_REFLECT
+
+import kotlin.reflect.typeOf
+import kotlin.reflect.KType
+import kotlin.test.assertEquals
+
+inline fun <reified T> foo() =
+    object { val x = typeOf<T>() }.x
+
+inline fun <reified T> bar(expected: KType) {
+    assertEquals(expected, foo<List<T>>())
+    assertEquals(expected, object { val x = typeOf<List<T>>() }.x)
+    assertEquals(expected, typeOf<List<T>>())
+}
+
+fun box(): String {
+    bar<Int>(typeOf<List<Int>>())
+    return "OK"
+}

--- a/compiler/testData/codegen/box/reified/typeTokenWrapper.kt
+++ b/compiler/testData/codegen/box/reified/typeTokenWrapper.kt
@@ -1,0 +1,32 @@
+// TARGET_BACKEND: JVM
+// ISSUE: KT-53761
+// WITH_STDLIB
+
+import kotlin.test.assertEquals
+
+open class TypeToken<T> {
+    val type = javaClass.genericSuperclass
+}
+
+inline fun <reified E> myTypeOf() =
+    object : TypeToken<E>() {}.type
+
+inline fun <reified T> myTypeOfArrayOf() =
+    object : TypeToken<Array<T>>() {}.type
+
+inline fun <reified T> myTypeOfArrayOf2() =
+    myTypeOf<Array<T>>()
+
+inline fun <reified T> myTypeOfListOf() =
+    object : TypeToken<List<T>>() {}.type
+
+inline fun <reified T> myTypeOfListOf2() =
+    myTypeOf<List<T>>()
+
+fun box(): String {
+    assertEquals(myTypeOf<Array<String>>(), myTypeOfArrayOf<String>())
+    assertEquals(myTypeOf<Array<String>>(), myTypeOfArrayOf2<String>())
+    assertEquals(myTypeOf<List<String>>(), myTypeOfListOf<String>())
+    assertEquals(myTypeOf<List<String>>(), myTypeOfListOf2<String>())
+    return "OK"
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -43087,6 +43087,12 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             }
 
             @Test
+            @TestMetadata("arrayOfNullableReified.kt")
+            public void testArrayOfNullableReified() throws Exception {
+                runTest("compiler/testData/codegen/box/reflection/typeOf/arrayOfNullableReified.kt");
+            }
+
+            @Test
             @TestMetadata("classes.kt")
             public void testClasses() throws Exception {
                 runTest("compiler/testData/codegen/box/reflection/typeOf/classes.kt");
@@ -43168,6 +43174,12 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             @TestMetadata("rawTypes_before.kt")
             public void testRawTypes_before() throws Exception {
                 runTest("compiler/testData/codegen/box/reflection/typeOf/rawTypes_before.kt");
+            }
+
+            @Test
+            @TestMetadata("reifiedAsNestedArgument.kt")
+            public void testReifiedAsNestedArgument() throws Exception {
+                runTest("compiler/testData/codegen/box/reflection/typeOf/reifiedAsNestedArgument.kt");
             }
 
             @Test
@@ -44481,6 +44493,12 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
         @TestMetadata("spreads.kt")
         public void testSpreads() throws Exception {
             runTest("compiler/testData/codegen/box/reified/spreads.kt");
+        }
+
+        @Test
+        @TestMetadata("typeTokenWrapper.kt")
+        public void testTypeTokenWrapper() throws Exception {
+            runTest("compiler/testData/codegen/box/reified/typeTokenWrapper.kt");
         }
 
         @Test

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -44545,6 +44545,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             }
 
             @Test
+            @TestMetadata("arrayOfNullableReified.kt")
+            public void testArrayOfNullableReified() throws Exception {
+                runTest("compiler/testData/codegen/box/reflection/typeOf/arrayOfNullableReified.kt");
+            }
+
+            @Test
             @TestMetadata("caching.kt")
             public void testCaching() throws Exception {
                 runTest("compiler/testData/codegen/box/reflection/typeOf/caching.kt");
@@ -44632,6 +44638,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             @TestMetadata("rawTypes_before.kt")
             public void testRawTypes_before() throws Exception {
                 runTest("compiler/testData/codegen/box/reflection/typeOf/rawTypes_before.kt");
+            }
+
+            @Test
+            @TestMetadata("reifiedAsNestedArgument.kt")
+            public void testReifiedAsNestedArgument() throws Exception {
+                runTest("compiler/testData/codegen/box/reflection/typeOf/reifiedAsNestedArgument.kt");
             }
 
             @Test
@@ -45945,6 +45957,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         @TestMetadata("spreads.kt")
         public void testSpreads() throws Exception {
             runTest("compiler/testData/codegen/box/reified/spreads.kt");
+        }
+
+        @Test
+        @TestMetadata("typeTokenWrapper.kt")
+        public void testTypeTokenWrapper() throws Exception {
+            runTest("compiler/testData/codegen/box/reified/typeTokenWrapper.kt");
         }
 
         @Test

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -34632,6 +34632,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
         @TestDataPath("$PROJECT_ROOT")
         @RunWith(JUnit3RunnerWithInners.class)
         public static class TypeOf extends AbstractLightAnalysisModeTest {
+            @TestMetadata("arrayOfNullableReified.kt")
+            public void ignoreArrayOfNullableReified() throws Exception {
+                runTest("compiler/testData/codegen/box/reflection/typeOf/arrayOfNullableReified.kt");
+            }
+
             private void runTest(String testDataFilePath) throws Exception {
                 KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM, testDataFilePath);
             }
@@ -34713,6 +34718,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             @TestMetadata("rawTypes_before.kt")
             public void testRawTypes_before() throws Exception {
                 runTest("compiler/testData/codegen/box/reflection/typeOf/rawTypes_before.kt");
+            }
+
+            @TestMetadata("reifiedAsNestedArgument.kt")
+            public void testReifiedAsNestedArgument() throws Exception {
+                runTest("compiler/testData/codegen/box/reflection/typeOf/reifiedAsNestedArgument.kt");
             }
 
             @TestMetadata("typeOfCapturedStar.kt")
@@ -35854,6 +35864,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
         @TestMetadata("spreads.kt")
         public void testSpreads() throws Exception {
             runTest("compiler/testData/codegen/box/reified/spreads.kt");
+        }
+
+        @TestMetadata("typeTokenWrapper.kt")
+        public void testTypeTokenWrapper() throws Exception {
+            runTest("compiler/testData/codegen/box/reified/typeTokenWrapper.kt");
         }
 
         @TestMetadata("varargs.kt")

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/JsCodegenBoxTestGenerated.java
@@ -32475,6 +32475,12 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             }
 
             @Test
+            @TestMetadata("arrayOfNullableReified.kt")
+            public void testArrayOfNullableReified() throws Exception {
+                runTest("compiler/testData/codegen/box/reflection/typeOf/arrayOfNullableReified.kt");
+            }
+
+            @Test
             @TestMetadata("classes.kt")
             public void testClasses() throws Exception {
                 runTest("compiler/testData/codegen/box/reflection/typeOf/classes.kt");
@@ -32502,6 +32508,12 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
             @TestMetadata("multipleLayers.kt")
             public void testMultipleLayers() throws Exception {
                 runTest("compiler/testData/codegen/box/reflection/typeOf/multipleLayers.kt");
+            }
+
+            @Test
+            @TestMetadata("reifiedAsNestedArgument.kt")
+            public void testReifiedAsNestedArgument() throws Exception {
+                runTest("compiler/testData/codegen/box/reflection/typeOf/reifiedAsNestedArgument.kt");
             }
 
             @Test

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/IrJsCodegenBoxTestGenerated.java
@@ -32649,6 +32649,12 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             }
 
             @Test
+            @TestMetadata("arrayOfNullableReified.kt")
+            public void testArrayOfNullableReified() throws Exception {
+                runTest("compiler/testData/codegen/box/reflection/typeOf/arrayOfNullableReified.kt");
+            }
+
+            @Test
             @TestMetadata("classes.kt")
             public void testClasses() throws Exception {
                 runTest("compiler/testData/codegen/box/reflection/typeOf/classes.kt");
@@ -32676,6 +32682,12 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
             @TestMetadata("multipleLayers.kt")
             public void testMultipleLayers() throws Exception {
                 runTest("compiler/testData/codegen/box/reflection/typeOf/multipleLayers.kt");
+            }
+
+            @Test
+            @TestMetadata("reifiedAsNestedArgument.kt")
+            public void testReifiedAsNestedArgument() throws Exception {
+                runTest("compiler/testData/codegen/box/reflection/typeOf/reifiedAsNestedArgument.kt");
             }
 
             @Test

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/testOld/wasm/semantics/IrCodegenBoxWasmTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/testOld/wasm/semantics/IrCodegenBoxWasmTestGenerated.java
@@ -29280,6 +29280,11 @@ public class IrCodegenBoxWasmTestGenerated extends AbstractIrCodegenBoxWasmTest 
                 KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/typeOf"), Pattern.compile("^([^_](.+))\\.kt$"), null, TargetBackend.WASM, true);
             }
 
+            @TestMetadata("arrayOfNullableReified.kt")
+            public void testArrayOfNullableReified() throws Exception {
+                runTest("compiler/testData/codegen/box/reflection/typeOf/arrayOfNullableReified.kt");
+            }
+
             @TestMetadata("classes.kt")
             public void testClasses() throws Exception {
                 runTest("compiler/testData/codegen/box/reflection/typeOf/classes.kt");
@@ -29303,6 +29308,11 @@ public class IrCodegenBoxWasmTestGenerated extends AbstractIrCodegenBoxWasmTest 
             @TestMetadata("multipleLayers.kt")
             public void testMultipleLayers() throws Exception {
                 runTest("compiler/testData/codegen/box/reflection/typeOf/multipleLayers.kt");
+            }
+
+            @TestMetadata("reifiedAsNestedArgument.kt")
+            public void testReifiedAsNestedArgument() throws Exception {
+                runTest("compiler/testData/codegen/box/reflection/typeOf/reifiedAsNestedArgument.kt");
             }
 
             @TestMetadata("typeOfCapturedStar.kt")

--- a/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/NativeCodegenBoxTestGenerated.java
+++ b/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/NativeCodegenBoxTestGenerated.java
@@ -35726,6 +35726,12 @@ public class NativeCodegenBoxTestGenerated extends AbstractNativeCodegenBoxTest 
                 }
 
                 @Test
+                @TestMetadata("arrayOfNullableReified.kt")
+                public void testArrayOfNullableReified() throws Exception {
+                    runTest("compiler/testData/codegen/box/reflection/typeOf/arrayOfNullableReified.kt");
+                }
+
+                @Test
                 @TestMetadata("classes.kt")
                 public void testClasses() throws Exception {
                     runTest("compiler/testData/codegen/box/reflection/typeOf/classes.kt");
@@ -35753,6 +35759,12 @@ public class NativeCodegenBoxTestGenerated extends AbstractNativeCodegenBoxTest 
                 @TestMetadata("multipleLayers.kt")
                 public void testMultipleLayers() throws Exception {
                     runTest("compiler/testData/codegen/box/reflection/typeOf/multipleLayers.kt");
+                }
+
+                @Test
+                @TestMetadata("reifiedAsNestedArgument.kt")
+                public void testReifiedAsNestedArgument() throws Exception {
+                    runTest("compiler/testData/codegen/box/reflection/typeOf/reifiedAsNestedArgument.kt");
                 }
 
                 @Test

--- a/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/SerializationJvmIrIntrinsicSupport.kt
+++ b/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/SerializationJvmIrIntrinsicSupport.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.backend.jvm.intrinsics.IntrinsicMethod
 import org.jetbrains.kotlin.backend.jvm.ir.representativeUpperBound
 import org.jetbrains.kotlin.backend.jvm.mapping.mapClass
 import org.jetbrains.kotlin.codegen.AsmUtil
+import org.jetbrains.kotlin.codegen.extractUsedReifiedParameters
 import org.jetbrains.kotlin.codegen.inline.ReifiedTypeInliner
 import org.jetbrains.kotlin.codegen.inline.ReifiedTypeInliner.Companion.pluginIntrinsicsMarkerMethod
 import org.jetbrains.kotlin.codegen.inline.ReifiedTypeInliner.Companion.pluginIntrinsicsMarkerOwner
@@ -92,6 +93,7 @@ class SerializationJvmIrIntrinsicSupport(val jvmBackendContext: JvmBackendContex
                     mv,
                     intrinsicType
                 )
+                codegen.propagateChildReifiedTypeParametersUsages(codegen.typeMapper.typeSystem.extractUsedReifiedParameters(argument))
                 if (withModule) {
                     frameMap.leaveTemp(serializersModuleType)
                 }


### PR DESCRIPTION
cc @udalov

I'm doing my best here but the core problem is that reified type parameters are severely under-defined. [The main piece of design documentation here](https://github.com/JetBrains/kotlin/blob/master/spec-docs/reified-type-parameters.md) basically defines "runtime-available types" as follows:

1. A reified type parameter reference is runtime-available.
2. A classifier type where reified type parameters are substituted with runtime-available type arguments and the rest are star projections is also runtime-available. (The only type that has reified type parameters is Array, and [we've already seen how that works, or doesn't work](https://youtrack.jetbrains.com/issue/KT-44646/Treat-ArrayT-as-runtime-available-if-T-is-runtime-available).)

The problem is that this doesn't really map to the JVM in a meaningful way. Of the 7 supported "intrinsic" reified operations, really only `NEW_ARRAY` abides by this, faithfully returning the array of the required type. As for the rest:

* `AS`, `SAFE_AS`, and `IS` in theory can only support `Array` if its reified argument is nullable (so a subset of runtime-available types), and in practice don't support it at all right now (see link above);
* `JAVA_CLASS` discards all nullability information;
* `ENUM_REIFIED` only works on concrete subtypes of `Enum` anyway;
* `TYPE_OF` doesn't even require its type argument to be runtime-available - `typeOf<List<String>>()` and `typeOf<List</
*non-reified*/ T>>()` work just fine - so its type parameter shouldn't even be reified I believe (`typeOf</*non-reified*/ T>()` should also be allowed). Speaking of this case, the fact that you can pass `List<String>` as a value to a reified type parameter may be wrong since it's not runtime-available (`List<*>` is).

And finally, what happens to signatures containing reified types is just completely undefined whatsoever and kind of only works on a best-effort basis. Sometimes even non-reified type parameters get reified in signatures if the type is regenerated for another reason, and I've actually seen code depend on that to do weird tricks:

```
// MODULE: lib
// FILE: tt.kt
inline fun </*non-reified!*/ T> weird() = object : TypeToken<T> {}

// MODULE: main(lib)
// FILE: use.kt
// passing non-reified V is fine because T is not reified either, but the object is regenerated
// because it's in another module so its supertype becomes TypeToken<V> and you can get
// a reference to V; this **does not work if you put everything in one module**!!!
fun <V> use() = weird<V>()
```

Note that this case could theoretically be covered by `typeOf<V>()`, which is currently disallowed even though it should work as I already said.

^KT-53761 Fixed