### PR TITLE
FIR: Fix operator and infix flags for FIR builtins

### DIFF
--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/IrBuiltInsOverFir.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/IrBuiltInsOverFir.kt
@@ -823,10 +823,11 @@ class IrBuiltInsOverFir(
         origin: IrDeclarationOrigin = object : IrDeclarationOriginImpl("BUILTIN_CLASS_METHOD") {},
         modality: Modality = Modality.FINAL,
         isOperator: Boolean = false,
+        isInfix: Boolean = false,
         isIntrinsicConst: Boolean = true,
         build: IrFunctionBuilder.() -> Unit = {}
     ) = parent.createFunction(
-        name, returnType, valueParameterTypes, origin, modality, isOperator, isIntrinsicConst, build
+        name, returnType, valueParameterTypes, origin, modality, isOperator, isInfix, isIntrinsicConst, build
     ).also { fn ->
         fn.addDispatchReceiver { type = this@createMemberFunction.defaultType }
         declarations.add(fn)
@@ -856,12 +857,14 @@ class IrBuiltInsOverFir(
         origin: IrDeclarationOrigin = object : IrDeclarationOriginImpl("BUILTIN_CLASS_METHOD") {},
         modality: Modality = Modality.FINAL,
         isOperator: Boolean = false,
+        isInfix: Boolean = false,
         isIntrinsicConst: Boolean = true,
         build: IrFunctionBuilder.() -> Unit = {}
     ) =
         createMemberFunction(
             name.asString(), returnType, *valueParameterTypes,
-            origin = origin, modality = modality, isOperator = isOperator, isIntrinsicConst = isIntrinsicConst, build = build
+            origin = origin, modality = modality, isOperator = isOperator, isInfix = isInfix,
+            isIntrinsicConst = isIntrinsicConst, build = build
         )
 
     private fun IrClass.configureSuperTypes(vararg superTypes: BuiltInClassValue, defaultAny: Boolean = true) {
@@ -887,6 +890,7 @@ class IrBuiltInsOverFir(
         origin: IrDeclarationOrigin = IrDeclarationOrigin.IR_EXTERNAL_DECLARATION_STUB,
         modality: Modality = Modality.FINAL,
         isOperator: Boolean = false,
+        isInfix: Boolean = false,
         isIntrinsicConst: Boolean = false,
         build: IrFunctionBuilder.() -> Unit = {}
     ) = irFactory.buildFun {
@@ -895,6 +899,7 @@ class IrBuiltInsOverFir(
         this.origin = origin
         this.modality = modality
         this.isOperator = isOperator
+        this.isInfix = isInfix
         build()
     }.also { fn ->
         valueParameterTypes.forEachIndexed { index, (pName, irType) ->
@@ -1074,12 +1079,12 @@ class IrBuiltInsOverFir(
 
     private fun IrClass.createStandardBitwiseOps(thisType: IrType) {
         for (op in bitwiseOperators) {
-            createMemberFunction(op, thisType, "other" to thisType, isOperator = true)
+            createMemberFunction(op, thisType, "other" to thisType, isInfix = true)
         }
         for (op in shiftOperators) {
-            createMemberFunction(op, thisType, "bitCount" to intType, isOperator = true)
+            createMemberFunction(op, thisType, "bitCount" to intType, isInfix = true)
         }
-        createMemberFunction(OperatorNameConventions.INV, thisType, isOperator = true)
+        createMemberFunction(OperatorNameConventions.INV, thisType)
     }
 
     private fun IrClass.createStandardRangeMembers(thisType: IrType) {

--- a/compiler/fir/fir2ir/testData/ir/irText/properties/backingField/independentBackingFieldType.ir.txt
+++ b/compiler/fir/fir2ir/testData/ir/irText/properties/backingField/independentBackingFieldType.ir.txt
@@ -48,7 +48,7 @@ FILE fqName:<root> fileName:/independentBackingFieldType.kt
       VAR name:a type:<root>.A [val]
         CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in <root>.A' type=<root>.A origin=null
       VAR name:it type:kotlin.Int [val]
-        CALL 'public final fun and (other: kotlin.Int): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=null
+        CALL 'public final fun and (other: kotlin.Int): kotlin.Int [infix] declared in kotlin.Int' type=kotlin.Int origin=null
           $this: CALL 'public final fun <get-it> (): kotlin.Int declared in <root>.A' type=kotlin.Int origin=GET_PROPERTY
             $this: CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in <root>.A' type=<root>.A origin=null
           other: CONST Int type=kotlin.Int value=10

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/ir/Fir2IrTextTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/ir/Fir2IrTextTestGenerated.java
@@ -1257,6 +1257,12 @@ public class Fir2IrTextTestGenerated extends AbstractFir2IrTextTest {
         }
 
         @Test
+        @TestMetadata("builtinOperators.kt")
+        public void testBuiltinOperators() throws Exception {
+            runTest("compiler/testData/ir/irText/expressions/builtinOperators.kt");
+        }
+
+        @Test
         @TestMetadata("callWithReorderedArguments.kt")
         public void testCallWithReorderedArguments() throws Exception {
             runTest("compiler/testData/ir/irText/expressions/callWithReorderedArguments.kt");

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/ir/LightTreeFir2IrTextTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/ir/LightTreeFir2IrTextTestGenerated.java
@@ -1257,6 +1257,12 @@ public class LightTreeFir2IrTextTestGenerated extends AbstractLightTreeFir2IrTex
         }
 
         @Test
+        @TestMetadata("builtinOperators.kt")
+        public void testBuiltinOperators() throws Exception {
+            runTest("compiler/testData/ir/irText/expressions/builtinOperators.kt");
+        }
+
+        @Test
         @TestMetadata("callWithReorderedArguments.kt")
         public void testCallWithReorderedArguments() throws Exception {
             runTest("compiler/testData/ir/irText/expressions/callWithReorderedArguments.kt");

--- a/compiler/testData/ir/irText/expressions/builtinOperators.ir.txt
+++ b/compiler/testData/ir/irText/expressions/builtinOperators.ir.txt
@@ -1,0 +1,24 @@
+FILE fqName:test fileName:/test.kt
+  FUN name:callBuiltinFunctions visibility:public modality:FINAL <> (a:kotlin.Int, b:kotlin.Int) returnType:kotlin.Unit
+    VALUE_PARAMETER name:a index:0 type:kotlin.Int
+    VALUE_PARAMETER name:b index:1 type:kotlin.Int
+    BLOCK_BODY
+      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+        CALL 'public final fun plus (other: kotlin.Int): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=PLUS
+          $this: GET_VAR 'a: kotlin.Int declared in test.callBuiltinFunctions' type=kotlin.Int origin=null
+          other: GET_VAR 'b: kotlin.Int declared in test.callBuiltinFunctions' type=kotlin.Int origin=null
+      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+        CALL 'public final fun or (other: kotlin.Int): kotlin.Int [infix] declared in kotlin.Int' type=kotlin.Int origin=null
+          $this: GET_VAR 'a: kotlin.Int declared in test.callBuiltinFunctions' type=kotlin.Int origin=null
+          other: GET_VAR 'b: kotlin.Int declared in test.callBuiltinFunctions' type=kotlin.Int origin=null
+      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+        CALL 'public final fun and (other: kotlin.Int): kotlin.Int [infix] declared in kotlin.Int' type=kotlin.Int origin=null
+          $this: GET_VAR 'a: kotlin.Int declared in test.callBuiltinFunctions' type=kotlin.Int origin=null
+          other: GET_VAR 'b: kotlin.Int declared in test.callBuiltinFunctions' type=kotlin.Int origin=null
+      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+        CALL 'public final fun inv (): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=null
+          $this: GET_VAR 'a: kotlin.Int declared in test.callBuiltinFunctions' type=kotlin.Int origin=null
+      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+        CALL 'public final fun shl (bitCount: kotlin.Int): kotlin.Int [infix] declared in kotlin.Int' type=kotlin.Int origin=null
+          $this: GET_VAR 'a: kotlin.Int declared in test.callBuiltinFunctions' type=kotlin.Int origin=null
+          bitCount: GET_VAR 'b: kotlin.Int declared in test.callBuiltinFunctions' type=kotlin.Int origin=null

--- a/compiler/testData/ir/irText/expressions/builtinOperators.kt
+++ b/compiler/testData/ir/irText/expressions/builtinOperators.kt
@@ -1,0 +1,12 @@
+// FIR_IDENTICAL
+// FILE: test.kt
+
+package test
+
+fun callBuiltinFunctions(a: Int, b: Int) {
+    a + b
+    a or b
+    a and b
+    a.inv()
+    a shl b
+}

--- a/compiler/testData/ir/irText/expressions/builtinOperators.kt.txt
+++ b/compiler/testData/ir/irText/expressions/builtinOperators.kt.txt
@@ -1,0 +1,9 @@
+package test
+
+fun callBuiltinFunctions(a: Int, b: Int) {
+  a.plus(other = b) /*~> Unit */
+  a.or(other = b) /*~> Unit */
+  a.and(other = b) /*~> Unit */
+  a.inv() /*~> Unit */
+  a.shl(bitCount = b) /*~> Unit */
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/ir/IrTextTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/ir/IrTextTestGenerated.java
@@ -1257,6 +1257,12 @@ public class IrTextTestGenerated extends AbstractIrTextTest {
         }
 
         @Test
+        @TestMetadata("builtinOperators.kt")
+        public void testBuiltinOperators() throws Exception {
+            runTest("compiler/testData/ir/irText/expressions/builtinOperators.kt");
+        }
+
+        @Test
         @TestMetadata("callWithReorderedArguments.kt")
         public void testCallWithReorderedArguments() throws Exception {
             runTest("compiler/testData/ir/irText/expressions/callWithReorderedArguments.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/klib/KlibTextTestCaseGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/klib/KlibTextTestCaseGenerated.java
@@ -967,6 +967,11 @@ public class KlibTextTestCaseGenerated extends AbstractKlibTextTestCase {
             runTest("compiler/testData/ir/irText/expressions/breakContinueInWhen.kt");
         }
 
+        @TestMetadata("builtinOperators.kt")
+        public void testBuiltinOperators() throws Exception {
+            runTest("compiler/testData/ir/irText/expressions/builtinOperators.kt");
+        }
+
         @TestMetadata("callWithReorderedArguments.kt")
         public void testCallWithReorderedArguments() throws Exception {
             runTest("compiler/testData/ir/irText/expressions/callWithReorderedArguments.kt");


### PR DESCRIPTION
Binary bitwise operations are infix functions instead of operators. Bitwise negation is a normal function.