### PR TITLE
FIR: keep nullability when serializing suspend function types

### DIFF
--- a/compiler/fir/fir2ir/testData/codegen/bytecodeListing/nullabilityAnnotations/suspendFunction.kt
+++ b/compiler/fir/fir2ir/testData/codegen/bytecodeListing/nullabilityAnnotations/suspendFunction.kt
@@ -1,0 +1,11 @@
+// MODULE: lib
+// FILE: 1.kt
+interface I {
+    fun foo(x: (suspend () -> Unit)?): (suspend () -> Unit)?
+}
+
+// MODULE: main(lib)
+// FILE: 2.kt
+class C : I {
+    override fun foo(x: (suspend () -> Unit)?) = x
+}

--- a/compiler/fir/fir2ir/testData/codegen/bytecodeListing/nullabilityAnnotations/suspendFunction.txt
+++ b/compiler/fir/fir2ir/testData/codegen/bytecodeListing/nullabilityAnnotations/suspendFunction.txt
@@ -1,0 +1,13 @@
+Module: lib
+@kotlin.Metadata
+public interface I {
+    // source: '1.kt'
+    public abstract @org.jetbrains.annotations.Nullable method foo(@org.jetbrains.annotations.Nullable p0: kotlin.jvm.functions.Function1): kotlin.jvm.functions.Function1
+}
+Module: main
+@kotlin.Metadata
+public final class C {
+    // source: '2.kt'
+    public method <init>(): void
+    public @org.jetbrains.annotations.Nullable method foo(@org.jetbrains.annotations.Nullable p0: kotlin.jvm.functions.Function1): kotlin.jvm.functions.Function1
+}

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/Fir2IrSpecificBytecodeListingTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/Fir2IrSpecificBytecodeListingTestGenerated.java
@@ -26,6 +26,22 @@ public class Fir2IrSpecificBytecodeListingTestGenerated extends AbstractFirBytec
     }
 
     @Nested
+    @TestMetadata("compiler/fir/fir2ir/testData/codegen/bytecodeListing/nullabilityAnnotations")
+    @TestDataPath("$PROJECT_ROOT")
+    public class NullabilityAnnotations {
+        @Test
+        public void testAllFilesPresentInNullabilityAnnotations() throws Exception {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/fir/fir2ir/testData/codegen/bytecodeListing/nullabilityAnnotations"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+        }
+
+        @Test
+        @TestMetadata("suspendFunction.kt")
+        public void testSuspendFunction() throws Exception {
+            runTest("compiler/fir/fir2ir/testData/codegen/bytecodeListing/nullabilityAnnotations/suspendFunction.kt");
+        }
+    }
+
+    @Nested
     @TestMetadata("compiler/fir/fir2ir/testData/codegen/bytecodeListing/properties")
     @TestDataPath("$PROJECT_ROOT")
     public class Properties {

--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/types/InferenceUtils.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/types/InferenceUtils.kt
@@ -127,7 +127,7 @@ fun ConeKotlinType.suspendFunctionTypeToFunctionTypeWithContinuation(session: Fi
             arrayOf(lastTypeArgument),
             isNullable = false
         ) + lastTypeArgument).toTypedArray(),
-        isNullable = false,
+        isNullable = fullyExpandedType.isNullable,
         attributes = fullyExpandedType.attributes
     )
 }


### PR DESCRIPTION
No clue where to put the test for that since diagnostic tests, even multi-module ones, keep everything in memory and never touch the serializer. So the test is a bytecode text one pretending to be about nullability annotations even though it also affects what resolution in another module will do.