### PR TITLE
KT-48714 : Add webpack historyApiFallback option

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin-js-test-webpack-config-devServer/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin-js-test-webpack-config-devServer/build.gradle.kts
@@ -1,0 +1,62 @@
+import org.jetbrains.kotlin.gradle.targets.js.npm.npmProject
+import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig
+import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig.DevServer.HistoryApiFallback
+
+plugins {
+    kotlin("js")
+}
+
+dependencies {
+    implementation(kotlin("stdlib-js"))
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+tasks.register("prepareKotlinBuildScriptModel"){}
+kotlin {
+    js(IR) {
+        val compilation = compilations.getByName("main")
+        org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsExec.create(compilation, "checkConfigDevelopmentWebpack") {
+            inputFileProperty.set(provider { compilation.npmProject.require("webpack/bin/webpack.js") }.map { RegularFile { File(it) } })
+            dependsOn("browserDevelopmentWebpack")
+            val configFile = tasks.named<org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpack>("browserDevelopmentWebpack").map { it.configFile }.get()
+            args("configtest")
+            args(configFile.absolutePath)
+        }
+        org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsExec.create(compilation, "checkConfigProductionWebpack") {
+            inputFileProperty.set(provider { compilation.npmProject.require("webpack/bin/webpack.js") }.map { RegularFile { File(it) } })
+            dependsOn("browserProductionWebpack")
+            val configFile = tasks.named<org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpack>("browserProductionWebpack").map { it.configFile }.get()
+            args("configtest")
+            args(configFile.absolutePath)
+        }
+        org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsExec.create(compilation, "checkConfigDevelopmentRun") {
+            inputFileProperty.set(provider { compilation.npmProject.require("webpack/bin/webpack.js") }.map { RegularFile { File(it) } })
+            dependsOn("browserDevelopmentRun")
+            val configFile = tasks.named<org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpack>("browserDevelopmentRun").map { it.configFile }.get()
+            args("configtest")
+            args(configFile.absolutePath)
+        }
+        org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsExec.create(compilation, "checkConfigProductionRun") {
+            inputFileProperty.set(provider { compilation.npmProject.require("webpack/bin/webpack.js") }.map { RegularFile { File(it) } })
+            dependsOn("browserProductionRun")
+            val configFile = tasks.named<org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpack>("browserProductionRun").map { it.configFile }.get()
+            args("configtest")
+            args(configFile.absolutePath)
+        }
+        binaries.executable()
+        browser {
+            webpackTask {
+                generateConfigOnly = true
+            }
+            runTask {
+                generateConfigOnly = true
+            }
+            commonWebpackConfig {
+                devServer= KotlinWebpackConfig.DevServer(historyApiFallback = HistoryApiFallback(disableDotRule = false))
+            }
+        }
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin-js-test-webpack-config-devServer/src/main/kotlin/Simple.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin-js-test-webpack-config-devServer/src/main/kotlin/Simple.kt
@@ -1,0 +1,6 @@
+
+fun main() {
+    console.log("Hello, ${greet()}")
+}
+
+fun greet() = "world"

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/webpack/KotlinWebpackConfig.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/webpack/KotlinWebpackConfig.kt
@@ -8,8 +8,6 @@
 package org.jetbrains.kotlin.gradle.targets.js.webpack
 
 import com.google.gson.GsonBuilder
-import org.gradle.api.ExtensiblePolymorphicDomainObjectContainer
-import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Nested
@@ -164,8 +162,22 @@ data class KotlinWebpackConfig(
         var proxy: MutableMap<String, Any>? = null,
         var static: MutableList<String>? = null,
         var contentBase: MutableList<String>? = null,
-        var client: Client? = null
+        var client: Client? = null,
+        var historyApiFallback: Any? /* HistoryApiFallback | Boolean */ = null
     ) : Serializable {
+        data class HistoryApiFallback(
+            var rewrites: MutableList<Rewrite>? = null,
+            var disableDotRule: Boolean? = null,
+            var index: String? = null,
+            var verbose: Boolean? = null,
+            var htmlAcceptHeaders: MutableList<String>? = null,
+        ) : Serializable {
+            data class Rewrite(
+                var from: String,
+                var to: String
+            ) : Serializable
+        }
+
         data class Client(
             var overlay: Any /* Overlay | Boolean */
         ) : Serializable {


### PR DESCRIPTION
Fixed KT-48714
Also, I'm person who opened KT-54365.
I change DevServer class and added historyApiFallback option to it.

(libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/webpack/KotlinWebpackConfig.kt)
```kt
    @Suppress("unused")
    data class DevServer(
        var open: Any = true,
        var port: Int? = null,
        var proxy: MutableMap<String, Any>? = null,
        var static: MutableList<String>? = null,
        var contentBase: MutableList<String>? = null,
        var client: Client? = null,
        var historyApiFallback: Any? /* HistoryApiFallback | Boolean */ = null
    ) : Serializable {
        data class HistoryApiFallback(
            var rewrites: MutableList<Rewrite>? = null,
            var disableDotRule: Boolean? = null,
            var index: String? = null,
            var verbose: Boolean? = null,
            var htmlAcceptHeaders: MutableList<String>? = null,
        ) : Serializable {
            data class Rewrite(
                var from: String,
                var to: String
            ) : Serializable
        }

        data class Client(
            var overlay: Any /* Overlay | Boolean */
        ) : Serializable {
            data class Overlay(
                var errors: Boolean,
                var warnings: Boolean
            ) : Serializable
        }
    }
```
This is the webpack.config result by using historyApiFallback option;
[webpack.config.evaluated.js.txt](https://github.com/JetBrains/kotlin/files/9794745/webpack.config.evaluated.js.txt)
