### PR TITLE
KAPT: Kapt generates illegal stubs for private interface methods

### DIFF
--- a/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/ClassFileToSourceStubConverter.kt
+++ b/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/ClassFileToSourceStubConverter.kt
@@ -915,7 +915,7 @@ class ClassFileToSourceStubConverter(val kaptContext: KaptContextForStubGenerati
             ElementKind.METHOD, packageFqName, visibleAnnotations, method.invisibleAnnotations, descriptor.annotations
         )
 
-        if (containingClass.isInterface() && !method.isAbstract() && !method.isStatic()) {
+        if (containingClass.isInterface() && !method.isAbstract() && !method.isStatic() && (method.access and Opcodes.ACC_PRIVATE == 0)) {
             modifiers.flags = modifiers.flags or Flags.DEFAULT
         }
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/jvmDefaultAll.kt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/jvmDefaultAll.kt
@@ -1,4 +1,5 @@
 // !JVM_DEFAULT_MODE: all
+// EXPECTED_ERROR: (kotlin:15:5) modifier private not allowed here
 
 interface Foo {
     fun foo() {
@@ -10,4 +11,8 @@ interface Foo {
     }
 
     fun bar()
+
+    private fun privateMethodWithDefault() {
+        System.out.println("privateMethodWithDefault")
+    }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/jvmDefaultAll.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/jvmDefaultAll.txt
@@ -10,4 +10,7 @@ public abstract interface Foo {
     }
 
     public abstract void bar();
+
+    private void privateMethodWithDefault() {
+    }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/jvmDefaultAllCompatibility.kt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/jvmDefaultAllCompatibility.kt
@@ -1,4 +1,5 @@
 // !JVM_DEFAULT_MODE: all-compatibility
+// EXPECTED_ERROR: (kotlin:15:5) modifier private not allowed here
 
 interface Foo {
     fun foo() {
@@ -10,4 +11,8 @@ interface Foo {
     }
 
     fun bar()
+
+    private fun privateMethodWithDefault() {
+        System.out.println("privateMethodWithDefault")
+    }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/jvmDefaultAllCompatibility.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/jvmDefaultAllCompatibility.txt
@@ -11,6 +11,9 @@ public abstract interface Foo {
 
     public abstract void bar();
 
+    private void privateMethodWithDefault() {
+    }
+
     @kotlin.Metadata()
     public static final class DefaultImpls {
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/jvmDefaultDisable.kt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/jvmDefaultDisable.kt
@@ -1,4 +1,5 @@
 // !JVM_DEFAULT_MODE: disable
+// EXPECTED_ERROR: (kotlin:20:5) modifier private not allowed here
 
 interface Foo {
     fun foo() {
@@ -11,4 +12,13 @@ interface Foo {
     }
 
     fun bar()
+
+    private fun privateMethodWithDefault() {
+        System.out.println("privateMethodWithDefault")
+    }
+
+    @JvmDefault
+    private fun privateMethodWithDefault2() {
+        System.out.println("privateMethodWithDefault2")
+    }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/jvmDefaultDisable.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/jvmDefaultDisable.txt
@@ -11,6 +11,10 @@ public abstract interface Foo {
 
     public abstract void bar();
 
+    @kotlin.jvm.JvmDefault()
+    private void privateMethodWithDefault2() {
+    }
+
     @kotlin.Metadata()
     public static final class DefaultImpls {
 
@@ -20,6 +24,9 @@ public abstract interface Foo {
 
         public static void foo(@org.jetbrains.annotations.NotNull()
         Foo $this) {
+        }
+
+        private static void privateMethodWithDefault(Foo $this) {
         }
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/jvmDefaultEnable.kt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/jvmDefaultEnable.kt
@@ -1,4 +1,5 @@
 // !JVM_DEFAULT_MODE: enable
+// EXPECTED_ERROR: (kotlin:20:5) modifier private not allowed here
 
 interface Foo {
     fun foo() {
@@ -11,4 +12,13 @@ interface Foo {
     }
 
     fun bar()
+
+    private fun privateMethodWithDefault() {
+        System.out.println("privateMethodWithDefault")
+    }
+
+    @JvmDefault
+    private fun privateMethodWithDefault2() {
+        System.out.println("privateMethodWithDefault2")
+    }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/jvmDefaultEnable.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/jvmDefaultEnable.txt
@@ -11,6 +11,10 @@ public abstract interface Foo {
 
     public abstract void bar();
 
+    @kotlin.jvm.JvmDefault()
+    private void privateMethodWithDefault2() {
+    }
+
     @kotlin.Metadata()
     public static final class DefaultImpls {
 
@@ -20,6 +24,9 @@ public abstract interface Foo {
 
         public static void foo(@org.jetbrains.annotations.NotNull()
         Foo $this) {
+        }
+
+        private static void privateMethodWithDefault(Foo $this) {
         }
     }
 }


### PR DESCRIPTION
Interface methods that were private got both the `default` and `private` modifiers when using `jvm-default=all` which is not valid.

The stub will now just contain `private` in this case.

This fixes [KT-48013](https://youtrack.jetbrains.com/issue/KT-48013/Kapt-generates-illegal-stubs-for-private-interface-methods).