### PR TITLE
Enable 'system' flag on the jline Terminal for the Kotlin Scripting REPL to get keyboard shortcuts working

### DIFF
--- a/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/repl/reader/ConsoleReplCommandReader.kt
+++ b/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/repl/reader/ConsoleReplCommandReader.kt
@@ -18,7 +18,11 @@ import java.util.logging.Logger
 class ConsoleReplCommandReader : ReplCommandReader {
     private val lineReader = LineReaderBuilder.builder()
         .appName("kotlin")
-        .terminal(TerminalBuilder.terminal())
+        .terminal(
+            TerminalBuilder.builder()
+                .system(true)
+                .build()
+        )
         .variable(LineReader.HISTORY_FILE, File(File(System.getProperty("user.home")), ".kotlinc_history").absolutePath)
         .build()
         .apply {

--- a/prepare/compiler/compiler.pro
+++ b/prepare/compiler/compiler.pro
@@ -299,6 +299,7 @@
 -keep class org.jline.reader.History { *; }
 -keep class org.jline.reader.EndOfFileException { *; }
 -keep class org.jline.reader.UserInterruptException { *; }
+-keep class org.jline.terminal.TerminalBuilder { *; }
 -keep class org.jline.terminal.impl.jna.JnaSupportImpl  { *; }
 -keep class org.jline.terminal.impl.jansi.JansiSupportImpl  { *; }
 


### PR DESCRIPTION
When running `kotlinc` in REPL mode, you cannot use `GNU Readline`-like keyboard shortcuts (`Ctrl + a`, `Ctrl + e`, `Ctrl + l` and others) unlike REPL in other languages (e.g. jshell, python). 

This PR allows such input to be handled by toggling the 'system' flag on the jline Terminal object. 