### PR TITLE
Update package.py to set min mac os version supported to 10.15

### DIFF
--- a/kotlin-native/tools/llvm_builder/package.py
+++ b/kotlin-native/tools/llvm_builder/package.py
@@ -143,6 +143,8 @@ def construct_cmake_flags(
 
     if host_is_darwin():
         cmake_args.append('-DLLVM_ENABLE_LIBCXX=ON')
+        # Required when building with newer Xcodes to keep libc++ working.
+        cmake_args.append('-DCMAKE_OSX_DEPLOYMENT_TARGET=10.15')
         if building_bootstrap:
             # Don't waste time by doing unnecessary work for throwaway toolchain.
             cmake_args.extend([


### PR DESCRIPTION
Fixes issue building with Xcode 15.3 (and probably lower):

```
dyld[23208]: Symbol not found: __ZNKSt3__115basic_stringbufIcNS_11char_traitsIcEENS_9allocatorIcEEE3strEv
      Referenced from: <B78AD1C6-8BDF-3D1A-8758-53D2D60ACFB4> /Users/dmaclach/src/kotlin/kotlin-native/tools/llvm_builder/llvm-stage-1/lib/libLTO.dylib
      Expected in:     <7BC3AD48-7344-3A3E-9C1D-1435688D7FC2> /Users/dmaclach/src/kotlin/kotlin-native/tools/llvm_builder/llvm-stage-1/lib/libc++.1.0.dylib
    clang-11: error: unable to execute command: Abort trap: 6
    clang-11: error: linker command failed due to signal (use -v to see invocation)
    ninja: build stopped: subcommand failed.
```