### PR TITLE
Move attribute accesses to `TypeSystemInferenceExtensionContext`

### DIFF
--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/types/ConeInferenceContext.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/types/ConeInferenceContext.kt
@@ -299,6 +299,23 @@ interface ConeInferenceContext : TypeSystemInferenceExtensionContext, ConeTypeCo
         return attributes.noInfer != null
     }
 
+    override fun KotlinTypeMarker.getAttributes(): List<AnnotationMarker> {
+        require(this is ConeKotlinType)
+        return attributes.toList()
+    }
+
+    override fun KotlinTypeMarker.hasCustomAttributes(): Boolean {
+        require(this is ConeKotlinType)
+        val compilerAttributes = CompilerConeAttributes.classIdByCompilerAttributeKey
+        return this.attributes.any { it.key !in compilerAttributes && it !is CustomAnnotationTypeAttribute }
+    }
+
+    override fun KotlinTypeMarker.getCustomAttributes(): List<AnnotationMarker> {
+        require(this is ConeKotlinType)
+        val compilerAttributes = CompilerConeAttributes.classIdByCompilerAttributeKey
+        return attributes.filterNot { it.key in compilerAttributes || it is CustomAnnotationTypeAttribute }
+    }
+
     override fun TypeConstructorMarker.isFinalClassConstructor(): Boolean {
         val symbol = toClassLikeSymbol() ?: return false
         if (symbol is FirAnonymousObjectSymbol) return true

--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/types/ConeTypeContext.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/types/ConeTypeContext.kt
@@ -423,23 +423,6 @@ interface ConeTypeContext : TypeSystemContext, TypeSystemOptimizationContext, Ty
         return false
     }
 
-    override fun KotlinTypeMarker.getAttributes(): List<AnnotationMarker> {
-        require(this is ConeKotlinType)
-        return attributes.toList()
-    }
-
-    override fun KotlinTypeMarker.hasCustomAttributes(): Boolean {
-        require(this is ConeKotlinType)
-        val compilerAttributes = CompilerConeAttributes.classIdByCompilerAttributeKey
-        return this.attributes.any { it.key !in compilerAttributes && it !is CustomAnnotationTypeAttribute }
-    }
-
-    override fun KotlinTypeMarker.getCustomAttributes(): List<AnnotationMarker> {
-        require(this is ConeKotlinType)
-        val compilerAttributes = CompilerConeAttributes.classIdByCompilerAttributeKey
-        return attributes.filterNot { it.key in compilerAttributes || it is CustomAnnotationTypeAttribute }
-    }
-
     override fun SimpleTypeMarker.isStubType(): Boolean {
         return this is ConeStubType
     }

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/types/IrTypeSystemContext.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/types/IrTypeSystemContext.kt
@@ -11,7 +11,6 @@ import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.ir.IrBuiltIns
-import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.expressions.IrConst
 import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
@@ -410,20 +409,6 @@ interface IrTypeSystemContext : TypeSystemContext, TypeSystemCommonSuperTypesCon
 
     override fun SimpleTypeMarker.isPrimitiveType(): Boolean =
         this is IrSimpleType && irTypePredicates_isPrimitiveType()
-
-    override fun KotlinTypeMarker.getAttributes(): List<AnnotationMarker> {
-        require(this is IrType)
-        return this.annotations.memoryOptimizedMap { object : AnnotationMarker, IrElement by it {} }
-    }
-
-    override fun KotlinTypeMarker.hasCustomAttributes(): Boolean {
-        return false
-    }
-
-    override fun KotlinTypeMarker.getCustomAttributes(): List<AnnotationMarker> {
-        require(this is IrType)
-        return emptyList()
-    }
 
     override fun createErrorType(debugName: String): SimpleTypeMarker {
         TODO("IrTypeSystemContext doesn't support constraint system resolution")

--- a/core/compiler.common/src/org/jetbrains/kotlin/types/model/TypeSystemContext.kt
+++ b/core/compiler.common/src/org/jetbrains/kotlin/types/model/TypeSystemContext.kt
@@ -219,6 +219,10 @@ interface TypeSystemInferenceExtensionContext : TypeSystemContext, TypeSystemBui
     fun KotlinTypeMarker.hasExactAnnotation(): Boolean
     fun KotlinTypeMarker.hasNoInferAnnotation(): Boolean
 
+    fun KotlinTypeMarker.getAttributes(): List<AnnotationMarker>
+    fun KotlinTypeMarker.hasCustomAttributes(): Boolean
+    fun KotlinTypeMarker.getCustomAttributes(): List<AnnotationMarker>
+
     fun TypeConstructorMarker.isFinalClassConstructor(): Boolean
 
     fun TypeVariableMarker.freshTypeConstructor(): TypeConstructorMarker
@@ -542,12 +546,6 @@ interface TypeSystemContext : TypeSystemOptimizationContext {
     fun KotlinTypeMarker.isSimpleType(): Boolean = asSimpleType() != null
 
     fun SimpleTypeMarker.isPrimitiveType(): Boolean
-
-    fun KotlinTypeMarker.getAttributes(): List<AnnotationMarker>
-
-    fun KotlinTypeMarker.hasCustomAttributes(): Boolean
-
-    fun KotlinTypeMarker.getCustomAttributes(): List<AnnotationMarker>
 
     fun substitutionSupertypePolicy(type: SimpleTypeMarker): TypeCheckerState.SupertypesPolicy
 


### PR DESCRIPTION
## Summary
`getAttributes`/`hasCustomAttributes`/`getCustomAttributes` from `TypeSystemContext` are only used when the implementation is also a `TypeSystemInferenceExtensionContext`.

This PR removes these three functions from `IrTypeSystemContext` while keeping them unchanged in `ConeInferenceContext` and `ClassicTypeSystemContext`.

## Motivation
During an analysis of the Kotlin IR tree, there was an unaccountable and unused instance of `IrElement` found inside `IrTypeSystemContext`. A minor refactoring could eliminate the need for such a placeholder and, at the same time, align the definition of `TypeSystemContext` with its actual use.