### PR TITLE
[Codegen][JVM]: Mark line number before invoking intrinsics

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirLightTreeBytecodeTextTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirLightTreeBytecodeTextTestGenerated.java
@@ -4607,6 +4607,12 @@ public class FirLightTreeBytecodeTextTestGenerated extends AbstractFirLightTreeB
         }
 
         @Test
+        @TestMetadata("kt61768.kt")
+        public void testKt61768() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/lineNumbers/kt61768.kt");
+        }
+
+        @Test
         @TestMetadata("singleThen.kt")
         public void testSingleThen() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/lineNumbers/singleThen.kt");

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirPsiBytecodeTextTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirPsiBytecodeTextTestGenerated.java
@@ -4607,6 +4607,12 @@ public class FirPsiBytecodeTextTestGenerated extends AbstractFirPsiBytecodeTextT
         }
 
         @Test
+        @TestMetadata("kt61768.kt")
+        public void testKt61768() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/lineNumbers/kt61768.kt");
+        }
+
+        @Test
         @TestMetadata("singleThen.kt")
         public void testSingleThen() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/lineNumbers/singleThen.kt");

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -582,7 +582,10 @@ class ExpressionCodegen(
 
     override fun visitCall(expression: IrCall, data: BlockInfo): PromisedValue {
         val intrinsic = classCodegen.context.getIntrinsic(expression.symbol) as IntrinsicMethod?
-        intrinsic?.invoke(expression, this, data)?.let { return it }
+        if (intrinsic != null) {
+            expression.markLineNumber(true)
+            intrinsic.invoke(expression, this, data)?.let { return it }
+        }
 
         val callee = expression.symbol.owner
         require(callee.parent is IrClass) { "Unhandled intrinsic in ExpressionCodegen: ${callee.render()}" }

--- a/compiler/testData/codegen/bytecodeText/lineNumbers/kt61768.kt
+++ b/compiler/testData/codegen/bytecodeText/lineNumbers/kt61768.kt
@@ -1,0 +1,8 @@
+// TARGET_BACKEND: JVM_IR
+
+fun increment() {
+    var i = 10
+    i = i + 10
+}
+
+// 1 LINENUMBER 5 L1\n +IINC

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBytecodeTextTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBytecodeTextTestGenerated.java
@@ -4607,6 +4607,12 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
         }
 
         @Test
+        @TestMetadata("kt61768.kt")
+        public void testKt61768() throws Exception {
+            runTest("compiler/testData/codegen/bytecodeText/lineNumbers/kt61768.kt");
+        }
+
+        @Test
         @TestMetadata("singleThen.kt")
         public void testSingleThen() throws Exception {
             runTest("compiler/testData/codegen/bytecodeText/lineNumbers/singleThen.kt");


### PR DESCRIPTION
Fixes #KT-61768

Code generated now and after: 
![image](https://github.com/JetBrains/kotlin/assets/5899940/eb7054bd-c77f-4722-8a55-b609198a724c)
