### PR TITLE
Fix Path.invariantSeparatorsPathString on Linux

### DIFF
--- a/libraries/stdlib/jdk7/src/kotlin/io/path/PathUtils.kt
+++ b/libraries/stdlib/jdk7/src/kotlin/io/path/PathUtils.kt
@@ -67,10 +67,7 @@ public inline val Path.pathString: String
 @SinceKotlin("1.5")
 @WasExperimental(ExperimentalPathApi::class)
 public val Path.invariantSeparatorsPathString: String
-    get() {
-        val separator = fileSystem.separator
-        return if (separator != "/") toString().replace(separator, "/") else toString()
-    }
+    get() = toString().replace('\\', '/')
 
 @SinceKotlin("1.4")
 @ExperimentalPathApi


### PR DESCRIPTION
This fixes [KT-62225](https://youtrack.jetbrains.com/issue/KT-62225/PathinvariantSeparatorsPathString-does-not-work-in-Linux-for-strings-containing-backslash).

```kotlin
Path("a/b/c").invariantSeparatorsPathString // In both Windows and Linux correctly returns a/b/c

Path("a\\b\\c").invariantSeparatorsPathString // In Windows correctly returns a/b/c but in Linux returns a\b\c
```

The normalization of separators should be irrespective of the OS or filesystem path separator.

I didn't know how to add unit tests for this change without mocking:

https://github.com/JetBrains/kotlin/blob/1dad8906521528e0a63fe89f4c3f98ed42957a52/libraries/stdlib/jdk7/test/PathExtensionsTest.kt#L38-L46

But I locally tested the change and it passed all the tests below:

```kotlin
@ExtendWith(MockKExtension::class)
class Test {
    @MockK lateinit var mockPath: Path
    @MockK lateinit var mockFileSystem: FileSystem

    @Nested
    inner class Windows {
        @Test
        fun backslash() {
            every { mockPath.toString() } returns "a\\b\\c"
            every { mockPath.fileSystem } returns mockFileSystem
            every { mockFileSystem.separator } returns """\"""
            val result = mockPath.invariantSeparatorsPathString2
            assertThat(result).isEqualTo("a/b/c")
        }

        @Test
        fun slash() {
            every { mockPath.toString() } returns "a/b/c"
            every { mockPath.fileSystem } returns mockFileSystem
            every { mockFileSystem.separator } returns """\"""
            val result = mockPath.invariantSeparatorsPathString2
            assertThat(result).isEqualTo("a/b/c")
        }

        @Test
        fun mixed() {
            every { mockPath.toString() } returns """a/b\c/d\e"""
            every { mockPath.fileSystem } returns mockFileSystem
            every { mockFileSystem.separator } returns """\"""
            val result = mockPath.invariantSeparatorsPathString2
            assertThat(result).isEqualTo("a/b/c/d/e")
        }
    }

    @Nested
    inner class Linux {
        @Test
        fun backslash() {
            every { mockPath.toString() } returns "a\\b\\c"
            every { mockPath.fileSystem } returns mockFileSystem
            every { mockFileSystem.separator } returns """/"""
            val result = mockPath.invariantSeparatorsPathString2
            assertThat(result).isEqualTo("a/b/c")
        }

        @Test
        fun slash() {
            every { mockPath.toString() } returns "a/b/c"
            every { mockPath.fileSystem } returns mockFileSystem
            every { mockFileSystem.separator } returns """/"""
            val result = mockPath.invariantSeparatorsPathString2
            assertThat(result).isEqualTo("a/b/c")
        }

        @Test
        fun mixed() {
            every { mockPath.toString() } returns """a/b\c/d\e"""
            every { mockPath.fileSystem } returns mockFileSystem
            every { mockFileSystem.separator } returns """/"""
            val result = mockPath.invariantSeparatorsPathString2
            assertThat(result).isEqualTo("a/b/c/d/e")
        }
    }
}
```