### PR TITLE
Added KotlinSingleJavaTargetExtensionCompilerSupport

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinProjectExtension.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinProjectExtension.kt
@@ -194,14 +194,15 @@ abstract class KotlinSingleTargetExtension<TARGET : KotlinTarget>(project: Proje
     fun target(body: Action<TARGET>) = body.execute(target)
 }
 
-abstract class KotlinSingleJavaTargetExtension(project: Project) : KotlinSingleTargetExtension<KotlinWithJavaTarget<*, *>>(project)
-abstract class KotlinSingleJavaTargetExtensionCompilerSupport(project: Project) : KotlinSingleJavaTargetExtension(project){
-    abstract val compilerOptions: KotlinJvmCompilerOptions
-    abstract fun compilerOptions(configure: Action<KotlinJvmCompilerOptions>)
-    abstract fun compilerOptions(configure: KotlinJvmCompilerOptions.() -> Unit)
+interface KotlinSingleJavaTargetCompilerSupportExtension {
+    val compilerOptions: KotlinJvmCompilerOptions
+    fun compilerOptions(configure: Action<KotlinJvmCompilerOptions>)
+    fun compilerOptions(configure: KotlinJvmCompilerOptions.() -> Unit)
 }
 
-abstract class KotlinJvmProjectExtension(project: Project) : KotlinSingleJavaTargetExtensionCompilerSupport(project) {
+abstract class KotlinSingleJavaTargetExtension(project: Project) : KotlinSingleTargetExtension<KotlinWithJavaTarget<*, *>>(project)
+
+abstract class KotlinJvmProjectExtension(project: Project) : KotlinSingleJavaTargetExtension(project), KotlinSingleJavaTargetCompilerSupportExtension {
     @Suppress("DEPRECATION")
     override val target: KotlinWithJavaTarget<KotlinJvmOptions, KotlinJvmCompilerOptions>
         get() = targetFuture.getOrThrow()
@@ -210,7 +211,7 @@ abstract class KotlinJvmProjectExtension(project: Project) : KotlinSingleJavaTar
     override val targetFuture = CompletableFuture<KotlinWithJavaTarget<KotlinJvmOptions, KotlinJvmCompilerOptions>>()
 
     open fun target(
-        @Suppress("DEPRECATION") body: KotlinWithJavaTarget<KotlinJvmOptions, KotlinJvmCompilerOptions>.() -> Unit
+        @Suppress("DEPRECATION") body: KotlinWithJavaTarget<KotlinJvmOptions, KotlinJvmCompilerOptions>.() -> Unit,
     ) {
         project.launch(Undispatched) { targetFuture.await().body() }
     }
@@ -237,7 +238,7 @@ abstract class Kotlin2JsProjectExtension(project: Project) : KotlinSingleJavaTar
     @Suppress("DEPRECATION")
     override val targetFuture = CompletableFuture<KotlinWithJavaTarget<KotlinJsOptions, KotlinJsCompilerOptions>>()
     open fun target(
-        @Suppress("DEPRECATION") body: KotlinWithJavaTarget<KotlinJsOptions, KotlinJsCompilerOptions>.() -> Unit
+        @Suppress("DEPRECATION") body: KotlinWithJavaTarget<KotlinJsOptions, KotlinJsCompilerOptions>.() -> Unit,
     ) {
         project.launch(Undispatched) { targetFuture.await().body() }
     }
@@ -344,7 +345,7 @@ abstract class KotlinCommonProjectExtension(project: Project) : KotlinSingleJava
     }
 }
 
-abstract class KotlinAndroidProjectExtension(project: Project) : KotlinSingleJavaTargetExtensionCompilerSupport<KotlinAndroidTarget>(project) {
+abstract class KotlinAndroidProjectExtension(project: Project) : KotlinSingleTargetExtension<KotlinAndroidTarget>(project), KotlinSingleJavaTargetCompilerSupportExtension {
     override val target: KotlinAndroidTarget get() = targetFuture.getOrThrow()
     override val targetFuture = CompletableFuture<KotlinAndroidTarget>()
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinProjectExtension.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinProjectExtension.kt
@@ -195,8 +195,13 @@ abstract class KotlinSingleTargetExtension<TARGET : KotlinTarget>(project: Proje
 }
 
 abstract class KotlinSingleJavaTargetExtension(project: Project) : KotlinSingleTargetExtension<KotlinWithJavaTarget<*, *>>(project)
+abstract class KotlinSingleJavaTargetExtensionCompilerSupport(project: Project) : KotlinSingleJavaTargetExtension(project){
+    abstract val compilerOptions: KotlinJvmCompilerOptions
+    abstract fun compilerOptions(configure: Action<KotlinJvmCompilerOptions>)
+    abstract fun compilerOptions(configure: KotlinJvmCompilerOptions.() -> Unit)
+}
 
-abstract class KotlinJvmProjectExtension(project: Project) : KotlinSingleJavaTargetExtension(project) {
+abstract class KotlinJvmProjectExtension(project: Project) : KotlinSingleJavaTargetExtensionCompilerSupport(project) {
     @Suppress("DEPRECATION")
     override val target: KotlinWithJavaTarget<KotlinJvmOptions, KotlinJvmCompilerOptions>
         get() = targetFuture.getOrThrow()
@@ -210,13 +215,13 @@ abstract class KotlinJvmProjectExtension(project: Project) : KotlinSingleJavaTar
         project.launch(Undispatched) { targetFuture.await().body() }
     }
 
-    val compilerOptions: KotlinJvmCompilerOptions = project.objects.KotlinJvmCompilerOptionsDefault(project)
+    override val compilerOptions: KotlinJvmCompilerOptions = project.objects.KotlinJvmCompilerOptionsDefault(project)
 
-    fun compilerOptions(configure: Action<KotlinJvmCompilerOptions>) {
+    override fun compilerOptions(configure: Action<KotlinJvmCompilerOptions>) {
         configure.execute(compilerOptions)
     }
 
-    fun compilerOptions(configure: KotlinJvmCompilerOptions.() -> Unit) {
+    override fun compilerOptions(configure: KotlinJvmCompilerOptions.() -> Unit) {
         configure(compilerOptions)
     }
 }
@@ -339,7 +344,7 @@ abstract class KotlinCommonProjectExtension(project: Project) : KotlinSingleJava
     }
 }
 
-abstract class KotlinAndroidProjectExtension(project: Project) : KotlinSingleTargetExtension<KotlinAndroidTarget>(project) {
+abstract class KotlinAndroidProjectExtension(project: Project) : KotlinSingleJavaTargetExtensionCompilerSupport<KotlinAndroidTarget>(project) {
     override val target: KotlinAndroidTarget get() = targetFuture.getOrThrow()
     override val targetFuture = CompletableFuture<KotlinAndroidTarget>()
 
@@ -347,13 +352,13 @@ abstract class KotlinAndroidProjectExtension(project: Project) : KotlinSingleTar
         targetFuture.await().body()
     }
 
-    val compilerOptions: KotlinJvmCompilerOptions = project.objects.KotlinJvmCompilerOptionsDefault(project)
+    override val compilerOptions: KotlinJvmCompilerOptions = project.objects.KotlinJvmCompilerOptionsDefault(project)
 
-    fun compilerOptions(configure: Action<KotlinJvmCompilerOptions>) {
+    override fun compilerOptions(configure: Action<KotlinJvmCompilerOptions>) {
         configure.execute(compilerOptions)
     }
 
-    fun compilerOptions(configure: KotlinJvmCompilerOptions.() -> Unit) {
+    override fun compilerOptions(configure: KotlinJvmCompilerOptions.() -> Unit) {
         configure(compilerOptions)
     }
 }


### PR DESCRIPTION
`KotlinJvmProjectExtension` and `KotlinAndroidProjectExtension` have identical public methods but are not unified under a single interface. As a result, Kotlin configuration logic cannot be reused between AAR and JAR modules, leading to code duplication.