### PR TITLE
Remove linker warning

### DIFF
--- a/kotlin-native/Interop/Indexer/build.gradle.kts
+++ b/kotlin-native/Interop/Indexer/build.gradle.kts
@@ -67,7 +67,7 @@ if (libclangextIsEnabled) {
 
     val llvmLibs = listOf(
             "clangAST", "clangASTMatchers", "clangAnalysis", "clangBasic", "clangDriver", "clangEdit",
-            "clangFrontend", "clangFrontendTool", "clangLex", "clangParse", "clangSema", "clangEdit",
+            "clangFrontend", "clangFrontendTool", "clangLex", "clangParse", "clangSema",
             "clangRewrite", "clangRewriteFrontend", "clangStaticAnalyzerFrontend",
             "clangStaticAnalyzerCheckers", "clangStaticAnalyzerCore", "clangSerialization",
             "clangToolingCore",


### PR DESCRIPTION
Building with macOS gave the linker warning
`ld: warning: ignoring duplicate libraries: '/Users/foo/.konan/dependencies/apple-llvm-20200714-macos-aarch64-1/lib/libclangEdit.a'`