### PR TITLE
Fix for Xcode 15rc SDK

### DIFF
--- a/kotlin-native/platformLibs/src/platform/ios/NewsstandKit.def.disabled
+++ b/kotlin-native/platformLibs/src/platform/ios/NewsstandKit.def.disabled
@@ -5,3 +5,4 @@ modules = NewsstandKit
 
 compilerOpts = -framework NewsstandKit
 linkerOpts = -framework NewsstandKit
+# Deprecated in Xcode14, removed in Xcode 15

--- a/kotlin-native/platformLibs/src/platform/osx/ExposureNotification.def.disabled
+++ b/kotlin-native/platformLibs/src/platform/osx/ExposureNotification.def.disabled
@@ -5,3 +5,4 @@ package = platform.ExposureNotification
 modules = ExposureNotification
 compilerOpts = -framework ExposureNotification
 linkerOpts = -framework ExposureNotification
+# Removed in Xcode 15

--- a/kotlin-native/platformLibs/src/platform/osx/JavaNativeFoundation.def
+++ b/kotlin-native/platformLibs/src/platform/osx/JavaNativeFoundation.def
@@ -2,7 +2,8 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.JavaNativeFoundation
 
-modules.macos_x64 = JavaNativeFoundation
+# Xcode 15 does not have a module for this framework.
+# modules.macos_x64 = JavaNativeFoundation
 compilerOpts.macos_x64 = -framework JavaNativeFoundation
 linkerOpts.macos_x64 = -framework JavaNativeFoundation
 


### PR DESCRIPTION
Xcode 15 does not include NewsstandKit on iOS or ExposureNotification on macOS. Also the JavaNativeFoundation framework does not have a module associated with it.