### PR TITLE
[Analysis API] Updated documentation to match code references. "analyse" -> "analyze".

### DIFF
--- a/analysis/analysis-api/src/org/jetbrains/kotlin/analysis/api/components/KtAnalysisScopeProvider.kt
+++ b/analysis/analysis-api/src/org/jetbrains/kotlin/analysis/api/components/KtAnalysisScopeProvider.kt
@@ -20,7 +20,7 @@ public typealias KtAnalysisScopeProvider = KaAnalysisScopeProvider
 
 public interface KaAnalysisScopeProviderMixIn : KaSessionMixIn {
     /**
-     * Return [GlobalSearchScope] represent a scope code in which can be analysed by current [KaSession].
+     * Return [GlobalSearchScope] represent a scope code in which can be analyzed by current [KaSession].
      * That means [org.jetbrains.kotlin.analysis.api.symbols.KaSymbol] can be built for the declarations from this scope.
      */
     public val analysisScope: GlobalSearchScope

--- a/analysis/analysis-api/src/org/jetbrains/kotlin/analysis/api/permissions/permissions.kt
+++ b/analysis/analysis-api/src/org/jetbrains/kotlin/analysis/api/permissions/permissions.kt
@@ -81,7 +81,7 @@ private annotation class KaAllowProhibitedAnalyzeFromWriteAction
  *
  * // use case code
  * fun useCase() {
- *   analyse(function) {
+ *   analyze(function) {
  *    // 'getConstantFromExpressionBody' is an imaginary function
  *    val valueBefore = function.getConstantFromExpressionBody() // valueBefore is 0
  *
@@ -89,7 +89,7 @@ private annotation class KaAllowProhibitedAnalyzeFromWriteAction
  *    val valueAfter = function.getConstantFromExpressionBody() // Wrong way: valueAfter is not guarantied to be '1'
  *   }
  *
- *   analyse(function) {
+ *   analyze(function) {
  *    val valueAfter = function.getConstantFromExpressionBody() // OK: valueAfter is guarantied to be '1'
  *   }
  * }

--- a/analysis/analysis-api/src/org/jetbrains/kotlin/analysis/api/session/KtAnalysisSessionProvider.kt
+++ b/analysis/analysis-api/src/org/jetbrains/kotlin/analysis/api/session/KtAnalysisSessionProvider.kt
@@ -28,7 +28,7 @@ public abstract class KaSessionProvider(public val project: Project) : Disposabl
 
     public abstract fun getAnalysisSessionByUseSiteKtModule(useSiteKtModule: KtModule): KaSession
 
-    // The `analyse` functions affect binary compatibility as they are inlined with every `analyze` call. To avoid breaking binary
+    // The `analyze` functions affect binary compatibility as they are inlined with every `analyze` call. To avoid breaking binary
     // compatibility, their implementations should not be changed unless absolutely necessary. It should be possible to put most
     // functionality into `beforeEnteringAnalysis` and/or `afterLeavingAnalysis`.
 

--- a/docs/analysis/analysis-api/analysis-api-usage.md
+++ b/docs/analysis/analysis-api/analysis-api-usage.md
@@ -1,15 +1,15 @@
 # Analysis API Usage
 
-To use Analysis API, you need to be in the `KaSession` context. Basically, it means that you need to call [`analyse(contextElement: KtElement, action: KaSession.() -> R): R`](https://github.com/JetBrains/kotlin/blob/master/analysis/analysis-api/src/org/jetbrains/kotlin/analysis/api/KaAnalysisSessionProvider.kt#L106) function. All your actions with Analysis API will be performed with `KaSession` receiver available.
+To use Analysis API, you need to be in the `KaSession` context. Basically, it means that you need to call [`analyze(contextElement: KtElement, action: KaSession.() -> R): R`](https://github.com/JetBrains/kotlin/blob/master/analysis/analysis-api/src/org/jetbrains/kotlin/analysis/api/session/KtAnalysisSessionProvider.kt#L35) function. All your actions with Analysis API will be performed with `KaSession` receiver available.
 ```kotlin
-analyse(psiElementForContext) { // you are inside KaSession Context
+analyze(psiElementForContext) { // you are inside KaSession Context
     // you can use a wide variety of Analysis API functions here: work with types, symbols, signatures, scopes and more.
 }
 ```
 ## Functions
 You may want to decompose your logic into functions. In such a case, add KaSession receiver to it. Such a thing should be done even if your function does not use the receiver. The approach may look cumbersome, but it is important to be sure that we do not publish resolution results. Publishing resolution results may cause memory leaks or working with out-of-date resolution results.
 ```kotlin
-analyse(psiElementForContext) {
+analyze(psiElementForContext) {
     val symbol = getSymbol()
     ...
 }

--- a/docs/analysis/analysis-api/analysis-api.md
+++ b/docs/analysis/analysis-api/analysis-api.md
@@ -49,11 +49,11 @@ analysis `KaSession` we can see only modules and libraries which are transitive 
 
 ## KaSession Scope
 
-All interaction with the Analysis API should be performed **only** in **KaSession Scope**. To enter such scope `analyse`
+All interaction with the Analysis API should be performed **only** in **KaSession Scope**. To enter such scope `analyze`
 function should be used:
 
 ```kotlin
-fun <R> analyse(contextElement: KtElement, action: KaSession.() -> R): R
+fun <R> analyze(contextElement: KtElement, action: KaSession.() -> R): R
 ```
 
 Where `action` lambda represents the **KaSession Scope**.
@@ -61,8 +61,8 @@ Where `action` lambda represents the **KaSession Scope**.
 ## Lifecycle Owners
 
 Every Lifecycle Owner has its lifecycle which is defined by corresponding `KaLifetimeToken`. There is a special
-function `analyseWithCustomToken` which allows specifying needed behaviour. There are also analyse function which is made for the IDE which
-analyses with `KaReadActionConfinementLifetimeToken`
+function `analyseWithCustomToken` which allows specifying needed behaviour. There are also analyze function which is made for the IDE which
+analyzes with `KaReadActionConfinementLifetimeToken`
 
 `KaReadActionConfinementLifetimeToken` has the following contracts:
 
@@ -71,7 +71,7 @@ analyses with `KaReadActionConfinementLifetimeToken`
         * If you have no choice consider using `analyseInModalWindow` function instead (but it may be rather slow and also shows a modal
           window, so use it with caution)
     * Analysis should be called from a **read action**
-    * Analysis should not be called outside **KaSession Scope** (i.e, outside `analyse(context) { ... }` lambda
+    * Analysis should not be called outside **KaSession Scope** (i.e, outside `analyze(context) { ... }` lambda
 * Validity contracts:
     * Lifecycle Owner is valid only inside Analysis Context it was created in.
 


### PR DESCRIPTION
The public API changed to use the spelling `analyze` instead of `analyse` in 2022 here: https://github.com/JetBrains/kotlin/commit/eb9085c083797cbeef080ab8cd37b8a384988078

This PR updates the documentation which refers to the public API so that it matches the current naming.

The current `analyze` public API resides here: https://github.com/JetBrains/kotlin/blob/master/analysis/analysis-api/src/org/jetbrains/kotlin/analysis/api/analyze.kt

Example: https://github.com/JetBrains/kotlin/blob/1b4864f0f20cad1b6175a2b0e37306985c378717/analysis/analysis-api/src/org/jetbrains/kotlin/analysis/api/analyze.kt#L39-L45