### PR TITLE
Fix the links in ComposeCompilerGradlePluginExtension

### DIFF
--- a/libraries/tools/kotlin-compose-compiler/src/common/kotlin/org/jetbrains/kotlin/compose/compiler/gradle/ComposeCompilerGradlePluginExtension.kt
+++ b/libraries/tools/kotlin-compose-compiler/src/common/kotlin/org/jetbrains/kotlin/compose/compiler/gradle/ComposeCompilerGradlePluginExtension.kt
@@ -49,7 +49,7 @@ abstract class ComposeCompilerGradlePluginExtension @Inject constructor(objectFa
      * number of stable classes/parameters, skippable functions, etc.
      *
      * For more information, see these links:
-     *  - [AndroidX compiler metrics](https://github.com/androidx/androidx/blob/androidx-main/compose/compiler/design/compiler-metrics.md)
+     *  - [AndroidX compiler metrics](https://github.com/JetBrains/kotlin/blob/master/plugins/compose/design/compiler-metrics.md)
      *  - [Composable metrics blog post](https://chrisbanes.me/posts/composable-metrics/)
      */
     abstract val metricsDestination: DirectoryProperty
@@ -62,7 +62,7 @@ abstract class ComposeCompilerGradlePluginExtension @Inject constructor(objectFa
      * which are restartable, which are readonly, etc.
      *
      * For more information, see these links:
-     *  - [AndroidX compiler metrics](https://github.com/androidx/androidx/blob/androidx-main/compose/compiler/design/compiler-metrics.md)
+     *  - [AndroidX compiler metrics](https://github.com/JetBrains/kotlin/blob/master/plugins/compose/design/compiler-metrics.md)
      *  - [Composable metrics blog post](https://chrisbanes.me/posts/composable-metrics/)
      */
     abstract val reportsDestination: DirectoryProperty
@@ -107,7 +107,7 @@ abstract class ComposeCompilerGradlePluginExtension @Inject constructor(objectFa
      * unstable parameters become skippable and lambdas with unstable captures will be memoized.
      *
      * For more information, see this link:
-     *  - [AndroidX strong skipping](https://github.com/androidx/androidx/blob/androidx-main/compose/compiler/design/strong-skipping.md)
+     *  - [AndroidX strong skipping](https://github.com/JetBrains/kotlin/blob/master/plugins/compose/design/strong-skipping.md)
      */
     @Deprecated("Use the featureFlags option instead")
     val enableStrongSkippingMode: Property<Boolean> = objectFactory.property(Boolean::class.java).convention(true)


### PR DESCRIPTION
They the referenced markdown documents have moved.