### PR TITLE
simplify reference to IrFactory

### DIFF
--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/IrBuiltInsOverFir.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/IrBuiltInsOverFir.kt
@@ -46,7 +46,7 @@ class IrBuiltInsOverFir(
     private val tryLoadBuiltInsFirst: Boolean = false
 ) : IrBuiltIns() {
 
-    override val irFactory: IrFactory = components.symbolTable.irFactory
+    override val irFactory: IrFactory = components.irFactory
 
     private val kotlinPackage = StandardClassIds.BASE_KOTLIN_PACKAGE
     private val kotlinInternalPackage = StandardClassIds.BASE_INTERNAL_PACKAGE


### PR DESCRIPTION
`irFactory` referenced in `symbolTable` is the same as the `irFactory` in `components`
both of them reference to `IrFactoryImpl` object