### PR TITLE
invokeSuspend function should keep the annotations of the inline function

### DIFF
--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/SuspendLambdaLowering.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/SuspendLambdaLowering.kt
@@ -226,6 +226,7 @@ private class SuspendLambdaLowering(context: JvmBackendContext) : SuspendLowerin
                     it.valueParameters[0].type.isKotlinResult()
         }
         return addFunctionOverride(superMethod, irFunction.startOffset, irFunction.endOffset).apply {
+            annotations += irFunction.annotations
             val localVals: List<IrVariable?> = parameterInfos.map { param ->
                 if (param.isUsed) {
                     buildVariable(


### PR DESCRIPTION
Similar to the code doing this for non-suspendable functions:

https://github.com/JetBrains/kotlin/blob/2096d22/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/FunctionReferenceLowering.kt#L784

Ticket – https://youtrack.jetbrains.com/issue/KT-64943/AnnotationTarget.FUNCTION-and-AnnotationRetention.RUNTIME-annotations-are-not-visible-on-inline-suspendable-functions
