### PR TITLE
New Feature ::  The Kotlin string extension is named `String.isNotNullAndNotEmpty()`

### DIFF
--- a/libraries/stdlib/src/kotlin/text/Strings.kt
+++ b/libraries/stdlib/src/kotlin/text/Strings.kt
@@ -336,12 +336,12 @@ public inline fun CharSequence?.isNullOrBlank(): Boolean {
  * @sample samples.text.Strings.stringIsNullOrBlank
  */
 @kotlin.internal.InlineOnly
-public inline fun CharSequence?.isNotNullOrNotBlank(): Boolean {
+public inline fun CharSequence?.isNotNullAndNotBlank(): Boolean {
     contract {
-        returns(false) implies (this@isNotNullOrNotBlank != null)
+        returns(false) implies (this@isNotNullAndNotBlank != null)
     }
 
-    return this != null || this.isNotBlank()
+    return this != null && this.isNotBlank()
 }
 
 

--- a/libraries/stdlib/src/kotlin/text/Strings.kt
+++ b/libraries/stdlib/src/kotlin/text/Strings.kt
@@ -329,6 +329,22 @@ public inline fun CharSequence?.isNullOrBlank(): Boolean {
     return this == null || this.isBlank()
 }
 
+
+/**
+ * Returns true if this nullable char sequence is not either null or empty or consists solely of whitespace characters.
+ *
+ * @sample samples.text.Strings.stringIsNullOrBlank
+ */
+@kotlin.internal.InlineOnly
+public inline fun CharSequence?.isNotNullOrNotBlank(): Boolean {
+    contract {
+        returns(false) implies (this@isNotNullOrNotBlank != null)
+    }
+
+    return this != null || this.isNotBlank()
+}
+
+
 /**
  * Iterator for characters of the given char sequence.
  */

--- a/libraries/stdlib/src/kotlin/text/Strings.kt
+++ b/libraries/stdlib/src/kotlin/text/Strings.kt
@@ -331,7 +331,7 @@ public inline fun CharSequence?.isNullOrBlank(): Boolean {
 
 
 /**
- * Returns true if this nullable char sequence is not either null or empty or consists solely of whitespace characters.
+ * Returns true if this nullable char sequence is not either null or blank and consists solely of whitespace characters.
  *
  * @sample samples.text.Strings.stringIsNullOrBlank
  */

--- a/libraries/stdlib/test/text/StringTest.kt
+++ b/libraries/stdlib/test/text/StringTest.kt
@@ -159,21 +159,23 @@ class StringTest {
     }
 
     
-    @Test fun isNotNullOrNotBlank() = withOneCharSequenceArg { arg1 ->
-        data class Case(val value: String?, val isNull: Boolean = false, val isNotNullOrNotBlank: Boolean = false)
+    @Test
+    fun isNotNullAndNotBlank() = withOneCharSequenceArg { arg1 ->
+        data class Case(val value: String?, val isNull: Boolean = false, val isNotBlank: Boolean = false)
 
         val cases = listOf(
-            Case(null,               isNull = true),
-            Case("",                 isNotNullOrNotBlank = false),
-            Case("  \r\n\t\u00A0",   isNotNullOrNotBlank = false),
-            Case(" Some ",    isNotNullOrNotBlank = true)
+            Case(null,              isNull = true),
+            Case("",                isNotBlank = false),
+            Case("  \r\n\t\u00A0",  isNotBlank = false),
+            Case(" Some ",          isNotBlank = true)
         )
 
         for (case in cases) {
             val value = case.value?.let { arg1(it) }
-            assertEquals(case.isNull || case.isNotNullOrNotBlank, value.isNotNullOrNotBlank(), "failed for case '$value'")
+            assertEquals(case.isNull || case.isNotBlank, value.isNotNullAndNotBlank(), "failed for case '$value'")
         }
     }
+
 
 
     @Test fun orEmpty() {

--- a/libraries/stdlib/test/text/StringTest.kt
+++ b/libraries/stdlib/test/text/StringTest.kt
@@ -138,7 +138,7 @@ class StringTest {
     }
 
     @Test fun isEmptyAndBlank() = withOneCharSequenceArg { arg1 ->
-        class Case(val value: String?, val isNull: Boolean = false, val isEmpty: Boolean = false, val isBlank: Boolean = false)
+        data class Case(val value: String?, val isNull: Boolean = false, val isEmpty: Boolean = false, val isBlank: Boolean = false)
 
         val cases = listOf(
             Case(null,              isNull = true),

--- a/libraries/stdlib/test/text/StringTest.kt
+++ b/libraries/stdlib/test/text/StringTest.kt
@@ -158,6 +158,24 @@ class StringTest {
         }
     }
 
+    
+    @Test fun isNotNullOrNotBlank() = withOneCharSequenceArg { arg1 ->
+        data class Case(val value: String?, val isNull: Boolean = false, val isNotNullOrNotBlank: Boolean = false)
+
+        val cases = listOf(
+            Case(null,               isNull = true),
+            Case("",                 isNotNullOrNotBlank = false),
+            Case("  \r\n\t\u00A0",   isNotNullOrNotBlank = false),
+            Case(" Some ",    isNotNullOrNotBlank = true)
+        )
+
+        for (case in cases) {
+            val value = case.value?.let { arg1(it) }
+            assertEquals(case.isNull || case.isNotNullOrNotBlank, value.isNotNullOrNotBlank(), "failed for case '$value'")
+        }
+    }
+
+
     @Test fun orEmpty() {
         val s: String? = "hey"
         val ns: String? = null


### PR DESCRIPTION
### Type of PR

I have implemented a logic for handling conditions in Kotlin where the value is not null or empty. Here is the code I have written:

```kt
if(!isNullOrEmpty(value)) {
}

// or

if(value != null && value.isNotEmpty()) {
}
```
### Example
```kt
 override fun doFilterInternal(
        request: HttpServletRequest,
        response: HttpServletResponse,
        filterChain: FilterChain
    ) {
        val accessToken = jwtParserPort.parseAccessToken(request)
        if (!accessToken.isNullOrBlank()) { // accessToken != null && accessToken.isNotBlank()
            val authentication = jwtParserPort.authentication(accessToken)
            SecurityContextHolder.clearContext()
            val securityContext = SecurityContextHolder.getContext()
            securityContext.authentication = authentication
        }
        filterChain.doFilter(request, response)
    }
}
```


Although developers would understand its meaning, I believe it would be useful to have a method that does not require the use of "!". So, I have developed a method called String.isNotNullAndNotEmpty().

<br>

### Code Impl
```kt
@kotlin.internal.InlineOnly
public inline fun CharSequence?.isNotNullAndNotBlank(): Boolean {
    contract {
        returns(false) implies (this@isNotNullOrNotBlank != null)
    }

    return this != null && this.isNotBlank()
}
```

This function has the internal inlineOnly option applied.

---

As a side note, I'm uncertain whether the function should be named `isNotNullAndNotEmpty()` or `isNotNullAndEmpty()`. I would appreciate your feedback on which naming convention would be more appropriate. Based on your input, I will proceed with the naming convention you suggest.


