### PR TITLE
Use RandomAccess sublist only if the AbstractList is RandomAccess

### DIFF
--- a/libraries/stdlib/src/kotlin/collections/AbstractList.kt
+++ b/libraries/stdlib/src/kotlin/collections/AbstractList.kt
@@ -32,9 +32,10 @@ public abstract class AbstractList<out E> protected constructor() : AbstractColl
 
     override fun listIterator(index: Int): ListIterator<E> = ListIteratorImpl(index)
 
-    override fun subList(fromIndex: Int, toIndex: Int): List<E> = SubList(this, fromIndex, toIndex)
+    override fun subList(fromIndex: Int, toIndex: Int): List<E> =
+        if (this is RandomAccess) RandomAccessSubList(this, fromIndex, toIndex) else SubList(this, fromIndex, toIndex)
 
-    private class SubList<out E>(private val list: AbstractList<E>, private val fromIndex: Int, toIndex: Int) : AbstractList<E>(), RandomAccess {
+    private open class SubList<out E>(private val list: AbstractList<E>, private val fromIndex: Int, toIndex: Int) : AbstractList<E>() {
         private var _size: Int = 0
 
         init {
@@ -50,6 +51,9 @@ public abstract class AbstractList<out E> protected constructor() : AbstractColl
 
         override val size: Int get() = _size
     }
+
+    private class RandomAccessSubList<out E>(list: AbstractList<E>, fromIndex: Int, toIndex: Int)
+        : SubList<E>(list, fromIndex, toIndex), RandomAccess
 
     /**
      * Compares this list with other list instance with the ordered structural equality.


### PR DESCRIPTION
AbstractList.subList() would always return a sublist that is RandomAccess, even if the AbstractList is not a RandomAccess list, due to the private class SubList. This fixes that with the added extended class RandomAccessSubList. Now subList() will return a RandomAccess subList() if this is RandomAccess.

Fixes [KT-60207](https://youtrack.jetbrains.com/issue/KT-60207)