### PR TITLE
KT-65343 [IR] Add missing source element when copy class with DeepCopyIrTreeWithSymbols

### DIFF
--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/DeepCopyIrTreeWithSymbols.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/DeepCopyIrTreeWithSymbols.kt
@@ -163,6 +163,7 @@ open class DeepCopyIrTreeWithSymbols(
             isExpect = declaration.isExpect,
             isFun = declaration.isFun,
             hasEnumEntries = declaration.hasEnumEntries,
+            source = declaration.source,
         ).apply {
             transformAnnotations(declaration)
             copyTypeParametersFrom(declaration)


### PR DESCRIPTION
Fixes [KT-65343](https://youtrack.jetbrains.com/issue/KT-65343/Source-parameter-is-lost-when-copying-with-DeepCopyIrTreeWithSymbols)

Fixes when using DeepCopyIrTreeWithSymbols as class transformer to transform the IrClass, the source element of IrClass will be set to SourceElement.NO_SOURCE after the transform