### PR TITLE
Omit dependency classpath from compiler args

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/internal/CompilerArgumentAware.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/internal/CompilerArgumentAware.kt
@@ -81,5 +81,4 @@ interface CompilerArgumentAware<T : CommonToolArguments> : KotlinCompilerArgumen
 private val includedArgumentTypes = setOf(
     ArgumentType.Primitive,
     ArgumentType.PluginClasspath,
-    ArgumentType.DependencyClasspath,
 )

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/compilerArgumetns/Kotlin2JsCompileArgumentsTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/compilerArgumetns/Kotlin2JsCompileArgumentsTest.kt
@@ -9,6 +9,10 @@ package org.jetbrains.kotlin.gradle.unitTests.compilerArgumetns
 
 import org.jetbrains.kotlin.compilerRunner.ArgumentUtils
 import org.jetbrains.kotlin.gradle.dsl.multiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.CreateCompilerArgumentsContext
+import org.jetbrains.kotlin.gradle.plugin.KotlinCompilerArgumentsProducer
+import org.jetbrains.kotlin.gradle.plugin.KotlinCompilerArgumentsProducer.ArgumentType.PluginClasspath
+import org.jetbrains.kotlin.gradle.plugin.KotlinCompilerArgumentsProducer.ArgumentType.Primitive
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilerArgumentsProducer.CreateCompilerArgumentsContext.Companion.default
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilerArgumentsProducer.CreateCompilerArgumentsContext.Companion.lenient
 import org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType
@@ -31,7 +35,12 @@ class Kotlin2JsCompileArgumentsTest {
         project.evaluate()
 
         val jsMainCompileTask = jsMainCompilation.compileTaskProvider.get()
-        val argumentsFromCompilerArgumentsProducer = jsMainCompileTask.createCompilerArguments(lenient)
+        val argumentsFromCompilerArgumentsProducer = jsMainCompileTask.createCompilerArguments(
+            CreateCompilerArgumentsContext(
+                includeArgumentTypes = setOf(Primitive, PluginClasspath),
+                isLenient = true
+            )
+        )
 
         @Suppress("DEPRECATION_ERROR")
         assertEquals(

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/compilerArgumetns/KotlinCompileArgumentsTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/compilerArgumetns/KotlinCompileArgumentsTest.kt
@@ -18,6 +18,10 @@ import org.jetbrains.kotlin.gradle.dependencyResolutionTests.mavenCentralCacheRe
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.dsl.kotlinJvmExtension
 import org.jetbrains.kotlin.gradle.dsl.multiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.CreateCompilerArgumentsContext
+import org.jetbrains.kotlin.gradle.plugin.KotlinCompilerArgumentsProducer
+import org.jetbrains.kotlin.gradle.plugin.KotlinCompilerArgumentsProducer.ArgumentType.PluginClasspath
+import org.jetbrains.kotlin.gradle.plugin.KotlinCompilerArgumentsProducer.ArgumentType.Primitive
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilerArgumentsProducer.CreateCompilerArgumentsContext.Companion.lenient
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jetbrains.kotlin.gradle.util.assertNotNull
@@ -43,7 +47,12 @@ class KotlinCompileArgumentsTest {
 
         val mainCompilation = kotlin.target.compilations.getByName("main")
         val mainCompilationTask = mainCompilation.compileTaskProvider.get() as KotlinCompile
-        val argumentsFromKotlinCompilerArgumentsAware = mainCompilationTask.createCompilerArguments(lenient)
+        val argumentsFromKotlinCompilerArgumentsAware = mainCompilationTask.createCompilerArguments(
+            CreateCompilerArgumentsContext(
+                includeArgumentTypes = setOf(Primitive, PluginClasspath),
+                isLenient = true
+            )
+        )
 
         @Suppress("DEPRECATION_ERROR")
         assertEquals(


### PR DESCRIPTION
This is in the context of the following issue:
https://youtrack.jetbrains.com/issue/KTIJ-24724