### PR TITLE
[K/N] Fix Boolean bridge

### DIFF
--- a/kotlin-native/backend.native/tests/objcexport/values.swift
+++ b/kotlin-native/backend.native/tests/objcexport/values.swift
@@ -85,6 +85,7 @@ func testNumbers() throws {
     try assertEquals(actual: KotlinBoolean(value: false).intValue, expected: 0)
     try assertEquals(actual: KotlinBoolean(value: true), expected: true)
     try assertFalse(KotlinBoolean(value: false) as! Bool)
+    try assertTrue(CFGetTypeID(KotlinBoolean(value: true)) == CFBooleanGetTypeID())
 
     try assertEquals(actual: KotlinByte(value: -1).int8Value, expected: -1)
     try assertEquals(actual: KotlinByte(value: -1).int32Value, expected: -1)

--- a/kotlin-native/runtime/src/objc/cpp/ObjCExportNumbers.mm
+++ b/kotlin-native/runtime/src/objc/cpp/ObjCExportNumbers.mm
@@ -150,6 +150,10 @@ private fun genBoolean(): String = """
   return "c";
 }
 
+- (CFTypeID)_cfTypeID {
+  return CFBooleanGetTypeID();
+}
+
 -(ObjHeader*)toKotlin:(ObjHeader**)OBJ_RESULT {
   RETURN_RESULT_OF(Kotlin_boxBoolean, value_);
 }
@@ -308,6 +312,10 @@ ${if (cType != "double") """
 
 - (const char *)objCType {
   return "c";
+}
+
+- (CFTypeID)_cfTypeID {
+  return CFBooleanGetTypeID();
 }
 
 -(ObjHeader*)toKotlin:(ObjHeader**)OBJ_RESULT {


### PR DESCRIPTION
Fixes #KT-45781

Boolean is exported to Objective-C as `KotlinBoolean` successor of `NSNumber`. 

In this case, the attribute it was a number or `Boolean` is lost.

```swift
let parameters: [String: Any] = parametersFromKotlin() // mapOf("flag" to true)
let data = try JSONSerialization.data(withJSONObject: parameters)
let string = String(data: data, encoding: .utf8)!
// {"flag":1}
```

## Solution

For the solution, a private method is implemented as in Swift [NSCFBoolean](https://github.com/apple/swift-corelibs-foundation/blob/main/Sources/Foundation/NSCFBoolean.swift#L74)

## Workaround

As a temporary solution, you can add a `KotlinBoolean` extension to your code

```swift
extension KotlinBoolean {
    @objc public var _cfTypeID: CFTypeID { 
        return CFBooleanGetTypeID() 
    }
}
```

```swift
let parameters: [String: Any] = parametersFromKotlin() // mapOf("flag" to true)
let data = try JSONSerialization.data(withJSONObject: parameters)
let string = String(data: data, encoding: .utf8)!
// {"flag":true}
```