### PR TITLE
[Gradle] Fix that CInterop commonizer modified project description

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/internal/CInteropCommonizerConfigurations.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/internal/CInteropCommonizerConfigurations.kt
@@ -119,7 +119,7 @@ internal suspend fun Project.locateOrCreateCommonizedCInteropDependencyConfigura
             CInteropCommonizerArtifactTypeAttribute.attribute,
             CInteropCommonizerArtifactTypeAttribute.KLIB
         )
-        description = "Commonized CInterop dependencies for $sourceSet with targets: '$commonizerTarget'."
+        configuration.description = "Commonized CInterop dependencies for $sourceSet with targets: '$commonizerTarget'."
     }
 
     return configuration


### PR DESCRIPTION
This PR fixes a bug in the CInterop commonizer Gradle configuration which modified Gradle Project description instead of the created Configuration description. 

The bug manifested only in projects with `kotlin.mpp.enableCInteropCommonization=true`
