### PR TITLE
KAPT: Skip importing java.lang.System in the stubs

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kapt3IT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kapt3IT.kt
@@ -586,12 +586,7 @@ open class Kapt3IT : Kapt3BaseIT() {
 
             buildAndFail("build") {
                 val actual = getErrorMessages()
-                // try as 0 starting lines first, then as 1 starting line
-                try {
-                    assertEquals(expected = genJavaErrorString(8, 20), actual = actual)
-                } catch (e: AssertionError) {
-                    assertEquals(expected = genJavaErrorString(9, 21), actual = actual)
-                }
+                assertEquals(expected = genJavaErrorString(7, 19), actual = actual)
             }
 
             buildGradle.modify {
@@ -600,12 +595,7 @@ open class Kapt3IT : Kapt3BaseIT() {
 
             buildAndFail("build") {
                 val actual = getErrorMessages()
-                // try as 0 starting lines first, then as 1 starting line
-                try {
-                    assertEquals(expected = genKotlinErrorString(3, 6), actual = actual)
-                } catch (e: AssertionError) {
-                    assertEquals(expected = genKotlinErrorString(4, 7), actual = actual)
-                }
+                assertEquals(expected = genKotlinErrorString(4, 7), actual = actual)
             }
         }
     }

--- a/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/ClassFileToSourceStubConverter.kt
+++ b/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/ClassFileToSourceStubConverter.kt
@@ -206,14 +206,9 @@ class ClassFileToSourceStubConverter(val kaptContext: KaptContextForStubGenerati
 
         val imports = if (correctErrorTypes) convertImports(ktFile, classDeclaration) else JavacList.nil()
 
-        val nonEmptyImports: JavacList<JCTree> = when {
-            imports.size > 0 -> imports
-            else -> JavacList.of(treeMaker.Import(treeMaker.FqName("java.lang.System"), false))
-        }
-
         val classes = JavacList.of<JCTree>(classDeclaration)
 
-        val topLevel = treeMaker.TopLevelJava9Aware(packageClause, nonEmptyImports + classes)
+        val topLevel = treeMaker.TopLevelJava9Aware(packageClause, imports + classes)
         if (kdocCommentKeeper != null) {
             topLevel.docComments = kdocCommentKeeper.getDocTable(topLevel)
         }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/abstractEnum.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/abstractEnum.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public enum E {
     /*public static final*/ X /* = new E() */,
@@ -35,8 +33,6 @@ public enum E {
 ////////////////////
 
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public enum E2 {
     /*public static final*/ X /* = new E2() */,
@@ -53,8 +49,6 @@ public enum E2 {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public enum E3 {
@@ -74,8 +68,6 @@ public enum E3 {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public enum E4 {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/abstractMethods.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/abstractMethods.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract class Base {
 
@@ -16,8 +14,6 @@ public abstract class Base {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Impl extends Base {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/annotations.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/annotations.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
 public abstract @interface Anno1 {
@@ -7,8 +5,6 @@ public abstract @interface Anno1 {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
@@ -36,8 +32,6 @@ public abstract @interface Anno2 {
 ////////////////////
 
 
-import java.lang.System;
-
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
 public abstract @interface Anno3 {
@@ -47,8 +41,6 @@ public abstract @interface Anno3 {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public enum Colors {
@@ -61,8 +53,6 @@ public enum Colors {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public enum Enum1 {
@@ -77,8 +67,6 @@ public enum Enum1 {
 ////////////////////
 
 
-import java.lang.System;
-
 @Anno1()
 @Anno2(a = @Anno1(), clazz = TestAnno.class, classes = {TestAnno.class, Anno1.class})
 @Anno3(value = "value")
@@ -92,8 +80,6 @@ public final class TestAnno {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @Anno3(value = "value")
 @Anno2(i = 6, s = "BCD", ii = {4, 5, 6}, ss = {"Z", "X"}, a = @Anno1(), color = Colors.WHITE, colors = {Colors.WHITE}, clazz = TestAnno.class, classes = {TestAnno.class, Anno1.class})

--- a/plugins/kapt3/kapt3-compiler/testData/converter/annotations2.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/annotations2.txt
@@ -1,7 +1,5 @@
 package test;
 
-import java.lang.System;
-
 @Anno(value = "anno-class")
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
@@ -13,8 +11,6 @@ public abstract @interface Anno {
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 @kotlin.jvm.JvmName(name = "AnnotationsTest")
@@ -46,8 +42,6 @@ public final class AnnotationsTest {
 
 package test;
 
-import java.lang.System;
-
 @Anno(value = "enum")
 @kotlin.Metadata()
 public enum Enum {
@@ -70,8 +64,6 @@ public enum Enum {
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @Anno(value = "clazz")
 @kotlin.Metadata()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/annotations2_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/annotations2_ir.txt
@@ -1,7 +1,5 @@
 package test;
 
-import java.lang.System;
-
 @Anno(value = "anno-class")
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
@@ -13,8 +11,6 @@ public abstract @interface Anno {
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 @kotlin.jvm.JvmName(name = "AnnotationsTest")
@@ -46,8 +42,6 @@ public final class AnnotationsTest {
 
 package test;
 
-import java.lang.System;
-
 @Anno(value = "enum")
 @kotlin.Metadata()
 public enum Enum {
@@ -70,8 +64,6 @@ public enum Enum {
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @Anno(value = "clazz")
 @kotlin.Metadata()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/annotations3.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/annotations3.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class B {
 
@@ -10,8 +8,6 @@ public final class B {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class BParceler implements Parceler<B> {
@@ -26,8 +22,6 @@ public final class BParceler implements Parceler<B> {
 ////////////////////
 
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class C {
 
@@ -38,8 +32,6 @@ public final class C {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class CParceler implements Parceler<C> {
@@ -54,16 +46,12 @@ public final class CParceler implements Parceler<C> {
 ////////////////////
 
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract interface Parceler<T extends java.lang.Object> {
 }
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 @TypeParceler()
@@ -77,8 +65,6 @@ public final class Test {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.annotation.Retention(value = kotlin.annotation.AnnotationRetention.SOURCE)
 @kotlin.annotation.Repeatable()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/annotations3_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/annotations3_ir.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class B {
 
@@ -10,8 +8,6 @@ public final class B {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class BParceler implements Parceler<B> {
@@ -26,8 +22,6 @@ public final class BParceler implements Parceler<B> {
 ////////////////////
 
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class C {
 
@@ -38,8 +32,6 @@ public final class C {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class CParceler implements Parceler<C> {
@@ -54,16 +46,12 @@ public final class CParceler implements Parceler<C> {
 ////////////////////
 
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract interface Parceler<T extends java.lang.Object> {
 }
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 @TypeParceler()
@@ -77,8 +65,6 @@ public final class Test {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.annotation.Retention(value = kotlin.annotation.AnnotationRetention.SOURCE)
 @kotlin.annotation.Repeatable()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/annotationsWithConstants.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/annotationsWithConstants.txt
@@ -1,7 +1,5 @@
 package app;
 
-import java.lang.System;
-
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
 public abstract @interface Anno {
@@ -57,8 +55,6 @@ public class B {
 
 package app;
 
-import java.lang.System;
-
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
 public abstract @interface Bind {
@@ -69,8 +65,6 @@ public abstract @interface Bind {
 ////////////////////
 
 package app;
-
-import java.lang.System;
 
 @kotlin.annotation.Target(allowedTargets = {kotlin.annotation.AnnotationTarget.FIELD})
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
@@ -84,8 +78,6 @@ public abstract @interface BindField {
 ////////////////////
 
 package app;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class JJ {
@@ -113,8 +105,6 @@ public final class JJ {
 
 package app;
 
-import java.lang.System;
-
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
 public abstract @interface MultiValue {
@@ -125,8 +115,6 @@ public abstract @interface MultiValue {
 ////////////////////
 
 package app;
-
-import java.lang.System;
 
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
@@ -139,8 +127,6 @@ public abstract @interface MultiValueByte {
 
 package app;
 
-import java.lang.System;
-
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
 public abstract @interface MultiValueString {
@@ -151,8 +137,6 @@ public abstract @interface MultiValueString {
 ////////////////////
 
 package app;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class MyActivity {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/annotationsWithConstants_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/annotationsWithConstants_ir.txt
@@ -1,7 +1,5 @@
 package app;
 
-import java.lang.System;
-
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
 public abstract @interface Anno {
@@ -57,8 +55,6 @@ public class B {
 
 package app;
 
-import java.lang.System;
-
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
 public abstract @interface Bind {
@@ -69,8 +65,6 @@ public abstract @interface Bind {
 ////////////////////
 
 package app;
-
-import java.lang.System;
 
 @kotlin.annotation.Target(allowedTargets = {kotlin.annotation.AnnotationTarget.FIELD})
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
@@ -84,8 +78,6 @@ public abstract @interface BindField {
 ////////////////////
 
 package app;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class JJ {
@@ -113,8 +105,6 @@ public final class JJ {
 
 package app;
 
-import java.lang.System;
-
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
 public abstract @interface MultiValue {
@@ -125,8 +115,6 @@ public abstract @interface MultiValue {
 ////////////////////
 
 package app;
-
-import java.lang.System;
 
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
@@ -139,8 +127,6 @@ public abstract @interface MultiValueByte {
 
 package app;
 
-import java.lang.System;
-
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
 public abstract @interface MultiValueString {
@@ -151,8 +137,6 @@ public abstract @interface MultiValueString {
 ////////////////////
 
 package app;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class MyActivity {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/annotationsWithTargets.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/annotationsWithTargets.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
 public abstract @interface Anno {
@@ -7,8 +5,6 @@ public abstract @interface Anno {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Bar {
@@ -35,8 +31,6 @@ public final class Bar {
 ////////////////////
 
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Baz {
     @FieldAnno()
@@ -57,8 +51,6 @@ public final class Baz {
 ////////////////////
 
 
-import java.lang.System;
-
 @kotlin.annotation.Target(allowedTargets = {kotlin.annotation.AnnotationTarget.FIELD})
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @java.lang.annotation.Target(value = {java.lang.annotation.ElementType.FIELD})
@@ -68,8 +60,6 @@ public abstract @interface FieldAnno {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Foo {
@@ -98,8 +88,6 @@ public final class Foo {
 ////////////////////
 
 
-import java.lang.System;
-
 @kotlin.annotation.Target(allowedTargets = {kotlin.annotation.AnnotationTarget.VALUE_PARAMETER})
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @java.lang.annotation.Target(value = {java.lang.annotation.ElementType.PARAMETER})
@@ -109,8 +97,6 @@ public abstract @interface ParameterAnno {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.annotation.Target(allowedTargets = {kotlin.annotation.AnnotationTarget.PROPERTY})
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)

--- a/plugins/kapt3/kapt3-compiler/testData/converter/annotations_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/annotations_ir.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 public abstract @interface Anno1 {
@@ -7,8 +5,6 @@ public abstract @interface Anno1 {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
@@ -36,8 +32,6 @@ public abstract @interface Anno2 {
 ////////////////////
 
 
-import java.lang.System;
-
 @kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 public abstract @interface Anno3 {
@@ -47,8 +41,6 @@ public abstract @interface Anno3 {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public enum Colors {
@@ -61,8 +53,6 @@ public enum Colors {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public enum Enum1 {
@@ -77,8 +67,6 @@ public enum Enum1 {
 ////////////////////
 
 
-import java.lang.System;
-
 @kotlin.Metadata()
 @Anno3(value = "value")
 @Anno2(a = @Anno1(), clazz = TestAnno.class, classes = {TestAnno.class, Anno1.class})
@@ -92,8 +80,6 @@ public final class TestAnno {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 @Anno2(i = 6, s = "BCD", ii = {4, 5, 6}, ss = {"Z", "X"}, a = @Anno1(), color = Colors.WHITE, colors = {Colors.WHITE}, clazz = TestAnno.class, classes = {TestAnno.class, Anno1.class})

--- a/plugins/kapt3/kapt3-compiler/testData/converter/anonymousInitializer.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/anonymousInitializer.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class C {
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/comments.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/comments.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.annotation.Target(allowedTargets = {kotlin.annotation.AnnotationTarget.PROPERTY})
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @java.lang.annotation.Target(value = {})
@@ -9,8 +7,6 @@ public abstract @interface Anno {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public enum EnumError {
@@ -27,8 +23,6 @@ public enum EnumError {
 ////////////////////
 
 
-import java.lang.System;
-
 /**
  * Obj.
  */
@@ -44,8 +38,6 @@ public final class Obj {
 
 ////////////////////
 
-
-import java.lang.System;
 
 /**
  * Test.
@@ -120,8 +112,6 @@ public final class Test {
 ////////////////////
 
 
-import java.lang.System;
-
 /**
  * Test2
  * Multiline
@@ -146,8 +136,6 @@ public final class Test2 {
 ////////////////////
 
 
-import java.lang.System;
-
 /**
  * constructor.
  */
@@ -170,8 +158,6 @@ public final class Test3 {
 ////////////////////
 
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Test4 {
 
@@ -185,8 +171,6 @@ public final class Test4 {
 
 ////////////////////
 
-
-import java.lang.System;
 
 /**
  * `/ * Failure * /`

--- a/plugins/kapt3/kapt3-compiler/testData/converter/commentsRemoved.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/commentsRemoved.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.annotation.Target(allowedTargets = {kotlin.annotation.AnnotationTarget.PROPERTY})
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @java.lang.annotation.Target(value = {})
@@ -9,8 +7,6 @@ public abstract @interface Anno {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public enum EnumError {
@@ -27,8 +23,6 @@ public enum EnumError {
 ////////////////////
 
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Obj {
     @org.jetbrains.annotations.NotNull()
@@ -41,8 +35,6 @@ public final class Obj {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Test {
@@ -88,8 +80,6 @@ public final class Test {
 ////////////////////
 
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Test2 {
     @org.jetbrains.annotations.NotNull()
@@ -108,8 +98,6 @@ public final class Test2 {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Test3 {
@@ -130,8 +118,6 @@ public final class Test3 {
 ////////////////////
 
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Test4 {
 
@@ -145,8 +131,6 @@ public final class Test4 {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public abstract interface TestComponent {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/commentsRemoved_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/commentsRemoved_ir.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.annotation.Target(allowedTargets = {kotlin.annotation.AnnotationTarget.PROPERTY})
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @java.lang.annotation.Target(value = {})
@@ -9,8 +7,6 @@ public abstract @interface Anno {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public enum EnumError {
@@ -27,8 +23,6 @@ public enum EnumError {
 ////////////////////
 
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Obj {
     @org.jetbrains.annotations.NotNull()
@@ -41,8 +35,6 @@ public final class Obj {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Test {
@@ -88,8 +80,6 @@ public final class Test {
 ////////////////////
 
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Test2 {
     @org.jetbrains.annotations.NotNull()
@@ -108,8 +98,6 @@ public final class Test2 {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Test3 {
@@ -130,8 +118,6 @@ public final class Test3 {
 ////////////////////
 
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Test4 {
 
@@ -145,8 +131,6 @@ public final class Test4 {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public abstract interface TestComponent {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/comments_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/comments_ir.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 @java.lang.annotation.Target(value = {})
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
@@ -9,8 +7,6 @@ public abstract @interface Anno {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public enum EnumError {
@@ -27,8 +23,6 @@ public enum EnumError {
 ////////////////////
 
 
-import java.lang.System;
-
 /**
  * Obj.
  */
@@ -44,8 +38,6 @@ public final class Obj {
 
 ////////////////////
 
-
-import java.lang.System;
 
 /**
  * Test.
@@ -120,8 +112,6 @@ public final class Test {
 ////////////////////
 
 
-import java.lang.System;
-
 /**
  * Test2
  * Multiline
@@ -146,8 +136,6 @@ public final class Test2 {
 ////////////////////
 
 
-import java.lang.System;
-
 /**
  * constructor.
  */
@@ -170,8 +158,6 @@ public final class Test3 {
 ////////////////////
 
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Test4 {
 
@@ -185,8 +171,6 @@ public final class Test4 {
 
 ////////////////////
 
-
-import java.lang.System;
 
 /**
  * `/ * Failure * /`

--- a/plugins/kapt3/kapt3-compiler/testData/converter/cyrillicClassName.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/cyrillicClassName.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class République {
 
@@ -10,8 +8,6 @@ public final class République {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Привет {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/dataClass.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/dataClass.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class User {
     @org.jetbrains.annotations.NotNull()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/dataClass_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/dataClass_ir.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class User {
     @org.jetbrains.annotations.NotNull()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/defaultImpls.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/defaultImpls.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract interface Intf {
     @org.jetbrains.annotations.NotNull()
@@ -39,8 +37,6 @@ public abstract interface Intf {
 ////////////////////
 
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract interface IntfWithDefaultImpls {
 
@@ -61,8 +57,6 @@ public abstract interface IntfWithDefaultImpls {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public abstract interface IntfWithoutDefaultImpls {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/defaultImpls_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/defaultImpls_ir.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract interface Intf {
     public static final int WHITE = 2;
@@ -39,8 +37,6 @@ public abstract interface Intf {
 ////////////////////
 
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract interface IntfWithDefaultImpls {
 
@@ -61,8 +57,6 @@ public abstract interface IntfWithDefaultImpls {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public abstract interface IntfWithoutDefaultImpls {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/defaultPackage.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/defaultPackage.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class AnotherRootClass {
 
@@ -10,8 +8,6 @@ public final class AnotherRootClass {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class RootClass {
@@ -41,8 +37,6 @@ public @interface ClassRefAnnotation {
 
 package test;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract interface PackedClass {
 
@@ -59,8 +53,6 @@ public abstract interface PackedClass {
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @ClassRefAnnotation(value = {RootClass.class})
 @kotlin.Metadata()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/defaultPackageCorrectErrorTypes.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/defaultPackageCorrectErrorTypes.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class AnotherRootClass {
 
@@ -10,8 +8,6 @@ public final class AnotherRootClass {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class RootClass {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/defaultParameterValueOff.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/defaultParameterValueOff.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public enum Em {
     /*public static final*/ FOO /* = new Em() */,
@@ -11,8 +9,6 @@ public enum Em {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Foo {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/defaultParameterValueOff_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/defaultParameterValueOff_ir.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public enum Em {
     /*public static final*/ FOO /* = new Em() */,
@@ -11,8 +9,6 @@ public enum Em {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Foo {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/defaultParameterValueOn.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/defaultParameterValueOn.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public enum Em {
     /*public static final*/ FOO /* = new Em() */,
@@ -11,8 +9,6 @@ public enum Em {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Foo {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/defaultParameterValueOn_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/defaultParameterValueOn_ir.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public enum Em {
     /*public static final*/ FOO /* = new Em() */,
@@ -11,8 +9,6 @@ public enum Em {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Foo {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/delegateCorrectErrorTypes.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/delegateCorrectErrorTypes.txt
@@ -1,7 +1,5 @@
 package test;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Bar {
     private final test.Delegate unknown$delegate = null;
@@ -19,8 +17,6 @@ public final class Bar {
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Delegate {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/delegatedProperties.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/delegatedProperties.txt
@@ -1,7 +1,5 @@
 package test;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class A {
     @org.jetbrains.annotations.NotNull()
@@ -53,8 +51,6 @@ public final class A {
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public class C<T extends java.lang.Object> {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/delegatedProperties_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/delegatedProperties_ir.txt
@@ -1,7 +1,5 @@
 package test;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class A {
     @org.jetbrains.annotations.NotNull()
@@ -53,8 +51,6 @@ public final class A {
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public class C<T extends java.lang.Object> {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/deprecated.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/deprecated.txt
@@ -1,7 +1,5 @@
 package deprecated;
 
-import java.lang.System;
-
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
 @java.lang.Deprecated()
@@ -11,8 +9,6 @@ public abstract @interface Anno {
 ////////////////////
 
 package deprecated;
-
-import java.lang.System;
 
 @Anno()
 @kotlin.Metadata()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/deprecated_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/deprecated_ir.txt
@@ -1,7 +1,5 @@
 package deprecated;
 
-import java.lang.System;
-
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
 @java.lang.Deprecated()
@@ -11,8 +9,6 @@ public abstract @interface Anno {
 ////////////////////
 
 package deprecated;
-
-import java.lang.System;
 
 @Anno()
 @kotlin.Metadata()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/enumInCompanion.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/enumInCompanion.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Test {
     private final Test.Companion.Example foo;
@@ -29,8 +27,6 @@ public final class Test {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Test2 {
@@ -62,8 +58,6 @@ public final class Test2 {
 ////////////////////
 
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Test3 {
     private final Test3.Amigo.Example foo = Test3.Amigo.Example.FOO;
@@ -93,8 +87,6 @@ public final class Test3 {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Test4 {
@@ -128,8 +120,6 @@ public final class Test4 {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Test5 {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/enumInCompanion_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/enumInCompanion_ir.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Test {
     @org.jetbrains.annotations.NotNull()
@@ -30,8 +28,6 @@ public final class Test {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Test2 {
@@ -64,8 +60,6 @@ public final class Test2 {
 ////////////////////
 
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Test3 {
     @org.jetbrains.annotations.NotNull()
@@ -96,8 +90,6 @@ public final class Test3 {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Test4 {
@@ -131,8 +123,6 @@ public final class Test4 {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Test5 {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/enums.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/enums.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
 public abstract @interface Anno1 {
@@ -9,8 +7,6 @@ public abstract @interface Anno1 {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public enum Enum1 {
@@ -23,8 +19,6 @@ public enum Enum1 {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public enum Enum2 {
@@ -63,8 +57,6 @@ public enum Enum2 {
 ////////////////////
 
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract interface I {
 
@@ -79,8 +71,6 @@ public abstract interface I {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public enum Nested1 {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/errorExtensionReceiver.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/errorExtensionReceiver.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 @kotlin.Suppress(names = {"UNRESOLVED_REFERENCE"})
 public final class TypeHook {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/errorSuperclass.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/errorSuperclass.txt
@@ -1,7 +1,5 @@
 package test;
 
-import java.lang.System;
-
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
 public abstract @interface Anno {
@@ -10,8 +8,6 @@ public abstract @interface Anno {
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @Anno()
 @kotlin.Metadata()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/errorSuperclassCorrectErrorTypes.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/errorSuperclassCorrectErrorTypes.txt
@@ -1,7 +1,5 @@
 package test;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Child extends kotlin.collections.AbstractList<java.lang.String> implements test.Parent<java.lang.String, java.lang.Integer>, java.util.List<java.lang.String> {
 
@@ -44,8 +42,6 @@ public final class Child extends kotlin.collections.AbstractList<java.lang.Strin
 
 package test;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public class Cl {
 
@@ -57,8 +53,6 @@ public class Cl {
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Generics1 extends Foo<java.lang.String> {
@@ -72,8 +66,6 @@ public final class Generics1 extends Foo<java.lang.String> {
 
 package test;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Generics2 implements Foo<java.lang.String> {
 
@@ -85,8 +77,6 @@ public final class Generics2 implements Foo<java.lang.String> {
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Generics3 implements Foo<Bar, Baz, Boo<Baz, java.util.List<?>>, java.lang.String> {
@@ -100,8 +90,6 @@ public final class Generics3 implements Foo<Bar, Baz, Boo<Baz, java.util.List<?>
 
 package test;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract interface Intf {
 }
@@ -109,8 +97,6 @@ public abstract interface Intf {
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class MappedList<R extends java.lang.Object> extends kotlin.collections.AbstractList<R> implements java.util.List<R> {
@@ -135,8 +121,6 @@ public final class MappedList<R extends java.lang.Object> extends kotlin.collect
 
 package test;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract interface Parent<A extends java.lang.CharSequence, B extends java.lang.Object> {
 }
@@ -144,8 +128,6 @@ public abstract interface Parent<A extends java.lang.CharSequence, B extends jav
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class TBarBazCl extends test.Cl implements Bar, Baz {
@@ -159,8 +141,6 @@ public final class TBarBazCl extends test.Cl implements Bar, Baz {
 
 package test;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class TClBarBaz extends test.Cl implements Bar, Baz {
 
@@ -172,8 +152,6 @@ public final class TClBarBaz extends test.Cl implements Bar, Baz {
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class TFooBar extends Foo implements test.Intf, Bar {
@@ -195,8 +173,6 @@ public final class TFooBar extends Foo implements test.Intf, Bar {
 
 package test;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class TFooBar2 implements Foo, Bar {
     @org.jetbrains.annotations.NotNull()
@@ -217,8 +193,6 @@ public final class TFooBar2 implements Foo, Bar {
 
 package test;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class TFooBarBaz extends Foo implements Bar, Baz {
 
@@ -230,8 +204,6 @@ public final class TFooBarBaz extends Foo implements Bar, Baz {
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class TFooBarBaz2 implements test.Intf {
@@ -245,8 +217,6 @@ public final class TFooBarBaz2 implements test.Intf {
 
 package test;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class TFooBarBaz3 implements Foo, Bar, Baz {
 
@@ -259,8 +229,6 @@ public final class TFooBarBaz3 implements Foo, Bar, Baz {
 
 package test;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class TFooBarBaz4 implements Foo, Bar, Baz {
 
@@ -272,8 +240,6 @@ public final class TFooBarBaz4 implements Foo, Bar, Baz {
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class TFooBarBaz5 implements Foo, Bar, Baz {
@@ -292,8 +258,6 @@ public final class TFooBarBaz5 implements Foo, Bar, Baz {
 
 package test;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class TFooBarBaz6 extends Foo implements Bar, Baz {
 
@@ -307,8 +271,6 @@ public final class TFooBarBaz6 extends Foo implements Bar, Baz {
 
 package test;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class TxFooxBarxBaz extends x.Foo implements test.Intf, x.Bar, x.Baz {
 
@@ -320,8 +282,6 @@ public final class TxFooxBarxBaz extends x.Foo implements test.Intf, x.Bar, x.Ba
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class TxFooxBarxBaz2 {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/errorSuperclass_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/errorSuperclass_ir.txt
@@ -1,7 +1,5 @@
 package test;
 
-import java.lang.System;
-
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
 public abstract @interface Anno {
@@ -10,8 +8,6 @@ public abstract @interface Anno {
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @Anno()
 @kotlin.Metadata()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/fileFacadeJvmName.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/fileFacadeJvmName.txt
@@ -1,7 +1,5 @@
 package a.b.c;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 @kotlin.jvm.JvmName(name = "FacadeName")
 public final class FacadeName {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/functions.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/functions.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class FunctionsTest {
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/genericParameters.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/genericParameters.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class MappedList<T extends java.lang.Object, R extends java.lang.Object> extends kotlin.collections.AbstractList<R> implements java.util.List<R> {
     @org.jetbrains.annotations.NotNull()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/genericParameters_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/genericParameters_ir.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class MappedList<T extends java.lang.Object, R extends java.lang.Object> extends kotlin.collections.AbstractList<R> implements java.util.List<R> {
     @org.jetbrains.annotations.NotNull()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/genericRawSignatures.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/genericRawSignatures.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class GenericRawSignatures {
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/genericSimple.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/genericSimple.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract interface ABC {
 
@@ -16,8 +14,6 @@ public abstract interface ABC {
 ////////////////////
 
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public class BaseClass<B extends java.lang.Object> {
 
@@ -29,8 +25,6 @@ public class BaseClass<B extends java.lang.Object> {
 ////////////////////
 
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract interface Intf<I1 extends java.lang.Object, I2 extends java.io.Serializable> {
 }
@@ -38,16 +32,12 @@ public abstract interface Intf<I1 extends java.lang.Object, I2 extends java.io.S
 ////////////////////
 
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract interface Intf2<T extends java.util.List<? extends java.lang.String>, M extends T> {
 }
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class MyClass<M1 extends java.lang.Object, M2 extends java.lang.Object> extends BaseClass<java.lang.RuntimeException> implements Intf<java.lang.Object, java.util.Date>, OtherIntf<java.lang.String> {
@@ -66,8 +56,6 @@ public final class MyClass<M1 extends java.lang.Object, M2 extends java.lang.Obj
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public abstract interface OtherIntf<O extends java.lang.CharSequence> {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/ignoredMembers.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/ignoredMembers.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Test {
     @org.jetbrains.annotations.NotNull()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/implicitReturnTypes.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/implicitReturnTypes.txt
@@ -15,8 +15,6 @@ public abstract class Prop<T> {
 
 package test;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Cl {
     @org.jetbrains.annotations.NotNull()
@@ -40,8 +38,6 @@ public final class Cl {
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class TestKt {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/incorrectDelegate.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/incorrectDelegate.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class GroupedNewsListDelegateAdapter {
 
@@ -11,8 +9,6 @@ public final class GroupedNewsListDelegateAdapter {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class HomeFragment {
@@ -39,8 +35,6 @@ public final class HomeFragment {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class IncorrectDelegateKt {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/incorrectDelegate_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/incorrectDelegate_ir.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class GroupedNewsListDelegateAdapter {
 
@@ -11,8 +9,6 @@ public final class GroupedNewsListDelegateAdapter {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class HomeFragment {
@@ -41,8 +37,6 @@ public final class HomeFragment {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class IncorrectDelegateKt {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/inheritanceSimple.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/inheritanceSimple.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract class BaseClass {
 
@@ -15,16 +13,12 @@ public abstract class BaseClass {
 ////////////////////
 
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract interface Context {
 }
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Inheritor extends BaseClass {
@@ -43,8 +37,6 @@ public final class Inheritor extends BaseClass {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public enum Result {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/inlineClasses.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/inlineClasses.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.jvm.JvmInline()
 @kotlin.Metadata()
 public final class Cl {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/inlineClasses_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/inlineClasses_ir.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.jvm.JvmInline()
 @kotlin.Metadata()
 public final class Cl {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/innerClassesWithTypeParameters.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/innerClassesWithTypeParameters.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Test {
     private Test.FilterValueDelegate<java.lang.Float> a;
@@ -19,8 +17,6 @@ public final class Test {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Test2 {
@@ -49,8 +45,6 @@ public final class Test2 {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Test3 {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/innerClassesWithTypeParameters_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/innerClassesWithTypeParameters_ir.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Test {
     @org.jetbrains.annotations.NotNull()
@@ -20,8 +18,6 @@ public final class Test {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Test2 {
@@ -51,8 +47,6 @@ public final class Test2 {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Test3 {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/interfaceImplementation.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/interfaceImplementation.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract interface Named {
 
@@ -9,8 +7,6 @@ public abstract interface Named {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Product2 implements Named {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/invalidFieldName.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/invalidFieldName.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @Anno(color = Color.InvalidFieldName)
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
@@ -10,8 +8,6 @@ public abstract @interface Anno {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public enum Color {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/javaKeywordsInPackageNames.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/javaKeywordsInPackageNames.txt
@@ -1,7 +1,5 @@
 package a.b.c;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class A {
 
@@ -13,8 +11,6 @@ public final class A {
 ////////////////////
 
 package a.b.typealias.c;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class E {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/javadoc.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/javadoc.txt
@@ -1,7 +1,5 @@
 package javadoc;
 
-import java.lang.System;
-
 /**
  * Simple
  */
@@ -16,8 +14,6 @@ public final class A {
 ////////////////////
 
 package javadoc;
-
-import java.lang.System;
 
 /**
  * Multi

--- a/plugins/kapt3/kapt3-compiler/testData/converter/jvmDefaultAll.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/jvmDefaultAll.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract interface Foo {
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/jvmDefaultAllCompatibility.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/jvmDefaultAllCompatibility.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract interface Foo {
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/jvmDefaultDisable.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/jvmDefaultDisable.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract interface Foo {
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/jvmDefaultEnable.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/jvmDefaultEnable.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract interface Foo {
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/jvmOverloads.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/jvmOverloads.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class State {
     private final int someInt = 0;
@@ -34,8 +32,6 @@ public final class State {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class State2 {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/jvmOverloads_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/jvmOverloads_ir.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class State {
     private final int someInt = 0;
@@ -34,8 +32,6 @@ public final class State {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class State2 {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/jvmRepeatableAnnotation.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/jvmRepeatableAnnotation.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @Condition(condition = "value1")
 @Condition(condition = "value2")
 @kotlin.Metadata()
@@ -12,8 +10,6 @@ public final class A {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/jvmStatic.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/jvmStatic.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract interface FooComponent {
     @org.jetbrains.annotations.NotNull()
@@ -30,8 +28,6 @@ public abstract interface FooComponent {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class JvmStaticTest {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/jvmStaticFieldInParent.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/jvmStaticFieldInParent.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Test {
     @org.jetbrains.annotations.NotNull()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/jvmStaticFieldInParent_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/jvmStaticFieldInParent_ir.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Test {
     @org.jetbrains.annotations.NotNull()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/jvmStatic_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/jvmStatic_ir.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract interface FooComponent {
     @org.jetbrains.annotations.NotNull()
@@ -30,8 +28,6 @@ public abstract interface FooComponent {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class JvmStaticTest {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt14996.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt14996.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Kt14996Kt {
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt14997.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt14997.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public class CrashMe {
     private final java.lang.Runnable notReally = null;
@@ -11,8 +9,6 @@ public class CrashMe {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 @kotlin.Suppress(names = {"AMBIGUOUS_ANONYMOUS_TYPE_INFERRED"})

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt14997_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt14997_ir.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public class CrashMe {
     @org.jetbrains.annotations.NotNull()
@@ -12,8 +10,6 @@ public class CrashMe {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 @kotlin.Suppress(names = {"AMBIGUOUS_ANONYMOUS_TYPE_INFERRED"})

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt14998.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt14998.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Outer {
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt15145.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt15145.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract interface MyInterface {
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt17567.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt17567.txt
@@ -1,7 +1,5 @@
 package test;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class MutableEntry<K extends java.lang.Object, V extends java.lang.Object> implements java.util.Map.Entry<K, V>, kotlin.jvm.internal.markers.KMutableMap.Entry {
     private final java.util.Map<K, V> internal = null;

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt17567_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt17567_ir.txt
@@ -1,7 +1,5 @@
 package test;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class MutableEntry<K extends java.lang.Object, V extends java.lang.Object> implements java.util.Map.Entry<K, V>, kotlin.jvm.internal.markers.KMutableMap.Entry {
     @org.jetbrains.annotations.NotNull()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt18377.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt18377.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Kt18377Kt {
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt18682.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt18682.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract class Foo {
 
@@ -10,8 +8,6 @@ public abstract class Foo {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Kt18682Kt {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt19700.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt19700.txt
@@ -1,7 +1,5 @@
 package test;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract interface ListUpdateCallback {
 
@@ -11,8 +9,6 @@ public abstract interface ListUpdateCallback {
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Test<T extends java.lang.CharSequence, N extends java.lang.Number> {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt19700_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt19700_ir.txt
@@ -1,7 +1,5 @@
 package test;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract interface ListUpdateCallback {
 
@@ -11,8 +9,6 @@ public abstract interface ListUpdateCallback {
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Test<T extends java.lang.CharSequence, N extends java.lang.Number> {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt19750.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt19750.txt
@@ -1,7 +1,5 @@
 package test;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Test<T extends java.lang.CharSequence, N extends java.lang.Number> {
     private final test.TypedListUpdateCallback<java.lang.String, java.lang.Long> x = null;
@@ -14,8 +12,6 @@ public final class Test<T extends java.lang.CharSequence, N extends java.lang.Nu
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public abstract interface TypedListUpdateCallback<T extends java.lang.Object, C extends java.lang.Number> {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt19750_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt19750_ir.txt
@@ -1,7 +1,5 @@
 package test;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Test<T extends java.lang.CharSequence, N extends java.lang.Number> {
     @org.jetbrains.annotations.NotNull()
@@ -15,8 +13,6 @@ public final class Test<T extends java.lang.CharSequence, N extends java.lang.Nu
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public abstract interface TypedListUpdateCallback<T extends java.lang.Object, C extends java.lang.Number> {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt24272.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt24272.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Foo {
     private final java.lang.String string = null;

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt24272_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt24272_ir.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Foo {
     @org.jetbrains.annotations.NotNull()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt25071.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt25071.txt
@@ -1,7 +1,5 @@
 package kapt;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class StaticImport {
     private final java.util.Collection<java.lang.String> x = null;
@@ -57,8 +55,6 @@ public class StaticMethod<T> {
 ////////////////////
 
 package my.lib;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class LibKt {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt27126.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt27126.txt
@@ -1,7 +1,5 @@
 package test;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract class BundleProperty<AA extends java.lang.Object> extends test.NullableBundleProperty<AA> {
 
@@ -40,8 +38,6 @@ public abstract class BundleProperty<AA extends java.lang.Object> extends test.N
 
 package test;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 @kotlin.Suppress(names = {"NOTHING_TO_INLINE"})
 public final class Kt27126Kt {
@@ -60,8 +56,6 @@ public final class Kt27126Kt {
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public abstract class NullableBundleProperty<EE extends java.lang.Object> implements kotlin.properties.ReadWriteProperty<java.lang.Object, EE> {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt27126_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt27126_ir.txt
@@ -1,7 +1,5 @@
 package test;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract class BundleProperty<AA extends java.lang.Object> extends test.NullableBundleProperty<AA> {
 
@@ -40,8 +38,6 @@ public abstract class BundleProperty<AA extends java.lang.Object> extends test.N
 
 package test;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 @kotlin.Suppress(names = {"NOTHING_TO_INLINE"})
 public final class Kt27126Kt {
@@ -60,8 +56,6 @@ public final class Kt27126Kt {
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public abstract class NullableBundleProperty<EE extends java.lang.Object> implements kotlin.properties.ReadWriteProperty<java.lang.Object, EE> {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt28306.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt28306.txt
@@ -1,7 +1,5 @@
 package foo;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract interface InterfaceWithDefaults<T extends java.lang.Object> {
 
@@ -23,8 +21,6 @@ public abstract interface InterfaceWithDefaults<T extends java.lang.Object> {
 ////////////////////
 
 package foo;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public abstract interface SubInterface<T extends java.lang.Object> extends foo.InterfaceWithDefaults<T> {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt28306_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt28306_ir.txt
@@ -1,7 +1,5 @@
 package foo;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract interface InterfaceWithDefaults<T extends java.lang.Object> {
 
@@ -23,8 +21,6 @@ public abstract interface InterfaceWithDefaults<T extends java.lang.Object> {
 ////////////////////
 
 package foo;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public abstract interface SubInterface<T extends java.lang.Object> extends foo.InterfaceWithDefaults<T> {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt34569.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt34569.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class T implements java.lang.Runnable {
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/lazyProperty.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/lazyProperty.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Foo {
     private final kotlin.Lazy foo$delegate = null;
@@ -31,16 +29,12 @@ public final class Foo {
 ////////////////////
 
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract interface GenericIntf<T extends java.lang.Object> {
 }
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public abstract interface Intf {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/lazyProperty_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/lazyProperty_ir.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Foo {
     @org.jetbrains.annotations.NotNull()
@@ -35,16 +33,12 @@ public final class Foo {
 ////////////////////
 
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract interface GenericIntf<T extends java.lang.Object> {
 }
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public abstract interface Intf {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/leadingDollars.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/leadingDollars.txt
@@ -33,8 +33,6 @@ public class Test$ {
 
 package test;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class TestKt {
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/mapEntry.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/mapEntry.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract interface EntryHolder {
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/methodParameterNames.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/methodParameterNames.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract class Cls {
 
@@ -18,8 +16,6 @@ public abstract class Cls {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public abstract interface Intf {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/methodPropertySignatureClash.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/methodPropertySignatureClash.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class CrashMe {
     private final int resources = 1;

--- a/plugins/kapt3/kapt3-compiler/testData/converter/modifiers.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/modifiers.txt
@@ -1,7 +1,5 @@
 package modifiers;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class InternalClass {
 
@@ -14,8 +12,6 @@ public final class InternalClass {
 
 package modifiers;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract interface InternalInterface {
 }
@@ -23,8 +19,6 @@ public abstract interface InternalInterface {
 ////////////////////
 
 package modifiers;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Modifiers {
@@ -82,8 +76,6 @@ public final class Modifiers {
 
 package modifiers;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 final class PrivateClass {
 
@@ -96,8 +88,6 @@ final class PrivateClass {
 
 package modifiers;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 abstract interface PrivateInterface {
 }
@@ -105,8 +95,6 @@ abstract interface PrivateInterface {
 ////////////////////
 
 package modifiers;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class PublicClass {
@@ -120,8 +108,6 @@ public final class PublicClass {
 
 package modifiers;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract class PublicClassPrivateConstructor {
 
@@ -133,8 +119,6 @@ public abstract class PublicClassPrivateConstructor {
 ////////////////////
 
 package modifiers;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public class PublicClassProtectedConstructor {
@@ -156,8 +140,6 @@ public class PublicClassProtectedConstructor {
 
 package modifiers;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract interface PublicInterface {
 }
@@ -165,8 +147,6 @@ public abstract interface PublicInterface {
 ////////////////////
 
 package modifiers;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public abstract class SealedClass {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/modifiers_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/modifiers_ir.txt
@@ -1,7 +1,5 @@
 package modifiers;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class InternalClass {
 
@@ -14,8 +12,6 @@ public final class InternalClass {
 
 package modifiers;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract interface InternalInterface {
 }
@@ -23,8 +19,6 @@ public abstract interface InternalInterface {
 ////////////////////
 
 package modifiers;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Modifiers {
@@ -82,8 +76,6 @@ public final class Modifiers {
 
 package modifiers;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 final class PrivateClass {
 
@@ -96,8 +88,6 @@ final class PrivateClass {
 
 package modifiers;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 abstract interface PrivateInterface {
 }
@@ -105,8 +95,6 @@ abstract interface PrivateInterface {
 ////////////////////
 
 package modifiers;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class PublicClass {
@@ -120,8 +108,6 @@ public final class PublicClass {
 
 package modifiers;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract class PublicClassPrivateConstructor {
 
@@ -133,8 +119,6 @@ public abstract class PublicClassPrivateConstructor {
 ////////////////////
 
 package modifiers;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public class PublicClassProtectedConstructor {
@@ -156,8 +140,6 @@ public class PublicClassProtectedConstructor {
 
 package modifiers;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract interface PublicInterface {
 }
@@ -165,8 +147,6 @@ public abstract interface PublicInterface {
 ////////////////////
 
 package modifiers;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public abstract class SealedClass {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/multifileClass.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/multifileClass.txt
@@ -1,7 +1,5 @@
 package test;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class M1 {
 
@@ -19,8 +17,6 @@ public final class M1 {
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class M2 {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/nestedClasses.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/nestedClasses.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class A {
     @org.jetbrains.annotations.Nullable()
@@ -49,8 +47,6 @@ public final class A {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class A2 {
@@ -103,8 +99,6 @@ public final class A2 {
 ////////////////////
 
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Foo {
 
@@ -115,8 +109,6 @@ public final class Foo {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Test {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/nestedClasses2.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/nestedClasses2.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class A$B {
     @kotlin.jvm.JvmField()
@@ -83,8 +81,6 @@ public final class A$B {
 ////////////////////
 
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Experiment {
 
@@ -150,8 +146,6 @@ public final class Experiment {
 ////////////////////
 
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Foo {
 
@@ -180,8 +174,6 @@ public final class Foo {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public abstract interface IFoo {
@@ -281,8 +273,6 @@ public class JavaClass {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @IFoo.IBar.Anno(value = {IFoo.IBar.IZoo.class, Foo.Bar.class})
 @kotlin.Metadata()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/nestedClasses2_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/nestedClasses2_ir.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class A$B {
     @kotlin.jvm.JvmField()
@@ -83,8 +81,6 @@ public final class A$B {
 ////////////////////
 
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Experiment {
 
@@ -150,8 +146,6 @@ public final class Experiment {
 ////////////////////
 
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Foo {
 
@@ -180,8 +174,6 @@ public final class Foo {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public abstract interface IFoo {
@@ -281,8 +273,6 @@ public class JavaClass {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @IFoo.IBar.Anno(value = {IFoo.IBar.IZoo.class, Foo.Bar.class})
 @kotlin.Metadata()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/nestedClassesNonRootPackage.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/nestedClassesNonRootPackage.txt
@@ -1,7 +1,5 @@
 package test;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class A$B {
     @kotlin.jvm.JvmField()
@@ -86,8 +84,6 @@ public final class A$B {
 
 package test;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Experiment {
 
@@ -150,8 +146,6 @@ public final class Experiment {
 
 package test;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Foo {
 
@@ -181,8 +175,6 @@ public final class Foo {
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public abstract interface IFoo {
@@ -285,8 +277,6 @@ class JavaClass {
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @test.IFoo.IBar.Anno(value = {test.IFoo.IBar.IZoo.class, test.Foo.Bar.class})
 @kotlin.Metadata()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/nestedClassesNonRootPackage_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/nestedClassesNonRootPackage_ir.txt
@@ -1,7 +1,5 @@
 package test;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class A$B {
     @kotlin.jvm.JvmField()
@@ -86,8 +84,6 @@ public final class A$B {
 
 package test;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Experiment {
 
@@ -150,8 +146,6 @@ public final class Experiment {
 
 package test;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Foo {
 
@@ -181,8 +175,6 @@ public final class Foo {
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public abstract interface IFoo {
@@ -285,8 +277,6 @@ class JavaClass {
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @test.IFoo.IBar.Anno(value = {test.IFoo.IBar.IZoo.class, test.Foo.Bar.class})
 @kotlin.Metadata()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/nonExistentClass.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/nonExistentClass.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 @kotlin.Suppress(names = {"UNRESOLVED_REFERENCE"})
 public final class NonExistentType {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/nonExistentClassWIthoutCorrection.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/nonExistentClassWIthoutCorrection.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 @kotlin.Suppress(names = {"UNRESOLVED_REFERENCE"})
 public final class NonExistentClassWIthoutCorrectionKt {
@@ -7,8 +5,6 @@ public final class NonExistentClassWIthoutCorrectionKt {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class NonExistentType {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/nonExistentClassWIthoutCorrection_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/nonExistentClassWIthoutCorrection_ir.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 @kotlin.Suppress(names = {"UNRESOLVED_REFERENCE"})
 public final class NonExistentClassWIthoutCorrectionKt {
@@ -7,8 +5,6 @@ public final class NonExistentClassWIthoutCorrectionKt {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class NonExistentType {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/nonExistentClass_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/nonExistentClass_ir.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 @kotlin.Suppress(names = {"UNRESOLVED_REFERENCE"})
 public final class NonExistentType {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/primitiveTypes.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/primitiveTypes.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class PrimitiveTypes {
     @org.jetbrains.annotations.NotNull()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/primitiveTypes_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/primitiveTypes_ir.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class PrimitiveTypes {
     public static final boolean booleanFalse = false;

--- a/plugins/kapt3/kapt3-compiler/testData/converter/properties.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/properties.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Test {
     @org.jetbrains.annotations.NotNull()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/propertyAnnotations.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/propertyAnnotations.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
 public abstract @interface Anno {
@@ -7,8 +5,6 @@ public abstract @interface Anno {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.annotation.Target(allowedTargets = {kotlin.annotation.AnnotationTarget.PROPERTY, kotlin.annotation.AnnotationTarget.CLASS})
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
@@ -19,8 +15,6 @@ public abstract @interface Anno2 {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Test {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/recentlyNullable.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/recentlyNullable.txt
@@ -21,8 +21,6 @@ import java.lang.annotation.*;
 
 package app;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class KBox implements androidx.annotation.Box {
     @org.jetbrains.annotations.NotNull()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/repeatableAnnotations.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/repeatableAnnotations.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
 public abstract @interface AnnoArray {
@@ -11,8 +9,6 @@ public abstract @interface AnnoArray {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
@@ -26,8 +22,6 @@ public abstract @interface AnnoBoolean {
 ////////////////////
 
 
-import java.lang.System;
-
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
 public abstract @interface AnnoChar {
@@ -39,8 +33,6 @@ public abstract @interface AnnoChar {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
@@ -54,8 +46,6 @@ public abstract @interface AnnoClass {
 ////////////////////
 
 
-import java.lang.System;
-
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
 public abstract @interface AnnoDouble {
@@ -67,8 +57,6 @@ public abstract @interface AnnoDouble {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
@@ -82,8 +70,6 @@ public abstract @interface AnnoEnum {
 ////////////////////
 
 
-import java.lang.System;
-
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
 public abstract @interface AnnoFloat {
@@ -95,8 +81,6 @@ public abstract @interface AnnoFloat {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
@@ -110,8 +94,6 @@ public abstract @interface AnnoInt {
 ////////////////////
 
 
-import java.lang.System;
-
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
 public abstract @interface AnnoIntArray {
@@ -123,8 +105,6 @@ public abstract @interface AnnoIntArray {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
@@ -138,8 +118,6 @@ public abstract @interface AnnoLong {
 ////////////////////
 
 
-import java.lang.System;
-
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
 public abstract @interface AnnoLongArray {
@@ -151,8 +129,6 @@ public abstract @interface AnnoLongArray {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
@@ -166,8 +142,6 @@ public abstract @interface AnnoString {
 ////////////////////
 
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public enum Color {
     /*public static final*/ BLACK /* = new Color() */;
@@ -178,8 +152,6 @@ public enum Color {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Test {
@@ -205,8 +177,6 @@ public final class Test {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @AnnoChar(x = lib.R.id.textView, chr = 'c')
 @AnnoBoolean(x = lib.R.id.textView, bool = false)

--- a/plugins/kapt3/kapt3-compiler/testData/converter/secondaryConstructor.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/secondaryConstructor.txt
@@ -1,7 +1,5 @@
 package secondary;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public abstract interface Named {
 
@@ -12,8 +10,6 @@ public abstract interface Named {
 ////////////////////
 
 package secondary;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Product2 implements secondary.Named {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/severalPackageParts.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/severalPackageParts.txt
@@ -1,7 +1,5 @@
 package test;
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class AKt {
 
@@ -16,8 +14,6 @@ public final class AKt {
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class BKt {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/strangeIdentifiers.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/strangeIdentifiers.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
 public abstract @interface Anno {
@@ -11,8 +9,6 @@ public abstract @interface Anno {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public enum StrangeEnum {
@@ -31,8 +27,6 @@ public enum StrangeEnum {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Test {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/strangeIdentifiers_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/strangeIdentifiers_ir.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
 public abstract @interface Anno {
@@ -11,8 +9,6 @@ public abstract @interface Anno {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public enum StrangeEnum {
@@ -31,8 +27,6 @@ public enum StrangeEnum {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Test {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/stripMetadata.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/stripMetadata.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 public abstract class BaseClass {
 
     public BaseClass(@org.jetbrains.annotations.NotNull()
@@ -14,15 +12,11 @@ public abstract class BaseClass {
 ////////////////////
 
 
-import java.lang.System;
-
 public abstract interface Context {
 }
 
 ////////////////////
 
-
-import java.lang.System;
 
 public final class Inheritor extends BaseClass {
 
@@ -40,8 +34,6 @@ public final class Inheritor extends BaseClass {
 
 ////////////////////
 
-
-import java.lang.System;
 
 public enum Result {
     /*public static final*/ SUCCESS /* = new Result() */,

--- a/plugins/kapt3/kapt3-compiler/testData/converter/suspendArgName.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/suspendArgName.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public class Test {
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/suspendArgName_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/suspendArgName_ir.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public class Test {
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/suspendErrorTypes.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/suspendErrorTypes.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Foo {
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/topLevel.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/topLevel.txt
@@ -1,7 +1,5 @@
 package test.another;
 
-import java.lang.System;
-
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
 public abstract @interface Anno {
@@ -12,8 +10,6 @@ public abstract @interface Anno {
 ////////////////////
 
 package test.another;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class TopLevelKt {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/topLevel_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/topLevel_ir.txt
@@ -1,7 +1,5 @@
 package test.another;
 
-import java.lang.System;
-
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
 public abstract @interface Anno {
@@ -12,8 +10,6 @@ public abstract @interface Anno {
 ////////////////////
 
 package test.another;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class TopLevelKt {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/unsafePropertyInitializers.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/unsafePropertyInitializers.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Boo {
     @org.jetbrains.annotations.NotNull()
@@ -24,8 +22,6 @@ public final class Boo {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Foo {
@@ -122,8 +118,6 @@ public final class Foo {
 ////////////////////
 
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class HavingState {
     @org.jetbrains.annotations.NotNull()
@@ -219,8 +213,6 @@ public final class HavingState {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public enum State {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/unsafePropertyInitializers_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/unsafePropertyInitializers_ir.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class Boo {
     @org.jetbrains.annotations.NotNull()
@@ -24,8 +22,6 @@ public final class Boo {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Foo {
@@ -122,8 +118,6 @@ public final class Foo {
 ////////////////////
 
 
-import java.lang.System;
-
 @kotlin.Metadata()
 public final class HavingState {
     @org.jetbrains.annotations.NotNull()
@@ -219,8 +213,6 @@ public final class HavingState {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public enum State {

--- a/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/DefaultParameterValues.it.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/DefaultParameterValues.it.txt
@@ -7,8 +7,6 @@ public final class NonExistentClass {
 
 package test;
 
-import java.lang.System;
-
 @Anno()
 @kotlin.Metadata()
 public final class User {
@@ -33,8 +31,6 @@ public final class User {
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()

--- a/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/DefaultParameterValues.it_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/DefaultParameterValues.it_ir.txt
@@ -7,8 +7,6 @@ public final class NonExistentClass {
 
 package test;
 
-import java.lang.System;
-
 @Anno()
 @kotlin.Metadata()
 public final class User {
@@ -33,8 +31,6 @@ public final class User {
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()

--- a/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/ErrorLocationMapping.it.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/ErrorLocationMapping.it.txt
@@ -1,5 +1,3 @@
-import java.lang.System;
-
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
 public abstract @interface MyAnnotation {
@@ -7,8 +5,6 @@ public abstract @interface MyAnnotation {
 
 ////////////////////
 
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Subject {

--- a/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/NestedClasses.it.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/NestedClasses.it.txt
@@ -7,8 +7,6 @@ public final class NonExistentClass {
 
 package test;
 
-import java.lang.System;
-
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
 public abstract @interface MyAnnotation {
@@ -17,8 +15,6 @@ public abstract @interface MyAnnotation {
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Simple {

--- a/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/NestedClasses.it_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/NestedClasses.it_ir.txt
@@ -7,8 +7,6 @@ public final class NonExistentClass {
 
 package test;
 
-import java.lang.System;
-
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
 public abstract @interface MyAnnotation {
@@ -17,8 +15,6 @@ public abstract @interface MyAnnotation {
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public final class Simple {

--- a/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/Overloads.it.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/Overloads.it.txt
@@ -7,8 +7,6 @@ public final class NonExistentClass {
 
 package test;
 
-import java.lang.System;
-
 @MyAnnotation()
 @kotlin.Metadata()
 public final class State {
@@ -45,8 +43,6 @@ public final class State {
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()

--- a/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/Overloads.it_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/Overloads.it_ir.txt
@@ -7,8 +7,6 @@ public final class NonExistentClass {
 
 package test;
 
-import java.lang.System;
-
 @MyAnnotation()
 @kotlin.Metadata()
 public final class State {
@@ -45,8 +43,6 @@ public final class State {
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()

--- a/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/Simple.it.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/Simple.it.txt
@@ -7,8 +7,6 @@ public final class NonExistentClass {
 
 package test;
 
-import java.lang.System;
-
 /**
  * KDoc comment.
  */
@@ -33,8 +31,6 @@ public final class Simple {
 
 package test;
 
-import java.lang.System;
-
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
 public abstract @interface MyAnnotation {
@@ -43,8 +39,6 @@ public abstract @interface MyAnnotation {
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public enum EnumClass {
@@ -58,8 +52,6 @@ public enum EnumClass {
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public enum EnumClass2 {

--- a/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/Simple.it_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/Simple.it_ir.txt
@@ -7,8 +7,6 @@ public final class NonExistentClass {
 
 package test;
 
-import java.lang.System;
-
 /**
  * KDoc comment.
  */
@@ -33,8 +31,6 @@ public final class Simple {
 
 package test;
 
-import java.lang.System;
-
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.Metadata()
 public abstract @interface MyAnnotation {
@@ -43,8 +39,6 @@ public abstract @interface MyAnnotation {
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public enum EnumClass {
@@ -58,8 +52,6 @@ public enum EnumClass {
 ////////////////////
 
 package test;
-
-import java.lang.System;
 
 @kotlin.Metadata()
 public enum EnumClass2 {


### PR DESCRIPTION
This fixes [KT-43117](https://youtrack.jetbrains.com/issue/KT-43117/Kapt-System-is-already-defined-in-this-compilation-unit)