### PR TITLE
Kotlin scripting considers <servers> section in maven settings during dependency resolution 

### DIFF
--- a/libraries/scripting/dependencies-maven/src/kotlin/script/experimental/dependencies/maven/MavenDependenciesResolver.kt
+++ b/libraries/scripting/dependencies-maven/src/kotlin/script/experimental/dependencies/maven/MavenDependenciesResolver.kt
@@ -103,7 +103,7 @@ class MavenDependenciesResolver(
     ): ResultWithDiagnostics<Boolean> {
         val url = repositoryCoordinates.toRepositoryUrlOrNull()
             ?: return false.asSuccess()
-        val repoId = repositoryCoordinates.string.replace(FORBIDDEN_CHARS, "_")
+        val repoId = options.mavenRepoId ?: repositoryCoordinates.string.replace(FORBIDDEN_CHARS, "_")
 
         val usernameRaw = options.username
         val passwordRaw = options.password

--- a/libraries/scripting/dependencies-maven/src/kotlin/script/experimental/dependencies/maven/impl/aether.kt
+++ b/libraries/scripting/dependencies-maven/src/kotlin/script/experimental/dependencies/maven/impl/aether.kt
@@ -307,17 +307,15 @@ internal class AetherResolveSession(
         val mirrorSelector = getMirrorSelector()
         val authenticationSelector = getAuthenticationSelector()
 
-        val mirror = mirrorSelector.getMirror(remote)
-
-        return if (mirror != null) {
-            RemoteRepository.Builder(mirror)
-                .setAuthentication(authenticationSelector.getAuthentication(mirror))
+        val finalServer = mirrorSelector.getMirror(remote) ?: remote
+        return if (finalServer.authentication == null) {
+            RemoteRepository.Builder(finalServer)
+                .setAuthentication(authenticationSelector.getAuthentication(finalServer))
                 .build()
         } else {
-            remote
+            finalServer
         }
     }
-
 
     private val settings: Settings by lazy {
         settingsFactory()

--- a/libraries/scripting/dependencies-maven/test/kotlin/script/experimental/test/AetherResolveSessionTest.kt
+++ b/libraries/scripting/dependencies-maven/test/kotlin/script/experimental/test/AetherResolveSessionTest.kt
@@ -45,6 +45,29 @@ class AetherResolveSessionTest : TestCase() {
         assertEquals("http://myMirror.org", result.url)
     }
 
+    fun testAuthenticateBasedOnId() {
+        val aether = sessionFrom(Settings().apply {
+            servers = listOf(Server().apply {
+                id = "myServer"
+                username = "myUsername"
+                password = "myPasswword"
+            })
+        })
+
+        val remote = RemoteRepository.Builder("myServer", "default", "http://example.org")
+            .build()
+        val result = aether.resolveRemote(remote)
+        assertEquals("myServer", result.id)
+        assertEquals("http://example.org", result.url)
+        assertEquals(
+            AuthenticationBuilder()
+                .addUsername("myUsername")
+                .addPassword("myPasswword")
+                .build(),
+            result.authentication
+        )
+    }
+
     fun testAuthenticateBasedOnIdWithMirror() {
         val aether = sessionFrom(Settings().apply {
             servers = listOf(

--- a/libraries/scripting/dependencies-maven/test/kotlin/script/experimental/test/AetherResolveSessionTest.kt
+++ b/libraries/scripting/dependencies-maven/test/kotlin/script/experimental/test/AetherResolveSessionTest.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package kotlin.script.experimental.test
+
+import junit.framework.TestCase
+import org.apache.maven.settings.Mirror
+import org.apache.maven.settings.Server
+import org.apache.maven.settings.Settings
+import org.eclipse.aether.repository.RemoteRepository
+import org.eclipse.aether.util.repository.AuthenticationBuilder
+import kotlin.script.experimental.dependencies.maven.impl.AetherResolveSession
+
+class AetherResolveSessionTest : TestCase() {
+
+    private fun sessionFrom(settings: Settings) = AetherResolveSession(settingsFactory = { settings })
+
+    fun testWorksWithEmptySettings() {
+        val aether = sessionFrom(Settings())
+
+        val remote = RemoteRepository.Builder("myServer", "default", "http://example.org")
+            .build()
+        val result = aether.resolveRemote(remote)
+        assertEquals("myServer", result.id)
+        assertEquals(null, result.authentication)
+        assertEquals("http://example.org", result.url)
+    }
+
+    fun testMirror() {
+        val aether = sessionFrom(Settings().apply {
+            mirrors = listOf(Mirror().apply {
+                id = "myMirror"
+                url = "http://myMirror.org"
+                mirrorOf = "*"
+            })
+        })
+
+        val remote = RemoteRepository.Builder("myServer", "default", "http://example.org")
+            .build()
+        val result = aether.resolveRemote(remote)
+        assertEquals("myMirror", result.id)
+        assertEquals(null, result.authentication)
+        assertEquals("http://myMirror.org", result.url)
+    }
+
+    fun testAuthenticateBasedOnIdWithMirror() {
+        val aether = sessionFrom(Settings().apply {
+            servers = listOf(
+                Server().apply {
+                    id = "myIServer"
+                    username = "myUsername"
+                    password = "myPasswword"
+                },
+                Server().apply {
+                    id = "myMirror"
+                    username = "myMirrorUsername"
+                    password = "myMirrorPassword"
+                },
+
+                )
+            mirrors = listOf(Mirror().apply {
+                id = "myMirror"
+                url = "http://myMirror.org"
+                mirrorOf = "*"
+            })
+
+        })
+
+        val remote = RemoteRepository.Builder("myServer", "default", "http://example.org")
+            .build()
+        val result = aether.resolveRemote(remote)
+        assertEquals("myMirror", result.id)
+        assertEquals("http://myMirror.org", result.url)
+        assertEquals(
+            AuthenticationBuilder()
+                .addUsername("myMirrorUsername")
+                .addPassword("myMirrorPassword")
+                .build(),
+            result.authentication
+        )
+    }
+
+    fun testDoNotOverwriteCredentials() {
+        val aether = sessionFrom(Settings().apply {
+            servers = listOf(Server().apply {
+                id = "myServer"
+                username = "myUsername"
+                password = "myPasswword"
+            })
+        })
+
+        val remote = RemoteRepository.Builder("myServer", "default", "http://example.org")
+            .setAuthentication(AuthenticationBuilder().addUsername("a").addPassword("b").build())
+            .build()
+        val result = aether.resolveRemote(remote)
+        assertEquals("myServer", result.id)
+        assertEquals("http://example.org", result.url)
+        assertEquals(
+            AuthenticationBuilder()
+                .addUsername("a")
+                .addPassword("b")
+                .build(),
+            result.authentication
+        )
+    }
+
+
+
+
+}

--- a/libraries/scripting/dependencies/src/kotlin/script/experimental/dependencies/impl/resolverNamedOptions.kt
+++ b/libraries/scripting/dependencies/src/kotlin/script/experimental/dependencies/impl/resolverNamedOptions.kt
@@ -30,7 +30,8 @@ enum class DependenciesResolverOptionsName(optionName: String? = null) {
     KEY_FILE,
     KEY_PASSPHRASE,
     CLASSIFIER,
-    EXTENSION;
+    EXTENSION,
+    MAVEN_REPOSITORY_ID;
 
     val key = optionName ?: name.lowercase()
 }
@@ -83,3 +84,9 @@ val ExternalDependenciesResolver.Options.classifier
  */
 val ExternalDependenciesResolver.Options.extension
     get() = value(DependenciesResolverOptionsName.EXTENSION)
+
+/**
+ * Id of the repository that is used to match against <server> in maven settings with the same id
+ */
+val ExternalDependenciesResolver.Options.mavenRepoId
+    get() = value(DependenciesResolverOptionsName.MAVEN_REPOSITORY_ID)


### PR DESCRIPTION
This PR contains two separate commits to address long standing issues around the support of maven settings during dependency resolution in kotlin scripts.

Related to discussion in KT-49511