### PR TITLE
Fixed remote build cache setup for forked PRs

### DIFF
--- a/repo/gradle-settings-conventions/build-cache/src/main/kotlin/build-cache.settings.gradle.kts
+++ b/repo/gradle-settings-conventions/build-cache/src/main/kotlin/build-cache.settings.gradle.kts
@@ -11,11 +11,11 @@ buildCache {
     val remoteBuildCacheUrl = buildProperties.buildCacheUrl?.trim()
     if (!remoteBuildCacheUrl.isNullOrEmpty()) {
         remote<HttpBuildCache> {
+            val buildCacheCredentialsAvailable = buildProperties.buildCacheUser != null && buildProperties.buildCachePassword != null
+            
             url = uri(remoteBuildCacheUrl)
-            isPush = buildProperties.pushToBuildCache
-            if (buildProperties.buildCacheUser != null &&
-                buildProperties.buildCachePassword != null
-            ) {
+            isPush = buildProperties.pushToBuildCache && buildCacheCredentialsAvailable
+            if (buildCacheCredentialsAvailable) {
                 credentials.username = buildProperties.buildCacheUser
                 credentials.password = buildProperties.buildCachePassword
             }

--- a/repo/gradle-settings-conventions/settings.gradle.kts
+++ b/repo/gradle-settings-conventions/settings.gradle.kts
@@ -51,11 +51,11 @@ buildCache {
     val remoteBuildCacheUrl = buildProperties.buildCacheUrl?.trim()
     if (!remoteBuildCacheUrl.isNullOrEmpty()) {
         remote<HttpBuildCache> {
+            val buildCacheCredentialsAvailable = buildProperties.buildCacheUser != null && buildProperties.buildCachePassword != null
+            
             url = uri(remoteBuildCacheUrl)
-            isPush = buildProperties.pushToBuildCache
-            if (buildProperties.buildCacheUser != null &&
-                buildProperties.buildCachePassword != null
-            ) {
+            isPush = buildProperties.pushToBuildCache && buildCacheCredentialsAvailable
+            if (buildCacheCredentialsAvailable) {
                 credentials.username = buildProperties.buildCacheUser
                 credentials.password = buildProperties.buildCachePassword
             }


### PR DESCRIPTION
Fixed remote build cache setup for forked PRs. This addresses the case where a PR from a fork runs on the CI, which has `buildProperties.pushToBuildCache` set to true, but is missing the remote build cache credentials as it's not running in a secure environment. In that case we want to disable pushing to remote cache. If left enabled, the build will try to push and fail, which will in return turn remote build cache off for the rest of the build, causing build performance degradation.