### PR TITLE
Changes inside Js's DCE & IR dumps

### DIFF
--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/dce/UsefulDeclarationProcessor.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/dce/UsefulDeclarationProcessor.kt
@@ -333,5 +333,5 @@ private fun transformToJsonString(reachabilityInfos: List<ReachabilityInfo>): St
 }
 
 private fun transformToJsConstDeclaration(reachabilityInfos: List<ReachabilityInfo>): String {
-    return "const kotlinReachabilityInfos = " + transformToJsonString(reachabilityInfos) + ";"
+    return "export const kotlinReachabilityInfos = " + transformToJsonString(reachabilityInfos) + ";"
 }

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/dce/UsefulDeclarationProcessor.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/dce/UsefulDeclarationProcessor.kt
@@ -324,9 +324,9 @@ private fun transformToJsonString(reachabilityInfos: List<ReachabilityInfo>): St
     return "[\n" + transformToStringBy(reachabilityInfos, ",\n") { sourceFqn, targetFqn, description, isTargetContagious ->
         """
         |    {
-        |        "source" : "$sourceFqn",
-        |        "target" : "$targetFqn",
-        |        "description" : "$description",
+        |        "source" : "${sourceFqn.removeQuotes()}",
+        |        "target" : "${targetFqn.removeQuotes()}",
+        |        "description" : "${description.removeQuotes()}",
         |        "isTargetContagious" : $isTargetContagious
         |    }""".trimMargin()
     } + "\n]"

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/dce/utils.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/dce/utils.kt
@@ -60,7 +60,7 @@ fun dumpDeclarationIrSizesIfNeed(path: String?, allModules: List<IrModuleFragmen
     val out = File(path)
     val (prefix, postfix, separator, indent) = when (out.extension) {
         "json" -> listOf("{\n", "\n}", ",\n", "    ")
-        "js" -> listOf("const kotlinDeclarationsSize = {\n", "\n};\n", ",\n", "    ")
+        "js" -> listOf("export const kotlinDeclarationsSize = {\n", "\n};\n", ",\n", "    ")
         else -> listOf("", "", "\n", "")
     }
 

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/dce/utils.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/dce/utils.kt
@@ -48,7 +48,6 @@ fun dumpDeclarationIrSizesIfNeed(path: String?, allModules: List<IrModuleFragmen
                     is IrProperty -> "property"
                     is IrField -> "field"
                     is IrAnonymousInitializer -> "anonymous initializer"
-                    is IrClass -> "class"
                     else -> null
                 }
                 type?.let {


### PR DESCRIPTION
Changes:

- Quotes and backslashes now escaped and do not break json format
- Added a type field for IR dump. This has added more context for analyzing