### PR TITLE
CLI: Improve error message

### DIFF
--- a/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/modules/JavaModuleInfo.kt
+++ b/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/modules/JavaModuleInfo.kt
@@ -47,6 +47,8 @@ class JavaModuleInfo(
 
     override fun toString() = "Module $moduleName (${requires.size} requires, ${exports.size} exports)"
 
+    class FileReadingException(override val message: String, override val cause: Throwable) : IllegalStateException(message, cause)
+
     companion object {
         fun create(psiJavaModule: PsiJavaModule) = JavaModuleInfo(
             psiJavaModule.name,
@@ -111,8 +113,8 @@ class JavaModuleInfo(
                     }
                 }, ClassReader.SKIP_DEBUG or ClassReader.SKIP_CODE or ClassReader.SKIP_FRAMES)
             } catch (e: Exception) {
-                throw IllegalStateException(
-                    "Could not load module definition from: $file. The file might be broken " +
+                throw FileReadingException (
+                    "Could not load module definition from: ${file.canonicalPath}. The file might be broken " +
                             "by incorrect post-processing via bytecode tools. Please remove this file from the classpath.",
                     e
                 )

--- a/compiler/test-infrastructure-utils/tests/org/jetbrains/kotlin/test/CompilerTestUtil.kt
+++ b/compiler/test-infrastructure-utils/tests/org/jetbrains/kotlin/test/CompilerTestUtil.kt
@@ -79,6 +79,7 @@ object CompilerTestUtil {
             .replace(KtTestUtil.getJdk8Home().absolutePath.replace("\\", "/"), "\$JDK_1_8")
             .replace(KtTestUtil.getJdk11Home().absolutePath.replace("\\", "/"), "\$JDK_11")
             .replace(KtTestUtil.getJdk17Home().absolutePath.replace("\\", "/"), "\$JDK_17")
+            .replace(KtTestUtil.getJdk21Home().absolutePath.replace("\\", "/"), "\$JDK_21")
             .replace("info: executable production duration: \\d+ms".toRegex(), "info: executable production duration: [time]")
             .replace(KotlinCompilerVersion.VERSION, "\$VERSION$")
             .replace(System.getProperty("java.runtime.version"), "\$JVM_VERSION$")

--- a/compiler/testData/cli/jvm/jdkRelease20WithCorruptedClass.args
+++ b/compiler/testData/cli/jvm/jdkRelease20WithCorruptedClass.args
@@ -1,0 +1,6 @@
+-Xjdk-release=20
+-jdk-home
+$JDK_21
+$TESTDATA_DIR$/jdkRelease.kt
+-d
+$TEMP_DIR$

--- a/compiler/testData/cli/jvm/jdkRelease20WithCorruptedClass.out
+++ b/compiler/testData/cli/jvm/jdkRelease20WithCorruptedClass.out
@@ -1,0 +1,3 @@
+error: could not load module definition from: $JDK_21/lib/ct.sym!/IJK/jdk.httpserver/module-info.sig. The file might be broken by incorrect post-processing via bytecode tools. Please remove this file from the classpath.
+Caused by: java.lang.ArrayIndexOutOfBoundsException: 36
+COMPILATION_ERROR

--- a/compiler/tests-common/tests/org/jetbrains/kotlin/cli/AbstractCliTest.java
+++ b/compiler/tests-common/tests/org/jetbrains/kotlin/cli/AbstractCliTest.java
@@ -231,8 +231,14 @@ public abstract class AbstractCliTest extends TestCaseWithTmpdir {
             return null;
         }
 
-        if (arg.equals("$JDK_1_8")) return KtTestUtil.getJdk8Home().getAbsolutePath();
-        if (arg.equals("$JDK_11_0")) return KtTestUtil.getJdk11Home().getAbsolutePath();
+        switch (arg) {
+            case "$JDK_1_8":
+                return KtTestUtil.getJdk8Home().getAbsolutePath();
+            case "$JDK_11_0":
+                return KtTestUtil.getJdk11Home().getAbsolutePath();
+            case "$JDK_21":
+                return KtTestUtil.getJdk21Home().getAbsolutePath();
+        }
 
         String argWithColonsReplaced = arg
                 .replace("\\:", "$COLON$")

--- a/compiler/tests-gen/org/jetbrains/kotlin/cli/CliTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/cli/CliTestGenerated.java
@@ -833,6 +833,11 @@ public class CliTestGenerated extends AbstractCliTest {
       runTest("compiler/testData/cli/jvm/jdkRelease.args");
     }
 
+    @TestMetadata("jdkRelease20WithCorruptedClass.args")
+    public void testJdkRelease20WithCorruptedClass() {
+      runTest("compiler/testData/cli/jvm/jdkRelease20WithCorruptedClass.args");
+    }
+
     @TestMetadata("jdkRelease6WithJvmTarget8Jdk11.args")
     public void testJdkRelease6WithJvmTarget8Jdk11() {
       runTest("compiler/testData/cli/jvm/jdkRelease6WithJvmTarget8Jdk11.args");


### PR DESCRIPTION
When JDK used in -Xjdk-release has corrupted class files .

Fixes: [KT-67739](https://youtrack.jetbrains.com/issue/KT-67739/Improve-error-message-when-JDK-used-in-Xjdk-release-has-corrupted-class-files)