### PR TITLE
KT-63044 - KGP: Fix configuration cache problem in KotlinJsIrLinkConfig

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/configuration/KotlinJsIrLinkConfig.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/configuration/KotlinJsIrLinkConfig.kt
@@ -29,10 +29,8 @@ internal open class KotlinJsIrLinkConfig(
             task.dependsOn(compilation.compileTaskProvider)
             task.dependsOn(compilation.output.classesDirs)
             task.entryModule.fileProvider(
-                compilation.output.classesDirs.elements.flatMap {
-                    task.project.providers.provider {
-                        it.single().asFile
-                    }
+                compilation.output.classesDirs.elements.map {
+                    it.single().asFile
                 }
             ).disallowChanges()
             task.rootCacheDirectory.set(project.layout.buildDirectory.map { it.dir("klib/cache/js/${binary.name}") })


### PR DESCRIPTION
Related to [KT-63044](https://youtrack.jetbrains.com/issue/KT-63044/KGP-Multiplatform-8.4-configuration-cache-support)

There is no need to create a provider inside an existing provider.