### PR TITLE
JVM Inline: Don't regenerate anonymous object if transformations are empty

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInliner.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInliner.kt
@@ -215,7 +215,11 @@ class MethodInliner(
 
             override fun anew(type: Type) {
                 if (isSamWrapper(type.internalName) || isAnonymousClass(type.internalName)) {
-                    handleAnonymousObjectRegeneration()
+                    if (transformations.isNotEmpty()) {
+                        handleAnonymousObjectRegeneration()
+                    } else {
+                        result.addNotChangedClass(type.internalName)
+                    }
                 }
 
                 //in case of regenerated transformationInfo type would be remapped to new one via remappingMethodAdapter

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirLightTreeBlackBoxInlineCodegenWithBytecodeInlinerTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirLightTreeBlackBoxInlineCodegenWithBytecodeInlinerTestGenerated.java
@@ -399,6 +399,12 @@ public class FirLightTreeBlackBoxInlineCodegenWithBytecodeInlinerTestGenerated e
         }
 
         @Test
+        @TestMetadata("kt57512.kt")
+        public void testKt57512() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt57512.kt");
+        }
+
+        @Test
         @TestMetadata("kt6007.kt")
         public void testKt6007() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt6007.kt");

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirLightTreeBlackBoxInlineCodegenWithIrInlinerTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirLightTreeBlackBoxInlineCodegenWithIrInlinerTestGenerated.java
@@ -399,6 +399,12 @@ public class FirLightTreeBlackBoxInlineCodegenWithIrInlinerTestGenerated extends
         }
 
         @Test
+        @TestMetadata("kt57512.kt")
+        public void testKt57512() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt57512.kt");
+        }
+
+        @Test
         @TestMetadata("kt6007.kt")
         public void testKt6007() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt6007.kt");

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirLightTreeSerializeCompileKotlinAgainstInlineKotlinTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirLightTreeSerializeCompileKotlinAgainstInlineKotlinTestGenerated.java
@@ -399,6 +399,12 @@ public class FirLightTreeSerializeCompileKotlinAgainstInlineKotlinTestGenerated 
         }
 
         @Test
+        @TestMetadata("kt57512.kt")
+        public void testKt57512() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt57512.kt");
+        }
+
+        @Test
         @TestMetadata("kt6007.kt")
         public void testKt6007() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt6007.kt");

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirPsiBlackBoxInlineCodegenWithBytecodeInlinerTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirPsiBlackBoxInlineCodegenWithBytecodeInlinerTestGenerated.java
@@ -399,6 +399,12 @@ public class FirPsiBlackBoxInlineCodegenWithBytecodeInlinerTestGenerated extends
         }
 
         @Test
+        @TestMetadata("kt57512.kt")
+        public void testKt57512() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt57512.kt");
+        }
+
+        @Test
         @TestMetadata("kt6007.kt")
         public void testKt6007() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt6007.kt");

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirPsiBlackBoxInlineCodegenWithIrInlinerTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirPsiBlackBoxInlineCodegenWithIrInlinerTestGenerated.java
@@ -399,6 +399,12 @@ public class FirPsiBlackBoxInlineCodegenWithIrInlinerTestGenerated extends Abstr
         }
 
         @Test
+        @TestMetadata("kt57512.kt")
+        public void testKt57512() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt57512.kt");
+        }
+
+        @Test
         @TestMetadata("kt6007.kt")
         public void testKt6007() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt6007.kt");

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirPsiSerializeCompileKotlinAgainstInlineKotlinTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirPsiSerializeCompileKotlinAgainstInlineKotlinTestGenerated.java
@@ -399,6 +399,12 @@ public class FirPsiSerializeCompileKotlinAgainstInlineKotlinTestGenerated extend
         }
 
         @Test
+        @TestMetadata("kt57512.kt")
+        public void testKt57512() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt57512.kt");
+        }
+
+        @Test
         @TestMetadata("kt6007.kt")
         public void testKt6007() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt6007.kt");

--- a/compiler/testData/codegen/boxInline/anonymousObject/kt57512.kt
+++ b/compiler/testData/codegen/boxInline/anonymousObject/kt57512.kt
@@ -1,0 +1,16 @@
+// IGNORE_BACKEND: JS
+// WITH_STDLIB
+
+// FILE: 1.kt
+inline fun test() {
+    val localX = (TODO() as String)::plus
+}
+
+// FILE: 2.kt
+fun box(): String {
+    try {
+        test()
+    } catch (e: NotImplementedError) {
+    }
+    return "OK"
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxInlineCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxInlineCodegenTestGenerated.java
@@ -399,6 +399,12 @@ public class BlackBoxInlineCodegenTestGenerated extends AbstractBlackBoxInlineCo
         }
 
         @Test
+        @TestMetadata("kt57512.kt")
+        public void testKt57512() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt57512.kt");
+        }
+
+        @Test
         @TestMetadata("kt6007.kt")
         public void testKt6007() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt6007.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/CompileKotlinAgainstInlineKotlinTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/CompileKotlinAgainstInlineKotlinTestGenerated.java
@@ -399,6 +399,12 @@ public class CompileKotlinAgainstInlineKotlinTestGenerated extends AbstractCompi
         }
 
         @Test
+        @TestMetadata("kt57512.kt")
+        public void testKt57512() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt57512.kt");
+        }
+
+        @Test
         @TestMetadata("kt6007.kt")
         public void testKt6007() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt6007.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxInlineCodegenWithBytecodeInlinerTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxInlineCodegenWithBytecodeInlinerTestGenerated.java
@@ -399,6 +399,12 @@ public class IrBlackBoxInlineCodegenWithBytecodeInlinerTestGenerated extends Abs
         }
 
         @Test
+        @TestMetadata("kt57512.kt")
+        public void testKt57512() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt57512.kt");
+        }
+
+        @Test
         @TestMetadata("kt6007.kt")
         public void testKt6007() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt6007.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxInlineCodegenWithIrInlinerTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxInlineCodegenWithIrInlinerTestGenerated.java
@@ -399,6 +399,12 @@ public class IrBlackBoxInlineCodegenWithIrInlinerTestGenerated extends AbstractI
         }
 
         @Test
+        @TestMetadata("kt57512.kt")
+        public void testKt57512() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt57512.kt");
+        }
+
+        @Test
         @TestMetadata("kt6007.kt")
         public void testKt6007() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt6007.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrCompileKotlinAgainstInlineKotlinTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrCompileKotlinAgainstInlineKotlinTestGenerated.java
@@ -399,6 +399,12 @@ public class IrCompileKotlinAgainstInlineKotlinTestGenerated extends AbstractIrC
         }
 
         @Test
+        @TestMetadata("kt57512.kt")
+        public void testKt57512() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt57512.kt");
+        }
+
+        @Test
         @TestMetadata("kt6007.kt")
         public void testKt6007() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt6007.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrSerializeCompileKotlinAgainstInlineKotlinTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrSerializeCompileKotlinAgainstInlineKotlinTestGenerated.java
@@ -399,6 +399,12 @@ public class IrSerializeCompileKotlinAgainstInlineKotlinTestGenerated extends Ab
         }
 
         @Test
+        @TestMetadata("kt57512.kt")
+        public void testKt57512() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt57512.kt");
+        }
+
+        @Test
         @TestMetadata("kt6007.kt")
         public void testKt6007() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt6007.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/JvmIrAgainstOldBoxInlineTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/JvmIrAgainstOldBoxInlineTestGenerated.java
@@ -399,6 +399,12 @@ public class JvmIrAgainstOldBoxInlineTestGenerated extends AbstractJvmIrAgainstO
         }
 
         @Test
+        @TestMetadata("kt57512.kt")
+        public void testKt57512() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt57512.kt");
+        }
+
+        @Test
         @TestMetadata("kt6007.kt")
         public void testKt6007() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt6007.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/JvmOldAgainstIrBoxInlineTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/JvmOldAgainstIrBoxInlineTestGenerated.java
@@ -399,6 +399,12 @@ public class JvmOldAgainstIrBoxInlineTestGenerated extends AbstractJvmOldAgainst
         }
 
         @Test
+        @TestMetadata("kt57512.kt")
+        public void testKt57512() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt57512.kt");
+        }
+
+        @Test
         @TestMetadata("kt6007.kt")
         public void testKt6007() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt6007.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/fir/FirJsCodegenInlineTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/fir/FirJsCodegenInlineTestGenerated.java
@@ -357,6 +357,12 @@ public class FirJsCodegenInlineTestGenerated extends AbstractFirJsCodegenInlineT
         }
 
         @Test
+        @TestMetadata("kt57512.kt")
+        public void testKt57512() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt57512.kt");
+        }
+
+        @Test
         @TestMetadata("kt6007.kt")
         public void testKt6007() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt6007.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/IrJsCodegenInlineTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/IrJsCodegenInlineTestGenerated.java
@@ -357,6 +357,12 @@ public class IrJsCodegenInlineTestGenerated extends AbstractIrJsCodegenInlineTes
         }
 
         @Test
+        @TestMetadata("kt57512.kt")
+        public void testKt57512() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt57512.kt");
+        }
+
+        @Test
         @TestMetadata("kt6007.kt")
         public void testKt6007() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt6007.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/IrJsES6CodegenInlineTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/IrJsES6CodegenInlineTestGenerated.java
@@ -357,6 +357,12 @@ public class IrJsES6CodegenInlineTestGenerated extends AbstractIrJsES6CodegenInl
         }
 
         @Test
+        @TestMetadata("kt57512.kt")
+        public void testKt57512() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt57512.kt");
+        }
+
+        @Test
         @TestMetadata("kt6007.kt")
         public void testKt6007() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt6007.kt");

--- a/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/FirNativeCodegenBoxTestGenerated.java
+++ b/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/FirNativeCodegenBoxTestGenerated.java
@@ -41057,6 +41057,12 @@ public class FirNativeCodegenBoxTestGenerated extends AbstractNativeCodegenBoxTe
             }
 
             @Test
+            @TestMetadata("kt57512.kt")
+            public void testKt57512() throws Exception {
+                runTest("compiler/testData/codegen/boxInline/anonymousObject/kt57512.kt");
+            }
+
+            @Test
             @TestMetadata("kt6007.kt")
             public void testKt6007() throws Exception {
                 runTest("compiler/testData/codegen/boxInline/anonymousObject/kt6007.kt");

--- a/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/FirNativeCodegenBoxTestNoPLGenerated.java
+++ b/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/FirNativeCodegenBoxTestNoPLGenerated.java
@@ -42101,6 +42101,12 @@ public class FirNativeCodegenBoxTestNoPLGenerated extends AbstractNativeCodegenB
             }
 
             @Test
+            @TestMetadata("kt57512.kt")
+            public void testKt57512() throws Exception {
+                runTest("compiler/testData/codegen/boxInline/anonymousObject/kt57512.kt");
+            }
+
+            @Test
             @TestMetadata("kt6007.kt")
             public void testKt6007() throws Exception {
                 runTest("compiler/testData/codegen/boxInline/anonymousObject/kt6007.kt");

--- a/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/NativeCodegenBoxTestGenerated.java
+++ b/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/NativeCodegenBoxTestGenerated.java
@@ -40536,6 +40536,12 @@ public class NativeCodegenBoxTestGenerated extends AbstractNativeCodegenBoxTest 
             }
 
             @Test
+            @TestMetadata("kt57512.kt")
+            public void testKt57512() throws Exception {
+                runTest("compiler/testData/codegen/boxInline/anonymousObject/kt57512.kt");
+            }
+
+            @Test
             @TestMetadata("kt6007.kt")
             public void testKt6007() throws Exception {
                 runTest("compiler/testData/codegen/boxInline/anonymousObject/kt6007.kt");

--- a/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/NativeCodegenBoxTestNoPLGenerated.java
+++ b/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/blackboxtest/NativeCodegenBoxTestNoPLGenerated.java
@@ -41058,6 +41058,12 @@ public class NativeCodegenBoxTestNoPLGenerated extends AbstractNativeCodegenBoxT
             }
 
             @Test
+            @TestMetadata("kt57512.kt")
+            public void testKt57512() throws Exception {
+                runTest("compiler/testData/codegen/boxInline/anonymousObject/kt57512.kt");
+            }
+
+            @Test
             @TestMetadata("kt6007.kt")
             public void testKt6007() throws Exception {
                 runTest("compiler/testData/codegen/boxInline/anonymousObject/kt6007.kt");

--- a/wasm/wasm.tests/tests-gen/org/jetbrains/kotlin/wasm/test/FirWasmCodegenBoxInlineTestGenerated.java
+++ b/wasm/wasm.tests/tests-gen/org/jetbrains/kotlin/wasm/test/FirWasmCodegenBoxInlineTestGenerated.java
@@ -357,6 +357,12 @@ public class FirWasmCodegenBoxInlineTestGenerated extends AbstractFirWasmCodegen
         }
 
         @Test
+        @TestMetadata("kt57512.kt")
+        public void testKt57512() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt57512.kt");
+        }
+
+        @Test
         @TestMetadata("kt6007.kt")
         public void testKt6007() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt6007.kt");

--- a/wasm/wasm.tests/tests-gen/org/jetbrains/kotlin/wasm/test/K1WasmCodegenBoxInlineTestGenerated.java
+++ b/wasm/wasm.tests/tests-gen/org/jetbrains/kotlin/wasm/test/K1WasmCodegenBoxInlineTestGenerated.java
@@ -357,6 +357,12 @@ public class K1WasmCodegenBoxInlineTestGenerated extends AbstractK1WasmCodegenBo
         }
 
         @Test
+        @TestMetadata("kt57512.kt")
+        public void testKt57512() throws Exception {
+            runTest("compiler/testData/codegen/boxInline/anonymousObject/kt57512.kt");
+        }
+
+        @Test
         @TestMetadata("kt6007.kt")
         public void testKt6007() throws Exception {
             runTest("compiler/testData/codegen/boxInline/anonymousObject/kt6007.kt");


### PR DESCRIPTION
Take the box test as example, no transformations are recorded after function `test` is analyzed by `analyzeMethodNodeWithInterpreter`, because there is no `frame` in `sources` after instruction `throw`.

Fix [#KT-57512](https://youtrack.jetbrains.com/issue/KT-57512/NoSuchElementException-with-Array-extension-function-with-cast)