### PR TITLE
Gradle plugin use a fixed locale for lowercase for JsCompiler names

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-api/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinJsCompilerType.kt
+++ b/libraries/tools/kotlin-gradle-plugin-api/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinJsCompilerType.kt
@@ -27,7 +27,7 @@ enum class KotlinJsCompilerType {
 }
 
 val KotlinJsCompilerType.lowerName
-    get() = name.toLowerCase()
+    get() = name.toLowerCase(Locale.ENGLISH)
 
 fun String.removeJsCompilerSuffix(compilerType: KotlinJsCompilerType): String {
     val truncatedString = removeSuffix(compilerType.lowerName)


### PR DESCRIPTION
One example where this is problematic is turkish computers that will will see things like `"jsır"` instead of `"jsir"`

Fixes flakyness of `./gradlew :kotlin-gradle-plugin:functionalTest` on my laptop