### PR TITLE
Allow at-sign in Options values

### DIFF
--- a/libraries/scripting/dependencies/src/kotlin/script/experimental/dependencies/impl/SimpleExternalDependenciesResolverOptionsParser.kt
+++ b/libraries/scripting/dependencies/src/kotlin/script/experimental/dependencies/impl/SimpleExternalDependenciesResolverOptionsParser.kt
@@ -9,7 +9,7 @@ import kotlin.script.experimental.api.*
 import kotlin.script.experimental.dependencies.ExternalDependenciesResolver
 
 private val nameRegex = Regex("^[^\\S\\r\\n]*([a-zA-Z][a-zA-Z0-9-_]*)[^\\S\\r\\n]?")
-private val valueRegex = Regex("^[^\\S\\r\\n]*((([a-zA-Z0-9-_,/$.:])|(\\\\[\\\\ nt]))+)[^\\S\\r\\n]?")
+private val valueRegex = Regex("^[^\\S\\r\\n]*((([a-zA-Z0-9-_,/@$.:])|(\\\\[\\\\ nt]))+)[^\\S\\r\\n]?")
 private val equalsRegex = Regex("^[^\\S\\r\\n]*=")
 private val escapeRegex = Regex("\\\\(.)")
 


### PR DESCRIPTION
Options values are used to specify usernames and usernames often are email addresses, which include the at-sign (@).

I'm trying do this in Kotlin Script:
```
@file:Repository("https://invitae.jfrog.io/artifactory/java", options=arrayOf(
    "username=jd.brennan@invitae.com", 
    "password=REDACTED")
)
```
which yields:
```
error: failed to parse options from annotation. Expected a valid option name but received:
@invitae.com
```
Passwords can have ! # % ^ & * so I'm tempted to add those as well, but I don't know why the options value are so restrictive. And all I need to make my script work is @ in the username.