### PR TITLE
Use default build-tool version in test projects

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidIcepickProject/app/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidIcepickProject/app/build.gradle
@@ -14,7 +14,6 @@ dependencies {
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.example.icepick.kotlin"

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidIncrementalMultiModule/app/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidIncrementalMultiModule/app/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.example"

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidIncrementalMultiModule/libAndroid/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidIncrementalMultiModule/libAndroid/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         minSdkVersion 14

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidIncrementalMultiModule/libAndroidClassesOnly/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidIncrementalMultiModule/libAndroidClassesOnly/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 14

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidIncrementalSingleModuleProject/app/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidIncrementalSingleModuleProject/app/build.gradle
@@ -16,7 +16,6 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.example"

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidJackProject/Android/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidJackProject/Android/build.gradle
@@ -9,7 +9,6 @@ dependencies {
 
 android {
     compileSdkVersion 22
-    buildToolsVersion "25.0.1"
 
     sourceSets {
         main.java.srcDirs += 'src/main/java2'

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidJackProject/Lib/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidJackProject/Lib/build.gradle
@@ -10,7 +10,6 @@ dependencies {
 
 android {
     compileSdkVersion 22
-    buildToolsVersion "25.0.1"
 
     defaultConfig {
         minSdkVersion 7

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidKaptChangingDependencies/aaa/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidKaptChangingDependencies/aaa/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         minSdkVersion 19

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidKaptChangingDependencies/app/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidKaptChangingDependencies/app/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.example.kapt"

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidKaptChangingDependencies/lib-a/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidKaptChangingDependencies/lib-a/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         minSdkVersion 19

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidLibraryKotlinProject/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidLibraryKotlinProject/build.gradle
@@ -23,7 +23,6 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "25.0.2"
 }
 
 dependencies {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidParcelizeProject/app/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidParcelizeProject/app/build.gradle
@@ -4,7 +4,6 @@ apply plugin: 'kotlin-parcelize'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.example.dagger.kotlin"

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidProject/Android/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidProject/Android/build.gradle
@@ -7,7 +7,6 @@ plugins {
 
 android {
     compileSdkVersion 22
-    buildToolsVersion "28.0.3"
 
     sourceSets {
         main.java.srcDirs += 'src/main/java2'

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidProject/Lib/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidProject/Lib/build.gradle
@@ -13,7 +13,6 @@ dependencies {
 
 android {
     compileSdkVersion 22
-    buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 7

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidProject/Test/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidProject/Test/build.gradle
@@ -11,7 +11,6 @@ dependencies {
 
 android {
     compileSdkVersion 22
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         minSdkVersion 7

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-databinding-androidX/app/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-databinding-androidX/app/build.gradle
@@ -4,7 +4,6 @@ apply plugin: 'kotlin-kapt'
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "25.0.2"
     defaultConfig {
         applicationId "com.example.databinding"
         minSdkVersion 21

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-databinding/app/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-databinding/app/build.gradle
@@ -4,7 +4,6 @@ apply plugin: 'kotlin-kapt'
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "25.0.2"
     defaultConfig {
         applicationId "com.example.databinding"
         minSdkVersion 21

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-databinding/library/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-databinding/library/build.gradle
@@ -4,7 +4,6 @@ apply plugin: 'kotlin-kapt'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion "27.0.3"
 
     defaultConfig {
         minSdkVersion 21

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-dbflow/app/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-dbflow/app/build.gradle
@@ -4,7 +4,6 @@ apply plugin: 'kotlin-kapt'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         minSdkVersion 14

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-inter-project-ic/app/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-inter-project-ic/app/build.gradle
@@ -4,7 +4,6 @@ apply plugin: 'kotlin-kapt'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "org.example.inter.project.ic"

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-inter-project-ic/lib-android/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-inter-project-ic/lib-android/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         minSdkVersion 15

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-realm/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-realm/build.gradle
@@ -23,7 +23,6 @@ apply plugin: 'realm-android'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "25.0.2"
     defaultConfig {
         applicationId 'io.realm.examples.kotlin'
         minSdkVersion 14

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/androidx-navigation-safe-args/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/androidx-navigation-safe-args/build.gradle
@@ -18,7 +18,6 @@ apply plugin: 'androidx.navigation.safeargs'
 
 android {
     compileSdkVersion 28
-    buildToolsVersion "28.0.3"
     defaultConfig {
         applicationId 'test.androidx.navigation'
         minSdkVersion 14

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/icAnonymousTypes/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/icAnonymousTypes/build.gradle
@@ -17,7 +17,6 @@ apply plugin: 'kotlin-kapt'
 
 android {
   compileSdkVersion 27
-  buildToolsVersion "27.0.3"
 
   defaultConfig {
     applicationId "org.kotlinlang.test"

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/kt15001/app/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/kt15001/app/build.gradle
@@ -4,7 +4,6 @@ apply plugin: 'kotlin-kapt'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.example.kt15001"

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinToolingMetadataAndroid/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinToolingMetadataAndroid/build.gradle.kts
@@ -11,7 +11,6 @@ repositories {
 
 android {
     compileSdkVersion(23)
-    buildToolsVersion("25.0.2")
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kt-35942-android/lib1/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kt-35942-android/lib1/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'kotlin-android'
 
 android {
   compileSdkVersion 26
-  buildToolsVersion "28.0.3"
 
   defaultConfig {
     minSdkVersion 26

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kt-35942-android/lib2/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kt-35942-android/lib2/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 26


### PR DESCRIPTION
AGP no longer require buildToolsVersion in configuration and uses a default version of build tools. By removing the hardcoded version from test projects make sure that the test runs with more recent build tools version.