### PR TITLE
Fix regression where  was removed from generated modulemaps

### DIFF
--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExport.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExport.kt
@@ -87,7 +87,7 @@ internal fun createObjCFramework(
             frameworkDirectory,
             frameworkName,
             exportedInterface.headerLines,
-            moduleDependencies = emptySet()
+            moduleDependencies = setOf("Foundation")
     )
 }
 


### PR DESCRIPTION
There is a regression in the 1.8.20 compiler where generated module maps no longer include the line `use Foundation`. [This commit](https://github.com/JetBrains/kotlin/commit/56602290ecff7612936d345fd012269e7db58cb5) removed the line from the generated module map.

This is just a relanding of a [previous commit](https://github.com/JetBrains/kotlin/commit/2a1d5d3e0a63dd92b6a43882ddda0279aaa7f636) that added the `use Foundation` line to the generated module map.