### PR TITLE
Add mapping functions for Pair and Triple

### DIFF
--- a/libraries/stdlib/samples/test/samples/misc/tuples.kt
+++ b/libraries/stdlib/samples/test/samples/misc/tuples.kt
@@ -43,4 +43,40 @@ class Tuples {
         assertPrints(intList, "[0, 1, 2]")
     }
 
+    @Sample
+    fun pairMapFirst() {
+        val x = Pair(1, "hello").mapFirst { it + 100 }
+        assertPrints(x, "(101, hello)")
+        assertEquals(Pair(101, "hello"), x)
+    }
+
+    @Sample
+    fun pairMapSecond() {
+        val x = Pair(1, "hello").mapSecond { it.length }
+        assertPrints(x, "(1, 5)")
+        assertEquals(Pair(1, 5), x)
+    }
+
+    @Sample
+    fun tripleMapFirst() {
+        val x = Triple(1, "hello", 3.14).mapFirst { it + 100 }
+        assertPrints(x, "(101, hello, 3.14)")
+        assertEquals(Triple(101, "hello", 3.14), x)
+    }
+
+
+    @Sample
+    fun tripleMapSecond() {
+        val x = Triple(1, "hello", 3.14).mapSecond { it.length }
+        assertPrints(x, "(1, 5, 3.14)")
+        assertEquals(Triple(1, 5, 3.14), x)
+    }
+
+    @Sample
+    fun tripleMapThird() {
+        val x = Triple(1, "hello", 3.14).mapThird { it.toString().reversed() }
+        assertPrints(x, "(1, hello, 41.3)")
+        assertEquals(Triple(1, "hello", "41.3"), x)
+    }
+
 }

--- a/libraries/stdlib/src/kotlin/util/Tuples.kt
+++ b/libraries/stdlib/src/kotlin/util/Tuples.kt
@@ -7,6 +7,10 @@
 
 package kotlin
 
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+import kotlin.internal.InlineOnly
+
 
 /**
  * Represents a generic pair of two values.
@@ -49,6 +53,30 @@ public infix fun <A, B> A.to(that: B): Pair<A, B> = Pair(this, that)
 public fun <T> Pair<T, T>.toList(): List<T> = listOf(first, second)
 
 /**
+ * Transforms the first component of a [Pair] by applying the given [transform]
+ * function.
+ *  @sample samples.misc.Tuples.pairMapFirst
+ */
+public inline fun <A, B, T> Pair<A, B>.mapFirst(transform: (A) -> T): Pair<T, B> {
+    contract {
+        callsInPlace(transform, InvocationKind.EXACTLY_ONCE)
+    }
+    return Pair(transform(first), second)
+}
+
+/**
+ * Transforms the second component of a [Pair] by applying the given [transform]
+ * function.
+ *  @sample samples.misc.Tuples.pairMapSecond
+ */
+public inline fun <A, B, T> Pair<A, B>.mapSecond(transform: (B) -> T): Pair<A, T> {
+    contract {
+        callsInPlace(transform, InvocationKind.EXACTLY_ONCE)
+    }
+    return Pair(first, transform(second))
+}
+
+/**
  * Represents a triad of values
  *
  * There is no meaning attached to values in this class, it can be used for any purpose.
@@ -80,3 +108,39 @@ public data class Triple<out A, out B, out C>(
  * @sample samples.misc.Tuples.tripleToList
  */
 public fun <T> Triple<T, T, T>.toList(): List<T> = listOf(first, second, third)
+
+/**
+ * Transforms the first component of a [Triple] by applying the given [transform]
+ * function.
+ *  @sample samples.misc.Tuples.tripleMapFirst
+ */
+public inline fun <A, B, C, T> Triple<A, B, C>.mapFirst(transform: (A) -> T): Triple<T, B, C> {
+    contract {
+        callsInPlace(transform, InvocationKind.EXACTLY_ONCE)
+    }
+    return Triple(transform(first), second, third)
+}
+
+/**
+ * Transforms the second component of a [Triple] by applying the given [transform]
+ * function.
+ *  @sample samples.misc.Tuples.tripleMapSecond
+ */
+public inline fun <A, B, C, T> Triple<A, B, C>.mapSecond(transform: (B) -> T): Triple<A, T, C> {
+    contract {
+        callsInPlace(transform, InvocationKind.EXACTLY_ONCE)
+    }
+    return Triple(first, transform(second), third)
+}
+
+/**
+ * Transforms the third component of a [Triple] by applying the given [transform]
+ * function.
+ *  @sample samples.misc.Tuples.tripleMapThird
+ */
+public inline fun <A, B, C, T> Triple<A, B, C>.mapThird(transform: (C) -> T): Triple<A, B, T> {
+    contract {
+        callsInPlace(transform, InvocationKind.EXACTLY_ONCE)
+    }
+    return Triple(first, second, transform(third))
+}


### PR DESCRIPTION
The `Pair` and `Triple` data types lacks a convenient way to map the individual components using a transformation function. The Result type already have map to transform the success value so it is already an established pattern in the stdlib.

For Pair `mapFirst` and `mapSecond` are added.
For Triple `mapFirst`, `mapSecond` and `mapThird` are added.

KT-21648 Fixed