### PR TITLE
Support WASM in KotlinTargetHierarchyBuilder

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-api/api/kotlin-gradle-plugin-api.api
+++ b/libraries/tools/kotlin-gradle-plugin-api/api/kotlin-gradle-plugin-api.api
@@ -1084,6 +1084,7 @@ public abstract interface class org/jetbrains/kotlin/gradle/plugin/KotlinTargetH
 	public abstract fun withTvosArm64 ()V
 	public abstract fun withTvosSimulatorArm64 ()V
 	public abstract fun withTvosX64 ()V
+	public abstract fun withWasm ()V
 	public abstract fun withWasm32 ()V
 	public abstract fun withWatchos ()V
 	public abstract fun withWatchosArm32 ()V

--- a/libraries/tools/kotlin-gradle-plugin-api/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinTargetHierarchyBuilder.kt
+++ b/libraries/tools/kotlin-gradle-plugin-api/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinTargetHierarchyBuilder.kt
@@ -28,9 +28,10 @@ interface KotlinTargetHierarchyBuilder {
     fun withMingw()
     fun withLinux()
     fun withAndroidNative()
-    fun withJs()
 
     /* Actual targets */
+    fun withJs()
+    fun withWasm()
     fun withJvm()
     fun withAndroid()
     fun withAndroidNativeX64()

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/targetHierarchy/buildKotlinTargetHierarchy.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/targetHierarchy/buildKotlinTargetHierarchy.kt
@@ -11,6 +11,8 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinAndroidTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinWithJavaTarget
 import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinJsTargetDsl
+import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinWasmTargetDsl
+import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrTarget
 import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
 import org.jetbrains.kotlin.konan.target.DEPRECATED_TARGET_MESSAGE
 import org.jetbrains.kotlin.konan.target.Family
@@ -117,7 +119,9 @@ private class KotlinTargetHierarchyBuilderImpl(
 
     override fun withAndroidNative() = addTargets { it is KotlinNativeTarget && it.konanTarget.family == Family.ANDROID }
 
-    override fun withJs() = addTargets { it is KotlinJsTargetDsl }
+    /** Don't check for instance of [KotlinJsTargetDsl] or [KotlinWasmTargetDsl] because they are implemented by single target [KotlinJsIrTarget] */
+    override fun withJs() = addTargets { it.platformType == KotlinPlatformType.js }
+    override fun withWasm() = addTargets { it.platformType == KotlinPlatformType.wasm }
 
     override fun withJvm() = addTargets {
         it is KotlinJvmTarget ||

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/targetHierarchy/buildKotlinTargetHierarchy.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/targetHierarchy/buildKotlinTargetHierarchy.kt
@@ -119,7 +119,7 @@ private class KotlinTargetHierarchyBuilderImpl(
 
     override fun withAndroidNative() = addTargets { it is KotlinNativeTarget && it.konanTarget.family == Family.ANDROID }
 
-    /** Don't check for instance of [KotlinJsTargetDsl] or [KotlinWasmTargetDsl] because they are implemented by single target [KotlinJsIrTarget] */
+    // Don't check for instance of [KotlinJsTargetDsl] or [KotlinWasmTargetDsl] because they are implemented by single target [KotlinJsIrTarget]
     override fun withJs() = addTargets { it.platformType == KotlinPlatformType.js }
     override fun withWasm() = addTargets { it.platformType == KotlinPlatformType.wasm }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinTargetHierarchyDslTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinTargetHierarchyDslTest.kt
@@ -4,6 +4,7 @@
  */
 
 @file:Suppress("FunctionName", "DuplicatedCode")
+@file:OptIn(ExperimentalWasmDsl::class)
 
 package org.jetbrains.kotlin.gradle.unitTests
 
@@ -331,7 +332,6 @@ class KotlinTargetHierarchyDslTest {
             }
         }
 
-        @OptIn(ExperimentalWasmDsl::class)
         kotlin.wasm()
         kotlin.js()
 
@@ -361,7 +361,6 @@ class KotlinTargetHierarchyDslTest {
             }
         }
 
-        @OptIn(ExperimentalWasmDsl::class)
         kotlin.wasm()
         kotlin.js()
         kotlin.jvm()

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinTargetHierarchyDslTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinTargetHierarchyDslTest.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 import org.jetbrains.kotlin.gradle.plugin.KotlinTargetHierarchyDescriptor
 import org.jetbrains.kotlin.gradle.plugin.mpp.targetHierarchy.buildKotlinTargetHierarchy
 import org.jetbrains.kotlin.gradle.plugin.mpp.targetHierarchy.naturalKotlinTargetHierarchy
+import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.util.*
 import kotlin.test.*
 
@@ -316,6 +317,69 @@ class KotlinTargetHierarchyDslTest {
         assertEquals(
             stringSetOf("linuxX64Main", "macosX64Main"),
             kotlin.dependingSourceSetNames("nixMain")
+        )
+    }
+
+    @Test
+    fun `test - hierarchy js and wasm`() {
+        kotlin.targetHierarchy.custom {
+            common {
+                group("web") {
+                    withJs()
+                    withWasm()
+                }
+            }
+        }
+
+        @OptIn(ExperimentalWasmDsl::class)
+        kotlin.wasm()
+        kotlin.js()
+
+        assertEquals(
+            stringSetOf("webMain", "jsMain", "wasmMain"),
+            kotlin.dependingSourceSetNames("commonMain")
+        )
+
+        assertEquals(
+            stringSetOf("jsMain", "wasmMain"),
+            kotlin.dependingSourceSetNames("webMain")
+        )
+    }
+
+    @Test
+    fun `test - hierarchy js and wasm split`() {
+        kotlin.targetHierarchy.custom {
+            common {
+                group("jsAndJvm") {
+                    withJs()
+                    withJvm()
+                }
+                group("wasmAndLinux") {
+                    withWasm()
+                    withLinuxX64()
+                }
+            }
+        }
+
+        @OptIn(ExperimentalWasmDsl::class)
+        kotlin.wasm()
+        kotlin.js()
+        kotlin.jvm()
+        kotlin.linuxX64()
+
+        assertEquals(
+            stringSetOf("jsAndJvmMain", "wasmAndLinuxMain", "jvmMain", "linuxX64Main", "jsMain", "wasmMain"),
+            kotlin.dependingSourceSetNames("commonMain")
+        )
+
+        assertEquals(
+            stringSetOf("jsMain", "jvmMain"),
+            kotlin.dependingSourceSetNames("jsAndJvmMain")
+        )
+
+        assertEquals(
+            stringSetOf("wasmMain", "linuxX64Main"),
+            kotlin.dependingSourceSetNames("wasmAndLinuxMain")
         )
     }
 


### PR DESCRIPTION
Kotlin 1.8.20-Beta introduced experimental WASM support, though it was missed in introduced in the same version experimental `KotlinTargetHierarchy*` API