### PR TITLE
KT-25047 Bump JetBrains Annotation api dependency to 24 with Java8 support

### DIFF
--- a/libraries/stdlib/jvm/build.gradle
+++ b/libraries/stdlib/jvm/build.gradle
@@ -70,7 +70,7 @@ dependencies {
 
     commonSources project(path: ":kotlin-stdlib-common", configuration: "sources")
 
-    api group: 'org.jetbrains', name: 'annotations', version:'13.0'
+    api group: 'org.jetbrains', name: 'annotations', version:'24.0.0'
 
     mainJdk7Api sourceSets.main.output
     mainJdk8Api sourceSets.main.output


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-25047/Upgrade-org.jetbrainsannotations-dependency-to-latest-currently-16.0.2

Kotlin 1.8 now targets JVM 1.8 by default so a newer annotation version dropping support for JVM 5 can be used.