### PR TITLE
Rename RingBuffer#add for the JVM to not shadow

### DIFF
--- a/libraries/stdlib/src/kotlin/collections/SlidingWindow.kt
+++ b/libraries/stdlib/src/kotlin/collections/SlidingWindow.kt
@@ -168,6 +168,7 @@ private class RingBuffer<T>(private val buffer: Array<Any?>, filledSize: Int) : 
     /**
      * Add [element] to the buffer or fail with [IllegalStateException] if no free space available in the buffer
      */
+    @kotlin.jvm.JvmName("addToBuffer")
     fun add(element: T) {
         if (isFull()) {
             throw IllegalStateException("ring buffer is full")


### PR DESCRIPTION
RingBuffer extends from the non-mutable AbstractList, but defines its own `add` fun which doesn't return any value. For the JVM there will implicitly be a `fun add(T): boolean` added to the supertype, which means `RingBuffer#add` is now shadowing it.

Thankfully this is all in a private class so we don't need to worry about a breaking API change.

^KT-55562