### PR TITLE
JVM Codegen: Emit lookupswitch/tableswitch for when-expressions over Char if possible

### DIFF
--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/SwitchGenerator.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/SwitchGenerator.kt
@@ -131,6 +131,15 @@ class SwitchGenerator(private val expression: IrWhen, private val data: BlockInf
                     cases
                 )
             }
+            subject is IrGetValue && areConstCharComparisons(conditions) -> {
+                val cases = extractSwitchCasesAndFilterUnreachableLabels(callToLabels, expressionToLabels)
+                IntSwitch(
+                    subject,
+                    elseExpression,
+                    expressionToLabels,
+                    cases.map { ValueToLabel((it.value as Char).code, it.label) }
+                )
+            }
             areConstStringComparisons(conditions) -> {
                 val cases = extractSwitchCasesAndFilterUnreachableLabels(callToLabels, expressionToLabels)
                 StringSwitch(
@@ -191,6 +200,10 @@ class SwitchGenerator(private val expression: IrWhen, private val data: BlockInf
 
     private fun areConstIntComparisons(conditions: List<IrCall>): Boolean {
         return checkTypeSpecifics(conditions, { it.isInt() }, { it.kind == IrConstKind.Int })
+    }
+
+    private fun areConstCharComparisons(conditions: List<IrCall>): Boolean {
+        return checkTypeSpecifics(conditions, { it.isChar() }, { it.kind == IrConstKind.Char })
     }
 
     private fun areConstStringComparisons(conditions: List<IrCall>): Boolean {

--- a/compiler/testData/codegen/bytecodeText/when/lookupSwitch.kt
+++ b/compiler/testData/codegen/bytecodeText/when/lookupSwitch.kt
@@ -7,5 +7,14 @@ fun foo(x: Int): String {
     }
 }
 
-// 1 LOOKUPSWITCH
+fun foo(p: Char): String {
+    return when (p) {
+        'a' -> "a"
+        'g' -> "g"
+        'h' -> "h"
+        else -> "else"
+    }
+}
+
+// 2 LOOKUPSWITCH
 // 0 TABLESWITCH

--- a/compiler/testData/codegen/bytecodeText/when/tableSwitch.kt
+++ b/compiler/testData/codegen/bytecodeText/when/tableSwitch.kt
@@ -7,5 +7,19 @@ fun foo(x: Int): String {
     }
 }
 
+fun foo(p: Char): String {
+    return when (p) {
+        'a' -> "a"
+        'b' -> "b"
+        'c' -> "c"
+        'd' -> "d"
+        'e' -> "e"
+        'f' -> "f"
+        'g' -> "g"
+        'h' -> "h"
+        else -> "else"
+    }
+}
+
 // 0 LOOKUPSWITCH
-// 1 TABLESWITCH
+// 2 TABLESWITCH


### PR DESCRIPTION
Fixes: [KT-64779](https://youtrack.jetbrains.com/issue/KT-64779)