### PR TITLE
KT-57870: Suppress InvalidPathException for paths with invalid characters when loading Konan library

### DIFF
--- a/kotlin-native/Interop/Runtime/src/jvm/kotlin/kotlinx/cinterop/JvmUtils.kt
+++ b/kotlin-native/Interop/Runtime/src/jvm/kotlin/kotlinx/cinterop/JvmUtils.kt
@@ -114,7 +114,11 @@ private val systemTmpDir = System.getProperty("java.io.tmpdir")
 
 // TODO: File(..).deleteOnExit() does not work on Windows. May be use FILE_FLAG_DELETE_ON_CLOSE?
 private fun tryLoadKonanLibrary(dir: String, fullLibraryName: String, runFromDaemon: Boolean): Boolean {
-    val fullLibraryPath = Paths.get(dir, fullLibraryName)
+    val fullLibraryPath = try {
+        Paths.get(dir, fullLibraryName)
+    } catch (ignored: InvalidPathException) {
+        return false
+    }
     if (!Files.exists(fullLibraryPath)) return false
 
     fun createTempDirWithLibrary() = if (runFromDaemon) {


### PR DESCRIPTION
This is a Kotlin/Native related PR.

Relating issue: [KT-57870](https://youtrack.jetbrains.com/issue/KT-57870/compileKotlinNative-fails-on-windows-if-PATH-contains-invalid-entry).

When I was following the [official Kotlin/Native tutorials](https://kotlinlang.org/docs/native-gradle.html#create-project-files) in an attempt to create my first Kotlin/Native project, I ran into the exact same problem ([KT-57870](https://youtrack.jetbrains.com/issue/KT-57870/compileKotlinNative-fails-on-windows-if-PATH-contains-invalid-entry)). This issue occurred because my Windows Environment Variable `PATH` contained invalid characters `"`. The stack trace for the error is displayed below:

```
Caused by: java.nio.file.InvalidPathException: Illegal char <"> at index 23: C:\Program Files\nodejs" /M\orgjetbrainskotlinbackendkonanenvstubs.dll	
	at java.base/sun.nio.fs.WindowsPathParser.normalize(WindowsPathParser.java:182)
	at java.base/sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:153)
	at java.base/sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:77)
	at java.base/sun.nio.fs.WindowsPath.parse(WindowsPath.java:92)
	at java.base/sun.nio.fs.WindowsFileSystem.getPath(WindowsFileSystem.java:232)
	at java.base/java.nio.file.Path.of(Path.java:147)
	at java.base/java.nio.file.Paths.get(Paths.java:69)
	at kotlinx.cinterop.JvmUtilsKt.tryLoadKonanLibrary(JvmUtils.kt:117)	
	at kotlinx.cinterop.JvmUtilsKt.loadKonanLibrary(JvmUtils.kt:188)	
	at org.jetbrains.kotlin.backend.konan.env.env.<clinit>(env.kt:16)	
	at org.jetbrains.kotlin.cli.utilities.MainKt.setupClangEnv(main.kt:48)	
	at org.jetbrains.kotlin.cli.utilities.MainKt.inProcessMain(main.kt:57)	
	at org.jetbrains.kotlin.cli.utilities.MainKt.daemonMain(main.kt:51)	
	at org.jetbrains.kotlin.compilerRunner.KotlinToolRunner.runInProcess(KotlinToolRunner.kt:189)	
	at org.jetbrains.kotlin.compilerRunner.KotlinToolRunner.run(KotlinToolRunner.kt:132)	
	at org.jetbrains.kotlin.gradle.tasks.KotlinNativeCompile.compile(KotlinNativeTasks.kt:525)	
	at org.gradle.internal.reflect.JavaMethod.invoke(JavaMethod.java:125)
```

Given that [the line which follows in the original code](https://github.com/JetBrains/kotlin/blob/1a36a06a078a60b90e2c2cde04c93ee08b8d3ad6/kotlin-native/Interop/Runtime/src/jvm/kotlin/kotlinx/cinterop/JvmUtils.kt#L118) (`if (!Files.exists(fullLibraryPath)) return false`) verifies the existence of the file, I have modified [the method invocation](https://github.com/JetBrains/kotlin/blob/1a36a06a078a60b90e2c2cde04c93ee08b8d3ad6/kotlin-native/Interop/Runtime/src/jvm/kotlin/kotlinx/cinterop/JvmUtils.kt#L117) (`val fullLibraryPath = Paths.get(dir, fullLibraryName)`) to ignore the `InvalidPathException`. This modification aims to enhance the robustness of the code and prevent any further occurrences like [KT-57870](https://youtrack.jetbrains.com/issue/KT-57870/compileKotlinNative-fails-on-windows-if-PATH-contains-invalid-entry), [StackOverflow-77068534](https://stackoverflow.com/questions/77068534/when-i-compile-a-kotlin-native-project-i-get-could-not-initialize-class-org-jet).

Please feel free to share any suggestions you may have.