### PR TITLE
[JVM] Retain deprecated status for interface companion const property.

### DIFF
--- a/compiler/testData/codegen/bytecodeListing/deprecatedConstantPropertyInterfaceCompanion.kt
+++ b/compiler/testData/codegen/bytecodeListing/deprecatedConstantPropertyInterfaceCompanion.kt
@@ -1,0 +1,13 @@
+interface A {
+    companion object {
+        @Deprecated("no")
+        const val s = "yes"
+    }
+}
+
+class B {
+    companion object {
+        @Deprecated("no")
+        const val s = "yes"
+    }
+}

--- a/compiler/testData/codegen/bytecodeListing/deprecatedConstantPropertyInterfaceCompanion.txt
+++ b/compiler/testData/codegen/bytecodeListing/deprecatedConstantPropertyInterfaceCompanion.txt
@@ -1,0 +1,38 @@
+@kotlin.Metadata
+public final class A$Companion {
+    // source: 'deprecatedConstantPropertyInterfaceCompanion.kt'
+    synthetic final static field $$INSTANCE: A$Companion
+    public deprecated final static @org.jetbrains.annotations.NotNull field s: java.lang.String
+    static method <clinit>(): void
+    private method <init>(): void
+    public synthetic deprecated static @kotlin.Deprecated(message="no") method getS$annotations(): void
+    public final inner class A$Companion
+}
+
+@kotlin.Metadata
+public interface A {
+    // source: 'deprecatedConstantPropertyInterfaceCompanion.kt'
+    public final static @org.jetbrains.annotations.NotNull field Companion: A$Companion
+    public final static @kotlin.Deprecated(message="no") @org.jetbrains.annotations.NotNull field s: java.lang.String
+    static method <clinit>(): void
+    public final inner class A$Companion
+}
+
+@kotlin.Metadata
+public final class B$Companion {
+    // source: 'deprecatedConstantPropertyInterfaceCompanion.kt'
+    private method <init>(): void
+    public synthetic method <init>(p0: kotlin.jvm.internal.DefaultConstructorMarker): void
+    public synthetic deprecated static @kotlin.Deprecated(message="no") method getS$annotations(): void
+    public final inner class B$Companion
+}
+
+@kotlin.Metadata
+public final class B {
+    // source: 'deprecatedConstantPropertyInterfaceCompanion.kt'
+    public final static @org.jetbrains.annotations.NotNull field Companion: B$Companion
+    public deprecated final static @org.jetbrains.annotations.NotNull field s: java.lang.String
+    static method <clinit>(): void
+    public method <init>(): void
+    public final inner class B$Companion
+}

--- a/compiler/testData/codegen/bytecodeListing/deprecatedConstantPropertyInterfaceCompanion_ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/deprecatedConstantPropertyInterfaceCompanion_ir.txt
@@ -1,0 +1,38 @@
+@kotlin.Metadata
+public final class A$Companion {
+    // source: 'deprecatedConstantPropertyInterfaceCompanion.kt'
+    synthetic final static field $$INSTANCE: A$Companion
+    public deprecated final static @org.jetbrains.annotations.NotNull field s: java.lang.String
+    static method <clinit>(): void
+    private method <init>(): void
+    public synthetic deprecated static @kotlin.Deprecated(message="no") method getS$annotations(): void
+    public final inner class A$Companion
+}
+
+@kotlin.Metadata
+public interface A {
+    // source: 'deprecatedConstantPropertyInterfaceCompanion.kt'
+    public final static @org.jetbrains.annotations.NotNull field Companion: A$Companion
+    public deprecated final static @org.jetbrains.annotations.NotNull field s: java.lang.String
+    static method <clinit>(): void
+    public final inner class A$Companion
+}
+
+@kotlin.Metadata
+public final class B$Companion {
+    // source: 'deprecatedConstantPropertyInterfaceCompanion.kt'
+    private method <init>(): void
+    public synthetic method <init>(p0: kotlin.jvm.internal.DefaultConstructorMarker): void
+    public synthetic deprecated static @kotlin.Deprecated(message="no") method getS$annotations(): void
+    public final inner class B$Companion
+}
+
+@kotlin.Metadata
+public final class B {
+    // source: 'deprecatedConstantPropertyInterfaceCompanion.kt'
+    public final static @org.jetbrains.annotations.NotNull field Companion: B$Companion
+    public deprecated final static @org.jetbrains.annotations.NotNull field s: java.lang.String
+    static method <clinit>(): void
+    public method <init>(): void
+    public final inner class B$Companion
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BytecodeListingTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BytecodeListingTestGenerated.java
@@ -98,6 +98,12 @@ public class BytecodeListingTestGenerated extends AbstractBytecodeListingTest {
     }
 
     @Test
+    @TestMetadata("deprecatedConstantPropertyInterfaceCompanion.kt")
+    public void testDeprecatedConstantPropertyInterfaceCompanion() throws Exception {
+        runTest("compiler/testData/codegen/bytecodeListing/deprecatedConstantPropertyInterfaceCompanion.kt");
+    }
+
+    @Test
     @TestMetadata("deserializeLambdaMethod.kt")
     public void testDeserializeLambdaMethod() throws Exception {
         runTest("compiler/testData/codegen/bytecodeListing/deserializeLambdaMethod.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBytecodeListingTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBytecodeListingTestGenerated.java
@@ -98,6 +98,12 @@ public class IrBytecodeListingTestGenerated extends AbstractIrBytecodeListingTes
     }
 
     @Test
+    @TestMetadata("deprecatedConstantPropertyInterfaceCompanion.kt")
+    public void testDeprecatedConstantPropertyInterfaceCompanion() throws Exception {
+        runTest("compiler/testData/codegen/bytecodeListing/deprecatedConstantPropertyInterfaceCompanion.kt");
+    }
+
+    @Test
     @TestMetadata("deserializeLambdaMethod.kt")
     public void testDeserializeLambdaMethod() throws Exception {
         runTest("compiler/testData/codegen/bytecodeListing/deserializeLambdaMethod.kt");


### PR DESCRIPTION
Create the field directly and maintain the fact that its corresponding property is the companion object property. That property has the deprecated annotation which puts the deprecated marker on the field when code generating the field.

^KT-54840 Fixed