### PR TITLE
KT-55398 Fix nested inline variable not correctly

### DIFF
--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ClassCodegen.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ClassCodegen.kt
@@ -38,7 +38,6 @@ import org.jetbrains.kotlin.ir.expressions.IrConst
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.impl.IrBlockBodyImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrSetFieldImpl
-import org.jetbrains.kotlin.ir.symbols.IrTypeParameterSymbol
 import org.jetbrains.kotlin.ir.types.*
 import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.load.java.JvmAnnotationNames
@@ -209,7 +208,7 @@ class ClassCodegen private constructor(
             }
         }
 
-        addReifiedParametersFromSignature()
+        reifiedTypeParametersUsages.mergeAll(irClass.reifiedTypeParameters)
 
         generateInnerAndOuterClasses()
 
@@ -231,26 +230,6 @@ class ClassCodegen private constructor(
         val classVisitor = visitor.visitor
         for (sealedSubclassSymbol in sealedSubclasses) {
             classVisitor.visitPermittedSubclass(typeMapper.mapClass(sealedSubclassSymbol.owner).internalName)
-        }
-    }
-
-    private fun addReifiedParametersFromSignature() {
-        for (type in irClass.superTypes) {
-            processTypeParameters(type)
-        }
-    }
-
-    private fun processTypeParameters(type: IrType) {
-        for (supertypeArgument in (type as? IrSimpleType)?.arguments ?: emptyList()) {
-            if (supertypeArgument is IrTypeProjection) {
-                val typeArgument = supertypeArgument.type
-                if (typeArgument.isReifiedTypeParameter) {
-                    val typeParameter = typeArgument.classifierOrFail as IrTypeParameterSymbol
-                    reifiedTypeParametersUsages.addUsedReifiedParameter(typeParameter.owner.name.asString())
-                } else {
-                    processTypeParameters(typeArgument)
-                }
-            }
         }
     }
 

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -866,7 +866,8 @@ class ExpressionCodegen(
     }
 
     private fun putNeedClassReificationMarker(declaration: IrClass) {
-        val reifiedTypeParameters = closureReifiedMarkers[declaration] ?: return
+        // Fix KT-55398, try to get nested irclass type parameters reified info
+        val reifiedTypeParameters = closureReifiedMarkers.getOrPut(declaration) { declaration.reifiedTypeParameters }
         if (reifiedTypeParameters.wereUsedReifiedParameters()) {
             putNeedClassReificationMarker(mv)
             propagateChildReifiedTypeParametersUsages(reifiedTypeParameters)
@@ -1500,9 +1501,6 @@ class ExpressionCodegen(
 
     val isFinallyMarkerRequired: Boolean
         get() = irFunction.isInline || irFunction.origin == JvmLoweredDeclarationOrigin.INLINE_LAMBDA
-
-    val IrType.isReifiedTypeParameter: Boolean
-        get() = (classifierOrNull as? IrTypeParameterSymbol)?.owner?.isReified == true
 
     companion object {
         internal fun generateClassInstance(v: InstructionAdapter, classType: IrType, typeMapper: IrTypeMapper, wrapPrimitives: Boolean) {

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/irCodegenUtils.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/irCodegenUtils.kt
@@ -8,10 +8,7 @@ package org.jetbrains.kotlin.backend.jvm.codegen
 import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
 import org.jetbrains.kotlin.backend.jvm.JvmLoweredDeclarationOrigin
 import org.jetbrains.kotlin.backend.jvm.MultifileFacadeFileEntry
-import org.jetbrains.kotlin.backend.jvm.ir.fileParent
-import org.jetbrains.kotlin.backend.jvm.ir.isInlineOnly
-import org.jetbrains.kotlin.backend.jvm.ir.isJvmInterface
-import org.jetbrains.kotlin.backend.jvm.ir.isPrivateInlineSuspend
+import org.jetbrains.kotlin.backend.jvm.ir.*
 import org.jetbrains.kotlin.backend.jvm.mapping.IrTypeMapper
 import org.jetbrains.kotlin.backend.jvm.mapping.mapClass
 import org.jetbrains.kotlin.backend.jvm.mapping.mapSupertype
@@ -21,6 +18,7 @@ import org.jetbrains.kotlin.codegen.AsmUtil
 import org.jetbrains.kotlin.codegen.FrameMapBase
 import org.jetbrains.kotlin.codegen.OwnerKind
 import org.jetbrains.kotlin.codegen.SourceInfo
+import org.jetbrains.kotlin.codegen.inline.ReifiedTypeParametersUsages
 import org.jetbrains.kotlin.codegen.inline.SourceMapper
 import org.jetbrains.kotlin.codegen.signature.BothSignatureWriter
 import org.jetbrains.kotlin.descriptors.ClassKind
@@ -30,9 +28,8 @@ import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.ir.expressions.IrExpressionBody
 import org.jetbrains.kotlin.ir.symbols.IrSymbol
-import org.jetbrains.kotlin.ir.types.IrType
-import org.jetbrains.kotlin.ir.types.classOrNull
-import org.jetbrains.kotlin.ir.types.getClass
+import org.jetbrains.kotlin.ir.symbols.IrTypeParameterSymbol
+import org.jetbrains.kotlin.ir.types.*
 import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.load.java.JavaDescriptorVisibilities
 import org.jetbrains.kotlin.name.FqName
@@ -320,3 +317,27 @@ private fun IrFunction.isAccessorForDeprecatedJvmStaticProperty(context: JvmBack
     val property = callee.correspondingPropertySymbol?.owner ?: return false
     return property.isDeprecatedCallable(context)
 }
+
+val IrClass.reifiedTypeParameters: ReifiedTypeParametersUsages
+    get() {
+        val tempReifiedTypeParametersUsages = ReifiedTypeParametersUsages()
+        fun processTypeParameters(type: IrType) {
+            for (supertypeArgument in (type as? IrSimpleType)?.arguments ?: emptyList()) {
+                if (supertypeArgument is IrTypeProjection) {
+                    val typeArgument = supertypeArgument.type
+                    if (typeArgument.isReifiedTypeParameter) {
+                        val typeParameter = typeArgument.classifierOrFail as IrTypeParameterSymbol
+                        tempReifiedTypeParametersUsages.addUsedReifiedParameter(typeParameter.owner.name.asString())
+                    } else {
+                        processTypeParameters(typeArgument)
+                    }
+                }
+            }
+        }
+
+        for (type in superTypes) {
+            processTypeParameters(type)
+        }
+
+        return tempReifiedTypeParametersUsages
+    }

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/intrinsics/EnumIntrinsics.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/intrinsics/EnumIntrinsics.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlin.backend.jvm.codegen.BlockInfo
 import org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen
 import org.jetbrains.kotlin.backend.jvm.codegen.MaterialValue
 import org.jetbrains.kotlin.backend.jvm.codegen.materializedAt
+import org.jetbrains.kotlin.backend.jvm.ir.isReifiedTypeParameter
 import org.jetbrains.kotlin.codegen.AsmUtil
 import org.jetbrains.kotlin.codegen.inline.ReifiedTypeInliner
 import org.jetbrains.kotlin.codegen.putReifiedOperationMarkerIfTypeIsReifiedParameter

--- a/compiler/testData/codegen/boxInline/reified/kt55398.kt
+++ b/compiler/testData/codegen/boxInline/reified/kt55398.kt
@@ -1,0 +1,47 @@
+// TARGET_BACKEND: JVM
+// WITH_STDLIB
+// FULL_JDK
+// FILE: 1.kt
+package test
+
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
+interface Base {
+}
+
+class BaseImpl : Base {
+}
+
+class ObjectContainer {
+}
+
+typealias ObjectContainerProvider = () -> ObjectContainer?
+
+internal inline fun <reified T : Base> ObjectContainerProvider.extensionFun(): ReadOnlyProperty<Any, T> {
+
+    return object : ReadOnlyProperty<Any, T> {
+        val emptyProxy: T by lazy {
+            T::class.java.getDeclaredConstructor().newInstance()
+        }
+
+        override fun getValue(thisRef: Any, property: KProperty<*>): T = emptyProxy
+    }
+
+}
+
+// FILE: 2.kt
+import test.*
+
+class DefaultObjectContainerProvider : ObjectContainerProvider {
+    val baseImpl: BaseImpl by extensionFun<BaseImpl>()
+
+    override fun invoke(): ObjectContainer? {
+        return null
+    }
+}
+
+fun box(): String {
+    DefaultObjectContainerProvider().baseImpl
+
+    return "OK"
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxInlineCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxInlineCodegenTestGenerated.java
@@ -4062,6 +4062,12 @@ public class BlackBoxInlineCodegenTestGenerated extends AbstractBlackBoxInlineCo
             runTest("compiler/testData/codegen/boxInline/reified/singletonLambda.kt");
         }
 
+        @Test
+        @TestMetadata("kt55398.kt")
+        public void testKt55398() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/reified/kt55398.kt");
+        }
+
         @Nested
         @TestMetadata("compiler/testData/codegen/boxInline/reified/checkCast")
         @TestDataPath("$PROJECT_ROOT")

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/CompileKotlinAgainstInlineKotlinTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/CompileKotlinAgainstInlineKotlinTestGenerated.java
@@ -4062,6 +4062,12 @@ public class CompileKotlinAgainstInlineKotlinTestGenerated extends AbstractCompi
             runTest("compiler/testData/codegen/boxInline/reified/singletonLambda.kt");
         }
 
+        @Test
+        @TestMetadata("kt55398.kt")
+        public void testKt55398() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/reified/kt55398.kt");
+        }
+
         @Nested
         @TestMetadata("compiler/testData/codegen/boxInline/reified/checkCast")
         @TestDataPath("$PROJECT_ROOT")

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxInlineCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxInlineCodegenTestGenerated.java
@@ -4086,6 +4086,12 @@ public class IrBlackBoxInlineCodegenTestGenerated extends AbstractIrBlackBoxInli
             runTest("compiler/testData/codegen/boxInline/reified/singletonLambda.kt");
         }
 
+        @Test
+        @TestMetadata("kt55398.kt")
+        public void testKt55398() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/reified/kt55398.kt");
+        }
+
         @Nested
         @TestMetadata("compiler/testData/codegen/boxInline/reified/checkCast")
         @TestDataPath("$PROJECT_ROOT")

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrCompileKotlinAgainstInlineKotlinTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrCompileKotlinAgainstInlineKotlinTestGenerated.java
@@ -4086,6 +4086,12 @@ public class IrCompileKotlinAgainstInlineKotlinTestGenerated extends AbstractIrC
             runTest("compiler/testData/codegen/boxInline/reified/singletonLambda.kt");
         }
 
+        @Test
+        @TestMetadata("kt55398.kt")
+        public void testKt55398() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/reified/kt55398.kt");
+        }
+
         @Nested
         @TestMetadata("compiler/testData/codegen/boxInline/reified/checkCast")
         @TestDataPath("$PROJECT_ROOT")


### PR DESCRIPTION
Fix [KT-55398](https://youtrack.jetbrains.com/issue/KT-55398/Kotlin-inline-nested-inline-lambdas-inline-variable-will-inline-not-correctly), nested lambda's variable lambda inline not correctly, add irclass reified info when judge needed put class reification marker

Also add test case into boxInline/reified