### PR TITLE
KT-55616 KGP: Native - Don't return nullable runTaskProvider

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/NativeBinaries.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/NativeBinaries.kt
@@ -182,7 +182,7 @@ class Executable constructor(
      * Returns null if the executables's target is not a host one (macosArm64, macosX64, linuxX64 or mingw64).
      */
     val runTaskProvider: TaskProvider<AbstractExecTask<*>>
-        get() = project.tasks.withType(AbstractExecTask::class.java).named(it)
+        get() = project.tasks.withType(AbstractExecTask::class.java).named(runTaskName)
 
     val runTask: AbstractExecTask<*>?
         get() = runTaskProvider.getOrNull()

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/NativeBinaries.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/NativeBinaries.kt
@@ -181,11 +181,11 @@ class Executable constructor(
      * A task running this executable.
      * Returns null if the executables's target is not a host one (macosArm64, macosX64, linuxX64 or mingw64).
      */
-    val runTaskProvider: TaskProvider<AbstractExecTask<*>>?
-        get() = runTaskName?.let { project.tasks.withType(AbstractExecTask::class.java).named(it) }
+    val runTaskProvider: TaskProvider<AbstractExecTask<*>>
+        get() = project.tasks.withType(AbstractExecTask::class.java).named(it)
 
     val runTask: AbstractExecTask<*>?
-        get() = runTaskProvider?.get()
+        get() = runTaskProvider.getOrNull()
 }
 
 class TestExecutable(


### PR DESCRIPTION
A TaskProvider is already a holder for a nullable task, so making the provider itself nullable is useless.