### PR TITLE
[K/WASM] Add a static initializers invoking phase to the IR lowerings ^KT-66103 Fixed

### DIFF
--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/InvokeStaticInitializersLowering.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/InvokeStaticInitializersLowering.kt
@@ -6,7 +6,7 @@
 package org.jetbrains.kotlin.ir.backend.js.lower
 
 import org.jetbrains.kotlin.backend.common.BodyLoweringPass
-import org.jetbrains.kotlin.ir.backend.js.JsIrBackendContext
+import org.jetbrains.kotlin.ir.backend.js.JsCommonBackendContext
 import org.jetbrains.kotlin.ir.backend.js.JsStatementOrigins
 import org.jetbrains.kotlin.ir.declarations.IrConstructor
 import org.jetbrains.kotlin.ir.declarations.IrDeclaration
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.ir.expressions.IrStatementContainer
 import org.jetbrains.kotlin.ir.expressions.impl.IrCallImpl
 import org.jetbrains.kotlin.ir.util.*
 
-class InvokeStaticInitializersLowering(val context: JsIrBackendContext) : BodyLoweringPass {
+class InvokeStaticInitializersLowering(val context: JsCommonBackendContext) : BodyLoweringPass {
     override fun lower(irBody: IrBody, container: IrDeclaration) {
         if (container !is IrConstructor) return
         if (container.parentClassOrNull?.isEnumClass == true) return

--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/WasmLoweringPhases.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/WasmLoweringPhases.kt
@@ -515,6 +515,13 @@ private val objectDeclarationLoweringPhase = makeIrModulePhase(
     prerequisite = setOf(enumClassCreateInitializerLoweringPhase, staticCallableReferenceLoweringPhase)
 )
 
+private val invokeStaticInitializersPhase = makeIrModulePhase(
+    ::InvokeStaticInitializersLowering,
+    name = "IntroduceStaticInitializersLowering",
+    description = "Invoke companion object's initializers from companion object in object constructor",
+    prerequisite = setOf(objectDeclarationLoweringPhase)
+)
+
 private val objectUsageLoweringPhase = makeIrModulePhase(
     ::ObjectUsageLowering,
     name = "ObjectUsageLowering",
@@ -754,6 +761,7 @@ val loweringList = listOf(
     builtInsLoweringPhase,
 
     virtualDispatchReceiverExtractionPhase,
+    invokeStaticInitializersPhase,
     staticMembersLoweringPhase,
     inlineObjectsWithPureInitializationLoweringPhase,
     validateIrAfterLowering,

--- a/compiler/testData/codegen/box/initializers/initializers1.kt
+++ b/compiler/testData/codegen/box/initializers/initializers1.kt
@@ -2,8 +2,6 @@
  * Copyright 2010-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
  * that can be found in the LICENSE file.
  */
-// KT-66103: companion object is not initialized
-// IGNORE_BACKEND: WASM
 // JVM_ABI_K1_K2_DIFF: KT-63864
 // WITH_STDLIB
 import kotlin.test.*


### PR DESCRIPTION
The `loweringList` in the WASM compiler currently lacks a phase dedicated to invoking static initializers. During the `staticMembersLoweringPhase`, the companion object is extracted from the class without the corresponding initializer being invoked in the primary constructor. Reusing the `invokeStaticInitializersPhase` from the JavaScript compiler and positioning it prior to the `staticMembersLoweringPhase` effectively resolves the issue.