### PR TITLE
JVM_IR: Fix local variable slot index problem of context receivers

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -18776,6 +18776,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         }
 
         @Test
+        @TestMetadata("kt52027.kt")
+        public void testKt52027() throws Exception {
+            runTest("compiler/testData/codegen/box/functions/kt52027.kt");
+        }
+
+        @Test
         @TestMetadata("kt785.kt")
         public void testKt785() throws Exception {
             runTest("compiler/testData/codegen/box/functions/kt785.kt");

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -499,6 +499,7 @@ class ExpressionCodegen(
             callGenerator.genValueAndPut(irParameter, arg, parameterType, this, data)
         }
 
+        callGenerator.beforeContextParametersStart()
         val contextReceivers = callee.valueParameters.subList(0, callee.contextReceiverParametersCount)
         contextReceivers.forEachIndexed(::handleValueParameter)
 

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/IrCallGenerator.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/IrCallGenerator.kt
@@ -36,6 +36,7 @@ interface IrCallGenerator {
 
     fun beforeCallStart() {}
 
+    fun beforeContextParametersStart() {}
     fun beforeValueParametersStart(contextReceiversCount: Int) {}
 
     fun afterCallEnd() {}

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/IrInlineCodegen.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/IrInlineCodegen.kt
@@ -150,6 +150,10 @@ class IrInlineCodegen(
         }
     }
 
+    override fun beforeContextParametersStart() {
+        invocationParamBuilder.markValueParametersStart(0)
+    }
+
     override fun beforeValueParametersStart(contextReceiversCount: Int) {
         invocationParamBuilder.markValueParametersStart(contextReceiversCount)
     }

--- a/compiler/testData/codegen/box/functions/kt52027.kt
+++ b/compiler/testData/codegen/box/functions/kt52027.kt
@@ -1,0 +1,17 @@
+// !LANGUAGE: +ContextReceivers
+// TARGET_BACKEND: JVM_IR
+
+class Foo {
+    fun myFn() = "OK"
+}
+
+class Bar {
+    context(Foo)
+    inline fun ok() = myFn()
+}
+
+fun box(): String {
+    with(Foo()) {
+        return Bar().ok()
+    }
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -18776,6 +18776,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         }
 
         @Test
+        @TestMetadata("kt52027.kt")
+        public void testKt52027() throws Exception {
+            runTest("compiler/testData/codegen/box/functions/kt52027.kt");
+        }
+
+        @Test
         @TestMetadata("kt785.kt")
         public void testKt785() throws Exception {
             runTest("compiler/testData/codegen/box/functions/kt785.kt");


### PR DESCRIPTION
issue: [KT-52027](https://youtrack.jetbrains.com/issue/KT-52027/NullPointerException-when-using-context-receivers-with-inline-fun) 
   
For `IrInlineCodegen`, take callee `ok` in the test case of this PR for 
example, it has both a `dispatch receiver` and a `context receiver`, 
the `byDeclarationIndex` of a `context receiver` should  start from `1` 
instead of `0`.

Otherwise, two params with same `declIndexesToActual` would overwrite 
each other when they put into `paramToDeclByteCodeIndex` 