### PR TITLE
[debug][bindings][python] Let lldb filter the list of symbols

### DIFF
--- a/kotlin-native/llvmDebugInfoC/src/scripts/konan_lldb.py
+++ b/kotlin-native/llvmDebugInfoC/src/scripts/konan_lldb.py
@@ -77,7 +77,7 @@ def _symbol_loaded_address(name, debugger = lldb.debugger):
     process = target.GetProcess()
     thread = process.GetSelectedThread()
     frame = thread.GetSelectedFrame()
-    candidates = list(filter(lambda x: x.name == name, frame.module.symbols))
+    candidates = frame.module.symbol[name]
     # take first
     for candidate in candidates:
         address = candidate.GetStartAddress().GetLoadAddress(target)


### PR DESCRIPTION
Marshalling the full list of symbols to Python and filtering that was slow for binaries with large numbers of symbols.

^KT-63749 Fixed