### PR TITLE
docs: mod/rem: clarify who is dividend and divisor

### DIFF
--- a/core/builtins/native/kotlin/Primitives.kt
+++ b/core/builtins/native/kotlin/Primitives.kt
@@ -161,7 +161,7 @@ public class Byte private constructor() : Number(), Comparable<Byte> {
     public operator fun div(other: Double): Double
 
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is either zero or has the same sign as the _dividend_ and has the absolute value less than the absolute value of the divisor.
      */
@@ -169,7 +169,7 @@ public class Byte private constructor() : Number(), Comparable<Byte> {
     @kotlin.internal.IntrinsicConstEvaluation
     public operator fun rem(other: Byte): Int
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is either zero or has the same sign as the _dividend_ and has the absolute value less than the absolute value of the divisor.
      */
@@ -177,7 +177,7 @@ public class Byte private constructor() : Number(), Comparable<Byte> {
     @kotlin.internal.IntrinsicConstEvaluation
     public operator fun rem(other: Short): Int
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is either zero or has the same sign as the _dividend_ and has the absolute value less than the absolute value of the divisor.
      */
@@ -185,7 +185,7 @@ public class Byte private constructor() : Number(), Comparable<Byte> {
     @kotlin.internal.IntrinsicConstEvaluation
     public operator fun rem(other: Int): Int
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is either zero or has the same sign as the _dividend_ and has the absolute value less than the absolute value of the divisor.
      */
@@ -193,7 +193,7 @@ public class Byte private constructor() : Number(), Comparable<Byte> {
     @kotlin.internal.IntrinsicConstEvaluation
     public operator fun rem(other: Long): Long
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is either zero or has the same sign as the _dividend_ and has the absolute value less than the absolute value of the divisor.
      */
@@ -201,7 +201,7 @@ public class Byte private constructor() : Number(), Comparable<Byte> {
     @kotlin.internal.IntrinsicConstEvaluation
     public operator fun rem(other: Float): Float
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is either zero or has the same sign as the _dividend_ and has the absolute value less than the absolute value of the divisor.
      */
@@ -496,7 +496,7 @@ public class Short private constructor() : Number(), Comparable<Short> {
     public operator fun div(other: Double): Double
 
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is either zero or has the same sign as the _dividend_ and has the absolute value less than the absolute value of the divisor.
      */
@@ -504,7 +504,7 @@ public class Short private constructor() : Number(), Comparable<Short> {
     @kotlin.internal.IntrinsicConstEvaluation
     public operator fun rem(other: Byte): Int
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is either zero or has the same sign as the _dividend_ and has the absolute value less than the absolute value of the divisor.
      */
@@ -512,7 +512,7 @@ public class Short private constructor() : Number(), Comparable<Short> {
     @kotlin.internal.IntrinsicConstEvaluation
     public operator fun rem(other: Short): Int
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is either zero or has the same sign as the _dividend_ and has the absolute value less than the absolute value of the divisor.
      */
@@ -520,7 +520,7 @@ public class Short private constructor() : Number(), Comparable<Short> {
     @kotlin.internal.IntrinsicConstEvaluation
     public operator fun rem(other: Int): Int
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is either zero or has the same sign as the _dividend_ and has the absolute value less than the absolute value of the divisor.
      */
@@ -528,7 +528,7 @@ public class Short private constructor() : Number(), Comparable<Short> {
     @kotlin.internal.IntrinsicConstEvaluation
     public operator fun rem(other: Long): Long
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is either zero or has the same sign as the _dividend_ and has the absolute value less than the absolute value of the divisor.
      */
@@ -536,7 +536,7 @@ public class Short private constructor() : Number(), Comparable<Short> {
     @kotlin.internal.IntrinsicConstEvaluation
     public operator fun rem(other: Float): Float
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is either zero or has the same sign as the _dividend_ and has the absolute value less than the absolute value of the divisor.
      */
@@ -829,7 +829,7 @@ public class Int private constructor() : Number(), Comparable<Int> {
     public operator fun div(other: Double): Double
 
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is either zero or has the same sign as the _dividend_ and has the absolute value less than the absolute value of the divisor.
      */
@@ -837,7 +837,7 @@ public class Int private constructor() : Number(), Comparable<Int> {
     @kotlin.internal.IntrinsicConstEvaluation
     public operator fun rem(other: Byte): Int
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is either zero or has the same sign as the _dividend_ and has the absolute value less than the absolute value of the divisor.
      */
@@ -845,7 +845,7 @@ public class Int private constructor() : Number(), Comparable<Int> {
     @kotlin.internal.IntrinsicConstEvaluation
     public operator fun rem(other: Short): Int
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is either zero or has the same sign as the _dividend_ and has the absolute value less than the absolute value of the divisor.
      */
@@ -853,7 +853,7 @@ public class Int private constructor() : Number(), Comparable<Int> {
     @kotlin.internal.IntrinsicConstEvaluation
     public operator fun rem(other: Int): Int
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is either zero or has the same sign as the _dividend_ and has the absolute value less than the absolute value of the divisor.
      */
@@ -861,7 +861,7 @@ public class Int private constructor() : Number(), Comparable<Int> {
     @kotlin.internal.IntrinsicConstEvaluation
     public operator fun rem(other: Long): Long
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is either zero or has the same sign as the _dividend_ and has the absolute value less than the absolute value of the divisor.
      */
@@ -869,7 +869,7 @@ public class Int private constructor() : Number(), Comparable<Int> {
     @kotlin.internal.IntrinsicConstEvaluation
     public operator fun rem(other: Float): Float
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is either zero or has the same sign as the _dividend_ and has the absolute value less than the absolute value of the divisor.
      */
@@ -1204,7 +1204,7 @@ public class Long private constructor() : Number(), Comparable<Long> {
     public operator fun div(other: Double): Double
 
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is either zero or has the same sign as the _dividend_ and has the absolute value less than the absolute value of the divisor.
      */
@@ -1212,7 +1212,7 @@ public class Long private constructor() : Number(), Comparable<Long> {
     @kotlin.internal.IntrinsicConstEvaluation
     public operator fun rem(other: Byte): Long
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is either zero or has the same sign as the _dividend_ and has the absolute value less than the absolute value of the divisor.
      */
@@ -1220,7 +1220,7 @@ public class Long private constructor() : Number(), Comparable<Long> {
     @kotlin.internal.IntrinsicConstEvaluation
     public operator fun rem(other: Short): Long
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is either zero or has the same sign as the _dividend_ and has the absolute value less than the absolute value of the divisor.
      */
@@ -1228,7 +1228,7 @@ public class Long private constructor() : Number(), Comparable<Long> {
     @kotlin.internal.IntrinsicConstEvaluation
     public operator fun rem(other: Int): Long
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is either zero or has the same sign as the _dividend_ and has the absolute value less than the absolute value of the divisor.
      */
@@ -1236,7 +1236,7 @@ public class Long private constructor() : Number(), Comparable<Long> {
     @kotlin.internal.IntrinsicConstEvaluation
     public operator fun rem(other: Long): Long
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is either zero or has the same sign as the _dividend_ and has the absolute value less than the absolute value of the divisor.
      */
@@ -1244,7 +1244,7 @@ public class Long private constructor() : Number(), Comparable<Long> {
     @kotlin.internal.IntrinsicConstEvaluation
     public operator fun rem(other: Float): Float
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is either zero or has the same sign as the _dividend_ and has the absolute value less than the absolute value of the divisor.
      */
@@ -1598,7 +1598,7 @@ public class Float private constructor() : Number(), Comparable<Float> {
     public operator fun div(other: Double): Double
 
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is either zero or has the same sign as the _dividend_ and has the absolute value less than the absolute value of the divisor.
      */
@@ -1606,7 +1606,7 @@ public class Float private constructor() : Number(), Comparable<Float> {
     @kotlin.internal.IntrinsicConstEvaluation
     public operator fun rem(other: Byte): Float
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is either zero or has the same sign as the _dividend_ and has the absolute value less than the absolute value of the divisor.
      */
@@ -1614,7 +1614,7 @@ public class Float private constructor() : Number(), Comparable<Float> {
     @kotlin.internal.IntrinsicConstEvaluation
     public operator fun rem(other: Short): Float
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is either zero or has the same sign as the _dividend_ and has the absolute value less than the absolute value of the divisor.
      */
@@ -1622,7 +1622,7 @@ public class Float private constructor() : Number(), Comparable<Float> {
     @kotlin.internal.IntrinsicConstEvaluation
     public operator fun rem(other: Int): Float
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is either zero or has the same sign as the _dividend_ and has the absolute value less than the absolute value of the divisor.
      */
@@ -1630,7 +1630,7 @@ public class Float private constructor() : Number(), Comparable<Float> {
     @kotlin.internal.IntrinsicConstEvaluation
     public operator fun rem(other: Long): Float
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is either zero or has the same sign as the _dividend_ and has the absolute value less than the absolute value of the divisor.
      */
@@ -1638,7 +1638,7 @@ public class Float private constructor() : Number(), Comparable<Float> {
     @kotlin.internal.IntrinsicConstEvaluation
     public operator fun rem(other: Float): Float
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is either zero or has the same sign as the _dividend_ and has the absolute value less than the absolute value of the divisor.
      */
@@ -1900,7 +1900,7 @@ public class Double private constructor() : Number(), Comparable<Double> {
     public operator fun div(other: Double): Double
 
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is either zero or has the same sign as the _dividend_ and has the absolute value less than the absolute value of the divisor.
      */
@@ -1908,7 +1908,7 @@ public class Double private constructor() : Number(), Comparable<Double> {
     @kotlin.internal.IntrinsicConstEvaluation
     public operator fun rem(other: Byte): Double
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is either zero or has the same sign as the _dividend_ and has the absolute value less than the absolute value of the divisor.
      */
@@ -1916,7 +1916,7 @@ public class Double private constructor() : Number(), Comparable<Double> {
     @kotlin.internal.IntrinsicConstEvaluation
     public operator fun rem(other: Short): Double
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is either zero or has the same sign as the _dividend_ and has the absolute value less than the absolute value of the divisor.
      */
@@ -1924,7 +1924,7 @@ public class Double private constructor() : Number(), Comparable<Double> {
     @kotlin.internal.IntrinsicConstEvaluation
     public operator fun rem(other: Int): Double
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is either zero or has the same sign as the _dividend_ and has the absolute value less than the absolute value of the divisor.
      */
@@ -1932,7 +1932,7 @@ public class Double private constructor() : Number(), Comparable<Double> {
     @kotlin.internal.IntrinsicConstEvaluation
     public operator fun rem(other: Long): Double
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is either zero or has the same sign as the _dividend_ and has the absolute value less than the absolute value of the divisor.
      */
@@ -1940,7 +1940,7 @@ public class Double private constructor() : Number(), Comparable<Double> {
     @kotlin.internal.IntrinsicConstEvaluation
     public operator fun rem(other: Float): Double
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is either zero or has the same sign as the _dividend_ and has the absolute value less than the absolute value of the divisor.
      */

--- a/generators/builtins/primitives.kt
+++ b/generators/builtins/primitives.kt
@@ -71,14 +71,14 @@ class GeneratePrimitives(out: PrintWriter) : BuiltInsSourceGenerator(out) {
                 "Divides this value by the other value, flooring the result to an integer that is closer to negative infinity."
             "rem" -> {
                 """
-                Calculates the remainder of truncating division of this value by the other value.
+                Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
                 
                 The result is either zero or has the same sign as the _dividend_ and has the absolute value less than the absolute value of the divisor.
                 """.trimIndent()
             }
             "mod" -> {
                 """
-                Calculates the remainder of flooring division of this value by the other value.
+                Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
 
                 The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
                 """.trimIndent() + if (operand1.isFloatingPoint)

--- a/generators/builtins/unsignedTypes.kt
+++ b/generators/builtins/unsignedTypes.kt
@@ -41,14 +41,14 @@ class UnsignedTypeGenerator(val type: UnsignedType, out: PrintWriter) : BuiltIns
             """.trimIndent()
         "rem" -> {
             """
-                Calculates the remainder of truncating division of this value by the other value.
+                Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
                 
                 The result is always less than the divisor.
                 """.trimIndent()
         }
         "mod" -> {
             """
-                Calculates the remainder of flooring division of this value by the other value.
+                Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
 
                 The result is always less than the divisor.
                 

--- a/libraries/stdlib/src/kotlin/util/FloorDivMod.kt
+++ b/libraries/stdlib/src/kotlin/util/FloorDivMod.kt
@@ -19,7 +19,7 @@ public inline fun Byte.floorDiv(other: Byte): Int =
     this.toInt().floorDiv(other.toInt())
 
 /**
- * Calculates the remainder of flooring division of this value by the other value.
+ * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
  * 
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
  */
@@ -37,7 +37,7 @@ public inline fun Byte.floorDiv(other: Short): Int =
     this.toInt().floorDiv(other.toInt())
 
 /**
- * Calculates the remainder of flooring division of this value by the other value.
+ * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
  * 
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
  */
@@ -55,7 +55,7 @@ public inline fun Byte.floorDiv(other: Int): Int =
     this.toInt().floorDiv(other)
 
 /**
- * Calculates the remainder of flooring division of this value by the other value.
+ * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
  * 
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
  */
@@ -73,7 +73,7 @@ public inline fun Byte.floorDiv(other: Long): Long =
     this.toLong().floorDiv(other)
 
 /**
- * Calculates the remainder of flooring division of this value by the other value.
+ * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
  * 
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
  */
@@ -91,7 +91,7 @@ public inline fun Short.floorDiv(other: Byte): Int =
     this.toInt().floorDiv(other.toInt())
 
 /**
- * Calculates the remainder of flooring division of this value by the other value.
+ * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
  * 
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
  */
@@ -109,7 +109,7 @@ public inline fun Short.floorDiv(other: Short): Int =
     this.toInt().floorDiv(other.toInt())
 
 /**
- * Calculates the remainder of flooring division of this value by the other value.
+ * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
  * 
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
  */
@@ -127,7 +127,7 @@ public inline fun Short.floorDiv(other: Int): Int =
     this.toInt().floorDiv(other)
 
 /**
- * Calculates the remainder of flooring division of this value by the other value.
+ * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
  * 
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
  */
@@ -145,7 +145,7 @@ public inline fun Short.floorDiv(other: Long): Long =
     this.toLong().floorDiv(other)
 
 /**
- * Calculates the remainder of flooring division of this value by the other value.
+ * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
  * 
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
  */
@@ -163,7 +163,7 @@ public inline fun Int.floorDiv(other: Byte): Int =
     this.floorDiv(other.toInt())
 
 /**
- * Calculates the remainder of flooring division of this value by the other value.
+ * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
  * 
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
  */
@@ -181,7 +181,7 @@ public inline fun Int.floorDiv(other: Short): Int =
     this.floorDiv(other.toInt())
 
 /**
- * Calculates the remainder of flooring division of this value by the other value.
+ * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
  * 
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
  */
@@ -202,7 +202,7 @@ public inline fun Int.floorDiv(other: Int): Int {
 }
 
 /**
- * Calculates the remainder of flooring division of this value by the other value.
+ * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
  * 
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
  */
@@ -222,7 +222,7 @@ public inline fun Int.floorDiv(other: Long): Long =
     this.toLong().floorDiv(other)
 
 /**
- * Calculates the remainder of flooring division of this value by the other value.
+ * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
  * 
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
  */
@@ -240,7 +240,7 @@ public inline fun Long.floorDiv(other: Byte): Long =
     this.floorDiv(other.toLong())
 
 /**
- * Calculates the remainder of flooring division of this value by the other value.
+ * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
  * 
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
  */
@@ -258,7 +258,7 @@ public inline fun Long.floorDiv(other: Short): Long =
     this.floorDiv(other.toLong())
 
 /**
- * Calculates the remainder of flooring division of this value by the other value.
+ * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
  * 
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
  */
@@ -276,7 +276,7 @@ public inline fun Long.floorDiv(other: Int): Long =
     this.floorDiv(other.toLong())
 
 /**
- * Calculates the remainder of flooring division of this value by the other value.
+ * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
  * 
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
  */
@@ -297,7 +297,7 @@ public inline fun Long.floorDiv(other: Long): Long {
 }
 
 /**
- * Calculates the remainder of flooring division of this value by the other value.
+ * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
  * 
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
  */
@@ -310,7 +310,7 @@ public inline fun Long.mod(other: Long): Long {
 }
 
 /**
- * Calculates the remainder of flooring division of this value by the other value.
+ * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
  * 
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
  * 
@@ -325,7 +325,7 @@ public inline fun Float.mod(other: Float): Float {
 }
 
 /**
- * Calculates the remainder of flooring division of this value by the other value.
+ * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
  * 
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
  * 
@@ -338,7 +338,7 @@ public inline fun Float.mod(other: Double): Double =
     this.toDouble().mod(other)
 
 /**
- * Calculates the remainder of flooring division of this value by the other value.
+ * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
  * 
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
  * 
@@ -351,7 +351,7 @@ public inline fun Double.mod(other: Float): Double =
     this.mod(other.toDouble())
 
 /**
- * Calculates the remainder of flooring division of this value by the other value.
+ * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
  * 
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
  * 

--- a/libraries/stdlib/unsigned/src/kotlin/UByte.kt
+++ b/libraries/stdlib/unsigned/src/kotlin/UByte.kt
@@ -123,28 +123,28 @@ public value class UByte @kotlin.internal.IntrinsicConstEvaluation @PublishedApi
     public inline operator fun div(other: ULong): ULong = this.toULong().div(other)
 
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is always less than the divisor.
      */
     @kotlin.internal.InlineOnly
     public inline operator fun rem(other: UByte): UInt = this.toUInt().rem(other.toUInt())
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is always less than the divisor.
      */
     @kotlin.internal.InlineOnly
     public inline operator fun rem(other: UShort): UInt = this.toUInt().rem(other.toUInt())
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is always less than the divisor.
      */
     @kotlin.internal.InlineOnly
     public inline operator fun rem(other: UInt): UInt = this.toUInt().rem(other)
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is always less than the divisor.
      */
@@ -181,7 +181,7 @@ public value class UByte @kotlin.internal.IntrinsicConstEvaluation @PublishedApi
     public inline fun floorDiv(other: ULong): ULong = this.toULong().floorDiv(other)
 
     /**
-     * Calculates the remainder of flooring division of this value by the other value.
+     * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
      * 
      * The result is always less than the divisor.
      * 
@@ -190,7 +190,7 @@ public value class UByte @kotlin.internal.IntrinsicConstEvaluation @PublishedApi
     @kotlin.internal.InlineOnly
     public inline fun mod(other: UByte): UByte = this.toUInt().mod(other.toUInt()).toUByte()
     /**
-     * Calculates the remainder of flooring division of this value by the other value.
+     * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
      * 
      * The result is always less than the divisor.
      * 
@@ -199,7 +199,7 @@ public value class UByte @kotlin.internal.IntrinsicConstEvaluation @PublishedApi
     @kotlin.internal.InlineOnly
     public inline fun mod(other: UShort): UShort = this.toUInt().mod(other.toUInt()).toUShort()
     /**
-     * Calculates the remainder of flooring division of this value by the other value.
+     * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
      * 
      * The result is always less than the divisor.
      * 
@@ -208,7 +208,7 @@ public value class UByte @kotlin.internal.IntrinsicConstEvaluation @PublishedApi
     @kotlin.internal.InlineOnly
     public inline fun mod(other: UInt): UInt = this.toUInt().mod(other)
     /**
-     * Calculates the remainder of flooring division of this value by the other value.
+     * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
      * 
      * The result is always less than the divisor.
      * 

--- a/libraries/stdlib/unsigned/src/kotlin/UInt.kt
+++ b/libraries/stdlib/unsigned/src/kotlin/UInt.kt
@@ -123,28 +123,28 @@ public value class UInt @kotlin.internal.IntrinsicConstEvaluation @PublishedApi 
     public inline operator fun div(other: ULong): ULong = this.toULong().div(other)
 
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is always less than the divisor.
      */
     @kotlin.internal.InlineOnly
     public inline operator fun rem(other: UByte): UInt = this.rem(other.toUInt())
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is always less than the divisor.
      */
     @kotlin.internal.InlineOnly
     public inline operator fun rem(other: UShort): UInt = this.rem(other.toUInt())
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is always less than the divisor.
      */
     @kotlin.internal.InlineOnly
     public inline operator fun rem(other: UInt): UInt = uintRemainder(this, other)
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is always less than the divisor.
      */
@@ -181,7 +181,7 @@ public value class UInt @kotlin.internal.IntrinsicConstEvaluation @PublishedApi 
     public inline fun floorDiv(other: ULong): ULong = this.toULong().floorDiv(other)
 
     /**
-     * Calculates the remainder of flooring division of this value by the other value.
+     * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
      * 
      * The result is always less than the divisor.
      * 
@@ -190,7 +190,7 @@ public value class UInt @kotlin.internal.IntrinsicConstEvaluation @PublishedApi 
     @kotlin.internal.InlineOnly
     public inline fun mod(other: UByte): UByte = this.mod(other.toUInt()).toUByte()
     /**
-     * Calculates the remainder of flooring division of this value by the other value.
+     * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
      * 
      * The result is always less than the divisor.
      * 
@@ -199,7 +199,7 @@ public value class UInt @kotlin.internal.IntrinsicConstEvaluation @PublishedApi 
     @kotlin.internal.InlineOnly
     public inline fun mod(other: UShort): UShort = this.mod(other.toUInt()).toUShort()
     /**
-     * Calculates the remainder of flooring division of this value by the other value.
+     * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
      * 
      * The result is always less than the divisor.
      * 
@@ -208,7 +208,7 @@ public value class UInt @kotlin.internal.IntrinsicConstEvaluation @PublishedApi 
     @kotlin.internal.InlineOnly
     public inline fun mod(other: UInt): UInt = rem(other)
     /**
-     * Calculates the remainder of flooring division of this value by the other value.
+     * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
      * 
      * The result is always less than the divisor.
      * 

--- a/libraries/stdlib/unsigned/src/kotlin/ULong.kt
+++ b/libraries/stdlib/unsigned/src/kotlin/ULong.kt
@@ -123,28 +123,28 @@ public value class ULong @kotlin.internal.IntrinsicConstEvaluation @PublishedApi
     public inline operator fun div(other: ULong): ULong = ulongDivide(this, other)
 
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is always less than the divisor.
      */
     @kotlin.internal.InlineOnly
     public inline operator fun rem(other: UByte): ULong = this.rem(other.toULong())
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is always less than the divisor.
      */
     @kotlin.internal.InlineOnly
     public inline operator fun rem(other: UShort): ULong = this.rem(other.toULong())
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is always less than the divisor.
      */
     @kotlin.internal.InlineOnly
     public inline operator fun rem(other: UInt): ULong = this.rem(other.toULong())
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is always less than the divisor.
      */
@@ -181,7 +181,7 @@ public value class ULong @kotlin.internal.IntrinsicConstEvaluation @PublishedApi
     public inline fun floorDiv(other: ULong): ULong = div(other)
 
     /**
-     * Calculates the remainder of flooring division of this value by the other value.
+     * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
      * 
      * The result is always less than the divisor.
      * 
@@ -190,7 +190,7 @@ public value class ULong @kotlin.internal.IntrinsicConstEvaluation @PublishedApi
     @kotlin.internal.InlineOnly
     public inline fun mod(other: UByte): UByte = this.mod(other.toULong()).toUByte()
     /**
-     * Calculates the remainder of flooring division of this value by the other value.
+     * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
      * 
      * The result is always less than the divisor.
      * 
@@ -199,7 +199,7 @@ public value class ULong @kotlin.internal.IntrinsicConstEvaluation @PublishedApi
     @kotlin.internal.InlineOnly
     public inline fun mod(other: UShort): UShort = this.mod(other.toULong()).toUShort()
     /**
-     * Calculates the remainder of flooring division of this value by the other value.
+     * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
      * 
      * The result is always less than the divisor.
      * 
@@ -208,7 +208,7 @@ public value class ULong @kotlin.internal.IntrinsicConstEvaluation @PublishedApi
     @kotlin.internal.InlineOnly
     public inline fun mod(other: UInt): UInt = this.mod(other.toULong()).toUInt()
     /**
-     * Calculates the remainder of flooring division of this value by the other value.
+     * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
      * 
      * The result is always less than the divisor.
      * 

--- a/libraries/stdlib/unsigned/src/kotlin/UShort.kt
+++ b/libraries/stdlib/unsigned/src/kotlin/UShort.kt
@@ -123,28 +123,28 @@ public value class UShort @kotlin.internal.IntrinsicConstEvaluation @PublishedAp
     public inline operator fun div(other: ULong): ULong = this.toULong().div(other)
 
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is always less than the divisor.
      */
     @kotlin.internal.InlineOnly
     public inline operator fun rem(other: UByte): UInt = this.toUInt().rem(other.toUInt())
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is always less than the divisor.
      */
     @kotlin.internal.InlineOnly
     public inline operator fun rem(other: UShort): UInt = this.toUInt().rem(other.toUInt())
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is always less than the divisor.
      */
     @kotlin.internal.InlineOnly
     public inline operator fun rem(other: UInt): UInt = this.toUInt().rem(other)
     /**
-     * Calculates the remainder of truncating division of this value by the other value.
+     * Calculates the remainder of truncating division of this value (dividend) by the other value (divisor).
      * 
      * The result is always less than the divisor.
      */
@@ -181,7 +181,7 @@ public value class UShort @kotlin.internal.IntrinsicConstEvaluation @PublishedAp
     public inline fun floorDiv(other: ULong): ULong = this.toULong().floorDiv(other)
 
     /**
-     * Calculates the remainder of flooring division of this value by the other value.
+     * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
      * 
      * The result is always less than the divisor.
      * 
@@ -190,7 +190,7 @@ public value class UShort @kotlin.internal.IntrinsicConstEvaluation @PublishedAp
     @kotlin.internal.InlineOnly
     public inline fun mod(other: UByte): UByte = this.toUInt().mod(other.toUInt()).toUByte()
     /**
-     * Calculates the remainder of flooring division of this value by the other value.
+     * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
      * 
      * The result is always less than the divisor.
      * 
@@ -199,7 +199,7 @@ public value class UShort @kotlin.internal.IntrinsicConstEvaluation @PublishedAp
     @kotlin.internal.InlineOnly
     public inline fun mod(other: UShort): UShort = this.toUInt().mod(other.toUInt()).toUShort()
     /**
-     * Calculates the remainder of flooring division of this value by the other value.
+     * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
      * 
      * The result is always less than the divisor.
      * 
@@ -208,7 +208,7 @@ public value class UShort @kotlin.internal.IntrinsicConstEvaluation @PublishedAp
     @kotlin.internal.InlineOnly
     public inline fun mod(other: UInt): UInt = this.toUInt().mod(other)
     /**
-     * Calculates the remainder of flooring division of this value by the other value.
+     * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
      * 
      * The result is always less than the divisor.
      * 


### PR DESCRIPTION
When reading the [current docs for `mod`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/mod.html), I had to think about "now, which of the two operands is actually called _divisor_", as that term is just used in the second sentence, not in the first one.

> Calculates the remainder of flooring division of this value by the other value.
> 
> The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.

Now the first sentence includes "(dividend)" and "(divisor)", which makes it clear also for "mathematically challenged people" like me (or rather, people who don't have the English vocabulary for these terms at hand). The same change is done for `rem`.

For consistency, the same change is also done for the signed and unsigned primitives (even though there the sign question doesn't arise)

I also regenerated the files affected by this (using `../gradlew generateBuiltins` in the generators directory).