### PR TITLE
[BT] Add support for SourcesChanges.ToBeCalculated

### DIFF
--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/icAdapters.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/icAdapters.kt
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.incremental.ClasspathSnapshotFiles
 internal val SourcesChanges.asChangedFiles
     get() = when (this) {
         is SourcesChanges.Known -> ChangedFiles.Known(modifiedFiles, removedFiles)
-        is SourcesChanges.ToBeCalculated -> ChangedFiles.Unknown() // TODO: add proper support for SourcesChanges.ToBeCalculated
+        is SourcesChanges.ToBeCalculated -> null
         is SourcesChanges.Unknown -> ChangedFiles.Unknown()
     }
 


### PR DESCRIPTION
[KT-70556](https://youtrack.jetbrains.com/issue/KT-70556)

Currently, the conversion from `org.jetbrains.kotlin.buildtools.api.SourcesChanges.ToBeCalculated` to `org.jetbrains.kotlin.incremental.ChangedFiles` results in the use of `ChangedFiles.Unknown` ([codepointer](https://github.com/JetBrains/kotlin/blob/f8232c95542812fe88b081beb494039e6dd4c67f/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/icAdapters.kt#L18)). This configuration triggers a rebuild of the whole module ([codepointer](https://github.com/JetBrains/kotlin/blob/f8232c95542812fe88b081beb494039e6dd4c67f/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/IncrementalCompilerRunner.kt#L192)).

Instead of using `ChangedFiles.Unknown`, I propose returning `null` to prompt the IC to track the file changes.

**Testing**
```
./gradlew :compiler:build-tools:kotlin-build-tools-api-tests:check

Reusing configuration cache.

BUILD SUCCESSFUL in 40s
366 actionable tasks: 163 executed, 193 from cache, 10 up-to-date

Publishing build scan...
https://gradle.com/s/eha7w77c4ygvi

Configuration cache entry reused.
```

