### PR TITLE
Remove usage of deprecated Gradle field, replace with equivalent

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinTargetConfigurator.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinTargetConfigurator.kt
@@ -18,7 +18,6 @@ import org.gradle.api.attributes.Category
 import org.gradle.api.attributes.Usage
 import org.gradle.api.attributes.Usage.USAGE_ATTRIBUTE
 import org.gradle.api.file.FileCollection
-import org.gradle.api.internal.artifacts.ArtifactAttributes
 import org.gradle.api.plugins.BasePlugin
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.plugins.JavaBasePlugin
@@ -448,7 +447,7 @@ abstract class KotlinOnlyTargetConfigurator<KotlinCompilationType : KotlinCompil
 
             // Configure an implicit variant
             publications.artifacts.add(jarArtifact)
-            publications.attributes.attribute(ArtifactAttributes.ARTIFACT_FORMAT, archiveType)
+            publications.attributes.attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, archiveType)
         }
     }
 }


### PR DESCRIPTION
Gradle's `ArtifactAttributes` class is an internal class which contains only a single field that is [deprecated for removal](https://github.com/gradle/gradle/blob/master/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/ArtifactAttributes.java).

That single field references the part of the public API that should be referenced directly.  This PR makes that change.

Fixes [#KT-54447](https://youtrack.jetbrains.com/issue/KT-54447/Remove-usage-of-deprecated-internal-Gradle-field-in-Kotlin-Gradle-Plugin-replace-with-equivalent-in-public-API)
