### PR TITLE
Fix stability inferencing of interfaces on incremental compilation

### DIFF
--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/analysis/Stability.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/analysis/Stability.kt
@@ -277,6 +277,10 @@ class StabilityInferencer(
                 mask = externalTypeMatcherCollection
                     .maskForName(declaration.fqNameWhenAvailable) ?: 0
                 stability = Stability.Stable
+            } else if (declaration.isInterface && declaration.isInCurrentModule()) {
+                // trying to avoid extracting stability bitmask for interfaces in current module
+                // to support incremental compilation
+                return Stability.Unknown(declaration)
             } else {
                 val bitmask = declaration.stabilityParamBitmask() ?: return Stability.Unstable
 


### PR DESCRIPTION
Sometimes during incremental compilation, interfaces located in the current module are considered unstable because Compose Compiler cannot extract the bitmask from them, even though these interfaces were inferenced as uncertain (or unknown) on a previous compilation

https://github.com/JetBrains/kotlin/blob/4376a03f224f66fea0e0f21072ffd605cebec433/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/analysis/Stability.kt#L315-L317



