### PR TITLE
KT-61737: Add missing space in `GradleStyleMessagerRenderer.render()`

### DIFF
--- a/compiler/cli/src/org/jetbrains/kotlin/cli/common/messages/GradleStyleMessagerRenderer.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/common/messages/GradleStyleMessagerRenderer.kt
@@ -24,8 +24,9 @@ class GradleStyleMessageRenderer : MessageRenderer {
                 val fileUri = File(path).toPath().toUri()
                 append("$fileUri")
                 if (line > 0 && column > 0) {
-                    append(":$line:$column ")
+                    append(":$line:$column")
                 }
+                append(' ')
             }
 
             append(message)


### PR DESCRIPTION
In `GradleStyleMessagerRenderer.render` method, when there is `location` pointing to some file and coordinates `line:column = 0:0`, then a space between the location and the message was not printed.

Fixes [KT-61737](https://youtrack.jetbrains.com/issue/KT-61737/GradleStyleMessageRenderer.render-misses-a-space-between-the-file-and-the-message-when-location-is-linecolumn-00)