### PR TITLE
[WASM] KT-60505 - generate structs without subtypes or supertypes as final

### DIFF
--- a/wasm/wasm.ir/src/org/jetbrains/kotlin/wasm/ir/convertors/WasmIrToBinary.kt
+++ b/wasm/wasm.ir/src/org/jetbrains/kotlin/wasm/ir/convertors/WasmIrToBinary.kt
@@ -368,7 +368,7 @@ class WasmIrToBinary(
         val superType = type.superType
         
         if (hasSubtypes || superType != null) {
-            this.b.writeVarInt7(WasmBinary.SUB_TYPE)
+            b.writeVarInt7(WasmBinary.SUB_TYPE)
             if (superType != null) {
                 appendVectorSize(1)
                 appendModuleFieldReference(superType.owner)
@@ -378,8 +378,8 @@ class WasmIrToBinary(
         }
 
 
-        this.b.writeVarInt7(WasmBinary.STRUCT_TYPE)
-        this.b.writeVarUInt32(type.fields.size)
+        b.writeVarInt7(WasmBinary.STRUCT_TYPE)
+        b.writeVarUInt32(type.fields.size)
         type.fields.forEach {
             appendFiledType(it)
         }


### PR DESCRIPTION
[KT-60505](https://youtrack.jetbrains.com/issue/KT-60505) fixed

Structs are created as 'final' if they have no subtypes or supertype

Checked against the [binary encoding ](https://webassembly.github.io/gc/core/binary/types.html#binary-structtype) for extra validation

Possible problem: This only checks if there are subtypes *within this module*, and thus if we try to subtype a struct from this module, from *another* module, it will fail - but if that's a concern then we should probably drop KT-60505 entirely.

I was unfortunately unable to run tests because the WASM test failed - bizarrely - on `':kotlin-stdlib:compileMainJdk7KotlinJvm'`, with error `Unable to download toolchain matching the requirements` - looks entirely unrelated, but I *would* like to be able to run the tests

I read the contribution guidelines, but this is my first PR here, so if there are additional guidelines or something I missed I would be glad to know :)