### PR TITLE
KAPT3: Move to use reflection to access JDK8 APIs to Support Java 9+ Builds

### DIFF
--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/annotationProcessing.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/annotationProcessing.kt
@@ -56,11 +56,11 @@ fun KaptContext.doAnnotationProcessing(
             return
         }
 
+        val initProcessAnnotationsMethod = JavaCompiler::class.java.declaredMethods.single { it.name == "initProcessAnnotations" }
         if (isJava9OrLater()) {
-            val initProcessAnnotationsMethod = JavaCompiler::class.java.declaredMethods.single { it.name == "initProcessAnnotations" }
             initProcessAnnotationsMethod.invoke(compiler, wrappedProcessors, emptyList<JavaFileObject>(), emptyList<String>())
         } else {
-            compiler.initProcessAnnotations(wrappedProcessors)
+            initProcessAnnotationsMethod.invoke(compiler, wrappedProcessors)
         }
 
         if (logger.isVerbose) {
@@ -90,7 +90,9 @@ fun KaptContext.doAnnotationProcessing(
                 processAnnotationsMethod.invoke(compiler, analyzedFiles, additionalClassNames)
                 compiler
             } else {
-                compiler.processAnnotations(analyzedFiles, additionalClassNames)
+                val processAnnotationsMethod =
+                    compiler.javaClass.getMethod("processAnnotations", JavacList::class.java, JavacList::class.java)
+                processAnnotationsMethod.invoke(compiler, analyzedFiles, additionalClassNames) as JavaCompiler
             }
         } catch (e: AnnotationProcessingError) {
             throw KaptBaseError(KaptBaseError.Kind.EXCEPTION, e.cause ?: e)

--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/annotationProcessing.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/annotationProcessing.kt
@@ -56,11 +56,11 @@ fun KaptContext.doAnnotationProcessing(
             return
         }
 
-        val initProcessAnnotationsMethod = JavaCompiler::class.java.declaredMethods.single { it.name == "initProcessAnnotations" }
         if (isJava9OrLater()) {
+            val initProcessAnnotationsMethod = JavaCompiler::class.java.declaredMethods.single { it.name == "initProcessAnnotations" }
             initProcessAnnotationsMethod.invoke(compiler, wrappedProcessors, emptyList<JavaFileObject>(), emptyList<String>())
         } else {
-            initProcessAnnotationsMethod.invoke(compiler, wrappedProcessors)
+            compiler.initProcessAnnotations(wrappedProcessors)
         }
 
         if (logger.isVerbose) {
@@ -90,9 +90,7 @@ fun KaptContext.doAnnotationProcessing(
                 processAnnotationsMethod.invoke(compiler, analyzedFiles, additionalClassNames)
                 compiler
             } else {
-                val processAnnotationsMethod =
-                    compiler.javaClass.getMethod("processAnnotations", JavacList::class.java, JavacList::class.java)
-                processAnnotationsMethod.invoke(compiler, analyzedFiles, additionalClassNames) as JavaCompiler
+                compiler.processAnnotations(analyzedFiles, additionalClassNames)
             }
         } catch (e: AnnotationProcessingError) {
             throw KaptBaseError(KaptBaseError.Kind.EXCEPTION, e.cause ?: e)

--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/javac/KaptJavaLog.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/javac/KaptJavaLog.kt
@@ -263,7 +263,15 @@ private fun JCDiagnostic.Factory.errorJava9Aware(
 
         errorMethod.invoke(this, JCDiagnostic.DiagnosticFlag.MANDATORY, source, pos, key, args) as JCDiagnostic
     } else {
-        this.error(source, pos, key, *args)
+        val errorMethod = this::class.java.getDeclaredMethod(
+            "error",
+            DiagnosticSource::class.java,
+            JCDiagnostic.DiagnosticPosition::class.java,
+            String::class.java,
+            Array<Any>::class.java
+        )
+
+        errorMethod.invoke(this, source, pos, key, args) as JCDiagnostic
     }
 }
 

--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/javac/KaptJavaLog.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/javac/KaptJavaLog.kt
@@ -263,15 +263,7 @@ private fun JCDiagnostic.Factory.errorJava9Aware(
 
         errorMethod.invoke(this, JCDiagnostic.DiagnosticFlag.MANDATORY, source, pos, key, args) as JCDiagnostic
     } else {
-        val errorMethod = this::class.java.getDeclaredMethod(
-            "error",
-            DiagnosticSource::class.java,
-            JCDiagnostic.DiagnosticPosition::class.java,
-            String::class.java,
-            Array<Any>::class.java
-        )
-
-        errorMethod.invoke(this, source, pos, key, args) as JCDiagnostic
+        this.error(source, pos, key, *args)
     }
 }
 

--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/util/java9Utils.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/util/java9Utils.kt
@@ -52,7 +52,8 @@ fun TreeMaker.TopLevelJava9Aware(packageClause: JCTree.JCExpression?, declaratio
         val allDeclarations = if (packageDecl != null) JavacList.of(packageDecl) + declarations else declarations
         topLevelMethod.invoke(this, allDeclarations) as JCTree.JCCompilationUnit
     } else {
-        TopLevel(JavacList.nil(), packageClause, declarations)
+        val topLevelMethod = TreeMaker::class.java.declaredMethods.single { it.name == "TopLevel" }
+        topLevelMethod.invoke(this, JavacList.nil<JCTree.JCAnnotation>(), packageClause, declarations) as JCTree.JCCompilationUnit
     }
 }
 
@@ -60,6 +61,6 @@ fun JCTree.JCCompilationUnit.getPackageNameJava9Aware(): JCTree? {
     return if (isJava9OrLater()) {
         JCTree.JCCompilationUnit::class.java.getDeclaredMethod("getPackageName").invoke(this) as JCTree?
     } else {
-        this.packageName
+        this.packageName as JCTree?
     }
 }

--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/util/java9Utils.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/util/java9Utils.kt
@@ -52,8 +52,7 @@ fun TreeMaker.TopLevelJava9Aware(packageClause: JCTree.JCExpression?, declaratio
         val allDeclarations = if (packageDecl != null) JavacList.of(packageDecl) + declarations else declarations
         topLevelMethod.invoke(this, allDeclarations) as JCTree.JCCompilationUnit
     } else {
-        val topLevelMethod = TreeMaker::class.java.declaredMethods.single { it.name == "TopLevel" }
-        topLevelMethod.invoke(this, JavacList.nil<JCTree.JCAnnotation>(), packageClause, declarations) as JCTree.JCCompilationUnit
+        TopLevel(JavacList.nil(), packageClause, declarations)
     }
 }
 
@@ -61,6 +60,6 @@ fun JCTree.JCCompilationUnit.getPackageNameJava9Aware(): JCTree? {
     return if (isJava9OrLater()) {
         JCTree.JCCompilationUnit::class.java.getDeclaredMethod("getPackageName").invoke(this) as JCTree?
     } else {
-        this.packageName as JCTree?
+        this.packageName
     }
 }


### PR DESCRIPTION
- Fix [KT-59349](https://youtrack.jetbrains.com/issue/KT-59349/Kapt3-Make-KAPT-library-buildable-on-JDK9-JDK11-JDK-17)