### PR TITLE
Codegen JVM: Use IXOR to optimize materialization of BooleanNegation

### DIFF
--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirLightTreeBytecodeTextTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirLightTreeBytecodeTextTestGenerated.java
@@ -1369,6 +1369,12 @@ public class FirLightTreeBytecodeTextTestGenerated extends AbstractFirLightTreeB
     }
 
     @Test
+    @TestMetadata("negatedStringCompare.kt")
+    public void testNegatedStringCompare() {
+      runTest("compiler/testData/codegen/bytecodeText/conditions/negatedStringCompare.kt");
+    }
+
+    @Test
     @TestMetadata("negatedZeroCompareInDoWhile.kt")
     public void testNegatedZeroCompareInDoWhile() {
       runTest("compiler/testData/codegen/bytecodeText/conditions/negatedZeroCompareInDoWhile.kt");

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirPsiBytecodeTextTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirPsiBytecodeTextTestGenerated.java
@@ -1369,6 +1369,12 @@ public class FirPsiBytecodeTextTestGenerated extends AbstractFirPsiBytecodeTextT
     }
 
     @Test
+    @TestMetadata("negatedStringCompare.kt")
+    public void testNegatedStringCompare() {
+      runTest("compiler/testData/codegen/bytecodeText/conditions/negatedStringCompare.kt");
+    }
+
+    @Test
     @TestMetadata("negatedZeroCompareInDoWhile.kt")
     public void testNegatedZeroCompareInDoWhile() {
       runTest("compiler/testData/codegen/bytecodeText/conditions/negatedZeroCompareInDoWhile.kt");

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/PromisedValue.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/PromisedValue.kt
@@ -145,6 +145,10 @@ fun PromisedValue.coerceToBoolean(): BooleanValue =
             override fun discard() {
                 this@coerceToBoolean.discard()
             }
+
+            override fun materializeAt(target: Type, irTarget: IrType, castForReified: Boolean) {
+                this@coerceToBoolean.materializeAt(target, irTarget, castForReified)
+            }
         }
     }
 

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/intrinsics/Not.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/intrinsics/Not.kt
@@ -16,13 +16,12 @@
 
 package org.jetbrains.kotlin.backend.jvm.intrinsics
 
-import org.jetbrains.kotlin.backend.jvm.codegen.BlockInfo
-import org.jetbrains.kotlin.backend.jvm.codegen.BooleanValue
-import org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen
-import org.jetbrains.kotlin.backend.jvm.codegen.coerceToBoolean
+import org.jetbrains.kotlin.backend.jvm.codegen.*
+import org.jetbrains.kotlin.codegen.StackValue
 import org.jetbrains.kotlin.ir.expressions.IrFunctionAccessExpression
+import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.org.objectweb.asm.Label
-import kotlin.math.exp
+import org.jetbrains.org.objectweb.asm.Type
 
 object Not : IntrinsicMethod() {
     class BooleanNegation(val expression: IrFunctionAccessExpression, val value: BooleanValue) : BooleanValue(value.codegen) {
@@ -39,6 +38,13 @@ object Not : IntrinsicMethod() {
         override fun discard() {
             markLineNumber(expression)
             value.discard()
+        }
+
+        override fun materializeAt(target: Type, irTarget: IrType, castForReified: Boolean) {
+            value.materializeAt(Type.BOOLEAN_TYPE, codegen.context.irBuiltIns.booleanType, false)
+            mv.iconst(1)
+            mv.xor(Type.INT_TYPE)
+            StackValue.coerce(Type.BOOLEAN_TYPE, target, mv)
         }
     }
 

--- a/compiler/testData/codegen/bytecodeText/conditions/negatedStringCompare.kt
+++ b/compiler/testData/codegen/bytecodeText/conditions/negatedStringCompare.kt
@@ -1,0 +1,3 @@
+fun foo(a: String?, b: String): Boolean = a != b
+
+//1 IXOR

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/JvmAbiConsistencyTestRestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/JvmAbiConsistencyTestRestGenerated.java
@@ -8254,6 +8254,12 @@ public class JvmAbiConsistencyTestRestGenerated extends AbstractJvmAbiConsistenc
       }
 
       @Test
+      @TestMetadata("negatedStringCompare.kt")
+      public void testNegatedStringCompare() {
+        runTest("compiler/testData/codegen/bytecodeText/conditions/negatedStringCompare.kt");
+      }
+
+      @Test
       @TestMetadata("negatedZeroCompareInDoWhile.kt")
       public void testNegatedZeroCompareInDoWhile() {
         runTest("compiler/testData/codegen/bytecodeText/conditions/negatedZeroCompareInDoWhile.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BytecodeTextTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BytecodeTextTestGenerated.java
@@ -1321,6 +1321,12 @@ public class BytecodeTextTestGenerated extends AbstractBytecodeTextTest {
     }
 
     @Test
+    @TestMetadata("negatedStringCompare.kt")
+    public void testNegatedStringCompare() {
+      runTest("compiler/testData/codegen/bytecodeText/conditions/negatedStringCompare.kt");
+    }
+
+    @Test
     @TestMetadata("negatedZeroCompareInDoWhile.kt")
     public void testNegatedZeroCompareInDoWhile() {
       runTest("compiler/testData/codegen/bytecodeText/conditions/negatedZeroCompareInDoWhile.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBytecodeTextTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBytecodeTextTestGenerated.java
@@ -1369,6 +1369,12 @@ public class IrBytecodeTextTestGenerated extends AbstractIrBytecodeTextTest {
     }
 
     @Test
+    @TestMetadata("negatedStringCompare.kt")
+    public void testNegatedStringCompare() {
+      runTest("compiler/testData/codegen/bytecodeText/conditions/negatedStringCompare.kt");
+    }
+
+    @Test
     @TestMetadata("negatedZeroCompareInDoWhile.kt")
     public void testNegatedZeroCompareInDoWhile() {
       runTest("compiler/testData/codegen/bytecodeText/conditions/negatedZeroCompareInDoWhile.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/inlineScopes/FirBytecodeTextTestWithInlineScopesGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/inlineScopes/FirBytecodeTextTestWithInlineScopesGenerated.java
@@ -1369,6 +1369,12 @@ public class FirBytecodeTextTestWithInlineScopesGenerated extends AbstractFirByt
     }
 
     @Test
+    @TestMetadata("negatedStringCompare.kt")
+    public void testNegatedStringCompare() {
+      runTest("compiler/testData/codegen/bytecodeText/conditions/negatedStringCompare.kt");
+    }
+
+    @Test
     @TestMetadata("negatedZeroCompareInDoWhile.kt")
     public void testNegatedZeroCompareInDoWhile() {
       runTest("compiler/testData/codegen/bytecodeText/conditions/negatedZeroCompareInDoWhile.kt");


### PR DESCRIPTION
Fixes: [KT-65357](https://youtrack.jetbrains.com/issue/KT-65357/JVMIR-Suboptimal-negation-bytecode-for-operator)