### PR TITLE
FIR: intersect flexible type bounds separately

### DIFF
--- a/analysis/low-level-api-fir/tests/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/compiler/based/DiagnosisCompilerTestFE10TestdataTestGenerated.java
+++ b/analysis/low-level-api-fir/tests/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/compiler/based/DiagnosisCompilerTestFE10TestdataTestGenerated.java
@@ -38755,6 +38755,12 @@ public class DiagnosisCompilerTestFE10TestdataTestGenerated extends AbstractDiag
             }
 
             @Test
+            @TestMetadata("intersectFlexibleAndMutable.kt")
+            public void testIntersectFlexibleAndMutable() throws Exception {
+                runTest("compiler/testData/diagnostics/testsWithStdLib/java/intersectFlexibleAndMutable.kt");
+            }
+
+            @Test
             @TestMetadata("patternCompileCallableReference.kt")
             public void testPatternCompileCallableReference() throws Exception {
                 runTest("compiler/testData/diagnostics/testsWithStdLib/java/patternCompileCallableReference.kt");

--- a/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsTestGenerated.java
@@ -38755,6 +38755,12 @@ public class FirOldFrontendDiagnosticsTestGenerated extends AbstractFirDiagnosti
             }
 
             @Test
+            @TestMetadata("intersectFlexibleAndMutable.kt")
+            public void testIntersectFlexibleAndMutable() throws Exception {
+                runTest("compiler/testData/diagnostics/testsWithStdLib/java/intersectFlexibleAndMutable.kt");
+            }
+
+            @Test
             @TestMetadata("patternCompileCallableReference.kt")
             public void testPatternCompileCallableReference() throws Exception {
                 runTest("compiler/testData/diagnostics/testsWithStdLib/java/patternCompileCallableReference.kt");

--- a/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsWithLightTreeTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirOldFrontendDiagnosticsWithLightTreeTestGenerated.java
@@ -38755,6 +38755,12 @@ public class FirOldFrontendDiagnosticsWithLightTreeTestGenerated extends Abstrac
             }
 
             @Test
+            @TestMetadata("intersectFlexibleAndMutable.kt")
+            public void testIntersectFlexibleAndMutable() throws Exception {
+                runTest("compiler/testData/diagnostics/testsWithStdLib/java/intersectFlexibleAndMutable.kt");
+            }
+
+            @Test
             @TestMetadata("patternCompileCallableReference.kt")
             public void testPatternCompileCallableReference() throws Exception {
                 runTest("compiler/testData/diagnostics/testsWithStdLib/java/patternCompileCallableReference.kt");

--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrTypeConverter.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrTypeConverter.kt
@@ -173,8 +173,8 @@ class Fir2IrTypeConverter(
             is ConeFlexibleType -> with(session.typeContext) {
                 if (upperBound is ConeClassLikeType) {
                     val upper = upperBound as ConeClassLikeType
-                    val lower = lowerBound as? ConeClassLikeType ?: error("Expecting class-like type, got $lowerBound")
-                    val intermediate = if (lower.lookupTag == upper.lookupTag) {
+                    val lower = lowerBound
+                    val intermediate = if (lower is ConeClassLikeType && lower.lookupTag == upper.lookupTag) {
                         lower.replaceArguments(upper.getArguments())
                     } else lower
                     (intermediate.withNullability(upper.isNullable) as ConeKotlinType)

--- a/compiler/testData/diagnostics/tests/j+k/purelyImplementedSupertype.fir.kt
+++ b/compiler/testData/diagnostics/tests/j+k/purelyImplementedSupertype.fir.kt
@@ -21,7 +21,7 @@ fun testWithUtil(map: ConcurrentHashMap<Int, String>): Int {
     if (string == null) {
         string = Util.getString()
     }
-    return string<!UNSAFE_CALL!>.<!>length
+    return string.length
 }
 
 fun test(list: java.util.ArrayList<String?>) {

--- a/compiler/testData/diagnostics/testsWithStdLib/java/intersectFlexibleAndMutable.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/java/intersectFlexibleAndMutable.kt
@@ -1,0 +1,14 @@
+// FIR_IDENTICAL
+// FILE: Util.java
+import java.util.List;
+
+public class Util {
+    public static <T> List<T> id(List<T> x) { return x; }
+}
+
+// FILE: main.kt
+fun main() {
+    var list = mutableListOf(1)
+    list = Util.id(list)
+    list += 2
+}

--- a/compiler/testData/diagnostics/testsWithStdLib/java/intersectFlexibleAndMutable.txt
+++ b/compiler/testData/diagnostics/testsWithStdLib/java/intersectFlexibleAndMutable.txt
@@ -1,0 +1,13 @@
+package
+
+public fun main(): kotlin.Unit
+
+public open class Util {
+    public constructor Util()
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+
+    // Static members
+    public open fun </*0*/ T : kotlin.Any!> id(/*0*/ x: kotlin.collections.(Mutable)List<T!>!): kotlin.collections.(Mutable)List<T!>!
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/DiagnosticTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/DiagnosticTestGenerated.java
@@ -38845,6 +38845,12 @@ public class DiagnosticTestGenerated extends AbstractDiagnosticTest {
             }
 
             @Test
+            @TestMetadata("intersectFlexibleAndMutable.kt")
+            public void testIntersectFlexibleAndMutable() throws Exception {
+                runTest("compiler/testData/diagnostics/testsWithStdLib/java/intersectFlexibleAndMutable.kt");
+            }
+
+            @Test
             @TestMetadata("patternCompileCallableReference.kt")
             public void testPatternCompileCallableReference() throws Exception {
                 runTest("compiler/testData/diagnostics/testsWithStdLib/java/patternCompileCallableReference.kt");


### PR DESCRIPTION
So `A & (A..B)` = `A` and `B & (A..B)` = `A..B`.

Seems to make sense under the "unknown nullability" interpretation of flexible types that they take a place between the lower and upper bounds in smart casts.

^KT-54522 Fixed