### PR TITLE
use-yieldAll-and-yield

### DIFF
--- a/libraries/stdlib/common/src/generated/_Sequences.kt
+++ b/libraries/stdlib/common/src/generated/_Sequences.kt
@@ -2722,7 +2722,7 @@ public inline fun <T> Sequence<T>.partition(predicate: (T) -> Boolean): Pair<Lis
  * The operation is _intermediate_ and _stateless_.
  */
 public operator fun <T> Sequence<T>.plus(element: T): Sequence<T> {
-    return sequenceOf(this, sequenceOf(element)).flatten()
+    val seq = this; return sequence { yieldAll(seq); yield(element) }
 }
 
 /**
@@ -2746,7 +2746,7 @@ public operator fun <T> Sequence<T>.plus(elements: Array<out T>): Sequence<T> {
  * The operation is _intermediate_ and _stateless_.
  */
 public operator fun <T> Sequence<T>.plus(elements: Iterable<T>): Sequence<T> {
-    return sequenceOf(this, elements.asSequence()).flatten()
+    val seq = this; return sequence { yieldAll(seq); yieldAll(elements) }
 }
 
 /**
@@ -2758,7 +2758,7 @@ public operator fun <T> Sequence<T>.plus(elements: Iterable<T>): Sequence<T> {
  * The operation is _intermediate_ and _stateless_.
  */
 public operator fun <T> Sequence<T>.plus(elements: Sequence<T>): Sequence<T> {
-    return sequenceOf(this, elements).flatten()
+    val seq = this; return sequence { yieldAll(seq); yieldAll(elements) }
 }
 
 /**

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Generators.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Generators.kt
@@ -93,7 +93,7 @@ object Generators : TemplateGroupBase() {
             doc { "Returns a sequence containing all elements of the original sequence and then the given [element]." }
             body {
                 """
-                return sequenceOf(this, sequenceOf(element)).flatten()
+                val seq = this; return sequence { yieldAll(seq); yield(element) }
                 """
             }
         }
@@ -160,7 +160,7 @@ object Generators : TemplateGroupBase() {
             sequenceClassification(intermediate, stateless)
             body {
                 """
-                return sequenceOf(this, elements.asSequence()).flatten()
+                val seq = this; return sequence { yieldAll(seq); yieldAll(elements) }
                 """
             }
         }
@@ -286,7 +286,7 @@ object Generators : TemplateGroupBase() {
             sequenceClassification(intermediate, stateless)
             body {
                 """
-                return sequenceOf(this, elements).flatten()
+                val seq = this; return sequence { yieldAll(seq); yieldAll(elements) }
                 """
             }
         }


### PR DESCRIPTION
[suggested fix for Sequence.plus implementation optimization](https://youtrack.jetbrains.com/issue/KT-47553/Sequence.plus-implementation-optimization)

as there are only two operands, we can just use `yieldAll` and/or `yield` - seems to run a bit faster.