### PR TITLE
Append Kapt stats if file exists

### DIFF
--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/annotationProcessing.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/annotationProcessing.kt
@@ -19,6 +19,7 @@ import org.jetbrains.kotlin.kapt3.base.util.KaptLogger
 import org.jetbrains.kotlin.kapt3.base.util.isJava9OrLater
 import org.jetbrains.kotlin.kapt3.base.util.measureTimeMillisWithResult
 import java.io.File
+import java.time.LocalDateTime
 import javax.annotation.processing.ProcessingEnvironment
 import javax.annotation.processing.Processor
 import javax.annotation.processing.RoundEnvironment
@@ -151,8 +152,8 @@ private fun showProcessorStats(wrappedProcessors: List<ProcessorWrapper>, logger
 private fun dumpProcessorStats(wrappedProcessors: List<ProcessorWrapper>, apReportFile: File, logger: (String) -> Unit) {
     logger("Dumping Kapt Annotation Processing performance report to ${apReportFile.absolutePath}")
 
-    apReportFile.writeText(buildString {
-        appendLine("Kapt Annotation Processing performance report:")
+    apReportFile.appendText(buildString {
+        appendLine("${LocalDateTime.now()} Kapt Annotation Processing performance report:")
         wrappedProcessors.forEach { processor ->
             appendLine(processor.renderSpentTime())
         }


### PR DESCRIPTION
When running KAPT in a multi-module project, it's awkward to specify separate processor statistics dump files for each sub-module. This PR makes it so that previous statistics dumps are not overwritten, and adds a timestamp to make it easier to identify which run is which. 

Ideally, there should be a way to identify which KAPT invocation is being reported on, but as far as I can tell, that information isn't available at the time the report file is created, and it seems like it might be too big a change. 

I have *not* built this code locally, because I haven't been able to get the repository to build. The instructions in the README don't work for my M1. If the PR doesn't build, I was hoping that some kind soul might make whatever tweaks are necessary to make it mergeable. :) 