### PR TITLE
Add support for serializing kotlin.time.Duration in Parcelize plugin.

### DIFF
--- a/plugins/parcelize/parcelize-compiler/parcelize.backend/src/org/jetbrains/kotlin/parcelize/AndroidSymbols.kt
+++ b/plugins/parcelize/parcelize-compiler/parcelize.backend/src/org/jetbrains/kotlin/parcelize/AndroidSymbols.kt
@@ -47,6 +47,7 @@ class AndroidSymbols(
     private val kotlin: IrPackageFragment = createPackage("kotlin")
     private val kotlinJvm: IrPackageFragment = createPackage("kotlin.jvm")
     private val kotlinJvmInternalPackage: IrPackageFragment = createPackage("kotlin.jvm.internal")
+    private val kotlinTime: IrPackageFragment = createPackage("kotlin.time")
 
     private val androidOs: IrPackageFragment = createPackage("android.os")
     private val androidUtil: IrPackageFragment = createPackage("android.util")
@@ -184,6 +185,12 @@ class AndroidSymbols(
             addValueParameter("size", irBuiltIns.intType)
         }
     }.symbol
+
+    val kotlinTimeDuration: IrClassSymbol = createClass(
+        kotlinTime, "Duration", ClassKind.CLASS, Modality.FINAL, true
+    ).apply {
+        owner.valueClassRepresentation = InlineClassRepresentation(Name.identifier("rawValue"), irBuiltIns.longType as IrSimpleType)
+    }
 
     val kotlinKClassJava: IrPropertySymbol = irFactory.buildProperty {
         name = Name.identifier("java")

--- a/plugins/parcelize/parcelize-compiler/parcelize.backend/src/org/jetbrains/kotlin/parcelize/IrParcelSerializerFactory.kt
+++ b/plugins/parcelize/parcelize-compiler/parcelize.backend/src/org/jetbrains/kotlin/parcelize/IrParcelSerializerFactory.kt
@@ -153,6 +153,9 @@ class IrParcelSerializerFactory(private val symbols: AndroidSymbols) {
                 return uintArraySerializer
             "kotlin.ULongArray" ->
                 return ulongArraySerializer
+            // Library types
+            "kotlin.time.Duration" ->
+                return wrapNullableSerializerIfNeeded(irType, durationSerializer)
         }
 
         // Generic container types
@@ -429,4 +432,11 @@ class IrParcelSerializerFactory(private val symbols: AndroidSymbols) {
     private val sizeFSerializer = IrSimpleParcelSerializer(symbols.parcelReadSizeF, symbols.parcelWriteSizeF)
     private val sparseBooleanArraySerializer =
         IrSimpleParcelSerializer(symbols.parcelReadSparseBooleanArray, symbols.parcelWriteSparseBooleanArray)
+
+    // library types serializers
+    private val durationSerializer = IrUnsafeCoerceWrappedSerializer(
+        longSerializer,
+        symbols.kotlinTimeDuration.defaultType,
+        irBuiltIns.longType
+    )
 }

--- a/plugins/parcelize/parcelize-compiler/parcelize.common/src/org/jetbrains/kotlin/parcelize/BuiltinParcelableTypes.kt
+++ b/plugins/parcelize/parcelize-compiler/parcelize.common/src/org/jetbrains/kotlin/parcelize/BuiltinParcelableTypes.kt
@@ -86,6 +86,7 @@ object BuiltinParcelableTypes {
         "kotlin.ULongArray",
         "kotlin.UShort",
         "kotlin.UShortArray",
+        "kotlin.time.Duration",
     ) + PARCELABLE_SUPERTYPE_FQNAMES
 
     val PARCELABLE_CONTAINER_FQNAMES = setOf(

--- a/plugins/parcelize/parcelize-compiler/testData/box/duration.kt
+++ b/plugins/parcelize/parcelize-compiler/testData/box/duration.kt
@@ -1,6 +1,6 @@
 // WITH_STDLIB
-@file:JvmName("TestKt")
 
+@file:JvmName("TestKt")
 package test
 
 import kotlinx.parcelize.*
@@ -33,14 +33,10 @@ fun box() = parcelTest { parcel ->
         infinite = Duration.INFINITE,
         negativeInfinite = -Duration.INFINITE,
     )
-    println("test: $test")
     test.writeToParcel(parcel, 0)
     val bytes = parcel.marshall()
-    println("bytes: $bytes")
     parcel.unmarshall(bytes, 0, bytes.size)
     parcel.setDataPosition(0)
     val got = parcelableCreator<Test>().createFromParcel(parcel)
-    println("expected: $test")
-    println("got: $got")
     assert(test == got)
 }

--- a/plugins/parcelize/parcelize-compiler/testData/box/duration.kt
+++ b/plugins/parcelize/parcelize-compiler/testData/box/duration.kt
@@ -1,0 +1,46 @@
+// WITH_STDLIB
+@file:JvmName("TestKt")
+
+package test
+
+import kotlinx.parcelize.*
+import android.os.Parcelable
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Duration.Companion.nanoseconds
+
+@Parcelize
+data class Test(
+    val basic: Duration,
+    val negative: Duration,
+    val nullable: Duration?,
+    val nullableWithValue: Duration?,
+    val noNanoseconds: Duration,
+    val noSeconds: Duration,
+    val infinite: Duration,
+    val negativeInfinite: Duration,
+) : Parcelable
+
+
+fun box() = parcelTest { parcel ->
+    val test = Test(
+        basic = 10.seconds + 2.nanoseconds,
+        negative = -10.seconds - 2.nanoseconds,
+        nullable = null,
+        nullableWithValue = 10.seconds + 2.nanoseconds,
+        noNanoseconds = 10.seconds,
+        noSeconds = 2.nanoseconds,
+        infinite = Duration.INFINITE,
+        negativeInfinite = -Duration.INFINITE,
+    )
+    println("test: $test")
+    test.writeToParcel(parcel, 0)
+    val bytes = parcel.marshall()
+    println("bytes: $bytes")
+    parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
+    val got = parcelableCreator<Test>().createFromParcel(parcel)
+    println("expected: $test")
+    println("got: $got")
+    assert(test == got)
+}

--- a/plugins/parcelize/parcelize-compiler/tests-gen/org/jetbrains/kotlin/parcelize/test/runners/ParcelizeFirLightTreeBoxTestGenerated.java
+++ b/plugins/parcelize/parcelize-compiler/tests-gen/org/jetbrains/kotlin/parcelize/test/runners/ParcelizeFirLightTreeBoxTestGenerated.java
@@ -128,6 +128,12 @@ public class ParcelizeFirLightTreeBoxTestGenerated extends AbstractParcelizeFirL
     }
 
     @Test
+    @TestMetadata("duration.kt")
+    public void testDuration() throws Exception {
+        runTest("plugins/parcelize/parcelize-compiler/testData/box/duration.kt");
+    }
+
+    @Test
     @TestMetadata("enumObject.kt")
     public void testEnumObject() throws Exception {
         runTest("plugins/parcelize/parcelize-compiler/testData/box/enumObject.kt");

--- a/plugins/parcelize/parcelize-compiler/tests-gen/org/jetbrains/kotlin/parcelize/test/runners/ParcelizeIrBoxTestGenerated.java
+++ b/plugins/parcelize/parcelize-compiler/tests-gen/org/jetbrains/kotlin/parcelize/test/runners/ParcelizeIrBoxTestGenerated.java
@@ -128,6 +128,12 @@ public class ParcelizeIrBoxTestGenerated extends AbstractParcelizeIrBoxTest {
     }
 
     @Test
+    @TestMetadata("duration.kt")
+    public void testDuration() throws Exception {
+        runTest("plugins/parcelize/parcelize-compiler/testData/box/duration.kt");
+    }
+
+    @Test
     @TestMetadata("enumObject.kt")
     public void testEnumObject() throws Exception {
         runTest("plugins/parcelize/parcelize-compiler/testData/box/enumObject.kt");


### PR DESCRIPTION
Add support for the Parcelize plugin to generate default serialization implementation for the kotlin.time.Duration. 

As Parcelize already supports serializing some of the kotlin library collection types it makes sense to support more common ones for the user convenience.

This implementation generates code with the idea similar to this:
```
fun writeParcel(parcel, flags) {
    this.duration_field.toComponents { seconds, nanoseconds ->
        parcel.writeLong(seconds)
        parcel.writeInt(nanoseconds)
    }
}

fun readParcel(parcel) {
     val seconds = parcel.readLong().seconds
     val nanosecnods = parcel.readInt().nanosecods
     this.duration_fiels = seconds + nanoseconds
}
```

If the field type to serialize is `Duration?` then a tag is used to know if a value is null or not. 