### PR TITLE
minor: add Automatic-Module-Name to kotlinx-metadata

### DIFF
--- a/libraries/kotlinx-metadata/jvm/build.gradle.kts
+++ b/libraries/kotlinx-metadata/jvm/build.gradle.kts
@@ -89,6 +89,12 @@ tasks.dokkaHtml.configure {
     }
 }
 
+tasks.named<Jar>("jar"){
+    manifest {
+        attributes("Automatic-Module-Name" to "kotlin.metadata.jvm")
+    }
+}
+
 sourcesJar()
 
 javadocJar()


### PR DESCRIPTION
So that it could be used modularity.