### PR TITLE
Restore kludge to deal with typed null values in spilled var analysis

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/coroutines/CoroutineTransformerMethodVisitor.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/coroutines/CoroutineTransformerMethodVisitor.kt
@@ -668,7 +668,7 @@ class CoroutineTransformerMethodVisitor(
                 val value = frame.getLocal(slot)
                 if (value.type == null || (shouldOptimiseUnusedVariables && !livenessFrame.isAlive(slot))) continue
 
-                if (value == StrictBasicValue.NULL_VALUE) {
+                if (value == StrictBasicValue.NULL_VALUE || value is TypedNullValue) {
                     referencesToSpill += slot to null
                     continue
                 }

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/coroutines/SpilledVariableFieldTypesAnalysis.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/coroutines/SpilledVariableFieldTypesAnalysis.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.codegen.coroutines
 import org.jetbrains.kotlin.codegen.StackValue
 import org.jetbrains.kotlin.codegen.optimization.common.FastMethodAnalyzer
 import org.jetbrains.kotlin.codegen.optimization.common.OptimizationBasicInterpreter
+import org.jetbrains.kotlin.codegen.optimization.common.StrictBasicValue
 import org.jetbrains.org.objectweb.asm.Label
 import org.jetbrains.org.objectweb.asm.Opcodes
 import org.jetbrains.org.objectweb.asm.Type
@@ -134,7 +135,7 @@ internal fun performSpilledVariableFieldTypesAnalysis(
     for ((insn, type) in interpreter.needsToBeCoerced) {
         methodNode.instructions.insert(insn, withInstructionAdapter { coerceInt(type, this) })
     }
-    return FastMethodAnalyzer(thisName, methodNode, OptimizationBasicInterpreter()).analyze()
+    return FastMethodAnalyzer(thisName, methodNode, NullCheckcastAwareOptimizationBasicInterpreter()).analyze()
 }
 
 private fun coerceInt(to: Type, v: InstructionAdapter) {
@@ -157,4 +158,25 @@ private fun coerceInt(to: Type, v: InstructionAdapter) {
 private fun Type.isIntLike(): Boolean = when (sort) {
     Type.BOOLEAN, Type.BYTE, Type.CHAR, Type.SHORT -> true
     else -> false
+}
+
+// Represents [ACONST_NULL, CHECKCAST Type] sequence result.
+internal class TypedNullValue(type: Type) : StrictBasicValue(type)
+
+// Preserves nulls through CHECKCASTS.
+private class NullCheckcastAwareOptimizationBasicInterpreter : OptimizationBasicInterpreter() {
+    override fun unaryOperation(insn: AbstractInsnNode, value: BasicValue?): BasicValue? {
+        if (insn.opcode == Opcodes.CHECKCAST && (value == StrictBasicValue.NULL_VALUE || value is TypedNullValue)) {
+            return TypedNullValue(Type.getObjectType((insn as TypeInsnNode).desc))
+        }
+        return super.unaryOperation(insn, value)
+    }
+
+    override fun merge(v: BasicValue, w: BasicValue): BasicValue =
+        when {
+            v is TypedNullValue && w is TypedNullValue -> if (v.type == w.type) v else StrictBasicValue.NULL_VALUE
+            v is TypedNullValue -> super.merge(StrictBasicValue.NULL_VALUE, w)
+            w is TypedNullValue -> super.merge(v, StrictBasicValue.NULL_VALUE)
+            else -> super.merge(v, w)
+        }
 }

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/common/OptimizationBasicInterpreter.java
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/common/OptimizationBasicInterpreter.java
@@ -204,7 +204,7 @@ public class OptimizationBasicInterpreter extends Interpreter<BasicValue> implem
             case DREM:
                 return StrictBasicValue.DOUBLE_VALUE;
             case AALOAD:
-                return StrictBasicValue.NULL_VALUE;
+                return StrictBasicValue.REFERENCE_VALUE;
             case LCMP:
             case FCMPL:
             case FCMPG:

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -4830,6 +4830,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         }
 
         @Test
+        @TestMetadata("kt54802.kt")
+        public void testKt54802() throws Exception {
+            runTest("compiler/testData/codegen/box/casts/kt54802.kt");
+        }
+
+        @Test
         @TestMetadata("lambdaToUnitCast.kt")
         public void testLambdaToUnitCast() throws Exception {
             runTest("compiler/testData/codegen/box/casts/lambdaToUnitCast.kt");

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -651,6 +651,20 @@ class ExpressionCodegen(
             val value = initializer.accept(this, data)
             initializer.markLineNumber(startOffset = true)
             value.materializeAt(varType, declaration.type)
+
+            // We need to generate CHECKCAST from ACONST_NULL here for coroutines,
+            // since otherwise, upon spilling and then unspilling, we will get VerifyError,
+            // because state-machine builder does not know the type of the ACONST_NULL
+            // and assumes it to be Ljava/lang/Object;, which is incorrect.
+            // Generating CHECKCAST hints the state-machine builder the type of the variable
+            // avoiding the issue of VerifyError. See KT-51718
+            // Exception is Ljava/lang/Object;, since CHECKCAST Ljava/lang/Object; is effectively no-op.
+            if (initializer.isNullConst() && varType != OBJECT_TYPE &&
+                (irFunction.isSuspend || irFunction.isInvokeSuspendOfLambda())
+            ) {
+                mv.checkcast(varType)
+            }
+
             declaration.markLineNumber(startOffset = true)
             mv.store(index, varType)
         } else if (declaration.isVisibleInLVT) {

--- a/compiler/testData/codegen/box/casts/kt54707.kt
+++ b/compiler/testData/codegen/box/casts/kt54707.kt
@@ -1,6 +1,3 @@
-// IGNORE_BACKEND: JVM
-// IGNORE_LIGHT_ANALYSIS
-
 fun box(): String =
     g(arrayOf("O"))
 
@@ -12,4 +9,3 @@ inline fun <T> Array<out T>.f(lambda: (T) -> T): T =
 
 inline fun <reified T> Array<out T>?.orEmpty0(): Array<out T> =
     this ?: (arrayOfNulls<T>(0) as Array<T>)
-

--- a/compiler/testData/codegen/box/casts/kt54802.kt
+++ b/compiler/testData/codegen/box/casts/kt54802.kt
@@ -1,0 +1,14 @@
+class K {
+    val x: String = "OK"
+}
+
+inline fun <T> Array<out T>.ifEmpty(body: () -> Array<out T>): Array<out T> =
+    if (size == 0) body() else this
+
+inline fun <T> Array<out T>.f(p: (T) -> String): String =
+    p(this[0])
+
+fun box(): String =
+    emptyArray<K>()
+        .ifEmpty { arrayOf(K()) }
+        .f(K::x)

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -4698,6 +4698,12 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
         }
 
         @Test
+        @TestMetadata("kt54802.kt")
+        public void testKt54802() throws Exception {
+            runTest("compiler/testData/codegen/box/casts/kt54802.kt");
+        }
+
+        @Test
         @TestMetadata("lambdaToUnitCast.kt")
         public void testLambdaToUnitCast() throws Exception {
             runTest("compiler/testData/codegen/box/casts/lambdaToUnitCast.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -4830,6 +4830,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         }
 
         @Test
+        @TestMetadata("kt54802.kt")
+        public void testKt54802() throws Exception {
+            runTest("compiler/testData/codegen/box/casts/kt54802.kt");
+        }
+
+        @Test
         @TestMetadata("lambdaToUnitCast.kt")
         public void testLambdaToUnitCast() throws Exception {
             runTest("compiler/testData/codegen/box/casts/lambdaToUnitCast.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -3958,11 +3958,6 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)
     public static class Casts extends AbstractLightAnalysisModeTest {
-        @TestMetadata("kt54707.kt")
-        public void ignoreKt54707() throws Exception {
-            runTest("compiler/testData/codegen/box/casts/kt54707.kt");
-        }
-
         private void runTest(String testDataFilePath) throws Exception {
             KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM, testDataFilePath);
         }
@@ -4094,6 +4089,16 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
         @TestMetadata("kt54581.kt")
         public void testKt54581() throws Exception {
             runTest("compiler/testData/codegen/box/casts/kt54581.kt");
+        }
+
+        @TestMetadata("kt54707.kt")
+        public void testKt54707() throws Exception {
+            runTest("compiler/testData/codegen/box/casts/kt54707.kt");
+        }
+
+        @TestMetadata("kt54802.kt")
+        public void testKt54802() throws Exception {
+            runTest("compiler/testData/codegen/box/casts/kt54802.kt");
         }
 
         @TestMetadata("lambdaToUnitCast.kt")

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/JsCodegenBoxTestGenerated.java
@@ -3420,6 +3420,12 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
         }
 
         @Test
+        @TestMetadata("kt54802.kt")
+        public void testKt54802() throws Exception {
+            runTest("compiler/testData/codegen/box/casts/kt54802.kt");
+        }
+
+        @Test
         @TestMetadata("lambdaToUnitCast.kt")
         public void testLambdaToUnitCast() throws Exception {
             runTest("compiler/testData/codegen/box/casts/lambdaToUnitCast.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/IrJsCodegenBoxTestGenerated.java
@@ -3480,6 +3480,12 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
         }
 
         @Test
+        @TestMetadata("kt54802.kt")
+        public void testKt54802() throws Exception {
+            runTest("compiler/testData/codegen/box/casts/kt54802.kt");
+        }
+
+        @Test
         @TestMetadata("lambdaToUnitCast.kt")
         public void testLambdaToUnitCast() throws Exception {
             runTest("compiler/testData/codegen/box/casts/lambdaToUnitCast.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/testOld/wasm/semantics/IrCodegenBoxWasmTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/testOld/wasm/semantics/IrCodegenBoxWasmTestGenerated.java
@@ -3071,6 +3071,11 @@ public class IrCodegenBoxWasmTestGenerated extends AbstractIrCodegenBoxWasmTest 
             runTest("compiler/testData/codegen/box/casts/kt54707.kt");
         }
 
+        @TestMetadata("kt54802.kt")
+        public void testKt54802() throws Exception {
+            runTest("compiler/testData/codegen/box/casts/kt54802.kt");
+        }
+
         @TestMetadata("lambdaToUnitCast.kt")
         public void testLambdaToUnitCast() throws Exception {
             runTest("compiler/testData/codegen/box/casts/lambdaToUnitCast.kt");

--- a/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/NativeCodegenBoxTestGenerated.java
+++ b/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/NativeCodegenBoxTestGenerated.java
@@ -3554,6 +3554,12 @@ public class NativeCodegenBoxTestGenerated extends AbstractNativeCodegenBoxTest 
             }
 
             @Test
+            @TestMetadata("kt54802.kt")
+            public void testKt54802() throws Exception {
+                runTest("compiler/testData/codegen/box/casts/kt54802.kt");
+            }
+
+            @Test
             @TestMetadata("lambdaToUnitCast.kt")
             public void testLambdaToUnitCast() throws Exception {
                 runTest("compiler/testData/codegen/box/casts/lambdaToUnitCast.kt");


### PR DESCRIPTION
This is a partial revert of 0fc676a20cf (and thus a re-application of 7579be6c685). The main problem in that commit was the change in `OptimizationBasicInterpreter.binaryOperation` where some AALOAD operations started to produce null values, which became an issue since 65c153a722b where casts on such values started to be recognized as unnecessary and became incorrectly optimized out.

Returning `REFERENCE_VALUE` for any AALOAD would seem like the most natural solution, but unfortunately it breaks the test added in 7579be6c685 because the null value gets spilled again and coroutine transformer can't deduce its type, which leads to VerifyError.

So in this change, I'm restoring the original implementation from 7579be6c685 as it seems like the safest option.

 #KT-54802 Fixed