### PR TITLE
[KT-70029] Allow setting of configFile

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinBrowserJsIr.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinBrowserJsIr.kt
@@ -279,6 +279,8 @@ abstract class KotlinBrowserJsIr @Inject constructor(target: KotlinJsIrTarget) :
 
         this.inputFilesDirectory.set(inputFilesDirectory)
 
+        this.configFile.set(project.file(npmProjectDir.map { it.resolve("webpack.config.js") }))
+
         val platformType = binary.compilation.platformType
         val moduleKind = binary.linkTask.flatMap { task ->
             task.compilerOptions.moduleKind.orElse(task.compilerOptions.target.map {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/webpack/KotlinWebpack.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/webpack/KotlinWebpack.kt
@@ -12,6 +12,7 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileTree
 import org.gradle.api.file.FileTreeElement
 import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
@@ -131,8 +132,7 @@ constructor(
     internal var resolveFromModulesFirst: Boolean = false
 
     @get:OutputFile
-    open val configFile: Provider<File> =
-        npmProjectDir.map { it.resolve("webpack.config.js") }
+    abstract val configFile: RegularFileProperty
 
     @Nested
     val output: KotlinWebpackOutput = KotlinWebpackOutput(
@@ -274,7 +274,7 @@ constructor(
         return KotlinWebpackRunner(
             npmProject,
             logger,
-            configFile.get(),
+            configFile.get().asFile,
             execHandleFactory,
             bin,
             webpackArgs,
@@ -293,7 +293,7 @@ constructor(
         val runner = createRunner()
 
         if (generateConfigOnly) {
-            runner.config.save(configFile.get())
+            runner.config.save(configFile.get().asFile)
             return
         }
 


### PR DESCRIPTION
The tasks:

```
"wasmJsBrowserDevelopmentWebpack",
"wasmJsBrowserDevelopmentRun",
"wasmJsBrowserProductionWebpack",
"wasmJsBrowserProductionRun",
```

of type `KotlinWebpack` have the same output configFile file:
```
projectBuildDir/js/packages/projectName-wasm-js/webpack.config.js
```

I want to be able to set these to different locations.
