### PR TITLE
KAPT: allow setting aptMode in the maven plugin

### DIFF
--- a/libraries/tools/kotlin-maven-plugin/src/main/java/org/jetbrains/kotlin/maven/kapt/KaptJVMCompilerMojo.java
+++ b/libraries/tools/kotlin-maven-plugin/src/main/java/org/jetbrains/kotlin/maven/kapt/KaptJVMCompilerMojo.java
@@ -50,6 +50,9 @@ public class KaptJVMCompilerMojo extends K2JVMCompileMojo {
     private List<DependencyCoordinate> annotationProcessorPaths;
 
     @Parameter
+    private String aptMode = "stubsAndApt";
+
+    @Parameter
     private boolean useLightAnalysis = true;
 
     @Parameter
@@ -94,7 +97,7 @@ public class KaptJVMCompilerMojo extends K2JVMCompileMojo {
     ) {
         List<KaptOption> options = new ArrayList<>();
 
-        options.add(new KaptOption("aptMode", "stubsAndApt"));
+        options.add(new KaptOption("aptMode", aptMode));
         options.add(new KaptOption("useLightAnalysis", useLightAnalysis));
         options.add(new KaptOption("correctErrorTypes", correctErrorTypes));
         options.add(new KaptOption("mapDiagnosticLocations", mapDiagnosticLocations));


### PR DESCRIPTION
This fixes [KT-41129](https://youtrack.jetbrains.com/issue/KT-41129/kotlin-maven-plugin-kapt-allow-aptMode-to-be-set-according-to-docs).