### PR TITLE
[KT-54284][Native] Produce deterministic klibs from cinterop.

### DIFF
--- a/kotlin-native/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/NativeIndex.kt
+++ b/kotlin-native/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/NativeIndex.kt
@@ -16,10 +16,10 @@
 
 package org.jetbrains.kotlin.native.interop.indexer
 
-enum class Language(val sourceFileExtension: String) {
-    C("c"),
-    CPP("cpp"),
-    OBJECTIVE_C("m")
+enum class Language(val sourceFileExtension: String, val clangLanguageName: String) {
+    C("c", "c"),
+    CPP("cpp", "c++"),
+    OBJECTIVE_C("m", "objective-c")
 }
 
 interface HeaderInclusionPolicy {

--- a/kotlin-native/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/main.kt
+++ b/kotlin-native/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/main.kt
@@ -105,9 +105,9 @@ private fun List<String>?.isTrue(): Boolean {
     return this?.last() == "true"
 }
 
-private fun runCmd(command: Array<String>, verbose: Boolean = false) {
+private fun runCmd(command: Array<String>, verbose: Boolean = false, redirectInputFile: File? = null) {
     if (verbose) println("COMMAND: " + command.joinToString(" "))
-    Command(*command).getOutputLines(true).let { lines ->
+    Command(command.toList(), redirectInputFile = redirectInputFile).getOutputLines(true).let { lines ->
         if (verbose) lines.forEach(::println)
     }
 }
@@ -385,8 +385,8 @@ private fun processCLib(flavor: KotlinPlatform, cinteropArguments: CInteropArgum
         KotlinPlatform.NATIVE -> {
             val outLib = File(nativeLibsDir, "$libName.bc")
             val compilerCmd = arrayOf(compiler, *compilerArgs,
-                    "-emit-llvm", "-c", outCFile.absolutePath, "-o", outLib.absolutePath)
-            runCmd(compilerCmd, verbose)
+                    "-emit-llvm", "-x", "c", "-c", "-", "-o", outLib.absolutePath)
+            runCmd(compilerCmd, verbose, redirectInputFile = File(outCFile.absolutePath))
             outLib.absolutePath
         }
     }

--- a/kotlin-native/shared/src/main/kotlin/org/jetbrains/kotlin/konan/exec/ExecuteCommand.kt
+++ b/kotlin-native/shared/src/main/kotlin/org/jetbrains/kotlin/konan/exec/ExecuteCommand.kt
@@ -18,12 +18,13 @@ package org.jetbrains.kotlin.konan.exec
 
 import org.jetbrains.kotlin.konan.KonanExternalToolFailure
 import java.io.BufferedReader
+import java.io.File
 import java.io.InputStreamReader
 import java.lang.ProcessBuilder.Redirect
 import java.nio.file.Files
 
 
-open class Command(initialCommand: List<String>) {
+open class Command(initialCommand: List<String>, val redirectInputFile: File? = null) {
 
     constructor(tool: String) : this(listOf(tool)) 
     constructor(vararg command: String) : this(command.toList<String>()) 
@@ -58,7 +59,11 @@ open class Command(initialCommand: List<String>) {
         val builder = ProcessBuilder(command)
 
         builder.redirectOutput(Redirect.INHERIT)
-        builder.redirectInput(Redirect.INHERIT)
+        if (redirectInputFile == null) {
+          builder.redirectInput(Redirect.INHERIT)
+        } else {
+          builder.redirectInput(redirectInputFile)
+        }
 
         val process = builder.start()
 
@@ -90,7 +95,11 @@ open class Command(initialCommand: List<String>) {
         try {
             val builder = ProcessBuilder(command)
 
-            builder.redirectInput(Redirect.INHERIT)
+            if (redirectInputFile == null) {
+              builder.redirectInput(Redirect.INHERIT)
+            } else {
+              builder.redirectInput(redirectInputFile)
+            }
             builder.redirectError(Redirect.INHERIT)
             builder.redirectOutput(Redirect.to(outputFile))
                     .redirectErrorStream(withErrors)


### PR DESCRIPTION
Pass in temp-file C sources to clang via stdin instead of by name. This prevents absolute paths of temp files from being encoded in bitcode.

Tested manually via the following on macOS:

```bash
$ kotlin-native/dist/bin/cinterop -def kotlin-native/platformLibs/src/platform/osx/posix.def -o /tmp/a/posix.klib
$ kotlin-native/dist/bin/cinterop -def kotlin-native/platformLibs/src/platform/osx/posix.def -o /tmp/b/posix.klib
$ shasum /tmp/a/posix.klib /tmp/b/posix.klib
c3ae6962ffc0b52d2191eaa02dfd0b94176f98c0  /tmp/a/posix.klib
c3ae6962ffc0b52d2191eaa02dfd0b94176f98c0  /tmp/b/posix.klib
```