### PR TITLE
[KT-51478] Prevent multiple context receiver candidates from allowing to call inapplicable extension functions

### DIFF
--- a/analysis/low-level-api-fir/tests/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/compiler/based/DiagnosisCompilerTestFE10TestdataTestGenerated.java
+++ b/analysis/low-level-api-fir/tests/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/compiler/based/DiagnosisCompilerTestFE10TestdataTestGenerated.java
@@ -11080,6 +11080,12 @@ public class DiagnosisCompilerTestFE10TestdataTestGenerated extends AbstractDiag
                 }
 
                 @Test
+                @TestMetadata("twoReceiverCandidatesError.kt")
+                public void testTwoReceiverCandidatesError() throws Exception {
+                    runTest("compiler/testData/diagnostics/tests/extensions/contextReceivers/twoReceiverCandidatesError.kt");
+                }
+
+                @Test
                 @TestMetadata("typeParameterAsContextReceiver.kt")
                 public void testTypeParameterAsContextReceiver() throws Exception {
                     runTest("compiler/testData/diagnostics/tests/extensions/contextReceivers/typeParameterAsContextReceiver.kt");

--- a/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsTestGenerated.java
@@ -11080,6 +11080,12 @@ public class FirOldFrontendDiagnosticsTestGenerated extends AbstractFirDiagnosti
                 }
 
                 @Test
+                @TestMetadata("twoReceiverCandidatesError.kt")
+                public void testTwoReceiverCandidatesError() throws Exception {
+                    runTest("compiler/testData/diagnostics/tests/extensions/contextReceivers/twoReceiverCandidatesError.kt");
+                }
+
+                @Test
                 @TestMetadata("typeParameterAsContextReceiver.kt")
                 public void testTypeParameterAsContextReceiver() throws Exception {
                     runTest("compiler/testData/diagnostics/tests/extensions/contextReceivers/typeParameterAsContextReceiver.kt");

--- a/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsWithLightTreeTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsWithLightTreeTestGenerated.java
@@ -11080,6 +11080,12 @@ public class FirOldFrontendDiagnosticsWithLightTreeTestGenerated extends Abstrac
                 }
 
                 @Test
+                @TestMetadata("twoReceiverCandidatesError.kt")
+                public void testTwoReceiverCandidatesError() throws Exception {
+                    runTest("compiler/testData/diagnostics/tests/extensions/contextReceivers/twoReceiverCandidatesError.kt");
+                }
+
+                @Test
                 @TestMetadata("typeParameterAsContextReceiver.kt")
                 public void testTypeParameterAsContextReceiver() throws Exception {
                     runTest("compiler/testData/diagnostics/tests/extensions/contextReceivers/typeParameterAsContextReceiver.kt");

--- a/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/ResolutionParts.kt
+++ b/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/components/ResolutionParts.kt
@@ -704,7 +704,10 @@ internal object CheckReceivers : ResolutionPart() {
         val extensionReceiverParameter = candidateDescriptor.extensionReceiverParameter ?: return null
         val compatible = receiverCandidates.mapNotNull { getReceiverArgumentWithConstraintIfCompatible(it, extensionReceiverParameter) }
         return when (compatible.size) {
-            0 -> null
+            0 -> {
+                addDiagnostic(NoMatchingContextReceiver())
+                null
+            }
             1 -> compatible.single().argument
             else -> {
                 addDiagnostic(ContextReceiverAmbiguity())

--- a/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tower/ImplicitScopeTower.kt
+++ b/compiler/resolution/src/org/jetbrains/kotlin/resolve/calls/tower/ImplicitScopeTower.kt
@@ -114,6 +114,12 @@ abstract class ResolutionDiagnostic(candidateApplicability: CandidateApplicabili
     }
 }
 
+class NoMatchingContextReceiver : ResolutionDiagnostic(INAPPLICABLE_WRONG_RECEIVER) {
+    override fun report(reporter: DiagnosticReporter) {
+        reporter.onCall(this)
+    }
+}
+
 class ContextReceiverAmbiguity : ResolutionDiagnostic(RESOLVED_WITH_ERROR) {
     override fun report(reporter: DiagnosticReporter) {
         reporter.onCall(this)

--- a/compiler/testData/diagnostics/tests/extensions/contextReceivers/twoReceiverCandidatesError.kt
+++ b/compiler/testData/diagnostics/tests/extensions/contextReceivers/twoReceiverCandidatesError.kt
@@ -1,0 +1,17 @@
+// !LANGUAGE: +ContextReceivers
+// FIR_IDENTICAL
+
+fun String.foo() {}
+
+context(Int, Double)
+fun bar() {
+    <!UNRESOLVED_REFERENCE_WRONG_RECEIVER!>foo<!>() // should be prohibited
+}
+
+fun main() {
+    with(1) {
+        with(2.0) {
+            bar()
+        }
+    }
+}

--- a/compiler/testData/diagnostics/tests/extensions/contextReceivers/twoReceiverCandidatesError.txt
+++ b/compiler/testData/diagnostics/tests/extensions/contextReceivers/twoReceiverCandidatesError.txt
@@ -1,0 +1,5 @@
+package
+
+context(kotlin.Int, kotlin.Double) public fun bar(): kotlin.Unit
+public fun main(): kotlin.Unit
+public fun kotlin.String.foo(): kotlin.Unit

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/DiagnosticTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/DiagnosticTestGenerated.java
@@ -11086,6 +11086,12 @@ public class DiagnosticTestGenerated extends AbstractDiagnosticTest {
                 }
 
                 @Test
+                @TestMetadata("twoReceiverCandidatesError.kt")
+                public void testTwoReceiverCandidatesError() throws Exception {
+                    runTest("compiler/testData/diagnostics/tests/extensions/contextReceivers/twoReceiverCandidatesError.kt");
+                }
+
+                @Test
                 @TestMetadata("typeParameterAsContextReceiver.kt")
                 public void testTypeParameterAsContextReceiver() throws Exception {
                     runTest("compiler/testData/diagnostics/tests/extensions/contextReceivers/typeParameterAsContextReceiver.kt");


### PR DESCRIPTION
The issue was that, when various context elements were available to fulfill a need for an extension receiver, but none of them were applicable to it, the compiler behaved the same way as if there was no extension receiver at all.

https://youtrack.jetbrains.com/issue/KT-51478/Inapplicable-receiver-diagnostic-expected-when-there-are-two-context-receiver-candidates