### PR TITLE
KT-62969 Allow plugins to generate enum entries

### DIFF
--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/extensions/FirDeclarationGenerationExtension.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/extensions/FirDeclarationGenerationExtension.kt
@@ -54,6 +54,7 @@ abstract class FirDeclarationGenerationExtension(session: FirSession) : FirExten
     // Can be called on STATUS stage
     open fun generateFunctions(callableId: CallableId, context: MemberGenerationContext?): List<FirNamedFunctionSymbol> = emptyList()
     open fun generateProperties(callableId: CallableId, context: MemberGenerationContext?): List<FirPropertySymbol> = emptyList()
+    open fun generateEnumEntries(callableId: CallableId, context: MemberGenerationContext): List<FirEnumEntrySymbol> = emptyList()
     open fun generateConstructors(context: MemberGenerationContext): List<FirConstructorSymbol> = emptyList()
 
     // Can be called on IMPORTS stage

--- a/plugins/fir-plugin-prototype/plugin-annotations/src/commonMain/kotlin/org/jetbrains/kotlin/fir/plugin/annotations.kt
+++ b/plugins/fir-plugin-prototype/plugin-annotations/src/commonMain/kotlin/org/jetbrains/kotlin/fir/plugin/annotations.kt
@@ -15,6 +15,7 @@ annotation class ExternalClassWithNested
 annotation class NestedClassAndMaterializeMember
 annotation class MyInterfaceSupertype
 annotation class CompanionWithFoo
+annotation class GenerateEnumConstant
 
 annotation class MySerializable
 annotation class CoreSerializer

--- a/plugins/fir-plugin-prototype/src/org/jetbrains/kotlin/fir/plugin/FirPluginPrototypeExtensionRegistrar.kt
+++ b/plugins/fir-plugin-prototype/src/org/jetbrains/kotlin/fir/plugin/FirPluginPrototypeExtensionRegistrar.kt
@@ -34,6 +34,7 @@ class FirPluginPrototypeExtensionRegistrar : FirExtensionRegistrar() {
         +::AdditionalMembersGenerator
         +::CompanionGenerator
         +::MembersOfSerializerGenerator
+        +::EnumGenerator
 
         +::AllPropertiesConstructorMetadataProvider
     }

--- a/plugins/fir-plugin-prototype/src/org/jetbrains/kotlin/fir/plugin/generators/EnumGenerator.kt
+++ b/plugins/fir-plugin-prototype/src/org/jetbrains/kotlin/fir/plugin/generators/EnumGenerator.kt
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.fir.plugin.generators
+
+import org.jetbrains.kotlin.GeneratedDeclarationKey
+import org.jetbrains.kotlin.builtins.StandardNames
+import org.jetbrains.kotlin.descriptors.ClassKind
+import org.jetbrains.kotlin.descriptors.Visibilities
+import org.jetbrains.kotlin.fir.*
+import org.jetbrains.kotlin.fir.declarations.FirResolvePhase
+import org.jetbrains.kotlin.fir.declarations.builder.buildEnumEntry
+import org.jetbrains.kotlin.fir.declarations.impl.FirResolvedDeclarationStatusImpl
+import org.jetbrains.kotlin.fir.declarations.origin
+import org.jetbrains.kotlin.fir.extensions.FirDeclarationGenerationExtension
+import org.jetbrains.kotlin.fir.extensions.FirDeclarationPredicateRegistrar
+import org.jetbrains.kotlin.fir.extensions.MemberGenerationContext
+import org.jetbrains.kotlin.fir.extensions.predicate.LookupPredicate
+import org.jetbrains.kotlin.fir.extensions.predicateBasedProvider
+import org.jetbrains.kotlin.fir.plugin.createConstructor
+import org.jetbrains.kotlin.fir.plugin.createTopLevelClass
+import org.jetbrains.kotlin.fir.plugin.fqn
+import org.jetbrains.kotlin.fir.symbols.impl.*
+import org.jetbrains.kotlin.fir.types.*
+import org.jetbrains.kotlin.name.*
+
+/*
+ * Generates an enum 'foo.GeneratedEnum` with an entry for every class annotated '@GenerateEnumConstant'.
+ */
+class EnumGenerator(session: FirSession) : FirDeclarationGenerationExtension(session) {
+    companion object {
+        private val FOO_PACKAGE = FqName.topLevel(Name.identifier("foo"))
+        private val GENERATED_CLASS_ID = ClassId(FOO_PACKAGE, Name.identifier("GeneratedEnum"))
+
+        private val PREDICATE = LookupPredicate.create { annotated("GenerateEnumConstant".fqn()) }
+    }
+
+    object Key : GeneratedDeclarationKey() {
+        override fun toString(): String {
+            return "EnumGeneratorKey"
+        }
+    }
+
+    private val predicateBasedProvider = session.predicateBasedProvider
+    private val matchedClasses by lazy {
+        predicateBasedProvider.getSymbolsByPredicate(PREDICATE).filterIsInstance<FirRegularClassSymbol>()
+    }
+    private val entryNames by lazy {
+        matchedClasses.map { it.name }
+    }
+
+    override fun generateTopLevelClassLikeDeclaration(classId: ClassId): FirClassLikeSymbol<*>? {
+        if (classId != GENERATED_CLASS_ID) return null
+
+        val selfType = classId.constructClassLikeType()
+        val enumClass = createTopLevelClass(classId, Key, classKind = ClassKind.ENUM_CLASS) {
+            superType(session.builtinTypes.enumType.type.withArguments(arrayOf(selfType)))
+        }
+
+        return enumClass.symbol
+    }
+
+    override fun getCallableNamesForClass(classSymbol: FirClassSymbol<*>, context: MemberGenerationContext): Set<Name> {
+        if (classSymbol.classId != GENERATED_CLASS_ID) return emptySet()
+
+        return buildSet {
+            add(SpecialNames.INIT)
+            addAll(entryNames)
+            add(StandardNames.ENUM_VALUES)
+            add(StandardNames.ENUM_VALUE_OF)
+            add(StandardNames.ENUM_ENTRIES)
+        }
+    }
+
+    override fun generateConstructors(context: MemberGenerationContext): List<FirConstructorSymbol> {
+        if (context.owner.classId != GENERATED_CLASS_ID) return emptyList()
+
+        val constructor = createConstructor(context.owner, Key, isPrimary = true) {
+            visibility = Visibilities.Private
+
+            status {
+                isFromEnumClass = true
+            }
+        }
+
+        return listOf(constructor.symbol)
+    }
+
+    override fun generateProperties(callableId: CallableId, context: MemberGenerationContext?): List<FirPropertySymbol> {
+        val classId = callableId.classId
+        if (classId != GENERATED_CLASS_ID || context == null) return emptyList()
+
+        return when (callableId.callableName) {
+            StandardNames.ENUM_ENTRIES -> listOf(
+                createEnumEntriesGetter(
+                    context.owner,
+                    context.owner.resolvedStatus,
+                    FirResolvePhase.BODY_RESOLVE,
+                    session.moduleData,
+                    classId.packageFqName,
+                    classId.relativeClassName,
+                    Key.origin
+                ).symbol
+            )
+            else -> emptyList()
+        }
+    }
+
+    override fun generateFunctions(callableId: CallableId, context: MemberGenerationContext?): List<FirNamedFunctionSymbol> {
+        val classId = callableId.classId
+        if (classId != GENERATED_CLASS_ID || context == null) return emptyList()
+
+        return when (callableId.callableName) {
+            StandardNames.ENUM_VALUES -> listOf(
+                createEnumValuesFunction(
+                    context.owner,
+                    context.owner.resolvedStatus,
+                    FirResolvePhase.BODY_RESOLVE,
+                    session.moduleData,
+                    classId.packageFqName,
+                    classId.relativeClassName,
+                    Key.origin
+                ).symbol
+            )
+            StandardNames.ENUM_VALUE_OF -> listOf(
+                createEnumValueOfFunction(
+                    context.owner,
+                    context.owner.resolvedStatus,
+                    FirResolvePhase.BODY_RESOLVE,
+                    session.moduleData,
+                    classId.packageFqName,
+                    classId.relativeClassName,
+                    Key.origin
+                ).symbol
+            )
+            else -> emptyList()
+        }
+    }
+
+    override fun generateEnumEntries(callableId: CallableId, context: MemberGenerationContext): List<FirEnumEntrySymbol> {
+        val classId = callableId.classId
+        if (classId != GENERATED_CLASS_ID || callableId.callableName !in entryNames) return emptyList()
+
+        val entry = buildEnumEntry {
+            resolvePhase = FirResolvePhase.BODY_RESOLVE
+            moduleData = session.moduleData
+            origin = Key.origin
+
+            returnTypeRef = classId.constructClassLikeType().toFirResolvedTypeRef()
+
+            name = callableId.callableName
+            symbol = FirEnumEntrySymbol(callableId)
+            status = FirResolvedDeclarationStatusImpl.DEFAULT_STATUS_FOR_STATUSLESS_DECLARATIONS.copy(isStatic = true)
+        }
+
+        return listOf(entry.symbol)
+    }
+
+    override fun getTopLevelClassIds(): Set<ClassId> {
+        return if (matchedClasses.isEmpty()) emptySet() else setOf(GENERATED_CLASS_ID)
+    }
+
+    override fun hasPackage(packageFqName: FqName): Boolean {
+        return packageFqName == FOO_PACKAGE
+    }
+
+    override fun FirDeclarationPredicateRegistrar.registerPredicates() {
+        register(PREDICATE)
+    }
+}

--- a/plugins/fir-plugin-prototype/src/org/jetbrains/kotlin/ir/plugin/GeneratedDeclarationsIrBodyFiller.kt
+++ b/plugins/fir-plugin-prototype/src/org/jetbrains/kotlin/ir/plugin/GeneratedDeclarationsIrBodyFiller.kt
@@ -17,6 +17,7 @@ class GeneratedDeclarationsIrBodyFiller : IrGenerationExtension {
             TransformerForCompanionGenerator(pluginContext),
             TransformerForAdditionalMembersGenerator(pluginContext),
             TransformerForTopLevelDeclarationsGenerator(pluginContext),
+            TransformerForEnumGenerator(pluginContext),
             AllPropertiesConstructorIrGenerator(pluginContext),
             TransformerForAddingAnnotations(pluginContext),
             ComposableFunctionsTransformer(pluginContext),

--- a/plugins/fir-plugin-prototype/src/org/jetbrains/kotlin/ir/plugin/TransformerForEnumGenerator.kt
+++ b/plugins/fir-plugin-prototype/src/org/jetbrains/kotlin/ir/plugin/TransformerForEnumGenerator.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.ir.plugin
+
+import org.jetbrains.kotlin.GeneratedDeclarationKey
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.fir.plugin.generators.EnumGenerator
+import org.jetbrains.kotlin.ir.declarations.IrClass
+import org.jetbrains.kotlin.ir.declarations.IrConstructor
+import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
+import org.jetbrains.kotlin.ir.declarations.createBlockBody
+import org.jetbrains.kotlin.ir.expressions.IrBody
+import org.jetbrains.kotlin.ir.expressions.impl.IrEnumConstructorCallImpl
+import org.jetbrains.kotlin.ir.expressions.impl.IrInstanceInitializerCallImpl
+import org.jetbrains.kotlin.ir.types.IrSimpleType
+import org.jetbrains.kotlin.ir.util.constructors
+
+class TransformerForEnumGenerator(context: IrPluginContext) : AbstractTransformerForGenerator(context, visitBodies = true) {
+    override fun interestedIn(key: GeneratedDeclarationKey?): Boolean {
+        return key == EnumGenerator.Key
+    }
+
+    override fun generateBodyForFunction(function: IrSimpleFunction, key: GeneratedDeclarationKey?): IrBody? {
+        return null
+    }
+
+    override fun generateBodyForConstructor(constructor: IrConstructor, key: GeneratedDeclarationKey?): IrBody? {
+        val type = constructor.returnType as? IrSimpleType ?: return null
+
+        val enumConstructor = irBuiltIns.enumClass.owner.constructors.singleOrNull() ?: return null
+        val delegatingCall = IrEnumConstructorCallImpl(
+            -1,
+            -1,
+            type,
+            enumConstructor.symbol,
+            typeArgumentsCount = 1,
+            valueArgumentsCount = enumConstructor.valueParameters.size
+        )
+        delegatingCall.putTypeArgument(0, type)
+
+        val initializerCall = IrInstanceInitializerCallImpl(
+            -1,
+            -1,
+            (constructor.parent as? IrClass)?.symbol ?: return null,
+            type
+        )
+
+        return irFactory.createBlockBody(-1, -1, listOf(delegatingCall, initializerCall))
+    }
+}

--- a/plugins/fir-plugin-prototype/testData/box/generatedEnumClass.fir.txt
+++ b/plugins/fir-plugin-prototype/testData/box/generatedEnumClass.fir.txt
@@ -1,0 +1,142 @@
+FILE: generatedEnumClass.kt
+    @R|org/jetbrains/kotlin/fir/plugin/GenerateEnumConstant|() public final class A : R|kotlin/Any| {
+        public constructor(): R|A| {
+            super<R|kotlin/Any|>()
+        }
+
+    }
+    @R|org/jetbrains/kotlin/fir/plugin/GenerateEnumConstant|() public final class B : R|kotlin/Any| {
+        public constructor(): R|B| {
+            super<R|kotlin/Any|>()
+        }
+
+    }
+    @R|org/jetbrains/kotlin/fir/plugin/GenerateEnumConstant|() public final class C : R|kotlin/Any| {
+        public constructor(): R|C| {
+            super<R|kotlin/Any|>()
+        }
+
+    }
+    public final fun testEnumEntryVariables(): R|kotlin/Unit| {
+        lval entryA: R|foo/GeneratedEnum| = Q|foo/GeneratedEnum|.R|foo/GeneratedEnum.A|
+        lval entryB: R|foo/GeneratedEnum| = Q|foo/GeneratedEnum|.R|foo/GeneratedEnum.B|
+        lval entryC: R|foo/GeneratedEnum| = Q|foo/GeneratedEnum|.R|foo/GeneratedEnum.C|
+        when () {
+            !=(R|<local>/entryA|.R|SubstitutionOverride<foo/GeneratedEnum.name: R|kotlin/String|>|, String(A)) || !=(R|<local>/entryA|.R|SubstitutionOverride<foo/GeneratedEnum.ordinal: R|kotlin/Int|>|, Int(0)) ->  {
+                throw R|java/lang/IllegalArgumentException.IllegalArgumentException|()
+            }
+        }
+
+        when () {
+            !=(R|<local>/entryB|.R|SubstitutionOverride<foo/GeneratedEnum.name: R|kotlin/String|>|, String(B)) || !=(R|<local>/entryB|.R|SubstitutionOverride<foo/GeneratedEnum.ordinal: R|kotlin/Int|>|, Int(1)) ->  {
+                throw R|java/lang/IllegalArgumentException.IllegalArgumentException|()
+            }
+        }
+
+        when () {
+            !=(R|<local>/entryC|.R|SubstitutionOverride<foo/GeneratedEnum.name: R|kotlin/String|>|, String(C)) || !=(R|<local>/entryC|.R|SubstitutionOverride<foo/GeneratedEnum.ordinal: R|kotlin/Int|>|, Int(2)) ->  {
+                throw R|java/lang/IllegalArgumentException.IllegalArgumentException|()
+            }
+        }
+
+    }
+    public final fun testEnumValues(): R|kotlin/Unit| {
+        lval values: R|kotlin/Array<foo/GeneratedEnum>| = Q|foo/GeneratedEnum|.R|foo/GeneratedEnum.values*s|()
+        when () {
+            !=(R|<local>/values|.R|SubstitutionOverride<kotlin/Array.size: R|kotlin/Int|>|, Int(3)) ->  {
+                throw R|java/lang/IllegalArgumentException.IllegalArgumentException|()
+            }
+        }
+
+        when () {
+            !=(R|<local>/values|.R|SubstitutionOverride<kotlin/Array.get: R|foo/GeneratedEnum|>|(Int(0)), Q|foo/GeneratedEnum|.R|foo/GeneratedEnum.A|) ->  {
+                throw R|java/lang/IllegalArgumentException.IllegalArgumentException|()
+            }
+        }
+
+        when () {
+            !=(R|<local>/values|.R|SubstitutionOverride<kotlin/Array.get: R|foo/GeneratedEnum|>|(Int(1)), Q|foo/GeneratedEnum|.R|foo/GeneratedEnum.B|) ->  {
+                throw R|java/lang/IllegalArgumentException.IllegalArgumentException|()
+            }
+        }
+
+        when () {
+            !=(R|<local>/values|.R|SubstitutionOverride<kotlin/Array.get: R|foo/GeneratedEnum|>|(Int(2)), Q|foo/GeneratedEnum|.R|foo/GeneratedEnum.C|) ->  {
+                throw R|java/lang/IllegalArgumentException.IllegalArgumentException|()
+            }
+        }
+
+    }
+    public final fun testEnumValueOf(): R|kotlin/Unit| {
+        when () {
+            !=(Q|foo/GeneratedEnum|.R|foo/GeneratedEnum.A|, Q|foo/GeneratedEnum|.R|foo/GeneratedEnum.valueOf*s|(String(A))) ->  {
+                throw R|java/lang/IllegalArgumentException.IllegalArgumentException|()
+            }
+        }
+
+        when () {
+            !=(Q|foo/GeneratedEnum|.R|foo/GeneratedEnum.B|, Q|foo/GeneratedEnum|.R|foo/GeneratedEnum.valueOf*s|(String(B))) ->  {
+                throw R|java/lang/IllegalArgumentException.IllegalArgumentException|()
+            }
+        }
+
+        when () {
+            !=(Q|foo/GeneratedEnum|.R|foo/GeneratedEnum.C|, Q|foo/GeneratedEnum|.R|foo/GeneratedEnum.valueOf*s|(String(C))) ->  {
+                throw R|java/lang/IllegalArgumentException.IllegalArgumentException|()
+            }
+        }
+
+    }
+    public final fun testEnumEntries(): R|kotlin/Unit| {
+        lval entries: R|kotlin/enums/EnumEntries<foo/GeneratedEnum>| = Q|foo/GeneratedEnum|.R|foo/GeneratedEnum.entries*s|
+        when () {
+            !=(R|<local>/entries|.R|SubstitutionOverride<kotlin/enums/EnumEntries.size: R|kotlin/Int|>|, Int(3)) ->  {
+                throw R|java/lang/IllegalArgumentException.IllegalArgumentException|()
+            }
+        }
+
+        when () {
+            !=(R|<local>/entries|.R|SubstitutionOverride<kotlin/enums/EnumEntries.get: R|foo/GeneratedEnum|>|(Int(0)), Q|foo/GeneratedEnum|.R|foo/GeneratedEnum.A|) ->  {
+                throw R|java/lang/IllegalArgumentException.IllegalArgumentException|()
+            }
+        }
+
+        when () {
+            !=(R|<local>/entries|.R|SubstitutionOverride<kotlin/enums/EnumEntries.get: R|foo/GeneratedEnum|>|(Int(1)), Q|foo/GeneratedEnum|.R|foo/GeneratedEnum.B|) ->  {
+                throw R|java/lang/IllegalArgumentException.IllegalArgumentException|()
+            }
+        }
+
+        when () {
+            !=(R|<local>/entries|.R|SubstitutionOverride<kotlin/enums/EnumEntries.get: R|foo/GeneratedEnum|>|(Int(2)), Q|foo/GeneratedEnum|.R|foo/GeneratedEnum.C|) ->  {
+                throw R|java/lang/IllegalArgumentException.IllegalArgumentException|()
+            }
+        }
+
+    }
+    public final fun box(): R|kotlin/String| {
+        R|/testEnumEntryVariables|()
+        R|/testEnumValues|()
+        R|/testEnumValueOf|()
+        R|/testEnumEntries|()
+        ^box String(OK)
+    }
+FILE: __GENERATED DECLARATIONS__.kt
+    package foo
+
+    public final enum class GeneratedEnum : R|kotlin/Enum<foo/GeneratedEnum>| {
+        public final static enum entry A: R|foo/GeneratedEnum|
+        public final static enum entry B: R|foo/GeneratedEnum|
+        public final static enum entry C: R|foo/GeneratedEnum|
+        public final static fun values(): R|kotlin/Array<foo/GeneratedEnum>| {
+        }
+
+        public final static fun valueOf(value: R|kotlin/String|): R|foo/GeneratedEnum| {
+        }
+
+        public final static val entries: R|kotlin/enums/EnumEntries<foo/GeneratedEnum>|
+            public get(): R|kotlin/enums/EnumEntries<foo/GeneratedEnum>|
+
+        private constructor(): R|foo/GeneratedEnum|
+
+    }

--- a/plugins/fir-plugin-prototype/testData/box/generatedEnumClass.kt
+++ b/plugins/fir-plugin-prototype/testData/box/generatedEnumClass.kt
@@ -1,0 +1,55 @@
+import foo.GeneratedEnum
+import java.util.Arrays
+import org.jetbrains.kotlin.fir.plugin.GenerateEnumConstant
+
+@GenerateEnumConstant
+class A
+
+@GenerateEnumConstant
+class B
+
+@GenerateEnumConstant
+class C
+
+fun testEnumEntryVariables() {
+    val entryA: GeneratedEnum = GeneratedEnum.A
+    val entryB: GeneratedEnum = GeneratedEnum.B
+    val entryC: GeneratedEnum = GeneratedEnum.C
+
+    if (entryA.name != "A" || entryA.ordinal != 0) throw IllegalArgumentException()
+    if (entryB.name != "B" || entryB.ordinal != 1) throw IllegalArgumentException()
+    if (entryC.name != "C" || entryC.ordinal != 2) throw IllegalArgumentException()
+}
+
+fun testEnumValues() {
+    val values = GeneratedEnum.values()
+
+    if (values.size != 3) throw IllegalArgumentException()
+    if (values[0] != GeneratedEnum.A) throw IllegalArgumentException()
+    if (values[1] != GeneratedEnum.B) throw IllegalArgumentException()
+    if (values[2] != GeneratedEnum.C) throw IllegalArgumentException()
+}
+
+fun testEnumValueOf() {
+    if (GeneratedEnum.A != GeneratedEnum.valueOf("A")) throw IllegalArgumentException()
+    if (GeneratedEnum.B != GeneratedEnum.valueOf("B")) throw IllegalArgumentException()
+    if (GeneratedEnum.C != GeneratedEnum.valueOf("C")) throw IllegalArgumentException()
+}
+
+fun testEnumEntries() {
+    val entries = GeneratedEnum.entries
+
+    if (entries.size != 3) throw IllegalArgumentException()
+    if (entries[0] != GeneratedEnum.A) throw IllegalArgumentException()
+    if (entries[1] != GeneratedEnum.B) throw IllegalArgumentException()
+    if (entries[2] != GeneratedEnum.C) throw IllegalArgumentException()
+}
+
+fun box(): String {
+    testEnumEntryVariables()
+    testEnumValues()
+    testEnumValueOf()
+    testEnumEntries()
+
+    return "OK"
+}

--- a/plugins/fir-plugin-prototype/tests-gen/org/jetbrains/kotlin/fir/plugin/runners/FirLightTreePluginBlackBoxCodegenTestGenerated.java
+++ b/plugins/fir-plugin-prototype/tests-gen/org/jetbrains/kotlin/fir/plugin/runners/FirLightTreePluginBlackBoxCodegenTestGenerated.java
@@ -120,4 +120,10 @@ public class FirLightTreePluginBlackBoxCodegenTestGenerated extends AbstractFirL
     public void testTopLevelCallables() throws Exception {
         runTest("plugins/fir-plugin-prototype/testData/box/topLevelCallables.kt");
     }
+
+    @Test
+    @TestMetadata("generatedEnumClass.kt")
+    public void generatedEnumClass() throws Exception {
+        runTest("plugins/fir-plugin-prototype/testData/box/generatedEnumClass.kt");
+    }
 }


### PR DESCRIPTION
Fixes [KT-62969](https://youtrack.jetbrains.com/issue/KT-62969)

Introduces the ability for K2 compiler plugins to generate enum entries using a `FirDeclarationGenerationExtension`. Also introduces a black box test that verifies a fully functional enum can actually be generated using this method.

This could also be solved by making `generateProperties` return `List<FirVariableSymbol<*>>` instead, however `generateProperties` is also used from another context for generating top-level properties, so I think a separate function fits better. Doing it in a separate function also has the added advantage that the `MemberGenerationContext` can be non-null for this separate function.
