### PR TITLE
AA: Fix type annotations on and aliases to function types

### DIFF
--- a/analysis/analysis-api-fe10/tests-gen/org/jetbrains/kotlin/analysis/api/fe10/test/cases/generated/cases/symbols/Fe10IdeNormalAnalysisSourceModuleSingleSymbolByPsiGenerated.java
+++ b/analysis/analysis-api-fe10/tests-gen/org/jetbrains/kotlin/analysis/api/fe10/test/cases/generated/cases/symbols/Fe10IdeNormalAnalysisSourceModuleSingleSymbolByPsiGenerated.java
@@ -119,6 +119,12 @@ public class Fe10IdeNormalAnalysisSourceModuleSingleSymbolByPsiGenerated extends
     }
 
     @Test
+    @TestMetadata("typeAnnotationsOnFunctionalTypeWithTypeAlias.kt")
+    public void testTypeAnnotationsOnFunctionalTypeWithTypeAlias() throws Exception {
+        runTest("analysis/analysis-api/testData/symbols/singleSymbolByPsi/typeAnnotationsOnFunctionalTypeWithTypeAlias.kt");
+    }
+
+    @Test
     @TestMetadata("typeAnnotationsOnPropertyGetterReturnType.kt")
     public void testTypeAnnotationsOnPropertyGetterReturnType() throws Exception {
         runTest("analysis/analysis-api/testData/symbols/singleSymbolByPsi/typeAnnotationsOnPropertyGetterReturnType.kt");

--- a/analysis/analysis-api-fir/tests-gen/org/jetbrains/kotlin/analysis/api/fir/test/cases/generated/cases/symbols/FirIdeNormalAnalysisSourceModuleSingleSymbolByPsiGenerated.java
+++ b/analysis/analysis-api-fir/tests-gen/org/jetbrains/kotlin/analysis/api/fir/test/cases/generated/cases/symbols/FirIdeNormalAnalysisSourceModuleSingleSymbolByPsiGenerated.java
@@ -119,6 +119,12 @@ public class FirIdeNormalAnalysisSourceModuleSingleSymbolByPsiGenerated extends 
     }
 
     @Test
+    @TestMetadata("typeAnnotationsOnFunctionalTypeWithTypeAlias.kt")
+    public void testTypeAnnotationsOnFunctionalTypeWithTypeAlias() throws Exception {
+        runTest("analysis/analysis-api/testData/symbols/singleSymbolByPsi/typeAnnotationsOnFunctionalTypeWithTypeAlias.kt");
+    }
+
+    @Test
     @TestMetadata("typeAnnotationsOnPropertyGetterReturnType.kt")
     public void testTypeAnnotationsOnPropertyGetterReturnType() throws Exception {
         runTest("analysis/analysis-api/testData/symbols/singleSymbolByPsi/typeAnnotationsOnPropertyGetterReturnType.kt");

--- a/analysis/analysis-api-impl-base/tests/org/jetbrains/kotlin/analysis/api/impl/base/test/cases/symbols/AbstractSymbolTest.kt
+++ b/analysis/analysis-api-impl-base/tests/org/jetbrains/kotlin/analysis/api/impl/base/test/cases/symbols/AbstractSymbolTest.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlin.analysis.api.impl.base.test.cases.symbols.SymbolTest
 import org.jetbrains.kotlin.analysis.api.renderer.declarations.KtDeclarationRenderer
 import org.jetbrains.kotlin.analysis.api.renderer.declarations.impl.KtDeclarationRendererForDebug
 import org.jetbrains.kotlin.analysis.api.renderer.declarations.renderers.KtClassifierBodyRenderer
+import org.jetbrains.kotlin.analysis.api.renderer.types.renderers.KtFunctionalTypeRenderer
 import org.jetbrains.kotlin.analysis.api.renderer.types.renderers.KtUsualClassTypeRenderer
 import org.jetbrains.kotlin.analysis.api.symbols.*
 import org.jetbrains.kotlin.analysis.api.symbols.markers.KtSymbolWithTypeParameters
@@ -337,6 +338,7 @@ enum class PrettyRendererOption(val transformation: (KtDeclarationRenderer) -> K
             renderer.with {
                 typeRenderer = typeRenderer.with {
                     usualClassTypeRenderer = KtUsualClassTypeRenderer.AS_FULLY_EXPANDED_CLASS_TYPE_WITH_TYPE_ARGUMENTS
+                    functionalTypeRenderer = KtFunctionalTypeRenderer.AS_FULLY_EXPANDED_CLASS_TYPE_FOR_REFELCTION_TYPES
                 }
             }
         }

--- a/analysis/analysis-api-standalone/tests-gen/org/jetbrains/kotlin/analysis/api/standalone/fir/test/cases/generated/cases/symbols/FirStandaloneNormalAnalysisSourceModuleSingleSymbolByPsiGenerated.java
+++ b/analysis/analysis-api-standalone/tests-gen/org/jetbrains/kotlin/analysis/api/standalone/fir/test/cases/generated/cases/symbols/FirStandaloneNormalAnalysisSourceModuleSingleSymbolByPsiGenerated.java
@@ -119,6 +119,12 @@ public class FirStandaloneNormalAnalysisSourceModuleSingleSymbolByPsiGenerated e
     }
 
     @Test
+    @TestMetadata("typeAnnotationsOnFunctionalTypeWithTypeAlias.kt")
+    public void testTypeAnnotationsOnFunctionalTypeWithTypeAlias() throws Exception {
+        runTest("analysis/analysis-api/testData/symbols/singleSymbolByPsi/typeAnnotationsOnFunctionalTypeWithTypeAlias.kt");
+    }
+
+    @Test
     @TestMetadata("typeAnnotationsOnPropertyGetterReturnType.kt")
     public void testTypeAnnotationsOnPropertyGetterReturnType() throws Exception {
         runTest("analysis/analysis-api/testData/symbols/singleSymbolByPsi/typeAnnotationsOnPropertyGetterReturnType.kt");

--- a/analysis/analysis-api/src/org/jetbrains/kotlin/analysis/api/renderer/types/renderers/KtFunctionalTypeRenderer.kt
+++ b/analysis/analysis-api/src/org/jetbrains/kotlin/analysis/api/renderer/types/renderers/KtFunctionalTypeRenderer.kt
@@ -71,4 +71,16 @@ public interface KtFunctionalTypeRenderer {
         }
     }
 
+    public object AS_FULLY_EXPANDED_CLASS_TYPE_FOR_REFELCTION_TYPES : KtFunctionalTypeRenderer {
+        context(KtAnalysisSession, KtTypeRenderer)
+        override fun renderType(type: KtFunctionalType, printer: PrettyPrinter): Unit {
+            val fullyExpandedType = type.fullyExpandedType
+            if (fullyExpandedType is KtFunctionalType) {
+                val renderer = if (fullyExpandedType.isReflectType) AS_CLASS_TYPE else AS_FUNCTIONAL_TYPE
+                renderer.renderType(fullyExpandedType, printer)
+            } else {
+                renderType(fullyExpandedType, printer)
+            }
+        }
+    }
 }

--- a/analysis/analysis-api/testData/symbols/singleSymbolByPsi/typeAnnotationsOnFunctionalTypeWithTypeAlias.descriptors.pretty.txt
+++ b/analysis/analysis-api/testData/symbols/singleSymbolByPsi/typeAnnotationsOnFunctionalTypeWithTypeAlias.descriptors.pretty.txt
@@ -1,0 +1,1 @@
+fun foo(): @Anno3 @Anno2 @Anno1 (() -> kotlin.Unit)

--- a/analysis/analysis-api/testData/symbols/singleSymbolByPsi/typeAnnotationsOnFunctionalTypeWithTypeAlias.descriptors.txt
+++ b/analysis/analysis-api/testData/symbols/singleSymbolByPsi/typeAnnotationsOnFunctionalTypeWithTypeAlias.descriptors.txt
@@ -1,0 +1,33 @@
+KtFunctionSymbol:
+  annotationsList: []
+  callableIdIfNonLocal: /foo
+  contextReceivers: []
+  contractEffects: []
+  hasStableParameterNames: true
+  isBuiltinFunctionInvoke: false
+  isExtension: false
+  isExternal: false
+  isInfix: false
+  isInline: false
+  isOperator: false
+  isOverride: false
+  isStatic: false
+  isSuspend: false
+  modality: FINAL
+  name: foo
+  origin: SOURCE
+  receiverParameter: null
+  returnType: [
+    Anno3()
+      psi: KtAnnotationEntry
+    Anno2()
+      psi: KtAnnotationEntry
+    Anno1()
+      psi: KtAnnotationEntry
+  ] @R|Anno3|() @R|Anno2|() @R|Anno1|()  @R|Anno3|()  SecondTypeAlias
+  symbolKind: TOP_LEVEL
+  typeParameters: []
+  valueParameters: []
+  visibility: Public
+  getContainingModule: KtSourceModule "Sources of main"
+  deprecationStatus: null

--- a/analysis/analysis-api/testData/symbols/singleSymbolByPsi/typeAnnotationsOnFunctionalTypeWithTypeAlias.kt
+++ b/analysis/analysis-api/testData/symbols/singleSymbolByPsi/typeAnnotationsOnFunctionalTypeWithTypeAlias.kt
@@ -1,0 +1,13 @@
+// DO_NOT_CHECK_NON_PSI_SYMBOL_RESTORE_K1
+// PRETTY_RENDERER_OPTION: FULLY_EXPANDED_TYPES
+@Target(AnnotationTarget.TYPE)
+annotation class Anno1
+@Target(AnnotationTarget.TYPE)
+annotation class Anno2
+@Target(AnnotationTarget.TYPE)
+annotation class Anno3
+
+typealias FirstTypeAlias = @Anno1 (() -> Unit)
+typealias SecondTypeAlias = @Anno2 FirstTypeAlias
+
+fun f<caret>oo(): @Anno3 SecondTypeAlias = {}

--- a/analysis/analysis-api/testData/symbols/singleSymbolByPsi/typeAnnotationsOnFunctionalTypeWithTypeAlias.pretty.txt
+++ b/analysis/analysis-api/testData/symbols/singleSymbolByPsi/typeAnnotationsOnFunctionalTypeWithTypeAlias.pretty.txt
@@ -1,0 +1,1 @@
+fun foo(): @Anno1 @Anno2 @Anno3 (() -> kotlin.Unit)

--- a/analysis/analysis-api/testData/symbols/singleSymbolByPsi/typeAnnotationsOnFunctionalTypeWithTypeAlias.txt
+++ b/analysis/analysis-api/testData/symbols/singleSymbolByPsi/typeAnnotationsOnFunctionalTypeWithTypeAlias.txt
@@ -1,0 +1,33 @@
+KtFunctionSymbol:
+  annotationsList: []
+  callableIdIfNonLocal: /foo
+  contextReceivers: []
+  contractEffects: []
+  hasStableParameterNames: true
+  isBuiltinFunctionInvoke: false
+  isExtension: false
+  isExternal: false
+  isInfix: false
+  isInline: false
+  isOperator: false
+  isOverride: false
+  isStatic: false
+  isSuspend: false
+  modality: FINAL
+  name: foo
+  origin: SOURCE
+  receiverParameter: null
+  returnType: [
+    Anno1()
+      psi: KtAnnotationEntry
+    Anno2()
+      psi: KtAnnotationEntry
+    Anno3()
+      psi: KtAnnotationEntry
+  ] @R|Anno1|()  @R|Anno2|()  @R|Anno3|()  kotlin/Function0<kotlin/Unit>
+  symbolKind: TOP_LEVEL
+  typeParameters: []
+  valueParameters: []
+  visibility: Public
+  getContainingModule: KtSourceModule "Sources of main"
+  deprecationStatus: null

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/providers/impl/FirTypeResolverImpl.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/providers/impl/FirTypeResolverImpl.kt
@@ -443,7 +443,10 @@ class FirTypeResolverImpl(private val session: FirSession) : FirTypeResolver() {
         }
     }
 
-    private fun createFunctionType(typeRef: FirFunctionTypeRef): Pair<ConeClassLikeTypeImpl, ConeDiagnostic?> {
+    private fun createFunctionType(
+        typeRef: FirFunctionTypeRef,
+        containerDeclaration: FirDeclaration? = null
+    ): Pair<ConeClassLikeTypeImpl, ConeDiagnostic?> {
         val parameters =
             typeRef.contextReceiverTypeRefs.map { it.coneType } +
                     listOfNotNull(typeRef.receiverTypeRef?.coneType) +
@@ -472,7 +475,8 @@ class FirTypeResolverImpl(private val session: FirSession) : FirTypeResolver() {
                 if (typeRef.contextReceiverTypeRefs.isNotEmpty()) {
                     add(CompilerConeAttributes.ContextFunctionTypeParams(typeRef.contextReceiverTypeRefs.size))
                 }
-            }
+            },
+            containerDeclaration
         )
         return ConeClassLikeTypeImpl(
             classId.toLookupTag(),
@@ -503,7 +507,7 @@ class FirTypeResolverImpl(private val session: FirSession) : FirTypeResolver() {
                     isOperandOfIsOperator,
                 ) to (result as? TypeResolutionResult.Resolved)?.typeCandidate?.diagnostic
             }
-            is FirFunctionTypeRef -> createFunctionType(typeRef)
+            is FirFunctionTypeRef -> createFunctionType(typeRef, scopeClassDeclaration.containerDeclaration)
             is FirDynamicTypeRef -> ConeDynamicType.create(session) to null
             is FirIntersectionTypeRef -> {
                 val leftType = typeRef.leftType.coneType


### PR DESCRIPTION
There are two issues addressed in two commits in this PR because I discovered the second when writing the test for the first. I'm not too confident, especially for the second commit (AA), though, but at least they don't break `analysisAllTests --tests *`.
1. [FIR] Pass container when creating function type, so that their type annotations can be resolved properly.
2. [AA] Expand aliases when computing `KtFirFunctionalType.parameterTypes` etc.