### PR TITLE
[KT-69003] Correct the return type of setters from `Boolean` to their return type (`Unit`)

### DIFF
--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/lower/InvokeOnExportedFunctionExitLowering.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/lower/InvokeOnExportedFunctionExitLowering.kt
@@ -72,7 +72,11 @@ internal class InvokeOnExportedFunctionExitLowering(val context: WasmBackendCont
                 irGet(irBooleanType, null, isNotFirstWasmExportCallGetter)
 
             val tryBody = irComposite {
-                +irSet(irBooleanType, null, isNotFirstWasmExportCallSetter, true.toIrConst(irBooleanType))
+                +irSet(
+                    isNotFirstWasmExportCallSetter.owner.returnType,
+                    null, isNotFirstWasmExportCallSetter,
+                    true.toIrConst(irBooleanType)
+                )
                 when (body) {
                     is IrBlockBody -> body.statements.forEach { +it }
                     is IrExpressionBody -> +body.expression
@@ -82,7 +86,7 @@ internal class InvokeOnExportedFunctionExitLowering(val context: WasmBackendCont
 
             val finally = irComposite(resultType = context.irBuiltIns.unitType) {
                 +irSet(
-                    type = irBooleanType,
+                    type = isNotFirstWasmExportCallSetter.owner.returnType,
                     receiver = null,
                     setterSymbol = isNotFirstWasmExportCallSetter,
                     value = irGet(currentIsNotFirstWasmExportCall, irBooleanType)

--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/lower/UnhandledExceptionLowering.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/lower/UnhandledExceptionLowering.kt
@@ -84,7 +84,11 @@ internal class UnhandledExceptionLowering(val context: WasmBackendContext) : Fil
                 irGet(irBooleanType, null, isNotFirstWasmExportCallGetter)
 
             val tryBody = irComposite {
-                +irSet(irBooleanType, null, isNotFirstWasmExportCallSetter, true.toIrConst(irBooleanType))
+                +irSet(
+                    isNotFirstWasmExportCallSetter.owner.returnType,
+                    null, isNotFirstWasmExportCallSetter,
+                    true.toIrConst(irBooleanType)
+                )
                 when (body) {
                     is IrBlockBody -> body.statements.forEach { +it }
                     is IrExpressionBody -> +body.expression
@@ -104,7 +108,7 @@ internal class UnhandledExceptionLowering(val context: WasmBackendContext) : Fil
 
 
             val finally = irSet(
-                type = irBooleanType,
+                type = isNotFirstWasmExportCallSetter.owner.returnType,
                 receiver = null,
                 setterSymbol = isNotFirstWasmExportCallSetter,
                 value = irGet(currentIsNotFirstWasmExportCall, irBooleanType)


### PR DESCRIPTION
This fixes a wrong return type (`Boolean`) of some setter functions, currently returning `Unit`.

This issue doesn't affect the code directly because of the `propertyAccessorInlinerLoweringPhase` optimization, which inlines setters and getters, essentially hiding the bug.

Without `propertyAccessorInlinerLoweringPhase`, the resulting Wasm code will not compile because of an illegal cast.

Here is the erroneous Wasm code that will be produced without `propertyAccessorInlinerLoweringPhase`:
```
i32.const 1
call $kotlin.wasm.internal.<set-isNotFirstWasmExportCall>___fun_1534
global.get $kotlin.Unit_instance___g_513
ref.cast $kotlin.Boolean___type_432  ;; <------------  Illegal cast here
struct.get_s $kotlin.Boolean___type_432 4
drop
```

https://youtrack.jetbrains.com/issue/KT-69003/Wasm-Setter-of-isNotFirstWasmExport-returns-a-Boolean-instead-of-a-Unit