### PR TITLE
[KT-69845][Compose] Fix the setting of the annotations of the IrClass instead of the annotations of the IrFunctionBuilder

### DIFF
--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/AbstractComposeLowering.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/AbstractComposeLowering.kt
@@ -944,13 +944,13 @@ abstract class AbstractComposeLowering(
             returnType = stabilityField.type
             visibility = DescriptorVisibilities.PUBLIC
             origin = IrDeclarationOrigin.GeneratedByPlugin(ComposeCompilerKey)
-            annotations = listOf(hiddenFromObjCAnnotation)
         }.also { fn ->
             fn.parent = parent
             fn.body = DeclarationIrBuilder(context, fn.symbol).irBlockBody {
                 +irReturn(irGetField(stabilityField))
             }
             parent.addChild(fn)
+            fn.annotations = listOf(hiddenFromObjCAnnotation)
         }
 
         context.metadataDeclarationRegistrar.addMetadataVisibleAnnotationsToElement(stabilityGetter, hiddenFromObjCAnnotation)


### PR DESCRIPTION
AbstractComposeLowering.kt:947 sets the annotations of the extension receiver IrClass instead of the IrFunctionBuilder.

This has resulted in some failure cases, like having Compose with Wasm example that is using the `@Serializable` annotation fail because this line was removing the `@Serializable` annotation when Compose is run first.

Failure examples are attached at https://youtrack.jetbrains.com/issue/KT-69845