### PR TITLE
Fix error message for `-Xjspecify-annotations`.

### DIFF
--- a/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/arguments/JavaTypeEnhancementStateParser.kt
+++ b/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/arguments/JavaTypeEnhancementStateParser.kt
@@ -109,7 +109,7 @@ class JavaTypeEnhancementStateParser(
         if (reportLevel == null) {
             collector.report(
                 CompilerMessageSeverity.ERROR,
-                "Unrecognized -Xjspecify-annotations option: $jspecifyState. Possible values are 'disable'/'warn'/'strict'"
+                "Unrecognized -Xjspecify-annotations option: $jspecifyState. Possible values are 'ignore'/'warn'/'strict'"
             )
             return getReportLevelForAnnotation(JSPECIFY_ANNOTATIONS_PACKAGE, nullabilityAnnotationReportLevels, kotlinVersion)
         }


### PR DESCRIPTION
The message currently claims that you can pass the value "disable," but
in fact the value it means is "ignore."
