### PR TITLE
[O] Optimize CharSequence.lines()

### DIFF
--- a/libraries/stdlib/src/kotlin/text/Strings.kt
+++ b/libraries/stdlib/src/kotlin/text/Strings.kt
@@ -1403,14 +1403,14 @@ public inline fun CharSequence.splitToSequence(regex: Regex, limit: Int = 0): Se
  *
  * The lines returned do not include terminating line separators.
  */
-public fun CharSequence.lineSequence(): Sequence<String> = splitToSequence("\r\n", "\n", "\r")
+public fun CharSequence.lineSequence(): Sequence<String> = toString().replace("\r\n", "\n").splitToSequence('\r', '\n')
 
 /**
  * Splits this char sequence to a list of lines delimited by any of the following character sequences: CRLF, LF or CR.
  *
  * The lines returned do not include terminating line separators.
  */
-public fun CharSequence.lines(): List<String> = lineSequence().toList()
+public fun CharSequence.lines(): List<String> = toString().replace("\r\n", "\n").split('\r', '\n')
 
 /**
  * Returns `true` if the contents of this char sequence are equal to the contents of the specified [other],

--- a/libraries/stdlib/src/kotlin/text/Strings.kt
+++ b/libraries/stdlib/src/kotlin/text/Strings.kt
@@ -1403,14 +1403,14 @@ public inline fun CharSequence.splitToSequence(regex: Regex, limit: Int = 0): Se
  *
  * The lines returned do not include terminating line separators.
  */
-public fun CharSequence.lineSequence(): Sequence<String> = toString().replace("\r\n", "\n").splitToSequence('\r', '\n')
+public fun CharSequence.lineSequence(): Sequence<String> = toString().replace("\r\n", "\n").replace('\r', '\n').splitToSequence('\n')
 
 /**
  * Splits this char sequence to a list of lines delimited by any of the following character sequences: CRLF, LF or CR.
  *
  * The lines returned do not include terminating line separators.
  */
-public fun CharSequence.lines(): List<String> = toString().replace("\r\n", "\n").split('\r', '\n')
+public fun CharSequence.lines(): List<String> = toString().replace("\r\n", "\n").replace('\r', '\n').split('\n')
 
 /**
  * Returns `true` if the contents of this char sequence are equal to the contents of the specified [other],


### PR DESCRIPTION
Splitting lines by doing two string replacements and then splitting by one character is way faster than splitting by three substrings.

https://youtrack.jetbrains.com/issue/KT-66715/Performance-faster-alternative-to-String.lines

Profiling of the two methods:

![image](https://github.com/JetBrains/kotlin/assets/22280294/a33b0050-1ccf-4937-bc86-2c1f9c6446b2)

Detailed time usage:

![image](https://github.com/JetBrains/kotlin/assets/22280294/b2963b2b-ef0d-4f26-867b-e906f6922707)

In-process time output:

![image](https://github.com/JetBrains/kotlin/assets/22280294/bba5ef4a-75a0-4cba-b681-810920a375f2)

