### PR TITLE
Add median to stdlib [KT-50138]

### DIFF
--- a/libraries/stdlib/common/src/generated/_Arrays.kt
+++ b/libraries/stdlib/common/src/generated/_Arrays.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -24550,6 +24550,720 @@ public fun DoubleArray.average(): Double {
         ++count
     }
     return if (count == 0) Double.NaN else sum / count
+}
+
+/**
+ * Returns the median value of the elements in the array, or Double.NaN if the array is empty.
+ * 
+ * It does so in linear time, based on [QuickSelect](https://en.wikipedia.org/wiki/Quickselect).
+ */
+@kotlin.jvm.JvmName("medianOfByte")
+public fun Array<out Byte>.median(): Double {
+    return with(toMutableList()) {
+        if (size == 0) {
+            return Double.NaN
+        }
+        fun swap(index1: Int, index2: Int) {
+            val temp = get(index1)
+            this[index1] = this[index2]
+            this[index2] = temp
+        }
+        fun partition(leftIndex: Int, rightIndex: Int): Int {
+            val pivotIndex = (leftIndex + rightIndex) / 2
+            val pivot = get(pivotIndex)
+            swap(pivotIndex, rightIndex)
+            var storageIndex = leftIndex
+            for(i in leftIndex until rightIndex) {
+                if(get(i) < pivot) {
+                    swap(i, storageIndex)
+                    storageIndex++
+                }
+            }
+            swap(rightIndex, storageIndex)
+            return storageIndex
+        }
+        val midIndex = size / 2
+        var left = 0
+        var lastLeft = 0
+        var right = lastIndex
+        var pivotIndex = partition(left, right)
+        while (pivotIndex != midIndex) {
+            if (pivotIndex > midIndex) {
+                right = pivotIndex - 1
+            } else {
+                lastLeft = left
+                left = pivotIndex + 1
+            }
+            pivotIndex = partition(left, right)
+        }
+        if (size % 2 == 0) {
+            // The right-sided middle value was already found, now we need to find the biggest 
+            // element to its left side. At this point, we're sure that the element is between
+            // the lastLeft and midIndex, so just iterate through this range
+            var currentMax = get(lastLeft)
+            for (i in lastLeft until midIndex) {
+                if (get(i) > currentMax)
+                    currentMax = get(i)
+            }
+            get(pivotIndex) * 0.5 + currentMax * 0.5
+        } else {
+            get(pivotIndex).toDouble()
+        }
+    }
+}
+
+/**
+ * Returns the median value of the elements in the array, or Double.NaN if the array is empty.
+ * 
+ * It does so in linear time, based on [QuickSelect](https://en.wikipedia.org/wiki/Quickselect).
+ */
+@kotlin.jvm.JvmName("medianOfShort")
+public fun Array<out Short>.median(): Double {
+    return with(toMutableList()) {
+        if (size == 0) {
+            return Double.NaN
+        }
+        fun swap(index1: Int, index2: Int) {
+            val temp = get(index1)
+            this[index1] = this[index2]
+            this[index2] = temp
+        }
+        fun partition(leftIndex: Int, rightIndex: Int): Int {
+            val pivotIndex = (leftIndex + rightIndex) / 2
+            val pivot = get(pivotIndex)
+            swap(pivotIndex, rightIndex)
+            var storageIndex = leftIndex
+            for(i in leftIndex until rightIndex) {
+                if(get(i) < pivot) {
+                    swap(i, storageIndex)
+                    storageIndex++
+                }
+            }
+            swap(rightIndex, storageIndex)
+            return storageIndex
+        }
+        val midIndex = size / 2
+        var left = 0
+        var lastLeft = 0
+        var right = lastIndex
+        var pivotIndex = partition(left, right)
+        while (pivotIndex != midIndex) {
+            if (pivotIndex > midIndex) {
+                right = pivotIndex - 1
+            } else {
+                lastLeft = left
+                left = pivotIndex + 1
+            }
+            pivotIndex = partition(left, right)
+        }
+        if (size % 2 == 0) {
+            // The right-sided middle value was already found, now we need to find the biggest 
+            // element to its left side. At this point, we're sure that the element is between
+            // the lastLeft and midIndex, so just iterate through this range
+            var currentMax = get(lastLeft)
+            for (i in lastLeft until midIndex) {
+                if (get(i) > currentMax)
+                    currentMax = get(i)
+            }
+            get(pivotIndex) * 0.5 + currentMax * 0.5
+        } else {
+            get(pivotIndex).toDouble()
+        }
+    }
+}
+
+/**
+ * Returns the median value of the elements in the array, or Double.NaN if the array is empty.
+ * 
+ * It does so in linear time, based on [QuickSelect](https://en.wikipedia.org/wiki/Quickselect).
+ */
+@kotlin.jvm.JvmName("medianOfInt")
+public fun Array<out Int>.median(): Double {
+    return with(toMutableList()) {
+        if (size == 0) {
+            return Double.NaN
+        }
+        fun swap(index1: Int, index2: Int) {
+            val temp = get(index1)
+            this[index1] = this[index2]
+            this[index2] = temp
+        }
+        fun partition(leftIndex: Int, rightIndex: Int): Int {
+            val pivotIndex = (leftIndex + rightIndex) / 2
+            val pivot = get(pivotIndex)
+            swap(pivotIndex, rightIndex)
+            var storageIndex = leftIndex
+            for(i in leftIndex until rightIndex) {
+                if(get(i) < pivot) {
+                    swap(i, storageIndex)
+                    storageIndex++
+                }
+            }
+            swap(rightIndex, storageIndex)
+            return storageIndex
+        }
+        val midIndex = size / 2
+        var left = 0
+        var lastLeft = 0
+        var right = lastIndex
+        var pivotIndex = partition(left, right)
+        while (pivotIndex != midIndex) {
+            if (pivotIndex > midIndex) {
+                right = pivotIndex - 1
+            } else {
+                lastLeft = left
+                left = pivotIndex + 1
+            }
+            pivotIndex = partition(left, right)
+        }
+        if (size % 2 == 0) {
+            // The right-sided middle value was already found, now we need to find the biggest 
+            // element to its left side. At this point, we're sure that the element is between
+            // the lastLeft and midIndex, so just iterate through this range
+            var currentMax = get(lastLeft)
+            for (i in lastLeft until midIndex) {
+                if (get(i) > currentMax)
+                    currentMax = get(i)
+            }
+            get(pivotIndex) * 0.5 + currentMax * 0.5
+        } else {
+            get(pivotIndex).toDouble()
+        }
+    }
+}
+
+/**
+ * Returns the median value of the elements in the array, or Double.NaN if the array is empty.
+ * 
+ * It does so in linear time, based on [QuickSelect](https://en.wikipedia.org/wiki/Quickselect).
+ */
+@kotlin.jvm.JvmName("medianOfLong")
+public fun Array<out Long>.median(): Double {
+    return with(toMutableList()) {
+        if (size == 0) {
+            return Double.NaN
+        }
+        fun swap(index1: Int, index2: Int) {
+            val temp = get(index1)
+            this[index1] = this[index2]
+            this[index2] = temp
+        }
+        fun partition(leftIndex: Int, rightIndex: Int): Int {
+            val pivotIndex = (leftIndex + rightIndex) / 2
+            val pivot = get(pivotIndex)
+            swap(pivotIndex, rightIndex)
+            var storageIndex = leftIndex
+            for(i in leftIndex until rightIndex) {
+                if(get(i) < pivot) {
+                    swap(i, storageIndex)
+                    storageIndex++
+                }
+            }
+            swap(rightIndex, storageIndex)
+            return storageIndex
+        }
+        val midIndex = size / 2
+        var left = 0
+        var lastLeft = 0
+        var right = lastIndex
+        var pivotIndex = partition(left, right)
+        while (pivotIndex != midIndex) {
+            if (pivotIndex > midIndex) {
+                right = pivotIndex - 1
+            } else {
+                lastLeft = left
+                left = pivotIndex + 1
+            }
+            pivotIndex = partition(left, right)
+        }
+        if (size % 2 == 0) {
+            // The right-sided middle value was already found, now we need to find the biggest 
+            // element to its left side. At this point, we're sure that the element is between
+            // the lastLeft and midIndex, so just iterate through this range
+            var currentMax = get(lastLeft)
+            for (i in lastLeft until midIndex) {
+                if (get(i) > currentMax)
+                    currentMax = get(i)
+            }
+            get(pivotIndex) * 0.5 + currentMax * 0.5
+        } else {
+            get(pivotIndex).toDouble()
+        }
+    }
+}
+
+/**
+ * Returns the median value of the elements in the array, or Double.NaN if the array is empty.
+ * 
+ * It does so in linear time, based on [QuickSelect](https://en.wikipedia.org/wiki/Quickselect).
+ */
+@kotlin.jvm.JvmName("medianOfFloat")
+public fun Array<out Float>.median(): Double {
+    return with(toMutableList()) {
+        if (size == 0) {
+            return Double.NaN
+        }
+        fun swap(index1: Int, index2: Int) {
+            val temp = get(index1)
+            this[index1] = this[index2]
+            this[index2] = temp
+        }
+        fun partition(leftIndex: Int, rightIndex: Int): Int {
+            val pivotIndex = (leftIndex + rightIndex) / 2
+            val pivot = get(pivotIndex)
+            swap(pivotIndex, rightIndex)
+            var storageIndex = leftIndex
+            for(i in leftIndex until rightIndex) {
+                if(get(i) < pivot) {
+                    swap(i, storageIndex)
+                    storageIndex++
+                }
+            }
+            swap(rightIndex, storageIndex)
+            return storageIndex
+        }
+        val midIndex = size / 2
+        var left = 0
+        var lastLeft = 0
+        var right = lastIndex
+        var pivotIndex = partition(left, right)
+        while (pivotIndex != midIndex) {
+            if (pivotIndex > midIndex) {
+                right = pivotIndex - 1
+            } else {
+                lastLeft = left
+                left = pivotIndex + 1
+            }
+            pivotIndex = partition(left, right)
+        }
+        if (size % 2 == 0) {
+            // The right-sided middle value was already found, now we need to find the biggest 
+            // element to its left side. At this point, we're sure that the element is between
+            // the lastLeft and midIndex, so just iterate through this range
+            var currentMax = get(lastLeft)
+            for (i in lastLeft until midIndex) {
+                if (get(i) > currentMax)
+                    currentMax = get(i)
+            }
+            get(pivotIndex) * 0.5 + currentMax * 0.5
+        } else {
+            get(pivotIndex).toDouble()
+        }
+    }
+}
+
+/**
+ * Returns the median value of the elements in the array, or Double.NaN if the array is empty.
+ * 
+ * It does so in linear time, based on [QuickSelect](https://en.wikipedia.org/wiki/Quickselect).
+ */
+@kotlin.jvm.JvmName("medianOfDouble")
+public fun Array<out Double>.median(): Double {
+    return with(toMutableList()) {
+        if (size == 0) {
+            return Double.NaN
+        }
+        fun swap(index1: Int, index2: Int) {
+            val temp = get(index1)
+            this[index1] = this[index2]
+            this[index2] = temp
+        }
+        fun partition(leftIndex: Int, rightIndex: Int): Int {
+            val pivotIndex = (leftIndex + rightIndex) / 2
+            val pivot = get(pivotIndex)
+            swap(pivotIndex, rightIndex)
+            var storageIndex = leftIndex
+            for(i in leftIndex until rightIndex) {
+                if(get(i) < pivot) {
+                    swap(i, storageIndex)
+                    storageIndex++
+                }
+            }
+            swap(rightIndex, storageIndex)
+            return storageIndex
+        }
+        val midIndex = size / 2
+        var left = 0
+        var lastLeft = 0
+        var right = lastIndex
+        var pivotIndex = partition(left, right)
+        while (pivotIndex != midIndex) {
+            if (pivotIndex > midIndex) {
+                right = pivotIndex - 1
+            } else {
+                lastLeft = left
+                left = pivotIndex + 1
+            }
+            pivotIndex = partition(left, right)
+        }
+        if (size % 2 == 0) {
+            // The right-sided middle value was already found, now we need to find the biggest 
+            // element to its left side. At this point, we're sure that the element is between
+            // the lastLeft and midIndex, so just iterate through this range
+            var currentMax = get(lastLeft)
+            for (i in lastLeft until midIndex) {
+                if (get(i) > currentMax)
+                    currentMax = get(i)
+            }
+            get(pivotIndex) * 0.5 + currentMax * 0.5
+        } else {
+            get(pivotIndex).toDouble()
+        }
+    }
+}
+
+/**
+ * Returns the median value of the elements in the array, or Double.NaN if the array is empty.
+ * 
+ * It does so in linear time, based on [QuickSelect](https://en.wikipedia.org/wiki/Quickselect).
+ */
+public fun ByteArray.median(): Double {
+    return with(toMutableList()) {
+        if (size == 0) {
+            return Double.NaN
+        }
+        fun swap(index1: Int, index2: Int) {
+            val temp = get(index1)
+            this[index1] = this[index2]
+            this[index2] = temp
+        }
+        fun partition(leftIndex: Int, rightIndex: Int): Int {
+            val pivotIndex = (leftIndex + rightIndex) / 2
+            val pivot = get(pivotIndex)
+            swap(pivotIndex, rightIndex)
+            var storageIndex = leftIndex
+            for(i in leftIndex until rightIndex) {
+                if(get(i) < pivot) {
+                    swap(i, storageIndex)
+                    storageIndex++
+                }
+            }
+            swap(rightIndex, storageIndex)
+            return storageIndex
+        }
+        val midIndex = size / 2
+        var left = 0
+        var lastLeft = 0
+        var right = lastIndex
+        var pivotIndex = partition(left, right)
+        while (pivotIndex != midIndex) {
+            if (pivotIndex > midIndex) {
+                right = pivotIndex - 1
+            } else {
+                lastLeft = left
+                left = pivotIndex + 1
+            }
+            pivotIndex = partition(left, right)
+        }
+        if (size % 2 == 0) {
+            // The right-sided middle value was already found, now we need to find the biggest 
+            // element to its left side. At this point, we're sure that the element is between
+            // the lastLeft and midIndex, so just iterate through this range
+            var currentMax = get(lastLeft)
+            for (i in lastLeft until midIndex) {
+                if (get(i) > currentMax)
+                    currentMax = get(i)
+            }
+            get(pivotIndex) * 0.5 + currentMax * 0.5
+        } else {
+            get(pivotIndex).toDouble()
+        }
+    }
+}
+
+/**
+ * Returns the median value of the elements in the array, or Double.NaN if the array is empty.
+ * 
+ * It does so in linear time, based on [QuickSelect](https://en.wikipedia.org/wiki/Quickselect).
+ */
+public fun ShortArray.median(): Double {
+    return with(toMutableList()) {
+        if (size == 0) {
+            return Double.NaN
+        }
+        fun swap(index1: Int, index2: Int) {
+            val temp = get(index1)
+            this[index1] = this[index2]
+            this[index2] = temp
+        }
+        fun partition(leftIndex: Int, rightIndex: Int): Int {
+            val pivotIndex = (leftIndex + rightIndex) / 2
+            val pivot = get(pivotIndex)
+            swap(pivotIndex, rightIndex)
+            var storageIndex = leftIndex
+            for(i in leftIndex until rightIndex) {
+                if(get(i) < pivot) {
+                    swap(i, storageIndex)
+                    storageIndex++
+                }
+            }
+            swap(rightIndex, storageIndex)
+            return storageIndex
+        }
+        val midIndex = size / 2
+        var left = 0
+        var lastLeft = 0
+        var right = lastIndex
+        var pivotIndex = partition(left, right)
+        while (pivotIndex != midIndex) {
+            if (pivotIndex > midIndex) {
+                right = pivotIndex - 1
+            } else {
+                lastLeft = left
+                left = pivotIndex + 1
+            }
+            pivotIndex = partition(left, right)
+        }
+        if (size % 2 == 0) {
+            // The right-sided middle value was already found, now we need to find the biggest 
+            // element to its left side. At this point, we're sure that the element is between
+            // the lastLeft and midIndex, so just iterate through this range
+            var currentMax = get(lastLeft)
+            for (i in lastLeft until midIndex) {
+                if (get(i) > currentMax)
+                    currentMax = get(i)
+            }
+            get(pivotIndex) * 0.5 + currentMax * 0.5
+        } else {
+            get(pivotIndex).toDouble()
+        }
+    }
+}
+
+/**
+ * Returns the median value of the elements in the array, or Double.NaN if the array is empty.
+ * 
+ * It does so in linear time, based on [QuickSelect](https://en.wikipedia.org/wiki/Quickselect).
+ */
+public fun IntArray.median(): Double {
+    return with(toMutableList()) {
+        if (size == 0) {
+            return Double.NaN
+        }
+        fun swap(index1: Int, index2: Int) {
+            val temp = get(index1)
+            this[index1] = this[index2]
+            this[index2] = temp
+        }
+        fun partition(leftIndex: Int, rightIndex: Int): Int {
+            val pivotIndex = (leftIndex + rightIndex) / 2
+            val pivot = get(pivotIndex)
+            swap(pivotIndex, rightIndex)
+            var storageIndex = leftIndex
+            for(i in leftIndex until rightIndex) {
+                if(get(i) < pivot) {
+                    swap(i, storageIndex)
+                    storageIndex++
+                }
+            }
+            swap(rightIndex, storageIndex)
+            return storageIndex
+        }
+        val midIndex = size / 2
+        var left = 0
+        var lastLeft = 0
+        var right = lastIndex
+        var pivotIndex = partition(left, right)
+        while (pivotIndex != midIndex) {
+            if (pivotIndex > midIndex) {
+                right = pivotIndex - 1
+            } else {
+                lastLeft = left
+                left = pivotIndex + 1
+            }
+            pivotIndex = partition(left, right)
+        }
+        if (size % 2 == 0) {
+            // The right-sided middle value was already found, now we need to find the biggest 
+            // element to its left side. At this point, we're sure that the element is between
+            // the lastLeft and midIndex, so just iterate through this range
+            var currentMax = get(lastLeft)
+            for (i in lastLeft until midIndex) {
+                if (get(i) > currentMax)
+                    currentMax = get(i)
+            }
+            get(pivotIndex) * 0.5 + currentMax * 0.5
+        } else {
+            get(pivotIndex).toDouble()
+        }
+    }
+}
+
+/**
+ * Returns the median value of the elements in the array, or Double.NaN if the array is empty.
+ * 
+ * It does so in linear time, based on [QuickSelect](https://en.wikipedia.org/wiki/Quickselect).
+ */
+public fun LongArray.median(): Double {
+    return with(toMutableList()) {
+        if (size == 0) {
+            return Double.NaN
+        }
+        fun swap(index1: Int, index2: Int) {
+            val temp = get(index1)
+            this[index1] = this[index2]
+            this[index2] = temp
+        }
+        fun partition(leftIndex: Int, rightIndex: Int): Int {
+            val pivotIndex = (leftIndex + rightIndex) / 2
+            val pivot = get(pivotIndex)
+            swap(pivotIndex, rightIndex)
+            var storageIndex = leftIndex
+            for(i in leftIndex until rightIndex) {
+                if(get(i) < pivot) {
+                    swap(i, storageIndex)
+                    storageIndex++
+                }
+            }
+            swap(rightIndex, storageIndex)
+            return storageIndex
+        }
+        val midIndex = size / 2
+        var left = 0
+        var lastLeft = 0
+        var right = lastIndex
+        var pivotIndex = partition(left, right)
+        while (pivotIndex != midIndex) {
+            if (pivotIndex > midIndex) {
+                right = pivotIndex - 1
+            } else {
+                lastLeft = left
+                left = pivotIndex + 1
+            }
+            pivotIndex = partition(left, right)
+        }
+        if (size % 2 == 0) {
+            // The right-sided middle value was already found, now we need to find the biggest 
+            // element to its left side. At this point, we're sure that the element is between
+            // the lastLeft and midIndex, so just iterate through this range
+            var currentMax = get(lastLeft)
+            for (i in lastLeft until midIndex) {
+                if (get(i) > currentMax)
+                    currentMax = get(i)
+            }
+            get(pivotIndex) * 0.5 + currentMax * 0.5
+        } else {
+            get(pivotIndex).toDouble()
+        }
+    }
+}
+
+/**
+ * Returns the median value of the elements in the array, or Double.NaN if the array is empty.
+ * 
+ * It does so in linear time, based on [QuickSelect](https://en.wikipedia.org/wiki/Quickselect).
+ */
+public fun FloatArray.median(): Double {
+    return with(toMutableList()) {
+        if (size == 0) {
+            return Double.NaN
+        }
+        fun swap(index1: Int, index2: Int) {
+            val temp = get(index1)
+            this[index1] = this[index2]
+            this[index2] = temp
+        }
+        fun partition(leftIndex: Int, rightIndex: Int): Int {
+            val pivotIndex = (leftIndex + rightIndex) / 2
+            val pivot = get(pivotIndex)
+            swap(pivotIndex, rightIndex)
+            var storageIndex = leftIndex
+            for(i in leftIndex until rightIndex) {
+                if(get(i) < pivot) {
+                    swap(i, storageIndex)
+                    storageIndex++
+                }
+            }
+            swap(rightIndex, storageIndex)
+            return storageIndex
+        }
+        val midIndex = size / 2
+        var left = 0
+        var lastLeft = 0
+        var right = lastIndex
+        var pivotIndex = partition(left, right)
+        while (pivotIndex != midIndex) {
+            if (pivotIndex > midIndex) {
+                right = pivotIndex - 1
+            } else {
+                lastLeft = left
+                left = pivotIndex + 1
+            }
+            pivotIndex = partition(left, right)
+        }
+        if (size % 2 == 0) {
+            // The right-sided middle value was already found, now we need to find the biggest 
+            // element to its left side. At this point, we're sure that the element is between
+            // the lastLeft and midIndex, so just iterate through this range
+            var currentMax = get(lastLeft)
+            for (i in lastLeft until midIndex) {
+                if (get(i) > currentMax)
+                    currentMax = get(i)
+            }
+            get(pivotIndex) * 0.5 + currentMax * 0.5
+        } else {
+            get(pivotIndex).toDouble()
+        }
+    }
+}
+
+/**
+ * Returns the median value of the elements in the array, or Double.NaN if the array is empty.
+ * 
+ * It does so in linear time, based on [QuickSelect](https://en.wikipedia.org/wiki/Quickselect).
+ */
+public fun DoubleArray.median(): Double {
+    return with(toMutableList()) {
+        if (size == 0) {
+            return Double.NaN
+        }
+        fun swap(index1: Int, index2: Int) {
+            val temp = get(index1)
+            this[index1] = this[index2]
+            this[index2] = temp
+        }
+        fun partition(leftIndex: Int, rightIndex: Int): Int {
+            val pivotIndex = (leftIndex + rightIndex) / 2
+            val pivot = get(pivotIndex)
+            swap(pivotIndex, rightIndex)
+            var storageIndex = leftIndex
+            for(i in leftIndex until rightIndex) {
+                if(get(i) < pivot) {
+                    swap(i, storageIndex)
+                    storageIndex++
+                }
+            }
+            swap(rightIndex, storageIndex)
+            return storageIndex
+        }
+        val midIndex = size / 2
+        var left = 0
+        var lastLeft = 0
+        var right = lastIndex
+        var pivotIndex = partition(left, right)
+        while (pivotIndex != midIndex) {
+            if (pivotIndex > midIndex) {
+                right = pivotIndex - 1
+            } else {
+                lastLeft = left
+                left = pivotIndex + 1
+            }
+            pivotIndex = partition(left, right)
+        }
+        if (size % 2 == 0) {
+            // The right-sided middle value was already found, now we need to find the biggest 
+            // element to its left side. At this point, we're sure that the element is between
+            // the lastLeft and midIndex, so just iterate through this range
+            var currentMax = get(lastLeft)
+            for (i in lastLeft until midIndex) {
+                if (get(i) > currentMax)
+                    currentMax = get(i)
+            }
+            get(pivotIndex) * 0.5 + currentMax * 0.5
+        } else {
+            get(pivotIndex).toDouble()
+        }
+    }
 }
 
 /**

--- a/libraries/stdlib/common/src/generated/_Collections.kt
+++ b/libraries/stdlib/common/src/generated/_Collections.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -3606,6 +3606,366 @@ public fun Iterable<Double>.average(): Double {
         checkCountOverflow(++count)
     }
     return if (count == 0) Double.NaN else sum / count
+}
+
+/**
+ * Returns the median value of the elements in the collection, or Double.NaN if the collection is empty.
+ * 
+ * It does so in linear time, based on [QuickSelect](https://en.wikipedia.org/wiki/Quickselect).
+ */
+@kotlin.jvm.JvmName("medianOfByte")
+public fun Iterable<Byte>.median(): Double {
+    return with(toMutableList()) {
+        if (size == 0) {
+            return Double.NaN
+        }
+        fun swap(index1: Int, index2: Int) {
+            val temp = get(index1)
+            this[index1] = this[index2]
+            this[index2] = temp
+        }
+        fun partition(leftIndex: Int, rightIndex: Int): Int {
+            val pivotIndex = (leftIndex + rightIndex) / 2
+            val pivot = get(pivotIndex)
+            swap(pivotIndex, rightIndex)
+            var storageIndex = leftIndex
+            for(i in leftIndex until rightIndex) {
+                if(get(i) < pivot) {
+                    swap(i, storageIndex)
+                    storageIndex++
+                }
+            }
+            swap(rightIndex, storageIndex)
+            return storageIndex
+        }
+        val midIndex = size / 2
+        var left = 0
+        var lastLeft = 0
+        var right = lastIndex
+        var pivotIndex = partition(left, right)
+        while (pivotIndex != midIndex) {
+            if (pivotIndex > midIndex) {
+                right = pivotIndex - 1
+            } else {
+                lastLeft = left
+                left = pivotIndex + 1
+            }
+            pivotIndex = partition(left, right)
+        }
+        if (size % 2 == 0) {
+            // The right-sided middle value was already found, now we need to find the biggest 
+            // element to its left side. At this point, we're sure that the element is between
+            // the lastLeft and midIndex, so just iterate through this range
+            var currentMax = get(lastLeft)
+            for (i in lastLeft until midIndex) {
+                if (get(i) > currentMax)
+                    currentMax = get(i)
+            }
+            get(pivotIndex) * 0.5 + currentMax * 0.5
+        } else {
+            get(pivotIndex).toDouble()
+        }
+    }
+}
+
+/**
+ * Returns the median value of the elements in the collection, or Double.NaN if the collection is empty.
+ * 
+ * It does so in linear time, based on [QuickSelect](https://en.wikipedia.org/wiki/Quickselect).
+ */
+@kotlin.jvm.JvmName("medianOfShort")
+public fun Iterable<Short>.median(): Double {
+    return with(toMutableList()) {
+        if (size == 0) {
+            return Double.NaN
+        }
+        fun swap(index1: Int, index2: Int) {
+            val temp = get(index1)
+            this[index1] = this[index2]
+            this[index2] = temp
+        }
+        fun partition(leftIndex: Int, rightIndex: Int): Int {
+            val pivotIndex = (leftIndex + rightIndex) / 2
+            val pivot = get(pivotIndex)
+            swap(pivotIndex, rightIndex)
+            var storageIndex = leftIndex
+            for(i in leftIndex until rightIndex) {
+                if(get(i) < pivot) {
+                    swap(i, storageIndex)
+                    storageIndex++
+                }
+            }
+            swap(rightIndex, storageIndex)
+            return storageIndex
+        }
+        val midIndex = size / 2
+        var left = 0
+        var lastLeft = 0
+        var right = lastIndex
+        var pivotIndex = partition(left, right)
+        while (pivotIndex != midIndex) {
+            if (pivotIndex > midIndex) {
+                right = pivotIndex - 1
+            } else {
+                lastLeft = left
+                left = pivotIndex + 1
+            }
+            pivotIndex = partition(left, right)
+        }
+        if (size % 2 == 0) {
+            // The right-sided middle value was already found, now we need to find the biggest 
+            // element to its left side. At this point, we're sure that the element is between
+            // the lastLeft and midIndex, so just iterate through this range
+            var currentMax = get(lastLeft)
+            for (i in lastLeft until midIndex) {
+                if (get(i) > currentMax)
+                    currentMax = get(i)
+            }
+            get(pivotIndex) * 0.5 + currentMax * 0.5
+        } else {
+            get(pivotIndex).toDouble()
+        }
+    }
+}
+
+/**
+ * Returns the median value of the elements in the collection, or Double.NaN if the collection is empty.
+ * 
+ * It does so in linear time, based on [QuickSelect](https://en.wikipedia.org/wiki/Quickselect).
+ */
+@kotlin.jvm.JvmName("medianOfInt")
+public fun Iterable<Int>.median(): Double {
+    return with(toMutableList()) {
+        if (size == 0) {
+            return Double.NaN
+        }
+        fun swap(index1: Int, index2: Int) {
+            val temp = get(index1)
+            this[index1] = this[index2]
+            this[index2] = temp
+        }
+        fun partition(leftIndex: Int, rightIndex: Int): Int {
+            val pivotIndex = (leftIndex + rightIndex) / 2
+            val pivot = get(pivotIndex)
+            swap(pivotIndex, rightIndex)
+            var storageIndex = leftIndex
+            for(i in leftIndex until rightIndex) {
+                if(get(i) < pivot) {
+                    swap(i, storageIndex)
+                    storageIndex++
+                }
+            }
+            swap(rightIndex, storageIndex)
+            return storageIndex
+        }
+        val midIndex = size / 2
+        var left = 0
+        var lastLeft = 0
+        var right = lastIndex
+        var pivotIndex = partition(left, right)
+        while (pivotIndex != midIndex) {
+            if (pivotIndex > midIndex) {
+                right = pivotIndex - 1
+            } else {
+                lastLeft = left
+                left = pivotIndex + 1
+            }
+            pivotIndex = partition(left, right)
+        }
+        if (size % 2 == 0) {
+            // The right-sided middle value was already found, now we need to find the biggest 
+            // element to its left side. At this point, we're sure that the element is between
+            // the lastLeft and midIndex, so just iterate through this range
+            var currentMax = get(lastLeft)
+            for (i in lastLeft until midIndex) {
+                if (get(i) > currentMax)
+                    currentMax = get(i)
+            }
+            get(pivotIndex) * 0.5 + currentMax * 0.5
+        } else {
+            get(pivotIndex).toDouble()
+        }
+    }
+}
+
+/**
+ * Returns the median value of the elements in the collection, or Double.NaN if the collection is empty.
+ * 
+ * It does so in linear time, based on [QuickSelect](https://en.wikipedia.org/wiki/Quickselect).
+ */
+@kotlin.jvm.JvmName("medianOfLong")
+public fun Iterable<Long>.median(): Double {
+    return with(toMutableList()) {
+        if (size == 0) {
+            return Double.NaN
+        }
+        fun swap(index1: Int, index2: Int) {
+            val temp = get(index1)
+            this[index1] = this[index2]
+            this[index2] = temp
+        }
+        fun partition(leftIndex: Int, rightIndex: Int): Int {
+            val pivotIndex = (leftIndex + rightIndex) / 2
+            val pivot = get(pivotIndex)
+            swap(pivotIndex, rightIndex)
+            var storageIndex = leftIndex
+            for(i in leftIndex until rightIndex) {
+                if(get(i) < pivot) {
+                    swap(i, storageIndex)
+                    storageIndex++
+                }
+            }
+            swap(rightIndex, storageIndex)
+            return storageIndex
+        }
+        val midIndex = size / 2
+        var left = 0
+        var lastLeft = 0
+        var right = lastIndex
+        var pivotIndex = partition(left, right)
+        while (pivotIndex != midIndex) {
+            if (pivotIndex > midIndex) {
+                right = pivotIndex - 1
+            } else {
+                lastLeft = left
+                left = pivotIndex + 1
+            }
+            pivotIndex = partition(left, right)
+        }
+        if (size % 2 == 0) {
+            // The right-sided middle value was already found, now we need to find the biggest 
+            // element to its left side. At this point, we're sure that the element is between
+            // the lastLeft and midIndex, so just iterate through this range
+            var currentMax = get(lastLeft)
+            for (i in lastLeft until midIndex) {
+                if (get(i) > currentMax)
+                    currentMax = get(i)
+            }
+            get(pivotIndex) * 0.5 + currentMax * 0.5
+        } else {
+            get(pivotIndex).toDouble()
+        }
+    }
+}
+
+/**
+ * Returns the median value of the elements in the collection, or Double.NaN if the collection is empty.
+ * 
+ * It does so in linear time, based on [QuickSelect](https://en.wikipedia.org/wiki/Quickselect).
+ */
+@kotlin.jvm.JvmName("medianOfFloat")
+public fun Iterable<Float>.median(): Double {
+    return with(toMutableList()) {
+        if (size == 0) {
+            return Double.NaN
+        }
+        fun swap(index1: Int, index2: Int) {
+            val temp = get(index1)
+            this[index1] = this[index2]
+            this[index2] = temp
+        }
+        fun partition(leftIndex: Int, rightIndex: Int): Int {
+            val pivotIndex = (leftIndex + rightIndex) / 2
+            val pivot = get(pivotIndex)
+            swap(pivotIndex, rightIndex)
+            var storageIndex = leftIndex
+            for(i in leftIndex until rightIndex) {
+                if(get(i) < pivot) {
+                    swap(i, storageIndex)
+                    storageIndex++
+                }
+            }
+            swap(rightIndex, storageIndex)
+            return storageIndex
+        }
+        val midIndex = size / 2
+        var left = 0
+        var lastLeft = 0
+        var right = lastIndex
+        var pivotIndex = partition(left, right)
+        while (pivotIndex != midIndex) {
+            if (pivotIndex > midIndex) {
+                right = pivotIndex - 1
+            } else {
+                lastLeft = left
+                left = pivotIndex + 1
+            }
+            pivotIndex = partition(left, right)
+        }
+        if (size % 2 == 0) {
+            // The right-sided middle value was already found, now we need to find the biggest 
+            // element to its left side. At this point, we're sure that the element is between
+            // the lastLeft and midIndex, so just iterate through this range
+            var currentMax = get(lastLeft)
+            for (i in lastLeft until midIndex) {
+                if (get(i) > currentMax)
+                    currentMax = get(i)
+            }
+            get(pivotIndex) * 0.5 + currentMax * 0.5
+        } else {
+            get(pivotIndex).toDouble()
+        }
+    }
+}
+
+/**
+ * Returns the median value of the elements in the collection, or Double.NaN if the collection is empty.
+ * 
+ * It does so in linear time, based on [QuickSelect](https://en.wikipedia.org/wiki/Quickselect).
+ */
+@kotlin.jvm.JvmName("medianOfDouble")
+public fun Iterable<Double>.median(): Double {
+    return with(toMutableList()) {
+        if (size == 0) {
+            return Double.NaN
+        }
+        fun swap(index1: Int, index2: Int) {
+            val temp = get(index1)
+            this[index1] = this[index2]
+            this[index2] = temp
+        }
+        fun partition(leftIndex: Int, rightIndex: Int): Int {
+            val pivotIndex = (leftIndex + rightIndex) / 2
+            val pivot = get(pivotIndex)
+            swap(pivotIndex, rightIndex)
+            var storageIndex = leftIndex
+            for(i in leftIndex until rightIndex) {
+                if(get(i) < pivot) {
+                    swap(i, storageIndex)
+                    storageIndex++
+                }
+            }
+            swap(rightIndex, storageIndex)
+            return storageIndex
+        }
+        val midIndex = size / 2
+        var left = 0
+        var lastLeft = 0
+        var right = lastIndex
+        var pivotIndex = partition(left, right)
+        while (pivotIndex != midIndex) {
+            if (pivotIndex > midIndex) {
+                right = pivotIndex - 1
+            } else {
+                lastLeft = left
+                left = pivotIndex + 1
+            }
+            pivotIndex = partition(left, right)
+        }
+        if (size % 2 == 0) {
+            // The right-sided middle value was already found, now we need to find the biggest 
+            // element to its left side. At this point, we're sure that the element is between
+            // the lastLeft and midIndex, so just iterate through this range
+            var currentMax = get(lastLeft)
+            for (i in lastLeft until midIndex) {
+                if (get(i) > currentMax)
+                    currentMax = get(i)
+            }
+            get(pivotIndex) * 0.5 + currentMax * 0.5
+        } else {
+            get(pivotIndex).toDouble()
+        }
+    }
 }
 
 /**

--- a/libraries/stdlib/common/src/generated/_Sequences.kt
+++ b/libraries/stdlib/common/src/generated/_Sequences.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -3005,6 +3005,378 @@ public fun Sequence<Double>.average(): Double {
         checkCountOverflow(++count)
     }
     return if (count == 0) Double.NaN else sum / count
+}
+
+/**
+ * Returns the median value of the elements in the sequence, or Double.NaN if the sequence is empty.
+ * 
+ * It does so in linear time, based on [QuickSelect](https://en.wikipedia.org/wiki/Quickselect).
+ *
+ * The operation is _terminal_.
+ */
+@kotlin.jvm.JvmName("medianOfByte")
+public fun Sequence<Byte>.median(): Double {
+    return with(toMutableList()) {
+        if (size == 0) {
+            return Double.NaN
+        }
+        fun swap(index1: Int, index2: Int) {
+            val temp = get(index1)
+            this[index1] = this[index2]
+            this[index2] = temp
+        }
+        fun partition(leftIndex: Int, rightIndex: Int): Int {
+            val pivotIndex = (leftIndex + rightIndex) / 2
+            val pivot = get(pivotIndex)
+            swap(pivotIndex, rightIndex)
+            var storageIndex = leftIndex
+            for(i in leftIndex until rightIndex) {
+                if(get(i) < pivot) {
+                    swap(i, storageIndex)
+                    storageIndex++
+                }
+            }
+            swap(rightIndex, storageIndex)
+            return storageIndex
+        }
+        val midIndex = size / 2
+        var left = 0
+        var lastLeft = 0
+        var right = lastIndex
+        var pivotIndex = partition(left, right)
+        while (pivotIndex != midIndex) {
+            if (pivotIndex > midIndex) {
+                right = pivotIndex - 1
+            } else {
+                lastLeft = left
+                left = pivotIndex + 1
+            }
+            pivotIndex = partition(left, right)
+        }
+        if (size % 2 == 0) {
+            // The right-sided middle value was already found, now we need to find the biggest 
+            // element to its left side. At this point, we're sure that the element is between
+            // the lastLeft and midIndex, so just iterate through this range
+            var currentMax = get(lastLeft)
+            for (i in lastLeft until midIndex) {
+                if (get(i) > currentMax)
+                    currentMax = get(i)
+            }
+            get(pivotIndex) * 0.5 + currentMax * 0.5
+        } else {
+            get(pivotIndex).toDouble()
+        }
+    }
+}
+
+/**
+ * Returns the median value of the elements in the sequence, or Double.NaN if the sequence is empty.
+ * 
+ * It does so in linear time, based on [QuickSelect](https://en.wikipedia.org/wiki/Quickselect).
+ *
+ * The operation is _terminal_.
+ */
+@kotlin.jvm.JvmName("medianOfShort")
+public fun Sequence<Short>.median(): Double {
+    return with(toMutableList()) {
+        if (size == 0) {
+            return Double.NaN
+        }
+        fun swap(index1: Int, index2: Int) {
+            val temp = get(index1)
+            this[index1] = this[index2]
+            this[index2] = temp
+        }
+        fun partition(leftIndex: Int, rightIndex: Int): Int {
+            val pivotIndex = (leftIndex + rightIndex) / 2
+            val pivot = get(pivotIndex)
+            swap(pivotIndex, rightIndex)
+            var storageIndex = leftIndex
+            for(i in leftIndex until rightIndex) {
+                if(get(i) < pivot) {
+                    swap(i, storageIndex)
+                    storageIndex++
+                }
+            }
+            swap(rightIndex, storageIndex)
+            return storageIndex
+        }
+        val midIndex = size / 2
+        var left = 0
+        var lastLeft = 0
+        var right = lastIndex
+        var pivotIndex = partition(left, right)
+        while (pivotIndex != midIndex) {
+            if (pivotIndex > midIndex) {
+                right = pivotIndex - 1
+            } else {
+                lastLeft = left
+                left = pivotIndex + 1
+            }
+            pivotIndex = partition(left, right)
+        }
+        if (size % 2 == 0) {
+            // The right-sided middle value was already found, now we need to find the biggest 
+            // element to its left side. At this point, we're sure that the element is between
+            // the lastLeft and midIndex, so just iterate through this range
+            var currentMax = get(lastLeft)
+            for (i in lastLeft until midIndex) {
+                if (get(i) > currentMax)
+                    currentMax = get(i)
+            }
+            get(pivotIndex) * 0.5 + currentMax * 0.5
+        } else {
+            get(pivotIndex).toDouble()
+        }
+    }
+}
+
+/**
+ * Returns the median value of the elements in the sequence, or Double.NaN if the sequence is empty.
+ * 
+ * It does so in linear time, based on [QuickSelect](https://en.wikipedia.org/wiki/Quickselect).
+ *
+ * The operation is _terminal_.
+ */
+@kotlin.jvm.JvmName("medianOfInt")
+public fun Sequence<Int>.median(): Double {
+    return with(toMutableList()) {
+        if (size == 0) {
+            return Double.NaN
+        }
+        fun swap(index1: Int, index2: Int) {
+            val temp = get(index1)
+            this[index1] = this[index2]
+            this[index2] = temp
+        }
+        fun partition(leftIndex: Int, rightIndex: Int): Int {
+            val pivotIndex = (leftIndex + rightIndex) / 2
+            val pivot = get(pivotIndex)
+            swap(pivotIndex, rightIndex)
+            var storageIndex = leftIndex
+            for(i in leftIndex until rightIndex) {
+                if(get(i) < pivot) {
+                    swap(i, storageIndex)
+                    storageIndex++
+                }
+            }
+            swap(rightIndex, storageIndex)
+            return storageIndex
+        }
+        val midIndex = size / 2
+        var left = 0
+        var lastLeft = 0
+        var right = lastIndex
+        var pivotIndex = partition(left, right)
+        while (pivotIndex != midIndex) {
+            if (pivotIndex > midIndex) {
+                right = pivotIndex - 1
+            } else {
+                lastLeft = left
+                left = pivotIndex + 1
+            }
+            pivotIndex = partition(left, right)
+        }
+        if (size % 2 == 0) {
+            // The right-sided middle value was already found, now we need to find the biggest 
+            // element to its left side. At this point, we're sure that the element is between
+            // the lastLeft and midIndex, so just iterate through this range
+            var currentMax = get(lastLeft)
+            for (i in lastLeft until midIndex) {
+                if (get(i) > currentMax)
+                    currentMax = get(i)
+            }
+            get(pivotIndex) * 0.5 + currentMax * 0.5
+        } else {
+            get(pivotIndex).toDouble()
+        }
+    }
+}
+
+/**
+ * Returns the median value of the elements in the sequence, or Double.NaN if the sequence is empty.
+ * 
+ * It does so in linear time, based on [QuickSelect](https://en.wikipedia.org/wiki/Quickselect).
+ *
+ * The operation is _terminal_.
+ */
+@kotlin.jvm.JvmName("medianOfLong")
+public fun Sequence<Long>.median(): Double {
+    return with(toMutableList()) {
+        if (size == 0) {
+            return Double.NaN
+        }
+        fun swap(index1: Int, index2: Int) {
+            val temp = get(index1)
+            this[index1] = this[index2]
+            this[index2] = temp
+        }
+        fun partition(leftIndex: Int, rightIndex: Int): Int {
+            val pivotIndex = (leftIndex + rightIndex) / 2
+            val pivot = get(pivotIndex)
+            swap(pivotIndex, rightIndex)
+            var storageIndex = leftIndex
+            for(i in leftIndex until rightIndex) {
+                if(get(i) < pivot) {
+                    swap(i, storageIndex)
+                    storageIndex++
+                }
+            }
+            swap(rightIndex, storageIndex)
+            return storageIndex
+        }
+        val midIndex = size / 2
+        var left = 0
+        var lastLeft = 0
+        var right = lastIndex
+        var pivotIndex = partition(left, right)
+        while (pivotIndex != midIndex) {
+            if (pivotIndex > midIndex) {
+                right = pivotIndex - 1
+            } else {
+                lastLeft = left
+                left = pivotIndex + 1
+            }
+            pivotIndex = partition(left, right)
+        }
+        if (size % 2 == 0) {
+            // The right-sided middle value was already found, now we need to find the biggest 
+            // element to its left side. At this point, we're sure that the element is between
+            // the lastLeft and midIndex, so just iterate through this range
+            var currentMax = get(lastLeft)
+            for (i in lastLeft until midIndex) {
+                if (get(i) > currentMax)
+                    currentMax = get(i)
+            }
+            get(pivotIndex) * 0.5 + currentMax * 0.5
+        } else {
+            get(pivotIndex).toDouble()
+        }
+    }
+}
+
+/**
+ * Returns the median value of the elements in the sequence, or Double.NaN if the sequence is empty.
+ * 
+ * It does so in linear time, based on [QuickSelect](https://en.wikipedia.org/wiki/Quickselect).
+ *
+ * The operation is _terminal_.
+ */
+@kotlin.jvm.JvmName("medianOfFloat")
+public fun Sequence<Float>.median(): Double {
+    return with(toMutableList()) {
+        if (size == 0) {
+            return Double.NaN
+        }
+        fun swap(index1: Int, index2: Int) {
+            val temp = get(index1)
+            this[index1] = this[index2]
+            this[index2] = temp
+        }
+        fun partition(leftIndex: Int, rightIndex: Int): Int {
+            val pivotIndex = (leftIndex + rightIndex) / 2
+            val pivot = get(pivotIndex)
+            swap(pivotIndex, rightIndex)
+            var storageIndex = leftIndex
+            for(i in leftIndex until rightIndex) {
+                if(get(i) < pivot) {
+                    swap(i, storageIndex)
+                    storageIndex++
+                }
+            }
+            swap(rightIndex, storageIndex)
+            return storageIndex
+        }
+        val midIndex = size / 2
+        var left = 0
+        var lastLeft = 0
+        var right = lastIndex
+        var pivotIndex = partition(left, right)
+        while (pivotIndex != midIndex) {
+            if (pivotIndex > midIndex) {
+                right = pivotIndex - 1
+            } else {
+                lastLeft = left
+                left = pivotIndex + 1
+            }
+            pivotIndex = partition(left, right)
+        }
+        if (size % 2 == 0) {
+            // The right-sided middle value was already found, now we need to find the biggest 
+            // element to its left side. At this point, we're sure that the element is between
+            // the lastLeft and midIndex, so just iterate through this range
+            var currentMax = get(lastLeft)
+            for (i in lastLeft until midIndex) {
+                if (get(i) > currentMax)
+                    currentMax = get(i)
+            }
+            get(pivotIndex) * 0.5 + currentMax * 0.5
+        } else {
+            get(pivotIndex).toDouble()
+        }
+    }
+}
+
+/**
+ * Returns the median value of the elements in the sequence, or Double.NaN if the sequence is empty.
+ * 
+ * It does so in linear time, based on [QuickSelect](https://en.wikipedia.org/wiki/Quickselect).
+ *
+ * The operation is _terminal_.
+ */
+@kotlin.jvm.JvmName("medianOfDouble")
+public fun Sequence<Double>.median(): Double {
+    return with(toMutableList()) {
+        if (size == 0) {
+            return Double.NaN
+        }
+        fun swap(index1: Int, index2: Int) {
+            val temp = get(index1)
+            this[index1] = this[index2]
+            this[index2] = temp
+        }
+        fun partition(leftIndex: Int, rightIndex: Int): Int {
+            val pivotIndex = (leftIndex + rightIndex) / 2
+            val pivot = get(pivotIndex)
+            swap(pivotIndex, rightIndex)
+            var storageIndex = leftIndex
+            for(i in leftIndex until rightIndex) {
+                if(get(i) < pivot) {
+                    swap(i, storageIndex)
+                    storageIndex++
+                }
+            }
+            swap(rightIndex, storageIndex)
+            return storageIndex
+        }
+        val midIndex = size / 2
+        var left = 0
+        var lastLeft = 0
+        var right = lastIndex
+        var pivotIndex = partition(left, right)
+        while (pivotIndex != midIndex) {
+            if (pivotIndex > midIndex) {
+                right = pivotIndex - 1
+            } else {
+                lastLeft = left
+                left = pivotIndex + 1
+            }
+            pivotIndex = partition(left, right)
+        }
+        if (size % 2 == 0) {
+            // The right-sided middle value was already found, now we need to find the biggest 
+            // element to its left side. At this point, we're sure that the element is between
+            // the lastLeft and midIndex, so just iterate through this range
+            var currentMax = get(lastLeft)
+            for (i in lastLeft until midIndex) {
+                if (get(i) > currentMax)
+                    currentMax = get(i)
+            }
+            get(pivotIndex) * 0.5 + currentMax * 0.5
+        } else {
+            get(pivotIndex).toDouble()
+        }
+    }
 }
 
 /**

--- a/libraries/stdlib/samples/test/samples/collections/collections.kt
+++ b/libraries/stdlib/samples/test/samples/collections/collections.kt
@@ -1026,4 +1026,20 @@ class Collections {
         }
 
     }
+
+    class Numeric {
+
+        @Sample
+        fun median() {
+            // When number of items is odd, takes the middle value
+            // Middle values = 3
+            val items = listOf(5, 3, 4, 1, 2)
+            assertPrints(items.median(), "3.0")
+
+            // When number of items is even, take the average between them
+            // Middle values = 3 and 4
+            val evenItems = listOf(5, 3, 4, 6, 2, 1)
+            assertPrints(evenItems.median(), "3.5")
+        }
+    }
 }

--- a/libraries/stdlib/test/collections/ArraysTest.kt
+++ b/libraries/stdlib/test/collections/ArraysTest.kt
@@ -502,6 +502,32 @@ class ArraysTest {
         // for each arr with size > 0  arr.average() = arr.sum().toDouble() / arr.size()
     }
 
+    @Test fun median() {
+        assertTrue { intArrayOf().average().isNaN() }
+        expect(1.0) { arrayOf(1).median() }
+        // Middle values = 1 and 3
+        expect(2.0) { arrayOf(3, 1).median() }
+        expect(2.0) { arrayOf(1, 3).median() }
+        // Middle value = 3
+        expect(3.0) { arrayOf(4.0, 1.0, 2.0, 3.0, 5.0).median() }
+        // Middle values = 4 and 4
+        expect(4.0) { arrayOf(5, 3, 4, 6, 4, 1).median() }
+        // Middle values = 5 and 6
+        expect(4.5) { arrayOf(1, 3, 5, 6, 4, 5).median() }
+        // Middle value = 3
+        expect(3.0) { arrayOf(1, 3, 7).median() }
+        expect(3.0) { arrayOf(1f, 7f, 3f).median() }
+        expect(0x3.toDouble()) { arrayOf(0x7, 0x1, 0x3).median() }
+        // Middle values = 3 and 5
+        expect(4.0) { arrayOf(1, 3, 7, 5).median() }
+        expect(4.0) { arrayOf(7, 5, 1, 3).median() }
+        expect(4.0) { arrayOf(5, 7, 1, 3).median() }
+        // Middle values = 5 and 6
+        expect(5.5) { arrayOf(10, 6, 4, 2, 7, 9, 5, 8, 3, 1).median() }
+        expect(5.5) { arrayOf(10, 4, 8, 2, 9, 7, 6, 4, 5, 1).median() }
+        expect(5.5) { arrayOf(1, 4, 8, 2, 7, 9, 6, 4, 5, 10).median() }
+    }
+
     @Test fun indexOfInPrimitiveArrays() {
         expect(-1) { byteArrayOf(1, 2, 3).indexOf(0) }
         expect(0) { byteArrayOf(1, 2, 3).indexOf(1) }

--- a/libraries/stdlib/test/collections/CollectionTest.kt
+++ b/libraries/stdlib/test/collections/CollectionTest.kt
@@ -1008,6 +1008,32 @@ class CollectionTest {
         expect(n.toDouble()/2) { range.average() }
     }
 
+    @Test fun median() {
+        assertTrue { listOf<Int>().average().isNaN() }
+        expect(1.0) { listOf(1).median() }
+        // Middle values = 1 and 3
+        expect(2.0) { listOf(3, 1).median() }
+        expect(2.0) { listOf(1, 3).median() }
+        // Middle value = 3
+        expect(3.0) { listOf(4.0, 1.0, 2.0, 3.0, 5.0).median() }
+        // Middle values = 4 and 4
+        expect(4.0) { listOf(5, 3, 4, 6, 4, 1).median() }
+        // Middle values = 5 and 6
+        expect(4.5) { listOf(1, 3, 5, 6, 4, 5).median() }
+        // Middle value = 3
+        expect(3.0) { listOf(1, 3, 7).median() }
+        expect(3.0) { listOf(1f, 7f, 3f).median() }
+        expect(0x3.toDouble()) { listOf(0x7, 0x1, 0x3).median() }
+        // Middle values = 3 and 5
+        expect(4.0) { listOf(1, 3, 7, 5).median() }
+        expect(4.0) { listOf(7, 5, 1, 3).median() }
+        expect(4.0) { listOf(5, 7, 1, 3).median() }
+        // Middle values = 5 and 6
+        expect(5.5) { listOf(10, 6, 4, 2, 7, 9, 5, 8, 3, 1).median() }
+        expect(5.5) { listOf(10, 4, 8, 2, 9, 7, 6, 4, 5, 1).median() }
+        expect(5.5) { listOf(1, 4, 8, 2, 7, 9, 6, 4, 5, 10).median() }
+    }
+
     @Test fun takeReturnsFirstNElements() {
         expect(listOf(1, 2, 3, 4, 5)) { (1..10).take(5) }
         expect(listOf(1, 2, 3, 4, 5)) { (1..10).toList().take(5) }

--- a/libraries/tools/binary-compatibility-validator/reference-public-api/kotlin-stdlib-runtime-merged.txt
+++ b/libraries/tools/binary-compatibility-validator/reference-public-api/kotlin-stdlib-runtime-merged.txt
@@ -1455,6 +1455,18 @@ public final class kotlin/collections/ArraysKt {
 	public static final fun maxWithOrThrow ([Ljava/lang/Object;Ljava/util/Comparator;)Ljava/lang/Object;
 	public static final fun maxWithOrThrow ([SLjava/util/Comparator;)S
 	public static final fun maxWithOrThrow ([ZLjava/util/Comparator;)Z
+	public static final fun median ([B)D
+	public static final fun median ([D)D
+	public static final fun median ([F)D
+	public static final fun median ([I)D
+	public static final fun median ([J)D
+	public static final fun median ([S)D
+	public static final fun medianOfByte ([Ljava/lang/Byte;)D
+	public static final fun medianOfDouble ([Ljava/lang/Double;)D
+	public static final fun medianOfFloat ([Ljava/lang/Float;)D
+	public static final fun medianOfInt ([Ljava/lang/Integer;)D
+	public static final fun medianOfLong ([Ljava/lang/Long;)D
+	public static final fun medianOfShort ([Ljava/lang/Short;)D
 	public static final synthetic fun min ([B)Ljava/lang/Byte;
 	public static final synthetic fun min ([C)Ljava/lang/Character;
 	public static final synthetic fun min ([D)Ljava/lang/Double;
@@ -2313,6 +2325,12 @@ public final class kotlin/collections/CollectionsKt {
 	public static final synthetic fun maxWith (Ljava/lang/Iterable;Ljava/util/Comparator;)Ljava/lang/Object;
 	public static final fun maxWithOrNull (Ljava/lang/Iterable;Ljava/util/Comparator;)Ljava/lang/Object;
 	public static final fun maxWithOrThrow (Ljava/lang/Iterable;Ljava/util/Comparator;)Ljava/lang/Object;
+	public static final fun medianOfByte (Ljava/lang/Iterable;)D
+	public static final fun medianOfDouble (Ljava/lang/Iterable;)D
+	public static final fun medianOfFloat (Ljava/lang/Iterable;)D
+	public static final fun medianOfInt (Ljava/lang/Iterable;)D
+	public static final fun medianOfLong (Ljava/lang/Iterable;)D
+	public static final fun medianOfShort (Ljava/lang/Iterable;)D
 	public static final synthetic fun min (Ljava/lang/Iterable;)Ljava/lang/Comparable;
 	public static final synthetic fun min (Ljava/lang/Iterable;)Ljava/lang/Double;
 	public static final synthetic fun min (Ljava/lang/Iterable;)Ljava/lang/Float;
@@ -5187,6 +5205,12 @@ public final class kotlin/sequences/SequencesKt {
 	public static final synthetic fun maxWith (Lkotlin/sequences/Sequence;Ljava/util/Comparator;)Ljava/lang/Object;
 	public static final fun maxWithOrNull (Lkotlin/sequences/Sequence;Ljava/util/Comparator;)Ljava/lang/Object;
 	public static final fun maxWithOrThrow (Lkotlin/sequences/Sequence;Ljava/util/Comparator;)Ljava/lang/Object;
+	public static final fun medianOfByte (Lkotlin/sequences/Sequence;)D
+	public static final fun medianOfDouble (Lkotlin/sequences/Sequence;)D
+	public static final fun medianOfFloat (Lkotlin/sequences/Sequence;)D
+	public static final fun medianOfInt (Lkotlin/sequences/Sequence;)D
+	public static final fun medianOfLong (Lkotlin/sequences/Sequence;)D
+	public static final fun medianOfShort (Lkotlin/sequences/Sequence;)D
 	public static final synthetic fun min (Lkotlin/sequences/Sequence;)Ljava/lang/Comparable;
 	public static final synthetic fun min (Lkotlin/sequences/Sequence;)Ljava/lang/Double;
 	public static final synthetic fun min (Lkotlin/sequences/Sequence;)Ljava/lang/Float;


### PR DESCRIPTION
As seen in [KT-50138](https://youtrack.jetbrains.com/issue/KT-50138/Add-median-to-stdlib).

Although figuring out the median is trivial when the numbers are sorted, it is not that straight-forward to do it in a performant way when the numbers are not guaranteed to be sorted.

The naive approach would be to just sort the elements and then get the median value. However, sorting is sub-optimal, with a time complexity of `O(n.log(n))`.

For calculating the median, [QuickSelect](https://en.wikipedia.org/wiki/Quickselect) can be used to perform the task in linear time: `O(n)`.

By adding this to the stdlib, developers can rely on a standard implementation instead of having to come up with an implementation of their own.