### PR TITLE
Sort class members in jvm-abi-gen

### DIFF
--- a/plugins/jvm-abi-gen/src/org/jetbrains/kotlin/jvm/abi/JvmAbiMetadataProcessor.kt
+++ b/plugins/jvm-abi-gen/src/org/jetbrains/kotlin/jvm/abi/JvmAbiMetadataProcessor.kt
@@ -6,10 +6,7 @@
 package org.jetbrains.kotlin.jvm.abi
 
 import kotlinx.metadata.*
-import kotlinx.metadata.jvm.JvmMetadataVersion
-import kotlinx.metadata.jvm.KotlinClassMetadata
-import kotlinx.metadata.jvm.Metadata
-import kotlinx.metadata.jvm.localDelegatedProperties
+import kotlinx.metadata.jvm.*
 import org.jetbrains.kotlin.load.java.JvmAnnotationNames.*
 import org.jetbrains.org.objectweb.asm.AnnotationVisitor
 import org.jetbrains.org.objectweb.asm.Opcodes
@@ -165,6 +162,9 @@ private fun KmPackage.removePrivateDeclarations() {
 private fun KmDeclarationContainer.removePrivateDeclarations() {
     functions.removeIf { it.visibility.isPrivate }
     properties.removeIf { it.visibility.isPrivate }
+
+    functions.sortWith(compareBy(KmFunction::name, { it.signature?.descriptor }))
+    properties.sortWith(compareBy(KmProperty::name, { it.getterSignature?.descriptor }))
 
     for (property in properties) {
         // Whether or not the *non-const* property is initialized by a compile-time constant is not a part of the ABI.

--- a/plugins/jvm-abi-gen/src/org/jetbrains/kotlin/jvm/abi/JvmAbiMetadataProcessor.kt
+++ b/plugins/jvm-abi-gen/src/org/jetbrains/kotlin/jvm/abi/JvmAbiMetadataProcessor.kt
@@ -163,8 +163,8 @@ private fun KmDeclarationContainer.removePrivateDeclarations() {
     functions.removeIf { it.visibility.isPrivate }
     properties.removeIf { it.visibility.isPrivate }
 
-    functions.sortWith(compareBy(KmFunction::name, { it.signature?.descriptor }))
-    properties.sortWith(compareBy(KmProperty::name, { it.getterSignature?.descriptor }))
+    functions.sortWith(compareBy(KmFunction::name, { it.signature.toString() }))
+    properties.sortWith(compareBy(KmProperty::name, { it.getterSignature.toString() }))
 
     for (property in properties) {
         // Whether or not the *non-const* property is initialized by a compile-time constant is not a part of the ABI.

--- a/plugins/jvm-abi-gen/test/org/jetbrains/kotlin/jvm/abi/CompareJvmAbiTestGenerated.java
+++ b/plugins/jvm-abi-gen/test/org/jetbrains/kotlin/jvm/abi/CompareJvmAbiTestGenerated.java
@@ -8,9 +8,9 @@ package org.jetbrains.kotlin.jvm.abi;
 import com.intellij.testFramework.TestDataPath;
 import org.jetbrains.kotlin.test.JUnit3RunnerWithInners;
 import org.jetbrains.kotlin.test.KotlinTestUtils;
-import org.jetbrains.kotlin.test.util.KtTestUtil;
 import org.jetbrains.kotlin.test.TargetBackend;
 import org.jetbrains.kotlin.test.TestMetadata;
+import org.jetbrains.kotlin.test.util.KtTestUtil;
 import org.junit.runner.RunWith;
 
 import java.io.File;
@@ -88,6 +88,16 @@ public class CompareJvmAbiTestGenerated extends AbstractCompareJvmAbiTest {
     @TestMetadata("declarationOrderPrivateInline")
     public void testDeclarationOrderPrivateInline() throws Exception {
         runTest("plugins/jvm-abi-gen/testData/compare/declarationOrderPrivateInline/");
+    }
+
+    @TestMetadata("fieldOrder")
+    public void testFieldOrder() throws Exception {
+        runTest("plugins/jvm-abi-gen/testData/compare/fieldOrder/");
+    }
+
+    @TestMetadata("funOrder")
+    public void testFunOrder() throws Exception {
+        runTest("plugins/jvm-abi-gen/testData/compare/funOrder/");
     }
 
     @TestMetadata("functionBody")

--- a/plugins/jvm-abi-gen/test/org/jetbrains/kotlin/jvm/abi/CompareJvmAbiTestGenerated.java
+++ b/plugins/jvm-abi-gen/test/org/jetbrains/kotlin/jvm/abi/CompareJvmAbiTestGenerated.java
@@ -8,9 +8,9 @@ package org.jetbrains.kotlin.jvm.abi;
 import com.intellij.testFramework.TestDataPath;
 import org.jetbrains.kotlin.test.JUnit3RunnerWithInners;
 import org.jetbrains.kotlin.test.KotlinTestUtils;
+import org.jetbrains.kotlin.test.util.KtTestUtil;
 import org.jetbrains.kotlin.test.TargetBackend;
 import org.jetbrains.kotlin.test.TestMetadata;
-import org.jetbrains.kotlin.test.util.KtTestUtil;
 import org.junit.runner.RunWith;
 
 import java.io.File;

--- a/plugins/jvm-abi-gen/testData/compare/fieldOrder/base/test.kt
+++ b/plugins/jvm-abi-gen/testData/compare/fieldOrder/base/test.kt
@@ -1,0 +1,11 @@
+package test
+
+
+class Class {
+    @JvmField
+    val first = Unit
+    @JvmField
+    val second = Unit
+    val String.first
+        get() = this
+}

--- a/plugins/jvm-abi-gen/testData/compare/fieldOrder/sameAbi/test.kt
+++ b/plugins/jvm-abi-gen/testData/compare/fieldOrder/sameAbi/test.kt
@@ -1,0 +1,10 @@
+package test
+
+class Class {
+    val String.first
+        get() = this
+    @JvmField
+    val second = Unit
+    @JvmField
+    val first = Unit
+}

--- a/plugins/jvm-abi-gen/testData/compare/funOrder/base/test.kt
+++ b/plugins/jvm-abi-gen/testData/compare/funOrder/base/test.kt
@@ -1,0 +1,8 @@
+package test
+
+
+class Class {
+    fun first() = Unit
+    fun first(a: Any) = Unit
+    fun second() = Unit
+}

--- a/plugins/jvm-abi-gen/testData/compare/funOrder/sameAbi/test.kt
+++ b/plugins/jvm-abi-gen/testData/compare/funOrder/sameAbi/test.kt
@@ -1,0 +1,7 @@
+package test
+
+class Class {
+    fun second() = Unit
+    fun first(a: Any) = Unit
+    fun first() = Unit
+}

--- a/plugins/jvm-abi-gen/testData/content/anonymousWhenMapping/signatures.txt
+++ b/plugins/jvm-abi-gen/testData/content/anonymousWhenMapping/signatures.txt
@@ -3,9 +3,9 @@ public final enum class test/E {
     // source: 'test.kt'
     public final enum static field A: test.E
     public final enum static field B: test.E
-    public static method values(): test.E[]
-    public static method valueOf(p0: java.lang.String): test.E
     public static @org.jetbrains.annotations.NotNull method getEntries(): kotlin.enums.EnumEntries
+    public static method valueOf(p0: java.lang.String): test.E
+    public static method values(): test.E[]
 }
 @kotlin.Metadata
 public final class test/Test {

--- a/plugins/jvm-abi-gen/testData/content/class/signatures.txt
+++ b/plugins/jvm-abi-gen/testData/content/class/signatures.txt
@@ -11,12 +11,12 @@ public class test/BaseClass {
     public final static @org.jetbrains.annotations.NotNull field Companion: test.BaseClass$Companion
     public final static field basePublicConst: int
     public method <init>(): void
-    public method getBaseClassPublicVal(): int
+    public final method baseClassInternalFun$main(): int
+    protected final method baseClassProtectedFun(): int
     public method baseClassPublicFun(): int
     public final method getBaseClassInternalVal$main(): int
-    public final method baseClassInternalFun$main(): int
     protected final method getBaseClassProtectedVal(): int
-    protected final method baseClassProtectedFun(): int
+    public method getBaseClassPublicVal(): int
 }
 @kotlin.Metadata
 public final class test/Class$NestedInnerClass$NestedNestedInnerClass {

--- a/plugins/jvm-abi-gen/testData/content/kt50005/signatures.txt
+++ b/plugins/jvm-abi-gen/testData/content/kt50005/signatures.txt
@@ -1,12 +1,12 @@
 @kotlin.Metadata
 public final class test/A {
     // source: 'test.kt'
-    public final @kotlin.jvm.JvmField field b: int
     public field a: java.lang.String
+    public final @kotlin.jvm.JvmField field b: int
     public method <init>(): void
-    public final @org.jetbrains.annotations.NotNull method getA(): java.lang.String
-    public final method setA(@org.jetbrains.annotations.NotNull p0: java.lang.String): void
-    public final method g(): void
     public final method f(): void
+    public final method g(): void
+    public final @org.jetbrains.annotations.NotNull method getA(): java.lang.String
     public final method h(): void
+    public final method setA(@org.jetbrains.annotations.NotNull p0: java.lang.String): void
 }

--- a/plugins/jvm-abi-gen/testData/content/whenMapping/signatures.txt
+++ b/plugins/jvm-abi-gen/testData/content/whenMapping/signatures.txt
@@ -3,9 +3,9 @@ public final enum class test/E {
     // source: 'test.kt'
     public final enum static field A: test.E
     public final enum static field B: test.E
-    public static method values(): test.E[]
-    public static method valueOf(p0: java.lang.String): test.E
     public static @org.jetbrains.annotations.NotNull method getEntries(): kotlin.enums.EnumEntries
+    public static method valueOf(p0: java.lang.String): test.E
+    public static method values(): test.E[]
 }
 @kotlin.Metadata
 public synthetic final class test/Test$WhenMappings {


### PR DESCRIPTION
These two classes should be identical from the ABI perspective but they are not:

```kotlin
class Class {
  fun one() = Unit
  fun two() = Unit
}

class Class {
  fun two() = Unit
  fun one() = Unit
}
```

https://youtrack.jetbrains.com/issue/KT-64589/Order-of-class-members-affects-ABI-jar