### PR TITLE
Add StandWithUkraine banner

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,3 +1,4 @@
+[![Stand With Ukraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/banner2-direct.svg)](https://stand-with-ukraine.pp.ua)
 [![official project](https://jb.gg/badges/official.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub)
 [![TeamCity (simple build status)](https://img.shields.io/teamcity/http/teamcity.jetbrains.com/s/Kotlin_KotlinPublic_Compiler.svg)](https://teamcity.jetbrains.com/buildConfiguration/Kotlin_KotlinPublic_Compiler?branch=%3Cdefault%3E&buildTypeTab=overview&mode=builds)
 [![Maven Central](https://img.shields.io/maven-central/v/org.jetbrains.kotlin/kotlin-maven-plugin.svg)](https://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.jetbrains.kotlin%22)


### PR DESCRIPTION
This commit adds a banner to the README.md file to show support for Ukraine in its struggle against Russian aggression. The banner links to a website that provides information and resources on how to stand with Ukraine and help its people defend their sovereignty and democracy. The banner is a simple and effective way to raise awareness and solidarity among the GitHub community and beyond. I hope you will accept this pull request and join me in standing with Ukraine. Thank you.