### PR TITLE
FIR: render entire declaration header in *_MISMATCH_ON_OVERRIDE

### DIFF
--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/FirErrorsDefaultMessages.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/FirErrorsDefaultMessages.kt
@@ -1333,19 +1333,19 @@ object FirErrorsDefaultMessages : BaseDiagnosticRendererFactory() {
             RETURN_TYPE_MISMATCH_ON_OVERRIDE,
             "Return type of ''{0}'' is not a subtype of the return type of the overridden member ''{1}''",
             DECLARATION_NAME,
-            DECLARATION_NAME
+            SYMBOL
         )
         map.put(
             PROPERTY_TYPE_MISMATCH_ON_OVERRIDE,
             "Type of ''{0}'' is not a subtype of the overridden property ''{1}''",
             DECLARATION_NAME,
-            DECLARATION_NAME
+            SYMBOL
         )
         map.put(
             VAR_TYPE_MISMATCH_ON_OVERRIDE,
             "Type of ''{0}'' doesn''t match the type of the overridden var-property ''{1}''",
             DECLARATION_NAME,
-            DECLARATION_NAME
+            SYMBOL
         )
 
         map.put(


### PR DESCRIPTION
Otherwise it's really not clear what exactly the type is supposed to be.