### PR TITLE
FIR: erase captured types when checking override specificity

### DIFF
--- a/analysis/low-level-api-fir/tests/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/compiler/based/DiagnosisCompilerTestFE10TestdataTestGenerated.java
+++ b/analysis/low-level-api-fir/tests/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/compiler/based/DiagnosisCompilerTestFE10TestdataTestGenerated.java
@@ -29592,6 +29592,12 @@ public class DiagnosisCompilerTestFE10TestdataTestGenerated extends AbstractDiag
                 }
 
                 @Test
+                @TestMetadata("capturedSpecificity.kt")
+                public void testCapturedSpecificity() throws Exception {
+                    runTest("compiler/testData/diagnostics/tests/smartCasts/intersectionScope/capturedSpecificity.kt");
+                }
+
+                @Test
                 @TestMetadata("conflictTypeParameters.kt")
                 public void testConflictTypeParameters() throws Exception {
                     runTest("compiler/testData/diagnostics/tests/smartCasts/intersectionScope/conflictTypeParameters.kt");

--- a/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsTestGenerated.java
@@ -29592,6 +29592,12 @@ public class FirOldFrontendDiagnosticsTestGenerated extends AbstractFirDiagnosti
                 }
 
                 @Test
+                @TestMetadata("capturedSpecificity.kt")
+                public void testCapturedSpecificity() throws Exception {
+                    runTest("compiler/testData/diagnostics/tests/smartCasts/intersectionScope/capturedSpecificity.kt");
+                }
+
+                @Test
                 @TestMetadata("conflictTypeParameters.kt")
                 public void testConflictTypeParameters() throws Exception {
                     runTest("compiler/testData/diagnostics/tests/smartCasts/intersectionScope/conflictTypeParameters.kt");

--- a/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsWithLightTreeTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsWithLightTreeTestGenerated.java
@@ -29592,6 +29592,12 @@ public class FirOldFrontendDiagnosticsWithLightTreeTestGenerated extends Abstrac
                 }
 
                 @Test
+                @TestMetadata("capturedSpecificity.kt")
+                public void testCapturedSpecificity() throws Exception {
+                    runTest("compiler/testData/diagnostics/tests/smartCasts/intersectionScope/capturedSpecificity.kt");
+                }
+
+                @Test
                 @TestMetadata("conflictTypeParameters.kt")
                 public void testConflictTypeParameters() throws Exception {
                     runTest("compiler/testData/diagnostics/tests/smartCasts/intersectionScope/conflictTypeParameters.kt");

--- a/compiler/testData/diagnostics/tests/smartCasts/intersectionScope/capturedSpecificity.kt
+++ b/compiler/testData/diagnostics/tests/smartCasts/intersectionScope/capturedSpecificity.kt
@@ -1,0 +1,13 @@
+// FIR_IDENTICAL
+class C<T>(val value: T?)
+
+fun <T> assignable(x: () -> T) {}
+
+fun <V> foo(t: C<out Any>, v: C<out V>) {
+    assignable<V?> { v.value }
+    if (t == v) {
+        // `value: CapturedType(out V)?` <: `value: CapturedType(out Any)?` - same instantiation
+        assignable<V?> { v.value }
+        assignable<V?> { t.value }
+    }
+}

--- a/compiler/testData/diagnostics/tests/smartCasts/intersectionScope/capturedSpecificity.txt
+++ b/compiler/testData/diagnostics/tests/smartCasts/intersectionScope/capturedSpecificity.txt
@@ -1,0 +1,12 @@
+package
+
+public fun </*0*/ T> assignable(/*0*/ x: () -> T): kotlin.Unit
+public fun </*0*/ V> foo(/*0*/ t: C<out kotlin.Any>, /*1*/ v: C<out V>): kotlin.Unit
+
+public final class C</*0*/ T> {
+    public constructor C</*0*/ T>(/*0*/ value: T?)
+    public final val value: T?
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/DiagnosticTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/DiagnosticTestGenerated.java
@@ -29682,6 +29682,12 @@ public class DiagnosticTestGenerated extends AbstractDiagnosticTest {
                 }
 
                 @Test
+                @TestMetadata("capturedSpecificity.kt")
+                public void testCapturedSpecificity() throws Exception {
+                    runTest("compiler/testData/diagnostics/tests/smartCasts/intersectionScope/capturedSpecificity.kt");
+                }
+
+                @Test
                 @TestMetadata("conflictTypeParameters.kt")
                 public void testConflictTypeParameters() throws Exception {
                     runTest("compiler/testData/diagnostics/tests/smartCasts/intersectionScope/conflictTypeParameters.kt");


### PR DESCRIPTION
In this case the instantiations of these types are guaranteed to be the same, as there is only one runtime object on which both methods reside.

The situation where this is important can only be achieved with a very particular combination of types though - usually the smart casts required for this would not produce an intersection type as one of the types will be a strict subtype of another. The motivating code was not-really-correctly using java.lang.Class:

```kt
// technically should be `fun <T : Any> foo(x: Any, t: Class<out T>): T?`
fun <T> foo(x: Any, t: Class<T>): T? =
  // smart casts `t` to `Class<out Any> & Class<T>`; neither `cast(...): CT(out Any)..CT(out Any)?`
  // nor `cast(...): T&Any..T?` is more specific than the other, so the former is chosen and this
  // fails to type check
  if (x::class.java == t) t.cast(x) else null // could've just done an unchecked cast...
```

Note that in both FIR and FE1.0 there is also the general problem where sometimes intersection types in smart casts can make it so that a declaration has a completely different and unrelated type after a smart cast.

```kt
class C<T>(val value: T)

fun <T> assignable(x: () -> T) {}

fun <T, V> foo(t: C<out T>, v: C<out V>) {
  assignable<T> { t.value } // sure
  assignable<V> { v.value } // obviously
  if (t == v) {
    assignable<T> { t.value } // not anymore?
    assignable<V> { v.value } // also no?
    assignable<T> { v.value } // smart cast
    assignable<V> { t.value } // smart cast
  }
}
```

In this case the two base declarations of an intersection override are not ordered by specificity so which one is chosen depends on the intersection order, and it so happens that the original type comes last.