### PR TITLE
FIR: Implement moduleDescriptor in Fir2IrPluginContext

### DIFF
--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrConverter.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrConverter.kt
@@ -97,7 +97,7 @@ class Fir2IrConverter(
         }
 
         if (irGenerationExtensions.isNotEmpty()) {
-            val pluginContext = Fir2IrPluginContext(components)
+            val pluginContext = Fir2IrPluginContext(components, irModuleFragment.descriptor)
             for (extension in irGenerationExtensions) {
                 extension.generate(irModuleFragment, pluginContext)
             }

--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrPluginContext.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrPluginContext.kt
@@ -34,15 +34,16 @@ import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.platform.TargetPlatform
 import org.jetbrains.kotlin.resolve.BindingContext
 
-class Fir2IrPluginContext(private val components: Fir2IrComponents) : IrPluginContext {
+class Fir2IrPluginContext(
+    private val components: Fir2IrComponents,
+    descriptor: ModuleDescriptor
+) : IrPluginContext {
     companion object {
         private const val ERROR_MESSAGE = "This API is not supported for K2"
     }
 
     @ObsoleteDescriptorBasedAPI
-    @FirIncompatiblePluginAPI
-    override val moduleDescriptor: ModuleDescriptor
-        get() = error(ERROR_MESSAGE)
+    override val moduleDescriptor: ModuleDescriptor = descriptor
 
     @ObsoleteDescriptorBasedAPI
     @FirIncompatiblePluginAPI


### PR DESCRIPTION
A ModuleDescriptor is needed to create external package fragments with descriptors (see JvmSymbols.kt). Descriptorless external package fragments can fail in code using obsolete descriptor based APIs.