### PR TITLE
Add a reproducer project for composite MPP build (KT-52172)

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mpp-composite-build/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mpp-composite-build/build.gradle.kts
@@ -1,0 +1,28 @@
+plugins {
+    id("org.jetbrains.kotlin.multiplatform").version("1.7.21")
+}
+
+repositories {
+    mavenCentral()
+}
+
+kotlin {
+    jvm()
+    js(IR) {
+        nodejs()
+    }
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation("included-build:included")
+            }
+        }
+        val commonTest by getting {
+            dependencies {
+                implementation("org.jetbrains.kotlin:kotlin-test")
+            }
+        }
+    }
+}
+

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mpp-composite-build/included-build/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mpp-composite-build/included-build/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    id("org.jetbrains.kotlin.multiplatform").version("1.7.21").apply(false)
+}
+
+
+group = "included-build"
+version = "0.0.1"

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mpp-composite-build/included-build/included/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mpp-composite-build/included-build/included/build.gradle.kts
@@ -1,0 +1,10 @@
+plugins {
+    id("org.jetbrains.kotlin.multiplatform")
+}
+
+kotlin {
+    jvm()
+    js(IR) {
+        nodejs()
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mpp-composite-build/included-build/included/src/commonMain/kotlin/included/Hello.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mpp-composite-build/included-build/included/src/commonMain/kotlin/included/Hello.kt
@@ -1,0 +1,7 @@
+package included
+
+expect val sourceSet: String
+
+fun greet() {
+    println("Hello from sourceSet $sourceSet")
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mpp-composite-build/included-build/included/src/jsMain/kotlin/included/sourceSet.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mpp-composite-build/included-build/included/src/jsMain/kotlin/included/sourceSet.kt
@@ -1,0 +1,4 @@
+package included
+
+actual val sourceSet: String
+    get() = "jsMain"

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mpp-composite-build/included-build/included/src/jvmMain/kotlin/included/sourceSet.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mpp-composite-build/included-build/included/src/jvmMain/kotlin/included/sourceSet.kt
@@ -1,0 +1,4 @@
+package included
+
+actual val sourceSet: String
+    get() = "jvmMain"

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mpp-composite-build/included-build/settings.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mpp-composite-build/included-build/settings.gradle.kts
@@ -1,0 +1,7 @@
+include("included")
+
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mpp-composite-build/settings.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mpp-composite-build/settings.gradle.kts
@@ -1,0 +1,1 @@
+includeBuild("included-build")

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mpp-composite-build/src/commonMain/kotlin/com/example/Main.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mpp-composite-build/src/commonMain/kotlin/com/example/Main.kt
@@ -1,0 +1,7 @@
+package com.example
+
+import included.greet
+
+fun main(args: Array<String>) {
+    greet()
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mpp-composite-build/src/commonTest/kotlin/com/example/MainTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mpp-composite-build/src/commonTest/kotlin/com/example/MainTest.kt
@@ -1,0 +1,11 @@
+package com.example
+
+import included.greet
+import kotlin.test.Test
+
+class MainTest {
+    @Test
+    fun test() {
+        greet()
+    }
+}


### PR DESCRIPTION
Open the project in IntelliJ, the `greet` symbol should be underlined with red while running the tests (`./gradlew allTests) works fine.

![Screenshot 2022-12-09 at 17 02 39](https://user-images.githubusercontent.com/3974977/206742818-806ac5d3-4824-419b-adba-1dfde834ec3b.png)
