### PR TITLE
FIR: ignore redundant DEFINITELY_NOT_NULL_TYPE flags in deserialization

### DIFF
--- a/compiler/fir/fir-deserialization/src/org/jetbrains/kotlin/fir/deserialization/FirTypeDeserializer.kt
+++ b/compiler/fir/fir-deserialization/src/org/jetbrains/kotlin/fir/deserialization/FirTypeDeserializer.kt
@@ -149,7 +149,7 @@ class FirTypeDeserializer(
         if (constructor is ConeTypeParameterLookupTag) {
             return ConeTypeParameterTypeImpl(constructor, isNullable = proto.nullable).let {
                 if (Flags.DEFINITELY_NOT_NULL_TYPE.get(proto.flags))
-                    ConeDefinitelyNotNullType.create(it, moduleData.session.typeContext)
+                    ConeDefinitelyNotNullType.create(it, moduleData.session.typeContext) ?: it
                 else
                     it
             }


### PR DESCRIPTION
I.e. if T is already bounded by Any, deserialize T&Any as simply T (instead of producing either an error type or an NPE, the latter happening when the T&Any is the lower bound of a flexible type somehow)

Once again this is a problem of the kind where some weird combination of FE1.0 and FIR causes a weird edge case error on invalid input and creating a test with that specific setup is not really feasible.