### PR TITLE
Add new kotlin multiplatform plugin id to list of android plugins

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/utils/androidPluginIds.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/utils/androidPluginIds.kt
@@ -14,7 +14,8 @@ internal val androidPluginIds = listOf(
     "com.android.test",
     // Deprecated android plugins
     "com.android.instantapp",
-    "com.android.feature"
+    "com.android.feature",
+    "com.android.kotlin.multiplatform"
     // For following plugins 'kotlin-android' should never be applied
     // see https://issuetracker.google.com/issues/228449122
     //"com.android.asset-pack",


### PR DESCRIPTION
Add the id of the new kotlin multiplatform android library plugin to the list of the known android plugin ids.