### PR TITLE
KAPT: Omit property initializers for non const properties in stubs

### DIFF
--- a/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/ClassFileToSourceStubConverter.kt
+++ b/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/ClassFileToSourceStubConverter.kt
@@ -805,7 +805,7 @@ class ClassFileToSourceStubConverter(val kaptContext: KaptContextForStubGenerati
 
         // If the field does not have a simple default value and is final the default value for that type is used.
         // The value will be omitted for inlinable types (primitives and strings) except for static interface fields as they are required
-        // to have an initializer.
+        // to have an initializer as static initializes are not allowed in interfaces.
         if (isFinal(field.access) && (!isPrimitiveOrString || isStaticInterfaceField)) {
             val type = Type.getType(field.desc)
             return convertLiteralExpression(containingClass, getDefaultValue(type))

--- a/plugins/kapt3/kapt3-compiler/testData/converter/abstractEnum.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/abstractEnum.txt
@@ -61,7 +61,7 @@ public enum E3 {
     /*public static final*/ X /* = new E3() */,
     /*public static final*/ Y /* = new E3() */;
     @org.jetbrains.annotations.NotNull()
-    private final java.lang.String a = null;
+    private final java.lang.String a;
 
     E3(java.lang.String a) {
     }
@@ -81,10 +81,10 @@ import java.lang.System;
 public enum E4 {
     /*public static final*/ X /* = new E4() */;
     @org.jetbrains.annotations.NotNull()
-    private final java.lang.String a = null;
-    private final int b = 0;
-    private final long c = 0L;
-    private final boolean d = false;
+    private final java.lang.String a;
+    private final int b;
+    private final long c;
+    private final boolean d;
 
     E4(java.lang.String a, int b, long c, boolean d) {
     }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/annotations2.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/annotations2.txt
@@ -55,7 +55,7 @@ public enum Enum {
     /*public static final*/ WHITE /* = new Enum() */,
     @Anno(value = "black")
     /*public static final*/ BLACK /* = new Enum() */;
-    private final int x = 0;
+    private final int x;
 
     @Anno(value = "enum-constructor")
     Enum(@Anno(value = "x")

--- a/plugins/kapt3/kapt3-compiler/testData/converter/annotations2_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/annotations2_ir.txt
@@ -55,7 +55,7 @@ public enum Enum {
     /*public static final*/ WHITE /* = new Enum() */,
     @Anno(value = "black")
     /*public static final*/ BLACK /* = new Enum() */;
-    private final int x = 0;
+    private final int x;
 
     @Anno(value = "enum-constructor")
     Enum(@Anno(value = "x")

--- a/plugins/kapt3/kapt3-compiler/testData/converter/annotationsWithConstants.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/annotationsWithConstants.txt
@@ -92,7 +92,7 @@ public final class JJ {
     @org.jetbrains.annotations.NotNull()
     public static final app.JJ INSTANCE = null;
     @org.jetbrains.annotations.NotNull()
-    private static final java.lang.String b = null;
+    private static final java.lang.String b;
 
     private JJ() {
         super();
@@ -175,7 +175,7 @@ public final class MyActivity {
     public final int propD = app.B.id.textView;
     @kotlin.jvm.JvmField()
     public int propE = app.B.id.textView;
-    private final int propF = 0;
+    private final int propF;
 
     public MyActivity() {
         super();

--- a/plugins/kapt3/kapt3-compiler/testData/converter/annotationsWithConstants_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/annotationsWithConstants_ir.txt
@@ -90,7 +90,7 @@ import java.lang.System;
 @kotlin.Metadata()
 public final class JJ {
     @org.jetbrains.annotations.NotNull()
-    private static final java.lang.String b = null;
+    private static final java.lang.String b;
     @org.jetbrains.annotations.NotNull()
     public static final app.JJ INSTANCE = null;
 
@@ -175,7 +175,7 @@ public final class MyActivity {
     public final int propD = app.B.id.textView;
     @kotlin.jvm.JvmField()
     public int propE = app.B.id.textView;
-    private final int propF = 0;
+    private final int propF;
 
     public MyActivity() {
         super();

--- a/plugins/kapt3/kapt3-compiler/testData/converter/annotationsWithTargets.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/annotationsWithTargets.txt
@@ -75,7 +75,7 @@ import java.lang.System;
 public final class Foo {
     @org.jetbrains.annotations.NotNull()
     @FieldAnno()
-    private final java.lang.String a = null;
+    private final java.lang.String a;
 
     public Foo(@org.jetbrains.annotations.NotNull()
     @Anno()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/comments.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/comments.txt
@@ -130,7 +130,7 @@ import java.lang.System;
 @kotlin.Metadata()
 public final class Test2 {
     @org.jetbrains.annotations.NotNull()
-    private final java.lang.String a = null;
+    private final java.lang.String a;
 
     public Test2(@org.jetbrains.annotations.NotNull()
     java.lang.String a) {
@@ -154,7 +154,7 @@ import java.lang.System;
 @kotlin.Metadata()
 public final class Test3 {
     @org.jetbrains.annotations.NotNull()
-    private final java.lang.String a = null;
+    private final java.lang.String a;
 
     protected Test3(@org.jetbrains.annotations.NotNull()
     java.lang.String a) {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/commentsRemoved.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/commentsRemoved.txt
@@ -93,7 +93,7 @@ import java.lang.System;
 @kotlin.Metadata()
 public final class Test2 {
     @org.jetbrains.annotations.NotNull()
-    private final java.lang.String a = null;
+    private final java.lang.String a;
 
     public Test2(@org.jetbrains.annotations.NotNull()
     java.lang.String a) {
@@ -114,7 +114,7 @@ import java.lang.System;
 @kotlin.Metadata()
 public final class Test3 {
     @org.jetbrains.annotations.NotNull()
-    private final java.lang.String a = null;
+    private final java.lang.String a;
 
     protected Test3(@org.jetbrains.annotations.NotNull()
     java.lang.String a) {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/commentsRemoved_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/commentsRemoved_ir.txt
@@ -93,7 +93,7 @@ import java.lang.System;
 @kotlin.Metadata()
 public final class Test2 {
     @org.jetbrains.annotations.NotNull()
-    private final java.lang.String a = null;
+    private final java.lang.String a;
 
     public Test2(@org.jetbrains.annotations.NotNull()
     java.lang.String a) {
@@ -114,7 +114,7 @@ import java.lang.System;
 @kotlin.Metadata()
 public final class Test3 {
     @org.jetbrains.annotations.NotNull()
-    private final java.lang.String a = null;
+    private final java.lang.String a;
 
     protected Test3(@org.jetbrains.annotations.NotNull()
     java.lang.String a) {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/dataClass.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/dataClass.txt
@@ -3,10 +3,10 @@ import java.lang.System;
 @kotlin.Metadata()
 public final class User {
     @org.jetbrains.annotations.NotNull()
-    private final java.lang.String firstName = null;
+    private final java.lang.String firstName;
     @org.jetbrains.annotations.NotNull()
-    private final java.lang.String secondName = null;
-    private final int age = 0;
+    private final java.lang.String secondName;
+    private final int age;
 
     @org.jetbrains.annotations.NotNull()
     public final User copy(@org.jetbrains.annotations.NotNull()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/dataClass_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/dataClass_ir.txt
@@ -3,10 +3,10 @@ import java.lang.System;
 @kotlin.Metadata()
 public final class User {
     @org.jetbrains.annotations.NotNull()
-    private final java.lang.String firstName = null;
+    private final java.lang.String firstName;
     @org.jetbrains.annotations.NotNull()
-    private final java.lang.String secondName = null;
-    private final int age = 0;
+    private final java.lang.String secondName;
+    private final int age;
 
     public User(@org.jetbrains.annotations.NotNull()
     java.lang.String firstName, @org.jetbrains.annotations.NotNull()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/defaultParameterValueOff.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/defaultParameterValueOff.txt
@@ -16,17 +16,17 @@ import java.lang.System;
 
 @kotlin.Metadata()
 public final class Foo {
-    private final boolean z = false;
-    private final byte b = 0;
-    private final char c = '\u0000';
-    private final char c2 = '\u0000';
-    private final short sh = 0;
-    private final int i = 0;
-    private final long l = 0L;
-    private final float f = 0.0F;
-    private final double d = 0.0;
+    private final boolean z;
+    private final byte b;
+    private final char c;
+    private final char c2;
+    private final short sh;
+    private final int i;
+    private final long l;
+    private final float f;
+    private final double d;
     @org.jetbrains.annotations.NotNull()
-    private final java.lang.String s = null;
+    private final java.lang.String s;
     @org.jetbrains.annotations.NotNull()
     private final int[] iarr = null;
     @org.jetbrains.annotations.NotNull()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/defaultParameterValueOff_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/defaultParameterValueOff_ir.txt
@@ -16,17 +16,17 @@ import java.lang.System;
 
 @kotlin.Metadata()
 public final class Foo {
-    private final boolean z = false;
-    private final byte b = 0;
-    private final char c = '\u0000';
-    private final char c2 = '\u0000';
-    private final short sh = 0;
-    private final int i = 0;
-    private final long l = 0L;
-    private final float f = 0.0F;
-    private final double d = 0.0;
+    private final boolean z;
+    private final byte b;
+    private final char c;
+    private final char c2;
+    private final short sh;
+    private final int i;
+    private final long l;
+    private final float f;
+    private final double d;
     @org.jetbrains.annotations.NotNull()
-    private final java.lang.String s = null;
+    private final java.lang.String s;
     @org.jetbrains.annotations.NotNull()
     private final int[] iarr = null;
     @org.jetbrains.annotations.NotNull()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/enums.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/enums.txt
@@ -31,8 +31,8 @@ public enum Enum2 {
     /*public static final*/ RED /* = new Enum2() */,
     /*public static final*/ WHITE /* = new Enum2() */;
     @org.jetbrains.annotations.NotNull()
-    private final java.lang.String col = null;
-    private final int col2 = 0;
+    private final java.lang.String col;
+    private final int col2;
 
     Enum2(@Anno1(value = "first")
     java.lang.String col, @Anno1(value = "second")

--- a/plugins/kapt3/kapt3-compiler/testData/converter/errorLocationMapping.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/errorLocationMapping.txt
@@ -29,7 +29,7 @@ import kotlin.reflect.KClass;
 @kotlin.Metadata()
 public final class ErrorInConstructorParameter {
     @org.jetbrains.annotations.NotNull()
-    private final java.lang.String a = null;
+    private final java.lang.String a;
     @org.jetbrains.annotations.NotNull()
     private final ABC b = null;
     @org.jetbrains.annotations.NotNull()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/inlineClasses.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/inlineClasses.txt
@@ -8,7 +8,7 @@ public final class Cl {
         super();
     }
     @org.jetbrains.annotations.NotNull()
-    private final java.lang.String a = null;
+    private final java.lang.String a;
 
     @java.lang.Override()
     public boolean equals(java.lang.Object other) {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/inlineClasses_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/inlineClasses_ir.txt
@@ -8,7 +8,7 @@ public final class Cl {
         super();
     }
     @org.jetbrains.annotations.NotNull()
-    private final java.lang.String a = null;
+    private final java.lang.String a;
 
     @org.jetbrains.annotations.NotNull()
     public final java.lang.String getA() {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/interfaceImplementation.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/interfaceImplementation.txt
@@ -15,7 +15,7 @@ import java.lang.System;
 @kotlin.Metadata()
 public final class Product2 implements Named {
     @org.jetbrains.annotations.Nullable()
-    private java.lang.String name;
+    private java.lang.String name = null;
 
     @org.jetbrains.annotations.Nullable()
     @java.lang.Override()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/jvmOverloads.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/jvmOverloads.txt
@@ -2,10 +2,10 @@ import java.lang.System;
 
 @kotlin.Metadata()
 public final class State {
-    private final int someInt = 0;
-    private final long someLong = 0L;
+    private final int someInt;
+    private final long someLong;
     @org.jetbrains.annotations.NotNull()
-    private final java.lang.String someString = null;
+    private final java.lang.String someString;
 
     @kotlin.jvm.JvmOverloads()
     public State(int someInt, long someLong) {
@@ -40,12 +40,12 @@ import java.lang.System;
 @kotlin.Metadata()
 public final class State2 {
     @kotlin.jvm.JvmField()
-    public final int someInt = 0;
+    public final int someInt;
     @kotlin.jvm.JvmField()
-    public final long someLong = 0L;
+    public final long someLong;
     @org.jetbrains.annotations.NotNull()
     @kotlin.jvm.JvmField()
-    public final java.lang.String someString = null;
+    public final java.lang.String someString;
 
     @kotlin.jvm.JvmOverloads()
     public State2(int someInt) {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/jvmOverloads_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/jvmOverloads_ir.txt
@@ -2,10 +2,10 @@ import java.lang.System;
 
 @kotlin.Metadata()
 public final class State {
-    private final int someInt = 0;
-    private final long someLong = 0L;
+    private final int someInt;
+    private final long someLong;
     @org.jetbrains.annotations.NotNull()
-    private final java.lang.String someString = null;
+    private final java.lang.String someString;
 
     @kotlin.jvm.JvmOverloads()
     public State(int someInt, long someLong, @org.jetbrains.annotations.NotNull()
@@ -40,12 +40,12 @@ import java.lang.System;
 @kotlin.Metadata()
 public final class State2 {
     @kotlin.jvm.JvmField()
-    public final int someInt = 0;
+    public final int someInt;
     @kotlin.jvm.JvmField()
-    public final long someLong = 0L;
+    public final long someLong;
     @org.jetbrains.annotations.NotNull()
     @kotlin.jvm.JvmField()
-    public final java.lang.String someString = null;
+    public final java.lang.String someString;
 
     @kotlin.jvm.JvmOverloads()
     public State2(int someInt, long someLong, @org.jetbrains.annotations.NotNull()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt14998.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt14998.txt
@@ -14,9 +14,9 @@ public final class Outer {
     @kotlin.Metadata()
     final class Inner {
         @org.jetbrains.annotations.NotNull()
-        private final java.lang.String foo = null;
+        private final java.lang.String foo;
         @org.jetbrains.annotations.NotNull()
-        private final java.lang.String bar = null;
+        private final java.lang.String bar;
 
         public Inner(@org.jetbrains.annotations.NotNull()
         java.lang.String foo, @org.jetbrains.annotations.NotNull()
@@ -38,9 +38,9 @@ public final class Outer {
     @kotlin.Metadata()
     static final class Nested {
         @org.jetbrains.annotations.NotNull()
-        private final java.lang.String foo = null;
+        private final java.lang.String foo;
         @org.jetbrains.annotations.NotNull()
-        private final java.lang.String bar = null;
+        private final java.lang.String bar;
 
         public Nested(@org.jetbrains.annotations.NotNull()
         java.lang.String foo, @org.jetbrains.annotations.NotNull()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt24272.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt24272.txt
@@ -2,7 +2,7 @@ import java.lang.System;
 
 @kotlin.Metadata()
 public final class Foo {
-    private final java.lang.String string = null;
+    private final java.lang.String string;
     @org.jetbrains.annotations.NotNull()
     private final Foo.Bar bar = null;
 
@@ -19,7 +19,7 @@ public final class Foo {
     @kotlin.Metadata()
     public static final class Bar {
         @org.jetbrains.annotations.NotNull()
-        private final java.lang.String string = null;
+        private final java.lang.String string;
         @org.jetbrains.annotations.NotNull()
         private final java.util.ArrayList<Foo.Bar.Bar> bars = null;
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt24272_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt24272_ir.txt
@@ -3,7 +3,7 @@ import java.lang.System;
 @kotlin.Metadata()
 public final class Foo {
     @org.jetbrains.annotations.NotNull()
-    private final java.lang.String string = null;
+    private final java.lang.String string;
     @org.jetbrains.annotations.NotNull()
     private final Foo.Bar bar = null;
 
@@ -20,7 +20,7 @@ public final class Foo {
     @kotlin.Metadata()
     public static final class Bar {
         @org.jetbrains.annotations.NotNull()
-        private final java.lang.String string = null;
+        private final java.lang.String string;
         @org.jetbrains.annotations.NotNull()
         private final java.util.ArrayList<Foo.Bar.Bar> bars = null;
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt25071.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt25071.txt
@@ -7,7 +7,7 @@ public final class StaticImport {
     private final java.util.Collection<java.lang.String> x = null;
     private final kapt.StaticMethod<java.lang.String> l = null;
     private final kapt.StaticMethod<java.lang.String> m = null;
-    private final int y = 0;
+    private final int y;
 
     public StaticImport() {
         super();

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt27126.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt27126.txt
@@ -65,7 +65,7 @@ import java.lang.System;
 
 @kotlin.Metadata()
 public abstract class NullableBundleProperty<EE extends java.lang.Object> implements kotlin.properties.ReadWriteProperty<java.lang.Object, EE> {
-    private final java.lang.String key = null;
+    private final java.lang.String key;
 
     public NullableBundleProperty(@org.jetbrains.annotations.Nullable()
     java.lang.String key) {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt27126_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt27126_ir.txt
@@ -66,7 +66,7 @@ import java.lang.System;
 @kotlin.Metadata()
 public abstract class NullableBundleProperty<EE extends java.lang.Object> implements kotlin.properties.ReadWriteProperty<java.lang.Object, EE> {
     @org.jetbrains.annotations.Nullable()
-    private final java.lang.String key = null;
+    private final java.lang.String key;
 
     public NullableBundleProperty(@org.jetbrains.annotations.Nullable()
     java.lang.String key) {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/nestedClassesNonRootPackage.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/nestedClassesNonRootPackage.txt
@@ -104,7 +104,7 @@ public final class Experiment {
     @test.Experiment.Type()
     public static final class Group {
         @org.jetbrains.annotations.NotNull()
-        private final java.lang.String s = null;
+        private final java.lang.String s;
 
         @org.jetbrains.annotations.NotNull()
         public final test.Experiment.Group copy(@org.jetbrains.annotations.NotNull()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/nestedClassesNonRootPackage_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/nestedClassesNonRootPackage_ir.txt
@@ -104,7 +104,7 @@ public final class Experiment {
     @test.Experiment.Type()
     public static final class Group {
         @org.jetbrains.annotations.NotNull()
-        private final java.lang.String s = null;
+        private final java.lang.String s;
 
         public Group(@org.jetbrains.annotations.NotNull()
         java.lang.String s) {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/primitivePropertyInitializers.kt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/primitivePropertyInitializers.kt
@@ -1,0 +1,18 @@
+class RegularClass(
+    val constructorProperty: Int = 1
+) {
+    val dependentProperty = constructorProperty
+    val staticProperty = true
+
+    companion object {
+        val companionProperty = 1.0
+        const val constCompanionProperty = 1.0f
+    }
+}
+
+object Object {
+    val objectProperty = 1.0
+    @JvmField
+    val objectFieldProperty = 'c'
+    const val constObjectProperty = 1.0f
+}

--- a/plugins/kapt3/kapt3-compiler/testData/converter/primitivePropertyInitializers.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/primitivePropertyInitializers.txt
@@ -1,0 +1,67 @@
+import java.lang.System;
+
+@kotlin.Metadata()
+public final class Object {
+    @org.jetbrains.annotations.NotNull()
+    public static final Object INSTANCE = null;
+    private static final double objectProperty = 1.0;
+    @kotlin.jvm.JvmField()
+    public static final char objectFieldProperty = 'c';
+    public static final float constObjectProperty = 1.0F;
+
+    private Object() {
+        super();
+    }
+
+    public final double getObjectProperty() {
+        return 0.0;
+    }
+}
+
+////////////////////
+
+
+import java.lang.System;
+
+@kotlin.Metadata()
+public final class RegularClass {
+    private final int constructorProperty;
+    private final int dependentProperty;
+    private final boolean staticProperty = true;
+    @org.jetbrains.annotations.NotNull()
+    public static final RegularClass.Companion Companion = null;
+    private static final double companionProperty = 1.0;
+    public static final float constCompanionProperty = 1.0F;
+
+    public RegularClass() {
+        super();
+    }
+
+    public RegularClass(int constructorProperty) {
+        super();
+    }
+
+    public final int getConstructorProperty() {
+        return 0;
+    }
+
+    public final int getDependentProperty() {
+        return 0;
+    }
+
+    public final boolean getStaticProperty() {
+        return false;
+    }
+
+    @kotlin.Metadata()
+    public static final class Companion {
+
+        private Companion() {
+            super();
+        }
+
+        public final double getCompanionProperty() {
+            return 0.0;
+        }
+    }
+}

--- a/plugins/kapt3/kapt3-compiler/testData/converter/primitivePropertyInitializers_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/primitivePropertyInitializers_ir.txt
@@ -1,0 +1,67 @@
+import java.lang.System;
+
+@kotlin.Metadata()
+public final class Object {
+    private static final double objectProperty = 1.0;
+    @kotlin.jvm.JvmField()
+    public static final char objectFieldProperty = 'c';
+    public static final float constObjectProperty = 1.0F;
+    @org.jetbrains.annotations.NotNull()
+    public static final Object INSTANCE = null;
+
+    private Object() {
+        super();
+    }
+
+    public final double getObjectProperty() {
+        return 0.0;
+    }
+}
+
+////////////////////
+
+
+import java.lang.System;
+
+@kotlin.Metadata()
+public final class RegularClass {
+    private final int constructorProperty;
+    private final int dependentProperty;
+    private final boolean staticProperty = true;
+    private static final double companionProperty = 1.0;
+    public static final float constCompanionProperty = 1.0F;
+    @org.jetbrains.annotations.NotNull()
+    public static final RegularClass.Companion Companion = null;
+
+    public RegularClass(int constructorProperty) {
+        super();
+    }
+
+    public final int getConstructorProperty() {
+        return 0;
+    }
+
+    public final int getDependentProperty() {
+        return 0;
+    }
+
+    public final boolean getStaticProperty() {
+        return false;
+    }
+
+    public RegularClass() {
+        super();
+    }
+
+    @kotlin.Metadata()
+    public static final class Companion {
+
+        private Companion() {
+            super();
+        }
+
+        public final double getCompanionProperty() {
+            return 0.0;
+        }
+    }
+}

--- a/plugins/kapt3/kapt3-compiler/testData/converter/properties.kt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/properties.kt
@@ -1,5 +1,6 @@
 class Test {
     val simple: String = "123"
+    val nullable: String? = null
 
     val inferType = simple.length.toString() + "4891"
 
@@ -8,4 +9,5 @@ class Test {
 
     val constJavaClassValue: Class<*> = String::class.java
     val constClassValue: kotlin.reflect.KClass<*> = (String::class)
+    val nullableClassValue: kotlin.reflect.KClass<*>? = null
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/properties.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/properties.txt
@@ -4,14 +4,18 @@ import java.lang.System;
 public final class Test {
     @org.jetbrains.annotations.NotNull()
     private final java.lang.String simple = "123";
+    @org.jetbrains.annotations.Nullable()
+    private final java.lang.String nullable = null;
     @org.jetbrains.annotations.NotNull()
-    private final java.lang.String inferType = null;
+    private final java.lang.String inferType;
     @org.jetbrains.annotations.NotNull()
     private final java.lang.String getter = "O";
     @org.jetbrains.annotations.NotNull()
     private final java.lang.Class<?> constJavaClassValue = null;
     @org.jetbrains.annotations.NotNull()
     private final kotlin.reflect.KClass<?> constClassValue = null;
+    @org.jetbrains.annotations.Nullable()
+    private final kotlin.reflect.KClass<?> nullableClassValue = null;
 
     public Test() {
         super();
@@ -19,6 +23,11 @@ public final class Test {
 
     @org.jetbrains.annotations.NotNull()
     public final java.lang.String getSimple() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.Nullable()
+    public final java.lang.String getNullable() {
         return null;
     }
 
@@ -39,6 +48,11 @@ public final class Test {
 
     @org.jetbrains.annotations.NotNull()
     public final kotlin.reflect.KClass<?> getConstClassValue() {
+        return null;
+    }
+
+    @org.jetbrains.annotations.Nullable()
+    public final kotlin.reflect.KClass<?> getNullableClassValue() {
         return null;
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/secondaryConstructor.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/secondaryConstructor.txt
@@ -18,7 +18,7 @@ import java.lang.System;
 @kotlin.Metadata()
 public final class Product2 implements secondary.Named {
     @org.jetbrains.annotations.Nullable()
-    private java.lang.String name;
+    private java.lang.String name = null;
 
     @org.jetbrains.annotations.Nullable()
     @java.lang.Override()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/strangeIdentifiers.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/strangeIdentifiers.txt
@@ -18,7 +18,7 @@ import java.lang.System;
 public enum StrangeEnum {
     /*public static final*/ InvalidFieldName /* = new StrangeEnum() */;
     @org.jetbrains.annotations.NotNull()
-    private final java.lang.String size = null;
+    private final java.lang.String size;
 
     StrangeEnum(java.lang.String size) {
     }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/strangeIdentifiers_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/strangeIdentifiers_ir.txt
@@ -18,7 +18,7 @@ import java.lang.System;
 public enum StrangeEnum {
     /*public static final*/ InvalidFieldName /* = new StrangeEnum() */;
     @org.jetbrains.annotations.NotNull()
-    private final java.lang.String size = null;
+    private final java.lang.String size;
 
     StrangeEnum(java.lang.String size) {
     }
@@ -36,7 +36,7 @@ import java.lang.System;
 
 @kotlin.Metadata()
 public final class Test {
-    public final java.lang.String simpleName = null;
+    public final java.lang.String simpleName;
 
     public Test() {
         super();

--- a/plugins/kapt3/kapt3-compiler/testData/converter/unsafePropertyInitializers.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/unsafePropertyInitializers.txt
@@ -5,7 +5,7 @@ public final class Boo {
     @org.jetbrains.annotations.NotNull()
     public static final Boo INSTANCE = null;
     @org.jetbrains.annotations.NotNull()
-    private static final java.lang.String z = null;
+    private static final java.lang.String z;
 
     private Boo() {
         super();
@@ -41,17 +41,17 @@ public final class Foo {
     private static java.lang.String cString = "baz";
     private static int cInt = 7;
     @org.jetbrains.annotations.NotNull()
-    private static final java.lang.String d = null;
-    private static final int e = 0;
+    private static final java.lang.String d;
+    private static final int e;
     private static final int f = 8;
     @org.jetbrains.annotations.NotNull()
     private static final java.lang.String g = "ab";
     private static final int h = -4;
     private static final int i = 2147483647;
     @org.jetbrains.annotations.NotNull()
-    private static final java.lang.String j = null;
+    private static final java.lang.String j;
     @org.jetbrains.annotations.NotNull()
-    private static final java.lang.String k = null;
+    private static final java.lang.String k;
 
     private Foo() {
         super();

--- a/plugins/kapt3/kapt3-compiler/testData/converter/unsafePropertyInitializers_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/unsafePropertyInitializers_ir.txt
@@ -3,7 +3,7 @@ import java.lang.System;
 @kotlin.Metadata()
 public final class Boo {
     @org.jetbrains.annotations.NotNull()
-    private static final java.lang.String z = null;
+    private static final java.lang.String z;
     @org.jetbrains.annotations.NotNull()
     public static final Boo INSTANCE = null;
 
@@ -39,17 +39,17 @@ public final class Foo {
     private static java.lang.String cString = "baz";
     private static int cInt = 7;
     @org.jetbrains.annotations.NotNull()
-    private static final java.lang.String d = null;
-    private static final int e = 0;
+    private static final java.lang.String d;
+    private static final int e;
     private static final int f = 8;
     @org.jetbrains.annotations.NotNull()
     private static final java.lang.String g = "ab";
     private static final int h = -4;
     private static final int i = 2147483647;
     @org.jetbrains.annotations.NotNull()
-    private static final java.lang.String j = null;
+    private static final java.lang.String j;
     @org.jetbrains.annotations.NotNull()
-    private static final java.lang.String k = null;
+    private static final java.lang.String k;
     @org.jetbrains.annotations.NotNull()
     public static final Foo INSTANCE = null;
 

--- a/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/NestedClasses.it.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/NestedClasses.it.txt
@@ -23,7 +23,7 @@ import java.lang.System;
 @kotlin.Metadata()
 public final class Simple {
     @org.jetbrains.annotations.NotNull()
-    public static final test.Simple.Companion Companion = null;
+    public static final test.Simple.Companion Companion;
 
     public Simple() {
         super();

--- a/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/Overloads.it.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/Overloads.it.txt
@@ -26,7 +26,7 @@ public final class State {
     private final int someInt = 0;
     private final long someLong = 0L;
     @org.jetbrains.annotations.NotNull()
-    private final java.lang.String someString = null;
+    private final java.lang.String someString;
 
     @kotlin.jvm.JvmOverloads()
     public State(int someInt, long someLong) {

--- a/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/Simple.it.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/Simple.it.txt
@@ -65,7 +65,7 @@ import java.lang.System;
 public enum EnumClass2 {
     /*public static final*/ WHITE /* = new WHITE(null) */,
     /*public static final*/ RED /* = new RED(null) */;
-    private final java.lang.String blah = null;
+    private final java.lang.String blah;
 
     EnumClass2(java.lang.String blah) {
     }

--- a/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/Simple.it_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/Simple.it_ir.txt
@@ -66,7 +66,7 @@ public enum EnumClass2 {
     /*public static final*/ WHITE /* = new WHITE(null) */,
     /*public static final*/ RED /* = new RED(null) */;
     @org.jetbrains.annotations.NotNull()
-    private final java.lang.String blah = null;
+    private final java.lang.String blah;
 
     EnumClass2(java.lang.String blah) {
     }

--- a/plugins/kapt3/kapt3-compiler/tests-gen/org/jetbrains/kotlin/kapt3/test/runners/ClassFileToSourceStubConverterTestGenerated.java
+++ b/plugins/kapt3/kapt3-compiler/tests-gen/org/jetbrains/kotlin/kapt3/test/runners/ClassFileToSourceStubConverterTestGenerated.java
@@ -524,6 +524,12 @@ public class ClassFileToSourceStubConverterTestGenerated extends AbstractClassFi
     }
 
     @Test
+    @TestMetadata("primitivePropertyInitializers.kt")
+    public void testPrimitivePropertyInitializers() throws Exception {
+        runTest("plugins/kapt3/kapt3-compiler/testData/converter/primitivePropertyInitializers.kt");
+    }
+
+    @Test
     @TestMetadata("primitiveTypes.kt")
     public void testPrimitiveTypes() throws Exception {
         runTest("plugins/kapt3/kapt3-compiler/testData/converter/primitiveTypes.kt");

--- a/plugins/kapt3/kapt3-compiler/tests-gen/org/jetbrains/kotlin/kapt3/test/runners/IrClassFileToSourceStubConverterTestGenerated.java
+++ b/plugins/kapt3/kapt3-compiler/tests-gen/org/jetbrains/kotlin/kapt3/test/runners/IrClassFileToSourceStubConverterTestGenerated.java
@@ -524,6 +524,12 @@ public class IrClassFileToSourceStubConverterTestGenerated extends AbstractIrCla
     }
 
     @Test
+    @TestMetadata("primitivePropertyInitializers.kt")
+    public void testPrimitivePropertyInitializers() throws Exception {
+        runTest("plugins/kapt3/kapt3-compiler/testData/converter/primitivePropertyInitializers.kt");
+    }
+
+    @Test
     @TestMetadata("primitiveTypes.kt")
     public void testPrimitiveTypes() throws Exception {
         runTest("plugins/kapt3/kapt3-compiler/testData/converter/primitiveTypes.kt");


### PR DESCRIPTION
The values might be read as compile time constants when they are in fact not.

This fixes [KT-52410](https://youtrack.jetbrains.com/issue/KT-52410).