### PR TITLE
Update ExecuteCommand.kt

### DIFF
--- a/native/utils/src/org/jetbrains/kotlin/konan/exec/ExecuteCommand.kt
+++ b/native/utils/src/org/jetbrains/kotlin/konan/exec/ExecuteCommand.kt
@@ -133,6 +133,6 @@ open class Command(initialCommand: List<String>, val redirectInputFile: File? = 
     }
 
     private fun log() {
-        if (logger != null) logger!! { command.joinToString(" ") }
+        logger?.invoke(command.joinToString(" "))
     }
 }


### PR DESCRIPTION
We directly pass `command.joinToString(" ")` as an argument to `logger?.invoke()` instead of using a separate statement to join the elements of `command`.