### PR TITLE
KT-50777 [stblib] `String.lastIndexOf("")` returns length

### DIFF
--- a/libraries/stdlib/src/kotlin/text/Strings.kt
+++ b/libraries/stdlib/src/kotlin/text/Strings.kt
@@ -952,7 +952,7 @@ public fun CharSequence.indexOfAny(chars: CharArray, startIndex: Int = 0, ignore
  * @return An index of the last occurrence of matched character from [chars] or -1 if none of [chars] are found.
  *
  */
-public fun CharSequence.lastIndexOfAny(chars: CharArray, startIndex: Int = lastIndex, ignoreCase: Boolean = false): Int {
+public fun CharSequence.lastIndexOfAny(chars: CharArray, startIndex: Int = length, ignoreCase: Boolean = false): Int {
     if (!ignoreCase && chars.size == 1 && this is String) {
         val char = chars.single()
         return nativeLastIndexOf(char, startIndex)
@@ -973,7 +973,7 @@ private fun CharSequence.indexOf(other: CharSequence, startIndex: Int, endIndex:
     val indices = if (!last)
         startIndex.coerceAtLeast(0)..endIndex.coerceAtMost(length)
     else
-        startIndex.coerceAtMost(lastIndex) downTo endIndex.coerceAtLeast(0)
+        startIndex.coerceAtMost(length) downTo endIndex.coerceAtLeast(0)
 
     if (this is String && other is String) { // smart cast
         for (index in indices) {
@@ -996,7 +996,7 @@ private fun CharSequence.findAnyOf(strings: Collection<String>, startIndex: Int,
         return if (index < 0) null else index to string
     }
 
-    val indices = if (!last) startIndex.coerceAtLeast(0)..length else startIndex.coerceAtMost(lastIndex) downTo 0
+    val indices = if (!last) startIndex.coerceAtLeast(0)..length else startIndex.coerceAtMost(length) downTo 0
 
     if (this is String) {
         for (index in indices) {
@@ -1042,7 +1042,7 @@ public fun CharSequence.findAnyOf(strings: Collection<String>, startIndex: Int =
  * the end toward the beginning of this string, and finds at each position the first element in [strings]
  * that matches this string at that position.
  */
-public fun CharSequence.findLastAnyOf(strings: Collection<String>, startIndex: Int = lastIndex, ignoreCase: Boolean = false): Pair<Int, String>? =
+public fun CharSequence.findLastAnyOf(strings: Collection<String>, startIndex: Int = length, ignoreCase: Boolean = false): Pair<Int, String>? =
     findAnyOf(strings, startIndex, ignoreCase, last = true)
 
 /**
@@ -1071,7 +1071,7 @@ public fun CharSequence.indexOfAny(strings: Collection<String>, startIndex: Int 
  * the end toward the beginning of this string, and finds at each position the first element in [strings]
  * that matches this string at that position.
  */
-public fun CharSequence.lastIndexOfAny(strings: Collection<String>, startIndex: Int = lastIndex, ignoreCase: Boolean = false): Int =
+public fun CharSequence.lastIndexOfAny(strings: Collection<String>, startIndex: Int = length, ignoreCase: Boolean = false): Int =
     findAnyOf(strings, startIndex, ignoreCase, last = true)?.first ?: -1
 
 
@@ -1128,7 +1128,7 @@ public fun CharSequence.lastIndexOf(char: Char, startIndex: Int = lastIndex, ign
  * @param ignoreCase `true` to ignore character case when matching a string. By default `false`.
  * @return An index of the last occurrence of [string] or -1 if none is found.
  */
-public fun CharSequence.lastIndexOf(string: String, startIndex: Int = lastIndex, ignoreCase: Boolean = false): Int {
+public fun CharSequence.lastIndexOf(string: String, startIndex: Int = length, ignoreCase: Boolean = false): Int {
     return if (ignoreCase || this !is String)
         indexOf(string, startIndex, 0, ignoreCase, last = true)
     else

--- a/libraries/stdlib/test/text/StringTest.kt
+++ b/libraries/stdlib/test/text/StringTest.kt
@@ -411,6 +411,8 @@ class StringTest {
         assertEquals("3+", s.substringAfterLast(","))
         assertEquals("-1", s.substringBefore(","))
         assertEquals("-1,22", s.substringBeforeLast(","))
+        assertEquals("-1,22,3+", s.substringBeforeLast(""))
+        assertEquals("", s.substringAfterLast(""))
 
         // non-existing delimiter
         assertEquals("", s.substringAfter("+"))
@@ -435,6 +437,8 @@ class StringTest {
         assertEquals("/user/folder/another.doc", s.replaceAfterLast("/", "another.doc"))
         assertEquals("new name.extension", s.replaceBefore(".", "new name"))
         assertEquals("/new/path/file.extension", s.replaceBeforeLast("/", "/new/path"))
+        assertEquals("new", s.replaceBeforeLast("", "new"))
+        assertEquals("/user/folder/file.extension.append", s.replaceAfterLast("", ".append"))
 
         // non-existing delimiter
         assertEquals("/user/folder/file.extension", s.replaceAfter("=", "doc"))
@@ -734,6 +738,7 @@ class StringTest {
         assertEquals(-1, string.lastIndexOfAny(substrings, 1))
 
         assertEquals(0, string.indexOfAny(listOf("dab", "")), "empty strings are not ignored")
+        assertEquals(11, string.lastIndexOfAny(listOf("dab", "")), "empty strings are not ignored")
         assertEquals(-1, string.indexOfAny(listOf()))
     }
 
@@ -762,6 +767,7 @@ class StringTest {
         assertEquals(null, string.findLastAnyOf(substrings, 1))
 
         assertEquals(0 to "", string.findAnyOf(listOf("dab", "")), "empty strings are not ignored")
+        assertEquals(11 to "", string.findLastAnyOf(listOf("dab", "")), "empty strings are not ignored")
         assertEquals(null, string.findAnyOf(listOf()))
     }
 
@@ -819,6 +825,10 @@ class StringTest {
         assertEquals(1, string.indexOf("ced"))
         assertEquals(4, string.indexOf("ed", 3))
         assertEquals(-1, string.indexOf("abcdefgh"))
+
+        assertEquals(4, string.lastIndexOf("ed"))
+        assertEquals(2, string.lastIndexOf("ed", 3))
+        assertEquals(6, string.lastIndexOf(""))
     }
 
     @Test fun indexOfStringIgnoreCase() = withOneCharSequenceArg("bceded") { string ->


### PR DESCRIPTION
`String.lastIndexOf("")` should return string `length` instead of `lastIndex`. Other related incorrect behaviours include `lastIndexOfAny`, `findLastAnyOf`, `replaceBefore/AfterLast`, `substringBefore/AfterLast`. These were fixed to match the correct behaviour that an empty string is present at the end (index `length`). Corresponding tests were added.

^[KT-50777](https://youtrack.jetbrains.com/issue/KT-50777/String.lastIndexOf-doesnt-return-length) Fixed