### PR TITLE
Uncomment `binarySearchBy` overload taking a `Comparator`

### DIFF
--- a/libraries/stdlib/src/kotlin/collections/Collections.kt
+++ b/libraries/stdlib/src/kotlin/collections/Collections.kt
@@ -350,8 +350,6 @@ public fun <T : Comparable<T>> List<T?>.binarySearch(element: T?, fromIndex: Int
  *
  * If the list contains multiple elements equal to the specified [element], there is no guarantee which one will be found.
  *
- * `null` value is considered to be less than any non-null value.
- *
  * @return the index of the element, if it is contained in the list within the specified range;
  * otherwise, the inverted insertion point `(-insertion point - 1)`.
  * The insertion point is defined as the index at which the element should be inserted,


### PR DESCRIPTION
- ~~provided the link to the related issue(s) from YouTrack~~ N/A
- [x] made a reasonable amount of changes related only to the provided issues
- [x] can explain changes made in the pull request
	- I was looking for this overload and noticed the comment upon jumping to the source of another overload. Turns out it's as old as the initial implementation. Having this overload in the standard library "completes the family", and it's useful to at least me. I'm rolling my own copy with the same implementation for now.
- [ ] ran the build locally and verified new functionality
- [ ] ran related tests locally and they passed
- [x] do not have merge commits in the pull request