### PR TITLE
IR: KT-56446 Lax TypedIntrinsic annotation package

### DIFF
--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/RuntimeNames.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/RuntimeNames.kt
@@ -24,6 +24,5 @@ object RuntimeNames {
     val kotlinNativeInternalPackageName = FqName.fromSegments(listOf("kotlin", "native", "internal"))
     val kotlinNativeCoroutinesInternalPackageName = FqName.fromSegments(listOf("kotlin", "coroutines", "native", "internal"))
     val associatedObjectKey = FqName("kotlin.reflect.AssociatedObjectKey")
-    val typedIntrinsicAnnotation = FqName("kotlin.native.internal.TypedIntrinsic")
     val cleaner = FqName("kotlin.native.internal.Cleaner")
 }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/Ir.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/Ir.kt
@@ -97,7 +97,7 @@ internal abstract class KonanSymbols(
     val symbolName = topLevelClass(RuntimeNames.symbolNameAnnotation)
     val filterExceptions = topLevelClass(RuntimeNames.filterExceptions)
     val exportForCppRuntime = topLevelClass(RuntimeNames.exportForCppRuntime)
-    val typedIntrinsic = topLevelClass(RuntimeNames.typedIntrinsicAnnotation)
+    val typedIntrinsic = topLevelClass(KonanFqNames.typedIntrinsic)
 
     val objCMethodImp = symbolTable.referenceClass(descriptorsLookup.interopBuiltIns.objCMethodImp)
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IntrinsicGenerator.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IntrinsicGenerator.kt
@@ -136,7 +136,7 @@ internal fun tryGetIntrinsicType(callSite: IrFunctionAccessExpression): Intrinsi
 
 private fun getIntrinsicType(callSite: IrFunctionAccessExpression): IntrinsicType {
     val function = callSite.symbol.owner
-    val annotation = function.annotations.findAnnotation(RuntimeNames.typedIntrinsicAnnotation)!!
+    val annotation = function.annotations.findAnnotation(KonanFqNames.typedIntrinsic)!!
     val value = annotation.getAnnotationStringValue()!!
     return IntrinsicType.valueOf(value)
 }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IntrinsicGenerator.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IntrinsicGenerator.kt
@@ -4,8 +4,8 @@ import kotlinx.cinterop.cValuesOf
 import llvm.*
 import org.jetbrains.kotlin.backend.konan.KonanFqNames
 import org.jetbrains.kotlin.backend.konan.MemoryModel
-import org.jetbrains.kotlin.backend.konan.RuntimeNames
 import org.jetbrains.kotlin.backend.konan.descriptors.getAnnotationStringValue
+import org.jetbrains.kotlin.backend.konan.descriptors.getTypedIntrinsic
 import org.jetbrains.kotlin.backend.konan.descriptors.isConstantConstructorIntrinsic
 import org.jetbrains.kotlin.backend.konan.descriptors.isTypedIntrinsic
 import org.jetbrains.kotlin.backend.konan.llvm.objc.genObjCSelector
@@ -136,7 +136,8 @@ internal fun tryGetIntrinsicType(callSite: IrFunctionAccessExpression): Intrinsi
 
 private fun getIntrinsicType(callSite: IrFunctionAccessExpression): IntrinsicType {
     val function = callSite.symbol.owner
-    val annotation = function.annotations.findAnnotation(KonanFqNames.typedIntrinsic)!!
+    val annotation = function.getTypedIntrinsic()
+            ?: error("Can't find getIntrinsicType in $function at $callSite")
     val value = annotation.getAnnotationStringValue()!!
     return IntrinsicType.valueOf(value)
 }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InteropCallConvertors.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InteropCallConvertors.kt
@@ -4,6 +4,7 @@
  */
 package org.jetbrains.kotlin.backend.konan.lower
 
+import org.jetbrains.kotlin.backend.konan.KonanFqNames
 import org.jetbrains.kotlin.backend.konan.PrimitiveBinaryType
 import org.jetbrains.kotlin.backend.konan.RuntimeNames
 import org.jetbrains.kotlin.backend.konan.cgen.*
@@ -56,7 +57,7 @@ private fun InteropCallContext.findMemoryAccessFunction(isRead: Boolean, valueTy
     val nativeMemUtilsClass = symbols.nativeMemUtils.owner
     return nativeMemUtilsClass.functions.filter {
         val annotationArgument = it.annotations
-                .findAnnotation(RuntimeNames.typedIntrinsicAnnotation)
+                .findAnnotation(KonanFqNames.typedIntrinsic)
                 ?.getAnnotationStringValue()
         annotationArgument == requiredType.name
     }.firstOrNull {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InteropCallConvertors.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InteropCallConvertors.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlin.backend.konan.PrimitiveBinaryType
 import org.jetbrains.kotlin.backend.konan.RuntimeNames
 import org.jetbrains.kotlin.backend.konan.cgen.*
 import org.jetbrains.kotlin.backend.konan.descriptors.getAnnotationStringValue
+import org.jetbrains.kotlin.backend.konan.descriptors.getTypedIntrinsic
 import org.jetbrains.kotlin.backend.konan.ir.KonanSymbols
 import org.jetbrains.kotlin.backend.konan.llvm.IntrinsicType
 import org.jetbrains.kotlin.ir.IrBuiltIns
@@ -56,9 +57,7 @@ private fun InteropCallContext.findMemoryAccessFunction(isRead: Boolean, valueTy
     }
     val nativeMemUtilsClass = symbols.nativeMemUtils.owner
     return nativeMemUtilsClass.functions.filter {
-        val annotationArgument = it.annotations
-                .findAnnotation(KonanFqNames.typedIntrinsic)
-                ?.getAnnotationStringValue()
+        val annotationArgument = it.getTypedIntrinsic()?.getAnnotationStringValue()
         annotationArgument == requiredType.name
     }.firstOrNull {
         if (isRead) {


### PR DESCRIPTION
This makes TypedIntrinsic annotation to be able to appear as a
subpackage of kotlin.native.internal. This would allow libraries to
internally redefine that annotation in those subpackages as a workaround
for KT-56446

Example of usage here: https://github.com/korlibs/korge/pull/1346