### PR TITLE
Generate unique protocol wrapper class stub names

### DIFF
--- a/kotlin-native/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/ObjCStubs.kt
+++ b/kotlin-native/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/ObjCStubs.kt
@@ -444,7 +444,7 @@ internal abstract class ObjCContainerStubBuilder(
                 metaContainerStub.protocolGetter!!
             } else {
                 // TODO: handle the case when protocol getter stub can't be compiled.
-                context.generateNextUniqueId("kniprot_")
+                "${context.generateNextUniqueId("kniprot_")}_${container.name}"
             }
             AnnotationStub.ObjC.ExternalClass(protocolGetter)
         }

--- a/native/native.tests/testData/CInterop/framework/frameworkDefs/protocolDefs/contents.gold.txt
+++ b/native/native.tests/testData/CInterop/framework/frameworkDefs/protocolDefs/contents.gold.txt
@@ -1,0 +1,6 @@
+
+package objcinterop {
+    @ExternalObjCClass(protocolGetter = "kniprot_objcinterop0_Simple") interface SimpleProtocol : ObjCObject
+    @ExternalObjCClass(protocolGetter = "kniprot_objcinterop0_Simple") interface SimpleProtocolMeta : ObjCObjectMeta /* = ObjCClass */
+}
+

--- a/native/native.tests/testData/CInterop/framework/frameworkDefs/protocolDefs/pod1.def
+++ b/native/native.tests/testData/CInterop/framework/frameworkDefs/protocolDefs/pod1.def
@@ -1,0 +1,3 @@
+language = Objective-C
+headers = protocol/protocol.h
+package = objcinterop

--- a/native/native.tests/testData/CInterop/framework/protocol.framework/Headers/protocol.h
+++ b/native/native.tests/testData/CInterop/framework/protocol.framework/Headers/protocol.h
@@ -1,0 +1,3 @@
+
+@protocol Simple
+@end

--- a/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/CInteropFModulesTestGenerated.java
+++ b/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/CInteropFModulesTestGenerated.java
@@ -193,6 +193,12 @@ public class CInteropFModulesTestGenerated extends AbstractNativeCInteropFModule
         }
 
         @Test
+        @TestMetadata("protocolDefs")
+        public void testProtocolDefs() throws Exception {
+            runTest("native/native.tests/testData/CInterop/framework/frameworkDefs/protocolDefs/");
+        }
+
+        @Test
         @TestMetadata("twoChildren")
         public void testTwoChildren() throws Exception {
             runTest("native/native.tests/testData/CInterop/framework/frameworkDefs/twoChildren/");

--- a/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/CInteropNoFModulesTestGenerated.java
+++ b/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/CInteropNoFModulesTestGenerated.java
@@ -193,6 +193,12 @@ public class CInteropNoFModulesTestGenerated extends AbstractNativeCInteropNoFMo
         }
 
         @Test
+        @TestMetadata("protocolDefs")
+        public void testProtocolDefs() throws Exception {
+            runTest("native/native.tests/testData/CInterop/framework/frameworkDefs/protocolDefs/");
+        }
+
+        @Test
         @TestMetadata("twoChildren")
         public void testTwoChildren() throws Exception {
             runTest("native/native.tests/testData/CInterop/framework/frameworkDefs/twoChildren/");


### PR DESCRIPTION
Simple change that addresses the issue raised in:
https://youtrack.jetbrains.com/issue/KT-57490/K2-N-Duplicate-package-names-for-cinterop-klibs-with-objc-protocols-fails-to-link