### PR TITLE
Fix nested inc and dec operator extensions

### DIFF
--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/declarations/OperatorFunctionChecks.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/declarations/OperatorFunctionChecks.kt
@@ -130,7 +130,7 @@ object OperatorFunctionChecks {
             setOf(OperatorNameConventions.INC, OperatorNameConventions.DEC),
             Checks.memberOrExtension,
             Checks.full("receiver must be a supertype of the return type") { session, function ->
-                val receiver = function.dispatchReceiverType ?: function.receiverParameter?.typeRef?.coneType ?: return@full false
+                val receiver = function.receiverParameter?.typeRef?.coneType ?: function.dispatchReceiverType ?: return@full false
                 function.returnTypeRef.coneType.isSubtypeOf(session.typeContext, receiver)
             }
         )

--- a/compiler/testData/diagnostics/tests/OperatorChecks.kt
+++ b/compiler/testData/diagnostics/tests/OperatorChecks.kt
@@ -96,6 +96,13 @@ interface Example3 {
     <!INAPPLICABLE_OPERATOR_MODIFIER!>operator<!> fun contains(n: Int)
 }
 
+interface DispatchReceiverType {
+    interface ExtensionReceiverType
+
+    operator fun ExtensionReceiverType.inc(): ExtensionReceiverType
+    <!INAPPLICABLE_OPERATOR_MODIFIER!>operator<!> fun ExtensionReceiverType.dec(): DispatchReceiverType
+}
+
 
 
 

--- a/compiler/testData/diagnostics/tests/OperatorChecks.txt
+++ b/compiler/testData/diagnostics/tests/OperatorChecks.txt
@@ -96,6 +96,20 @@ public final class DelegatesWithErrors {
     public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
 }
 
+public interface DispatchReceiverType {
+    public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+    public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+    public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+    public abstract operator fun DispatchReceiverType.ExtensionReceiverType.dec(): DispatchReceiverType
+    public abstract operator fun DispatchReceiverType.ExtensionReceiverType.inc(): DispatchReceiverType.ExtensionReceiverType
+
+    public interface ExtensionReceiverType {
+        public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
+        public open override /*1*/ /*fake_override*/ fun hashCode(): kotlin.Int
+        public open override /*1*/ /*fake_override*/ fun toString(): kotlin.String
+    }
+}
+
 public interface Example {
     public abstract operator fun compareTo(/*0*/ other: Example): kotlin.Int
     public abstract operator fun component1(): kotlin.Int

--- a/core/descriptors/src/org/jetbrains/kotlin/util/modifierChecks.kt
+++ b/core/descriptors/src/org/jetbrains/kotlin/util/modifierChecks.kt
@@ -216,7 +216,7 @@ object OperatorChecks : AbstractModifierChecks() {
         Checks(BINARY_OPERATION_NAMES, MemberOrExtension, SingleValueParameter, NoDefaultAndVarargsCheck),
         Checks(SIMPLE_UNARY_OPERATION_NAMES, MemberOrExtension, NoValueParameters),
         Checks(listOf(INC, DEC), MemberOrExtension) {
-            val receiver = dispatchReceiverParameter ?: extensionReceiverParameter
+            val receiver = extensionReceiverParameter ?: dispatchReceiverParameter
             ensure(receiver != null && ((returnType?.isSubtypeOf(receiver.type) ?: false) || incDecCheckForExpectClass(receiver))) {
                 "receiver must be a supertype of the return type"
             }


### PR DESCRIPTION
This fixes [KT-24800](https://youtrack.jetbrains.com/issue/KT-24800). Defining `inc` and `dec` operator extensions as members was erroring with

```
[INAPPLICABLE_OPERATOR_MODIFIER] 'operator' modifier is inapplicable on this function: receiver must be a supertype of the return type
```

At the same time, declaring `inc` or `dec`'s return type to be the dispatch receiver type instead of the extension receiver type wouldn't error. For example:

```kotlin
object Foo

object Bar {
    operator fun Foo.inc(): Foo = TODO()  // error
    operator fun Foo.dec(): Bar = TODO()  // no error
}

// outside of Bar, defining these extensions behaves as expected
operator fun Foo.inc(): Foo = TODO()  // no error
operator fun Foo.dec(): Bar = TODO()  // error
```