### PR TITLE
Add capability to fetch coroutine stack trace info in one call

### DIFF
--- a/libraries/stdlib/jvm/build.gradle
+++ b/libraries/stdlib/jvm/build.gradle
@@ -79,6 +79,8 @@ dependencies {
     testApi project(':kotlin-test:kotlin-test-junit')
 
     builtins project(':core:builtins')
+
+    testImplementation("com.google.code.gson:gson:2.8.9")
 }
 
 jar {


### PR DESCRIPTION
This pull request addresses the issue of slow coroutine stack trace loading time when debugging an android app on a phone.

When fetching the asynchronous call stack of a coroutine, the debugger uses JDI to traverse the list of coroutine contexts to collect information about stack frames and spilled variables. When the stack trace is large, the debugger starts to spend a lot of time fetching the information, since the JDI communication with a phone is very slow. 

This issue also affects the stepping time in coroutine contexts. After any stepping action is performed, the debugger has to refetch the stack trace, which can lead to very slow stepping when a stack trace is large.
 
This pr adds a method that fetches all of the required information about a stack trace on the client VM side, which significantly speeds up the stack trace loading time. Right now the debugger will need to invoke only one JDI call to get the information about the entire stack trace. Here is the comparison chart:


![CoroutineStackTraceLoadingTime](https://user-images.githubusercontent.com/25721619/216279416-5998191b-0d87-43ef-998f-e94d2de8fa9b.png)

