### PR TITLE
Update samples for buildMap and buildSet

### DIFF
--- a/libraries/stdlib/samples/test/samples/collections/builders.kt
+++ b/libraries/stdlib/samples/test/samples/collections/builders.kt
@@ -9,7 +9,7 @@ class Builders {
         fun buildListSample() {
             val x = listOf('b', 'c')
 
-            val y = buildList() {
+            val y = buildList {
                 add('a')
                 addAll(x)
                 add('d')
@@ -37,6 +37,19 @@ class Builders {
         fun buildSetSample() {
             val x = setOf('a', 'b')
 
+            val y = buildSet {
+                add('b')
+                addAll(x)
+                add('c')
+            }
+
+            assertPrints(y, "[b, a, c]")
+        }
+
+        @Sample
+        fun buildSetSampleWithCapacity() {
+            val x = setOf('a', 'b')
+
             val y = buildSet(x.size + 2) {
                 add('b')
                 addAll(x)
@@ -50,6 +63,20 @@ class Builders {
     class Maps {
         @Sample
         fun buildMapSample() {
+            val x = mapOf('b' to 2, 'c' to 3)
+
+            val y = buildMap<Char, Int> {
+                put('a', 1)
+                put('c', 0)
+                putAll(x)
+                put('d', 4)
+            }
+
+            assertPrints(y, "{a=1, c=3, b=2, d=4}")
+        }
+
+        @Sample
+        fun buildMapSampleWithCapacity() {
             val x = mapOf('b' to 2, 'c' to 3)
 
             val y = buildMap<Char, Int>(x.size + 2) {

--- a/libraries/stdlib/src/kotlin/collections/Maps.kt
+++ b/libraries/stdlib/src/kotlin/collections/Maps.kt
@@ -176,7 +176,7 @@ internal expect inline fun <K, V> buildMapInternal(builderAction: MutableMap<K, 
  *
  * @throws IllegalArgumentException if the given [capacity] is negative.
  *
- * @sample samples.collections.Builders.Maps.buildMapSample
+ * @sample samples.collections.Builders.Maps.buildMapSampleWithCapacity
  */
 @SinceKotlin("1.6")
 @WasExperimental(ExperimentalStdlibApi::class)

--- a/libraries/stdlib/src/kotlin/collections/Sets.kt
+++ b/libraries/stdlib/src/kotlin/collections/Sets.kt
@@ -161,7 +161,7 @@ internal expect inline fun <E> buildSetInternal(builderAction: MutableSet<E>.() 
  *
  * @throws IllegalArgumentException if the given [capacity] is negative.
  *
- * @sample samples.collections.Builders.Sets.buildSetSample
+ * @sample samples.collections.Builders.Sets.buildSetSampleWithCapacity
  */
 @SinceKotlin("1.6")
 @WasExperimental(ExperimentalStdlibApi::class)


### PR DESCRIPTION
The samples for buildMap and buildSet are updated to have two versions: with capacity parameter, and without it.