### PR TITLE
KT-54316: invalid signature inside companion.

### DIFF
--- a/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/DoubleColonExpressionResolver.kt
+++ b/compiler/frontend/src/org/jetbrains/kotlin/types/expressions/DoubleColonExpressionResolver.kt
@@ -838,7 +838,10 @@ class DoubleColonExpressionResolver(
             descriptor.contextReceiverParameters.map { it.type }
 
         private fun receiverTypeFor(descriptor: CallableDescriptor, lhs: DoubleColonLHS?): KotlinType? =
-            (descriptor.extensionReceiverParameter ?: descriptor.dispatchReceiverParameter)?.let { (lhs as? DoubleColonLHS.Type)?.type }
+            (descriptor.extensionReceiverParameter ?: descriptor.dispatchReceiverParameter)
+                // checker descriptor is inside companion object.
+                ?.takeUnless { DescriptorUtils.isCompanionObject(it.containingDeclaration as? ClassDescriptor) }
+                ?.let { (lhs as? DoubleColonLHS.Type)?.type }
 
         private fun isMutablePropertyReference(
             descriptor: PropertyDescriptor,

--- a/compiler/testData/cli/jvm/KT-54316.args
+++ b/compiler/testData/cli/jvm/KT-54316.args
@@ -1,0 +1,3 @@
+$TESTDATA_DIR$/KT-54316.kt
+-d
+$TEMP_DIR$

--- a/compiler/testData/cli/jvm/KT-54316.kt
+++ b/compiler/testData/cli/jvm/KT-54316.kt
@@ -1,0 +1,13 @@
+class Foo {
+    companion object {
+        fun bar() {
+            println("Invoked")
+        }
+    }
+}
+
+fun main() {
+    val a = Foo::bar
+    a.invoke()
+    a.invoke(Foo())
+}

--- a/compiler/testData/cli/jvm/KT-54316.out
+++ b/compiler/testData/cli/jvm/KT-54316.out
@@ -1,0 +1,4 @@
+compiler/testData/cli/jvm/KT-54316.kt:12:14: error: too many arguments for public abstract fun invoke(): Unit defined in kotlin.reflect.KFunction0
+    a.invoke(Foo())
+             ^
+COMPILATION_ERROR

--- a/compiler/tests-gen/org/jetbrains/kotlin/cli/CliTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/cli/CliTestGenerated.java
@@ -732,6 +732,11 @@ public class CliTestGenerated extends AbstractCliTest {
             runTest("compiler/testData/cli/jvm/jvmRecordWrongTarget.args");
         }
 
+        @TestMetadata("KT-54316.args")
+        public void testKT_54316() throws Exception {
+            runTest("compiler/testData/cli/jvm/KT-54316.args");
+        }
+
         @TestMetadata("kotlinHomeWithoutStdlib.args")
         public void testKotlinHomeWithoutStdlib() throws Exception {
             runTest("compiler/testData/cli/jvm/kotlinHomeWithoutStdlib.args");


### PR DESCRIPTION
Fixed: [KT-54316](https://youtrack.jetbrains.com/issue/KT-54316/Reference-to-companion-objects-member-has-invalid-signature)