### PR TITLE
KT-56200 Don't leak user code in reference resolve exception

### DIFF
--- a/analysis/analysis-api-fir/src/org/jetbrains/kotlin/analysis/api/fir/references/KtFirReferenceResolver.kt
+++ b/analysis/analysis-api-fir/src/org/jetbrains/kotlin/analysis/api/fir/references/KtFirReferenceResolver.kt
@@ -12,8 +12,11 @@ import com.intellij.psi.impl.source.resolve.ResolveCache
 import org.jetbrains.kotlin.analysis.api.KtAllowAnalysisOnEdt
 import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.lifetime.allowAnalysisOnEdt
-import org.jetbrains.kotlin.analysis.utils.printer.getElementTextInContext
+import org.jetbrains.kotlin.analysis.utils.errors.buildErrorWithAttachment
+import org.jetbrains.kotlin.analysis.utils.errors.withPsiEntry
+import org.jetbrains.kotlin.diagnostics.PsiDiagnosticUtils
 import org.jetbrains.kotlin.util.shouldIjPlatformExceptionBeRethrown
+import org.jetbrains.kotlin.utils.KotlinExceptionWithAttachments
 
 object KtFirReferenceResolver : ResolveCache.PolyVariantResolver<KtReference> {
     class KotlinResolveResult(element: PsiElement) : PsiElementResolveResult(element)
@@ -38,4 +41,8 @@ object KtFirReferenceResolver : ResolveCache.PolyVariantResolver<KtReference> {
 class KtReferenceResolveException(
     reference: KtReference,
     cause: Throwable
-) : RuntimeException("Reference is:\n${reference.element.getElementTextInContext()}", cause)
+) : KotlinExceptionWithAttachments("Unable to resolve reference at: ${PsiDiagnosticUtils.atLocation(reference.element)}", cause) {
+    init {
+        withPsiAttachment("element.kt", reference.element)
+    }
+}


### PR DESCRIPTION
The element text here can be added as an attachment, this makes it possible to opt out of sending user code when reporting an exception in the IDE.