### PR TITLE
KT-50288 Support `org.springframework.lang.Nullable` and `NonNull` as nullability annotation

### DIFF
--- a/core/compiler.common.jvm/src/org/jetbrains/kotlin/load/java/JvmAnnotationNames.kt
+++ b/core/compiler.common.jvm/src/org/jetbrains/kotlin/load/java/JvmAnnotationNames.kt
@@ -40,7 +40,8 @@ val NULLABLE_ANNOTATIONS = listOf(
     FqName("edu.umd.cs.findbugs.annotations.Nullable"),
     FqName("edu.umd.cs.findbugs.annotations.PossiblyNull"),
     FqName("io.reactivex.annotations.Nullable"),
-    FqName("io.reactivex.rxjava3.annotations.Nullable")
+    FqName("io.reactivex.rxjava3.annotations.Nullable"),
+    FqName("org.springframework.lang.Nullable")
 )
 
 val JAVAX_NONNULL_ANNOTATION = FqName("javax.annotation.Nonnull")
@@ -57,7 +58,8 @@ val NOT_NULL_ANNOTATIONS = listOf(
     FqName("org.checkerframework.checker.nullness.qual.NonNull"),
     FqName("lombok.NonNull"),
     FqName("io.reactivex.annotations.NonNull"),
-    FqName("io.reactivex.rxjava3.annotations.NonNull")
+    FqName("io.reactivex.rxjava3.annotations.NonNull"),
+    FqName("org.springframework.lang.NonNull")
 )
 
 val COMPATQUAL_NULLABLE_ANNOTATION = FqName("org.checkerframework.checker.nullness.compatqual.NullableDecl")


### PR DESCRIPTION
Resolve [KT-50288](https://youtrack.jetbrains.com/issue/KT-50288).

---

Do we need to consider `NonNullApi` and `NonNullFields`?
I also read `LombokNames`, but it didn't seem to be included.
https://spring.pleiades.io/spring-framework/docs/current/javadoc-api/org/springframework/lang/package-summary.html