### PR TITLE
Add more methods to DescriptorSerializerPlugin

### DIFF
--- a/compiler/serialization/src/org/jetbrains/kotlin/serialization/DescriptorSerializer.kt
+++ b/compiler/serialization/src/org/jetbrains/kotlin/serialization/DescriptorSerializer.kt
@@ -70,6 +70,7 @@ class DescriptorSerializer private constructor(
             descriptor, Interner(typeParameters), extension, typeTable, versionRequirementTable,
             serializeTypeTableToFunction = false, typeAttributeTranslators = typeAttributeTranslators,
             languageVersionSettings = languageVersionSettings,
+            plugins = plugins,
         )
 
     val stringTable: DescriptorAwareStringTable
@@ -362,6 +363,8 @@ class DescriptorSerializer private constructor(
 
         extension.serializeProperty(descriptor, builder, versionRequirementTable, local)
 
+        plugins.forEach { it.afterProperty(descriptor, builder, versionRequirementTable, this, extension) }
+
         return builder
     }
 
@@ -435,6 +438,8 @@ class DescriptorSerializer private constructor(
 
         extension.serializeFunction(descriptor, builder, versionRequirementTable, local)
 
+        plugins.forEach { it.afterFunction(descriptor, builder, versionRequirementTable, this, extension) }
+
         if (serializeTypeTableToFunction) {
             typeTable.serialize()?.let { builder.typeTable = it }
         }
@@ -496,6 +501,8 @@ class DescriptorSerializer private constructor(
         }
 
         extension.serializeConstructor(descriptor, builder, local)
+
+        plugins.forEach { it.afterConstructor(descriptor, builder, versionRequirementTable, this, extension) }
 
         return builder
     }
@@ -568,6 +575,8 @@ class DescriptorSerializer private constructor(
         }
 
         extension.serializeTypeAlias(descriptor, builder)
+
+        plugins.forEach { it.afterTypealias(descriptor, builder, versionRequirementTable, this, extension) }
 
         return builder
     }
@@ -874,6 +883,7 @@ class DescriptorSerializer private constructor(
                 null, Interner(), extension, MutableTypeTable(), MutableVersionRequirementTable(), serializeTypeTableToFunction = false,
                 typeAttributeTranslators = project?.let { TypeAttributeTranslatorExtension.createTranslators(it) },
                 languageVersionSettings = languageVersionSettings,
+                plugins = project?.let { DescriptorSerializerPlugin.getInstances(it) }.orEmpty(),
             )
 
         @JvmStatic

--- a/compiler/serialization/src/org/jetbrains/kotlin/serialization/DescriptorSerializerPlugin.kt
+++ b/compiler/serialization/src/org/jetbrains/kotlin/serialization/DescriptorSerializerPlugin.kt
@@ -5,7 +5,7 @@
 
 package org.jetbrains.kotlin.serialization
 
-import org.jetbrains.kotlin.descriptors.ClassDescriptor
+import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.extensions.ProjectExtensionDescriptor
 import org.jetbrains.kotlin.metadata.ProtoBuf
 import org.jetbrains.kotlin.metadata.serialization.MutableVersionRequirementTable
@@ -15,6 +15,42 @@ interface DescriptorSerializerPlugin {
         descriptor: ClassDescriptor,
         proto: ProtoBuf.Class.Builder,
         versionRequirementTable: MutableVersionRequirementTable,
+        childSerializer: DescriptorSerializer,
+        extension: SerializerExtension
+    ) {
+    }
+
+    fun afterFunction(
+        descriptor: FunctionDescriptor,
+        proto: ProtoBuf.Function.Builder,
+        versionRequirementTable: MutableVersionRequirementTable?,
+        childSerializer: DescriptorSerializer,
+        extension: SerializerExtension
+    ) {
+    }
+
+    fun afterConstructor(
+        descriptor: ConstructorDescriptor,
+        proto: ProtoBuf.Constructor.Builder,
+        versionRequirementTable: MutableVersionRequirementTable?,
+        childSerializer: DescriptorSerializer,
+        extension: SerializerExtension
+    ) {
+    }
+
+    fun afterProperty(
+        descriptor: PropertyDescriptor,
+        proto: ProtoBuf.Property.Builder,
+        versionRequirementTable: MutableVersionRequirementTable?,
+        childSerializer: DescriptorSerializer,
+        extension: SerializerExtension
+    ) {
+    }
+
+    fun afterTypealias(
+        descriptor: TypeAliasDescriptor,
+        proto: ProtoBuf.TypeAlias.Builder,
+        versionRequirementTable: MutableVersionRequirementTable?,
         childSerializer: DescriptorSerializer,
         extension: SerializerExtension
     ) {


### PR DESCRIPTION
New methods:
afterFunction, afterConstructor, afterProperty, afterTypealias
___
### The problem:
The use case comes from Compose. 
The issue arises when building an app for ios (when CompilerOutputKind.FRAMEWORK).

Given a public function:
```kotlin
fun setCContent(content: @Composable () -> Unit) { ... }
```
Compose transforms its IR to: `fun setCContent(content: Function2<Compose, Int, Unit>)`

Then when we try to build the app, it fails:
```
Undefined symbol: _kfun:example.imageviewer#setCContent(kotlin.Function0<kotlin.Unit>){} // notice a different Function arity comparing with what Compose emits
```

Currently, we use a really inconvenient workaround - marking all such functions `internal`. It prevents them from being added to the public Objective-C API. 

Since kotlin 1.8.0 there is a new annotation - `HiddenFromObjC`, it can be added to a function instead of making it internal. But it still requires the same amount of efforts to mark every public function with Composable annotation or Composable parameters, or Composable return type.
We want to add this annotation using the Compose plugin.
____

As I figured out, we have to add this annotation to a FunctionDescriptor, because `internal fun ObjCExportMapper.shouldBeExposed(descriptor: CallableMemberDescriptor): Boolean ` takes a descriptor as a parameter:
https://github.com/JetBrains/kotlin/blob/6ae517a2df559f565cc30bf17a3b0481af5d068b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportMapper.kt#L100

Adding the annotation to a function IR doesn't make any difference and the descriptor remains intact.

I didn't find a way to modify the descriptor directly (so the changes would be really applied). One way suggested by @SvyatoslavScherbina was to modify it during the serialization. And there is already a plugin for it - `DescriptorSerializerPlugin` which currently has only 1 function - `afterClass`.

So this PR adds 4 more functions to modify the serialized descriptors.
The usage in Compose would look like this:
```kotlin
private val annotationToAdd = "kotlin/native/HiddenFromObjC"

private fun ProtoBuf.Function.Builder.addHiddenFromObjC(extension: SerializerExtension) {
    val annotationProto = ProtoBuf.Annotation.newBuilder().apply {
        id = extension.stringTable.getQualifiedClassNameIndex(ClassId.fromString(annotationToAdd))
    }.build()
    addExtension(KlibMetadataSerializerProtocol.functionAnnotation, annotationProto)
    flags = flags or hasAnnotationFlag
}

override fun afterFunction(
    descriptor: FunctionDescriptor,
    proto: ProtoBuf.Function.Builder,
    versionRequirementTable: MutableVersionRequirementTable?,
    childSerializer: DescriptorSerializer,
    extension: SerializerExtension
) {
    val shouldAdd = descriptor.hasComposableAnnotation() ||
        descriptor.valueParameters.any { it.type.hasComposable() } ||
        descriptor.typeParameters.any { it.defaultType.hasComposable() } ||
        descriptor.returnType?.hasComposable() == true
    if (shouldAdd) {
        proto.addHiddenFromObjC(extension)
    }
}
```

Questions: 
- is there a better extension point to modify the descriptors?
- Is this solution with modifying descriptor a future proof? (considering the future of descriptors?)


