### PR TITLE
Allow overriding ansi mode on PlainTextMessageRenderer

### DIFF
--- a/compiler/cli/src/org/jetbrains/kotlin/cli/common/messages/PlainTextMessageRenderer.java
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/common/messages/PlainTextMessageRenderer.java
@@ -52,6 +52,19 @@ public abstract class PlainTextMessageRenderer implements MessageRenderer {
 
     private static final Set<CompilerMessageSeverity> IMPORTANT_MESSAGE_SEVERITIES = EnumSet.of(EXCEPTION, ERROR, STRONG_WARNING, WARNING);
 
+    private final boolean colorEnabled;
+
+    public PlainTextMessageRenderer() {
+        this(COLOR_ENABLED);
+    }
+
+    // This constructor is not used in this project
+    // but it can be useful in a compilation server to still be able to generate colored output
+    @SuppressWarnings("WeakerAccess")
+    public PlainTextMessageRenderer(boolean colorEnabled) {
+        this.colorEnabled = colorEnabled;
+    }
+
     @Override
     public String renderPreamble() {
         return "";
@@ -78,7 +91,7 @@ public abstract class PlainTextMessageRenderer implements MessageRenderer {
             result.append(" ");
         }
 
-        if (COLOR_ENABLED) {
+        if (this.colorEnabled) {
             Ansi ansi = Ansi.ansi()
                     .bold()
                     .fg(severityColor(severity))


### PR DESCRIPTION
issue: https://youtrack.jetbrains.com/issue/KT-55784/Unable-to-format-compilation-errors-with-ansi-colors-in-compilation-server

Currently, ansi mode is used only if stderr is a TTY, while `PlainTextMessageRenderer` is not designed to write the error to the console but only to format it to a string in the `render` method.

This change would allow to compile kotlin code and format the warning/errors with ansi tags in a compilation server (where the stderr being a TTY is not relevant)