### PR TITLE
Check if the provided signature is public before adding a symbol to the SymbolTable.

### DIFF
--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/SymbolTable.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/SymbolTable.kt
@@ -13,7 +13,7 @@ import org.jetbrains.kotlin.ir.symbols.*
 import org.jetbrains.kotlin.ir.symbols.impl.*
 
 private fun <SymbolOwner : IrSymbolOwner, Symbol : IrBindableSymbol<*, SymbolOwner>> IdSignatureSymbolTableSlice(lock: IrLock) =
-    SymbolTableSlice.Flat<IdSignature, SymbolOwner, Symbol>(lock) { it.signature != null }
+    SymbolTableSlice.Flat<IdSignature, SymbolOwner, Symbol>(lock) { key, symbol -> key.isPubliclyVisible }
 
 @OptIn(SymbolTableInternals::class)
 open class SymbolTable(

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/SymbolTableSlice.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/SymbolTableSlice.kt
@@ -91,7 +91,7 @@ abstract class SymbolTableSlice<Key, SymbolOwner, Symbol>(val lock: IrLock)
         return owner
     }
 
-    class Flat<Key, SymbolOwner, Symbol>(lock: IrLock, val symbolFilter: (Symbol) -> Boolean = { true }) : SymbolTableSlice<Key, SymbolOwner, Symbol>(lock)
+    class Flat<Key, SymbolOwner, Symbol>(lock: IrLock, val symbolFilter: (Key, Symbol) -> Boolean = { _,_ -> true }) : SymbolTableSlice<Key, SymbolOwner, Symbol>(lock)
             where SymbolOwner : IrSymbolOwner, Symbol : IrBindableSymbol<*, SymbolOwner> {
         private val signatureToSymbol = hashMapOf<Key, Symbol>()
 
@@ -100,7 +100,7 @@ abstract class SymbolTableSlice<Key, SymbolOwner, Symbol>(val lock: IrLock)
         }
 
         override fun set(key: Key, symbol: Symbol) {
-            if (symbolFilter(symbol)) {
+            if (symbolFilter(key, symbol)) {
                 signatureToSymbol[key] = symbol
             }
         }


### PR DESCRIPTION
This is needed for Kotlin/Closure that needs to temporary populate the SymbolTable in order to be able to deserialize IR. IR symbol created by K2 does not have signature.