### PR TITLE
Added String.replacePrefix and String.replaceSuffix to stdlib

### DIFF
--- a/libraries/stdlib/src/kotlin/text/Strings.kt
+++ b/libraries/stdlib/src/kotlin/text/Strings.kt
@@ -641,6 +641,17 @@ public fun String.removeSuffix(suffix: CharSequence): String {
 }
 
 /**
+ * If this string starts with the given [suffix], returns a new string with the suffix
+ * replaced with [replacement]. Otherwise, returns this string.
+ */
+public fun String.replaceSuffix(suffix: CharSequence, replacement: String): String {
+    if (endsWith(suffix)) {
+        return substring(0, length - suffix.length) + replacement
+    }
+    return this
+}
+
+/**
  * When this char sequence starts with the given [prefix] and ends with the given [suffix],
  * returns a new char sequence having both the given [prefix] and [suffix] removed.
  * Otherwise returns a new char sequence with the same characters.

--- a/libraries/stdlib/src/kotlin/text/Strings.kt
+++ b/libraries/stdlib/src/kotlin/text/Strings.kt
@@ -608,6 +608,17 @@ public fun String.removePrefix(prefix: CharSequence): String {
 }
 
 /**
+ * If this string starts with the given [prefix], returns a new string with the prefix
+ * replaced with [replacement]. Otherwise, returns this string.
+ */
+public fun String.replacePrefix(prefix: CharSequence, replacement: String): String {
+    if (startsWith(prefix)) {
+        return replacement + substring(prefix.length)
+    }
+    return this
+}
+
+/**
  * If this char sequence ends with the given [suffix], returns a new char sequence
  * with the suffix removed. Otherwise, returns a new char sequence with the same characters.
  */
@@ -817,7 +828,13 @@ public inline infix fun CharSequence.matches(regex: Regex): Boolean = regex.matc
  * Implementation of [regionMatches] for CharSequences.
  * Invoked when it's already known that arguments are not Strings, so that no additional type checks are performed.
  */
-internal fun CharSequence.regionMatchesImpl(thisOffset: Int, other: CharSequence, otherOffset: Int, length: Int, ignoreCase: Boolean): Boolean {
+internal fun CharSequence.regionMatchesImpl(
+    thisOffset: Int,
+    other: CharSequence,
+    otherOffset: Int,
+    length: Int,
+    ignoreCase: Boolean
+): Boolean {
     if ((otherOffset < 0) || (thisOffset < 0) || (thisOffset > this.length - length) || (otherOffset > other.length - length)) {
         return false
     }
@@ -1042,7 +1059,11 @@ public fun CharSequence.findAnyOf(strings: Collection<String>, startIndex: Int =
  * the end toward the beginning of this string, and finds at each position the first element in [strings]
  * that matches this string at that position.
  */
-public fun CharSequence.findLastAnyOf(strings: Collection<String>, startIndex: Int = lastIndex, ignoreCase: Boolean = false): Pair<Int, String>? =
+public fun CharSequence.findLastAnyOf(
+    strings: Collection<String>,
+    startIndex: Int = lastIndex,
+    ignoreCase: Boolean = false
+): Pair<Int, String>? =
     findAnyOf(strings, startIndex, ignoreCase, last = true)
 
 /**
@@ -1148,7 +1169,6 @@ public operator fun CharSequence.contains(other: CharSequence, ignoreCase: Boole
         indexOf(other, 0, length, ignoreCase) >= 0
 
 
-
 /**
  * Returns `true` if this char sequence contains the specified character [char].
  *
@@ -1236,7 +1256,12 @@ private class DelimitedRangesSequence(
  * @param ignoreCase `true` to ignore character case when matching a delimiter. By default `false`.
  * @param limit The maximum number of substrings to return. Zero by default means no limit is set.
  */
-private fun CharSequence.rangesDelimitedBy(delimiters: CharArray, startIndex: Int = 0, ignoreCase: Boolean = false, limit: Int = 0): Sequence<IntRange> {
+private fun CharSequence.rangesDelimitedBy(
+    delimiters: CharArray,
+    startIndex: Int = 0,
+    ignoreCase: Boolean = false,
+    limit: Int = 0
+): Sequence<IntRange> {
     requireNonNegativeLimit(limit)
 
     return DelimitedRangesSequence(this, startIndex, limit, { currentIndex ->
@@ -1259,11 +1284,27 @@ private fun CharSequence.rangesDelimitedBy(delimiters: CharArray, startIndex: In
  * the beginning to the end of this string, and finds at each position the first element in [delimiters]
  * that matches this string at that position.
  */
-private fun CharSequence.rangesDelimitedBy(delimiters: Array<out String>, startIndex: Int = 0, ignoreCase: Boolean = false, limit: Int = 0): Sequence<IntRange> {
+private fun CharSequence.rangesDelimitedBy(
+    delimiters: Array<out String>,
+    startIndex: Int = 0,
+    ignoreCase: Boolean = false,
+    limit: Int = 0
+): Sequence<IntRange> {
     requireNonNegativeLimit(limit)
     val delimitersList = delimiters.asList()
 
-    return DelimitedRangesSequence(this, startIndex, limit, { currentIndex -> findAnyOf(delimitersList, currentIndex, ignoreCase = ignoreCase, last = false)?.let { it.first to it.second.length } })
+    return DelimitedRangesSequence(
+        this,
+        startIndex,
+        limit,
+        { currentIndex ->
+            findAnyOf(
+                delimitersList,
+                currentIndex,
+                ignoreCase = ignoreCase,
+                last = false
+            )?.let { it.first to it.second.length }
+        })
 
 }
 


### PR DESCRIPTION
New methods:
replacePrefix, replaceSuffix

I have been using String.removePrefix for removing some specific patterns (i.e. global phone numbers prefix, +82-1234-5678). I figured out that there are removePrefix, replace, replaceFirst, and such to use conveniently, but there is no removePrefix, and removeSuffix also. I know this may be easily solved through using regex to replace specific patterns, but in the sense of readability and convenience, it might be a good idea to add these extension functions.

I have only added these for String. It would be great if anyone can add these for CharSequence too.

p.s. I have figured out that my code auto formatting has fixed some of the methods' alignment. It looks better to read, but I do not know if the original alignments were made intentionally. If so, I will fix it back.