### PR TITLE
[FIR2IR] Do not coerce to Unit if when is used as expression.

### DIFF
--- a/analysis/low-level-api-fir/tests/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/compiler/based/LLFirBlackBoxCodegenBasedTestGenerated.java
+++ b/analysis/low-level-api-fir/tests/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/compiler/based/LLFirBlackBoxCodegenBasedTestGenerated.java
@@ -2901,6 +2901,12 @@ public class LLFirBlackBoxCodegenBasedTestGenerated extends AbstractLLFirBlackBo
     }
 
     @Test
+    @TestMetadata("kt68449.kt")
+    public void testKt68449() {
+      runTest("compiler/testData/codegen/box/branching/kt68449.kt");
+    }
+
+    @Test
     @TestMetadata("when2.kt")
     public void testWhen2() {
       runTest("compiler/testData/codegen/box/branching/when2.kt");

--- a/analysis/low-level-api-fir/tests/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/compiler/based/LLFirReversedBlackBoxCodegenBasedTestGenerated.java
+++ b/analysis/low-level-api-fir/tests/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/compiler/based/LLFirReversedBlackBoxCodegenBasedTestGenerated.java
@@ -2901,6 +2901,12 @@ public class LLFirReversedBlackBoxCodegenBasedTestGenerated extends AbstractLLFi
     }
 
     @Test
+    @TestMetadata("kt68449.kt")
+    public void testKt68449() {
+      runTest("compiler/testData/codegen/box/branching/kt68449.kt");
+    }
+
+    @Test
     @TestMetadata("when2.kt")
     public void testWhen2() {
       runTest("compiler/testData/codegen/box/branching/when2.kt");

--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrVisitor.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrVisitor.kt
@@ -1244,9 +1244,14 @@ class Fir2IrVisitor(
                 }
                 val isProperlyExhaustive = whenExpression.isDeeplyProperlyExhaustive()
                 val whenExpressionType =
-                    if (isProperlyExhaustive && whenExpression.branches.none {
+                    if ((isProperlyExhaustive && whenExpression.branches.none {
                             it.condition is FirElseIfTrueCondition && it.result.statements.isEmpty()
-                        }) whenExpression.resolvedType else session.builtinTypes.unitType.type
+                        })
+                        /** KT-68449 if `whenExpression` is used as an expression, do not coerce to Unit.
+                         * See [org.jetbrains.kotlin.psi2ir.generators.getExpressionTypeWithCoercionToUnit]
+                         */
+                        || whenExpression.usedAsExpression
+                    ) whenExpression.resolvedType else session.builtinTypes.unitType.type
                 val irBranches = whenExpression.convertWhenBranchesTo(
                     mutableListOf(),
                     whenExpressionType,

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirLightTreeBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirLightTreeBlackBoxCodegenTestGenerated.java
@@ -2890,6 +2890,12 @@ public class FirLightTreeBlackBoxCodegenTestGenerated extends AbstractFirLightTr
     }
 
     @Test
+    @TestMetadata("kt68449.kt")
+    public void testKt68449() {
+      runTest("compiler/testData/codegen/box/branching/kt68449.kt");
+    }
+
+    @Test
     @TestMetadata("when2.kt")
     public void testWhen2() {
       runTest("compiler/testData/codegen/box/branching/when2.kt");

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirPsiBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirPsiBlackBoxCodegenTestGenerated.java
@@ -2890,6 +2890,12 @@ public class FirPsiBlackBoxCodegenTestGenerated extends AbstractFirPsiBlackBoxCo
     }
 
     @Test
+    @TestMetadata("kt68449.kt")
+    public void testKt68449() {
+      runTest("compiler/testData/codegen/box/branching/kt68449.kt");
+    }
+
+    @Test
     @TestMetadata("when2.kt")
     public void testWhen2() {
       runTest("compiler/testData/codegen/box/branching/when2.kt");

--- a/compiler/testData/codegen/box/branching/kt68449.kt
+++ b/compiler/testData/codegen/box/branching/kt68449.kt
@@ -1,0 +1,13 @@
+// WITH_STDLIB
+fun func(obj: Any): String {
+    val result = when (obj) {
+        is String -> obj.uppercase()
+        is Long -> obj + 10
+        else -> {}
+    }
+    return result.toString()
+}
+
+fun box(): String {
+    return func("ok")
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/JvmAbiConsistencyTestBoxGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/JvmAbiConsistencyTestBoxGenerated.java
@@ -2890,6 +2890,12 @@ public class JvmAbiConsistencyTestBoxGenerated extends AbstractJvmAbiConsistency
     }
 
     @Test
+    @TestMetadata("kt68449.kt")
+    public void testKt68449() {
+      runTest("compiler/testData/codegen/box/branching/kt68449.kt");
+    }
+
+    @Test
     @TestMetadata("when2.kt")
     public void testWhen2() {
       runTest("compiler/testData/codegen/box/branching/when2.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/BlackBoxCodegenTestGenerated.java
@@ -2656,6 +2656,12 @@ public class BlackBoxCodegenTestGenerated extends AbstractBlackBoxCodegenTest {
     }
 
     @Test
+    @TestMetadata("kt68449.kt")
+    public void testKt68449() {
+      runTest("compiler/testData/codegen/box/branching/kt68449.kt");
+    }
+
+    @Test
     @TestMetadata("when2.kt")
     public void testWhen2() {
       runTest("compiler/testData/codegen/box/branching/when2.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -2890,6 +2890,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
     }
 
     @Test
+    @TestMetadata("kt68449.kt")
+    public void testKt68449() {
+      runTest("compiler/testData/codegen/box/branching/kt68449.kt");
+    }
+
+    @Test
     @TestMetadata("when2.kt")
     public void testWhen2() {
       runTest("compiler/testData/codegen/box/branching/when2.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenWithIrInlinerTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenWithIrInlinerTestGenerated.java
@@ -2890,6 +2890,12 @@ public class IrBlackBoxCodegenWithIrInlinerTestGenerated extends AbstractIrBlack
     }
 
     @Test
+    @TestMetadata("kt68449.kt")
+    public void testKt68449() {
+      runTest("compiler/testData/codegen/box/branching/kt68449.kt");
+    }
+
+    @Test
     @TestMetadata("when2.kt")
     public void testWhen2() {
       runTest("compiler/testData/codegen/box/branching/when2.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/inlineScopes/FirBlackBoxCodegenTestWithInlineScopesGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/inlineScopes/FirBlackBoxCodegenTestWithInlineScopesGenerated.java
@@ -2890,6 +2890,12 @@ public class FirBlackBoxCodegenTestWithInlineScopesGenerated extends AbstractFir
     }
 
     @Test
+    @TestMetadata("kt68449.kt")
+    public void testKt68449() {
+      runTest("compiler/testData/codegen/box/branching/kt68449.kt");
+    }
+
+    @Test
     @TestMetadata("when2.kt")
     public void testWhen2() {
       runTest("compiler/testData/codegen/box/branching/when2.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -2524,6 +2524,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
       runTest("compiler/testData/codegen/box/branching/if_else.kt");
     }
 
+    @TestMetadata("kt68449.kt")
+    public void testKt68449() {
+      runTest("compiler/testData/codegen/box/branching/kt68449.kt");
+    }
+
     @TestMetadata("when2.kt")
     public void testWhen2() {
       runTest("compiler/testData/codegen/box/branching/when2.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/fir/FirJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/fir/FirJsCodegenBoxTestGenerated.java
@@ -1996,6 +1996,12 @@ public class FirJsCodegenBoxTestGenerated extends AbstractFirJsCodegenBoxTest {
     }
 
     @Test
+    @TestMetadata("kt68449.kt")
+    public void testKt68449() {
+      runTest("compiler/testData/codegen/box/branching/kt68449.kt");
+    }
+
+    @Test
     @TestMetadata("when2.kt")
     public void testWhen2() {
       runTest("compiler/testData/codegen/box/branching/when2.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/fir/FirJsES6CodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/fir/FirJsES6CodegenBoxTestGenerated.java
@@ -1996,6 +1996,12 @@ public class FirJsES6CodegenBoxTestGenerated extends AbstractFirJsES6CodegenBoxT
     }
 
     @Test
+    @TestMetadata("kt68449.kt")
+    public void testKt68449() {
+      runTest("compiler/testData/codegen/box/branching/kt68449.kt");
+    }
+
+    @Test
     @TestMetadata("when2.kt")
     public void testWhen2() {
       runTest("compiler/testData/codegen/box/branching/when2.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/IrJsCodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/IrJsCodegenBoxTestGenerated.java
@@ -1996,6 +1996,12 @@ public class IrJsCodegenBoxTestGenerated extends AbstractIrJsCodegenBoxTest {
     }
 
     @Test
+    @TestMetadata("kt68449.kt")
+    public void testKt68449() {
+      runTest("compiler/testData/codegen/box/branching/kt68449.kt");
+    }
+
+    @Test
     @TestMetadata("when2.kt")
     public void testWhen2() {
       runTest("compiler/testData/codegen/box/branching/when2.kt");

--- a/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/IrJsES6CodegenBoxTestGenerated.java
+++ b/js/js.tests/tests-gen/org/jetbrains/kotlin/js/test/ir/IrJsES6CodegenBoxTestGenerated.java
@@ -1996,6 +1996,12 @@ public class IrJsES6CodegenBoxTestGenerated extends AbstractIrJsES6CodegenBoxTes
     }
 
     @Test
+    @TestMetadata("kt68449.kt")
+    public void testKt68449() {
+      runTest("compiler/testData/codegen/box/branching/kt68449.kt");
+    }
+
+    @Test
     @TestMetadata("when2.kt")
     public void testWhen2() {
       runTest("compiler/testData/codegen/box/branching/when2.kt");

--- a/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/FirNativeCodegenBoxTestGenerated.java
+++ b/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/FirNativeCodegenBoxTestGenerated.java
@@ -2085,6 +2085,12 @@ public class FirNativeCodegenBoxTestGenerated extends AbstractNativeCodegenBoxTe
       }
 
       @Test
+      @TestMetadata("kt68449.kt")
+      public void testKt68449() {
+        runTest("compiler/testData/codegen/box/branching/kt68449.kt");
+      }
+
+      @Test
       @TestMetadata("when2.kt")
       public void testWhen2() {
         runTest("compiler/testData/codegen/box/branching/when2.kt");

--- a/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/FirNativeCodegenBoxTestNoPLGenerated.java
+++ b/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/FirNativeCodegenBoxTestNoPLGenerated.java
@@ -2135,6 +2135,12 @@ public class FirNativeCodegenBoxTestNoPLGenerated extends AbstractNativeCodegenB
       }
 
       @Test
+      @TestMetadata("kt68449.kt")
+      public void testKt68449() {
+        runTest("compiler/testData/codegen/box/branching/kt68449.kt");
+      }
+
+      @Test
       @TestMetadata("when2.kt")
       public void testWhen2() {
         runTest("compiler/testData/codegen/box/branching/when2.kt");

--- a/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/NativeCodegenBoxTestGenerated.java
+++ b/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/NativeCodegenBoxTestGenerated.java
@@ -2035,6 +2035,12 @@ public class NativeCodegenBoxTestGenerated extends AbstractNativeCodegenBoxTest 
       }
 
       @Test
+      @TestMetadata("kt68449.kt")
+      public void testKt68449() {
+        runTest("compiler/testData/codegen/box/branching/kt68449.kt");
+      }
+
+      @Test
       @TestMetadata("when2.kt")
       public void testWhen2() {
         runTest("compiler/testData/codegen/box/branching/when2.kt");

--- a/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/NativeCodegenBoxTestNoPLGenerated.java
+++ b/native/native.tests/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/NativeCodegenBoxTestNoPLGenerated.java
@@ -2086,6 +2086,12 @@ public class NativeCodegenBoxTestNoPLGenerated extends AbstractNativeCodegenBoxT
       }
 
       @Test
+      @TestMetadata("kt68449.kt")
+      public void testKt68449() {
+        runTest("compiler/testData/codegen/box/branching/kt68449.kt");
+      }
+
+      @Test
       @TestMetadata("when2.kt")
       public void testWhen2() {
         runTest("compiler/testData/codegen/box/branching/when2.kt");

--- a/wasm/wasm.tests/tests-gen/org/jetbrains/kotlin/wasm/test/FirWasmJsCodegenBoxTestGenerated.java
+++ b/wasm/wasm.tests/tests-gen/org/jetbrains/kotlin/wasm/test/FirWasmJsCodegenBoxTestGenerated.java
@@ -1996,6 +1996,12 @@ public class FirWasmJsCodegenBoxTestGenerated extends AbstractFirWasmJsCodegenBo
     }
 
     @Test
+    @TestMetadata("kt68449.kt")
+    public void testKt68449() {
+      runTest("compiler/testData/codegen/box/branching/kt68449.kt");
+    }
+
+    @Test
     @TestMetadata("when2.kt")
     public void testWhen2() {
       runTest("compiler/testData/codegen/box/branching/when2.kt");

--- a/wasm/wasm.tests/tests-gen/org/jetbrains/kotlin/wasm/test/K1WasmCodegenBoxTestGenerated.java
+++ b/wasm/wasm.tests/tests-gen/org/jetbrains/kotlin/wasm/test/K1WasmCodegenBoxTestGenerated.java
@@ -1996,6 +1996,12 @@ public class K1WasmCodegenBoxTestGenerated extends AbstractK1WasmCodegenBoxTest 
     }
 
     @Test
+    @TestMetadata("kt68449.kt")
+    public void testKt68449() {
+      runTest("compiler/testData/codegen/box/branching/kt68449.kt");
+    }
+
+    @Test
     @TestMetadata("when2.kt")
     public void testWhen2() {
       runTest("compiler/testData/codegen/box/branching/when2.kt");


### PR DESCRIPTION
KT-68449 fixed.

add a box test.