### PR TITLE
K2 JVM: Fix an annotation compile-time value issue

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirLightTreeBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirLightTreeBlackBoxCodegenTestGenerated.java
@@ -300,6 +300,12 @@ public class FirLightTreeBlackBoxCodegenTestGenerated extends AbstractFirLightTr
         }
 
         @Test
+        @TestMetadata("kt58007.kt")
+        public void testKt58007() throws Exception {
+            runTest("compiler/testData/codegen/box/annotations/kt58007.kt");
+        }
+
+        @Test
         @TestMetadata("mustBeDocumented.kt")
         public void testMustBeDocumented() throws Exception {
             runTest("compiler/testData/codegen/box/annotations/mustBeDocumented.kt");

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirPsiBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirPsiBlackBoxCodegenTestGenerated.java
@@ -300,6 +300,12 @@ public class FirPsiBlackBoxCodegenTestGenerated extends AbstractFirPsiBlackBoxCo
         }
 
         @Test
+        @TestMetadata("kt58007.kt")
+        public void testKt58007() throws Exception {
+            runTest("compiler/testData/codegen/box/annotations/kt58007.kt");
+        }
+
+        @Test
         @TestMetadata("mustBeDocumented.kt")
         public void testMustBeDocumented() throws Exception {
             runTest("compiler/testData/codegen/box/annotations/mustBeDocumented.kt");

--- a/compiler/testData/codegen/box/annotations/kt58007.kt
+++ b/compiler/testData/codegen/box/annotations/kt58007.kt
@@ -1,0 +1,14 @@
+// IGNORE_BACKEND: JS
+// WITH_STDLIB
+
+annotation class Ann(val value: Int = Int.MIN_VALUE)
+
+@Ann
+class A
+
+fun box(): String {
+    val default = A::class.java.getAnnotation(Ann::class.java).value
+
+    return if (default == Int.MIN_VALUE) "OK"
+    else "FAIL"
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -252,6 +252,12 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
         }
 
         @Test
+        @TestMetadata("kt58007.kt")
+        public void testKt58007() throws Exception {
+            runTest("compiler/testData/codegen/box/annotations/kt58007.kt");
+        }
+
+        @Test
         @TestMetadata("mustBeDocumented.kt")
         public void testMustBeDocumented() throws Exception {
             runTest("compiler/testData/codegen/box/annotations/mustBeDocumented.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -300,6 +300,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
         }
 
         @Test
+        @TestMetadata("kt58007.kt")
+        public void testKt58007() throws Exception {
+            runTest("compiler/testData/codegen/box/annotations/kt58007.kt");
+        }
+
+        @Test
         @TestMetadata("mustBeDocumented.kt")
         public void testMustBeDocumented() throws Exception {
             runTest("compiler/testData/codegen/box/annotations/mustBeDocumented.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenWithIrInlinerTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenWithIrInlinerTestGenerated.java
@@ -300,6 +300,12 @@ public class IrBlackBoxCodegenWithIrInlinerTestGenerated extends AbstractIrBlack
         }
 
         @Test
+        @TestMetadata("kt58007.kt")
+        public void testKt58007() throws Exception {
+            runTest("compiler/testData/codegen/box/annotations/kt58007.kt");
+        }
+
+        @Test
         @TestMetadata("mustBeDocumented.kt")
         public void testMustBeDocumented() throws Exception {
             runTest("compiler/testData/codegen/box/annotations/mustBeDocumented.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -233,6 +233,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
             runTest("compiler/testData/codegen/box/annotations/kt25489.kt");
         }
 
+        @TestMetadata("kt58007.kt")
+        public void testKt58007() throws Exception {
+            runTest("compiler/testData/codegen/box/annotations/kt58007.kt");
+        }
+
         @TestMetadata("mustBeDocumented.kt")
         public void testMustBeDocumented() throws Exception {
             runTest("compiler/testData/codegen/box/annotations/mustBeDocumented.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/JsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/JsCodegenBoxTestGenerated.java
@@ -48,6 +48,12 @@ public class JsCodegenBoxTestGenerated extends AbstractJsCodegenBoxTest {
         }
 
         @Test
+        @TestMetadata("kt58007.kt")
+        public void testKt58007() throws Exception {
+            runTest("compiler/testData/codegen/box/annotations/kt58007.kt");
+        }
+
+        @Test
         @TestMetadata("nestedAnnotation.kt")
         public void testNestedAnnotation() throws Exception {
             runTest("compiler/testData/codegen/box/annotations/nestedAnnotation.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/fir/FirJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/fir/FirJsCodegenBoxTestGenerated.java
@@ -48,6 +48,12 @@ public class FirJsCodegenBoxTestGenerated extends AbstractFirJsCodegenBoxTest {
         }
 
         @Test
+        @TestMetadata("kt58007.kt")
+        public void testKt58007() throws Exception {
+            runTest("compiler/testData/codegen/box/annotations/kt58007.kt");
+        }
+
+        @Test
         @TestMetadata("nestedAnnotation.kt")
         public void testNestedAnnotation() throws Exception {
             runTest("compiler/testData/codegen/box/annotations/nestedAnnotation.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/IrJsCodegenBoxTestGenerated.java
@@ -48,6 +48,12 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
         }
 
         @Test
+        @TestMetadata("kt58007.kt")
+        public void testKt58007() throws Exception {
+            runTest("compiler/testData/codegen/box/annotations/kt58007.kt");
+        }
+
+        @Test
         @TestMetadata("nestedAnnotation.kt")
         public void testNestedAnnotation() throws Exception {
             runTest("compiler/testData/codegen/box/annotations/nestedAnnotation.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/IrJsES6CodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/IrJsES6CodegenBoxTestGenerated.java
@@ -48,6 +48,12 @@ public class IrJsES6CodegenBoxTestGenerated extends AbstractIrJsES6CodegenBoxTes
         }
 
         @Test
+        @TestMetadata("kt58007.kt")
+        public void testKt58007() throws Exception {
+            runTest("compiler/testData/codegen/box/annotations/kt58007.kt");
+        }
+
+        @Test
         @TestMetadata("nestedAnnotation.kt")
         public void testNestedAnnotation() throws Exception {
             runTest("compiler/testData/codegen/box/annotations/nestedAnnotation.kt");

--- a/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/FirNativeCodegenBoxTestGenerated.java
+++ b/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/FirNativeCodegenBoxTestGenerated.java
@@ -59,6 +59,12 @@ public class FirNativeCodegenBoxTestGenerated extends AbstractNativeCodegenBoxTe
             }
 
             @Test
+            @TestMetadata("kt58007.kt")
+            public void testKt58007() throws Exception {
+                runTest("compiler/testData/codegen/box/annotations/kt58007.kt");
+            }
+
+            @Test
             @TestMetadata("nestedAnnotation.kt")
             public void testNestedAnnotation() throws Exception {
                 runTest("compiler/testData/codegen/box/annotations/nestedAnnotation.kt");

--- a/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/FirNativeCodegenBoxTestNoPLGenerated.java
+++ b/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/FirNativeCodegenBoxTestNoPLGenerated.java
@@ -65,6 +65,12 @@ public class FirNativeCodegenBoxTestNoPLGenerated extends AbstractNativeCodegenB
             }
 
             @Test
+            @TestMetadata("kt58007.kt")
+            public void testKt58007() throws Exception {
+                runTest("compiler/testData/codegen/box/annotations/kt58007.kt");
+            }
+
+            @Test
             @TestMetadata("nestedAnnotation.kt")
             public void testNestedAnnotation() throws Exception {
                 runTest("compiler/testData/codegen/box/annotations/nestedAnnotation.kt");

--- a/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/NativeCodegenBoxTestGenerated.java
+++ b/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/NativeCodegenBoxTestGenerated.java
@@ -57,6 +57,12 @@ public class NativeCodegenBoxTestGenerated extends AbstractNativeCodegenBoxTest 
             }
 
             @Test
+            @TestMetadata("kt58007.kt")
+            public void testKt58007() throws Exception {
+                runTest("compiler/testData/codegen/box/annotations/kt58007.kt");
+            }
+
+            @Test
             @TestMetadata("nestedAnnotation.kt")
             public void testNestedAnnotation() throws Exception {
                 runTest("compiler/testData/codegen/box/annotations/nestedAnnotation.kt");

--- a/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/NativeCodegenBoxTestNoPLGenerated.java
+++ b/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/NativeCodegenBoxTestNoPLGenerated.java
@@ -60,6 +60,12 @@ public class NativeCodegenBoxTestNoPLGenerated extends AbstractNativeCodegenBoxT
             }
 
             @Test
+            @TestMetadata("kt58007.kt")
+            public void testKt58007() throws Exception {
+                runTest("compiler/testData/codegen/box/annotations/kt58007.kt");
+            }
+
+            @Test
             @TestMetadata("nestedAnnotation.kt")
             public void testNestedAnnotation() throws Exception {
                 runTest("compiler/testData/codegen/box/annotations/nestedAnnotation.kt");

--- a/wasm/wasm.tests/tests-gen/org/jetbrains/kotlin/wasm/test/IrCodegenBoxWasmTestGenerated.java
+++ b/wasm/wasm.tests/tests-gen/org/jetbrains/kotlin/wasm/test/IrCodegenBoxWasmTestGenerated.java
@@ -53,6 +53,11 @@ public class IrCodegenBoxWasmTestGenerated extends AbstractIrCodegenBoxWasmTest 
             runTest("compiler/testData/codegen/box/annotations/genericAnnotations.kt");
         }
 
+        @TestMetadata("kt58007.kt")
+        public void testKt58007() throws Exception {
+            runTest("compiler/testData/codegen/box/annotations/kt58007.kt");
+        }
+
         @TestMetadata("nestedAnnotation.kt")
         public void testNestedAnnotation() throws Exception {
             runTest("compiler/testData/codegen/box/annotations/nestedAnnotation.kt");


### PR DESCRIPTION
issue: [KT-58007](https://youtrack.jetbrains.com/issue/KT-58007/K2-Unsupported-compile-time-value-GETFIELD-FIELD-PROPERTYBACKINGFIELD-when-const-value-is-default-for-annotation)