### PR TITLE
KT-64882 Fix KAPT stub for useJvmIr=False

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/state/GenerationState.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/state/GenerationState.kt
@@ -341,6 +341,13 @@ class GenerationState private constructor(
 
     @Suppress("UNCHECKED_CAST", "DEPRECATION_ERROR")
     private fun loadClassBuilderInterceptors(): List<org.jetbrains.kotlin.codegen.extensions.ClassBuilderInterceptorExtension> {
+        // KAPT with useJvmIr=False (non-Ir backend) can't use ClassBuilderExtensionAdapter
+        // Anything that's not JvmIrDeclarationOrigin became NO_ORIGIN after ClassBuilderExtensionAdapter's
+        // unwrapOrigin() and wrapToOrigin(), causing it to lose necessary information for KAPT stub generation.
+        if (!isIrBackend) {
+            return org.jetbrains.kotlin.codegen.extensions.ClassBuilderInterceptorExtension.getInstances(project)
+        }
+
         // Using Class.forName here because we're in the old JVM backend, and we need to load extensions declared in the JVM IR backend.
         val adapted = Class.forName("org.jetbrains.kotlin.backend.jvm.extensions.ClassBuilderExtensionAdapter")
             .getDeclaredMethod("getExtensions", Project::class.java)


### PR DESCRIPTION
KT-64882 I found KAPT useJvmIr=false have stub gen wrongness (all function is missing from stub)

After debug i found the reason functions are missing in stub!
The direct reason is, in ClassFileToSourceStubConverter.kt, `kaptContext.origins` contain methods with null `descriptor`, causing “convertMethod” to return skip the method.
As to how is the method's `origin.descriptor` get lost, i found it's lost during the `origin.unwrapOrigin()` and `declaration.wrapToOrigin()` of `ClassBuilderExtensionAdapter`. Anything that's not JvmIrDeclarationOrigin became NO_ORIGIN after a round of wrap and unwrap (But things are always not JvmIrDeclaration when useJvmIr=false). So existence of any ClassGeneratorExtension (like JvmAbiGen) will make the origin lost its descriptor

I tried skipping ClassBuilderExtensionAdapter in GenerationState.loadClassBuilderInterceptors whenever isIrBackend=false, and the problem is indeed gone, which confirmed this is the cause

Synced with @udalov and confirmed this solution make sense and can submit PR