### PR TITLE
Add Continuation<Unit>.resume()

### DIFF
--- a/libraries/stdlib/src/kotlin/coroutines/Continuation.kt
+++ b/libraries/stdlib/src/kotlin/coroutines/Continuation.kt
@@ -39,7 +39,8 @@ public annotation class RestrictsSuspension
 /**
  * Resumes the execution of the corresponding coroutine with no return value.
  */
-public inline fun Continuation<Unit>.resume(): Unit = resume(Unit)
+public inline fun Continuation<Unit>.resume(): Unit =
+    resume(Unit)
 
 /**
  * Resumes the execution of the corresponding coroutine passing [value] as the return value of the last suspension point.

--- a/libraries/stdlib/src/kotlin/coroutines/Continuation.kt
+++ b/libraries/stdlib/src/kotlin/coroutines/Continuation.kt
@@ -37,6 +37,11 @@ public interface Continuation<in T> {
 public annotation class RestrictsSuspension
 
 /**
+ * Resumes the execution of the corresponding coroutine with no return value.
+ */
+public inline fun Continuation<Unit>.resume(): Unit = resume(Unit)
+
+/**
  * Resumes the execution of the corresponding coroutine passing [value] as the return value of the last suspension point.
  */
 @SinceKotlin("1.3")


### PR DESCRIPTION
suspendCoroutine is commonly used to convert callbacks to suspend functions, but some callbacks don't have a result.