### PR TITLE
Remove stdlib duplicated zero size checks

### DIFF
--- a/libraries/stdlib/src/kotlin/collections/Sequences.kt
+++ b/libraries/stdlib/src/kotlin/collections/Sequences.kt
@@ -34,7 +34,7 @@ public fun <T> Iterator<T>.asSequence(): Sequence<T> = Sequence { this }.constra
  *
  * @sample samples.collections.Sequences.Building.sequenceOfValues
  */
-public fun <T> sequenceOf(vararg elements: T): Sequence<T> = if (elements.isEmpty()) emptySequence() else elements.asSequence()
+public fun <T> sequenceOf(vararg elements: T): Sequence<T> = elements.asSequence()
 
 /**
  * Returns an empty sequence.

--- a/libraries/stdlib/src/kotlin/collections/Sets.kt
+++ b/libraries/stdlib/src/kotlin/collections/Sets.kt
@@ -41,7 +41,7 @@ public fun <T> emptySet(): Set<T> = EmptySet
  * The returned set is serializable (JVM).
  * @sample samples.collections.Collections.Sets.readOnlySet
  */
-public fun <T> setOf(vararg elements: T): Set<T> = if (elements.size > 0) elements.toSet() else emptySet()
+public fun <T> setOf(vararg elements: T): Set<T> = elements.toSet()
 
 /**
  * Returns a new read-only set containing only the specified object [element].


### PR DESCRIPTION
The modified functions:
* setOf
* sequenceOf

Call corresponding toSet()/asSequence() extension functions that do the same empty check already inside.
There is no need for duplicate optimization.


