### PR TITLE
kotlin-maven-plugin: Don't print warning on no sources to compile

### DIFF
--- a/libraries/tools/kotlin-maven-plugin/src/main/java/org/jetbrains/kotlin/maven/KotlinCompileMojoBase.java
+++ b/libraries/tools/kotlin-maven-plugin/src/main/java/org/jetbrains/kotlin/maven/KotlinCompileMojoBase.java
@@ -203,7 +203,7 @@ public abstract class KotlinCompileMojoBase<A extends CommonCompilerArguments> e
                 " (JRE " + System.getProperty("java.runtime.version") + ")");
 
         if (!hasKotlinFilesInSources()) {
-            getLog().warn("No sources found skipping Kotlin compile");
+            getLog().info("No sources found skipping Kotlin compile");
             return;
         }
 


### PR DESCRIPTION
Use `info` instead of `warn` to be more in line with the Java compiler plugin.

![image](https://github.com/JetBrains/kotlin/assets/836833/73a8ac78-c054-45d4-91af-b2c3fb65a5ed)