### PR TITLE
[JVM_IR] Limit inner class attributes to types in class file

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBytecodeTextTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBytecodeTextTestGenerated.java
@@ -4137,6 +4137,12 @@ public class FirBytecodeTextTestGenerated extends AbstractFirBytecodeTextTest {
         }
 
         @Test
+        @TestMetadata("kt56104.kt")
+        public void testKt56104() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/innerClasses/kt56104.kt");
+        }
+
+        @Test
         @TestMetadata("nestedClassInAnnotationArgument.kt")
         public void testNestedClassInAnnotationArgument() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/innerClasses/nestedClassInAnnotationArgument.kt");

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ClassCodegen.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ClassCodegen.kt
@@ -86,13 +86,16 @@ class ClassCodegen private constructor(
         if (context.state.oldInnerClassesLogic)
             context.defaultTypeMapper
         else object : IrTypeMapper(context) {
-            override fun mapType(type: IrType, mode: TypeMappingMode, sw: JvmSignatureWriter?): Type {
+            override fun mapType(type: IrType, mode: TypeMappingMode, sw: JvmSignatureWriter?, materialized: Boolean): Type {
                 var t = type
                 while (t.isArray()) {
                     t = t.getArrayElementType(context.irBuiltIns)
                 }
-                t.classOrNull?.owner?.let(::addInnerClassInfo)
-                return super.mapType(type, mode, sw)
+                // Only record inner class info for types that are materialized in the class file.
+                if (materialized) {
+                    t.classOrNull?.owner?.let(::addInnerClassInfo)
+                }
+                return super.mapType(type, mode, sw, materialized)
             }
         }
 

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/JvmSignatureClashDetector.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/JvmSignatureClashDetector.kt
@@ -42,7 +42,7 @@ class JvmSignatureClashDetector(
     }
 
     private fun mapRawSignature(irFunction: IrFunction): RawSignature {
-        val jvmSignature = classCodegen.methodSignatureMapper.mapSignatureSkipGeneric(irFunction)
+        val jvmSignature = classCodegen.methodSignatureMapper.mapFakeOverrideSignatureSkipGeneric(irFunction)
         return RawSignature(jvmSignature.asmMethod.name, jvmSignature.asmMethod.descriptor, MemberKind.METHOD)
     }
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/mapping/IrTypeMapper.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/mapping/IrTypeMapper.kt
@@ -130,7 +130,7 @@ open class IrTypeMapper(private val context: JvmBackendContext) : KotlinTypeMapp
         mode: TypeMappingMode = TypeMappingMode.DEFAULT,
         sw: JvmSignatureWriter? = null,
         materialized: Boolean = true
-    ): Type = AbstractTypeMapper.mapType(this, type, mode, sw)
+    ): Type = AbstractTypeMapper.mapType(this, type, mode, sw, materialized)
 
     override fun JvmSignatureWriter.writeGenericType(type: KotlinTypeMarker, asmType: Type, mode: TypeMappingMode) {
         if (type is IrErrorType) {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/mapping/IrTypeMapper.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/mapping/IrTypeMapper.kt
@@ -128,7 +128,8 @@ open class IrTypeMapper(private val context: JvmBackendContext) : KotlinTypeMapp
     open fun mapType(
         type: IrType,
         mode: TypeMappingMode = TypeMappingMode.DEFAULT,
-        sw: JvmSignatureWriter? = null
+        sw: JvmSignatureWriter? = null,
+        materialized: Boolean = true
     ): Type = AbstractTypeMapper.mapType(this, type, mode, sw)
 
     override fun JvmSignatureWriter.writeGenericType(type: KotlinTypeMarker, asmType: Type, mode: TypeMappingMode) {

--- a/compiler/testData/codegen/bytecodeText/innerClasses/kt56104.kt
+++ b/compiler/testData/codegen/bytecodeText/innerClasses/kt56104.kt
@@ -1,0 +1,13 @@
+// TARGET_BACKEND: JVM_IR
+
+// FILE: classes.kt
+
+open class A {
+    class Inner
+    fun foo(i: Inner): Inner = Inner()
+}
+
+class B: A()
+
+// A and A$Inner both need an inner class attribute for the relationship. B does not.
+// 2 INNERCLASS A\$Inner A Inner

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBytecodeTextTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBytecodeTextTestGenerated.java
@@ -4137,6 +4137,12 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
         }
 
         @Test
+        @TestMetadata("kt56104.kt")
+        public void testKt56104() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/innerClasses/kt56104.kt");
+        }
+
+        @Test
         @TestMetadata("nestedClassInAnnotationArgument.kt")
         public void testNestedClassInAnnotationArgument() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/innerClasses/nestedClassInAnnotationArgument.kt");


### PR DESCRIPTION
Inner class attributes should only be recorded for types that are materialized in the result class file. In particular, we should not emit inner classes attributes for types that appear only in fake overrides. We do map these types to track the fake overrides for JVM signature clashes but they are not materialized in the class file.

^KT-56104 Fixed