### PR TITLE
FIR: create substitution overrides for static Java members

### DIFF
--- a/compiler/fir/analysis-tests/testData/resolveWithStdlib/j+k/StaticFromBaseClass.fir.txt
+++ b/compiler/fir/analysis-tests/testData/resolveWithStdlib/j+k/StaticFromBaseClass.fir.txt
@@ -1,5 +1,5 @@
 FILE: main.kt
     public final fun test(): R|kotlin/Unit| {
-        lval project: R|kotlin/String| = Q|PlatformDataKeys|.R|/CommonDataKeys.PROJECT|
+        lval project: R|kotlin/String| = Q|PlatformDataKeys|.R|SubstitutionOverride</PlatformDataKeys.PROJECT>|
         lval member: R|kotlin/String!| = R|/PlatformDataKeys.PlatformDataKeys|().R|/CommonDataKeys.MEMBER|
     }

--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/generators/FakeOverrideGenerator.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/generators/FakeOverrideGenerator.kt
@@ -176,7 +176,7 @@ class FakeOverrideGenerator(
     }
 
     private fun FirCallableSymbol<*>.shouldHaveComputedBaseSymbolsForClass(classLookupTag: ConeClassLikeLookupTag): Boolean =
-        fir.origin.fromSupertypes && dispatchReceiverClassOrNull() == classLookupTag
+        fir.origin.fromSupertypes && containingClassLookupTag() == classLookupTag
 
     private inline fun <reified D : FirCallableDeclaration, reified S : FirCallableSymbol<D>, reified I : IrDeclaration> createFakeOverriddenIfNeeded(
         klass: FirClass,

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -28721,6 +28721,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
             public void testPackageProperty() throws Exception {
                 runTest("compiler/testData/codegen/box/javaVisibility/package/packageProperty.kt");
             }
+
+            @Test
+            @TestMetadata("publicInterfaceImplementedByPackagePrivateClass.kt")
+            public void testPublicInterfaceImplementedByPackagePrivateClass() throws Exception {
+                runTest("compiler/testData/codegen/box/javaVisibility/package/publicInterfaceImplementedByPackagePrivateClass.kt");
+            }
         }
 
         @Nested

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -28699,6 +28699,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
             }
 
             @Test
+            @TestMetadata("inheritedPackageStaticField.kt")
+            public void testInheritedPackageStaticField() throws Exception {
+                runTest("compiler/testData/codegen/box/javaVisibility/package/inheritedPackageStaticField.kt");
+            }
+
+            @Test
             @TestMetadata("kt2781.kt")
             public void testKt2781() throws Exception {
                 runTest("compiler/testData/codegen/box/javaVisibility/package/kt2781.kt");

--- a/compiler/fir/java/src/org/jetbrains/kotlin/fir/java/JavaScopeProvider.kt
+++ b/compiler/fir/java/src/org/jetbrains/kotlin/fir/java/JavaScopeProvider.kt
@@ -141,6 +141,7 @@ object JavaScopeProvider : FirScopeProvider() {
                 klass.symbol,
                 JavaClassStaticUseSiteScope(
                     useSiteSession,
+                    klass.symbol.toLookupTag(),
                     declaredMemberScope = declaredScope,
                     superClassScope, superTypesScopes,
                     klass.javaTypeParameterStack

--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/FirVisibilityChecker.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/FirVisibilityChecker.kt
@@ -87,7 +87,7 @@ abstract class FirVisibilityChecker : FirSessionComponent {
         supertypeSupplier: SupertypeSupplier = SupertypeSupplier.Default
     ): Boolean {
         if (!isSpecificDeclarationVisible(
-                declaration,
+                if (declaration is FirCallableDeclaration) declaration.originalOrSelf() else declaration,
                 session,
                 useSiteFile,
                 containingDeclarations,

--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/FirVisibilityChecker.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/FirVisibilityChecker.kt
@@ -148,9 +148,12 @@ abstract class FirVisibilityChecker : FirSessionComponent {
     ): FirClassLikeDeclaration? {
         return when (this) {
             is FirCallableDeclaration -> {
-                if (dispatchReceiverValue != null && dispatchReceiverType != null) {
-                    dispatchReceiverValue.type.findClassRepresentation(dispatchReceiverType!!, session)?.toSymbol(session)?.fir?.let {
-                        return it
+                if (dispatchReceiverValue != null) {
+                    val baseReceiverType = dispatchReceiverClassTypeOrNull()
+                    if (baseReceiverType != null) {
+                        dispatchReceiverValue.type.findClassRepresentation(baseReceiverType, session)?.toSymbol(session)?.fir?.let {
+                            return it
+                        }
                     }
                 }
 

--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/scopes/impl/FirFakeOverrideGenerator.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/scopes/impl/FirFakeOverrideGenerator.kt
@@ -456,7 +456,8 @@ object FirFakeOverrideGenerator {
         baseField: FirField,
         baseSymbol: FirFieldSymbol,
         newReturnType: ConeKotlinType?,
-        derivedClassId: ClassId?
+        derivedClassId: ClassId?,
+        withInitializer: Boolean = false
     ): FirFieldSymbol {
         val symbol = FirFieldSymbol(
             CallableId(derivedClassId ?: baseSymbol.callableId.classId!!, baseField.name)
@@ -476,6 +477,10 @@ object FirFakeOverrideGenerator {
             annotations += baseField.annotations
             attributes = baseField.attributes.copy()
             dispatchReceiverType = baseField.dispatchReceiverType
+            deprecationsProvider = baseField.deprecationsProvider
+            if (withInitializer) {
+                initializer = baseField.initializer
+            }
         }.apply {
             originalForSubstitutionOverrideAttr = baseField
         }

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/VisibilityUtils.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/VisibilityUtils.kt
@@ -28,26 +28,15 @@ fun FirVisibilityChecker.isVisible(
     declaration: FirMemberDeclaration,
     callInfo: CallInfo,
     dispatchReceiverValue: ReceiverValue?
-): Boolean {
-    if (declaration is FirCallableDeclaration && (declaration.isIntersectionOverride || declaration.isSubstitutionOverride)) {
-        @Suppress("UNCHECKED_CAST")
-        return isVisible(declaration.originalIfFakeOverride() as FirMemberDeclaration, callInfo, dispatchReceiverValue)
-    }
-
-    val useSiteFile = callInfo.containingFile
-    val containingDeclarations = callInfo.containingDeclarations
-    val session = callInfo.session
-
-    return isVisible(
+): Boolean =
+    isVisible(
         declaration,
-        session,
-        useSiteFile,
-        containingDeclarations,
+        callInfo.session,
+        callInfo.containingFile,
+        callInfo.containingDeclarations,
         dispatchReceiverValue,
         callInfo.callSite is FirVariableAssignment
     )
-
-}
 
 fun FirVisibilityChecker.isVisible(
     declaration: FirMemberDeclaration,
@@ -66,14 +55,7 @@ fun FirVisibilityChecker.isVisible(
 
     val backingField = declaration.getBackingFieldIfApplicable()
     if (backingField != null) {
-        candidate.hasVisibleBackingField = isVisible(
-            backingField,
-            callInfo.session,
-            callInfo.containingFile,
-            callInfo.containingDeclarations,
-            candidate.dispatchReceiverValue,
-            candidate.callInfo.callSite is FirVariableAssignment,
-        )
+        candidate.hasVisibleBackingField = isVisible(backingField, callInfo, candidate.dispatchReceiverValue)
     }
 
     return true

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/ClassMembers.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/ClassMembers.kt
@@ -19,11 +19,14 @@ fun FirCallableSymbol<*>.dispatchReceiverTypeOrNull(): ConeKotlinType? =
 fun FirCallableSymbol<*>.dispatchReceiverClassOrNull(): ConeClassLikeLookupTag? =
     fir.dispatchReceiverClassOrNull()
 
-fun FirCallableDeclaration.dispatchReceiverClassOrNull(): ConeClassLikeLookupTag? {
-    if (dispatchReceiverType is ConeIntersectionType && isIntersectionOverride) return symbol.baseForIntersectionOverride!!.fir.dispatchReceiverClassOrNull()
+fun FirCallableDeclaration.dispatchReceiverClassTypeOrNull(): ConeClassLikeType? =
+    if (dispatchReceiverType is ConeIntersectionType && isIntersectionOverride)
+        baseForIntersectionOverride!!.dispatchReceiverClassTypeOrNull()
+    else
+        dispatchReceiverType as? ConeClassLikeType
 
-    return (dispatchReceiverType as? ConeClassLikeType)?.lookupTag
-}
+fun FirCallableDeclaration.dispatchReceiverClassOrNull(): ConeClassLikeLookupTag? =
+    dispatchReceiverClassTypeOrNull()?.lookupTag
 
 fun FirCallableSymbol<*>.containingClassLookupTag(): ConeClassLikeLookupTag? = fir.containingClassLookupTag()
 fun FirCallableDeclaration.containingClassLookupTag(): ConeClassLikeLookupTag? {

--- a/compiler/testData/codegen/box/javaVisibility/package/inheritedPackageStaticField.kt
+++ b/compiler/testData/codegen/box/javaVisibility/package/inheritedPackageStaticField.kt
@@ -1,0 +1,18 @@
+// TARGET_BACKEND: JVM
+// ISSUE: KT-53441
+// MODULE: lib
+// FILE: test/J.java
+package test;
+
+interface I {
+    // Not a String to avoid constant inlining
+    public static String[] OK = new String[]{"OK"};
+}
+
+public class J implements I {}
+
+// MODULE: main(lib)
+// FILE: k.kt
+import test.J
+
+fun box() = J.OK[0] // accessible by JVM rules as J.OK, but not I.OK

--- a/compiler/testData/codegen/box/javaVisibility/package/publicInterfaceImplementedByPackagePrivateClass.kt
+++ b/compiler/testData/codegen/box/javaVisibility/package/publicInterfaceImplementedByPackagePrivateClass.kt
@@ -1,0 +1,33 @@
+// TARGET_PLATFORM: JVM
+// MODULE: lib
+// FILE: I.java
+package test;
+
+public interface I {
+    String foo();
+}
+
+// FILE: J.java
+package test;
+
+class JBase<T> {
+    public String foo() { return "OK"; }
+}
+
+public class J extends JBase<String> {}
+
+// FILE: JImpl.java
+package test;
+
+public class JImpl {
+    public static class C1 extends J implements I {}
+    public static class C2 extends J implements I {}
+}
+
+// MODULE: main(lib)
+// FILE: main.kt
+import test.JImpl
+
+fun <T> select(a: T, b: T): T = a
+
+fun box() = select(JImpl.C1(), JImpl.C2()).foo()

--- a/compiler/testData/codegen/bytecodeText/javaStatics.kt
+++ b/compiler/testData/codegen/bytecodeText/javaStatics.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND_FIR: JVM_IR
 // FILE: Child.java
 
 class Child extends Parent {

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -27887,6 +27887,12 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             public void testPackageProperty() throws Exception {
                 runTest("compiler/testData/codegen/box/javaVisibility/package/packageProperty.kt");
             }
+
+            @Test
+            @TestMetadata("publicInterfaceImplementedByPackagePrivateClass.kt")
+            public void testPublicInterfaceImplementedByPackagePrivateClass() throws Exception {
+                runTest("compiler/testData/codegen/box/javaVisibility/package/publicInterfaceImplementedByPackagePrivateClass.kt");
+            }
         }
 
         @Nested

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -27865,6 +27865,12 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
             }
 
             @Test
+            @TestMetadata("inheritedPackageStaticField.kt")
+            public void testInheritedPackageStaticField() throws Exception {
+                runTest("compiler/testData/codegen/box/javaVisibility/package/inheritedPackageStaticField.kt");
+            }
+
+            @Test
             @TestMetadata("kt2781.kt")
             public void testKt2781() throws Exception {
                 runTest("compiler/testData/codegen/box/javaVisibility/package/kt2781.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -28721,6 +28721,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             public void testPackageProperty() throws Exception {
                 runTest("compiler/testData/codegen/box/javaVisibility/package/packageProperty.kt");
             }
+
+            @Test
+            @TestMetadata("publicInterfaceImplementedByPackagePrivateClass.kt")
+            public void testPublicInterfaceImplementedByPackagePrivateClass() throws Exception {
+                runTest("compiler/testData/codegen/box/javaVisibility/package/publicInterfaceImplementedByPackagePrivateClass.kt");
+            }
         }
 
         @Nested

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -28699,6 +28699,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
             }
 
             @Test
+            @TestMetadata("inheritedPackageStaticField.kt")
+            public void testInheritedPackageStaticField() throws Exception {
+                runTest("compiler/testData/codegen/box/javaVisibility/package/inheritedPackageStaticField.kt");
+            }
+
+            @Test
             @TestMetadata("kt2781.kt")
             public void testKt2781() throws Exception {
                 runTest("compiler/testData/codegen/box/javaVisibility/package/kt2781.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -23577,6 +23577,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             public void testPackageProperty() throws Exception {
                 runTest("compiler/testData/codegen/box/javaVisibility/package/packageProperty.kt");
             }
+
+            @TestMetadata("publicInterfaceImplementedByPackagePrivateClass.kt")
+            public void testPublicInterfaceImplementedByPackagePrivateClass() throws Exception {
+                runTest("compiler/testData/codegen/box/javaVisibility/package/publicInterfaceImplementedByPackagePrivateClass.kt");
+            }
         }
 
         @TestMetadata("compiler/testData/codegen/box/javaVisibility/protectedAndPackage")

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -23558,6 +23558,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
                 KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/javaVisibility/package"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM, true);
             }
 
+            @TestMetadata("inheritedPackageStaticField.kt")
+            public void testInheritedPackageStaticField() throws Exception {
+                runTest("compiler/testData/codegen/box/javaVisibility/package/inheritedPackageStaticField.kt");
+            }
+
             @TestMetadata("kt2781.kt")
             public void testKt2781() throws Exception {
                 runTest("compiler/testData/codegen/box/javaVisibility/package/kt2781.kt");


### PR DESCRIPTION
Because static members have no receivers, the class through which the member is accessed has to be encoded in the declaration itself, and this seems like the most logical way to do this. And the class *needs* to be encoded because the supertype may be invisible, which causes false positive INVISIBLE_REFERENCE errors; even if those errors are ignored, a reference to the super class in the bytecode will cause a JVM access violation (whereas accessing the same member through the subclass is perfectly fine).

^KT-53441 Fixed