### PR TITLE
fix: Fix memory leak in ZipImplementation with`-Xuse-fast-jar-file-system`

### DIFF
--- a/compiler/cli/cli-base/src/org/jetbrains/kotlin/cli/jvm/compiler/jarfs/ZipImplementation.kt
+++ b/compiler/cli/cli-base/src/org/jetbrains/kotlin/cli/jvm/compiler/jarfs/ZipImplementation.kt
@@ -53,6 +53,7 @@ fun MappedByteBuffer.contentsToByteArray(
             val result = ByteArray(zipEntryDescription.uncompressedSize)
 
             inflater.inflate(result)
+            inflater.end()
 
             result
         }


### PR DESCRIPTION
When using the compiler with `-Xuse-fast-jar-file-system` enabled, the compiler causes memory leak in ZipImplementation class at MappedByteBuffer.contentsToByteArray method since the Inflater used to inflate zip/jar files, isn't released/ended after the task.