### PR TITLE
KT-54819 change slf4j-nop to slf4j-api

### DIFF
--- a/libraries/tools/kotlin-main-kts/build.gradle.kts
+++ b/libraries/tools/kotlin-main-kts/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
     embedded(project(":kotlin-scripting-jvm")) { isTransitive = false }
     embedded(project(":kotlin-scripting-jvm-host-unshaded")) { isTransitive = false }
     embedded(project(":kotlin-scripting-dependencies-maven-all")) { isTransitive = false }
-    embedded("org.slf4j:slf4j-nop:1.7.30")
+    embedded("org.slf4j:slf4j-api:1.7.30")
     embedded(commonDependency("org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm")) {
         isTransitive = false
         attributes {


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-54819/

> Note that embedded components such as libraries or frameworks should not declare a dependency on any SLF4J binding but only depend on slf4j-api. When a library declares a compile-time dependency on a SLF4J binding, it imposes that binding on the end-user, thus negating SLF4J's purpose.
> https://www.slf4j.org/codes.html#StaticLoggerBinder