### PR TITLE
KT-69805: YarnSetupTask work with both custom and default downloads

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/yarn/YarnSetupTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/yarn/YarnSetupTask.kt
@@ -29,14 +29,10 @@ abstract class YarnSetupTask : AbstractSetupTask<YarnEnv, YarnRootExtension>() {
         get() = "yarn"
 
     override fun extract(archive: File) {
-        val dirInTar = archive.name.removeSuffix(".tar.gz")
         fs.copy {
             it.from(archiveOperations.tarTree(archive))
             it.into(destination.parentFile)
             it.includeEmptyDirs = false
-            it.eachFile { fileCopy ->
-                fileCopy.path = fileCopy.path.removePrefix(dirInTar)
-            }
         }
     }
 


### PR DESCRIPTION
Specifying a custom `downloadBaseUrl` for Yarn causes a `NullPointerException` as the file content is not extracted to match the destination field. 

This works for the default due to the downloaded tar archive name having a different name than the top-level directory in the tar, meaning the removePrefix actually did nothing. Remove altogether. 

More detailed explanation in: https://youtrack.jetbrains.com/issue/KT-69805/YarnSetupTask-does-not-work-for-custom-downloadBaseUrl