### PR TITLE
JVM Inline: Update tryCatchBlocks when expand mask conditions

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/defaultMethodUtil.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/defaultMethodUtil.kt
@@ -112,6 +112,10 @@ fun expandMaskConditionsAndUpdateVariableNodes(
         (it.start in toDelete && it.end in toDelete) || validOffsets.contains(it.index)
     }
 
+    node.tryCatchBlocks.removeIf {
+        toDelete.contains(it.start) && toDelete.contains(it.end)
+    }
+
     node.remove(toDelete)
 
     return defaultLambdasInfo

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxCodegenTestGenerated.java
@@ -18848,6 +18848,12 @@ public class FirBlackBoxCodegenTestGenerated extends AbstractFirBlackBoxCodegenT
         }
 
         @Test
+        @TestMetadata("kt48989.kt")
+        public void testKt48989() throws Exception {
+            runTest("compiler/testData/codegen/box/functions/kt48989.kt");
+        }
+
+        @Test
         @TestMetadata("kt785.kt")
         public void testKt785() throws Exception {
             runTest("compiler/testData/codegen/box/functions/kt785.kt");

--- a/compiler/testData/codegen/box/functions/kt48989.kt
+++ b/compiler/testData/codegen/box/functions/kt48989.kt
@@ -1,0 +1,9 @@
+// TARGET_BACKEND: JVM_IR
+fun box() = inlineFunctionWithDefaultArguments("OK")
+
+inline fun inlineFunctionWithDefaultArguments(
+    p0: String = try {
+        "42"
+    } finally {
+    }, p1: Any = p0
+) = p1

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -18848,6 +18848,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         }
 
         @Test
+        @TestMetadata("kt48989.kt")
+        public void testKt48989() throws Exception {
+            runTest("compiler/testData/codegen/box/functions/kt48989.kt");
+        }
+
+        @Test
         @TestMetadata("kt785.kt")
         public void testKt785() throws Exception {
             runTest("compiler/testData/codegen/box/functions/kt785.kt");


### PR DESCRIPTION
Because labels of `tryCatchBlocks` have been deleted in this case.

Fixes: [KT-48989](https://youtrack.jetbrains.com/issue/KT-48989/JVM-IR-IllegalStateException-Bad-exception-handler-end-when-first-parameter-of-inline-function-is-nullable-with-try-catch)