### PR TITLE
[Fixes KT-67444] Added the `KotlinWebpackConfig.DevServer.Proxy` dsl data type similar to webpack.devServer.proxy

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/webpack/KotlinWebpackConfig.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/webpack/KotlinWebpackConfig.kt
@@ -91,7 +91,7 @@ data class KotlinWebpackConfig(
     data class DevServer(
         var open: Any = true,
         var port: Int? = null,
-        var proxy: MutableMap<String, Any>? = null,
+        var proxy: MutableList<Proxy>? = null,
         var static: MutableList<String>? = null,
         var contentBase: MutableList<String>? = null,
         var client: Client? = null
@@ -104,6 +104,14 @@ data class KotlinWebpackConfig(
                 var warnings: Boolean
             ) : Serializable
         }
+
+        data class Proxy(
+            val context: MutableList<String>,
+            val target: String,
+            val pathRewrite: MutableMap<String, String>? = null,
+            val secure: Boolean? = null,
+            val changeOrigin: Boolean? = null
+        ) : Serializable
     }
 
     @Suppress("unused")


### PR DESCRIPTION
The proxy parameter in DevServer data class within KotlinWebpackConfig has been refactored from a MutableMap to a MutableList of the newly defined Proxy data class. This new Proxy data class comprises properties from https://webpack.js.org/configuration/dev-server/#devserverproxy.