### PR TITLE
Fix a grammatical issue in String::isNotBlank documentation

### DIFF
--- a/libraries/stdlib/src/kotlin/text/Strings.kt
+++ b/libraries/stdlib/src/kotlin/text/Strings.kt
@@ -308,7 +308,7 @@ public inline fun CharSequence.isNotEmpty(): Boolean = length > 0
 
 
 /**
- * Returns `true` if this char sequence is not empty and contains some characters except of whitespace characters.
+ * Returns `true` if this char sequence is not empty and contains some characters except whitespace characters.
  *
  * @sample samples.text.Strings.stringIsNotBlank
  */


### PR DESCRIPTION
`except of ...` is wrong.  
Instead, it should be either of the following:
  - `except ...`
  - `except for ...`
  - `with the exception of ...`

See https://www.merriam-webster.com/dictionary/except%20for  
and https://ell.stackexchange.com/q/148197