### PR TITLE
KAPT: Fix error types for receivers and property setters in stubs

### DIFF
--- a/plugins/kapt3/kapt3-compiler/testData/converter/errorExtensionReceiver.kt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/errorExtensionReceiver.kt
@@ -1,0 +1,20 @@
+// CORRECT_ERROR_TYPES
+
+@Suppress("UNRESOLVED_REFERENCE")
+class TypeHook {
+    var customProperty: UnknownType
+        get() = UnknownType()
+        set(value) {}
+
+    var UnknownType.receiverProperty: UnknownType
+        get() = UnknownType()
+        set(value) {}
+
+    fun UnknownType.receiverFunction(): UnknownType = UnknownType()
+
+    companion object {
+        var UnknownType.extensionProperty: UnknownType
+            get() = UnknownType()
+            set(value) {}
+    }
+}

--- a/plugins/kapt3/kapt3-compiler/testData/converter/errorExtensionReceiver.txt
+++ b/plugins/kapt3/kapt3-compiler/testData/converter/errorExtensionReceiver.txt
@@ -1,0 +1,57 @@
+import java.lang.System;
+
+@kotlin.Metadata()
+@kotlin.Suppress(names = {"UNRESOLVED_REFERENCE"})
+public final class TypeHook {
+    @org.jetbrains.annotations.NotNull()
+    public static final TypeHook.Companion Companion = null;
+
+    public TypeHook() {
+        super();
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final UnknownType getCustomProperty() {
+        return null;
+    }
+
+    public final void setCustomProperty(@org.jetbrains.annotations.NotNull()
+    UnknownType value) {
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final UnknownType getReceiverProperty(@org.jetbrains.annotations.NotNull()
+    UnknownType $this$receiverProperty) {
+        return null;
+    }
+
+    public final void setReceiverProperty(@org.jetbrains.annotations.NotNull()
+    UnknownType $this$receiverProperty, @org.jetbrains.annotations.NotNull()
+    UnknownType value) {
+    }
+
+    @org.jetbrains.annotations.NotNull()
+    public final UnknownType receiverFunction(@org.jetbrains.annotations.NotNull()
+    UnknownType $this$receiverFunction) {
+        return null;
+    }
+
+    @kotlin.Metadata()
+    public static final class Companion {
+
+        private Companion() {
+            super();
+        }
+
+        @org.jetbrains.annotations.NotNull()
+        public final UnknownType getExtensionProperty(@org.jetbrains.annotations.NotNull()
+        UnknownType $this$extensionProperty) {
+            return null;
+        }
+
+        public final void setExtensionProperty(@org.jetbrains.annotations.NotNull()
+        UnknownType $this$extensionProperty, @org.jetbrains.annotations.NotNull()
+        UnknownType value) {
+        }
+    }
+}

--- a/plugins/kapt3/kapt3-compiler/tests-gen/org/jetbrains/kotlin/kapt3/test/runners/ClassFileToSourceStubConverterTestGenerated.java
+++ b/plugins/kapt3/kapt3-compiler/tests-gen/org/jetbrains/kotlin/kapt3/test/runners/ClassFileToSourceStubConverterTestGenerated.java
@@ -182,6 +182,12 @@ public class ClassFileToSourceStubConverterTestGenerated extends AbstractClassFi
     }
 
     @Test
+    @TestMetadata("errorExtensionReceiver.kt")
+    public void testErrorExtensionReceiver() throws Exception {
+        runTest("plugins/kapt3/kapt3-compiler/testData/converter/errorExtensionReceiver.kt");
+    }
+
+    @Test
     @TestMetadata("errorLocationMapping.kt")
     public void testErrorLocationMapping() throws Exception {
         runTest("plugins/kapt3/kapt3-compiler/testData/converter/errorLocationMapping.kt");

--- a/plugins/kapt3/kapt3-compiler/tests-gen/org/jetbrains/kotlin/kapt3/test/runners/IrClassFileToSourceStubConverterTestGenerated.java
+++ b/plugins/kapt3/kapt3-compiler/tests-gen/org/jetbrains/kotlin/kapt3/test/runners/IrClassFileToSourceStubConverterTestGenerated.java
@@ -182,6 +182,12 @@ public class IrClassFileToSourceStubConverterTestGenerated extends AbstractIrCla
     }
 
     @Test
+    @TestMetadata("errorExtensionReceiver.kt")
+    public void testErrorExtensionReceiver() throws Exception {
+        runTest("plugins/kapt3/kapt3-compiler/testData/converter/errorExtensionReceiver.kt");
+    }
+
+    @Test
     @TestMetadata("errorLocationMapping.kt")
     public void testErrorLocationMapping() throws Exception {
         runTest("plugins/kapt3/kapt3-compiler/testData/converter/errorLocationMapping.kt");


### PR DESCRIPTION
When using correct error types and there is a property setter or
receiver for an unknown type then the parameter type would be `Object` instead
of the error type.

This fixes [KT-46965](https://youtrack.jetbrains.com/issue/KT-46965/Kapt-correctErrorTypes-custom-setter-gets-Object-parameter-type) and [KT-46966](https://youtrack.jetbrains.com/issue/KT-46966/Kapt-correctErrorTypes-receiver-type-is-NonExistentClass).