### PR TITLE
Implement ObjC class name generation based on Kotlin class FQNames

### DIFF
--- a/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/arguments/K2NativeCompilerArguments.kt
+++ b/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/arguments/K2NativeCompilerArguments.kt
@@ -375,6 +375,12 @@ class K2NativeCompilerArguments : CommonCompilerArguments() {
     @Argument(value = "-Xruntime-logs", valueDescription = "<tag1=level1,tag2=level2,...>", description = "Enable logging for runtime with tags.")
     var runtimeLogs: String? = null
 
+    @Argument(value = "-Xtop-level-prefix", valueDescription = "<prefix>", description = "Top level prefix for generated Objective-C classes and C functions.")
+    var topLevelPrefix: String? = null
+
+    @Argument(value = "-Xobjc-fqnames", description = "Use Fully Qualified Kotlin Class names when generating ObjC Classes.")
+    var objcFqnames: Boolean = false
+
     @Argument(
         value = "-Xdump-tests-to",
         valueDescription = "<path>",

--- a/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/serialization/LegacyDescriptorUtils.kt
+++ b/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/serialization/LegacyDescriptorUtils.kt
@@ -36,7 +36,7 @@ val ModuleDescriptor.isForwardDeclarationModule get() =
 private fun sourceByIndex(descriptor: CallableMemberDescriptor, index: Int): SourceFile {
     val fragment = descriptor.findPackage() as KlibMetadataDeserializedPackageFragment
     val fileName = fragment.proto.strings.stringList[index]
-    return DeserializedSourceFile(fileName, descriptor.module.kotlinLibrary)
+    return DeserializedSourceFile(fileName, descriptor.module.kotlinLibrary, fragment.fqName)
 }
 
 fun CallableMemberDescriptor.findSourceFile(): SourceFile {

--- a/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/DeserializedSourceFile.kt
+++ b/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/DeserializedSourceFile.kt
@@ -6,9 +6,10 @@ package org.jetbrains.kotlin.library.metadata
 
 import org.jetbrains.kotlin.descriptors.SourceFile
 import org.jetbrains.kotlin.library.KotlinLibrary
+import org.jetbrains.kotlin.name.FqName
 
 class DeserializedSourceFile(
-    val name_: String, val library: KotlinLibrary
+    val name_: String, val library: KotlinLibrary, val packageFqName: FqName
 ) : SourceFile {
     override fun getName(): String? = name_
 

--- a/kotlin-native/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2Native.kt
+++ b/kotlin-native/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2Native.kt
@@ -147,8 +147,9 @@ class K2Native : CLICompiler<K2NativeCompilerArguments>() {
                         arguments.singleLinkerArguments.toNonNullList())
                 arguments.moduleName?.let{ put(MODULE_NAME, it) }
 
-                // TODO: allow overriding the prefix directly.
-                arguments.moduleName?.let { put(FULL_EXPORTED_NAME_PREFIX, it) }
+                (arguments.topLevelPrefix ?: arguments.moduleName)?.let { put(FULL_EXPORTED_NAME_PREFIX, it) }
+
+                put(OBJC_FQNAMES, arguments.objcFqnames)
 
                 arguments.target?.let{ put(TARGET, it) }
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanCompilerFrontendServices.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanCompilerFrontendServices.kt
@@ -41,6 +41,9 @@ internal fun StorageComponentContainer.initContainer(config: KonanConfig) {
 
             override val unitSuspendFunctionExport: UnitSuspendFunctionObjCExport
                 get() = config.unitSuspendFunctionObjCExport
+
+            override val objcFqnames: Boolean
+                get() = config.objcFqnames
         })
     }
 }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanConfig.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanConfig.kt
@@ -232,6 +232,9 @@ class KonanConfig(val project: Project, val configuration: CompilerConfiguration
     val fullExportedNamePrefix: String
         get() = configuration.get(KonanConfigKeys.FULL_EXPORTED_NAME_PREFIX) ?: implicitModuleName
 
+    val objcFqnames: Boolean
+        get() = configuration.getBoolean(KonanConfigKeys.OBJC_FQNAMES)
+
     val moduleId: String
         get() = configuration.get(KonanConfigKeys.MODULE_NAME) ?: implicitModuleName
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanConfigurationKeys.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanConfigurationKeys.kt
@@ -83,6 +83,8 @@ class KonanConfigKeys {
                 = CompilerConfigurationKey.create("don't link with stdlib")
         val NOPACK: CompilerConfigurationKey<Boolean> 
                 = CompilerConfigurationKey.create("don't the library into a klib file")
+        val OBJC_FQNAMES: CompilerConfigurationKey<Boolean> 
+                = CompilerConfigurationKey.create("use kotlin fqnames to generate objc class names")
         val OPTIMIZATION: CompilerConfigurationKey<Boolean> 
                 = CompilerConfigurationKey.create("optimized compilation")
         val OUTPUT: CompilerConfigurationKey<String> 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExport.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExport.kt
@@ -48,7 +48,8 @@ internal fun produceObjCExportInterface(context: Context): ObjCExportedInterface
             mapper,
             topLevelNamePrefix,
             local = false,
-            objcGenerics = objcGenerics
+            objcGenerics = objcGenerics,
+            useFqnames = context.config.objcFqnames
     )
     val headerGenerator = ObjCExportHeaderGeneratorImpl(context, moduleDescriptors, mapper, namer, objcGenerics)
     headerGenerator.translateModule()
@@ -80,7 +81,8 @@ internal class ObjCExport(
                 context.moduleDescriptor.builtIns,
                 mapper,
                 topLevelNamePrefix,
-                local = false
+                local = false,
+                useFqnames = context.config.objcFqnames
         )
 
         val objCCodeGenerator = ObjCExportCodeGenerator(codegen, namer, mapper)

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportLazy.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportLazy.kt
@@ -45,6 +45,7 @@ interface ObjCExportLazy {
         fun getCompilerModuleName(moduleInfo: ModuleInfo): String
         val objcGenerics: Boolean
         val unitSuspendFunctionExport: UnitSuspendFunctionObjCExport
+        val objcFqnames: Boolean
     }
 
     fun generateBase(): List<ObjCTopLevel<*>>
@@ -447,6 +448,8 @@ internal fun createNamerConfiguration(configuration: ObjCExportLazy.Configuratio
         }
 
         override val objcGenerics = configuration.objcGenerics
+
+        override val useFqname = configuration.objcFqnames
     }
 }
 


### PR DESCRIPTION
Current Kotlin Native Objc Class name generation uses trailing underscores to name mangle classes with the same short name. This PR adds an additional compiler flag that switches to use the fully qualified Kotlin class name as the exported ObjC class name. 