### PR TITLE
Use Classpath normalization on friendDependencies property

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/Tasks.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/Tasks.kt
@@ -1040,7 +1040,7 @@ abstract class Kotlin2JsCompile @Inject constructor(
     @get:Incremental
     @get:Optional
     @get:NormalizeLineEndings
-    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:Classpath
     internal val friendDependencies: FileCollection = objectFactory
         .fileCollection()
         .from(friendPaths)


### PR DESCRIPTION
Currently subsequent build involving Kotlin2JsCompile task will lead to Gradle cache misse(s) because `klib` files are not recognized as zip files by Gradle, see below:
<img width="1145" alt="image" src="https://user-images.githubusercontent.com/736523/196943551-b2d9d7bf-5cd3-49c5-b7e7-cbf74c6ec54a.png">

This will be solved with Gradle 7.6, see commit: https://github.com/gradle/gradle/commit/763f6bfaaa4d74811cbfd109f44015a2c517846e

Then, switching to `Classpath` normalization will treat klib as archives and only consider the archive content, leading to cache hits.