### PR TITLE
FIR: deserialize value class representation from metadata

### DIFF
--- a/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/types/SupertypesAndBounds.txt
+++ b/compiler/fir/analysis-tests/testData/loadCompiledKotlin/annotations/types/SupertypesAndBounds.txt
@@ -3,7 +3,7 @@
 
 }
 
-public abstract interface Foo<T : R|@R|test/A|()  kotlin/Number|> : R|java/io/Serializable| {
+public abstract interface Foo<T : R|@R|test/A|()  kotlin/Number|> : R|@R|test/A|()  java/io/Serializable| {
     public abstract fun <E, F : R|E|> bar(): R|kotlin/Unit|
 
 }

--- a/compiler/fir/fir-deserialization/src/org/jetbrains/kotlin/fir/deserialization/FirMemberDeserializer.kt
+++ b/compiler/fir/fir-deserialization/src/org/jetbrains/kotlin/fir/deserialization/FirMemberDeserializer.kt
@@ -635,11 +635,6 @@ class FirMemberDeserializer(private val c: FirDeserializationContext) {
         }.toList()
     }
 
-    private fun ProtoBuf.Type.toTypeRef(context: FirDeserializationContext): FirTypeRef {
-        return buildResolvedTypeRef {
-            annotations += context.annotationDeserializer.loadTypeAnnotations(this@toTypeRef, context.nameResolver)
-            val attributes = annotations.computeTypeAttributes(context.session)
-            type = context.typeDeserializer.type(this@toTypeRef, attributes)
-        }
-    }
+    private fun ProtoBuf.Type.toTypeRef(context: FirDeserializationContext): FirTypeRef =
+        context.typeDeserializer.typeRef(this)
 }

--- a/core/deserialization.common/src/org/jetbrains/kotlin/serialization/deserialization/ValueClassUtil.kt
+++ b/core/deserialization.common/src/org/jetbrains/kotlin/serialization/deserialization/ValueClassUtil.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.serialization.deserialization
+
+import org.jetbrains.kotlin.descriptors.InlineClassRepresentation
+import org.jetbrains.kotlin.descriptors.MultiFieldValueClassRepresentation
+import org.jetbrains.kotlin.descriptors.ValueClassRepresentation
+import org.jetbrains.kotlin.metadata.ProtoBuf
+import org.jetbrains.kotlin.metadata.deserialization.NameResolver
+import org.jetbrains.kotlin.metadata.deserialization.TypeTable
+import org.jetbrains.kotlin.metadata.deserialization.inlineClassUnderlyingType
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.types.model.SimpleTypeMarker
+
+fun <T : SimpleTypeMarker> ProtoBuf.Class.loadValueClassRepresentation(
+    nameResolver: NameResolver,
+    typeTable: TypeTable,
+    typeDeserializer: (ProtoBuf.Type) -> T,
+    typeOfPublicProperty: (Name) -> T?,
+): ValueClassRepresentation<T>? {
+    if (multiFieldValueClassUnderlyingNameCount > 0) {
+        val names = multiFieldValueClassUnderlyingNameList.map { nameResolver.getName(it) }
+        val typeIdCount = multiFieldValueClassUnderlyingTypeIdCount
+        val typeCount = multiFieldValueClassUnderlyingTypeCount
+        val types = when (typeIdCount to typeCount) {
+            names.size to 0 -> multiFieldValueClassUnderlyingTypeIdList.map { typeTable[it] }
+            0 to names.size -> multiFieldValueClassUnderlyingTypeList
+            else -> error("class ${nameResolver.getName(fqName)} has illegal multi-field value class representation")
+        }.map(typeDeserializer)
+        return MultiFieldValueClassRepresentation(names zip types)
+    }
+
+    if (hasInlineClassUnderlyingPropertyName()) {
+        val propertyName = nameResolver.getName(inlineClassUnderlyingPropertyName)
+        val propertyType = inlineClassUnderlyingType(typeTable)?.let(typeDeserializer)
+            ?: typeOfPublicProperty(propertyName)
+            ?: error("cannot determine underlying type for value class ${nameResolver.getName(fqName)} with property $propertyName")
+        return InlineClassRepresentation(propertyName, propertyType)
+    }
+
+    return null
+}

--- a/core/deserialization/src/org/jetbrains/kotlin/serialization/deserialization/descriptors/DeserializedClassDescriptor.kt
+++ b/core/deserialization/src/org/jetbrains/kotlin/serialization/deserialization/descriptors/DeserializedClassDescriptor.kt
@@ -162,7 +162,7 @@ class DeserializedClassDescriptor(
                 null
             ),
             Annotations.EMPTY
-        );
+        )
     }
 
     private fun computeCompanionObjectDescriptor(): ClassDescriptor? {
@@ -196,60 +196,23 @@ class DeserializedClassDescriptor(
     override fun getValueClassRepresentation(): ValueClassRepresentation<SimpleType>? = valueClassRepresentation()
 
     private fun computeValueClassRepresentation(): ValueClassRepresentation<SimpleType>? {
-        val inlineClassRepresentation = computeInlineClassRepresentation()
-        val multiFieldValueClassRepresentation = computeMultiFieldValueClassRepresentation()
-        return when {
-            inlineClassRepresentation != null && multiFieldValueClassRepresentation != null ->
-                throw IllegalArgumentException("Class cannot have both inline class representation and multi field class representation: $this")
-            (isValue || isInline) && inlineClassRepresentation == null && multiFieldValueClassRepresentation == null ->
-                throw IllegalArgumentException("Value class has no value class representation: $this")
-            else -> inlineClassRepresentation ?: multiFieldValueClassRepresentation
-        }
-    }
-
-    private fun computeInlineClassRepresentation(): InlineClassRepresentation<SimpleType>? {
         if (!isInline && !isValue) return null
-        if (isValue &&
-            !classProto.hasInlineClassUnderlyingPropertyName() &&
-            !classProto.hasInlineClassUnderlyingType() &&
-            !classProto.hasInlineClassUnderlyingTypeId() &&
-            classProto.multiFieldValueClassUnderlyingNameCount > 0
-        ) return null
-
-        val propertyName = when {
-            classProto.hasInlineClassUnderlyingPropertyName() ->
-                c.nameResolver.getName(classProto.inlineClassUnderlyingPropertyName)
-            !metadataVersion.isAtLeast(1, 5, 1) -> {
-                // Before 1.5, inline classes did not have underlying property name & type in the metadata.
-                // However, they were experimental, so supposedly this logic can be removed at some point in the future.
-                val constructor = unsubstitutedPrimaryConstructor ?: error("Inline class has no primary constructor: $this")
-                constructor.valueParameters.first().name
-            }
-            else -> error("Inline class has no underlying property name in metadata: $this")
+        classProto.loadValueClassRepresentation(c.nameResolver, c.typeTable, c.typeDeserializer::simpleType, ::getValueClassPropertyType)
+            ?.let { return it }
+        if (!metadataVersion.isAtLeast(1, 5, 1)) {
+            // Before 1.5, inline classes did not have underlying property name & type in the metadata.
+            // However, they were experimental, so supposedly this logic can be removed at some point in the future.
+            val constructor = unsubstitutedPrimaryConstructor ?: error("Inline class has no primary constructor: $this")
+            val propertyName = constructor.valueParameters.first().name
+            val propertyType = getValueClassPropertyType(propertyName) ?: error("Value class has no underlying property: $this")
+            return InlineClassRepresentation(propertyName, propertyType)
         }
-
-        val type = classProto.inlineClassUnderlyingType(c.typeTable)?.let(c.typeDeserializer::simpleType) ?: run {
-            val underlyingProperty = memberScope.getContributedVariables(propertyName, NoLookupLocation.FROM_DESERIALIZATION)
-                .singleOrNull { it.extensionReceiverParameter == null } ?: error("Value class has no underlying property: $this")
-            underlyingProperty.type as SimpleType
-        }
-
-        return InlineClassRepresentation(propertyName, type)
+        return null
     }
 
-    private fun computeMultiFieldValueClassRepresentation(): MultiFieldValueClassRepresentation<SimpleType>? {
-        val names = classProto.multiFieldValueClassUnderlyingNameList.map { c.nameResolver.getName(it) }.takeIf { it.isNotEmpty() } 
-            ?: return null
-        require(isValue) { "Not a value class: $this" }
-        val typeIdCount = classProto.multiFieldValueClassUnderlyingTypeIdCount
-        val typeCount = classProto.multiFieldValueClassUnderlyingTypeCount
-        val types = when (typeIdCount to typeCount) {
-            names.size to 0 -> classProto.multiFieldValueClassUnderlyingTypeIdList.map { c.typeTable[it] }
-            0 to names.size -> classProto.multiFieldValueClassUnderlyingTypeList
-            else -> error("Illegal multi-field value class representation: $this")
-        }.map { c.typeDeserializer.simpleType(it) }
-        return MultiFieldValueClassRepresentation(names zip types)
-    }
+    private fun getValueClassPropertyType(propertyName: Name): SimpleType? =
+        memberScope.getContributedVariables(propertyName, NoLookupLocation.FROM_DESERIALIZATION)
+            .singleOrNull { it.extensionReceiverParameter == null }?.type as SimpleType?
 
     override fun toString() =
         "deserialized ${if (isExpect) "expect " else ""}class $name" // not using descriptor renderer to preserve laziness


### PR DESCRIPTION
This is necessary when jvm-abi-gen strips out private constructors. I don't know if there is test infrastructure for this. @sfs you'll like this.

Also it seems I've accidentally fixed deserialization of annotations on supertypes.

^KT-54897 Fixed