### PR TITLE
Introduce KotlinJvmFactory.registerKotlinJvmCompileWithJavaTask

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-api/api/kotlin-gradle-plugin-api.api
+++ b/libraries/tools/kotlin-gradle-plugin-api/api/kotlin-gradle-plugin-api.api
@@ -922,6 +922,7 @@ public abstract interface class org/jetbrains/kotlin/gradle/plugin/KotlinJvmFact
 	public abstract fun registerKaptGenerateStubsTask (Ljava/lang/String;)Lorg/gradle/api/tasks/TaskProvider;
 	public abstract fun registerKaptTask (Ljava/lang/String;)Lorg/gradle/api/tasks/TaskProvider;
 	public abstract fun registerKotlinJvmCompileTask (Ljava/lang/String;)Lorg/gradle/api/tasks/TaskProvider;
+	public abstract fun registerKotlinJvmCompileWithJavaTask (Ljava/lang/String;)Lorg/gradle/api/tasks/TaskProvider;
 }
 
 public final class org/jetbrains/kotlin/gradle/plugin/KotlinPlatformType : java/lang/Enum, java/io/Serializable, org/gradle/api/Named {

--- a/libraries/tools/kotlin-gradle-plugin-api/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinJvmFactory.kt
+++ b/libraries/tools/kotlin-gradle-plugin-api/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinJvmFactory.kt
@@ -41,6 +41,9 @@ interface KotlinJvmFactory {
     /** Creates a Kotlin compile task. */
     fun registerKotlinJvmCompileTask(taskName: String): TaskProvider<out KotlinJvmCompile>
 
+    /** Creates a Kotlin compile task that accept java-only inputs. */
+    fun registerKotlinJvmCompileWithJavaTask(taskName: String): TaskProvider<out KotlinJvmCompile>
+
     /** Creates a stub generation task which creates Java sources stubs from Kotlin sources. */
     fun registerKaptGenerateStubsTask(taskName: String): TaskProvider<out KaptGenerateStubs>
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinBaseApiPlugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinBaseApiPlugin.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.gradle.internal.KaptGenerateStubsTask
 import org.jetbrains.kotlin.gradle.internal.KaptWithoutKotlincTask
 import org.jetbrains.kotlin.gradle.tasks.*
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
+import org.jetbrains.kotlin.gradle.tasks.configuration.BaseKotlinCompileConfig
 import org.jetbrains.kotlin.gradle.tasks.configuration.KaptGenerateStubsConfig
 import org.jetbrains.kotlin.gradle.tasks.configuration.KaptWithoutKotlincConfig
 import org.jetbrains.kotlin.gradle.tasks.configuration.KotlinCompileConfig
@@ -67,6 +68,15 @@ abstract class KotlinBaseApiPlugin : DefaultKotlinBasePlugin(), KotlinJvmFactory
             taskName,
             createCompilerJvmOptions(),
             KotlinCompileConfig(myProject, kotlinExtension)
+        )
+    }
+
+    override fun registerKotlinJvmCompileWithJavaTask(taskName: String): TaskProvider<out KotlinJvmCompile> {
+        return taskCreator.registerKotlinJVMWithJavaTask(
+            myProject,
+            taskName,
+            createCompilerJvmOptions(),
+            BaseKotlinCompileConfig<KotlinCompileWithJava>(myProject, kotlinExtension)
         )
     }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/Tasks.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/Tasks.kt
@@ -924,6 +924,33 @@ abstract class KotlinCompile @Inject constructor(
     }
 }
 
+/**
+ * KotlinCompile is skipped when there is no Kotlin souces.
+ * KotlinCompileWithJava runs when any of Kotlin or Java sources exist.
+ */
+@CacheableTask
+abstract class KotlinCompileWithJava @Inject constructor(
+    compilerOptions: KotlinJvmCompilerOptions,
+    workerExecutor: WorkerExecutor,
+    objectFactory: ObjectFactory
+) : KotlinCompile(compilerOptions, workerExecutor, objectFactory) {
+
+    override fun skipCondition(): Boolean = super.skipCondition() && javaSources.isEmpty
+
+    @get:SkipWhenEmpty
+    @get:InputFiles
+    @get:IgnoreEmptyDirectories
+    @get:NormalizeLineEndings
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    override val javaSources: FileCollection
+        get() = super.javaSources
+
+    override fun setupCompilerArgs(args: K2JVMCompilerArguments, defaultsOnly: Boolean, ignoreClasspathResolutionErrors: Boolean) {
+        super.setupCompilerArgs(args, defaultsOnly, ignoreClasspathResolutionErrors)
+        args.allowNoSourceFiles = true
+    }
+}
+
 @CacheableTask
 abstract class Kotlin2JsCompile @Inject constructor(
     override val compilerOptions: KotlinJsCompilerOptions,

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/TasksProvider.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/TasksProvider.kt
@@ -108,6 +108,17 @@ internal open class KotlinTasksProvider {
         }
     }
 
+    open fun registerKotlinJVMWithJavaTask(
+        project: Project,
+        taskName: String,
+        compilerOptions: KotlinJvmCompilerOptions,
+        configuration: BaseKotlinCompileConfig<KotlinCompileWithJava>
+    ): TaskProvider<out KotlinCompile> {
+        return project.registerTask(taskName, KotlinCompileWithJava::class.java, constructorArgs = listOf(compilerOptions)).also {
+            configuration.execute(it)
+        }
+    }
+
     fun registerKotlinJSTask(
         project: Project,
         taskName: String,


### PR DESCRIPTION
to create a `KotlinJvmCompile` that handles Java only cases.

`KotlinCompile` is skipped when there is no Kotlin sources. `KotlinCompileWithJava` runs when there are Kotlin or Java sources.

KT-52147