### PR TITLE
[Test] Modified classes declared as inline class to value class

### DIFF
--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/inlineClassConstructor.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/inlineClassConstructor.kt
@@ -4,28 +4,35 @@
 import kotlin.reflect.KCallable
 import kotlin.test.assertEquals
 
-inline class Z(val x: Int) {
+@JvmInline
+value class Z(val x: Int) {
     constructor(a: Int, b: Int) : this(a + b)
 }
 
-inline class L(val x: Long) {
+@JvmInline
+value class L(val x: Long) {
     constructor(a: Long, b: Long) : this(a + b)
 }
 
-inline class S1(val x: String) {
+@JvmInline
+value class S1(val x: String) {
     constructor(a: String, b: String) : this(a + b)
 }
 
-inline class S2(val x: String?) {
+@JvmInline
+value class S2(val x: String?) {
     constructor(a: String?, b: String?) : this(a!! + b!!)
 }
 
-inline class A(val x: Any) {
+@JvmInline
+value class A(val x: Any) {
     constructor(a: String, b: String) : this(a + b)
 }
 
-inline class Z2(val z: Z)
-inline class Z3(val z: Z?)
+@JvmInline
+value class Z2(val z: Z)
+@JvmInline
+value class Z3(val z: Z?)
 
 fun box(): String {
     val ctorZ1_1: (Int) -> Z = ::Z

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/internalPrimaryValOfInlineClass.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/internalPrimaryValOfInlineClass.kt
@@ -3,16 +3,24 @@
 
 import kotlin.test.assertEquals
 
-inline class Z(internal val x: Int)
-inline class Z2(internal val x: Z)
+@JvmInline
+value class Z(internal val x: Int)
+@JvmInline
+value class Z2(internal val x: Z)
 
-inline class L(internal val x: Long)
-inline class L2(internal val x: L)
+@JvmInline
+value class L(internal val x: Long)
+@JvmInline
+value class L2(internal val x: L)
 
-inline class A1(internal val x: Any?)
-inline class A1_2(internal val x: A1)
-inline class A2(internal val x: Any)
-inline class A2_2(internal val x: A2)
+@JvmInline
+value class A1(internal val x: Any?)
+@JvmInline
+value class A1_2(internal val x: A1)
+@JvmInline
+value class A2(internal val x: Any)
+@JvmInline
+value class A2_2(internal val x: A2)
 
 fun box(): String {
     assertEquals(42, Z::x.call(Z(42)))

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/nonNullObject/constructorWithInlineClassParameters.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/nonNullObject/constructorWithInlineClassParameters.kt
@@ -3,7 +3,8 @@
 
 import kotlin.test.assertEquals
 
-inline class S(val x: String)
+@JvmInline
+value class S(val x: String)
 
 class Outer(val z1: S, val z2: S?) {
     inner class Inner(val z3: S, val z4: S?) {
@@ -11,14 +12,16 @@ class Outer(val z1: S, val z2: S?) {
     }
 }
 
-inline class InlineNonNullOuter(val z1: S) {
+@JvmInline
+value class InlineNonNullOuter(val z1: S) {
     @Suppress("INNER_CLASS_INSIDE_VALUE_CLASS")
     inner class Inner(val z2: S, val z3: S?) {
         val test = "$z1 $z2 $z3"
     }
 }
 
-inline class InlineNullableOuter(val z1: S?) {
+@JvmInline
+value class InlineNullableOuter(val z1: S?) {
     @Suppress("INNER_CLASS_INSIDE_VALUE_CLASS")
     inner class Inner(val z2: S, val z3: S?) {
         val test = "$z1 $z2 $z3"

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/nonNullObject/fieldAccessors.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/nonNullObject/fieldAccessors.kt
@@ -4,7 +4,8 @@
 import kotlin.reflect.jvm.isAccessible
 import kotlin.test.assertEquals
 
-inline class S(val value: String) {
+@JvmInline
+value class S(val value: String) {
     operator fun plus(other: S): S = S(this.value + other.value)
 }
 

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/nonNullObject/functionsWithInlineClassParameters.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/nonNullObject/functionsWithInlineClassParameters.kt
@@ -3,7 +3,8 @@
 
 import kotlin.test.assertEquals
 
-inline class S(val value: String) {
+@JvmInline
+value class S(val value: String) {
     operator fun plus(other: S): S = S(this.value + other.value)
 }
 

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/nonNullObject/jvmStaticFieldInObject.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/nonNullObject/jvmStaticFieldInObject.kt
@@ -6,7 +6,8 @@ import kotlin.reflect.KMutableProperty1
 import kotlin.reflect.jvm.isAccessible
 import kotlin.test.assertEquals
 
-inline class S(val value: String) {
+@JvmInline
+value class S(val value: String) {
     operator fun plus(other: S): S = S(this.value + other.value)
 }
 

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/nonNullObject/jvmStaticFunction.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/nonNullObject/jvmStaticFunction.kt
@@ -5,7 +5,8 @@
 import kotlin.reflect.KFunction
 import kotlin.test.assertEquals
 
-inline class S(val value: String) {
+@JvmInline
+value class S(val value: String) {
     operator fun plus(other: S): S = S(this.value + other.value)
 }
 

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/nonNullObject/nonOverridingFunOfInlineClass.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/nonNullObject/nonOverridingFunOfInlineClass.kt
@@ -3,15 +3,18 @@
 
 import kotlin.test.assertEquals
 
-inline class S(val x: String) {
+@JvmInline
+value class S(val x: String) {
     fun test(a: String, b: S, c: S?) = "$x$a${b.x}${c!!.x}"
 }
 
-inline class Z(val x: Int) {
+@JvmInline
+value class Z(val x: Int) {
     fun test(a: String, b: S, c: S?) = "$x$a${b.x}${c!!.x}"
 }
 
-inline class A(val x: Any) {
+@JvmInline
+value class A(val x: Any) {
     fun test(a: String, b: S, c: S?) = "$x$a${b.x}${c!!.x}"
 }
 

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/nonNullObject/nonOverridingVarOfInlineClass.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/nonNullObject/nonOverridingVarOfInlineClass.kt
@@ -5,7 +5,8 @@ import kotlin.test.assertEquals
 
 var global = S("")
 
-inline class S(val x: String) {
+@JvmInline
+value class S(val x: String) {
     var nonNullTest: S
         get() = S("${global.x}$x")
         set(value) {
@@ -19,7 +20,8 @@ inline class S(val x: String) {
         }
 }
 
-inline class Z(val x: Int) {
+@JvmInline
+value class Z(val x: Int) {
     var nonNullTest: S
         get() = S("${global.x}$x")
         set(value) {
@@ -33,7 +35,8 @@ inline class Z(val x: Int) {
         }
 }
 
-inline class A(val x: Any) {
+@JvmInline
+value class A(val x: Any) {
     var nonNullTest: S
         get() = S("${global.x}$x")
         set(value) {

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/nonNullObject/overridingFunOfInlineClass.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/nonNullObject/overridingFunOfInlineClass.kt
@@ -7,15 +7,18 @@ interface ITest {
     fun test(a: String, b: S, c: S?): String
 }
 
-inline class S(val x: String) : ITest {
+@JvmInline
+value class S(val x: String) : ITest {
     override fun test(a: String, b: S, c: S?) = "$x$a${b.x}${c!!.x}"
 }
 
-inline class Z(val x: Int) : ITest {
+@JvmInline
+value class Z(val x: Int) : ITest {
     override fun test(a: String, b: S, c: S?) = "$x$a${b.x}${c!!.x}"
 }
 
-inline class A(val x: Any) : ITest {
+@JvmInline
+value class A(val x: Any) : ITest {
     override fun test(a: String, b: S, c: S?) = "$x$a${b.x}${c!!.x}"
 }
 

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/nonNullObject/overridingVarOfInlineClass.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/nonNullObject/overridingVarOfInlineClass.kt
@@ -10,7 +10,8 @@ interface ITest {
     var nullableTest: S?
 }
 
-inline class S(val x: String) : ITest {
+@JvmInline
+value class S(val x: String) : ITest {
     override var nonNullTest: S
         get() = S("${global.x}$x")
         set(value) {
@@ -24,7 +25,8 @@ inline class S(val x: String) : ITest {
         }
 }
 
-inline class Z(val x: Int) : ITest {
+@JvmInline
+value class Z(val x: Int) : ITest {
     override var nonNullTest: S
         get() = S("${global.x}$x")
         set(value) {
@@ -38,7 +40,8 @@ inline class Z(val x: Int) : ITest {
         }
 }
 
-inline class A(val x: Any) : ITest {
+@JvmInline
+value class A(val x: Any) : ITest {
     override var nonNullTest: S
         get() = S("${global.x}$x")
         set(value) {

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/nonNullObject/properties.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/nonNullObject/properties.kt
@@ -4,7 +4,8 @@
 import kotlin.reflect.KMutableProperty2
 import kotlin.test.assertEquals
 
-inline class S(val value: String) {
+@JvmInline
+value class S(val value: String) {
     operator fun plus(other: S): S = S(this.value + other.value)
 }
 

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/nonNullObject/suspendFunction.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/nonNullObject/suspendFunction.kt
@@ -7,7 +7,8 @@ import kotlin.reflect.full.callSuspend
 import kotlin.test.assertEquals
 import helpers.*
 
-inline class S(val value: String)
+@JvmInline
+value class S(val value: String)
 
 class C {
     private var value: S = S("")

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/constructorWithInlineClassParameters.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/constructorWithInlineClassParameters.kt
@@ -3,7 +3,8 @@
 
 import kotlin.test.assertEquals
 
-inline class S(val x: String?)
+@JvmInline
+value class S(val x: String?)
 
 class Outer(val z1: S, val z2: S?) {
     inner class Inner(val z3: S, val z4: S?) {
@@ -11,14 +12,16 @@ class Outer(val z1: S, val z2: S?) {
     }
 }
 
-inline class InlineNonNullOuter(val z1: S) {
+@JvmInline
+value class InlineNonNullOuter(val z1: S) {
     @Suppress("INNER_CLASS_INSIDE_VALUE_CLASS")
     inner class Inner(val z2: S, val z3: S?) {
         val test = "$z1 $z2 $z3"
     }
 }
 
-inline class InlineNullableOuter(val z1: S?) {
+@JvmInline
+value class InlineNullableOuter(val z1: S?) {
     @Suppress("INNER_CLASS_INSIDE_VALUE_CLASS")
     inner class Inner(val z2: S, val z3: S?) {
         val test = "$z1 $z2 $z3"

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/fieldAccessors.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/fieldAccessors.kt
@@ -4,7 +4,8 @@
 import kotlin.reflect.jvm.isAccessible
 import kotlin.test.assertEquals
 
-inline class S(val value: String?) {
+@JvmInline
+value class S(val value: String?) {
     operator fun plus(other: S): S = S(this.value!! + other.value!!)
 }
 

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/functionsWithInlineClassParameters.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/functionsWithInlineClassParameters.kt
@@ -3,7 +3,8 @@
 
 import kotlin.test.assertEquals
 
-inline class S(val value: String?) {
+@JvmInline
+value class S(val value: String?) {
     operator fun plus(other: S): S = S(this.value + other.value)
 }
 

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/jvmStaticFieldInObject.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/jvmStaticFieldInObject.kt
@@ -6,7 +6,8 @@ import kotlin.reflect.KMutableProperty1
 import kotlin.reflect.jvm.isAccessible
 import kotlin.test.assertEquals
 
-inline class S(val value: String?) {
+@JvmInline
+value class S(val value: String?) {
     operator fun plus(other: S): S = S(this.value!! + other.value!!)
 }
 

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/jvmStaticFunction.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/jvmStaticFunction.kt
@@ -5,7 +5,8 @@
 import kotlin.reflect.KFunction
 import kotlin.test.assertEquals
 
-inline class S(val value: String?) {
+@JvmInline
+value class S(val value: String?) {
     operator fun plus(other: S): S = S(this.value!! + other.value!!)
 }
 

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/nonOverridingFunOfInlineClass.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/nonOverridingFunOfInlineClass.kt
@@ -3,15 +3,18 @@
 
 import kotlin.test.assertEquals
 
-inline class S(val x: String?) {
+@JvmInline
+value class S(val x: String?) {
     fun test(a: String, b: S, c: S?) = "$x$a${b.x}${c!!.x}"
 }
 
-inline class Z(val x: Int) {
+@JvmInline
+value class Z(val x: Int) {
     fun test(a: String, b: S, c: S?) = "$x$a${b.x}${c!!.x}"
 }
 
-inline class A(val x: Any) {
+@JvmInline
+value class A(val x: Any) {
     fun test(a: String, b: S, c: S?) = "$x$a${b.x}${c!!.x}"
 }
 

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/nonOverridingVarOfInlineClass.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/nonOverridingVarOfInlineClass.kt
@@ -5,7 +5,8 @@ import kotlin.test.assertEquals
 
 var global = S("")
 
-inline class S(val x: String?) {
+@JvmInline
+value class S(val x: String?) {
     var nonNullTest: S
         get() = S("${global.x}$x")
         set(value) {
@@ -19,7 +20,8 @@ inline class S(val x: String?) {
         }
 }
 
-inline class Z(val x: Int) {
+@JvmInline
+value class Z(val x: Int) {
     var nonNullTest: S
         get() = S("${global.x}$x")
         set(value) {
@@ -33,7 +35,8 @@ inline class Z(val x: Int) {
         }
 }
 
-inline class A(val x: Any) {
+@JvmInline
+value class A(val x: Any) {
     var nonNullTest: S
         get() = S("${global.x}$x")
         set(value) {

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/overridingFunOfInlineClass.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/overridingFunOfInlineClass.kt
@@ -7,15 +7,18 @@ interface ITest {
     fun test(a: String, b: S, c: S?): String
 }
 
-inline class S(val x: String?) : ITest {
+@JvmInline
+value class S(val x: String?) : ITest {
     override fun test(a: String, b: S, c: S?) = "$x$a${b.x}${c!!.x}"
 }
 
-inline class Z(val x: Int) : ITest {
+@JvmInline
+value class Z(val x: Int) : ITest {
     override fun test(a: String, b: S, c: S?) = "$x$a${b.x}${c!!.x}"
 }
 
-inline class A(val x: Any) : ITest {
+@JvmInline
+value class A(val x: Any) : ITest {
     override fun test(a: String, b: S, c: S?) = "$x$a${b.x}${c!!.x}"
 }
 

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/overridingVarOfInlineClass.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/overridingVarOfInlineClass.kt
@@ -10,7 +10,8 @@ interface ITest {
     var nullableTest: S?
 }
 
-inline class S(val x: String?) : ITest {
+@JvmInline
+value class S(val x: String?) : ITest {
     override var nonNullTest: S
         get() = S("${global.x}$x")
         set(value) {
@@ -24,7 +25,8 @@ inline class S(val x: String?) : ITest {
         }
 }
 
-inline class Z(val x: Int) : ITest {
+@JvmInline
+value class Z(val x: Int) : ITest {
     override var nonNullTest: S
         get() = S("${global.x}$x")
         set(value) {
@@ -38,7 +40,8 @@ inline class Z(val x: Int) : ITest {
         }
 }
 
-inline class A(val x: Any) : ITest {
+@JvmInline
+value class A(val x: Any) : ITest {
     override var nonNullTest: S
         get() = S("${global.x}$x")
         set(value) {

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/properties.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/properties.kt
@@ -4,7 +4,8 @@
 import kotlin.reflect.KMutableProperty2
 import kotlin.test.assertEquals
 
-inline class S(val value: String?) {
+@JvmInline
+value class S(val value: String?) {
     operator fun plus(other: S): S = S(this.value!! + other.value!!)
 }
 

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/suspendFunction.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/nullableObject/suspendFunction.kt
@@ -7,7 +7,8 @@ import kotlin.reflect.full.callSuspend
 import kotlin.test.assertEquals
 import helpers.*
 
-inline class S(val value: String?)
+@JvmInline
+value class S(val value: String?)
 
 class C {
     private var value: S = S("")

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/primaryValOfInlineClass.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/primaryValOfInlineClass.kt
@@ -3,17 +3,25 @@
 
 import kotlin.test.assertEquals
 
-inline class Z(val x: Int)
-inline class Z2(val x: Z)
+@JvmInline
+value class Z(val x: Int)
+@JvmInline
+value class Z2(val x: Z)
 
-inline class L(val x: Long)
-inline class L2(val x: L)
+@JvmInline
+value class L(val x: Long)
+@JvmInline
+value class L2(val x: L)
 
-inline class A1(val x: Any?)
-inline class A1_2(val x: A1)
+@JvmInline
+value class A1(val x: Any?)
+@JvmInline
+value class A1_2(val x: A1)
 
-inline class A2(val x: Any)
-inline class A2_2(val x: A2)
+@JvmInline
+value class A2(val x: Any)
+@JvmInline
+value class A2_2(val x: A2)
 
 fun box(): String {
     assertEquals(42, Z::x.call(Z(42)))

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/primitive/constructorWithInlineClassParameters.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/primitive/constructorWithInlineClassParameters.kt
@@ -3,7 +3,8 @@
 
 import kotlin.test.assertEquals
 
-inline class Z(val x: Int)
+@JvmInline
+value class Z(val x: Int)
 
 class Outer(val z1: Z, val z2: Z?) {
     inner class Inner(val z3: Z, val z4: Z?) {
@@ -11,14 +12,16 @@ class Outer(val z1: Z, val z2: Z?) {
     }
 }
 
-inline class InlineNonNullOuter(val z1: Z) {
+@JvmInline
+value class InlineNonNullOuter(val z1: Z) {
     @Suppress("INNER_CLASS_INSIDE_VALUE_CLASS")
     inner class Inner(val z2: Z, val z3: Z?) {
         val test = "$z1 $z2 $z3"
     }
 }
 
-inline class InlineNullableOuter(val z1: Z?) {
+@JvmInline
+value class InlineNullableOuter(val z1: Z?) {
     @Suppress("INNER_CLASS_INSIDE_VALUE_CLASS")
     inner class Inner(val z2: Z, val z3: Z?) {
         val test = "$z1 $z2 $z3"

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/primitive/fieldAccessors.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/primitive/fieldAccessors.kt
@@ -4,7 +4,8 @@
 import kotlin.reflect.jvm.isAccessible
 import kotlin.test.assertEquals
 
-inline class S(val value: Int) {
+@JvmInline
+value class S(val value: Int) {
     operator fun plus(other: S): S = S(this.value + other.value)
 }
 

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/primitive/functionsWithInlineClassParameters.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/primitive/functionsWithInlineClassParameters.kt
@@ -3,7 +3,8 @@
 
 import kotlin.test.assertEquals
 
-inline class S(val value: Int) {
+@JvmInline
+value class S(val value: Int) {
     operator fun plus(other: S): S = S(this.value + other.value)
 }
 

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/primitive/jvmStaticFieldInObject.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/primitive/jvmStaticFieldInObject.kt
@@ -6,7 +6,8 @@ import kotlin.reflect.KMutableProperty1
 import kotlin.reflect.jvm.isAccessible
 import kotlin.test.assertEquals
 
-inline class Z(val value: Int) {
+@JvmInline
+value class Z(val value: Int) {
     operator fun plus(other: Z): Z = Z(this.value + other.value)
 }
 

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/primitive/jvmStaticFunction.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/primitive/jvmStaticFunction.kt
@@ -5,7 +5,8 @@
 import kotlin.reflect.KFunction
 import kotlin.test.assertEquals
 
-inline class Z(val value: Int) {
+@JvmInline
+value class Z(val value: Int) {
     operator fun plus(other: Z): Z = Z(this.value + other.value)
 }
 

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/primitive/nonOverridingFunOfInlineClass.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/primitive/nonOverridingFunOfInlineClass.kt
@@ -3,15 +3,18 @@
 
 import kotlin.test.assertEquals
 
-inline class Z(val x: Int) {
+@JvmInline
+value class Z(val x: Int) {
     fun test(a: Int, b: Z, c: Z?) = "$x$a${b.x}${c!!.x}"
 }
 
-inline class S(val x: String) {
+@JvmInline
+value class S(val x: String) {
     fun test(a: Int, b: Z, c: Z?) = "$x$a${b.x}${c!!.x}"
 }
 
-inline class A(val x: Any) {
+@JvmInline
+value class A(val x: Any) {
     fun test(a: Int, b: Z, c: Z?) = "$x$a${b.x}${c!!.x}"
 }
 

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/primitive/nonOverridingVarOfInlineClass.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/primitive/nonOverridingVarOfInlineClass.kt
@@ -5,7 +5,8 @@ import kotlin.test.assertEquals
 
 var global = Z(0)
 
-inline class Z(val x: Int) {
+@JvmInline
+value class Z(val x: Int) {
     var nonNullTest: Z
         get() = Z(global.x + this.x)
         set(value) {
@@ -19,7 +20,8 @@ inline class Z(val x: Int) {
         }
 }
 
-inline class S(val x: String) {
+@JvmInline
+value class S(val x: String) {
     var nonNullTest: Z
         get() = Z(global.x + x.toInt())
         set(value) {
@@ -33,7 +35,8 @@ inline class S(val x: String) {
         }
 }
 
-inline class A(val x: Any) {
+@JvmInline
+value class A(val x: Any) {
     var nonNullTest: Z
         get() = Z(global.x + this.x as Int)
         set(value) {

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/primitive/overridingFunOfInlineClass.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/primitive/overridingFunOfInlineClass.kt
@@ -7,15 +7,18 @@ interface ITest {
     fun test(a: Int, b: Z, c: Z?): String
 }
 
-inline class Z(val x: Int) : ITest {
+@JvmInline
+value class Z(val x: Int) : ITest {
     override fun test(a: Int, b: Z, c: Z?) = "$x$a${b.x}${c!!.x}"
 }
 
-inline class S(val x: String) : ITest {
+@JvmInline
+value class S(val x: String) : ITest {
     override fun test(a: Int, b: Z, c: Z?) = "$x$a${b.x}${c!!.x}"
 }
 
-inline class A(val x: Any) : ITest {
+@JvmInline
+value class A(val x: Any) : ITest {
     override fun test(a: Int, b: Z, c: Z?) = "$x$a${b.x}${c!!.x}"
 }
 

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/primitive/overridingVarOfInlineClass.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/primitive/overridingVarOfInlineClass.kt
@@ -10,7 +10,8 @@ interface ITest {
     var nullableTest: Z?
 }
 
-inline class Z(val x: Int) : ITest {
+@JvmInline
+value class Z(val x: Int) : ITest {
     override var nonNullTest: Z
         get() = Z(global.x + this.x)
         set(value) {
@@ -24,7 +25,8 @@ inline class Z(val x: Int) : ITest {
         }
 }
 
-inline class S(val x: String) : ITest {
+@JvmInline
+value class S(val x: String) : ITest {
     override var nonNullTest: Z
         get() = Z(global.x + x.toInt())
         set(value) {
@@ -38,7 +40,8 @@ inline class S(val x: String) : ITest {
         }
 }
 
-inline class A(val x: Any) : ITest {
+@JvmInline
+value class A(val x: Any) : ITest {
     override var nonNullTest: Z
         get() = Z(global.x + this.x as Int)
         set(value) {

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/primitive/properties.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/primitive/properties.kt
@@ -4,7 +4,8 @@
 import kotlin.reflect.KMutableProperty2
 import kotlin.test.assertEquals
 
-inline class Z(val value: Int) {
+@JvmInline
+value class Z(val value: Int) {
     operator fun plus(other: Z): Z = Z(this.value + other.value)
 }
 

--- a/compiler/testData/codegen/box/reflection/call/inlineClasses/primitive/suspendFunction.kt
+++ b/compiler/testData/codegen/box/reflection/call/inlineClasses/primitive/suspendFunction.kt
@@ -7,7 +7,8 @@ import kotlin.reflect.full.callSuspend
 import kotlin.test.assertEquals
 import helpers.*
 
-inline class Z(val value: Int)
+@JvmInline
+value class Z(val value: Int)
 
 class C {
     private var value: Z = Z(0)

--- a/compiler/testData/codegen/box/reflection/callBy/inlineClassDefaultArguments.kt
+++ b/compiler/testData/codegen/box/reflection/callBy/inlineClassDefaultArguments.kt
@@ -3,7 +3,8 @@
 
 import kotlin.test.assertEquals
 
-inline class A(val x: Int)
+@JvmInline
+value class A(val x: Int)
 
 fun test1(x: A = A(0)) = "OK"
 

--- a/compiler/testData/codegen/box/reflection/callBy/inlineClassFunctionsAndConstructors.kt
+++ b/compiler/testData/codegen/box/reflection/callBy/inlineClassFunctionsAndConstructors.kt
@@ -3,7 +3,8 @@
 
 import kotlin.test.assertEquals
 
-inline class S(val value: String) {
+@JvmInline
+value class S(val value: String) {
     operator fun plus(other: S): S = S(this.value + other.value)
 }
 

--- a/compiler/testData/codegen/box/reflection/callBy/inlineClassInterface.kt
+++ b/compiler/testData/codegen/box/reflection/callBy/inlineClassInterface.kt
@@ -11,7 +11,8 @@ interface IIC {
     fun f(i1: Int = 1): Int
 }
 
-inline class IC(val x: Int) : IIC {
+@JvmInline
+value class IC(val x: Int) : IIC {
     override fun f(i1: Int) = x + i1
 }
 

--- a/compiler/testData/codegen/box/reflection/callBy/inlineClassInterfaceJvmDefault.kt
+++ b/compiler/testData/codegen/box/reflection/callBy/inlineClassInterfaceJvmDefault.kt
@@ -12,7 +12,8 @@ interface IIC {
     fun f(i1: Int = 1): Int
 }
 
-inline class IC(val x: Int) : IIC {
+@JvmInline
+value class IC(val x: Int) : IIC {
     override fun f(i1: Int) = x + i1
 }
 

--- a/compiler/testData/codegen/box/reflection/callBy/inlineClassMembers.kt
+++ b/compiler/testData/codegen/box/reflection/callBy/inlineClassMembers.kt
@@ -10,7 +10,8 @@ interface IFoo {
 var global = Z(0)
 
 
-inline class Z(val x: Int) : IFoo {
+@JvmInline
+value class Z(val x: Int) : IFoo {
 
     override fun fooFun(z: Z): Z = Z(z.x + x)
 

--- a/compiler/testData/codegen/box/reflection/lambdaClasses/reflectOnDefaultWithInlineClassArgument.kt
+++ b/compiler/testData/codegen/box/reflection/lambdaClasses/reflectOnDefaultWithInlineClassArgument.kt
@@ -5,7 +5,8 @@
 
 import kotlin.reflect.jvm.reflect
 
-inline class C(val x: Int)
+@JvmInline
+value class C(val x: Int)
 
 fun C.f(x: (String) -> Unit = { OK: String -> }) = x.reflect()?.parameters?.singleOrNull()?.name
 

--- a/compiler/testData/codegen/box/reflection/mapping/constructorWithInlineClassParameters.kt
+++ b/compiler/testData/codegen/box/reflection/mapping/constructorWithInlineClassParameters.kt
@@ -5,7 +5,8 @@ import kotlin.reflect.jvm.javaConstructor
 import kotlin.reflect.jvm.kotlinFunction
 import kotlin.test.assertEquals
 
-inline class Z(val x: Int)
+@JvmInline
+value class Z(val x: Int)
 
 class Test(val x: Z)
 

--- a/compiler/testData/codegen/box/reflection/mapping/inlineClasses/inlineClassPrimaryVal.kt
+++ b/compiler/testData/codegen/box/reflection/mapping/inlineClasses/inlineClassPrimaryVal.kt
@@ -4,21 +4,24 @@
 import kotlin.reflect.jvm.*
 import kotlin.test.assertEquals
 
-inline class Z1(val publicX: Int) {
+@JvmInline
+value class Z1(val publicX: Int) {
     companion object {
         val publicXRef = Z1::publicX
         val publicXBoundRef = Z1(42)::publicX
     }
 }
 
-inline class Z2(internal val internalX: Int) {
+@JvmInline
+value class Z2(internal val internalX: Int) {
     companion object {
         val internalXRef = Z2::internalX
         val internalXBoundRef = Z2(42)::internalX
     }
 }
 
-inline class Z3(private val privateX: Int) {
+@JvmInline
+value class Z3(private val privateX: Int) {
     companion object {
         val privateXRef = Z3::privateX
         val privateXBoundRef = Z3(42)::privateX

--- a/compiler/testData/codegen/box/reflection/mapping/inlineClasses/suspendFunctionWithInlineClassInSignature.kt
+++ b/compiler/testData/codegen/box/reflection/mapping/inlineClasses/suspendFunctionWithInlineClassInSignature.kt
@@ -8,7 +8,8 @@ import kotlin.reflect.jvm.*
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-inline class Z(val value: String)
+@JvmInline
+value class Z(val value: String)
 
 class S {
     suspend fun consumeZ(z: Z) {}

--- a/compiler/testData/codegen/box/reflection/mapping/types/inlineClassInSignature.kt
+++ b/compiler/testData/codegen/box/reflection/mapping/types/inlineClassInSignature.kt
@@ -4,11 +4,13 @@
 import kotlin.reflect.jvm.*
 import kotlin.test.assertEquals
 
-inline class S(val value: String)
+@JvmInline
+value class S(val value: String)
 
 fun S.foo(x: Int, s: S): S = this
 
-inline class T(val s: S) {
+@JvmInline
+value class T(val s: S) {
     fun bar(u: S): T = this
 }
 

--- a/compiler/testData/codegen/box/reflection/mapping/types/inlineClassPrimaryVal.kt
+++ b/compiler/testData/codegen/box/reflection/mapping/types/inlineClassPrimaryVal.kt
@@ -6,28 +6,32 @@ import kotlin.reflect.KCallable
 import kotlin.reflect.jvm.*
 import kotlin.test.assertEquals
 
-inline class Z1(val publicX: Int) {
+@JvmInline
+value class Z1(val publicX: Int) {
     companion object {
         val publicXRef = Z1::publicX
         val publicXBoundRef = Z1(42)::publicX
     }
 }
 
-inline class Z2(internal val internalX: Int) {
+@JvmInline
+value class Z2(internal val internalX: Int) {
     companion object {
         val internalXRef = Z2::internalX
         val internalXBoundRef = Z2(42)::internalX
     }
 }
 
-inline class Z3(private val privateX: Int) {
+@JvmInline
+value class Z3(private val privateX: Int) {
     companion object {
         val privateXRef = Z3::privateX
         val privateXBoundRef = Z3(42)::privateX
     }
 }
 
-inline class ZZ(val x: Z1)
+@JvmInline
+value class ZZ(val x: Z1)
 
 fun KCallable<*>.getJavaTypesOfParams() = parameters.map { it.type.javaType }.toString()
 fun KCallable<*>.getJavaTypeOfResult() = returnType.javaType.toString()

--- a/compiler/testData/codegen/box/reflection/typeOf/inlineClasses.kt
+++ b/compiler/testData/codegen/box/reflection/typeOf/inlineClasses.kt
@@ -8,8 +8,7 @@ import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 import kotlin.test.assertEquals
 
-@JvmInline
-value class Z(val value: String)
+inline class Z(val value: String)
 
 fun check(expected: String, actual: KType) {
     assertEquals(expected, actual.toString())

--- a/compiler/testData/codegen/box/reflection/typeOf/inlineClasses.kt
+++ b/compiler/testData/codegen/box/reflection/typeOf/inlineClasses.kt
@@ -8,7 +8,8 @@ import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 import kotlin.test.assertEquals
 
-inline class Z(val value: String)
+@JvmInline
+value class Z(val value: String)
 
 fun check(expected: String, actual: KType) {
     assertEquals(expected, actual.toString())

--- a/compiler/testData/codegen/box/reflection/typeOf/js/inlineClasses.kt
+++ b/compiler/testData/codegen/box/reflection/typeOf/js/inlineClasses.kt
@@ -8,8 +8,7 @@ import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 import kotlin.test.assertEquals
 
-@JvmInline
-value class Z(val value: String)
+inline class Z(val value: String)
 
 fun check(expected: String, actual: KType) {
     assertEquals(expected, actual.toString())

--- a/compiler/testData/codegen/box/reflection/typeOf/js/inlineClasses.kt
+++ b/compiler/testData/codegen/box/reflection/typeOf/js/inlineClasses.kt
@@ -8,7 +8,8 @@ import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 import kotlin.test.assertEquals
 
-inline class Z(val value: String)
+@JvmInline
+value class Z(val value: String)
 
 fun check(expected: String, actual: KType) {
     assertEquals(expected, actual.toString())

--- a/compiler/testData/codegen/box/reflection/typeOf/noReflect/inlineClasses.kt
+++ b/compiler/testData/codegen/box/reflection/typeOf/noReflect/inlineClasses.kt
@@ -7,7 +7,8 @@ import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 import kotlin.test.assertEquals
 
-inline class Z(val value: String)
+@JvmInline
+value class Z(val value: String)
 
 fun check(expected: String, actual: KType) {
     assertEquals(expected + " (Kotlin reflection is not available)", actual.toString())


### PR DESCRIPTION
This is due to the following comment received in a previously submitted PR.
https://github.com/JetBrains/kotlin/pull/5269#discussion_r1500530556

Since this is a preparation for the addition of a new test, the scope of the correction is limited to `compiler/testData/codegen/box/reflection`.