### PR TITLE
Use TestReport#destinationDirectory. Fixes KT-54221

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/testing/internal/KotlinTestsRegistry.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/testing/internal/KotlinTestsRegistry.kt
@@ -72,7 +72,7 @@ class KotlinTestsRegistry(val project: Project, val allTestsTaskName: String = "
             aggregate.description = description
             aggregate.group = JavaBasePlugin.VERIFICATION_GROUP
 
-            aggregate.destinationDir = project.testReportsDir.resolve(reportName)
+            aggregate.destinationDirectory.set(project.testReportsDir.resolve(reportName))
 
             val isIdeaActive = project.readSystemPropertyAtConfigurationTime("idea.active").isPresent
 


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-52490

TestReport#destinationDir has been removed in Gradle 8.0 and causes a runtime crash for KGP.