### PR TITLE
FIR2IR: load property setter noinline/crossinline flags

### DIFF
--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrDeclarationStorage.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrDeclarationStorage.kt
@@ -304,13 +304,15 @@ class Fir2IrDeclarationStorage(
         endOffset: Int,
         type: IrType,
         parent: IrFunction,
-        name: Name? = null
+        name: Name? = null,
+        isCrossinline: Boolean = false,
+        isNoinline: Boolean = false,
     ): IrValueParameter {
         return irFactory.createValueParameter(
             startOffset, endOffset, IrDeclarationOrigin.DEFINED, IrValueParameterSymbolImpl(),
             name ?: SpecialNames.IMPLICIT_SET_PARAMETER, 0, type,
             varargElementType = null,
-            isCrossinline = false, isNoinline = false,
+            isCrossinline = isCrossinline, isNoinline = isNoinline,
             isHidden = false, isAssignable = false
         ).apply {
             this.parent = parent

--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/lazy/Fir2IrLazyProperty.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/lazy/Fir2IrLazyProperty.kt
@@ -162,6 +162,8 @@ class Fir2IrLazyProperty(
             containingClass?.symbol?.toLookupTag(),
             forceTopLevelPrivate = symbol.signature.isComposite()
         )!!
+        symbolTable.referenceSimpleFunctionIfAny(signature)
+            ?.takeIf { it.isBound }?.let { return@lazyVar it.owner }
         symbolTable.declareSimpleFunction(signature, symbolFactory = { Fir2IrSimpleFunctionSymbol(signature) }) { symbol ->
             Fir2IrLazyPropertyAccessor(
                 components, startOffset, endOffset,
@@ -196,6 +198,8 @@ class Fir2IrLazyProperty(
                 containingClass?.symbol?.toLookupTag(),
                 forceTopLevelPrivate = symbol.signature.isComposite()
             )!!
+            symbolTable.referenceSimpleFunctionIfAny(signature)
+                ?.takeIf { it.isBound }?.let { return@lazyVar it.owner }
             symbolTable.declareSimpleFunction(signature, symbolFactory = { Fir2IrSimpleFunctionSymbol(signature) }) { symbol ->
                 Fir2IrLazyPropertyAccessor(
                     components, startOffset, endOffset,

--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/lazy/Fir2IrLazyPropertyAccessor.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/lazy/Fir2IrLazyPropertyAccessor.kt
@@ -95,7 +95,9 @@ class Fir2IrLazyPropertyAccessor(
                                 typeConverter, conversionTypeContext
                             ),
                             parent = this@Fir2IrLazyPropertyAccessor,
-                            name = valueParameter?.name
+                            name = valueParameter?.name,
+                            isCrossinline = valueParameter?.isCrossinline == true,
+                            isNoinline = valueParameter?.isNoinline == true
                         )
                     )
                 }

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxInlineCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirBlackBoxInlineCodegenTestGenerated.java
@@ -3849,6 +3849,12 @@ public class FirBlackBoxInlineCodegenTestGenerated extends AbstractFirBlackBoxIn
         }
 
         @Test
+        @TestMetadata("noinlineFunctional.kt")
+        public void testNoinlineFunctional() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/property/noinlineFunctional.kt");
+        }
+
+        @Test
         @TestMetadata("property.kt")
         public void testProperty() throws Exception {
             runTest("compiler/testData/codegen/boxInline/property/property.kt");

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirLightTreeBlackBoxInlineCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirLightTreeBlackBoxInlineCodegenTestGenerated.java
@@ -3849,6 +3849,12 @@ public class FirLightTreeBlackBoxInlineCodegenTestGenerated extends AbstractFirL
         }
 
         @Test
+        @TestMetadata("noinlineFunctional.kt")
+        public void testNoinlineFunctional() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/property/noinlineFunctional.kt");
+        }
+
+        @Test
         @TestMetadata("property.kt")
         public void testProperty() throws Exception {
             runTest("compiler/testData/codegen/boxInline/property/property.kt");

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirSerializeCompileKotlinAgainstInlineKotlinTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirSerializeCompileKotlinAgainstInlineKotlinTestGenerated.java
@@ -3849,6 +3849,12 @@ public class FirSerializeCompileKotlinAgainstInlineKotlinTestGenerated extends A
         }
 
         @Test
+        @TestMetadata("noinlineFunctional.kt")
+        public void testNoinlineFunctional() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/property/noinlineFunctional.kt");
+        }
+
+        @Test
         @TestMetadata("property.kt")
         public void testProperty() throws Exception {
             runTest("compiler/testData/codegen/boxInline/property/property.kt");

--- a/compiler/testData/codegen/boxInline/property/noinlineFunctional.kt
+++ b/compiler/testData/codegen/boxInline/property/noinlineFunctional.kt
@@ -1,0 +1,26 @@
+// FILE: 1.kt
+package test
+
+class C {
+    var x: () -> Unit
+        inline get() = {}
+        inline set(noinline value) {
+            bar(value)
+        }
+
+    fun bar(i: I) = i.foo()
+}
+
+fun interface I {
+    fun foo()
+}
+
+// FILE: 2.kt
+import test.*
+
+fun box(): String {
+    var result = "fail"
+    val c = C()
+    c.x = { result = "OK" }
+    return result
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxInlineCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxInlineCodegenTestGenerated.java
@@ -3825,6 +3825,12 @@ public class BlackBoxInlineCodegenTestGenerated extends AbstractBlackBoxInlineCo
         }
 
         @Test
+        @TestMetadata("noinlineFunctional.kt")
+        public void testNoinlineFunctional() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/property/noinlineFunctional.kt");
+        }
+
+        @Test
         @TestMetadata("property.kt")
         public void testProperty() throws Exception {
             runTest("compiler/testData/codegen/boxInline/property/property.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/CompileKotlinAgainstInlineKotlinTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/CompileKotlinAgainstInlineKotlinTestGenerated.java
@@ -3825,6 +3825,12 @@ public class CompileKotlinAgainstInlineKotlinTestGenerated extends AbstractCompi
         }
 
         @Test
+        @TestMetadata("noinlineFunctional.kt")
+        public void testNoinlineFunctional() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/property/noinlineFunctional.kt");
+        }
+
+        @Test
         @TestMetadata("property.kt")
         public void testProperty() throws Exception {
             runTest("compiler/testData/codegen/boxInline/property/property.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxInlineCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxInlineCodegenTestGenerated.java
@@ -3849,6 +3849,12 @@ public class IrBlackBoxInlineCodegenTestGenerated extends AbstractIrBlackBoxInli
         }
 
         @Test
+        @TestMetadata("noinlineFunctional.kt")
+        public void testNoinlineFunctional() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/property/noinlineFunctional.kt");
+        }
+
+        @Test
         @TestMetadata("property.kt")
         public void testProperty() throws Exception {
             runTest("compiler/testData/codegen/boxInline/property/property.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrCompileKotlinAgainstInlineKotlinTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrCompileKotlinAgainstInlineKotlinTestGenerated.java
@@ -3849,6 +3849,12 @@ public class IrCompileKotlinAgainstInlineKotlinTestGenerated extends AbstractIrC
         }
 
         @Test
+        @TestMetadata("noinlineFunctional.kt")
+        public void testNoinlineFunctional() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/property/noinlineFunctional.kt");
+        }
+
+        @Test
         @TestMetadata("property.kt")
         public void testProperty() throws Exception {
             runTest("compiler/testData/codegen/boxInline/property/property.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrSerializeCompileKotlinAgainstInlineKotlinTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrSerializeCompileKotlinAgainstInlineKotlinTestGenerated.java
@@ -3849,6 +3849,12 @@ public class IrSerializeCompileKotlinAgainstInlineKotlinTestGenerated extends Ab
         }
 
         @Test
+        @TestMetadata("noinlineFunctional.kt")
+        public void testNoinlineFunctional() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/property/noinlineFunctional.kt");
+        }
+
+        @Test
         @TestMetadata("property.kt")
         public void testProperty() throws Exception {
             runTest("compiler/testData/codegen/boxInline/property/property.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/JvmIrAgainstOldBoxInlineTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/JvmIrAgainstOldBoxInlineTestGenerated.java
@@ -3849,6 +3849,12 @@ public class JvmIrAgainstOldBoxInlineTestGenerated extends AbstractJvmIrAgainstO
         }
 
         @Test
+        @TestMetadata("noinlineFunctional.kt")
+        public void testNoinlineFunctional() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/property/noinlineFunctional.kt");
+        }
+
+        @Test
         @TestMetadata("property.kt")
         public void testProperty() throws Exception {
             runTest("compiler/testData/codegen/boxInline/property/property.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/JvmOldAgainstIrBoxInlineTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/JvmOldAgainstIrBoxInlineTestGenerated.java
@@ -3825,6 +3825,12 @@ public class JvmOldAgainstIrBoxInlineTestGenerated extends AbstractJvmOldAgainst
         }
 
         @Test
+        @TestMetadata("noinlineFunctional.kt")
+        public void testNoinlineFunctional() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/property/noinlineFunctional.kt");
+        }
+
+        @Test
         @TestMetadata("property.kt")
         public void testProperty() throws Exception {
             runTest("compiler/testData/codegen/boxInline/property/property.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/JsCodegenInlineTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/JsCodegenInlineTestGenerated.java
@@ -3429,6 +3429,12 @@ public class JsCodegenInlineTestGenerated extends AbstractJsCodegenInlineTest {
         }
 
         @Test
+        @TestMetadata("noinlineFunctional.kt")
+        public void testNoinlineFunctional() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/property/noinlineFunctional.kt");
+        }
+
+        @Test
         @TestMetadata("property.kt")
         public void testProperty() throws Exception {
             runTest("compiler/testData/codegen/boxInline/property/property.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/fir/FirJsCodegenInlineTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/fir/FirJsCodegenInlineTestGenerated.java
@@ -3429,6 +3429,12 @@ public class FirJsCodegenInlineTestGenerated extends AbstractFirJsCodegenInlineT
         }
 
         @Test
+        @TestMetadata("noinlineFunctional.kt")
+        public void testNoinlineFunctional() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/property/noinlineFunctional.kt");
+        }
+
+        @Test
         @TestMetadata("property.kt")
         public void testProperty() throws Exception {
             runTest("compiler/testData/codegen/boxInline/property/property.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/IrJsCodegenInlineTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/IrJsCodegenInlineTestGenerated.java
@@ -3429,6 +3429,12 @@ public class IrJsCodegenInlineTestGenerated extends AbstractIrJsCodegenInlineTes
         }
 
         @Test
+        @TestMetadata("noinlineFunctional.kt")
+        public void testNoinlineFunctional() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/property/noinlineFunctional.kt");
+        }
+
+        @Test
         @TestMetadata("property.kt")
         public void testProperty() throws Exception {
             runTest("compiler/testData/codegen/boxInline/property/property.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/IrJsES6CodegenInlineTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/IrJsES6CodegenInlineTestGenerated.java
@@ -3429,6 +3429,12 @@ public class IrJsES6CodegenInlineTestGenerated extends AbstractIrJsES6CodegenInl
         }
 
         @Test
+        @TestMetadata("noinlineFunctional.kt")
+        public void testNoinlineFunctional() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/property/noinlineFunctional.kt");
+        }
+
+        @Test
         @TestMetadata("property.kt")
         public void testProperty() throws Exception {
             runTest("compiler/testData/codegen/boxInline/property/property.kt");

--- a/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/K2NativeCodegenBoxTestGenerated.java
+++ b/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/K2NativeCodegenBoxTestGenerated.java
@@ -44507,6 +44507,12 @@ public class K2NativeCodegenBoxTestGenerated extends AbstractNativeCodegenBoxTes
             }
 
             @Test
+            @TestMetadata("noinlineFunctional.kt")
+            public void testNoinlineFunctional() throws Exception {
+                runTest("compiler/testData/codegen/boxInline/property/noinlineFunctional.kt");
+            }
+
+            @Test
             @TestMetadata("property.kt")
             public void testProperty() throws Exception {
                 runTest("compiler/testData/codegen/boxInline/property/property.kt");

--- a/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/NativeCodegenBoxTestGenerated.java
+++ b/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/NativeCodegenBoxTestGenerated.java
@@ -43941,6 +43941,12 @@ public class NativeCodegenBoxTestGenerated extends AbstractNativeCodegenBoxTest 
             }
 
             @Test
+            @TestMetadata("noinlineFunctional.kt")
+            public void testNoinlineFunctional() throws Exception {
+                runTest("compiler/testData/codegen/boxInline/property/noinlineFunctional.kt");
+            }
+
+            @Test
             @TestMetadata("property.kt")
             public void testProperty() throws Exception {
                 runTest("compiler/testData/codegen/boxInline/property/property.kt");


### PR DESCRIPTION
Also, try deserialized accessors before creating lazy ones.

^KT-56234 Fixed