### PR TITLE
Close katpContext after processing

### DIFF
--- a/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/Kapt.kt
+++ b/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/Kapt.kt
@@ -31,26 +31,27 @@ object Kapt {
             return false
         }
 
-        val kaptContext = KaptContext(options, false, logger)
+        KaptContext(options, false, logger).use { kaptContext ->
 
-        logger.info { options.logString("stand-alone mode") }
+            logger.info { options.logString("stand-alone mode") }
 
-        val javaSourceFiles = options.collectJavaSourceFiles(kaptContext.sourcesToReprocess)
+            val javaSourceFiles = options.collectJavaSourceFiles(kaptContext.sourcesToReprocess)
 
-        val processorLoader = ProcessorLoader(options, logger)
+            val processorLoader = ProcessorLoader(options, logger)
 
-        processorLoader.use {
-            val processors = processorLoader.loadProcessors(findClassLoaderWithJavac())
+            processorLoader.use {
+                val processors = processorLoader.loadProcessors(findClassLoaderWithJavac())
 
-            val annotationProcessingTime = measureTimeMillis {
-                kaptContext.doAnnotationProcessing(
-                    javaSourceFiles,
-                    processors.processors,
-                    binaryTypesToReprocess = collectAggregatedTypes(kaptContext.sourcesToReprocess)
-                )
+                val annotationProcessingTime = measureTimeMillis {
+                    kaptContext.doAnnotationProcessing(
+                        javaSourceFiles,
+                        processors.processors,
+                        binaryTypesToReprocess = collectAggregatedTypes(kaptContext.sourcesToReprocess)
+                    )
+                }
+
+                logger.info { "Annotation processing took $annotationProcessingTime ms" }
             }
-
-            logger.info { "Annotation processing took $annotationProcessingTime ms" }
         }
 
         return true


### PR DESCRIPTION
Bug reported here: https://youtrack.jetbrains.com/issue/KT-67495/File-leak-in-when-building-with-kapt

Basically, the `kaptContext` object is not closed in the `kapt()` function, leading to a large number of open files. This ensures that the `kaptContext` object is closed.