### PR TITLE
Add commas to number check

### DIFF
--- a/libraries/stdlib/jvm/src/kotlin/text/StringNumberConversionsJVM.kt
+++ b/libraries/stdlib/jvm/src/kotlin/text/StringNumberConversionsJVM.kt
@@ -248,11 +248,11 @@ private object ScreenFloatValueRegEx {
         val HexDigits = "(\\p{XDigit}+)"
         val Exp = "[eE][+-]?$Digits"
 
-        val HexString = "(0[xX]$HexDigits(\\.)?)|" + // 0[xX] HexDigits ._opt BinaryExponent FloatTypeSuffix_opt
-                "(0[xX]$HexDigits?(\\.)$HexDigits)"  // 0[xX] HexDigits_opt . HexDigits BinaryExponent FloatTypeSuffix_opt
+        val HexString = "(0[xX]$HexDigits(\\.|,)?)|" + // 0[xX] HexDigits ._opt BinaryExponent FloatTypeSuffix_opt
+                "(0[xX]$HexDigits?(\\.|,)$HexDigits)"  // 0[xX] HexDigits_opt . HexDigits BinaryExponent FloatTypeSuffix_opt
 
-        val Number = "($Digits(\\.)?($Digits?)($Exp)?)|" +  // Digits ._opt Digits_opt ExponentPart_opt FloatTypeSuffix_opt
-                "(\\.($Digits)($Exp)?)|" +                  // . Digits ExponentPart_opt FloatTypeSuffix_opt
+        val Number = "($Digits(\\.|,)?($Digits?)($Exp)?)|" +  // Digits ._opt Digits_opt ExponentPart_opt FloatTypeSuffix_opt
+                "((\\.|,)($Digits)($Exp)?)|" +                  // . Digits ExponentPart_opt FloatTypeSuffix_opt
                 "(($HexString)[pP][+-]?$Digits)"            // HexSignificand BinaryExponent
 
         val fpRegex = "[\\x00-\\x20]*[+-]?(NaN|Infinity|(($Number)[fFdD]?))[\\x00-\\x20]*"


### PR DESCRIPTION
The current implementation does not provide that in some languages ​​floating-point numbers are written not with a dot, but with a comma