### PR TITLE
[FIR] KT-63563 check explicit anonymous function return type

### DIFF
--- a/analysis/low-level-api-fir/tests/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/compiler/based/DiagnosticCompilerTestFE10TestdataTestGenerated.java
+++ b/analysis/low-level-api-fir/tests/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/compiler/based/DiagnosticCompilerTestFE10TestdataTestGenerated.java
@@ -13499,6 +13499,12 @@ public class DiagnosticCompilerTestFE10TestdataTestGenerated extends AbstractDia
             }
 
             @Test
+            @TestMetadata("kt63563.kt")
+            public void testKt63563() throws Exception {
+                runTest("compiler/testData/diagnostics/tests/functionLiterals/kt63563.kt");
+            }
+
+            @Test
             @TestMetadata("kt6541_extensionForExtensionFunction.kt")
             public void testKt6541_extensionForExtensionFunction() throws Exception {
                 runTest("compiler/testData/diagnostics/tests/functionLiterals/kt6541_extensionForExtensionFunction.kt");

--- a/analysis/low-level-api-fir/tests/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/compiler/based/LLFirPreresolvedReversedDiagnosticCompilerFE10TestDataTestGenerated.java
+++ b/analysis/low-level-api-fir/tests/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/compiler/based/LLFirPreresolvedReversedDiagnosticCompilerFE10TestDataTestGenerated.java
@@ -13499,6 +13499,12 @@ public class LLFirPreresolvedReversedDiagnosticCompilerFE10TestDataTestGenerated
             }
 
             @Test
+            @TestMetadata("kt63563.kt")
+            public void testKt63563() throws Exception {
+                runTest("compiler/testData/diagnostics/tests/functionLiterals/kt63563.kt");
+            }
+
+            @Test
             @TestMetadata("kt6541_extensionForExtensionFunction.kt")
             public void testKt6541_extensionForExtensionFunction() throws Exception {
                 runTest("compiler/testData/diagnostics/tests/functionLiterals/kt6541_extensionForExtensionFunction.kt");

--- a/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirLightTreeOldFrontendDiagnosticsTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirLightTreeOldFrontendDiagnosticsTestGenerated.java
@@ -13397,6 +13397,12 @@ public class FirLightTreeOldFrontendDiagnosticsTestGenerated extends AbstractFir
             }
 
             @Test
+            @TestMetadata("explicitAnonymousFunctionReturnType.kt")
+            public void testExplicitAnonymousFunctionReturnType() throws Exception {
+                runTest("compiler/testData/diagnostics/tests/functionLiterals/explicitAnonymousFunctionReturnType.kt");
+            }
+
+            @Test
             @TestMetadata("functionExpressionAsLastExpressionInBlock.kt")
             public void testFunctionExpressionAsLastExpressionInBlock() throws Exception {
                 runTest("compiler/testData/diagnostics/tests/functionLiterals/functionExpressionAsLastExpressionInBlock.kt");

--- a/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirPsiOldFrontendDiagnosticsTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirPsiOldFrontendDiagnosticsTestGenerated.java
@@ -13403,6 +13403,12 @@ public class FirPsiOldFrontendDiagnosticsTestGenerated extends AbstractFirPsiDia
             }
 
             @Test
+            @TestMetadata("explicitAnonymousFunctionReturnType.kt")
+            public void testExplicitAnonymousFunctionReturnType() throws Exception {
+                runTest("compiler/testData/diagnostics/tests/functionLiterals/explicitAnonymousFunctionReturnType.kt");
+            }
+
+            @Test
             @TestMetadata("functionExpressionAsLastExpressionInBlock.kt")
             public void testFunctionExpressionAsLastExpressionInBlock() throws Exception {
                 runTest("compiler/testData/diagnostics/tests/functionLiterals/functionExpressionAsLastExpressionInBlock.kt");

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/expression/FirFunctionReturnTypeMismatchChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/expression/FirFunctionReturnTypeMismatchChecker.kt
@@ -19,7 +19,6 @@ import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors.SMARTCAST_IMPOSSI
 import org.jetbrains.kotlin.fir.declarations.*
 import org.jetbrains.kotlin.fir.expressions.*
 import org.jetbrains.kotlin.fir.expressions.impl.FirResolvedArgumentList
-import org.jetbrains.kotlin.fir.resolve.dfa.cfg.SplitPostponedLambdasNode
 import org.jetbrains.kotlin.fir.resolve.dfa.controlFlowGraph
 import org.jetbrains.kotlin.fir.types.*
 
@@ -119,10 +118,8 @@ object FirFunctionReturnTypeMismatchChecker : FirReturnExpressionChecker() {
     private fun shouldCheckMismatchForAnonymousFunction(targetElement: FirFunction, expression: FirReturnExpression, context: CheckerContext): Boolean {
         if (targetElement !is FirAnonymousFunction || !targetElement.isLambda) return true
         val cfgNodes = targetElement.controlFlowGraphReference?.controlFlowGraph?.exitNode?.previousCfgNodes ?: return true
-        val splitPostponedLambdasNode =
-            targetElement.controlFlowGraphReference?.controlFlowGraph?.enterNode?.previousCfgNodes?.singleOrNull() as? SplitPostponedLambdasNode
-        if (splitPostponedLambdasNode != null) {
-            val functionCall = splitPostponedLambdasNode.fir as FirFunctionCall
+        val functionCall = context.callsOrAssignments.lastOrNull() as? FirFunctionCall
+        if (functionCall != null) {
             val argumentList = functionCall.argumentList
             if (argumentList is FirResolvedArgumentList) {
                 for ((key, value) in argumentList.mapping) {

--- a/compiler/testData/diagnostics/tests/functionLiterals/explicitAnonymousFunctionReturnType.kt
+++ b/compiler/testData/diagnostics/tests/functionLiterals/explicitAnonymousFunctionReturnType.kt
@@ -1,0 +1,63 @@
+// FIR_IDENTICAL
+// KT-63563 If the return type of an anonymous function is explicitly specified and the return type is not a ConeTypeParameter, then RETURN_TYPE_MISMATCH should be reported
+fun foo(x: () -> Any?) {}
+fun <T> fooWithTypeParameter(x: () -> T): T = x()
+fun foo2(x2: () -> Any?, y2: () -> Any?) {}
+fun <T> foo2WithTypeParameter(x2: () -> T, y2: () -> Any?) {}
+
+fun test() {
+    run {
+        if ("".hashCode() == 1) return@run
+
+        ""
+    }
+}
+
+fun test1() {
+    foo {
+        if ("".hashCode() == 1) ""
+
+        <!RETURN_TYPE_MISMATCH!>return@foo<!>
+    }
+}
+
+fun test2() {
+    foo {
+        if ("".hashCode() == 1) <!RETURN_TYPE_MISMATCH!>return@foo<!>
+
+        ""
+    }
+}
+
+fun test3() {
+    foo2WithTypeParameter(
+        {
+            if ("".hashCode() == 1) return@foo2WithTypeParameter
+
+            ""
+        }) {
+        if ("".hashCode() == 2) <!RETURN_TYPE_MISMATCH!>return@foo2WithTypeParameter<!>
+
+        ""
+    }
+}
+
+fun test4() {
+    foo2({
+             if ("".hashCode() == 1) <!RETURN_TYPE_MISMATCH!>return@foo2<!>
+
+             ""
+         }) {
+        if ("".hashCode() == 2) <!RETURN_TYPE_MISMATCH!>return@foo2<!>
+
+        ""
+    }
+}
+
+fun test5() {
+    fooWithTypeParameter {
+        if (true) return@fooWithTypeParameter
+        if (true) return@fooWithTypeParameter Unit
+        fooWithTypeParameter { Any() }
+    }
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/DiagnosticTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/DiagnosticTestGenerated.java
@@ -13403,6 +13403,12 @@ public class DiagnosticTestGenerated extends AbstractDiagnosticTest {
             }
 
             @Test
+            @TestMetadata("explicitAnonymousFunctionReturnType.kt")
+            public void testExplicitAnonymousFunctionReturnType() throws Exception {
+                runTest("compiler/testData/diagnostics/tests/functionLiterals/explicitAnonymousFunctionReturnType.kt");
+            }
+
+            @Test
             @TestMetadata("functionExpressionAsLastExpressionInBlock.kt")
             public void testFunctionExpressionAsLastExpressionInBlock() throws Exception {
                 runTest("compiler/testData/diagnostics/tests/functionLiterals/functionExpressionAsLastExpressionInBlock.kt");


### PR DESCRIPTION
If the return type of an anonymous function is explicitly specified in the value parameter of the parent function call and the return type is not `ConeTypeParameter`, then `RETURN_TYPE_MISMATCH` shall be reported

[KT-63563](https://youtrack.jetbrains.com/issue/KT-63563)