### PR TITLE
KT-63544: Fix Gradle CC problem in KotlinJsIrLink

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/configuration/KotlinJsIrLinkConfig.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/configuration/KotlinJsIrLinkConfig.kt
@@ -29,10 +29,8 @@ internal open class KotlinJsIrLinkConfig(
             task.dependsOn(compilation.compileTaskProvider)
             task.dependsOn(compilation.output.classesDirs)
             task.entryModule.fileProvider(
-                compilation.output.classesDirs.elements.flatMap {
-                    task.project.providers.provider {
-                        it.single().asFile
-                    }
+                compilation.output.classesDirs.elements.map {
+                    it.single().asFile
                 }
             ).disallowChanges()
             task.rootCacheDirectory.set(project.layout.buildDirectory.map { it.dir("klib/cache/js/${binary.name}") })


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-63544/KGP-JS-KotlinJsIrLink-is-not-compatible-with-Gradle-CC-starting-8.4

Follow-up of https://youtrack.jetbrains.com/issue/KT-63044/KGP-Multiplatform-8.4-configuration-cache-support