### PR TITLE
Allow `KtPsiFactory#createModifierList` to create `fun` modifier

### DIFF
--- a/compiler/psi/src/org/jetbrains/kotlin/psi/KtPsiFactory.kt
+++ b/compiler/psi/src/org/jetbrains/kotlin/psi/KtPsiFactory.kt
@@ -354,7 +354,7 @@ class KtPsiFactory @JvmOverloads constructor(private val project: Project, val m
     }
 
     fun createModifierList(@NonNls text: String): KtModifierList {
-        return createProperty("$text val x").modifierList!!
+        return createClass("$text interface x").modifierList!!
     }
 
     fun createEmptyModifierList() = createModifierList(KtTokens.PRIVATE_KEYWORD).apply { firstChild.delete() }

--- a/compiler/tests/org/jetbrains/kotlin/psi/KtPsiFactoryTest.kt
+++ b/compiler/tests/org/jetbrains/kotlin/psi/KtPsiFactoryTest.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.psi
+
+import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.test.KotlinTestUtils
+import org.jetbrains.kotlin.test.KotlinTestWithEnvironment
+import org.junit.Assert
+
+class KtPsiFactoryTest : KotlinTestWithEnvironment() {
+    fun testCreateModifierList() {
+        val psiFactory = KtPsiFactory(project)
+        KtTokens.MODIFIER_KEYWORDS_ARRAY.forEach {
+            val modifier = psiFactory.createModifierList(it)
+            Assert.assertTrue(modifier.hasModifier(it))
+        }
+    }
+
+    override fun createEnvironment(): KotlinCoreEnvironment {
+        return KotlinCoreEnvironment.createForTests(
+            testRootDisposable, KotlinTestUtils.newConfiguration(), EnvironmentConfigFiles.JVM_CONFIG_FILES
+        )
+    }
+}


### PR DESCRIPTION
Related: https://youtrack.jetbrains.com/issue/KTIJ-16332

I want to add a `fun` modifier to the `interface` declaration, but `KtPsiFactory#createModifier` throws the following exception:
```
org.jetbrains.kotlin.utils.KotlinExceptionWithAttachments: unexpected 2 declarations
	at org.jetbrains.kotlin.psi.KtPsiFactory.createDeclaration(KtPsiFactory.kt:924)
	at org.jetbrains.kotlin.psi.KtPsiFactory.createProperty(KtPsiFactory.kt:269)
	at org.jetbrains.kotlin.psi.KtPsiFactory.createModifierList(KtPsiFactory.kt:357)
	at org.jetbrains.kotlin.psi.addRemoveModifier.AddRemoveModifierKt.createModifierList(addRemoveModifier.kt:25)
	at org.jetbrains.kotlin.psi.addRemoveModifier.AddRemoveModifierKt.addModifier(addRemoveModifier.kt:40)
	at org.jetbrains.kotlin.psi.KtModifierListOwnerStub.addModifier(KtModifierListOwnerStub.java:54)
```