### PR TITLE
KAPT: Fix an ISE when processing unresolved generic types

### DIFF
--- a/core/descriptors/src/org/jetbrains/kotlin/types/TypeSubstitution.kt
+++ b/core/descriptors/src/org/jetbrains/kotlin/types/TypeSubstitution.kt
@@ -19,6 +19,10 @@ package org.jetbrains.kotlin.types
 import org.jetbrains.kotlin.descriptors.TypeParameterDescriptor
 import org.jetbrains.kotlin.descriptors.annotations.Annotations
 import org.jetbrains.kotlin.descriptors.annotations.FilteredAnnotations
+import org.jetbrains.kotlin.types.checker.SimpleClassicTypeSystemContext.replaceArguments
+import org.jetbrains.kotlin.types.error.ErrorType
+import org.jetbrains.kotlin.types.error.ErrorUtils
+import org.jetbrains.kotlin.types.model.typeConstructor
 
 abstract class TypeSubstitution {
     companion object {
@@ -169,6 +173,10 @@ fun SimpleType.replace(
 
     if (newArguments.isEmpty()) {
         return replaceAttributes(newAttributes)
+    }
+
+    if (this is ErrorType) {
+        return replaceArguments(newArguments)
     }
 
     return KotlinTypeFactory.simpleType(

--- a/core/descriptors/src/org/jetbrains/kotlin/types/error/ErrorType.kt
+++ b/core/descriptors/src/org/jetbrains/kotlin/types/error/ErrorType.kt
@@ -24,8 +24,11 @@ class ErrorType @JvmOverloads internal constructor(
 
     override fun replaceAttributes(newAttributes: TypeAttributes): SimpleType = this
 
+    fun replaceArguments(newArguments: List<TypeProjection>): ErrorType =
+        ErrorType(constructor, memberScope, kind, newArguments, isMarkedNullable, *formatParams)
+
     override fun makeNullableAsSpecified(newNullability: Boolean): SimpleType =
-            ErrorType(constructor, memberScope, kind, arguments, newNullability, *formatParams)
+        ErrorType(constructor, memberScope, kind, arguments, newNullability, *formatParams)
 
     @TypeRefinement
     override fun refine(kotlinTypeRefiner: KotlinTypeRefiner) = this

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt43786.kt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt43786.kt
@@ -1,0 +1,14 @@
+// CORRECT_ERROR_TYPES
+
+@Suppress("UNRESOLVED_REFERENCE")
+class Application {
+    lateinit var _preferencesDataStore: DataStore<Preferences>
+
+    companion object {
+        @JvmStatic
+        fun get(): Application = error()
+
+        @JvmStatic
+        fun getPreferencesDataStore() = get()._preferencesDataStore
+    }
+}

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt43786.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt43786.txt
@@ -1,0 +1,52 @@
+@kotlin.Metadata()
+@kotlin.Suppress(names = {"UNRESOLVED_REFERENCE"})
+public final class Application {
+    public DataStore<Preferences> _preferencesDataStore;
+    @org.jetbrains.annotations.NotNull()
+    public static final Application.Companion Companion = null;
+
+    public Application() {
+        super();
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final DataStore<Preferences> get_preferencesDataStore() {
+        return null;
+    }
+
+    public final void set_preferencesDataStore(@org.jetbrains.annotations.NotNull()
+    DataStore<Preferences> p0) {
+    }
+
+    @kotlin.jvm.JvmStatic()
+    @org.jetbrains.annotations.NotNull()
+    public static final Application get() {
+        return null;
+    }
+
+    @kotlin.jvm.JvmStatic()
+    @org.jetbrains.annotations.NotNull()
+    public static final java.lang.Object getPreferencesDataStore() {
+        return null;
+    }
+
+    @kotlin.Metadata()
+    public static final class Companion {
+
+        private Companion() {
+            super();
+        }
+
+        @kotlin.jvm.JvmStatic()
+        @org.jetbrains.annotations.NotNull()
+        public final Application get() {
+            return null;
+        }
+
+        @kotlin.jvm.JvmStatic()
+        @org.jetbrains.annotations.NotNull()
+        public final java.lang.Object getPreferencesDataStore() {
+            return null;
+        }
+    }
+}

--- a/plugins/kapt3/kapt3-compiler/tests-gen/org/jetbrains/kotlin/kapt3/test/runners/ClassFileToSourceStubConverterTestGenerated.java
+++ b/plugins/kapt3/kapt3-compiler/tests-gen/org/jetbrains/kotlin/kapt3/test/runners/ClassFileToSourceStubConverterTestGenerated.java
@@ -452,6 +452,12 @@ public class ClassFileToSourceStubConverterTestGenerated extends AbstractClassFi
     }
 
     @Test
+    @TestMetadata("kt43786.kt")
+    public void testKt43786() throws Exception {
+        runTest("plugins/kapt3/kapt3-compiler/testData/converter/kt43786.kt");
+    }
+
+    @Test
     @TestMetadata("lazyProperty.kt")
     public void testLazyProperty() throws Exception {
         runTest("plugins/kapt3/kapt3-compiler/testData/converter/lazyProperty.kt");

--- a/plugins/kapt3/kapt3-compiler/tests-gen/org/jetbrains/kotlin/kapt3/test/runners/IrClassFileToSourceStubConverterTestGenerated.java
+++ b/plugins/kapt3/kapt3-compiler/tests-gen/org/jetbrains/kotlin/kapt3/test/runners/IrClassFileToSourceStubConverterTestGenerated.java
@@ -452,6 +452,12 @@ public class IrClassFileToSourceStubConverterTestGenerated extends AbstractIrCla
     }
 
     @Test
+    @TestMetadata("kt43786.kt")
+    public void testKt43786() throws Exception {
+        runTest("plugins/kapt3/kapt3-compiler/testData/converter/kt43786.kt");
+    }
+
+    @Test
     @TestMetadata("lazyProperty.kt")
     public void testLazyProperty() throws Exception {
         runTest("plugins/kapt3/kapt3-compiler/testData/converter/lazyProperty.kt");


### PR DESCRIPTION
Error types that are generic could sometimes throw an ISE when generating the stub.

This fixes [KT-43786](https://youtrack.jetbrains.com/issue/KT-43786/KAPT-IllegalStateException-SimpleTypeImpl-should-not-be-created-for-error-type-ErrorScope).