### PR TITLE
Fix Gradle deprecation warning on missing task dependency

### DIFF
--- a/prepare/compiler/build.gradle.kts
+++ b/prepare/compiler/build.gradle.kts
@@ -334,7 +334,7 @@ sourcesJar {
         }
     }
 
-    dependsOn(":compiler:fir:checkers:generateCheckersComponents")
+    dependsOn(":compiler:fir:checkers:generateCheckersComponents", ":compiler:ir.tree:generateTree")
 }
 
 javadocJar()


### PR DESCRIPTION
This PR adds a missing task dependency to allow cache hits for `:kotlin-compiler:sourcesJar`.

We have this deprecation warning when running the build (on `install` task):
`Task ':kotlin-compiler:sourcesJar' uses this output of task ':compiler:ir.tree:generateTree' without declaring an explicit or implicit dependency.`

The optimizations are currently disabled for this task:
<img width="990" alt="Screenshot 2023-02-15 at 4 07 07 PM" src="https://user-images.githubusercontent.com/10243934/219066812-c1f83629-088f-406d-a5d1-1320fd26f04d.png">
