### PR TITLE
Add StandWithUkraine badge

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -3,6 +3,8 @@
 [![Maven Central](https://img.shields.io/maven-central/v/org.jetbrains.kotlin/kotlin-maven-plugin.svg)](https://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.jetbrains.kotlin%22)
 [![GitHub license](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Revved up by Gradle Enterprise](https://img.shields.io/badge/Revved%20up%20by-Gradle%20Enterprise-06A0CE?logo=Gradle&labelColor=02303A)](https://ge.jetbrains.com/scans?search.rootProjectNames=Kotlin)
+[![Stand With Ukraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg)](https://stand-with-ukraine.pp.ua)
+
 
 # Kotlin Programming Language
 


### PR DESCRIPTION
This commit adds a badge to the README.md file to show support for Ukraine in its struggle against Russian aggression. The badge links to a website that provides information and resources on how to stand with Ukraine and help its people defend their sovereignty and democracy. The badge is a simple and effective way to raise awareness and solidarity among the GitHub community and beyond. I hope you will accept this pull request and join me in standing with Ukraine. Thank you.