### PR TITLE
JVM_IR: Don't treat java constructor as 'hidden' one in syntheticAccessorLoweringPhase

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -22314,6 +22314,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         }
 
         @Test
+        @TestMetadata("kt54656.kt")
+        public void testKt54656() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/kt54656.kt");
+        }
+
+        @Test
         @TestMetadata("mangledDefaultParameterFunction.kt")
         public void testMangledDefaultParameterFunction() throws Exception {
             runTest("compiler/testData/codegen/box/inlineClasses/mangledDefaultParameterFunction.kt", TransformersFunctions.getReplaceOptionalJvmInlineAnnotationWithReal());

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/SyntheticAccessorLowering.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/SyntheticAccessorLowering.kt
@@ -363,7 +363,8 @@ private class SyntheticAccessorTransformer(
 
             if (origin == IrDeclarationOrigin.FUNCTION_FOR_DEFAULT_PARAMETER ||
                 origin == JvmLoweredDeclarationOrigin.SYNTHETIC_ACCESSOR ||
-                origin == JvmLoweredDeclarationOrigin.SYNTHETIC_ACCESSOR_FOR_HIDDEN_CONSTRUCTOR
+                origin == JvmLoweredDeclarationOrigin.SYNTHETIC_ACCESSOR_FOR_HIDDEN_CONSTRUCTOR ||
+                origin == IrDeclarationOrigin.IR_EXTERNAL_JAVA_DECLARATION_STUB
             ) {
                 return false
             }

--- a/compiler/testData/codegen/box/inlineClasses/kt54656.kt
+++ b/compiler/testData/codegen/box/inlineClasses/kt54656.kt
@@ -1,0 +1,17 @@
+// TARGET_BACKEND: JVM_IR
+// WITH_STDLIB
+
+// FILE: J.java
+public class J {
+    public J(Email email) {}
+}
+
+// FILE: 1.kt
+@JvmInline
+value class Email(val address: String)
+
+fun box():String {
+    J(Email("test"))
+    return "OK"
+}
+

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -22314,6 +22314,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         }
 
         @Test
+        @TestMetadata("kt54656.kt")
+        public void testKt54656() throws Exception {
+            runTest("compiler/testData/codegen/box/inlineClasses/kt54656.kt");
+        }
+
+        @Test
         @TestMetadata("mangledDefaultParameterFunction.kt")
         public void testMangledDefaultParameterFunction() throws Exception {
             runTest("compiler/testData/codegen/box/inlineClasses/mangledDefaultParameterFunction.kt", TransformersFunctions.getReplaceOptionalJvmInlineAnnotationWithReal());


### PR DESCRIPTION
Please correct me if I'm wrong:

In `syntheticAccessorLoweringPhase`, '`hidden constructor`' looks like a concept related to some kind of `sealed classes` & `annotation classes`. A constructor from `Java` doesn't look like one of them and should not add a `constructor marker` argument to its accessor.

Fix [KT-54656](https://youtrack.jetbrains.com/issue/KT-54656/NoSuchMethodError-on-invoking-Java-constructor-which-takes-an-inline-value-class-as-a-parameter)