### PR TITLE
fix : example ' ' generete fail

### DIFF
--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportNamer.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportNamer.kt
@@ -511,7 +511,7 @@ internal class ObjCExportNamerImpl(
             parameters.forEachIndexed { index, (bridge, it) ->
                 val name = when (bridge) {
                     is MethodBridgeValueParameter.Mapped -> when {
-                        it is ReceiverParameterDescriptor -> it.getObjCName().asIdentifier(false) { "" }
+                        it is ReceiverParameterDescriptor -> "receiver"
                         method is PropertySetterDescriptor -> when (parameters.size) {
                             1 -> ""
                             else -> "value"


### PR DESCRIPTION
for fix this example when need throw exception and is lambda extension and no parameter generate error

`fun <T> (() -> T).asFlow(): Flow<T> `

Because when this situation, error will insert to index 0, and receiver is index 1.
And cannot get ObjC name when generate selector, because it's extension receiver.
When next step, selectorParts.
It will remove last ':', so selectorParts size isn't equal parameter size