### PR TITLE
JVM: Check for multiple {POP, Unit} sequences in suspend function TCO

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/coroutines/TailCallOptimization.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/coroutines/TailCallOptimization.kt
@@ -87,7 +87,7 @@ private val AbstractInsnNode.nextMeaningful: AbstractInsnNode?
     get() = next.skipUntilMeaningful()
 
 private val AbstractInsnNode.isReturnUnit: Boolean
-    get() = isUnitInstance() && nextMeaningful?.opcode == Opcodes.ARETURN
+    get() = isUnitInstance() && nextMeaningful?.let { it.opcode == Opcodes.ARETURN || it.isPopBeforeReturnUnit } == true
 
 private val AbstractInsnNode.isPopBeforeReturnUnit: Boolean
     get() = opcode == Opcodes.POP && nextMeaningful?.isReturnUnit == true

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -13021,6 +13021,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
             }
 
             @Test
+            @TestMetadata("lambdaParameterInlining.kt")
+            public void testLambdaParameterInlining() throws Exception {
+                runTest("compiler/testData/codegen/box/coroutines/tailCallOptimizations/lambdaParameterInlining.kt");
+            }
+
+            @Test
             @TestMetadata("returnInlineClass.kt")
             public void testReturnInlineClass() throws Exception {
                 runTest("compiler/testData/codegen/box/coroutines/tailCallOptimizations/returnInlineClass.kt");

--- a/compiler/testData/codegen/box/coroutines/tailCallOptimizations/lambdaParameterInlining.kt
+++ b/compiler/testData/codegen/box/coroutines/tailCallOptimizations/lambdaParameterInlining.kt
@@ -1,0 +1,72 @@
+// TARGET_BACKEND: JVM
+// FULL_JDK
+// WITH_STDLIB
+// WITH_COROUTINES
+// CHECK_TAIL_CALL_OPTIMIZATION
+
+import helpers.*
+import kotlin.coroutines.*
+import kotlin.coroutines.intrinsics.*
+
+fun assert(value: () -> Boolean) {}
+
+class ChannelSegment<E>(val id: Long)
+
+suspend fun suspendHere() = suspendCoroutineUninterceptedOrReturn<Unit> { x ->
+    TailCallOptimizationChecker.saveStackTrace(x)
+    COROUTINE_SUSPENDED
+}
+
+private const val RESULT_SUSPEND_NO_WAITER = 3
+
+open class BufferedChannel<E> {
+    private val sendSegment = ChannelSegment<E>(0)
+
+    suspend fun send(element: E): Unit =
+        sendImpl(
+            onClosed = {},
+            onNoWaiterSuspend = { sendOnNoWaiterSuspend() }
+        )
+
+    private suspend fun sendOnNoWaiterSuspend() {
+        suspendHere()
+    }
+
+    private fun findSegmentSend(): ChannelSegment<E>? = null
+
+    private fun updateCellSend(): Int = RESULT_SUSPEND_NO_WAITER
+
+    private inline fun <R> sendImpl(
+        onClosed: () -> R,
+        onNoWaiterSuspend: () -> R = { error("unexpected") }
+    ): R {
+        var segment = sendSegment
+        while (true) {
+            val closed = false
+            val id = 0L
+            if (segment.id != id) {
+                assert { segment.id < id }
+                // Find the required segment.
+                segment = null ?:
+                        if (closed) return onClosed() else continue
+            }
+            when(updateCellSend()) {
+                RESULT_SUSPEND_NO_WAITER -> {
+                    return onNoWaiterSuspend()
+                }
+            }
+        }
+    }
+}
+
+fun builder(c: suspend () -> Unit) {
+    c.startCoroutine(EmptyContinuation)
+}
+
+fun box(): String {
+    builder {
+        BufferedChannel<Int>().send(0)
+    }
+    TailCallOptimizationChecker.checkNoStateMachineIn("send")
+    return "OK"
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -12853,6 +12853,12 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             }
 
             @Test
+            @TestMetadata("lambdaParameterInlining.kt")
+            public void testLambdaParameterInlining() throws Exception {
+                runTest("compiler/testData/codegen/box/coroutines/tailCallOptimizations/lambdaParameterInlining.kt");
+            }
+
+            @Test
             @TestMetadata("returnInlineClass.kt")
             public void testReturnInlineClass() throws Exception {
                 runTest("compiler/testData/codegen/box/coroutines/tailCallOptimizations/returnInlineClass.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -13021,6 +13021,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             }
 
             @Test
+            @TestMetadata("lambdaParameterInlining.kt")
+            public void testLambdaParameterInlining() throws Exception {
+                runTest("compiler/testData/codegen/box/coroutines/tailCallOptimizations/lambdaParameterInlining.kt");
+            }
+
+            @Test
             @TestMetadata("returnInlineClass.kt")
             public void testReturnInlineClass() throws Exception {
                 runTest("compiler/testData/codegen/box/coroutines/tailCallOptimizations/returnInlineClass.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -10366,6 +10366,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
                 runTest("compiler/testData/codegen/box/coroutines/tailCallOptimizations/interfaceDelegation.kt");
             }
 
+            @TestMetadata("lambdaParameterInlining.kt")
+            public void testLambdaParameterInlining() throws Exception {
+                runTest("compiler/testData/codegen/box/coroutines/tailCallOptimizations/lambdaParameterInlining.kt");
+            }
+
             @TestMetadata("returnInlineClass.kt")
             public void testReturnInlineClass() throws Exception {
                 runTest("compiler/testData/codegen/box/coroutines/tailCallOptimizations/returnInlineClass.kt");


### PR DESCRIPTION
We already check for {POP, Unit} sequence before ARETURN, but if the there are multiple sequence before ARETURN, the compiler assumes, that TCO misses.

The fix is to check, that the instruction after the sequence is either ARETURN or another {POP, Unit} sequence.

 #KT-50835