### PR TITLE
Autogenerate IrMemberAccessExpression

### DIFF
--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -1601,7 +1601,7 @@ class ExpressionCodegen(
                 //avoid ambiguity with type constructor type parameters
                 emptyMap()
             } else typeArgumentContainer.typeParameters.associate {
-                it.symbol to element.getTypeArgumentOrDefault(it)
+                it.symbol to (element.getTypeArgument(it.index) ?: it.defaultType)
             }
 
         val mappings = TypeParameterMappings(typeMapper.typeSystem, typeArguments, allReified = false, typeMapper::mapTypeParameter)

--- a/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/ArgumentsGenerationUtils.kt
+++ b/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/ArgumentsGenerationUtils.kt
@@ -862,3 +862,13 @@ internal fun unwrapCallableDescriptorAndTypeArguments(resolvedCall: ResolvedCall
 
     return CallBuilder(resolvedCall, substitutedUnwrappedDescriptor, unwrappedTypeArguments)
 }
+
+internal inline fun IrMemberAccessExpression<*>.putTypeArguments(
+    typeArguments: Map<TypeParameterDescriptor, KotlinType>?,
+    toIrType: (KotlinType) -> IrType
+) {
+    if (typeArguments == null) return
+    for ((typeParameter, typeArgument) in typeArguments) {
+        putTypeArgument(typeParameter.index, toIrType(typeArgument))
+    }
+}

--- a/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/ClassGenerator.kt
+++ b/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/ClassGenerator.kt
@@ -28,7 +28,6 @@ import org.jetbrains.kotlin.ir.expressions.impl.IrCallImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrGetFieldImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrGetValueImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrReturnImpl
-import org.jetbrains.kotlin.ir.expressions.putTypeArguments
 import org.jetbrains.kotlin.ir.expressions.typeParametersCount
 import org.jetbrains.kotlin.ir.symbols.impl.IrFieldSymbolImpl
 import org.jetbrains.kotlin.ir.types.IrSimpleType

--- a/compiler/ir/ir.tree/gen/org/jetbrains/kotlin/ir/expressions/IrMemberAccessExpression.kt
+++ b/compiler/ir/ir.tree/gen/org/jetbrains/kotlin/ir/expressions/IrMemberAccessExpression.kt
@@ -1,18 +1,23 @@
 /*
- * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
+
+// This file was generated automatically. See compiler/ir/ir.tree/tree-generator/ReadMe.md.
+// DO NOT MODIFY IT MANUALLY.
 
 package org.jetbrains.kotlin.ir.expressions
 
 import org.jetbrains.kotlin.ir.symbols.IrSymbol
 import org.jetbrains.kotlin.ir.types.IrType
+import org.jetbrains.kotlin.ir.util.transformInPlace
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformer
 import org.jetbrains.kotlin.ir.visitors.IrElementVisitor
 
-// todo: autogenerate
 /**
  * A non-leaf IR tree element.
+ *
+ * Generated from: [org.jetbrains.kotlin.ir.generator.IrTree.memberAccessExpression]
  */
 abstract class IrMemberAccessExpression<S : IrSymbol> : IrDeclarationReference() {
     var dispatchReceiver: IrExpression? = null
@@ -42,9 +47,7 @@ abstract class IrMemberAccessExpression<S : IrSymbol> : IrDeclarationReference()
     override fun <D> transformChildren(transformer: IrElementTransformer<D>, data: D) {
         dispatchReceiver = dispatchReceiver?.transform(transformer, data)
         extensionReceiver = extensionReceiver?.transform(transformer, data)
-        valueArguments.forEachIndexed { i, irExpression ->
-            valueArguments[i] = irExpression?.transform(transformer, data)
-        }
+        valueArguments.transformInPlace(transformer, data)
     }
 
     fun getValueArgument(index: Int): IrExpression? {

--- a/compiler/ir/ir.tree/gen/org/jetbrains/kotlin/ir/expressions/IrMemberAccessExpression.kt
+++ b/compiler/ir/ir.tree/gen/org/jetbrains/kotlin/ir/expressions/IrMemberAccessExpression.kt
@@ -26,7 +26,7 @@ abstract class IrMemberAccessExpression<S : IrSymbol> : IrDeclarationReference()
 
     abstract override val symbol: S
 
-    abstract val origin: IrStatementOrigin?
+    abstract var origin: IrStatementOrigin?
 
     protected abstract val valueArguments: Array<IrExpression?>
 

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/IrExpressions.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/IrExpressions.kt
@@ -68,11 +68,13 @@ fun IrExpression.isUnchanging(): Boolean =
 fun IrExpression.hasNoSideEffects(): Boolean =
     isUnchanging() || this is IrGetValue
 
-internal fun IrMemberAccessExpression<*>.throwNoSuchArgumentSlotException(kind: String, index: Int, total: Int): Nothing {
-    throw AssertionError(
-        "No such $kind argument slot in ${this::class.java.simpleName}: $index (total=$total)" +
-                (symbol.signature?.let { ".\nSymbol: $it" } ?: "")
-    )
+internal fun IrMemberAccessExpression<*>.checkArgumentSlotAccess(kind: String, index: Int, total: Int) {
+    if (index >= total) {
+        throw AssertionError(
+            "No such $kind argument slot in ${this::class.java.simpleName}: $index (total=$total)" +
+                    (symbol.signature?.let { ".\nSymbol: $it" } ?: "")
+        )
+    }
 }
 
 fun IrMemberAccessExpression<*>.copyTypeArgumentsFrom(other: IrMemberAccessExpression<*>, shift: Int = 0) {

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/IrExpressions.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/IrExpressions.kt
@@ -5,6 +5,9 @@
 
 package org.jetbrains.kotlin.ir.expressions
 
+import org.jetbrains.kotlin.descriptors.CallableDescriptor
+import org.jetbrains.kotlin.descriptors.PropertyAccessorDescriptor
+import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.declarations.IrValueParameter
 import org.jetbrains.kotlin.ir.declarations.IrVariable
 import org.jetbrains.kotlin.ir.expressions.impl.IrTypeOperatorCallImpl
@@ -64,3 +67,33 @@ fun IrExpression.isUnchanging(): Boolean =
 
 fun IrExpression.hasNoSideEffects(): Boolean =
     isUnchanging() || this is IrGetValue
+
+internal fun IrMemberAccessExpression<*>.throwNoSuchArgumentSlotException(kind: String, index: Int, total: Int): Nothing {
+    throw AssertionError(
+        "No such $kind argument slot in ${this::class.java.simpleName}: $index (total=$total)" +
+                (symbol.signature?.let { ".\nSymbol: $it" } ?: "")
+    )
+}
+
+fun IrMemberAccessExpression<*>.copyTypeArgumentsFrom(other: IrMemberAccessExpression<*>, shift: Int = 0) {
+    assert(typeArgumentsCount == other.typeArgumentsCount + shift) {
+        "Mismatching type arguments: $typeArgumentsCount vs ${other.typeArgumentsCount} + $shift"
+    }
+    for (i in 0 until other.typeArgumentsCount) {
+        putTypeArgument(i + shift, other.getTypeArgument(i))
+    }
+}
+
+val CallableDescriptor.typeParametersCount: Int
+    get() =
+        when (this) {
+            is PropertyAccessorDescriptor -> correspondingProperty.typeParameters.size
+            else -> typeParameters.size
+        }
+
+fun IrMemberAccessExpression<*>.putArgument(callee: IrFunction, parameter: IrValueParameter, argument: IrExpression) =
+    when (parameter) {
+        callee.dispatchReceiverParameter -> dispatchReceiver = argument
+        callee.extensionReceiverParameter -> extensionReceiver = argument
+        else -> putValueArgument(parameter.index, argument)
+    }

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/IrMemberAccessExpression.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/IrMemberAccessExpression.kt
@@ -8,14 +8,10 @@ package org.jetbrains.kotlin.ir.expressions
 import org.jetbrains.kotlin.descriptors.CallableDescriptor
 import org.jetbrains.kotlin.descriptors.PropertyAccessorDescriptor
 import org.jetbrains.kotlin.descriptors.TypeParameterDescriptor
-import org.jetbrains.kotlin.descriptors.ValueParameterDescriptor
-import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
 import org.jetbrains.kotlin.ir.declarations.IrFunction
-import org.jetbrains.kotlin.ir.declarations.IrTypeParameter
 import org.jetbrains.kotlin.ir.declarations.IrValueParameter
 import org.jetbrains.kotlin.ir.symbols.IrSymbol
 import org.jetbrains.kotlin.ir.types.IrType
-import org.jetbrains.kotlin.ir.types.defaultType
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformer
 import org.jetbrains.kotlin.ir.visitors.IrElementVisitor
 import org.jetbrains.kotlin.types.KotlinType
@@ -92,9 +88,6 @@ internal fun IrMemberAccessExpression<*>.throwNoSuchArgumentSlotException(kind: 
     )
 }
 
-fun IrMemberAccessExpression<*>.getTypeArgument(typeParameterDescriptor: TypeParameterDescriptor): IrType? =
-    getTypeArgument(typeParameterDescriptor.index)
-
 fun IrMemberAccessExpression<*>.copyTypeArgumentsFrom(other: IrMemberAccessExpression<*>, shift: Int = 0) {
     assert(typeArgumentsCount == other.typeArgumentsCount + shift) {
         "Mismatching type arguments: $typeArgumentsCount vs ${other.typeArgumentsCount} + $shift"
@@ -104,59 +97,12 @@ fun IrMemberAccessExpression<*>.copyTypeArgumentsFrom(other: IrMemberAccessExpre
     }
 }
 
-inline fun IrMemberAccessExpression<*>.putTypeArguments(
-    typeArguments: Map<TypeParameterDescriptor, KotlinType>?,
-    toIrType: (KotlinType) -> IrType
-) {
-    if (typeArguments == null) return
-    for ((typeParameter, typeArgument) in typeArguments) {
-        putTypeArgument(typeParameter.index, toIrType(typeArgument))
-    }
-}
-
 val CallableDescriptor.typeParametersCount: Int
     get() =
         when (this) {
             is PropertyAccessorDescriptor -> correspondingProperty.typeParameters.size
             else -> typeParameters.size
         }
-
-fun IrMemberAccessExpression<*>.getTypeArgumentOrDefault(irTypeParameter: IrTypeParameter) =
-    getTypeArgument(irTypeParameter.index) ?: irTypeParameter.defaultType
-
-fun IrMemberAccessExpression<*>.getValueArgument(valueParameterDescriptor: ValueParameterDescriptor) =
-    getValueArgument(valueParameterDescriptor.index)
-
-fun IrMemberAccessExpression<*>.putValueArgument(valueParameterDescriptor: ValueParameterDescriptor, valueArgument: IrExpression?) {
-    putValueArgument(valueParameterDescriptor.index, valueArgument)
-}
-
-@ObsoleteDescriptorBasedAPI
-inline fun <T : IrMemberAccessExpression<*>> T.mapTypeParameters(transform: (TypeParameterDescriptor) -> IrType) : T =
-    apply {
-        val descriptor = symbol.descriptor as CallableDescriptor
-        descriptor.typeParameters.forEach {
-            putTypeArgument(it.index, transform(it))
-        }
-    }
-
-@ObsoleteDescriptorBasedAPI
-inline fun <T : IrMemberAccessExpression<*>> T.mapValueParameters(transform: (ValueParameterDescriptor) -> IrExpression?): T =
-    apply {
-        val descriptor = symbol.descriptor as CallableDescriptor
-        descriptor.valueParameters.forEach {
-            putValueArgument(it.index, transform(it))
-        }
-    }
-
-@ObsoleteDescriptorBasedAPI
-inline fun <T : IrMemberAccessExpression<*>> T.mapValueParametersIndexed(transform: (Int, ValueParameterDescriptor) -> IrExpression?): T =
-    apply {
-        val descriptor = symbol.descriptor as CallableDescriptor
-        descriptor.valueParameters.forEach {
-            putValueArgument(it.index, transform(it.index, it))
-        }
-    }
 
 fun IrMemberAccessExpression<*>.putArgument(callee: IrFunction, parameter: IrValueParameter, argument: IrExpression) =
     when (parameter) {

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/IrMemberAccessExpression.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/IrMemberAccessExpression.kt
@@ -5,16 +5,10 @@
 
 package org.jetbrains.kotlin.ir.expressions
 
-import org.jetbrains.kotlin.descriptors.CallableDescriptor
-import org.jetbrains.kotlin.descriptors.PropertyAccessorDescriptor
-import org.jetbrains.kotlin.descriptors.TypeParameterDescriptor
-import org.jetbrains.kotlin.ir.declarations.IrFunction
-import org.jetbrains.kotlin.ir.declarations.IrValueParameter
 import org.jetbrains.kotlin.ir.symbols.IrSymbol
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformer
 import org.jetbrains.kotlin.ir.visitors.IrElementVisitor
-import org.jetbrains.kotlin.types.KotlinType
 
 // todo: autogenerate
 /**
@@ -80,33 +74,3 @@ abstract class IrMemberAccessExpression<S : IrSymbol> : IrDeclarationReference()
         }
     }
 }
-
-internal fun IrMemberAccessExpression<*>.throwNoSuchArgumentSlotException(kind: String, index: Int, total: Int): Nothing {
-    throw AssertionError(
-        "No such $kind argument slot in ${this::class.java.simpleName}: $index (total=$total)" +
-                (symbol.signature?.let { ".\nSymbol: $it" } ?: "")
-    )
-}
-
-fun IrMemberAccessExpression<*>.copyTypeArgumentsFrom(other: IrMemberAccessExpression<*>, shift: Int = 0) {
-    assert(typeArgumentsCount == other.typeArgumentsCount + shift) {
-        "Mismatching type arguments: $typeArgumentsCount vs ${other.typeArgumentsCount} + $shift"
-    }
-    for (i in 0 until other.typeArgumentsCount) {
-        putTypeArgument(i + shift, other.getTypeArgument(i))
-    }
-}
-
-val CallableDescriptor.typeParametersCount: Int
-    get() =
-        when (this) {
-            is PropertyAccessorDescriptor -> correspondingProperty.typeParameters.size
-            else -> typeParameters.size
-        }
-
-fun IrMemberAccessExpression<*>.putArgument(callee: IrFunction, parameter: IrValueParameter, argument: IrExpression) =
-    when (parameter) {
-        callee.dispatchReceiverParameter -> dispatchReceiver = argument
-        callee.extensionReceiverParameter -> extensionReceiver = argument
-        else -> putValueArgument(parameter.index, argument)
-    }

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/IrMemberAccessExpression.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/IrMemberAccessExpression.kt
@@ -32,45 +32,45 @@ abstract class IrMemberAccessExpression<S : IrSymbol> : IrDeclarationReference()
 
     abstract val origin: IrStatementOrigin?
 
-    protected abstract val typeArgumentsByIndex: Array<IrType?>
-    val typeArgumentsCount: Int get() = typeArgumentsByIndex.size
+    protected abstract val typeArguments: Array<IrType?>
+    val typeArgumentsCount: Int get() = typeArguments.size
 
-    protected abstract val argumentsByParameterIndex: Array<IrExpression?>
-    open val valueArgumentsCount: Int get() = argumentsByParameterIndex.size
+    protected abstract val valueArguments: Array<IrExpression?>
+    open val valueArgumentsCount: Int get() = valueArguments.size
 
     fun getValueArgument(index: Int): IrExpression? {
         if (index >= valueArgumentsCount) {
             throw AssertionError("$this: No such value argument slot: $index")
         }
-        return argumentsByParameterIndex[index]
+        return valueArguments[index]
     }
 
     fun putValueArgument(index: Int, valueArgument: IrExpression?) {
         if (index >= valueArgumentsCount) {
             throw AssertionError("$this: No such value argument slot: $index")
         }
-        argumentsByParameterIndex[index] = valueArgument
+        valueArguments[index] = valueArgument
     }
 
     fun getTypeArgument(index: Int): IrType? {
         if (index >= typeArgumentsCount) {
             throwNoSuchArgumentSlotException("type", index, typeArgumentsCount)
         }
-        return typeArgumentsByIndex[index]
+        return typeArguments[index]
     }
 
     fun putTypeArgument(index: Int, type: IrType?) {
         if (index >= typeArgumentsCount) {
             throwNoSuchArgumentSlotException("type", index, typeArgumentsCount)
         }
-        typeArgumentsByIndex[index] = type
+        typeArguments[index] = type
     }
 
     override fun <D> acceptChildren(visitor: IrElementVisitor<Unit, D>, data: D) {
         dispatchReceiver?.accept(visitor, data)
         extensionReceiver?.accept(visitor, data)
         if (valueArgumentsCount > 0) {
-            argumentsByParameterIndex.forEach { it?.accept(visitor, data) }
+            valueArguments.forEach { it?.accept(visitor, data) }
         }
     }
 
@@ -78,8 +78,8 @@ abstract class IrMemberAccessExpression<S : IrSymbol> : IrDeclarationReference()
         dispatchReceiver = dispatchReceiver?.transform(transformer, data)
         extensionReceiver = extensionReceiver?.transform(transformer, data)
         if (valueArgumentsCount > 0) {
-            argumentsByParameterIndex.forEachIndexed { i, irExpression ->
-                argumentsByParameterIndex[i] = irExpression?.transform(transformer, data)
+            valueArguments.forEachIndexed { i, irExpression ->
+                valueArguments[i] = irExpression?.transform(transformer, data)
             }
         }
     }

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrCallImpl.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrCallImpl.kt
@@ -38,9 +38,9 @@ class IrCallImpl(
     override var superQualifierSymbol: IrClassSymbol? = null
 ) : IrCall() {
 
-    override val typeArgumentsByIndex: Array<IrType?> = arrayOfNulls(typeArgumentsCount)
+    override val typeArguments: Array<IrType?> = arrayOfNulls(typeArgumentsCount)
 
-    override val argumentsByParameterIndex: Array<IrExpression?> = arrayOfNulls(valueArgumentsCount)
+    override val valueArguments: Array<IrExpression?> = arrayOfNulls(valueArgumentsCount)
 
     override var contextReceiversCount = 0
 

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrCallImpl.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrCallImpl.kt
@@ -34,7 +34,7 @@ class IrCallImpl(
     override val symbol: IrSimpleFunctionSymbol,
     typeArgumentsCount: Int,
     valueArgumentsCount: Int,
-    override val origin: IrStatementOrigin? = null,
+    override var origin: IrStatementOrigin? = null,
     override var superQualifierSymbol: IrClassSymbol? = null
 ) : IrCall() {
 

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrConstructorCallImpl.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrConstructorCallImpl.kt
@@ -26,9 +26,9 @@ class IrConstructorCallImpl(
     override val origin: IrStatementOrigin? = null,
     override var source: SourceElement = SourceElement.NO_SOURCE
 ) : IrConstructorCall() {
-    override val typeArgumentsByIndex: Array<IrType?> = arrayOfNulls(typeArgumentsCount)
+    override val typeArguments: Array<IrType?> = arrayOfNulls(typeArgumentsCount)
 
-    override val argumentsByParameterIndex: Array<IrExpression?> = arrayOfNulls(valueArgumentsCount)
+    override val valueArguments: Array<IrExpression?> = arrayOfNulls(valueArgumentsCount)
 
     override var contextReceiversCount = 0
 

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrConstructorCallImpl.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrConstructorCallImpl.kt
@@ -23,7 +23,7 @@ class IrConstructorCallImpl(
     typeArgumentsCount: Int,
     override var constructorTypeArgumentsCount: Int,
     valueArgumentsCount: Int,
-    override val origin: IrStatementOrigin? = null,
+    override var origin: IrStatementOrigin? = null,
     override var source: SourceElement = SourceElement.NO_SOURCE
 ) : IrConstructorCall() {
     override val typeArguments: Array<IrType?> = arrayOfNulls(typeArgumentsCount)

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrDelegatingConstructorCallImpl.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrDelegatingConstructorCallImpl.kt
@@ -33,8 +33,7 @@ class IrDelegatingConstructorCallImpl(
     typeArgumentsCount: Int,
     valueArgumentsCount: Int,
 ) : IrDelegatingConstructorCall() {
-    override val origin: IrStatementOrigin?
-        get() = null
+    override var origin: IrStatementOrigin? = null
 
     override val typeArguments: Array<IrType?> = arrayOfNulls(typeArgumentsCount)
 

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrDelegatingConstructorCallImpl.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrDelegatingConstructorCallImpl.kt
@@ -36,9 +36,9 @@ class IrDelegatingConstructorCallImpl(
     override val origin: IrStatementOrigin?
         get() = null
 
-    override val typeArgumentsByIndex: Array<IrType?> = arrayOfNulls(typeArgumentsCount)
+    override val typeArguments: Array<IrType?> = arrayOfNulls(typeArgumentsCount)
 
-    override val argumentsByParameterIndex: Array<IrExpression?> = arrayOfNulls(valueArgumentsCount)
+    override val valueArguments: Array<IrExpression?> = arrayOfNulls(valueArgumentsCount)
 
     override var contextReceiversCount = 0
 

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrEnumConstructorCallImpl.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrEnumConstructorCallImpl.kt
@@ -31,8 +31,7 @@ class IrEnumConstructorCallImpl(
     typeArgumentsCount: Int,
     valueArgumentsCount: Int
 ) : IrEnumConstructorCall() {
-    override val origin: IrStatementOrigin?
-        get() = null
+    override var origin: IrStatementOrigin? = null
 
     override val typeArguments: Array<IrType?> = arrayOfNulls(typeArgumentsCount)
 

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrEnumConstructorCallImpl.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrEnumConstructorCallImpl.kt
@@ -34,9 +34,9 @@ class IrEnumConstructorCallImpl(
     override val origin: IrStatementOrigin?
         get() = null
 
-    override val typeArgumentsByIndex: Array<IrType?> = arrayOfNulls(typeArgumentsCount)
+    override val typeArguments: Array<IrType?> = arrayOfNulls(typeArgumentsCount)
 
-    override val argumentsByParameterIndex: Array<IrExpression?> = arrayOfNulls(valueArgumentsCount)
+    override val valueArguments: Array<IrExpression?> = arrayOfNulls(valueArgumentsCount)
 
     override var contextReceiversCount = 0
 

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrFunctionReferenceImpl.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrFunctionReferenceImpl.kt
@@ -33,9 +33,9 @@ class IrFunctionReferenceImpl(
     override var reflectionTarget: IrFunctionSymbol? = symbol,
     override val origin: IrStatementOrigin? = null,
 ) : IrFunctionReference() {
-    override val typeArgumentsByIndex: Array<IrType?> = arrayOfNulls(typeArgumentsCount)
+    override val typeArguments: Array<IrType?> = arrayOfNulls(typeArgumentsCount)
 
-    override val argumentsByParameterIndex: Array<IrExpression?> = arrayOfNulls(valueArgumentsCount)
+    override val valueArguments: Array<IrExpression?> = arrayOfNulls(valueArgumentsCount)
 
     companion object {
         @ObsoleteDescriptorBasedAPI

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrFunctionReferenceImpl.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrFunctionReferenceImpl.kt
@@ -31,7 +31,7 @@ class IrFunctionReferenceImpl(
     typeArgumentsCount: Int,
     valueArgumentsCount: Int,
     override var reflectionTarget: IrFunctionSymbol? = symbol,
-    override val origin: IrStatementOrigin? = null,
+    override var origin: IrStatementOrigin? = null,
 ) : IrFunctionReference() {
     override val typeArguments: Array<IrType?> = arrayOfNulls(typeArgumentsCount)
 

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrLocalDelegatedPropertyReferenceImpl.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrLocalDelegatedPropertyReferenceImpl.kt
@@ -34,9 +34,9 @@ class IrLocalDelegatedPropertyReferenceImpl(
     override var setter: IrSimpleFunctionSymbol?,
     override val origin: IrStatementOrigin? = null,
 ) : IrLocalDelegatedPropertyReference() {
-    override val typeArgumentsByIndex: Array<IrType?> = emptyArray()
+    override val typeArguments: Array<IrType?> = emptyArray()
 
-    override val argumentsByParameterIndex: Array<IrExpression?>
+    override val valueArguments: Array<IrExpression?>
         get() = throw UnsupportedOperationException("Property reference $symbol has no value arguments")
 
     override val valueArgumentsCount: Int

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrLocalDelegatedPropertyReferenceImpl.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrLocalDelegatedPropertyReferenceImpl.kt
@@ -34,11 +34,14 @@ class IrLocalDelegatedPropertyReferenceImpl(
     override var setter: IrSimpleFunctionSymbol?,
     override val origin: IrStatementOrigin? = null,
 ) : IrLocalDelegatedPropertyReference() {
-    override val typeArguments: Array<IrType?> = emptyArray()
+    override val typeArguments: Array<IrType?>
+        get() = EMPTY_TYPE_ARGUMENTS
 
     override val valueArguments: Array<IrExpression?>
-        get() = throw UnsupportedOperationException("Property reference $symbol has no value arguments")
+        get() = EMPTY_VALUE_ARGUMENTS
 
-    override val valueArgumentsCount: Int
-        get() = 0
+    companion object {
+        private val EMPTY_TYPE_ARGUMENTS = emptyArray<IrType?>()
+        private val EMPTY_VALUE_ARGUMENTS = emptyArray<IrExpression?>()
+    }
 }

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrLocalDelegatedPropertyReferenceImpl.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrLocalDelegatedPropertyReferenceImpl.kt
@@ -32,7 +32,7 @@ class IrLocalDelegatedPropertyReferenceImpl(
     override var delegate: IrVariableSymbol,
     override var getter: IrSimpleFunctionSymbol,
     override var setter: IrSimpleFunctionSymbol?,
-    override val origin: IrStatementOrigin? = null,
+    override var origin: IrStatementOrigin? = null,
 ) : IrLocalDelegatedPropertyReference() {
     override val typeArguments: Array<IrType?>
         get() = EMPTY_TYPE_ARGUMENTS

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrPropertyReferenceImpl.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrPropertyReferenceImpl.kt
@@ -33,7 +33,7 @@ class IrPropertyReferenceImpl(
     override var field: IrFieldSymbol?,
     override var getter: IrSimpleFunctionSymbol?,
     override var setter: IrSimpleFunctionSymbol?,
-    override val origin: IrStatementOrigin? = null,
+    override var origin: IrStatementOrigin? = null,
 ) : IrPropertyReference() {
     override val typeArguments: Array<IrType?> = arrayOfNulls(typeArgumentsCount)
 

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrPropertyReferenceImpl.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrPropertyReferenceImpl.kt
@@ -35,9 +35,9 @@ class IrPropertyReferenceImpl(
     override var setter: IrSimpleFunctionSymbol?,
     override val origin: IrStatementOrigin? = null,
 ) : IrPropertyReference() {
-    override val typeArgumentsByIndex: Array<IrType?> = arrayOfNulls(typeArgumentsCount)
+    override val typeArguments: Array<IrType?> = arrayOfNulls(typeArgumentsCount)
 
-    override val argumentsByParameterIndex: Array<IrExpression?>
+    override val valueArguments: Array<IrExpression?>
         get() = throw UnsupportedOperationException("Property reference $symbol has no value arguments")
 
     override val valueArgumentsCount: Int

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrPropertyReferenceImpl.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrPropertyReferenceImpl.kt
@@ -38,8 +38,9 @@ class IrPropertyReferenceImpl(
     override val typeArguments: Array<IrType?> = arrayOfNulls(typeArgumentsCount)
 
     override val valueArguments: Array<IrExpression?>
-        get() = throw UnsupportedOperationException("Property reference $symbol has no value arguments")
+        get() = EMPTY_VALUE_ARGUMENTS
 
-    override val valueArgumentsCount: Int
-        get() = 0
+    companion object {
+        private val EMPTY_VALUE_ARGUMENTS = emptyArray<IrExpression?>()
+    }
 }

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/DataClassMembersGenerator.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/DataClassMembersGenerator.kt
@@ -117,10 +117,11 @@ abstract class DataClassMembersGenerator(
                     irClass.defaultType,
                     constructedClass = irClass
                 ).apply {
-                    mapTypeParameters(::transform)
-                    mapValueParameters {
-                        val irValueParameter = irFunction.valueParameters[it.index]
-                        irGet(irValueParameter.type, irValueParameter.symbol)
+                    for ((i, typeParameter) in constructorSymbol.descriptor.typeParameters.withIndex()) {
+                        putTypeArgument(i, transform(typeParameter))
+                    }
+                    for ((i, valueParameter) in irFunction.valueParameters.withIndex()) {
+                        putValueArgument(i, irGet(valueParameter.type, valueParameter.symbol))
                     }
                 }
             )

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/IrUtils.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/IrUtils.kt
@@ -82,7 +82,7 @@ fun IrFunctionAccessExpression.getArgumentsWithSymbols(): List<Pair<IrValueParam
     }
 
     irFunction.valueParameters.forEach {
-        val arg = getValueArgument(it.descriptor as ValueParameterDescriptor)
+        val arg = getValueArgument((it.descriptor as ValueParameterDescriptor).index)
         if (arg != null) {
             res += (it.symbol to arg)
         }

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/transform.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/transform.kt
@@ -36,6 +36,17 @@ fun <T : IrElement, D> MutableList<T>.transformInPlace(transformer: IrElementTra
     }
 }
 
+fun <T : IrElement, D> Array<T?>.transformInPlace(transformer: IrElementTransformer<D>, data: D) {
+    for (i in indices) {
+        // Cast to IrElementBase to avoid casting to interface and invokeinterface, both of which are slow.
+        val element = get(i) as IrElementBase?
+        if (element != null) {
+            @Suppress("UNCHECKED_CAST")
+            set(i, element.transform(transformer, data) as T)
+        }
+    }
+}
+
 /**
  * Transforms a mutable list in place.
  * Each element `it` is replaced with a result of `transformation(it)`,

--- a/compiler/ir/ir.tree/tree-generator/src/org/jetbrains/kotlin/ir/generator/IrTree.kt
+++ b/compiler/ir/ir.tree/tree-generator/src/org/jetbrains/kotlin/ir/generator/IrTree.kt
@@ -608,7 +608,7 @@ object IrTree : AbstractTreeBuilder() {
             baseDefaultValue = code("null")
         }
         +symbol(s)
-        +field("origin", statementOriginType, nullable = true, mutable = false)
+        +field("origin", statementOriginType, nullable = true)
         +listField("valueArguments", expression.copy(nullable = true), mutability = Array, isChild = true) {
             generationCallback = {
                 addModifiers(KModifier.PROTECTED)

--- a/compiler/ir/ir.tree/tree-generator/src/org/jetbrains/kotlin/ir/generator/config/ConfigModel.kt
+++ b/compiler/ir/ir.tree/tree-generator/src/org/jetbrains/kotlin/ir/generator/config/ConfigModel.kt
@@ -116,6 +116,7 @@ class ListFieldConfig(
     enum class Mutability {
         Immutable,
         Var,
-        List
+        List,
+        Array
     }
 }

--- a/compiler/ir/ir.tree/tree-generator/src/org/jetbrains/kotlin/ir/generator/model/Transformations.kt
+++ b/compiler/ir/ir.tree/tree-generator/src/org/jetbrains/kotlin/ir/generator/model/Transformations.kt
@@ -32,10 +32,17 @@ fun config2model(config: Config): Model {
                     fc.baseGetter
                 )
                 is ListFieldConfig -> {
-                    val listType = if (fc.mutability == ListFieldConfig.Mutability.List) type(
-                        "kotlin.collections",
-                        "MutableList"
-                    ) else type("kotlin.collections", "List")
+                    val listType = when (fc.mutability) {
+                        ListFieldConfig.Mutability.List -> type(
+                            "kotlin.collections",
+                            "MutableList"
+                        )
+                        ListFieldConfig.Mutability.Array -> type(
+                            "kotlin.",
+                            "Array"
+                        )
+                        else -> type("kotlin.collections", "List")
+                    }
                     ListField(
                         fc,
                         fc.name,

--- a/compiler/ir/ir.tree/tree-generator/src/org/jetbrains/kotlin/ir/generator/print/Elements.kt
+++ b/compiler/ir/ir.tree/tree-generator/src/org/jetbrains/kotlin/ir/generator/print/Elements.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.ir.generator.elementTransformerType
 import org.jetbrains.kotlin.ir.generator.elementVisitorType
 import org.jetbrains.kotlin.ir.generator.model.*
 import org.jetbrains.kotlin.ir.generator.util.TypeKind
+import org.jetbrains.kotlin.ir.generator.util.TypeRefWithNullability
 import org.jetbrains.kotlin.ir.generator.util.tryParameterizedBy
 import java.io.File
 
@@ -161,7 +162,11 @@ fun printElements(generationPath: File, model: Model) = sequence {
                             if (child.nullable) append("?")
                             when (child) {
                                 is SingleField -> append(".%N(%N, %N)")
-                                is ListField -> append(".forEach { it.%N(%N, %N) }")
+                                is ListField -> {
+                                    append(".forEach { it")
+                                    if ((child.elementType as? TypeRefWithNullability)?.nullable == true) append("?")
+                                    append(".%N(%N, %N) }")
+                                }
                             }
                         }, child.name, acceptMethodName, visitorParam, dataParam)
                     }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IntrinsicGenerator.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IntrinsicGenerator.kt
@@ -414,7 +414,7 @@ internal class IntrinsicGenerator(private val environment: IntrinsicGeneratorEnv
 
     private fun FunctionGenerationContext.emitCreateUninitializedInstance(callSite: IrCall, resultSlot: LLVMValueRef?): LLVMValueRef {
         val typeParameterT = context.ir.symbols.createUninitializedInstance.descriptor.typeParameters[0]
-        val enumClass = callSite.getTypeArgument(typeParameterT)!!
+        val enumClass = callSite.getTypeArgument(typeParameterT.index)!!
         val enumIrClass = enumClass.getClass()!!
         return allocInstance(enumIrClass, environment.calculateLifetime(callSite), resultSlot)
     }


### PR DESCRIPTION
This PR completes #4560 by generating the last left over element class. That fix allows further bulk operations and experiments involving the whole tree.

Most significantly the `valueArguments` and `typeArguments` lists were converted from arrays to (preallocated) MutableLists.
One outcome is that it's now possible to work with them like with regular lists instead of throught the `getValueArgument`/`putTypeArgument` methods. OOTH the everything  still uses the latter. But it should be possible to inline those methods with a refactoring action for the whole codebase if that's desired.

The other thing is possible performance regression.I have not run any benchamrk but I'm keen on seeing its results.