### PR TITLE
FIR: improve visibility check for overrides

### DIFF
--- a/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsTestGenerated.java
@@ -33789,6 +33789,18 @@ public class FirOldFrontendDiagnosticsTestGenerated extends AbstractFirDiagnosti
             }
 
             @Test
+            @TestMetadata("notOverridingInternal.kt")
+            public void testNotOverridingInternal() throws Exception {
+                runTest("compiler/testData/diagnostics/tests/visibility/notOverridingInternal.kt");
+            }
+
+            @Test
+            @TestMetadata("notOverridingPackagePrivate.kt")
+            public void testNotOverridingPackagePrivate() throws Exception {
+                runTest("compiler/testData/diagnostics/tests/visibility/notOverridingPackagePrivate.kt");
+            }
+
+            @Test
             @TestMetadata("overrideOfMemberInPackagePrivateClass.kt")
             public void testOverrideOfMemberInPackagePrivateClass() throws Exception {
                 runTest("compiler/testData/diagnostics/tests/visibility/overrideOfMemberInPackagePrivateClass.kt");

--- a/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsWithLightTreeTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsWithLightTreeTestGenerated.java
@@ -33789,6 +33789,18 @@ public class FirOldFrontendDiagnosticsWithLightTreeTestGenerated extends Abstrac
             }
 
             @Test
+            @TestMetadata("notOverridingInternal.kt")
+            public void testNotOverridingInternal() throws Exception {
+                runTest("compiler/testData/diagnostics/tests/visibility/notOverridingInternal.kt");
+            }
+
+            @Test
+            @TestMetadata("notOverridingPackagePrivate.kt")
+            public void testNotOverridingPackagePrivate() throws Exception {
+                runTest("compiler/testData/diagnostics/tests/visibility/notOverridingPackagePrivate.kt");
+            }
+
+            @Test
             @TestMetadata("overrideOfMemberInPackagePrivateClass.kt")
             public void testOverrideOfMemberInPackagePrivateClass() throws Exception {
                 runTest("compiler/testData/diagnostics/tests/visibility/overrideOfMemberInPackagePrivateClass.kt");

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirOverrideChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirOverrideChecker.kt
@@ -174,7 +174,7 @@ object FirOverrideChecker : FirClassChecker() {
             )
         }
         if (!hasVisibleBase) {
-            //NB: Old FE reports this in an attempt to override private member,
+            //NB: Old FE reports this in an attempt to override private/internal/package-private member,
             //while the new FE doesn't treat super's private members as overridable, so you won't get them here
             //instead you will get NOTHING_TO_OVERRIDE, which seems acceptable
             reporter.reportOn(source, FirErrors.CANNOT_OVERRIDE_INVISIBLE_MEMBER, this, overriddenSymbols.first(), context)

--- a/compiler/fir/java/src/org/jetbrains/kotlin/fir/java/FirJavaVisibilityChecker.kt
+++ b/compiler/fir/java/src/org/jetbrains/kotlin/fir/java/FirJavaVisibilityChecker.kt
@@ -17,6 +17,7 @@ import org.jetbrains.kotlin.fir.resolve.SupertypeSupplier
 import org.jetbrains.kotlin.fir.resolve.calls.FirSimpleSyntheticPropertySymbol
 import org.jetbrains.kotlin.fir.resolve.calls.ReceiverValue
 import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
+import org.jetbrains.kotlin.name.FqName
 
 @NoMutableState
 object FirJavaVisibilityChecker : FirVisibilityChecker() {
@@ -50,17 +51,22 @@ object FirJavaVisibilityChecker : FirVisibilityChecker() {
                 }
             }
 
-            JavaVisibilities.PackageVisibility -> {
-                if (symbol.packageFqName() == useSiteFile.packageFqName) {
-                    true
-                } else if (symbol.fir is FirSyntheticPropertyAccessor) {
-                    symbol.getOwnerLookupTag()?.classId?.packageFqName == useSiteFile.packageFqName
-                } else {
-                    false
-                }
-            }
-
+            JavaVisibilities.PackageVisibility -> symbol.isInPackage(useSiteFile.packageFqName)
             else -> true
         }
     }
+
+    override fun platformOverrideVisibilityCheck(
+        session: FirSession,
+        overrideCandidate: FirBasedSymbol<*>,
+        baseSymbol: FirBasedSymbol<*>,
+        baseDeclarationVisibility: Visibility,
+    ): Boolean = when (baseDeclarationVisibility) {
+        JavaVisibilities.ProtectedAndPackage, JavaVisibilities.ProtectedStaticVisibility -> true
+        JavaVisibilities.PackageVisibility -> baseSymbol.isInPackage(overrideCandidate.packageFqName())
+        else -> true
+    }
+
+    private fun FirBasedSymbol<*>.isInPackage(expected: FqName): Boolean =
+        packageFqName() == expected || (fir is FirSyntheticPropertyAccessor && getOwnerLookupTag()?.classId?.packageFqName == expected)
 }

--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/scopes/impl/FirStandardOverrideChecker.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/scopes/impl/FirStandardOverrideChecker.kt
@@ -5,14 +5,13 @@
 
 package org.jetbrains.kotlin.fir.scopes.impl
 
-import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.declarations.*
-import org.jetbrains.kotlin.fir.declarations.utils.visibility
 import org.jetbrains.kotlin.fir.resolve.substitution.ConeSubstitutor
 import org.jetbrains.kotlin.fir.resolve.transformers.ensureResolvedTypeDeclaration
 import org.jetbrains.kotlin.fir.symbols.lazyResolveToPhase
 import org.jetbrains.kotlin.fir.types.*
+import org.jetbrains.kotlin.fir.visibilityChecker
 import org.jetbrains.kotlin.types.AbstractTypeChecker
 import org.jetbrains.kotlin.types.model.KotlinTypeMarker
 import org.jetbrains.kotlin.types.model.SimpleTypeMarker
@@ -122,9 +121,8 @@ class FirStandardOverrideChecker(private val session: FirSession) : FirAbstractO
     }
 
     override fun isOverriddenFunction(overrideCandidate: FirSimpleFunction, baseDeclaration: FirSimpleFunction): Boolean {
-        if (Visibilities.isPrivate(baseDeclaration.visibility)) return false
-
         if (overrideCandidate.valueParameters.size != baseDeclaration.valueParameters.size) return false
+        if (!session.visibilityChecker.isVisibleForOverriding(session, overrideCandidate, baseDeclaration)) return false
 
         val substitutor = buildTypeParametersSubstitutorIfCompatible(overrideCandidate, baseDeclaration) ?: return false
 
@@ -141,9 +139,9 @@ class FirStandardOverrideChecker(private val session: FirSession) : FirAbstractO
         overrideCandidate: FirCallableDeclaration,
         baseDeclaration: FirProperty
     ): Boolean {
-        if (Visibilities.isPrivate(baseDeclaration.visibility)) return false
-
         if (overrideCandidate !is FirProperty) return false
+        if (!session.visibilityChecker.isVisibleForOverriding(session, overrideCandidate, baseDeclaration)) return false
+
         val substitutor = buildTypeParametersSubstitutorIfCompatible(overrideCandidate, baseDeclaration) ?: return false
         overrideCandidate.lazyResolveToPhase(FirResolvePhase.TYPES)
         baseDeclaration.lazyResolveToPhase(FirResolvePhase.TYPES)

--- a/compiler/testData/diagnostics/tests/visibility/abstractInvisibleMemberFromKotlin.fir.kt
+++ b/compiler/testData/diagnostics/tests/visibility/abstractInvisibleMemberFromKotlin.fir.kt
@@ -33,8 +33,8 @@ import intermediate.*
 
 class ImplDirectFromBaseWithOverride : BaseWithOverride()
 
-class ImplDirectFromBaseWithOverrid : Base() {
-    <!CANNOT_OVERRIDE_INVISIBLE_MEMBER!>override<!> fun internalFoo(): String = ""
+<!INVISIBLE_ABSTRACT_MEMBER_FROM_SUPER_ERROR!>class ImplDirectFromBaseWithOverrid<!> : Base() {
+    <!NOTHING_TO_OVERRIDE!>override<!> fun internalFoo(): String = ""
 }
 
 <!INVISIBLE_ABSTRACT_MEMBER_FROM_SUPER_ERROR!>class ImplViaIntermediate<!> : Intermediate()

--- a/compiler/testData/diagnostics/tests/visibility/notOverridingInternal.kt
+++ b/compiler/testData/diagnostics/tests/visibility/notOverridingInternal.kt
@@ -1,0 +1,24 @@
+// FIR_IDENTICAL
+// MODULE: base
+// FILE: Base.kt
+package base
+
+abstract class Base {
+    fun foo() = internalFoo()
+
+    internal fun internalFoo() {}
+}
+
+// MODULE: impl(base)
+// FILE: Impl.kt
+package impl
+import base.*
+
+class Impl : Base() {
+    fun internalFoo() { /*not an override*/ }
+}
+
+fun foo() {
+    Impl().foo()
+    Impl().internalFoo()
+}

--- a/compiler/testData/diagnostics/tests/visibility/notOverridingInternal.txt
+++ b/compiler/testData/diagnostics/tests/visibility/notOverridingInternal.txt
@@ -1,0 +1,30 @@
+// -- Module: <base> --
+package
+
+package base {
+
+    public abstract class Base {
+        public constructor Base()
+        public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+        public final fun foo(): kotlin.Unit
+        public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+        internal final fun internalFoo(): kotlin.Unit
+        public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+    }
+}
+
+// -- Module: <impl> --
+package
+
+package impl {
+    public fun foo(): kotlin.Unit
+
+    public final class Impl : base.Base {
+        public constructor Impl()
+        public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+        public final override /*1*/ /*fake_override*/ fun foo(): kotlin.Unit
+        public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+        public final fun internalFoo(): kotlin.Unit
+        public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+    }
+}

--- a/compiler/testData/diagnostics/tests/visibility/notOverridingPackagePrivate.kt
+++ b/compiler/testData/diagnostics/tests/visibility/notOverridingPackagePrivate.kt
@@ -1,0 +1,24 @@
+// FIR_IDENTICAL
+// FILE: base/Base.java
+package base;
+
+public abstract class Base {
+    public void foo() {
+        packagePrivateFoo();
+    }
+
+    /* package-private */ void packagePrivateFoo() {};
+}
+
+// FILE: Impl.kt
+package impl
+import base.*
+
+class Impl : Base() {
+    fun packagePrivateFoo() { /*not an override*/ }
+}
+
+fun foo() {
+    Impl().foo()
+    Impl().packagePrivateFoo()
+}

--- a/compiler/testData/diagnostics/tests/visibility/notOverridingPackagePrivate.txt
+++ b/compiler/testData/diagnostics/tests/visibility/notOverridingPackagePrivate.txt
@@ -1,0 +1,26 @@
+package
+
+package base {
+
+    public abstract class Base {
+        public constructor Base()
+        public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+        public open fun foo(): kotlin.Unit
+        public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+        public/*package*/ open fun packagePrivateFoo(): kotlin.Unit
+        public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+    }
+}
+
+package impl {
+    public fun foo(): kotlin.Unit
+
+    public final class Impl : base.Base {
+        public constructor Impl()
+        public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+        public open override /*1*/ /*fake_override*/ fun foo(): kotlin.Unit
+        public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+        public final fun packagePrivateFoo(): kotlin.Unit
+        public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+    }
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/DiagnosticTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/DiagnosticTestGenerated.java
@@ -33879,6 +33879,18 @@ public class DiagnosticTestGenerated extends AbstractDiagnosticTest {
             }
 
             @Test
+            @TestMetadata("notOverridingInternal.kt")
+            public void testNotOverridingInternal() throws Exception {
+                runTest("compiler/testData/diagnostics/tests/visibility/notOverridingInternal.kt");
+            }
+
+            @Test
+            @TestMetadata("notOverridingPackagePrivate.kt")
+            public void testNotOverridingPackagePrivate() throws Exception {
+                runTest("compiler/testData/diagnostics/tests/visibility/notOverridingPackagePrivate.kt");
+            }
+
+            @Test
             @TestMetadata("overrideOfMemberInPackagePrivateClass.kt")
             public void testOverrideOfMemberInPackagePrivateClass() throws Exception {
                 runTest("compiler/testData/diagnostics/tests/visibility/overrideOfMemberInPackagePrivateClass.kt");

--- a/compiler/tests-spec/testData/diagnostics/linked/declarations/classifier-declaration/class-declaration/abstract-classes/p-2/neg/1.6.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/linked/declarations/classifier-declaration/class-declaration/abstract-classes/p-2/neg/1.6.fir.kt
@@ -26,8 +26,8 @@ import base.*
 
 // TESTCASE NUMBER: 1
 
-class Case1 : BaseJava() {
-    <!CANNOT_OVERRIDE_INVISIBLE_MEMBER!>override<!> fun foo(b: Boolean?) {}
+<!INVISIBLE_ABSTRACT_MEMBER_FROM_SUPER_ERROR!>class Case1<!> : BaseJava() {
+    <!NOTHING_TO_OVERRIDE!>override<!> fun foo(b: Boolean?) {}
 }
 
 fun case1() {
@@ -40,8 +40,8 @@ fun case1() {
 */
 abstract class AbstractClassCase2 : BaseJava() {}
 
-class Case2: AbstractClassCase2() {
-    <!CANNOT_OVERRIDE_INVISIBLE_MEMBER!>override<!> fun foo(b: Boolean?) {}
+<!INVISIBLE_ABSTRACT_MEMBER_FROM_SUPER_ERROR!>class Case2<!>: AbstractClassCase2() {
+    <!NOTHING_TO_OVERRIDE!>override<!> fun foo(b: Boolean?) {}
 }
 
 fun case2() {

--- a/compiler/tests-spec/testData/diagnostics/linked/declarations/classifier-declaration/class-declaration/abstract-classes/p-2/neg/1.7.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/linked/declarations/classifier-declaration/class-declaration/abstract-classes/p-2/neg/1.7.fir.kt
@@ -26,16 +26,16 @@ import base.*
 
 // TESTCASE NUMBER: 1
 
-class Case1 : BaseKotlin() {
-    <!CANNOT_OVERRIDE_INVISIBLE_MEMBER!>override<!> fun foo(b: Boolean?) {}
+<!INVISIBLE_ABSTRACT_MEMBER_FROM_SUPER_ERROR!>class Case1<!> : BaseKotlin() {
+    <!NOTHING_TO_OVERRIDE!>override<!> fun foo(b: Boolean?) {}
 }
 
 fun case1() {
     val v = Case1()
     v.boo(true)
 
-    val o = object :  BaseKotlin() {
-        <!CANNOT_OVERRIDE_INVISIBLE_MEMBER!>override<!> fun foo(b: Boolean?) {}
+    val o = <!INVISIBLE_ABSTRACT_MEMBER_FROM_SUPER_ERROR!>object<!> :  BaseKotlin() {
+        <!NOTHING_TO_OVERRIDE!>override<!> fun foo(b: Boolean?) {}
     }
 }
 
@@ -44,16 +44,16 @@ fun case1() {
 */
 abstract class AbstractClassCase2 : BaseKotlin() {}
 
-class Case2: AbstractClassCase2() {
-    <!CANNOT_OVERRIDE_INVISIBLE_MEMBER!>override<!> fun foo(b: Boolean?) {}
+<!INVISIBLE_ABSTRACT_MEMBER_FROM_SUPER_ERROR!>class Case2<!>: AbstractClassCase2() {
+    <!NOTHING_TO_OVERRIDE!>override<!> fun foo(b: Boolean?) {}
 }
 
 fun case2() {
     val v = Case2()
     v.boo(true)
 
-    val o = object : AbstractClassCase2() {
-        <!CANNOT_OVERRIDE_INVISIBLE_MEMBER!>override<!> fun foo(b: Boolean?) {}
+    val o = <!INVISIBLE_ABSTRACT_MEMBER_FROM_SUPER_ERROR!>object<!> : AbstractClassCase2() {
+        <!NOTHING_TO_OVERRIDE!>override<!> fun foo(b: Boolean?) {}
     }
 }
 


### PR DESCRIPTION
Internal methods from non-friend modules and package-private methods from other packages should not be considered when determining whether a method is an override (in addition to private methods).