### PR TITLE
K2 JVM: Fix JVM declarations conflicting error reporting

### DIFF
--- a/compiler/frontend.common/src/org/jetbrains/kotlin/diagnostics/DiagnosticReporter.kt
+++ b/compiler/frontend.common/src/org/jetbrains/kotlin/diagnostics/DiagnosticReporter.kt
@@ -38,6 +38,10 @@ open class KtDiagnosticReporterWithContext(
 ) : DiagnosticReporter() {
     override fun report(diagnostic: KtDiagnostic?, context: DiagnosticContext) = diagnosticReporter.report(diagnostic, context)
 
+    override fun checkAndCommitReportsOn(element: AbstractKtSourceElement, context: DiagnosticContext?) {
+        diagnosticReporter.checkAndCommitReportsOn(element, context)
+    }
+
     open fun at(sourceElement: AbstractKtSourceElement?, containingFilePath: String): DiagnosticContextImpl =
         DiagnosticContextImpl(sourceElement, containingFilePath)
 
@@ -79,6 +83,13 @@ open class KtDiagnosticReporterWithContext(
             positioningStrategy: AbstractSourceElementPositioningStrategy? = null
         ) {
             sourceElement?.let { report(factory.on(it, a1, a2, positioningStrategy), this) }
+        }
+
+        fun <A : Any> reportAndCommit(factory: KtDiagnosticFactory1<A>, a: A) {
+            sourceElement?.let {
+                reportOn(it, factory, a, this)
+                checkAndCommitReportsOn(it, this)
+            }
         }
 
         override fun equals(other: Any?): Boolean {

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/JvmSignatureClashDetector.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/JvmSignatureClashDetector.kt
@@ -147,7 +147,7 @@ class JvmSignatureClashDetector(
         irDeclarations.mapNotNullTo(LinkedHashSet()) { irDeclaration ->
             classCodegen.context.ktDiagnosticReporter.atFirstValidFrom(irDeclaration, classCodegen.irClass, containingIrFile = irDeclaration.file)
         }.forEach {
-            it.report(diagnosticFactory1, conflictingJvmDeclarationsData)
+            it.reportAndCommit(diagnosticFactory1, conflictingJvmDeclarationsData)
         }
     }
 

--- a/compiler/testData/cli/jvm/conflictingJvmDeclarations.args
+++ b/compiler/testData/cli/jvm/conflictingJvmDeclarations.args
@@ -1,0 +1,4 @@
+$TESTDATA_DIR$/conflictingJvmDeclarations.kt
+-Xuse-k2
+-d
+$TEMP_DIR$

--- a/compiler/testData/cli/jvm/conflictingJvmDeclarations.kt
+++ b/compiler/testData/cli/jvm/conflictingJvmDeclarations.kt
@@ -1,0 +1,9 @@
+class Foo {
+    val x: Int
+        get() = 42
+
+    fun getX() = 42
+
+    @JvmName("getX")
+    fun getY() = 42
+}

--- a/compiler/testData/cli/jvm/conflictingJvmDeclarations.out
+++ b/compiler/testData/cli/jvm/conflictingJvmDeclarations.out
@@ -1,0 +1,22 @@
+warning: ATTENTION!
+ This build uses experimental K2 compiler:
+  -Xuse-k2
+compiler/testData/cli/jvm/conflictingJvmDeclarations.kt:2:5: error: platform declaration clash: The following declarations have the same JVM signature (getX()I):
+    fun `<get-x>`(): Int defined in Foo
+    fun getX(): Int defined in Foo
+    fun getY(): Int defined in Foo
+    val x: Int
+    ^
+compiler/testData/cli/jvm/conflictingJvmDeclarations.kt:5:5: error: platform declaration clash: The following declarations have the same JVM signature (getX()I):
+    fun `<get-x>`(): Int defined in Foo
+    fun getX(): Int defined in Foo
+    fun getY(): Int defined in Foo
+    fun getX() = 42
+    ^
+compiler/testData/cli/jvm/conflictingJvmDeclarations.kt:7:5: error: platform declaration clash: The following declarations have the same JVM signature (getX()I):
+    fun `<get-x>`(): Int defined in Foo
+    fun getX(): Int defined in Foo
+    fun getY(): Int defined in Foo
+    @JvmName("getX")
+    ^
+COMPILATION_ERROR

--- a/compiler/tests-gen/org/jetbrains/kotlin/cli/CliTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/cli/CliTestGenerated.java
@@ -237,6 +237,11 @@ public class CliTestGenerated extends AbstractCliTest {
             runTest("compiler/testData/cli/jvm/compatqualWrong.args");
         }
 
+        @TestMetadata("conflictingJvmDeclarations.args")
+        public void testConflictingJvmDeclarations() throws Exception {
+            runTest("compiler/testData/cli/jvm/conflictingJvmDeclarations.args");
+        }
+
         @TestMetadata("conflictingOverloads.args")
         public void testConflictingOverloads() throws Exception {
             runTest("compiler/testData/cli/jvm/conflictingOverloads.args");


### PR DESCRIPTION
Since `SimpleDiagnosticsCollectorWithSuppress` have been replaced by 
`PendingDiagnosticsCollectorWithSuppress` after commit 9add6f3d55457, 
diagnostics need to be committed now.

Fixes: [KT-54366](https://youtrack.jetbrains.com/issue/KT-54366/K2-False-negative-CONFLICTINGJVMDECLARATIONS-in-18)