### PR TITLE
jvm-abi-gen: Remove empty FileClasses from abi

### DIFF
--- a/plugins/jvm-abi-gen/src/org/jetbrains/kotlin/jvm/abi/JvmAbiComponentRegistrar.kt
+++ b/plugins/jvm-abi-gen/src/org/jetbrains/kotlin/jvm/abi/JvmAbiComponentRegistrar.kt
@@ -26,6 +26,7 @@ class JvmAbiComponentRegistrar : CompilerPluginRegistrar() {
         )
         val outputExtension = JvmAbiOutputExtension(
             File(outputPath), builderExtension::buildAbiClassInfoAndReleaseResources,
+            builderExtension.removedEmptyFileClassesWithoutAliases,
             messageCollector, configuration.getBoolean(JvmAbiConfigurationKeys.REMOVE_DEBUG_INFO),
             removeDataClassCopy,
             configuration.getBoolean(JvmAbiConfigurationKeys.PRESERVE_DECLARATION_ORDER),

--- a/plugins/jvm-abi-gen/test/org/jetbrains/kotlin/jvm/abi/CompareJvmAbiTestGenerated.java
+++ b/plugins/jvm-abi-gen/test/org/jetbrains/kotlin/jvm/abi/CompareJvmAbiTestGenerated.java
@@ -100,6 +100,11 @@ public class CompareJvmAbiTestGenerated extends AbstractCompareJvmAbiTest {
         runTest("plugins/jvm-abi-gen/testData/compare/declarationOrderPrivateInline/");
     }
 
+    @TestMetadata("emptyKtClassIsRemoved")
+    public void testEmptyKtClassIsRemoved() throws Exception {
+        runTest("plugins/jvm-abi-gen/testData/compare/emptyKtClassIsRemoved/");
+    }
+
     @TestMetadata("fieldOrder")
     public void testFieldOrder() throws Exception {
         runTest("plugins/jvm-abi-gen/testData/compare/fieldOrder/");

--- a/plugins/jvm-abi-gen/testData/compare/emptyKtClassIsRemoved/base/test.kt
+++ b/plugins/jvm-abi-gen/testData/compare/emptyKtClassIsRemoved/base/test.kt
@@ -1,0 +1,5 @@
+package test
+
+private fun hostingClassShouldNotAffectAbi() = Unit
+
+class JustClass

--- a/plugins/jvm-abi-gen/testData/compare/emptyKtClassIsRemoved/sameAbi/test.kt
+++ b/plugins/jvm-abi-gen/testData/compare/emptyKtClassIsRemoved/sameAbi/test.kt
@@ -1,0 +1,3 @@
+package test
+
+class JustClass


### PR DESCRIPTION
These two code snippets have different abi:

```kotlin
//file test.kt
private fun funToBeRemoved() = Unit

class Class
```
and
```kotlin
//file test.kt
class Class
```

It happens because of two reasons:
* Empty (absolutely, even zero constructors) FileClass TestKt is not being removed from the `abi.jar`
* `kotlin_module` file has a record for mentioned FileClass as well

Meaning that adding/removing first/last top-level function in a file invalidates ABI in 100% cases.

I've tried to fix the issue, but can't make `kotlin_module` the same for two snippets above.

Youtrack ticket: