### PR TITLE
Option to generate JvmStatic functions as static methods without companion declaration

### DIFF
--- a/analysis/symbol-light-classes/tests/org/jetbrains/kotlin/light/classes/symbol/decompiled/SymbolLightClassesLoadingForLibraryTestGenerated.java
+++ b/analysis/symbol-light-classes/tests/org/jetbrains/kotlin/light/classes/symbol/decompiled/SymbolLightClassesLoadingForLibraryTestGenerated.java
@@ -163,6 +163,12 @@ public class SymbolLightClassesLoadingForLibraryTestGenerated extends AbstractSy
     }
 
     @Test
+    @TestMetadata("jvmOverloadsWithStaticDeclarationRewrite.kt")
+    public void testJvmOverloadsWithStaticDeclarationRewrite() throws Exception {
+        runTest("compiler/testData/asJava/ultraLightClasses/jvmOverloadsWithStaticDeclarationRewrite.kt");
+    }
+
+    @Test
     @TestMetadata("jvmRecord.kt")
     public void testJvmRecord() throws Exception {
         runTest("compiler/testData/asJava/ultraLightClasses/jvmRecord.kt");
@@ -214,6 +220,12 @@ public class SymbolLightClassesLoadingForLibraryTestGenerated extends AbstractSy
     @TestMetadata("objects.kt")
     public void testObjects() throws Exception {
         runTest("compiler/testData/asJava/ultraLightClasses/objects.kt");
+    }
+
+    @Test
+    @TestMetadata("objectsWithStaticDeclarationRewrite.kt")
+    public void testObjectsWithStaticDeclarationRewrite() throws Exception {
+        runTest("compiler/testData/asJava/ultraLightClasses/objectsWithStaticDeclarationRewrite.kt");
     }
 
     @Test

--- a/analysis/symbol-light-classes/tests/org/jetbrains/kotlin/light/classes/symbol/source/SymbolLightClassesLoadingForSourceTestGenerated.java
+++ b/analysis/symbol-light-classes/tests/org/jetbrains/kotlin/light/classes/symbol/source/SymbolLightClassesLoadingForSourceTestGenerated.java
@@ -163,6 +163,12 @@ public class SymbolLightClassesLoadingForSourceTestGenerated extends AbstractSym
     }
 
     @Test
+    @TestMetadata("jvmOverloadsWithStaticDeclarationRewrite.kt")
+    public void testJvmOverloadsWithStaticDeclarationRewrite() throws Exception {
+        runTest("compiler/testData/asJava/ultraLightClasses/jvmOverloadsWithStaticDeclarationRewrite.kt");
+    }
+
+    @Test
     @TestMetadata("jvmRecord.kt")
     public void testJvmRecord() throws Exception {
         runTest("compiler/testData/asJava/ultraLightClasses/jvmRecord.kt");
@@ -214,6 +220,12 @@ public class SymbolLightClassesLoadingForSourceTestGenerated extends AbstractSym
     @TestMetadata("objects.kt")
     public void testObjects() throws Exception {
         runTest("compiler/testData/asJava/ultraLightClasses/objects.kt");
+    }
+
+    @Test
+    @TestMetadata("objectsWithStaticDeclarationRewrite.kt")
+    public void testObjectsWithStaticDeclarationRewrite() throws Exception {
+        runTest("compiler/testData/asJava/ultraLightClasses/objectsWithStaticDeclarationRewrite.kt");
     }
 
     @Test

--- a/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/arguments/K2JVMCompilerArguments.kt
+++ b/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/arguments/K2JVMCompilerArguments.kt
@@ -546,6 +546,13 @@ Also sets `-jvm-target` value equal to the selected JDK version"""
     )
     var oldInnerClassesLogic: Boolean by FreezableVar(false)
 
+    @Argument(
+        value = "-Xrewrite-jvm-static-in-companion",
+        description = "If JvmStatic methods should be generated as static methods without a companion declaration, or as a static " +
+                "method that acts as a proxy to a companion method."
+    )
+    var rewriteJvmStaticInCompanion: Boolean by FreezableVar(false)
+
     override fun configureAnalysisFlags(collector: MessageCollector, languageVersion: LanguageVersion): MutableMap<AnalysisFlag<*>, Any> {
         val result = super.configureAnalysisFlags(collector, languageVersion)
         result[JvmAnalysisFlags.strictMetadataVersionSemantics] = strictMetadataVersionSemantics

--- a/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/jvmArguments.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/jvmArguments.kt
@@ -308,6 +308,7 @@ fun CompilerConfiguration.configureAdvancedJvmOptions(arguments: K2JVMCompilerAr
     put(JVMConfigurationKeys.IGNORE_CONST_OPTIMIZATION_ERRORS, arguments.ignoreConstOptimizationErrors)
     put(JVMConfigurationKeys.NO_NEW_JAVA_ANNOTATION_TARGETS, arguments.noNewJavaAnnotationTargets)
     put(JVMConfigurationKeys.OLD_INNER_CLASSES_LOGIC, arguments.oldInnerClassesLogic)
+    put(JVMConfigurationKeys.REWRITE_JVM_STATIC_IN_COMPANION, arguments.rewriteJvmStaticInCompanion)
 
     val assertionsMode =
         JVMAssertionsMode.fromStringOrNull(arguments.assertionsMode)

--- a/compiler/config.jvm/src/org/jetbrains/kotlin/config/JVMConfigurationKeys.java
+++ b/compiler/config.jvm/src/org/jetbrains/kotlin/config/JVMConfigurationKeys.java
@@ -168,4 +168,8 @@ public class JVMConfigurationKeys {
 
     public static final CompilerConfigurationKey<Boolean> OLD_INNER_CLASSES_LOGIC =
             CompilerConfigurationKey.create("Use old logic for generation of InnerClasses attributes");
+
+    public static final CompilerConfigurationKey<Boolean> REWRITE_JVM_STATIC_IN_COMPANION =
+            CompilerConfigurationKey.create("If JvmStatic methods should be generated as static methods without a companion declaration," +
+                                            "or as a static method that acts as a proxy to a companion method.");
 }

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/JvmStaticAnnotationLowering.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/JvmStaticAnnotationLowering.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.backend.jvm.JvmLoweredDeclarationOrigin
 import org.jetbrains.kotlin.backend.jvm.ir.isEffectivelyInlineOnly
 import org.jetbrains.kotlin.backend.jvm.ir.isInlineFunctionCall
 import org.jetbrains.kotlin.backend.jvm.ir.replaceThisByStaticReference
+import org.jetbrains.kotlin.config.JVMConfigurationKeys
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.ir.IrBuiltIns
 import org.jetbrains.kotlin.ir.IrStatement
@@ -128,14 +129,27 @@ private class CompanionObjectJvmStaticTransformer(val context: JvmBackendContext
         else -> !origin.isSynthetic
     }
 
+    private fun shouldReplaceDeclarations(): Boolean =
+        context.configuration.getBoolean(JVMConfigurationKeys.REWRITE_JVM_STATIC_IN_COMPANION)
+
     override fun visitClass(declaration: IrClass): IrStatement =
         super.visitClass(declaration).also {
-            declaration.companionObject()?.declarations?.transformInPlace {
-                if (it is IrSimpleFunction && it.isJvmStaticDeclaration() && it.needsStaticProxy()) {
-                    val (static, companionFun) = context.cachedDeclarations.getStaticAndCompanionDeclaration(it)
-                    declaration.declarations.add(static)
-                    companionFun
-                } else it
+            val iterator = declaration.companionObject()?.declarations?.listIterator() ?: return@also
+            while (iterator.hasNext()) {
+                val function = iterator.next()
+                // Skip all non-functions as we shouldn't be doing anything with them.
+                if (function !is IrSimpleFunction) continue
+                if (function.isJvmStaticDeclaration() && function.needsStaticProxy()) {
+                    if (shouldReplaceDeclarations()) {
+                        val replacement = context.cachedDeclarations.getStaticCompanionReplacementDeclaration(function)
+                        declaration.declarations.add(replacement)
+                        iterator.remove()
+                    } else {
+                        val (static, companionFun) = context.cachedDeclarations.getStaticAndCompanionDeclaration(function)
+                        declaration.declarations.add(static)
+                        iterator.set(companionFun)
+                    }
+                }
             }
         }
 
@@ -146,8 +160,14 @@ private class CompanionObjectJvmStaticTransformer(val context: JvmBackendContext
         val callee = expression.symbol.owner
         return when {
             shouldReplaceWithStaticCall(callee) -> {
-                val (staticProxy, _) = context.cachedDeclarations.getStaticAndCompanionDeclaration(callee)
-                expression.makeStatic(context.irBuiltIns, staticProxy)
+                val static = if (shouldReplaceDeclarations()) {
+                    // If this is true, we know that companion jvm statics were replaced with actual static methods, so we know we need to
+                    // replace the calls with the corresponding static replacement methods.
+                    context.cachedDeclarations.getStaticCompanionReplacementDeclaration(callee)
+                } else {
+                    context.cachedDeclarations.getStaticAndCompanionDeclaration(callee).first
+                }
+                expression.makeStatic(context.irBuiltIns, static)
             }
             callee.symbol == context.ir.symbols.indyLambdaMetafactoryIntrinsic -> {
                 val implFunRef = expression.getValueArgument(1) as? IrFunctionReference

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLoweredDeclarationOrigin.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmLoweredDeclarationOrigin.kt
@@ -21,6 +21,8 @@ interface JvmLoweredDeclarationOrigin : IrDeclarationOrigin {
     object SYNTHETIC_MARKER_PARAMETER : IrDeclarationOriginImpl("SYNTHETIC_MARKER_PARAMETER", isSynthetic = true)
     object TO_ARRAY : IrDeclarationOriginImpl("TO_ARRAY")
     object JVM_STATIC_WRAPPER : IrDeclarationOriginImpl("JVM_STATIC_WRAPPER")
+    // Used to distinguish a bridge JvmStatic method (above) from one with a full body and no corresponding companion method (below).
+    object JVM_STATIC_REPLACEMENT_METHOD : IrDeclarationOriginImpl("JVM_STATIC_METHOD")
     object JVM_OVERLOADS_WRAPPER : IrDeclarationOriginImpl("JVM_OVERLOADS_WRAPPER")
     object SYNTHETIC_METHOD_FOR_PROPERTY_OR_TYPEALIAS_ANNOTATIONS :
         IrDeclarationOriginImpl("SYNTHETIC_METHOD_FOR_PROPERTY_OR_TYPEALIAS_ANNOTATIONS", isSynthetic = true)

--- a/compiler/test-infrastructure/tests/org/jetbrains/kotlin/test/directives/LanguageSettingsDirectives.kt
+++ b/compiler/test-infrastructure/tests/org/jetbrains/kotlin/test/directives/LanguageSettingsDirectives.kt
@@ -76,6 +76,7 @@ object LanguageSettingsDirectives : SimpleDirectivesContainer() {
     val USE_TYPE_TABLE by directive("Use type table in metadata serialization")
     val NO_NEW_JAVA_ANNOTATION_TARGETS by directive("Do not generate Java annotation targets TYPE_USE/TYPE_PARAMETER for Kotlin annotation classes with Kotlin targets TYPE/TYPE_PARAMETER")
     val OLD_INNER_CLASSES_LOGIC by directive("Use old logic for generation of InnerClasses attributes")
+    val REWRITE_JVM_STATIC_IN_COMPANION by directive("If JvmStatic methods should be generated as static methods without a companion declaration, or as a static method that acts as a proxy to a companion method.")
     val LINK_VIA_SIGNATURES by directive("Use linkage via signatures instead of descriptors / FIR")
 
     // --------------------- Utils ---------------------

--- a/compiler/testData/asJava/ultraLightClasses/jvmOverloadsWithStaticDeclarationRewrite.java
+++ b/compiler/testData/asJava/ultraLightClasses/jvmOverloadsWithStaticDeclarationRewrite.java
@@ -1,0 +1,105 @@
+public final class C /* C*/ {
+  @org.jetbrains.annotations.NotNull()
+  private final java.lang.String p2;
+
+  @org.jetbrains.annotations.NotNull()
+  public static final C.Companion Companion;
+
+  @org.jetbrains.annotations.Nullable()
+  private final java.lang.String type;
+
+  private final boolean p1 = false /* initializer type: boolean */;
+
+  @kotlin.jvm.JvmOverloads()
+  @kotlin.jvm.JvmStatic()
+  public static final void fooStatic(double);//  fooStatic(double)
+
+  @kotlin.jvm.JvmOverloads()
+  @kotlin.jvm.JvmStatic()
+  public static final void fooStatic(int, double);//  fooStatic(int, double)
+
+  @kotlin.jvm.JvmOverloads()
+  @kotlin.jvm.JvmStatic()
+  public static final void fooStatic(int, double, @org.jetbrains.annotations.NotNull() java.lang.String);//  fooStatic(int, double, java.lang.String)
+
+  @kotlin.jvm.JvmOverloads()
+  public  C(@org.jetbrains.annotations.Nullable() java.lang.String);//  .ctor(java.lang.String)
+
+  @kotlin.jvm.JvmOverloads()
+  public  C(@org.jetbrains.annotations.Nullable() java.lang.String, boolean);//  .ctor(java.lang.String, boolean)
+
+  @kotlin.jvm.JvmOverloads()
+  public  C(@org.jetbrains.annotations.Nullable() java.lang.String, boolean, @org.jetbrains.annotations.NotNull() java.lang.String);//  .ctor(java.lang.String, boolean, java.lang.String)
+
+  @kotlin.jvm.JvmOverloads()
+  public final void bar();//  bar()
+
+  @kotlin.jvm.JvmOverloads()
+  public final void bar(int);//  bar(int)
+
+  @kotlin.jvm.JvmOverloads()
+  public final void bar(int, double);//  bar(int, double)
+
+  @kotlin.jvm.JvmOverloads()
+  public final void bar(int, double, @org.jetbrains.annotations.NotNull() java.lang.String);//  bar(int, double, java.lang.String)
+
+  @kotlin.jvm.JvmOverloads()
+  public final void baz(@org.jetbrains.annotations.NotNull() java.lang.String);//  baz(java.lang.String)
+
+  @kotlin.jvm.JvmOverloads()
+  public final void baz(int, @org.jetbrains.annotations.NotNull() java.lang.String);//  baz(int, java.lang.String)
+
+  @kotlin.jvm.JvmOverloads()
+  public final void baz(int, double, @org.jetbrains.annotations.NotNull() java.lang.String);//  baz(int, double, java.lang.String)
+
+  @kotlin.jvm.JvmOverloads()
+  public final void foo(double);//  foo(double)
+
+  @kotlin.jvm.JvmOverloads()
+  public final void foo(int, double);//  foo(int, double)
+
+  @kotlin.jvm.JvmOverloads()
+  public final void foo(int, double, @org.jetbrains.annotations.NotNull() java.lang.String);//  foo(int, double, java.lang.String)
+
+  @kotlin.jvm.JvmOverloads()
+  public final void foobar(int);//  foobar(int)
+
+  @kotlin.jvm.JvmOverloads()
+  public final void foobar(int, double);//  foobar(int, double)
+
+  @kotlin.jvm.JvmOverloads()
+  public final void foobar(int, double, @org.jetbrains.annotations.NotNull() java.lang.String);//  foobar(int, double, java.lang.String)
+
+  @kotlin.jvm.JvmOverloads()
+  public final void foobarbaz(int, @org.jetbrains.annotations.NotNull() java.lang.String);//  foobarbaz(int, java.lang.String)
+
+  @kotlin.jvm.JvmOverloads()
+  public final void foobarbaz(int, double, @org.jetbrains.annotations.NotNull() java.lang.String);//  foobarbaz(int, double, java.lang.String)
+
+  @org.jetbrains.annotations.NotNull()
+  public final java.lang.String getP2();//  getP2()
+
+  @org.jetbrains.annotations.Nullable()
+  public final java.lang.String getType();//  getType()
+
+  public final boolean getP1();//  getP1()
+
+
+  class Companion ...
+
+  }
+
+public static final class Companion /* C.Companion*/ {
+  @kotlin.jvm.JvmOverloads()
+  public final void foo123(double);//  foo123(double)
+
+  @kotlin.jvm.JvmOverloads()
+  public final void foo123(int, double);//  foo123(int, double)
+
+  @kotlin.jvm.JvmOverloads()
+  public final void foo123(int, double, @org.jetbrains.annotations.NotNull() java.lang.String);//  foo123(int, double, java.lang.String)
+
+  private  Companion();//  .ctor()
+
+}
+

--- a/compiler/testData/asJava/ultraLightClasses/jvmOverloadsWithStaticDeclarationRewrite.kt
+++ b/compiler/testData/asJava/ultraLightClasses/jvmOverloadsWithStaticDeclarationRewrite.kt
@@ -1,0 +1,26 @@
+class C @JvmOverloads constructor(
+    val type: String?,
+    val p1: Boolean = false,
+    val p2: String = type!!
+) {
+    @JvmOverloads
+    fun foo(x: Int = 1, y: Double, z: String = "") {}
+    @JvmOverloads
+    fun bar(x: Int = 1, y: Double = 1.3, z: String = "") {}
+    @JvmOverloads
+    fun baz(x: Int = 1, y: Double = 1.3, z: String) {}
+    @JvmOverloads
+    fun foobar(x: Int, y: Double = 1.3, z: String = "") {}
+    @JvmOverloads
+    fun foobarbaz(x: Int, y: Double = 1.3, z: String) {}
+
+    companion object {
+        @JvmOverloads
+        fun foo123(x: Int = 1, y: Double, z: String = "") {}
+        @JvmStatic
+        @JvmOverloads
+        fun fooStatic(x: Int = 1, y: Double, z: String = "") {}
+    }
+}
+
+// REWRITE_JVM_STATIC_IN_COMPANION

--- a/compiler/testData/asJava/ultraLightClasses/jvmOverloadsWithStaticDeclarationRewrite.lib.java
+++ b/compiler/testData/asJava/ultraLightClasses/jvmOverloadsWithStaticDeclarationRewrite.lib.java
@@ -1,0 +1,104 @@
+public final class C /* C*/ {
+  @org.jetbrains.annotations.NotNull()
+  private final java.lang.String p2;
+
+  @org.jetbrains.annotations.NotNull()
+  public static final C.Companion Companion;
+
+  @org.jetbrains.annotations.Nullable()
+  private final java.lang.String type;
+
+  private final boolean p1;
+
+  @kotlin.jvm.JvmOverloads()
+  @kotlin.jvm.JvmStatic()
+  public static final void fooStatic(double);//  fooStatic(double)
+
+  @kotlin.jvm.JvmOverloads()
+  @kotlin.jvm.JvmStatic()
+  public static final void fooStatic(int, double);//  fooStatic(int, double)
+
+  @kotlin.jvm.JvmOverloads()
+  @kotlin.jvm.JvmStatic()
+  public static final void fooStatic(int, double, @org.jetbrains.annotations.NotNull() java.lang.String);//  fooStatic(int, double, java.lang.String)
+
+  @kotlin.jvm.JvmOverloads()
+  public  C(@org.jetbrains.annotations.Nullable() java.lang.String);//  .ctor(java.lang.String)
+
+  @kotlin.jvm.JvmOverloads()
+  public  C(@org.jetbrains.annotations.Nullable() java.lang.String, boolean);//  .ctor(java.lang.String, boolean)
+
+  @kotlin.jvm.JvmOverloads()
+  public  C(@org.jetbrains.annotations.Nullable() java.lang.String, boolean, @org.jetbrains.annotations.NotNull() java.lang.String);//  .ctor(java.lang.String, boolean, java.lang.String)
+
+  @kotlin.jvm.JvmOverloads()
+  public final void bar();//  bar()
+
+  @kotlin.jvm.JvmOverloads()
+  public final void bar(int);//  bar(int)
+
+  @kotlin.jvm.JvmOverloads()
+  public final void bar(int, double);//  bar(int, double)
+
+  @kotlin.jvm.JvmOverloads()
+  public final void bar(int, double, @org.jetbrains.annotations.NotNull() java.lang.String);//  bar(int, double, java.lang.String)
+
+  @kotlin.jvm.JvmOverloads()
+  public final void baz(@org.jetbrains.annotations.NotNull() java.lang.String);//  baz(java.lang.String)
+
+  @kotlin.jvm.JvmOverloads()
+  public final void baz(int, @org.jetbrains.annotations.NotNull() java.lang.String);//  baz(int, java.lang.String)
+
+  @kotlin.jvm.JvmOverloads()
+  public final void baz(int, double, @org.jetbrains.annotations.NotNull() java.lang.String);//  baz(int, double, java.lang.String)
+
+  @kotlin.jvm.JvmOverloads()
+  public final void foo(double);//  foo(double)
+
+  @kotlin.jvm.JvmOverloads()
+  public final void foo(int, double);//  foo(int, double)
+
+  @kotlin.jvm.JvmOverloads()
+  public final void foo(int, double, @org.jetbrains.annotations.NotNull() java.lang.String);//  foo(int, double, java.lang.String)
+
+  @kotlin.jvm.JvmOverloads()
+  public final void foobar(int);//  foobar(int)
+
+  @kotlin.jvm.JvmOverloads()
+  public final void foobar(int, double);//  foobar(int, double)
+
+  @kotlin.jvm.JvmOverloads()
+  public final void foobar(int, double, @org.jetbrains.annotations.NotNull() java.lang.String);//  foobar(int, double, java.lang.String)
+
+  @kotlin.jvm.JvmOverloads()
+  public final void foobarbaz(int, @org.jetbrains.annotations.NotNull() java.lang.String);//  foobarbaz(int, java.lang.String)
+
+  @kotlin.jvm.JvmOverloads()
+  public final void foobarbaz(int, double, @org.jetbrains.annotations.NotNull() java.lang.String);//  foobarbaz(int, double, java.lang.String)
+
+  @org.jetbrains.annotations.NotNull()
+  public final java.lang.String getP2();//  getP2()
+
+  @org.jetbrains.annotations.Nullable()
+  public final java.lang.String getType();//  getType()
+
+  public final boolean getP1();//  getP1()
+
+
+  class Companion ...
+
+  }
+
+public static final class Companion /* C.Companion*/ {
+  @kotlin.jvm.JvmOverloads()
+  public final void foo123(double);//  foo123(double)
+
+  @kotlin.jvm.JvmOverloads()
+  public final void foo123(int, double);//  foo123(int, double)
+
+  @kotlin.jvm.JvmOverloads()
+  public final void foo123(int, double, @org.jetbrains.annotations.NotNull() java.lang.String);//  foo123(int, double, java.lang.String)
+
+  private  Companion();//  .ctor()
+
+}

--- a/compiler/testData/asJava/ultraLightClasses/objectsWithStaticDeclarationRewrite.fir.java
+++ b/compiler/testData/asJava/ultraLightClasses/objectsWithStaticDeclarationRewrite.fir.java
@@ -1,0 +1,171 @@
+public final class C /* C*/ {
+  @kotlin.jvm.JvmStatic()
+  @org.jetbrains.annotations.NotNull()
+  private static java.lang.String x = "" /* initializer type: java.lang.String */;
+
+  @org.jetbrains.annotations.NotNull()
+  private static java.lang.String c1;
+
+  @org.jetbrains.annotations.NotNull()
+  private static java.lang.String c;
+
+  @org.jetbrains.annotations.NotNull()
+  public static final C.Companion Companion;
+
+  @org.jetbrains.annotations.NotNull()
+  public static final C.Factory Factory;
+
+  @kotlin.jvm.JvmStatic()
+  @org.jetbrains.annotations.NotNull()
+  public static final java.lang.String getC(@org.jetbrains.annotations.NotNull() I);//  getC(I)
+
+  @kotlin.jvm.JvmStatic()
+  public static final void foo();//  foo()
+
+  @kotlin.jvm.JvmStatic()
+  public static final void setC(@org.jetbrains.annotations.NotNull() I, @org.jetbrains.annotations.NotNull() java.lang.String);//  setC(I, java.lang.String)
+
+  @kotlin.jvm.JvmStatic()
+  public static final void setC1(@org.jetbrains.annotations.NotNull() java.lang.String);//  setC1(java.lang.String)
+
+  @org.jetbrains.annotations.NotNull()
+  public static final java.lang.String getX();//  getX()
+
+  public  C();//  .ctor()
+
+  public static final void setX(@org.jetbrains.annotations.NotNull() java.lang.String);//  setX(java.lang.String)
+
+
+
+  class Companion ...
+
+    class Factory ...
+
+  }
+
+public static final class Companion /* C.Companion*/ {
+  @org.jetbrains.annotations.NotNull()
+  public final java.lang.String getC1();//  getC1()
+
+  @org.jetbrains.annotations.NotNull()
+  public final java.lang.String getX();//  getX()
+
+  private  Companion();//  .ctor()
+
+  public final void bar();//  bar()
+
+  public final void setX(@org.jetbrains.annotations.NotNull() java.lang.String);//  setX(java.lang.String)
+
+}
+
+public static final class Factory /* C.Factory*/ {
+  private  Factory();//  .ctor()
+
+}
+
+public final class C1 /* C1*/ {
+  @org.jetbrains.annotations.NotNull()
+  private static final C1.Companion Companion;
+
+  public  C1();//  .ctor()
+
+
+  class Companion ...
+
+  }
+
+private static final class Companion /* C1.Companion*/ {
+  private  Companion();//  .ctor()
+
+}
+
+public abstract interface I /* I*/ {
+  @org.jetbrains.annotations.NotNull()
+  public static final I.Companion Companion;
+
+
+  class Companion ...
+
+  }
+
+public static final class Companion /* I.Companion*/ {
+  private  Companion();//  .ctor()
+
+}
+
+public final class Obj /* Obj*/ implements java.lang.Runnable {
+  @kotlin.jvm.JvmStatic()
+  @org.jetbrains.annotations.NotNull()
+  private static java.lang.String x = "" /* initializer type: java.lang.String */;
+
+  @org.jetbrains.annotations.NotNull()
+  public static final Obj INSTANCE;
+
+  @java.lang.Override()
+  public final void run();//  run()
+
+  @kotlin.jvm.JvmStatic()
+  public static final int zoo();//  zoo()
+
+  @org.jetbrains.annotations.NotNull()
+  public static final java.lang.String getX();//  getX()
+
+  private  Obj();//  .ctor()
+
+  public static final void setX(@org.jetbrains.annotations.NotNull() java.lang.String);//  setX(java.lang.String)
+
+}
+
+public final class ConstContainer /* ConstContainer*/ {
+  @org.jetbrains.annotations.NotNull()
+  public static final ConstContainer INSTANCE;
+
+  @org.jetbrains.annotations.NotNull()
+  public static final java.lang.String str = "one" /* initializer type: java.lang.String */ /* constant value one */;
+
+  public static final double complexFloat = 5.118281745910645 /* initializer type: double */ /* constant value 5.118281745910645 */;
+
+  public static final double e = 2.7182818284 /* initializer type: double */ /* constant value 2.7182818284 */;
+
+  public static final float eFloat = 2.7182817f /* initializer type: float */ /* constant value 2.7182817 */;
+
+  public static final int one = 1 /* initializer type: int */ /* constant value 1 */;
+
+  public static final long complexLong = 2L /* initializer type: long */ /* constant value 2 */;
+
+  public static final long oneLong = 1L /* initializer type: long */ /* constant value 1 */;
+
+  private  ConstContainer();//  .ctor()
+
+}
+
+public final class ClassWithConstContainer /* ClassWithConstContainer*/ {
+  @org.jetbrains.annotations.NotNull()
+  public static final ClassWithConstContainer.Companion Companion;
+
+  @org.jetbrains.annotations.NotNull()
+  public static final java.lang.String str = "one" /* initializer type: java.lang.String */ /* constant value one */;
+
+  public static final double complexFloat = 5.118281745910645 /* initializer type: double */ /* constant value 5.118281745910645 */;
+
+  public static final double e = 2.7182818284 /* initializer type: double */ /* constant value 2.7182818284 */;
+
+  public static final float eFloat = 2.7182817f /* initializer type: float */ /* constant value 2.7182817 */;
+
+  public static final int one = 1 /* initializer type: int */ /* constant value 1 */;
+
+  public static final long complexLong = 2L /* initializer type: long */ /* constant value 2 */;
+
+  public static final long oneLong = 1L /* initializer type: long */ /* constant value 1 */;
+
+  public  ClassWithConstContainer();//  .ctor()
+
+
+  class Companion ...
+
+  }
+
+public static final class Companion /* ClassWithConstContainer.Companion*/ {
+  private  Companion();//  .ctor()
+
+}

--- a/compiler/testData/asJava/ultraLightClasses/objectsWithStaticDeclarationRewrite.java
+++ b/compiler/testData/asJava/ultraLightClasses/objectsWithStaticDeclarationRewrite.java
@@ -1,0 +1,158 @@
+public final class C /* C*/ {
+  @org.jetbrains.annotations.NotNull()
+  private static java.lang.String x;
+
+  @org.jetbrains.annotations.NotNull()
+  public static final C.Companion Companion;
+
+  @kotlin.jvm.JvmStatic()
+  @org.jetbrains.annotations.NotNull()
+  public static final java.lang.String getC(@org.jetbrains.annotations.NotNull() I);//  getC(I)
+
+  @kotlin.jvm.JvmStatic()
+  public static final void foo();//  foo()
+
+  @kotlin.jvm.JvmStatic()
+  public static final void setC(@org.jetbrains.annotations.NotNull() I, @org.jetbrains.annotations.NotNull() java.lang.String);//  setC(I, java.lang.String)
+
+  @kotlin.jvm.JvmStatic()
+  public static final void setC1(@org.jetbrains.annotations.NotNull() java.lang.String);//  setC1(java.lang.String)
+
+  @org.jetbrains.annotations.NotNull()
+  public static final java.lang.String getX();//  getX()
+
+  public  C();//  .ctor()
+
+  public static final void setX(@org.jetbrains.annotations.NotNull() java.lang.String);//  setX(java.lang.String)
+
+
+
+  class Companion ...
+
+    class Factory ...
+
+  }
+
+public static final class Companion /* C.Companion*/ {
+  @org.jetbrains.annotations.NotNull()
+  public final java.lang.String getC1();//  getC1()
+
+  @org.jetbrains.annotations.NotNull()
+  public final java.lang.String getX();//  getX()
+
+  private  Companion();//  .ctor()
+
+  public final void bar();//  bar()
+
+  public final void setX(@org.jetbrains.annotations.NotNull() java.lang.String);//  setX(java.lang.String)
+
+}
+
+public static final class Factory /* C.Factory*/ {
+  private  Factory();//  .ctor()
+
+}
+
+public final class C1 /* C1*/ {
+  private static final C1.Companion Companion;
+
+  public  C1();//  .ctor()
+
+
+  class Companion ...
+
+  }
+
+private static final class Companion /* C1.Companion*/ {
+  private  Companion();//  .ctor()
+
+}
+
+public abstract interface I /* I*/ {
+  @org.jetbrains.annotations.NotNull()
+  public static final I.Companion Companion;
+
+
+  class Companion ...
+
+  }
+
+public static final class Companion /* I.Companion*/ {
+  private  Companion();//  .ctor()
+
+}
+
+public final class Obj /* Obj*/ implements java.lang.Runnable {
+  @org.jetbrains.annotations.NotNull()
+  private static java.lang.String x;
+
+  @org.jetbrains.annotations.NotNull()
+  public static final Obj INSTANCE;
+
+  @kotlin.jvm.JvmStatic()
+  public static final int zoo();//  zoo()
+
+  @org.jetbrains.annotations.NotNull()
+  public static final java.lang.String getX();//  getX()
+
+  private  Obj();//  .ctor()
+
+  public static final void setX(@org.jetbrains.annotations.NotNull() java.lang.String);//  setX(java.lang.String)
+
+  public void run();//  run()
+
+}
+
+public final class ConstContainer /* ConstContainer*/ {
+  @org.jetbrains.annotations.NotNull()
+  public static final ConstContainer INSTANCE;
+
+  @org.jetbrains.annotations.NotNull()
+  public static final java.lang.String str = "one" /* initializer type: java.lang.String */ /* constant value one */;
+
+  public static final double complexFloat = 5.118281745910645 /* initializer type: double */ /* constant value 5.118281745910645 */;
+
+  public static final double e = 2.7182818284 /* initializer type: double */ /* constant value 2.7182818284 */;
+
+  public static final float eFloat = 2.7182817f /* initializer type: float */ /* constant value 2.7182817 */;
+
+  public static final int one = 1 /* initializer type: int */ /* constant value 1 */;
+
+  public static final long complexLong = 2L /* initializer type: long */ /* constant value 2 */;
+
+  public static final long oneLong = 1L /* initializer type: long */ /* constant value 1 */;
+
+  private  ConstContainer();//  .ctor()
+
+}
+
+public final class ClassWithConstContainer /* ClassWithConstContainer*/ {
+  @org.jetbrains.annotations.NotNull()
+  public static final ClassWithConstContainer.Companion Companion;
+
+  @org.jetbrains.annotations.NotNull()
+  public static final java.lang.String str = "one" /* initializer type: java.lang.String */ /* constant value one */;
+
+  public static final double complexFloat = 5.118281745910645 /* initializer type: double */ /* constant value 5.118281745910645 */;
+
+  public static final double e = 2.7182818284 /* initializer type: double */ /* constant value 2.7182818284 */;
+
+  public static final float eFloat = 2.7182817f /* initializer type: float */ /* constant value 2.7182817 */;
+
+  public static final int one = 1 /* initializer type: int */ /* constant value 1 */;
+
+  public static final long complexLong = 2L /* initializer type: long */ /* constant value 2 */;
+
+  public static final long oneLong = 1L /* initializer type: long */ /* constant value 1 */;
+
+  public  ClassWithConstContainer();//  .ctor()
+
+
+  class Companion ...
+
+  }
+
+public static final class Companion /* ClassWithConstContainer.Companion*/ {
+  private  Companion();//  .ctor()
+
+}

--- a/compiler/testData/asJava/ultraLightClasses/objectsWithStaticDeclarationRewrite.kt
+++ b/compiler/testData/asJava/ultraLightClasses/objectsWithStaticDeclarationRewrite.kt
@@ -1,0 +1,55 @@
+class C {
+    companion object {
+        @JvmStatic fun foo() {}
+        fun bar() {}
+        @JvmStatic var x: String = ""
+
+        var I.c: String
+            @JvmStatic get() = "OK"
+            @JvmStatic set(t: String) {}
+
+        var c1: String
+            get() = "OK"
+            @JvmStatic set(t: String) {}
+    }
+    companion object Factory {}
+}
+
+class C1 {
+  private companion object {}
+}
+
+interface I {
+  companion object { }
+}
+
+object Obj : java.lang.Runnable {
+    @JvmStatic var x: String = ""
+    override fun run() {}
+    @JvmStatic fun zoo(): Int = 2
+}
+
+object ConstContainer {
+    const val str = "one" // String
+    const val one = 1 // Int
+    const val oneLong = 1L // Long
+    const val complexLong = 1L + 1 // Long
+    const val e = 2.7182818284 // Double
+    const val eFloat = 2.7182818284f // Float
+    const val complexFloat = 2.7182818284f + 2.4 // Float
+}
+
+class ClassWithConstContainer {
+    companion object {
+        const val str = "one" // String
+        const val one = 1 // Int
+        const val oneLong = 1L // Long
+        const val complexLong = 1L + 1 // Long
+        const val e = 2.7182818284 // Double
+        const val eFloat = 2.7182818284f // Float
+        const val complexFloat = 2.7182818284f + 2.4 // Float
+    }
+}
+
+// REWRITE_JVM_STATIC_IN_COMPANION
+// COMPILATION_ERRORS

--- a/compiler/testData/codegen/bytecodeListing/jvmStatic/jvmStaticExternalWithDeclarationRewrite.kt
+++ b/compiler/testData/codegen/bytecodeListing/jvmStatic/jvmStaticExternalWithDeclarationRewrite.kt
@@ -1,0 +1,15 @@
+// WITH_STDLIB
+// REWRITE_JVM_STATIC_IN_COMPANION
+// JVM_TARGET: 1.8
+
+object TestObject {
+    @JvmStatic
+    external fun foo()
+}
+
+class TestClassCompanion {
+    companion object {
+        @JvmStatic
+        external fun foo()
+    }
+}

--- a/compiler/testData/codegen/bytecodeListing/jvmStatic/jvmStaticExternalWithDeclarationRewrite.txt
+++ b/compiler/testData/codegen/bytecodeListing/jvmStatic/jvmStaticExternalWithDeclarationRewrite.txt
@@ -1,0 +1,26 @@
+@kotlin.Metadata
+public final class TestClassCompanion$Companion {
+    // source: 'jvmStaticExternalWithDeclarationRewrite.kt'
+    private method <init>(): void
+    public synthetic method <init>(p0: kotlin.jvm.internal.DefaultConstructorMarker): void
+    public final inner class TestClassCompanion$Companion
+}
+
+@kotlin.Metadata
+public final class TestClassCompanion {
+    // source: 'jvmStaticExternalWithDeclarationRewrite.kt'
+    public final static @org.jetbrains.annotations.NotNull field Companion: TestClassCompanion$Companion
+    static method <clinit>(): void
+    public method <init>(): void
+    public native final static @kotlin.jvm.JvmStatic method foo(): void
+    public final inner class TestClassCompanion$Companion
+}
+
+@kotlin.Metadata
+public final class TestObject {
+    // source: 'jvmStaticExternalWithDeclarationRewrite.kt'
+    public final static @org.jetbrains.annotations.NotNull field INSTANCE: TestObject
+    static method <clinit>(): void
+    private method <init>(): void
+    public native final static @kotlin.jvm.JvmStatic method foo(): void
+}

--- a/compiler/testData/codegen/bytecodeListing/jvmStatic/jvmStaticPrivateWithDeclarationRewrite.ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/jvmStatic/jvmStaticPrivateWithDeclarationRewrite.ir.txt
@@ -1,0 +1,34 @@
+@kotlin.Metadata
+public final class A$Companion {
+    // source: 'jvmStaticPrivateWithDeclarationRewrite.kt'
+    private method <init>(): void
+    public synthetic method <init>(p0: kotlin.jvm.internal.DefaultConstructorMarker): void
+    private synthetic deprecated static @kotlin.jvm.JvmStatic method getX$annotations(): void
+    public final inner class A$Companion
+}
+
+@kotlin.Metadata
+public final class A {
+    // source: 'jvmStaticPrivateWithDeclarationRewrite.kt'
+    public final static @org.jetbrains.annotations.NotNull field Companion: A$Companion
+    private final static @org.jetbrains.annotations.NotNull field x: java.lang.String
+    static method <clinit>(): void
+    public method <init>(): void
+    private final static @kotlin.jvm.JvmStatic method f(p0: int): void
+    private final static @kotlin.jvm.JvmStatic method getXx(): java.lang.String
+    private final static @kotlin.jvm.JvmStatic method setXx(p0: java.lang.String): void
+    public final inner class A$Companion
+}
+
+@kotlin.Metadata
+public final class O {
+    // source: 'jvmStaticPrivateWithDeclarationRewrite.kt'
+    public final static @org.jetbrains.annotations.NotNull field INSTANCE: O
+    private final static @org.jetbrains.annotations.NotNull field y: java.lang.String
+    static method <clinit>(): void
+    private method <init>(): void
+    private final static @kotlin.jvm.JvmStatic method g(p0: int): void
+    private synthetic deprecated static @kotlin.jvm.JvmStatic method getY$annotations(): void
+    private final static @kotlin.jvm.JvmStatic method getYy(): java.lang.String
+    private final static @kotlin.jvm.JvmStatic method setYy(p0: java.lang.String): void
+}

--- a/compiler/testData/codegen/bytecodeListing/jvmStatic/jvmStaticPrivateWithDeclarationRewrite.kt
+++ b/compiler/testData/codegen/bytecodeListing/jvmStatic/jvmStaticPrivateWithDeclarationRewrite.kt
@@ -1,0 +1,33 @@
+// WITH_STDLIB
+// REWRITE_JVM_STATIC_IN_COMPANION
+
+// For a private @JvmStatic function `f` in `A.Companion` with rewriting @JvmStatic declaration, we generate a private static
+// method `f` in `A`, with the actual implementation.
+// This exists as a counterpart to the jvmStaticPrivate.kt test, to ensure that we don't generate an accessor if we're not generating
+// a proxy to the companion object.
+
+class A {
+    companion object {
+        @JvmStatic
+        private fun f(p: Int) {}
+
+        @JvmStatic
+        private val x = ""
+
+        private var xx: String
+            @JvmStatic get() = ""
+            @JvmStatic set(value) {}
+    }
+}
+
+object O {
+    @JvmStatic
+    private fun g(q: Int) {}
+
+    @JvmStatic
+    private val y = ""
+
+    private var yy: String
+        @JvmStatic get() = ""
+        @JvmStatic set(value) {}
+}

--- a/compiler/testData/codegen/bytecodeListing/jvmStatic/jvmStaticPrivateWithDeclarationRewrite.txt
+++ b/compiler/testData/codegen/bytecodeListing/jvmStatic/jvmStaticPrivateWithDeclarationRewrite.txt
@@ -1,0 +1,35 @@
+@kotlin.Metadata
+public final class A$Companion {
+    // source: 'jvmStaticPrivateWithDeclarationRewrite.kt'
+    private method <init>(): void
+    public synthetic method <init>(p0: kotlin.jvm.internal.DefaultConstructorMarker): void
+    public final inner class A$Companion
+}
+
+@kotlin.Metadata
+public final class A {
+    // source: 'jvmStaticPrivateWithDeclarationRewrite.kt'
+    public final static @org.jetbrains.annotations.NotNull field Companion: A$Companion
+    private final static field x: java.lang.String
+    static method <clinit>(): void
+    public method <init>(): void
+    private final static @kotlin.jvm.JvmStatic method f(p0: int): void
+    private synthetic deprecated static @kotlin.jvm.JvmStatic method getX$annotations(): void
+    private final static @kotlin.jvm.JvmStatic method getXx(): java.lang.String
+    private final static @kotlin.jvm.JvmStatic method setXx(p0: java.lang.String): void
+    public final inner class A$Companion
+}
+
+@kotlin.Metadata
+public final class O {
+    // source: 'jvmStaticPrivateWithDeclarationRewrite.kt'
+    public final static @org.jetbrains.annotations.NotNull field INSTANCE: O
+    private final static field y: java.lang.String
+    static method <clinit>(): void
+    private method <init>(): void
+    private final static @kotlin.jvm.JvmStatic method g(p0: int): void
+    private synthetic deprecated static @kotlin.jvm.JvmStatic method getY$annotations(): void
+    private final static @kotlin.jvm.JvmStatic method getYy(): java.lang.String
+    private final static @kotlin.jvm.JvmStatic method setYy(p0: java.lang.String): void
+}
+

--- a/compiler/testData/codegen/bytecodeListing/jvmStatic/jvmStaticWithDefaultParametersWithDeclarationRewrite.kt
+++ b/compiler/testData/codegen/bytecodeListing/jvmStatic/jvmStaticWithDefaultParametersWithDeclarationRewrite.kt
@@ -1,0 +1,14 @@
+// WITH_STDLIB
+// REWRITE_JVM_STATIC_IN_COMPANION
+
+class WithCompanion {
+    companion object {
+        @JvmStatic
+        fun foo(x: Int = 1) {}
+    }
+}
+
+object AnObject {
+    @JvmStatic
+    fun foo(x: Int = 1) {}
+}

--- a/compiler/testData/codegen/bytecodeListing/jvmStatic/jvmStaticWithDefaultParametersWithDeclarationRewrite.txt
+++ b/compiler/testData/codegen/bytecodeListing/jvmStatic/jvmStaticWithDefaultParametersWithDeclarationRewrite.txt
@@ -1,0 +1,28 @@
+@kotlin.Metadata
+public final class AnObject {
+    // source: 'jvmStaticWithDefaultParametersWithDeclarationRewrite.kt'
+    public final static @org.jetbrains.annotations.NotNull field INSTANCE: AnObject
+    static method <clinit>(): void
+    private method <init>(): void
+    public synthetic static method foo$default(p0: int, p1: int, p2: java.lang.Object): void
+    public final static @kotlin.jvm.JvmStatic method foo(p0: int): void
+}
+
+@kotlin.Metadata
+public final class WithCompanion$Companion {
+    // source: 'jvmStaticWithDefaultParametersWithDeclarationRewrite.kt'
+    private method <init>(): void
+    public synthetic method <init>(p0: kotlin.jvm.internal.DefaultConstructorMarker): void
+    public synthetic static method foo$default(p0: WithCompanion$Companion, p1: int, p2: int, p3: java.lang.Object): void
+    public final inner class WithCompanion$Companion
+}
+
+@kotlin.Metadata
+public final class WithCompanion {
+    // source: 'jvmStaticWithDefaultParametersWithDeclarationRewrite.kt'
+    public final static @org.jetbrains.annotations.NotNull field Companion: WithCompanion$Companion
+    static method <clinit>(): void
+    public method <init>(): void
+    public final static @kotlin.jvm.JvmStatic method foo(p0: int): void
+    public final inner class WithCompanion$Companion
+}

--- a/compiler/testData/codegen/bytecodeListing/jvmStatic/kt31389WithDeclarationRewrite.ir.txt
+++ b/compiler/testData/codegen/bytecodeListing/jvmStatic/kt31389WithDeclarationRewrite.ir.txt
@@ -1,0 +1,26 @@
+@kotlin.Metadata
+public final class Annotation$Companion {
+    // source: 'kt31389WithDeclarationRewrite.kt'
+    synthetic final static field $$INSTANCE: Annotation$Companion
+    private static @org.jetbrains.annotations.NotNull field TEST_FIELD2: java.lang.String
+    private final static @org.jetbrains.annotations.NotNull field TEST_FIELD: java.lang.String
+    static method <clinit>(): void
+    private method <init>(): void
+    public synthetic deprecated static @kotlin.jvm.JvmStatic method getTEST_FIELD$annotations(): void
+    public final @org.jetbrains.annotations.NotNull method getTEST_FIELD(): java.lang.String
+    public final @kotlin.jvm.JvmStatic @org.jetbrains.annotations.NotNull method getTEST_FIELD2(): java.lang.String
+    public final @kotlin.jvm.JvmStatic method setTEST_FIELD2(@org.jetbrains.annotations.NotNull p0: java.lang.String): void
+    public final inner class Annotation$Companion
+}
+
+@java.lang.annotation.Retention(value=RUNTIME)
+@kotlin.Metadata
+public annotation class Annotation {
+    // source: 'kt31389WithDeclarationRewrite.kt'
+    public final static @org.jetbrains.annotations.NotNull field Companion: Annotation$Companion
+    static method <clinit>(): void
+    public static @org.jetbrains.annotations.NotNull method getTEST_FIELD(): java.lang.String
+    public static @kotlin.jvm.JvmStatic @org.jetbrains.annotations.NotNull method getTEST_FIELD2(): java.lang.String
+    public static @kotlin.jvm.JvmStatic method setTEST_FIELD2(@org.jetbrains.annotations.NotNull p0: java.lang.String): void
+    public final inner class Annotation$Companion
+}

--- a/compiler/testData/codegen/bytecodeListing/jvmStatic/kt31389WithDeclarationRewrite.kt
+++ b/compiler/testData/codegen/bytecodeListing/jvmStatic/kt31389WithDeclarationRewrite.kt
@@ -1,0 +1,13 @@
+// JVM_TARGET: 1.8
+// WITH_STDLIB
+// REWRITE_JVM_STATIC_IN_COMPANION
+
+annotation class Annotation {
+    companion object {
+        @JvmStatic val TEST_FIELD = "OK"
+
+        var TEST_FIELD2 = ""
+            @JvmStatic get
+            @JvmStatic set
+    }
+}

--- a/compiler/testData/codegen/bytecodeListing/jvmStatic/kt31389WithDeclarationRewrite.txt
+++ b/compiler/testData/codegen/bytecodeListing/jvmStatic/kt31389WithDeclarationRewrite.txt
@@ -1,0 +1,26 @@
+@kotlin.Metadata
+public final class Annotation$Companion {
+    // source: 'kt31389WithDeclarationRewrite.kt'
+    synthetic final static field $$INSTANCE: Annotation$Companion
+    private static @org.jetbrains.annotations.NotNull field TEST_FIELD2: java.lang.String
+    private final static @org.jetbrains.annotations.NotNull field TEST_FIELD: java.lang.String
+    static method <clinit>(): void
+    private method <init>(): void
+    public synthetic deprecated static @kotlin.jvm.JvmStatic method getTEST_FIELD$annotations(): void
+    public final @org.jetbrains.annotations.NotNull method getTEST_FIELD(): java.lang.String
+    public final @kotlin.jvm.JvmStatic @org.jetbrains.annotations.NotNull method getTEST_FIELD2(): java.lang.String
+    public final @kotlin.jvm.JvmStatic method setTEST_FIELD2(@org.jetbrains.annotations.NotNull p0: java.lang.String): void
+    public final inner class Annotation$Companion
+}
+
+@java.lang.annotation.Retention(value=RUNTIME)
+@kotlin.Metadata
+public annotation class Annotation {
+    // source: 'kt31389WithDeclarationRewrite.kt'
+    public final static @org.jetbrains.annotations.NotNull field Companion: Annotation$Companion
+    static method <clinit>(): void
+    public static method getTEST_FIELD(): java.lang.String
+    public static @kotlin.jvm.JvmStatic method getTEST_FIELD2(): java.lang.String
+    public static @kotlin.jvm.JvmStatic method setTEST_FIELD2(@org.jetbrains.annotations.NotNull p0: java.lang.String): void
+    public final inner class Annotation$Companion
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BytecodeListingTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BytecodeListingTestGenerated.java
@@ -1853,9 +1853,21 @@ public class BytecodeListingTestGenerated extends AbstractBytecodeListingTest {
         }
 
         @Test
+        @TestMetadata("jvmStaticExternalWithDeclarationRewrite.kt")
+        public void testJvmStaticExternalWithDeclarationRewrite() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeListing/jvmStatic/jvmStaticExternalWithDeclarationRewrite.kt");
+        }
+
+        @Test
         @TestMetadata("jvmStaticPrivate.kt")
         public void testJvmStaticPrivate() throws Exception {
             runTest("compiler/testData/codegen/bytecodeListing/jvmStatic/jvmStaticPrivate.kt");
+        }
+
+        @Test
+        @TestMetadata("jvmStaticPrivateWithDeclarationRewrite.kt")
+        public void testJvmStaticPrivateWithDeclarationRewrite() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeListing/jvmStatic/jvmStaticPrivateWithDeclarationRewrite.kt");
         }
 
         @Test
@@ -1865,9 +1877,21 @@ public class BytecodeListingTestGenerated extends AbstractBytecodeListingTest {
         }
 
         @Test
+        @TestMetadata("jvmStaticWithDefaultParametersWithDeclarationRewrite.kt")
+        public void testJvmStaticWithDefaultParametersWithDeclarationRewrite() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeListing/jvmStatic/jvmStaticWithDefaultParametersWithDeclarationRewrite.kt");
+        }
+
+        @Test
         @TestMetadata("kt31389.kt")
         public void testKt31389() throws Exception {
             runTest("compiler/testData/codegen/bytecodeListing/jvmStatic/kt31389.kt");
+        }
+
+        @Test
+        @TestMetadata("kt31389WithDeclarationRewrite.kt")
+        public void testKt31389WithDeclarationRewrite() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeListing/jvmStatic/kt31389WithDeclarationRewrite.kt");
         }
     }
 

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBytecodeListingTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBytecodeListingTestGenerated.java
@@ -1955,9 +1955,21 @@ public class IrBytecodeListingTestGenerated extends AbstractIrBytecodeListingTes
         }
 
         @Test
+        @TestMetadata("jvmStaticExternalWithDeclarationRewrite.kt")
+        public void testJvmStaticExternalWithDeclarationRewrite() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeListing/jvmStatic/jvmStaticExternalWithDeclarationRewrite.kt");
+        }
+
+        @Test
         @TestMetadata("jvmStaticPrivate.kt")
         public void testJvmStaticPrivate() throws Exception {
             runTest("compiler/testData/codegen/bytecodeListing/jvmStatic/jvmStaticPrivate.kt");
+        }
+
+        @Test
+        @TestMetadata("jvmStaticPrivateWithDeclarationRewrite.kt")
+        public void testJvmStaticPrivateWithDeclarationRewrite() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeListing/jvmStatic/jvmStaticPrivateWithDeclarationRewrite.kt");
         }
 
         @Test
@@ -1967,9 +1979,21 @@ public class IrBytecodeListingTestGenerated extends AbstractIrBytecodeListingTes
         }
 
         @Test
+        @TestMetadata("jvmStaticWithDefaultParametersWithDeclarationRewrite.kt")
+        public void testJvmStaticWithDefaultParametersWithDeclarationRewrite() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeListing/jvmStatic/jvmStaticWithDefaultParametersWithDeclarationRewrite.kt");
+        }
+
+        @Test
         @TestMetadata("kt31389.kt")
         public void testKt31389() throws Exception {
             runTest("compiler/testData/codegen/bytecodeListing/jvmStatic/kt31389.kt");
+        }
+
+        @Test
+        @TestMetadata("kt31389WithDeclarationRewrite.kt")
+        public void testKt31389WithDeclarationRewrite() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeListing/jvmStatic/kt31389WithDeclarationRewrite.kt");
         }
     }
 

--- a/compiler/tests-common-new/tests/org/jetbrains/kotlin/test/services/configuration/JvmEnvironmentConfigurator.kt
+++ b/compiler/tests-common-new/tests/org/jetbrains/kotlin/test/services/configuration/JvmEnvironmentConfigurator.kt
@@ -51,6 +51,7 @@ import org.jetbrains.kotlin.test.directives.LanguageSettingsDirectives.JDK_RELEA
 import org.jetbrains.kotlin.test.directives.LanguageSettingsDirectives.LINK_VIA_SIGNATURES
 import org.jetbrains.kotlin.test.directives.LanguageSettingsDirectives.NO_NEW_JAVA_ANNOTATION_TARGETS
 import org.jetbrains.kotlin.test.directives.LanguageSettingsDirectives.OLD_INNER_CLASSES_LOGIC
+import org.jetbrains.kotlin.test.directives.LanguageSettingsDirectives.REWRITE_JVM_STATIC_IN_COMPANION
 import org.jetbrains.kotlin.test.directives.LanguageSettingsDirectives.USE_TYPE_TABLE
 import org.jetbrains.kotlin.test.directives.model.DirectivesContainer
 import org.jetbrains.kotlin.test.directives.model.RegisteredDirectives
@@ -177,6 +178,7 @@ class JvmEnvironmentConfigurator(testServices: TestServices) : EnvironmentConfig
         register(ENABLE_DEBUG_MODE, JVMConfigurationKeys.ENABLE_DEBUG_MODE)
         register(NO_NEW_JAVA_ANNOTATION_TARGETS, JVMConfigurationKeys.NO_NEW_JAVA_ANNOTATION_TARGETS)
         register(OLD_INNER_CLASSES_LOGIC, JVMConfigurationKeys.OLD_INNER_CLASSES_LOGIC)
+        register(REWRITE_JVM_STATIC_IN_COMPANION, JVMConfigurationKeys.REWRITE_JVM_STATIC_IN_COMPANION)
         register(LINK_VIA_SIGNATURES, JVMConfigurationKeys.LINK_VIA_SIGNATURES)
     }
 


### PR DESCRIPTION
This is my first PR and first change that I've ever made to the Kotlin compiler, so please feel free to point out anything wrong with this.

This PR adds a new compiler option to have JvmStatic declarations in companion objects be generated as static methods, with the body copied in to the static method and the companion declaration removed in the output code, rather than the existing behaviour, which is generating a static proxy method that just calls the companion declaration.

I've spent the past few hours trying to get my head around the testing system, and I still don't think I've quite worked it out. The tests still fail, which also will be addressed, however I don't really understand why the KT-31389 test fails, that specifically has to be looked in to. Three of the analysis tests also fail, however one of them is to do with FIR, and I imagine it's probably because there's somewhere in the FIR logic that handles JvmStatic declarations, unless this isn't the case, in which I have no idea.