### PR TITLE
Switch to use System.nanoTime in measureTimeMillis

### DIFF
--- a/libraries/stdlib/jvm/src/kotlin/system/Timing.kt
+++ b/libraries/stdlib/jvm/src/kotlin/system/Timing.kt
@@ -17,7 +17,7 @@ public inline fun measureTimeMillis(block: () -> Unit): Long {
     contract {
         callsInPlace(block, InvocationKind.EXACTLY_ONCE)
     }
-    return measureNanoTime(block) / 1_000_000L
+    return (measureNanoTime(block) + 500_000L) / 1_000_000L
 }
 
 /**

--- a/libraries/stdlib/jvm/src/kotlin/system/Timing.kt
+++ b/libraries/stdlib/jvm/src/kotlin/system/Timing.kt
@@ -17,9 +17,7 @@ public inline fun measureTimeMillis(block: () -> Unit): Long {
     contract {
         callsInPlace(block, InvocationKind.EXACTLY_ONCE)
     }
-    val start = System.currentTimeMillis()
-    block()
-    return System.currentTimeMillis() - start
+    return measureNanoTime(block) / 1_000_000L
 }
 
 /**


### PR DESCRIPTION
Previously measureTimeMillis used System.currentTimeMillis which is not ideal for several reasons. Firstly it often has a resolution of 10s of milliseconds and secondly because it can be adjusted by something like an NTP update so the returned value could be negative.

Instead it now delegates to measureNanoTime which uses System.nanoTime which has the highest resolution the system provides as well as being guaranteed to be monotonically increasing.

This fixes [KT-52686](https://youtrack.jetbrains.com/issue/KT-52686) and [KT-24431](https://youtrack.jetbrains.com/issue/KT-24431)