### PR TITLE
Update JetBrains annotations dependency

### DIFF
--- a/libraries/stdlib/jvm/build.gradle
+++ b/libraries/stdlib/jvm/build.gradle
@@ -70,7 +70,7 @@ dependencies {
 
     commonSources project(path: ":kotlin-stdlib-common", configuration: "sources")
 
-    api group: 'org.jetbrains', name: 'annotations', version:'13.0'
+    api group: 'org.jetbrains', name: 'annotations', version:'23.0.0'
 
     mainJdk7Api sourceSets.main.output
     mainJdk8Api sourceSets.main.output


### PR DESCRIPTION
Currently the Kotlin Stdlib fully supports JPMS (Java Platform Module System) but it's sole dependency does not.
Fortunately `org.jetbrains:annotations:21.0.1` and up contains an explicit module-info descriptor in the JAR.
Increasing the version here would significantly improve the compatibility with the module system.

In my case, the automatic module name `annotations` conflicted with `com.google.android:annotations` which results in the same 'automatic' module name. The updated version of `org.jetbrains:annotations` has an explicit module name of `org.jetbrains.annotations` which directly fixes my problem. In the meanwhile I just override the version in my local build script..