### PR TITLE
Parameter to control if compiler arguments include the classpath

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/CompilerArgumentsIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/CompilerArgumentsIT.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle
+
+import org.gradle.util.GradleVersion
+import org.jetbrains.kotlin.gradle.testbase.*
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.DisplayName
+import kotlin.io.path.appendText
+
+@DisplayName("Compiler arguments related tests")
+@JvmGradlePluginTests
+class CompilerArgumentsIT : KGPBaseTest() {
+
+    @DisplayName("Classpath is included when requested")
+    @GradleTest
+    fun testClasspathIsIncludedWhenRequested(gradleVersion: GradleVersion) {
+        project("simpleProject", gradleVersion) {
+            buildGradle.appendText(
+                //language=Groovy
+                """ 
+                tasks.register("checkArgsWithClasspath") {
+                        def task = project.tasks.named("compileKotlin").get()
+                        def args = task.createCompilerArgs()
+                        task.setupCompilerArgs(args, 
+                            /* defaultsOnly=*/ false, 
+                            /* ignoreClasspathResolutionErrors=*/ false, 
+                            /* includeClasspath=*/ true)
+                        println("$CLASSPATH_MARKER" + args.classpath)
+                }
+                """.trimIndent()
+            )
+
+            verifyClasspathIsPresentInOutput()
+
+        }
+    }
+
+    @DisplayName("Classpath is included by default")
+    @GradleTest
+    fun testClasspathIsIncludedByDefault(gradleVersion: GradleVersion) {
+        project("simpleProject", gradleVersion) {
+            buildGradle.appendText(
+                //language=Groovy
+                """ 
+                tasks.register("checkArgsWithClasspath") {
+                        def task = project.tasks.named("compileKotlin").get()
+                        def args = task.createCompilerArgs()
+                        task.setupCompilerArgs(args, 
+                            /* defaultsOnly=*/ false, 
+                            /* ignoreClasspathResolutionErrors=*/ false)
+                        println("$CLASSPATH_MARKER" + args.classpath)
+                }
+                """.trimIndent()
+            )
+
+            verifyClasspathIsPresentInOutput()
+
+        }
+    }
+
+    @DisplayName("Classpath is included by default in the Kotlin compile task")
+    @GradleTest
+    fun testClasspathIsIncludedByDefaultInKotlinCompileTask(gradleVersion: GradleVersion) {
+        project("simpleProject", gradleVersion) {
+            buildGradle.appendText(
+                //language=Groovy
+                """ 
+                tasks.register("checkArgsWithClasspath") {
+                        def task = project.tasks.named("compileKotlin").get()
+                        println("$CLASSPATH_MARKER" + String.join(":", task.classpath.asList()*.toString()))
+                }
+                """.trimIndent()
+
+            )
+
+            verifyClasspathIsPresentInOutput()
+
+        }
+    }
+
+    private fun TestProject.verifyClasspathIsPresentInOutput() {
+        build("checkArgsWithClasspath") {
+            println(output)
+            val classpath = output.lines()
+                .firstOrNull { it.startsWith(CLASSPATH_MARKER) }
+                ?.removePrefix(CLASSPATH_MARKER)
+                ?.split(":")
+                ?.filter { it.isNotEmpty() }
+                ?: emptyList()
+
+            Assertions.assertTrue(classpath.isNotEmpty())
+
+        }
+    }
+
+
+    companion object {
+        const val CLASSPATH_MARKER = "CLASSPATH>"
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/internal/CompilerArgumentAware.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/internal/CompilerArgumentAware.kt
@@ -36,8 +36,19 @@ interface CompilerArgumentAware<T : CommonToolArguments> {
             .let(ArgumentUtils::convertArgumentsToStringList)
 
     fun createCompilerArgs(): T
-    fun setupCompilerArgs(args: T, defaultsOnly: Boolean = false, ignoreClasspathResolutionErrors: Boolean = false)
+
+    // This function is called via reflection from IntelliJ Kotlin plugin, so keeping the old signature around too.
+    // Since this is an interface, we can't use @JvmOverloads here.
+    fun setupCompilerArgs(args: T, defaultsOnly: Boolean = false, ignoreClasspathResolutionErrors: Boolean = false) =
+        setupCompilerArgs(
+            args = args,
+            defaultsOnly = defaultsOnly,
+            ignoreClasspathResolutionErrors = ignoreClasspathResolutionErrors,
+            includeClasspath = true
+        )
+
+    fun setupCompilerArgs(args: T, defaultsOnly: Boolean = false, ignoreClasspathResolutionErrors: Boolean = false, includeClasspath: Boolean = true)
 }
 
-internal fun <T : CommonToolArguments> CompilerArgumentAware<T>.prepareCompilerArguments(ignoreClasspathResolutionErrors: Boolean = false) =
-    createCompilerArgs().also { setupCompilerArgs(it, ignoreClasspathResolutionErrors = ignoreClasspathResolutionErrors) }
+internal fun <T : CommonToolArguments> CompilerArgumentAware<T>.prepareCompilerArguments(ignoreClasspathResolutionErrors: Boolean = false, includeClasspath : Boolean = true) =
+    createCompilerArgs().also { setupCompilerArgs(it, ignoreClasspathResolutionErrors = ignoreClasspathResolutionErrors, includeClasspath = includeClasspath) }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/internal/CompilerArgumentsContributor.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/internal/CompilerArgumentsContributor.kt
@@ -28,11 +28,13 @@ internal interface CompilerArgumentsConfigurationFlag
 
 internal object DefaultsOnly : CompilerArgumentsConfigurationFlag
 internal object IgnoreClasspathResolutionErrors : CompilerArgumentsConfigurationFlag
+internal object IncludeClasspath : CompilerArgumentsConfigurationFlag
 
-internal fun compilerArgumentsConfigurationFlags(defaultsOnly: Boolean, ignoreClasspathResolutionErrors: Boolean) =
+internal fun compilerArgumentsConfigurationFlags(defaultsOnly: Boolean, ignoreClasspathResolutionErrors: Boolean, includeClasspath: Boolean) =
     mutableSetOf<CompilerArgumentsConfigurationFlag>().apply {
         if (defaultsOnly) add(DefaultsOnly)
         if (ignoreClasspathResolutionErrors) add(IgnoreClasspathResolutionErrors)
+        if (includeClasspath) add(IncludeClasspath)
     }
 
 /** The primary purpose of this class is to encapsulate compiler arguments setup done by the AbstractKotlinCompiler tasks,
@@ -91,10 +93,12 @@ internal open class KotlinJvmCompilerArgumentsContributor(
         if (DefaultsOnly in flags) return
 
         args.allowNoSourceFiles = true
-        args.classpathAsList = try {
-            compileClasspath.toList().filter { it.exists() }
-        } catch (e: Exception) {
-            if (IgnoreClasspathResolutionErrors in flags) emptyList() else throw(e)
+        if (IncludeClasspath in flags) {
+            args.classpathAsList = try {
+                compileClasspath.toList().filter { it.exists() }
+            } catch (e: Exception) {
+                if (IgnoreClasspathResolutionErrors in flags) emptyList() else throw (e)
+            }
         }
         args.destinationAsFile = destinationDir
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/KaptGenerateStubsTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/KaptGenerateStubsTask.kt
@@ -98,13 +98,15 @@ abstract class KaptGenerateStubsTask @Inject constructor(
     override fun setupCompilerArgs(
         args: K2JVMCompilerArguments,
         defaultsOnly: Boolean,
-        ignoreClasspathResolutionErrors: Boolean
+        ignoreClasspathResolutionErrors: Boolean,
+        includeClasspath: Boolean
     ) {
         compileKotlinArgumentsContributor.get().contributeArguments(
             args,
             compilerArgumentsConfigurationFlags(
                 defaultsOnly,
-                ignoreClasspathResolutionErrors
+                ignoreClasspathResolutionErrors,
+                includeClasspath
             )
         )
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/tasks/KotlinNativeLink.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/tasks/KotlinNativeLink.kt
@@ -198,7 +198,8 @@ constructor(
     override fun setupCompilerArgs(
         args: StubK2NativeCompilerArguments,
         defaultsOnly: Boolean,
-        ignoreClasspathResolutionErrors: Boolean
+        ignoreClasspathResolutionErrors: Boolean,
+        includeClasspath: Boolean
     ) = Unit
 
     private fun validatedExportedLibraries() {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/tasks/KotlinNativeTasks.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/tasks/KotlinNativeTasks.kt
@@ -421,7 +421,8 @@ internal constructor(
     override fun setupCompilerArgs(
         args: StubK2NativeCompilerArguments,
         defaultsOnly: Boolean,
-        ignoreClasspathResolutionErrors: Boolean
+        ignoreClasspathResolutionErrors: Boolean,
+        includeClasspath: Boolean
     ) = Unit
 
     override fun buildCommonArgs(defaultsOnly: Boolean): List<String> {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/KotlinCompileCommon.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/KotlinCompileCommon.kt
@@ -64,9 +64,9 @@ abstract class KotlinCompileCommon @Inject constructor(
     override fun createCompilerArgs(): K2MetadataCompilerArguments =
         K2MetadataCompilerArguments()
 
-    override fun setupCompilerArgs(args: K2MetadataCompilerArguments, defaultsOnly: Boolean, ignoreClasspathResolutionErrors: Boolean) {
+    override fun setupCompilerArgs(args: K2MetadataCompilerArguments, defaultsOnly: Boolean, ignoreClasspathResolutionErrors: Boolean, includeClasspath: Boolean) {
         (compilerOptions as KotlinMultiplatformCommonCompilerOptionsDefault).fillDefaultValues(args)
-        super.setupCompilerArgs(args, defaultsOnly = defaultsOnly, ignoreClasspathResolutionErrors = ignoreClasspathResolutionErrors)
+        super.setupCompilerArgs(args, defaultsOnly = defaultsOnly, ignoreClasspathResolutionErrors = ignoreClasspathResolutionErrors, includeClasspath = includeClasspath)
 
         args.moduleName = this@KotlinCompileCommon.moduleName.get()
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/KotlinJsDce.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/KotlinJsDce.kt
@@ -57,7 +57,7 @@ abstract class KotlinJsDce @Inject constructor(
 
     override fun createCompilerArgs(): K2JSDceArguments = K2JSDceArguments()
 
-    override fun setupCompilerArgs(args: K2JSDceArguments, defaultsOnly: Boolean, ignoreClasspathResolutionErrors: Boolean) {
+    override fun setupCompilerArgs(args: K2JSDceArguments, defaultsOnly: Boolean, ignoreClasspathResolutionErrors: Boolean, includeClasspath: Boolean) {
         (toolOptions as KotlinJsDceCompilerToolOptionsDefault).fillCompilerArguments(args)
         args.declarationsToKeep = keep.toTypedArray()
     }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/Tasks.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/Tasks.kt
@@ -487,10 +487,10 @@ abstract class AbstractKotlinCompile<T : CommonCompilerArguments> @Inject constr
         )
     }
 
-    override fun setupCompilerArgs(args: T, defaultsOnly: Boolean, ignoreClasspathResolutionErrors: Boolean) {
+    override fun setupCompilerArgs(args: T, defaultsOnly: Boolean, ignoreClasspathResolutionErrors: Boolean, includeClasspath: Boolean) {
         abstractKotlinCompileArgumentsContributor.contributeArguments(
             args,
-            compilerArgumentsConfigurationFlags(defaultsOnly, ignoreClasspathResolutionErrors)
+            compilerArgumentsConfigurationFlags(defaultsOnly, ignoreClasspathResolutionErrors, includeClasspath)
         )
         if (reportingSettings().buildReportMode == BuildReportMode.VERBOSE) {
             args.reportPerf = true
@@ -681,11 +681,12 @@ abstract class KotlinCompile @Inject constructor(
     @get:Internal
     internal var executionTimeFreeCompilerArgs: List<String>? = null
 
-    override fun setupCompilerArgs(args: K2JVMCompilerArguments, defaultsOnly: Boolean, ignoreClasspathResolutionErrors: Boolean) {
+    override fun setupCompilerArgs(args: K2JVMCompilerArguments, defaultsOnly: Boolean, ignoreClasspathResolutionErrors: Boolean, includeClasspath: Boolean) {
         compilerArgumentsContributor.contributeArguments(
             args, compilerArgumentsConfigurationFlags(
                 defaultsOnly,
-                ignoreClasspathResolutionErrors
+                ignoreClasspathResolutionErrors,
+                includeClasspath
             )
         )
 
@@ -980,9 +981,14 @@ abstract class Kotlin2JsCompile @Inject constructor(
     override fun createCompilerArgs(): K2JSCompilerArguments =
         K2JSCompilerArguments()
 
-    override fun setupCompilerArgs(args: K2JSCompilerArguments, defaultsOnly: Boolean, ignoreClasspathResolutionErrors: Boolean) {
+    override fun setupCompilerArgs(
+        args: K2JSCompilerArguments,
+        defaultsOnly: Boolean,
+        ignoreClasspathResolutionErrors: Boolean,
+        includeClasspath: Boolean
+    ) {
         (compilerOptions as KotlinJsCompilerOptionsDefault).fillDefaultValues(args)
-        super.setupCompilerArgs(args, defaultsOnly = defaultsOnly, ignoreClasspathResolutionErrors = ignoreClasspathResolutionErrors)
+        super.setupCompilerArgs(args, defaultsOnly = defaultsOnly, ignoreClasspathResolutionErrors = ignoreClasspathResolutionErrors, includeClasspath = includeClasspath)
 
         if (defaultsOnly) return
 


### PR DESCRIPTION
This is in the context of the following issue:
https://youtrack.jetbrains.com/issue/KTIJ-24724

Classpath will be included by default on KGP side, but will be omitted by the IDEA plugin by default. Here is the IDEA plugin side PR: https://github.com/JetBrains/intellij-community/pull/2335

Tested the changes manually and via the integration tests added in CompilerArgumentsIT class.