### PR TITLE
Psi2Ir: Fix unbound symbols and IrValidation issues

### DIFF
--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/CheckIrElementVisitor.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/CheckIrElementVisitor.kt
@@ -170,7 +170,6 @@ class CheckIrElementVisitor(
             returnType.classifier is IrClassSymbol &&
             returnType.arguments.isEmpty()
         ) {
-
             expression.ensureTypeIs(returnType)
         }
 
@@ -258,6 +257,7 @@ class CheckIrElementVisitor(
 
             val allDescriptors = declaration.descriptor.unsubstitutedMemberScope
                 .getContributedDescriptors().filterIsInstance<CallableMemberDescriptor>()
+                .filter { it.visibility != DescriptorVisibilities.INVISIBLE_FAKE }
 
             val presentDescriptors = declaration.declarations.map { it.descriptor }
 

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/phaser/DumperVerifier.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/phaser/DumperVerifier.kt
@@ -131,7 +131,7 @@ fun <Data, Context> dumpToStdout(
 
 val defaultDumper = makeDumpAction(dumpToStdout(::dumpIrElement) + dumpToFile("ir", ::dumpIrElement))
 
-fun <Fragment : IrElement> validationCallback(context: CommonBackendContext, fragment: Fragment, checkProperties: Boolean = false) {
+fun validationCallback(context: CommonBackendContext, fragment: IrElement, checkProperties: Boolean = false) {
     val validatorConfig = IrValidatorConfig(
         abortOnError = true,
         ensureAllNodesAreDifferent = true,

--- a/compiler/ir/backend.jvm/entrypoint/src/org/jetbrains/kotlin/backend/jvm/JvmIrCodegenFactory.kt
+++ b/compiler/ir/backend.jvm/entrypoint/src/org/jetbrains/kotlin/backend/jvm/JvmIrCodegenFactory.kt
@@ -161,31 +161,31 @@ open class JvmIrCodegenFactory(
             enableIdSignatures,
         )
 
-        val pluginContext by lazy {
-            psi2irContext.run {
-                IrPluginContextImpl(
-                    moduleDescriptor,
-                    bindingContext,
-                    languageVersionSettings,
-                    symbolTable,
-                    typeTranslator,
-                    irBuiltIns,
-                    irLinker,
-                    messageLogger
-                )
-            }
-        }
-
         SourceDeclarationsPreprocessor(psi2irContext).run(input.files)
 
-        for (extension in pluginExtensions) {
-            psi2ir.addPostprocessingStep { module ->
-                val old = stubGenerator.unboundSymbolGeneration
-                try {
-                    stubGenerator.unboundSymbolGeneration = true
-                    extension.generate(module, pluginContext)
-                } finally {
-                    stubGenerator.unboundSymbolGeneration = old
+        if (pluginExtensions.isNotEmpty()) {
+            // The plugin context contains unbound symbols right after construction and has to be
+            // instantiated before we resolve unbound symbols and invoke any postprocessing steps.
+            val pluginContext = IrPluginContextImpl(
+                psi2irContext.moduleDescriptor,
+                psi2irContext.bindingContext,
+                psi2irContext.languageVersionSettings,
+                symbolTable,
+                psi2irContext.typeTranslator,
+                psi2irContext.irBuiltIns,
+                irLinker,
+                messageLogger
+            )
+
+            for (extension in pluginExtensions) {
+                psi2ir.addPostprocessingStep { module ->
+                    val old = stubGenerator.unboundSymbolGeneration
+                    try {
+                        stubGenerator.unboundSymbolGeneration = true
+                        extension.generate(module, pluginContext)
+                    } finally {
+                        stubGenerator.unboundSymbolGeneration = old
+                    }
                 }
             }
         }

--- a/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/intermediate/PropertyLValue.kt
+++ b/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/intermediate/PropertyLValue.kt
@@ -173,9 +173,15 @@ class AccessorPropertyLValue(
 
     override fun store(irExpression: IrExpression) =
         callReceiver.adjustForCallee(setterDescriptor!!).call { dispatchReceiverValue, extensionReceiverValue, contextReceiverValues ->
+            // We translate getX/setX methods coming from Java into Kotlin properties, even if
+            // the setX call has a non-void return type.
+            val returnType = setterDescriptor.returnType?.let {
+                context.typeTranslator.translateType(it)
+            } ?: context.irBuiltIns.unitType
+
             IrCallImpl(
                 startOffset, endOffset,
-                context.irBuiltIns.unitType,
+                returnType,
                 setter!!, typeArgumentsCount,
                 1 + contextReceiverValues.size,
                 origin,

--- a/compiler/tests-common-new/tests/org/jetbrains/kotlin/test/services/CompilerConfigurationProvider.kt
+++ b/compiler/tests-common-new/tests/org/jetbrains/kotlin/test/services/CompilerConfigurationProvider.kt
@@ -11,6 +11,7 @@ import com.intellij.psi.search.GlobalSearchScope
 import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSourceLocation
+import org.jetbrains.kotlin.cli.common.messages.IrMessageCollector
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
 import org.jetbrains.kotlin.cli.jvm.compiler.JvmPackagePartProvider
@@ -21,6 +22,7 @@ import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.CompilerConfigurationKey
 import org.jetbrains.kotlin.config.languageVersionSettings
+import org.jetbrains.kotlin.ir.util.IrMessageLogger
 import org.jetbrains.kotlin.js.config.JSConfigurationKeys
 import org.jetbrains.kotlin.platform.TargetPlatform
 import org.jetbrains.kotlin.platform.isCommon
@@ -31,7 +33,6 @@ import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.test.TestInfrastructureInternals
 import org.jetbrains.kotlin.test.directives.JsEnvironmentConfigurationDirectives
 import org.jetbrains.kotlin.test.model.FrontendKinds
-import org.jetbrains.kotlin.test.model.TestFile
 import org.jetbrains.kotlin.test.model.TestModule
 import java.io.File
 
@@ -134,7 +135,7 @@ fun createCompilerConfiguration(module: TestModule, configurators: List<Abstract
         configuration[CommonConfigurationKeys.USE_FIR] = true
     }
 
-    configuration[CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY] = object : MessageCollector {
+    val messageCollector = object : MessageCollector {
         override fun clear() {}
 
         override fun report(severity: CompilerMessageSeverity, message: String, location: CompilerMessageSourceLocation?) {
@@ -146,6 +147,8 @@ fun createCompilerConfiguration(module: TestModule, configurators: List<Abstract
 
         override fun hasErrors(): Boolean = false
     }
+    configuration[CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY] = messageCollector
+    configuration[IrMessageLogger.IR_MESSAGE_LOGGER] = IrMessageCollector(messageCollector)
     configuration.languageVersionSettings = module.languageVersionSettings
 
     configurators.forEach { it.configureCompileConfigurationWithAdditionalConfigurationKeys(configuration, module) }


### PR DESCRIPTION
This PR contains a number of small fixes for invalid IR coming from Psi2Ir.

The background is that I ran into issues with invalid IR (specifically unbound symbols, see 06270dbe2ad4fae95882b24815fdd285ed57959b) in the Compose plugin. After fixing this problem I tried to turn on IR validation and unbound symbol checking in Psi2Ir. I found a couple of smaller issues which are also fixed in this PR, but didn't manage to turn on IR validation by default because of the following issues.
- [KT-54208](https://youtrack.jetbrains.com/issue/KT-54208/Missing-errors-for-unimplemented-interface-delegation-members): This is really a missing frontend error which results in invalid IR. This was apparently already well-known and had been filed as [KT-46120](https://youtrack.jetbrains.com/issue/KT-46120/AME-when-Java-interface-method-is-implemented-by-delegation-to-Java-class-where-corresponding-method-has-different-generic) a year ago. The main issue with fixing this is that we resolve interface delegation before type checking, so we'll need to introduce a diagnostic afterwards.
- [KT-54230](https://youtrack.jetbrains.com/issue/KT-54230/IR-IrDescriptorBasedFunctionFactory-produces-unbound-symbols): Some of the APIs in `IrBuiltIns` are currently broken and produce unbound symbols, which is potentially dangerous. Now, this would be trivial to fix on the JVM backend, but I couldn't figure out how to force the JS backend to ensure that the symbols for `kotlin.Function` and `kotlin.KFunction` are bound before we try to generate the synthetic `FunctionN` classes. Any help here would be much appreciated. :)
- `ScopeValidator` doesn't handle `IrScript`. This is easy enough to fix, but is probably better submitted as part of a PR to enable IR validation and actually use `ScopeValidator` for anything...