### PR TITLE
Add test cases for constructors with `SFVC` as a parameter.

### DIFF
--- a/analysis/low-level-api-fir/tests/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/compiler/based/LLFirBlackBoxCodegenBasedTestGenerated.java
+++ b/analysis/low-level-api-fir/tests/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/compiler/based/LLFirBlackBoxCodegenBasedTestGenerated.java
@@ -50214,6 +50214,94 @@ public class LLFirBlackBoxCodegenBasedTestGenerated extends AbstractLLFirBlackBo
       public void testSimpleTopLevelFunction() {
         runTest("compiler/testData/codegen/box/reflection/callBy/simpleTopLevelFunction.kt");
       }
+
+      @Nested
+      @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses")
+      @TestDataPath("$PROJECT_ROOT")
+      public class ValueClasses {
+        @Test
+        public void testAllFilesPresentInValueClasses() {
+          KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses"), Pattern.compile("^(.+)\\.kt$"), null, true);
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject")
+        @TestDataPath("$PROJECT_ROOT")
+        public class NonNullObject {
+          @Test
+          public void testAllFilesPresentInNonNullObject() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject"), Pattern.compile("^(.+)\\.kt$"), null, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, true);
+            }
+
+            @Test
+            @TestMetadata("constructorWithInlineClassParameters.kt")
+            public void testConstructorWithInlineClassParameters() {
+              runTest("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments/constructorWithInlineClassParameters.kt");
+            }
+          }
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject")
+        @TestDataPath("$PROJECT_ROOT")
+        public class NullableObject {
+          @Test
+          public void testAllFilesPresentInNullableObject() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject"), Pattern.compile("^(.+)\\.kt$"), null, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, true);
+            }
+
+            @Test
+            @TestMetadata("constructorWithInlineClassParameters.kt")
+            public void testConstructorWithInlineClassParameters() {
+              runTest("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments/constructorWithInlineClassParameters.kt");
+            }
+          }
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive")
+        @TestDataPath("$PROJECT_ROOT")
+        public class Primitive {
+          @Test
+          public void testAllFilesPresentInPrimitive() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive"), Pattern.compile("^(.+)\\.kt$"), null, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, true);
+            }
+
+            @Test
+            @TestMetadata("constructorWithInlineClassParameters.kt")
+            public void testConstructorWithInlineClassParameters() {
+              runTest("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments/constructorWithInlineClassParameters.kt");
+            }
+          }
+        }
+      }
     }
 
     @Nested

--- a/analysis/low-level-api-fir/tests/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/compiler/based/LLFirReversedBlackBoxCodegenBasedTestGenerated.java
+++ b/analysis/low-level-api-fir/tests/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/compiler/based/LLFirReversedBlackBoxCodegenBasedTestGenerated.java
@@ -50214,6 +50214,94 @@ public class LLFirReversedBlackBoxCodegenBasedTestGenerated extends AbstractLLFi
       public void testSimpleTopLevelFunction() {
         runTest("compiler/testData/codegen/box/reflection/callBy/simpleTopLevelFunction.kt");
       }
+
+      @Nested
+      @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses")
+      @TestDataPath("$PROJECT_ROOT")
+      public class ValueClasses {
+        @Test
+        public void testAllFilesPresentInValueClasses() {
+          KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses"), Pattern.compile("^(.+)\\.kt$"), null, true);
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject")
+        @TestDataPath("$PROJECT_ROOT")
+        public class NonNullObject {
+          @Test
+          public void testAllFilesPresentInNonNullObject() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject"), Pattern.compile("^(.+)\\.kt$"), null, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, true);
+            }
+
+            @Test
+            @TestMetadata("constructorWithInlineClassParameters.kt")
+            public void testConstructorWithInlineClassParameters() {
+              runTest("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments/constructorWithInlineClassParameters.kt");
+            }
+          }
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject")
+        @TestDataPath("$PROJECT_ROOT")
+        public class NullableObject {
+          @Test
+          public void testAllFilesPresentInNullableObject() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject"), Pattern.compile("^(.+)\\.kt$"), null, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, true);
+            }
+
+            @Test
+            @TestMetadata("constructorWithInlineClassParameters.kt")
+            public void testConstructorWithInlineClassParameters() {
+              runTest("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments/constructorWithInlineClassParameters.kt");
+            }
+          }
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive")
+        @TestDataPath("$PROJECT_ROOT")
+        public class Primitive {
+          @Test
+          public void testAllFilesPresentInPrimitive() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive"), Pattern.compile("^(.+)\\.kt$"), null, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, true);
+            }
+
+            @Test
+            @TestMetadata("constructorWithInlineClassParameters.kt")
+            public void testConstructorWithInlineClassParameters() {
+              runTest("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments/constructorWithInlineClassParameters.kt");
+            }
+          }
+        }
+      }
     }
 
     @Nested

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirLightTreeBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirLightTreeBlackBoxCodegenTestGenerated.java
@@ -49987,6 +49987,94 @@ public class FirLightTreeBlackBoxCodegenTestGenerated extends AbstractFirLightTr
       public void testSimpleTopLevelFunction() {
         runTest("compiler/testData/codegen/box/reflection/callBy/simpleTopLevelFunction.kt");
       }
+
+      @Nested
+      @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses")
+      @TestDataPath("$PROJECT_ROOT")
+      public class ValueClasses {
+        @Test
+        public void testAllFilesPresentInValueClasses() {
+          KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject")
+        @TestDataPath("$PROJECT_ROOT")
+        public class NonNullObject {
+          @Test
+          public void testAllFilesPresentInNonNullObject() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+            }
+
+            @Test
+            @TestMetadata("constructorWithInlineClassParameters.kt")
+            public void testConstructorWithInlineClassParameters() {
+              runTest("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments/constructorWithInlineClassParameters.kt");
+            }
+          }
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject")
+        @TestDataPath("$PROJECT_ROOT")
+        public class NullableObject {
+          @Test
+          public void testAllFilesPresentInNullableObject() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+            }
+
+            @Test
+            @TestMetadata("constructorWithInlineClassParameters.kt")
+            public void testConstructorWithInlineClassParameters() {
+              runTest("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments/constructorWithInlineClassParameters.kt");
+            }
+          }
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive")
+        @TestDataPath("$PROJECT_ROOT")
+        public class Primitive {
+          @Test
+          public void testAllFilesPresentInPrimitive() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+            }
+
+            @Test
+            @TestMetadata("constructorWithInlineClassParameters.kt")
+            public void testConstructorWithInlineClassParameters() {
+              runTest("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments/constructorWithInlineClassParameters.kt");
+            }
+          }
+        }
+      }
     }
 
     @Nested

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirLightTreeBlackBoxCodegenWithFir2IrFakeOverrideGeneratorTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirLightTreeBlackBoxCodegenWithFir2IrFakeOverrideGeneratorTestGenerated.java
@@ -49987,6 +49987,94 @@ public class FirLightTreeBlackBoxCodegenWithFir2IrFakeOverrideGeneratorTestGener
       public void testSimpleTopLevelFunction() {
         runTest("compiler/testData/codegen/box/reflection/callBy/simpleTopLevelFunction.kt");
       }
+
+      @Nested
+      @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses")
+      @TestDataPath("$PROJECT_ROOT")
+      public class ValueClasses {
+        @Test
+        public void testAllFilesPresentInValueClasses() {
+          KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject")
+        @TestDataPath("$PROJECT_ROOT")
+        public class NonNullObject {
+          @Test
+          public void testAllFilesPresentInNonNullObject() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+            }
+
+            @Test
+            @TestMetadata("constructorWithInlineClassParameters.kt")
+            public void testConstructorWithInlineClassParameters() {
+              runTest("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments/constructorWithInlineClassParameters.kt");
+            }
+          }
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject")
+        @TestDataPath("$PROJECT_ROOT")
+        public class NullableObject {
+          @Test
+          public void testAllFilesPresentInNullableObject() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+            }
+
+            @Test
+            @TestMetadata("constructorWithInlineClassParameters.kt")
+            public void testConstructorWithInlineClassParameters() {
+              runTest("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments/constructorWithInlineClassParameters.kt");
+            }
+          }
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive")
+        @TestDataPath("$PROJECT_ROOT")
+        public class Primitive {
+          @Test
+          public void testAllFilesPresentInPrimitive() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+            }
+
+            @Test
+            @TestMetadata("constructorWithInlineClassParameters.kt")
+            public void testConstructorWithInlineClassParameters() {
+              runTest("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments/constructorWithInlineClassParameters.kt");
+            }
+          }
+        }
+      }
     }
 
     @Nested

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirPsiBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirPsiBlackBoxCodegenTestGenerated.java
@@ -49987,6 +49987,94 @@ public class FirPsiBlackBoxCodegenTestGenerated extends AbstractFirPsiBlackBoxCo
       public void testSimpleTopLevelFunction() {
         runTest("compiler/testData/codegen/box/reflection/callBy/simpleTopLevelFunction.kt");
       }
+
+      @Nested
+      @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses")
+      @TestDataPath("$PROJECT_ROOT")
+      public class ValueClasses {
+        @Test
+        public void testAllFilesPresentInValueClasses() {
+          KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject")
+        @TestDataPath("$PROJECT_ROOT")
+        public class NonNullObject {
+          @Test
+          public void testAllFilesPresentInNonNullObject() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+            }
+
+            @Test
+            @TestMetadata("constructorWithInlineClassParameters.kt")
+            public void testConstructorWithInlineClassParameters() {
+              runTest("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments/constructorWithInlineClassParameters.kt");
+            }
+          }
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject")
+        @TestDataPath("$PROJECT_ROOT")
+        public class NullableObject {
+          @Test
+          public void testAllFilesPresentInNullableObject() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+            }
+
+            @Test
+            @TestMetadata("constructorWithInlineClassParameters.kt")
+            public void testConstructorWithInlineClassParameters() {
+              runTest("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments/constructorWithInlineClassParameters.kt");
+            }
+          }
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive")
+        @TestDataPath("$PROJECT_ROOT")
+        public class Primitive {
+          @Test
+          public void testAllFilesPresentInPrimitive() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+            }
+
+            @Test
+            @TestMetadata("constructorWithInlineClassParameters.kt")
+            public void testConstructorWithInlineClassParameters() {
+              runTest("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments/constructorWithInlineClassParameters.kt");
+            }
+          }
+        }
+      }
     }
 
     @Nested

--- a/compiler/testData/codegen/box/reflection/callBy/inlineClassDefaultArguments.kt
+++ b/compiler/testData/codegen/box/reflection/callBy/inlineClassDefaultArguments.kt
@@ -59,72 +59,12 @@ fun test65(
     arg60: Long = 0L, arg61: Long = 0L, arg62: Long = 0L, arg63: Long = 0L, x: A = A(0)
 ) = "OK"
 
-data class TestCtor1(val x: A = A(0))
-
-data class TestCtor32(
-    val arg00: Long = 0L, val arg01: Long = 0L, val arg02: Long = 0L, val arg03: Long = 0L, val arg04: Long = 0L,
-    val arg05: Long = 0L, val arg06: Long = 0L, val arg07: Long = 0L, val arg08: Long = 0L, val arg09: Long = 0L,
-    val arg10: Long = 0L, val arg11: Long = 0L, val arg12: Long = 0L, val arg13: Long = 0L, val arg14: Long = 0L,
-    val arg15: Long = 0L, val arg16: Long = 0L, val arg17: Long = 0L, val arg18: Long = 0L, val arg19: Long = 0L,
-    val arg20: Long = 0L, val arg21: Long = 0L, val arg22: Long = 0L, val arg23: Long = 0L, val arg24: Long = 0L,
-    val arg25: Long = 0L, val arg26: Long = 0L, val arg27: Long = 0L, val arg28: Long = 0L, val arg29: Long = 0L,
-    val arg30: Long = 0L, val x: A = A(0)
-)
-
-data class TestCtor33(
-    val arg00: Long = 0L, val arg01: Long = 0L, val arg02: Long = 0L, val arg03: Long = 0L, val arg04: Long = 0L,
-    val arg05: Long = 0L, val arg06: Long = 0L, val arg07: Long = 0L, val arg08: Long = 0L, val arg09: Long = 0L,
-    val arg10: Long = 0L, val arg11: Long = 0L, val arg12: Long = 0L, val arg13: Long = 0L, val arg14: Long = 0L,
-    val arg15: Long = 0L, val arg16: Long = 0L, val arg17: Long = 0L, val arg18: Long = 0L, val arg19: Long = 0L,
-    val arg20: Long = 0L, val arg21: Long = 0L, val arg22: Long = 0L, val arg23: Long = 0L, val arg24: Long = 0L,
-    val arg25: Long = 0L, val arg26: Long = 0L, val arg27: Long = 0L, val arg28: Long = 0L, val arg29: Long = 0L,
-    val arg30: Long = 0L, val arg31: Long = 0L, val x: A = A(0)
-)
-
-data class TestCtor64(
-    val arg00: Long = 0L, val arg01: Long = 0L, val arg02: Long = 0L, val arg03: Long = 0L, val arg04: Long = 0L,
-    val arg05: Long = 0L, val arg06: Long = 0L, val arg07: Long = 0L, val arg08: Long = 0L, val arg09: Long = 0L,
-    val arg10: Long = 0L, val arg11: Long = 0L, val arg12: Long = 0L, val arg13: Long = 0L, val arg14: Long = 0L,
-    val arg15: Long = 0L, val arg16: Long = 0L, val arg17: Long = 0L, val arg18: Long = 0L, val arg19: Long = 0L,
-    val arg20: Long = 0L, val arg21: Long = 0L, val arg22: Long = 0L, val arg23: Long = 0L, val arg24: Long = 0L,
-    val arg25: Long = 0L, val arg26: Long = 0L, val arg27: Long = 0L, val arg28: Long = 0L, val arg29: Long = 0L,
-    val arg30: Long = 0L, val arg31: Long = 0L, val arg32: Long = 0L, val arg33: Long = 0L, val arg34: Long = 0L,
-    val arg35: Long = 0L, val arg36: Long = 0L, val arg37: Long = 0L, val arg38: Long = 0L, val arg39: Long = 0L,
-    val arg40: Long = 0L, val arg41: Long = 0L, val arg42: Long = 0L, val arg43: Long = 0L, val arg44: Long = 0L,
-    val arg45: Long = 0L, val arg46: Long = 0L, val arg47: Long = 0L, val arg48: Long = 0L, val arg49: Long = 0L,
-    val arg50: Long = 0L, val arg51: Long = 0L, val arg52: Long = 0L, val arg53: Long = 0L, val arg54: Long = 0L,
-    val arg55: Long = 0L, val arg56: Long = 0L, val arg57: Long = 0L, val arg58: Long = 0L, val arg59: Long = 0L,
-    val arg60: Long = 0L, val arg61: Long = 0L, val arg62: Long = 0L, val x: A = A(0)
-)
-
-data class TestCtor65(
-    val arg00: Long = 0L, val arg01: Long = 0L, val arg02: Long = 0L, val arg03: Long = 0L, val arg04: Long = 0L,
-    val arg05: Long = 0L, val arg06: Long = 0L, val arg07: Long = 0L, val arg08: Long = 0L, val arg09: Long = 0L,
-    val arg10: Long = 0L, val arg11: Long = 0L, val arg12: Long = 0L, val arg13: Long = 0L, val arg14: Long = 0L,
-    val arg15: Long = 0L, val arg16: Long = 0L, val arg17: Long = 0L, val arg18: Long = 0L, val arg19: Long = 0L,
-    val arg20: Long = 0L, val arg21: Long = 0L, val arg22: Long = 0L, val arg23: Long = 0L, val arg24: Long = 0L,
-    val arg25: Long = 0L, val arg26: Long = 0L, val arg27: Long = 0L, val arg28: Long = 0L, val arg29: Long = 0L,
-    val arg30: Long = 0L, val arg31: Long = 0L, val arg32: Long = 0L, val arg33: Long = 0L, val arg34: Long = 0L,
-    val arg35: Long = 0L, val arg36: Long = 0L, val arg37: Long = 0L, val arg38: Long = 0L, val arg39: Long = 0L,
-    val arg40: Long = 0L, val arg41: Long = 0L, val arg42: Long = 0L, val arg43: Long = 0L, val arg44: Long = 0L,
-    val arg45: Long = 0L, val arg46: Long = 0L, val arg47: Long = 0L, val arg48: Long = 0L, val arg49: Long = 0L,
-    val arg50: Long = 0L, val arg51: Long = 0L, val arg52: Long = 0L, val arg53: Long = 0L, val arg54: Long = 0L,
-    val arg55: Long = 0L, val arg56: Long = 0L, val arg57: Long = 0L, val arg58: Long = 0L, val arg59: Long = 0L,
-    val arg60: Long = 0L, val arg61: Long = 0L, val arg62: Long = 0L, val arg63: Long = 0L, val x: A = A(0)
-)
-
 fun box(): String {
     assertEquals("OK", ::test1.callBy(mapOf()))
     assertEquals("OK", ::test32.callBy(mapOf()))
     assertEquals("OK", ::test33.callBy(mapOf()))
     assertEquals("OK", ::test64.callBy(mapOf()))
     assertEquals("OK", ::test65.callBy(mapOf()))
-
-    assertEquals(TestCtor1(), ::TestCtor1.callBy(mapOf()))
-    assertEquals(TestCtor32(), ::TestCtor32.callBy(mapOf()))
-    assertEquals(TestCtor33(), ::TestCtor33.callBy(mapOf()))
-    assertEquals(TestCtor64(), ::TestCtor64.callBy(mapOf()))
-    assertEquals(TestCtor65(), ::TestCtor65.callBy(mapOf()))
 
     return "OK"
 }

--- a/compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments/constructorWithInlineClassParameters.kt
+++ b/compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments/constructorWithInlineClassParameters.kt
@@ -1,0 +1,125 @@
+// TARGET_BACKEND: JVM
+// WITH_REFLECT
+
+import kotlin.test.assertEquals
+
+@JvmInline
+value class A(val x: String)
+
+data class TestCtor1_1(val x: A = A("0"))
+data class TestCtor1_2(val x: A? = A("0"))
+
+data class TestCtor32_1(
+    val arg00: Long = 0L, val arg01: Long = 0L, val arg02: Long = 0L, val arg03: Long = 0L, val arg04: Long = 0L,
+    val arg05: Long = 0L, val arg06: Long = 0L, val arg07: Long = 0L, val arg08: Long = 0L, val arg09: Long = 0L,
+    val arg10: Long = 0L, val arg11: Long = 0L, val arg12: Long = 0L, val arg13: Long = 0L, val arg14: Long = 0L,
+    val arg15: Long = 0L, val arg16: Long = 0L, val arg17: Long = 0L, val arg18: Long = 0L, val arg19: Long = 0L,
+    val arg20: Long = 0L, val arg21: Long = 0L, val arg22: Long = 0L, val arg23: Long = 0L, val arg24: Long = 0L,
+    val arg25: Long = 0L, val arg26: Long = 0L, val arg27: Long = 0L, val arg28: Long = 0L, val arg29: Long = 0L,
+    val arg30: Long = 0L, val x: A = A("0")
+)
+data class TestCtor32_2(
+    val arg00: Long = 0L, val arg01: Long = 0L, val arg02: Long = 0L, val arg03: Long = 0L, val arg04: Long = 0L,
+    val arg05: Long = 0L, val arg06: Long = 0L, val arg07: Long = 0L, val arg08: Long = 0L, val arg09: Long = 0L,
+    val arg10: Long = 0L, val arg11: Long = 0L, val arg12: Long = 0L, val arg13: Long = 0L, val arg14: Long = 0L,
+    val arg15: Long = 0L, val arg16: Long = 0L, val arg17: Long = 0L, val arg18: Long = 0L, val arg19: Long = 0L,
+    val arg20: Long = 0L, val arg21: Long = 0L, val arg22: Long = 0L, val arg23: Long = 0L, val arg24: Long = 0L,
+    val arg25: Long = 0L, val arg26: Long = 0L, val arg27: Long = 0L, val arg28: Long = 0L, val arg29: Long = 0L,
+    val arg30: Long = 0L, val x: A? = A("0")
+)
+
+data class TestCtor33_1(
+    val arg00: Long = 0L, val arg01: Long = 0L, val arg02: Long = 0L, val arg03: Long = 0L, val arg04: Long = 0L,
+    val arg05: Long = 0L, val arg06: Long = 0L, val arg07: Long = 0L, val arg08: Long = 0L, val arg09: Long = 0L,
+    val arg10: Long = 0L, val arg11: Long = 0L, val arg12: Long = 0L, val arg13: Long = 0L, val arg14: Long = 0L,
+    val arg15: Long = 0L, val arg16: Long = 0L, val arg17: Long = 0L, val arg18: Long = 0L, val arg19: Long = 0L,
+    val arg20: Long = 0L, val arg21: Long = 0L, val arg22: Long = 0L, val arg23: Long = 0L, val arg24: Long = 0L,
+    val arg25: Long = 0L, val arg26: Long = 0L, val arg27: Long = 0L, val arg28: Long = 0L, val arg29: Long = 0L,
+    val arg30: Long = 0L, val arg31: Long = 0L, val x: A = A("0")
+)
+data class TestCtor33_2(
+    val arg00: Long = 0L, val arg01: Long = 0L, val arg02: Long = 0L, val arg03: Long = 0L, val arg04: Long = 0L,
+    val arg05: Long = 0L, val arg06: Long = 0L, val arg07: Long = 0L, val arg08: Long = 0L, val arg09: Long = 0L,
+    val arg10: Long = 0L, val arg11: Long = 0L, val arg12: Long = 0L, val arg13: Long = 0L, val arg14: Long = 0L,
+    val arg15: Long = 0L, val arg16: Long = 0L, val arg17: Long = 0L, val arg18: Long = 0L, val arg19: Long = 0L,
+    val arg20: Long = 0L, val arg21: Long = 0L, val arg22: Long = 0L, val arg23: Long = 0L, val arg24: Long = 0L,
+    val arg25: Long = 0L, val arg26: Long = 0L, val arg27: Long = 0L, val arg28: Long = 0L, val arg29: Long = 0L,
+    val arg30: Long = 0L, val arg31: Long = 0L, val x: A? = A("0")
+)
+
+data class TestCtor64_1(
+    val arg00: Long = 0L, val arg01: Long = 0L, val arg02: Long = 0L, val arg03: Long = 0L, val arg04: Long = 0L,
+    val arg05: Long = 0L, val arg06: Long = 0L, val arg07: Long = 0L, val arg08: Long = 0L, val arg09: Long = 0L,
+    val arg10: Long = 0L, val arg11: Long = 0L, val arg12: Long = 0L, val arg13: Long = 0L, val arg14: Long = 0L,
+    val arg15: Long = 0L, val arg16: Long = 0L, val arg17: Long = 0L, val arg18: Long = 0L, val arg19: Long = 0L,
+    val arg20: Long = 0L, val arg21: Long = 0L, val arg22: Long = 0L, val arg23: Long = 0L, val arg24: Long = 0L,
+    val arg25: Long = 0L, val arg26: Long = 0L, val arg27: Long = 0L, val arg28: Long = 0L, val arg29: Long = 0L,
+    val arg30: Long = 0L, val arg31: Long = 0L, val arg32: Long = 0L, val arg33: Long = 0L, val arg34: Long = 0L,
+    val arg35: Long = 0L, val arg36: Long = 0L, val arg37: Long = 0L, val arg38: Long = 0L, val arg39: Long = 0L,
+    val arg40: Long = 0L, val arg41: Long = 0L, val arg42: Long = 0L, val arg43: Long = 0L, val arg44: Long = 0L,
+    val arg45: Long = 0L, val arg46: Long = 0L, val arg47: Long = 0L, val arg48: Long = 0L, val arg49: Long = 0L,
+    val arg50: Long = 0L, val arg51: Long = 0L, val arg52: Long = 0L, val arg53: Long = 0L, val arg54: Long = 0L,
+    val arg55: Long = 0L, val arg56: Long = 0L, val arg57: Long = 0L, val arg58: Long = 0L, val arg59: Long = 0L,
+    val arg60: Long = 0L, val arg61: Long = 0L, val arg62: Long = 0L, val x: A = A("0")
+)
+data class TestCtor64_2(
+    val arg00: Long = 0L, val arg01: Long = 0L, val arg02: Long = 0L, val arg03: Long = 0L, val arg04: Long = 0L,
+    val arg05: Long = 0L, val arg06: Long = 0L, val arg07: Long = 0L, val arg08: Long = 0L, val arg09: Long = 0L,
+    val arg10: Long = 0L, val arg11: Long = 0L, val arg12: Long = 0L, val arg13: Long = 0L, val arg14: Long = 0L,
+    val arg15: Long = 0L, val arg16: Long = 0L, val arg17: Long = 0L, val arg18: Long = 0L, val arg19: Long = 0L,
+    val arg20: Long = 0L, val arg21: Long = 0L, val arg22: Long = 0L, val arg23: Long = 0L, val arg24: Long = 0L,
+    val arg25: Long = 0L, val arg26: Long = 0L, val arg27: Long = 0L, val arg28: Long = 0L, val arg29: Long = 0L,
+    val arg30: Long = 0L, val arg31: Long = 0L, val arg32: Long = 0L, val arg33: Long = 0L, val arg34: Long = 0L,
+    val arg35: Long = 0L, val arg36: Long = 0L, val arg37: Long = 0L, val arg38: Long = 0L, val arg39: Long = 0L,
+    val arg40: Long = 0L, val arg41: Long = 0L, val arg42: Long = 0L, val arg43: Long = 0L, val arg44: Long = 0L,
+    val arg45: Long = 0L, val arg46: Long = 0L, val arg47: Long = 0L, val arg48: Long = 0L, val arg49: Long = 0L,
+    val arg50: Long = 0L, val arg51: Long = 0L, val arg52: Long = 0L, val arg53: Long = 0L, val arg54: Long = 0L,
+    val arg55: Long = 0L, val arg56: Long = 0L, val arg57: Long = 0L, val arg58: Long = 0L, val arg59: Long = 0L,
+    val arg60: Long = 0L, val arg61: Long = 0L, val arg62: Long = 0L, val x: A? = A("0")
+)
+
+data class TestCtor65_1(
+    val arg00: Long = 0L, val arg01: Long = 0L, val arg02: Long = 0L, val arg03: Long = 0L, val arg04: Long = 0L,
+    val arg05: Long = 0L, val arg06: Long = 0L, val arg07: Long = 0L, val arg08: Long = 0L, val arg09: Long = 0L,
+    val arg10: Long = 0L, val arg11: Long = 0L, val arg12: Long = 0L, val arg13: Long = 0L, val arg14: Long = 0L,
+    val arg15: Long = 0L, val arg16: Long = 0L, val arg17: Long = 0L, val arg18: Long = 0L, val arg19: Long = 0L,
+    val arg20: Long = 0L, val arg21: Long = 0L, val arg22: Long = 0L, val arg23: Long = 0L, val arg24: Long = 0L,
+    val arg25: Long = 0L, val arg26: Long = 0L, val arg27: Long = 0L, val arg28: Long = 0L, val arg29: Long = 0L,
+    val arg30: Long = 0L, val arg31: Long = 0L, val arg32: Long = 0L, val arg33: Long = 0L, val arg34: Long = 0L,
+    val arg35: Long = 0L, val arg36: Long = 0L, val arg37: Long = 0L, val arg38: Long = 0L, val arg39: Long = 0L,
+    val arg40: Long = 0L, val arg41: Long = 0L, val arg42: Long = 0L, val arg43: Long = 0L, val arg44: Long = 0L,
+    val arg45: Long = 0L, val arg46: Long = 0L, val arg47: Long = 0L, val arg48: Long = 0L, val arg49: Long = 0L,
+    val arg50: Long = 0L, val arg51: Long = 0L, val arg52: Long = 0L, val arg53: Long = 0L, val arg54: Long = 0L,
+    val arg55: Long = 0L, val arg56: Long = 0L, val arg57: Long = 0L, val arg58: Long = 0L, val arg59: Long = 0L,
+    val arg60: Long = 0L, val arg61: Long = 0L, val arg62: Long = 0L, val arg63: Long = 0L, val x: A = A("0")
+)
+data class TestCtor65_2(
+    val arg00: Long = 0L, val arg01: Long = 0L, val arg02: Long = 0L, val arg03: Long = 0L, val arg04: Long = 0L,
+    val arg05: Long = 0L, val arg06: Long = 0L, val arg07: Long = 0L, val arg08: Long = 0L, val arg09: Long = 0L,
+    val arg10: Long = 0L, val arg11: Long = 0L, val arg12: Long = 0L, val arg13: Long = 0L, val arg14: Long = 0L,
+    val arg15: Long = 0L, val arg16: Long = 0L, val arg17: Long = 0L, val arg18: Long = 0L, val arg19: Long = 0L,
+    val arg20: Long = 0L, val arg21: Long = 0L, val arg22: Long = 0L, val arg23: Long = 0L, val arg24: Long = 0L,
+    val arg25: Long = 0L, val arg26: Long = 0L, val arg27: Long = 0L, val arg28: Long = 0L, val arg29: Long = 0L,
+    val arg30: Long = 0L, val arg31: Long = 0L, val arg32: Long = 0L, val arg33: Long = 0L, val arg34: Long = 0L,
+    val arg35: Long = 0L, val arg36: Long = 0L, val arg37: Long = 0L, val arg38: Long = 0L, val arg39: Long = 0L,
+    val arg40: Long = 0L, val arg41: Long = 0L, val arg42: Long = 0L, val arg43: Long = 0L, val arg44: Long = 0L,
+    val arg45: Long = 0L, val arg46: Long = 0L, val arg47: Long = 0L, val arg48: Long = 0L, val arg49: Long = 0L,
+    val arg50: Long = 0L, val arg51: Long = 0L, val arg52: Long = 0L, val arg53: Long = 0L, val arg54: Long = 0L,
+    val arg55: Long = 0L, val arg56: Long = 0L, val arg57: Long = 0L, val arg58: Long = 0L, val arg59: Long = 0L,
+    val arg60: Long = 0L, val arg61: Long = 0L, val arg62: Long = 0L, val arg63: Long = 0L, val x: A? = A("0")
+)
+
+fun box(): String {
+    assertEquals(TestCtor1_1(), ::TestCtor1_1.callBy(mapOf()))
+    assertEquals(TestCtor1_2(), ::TestCtor1_2.callBy(mapOf()))
+    assertEquals(TestCtor32_1(), ::TestCtor32_1.callBy(mapOf()))
+    assertEquals(TestCtor32_2(), ::TestCtor32_2.callBy(mapOf()))
+    assertEquals(TestCtor33_1(), ::TestCtor33_1.callBy(mapOf()))
+    assertEquals(TestCtor33_2(), ::TestCtor33_2.callBy(mapOf()))
+    assertEquals(TestCtor64_1(), ::TestCtor64_1.callBy(mapOf()))
+    assertEquals(TestCtor64_2(), ::TestCtor64_2.callBy(mapOf()))
+    assertEquals(TestCtor65_1(), ::TestCtor65_1.callBy(mapOf()))
+    assertEquals(TestCtor65_2(), ::TestCtor65_2.callBy(mapOf()))
+
+    return "OK"
+}

--- a/compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments/constructorWithInlineClassParameters.kt
+++ b/compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments/constructorWithInlineClassParameters.kt
@@ -1,0 +1,126 @@
+// TARGET_BACKEND: JVM
+// IGNORE_BACKEND: JVM_IR
+// WITH_REFLECT
+
+import kotlin.test.assertEquals
+
+@JvmInline
+value class A(val x: String?)
+
+data class TestCtor1_1(val x: A = A("0"))
+data class TestCtor1_2(val x: A? = A("0"))
+
+data class TestCtor32_1(
+    val arg00: Long = 0L, val arg01: Long = 0L, val arg02: Long = 0L, val arg03: Long = 0L, val arg04: Long = 0L,
+    val arg05: Long = 0L, val arg06: Long = 0L, val arg07: Long = 0L, val arg08: Long = 0L, val arg09: Long = 0L,
+    val arg10: Long = 0L, val arg11: Long = 0L, val arg12: Long = 0L, val arg13: Long = 0L, val arg14: Long = 0L,
+    val arg15: Long = 0L, val arg16: Long = 0L, val arg17: Long = 0L, val arg18: Long = 0L, val arg19: Long = 0L,
+    val arg20: Long = 0L, val arg21: Long = 0L, val arg22: Long = 0L, val arg23: Long = 0L, val arg24: Long = 0L,
+    val arg25: Long = 0L, val arg26: Long = 0L, val arg27: Long = 0L, val arg28: Long = 0L, val arg29: Long = 0L,
+    val arg30: Long = 0L, val x: A = A("0")
+)
+data class TestCtor32_2(
+    val arg00: Long = 0L, val arg01: Long = 0L, val arg02: Long = 0L, val arg03: Long = 0L, val arg04: Long = 0L,
+    val arg05: Long = 0L, val arg06: Long = 0L, val arg07: Long = 0L, val arg08: Long = 0L, val arg09: Long = 0L,
+    val arg10: Long = 0L, val arg11: Long = 0L, val arg12: Long = 0L, val arg13: Long = 0L, val arg14: Long = 0L,
+    val arg15: Long = 0L, val arg16: Long = 0L, val arg17: Long = 0L, val arg18: Long = 0L, val arg19: Long = 0L,
+    val arg20: Long = 0L, val arg21: Long = 0L, val arg22: Long = 0L, val arg23: Long = 0L, val arg24: Long = 0L,
+    val arg25: Long = 0L, val arg26: Long = 0L, val arg27: Long = 0L, val arg28: Long = 0L, val arg29: Long = 0L,
+    val arg30: Long = 0L, val x: A? = A("0")
+)
+
+data class TestCtor33_1(
+    val arg00: Long = 0L, val arg01: Long = 0L, val arg02: Long = 0L, val arg03: Long = 0L, val arg04: Long = 0L,
+    val arg05: Long = 0L, val arg06: Long = 0L, val arg07: Long = 0L, val arg08: Long = 0L, val arg09: Long = 0L,
+    val arg10: Long = 0L, val arg11: Long = 0L, val arg12: Long = 0L, val arg13: Long = 0L, val arg14: Long = 0L,
+    val arg15: Long = 0L, val arg16: Long = 0L, val arg17: Long = 0L, val arg18: Long = 0L, val arg19: Long = 0L,
+    val arg20: Long = 0L, val arg21: Long = 0L, val arg22: Long = 0L, val arg23: Long = 0L, val arg24: Long = 0L,
+    val arg25: Long = 0L, val arg26: Long = 0L, val arg27: Long = 0L, val arg28: Long = 0L, val arg29: Long = 0L,
+    val arg30: Long = 0L, val arg31: Long = 0L, val x: A = A("0")
+)
+data class TestCtor33_2(
+    val arg00: Long = 0L, val arg01: Long = 0L, val arg02: Long = 0L, val arg03: Long = 0L, val arg04: Long = 0L,
+    val arg05: Long = 0L, val arg06: Long = 0L, val arg07: Long = 0L, val arg08: Long = 0L, val arg09: Long = 0L,
+    val arg10: Long = 0L, val arg11: Long = 0L, val arg12: Long = 0L, val arg13: Long = 0L, val arg14: Long = 0L,
+    val arg15: Long = 0L, val arg16: Long = 0L, val arg17: Long = 0L, val arg18: Long = 0L, val arg19: Long = 0L,
+    val arg20: Long = 0L, val arg21: Long = 0L, val arg22: Long = 0L, val arg23: Long = 0L, val arg24: Long = 0L,
+    val arg25: Long = 0L, val arg26: Long = 0L, val arg27: Long = 0L, val arg28: Long = 0L, val arg29: Long = 0L,
+    val arg30: Long = 0L, val arg31: Long = 0L, val x: A? = A("0")
+)
+
+data class TestCtor64_1(
+    val arg00: Long = 0L, val arg01: Long = 0L, val arg02: Long = 0L, val arg03: Long = 0L, val arg04: Long = 0L,
+    val arg05: Long = 0L, val arg06: Long = 0L, val arg07: Long = 0L, val arg08: Long = 0L, val arg09: Long = 0L,
+    val arg10: Long = 0L, val arg11: Long = 0L, val arg12: Long = 0L, val arg13: Long = 0L, val arg14: Long = 0L,
+    val arg15: Long = 0L, val arg16: Long = 0L, val arg17: Long = 0L, val arg18: Long = 0L, val arg19: Long = 0L,
+    val arg20: Long = 0L, val arg21: Long = 0L, val arg22: Long = 0L, val arg23: Long = 0L, val arg24: Long = 0L,
+    val arg25: Long = 0L, val arg26: Long = 0L, val arg27: Long = 0L, val arg28: Long = 0L, val arg29: Long = 0L,
+    val arg30: Long = 0L, val arg31: Long = 0L, val arg32: Long = 0L, val arg33: Long = 0L, val arg34: Long = 0L,
+    val arg35: Long = 0L, val arg36: Long = 0L, val arg37: Long = 0L, val arg38: Long = 0L, val arg39: Long = 0L,
+    val arg40: Long = 0L, val arg41: Long = 0L, val arg42: Long = 0L, val arg43: Long = 0L, val arg44: Long = 0L,
+    val arg45: Long = 0L, val arg46: Long = 0L, val arg47: Long = 0L, val arg48: Long = 0L, val arg49: Long = 0L,
+    val arg50: Long = 0L, val arg51: Long = 0L, val arg52: Long = 0L, val arg53: Long = 0L, val arg54: Long = 0L,
+    val arg55: Long = 0L, val arg56: Long = 0L, val arg57: Long = 0L, val arg58: Long = 0L, val arg59: Long = 0L,
+    val arg60: Long = 0L, val arg61: Long = 0L, val arg62: Long = 0L, val x: A = A("0")
+)
+data class TestCtor64_2(
+    val arg00: Long = 0L, val arg01: Long = 0L, val arg02: Long = 0L, val arg03: Long = 0L, val arg04: Long = 0L,
+    val arg05: Long = 0L, val arg06: Long = 0L, val arg07: Long = 0L, val arg08: Long = 0L, val arg09: Long = 0L,
+    val arg10: Long = 0L, val arg11: Long = 0L, val arg12: Long = 0L, val arg13: Long = 0L, val arg14: Long = 0L,
+    val arg15: Long = 0L, val arg16: Long = 0L, val arg17: Long = 0L, val arg18: Long = 0L, val arg19: Long = 0L,
+    val arg20: Long = 0L, val arg21: Long = 0L, val arg22: Long = 0L, val arg23: Long = 0L, val arg24: Long = 0L,
+    val arg25: Long = 0L, val arg26: Long = 0L, val arg27: Long = 0L, val arg28: Long = 0L, val arg29: Long = 0L,
+    val arg30: Long = 0L, val arg31: Long = 0L, val arg32: Long = 0L, val arg33: Long = 0L, val arg34: Long = 0L,
+    val arg35: Long = 0L, val arg36: Long = 0L, val arg37: Long = 0L, val arg38: Long = 0L, val arg39: Long = 0L,
+    val arg40: Long = 0L, val arg41: Long = 0L, val arg42: Long = 0L, val arg43: Long = 0L, val arg44: Long = 0L,
+    val arg45: Long = 0L, val arg46: Long = 0L, val arg47: Long = 0L, val arg48: Long = 0L, val arg49: Long = 0L,
+    val arg50: Long = 0L, val arg51: Long = 0L, val arg52: Long = 0L, val arg53: Long = 0L, val arg54: Long = 0L,
+    val arg55: Long = 0L, val arg56: Long = 0L, val arg57: Long = 0L, val arg58: Long = 0L, val arg59: Long = 0L,
+    val arg60: Long = 0L, val arg61: Long = 0L, val arg62: Long = 0L, val x: A? = A("0")
+)
+
+data class TestCtor65_1(
+    val arg00: Long = 0L, val arg01: Long = 0L, val arg02: Long = 0L, val arg03: Long = 0L, val arg04: Long = 0L,
+    val arg05: Long = 0L, val arg06: Long = 0L, val arg07: Long = 0L, val arg08: Long = 0L, val arg09: Long = 0L,
+    val arg10: Long = 0L, val arg11: Long = 0L, val arg12: Long = 0L, val arg13: Long = 0L, val arg14: Long = 0L,
+    val arg15: Long = 0L, val arg16: Long = 0L, val arg17: Long = 0L, val arg18: Long = 0L, val arg19: Long = 0L,
+    val arg20: Long = 0L, val arg21: Long = 0L, val arg22: Long = 0L, val arg23: Long = 0L, val arg24: Long = 0L,
+    val arg25: Long = 0L, val arg26: Long = 0L, val arg27: Long = 0L, val arg28: Long = 0L, val arg29: Long = 0L,
+    val arg30: Long = 0L, val arg31: Long = 0L, val arg32: Long = 0L, val arg33: Long = 0L, val arg34: Long = 0L,
+    val arg35: Long = 0L, val arg36: Long = 0L, val arg37: Long = 0L, val arg38: Long = 0L, val arg39: Long = 0L,
+    val arg40: Long = 0L, val arg41: Long = 0L, val arg42: Long = 0L, val arg43: Long = 0L, val arg44: Long = 0L,
+    val arg45: Long = 0L, val arg46: Long = 0L, val arg47: Long = 0L, val arg48: Long = 0L, val arg49: Long = 0L,
+    val arg50: Long = 0L, val arg51: Long = 0L, val arg52: Long = 0L, val arg53: Long = 0L, val arg54: Long = 0L,
+    val arg55: Long = 0L, val arg56: Long = 0L, val arg57: Long = 0L, val arg58: Long = 0L, val arg59: Long = 0L,
+    val arg60: Long = 0L, val arg61: Long = 0L, val arg62: Long = 0L, val arg63: Long = 0L, val x: A = A("0")
+)
+data class TestCtor65_2(
+    val arg00: Long = 0L, val arg01: Long = 0L, val arg02: Long = 0L, val arg03: Long = 0L, val arg04: Long = 0L,
+    val arg05: Long = 0L, val arg06: Long = 0L, val arg07: Long = 0L, val arg08: Long = 0L, val arg09: Long = 0L,
+    val arg10: Long = 0L, val arg11: Long = 0L, val arg12: Long = 0L, val arg13: Long = 0L, val arg14: Long = 0L,
+    val arg15: Long = 0L, val arg16: Long = 0L, val arg17: Long = 0L, val arg18: Long = 0L, val arg19: Long = 0L,
+    val arg20: Long = 0L, val arg21: Long = 0L, val arg22: Long = 0L, val arg23: Long = 0L, val arg24: Long = 0L,
+    val arg25: Long = 0L, val arg26: Long = 0L, val arg27: Long = 0L, val arg28: Long = 0L, val arg29: Long = 0L,
+    val arg30: Long = 0L, val arg31: Long = 0L, val arg32: Long = 0L, val arg33: Long = 0L, val arg34: Long = 0L,
+    val arg35: Long = 0L, val arg36: Long = 0L, val arg37: Long = 0L, val arg38: Long = 0L, val arg39: Long = 0L,
+    val arg40: Long = 0L, val arg41: Long = 0L, val arg42: Long = 0L, val arg43: Long = 0L, val arg44: Long = 0L,
+    val arg45: Long = 0L, val arg46: Long = 0L, val arg47: Long = 0L, val arg48: Long = 0L, val arg49: Long = 0L,
+    val arg50: Long = 0L, val arg51: Long = 0L, val arg52: Long = 0L, val arg53: Long = 0L, val arg54: Long = 0L,
+    val arg55: Long = 0L, val arg56: Long = 0L, val arg57: Long = 0L, val arg58: Long = 0L, val arg59: Long = 0L,
+    val arg60: Long = 0L, val arg61: Long = 0L, val arg62: Long = 0L, val arg63: Long = 0L, val x: A? = A("0")
+)
+
+fun box(): String {
+    assertEquals(TestCtor1_1(), ::TestCtor1_1.callBy(mapOf()))
+    assertEquals(TestCtor1_2(), ::TestCtor1_2.callBy(mapOf()))
+    assertEquals(TestCtor32_1(), ::TestCtor32_1.callBy(mapOf()))
+    assertEquals(TestCtor32_2(), ::TestCtor32_2.callBy(mapOf()))
+    assertEquals(TestCtor33_1(), ::TestCtor33_1.callBy(mapOf()))
+    assertEquals(TestCtor33_2(), ::TestCtor33_2.callBy(mapOf()))
+    assertEquals(TestCtor64_1(), ::TestCtor64_1.callBy(mapOf()))
+    assertEquals(TestCtor64_2(), ::TestCtor64_2.callBy(mapOf()))
+    assertEquals(TestCtor65_1(), ::TestCtor65_1.callBy(mapOf()))
+    assertEquals(TestCtor65_2(), ::TestCtor65_2.callBy(mapOf()))
+
+    return "OK"
+}

--- a/compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments/constructorWithInlineClassParameters.kt
+++ b/compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments/constructorWithInlineClassParameters.kt
@@ -1,0 +1,125 @@
+// TARGET_BACKEND: JVM
+// WITH_REFLECT
+
+import kotlin.test.assertEquals
+
+@JvmInline
+value class A(val x: Int)
+
+data class TestCtor1_1(val x: A = A(0))
+data class TestCtor1_2(val x: A? = A(0))
+
+data class TestCtor32_1(
+    val arg00: Long = 0L, val arg01: Long = 0L, val arg02: Long = 0L, val arg03: Long = 0L, val arg04: Long = 0L,
+    val arg05: Long = 0L, val arg06: Long = 0L, val arg07: Long = 0L, val arg08: Long = 0L, val arg09: Long = 0L,
+    val arg10: Long = 0L, val arg11: Long = 0L, val arg12: Long = 0L, val arg13: Long = 0L, val arg14: Long = 0L,
+    val arg15: Long = 0L, val arg16: Long = 0L, val arg17: Long = 0L, val arg18: Long = 0L, val arg19: Long = 0L,
+    val arg20: Long = 0L, val arg21: Long = 0L, val arg22: Long = 0L, val arg23: Long = 0L, val arg24: Long = 0L,
+    val arg25: Long = 0L, val arg26: Long = 0L, val arg27: Long = 0L, val arg28: Long = 0L, val arg29: Long = 0L,
+    val arg30: Long = 0L, val x: A = A(0)
+)
+data class TestCtor32_2(
+    val arg00: Long = 0L, val arg01: Long = 0L, val arg02: Long = 0L, val arg03: Long = 0L, val arg04: Long = 0L,
+    val arg05: Long = 0L, val arg06: Long = 0L, val arg07: Long = 0L, val arg08: Long = 0L, val arg09: Long = 0L,
+    val arg10: Long = 0L, val arg11: Long = 0L, val arg12: Long = 0L, val arg13: Long = 0L, val arg14: Long = 0L,
+    val arg15: Long = 0L, val arg16: Long = 0L, val arg17: Long = 0L, val arg18: Long = 0L, val arg19: Long = 0L,
+    val arg20: Long = 0L, val arg21: Long = 0L, val arg22: Long = 0L, val arg23: Long = 0L, val arg24: Long = 0L,
+    val arg25: Long = 0L, val arg26: Long = 0L, val arg27: Long = 0L, val arg28: Long = 0L, val arg29: Long = 0L,
+    val arg30: Long = 0L, val x: A? = A(0)
+)
+
+data class TestCtor33_1(
+    val arg00: Long = 0L, val arg01: Long = 0L, val arg02: Long = 0L, val arg03: Long = 0L, val arg04: Long = 0L,
+    val arg05: Long = 0L, val arg06: Long = 0L, val arg07: Long = 0L, val arg08: Long = 0L, val arg09: Long = 0L,
+    val arg10: Long = 0L, val arg11: Long = 0L, val arg12: Long = 0L, val arg13: Long = 0L, val arg14: Long = 0L,
+    val arg15: Long = 0L, val arg16: Long = 0L, val arg17: Long = 0L, val arg18: Long = 0L, val arg19: Long = 0L,
+    val arg20: Long = 0L, val arg21: Long = 0L, val arg22: Long = 0L, val arg23: Long = 0L, val arg24: Long = 0L,
+    val arg25: Long = 0L, val arg26: Long = 0L, val arg27: Long = 0L, val arg28: Long = 0L, val arg29: Long = 0L,
+    val arg30: Long = 0L, val arg31: Long = 0L, val x: A = A(0)
+)
+data class TestCtor33_2(
+    val arg00: Long = 0L, val arg01: Long = 0L, val arg02: Long = 0L, val arg03: Long = 0L, val arg04: Long = 0L,
+    val arg05: Long = 0L, val arg06: Long = 0L, val arg07: Long = 0L, val arg08: Long = 0L, val arg09: Long = 0L,
+    val arg10: Long = 0L, val arg11: Long = 0L, val arg12: Long = 0L, val arg13: Long = 0L, val arg14: Long = 0L,
+    val arg15: Long = 0L, val arg16: Long = 0L, val arg17: Long = 0L, val arg18: Long = 0L, val arg19: Long = 0L,
+    val arg20: Long = 0L, val arg21: Long = 0L, val arg22: Long = 0L, val arg23: Long = 0L, val arg24: Long = 0L,
+    val arg25: Long = 0L, val arg26: Long = 0L, val arg27: Long = 0L, val arg28: Long = 0L, val arg29: Long = 0L,
+    val arg30: Long = 0L, val arg31: Long = 0L, val x: A? = A(0)
+)
+
+data class TestCtor64_1(
+    val arg00: Long = 0L, val arg01: Long = 0L, val arg02: Long = 0L, val arg03: Long = 0L, val arg04: Long = 0L,
+    val arg05: Long = 0L, val arg06: Long = 0L, val arg07: Long = 0L, val arg08: Long = 0L, val arg09: Long = 0L,
+    val arg10: Long = 0L, val arg11: Long = 0L, val arg12: Long = 0L, val arg13: Long = 0L, val arg14: Long = 0L,
+    val arg15: Long = 0L, val arg16: Long = 0L, val arg17: Long = 0L, val arg18: Long = 0L, val arg19: Long = 0L,
+    val arg20: Long = 0L, val arg21: Long = 0L, val arg22: Long = 0L, val arg23: Long = 0L, val arg24: Long = 0L,
+    val arg25: Long = 0L, val arg26: Long = 0L, val arg27: Long = 0L, val arg28: Long = 0L, val arg29: Long = 0L,
+    val arg30: Long = 0L, val arg31: Long = 0L, val arg32: Long = 0L, val arg33: Long = 0L, val arg34: Long = 0L,
+    val arg35: Long = 0L, val arg36: Long = 0L, val arg37: Long = 0L, val arg38: Long = 0L, val arg39: Long = 0L,
+    val arg40: Long = 0L, val arg41: Long = 0L, val arg42: Long = 0L, val arg43: Long = 0L, val arg44: Long = 0L,
+    val arg45: Long = 0L, val arg46: Long = 0L, val arg47: Long = 0L, val arg48: Long = 0L, val arg49: Long = 0L,
+    val arg50: Long = 0L, val arg51: Long = 0L, val arg52: Long = 0L, val arg53: Long = 0L, val arg54: Long = 0L,
+    val arg55: Long = 0L, val arg56: Long = 0L, val arg57: Long = 0L, val arg58: Long = 0L, val arg59: Long = 0L,
+    val arg60: Long = 0L, val arg61: Long = 0L, val arg62: Long = 0L, val x: A = A(0)
+)
+data class TestCtor64_2(
+    val arg00: Long = 0L, val arg01: Long = 0L, val arg02: Long = 0L, val arg03: Long = 0L, val arg04: Long = 0L,
+    val arg05: Long = 0L, val arg06: Long = 0L, val arg07: Long = 0L, val arg08: Long = 0L, val arg09: Long = 0L,
+    val arg10: Long = 0L, val arg11: Long = 0L, val arg12: Long = 0L, val arg13: Long = 0L, val arg14: Long = 0L,
+    val arg15: Long = 0L, val arg16: Long = 0L, val arg17: Long = 0L, val arg18: Long = 0L, val arg19: Long = 0L,
+    val arg20: Long = 0L, val arg21: Long = 0L, val arg22: Long = 0L, val arg23: Long = 0L, val arg24: Long = 0L,
+    val arg25: Long = 0L, val arg26: Long = 0L, val arg27: Long = 0L, val arg28: Long = 0L, val arg29: Long = 0L,
+    val arg30: Long = 0L, val arg31: Long = 0L, val arg32: Long = 0L, val arg33: Long = 0L, val arg34: Long = 0L,
+    val arg35: Long = 0L, val arg36: Long = 0L, val arg37: Long = 0L, val arg38: Long = 0L, val arg39: Long = 0L,
+    val arg40: Long = 0L, val arg41: Long = 0L, val arg42: Long = 0L, val arg43: Long = 0L, val arg44: Long = 0L,
+    val arg45: Long = 0L, val arg46: Long = 0L, val arg47: Long = 0L, val arg48: Long = 0L, val arg49: Long = 0L,
+    val arg50: Long = 0L, val arg51: Long = 0L, val arg52: Long = 0L, val arg53: Long = 0L, val arg54: Long = 0L,
+    val arg55: Long = 0L, val arg56: Long = 0L, val arg57: Long = 0L, val arg58: Long = 0L, val arg59: Long = 0L,
+    val arg60: Long = 0L, val arg61: Long = 0L, val arg62: Long = 0L, val x: A? = A(0)
+)
+
+data class TestCtor65_1(
+    val arg00: Long = 0L, val arg01: Long = 0L, val arg02: Long = 0L, val arg03: Long = 0L, val arg04: Long = 0L,
+    val arg05: Long = 0L, val arg06: Long = 0L, val arg07: Long = 0L, val arg08: Long = 0L, val arg09: Long = 0L,
+    val arg10: Long = 0L, val arg11: Long = 0L, val arg12: Long = 0L, val arg13: Long = 0L, val arg14: Long = 0L,
+    val arg15: Long = 0L, val arg16: Long = 0L, val arg17: Long = 0L, val arg18: Long = 0L, val arg19: Long = 0L,
+    val arg20: Long = 0L, val arg21: Long = 0L, val arg22: Long = 0L, val arg23: Long = 0L, val arg24: Long = 0L,
+    val arg25: Long = 0L, val arg26: Long = 0L, val arg27: Long = 0L, val arg28: Long = 0L, val arg29: Long = 0L,
+    val arg30: Long = 0L, val arg31: Long = 0L, val arg32: Long = 0L, val arg33: Long = 0L, val arg34: Long = 0L,
+    val arg35: Long = 0L, val arg36: Long = 0L, val arg37: Long = 0L, val arg38: Long = 0L, val arg39: Long = 0L,
+    val arg40: Long = 0L, val arg41: Long = 0L, val arg42: Long = 0L, val arg43: Long = 0L, val arg44: Long = 0L,
+    val arg45: Long = 0L, val arg46: Long = 0L, val arg47: Long = 0L, val arg48: Long = 0L, val arg49: Long = 0L,
+    val arg50: Long = 0L, val arg51: Long = 0L, val arg52: Long = 0L, val arg53: Long = 0L, val arg54: Long = 0L,
+    val arg55: Long = 0L, val arg56: Long = 0L, val arg57: Long = 0L, val arg58: Long = 0L, val arg59: Long = 0L,
+    val arg60: Long = 0L, val arg61: Long = 0L, val arg62: Long = 0L, val arg63: Long = 0L, val x: A = A(0)
+)
+data class TestCtor65_2(
+    val arg00: Long = 0L, val arg01: Long = 0L, val arg02: Long = 0L, val arg03: Long = 0L, val arg04: Long = 0L,
+    val arg05: Long = 0L, val arg06: Long = 0L, val arg07: Long = 0L, val arg08: Long = 0L, val arg09: Long = 0L,
+    val arg10: Long = 0L, val arg11: Long = 0L, val arg12: Long = 0L, val arg13: Long = 0L, val arg14: Long = 0L,
+    val arg15: Long = 0L, val arg16: Long = 0L, val arg17: Long = 0L, val arg18: Long = 0L, val arg19: Long = 0L,
+    val arg20: Long = 0L, val arg21: Long = 0L, val arg22: Long = 0L, val arg23: Long = 0L, val arg24: Long = 0L,
+    val arg25: Long = 0L, val arg26: Long = 0L, val arg27: Long = 0L, val arg28: Long = 0L, val arg29: Long = 0L,
+    val arg30: Long = 0L, val arg31: Long = 0L, val arg32: Long = 0L, val arg33: Long = 0L, val arg34: Long = 0L,
+    val arg35: Long = 0L, val arg36: Long = 0L, val arg37: Long = 0L, val arg38: Long = 0L, val arg39: Long = 0L,
+    val arg40: Long = 0L, val arg41: Long = 0L, val arg42: Long = 0L, val arg43: Long = 0L, val arg44: Long = 0L,
+    val arg45: Long = 0L, val arg46: Long = 0L, val arg47: Long = 0L, val arg48: Long = 0L, val arg49: Long = 0L,
+    val arg50: Long = 0L, val arg51: Long = 0L, val arg52: Long = 0L, val arg53: Long = 0L, val arg54: Long = 0L,
+    val arg55: Long = 0L, val arg56: Long = 0L, val arg57: Long = 0L, val arg58: Long = 0L, val arg59: Long = 0L,
+    val arg60: Long = 0L, val arg61: Long = 0L, val arg62: Long = 0L, val arg63: Long = 0L, val x: A? = A(0)
+)
+
+fun box(): String {
+    assertEquals(TestCtor1_1(), ::TestCtor1_1.callBy(mapOf()))
+    assertEquals(TestCtor1_2(), ::TestCtor1_2.callBy(mapOf()))
+    assertEquals(TestCtor32_1(), ::TestCtor32_1.callBy(mapOf()))
+    assertEquals(TestCtor32_2(), ::TestCtor32_2.callBy(mapOf()))
+    assertEquals(TestCtor33_1(), ::TestCtor33_1.callBy(mapOf()))
+    assertEquals(TestCtor33_2(), ::TestCtor33_2.callBy(mapOf()))
+    assertEquals(TestCtor64_1(), ::TestCtor64_1.callBy(mapOf()))
+    assertEquals(TestCtor64_2(), ::TestCtor64_2.callBy(mapOf()))
+    assertEquals(TestCtor65_1(), ::TestCtor65_1.callBy(mapOf()))
+    assertEquals(TestCtor65_2(), ::TestCtor65_2.callBy(mapOf()))
+
+    return "OK"
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/JvmAbiConsistencyTestBoxGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/JvmAbiConsistencyTestBoxGenerated.java
@@ -49273,6 +49273,94 @@ public class JvmAbiConsistencyTestBoxGenerated extends AbstractJvmAbiConsistency
       public void testSimpleTopLevelFunction() {
         runTest("compiler/testData/codegen/box/reflection/callBy/simpleTopLevelFunction.kt");
       }
+
+      @Nested
+      @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses")
+      @TestDataPath("$PROJECT_ROOT")
+      public class ValueClasses {
+        @Test
+        public void testAllFilesPresentInValueClasses() {
+          KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject")
+        @TestDataPath("$PROJECT_ROOT")
+        public class NonNullObject {
+          @Test
+          public void testAllFilesPresentInNonNullObject() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+            }
+
+            @Test
+            @TestMetadata("constructorWithInlineClassParameters.kt")
+            public void testConstructorWithInlineClassParameters() {
+              runTest("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments/constructorWithInlineClassParameters.kt");
+            }
+          }
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject")
+        @TestDataPath("$PROJECT_ROOT")
+        public class NullableObject {
+          @Test
+          public void testAllFilesPresentInNullableObject() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+            }
+
+            @Test
+            @TestMetadata("constructorWithInlineClassParameters.kt")
+            public void testConstructorWithInlineClassParameters() {
+              runTest("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments/constructorWithInlineClassParameters.kt");
+            }
+          }
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive")
+        @TestDataPath("$PROJECT_ROOT")
+        public class Primitive {
+          @Test
+          public void testAllFilesPresentInPrimitive() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+            }
+
+            @Test
+            @TestMetadata("constructorWithInlineClassParameters.kt")
+            public void testConstructorWithInlineClassParameters() {
+              runTest("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments/constructorWithInlineClassParameters.kt");
+            }
+          }
+        }
+      }
     }
 
     @Nested

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -46195,6 +46195,94 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
       public void testSimpleTopLevelFunction() {
         runTest("compiler/testData/codegen/box/reflection/callBy/simpleTopLevelFunction.kt");
       }
+
+      @Nested
+      @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses")
+      @TestDataPath("$PROJECT_ROOT")
+      public class ValueClasses {
+        @Test
+        public void testAllFilesPresentInValueClasses() {
+          KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM, true);
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject")
+        @TestDataPath("$PROJECT_ROOT")
+        public class NonNullObject {
+          @Test
+          public void testAllFilesPresentInNonNullObject() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM, true);
+            }
+
+            @Test
+            @TestMetadata("constructorWithInlineClassParameters.kt")
+            public void testConstructorWithInlineClassParameters() {
+              runTest("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments/constructorWithInlineClassParameters.kt");
+            }
+          }
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject")
+        @TestDataPath("$PROJECT_ROOT")
+        public class NullableObject {
+          @Test
+          public void testAllFilesPresentInNullableObject() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM, true);
+            }
+
+            @Test
+            @TestMetadata("constructorWithInlineClassParameters.kt")
+            public void testConstructorWithInlineClassParameters() {
+              runTest("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments/constructorWithInlineClassParameters.kt");
+            }
+          }
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive")
+        @TestDataPath("$PROJECT_ROOT")
+        public class Primitive {
+          @Test
+          public void testAllFilesPresentInPrimitive() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM, true);
+            }
+
+            @Test
+            @TestMetadata("constructorWithInlineClassParameters.kt")
+            public void testConstructorWithInlineClassParameters() {
+              runTest("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments/constructorWithInlineClassParameters.kt");
+            }
+          }
+        }
+      }
     }
 
     @Nested

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -49273,6 +49273,94 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
       public void testSimpleTopLevelFunction() {
         runTest("compiler/testData/codegen/box/reflection/callBy/simpleTopLevelFunction.kt");
       }
+
+      @Nested
+      @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses")
+      @TestDataPath("$PROJECT_ROOT")
+      public class ValueClasses {
+        @Test
+        public void testAllFilesPresentInValueClasses() {
+          KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject")
+        @TestDataPath("$PROJECT_ROOT")
+        public class NonNullObject {
+          @Test
+          public void testAllFilesPresentInNonNullObject() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+            }
+
+            @Test
+            @TestMetadata("constructorWithInlineClassParameters.kt")
+            public void testConstructorWithInlineClassParameters() {
+              runTest("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments/constructorWithInlineClassParameters.kt");
+            }
+          }
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject")
+        @TestDataPath("$PROJECT_ROOT")
+        public class NullableObject {
+          @Test
+          public void testAllFilesPresentInNullableObject() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+            }
+
+            @Test
+            @TestMetadata("constructorWithInlineClassParameters.kt")
+            public void testConstructorWithInlineClassParameters() {
+              runTest("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments/constructorWithInlineClassParameters.kt");
+            }
+          }
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive")
+        @TestDataPath("$PROJECT_ROOT")
+        public class Primitive {
+          @Test
+          public void testAllFilesPresentInPrimitive() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+            }
+
+            @Test
+            @TestMetadata("constructorWithInlineClassParameters.kt")
+            public void testConstructorWithInlineClassParameters() {
+              runTest("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments/constructorWithInlineClassParameters.kt");
+            }
+          }
+        }
+      }
     }
 
     @Nested

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenWithIrInlinerTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenWithIrInlinerTestGenerated.java
@@ -49273,6 +49273,94 @@ public class IrBlackBoxCodegenWithIrInlinerTestGenerated extends AbstractIrBlack
       public void testSimpleTopLevelFunction() {
         runTest("compiler/testData/codegen/box/reflection/callBy/simpleTopLevelFunction.kt");
       }
+
+      @Nested
+      @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses")
+      @TestDataPath("$PROJECT_ROOT")
+      public class ValueClasses {
+        @Test
+        public void testAllFilesPresentInValueClasses() {
+          KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject")
+        @TestDataPath("$PROJECT_ROOT")
+        public class NonNullObject {
+          @Test
+          public void testAllFilesPresentInNonNullObject() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+            }
+
+            @Test
+            @TestMetadata("constructorWithInlineClassParameters.kt")
+            public void testConstructorWithInlineClassParameters() {
+              runTest("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments/constructorWithInlineClassParameters.kt");
+            }
+          }
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject")
+        @TestDataPath("$PROJECT_ROOT")
+        public class NullableObject {
+          @Test
+          public void testAllFilesPresentInNullableObject() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+            }
+
+            @Test
+            @TestMetadata("constructorWithInlineClassParameters.kt")
+            public void testConstructorWithInlineClassParameters() {
+              runTest("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments/constructorWithInlineClassParameters.kt");
+            }
+          }
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive")
+        @TestDataPath("$PROJECT_ROOT")
+        public class Primitive {
+          @Test
+          public void testAllFilesPresentInPrimitive() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+            }
+
+            @Test
+            @TestMetadata("constructorWithInlineClassParameters.kt")
+            public void testConstructorWithInlineClassParameters() {
+              runTest("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments/constructorWithInlineClassParameters.kt");
+            }
+          }
+        }
+      }
     }
 
     @Nested

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/inlineScopes/FirBlackBoxCodegenTestWithInlineScopesGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/inlineScopes/FirBlackBoxCodegenTestWithInlineScopesGenerated.java
@@ -49273,6 +49273,94 @@ public class FirBlackBoxCodegenTestWithInlineScopesGenerated extends AbstractFir
       public void testSimpleTopLevelFunction() {
         runTest("compiler/testData/codegen/box/reflection/callBy/simpleTopLevelFunction.kt");
       }
+
+      @Nested
+      @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses")
+      @TestDataPath("$PROJECT_ROOT")
+      public class ValueClasses {
+        @Test
+        public void testAllFilesPresentInValueClasses() {
+          KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject")
+        @TestDataPath("$PROJECT_ROOT")
+        public class NonNullObject {
+          @Test
+          public void testAllFilesPresentInNonNullObject() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+            }
+
+            @Test
+            @TestMetadata("constructorWithInlineClassParameters.kt")
+            public void testConstructorWithInlineClassParameters() {
+              runTest("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments/constructorWithInlineClassParameters.kt");
+            }
+          }
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject")
+        @TestDataPath("$PROJECT_ROOT")
+        public class NullableObject {
+          @Test
+          public void testAllFilesPresentInNullableObject() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+            }
+
+            @Test
+            @TestMetadata("constructorWithInlineClassParameters.kt")
+            public void testConstructorWithInlineClassParameters() {
+              runTest("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments/constructorWithInlineClassParameters.kt");
+            }
+          }
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive")
+        @TestDataPath("$PROJECT_ROOT")
+        public class Primitive {
+          @Test
+          public void testAllFilesPresentInPrimitive() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+            }
+
+            @Test
+            @TestMetadata("constructorWithInlineClassParameters.kt")
+            public void testConstructorWithInlineClassParameters() {
+              runTest("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments/constructorWithInlineClassParameters.kt");
+            }
+          }
+        }
+      }
     }
 
     @Nested

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -39449,6 +39449,112 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
       public void testSimpleTopLevelFunction() {
         runTest("compiler/testData/codegen/box/reflection/callBy/simpleTopLevelFunction.kt");
       }
+
+      @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses")
+      @TestDataPath("$PROJECT_ROOT")
+      @RunWith(JUnit3RunnerWithInners.class)
+      public static class ValueClasses extends AbstractLightAnalysisModeTest {
+        private void runTest(String testDataFilePath) {
+          KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM_IR, testDataFilePath);
+        }
+
+        public void testAllFilesPresentInValueClasses() {
+          KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+        }
+
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class NonNullObject extends AbstractLightAnalysisModeTest {
+          private void runTest(String testDataFilePath) {
+            KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM_IR, testDataFilePath);
+          }
+
+          public void testAllFilesPresentInNonNullObject() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+          }
+
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          @RunWith(JUnit3RunnerWithInners.class)
+          public static class DefaultArguments extends AbstractLightAnalysisModeTest {
+            private void runTest(String testDataFilePath) {
+              KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM_IR, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+            }
+
+            @TestMetadata("constructorWithInlineClassParameters.kt")
+            public void testConstructorWithInlineClassParameters() {
+              runTest("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments/constructorWithInlineClassParameters.kt");
+            }
+          }
+        }
+
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class NullableObject extends AbstractLightAnalysisModeTest {
+          private void runTest(String testDataFilePath) {
+            KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM_IR, testDataFilePath);
+          }
+
+          public void testAllFilesPresentInNullableObject() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+          }
+
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          @RunWith(JUnit3RunnerWithInners.class)
+          public static class DefaultArguments extends AbstractLightAnalysisModeTest {
+            @TestMetadata("constructorWithInlineClassParameters.kt")
+            public void ignoreConstructorWithInlineClassParameters() {
+              runTest("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments/constructorWithInlineClassParameters.kt");
+            }
+
+            private void runTest(String testDataFilePath) {
+              KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM_IR, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+            }
+          }
+        }
+
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive")
+        @TestDataPath("$PROJECT_ROOT")
+        @RunWith(JUnit3RunnerWithInners.class)
+        public static class Primitive extends AbstractLightAnalysisModeTest {
+          private void runTest(String testDataFilePath) {
+            KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM_IR, testDataFilePath);
+          }
+
+          public void testAllFilesPresentInPrimitive() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+          }
+
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          @RunWith(JUnit3RunnerWithInners.class)
+          public static class DefaultArguments extends AbstractLightAnalysisModeTest {
+            private void runTest(String testDataFilePath) {
+              KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM_IR, testDataFilePath);
+            }
+
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+            }
+
+            @TestMetadata("constructorWithInlineClassParameters.kt")
+            public void testConstructorWithInlineClassParameters() {
+              runTest("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments/constructorWithInlineClassParameters.kt");
+            }
+          }
+        }
+      }
     }
 
     @TestMetadata("compiler/testData/codegen/box/reflection/classLiterals")

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/fir/FirJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/fir/FirJsCodegenBoxTestGenerated.java
@@ -37165,6 +37165,76 @@ public class FirJsCodegenBoxTestGenerated extends AbstractFirJsCodegenBoxTest {
       public void testAllFilesPresentInCallBy() {
         KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR, true);
       }
+
+      @Nested
+      @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses")
+      @TestDataPath("$PROJECT_ROOT")
+      public class ValueClasses {
+        @Test
+        public void testAllFilesPresentInValueClasses() {
+          KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR, true);
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject")
+        @TestDataPath("$PROJECT_ROOT")
+        public class NonNullObject {
+          @Test
+          public void testAllFilesPresentInNonNullObject() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR, true);
+            }
+          }
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject")
+        @TestDataPath("$PROJECT_ROOT")
+        public class NullableObject {
+          @Test
+          public void testAllFilesPresentInNullableObject() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR, true);
+            }
+          }
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive")
+        @TestDataPath("$PROJECT_ROOT")
+        public class Primitive {
+          @Test
+          public void testAllFilesPresentInPrimitive() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR, true);
+            }
+          }
+        }
+      }
     }
 
     @Nested

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/fir/FirJsES6CodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/fir/FirJsES6CodegenBoxTestGenerated.java
@@ -37165,6 +37165,76 @@ public class FirJsES6CodegenBoxTestGenerated extends AbstractFirJsES6CodegenBoxT
       public void testAllFilesPresentInCallBy() {
         KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR_ES6, true);
       }
+
+      @Nested
+      @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses")
+      @TestDataPath("$PROJECT_ROOT")
+      public class ValueClasses {
+        @Test
+        public void testAllFilesPresentInValueClasses() {
+          KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR_ES6, true);
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject")
+        @TestDataPath("$PROJECT_ROOT")
+        public class NonNullObject {
+          @Test
+          public void testAllFilesPresentInNonNullObject() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR_ES6, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR_ES6, true);
+            }
+          }
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject")
+        @TestDataPath("$PROJECT_ROOT")
+        public class NullableObject {
+          @Test
+          public void testAllFilesPresentInNullableObject() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR_ES6, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR_ES6, true);
+            }
+          }
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive")
+        @TestDataPath("$PROJECT_ROOT")
+        public class Primitive {
+          @Test
+          public void testAllFilesPresentInPrimitive() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR_ES6, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR_ES6, true);
+            }
+          }
+        }
+      }
     }
 
     @Nested

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/IrJsCodegenBoxTestGenerated.java
@@ -36577,6 +36577,76 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
       public void testAllFilesPresentInCallBy() {
         KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR, true);
       }
+
+      @Nested
+      @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses")
+      @TestDataPath("$PROJECT_ROOT")
+      public class ValueClasses {
+        @Test
+        public void testAllFilesPresentInValueClasses() {
+          KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR, true);
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject")
+        @TestDataPath("$PROJECT_ROOT")
+        public class NonNullObject {
+          @Test
+          public void testAllFilesPresentInNonNullObject() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR, true);
+            }
+          }
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject")
+        @TestDataPath("$PROJECT_ROOT")
+        public class NullableObject {
+          @Test
+          public void testAllFilesPresentInNullableObject() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR, true);
+            }
+          }
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive")
+        @TestDataPath("$PROJECT_ROOT")
+        public class Primitive {
+          @Test
+          public void testAllFilesPresentInPrimitive() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR, true);
+            }
+          }
+        }
+      }
     }
 
     @Nested

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/IrJsES6CodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/IrJsES6CodegenBoxTestGenerated.java
@@ -36577,6 +36577,76 @@ public class IrJsES6CodegenBoxTestGenerated extends AbstractIrJsES6CodegenBoxTes
       public void testAllFilesPresentInCallBy() {
         KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR_ES6, true);
       }
+
+      @Nested
+      @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses")
+      @TestDataPath("$PROJECT_ROOT")
+      public class ValueClasses {
+        @Test
+        public void testAllFilesPresentInValueClasses() {
+          KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR_ES6, true);
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject")
+        @TestDataPath("$PROJECT_ROOT")
+        public class NonNullObject {
+          @Test
+          public void testAllFilesPresentInNonNullObject() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR_ES6, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR_ES6, true);
+            }
+          }
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject")
+        @TestDataPath("$PROJECT_ROOT")
+        public class NullableObject {
+          @Test
+          public void testAllFilesPresentInNullableObject() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR_ES6, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR_ES6, true);
+            }
+          }
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive")
+        @TestDataPath("$PROJECT_ROOT")
+        public class Primitive {
+          @Test
+          public void testAllFilesPresentInPrimitive() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR_ES6, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JS_IR_ES6, true);
+            }
+          }
+        }
+      }
     }
 
     @Nested

--- a/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/FirNativeCodegenBoxTestGenerated.java
+++ b/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/FirNativeCodegenBoxTestGenerated.java
@@ -40527,6 +40527,97 @@ public class FirNativeCodegenBoxTestGenerated extends AbstractNativeCodegenBoxTe
         public void testAllFilesPresentInCallBy() {
           KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.NATIVE, true);
         }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses")
+        @TestDataPath("$PROJECT_ROOT")
+        @Tag("frontend-fir")
+        @FirPipeline()
+        @UseExtTestCaseGroupProvider()
+        public class ValueClasses {
+          @Test
+          public void testAllFilesPresentInValueClasses() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.NATIVE, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject")
+          @TestDataPath("$PROJECT_ROOT")
+          @Tag("frontend-fir")
+          @FirPipeline()
+          @UseExtTestCaseGroupProvider()
+          public class NonNullObject {
+            @Test
+            public void testAllFilesPresentInNonNullObject() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.NATIVE, true);
+            }
+
+            @Nested
+            @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments")
+            @TestDataPath("$PROJECT_ROOT")
+            @Tag("frontend-fir")
+            @FirPipeline()
+            @UseExtTestCaseGroupProvider()
+            public class DefaultArguments {
+              @Test
+              public void testAllFilesPresentInDefaultArguments() {
+                KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.NATIVE, true);
+              }
+            }
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject")
+          @TestDataPath("$PROJECT_ROOT")
+          @Tag("frontend-fir")
+          @FirPipeline()
+          @UseExtTestCaseGroupProvider()
+          public class NullableObject {
+            @Test
+            public void testAllFilesPresentInNullableObject() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.NATIVE, true);
+            }
+
+            @Nested
+            @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments")
+            @TestDataPath("$PROJECT_ROOT")
+            @Tag("frontend-fir")
+            @FirPipeline()
+            @UseExtTestCaseGroupProvider()
+            public class DefaultArguments {
+              @Test
+              public void testAllFilesPresentInDefaultArguments() {
+                KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.NATIVE, true);
+              }
+            }
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive")
+          @TestDataPath("$PROJECT_ROOT")
+          @Tag("frontend-fir")
+          @FirPipeline()
+          @UseExtTestCaseGroupProvider()
+          public class Primitive {
+            @Test
+            public void testAllFilesPresentInPrimitive() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.NATIVE, true);
+            }
+
+            @Nested
+            @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments")
+            @TestDataPath("$PROJECT_ROOT")
+            @Tag("frontend-fir")
+            @FirPipeline()
+            @UseExtTestCaseGroupProvider()
+            public class DefaultArguments {
+              @Test
+              public void testAllFilesPresentInDefaultArguments() {
+                KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.NATIVE, true);
+              }
+            }
+          }
+        }
       }
 
       @Nested

--- a/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/FirNativeCodegenBoxTestNoPLGenerated.java
+++ b/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/FirNativeCodegenBoxTestNoPLGenerated.java
@@ -41477,6 +41477,111 @@ public class FirNativeCodegenBoxTestNoPLGenerated extends AbstractNativeCodegenB
         public void testAllFilesPresentInCallBy() {
           KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.NATIVE, true);
         }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses")
+        @TestDataPath("$PROJECT_ROOT")
+        @Tag("frontend-fir")
+        @FirPipeline()
+        @UseExtTestCaseGroupProvider()
+        @UsePartialLinkage(mode = Mode.DISABLED)
+        @Tag("no-partial-linkage-may-be-skipped")
+        public class ValueClasses {
+          @Test
+          public void testAllFilesPresentInValueClasses() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.NATIVE, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject")
+          @TestDataPath("$PROJECT_ROOT")
+          @Tag("frontend-fir")
+          @FirPipeline()
+          @UseExtTestCaseGroupProvider()
+          @UsePartialLinkage(mode = Mode.DISABLED)
+          @Tag("no-partial-linkage-may-be-skipped")
+          public class NonNullObject {
+            @Test
+            public void testAllFilesPresentInNonNullObject() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.NATIVE, true);
+            }
+
+            @Nested
+            @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments")
+            @TestDataPath("$PROJECT_ROOT")
+            @Tag("frontend-fir")
+            @FirPipeline()
+            @UseExtTestCaseGroupProvider()
+            @UsePartialLinkage(mode = Mode.DISABLED)
+            @Tag("no-partial-linkage-may-be-skipped")
+            public class DefaultArguments {
+              @Test
+              public void testAllFilesPresentInDefaultArguments() {
+                KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.NATIVE, true);
+              }
+            }
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject")
+          @TestDataPath("$PROJECT_ROOT")
+          @Tag("frontend-fir")
+          @FirPipeline()
+          @UseExtTestCaseGroupProvider()
+          @UsePartialLinkage(mode = Mode.DISABLED)
+          @Tag("no-partial-linkage-may-be-skipped")
+          public class NullableObject {
+            @Test
+            public void testAllFilesPresentInNullableObject() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.NATIVE, true);
+            }
+
+            @Nested
+            @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments")
+            @TestDataPath("$PROJECT_ROOT")
+            @Tag("frontend-fir")
+            @FirPipeline()
+            @UseExtTestCaseGroupProvider()
+            @UsePartialLinkage(mode = Mode.DISABLED)
+            @Tag("no-partial-linkage-may-be-skipped")
+            public class DefaultArguments {
+              @Test
+              public void testAllFilesPresentInDefaultArguments() {
+                KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.NATIVE, true);
+              }
+            }
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive")
+          @TestDataPath("$PROJECT_ROOT")
+          @Tag("frontend-fir")
+          @FirPipeline()
+          @UseExtTestCaseGroupProvider()
+          @UsePartialLinkage(mode = Mode.DISABLED)
+          @Tag("no-partial-linkage-may-be-skipped")
+          public class Primitive {
+            @Test
+            public void testAllFilesPresentInPrimitive() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.NATIVE, true);
+            }
+
+            @Nested
+            @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments")
+            @TestDataPath("$PROJECT_ROOT")
+            @Tag("frontend-fir")
+            @FirPipeline()
+            @UseExtTestCaseGroupProvider()
+            @UsePartialLinkage(mode = Mode.DISABLED)
+            @Tag("no-partial-linkage-may-be-skipped")
+            public class DefaultArguments {
+              @Test
+              public void testAllFilesPresentInDefaultArguments() {
+                KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.NATIVE, true);
+              }
+            }
+          }
+        }
       }
 
       @Nested

--- a/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/NativeCodegenBoxTestGenerated.java
+++ b/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/NativeCodegenBoxTestGenerated.java
@@ -38977,6 +38977,83 @@ public class NativeCodegenBoxTestGenerated extends AbstractNativeCodegenBoxTest 
         public void testAllFilesPresentInCallBy() {
           KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.NATIVE, true);
         }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses")
+        @TestDataPath("$PROJECT_ROOT")
+        @UseExtTestCaseGroupProvider()
+        public class ValueClasses {
+          @Test
+          public void testAllFilesPresentInValueClasses() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.NATIVE, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject")
+          @TestDataPath("$PROJECT_ROOT")
+          @UseExtTestCaseGroupProvider()
+          public class NonNullObject {
+            @Test
+            public void testAllFilesPresentInNonNullObject() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.NATIVE, true);
+            }
+
+            @Nested
+            @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments")
+            @TestDataPath("$PROJECT_ROOT")
+            @UseExtTestCaseGroupProvider()
+            public class DefaultArguments {
+              @Test
+              public void testAllFilesPresentInDefaultArguments() {
+                KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.NATIVE, true);
+              }
+            }
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject")
+          @TestDataPath("$PROJECT_ROOT")
+          @UseExtTestCaseGroupProvider()
+          public class NullableObject {
+            @Test
+            public void testAllFilesPresentInNullableObject() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.NATIVE, true);
+            }
+
+            @Nested
+            @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments")
+            @TestDataPath("$PROJECT_ROOT")
+            @UseExtTestCaseGroupProvider()
+            public class DefaultArguments {
+              @Test
+              public void testAllFilesPresentInDefaultArguments() {
+                KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.NATIVE, true);
+              }
+            }
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive")
+          @TestDataPath("$PROJECT_ROOT")
+          @UseExtTestCaseGroupProvider()
+          public class Primitive {
+            @Test
+            public void testAllFilesPresentInPrimitive() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.NATIVE, true);
+            }
+
+            @Nested
+            @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments")
+            @TestDataPath("$PROJECT_ROOT")
+            @UseExtTestCaseGroupProvider()
+            public class DefaultArguments {
+              @Test
+              public void testAllFilesPresentInDefaultArguments() {
+                KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.NATIVE, true);
+              }
+            }
+          }
+        }
       }
 
       @Nested

--- a/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/NativeCodegenBoxTestNoPLGenerated.java
+++ b/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/NativeCodegenBoxTestNoPLGenerated.java
@@ -39916,6 +39916,97 @@ public class NativeCodegenBoxTestNoPLGenerated extends AbstractNativeCodegenBoxT
         public void testAllFilesPresentInCallBy() {
           KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.NATIVE, true);
         }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses")
+        @TestDataPath("$PROJECT_ROOT")
+        @UseExtTestCaseGroupProvider()
+        @UsePartialLinkage(mode = Mode.DISABLED)
+        @Tag("no-partial-linkage-may-be-skipped")
+        public class ValueClasses {
+          @Test
+          public void testAllFilesPresentInValueClasses() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.NATIVE, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject")
+          @TestDataPath("$PROJECT_ROOT")
+          @UseExtTestCaseGroupProvider()
+          @UsePartialLinkage(mode = Mode.DISABLED)
+          @Tag("no-partial-linkage-may-be-skipped")
+          public class NonNullObject {
+            @Test
+            public void testAllFilesPresentInNonNullObject() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.NATIVE, true);
+            }
+
+            @Nested
+            @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments")
+            @TestDataPath("$PROJECT_ROOT")
+            @UseExtTestCaseGroupProvider()
+            @UsePartialLinkage(mode = Mode.DISABLED)
+            @Tag("no-partial-linkage-may-be-skipped")
+            public class DefaultArguments {
+              @Test
+              public void testAllFilesPresentInDefaultArguments() {
+                KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.NATIVE, true);
+              }
+            }
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject")
+          @TestDataPath("$PROJECT_ROOT")
+          @UseExtTestCaseGroupProvider()
+          @UsePartialLinkage(mode = Mode.DISABLED)
+          @Tag("no-partial-linkage-may-be-skipped")
+          public class NullableObject {
+            @Test
+            public void testAllFilesPresentInNullableObject() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.NATIVE, true);
+            }
+
+            @Nested
+            @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments")
+            @TestDataPath("$PROJECT_ROOT")
+            @UseExtTestCaseGroupProvider()
+            @UsePartialLinkage(mode = Mode.DISABLED)
+            @Tag("no-partial-linkage-may-be-skipped")
+            public class DefaultArguments {
+              @Test
+              public void testAllFilesPresentInDefaultArguments() {
+                KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.NATIVE, true);
+              }
+            }
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive")
+          @TestDataPath("$PROJECT_ROOT")
+          @UseExtTestCaseGroupProvider()
+          @UsePartialLinkage(mode = Mode.DISABLED)
+          @Tag("no-partial-linkage-may-be-skipped")
+          public class Primitive {
+            @Test
+            public void testAllFilesPresentInPrimitive() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.NATIVE, true);
+            }
+
+            @Nested
+            @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments")
+            @TestDataPath("$PROJECT_ROOT")
+            @UseExtTestCaseGroupProvider()
+            @UsePartialLinkage(mode = Mode.DISABLED)
+            @Tag("no-partial-linkage-may-be-skipped")
+            public class DefaultArguments {
+              @Test
+              public void testAllFilesPresentInDefaultArguments() {
+                KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.NATIVE, true);
+              }
+            }
+          }
+        }
       }
 
       @Nested

--- a/wasm/wasm.tests/tests-gen/org/jetbrains/kotlin/wasm/test/FirWasmJsCodegenBoxTestGenerated.java
+++ b/wasm/wasm.tests/tests-gen/org/jetbrains/kotlin/wasm/test/FirWasmJsCodegenBoxTestGenerated.java
@@ -37093,6 +37093,76 @@ public class FirWasmJsCodegenBoxTestGenerated extends AbstractFirWasmJsCodegenBo
       public void testAllFilesPresentInCallBy() {
         KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy"), Pattern.compile("^([^_](.+))\\.kt$"), null, TargetBackend.WASM, true);
       }
+
+      @Nested
+      @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses")
+      @TestDataPath("$PROJECT_ROOT")
+      public class ValueClasses {
+        @Test
+        public void testAllFilesPresentInValueClasses() {
+          KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses"), Pattern.compile("^([^_](.+))\\.kt$"), null, TargetBackend.WASM, true);
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject")
+        @TestDataPath("$PROJECT_ROOT")
+        public class NonNullObject {
+          @Test
+          public void testAllFilesPresentInNonNullObject() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject"), Pattern.compile("^([^_](.+))\\.kt$"), null, TargetBackend.WASM, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments"), Pattern.compile("^([^_](.+))\\.kt$"), null, TargetBackend.WASM, true);
+            }
+          }
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject")
+        @TestDataPath("$PROJECT_ROOT")
+        public class NullableObject {
+          @Test
+          public void testAllFilesPresentInNullableObject() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject"), Pattern.compile("^([^_](.+))\\.kt$"), null, TargetBackend.WASM, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments"), Pattern.compile("^([^_](.+))\\.kt$"), null, TargetBackend.WASM, true);
+            }
+          }
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive")
+        @TestDataPath("$PROJECT_ROOT")
+        public class Primitive {
+          @Test
+          public void testAllFilesPresentInPrimitive() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive"), Pattern.compile("^([^_](.+))\\.kt$"), null, TargetBackend.WASM, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments"), Pattern.compile("^([^_](.+))\\.kt$"), null, TargetBackend.WASM, true);
+            }
+          }
+        }
+      }
     }
 
     @Nested

--- a/wasm/wasm.tests/tests-gen/org/jetbrains/kotlin/wasm/test/K1WasmCodegenBoxTestGenerated.java
+++ b/wasm/wasm.tests/tests-gen/org/jetbrains/kotlin/wasm/test/K1WasmCodegenBoxTestGenerated.java
@@ -36505,6 +36505,76 @@ public class K1WasmCodegenBoxTestGenerated extends AbstractK1WasmCodegenBoxTest 
       public void testAllFilesPresentInCallBy() {
         KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy"), Pattern.compile("^([^_](.+))\\.kt$"), null, TargetBackend.WASM, true);
       }
+
+      @Nested
+      @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses")
+      @TestDataPath("$PROJECT_ROOT")
+      public class ValueClasses {
+        @Test
+        public void testAllFilesPresentInValueClasses() {
+          KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses"), Pattern.compile("^([^_](.+))\\.kt$"), null, TargetBackend.WASM, true);
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject")
+        @TestDataPath("$PROJECT_ROOT")
+        public class NonNullObject {
+          @Test
+          public void testAllFilesPresentInNonNullObject() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject"), Pattern.compile("^([^_](.+))\\.kt$"), null, TargetBackend.WASM, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nonNullObject/defaultArguments"), Pattern.compile("^([^_](.+))\\.kt$"), null, TargetBackend.WASM, true);
+            }
+          }
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject")
+        @TestDataPath("$PROJECT_ROOT")
+        public class NullableObject {
+          @Test
+          public void testAllFilesPresentInNullableObject() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject"), Pattern.compile("^([^_](.+))\\.kt$"), null, TargetBackend.WASM, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/nullableObject/defaultArguments"), Pattern.compile("^([^_](.+))\\.kt$"), null, TargetBackend.WASM, true);
+            }
+          }
+        }
+
+        @Nested
+        @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive")
+        @TestDataPath("$PROJECT_ROOT")
+        public class Primitive {
+          @Test
+          public void testAllFilesPresentInPrimitive() {
+            KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive"), Pattern.compile("^([^_](.+))\\.kt$"), null, TargetBackend.WASM, true);
+          }
+
+          @Nested
+          @TestMetadata("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments")
+          @TestDataPath("$PROJECT_ROOT")
+          public class DefaultArguments {
+            @Test
+            public void testAllFilesPresentInDefaultArguments() {
+              KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/codegen/box/reflection/callBy/valueClasses/primitive/defaultArguments"), Pattern.compile("^([^_](.+))\\.kt$"), null, TargetBackend.WASM, true);
+            }
+          }
+        }
+      }
     }
 
     @Nested


### PR DESCRIPTION
Completed missing test cases regarding the type that `value class` wraps and nullability as a parameter.

---

For `SFCV`, these test cases are largely missing.
I would like to continue to contribute to the completion of such test cases.

By the way, are there any rules on how to write commit messages?
Also, are there any recommended per-commit guidelines?
I have had these corrected several times and I apologize for that.