### PR TITLE
KT-62518: Run kapt even when all dependencies are indirect

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kapt3IT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kapt3IT.kt
@@ -159,6 +159,16 @@ open class Kapt3IT : Kapt3BaseIT() {
         }
     }
 
+    @DisplayName("Kapt is not skipped when all annotation processors are declared as indirect dependencies")
+    @GradleTest
+    fun testKaptNotSkippedWithIndirectDependencies(gradleVersion: GradleVersion) {
+        project("indirectDependencies".withPrefix, gradleVersion) {
+            build("assemble") {
+                assertTasksExecuted(":kaptGenerateStubsKotlin", ":kaptKotlin")
+            }
+        }
+    }
+
     @DisplayName("Kapt is working with newer JDKs")
     @JdkVersions(versions = [JavaVersion.VERSION_1_10, JavaVersion.VERSION_11, JavaVersion.VERSION_16, JavaVersion.VERSION_17])
     @GradleWithJdkTest

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/indirectDependencies/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/indirectDependencies/build.gradle
@@ -1,0 +1,27 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
+
+plugins {
+    id "java"
+    id "org.jetbrains.kotlin.jvm"
+    id "org.jetbrains.kotlin.kapt"
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+configurations {
+    baseAnnos
+    kapt.extendsFrom(baseAnnos)
+}
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:annotation-processor-example:$kotlin_version"
+    baseAnnos "org.jetbrains.kotlin:annotation-processor-example:$kotlin_version"
+}
+
+tasks.named("compileKotlin", KotlinJvmCompile) {
+    compilerOptions.allWarningsAsErrors = false // compilation with LV=2.0 prints warning about kapt fallback
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/indirectDependencies/src/main/java/test.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/indirectDependencies/src/main/java/test.kt
@@ -1,0 +1,12 @@
+package example
+
+@example.ExampleAnnotation
+@example.ExampleSourceAnnotation
+@example.ExampleBinaryAnnotation
+@example.ExampleRuntimeAnnotation
+public class TestClass {
+
+    @example.ExampleAnnotation
+    public val testVal: String = "text"
+
+}

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/Kapt3KotlinGradleSubplugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/Kapt3KotlinGradleSubplugin.kt
@@ -276,7 +276,7 @@ class Kapt3GradleSubplugin @Inject internal constructor(private val registry: To
 
         val kaptExtension = project.extensions.getByType(KaptExtension::class.java)
 
-        val nonEmptyKaptConfigurations = kaptConfigurations.filter { it.dependencies.isNotEmpty() }
+        val nonEmptyKaptConfigurations = kaptConfigurations.filter { it.allDependencies.isNotEmpty() }
 
         val javaCompileOrNull = findJavaTaskForKotlinCompilation(kotlinCompilation)
 
@@ -358,7 +358,6 @@ class Kapt3GradleSubplugin @Inject internal constructor(private val registry: To
         generateStubsTask: TaskProvider<KaptGenerateStubsTask>
     ): TaskProvider<out KaptTask> {
         val taskName = kotlinCompile.kaptTaskName
-        @Suppress("UNCHECKED_CAST")
         val taskConfigAction = KaptWithoutKotlincConfig(
             kotlinCompilation.project,
             generateStubsTask,

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/regressionTests/KT62518KaptWorksWithIndirectDeps.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/regressionTests/KT62518KaptWorksWithIndirectDeps.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+@file:Suppress("FunctionName")
+
+package org.jetbrains.kotlin.gradle.regressionTests
+
+import org.gradle.api.NamedDomainObjectProvider
+import org.gradle.api.artifacts.Configuration
+import org.jetbrains.kotlin.gradle.internal.Kapt3GradleSubplugin
+import org.jetbrains.kotlin.gradle.util.buildProjectWithJvm
+import kotlin.test.Test
+
+class KT62518KaptWorksWithIndirectDeps {
+    @Test
+    fun `let kapt extend from another configuration`() {
+        val project = buildProjectWithJvm {
+            plugins.apply(Kapt3GradleSubplugin::class.java)
+        }
+        val dep = project.dependencies.create("unresolved:dependency")
+        val baseConfig: NamedDomainObjectProvider<Configuration> = project.configurations.register("baseConfig") {
+            it.dependencies.add(dep)
+        }
+        project.configurations.named(Kapt3GradleSubplugin.MAIN_KAPT_CONFIGURATION_NAME) {
+            it.extendsFrom(baseConfig.get())
+        }
+        project.evaluate()
+
+        val taskSpecificConfig = project.configurations.getByName("kaptClasspath_kaptKotlin")
+
+        assert(dep in taskSpecificConfig.allDependencies)
+    }
+}


### PR DESCRIPTION
Previously, kapt skipped the execution, if the "kapt" configuration had
no direct dependencies (via `kapt.dependencies.isEmpty()`).
This lead to kapt not working, if all
annotation processors are declared in a super-configuration of kapt.

With this change, we also consider super-configurations
(via `kapt.allDependencies.isEmpty`) and fix the described bug.
