### PR TITLE
Fix directory creation race condition

### DIFF
--- a/generators/main/GeneratorsFileUtil.kt
+++ b/generators/main/GeneratorsFileUtil.kt
@@ -35,7 +35,7 @@ object GeneratorsFileUtil {
             }
             if (parentFile.mkdirs()) {
                 println("Directory created: " + parentFile.absolutePath)
-            } else {
+            } else if (!parentFile.exists()) {
                 throw IllegalStateException("Cannot create directory: $parentFile")
             }
         }


### PR DESCRIPTION
Test generation has been parallelized in https://github.com/JetBrains/kotlin/commit/bb8a46c3a0d69ffe57abbbe43e28afd434430fdf.
This however creates a race condition in case a directory needs to be created for multiple tests.
`mkdirs` only returns `true` if the directory was actually created, adding an additional check on the existence of the directory should solve that. 