### PR TITLE
Only mention one default value for the compiler's `jvmTarget`

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-api/src/common/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinJvmCompilerOptions.kt
+++ b/libraries/tools/kotlin-gradle-plugin-api/src/common/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinJvmCompilerOptions.kt
@@ -19,7 +19,7 @@ interface KotlinJvmCompilerOptions : org.jetbrains.kotlin.gradle.dsl.KotlinCommo
     val javaParameters: org.gradle.api.provider.Property<kotlin.Boolean>
 
     /**
-     * The target version of the generated JVM bytecode (1.8, 9, 10, ..., 21), with 1.8 as the default.
+     * The target version of the generated JVM bytecode (1.8, 9, 10, ..., 21).
      *
      * Possible values: "1.8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21"
      *


### PR DESCRIPTION
The current docs mention both "1.8" and "JvmTarget.DEFAULT" as default values for the `jvmTarget` property. Only keep the latter which is the correct default value.