### PR TITLE
[Gradle] Use platform classloader as parent in K2Native isolated class loader

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/KotlinNativeIsolatedClassloaderIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/KotlinNativeIsolatedClassloaderIT.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.native
+
+import org.gradle.api.JavaVersion
+import org.gradle.util.GradleVersion
+import org.jetbrains.kotlin.gradle.dsl.NativeCacheKind
+import org.jetbrains.kotlin.gradle.testbase.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.condition.OS
+import kotlin.io.path.appendText
+
+@DisplayName("KotlinNative isolated class loader test")
+@NativeGradlePluginTests
+internal class KotlinNativeIsolatedClassloaderIT : KGPBaseTest() {
+
+    @DisplayName("KT-65761: K2Native isolated class loader should be able to load platform classes")
+    @JdkVersions(versions = [JavaVersion.VERSION_1_8, JavaVersion.VERSION_21])
+    @GradleWithJdkTest
+    fun shouldLoadPlatformClasses(gradleVersion: GradleVersion, providedJdk: JdkVersions.ProvidedJdk) {
+        nativeProject("compilerPlugins/pluginUsesJdkClass", gradleVersion, buildJdk = providedJdk.location) {
+            build(":library:compileKotlinLinuxX64")
+        }
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/compilerPlugins/pluginUsesJdkClass/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/compilerPlugins/pluginUsesJdkClass/build.gradle.kts
@@ -1,0 +1,7 @@
+allprojects {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        google()
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/compilerPlugins/pluginUsesJdkClass/library/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/compilerPlugins/pluginUsesJdkClass/library/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    kotlin("multiplatform")
+}
+
+kotlin {
+    linuxX64()
+}
+
+dependencies {
+    add("kotlinNativeCompilerPluginClasspath", project(":plugin"))
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/compilerPlugins/pluginUsesJdkClass/library/src/nativeMain/kotlin/library/SomeClass.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/compilerPlugins/pluginUsesJdkClass/library/src/nativeMain/kotlin/library/SomeClass.kt
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package library
+
+class SomeClass

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/compilerPlugins/pluginUsesJdkClass/plugin/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/compilerPlugins/pluginUsesJdkClass/plugin/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+    kotlin("jvm")
+}
+
+dependencies {
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin-api")
+    compileOnly("org.jetbrains.kotlin:kotlin-compiler-embeddable")
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/compilerPlugins/pluginUsesJdkClass/plugin/src/main/kotlin/test/compiler/plugin/TestComponentRegistrar.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/compilerPlugins/pluginUsesJdkClass/plugin/src/main/kotlin/test/compiler/plugin/TestComponentRegistrar.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package test.compiler.plugin
+
+import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import java.sql.SQLException
+
+@OptIn(ExperimentalCompilerApi::class)
+class TestComponentRegistrar : CompilerPluginRegistrar() {
+    override fun ExtensionStorage.registerExtensions(
+        configuration: CompilerConfiguration
+    ) {
+        // Validates plugin is able to use JDK platform classes
+        try {
+            throw SQLException()
+        } catch (ex: SQLException) {
+            // no-op
+        }
+    }
+
+    override val supportsK2: Boolean = true
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/compilerPlugins/pluginUsesJdkClass/plugin/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/compilerPlugins/pluginUsesJdkClass/plugin/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
@@ -1,0 +1,6 @@
+#
+# Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors.
+# Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+#
+
+test.compiler.plugin.TestComponentRegistrar

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/compilerPlugins/pluginUsesJdkClass/settings.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/compilerPlugins/pluginUsesJdkClass/settings.gradle.kts
@@ -1,0 +1,2 @@
+include(":plugin")
+include(":library")

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/compilerRunner/KotlinToolRunner.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/compilerRunner/KotlinToolRunner.kt
@@ -89,7 +89,7 @@ abstract class KotlinToolRunner(
 
     private fun getIsolatedClassLoader(): URLClassLoader = isolatedClassLoaders.computeIfAbsent(isolatedClassLoaderCacheKey) {
         val arrayOfURLs = classpath.map { File(it.absolutePath).toURI().toURL() }.toTypedArray()
-        URLClassLoader(arrayOfURLs, null).apply {
+        URLClassLoader(arrayOfURLs).apply {
             setDefaultAssertionStatus(enableAssertions)
         }
     }


### PR DESCRIPTION
Fixes [KT-65761](https://youtrack.jetbrains.com/issue/KT-65761)