### PR TITLE
Use original list when creating a sublist of a sublist

### DIFF
--- a/libraries/stdlib/src/kotlin/collections/AbstractList.kt
+++ b/libraries/stdlib/src/kotlin/collections/AbstractList.kt
@@ -49,6 +49,11 @@ public abstract class AbstractList<out E> protected constructor() : AbstractColl
         }
 
         override val size: Int get() = _size
+
+        override fun subList(fromIndex: Int, toIndex: Int): List<E> {
+            checkRangeIndexes(fromIndex, toIndex, _size)
+            return SubList(list, this.fromIndex + fromIndex, this.fromIndex + toIndex)
+        }
     }
 
     /**

--- a/libraries/stdlib/test/collections/AbstractCollectionsTest.kt
+++ b/libraries/stdlib/test/collections/AbstractCollectionsTest.kt
@@ -63,6 +63,16 @@ class AbstractCollectionsTest {
     }
 
     @Test
+    fun chainedSubList() {
+        val list = object : AbstractList<Int>() {
+            override val size = 5
+            override fun get(index: Int) = if (index in 0 until size) index else -1
+        }
+        val subList = list.subList(0, 5).subList(1, 4)
+        assertEquals(listOf(1, 2, 3), subList)
+    }
+
+    @Test
     fun abstractMap() {
         val map = ReadOnlyMap()
         assertEquals(1, map.size)


### PR DESCRIPTION
When creating a sublist from a sublist the implementation of subList from AbstractList is used. This implementation treats the parent sublist as a list in its own right, and this leads to the child sublist holding a reference to the parent sublist, when holding a reference to the original list would suffice. This prevents the parent sublist from being ellegible for garbage collection as long as the child sublist is needed, and can lead to StackOverflowError or OutOfMemoryError errors if multiple calls to subList are chained. Moreover, it can also make accessing elements of the sublist slower, as each sublist must call the get function from the sublist it originated from to access the element.

With this change, when calling subList from a sublist, we return a sublist holding a reference to the original list instead of to the parent sublist, which frees the parent sublist for garbage collection and allows the child sublist to access elements by calling directly the get function of the original list.

Fixes [KT-50081](https://youtrack.jetbrains.com/issue/KT-50081)
Fixes [KT-46103](https://youtrack.jetbrains.com/issue/KT-46103)