### PR TITLE
Empty companion object breaks parsing

### DIFF
--- a/plugins/jvm-abi-gen/test/org/jetbrains/kotlin/jvm/abi/CompareJvmAbiTestGenerated.java
+++ b/plugins/jvm-abi-gen/test/org/jetbrains/kotlin/jvm/abi/CompareJvmAbiTestGenerated.java
@@ -8,9 +8,9 @@ package org.jetbrains.kotlin.jvm.abi;
 import com.intellij.testFramework.TestDataPath;
 import org.jetbrains.kotlin.test.JUnit3RunnerWithInners;
 import org.jetbrains.kotlin.test.KotlinTestUtils;
-import org.jetbrains.kotlin.test.util.KtTestUtil;
 import org.jetbrains.kotlin.test.TargetBackend;
 import org.jetbrains.kotlin.test.TestMetadata;
+import org.jetbrains.kotlin.test.util.KtTestUtil;
 import org.junit.runner.RunWith;
 
 import java.io.File;
@@ -88,6 +88,11 @@ public class CompareJvmAbiTestGenerated extends AbstractCompareJvmAbiTest {
     @TestMetadata("declarationOrderPrivateInline")
     public void testDeclarationOrderPrivateInline() throws Exception {
         runTest("plugins/jvm-abi-gen/testData/compare/declarationOrderPrivateInline/");
+    }
+
+    @TestMetadata("emptyCompanion")
+    public void testEmptyCompanion() throws Exception {
+        runTest("plugins/jvm-abi-gen/testData/compare/emptyCompanion/");
     }
 
     @TestMetadata("functionBody")

--- a/plugins/jvm-abi-gen/testData/compare/emptyCompanion/base/test.kt
+++ b/plugins/jvm-abi-gen/testData/compare/emptyCompanion/base/test.kt
@@ -1,0 +1,7 @@
+package test
+
+
+class Class {
+    private companion object { }
+    private val regularProperty = 42
+}

--- a/plugins/jvm-abi-gen/testData/compare/emptyCompanion/sameAbi/test.kt
+++ b/plugins/jvm-abi-gen/testData/compare/emptyCompanion/sameAbi/test.kt
@@ -1,0 +1,7 @@
+package test
+
+class Class {
+    private companion object
+    //↓ "private" becomes the name of the companion object, regular property becomes public
+    private val regularProperty = 42
+}


### PR DESCRIPTION
Original problem arose when two code snippets had different ABI:

```kotlin
class Class {
  companion object
} 
```

```kotlin
class Class {
  companion object
  private val thisPropertyBecomesPublic = 42
}
```

ABI is different because `companion object` steals next `private` word and uses it as a name during parsing. Adding body to the companion or adding name to it fixes the issue.

https://youtrack.jetbrains.com/issue/KT-64594/Empty-companion-object-breaks-parsing