### PR TITLE
Added serialization support for the `kotlin.text.Regex` class

### DIFF
--- a/plugins/kotlinx-serialization/kotlinx-serialization.common/src/org/jetbrains/kotlinx/serialization/compiler/resolve/NamingConventions.kt
+++ b/plugins/kotlinx-serialization/kotlinx-serialization.common/src/org/jetbrains/kotlinx/serialization/compiler/resolve/NamingConventions.kt
@@ -249,6 +249,7 @@ fun findStandardKotlinTypeSerializerName(typeName: String?): String? {
         "kotlin.DoubleArray" -> "DoubleArraySerializer"
         "kotlin.BooleanArray" -> "BooleanArraySerializer"
         "kotlin.time.Duration" -> "DurationSerializer"
+        "kotlin.text.Regex" -> "RegexSerializer"
         "java.lang.Boolean" -> "BooleanSerializer"
         "java.lang.Byte" -> "ByteSerializer"
         "java.lang.Short" -> "ShortSerializer"


### PR DESCRIPTION
Support [PR Added support for the kotlin.text.Regex class as built-in](https://github.com/Kotlin/kotlinx.serialization/pull/2137) in kotlin-serialization plugin