### PR TITLE
Support jakarta Nullability annotations

### DIFF
--- a/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirPsiOldFrontendForeignAnnotationsCompiledJavaTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirPsiOldFrontendForeignAnnotationsCompiledJavaTestGenerated.java
@@ -99,6 +99,30 @@ public class FirPsiOldFrontendForeignAnnotationsCompiledJavaTestGenerated extend
     }
 
     @Test
+    @TestMetadata("jakartaDefault.kt")
+    public void testJakartaDefault() {
+      runTest("compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaDefault.kt");
+    }
+
+    @Test
+    @TestMetadata("jakartaErrors.kt")
+    public void testJakartaErrors() {
+      runTest("compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaErrors.kt");
+    }
+
+    @Test
+    @TestMetadata("jakartaIgnore.kt")
+    public void testJakartaIgnore() {
+      runTest("compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaIgnore.kt");
+    }
+
+    @Test
+    @TestMetadata("jakartaWarnings.kt")
+    public void testJakartaWarnings() {
+      runTest("compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaWarnings.kt");
+    }
+
+    @Test
     @TestMetadata("kt47833.kt")
     public void testKt47833() {
       runTest("compiler/testData/diagnostics/foreignAnnotationsTests/tests/kt47833.kt");

--- a/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirPsiOldFrontendForeignAnnotationsCompiledJavaWithPsiClassReadingTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirPsiOldFrontendForeignAnnotationsCompiledJavaWithPsiClassReadingTestGenerated.java
@@ -99,6 +99,30 @@ public class FirPsiOldFrontendForeignAnnotationsCompiledJavaWithPsiClassReadingT
     }
 
     @Test
+    @TestMetadata("jakartaDefault.kt")
+    public void testJakartaDefault() {
+      runTest("compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaDefault.kt");
+    }
+
+    @Test
+    @TestMetadata("jakartaErrors.kt")
+    public void testJakartaErrors() {
+      runTest("compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaErrors.kt");
+    }
+
+    @Test
+    @TestMetadata("jakartaIgnore.kt")
+    public void testJakartaIgnore() {
+      runTest("compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaIgnore.kt");
+    }
+
+    @Test
+    @TestMetadata("jakartaWarnings.kt")
+    public void testJakartaWarnings() {
+      runTest("compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaWarnings.kt");
+    }
+
+    @Test
     @TestMetadata("kt47833.kt")
     public void testKt47833() {
       runTest("compiler/testData/diagnostics/foreignAnnotationsTests/tests/kt47833.kt");

--- a/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirPsiOldFrontendForeignAnnotationsSourceJavaTestGenerated.java
+++ b/compiler/fir/analysis-tests/tests-gen/org/jetbrains/kotlin/test/runners/FirPsiOldFrontendForeignAnnotationsSourceJavaTestGenerated.java
@@ -99,6 +99,30 @@ public class FirPsiOldFrontendForeignAnnotationsSourceJavaTestGenerated extends 
     }
 
     @Test
+    @TestMetadata("jakartaDefault.kt")
+    public void testJakartaDefault() {
+      runTest("compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaDefault.kt");
+    }
+
+    @Test
+    @TestMetadata("jakartaErrors.kt")
+    public void testJakartaErrors() {
+      runTest("compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaErrors.kt");
+    }
+
+    @Test
+    @TestMetadata("jakartaIgnore.kt")
+    public void testJakartaIgnore() {
+      runTest("compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaIgnore.kt");
+    }
+
+    @Test
+    @TestMetadata("jakartaWarnings.kt")
+    public void testJakartaWarnings() {
+      runTest("compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaWarnings.kt");
+    }
+
+    @Test
     @TestMetadata("kt47833.kt")
     public void testKt47833() {
       runTest("compiler/testData/diagnostics/foreignAnnotationsTests/tests/kt47833.kt");

--- a/compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaDefault.kt
+++ b/compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaDefault.kt
@@ -1,0 +1,43 @@
+// FIR_IDENTICAL
+// FILE: A.java
+
+import jakarta.annotation.*;
+
+public class A<T> {
+    @Nullable public String field = null;
+
+    @Nullable
+    public String foo(@Nonnull String x, @Nullable CharSequence y) {
+        return "";
+    }
+
+    @Nonnull
+    public String bar() {
+        return "";
+    }
+
+    @Nullable
+    public T baz(@Nonnull T x) { return x; }
+}
+
+// FILE: main.kt
+
+fun main(a: A<String>, a1: A<String?>) {
+    a.foo("", null)?.length
+    <!RECEIVER_NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS!>a.foo("", null)<!>.length
+    <!RECEIVER_NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS!>a.foo(<!NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS!>null<!>, "")<!>.length
+    a.foo("", null)!!.length
+
+    a.bar().length
+    a.bar()<!UNNECESSARY_NOT_NULL_ASSERTION!>!!<!>.length
+
+    a.field?.length
+    <!RECEIVER_NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS!>a.field<!>.length
+
+    <!RECEIVER_NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS!>a.baz("")<!>.length
+    a.baz("")?.length
+    <!RECEIVER_NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS!>a.baz(<!NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS!>null<!>)<!>.length
+
+    a1.baz("")!!.length
+    a1.baz(<!NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS!>null<!>)!!.length
+}

--- a/compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaDefault.txt
+++ b/compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaDefault.txt
@@ -1,0 +1,14 @@
+package
+
+public fun main(/*0*/ a: A<kotlin.String>, /*1*/ a1: A<kotlin.String?>): kotlin.Unit
+
+public open class A</*0*/ T : kotlin.Any!> {
+    public constructor A</*0*/ T : kotlin.Any!>()
+    @jakarta.annotation.Nullable public final var field: @jakarta.annotation.Nullable kotlin.String!
+    @jakarta.annotation.Nonnull public open fun bar(): @jakarta.annotation.Nonnull kotlin.String!
+    @jakarta.annotation.Nullable public open fun baz(/*0*/ @jakarta.annotation.Nonnull x: @jakarta.annotation.Nonnull T!): @jakarta.annotation.Nullable T!
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    @jakarta.annotation.Nullable public open fun foo(/*0*/ @jakarta.annotation.Nonnull x: @jakarta.annotation.Nonnull kotlin.String!, /*1*/ @jakarta.annotation.Nullable y: @jakarta.annotation.Nullable kotlin.CharSequence!): @jakarta.annotation.Nullable kotlin.String!
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}

--- a/compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaDefault.txt
+++ b/compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaDefault.txt
@@ -4,11 +4,11 @@ public fun main(/*0*/ a: A<kotlin.String>, /*1*/ a1: A<kotlin.String?>): kotlin.
 
 public open class A</*0*/ T : kotlin.Any!> {
     public constructor A</*0*/ T : kotlin.Any!>()
-    @jakarta.annotation.Nullable public final var field: @jakarta.annotation.Nullable kotlin.String!
-    @jakarta.annotation.Nonnull public open fun bar(): @jakarta.annotation.Nonnull kotlin.String!
-    @jakarta.annotation.Nullable public open fun baz(/*0*/ @jakarta.annotation.Nonnull x: @jakarta.annotation.Nonnull T!): @jakarta.annotation.Nullable T!
+    @jakarta.annotation.Nullable public final var field: kotlin.String!
+    @jakarta.annotation.Nonnull public open fun bar(): kotlin.String!
+    @jakarta.annotation.Nullable public open fun baz(/*0*/ @jakarta.annotation.Nonnull x: T!): T!
     public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
-    @jakarta.annotation.Nullable public open fun foo(/*0*/ @jakarta.annotation.Nonnull x: @jakarta.annotation.Nonnull kotlin.String!, /*1*/ @jakarta.annotation.Nullable y: @jakarta.annotation.Nullable kotlin.CharSequence!): @jakarta.annotation.Nullable kotlin.String!
+    @jakarta.annotation.Nullable public open fun foo(/*0*/ @jakarta.annotation.Nonnull x: kotlin.String!, /*1*/ @jakarta.annotation.Nullable y: kotlin.CharSequence!): kotlin.String!
     public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
     public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
 }

--- a/compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaErrors.kt
+++ b/compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaErrors.kt
@@ -1,0 +1,44 @@
+// FIR_IDENTICAL
+// NULLABILITY_ANNOTATIONS: @jakarta.annotation:strict
+
+// FILE: A.java
+
+import jakarta.annotation.*;
+
+public class A<T> {
+    @Nullable public String field = null;
+
+    @Nullable
+    public String foo(@Nonnull String x, @Nullable CharSequence y) {
+        return "";
+    }
+
+    @Nonnull
+    public String bar() {
+        return "";
+    }
+
+    @Nullable
+    public T baz(@Nonnull T x) { return x; }
+}
+
+// FILE: main.kt
+
+fun main(a: A<String>, a1: A<String?>) {
+    a.foo("", null)?.length
+    a.foo("", null)<!UNSAFE_CALL!>.<!>length
+    a.foo(<!NULL_FOR_NONNULL_TYPE!>null<!>, "")<!UNSAFE_CALL!>.<!>length
+
+    a.bar().length
+    a.bar()<!UNNECESSARY_NOT_NULL_ASSERTION!>!!<!>.length
+
+    a.field?.length
+    a.field<!UNSAFE_CALL!>.<!>length
+
+    a.baz("")<!UNSAFE_CALL!>.<!>length
+    a.baz("")?.length
+    a.baz(<!NULL_FOR_NONNULL_TYPE!>null<!>)<!UNSAFE_CALL!>.<!>length
+
+    a1.baz("")!!.length
+    a1.baz(<!NULL_FOR_NONNULL_TYPE!>null<!>)!!.length
+}

--- a/compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaErrors.txt
+++ b/compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaErrors.txt
@@ -4,11 +4,11 @@ public fun main(/*0*/ a: A<kotlin.String>, /*1*/ a1: A<kotlin.String?>): kotlin.
 
 public open class A</*0*/ T : kotlin.Any!> {
     public constructor A</*0*/ T : kotlin.Any!>()
-    @jakarta.annotation.Nullable public final var field: @jakarta.annotation.Nullable kotlin.String?
-    @jakarta.annotation.Nonnull public open fun bar(): @jakarta.annotation.Nonnull kotlin.String
-    @jakarta.annotation.Nullable public open fun baz(/*0*/ @jakarta.annotation.Nonnull x: @jakarta.annotation.Nonnull T & Any): @jakarta.annotation.Nullable T?
+    @jakarta.annotation.Nullable public final var field: kotlin.String?
+    @jakarta.annotation.Nonnull public open fun bar(): kotlin.String
+    @jakarta.annotation.Nullable public open fun baz(/*0*/ @jakarta.annotation.Nonnull x: T & Any): T?
     public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
-    @jakarta.annotation.Nullable public open fun foo(/*0*/ @jakarta.annotation.Nonnull x: @jakarta.annotation.Nonnull kotlin.String, /*1*/ @jakarta.annotation.Nullable y: @jakarta.annotation.Nullable kotlin.CharSequence?): @jakarta.annotation.Nullable kotlin.String?
+    @jakarta.annotation.Nullable public open fun foo(/*0*/ @jakarta.annotation.Nonnull x: kotlin.String, /*1*/ @jakarta.annotation.Nullable y: kotlin.CharSequence?): kotlin.String?
     public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
     public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
 }

--- a/compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaErrors.txt
+++ b/compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaErrors.txt
@@ -1,0 +1,15 @@
+package
+
+public fun main(/*0*/ a: A<kotlin.String>, /*1*/ a1: A<kotlin.String?>): kotlin.Unit
+
+public open class A</*0*/ T : kotlin.Any!> {
+    public constructor A</*0*/ T : kotlin.Any!>()
+    @jakarta.annotation.Nullable public final var field: @jakarta.annotation.Nullable kotlin.String?
+    @jakarta.annotation.Nonnull public open fun bar(): @jakarta.annotation.Nonnull kotlin.String
+    @jakarta.annotation.Nullable public open fun baz(/*0*/ @jakarta.annotation.Nonnull x: @jakarta.annotation.Nonnull T & Any): @jakarta.annotation.Nullable T?
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    @jakarta.annotation.Nullable public open fun foo(/*0*/ @jakarta.annotation.Nonnull x: @jakarta.annotation.Nonnull kotlin.String, /*1*/ @jakarta.annotation.Nullable y: @jakarta.annotation.Nullable kotlin.CharSequence?): @jakarta.annotation.Nullable kotlin.String?
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}
+

--- a/compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaIgnore.kt
+++ b/compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaIgnore.kt
@@ -1,0 +1,44 @@
+// FIR_IDENTICAL
+// NULLABILITY_ANNOTATIONS: @jakarta.annotation:ignore
+
+// FILE: A.java
+
+import jakarta.annotation.*;
+
+public class A<T> {
+    @Nullable public String field = null;
+
+    @Nullable
+    public String foo(@Nonnull String x, @Nullable CharSequence y) {
+        return "";
+    }
+
+    @Nonnull
+    public String bar() {
+        return "";
+    }
+
+    @Nullable
+    public T baz(@Nonnull T x) { return x; }
+}
+
+// FILE: main.kt
+
+fun main(a: A<String>, a1: A<String?>) {
+    a.foo("", null)?.length
+    a.foo("", null).length
+    a.foo(null, "").length
+
+    a.bar().length
+    a.bar()!!.length
+
+    a.field?.length
+    a.field.length
+
+    a.baz("").length
+    a.baz("")?.length
+    a.baz(null).length
+
+    a1.baz("")!!.length
+    a1.baz(null)!!.length
+}

--- a/compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaIgnore.txt
+++ b/compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaIgnore.txt
@@ -1,0 +1,14 @@
+package
+
+public fun main(/*0*/ a: A<kotlin.String>, /*1*/ a1: A<kotlin.String?>): kotlin.Unit
+
+public open class A</*0*/ T : kotlin.Any!> {
+    public constructor A</*0*/ T : kotlin.Any!>()
+    @jakarta.annotation.Nullable public final var field: @jakarta.annotation.Nullable kotlin.String!
+    @jakarta.annotation.Nonnull public open fun bar(): @jakarta.annotation.Nonnull kotlin.String!
+    @jakarta.annotation.Nullable public open fun baz(/*0*/ @jakarta.annotation.Nonnull x: @jakarta.annotation.Nonnull T!): @jakarta.annotation.Nullable T!
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    @jakarta.annotation.Nullable public open fun foo(/*0*/ @jakarta.annotation.Nonnull x: @jakarta.annotation.Nonnull kotlin.String!, /*1*/ @jakarta.annotation.Nullable y: @jakarta.annotation.Nullable kotlin.CharSequence!): @jakarta.annotation.Nullable kotlin.String!
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}

--- a/compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaIgnore.txt
+++ b/compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaIgnore.txt
@@ -4,11 +4,11 @@ public fun main(/*0*/ a: A<kotlin.String>, /*1*/ a1: A<kotlin.String?>): kotlin.
 
 public open class A</*0*/ T : kotlin.Any!> {
     public constructor A</*0*/ T : kotlin.Any!>()
-    @jakarta.annotation.Nullable public final var field: @jakarta.annotation.Nullable kotlin.String!
-    @jakarta.annotation.Nonnull public open fun bar(): @jakarta.annotation.Nonnull kotlin.String!
-    @jakarta.annotation.Nullable public open fun baz(/*0*/ @jakarta.annotation.Nonnull x: @jakarta.annotation.Nonnull T!): @jakarta.annotation.Nullable T!
+    @jakarta.annotation.Nullable public final var field: kotlin.String!
+    @jakarta.annotation.Nonnull public open fun bar(): kotlin.String!
+    @jakarta.annotation.Nullable public open fun baz(/*0*/ @jakarta.annotation.Nonnull x: T!): T!
     public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
-    @jakarta.annotation.Nullable public open fun foo(/*0*/ @jakarta.annotation.Nonnull x: @jakarta.annotation.Nonnull kotlin.String!, /*1*/ @jakarta.annotation.Nullable y: @jakarta.annotation.Nullable kotlin.CharSequence!): @jakarta.annotation.Nullable kotlin.String!
+    @jakarta.annotation.Nullable public open fun foo(/*0*/ @jakarta.annotation.Nonnull x: kotlin.String!, /*1*/ @jakarta.annotation.Nullable y: kotlin.CharSequence!): kotlin.String!
     public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
     public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
 }

--- a/compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaWarnings.kt
+++ b/compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaWarnings.kt
@@ -1,0 +1,44 @@
+// FIR_IDENTICAL
+// NULLABILITY_ANNOTATIONS: @jakarta.annotation:warn
+
+// FILE: A.java
+
+import jakarta.annotation.*;
+
+public class A<T> {
+    @Nullable public String field = null;
+
+    @Nullable
+    public String foo(@Nonnull String x, @Nullable CharSequence y) {
+        return "";
+    }
+
+    @Nonnull
+    public String bar() {
+        return "";
+    }
+
+    @Nullable
+    public T baz(@Nonnull T x) { return x; }
+}
+
+// FILE: main.kt
+
+fun main(a: A<String>, a1: A<String?>) {
+    a.foo("", null)?.length
+    <!RECEIVER_NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS!>a.foo("", null)<!>.length
+    <!RECEIVER_NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS!>a.foo(<!NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS!>null<!>, "")<!>.length
+
+    a.bar().length
+    a.bar()<!UNNECESSARY_NOT_NULL_ASSERTION!>!!<!>.length
+
+    a.field?.length
+    <!RECEIVER_NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS!>a.field<!>.length
+
+    <!RECEIVER_NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS!>a.baz("")<!>.length
+    a.baz("")?.length
+    <!RECEIVER_NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS!>a.baz(<!NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS!>null<!>)<!>.length
+
+    a1.baz("")!!.length
+    a1.baz(<!NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS!>null<!>)!!.length
+}

--- a/compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaWarnings.txt
+++ b/compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaWarnings.txt
@@ -1,0 +1,14 @@
+package
+
+public fun main(/*0*/ a: A<kotlin.String>, /*1*/ a1: A<kotlin.String?>): kotlin.Unit
+
+public open class A</*0*/ T : kotlin.Any!> {
+    public constructor A</*0*/ T : kotlin.Any!>()
+    @jakarta.annotation.Nullable public final var field: @jakarta.annotation.Nullable kotlin.String!
+    @jakarta.annotation.Nonnull public open fun bar(): @jakarta.annotation.Nonnull kotlin.String!
+    @jakarta.annotation.Nullable public open fun baz(/*0*/ @jakarta.annotation.Nonnull x: @jakarta.annotation.Nonnull T!): @jakarta.annotation.Nullable T!
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    @jakarta.annotation.Nullable public open fun foo(/*0*/ @jakarta.annotation.Nonnull x: @jakarta.annotation.Nonnull kotlin.String!, /*1*/ @jakarta.annotation.Nullable y: @jakarta.annotation.Nullable kotlin.CharSequence!): @jakarta.annotation.Nullable kotlin.String!
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+}

--- a/compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaWarnings.txt
+++ b/compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaWarnings.txt
@@ -4,11 +4,11 @@ public fun main(/*0*/ a: A<kotlin.String>, /*1*/ a1: A<kotlin.String?>): kotlin.
 
 public open class A</*0*/ T : kotlin.Any!> {
     public constructor A</*0*/ T : kotlin.Any!>()
-    @jakarta.annotation.Nullable public final var field: @jakarta.annotation.Nullable kotlin.String!
-    @jakarta.annotation.Nonnull public open fun bar(): @jakarta.annotation.Nonnull kotlin.String!
-    @jakarta.annotation.Nullable public open fun baz(/*0*/ @jakarta.annotation.Nonnull x: @jakarta.annotation.Nonnull T!): @jakarta.annotation.Nullable T!
+    @jakarta.annotation.Nullable public final var field: kotlin.String!
+    @jakarta.annotation.Nonnull public open fun bar(): kotlin.String!
+    @jakarta.annotation.Nullable public open fun baz(/*0*/ @jakarta.annotation.Nonnull x: T!): T!
     public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
-    @jakarta.annotation.Nullable public open fun foo(/*0*/ @jakarta.annotation.Nonnull x: @jakarta.annotation.Nonnull kotlin.String!, /*1*/ @jakarta.annotation.Nullable y: @jakarta.annotation.Nullable kotlin.CharSequence!): @jakarta.annotation.Nullable kotlin.String!
+    @jakarta.annotation.Nullable public open fun foo(/*0*/ @jakarta.annotation.Nonnull x: kotlin.String!, /*1*/ @jakarta.annotation.Nullable y: kotlin.CharSequence!): kotlin.String!
     public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
     public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
 }

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/ForeignAnnotationsCompiledJavaTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/ForeignAnnotationsCompiledJavaTestGenerated.java
@@ -99,6 +99,30 @@ public class ForeignAnnotationsCompiledJavaTestGenerated extends AbstractForeign
     }
 
     @Test
+    @TestMetadata("jakartaDefault.kt")
+    public void testJakartaDefault() {
+      runTest("compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaDefault.kt");
+    }
+
+    @Test
+    @TestMetadata("jakartaErrors.kt")
+    public void testJakartaErrors() {
+      runTest("compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaErrors.kt");
+    }
+
+    @Test
+    @TestMetadata("jakartaIgnore.kt")
+    public void testJakartaIgnore() {
+      runTest("compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaIgnore.kt");
+    }
+
+    @Test
+    @TestMetadata("jakartaWarnings.kt")
+    public void testJakartaWarnings() {
+      runTest("compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaWarnings.kt");
+    }
+
+    @Test
     @TestMetadata("kt47833.kt")
     public void testKt47833() {
       runTest("compiler/testData/diagnostics/foreignAnnotationsTests/tests/kt47833.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/ForeignAnnotationsCompiledJavaWithPsiClassReadingTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/ForeignAnnotationsCompiledJavaWithPsiClassReadingTestGenerated.java
@@ -99,6 +99,30 @@ public class ForeignAnnotationsCompiledJavaWithPsiClassReadingTestGenerated exte
     }
 
     @Test
+    @TestMetadata("jakartaDefault.kt")
+    public void testJakartaDefault() {
+      runTest("compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaDefault.kt");
+    }
+
+    @Test
+    @TestMetadata("jakartaErrors.kt")
+    public void testJakartaErrors() {
+      runTest("compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaErrors.kt");
+    }
+
+    @Test
+    @TestMetadata("jakartaIgnore.kt")
+    public void testJakartaIgnore() {
+      runTest("compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaIgnore.kt");
+    }
+
+    @Test
+    @TestMetadata("jakartaWarnings.kt")
+    public void testJakartaWarnings() {
+      runTest("compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaWarnings.kt");
+    }
+
+    @Test
     @TestMetadata("kt47833.kt")
     public void testKt47833() {
       runTest("compiler/testData/diagnostics/foreignAnnotationsTests/tests/kt47833.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/ForeignAnnotationsSourceJavaTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/ForeignAnnotationsSourceJavaTestGenerated.java
@@ -99,6 +99,30 @@ public class ForeignAnnotationsSourceJavaTestGenerated extends AbstractForeignAn
     }
 
     @Test
+    @TestMetadata("jakartaDefault.kt")
+    public void testJakartaDefault() {
+      runTest("compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaDefault.kt");
+    }
+
+    @Test
+    @TestMetadata("jakartaErrors.kt")
+    public void testJakartaErrors() {
+      runTest("compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaErrors.kt");
+    }
+
+    @Test
+    @TestMetadata("jakartaIgnore.kt")
+    public void testJakartaIgnore() {
+      runTest("compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaIgnore.kt");
+    }
+
+    @Test
+    @TestMetadata("jakartaWarnings.kt")
+    public void testJakartaWarnings() {
+      runTest("compiler/testData/diagnostics/foreignAnnotationsTests/tests/jakartaWarnings.kt");
+    }
+
+    @Test
     @TestMetadata("kt47833.kt")
     public void testKt47833() {
       runTest("compiler/testData/diagnostics/foreignAnnotationsTests/tests/kt47833.kt");

--- a/core/compiler.common.jvm/src/org/jetbrains/kotlin/load/java/JavaNullabilityAnnotationSettings.kt
+++ b/core/compiler.common.jvm/src/org/jetbrains/kotlin/load/java/JavaNullabilityAnnotationSettings.kt
@@ -58,6 +58,11 @@ val NULLABILITY_ANNOTATION_SETTINGS: NullabilityAnnotationStates<JavaNullability
             sinceVersion = KotlinVersion(1, 8),
             reportLevelAfter = ReportLevel.STRICT
         ),
+        FqName("jakarta.annotation") to JavaNullabilityAnnotationsStatus(
+            reportLevelBefore = ReportLevel.WARN,
+            sinceVersion = KotlinVersion(2, 1),
+            reportLevelAfter = ReportLevel.STRICT
+        ),
     )
 )
 

--- a/core/compiler.common.jvm/src/org/jetbrains/kotlin/load/java/JavaNullabilityAnnotationSettings.kt
+++ b/core/compiler.common.jvm/src/org/jetbrains/kotlin/load/java/JavaNullabilityAnnotationSettings.kt
@@ -91,7 +91,7 @@ fun getDefaultReportLevelForAnnotation(annotationFqName: FqName) =
 fun getReportLevelForAnnotation(
     annotation: FqName,
     configuredReportLevels: NullabilityAnnotationStates<ReportLevel>,
-    configuredKotlinVersion: KotlinVersion = KotlinVersion(1, 7, 20)
+    configuredKotlinVersion: KotlinVersion = KotlinVersion(1, 7, 20),
 ): ReportLevel {
     configuredReportLevels[annotation]?.let { return it }
 

--- a/core/compiler.common.jvm/src/org/jetbrains/kotlin/load/java/JvmAnnotationNames.kt
+++ b/core/compiler.common.jvm/src/org/jetbrains/kotlin/load/java/JvmAnnotationNames.kt
@@ -86,6 +86,8 @@ val NOT_NULL_ANNOTATIONS: Set<FqName> = setOf(
     FqName("org.eclipse.jdt.annotation.NonNull"),
     // Lombok
     FqName("lombok.NonNull"),
+    // jakarta
+    FqName("jakarta.annotation.Nonnull"),
 )
 
 val NULLABLE_ANNOTATIONS: Set<FqName> = setOf(
@@ -115,6 +117,8 @@ val NULLABLE_ANNOTATIONS: Set<FqName> = setOf(
     FqName("io.reactivex.rxjava3.annotations.Nullable"),
     // Eclipse JDT
     FqName("org.eclipse.jdt.annotation.Nullable"),
+    // jakarta
+    FqName("jakarta.annotation.Nullable"),
 )
 
 val FORCE_FLEXIBILITY_ANNOTATIONS: Set<FqName> = setOf(

--- a/third-party/annotations/jakarta/annotation/Nonnull.java
+++ b/third-party/annotations/jakarta/annotation/Nonnull.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * The annotated element must not be null.
+ * <p>
+ * Annotated fields must not be null after construction has completed.
+ * <p>
+ * When this annotation is applied to a method it applies to the method return value.
+ *
+ * @see jakarta.annotation.Nullable
+ * @since 2.0
+ */
+@Documented
+@Retention(RUNTIME)
+public @interface Nonnull {
+}

--- a/third-party/annotations/jakarta/annotation/Nullable.java
+++ b/third-party/annotations/jakarta/annotation/Nullable.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * The annotated element could be null under some circumstances.
+ * <p>
+ * In general, this means developers will have to read the documentation to
+ * determine when a null value is acceptable and whether it is necessary to
+ * check for a null value.
+ * <p>
+ * This annotation is useful mostly for overriding a {@link Nonnull} annotation.
+ * Static analysis tools should generally treat the annotated items as though they
+ * had no annotation, unless they are configured to minimize false negatives.
+ * <p>
+ * When this annotation is applied to a method it applies to the method return value.
+ *
+ * @see jakarta.annotation.Nonnull
+ * @since 2.0
+ */
+@Documented
+@Retention(RUNTIME)
+public @interface Nullable {
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-54205/Support-jakarta-Nullability-annotations

Many users are migrating from `javax.*` to `jakarta.*` as a result of spring's javax EE migration.

If we are careless at this time and migrate `javax.annotation.Nullable` to `jakarta.annotation.Nullable` as well, we will have a problem.
Because kotlin does not support it.

It would be great if kotlin would support it as well.