### PR TITLE
FIR: intersect return types of declarations in intersection scopes

### DIFF
--- a/analysis/low-level-api-fir/tests/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/compiler/based/DiagnosisCompilerTestFE10TestdataTestGenerated.java
+++ b/analysis/low-level-api-fir/tests/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/compiler/based/DiagnosisCompilerTestFE10TestdataTestGenerated.java
@@ -29622,6 +29622,12 @@ public class DiagnosisCompilerTestFE10TestdataTestGenerated extends AbstractDiag
                 }
 
                 @Test
+                @TestMetadata("capturedSpecificity.kt")
+                public void testCapturedSpecificity() throws Exception {
+                    runTest("compiler/testData/diagnostics/tests/smartCasts/intersectionScope/capturedSpecificity.kt");
+                }
+
+                @Test
                 @TestMetadata("conflictTypeParameters.kt")
                 public void testConflictTypeParameters() throws Exception {
                     runTest("compiler/testData/diagnostics/tests/smartCasts/intersectionScope/conflictTypeParameters.kt");
@@ -29637,6 +29643,12 @@ public class DiagnosisCompilerTestFE10TestdataTestGenerated extends AbstractDiag
                 @TestMetadata("flexibleTypes.kt")
                 public void testFlexibleTypes() throws Exception {
                     runTest("compiler/testData/diagnostics/tests/smartCasts/intersectionScope/flexibleTypes.kt");
+                }
+
+                @Test
+                @TestMetadata("intersectReturnType.kt")
+                public void testIntersectReturnType() throws Exception {
+                    runTest("compiler/testData/diagnostics/tests/smartCasts/intersectionScope/intersectReturnType.kt");
                 }
 
                 @Test

--- a/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsTestGenerated.java
@@ -29622,6 +29622,12 @@ public class FirOldFrontendDiagnosticsTestGenerated extends AbstractFirDiagnosti
                 }
 
                 @Test
+                @TestMetadata("capturedSpecificity.kt")
+                public void testCapturedSpecificity() throws Exception {
+                    runTest("compiler/testData/diagnostics/tests/smartCasts/intersectionScope/capturedSpecificity.kt");
+                }
+
+                @Test
                 @TestMetadata("conflictTypeParameters.kt")
                 public void testConflictTypeParameters() throws Exception {
                     runTest("compiler/testData/diagnostics/tests/smartCasts/intersectionScope/conflictTypeParameters.kt");
@@ -29637,6 +29643,12 @@ public class FirOldFrontendDiagnosticsTestGenerated extends AbstractFirDiagnosti
                 @TestMetadata("flexibleTypes.kt")
                 public void testFlexibleTypes() throws Exception {
                     runTest("compiler/testData/diagnostics/tests/smartCasts/intersectionScope/flexibleTypes.kt");
+                }
+
+                @Test
+                @TestMetadata("intersectReturnType.kt")
+                public void testIntersectReturnType() throws Exception {
+                    runTest("compiler/testData/diagnostics/tests/smartCasts/intersectionScope/intersectReturnType.kt");
                 }
 
                 @Test

--- a/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsWithLightTreeTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsWithLightTreeTestGenerated.java
@@ -29622,6 +29622,12 @@ public class FirOldFrontendDiagnosticsWithLightTreeTestGenerated extends Abstrac
                 }
 
                 @Test
+                @TestMetadata("capturedSpecificity.kt")
+                public void testCapturedSpecificity() throws Exception {
+                    runTest("compiler/testData/diagnostics/tests/smartCasts/intersectionScope/capturedSpecificity.kt");
+                }
+
+                @Test
                 @TestMetadata("conflictTypeParameters.kt")
                 public void testConflictTypeParameters() throws Exception {
                     runTest("compiler/testData/diagnostics/tests/smartCasts/intersectionScope/conflictTypeParameters.kt");
@@ -29637,6 +29643,12 @@ public class FirOldFrontendDiagnosticsWithLightTreeTestGenerated extends Abstrac
                 @TestMetadata("flexibleTypes.kt")
                 public void testFlexibleTypes() throws Exception {
                     runTest("compiler/testData/diagnostics/tests/smartCasts/intersectionScope/flexibleTypes.kt");
+                }
+
+                @Test
+                @TestMetadata("intersectReturnType.kt")
+                public void testIntersectReturnType() throws Exception {
+                    runTest("compiler/testData/diagnostics/tests/smartCasts/intersectionScope/intersectReturnType.kt");
                 }
 
                 @Test

--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/scopes/FirOverrideService.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/scopes/FirOverrideService.kt
@@ -6,11 +6,9 @@
 package org.jetbrains.kotlin.fir.scopes
 
 import org.jetbrains.kotlin.descriptors.Visibilities
-import org.jetbrains.kotlin.descriptors.Visibility
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.FirSessionComponent
 import org.jetbrains.kotlin.fir.declarations.FirProperty
-import org.jetbrains.kotlin.fir.declarations.FirPropertyAccessor
 import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
 import org.jetbrains.kotlin.fir.declarations.utils.visibility
 import org.jetbrains.kotlin.fir.resolve.transformers.ReturnTypeCalculator
@@ -19,10 +17,8 @@ import org.jetbrains.kotlin.fir.scopes.impl.similarFunctionsOrBothProperties
 import org.jetbrains.kotlin.fir.symbols.impl.FirCallableSymbol
 import org.jetbrains.kotlin.fir.types.ConeFlexibleType
 import org.jetbrains.kotlin.fir.types.ConeKotlinType
-import org.jetbrains.kotlin.fir.types.coneTypeSafe
 import org.jetbrains.kotlin.fir.types.typeContext
 import org.jetbrains.kotlin.types.AbstractTypeChecker
-import org.jetbrains.kotlin.types.TypeCheckerState
 import org.jetbrains.kotlin.utils.SmartSet
 import java.util.*
 
@@ -51,7 +47,7 @@ class FirOverrideService(val session: FirSession) : FirSessionComponent {
             val mostSpecific = selectMostSpecificMember(overridableGroup, returnTypeCalculator)
 
             overridableGroup.filterNotTo(conflictedHandles) {
-                isMoreSpecific(mostSpecific.member, it.member, returnTypeCalculator)
+                isMoreSpecificOrEqual(mostSpecific, it, returnTypeCalculator)
             }
 
             if (conflictedHandles.isNotEmpty()) {
@@ -104,92 +100,125 @@ class FirOverrideService(val session: FirSession) : FirSessionComponent {
         return result
     }
 
-    fun <D : FirCallableSymbol<*>> selectMostSpecificMember(
-        overridables: Collection<MemberWithBaseScope<D>>,
+    fun <D : FirCallableSymbol<*>> selectMostSpecificMembers(
+        overridables: List<MemberWithBaseScope<D>>,
         returnTypeCalculator: ReturnTypeCalculator
-    ): MemberWithBaseScope<D> {
+    ): List<MemberWithBaseScope<D>> {
         require(overridables.isNotEmpty()) { "Should have at least one overridable symbol" }
         if (overridables.size == 1) {
-            return overridables.first()
+            return overridables
         }
 
-        val candidates: MutableCollection<MemberWithBaseScope<D>> = ArrayList(2)
-        var transitivelyMostSpecific: MemberWithBaseScope<D> = overridables.first()
-
-        for (candidate in overridables) {
-            if (overridables.all { isMoreSpecific(candidate.member, it.member, returnTypeCalculator) }) {
-                candidates.add(candidate)
+        val maximums: MutableList<MemberWithBaseScopeAndReturnType<D>> = ArrayList(2)
+        skipCandidate@ for (candidate in overridables) {
+            val withReturnType = MemberWithBaseScopeAndReturnType(candidate, returnTypeCalculator)
+            // 1. Remove those members that are less specific than the current one;
+            // 2. Add this member if none of the existing ones are more or equally specific.
+            // The former, at least in theory, implies the latter, otherwise `compare` does not
+            // define a correct partial order (there are a and b such that a < candidate < b, but
+            // not a < b), so `skip = true` is equivalent to `continue`.
+            var skip = false
+            val toRemove = BooleanArray(maximums.size) { i ->
+                val c = maximums[i].compareTo(withReturnType) ?: return@BooleanArray false
+                if (c >= 0) {
+                    skip = true
+                }
+                c < 0
             }
-
-            if (isMoreSpecific(candidate.member, transitivelyMostSpecific.member, returnTypeCalculator) &&
-                !isMoreSpecific(transitivelyMostSpecific.member, candidate.member, returnTypeCalculator)
-            ) {
-                transitivelyMostSpecific = candidate
+            maximums.removeFlagged(toRemove)
+            if (!skip) {
+                maximums.add(withReturnType)
             }
         }
+        return maximums.map { it.memberWithBaseScope }
+    }
 
-        return when {
-            candidates.isEmpty() -> transitivelyMostSpecific
-            candidates.size == 1 -> candidates.first()
-            else -> {
-                candidates.firstOrNull {
-                    val type = it.member.fir.returnTypeRef.coneTypeSafe<ConeKotlinType>()
-                    type != null && type !is ConeFlexibleType
-                }?.let { return it }
-                candidates.first()
+    fun <D : FirCallableSymbol<*>> selectMostSpecificMember(
+        overridables: List<MemberWithBaseScope<D>>,
+        returnTypeCalculator: ReturnTypeCalculator
+    ): MemberWithBaseScope<D> = selectMostSpecificMembers(overridables, returnTypeCalculator).first()
+
+    private fun <E> MutableList<E>.removeFlagged(flags: BooleanArray) {
+        var dest = 0
+        for (i in flags.indices) {
+            if (!flags[i]) {
+                this[dest++] = this[i]
             }
+        }
+        while (size > dest) {
+            removeLast()
         }
     }
 
-    private fun isMoreSpecific(
-        a: FirCallableSymbol<*>,
-        b: FirCallableSymbol<*>,
+    private fun isMoreSpecificOrEqual(
+        a: MemberWithBaseScope<*>,
+        b: MemberWithBaseScope<*>,
         returnTypeCalculator: ReturnTypeCalculator
-    ): Boolean {
-        val aFir = a.fir
-        val bFir = b.fir
+    ) = MemberWithBaseScopeAndReturnType(a, returnTypeCalculator).compareTo(MemberWithBaseScopeAndReturnType(b, returnTypeCalculator)).let {
+        it != null && it >= 0
+    }
 
-        if (!isVisibilityMoreSpecific(aFir.visibility, bFir.visibility)) return false
+    private class MemberWithBaseScopeAndReturnType<out D : FirCallableSymbol<*>>(
+        val memberWithBaseScope: MemberWithBaseScope<D>,
+        returnTypeCalculator: ReturnTypeCalculator
+    ) {
+        val returnType: ConeKotlinType? = returnTypeCalculator.tryCalculateReturnTypeOrNull(memberWithBaseScope.member.fir)?.type
+    }
 
-        val substitutor = buildSubstitutorForOverridesCheck(aFir, bFir, session) ?: return false
+    private fun MemberWithBaseScopeAndReturnType<*>.compareTo(other: MemberWithBaseScopeAndReturnType<*>): Int? {
+        fun merge(preferA: Boolean, preferB: Boolean, previous: Int): Int? = when {
+            preferA == preferB -> previous
+            preferA && previous >= 0 -> 1
+            preferB && previous <= 0 -> -1
+            else -> null
+        }
+
+        val aFir = memberWithBaseScope.member.fir
+        val bFir = other.memberWithBaseScope.member.fir
+        val byVisibility = Visibilities.compare(aFir.visibility, bFir.visibility) ?: 0
+
+        val substitutor = buildSubstitutorForOverridesCheck(aFir, bFir, session) ?: return null
         // NB: these lines throw CCE in modularized tests when changed to just .coneType (FirImplicitTypeRef)
-        val aReturnType = returnTypeCalculator.tryCalculateReturnTypeOrNull(a.fir)?.type?.let(substitutor::substituteOrSelf) ?: return false
-        val bReturnType = returnTypeCalculator.tryCalculateReturnTypeOrNull(b.fir)?.type ?: return false
+        //  See also KT-41917 and the corresponding test (compiler/fir/analysis-tests/testData/resolveWithStdlib/delegates/kt41917.kt)
+        val aReturnType = returnType?.let(substitutor::substituteOrSelf) ?: return null
+        val bReturnType = other.returnType ?: return null
 
         val typeCheckerState = session.typeContext.newTypeCheckerState(
             errorTypesEqualToAnything = false,
             stubTypesEqualToAnything = false
         )
+        val aSubtypesB = AbstractTypeChecker.isSubtypeOf(typeCheckerState, aReturnType, bReturnType)
+        val bSubtypesA = AbstractTypeChecker.isSubtypeOf(typeCheckerState, bReturnType, aReturnType)
+        val byVisibilityAndType = when {
+            // Could be that one of them is flexible, in which case the types are not equal but still subtypes of one another;
+            // make the inflexible one more specific.
+            aSubtypesB && bSubtypesA -> merge(aReturnType !is ConeFlexibleType, bReturnType !is ConeFlexibleType, byVisibility)
+                ?: return null
 
-        if (aFir is FirSimpleFunction) {
-            require(bFir is FirSimpleFunction) { "b is " + b.javaClass }
-            return isTypeMoreSpecific(aReturnType, bReturnType, typeCheckerState)
+            aSubtypesB && byVisibility >= 0 -> 1
+            bSubtypesA && byVisibility <= 0 -> -1
+            else -> return null // unorderable by types, or visibility disagrees
         }
-        if (aFir is FirProperty) {
-            require(bFir is FirProperty) { "b is " + b.javaClass }
 
-            if (!isAccessorMoreSpecific(aFir.setter, bFir.setter)) return false
-
-            return if (aFir.isVar && bFir.isVar) {
-                AbstractTypeChecker.equalTypes(typeCheckerState, aReturnType, bReturnType)
-            } else { // both vals or var vs val: val can't be more specific then var
-                !(!aFir.isVar && bFir.isVar) && isTypeMoreSpecific(aReturnType, bReturnType, typeCheckerState)
+        return when (aFir) {
+            is FirSimpleFunction -> {
+                require(bFir is FirSimpleFunction) { "b is " + bFir.javaClass }
+                byVisibilityAndType
             }
+
+            is FirProperty -> {
+                require(bFir is FirProperty) { "b is " + bFir.javaClass }
+                // At least one of `subtypes` is true here, so `!xSubtypesY` implies `ySubtypesX`, meaning y's type
+                // is a *strict* subtype of x's. Vars are more specific than vals, so if one is a var and another
+                // has a strict subtype, then they are unorderable - one is a val with a more specific type than
+                // the other var, or both are vars of different types.
+                if (aFir.isVar && !aSubtypesB) return null
+                if (bFir.isVar && !bSubtypesA) return null
+                merge(aFir.isVar, bFir.isVar, byVisibilityAndType)
+            }
+
+            else -> throw IllegalArgumentException("Unexpected callable: " + aFir.javaClass)
         }
-        throw IllegalArgumentException("Unexpected callable: " + a.javaClass)
-    }
-
-    private fun isTypeMoreSpecific(a: ConeKotlinType, b: ConeKotlinType, typeCheckerState: TypeCheckerState): Boolean =
-        AbstractTypeChecker.isSubtypeOf(typeCheckerState, a, b)
-
-    private fun isAccessorMoreSpecific(a: FirPropertyAccessor?, b: FirPropertyAccessor?): Boolean {
-        if (a == null || b == null) return true
-        return isVisibilityMoreSpecific(a.visibility, b.visibility)
-    }
-
-    private fun isVisibilityMoreSpecific(a: Visibility, b: Visibility): Boolean {
-        val result = Visibilities.compare(a, b)
-        return result == null || result >= 0
     }
 }
 

--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/scopes/impl/AbstractFirUseSiteMemberScope.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/scopes/impl/AbstractFirUseSiteMemberScope.kt
@@ -130,7 +130,7 @@ abstract class AbstractFirUseSiteMemberScope(
              *
              * TODO: is it enough to check only one function?
              */
-            mostSpecific
+            keySymbol
         } else {
             chosenSymbol
         }

--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/scopes/impl/AbstractFirUseSiteMemberScope.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/scopes/impl/AbstractFirUseSiteMemberScope.kt
@@ -23,7 +23,7 @@ abstract class AbstractFirUseSiteMemberScope(
     protected val declaredMemberScope: FirContainingNamesAwareScope
 ) : AbstractFirOverrideScope(session, overrideChecker) {
     protected val supertypeScopeContext =
-        FirTypeIntersectionScopeContext(session, overrideChecker, superTypeScopes, dispatchReceiverType, forSubtyping = true)
+        FirTypeIntersectionScopeContext(session, overrideChecker, superTypeScopes, dispatchReceiverType, forClassUseSiteScope = true)
 
     private val functions: MutableMap<Name, Collection<FirNamedFunctionSymbol>> = hashMapOf()
 

--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/scopes/impl/AbstractFirUseSiteMemberScope.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/scopes/impl/AbstractFirUseSiteMemberScope.kt
@@ -22,7 +22,8 @@ abstract class AbstractFirUseSiteMemberScope(
     dispatchReceiverType: ConeSimpleKotlinType,
     protected val declaredMemberScope: FirContainingNamesAwareScope
 ) : AbstractFirOverrideScope(session, overrideChecker) {
-    protected val supertypeScopeContext = FirTypeIntersectionScopeContext(session, overrideChecker, superTypeScopes, dispatchReceiverType)
+    protected val supertypeScopeContext =
+        FirTypeIntersectionScopeContext(session, overrideChecker, superTypeScopes, dispatchReceiverType, forSubtyping = true)
 
     private val functions: MutableMap<Name, Collection<FirNamedFunctionSymbol>> = hashMapOf()
 

--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/scopes/impl/FirTypeIntersectionScope.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/scopes/impl/FirTypeIntersectionScope.kt
@@ -19,7 +19,7 @@ class FirTypeIntersectionScope private constructor(
     dispatchReceiverType: ConeSimpleKotlinType,
 ) : AbstractFirOverrideScope(session, overrideChecker) {
     private val intersectionContext =
-        FirTypeIntersectionScopeContext(session, overrideChecker, scopes, dispatchReceiverType, forSubtyping = false)
+        FirTypeIntersectionScopeContext(session, overrideChecker, scopes, dispatchReceiverType, forClassUseSiteScope = false)
 
     private val absentFunctions: MutableSet<Name> = mutableSetOf()
     private val absentProperties: MutableSet<Name> = mutableSetOf()

--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/scopes/impl/FirTypeIntersectionScope.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/scopes/impl/FirTypeIntersectionScope.kt
@@ -18,7 +18,8 @@ class FirTypeIntersectionScope private constructor(
     private val scopes: List<FirTypeScope>,
     dispatchReceiverType: ConeSimpleKotlinType,
 ) : AbstractFirOverrideScope(session, overrideChecker) {
-    private val intersectionContext = FirTypeIntersectionScopeContext(session, overrideChecker, scopes, dispatchReceiverType)
+    private val intersectionContext =
+        FirTypeIntersectionScopeContext(session, overrideChecker, scopes, dispatchReceiverType, forSubtyping = false)
 
     private val absentFunctions: MutableSet<Name> = mutableSetOf()
     private val absentProperties: MutableSet<Name> = mutableSetOf()

--- a/compiler/testData/diagnostics/tests/smartCasts/intersectionScope/capturedSpecificity.kt
+++ b/compiler/testData/diagnostics/tests/smartCasts/intersectionScope/capturedSpecificity.kt
@@ -1,0 +1,14 @@
+// FIR_IDENTICAL
+// SKIP_TXT
+class C<T>(val value: T?)
+
+fun <T> assignable(x: () -> T) {}
+
+fun <V> foo(t: C<out Any>, v: C<out V>) {
+    assignable<V?> { v.value }
+    if (t == v) {
+        // `value: CapturedType(out V)?` <: `value: CapturedType(out Any)?` - same instantiation
+        assignable<V?> { v.value }
+        assignable<V?> { t.value }
+    }
+}

--- a/compiler/testData/diagnostics/tests/smartCasts/intersectionScope/intersectReturnType.fir.kt
+++ b/compiler/testData/diagnostics/tests/smartCasts/intersectionScope/intersectReturnType.fir.kt
@@ -1,0 +1,17 @@
+// SKIP_TXT
+class C<T>(val value: T)
+
+fun <T> assignable(x: () -> T) {}
+
+fun <T, V> foo(t: C<out T>, v: C<out V>) {
+    assignable<T> { t.value } // sure
+    assignable<V> { v.value } // obviously
+    if (t == v) {
+        // => {t,v} is C<out T> & C<out V>
+        // => {t,v}.value is T & V
+        assignable<T> { t.value }
+        assignable<V> { v.value }
+        assignable<T> { v.value }
+        assignable<V> { t.value }
+    }
+}

--- a/compiler/testData/diagnostics/tests/smartCasts/intersectionScope/intersectReturnType.kt
+++ b/compiler/testData/diagnostics/tests/smartCasts/intersectionScope/intersectReturnType.kt
@@ -1,0 +1,17 @@
+// SKIP_TXT
+class C<T>(val value: T)
+
+fun <T> assignable(x: () -> T) {}
+
+fun <T, V> foo(t: C<out T>, v: C<out V>) {
+    assignable<T> { t.value } // sure
+    assignable<V> { v.value } // obviously
+    if (t == v) {
+        // => {t,v} is C<out T> & C<out V>
+        // => {t,v}.value is T & V
+        assignable<T> { <!TYPE_MISMATCH!>t.value<!> }
+        assignable<V> { <!TYPE_MISMATCH!>v.value<!> }
+        assignable<T> { v.value }
+        assignable<V> { t.value }
+    }
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/DiagnosticTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/DiagnosticTestGenerated.java
@@ -29712,6 +29712,12 @@ public class DiagnosticTestGenerated extends AbstractDiagnosticTest {
                 }
 
                 @Test
+                @TestMetadata("capturedSpecificity.kt")
+                public void testCapturedSpecificity() throws Exception {
+                    runTest("compiler/testData/diagnostics/tests/smartCasts/intersectionScope/capturedSpecificity.kt");
+                }
+
+                @Test
                 @TestMetadata("conflictTypeParameters.kt")
                 public void testConflictTypeParameters() throws Exception {
                     runTest("compiler/testData/diagnostics/tests/smartCasts/intersectionScope/conflictTypeParameters.kt");
@@ -29727,6 +29733,12 @@ public class DiagnosticTestGenerated extends AbstractDiagnosticTest {
                 @TestMetadata("flexibleTypes.kt")
                 public void testFlexibleTypes() throws Exception {
                     runTest("compiler/testData/diagnostics/tests/smartCasts/intersectionScope/flexibleTypes.kt");
+                }
+
+                @Test
+                @TestMetadata("intersectReturnType.kt")
+                public void testIntersectReturnType() throws Exception {
+                    runTest("compiler/testData/diagnostics/tests/smartCasts/intersectionScope/intersectReturnType.kt");
                 }
 
                 @Test

--- a/compiler/tests-spec/testData/diagnostics/notLinked/dfa/pos/72.fir.kt
+++ b/compiler/tests-spec/testData/diagnostics/notLinked/dfa/pos/72.fir.kt
@@ -12,5 +12,5 @@ fun case_1() {
     val strs = list as MutableList<String>
     strs.add("two")
     <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.collections.MutableList<kotlin.String> & kotlin.collections.MutableList<kotlin.Int> & kotlin.collections.MutableList<kotlin.String>")!>list<!>
-    val s: String = <!INITIALIZER_TYPE_MISMATCH, TYPE_MISMATCH!><!DEBUG_INFO_EXPRESSION_TYPE("kotlin.collections.MutableList<kotlin.String> & kotlin.collections.MutableList<kotlin.Int> & kotlin.collections.MutableList<kotlin.String>")!>list<!>[0]<!>
+    val s: String = <!DEBUG_INFO_EXPRESSION_TYPE("kotlin.collections.MutableList<kotlin.String> & kotlin.collections.MutableList<kotlin.Int> & kotlin.collections.MutableList<kotlin.String>")!>list<!>[0]
 }


### PR DESCRIPTION
@dzharkov 

This doesn't entirely work if enabled for subtyping scopes, even if disregarding backwards compatibility concerns: if a default interface method with inferred return type is inherited through multiple substitution scopes, its return type is not known until full body resolution stage, so the intersection scope assumes they might be different and creates an intersection override which results in a false positive MANY_INTERFACES_MEMBER_NOT_IMPLEMENTED (there is only one real member so it's fine). This looks like a problem in either ReturnTypeCalculatorForFullBodyResolve or the checker.

Also, if the same interface is inherited with different type parameter substitutions, there will be *_TYPE_MISMATCH_ON_INHERITANCE in addition to INCONSISTENT_TYPE_PARAMETER_VALUES, which seems to be fine in principle, but redundant noise in practice - that's definitely to be filtered out on checker side.