### PR TITLE
KT-54227: Allow Nullable Nothing be reified.

### DIFF
--- a/analysis/low-level-api-fir/tests/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/compiler/based/LLFirBlackBoxCodegenBasedTestGenerated.java
+++ b/analysis/low-level-api-fir/tests/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/compiler/based/LLFirBlackBoxCodegenBasedTestGenerated.java
@@ -54215,6 +54215,18 @@ public class LLFirBlackBoxCodegenBasedTestGenerated extends AbstractLLFirBlackBo
     }
 
     @Test
+    @TestMetadata("kt54227_1.kt")
+    public void testKt54227_1() {
+      runTest("compiler/testData/codegen/box/reified/kt54227_1.kt");
+    }
+
+    @Test
+    @TestMetadata("kt54227_2.kt")
+    public void testKt54227_2() {
+      runTest("compiler/testData/codegen/box/reified/kt54227_2.kt");
+    }
+
+    @Test
     @TestMetadata("nestedReified.kt")
     public void testNestedReified() {
       runTest("compiler/testData/codegen/box/reified/nestedReified.kt");

--- a/analysis/low-level-api-fir/tests/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/compiler/based/LLFirReversedBlackBoxCodegenBasedTestGenerated.java
+++ b/analysis/low-level-api-fir/tests/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/compiler/based/LLFirReversedBlackBoxCodegenBasedTestGenerated.java
@@ -54215,6 +54215,18 @@ public class LLFirReversedBlackBoxCodegenBasedTestGenerated extends AbstractLLFi
     }
 
     @Test
+    @TestMetadata("kt54227_1.kt")
+    public void testKt54227_1() {
+      runTest("compiler/testData/codegen/box/reified/kt54227_1.kt");
+    }
+
+    @Test
+    @TestMetadata("kt54227_2.kt")
+    public void testKt54227_2() {
+      runTest("compiler/testData/codegen/box/reified/kt54227_2.kt");
+    }
+
+    @Test
     @TestMetadata("nestedReified.kt")
     public void testNestedReified() {
       runTest("compiler/testData/codegen/box/reified/nestedReified.kt");

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/expression/FirReifiedChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/expression/FirReifiedChecker.kt
@@ -57,7 +57,7 @@ object FirReifiedChecker : FirQualifiedAccessExpressionChecker(MppCheckerKind.Co
     private fun ConeKotlinType.cannotBeReified() = when (this) {
         is ConeCapturedType -> true
         is ConeDynamicType -> true
-        else -> isNothing || isNullableNothing
+        else -> isNothing
     }
 
     private fun checkArgumentAndReport(

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirLightTreeBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirLightTreeBlackBoxCodegenTestGenerated.java
@@ -53916,6 +53916,18 @@ public class FirLightTreeBlackBoxCodegenTestGenerated extends AbstractFirLightTr
     }
 
     @Test
+    @TestMetadata("kt54227_1.kt")
+    public void testKt54227_1() {
+      runTest("compiler/testData/codegen/box/reified/kt54227_1.kt");
+    }
+
+    @Test
+    @TestMetadata("kt54227_2.kt")
+    public void testKt54227_2() {
+      runTest("compiler/testData/codegen/box/reified/kt54227_2.kt");
+    }
+
+    @Test
     @TestMetadata("nestedReified.kt")
     public void testNestedReified() {
       runTest("compiler/testData/codegen/box/reified/nestedReified.kt");

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirPsiBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirPsiBlackBoxCodegenTestGenerated.java
@@ -53916,6 +53916,18 @@ public class FirPsiBlackBoxCodegenTestGenerated extends AbstractFirPsiBlackBoxCo
     }
 
     @Test
+    @TestMetadata("kt54227_1.kt")
+    public void testKt54227_1() {
+      runTest("compiler/testData/codegen/box/reified/kt54227_1.kt");
+    }
+
+    @Test
+    @TestMetadata("kt54227_2.kt")
+    public void testKt54227_2() {
+      runTest("compiler/testData/codegen/box/reified/kt54227_2.kt");
+    }
+
+    @Test
     @TestMetadata("nestedReified.kt")
     public void testNestedReified() {
       runTest("compiler/testData/codegen/box/reified/nestedReified.kt");

--- a/compiler/testData/codegen/box/reified/kt54227_1.kt
+++ b/compiler/testData/codegen/box/reified/kt54227_1.kt
@@ -1,0 +1,19 @@
+interface TypeParameter
+
+interface A<OptionalTypeParameter : TypeParameter?> {
+    fun whatever(params: OptionalTypeParameter)
+}
+
+// Class B doesn't use the type parameter
+class B : A<Nothing?> {
+    override fun whatever(params: Nothing?) {
+        // We know this class doesn't use the type parameter, the value is just 'null'
+    }
+}
+
+inline fun <reified T : TypeParameter?> foo(it: A<T>) = "OK"
+
+fun box(): String {
+    val b = B()
+    return foo(b)
+}

--- a/compiler/testData/codegen/box/reified/kt54227_2.kt
+++ b/compiler/testData/codegen/box/reified/kt54227_2.kt
@@ -1,0 +1,14 @@
+interface Intf
+class A<T0: Intf?> {
+    fun func(t: T0): String {
+        return "OK"
+    }
+}
+
+inline fun <reified T1 : Intf?> foo(it: A<T1>, t: T1): String {
+    return it.func(t)
+}
+
+fun box(): String {
+    return foo(A<Nothing?>(), null)
+}

--- a/compiler/testData/diagnostics/testsWithStdLib/reified/reifiedNothingSubstitution.kt
+++ b/compiler/testData/diagnostics/testsWithStdLib/reified/reifiedNothingSubstitution.kt
@@ -7,11 +7,10 @@ inline fun <reified T: Any> javaClass(): Class<T> = T::class.java
 
 fun box() {
     val a = <!REIFIED_TYPE_FORBIDDEN_SUBSTITUTION, UNSUPPORTED!>arrayOf<!>(null!!)
-    val b = <!UNSUPPORTED!>Array<!><<!REIFIED_TYPE_FORBIDDEN_SUBSTITUTION!>Nothing?<!>>(5) { null!! }
     val c = <!REIFIED_TYPE_FORBIDDEN_SUBSTITUTION!>foo<!>() { null!! }
     val d = foo<Any> { null!! }
     val e = <!REIFIED_TYPE_FORBIDDEN_SUBSTITUTION!>foo<!> { "1" <!CAST_NEVER_SUCCEEDS!>as<!> Nothing }
-    val e1 = <!REIFIED_TYPE_FORBIDDEN_SUBSTITUTION!>foo<!> { "1" <!CAST_NEVER_SUCCEEDS!>as<!> Nothing? }
+    val e1 = foo { "1" <!CAST_NEVER_SUCCEEDS!>as<!> Nothing? }
 
     val f = javaClass<<!REIFIED_TYPE_FORBIDDEN_SUBSTITUTION!>Nothing<!>>()
 }

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/JvmAbiConsistencyTestBoxGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/JvmAbiConsistencyTestBoxGenerated.java
@@ -53186,6 +53186,18 @@ public class JvmAbiConsistencyTestBoxGenerated extends AbstractJvmAbiConsistency
     }
 
     @Test
+    @TestMetadata("kt54227_1.kt")
+    public void testKt54227_1() {
+      runTest("compiler/testData/codegen/box/reified/kt54227_1.kt");
+    }
+
+    @Test
+    @TestMetadata("kt54227_2.kt")
+    public void testKt54227_2() {
+      runTest("compiler/testData/codegen/box/reified/kt54227_2.kt");
+    }
+
+    @Test
     @TestMetadata("nestedReified.kt")
     public void testNestedReified() {
       runTest("compiler/testData/codegen/box/reified/nestedReified.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -49976,6 +49976,18 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
     }
 
     @Test
+    @TestMetadata("kt54227_1.kt")
+    public void testKt54227_1() {
+      runTest("compiler/testData/codegen/box/reified/kt54227_1.kt");
+    }
+
+    @Test
+    @TestMetadata("kt54227_2.kt")
+    public void testKt54227_2() {
+      runTest("compiler/testData/codegen/box/reified/kt54227_2.kt");
+    }
+
+    @Test
     @TestMetadata("nestedReified.kt")
     public void testNestedReified() {
       runTest("compiler/testData/codegen/box/reified/nestedReified.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -53186,6 +53186,18 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
     }
 
     @Test
+    @TestMetadata("kt54227_1.kt")
+    public void testKt54227_1() {
+      runTest("compiler/testData/codegen/box/reified/kt54227_1.kt");
+    }
+
+    @Test
+    @TestMetadata("kt54227_2.kt")
+    public void testKt54227_2() {
+      runTest("compiler/testData/codegen/box/reified/kt54227_2.kt");
+    }
+
+    @Test
     @TestMetadata("nestedReified.kt")
     public void testNestedReified() {
       runTest("compiler/testData/codegen/box/reified/nestedReified.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenWithIrInlinerTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenWithIrInlinerTestGenerated.java
@@ -53186,6 +53186,18 @@ public class IrBlackBoxCodegenWithIrInlinerTestGenerated extends AbstractIrBlack
     }
 
     @Test
+    @TestMetadata("kt54227_1.kt")
+    public void testKt54227_1() {
+      runTest("compiler/testData/codegen/box/reified/kt54227_1.kt");
+    }
+
+    @Test
+    @TestMetadata("kt54227_2.kt")
+    public void testKt54227_2() {
+      runTest("compiler/testData/codegen/box/reified/kt54227_2.kt");
+    }
+
+    @Test
     @TestMetadata("nestedReified.kt")
     public void testNestedReified() {
       runTest("compiler/testData/codegen/box/reified/nestedReified.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/inlineScopes/FirBlackBoxCodegenTestWithInlineScopesGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/inlineScopes/FirBlackBoxCodegenTestWithInlineScopesGenerated.java
@@ -53186,6 +53186,18 @@ public class FirBlackBoxCodegenTestWithInlineScopesGenerated extends AbstractFir
     }
 
     @Test
+    @TestMetadata("kt54227_1.kt")
+    public void testKt54227_1() {
+      runTest("compiler/testData/codegen/box/reified/kt54227_1.kt");
+    }
+
+    @Test
+    @TestMetadata("kt54227_2.kt")
+    public void testKt54227_2() {
+      runTest("compiler/testData/codegen/box/reified/kt54227_2.kt");
+    }
+
+    @Test
     @TestMetadata("nestedReified.kt")
     public void testNestedReified() {
       runTest("compiler/testData/codegen/box/reified/nestedReified.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -42938,6 +42938,16 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
       runTest("compiler/testData/codegen/box/reified/kt39256_privateInlineWithAnonymousObject.kt");
     }
 
+    @TestMetadata("kt54227_1.kt")
+    public void testKt54227_1() {
+      runTest("compiler/testData/codegen/box/reified/kt54227_1.kt");
+    }
+
+    @TestMetadata("kt54227_2.kt")
+    public void testKt54227_2() {
+      runTest("compiler/testData/codegen/box/reified/kt54227_2.kt");
+    }
+
     @TestMetadata("nestedReified.kt")
     public void testNestedReified() {
       runTest("compiler/testData/codegen/box/reified/nestedReified.kt");

--- a/core/descriptors/src/org/jetbrains/kotlin/types/TypeUtils.kt
+++ b/core/descriptors/src/org/jetbrains/kotlin/types/TypeUtils.kt
@@ -107,7 +107,7 @@ fun isNullabilityMismatch(expected: KotlinType, actual: KotlinType) =
     !expected.isMarkedNullable && actual.isMarkedNullable && actual.isSubtypeOf(TypeUtils.makeNullable(expected))
 
 fun KotlinType.cannotBeReified(): Boolean =
-    KotlinBuiltIns.isNothingOrNullableNothing(this) || this.isDynamic() || this.isCaptured()
+    KotlinBuiltIns.isNothing(this) || this.isDynamic() || this.isCaptured()
 
 fun TypeProjection.substitute(doSubstitute: (KotlinType) -> KotlinType): TypeProjection {
     return if (isStarProjection)

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/fir/FirJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/fir/FirJsCodegenBoxTestGenerated.java
@@ -38580,6 +38580,18 @@ public class FirJsCodegenBoxTestGenerated extends AbstractFirJsCodegenBoxTest {
     }
 
     @Test
+    @TestMetadata("kt54227_1.kt")
+    public void testKt54227_1() {
+      runTest("compiler/testData/codegen/box/reified/kt54227_1.kt");
+    }
+
+    @Test
+    @TestMetadata("kt54227_2.kt")
+    public void testKt54227_2() {
+      runTest("compiler/testData/codegen/box/reified/kt54227_2.kt");
+    }
+
+    @Test
     @TestMetadata("newArrayInt.kt")
     public void testNewArrayInt() {
       runTest("compiler/testData/codegen/box/reified/newArrayInt.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/fir/FirJsES6CodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/fir/FirJsES6CodegenBoxTestGenerated.java
@@ -38580,6 +38580,18 @@ public class FirJsES6CodegenBoxTestGenerated extends AbstractFirJsES6CodegenBoxT
     }
 
     @Test
+    @TestMetadata("kt54227_1.kt")
+    public void testKt54227_1() {
+      runTest("compiler/testData/codegen/box/reified/kt54227_1.kt");
+    }
+
+    @Test
+    @TestMetadata("kt54227_2.kt")
+    public void testKt54227_2() {
+      runTest("compiler/testData/codegen/box/reified/kt54227_2.kt");
+    }
+
+    @Test
     @TestMetadata("newArrayInt.kt")
     public void testNewArrayInt() {
       runTest("compiler/testData/codegen/box/reified/newArrayInt.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/IrJsCodegenBoxTestGenerated.java
@@ -37982,6 +37982,18 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
     }
 
     @Test
+    @TestMetadata("kt54227_1.kt")
+    public void testKt54227_1() {
+      runTest("compiler/testData/codegen/box/reified/kt54227_1.kt");
+    }
+
+    @Test
+    @TestMetadata("kt54227_2.kt")
+    public void testKt54227_2() {
+      runTest("compiler/testData/codegen/box/reified/kt54227_2.kt");
+    }
+
+    @Test
     @TestMetadata("newArrayInt.kt")
     public void testNewArrayInt() {
       runTest("compiler/testData/codegen/box/reified/newArrayInt.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/IrJsES6CodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/IrJsES6CodegenBoxTestGenerated.java
@@ -37982,6 +37982,18 @@ public class IrJsES6CodegenBoxTestGenerated extends AbstractIrJsES6CodegenBoxTes
     }
 
     @Test
+    @TestMetadata("kt54227_1.kt")
+    public void testKt54227_1() {
+      runTest("compiler/testData/codegen/box/reified/kt54227_1.kt");
+    }
+
+    @Test
+    @TestMetadata("kt54227_2.kt")
+    public void testKt54227_2() {
+      runTest("compiler/testData/codegen/box/reified/kt54227_2.kt");
+    }
+
+    @Test
     @TestMetadata("newArrayInt.kt")
     public void testNewArrayInt() {
       runTest("compiler/testData/codegen/box/reified/newArrayInt.kt");

--- a/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/FirNativeCodegenBoxTestGenerated.java
+++ b/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/FirNativeCodegenBoxTestGenerated.java
@@ -42050,6 +42050,18 @@ public class FirNativeCodegenBoxTestGenerated extends AbstractNativeCodegenBoxTe
       }
 
       @Test
+      @TestMetadata("kt54227_1.kt")
+      public void testKt54227_1() {
+        runTest("compiler/testData/codegen/box/reified/kt54227_1.kt");
+      }
+
+      @Test
+      @TestMetadata("kt54227_2.kt")
+      public void testKt54227_2() {
+        runTest("compiler/testData/codegen/box/reified/kt54227_2.kt");
+      }
+
+      @Test
       @TestMetadata("newArrayInt.kt")
       public void testNewArrayInt() {
         runTest("compiler/testData/codegen/box/reified/newArrayInt.kt");

--- a/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/FirNativeCodegenBoxTestNoPLGenerated.java
+++ b/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/FirNativeCodegenBoxTestNoPLGenerated.java
@@ -43100,6 +43100,18 @@ public class FirNativeCodegenBoxTestNoPLGenerated extends AbstractNativeCodegenB
       }
 
       @Test
+      @TestMetadata("kt54227_1.kt")
+      public void testKt54227_1() {
+        runTest("compiler/testData/codegen/box/reified/kt54227_1.kt");
+      }
+
+      @Test
+      @TestMetadata("kt54227_2.kt")
+      public void testKt54227_2() {
+        runTest("compiler/testData/codegen/box/reified/kt54227_2.kt");
+      }
+
+      @Test
       @TestMetadata("newArrayInt.kt")
       public void testNewArrayInt() {
         runTest("compiler/testData/codegen/box/reified/newArrayInt.kt");

--- a/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/NativeCodegenBoxTestGenerated.java
+++ b/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/NativeCodegenBoxTestGenerated.java
@@ -40389,6 +40389,18 @@ public class NativeCodegenBoxTestGenerated extends AbstractNativeCodegenBoxTest 
       }
 
       @Test
+      @TestMetadata("kt54227_1.kt")
+      public void testKt54227_1() {
+        runTest("compiler/testData/codegen/box/reified/kt54227_1.kt");
+      }
+
+      @Test
+      @TestMetadata("kt54227_2.kt")
+      public void testKt54227_2() {
+        runTest("compiler/testData/codegen/box/reified/kt54227_2.kt");
+      }
+
+      @Test
       @TestMetadata("newArrayInt.kt")
       public void testNewArrayInt() {
         runTest("compiler/testData/codegen/box/reified/newArrayInt.kt");

--- a/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/NativeCodegenBoxTestNoPLGenerated.java
+++ b/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/NativeCodegenBoxTestNoPLGenerated.java
@@ -41426,6 +41426,18 @@ public class NativeCodegenBoxTestNoPLGenerated extends AbstractNativeCodegenBoxT
       }
 
       @Test
+      @TestMetadata("kt54227_1.kt")
+      public void testKt54227_1() {
+        runTest("compiler/testData/codegen/box/reified/kt54227_1.kt");
+      }
+
+      @Test
+      @TestMetadata("kt54227_2.kt")
+      public void testKt54227_2() {
+        runTest("compiler/testData/codegen/box/reified/kt54227_2.kt");
+      }
+
+      @Test
       @TestMetadata("newArrayInt.kt")
       public void testNewArrayInt() {
         runTest("compiler/testData/codegen/box/reified/newArrayInt.kt");

--- a/wasm/wasm.tests/tests-gen/org/jetbrains/kotlin/wasm/test/FirWasmJsCodegenBoxTestGenerated.java
+++ b/wasm/wasm.tests/tests-gen/org/jetbrains/kotlin/wasm/test/FirWasmJsCodegenBoxTestGenerated.java
@@ -38448,6 +38448,18 @@ public class FirWasmJsCodegenBoxTestGenerated extends AbstractFirWasmJsCodegenBo
     }
 
     @Test
+    @TestMetadata("kt54227_1.kt")
+    public void testKt54227_1() {
+      runTest("compiler/testData/codegen/box/reified/kt54227_1.kt");
+    }
+
+    @Test
+    @TestMetadata("kt54227_2.kt")
+    public void testKt54227_2() {
+      runTest("compiler/testData/codegen/box/reified/kt54227_2.kt");
+    }
+
+    @Test
     @TestMetadata("newArrayInt.kt")
     public void testNewArrayInt() {
       runTest("compiler/testData/codegen/box/reified/newArrayInt.kt");

--- a/wasm/wasm.tests/tests-gen/org/jetbrains/kotlin/wasm/test/K1WasmCodegenBoxTestGenerated.java
+++ b/wasm/wasm.tests/tests-gen/org/jetbrains/kotlin/wasm/test/K1WasmCodegenBoxTestGenerated.java
@@ -37850,6 +37850,18 @@ public class K1WasmCodegenBoxTestGenerated extends AbstractK1WasmCodegenBoxTest 
     }
 
     @Test
+    @TestMetadata("kt54227_1.kt")
+    public void testKt54227_1() {
+      runTest("compiler/testData/codegen/box/reified/kt54227_1.kt");
+    }
+
+    @Test
+    @TestMetadata("kt54227_2.kt")
+    public void testKt54227_2() {
+      runTest("compiler/testData/codegen/box/reified/kt54227_2.kt");
+    }
+
+    @Test
     @TestMetadata("newArrayInt.kt")
     public void testNewArrayInt() {
       runTest("compiler/testData/codegen/box/reified/newArrayInt.kt");


### PR DESCRIPTION
KT-54227 fixed.
add 2 box test for this fix, 1 test change.
All tests related with "reified" passed.