### PR TITLE
Remove print statement

### DIFF
--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cexport/CAdapterApiExporter.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cexport/CAdapterApiExporter.kt
@@ -245,7 +245,6 @@ internal class CAdapterApiExporter(
         output("#endif  /* KONAN_${prefix.uppercase()}_H */")
 
         outputStreamWriter.close()
-        println("Produced library API in ${prefix}_api.h")
 
         outputStreamWriter = cppAdapterFile.printWriter()
 


### PR DESCRIPTION
This print statement should either be delated, as I did here, or if it must be kept should be properly logged at an INFO level so that gradle builds that are at the WARN level do not see this.