### PR TITLE
[reflect] Fix wrong argument size when calling default instance methods.

### DIFF
--- a/analysis/low-level-api-fir/tests/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/compiler/based/LLFirBlackBoxCodegenBasedTestGenerated.java
+++ b/analysis/low-level-api-fir/tests/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/compiler/based/LLFirBlackBoxCodegenBasedTestGenerated.java
@@ -50938,6 +50938,12 @@ public class LLFirBlackBoxCodegenBasedTestGenerated extends AbstractLLFirBlackBo
       }
 
       @Test
+      @TestMetadata("kt71378.kt")
+      public void testKt71378() {
+        runTest("compiler/testData/codegen/box/reflection/callBy/kt71378.kt");
+      }
+
+      @Test
       @TestMetadata("manyArgumentsNoneDefaultConstructor.kt")
       public void testManyArgumentsNoneDefaultConstructor() {
         runTest("compiler/testData/codegen/box/reflection/callBy/manyArgumentsNoneDefaultConstructor.kt");

--- a/analysis/low-level-api-fir/tests/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/compiler/based/LLFirBlackBoxCodegenBasedTestGenerated.java
+++ b/analysis/low-level-api-fir/tests/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/compiler/based/LLFirBlackBoxCodegenBasedTestGenerated.java
@@ -50854,6 +50854,12 @@ public class LLFirBlackBoxCodegenBasedTestGenerated extends AbstractLLFirBlackBo
       }
 
       @Test
+      @TestMetadata("dataClassCopyWithValueClass.kt")
+      public void testDataClassCopyWithValueClass() {
+        runTest("compiler/testData/codegen/box/reflection/callBy/dataClassCopyWithValueClass.kt");
+      }
+
+      @Test
       @TestMetadata("defaultAndNonDefaultIntertwined.kt")
       public void testDefaultAndNonDefaultIntertwined() {
         runTest("compiler/testData/codegen/box/reflection/callBy/defaultAndNonDefaultIntertwined.kt");
@@ -50935,12 +50941,6 @@ public class LLFirBlackBoxCodegenBasedTestGenerated extends AbstractLLFirBlackBo
       @TestMetadata("kt61304.kt")
       public void testKt61304() {
         runTest("compiler/testData/codegen/box/reflection/callBy/kt61304.kt");
-      }
-
-      @Test
-      @TestMetadata("kt71378.kt")
-      public void testKt71378() {
-        runTest("compiler/testData/codegen/box/reflection/callBy/kt71378.kt");
       }
 
       @Test

--- a/analysis/low-level-api-fir/tests/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/compiler/based/LLFirReversedBlackBoxCodegenBasedTestGenerated.java
+++ b/analysis/low-level-api-fir/tests/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/compiler/based/LLFirReversedBlackBoxCodegenBasedTestGenerated.java
@@ -50854,6 +50854,12 @@ public class LLFirReversedBlackBoxCodegenBasedTestGenerated extends AbstractLLFi
       }
 
       @Test
+      @TestMetadata("dataClassCopyWithValueClass.kt")
+      public void testDataClassCopyWithValueClass() {
+        runTest("compiler/testData/codegen/box/reflection/callBy/dataClassCopyWithValueClass.kt");
+      }
+
+      @Test
       @TestMetadata("defaultAndNonDefaultIntertwined.kt")
       public void testDefaultAndNonDefaultIntertwined() {
         runTest("compiler/testData/codegen/box/reflection/callBy/defaultAndNonDefaultIntertwined.kt");
@@ -50935,12 +50941,6 @@ public class LLFirReversedBlackBoxCodegenBasedTestGenerated extends AbstractLLFi
       @TestMetadata("kt61304.kt")
       public void testKt61304() {
         runTest("compiler/testData/codegen/box/reflection/callBy/kt61304.kt");
-      }
-
-      @Test
-      @TestMetadata("kt71378.kt")
-      public void testKt71378() {
-        runTest("compiler/testData/codegen/box/reflection/callBy/kt71378.kt");
       }
 
       @Test

--- a/analysis/low-level-api-fir/tests/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/compiler/based/LLFirReversedBlackBoxCodegenBasedTestGenerated.java
+++ b/analysis/low-level-api-fir/tests/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/compiler/based/LLFirReversedBlackBoxCodegenBasedTestGenerated.java
@@ -50938,6 +50938,12 @@ public class LLFirReversedBlackBoxCodegenBasedTestGenerated extends AbstractLLFi
       }
 
       @Test
+      @TestMetadata("kt71378.kt")
+      public void testKt71378() {
+        runTest("compiler/testData/codegen/box/reflection/callBy/kt71378.kt");
+      }
+
+      @Test
       @TestMetadata("manyArgumentsNoneDefaultConstructor.kt")
       public void testManyArgumentsNoneDefaultConstructor() {
         runTest("compiler/testData/codegen/box/reflection/callBy/manyArgumentsNoneDefaultConstructor.kt");

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirLightTreeBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirLightTreeBlackBoxCodegenTestGenerated.java
@@ -50549,6 +50549,12 @@ public class FirLightTreeBlackBoxCodegenTestGenerated extends AbstractFirLightTr
       }
 
       @Test
+      @TestMetadata("dataClassCopyWithValueClass.kt")
+      public void testDataClassCopyWithValueClass() {
+        runTest("compiler/testData/codegen/box/reflection/callBy/dataClassCopyWithValueClass.kt");
+      }
+
+      @Test
       @TestMetadata("defaultAndNonDefaultIntertwined.kt")
       public void testDefaultAndNonDefaultIntertwined() {
         runTest("compiler/testData/codegen/box/reflection/callBy/defaultAndNonDefaultIntertwined.kt");
@@ -50630,12 +50636,6 @@ public class FirLightTreeBlackBoxCodegenTestGenerated extends AbstractFirLightTr
       @TestMetadata("kt61304.kt")
       public void testKt61304() {
         runTest("compiler/testData/codegen/box/reflection/callBy/kt61304.kt");
-      }
-
-      @Test
-      @TestMetadata("kt71378.kt")
-      public void testKt71378() {
-        runTest("compiler/testData/codegen/box/reflection/callBy/kt71378.kt");
       }
 
       @Test

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirLightTreeBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirLightTreeBlackBoxCodegenTestGenerated.java
@@ -50633,6 +50633,12 @@ public class FirLightTreeBlackBoxCodegenTestGenerated extends AbstractFirLightTr
       }
 
       @Test
+      @TestMetadata("kt71378.kt")
+      public void testKt71378() {
+        runTest("compiler/testData/codegen/box/reflection/callBy/kt71378.kt");
+      }
+
+      @Test
       @TestMetadata("manyArgumentsNoneDefaultConstructor.kt")
       public void testManyArgumentsNoneDefaultConstructor() {
         runTest("compiler/testData/codegen/box/reflection/callBy/manyArgumentsNoneDefaultConstructor.kt");

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirPsiBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirPsiBlackBoxCodegenTestGenerated.java
@@ -50633,6 +50633,12 @@ public class FirPsiBlackBoxCodegenTestGenerated extends AbstractFirPsiBlackBoxCo
       }
 
       @Test
+      @TestMetadata("kt71378.kt")
+      public void testKt71378() {
+        runTest("compiler/testData/codegen/box/reflection/callBy/kt71378.kt");
+      }
+
+      @Test
       @TestMetadata("manyArgumentsNoneDefaultConstructor.kt")
       public void testManyArgumentsNoneDefaultConstructor() {
         runTest("compiler/testData/codegen/box/reflection/callBy/manyArgumentsNoneDefaultConstructor.kt");

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirPsiBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirPsiBlackBoxCodegenTestGenerated.java
@@ -50549,6 +50549,12 @@ public class FirPsiBlackBoxCodegenTestGenerated extends AbstractFirPsiBlackBoxCo
       }
 
       @Test
+      @TestMetadata("dataClassCopyWithValueClass.kt")
+      public void testDataClassCopyWithValueClass() {
+        runTest("compiler/testData/codegen/box/reflection/callBy/dataClassCopyWithValueClass.kt");
+      }
+
+      @Test
       @TestMetadata("defaultAndNonDefaultIntertwined.kt")
       public void testDefaultAndNonDefaultIntertwined() {
         runTest("compiler/testData/codegen/box/reflection/callBy/defaultAndNonDefaultIntertwined.kt");
@@ -50630,12 +50636,6 @@ public class FirPsiBlackBoxCodegenTestGenerated extends AbstractFirPsiBlackBoxCo
       @TestMetadata("kt61304.kt")
       public void testKt61304() {
         runTest("compiler/testData/codegen/box/reflection/callBy/kt61304.kt");
-      }
-
-      @Test
-      @TestMetadata("kt71378.kt")
-      public void testKt71378() {
-        runTest("compiler/testData/codegen/box/reflection/callBy/kt71378.kt");
       }
 
       @Test

--- a/compiler/testData/codegen/box/reflection/callBy/dataClassCopyWithValueClass.kt
+++ b/compiler/testData/codegen/box/reflection/callBy/dataClassCopyWithValueClass.kt
@@ -1,7 +1,6 @@
 // TARGET_BACKEND: JVM
-
 // WITH_REFLECT
-// WITH_STDLIB
+
 import kotlin.time.Duration
 
 data class Test(val a: Duration, val b: Boolean)

--- a/compiler/testData/codegen/box/reflection/callBy/inlineClasses/nonNullObject/defaultArguments/jvmStaticFunctionsOnCompanionObject.kt
+++ b/compiler/testData/codegen/box/reflection/callBy/inlineClasses/nonNullObject/defaultArguments/jvmStaticFunctionsOnCompanionObject.kt
@@ -152,13 +152,9 @@ fun box(): String {
 
     assertEquals(S("124"), I.Companion::bar.callBy(one, "2", four))
     assertEquals(four, I.Companion::staticDefault1_1.callBy(four))
-    assertFailsWith<Error>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(default, I.Companion::staticDefault1_1.callBy(emptyMap()))
-    }
+    assertEquals(default, I.Companion::staticDefault1_1.callBy(emptyMap()))
     assertEquals(four, I.Companion::staticDefault1_2.callBy(four))
-    assertFailsWith<Error>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(default, I.Companion::staticDefault1_2.callBy(emptyMap()))
-    }
+    assertEquals(default, I.Companion::staticDefault1_2.callBy(emptyMap()))
     assertEquals(
         S("00"),
         I.Companion::staticDefault32_1.callBy(
@@ -168,9 +164,7 @@ fun box(): String {
             0L, zero
         )
     )
-    assertFailsWith<Error>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(I.staticDefault32_1(), I.Companion::staticDefault32_1.callBy(emptyMap()))
-    }
+    assertEquals(I.staticDefault32_1(), I.Companion::staticDefault32_1.callBy(emptyMap()))
     assertEquals(
         S("00"),
         I.Companion::staticDefault32_2.callBy(
@@ -180,9 +174,7 @@ fun box(): String {
             0L, zero
         )
     )
-    assertFailsWith<Error>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(I.staticDefault32_2(), I.Companion::staticDefault32_2.callBy(emptyMap()))
-    }
+    assertEquals(I.staticDefault32_2(), I.Companion::staticDefault32_2.callBy(emptyMap()))
     assertEquals(
         S("00"),
         I.Companion::staticDefault33_1.callBy(
@@ -192,9 +184,7 @@ fun box(): String {
             0L, 0L, zero
         )
     )
-    assertFailsWith<Error>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(I.staticDefault33_1(), I.Companion::staticDefault33_1.callBy(emptyMap()))
-    }
+    assertEquals(I.staticDefault33_1(), I.Companion::staticDefault33_1.callBy(emptyMap()))
     assertEquals(
         S("00"),
         I.Companion::staticDefault33_2.callBy(
@@ -204,9 +194,7 @@ fun box(): String {
             0L, 0L, zero
         )
     )
-    assertFailsWith<Error>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(I.staticDefault33_2(), I.Companion::staticDefault33_2.callBy(emptyMap()))
-    }
+    assertEquals(I.staticDefault33_2(), I.Companion::staticDefault33_2.callBy(emptyMap()))
 
     return "OK"
 }

--- a/compiler/testData/codegen/box/reflection/callBy/inlineClasses/nonNullObject/defaultArguments/memberFunctionsWithInlineClassParameters.kt
+++ b/compiler/testData/codegen/box/reflection/callBy/inlineClasses/nonNullObject/defaultArguments/memberFunctionsWithInlineClassParameters.kt
@@ -141,13 +141,9 @@ fun box(): String {
 
     assertEquals(S("abc"), instance::member.callBy(S("a"), "b", S("c")))
     assertEquals(zero, instance::memberDefault1_1.callBy(zero))
-    assertFailsWith<Error>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(default, instance::memberDefault1_1.callBy(emptyMap()))
-    }
+    assertEquals(default, instance::memberDefault1_1.callBy(emptyMap()))
     assertEquals(zero, instance::memberDefault1_2.callBy(zero))
-    assertFailsWith<Error>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(default, instance::memberDefault1_2.callBy(emptyMap()))
-    }
+    assertEquals(default, instance::memberDefault1_2.callBy(emptyMap()))
     assertEquals(
         S("00"),
         instance::memberDefault32_1.callBy(
@@ -157,9 +153,7 @@ fun box(): String {
             0L, zero
         )
     )
-    assertFailsWith<Error>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(instance.memberDefault32_1(), instance::memberDefault32_1.callBy(emptyMap()))
-    }
+    assertEquals(instance.memberDefault32_1(), instance::memberDefault32_1.callBy(emptyMap()))
     assertEquals(
         S("00"),
         instance::memberDefault32_2.callBy(
@@ -169,9 +163,7 @@ fun box(): String {
             0L, zero
         )
     )
-    assertFailsWith<Error>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(instance.memberDefault32_2(), instance::memberDefault32_2.callBy(emptyMap()))
-    }
+    assertEquals(instance.memberDefault32_2(), instance::memberDefault32_2.callBy(emptyMap()))
     assertEquals(
         S("00"),
         instance::memberDefault33_1.callBy(
@@ -181,9 +173,7 @@ fun box(): String {
             0L, 0L, zero
         )
     )
-    assertFailsWith<Error>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(instance.memberDefault33_1(), instance::memberDefault33_1.callBy(emptyMap()))
-    }
+    assertEquals(instance.memberDefault33_1(), instance::memberDefault33_1.callBy(emptyMap()))
     assertEquals(
         S("00"),
         instance::memberDefault33_2.callBy(
@@ -193,9 +183,7 @@ fun box(): String {
             0L, 0L, zero
         )
     )
-    assertFailsWith<Error>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(instance.memberDefault33_2(), instance::memberDefault33_2.callBy(emptyMap()))
-    }
+    assertEquals(instance.memberDefault33_2(), instance::memberDefault33_2.callBy(emptyMap()))
 
     return "OK"
 }

--- a/compiler/testData/codegen/box/reflection/callBy/inlineClasses/nullableObject/defaultArguments/jvmStaticFunctionsOnCompanionObject.kt
+++ b/compiler/testData/codegen/box/reflection/callBy/inlineClasses/nullableObject/defaultArguments/jvmStaticFunctionsOnCompanionObject.kt
@@ -162,9 +162,7 @@ fun box(): String {
         assertEquals(default, I.Companion::staticDefault1_1.callBy(emptyMap()))
     }
     assertEquals(four, I.Companion::staticDefault1_2.callBy(four))
-    assertFailsWith<Error>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(default, I.Companion::staticDefault1_2.callBy(emptyMap()))
-    }
+    assertEquals(default, I.Companion::staticDefault1_2.callBy(emptyMap()))
     assertEquals(
         S("00"),
         I.Companion::staticDefault32_1.callBy(
@@ -186,9 +184,7 @@ fun box(): String {
             0L, zero
         )
     )
-    assertFailsWith<Error>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(I.staticDefault32_2(), I.Companion::staticDefault32_2.callBy(emptyMap()))
-    }
+    assertEquals(I.staticDefault32_2(), I.Companion::staticDefault32_2.callBy(emptyMap()))
     assertEquals(
         S("00"),
         I.Companion::staticDefault33_1.callBy(
@@ -210,9 +206,7 @@ fun box(): String {
             0L, 0L, zero
         )
     )
-    assertFailsWith<Error>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(I.staticDefault33_2(), I.Companion::staticDefault33_2.callBy(emptyMap()))
-    }
+    assertEquals(I.staticDefault33_2(), I.Companion::staticDefault33_2.callBy(emptyMap()))
 
     return "OK"
 }

--- a/compiler/testData/codegen/box/reflection/callBy/inlineClasses/nullableObject/defaultArguments/memberFunctionsWithInlineClassParameters.kt
+++ b/compiler/testData/codegen/box/reflection/callBy/inlineClasses/nullableObject/defaultArguments/memberFunctionsWithInlineClassParameters.kt
@@ -151,9 +151,7 @@ fun box(): String {
         assertEquals(default, instance::memberDefault1_1.callBy(emptyMap()))
     }
     assertEquals(zero, instance::memberDefault1_2.callBy(zero))
-    assertFailsWith<Error>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(default, instance::memberDefault1_2.callBy(emptyMap()))
-    }
+    assertEquals(default, instance::memberDefault1_2.callBy(emptyMap()))
     assertEquals(
         S("00"),
         instance::memberDefault32_1.callBy(
@@ -175,9 +173,7 @@ fun box(): String {
             0L, zero
         )
     )
-    assertFailsWith<Error>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(instance.memberDefault32_2(), instance::memberDefault32_2.callBy(emptyMap()))
-    }
+    assertEquals(instance.memberDefault32_2(), instance::memberDefault32_2.callBy(emptyMap()))
     assertEquals(
         S("00"),
         instance::memberDefault33_1.callBy(
@@ -199,9 +195,7 @@ fun box(): String {
             0L, 0L, zero
         )
     )
-    assertFailsWith<Error>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(instance.memberDefault33_2(), instance::memberDefault33_2.callBy(emptyMap()))
-    }
+    assertEquals(instance.memberDefault33_2(), instance::memberDefault33_2.callBy(emptyMap()))
 
     return "OK"
 }

--- a/compiler/testData/codegen/box/reflection/callBy/inlineClasses/primitive/defaultArguments/jvmStaticFunctionsOnCompanionObject.kt
+++ b/compiler/testData/codegen/box/reflection/callBy/inlineClasses/primitive/defaultArguments/jvmStaticFunctionsOnCompanionObject.kt
@@ -153,13 +153,9 @@ fun box(): String {
 
     assertEquals(seven, I.Companion::bar.callBy(one, 2, four))
     assertEquals(seven, I.Companion::staticDefault1_1.callBy(seven))
-    assertFailsWith<Error>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(default, I.Companion::staticDefault1_1.callBy(emptyMap()))
-    }
+    assertEquals(default, I.Companion::staticDefault1_1.callBy(emptyMap()))
     assertEquals(seven, I.Companion::staticDefault1_2.callBy(seven))
-    assertFailsWith<Error>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(default, I.Companion::staticDefault1_2.callBy(emptyMap()))
-    }
+    assertEquals(default, I.Companion::staticDefault1_2.callBy(emptyMap()))
     assertEquals(
         S(0),
         I.Companion::staticDefault32_1.callBy(
@@ -169,9 +165,7 @@ fun box(): String {
             0L, zero
         )
     )
-    assertFailsWith<Error>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(I.staticDefault32_1(), I.Companion::staticDefault32_1.callBy(emptyMap()))
-    }
+    assertEquals(I.staticDefault32_1(), I.Companion::staticDefault32_1.callBy(emptyMap()))
     assertEquals(
         S(0),
         I.Companion::staticDefault32_2.callBy(
@@ -181,9 +175,7 @@ fun box(): String {
             0L, zero
         )
     )
-    assertFailsWith<Error>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(I.staticDefault32_2(), I.Companion::staticDefault32_2.callBy(emptyMap()))
-    }
+    assertEquals(I.staticDefault32_2(), I.Companion::staticDefault32_2.callBy(emptyMap()))
     assertEquals(
         S(0),
         I.Companion::staticDefault33_1.callBy(
@@ -193,9 +185,7 @@ fun box(): String {
             0L, 0L, zero
         )
     )
-    assertFailsWith<Error>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(I.staticDefault33_1(), I.Companion::staticDefault33_1.callBy(emptyMap()))
-    }
+    assertEquals(I.staticDefault33_1(), I.Companion::staticDefault33_1.callBy(emptyMap()))
     assertEquals(
         S(0),
         I.Companion::staticDefault33_2.callBy(
@@ -205,9 +195,7 @@ fun box(): String {
             0L, 0L, zero
         )
     )
-    assertFailsWith<Error>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(I.staticDefault33_2(), I.Companion::staticDefault33_2.callBy(emptyMap()))
-    }
+    assertEquals(I.staticDefault33_2(), I.Companion::staticDefault33_2.callBy(emptyMap()))
 
     return "OK"
 }

--- a/compiler/testData/codegen/box/reflection/callBy/inlineClasses/primitive/defaultArguments/memberFunctionsWithInlineClassParameters.kt
+++ b/compiler/testData/codegen/box/reflection/callBy/inlineClasses/primitive/defaultArguments/memberFunctionsWithInlineClassParameters.kt
@@ -144,13 +144,9 @@ fun box(): String {
 
     assertEquals(seven, instance::member.callBy(one, 2, four))
     assertEquals(seven, instance::memberDefault1_1.callBy(seven))
-    assertFailsWith<Error>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(default, instance::memberDefault1_1.callBy(emptyMap()))
-    }
+    assertEquals(default, instance::memberDefault1_1.callBy(emptyMap()))
     assertEquals(seven, instance::memberDefault1_2.callBy(seven))
-    assertFailsWith<Error>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(default, instance::memberDefault1_2.callBy(emptyMap()))
-    }
+    assertEquals(default, instance::memberDefault1_2.callBy(emptyMap()))
     assertEquals(
         S(0),
         instance::memberDefault32_1.callBy(
@@ -160,9 +156,7 @@ fun box(): String {
             0L, zero
         )
     )
-    assertFailsWith<Error>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(instance.memberDefault32_1(), instance::memberDefault32_1.callBy(emptyMap()))
-    }
+    assertEquals(instance.memberDefault32_1(), instance::memberDefault32_1.callBy(emptyMap()))
     assertEquals(
         S(0),
         instance::memberDefault32_2.callBy(
@@ -172,9 +166,7 @@ fun box(): String {
             0L, zero
         )
     )
-    assertFailsWith<Error>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(instance.memberDefault32_2(), instance::memberDefault32_2.callBy(emptyMap()))
-    }
+    assertEquals(instance.memberDefault32_2(), instance::memberDefault32_2.callBy(emptyMap()))
     assertEquals(
         S(0),
         instance::memberDefault33_1.callBy(
@@ -184,9 +176,7 @@ fun box(): String {
             0L, 0L, zero
         )
     )
-    assertFailsWith<Error>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(instance.memberDefault33_1(), instance::memberDefault33_1.callBy(emptyMap()))
-    }
+    assertEquals(instance.memberDefault33_1(), instance::memberDefault33_1.callBy(emptyMap()))
     assertEquals(
         S(0),
         instance::memberDefault33_2.callBy(
@@ -196,9 +186,7 @@ fun box(): String {
             0L, 0L, zero
         )
     )
-    assertFailsWith<Error>("Remove assertFailsWith and try again, as this problem may have been fixed.") {
-        assertEquals(instance.memberDefault33_2(), instance::memberDefault33_2.callBy(emptyMap()))
-    }
+    assertEquals(instance.memberDefault33_2(), instance::memberDefault33_2.callBy(emptyMap()))
 
     return "OK"
 }

--- a/compiler/testData/codegen/box/reflection/callBy/kt71378.kt
+++ b/compiler/testData/codegen/box/reflection/callBy/kt71378.kt
@@ -1,0 +1,19 @@
+// TARGET_BACKEND: JVM
+
+// WITH_REFLECT
+// WITH_STDLIB
+import kotlin.time.Duration
+
+data class Test(val a: Duration, val b: Boolean)
+
+fun box(): String {
+    val test = Test(Duration.ZERO, false)
+    val methodReference = test::copy
+    val parameterReference = methodReference.parameters.single { it.name == "b" }
+    val modified = methodReference.callBy(mapOf(parameterReference to true))
+    return if (modified.b) {
+        "OK"
+    } else {
+        "Fail"
+    }
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/JvmAbiConsistencyTestBoxGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/JvmAbiConsistencyTestBoxGenerated.java
@@ -49693,6 +49693,12 @@ public class JvmAbiConsistencyTestBoxGenerated extends AbstractJvmAbiConsistency
       }
 
       @Test
+      @TestMetadata("dataClassCopyWithValueClass.kt")
+      public void testDataClassCopyWithValueClass() {
+        runTest("compiler/testData/codegen/box/reflection/callBy/dataClassCopyWithValueClass.kt");
+      }
+
+      @Test
       @TestMetadata("defaultAndNonDefaultIntertwined.kt")
       public void testDefaultAndNonDefaultIntertwined() {
         runTest("compiler/testData/codegen/box/reflection/callBy/defaultAndNonDefaultIntertwined.kt");
@@ -49774,12 +49780,6 @@ public class JvmAbiConsistencyTestBoxGenerated extends AbstractJvmAbiConsistency
       @TestMetadata("kt61304.kt")
       public void testKt61304() {
         runTest("compiler/testData/codegen/box/reflection/callBy/kt61304.kt");
-      }
-
-      @Test
-      @TestMetadata("kt71378.kt")
-      public void testKt71378() {
-        runTest("compiler/testData/codegen/box/reflection/callBy/kt71378.kt");
       }
 
       @Test

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/JvmAbiConsistencyTestBoxGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/JvmAbiConsistencyTestBoxGenerated.java
@@ -49777,6 +49777,12 @@ public class JvmAbiConsistencyTestBoxGenerated extends AbstractJvmAbiConsistency
       }
 
       @Test
+      @TestMetadata("kt71378.kt")
+      public void testKt71378() {
+        runTest("compiler/testData/codegen/box/reflection/callBy/kt71378.kt");
+      }
+
+      @Test
       @TestMetadata("manyArgumentsNoneDefaultConstructor.kt")
       public void testManyArgumentsNoneDefaultConstructor() {
         runTest("compiler/testData/codegen/box/reflection/callBy/manyArgumentsNoneDefaultConstructor.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -49693,6 +49693,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
       }
 
       @Test
+      @TestMetadata("dataClassCopyWithValueClass.kt")
+      public void testDataClassCopyWithValueClass() {
+        runTest("compiler/testData/codegen/box/reflection/callBy/dataClassCopyWithValueClass.kt");
+      }
+
+      @Test
       @TestMetadata("defaultAndNonDefaultIntertwined.kt")
       public void testDefaultAndNonDefaultIntertwined() {
         runTest("compiler/testData/codegen/box/reflection/callBy/defaultAndNonDefaultIntertwined.kt");
@@ -49774,12 +49780,6 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
       @TestMetadata("kt61304.kt")
       public void testKt61304() {
         runTest("compiler/testData/codegen/box/reflection/callBy/kt61304.kt");
-      }
-
-      @Test
-      @TestMetadata("kt71378.kt")
-      public void testKt71378() {
-        runTest("compiler/testData/codegen/box/reflection/callBy/kt71378.kt");
       }
 
       @Test

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -49777,6 +49777,12 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
       }
 
       @Test
+      @TestMetadata("kt71378.kt")
+      public void testKt71378() {
+        runTest("compiler/testData/codegen/box/reflection/callBy/kt71378.kt");
+      }
+
+      @Test
       @TestMetadata("manyArgumentsNoneDefaultConstructor.kt")
       public void testManyArgumentsNoneDefaultConstructor() {
         runTest("compiler/testData/codegen/box/reflection/callBy/manyArgumentsNoneDefaultConstructor.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenWithIrInlinerTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenWithIrInlinerTestGenerated.java
@@ -49693,6 +49693,12 @@ public class IrBlackBoxCodegenWithIrInlinerTestGenerated extends AbstractIrBlack
       }
 
       @Test
+      @TestMetadata("dataClassCopyWithValueClass.kt")
+      public void testDataClassCopyWithValueClass() {
+        runTest("compiler/testData/codegen/box/reflection/callBy/dataClassCopyWithValueClass.kt");
+      }
+
+      @Test
       @TestMetadata("defaultAndNonDefaultIntertwined.kt")
       public void testDefaultAndNonDefaultIntertwined() {
         runTest("compiler/testData/codegen/box/reflection/callBy/defaultAndNonDefaultIntertwined.kt");
@@ -49774,12 +49780,6 @@ public class IrBlackBoxCodegenWithIrInlinerTestGenerated extends AbstractIrBlack
       @TestMetadata("kt61304.kt")
       public void testKt61304() {
         runTest("compiler/testData/codegen/box/reflection/callBy/kt61304.kt");
-      }
-
-      @Test
-      @TestMetadata("kt71378.kt")
-      public void testKt71378() {
-        runTest("compiler/testData/codegen/box/reflection/callBy/kt71378.kt");
       }
 
       @Test

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenWithIrInlinerTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenWithIrInlinerTestGenerated.java
@@ -49777,6 +49777,12 @@ public class IrBlackBoxCodegenWithIrInlinerTestGenerated extends AbstractIrBlack
       }
 
       @Test
+      @TestMetadata("kt71378.kt")
+      public void testKt71378() {
+        runTest("compiler/testData/codegen/box/reflection/callBy/kt71378.kt");
+      }
+
+      @Test
       @TestMetadata("manyArgumentsNoneDefaultConstructor.kt")
       public void testManyArgumentsNoneDefaultConstructor() {
         runTest("compiler/testData/codegen/box/reflection/callBy/manyArgumentsNoneDefaultConstructor.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/inlineScopes/FirBlackBoxCodegenTestWithInlineScopesGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/inlineScopes/FirBlackBoxCodegenTestWithInlineScopesGenerated.java
@@ -49777,6 +49777,12 @@ public class FirBlackBoxCodegenTestWithInlineScopesGenerated extends AbstractFir
       }
 
       @Test
+      @TestMetadata("kt71378.kt")
+      public void testKt71378() {
+        runTest("compiler/testData/codegen/box/reflection/callBy/kt71378.kt");
+      }
+
+      @Test
       @TestMetadata("manyArgumentsNoneDefaultConstructor.kt")
       public void testManyArgumentsNoneDefaultConstructor() {
         runTest("compiler/testData/codegen/box/reflection/callBy/manyArgumentsNoneDefaultConstructor.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/inlineScopes/FirBlackBoxCodegenTestWithInlineScopesGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/inlineScopes/FirBlackBoxCodegenTestWithInlineScopesGenerated.java
@@ -49693,6 +49693,12 @@ public class FirBlackBoxCodegenTestWithInlineScopesGenerated extends AbstractFir
       }
 
       @Test
+      @TestMetadata("dataClassCopyWithValueClass.kt")
+      public void testDataClassCopyWithValueClass() {
+        runTest("compiler/testData/codegen/box/reflection/callBy/dataClassCopyWithValueClass.kt");
+      }
+
+      @Test
       @TestMetadata("defaultAndNonDefaultIntertwined.kt")
       public void testDefaultAndNonDefaultIntertwined() {
         runTest("compiler/testData/codegen/box/reflection/callBy/defaultAndNonDefaultIntertwined.kt");
@@ -49774,12 +49780,6 @@ public class FirBlackBoxCodegenTestWithInlineScopesGenerated extends AbstractFir
       @TestMetadata("kt61304.kt")
       public void testKt61304() {
         runTest("compiler/testData/codegen/box/reflection/callBy/kt61304.kt");
-      }
-
-      @Test
-      @TestMetadata("kt71378.kt")
-      public void testKt71378() {
-        runTest("compiler/testData/codegen/box/reflection/callBy/kt71378.kt");
       }
 
       @Test

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -39787,6 +39787,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
         runTest("compiler/testData/codegen/box/reflection/callBy/companionObject.kt");
       }
 
+      @TestMetadata("dataClassCopyWithValueClass.kt")
+      public void testDataClassCopyWithValueClass() {
+        runTest("compiler/testData/codegen/box/reflection/callBy/dataClassCopyWithValueClass.kt");
+      }
+
       @TestMetadata("defaultAndNonDefaultIntertwined.kt")
       public void testDefaultAndNonDefaultIntertwined() {
         runTest("compiler/testData/codegen/box/reflection/callBy/defaultAndNonDefaultIntertwined.kt");
@@ -39855,11 +39860,6 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
       @TestMetadata("kt61304.kt")
       public void testKt61304() {
         runTest("compiler/testData/codegen/box/reflection/callBy/kt61304.kt");
-      }
-
-      @TestMetadata("kt71378.kt")
-      public void testKt71378() {
-        runTest("compiler/testData/codegen/box/reflection/callBy/kt71378.kt");
       }
 
       @TestMetadata("manyArgumentsNoneDefaultConstructor.kt")

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -39857,6 +39857,11 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
         runTest("compiler/testData/codegen/box/reflection/callBy/kt61304.kt");
       }
 
+      @TestMetadata("kt71378.kt")
+      public void testKt71378() {
+        runTest("compiler/testData/codegen/box/reflection/callBy/kt71378.kt");
+      }
+
       @TestMetadata("manyArgumentsNoneDefaultConstructor.kt")
       public void testManyArgumentsNoneDefaultConstructor() {
         runTest("compiler/testData/codegen/box/reflection/callBy/manyArgumentsNoneDefaultConstructor.kt");

--- a/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KFunctionImpl.kt
+++ b/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KFunctionImpl.kt
@@ -145,11 +145,7 @@ internal class KFunctionImpl private constructor(
                     createJvmStaticInObjectCaller(member)
 
                 else -> {
-                    createStaticMethodCaller(
-                        member,
-                        isCallByToValueClassMangledMethod = caller is ValueClassAwareCaller<*> &&
-                                (caller as ValueClassAwareCaller<*>).caller is CallerImpl.Method.BoundInstance
-                    )
+                    createStaticMethodCaller(member, isCallByToValueClassMangledMethod = caller.isBoundInstanceCallWithValueClasses)
                 }
             }
             else -> null

--- a/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KPropertyImpl.kt
+++ b/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KPropertyImpl.kt
@@ -289,7 +289,7 @@ private fun KPropertyImpl.Accessor<*, *>.computeCallerForAccessor(isGetter: Bool
                     if (isBound) CallerImpl.Method.BoundJvmStaticInObject(accessor)
                     else CallerImpl.Method.JvmStaticInObject(accessor)
                 else ->
-                    if (isBound) CallerImpl.Method.BoundStatic(accessor, boundReceiver)
+                    if (isBound) CallerImpl.Method.BoundStatic(accessor, isCallByToValueClassMangledMethod = false, boundReceiver)
                     else CallerImpl.Method.Static(accessor)
             }
         }

--- a/core/reflection.jvm/src/kotlin/reflect/jvm/internal/calls/Caller.kt
+++ b/core/reflection.jvm/src/kotlin/reflect/jvm/internal/calls/Caller.kt
@@ -22,6 +22,12 @@ internal interface Caller<out M : Member?> {
     }
 
     fun call(args: Array<*>): Any?
+
+    /**
+     * @see [CallerImpl.Method.BoundStatic.isCallByToValueClassMangledMethod]
+     */
+    val isBoundInstanceCallWithValueClasses: Boolean
+        get() = false
 }
 
 internal val Caller<*>.arity: Int

--- a/core/reflection.jvm/src/kotlin/reflect/jvm/internal/calls/CallerImpl.kt
+++ b/core/reflection.jvm/src/kotlin/reflect/jvm/internal/calls/CallerImpl.kt
@@ -122,7 +122,23 @@ internal sealed class CallerImpl<out M : Member>(
             }
         }
 
-        open class BoundStatic(method: ReflectMethod, internal val boundReceiver: Any?) : BoundCaller, Method(
+        /**
+         * @param isCallByToValueClassMangledMethod true if this is a `callBy` caller whose original caller is an instance method that is
+         *  mangled due to value classes in the signature.
+         * ```kotlin
+         * class Bar {
+         *     // original caller calls this method
+         *     fun foo(param1: Foo = ..., param2: Foo = ...): ReturnType = ...
+         *     // generated caller for default parameter call
+         *     // static ReturnType foo$default(Bar, Foo, Foo, Int, Object);
+         * }
+         * ```
+         * If `Foo` is value class or `ReturnType` is inline class, [ValueClassAwareCaller] regards it as a normal static function
+         * rather than a top level extension function/property (see KT-71378).
+         */
+        class BoundStatic(
+            method: ReflectMethod, internal val isCallByToValueClassMangledMethod: Boolean, internal val boundReceiver: Any?,
+        ) : BoundCaller, Method(
             method, requiresInstance = false, parameterTypes = method.genericParameterTypes.dropFirst()
         ) {
             override fun call(args: Array<*>): Any? {
@@ -130,22 +146,6 @@ internal sealed class CallerImpl<out M : Member>(
                 return callMethod(null, arrayOf(boundReceiver, *args))
             }
         }
-
-        /**
-         * A default caller whose original caller is a instance method.
-         * ```kotlin
-         * class Bar {
-         *     // original caller calls this method
-         *     fun foo(param1: Foo = 1, param2: Foo = 2): ReturnType = ...
-         *     // generated caller for default parameter call
-         *     // static ReturnType foo$default(Bar, Foo, Foo, Int, Object);
-         * }
-         * ```
-         * if Foo is value class or ReturnType is inline class,
-         * [ValueClassAwareCaller] regards it as a normal static function rather than a top level extension function/property.
-         * see [KT-71378](https://youtrack.jetbrains.com/issue/KT-71378)
-         */
-        class DefaultInstanceBoundStatic(method: ReflectMethod, boundReceiver: Any?): BoundStatic(method, boundReceiver)
 
         class BoundStaticMultiFieldValueClass(
             method: ReflectMethod, internal val boundReceiverComponents: Array<Any?>

--- a/core/reflection.jvm/src/kotlin/reflect/jvm/internal/calls/ValueClassAwareCaller.kt
+++ b/core/reflection.jvm/src/kotlin/reflect/jvm/internal/calls/ValueClassAwareCaller.kt
@@ -85,16 +85,13 @@ internal class ValueClassAwareCaller<out M : Member?>(
         }
 
         val shift = when {
-            caller is CallerImpl.Method.DefaultInstanceBoundStatic -> {
-                0
-            }
-
-            caller is CallerImpl.Method.BoundStatic || caller is CallerImpl.Method.BoundStaticMultiFieldValueClass -> {
-                // Expect CallerImpl.Method.DefaultInstanceBoundStatic below,
+            caller is CallerImpl.Method.BoundStatic && !caller.isCallByToValueClassMangledMethod -> {
                 // Bound reference to a static method is only possible for a top level extension function/property,
                 // and in that case the number of expected arguments is one less than usual, hence -1
                 -1
             }
+
+            caller is CallerImpl.Method.BoundStaticMultiFieldValueClass -> -1
 
             descriptor is ConstructorDescriptor ->
                 if (caller is BoundCaller) -1 else 0


### PR DESCRIPTION
KT-71378 fixed.
Since there are other failed tests here that can now pass, no more tests have been created.