### PR TITLE
Make K2 incompatible ObjCName error consistent with K1

### DIFF
--- a/compiler/fir/checkers/checkers.native/src/org/jetbrains/kotlin/fir/analysis/native/checkers/FirNativeObjCNameUtilities.kt
+++ b/compiler/fir/checkers/checkers.native/src/org/jetbrains/kotlin/fir/analysis/native/checkers/FirNativeObjCNameUtilities.kt
@@ -82,7 +82,7 @@ object FirNativeObjCNameUtilities {
             reporter.reportOn(
                 declarationToReport.source,
                 FirNativeErrors.INCOMPATIBLE_OBJC_NAME_OVERRIDE,
-                declarationToReport.symbol,
+                memberSymbol,
                 containingDeclarations,
                 context
             )


### PR DESCRIPTION
This changes the K2 error message from:
```
Repro.kt:16:1: error: member 'class DerivedFoo : AbstractFoo, IFoo' inherits inconsistent '@ObjCName' from '[class AbstractFoo : Any, interface IFoo : Any]'.
class DerivedFoo : AbstractFoo(), IFoo {}
^
```

To:
```
Repro.kt:16:1: error: member '@ObjCName(...) fun foo(): Unit' inherits inconsistent '@ObjCName' from '[class AbstractFoo : Any, interface IFoo : Any]'.
class DerivedFoo : AbstractFoo(), IFoo {}
^
```

Which is more in line with the error from 1.9:
```
/Users/markmann/incompatible-objc-name/Repro.kt:16:1: error: member "foo" inherits inconsistent @ObjCName from AbstractFoo, IFoo
class DerivedFoo : AbstractFoo(), IFoo {}
^
```

^KT-65572