### PR TITLE
KAPT: Preserve the order of annotations in the stubs

### DIFF
--- a/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/ClassFileToSourceStubConverter.kt
+++ b/plugins/kapt3/kapt3-compiler/src/org/jetbrains/kotlin/kapt3/stubs/ClassFileToSourceStubConverter.kt
@@ -1175,7 +1175,7 @@ class ClassFileToSourceStubConverter(val kaptContext: KaptContextForStubGenerati
                 seenAnnotations += it
             }
             val annotationTree = convertAnnotation(containingClass, annotation, packageFqName, annotationDescriptor) ?: return list
-            return list.prepend(annotationTree)
+            return list.append(annotationTree)
         }
 
         var annotations = visibleAnnotations?.fold(JavacList.nil<JCAnnotation>(), ::convertAndAdd) ?: JavacList.nil()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/annotationWithFqNames.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/annotationWithFqNames.txt
@@ -19,8 +19,8 @@ package test;
 import lib.Anno;
 import lib.impl.Impl;
 
-@kotlin.Metadata()
 @lib.Anno(impls = {lib.impl.Impl.class, ABC.class})
+@kotlin.Metadata()
 public final class Bar {
 
     public Bar() {
@@ -35,8 +35,8 @@ package test;
 import lib.Anno;
 import lib.impl.Impl;
 
-@kotlin.Metadata()
 @lib.Anno(impls = {lib.impl.Impl.class})
+@kotlin.Metadata()
 public final class Boo {
 
     public Boo() {
@@ -51,8 +51,8 @@ package test;
 import lib.Anno;
 import lib.impl.Impl;
 
-@kotlin.Metadata()
 @lib.Anno(impls = {lib.impl.Impl.class})
+@kotlin.Metadata()
 public final class Foo {
 
     public Foo() {
@@ -67,7 +67,7 @@ package test;
 import lib.Anno;
 import lib.impl.Impl;
 
-@kotlin.Suppress(names = {"UNRESOLVED_REFERENCE", "ANNOTATION_ARGUMENT_MUST_BE_CONST", "NON_CONST_VAL_USED_IN_CONSTANT_EXPRESSION"})
 @kotlin.Metadata()
+@kotlin.Suppress(names = {"UNRESOLVED_REFERENCE", "ANNOTATION_ARGUMENT_MUST_BE_CONST", "NON_CONST_VAL_USED_IN_CONSTANT_EXPRESSION"})
 public final class TestKt {
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/annotations.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/annotations.txt
@@ -1,7 +1,7 @@
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface Anno1 {
 }
 
@@ -10,8 +10,8 @@ public abstract @interface Anno1 {
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface Anno2 {
 
     public abstract int i() default 5;
@@ -38,8 +38,8 @@ public abstract @interface Anno2 {
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface Anno3 {
 
     public abstract java.lang.String value();
@@ -79,10 +79,10 @@ public enum Enum1 {
 
 import java.lang.System;
 
-@kotlin.Metadata()
-@Anno3(value = "value")
-@Anno2(a = @Anno1(), clazz = TestAnno.class, classes = {TestAnno.class, Anno1.class})
 @Anno1()
+@Anno2(a = @Anno1(), clazz = TestAnno.class, classes = {TestAnno.class, Anno1.class})
+@Anno3(value = "value")
+@kotlin.Metadata()
 public final class TestAnno {
 
     public TestAnno() {
@@ -95,12 +95,12 @@ public final class TestAnno {
 
 import java.lang.System;
 
-@kotlin.Metadata()
-@Anno2(i = 6, s = "BCD", ii = {4, 5, 6}, ss = {"Z", "X"}, a = @Anno1(), color = Colors.WHITE, colors = {Colors.WHITE}, clazz = TestAnno.class, classes = {TestAnno.class, Anno1.class})
 @Anno3(value = "value")
+@Anno2(i = 6, s = "BCD", ii = {4, 5, 6}, ss = {"Z", "X"}, a = @Anno1(), color = Colors.WHITE, colors = {Colors.WHITE}, clazz = TestAnno.class, classes = {TestAnno.class, Anno1.class})
+@kotlin.Metadata()
 public final class TestAnno2 {
-    @org.jetbrains.annotations.NotNull()
     @Anno3(value = "field")
+    @org.jetbrains.annotations.NotNull()
     private java.lang.String b = "property initializer";
 
     public TestAnno2() {
@@ -108,13 +108,13 @@ public final class TestAnno2 {
     }
 
     @Anno1()
-    public final void a(@org.jetbrains.annotations.NotNull()
-    @Anno3(value = "param-pam-pam")
+    public final void a(@Anno3(value = "param-pam-pam")
+    @org.jetbrains.annotations.NotNull()
     java.lang.String param) {
     }
 
-    @org.jetbrains.annotations.NotNull()
     @Anno3(value = "getter")
+    @org.jetbrains.annotations.NotNull()
     public final java.lang.String getB() {
         return null;
     }
@@ -125,8 +125,8 @@ public final class TestAnno2 {
     }
 
     @Anno3(value = "setter")
-    public final void setB(@org.jetbrains.annotations.NotNull()
-    @Anno3(value = "setparam")
+    public final void setB(@Anno3(value = "setparam")
+    @org.jetbrains.annotations.NotNull()
     java.lang.String p0) {
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/annotations2.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/annotations2.txt
@@ -2,9 +2,9 @@ package test;
 
 import java.lang.System;
 
-@kotlin.Metadata()
-@java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @Anno(value = "anno-class")
+@java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface Anno {
 
     public abstract java.lang.String value();
@@ -16,8 +16,8 @@ package test;
 
 import java.lang.System;
 
-@kotlin.jvm.JvmName(name = "AnnotationsTest")
 @kotlin.Metadata()
+@kotlin.jvm.JvmName(name = "AnnotationsTest")
 public final class AnnotationsTest {
 
     public AnnotationsTest() {
@@ -25,8 +25,8 @@ public final class AnnotationsTest {
     }
 
     @Anno(value = "top-level-fun")
-    public static final void topLevelFun(@org.jetbrains.annotations.NotNull()
-    @Anno(value = "top-level-fun-receiver")
+    public static final void topLevelFun(@Anno(value = "top-level-fun-receiver")
+    @org.jetbrains.annotations.NotNull()
     java.lang.String $this$topLevelFun) {
     }
 
@@ -48,8 +48,8 @@ package test;
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @Anno(value = "enum")
+@kotlin.Metadata()
 public enum Enum {
     @Anno(value = "white")
     /*public static final*/ WHITE /* = new Enum() */,
@@ -73,21 +73,21 @@ package test;
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @Anno(value = "clazz")
+@kotlin.Metadata()
 public abstract class Test {
     @org.jetbrains.annotations.NotNull()
     private java.lang.String v;
 
     @Anno(value = "test-constructor")
-    protected Test(@org.jetbrains.annotations.NotNull()
-    @Anno(value = "v-param")
+    protected Test(@Anno(value = "v-param")
+    @org.jetbrains.annotations.NotNull()
     java.lang.String v) {
         super();
     }
 
-    @org.jetbrains.annotations.NotNull()
     @Anno(value = "v-get")
+    @org.jetbrains.annotations.NotNull()
     public final java.lang.String getV() {
         return null;
     }
@@ -98,13 +98,13 @@ public abstract class Test {
     }
 
     @Anno(value = "v-set")
-    public final void setV(@org.jetbrains.annotations.NotNull()
-    @Anno(value = "v-setparam")
+    public final void setV(@Anno(value = "v-setparam")
+    @org.jetbrains.annotations.NotNull()
     java.lang.String p0) {
     }
 
-    @org.jetbrains.annotations.NotNull()
     @Anno(value = "abstract-method")
+    @org.jetbrains.annotations.NotNull()
     public abstract java.lang.String abstractMethod();
 
     @org.jetbrains.annotations.NotNull()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/annotations2_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/annotations2_ir.txt
@@ -2,9 +2,9 @@ package test;
 
 import java.lang.System;
 
-@kotlin.Metadata()
-@java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @Anno(value = "anno-class")
+@java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface Anno {
 
     public abstract java.lang.String value();
@@ -16,8 +16,8 @@ package test;
 
 import java.lang.System;
 
-@kotlin.jvm.JvmName(name = "AnnotationsTest")
 @kotlin.Metadata()
+@kotlin.jvm.JvmName(name = "AnnotationsTest")
 public final class AnnotationsTest {
 
     public AnnotationsTest() {
@@ -25,8 +25,8 @@ public final class AnnotationsTest {
     }
 
     @Anno(value = "top-level-fun")
-    public static final void topLevelFun(@org.jetbrains.annotations.NotNull()
-    @Anno(value = "top-level-fun-receiver")
+    public static final void topLevelFun(@Anno(value = "top-level-fun-receiver")
+    @org.jetbrains.annotations.NotNull()
     java.lang.String $this$topLevelFun) {
     }
 
@@ -48,8 +48,8 @@ package test;
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @Anno(value = "enum")
+@kotlin.Metadata()
 public enum Enum {
     @Anno(value = "white")
     /*public static final*/ WHITE /* = new Enum() */,
@@ -73,33 +73,33 @@ package test;
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @Anno(value = "clazz")
+@kotlin.Metadata()
 public abstract class Test {
     @org.jetbrains.annotations.NotNull()
     private java.lang.String v;
 
     @Anno(value = "test-constructor")
-    protected Test(@org.jetbrains.annotations.NotNull()
-    @Anno(value = "v-param")
+    protected Test(@Anno(value = "v-param")
+    @org.jetbrains.annotations.NotNull()
     java.lang.String v) {
         super();
     }
 
-    @org.jetbrains.annotations.NotNull()
     @Anno(value = "v-get")
+    @org.jetbrains.annotations.NotNull()
     public final java.lang.String getV() {
         return null;
     }
 
     @Anno(value = "v-set")
-    public final void setV(@org.jetbrains.annotations.NotNull()
-    @Anno(value = "v-setparam")
+    public final void setV(@Anno(value = "v-setparam")
+    @org.jetbrains.annotations.NotNull()
     java.lang.String p0) {
     }
 
-    @org.jetbrains.annotations.NotNull()
     @Anno(value = "abstract-method")
+    @org.jetbrains.annotations.NotNull()
     public abstract java.lang.String abstractMethod();
 
     @org.jetbrains.annotations.NotNull()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/annotations3.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/annotations3.txt
@@ -65,9 +65,9 @@ public abstract interface Parceler<T extends java.lang.Object> {
 
 import java.lang.System;
 
-@TypeParceler()
-@TypeParceler()
 @kotlin.Metadata()
+@TypeParceler()
+@TypeParceler()
 public final class Test {
 
     public Test() {
@@ -80,11 +80,11 @@ public final class Test {
 
 import java.lang.System;
 
-@kotlin.Metadata()
-@java.lang.annotation.Target(value = {java.lang.annotation.ElementType.TYPE})
-@java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.SOURCE)
-@kotlin.annotation.Target(allowedTargets = {kotlin.annotation.AnnotationTarget.CLASS, kotlin.annotation.AnnotationTarget.PROPERTY})
-@kotlin.annotation.Repeatable()
 @kotlin.annotation.Retention(value = kotlin.annotation.AnnotationRetention.SOURCE)
+@kotlin.annotation.Repeatable()
+@kotlin.annotation.Target(allowedTargets = {kotlin.annotation.AnnotationTarget.CLASS, kotlin.annotation.AnnotationTarget.PROPERTY})
+@java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.SOURCE)
+@java.lang.annotation.Target(value = {java.lang.annotation.ElementType.TYPE})
+@kotlin.Metadata()
 public abstract @interface TypeParceler<T extends java.lang.Object, P extends Parceler<? super T>> extends java.lang.annotation.Annotation {
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/annotations3_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/annotations3_ir.txt
@@ -65,9 +65,9 @@ public abstract interface Parceler<T extends java.lang.Object> {
 
 import java.lang.System;
 
-@TypeParceler()
-@TypeParceler()
 @kotlin.Metadata()
+@TypeParceler()
+@TypeParceler()
 public final class Test {
 
     public Test() {
@@ -80,21 +80,21 @@ public final class Test {
 
 import java.lang.System;
 
-@kotlin.Metadata()
-@java.lang.annotation.Repeatable(value = TypeParceler.Container.class)
-@java.lang.annotation.Target(value = {java.lang.annotation.ElementType.TYPE})
-@java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.SOURCE)
-@kotlin.annotation.Target(allowedTargets = {kotlin.annotation.AnnotationTarget.CLASS, kotlin.annotation.AnnotationTarget.PROPERTY})
-@kotlin.annotation.Repeatable()
 @kotlin.annotation.Retention(value = kotlin.annotation.AnnotationRetention.SOURCE)
+@kotlin.annotation.Repeatable()
+@kotlin.annotation.Target(allowedTargets = {kotlin.annotation.AnnotationTarget.CLASS, kotlin.annotation.AnnotationTarget.PROPERTY})
+@java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.SOURCE)
+@java.lang.annotation.Target(value = {java.lang.annotation.ElementType.TYPE})
+@java.lang.annotation.Repeatable(value = TypeParceler.Container.class)
+@kotlin.Metadata()
 public abstract @interface TypeParceler<T extends java.lang.Object, P extends Parceler<? super T>> extends java.lang.annotation.Annotation {
 
-    @kotlin.Metadata()
-    @java.lang.annotation.Target(value = {java.lang.annotation.ElementType.TYPE})
-    @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.SOURCE)
-    @kotlin.jvm.internal.RepeatableContainer()
-    @kotlin.annotation.Target(allowedTargets = {kotlin.annotation.AnnotationTarget.CLASS, kotlin.annotation.AnnotationTarget.PROPERTY})
     @kotlin.annotation.Retention(value = kotlin.annotation.AnnotationRetention.SOURCE)
+    @kotlin.annotation.Target(allowedTargets = {kotlin.annotation.AnnotationTarget.CLASS, kotlin.annotation.AnnotationTarget.PROPERTY})
+    @kotlin.jvm.internal.RepeatableContainer()
+    @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.SOURCE)
+    @java.lang.annotation.Target(value = {java.lang.annotation.ElementType.TYPE})
+    @kotlin.Metadata()
     public static abstract @interface Container {
 
         public abstract TypeParceler[] value();

--- a/plugins/kapt3/kapt3-compiler/testData/converter/annotationsWithConstants.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/annotationsWithConstants.txt
@@ -2,8 +2,8 @@ package app;
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface Anno {
 
     public abstract boolean a1();
@@ -59,8 +59,8 @@ package app;
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface Bind {
 
     public abstract int id();
@@ -72,10 +72,10 @@ package app;
 
 import java.lang.System;
 
-@kotlin.Metadata()
-@java.lang.annotation.Target(value = {java.lang.annotation.ElementType.FIELD})
-@java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.annotation.Target(allowedTargets = {kotlin.annotation.AnnotationTarget.FIELD})
+@java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@java.lang.annotation.Target(value = {java.lang.annotation.ElementType.FIELD})
+@kotlin.Metadata()
 public abstract @interface BindField {
 
     public abstract int id();
@@ -115,8 +115,8 @@ package app;
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface MultiValue {
 
     public abstract int[] ids();
@@ -128,8 +128,8 @@ package app;
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface MultiValueByte {
 
     public abstract byte[] ids();
@@ -141,8 +141,8 @@ package app;
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface MultiValueString {
 
     public abstract java.lang.String[] ids();
@@ -221,8 +221,8 @@ public final class MyActivity {
         return 0;
     }
 
-    @Anno(a1 = app.B.a1, a2 = app.B.a2, a3 = app.B.a3, a4 = app.B.a4, a5 = app.B.a5, a6 = app.B.a6, a7 = app.B.a7, a8 = app.B.a8, a9 = "A")
     @Bind(id = app.R2.layout.mainActivity)
+    @Anno(a1 = app.B.a1, a2 = app.B.a2, a3 = app.B.a3, a4 = app.B.a4, a5 = app.B.a5, a6 = app.B.a6, a7 = app.B.a7, a8 = app.B.a8, a9 = "A")
     @java.lang.Deprecated()
     public static void getE$annotations() {
     }
@@ -252,8 +252,8 @@ public final class MyActivity {
     public final void foo4() {
     }
 
-    @Anno(a1 = app.B.a1, a2 = app.B.a2, a3 = app.B.a3, a4 = app.B.a4, a5 = app.B.a5, a6 = app.B.a6, a7 = app.B.a7, a8 = app.B.a8, a9 = "A")
     @Bind(id = app.R2.layout.mainActivity)
+    @Anno(a1 = app.B.a1, a2 = app.B.a2, a3 = app.B.a3, a4 = app.B.a4, a5 = app.B.a5, a6 = app.B.a6, a7 = app.B.a7, a8 = app.B.a8, a9 = "A")
     public final void foo5() {
     }
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/annotationsWithConstants_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/annotationsWithConstants_ir.txt
@@ -2,8 +2,8 @@ package app;
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface Anno {
 
     public abstract boolean a1();
@@ -59,8 +59,8 @@ package app;
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface Bind {
 
     public abstract int id();
@@ -72,10 +72,10 @@ package app;
 
 import java.lang.System;
 
-@kotlin.Metadata()
-@java.lang.annotation.Target(value = {java.lang.annotation.ElementType.FIELD})
-@java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.annotation.Target(allowedTargets = {kotlin.annotation.AnnotationTarget.FIELD})
+@java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@java.lang.annotation.Target(value = {java.lang.annotation.ElementType.FIELD})
+@kotlin.Metadata()
 public abstract @interface BindField {
 
     public abstract int id();
@@ -115,8 +115,8 @@ package app;
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface MultiValue {
 
     public abstract int[] ids();
@@ -128,8 +128,8 @@ package app;
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface MultiValueByte {
 
     public abstract byte[] ids();
@@ -141,8 +141,8 @@ package app;
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface MultiValueString {
 
     public abstract java.lang.String[] ids();
@@ -221,8 +221,8 @@ public final class MyActivity {
     public final void foo4() {
     }
 
-    @Anno(a1 = app.B.a1, a2 = app.B.a2, a3 = app.B.a3, a4 = app.B.a4, a5 = app.B.a5, a6 = app.B.a6, a7 = app.B.a7, a8 = app.B.a8, a9 = "A")
     @Bind(id = app.R2.layout.mainActivity)
+    @Anno(a1 = app.B.a1, a2 = app.B.a2, a3 = app.B.a3, a4 = app.B.a4, a5 = app.B.a5, a6 = app.B.a6, a7 = app.B.a7, a8 = app.B.a8, a9 = "A")
     public final void foo5() {
     }
 
@@ -297,8 +297,8 @@ public final class MyActivity {
     public static void getD$annotations() {
     }
 
-    @Anno(a1 = app.B.a1, a2 = app.B.a2, a3 = app.B.a3, a4 = app.B.a4, a5 = app.B.a5, a6 = app.B.a6, a7 = app.B.a7, a8 = app.B.a8, a9 = "A")
     @Bind(id = app.R2.layout.mainActivity)
+    @Anno(a1 = app.B.a1, a2 = app.B.a2, a3 = app.B.a3, a4 = app.B.a4, a5 = app.B.a5, a6 = app.B.a6, a7 = app.B.a7, a8 = app.B.a8, a9 = "A")
     @java.lang.Deprecated()
     public static void getE$annotations() {
     }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/annotationsWithTargets.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/annotationsWithTargets.txt
@@ -1,7 +1,7 @@
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface Anno {
 }
 
@@ -12,8 +12,8 @@ import java.lang.System;
 
 @kotlin.Metadata()
 public final class Bar {
-    @org.jetbrains.annotations.NotNull()
     @FieldAnno()
+    @org.jetbrains.annotations.NotNull()
     private final java.lang.String a = "";
 
     public Bar() {
@@ -25,8 +25,8 @@ public final class Bar {
         return null;
     }
 
-    @Anno()
     @PropertyAnno()
+    @Anno()
     @java.lang.Deprecated()
     public static void getA$annotations() {
     }
@@ -39,9 +39,9 @@ import java.lang.System;
 
 @kotlin.Metadata()
 public final class Baz {
-    @org.jetbrains.annotations.NotNull()
-    @kotlin.jvm.JvmField()
     @FieldAnno()
+    @kotlin.jvm.JvmField()
+    @org.jetbrains.annotations.NotNull()
     public final java.lang.String a = "";
 
     public Baz() {
@@ -59,10 +59,10 @@ public final class Baz {
 
 import java.lang.System;
 
-@kotlin.Metadata()
-@java.lang.annotation.Target(value = {java.lang.annotation.ElementType.FIELD})
-@java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.annotation.Target(allowedTargets = {kotlin.annotation.AnnotationTarget.FIELD})
+@java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@java.lang.annotation.Target(value = {java.lang.annotation.ElementType.FIELD})
+@kotlin.Metadata()
 public abstract @interface FieldAnno {
 }
 
@@ -73,13 +73,13 @@ import java.lang.System;
 
 @kotlin.Metadata()
 public final class Foo {
-    @org.jetbrains.annotations.NotNull()
     @FieldAnno()
+    @org.jetbrains.annotations.NotNull()
     private final java.lang.String a = null;
 
-    public Foo(@org.jetbrains.annotations.NotNull()
+    public Foo(@ParameterAnno()
     @Anno()
-    @ParameterAnno()
+    @org.jetbrains.annotations.NotNull()
     java.lang.String a) {
         super();
     }
@@ -100,10 +100,10 @@ public final class Foo {
 
 import java.lang.System;
 
-@kotlin.Metadata()
-@java.lang.annotation.Target(value = {java.lang.annotation.ElementType.PARAMETER})
-@java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.annotation.Target(allowedTargets = {kotlin.annotation.AnnotationTarget.VALUE_PARAMETER})
+@java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@java.lang.annotation.Target(value = {java.lang.annotation.ElementType.PARAMETER})
+@kotlin.Metadata()
 public abstract @interface ParameterAnno {
 }
 
@@ -112,9 +112,9 @@ public abstract @interface ParameterAnno {
 
 import java.lang.System;
 
-@kotlin.Metadata()
-@java.lang.annotation.Target(value = {})
-@java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.annotation.Target(allowedTargets = {kotlin.annotation.AnnotationTarget.PROPERTY})
+@java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@java.lang.annotation.Target(value = {})
+@kotlin.Metadata()
 public abstract @interface PropertyAnno {
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/comments.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/comments.txt
@@ -1,9 +1,9 @@
 import java.lang.System;
 
-@kotlin.Metadata()
-@java.lang.annotation.Target(value = {})
-@java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.annotation.Target(allowedTargets = {kotlin.annotation.AnnotationTarget.PROPERTY})
+@java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@java.lang.annotation.Target(value = {})
+@kotlin.Metadata()
 public abstract @interface Anno {
 }
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/commentsRemoved.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/commentsRemoved.txt
@@ -1,9 +1,9 @@
 import java.lang.System;
 
-@kotlin.Metadata()
-@java.lang.annotation.Target(value = {})
-@java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.annotation.Target(allowedTargets = {kotlin.annotation.AnnotationTarget.PROPERTY})
+@java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@java.lang.annotation.Target(value = {})
+@kotlin.Metadata()
 public abstract @interface Anno {
 }
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/commentsRemoved_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/commentsRemoved_ir.txt
@@ -1,9 +1,9 @@
 import java.lang.System;
 
-@kotlin.Metadata()
-@java.lang.annotation.Target(value = {})
-@java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.annotation.Target(allowedTargets = {kotlin.annotation.AnnotationTarget.PROPERTY})
+@java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@java.lang.annotation.Target(value = {})
+@kotlin.Metadata()
 public abstract @interface Anno {
 }
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/dataClass.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/dataClass.txt
@@ -26,8 +26,8 @@ public final class User {
         return 0;
     }
 
-    @org.jetbrains.annotations.NotNull()
     @java.lang.Override()
+    @org.jetbrains.annotations.NotNull()
     public java.lang.String toString() {
         return null;
     }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/dataClass_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/dataClass_ir.txt
@@ -63,8 +63,8 @@ public final class User {
         return 0;
     }
 
-    @org.jetbrains.annotations.NotNull()
     @java.lang.Override()
+    @org.jetbrains.annotations.NotNull()
     public java.lang.String toString() {
         return null;
     }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/defaultPackage.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/defaultPackage.txt
@@ -62,8 +62,8 @@ package test;
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @ClassRefAnnotation(value = {RootClass.class})
+@kotlin.Metadata()
 public final class PackedWithAnnotation {
 
     public PackedWithAnnotation() {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/defaultPackageCorrectErrorTypes.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/defaultPackageCorrectErrorTypes.txt
@@ -62,8 +62,8 @@ package test;
 
 import java.lang.Number;
 
-@kotlin.Metadata()
 @ClassRefAnnotation(value = {RootClass.class})
+@kotlin.Metadata()
 public final class PackedWithAnnotation {
 
     public PackedWithAnnotation() {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/deprecated.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/deprecated.txt
@@ -2,8 +2,8 @@ package deprecated;
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 @java.lang.Deprecated()
 public abstract @interface Anno {
 }
@@ -14,8 +14,8 @@ package deprecated;
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @Anno()
+@kotlin.Metadata()
 @java.lang.Deprecated()
 public final class Foo {
     @java.lang.Deprecated()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/deprecated_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/deprecated_ir.txt
@@ -2,8 +2,8 @@ package deprecated;
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 @java.lang.Deprecated()
 public abstract @interface Anno {
 }
@@ -14,8 +14,8 @@ package deprecated;
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @Anno()
+@kotlin.Metadata()
 @java.lang.Deprecated()
 public final class Foo {
     @java.lang.Deprecated()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/enums.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/enums.txt
@@ -1,7 +1,7 @@
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface Anno1 {
 
     public abstract java.lang.String value();

--- a/plugins/kapt3/kapt3-compiler/testData/converter/errorLocationMapping.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/errorLocationMapping.txt
@@ -1,7 +1,7 @@
 import kotlin.reflect.KClass;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface Anno {
 
     public abstract java.lang.Class<java.lang.Object> a();
@@ -12,8 +12,8 @@ public abstract @interface Anno {
 
 import kotlin.reflect.KClass;
 
-@kotlin.Metadata()
 @Anno(a = ABC.class)
+@kotlin.Metadata()
 public final class ErrorInAnnotation {
 
     public ErrorInAnnotation() {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/errorSuperclass.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/errorSuperclass.txt
@@ -2,8 +2,8 @@ package test;
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface Anno {
 }
 
@@ -13,9 +13,9 @@ package test;
 
 import java.lang.System;
 
-@kotlin.Suppress(names = {"UNRESOLVED_REFERENCE"})
-@kotlin.Metadata()
 @Anno()
+@kotlin.Metadata()
+@kotlin.Suppress(names = {"UNRESOLVED_REFERENCE"})
 public final class ClassWithParent implements java.lang.CharSequence {
 
     public ClassWithParent() {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/errorSuperclassCorrectErrorTypes.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/errorSuperclassCorrectErrorTypes.txt
@@ -119,8 +119,8 @@ public final class MappedList<R extends java.lang.Object> extends kotlin.collect
         super();
     }
 
-    @org.jetbrains.annotations.NotNull()
     @java.lang.Override()
+    @org.jetbrains.annotations.NotNull()
     public java.lang.Void get(int index) {
         return null;
     }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/errorSuperclass_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/errorSuperclass_ir.txt
@@ -2,8 +2,8 @@ package test;
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface Anno {
 }
 
@@ -13,9 +13,9 @@ package test;
 
 import java.lang.System;
 
-@kotlin.Suppress(names = {"UNRESOLVED_REFERENCE"})
-@kotlin.Metadata()
 @Anno()
+@kotlin.Metadata()
+@kotlin.Suppress(names = {"UNRESOLVED_REFERENCE"})
 public final class ClassWithParent implements java.lang.CharSequence {
 
     public ClassWithParent() {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/fileFacadeJvmName.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/fileFacadeJvmName.txt
@@ -2,8 +2,8 @@ package a.b.c;
 
 import java.lang.System;
 
-@kotlin.jvm.JvmName(name = "FacadeName")
 @kotlin.Metadata()
+@kotlin.jvm.JvmName(name = "FacadeName")
 public final class FacadeName {
 
     public FacadeName() {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/inheritanceSimple.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/inheritanceSimple.txt
@@ -34,8 +34,8 @@ public final class Inheritor extends BaseClass {
         super(null, 0, false);
     }
 
-    @org.jetbrains.annotations.NotNull()
     @java.lang.Override()
+    @org.jetbrains.annotations.NotNull()
     public Result doJob() {
         return null;
     }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/inlineClasses.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/inlineClasses.txt
@@ -1,7 +1,7 @@
 import java.lang.System;
 
-@kotlin.Metadata()
 @kotlin.jvm.JvmInline()
+@kotlin.Metadata()
 public final class Cl {
 
     public Cl() {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/inlineClasses_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/inlineClasses_ir.txt
@@ -1,7 +1,7 @@
 import java.lang.System;
 
-@kotlin.Metadata()
 @kotlin.jvm.JvmInline()
+@kotlin.Metadata()
 public final class Cl {
 
     public Cl() {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/interfaceImplementation.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/interfaceImplementation.txt
@@ -17,8 +17,8 @@ public final class Product2 implements Named {
     @org.jetbrains.annotations.Nullable()
     private java.lang.String name;
 
-    @org.jetbrains.annotations.Nullable()
     @java.lang.Override()
+    @org.jetbrains.annotations.Nullable()
     public java.lang.String getName() {
         return null;
     }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/invalidFieldName.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/invalidFieldName.txt
@@ -1,8 +1,8 @@
 import java.lang.System;
 
-@kotlin.Metadata()
-@java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @Anno(color = Color.InvalidFieldName)
+@java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface Anno {
 
     public abstract Color color();

--- a/plugins/kapt3/kapt3-compiler/testData/converter/jvmOverloads.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/jvmOverloads.txt
@@ -43,8 +43,8 @@ public final class State2 {
     public final int someInt = 0;
     @kotlin.jvm.JvmField()
     public final long someLong = 0L;
-    @org.jetbrains.annotations.NotNull()
     @kotlin.jvm.JvmField()
+    @org.jetbrains.annotations.NotNull()
     public final java.lang.String someString = null;
 
     @kotlin.jvm.JvmOverloads()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/jvmOverloads_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/jvmOverloads_ir.txt
@@ -43,8 +43,8 @@ public final class State2 {
     public final int someInt = 0;
     @kotlin.jvm.JvmField()
     public final long someLong = 0L;
-    @org.jetbrains.annotations.NotNull()
     @kotlin.jvm.JvmField()
+    @org.jetbrains.annotations.NotNull()
     public final java.lang.String someString = null;
 
     @kotlin.jvm.JvmOverloads()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/jvmRepeatableAnnotation.kt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/jvmRepeatableAnnotation.kt
@@ -1,0 +1,10 @@
+// EXPECTED_ERROR: This class does not have a constructor (1,2)
+
+//import kotlin.jvm.JvmRepeatable
+
+//@JvmRepeatable
+annotation class Condition(val condition: String)
+
+@Condition(condition = "value1")
+@Condition(condition = "value2")
+class A

--- a/plugins/kapt3/kapt3-compiler/testData/converter/jvmRepeatableAnnotation.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/jvmRepeatableAnnotation.txt
@@ -1,0 +1,23 @@
+import java.lang.System;
+
+@Condition(condition = "value1")
+@Condition(condition = "value2")
+@kotlin.Metadata()
+public final class A {
+
+    public A() {
+        super();
+    }
+}
+
+////////////////////
+
+
+import java.lang.System;
+
+@java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
+public abstract @interface Condition {
+
+    public abstract java.lang.String condition();
+}

--- a/plugins/kapt3/kapt3-compiler/testData/converter/jvmStatic.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/jvmStatic.txt
@@ -5,8 +5,8 @@ public abstract interface FooComponent {
     @org.jetbrains.annotations.NotNull()
     public static final FooComponent.Companion Companion = null;
 
-    @org.jetbrains.annotations.NotNull()
     @kotlin.jvm.JvmStatic()
+    @org.jetbrains.annotations.NotNull()
     public static java.lang.String create(@org.jetbrains.annotations.NotNull()
     java.lang.String context) {
         return null;
@@ -19,8 +19,8 @@ public abstract interface FooComponent {
             super();
         }
 
-        @org.jetbrains.annotations.NotNull()
         @kotlin.jvm.JvmStatic()
+        @org.jetbrains.annotations.NotNull()
         public final java.lang.String create(@org.jetbrains.annotations.NotNull()
         java.lang.String context) {
             return null;

--- a/plugins/kapt3/kapt3-compiler/testData/converter/jvmStatic_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/jvmStatic_ir.txt
@@ -5,8 +5,8 @@ public abstract interface FooComponent {
     @org.jetbrains.annotations.NotNull()
     public static final FooComponent.Companion Companion = null;
 
-    @org.jetbrains.annotations.NotNull()
     @kotlin.jvm.JvmStatic()
+    @org.jetbrains.annotations.NotNull()
     public static java.lang.String create(@org.jetbrains.annotations.NotNull()
     java.lang.String context) {
         return null;
@@ -19,8 +19,8 @@ public abstract interface FooComponent {
             super();
         }
 
-        @org.jetbrains.annotations.NotNull()
         @kotlin.jvm.JvmStatic()
+        @org.jetbrains.annotations.NotNull()
         public final java.lang.String create(@org.jetbrains.annotations.NotNull()
         java.lang.String context) {
             return null;

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt14997.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt14997.txt
@@ -14,8 +14,8 @@ public class CrashMe {
 
 import java.lang.System;
 
-@kotlin.Suppress(names = {"AMBIGUOUS_ANONYMOUS_TYPE_INFERRED"})
 @kotlin.Metadata()
+@kotlin.Suppress(names = {"AMBIGUOUS_ANONYMOUS_TYPE_INFERRED"})
 public final class Kt14997Kt {
 
     public Kt14997Kt() {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt14997_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt14997_ir.txt
@@ -15,8 +15,8 @@ public class CrashMe {
 
 import java.lang.System;
 
-@kotlin.Suppress(names = {"AMBIGUOUS_ANONYMOUS_TYPE_INFERRED"})
 @kotlin.Metadata()
+@kotlin.Suppress(names = {"AMBIGUOUS_ANONYMOUS_TYPE_INFERRED"})
 public final class Kt14997Kt {
 
     public Kt14997Kt() {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt27126.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt27126.txt
@@ -42,8 +42,8 @@ package test;
 
 import java.lang.System;
 
-@kotlin.Suppress(names = {"NOTHING_TO_INLINE"})
 @kotlin.Metadata()
+@kotlin.Suppress(names = {"NOTHING_TO_INLINE"})
 public final class Kt27126Kt {
 
     public Kt27126Kt() {
@@ -76,8 +76,8 @@ public abstract class NullableBundleProperty<EE extends java.lang.Object> implem
         return null;
     }
 
-    @org.jetbrains.annotations.Nullable()
     @java.lang.Override()
+    @org.jetbrains.annotations.Nullable()
     public EE getValue(@org.jetbrains.annotations.NotNull()
     java.lang.Object thisRef, @org.jetbrains.annotations.NotNull()
     kotlin.reflect.KProperty<?> property) {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt27126_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt27126_ir.txt
@@ -42,8 +42,8 @@ package test;
 
 import java.lang.System;
 
-@kotlin.Suppress(names = {"NOTHING_TO_INLINE"})
 @kotlin.Metadata()
+@kotlin.Suppress(names = {"NOTHING_TO_INLINE"})
 public final class Kt27126Kt {
 
     public Kt27126Kt() {
@@ -77,8 +77,8 @@ public abstract class NullableBundleProperty<EE extends java.lang.Object> implem
         return null;
     }
 
-    @org.jetbrains.annotations.Nullable()
     @java.lang.Override()
+    @org.jetbrains.annotations.Nullable()
     public EE getValue(@org.jetbrains.annotations.NotNull()
     java.lang.Object thisRef, @org.jetbrains.annotations.NotNull()
     kotlin.reflect.KProperty<?> property) {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/kt32596.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/kt32596.txt
@@ -1,7 +1,7 @@
 import kotlin.reflect.KClass;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface Anno {
 
     public abstract java.lang.Class<?> klass();
@@ -12,8 +12,8 @@ public abstract @interface Anno {
 
 import kotlin.reflect.KClass;
 
-@kotlin.Metadata()
 @ABC()
+@kotlin.Metadata()
 public final class ErrorMissingAnnotation {
 
     public ErrorMissingAnnotation() {
@@ -26,9 +26,9 @@ public final class ErrorMissingAnnotation {
 
 import kotlin.reflect.KClass;
 
-@kotlin.Metadata()
-@CDE()
 @ABC()
+@CDE()
+@kotlin.Metadata()
 public final class ErrorMultipleMissingAnnotations {
 
     public ErrorMultipleMissingAnnotations() {
@@ -41,10 +41,10 @@ public final class ErrorMultipleMissingAnnotations {
 
 import kotlin.reflect.KClass;
 
-@kotlin.Metadata()
-@ABC()
-@Anno(klass = ABC.class)
 @CDE()
+@Anno(klass = ABC.class)
+@ABC()
+@kotlin.Metadata()
 public final class ErrorSomeMissingAnnotations {
 
     public ErrorSomeMissingAnnotations() {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/leadingDollars2.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/leadingDollars2.txt
@@ -14,8 +14,8 @@ package te.st.a;
 import te.st.a.$Test.Inner;
 import te.st.a.Test$.Inner$;
 
-@kotlin.Suppress(names = {"UNRESOLVED_REFERENCE"})
 @kotlin.Metadata()
+@kotlin.Suppress(names = {"UNRESOLVED_REFERENCE"})
 public final class TestKt {
 
     public TestKt() {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/modifiers.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/modifiers.txt
@@ -28,11 +28,11 @@ import java.lang.System;
 
 @kotlin.Metadata()
 public final class Modifiers {
-    @org.jetbrains.annotations.NotNull()
     @kotlin.jvm.Transient()
-    private final transient java.lang.String transientField = "";
     @org.jetbrains.annotations.NotNull()
+    private final transient java.lang.String transientField = "";
     @kotlin.jvm.Volatile()
+    @org.jetbrains.annotations.NotNull()
     private volatile java.lang.String volatileField = "";
 
     public Modifiers() {
@@ -57,21 +57,21 @@ public final class Modifiers {
     public final strictfp void strictFp() {
     }
 
-    @org.jetbrains.annotations.NotNull()
     @kotlin.jvm.JvmOverloads()
+    @org.jetbrains.annotations.NotNull()
     public final java.lang.String overloads() {
         return null;
     }
 
-    @org.jetbrains.annotations.NotNull()
     @kotlin.jvm.JvmOverloads()
+    @org.jetbrains.annotations.NotNull()
     public final java.lang.String overloads(@org.jetbrains.annotations.NotNull()
     java.lang.String a) {
         return null;
     }
 
-    @org.jetbrains.annotations.NotNull()
     @kotlin.jvm.JvmOverloads()
+    @org.jetbrains.annotations.NotNull()
     public final java.lang.String overloads(@org.jetbrains.annotations.NotNull()
     java.lang.String a, int n) {
         return null;

--- a/plugins/kapt3/kapt3-compiler/testData/converter/nestedClasses2.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/nestedClasses2.txt
@@ -92,13 +92,13 @@ public final class Experiment {
         super();
     }
 
-    @kotlin.Metadata()
     @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+    @kotlin.Metadata()
     public static abstract @interface Type {
     }
 
-    @kotlin.Metadata()
     @Experiment.Type()
+    @kotlin.Metadata()
     public static final class Group {
         @org.jetbrains.annotations.NotNull()
         private java.lang.String s;
@@ -120,8 +120,8 @@ public final class Experiment {
             return 0;
         }
 
-        @org.jetbrains.annotations.NotNull()
         @java.lang.Override()
+        @org.jetbrains.annotations.NotNull()
         public java.lang.String toString() {
             return null;
         }
@@ -189,15 +189,15 @@ public abstract interface IFoo {
     @kotlin.Metadata()
     public static abstract interface IBar {
 
-        @kotlin.Metadata()
         @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+        @kotlin.Metadata()
         public static abstract @interface Anno {
 
             public abstract java.lang.Class<?>[] value();
         }
 
-        @kotlin.Metadata()
         @IFoo.IBar.Anno(value = {IFoo.IBar.IZoo.class})
+        @kotlin.Metadata()
         public static abstract interface IZoo {
         }
     }
@@ -284,8 +284,8 @@ public class JavaClass {
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @IFoo.IBar.Anno(value = {IFoo.IBar.IZoo.class, Foo.Bar.class})
+@kotlin.Metadata()
 public final class Test1 extends Foo.Bar implements IFoo.IBar, IFoo.IBar.IZoo {
     @org.jetbrains.annotations.NotNull()
     private final Foo.Bar.Zoo zoo = null;

--- a/plugins/kapt3/kapt3-compiler/testData/converter/nestedClasses2_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/nestedClasses2_ir.txt
@@ -92,13 +92,13 @@ public final class Experiment {
         super();
     }
 
-    @kotlin.Metadata()
     @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+    @kotlin.Metadata()
     public static abstract @interface Type {
     }
 
-    @kotlin.Metadata()
     @Experiment.Type()
+    @kotlin.Metadata()
     public static final class Group {
         @org.jetbrains.annotations.NotNull()
         private java.lang.String s;
@@ -139,8 +139,8 @@ public final class Experiment {
             return 0;
         }
 
-        @org.jetbrains.annotations.NotNull()
         @java.lang.Override()
+        @org.jetbrains.annotations.NotNull()
         public java.lang.String toString() {
             return null;
         }
@@ -189,15 +189,15 @@ public abstract interface IFoo {
     @kotlin.Metadata()
     public static abstract interface IBar {
 
-        @kotlin.Metadata()
         @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+        @kotlin.Metadata()
         public static abstract @interface Anno {
 
             public abstract java.lang.Class<?>[] value();
         }
 
-        @kotlin.Metadata()
         @IFoo.IBar.Anno(value = {IFoo.IBar.IZoo.class})
+        @kotlin.Metadata()
         public static abstract interface IZoo {
         }
     }
@@ -284,8 +284,8 @@ public class JavaClass {
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @IFoo.IBar.Anno(value = {IFoo.IBar.IZoo.class, Foo.Bar.class})
+@kotlin.Metadata()
 public final class Test1 extends Foo.Bar implements IFoo.IBar, IFoo.IBar.IZoo {
     @org.jetbrains.annotations.NotNull()
     private final Foo.Bar.Zoo zoo = null;

--- a/plugins/kapt3/kapt3-compiler/testData/converter/nestedClassesNonRootPackage.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/nestedClassesNonRootPackage.txt
@@ -95,13 +95,13 @@ public final class Experiment {
         super();
     }
 
-    @kotlin.Metadata()
     @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+    @kotlin.Metadata()
     public static abstract @interface Type {
     }
 
-    @kotlin.Metadata()
     @test.Experiment.Type()
+    @kotlin.Metadata()
     public static final class Group {
         @org.jetbrains.annotations.NotNull()
         private final java.lang.String s = null;
@@ -123,8 +123,8 @@ public final class Experiment {
             return 0;
         }
 
-        @org.jetbrains.annotations.NotNull()
         @java.lang.Override()
+        @org.jetbrains.annotations.NotNull()
         public java.lang.String toString() {
             return null;
         }
@@ -190,15 +190,15 @@ public abstract interface IFoo {
     @kotlin.Metadata()
     public static abstract interface IBar {
 
-        @kotlin.Metadata()
         @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+        @kotlin.Metadata()
         public static abstract @interface Anno {
 
             public abstract java.lang.Class<?>[] value();
         }
 
-        @kotlin.Metadata()
         @test.IFoo.IBar.Anno(value = {test.IFoo.IBar.IZoo.class})
+        @kotlin.Metadata()
         public static abstract interface IZoo {
         }
     }
@@ -288,8 +288,8 @@ package test;
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @test.IFoo.IBar.Anno(value = {test.IFoo.IBar.IZoo.class, test.Foo.Bar.class})
+@kotlin.Metadata()
 public final class Test1 extends test.Foo.Bar implements test.IFoo.IBar, test.IFoo.IBar.IZoo {
     @org.jetbrains.annotations.NotNull()
     private final test.Foo.Bar.Zoo zoo = null;

--- a/plugins/kapt3/kapt3-compiler/testData/converter/nestedClassesNonRootPackage_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/nestedClassesNonRootPackage_ir.txt
@@ -95,13 +95,13 @@ public final class Experiment {
         super();
     }
 
-    @kotlin.Metadata()
     @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+    @kotlin.Metadata()
     public static abstract @interface Type {
     }
 
-    @kotlin.Metadata()
     @test.Experiment.Type()
+    @kotlin.Metadata()
     public static final class Group {
         @org.jetbrains.annotations.NotNull()
         private final java.lang.String s = null;
@@ -138,8 +138,8 @@ public final class Experiment {
             return 0;
         }
 
-        @org.jetbrains.annotations.NotNull()
         @java.lang.Override()
+        @org.jetbrains.annotations.NotNull()
         public java.lang.String toString() {
             return null;
         }
@@ -190,15 +190,15 @@ public abstract interface IFoo {
     @kotlin.Metadata()
     public static abstract interface IBar {
 
-        @kotlin.Metadata()
         @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+        @kotlin.Metadata()
         public static abstract @interface Anno {
 
             public abstract java.lang.Class<?>[] value();
         }
 
-        @kotlin.Metadata()
         @test.IFoo.IBar.Anno(value = {test.IFoo.IBar.IZoo.class})
+        @kotlin.Metadata()
         public static abstract interface IZoo {
         }
     }
@@ -288,8 +288,8 @@ package test;
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @test.IFoo.IBar.Anno(value = {test.IFoo.IBar.IZoo.class, test.Foo.Bar.class})
+@kotlin.Metadata()
 public final class Test1 extends test.Foo.Bar implements test.IFoo.IBar, test.IFoo.IBar.IZoo {
     @org.jetbrains.annotations.NotNull()
     private final test.Foo.Bar.Zoo zoo = null;

--- a/plugins/kapt3/kapt3-compiler/testData/converter/nonExistentClass.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/nonExistentClass.txt
@@ -1,7 +1,7 @@
 import java.lang.System;
 
-@kotlin.Suppress(names = {"UNRESOLVED_REFERENCE"})
 @kotlin.Metadata()
+@kotlin.Suppress(names = {"UNRESOLVED_REFERENCE"})
 public final class NonExistentType {
     @org.jetbrains.annotations.NotNull()
     public static final NonExistentType INSTANCE = null;

--- a/plugins/kapt3/kapt3-compiler/testData/converter/nonExistentClassTypesConversion.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/nonExistentClassTypesConversion.txt
@@ -1,8 +1,8 @@
 import java.util.Calendar;
 import kotlin.reflect.KClass;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface Anno {
 
     public abstract java.lang.Class<?> a();
@@ -34,8 +34,8 @@ public final class MyType<T extends java.lang.Object> {
 import java.util.Calendar;
 import kotlin.reflect.KClass;
 
-@kotlin.Suppress(names = {"UNRESOLVED_REFERENCE", "ANNOTATION_ARGUMENT_MUST_BE_CONST", "NON_CONST_VAL_USED_IN_CONSTANT_EXPRESSION", "UNSUPPORTED_FEATURE"})
 @kotlin.Metadata()
+@kotlin.Suppress(names = {"UNRESOLVED_REFERENCE", "ANNOTATION_ARGUMENT_MUST_BE_CONST", "NON_CONST_VAL_USED_IN_CONSTANT_EXPRESSION", "UNSUPPORTED_FEATURE"})
 public final class NonExistentClassTypesConversionKt {
 }
 
@@ -45,8 +45,8 @@ public final class NonExistentClassTypesConversionKt {
 import java.util.Calendar;
 import kotlin.reflect.KClass;
 
-@kotlin.Metadata()
 @Anno(a = Blah.class, b = {NoFoo1.class, NoBar1.class}, c = {NoFoo2.class, kotlin.String.class}, d = {kotlin.Boolean.class, NoBar3.class})
+@kotlin.Metadata()
 public final class Test<G extends java.lang.Object> {
     public ABC a;
     @org.jetbrains.annotations.Nullable()

--- a/plugins/kapt3/kapt3-compiler/testData/converter/nonExistentClassWIthoutCorrection.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/nonExistentClassWIthoutCorrection.txt
@@ -1,7 +1,7 @@
 import java.lang.System;
 
-@kotlin.Suppress(names = {"UNRESOLVED_REFERENCE"})
 @kotlin.Metadata()
+@kotlin.Suppress(names = {"UNRESOLVED_REFERENCE"})
 public final class NonExistentClassWIthoutCorrectionKt {
 }
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/nonExistentClassWIthoutCorrection_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/nonExistentClassWIthoutCorrection_ir.txt
@@ -1,7 +1,7 @@
 import java.lang.System;
 
-@kotlin.Suppress(names = {"UNRESOLVED_REFERENCE"})
 @kotlin.Metadata()
+@kotlin.Suppress(names = {"UNRESOLVED_REFERENCE"})
 public final class NonExistentClassWIthoutCorrectionKt {
 }
 

--- a/plugins/kapt3/kapt3-compiler/testData/converter/nonExistentClass_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/nonExistentClass_ir.txt
@@ -1,7 +1,7 @@
 import java.lang.System;
 
-@kotlin.Suppress(names = {"UNRESOLVED_REFERENCE"})
 @kotlin.Metadata()
+@kotlin.Suppress(names = {"UNRESOLVED_REFERENCE"})
 public final class NonExistentType {
     @org.jetbrains.annotations.Nullable()
     private static final ABCDEF a = null;

--- a/plugins/kapt3/kapt3-compiler/testData/converter/propertyAnnotations.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/propertyAnnotations.txt
@@ -1,7 +1,7 @@
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface Anno {
 }
 
@@ -10,10 +10,10 @@ public abstract @interface Anno {
 
 import java.lang.System;
 
-@kotlin.Metadata()
-@java.lang.annotation.Target(value = {java.lang.annotation.ElementType.TYPE})
-@java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
 @kotlin.annotation.Target(allowedTargets = {kotlin.annotation.AnnotationTarget.PROPERTY, kotlin.annotation.AnnotationTarget.CLASS})
+@java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@java.lang.annotation.Target(value = {java.lang.annotation.ElementType.TYPE})
+@kotlin.Metadata()
 public abstract @interface Anno2 {
 }
 
@@ -36,8 +36,8 @@ public final class Test {
         return null;
     }
 
-    @Anno2()
     @Anno()
+    @Anno2()
     @java.lang.Deprecated()
     public static void getProp$annotations() {
     }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/recentlyNullable.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/recentlyNullable.txt
@@ -38,8 +38,8 @@ public final class KBox implements androidx.annotation.Box {
         return null;
     }
 
-    @androidx.annotation.RecentlyNullable()
     @java.lang.Override()
+    @androidx.annotation.RecentlyNullable()
     public java.lang.String foo() {
         return null;
     }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/repeatableAnnotations.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/repeatableAnnotations.txt
@@ -1,7 +1,7 @@
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface AnnoArray {
 
     public abstract int x();
@@ -14,8 +14,8 @@ public abstract @interface AnnoArray {
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface AnnoBoolean {
 
     public abstract int x();
@@ -28,8 +28,8 @@ public abstract @interface AnnoBoolean {
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface AnnoChar {
 
     public abstract int x();
@@ -42,8 +42,8 @@ public abstract @interface AnnoChar {
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface AnnoClass {
 
     public abstract int x();
@@ -56,8 +56,8 @@ public abstract @interface AnnoClass {
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface AnnoDouble {
 
     public abstract int x();
@@ -70,8 +70,8 @@ public abstract @interface AnnoDouble {
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface AnnoEnum {
 
     public abstract int x();
@@ -84,8 +84,8 @@ public abstract @interface AnnoEnum {
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface AnnoFloat {
 
     public abstract int x();
@@ -98,8 +98,8 @@ public abstract @interface AnnoFloat {
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface AnnoInt {
 
     public abstract int x();
@@ -112,8 +112,8 @@ public abstract @interface AnnoInt {
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface AnnoIntArray {
 
     public abstract int x();
@@ -126,8 +126,8 @@ public abstract @interface AnnoIntArray {
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface AnnoLong {
 
     public abstract int x();
@@ -140,8 +140,8 @@ public abstract @interface AnnoLong {
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface AnnoLongArray {
 
     public abstract int x();
@@ -154,8 +154,8 @@ public abstract @interface AnnoLongArray {
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface AnnoString {
 
     public abstract int x();
@@ -195,9 +195,9 @@ public final class Test {
         return null;
     }
 
-    @lib.Anno(value = "3", construct = {"C"})
-    @lib.Anno(value = "2", construct = {"A", "B"})
     @lib.Anno(value = "1")
+    @lib.Anno(value = "2", construct = {"A", "B"})
+    @lib.Anno(value = "3", construct = {"C"})
     @java.lang.Deprecated()
     public static void getValue$annotations() {
     }
@@ -208,17 +208,17 @@ public final class Test {
 
 import java.lang.System;
 
-@kotlin.Metadata()
-@AnnoClass(x = lib.R.id.textView, c = Color.class)
-@AnnoArray(x = lib.R.id.textView, a = {"A", "B"})
-@AnnoLongArray(x = lib.R.id.textView, b = {1L, 3L})
-@AnnoIntArray(x = lib.R.id.textView, b = {1, 2, 3})
-@AnnoString(x = lib.R.id.textView, s = "AAA")
-@AnnoDouble(x = lib.R.id.textView, dbl = 4.0)
-@AnnoFloat(x = lib.R.id.textView, flt = 1.0F)
-@AnnoInt(x = lib.R.id.textView, i = 5)
-@AnnoBoolean(x = lib.R.id.textView, bool = false)
 @AnnoChar(x = lib.R.id.textView, chr = 'c')
+@AnnoBoolean(x = lib.R.id.textView, bool = false)
+@AnnoInt(x = lib.R.id.textView, i = 5)
+@AnnoFloat(x = lib.R.id.textView, flt = 1.0F)
+@AnnoDouble(x = lib.R.id.textView, dbl = 4.0)
+@AnnoString(x = lib.R.id.textView, s = "AAA")
+@AnnoIntArray(x = lib.R.id.textView, b = {1, 2, 3})
+@AnnoLongArray(x = lib.R.id.textView, b = {1L, 3L})
+@AnnoArray(x = lib.R.id.textView, a = {"A", "B"})
+@AnnoClass(x = lib.R.id.textView, c = Color.class)
+@kotlin.Metadata()
 public final class Test2 {
 
     public Test2() {

--- a/plugins/kapt3/kapt3-compiler/testData/converter/secondaryConstructor.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/secondaryConstructor.txt
@@ -20,8 +20,8 @@ public final class Product2 implements secondary.Named {
     @org.jetbrains.annotations.Nullable()
     private java.lang.String name;
 
-    @org.jetbrains.annotations.Nullable()
     @java.lang.Override()
+    @org.jetbrains.annotations.Nullable()
     public java.lang.String getName() {
         return null;
     }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/strangeIdentifiers.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/strangeIdentifiers.txt
@@ -1,7 +1,7 @@
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface Anno {
 
     public abstract StrangeEnum size();

--- a/plugins/kapt3/kapt3-compiler/testData/converter/strangeIdentifiers_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/strangeIdentifiers_ir.txt
@@ -1,7 +1,7 @@
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface Anno {
 
     public abstract StrangeEnum size();

--- a/plugins/kapt3/kapt3-compiler/testData/converter/stripMetadata.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/stripMetadata.txt
@@ -31,8 +31,8 @@ public final class Inheritor extends BaseClass {
         super(null, 0, false);
     }
 
-    @org.jetbrains.annotations.NotNull()
     @java.lang.Override()
+    @org.jetbrains.annotations.NotNull()
     public Result doJob() {
         return null;
     }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/topLevel.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/topLevel.txt
@@ -2,8 +2,8 @@ package test.another;
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface Anno {
 
     public abstract java.lang.String value();
@@ -43,12 +43,12 @@ public final class TopLevelKt {
         return null;
     }
 
-    public static final void extensionFunction(@org.jetbrains.annotations.NotNull()
-    @Anno(value = "rec")
-    java.lang.String $this$extensionFunction, @org.jetbrains.annotations.NotNull()
-    @Anno(value = "1")
-    java.lang.String a, @org.jetbrains.annotations.NotNull()
-    @Anno(value = "2")
+    public static final void extensionFunction(@Anno(value = "rec")
+    @org.jetbrains.annotations.NotNull()
+    java.lang.String $this$extensionFunction, @Anno(value = "1")
+    @org.jetbrains.annotations.NotNull()
+    java.lang.String a, @Anno(value = "2")
+    @org.jetbrains.annotations.NotNull()
     java.lang.String b) {
     }
 
@@ -58,16 +58,16 @@ public final class TopLevelKt {
     }
 
     @org.jetbrains.annotations.NotNull()
-    public static final <T extends java.lang.Object>java.lang.String getExtensionProperty(@org.jetbrains.annotations.NotNull()
-    @Anno(value = "propRec")
+    public static final <T extends java.lang.Object>java.lang.String getExtensionProperty(@Anno(value = "propRec")
+    @org.jetbrains.annotations.NotNull()
     T $this$extensionProperty) {
         return null;
     }
 
-    public static final <T extends java.lang.Object>void setExtensionProperty(@org.jetbrains.annotations.NotNull()
-    @Anno(value = "propRec")
-    T $this$extensionProperty, @org.jetbrains.annotations.NotNull()
-    @Anno(value = "setparam")
+    public static final <T extends java.lang.Object>void setExtensionProperty(@Anno(value = "propRec")
+    @org.jetbrains.annotations.NotNull()
+    T $this$extensionProperty, @Anno(value = "setparam")
+    @org.jetbrains.annotations.NotNull()
     java.lang.String setParamName) {
     }
 }

--- a/plugins/kapt3/kapt3-compiler/testData/converter/topLevel_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/topLevel_ir.txt
@@ -2,8 +2,8 @@ package test.another;
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface Anno {
 
     public abstract java.lang.String value();
@@ -43,26 +43,26 @@ public final class TopLevelKt {
         return null;
     }
 
-    public static final void extensionFunction(@org.jetbrains.annotations.NotNull()
-    @Anno(value = "rec")
-    java.lang.String $this$extensionFunction, @org.jetbrains.annotations.NotNull()
-    @Anno(value = "1")
-    java.lang.String a, @org.jetbrains.annotations.NotNull()
-    @Anno(value = "2")
+    public static final void extensionFunction(@Anno(value = "rec")
+    @org.jetbrains.annotations.NotNull()
+    java.lang.String $this$extensionFunction, @Anno(value = "1")
+    @org.jetbrains.annotations.NotNull()
+    java.lang.String a, @Anno(value = "2")
+    @org.jetbrains.annotations.NotNull()
     java.lang.String b) {
     }
 
     @org.jetbrains.annotations.NotNull()
-    public static final <T extends java.lang.Object>java.lang.String getExtensionProperty(@org.jetbrains.annotations.NotNull()
-    @Anno(value = "propRec")
+    public static final <T extends java.lang.Object>java.lang.String getExtensionProperty(@Anno(value = "propRec")
+    @org.jetbrains.annotations.NotNull()
     T $this$extensionProperty) {
         return null;
     }
 
-    public static final <T extends java.lang.Object>void setExtensionProperty(@org.jetbrains.annotations.NotNull()
-    @Anno(value = "propRec")
-    T $this$extensionProperty, @org.jetbrains.annotations.NotNull()
-    @Anno(value = "setparam")
+    public static final <T extends java.lang.Object>void setExtensionProperty(@Anno(value = "propRec")
+    @org.jetbrains.annotations.NotNull()
+    T $this$extensionProperty, @Anno(value = "setparam")
+    @org.jetbrains.annotations.NotNull()
     java.lang.String setParamName) {
     }
 

--- a/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/DefaultParameterValues.it.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/DefaultParameterValues.it.txt
@@ -9,19 +9,8 @@ package test;
 
 import java.lang.System;
 
-@kotlin.Metadata()
-@java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
-public abstract @interface Anno {
-}
-
-////////////////////
-
-package test;
-
-import java.lang.System;
-
-@kotlin.Metadata()
 @Anno()
+@kotlin.Metadata()
 public final class User {
     @org.jetbrains.annotations.NotNull()
     private final java.lang.String name = "John";
@@ -39,4 +28,15 @@ public final class User {
     public final java.lang.String getName() {
         return null;
     }
+}
+
+////////////////////
+
+package test;
+
+import java.lang.System;
+
+@java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
+public abstract @interface Anno {
 }

--- a/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/DefaultParameterValues.it_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/DefaultParameterValues.it_ir.txt
@@ -9,19 +9,8 @@ package test;
 
 import java.lang.System;
 
-@kotlin.Metadata()
-@java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
-public abstract @interface Anno {
-}
-
-////////////////////
-
-package test;
-
-import java.lang.System;
-
-@kotlin.Metadata()
 @Anno()
+@kotlin.Metadata()
 public final class User {
     @org.jetbrains.annotations.NotNull()
     private final java.lang.String name = "John";
@@ -39,4 +28,15 @@ public final class User {
     public User() {
         super();
     }
+}
+
+////////////////////
+
+package test;
+
+import java.lang.System;
+
+@java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
+public abstract @interface Anno {
 }

--- a/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/ErrorLocationMapping.it.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/ErrorLocationMapping.it.txt
@@ -1,7 +1,7 @@
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface MyAnnotation {
 }
 

--- a/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/NestedClasses.it.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/NestedClasses.it.txt
@@ -9,8 +9,8 @@ package test;
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface MyAnnotation {
 }
 

--- a/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/NestedClasses.it_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/NestedClasses.it_ir.txt
@@ -9,8 +9,8 @@ package test;
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface MyAnnotation {
 }
 

--- a/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/Overloads.it.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/Overloads.it.txt
@@ -9,19 +9,8 @@ package test;
 
 import java.lang.System;
 
-@kotlin.Metadata()
-@java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
-public abstract @interface MyAnnotation {
-}
-
-////////////////////
-
-package test;
-
-import java.lang.System;
-
-@kotlin.Metadata()
 @MyAnnotation()
+@kotlin.Metadata()
 public final class State {
     private final int someInt = 0;
     private final long someLong = 0L;
@@ -51,4 +40,15 @@ public final class State {
     public final java.lang.String getSomeString() {
         return null;
     }
+}
+
+////////////////////
+
+package test;
+
+import java.lang.System;
+
+@java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
+public abstract @interface MyAnnotation {
 }

--- a/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/Overloads.it_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/Overloads.it_ir.txt
@@ -9,19 +9,8 @@ package test;
 
 import java.lang.System;
 
-@kotlin.Metadata()
-@java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
-public abstract @interface MyAnnotation {
-}
-
-////////////////////
-
-package test;
-
-import java.lang.System;
-
-@kotlin.Metadata()
 @MyAnnotation()
+@kotlin.Metadata()
 public final class State {
     private final int someInt = 0;
     private final long someLong = 0L;
@@ -51,4 +40,15 @@ public final class State {
     public State(int someInt, long someLong) {
         super();
     }
+}
+
+////////////////////
+
+package test;
+
+import java.lang.System;
+
+@java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
+public abstract @interface MyAnnotation {
 }

--- a/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/Simple.it.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/Simple.it.txt
@@ -12,8 +12,8 @@ import java.lang.System;
 /**
  * KDoc comment.
  */
-@kotlin.Suppress(names = {"UNRESOLVED_REFERENCE"})
 @kotlin.Metadata()
+@kotlin.Suppress(names = {"UNRESOLVED_REFERENCE"})
 public final class Simple {
 
     public Simple() {
@@ -35,8 +35,8 @@ package test;
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface MyAnnotation {
 }
 

--- a/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/Simple.it_ir.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/kotlinRunner/Simple.it_ir.txt
@@ -12,8 +12,8 @@ import java.lang.System;
 /**
  * KDoc comment.
  */
-@kotlin.Suppress(names = {"UNRESOLVED_REFERENCE"})
 @kotlin.Metadata()
+@kotlin.Suppress(names = {"UNRESOLVED_REFERENCE"})
 public final class Simple {
 
     public Simple() {
@@ -35,8 +35,8 @@ package test;
 
 import java.lang.System;
 
-@kotlin.Metadata()
 @java.lang.annotation.Retention(value = java.lang.annotation.RetentionPolicy.RUNTIME)
+@kotlin.Metadata()
 public abstract @interface MyAnnotation {
 }
 

--- a/plugins/kapt3/kapt3-compiler/tests-gen/org/jetbrains/kotlin/kapt3/test/runners/ClassFileToSourceStubConverterTestGenerated.java
+++ b/plugins/kapt3/kapt3-compiler/tests-gen/org/jetbrains/kotlin/kapt3/test/runners/ClassFileToSourceStubConverterTestGenerated.java
@@ -338,6 +338,12 @@ public class ClassFileToSourceStubConverterTestGenerated extends AbstractClassFi
     }
 
     @Test
+    @TestMetadata("jvmRepeatableAnnotation.kt")
+    public void testJvmRepeatableAnnotation() throws Exception {
+        runTest("plugins/kapt3/kapt3-compiler/testData/converter/jvmRepeatableAnnotation.kt");
+    }
+
+    @Test
     @TestMetadata("jvmStatic.kt")
     public void testJvmStatic() throws Exception {
         runTest("plugins/kapt3/kapt3-compiler/testData/converter/jvmStatic.kt");

--- a/plugins/kapt3/kapt3-compiler/tests-gen/org/jetbrains/kotlin/kapt3/test/runners/IrClassFileToSourceStubConverterTestGenerated.java
+++ b/plugins/kapt3/kapt3-compiler/tests-gen/org/jetbrains/kotlin/kapt3/test/runners/IrClassFileToSourceStubConverterTestGenerated.java
@@ -338,6 +338,12 @@ public class IrClassFileToSourceStubConverterTestGenerated extends AbstractIrCla
     }
 
     @Test
+    @TestMetadata("jvmRepeatableAnnotation.kt")
+    public void testJvmRepeatableAnnotation() throws Exception {
+        runTest("plugins/kapt3/kapt3-compiler/testData/converter/jvmRepeatableAnnotation.kt");
+    }
+
+    @Test
     @TestMetadata("jvmStatic.kt")
     public void testJvmStatic() throws Exception {
         runTest("plugins/kapt3/kapt3-compiler/testData/converter/jvmStatic.kt");


### PR DESCRIPTION
Previously the annotations were included in reverse order. With this change they are kept in the same order as in the source file.

This changes the test case for KT-23427 but that issue seems to relate to annotation arguments that are missing, not the order of repeatable annotations.

This fixes KT-51087