### PR TITLE
JVM_IR: Fix suspend function tail-call optimization glitch

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirLightTreeBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirLightTreeBlackBoxCodegenTestGenerated.java
@@ -10598,6 +10598,12 @@ public class FirLightTreeBlackBoxCodegenTestGenerated extends AbstractFirLightTr
         }
 
         @Test
+        @TestMetadata("kt55559.kt")
+        public void testKt55559() throws Exception {
+            runTest("compiler/testData/codegen/box/coroutines/kt55559.kt");
+        }
+
+        @Test
         @TestMetadata("kt56407.kt")
         public void testKt56407() throws Exception {
             runTest("compiler/testData/codegen/box/coroutines/kt56407.kt");

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirPsiBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirPsiBlackBoxCodegenTestGenerated.java
@@ -10598,6 +10598,12 @@ public class FirPsiBlackBoxCodegenTestGenerated extends AbstractFirPsiBlackBoxCo
         }
 
         @Test
+        @TestMetadata("kt55559.kt")
+        public void testKt55559() throws Exception {
+            runTest("compiler/testData/codegen/box/coroutines/kt55559.kt");
+        }
+
+        @Test
         @TestMetadata("kt56407.kt")
         public void testKt56407() throws Exception {
             runTest("compiler/testData/codegen/box/coroutines/kt56407.kt");

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/CoroutineCodegen.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/CoroutineCodegen.kt
@@ -55,7 +55,7 @@ internal fun MethodNode.acceptWithStateMachine(
         isForNamedFunction = irFunction.isSuspend,
         disableTailCallOptimizationForFunctionReturningUnit = irFunction.isSuspend && irFunction.suspendFunctionOriginal().let {
             it.returnType.isUnit() && it.anyOfOverriddenFunctionsReturnsNonUnit()
-        },
+        } || (irFunction in (context.suspendFunctionUsedAsFunctionRef)),
         reportSuspensionPointInsideMonitor = {
             classCodegen.context.ktDiagnosticReporter.at(irFunction, classCodegen.irClass)
                 .report(JvmBackendErrors.SUSPENSION_POINT_INSIDE_MONITOR, it)
@@ -70,6 +70,7 @@ internal fun MethodNode.acceptWithStateMachine(
         shouldOptimiseUnusedVariables = !context.configuration.getBoolean(JVMConfigurationKeys.ENABLE_DEBUG_MODE)
     )
     accept(visitor)
+    context.suspendFunctionUsedAsFunctionRef.remove(irFunction)
 }
 
 private fun IrFunction.anyOfOverriddenFunctionsReturnsNonUnit(): Boolean =

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/JvmLower.kt
@@ -397,6 +397,7 @@ private val jvmFilePhases = listOf(
     toArrayPhase,
     jvmSafeCallFoldingPhase,
     jvmOptimizationLoweringPhase,
+    recordSuspendFunctionUsedAsFrLoweringPhase,
     additionalClassAnnotationPhase,
     recordEnclosingMethodsPhase,
     typeOperatorLowering,

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/RecordSuspendFunctionUsedAsFrLowering.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/RecordSuspendFunctionUsedAsFrLowering.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.jvm.lower
+
+import org.jetbrains.kotlin.backend.common.FileLoweringPass
+import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
+import org.jetbrains.kotlin.backend.common.phaser.makeIrFilePhase
+import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
+import org.jetbrains.kotlin.ir.declarations.*
+import org.jetbrains.kotlin.ir.expressions.*
+import org.jetbrains.kotlin.ir.types.isNullableAny
+import org.jetbrains.kotlin.ir.types.isUnit
+import org.jetbrains.kotlin.ir.util.*
+import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
+
+internal val recordSuspendFunctionUsedAsFrLoweringPhase = makeIrFilePhase(
+    ::RecordSuspendFunctionUsedAsFrLowering,
+    name = "RecordSuspendFunctionUsedAsFrLowering",
+    description = "Record suspend function used as function reference lowering phase"
+)
+
+class RecordSuspendFunctionUsedAsFrLowering(val context: JvmBackendContext) : FileLoweringPass, IrElementTransformerVoidWithContext() {
+    override fun lower(irFile: IrFile) {
+        irFile.transformChildrenVoid(this)
+    }
+
+    private fun IrFunctionReference.isSuspendFunctionReference(): Boolean = isSuspend &&
+            (origin == null || origin == IrStatementOrigin.ADAPTED_FUNCTION_REFERENCE || origin == IrStatementOrigin.SUSPEND_CONVERSION)
+
+    override fun visitFunctionReference(expression: IrFunctionReference): IrExpression {
+        if (expression.isSuspendFunctionReference()) {
+            val owner = expression.symbol.owner
+            if (owner.returnType.isNullableAny() && owner.originalFunction.returnType.isUnit()) {
+                context.suspendFunctionUsedAsFunctionRef.add(owner)
+            }
+        }
+        return expression
+    }
+}

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendContext.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendContext.kt
@@ -162,6 +162,7 @@ class JvmBackendContext(
 
     val suspendLambdaToOriginalFunctionMap = ConcurrentHashMap<IrAttributeContainer, IrFunction>()
     val suspendFunctionOriginalToView = ConcurrentHashMap<IrSimpleFunction, IrSimpleFunction>()
+    val suspendFunctionUsedAsFunctionRef = mutableListOf<IrFunction>()
 
     val staticDefaultStubs = ConcurrentHashMap<IrSimpleFunctionSymbol, IrSimpleFunction>()
 

--- a/compiler/testData/codegen/box/coroutines/kt55559.kt
+++ b/compiler/testData/codegen/box/coroutines/kt55559.kt
@@ -1,0 +1,39 @@
+// TARGET_BACKEND: JVM_IR
+// WITH_STDLIB
+// WITH_COROUTINES
+
+import helpers.*
+import kotlin.coroutines.*
+import kotlin.coroutines.intrinsics.*
+
+var c: Continuation<Unit>? = null
+
+suspend fun delay() = suspendCoroutine {
+    c = it
+    COROUTINE_SUSPENDED
+}
+
+class Foo {
+    suspend fun bar() {
+        baz()
+    }
+
+    suspend fun baz(): Long {
+        delay()
+        return 1000L
+    }
+}
+
+suspend fun <T> process(fn: suspend () -> T): String {
+    val r = fn()
+    return if (r is Unit) "OK" else "FAIL"
+}
+
+fun box(): String {
+    var result = ""
+    suspend {
+        result = process(Foo()::bar)
+    }.startCoroutine(EmptyContinuation)
+    c?.resume(Unit)
+    return result
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -10598,6 +10598,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         }
 
         @Test
+        @TestMetadata("kt55559.kt")
+        public void testKt55559() throws Exception {
+            runTest("compiler/testData/codegen/box/coroutines/kt55559.kt");
+        }
+
+        @Test
         @TestMetadata("kt56407.kt")
         public void testKt56407() throws Exception {
             runTest("compiler/testData/codegen/box/coroutines/kt56407.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenWithIrInlinerTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenWithIrInlinerTestGenerated.java
@@ -10598,6 +10598,12 @@ public class IrBlackBoxCodegenWithIrInlinerTestGenerated extends AbstractIrBlack
         }
 
         @Test
+        @TestMetadata("kt55559.kt")
+        public void testKt55559() throws Exception {
+            runTest("compiler/testData/codegen/box/coroutines/kt55559.kt");
+        }
+
+        @Test
         @TestMetadata("kt56407.kt")
         public void testKt56407() throws Exception {
             runTest("compiler/testData/codegen/box/coroutines/kt56407.kt");


### PR DESCRIPTION
This is a proposal to fix [KT-55559
](https://youtrack.jetbrains.com/issue/KT-55559/JVM-ClassCastException-with-Unit-returning-suspend-function-and-tail-call-Non-Unit-returning-suspend-function-and-callable)

The issue is caused by tail-call optimization, since there is only a tail call of another suspend function inside function bar, there is no way it can suspend in the middle of the function `bar`, so compiler doesn't generate a state machine for it. 

This optimization works fine for most of time. But in this case, when we resume with value `1000L` from `baz`, due to missing a link   in the completion chain, state machine of function `process` would be resumed with `Result(1000L)` , and 1000L would be considered to be the return value of call of `fn`.

Since the return type of `fn` is not guaranteed to be Unit at runtime in such case, we can't resolve the issue by popping out the return value and pushing Unit onto the stack.

Thus, we need to disable the tail-call optimization, and generate a state machine for suspend function `bar`.

But I admit this is not an ideal solution for 2 reasons:
1. it would be good to resolve this issue without disable the optimization, if it's possible.
2. this proposal need to track suspend function references whose return type is generic type. It requires more memory, and somewhat unpredictable.