### PR TITLE
Avoid unnecessary configuration of commonizeNativeDistribution task

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/internal/KotlinNativePlatformDependencies.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/internal/KotlinNativePlatformDependencies.kt
@@ -61,7 +61,9 @@ internal fun Project.setupKotlinNativePlatformDependencies() {
 internal fun Project.getNativeDistributionDependencies(target: CommonizerTarget): FileCollection {
     return when (target) {
         is LeafCommonizerTarget -> getOriginalPlatformLibrariesFor(target)
-        is SharedCommonizerTarget -> commonizeNativeDistributionTask?.get()?.getCommonizedPlatformLibrariesFor(target) ?: project.files()
+        is SharedCommonizerTarget -> project.files(
+            commonizeNativeDistributionTask?.map { it.getCommonizedPlatformLibrariesFor(target) } ?: project.files()
+        )
     }
 }
 


### PR DESCRIPTION
Currently the task is realised during Gradle's configuration phase, even when it is not going to be executed.